### PR TITLE
refactor: inline single-use test data for readability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,18 +6,73 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Vimeflow is a **coding agent conversation manager** — a Tauri desktop application (Rust backend + React/TypeScript frontend) for managing conversations with AI coding agents.
 
-**Phase: Foundation / Pre-implementation** — CI/CD tooling infrastructure is established; application code (Tauri scaffolding, `src/`, `src-tauri/`) does not exist yet.
+**Phase: Early implementation** — CI/CD tooling, design system, and layout shell are established. Chat UI with mock data is functional. No Tauri/Rust backend yet (`src-tauri/` does not exist).
 
-## Where to Look
+## Commands
 
-Each topic is self-contained. Start here, drill down as needed.
+```bash
+npm run dev             # Vite dev server
+npm run build           # tsc -b && vite build
+npm run test            # Vitest (--passWithNoTests)
+npx vitest run src/path/to/file.test.tsx  # Run a single test file
+npm run lint            # ESLint (flat config, type-checked)
+npm run lint:fix        # ESLint with auto-fix
+npm run format:check    # Prettier check
+npm run format          # Prettier write
+npm run type-check      # tsc -b
+```
 
-| What You Need                                            | Where                        |
+Node >= 24 (see `.nvmrc`). ESM-only (`"type": "module"`).
+
+## Architecture
+
+```
+src/
+├── main.tsx                    # React entry point
+├── App.tsx                     # Root component, renders ChatView
+├── index.css                   # Tailwind + global styles
+├── components/layout/          # Shared layout shells (IconRail, Sidebar, TopTabBar, ContextPanel)
+├── features/chat/              # Chat feature module
+│   ├── ChatView.tsx            # Page assembly — composes layout + chat components
+│   ├── components/             # Chat-specific components (MessageThread, MessageInput, AgentMessage, etc.)
+│   ├── data/mockMessages.ts    # Mock conversation data
+│   └── types/index.ts          # Chat domain types (Message, Conversation, etc.)
+└── test/setup.ts               # Vitest setup (jsdom, testing-library matchers)
+```
+
+**Feature-based organization**: code lives under `src/features/<name>/` with co-located components, types, and data. Shared layout components live in `src/components/layout/`.
+
+**Test co-location**: every `.tsx`/`.ts` file has a sibling `.test.tsx`/`.test.ts` file.
+
+## Code Style (Enforced by ESLint + Prettier)
+
+- No semicolons, single quotes, trailing commas (es5)
+- Arrow-function components only (`react/function-component-definition`)
+- Explicit return types on all exported functions (`@typescript-eslint/explicit-function-return-type`)
+- No `console.log` (`no-console: error`)
+- `test()` not `it()` in Vitest (`vitest/consistent-test-it`)
+- CSpell spell-checking enabled via ESLint
+- Conventional commits enforced by commitlint: `feat|fix|refactor|docs|test|chore|perf|ci: description`
+
+## Design System: "The Obsidian Lens"
+
+Dark atmospheric UI built on Catppuccin Mocha palette. Colors defined as semantic tokens in `tailwind.config.js` (e.g. `bg-surface-container`, `text-on-surface`, `text-primary`). Fonts: Manrope (headlines), Inter (body/labels), JetBrains Mono (code). No visible borders — use tonal depth and glassmorphism. See `DESIGN.md` and `docs/design/` for full specs.
+
+## Git Hooks (Husky)
+
+- **pre-commit**: lint-staged (ESLint + Prettier on staged files)
+- **commit-msg**: commitlint (conventional commits)
+- **pre-push**: vitest run
+
+## Structure: Index-Only by Design
+
+This file covers what you need to start working. For deeper topics, read the linked doc — do NOT inline their content back here.
+
+| Topic                                                    | Where                        |
 | -------------------------------------------------------- | ---------------------------- |
