### PR TITLE
ci: add Claude Code review workflow alongside Codex

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,6 +13,8 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+    outputs:
+      structured_output: ${{ steps.claude.outputs.structured_output }}
     steps:
       - name: Checkout PR merge commit
         uses: actions/checkout@v5
@@ -28,12 +30,17 @@ jobs:
             "$PR_BASE_REF" \
             "+refs/pull/$PR_NUMBER/head"
 
+      - name: Load output schema
+        id: schema
+        run: |
+          SCHEMA=$(jq -c . .github/codex/codex-output-schema.json)
+          echo "json=$SCHEMA" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude review
+        id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: 'true'
-          use_sticky_comment: 'true'
           prompt: |
             This is PR #${{ github.event.pull_request.number }} for ${{ github.repository }}.
 
@@ -52,15 +59,73 @@ jobs:
             - If a bug class appears in multiple places (e.g. missing error handling in both skip_review and review paths), report them together in one finding rather than separately.
 
             Apply confidence-based filtering: only report issues you are >80% confident about.
-            Use severity levels: CRITICAL, HIGH, MEDIUM, LOW. Prefix each finding title with the severity in brackets, e.g. "[HIGH] Missing null check in …".
+            Use severity levels: CRITICAL, HIGH, MEDIUM, LOW.
             Focus on issues introduced by this PR — do not flag pre-existing problems.
 
-            Format the final comment as:
-            ## Claude Code Review
-
-            Then one section per finding, followed by an "Overall" verdict line and a one-paragraph summary.
+            Return your review as structured JSON matching the provided schema. Do not post any comments directly — the workflow will format and post the findings.
 
             Pull request title and body:
             ----
             ${{ github.event.pull_request.title }}
             ${{ github.event.pull_request.body }}
+          claude_args: |
+            --json-schema '${{ steps.schema.outputs.json }}'
+
+  post-feedback:
+    name: Post Review Comment
+    runs-on: ubuntu-latest
+    needs: claude-review
+    if: needs.claude-review.outputs.structured_output != ''
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Format and post Claude review
+        uses: actions/github-script@v7
+        env:
+          CLAUDE_STRUCTURED_OUTPUT: ${{ needs.claude-review.outputs.structured_output }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const raw = process.env.CLAUDE_STRUCTURED_OUTPUT
+            let body
+
+            try {
+              const review = JSON.parse(raw)
+              const lines = ['## Claude Code Review', '']
+
+              if (review.findings && review.findings.length > 0) {
+                const icon = { CRITICAL: '🔴', HIGH: '🟠', MEDIUM: '🟡', LOW: '🔵' }
+                for (const f of review.findings) {
+                  const sev = icon[f.severity] || '⚪'
+                  lines.push(`### ${sev} [${f.severity}] ${f.title}`)
+                  lines.push('')
+                  lines.push(`📍 \`${f.code_location.absolute_file_path}\` L${f.code_location.line_range.start}-${f.code_location.line_range.end}`)
+                  lines.push(`🎯 Confidence: ${(f.confidence_score * 100).toFixed(0)}%`)
+                  lines.push('')
+                  lines.push(f.body)
+                  lines.push('')
+                  lines.push('---')
+                  lines.push('')
+                }
+              } else {
+                lines.push('✅ No issues found.')
+                lines.push('')
+              }
+
+              const verdict = review.overall_correctness === 'patch is correct' ? '✅' : '⚠️'
+              lines.push(`**Overall: ${verdict} ${review.overall_correctness}** (confidence: ${(review.overall_confidence_score * 100).toFixed(0)}%)`)
+              lines.push('')
+              lines.push(`> ${review.overall_explanation}`)
+
+              body = lines.join('\n')
+            } catch {
+              body = `## Claude Code Review\n\n${raw}`
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            })

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,8 +32,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: "true"
-          use_sticky_comment: "true"
+          track_progress: 'true'
+          use_sticky_comment: 'true'
           prompt: |
             This is PR #${{ github.event.pull_request.number }} for ${{ github.repository }}.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,65 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  claude-review:
+    name: Claude Code Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout PR merge commit
+        uses: actions/checkout@v5
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Pre-fetch base and head refs
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch --no-tags origin \
+            "$PR_BASE_REF" \
+            "+refs/pull/$PR_NUMBER/head"
+
+      - name: Run Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: "true"
+          use_sticky_comment: "true"
+          prompt: |
+            This is PR #${{ github.event.pull_request.number }} for ${{ github.repository }}.
+
+            Review ONLY the changes introduced by the PR. Consider:
+               git log --oneline ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+
+            Read AGENTS.md and CLAUDE.md at the repo root for project context and review standards.
+            Read agents/code-reviewer.md for the full review checklist and methodology.
+            Read agents/security-reviewer.md for security review patterns.
+
+            REVIEW QUALITY REQUIREMENTS:
+            - For each finding, specify the EXACT file path and narrowest possible line range (start-end). Read the actual lines and pinpoint where the issue is. Never use L1-1 as a placeholder.
+            - When reporting control flow bugs (loops, branches, error handling), trace ALL code paths through the construct and report the complete issue in ONE finding. Do not split related paths across multiple findings.
+            - Report ALL issues you find in this single review. Assume this is your ONLY chance to review — do not hold back findings for later rounds.
+            - For each finding, explain: (1) what the current code does wrong, (2) the concrete impact, and (3) what the fix should be.
+            - If a bug class appears in multiple places (e.g. missing error handling in both skip_review and review paths), report them together in one finding rather than separately.
+
+            Apply confidence-based filtering: only report issues you are >80% confident about.
+            Use severity levels: CRITICAL, HIGH, MEDIUM, LOW. Prefix each finding title with the severity in brackets, e.g. "[HIGH] Missing null check in …".
+            Focus on issues introduced by this PR — do not flag pre-existing problems.
+
+            Format the final comment as:
+            ## Claude Code Review
+
+            Then one section per finding, followed by an "Overall" verdict line and a one-paragraph summary.
+
+            Pull request title and body:
+            ----
+            ${{ github.event.pull_request.title }}
+            ${{ github.event.pull_request.body }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Checkout PR merge commit
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-review.yml` running `anthropics/claude-code-action@v1` on every `pull_request` in parallel with the existing Codex review.
- Authenticates via `CLAUDE_CODE_OAUTH_TOKEN` so usage bills against the Claude subscription instead of the API.
- Uses `track_progress: true` to force review mode on `pull_request` events and `use_sticky_comment: true` to reuse one comment across pushes instead of stacking new ones.
- Review prompt is reused nearly verbatim from the Codex workflow, with an added instruction to prefix findings with `[SEVERITY]` and use a `## Claude Code Review` header so the two bots' comments are visually distinct.

## Test plan
- [x] Confirm `CLAUDE_CODE_OAUTH_TOKEN` repo secret is set
- ~~[ ] This PR itself triggers the new workflow — verify the Claude review job runs green and posts a comment~~
- [x] Verify the existing Codex review still runs and posts its own separate comment
- [x] Push a follow-up commit and confirm Claude updates the same sticky comment rather than creating a new one
- [ ] Sanity-check that findings use the `[SEVERITY]` prefix and the `## Claude Code Review` header