### PR TITLE
feat: add hookify pre-launch safety rules for harness

### DIFF
--- a/.claude/hookify.block-harness-no-api-key.local.md
+++ b/.claude/hookify.block-harness-no-api-key.local.md
@@ -1,0 +1,27 @@
+---
+name: block-harness-no-api-key
+enabled: true
+event: bash
+pattern: python3?\s+.*autonomous_agent_demo\.py
+action: block
+---
+
+**BLOCKED: `ANTHROPIC_API_KEY` must be set before launching the harness.**
+
+Git worktrees do NOT include untracked files like `.env`. The API keys live in the **original project root**, not in the worktree.
+
+**Source the env file from the source repo:**
+
+```bash
+set -a && source /home/claw/projects/Vimeflow/.env && set +a
+```
+
+**Verify it's set:**
+
+```bash
+echo "ANTHROPIC_API_KEY is ${ANTHROPIC_API_KEY:+set}"
+```
+
+Only proceed if it prints "set".
+
+**Why:** Without API keys, the harness dry-run hangs, the pre-bash hook blocks on missing `ANTHROPIC_API_KEY`, and agents waste iterations regenerating `app_spec.md` from scratch. This is especially common in worktrees because `.env` is gitignored and never copied.

--- a/.claude/hookify.block-harness-no-api-key.local.md
+++ b/.claude/hookify.block-harness-no-api-key.local.md
@@ -3,17 +3,18 @@ name: block-harness-no-api-key
 enabled: true
 event: bash
 pattern: python3?\s+.*autonomous_agent_demo\.py
-action: block
+action: warn
 ---
 
-**BLOCKED: `ANTHROPIC_API_KEY` must be set before launching the harness.**
+**WARNING: Verify `ANTHROPIC_API_KEY` is set before launching the harness.**
 
 Git worktrees do NOT include untracked files like `.env`. The API keys live in the **original project root**, not in the worktree.
 
-**Source the env file from the source repo:**
+**Source the env file from the source repo root:**
 
 ```bash
-set -a && source /home/claw/projects/Vimeflow/.env && set +a
+SOURCE_ROOT=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+set -a && source "$SOURCE_ROOT/.env" && set +a
 ```
 
 **Verify it's set:**

--- a/.claude/hookify.block-harness-on-main.local.md
+++ b/.claude/hookify.block-harness-on-main.local.md
@@ -3,10 +3,12 @@ name: block-harness-on-main
 enabled: true
 event: bash
 pattern: python3?\s+.*autonomous_agent_demo\.py
-action: block
+action: warn
 ---
 
-**BLOCKED: Harness must run in a git worktree, not on `main`.**
+**WARNING: Harness must run in a git worktree, not on `main`.**
+
+Before proceeding, check your branch:
 
 Before launching the harness, you MUST be on a feature branch inside a git worktree.
 

--- a/.claude/hookify.block-harness-on-main.local.md
+++ b/.claude/hookify.block-harness-on-main.local.md
@@ -1,0 +1,33 @@
+---
+name: block-harness-on-main
+enabled: true
+event: bash
+pattern: python3?\s+.*autonomous_agent_demo\.py
+action: block
+---
+
+**BLOCKED: Harness must run in a git worktree, not on `main`.**
+
+Before launching the harness, you MUST be on a feature branch inside a git worktree.
+
+**Check your branch:**
+
+```bash
+git branch --show-current
+```
+
+If it says `main`, STOP and create a worktree first:
+
+```
+EnterWorktree(name="harness-<feature-name>")
+```
+
+Or manually:
+
+```bash
+git worktree add .claude/worktrees/harness-<feature-name> -b feat/<feature-name>
+cd .claude/worktrees/harness-<feature-name>
+npm install
+```
+
+**Why:** The harness creates commits and pushes code. Running on `main` would commit directly to the main branch, violating the project's branch protection policy. Worktree isolation keeps all harness work on a feature branch, ready for PR and squash-merge.

