### PR TITLE
docs: add git worktree management rules and squash merge policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ harness/.env
 
 # Codex review output (local only)
 .codex-reviews/
+
+# Git worktrees (local per-agent checkouts)
+.claude/worktrees/

--- a/rules/CLAUDE.md
+++ b/rules/CLAUDE.md
@@ -36,6 +36,7 @@ Each directory contains files covering the same topics:
 | `performance.md`          | Profiling, caching, bundle size (common only)                        |
 | `code-review.md`          | Review triggers, severity levels, agent delegation (common only)     |
 | `agents.md`               | Agent orchestration, parallel execution (common only)                |
+| `worktrees.md`            | Git worktree lifecycle, lock guardrails, cleanup (common only)       |
 
 ## Precedence
 

--- a/rules/common/git-workflow.md
+++ b/rules/common/git-workflow.md
@@ -34,6 +34,18 @@ When creating PRs:
 4. Include test plan with TODOs
 5. Push with `-u` flag if new branch
 6. Merge with `--squash` only
+7. **Stay on the branch** — do not switch back to `main` after creating the PR
+
+## Post-PR Protocol
+
+After creating a PR, the agent remains on the feature branch/worktree until the PR is resolved:
+
+1. **Stay**: remain in the worktree/branch — do not return to `main`
+2. **Review-fix loop**: run `/review-fix` to fetch and address code review findings
+3. **Push fixes**: commit and push from the same branch
+4. **Repeat**: wait for next review cycle, fix, push
+5. **Done**: only the user merges or closes the PR
+6. **Cleanup**: after merge, return to main and clean up the worktree/branch (see [worktrees.md](./worktrees.md))
 
 > For the full development process (planning, TDD, code review) before git operations,
 > see [development-workflow.md](./development-workflow.md).

--- a/rules/common/git-workflow.md
+++ b/rules/common/git-workflow.md
@@ -12,6 +12,18 @@ Types: feat, fix, refactor, docs, test, chore, perf, ci
 
 Note: Attribution disabled globally via ~/.claude/settings.json.
 
+## Merge Strategy: Squash and Merge Only
+
+All PRs must be **squash merged** into `main`. No merge commits, no rebase-and-merge.
+
+- `main` history stays linear — one commit per PR
+- The squash commit message must follow conventional commit format (`feat: ...`, `fix: ...`, etc.)
+- Individual branch commits are development noise — they collapse into a single meaningful commit on merge
+- When using `gh pr merge`, always pass `--squash`:
+  ```bash
+  gh pr merge <number> --squash
+  ```
+
 ## Pull Request Workflow
 
 When creating PRs:
@@ -21,6 +33,11 @@ When creating PRs:
 3. Draft comprehensive PR summary
 4. Include test plan with TODOs
 5. Push with `-u` flag if new branch
+6. Merge with `--squash` only
 
 > For the full development process (planning, TDD, code review) before git operations,
 > see [development-workflow.md](./development-workflow.md).
+
+## Multi-Agent Workflows
+
+When multiple agents work simultaneously, each must use a dedicated git worktree. See [worktrees.md](./worktrees.md) for lifecycle, lock contention guardrails, and cleanup procedures.

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -142,9 +142,14 @@ git branch --merged main | grep -v '^\*\|main' | xargs -r git branch -d
 
 ## Hook Enforcement
 
-A PreToolUse hook blocks commits and pushes from the main worktree. See `scripts/hooks/block-main-commit.sh`.
+Two hooks support the worktree workflow:
 
