### PR TITLE
refactor: restructure harness skills into namespace with sub-skills

### DIFF
--- a/.claude/skills/harness/SKILL.md
+++ b/.claude/skills/harness/SKILL.md
@@ -1,109 +1,35 @@
 ---
 name: harness
-description: Launch the VIBM autonomous development harness — gathers requirements, brainstorms spec, generates app_spec.md, and starts the agent loop
+description: Autonomous development harness — build features (/harness:loop), run local Codex review (/harness:review), or fix cloud PR review findings (/harness:github-review)
 tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Agent
 ---
 
 # /harness — Autonomous Development Harness
 
-Launch the VIBM autonomous development harness. Gathers feature requirements, brainstorms the spec, generates `app_spec.md`, and starts the agent loop.
+The harness namespace provides three commands for the VIBM development cycle:
 
-## Step 1: Gather Requirements
+| Command | Purpose | When to Use |
+|---------|---------|-------------|
+| `/harness:loop` | Launch the autonomous coder agent loop | Building new features from a spec |
+| `/harness:review` | Run local Codex code review | Before creating a PR, quick feedback |
+| `/harness:github-review` | Fix cloud Codex PR review findings | After pushing / creating a PR |
 
-Use the `AskUserQuestion` tool to ask the user TWO questions:
+## Quick Reference
 
-**Question 1** — "What feature(s) do you want to build? Describe the functionality, screens, and user flows."
+- **Building a feature?** → `/harness:loop`
+- **Want a local review before PR?** → `/harness:review`
+- **PR has Codex review comments?** → `/harness:github-review`
 
-- Header: "Feature"
-- Options:
-  - "Full VIBM app" — Build the complete conversation manager (all screens, data model, IPC layer)
-  - "Specific feature" — Build one feature or module (user will describe in the text input)
-- multiSelect: false
+## Sub-Skill Files
 
-**Question 2** — "How many harness iterations should we run?"
+Each command's full instructions live in a dedicated file in this directory:
 
-- Header: "Iterations"
-- Options:
-  - "3 (quick test)" — Good for validating the harness works
-  - "10 (one session)" — Enough for scaffolding + a few features
-  - "Unlimited" — Run until all features are done or you stop it
-- multiSelect: false
+- `loop.md` — Gathers requirements, brainstorms spec, generates `app_spec.md`, launches the agent loop
+- `review.md` — Runs `npm run review` locally, parses findings, fixes issues
+- `github-review.md` — Fetches cloud Codex review from PR, fixes findings, pushes, polls for next review
 
-## Step 2: Brainstorm the Spec
+When the user invokes a sub-command (e.g., `/harness:loop`), read the corresponding file and follow its instructions.
 
-Invoke the `superpowers:brainstorming` skill using the Skill tool:
+## Worktree Requirement
 
-```
-skill: "superpowers:brainstorming"
-```
-
-When brainstorming, focus on producing a **product specification** for the harness, NOT an implementation plan. The brainstorming output should cover:
-
-- **Overview** — What the feature/app does in 2-3 sentences
-- **Tech Stack** — Tauri 2, React 19 + TypeScript, Rust, Vitest, Testing Library, ESLint, Prettier, CSpell, Storybook
-- **Core Features** — Bulleted list of every feature with brief description
-- **Data Model** — TypeScript interfaces and matching Rust structs for all entities
-- **IPC Commands** — List of `#[tauri::command]` handlers with argument/return types
-- **UI Screens** — Description of each screen/view and its components
-- **User Flows** — Step-by-step flows for key interactions
-
-**IMPORTANT:** After brainstorming, do NOT invoke `writing-plans`. Instead, proceed to Step 3.
-
-## Step 3: Generate app_spec.md
-
-Take the brainstormed spec and write it to `harness/prompts/app_spec.md` using the Write tool. The file should be a clean markdown document that the harness initializer agent can read to generate a `feature_list.json`.
-
-Structure the file as:
-
-```markdown
-# VIBM — App Specification
-
-## Overview
-
-[from brainstorming]
-
-## Tech Stack
-
-- Framework: Tauri 2
-- Frontend: React 19 + TypeScript (arrow-function components)
-- Backend: Rust (Tauri commands, managed state)
-- Testing: Vitest + Testing Library (frontend), cargo test (backend)
-- Linting: ESLint flat config, cargo clippy
-- Formatting: Prettier, cargo fmt
-
-## Core Features
-
-[from brainstorming — bulleted list]
-
-## Data Model
-
-[from brainstorming — TypeScript interfaces + Rust structs]
-
-## IPC Commands
-
-[from brainstorming — command table with args/returns]
-
-## UI Screens
-
-[from brainstorming — screen descriptions]
-
-## User Flows
-
-[from brainstorming — step-by-step flows]
-```
-
-## Step 4: Launch the Harness
-
-Run the harness using Bash:
-
-```bash
-cd harness && pip install -r requirements.txt 2>/dev/null && python autonomous_agent_demo.py --max-iterations <N>
-```
-
-Where `<N>` is the iteration count from Step 1. If "Unlimited", omit the `--max-iterations` flag entirely.
-
-**IMPORTANT:** This command will run for a long time. Use `run_in_background: true` on the Bash tool so the user isn't blocked. Tell the user the harness is running and they can check progress with:
-
-- `cat feature_list.json | grep '"passes": true' | wc -l` — count completed features
-- `cat claude-progress.txt` — read the latest progress notes
-- `git log --oneline -10` — see recent commits from the agent
+All harness commands that produce commits **must** run inside a git worktree, never on `main`. See `rules/common/worktrees.md` and `harness/CLAUDE.md` for details.

