### PR TITLE
docs: update documentation for Codex feedback loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,10 @@ Quick reference: no semicolons, single quotes, trailing commas (es5), arrow-func
 - `docs/design/git_diff/` — git diff viewer screen
 - `docs/design/command_palette/` — command palette overlay
 
+## Harness Integration
+
+This file is read by Codex during both **local reviews** (Phase 2 inner loop via `codex exec review --base main`) and **cloud reviews** (GitHub Action on PRs). It provides the project context that informs review quality. See `harness/CLAUDE.md` for the full three-phase harness workflow.
+
 ## Review Profile
 
 Follow the review process and checklist defined in `agents/code-reviewer.md`. Key points:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ npm run lint:fix        # ESLint with auto-fix
 npm run format:check    # Prettier check
 npm run format          # Prettier write
 npm run type-check      # tsc -b
+npm run review          # Local Codex code review (saves to .codex-reviews/)
+npm run review:fix      # Interactive review-fix loop (fetch → fix → push → poll)
 ```
 
 Node >= 24 (see `.nvmrc`). ESM-only (`"type": "module"`).
@@ -72,13 +74,14 @@ Dark atmospheric UI built on Catppuccin Mocha palette. Colors defined as semanti
 
 This file covers what you need to start working. For deeper topics, read the linked doc — do NOT inline their content back here.
 
-| Topic                                                    | Where                                                           |
-| -------------------------------------------------------- | --------------------------------------------------------------- |
-| Architecture decisions, Tauri IPC patterns               | `ARCHITECT.md`                                                  |
-| UI design system, screens, components                    | `DESIGN.md` → `docs/design/`                                    |
-| AI agent specs (planner, tdd-guide, code-reviewer, etc.) | `agents/CLAUDE.md`                                              |
-| Development standards (coding style, testing, security)  | `rules/CLAUDE.md`                                               |
-| Autonomous development loop (harness)                    | `harness/CLAUDE.md`                                             |
-| Architecture specs, exploration notes                    | `docs/CLAUDE.md`                                                |
-| Codex code review (project context for Codex)            | `AGENTS.md`                                                     |
-| Codex review design spec                                 | `docs/superpowers/specs/2026-04-02-codex-code-review-design.md` |
+| Topic                                                    | Where                                                             |
+| -------------------------------------------------------- | ----------------------------------------------------------------- |
+| Architecture decisions, Tauri IPC patterns               | `ARCHITECT.md`                                                    |
+| UI design system, screens, components                    | `DESIGN.md` → `docs/design/`                                      |
+| AI agent specs (planner, tdd-guide, code-reviewer, etc.) | `agents/CLAUDE.md`                                                |
+| Development standards (coding style, testing, security)  | `rules/CLAUDE.md`                                                 |
+| Autonomous development loop (harness + Codex review)     | `harness/CLAUDE.md`                                               |
+| Architecture specs, exploration notes                    | `docs/CLAUDE.md`                                                  |
+| Codex code review (project context for Codex)            | `AGENTS.md`                                                       |
+| Codex review design spec                                 | `docs/superpowers/specs/2026-04-02-codex-code-review-design.md`   |
+| Codex feedback loop design spec                          | `docs/superpowers/specs/2026-04-03-codex-feedback-loop-design.md` |

--- a/docs/superpowers/specs/2026-04-03-codex-feedback-loop-design.md
+++ b/docs/superpowers/specs/2026-04-03-codex-feedback-loop-design.md
@@ -1,7 +1,7 @@
 # Codex Feedback Loop — Design Spec
 
 **Date**: 2026-04-03
-**Status**: Implemented (in review)
+**Status**: Merged (PR #10, 2026-04-03)
 **Depends on**: Codex Code Review Agent (2026-04-02 spec, merged to main)
 
 ## Problem
@@ -287,5 +287,8 @@ Python module containing:
 | `gh api` blocked only for explicit `-X DELETE/PUT/PATCH`    | Also block `-X POST` and data flags (`-f`, `-F`, `--field`, `--raw-field`, `--input`) | Data flags implicitly switch `gh api` to POST, bypassing read-only intent        |
 | Cloud review comment parsing via newline splitting          | Parse as JSON array via `--jq '[.[].body]'`                                           | Multi-line comments get fragmented by newline splitting, causing false positives |
 | `--max-relay-loops` defined but unused                      | Wired into Phase 3 loop                                                               | Codex review caught the unused flag at 91% confidence                            |
-| `client.py` edit for review fix cluster                     | Not needed yet                                                                        | Phase 3 fix cluster spawning is stubbed (TODO), client changes deferred          |
-| `harness/CLAUDE.md` update                                  | Deferred to post-merge                                                                | Will update once PR is merged and workflow is validated                          |
+| `client.py` edit for review fix cluster                     | Uses existing `create_client` + `run_feature_iteration` with `prompt_override`        | No separate client needed — reuse Phase 2 infrastructure with reviewer prompt    |
+| `harness/CLAUDE.md` update                                  | Updated post-merge (docs/update-codex-feedback-loop branch)                           | Rewrote to document three-phase workflow, CLI flags, safety layers, file roles   |
+| Comment author not verified                                 | Filter by `user.login == "github-actions[bot]"` on all comment queries                | Codex review caught spoofing risk at 83% confidence                              |
+| Comment pagination missing                                  | Added `per_page=100&sort=created&direction=desc` to all `gh api` comment queries      | First page (30 oldest) could miss the latest review on busy PRs                  |
+| Substring-based `-X POST` blocking                          | Token-based parsing via `shlex.split` + `GH_BLOCKED_METHODS` constant                 | Extra whitespace (`-X   POST`) could bypass substring matching                   |

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -8,7 +8,7 @@ The harness is the project's primary engineering cycle — it drove the CI/CD an
 2. **Phase 2: Feature Loop** — for each pending feature, runs a Coder (Claude) + Reviewer (Codex CLI) inner loop. The Coder implements, Codex reviews locally, findings are fed back to the Coder. Repeats until clean or the per-feature iteration budget is exhausted.
 3. **Phase 3: Cloud Review** — the Coordinator pushes to GitHub, creates/finds a PR, polls for the cloud Codex review (via GitHub Action), and if issues are found, spawns a local Coder+Reviewer fix loop before pushing again. Up to `--max-relay-loops` cycles.
 
-Each phase creates fresh SDK clients as needed. The Coordinator (Python) handles all git/GitHub operations directly via subprocess — only Coder fix sessions spawn SDK agents.
+Phases 1 and 2 create SDK sessions for Initializer/Coder work. Phase 3 uses SDK sessions only for fix loops — all git/GitHub operations (push, PR, poll) are handled directly via subprocess by the Coordinator (Python).
 
 ## Environment Variables
 
@@ -74,7 +74,7 @@ Default model: `claude-sonnet-4-5-20250929`. Project dir defaults to repo root.
 | **Permissions**             | `client.py`   | `bypassPermissions` mode with file ops restricted to project dir                                                                                                                                               |
 | **Bash allowlist**          | `security.py` | Only whitelisted commands pass (`npm`, `cargo`, `git`, `gh`, `node`, etc.). Sensitive commands (`rm`, `pkill`, `chmod`, `gh`) get extra validation                                                             |
 | **gh subcommand validator** | `security.py` | Allowlist-only for `gh`: only `pr create/view/list`, `repo view`, `api` (GET), `auth status`. Blocks write methods (`-X POST/DELETE/PUT/PATCH`) and data flags (`-f`, `-F`, `--field`) via token-based parsing |
-| **Feature list protection** | `hooks.py`    | PreToolUse hook on Write — features cannot be removed or reordered, only `passes` field can change, must remain valid JSON array                                                                               |
+| **Feature list protection** | `hooks.py`    | PreToolUse hook on Write — features cannot be removed and descriptions cannot be edited; must remain valid JSON array. Note: Edit tool is not validated by this hook.                                          |
 | **Review comment auth**     | `review.py`   | Cloud review comments are only accepted from `github-actions[bot]` to prevent spoofing                                                                                                                         |
 
 ### Sandbox Configuration

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -2,12 +2,13 @@
 
 The harness is the project's primary engineering cycle — it drove the CI/CD and linter infrastructure already in place. Built on the Claude Code SDK, adapted from [Anthropic's autonomous-coding demo](https://github.com/anthropics/claude-quickstarts/tree/main/autonomous-coding).
 
-## Two-Agent Pattern
+## Three-Phase Workflow
 
-1. **Initializer** (first run, no `feature_list.json` present) — reads `app_spec.md`, decomposes it into a phased `feature_list.json` with dependencies
-2. **Coder** (all subsequent runs) — picks the next pending feature, implements it, marks `"passes": true` when done, auto-continues to the next feature
+1. **Phase 1: Initializer** (first run, no `feature_list.json`) — reads `app_spec.md`, decomposes it into a phased `feature_list.json` with dependencies
+2. **Phase 2: Feature Loop** — for each pending feature, runs a Coder (Claude) + Reviewer (Codex CLI) inner loop. The Coder implements, Codex reviews locally, findings are fed back to the Coder. Repeats until clean or the per-feature iteration budget is exhausted.
+3. **Phase 3: Cloud Review** — the Coordinator pushes to GitHub, creates/finds a PR, polls for the cloud Codex review (via GitHub Action), and if issues are found, spawns a local Coder+Reviewer fix loop before pushing again. Up to `--max-relay-loops` cycles.
 
-Each iteration creates a fresh SDK client (`client.py`) → loads the appropriate prompt (`prompts/initializer_prompt.md` or `prompts/coding_prompt.md`) → runs a session → prints progress → sleeps 3s → loops.
+Each phase creates fresh SDK clients as needed. The Coordinator (Python) handles all git/GitHub operations directly via subprocess — only Coder fix sessions spawn SDK agents.
 
 ## Environment Variables
 
@@ -15,6 +16,9 @@ Each iteration creates a fresh SDK client (`client.py`) → loads the appropriat
 | -------------------- | -------- | -------------------------------------------------------- |
 | `ANTHROPIC_API_KEY`  | Yes      | API key from console.anthropic.com (or compatible proxy) |
 | `ANTHROPIC_BASE_URL` | No       | Override API endpoint (for proxies or self-hosted)       |
+| `OPENAI_API_KEY`     | Yes\*    | Required for local Codex CLI review (Phase 2 + Phase 3)  |
+
+\*Not required if running with `--skip-review --skip-relay`.
 
 The harness does **not** auto-load `.env`. Source it before running:
 
@@ -22,14 +26,19 @@ The harness does **not** auto-load `.env`. Source it before running:
 set -a && source .env && set +a
 ```
 