-To register the hook, add to `.claude/settings.local.json`:
+| Hook               | Type        | Script                               | Purpose                                                             |
+| ------------------ | ----------- | ------------------------------------ | ------------------------------------------------------------------- |
+| Block main commits | PreToolUse  | `scripts/hooks/block-main-commit.sh` | Prevents `git commit`/`git push` on the main worktree               |
+| Post-push review   | PostToolUse | `scripts/hooks/post-push-review.sh`  | After `git push`, reminds agent to wait ~90s then run `/review-fix` |
+
+To register both hooks, add to `.claude/settings.local.json`:
 
 ```json
 {
@@ -156,6 +161,17 @@ To register the hook, add to `.claude/settings.local.json`:
           {
             "type": "command",
             "command": "bash scripts/hooks/block-main-commit.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/post-push-review.sh"
           }
         ]
       }

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -41,9 +41,19 @@ Or use Claude Code's built-in: `EnterWorktree` (creates under `.claude/worktrees
 
 Agent works normally — edit, commit, push, create PR. The worktree is a fully independent working directory.
 
+**Once a PR is created, the agent stays in the worktree/branch until the PR is resolved.** Do not switch back to `main` between creating the PR and the PR being merged or closed. This ensures review-fix cycles (`/review-fix`) happen in the correct working directory without branch switching.
+
+The PR lifecycle within a worktree:
+
+```
+create PR → wait for review → fix findings → push → wait for review → ... → merged/closed
+```
+
+Only the **user** decides when a PR is merged. Agents do not merge PRs unless explicitly instructed.
+
 ### CLEANUP
 