-| Commands, tech stack, code style                         | `DEVELOPMENT.md`             |
-| Architecture decisions, Tauri patterns                   | `ARCHITECT.md`               |
+| Architecture decisions, Tauri IPC patterns               | `ARCHITECT.md`               |
 | UI design system, screens, components                    | `DESIGN.md` → `docs/design/` |
 | AI agent specs (planner, tdd-guide, code-reviewer, etc.) | `agents/CLAUDE.md`           |
 | Development standards (coding style, testing, security)  | `rules/CLAUDE.md`            |
-| Autonomous development loop (drove CI/CD setup)          | `harness/CLAUDE.md`          |
+| Autonomous development loop (harness)                    | `harness/CLAUDE.md`          |
 | Architecture specs, exploration notes                    | `docs/CLAUDE.md`             |

--- a/rules/typescript/testing.md
+++ b/rules/typescript/testing.md
@@ -17,6 +17,41 @@ paths:
 - Test files: `*.test.ts` / `*.test.tsx` colocated with source
 - React component tests use **Testing Library** (`@testing-library/react`)
 
+## Test Data Style
+
+- **Inline single-use test data** directly into the call site instead of declaring a named variable. Readability of each test case matters more than DRY in tests.
+- Only extract a variable when it is referenced 2+ times in the same test (e.g. once in `render()` and once in an assertion comparing the same value).
+
+```typescript
+// WRONG: variable used only once adds indirection
+test('renders agent message', () => {
+  const message: Message = {
+    id: '1',
+    sender: 'agent',
+    content: 'Hello',
+    timestamp: '2026-03-31T10:00:00Z',
+  }
+
+  render(<AgentMessage message={message} />)
+  expect(screen.getByText('Hello')).toBeInTheDocument()
+})
+
+// CORRECT: inline the data where it's used
+test('renders agent message', () => {
+  render(
+    <AgentMessage
+      message={{
+        id: '1',
+        sender: 'agent',
+        content: 'Hello',
+        timestamp: '2026-03-31T10:00:00Z',
+      }}
+    />
+  )
+  expect(screen.getByText('Hello')).toBeInTheDocument()
+})
+```
+
 ## E2E Testing
 
 Use **Playwright** for E2E tests against the Tauri webview (via `tauri-driver` or remote debugging).

