### PR TITLE
docs: rewrite roadmap for CLI agent workspace pivot

### DIFF
--- a/docs/roadmap/progress.yaml
+++ b/docs/roadmap/progress.yaml
@@ -77,7 +77,8 @@ phases:
   - id: phase-2
     name: 'Workspace Layout Shell'
     status: pending
-    blocked_by: []
+    blocked_by:
+      - phase-1
     specs:
       - docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
       - docs/design/agent_workspace/code.html

--- a/docs/roadmap/progress.yaml
+++ b/docs/roadmap/progress.yaml
@@ -3,163 +3,189 @@
 # Source: docs/roadmap/tauri-migration-roadmap.md
 # Schema: phase → steps → dod (definition of done)
 # Status values: pending | in_progress | done | blocked
-# All items start as pending; commit/pr fields populated as work lands.
-# Revised: 2026-04-07 — pivoted from chat manager to CLI agent workspace
+# Revised: 2026-04-07 — Phase 1 done, new Phase 2 (Workspace Layout Shell) added
 
-version: 2
+version: 3
 updated: '2026-04-07'
 roadmap: docs/roadmap/tauri-migration-roadmap.md
 
 phases:
   - id: phase-1
     name: 'Tauri Scaffold + CI Green'
-    status: pending
+    status: done
     blocked_by: []
     specs: []
     steps:
       - id: p1-s1
         name: 'Run `npx tauri init` to scaffold `src-tauri/`'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: 9ce4d61
+        pr: 27
         notes: null
       - id: p1-s2
         name: 'Configure tauri.conf.json: devUrl → http://localhost:5173, frontendDist → ../dist'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: 9ce4d61
+        pr: 27
         notes: null
       - id: p1-s3
         name: 'Add `tauri:dev` and `tauri:build` npm scripts'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: 9ce4d61
+        pr: 27
         notes: null
       - id: p1-s4
         name: 'Create src/lib/environment.ts — isTauri() detection'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: 9ce4d61
+        pr: 27
         notes: null
       - id: p1-s5
         name: 'Update CI tauri-build.yml — add Rust caching'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: 9ce4d61
+        pr: 27
         notes: null
       - id: p1-s6
         name: 'Add .gitignore entries for src-tauri/target/, src-tauri/gen/'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: 9ce4d61
+        pr: 27
         notes: null
     dod:
       - id: p1-d1
         check: '`npm run tauri:dev` opens a native window showing the React app'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: 9ce4d61
+        pr: 27
       - id: p1-d2
         check: '`npm run dev` still works as standalone Vite dev server'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: 9ce4d61
+        pr: 27
       - id: p1-d3
         check: 'CI passes on macOS, Windows, Linux'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: 9ce4d61
+        pr: 27
       - id: p1-d4
         check: 'All existing tests still pass'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: 9ce4d61
+        pr: 27
 
   - id: phase-2
-    name: 'Terminal Core'
+    name: 'Workspace Layout Shell'
     status: pending
-    blocked_by:
-      - phase-1
+    blocked_by: []
     specs:
       - docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
+      - docs/design/agent_workspace/code.html
     steps:
       - id: p2-s1
-        name: 'Add `portable-pty` Rust crate for cross-platform PTY spawning'
+        name: 'Remove chat-related code: ChatView, features/chat/, chat types, mock messages'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s2
-        name: 'Implement Rust commands: pty_spawn, pty_write, pty_resize, pty_kill'
+        name: 'Refactor App.tsx from chat-first to workspace layout (4-zone grid)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s3
-        name: 'Wire PTY stdout → Tauri events → frontend'
+        name: 'Build new Icon Rail component — project avatars, + new project, settings'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s4
-        name: 'Wire frontend keyboard input → Tauri invoke → PTY stdin'
+        name: 'Build new Sidebar component — session list (mock data) + context switcher tabs'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s5
-        name: 'Add xterm.js + @xterm/addon-fit + @xterm/addon-webgl to frontend'
+        name: 'Build Terminal Zone placeholder — tab bar + mock terminal content area'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s6
-        name: 'Create TerminalPane React component rendering xterm.js'
+        name: 'Build Agent Activity panel — status card, context smiley, usage bar, collapsible sections (mock data)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s7
-        name: 'Add terminal tab bar (agent tab + shell tabs + "+" button)'
+        name: 'Wire context switcher tabs to show existing Files Explorer / Editor / Diff in sidebar'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s8
-        name: 'Configure Catppuccin Mocha theme for xterm.js'
+        name: 'Apply Obsidian Lens design tokens — match Stitch code.html reference with authoritative overrides'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p2-s9
+        name: 'Update Tailwind config with new semantic tokens (success, tertiary, primary-dim, etc.)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p2-s10
+        name: 'Update tests for new layout components'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p2-d1
-        check: 'Can spawn a shell process and interact with it in the terminal pane'
+        check: '4-zone layout renders: icon rail, sidebar, terminal zone, agent activity'
         status: pending
         commit: null
         pr: null
       - id: p2-d2
-        check: 'Can run `claude` (Claude Code) in a terminal pane'
+        check: 'Icon rail shows project avatars with active highlight'
         status: pending
         commit: null
         pr: null
       - id: p2-d3
-        check: 'Terminal resizes correctly when window resizes'
+        check: 'Sidebar shows mock session list with status badges'
         status: pending
         commit: null
         pr: null
       - id: p2-d4
-        check: 'Multiple terminal tabs work (switch between them)'
+        check: 'Context switcher tabs (Files/Editor/Diff) work in sidebar'
         status: pending
         commit: null
         pr: null
       - id: p2-d5
-        check: 'PTY processes are cleaned up on tab close / app exit'
+        check: 'Agent Activity panel shows all sections (mock data)'
+        status: pending
+        commit: null
+        pr: null
+      - id: p2-d6
+        check: 'Chat view and all chat code removed'
+        status: pending
+        commit: null
+        pr: null
+      - id: p2-d7
+        check: 'All new components match Stitch mockup (docs/design/agent_workspace/screen.png)'
+        status: pending
+        commit: null
+        pr: null
+      - id: p2-d8
+        check: 'All tests pass, Prettier + ESLint clean'
         status: pending
         commit: null
         pr: null
 
   - id: phase-3
-    name: 'Session Management + State'
+    name: 'Terminal Core'
     status: pending
     blocked_by:
       - phase-2
@@ -167,87 +193,82 @@ phases:
       - docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
     steps:
       - id: p3-s1
-        name: 'Install Zustand, create store architecture'
+        name: 'Add `portable-pty` Rust crate for cross-platform PTY spawning'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s2
-        name: 'Create appStore — migrate global state from App.tsx'
+        name: 'Implement Rust commands: pty_spawn, pty_write, pty_resize, pty_kill'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s3
-        name: 'Create sessionStore — project/session data model, CRUD operations'
+        name: 'Wire PTY stdout → Tauri events → frontend'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s4
-        name: 'Create terminalStore — manage PTY instances per session'
+        name: 'Wire frontend keyboard input → Tauri invoke → PTY stdin'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s5
-        name: 'Build sidebar session list component (Discord pattern)'
+        name: 'Add xterm.js + @xterm/addon-fit + @xterm/addon-webgl to frontend'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s6
-        name: 'Build icon rail with project avatars'
+        name: 'Create TerminalPane React component rendering xterm.js'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s7
-        name: 'Wire session switching: click session → update terminal + activity panel'
+        name: 'Replace terminal zone placeholder with real TerminalPane'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s8
-        name: 'Remove chat-related code: ChatView, features/chat/, chat types, mock messages'
+        name: 'Configure Catppuccin Mocha theme for xterm.js'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p3-d1
-        check: 'Projects appear as avatars in icon rail'
+        check: 'Can spawn a shell process and interact with it in the terminal pane'
         status: pending
         commit: null
         pr: null
       - id: p3-d2
-        check: 'Sessions listed in sidebar with name, status badge, timestamp'
+        check: 'Can run `claude` (Claude Code) in a terminal pane'
         status: pending
         commit: null
         pr: null
       - id: p3-d3
-        check: 'Clicking a session switches the terminal and activity panel'
+        check: 'Terminal resizes correctly when window resizes'
         status: pending
         commit: null
         pr: null
       - id: p3-d4
-        check: 'New session can be created (spawns Claude Code in a PTY)'
+        check: 'Multiple terminal tabs work (switch between them)'
         status: pending
         commit: null
         pr: null
       - id: p3-d5
-        check: 'Chat view and all chat-related code removed'
-        status: pending
-        commit: null
-        pr: null
-      - id: p3-d6
-        check: 'All tests pass, zero prop drilling'
+        check: 'PTY processes are cleaned up on tab close / app exit'
         status: pending
         commit: null
         pr: null
 
   - id: phase-4
-    name: 'File Watcher + Agent Activity Panel'
+    name: 'Session Management + State'
     status: pending
     blocked_by:
       - phase-3
@@ -255,365 +276,425 @@ phases:
       - docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
     steps:
       - id: p4-s1
-        name: 'Add `notify` Rust crate for filesystem watching'
+        name: 'Install Zustand, create store architecture'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s2
-        name: 'Implement Rust commands: watch_directory, unwatch_directory'
+        name: 'Create appStore — migrate global state from App.tsx'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s3
-        name: 'Emit file change events (created/modified/deleted) via Tauri events'
+        name: 'Create sessionStore — project/session data model, CRUD operations'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s4
-        name: 'Create activityStore — aggregate file changes per session'
+        name: 'Create terminalStore — manage PTY instances per session'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s5
-        name: 'Build Agent Activity panel component with collapsible sections'
+        name: 'Wire sidebar session list to sessionStore (replace mock data)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s6
-        name: 'Implement "Files Changed" section (live from file watcher)'
+        name: 'Wire icon rail project avatars to real project data'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s7
-        name: 'Implement pinned section: status card, context window smiley, 5-hour usage bar'
+        name: 'Wire session switching: click session → update terminal + activity panel'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s8
-        name: 'Implement collapsible sections: Tool Calls, Tests, Usage Details (placeholder data)'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
-      - id: p4-s9
-        name: 'Wire git diff integration: click changed file → opens in Diff context panel'
+        name: 'Persist sessions across app restarts (SQLite or JSON in app data dir)'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p4-d1
-        check: 'File changes appear in real-time as the agent modifies files'
+        check: 'Sessions backed by Zustand store, not mock data'
         status: pending
         commit: null
         pr: null
       - id: p4-d2
-        check: 'Context window smiley indicator displays correctly'
+        check: 'Clicking a session switches the terminal and activity panel'
         status: pending
         commit: null
         pr: null
       - id: p4-d3