-After PR merge (or abandonment):
+After the user merges or closes the PR:
 
 ```bash
 # From the main worktree

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -6,6 +6,7 @@
 2. **All code changes happen in worktrees** — any work that produces commits (`feat/`, `fix/`, `refactor/`, `docs/`, `test/`) must use a dedicated worktree.
 3. **Read-only tasks skip worktrees** — research, exploration, and answering questions can use the main worktree.
 4. **Harness always uses a worktree** — autonomous loops (`/init`) must be fully isolated.
+5. **Git commands start with `git`** — always invoke git as the first token in the command (e.g., `git push`, not `ENV=val git push` or `cd repo && git push`). This ensures the PreToolUse hook can reliably detect and guard git operations. This framework is designed for agents, not humans — compound shell expressions are unnecessary.
 
 ## Worktree Location
 

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -1,0 +1,161 @@
+# Git Worktree Management
+
+## Principles
+
+1. **Main worktree is sacred** — it stays on `main`, always clean, never committed to directly. It is the launchpad from which agents create worktrees.
+2. **All code changes happen in worktrees** — any work that produces commits (`feat/`, `fix/`, `refactor/`, `docs/`, `test/`) must use a dedicated worktree.
+3. **Read-only tasks skip worktrees** — research, exploration, and answering questions can use the main worktree.
+4. **Harness always uses a worktree** — autonomous loops (`/init`) must be fully isolated.
+
+## Worktree Location
+
+All worktrees live under `.claude/worktrees/` (gitignored, local-only):
+
+```
+Vimeflow/                          ← main worktree (stays on main)
+├── .claude/
+│   ├── skills/                    ← tracked in git (pushed to repo)
+│   └── worktrees/                 ← gitignored (local-only)
+│       ├── feat-chat-history/     ← agent 1's full checkout
+│       └── fix-layout-bug/        ← agent 2's full checkout
+├── src/
+└── ...
+```
+
+Each worktree is a complete working directory with its own `src/`, `node_modules/`, etc. They share only the `.git` object database with the main repo.
+
+## Lifecycle
+
+### CREATE
+
+```bash
+# From the main worktree (root project dir)
+git worktree add .claude/worktrees/<branch-name> -b <branch-name>
+cd .claude/worktrees/<branch-name>
+npm install
+```
+
+Or use Claude Code's built-in: `EnterWorktree` (creates under `.claude/worktrees/` by default).
+
+### ACTIVE
+
+Agent works normally — edit, commit, push, create PR. The worktree is a fully independent working directory.
+
+### CLEANUP
+
+After PR merge (or abandonment):
+
+```bash
+# From the main worktree
+git worktree remove .claude/worktrees/<branch-name>
+git branch -d <branch-name>       # delete local branch (use -D if unmerged and abandoned)
+git worktree prune                 # clean up stale worktree metadata
+```
+
+## Lock Contention Guardrails
+
+Multiple worktrees share one `.git` directory. Concurrent git operations can cause lock contention on `.git/index.lock` or ref locks.
+
+### Prevention
+
+```bash
+# Disable auto-gc — prevents surprise garbage collection during parallel work
+git config gc.auto 0
+
+# Run gc manually during maintenance windows only (no agents active)
+git gc
+```
+
+### Safe to Parallelize
+
+These operations use per-worktree state or are read-only — no lock contention:
+
+- `git add`, `git commit` (per-worktree index)
+- `git push` (network-bound, different refs)
+- `git log`, `git diff`, `git status`, `git branch` (read-only)
+
+### Must Serialize (never run in parallel across worktrees)
+
+These touch shared `.git` state and will cause lock contention:
+
+- `git gc`, `git prune`, `git repack`
+- `git fetch` (ref lock contention) — fetch once in the main worktree, all worktrees see the result
+- Large rebases that rewrite many refs
+
+### Lock Recovery
+
+If an agent encounters `fatal: Unable to create '.git/index.lock': File exists`:
+
+1. **Wait 2-5 seconds** and retry — another agent may be mid-operation
+2. **If lock persists > 30 seconds**, check the PID in the lockfile
+3. **Only remove a stale lock** if the owning process is confirmed dead
+4. **Never** `rm -f .git/index.lock` blindly
+
+## Auditing Worktrees
+
+### List all worktrees
+
+```bash
+git worktree list
+```
+
+### Find orphaned worktrees (branch already merged)
+
+```bash
+# List merged branches
+git branch --merged main
+
+# Cross-reference with active worktrees
+git worktree list --porcelain | grep "^branch" | sed 's|branch refs/heads/||'
+```
+
+### Staleness indicators
+
+A worktree is likely stale if:
+
+- Its branch has been merged to `main`
+- No commits in the last 7 days
+- The associated PR is closed/merged
+
+### Cleanup all stale worktrees
+
+```bash
+# Remove each stale worktree
+git worktree remove .claude/worktrees/<stale-branch>
+
+# After removing worktrees, prune metadata
+git worktree prune
+
+# Delete merged local branches
+git branch --merged main | grep -v '^\*\|main' | xargs -r git branch -d
+```
+
+## Hook Enforcement
+
+A PreToolUse hook blocks commits and pushes from the main worktree. See `scripts/hooks/block-main-commit.sh`.
+
+To register the hook, add to `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/block-main-commit.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Integration
+
+- [git-workflow.md](./git-workflow.md) — commit format, PR process
+- [development-workflow.md](./development-workflow.md) — full pipeline before git operations
+- [agents.md](./agents.md) — parallel agent orchestration

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block git commit/push on the main worktree.
+#
+# Returns exit 2 (block) if the agent is trying to commit or push
+# from the main worktree on the main branch.
+# Returns exit 0 (allow) otherwise.
+#
+# Hook input (JSON on stdin) contains the tool parameters.
+# We check the Bash command for git commit/push patterns.
+
+set -euo pipefail
+
+# Read the hook input from stdin
+input=$(cat)
+
+# Extract the bash command from the tool input
+command=$(echo "$input" | grep -oP '"command"\s*:\s*"[^"]*"' | head -1 | sed 's/"command"\s*:\s*"//;s/"$//')
+
+# Only care about git commit and git push commands
+if ! echo "$command" | grep -qE '^\s*git\s+(commit|push)'; then
+  exit 0
+fi
+
+# Check if we're on the main branch
+current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+if [ "$current_branch" != "main" ] && [ "$current_branch" != "master" ]; then
+  exit 0
+fi
+
+# Check if we're in the main worktree (not a linked worktree)
+# git rev-parse --git-common-dir returns the shared .git dir
+# git rev-parse --git-dir returns the per-worktree .git dir (or .git file for linked worktrees)
+git_dir=$(git rev-parse --git-dir 2>/dev/null || echo "")
+git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+
+# In the main worktree, --git-dir and --git-common-dir resolve to the same path
+# In a linked worktree, --git-dir points to .git/worktrees/<name>
+resolved_git_dir=$(cd "$git_dir" 2>/dev/null && pwd)
+resolved_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd)
+
+if [ "$resolved_git_dir" = "$resolved_common_dir" ]; then
+  # We're in the main worktree on main/master — block
+  echo "BLOCKED: Cannot commit/push directly on the main worktree. Create a worktree first: git worktree add .claude/worktrees/<branch-name> -b <branch-name>" >&2
+  exit 2
+fi
+
+# We're in a linked worktree — allow (even if branch happens to be main)
+exit 0

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -2,7 +2,7 @@
 # PreToolUse hook: block git commit/push on the main worktree.
 #
 # Returns exit 2 (block) if the agent is trying to commit or push
