### PR TITLE
feat: add vim-style command palette with nested command tree

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -33,9 +33,11 @@ words:
   - zustand
   - tanstack
   - conv
+  - framer
 
   # Design / UI
   - glassmorphism
+  - contenteditable
 
   # Tools
   - cspell

--- a/docs/superpowers/specs/2026-04-04-command-palette-design.md
+++ b/docs/superpowers/specs/2026-04-04-command-palette-design.md
@@ -1,0 +1,235 @@
+# Command Palette — Design Spec
+
+## Overview
+
+A vim-style command palette for Vimeflow, triggered by pressing `:` in normal mode (i.e. when no input element is focused). The palette provides a nested command tree with fuzzy search, keyboard navigation, and smooth spring-based animations via framer-motion. It should feel as natural as vim's `:` or Zed's command palette.
+
+## Tech Stack
+
+- **Framework:** React 19 + TypeScript (arrow-function components, explicit return types)
+- **Animation:** framer-motion (new dependency — spring physics, AnimatePresence exit animations)
+- **Styling:** Tailwind 4 with existing Catppuccin Mocha design tokens
+- **Icons:** Material Symbols Outlined (already available)
+- **Testing:** Vitest + Testing Library (co-located test files)
+
+## Trigger & Input Model
+
+### Opening
+
+- A global `keydown` listener intercepts `:` on `document`
+- **Guard:** if `document.activeElement` is an `<input>`, `<textarea>`, or `[contenteditable]`, the event passes through normally (palette does not open)
+- Otherwise, `preventDefault()` is called, and the palette opens with `:` pre-filled in the search input
+- The search input receives focus immediately
+
+### Closing
+
+- `Escape` key dismisses the palette
+- Clicking the backdrop dismisses the palette
+- Executing a command dismisses the palette
+- `Backspace` when the input contains only `:` dismisses the palette
+
+### Keyboard Navigation
+
+| Key                       | Action                                           |
+| ------------------------- | ------------------------------------------------ |
+| `Arrow Up` / `Arrow Down` | Navigate results (wraps around)                  |
+| `Enter`                   | Execute selected command or drill into namespace |
+| `Escape`                  | Close palette                                    |
+| `Backspace` on empty `:`  | Close palette                                    |
+| `Tab`                     | Autocomplete current match (bonus, not MVP)      |
+
+## Command Tree & Registry
+
+### Command Interface
+
+```typescript
+interface Command {
+  id: string
+  label: string // display name, e.g. ":open"
+  description?: string // secondary helper text for non-vim users
+  icon: string // Material Symbols icon name
+  children?: Command[] // sub-commands (nested tree)
+  execute?: (args: string) => void // leaf command handler
+  match?: (query: string) => number // custom fuzzy match scorer (optional)
+}
+```
+
+A command is either a **namespace** (has `children`, no `execute`) or a **leaf** (has `execute`, no `children`).
+
+### Initial Command Tree (Stubbed)
+
+```
+:open
+  ├── <filename>     → open file by name (fuzzy matched against mock file list)
+  └── recent         → show recently opened files
+:set
+  ├── theme          → switch color theme
+  └── font           → change editor font
+:help                → show command reference
+:new                 → create new conversation
+```
+
+All commands are stubbed with placeholder implementations for the initial build. The `:open <filename>` command fuzzy-matches against a mock file list.
+
+### Fuzzy Matching
+
+Custom implementation (no external library):
+
+- Substring match + character-skip scoring
+- Exact prefix matches weighted highest
+- Results sorted by descending score
+- Minimum score threshold to filter noise
+
+### Feature-Owned Commands
+
+Each feature exports its own command subtree:
+
+- `features/files/commands.ts` → `:open` branch
+- `features/chat/commands.ts` → `:new` branch
+- `features/command-palette/data/defaultCommands.ts` → merges all trees
+
+This is a static import/merge for now. Dynamic registration can be added later.
+
+## UI Components
+
+### Component Tree
+
+```
+CommandPalette (overlay + backdrop, AnimatePresence wrapper)
+├── CommandInput (search bar with `:` prefix, ESC badge)
+├── CommandResults (scrollable list of matches)
+│   └── CommandResultItem (icon + label + description + Enter/keyboard hints)
+└── CommandFooter (Navigate / Select hints, "Type ? for help")
+```
+
+### Layout & Styling
+
+Matches the reference design in `docs/design/command_palette/`:
+
+- **Overlay:** `fixed inset-0 z-[100]`, `backdrop-blur-sm bg-black/40`
+- **Panel:** centered at `pt-[15vh]`, `max-w-2xl`, `bg-[#1e1e2e]/90`, `glass-panel`, `rounded-2xl`, `border border-[#4a444f]/30`, `shadow-2xl`
+- **Input section:** search icon (primary-container), input with `:` pre-filled, ESC badge (top-right)
+- **Results:** `p-2`, each item is a row with icon + label + optional description + keyboard hint
+- **Selected item:** `bg-primary-container/10`, `border border-primary-container/10` — shows Enter badge
+- **Unselected items:** transparent bg, Enter badge appears on hover (`opacity-0 group-hover:opacity-100`)
+- **Footer:** `bg-surface-container-lowest/50`, keyboard hint chips (Navigate, Select), "Type ? for help" text
+
+### Helper Text for Non-Vim Users
+
+Secondary description text appears below or beside command labels in a muted color (`text-on-surface-variant`). This provides context for users unfamiliar with vim command syntax. Examples:
+
+- `:open` → "Open a file by name"
+- `:set theme` → "Change the color theme"
+- Footer shows "Type '?' for help" as a progressive disclosure entry point
+
+This is a bonus feature — present in the UI but not gating the core implementation.
+
+### Animation (framer-motion)
+
+**Backdrop:**
+
+- Fade in: `opacity: 0 → 1`, duration 150ms
+
+**Palette panel:**
+
+- Open: `scale: 0.96 → 1`, `opacity: 0 → 1`, `y: -8 → 0` — spring with `stiffness: 400, damping: 30`
+- Close: reverse with faster easing, 100ms duration
+
+**Results list:**
+
+- Staggered children entrance: each item fades in 30ms apart
+- Selected item highlight: `layoutId` for smooth selection indicator movement
+
+**Exit:**
+
+- `AnimatePresence` wraps the palette for clean unmount animations
+
+## File Structure
+
+```
+src/features/command-palette/
+├── CommandPalette.tsx            # Root overlay (AnimatePresence, backdrop, panel)
+├── components/
+│   ├── CommandInput.tsx          # Search icon + input + ESC badge
+│   ├── CommandResults.tsx        # Scrollable results container
+│   ├── CommandResultItem.tsx     # Single result row (icon, label, desc, hint)
+│   └── CommandFooter.tsx         # Keyboard shortcut hints bar
+├── hooks/
+│   └── useCommandPalette.ts     # Global `:` listener, open/close, navigation state
+├── registry/
+│   ├── types.ts                 # Command, CommandTree interfaces
+│   ├── commandTree.ts           # Tree builder, merge, traversal, namespace lookup
+│   └── fuzzyMatch.ts            # Substring + char-skip scoring algorithm
+├── data/
+│   └── defaultCommands.ts       # Stub commands, merges feature command exports
+└── types/
+    └── index.ts                 # Re-exports from registry/types
+```
+
+Co-located test files for every `.tsx` and `.ts` file (e.g. `CommandPalette.test.tsx`, `fuzzyMatch.test.ts`).
+
+## Integration
+
+### App.tsx
+
+The palette renders at the root level, alongside the active view:
+
+```tsx
+<>
+  {activeTab === 'Chat' ? <ChatView ... /> : <FilesView ... />}
+  <CommandPalette />
+</>
+```
+
+No changes to existing components. The palette is purely additive.
+
+### Z-Index
+
+The palette uses `z-[100]`, above all existing layers (IconRail/Sidebar at z-40/50, TopTabBar at z-30).
+
+### Accessibility
+
+- `role="dialog"`, `aria-modal="true"`, `aria-label="Command palette"`
+- Focus trap inside the palette when open
+- `role="listbox"` on results, `role="option"` on each item
+- `aria-activedescendant` tracks the selected item
+
+## Testing Strategy
+
+### Unit Tests
+
+- `fuzzyMatch.ts` — scoring accuracy, edge cases (empty query, exact match, no match, special characters)
+- `commandTree.ts` — tree traversal, merge two trees, namespace lookup, leaf lookup
+
+### Component Tests
+
+- `CommandInput` — renders with `:` prefix, ESC badge, fires onChange
+- `CommandResultItem` — renders icon, label, description, selected state
+- `CommandResults` — renders list, keyboard navigation updates selection
+- `CommandFooter` — renders keyboard hints
+- `CommandPalette` — full integration: open, type, navigate, select, close
+
+### Hook Tests
+
+- `useCommandPalette` — `:` opens palette when no input focused, suppressed when input focused, Escape closes, Backspace on empty `:` closes
+
+### Coverage Target
+
+80%+ line coverage across all new files.
+
+## Dependencies
+
+### New
+
+- `framer-motion` — spring-based animations, AnimatePresence for exit animations
+
+### Existing (no changes)
+
+- React 19, Tailwind 4, Material Symbols, Vitest, Testing Library
+
+## Out of Scope
+
+- Real file system integration (commands are stubbed)
+- Persistent command history
+- Custom user-defined commands
+- Editor insert-mode detection (future — for now, guard is input/textarea/contenteditable)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4",
+        "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9",
         "eslint-config-prettier": "^10",
         "eslint-plugin-import": "^2",
@@ -68,6 +69,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -414,6 +429,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -2119,6 +2144,77 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2205,6 +2301,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pkgr/core": {
@@ -3371,6 +3478,40 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -3788,6 +3929,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -4772,6 +4932,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.329",
@@ -6194,6 +6361,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/framer-motion": {
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
@@ -6419,6 +6603,28 @@
         "node": ">=16"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6430,6 +6636,39 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-directory": {
@@ -6625,6 +6864,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -7268,6 +7514,60 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7284,6 +7584,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -7987,6 +8303,34 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8114,6 +8458,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/motion-dom": {
@@ -8443,6 +8797,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
@@ -8514,6 +8875,30 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -9371,6 +9756,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -9483,6 +9924,30 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -9622,6 +10087,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/text-extensions": {
@@ -10432,6 +10912,96 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "framer-motion": "^12.38.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -6193,6 +6194,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -8088,6 +8116,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9759,6 +9802,12 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "framer-motion": "^12.38.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9",
     "eslint-config-prettier": "^10",
     "eslint-plugin-import": "^2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import type { TabName } from './components/layout/TopTabBar'
 import ChatView from './features/chat/ChatView'
 import FilesView from './features/files/FilesView'
+import { CommandPalette } from './features/command-palette/CommandPalette'
 
 const App = (): ReactElement => {
   const [activeTab, setActiveTab] = useState<TabName>('Chat')
@@ -11,13 +12,16 @@ const App = (): ReactElement => {
     setActiveTab(tab)
   }
 
-  switch (activeTab) {
-    case 'Files':
-      return <FilesView onTabChange={handleTabChange} />
-    case 'Chat':
-    default:
-      return <ChatView onTabChange={handleTabChange} />
-  }
+  return (
+    <>
+      {activeTab === 'Files' ? (
+        <FilesView onTabChange={handleTabChange} />
+      ) : (
+        <ChatView onTabChange={handleTabChange} />
+      )}
+      <CommandPalette />
+    </>
+  )
 }
 
 export default App

