### PR TITLE
fix: terminal rendering, WebGL, backspace, and progress tracker

### DIFF
--- a/docs/roadmap/progress.yaml
+++ b/docs/roadmap/progress.yaml
@@ -3,12 +3,12 @@
 # Source: docs/roadmap/tauri-migration-roadmap.md
 # Schema: phase → steps → dod (definition of done)
 # Status values: pending | in_progress | done | blocked
-# Revised: 2026-04-07 — Phase 1 done, new Phase 2 (Workspace Layout Shell) added
+# Revised: 2026-04-08 — Phase 2 done (incl. v2 design refresh), Phase 3 mostly done
 
-version: 3
-updated: '2026-04-07'
+version: 4
+updated: '2026-04-08'
 roadmap: docs/roadmap/tauri-migration-roadmap.md
-notes: 'Phase 2 (Workspace Layout Shell) completed - all 23 features passing, 92.99% test coverage'
+notes: 'Phase 2 + v2 design refresh merged (PR #31). Phase 3 terminal core mostly done (PTY backend, xterm.js, TerminalPane). Remaining: wire TauriTerminalService (issue #32).'
 
 phases:
   - id: phase-1
@@ -83,6 +83,8 @@ phases:
     specs:
       - docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
       - docs/design/agent_workspace/code.html
+      - docs/design/agent_workspace/v2/code.html
+    notes: 'Includes v2 design refresh: flat bookmark IconRail, FileExplorer-only sidebar, BottomDrawer (Editor/Diff). PR #31.'
     steps:
       - id: p2-s1
         name: 'Remove chat-related code: ChatView, features/chat/, chat types, mock messages'
@@ -188,86 +190,92 @@ phases:
 
   - id: phase-3
     name: 'Terminal Core'
-    status: pending
+    status: in_progress
     blocked_by:
       - phase-2
     specs:
       - docs/superpowers/specs/2026-04-06-cli-agent-workspace-design.md
+    notes: 'PTY backend + xterm.js frontend done in PR #31. Remaining: wire TauriTerminalService so UI uses real PTY (issue #32).'
     steps:
       - id: p3-s1
         name: 'Add `portable-pty` Rust crate for cross-platform PTY spawning'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: 'portable-pty in Cargo.toml, PtyState managed state'
       - id: p3-s2
         name: 'Implement Rust commands: pty_spawn, pty_write, pty_resize, pty_kill'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: 'src-tauri/src/terminal/commands.rs — with generation counter, IPC hardening, log redaction'
       - id: p3-s3
         name: 'Wire PTY stdout → Tauri events → frontend'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: 'read_pty_output on dedicated std::thread, emits pty-data/pty-exit/pty-error events'
       - id: p3-s4
         name: 'Wire frontend keyboard input → Tauri invoke → PTY stdin'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: 'useTerminal hook handles onData → service.write()'
       - id: p3-s5
         name: 'Add xterm.js + @xterm/addon-fit + @xterm/addon-webgl to frontend'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: '@xterm/xterm 6.x, @xterm/addon-fit, @xterm/addon-webgl'
       - id: p3-s6
         name: 'Create TerminalPane React component rendering xterm.js'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: 'TerminalPane with session caching, resize observer, WebGL renderer'
       - id: p3-s7
         name: 'Replace terminal zone placeholder with real TerminalPane'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: 'TerminalZone renders TerminalPane (still uses MockTerminalService — issue #32)'
       - id: p3-s8
         name: 'Configure Catppuccin Mocha theme for xterm.js'
-        status: pending
-        commit: null
-        pr: null
-        notes: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: 'src/features/terminal/theme/catppuccin-mocha.ts'
     dod:
       - id: p3-d1
         check: 'Can spawn a shell process and interact with it in the terminal pane'
         status: pending
         commit: null
         pr: null
+        notes: 'Rust PTY works, but UI still uses mock service — needs TauriTerminalService (issue #32)'
       - id: p3-d2
         check: 'Can run `claude` (Claude Code) in a terminal pane'
         status: pending
         commit: null
         pr: null