-# from the main worktree on the main branch.
+# from the main worktree, regardless of which branch is checked out.
 # Returns exit 0 (allow) otherwise.
 #
 # Hook input (JSON on stdin) contains the tool parameters.
@@ -16,33 +16,29 @@ input=$(cat)
 # Extract the bash command from the tool input
 command=$(echo "$input" | grep -oP '"command"\s*:\s*"[^"]*"' | head -1 | sed 's/"command"\s*:\s*"//;s/"$//')
 
-# Only care about git commit and git push commands
-if ! echo "$command" | grep -qE '^\s*git\s+(commit|push)'; then
+# Check if the command contains git commit or git push anywhere,
+# handling flags between git and the subcommand (e.g., git -C /path commit)
+if ! echo "$command" | grep -qP '^\s*git\s+(?:-.+\s+)*(?:commit|push)'; then
   exit 0
 fi
 
-# Check if we're on the main branch
-current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-if [ "$current_branch" != "main" ] && [ "$current_branch" != "master" ]; then
-  exit 0
-fi
-
-# Check if we're in the main worktree (not a linked worktree)
+# Check if we're in the main worktree (not a linked worktree).
+# Block regardless of branch — the main worktree should never be committed to.
+#
 # git rev-parse --git-common-dir returns the shared .git dir
 # git rev-parse --git-dir returns the per-worktree .git dir (or .git file for linked worktrees)
+# In the main worktree, both resolve to the same path.
+# In a linked worktree, --git-dir points to .git/worktrees/<name>.
 git_dir=$(git rev-parse --git-dir 2>/dev/null || echo "")
 git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
 
-# In the main worktree, --git-dir and --git-common-dir resolve to the same path
-# In a linked worktree, --git-dir points to .git/worktrees/<name>
 resolved_git_dir=$(cd "$git_dir" 2>/dev/null && pwd)
 resolved_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd)
 
 if [ "$resolved_git_dir" = "$resolved_common_dir" ]; then
-  # We're in the main worktree on main/master — block
-  echo "BLOCKED: Cannot commit/push directly on the main worktree. Create a worktree first: git worktree add .claude/worktrees/<branch-name> -b <branch-name>" >&2
+  echo "BLOCKED: Cannot commit/push from the main worktree. Create a worktree first: git worktree add .claude/worktrees/<branch-name> -b <branch-name>" >&2
   exit 2
 fi
 
-# We're in a linked worktree — allow (even if branch happens to be main)
+# We're in a linked worktree — allow
 exit 0

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -16,23 +16,42 @@ if [ -z "$command" ]; then
   exit 0
 fi
 
-# Extract the git subcommand, skipping flags and their values.
-# Handles: git -C /path commit, git -c key=val push, git --git-dir=/x commit, etc.
+# Extract the git subcommand and any -C/--git-dir target, skipping flags and their values.
 # Known git flags that consume the next token as a value:
 #   -C, -c, --git-dir, --work-tree, --namespace, --super-prefix
 subcmd=""
+git_target_dir=""
 skip_next=false
+capture_next=""
 for token in $(echo "$command" | sed -n 's/^\s*git\s\+//p'); do
   if $skip_next; then