--- a/src/features/command-palette/CommandPalette.test.tsx
+++ b/src/features/command-palette/CommandPalette.test.tsx
@@ -62,7 +62,7 @@ describe('CommandPalette - Integration Tests', () => {
     })
 
     await waitFor(() => {
-      const input = screen.getByRole('textbox', {
+      const input = screen.getByRole('combobox', {
         name: 'Command palette search',
       })
 
@@ -85,7 +85,7 @@ describe('CommandPalette - Integration Tests', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument()
     })
 
-    const input = screen.getByRole('textbox', {
+    const input = screen.getByRole('combobox', {
       name: 'Command palette search',
     })
 
@@ -138,7 +138,7 @@ describe('CommandPalette - Integration Tests', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument()
     })
 
-    const input = screen.getByRole('textbox', {
+    const input = screen.getByRole('combobox', {
       name: 'Command palette search',
     })
 
@@ -225,7 +225,7 @@ describe('CommandPalette - Integration Tests', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument()
     })
 
-    const input = screen.getByRole('textbox', {
+    const input = screen.getByRole('combobox', {
       name: 'Command palette search',
     })
 
@@ -272,7 +272,7 @@ describe('CommandPalette - Integration Tests', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument()
     })
 
-    const input = screen.getByRole('textbox', {
+    const input = screen.getByRole('combobox', {
       name: 'Command palette search',
     })
 
@@ -309,7 +309,7 @@ describe('CommandPalette - Integration Tests', () => {
     })
 
     await waitFor(() => {
-      const input = screen.getByRole('textbox', {
+      const input = screen.getByRole('combobox', {
         name: 'Command palette search',
       })
 

--- a/src/features/command-palette/CommandPalette.test.tsx
+++ b/src/features/command-palette/CommandPalette.test.tsx
@@ -1,0 +1,371 @@
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
+import { describe, test, expect, vi, afterEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { CommandPalette } from './CommandPalette'
+
+describe('CommandPalette - Integration Tests', () => {
+  afterEach(() => {
+    // Clean up any lingering event listeners
+    vi.restoreAllMocks()
+  })
+
+  test('does not render when closed initially', () => {
+    render(<CommandPalette />)
+
+    const dialog = screen.queryByRole('dialog')
+
+    expect(dialog).not.toBeInTheDocument()
+  })
+
+  test('opens palette when : key is pressed', async () => {
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog')
+
+      expect(dialog).toBeInTheDocument()
+    })
+  })
+
+  test('dialog has correct accessibility attributes', async () => {
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    const dialog = screen.getByRole('dialog')
+
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAttribute('aria-label', 'Command palette')
+  })
+
+  test('opens with : pre-filled in input', async () => {
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      const input = screen.getByRole('textbox', {
+        name: 'Command palette search',
+      })
+
+      expect(input).toHaveValue(':')
+    })
+  })
+
+  test('typing query filters results', async () => {
+    const user = userEvent.setup()
+
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('textbox', {
+      name: 'Command palette search',
+    })
+
+    await user.clear(input)
+    await user.type(input, ':open')
+
+    await waitFor(() => {
+      const openCommand = screen.getByText(':open')
+
+      expect(openCommand).toBeInTheDocument()
+    })
+  })
+
+  test('closes palette when Escape is pressed', async () => {
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: 'Escape' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      const dialog = screen.queryByRole('dialog')
+
+      expect(dialog).not.toBeInTheDocument()
+    })
+  })
+
+  test('closes palette when Backspace is pressed on empty : query', async () => {
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('textbox', {
+      name: 'Command palette search',
+    })
+
+    // Input starts with ':'
+    expect(input).toHaveValue(':')
+
+    // Fire Backspace event directly on input
+    fireEvent.keyDown(input, { key: 'Backspace' })
+
+    await waitFor(() => {
+      const dialog = screen.queryByRole('dialog')
+
+      expect(dialog).not.toBeInTheDocument()
+    })
+  })
+
+  test('arrow keys navigate results', async () => {
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      const results = screen.getAllByRole('option')
+
+      expect(results.length).toBeGreaterThan(0)
+    })
+
+    // First item should be selected initially
+    let firstResult = screen.getAllByRole('option')[0]
+
+    expect(firstResult).toHaveAttribute('aria-selected', 'true')
+
+    // Press ArrowDown
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      const secondResult = screen.getAllByRole('option')[1]
+
+      expect(secondResult).toHaveAttribute('aria-selected', 'true')
+    })
+
+    // Press ArrowUp to go back
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      firstResult = screen.getAllByRole('option')[0]
+
+      expect(firstResult).toHaveAttribute('aria-selected', 'true')
+    })
+  })
+
+  test('Enter executes leaf command and closes palette', async () => {
+    const user = userEvent.setup()
+
+    const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {
+      // Mock implementation
+    })
+
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('textbox', {
+      name: 'Command palette search',
+    })
+
+    await user.clear(input)
+    await user.type(input, ':help')
+
+    await waitFor(() => {
+      const helpCommand = screen.getByText(':help')
+
+      expect(helpCommand).toBeInTheDocument()
+    })
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: 'Enter' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      expect(consoleInfoSpy).toHaveBeenCalledWith('Showing command reference')
+    })
+
+    await waitFor(() => {
+      const dialog = screen.queryByRole('dialog')
+
+      expect(dialog).not.toBeInTheDocument()
+    })
+
+    consoleInfoSpy.mockRestore()
+  })
+
+  test('Enter drills into namespace command without closing palette', async () => {
+    const user = userEvent.setup()
+
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('textbox', {
+      name: 'Command palette search',
+    })
+
+    await user.clear(input)
+    await user.type(input, ':open')
+
+    await waitFor(() => {
+      const openCommand = screen.getByText(':open')
+
+      expect(openCommand).toBeInTheDocument()
+    })
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: 'Enter' })
+
+      document.dispatchEvent(event)
+    })
+
+    // Palette should still be open (namespace commands don't close)
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog')
+
+      expect(dialog).toBeInTheDocument()
+    })
+  })
+
+  test('renders CommandInput component', async () => {
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      const input = screen.getByRole('textbox', {
+        name: 'Command palette search',
+      })
+
+      expect(input).toBeInTheDocument()
+    })
+  })
+
+  test('renders CommandResults component', async () => {
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      const listbox = screen.getByRole('listbox')
+
+      expect(listbox).toBeInTheDocument()
+    })
+  })
+
+  test('renders CommandFooter component', async () => {
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      const navigateText = screen.getByText('Navigate')
+      const selectText = screen.getByText('Select')
+      const helpText = screen.getByText("Type '?' for help")
+
+      expect(navigateText).toBeInTheDocument()
+      expect(selectText).toBeInTheDocument()
+      expect(helpText).toBeInTheDocument()
+    })
+  })
+
+  test('has correct z-index for overlay', async () => {
+    render(<CommandPalette />)
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: ':' })
+
+      document.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog')
+
+      expect(dialog).toHaveClass('z-[100]')
+    })
+  })
+})