--- a/.claude/hookify.warn-harness-dry-run.local.md
+++ b/.claude/hookify.warn-harness-dry-run.local.md
@@ -1,0 +1,25 @@
+---
+name: warn-harness-dry-run
+enabled: true
+event: bash
+conditions:
+  - field: command
+    operator: regex_match
+    pattern: python3?\s+.*autonomous_agent_demo\.py
+  - field: command
+    operator: regex_match
+    pattern: ^(?!.*--max-iterations\s+1(\s|$))
+action: warn
+---
+
+**Warning: Consider a dry-run first.**
+
+If this is the first harness run in this worktree, do a single-iteration dry-run to verify the environment before scaling up:
+
+```bash
+python autonomous_agent_demo.py --no-sandbox --max-iterations 1
+```
+
+This catches issues with missing API keys, broken hooks, or permission problems before they waste 10+ iterations.
+
+After a successful dry-run, proceed with the full run. If you've already verified the environment, you can safely ignore this warning.

--- a/.claude/hookify.warn-worktree-npm-install.local.md
+++ b/.claude/hookify.warn-worktree-npm-install.local.md
@@ -16,8 +16,9 @@ npm install
 
 Without this, any `npm run` commands, test runs, or build steps will fail with missing dependencies.
 
-Also remember to source `.env` from the source repo:
+Also remember to source `.env` from the source repo root:
 
 ```bash
-set -a && source /home/claw/projects/Vimeflow/.env && set +a
+SOURCE_ROOT=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+set -a && source "$SOURCE_ROOT/.env" && set +a
 ```