+    if [ -n "$capture_next" ]; then
+      eval "$capture_next=\"$token\""
+      capture_next=""
+    fi
     skip_next=false
     continue
   fi
   case "$token" in
-    -C|-c|--git-dir|--work-tree|--namespace|--super-prefix)
+    -C)
+      skip_next=true
+      capture_next="git_target_dir"
+      continue
+      ;;
+    --git-dir|--work-tree)
+      skip_next=true
+      capture_next="git_target_dir"
+      continue
+      ;;
+    --git-dir=*|--work-tree=*)
+      git_target_dir="${token#*=}"
+      continue
+      ;;
+    -c|--namespace|--super-prefix)
       skip_next=true
       continue
       ;;
-    --git-dir=*|--work-tree=*|--namespace=*|--super-prefix=*)
+    --namespace=*|--super-prefix=*)
       continue
       ;;
     -*)
@@ -52,12 +71,21 @@ fi
 # Check if we're in the main worktree (not a linked worktree).
 # Block regardless of branch — the main worktree should never be committed to.
 #
+# If -C or --git-dir was used, run the check from that directory instead
+# of the current working directory — this prevents false positives when
+# agents use git -C .claude/worktrees/<branch> commit from the main worktree.
+#
 # git rev-parse --git-common-dir returns the shared .git dir
 # git rev-parse --git-dir returns the per-worktree .git dir (or .git file for linked worktrees)
 # In the main worktree, both resolve to the same path.
 # In a linked worktree, --git-dir points to .git/worktrees/<name>.
-git_dir=$(git rev-parse --git-dir 2>/dev/null || echo "")
-git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+if [ -n "$git_target_dir" ]; then
+  git_dir=$(git -C "$git_target_dir" rev-parse --git-dir 2>/dev/null || echo "")
+  git_common_dir=$(git -C "$git_target_dir" rev-parse --git-common-dir 2>/dev/null || echo "")
+else
+  git_dir=$(git rev-parse --git-dir 2>/dev/null || echo "")
+  git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+fi
 
 resolved_git_dir=$(cd "$git_dir" 2>/dev/null && pwd)
 resolved_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd)

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -16,42 +16,37 @@ if [ -z "$command" ]; then
   exit 0
 fi
 
-# Extract the git subcommand and any -C/--git-dir target, skipping flags and their values.
+# Extract the git subcommand and any -C/--work-tree target, skipping flags and their values.
 # Known git flags that consume the next token as a value:
 #   -C, -c, --git-dir, --work-tree, --namespace, --super-prefix
 subcmd=""
 git_target_dir=""
+next_is_target=false
 skip_next=false
-capture_next=""
 for token in $(echo "$command" | sed -n 's/^\s*git\s\+//p'); do
+  if $next_is_target; then
+    git_target_dir="$token"
+    next_is_target=false
+    continue
+  fi
   if $skip_next; then
-    if [ -n "$capture_next" ]; then
-      eval "$capture_next=\"$token\""
-      capture_next=""
-    fi
     skip_next=false
     continue
   fi
   case "$token" in
-    -C)
-      skip_next=true
-      capture_next="git_target_dir"
+    -C|--work-tree)
+      next_is_target=true
       continue
       ;;
-    --git-dir|--work-tree)
-      skip_next=true
-      capture_next="git_target_dir"
-      continue
-      ;;
-    --git-dir=*|--work-tree=*)
+    --work-tree=*)
       git_target_dir="${token#*=}"
       continue
       ;;
-    -c|--namespace|--super-prefix)
+    -c|--git-dir|--namespace|--super-prefix)
       skip_next=true
       continue
       ;;
-    --namespace=*|--super-prefix=*)
+    --git-dir=*|--namespace=*|--super-prefix=*)
       continue
       ;;
     -*)
@@ -87,8 +82,13 @@ else
   git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
 fi
 
