### PR TITLE
fix: restore init.sh and SETUP.md to git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ app_spec.md
 feature_list.json
 claude-progress.txt
 harness/prompts/app_spec.md
+harness/.env

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,4 @@ __pycache__/
 app_spec.md
 feature_list.json
 claude-progress.txt
-SETUP.md
-init.sh
 harness/prompts/app_spec.md

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,140 @@
+# VIBM Setup Guide
+
+This guide documents the manual steps needed to complete the CI/CD infrastructure setup.
+
+## Prerequisites
+
+- **Node.js 24+** - Install via [nvm](https://github.com/nvm-sh/nvm) or from [nodejs.org](https://nodejs.org/)
+- **Git** - For version control
+- **Rust** (optional, for future Tauri development) - Install from [rustup.rs](https://rustup.rs/)
+
+## Setup Steps
+
+### 1. Initialize Git Repository
+
+```bash
+git init
+```
+
+### 2. Make Scripts Executable
+
+```bash
+chmod +x init.sh
+chmod +x .husky/pre-commit
+chmod +x .husky/commit-msg
+chmod +x .husky/pre-push
+```
+
+### 3. Install Dependencies
+
+```bash
+npm install
+```
+
+This will install all devDependencies listed in `package.json`:
+
+- Husky 9 (git hooks)
+- lint-staged 15 (pre-commit checks)
+- commitlint 19 (commit message validation)
+- Prettier 3 (code formatting)
+- ESLint 9 (code linting)
+- TypeScript 5 (type checking)
+- Vitest 3 (testing)
+- And all ESLint plugins
+
+### 4. Initialize Husky
+
+```bash
+npm run prepare
+```
+
+This sets up the git hooks in the `.husky/` directory.
+
+### 5. Verify Installation
+
+Run the following commands to ensure everything is set up correctly:
+
+```bash
+# Check linting works
+npm run lint
+
+# Check formatting
+npm run format:check
+
+# Check TypeScript configuration (will error if no TS files exist yet)
+npm run type-check
+
+# Run tests (will pass with no tests for now)
+npm test
+```
+
+### 6. Create Initial Commit
+
+```bash
+git add .
+git commit -m "chore: initial CI/CD infrastructure setup"
+```
+
+This will trigger the pre-commit and commit-msg hooks for the first time.
+
+## What's Been Set Up
+
+### Configuration Files
+
+- `package.json` - Node 24+, all scripts, all devDependencies
+- `.nvmrc` - Node version 24
+- `.npmrc` - engine-strict=true
+- `.prettierrc` - Prettier configuration (no semis, single quotes)
+- `.prettierignore` - Ignore patterns
+- `lint-staged.config.js` - Pre-commit checks configuration
+- `commitlint.config.mjs` - Conventional commits configuration
+- `eslint.config.js` - ESLint flat config
+- `cspell.config.yaml` - Spell check configuration
+
+### Git Hooks (.husky/)
+
+- `pre-commit` - Runs lint-staged (ESLint, TypeScript, Prettier)
+- `commit-msg` - Validates commit message format
+- `pre-push` - Runs all tests
+
+### GitHub Actions Workflows (.github/workflows/)
+
+- `ci-checks.yml` - Code quality and unit tests (runs on feature branches)
+- `tauri-build.yml` - Cross-platform Tauri builds (runs on main branch, src-tauri/ changes only)
+
+### Utility Scripts
+
+- `init.sh` - Environment initialization script
+- `feature_list.json` - Autonomous development roadmap
+
+## Troubleshooting
+
+### Husky hooks not running
+
+If git hooks aren't executing:
+
+```bash
+npm run prepare
+git config core.hooksPath .husky
+```
+
+### ESLint errors
+
+The project has `eslint.config.js` already. If you see errors about missing plugins, ensure you ran `npm install`.
+
+### TypeScript errors
+
+TypeScript configuration requires `tsconfig.json`. If you see errors, ensure the TS config files exist.
+
+### Prettier conflicts with ESLint
+
+The `eslint-config-prettier` package is installed to disable conflicting ESLint rules.
+
+## Next Steps
+
+After completing this setup:
+
+1. **Verify all checks pass**: Run `npm run lint`, `npm run format:check`, `npm test`
+2. **Test git hooks**: Make a test commit to verify hooks trigger
+3. **Review feature_list.json**: See the full development roadmap
+4. **Start development**: Use the harness (`harness/CLAUDE.md`) or implement manually

--- a/harness/.env.example
+++ b/harness/.env.example
@@ -1,0 +1,7 @@
+# Harness Configuration
+# Copy this file to harness/.env and adjust as needed.
+
+# Disable OS-level sandbox (only recommended for Windows/WSL2).
+# On macOS/Linux, keep this commented out — sandbox provides
+# an additional security layer on top of the Python allowlist hooks.
+# HARNESS_NO_SANDBOX=1

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -33,6 +33,8 @@ python3 autonomous_agent_demo.py --max-iterations 5     # Capped
 python3 autonomous_agent_demo.py --model claude-sonnet-4-5-20250929  # Override model
 python3 autonomous_agent_demo.py --project-dir ../       # Custom project dir
 python3 autonomous_agent_demo.py --no-sandbox            # Windows/WSL2 only
+python3 autonomous_agent_demo.py --clean                 # Fresh start: wipe runtime files
+python3 autonomous_agent_demo.py --clean --max-iterations 10  # Typical new-phase launch
 ```
 
 Default model: `claude-sonnet-4-5-20250929`. Project dir defaults to repo root.
@@ -88,8 +90,15 @@ The coder agent picks the next feature whose dependencies are all satisfied.
 1. Write a new `app_spec.md` **at the project root** (not in `prompts/`)
    - `prompts.py` only copies `prompts/app_spec.md` → root if the root copy doesn't exist
    - Safest approach: write directly to the root `app_spec.md`
-2. Delete `feature_list.json` (or start fresh) to trigger the Initializer
-3. Run the harness — it generates a new feature list and begins implementing
+2. Run with `--clean` to wipe runtime files and trigger a fresh initializer:
+
+   ```bash
+   python3 autonomous_agent_demo.py --clean --max-iterations 10
+   ```
+
+   `--clean` removes `feature_list.json`, `claude-progress.txt`, and `app_spec.md` from the project root before starting. The initializer then reads the spec from `prompts/app_spec.md` (copied to root) and generates a fresh feature list.
+
+   Without `--clean`, the harness resumes from the existing `feature_list.json` — useful for continuing a previous run.
 
 ## SDK Hook API
 

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -47,6 +47,17 @@ Default model: `claude-sonnet-4-5-20250929`. Project dir defaults to repo root.
 | **Bash allowlist**          | `security.py` | Only whitelisted commands pass (`npm`, `cargo`, `git`, `node`, etc.). Sensitive commands (`rm`, `pkill`, `chmod`) get extra validation |
 | **Feature list protection** | `hooks.py`    | PreToolUse hook on Write — features cannot be removed or reordered, only `passes` field can change, must remain valid JSON array       |
 
+### Why No Sandbox?
+
+`sandbox.enabled` is a CLI-level setting that applies OS-level bash isolation. It is **not used** because:
+
+- On Linux/WSL2, sandbox support is unreliable or a no-op
+- `bypassPermissions` already skips CLI permission prompts; Python hooks provide the actual validation
+- Hooks fire regardless of permission mode and see the raw command (before any sandbox wrapping)
+- The Python allowlist in `security.py` gives finer control than OS-level sandbox
+
+The security model is: `bypassPermissions` (no CLI prompts) + Python hooks (command validation) + settings isolation (no user-level interference) + file path scoping (`permissions.allow` in `.claude_settings.json`).
+
 ## File Roles
 
 | File                       | Role                                                                                  |

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -9,26 +9,41 @@ The harness is the project's primary engineering cycle — it drove the CI/CD an
 
 Each iteration creates a fresh SDK client (`client.py`) → loads the appropriate prompt (`prompts/initializer_prompt.md` or `prompts/coding_prompt.md`) → runs a session → prints progress → sleeps 3s → loops.
 
+## Environment Variables
+
+| Variable             | Required | Description                                              |
+| -------------------- | -------- | -------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`  | Yes      | API key from console.anthropic.com (or compatible proxy) |
+| `ANTHROPIC_BASE_URL` | No       | Override API endpoint (for proxies or self-hosted)       |
+
+The harness does **not** auto-load `.env`. Source it before running:
+
+```bash
+set -a && source .env && set +a
+```
+
 ## Running
 
 ```bash
-cd harness && pip install -r requirements.txt
+cd harness && pip3 install -r requirements.txt
 
-# Requires ANTHROPIC_API_KEY in env (or .env at project root)
-python autonomous_agent_demo.py                        # Unlimited iterations
-python autonomous_agent_demo.py --max-iterations 5     # Capped
-python autonomous_agent_demo.py --model claude-sonnet-4-5-20250929  # Override model
-python autonomous_agent_demo.py --project-dir ../       # Custom project dir
+# Source env vars first (see above), then:
+python3 autonomous_agent_demo.py                        # Unlimited iterations
+python3 autonomous_agent_demo.py --max-iterations 5     # Capped
+python3 autonomous_agent_demo.py --model claude-sonnet-4-5-20250929  # Override model
+python3 autonomous_agent_demo.py --project-dir ../       # Custom project dir
 ```
 
 Default model: `claude-sonnet-4-5-20250929`. Project dir defaults to repo root.
+
+**Tip:** Always dry-run with `--max-iterations 1` first to verify the environment works before scaling up.
 
 ## Safety Layers
 
 | Layer                       | File          | Purpose                                                                                                                                |
 | --------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| **Sandbox**                 | `client.py`   | OS-level bash isolation (`sandbox.enabled: true`)                                                                                      |
-| **Permissions**             | `client.py`   | File ops restricted to project dir (`acceptEdits` mode)                                                                                |
+| **Settings isolation**      | `client.py`   | `CLAUDE_CONFIG_DIR` set to temp dir — prevents user-level hooks from interfering                                                       |
+| **Permissions**             | `client.py`   | `bypassPermissions` mode with file ops restricted to project dir                                                                       |
 | **Bash allowlist**          | `security.py` | Only whitelisted commands pass (`npm`, `cargo`, `git`, `node`, etc.). Sensitive commands (`rm`, `pkill`, `chmod`) get extra validation |
 | **Feature list protection** | `hooks.py`    | PreToolUse hook on Write — features cannot be removed or reordered, only `passes` field can change, must remain valid JSON array       |
 
@@ -56,6 +71,31 @@ The coder agent picks the next feature whose dependencies are all satisfied.
 
 ## Adding New Work
 
-1. Write a new `app_spec.md` in `prompts/` describing the next phase of work
+1. Write a new `app_spec.md` **at the project root** (not in `prompts/`)
+   - `prompts.py` only copies `prompts/app_spec.md` → root if the root copy doesn't exist
+   - Safest approach: write directly to the root `app_spec.md`
 2. Delete `feature_list.json` (or start fresh) to trigger the Initializer
 3. Run the harness — it generates a new feature list and begins implementing
+
+## SDK Hook API
+
+The Claude Code SDK (v0.0.25+) passes the **full hook context** to PreToolUse hooks, not just the tool's input params. The tool parameters are nested inside `input_data["tool_input"]`:
+
+```python
+async def my_hook(input_data, tool_use_id=None, context=None):
+    # input_data keys: session_id, transcript_path, cwd, permission_mode,
+    #                  hook_event_name, tool_name, tool_input, tool_use_id
+    tool_input = input_data.get("tool_input", input_data)
+    command = tool_input.get("command", "")
+```
+
+## Troubleshooting
+
+| Symptom                                        | Cause                                                                               | Fix                                                                                                                                     |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `python: command not found`                    | WSL2/Linux may only have `python3`                                                  | Use `python3` instead of `python`                                                                                                       |
+| All Bash commands blocked with "Empty command" | Hook reads `input_data["command"]` instead of `input_data["tool_input"]["command"]` | Already fixed in `security.py` and `hooks.py`                                                                                           |
+| `spawn rg EACCES` in Glob/Grep                 | Claude Code's vendored ripgrep binary lost +x permission                            | Preflight check auto-fixes this; or run `chmod +x ~/.npm-global/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/x64-linux/rg` |
+| User-level hooks interfere                     | SDK subprocess loads `~/.claude/settings.json`                                      | `client.py` sets `CLAUDE_CONFIG_DIR` to an isolated temp dir                                                                            |
+| `app_spec.md` empty at root                    | `prompts.py` skips copy if root file exists                                         | Write spec directly to root `app_spec.md`, not `prompts/app_spec.md`                                                                    |
+| `ANTHROPIC_API_KEY not set`                    | `.env` not sourced                                                                  | Run `set -a && source .env && set +a` before launching                                                                                  |

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -32,6 +32,7 @@ python3 autonomous_agent_demo.py                        # Unlimited iterations
 python3 autonomous_agent_demo.py --max-iterations 5     # Capped
 python3 autonomous_agent_demo.py --model claude-sonnet-4-5-20250929  # Override model
 python3 autonomous_agent_demo.py --project-dir ../       # Custom project dir
+python3 autonomous_agent_demo.py --no-sandbox            # Windows/WSL2 only
 ```
 
 Default model: `claude-sonnet-4-5-20250929`. Project dir defaults to repo root.
@@ -47,16 +48,18 @@ Default model: `claude-sonnet-4-5-20250929`. Project dir defaults to repo root.
 | **Bash allowlist**          | `security.py` | Only whitelisted commands pass (`npm`, `cargo`, `git`, `node`, etc.). Sensitive commands (`rm`, `pkill`, `chmod`) get extra validation |
 | **Feature list protection** | `hooks.py`    | PreToolUse hook on Write — features cannot be removed or reordered, only `passes` field can change, must remain valid JSON array       |
 
-### Why No Sandbox?
+### Sandbox Configuration
 
-`sandbox.enabled` is a CLI-level setting that applies OS-level bash isolation. It is **not used** because:
+OS-level sandbox is **enabled by default** (recommended for macOS/Linux). It provides an additional security layer via CLI-level bash isolation, on top of the Python allowlist hooks.
 
-- On Linux/WSL2, sandbox support is unreliable or a no-op
-- `bypassPermissions` already skips CLI permission prompts; Python hooks provide the actual validation
-- Hooks fire regardless of permission mode and see the raw command (before any sandbox wrapping)
-- The Python allowlist in `security.py` gives finer control than OS-level sandbox
+| Flag           | Sandbox | Permission Mode     | When to Use                       |
+| -------------- | ------- | ------------------- | --------------------------------- |
+| _(default)_    | ON      | `acceptEdits`       | macOS, native Linux               |
+| `--no-sandbox` | OFF     | `bypassPermissions` | Windows/WSL2 (sandbox unreliable) |
 
-The security model is: `bypassPermissions` (no CLI prompts) + Python hooks (command validation) + settings isolation (no user-level interference) + file path scoping (`permissions.allow` in `.claude_settings.json`).
+Python hooks (`security.py`, `hooks.py`) fire regardless of sandbox or permission mode. They always see the raw command before any sandbox wrapping.
+
+**WSL2 users:** The sandbox may be unreliable or a no-op on WSL2. If you encounter Bash commands being blocked unexpectedly, re-run with `--no-sandbox`. You accept the risk of running without OS-level isolation — Python hooks still validate every command.
 
 ## File Roles
 

--- a/harness/agent.py
+++ b/harness/agent.py
@@ -78,6 +78,7 @@ async def run_autonomous_agent(
     project_dir: Path,
     model: str,
     max_iterations: Optional[int] = None,
+    sandbox: bool = True,
 ) -> None:
     """Run the autonomous agent loop."""
     print("\n" + "=" * 70)
@@ -112,7 +113,7 @@ async def run_autonomous_agent(
 
         print_session_header(iteration, is_first_run)
 
-        client = create_client(project_dir, model)
+        client = create_client(project_dir, model, sandbox=sandbox)
 
         if is_first_run:
             prompt = get_initializer_prompt()

--- a/harness/autonomous_agent_demo.py
+++ b/harness/autonomous_agent_demo.py
@@ -9,15 +9,15 @@ Implements the two-agent pattern (initializer + coding agent) to
 autonomously build VIBM, a Tauri/TypeScript/Rust desktop application.
 
 Usage:
-  python autonomous_agent_demo.py
-  python autonomous_agent_demo.py --max-iterations 5
-  python autonomous_agent_demo.py --model claude-sonnet-4-5-20250929
+  python3 autonomous_agent_demo.py
+  python3 autonomous_agent_demo.py --max-iterations 5
+  python3 autonomous_agent_demo.py --no-sandbox   # Windows/WSL2 only
 """
 
 import argparse
 import asyncio
 import os
-import shutil
+import platform
 import stat
 from pathlib import Path
 
@@ -52,7 +52,45 @@ def parse_args() -> argparse.Namespace:
         help=f"Claude model (default: {DEFAULT_MODEL})",
     )
 
+    parser.add_argument(
+        "--no-sandbox",
+        action="store_true",
+        default=False,
+        help="Disable OS-level sandbox (only recommended for Windows/WSL2)",
+    )
+
     return parser.parse_args()
+
+
+def _is_wsl() -> bool:
+    """Detect if running inside WSL."""
+    try:
+        with open("/proc/version", "r") as f:
+            return "microsoft" in f.read().lower()
+    except OSError:
+        return False
+
+
+def resolve_sandbox(no_sandbox_flag: bool) -> bool:
+    """
+    Determine whether sandbox should be enabled.
+
+    Default: sandbox ON (recommended for macOS/Linux).
+    Disabled only when --no-sandbox is explicitly passed.
+    On WSL2 first run without --no-sandbox, warn the user.
+    """
+    if no_sandbox_flag:
+        print("  Sandbox: DISABLED (--no-sandbox flag)")
+        print("  Python hooks still validate all bash commands.")
+        return False
+
+    if _is_wsl():
+        print("  Warning: WSL2 detected. OS-level sandbox may be unreliable.")
+        print("  If you encounter issues, re-run with --no-sandbox")
+        print("  Python hooks still validate all bash commands regardless.")
+        print()
+
+    return True
 
 
 def preflight_checks() -> bool:
@@ -92,12 +130,17 @@ def main() -> None:
     if not preflight_checks():
         return
 
+    # --no-sandbox flag or HARNESS_NO_SANDBOX env var
+    no_sandbox = args.no_sandbox or os.environ.get("HARNESS_NO_SANDBOX") == "1"
+    sandbox = resolve_sandbox(no_sandbox)
+
     try:
         asyncio.run(
             run_autonomous_agent(
                 project_dir=args.project_dir,
                 model=args.model,
                 max_iterations=args.max_iterations,
+                sandbox=sandbox,
             )
         )
     except KeyboardInterrupt:

--- a/harness/autonomous_agent_demo.py
+++ b/harness/autonomous_agent_demo.py
@@ -17,6 +17,8 @@ Usage:
 import argparse
 import asyncio
 import os
+import shutil
+import stat
 from pathlib import Path
 
 from agent import run_autonomous_agent
@@ -53,13 +55,41 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def preflight_checks() -> bool:
+    """Run preflight checks before starting the harness."""
+    ok = True
+
+    # Check API key
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("Error: ANTHROPIC_API_KEY environment variable not set")
+        print("\nOption 1: export ANTHROPIC_API_KEY='your-key-here'")
+        print("Option 2: add it to .env at the project root")
+        print("   The harness does NOT auto-load .env; source it first:")
+        print("   set -a && source .env && set +a")
+        return False
+
+    # Check optional base URL
+    base_url = os.environ.get("ANTHROPIC_BASE_URL")
+    if base_url:
+        print(f"  API base URL: {base_url}")
+
+    # Fix ripgrep permissions (Claude Code vendor binary)
+    rg_paths = [
+        Path.home() / ".npm-global/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/x64-linux/rg",
+        Path.home() / ".local/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/x64-linux/rg",
+    ]
+    for rg_path in rg_paths:
+        if rg_path.exists() and not os.access(rg_path, os.X_OK):
+            print(f"  Fixing rg permissions: {rg_path}")
+            rg_path.chmod(rg_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    return ok
+
+
 def main() -> None:
     args = parse_args()
 
-    if not os.environ.get("ANTHROPIC_API_KEY"):
-        print("Error: ANTHROPIC_API_KEY environment variable not set")
-        print("\nGet your API key from: https://console.anthropic.com/")
-        print("Then: export ANTHROPIC_API_KEY='your-key-here'")
+    if not preflight_checks():
         return
 
     try:

--- a/harness/autonomous_agent_demo.py
+++ b/harness/autonomous_agent_demo.py
@@ -9,9 +9,9 @@ Implements the two-agent pattern (initializer + coding agent) to
 autonomously build VIBM, a Tauri/TypeScript/Rust desktop application.
 
 Usage:
-  python3 autonomous_agent_demo.py
+  python3 autonomous_agent_demo.py --clean         # Fresh start: wipe runtime files, run initializer
   python3 autonomous_agent_demo.py --max-iterations 5
-  python3 autonomous_agent_demo.py --no-sandbox   # Windows/WSL2 only
+  python3 autonomous_agent_demo.py --no-sandbox    # Windows/WSL2 only
 """
 
 import argparse
@@ -59,6 +59,13 @@ def parse_args() -> argparse.Namespace:
         help="Disable OS-level sandbox (only recommended for Windows/WSL2)",
     )
 
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        default=False,
+        help="Wipe runtime files (feature_list.json, claude-progress.txt, app_spec.md) before starting. Forces the initializer agent to run fresh.",
+    )
+
     return parser.parse_args()
 
 
@@ -91,6 +98,24 @@ def resolve_sandbox(no_sandbox_flag: bool) -> bool:
         print()
 
     return True
+
+
+RUNTIME_FILES = [
+    "feature_list.json",
+    "claude-progress.txt",
+    "app_spec.md",
+]
+
+
+def clean_runtime_files(project_dir: Path) -> None:
+    """Remove harness runtime files to force a fresh initializer run."""
+    print("  Cleaning runtime files...")
+    for name in RUNTIME_FILES:
+        path = project_dir / name
+        if path.exists():
+            path.unlink()
+            print(f"    Removed {name}")
+    print()
 
 
 def preflight_checks() -> bool:
@@ -129,6 +154,9 @@ def main() -> None:
 
     if not preflight_checks():
         return
+
+    if args.clean:
+        clean_runtime_files(args.project_dir)
 
     # --no-sandbox flag or HARNESS_NO_SANDBOX env var
     no_sandbox = args.no_sandbox or os.environ.get("HARNESS_NO_SANDBOX") == "1"

--- a/harness/client.py
+++ b/harness/client.py
@@ -39,9 +39,12 @@ def create_client(project_dir: Path, model: str) -> ClaudeSDKClient:
     Create a Claude Code SDK client with security layers.
 
     Security:
-      1. Sandbox — OS-level bash isolation
-      2. Permissions — file ops restricted to project_dir
-      3. Security hook — bash commands validated against allowlist
+      1. Settings isolation — CLAUDE_CONFIG_DIR prevents user-level hooks
+      2. Permissions — bypassPermissions for full autonomy, file ops scoped to project_dir
+      3. Python hooks — bash allowlist (security.py) + feature_list protection (hooks.py)
+
+    Note: sandbox.enabled is not used. On Linux/WSL2 it's unreliable (may be no-op)
+    and redundant when Python hooks already validate every bash command.
     """
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
@@ -67,8 +70,9 @@ def create_client(project_dir: Path, model: str) -> ClaudeSDKClient:
     with open(settings_file, "w") as f:
         json.dump(security_settings, f, indent=2)
 
-    print(f"  Security: sandbox enabled, fs restricted to {project_dir.resolve()}")
+    print(f"  Security: bypassPermissions, fs restricted to {project_dir.resolve()}")
     print(f"  Bash: allowlist-validated (see harness/security.py)")
+    print(f"  Config: isolated from user settings (CLAUDE_CONFIG_DIR)")
     print()
 
     return ClaudeSDKClient(

--- a/harness/client.py
+++ b/harness/client.py
@@ -34,25 +34,31 @@ BUILTIN_TOOLS = [
 ]
 
 
-def create_client(project_dir: Path, model: str) -> ClaudeSDKClient:
+def create_client(
+    project_dir: Path, model: str, *, sandbox: bool = True
+) -> ClaudeSDKClient:
     """
     Create a Claude Code SDK client with security layers.
 
     Security:
       1. Settings isolation — CLAUDE_CONFIG_DIR prevents user-level hooks
-      2. Permissions — bypassPermissions for full autonomy, file ops scoped to project_dir
-      3. Python hooks — bash allowlist (security.py) + feature_list protection (hooks.py)
+      2. Sandbox (default on) — OS-level bash isolation via the CLI
+      3. Permissions — acceptEdits with sandbox, bypassPermissions without
+      4. Python hooks — bash allowlist (security.py) + feature_list protection (hooks.py)
 
-    Note: sandbox.enabled is not used. On Linux/WSL2 it's unreliable (may be no-op)
-    and redundant when Python hooks already validate every bash command.
+    Args:
+        project_dir: Root directory for the project
+        model: Claude model identifier
+        sandbox: Enable OS-level sandbox (default: True).
+                 Recommended on macOS/Linux. On Windows/WSL2 the sandbox
+                 may be unreliable — pass --no-sandbox to disable.
     """
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         raise ValueError("ANTHROPIC_API_KEY not set")
 
-    security_settings = {
+    security_settings: dict = {
         "permissions": {
-            "defaultMode": "bypassPermissions",
             "allow": [
                 "Read(.//**)",
                 "Write(.//**)",
@@ -64,13 +70,24 @@ def create_client(project_dir: Path, model: str) -> ClaudeSDKClient:
         },
     }
 
+    if sandbox:
+        security_settings["sandbox"] = {
+            "enabled": True,
+            "autoAllowBashIfSandboxed": True,
+        }
+        security_settings["permissions"]["defaultMode"] = "acceptEdits"
+        mode_label = "sandbox + acceptEdits"
+    else:
+        security_settings["permissions"]["defaultMode"] = "bypassPermissions"
+        mode_label = "bypassPermissions (no sandbox)"
+
     project_dir.mkdir(parents=True, exist_ok=True)
 
     settings_file = project_dir / ".claude_settings.json"
     with open(settings_file, "w") as f:
         json.dump(security_settings, f, indent=2)
 
-    print(f"  Security: bypassPermissions, fs restricted to {project_dir.resolve()}")
+    print(f"  Security: {mode_label}, fs restricted to {project_dir.resolve()}")
     print(f"  Bash: allowlist-validated (see harness/security.py)")
     print(f"  Config: isolated from user settings (CLAUDE_CONFIG_DIR)")
     print()

--- a/harness/prompts/initializer_prompt.md
+++ b/harness/prompts/initializer_prompt.md
@@ -4,13 +4,14 @@ You are the FIRST agent in a long-running autonomous development process for VIB
 
 ### FIRST: Read the Project Context
 
-1. Read `app_spec.md` in your working directory — the complete product specification.
+1. Read `app_spec.md` in your working directory — the product specification for this phase of work.
 2. Read `CLAUDE.md` — project conventions and architecture.
-3. Skim `rules/` and `agents/` — development standards you must follow.
+3. Run `git log --oneline -10` to understand what already exists.
+4. Check what source directories exist (`ls -la src/ src-tauri/ 2>/dev/null`).
 
-### CRITICAL FIRST TASK: Create feature_list.json
+### CRITICAL TASK: Create feature_list.json
 
-Based on `app_spec.md`, create `feature_list.json` with detailed, phased features. This is the single source of truth for what needs to be built.
+Based on `app_spec.md`, create `feature_list.json` with detailed, phased features. This is the single source of truth for what needs to be built **in this phase**.
 
 **Format:**
 
@@ -20,31 +21,26 @@ Based on `app_spec.md`, create `feature_list.json` with detailed, phased feature
     "id": 1,
     "phase": 1,
     "category": "scaffold",
-    "description": "Initialize Tauri project with cargo tauri init",
-    "steps": [
-      "Run cargo tauri init in project root",
-      "Verify src-tauri/ directory exists with Cargo.toml and tauri.conf.json",
-      "Verify npm dependencies installed",
-      "Run cargo tauri dev and confirm window opens"
-    ],
+    "description": "Short description of the feature",
+    "steps": ["Step 1", "Step 2", "Step 3"],
     "passes": false,
     "dependencies": []
   }
 ]
 ```
 
-**Phase ordering:**
+**Phase ordering depends on what app_spec.md describes.** Typical phases:
 
-1. **Scaffold** — Tauri init, React setup, tsconfig, ESLint config, Vitest config
-2. **Data models** — TypeScript types, Rust structs, serde serialization
-3. **Backend commands** — Rust #[tauri::command] handlers, state management
-4. **Frontend components** — React UI components, routing, state
-5. **IPC wiring** — Connect frontend invoke() to backend commands
-6. **Testing** — Unit tests (cargo test + vitest), integration tests
-7. **Polish** — Error handling, loading states, edge cases
+1. **Scaffold** — Project setup, configs, dependencies
+2. **Data models** — Types, structs, schemas
+3. **Core implementation** — Backend commands, frontend components, or both
+4. **Wiring** — Integration between layers
+5. **Testing** — Unit, integration, E2E tests
+6. **Polish** — Error handling, edge cases, verification
 
 **Requirements:**
 
+- Read `app_spec.md` carefully — it defines scope. Do NOT add features beyond what it specifies.
 - Order features by dependency (scaffold before components, backend before IPC)
 - Set `dependencies` array to feature IDs that must complete first
 - ALL features start with `"passes": false`
@@ -53,37 +49,24 @@ Based on `app_spec.md`, create `feature_list.json` with detailed, phased feature
 
 **CRITICAL:** Never remove or edit features in future sessions. Features can ONLY have their `passes` field changed to `true`.
 
-### SECOND TASK: Create init.sh
+### IMPORTANT: Do NOT Overwrite Existing Source Files
 
-Create `init.sh` that future agents use to set up the dev environment:
+The project may already have infrastructure in place (git repo, `init.sh`, `SETUP.md`, CI/CD workflows, `eslint.config.js`, etc.). Do NOT:
 
-```bash
-#!/bin/bash
-# Install frontend deps
-npm install
-# Check Rust toolchain
-rustup show
-# Start Tauri dev mode
-cargo tauri dev
-```
+- Run `git init` — the repo already exists
+- Overwrite `init.sh` — it is a tracked source file
+- Overwrite `SETUP.md` — it is a tracked source file
+- Recreate configs that already exist (eslint, prettier, vitest, etc.)
 
-### THIRD TASK: Initialize Git
+If `app_spec.md` describes scaffold features, check if they already exist before implementing.
 
-```bash
-git init
-git add feature_list.json init.sh CLAUDE.md rules/ agents/
-git commit -m "chore: initial setup with feature list and project standards"
-```
+### SECOND TASK: Begin Phase 1
 
-### FOURTH TASK: Begin Scaffolding
+After creating `feature_list.json`, start implementing Phase 1 features. Follow the project's development workflow:
 
-Start implementing Phase 1 features:
-
-- Run `cargo tauri init` (or `npm create tauri-app`)
-- Set up React with TypeScript
-- Copy `eslint.config.js` and `cspell.config.yaml` from project root
-- Configure Vitest
-- Verify `cargo tauri dev` launches a window
+- Check `DEVELOPMENT.md` for available commands
+- Write tests first (TDD)
+- Verify with `npm run lint`, `npm run type-check`, `npm test`
 
 ### ENDING THIS SESSION
 

--- a/init.sh
+++ b/init.sh
@@ -60,3 +60,13 @@ echo "  - Review feature_list.json for development roadmap"
 echo "  - Run 'npm run lint' to check code quality"
 echo "  - Run 'npm test' to run tests"
 echo "  - Review CLAUDE.md for project conventions"
+echo ""
+
+# Check if Tauri is initialized
+if [ -d "src-tauri" ]; then
+    echo "Tauri backend detected!"
+    echo "To start development server: cargo tauri dev"
+else
+    echo "Tauri backend not yet initialized."
+    echo "To initialize: npm create tauri-app (or see feature_list.json #1)"
+fi

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# VIBM Development Environment Initialization
+# Run this script to set up your local development environment
+
+set -e
+
+echo "Initializing VIBM development environment..."
+
+# Check Node.js version
+echo "Checking Node.js version..."
+if ! command -v node &> /dev/null; then
+    echo "Node.js is not installed. Please install Node.js 24 or higher."
+    exit 1
+fi
+
+NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
+if [ "$NODE_VERSION" -lt 24 ]; then
+    echo "Warning: Node.js $NODE_VERSION detected. This project requires Node.js 24+."
+    echo "   Consider using nvm: nvm install 24 && nvm use 24"
+fi
+
+# Install npm dependencies
+echo "Installing npm dependencies..."
+if [ -f "package.json" ]; then
+    npm install
+else
+    echo "package.json not found. Run the initializer agent first."
+fi
+
+# Check if Rust is installed (for future Tauri work)
+echo "Checking Rust toolchain..."
+if command -v rustup &> /dev/null; then
+    rustup show
+else
+    echo "Rust is not installed. It will be needed for Tauri development."
+    echo "   Install from: https://rustup.rs/"
+fi
+
+# Initialize git hooks if Husky is set up
+if [ -d ".husky" ]; then
+    echo "Initializing git hooks..."
+    npm run prepare
+fi
+
+# Run verification checks
+echo "Running verification checks..."
+if [ -f "package.json" ]; then
+    echo "   - Checking lint configuration..."
+    npm run lint --silent || echo "Lint check failed"
+
+    echo "   - Checking format configuration..."
+    npm run format:check --silent || echo "Format check failed"
+fi
+
+echo ""
+echo "Environment initialization complete!"
+echo ""
+echo "Next steps:"
+echo "  - Review feature_list.json for development roadmap"
+echo "  - Run 'npm run lint' to check code quality"
+echo "  - Run 'npm test' to run tests"
+echo "  - Review CLAUDE.md for project conventions"


### PR DESCRIPTION
## Summary

- Removed `init.sh` and `SETUP.md` from `.gitignore` — these are source files, not harness runtime artifacts
- Restored original content from pre-PR #2 state

## Files

- **`init.sh`** — Dev environment initialization (Node check, npm install, Rust check, Husky init, verification)
- **`SETUP.md`** — Setup guide with prerequisites, installation steps, troubleshooting

Closes #4