--- a/src/features/command-palette/CommandPalette.tsx
+++ b/src/features/command-palette/CommandPalette.tsx
@@ -40,7 +40,15 @@ export const CommandPalette = (): ReactElement | null => {
             className="relative w-full max-w-2xl mx-4 bg-[#1e1e2e]/90 glass-panel rounded-2xl border border-[#4a444f]/30 shadow-2xl overflow-hidden flex flex-col h-fit"
           >
             {/* Input section */}
-            <CommandInput value={state.query} onChange={setQuery} />
+            <CommandInput
+              value={state.query}
+              onChange={setQuery}
+              activeDescendantId={
+                state.filteredResults[state.selectedIndex]
+                  ? `command-${state.filteredResults[state.selectedIndex].id}`
+                  : undefined
+              }
+            />
 
             {/* Divider */}
             <div className="h-px bg-surface-container-low/30" />

--- a/src/features/command-palette/CommandPalette.tsx
+++ b/src/features/command-palette/CommandPalette.tsx
@@ -1,0 +1,65 @@
+import { AnimatePresence, motion } from 'framer-motion'
+import type { ReactElement } from 'react'
+import { useCommandPalette } from './hooks/useCommandPalette'
+import { CommandInput } from './components/CommandInput'
+import { CommandResults } from './components/CommandResults'
+import { CommandFooter } from './components/CommandFooter'
+
+export const CommandPalette = (): ReactElement | null => {
+  const { state, setQuery, selectIndex } = useCommandPalette()
+
+  return (
+    <AnimatePresence>
+      {state.isOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Command palette"
+          className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh]"
+        >
+          {/* Backdrop */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="absolute inset-0 backdrop-blur-sm bg-black/40"
+            onClick={() => {
+              /* Close on backdrop click handled by hook */
+            }}
+          />
+
+          {/* Panel */}
+          <motion.div
+            initial={{ scale: 0.96, opacity: 0, y: -8 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.96, opacity: 0, y: -8 }}
+            transition={{
+              type: 'spring',
+              stiffness: 400,
+              damping: 30,
+            }}
+            className="relative w-full max-w-2xl mx-4 bg-[#1e1e2e]/90 glass-panel rounded-2xl border border-[#4a444f]/30 shadow-2xl overflow-hidden flex flex-col h-fit"
+          >
+            {/* Input section */}
+            <CommandInput value={state.query} onChange={setQuery} />
+
+            {/* Divider */}
+            <div className="h-px bg-surface-container-low/30" />
+
+            {/* Results */}
+            <CommandResults
+              filteredResults={state.filteredResults}
+              selectedIndex={state.selectedIndex}
+              onSelect={selectIndex}
+            />
+
+            {/* Footer */}
+            <div className="h-px bg-surface-container-low/30" />
+            <CommandFooter />
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/features/command-palette/CommandPalette.tsx
+++ b/src/features/command-palette/CommandPalette.tsx
@@ -6,7 +6,7 @@ import { CommandResults } from './components/CommandResults'
 import { CommandFooter } from './components/CommandFooter'
 
 export const CommandPalette = (): ReactElement | null => {
-  const { state, setQuery, selectIndex } = useCommandPalette()
+  const { state, close, setQuery, selectIndex } = useCommandPalette()
 
   return (
     <AnimatePresence>
@@ -24,9 +24,7 @@ export const CommandPalette = (): ReactElement | null => {
             exit={{ opacity: 0 }}
             transition={{ duration: 0.15 }}
             className="absolute inset-0 backdrop-blur-sm bg-black/40"
-            onClick={() => {
-              /* Close on backdrop click handled by hook */
-            }}
+            onClick={close}
           />
 
           {/* Panel */}

--- a/src/features/command-palette/components/CommandFooter.test.tsx
+++ b/src/features/command-palette/components/CommandFooter.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react'
+import { describe, test, expect } from 'vitest'
+import { CommandFooter } from './CommandFooter'
+
+describe('CommandFooter', () => {
+  test('renders Navigate hint text', () => {
+    render(<CommandFooter />)
+
+    const navigateText = screen.getByText('Navigate')
+
+    expect(navigateText).toBeInTheDocument()
+    expect(navigateText).toHaveClass('text-sm', 'text-on-surface/60')
+  })
+
+  test('renders arrow_upward icon for navigation', () => {
+    render(<CommandFooter />)
+
+    const upArrow = screen.getByText('arrow_upward')
+
+    expect(upArrow).toBeInTheDocument()
+    expect(upArrow).toHaveClass('material-symbols-outlined')
+  })
+
+  test('renders arrow_downward icon for navigation', () => {
+    render(<CommandFooter />)
+
+    const downArrow = screen.getByText('arrow_downward')
+
+    expect(downArrow).toBeInTheDocument()
+    expect(downArrow).toHaveClass('material-symbols-outlined')
+  })
+
+  test('renders Select hint text', () => {
+    render(<CommandFooter />)
+
+    const selectText = screen.getByText('Select')
+
+    expect(selectText).toBeInTheDocument()
+    expect(selectText).toHaveClass('text-sm', 'text-on-surface/60')
+  })
+
+  test('renders keyboard_return icon for select action', () => {
+    render(<CommandFooter />)
+
+    const returnIcon = screen.getByText('keyboard_return')
+
+    expect(returnIcon).toBeInTheDocument()
+    expect(returnIcon).toHaveClass('material-symbols-outlined')
+  })
+
+  test('renders help text', () => {
+    render(<CommandFooter />)
+
+    const helpText = screen.getByText("Type '?' for help")
+
+    expect(helpText).toBeInTheDocument()
+    expect(helpText).toHaveClass('text-sm', 'text-primary-container/60')
+  })
+
+  test('Navigate text has correct styling', () => {
+    render(<CommandFooter />)
+
+    const navigateText = screen.getByText('Navigate')
+
+    expect(navigateText).toHaveClass('text-sm')
+    expect(navigateText).toHaveClass('text-on-surface/60')
+  })
+
+  test('Select text has correct styling', () => {
+    render(<CommandFooter />)
+
+    const selectText = screen.getByText('Select')
+
+    expect(selectText).toHaveClass('text-sm')
+    expect(selectText).toHaveClass('text-on-surface/60')
+  })
+
+  test('all navigation icons have correct styling', () => {
+    render(<CommandFooter />)
+
+    const upArrow = screen.getByText('arrow_upward')
+    const downArrow = screen.getByText('arrow_downward')
+    const returnIcon = screen.getByText('keyboard_return')
+
+    expect(upArrow).toHaveClass('text-sm', 'text-on-surface/60')
+    expect(downArrow).toHaveClass('text-sm', 'text-on-surface/60')
+    expect(returnIcon).toHaveClass('text-sm', 'text-on-surface/60')
+  })
+
+  test('help text has correct primary-container color styling', () => {
+    render(<CommandFooter />)
+
+    const helpText = screen.getByText("Type '?' for help")
+
+    expect(helpText).toHaveClass('text-primary-container/60')
+  })
+})

--- a/src/features/command-palette/components/CommandFooter.tsx
+++ b/src/features/command-palette/components/CommandFooter.tsx
@@ -1,0 +1,34 @@
+import type { ReactElement } from 'react'
+
+export const CommandFooter = (): ReactElement => (
+  <div className="bg-surface-container-lowest/50 px-5 py-3 flex items-center justify-between">
+    {/* Keyboard shortcuts */}
+    <div className="flex items-center gap-4">
+      {/* Navigate hint */}
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
+          <span className="material-symbols-outlined text-sm text-on-surface/60">
+            arrow_upward
+          </span>
+          <span className="material-symbols-outlined text-sm text-on-surface/60">
+            arrow_downward
+          </span>
+        </div>
+        <span className="text-sm text-on-surface/60">Navigate</span>
+      </div>
+
+      {/* Select hint */}
+      <div className="flex items-center gap-2">
+        <span className="material-symbols-outlined text-sm text-on-surface/60">
+          keyboard_return
+        </span>
+        <span className="text-sm text-on-surface/60">Select</span>
+      </div>
+    </div>
+
+    {/* Help text */}
+    <div className="text-sm text-primary-container/60">
+      Type &apos;?&apos; for help
+    </div>
+  </div>
+)

--- a/src/features/command-palette/components/CommandInput.test.tsx
+++ b/src/features/command-palette/components/CommandInput.test.tsx
@@ -20,7 +20,7 @@ describe('CommandInput', () => {
 
     render(<CommandInput value=":" onChange={mockOnChange} />)
 
-    const input = screen.getByRole('textbox', {
+    const input = screen.getByRole('combobox', {
       name: /command palette search/i,
     })
     expect(input).toBeInTheDocument()
@@ -34,7 +34,7 @@ describe('CommandInput', () => {
 
     render(<CommandInput value=":open" onChange={mockOnChange} />)
 
-    const input = screen.getByRole('textbox', {
+    const input = screen.getByRole('combobox', {
       name: /command palette search/i,
     })
     expect(input).toHaveValue(':open')
@@ -45,7 +45,7 @@ describe('CommandInput', () => {
 
     render(<CommandInput value=":" onChange={mockOnChange} />)
 
-    const input = screen.getByRole('textbox', {
+    const input = screen.getByRole('combobox', {
       name: /command palette search/i,
     })
     expect(input).toHaveClass(
@@ -91,7 +91,7 @@ describe('CommandInput', () => {
 
     render(<CommandInput value=":" onChange={mockOnChange} />)
 
-    const input = screen.getByRole('textbox', {
+    const input = screen.getByRole('combobox', {
       name: /command palette search/i,
     })
     expect(input).toHaveFocus()
@@ -104,7 +104,7 @@ describe('CommandInput', () => {
 
     render(<CommandInput value=":" onChange={mockOnChange} />)
 
-    const input = screen.getByRole('textbox', {
+    const input = screen.getByRole('combobox', {
       name: /command palette search/i,
     })
 
@@ -121,7 +121,7 @@ describe('CommandInput', () => {
 
     render(<CommandInput value="" onChange={mockOnChange} />)
 
-    const input = screen.getByRole('textbox', {
+    const input = screen.getByRole('combobox', {
       name: /command palette search/i,
     })
 

--- a/src/features/command-palette/components/CommandInput.test.tsx
+++ b/src/features/command-palette/components/CommandInput.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, test, expect, vi } from 'vitest'
+import { CommandInput } from './CommandInput'
+
+describe('CommandInput', () => {
+  test('renders search icon', () => {
+    const mockOnChange = vi.fn()
+
+    render(<CommandInput value=":" onChange={mockOnChange} />)
+
+    const icon = screen.getByText('search')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveClass('material-symbols-outlined')
+    expect(icon).toHaveClass('text-primary-container')
+  })
+
+  test('renders input with correct attributes', () => {
+    const mockOnChange = vi.fn()
+
+    render(<CommandInput value=":" onChange={mockOnChange} />)
+
+    const input = screen.getByRole('textbox', {
+      name: /command palette search/i,
+    })
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveAttribute('type', 'text')
+    expect(input).toHaveAttribute('placeholder', ':')
+    expect(input).toHaveAttribute('aria-label', 'Command palette search')
+  })
+
+  test('renders input with correct value', () => {
+    const mockOnChange = vi.fn()
+
+    render(<CommandInput value=":open" onChange={mockOnChange} />)
+
+    const input = screen.getByRole('textbox', {
+      name: /command palette search/i,
+    })
+    expect(input).toHaveValue(':open')
+  })
+
+  test('renders input with correct Tailwind classes', () => {
+    const mockOnChange = vi.fn()
+
+    render(<CommandInput value=":" onChange={mockOnChange} />)
+
+    const input = screen.getByRole('textbox', {
+      name: /command palette search/i,
+    })
+    expect(input).toHaveClass(
+      'flex-1',
+      'bg-transparent',
+      'border-none',
+      'outline-none',
+      'text-on-surface',
+      'font-medium',
+      'text-lg'
+    )
+  })
+
+  test('renders ESC badge', () => {
+    const mockOnChange = vi.fn()
+
+    render(<CommandInput value=":" onChange={mockOnChange} />)
+
+    const badge = screen.getByText('ESC')
+    expect(badge).toBeInTheDocument()
+  })
+
+  test('ESC badge has correct Tailwind classes', () => {
+    const mockOnChange = vi.fn()
+
+    render(<CommandInput value=":" onChange={mockOnChange} />)
+
+    const badge = screen.getByText('ESC')
+    expect(badge).toHaveClass(
+      'bg-surface-container-highest/50',
+      'px-2',
+      'py-1',
+      'rounded',
+      'text-[10px]',
+      'font-bold',
+      'text-on-surface/60',
+      'font-mono'
+    )
+  })
+
+  test('input auto-focuses on mount', () => {
+    const mockOnChange = vi.fn()
+
+    render(<CommandInput value=":" onChange={mockOnChange} />)
+
+    const input = screen.getByRole('textbox', {
+      name: /command palette search/i,
+    })
+    expect(input).toHaveFocus()
+  })
+
+  test('calls onChange when user types', async () => {
+    const user = userEvent.setup()
+
+    const mockOnChange = vi.fn()
+
+    render(<CommandInput value=":" onChange={mockOnChange} />)
+
+    const input = screen.getByRole('textbox', {
+      name: /command palette search/i,
+    })
+
+    await user.clear(input)
+    await user.type(input, ':help')
+
+    expect(mockOnChange).toHaveBeenCalled()
+  })
+
+  test('onChange receives correct value when typing', async () => {
+    const user = userEvent.setup()
+
+    const mockOnChange = vi.fn()
+
+    render(<CommandInput value="" onChange={mockOnChange} />)
+
+    const input = screen.getByRole('textbox', {
+      name: /command palette search/i,
+    })
+
+    await user.type(input, 'h')
+
+    // The onChange should have been called with the new value
+    expect(mockOnChange).toHaveBeenCalledWith('h')
+  })
+})

--- a/src/features/command-palette/components/CommandInput.tsx
+++ b/src/features/command-palette/components/CommandInput.tsx
@@ -3,11 +3,13 @@ import { type ChangeEvent, type ReactElement, useEffect, useRef } from 'react'
 interface CommandInputProps {
   value: string
   onChange: (value: string) => void
+  activeDescendantId?: string
 }
 
 export const CommandInput = ({
   value,
   onChange,
+  activeDescendantId = undefined,
 }: CommandInputProps): ReactElement => {
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -35,7 +37,11 @@ export const CommandInput = ({
         onChange={handleChange}
         className="flex-1 bg-transparent border-none outline-none text-on-surface font-medium text-lg"
         placeholder=":"
+        role="combobox"
         aria-label="Command palette search"
+        aria-expanded
+        aria-controls="command-palette-listbox"
+        aria-activedescendant={activeDescendantId}
       />
 
       {/* ESC badge */}

--- a/src/features/command-palette/components/CommandInput.tsx
+++ b/src/features/command-palette/components/CommandInput.tsx
@@ -1,0 +1,47 @@
+import { type ChangeEvent, type ReactElement, useEffect, useRef } from 'react'
+
+interface CommandInputProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+export const CommandInput = ({
+  value,
+  onChange,
+}: CommandInputProps): ReactElement => {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Auto-focus on mount
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    onChange(event.target.value)
+  }
+
+  return (
+    <div className="px-5 py-4 flex items-center gap-3">
+      {/* Search icon */}
+      <span className="material-symbols-outlined text-primary-container text-xl">
+        search
+      </span>
+
+      {/* Input field */}
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={handleChange}
+        className="flex-1 bg-transparent border-none outline-none text-on-surface font-medium text-lg"
+        placeholder=":"
+        aria-label="Command palette search"
+      />
+
+      {/* ESC badge */}
+      <div className="bg-surface-container-highest/50 px-2 py-1 rounded text-[10px] font-bold text-on-surface/60 font-mono">
+        ESC
+      </div>
+    </div>
+  )
+}

--- a/src/features/command-palette/components/CommandResultItem.test.tsx
+++ b/src/features/command-palette/components/CommandResultItem.test.tsx
@@ -17,6 +17,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected={false}
         onSelect={mockOnSelect}
@@ -32,6 +33,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected={false}
         onSelect={mockOnSelect}
@@ -48,6 +50,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected={false}
         onSelect={mockOnSelect}
@@ -68,6 +71,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={commandWithDescription}
         isSelected={false}
         onSelect={mockOnSelect}
@@ -84,6 +88,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected
         onSelect={mockOnSelect}
@@ -100,6 +105,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected
         onSelect={mockOnSelect}
@@ -116,6 +122,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected={false}
         onSelect={mockOnSelect}
@@ -132,6 +139,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected={false}
         onSelect={mockOnSelect}
@@ -148,6 +156,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected
         onSelect={mockOnSelect}
@@ -165,6 +174,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected={false}
         onSelect={mockOnSelect}
@@ -180,6 +190,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected
         onSelect={mockOnSelect}
@@ -196,6 +207,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected
         onSelect={mockOnSelect}
@@ -211,6 +223,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected={false}
         onSelect={mockOnSelect}
@@ -228,6 +241,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected={false}
         onSelect={mockOnSelect}
@@ -246,6 +260,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={mockCommand}
         isSelected={false}
         onSelect={mockOnSelect}
@@ -266,6 +281,7 @@ describe('CommandResultItem', () => {
 
     render(
       <CommandResultItem
+        id="command-test"
         command={commandWithDifferentIcon}
         isSelected={false}
         onSelect={mockOnSelect}

--- a/src/features/command-palette/components/CommandResultItem.test.tsx
+++ b/src/features/command-palette/components/CommandResultItem.test.tsx
@@ -79,7 +79,7 @@ describe('CommandResultItem', () => {
     expect(description).toHaveClass('text-sm')
   })
 
-  test('selected state applies correct background styles', () => {
+  test('selected state applies correct background styles without border', () => {
     const mockOnSelect = vi.fn()
 
     render(
@@ -92,8 +92,7 @@ describe('CommandResultItem', () => {
 
     const option = screen.getByRole('option')
     expect(option).toHaveClass('bg-primary-container/10')
-    expect(option).toHaveClass('border')
-    expect(option).toHaveClass('border-primary-container/10')
+    expect(option).not.toHaveClass('border')
   })
 
   test('selected state applies filled icon variation', () => {
@@ -124,7 +123,7 @@ describe('CommandResultItem', () => {
     )
 
     const option = screen.getByRole('option')
-    expect(option).toHaveClass('hover:bg-surface-container-low/30')
+    expect(option).toHaveClass('hover:bg-surface-container-highest/50')
     expect(option).not.toHaveClass('bg-primary-container/10')
   })
 
@@ -141,7 +140,7 @@ describe('CommandResultItem', () => {
 
     const icon = screen.getByText('description')
     expect(icon).toHaveStyle({ fontVariationSettings: '"FILL" 0' })
-    expect(icon).toHaveClass('text-on-surface/60')
+    expect(icon).toHaveClass('text-on-surface-variant')
   })
 
   test('Enter badge visible when selected', () => {
@@ -155,12 +154,13 @@ describe('CommandResultItem', () => {
       />
     )
 
-    const badge = screen.getByText('↵')
+    const badge = screen.getByText('Enter')
     expect(badge).toBeInTheDocument()
-    expect(badge).toHaveClass('opacity-100')
+    const icon = screen.getByText('keyboard_return')
+    expect(icon).toBeInTheDocument()
   })
 
-  test('Enter badge has group-hover opacity when not selected', () => {
+  test('Enter badge hidden when not selected', () => {
     const mockOnSelect = vi.fn()
 
     render(
@@ -171,34 +171,24 @@ describe('CommandResultItem', () => {
       />
     )
 
-    const badge = screen.getByText('↵')
+    const badge = screen.getByText('Enter')
     expect(badge).toBeInTheDocument()
-    expect(badge).toHaveClass('opacity-0')
-    expect(badge).toHaveClass('group-hover:opacity-100')
   })
 
-  test('Enter badge has correct styling', () => {
+  test('Enter badge includes keyboard_return icon', () => {
     const mockOnSelect = vi.fn()
 
     render(
       <CommandResultItem
         command={mockCommand}
-        isSelected={false}
+        isSelected
         onSelect={mockOnSelect}
       />
     )
 
-    const badge = screen.getByText('↵')
-    expect(badge).toHaveClass(
-      'bg-surface-container-highest/50',
-      'px-2',
-      'py-1',
-      'rounded',
-      'text-[10px]',
-      'font-bold',
-      'text-on-surface/60',
-      'font-mono'
-    )
+    const icon = screen.getByText('keyboard_return')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveClass('material-symbols-outlined')
   })
 
   test('aria-selected is true when selected', () => {

--- a/src/features/command-palette/components/CommandResultItem.test.tsx
+++ b/src/features/command-palette/components/CommandResultItem.test.tsx
@@ -1,0 +1,288 @@
+/* eslint-disable react/jsx-boolean-value */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, test, expect, vi } from 'vitest'
+import type { Command } from '../types'
+import { CommandResultItem } from './CommandResultItem'
+
+describe('CommandResultItem', () => {
+  const mockCommand: Command = {
+    id: 'test',
+    label: 'Test Command',
+    icon: 'description',
+  }
+
+  test('renders with role option', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const option = screen.getByRole('option')
+    expect(option).toBeInTheDocument()
+  })
+
+  test('renders icon', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const icon = screen.getByText('description')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveClass('material-symbols-outlined')
+  })
+
+  test('renders label', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const label = screen.getByText('Test Command')
+    expect(label).toBeInTheDocument()
+  })
+
+  test('renders description when present', () => {
+    const mockOnSelect = vi.fn()
+
+    const commandWithDescription: Command = {
+      ...mockCommand,
+      description: 'This is a test description',
+    }
+
+    render(
+      <CommandResultItem
+        command={commandWithDescription}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const description = screen.getByText('This is a test description')
+    expect(description).toBeInTheDocument()
+    expect(description).toHaveClass('text-sm')
+  })
+
+  test('selected state applies correct background styles', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const option = screen.getByRole('option')
+    expect(option).toHaveClass('bg-primary-container/10')
+    expect(option).toHaveClass('border')
+    expect(option).toHaveClass('border-primary-container/10')
+  })
+
+  test('selected state applies filled icon variation', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const icon = screen.getByText('description')
+    expect(icon).toHaveStyle({ fontVariationSettings: '"FILL" 1' })
+    expect(icon).toHaveClass('text-primary-container')
+  })
+
+  test('unselected state applies hover background styles', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const option = screen.getByRole('option')
+    expect(option).toHaveClass('hover:bg-surface-container-low/30')
+    expect(option).not.toHaveClass('bg-primary-container/10')
+  })
+
+  test('unselected state applies outlined icon variation', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const icon = screen.getByText('description')
+    expect(icon).toHaveStyle({ fontVariationSettings: '"FILL" 0' })
+    expect(icon).toHaveClass('text-on-surface/60')
+  })
+
+  test('Enter badge visible when selected', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const badge = screen.getByText('↵')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveClass('opacity-100')
+  })
+
+  test('Enter badge has group-hover opacity when not selected', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const badge = screen.getByText('↵')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveClass('opacity-0')
+    expect(badge).toHaveClass('group-hover:opacity-100')
+  })
+
+  test('Enter badge has correct styling', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const badge = screen.getByText('↵')
+    expect(badge).toHaveClass(
+      'bg-surface-container-highest/50',
+      'px-2',
+      'py-1',
+      'rounded',
+      'text-[10px]',
+      'font-bold',
+      'text-on-surface/60',
+      'font-mono'
+    )
+  })
+
+  test('aria-selected is true when selected', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const option = screen.getByRole('option')
+    expect(option).toHaveAttribute('aria-selected', 'true')
+  })
+
+  test('aria-selected is false when not selected', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const option = screen.getByRole('option')
+    expect(option).toHaveAttribute('aria-selected', 'false')
+  })
+
+  test('calls onSelect when clicked', async () => {
+    const user = userEvent.setup()
+
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const option = screen.getByRole('option')
+
+    await user.click(option)
+
+    expect(mockOnSelect).toHaveBeenCalledTimes(1)
+  })
+
+  test('has cursor-pointer class', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResultItem
+        command={mockCommand}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const option = screen.getByRole('option')
+    expect(option).toHaveClass('cursor-pointer')
+  })
+
+  test('renders different icons correctly', () => {
+    const mockOnSelect = vi.fn()
+
+    const commandWithDifferentIcon: Command = {
+      ...mockCommand,
+      icon: 'folder',
+    }
+
+    render(
+      <CommandResultItem
+        command={commandWithDifferentIcon}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const icon = screen.getByText('folder')
+    expect(icon).toBeInTheDocument()
+  })
+})

--- a/src/features/command-palette/components/CommandResultItem.tsx
+++ b/src/features/command-palette/components/CommandResultItem.tsx
@@ -2,17 +2,20 @@ import type { ReactElement } from 'react'
 import type { Command } from '../types'
 
 interface CommandResultItemProps {
+  id: string
   command: Command
   isSelected: boolean
   onSelect: () => void
 }
 
 export const CommandResultItem = ({
+  id,
   command,
   isSelected,
   onSelect,
 }: CommandResultItemProps): ReactElement => (
   <div
+    id={id}
     role="option"
     aria-selected={isSelected}
     onClick={onSelect}

--- a/src/features/command-palette/components/CommandResultItem.tsx
+++ b/src/features/command-palette/components/CommandResultItem.tsx
@@ -17,35 +17,46 @@ export const CommandResultItem = ({
     aria-selected={isSelected}
     onClick={onSelect}
     className={`
-        group px-3 py-2.5 rounded-xl flex items-center gap-3 cursor-pointer transition-all
-        ${isSelected ? 'bg-primary-container/10 border border-primary-container/10' : 'hover:bg-surface-container-low/30'}
+        group px-3 py-2.5 rounded-xl flex items-center justify-between cursor-pointer transition-all
+        ${isSelected ? 'bg-primary-container/10' : 'hover:bg-surface-container-highest/50'}
       `}
   >
-    {/* Icon - filled if selected, outlined if not */}
-    <span
-      className={`material-symbols-outlined text-xl ${isSelected ? 'text-primary-container' : 'text-on-surface/60'}`}
-      style={{ fontVariationSettings: isSelected ? '"FILL" 1' : '"FILL" 0' }}
-    >
-      {command.icon}
-    </span>
+    <div className="flex items-center gap-3">
+      {/* Icon - filled if selected, outlined if not */}
+      <span
+        className={`material-symbols-outlined text-lg ${isSelected ? 'text-primary-container' : 'text-on-surface-variant'}`}
+        style={{
+          fontVariationSettings: isSelected ? '"FILL" 1' : '"FILL" 0',
+        }}
+      >
+        {command.icon}
+      </span>
 
-    {/* Label and description */}
-    <div className="flex-1 min-w-0">
-      <div className="text-on-surface font-medium">{command.label}</div>
-      {command.description && (
-        <div className="text-on-surface/60 text-sm">{command.description}</div>
-      )}
+      {/* Label and description */}
+      <div className="flex-1 min-w-0">
+        <span className="text-sm font-medium text-on-surface">
+          {command.label}
+        </span>
+        {command.description && (
+          <span className="text-sm text-on-surface-variant ml-2">
+            {command.description}
+          </span>
+        )}
+      </div>
     </div>
 
-    {/* Enter badge - always visible when selected, visible on hover otherwise */}
+    {/* Enter badge - matches design: icon + text */}
     <div
       className={`
-          bg-surface-container-highest/50 px-2 py-1 rounded text-[10px] font-bold text-on-surface/60 font-mono
+          flex items-center gap-1 px-1.5 py-0.5 rounded bg-surface-container-highest text-[10px] text-on-surface-variant font-bold uppercase
           ${isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}
           transition-opacity
         `}
     >
-      ↵
+      <span className="material-symbols-outlined text-[12px]">
+        keyboard_return
+      </span>
+      <span>Enter</span>
     </div>
   </div>
 )

--- a/src/features/command-palette/components/CommandResultItem.tsx
+++ b/src/features/command-palette/components/CommandResultItem.tsx
@@ -1,0 +1,51 @@
+import type { ReactElement } from 'react'
+import type { Command } from '../types'
+
+interface CommandResultItemProps {
+  command: Command
+  isSelected: boolean
+  onSelect: () => void
+}
+
+export const CommandResultItem = ({
+  command,
+  isSelected,
+  onSelect,
+}: CommandResultItemProps): ReactElement => (
+  <div
+    role="option"
+    aria-selected={isSelected}
+    onClick={onSelect}
+    className={`
+        group px-3 py-2.5 rounded-xl flex items-center gap-3 cursor-pointer transition-all
+        ${isSelected ? 'bg-primary-container/10 border border-primary-container/10' : 'hover:bg-surface-container-low/30'}
+      `}
+  >
+    {/* Icon - filled if selected, outlined if not */}
+    <span
+      className={`material-symbols-outlined text-xl ${isSelected ? 'text-primary-container' : 'text-on-surface/60'}`}
+      style={{ fontVariationSettings: isSelected ? '"FILL" 1' : '"FILL" 0' }}
+    >
+      {command.icon}
+    </span>
+
+    {/* Label and description */}
+    <div className="flex-1 min-w-0">
+      <div className="text-on-surface font-medium">{command.label}</div>
+      {command.description && (
+        <div className="text-on-surface/60 text-sm">{command.description}</div>
+      )}
+    </div>
+
+    {/* Enter badge - always visible when selected, visible on hover otherwise */}
+    <div
+      className={`
+          bg-surface-container-highest/50 px-2 py-1 rounded text-[10px] font-bold text-on-surface/60 font-mono
+          ${isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}
+          transition-opacity
+        `}
+    >
+      ↵
+    </div>
+  </div>
+)

--- a/src/features/command-palette/components/CommandResults.test.tsx
+++ b/src/features/command-palette/components/CommandResults.test.tsx
@@ -1,0 +1,268 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, test, expect, vi } from 'vitest'
+import type { Command } from '../types'
+import { CommandResults } from './CommandResults'
+
+describe('CommandResults', () => {
+  const mockCommands: Command[] = [
+    {
+      id: 'cmd1',
+      label: 'Open File',
+      icon: 'description',
+      description: 'Open a file by name',
+    },
+    {
+      id: 'cmd2',
+      label: 'Set Theme',
+      icon: 'settings',
+      description: 'Change color theme',
+    },
+    {
+      id: 'cmd3',
+      label: 'Help',
+      icon: 'help',
+    },
+  ]
+
+  test('renders with role listbox', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={0}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const listbox = screen.getByRole('listbox')
+    expect(listbox).toBeInTheDocument()
+  })
+
+  test('renders filtered list of results', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={0}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    // All three commands should be rendered
+    expect(screen.getByText('Open File')).toBeInTheDocument()
+    expect(screen.getByText('Set Theme')).toBeInTheDocument()
+    expect(screen.getByText('Help')).toBeInTheDocument()
+  })
+
+  test('renders empty list when no results', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={[]}
+        selectedIndex={0}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const listbox = screen.getByRole('listbox')
+
+    expect(listbox).toBeInTheDocument()
+    // No options should be rendered
+    expect(screen.queryAllByRole('option')).toHaveLength(0)
+  })
+
+  test('selectedIndex highlights correct item', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={1}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const options = screen.getAllByRole('option')
+
+    // First item should NOT be selected
+    expect(options[0]).toHaveAttribute('aria-selected', 'false')
+    expect(options[0]).not.toHaveClass('bg-primary-container/10')
+
+    // Second item SHOULD be selected
+    expect(options[1]).toHaveAttribute('aria-selected', 'true')
+    expect(options[1]).toHaveClass('bg-primary-container/10')
+
+    // Third item should NOT be selected
+    expect(options[2]).toHaveAttribute('aria-selected', 'false')
+    expect(options[2]).not.toHaveClass('bg-primary-container/10')
+  })
+
+  test('aria-activedescendant points to selected item', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={1}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const listbox = screen.getByRole('listbox')
+
+    expect(listbox).toHaveAttribute('aria-activedescendant', 'command-cmd2')
+  })
+
+  test('aria-activedescendant is undefined when no results', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={[]}
+        selectedIndex={0}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const listbox = screen.getByRole('listbox')
+
+    expect(listbox).not.toHaveAttribute('aria-activedescendant')
+  })
+
+  test('aria-activedescendant is undefined when selectedIndex out of bounds', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={99}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const listbox = screen.getByRole('listbox')
+
+    expect(listbox).not.toHaveAttribute('aria-activedescendant')
+  })
+
+  test('calls onSelect with correct index when item clicked', async () => {
+    const user = userEvent.setup()
+
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={0}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const options = screen.getAllByRole('option')
+
+    // Click the second item
+    await user.click(options[1])
+
+    expect(mockOnSelect).toHaveBeenCalledTimes(1)
+    expect(mockOnSelect).toHaveBeenCalledWith(1)
+  })
+
+  test('calls onSelect with correct index when first item clicked', async () => {
+    const user = userEvent.setup()
+
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={1}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const options = screen.getAllByRole('option')
+
+    // Click the first item
+    await user.click(options[0])
+
+    expect(mockOnSelect).toHaveBeenCalledTimes(1)
+    expect(mockOnSelect).toHaveBeenCalledWith(0)
+  })
+
+  test('calls onSelect with correct index when last item clicked', async () => {
+    const user = userEvent.setup()
+
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={0}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const options = screen.getAllByRole('option')
+
+    // Click the last item
+    await user.click(options[2])
+
+    expect(mockOnSelect).toHaveBeenCalledTimes(1)
+    expect(mockOnSelect).toHaveBeenCalledWith(2)
+  })
+
+  test('has correct Tailwind classes for scrolling', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={0}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    const listbox = screen.getByRole('listbox')
+
+    expect(listbox).toHaveClass('p-2', 'overflow-y-auto', 'max-h-96')
+  })
+
+  test('renders descriptions when present', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={0}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    // First two commands have descriptions
+    expect(screen.getByText('Open a file by name')).toBeInTheDocument()
+    expect(screen.getByText('Change color theme')).toBeInTheDocument()
+
+    // Third command has no description
+    expect(screen.queryByText('Help description')).not.toBeInTheDocument()
+  })
+
+  test('renders icons for all commands', () => {
+    const mockOnSelect = vi.fn()
+
+    render(
+      <CommandResults
+        filteredResults={mockCommands}
+        selectedIndex={0}
+        onSelect={mockOnSelect}
+      />
+    )
+
+    expect(screen.getByText('description')).toBeInTheDocument()
+    expect(screen.getByText('settings')).toBeInTheDocument()
+    expect(screen.getByText('help')).toBeInTheDocument()
+  })
+})

--- a/src/features/command-palette/components/CommandResults.test.tsx
+++ b/src/features/command-palette/components/CommandResults.test.tsx
@@ -101,7 +101,7 @@ describe('CommandResults', () => {
     expect(options[2]).not.toHaveClass('bg-primary-container/10')
   })
 
-  test('aria-activedescendant points to selected item', () => {
+  test('listbox has id for aria-controls reference', () => {
     const mockOnSelect = vi.fn()
 
     render(
@@ -114,39 +114,25 @@ describe('CommandResults', () => {
 
     const listbox = screen.getByRole('listbox')
 
-    expect(listbox).toHaveAttribute('aria-activedescendant', 'command-cmd2')
+    expect(listbox).toHaveAttribute('id', 'command-palette-listbox')
   })
 
-  test('aria-activedescendant is undefined when no results', () => {
-    const mockOnSelect = vi.fn()
-
-    render(
-      <CommandResults
-        filteredResults={[]}
-        selectedIndex={0}
-        onSelect={mockOnSelect}
-      />
-    )
-
-    const listbox = screen.getByRole('listbox')
-
-    expect(listbox).not.toHaveAttribute('aria-activedescendant')
-  })
-
-  test('aria-activedescendant is undefined when selectedIndex out of bounds', () => {
+  test('option elements have ids for aria-activedescendant', () => {
     const mockOnSelect = vi.fn()
 
     render(
       <CommandResults
         filteredResults={mockCommands}
-        selectedIndex={99}
+        selectedIndex={0}
         onSelect={mockOnSelect}
       />
     )
 
-    const listbox = screen.getByRole('listbox')
+    const options = screen.getAllByRole('option')
 
-    expect(listbox).not.toHaveAttribute('aria-activedescendant')
+    expect(options[0]).toHaveAttribute('id', 'command-cmd1')
+    expect(options[1]).toHaveAttribute('id', 'command-cmd2')
+    expect(options[2]).toHaveAttribute('id', 'command-cmd3')
   })
 
   test('calls onSelect with correct index when item clicked', async () => {

--- a/src/features/command-palette/components/CommandResults.tsx
+++ b/src/features/command-palette/components/CommandResults.tsx
@@ -1,0 +1,47 @@
+import { motion } from 'framer-motion'
+import type { ReactElement } from 'react'
+import type { Command } from '../types'
+import { CommandResultItem } from './CommandResultItem'
+
+interface CommandResultsProps {
+  filteredResults: Command[]
+  selectedIndex: number
+  onSelect: (index: number) => void
+}
+
+export const CommandResults = ({
+  filteredResults,
+  selectedIndex,
+  onSelect,
+}: CommandResultsProps): ReactElement => (
+  <div
+    role="listbox"
+    aria-activedescendant={
+      filteredResults[selectedIndex]
+        ? `command-${filteredResults[selectedIndex].id}`
+        : undefined
+    }
+    className="p-2 overflow-y-auto max-h-96"
+  >
+    {filteredResults.map((command, index) => (
+      <motion.div
+        key={command.id}
+        id={`command-${command.id}`}
+        initial={{ opacity: 0, y: -4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{
+          duration: 0.15,
+          delay: index * 0.03, // 30ms stagger
+        }}
+      >
+        <CommandResultItem
+          command={command}
+          isSelected={index === selectedIndex}
+          onSelect={() => {
+            onSelect(index)
+          }}
+        />
+      </motion.div>
+    ))}
+  </div>
+)

--- a/src/features/command-palette/components/CommandResults.tsx
+++ b/src/features/command-palette/components/CommandResults.tsx
@@ -15,18 +15,13 @@ export const CommandResults = ({
   onSelect,
 }: CommandResultsProps): ReactElement => (
   <div
+    id="command-palette-listbox"
     role="listbox"
-    aria-activedescendant={
-      filteredResults[selectedIndex]
-        ? `command-${filteredResults[selectedIndex].id}`
-        : undefined
-    }
     className="p-2 overflow-y-auto max-h-96"
   >
     {filteredResults.map((command, index) => (
       <motion.div
         key={command.id}
-        id={`command-${command.id}`}
         initial={{ opacity: 0, y: -4 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{
@@ -35,6 +30,7 @@ export const CommandResults = ({
         }}
       >
         <CommandResultItem
+          id={`command-${command.id}`}
           command={command}
           isSelected={index === selectedIndex}
           onSelect={() => {

--- a/src/features/command-palette/data/defaultCommands.ts
+++ b/src/features/command-palette/data/defaultCommands.ts
@@ -1,0 +1,84 @@
+import type { Command } from '../types'
+
+/**
+ * Default command tree with stubbed execute handlers.
+ * All leaf commands log their action to console.info.
+ */
+export const defaultCommands: Command[] = [
+  {
+    id: 'open',
+    label: ':open',
+    description: 'Open a file or recent item',
+    icon: 'folder',
+    children: [
+      {
+        id: 'open-filename',
+        label: '<filename>',
+        description: 'Open file by name (fuzzy search)',
+        icon: 'description',
+        execute: (args: string): void => {
+          // eslint-disable-next-line no-console
+          console.info('Opening file:', args || '(no filename provided)')
+        },
+      },
+      {
+        id: 'open-recent',
+        label: 'recent',
+        description: 'Show recently opened files',
+        icon: 'history',
+        execute: (): void => {
+          // eslint-disable-next-line no-console
+          console.info('Showing recently opened files')
+        },
+      },
+    ],
+  },
+  {
+    id: 'set',
+    label: ':set',
+    description: 'Change editor settings',
+    icon: 'settings',
+    children: [
+      {
+        id: 'set-theme',
+        label: 'theme',
+        description: 'Switch color theme',
+        icon: 'palette',
+        execute: (): void => {
+          // eslint-disable-next-line no-console
+          console.info('Switching color theme')
+        },
+      },
+      {
+        id: 'set-font',
+        label: 'font',
+        description: 'Change editor font',
+        icon: 'text_fields',
+        execute: (): void => {
+          // eslint-disable-next-line no-console
+          console.info('Changing editor font')
+        },
+      },
+    ],
+  },
+  {
+    id: 'help',
+    label: ':help',
+    description: 'Show command reference',
+    icon: 'help',
+    execute: (): void => {
+      // eslint-disable-next-line no-console
+      console.info('Showing command reference')
+    },
+  },
+  {
+    id: 'new',
+    label: ':new',
+    description: 'Create new conversation',
+    icon: 'add',
+    execute: (): void => {
+      // eslint-disable-next-line no-console
+      console.info('Creating new conversation')
+    },
+  },
+]

--- a/src/features/command-palette/hooks/useCommandPalette.test.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.test.ts
@@ -1,0 +1,664 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useCommandPalette } from './useCommandPalette'
+
+describe('useCommandPalette', () => {
+  beforeEach(() => {
+    // Clear any focused elements before each test
+    document.body.innerHTML = ''
+    if (document.activeElement && 'blur' in document.activeElement) {
+      const activeElement = document.activeElement as HTMLElement
+      activeElement.blur()
+    }
+  })
+
+  describe('initial state', () => {
+    test('starts closed with default values', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      expect(result.current.state.isOpen).toBe(false)
+      expect(result.current.state.query).toBe(':')
+      expect(result.current.state.selectedIndex).toBe(0)
+      expect(result.current.state.currentNamespace).toBe(null)
+      expect(result.current.state.filteredResults).toEqual([])
+    })
+  })
+
+  describe('open/close actions', () => {
+    test('open() sets isOpen to true and loads default commands', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+      })
+
+      expect(result.current.state.isOpen).toBe(true)
+      expect(result.current.state.query).toBe(':')
+      expect(result.current.state.selectedIndex).toBe(0)
+      expect(result.current.state.filteredResults.length).toBeGreaterThan(0)
+    })
+
+    test('close() resets state', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+        result.current.setQuery(':test')
+        result.current.selectIndex(2)
+      })
+
+      act(() => {
+        result.current.close()
+      })
+
+      expect(result.current.state.isOpen).toBe(false)
+      expect(result.current.state.query).toBe(':')
+      expect(result.current.state.selectedIndex).toBe(0)
+      expect(result.current.state.currentNamespace).toBe(null)
+      expect(result.current.state.filteredResults).toEqual([])
+    })
+  })
+
+  describe('keyboard trigger - ":" key', () => {
+    test('opens palette when ":" pressed and no input focused', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      expect(result.current.state.isOpen).toBe(false)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: ':' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(true)
+      })
+    })
+
+    test('suppresses ":" when input element is focused', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+
+      expect(document.activeElement).toBe(input)
+      expect(result.current.state.isOpen).toBe(false)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: ':' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(false)
+      })
+    })
+
+    test('suppresses ":" when textarea is focused', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+      const textarea = document.createElement('textarea')
+      document.body.appendChild(textarea)
+      textarea.focus()
+
+      expect(document.activeElement).toBe(textarea)
+      expect(result.current.state.isOpen).toBe(false)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: ':' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(false)
+      })
+    })
+
+    test('suppresses ":" when contenteditable element is focused', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+      const div = document.createElement('div')
+      div.setAttribute('contenteditable', 'true')
+      document.body.appendChild(div)
+      div.focus()
+
+      expect(document.activeElement).toBe(div)
+      expect(result.current.state.isOpen).toBe(false)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: ':' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(false)
+      })
+    })
+
+    test('suppresses ":" when contenteditable="" element is focused', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+      const div = document.createElement('div')
+      div.setAttribute('contenteditable', '')
+      document.body.appendChild(div)
+      div.focus()
+
+      expect(document.activeElement).toBe(div)
+      expect(result.current.state.isOpen).toBe(false)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: ':' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(false)
+      })
+    })
+
+    test('does not open when already open', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+        result.current.setQuery(':test')
+      })
+
+      const queryBeforeKeypress = result.current.state.query
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: ':' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.query).toBe(queryBeforeKeypress)
+      })
+    })
+  })
+
+  describe('keyboard navigation - Escape', () => {
+    test('closes palette when Escape pressed', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+      })
+
+      expect(result.current.state.isOpen).toBe(true)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'Escape' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(false)
+      })
+    })
+
+    test('does not trigger when palette is closed', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      expect(result.current.state.isOpen).toBe(false)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'Escape' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(false)
+      })
+    })
+  })
+
+  describe('keyboard navigation - Backspace', () => {
+    test('closes palette when Backspace pressed on empty query', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+      })
+
+      expect(result.current.state.isOpen).toBe(true)
+      expect(result.current.state.query).toBe(':')
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'Backspace' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(false)
+      })
+    })
+
+    test('does not close when query is not empty', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+        result.current.setQuery(':open')
+      })
+
+      expect(result.current.state.isOpen).toBe(true)
+      expect(result.current.state.query).toBe(':open')
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'Backspace' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(true)
+      })
+    })
+  })
+
+  describe('keyboard navigation - ArrowUp/ArrowDown', () => {
+    test('ArrowDown increments selectedIndex', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+      })
+
+      expect(result.current.state.selectedIndex).toBe(0)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'ArrowDown' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.selectedIndex).toBe(1)
+      })
+    })
+
+    test('ArrowDown wraps to 0 at end of results', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+      })
+
+      const lastIndex = result.current.state.filteredResults.length - 1
+
+      act(() => {
+        result.current.selectIndex(lastIndex)
+      })
+
+      expect(result.current.state.selectedIndex).toBe(lastIndex)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'ArrowDown' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.selectedIndex).toBe(0)
+      })
+    })
+
+    test('ArrowUp decrements selectedIndex', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+        result.current.selectIndex(2)
+      })
+
+      expect(result.current.state.selectedIndex).toBe(2)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'ArrowUp' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.selectedIndex).toBe(1)
+      })
+    })
+
+    test('ArrowUp wraps to last index when at 0', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+      })
+
+      expect(result.current.state.selectedIndex).toBe(0)
+
+      const lastIndex = result.current.state.filteredResults.length - 1
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'ArrowUp' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.selectedIndex).toBe(lastIndex)
+      })
+    })
+
+    test('navigation only works when palette is open', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      expect(result.current.state.isOpen).toBe(false)
+      expect(result.current.state.selectedIndex).toBe(0)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'ArrowDown' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.selectedIndex).toBe(0)
+      })
+    })
+  })
+
+  describe('keyboard navigation - Enter', () => {
+    test('Enter executes selected leaf command', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      const consoleInfoSpy = vi
+        .spyOn(console, 'info')
+        .mockImplementation(() => {
+          // Mock implementation - intentionally empty
+        })
+
+      act(() => {
+        result.current.open()
+        result.current.setQuery(':help')
+      })
+
+      // Find and select the :help command
+      const helpIndex = result.current.state.filteredResults.findIndex(
+        (cmd) => cmd.id === 'help'
+      )
+
+      if (helpIndex !== -1) {
+        act(() => {
+          result.current.selectIndex(helpIndex)
+        })
+
+        act(() => {
+          const event = new KeyboardEvent('keydown', { key: 'Enter' })
+          document.dispatchEvent(event)
+        })
+
+        await waitFor(() => {
+          expect(consoleInfoSpy).toHaveBeenCalled()
+          expect(result.current.state.isOpen).toBe(false)
+        })
+      }
+
+      consoleInfoSpy.mockRestore()
+    })
+
+    test('Enter drills into namespace command', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+        result.current.setQuery(':open')
+      })
+
+      // Find the :open namespace
+      const openIndex = result.current.state.filteredResults.findIndex(
+        (cmd) => cmd.id === 'open'
+      )
+
+      if (openIndex !== -1) {
+        act(() => {
+          result.current.selectIndex(openIndex)
+        })
+
+        const selectedCommand = result.current.state.filteredResults[openIndex]
+
+        const hasChildren =
+          selectedCommand.children && selectedCommand.children.length > 0
+
+        if (hasChildren) {
+          act(() => {
+            const event = new KeyboardEvent('keydown', { key: 'Enter' })
+            document.dispatchEvent(event)
+          })
+
+          await waitFor(() => {
+            expect(result.current.state.currentNamespace).not.toBe(null)
+            expect(result.current.state.isOpen).toBe(true)
+          })
+        }
+      }
+    })
+
+    test('Enter does nothing when no results', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+        result.current.setQuery(':nonexistent')
+      })
+
+      expect(result.current.state.filteredResults.length).toBe(0)
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'Enter' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(true)
+      })
+    })
+
+    test('Enter does nothing when selectedIndex out of bounds', async () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+        result.current.selectIndex(999)
+      })
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'Enter' })
+        document.dispatchEvent(event)
+      })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(true)
+      })
+    })
+  })
+
+  describe('query filtering', () => {
+    test('setQuery updates filteredResults via fuzzyMatch', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+      })
+
+      const initialResultsCount = result.current.state.filteredResults.length
+
+      act(() => {
+        result.current.setQuery(':op')
+      })
+
+      expect(result.current.state.query).toBe(':op')
+      expect(result.current.state.filteredResults.length).toBeGreaterThan(0)
+      expect(result.current.state.filteredResults.length).toBeLessThanOrEqual(
+        initialResultsCount
+      )
+    })
+
+    test('setQuery resets selectedIndex to 0', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+        result.current.selectIndex(3)
+      })
+
+      expect(result.current.state.selectedIndex).toBe(3)
+
+      act(() => {
+        result.current.setQuery(':help')
+      })
+
+      expect(result.current.state.selectedIndex).toBe(0)
+    })
+
+    test('empty query shows all commands', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+      })
+
+      const allCommandsCount = result.current.state.filteredResults.length
+
+      act(() => {
+        result.current.setQuery(':')
+      })
+
+      expect(result.current.state.filteredResults.length).toBe(allCommandsCount)
+    })
+
+    test('query filters commands based on fuzzy match score', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+        result.current.setQuery(':help')
+      })
+
+      const hasHelpCommand = result.current.state.filteredResults.some((cmd) =>
+        cmd.label.toLowerCase().includes('help')
+      )
+
+      expect(hasHelpCommand).toBe(true)
+    })
+  })
+
+  describe('cleanup', () => {
+    test('removes event listener on unmount', () => {
+      const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener')
+      const { unmount } = renderHook(() => useCommandPalette())
+
+      unmount()
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'keydown',
+        expect.any(Function)
+      )
+
+      removeEventListenerSpy.mockRestore()
+    })
+  })
+
+  describe('navigateUp/navigateDown direct calls', () => {
+    test('navigateDown increments selectedIndex', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+      })
+
+      expect(result.current.state.selectedIndex).toBe(0)
+
+      act(() => {
+        result.current.navigateDown()
+      })
+
+      expect(result.current.state.selectedIndex).toBe(1)
+    })
+
+    test('navigateUp decrements selectedIndex', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+        result.current.selectIndex(2)
+      })
+
+      expect(result.current.state.selectedIndex).toBe(2)
+
+      act(() => {
+        result.current.navigateUp()
+      })
+
+      expect(result.current.state.selectedIndex).toBe(1)
+    })
+  })
+
+  describe('selectIndex', () => {
+    test('updates selectedIndex to specified value', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        result.current.open()
+      })
+
+      act(() => {
+        result.current.selectIndex(5)
+      })
+
+      expect(result.current.state.selectedIndex).toBe(5)
+    })
+  })
+
+  describe('executeSelected', () => {
+    test('executes the selected command', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      const consoleInfoSpy = vi
+        .spyOn(console, 'info')
+        .mockImplementation(() => {
+          // Mock implementation - intentionally empty
+        })
+
+      act(() => {
+        result.current.open()
+        result.current.setQuery(':new')
+      })
+
+      const newIndex = result.current.state.filteredResults.findIndex(
+        (cmd) => cmd.id === 'new'
+      )
+
+      if (newIndex !== -1) {
+        act(() => {
+          result.current.selectIndex(newIndex)
+          result.current.executeSelected()
+        })
+
+        expect(consoleInfoSpy).toHaveBeenCalled()
+        expect(result.current.state.isOpen).toBe(false)
+      }
+
+      consoleInfoSpy.mockRestore()
+    })
+
+    test('does not execute when selectedIndex is out of bounds', () => {
+      const { result } = renderHook(() => useCommandPalette())
+
+      const consoleInfoSpy = vi
+        .spyOn(console, 'info')
+        .mockImplementation(() => {
+          // Mock implementation - intentionally empty
+        })
+
+      act(() => {
+        result.current.open()
+        result.current.selectIndex(-1)
+        result.current.executeSelected()
+      })
+
+      expect(consoleInfoSpy).not.toHaveBeenCalled()
+      expect(result.current.state.isOpen).toBe(true)
+
+      consoleInfoSpy.mockRestore()
+    })
+  })
+})

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -206,13 +206,13 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
   // Global keyboard listener
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
-      // Check if an input element is focused
-      if (isInputElement(document.activeElement)) {
-        return
-      }
-
-      // Open palette on ':'
+      // Open palette on ':' (only when no input is focused and palette is closed)
       if (event.key === ':' && !state.isOpen) {
+        // Skip if user is typing in another input
+        if (isInputElement(document.activeElement)) {
+          return
+        }
+
         event.preventDefault()
         open()
 

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { Command, CommandPaletteState } from '../types'
+import { fuzzyMatch } from '../registry/fuzzyMatch'
+import { defaultCommands } from '../data/defaultCommands'
+import { getAllLeaves, traverseNamespace } from '../registry/commandTree'
+
+interface UseCommandPaletteReturn {
+  state: CommandPaletteState
+  open: () => void
+  close: () => void
+  setQuery: (query: string) => void
+  selectIndex: (index: number) => void
+  executeSelected: () => void
+  navigateUp: () => void
+  navigateDown: () => void
+}
+
+const isInputElement = (element: Element | null): boolean => {
+  if (!element) {
+    return false
+  }
+
+  const tagName = element.tagName.toLowerCase()
+  if (tagName === 'input' || tagName === 'textarea') {
+    return true
+  }
+
+  // Check for contenteditable
+  if (element.hasAttribute('contenteditable')) {
+    const value = element.getAttribute('contenteditable')
+
+    return value === 'true' || value === ''
+  }
+
+  return false
+}
+
+export const useCommandPalette = (): UseCommandPaletteReturn => {
+  const [state, setState] = useState<CommandPaletteState>({
+    isOpen: false,
+    query: ':',
+    selectedIndex: 0,
+    currentNamespace: null,
+    filteredResults: [],
+  })
+
+  // Filter commands based on query
+  const filterCommands = useCallback(
+    (query: string, namespace: Command | null): Command[] => {
+      const searchSpace = namespace
+        ? (traverseNamespace(namespace) ?? [])
+        : defaultCommands
+
+      if (!query || query === ':') {
+        return searchSpace
+      }
+
+      // Remove ':' prefix for matching
+      const cleanQuery = query.startsWith(':') ? query.slice(1) : query
+
+      // Get all searchable commands (namespaces + leaves)
+      const allCommands = [...searchSpace]
+      const leaves = getAllLeaves(searchSpace)
+      allCommands.push(...leaves)
+
+      // Score and filter
+      const scored = allCommands
+        .map((cmd) => {
+          const score = cmd.match
+            ? cmd.match(cleanQuery)
+            : fuzzyMatch(cleanQuery, cmd.label.replace(':', ''))
+
+          return { cmd, score }
+        })
+        .filter(({ score }) => score > 0)
+        .sort((a, b) => b.score - a.score)
+        .map(({ cmd }) => cmd)
+
+      // Deduplicate by id
+      const seen = new Set<string>()
+
+      return scored.filter((cmd) => {
+        if (seen.has(cmd.id)) {
+          return false
+        }
+        seen.add(cmd.id)
+
+        return true
+      })
+    },
+    []
+  )
+
+  const open = useCallback((): void => {
+    setState((prev) => ({
+      ...prev,
+      isOpen: true,
+      query: ':',
+      selectedIndex: 0,
+      currentNamespace: null,
+      filteredResults: filterCommands(':', null),
+    }))
+  }, [filterCommands])
+
+  const close = useCallback((): void => {
+    setState((prev) => ({
+      ...prev,
+      isOpen: false,
+      query: ':',
+      selectedIndex: 0,
+      currentNamespace: null,
+      filteredResults: [],
+    }))
+  }, [])
+
+  const setQuery = useCallback(
+    (query: string): void => {
+      setState((prev) => {
+        const filteredResults = filterCommands(query, prev.currentNamespace)
+
+        return {
+          ...prev,
+          query,
+          selectedIndex: 0,
+          filteredResults,
+        }
+      })
+    },
+    [filterCommands]
+  )
+
+  const selectIndex = useCallback((index: number): void => {
+    setState((prev) => ({
+      ...prev,
+      selectedIndex: index,
+    }))
+  }, [])
+
+  const navigateUp = useCallback((): void => {
+    setState((prev) => {
+      const newIndex =
+        prev.selectedIndex <= 0
+          ? prev.filteredResults.length - 1
+          : prev.selectedIndex - 1
+
+      return {
+        ...prev,
+        selectedIndex: newIndex,
+      }
+    })
+  }, [])
+
+  const navigateDown = useCallback((): void => {
+    setState((prev) => {
+      const newIndex =
+        prev.selectedIndex >= prev.filteredResults.length - 1
+          ? 0
+          : prev.selectedIndex + 1
+
+      return {
+        ...prev,
+        selectedIndex: newIndex,
+      }
+    })
+  }, [])
+
+  const executeSelected = useCallback((): void => {
+    if (
+      state.selectedIndex < 0 ||
+      state.selectedIndex >= state.filteredResults.length
+    ) {
+      return
+    }
+
+    const selected = state.filteredResults[state.selectedIndex]
+
+    // If it's a namespace, drill into it
+    if (selected.children && selected.children.length > 0) {
+      setState((prev) => ({
+        ...prev,
+        currentNamespace: selected,
+        query: ':',
+        selectedIndex: 0,
+        filteredResults: filterCommands(':', selected),
+      }))
+
+      return
+    }
+
+    // If it's a leaf, execute it
+    if (selected.execute) {
+      const args = state.query.startsWith(':')
+        ? state.query.slice(1)
+        : state.query
+      selected.execute(args)
+      close()
+    }
+  }, [
+    state.filteredResults,
+    state.selectedIndex,
+    state.query,
+    filterCommands,
+    close,
+  ])
+
+  // Global keyboard listener
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      // Check if an input element is focused
+      if (isInputElement(document.activeElement)) {
+        return
+      }
+
+      // Open palette on ':'
+      if (event.key === ':' && !state.isOpen) {
+        event.preventDefault()
+        open()
+
+        return
+      }
+
+      // Handle keyboard navigation when palette is open
+      if (state.isOpen) {
+        switch (event.key) {
+          case 'Escape':
+            event.preventDefault()
+            close()
+            break
+          case 'ArrowUp':
+            event.preventDefault()
+            navigateUp()
+            break
+          case 'ArrowDown':
+            event.preventDefault()
+            navigateDown()
+            break
+          case 'Enter':
+            event.preventDefault()
+            executeSelected()
+            break
+          case 'Backspace':
+            // Close on backspace when query is empty ':'
+            if (state.query === ':') {
+              event.preventDefault()
+              close()
+            }
+            break
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return (): void => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [
+    state.isOpen,
+    state.query,
+    open,
+    close,
+    navigateUp,
+    navigateDown,
+    executeSelected,
+  ])
+
+  return {
+    state,
+    open,
+    close,
+    setQuery,
+    selectIndex,
+    executeSelected,
+    navigateUp,
+    navigateDown,
+  }
+}

--- a/src/features/command-palette/registry/commandTree.test.ts
+++ b/src/features/command-palette/registry/commandTree.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from 'vitest'
+import type { Command } from './types'
+import {
+  buildTree,
+  findCommandById,
+  findLeaf,
+  getAllLeaves,
+  mergeTrees,
+  traverseNamespace,
+} from './commandTree'
+
+describe('commandTree', () => {
+  const mockLeafCommand: Command = {
+    id: 'test-leaf',
+    label: 'Test Leaf',
+    icon: 'check',
+    execute: (): void => {
+      // Mock execute
+    },
+  }
+
+  const mockNamespaceCommand: Command = {
+    id: 'test-namespace',
+    label: 'Test Namespace',
+    icon: 'folder',
+    children: [
+      {
+        id: 'child-1',
+        label: 'Child 1',
+        icon: 'file',
+        execute: (): void => {
+          // Mock execute
+        },
+      },
+      {
+        id: 'child-2',
+        label: 'Child 2',
+        icon: 'file',
+        execute: (): void => {
+          // Mock execute
+        },
+      },
+    ],
+  }
+
+  const mockNestedCommand: Command = {
+    id: 'parent',
+    label: 'Parent',
+    icon: 'folder',
+    children: [
+      {
+        id: 'child',
+        label: 'Child',
+        icon: 'folder',
+        children: [
+          {
+            id: 'grandchild',
+            label: 'Grandchild',
+            icon: 'file',
+            execute: (): void => {
+              // Mock execute
+            },
+          },
+        ],
+      },
+    ],
+  }
+
+  describe('buildTree', () => {
+    test('returns the same array (no-op)', () => {
+      const commands = [mockLeafCommand, mockNamespaceCommand]
+      const result = buildTree(commands)
+      expect(result).toBe(commands)
+      expect(result).toEqual(commands)
+    })
+  })
+
+  describe('mergeTrees', () => {
+    test('combines multiple command trees', () => {
+      const tree1 = [mockLeafCommand]
+      const tree2 = [mockNamespaceCommand]
+      const result = mergeTrees(tree1, tree2)
+
+      expect(result).toHaveLength(2)
+      expect(result).toContain(mockLeafCommand)
+      expect(result).toContain(mockNamespaceCommand)
+    })
+
+    test('handles empty trees', () => {
+      const result = mergeTrees([], [])
+      expect(result).toEqual([])
+    })
+
+    test('flattens multiple tree levels', () => {
+      const tree1 = [mockLeafCommand]
+      const tree2 = [mockNamespaceCommand]
+      const tree3 = [mockNestedCommand]
+      const result = mergeTrees(tree1, tree2, tree3)
+
+      expect(result).toHaveLength(3)
+    })
+  })
+
+  describe('traverseNamespace', () => {
+    test('returns children for namespace command', () => {
+      const result = traverseNamespace(mockNamespaceCommand)
+      expect(result).toEqual(mockNamespaceCommand.children)
+      expect(result).toHaveLength(2)
+    })
+
+    test('returns null for leaf command (no children)', () => {
+      const result = traverseNamespace(mockLeafCommand)
+      expect(result).toBeNull()
+    })
+
+    test('returns null for null command', () => {
+      const result = traverseNamespace(null)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('findCommandById', () => {
+    test('finds root-level command', () => {
+      const commands = [mockLeafCommand, mockNamespaceCommand]
+      const result = findCommandById(commands, 'test-leaf')
+
+      expect(result).toBe(mockLeafCommand)
+    })
+
+    test('finds nested command', () => {
+      const commands = [mockNamespaceCommand]
+      const result = findCommandById(commands, 'child-1')
+
+      expect(result).toEqual(mockNamespaceCommand.children![0])
+    })
+
+    test('finds deeply nested command', () => {
+      const commands = [mockNestedCommand]
+      const result = findCommandById(commands, 'grandchild')
+
+      expect(result?.id).toBe('grandchild')
+      expect(result?.label).toBe('Grandchild')
+    })
+
+    test('returns null for non-existent command', () => {
+      const commands = [mockLeafCommand]
+      const result = findCommandById(commands, 'non-existent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('findLeaf', () => {
+    test('returns leaf command if found', () => {
+      const commands = [mockLeafCommand, mockNamespaceCommand]
+      const result = findLeaf(commands, 'test-leaf')
+
+      expect(result).toBe(mockLeafCommand)
+    })
+
+    test('returns null for namespace command', () => {
+      const commands = [mockNamespaceCommand]
+      const result = findLeaf(commands, 'test-namespace')
+
+      expect(result).toBeNull()
+    })
+
+    test('finds leaf command nested in namespace', () => {
+      const commands = [mockNamespaceCommand]
+      const result = findLeaf(commands, 'child-1')
+
+      expect(result?.id).toBe('child-1')
+      expect(result?.execute).toBeDefined()
+    })
+
+    test('returns null for non-existent command', () => {
+      const commands = [mockLeafCommand]
+      const result = findLeaf(commands, 'non-existent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getAllLeaves', () => {
+    test('returns all leaf commands from flat tree', () => {
+      const commands = [mockLeafCommand, mockLeafCommand]
+      const result = getAllLeaves(commands)
+
+      expect(result).toHaveLength(2)
+    })
+
+    test('extracts leaves from namespace', () => {
+      const commands = [mockNamespaceCommand]
+      const result = getAllLeaves(commands)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('child-1')
+      expect(result[1].id).toBe('child-2')
+    })
+
+    test('extracts leaves from deeply nested structure', () => {
+      const commands = [mockNestedCommand]
+      const result = getAllLeaves(commands)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('grandchild')
+    })
+
+    test('returns empty array for namespace-only tree', () => {
+      const namespaceOnly: Command = {
+        id: 'namespace',
+        label: 'Namespace',
+        icon: 'folder',
+        children: [
+          {
+            id: 'child-namespace',
+            label: 'Child Namespace',
+            icon: 'folder',
+            children: [],
+          },
+        ],
+      }
+
+      const result = getAllLeaves([namespaceOnly])
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/src/features/command-palette/registry/commandTree.ts
+++ b/src/features/command-palette/registry/commandTree.ts
@@ -1,0 +1,90 @@
+import type { Command } from './types'
+
+/**
+ * Build a command tree from an array of commands.
+ * No-op for now, as commands are already in tree structure.
+ */
+export const buildTree = (commands: Command[]): Command[] => commands
+
+/**
+ * Merge multiple command trees into a single tree.
+ * Combines arrays of root-level commands from different features.
+ */
+export const mergeTrees = (...trees: Command[][]): Command[] => trees.flat()
+
+/**
+ * Traverse into a namespace (command with children) and return its children.
+ * Returns null if the command is a leaf (no children) or doesn't exist.
+ */
+export const traverseNamespace = (
+  command: Command | null
+): Command[] | null => {
+  if (!command?.children) {
+    return null
+  }
+
+  return command.children
+}
+
+/**
+ * Find a command by ID in a command tree.
+ * Searches recursively through the tree structure.
+ */
+export const findCommandById = (
+  commands: Command[],
+  id: string
+): Command | null => {
+  for (const command of commands) {
+    if (command.id === id) {
+      return command
+    }
+    if (command.children) {
+      const found = findCommandById(command.children, id)
+      if (found) {
+        return found
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Find a leaf command (command with execute handler) by ID.
+ * Returns null if the command is a namespace or doesn't exist.
+ */
+export const findLeaf = (commands: Command[], id: string): Command | null => {
+  const command = findCommandById(commands, id)
+  if (!command) {
+    return null
+  }
+  // A leaf command has an execute handler and no children
+  if (command.execute && !command.children) {
+    return command
+  }
+
+  return null
+}
+
+/**
+ * Get all leaf commands (executable commands) from a tree.
+ * Flattens the tree and filters for commands with execute handlers.
+ */
+export const getAllLeaves = (commands: Command[]): Command[] => {
+  const leaves: Command[] = []
+
+  const traverse = (cmds: Command[]): void => {
+    for (const cmd of cmds) {
+      if (cmd.execute && !cmd.children) {
+        leaves.push(cmd)
+      }
+      if (cmd.children) {
+        traverse(cmd.children)
+      }
+    }
+  }
+
+  traverse(commands)
+
+  return leaves
+}

--- a/src/features/command-palette/registry/fuzzyMatch.test.ts
+++ b/src/features/command-palette/registry/fuzzyMatch.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'vitest'
+import { fuzzyMatch } from './fuzzyMatch'
+
+describe('fuzzyMatch', () => {
+  test('returns 0 for empty query', () => {
+    expect(fuzzyMatch('', 'target')).toBe(0)
+    expect(fuzzyMatch('   ', 'target')).toBe(0)
+  })
+
+  test('returns high score for exact match', () => {
+    const score = fuzzyMatch('open', 'open')
+    expect(score).toBe(1000)
+  })
+
+  test('returns high score for prefix match', () => {
+    const prefixScore = fuzzyMatch('op', 'open')
+    const substringScore = fuzzyMatch('pe', 'open')
+
+    // Prefix match should score higher than substring match
+    expect(prefixScore).toBeGreaterThan(substringScore)
+    expect(prefixScore).toBeGreaterThan(500)
+  })
+
+  test('returns positive score for substring match', () => {
+    const score = fuzzyMatch('pen', 'open')
+    expect(score).toBeGreaterThan(0)
+    expect(score).toBeLessThan(500) // Less than prefix match
+  })
+
+  test('returns 0 for no match', () => {
+    const score = fuzzyMatch('xyz', 'open')
+    expect(score).toBe(0)
+  })
+
+  test('handles special characters correctly', () => {
+    const score = fuzzyMatch(':', ':open')
+    expect(score).toBeGreaterThan(0)
+  })
+
+  test('substring matches earlier in the string score higher', () => {
+    const earlyScore = fuzzyMatch('op', 'open')
+    const lateScore = fuzzyMatch('en', 'open')
+
+    expect(earlyScore).toBeGreaterThan(lateScore)
+  })
+
+  test('character-skip match returns positive score', () => {
+    // "op" should match "open" via character skip (o, p)
+    const score = fuzzyMatch('on', 'open')
+    expect(score).toBeGreaterThan(0)
+  })
+
+  test('consecutive character matches score higher', () => {
+    // "ope" has 3 consecutive matches
+    // "opn" has non-consecutive matches
+    const consecutiveScore = fuzzyMatch('ope', 'open')
+    const nonConsecutiveScore = fuzzyMatch('opn', 'open')
+
+    expect(consecutiveScore).toBeGreaterThan(nonConsecutiveScore)
+  })
+
+  test('score ordering: exact > prefix > substring > char-skip > no match', () => {
+    const exactScore = fuzzyMatch('open', 'open')
+    const prefixScore = fuzzyMatch('op', 'open')
+    const substringScore = fuzzyMatch('pen', 'open')
+    const charSkipScore = fuzzyMatch('on', 'open')
+    const noMatchScore = fuzzyMatch('xyz', 'open')
+
+    expect(exactScore).toBeGreaterThan(prefixScore)
+    expect(prefixScore).toBeGreaterThan(substringScore)
+    expect(substringScore).toBeGreaterThan(charSkipScore)
+    expect(charSkipScore).toBeGreaterThan(noMatchScore)
+    expect(noMatchScore).toBe(0)
+  })
+
+  test('case insensitive matching', () => {
+    const score1 = fuzzyMatch('OPEN', 'open')
+    const score2 = fuzzyMatch('Open', 'OPEN')
+    const score3 = fuzzyMatch('open', 'open')
+
+    expect(score1).toBe(score3)
+    expect(score2).toBe(score3)
+  })
+
+  test('handles whitespace in query', () => {
+    const score = fuzzyMatch('  open  ', 'open')
+    expect(score).toBe(1000) // Should match exactly after trim
+  })
+})

--- a/src/features/command-palette/registry/fuzzyMatch.ts
+++ b/src/features/command-palette/registry/fuzzyMatch.ts
@@ -1,0 +1,69 @@
+/**
+ * Fuzzy match scoring algorithm.
+ * Returns a score for how well a query matches a target string.
+ * Higher scores indicate better matches.
+ *
+ * Scoring strategy:
+ * - Exact match: 1000
+ * - Prefix match: 500 + (100 / query.length)
+ * - Substring match: 100 + position penalty
+ * - Character-skip match: 10 + consecutive char bonus
+ * - No match: 0
+ */
+export const fuzzyMatch = (query: string, target: string): number => {
+  if (!query || query.trim() === '') {
+    return 0
+  }
+
+  const normalizedQuery = query.toLowerCase().trim()
+  const normalizedTarget = target.toLowerCase()
+
+  // Exact match
+  if (normalizedQuery === normalizedTarget) {
+    return 1000
+  }
+
+  // Prefix match (highest weight)
+  if (normalizedTarget.startsWith(normalizedQuery)) {
+    return 500 + 100 / normalizedQuery.length
+  }
+
+  // Substring match
+  const substringIndex = normalizedTarget.indexOf(normalizedQuery)
+  if (substringIndex !== -1) {
+    // Earlier positions score higher
+    const positionPenalty = substringIndex * 2
+
+    return Math.max(100 - positionPenalty, 50)
+  }
+
+  // Character-skip match (e.g., "op" matches "open")
+  let queryIndex = 0
+  let consecutiveMatches = 0
+  let maxConsecutive = 0
+  let lastMatchIndex = -1
+
+  for (
+    let i = 0;
+    i < normalizedTarget.length && queryIndex < normalizedQuery.length;
+    i++
+  ) {
+    if (normalizedTarget[i] === normalizedQuery[queryIndex]) {
+      queryIndex++
+      if (lastMatchIndex === i - 1) {
+        consecutiveMatches++
+        maxConsecutive = Math.max(maxConsecutive, consecutiveMatches)
+      } else {
+        consecutiveMatches = 1
+      }
+      lastMatchIndex = i
+    }
+  }
+
+  // If all query characters were matched
+  if (queryIndex === normalizedQuery.length) {
+    return 10 + maxConsecutive * 5
+  }
+
+  return 0
+}

--- a/src/features/command-palette/registry/types.ts
+++ b/src/features/command-palette/registry/types.ts
@@ -1,0 +1,17 @@
+export interface Command {
+  id: string
+  label: string
+  description?: string
+  icon: string
+  children?: Command[]
+  execute?: (args: string) => void
+  match?: (query: string) => number
+}
+
+export interface CommandPaletteState {
+  isOpen: boolean
+  query: string
+  selectedIndex: number
+  currentNamespace: Command | null
+  filteredResults: Command[]
+}

--- a/src/features/command-palette/types/index.ts
+++ b/src/features/command-palette/types/index.ts
@@ -1,0 +1,1 @@
+export type { Command, CommandPaletteState } from '../registry/types'


### PR DESCRIPTION
## Summary

- Add a vim-style command palette triggered by `:` globally (suppressed when typing in inputs). Nested command tree with fuzzy search, keyboard navigation (arrows, Enter, Escape, Backspace), and spring-based animations via framer-motion.
- Implements a typed command registry where each feature exports its own command subtree (`:open`, `:set`, `:help`, `:new` — all stubbed). Fuzzy matching with prefix-weighted scoring.
- UI matches the design reference in `docs/design/command_palette/` — glassmorphism panel, staggered result animations, keyboard hint footer, and proper Enter badge with `keyboard_return` icon.

## New files

```
src/features/command-palette/
├── CommandPalette.tsx            # Root overlay (AnimatePresence, backdrop, panel)
├── components/                   # CommandInput, CommandResults, CommandResultItem, CommandFooter
├── hooks/useCommandPalette.ts    # Global `:` listener, open/close, keyboard nav
├── registry/                     # types.ts, commandTree.ts, fuzzyMatch.ts
├── data/defaultCommands.ts       # Stubbed command tree
└── types/index.ts
```

## Test plan

- [x] 435 tests pass (125 new for command palette)
- [x] Type check clean (`tsc -b`)
- [x] ESLint + Prettier pass via pre-commit hooks
- [x] Local Codex review — 1 finding (backdrop click) fixed
- [ ] Visual review: open palette with `:`, navigate with arrows, Enter to drill/execute, Escape to close, click backdrop to close
- [ ] Verify `:` is suppressed when chat input is focused