--- a/src/features/chat/components/AgentMessage.test.tsx
+++ b/src/features/chat/components/AgentMessage.test.tsx
@@ -1,18 +1,19 @@
 import { describe, test, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import AgentMessage from './AgentMessage'
-import type { Message } from '../types'
 
 describe('AgentMessage', () => {
   test('renders agent avatar with psychology icon', () => {
-    const message: Message = {
-      id: '1',
-      sender: 'agent',
-      content: 'Test message',
-      timestamp: '2026-03-31T10:00:00Z',
-    }
-
-    render(<AgentMessage message={message} />)
+    render(
+      <AgentMessage
+        message={{
+          id: '1',
+          sender: 'agent',
+          content: 'Test message',
+          timestamp: '2026-03-31T10:00:00Z',
+        }}
+      />
+    )
 
     const avatar = screen.getByTestId('agent-avatar')
     expect(avatar).toBeInTheDocument()
@@ -24,28 +25,32 @@ describe('AgentMessage', () => {
   })
 
   test('renders VIBM Agent name', () => {
-    const message: Message = {
-      id: '1',
-      sender: 'agent',
-      content: 'Test message',
-      timestamp: '2026-03-31T10:00:00Z',
-    }
-
-    render(<AgentMessage message={message} />)
+    render(
+      <AgentMessage
+        message={{
+          id: '1',
+          sender: 'agent',
+          content: 'Test message',
+          timestamp: '2026-03-31T10:00:00Z',
+        }}
+      />
+    )
 
     expect(screen.getByText('VIBM Agent')).toBeInTheDocument()
   })
 
   test('renders StatusBadge when status provided', () => {
-    const message: Message = {
-      id: '1',
-      sender: 'agent',
-      content: 'Test message',
-      timestamp: '2026-03-31T10:00:00Z',
-      status: 'thinking',
-    }
-
-    render(<AgentMessage message={message} />)
+    render(
+      <AgentMessage
+        message={{
+          id: '1',
+          sender: 'agent',
+          content: 'Test message',
+          timestamp: '2026-03-31T10:00:00Z',
+          status: 'thinking',
+        }}
+      />
+    )
 
     const badge = screen.getByTestId('status-badge')
     expect(badge).toBeInTheDocument()
@@ -53,28 +58,32 @@ describe('AgentMessage', () => {
   })
 
   test('does not render StatusBadge when status not provided', () => {
-    const message: Message = {
-      id: '1',
-      sender: 'agent',
-      content: 'Test message',
-      timestamp: '2026-03-31T10:00:00Z',
-    }
-
-    render(<AgentMessage message={message} />)
+    render(
+      <AgentMessage
+        message={{
+          id: '1',
+          sender: 'agent',
+          content: 'Test message',
+          timestamp: '2026-03-31T10:00:00Z',
+        }}
+      />
+    )
 
     expect(screen.queryByTestId('status-badge')).not.toBeInTheDocument()
   })
 
   test('renders message content as thinking text when status is thinking', () => {
-    const message: Message = {
-      id: '1',
-      sender: 'agent',
-      content: 'Analyzing current middleware architecture...',
-      timestamp: '2026-03-31T10:00:00Z',
-      status: 'thinking',
-    }
-
-    render(<AgentMessage message={message} />)
+    render(
+      <AgentMessage
+        message={{
+          id: '1',
+          sender: 'agent',
+          content: 'Analyzing current middleware architecture...',
+          timestamp: '2026-03-31T10:00:00Z',
+          status: 'thinking',
+        }}
+      />
+    )
 
     const content = screen.getByText(
       'Analyzing current middleware architecture...'
@@ -84,15 +93,17 @@ describe('AgentMessage', () => {
   })
 
   test('renders message content normally when status is not thinking', () => {
-    const message: Message = {
-      id: '1',
-      sender: 'agent',
-      content: 'Analysis complete.',
-      timestamp: '2026-03-31T10:00:00Z',
-      status: 'completed',
-    }
-
-    render(<AgentMessage message={message} />)
+    render(
+      <AgentMessage
+        message={{
+          id: '1',
+          sender: 'agent',
+          content: 'Analysis complete.',
+          timestamp: '2026-03-31T10:00:00Z',
+          status: 'completed',
+        }}
+      />
+    )
 
     const content = screen.getByText('Analysis complete.')
     expect(content).toBeInTheDocument()
@@ -100,21 +111,23 @@ describe('AgentMessage', () => {
   })
 
   test('renders code blocks when codeSnippets provided', () => {
-    const message: Message = {
-      id: '1',
-      sender: 'agent',
-      content: 'Here is the refactored code:',
-      timestamp: '2026-03-31T10:00:00Z',
-      codeSnippets: [
-        {
-          filename: 'auth_middleware.py',
-          language: 'python',
-          code: 'import redis_client\nfrom vibm.sessions import SessionStore',
-        },
-      ],
-    }
-
-    render(<AgentMessage message={message} />)
+    render(
+      <AgentMessage
+        message={{
+          id: '1',
+          sender: 'agent',
+          content: 'Here is the refactored code:',
+          timestamp: '2026-03-31T10:00:00Z',
+          codeSnippets: [
+            {
+              filename: 'auth_middleware.py',
+              language: 'python',
+              code: 'import redis_client\nfrom vibm.sessions import SessionStore',
+            },
+          ],
+        }}
+      />
+    )
 
     expect(screen.getByTestId('code-block')).toBeInTheDocument()
     expect(screen.getByText('auth_middleware.py')).toBeInTheDocument()
@@ -122,40 +135,44 @@ describe('AgentMessage', () => {
   })
 
   test('renders multiple code blocks', () => {
-    const message: Message = {
-      id: '1',
-      sender: 'agent',
-      content: 'Multiple files updated:',
-      timestamp: '2026-03-31T10:00:00Z',
-      codeSnippets: [
-        {
-          filename: 'file1.ts',
-          language: 'typescript',
-          code: 'const x = 1',
-        },
-        {
-          filename: 'file2.ts',
-          language: 'typescript',
-          code: 'const y = 2',
-        },
-      ],
-    }
-
-    render(<AgentMessage message={message} />)
+    render(
+      <AgentMessage
+        message={{
+          id: '1',
+          sender: 'agent',
+          content: 'Multiple files updated:',
+          timestamp: '2026-03-31T10:00:00Z',
+          codeSnippets: [
+            {
+              filename: 'file1.ts',
+              language: 'typescript',
+              code: 'const x = 1',
+            },
+            {
+              filename: 'file2.ts',
+              language: 'typescript',
+              code: 'const y = 2',
+            },
+          ],
+        }}
+      />
+    )
 
     const codeBlocks = screen.getAllByTestId('code-block')
     expect(codeBlocks).toHaveLength(2)
   })
 
   test('applies correct Tailwind classes to message bubble', () => {
-    const message: Message = {
-      id: '1',
-      sender: 'agent',
-      content: 'Test message',
-      timestamp: '2026-03-31T10:00:00Z',
-    }
-
-    render(<AgentMessage message={message} />)
+    render(
+      <AgentMessage
+        message={{
+          id: '1',
+          sender: 'agent',
+          content: 'Test message',
+          timestamp: '2026-03-31T10:00:00Z',
+        }}
+      />
+    )
 
     const bubble = screen.getByTestId('agent-message-bubble')
     expect(bubble).toHaveClass(
@@ -169,14 +186,16 @@ describe('AgentMessage', () => {
   })
 
   test('renders container with proper structure', () => {
-    const message: Message = {
-      id: '1',
-      sender: 'agent',
-      content: 'Test message',
-      timestamp: '2026-03-31T10:00:00Z',
-    }
-
-    render(<AgentMessage message={message} />)
+    render(
+      <AgentMessage
+        message={{
+          id: '1',
+          sender: 'agent',
+          content: 'Test message',
+          timestamp: '2026-03-31T10:00:00Z',
+        }}
+      />
+    )
 
     const container = screen.getByTestId('agent-message-container')
     expect(container).toHaveClass('flex', 'gap-4', 'max-w-3xl', 'mx-auto')

--- a/src/features/chat/components/MessageThread.test.tsx
+++ b/src/features/chat/components/MessageThread.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { describe, test, expect } from 'vitest'
 import MessageThread from './MessageThread'
-import type { Message } from '../types'
 
 describe('MessageThread', () => {
   test('renders scrollable container with correct Tailwind classes', () => {
@@ -18,57 +17,66 @@ describe('MessageThread', () => {
   })
 
   test('renders UserMessage components for user messages', () => {
-    const messages: Message[] = [
-      {
-        id: 'msg-1',
-        sender: 'user',
-        content: 'Test user message',
-        timestamp: '2026-03-31T10:00:00Z',
-      },
-    ]
-    render(<MessageThread messages={messages} />)
+    render(
+      <MessageThread
+        messages={[
+          {
+            id: 'msg-1',
+            sender: 'user',
+            content: 'Test user message',
+            timestamp: '2026-03-31T10:00:00Z',
+          },
+        ]}
+      />
+    )
     expect(screen.getByTestId('user-message-container')).toBeInTheDocument()
     expect(screen.getByText('Test user message')).toBeInTheDocument()
   })
 
   test('renders AgentMessage components for agent messages', () => {
-    const messages: Message[] = [
-      {
-        id: 'msg-2',
-        sender: 'agent',
-        content: 'Test agent response',
-        timestamp: '2026-03-31T10:01:00Z',
-        status: 'thinking',
-      },
-    ]
-    render(<MessageThread messages={messages} />)
+    render(
+      <MessageThread
+        messages={[
+          {
+            id: 'msg-2',
+            sender: 'agent',
+            content: 'Test agent response',
+            timestamp: '2026-03-31T10:01:00Z',
+            status: 'thinking',
+          },
+        ]}
+      />
+    )
     expect(screen.getByTestId('agent-message-container')).toBeInTheDocument()
     expect(screen.getByText('Test agent response')).toBeInTheDocument()
   })
 
   test('renders multiple messages in order', () => {
-    const messages: Message[] = [
-      {
-        id: 'msg-1',
-        sender: 'user',
-        content: 'First message',
-        timestamp: '2026-03-31T10:00:00Z',
-      },
-      {
-        id: 'msg-2',
-        sender: 'agent',
-        content: 'Second message',
-        timestamp: '2026-03-31T10:01:00Z',
-        status: 'completed',
-      },
-      {
-        id: 'msg-3',
-        sender: 'user',
-        content: 'Third message',
-        timestamp: '2026-03-31T10:02:00Z',
-      },
-    ]
-    render(<MessageThread messages={messages} />)
+    render(
+      <MessageThread
+        messages={[
+          {
+            id: 'msg-1',
+            sender: 'user',
+            content: 'First message',
+            timestamp: '2026-03-31T10:00:00Z',
+          },
+          {
+            id: 'msg-2',
+            sender: 'agent',
+            content: 'Second message',
+            timestamp: '2026-03-31T10:01:00Z',
+            status: 'completed',
+          },
+          {
+            id: 'msg-3',
+            sender: 'user',
+            content: 'Third message',
+            timestamp: '2026-03-31T10:02:00Z',
+          },
+        ]}
+      />
+    )
     expect(screen.getByTestId('message-container-msg-1')).toBeInTheDocument()
     expect(screen.getByTestId('message-container-msg-2')).toBeInTheDocument()
     expect(screen.getByTestId('message-container-msg-3')).toBeInTheDocument()
@@ -85,59 +93,69 @@ describe('MessageThread', () => {
   })
 
   test('wraps messages in max-w-3xl mx-auto container', () => {
-    const messages: Message[] = [
-      {
-        id: 'msg-1',
-        sender: 'user',
-        content: 'Test message',
-        timestamp: '2026-03-31T10:00:00Z',
-      },
-    ]
-    render(<MessageThread messages={messages} />)
+    render(
+      <MessageThread
+        messages={[
+          {
+            id: 'msg-1',
+            sender: 'user',
+            content: 'Test message',
+            timestamp: '2026-03-31T10:00:00Z',
+          },
+        ]}
+      />
+    )
     const container = screen.getByTestId('message-container-msg-1')
     expect(container).toBeInTheDocument()
     expect(container).toHaveClass('max-w-3xl', 'mx-auto')
   })
 
   test('renders agent messages with code snippets', () => {
-    const messages: Message[] = [
-      {
-        id: 'msg-4',
-        sender: 'agent',
-        content: 'Here is the refactored code:',
-        timestamp: '2026-03-31T10:03:00Z',
-        status: 'completed',
-        codeSnippets: [
+    render(
+      <MessageThread
+        messages={[
           {
-            language: 'typescript',
-            filename: 'test.ts',
-            code: 'const foo = "bar"',
+            id: 'msg-4',
+            sender: 'agent',
+            content: 'Here is the refactored code:',
+            timestamp: '2026-03-31T10:03:00Z',
+            status: 'completed',
+            codeSnippets: [
+              {
+                language: 'typescript',
+                filename: 'test.ts',
+                code: 'const foo = "bar"',
+              },
+            ],
           },
-        ],
-      },
-    ]
-    render(<MessageThread messages={messages} />)
+        ]}
+      />
+    )
     expect(screen.getByTestId('agent-message-container')).toBeInTheDocument()
     expect(screen.getByText('Here is the refactored code:')).toBeInTheDocument()
     expect(screen.getByText('test.ts')).toBeInTheDocument()
   })
 
   test('uses message id as key for rendering', () => {
-    const messages: Message[] = [
-      {
-        id: 'unique-id-1',
-        sender: 'user',
-        content: 'Message 1',
-        timestamp: '2026-03-31T10:00:00Z',
-      },
-      {
-        id: 'unique-id-2',
-        sender: 'agent',
-        content: 'Message 2',
-        timestamp: '2026-03-31T10:01:00Z',
-      },
-    ]
-    render(<MessageThread messages={messages} />)
+    render(
+      <MessageThread
+        messages={[
+          {
+            id: 'unique-id-1',
+            sender: 'user',
+            content: 'Message 1',
+            timestamp: '2026-03-31T10:00:00Z',
+          },
+          {
+            id: 'unique-id-2',
+            sender: 'agent',
+            content: 'Message 2',
+            timestamp: '2026-03-31T10:01:00Z',
+          },
+        ]}
+      />
+    )
+
     expect(
       screen.getByTestId('message-container-unique-id-1')
     ).toBeInTheDocument()

--- a/src/features/chat/components/UserMessage.test.tsx
+++ b/src/features/chat/components/UserMessage.test.tsx
@@ -67,14 +67,16 @@ describe('UserMessage', () => {
   })
 
   test('renders inline code with special styling', () => {
-    const messageWithCode: Message = {
-      id: '2',
-      sender: 'user',
-      content: 'Can you refactor `auth_middleware.py` to use async?',
-      timestamp: '2026-03-31T10:42:00Z',
-    }
-
-    render(<UserMessage message={messageWithCode} />)
+    render(
+      <UserMessage
+        message={{
+          id: '2',
+          sender: 'user',
+          content: 'Can you refactor `auth_middleware.py` to use async?',
+          timestamp: '2026-03-31T10:42:00Z',
+        }}
+      />
+    )
 
     const codeElement = screen.getByText('auth_middleware.py')
     expect(codeElement.tagName).toBe('CODE')

--- a/src/features/chat/types/index.test.ts
+++ b/src/features/chat/types/index.test.ts
@@ -3,40 +3,31 @@ import { isMessage, isCodeSnippet, isConversationItem } from './index'
 
 describe('CodeSnippet type guard', () => {
   test('returns true for valid CodeSnippet', () => {
-    const validSnippet = {
-      language: 'typescript',
-      filename: 'example.ts',
-      code: 'const foo = "bar";',
-    }
-
-    expect(isCodeSnippet(validSnippet)).toBe(true)
+    expect(
+      isCodeSnippet({
+        language: 'typescript',
+        filename: 'example.ts',
+        code: 'const foo = "bar";',
+      })
+    ).toBe(true)
   })
 
   test('returns false for object missing language', () => {
-    const invalid = {
-      filename: 'example.ts',
-      code: 'const foo = "bar";',
-    }
-
-    expect(isCodeSnippet(invalid)).toBe(false)
+    expect(
+      isCodeSnippet({ filename: 'example.ts', code: 'const foo = "bar";' })
+    ).toBe(false)
   })
 
   test('returns false for object missing filename', () => {
-    const invalid = {
-      language: 'typescript',
-      code: 'const foo = "bar";',
-    }
-
-    expect(isCodeSnippet(invalid)).toBe(false)
+    expect(
+      isCodeSnippet({ language: 'typescript', code: 'const foo = "bar";' })
+    ).toBe(false)
   })
 
   test('returns false for object missing code', () => {
-    const invalid = {
-      language: 'typescript',
-      filename: 'example.ts',
-    }
-
-    expect(isCodeSnippet(invalid)).toBe(false)
+    expect(
+      isCodeSnippet({ language: 'typescript', filename: 'example.ts' })
+    ).toBe(false)
   })
 
   test('returns false for null', () => {
@@ -50,86 +41,86 @@ describe('CodeSnippet type guard', () => {
 
 describe('Message type guard', () => {
   test('returns true for valid Message without codeSnippets', () => {
-    const validMessage = {
-      id: '1',
-      sender: 'user',
-      content: 'Hello world',
-      timestamp: '2026-03-31T10:00:00Z',
-      status: 'sent',
-    }
-
-    expect(isMessage(validMessage)).toBe(true)
+    expect(
+      isMessage({
+        id: '1',
+        sender: 'user',
+        content: 'Hello world',
+        timestamp: '2026-03-31T10:00:00Z',
+        status: 'sent',
+      })
+    ).toBe(true)
   })
 
   test('returns true for valid Message with codeSnippets', () => {
-    const validMessage = {
-      id: '2',
-      sender: 'agent',
-      content: 'Here is some code',
-      timestamp: '2026-03-31T10:01:00Z',
-      codeSnippets: [
-        {
-          language: 'typescript',
-          filename: 'test.ts',
-          code: 'console.log("test");',
-        },
-      ],
-      status: 'thinking',
-    }
-
-    expect(isMessage(validMessage)).toBe(true)
+    expect(
+      isMessage({
+        id: '2',
+        sender: 'agent',
+        content: 'Here is some code',
+        timestamp: '2026-03-31T10:01:00Z',
+        codeSnippets: [
+          {
+            language: 'typescript',
+            filename: 'test.ts',
+            code: 'console.log("test");',
+          },
+        ],
+        status: 'thinking',
+      })
+    ).toBe(true)
   })
 
   test('returns false for object missing id', () => {
-    const invalid = {
-      sender: 'user',
-      content: 'Hello',
-      timestamp: '2026-03-31T10:00:00Z',
-    }
-
-    expect(isMessage(invalid)).toBe(false)
+    expect(
+      isMessage({
+        sender: 'user',
+        content: 'Hello',
+        timestamp: '2026-03-31T10:00:00Z',
+      })
+    ).toBe(false)
   })
 
   test('returns false for object missing sender', () => {
-    const invalid = {
-      id: '1',
-      content: 'Hello',
-      timestamp: '2026-03-31T10:00:00Z',
-    }
-
-    expect(isMessage(invalid)).toBe(false)
+    expect(
+      isMessage({
+        id: '1',
+        content: 'Hello',
+        timestamp: '2026-03-31T10:00:00Z',
+      })
+    ).toBe(false)
   })
 
   test('returns false for object missing content', () => {
-    const invalid = {
-      id: '1',
-      sender: 'user',
-      timestamp: '2026-03-31T10:00:00Z',
-    }
-
-    expect(isMessage(invalid)).toBe(false)
+    expect(
+      isMessage({
+        id: '1',
+        sender: 'user',
+        timestamp: '2026-03-31T10:00:00Z',
+      })
+    ).toBe(false)
   })
 
   test('returns false for object missing timestamp', () => {
-    const invalid = {
-      id: '1',
-      sender: 'user',
-      content: 'Hello',
-    }
-
-    expect(isMessage(invalid)).toBe(false)
+    expect(
+      isMessage({
+        id: '1',
+        sender: 'user',
+        content: 'Hello',
+      })
+    ).toBe(false)
   })
 
   test('returns false for invalid codeSnippets array', () => {
-    const invalid = {
-      id: '1',
-      sender: 'user',
-      content: 'Hello',
-      timestamp: '2026-03-31T10:00:00Z',
-      codeSnippets: [{ invalid: 'snippet' }],
-    }
-
-    expect(isMessage(invalid)).toBe(false)
+    expect(
+      isMessage({
+        id: '1',
+        sender: 'user',
+        content: 'Hello',
+        timestamp: '2026-03-31T10:00:00Z',
+        codeSnippets: [{ invalid: 'snippet' }],
+      })
+    ).toBe(false)
   })
 
   test('returns false for null', () => {
@@ -139,82 +130,82 @@ describe('Message type guard', () => {
 
 describe('ConversationItem type guard', () => {
   test('returns true for valid ConversationItem', () => {
-    const validItem = {
-      id: '1',
-      title: 'Conversation about TypeScript',
-      timestamp: '2026-03-31T10:00:00Z',
-      hasSubThreads: true,
-      active: true,
-    }
-
-    expect(isConversationItem(validItem)).toBe(true)
+    expect(
+      isConversationItem({
+        id: '1',
+        title: 'Conversation about TypeScript',
+        timestamp: '2026-03-31T10:00:00Z',
+        hasSubThreads: true,
+        active: true,
+      })
+    ).toBe(true)
   })
 
   test('returns true for inactive ConversationItem without sub-threads', () => {
-    const validItem = {
-      id: '2',
-      title: 'Old conversation',
-      timestamp: '2026-03-30T08:00:00Z',
-      hasSubThreads: false,
-      active: false,
-    }
-
-    expect(isConversationItem(validItem)).toBe(true)
+    expect(
+      isConversationItem({
+        id: '2',
+        title: 'Old conversation',
+        timestamp: '2026-03-30T08:00:00Z',
+        hasSubThreads: false,
+        active: false,
+      })
+    ).toBe(true)
   })
 
   test('returns false for object missing id', () => {
-    const invalid = {
-      title: 'Test',
-      timestamp: '2026-03-31T10:00:00Z',
-      hasSubThreads: false,
-      active: true,
-    }
-
-    expect(isConversationItem(invalid)).toBe(false)
+    expect(
+      isConversationItem({
+        title: 'Test',
+        timestamp: '2026-03-31T10:00:00Z',
+        hasSubThreads: false,
+        active: true,
+      })
+    ).toBe(false)
   })
 
   test('returns false for object missing title', () => {
-    const invalid = {
-      id: '1',
-      timestamp: '2026-03-31T10:00:00Z',
-      hasSubThreads: false,
-      active: true,
-    }
-
-    expect(isConversationItem(invalid)).toBe(false)
+    expect(
+      isConversationItem({
+        id: '1',
+        timestamp: '2026-03-31T10:00:00Z',
+        hasSubThreads: false,
+        active: true,
+      })
+    ).toBe(false)
   })
 
   test('returns false for object missing timestamp', () => {
-    const invalid = {
-      id: '1',
-      title: 'Test',
-      hasSubThreads: false,
-      active: true,
-    }
-
-    expect(isConversationItem(invalid)).toBe(false)
+    expect(
+      isConversationItem({
+        id: '1',
+        title: 'Test',
+        hasSubThreads: false,
+        active: true,
+      })
+    ).toBe(false)
   })
 
   test('returns false for object missing hasSubThreads', () => {
-    const invalid = {
-      id: '1',
-      title: 'Test',
-      timestamp: '2026-03-31T10:00:00Z',
-      active: true,
-    }
-
-    expect(isConversationItem(invalid)).toBe(false)
+    expect(
+      isConversationItem({
+        id: '1',
+        title: 'Test',
+        timestamp: '2026-03-31T10:00:00Z',
+        active: true,
+      })
+    ).toBe(false)
   })
 
   test('returns false for object missing active', () => {
-    const invalid = {
-      id: '1',
-      title: 'Test',
-      timestamp: '2026-03-31T10:00:00Z',
-      hasSubThreads: false,
-    }
-
-    expect(isConversationItem(invalid)).toBe(false)
+    expect(
+      isConversationItem({
+        id: '1',
+        title: 'Test',
+        timestamp: '2026-03-31T10:00:00Z',
+        hasSubThreads: false,
+      })
+    ).toBe(false)
   })
 
   test('returns false for null', () => {


### PR DESCRIPTION
## Summary

- **Document test data style principle** in `rules/typescript/testing.md` — inline single-use variables, only extract when referenced 2+ times
- **Inline test data** across 4 test files: AgentMessage, UserMessage, MessageThread, and types/index
- **Update CLAUDE.md** with commands, architecture, code style, and design system quick-reference sections

## Files changed

| File | Change |
|------|--------|
| `CLAUDE.md` | Added commands, architecture, code style, design system, git hooks sections |
| `rules/typescript/testing.md` | Added "Test Data Style" section with wrong/correct examples |
| `AgentMessage.test.tsx` | Inlined all 10 single-use `message` variables |
| `MessageThread.test.tsx` | Inlined 6 single-use `messages` arrays, removed unused `Message` import |
| `UserMessage.test.tsx` | Inlined `messageWithCode` (kept shared `mockMessage` — used 8x) |
| `types/index.test.ts` | Inlined all single-use `validSnippet`, `validMessage`, `validItem`, `invalid` variables |

## Test plan

- [x] All 160 tests pass (`npx vitest run`)
- [x] ESLint passes (pre-commit hook)
- [x] TypeScript type-check passes (pre-commit hook)
- [x] Prettier formatting passes (pre-commit hook)