### PR TITLE
fix(files): add hjkl keyboard nav with scroll-follow to file explorer

### DIFF
--- a/src/features/files/components/FileTree.test.tsx
+++ b/src/features/files/components/FileTree.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vi } from 'vitest'
 import { FileTree } from './FileTree'
 import type { FileNode, ContextMenuAction } from '../types'
 
@@ -137,5 +137,143 @@ describe('FileTree', () => {
     const tree = screen.getByRole('tree', { name: /file tree/i })
     expect(tree).toBeInTheDocument()
     expect(tree).toBeEmptyDOMElement()
+  })
+
+  describe('keyboard navigation', () => {
+    // Selection state is stored as a data attribute on the row. Testing
+    // Library has no a11y query for "currently-selected custom treeitem",
+    // so fall back to a scoped attribute query within the tree container.
+    /* eslint-disable testing-library/no-node-access */
+    const getSelectedRow = (): HTMLElement | null => {
+      const tree = screen.getByRole('tree', { name: /file tree/i })
+
+      return tree.querySelector<HTMLElement>(
+        '[data-file-tree-row="true"][data-selected="true"]'
+      )
+    }
+    /* eslint-enable testing-library/no-node-access */
+
+    test('tree container is focusable', () => {
+      render(<FileTree nodes={mockNodes} contextMenuActions={mockActions} />)
+
+      const tree = screen.getByRole('tree', { name: /file tree/i })
+      expect(tree).toHaveAttribute('tabindex', '0')
+    })
+
+    test('first visible row is selected on mount', () => {
+      render(<FileTree nodes={mockNodes} contextMenuActions={mockActions} />)
+
+      const selected = getSelectedRow()
+      expect(selected).not.toBeNull()
+      expect(selected?.textContent).toContain('src')
+    })
+
+    test('j moves selection to next visible row', () => {
+      render(<FileTree nodes={mockNodes} contextMenuActions={mockActions} />)
+
+      const tree = screen.getByRole('tree', { name: /file tree/i })
+      fireEvent.keyDown(tree, { key: 'j' })
+
+      expect(getSelectedRow()?.textContent).toContain('test.ts')
+    })
+
+    test('k moves selection to previous visible row', () => {
+      render(<FileTree nodes={mockNodes} contextMenuActions={mockActions} />)
+
+      const tree = screen.getByRole('tree', { name: /file tree/i })
+      fireEvent.keyDown(tree, { key: 'j' })
+      fireEvent.keyDown(tree, { key: 'j' })
+      expect(getSelectedRow()?.textContent).toContain('README.md')
+
+      fireEvent.keyDown(tree, { key: 'k' })
+      expect(getSelectedRow()?.textContent).toContain('test.ts')
+    })
+
+    test('ArrowDown is treated as j', () => {
+      render(<FileTree nodes={mockNodes} contextMenuActions={mockActions} />)
+
+      const tree = screen.getByRole('tree', { name: /file tree/i })
+      fireEvent.keyDown(tree, { key: 'ArrowDown' })
+      expect(getSelectedRow()?.textContent).toContain('test.ts')
+    })
+
+    test('j stops at the last row', () => {
+      render(<FileTree nodes={mockNodes} contextMenuActions={mockActions} />)
+
+      const tree = screen.getByRole('tree', { name: /file tree/i })
+      for (let i = 0; i < 10; i += 1) {
+        fireEvent.keyDown(tree, { key: 'j' })
+      }
+      expect(getSelectedRow()?.textContent).toContain('README.md')
+    })
+
+    test('k stops at the first row', () => {
+      render(<FileTree nodes={mockNodes} contextMenuActions={mockActions} />)
+
+      const tree = screen.getByRole('tree', { name: /file tree/i })
+      fireEvent.keyDown(tree, { key: 'k' })
+      fireEvent.keyDown(tree, { key: 'k' })
+      expect(getSelectedRow()?.textContent).toContain('src')
+    })
+
+    test('l activates the selected file row', () => {
+      const onNodeSelect = vi.fn()
+      render(
+        <FileTree
+          nodes={mockNodes}
+          contextMenuActions={mockActions}
+          onNodeSelect={onNodeSelect}
+        />
+      )
+
+      const tree = screen.getByRole('tree', { name: /file tree/i })
+      fireEvent.keyDown(tree, { key: 'j' })
+      fireEvent.keyDown(tree, { key: 'l' })
+
+      expect(onNodeSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'test.ts' }),
+        expect.any(String)
+      )
+    })
+
+    test('h collapses an expanded folder', () => {
+      render(<FileTree nodes={mockNodes} contextMenuActions={mockActions} />)
+
+      expect(screen.getByText('test.ts')).toBeInTheDocument()
+
+      const tree = screen.getByRole('tree', { name: /file tree/i })
+      fireEvent.keyDown(tree, { key: 'h' })
+
+      expect(screen.queryByText('test.ts')).not.toBeInTheDocument()
+    })
+
+    test('h jumps to parent row when on a non-expanded row', () => {
+      render(<FileTree nodes={mockNodes} contextMenuActions={mockActions} />)
+
+      const tree = screen.getByRole('tree', { name: /file tree/i })
+      fireEvent.keyDown(tree, { key: 'j' })
+      expect(getSelectedRow()?.textContent).toContain('test.ts')
+
+      fireEvent.keyDown(tree, { key: 'h' })
+      expect(getSelectedRow()?.textContent).toContain('src')
+    })
+
+    test('scrolls the selected row into view when navigating', () => {
+      const scrollSpy = vi.fn()
+      const original = HTMLElement.prototype.scrollIntoView
+      HTMLElement.prototype.scrollIntoView = scrollSpy
+
+      try {
+        render(<FileTree nodes={mockNodes} contextMenuActions={mockActions} />)
+
+        const tree = screen.getByRole('tree', { name: /file tree/i })
+        scrollSpy.mockClear()
+        fireEvent.keyDown(tree, { key: 'j' })
+
+        expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' })
+      } finally {
+        HTMLElement.prototype.scrollIntoView = original
+      }
+    })
   })
 })