-        check: '5-hour usage bar shows progress'
+        check: 'New session can be created (spawns Claude Code in a PTY)'
         status: pending
         commit: null
         pr: null
       - id: p4-d4
-        check: 'Collapsible sections expand/collapse with chevron toggle'
+        check: 'Session state persists across app restarts'
         status: pending
         commit: null
         pr: null
       - id: p4-d5
-        check: 'Clicking a file in "Files Changed" opens it in the sidebar Diff panel'
-        status: pending
-        commit: null
-        pr: null
-      - id: p4-d6
-        check: 'File watcher scoped to active session working directory'
+        check: 'All tests pass, zero prop drilling'
         status: pending
         commit: null
         pr: null
 
   - id: phase-5
-    name: 'Terminal Parser + Agent Adapters'
+    name: 'File Watcher + Agent Activity Panel'
     status: pending
     blocked_by:
       - phase-4
-    specs: []
+    specs:
+      - docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
     steps:
       - id: p5-s1
-        name: 'Design AgentAdapter interface (parse terminal output → structured events)'
+        name: 'Add `notify` Rust crate for filesystem watching'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p5-s2
-        name: 'Implement ClaudeCodeAdapter — tool calls, test results, status changes'
+        name: 'Implement Rust commands: watch_directory, unwatch_directory'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p5-s3
-        name: 'Implement GenericAdapter fallback (no parsing, file watcher only)'
+        name: 'Emit file change events (created/modified/deleted) via Tauri events'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p5-s4
-        name: 'Wire adapter output to activityStore'
+        name: 'Create activityStore — aggregate file changes per session'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p5-s5
-        name: 'Update Tool Calls and Tests sections with real parsed data'
+        name: 'Wire "Files Changed" section to live file watcher data'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p5-s6
-        name: 'Auto-expand sections on relevant events'
+        name: 'Wire pinned section to real session data (status, context, usage)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p5-s7
+        name: 'Wire git diff integration: click changed file → opens in Diff context panel'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p5-d1
-        check: 'Tool calls appear in real-time as Claude Code executes them'
+        check: 'File changes appear in real-time as the agent modifies files'
         status: pending
         commit: null
         pr: null
       - id: p5-d2
-        check: 'Test results appear when Claude Code runs tests'
+        check: 'Context window smiley indicator displays correctly'
         status: pending
         commit: null
         pr: null
       - id: p5-d3
-        check: 'Agent status updates reflected in status card'
+        check: '5-hour usage bar shows progress'
         status: pending
         commit: null
         pr: null
       - id: p5-d4
-        check: 'Generic adapter works for non-Claude-Code processes'
+        check: 'Collapsible sections expand/collapse with chevron toggle'
+        status: pending
+        commit: null
+        pr: null
+      - id: p5-d5
+        check: 'File watcher scoped to active session working directory'
         status: pending
         commit: null
         pr: null
 
   - id: phase-6
-    name: 'Context Panel Integration'
+    name: 'Terminal Parser + Agent Adapters'
     status: pending
     blocked_by:
-      - phase-3
-    specs:
-      - docs/superpowers/specs/2026-04-04-files-explorer-ui-design.md
-      - docs/superpowers/specs/2026-04-04-git-diff-viewer-design.md
+      - phase-5
+    specs: []
     steps:
       - id: p6-s1
-        name: 'Implement Rust git/file IPC commands (git2, walkdir, tokio::fs)'
+        name: 'Design AgentAdapter interface (parse terminal output → structured events)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p6-s2
-        name: 'Create TauriGitService and TauriFileService (service factory pattern)'
+        name: 'Implement ClaudeCodeAdapter — tool calls, test results, status changes'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p6-s3
-        name: 'Adapt Files Explorer for 260px sidebar width'
+        name: 'Implement GenericAdapter fallback (no parsing, file watcher only)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p6-s4
-        name: 'Adapt Code Editor for sidebar (compact) + full-width overlay'
+        name: 'Wire adapter output to activityStore'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p6-s5
-        name: 'Adapt Git Diff for sidebar (unified) + full-width overlay (side-by-side)'
+        name: 'Update Tool Calls and Tests sections with real parsed data'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p6-s6
-        name: 'Build context switcher tab row (Files/Editor/Diff) in sidebar'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
-      - id: p6-s7
-        name: 'Scope all context panels to active session working directory'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
-      - id: p6-s8
-        name: 'Cross-panel navigation: Files → Editor, modified file → Diff'
+        name: 'Auto-expand sections on relevant events'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p6-d1
-        check: 'Files/Editor/Diff panels render correctly in sidebar'
+        check: 'Tool calls appear in real-time as Claude Code executes them'
         status: pending
         commit: null
         pr: null
       - id: p6-d2
-        check: 'Panels scoped to active session working directory'
+        check: 'Test results appear when Claude Code runs tests'
         status: pending
         commit: null
         pr: null
       - id: p6-d3
-        check: 'Full-width overlay works for Editor and Diff'
+        check: 'Agent status updates reflected in status card'
         status: pending
         commit: null
         pr: null
       - id: p6-d4
-        check: 'Cross-panel navigation works'
-        status: pending
-        commit: null
-        pr: null
-      - id: p6-d5
-        check: 'Vite API plugins remain functional as dev fallback'
+        check: 'Generic adapter works for non-Claude-Code processes'
         status: pending
         commit: null
         pr: null
 
   - id: phase-7
-    name: 'Usage Metrics'
+    name: 'Context Panel Integration'
     status: pending
     blocked_by:
-      - phase-5
-    specs: []
+      - phase-4
+    specs:
+      - docs/superpowers/specs/2026-04-04-files-explorer-ui-design.md
+      - docs/superpowers/specs/2026-04-04-git-diff-viewer-design.md
     steps:
       - id: p7-s1
-        name: 'Research Claude Code usage data exposure (billing API, local logs, terminal output)'
+        name: 'Implement Rust git/file IPC commands (git2, walkdir, tokio::fs)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p7-s2
-        name: 'Implement context window tracking (parse from terminal or estimate)'
+        name: 'Create TauriGitService and TauriFileService (service factory pattern)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p7-s3
-        name: 'Implement 5-hour window usage counter'
+        name: 'Adapt Files Explorer for 260px sidebar width'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p7-s4
-        name: 'Build Usage Details collapsible section: weekly, monthly, cost breakdown'
+        name: 'Adapt Code Editor for sidebar (compact) + full-width overlay'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p7-s5
-        name: 'Persist usage data locally (SQLite or JSON in app data dir)'
+        name: 'Adapt Git Diff for sidebar (unified) + full-width overlay (side-by-side)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p7-s6
+        name: 'Scope all context panels to active session working directory'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p7-s7
+        name: 'Cross-panel navigation: Files → Editor, modified file → Diff'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p7-d1
-        check: 'Context window smiley reflects actual usage'
+        check: 'Files/Editor/Diff panels render correctly in sidebar'
         status: pending
         commit: null
         pr: null
       - id: p7-d2
-        check: '5-hour usage counter updates in real-time'
+        check: 'Panels scoped to active session working directory'
         status: pending
         commit: null
         pr: null
       - id: p7-d3
-        check: 'Usage Details shows weekly/monthly breakdown'
+        check: 'Full-width overlay works for Editor and Diff'
         status: pending
         commit: null
         pr: null
       - id: p7-d4
-        check: 'Usage persists across app restarts'
+        check: 'Cross-panel navigation works'
+        status: pending
+        commit: null
+        pr: null
+      - id: p7-d5
+        check: 'Vite API plugins remain functional as dev fallback'
         status: pending
         commit: null
         pr: null
 
   - id: phase-8
-    name: 'Desktop Polish'
+    name: 'Usage Metrics'
     status: pending
     blocked_by:
-      - phase-5
+      - phase-6
     specs: []
     steps:
       - id: p8-s1
-        name: 'Window state persistence (tauri-plugin-window-state)'
+        name: 'Research Claude Code usage data exposure (billing API, local logs, terminal output)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p8-s2
-        name: 'Native menu bar (platform-specific)'
+        name: 'Implement context window tracking (parse from terminal or estimate)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p8-s3
-        name: 'System tray with show/hide and quit'
+        name: 'Implement 5-hour window usage counter'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p8-s4
-        name: 'Global keyboard shortcuts (tauri-plugin-global-shortcut)'
+        name: 'Build Usage Details collapsible section: weekly, monthly, cost breakdown'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p8-s5
-        name: 'Auto-updater (tauri-plugin-updater + GitHub releases)'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
-      - id: p8-s6
-        name: 'Platform-specific title bar (macOS traffic lights, Windows controls)'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
-      - id: p8-s7
-        name: 'Bundle fonts (Manrope, Inter, JetBrains Mono) — no CDN dependency'
+        name: 'Persist usage data locally (SQLite or JSON in app data dir)'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p8-d1
-        check: 'Window position and size persists across restarts'
+        check: 'Context window smiley reflects actual usage'
         status: pending
         commit: null
         pr: null
       - id: p8-d2
-        check: 'System tray works on all platforms'
+        check: '5-hour usage counter updates in real-time'
         status: pending
         commit: null
         pr: null
       - id: p8-d3
-        check: 'Auto-updater checks GitHub releases and prompts user'
+        check: 'Usage Details shows weekly/monthly breakdown'
         status: pending
         commit: null
         pr: null
       - id: p8-d4
+        check: 'Usage persists across app restarts'
+        status: pending
+        commit: null
+        pr: null
+
+  - id: phase-9
+    name: 'Desktop Polish'
+    status: pending
+    blocked_by:
+      - phase-6
+    specs: []
+    steps:
+      - id: p9-s1
+        name: 'Window state persistence (tauri-plugin-window-state)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p9-s2
+        name: 'Native menu bar (platform-specific)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p9-s3
+        name: 'System tray with show/hide and quit'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p9-s4
+        name: 'Global keyboard shortcuts (tauri-plugin-global-shortcut)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p9-s5
+        name: 'Auto-updater (tauri-plugin-updater + GitHub releases)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p9-s6
+        name: 'Platform-specific title bar (macOS traffic lights, Windows controls)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p9-s7
+        name: 'Bundle fonts (Manrope, Inter, JetBrains Mono) — no CDN dependency'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+    dod:
+      - id: p9-d1
+        check: 'Window position and size persists across restarts'
+        status: pending
+        commit: null
+        pr: null
+      - id: p9-d2
+        check: 'System tray works on all platforms'
+        status: pending
+        commit: null
+        pr: null
+      - id: p9-d3
+        check: 'Auto-updater checks GitHub releases and prompts user'
+        status: pending
+        commit: null
+        pr: null
+      - id: p9-d4
         check: 'App renders correctly with no network connection (bundled fonts)'
         status: pending
         commit: null