-resolved_git_dir=$(cd "$git_dir" 2>/dev/null && pwd)
-resolved_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd)
+# Guard against empty paths — if git rev-parse failed, allow the command
+if [ -z "$git_dir" ] || [ -z "$git_common_dir" ]; then
+  exit 0
+fi
+
+resolved_git_dir=$(cd "$git_dir" 2>/dev/null && pwd || echo "")
+resolved_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd || echo "")
 
 if [ "$resolved_git_dir" = "$resolved_common_dir" ]; then
   echo "BLOCKED: Cannot commit/push from the main worktree. Create a worktree first: git worktree add .claude/worktrees/<branch-name> -b <branch-name>" >&2

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -10,15 +10,17 @@
 
 set -euo pipefail
 
-# Read the hook input from stdin
-input=$(cat)
+# Extract the bash command from the tool input (portable — no GNU grep -P)
+command=$(jq -r '.command // empty' 2>/dev/null || echo "")
+if [ -z "$command" ]; then
+  exit 0
+fi
 
-# Extract the bash command from the tool input
-command=$(echo "$input" | grep -oP '"command"\s*:\s*"[^"]*"' | head -1 | sed 's/"command"\s*:\s*"//;s/"$//')
-
-# Check if the command contains git commit or git push anywhere,
-# handling flags between git and the subcommand (e.g., git -C /path commit)
-if ! echo "$command" | grep -qP '^\s*git\s+(?:-.+\s+)*(?:commit|push)'; then
+# Check if the command contains git commit or git push,
+# handling flags between git and the subcommand (e.g., git -C /path commit).
+# Extract the first non-flag token after "git" as the subcommand.
+subcmd=$(echo "$command" | sed -n 's/^\s*git\s\+//p' | tr ' ' '\n' | grep -v '^-' | head -1 || true)
+if [ "$subcmd" != "commit" ] && [ "$subcmd" != "push" ]; then
   exit 0
 fi
 

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -7,6 +7,11 @@
 #
 # Hook input (JSON on stdin) contains the tool parameters.
 # We check the Bash command for git commit/push patterns.
+#
+# Design constraint: agents must start git commands with "git" as the first
+# token (see rules/common/worktrees.md principle 5). This hook does not parse
+# compound shell expressions (&&, ||, ;) or env-prefixed commands (ENV=val git).
+# This is intentional — this framework is for agents, not humans.
 
 set -euo pipefail
 

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -16,10 +16,35 @@ if [ -z "$command" ]; then
   exit 0
 fi
 
-# Check if the command contains git commit or git push,
-# handling flags between git and the subcommand (e.g., git -C /path commit).
-# Extract the first non-flag token after "git" as the subcommand.
-subcmd=$(echo "$command" | sed -n 's/^\s*git\s\+//p' | tr ' ' '\n' | grep -v '^-' | head -1 || true)
+# Extract the git subcommand, skipping flags and their values.
+# Handles: git -C /path commit, git -c key=val push, git --git-dir=/x commit, etc.
+# Known git flags that consume the next token as a value:
+#   -C, -c, --git-dir, --work-tree, --namespace, --super-prefix
+subcmd=""
+skip_next=false
+for token in $(echo "$command" | sed -n 's/^\s*git\s\+//p'); do
+  if $skip_next; then
+    skip_next=false
+    continue
+  fi
+  case "$token" in
+    -C|-c|--git-dir|--work-tree|--namespace|--super-prefix)
+      skip_next=true
+      continue
+      ;;
+    --git-dir=*|--work-tree=*|--namespace=*|--super-prefix=*)
+      continue
+      ;;
+    -*)
+      continue
+      ;;
+    *)
+      subcmd="$token"
+      break
+      ;;
+  esac
+done
+
 if [ "$subcmd" != "commit" ] && [ "$subcmd" != "push" ]; then
   exit 0
 fi

--- a/scripts/hooks/post-push-review.sh
+++ b/scripts/hooks/post-push-review.sh
@@ -14,8 +14,33 @@ if [ -z "$command" ]; then
   exit 0
 fi
 
