### PR TITLE
docs: update /review-fix references to /harness:github-review

### DIFF
--- a/rules/common/git-workflow.md
+++ b/rules/common/git-workflow.md
@@ -41,7 +41,7 @@ When creating PRs:
 After creating a PR, the agent remains on the feature branch/worktree until the PR is resolved:
 
 1. **Stay**: remain in the worktree/branch — do not return to `main`
-2. **Review-fix loop**: run `/review-fix` to fetch and address code review findings
+2. **Review-fix loop**: run `/harness:github-review` to fetch and address code review findings
 3. **Push fixes**: commit and push from the same branch
 4. **Repeat**: wait for next review cycle, fix, push
 5. **Done**: only the user merges or closes the PR

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -145,9 +145,9 @@ git branch --merged main | grep -v '^\*\|main' | xargs -r git branch -d
 
 Two hooks support the worktree workflow:
 
-| Hook               | Type        | Script                               | Purpose                                                             |
-| ------------------ | ----------- | ------------------------------------ | ------------------------------------------------------------------- |
-| Block main commits | PreToolUse  | `scripts/hooks/block-main-commit.sh` | Prevents `git commit`/`git push` on the main worktree               |
+| Hook               | Type        | Script                               | Purpose                                                               |
+| ------------------ | ----------- | ------------------------------------ | --------------------------------------------------------------------- |
+| Block main commits | PreToolUse  | `scripts/hooks/block-main-commit.sh` | Prevents `git commit`/`git push` on the main worktree                 |
 | Post-push review   | PostToolUse | `scripts/hooks/post-push-review.sh`  | After `git push` or `gh pr create`, triggers `/harness:github-review` |
 
 To register both hooks, add to `.claude/settings.local.json`:

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -42,7 +42,7 @@ Or use Claude Code's built-in: `EnterWorktree` (creates under `.claude/worktrees
 
 Agent works normally — edit, commit, push, create PR. The worktree is a fully independent working directory.
 
-**Once a PR is created, the agent stays in the worktree/branch until the PR is resolved.** Do not switch back to `main` between creating the PR and the PR being merged or closed. This ensures review-fix cycles (`/review-fix`) happen in the correct working directory without branch switching.
+**Once a PR is created, the agent stays in the worktree/branch until the PR is resolved.** Do not switch back to `main` between creating the PR and the PR being merged or closed. This ensures review-fix cycles (`/harness:github-review`) happen in the correct working directory without branch switching.
 
 The PR lifecycle within a worktree:
 
@@ -148,7 +148,7 @@ Two hooks support the worktree workflow:
 | Hook               | Type        | Script                               | Purpose                                                             |
 | ------------------ | ----------- | ------------------------------------ | ------------------------------------------------------------------- |
 | Block main commits | PreToolUse  | `scripts/hooks/block-main-commit.sh` | Prevents `git commit`/`git push` on the main worktree               |
-| Post-push review   | PostToolUse | `scripts/hooks/post-push-review.sh`  | After `git push`, reminds agent to wait ~90s then run `/review-fix` |
+| Post-push review   | PostToolUse | `scripts/hooks/post-push-review.sh`  | After `git push` or `gh pr create`, triggers `/harness:github-review` |
 
 To register both hooks, add to `.claude/settings.local.json`:
 


### PR DESCRIPTION
## Summary

- Update 3 stale `/review-fix` references in rules docs to `/harness:github-review`
- Update post-push hook description to reflect it now triggers on both `git push` and `gh pr create`

## Test plan

- [x] `grep -r '/review-fix' rules/` returns no matches