--- a/.claude/skills/harness/SKILL.md
+++ b/.claude/skills/harness/SKILL.md
@@ -8,11 +8,11 @@ tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Agent
 
 The harness namespace provides three commands for the VIBM development cycle:
 
-| Command | Purpose | When to Use |
-|---------|---------|-------------|
-| `/harness:loop` | Launch the autonomous coder agent loop | Building new features from a spec |
-| `/harness:review` | Run local Codex code review | Before creating a PR, quick feedback |
-| `/harness:github-review` | Fix cloud Codex PR review findings | After pushing / creating a PR |
+| Command                  | Purpose                                | When to Use                          |
+| ------------------------ | -------------------------------------- | ------------------------------------ |
+| `/harness:loop`          | Launch the autonomous coder agent loop | Building new features from a spec    |
+| `/harness:review`        | Run local Codex code review            | Before creating a PR, quick feedback |
+| `/harness:github-review` | Fix cloud Codex PR review findings     | After pushing / creating a PR        |
 
 ## Quick Reference
 

--- a/.claude/skills/harness/github-review.md
+++ b/.claude/skills/harness/github-review.md
@@ -29,6 +29,29 @@ REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 
 If no PR exists, tell the user and stop.
 
+## Step 1.5: Check CI Status
+
+Before looking at Codex review comments, check if the PR's CI checks are passing:
+
+```bash
+gh pr checks $PR_NUMBER
+```
+
+If any checks **other than Codex Code Review** are failing (e.g., Code Quality Check, Unit Tests):
+
+1. Read the failing check's log: `gh run view <run_id> --log-failed`
+2. Fix the issue (formatting, lint, type errors, test failures)
+3. Commit and push the fix
+4. Re-run this step until CI is green
+
+Common CI failures:
+
+- **Code Quality Check (Prettier)**: run `npx prettier --write <file>` on the flagged files
+- **Code Quality Check (ESLint)**: run `npm run lint:fix`
+- **Unit Tests**: run `npm run test` to reproduce, then fix
+
+Only proceed to Step 2 once all non-Codex checks are passing.
+
 ## Step 2: Fetch Latest Codex Review
 
 ```bash

--- a/.claude/skills/harness/github-review.md
+++ b/.claude/skills/harness/github-review.md
@@ -1,10 +1,10 @@
 ---
-name: review-fix
+name: harness:github-review
 description: Fetch Codex review findings from the current PR and fix them. Polls gh for the latest Codex comment, parses findings, fixes each issue, runs tests, commits, and pushes. Automatically loops — polls for the next review after each push.
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 
-# /review-fix — Fix Codex PR Review Findings (Self-Driving Loop)
+# /harness:github-review — Fix Codex PR Review Findings (Self-Driving Loop)
 
 Fetch the latest Codex code review from the current branch's PR, fix every finding, push, then poll for the next review and repeat — until the review comes back clean or the loop hits the max rounds limit.
 
@@ -113,7 +113,7 @@ gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
 ```
 
 - If a new comment appears (different ID): go back to **Step 3**
-- If no new comment after 10 minutes: tell the user the poll timed out, they can re-run `/review-fix` later
+- If no new comment after 10 minutes: tell the user the poll timed out, they can re-run `/harness:github-review` later
 - If max rounds (10) reached: tell the user the loop hit its cap
 
 ## Exit Conditions