--- a/docs/roadmap/progress.yaml
+++ b/docs/roadmap/progress.yaml
@@ -487,6 +487,11 @@ phases:
         commit: null
         pr: null
       - id: p6-d4
+        check: 'Collapsible sections auto-expand when relevant events occur'
+        status: pending
+        commit: null
+        pr: null
+      - id: p6-d5
         check: 'Generic adapter works for non-Claude-Code processes'
         status: pending
         commit: null

--- a/docs/roadmap/progress.yaml
+++ b/docs/roadmap/progress.yaml
@@ -1,12 +1,13 @@
 ---
-# Vimeflow Tauri Migration — Machine-Readable Progress Tracker
+# Vimeflow CLI Agent Workspace — Machine-Readable Progress Tracker
 # Source: docs/roadmap/tauri-migration-roadmap.md
 # Schema: phase → steps → dod (definition of done)
 # Status values: pending | in_progress | done | blocked
 # All items start as pending; commit/pr fields populated as work lands.
+# Revised: 2026-04-07 — pivoted from chat manager to CLI agent workspace
 
-version: 1
-updated: '2026-04-06'
+version: 2
+updated: '2026-04-07'
 roadmap: docs/roadmap/tauri-migration-roadmap.md
 
 phases:
@@ -17,7 +18,7 @@ phases:
     specs: []
     steps:
       - id: p1-s1
-        name: 'Run `npx tauri init` to scaffold `src-tauri/` (tauri.conf.json, Cargo.toml, src/main.rs, src/lib.rs)'
+        name: 'Run `npx tauri init` to scaffold `src-tauri/`'
         status: pending
         commit: null
         pr: null
@@ -29,19 +30,19 @@ phases:
         pr: null
         notes: null
       - id: p1-s3
-        name: 'Add `tauri:dev` and `tauri:build` npm scripts (keep existing dev/build unchanged)'
+        name: 'Add `tauri:dev` and `tauri:build` npm scripts'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p1-s4
-        name: 'Create src/lib/environment.ts — isTauri() detection via window.__TAURI_INTERNALS__'
+        name: 'Create src/lib/environment.ts — isTauri() detection'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p1-s5
-        name: 'Update CI tauri-build.yml — add src/** trigger, Rust caching'
+        name: 'Update CI tauri-build.yml — add Rust caching'
         status: pending
         commit: null
         pr: null
@@ -54,369 +55,566 @@ phases:
         notes: null
     dod:
       - id: p1-d1
-        check: '`npm run tauri:dev` opens a native window showing the existing React app'
+        check: '`npm run tauri:dev` opens a native window showing the React app'
         status: pending
         commit: null
         pr: null
       - id: p1-d2
-        check: '`npm run dev` still works as standalone Vite dev server (no regression)'
+        check: '`npm run dev` still works as standalone Vite dev server'
         status: pending
         commit: null
         pr: null
       - id: p1-d3
-        check: 'CI tauri-build.yml passes on macOS, Windows, Linux'
+        check: 'CI passes on macOS, Windows, Linux'
         status: pending
         commit: null
         pr: null
       - id: p1-d4
-        check: 'All existing test files still pass'
+        check: 'All existing tests still pass'
         status: pending
         commit: null
         pr: null
 
   - id: phase-2
-    name: 'IPC Layer + Service Abstraction'
+    name: 'Terminal Core'
     status: pending
     blocked_by:
       - phase-1
     specs:
-      - docs/superpowers/specs/2026-04-04-files-explorer-ui-design.md
+      - docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
     steps:
       - id: p2-s1
-        name: 'Define shared IPC type contracts (src/shared/ipc-types.ts)'
+        name: 'Add `portable-pty` Rust crate for cross-platform PTY spawning'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s2
-        name: 'Implement Rust git commands using git2 crate (git_status, git_diff, git_stage, git_unstage, git_discard)'
+        name: 'Implement Rust commands: pty_spawn, pty_write, pty_resize, pty_kill'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s3
-        name: 'Implement Rust file commands using walkdir + tokio::fs (file_tree, file_content)'
+        name: 'Wire PTY stdout → Tauri events → frontend'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s4
-        name: 'Register all commands in src-tauri/src/lib.rs'
+        name: 'Wire frontend keyboard input → Tauri invoke → PTY stdin'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s5
-        name: 'Refactor file service to interface/factory pattern (match git service)'
+        name: 'Add xterm.js + @xterm/addon-fit + @xterm/addon-webgl to frontend'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s6
-        name: 'Create TauriGitService using @tauri-apps/api/core invoke()'
+        name: 'Create TerminalPane React component rendering xterm.js'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s7
-        name: 'Create TauriFileService using invoke()'
+        name: 'Add terminal tab bar (agent tab + shell tabs + "+" button)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p2-s8
-        name: 'Update factories: test → mock, tauri → IPC, fallback → HTTP'
+        name: 'Configure Catppuccin Mocha theme for xterm.js'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p2-d1
-        check: 'Diff + Editor views work identically in browser and Tauri'
+        check: 'Can spawn a shell process and interact with it in the terminal pane'
         status: pending
         commit: null
         pr: null
       - id: p2-d2
-        check: 'All Rust commands validate inputs (path traversal prevention)'
+        check: 'Can run `claude` (Claude Code) in a terminal pane'
         status: pending
         commit: null
         pr: null
       - id: p2-d3
-        check: 'Rust commands have unit tests'
+        check: 'Terminal resizes correctly when window resizes'
         status: pending
         commit: null
         pr: null
       - id: p2-d4
-        check: 'Vite API plugins remain functional (dev fallback)'
+        check: 'Multiple terminal tabs work (switch between them)'
+        status: pending
+        commit: null
+        pr: null
+      - id: p2-d5
+        check: 'PTY processes are cleaned up on tab close / app exit'
         status: pending
         commit: null
         pr: null
 
   - id: phase-3
-    name: 'Global State Management'
+    name: 'Session Management + State'
     status: pending
     blocked_by:
       - phase-2
-    specs: []
+    specs:
+      - docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
     steps:
       - id: p3-s1
-        name: 'Install Zustand, create store architecture doc'
+        name: 'Install Zustand, create store architecture'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s2
-        name: 'Create appStore — migrate state from App.tsx (activeTab, contextPanelOpen, commandPaletteOpen)'
+        name: 'Create appStore — migrate global state from App.tsx'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s3
-        name: 'Create diffStore — migrate from DiffView local state (changedFiles, selectedFile, currentDiff)'
+        name: 'Create sessionStore — project/session data model, CRUD operations'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s4
-        name: 'Create editorStore — migrate from EditorView local state (fileTree, openTabs, activeTab, cursorPosition)'
+        name: 'Create terminalStore — manage PTY instances per session'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s5
-        name: 'Create chatStore — prepare shape for Phase 4 (conversations, activeConversation, messages, streamingMessage)'
+        name: 'Build sidebar session list component (Discord pattern)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s6
-        name: 'Refactor views to use stores (one view at a time)'
+        name: 'Build icon rail with project avatars'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p3-s7
-        name: 'Update tests for store-based components'
+        name: 'Wire session switching: click session → update terminal + activity panel'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p3-s8
+        name: 'Remove chat-related code: ChatView, features/chat/, chat types, mock messages'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p3-d1
-        check: 'Zero prop drilling from App.tsx to views'
+        check: 'Projects appear as avatars in icon rail'
         status: pending
         commit: null
         pr: null
       - id: p3-d2
-        check: "Cross-feature navigation works (e.g., 'open in diff' from editor)"
+        check: 'Sessions listed in sidebar with name, status badge, timestamp'
         status: pending
         commit: null
         pr: null
       - id: p3-d3
-        check: 'All existing tests pass'
+        check: 'Clicking a session switches the terminal and activity panel'
+        status: pending
+        commit: null
+        pr: null
+      - id: p3-d4
+        check: 'New session can be created (spawns Claude Code in a PTY)'
+        status: pending
+        commit: null
+        pr: null
+      - id: p3-d5
+        check: 'Chat view and all chat-related code removed'
+        status: pending
+        commit: null
+        pr: null
+      - id: p3-d6
+        check: 'All tests pass, zero prop drilling'
         status: pending
         commit: null
         pr: null
 
   - id: phase-4
-    name: 'Chat Backend + AI Integration'
+    name: 'File Watcher + Agent Activity Panel'
     status: pending
     blocked_by:
-      - phase-2
       - phase-3
     specs:
-      - docs/superpowers/specs/2026-03-31-chat-view-ui-design.md
+      - docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
     steps:
       - id: p4-s1
-        name: 'Design AI backend architecture (docs/architecture/ai-backend.md)'
+        name: 'Add `notify` Rust crate for filesystem watching'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s2
-        name: 'Implement Rust chat commands: create_conversation, send_message, get_conversations'
+        name: 'Implement Rust commands: watch_directory, unwatch_directory'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s3
-        name: 'Implement conversation persistence (SQLite: conversations + messages tables)'
+        name: 'Emit file change events (created/modified/deleted) via Tauri events'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s4
-        name: 'Create ChatService interface + TauriChatService + MockChatService'
+        name: 'Create activityStore — aggregate file changes per session'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s5
-        name: 'Build streaming message UI component'
+        name: 'Build Agent Activity panel component with collapsible sections'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s6
-        name: 'Implement Anthropic provider (reqwest + SSE → Tauri events)'
+        name: 'Implement "Files Changed" section (live from file watcher)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p4-s7
-        name: 'Add settings system (API keys via keychain, model selection, provider choice)'
+        name: 'Implement pinned section: status card, context window smiley, 5-hour usage bar'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p4-s8
+        name: 'Implement collapsible sections: Tool Calls, Tests, Usage Details (placeholder data)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p4-s9
+        name: 'Wire git diff integration: click changed file → opens in Diff context panel'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p4-d1
-        check: 'User sends message → streaming AI response → persists across restarts'
+        check: 'File changes appear in real-time as the agent modifies files'
         status: pending
         commit: null
         pr: null
       - id: p4-d2
-        check: 'API keys stored in OS keychain (not plaintext)'
+        check: 'Context window smiley indicator displays correctly'
         status: pending
         commit: null
         pr: null
       - id: p4-d3
-        check: 'Mock mode works for development without API keys'
+        check: '5-hour usage bar shows progress'
         status: pending
         commit: null
         pr: null
       - id: p4-d4