--- a/src/features/files/components/FileTree.tsx
+++ b/src/features/files/components/FileTree.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import type { ReactElement, MouseEvent } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
+import type { ReactElement, MouseEvent, KeyboardEvent } from 'react'
 import type { FileNode, ContextMenuState, ContextMenuAction } from '../types'
 import { FileTreeNode } from './FileTreeNode'
 import { ContextMenu } from './ContextMenu'
@@ -19,7 +19,23 @@ interface FileTreeProps {
 }
 
 /**
- * FileTree container component that manages the tree structure and context menu.
+ * FileTree container component that manages the tree structure, context menu,
+ * and vim-style keyboard navigation (h/j/k/l + arrows).
+ *
+ * Navigation model: selection is tracked via a DOM-querying approach rather
+ * than lifted tree state. Every rendered row in `FileTreeNode` carries a
+ * `data-file-tree-row` marker along with depth/expansion metadata, so the
+ * parent tree can treat the visible rows as an ordered flat list without
+ * having to hoist per-node expansion state out of each `FileTreeNode`.
+ *
+ * j/ArrowDown → next visible row
+ * k/ArrowUp   → previous visible row
+ * l/Enter/ArrowRight → activate current row (expand folder or open file)
+ * h/ArrowLeft → collapse expanded folder, otherwise jump to parent row
+ *
+ * The selected row is always scrolled into view with `scrollIntoView({ block:
+ * 'nearest' })` so a long tree scrolls to follow the cursor instead of
+ * stranding it off-screen.
  */
 export const FileTree = ({
   nodes,
@@ -33,6 +49,8 @@ export const FileTree = ({
     y: 0,
     targetNode: null,
   })
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
 
   const handleContextMenu = (event: MouseEvent, node: FileNode): void => {
     setContextMenuState({
@@ -52,9 +70,113 @@ export const FileTree = ({
     })
   }
 
+  const getRows = useCallback((): HTMLElement[] => {
+    if (!containerRef.current) {
+      return []
+    }
+
+    return Array.from(
+      containerRef.current.querySelectorAll<HTMLElement>(
+        '[data-file-tree-row="true"]'
+      )
+    )
+  }, [])
+
+  // Reset selection when the tree content changes (e.g. directory nav).
+  // Clamp the stored index to the new row count so a stale index doesn't
+  // point past the end of the visible list.
+  useEffect(() => {
+    const rows = getRows()
+    setSelectedIndex((prev) => {
+      if (rows.length === 0) {
+        return 0
+      }
+
+      return Math.min(prev, rows.length - 1)
+    })
+  }, [nodes, getRows])
+
+  // Paint the selection + scroll-follow behavior. Runs after every render
+  // so newly-expanded folders correctly re-mark the active row and bring it
+  // into view.
+  useEffect(() => {
+    const rows = getRows()
+    rows.forEach((row, i) => {
+      if (i === selectedIndex) {
+        row.setAttribute('data-selected', 'true')
+        row.scrollIntoView({ block: 'nearest' })
+      } else {
+        row.removeAttribute('data-selected')
+      }
+    })
+  })
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    const rows = getRows()
+    if (rows.length === 0) {
+      return
+    }
+
+    const key = event.key
+
+    if (key === 'j' || key === 'ArrowDown') {
+      event.preventDefault()
+      setSelectedIndex((i) => Math.min(rows.length - 1, i + 1))
+
+      return
+    }
+
+    if (key === 'k' || key === 'ArrowUp') {
+      event.preventDefault()
+      setSelectedIndex((i) => Math.max(0, i - 1))
+
+      return
+    }
+
+    if (key === 'l' || key === 'Enter' || key === 'ArrowRight') {
+      event.preventDefault()
+      rows[selectedIndex]?.click()
+
+      return
+    }
+
+    if (key === 'h' || key === 'ArrowLeft') {
+      event.preventDefault()
+      const current = rows[selectedIndex]
+
+      // Expanded folder → collapse in place.
+      if (current.getAttribute('data-is-expanded') === 'true') {
+        current.click()
+
+        return
+      }
+
+      // Otherwise walk backwards to the nearest row with shallower depth
+      // (the visual parent) and select it.
+      const depth = Number(current.getAttribute('data-depth') ?? '0')
+      for (let i = selectedIndex - 1; i >= 0; i -= 1) {
+        const candidateDepth = Number(
+          rows[i].getAttribute('data-depth') ?? '0'
+        )
+        if (candidateDepth < depth) {
+          setSelectedIndex(i)
+
+          return
+        }
+      }
+    }
+  }
+
   return (
     <>
-      <div role="tree" aria-label="File tree">
+      <div
+        ref={containerRef}
+        role="tree"
+        aria-label="File tree"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        className="outline-none focus-visible:ring-1 focus-visible:ring-primary/30"
+      >
         {nodes.map((node) => (
           <FileTreeNode
             key={node.id}

--- a/src/features/files/components/FileTreeNode.tsx
+++ b/src/features/files/components/FileTreeNode.tsx
@@ -105,7 +105,13 @@ export const FileTreeNode = ({
   return (
     <div role="treeitem" aria-expanded={isFolder ? isExpanded : undefined}>
       <div
-        className="group flex h-7 cursor-pointer items-center gap-1.5 rounded px-1 text-on-surface/80 transition-colors hover:bg-white/5"
+        data-file-tree-row="true"
+        data-depth={depth}
+        data-is-folder={isFolder ? 'true' : 'false'}
+        data-is-expanded={
+          isFolder ? (isExpanded ? 'true' : 'false') : undefined
+        }
+        className="group flex h-7 cursor-pointer items-center gap-1.5 rounded px-1 text-on-surface/80 transition-colors hover:bg-white/5 data-[selected=true]:bg-primary/15 data-[selected=true]:text-on-surface"
         style={{ paddingLeft: `${indent + 4}px` }}
         onClick={handleClick}
         onContextMenu={handleContextMenu}

--- a/src/features/workspace/components/panels/FileExplorer.tsx
+++ b/src/features/workspace/components/panels/FileExplorer.tsx
@@ -47,7 +47,10 @@ export const FileExplorer = ({
   const isRoot = currentPath === '~' || currentPath === '/'
 
   return (
-    <div className="flex h-full flex-col px-4 pt-3" data-testid="file-explorer">
+    <div
+      className="flex h-full min-h-0 flex-col px-4 pt-3"
+      data-testid="file-explorer"
+    >
       {/* Header */}
       <div className="mb-1 flex items-center gap-2">
         <span className="material-symbols-outlined text-base text-on-surface/50">
@@ -91,8 +94,13 @@ export const FileExplorer = ({
         </span>
       </div>
 
-      {/* Content */}
-      <div className="flex-1 overflow-y-auto">
+      {/* Content — `min-h-0` is required so this `flex-1` child can shrink
+          below the intrinsic height of its content. Without it, the
+          `overflow-y-auto` never engages because the flex child's default
+          `min-height: auto` forces the container to grow to fit the entire
+          tree, which pushed the scrollbar offscreen and made `scrollIntoView`
+          walk up to the wrong ancestor. */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
         {isLoading && (
           <div className="py-4 text-center font-mono text-xs text-on-surface/40">
             Loading...


### PR DESCRIPTION
## Summary

- The file explorer had no keyboard navigation, so pressing `h/j/k/l` did nothing and long directories couldn't be walked without a mouse.
- Added vim-style navigation directly in `FileTree` with auto-scroll so the viewport follows the cursor:
  - `j` / `ArrowDown`, `k` / `ArrowUp` — move selection across visible rows
  - `l` / `Enter` / `ArrowRight` — activate (expand folder / open file)
  - `h` / `ArrowLeft` — collapse expanded folder, else jump to parent row
  - Selected row is scrolled into view via `scrollIntoView({ block: 'nearest' })`
- Selection state is tracked via a DOM-querying approach over data attributes exposed on each `FileTreeNode` row (`data-file-tree-row`, `data-depth`, `data-is-expanded`), avoiding a broader refactor to lift per-node expansion state out of `FileTreeNode`.

## Test plan

- [x] `npx vitest run src/features/files/components/FileTree.test.tsx` — 22 passing (11 new keyboard-nav cases)
- [x] `npm test` — full suite, 1292 passing
- [x] `npm run type-check`
- [x] `npm run lint`
- [ ] Manual: click into the file explorer, navigate with `hjkl` in a long directory, confirm viewport scrolls to keep selection visible
- [ ] Manual: `l` on a folder expands; `h` on an expanded folder collapses; `h` on a file jumps to parent folder row