--- a/.claude/skills/harness/loop.md
+++ b/.claude/skills/harness/loop.md
@@ -1,0 +1,109 @@
+---
+name: harness:loop
+description: Launch the VIBM autonomous development harness — gathers requirements, brainstorms spec, generates app_spec.md, and starts the agent loop
+tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Agent
+---
+
+# /harness:loop — Autonomous Development Harness
+
+Launch the VIBM autonomous development harness. Gathers feature requirements, brainstorms the spec, generates `app_spec.md`, and starts the agent loop.
+
+## Step 1: Gather Requirements
+
+Use the `AskUserQuestion` tool to ask the user TWO questions:
+
+**Question 1** — "What feature(s) do you want to build? Describe the functionality, screens, and user flows."
+
+- Header: "Feature"
+- Options:
+  - "Full VIBM app" — Build the complete conversation manager (all screens, data model, IPC layer)
+  - "Specific feature" — Build one feature or module (user will describe in the text input)
+- multiSelect: false
+
+**Question 2** — "How many harness iterations should we run?"
+
+- Header: "Iterations"
+- Options:
+  - "3 (quick test)" — Good for validating the harness works
+  - "10 (one session)" — Enough for scaffolding + a few features
+  - "Unlimited" — Run until all features are done or you stop it
+- multiSelect: false
+
+## Step 2: Brainstorm the Spec
+
+Invoke the `superpowers:brainstorming` skill using the Skill tool:
+
+```
+skill: "superpowers:brainstorming"
+```
+
+When brainstorming, focus on producing a **product specification** for the harness, NOT an implementation plan. The brainstorming output should cover:
+
+- **Overview** — What the feature/app does in 2-3 sentences
+- **Tech Stack** — Tauri 2, React 19 + TypeScript, Rust, Vitest, Testing Library, ESLint, Prettier, CSpell, Storybook
+- **Core Features** — Bulleted list of every feature with brief description
+- **Data Model** — TypeScript interfaces and matching Rust structs for all entities
+- **IPC Commands** — List of `#[tauri::command]` handlers with argument/return types
+- **UI Screens** — Description of each screen/view and its components
+- **User Flows** — Step-by-step flows for key interactions
+
+**IMPORTANT:** After brainstorming, do NOT invoke `writing-plans`. Instead, proceed to Step 3.
+
+## Step 3: Generate app_spec.md
+
+Take the brainstormed spec and write it to `harness/prompts/app_spec.md` using the Write tool. The file should be a clean markdown document that the harness initializer agent can read to generate a `feature_list.json`.
+
+Structure the file as:
+
+```markdown
+# VIBM — App Specification
+
+## Overview
+
+[from brainstorming]
+
+## Tech Stack
+
+- Framework: Tauri 2
+- Frontend: React 19 + TypeScript (arrow-function components)
+- Backend: Rust (Tauri commands, managed state)
+- Testing: Vitest + Testing Library (frontend), cargo test (backend)
+- Linting: ESLint flat config, cargo clippy
+- Formatting: Prettier, cargo fmt
+
+## Core Features
+
+[from brainstorming — bulleted list]
+
+## Data Model
+
+[from brainstorming — TypeScript interfaces + Rust structs]
+
+## IPC Commands
+
+[from brainstorming — command table with args/returns]
+
+## UI Screens
+
+[from brainstorming — screen descriptions]
+
+## User Flows
+
+[from brainstorming — step-by-step flows]
+```
+
+## Step 4: Launch the Harness
+
+Run the harness using Bash:
+
+```bash
+cd harness && pip install -r requirements.txt 2>/dev/null && python autonomous_agent_demo.py --max-iterations <N>
+```
+
+Where `<N>` is the iteration count from Step 1. If "Unlimited", omit the `--max-iterations` flag entirely.
+
+**IMPORTANT:** This command will run for a long time. Use `run_in_background: true` on the Bash tool so the user isn't blocked. Tell the user the harness is running and they can check progress with:
+
+- `cat feature_list.json | grep '"passes": true' | wc -l` — count completed features
+- `cat claude-progress.txt` — read the latest progress notes
+- `git log --oneline -10` — see recent commits from the agent

