### PR TITLE
docs: add review knowledge base with patterns from 12 PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ VISUAL_VERIFICATION.md
 
 # Git worktrees (local per-agent checkouts)
 .claude/worktrees/
+.worktrees/
 
 # Verification screenshots (testing artifacts)
 feedback*.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,7 @@ Follow the review process and checklist defined in `agents/code-reviewer.md`. Ke
 - Severity levels: CRITICAL (security/data loss), HIGH (bugs), MEDIUM (maintainability), LOW (style)
 - Flag any hardcoded secrets, `console.log` statements, or `any` types
 - Approval: no CRITICAL/HIGH = approve; HIGH only = warn; CRITICAL = block
+
+## Review Knowledge Base
+
+Past review findings are collected in `docs/reviews/CLAUDE.md`, grouped by recurring pattern. When reviewing, check if a finding matches an existing pattern — if so, note it. When fixing findings, record the fix in the appropriate pattern file per the ingestion protocol in the design spec.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ This file covers what you need to start working. For deeper topics, read the lin
 | Codex feedback loop design spec                          | `docs/superpowers/specs/2026-04-03-codex-feedback-loop-design.md` |
 | Progress tracking (roadmap status)                       | `docs/roadmap/progress.yaml`                                      |
 | Shell OSC 7 setup (file explorer cwd sync)               | `README.md` → "Shell Setup (OSC 7)"                               |
+| Review knowledge base (patterns from past reviews)       | `docs/reviews/CLAUDE.md`                                          |
 
 ## Harness Plugin Setup
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -13,3 +13,7 @@ Additional design material: https://aistudio.google.com/apps/71779b0a-a865-421d-
 Architecture design documents and exploration notes. Contains dated spec files (e.g., `2026-03-29-cicd-infrastructure-design.md`) capturing design decisions made during planning phases.
 
 Note: `.superpowers/` at the repo root is a separate working directory used by the superpowers plugin — it is not documentation.
+
+### `reviews/`
+
+Review knowledge base — patterns learned from local Codex and GitHub Codex code reviews. Each pattern file in `patterns/` collects related findings with their fixes and commit links. Agents may consult relevant patterns before implementing to avoid repeating past mistakes. See `reviews/CLAUDE.md` for the index.

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -12,6 +12,7 @@ pattern or creating a new file. See the spec at
 `docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md` for the
 ingestion protocol.
 
-| Pattern                                          | Category | Findings | Refs | Last Updated |
-| ------------------------------------------------ | -------- | -------- | ---- | ------------ |
-| [Filesystem Scope](patterns/filesystem-scope.md) | security | 3        | 0    | 2026-04-09   |
+| Pattern                                          | Category       | Findings | Refs | Last Updated |
+| ------------------------------------------------ | -------------- | -------- | ---- | ------------ |
+| [Filesystem Scope](patterns/filesystem-scope.md) | security       | 3        | 0    | 2026-04-09   |
+| [React Lifecycle](patterns/react-lifecycle.md)   | react-patterns | 2        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -12,11 +12,12 @@ pattern or creating a new file. See the spec at
 `docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md` for the
 ingestion protocol.
 