+        notes: 'Blocked on #32'
       - id: p3-d3
         check: 'Terminal resizes correctly when window resizes'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: 'ResizeObserver + FitAddon + pty_resize'
       - id: p3-d4
         check: 'Multiple terminal tabs work (switch between them)'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: 'Terminal caching per sessionId with dispose on unmount'
       - id: p3-d5
         check: 'PTY processes are cleaned up on tab close / app exit'
-        status: pending
-        commit: null
-        pr: null
+        status: done
+        commit: ba395c7
+        pr: 31
+        notes: 'kill_pty + generation-aware cleanup in reader thread'
 
   - id: phase-4
     name: 'Session Management + State'

--- a/src/features/terminal/components/TerminalPane.test.tsx
+++ b/src/features/terminal/components/TerminalPane.test.tsx
@@ -137,14 +137,7 @@ describe('TerminalPane', () => {
     })
   })
 
-  test('loads WebGL addon', async () => {
-    render(<TerminalPane sessionId="test-session" cwd="/home/user" />)
-
-    await waitFor(() => {
-      expect(WebglAddon).toHaveBeenCalled()
-      expect(mockTerminal.loadAddon).toHaveBeenCalledWith(mockWebglAddon)
-    })
-  })
+  // WebGL addon test removed — addon disabled due to broken WebGL2 in Tauri webview
 
   test('opens terminal in container', async () => {
     render(<TerminalPane sessionId="test-session" cwd="/home/user" />)

--- a/src/features/terminal/components/TerminalPane.tsx
+++ b/src/features/terminal/components/TerminalPane.tsx
@@ -2,7 +2,9 @@ import type { ReactElement } from 'react'
 import { useEffect, useRef, useState, useMemo } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
-import { WebglAddon } from '@xterm/addon-webgl'
+// WebGL addon disabled — causes blank terminal in Tauri's webview (WebView2/WebKit)
+// due to broken WebGL2 context. Canvas2D renderer works fine. Re-enable with feature flag
+// when WebGL support is confirmed on all target platforms.
 import { catppuccinMocha, toXtermTheme } from '../theme/catppuccin-mocha'
 import { useTerminal } from '../hooks/useTerminal'
 import {
@@ -160,19 +162,6 @@ export const TerminalPane = ({
       fitAddon = new FitAddon()
       newTerminal.loadAddon(fitAddon)
       fitAddonRef.current = fitAddon
-
-      // Try to load WebGL addon (graceful degradation if not supported)
-      try {
-        const webglAddon = new WebglAddon()
-        newTerminal.loadAddon(webglAddon)
-        webglAddon.onContextLoss(() => {
-          webglAddon.dispose()
-        })
-      } catch (error) {
-        // WebGL not supported - continue with canvas renderer
-        // Error intentionally ignored for graceful degradation
-        void error
-      }
 
       // Open terminal in container
       newTerminal.open(containerRef.current)

--- a/src/features/terminal/components/TerminalPane.tsx
+++ b/src/features/terminal/components/TerminalPane.tsx
@@ -75,7 +75,7 @@ export interface TerminalPaneProps {
  * Features:
  * - Catppuccin Mocha theme
  * - Responsive sizing with fit addon
- * - Hardware-accelerated rendering with WebGL addon
+ * - Canvas2D renderer (WebGL disabled — broken in Tauri webview)
  * - PTY process spawning and lifecycle management
  * - Bidirectional data flow (xterm ↔ PTY)
  * - Automatic cleanup on unmount

--- a/src/features/terminal/services/terminalService.test.ts
+++ b/src/features/terminal/services/terminalService.test.ts
@@ -63,7 +63,7 @@ describe('MockTerminalService', () => {
   })
 
   describe('write', () => {
-    test('echoes input back', async () => {
+    test('echoes each character individually', async () => {
       const { sessionId } = await service.spawn({
         shell: '/bin/bash',
         cwd: '/home/user',
@@ -74,7 +74,11 @@ describe('MockTerminalService', () => {
 
       await service.write({ sessionId, data: 'hello' })
 
-      expect(onData).toHaveBeenCalledWith(sessionId, 'hello')
+      // Per-character processing: each char emitted separately
+      expect(onData).toHaveBeenCalledWith(sessionId, 'h')
+      expect(onData).toHaveBeenCalledWith(sessionId, 'e')
+      expect(onData).toHaveBeenCalledWith(sessionId, 'o')
+      expect(onData).toHaveBeenCalledTimes(5)
     })
 
     test('simulates echo command output on Enter', async () => {
@@ -116,7 +120,7 @@ describe('MockTerminalService', () => {
       expect(onData).toHaveBeenCalledWith(sessionId, '/home/user\r\n$ ')
     })
 
-    test('handles backspace', async () => {
+    test('handles backspace by removing last buffered character', async () => {
       const { sessionId } = await service.spawn({
         shell: '/bin/bash',
         cwd: '/home/user',
@@ -125,9 +129,29 @@ describe('MockTerminalService', () => {
       const onData = vi.fn()
       service.onData(onData)
 
+      // Type a character first so the buffer isn't empty
+      await service.write({ sessionId, data: 'a' })
+      onData.mockClear()
+
+      // Backspace should erase the character
       await service.write({ sessionId, data: '\x7f' })
 
       expect(onData).toHaveBeenCalledWith(sessionId, '\b \b')
+    })
+
+    test('ignores backspace on empty buffer', async () => {
+      const { sessionId } = await service.spawn({
+        shell: '/bin/bash',
+        cwd: '/home/user',
+      })
+
+      const onData = vi.fn()
+      service.onData(onData)
+
+      // Backspace on empty buffer should be a no-op
+      await service.write({ sessionId, data: '\x7f' })
+
+      expect(onData).not.toHaveBeenCalled()
     })
 
     test('throws error for non-existent session', async () => {

--- a/src/features/terminal/services/terminalService.test.ts
+++ b/src/features/terminal/services/terminalService.test.ts
@@ -77,7 +77,7 @@ describe('MockTerminalService', () => {
       expect(onData).toHaveBeenCalledWith(sessionId, 'hello')
     })
 
-    test('simulates echo command output', async () => {
+    test('simulates echo command output on Enter', async () => {
       const { sessionId } = await service.spawn({
         shell: '/bin/bash',
         cwd: '/home/user',
@@ -86,15 +86,18 @@ describe('MockTerminalService', () => {
       const onData = vi.fn()
       service.onData(onData)
 
-      await service.write({ sessionId, data: 'echo hello' })
+      // Type characters then press Enter
+      for (const ch of 'echo hello') {
+        await service.write({ sessionId, data: ch })
+      }
 
+      await service.write({ sessionId, data: '\r' })
       await new Promise((resolve) => setTimeout(resolve, 100))
 
-      expect(onData).toHaveBeenCalledWith(sessionId, 'echo hello')
       expect(onData).toHaveBeenCalledWith(sessionId, 'hello\r\n$ ')
     })
 
-    test('simulates pwd command output', async () => {
+    test('simulates pwd command output on Enter', async () => {
       const { sessionId } = await service.spawn({
         shell: '/bin/bash',
         cwd: '/home/user',
@@ -103,12 +106,28 @@ describe('MockTerminalService', () => {
       const onData = vi.fn()
       service.onData(onData)
 
-      await service.write({ sessionId, data: 'pwd' })
+      for (const ch of 'pwd') {
+        await service.write({ sessionId, data: ch })
+      }
 
+      await service.write({ sessionId, data: '\r' })
       await new Promise((resolve) => setTimeout(resolve, 100))
 
-      expect(onData).toHaveBeenCalledWith(sessionId, 'pwd')
       expect(onData).toHaveBeenCalledWith(sessionId, '/home/user\r\n$ ')
+    })
+
+    test('handles backspace', async () => {
+      const { sessionId } = await service.spawn({
+        shell: '/bin/bash',
+        cwd: '/home/user',
+      })
+
+      const onData = vi.fn()
+      service.onData(onData)
+
+      await service.write({ sessionId, data: '\x7f' })
+
+      expect(onData).toHaveBeenCalledWith(sessionId, '\b \b')
     })
 
     test('throws error for non-existent session', async () => {

--- a/src/features/terminal/services/terminalService.test.ts
+++ b/src/features/terminal/services/terminalService.test.ts
@@ -154,6 +154,27 @@ describe('MockTerminalService', () => {
       expect(onData).not.toHaveBeenCalled()
     })
 
+    test('CRLF input executes command only once', async () => {
+      const { sessionId } = await service.spawn({
+        shell: '/bin/bash',
+        cwd: '/home/user',
+      })
+
+      const onData = vi.fn()
+      service.onData(onData)
+
+      // Pasted text with CRLF should only trigger one command execution
+      await service.write({ sessionId, data: 'pwd\r\n' })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Count how many times the prompt '$ ' was emitted (should be exactly 1)
+      const promptCalls = onData.mock.calls.filter(
+        ([, d]) => d === '/home/user\r\n$ '
+      )
+
+      expect(promptCalls).toHaveLength(1)
+    })
+
     test('throws error for non-existent session', async () => {
       await expect(
         service.write({ sessionId: 'invalid', data: 'test' })

--- a/src/features/terminal/services/terminalService.ts
+++ b/src/features/terminal/services/terminalService.ts
@@ -56,7 +56,10 @@ export interface ITerminalService {
 export class MockTerminalService implements ITerminalService {
   private nextPid = 1000
   private nextSessionId = 1
-  private sessions = new Map<string, { pid: number; running: boolean }>()
+  private sessions = new Map<
+    string,
+    { pid: number; running: boolean; inputBuffer: string }
+  >()
   private dataCallbacks: ((sessionId: string, data: string) => void)[] = []
   private exitCallbacks: ((
     sessionId: string,
@@ -76,7 +79,7 @@ export class MockTerminalService implements ITerminalService {
     const sessionId = `mock-session-${this.nextSessionId++}`
     const pid = this.nextPid++
 
-    this.sessions.set(sessionId, { pid, running: true })
+    this.sessions.set(sessionId, { pid, running: true, inputBuffer: '' })
 
     // Simulate initial prompt
     setTimeout(() => {
@@ -94,23 +97,60 @@ export class MockTerminalService implements ITerminalService {
       )
     }
 
-    // Echo input back
-    this.emitData(params.sessionId, params.data)
+    const { data } = params
 
-    // Simulate command output for common commands
-    if (params.data.trim() === 'echo hello') {
-      setTimeout(() => {
-        this.emitData(params.sessionId, 'hello\r\n$ ')
-      }, 50)
-    } else if (params.data.trim() === 'pwd') {
-      setTimeout(() => {
-        this.emitData(params.sessionId, '/home/user\r\n$ ')
-      }, 50)
-    } else if (params.data.includes('\r') || params.data.includes('\n')) {
-      setTimeout(() => {
-        this.emitData(params.sessionId, '$ ')
-      }, 50)
+    // Handle backspace/delete (real shells do this via line discipline)
+    if (data === '\x7f' || data === '\b') {
+      this.emitData(params.sessionId, '\b \b')
+
+      return Promise.resolve()
     }
+
+    // Handle Enter — execute "command" and show new prompt
+    if (data === '\r' || data === '\n') {
+      this.emitData(params.sessionId, '\r\n')
+
+      // Simulate command output for common commands
+      const cmd = session.inputBuffer.trim()
+      if (cmd === 'echo hello') {
+        setTimeout(() => {
+          this.emitData(params.sessionId, 'hello\r\n$ ')
+        }, 50)
+      } else if (cmd === 'pwd') {
+        setTimeout(() => {
+          this.emitData(params.sessionId, '/home/user\r\n$ ')
+        }, 50)
+      } else if (cmd === 'help') {
+        setTimeout(() => {
+          this.emitData(
+            params.sessionId,
+            'Mock terminal — commands: echo hello, pwd, help, clear\r\n$ '
+          )
+        }, 50)
+      } else if (cmd === 'clear') {
+        this.emitData(params.sessionId, '\x1b[2J\x1b[H$ ')
+      } else if (cmd.length > 0) {
+        setTimeout(() => {
+          this.emitData(
+            params.sessionId,
+            `mock: command not found: ${cmd}\r\n$ `
+          )
+        }, 50)
+      } else {
+        setTimeout(() => {
+          this.emitData(params.sessionId, '$ ')
+        }, 50)
+      }
+
+      // Reset input buffer
+      session.inputBuffer = ''
+
+      return Promise.resolve()
+    }
+
+    // Regular character — echo and buffer
+    session.inputBuffer = session.inputBuffer + data
+    this.emitData(params.sessionId, data)
 
     return Promise.resolve()
   }

--- a/src/features/terminal/services/terminalService.ts
+++ b/src/features/terminal/services/terminalService.ts
@@ -97,8 +97,11 @@ export class MockTerminalService implements ITerminalService {
       )
     }
 
+    // Normalize CRLF to LF to prevent double-execution on pasted text
+    const normalized = params.data.replace(/\r\n/g, '\n')
+
     // Process each character individually to handle pasted text and buffered input
-    for (const ch of params.data) {
+    for (const ch of normalized) {
       this.processChar(params.sessionId, session, ch)
     }
 

--- a/src/features/terminal/services/terminalService.ts
+++ b/src/features/terminal/services/terminalService.ts
@@ -97,62 +97,75 @@ export class MockTerminalService implements ITerminalService {
       )
     }
 
-    const { data } = params
-
-    // Handle backspace/delete (real shells do this via line discipline)
-    if (data === '\x7f' || data === '\b') {
-      this.emitData(params.sessionId, '\b \b')
-
-      return Promise.resolve()
+    // Process each character individually to handle pasted text and buffered input
+    for (const ch of params.data) {
+      this.processChar(params.sessionId, session, ch)
     }
-
-    // Handle Enter — execute "command" and show new prompt
-    if (data === '\r' || data === '\n') {
-      this.emitData(params.sessionId, '\r\n')
-
-      // Simulate command output for common commands
-      const cmd = session.inputBuffer.trim()
-      if (cmd === 'echo hello') {
-        setTimeout(() => {
-          this.emitData(params.sessionId, 'hello\r\n$ ')
-        }, 50)
-      } else if (cmd === 'pwd') {
-        setTimeout(() => {
-          this.emitData(params.sessionId, '/home/user\r\n$ ')
-        }, 50)
-      } else if (cmd === 'help') {
-        setTimeout(() => {
-          this.emitData(
-            params.sessionId,
-            'Mock terminal — commands: echo hello, pwd, help, clear\r\n$ '
-          )
-        }, 50)
-      } else if (cmd === 'clear') {
-        this.emitData(params.sessionId, '\x1b[2J\x1b[H$ ')
-      } else if (cmd.length > 0) {
-        setTimeout(() => {
-          this.emitData(
-            params.sessionId,
-            `mock: command not found: ${cmd}\r\n$ `
-          )
-        }, 50)
-      } else {
-        setTimeout(() => {
-          this.emitData(params.sessionId, '$ ')
-        }, 50)
-      }
-
-      // Reset input buffer
-      session.inputBuffer = ''
-
-      return Promise.resolve()
-    }
-
-    // Regular character — echo and buffer
-    session.inputBuffer = session.inputBuffer + data
-    this.emitData(params.sessionId, data)
 
     return Promise.resolve()
+  }
+
+  private processChar(
+    sessionId: string,
+    session: { pid: number; running: boolean; inputBuffer: string },
+    ch: string
+  ): void {
+    // Backspace/delete — erase last character from buffer
+    if (ch === '\x7f' || ch === '\b') {
+      if (session.inputBuffer.length > 0) {
+        session.inputBuffer = session.inputBuffer.slice(0, -1)
+        this.emitData(sessionId, '\b \b')
+      }
+
+      return
+    }
+
+    // Enter — execute buffered command
+    if (ch === '\r' || ch === '\n') {
+      this.emitData(sessionId, '\r\n')
+      this.executeCommand(sessionId, session)
+
+      return
+    }
+
+    // Regular character — echo and append to buffer
+    session.inputBuffer = session.inputBuffer + ch
+    this.emitData(sessionId, ch)
+  }
+
+  private executeCommand(
+    sessionId: string,
+    session: { pid: number; running: boolean; inputBuffer: string }
+  ): void {
+    const cmd = session.inputBuffer.trim()
+    session.inputBuffer = ''
+
+    if (cmd === 'echo hello') {
+      setTimeout(() => {
+        this.emitData(sessionId, 'hello\r\n$ ')
+      }, 50)
+    } else if (cmd === 'pwd') {
+      setTimeout(() => {
+        this.emitData(sessionId, '/home/user\r\n$ ')
+      }, 50)
+    } else if (cmd === 'help') {
+      setTimeout(() => {
+        this.emitData(
+          sessionId,
+          'Mock terminal — commands: echo hello, pwd, help, clear\r\n$ '
+        )
+      }, 50)
+    } else if (cmd === 'clear') {
+      this.emitData(sessionId, '\x1b[2J\x1b[H$ ')
+    } else if (cmd.length > 0) {
+      setTimeout(() => {
+        this.emitData(sessionId, `mock: command not found: ${cmd}\r\n$ `)
+      }, 50)
+    } else {
+      setTimeout(() => {
+        this.emitData(sessionId, '$ ')
+      }, 50)
+    }
   }
 
   resize(params: PTYResizeParams): Promise<void> {

--- a/src/features/workspace/components/BottomDrawer.tsx
+++ b/src/features/workspace/components/BottomDrawer.tsx
@@ -17,7 +17,7 @@ const BottomDrawer = (): ReactElement => {
   return (
     <section
       data-testid="bottom-drawer"
-      className="h-1/3 bg-slate-900/95 backdrop-blur-2xl border-t border-white/5 flex flex-col z-30"
+      className="h-1/3 shrink-0 bg-slate-900/95 backdrop-blur-2xl border-t border-white/5 flex flex-col z-30"
     >
       {/* Tab Bar */}
       <div className="flex items-center px-8 h-12 bg-surface-container justify-between">

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -201,7 +201,8 @@ describe('TerminalZone', () => {
 
     expect(rootElement).toHaveClass('flex')
     expect(rootElement).toHaveClass('flex-col')
-    expect(rootElement).toHaveClass('h-full')
+    expect(rootElement).toHaveClass('flex-1')
+    expect(rootElement).toHaveClass('min-h-0')
   })
 
   // TerminalPane integration tests (Feature #30)

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -22,7 +22,7 @@ export const TerminalZone = ({
   }
 
   return (
-    <div data-testid="terminal-zone" className="flex h-full flex-col">
+    <div data-testid="terminal-zone" className="flex min-h-0 flex-1 flex-col">
       {/* Tab bar */}
       <div
         data-testid="tab-bar"

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -63,8 +63,11 @@ export const TerminalZone = ({
         </button>
       </div>
 
-      {/* Terminal content area */}
-      <div data-testid="terminal-content" className="flex-1 bg-surface">
+      {/* Terminal content area — relative + absolute inner to give xterm explicit dimensions */}
+      <div
+        data-testid="terminal-content"
+        className="relative min-h-0 flex-1 bg-surface"
+      >
         {sessions.length === 0 ? (
           <div className="flex h-full items-center justify-center font-mono text-on-surface/60">
             <p>No active session. Click + to create a new terminal.</p>
@@ -80,7 +83,7 @@ export const TerminalZone = ({
                 data-testid="terminal-pane"
                 data-session-id={session.id}
                 data-cwd={session.workingDirectory}
-                className={`h-full ${isActive ? '' : 'hidden'}`}
+                className={`absolute inset-0 ${isActive ? '' : 'hidden'}`}
               >
                 <TerminalPane
                   sessionId={session.id}


### PR DESCRIPTION
## Summary

- Fix terminal zone 0-height collapse — use `flex-1 min-h-0` + `absolute inset-0` for xterm container
- Disable WebGL addon — causes blank terminal in Tauri webview (broken WebGL2 context)
- Fix MockTerminalService: backspace support (`\x7f` → `\b \b`), per-character input buffering, command execution on Enter
- Add mock commands: `help`, `clear`, `command-not-found` feedback
- Update progress tracker for Phase 2 v2 + Phase 3 terminal core status

## Root cause

WebGL addon loaded successfully (no exception) but the WebGL2 context was silently broken in Tauri's webview (WebView2 on Windows, WebKit on Linux/macOS). xterm.js rendered to a canvas that never painted. Disabling WebGL falls back to canvas2D which works correctly.

## Test plan

- [ ] `npm run tauri:dev` shows terminal with `$ ` prompt
- [ ] Can type in terminal, characters echo
- [ ] Backspace erases characters
- [ ] `help`, `pwd`, `echo hello`, `clear` commands work
- [ ] `npm run lint` passes
- [ ] `npm run test` passes (1199 tests)