### PR TITLE
docs: rewrite README for current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,65 +2,161 @@
 
 <div align="center">
 
+**A CLI Agent Control Plane for the Terminal-First Era**
+
 🇺🇸 English | [🇨🇳 简体中文](./README.zh-CN.md)
 
 </div>
 
-> An experiment in **Harness-Engineered, AI-Native Development** — where autonomous agent loops build the application from specification to implementation, governed by layered rules and specialized agents.
+> A Tauri desktop app that unifies terminal sessions, file explorer, code editor, and git diff into a single workspace — purpose-built for AI coding agents like Claude Code.
 
-Vimeflow is a coding agent conversation manager built as a Tauri desktop app (Rust + React/TypeScript). But the product itself is secondary to the process: this repository is a testbed for exploring how far autonomous development harnesses can go when given well-structured specifications, safety guardrails, and progressive disclosure documentation.
+Vimeflow is a **CLI coding agent control plane** built with Tauri 2 (Rust + React/TypeScript). It gives you one window to manage terminal sessions where AI agents work, browse files, review diffs, and edit code — all with vim-style keybindings and a dark atmospheric UI.
 
-## What Makes This AI-Native
+But the product is only half the story. This repository is also a testbed for **harness-engineered, AI-native development**: an autonomous agent loop builds features from specification, governed by layered rules and specialized agents.
 
-Traditional projects have humans write code and AI assist. Vimeflow inverts this:
+## What's Built
 
-1. **Humans write specs** — product requirements, design system, development rules
-2. **An autonomous harness builds features** — a two-agent loop (Initializer + Coder) decomposes specs into feature lists and implements them incrementally
-3. **Specialized agents review the work** — 10 AI agents handle planning, TDD, code review, security, and documentation
-4. **Rules govern everything** — a hierarchical rule system (common + language-specific) ensures consistency without human intervention per commit
+### Terminal Core (Phase 3 — Latest)
 