--- a/.claude/hookify.warn-worktree-npm-install.local.md
+++ b/.claude/hookify.warn-worktree-npm-install.local.md
@@ -1,0 +1,23 @@
+---
+name: warn-worktree-npm-install
+enabled: true
+event: bash
+pattern: git\s+worktree\s+add
+action: warn
+---
+
+**Reminder: Run `npm install` in the new worktree.**
+
+Git worktrees do NOT include `node_modules/` (it's gitignored). After entering the worktree, run:
+
+```bash
+npm install
+```
+
+Without this, any `npm run` commands, test runs, or build steps will fail with missing dependencies.
+
+Also remember to source `.env` from the source repo:
+
+```bash
+set -a && source /home/claw/projects/Vimeflow/.env && set +a
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ This file covers what you need to start working. For deeper topics, read the lin
 | AI agent specs (planner, tdd-guide, code-reviewer, etc.) | `agents/CLAUDE.md`                                                |
 | Development standards (coding style, testing, security)  | `rules/CLAUDE.md`                                                 |
 | Autonomous development loop (harness + Codex review)     | `harness/CLAUDE.md`                                               |
+| Harness pre-launch safety hooks (hookify rules)          | `harness/CLAUDE.md` → "Hookify Pre-Launch Rules"                  |
 | Harness plugin (skills for agent loop, review, PR fix)   | `plugins/harness/` — see [Plugin Setup](#harness-plugin-setup)    |
 | Architecture specs, exploration notes                    | `docs/CLAUDE.md`                                                  |
 | Codex code review (project context for Codex)            | `AGENTS.md`                                                       |

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -142,6 +142,30 @@ Python hooks (`security.py`, `hooks.py`) fire regardless of sandbox or permissio
 
 **WSL2 users:** The sandbox may be unreliable or a no-op on WSL2. If you encounter Bash commands being blocked unexpectedly, re-run with `--no-sandbox`. You accept the risk of running without OS-level isolation — Python hooks still validate every command.
 
+### Hookify Pre-Launch Rules
+
+In addition to the runtime safety layers above, the project uses [hookify](https://github.com/anthropics/claude-code/tree/main/plugins/hookify) rules to catch common mistakes **before** the harness is launched. These rules live in `.claude/hookify.*.local.md` and are evaluated automatically by the hookify plugin on every tool call.
+
+| Rule                        | Event | Action    | What it catches                                                                                                                                      |
+| --------------------------- | ----- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `block-harness-on-main`     | bash  | **block** | Running `autonomous_agent_demo.py` while on the `main` branch. The harness creates commits — it must run in a git worktree.                          |
+| `block-harness-no-api-key`  | bash  | **block** | Running the harness without `ANTHROPIC_API_KEY` set. In worktrees, `.env` is absent (gitignored) and must be sourced from the original project root. |
+| `warn-worktree-npm-install` | bash  | warn      | Running `git worktree add` without a reminder to `npm install` afterward. `node_modules/` is gitignored and missing in fresh worktrees.              |
+| `warn-harness-dry-run`      | bash  | warn      | Running the harness with `--max-iterations` > 1 without having done a single-iteration dry-run first. Catches env/hook/permission issues early.      |
+
+**How they work:** Hookify rules are markdown files with YAML frontmatter that define a regex pattern, an event type (bash/file/stop), and an action (block/warn). The hookify plugin evaluates all enabled rules on every matching hook event. Block rules prevent the operation; warn rules show a message but allow it to proceed.
+
+**Why two block rules share a pattern:** Both `block-harness-on-main` and `block-harness-no-api-key` trigger on the same command (`python3? ... autonomous_agent_demo.py`). When both fire, the hookify engine concatenates their messages — the agent sees both the worktree and API key requirements in a single response.
+
+**Pre-launch checklist (enforced by these rules):**
+
+1. **Worktree** — `git branch --show-current` must NOT return `main`. Use `EnterWorktree` or `git worktree add`.
+2. **Environment** — `set -a && source /home/claw/projects/Vimeflow/.env && set +a` to load API keys from the source repo.
+3. **Dependencies** — `npm install` in the worktree (node_modules is gitignored).
+4. **Dry-run** — `python autonomous_agent_demo.py --no-sandbox --max-iterations 1` to verify the environment before scaling up.
+
+**Editing rules:** Rules take effect immediately on the next tool call — no restart needed. To disable a rule, set `enabled: false` in its frontmatter. To inspect all active rules at runtime, use the `/hookify:list` skill.
+
 ## File Roles
 
 | File                            | Role                                                                                |

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -146,23 +146,23 @@ Python hooks (`security.py`, `hooks.py`) fire regardless of sandbox or permissio
 
 In addition to the runtime safety layers above, the project uses [hookify](https://github.com/anthropics/claude-code/tree/main/plugins/hookify) rules to catch common mistakes **before** the harness is launched. These rules live in `.claude/hookify.*.local.md` and are evaluated automatically by the hookify plugin on every tool call.
 
-| Rule                        | Event | Action    | What it catches                                                                                                                                      |
-| --------------------------- | ----- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `block-harness-on-main`     | bash  | **block** | Running `autonomous_agent_demo.py` while on the `main` branch. The harness creates commits — it must run in a git worktree.                          |
-| `block-harness-no-api-key`  | bash  | **block** | Running the harness without `ANTHROPIC_API_KEY` set. In worktrees, `.env` is absent (gitignored) and must be sourced from the original project root. |
-| `warn-worktree-npm-install` | bash  | warn      | Running `git worktree add` without a reminder to `npm install` afterward. `node_modules/` is gitignored and missing in fresh worktrees.              |
-| `warn-harness-dry-run`      | bash  | warn      | Running the harness with `--max-iterations` > 1 without having done a single-iteration dry-run first. Catches env/hook/permission issues early.      |
+| Rule                        | Event | Action | What it catches                                                                                                                                           |
+| --------------------------- | ----- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `block-harness-on-main`     | bash  | warn   | Running `autonomous_agent_demo.py` — reminds to check branch and use a worktree. The harness creates commits and must not run on `main`.                  |
+| `block-harness-no-api-key`  | bash  | warn   | Running the harness — reminds to verify `ANTHROPIC_API_KEY` is set. In worktrees, `.env` is absent (gitignored) and must be sourced from the source repo. |
+| `warn-worktree-npm-install` | bash  | warn   | Running `git worktree add` without a reminder to `npm install` afterward. `node_modules/` is gitignored and missing in fresh worktrees.                   |
+| `warn-harness-dry-run`      | bash  | warn   | Running the harness with `--max-iterations` > 1 without having done a single-iteration dry-run first. Catches env/hook/permission issues early.           |
 
-**How they work:** Hookify rules are markdown files with YAML frontmatter that define a regex pattern, an event type (bash/file/stop), and an action (block/warn). The hookify plugin evaluates all enabled rules on every matching hook event. Block rules prevent the operation; warn rules show a message but allow it to proceed.
+**How they work:** Hookify rules are markdown files with YAML frontmatter that define a regex pattern, an event type (bash/file/stop), and an action (block/warn). The hookify plugin evaluates all enabled rules on every matching hook event. All four rules use `warn` — they show guidance but don't hard-block, since hookify pattern matching alone cannot inspect git state or environment variables at runtime.
 
-**Why two block rules share a pattern:** Both `block-harness-on-main` and `block-harness-no-api-key` trigger on the same command (`python3? ... autonomous_agent_demo.py`). When both fire, the hookify engine concatenates their messages — the agent sees both the worktree and API key requirements in a single response.
+**Why two rules share a pattern:** Both `block-harness-on-main` and `block-harness-no-api-key` trigger on the same command (`python3? ... autonomous_agent_demo.py`). When both fire, the hookify engine concatenates their messages — the agent sees both the worktree and API key reminders in a single response.
 
 **Pre-launch checklist (enforced by these rules):**
 
 1. **Worktree** — `git branch --show-current` must NOT return `main`. Use `EnterWorktree` or `git worktree add`.
-2. **Environment** — `set -a && source /home/claw/projects/Vimeflow/.env && set +a` to load API keys from the source repo.
+2. **Environment** — find the source repo root with `SOURCE_ROOT=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')`, then `set -a && source "$SOURCE_ROOT/.env" && set +a`.
 3. **Dependencies** — `npm install` in the worktree (node_modules is gitignored).
-4. **Dry-run** — `python autonomous_agent_demo.py --no-sandbox --max-iterations 1` to verify the environment before scaling up.
+4. **Dry-run** — `python autonomous_agent_demo.py --max-iterations 1` to verify the environment before scaling up. Add `--no-sandbox` only on WSL2.
 
 **Editing rules:** Rules take effect immediately on the next tool call — no restart needed. To disable a rule, set `enabled: false` in its frontmatter. To inspect all active rules at runtime, use the `/hookify:list` skill.
 

--- a/plugins/harness/skills/loop/SKILL.md
+++ b/plugins/harness/skills/loop/SKILL.md
@@ -38,10 +38,11 @@ npm install
 
 ### 0b. Source `.env` from the source repo
 
-Git worktrees do NOT include untracked files like `.env`. The API keys live in the **original project root**, not in the worktree. Source them explicitly using the absolute path:
+Git worktrees do NOT include untracked files like `.env`. The API keys live in the **original project root**, not in the worktree. Find the source repo root and source from there:
 
 ```bash
-set -a && source /home/claw/projects/Vimeflow/.env && set +a
+SOURCE_ROOT=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+set -a && source "$SOURCE_ROOT/.env" && set +a
 ```
 
 Verify the key is set:
@@ -145,14 +146,14 @@ Structure the file as:
 Run the harness using Bash:
 
 ```bash
-cd harness && pip install -r requirements.txt 2>/dev/null && python autonomous_agent_demo.py --no-sandbox --max-iterations <N>
+cd harness && pip install -r requirements.txt 2>/dev/null && python autonomous_agent_demo.py --max-iterations <N>
 ```
 
 Where `<N>` is the iteration count from Step 1. If "Unlimited", omit the `--max-iterations` flag entirely.
 
 Notes:
 
-- `--no-sandbox` is required on WSL2 (the sandbox is unreliable there)
+- On **WSL2 only**, add `--no-sandbox` (the OS-level sandbox is unreliable on WSL2). On macOS/Linux, omit it to keep sandbox isolation enabled.
 - The env vars from Step 0b are inherited by the subprocess automatically
 
 **IMPORTANT:** This command will run for a long time. Use `run_in_background: true` on the Bash tool so the user isn't blocked. Tell the user the harness is running and they can check progress with:

--- a/plugins/harness/skills/loop/SKILL.md
+++ b/plugins/harness/skills/loop/SKILL.md
@@ -8,6 +8,52 @@ tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Agent
 
 Launch the VIBM autonomous development harness. Gathers feature requirements, brainstorms the spec, generates `app_spec.md`, and starts the agent loop.
 
+## Step 0: Worktree & Environment (MANDATORY — do this FIRST)
+
+The harness creates commits and pushes code. It **MUST** run inside a git worktree, never on `main`.
+
+### 0a. Create or enter a worktree
+
+Check the current branch:
+
+```bash
+git branch --show-current
+```
+
+If it says `main`, you MUST create a worktree before proceeding. Use the `EnterWorktree` tool:
+
+```
+EnterWorktree(name="harness-<feature-name>")
+```
+
+Or create one manually:
+
+```bash
+git worktree add .claude/worktrees/harness-<feature-name> -b feat/<feature-name>
+cd .claude/worktrees/harness-<feature-name>
+npm install
+```
+
+**DO NOT skip this step.** If you are already in a non-main branch/worktree, you may proceed.
+
+### 0b. Source `.env` from the source repo
+
+Git worktrees do NOT include untracked files like `.env`. The API keys live in the **original project root**, not in the worktree. Source them explicitly using the absolute path:
+
+```bash
+set -a && source /home/claw/projects/Vimeflow/.env && set +a
+```
+
+Verify the key is set:
+
+```bash
+echo "ANTHROPIC_API_KEY is ${ANTHROPIC_API_KEY:+set}"
+```
+
+If it prints "set", proceed. If not, STOP — the harness will fail without API keys.
+
+**Why this matters:** Without this step, the harness dry-run hangs, the pre-bash hook blocks on missing `ANTHROPIC_API_KEY`, and agents waste iterations regenerating `app_spec.md` from scratch.
+
 ## Step 1: Gather Requirements
 
 Use the `AskUserQuestion` tool to ask the user TWO questions:
@@ -94,13 +140,20 @@ Structure the file as:
 
 ## Step 4: Launch the Harness
 
+**Pre-flight check:** Confirm you are NOT on `main` and that `ANTHROPIC_API_KEY` is set (both from Step 0). If either is missing, go back to Step 0.
+
 Run the harness using Bash:
 
 ```bash
-cd harness && pip install -r requirements.txt 2>/dev/null && python autonomous_agent_demo.py --max-iterations <N>
+cd harness && pip install -r requirements.txt 2>/dev/null && python autonomous_agent_demo.py --no-sandbox --max-iterations <N>
 ```
 
 Where `<N>` is the iteration count from Step 1. If "Unlimited", omit the `--max-iterations` flag entirely.
+
+Notes:
+
+- `--no-sandbox` is required on WSL2 (the sandbox is unreliable there)
+- The env vars from Step 0b are inherited by the subprocess automatically
 
 **IMPORTANT:** This command will run for a long time. Use `run_in_background: true` on the Bash tool so the user isn't blocked. Tell the user the harness is running and they can check progress with:
 


### PR DESCRIPTION
## Summary

- Add 4 hookify rules to catch common harness launch mistakes before they waste agent iterations
- Add **Step 0: Worktree & Environment** to `/harness-plugin:loop` skill so agents set up worktree + `.env` before gathering requirements
- Document all rules in `harness/CLAUDE.md` under the existing Safety Layers section

## Problem

Agents launching the harness would:
1. Start on `main` without creating a worktree — committing directly to the main branch
2. Miss `.env` in worktrees (it's gitignored) — no API keys, harness hangs, pre-bash hook blocks, agents waste iterations regenerating `app_spec.md`

## Hookify Rules

| Rule | Action | Trigger |
|---|---|---|
| `block-harness-on-main` | **block** | `python autonomous_agent_demo.py` on main |
| `block-harness-no-api-key` | **block** | harness launch without `ANTHROPIC_API_KEY` |
| `warn-worktree-npm-install` | warn | `git worktree add` (reminds about `npm install`) |
| `warn-harness-dry-run` | warn | harness launch without `--max-iterations 1` dry-run |

## Test plan

- [x] All regex patterns verified with Python test cases (15/15 pass)
- [x] Confirmed hookify loader requires `*.local.md` naming (verified in `config_loader.py`)
- [x] Fixed substring bug: `--max-iterations 1` no longer falsely matches `--max-iterations 10`
- [x] Narrowed pattern to `python3?\s+.*autonomous_agent_demo\.py` to avoid blocking read-only file inspection
- [x] All 634 existing tests pass