-| Pattern                                                  | Category       | Findings | Refs | Last Updated |
-| -------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
-| [Filesystem Scope](patterns/filesystem-scope.md)         | security       | 3        | 0    | 2026-04-09   |
-| [React Lifecycle](patterns/react-lifecycle.md)           | react-patterns | 2        | 0    | 2026-04-09   |
-| [Resource Cleanup](patterns/resource-cleanup.md)         | react-patterns | 1        | 0    | 2026-04-09   |
-| [Cross-Platform Paths](patterns/cross-platform-paths.md) | cross-platform | 1        | 0    | 2026-04-09   |
-| [Debug Artifacts](patterns/debug-artifacts.md)           | code-quality   | 2        | 0    | 2026-04-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                 | testing        | 1        | 0    | 2026-04-09   |
+| Pattern                                                        | Category       | Findings | Refs | Last Updated |
+| -------------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
+| [Filesystem Scope](patterns/filesystem-scope.md)               | security       | 3        | 0    | 2026-04-09   |
+| [React Lifecycle](patterns/react-lifecycle.md)                 | react-patterns | 2        | 0    | 2026-04-09   |
+| [Resource Cleanup](patterns/resource-cleanup.md)               | react-patterns | 1        | 0    | 2026-04-09   |
+| [Cross-Platform Paths](patterns/cross-platform-paths.md)       | cross-platform | 1        | 0    | 2026-04-09   |
+| [Debug Artifacts](patterns/debug-artifacts.md)                 | code-quality   | 2        | 0    | 2026-04-09   |
+| [Testing Gaps](patterns/testing-gaps.md)                       | testing        | 1        | 0    | 2026-04-09   |
+| [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -21,3 +21,4 @@ ingestion protocol.
 | [Debug Artifacts](patterns/debug-artifacts.md)                 | code-quality   | 2        | 0    | 2026-04-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                       | testing        | 1        | 0    | 2026-04-09   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 0    | 2026-04-09   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 2        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -23,3 +23,4 @@ ingestion protocol.
 | [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 0    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 2        | 0    | 2026-04-09   |
 | [Accessibility](patterns/accessibility.md)                     | a11y           | 4        | 0    | 2026-04-09   |
+| [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 3        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -18,7 +18,7 @@ ingestion protocol.
 | [React Lifecycle](patterns/react-lifecycle.md)                 | react-patterns | 2        | 0    | 2026-04-09   |
 | [Resource Cleanup](patterns/resource-cleanup.md)               | react-patterns | 1        | 0    | 2026-04-09   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)       | cross-platform | 1        | 0    | 2026-04-09   |
-| [Debug Artifacts](patterns/debug-artifacts.md)                 | code-quality   | 2        | 0    | 2026-04-09   |
+| [Debug Artifacts](patterns/debug-artifacts.md)                 | code-quality   | 3        | 0    | 2026-04-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                       | testing        | 1        | 0    | 2026-04-09   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 0    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 2        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -21,7 +21,7 @@ ingestion protocol.
 | [Debug Artifacts](patterns/debug-artifacts.md)                 | code-quality   | 3        | 0    | 2026-04-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                       | testing        | 1        | 0    | 2026-04-09   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 0    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 2        | 0    | 2026-04-09   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 5        | 0    | 2026-04-09   |
 | [Accessibility](patterns/accessibility.md)                     | a11y           | 4        | 0    | 2026-04-09   |
 | [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 3        | 0    | 2026-04-09   |
 | [Command Injection](patterns/command-injection.md)             | security       | 4        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -16,3 +16,4 @@ ingestion protocol.
 | ------------------------------------------------ | -------------- | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md) | security       | 3        | 0    | 2026-04-09   |
 | [React Lifecycle](patterns/react-lifecycle.md)   | react-patterns | 2        | 0    | 2026-04-09   |
+| [Resource Cleanup](patterns/resource-cleanup.md) | react-patterns | 1        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -22,3 +22,4 @@ ingestion protocol.
 | [Testing Gaps](patterns/testing-gaps.md)                       | testing        | 1        | 0    | 2026-04-09   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 0    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 2        | 0    | 2026-04-09   |
+| [Accessibility](patterns/accessibility.md)                     | a11y           | 4        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -24,3 +24,4 @@ ingestion protocol.
 | [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 2        | 0    | 2026-04-09   |
 | [Accessibility](patterns/accessibility.md)                     | a11y           | 4        | 0    | 2026-04-09   |
 | [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 3        | 0    | 2026-04-09   |
+| [Command Injection](patterns/command-injection.md)             | security       | 4        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -1,0 +1,16 @@
+# Review Knowledge Base
+
+Patterns learned from code reviews (local Codex and GitHub Codex). This is an
+optional reference — agents may consult relevant patterns before implementing
+to avoid repeating past mistakes.
+
+**For agents:** When you read a pattern file during implementation, bump its
+`ref_count` in frontmatter by 1 and update the Refs column below.
+
+**After a review-fix cycle:** Record new findings by appending to an existing
+pattern or creating a new file. See the spec at
+`docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md` for the
+ingestion protocol.
+
+| Pattern | Category | Findings | Refs | Last Updated |
+| ------- | -------- | -------- | ---- | ------------ |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -25,3 +25,4 @@ ingestion protocol.
 | [Accessibility](patterns/accessibility.md)                     | a11y           | 4        | 0    | 2026-04-09   |
 | [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 3        | 0    | 2026-04-09   |
 | [Command Injection](patterns/command-injection.md)             | security       | 4        | 0    | 2026-04-09   |
+| [CSP Configuration](patterns/csp-configuration.md)             | security       | 2        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -26,3 +26,4 @@ ingestion protocol.
 | [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 3        | 0    | 2026-04-09   |
 | [Command Injection](patterns/command-injection.md)             | security       | 4        | 0    | 2026-04-09   |
 | [CSP Configuration](patterns/csp-configuration.md)             | security       | 2        | 0    | 2026-04-09   |
+| [PTY Session Management](patterns/pty-session-management.md)   | backend        | 5        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -12,5 +12,6 @@ pattern or creating a new file. See the spec at
 `docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md` for the
 ingestion protocol.
 
-| Pattern | Category | Findings | Refs | Last Updated |
-| ------- | -------- | -------- | ---- | ------------ |
+| Pattern                                          | Category | Findings | Refs | Last Updated |
+| ------------------------------------------------ | -------- | -------- | ---- | ------------ |
+| [Filesystem Scope](patterns/filesystem-scope.md) | security | 3        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -19,3 +19,4 @@ ingestion protocol.
 | [Resource Cleanup](patterns/resource-cleanup.md)         | react-patterns | 1        | 0    | 2026-04-09   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md) | cross-platform | 1        | 0    | 2026-04-09   |
 | [Debug Artifacts](patterns/debug-artifacts.md)           | code-quality   | 2        | 0    | 2026-04-09   |
+| [Testing Gaps](patterns/testing-gaps.md)                 | testing        | 1        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -27,3 +27,4 @@ ingestion protocol.
 | [Command Injection](patterns/command-injection.md)             | security       | 4        | 0    | 2026-04-09   |
 | [CSP Configuration](patterns/csp-configuration.md)             | security       | 2        | 0    | 2026-04-09   |
 | [PTY Session Management](patterns/pty-session-management.md)   | backend        | 5        | 0    | 2026-04-09   |
+| [Git Operations](patterns/git-operations.md)                   | correctness    | 5        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -12,8 +12,9 @@ pattern or creating a new file. See the spec at
 `docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md` for the
 ingestion protocol.
 
-| Pattern                                          | Category       | Findings | Refs | Last Updated |
-| ------------------------------------------------ | -------------- | -------- | ---- | ------------ |
-| [Filesystem Scope](patterns/filesystem-scope.md) | security       | 3        | 0    | 2026-04-09   |
-| [React Lifecycle](patterns/react-lifecycle.md)   | react-patterns | 2        | 0    | 2026-04-09   |
-| [Resource Cleanup](patterns/resource-cleanup.md) | react-patterns | 1        | 0    | 2026-04-09   |
+| Pattern                                                  | Category       | Findings | Refs | Last Updated |
+| -------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
+| [Filesystem Scope](patterns/filesystem-scope.md)         | security       | 3        | 0    | 2026-04-09   |
+| [React Lifecycle](patterns/react-lifecycle.md)           | react-patterns | 2        | 0    | 2026-04-09   |
+| [Resource Cleanup](patterns/resource-cleanup.md)         | react-patterns | 1        | 0    | 2026-04-09   |
+| [Cross-Platform Paths](patterns/cross-platform-paths.md) | cross-platform | 1        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -18,3 +18,4 @@ ingestion protocol.
 | [React Lifecycle](patterns/react-lifecycle.md)           | react-patterns | 2        | 0    | 2026-04-09   |
 | [Resource Cleanup](patterns/resource-cleanup.md)         | react-patterns | 1        | 0    | 2026-04-09   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md) | cross-platform | 1        | 0    | 2026-04-09   |
+| [Debug Artifacts](patterns/debug-artifacts.md)           | code-quality   | 2        | 0    | 2026-04-09   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -1,0 +1,53 @@
+---
+id: accessibility
+category: a11y
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Accessibility
+
+## Summary
+
+Interactive components must have correct ARIA attributes and keyboard navigation.
+`aria-activedescendant` must reference elements with the correct role, and keyboard
+handlers must not trap focus without implementing the promised behavior.
+
+## Findings
+
+### 1. ARIA active descendant points to non-option element
+
+- **Source:** github-codex | PR #14 | 2026-04-01
+- **Severity:** MEDIUM
+- **File:** `src/features/command-palette/components/CommandResults.tsx`
+- **Finding:** `aria-activedescendant` set on listbox while focus remains in input, and referenced id is on `motion.div` wrapper rather than `role="option"` element
+- **Fix:** Moved `aria-activedescendant` to focused input and ensured id is on the option element
+- **Commit:** `e05cd3d feat: assemble complete Agent Activity panel (#14)`
+
+### 2. ARIA active descendant target lacks role option
+
+- **Source:** github-codex | PR #14 | 2026-04-01
+- **Severity:** MEDIUM
+- **File:** `src/features/command-palette/components/CommandResultItem.tsx`
+- **Finding:** `role="option"` element lacks the id that `aria-activedescendant` points to
+- **Fix:** Added id to the option element itself
+- **Commit:** `e05cd3d feat: assemble complete Agent Activity panel (#14)`
+
+### 3. Tab key globally trapped without behavior
+
+- **Source:** github-codex | PR #21 | 2026-04-03
+- **Severity:** LOW
+- **File:** `src/features/diff/hooks/useDiffKeyboard.ts`
+- **Finding:** Keyboard handler prevents default on Tab and calls a no-op handler, blocking focus navigation
+- **Fix:** Removed Tab handler until feature is implemented
+- **Commit:** `92eff2e feat: add lazygit-style git diff viewer (#21)`
+
+### 4. Keyboard navigation order doesn't match sorted display
+
+- **Source:** github-codex | PR #21 | 2026-04-03
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/DiffView.tsx`
+- **Finding:** `ChangedFilesList` sorts files by status for display but keyboard nav uses unsorted array indices
+- **Fix:** Used same sorted list for both rendering and keyboard selection
+- **Commit:** `92eff2e feat: add lazygit-style git diff viewer (#21)`

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -1,0 +1,45 @@
+---
+id: async-race-conditions
+category: react-patterns
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Async Race Conditions
+
+## Summary
+
+Async operations (file fetches, syntax highlighting) can resolve out of order
+when inputs change rapidly (tab switching, fast navigation). Always track the
+current request and discard stale responses. Clear state on new requests to
+prevent showing previous data.
+
+## Findings
+
+### 1. Stale file content renders when switching tabs quickly
+
+- **Source:** github-codex | PR #23 | 2026-04-04
+- **Severity:** HIGH
+- **File:** `src/features/editor/hooks/useFileContent.ts`
+- **Finding:** `useFileContent` keeps previous content while new fetch is in-flight and doesn't guard against out-of-order responses
+- **Fix:** Track requested path via ref, ignore stale responses, clear content on new fetch
+- **Commit:** `397353a feat: add IDE-style Editor view with file explorer and syntax highlighting (#23)`
+
+### 2. Async syntax highlighting applies stale results
+
+- **Source:** github-codex | PR #23 | 2026-04-04
+- **Severity:** MEDIUM
+- **File:** `src/features/editor/components/CodeEditor.tsx`
+- **Finding:** Async `highlightCode` in useEffect has no cancellation — slower prior highlight can overwrite current
+- **Fix:** Added cancellation flag in effect cleanup
+- **Commit:** `397353a feat: add IDE-style Editor view with file explorer and syntax highlighting (#23)`
+
+### 3. Selected file index out of range after refresh
+
+- **Source:** github-codex | PR #21 | 2026-04-03
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/DiffView.tsx`
+- **Finding:** After staging/discarding, `refreshStatus()` shrinks `changedFiles` but index is never clamped
+- **Fix:** Clamped `selectedFileIndex` when `changedFiles` updates
+- **Commit:** `92eff2e feat: add lazygit-style git diff viewer (#21)`

--- a/docs/reviews/patterns/command-injection.md
+++ b/docs/reviews/patterns/command-injection.md
@@ -1,0 +1,54 @@
+---
+id: command-injection
+category: security
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Command Injection
+
+## Summary
+
+Never interpolate user-supplied values into shell commands via template strings
+or string concatenation. Use `execFileSync`/`spawnSync` with an args array (no
+shell). For file APIs, validate paths are repo-relative and resolve symlinks
+before access.
+
+## Findings
+
+### 1. Shell injection via unescaped file parameter in execSync
+
+- **Source:** github-codex | PR #21 | 2026-04-03
+- **Severity:** CRITICAL
+- **File:** `vite.config.ts`
+- **Finding:** Untracked-file diff path uses `execSync` with template string interpolating `file` query parameter directly into shell command
+- **Fix:** Switched to `execFileSync` with args array, validated path is repo-relative
+- **Commit:** `92eff2e feat: add lazygit-style git diff viewer (#21)`
+
+### 2. Path traversal via symlink in file API
+
+- **Source:** github-codex | PR #23 | 2026-04-04
+- **Severity:** HIGH
+- **File:** `vite-plugin-files.ts`
+- **Finding:** `validateRepoPath` doesn't resolve symlinks — repo-contained symlink to external location bypasses validation
+- **Fix:** Resolved real paths with `fs.realpath` and validated real path is within repo root
+- **Commit:** `397353a feat: add IDE-style Editor view with file explorer and syntax highlighting (#23)`
+
+### 3. File API allows reading excluded/sensitive paths
+
+- **Source:** github-codex | PR #23 | 2026-04-04
+- **Severity:** HIGH
+- **File:** `vite-plugin-files.ts`
+- **Finding:** Exclude list only filters during tree traversal, not direct path access — `.git`, `.env` readable via direct query
+- **Fix:** Applied exclude check to all path access, not just tree traversal
+- **Commit:** `397353a feat: add IDE-style Editor view with file explorer and syntax highlighting (#23)`
+
+### 4. Untracked diff endpoint allows arbitrary file reads
+
+- **Source:** github-codex | PR #21 | 2026-04-03
+- **Severity:** HIGH
+- **File:** `vite.config.ts`
+- **Finding:** Untracked-file fallback only strips `..` — absolute paths and symlinks still pass through
+- **Fix:** Validated path resolves inside repo root using `path.resolve` + `path.relative`
+- **Commit:** `92eff2e feat: add lazygit-style git diff viewer (#21)`

--- a/docs/reviews/patterns/cross-platform-paths.md
+++ b/docs/reviews/patterns/cross-platform-paths.md
@@ -1,0 +1,27 @@
+---
+id: cross-platform-paths
+category: cross-platform
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Cross-Platform Paths
+
+## Summary
+
+Path manipulation using string operations (regex split on `/`) breaks on
+Windows. Drive roots like `C:/Users` become `C:` (drive-relative, not root)
+when the trailing segment is stripped. Always normalize drive roots and
+consider using path libraries for cross-platform code.
+
+## Findings
+
+### 1. Windows path navigation resolves to drive-relative `C:` instead of `C:/`
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** MEDIUM
+- **File:** `src/features/files/hooks/useFileTree.ts`
+- **Finding:** `navigateUp` strips last segment with `/` regex, turning `C:/Users` into `C:` — not a valid absolute path on Windows
+- **Fix:** Added Windows drive root detection — if result matches `^[A-Za-z]:$`, append `/`
+- **Commit:** `435e217 feat: interactive sidebar sessions, resizable panels, and real file explorer (#36)`

--- a/docs/reviews/patterns/csp-configuration.md
+++ b/docs/reviews/patterns/csp-configuration.md
@@ -1,0 +1,36 @@
+---
+id: csp-configuration
+category: security
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# CSP Configuration
+
+## Summary
+
+Content Security Policy in Tauri apps must be strict — no `unsafe-inline` for
+styles or scripts. In Tauri v2, CSP config must be at the top level of
+`tauri.conf.json`, not nested under `app`. Always verify the policy is actually
+applied, not just declared.
+
+## Findings
+
+### 1. CSP allows unsafe-inline styles
+
+- **Source:** github-codex | PR #27 | 2026-04-05
+- **Severity:** HIGH
+- **File:** `src-tauri/tauri.conf.json`
+- **Finding:** CSP includes `style-src 'unsafe-inline'`, weakening XSS defenses by allowing injected inline styles
+- **Fix:** Removed `unsafe-inline` from `style-src`, switched to class-based styles
+- **Commit:** `9ce4d61 feat: Phase 1 - Tauri scaffold with v2 configuration (#27)`
+
+### 2. CSP config nested under wrong key in Tauri v2
+
+- **Source:** github-codex | PR #27 | 2026-04-05
+- **Severity:** MEDIUM
+- **File:** `src-tauri/tauri.conf.json`
+- **Finding:** `security` nested under `app` which Tauri v2 doesn't read for CSP — policy likely not applied
+- **Fix:** Moved `security` to top level of `tauri.conf.json`
+- **Commit:** `9ce4d61 feat: Phase 1 - Tauri scaffold with v2 configuration (#27)`

--- a/docs/reviews/patterns/debug-artifacts.md
+++ b/docs/reviews/patterns/debug-artifacts.md
@@ -34,3 +34,12 @@ statements must not ship to production. Gate debug visuals behind
 - **Finding:** `border-2 border-red-500` wrapper and debug overlay shipped in production build
 - **Fix:** Removed debug styling
 - **Commit:** `2fc3fa2 feat: Xterm Terminal Core - TauriTerminalService IPC bridge (#34)`
+
+### 3. Console logging shipped in default command stubs
+
+- **Source:** github-codex | PR #14 | 2026-04-01
+- **Severity:** LOW
+- **File:** `src/features/command-palette/data/defaultCommands.ts`
+- **Finding:** Command stubs use `console.info` with ESLint `no-console` disabled — debug logging ships to production
+- **Fix:** Removed console.info calls and eslint-disable comments
+- **Commit:** `e05cd3d feat: assemble complete Agent Activity panel (#14)`

--- a/docs/reviews/patterns/debug-artifacts.md
+++ b/docs/reviews/patterns/debug-artifacts.md
@@ -1,0 +1,36 @@
+---
+id: debug-artifacts
+category: code-quality
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Debug Artifacts
+
+## Summary
+
+Debug UI elements (red borders, status bars, overlay text) and `console.log`
+statements must not ship to production. Gate debug visuals behind
+`import.meta.env.DEV` or remove them before committing. The project enforces
+`no-console: error` via ESLint, but inline debug UI bypasses this.
+
+## Findings
+
+### 1. Debug status bar rendered unconditionally in TerminalPane
+
+- **Source:** github-codex | PR #34 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane.tsx`
+- **Finding:** Always-on debug status bar with internal state leaks to users and conflicts with Obsidian Lens design
+- **Fix:** Removed debug UI or gated behind `import.meta.env.DEV`
+- **Commit:** `2fc3fa2 feat: Xterm Terminal Core - TauriTerminalService IPC bridge (#34)`
+
+### 2. Debug border and overlay in TerminalZone
+
+- **Source:** github-codex | PR #34 | 2026-04-08
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/TerminalZone.tsx`
+- **Finding:** `border-2 border-red-500` wrapper and debug overlay shipped in production build
+- **Fix:** Removed debug styling
+- **Commit:** `2fc3fa2 feat: Xterm Terminal Core - TauriTerminalService IPC bridge (#34)`

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -33,3 +33,30 @@ Stale documentation misleads future contributors and review agents.
 - **Finding:** Comment references `docs/design/left-sidebar/` but actual path is `docs/design/leftsidebar/`
 - **Fix:** Updated comment to correct directory name
 - **Commit:** `435e217 feat: interactive sidebar sessions, resizable panels, and real file explorer (#36)`
+
+### 3. Wrong dev server port in README
+
+- **Source:** github-codex | PR #35 | 2026-04-09
+- **Severity:** LOW
+- **File:** `README.md`
+- **Finding:** Quick Start says `npm run dev` serves at `localhost:1420` but Vite uses `localhost:5173`
+- **Fix:** Updated README to correct port
+- **Commit:** `95a4075 docs: rewrite README for current project state (#35)`
+
+### 4. Unverified security finding in roadmap
+
+- **Source:** github-codex | PR #25 | 2026-04-05
+- **Severity:** MEDIUM
+- **File:** `docs/roadmap/tauri-migration-roadmap.md`
+- **Finding:** Roadmap claims CRITICAL issue about `.env` using plain HTTP but no `.env` exists in repo — speculative finding presented as confirmed
+- **Fix:** Reframed as conditional risk with clear assumptions
+- **Commit:** `bacec0e docs: add Tauri migration roadmap (#25)`
+
+### 5. Roadmap dependency inconsistencies
+
+- **Source:** github-codex | PR #30 | 2026-04-06
+- **Severity:** LOW
+- **File:** `docs/roadmap/progress.yaml`
+- **Finding:** Phase dependencies inconsistent between roadmap narrative, dependency graph, and `progress.yaml`
+- **Fix:** Aligned all three sources for consistent dependency information
+- **Commit:** `6b80a60 docs: rewrite roadmap for CLI agent workspace pivot (#30)`

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -1,0 +1,35 @@
+---
+id: documentation-accuracy
+category: code-quality
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Documentation Accuracy
+
+## Summary
+
+When implementation changes (removing an addon, renaming a directory, changing
+behavior), inline docs and comments must be updated in the same commit.
+Stale documentation misleads future contributors and review agents.
+
+## Findings
+
+### 1. TerminalPane docs claim WebGL rendering after addon removal
+
+- **Source:** github-codex | PR #33 | 2026-04-08
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane.tsx`
+- **Finding:** Component doc comment lists "Hardware-accelerated rendering with WebGL addon" but WebGL addon was removed in this PR
+- **Fix:** Updated feature list to reflect Canvas2D renderer
+- **Commit:** `6a312b3 fix: terminal rendering, WebGL, backspace, and progress tracker (#33)`
+
+### 2. Broken design reference path in mock file tree
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** LOW
+- **File:** `src/features/files/data/mockFileTree.ts`
+- **Finding:** Comment references `docs/design/left-sidebar/` but actual path is `docs/design/leftsidebar/`
+- **Fix:** Updated comment to correct directory name
+- **Commit:** `435e217 feat: interactive sidebar sessions, resizable panels, and real file explorer (#36)`

--- a/docs/reviews/patterns/filesystem-scope.md
+++ b/docs/reviews/patterns/filesystem-scope.md
@@ -1,0 +1,44 @@
+---
+id: filesystem-scope
+category: security
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Filesystem Scope
+
+## Summary
+
+Tauri IPC commands that access the filesystem must validate paths against an
+allowlist. The webview is an untrusted boundary — a compromised renderer could
+enumerate sensitive directories without scope restrictions.
+
+## Findings
+
+### 1. Unrestricted filesystem access from Tauri command
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** HIGH
+- **File:** `src-tauri/src/filesystem/commands.rs`
+- **Finding:** `list_dir` accepts any client-supplied path without validating against an allowed root or Tauri fs scope
+- **Fix:** Added home-directory scope validation — canonicalize requested path, verify `starts_with(home_dir)` before reading
+- **Commit:** `435e217 feat: interactive sidebar sessions, resizable panels, and real file explorer (#36)`
+
+### 2. File explorer can navigate above home directory
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** MEDIUM
+- **File:** `src/features/files/hooks/useFileTree.ts`
+- **Finding:** `navigateUp` allows navigation to paths outside home scope, triggering access denied errors
+- **Fix:** Clamped `navigateUp` at home directory boundary
+- **Commit:** `435e217 feat: interactive sidebar sessions, resizable panels, and real file explorer (#36)`
+
+### 3. Rust filesystem tests use temp dir outside allowed home scope
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** HIGH
+- **File:** `src-tauri/src/filesystem/commands.rs`
+- **Finding:** Tests create directories under `/tmp` which is outside the enforced home-directory scope, causing test failures
+- **Fix:** Moved test directories under home directory path
+- **Commit:** `435e217 feat: interactive sidebar sessions, resizable panels, and real file explorer (#36)`

--- a/docs/reviews/patterns/git-operations.md
+++ b/docs/reviews/patterns/git-operations.md
@@ -1,0 +1,63 @@
+---
+id: git-operations
+category: correctness
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Git Operations
+
+## Summary
+
+Git operations exposed via API must handle edge cases: hunk-level staging/discard
+requires extracting the correct patch (not full-file `git add`), untracked files
+need special handling (`git diff --no-index`), and diff sources must be consistent
+between display and mutation operations.
+
+## Findings
+
+### 1. Stage hunk always stages the full file
+
+- **Source:** github-codex | PR #21 | 2026-04-03
+- **Severity:** MEDIUM
+- **File:** `vite.config.ts`
+- **Finding:** `/api/git/stage` ignores `hunkIndex` and always runs `git add` on entire file
+- **Fix:** Implemented hunk-level staging with `git apply --cached` on extracted patch
+- **Commit:** `92eff2e feat: add lazygit-style git diff viewer (#21)`
+
+### 2. Discard fails for untracked files
+
+- **Source:** github-codex | PR #21 | 2026-04-03
+- **Severity:** MEDIUM
+- **File:** `vite.config.ts`
+- **Finding:** Discard uses `git checkout -- <file>` which fails for untracked files
+- **Fix:** Detect untracked files and use `git clean -f -- <file>` instead
+- **Commit:** `92eff2e feat: add lazygit-style git diff viewer (#21)`
+
+### 3. Discarding a hunk discards the entire file (data loss)
+
+- **Source:** github-codex | PR #21 | 2026-04-03
+- **Severity:** HIGH
+- **File:** `vite.config.ts`
+- **Finding:** `/api/git/discard` ignores `hunkIndex` — pressing discard drops ALL changes in file
+- **Fix:** Implemented hunk-level discard with reverse patch via `git apply -R`
+- **Commit:** `92eff2e feat: add lazygit-style git diff viewer (#21)`
+
+### 4. Diff endpoint omits committed changes when working tree has edits
+
+- **Source:** github-codex | PR #21 | 2026-04-03
+- **Severity:** HIGH
+- **File:** `vite.config.ts`
+- **Finding:** Default view falls back between `git diff` and `git diff main` — silently drops committed changes
+- **Fix:** Always diff against base branch for default view
+- **Commit:** `92eff2e feat: add lazygit-style git diff viewer (#21)`
+
+### 5. Untracked files return 404 from diff endpoint
+
+- **Source:** github-codex | PR #21 | 2026-04-03
+- **Severity:** MEDIUM
+- **File:** `vite.config.ts`
+- **Finding:** `git diff` doesn't emit diffs for untracked paths — falls through to 404
+- **Fix:** Detect untracked files and use `git diff --no-index` or `git add -N`
+- **Commit:** `92eff2e feat: add lazygit-style git diff viewer (#21)`

--- a/docs/reviews/patterns/pty-session-management.md
+++ b/docs/reviews/patterns/pty-session-management.md
@@ -1,0 +1,62 @@
+---
+id: pty-session-management
+category: backend
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# PTY Session Management
+
+## Summary
+
+PTY sessions in Tauri must handle lifecycle carefully: validate IPC inputs,
+prevent session ID reuse conflicts, avoid blocking async runtime threads, and
+never log terminal input (may contain secrets).
+
+## Findings
+
+### 1. Unvalidated IPC input allows arbitrary shell execution
+
+- **Source:** github-codex | PR #31 | 2026-04-06
+- **Severity:** HIGH
+- **File:** `src-tauri/src/terminal/commands.rs`
+- **Finding:** `spawn_pty` trusts `request.shell`, `request.cwd`, `request.env` from webview without validation
+- **Fix:** Validated shell against allowlist, cwd within workspace root, whitelisted env keys
+- **Commit:** `ba395c7 feat: Phase 2 workspace layout shell with v2 design (#31)`
+
+### 2. Duplicate session IDs overwrite active PTY without cleanup
+
+- **Source:** github-codex | PR #31 | 2026-04-06
+- **Severity:** HIGH
+- **File:** `src-tauri/src/terminal/commands.rs`
+- **Finding:** `spawn_pty` inserts new session without checking if ID exists — previous session's process leaked
+- **Fix:** Check for existing session ID, kill/remove before replacing
+- **Commit:** `ba395c7 feat: Phase 2 workspace layout shell with v2 design (#31)`
+
+### 3. Session ID reuse causes stale reader to delete new session
+
+- **Source:** github-codex | PR #31 | 2026-04-06
+- **Severity:** HIGH
+- **File:** `src-tauri/src/terminal/commands.rs`
+- **Finding:** Old reader thread calls `state.remove(&session_id)` on EOF, removing the NEW session inserted with same ID
+- **Fix:** Track per-session generation token, reader only removes if generation matches
+- **Commit:** `ba395c7 feat: Phase 2 workspace layout shell with v2 design (#31)`
+
+### 4. Blocking PTY read loop on async runtime thread
+
+- **Source:** github-codex | PR #31 | 2026-04-06
+- **Severity:** MEDIUM
+- **File:** `src-tauri/src/terminal/commands.rs`
+- **Finding:** Blocking `reader.read()` loop inside async task starves runtime worker threads
+- **Fix:** Moved to `spawn_blocking` or dedicated thread
+- **Commit:** `ba395c7 feat: Phase 2 workspace layout shell with v2 design (#31)`
+
+### 5. PTY input logged verbatim (secret leakage)
+
+- **Source:** github-codex | PR #31 | 2026-04-06
+- **Severity:** MEDIUM
+- **File:** `src-tauri/src/terminal/commands.rs`
+- **Finding:** `write_pty` logs full terminal input via `log::debug!` — credentials and tokens exposed in logs
+- **Fix:** Log only metadata (session ID, byte length), not payload
+- **Commit:** `ba395c7 feat: Phase 2 workspace layout shell with v2 design (#31)`

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -1,0 +1,35 @@
+---
+id: react-lifecycle
+category: react-patterns
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# React Lifecycle
+
+## Summary
+
+React effects with async work or subscriptions must handle cleanup and guard
+against state updates after unmount. Effect dependency arrays must be minimal
+to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
+
+## Findings
+
+### 1. PTY respawns on every cwd update via OSC 7
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** HIGH
+- **File:** `src/features/terminal/hooks/useTerminal.ts`
+- **Finding:** PTY spawn effect depends on `cwd`, so any directory change kills the running session and spawns a new one
+- **Fix:** Decoupled spawning from cwd — treat cwd as initial spawn parameter stored in a ref
+- **Commit:** `435e217 feat: interactive sidebar sessions, resizable panels, and real file explorer (#36)`
+
+### 2. State updates after unmount in PTY spawn flow
+
+- **Source:** github-codex | PR #34 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/hooks/useTerminal.ts`
+- **Finding:** `setDebugInfo()` called even when `isMountedRef.current` is false, triggering React warnings
+- **Fix:** Gated all state updates (including debug) behind `isMountedRef` guard
+- **Commit:** `2fc3fa2 feat: Xterm Terminal Core - TauriTerminalService IPC bridge (#34)`

--- a/docs/reviews/patterns/resource-cleanup.md
+++ b/docs/reviews/patterns/resource-cleanup.md
@@ -1,0 +1,26 @@
+---
+id: resource-cleanup
+category: react-patterns
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Resource Cleanup
+
+## Summary
+
+Services that register global event listeners (especially Tauri IPC listeners)
+must be disposed on unmount. Creating a new service instance per component
+mount without cleanup causes listener accumulation and duplicate event handling.
+
+## Findings
+
+### 1. Tauri event listeners leak across terminal panes
+
+- **Source:** github-codex | PR #34 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/services/terminalService.ts`
+- **Finding:** Each `createTerminalService()` call registers global Tauri listeners with no `dispose()` on unmount — listeners accumulate as panes mount/unmount
+- **Fix:** Made Tauri service a singleton or added dispose call in cleanup
+- **Commit:** `2fc3fa2 feat: Xterm Terminal Core - TauriTerminalService IPC bridge (#34)`

--- a/docs/reviews/patterns/terminal-input-handling.md
+++ b/docs/reviews/patterns/terminal-input-handling.md
@@ -1,0 +1,45 @@
+---
+id: terminal-input-handling
+category: terminal
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Terminal Input Handling
+
+## Summary
+
+Terminal input processing must handle multi-character input (paste), control
+characters (backspace, delete), and line ending variants (CR, LF, CRLF).
+Processing char-by-char with proper buffer mutation prevents ghost characters,
+double execution, and paste failures.
+
+## Findings
+
+### 1. Backspace does not update the input buffer
+
+- **Source:** github-codex | PR #33 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/services/terminalService.ts`
+- **Finding:** Backspace handler emits visual `\b \b` but never removes the last character from `session.inputBuffer` — deleted characters still execute
+- **Fix:** Added buffer mutation on backspace with empty-buffer guard
+- **Commit:** `6a312b3 fix: terminal rendering, WebGL, backspace, and progress tracker (#33)`
+
+### 2. Pasted text with newline never executes
+
+- **Source:** github-codex | PR #33 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/services/terminalService.ts`
+- **Finding:** `write()` only checks `data === '\r'` for Enter — multi-char paste containing newlines falls through to regular character path
+- **Fix:** Process `data` per character, handling control chars individually
+- **Commit:** `6a312b3 fix: terminal rendering, WebGL, backspace, and progress tracker (#33)`
+
+### 3. CRLF input executes command twice
+
+- **Source:** github-codex | PR #33 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/services/terminalService.ts`
+- **Finding:** `\r` and `\n` treated as independent Enter events — `\r\n` paste triggers two command executions
+- **Fix:** Normalize input by replacing `\r\n` with `\n` before processing, or track previous char to skip `\n` after `\r`
+- **Commit:** `6a312b3 fix: terminal rendering, WebGL, backspace, and progress tracker (#33)`

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -1,0 +1,27 @@
+---
+id: testing-gaps
+category: testing
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Testing Gaps
+
+## Summary
+
+Every `.ts`/`.tsx` production file must have a co-located `.test.ts`/`.test.tsx`
+sibling. New modules added without tests violate the project testing rule and
+increase regression risk. Tests must also respect runtime constraints (e.g.,
+filesystem scope restrictions).
+
+## Findings
+
+### 1. New core modules lack co-located tests
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** HIGH
+- **File:** `src/features/workspace/hooks/useResizable.ts` (and 3 others)
+- **Finding:** Four new production modules added without sibling test files: `useResizable.ts`, `useSessionManager.ts`, `fileSystemService.ts`, `useFileTree.ts`
+- **Fix:** Added co-located test files for all new modules
+- **Commit:** `435e217 feat: interactive sidebar sessions, resizable panels, and real file explorer (#36)`

--- a/docs/superpowers/plans/2026-04-09-review-knowledge-base.md
+++ b/docs/superpowers/plans/2026-04-09-review-knowledge-base.md
@@ -1,0 +1,703 @@
+# Review Knowledge Base Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a persistent review knowledge base at `docs/reviews/` seeded with findings from PRs #33, #34, #36, and wire it into project discovery docs.
+
+**Architecture:** Flat markdown files — one per pattern in `docs/reviews/patterns/`, indexed by `docs/reviews/CLAUDE.md`. Findings are grouped by recurring pattern with YAML frontmatter for metadata and ref counting. No code, no scripts — pure documentation.
+
+**Tech Stack:** Markdown, YAML frontmatter, `gh` CLI (for fetching PR comments during seeding)
+
+**Worktree:** This plan MUST be executed in a git worktree, not on main.
+
+---
+
+## File Structure
+
+| File                                               | Action | Purpose                                                      |
+| -------------------------------------------------- | ------ | ------------------------------------------------------------ |
+| `docs/reviews/CLAUDE.md`                           | Create | Pattern index with ref counters                              |
+| `docs/reviews/patterns/filesystem-scope.md`        | Create | Filesystem access restrictions and path boundaries           |
+| `docs/reviews/patterns/react-lifecycle.md`         | Create | React effect cleanup, state-after-unmount, dependency arrays |
+| `docs/reviews/patterns/resource-cleanup.md`        | Create | Event listener leaks, service disposal                       |
+| `docs/reviews/patterns/cross-platform-paths.md`    | Create | Windows path handling, drive root normalization              |
+| `docs/reviews/patterns/debug-artifacts.md`         | Create | Debug UI/logging shipped to production                       |
+| `docs/reviews/patterns/testing-gaps.md`            | Create | Missing co-located tests, test scope mismatches              |
+| `docs/reviews/patterns/terminal-input-handling.md` | Create | Backspace, paste, CRLF, multi-char input                     |
+| `docs/reviews/patterns/documentation-accuracy.md`  | Create | Stale docs after implementation changes                      |
+| `CLAUDE.md`                                        | Modify | Add index table row                                          |
+| `docs/CLAUDE.md`                                   | Modify | Add `reviews/` subsection                                    |
+| `AGENTS.md`                                        | Modify | Add reference to review knowledge base                       |
+
+## Pattern Classification (from PR history)
+
+Findings from PRs #33, #34, #36 grouped into 8 patterns:
+
+| Pattern                 | Findings | Sources                                                                  |
+| ----------------------- | -------- | ------------------------------------------------------------------------ |
+| filesystem-scope        | 4        | PR #36 (unrestricted access x2, navigate above home, rust test scope x2) |
+| react-lifecycle         | 2        | PR #36 (PTY respawns on cwd), PR #34 (state after unmount)               |
+| resource-cleanup        | 1        | PR #34 (event listener leaks)                                            |
+| cross-platform-paths    | 2        | PR #36 (Windows `C:` path x2)                                            |
+| debug-artifacts         | 2        | PR #34 (debug UI x2)                                                     |
+| testing-gaps            | 1        | PR #36 (missing co-located tests)                                        |
+| terminal-input-handling | 3        | PR #33 (backspace, paste, CRLF)                                          |
+| documentation-accuracy  | 2        | PR #36 (broken ref path), PR #33 (stale WebGL docs)                      |
+
+**Skipped:** Merge conflict markers from PR #34 (one-time mistake, not a recurring pattern).
+
+---
+
+### Task 1: Create directory structure and empty index
+
+**Files:**
+
+- Create: `docs/reviews/CLAUDE.md`
+- Create: `docs/reviews/patterns/.gitkeep`
+
+- [ ] **Step 1: Create `docs/reviews/CLAUDE.md`**
+
+```markdown
+# Review Knowledge Base
+
+Patterns learned from code reviews (local Codex and GitHub Codex). This is an
+optional reference — agents may consult relevant patterns before implementing
+to avoid repeating past mistakes.
+
+**For agents:** When you read a pattern file during implementation, bump its
+`ref_count` in frontmatter by 1 and update the Refs column below.
+
+**After a review-fix cycle:** Record new findings by appending to an existing
+pattern or creating a new file. See the spec at
+`docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md` for the
+ingestion protocol.
+
+| Pattern | Category | Findings | Refs | Last Updated |
+| ------- | -------- | -------- | ---- | ------------ |
+```
+
+- [ ] **Step 2: Create `docs/reviews/patterns/.gitkeep`**
+
+Empty file to ensure the `patterns/` directory is tracked by git.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reviews/CLAUDE.md docs/reviews/patterns/.gitkeep
+git commit -m "docs: create review knowledge base directory structure"
+```
+
+---
+
+### Task 2: Seed pattern — filesystem-scope
+
+**Files:**
+
+- Create: `docs/reviews/patterns/filesystem-scope.md`
+- Modify: `docs/reviews/CLAUDE.md`
+
+- [ ] **Step 1: Fetch fix commits for PR #36 filesystem findings**
+
+```bash
+git log --oneline --all --grep="#36" | head -5
+```
+
+Use the commit hash(es) from the PR #36 merge to identify fix commits. If specific fix commits can't be traced, use the merge commit.
+
+- [ ] **Step 2: Create `docs/reviews/patterns/filesystem-scope.md`**
+
+```markdown
+---
+id: filesystem-scope
+category: security
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Filesystem Scope
+
+## Summary
+
+Tauri IPC commands that access the filesystem must validate paths against an
+allowlist. The webview is an untrusted boundary — a compromised renderer could
+enumerate sensitive directories without scope restrictions.
+
+## Findings
+
+### 1. Unrestricted filesystem access from Tauri command
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** HIGH
+- **File:** `src-tauri/src/filesystem/commands.rs`
+- **Finding:** `list_dir` accepts any client-supplied path without validating against an allowed root or Tauri fs scope
+- **Fix:** Added home-directory scope validation — canonicalize requested path, verify `starts_with(home_dir)` before reading
+- **Commit:** `<hash from step 1> <message>`
+
+### 2. File explorer can navigate above home directory
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** MEDIUM
+- **File:** `src/features/files/hooks/useFileTree.ts`
+- **Finding:** `navigateUp` allows navigation to paths outside home scope, triggering access denied errors
+- **Fix:** Clamped `navigateUp` at home directory boundary
+- **Commit:** `<hash from step 1> <message>`
+
+### 3. Rust filesystem tests use temp dir outside allowed home scope
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** HIGH
+- **File:** `src-tauri/src/filesystem/commands.rs`
+- **Finding:** Tests create directories under `/tmp` which is outside the enforced home-directory scope, causing test failures
+- **Fix:** Moved test directories under home directory path
+- **Commit:** `<hash from step 1> <message>`
+```
+
+Replace `<hash from step 1> <message>` with actual git log output from step 1.
+
+- [ ] **Step 3: Update index in `docs/reviews/CLAUDE.md`**
+
+Add this row to the table:
+
+```
+| [Filesystem Scope](patterns/filesystem-scope.md) | security | 3 | 0 | 2026-04-09 |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/reviews/patterns/filesystem-scope.md docs/reviews/CLAUDE.md
+git commit -m "docs: seed filesystem-scope review pattern from PR #36"
+```
+
+---
+
+### Task 3: Seed pattern — react-lifecycle
+
+**Files:**
+
+- Create: `docs/reviews/patterns/react-lifecycle.md`
+- Modify: `docs/reviews/CLAUDE.md`
+
+- [ ] **Step 1: Fetch fix commits for PRs #34 and #36**
+
+```bash
+git log --oneline --all --grep="#34\|#36" | head -10
+```
+
+- [ ] **Step 2: Create `docs/reviews/patterns/react-lifecycle.md`**
+
+```markdown
+---
+id: react-lifecycle
+category: react-patterns
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# React Lifecycle
+
+## Summary
+
+React effects with async work or subscriptions must handle cleanup and guard
+against state updates after unmount. Effect dependency arrays must be minimal
+to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
+
+## Findings
+
+### 1. PTY respawns on every cwd update via OSC 7
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** HIGH
+- **File:** `src/features/terminal/hooks/useTerminal.ts`
+- **Finding:** PTY spawn effect depends on `cwd`, so any directory change kills the running session and spawns a new one
+- **Fix:** Decoupled spawning from cwd — treat cwd as initial spawn parameter stored in a ref
+- **Commit:** `<hash> <message>`
+
+### 2. State updates after unmount in PTY spawn flow
+
+- **Source:** github-codex | PR #34 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/hooks/useTerminal.ts`
+- **Finding:** `setDebugInfo()` called even when `isMountedRef.current` is false, triggering React warnings
+- **Fix:** Gated all state updates (including debug) behind `isMountedRef` guard
+- **Commit:** `<hash> <message>`
+```
+
+- [ ] **Step 3: Update index in `docs/reviews/CLAUDE.md`**
+
+Add row:
+
+```
+| [React Lifecycle](patterns/react-lifecycle.md) | react-patterns | 2 | 0 | 2026-04-09 |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/reviews/patterns/react-lifecycle.md docs/reviews/CLAUDE.md
+git commit -m "docs: seed react-lifecycle review pattern from PRs #34, #36"
+```
+
+---
+
+### Task 4: Seed pattern — resource-cleanup
+
+**Files:**
+
+- Create: `docs/reviews/patterns/resource-cleanup.md`
+- Modify: `docs/reviews/CLAUDE.md`
+
+- [ ] **Step 1: Create `docs/reviews/patterns/resource-cleanup.md`**
+
+```markdown
+---
+id: resource-cleanup
+category: react-patterns
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Resource Cleanup
+
+## Summary
+
+Services that register global event listeners (especially Tauri IPC listeners)
+must be disposed on unmount. Creating a new service instance per component
+mount without cleanup causes listener accumulation and duplicate event handling.
+
+## Findings
+
+### 1. Tauri event listeners leak across terminal panes
+
+- **Source:** github-codex | PR #34 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/services/terminalService.ts`
+- **Finding:** Each `createTerminalService()` call registers global Tauri listeners with no `dispose()` on unmount — listeners accumulate as panes mount/unmount
+- **Fix:** Made Tauri service a singleton or added dispose call in cleanup
+- **Commit:** `<hash> <message>`
+```
+
+- [ ] **Step 2: Update index in `docs/reviews/CLAUDE.md`**
+
+Add row:
+
+```
+| [Resource Cleanup](patterns/resource-cleanup.md) | react-patterns | 1 | 0 | 2026-04-09 |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reviews/patterns/resource-cleanup.md docs/reviews/CLAUDE.md
+git commit -m "docs: seed resource-cleanup review pattern from PR #34"
+```
+
+---
+
+### Task 5: Seed pattern — cross-platform-paths
+
+**Files:**
+
+- Create: `docs/reviews/patterns/cross-platform-paths.md`
+- Modify: `docs/reviews/CLAUDE.md`
+
+- [ ] **Step 1: Create `docs/reviews/patterns/cross-platform-paths.md`**
+
+```markdown
+---
+id: cross-platform-paths
+category: cross-platform
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Cross-Platform Paths
+
+## Summary
+
+Path manipulation using string operations (regex split on `/`) breaks on
+Windows. Drive roots like `C:/Users` become `C:` (drive-relative, not root)
+when the trailing segment is stripped. Always normalize drive roots and
+consider using path libraries for cross-platform code.
+
+## Findings
+
+### 1. Windows path navigation resolves to drive-relative `C:` instead of `C:/`
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** MEDIUM
+- **File:** `src/features/files/hooks/useFileTree.ts`
+- **Finding:** `navigateUp` strips last segment with `/` regex, turning `C:/Users` into `C:` — not a valid absolute path on Windows
+- **Fix:** Added Windows drive root detection — if result matches `^[A-Za-z]:$`, append `/`
+- **Commit:** `<hash> <message>`
+```
+
+- [ ] **Step 2: Update index in `docs/reviews/CLAUDE.md`**
+
+Add row:
+
+```
+| [Cross-Platform Paths](patterns/cross-platform-paths.md) | cross-platform | 1 | 0 | 2026-04-09 |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reviews/patterns/cross-platform-paths.md docs/reviews/CLAUDE.md
+git commit -m "docs: seed cross-platform-paths review pattern from PR #36"
+```
+
+---
+
+### Task 6: Seed pattern — debug-artifacts
+
+**Files:**
+
+- Create: `docs/reviews/patterns/debug-artifacts.md`
+- Modify: `docs/reviews/CLAUDE.md`
+
+- [ ] **Step 1: Create `docs/reviews/patterns/debug-artifacts.md`**
+
+```markdown
+---
+id: debug-artifacts
+category: code-quality
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Debug Artifacts
+
+## Summary
+
+Debug UI elements (red borders, status bars, overlay text) and `console.log`
+statements must not ship to production. Gate debug visuals behind
+`import.meta.env.DEV` or remove them before committing. The project enforces
+`no-console: error` via ESLint, but inline debug UI bypasses this.
+
+## Findings
+
+### 1. Debug status bar rendered unconditionally in TerminalPane
+
+- **Source:** github-codex | PR #34 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane.tsx`
+- **Finding:** Always-on debug status bar with internal state leaks to users and conflicts with Obsidian Lens design
+- **Fix:** Removed debug UI or gated behind `import.meta.env.DEV`
+- **Commit:** `<hash> <message>`
+
+### 2. Debug border and overlay in TerminalZone
+
+- **Source:** github-codex | PR #34 | 2026-04-08
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/TerminalZone.tsx`
+- **Finding:** `border-2 border-red-500` wrapper and debug overlay shipped in production build
+- **Fix:** Removed debug styling
+- **Commit:** `<hash> <message>`
+```
+
+- [ ] **Step 2: Update index in `docs/reviews/CLAUDE.md`**
+
+Add row:
+
+```
+| [Debug Artifacts](patterns/debug-artifacts.md) | code-quality | 2 | 0 | 2026-04-09 |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reviews/patterns/debug-artifacts.md docs/reviews/CLAUDE.md
+git commit -m "docs: seed debug-artifacts review pattern from PR #34"
+```
+
+---
+
+### Task 7: Seed pattern — testing-gaps
+
+**Files:**
+
+- Create: `docs/reviews/patterns/testing-gaps.md`
+- Modify: `docs/reviews/CLAUDE.md`
+
+- [ ] **Step 1: Create `docs/reviews/patterns/testing-gaps.md`**
+
+```markdown
+---
+id: testing-gaps
+category: testing
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Testing Gaps
+
+## Summary
+
+Every `.ts`/`.tsx` production file must have a co-located `.test.ts`/`.test.tsx`
+sibling. New modules added without tests violate the project testing rule and
+increase regression risk. Tests must also respect runtime constraints (e.g.,
+filesystem scope restrictions).
+
+## Findings
+
+### 1. New core modules lack co-located tests
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** HIGH
+- **File:** `src/features/workspace/hooks/useResizable.ts` (and 3 others)
+- **Finding:** Four new production modules added without sibling test files: `useResizable.ts`, `useSessionManager.ts`, `fileSystemService.ts`, `useFileTree.ts`
+- **Fix:** Added co-located test files for all new modules
+- **Commit:** `<hash> <message>`
+```
+
+- [ ] **Step 2: Update index in `docs/reviews/CLAUDE.md`**
+
+Add row:
+
+```
+| [Testing Gaps](patterns/testing-gaps.md) | testing | 1 | 0 | 2026-04-09 |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reviews/patterns/testing-gaps.md docs/reviews/CLAUDE.md
+git commit -m "docs: seed testing-gaps review pattern from PR #36"
+```
+
+---
+
+### Task 8: Seed pattern — terminal-input-handling
+
+**Files:**
+
+- Create: `docs/reviews/patterns/terminal-input-handling.md`
+- Modify: `docs/reviews/CLAUDE.md`
+
+- [ ] **Step 1: Create `docs/reviews/patterns/terminal-input-handling.md`**
+
+```markdown
+---
+id: terminal-input-handling
+category: terminal
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Terminal Input Handling
+
+## Summary
+
+Terminal input processing must handle multi-character input (paste), control
+characters (backspace, delete), and line ending variants (CR, LF, CRLF).
+Processing char-by-char with proper buffer mutation prevents ghost characters,
+double execution, and paste failures.
+
+## Findings
+
+### 1. Backspace does not update the input buffer
+
+- **Source:** github-codex | PR #33 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/services/terminalService.ts`
+- **Finding:** Backspace handler emits visual `\b \b` but never removes the last character from `session.inputBuffer` — deleted characters still execute
+- **Fix:** Added buffer mutation on backspace with empty-buffer guard
+- **Commit:** `<hash> <message>`
+
+### 2. Pasted text with newline never executes
+
+- **Source:** github-codex | PR #33 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/services/terminalService.ts`
+- **Finding:** `write()` only checks `data === '\r'` for Enter — multi-char paste containing newlines falls through to regular character path
+- **Fix:** Process `data` per character, handling control chars individually
+- **Commit:** `<hash> <message>`
+
+### 3. CRLF input executes command twice
+
+- **Source:** github-codex | PR #33 | 2026-04-08
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/services/terminalService.ts`
+- **Finding:** `\r` and `\n` treated as independent Enter events — `\r\n` paste triggers two command executions
+- **Fix:** Normalize input by replacing `\r\n` with `\n` before processing, or track previous char to skip `\n` after `\r`
+- **Commit:** `<hash> <message>`
+```
+
+- [ ] **Step 2: Update index in `docs/reviews/CLAUDE.md`**
+
+Add row:
+
+```
+| [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal | 3 | 0 | 2026-04-09 |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reviews/patterns/terminal-input-handling.md docs/reviews/CLAUDE.md
+git commit -m "docs: seed terminal-input-handling review pattern from PR #33"
+```
+
+---
+
+### Task 9: Seed pattern — documentation-accuracy
+
+**Files:**
+
+- Create: `docs/reviews/patterns/documentation-accuracy.md`
+- Modify: `docs/reviews/CLAUDE.md`
+
+- [ ] **Step 1: Create `docs/reviews/patterns/documentation-accuracy.md`**
+
+```markdown
+---
+id: documentation-accuracy
+category: code-quality
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Documentation Accuracy
+
+## Summary
+
+When implementation changes (removing an addon, renaming a directory, changing
+behavior), inline docs and comments must be updated in the same commit.
+Stale documentation misleads future contributors and review agents.
+
+## Findings
+
+### 1. TerminalPane docs claim WebGL rendering after addon removal
+
+- **Source:** github-codex | PR #33 | 2026-04-08
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane.tsx`
+- **Finding:** Component doc comment lists "Hardware-accelerated rendering with WebGL addon" but WebGL addon was removed in this PR
+- **Fix:** Updated feature list to reflect Canvas2D renderer
+- **Commit:** `<hash> <message>`
+
+### 2. Broken design reference path in mock file tree
+
+- **Source:** github-codex | PR #36 | 2026-04-09
+- **Severity:** LOW
+- **File:** `src/features/files/data/mockFileTree.ts`
+- **Finding:** Comment references `docs/design/left-sidebar/` but actual path is `docs/design/leftsidebar/`
+- **Fix:** Updated comment to correct directory name
+- **Commit:** `<hash> <message>`
+```
+
+- [ ] **Step 2: Update index in `docs/reviews/CLAUDE.md`**
+
+Add row:
+
+```
+| [Documentation Accuracy](patterns/documentation-accuracy.md) | code-quality | 2 | 0 | 2026-04-09 |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reviews/patterns/documentation-accuracy.md docs/reviews/CLAUDE.md
+git commit -m "docs: seed documentation-accuracy review pattern from PRs #33, #36"
+```
+
+---
+
+### Task 10: Wire discovery pointers
+
+**Files:**
+
+- Modify: `CLAUDE.md` (root, index table around line 78-92)
+- Modify: `docs/CLAUDE.md` (add reviews subsection)
+- Modify: `AGENTS.md` (add reference)
+
+- [ ] **Step 1: Add row to root `CLAUDE.md` index table**
+
+Add after the "Shell OSC 7 setup" row (line 92):
+
+```
+| Review knowledge base (patterns from past reviews)       | `docs/reviews/CLAUDE.md`                                          |
+```
+
+- [ ] **Step 2: Add `reviews/` subsection to `docs/CLAUDE.md`**
+
+Add after the `superpowers/specs/` subsection (after line 15):
+
+```markdown
+### `reviews/`
+
+Review knowledge base — patterns learned from local Codex and GitHub Codex code reviews. Each pattern file in `patterns/` collects related findings with their fixes and commit links. Agents may consult relevant patterns before implementing to avoid repeating past mistakes. See `reviews/CLAUDE.md` for the index.
+```
+
+- [ ] **Step 3: Add reference to `AGENTS.md`**
+
+Add after the "Review Guidelines" section (after line 81):
+
+```markdown
+## Review Knowledge Base
+
+Past review findings are collected in `docs/reviews/CLAUDE.md`, grouped by recurring pattern. When reviewing, check if a finding matches an existing pattern — if so, note it. When fixing findings, record the fix in the appropriate pattern file per the ingestion protocol in the design spec.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md docs/CLAUDE.md AGENTS.md
+git commit -m "docs: wire review knowledge base into project discovery docs"
+```
+
+---
+
+### Task 11: Final verification
+
+- [ ] **Step 1: Verify all files exist and are well-formed**
+
+```bash
+ls -la docs/reviews/CLAUDE.md docs/reviews/patterns/*.md
+```
+
+Expected: `CLAUDE.md` + 8 pattern files.
+
+- [ ] **Step 2: Verify index table row count matches pattern count**
+
+```bash
+grep -c "patterns/" docs/reviews/CLAUDE.md
+```
+
+Expected: 8
+
+- [ ] **Step 3: Verify frontmatter is parseable in all pattern files**
+
+```bash
+for f in docs/reviews/patterns/*.md; do
+  echo "--- $f ---"
+  head -8 "$f"
+done
+```
+
+Expected: Each file has `---` delimited YAML with id, category, created, last_updated, ref_count.
+
+- [ ] **Step 4: Verify discovery pointers**
+
+```bash
+grep "reviews" CLAUDE.md docs/CLAUDE.md AGENTS.md
+```
+
+Expected: One match in each file pointing to `docs/reviews/CLAUDE.md`.
+
+- [ ] **Step 5: Remove `.gitkeep` if patterns directory has files**
+
+```bash
+rm docs/reviews/patterns/.gitkeep
+git add docs/reviews/patterns/.gitkeep
+git commit -m "chore: remove .gitkeep now that patterns directory has content"
+```

--- a/docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md
+++ b/docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md
@@ -1,0 +1,171 @@
+# Review Knowledge Base — Design Spec
+
+**Date**: 2026-04-09
+**Status**: Draft
+
+## Problem
+
+Code reviews (local Codex and GitHub Codex) produce findings and fixes, but this
+knowledge is ephemeral. Local reviews overwrite `.codex-reviews/latest.md` each run.
+GitHub reviews live scattered across PR comments. The connection between "finding →
+fix applied" is lost, and agents implementing new features cannot learn from past
+review cycles.
+
+## Solution
+
+A persistent, repo-level knowledge base that collects review findings grouped by
+recurring pattern. Each pattern file accumulates individual findings with their fixes
+and git commit links. Agents consult it during implementation as an optional reference
+— a project-specific "team wisdom" collection built from real reviews.
+
+## Decisions
+
+| Decision         | Choice                                         | Rationale                                                      |
+| ---------------- | ---------------------------------------------- | -------------------------------------------------------------- |
+| Primary consumer | Agents during implementation                   | Improve code quality by learning from past review findings     |
+| Granularity      | Pattern-level grouping, finding-level entries  | Patterns emerge as top-level, individual findings are evidence |
+| Location         | In the repo (`docs/reviews/`)                  | Shared across sessions, accessible to both Claude and Codex    |
+| Discovery        | Passive — referenced in CLAUDE.md/AGENTS.md    | Optional, not mandatory; "good to have" team culture           |
+| Usage tracking   | `ref_count` in frontmatter (honor-system bump) | Lightweight signal for whether agents actually consult it      |
+| Writing          | Automatic after each review-fix cycle          | Agent records finding + fix at the point it has all the data   |
+| Format           | One file per pattern + index                   | Scales well, agents read only what's relevant                  |
+| Git traceability | Commit one-liner per finding                   | `git log --oneline -1` captured at ingestion time              |
+
+## Directory Structure
+
+```
+docs/reviews/
+├── CLAUDE.md                   # Pattern index table with ref counters
+└── patterns/
+    ├── error-boundaries.md
+    ├── input-validation.md
+    ├── async-error-handling.md
+    └── ...
+```
+
+`CLAUDE.md` is the index file — named so it's auto-loaded when agents enter the
+`docs/reviews/` directory context.
+
+## Pattern File Format
+
+```markdown
+---
+id: error-boundaries
+category: react-patterns
+created: 2026-04-09
+last_updated: 2026-04-09
+ref_count: 0
+---
+
+# Error Boundaries
+
+## Summary
+
+React components doing async work need error boundaries to prevent
+white-screen crashes.
+
+## Findings
+
+### 1. Missing ErrorBoundary in FileTree async loader
+
+- **Source:** local-codex | PR #34 | 2026-04-08
+- **Severity:** HIGH
+- **File:** `src/features/files/components/FileTree.tsx`
+- **Finding:** Async file listing can throw but no error boundary catches it
+- **Fix:** Wrapped FileTree in ErrorBoundary with fallback UI
+- **Commit:** `a1b2c3d feat: add error boundary to FileTree component`
+```
+
+Each finding entry captures:
+
+- Source (local-codex / github-codex)
+- PR number (if applicable)
+- Date
+- Severity (CRITICAL / HIGH / MEDIUM / LOW)
+- File path
+- Finding description (one sentence)
+- Fix description (one sentence)
+- Commit one-liner (hash + message from `git log --oneline -1`)
+
+## Index File Format (CLAUDE.md)
+
+```markdown
+# Review Knowledge Base
+
+Patterns learned from code reviews. Agents: consult relevant patterns
+before implementing. Bump `ref_count` in frontmatter when you use one.
+
+| Pattern                                          | Category       | Findings | Refs | Last Updated |
+| ------------------------------------------------ | -------------- | -------- | ---- | ------------ |
+| [Error Boundaries](patterns/error-boundaries.md) | react-patterns | 2        | 0    | 2026-04-09   |
+| [Input Validation](patterns/input-validation.md) | security       | 1        | 0    | 2026-04-09   |
+```
+
+## Ingestion Flow
+
+After a review-fix cycle completes, the agent that performed the fix records it.
+
+**Trigger points:**
+
+1. Local review — after `npm run review` + fix cycle, before the agent stops
+2. GitHub review — after fetching PR comment + fix cycle, before pushing
+3. Harness inner loop — after each Coder+Reviewer iteration that produces fixes
+
+**Steps:**
+
+```
+1. Agent has: finding text + severity + file path + fix description
+2. Agent runs: git log --oneline -1 → captures commit hash + message
+3. Agent reads: docs/reviews/CLAUDE.md → scans for matching pattern
+4. Decision:
+   a) Match found → append new finding entry to existing pattern file
+   b) No match → create new pattern file + add row to CLAUDE.md index
+5. Agent updates: last_updated in frontmatter, finding count in CLAUDE.md
+```
+
+**Classification heuristic:** The agent matches by reading the pattern's Summary
+section and the finding description. A finding that could fit two patterns goes into
+the more specific one. Patterns can be split or merged manually over time.
+
+## Discovery & Reference Protocol
+
+**Pointers added to:**
+
+- Root `CLAUDE.md` index table → `docs/reviews/CLAUDE.md`
+- `docs/CLAUDE.md` → new `reviews/` subsection
+- `AGENTS.md` → reference to `docs/reviews/CLAUDE.md`
+
+**Ref counting protocol:**
+
+1. Agent reads a pattern file during implementation
+2. Agent bumps `ref_count` in that file's frontmatter (+1)
+3. Agent updates the Refs column in `docs/reviews/CLAUDE.md`
+
+Honor-system — agents do it because the instructions say to. If ref counts stay at 0,
+the knowledge base isn't being consulted and you can adjust the approach.
+
+**What this does NOT do:**
+
+- No mandatory pre-implementation check (optional reference)
+- No prompt injection (passive discovery only)
+- No blocking — agents can ignore it entirely
+
+## Integration Points
+
+| File                     | Change                                        |
+| ------------------------ | --------------------------------------------- |
+| `docs/reviews/CLAUDE.md` | Create — pattern index                        |
+| `docs/reviews/patterns/` | Create — pattern files (populated over time)  |
+| `CLAUDE.md` (root)       | Edit — add row to index table                 |
+| `docs/CLAUDE.md`         | Edit — add `reviews/` subsection              |
+| `AGENTS.md`              | Edit — add reference to review knowledge base |
+
+## Out of Scope (Future Iterations)
+
+1. **Automated ingestion hook** — PostToolUse hook or harness plugin that auto-triggers
+   recording. For now, agent-driven via prompt instructions.
+2. **Pattern merging/splitting** — manual curation. Could add a `/review-curate` skill.
+3. **Active prompt injection** — inject relevant patterns into coding prompts based on
+   files being modified. Useful once the collection is large enough.
+4. **Analytics** — ref_count trends, most-flagged categories, review quality over time.
+5. **Severity weighting** — patterns with more CRITICAL/HIGH findings surface higher.

--- a/docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md
+++ b/docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md
@@ -160,6 +160,32 @@ the knowledge base isn't being consulted and you can adjust the approach.
 | `docs/CLAUDE.md`         | Edit — add `reviews/` subsection              |
 | `AGENTS.md`              | Edit — add reference to review knowledge base |
 
+## Seed from History
+
+PRs #33, #34, and #36 have structured Codex review comments with consistent format
+(severity badge, file path, confidence, description). As part of implementation,
+retrospectively parse these comments and populate the initial pattern collection.
+
+**Source PRs:**
+
+| PR  | Title                                                  | Findings |
+| --- | ------------------------------------------------------ | -------- |
+| #36 | feat: interactive sidebar sessions, resizable panels   | ~5       |
+| #34 | feat: Phase 3 Terminal Core - TauriTerminalService IPC | ~3       |
+| #33 | fix: terminal rendering, WebGL, backspace              | ~3       |
+
+**Process:**
+
+1. Fetch review comments via `gh api repos/{owner}/{repo}/issues/{pr}/comments`
+2. Filter for `github-actions[bot]` comments containing findings (skip "No issues found")
+3. Parse each finding: severity, file path, description
+4. Trace fix commits via `git log --oneline` on the PR's merge commit range
+5. Group findings by pattern (agent classifies based on description similarity)
+6. Write pattern files and index
+
+If any PR's data is too noisy or the fix commits can't be traced cleanly, skip that
+PR and move on. The goal is to seed useful patterns, not achieve completeness.
+
 ## Out of Scope (Future Iterations)
 
 1. **Automated ingestion hook** — PostToolUse hook or harness plugin that auto-triggers


### PR DESCRIPTION
## Summary

- Creates `docs/reviews/` as a persistent review knowledge base — patterns learned from Codex code reviews, grouped by recurring theme
- Seeds **14 patterns** with **42 findings** from PRs #14, #21, #23, #25, #27, #30, #31, #33, #34, #35, #36
- Each pattern file has YAML frontmatter (id, category, ref_count) and structured findings with severity, file path, fix description, and commit link
- `docs/reviews/CLAUDE.md` serves as the index (auto-loaded by agents)
- Wires discovery pointers into root `CLAUDE.md`, `docs/CLAUDE.md`, and `AGENTS.md`

**Categories covered:** security (3 patterns), react-patterns (3), code-quality (2), a11y (1), terminal (1), backend (1), correctness (1), testing (1), cross-platform (1)

**Design spec:** `docs/superpowers/specs/2026-04-09-review-knowledge-base-design.md`

## Test plan

- [x] Verify `docs/reviews/CLAUDE.md` index has 14 rows matching 14 pattern files
- [x] Verify all pattern files have valid YAML frontmatter (id, category, created, last_updated, ref_count)
- [x] Verify root `CLAUDE.md`, `docs/CLAUDE.md`, `AGENTS.md` all reference `docs/reviews/CLAUDE.md`
- [x] Verify no code changes — docs only