-The CI/CD infrastructure, linter configuration, and git hooks already in this repository were all built by the harness from an `app_spec.md` specification.
+Full xterm.js terminal integrated with a Tauri Rust PTY backend:
+
+- **TauriTerminalService** — singleton IPC bridge between xterm.js and `portable-pty`
+- Rust PTY commands: spawn, write, resize, kill — with stdout streamed via Tauri events
+- Session caching per tab, multi-tab terminal support
+- ResizeObserver + FitAddon for responsive terminal sizing
+- WebGL renderer with Catppuccin Mocha theme
+
+### Workspace Layout (Phase 2)
+
+A 4-zone grid layout inspired by IDE + terminal multiplexer patterns:
+
+- **Icon Rail** — project avatars and navigation
+- **Sidebar** — session list with status indicators
+- **Terminal Zone** — primary workspace area (xterm.js terminals)
+- **Agent Activity Panel** — status, metrics, collapsible sections
+- **Context Switcher** — Files / Editor / Diff tabs in a top tab bar
+
+### Feature Modules
+
+| Module | Description |
+|--------|-------------|
+| **terminal** | xterm.js + Tauri PTY IPC bridge, session management |
+| **editor** | IDE-style tabbed editor with Shiki syntax highlighting, vim status bar |
+| **diff** | Lazygit-style git diff viewer (side-by-side + unified, hunk navigation, stage/discard) |
+| **files** | File explorer tree with breadcrumbs, git status badges (M/A/D/U), drag-and-drop |
+| **command-palette** | Vim-style `:command` palette with fuzzy matching and nested command tree |
+| **workspace** | Layout shell composing all zones above |
+
+### Quality
+
+- **1125+ tests** passing with **92%+ coverage**
+- Accessibility-first test queries (`getByRole` over `getByText`)
+- Pre-commit hooks: ESLint + Prettier on staged files
+- Commit-msg hook: conventional commits via commitlint
+- Pre-push hook: full Vitest run
+
+## Tech Stack
+
+| Layer | Technologies |
+|-------|-------------|
+| **Desktop** | Tauri 2, Rust, portable-pty, tokio |
+| **Frontend** | React 19, TypeScript 5 (strict), Vite |
+| **Styling** | Tailwind CSS v4, Catppuccin Mocha semantic tokens |
+| **Terminal** | xterm.js 6, WebGL addon, FitAddon |
+| **Editor** | Shiki 4 (syntax highlighting) |
+| **Animation** | Framer Motion 12 |
+| **Testing** | Vitest 3, Testing Library |
+| **Quality** | ESLint 9 (flat config), Prettier 3, Husky, commitlint |
+| **Git** | simple-git 3, diff2html 3 |
+
+## Design System: "The Obsidian Lens"
+
+Dark atmospheric UI built on the Catppuccin Mocha palette — treats UI as illuminated, translucent layers within a deep void.
+
+- **No visible borders** — use tonal depth and surface hierarchy (8 levels)
+- **Glassmorphism** for floating elements (60-80% opacity, 12-20px blur)
+- **Typography**: Manrope (headlines), Inter (body/labels), JetBrains Mono (code)
+- **Semantic tokens**: `bg-surface-container`, `text-on-surface`, `text-primary`, etc.
+
+Full spec: [`docs/design/DESIGN.md`](docs/design/DESIGN.md)
+
+## Quick Start
+
+```bash
+# Prerequisites: Node >= 24, Rust toolchain
+nvm use                          # Uses .nvmrc
+
+# Frontend only (no Tauri backend)
+npm install
+npm run dev                      # Vite dev server at localhost:1420
+
+# Full desktop app (requires Rust)
+npm run tauri:dev                # Tauri + Rust backend
+
+# Tests
+npm test                         # 1125+ tests
+npx vitest run src/path/file.test.tsx  # Single file
+
+# Quality
+npm run lint                     # ESLint (type-checked)
+npm run format:check             # Prettier check
+npm run type-check               # tsc -b
+```
 
 ## Repository Structure
 
 ```
-CLAUDE.md           <- AI navigation hub (start here for agents)
-README.md           <- You are here (for humans)
-DEVELOPMENT.md      <- Commands, tech stack, code style
-ARCHITECT.md        <- Architecture decisions, Tauri patterns
-DESIGN.md           <- UI design system (Obsidian Lens / Catppuccin Mocha)
+CLAUDE.md                   # AI navigation hub (agents start here)
+ARCHITECT.md                # Architecture decisions, Tauri IPC patterns
+docs/design/DESIGN.md       # UI design system (single source of truth)
 
-agents/             <- 10 specialized AI agent definitions
-rules/              <- Hierarchical development standards (common + TS + Rust)
-harness/            <- Autonomous development loop (Claude Code SDK, Python)
-docs/design/        <- Screen mockups, Stitch HTML/CSS, design spec
+src/
+├── features/
+│   ├── terminal/           # xterm.js + TauriTerminalService IPC bridge
+│   ├── editor/             # Tabbed code editor with Shiki
+│   ├── diff/               # Lazygit-style diff viewer
+│   ├── files/              # File explorer tree
+│   ├── command-palette/    # Vim-style command palette
+│   └── workspace/          # 4-zone layout shell
+├── components/layout/      # Shared layout (IconRail, Sidebar, TopTabBar, ContextPanel)
+└── test/                   # Vitest setup
+
+src-tauri/
+├── src/
+│   ├── main.rs             # Tauri entry point
+│   ├── lib.rs              # Library setup
+│   └── terminal/           # PTY commands, state, types
+├── Cargo.toml              # Rust dependencies
+└── tauri.conf.json         # Tauri configuration
+
+agents/                     # 10 specialized AI agent definitions
+rules/                      # Hierarchical dev standards (common + TS + Rust)
+harness/                    # Autonomous dev loop (Claude Code SDK, Python)
 ```
 
-## The Harness
+## The AI-Native Development Process
 
-The autonomous development harness (`harness/`) is the engine of this experiment. It is a Python-based loop built on the Claude Code SDK:
+Traditional projects have humans write code and AI assist. Vimeflow inverts this:
 
-- **Initializer agent** reads `app_spec.md` and decomposes it into a phased `feature_list.json`
-- **Coder agent** picks the next pending feature, implements it, marks it done, and auto-continues
-- **Safety layers** include a bash command allowlist, sandboxed execution, and write-protection on the feature list
+1. **Humans write specs** — product requirements, design system, development rules
+2. **An autonomous harness builds features** — a two-agent loop (Initializer + Coder) decomposes specs into a feature list and implements them incrementally
+3. **Specialized agents review the work** — 10 AI agents handle planning, TDD, code review, security, and documentation
+4. **Rules govern everything** — a hierarchical rule system (common + language-specific) ensures consistency without human intervention per commit
 