-        check: 'Error states handled (network failure, rate limit, invalid key)'
+        check: 'Collapsible sections expand/collapse with chevron toggle'
+        status: pending
+        commit: null
+        pr: null
+      - id: p4-d5
+        check: 'Clicking a file in "Files Changed" opens it in the sidebar Diff panel'
+        status: pending
+        commit: null
+        pr: null
+      - id: p4-d6
+        check: 'File watcher scoped to active session working directory'
         status: pending
         commit: null
         pr: null
 
   - id: phase-5
-    name: 'Desktop Polish'
+    name: 'Terminal Parser + Agent Adapters'
     status: pending
     blocked_by:
       - phase-4
     specs: []
     steps:
       - id: p5-s1
-        name: 'Window state persistence (tauri-plugin-window-state)'
+        name: 'Design AgentAdapter interface (parse terminal output → structured events)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p5-s2
-        name: 'Native menu bar (platform-specific conventions)'
+        name: 'Implement ClaudeCodeAdapter — tool calls, test results, status changes'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p5-s3
-        name: 'System tray with show/hide and quit'
+        name: 'Implement GenericAdapter fallback (no parsing, file watcher only)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p5-s4
-        name: 'Global keyboard shortcuts (tauri-plugin-global-shortcut)'
+        name: 'Wire adapter output to activityStore'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p5-s5
-        name: 'Auto-updater (tauri-plugin-updater + GitHub releases)'
+        name: 'Update Tool Calls and Tests sections with real parsed data'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p5-s6
-        name: 'Platform-specific title bar (macOS traffic lights, Windows controls)'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
-      - id: p5-s7
-        name: 'Bundle fonts (Manrope, Inter, JetBrains Mono) — no CDN dependency'
+        name: 'Auto-expand sections on relevant events'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p5-d1
-        check: 'Window position and size persists across restarts'
+        check: 'Tool calls appear in real-time as Claude Code executes them'
         status: pending
         commit: null
         pr: null
       - id: p5-d2
-        check: 'System tray works on all platforms (macOS, Windows, Linux)'
+        check: 'Test results appear when Claude Code runs tests'
         status: pending
         commit: null
         pr: null
       - id: p5-d3
-        check: 'Auto-updater checks GitHub releases and prompts user when update is available'
+        check: 'Agent status updates reflected in status card'
         status: pending
         commit: null
         pr: null
       - id: p5-d4
-        check: 'App renders correctly with no network connection (bundled fonts, no CDN dependency)'
+        check: 'Generic adapter works for non-Claude-Code processes'
         status: pending
         commit: null
         pr: null
 
   - id: phase-6
-    name: 'Advanced Features'
+    name: 'Context Panel Integration'
     status: pending
     blocked_by:
-      - phase-4
-    specs: []
+      - phase-3
+    specs:
+      - docs/superpowers/specs/2026-04-04-files-explorer-ui-design.md
+      - docs/superpowers/specs/2026-04-04-git-diff-viewer-design.md
     steps:
       - id: p6-s1
-        name: 'Multi-provider support (OpenAI)'
+        name: 'Implement Rust git/file IPC commands (git2, walkdir, tokio::fs)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p6-s2
-        name: 'Agent process management (spawn/monitor Claude Code, Codex CLI)'
+        name: 'Create TauriGitService and TauriFileService (service factory pattern)'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p6-s3
-        name: 'Conversation branching/forking'
+        name: 'Adapt Files Explorer for 260px sidebar width'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p6-s4
-        name: 'Workspace/project model (associate conversations with directories)'
+        name: 'Adapt Code Editor for sidebar (compact) + full-width overlay'
         status: pending
         commit: null
         pr: null
         notes: null
       - id: p6-s5
-        name: 'Export/import conversations'
+        name: 'Adapt Git Diff for sidebar (unified) + full-width overlay (side-by-side)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p6-s6
+        name: 'Build context switcher tab row (Files/Editor/Diff) in sidebar'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p6-s7
+        name: 'Scope all context panels to active session working directory'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p6-s8
+        name: 'Cross-panel navigation: Files → Editor, modified file → Diff'
         status: pending
         commit: null
         pr: null
         notes: null
     dod:
       - id: p6-d1
-        check: 'At least two AI providers (Anthropic and OpenAI) work end-to-end with streaming'
+        check: 'Files/Editor/Diff panels render correctly in sidebar'
         status: pending
         commit: null
         pr: null
       - id: p6-d2
-        check: 'Agent processes (Claude Code, Codex CLI) can be spawned and monitored from the UI'
+        check: 'Panels scoped to active session working directory'
         status: pending
         commit: null
         pr: null
       - id: p6-d3
-        check: 'Conversations can be branched at any message and diverge independently'
+        check: 'Full-width overlay works for Editor and Diff'
         status: pending
         commit: null
         pr: null
       - id: p6-d4
-        check: 'Conversations can be exported to JSON and re-imported without data loss'
+        check: 'Cross-panel navigation works'
+        status: pending
+        commit: null
+        pr: null
+      - id: p6-d5
+        check: 'Vite API plugins remain functional as dev fallback'
+        status: pending
+        commit: null
+        pr: null
+
+  - id: phase-7
+    name: 'Usage Metrics'
+    status: pending
+    blocked_by:
+      - phase-5
+    specs: []
+    steps:
+      - id: p7-s1
+        name: 'Research Claude Code usage data exposure (billing API, local logs, terminal output)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p7-s2
+        name: 'Implement context window tracking (parse from terminal or estimate)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p7-s3
+        name: 'Implement 5-hour window usage counter'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p7-s4
+        name: 'Build Usage Details collapsible section: weekly, monthly, cost breakdown'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p7-s5
+        name: 'Persist usage data locally (SQLite or JSON in app data dir)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+    dod:
+      - id: p7-d1
+        check: 'Context window smiley reflects actual usage'
+        status: pending
+        commit: null
+        pr: null
+      - id: p7-d2
+        check: '5-hour usage counter updates in real-time'
+        status: pending
+        commit: null
+        pr: null
+      - id: p7-d3
+        check: 'Usage Details shows weekly/monthly breakdown'
+        status: pending
+        commit: null
+        pr: null
+      - id: p7-d4
+        check: 'Usage persists across app restarts'
+        status: pending
+        commit: null
+        pr: null
+
+  - id: phase-8
+    name: 'Desktop Polish'
+    status: pending
+    blocked_by:
+      - phase-5
+    specs: []
+    steps:
+      - id: p8-s1
+        name: 'Window state persistence (tauri-plugin-window-state)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p8-s2
+        name: 'Native menu bar (platform-specific)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p8-s3
+        name: 'System tray with show/hide and quit'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p8-s4
+        name: 'Global keyboard shortcuts (tauri-plugin-global-shortcut)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p8-s5
+        name: 'Auto-updater (tauri-plugin-updater + GitHub releases)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p8-s6
+        name: 'Platform-specific title bar (macOS traffic lights, Windows controls)'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+      - id: p8-s7
+        name: 'Bundle fonts (Manrope, Inter, JetBrains Mono) — no CDN dependency'
+        status: pending
+        commit: null
+        pr: null
+        notes: null
+    dod:
+      - id: p8-d1
+        check: 'Window position and size persists across restarts'
+        status: pending
+        commit: null
+        pr: null
+      - id: p8-d2
+        check: 'System tray works on all platforms'
+        status: pending
+        commit: null
+        pr: null
+      - id: p8-d3
+        check: 'Auto-updater checks GitHub releases and prompts user'
+        status: pending
+        commit: null
+        pr: null
+      - id: p8-d4
+        check: 'App renders correctly with no network connection (bundled fonts)'
         status: pending
         commit: null
         pr: null

--- a/docs/roadmap/tauri-migration-roadmap.md
+++ b/docs/roadmap/tauri-migration-roadmap.md
@@ -14,56 +14,71 @@ Replaces the previous 6-phase chat-based roadmap. The core change: the primary w
 
 | Component           | Status                                                           |
 | ------------------- | ---------------------------------------------------------------- |