--- a/.claude/skills/harness/review.md
+++ b/.claude/skills/harness/review.md
@@ -1,0 +1,85 @@
+---
+name: harness:review
+description: Run local Codex code review via npm run review, parse findings from .codex-reviews/latest.md, and fix issues. Single pass — no polling loop.
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# /harness:review — Local Codex Code Review
+
+Run a local Codex code review against the current branch's diff from `main`, parse the findings, and fix each issue. This is a single-pass review — no PR required, no polling loop.
+
+## When to Use
+
+- Before creating a PR — get quick feedback locally
+- After writing code — catch issues before pushing
+- As a lighter alternative to `/harness:github-review` when you don't need cloud review
+
+## Step 1: Run the Review
+
+```bash
+npm run review
+```
+
+This runs `codex exec review --base main` via `scripts/review.sh`. It saves the review output to `.codex-reviews/latest.md`.
+
+Wait for the command to complete (may take 1-3 minutes).
+
+## Step 2: Read the Review Output
+
+```bash
+cat .codex-reviews/latest.md
+```
+
+The review output follows this format:
+
+```
+Review comment:
+
+- [SEVERITY] Description — file_path:line_range
+  Explanation of the issue and how to fix it.
+```
+
+If the review says "No issues found" or the patch is correct — tell the user **the review is clean** and stop.
+
+## Step 3: Parse and Fix Findings
+
+For each finding:
+
+1. **Read the file** at the specified path and line range
+2. **Understand the issue** in context
+3. **Decide**:
+   - **FIX** — make the minimal change to resolve the issue
+   - **SKIP** — explain why (false positive, intentional pattern, out of scope)
+4. If fixing: make the change
+
+Rules:
+
+- Fix ONLY what the review identified — no drive-by refactoring
+- Never introduce new issues while fixing existing ones
+
+## Step 4: Verify
+
+After all fixes:
+
+```bash
+npm run lint
+npm run test
+```
+
+Both must pass before reporting results.
+
+## Step 5: Report Results
+
+Tell the user:
+
+- Which findings were fixed
+- Which were skipped (with reasons)
+- Whether lint and tests pass
+
+Do NOT commit or push — leave that to the user or to the next step in their workflow.
+
+## Exit Conditions
+
+1. **Clean review** — no issues found
+2. **All findings processed** — each one fixed or skipped with explanation
+3. **Review command failed** — tell the user and stop (likely missing `OPENAI_API_KEY` or `codex` CLI)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ npm run format          # Prettier write
 npm run type-check      # tsc -b
 npm run review          # Local Codex code review (saves to .codex-reviews/)
 npm run review:fix      # Interactive review-fix loop (fetch → fix → push → poll)
+# Skills: /harness:review (local), /harness:github-review (cloud PR), /harness:loop (agent loop)
 ```
 
 Node >= 24 (see `.nvmrc`). ESM-only (`"type": "module"`).

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -28,6 +28,58 @@ set -a && source .env && set +a
 
 **Additional requirement:** `gh` CLI must be authenticated (`gh auth login`) for Phase 3 cloud operations.
 
+## Worktree Requirement (MANDATORY)
+
+**The harness MUST run inside a git worktree, never on `main`.** This is enforced by [rules/common/worktrees.md](../rules/common/worktrees.md):
+
+> _"Main worktree is sacred — it stays on `main`, always clean, never committed to directly."_
+> _"Harness always uses a worktree — autonomous loops must be fully isolated."_
+
+### Before Launching the Harness
+
+Create a worktree and switch into it **before** running any harness command:
+
+```bash
+# From the main worktree (project root)
+git worktree add .claude/worktrees/feat-<feature-name> -b feat/<feature-name>
+cd .claude/worktrees/feat-<feature-name>
+npm install
+
+# Source env vars
+set -a && source /path/to/project/.env && set +a
+
+# Now launch the harness (--project-dir points to the worktree, which is cwd)
+cd harness && python3 autonomous_agent_demo.py --clean --max-iterations 10
+```
+
+Or use Claude Code's built-in `EnterWorktree` tool, which creates the worktree under `.claude/worktrees/` automatically.
+
+### Why This Matters
+
+- The harness creates commits during Phase 2 (feature loop) and pushes in Phase 3 (cloud review)
+- Running on `main` would commit directly to the main branch, violating the project's branch protection policy
+- A worktree isolates all harness work on a feature branch, ready for PR and squash-merge
+- The `block-main-commit.sh` PreToolUse hook will reject commits on `main` if configured
+
+### After the Harness Completes
+
+From the worktree, create a PR and stay on the branch for review-fix cycles:
+
+```bash
+gh pr create --title "feat: <description>" --body "..." --squash
+# Stay here — run /harness:github-review for code review cycles
+# Only the user merges the PR
+```
+
+Cleanup (after PR is merged, from the main worktree):
+
+```bash
+cd /path/to/project  # back to main worktree
+git worktree remove .claude/worktrees/feat-<feature-name>
+git branch -d feat/<feature-name>
+git worktree prune
+```
+
 ## Running
 
 ```bash