+**Additional requirement:** `gh` CLI must be authenticated (`gh auth login`) for Phase 3 cloud operations.
+
 ## Running
 
 ```bash
 cd harness && pip3 install -r requirements.txt
 
 # Source env vars first (see above), then:
-python3 autonomous_agent_demo.py                        # Unlimited iterations
-python3 autonomous_agent_demo.py --max-iterations 5     # Capped
+python3 autonomous_agent_demo.py                        # Full loop (Phases 1-3)
+python3 autonomous_agent_demo.py --max-iterations 5     # 5 iterations per feature
+python3 autonomous_agent_demo.py --skip-review           # No local Codex review (Phase 2)
+python3 autonomous_agent_demo.py --skip-relay            # No cloud review (Phase 3)
+python3 autonomous_agent_demo.py --skip-review --skip-relay  # Coder only, no review
 python3 autonomous_agent_demo.py --model claude-sonnet-4-5-20250929  # Override model
 python3 autonomous_agent_demo.py --project-dir ../       # Custom project dir
 python3 autonomous_agent_demo.py --no-sandbox            # Windows/WSL2 only
@@ -41,14 +50,32 @@ Default model: `claude-sonnet-4-5-20250929`. Project dir defaults to repo root.
 
 **Tip:** Always dry-run with `--max-iterations 1` first to verify the environment works before scaling up.
 
+### CLI Flags
+
+| Flag                | Default                    | Description                                                |
+| ------------------- | -------------------------- | ---------------------------------------------------------- |
+| `--max-iterations`  | unlimited                  | Per-feature iteration budget (Coder → Review → Fix cycles) |
+| `--skip-review`     | false                      | Skip local Codex review in Phase 2 feature loop            |
+| `--skip-relay`      | false                      | Skip Phase 3 cloud review entirely                         |
+| `--review-timeout`  | 300 (5 min)                | Max seconds to wait for cloud Codex review comment         |
+| `--max-relay-loops` | 2                          | Max cloud review-fix cycles in Phase 3                     |
+| `--model`           | claude-sonnet-4-5-20250929 | Claude model for Coder sessions                            |
+| `--project-dir`     | repo root                  | Target project directory                                   |
+| `--no-sandbox`      | false                      | Disable OS-level sandbox (WSL2 only)                       |
+| `--clean`           | false                      | Wipe runtime files before starting                         |
+
+**Note:** `--max-iterations` is a **per-feature** budget, not a global count. With `--max-iterations 5` and 10 features, each feature gets up to 5 rounds of (code → review → fix).
+
 ## Safety Layers
 
-| Layer                       | File          | Purpose                                                                                                                                |
-| --------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| **Settings isolation**      | `client.py`   | `CLAUDE_CONFIG_DIR` set to temp dir — prevents user-level hooks from interfering                                                       |
-| **Permissions**             | `client.py`   | `bypassPermissions` mode with file ops restricted to project dir                                                                       |
-| **Bash allowlist**          | `security.py` | Only whitelisted commands pass (`npm`, `cargo`, `git`, `node`, etc.). Sensitive commands (`rm`, `pkill`, `chmod`) get extra validation |
-| **Feature list protection** | `hooks.py`    | PreToolUse hook on Write — features cannot be removed or reordered, only `passes` field can change, must remain valid JSON array       |
+| Layer                       | File          | Purpose                                                                                                                                                                                                        |
+| --------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Settings isolation**      | `client.py`   | `CLAUDE_CONFIG_DIR` set to temp dir — prevents user-level hooks from interfering                                                                                                                               |
+| **Permissions**             | `client.py`   | `bypassPermissions` mode with file ops restricted to project dir                                                                                                                                               |
+| **Bash allowlist**          | `security.py` | Only whitelisted commands pass (`npm`, `cargo`, `git`, `gh`, `node`, etc.). Sensitive commands (`rm`, `pkill`, `chmod`, `gh`) get extra validation                                                             |
+| **gh subcommand validator** | `security.py` | Allowlist-only for `gh`: only `pr create/view/list`, `repo view`, `api` (GET), `auth status`. Blocks write methods (`-X POST/DELETE/PUT/PATCH`) and data flags (`-f`, `-F`, `--field`) via token-based parsing |
+| **Feature list protection** | `hooks.py`    | PreToolUse hook on Write — features cannot be removed or reordered, only `passes` field can change, must remain valid JSON array                                                                               |
+| **Review comment auth**     | `review.py`   | Cloud review comments are only accepted from `github-actions[bot]` to prevent spoofing                                                                                                                         |
 
 ### Sandbox Configuration
 
@@ -65,16 +92,49 @@ Python hooks (`security.py`, `hooks.py`) fire regardless of sandbox or permissio
 
 ## File Roles
 
-| File                       | Role                                                                                  |
-| -------------------------- | ------------------------------------------------------------------------------------- |
-| `autonomous_agent_demo.py` | CLI entry point (argparse, asyncio.run)                                               |
-| `agent.py`                 | Core session loop — query SDK, stream response, handle tool use blocks                |
-| `client.py`                | SDK client factory — security config, system prompt, hooks registration               |
-| `security.py`              | Bash command allowlist + validators for `pkill`/`chmod`/`rm`                          |
-| `hooks.py`                 | PreToolUse hook protecting `feature_list.json` integrity                              |
-| `prompts.py`               | Load prompt templates from `prompts/` dir, copy `app_spec.md` on first run            |
-| `progress.py`              | Read `feature_list.json`, render progress bar                                         |
-| `prompts/`                 | Markdown prompt templates: `initializer_prompt.md`, `coding_prompt.md`, `app_spec.md` |
+| File                            | Role                                                                                |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| `autonomous_agent_demo.py`      | CLI entry point (argparse, asyncio.run, Phase 1-2-3 orchestration)                  |
+| `agent.py`                      | Core loop — per-feature Coder+Reviewer iterations, cloud review relay loop          |
+| `client.py`                     | SDK client factory — security config, system prompt, hooks registration             |
+| `security.py`                   | Bash command allowlist + validators for `pkill`/`chmod`/`rm`/`gh`                   |
+| `hooks.py`                      | PreToolUse hook protecting `feature_list.json` integrity                            |
+| `review.py`                     | Local Codex CLI review, cloud review polling (gh api), PR creation, comment parsing |
+| `prompts.py`                    | Load prompt templates, inject review findings, copy `app_spec.md` on first run      |
+| `progress.py`                   | Read `feature_list.json`, render progress bar                                       |
+| `prompts/initializer_prompt.md` | Prompt for Phase 1 (decompose spec into features)                                   |
+| `prompts/coding_prompt.md`      | Prompt for Coder sessions (implement features)                                      |
+| `prompts/reviewer_prompt.md`    | Prompt for fix sessions (address cloud review findings)                             |
+| `prompts/app_spec.md`           | Default app specification template                                                  |
+
+## Codex Code Review Integration
+
+A cross-vendor automated code review using OpenAI Codex provides a second-opinion gate that catches blind spots a same-model review would miss.
+
+### Local Review (Phase 2)
+
+Each feature iteration runs `codex exec review --base main` locally after the Coder finishes. If Codex finds issues, findings are fed back to the Coder on the next iteration. This loop continues until the review is clean or the iteration budget is exhausted.
+
+### Cloud Review (Phase 3)
+
+After all features are complete, the Coordinator:
+
+1. Pushes the branch and creates/finds a PR (`gh pr create`)
+2. Polls for a cloud Codex review comment (`gh api`, filtered by `github-actions[bot]`)
+3. If findings exist, spawns a local Coder+Reviewer fix loop (budget: 2 iterations)
+4. Pushes fixes and polls for the next review (up to `--max-relay-loops` cycles)
+
+### GitHub Action
+
+The Codex GitHub Action (`.github/workflows/codex-review.yml`) runs `openai/codex-action@v1` on every PR. It posts a formatted markdown comment with severity-tagged findings (CRITICAL/HIGH/MEDIUM/LOW). The structured output schema lives at `.github/codex/codex-output-schema.json`.
+
+### Interactive Fix Loop
+
+`npm run review:fix` or the `/review-fix` skill in Claude Code provides a self-driving fix loop: fetch Codex review → fix findings → push → poll for next review → repeat until clean (max 10 rounds).
+
+### Project Context
+
+Codex reads `AGENTS.md` at the repo root for project-specific review guidelines during both local and cloud reviews.
 
 ## Feature Tracking (`feature_list.json`)
 
@@ -83,7 +143,7 @@ Tracks implementation progress across phases. Each feature has:
 - `id`, `phase`, `category`, `description`, `steps[]`, `dependencies[]`
 - `"passes": true` = complete, `"passes": false` = pending
 
-The coder agent picks the next feature whose dependencies are all satisfied.
+The coder agent picks the next feature whose dependencies are all satisfied. Features that exhaust their iteration budget without passing are marked as exhausted and skipped.
 
 ## Adding New Work
 
@@ -112,20 +172,6 @@ async def my_hook(input_data, tool_use_id=None, context=None):
     command = tool_input.get("command", "")
 ```
 