-```bash
-cd harness && pip install -r requirements.txt
-python autonomous_agent_demo.py                    # Unlimited iterations
-python autonomous_agent_demo.py --max-iterations 5 # Capped
-```
+The harness (`harness/`) is a Python-based loop built on the Claude Code SDK. See [`harness/CLAUDE.md`](harness/CLAUDE.md) for details.
 
-See `harness/CLAUDE.md` for the full details.
+## Roadmap
 
-## Current Status
+| Phase | Status | Description |
+|-------|--------|-------------|
+| Phase 1 | Done | Tauri scaffold, Rust compilation, CI green |
+| Phase 2 | Done | Workspace layout shell (4-zone grid, all components) |
+| Phase 3 | Done | Terminal core (xterm.js + Tauri PTY IPC) |
+| Phase 4 | Next | Session management + Zustand state |
+| Phase 5+ | Planned | Real git ops, AI agent output streaming, drag-and-drop |
 
-**Phase: Foundation / Pre-implementation**
+Progress tracked in [`docs/roadmap/progress.yaml`](docs/roadmap/progress.yaml).
 
-- Development rules, agent specs, and CI/CD tooling are established
-- Design system (5 screens) specified via Google Stitch
-- Application code (Tauri scaffolding, `src/`, `src-tauri/`) does not exist yet
-- Next: harness builds the app from the design spec
+## License
 
-## Tech Stack
-
-Tauri 2 (Rust backend + web frontend) | React 19 + TypeScript | Vitest + Playwright | ESLint + Prettier | Husky + commitlint | GitHub Actions CI/CD
+MIT

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ A 4-zone grid layout inspired by IDE + terminal multiplexer patterns:
 
 ### Feature Modules
 
-| Module | Description |
-|--------|-------------|
-| **terminal** | xterm.js + Tauri PTY IPC bridge, session management |
-| **editor** | IDE-style tabbed editor with Shiki syntax highlighting, vim status bar |
-| **diff** | Lazygit-style git diff viewer (side-by-side + unified, hunk navigation, stage/discard) |
-| **files** | File explorer tree with breadcrumbs, git status badges (M/A/D/U), drag-and-drop |
-| **command-palette** | Vim-style `:command` palette with fuzzy matching and nested command tree |
-| **workspace** | Layout shell composing all zones above |
+| Module              | Description                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| **terminal**        | xterm.js + Tauri PTY IPC bridge, session management                                    |
+| **editor**          | IDE-style tabbed editor with Shiki syntax highlighting, vim status bar                 |
+| **diff**            | Lazygit-style git diff viewer (side-by-side + unified, hunk navigation, stage/discard) |
+| **files**           | File explorer tree with breadcrumbs, git status badges (M/A/D/U), drag-and-drop        |
+| **command-palette** | Vim-style `:command` palette with fuzzy matching and nested command tree               |
+| **workspace**       | Layout shell composing all zones above                                                 |
 
 ### Quality
 
@@ -57,17 +57,17 @@ A 4-zone grid layout inspired by IDE + terminal multiplexer patterns:
 
 ## Tech Stack
 
-| Layer | Technologies |
-|-------|-------------|
-| **Desktop** | Tauri 2, Rust, portable-pty, tokio |
-| **Frontend** | React 19, TypeScript 5 (strict), Vite |
-| **Styling** | Tailwind CSS v4, Catppuccin Mocha semantic tokens |
-| **Terminal** | xterm.js 6, WebGL addon, FitAddon |
-| **Editor** | Shiki 4 (syntax highlighting) |
-| **Animation** | Framer Motion 12 |
-| **Testing** | Vitest 3, Testing Library |
-| **Quality** | ESLint 9 (flat config), Prettier 3, Husky, commitlint |
-| **Git** | simple-git 3, diff2html 3 |
+| Layer         | Technologies                                          |
+| ------------- | ----------------------------------------------------- |
+| **Desktop**   | Tauri 2, Rust, portable-pty, tokio                    |
+| **Frontend**  | React 19, TypeScript 5 (strict), Vite                 |
+| **Styling**   | Tailwind CSS v4, Catppuccin Mocha semantic tokens     |
+| **Terminal**  | xterm.js 6, WebGL addon, FitAddon                     |
+| **Editor**    | Shiki 4 (syntax highlighting)                         |
+| **Animation** | Framer Motion 12                                      |
+| **Testing**   | Vitest 3, Testing Library                             |
+| **Quality**   | ESLint 9 (flat config), Prettier 3, Husky, commitlint |
+| **Git**       | simple-git 3, diff2html 3                             |
 
 ## Design System: "The Obsidian Lens"
 