-# Check for git push, handling flags between git and subcommand (e.g., git -C /path push)
-subcmd=$(echo "$command" | sed -n 's/^\s*git\s\+//p' | tr ' ' '\n' | grep -v '^-' | head -1 || true)
+# Extract the git subcommand, skipping flags and their values.
+# Handles: git -C /path push, git -c key=val push, git --git-dir=/x push, etc.
+subcmd=""
+skip_next=false
+for token in $(echo "$command" | sed -n 's/^\s*git\s\+//p'); do
+  if $skip_next; then
+    skip_next=false
+    continue
+  fi
+  case "$token" in
+    -C|-c|--git-dir|--work-tree|--namespace|--super-prefix)
+      skip_next=true
+      continue
+      ;;
+    --git-dir=*|--work-tree=*|--namespace=*|--super-prefix=*)
+      continue
+      ;;
+    -*)
+      continue
+      ;;
+    *)
+      subcmd="$token"
+      break
+      ;;
+  esac
+done
+
 if [ "$subcmd" != "push" ]; then
   exit 0
 fi

--- a/scripts/hooks/post-push-review.sh
+++ b/scripts/hooks/post-push-review.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# PostToolUse hook: after git push, remind the agent to run /review-fix.
+#
+# Detects git push commands and outputs a directive that the agent
+# sees in its context, prompting it to wait and then run /review-fix.
+#
+# Exit 0 always — PostToolUse hooks should never block.
+
+set -euo pipefail
+
+input=$(cat)
+
+# Extract the bash command from the tool input
+command=$(echo "$input" | grep -oP '"command"\s*:\s*"[^"]*"' | head -1 | sed 's/"command"\s*:\s*"//;s/"$//')
+
+# Only trigger on git push
+if ! echo "$command" | grep -qE '^\s*git\s+push'; then
+  exit 0
+fi
+
+echo "ACTION REQUIRED: Code was just pushed. Wait ~90 seconds for Codex review to post findings, then run /review-fix to fetch and address any code review comments."
+
+exit 0

--- a/scripts/hooks/post-push-review.sh
+++ b/scripts/hooks/post-push-review.sh
@@ -8,13 +8,15 @@
 
 set -euo pipefail
 
-input=$(cat)
+# Extract the bash command from the tool input (portable — no GNU grep -P)
+command=$(jq -r '.command // empty' 2>/dev/null || echo "")
+if [ -z "$command" ]; then
+  exit 0
+fi
 
-# Extract the bash command from the tool input
-command=$(echo "$input" | grep -oP '"command"\s*:\s*"[^"]*"' | head -1 | sed 's/"command"\s*:\s*"//;s/"$//')
-
-# Only trigger on git push
-if ! echo "$command" | grep -qE '^\s*git\s+push'; then
+# Check for git push, handling flags between git and subcommand (e.g., git -C /path push)
+subcmd=$(echo "$command" | sed -n 's/^\s*git\s\+//p' | tr ' ' '\n' | grep -v '^-' | head -1 || true)
+if [ "$subcmd" != "push" ]; then
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Add `rules/common/worktrees.md` — comprehensive git worktree lifecycle rules (create/active/cleanup), lock contention guardrails, and audit commands for multi-agent parallel development
- Add `scripts/hooks/block-main-commit.sh` — PreToolUse hook that blocks `git commit`/`git push` on the main worktree, enforcing worktree-based isolation
- Add squash-and-merge as the only allowed PR merge strategy to `rules/common/git-workflow.md`
- Update `.gitignore` to exclude `.claude/worktrees/` while keeping `.claude/skills/` tracked

## Test plan

- [x] Hook blocks `git commit` on main worktree (exit 2 with message on stderr)
- [x] Hook blocks `git push` on main worktree (exit 2)
- [x] Hook allows non-git commands (exit 0)
- [x] Hook allows read-only git commands like `git log` (exit 0)
- [x] `.claude/worktrees/` is gitignored (`git check-ignore` confirms)
- [x] `.claude/skills/` files remain tracked (`git ls-files` confirms)
- [x] All 310 existing tests pass