-## Codex Code Review Integration
-
-A cross-vendor automated code review using OpenAI Codex runs alongside the harness workflow. It provides a second-opinion gate that catches blind spots a same-model review would miss.
-
-### How It Works
-
-- **GitHub Action** (`.github/workflows/codex-review.yml`): Runs `openai/codex-action@v1` on every PR. Posts a formatted markdown comment with severity-tagged findings (CRITICAL/HIGH/MEDIUM/LOW).
-- **Local review** (`npm run review`): Runs `codex exec review --base main` locally, saves structured output to `.codex-reviews/latest.md`.
-- **Project context**: Codex reads `AGENTS.md` at the repo root for project-specific review guidelines.
-
-### Relationship to the Harness
-
-The Codex review is currently independent of the harness loop — it runs on PRs created after the harness completes a feature. The planned feedback loop (`docs/superpowers/specs/2026-04-03-codex-feedback-loop-design.md`) will integrate Codex as **Phase 3: Reviewer agent**, closing the loop so the Coder agent can automatically address review findings before the PR is merged.
-
 ## Troubleshooting
 
 | Symptom                                        | Cause                                                                               | Fix                                                                                                                                     |
@@ -136,3 +182,6 @@ The Codex review is currently independent of the harness loop — it runs on PRs
 | User-level hooks interfere                     | SDK subprocess loads `~/.claude/settings.json`                                      | `client.py` sets `CLAUDE_CONFIG_DIR` to an isolated temp dir                                                                            |
 | `app_spec.md` empty at root                    | `prompts.py` skips copy if root file exists                                         | Write spec directly to root `app_spec.md`, not `prompts/app_spec.md`                                                                    |
 | `ANTHROPIC_API_KEY not set`                    | `.env` not sourced                                                                  | Run `set -a && source .env && set +a` before launching                                                                                  |