@@ -147,12 +147,12 @@ The harness (`harness/`) is a Python-based loop built on the Claude Code SDK. Se
 
 ## Roadmap
 
-| Phase | Status | Description |
-|-------|--------|-------------|
-| Phase 1 | Done | Tauri scaffold, Rust compilation, CI green |
-| Phase 2 | Done | Workspace layout shell (4-zone grid, all components) |
-| Phase 3 | Done | Terminal core (xterm.js + Tauri PTY IPC) |
-| Phase 4 | Next | Session management + Zustand state |
+| Phase    | Status  | Description                                            |
+| -------- | ------- | ------------------------------------------------------ |
+| Phase 1  | Done    | Tauri scaffold, Rust compilation, CI green             |
+| Phase 2  | Done    | Workspace layout shell (4-zone grid, all components)   |
+| Phase 3  | Done    | Terminal core (xterm.js + Tauri PTY IPC)               |
+| Phase 4  | Next    | Session management + Zustand state                     |
 | Phase 5+ | Planned | Real git ops, AI agent output streaming, drag-and-drop |
 
 Progress tracked in [`docs/roadmap/progress.yaml`](docs/roadmap/progress.yaml).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,15 +2,139 @@
 
 <div align="center">
 
+**终端优先时代的 CLI Agent 控制面板**
+
 [English](./README.md) | 简体中文
 
 </div>
 
-> 一个关于**工程化 AI 原生开发**的实验 — 自主代理循环从规格说明到实现，全程由分层规则和专业代理管控，构建整个应用程序。
+> 一个 Tauri 桌面应用，将终端会话、文件浏览器、代码编辑器和 Git Diff 统一到一个工作空间 — 专为 Claude Code 等 AI 编码代理打造。
 
-Vimeflow 是一个编码代理对话管理器，采用 Tauri 桌面应用（Rust + React/TypeScript）构建。但产品本身是次要的，真正的重点在于过程：这个仓库是一个试验场，探索当自主开发引擎拥有结构化规格说明、安全防护栏和渐进式文档时，能走多远。
+Vimeflow 是一个 **CLI 编码代理控制面板**，基于 Tauri 2（Rust + React/TypeScript）构建。它在一个窗口内管理 AI 代理工作的终端会话、浏览文件、审查 Diff 和编辑代码 — 全部配备 Vim 风格快捷键和暗色氛围 UI。
 