@@ -130,7 +182,7 @@ The Codex GitHub Action (`.github/workflows/codex-review.yml`) runs `openai/code
 
 ### Interactive Fix Loop
 
-`npm run review:fix` or the `/review-fix` skill in Claude Code provides a self-driving fix loop: fetch Codex review → fix findings → push → poll for next review → repeat until clean (max 10 rounds).
+`npm run review:fix` or the `/harness:github-review` skill in Claude Code provides a self-driving fix loop: fetch Codex review → fix findings → push → poll for next review → repeat until clean (max 10 rounds).
 
 ### Project Context
 

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -15,8 +15,9 @@
 
 set -euo pipefail
 
-# Extract the bash command from the tool input (portable — no GNU grep -P)
-command=$(jq -r '.command // empty' 2>/dev/null || echo "")
+# Extract the bash command from the tool input.
+# Claude Code passes the full hook context with tool params nested under tool_input.
+command=$(jq -r '.tool_input.command // .command // empty' 2>/dev/null || echo "")
 if [ -z "$command" ]; then
   exit 0
 fi

--- a/scripts/hooks/post-push-review.sh
+++ b/scripts/hooks/post-push-review.sh
@@ -9,8 +9,9 @@
 
 set -euo pipefail
 
-# Extract the bash command from the tool input (portable — no GNU grep -P)
-command=$(jq -r '.command // empty' 2>/dev/null || echo "")
+# Extract the bash command from the tool input.
+# Claude Code passes the full hook context with tool params nested under tool_input.
+command=$(jq -r '.tool_input.command // .command // empty' 2>/dev/null || echo "")
 if [ -z "$command" ]; then
   exit 0
 fi

--- a/scripts/hooks/post-push-review.sh
+++ b/scripts/hooks/post-push-review.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# PostToolUse hook: after git push, remind the agent to run /review-fix.
+# PostToolUse hook: after git push or gh pr create, trigger /harness:github-review.
 #
-# Detects git push commands and outputs a directive that the agent
-# sees in its context, prompting it to wait and then run /review-fix.
+# Detects git push and gh pr create commands and outputs a directive
+# that the agent sees in its context, prompting it to invoke the
+# /harness:github-review skill automatically.
 #
 # Exit 0 always — PostToolUse hooks should never block.
 
@@ -14,6 +15,13 @@ if [ -z "$command" ]; then
   exit 0
 fi
 
+# Check for gh pr create
+if echo "$command" | grep -qE '^\s*gh\s+pr\s+create'; then
+  echo "ACTION REQUIRED: A pull request was just created. Wait ~90 seconds for the Codex GitHub Action to post its review, then invoke /harness:github-review to fetch and address any code review findings."
+  exit 0
+fi
+
+# Check for git push
 # Extract the git subcommand, skipping flags and their values.
 # Handles: git -C /path push, git -c key=val push, git --git-dir=/x push, etc.
 subcmd=""
@@ -45,6 +53,6 @@ if [ "$subcmd" != "push" ]; then
   exit 0
 fi
 
-echo "ACTION REQUIRED: Code was just pushed. Wait ~90 seconds for Codex review to post findings, then run /review-fix to fetch and address any code review comments."
+echo "ACTION REQUIRED: Code was just pushed. Wait ~90 seconds for the Codex GitHub Action to post its review, then invoke /harness:github-review to fetch and address any code review findings."
 
 exit 0


### PR DESCRIPTION
## Summary

- Restructure `/harness` and `/review-fix` skills into a `harness:*` namespace with progressive disclosure: `SKILL.md` is the index, sub-skills live in dedicated files
- `/harness:loop` — autonomous agent loop (was `/harness`)
- `/harness:github-review` — cloud Codex PR review fix loop (was `/review-fix`)
- `/harness:review` — new local Codex review via `npm run review`
- Post-push hook now triggers on both `git push` AND `gh pr create`, referencing `/harness:github-review` for automatic invocation

## Test plan

- [x] `echo '{"command":"git push origin main"}' | bash scripts/hooks/post-push-review.sh` — outputs `/harness:github-review` directive
- [x] `echo '{"command":"gh pr create --title test"}' | bash scripts/hooks/post-push-review.sh` — outputs `/harness:github-review` directive
- [x] `echo '{"command":"git commit -m test"}' | bash scripts/hooks/post-push-review.sh` — no output (correct)
- [x] Verify `ls .claude/skills/harness/` shows `SKILL.md`, `loop.md`, `github-review.md`, `review.md`
- [x] Verify `.claude/skills/review-fix/` no longer exists