+| Tauri scaffold      | **Done** — `src-tauri/` bootstrapped, CI green (PR #27)          |
 | Chat view           | UI shell + mock data — **deprecated, to be removed**             |
 | Diff view           | Wired — real git ops via Vite API plugin (`/api/git/*`)          |
 | Editor view         | Wired — file tree + content via Vite API plugin (`/api/files/*`) |
 | Command Palette     | UI shell + mock commands                                         |
-| Agent Workspace     | Design spec complete, Stitch mockup approved                     |
-| Tauri backend       | Does not exist (`src-tauri/` missing)                            |
+| Agent Workspace     | Design spec complete, Stitch mockup approved (PR #29)            |
 | Terminal (xterm.js) | Not yet implemented                                              |
 | State management    | None — prop drilling + `useState` in `App.tsx`                   |
-| CI                  | `tauri-build.yml` exists but blocked (no `src-tauri/`)           |
 
 ---
 
-## Phase 1: Tauri Scaffold + CI Green
+## Phase 1: Tauri Scaffold + CI Green ✅
 
-**Scope: Medium | Est: 3–5 days**
+**Status: Done** — PR #27, commit `9ce4d61`
+
+Bootstrapped `src-tauri/` with Tauri v2 configuration, npm scripts, environment detection, and CI pipeline.
+
+---
+
+## Phase 2: Workspace Layout Shell
+
+**Scope: Medium | Est: 4–6 days | Blocked by: Phase 1 ✅**
 
 ### Goal
 
-Bootstrap `src-tauri/` so the app runs as a Tauri window. No IPC commands yet — just the shell.
+Implement the 4-zone workspace layout from the Stitch mockup as a static frontend shell. Replace the chat-based layout with the new Discord-pattern architecture. Uses mock/placeholder data — no PTY or backend wiring yet.
 
 ### Steps
 
-1. Run `npx tauri init` to scaffold `src-tauri/`
-2. Configure `tauri.conf.json`: `devUrl` → `http://localhost:5173`, `frontendDist` → `../dist`
-3. Add `tauri:dev` and `tauri:build` npm scripts
-4. Create `src/lib/environment.ts` — `isTauri()` detection
-5. Update CI `tauri-build.yml` — add Rust caching
-6. Add `.gitignore` entries for `src-tauri/target/`, `src-tauri/gen/`
+1. Remove chat-related code: `ChatView`, `features/chat/`, chat types, mock messages
+2. Refactor `App.tsx` from chat-first to workspace layout (4-zone grid)
+3. Build new Icon Rail component — project avatars, `+` new project, `⚙` settings
+4. Build new Sidebar component — session list (mock data) + context switcher tabs (Files/Editor/Diff)
+5. Build Terminal Zone placeholder — tab bar + mock terminal content area
+6. Build Agent Activity panel — status card, context smiley, 5-hour usage bar, collapsible sections (all mock data)
+7. Wire context switcher tabs to show existing Files Explorer / Editor / Diff in sidebar
+8. Apply Obsidian Lens design tokens — match Stitch `code.html` reference (with authoritative color overrides)
+9. Update Tailwind config with new semantic tokens (`success`, `tertiary`, `primary-dim`, etc.)
+10. Update tests for new layout components
 
 ### Definition of Done
 
-- [ ] `npm run tauri:dev` opens a native window showing the React app
-- [ ] `npm run dev` still works as standalone Vite dev server
-- [ ] CI passes on macOS, Windows, Linux
-- [ ] All existing tests still pass
+- [ ] 4-zone layout renders: icon rail, sidebar, terminal zone, agent activity
+- [ ] Icon rail shows project avatars with active highlight
+- [ ] Sidebar shows mock session list with status badges
+- [ ] Context switcher tabs (Files/Editor/Diff) work in sidebar
+- [ ] Agent Activity panel shows all sections (mock data)
+- [ ] Chat view and all chat code removed
+- [ ] All new components match Stitch mockup (`docs/design/agent_workspace/screen.png`)
+- [ ] All tests pass, Prettier + ESLint clean
 
 ### Risks
 
-- WSL2: No native window — need WSLg or Windows-side cargo
-- Tauri 2 config: Use only official v2 docs
+- Large layout refactor touches many files — migrate incrementally, one zone at a time
+- Existing Files/Editor/Diff components may need width adaptations for 260px sidebar
 
 ---
 
-## Phase 2: Terminal Core
+## Phase 3: Terminal Core
 
-**Scope: Large | Est: 5–8 days | Blocked by: Phase 1**
+**Scope: Large | Est: 5–8 days | Blocked by: Phase 2**
 
 ### Goal
 
-Integrate xterm.js with a Rust-side PTY via Tauri. Render a working terminal pane that can run shell commands and Claude Code.
+Integrate xterm.js with a Rust-side PTY via Tauri. Replace the terminal zone placeholder with a real working terminal.
 
 ### Steps
 
@@ -73,7 +88,7 @@ Integrate xterm.js with a Rust-side PTY via Tauri. Render a working terminal pan
 4. Wire frontend keyboard input → Tauri invoke → PTY stdin
 5. Add `xterm.js` + `@xterm/addon-fit` + `@xterm/addon-webgl` to frontend
 6. Create `TerminalPane` React component rendering xterm.js
-7. Add terminal tab bar (agent tab + shell tabs + `+` button)
+7. Replace terminal zone placeholder with real `TerminalPane`
 8. Configure Catppuccin Mocha theme for xterm.js
 
 ### Definition of Done
@@ -91,13 +106,13 @@ Integrate xterm.js with a Rust-side PTY via Tauri. Render a working terminal pan
 
 ---
 
-## Phase 3: Session Management + State
+## Phase 4: Session Management + State
 
-**Scope: Medium | Est: 5–7 days | Blocked by: Phase 2**
+**Scope: Medium | Est: 5–7 days | Blocked by: Phase 3**
 
 ### Goal
 
-Introduce Zustand for global state. Build the project/session data model and sidebar session list.
+Introduce Zustand for global state. Wire the session list from Phase 2 to real data. Connect session switching to terminal panes.
 
 ### Store Structure
 
@@ -115,41 +130,39 @@ src/stores/
 2. Create `appStore` — migrate global state from `App.tsx`
 3. Create `sessionStore` — project/session data model, CRUD operations
 4. Create `terminalStore` — manage PTY instances per session
-5. Build sidebar session list component (Discord pattern from design spec)
-6. Build icon rail with project avatars
-7. Wire session switching: click session → update terminal zone + activity panel
-8. Remove chat-related code: `ChatView`, `features/chat/`, chat types, mock messages
+5. Wire sidebar session list to `sessionStore` (replace mock data)
+6. Wire icon rail project avatars to real project data
+7. Wire session switching: click session → update terminal + activity panel
+8. Persist sessions across app restarts (SQLite or JSON in app data dir)
 
 ### Definition of Done
 
-- [ ] Projects appear as avatars in icon rail
-- [ ] Sessions listed in sidebar with name, status badge, timestamp
+- [ ] Sessions backed by Zustand store, not mock data
 - [ ] Clicking a session switches the terminal and activity panel
 - [ ] New session can be created (spawns Claude Code in a PTY)
-- [ ] Chat view and all chat-related code removed
+- [ ] Session state persists across app restarts
 - [ ] All tests pass, zero prop drilling
 
 ---
 
-## Phase 4: File Watcher + Agent Activity Panel
+## Phase 5: File Watcher + Agent Activity Panel
 
-**Scope: Medium | Est: 5–7 days | Blocked by: Phase 3**
+**Scope: Medium | Est: 5–7 days | Blocked by: Phase 4**
 
 ### Goal
 
-Implement the Agent Activity sidebar with real-time file change tracking via Rust `notify` crate, and the always-visible usage metrics.
+Wire the Agent Activity sidebar (built as static shell in Phase 2) to real data via Rust `notify` file watcher.
 
 ### Steps
 
 1. Add `notify` Rust crate for filesystem watching
-2. Implement Rust command: `watch_directory` (starts watcher), `unwatch_directory`
+2. Implement Rust commands: `watch_directory`, `unwatch_directory`
 3. Emit file change events (created/modified/deleted) via Tauri events
 4. Create `activityStore` — aggregate file changes per session
-5. Build Agent Activity panel component with collapsible sections
-6. Implement "Files Changed" section (live from file watcher)
-7. Implement always-pinned section: status card, context window smiley, 5-hour usage bar
-8. Implement collapsible "Tool Calls", "Tests", "Usage Details" sections (placeholder data for now)
-9. Wire git diff integration: click a changed file → opens in Diff context panel
+5. Wire "Files Changed" section to live file watcher data
+6. Wire pinned section to real session data (status, context estimate, usage)
+7. Wire git diff integration: click a changed file → opens in Diff context panel
+8. Keep "Tool Calls", "Tests", "Usage Details" sections with placeholder data (wired in Phase 6)
 
 ### Definition of Done
 
@@ -162,9 +175,9 @@ Implement the Agent Activity sidebar with real-time file change tracking via Rus
 
 ---
 
-## Phase 5: Terminal Parser + Agent Adapters
+## Phase 6: Terminal Parser + Agent Adapters
 
-**Scope: Medium | Est: 4–6 days | Blocked by: Phase 4**
+**Scope: Medium | Est: 4–6 days | Blocked by: Phase 5**
 
 ### Goal
 
@@ -194,24 +207,23 @@ Parse Claude Code's terminal output to extract structured data: tool calls, test
 
 ---
 
-## Phase 6: Context Panel Integration
+## Phase 7: Context Panel Integration
 
-**Scope: Medium | Est: 4–6 days | Blocked by: Phase 3, builds on Phase 4**
+**Scope: Medium | Est: 4–6 days | Blocked by: Phase 4, builds on Phase 5**
 
 ### Goal
 
-Wire the existing Files Explorer, Code Editor, and Git Diff views to work as context panels in the sidebar, scoped to the active session's working directory.
+Wire the existing Files Explorer, Code Editor, and Git Diff views to Tauri IPC, scoped to the active session's working directory.
 
 ### Steps
 
-1. Refactor IPC layer: Rust git/file commands (reuse from old Phase 2 plan)
+1. Implement Rust git/file IPC commands (git2, walkdir, tokio::fs)
 2. Create `TauriGitService` and `TauriFileService` (service factory pattern)
 3. Adapt Files Explorer to render in 260px sidebar width
 4. Adapt Code Editor for sidebar (compact mode) + full-width overlay
 5. Adapt Git Diff for sidebar (unified only) + full-width overlay (side-by-side)
-6. Build context switcher tab row (Files/Editor/Diff) in sidebar
-7. Scope all context panels to active session's working directory
-8. Cross-panel navigation: click file in Files → opens in Editor; click modified file → opens Diff
+6. Scope all context panels to active session's working directory
+7. Cross-panel navigation: click file in Files → opens in Editor; click modified file → opens Diff
 
 ### Definition of Done
 
@@ -223,9 +235,9 @@ Wire the existing Files Explorer, Code Editor, and Git Diff views to work as con
 
 ---
 
-## Phase 7: Usage Metrics
+## Phase 8: Usage Metrics
 
-**Scope: Small | Est: 2–3 days | Blocked by: Phase 5**
+**Scope: Small | Est: 2–3 days | Blocked by: Phase 6**
 
 ### Goal
 
@@ -248,9 +260,9 @@ Wire real usage data into the Agent Activity panel.
 
 ---
 
-## Phase 8: Desktop Polish
+## Phase 9: Desktop Polish
 
-**Scope: Medium | Est: 4–6 days | Parallel with Phase 7**
+**Scope: Medium | Est: 4–6 days | Parallel with Phase 8**
 
 - Window state persistence (`tauri-plugin-window-state`)
 - Native menu bar (platform-specific)
@@ -265,23 +277,26 @@ Wire real usage data into the Agent Activity panel.
 ## Dependency Graph
 
 ```
-Phase 1: Tauri Scaffold
+Phase 1: Tauri Scaffold ✅
     │
     ▼
-Phase 2: Terminal Core
+Phase 2: Workspace Layout Shell ← NEXT
     │
     ▼
-Phase 3: Session Management + State ───────┐
+Phase 3: Terminal Core
+    │
+    ▼
+Phase 4: Session Management + State ───────┐
     │                                       │
     ▼                                       ▼
-Phase 4: File Watcher + Activity    Phase 6: Context Panels
+Phase 5: File Watcher + Activity    Phase 7: Context Panels
     │
     ▼
-Phase 5: Terminal Parser
+Phase 6: Terminal Parser
     │
     ├────────┬──────────┐
     ▼        ▼          ▼
-Phase 7  Phase 8    (parallel)
+Phase 8  Phase 9    (parallel)
 ```
 
 ---
@@ -290,9 +305,10 @@ Phase 7  Phase 8    (parallel)
 
 | Decision        | Recommendation                          | Rationale                                                       |
 | --------------- | --------------------------------------- | --------------------------------------------------------------- |
+| Layout first    | Static shell before backend wiring      | Validate design, get visual feedback early, unblock parallel UI |
 | Terminal        | xterm.js + portable-pty                 | De facto standard; matches Termio's stack                       |
 | PTY management  | One PTY per terminal tab                | Simple lifecycle; Rust owns spawn/kill                          |
-| State mgmt      | Zustand in Phase 3                      | After terminal works but before complex UI                      |
+| State mgmt      | Zustand in Phase 4                      | After terminal works but before complex UI                      |
 | Agent parsing   | Adapter pattern per agent CLI           | Claude Code first; extensible to Codex, Aider                   |
 | File watching   | Rust `notify` → Tauri events            | Agent-agnostic; works regardless of which process changes files |
 | Context panels  | Sidebar (260px) + full-width overlay    | Compact view in sidebar; expand for detailed work               |
@@ -316,15 +332,16 @@ Phase 7  Phase 8    (parallel)
 
 ## Timeline Summary
 
-| Phase                         | Scope  | Est. Days | Key Deliverable                       |
-| ----------------------------- | ------ | --------- | ------------------------------------- |
-| 1. Tauri Scaffold             | Medium | 3–5       | Native window + CI green              |
-| 2. Terminal Core              | Large  | 5–8       | xterm.js + PTY working                |
-| 3. Session Management + State | Medium | 5–7       | Projects, sessions, sidebar, Zustand  |
-| 4. File Watcher + Activity    | Medium | 5–7       | Agent Activity panel, real-time files |
-| 5. Terminal Parser            | Medium | 4–6       | Claude Code output → structured data  |
-| 6. Context Panels             | Medium | 4–6       | Files/Editor/Diff wired to sessions   |
-| 7. Usage Metrics              | Small  | 2–3       | Context window, billing data          |
-| 8. Desktop Polish             | Medium | 4–6       | Tray, menus, auto-update, fonts       |
+| Phase                         | Scope  | Est. Days | Status   | Key Deliverable                       |
+| ----------------------------- | ------ | --------- | -------- | ------------------------------------- |
+| 1. Tauri Scaffold             | Medium | 3–5       | **Done** | Native window + CI green              |
+| 2. Workspace Layout Shell     | Medium | 4–6       | Next     | 4-zone layout, mock data              |
+| 3. Terminal Core              | Large  | 5–8       | Pending  | xterm.js + PTY working                |
+| 4. Session Management + State | Medium | 5–7       | Pending  | Projects, sessions, Zustand           |
+| 5. File Watcher + Activity    | Medium | 5–7       | Pending  | Agent Activity panel, real-time files |
+| 6. Terminal Parser            | Medium | 4–6       | Pending  | Claude Code output → structured data  |
+| 7. Context Panels             | Medium | 4–6       | Pending  | Files/Editor/Diff wired to sessions   |
+| 8. Usage Metrics              | Small  | 2–3       | Pending  | Context window, billing data          |
+| 9. Desktop Polish             | Medium | 4–6       | Pending  | Tray, menus, auto-update, fonts       |
 
-**Total: ~32–48 days** (critical path ~24–34 days with Phase 6–8 parallel work)
+**Total: ~36–54 days** (critical path ~28–40 days with Phase 7–9 parallel work)

--- a/docs/roadmap/tauri-migration-roadmap.md
+++ b/docs/roadmap/tauri-migration-roadmap.md
@@ -202,14 +202,14 @@ Parse Claude Code's terminal output to extract structured data: tool calls, test
 - [ ] Tool calls appear in real-time as Claude Code executes them
 - [ ] Test results appear when Claude Code runs tests
 - [ ] Agent status updates (running/thinking/waiting) reflected in status card
-- [ ] Sections auto-expand when relevant events occur
+- [ ] Collapsible sections auto-expand when relevant events occur (e.g., Tests expands on test run)
 - [ ] Generic adapter works for non-Claude-Code processes (just file watcher)
 
 ---
 
 ## Phase 7: Context Panel Integration
 
-**Scope: Medium | Est: 4–6 days | Blocked by: Phase 4, builds on Phase 5**
+**Scope: Medium | Est: 4–6 days | Blocked by: Phase 4**
 
 ### Goal
 

--- a/docs/roadmap/tauri-migration-roadmap.md
+++ b/docs/roadmap/tauri-migration-roadmap.md
@@ -1,30 +1,28 @@
-# Vimeflow Tauri Migration Roadmap
+# Vimeflow CLI Agent Workspace — Roadmap
 
 > Created: 2026-04-06
-> Status: Draft — pending team review
-> Contributors: Architect agent, Planner agent, Security reviewer agent
+> Revised: 2026-04-07 — pivoted from chat manager to CLI agent workspace
+> Design spec: docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
 
 ## Overview
 
-This roadmap transforms Vimeflow from a pure React web app (with Vite API plugins simulating a backend) into a full Tauri 2 desktop application with Rust backend, IPC-based service layer, global state management, and AI agent integration.
+This roadmap transforms Vimeflow into a **CLI coding agent control plane** — a Tauri 2 desktop app that unifies terminal sessions (AI coding agents like Claude Code), file explorer, code editor, and git diff into one window.
+
+Replaces the previous 6-phase chat-based roadmap. The core change: the primary workspace is now terminal panes running agent processes, not a chat message thread.
 
 ## Current State
 
-| Component        | Status                                                           |
-| ---------------- | ---------------------------------------------------------------- |
-| Chat view        | UI shell + mock data, no input processing                        |
-| Diff view        | Wired — real git ops via Vite API plugin (`/api/git/*`)          |
-| Editor view      | Wired — file tree + content via Vite API plugin (`/api/files/*`) |
-| Command Palette  | UI shell + mock commands                                         |
-| Tauri backend    | Does not exist (`src-tauri/` missing)                            |
-| State management | None — prop drilling + `useState` in `App.tsx`                   |
-| CI               | `tauri-build.yml` exists but blocked (no `src-tauri/`)           |
-
-### Key Architecture Points
-
-- **Service factory pattern** already exists for git: `GitService` interface with `MockGitService` / `HttpGitService` + factory `createGitService()` switching on `import.meta.env.MODE`
-- **File service** uses bare functions (no interface/factory) — needs refactoring to match git pattern
-- **73 test files** with Vitest + Testing Library
+| Component           | Status                                                           |
+| ------------------- | ---------------------------------------------------------------- |
+| Chat view           | UI shell + mock data — **deprecated, to be removed**             |
+| Diff view           | Wired — real git ops via Vite API plugin (`/api/git/*`)          |
+| Editor view         | Wired — file tree + content via Vite API plugin (`/api/files/*`) |
+| Command Palette     | UI shell + mock commands                                         |
+| Agent Workspace     | Design spec complete, Stitch mockup approved                     |
+| Tauri backend       | Does not exist (`src-tauri/` missing)                            |
+| Terminal (xterm.js) | Not yet implemented                                              |
+| State management    | None — prop drilling + `useState` in `App.tsx`                   |
+| CI                  | `tauri-build.yml` exists but blocked (no `src-tauri/`)           |
 
 ---
 
@@ -34,217 +32,233 @@ This roadmap transforms Vimeflow from a pure React web app (with Vite API plugin
 
 ### Goal
 
-Bootstrap `src-tauri/` so the app runs as a Tauri window while the existing Vite dev workflow continues unchanged. No IPC commands yet — just the shell.
+Bootstrap `src-tauri/` so the app runs as a Tauri window. No IPC commands yet — just the shell.
 
 ### Steps
 
-1. Run `npx tauri init` to scaffold `src-tauri/` (`tauri.conf.json`, `Cargo.toml`, `src/main.rs`, `src/lib.rs`)
+1. Run `npx tauri init` to scaffold `src-tauri/`
 2. Configure `tauri.conf.json`: `devUrl` → `http://localhost:5173`, `frontendDist` → `../dist`
-3. Add `"tauri:dev"` and `"tauri:build"` npm scripts (keep existing `dev`/`build` unchanged)
-4. Create `src/lib/environment.ts` — `isTauri()` detection via `window.__TAURI_INTERNALS__`
-5. Update CI `tauri-build.yml` — add `src/**` trigger, Rust caching
+3. Add `tauri:dev` and `tauri:build` npm scripts
+4. Create `src/lib/environment.ts` — `isTauri()` detection
+5. Update CI `tauri-build.yml` — add Rust caching
 6. Add `.gitignore` entries for `src-tauri/target/`, `src-tauri/gen/`
 
 ### Definition of Done
 
-- [ ] `npm run tauri:dev` opens a native window showing the existing React app
-- [ ] `npm run dev` still works as standalone Vite dev server (no regression)
-- [ ] CI `tauri-build.yml` passes on macOS, Windows, Linux
-- [ ] All existing test files still pass
+- [ ] `npm run tauri:dev` opens a native window showing the React app
+- [ ] `npm run dev` still works as standalone Vite dev server
+- [ ] CI passes on macOS, Windows, Linux
+- [ ] All existing tests still pass
 
 ### Risks
 
-- **WSL2**: No native window — need WSLg or Windows-side cargo
-- **Tauri 2 config**: Online tutorials mix v1/v2 patterns; use only official v2 docs
+- WSL2: No native window — need WSLg or Windows-side cargo
+- Tauri 2 config: Use only official v2 docs
 
 ---
 
-## Phase 2: IPC Layer + Service Abstraction
+## Phase 2: Terminal Core
 
-**Scope: Large | Est: 5–8 days**
+**Scope: Large | Est: 5–8 days | Blocked by: Phase 1**
 
 ### Goal
 
-Build Rust-side Tauri commands replicating the Vite API plugins, plus TypeScript `TauriGitService` and `TauriFileService` implementations. Service factories switch automatically based on environment.
-
-### Rust Command Structure
-
-```
-src-tauri/src/
-  commands/
-    git.rs       # git_status, git_diff, git_stage, git_unstage, git_discard
-    files.rs     # file_tree, file_content
-    mod.rs       # re-exports
-  lib.rs         # register all command handlers
-```
-
-### IPC Mapping
-
-| Vite Route                      | Tauri Command  | Pattern |
-| ------------------------------- | -------------- | ------- |
-| `GET /api/git/status`           | `git_status`   | invoke  |
-| `GET /api/git/diff?file=X`      | `git_diff`     | invoke  |
-| `POST /api/git/stage`           | `git_stage`    | invoke  |
-| `POST /api/git/discard`         | `git_discard`  | invoke  |
-| `GET /api/files/tree`           | `file_tree`    | invoke  |
-| `GET /api/files/content?path=X` | `file_content` | invoke  |
+Integrate xterm.js with a Rust-side PTY via Tauri. Render a working terminal pane that can run shell commands and Claude Code.
 
 ### Steps
 
-1. Define shared IPC type contracts (`src/shared/ipc-types.ts`)
-2. Implement Rust git commands using `git2` crate
-3. Implement Rust file commands using `walkdir` + `tokio::fs`
-4. Register commands in `src-tauri/src/lib.rs`
-5. Refactor file service to interface/factory pattern (match git service)
-6. Create `TauriGitService` using `@tauri-apps/api/core` `invoke()`
-7. Create `TauriFileService` using `invoke()`
-8. Update factories: test → mock, tauri → IPC, fallback → HTTP
-
-### Dual-Mode Service Layer
-
-```
-GitService (interface)
-  ├── MockGitService      (tests)
-  ├── HttpGitService      (npm run dev — uses Vite plugin)
-  └── TauriGitService     (npm run tauri dev — uses invoke)
-
-FileService (interface)
-  ├── MockFileService     (tests)
-  ├── HttpFileService     (npm run dev — uses Vite plugin)
-  └── TauriFileService    (npm run tauri dev — uses invoke)
-```
-
-Detection in factory:
-
-```typescript
-if (import.meta.env.MODE === 'test') return new MockGitService()
-if (window.__TAURI_INTERNALS__) return new TauriGitService()
-return new HttpGitService()
-```
+1. Add `portable-pty` Rust crate for cross-platform PTY spawning
+2. Implement Rust commands: `pty_spawn`, `pty_write`, `pty_resize`, `pty_kill`
+3. Wire PTY stdout → Tauri events → frontend
+4. Wire frontend keyboard input → Tauri invoke → PTY stdin
+5. Add `xterm.js` + `@xterm/addon-fit` + `@xterm/addon-webgl` to frontend
+6. Create `TerminalPane` React component rendering xterm.js
+7. Add terminal tab bar (agent tab + shell tabs + `+` button)
+8. Configure Catppuccin Mocha theme for xterm.js
 
 ### Definition of Done
 
-- [ ] Diff + Editor views work identically in browser and Tauri
-- [ ] All Rust commands validate inputs (path traversal prevention)
-- [ ] Rust commands have unit tests
-- [ ] Vite API plugins remain functional (dev fallback)
+- [ ] Can spawn a shell process and interact with it in the terminal pane
+- [ ] Can run `claude` (Claude Code) in a terminal pane
+- [ ] Terminal resizes correctly when window resizes
+- [ ] Multiple terminal tabs work (switch between them)
+- [ ] PTY processes are cleaned up on tab close / app exit
 
 ### Risks
 
-- **`git2` diff parsing**: Differs from `simple-git`/`diff2html` — start with raw diff + frontend parsing
-- **Decision point**: Return structured `FileDiff` from Rust (preferred) or raw unified diff (simpler)
+- `portable-pty` behavior on Windows vs macOS vs Linux — test all three
+- xterm.js performance with large agent output — use WebGL renderer
 
 ---
 
-## Phase 3: Global State Management
+## Phase 3: Session Management + State
 
-**Scope: Medium | Est: 4–6 days**
+**Scope: Medium | Est: 5–7 days | Blocked by: Phase 2**
 
 ### Goal
 
-Introduce Zustand to replace prop drilling and enable cross-feature communication.
-
-### Why Zustand
-
-- 1KB gzipped, no providers or context wrappers
-- Selective subscriptions (components re-render only on their slice)
-- `persist` middleware for settings storage
-- Framework-agnostic core (works in tests without React)
+Introduce Zustand for global state. Build the project/session data model and sidebar session list.
 
 ### Store Structure
 
 ```
 src/stores/
-  appStore.ts       # activeTab, contextPanelOpen, commandPaletteOpen
-  diffStore.ts      # changedFiles, selectedFile, currentDiff
-  editorStore.ts    # fileTree, openTabs, activeTab, cursorPosition
-  chatStore.ts      # conversations, activeConversation, messages, streamingMessage
+  appStore.ts        # activeProject, sidebarCollapsed, contextPanel
+  sessionStore.ts    # sessions[], activeSession, session CRUD
+  terminalStore.ts   # terminals[], activeTerminal, terminal state per session
+  activityStore.ts   # fileChanges, toolCalls, testResults per session
 ```
 
 ### Steps
 
-1. Install Zustand, create store architecture doc
-2. Create `appStore` — migrate state from `App.tsx`
-3. Create `diffStore` — migrate from DiffView local state
-4. Create `editorStore` — migrate from EditorView local state
-5. Create `chatStore` — prepare shape for Phase 4 (streaming fields)
-6. Refactor views to use stores (one view at a time)
-7. Update tests for store-based components
+1. Install Zustand, create store architecture
+2. Create `appStore` — migrate global state from `App.tsx`
+3. Create `sessionStore` — project/session data model, CRUD operations
+4. Create `terminalStore` — manage PTY instances per session
+5. Build sidebar session list component (Discord pattern from design spec)
+6. Build icon rail with project avatars
+7. Wire session switching: click session → update terminal zone + activity panel
+8. Remove chat-related code: `ChatView`, `features/chat/`, chat types, mock messages
 
 ### Definition of Done
 
-- [ ] Zero prop drilling from `App.tsx` to views
-- [ ] Cross-feature navigation works (e.g., "open in diff" from editor)
-- [ ] All existing tests pass
-
-### Risks
-
-- Large refactor touches every view — migrate one at a time, separate PRs
+- [ ] Projects appear as avatars in icon rail
+- [ ] Sessions listed in sidebar with name, status badge, timestamp
+- [ ] Clicking a session switches the terminal and activity panel
+- [ ] New session can be created (spawns Claude Code in a PTY)
+- [ ] Chat view and all chat-related code removed
+- [ ] All tests pass, zero prop drilling
 
 ---
 
-## Phase 4: Chat Backend + AI Integration
+## Phase 4: File Watcher + Agent Activity Panel
 
-**Scope: Large | Est: 8–12 days**
+**Scope: Medium | Est: 5–7 days | Blocked by: Phase 3**
 
 ### Goal
 
-Wire Chat to a real AI backend with streaming responses, conversation persistence, and secure API key storage.
-
-### Architecture
-
-- **Streaming**: Tauri events (`app.emit` / `listen`), not invoke responses
-- **Persistence**: SQLite via `rusqlite` in `app_data_dir()`
-- **First provider**: Anthropic API via `reqwest` + SSE
-- **Credentials**: OS keychain via `keyring` crate — **never in frontend**
+Implement the Agent Activity sidebar with real-time file change tracking via Rust `notify` crate, and the always-visible usage metrics.
 
 ### Steps
 
-1. Design AI backend architecture (`docs/architecture/ai-backend.md`)
-2. Implement Rust chat commands: `create_conversation`, `send_message`, `get_conversations`
-3. Implement conversation persistence (SQLite: `conversations` + `messages` tables)
-4. Create `ChatService` interface + `TauriChatService` + `MockChatService`
-5. Build streaming message UI component
-6. Implement Anthropic provider (`reqwest` + SSE → Tauri events)
-7. Add settings system (API keys via keychain, model selection, provider choice)
+1. Add `notify` Rust crate for filesystem watching
+2. Implement Rust command: `watch_directory` (starts watcher), `unwatch_directory`
+3. Emit file change events (created/modified/deleted) via Tauri events
+4. Create `activityStore` — aggregate file changes per session
+5. Build Agent Activity panel component with collapsible sections
+6. Implement "Files Changed" section (live from file watcher)
+7. Implement always-pinned section: status card, context window smiley, 5-hour usage bar
+8. Implement collapsible "Tool Calls", "Tests", "Usage Details" sections (placeholder data for now)
+9. Wire git diff integration: click a changed file → opens in Diff context panel
 
 ### Definition of Done
 
-- [ ] User sends message → streaming AI response → persists across restarts
-- [ ] API keys stored in OS keychain (not plaintext)
-- [ ] Mock mode works for development without API keys
-- [ ] Error states handled (network failure, rate limit, invalid key)
-
-### Risks
-
-- Streaming over Tauri events may have ordering issues — add sequence numbers
-- Scope creep — one provider end-to-end first, multi-provider is Phase 6
+- [ ] File changes appear in real-time as the agent modifies files
+- [ ] Context window smiley indicator displays correctly
+- [ ] 5-hour usage bar shows progress
+- [ ] Collapsible sections expand/collapse with chevron toggle
+- [ ] Clicking a file in "Files Changed" opens it in the sidebar Diff panel
+- [ ] File watcher scoped to active session's working directory
 
 ---
 
-## Phase 5: Desktop Polish (parallel with Phase 6)
+## Phase 5: Terminal Parser + Agent Adapters
 
-**Scope: Medium | Est: 4–6 days**
+**Scope: Medium | Est: 4–6 days | Blocked by: Phase 4**
+
+### Goal
+
+Parse Claude Code's terminal output to extract structured data: tool calls, test results, agent status. Feed this into the Agent Activity panel.
+
+### Steps
+
+1. Design `AgentAdapter` interface (parse terminal output → structured events)
+2. Implement `ClaudeCodeAdapter` — parse Claude Code's stdout patterns:
+   - Tool call detection (Read, Write, Edit, Bash, etc.)
+   - Test result extraction (vitest/jest patterns)
+   - Status changes (thinking, writing, waiting for input)
+   - Context window usage (if parseable from output)
+3. Implement `GenericAdapter` fallback (no parsing, file watcher only)
+4. Wire adapter output to `activityStore`
+5. Update "Tool Calls" section with real parsed data
+6. Update "Tests" section with real parsed data
+7. Auto-expand sections on relevant events
+
+### Definition of Done
+
+- [ ] Tool calls appear in real-time as Claude Code executes them
+- [ ] Test results appear when Claude Code runs tests
+- [ ] Agent status updates (running/thinking/waiting) reflected in status card
+- [ ] Sections auto-expand when relevant events occur
+- [ ] Generic adapter works for non-Claude-Code processes (just file watcher)
+
+---
+
+## Phase 6: Context Panel Integration
+
+**Scope: Medium | Est: 4–6 days | Blocked by: Phase 3, builds on Phase 4**
+
+### Goal
+
+Wire the existing Files Explorer, Code Editor, and Git Diff views to work as context panels in the sidebar, scoped to the active session's working directory.
+
+### Steps
+
+1. Refactor IPC layer: Rust git/file commands (reuse from old Phase 2 plan)
+2. Create `TauriGitService` and `TauriFileService` (service factory pattern)
+3. Adapt Files Explorer to render in 260px sidebar width
+4. Adapt Code Editor for sidebar (compact mode) + full-width overlay
+5. Adapt Git Diff for sidebar (unified only) + full-width overlay (side-by-side)
+6. Build context switcher tab row (Files/Editor/Diff) in sidebar
+7. Scope all context panels to active session's working directory
+8. Cross-panel navigation: click file in Files → opens in Editor; click modified file → opens Diff
+
+### Definition of Done
+
+- [ ] Files/Editor/Diff panels render correctly in sidebar
+- [ ] Panels scoped to active session's working directory
+- [ ] Full-width overlay works for Editor and Diff
+- [ ] Cross-panel navigation works
+- [ ] Vite API plugins remain functional as dev fallback
+
+---
+
+## Phase 7: Usage Metrics
+
+**Scope: Small | Est: 2–3 days | Blocked by: Phase 5**
+
+### Goal
+
+Wire real usage data into the Agent Activity panel.
+
+### Steps
+
+1. Research Claude Code's usage data exposure (billing API, local logs, terminal output)
+2. Implement context window tracking (parse from terminal or estimate from adapter)
+3. Implement 5-hour window usage counter
+4. Build "Usage Details" collapsible section: weekly, monthly, cost breakdown
+5. Persist usage data locally (SQLite or JSON in app data dir)
+
+### Definition of Done
+
+- [ ] Context window smiley reflects actual usage
+- [ ] 5-hour usage counter updates in real-time
+- [ ] Usage Details section shows weekly/monthly breakdown
+- [ ] Usage persists across app restarts
+
+---
+
+## Phase 8: Desktop Polish
+
+**Scope: Medium | Est: 4–6 days | Parallel with Phase 7**
 
 - Window state persistence (`tauri-plugin-window-state`)
-- Native menu bar (platform-specific conventions)
+- Native menu bar (platform-specific)
 - System tray with show/hide and quit
 - Global keyboard shortcuts (`tauri-plugin-global-shortcut`)
 - Auto-updater (`tauri-plugin-updater` + GitHub releases)
 - Platform-specific title bar (macOS traffic lights, Windows controls)
 - Bundle fonts (Manrope, Inter, JetBrains Mono) — no CDN dependency
-
----
-
-## Phase 6: Advanced Features (parallel with Phase 5)
-
-**Scope: Large | Est: 8–12 days**
-
-- Multi-provider support (OpenAI)
-- Agent process management (spawn/monitor Claude Code, Codex CLI)
-- Conversation branching/forking
-- Workspace/project model (associate conversations with directories)
-- Export/import conversations
 
 ---
 
@@ -254,68 +268,63 @@ Wire Chat to a real AI backend with streaming responses, conversation persistenc
 Phase 1: Tauri Scaffold
     │
     ▼
-Phase 2: IPC Layer + Services ─────────┐
-    │                                   │
-    ▼                                   │
-Phase 3: State Management              │
-    │                                   │
-    ▼                                   ▼
-Phase 4: Chat + AI  ◄── (Phase 2 IPC patterns proven)
+Phase 2: Terminal Core
     │
-    ├───────┬────────┐
-    ▼       ▼        ▼
-Phase 5  Phase 6   (parallel)
+    ▼
+Phase 3: Session Management + State ───────┐
+    │                                       │
+    ▼                                       ▼
+Phase 4: File Watcher + Activity    Phase 6: Context Panels
+    │
+    ▼
+Phase 5: Terminal Parser
+    │
+    ├────────┬──────────┐
+    ▼        ▼          ▼
+Phase 7  Phase 8    (parallel)
 ```
 
 ---
 
 ## Key Architectural Decisions
 
-| Decision        | Recommendation                                        | Rationale                                                       |
-| --------------- | ----------------------------------------------------- | --------------------------------------------------------------- |
-| IPC design      | Per-feature command modules                           | Type-safe, avoids unbounded match arms                          |
-| State mgmt      | Zustand in Phase 3                                    | Too early = premature abstraction; too late = messy migration   |
-| Dev coexistence | `window.__TAURI_INTERNALS__` in factory               | `npm run dev` (web) and `npm run tauri:dev` (desktop) both work |
-| Type contracts  | Rust structs + `specta`/`ts-rs`                       | Eliminates drift between Rust and TypeScript types              |
-| Fonts           | Bundled, not CDN                                      | Desktop app must not depend on network for rendering            |
-| Diff parsing    | Raw diff from Rust, `diff2html` on frontend (Phase 2) | Simpler Rust, reuses existing frontend logic; optimize later    |
+| Decision        | Recommendation                          | Rationale                                                       |
+| --------------- | --------------------------------------- | --------------------------------------------------------------- |
+| Terminal        | xterm.js + portable-pty                 | De facto standard; matches Termio's stack                       |
+| PTY management  | One PTY per terminal tab                | Simple lifecycle; Rust owns spawn/kill                          |
+| State mgmt      | Zustand in Phase 3                      | After terminal works but before complex UI                      |
+| Agent parsing   | Adapter pattern per agent CLI           | Claude Code first; extensible to Codex, Aider                   |
+| File watching   | Rust `notify` → Tauri events            | Agent-agnostic; works regardless of which process changes files |
+| Context panels  | Sidebar (260px) + full-width overlay    | Compact view in sidebar; expand for detailed work               |
+| Session model   | Project → Sessions → Terminals          | Discord-like hierarchy; familiar mental model                   |
+| Dev coexistence | `window.__TAURI_INTERNALS__` in factory | `npm run dev` (web) and `npm run tauri:dev` both work           |
 
 ---
 
-## Security Findings
+## Security Considerations
 
-> Full report: security review conducted 2026-04-06
-
-### Pre-Migration (fix before starting Phase 1)
-
-| Severity | Issue                                                    | Action                                                    |
-| -------- | -------------------------------------------------------- | --------------------------------------------------------- |
-| MEDIUM   | If local `.env` uses plain HTTP for `ANTHROPIC_BASE_URL` | Rotate keys, switch to `https://` (verify in your `.env`) |
-| HIGH     | `baseBranch` param unvalidated in `vite.config.ts:62`    | Add `[a-zA-Z0-9/_.\-]+` allowlist, reject leading `-`     |
-| HIGH     | `hunkIndex` not type-checked in `vite.config.ts:219,301` | Rust `usize` in serde struct eliminates this structurally |
-
-### Migration Architecture
-
-| Concern            | Approach                                                                                   |
-| ------------------ | ------------------------------------------------------------------------------------------ |
-| API key storage    | OS keychain via `keyring` crate — never localStorage, never plaintext files                |
-| IPC security       | Typed Rust structs (serde) — no unbounded body reads                                       |
-| Path traversal     | `std::fs::canonicalize` + root boundary check in Rust                                      |
-| CSP                | `script-src 'self'`; `style-src 'self' 'unsafe-inline'` (Shiki needs it); no `unsafe-eval` |
-| Error messages     | Map to typed app errors in Rust — don't leak filesystem paths                              |
-| Tauri capabilities | Minimum permissions: scoped `fs:allow-read-file`, no blanket `$HOME` access                |
+| Concern            | Approach                                                           |
+| ------------------ | ------------------------------------------------------------------ |
+| PTY process mgmt   | Track all spawned processes; kill on session close / app exit      |
+| Path traversal     | `std::fs::canonicalize` + root boundary check for file operations  |
+| IPC security       | Typed Rust structs (serde) — no unbounded inputs                   |
+| CSP                | `script-src 'self'`; no `unsafe-eval`                              |
+| Tauri capabilities | Minimum permissions: scoped `fs`, `shell:allow-spawn` for PTY only |
+| File watcher scope | Restricted to session working directory, no upward traversal       |
 
 ---
 
 ## Timeline Summary
 
-| Phase             | Scope  | Est. Days | Key Deliverable                    |
-| ----------------- | ------ | --------- | ---------------------------------- |
-| 1. Tauri Scaffold | Medium | 3–5       | Native window + CI green           |
-| 2. IPC Layer      | Large  | 5–8       | Git + file ops via Tauri IPC       |
-| 3. State Mgmt     | Medium | 4–6       | Zustand stores, zero prop drilling |
-| 4. Chat + AI      | Large  | 8–12      | Streaming AI conversations         |
-| 5. Desktop Polish | Medium | 4–6       | Tray, menus, auto-update           |
-| 6. Advanced       | Large  | 8–12      | Multi-provider, agent mgmt         |
+| Phase                         | Scope  | Est. Days | Key Deliverable                       |
+| ----------------------------- | ------ | --------- | ------------------------------------- |
+| 1. Tauri Scaffold             | Medium | 3–5       | Native window + CI green              |
+| 2. Terminal Core              | Large  | 5–8       | xterm.js + PTY working                |
+| 3. Session Management + State | Medium | 5–7       | Projects, sessions, sidebar, Zustand  |
+| 4. File Watcher + Activity    | Medium | 5–7       | Agent Activity panel, real-time files |
+| 5. Terminal Parser            | Medium | 4–6       | Claude Code output → structured data  |
+| 6. Context Panels             | Medium | 4–6       | Files/Editor/Diff wired to sessions   |
+| 7. Usage Metrics              | Small  | 2–3       | Context window, billing data          |
+| 8. Desktop Polish             | Medium | 4–6       | Tray, menus, auto-update, fonts       |
 
-**Total: ~32–49 days** (critical path ~25–35 days with parallel work)
+**Total: ~32–48 days** (critical path ~24–34 days with Phase 6–8 parallel work)


### PR DESCRIPTION
## Summary

- **Rewrite roadmap** from chat-based 6 phases to terminal-first 8 phases aligned with the CLI agent workspace pivot (PR #29)
- **New phases**: Terminal Core (xterm.js + PTY), Session Management (Discord pattern), File Watcher + Agent Activity, Terminal Parser + Agent Adapters, Usage Metrics
- **Removed**: Chat Backend + AI Integration phase (replaced by terminal + agent adapter approach)
- **Kept**: Phase 1 (Tauri Scaffold) and Phase 8 (Desktop Polish) largely unchanged
- **Progress tracker**: Bumped to version 2 with all new phase/step/DoD entries

### Key Changes

| Old Phase | New Phase |
|-----------|-----------|
| Phase 2: IPC Layer | Phase 2: Terminal Core (xterm.js + portable-pty) |
| Phase 3: State Management | Phase 3: Session Management + State (project/session model) |
| Phase 4: Chat Backend + AI | Phase 4: File Watcher + Agent Activity Panel |
| Phase 5: Desktop Polish | Phase 5: Terminal Parser + Agent Adapters |
| Phase 6: Advanced Features | Phase 6: Context Panel Integration |
| — | Phase 7: Usage Metrics (new) |
| — | Phase 8: Desktop Polish |

## Test plan

- [ ] Verify roadmap phases match design spec (`docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md`)
- [ ] Confirm progress.yaml version bumped and all steps/DoD match roadmap
- [ ] Check dependency graph is consistent