-## 为什么说这是 AI 原生
+但产品只是故事的一半。这个仓库也是**工程化 AI 原生开发**的试验场：自主代理循环从规格说明构建功能，由分层规则和专业代理管控。
+
+## 已实现功能
+
+### 终端核心（第 3 阶段 — 最新）
+
+完整的 xterm.js 终端，集成 Tauri Rust PTY 后端：
+
+- **TauriTerminalService** — xterm.js 与 `portable-pty` 之间的单例 IPC 桥接
+- Rust PTY 命令：spawn、write、resize、kill — stdout 通过 Tauri 事件流式传输
+- 按标签页缓存会话，支持多标签终端
+- ResizeObserver + FitAddon 实现响应式终端尺寸
+- WebGL 渲染器 + Catppuccin Mocha 主题
+
+### 工作空间布局（第 2 阶段）
+
+借鉴 IDE + 终端复用器模式的 4 区网格布局：
+
+- **图标栏** — 项目头像和导航
+- **侧边栏** — 会话列表和状态指示器
+- **终端区** — 主工作区域（xterm.js 终端）
+- **代理活动面板** — 状态、指标、可折叠区域
+- **上下文切换器** — 文件 / 编辑器 / Diff 标签页
+
+### 功能模块
+
+| 模块 | 描述 |
+|------|------|
+| **terminal** | xterm.js + Tauri PTY IPC 桥接，会话管理 |
+| **editor** | IDE 风格标签编辑器，Shiki 语法高亮，Vim 状态栏 |
+| **diff** | Lazygit 风格 Git Diff 查看器（并排 + 统一视图，hunk 导航，暂存/丢弃） |
+| **files** | 文件浏览树，面包屑导航，Git 状态徽章（M/A/D/U），拖放支持 |
+| **command-palette** | Vim 风格 `:command` 命令面板，模糊匹配，嵌套命令树 |
+| **workspace** | 组合以上所有区域的布局外壳 |
+
+### 质量保障
+
+- **1125+ 测试**通过，**92%+ 覆盖率**
+- 无障碍优先的测试查询（`getByRole` 优于 `getByText`）
+- Pre-commit 钩子：对暂存文件运行 ESLint + Prettier
+- Commit-msg 钩子：commitlint 约定式提交
+- Pre-push 钩子：完整 Vitest 运行
+
+## 技术栈
+
+| 层级 | 技术 |
+|------|------|
+| **桌面** | Tauri 2、Rust、portable-pty、tokio |
+| **前端** | React 19、TypeScript 5（严格模式）、Vite |
+| **样式** | Tailwind CSS v4、Catppuccin Mocha 语义化 Token |
+| **终端** | xterm.js 6、WebGL addon、FitAddon |
+| **编辑器** | Shiki 4（语法高亮） |
+| **动画** | Framer Motion 12 |
+| **测试** | Vitest 3、Testing Library |
+| **质量** | ESLint 9（flat config）、Prettier 3、Husky、commitlint |
+| **Git** | simple-git 3、diff2html 3 |
+
+## 设计系统："黑曜石之眼"
+
+基于 Catppuccin Mocha 调色板的暗色氛围 UI — 将 UI 视为深邃虚空中的发光半透明层。
+
+- **无可见边框** — 使用色调深度和表面层级（8 级）
+- **玻璃态射** 用于浮动元素（60-80% 透明度，12-20px 模糊）
+- **字体**：Manrope（标题）、Inter（正文/标签）、JetBrains Mono（代码）
+- **语义化 Token**：`bg-surface-container`、`text-on-surface`、`text-primary` 等
+
+完整规格：[`docs/design/DESIGN.md`](docs/design/DESIGN.md)
+
+## 快速开始
+
+```bash
+# 前置条件：Node >= 24，Rust 工具链
+nvm use                          # 使用 .nvmrc
+
+# 仅前端（无 Tauri 后端）
+npm install
+npm run dev                      # Vite 开发服务器，localhost:1420
+
+# 完整桌面应用（需要 Rust）
+npm run tauri:dev                # Tauri + Rust 后端
+
+# 测试
+npm test                         # 1125+ 测试
+npx vitest run src/path/file.test.tsx  # 单文件测试
+
+# 质量检查
+npm run lint                     # ESLint（类型检查）
+npm run format:check             # Prettier 检查
+npm run type-check               # tsc -b
+```
+
+## 仓库结构
+
+```
+CLAUDE.md                   # AI 导航中心（代理从这里开始）
+ARCHITECT.md                # 架构决策、Tauri IPC 模式
+docs/design/DESIGN.md       # UI 设计系统（唯一真实来源）
+
+src/
+├── features/
+│   ├── terminal/           # xterm.js + TauriTerminalService IPC 桥接
+│   ├── editor/             # Shiki 标签式代码编辑器
+│   ├── diff/               # Lazygit 风格 Diff 查看器
+│   ├── files/              # 文件浏览树
+│   ├── command-palette/    # Vim 风格命令面板
+│   └── workspace/          # 4 区布局外壳
+├── components/layout/      # 共享布局（IconRail、Sidebar、TopTabBar、ContextPanel）
+└── test/                   # Vitest 配置
+
+src-tauri/
+├── src/
+│   ├── main.rs             # Tauri 入口
+│   ├── lib.rs              # 库配置
+│   └── terminal/           # PTY 命令、状态、类型
+├── Cargo.toml              # Rust 依赖
+└── tauri.conf.json         # Tauri 配置
+
+agents/                     # 10 个专业 AI 代理定义
+rules/                      # 分层开发标准（通用 + TS + Rust）
+harness/                    # 自主开发循环（Claude Code SDK，Python）
+```
+
+## AI 原生开发流程
 
 传统项目由人类编写代码，AI 辅助。Vimeflow 反转了这一模式：
 
@@ -19,48 +143,20 @@ Vimeflow 是一个编码代理对话管理器，采用 Tauri 桌面应用（Rust
 3. **专业代理审查工作** — 10 个 AI 代理分别负责规划、TDD、代码审查、安全和文档
 4. **规则管控一切** — 分层规则系统（通用层 + 语言特定层）确保一致性，无需人工逐次提交干预
 