+| Codex review always errors                     | `OPENAI_API_KEY` not set or `codex` CLI not installed                               | `npm i -g @openai/codex` and set `OPENAI_API_KEY`, or run with `--skip-review`                                                          |
+| Cloud review times out                         | GitHub Action slow or `gh` not authenticated                                        | Run `gh auth login` and increase `--review-timeout`                                                                                     |
+| `gh api` blocked by harness                    | Command uses a blocked method or data flag                                          | Only GET requests allowed; check `security.py` `GH_BLOCKED_METHODS` and `GH_API_DATA_FLAGS`                                             |


### PR DESCRIPTION
## Summary

- **harness/CLAUDE.md**: Major rewrite — Two-Agent → Three-Phase workflow, all CLI flags, env vars (`OPENAI_API_KEY`, `gh auth`), gh validator + comment auth in safety layers, expanded file roles, full Codex integration section (local/cloud/interactive)
- **CLAUDE.md**: Added `npm run review`/`review:fix` to commands, feedback loop spec to index table
- **AGENTS.md**: Added Harness Integration section explaining how Codex consumes this file
- **Feedback loop spec**: Status → "Merged (PR #10)", added 5 post-implementation deviations

## Test plan

- [x] Verify `harness/CLAUDE.md` accurately reflects the merged implementation
- [x] Verify all CLI flags documented match `autonomous_agent_demo.py` argparse
- [x] Verify index links in root `CLAUDE.md` resolve to correct files