-本仓库中的 CI/CD 基础设施、Linter 配置和 Git 钩子，全部由引擎根据 `app_spec.md` 规格说明自动构建。
+引擎（`harness/`）是基于 Claude Code SDK 构建的 Python 循环。详见 [`harness/CLAUDE.md`](harness/CLAUDE.md)。
 
-## 仓库结构
+## 路线图
 
-```
-CLAUDE.md           <- AI 导航中心（代理从这里开始）
-README.md           <- 你在这里（给人类阅读）
-DEVELOPMENT.md      <- 命令、技术栈、代码风格
-ARCHITECT.md        <- 架构决策、Tauri 模式
-DESIGN.md           <- UI 设计系统（Obsidian Lens / Catppuccin Mocha）
+| 阶段 | 状态 | 描述 |
+|------|------|------|
+| 第 1 阶段 | 已完成 | Tauri 脚手架、Rust 编译、CI 通过 |
+| 第 2 阶段 | 已完成 | 工作空间布局外壳（4 区网格，所有组件） |
+| 第 3 阶段 | 已完成 | 终端核心（xterm.js + Tauri PTY IPC） |
+| 第 4 阶段 | 下一步 | 会话管理 + Zustand 状态 |
+| 第 5+ 阶段 | 计划中 | 真实 Git 操作、AI 代理输出流、拖放功能 |
 
-agents/             <- 10 个专业 AI 代理定义
-rules/              <- 分层开发标准（通用 + TypeScript + Rust）
-harness/            <- 自主开发循环（Claude Code SDK，Python）
-docs/design/        <- 屏幕原型、Stitch HTML/CSS、设计规格
-```
+进度跟踪：[`docs/roadmap/progress.yaml`](docs/roadmap/progress.yaml)
 
-## 自主引擎
+## 许可证
 
-Harness Enginnering（`harness/`）是本实验的核心。它是基于 Claude Code SDK 构建的 Python 循环：
-
-- **初始化代理**读取 `app_spec.md`，将其分解为分阶段的 `feature_list.json`
-- **编码代理**选取下一个待完成功能，实现它，标记完成，并自动继续
-- **安全层**包括 Bash 命令白名单、沙盒执行和功能列表写保护
-
-```bash
-cd harness && pip install -r requirements.txt
-python autonomous_agent_demo.py                    # 无限迭代, 手动终止
-python autonomous_agent_demo.py --max-iterations 5 # 限制次数
-```
-
-详见 `harness/CLAUDE.md`。
-
-## 当前状态
-
-**阶段：基础 / 预实现**
-
-- 开发规则、代理规格和 CI/CD 工具链已建立
-- 设计系统（5 个屏幕）已通过 Google Stitch 指定
-- 应用代码（Tauri 脚手架、`src/`、`src-tauri/`）尚未创建
-- 下一步：引擎根据设计规格构建应用
-
-## 技术栈
-
-Tauri 2（Rust 后端 + Web 前端）| React 19 + TypeScript | Vitest + Playwright | ESLint + Prettier | Husky + commitlint | GitHub Actions CI/CD
+MIT

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,14 +38,14 @@ Vimeflow 是一个 **CLI 编码代理控制面板**，基于 Tauri 2（Rust + Re
 
 ### 功能模块
 
-| 模块 | 描述 |
-|------|------|
-| **terminal** | xterm.js + Tauri PTY IPC 桥接，会话管理 |
-| **editor** | IDE 风格标签编辑器，Shiki 语法高亮，Vim 状态栏 |
-| **diff** | Lazygit 风格 Git Diff 查看器（并排 + 统一视图，hunk 导航，暂存/丢弃） |
-| **files** | 文件浏览树，面包屑导航，Git 状态徽章（M/A/D/U），拖放支持 |
-| **command-palette** | Vim 风格 `:command` 命令面板，模糊匹配，嵌套命令树 |
-| **workspace** | 组合以上所有区域的布局外壳 |
+| 模块                | 描述                                                                  |
+| ------------------- | --------------------------------------------------------------------- |
+| **terminal**        | xterm.js + Tauri PTY IPC 桥接，会话管理                               |
+| **editor**          | IDE 风格标签编辑器，Shiki 语法高亮，Vim 状态栏                        |
+| **diff**            | Lazygit 风格 Git Diff 查看器（并排 + 统一视图，hunk 导航，暂存/丢弃） |
+| **files**           | 文件浏览树，面包屑导航，Git 状态徽章（M/A/D/U），拖放支持             |
+| **command-palette** | Vim 风格 `:command` 命令面板，模糊匹配，嵌套命令树                    |
+| **workspace**       | 组合以上所有区域的布局外壳                                            |
 
 ### 质量保障
 
@@ -57,17 +57,17 @@ Vimeflow 是一个 **CLI 编码代理控制面板**，基于 Tauri 2（Rust + Re
 
 ## 技术栈
 
-| 层级 | 技术 |
-|------|------|
-| **桌面** | Tauri 2、Rust、portable-pty、tokio |
-| **前端** | React 19、TypeScript 5（严格模式）、Vite |
-| **样式** | Tailwind CSS v4、Catppuccin Mocha 语义化 Token |
-| **终端** | xterm.js 6、WebGL addon、FitAddon |
-| **编辑器** | Shiki 4（语法高亮） |
-| **动画** | Framer Motion 12 |
-| **测试** | Vitest 3、Testing Library |
-| **质量** | ESLint 9（flat config）、Prettier 3、Husky、commitlint |
-| **Git** | simple-git 3、diff2html 3 |
+| 层级       | 技术                                                   |
+| ---------- | ------------------------------------------------------ |
+| **桌面**   | Tauri 2、Rust、portable-pty、tokio                     |
+| **前端**   | React 19、TypeScript 5（严格模式）、Vite               |
+| **样式**   | Tailwind CSS v4、Catppuccin Mocha 语义化 Token         |
+| **终端**   | xterm.js 6、WebGL addon、FitAddon                      |
+| **编辑器** | Shiki 4（语法高亮）                                    |
+| **动画**   | Framer Motion 12                                       |
+| **测试**   | Vitest 3、Testing Library                              |
+| **质量**   | ESLint 9（flat config）、Prettier 3、Husky、commitlint |
+| **Git**    | simple-git 3、diff2html 3                              |
 
 ## 设计系统："黑曜石之眼"
 
@@ -147,12 +147,12 @@ harness/                    # 自主开发循环（Claude Code SDK，Python）
 
 ## 路线图
 
-| 阶段 | 状态 | 描述 |
-|------|------|------|
-| 第 1 阶段 | 已完成 | Tauri 脚手架、Rust 编译、CI 通过 |
-| 第 2 阶段 | 已完成 | 工作空间布局外壳（4 区网格，所有组件） |
-| 第 3 阶段 | 已完成 | 终端核心（xterm.js + Tauri PTY IPC） |
-| 第 4 阶段 | 下一步 | 会话管理 + Zustand 状态 |
+| 阶段       | 状态   | 描述                                   |
+| ---------- | ------ | -------------------------------------- |
+| 第 1 阶段  | 已完成 | Tauri 脚手架、Rust 编译、CI 通过       |
+| 第 2 阶段  | 已完成 | 工作空间布局外壳（4 区网格，所有组件） |
+| 第 3 阶段  | 已完成 | 终端核心（xterm.js + Tauri PTY IPC）   |
+| 第 4 阶段  | 下一步 | 会话管理 + Zustand 状态                |
 | 第 5+ 阶段 | 计划中 | 真实 Git 操作、AI 代理输出流、拖放功能 |
 
 进度跟踪：[`docs/roadmap/progress.yaml`](docs/roadmap/progress.yaml)


### PR DESCRIPTION
## Summary
- Rewrote both `README.md` (English) and `README.zh-CN.md` (Chinese) to reflect the actual project state
- Replaced outdated "Pre-implementation / app code doesn't exist" messaging with current Phase 3 status
- Added sections: What's Built (Terminal Core, Workspace Layout, 6 feature modules), Tech Stack table, Quick Start, Roadmap

## What Changed
- **Status**: "Foundation / Pre-implementation" → Phase 3 complete (1125+ tests, 92%+ coverage)
- **Architecture**: Added `src/features/` and `src-tauri/` directory listings
- **Tech stack**: Detailed table (Tauri 2, xterm.js 6, Shiki 4, portable-pty, tokio, etc.)
- **Tagline**: "conversation manager" → "CLI Agent Control Plane"
- **New sections**: Quick Start, Feature Modules table, Roadmap table, Quality stats

## Test plan
- [ ] Verify all internal links resolve (`docs/design/DESIGN.md`, `harness/CLAUDE.md`, `docs/roadmap/progress.yaml`)
- [ ] Confirm markdown renders correctly on GitHub (tables, code blocks, language switcher)