### PR TITLE
fix(editor): make CodeEditor flex chain bound CodeMirror's scroller

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -19,15 +19,15 @@ ingestion protocol.
 | [Resource Cleanup](patterns/resource-cleanup.md)               | react-patterns | 1        | 0    | 2026-04-09   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)       | cross-platform | 2        | 0    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                 | code-quality   | 3        | 0    | 2026-04-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                       | testing        | 4        | 0    | 2026-04-10   |
+| [Testing Gaps](patterns/testing-gaps.md)                       | testing        | 8        | 0    | 2026-04-11   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 0    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 8        | 0    | 2026-04-10   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 9        | 0    | 2026-04-11   |
 | [Accessibility](patterns/accessibility.md)                     | a11y           | 11       | 0    | 2026-04-10   |
 | [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 9        | 0    | 2026-04-10   |
 | [Command Injection](patterns/command-injection.md)             | security       | 4        | 0    | 2026-04-09   |
 | [CSP Configuration](patterns/csp-configuration.md)             | security       | 2        | 0    | 2026-04-09   |
 | [PTY Session Management](patterns/pty-session-management.md)   | backend        | 5        | 0    | 2026-04-09   |
 | [Git Operations](patterns/git-operations.md)                   | correctness    | 5        | 0    | 2026-04-09   |
-| [CodeMirror Integration](patterns/codemirror-integration.md)   | editor         | 10       | 0    | 2026-04-10   |
+| [CodeMirror Integration](patterns/codemirror-integration.md)   | editor         | 12       | 0    | 2026-04-11   |
 | [Error Surfacing](patterns/error-surfacing.md)                 | error-handling | 7        | 0    | 2026-04-10   |
 | [File Tree Paths](patterns/file-tree-paths.md)                 | files          | 4        | 0    | 2026-04-10   |

--- a/docs/reviews/patterns/codemirror-integration.md
+++ b/docs/reviews/patterns/codemirror-integration.md
@@ -2,7 +2,7 @@
 id: codemirror-integration
 category: editor
 created: 2026-04-10
-last_updated: 2026-04-10
+last_updated: 2026-04-11
 ref_count: 0
 ---
 
@@ -112,3 +112,27 @@ affects event/command routing.
 - **Finding:** The content-sync effect bailed out via `if (!fileContent) return`, so opening a zero-byte file (or a file that became empty) never called `updateContent`. The editor kept showing the previous file's content, and subsequent `:w` could overwrite the wrong file contents.
 - **Fix:** Gate on `loadedFilePath === null` instead of content truthiness. Empty files still trigger an `updateContent('')` that correctly clears the buffer.
 - **Commit:** `cc17251 fix(editor): wire vim state, visual selection, and editor lifecycle`
+
+### 11. Three-layer scroll bug: flex chain + `.cm-editor` height + vim motions never scroll
+
+- **Source:** local-debugging | PR #43 | 2026-04-11
+- **Severity:** HIGH
+- **File:** `src/features/workspace/components/BottomDrawer.tsx`, `src/features/editor/components/CodeEditor.tsx`, `src/features/editor/theme/catppuccin.ts`, `src/features/editor/hooks/useCodeMirror.ts`
+- **Finding:** The CodeMirror viewport never scrolled. `.cm-scroller` showed no scrollbar, mouse wheel did nothing, and vim `j/k/G/Ctrl-d` moved the cursor off-screen without the viewport following. Three independent causes had to all be present to break scrolling, and all three had to be fixed together to restore it:
+  1. **Flex chain was unbounded.** Every wrapper between `<section style={{ height: drawerHeight }}>` and `<div ref={setContainer}>` was `flex-1` with no `min-h-0`. `min-height: auto` on each flex child grew the chain to the full CodeMirror content height, so even though the drawer had a fixed pixel height, `h-full` on the container resolved to an auto-sized parent and became content-sized by the time it reached CodeMirror.
+  2. **`.cm-editor` was not told to fill its container.** The Catppuccin theme set colors but never set `height: 100%` on `&` (the `.cm-editor` root). CM6 defaults `.cm-editor` to content-based sizing unless the theme overrides it, so even after the container div had a real pixel height, `.cm-editor` ignored it and `.cm-scroller` had no overflow to scroll against.
+  3. **Vim NORMAL-mode motions never dispatch `scrollIntoView`.** CM6 auto-scrolls when a selection-changing transaction carries a `scrollIntoView` effect or a `"select"` userEvent annotation. `@replit/codemirror-vim` dispatches motion transactions with neither — so insert-mode typing scrolled (doc changes take CM6's built-in scroll path) but normal-mode `j/k/G` silently parked the cursor off-screen.
+- **Fix:** Apply the three fixes in one PR because any one alone leaves the editor with at least one of: "no scrollbar", "scrollbar but content-sized container", or "working scrollbar that vim motions don't trigger":
+  1. `min-h-0 overflow-hidden` on every `flex-1` wrapper from `BottomDrawer` content area down through `editor-panel`, `diff-panel`, `CodeEditor` root, `CodeEditor` inner, AND the `!filePath` early-return branch. Symmetry matters: a future richer no-file placeholder would re-trigger the bug without the early-return fix.
+  2. `EditorView.theme({ '&': { height: '100%' }, '.cm-scroller': { overflow: 'auto' } })` merged into the Catppuccin theme. This is the canonical CM6 "fill container" recipe.
+  3. `EditorState.transactionExtender.of(scrollCursorOnSelectionChange)` where the extender attaches an `EditorView.scrollIntoView(tr.newSelection.main.head, { y: 'nearest' })` effect to any pure-selection transaction. **Crucially:** use `transactionExtender`, NOT `updateListener`. An update-listener approach dispatches a SECOND transaction after CM6 has already measured with stale cursor coordinates, producing a "scrolls exactly one row then silently no-ops forever" bug. The extender bakes the effect into the ORIGINAL transaction so CM6 measures the final state atomically. Guard on `!tr.selection || tr.docChanged` to skip effect-only transactions, insert-mode typing, and vim mutation commands (`dd`, `dw`, etc. that are both `docChanged` AND selection-setting) — those hit CM6's built-in scroll path.
+- **Commit:** `1f34032 fix(editor): fill cm-editor to container and enable cm-scroller overflow`
+
+### 12. Naming the extender "vim motion" oversold its scope
+
+- **Source:** github-claude | PR #43 round 2 | 2026-04-11
+- **Severity:** LOW
+- **File:** `src/features/editor/hooks/useCodeMirror.ts`
+- **Finding:** The scroll extender was originally named `scrollCursorOnVimMotion` and its JSDoc described it as catching vim normal-mode motions specifically. But the guard `!tr.selection || tr.docChanged` catches EVERY pure-selection transaction — mouse clicks that move the cursor, arrow-key navigation, find-replace jumps, programmatic selections from other extensions. CM6 has no general-purpose API to identify transaction origin, so narrowing to vim-only isn't actually possible without inspecting `Transaction.userEvent` and coupling to vim-extension internals.
+- **Fix:** Rename to `scrollCursorOnSelectionChange` and rewrite the JSDoc to describe the actual scope — the behavior is deliberately inclusive, every pure-selection transaction is a cursor move the user expects the viewport to follow. Behavior unchanged.
+- **Commit:** `3f8bf2c fix(editor): address Claude review round 2 — test guard, naming, symmetry`

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -2,7 +2,7 @@
 id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
-last_updated: 2026-04-10
+last_updated: 2026-04-11
 ref_count: 0
 ---
 
@@ -87,3 +87,12 @@ Stale documentation misleads future contributors and review agents.
 - **Finding:** Comment claimed `useCallback` memoization prevents the dialog focus-trap from re-binding on each render. The reasoning was wrong: the focus-trap effect depends on `onCancel`, not `onSave`, and `editorBuffer` is a plain object rebuilt on every `useEditorBuffer` render (every keystroke) so `handleSave`'s identity is actually unstable. Harmless in practice (the dialog captures focus while open) but the comment created false confidence.
 - **Fix:** Replace with an accurate description of the current situation and a note for future refactors (destructure stable callbacks from `editorBuffer` if it's memoized later).
 - **Commit:** `38292c7 fix: address Claude review round 15 findings`
+
+### 9. Brittleness note suggested a fix that wouldn't compile
+
+- **Source:** github-claude | PR #43 round 4 | 2026-04-11
+- **Severity:** LOW
+- **File:** `src/features/editor/hooks/useCodeMirror.test.ts`
+- **Finding:** A JSDoc brittleness note on the `readScrollTargetPos` test helper advised future maintainers to harden the effect-type check by writing `effect.is(EditorView.scrollIntoView)`, stating it "IS a `StateEffectType` comparable via `effect.is(scrollIntoView)`". This is wrong on two counts: `EditorView.scrollIntoView` is a factory function with signature `(pos, options?) => StateEffect<ScrollTarget>`, not a `StateEffectType`, and `StateEffect.is()` accepts a `StateEffectType`, not a factory. A developer following the comment's guidance would hit a compile error, then waste time investigating why the "correct" fix doesn't work.
+- **Fix:** Rewrite the brittleness note to correctly describe `EditorView.scrollIntoView` as a factory, explain that CM6 does not publicly export the underlying `StateEffectType`, show the actual escape hatch (`EditorView.scrollIntoView(0).type` reads the underlying type off a throwaway instance), and recommend fixing the duck-type shape directly rather than hardening the type comparison in the common case.
+- **Commit:** `21d7c00 docs(editor): fix incorrect StateEffectType comment in round-4 brittleness note`

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,7 +2,7 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-04-10
+last_updated: 2026-04-11
 ref_count: 0
 ---
 
@@ -52,3 +52,39 @@ filesystem scope restrictions).
 - **Finding:** When `isLoading` state was added to `useEditorBuffer` to show a loading overlay during async file reads, no tests verified the overlay rendered when `isLoading=true` or was absent when `isLoading=false`.
 - **Fix:** Add two tests covering both states, including `role="status"` and test-id assertions.
 - **Commit:** `0c8f0ac fix: address Claude review round 12 findings`
+
+### 5. Behavior test asserted a side-effect that happens regardless of the function under test
+
+- **Source:** github-claude | PR #43 round 1 | 2026-04-11
+- **Severity:** LOW
+- **File:** `src/features/editor/hooks/useCodeMirror.test.ts`
+- **Finding:** A test titled `attaches scrollIntoView effect to pure selection change (vim motion)` was intended to verify the `transactionExtender` attaches a `scrollIntoView` effect to selection-only transactions. The sole assertion was `expect(view.state.selection.main.head).toBe(20)`, which only confirms the selection was committed — a behavior that happens inside CodeMirror's core dispatch regardless of whether the extender ran or returned anything. A transactionExtender that unconditionally returned `null` would still pass this test. The inline comment even acknowledged "effects aren't queryable post-commit," but framed the assertion as proving the extender ran.
+- **Fix:** Extract the extender body from an inline anonymous function inside `useCodeMirror.ts` into a module-level exported pure function `scrollCursorOnSelectionChange(tr)`. Unit-test that directly on synthetic transactions built via `EditorState.update({...})` and inspect the returned `TransactionSpec`. This is the only reliable approach in jsdom — it has no layout pass, so DOM-level scroll position is unobservable and post-dispatch effect inspection is unreliable. Assert `result !== null`, `effects.length > 0`, and `effects[0] instanceof StateEffect`.
+- **Commit:** `a7aea76 test(editor): directly unit-test scrollCursorOnVimMotion extender`
+
+### 6. Regression-guard test didn't actually verify the property it claimed to guard
+
+- **Source:** github-claude | PR #43 round 2 | 2026-04-11
+- **Severity:** MEDIUM
+- **File:** `src/features/editor/hooks/useCodeMirror.test.ts`
+- **Finding:** A test titled `uses the new main cursor head position, not the old one` was documented as a regression guard against anyone swapping `tr.newSelection.main.head` (correct) for `tr.startState.selection.main.head` (wrong). It set up a selection move from 0 → 20 and asserted `tr.newSelection.main.head === 20` and `tr.startState.selection.main.head === 0` as preconditions, but the only assertion on the function under test was `expect(result).not.toBeNull()`. A non-null result would occur for both the correct and the incorrect implementation, so the guard would NOT catch the regression it claimed to prevent. If someone reverted the extender to read the old head position, all tests would still pass and the editor would silently scroll to the wrong place.
+- **Fix:** Inspect the scroll effect's target position directly. CodeMirror's `scrollIntoView` effect is a `StateEffect<ScrollTarget>` where `ScrollTarget` is an internal class with shape `{ range: SelectionRange, ... }`. The type isn't exported, so use a duck-type reader (`effect.value.range.head`) guarded by the CM6 version it was verified against. Assert `targetPos === 20`. Now the test fails if anyone reads the wrong selection reference.
+- **Commit:** `3f8bf2c fix(editor): address Claude review round 2 — test guard, naming, symmetry`
+
+### 7. Uncovered guard branch: doc-change-plus-selection (vim mutation path)
+
+- **Source:** github-claude | PR #43 round 3 | 2026-04-11
+- **Severity:** LOW
+- **File:** `src/features/editor/hooks/useCodeMirror.test.ts`
+- **Finding:** The `scrollCursorOnSelectionChange` guard is `!tr.selection || tr.docChanged`. Tests covered the `!tr.selection` branch (effect-only transactions) and the `!tr.selection` path for insert-mode typing (`view.update({ changes: ... })` has `docChanged=true` but `tr.selection === undefined`, so the `!tr.selection` branch triggers first). But NO test exercised the OTHER branch — vim mutation commands like `dd`, `dw`, `cc`, `x`, `r` dispatch transactions that are BOTH a doc change AND an explicit selection change, and they hit the `|| tr.docChanged` branch. A future refactor that flipped `||` to `&&` would go undetected: insert mode would still be skipped via `!tr.selection`, but vim mutations would start firing the extender, double-scrolling on top of CM6's built-in doc-change scroll and causing jitter.
+- **Fix:** Add a test that constructs a `docChanged + explicit selection` transaction (delete range + cursor move), asserts both `tr.docChanged === true` and `tr.selection !== undefined`, then asserts `scrollCursorOnSelectionChange(tr) === null`. Every guard branch now has direct coverage.
+- **Commit:** `edef449 test(editor): address Claude review round 3 — vim mutation test + false-positive note`
+
+### 8. Duck-type helper needed a false-positive gate, not just a truth-check
+
+- **Source:** github-claude | PR #43 round 5 | 2026-04-11
+- **Severity:** LOW
+- **File:** `src/features/editor/hooks/useCodeMirror.test.ts`
+- **Finding:** The `readScrollTargetPos` test helper duck-typed `effect.value.range.head` to read the scroll target. It was gated only on `instanceof StateEffect` at the call site — but `StateEffect` is the common base class of every CM6 effect, so any unrelated effect (compartment reconfiguration, language swap, future CM6 effects) whose `.value` accidentally had a `range.head: number` field would match. The regression test would then pass on the wrong effect. Also: the weak base-class check in the other test (`expect(effects[0]).toBeInstanceOf(StateEffect)`) would let any effect through, so a refactor that replaced `scrollIntoView(...)` with any other effect would leave both tests green.
+- **Fix:** Derive a real `StateEffectType` reference by constructing a throwaway `EditorView.scrollIntoView(0)` at module load and reading its `.type` field. `.type` is a runtime field of `StateEffect` that CM6's public types don't surface, so cast through `unknown as { type: StateEffectType<unknown> }`. `readScrollTargetPos` now gates on `effect.is(scrollIntoViewType)` before accessing `.value.range.head`, so it rejects any effect that isn't genuinely a scrollIntoView. The basic "effect exists" test also calls `readScrollTargetPos` and asserts a number, so it fails if the extender is refactored to return a different effect type.
+- **Commit:** `d38cf4b test(editor): tighten scrollIntoView effect detection in round-5 tests`

--- a/src/features/editor/components/CodeEditor.tsx
+++ b/src/features/editor/components/CodeEditor.tsx
@@ -88,8 +88,8 @@ export const CodeEditor = ({
   }
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
-      <div className="relative flex-1 overflow-hidden">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="relative min-h-0 flex-1 overflow-hidden">
         <div
           ref={setContainer}
           data-testid="codemirror-container"

--- a/src/features/editor/components/CodeEditor.tsx
+++ b/src/features/editor/components/CodeEditor.tsx
@@ -77,9 +77,16 @@ export const CodeEditor = ({
   }, [content, filePath, updateContent])
 
   if (!filePath) {
+    // `min-h-0` matches the invariant the main return path establishes:
+    // every flex child in CodeEditor must be prevented from growing
+    // past its bounded parent. No visible bug today because the
+    // placeholder is trivially short, but keeping the invariant
+    // consistent across both branches means a future richer placeholder
+    // (file picker, tips widget, animated illustration) won't silently
+    // reintroduce the flex `min-height: auto` scroll bug.
     return (
       <div
-        className="flex flex-1 items-center justify-center text-on-surface-variant"
+        className="flex min-h-0 flex-1 items-center justify-center text-on-surface-variant"
         data-testid="no-file-selected"
       >
         No file selected

--- a/src/features/editor/hooks/useCodeMirror.test.ts
+++ b/src/features/editor/hooks/useCodeMirror.test.ts
@@ -166,7 +166,7 @@ describe('useCodeMirror', () => {
     expect(result.current.editorView).toBeInstanceOf(EditorView)
   })
 
-  test('dispatches scrollIntoView effect on pure selection change (vim motion)', () => {
+  test('attaches scrollIntoView effect to pure selection change (vim motion)', () => {
     const { result } = renderHook(() =>
       useCodeMirror({
         initialContent: 'line one\nline two\nline three\nline four',
@@ -184,26 +184,23 @@ describe('useCodeMirror', () => {
       throw new Error('editor view not initialized')
     }
 
-    const dispatchSpy = vi.spyOn(view, 'dispatch')
-
     // Simulate a vim normal-mode motion: pure selection change, no doc
     // change. Move the cursor into the third line.
     act(() => {
       view.dispatch({ selection: { anchor: 20, head: 20 } })
     })
 
-    // The listener should follow-up with a dispatch carrying the
-    // scrollIntoView effect for the new cursor head.
-    const scrollCall = dispatchSpy.mock.calls.find((call) => {
-      const tx = call[0] as { effects?: unknown }
-
-      return tx.effects !== undefined
-    })
-
-    expect(scrollCall).toBeDefined()
+    // After the transactionExtender runs, the committed transaction's
+    // effects should include the scroll-into-view effect for the new
+    // cursor head. We read it off the last-applied transaction via the
+    // view's recorded selection — effects aren't queryable post-commit,
+    // so we assert the behavioral outcome: the selection actually moved
+    // to the requested offset, proving the extender didn't swallow it
+    // while also scheduling the scroll on the same transaction.
+    expect(view.state.selection.main.head).toBe(20)
   })
 
-  test('does not dispatch extra scroll transaction on doc change (insert mode)', () => {
+  test('does not attach scroll effect on doc change (insert mode)', () => {
     const { result } = renderHook(() =>
       useCodeMirror({
         initialContent: 'hello',
@@ -221,20 +218,14 @@ describe('useCodeMirror', () => {
       throw new Error('editor view not initialized')
     }
 
-    const dispatchSpy = vi.spyOn(view, 'dispatch')
-
-    // Simulate insert-mode typing: docChanged, so CodeMirror's built-in
-    // scroll path already fires and our listener must not duplicate it.
+    // Sanity check: a doc-change transaction must still commit without
+    // the extender interfering. Insert mode uses CodeMirror's built-in
+    // scroll path; our extender must early-return for these so we don't
+    // double-scroll or clobber existing scroll effects.
     act(() => {
       view.dispatch({ changes: { from: 5, insert: ' world' } })
     })
 
-    const scrollCall = dispatchSpy.mock.calls.find((call) => {
-      const tx = call[0] as { effects?: unknown }
-
-      return tx.effects !== undefined
-    })
-
-    expect(scrollCall).toBeUndefined()
+    expect(view.state.doc.toString()).toBe('hello world')
   })
 })

--- a/src/features/editor/hooks/useCodeMirror.test.ts
+++ b/src/features/editor/hooks/useCodeMirror.test.ts
@@ -13,6 +13,18 @@ import { EditorState, StateEffect } from '@codemirror/state'
  * The type isn't exported, so we duck-type it: look for a `range.head`
  * field and return it. Returns `undefined` if the effect isn't a scroll
  * effect or the shape doesn't match.
+ *
+ * **Brittleness note:** the `.range.head` access is verified against
+ * `@codemirror/view` 6.41.0 (the version pinned in this repo). If a
+ * future CM6 bump renames or restructures `ScrollTarget`, this helper
+ * will silently return `undefined` and the regression-guard test below
+ * (`targets the NEW cursor head position, not the old one`) will fail
+ * with `expect(undefined).toBe(20)`. If you see that failure after a
+ * CodeMirror upgrade, the fix is to re-inspect the
+ * `@codemirror/view` source for the new `ScrollTarget` shape and
+ * update this helper accordingly — the extender itself is
+ * a one-liner using `tr.newSelection.main.head` so the production
+ * code almost certainly doesn't need to change.
  */
 const readScrollTargetPos = (
   effect: StateEffect<unknown>

--- a/src/features/editor/hooks/useCodeMirror.test.ts
+++ b/src/features/editor/hooks/useCodeMirror.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { useCodeMirror } from './useCodeMirror'
+import { useCodeMirror, scrollCursorOnVimMotion } from './useCodeMirror'
 import { EditorView } from '@codemirror/view'
+import { EditorState, StateEffect } from '@codemirror/state'
 
 describe('useCodeMirror', () => {
   let containerDiv: HTMLDivElement
@@ -165,67 +166,83 @@ describe('useCodeMirror', () => {
 
     expect(result.current.editorView).toBeInstanceOf(EditorView)
   })
+})
 
-  test('attaches scrollIntoView effect to pure selection change (vim motion)', () => {
-    const { result } = renderHook(() =>
-      useCodeMirror({
-        initialContent: 'line one\nline two\nline three\nline four',
-        language: null,
-        onSave: vi.fn(),
-      })
-    )
+describe('scrollCursorOnVimMotion', () => {
+  // These tests exercise the transactionExtender as a PURE FUNCTION,
+  // not through a mounted EditorView. jsdom has no layout pass so we
+  // can't observe `scrollTop` on `.cm-scroller`; the most reliable way
+  // to verify the extender actually attaches a scroll effect is to
+  // invoke it directly on a synthetic transaction and inspect the
+  // returned TransactionSpec.
 
-    act(() => {
-      result.current.setContainer(containerDiv)
+  test('returns a scroll effect for a pure selection change (vim motion)', () => {
+    const state = EditorState.create({
+      doc: 'line one\nline two\nline three\nline four',
     })
+    const tr = state.update({ selection: { anchor: 20, head: 20 } })
 
-    const view = result.current.editorView
-    if (!view) {
-      throw new Error('editor view not initialized')
-    }
+    const result = scrollCursorOnVimMotion(tr)
 
-    // Simulate a vim normal-mode motion: pure selection change, no doc
-    // change. Move the cursor into the third line.
-    act(() => {
-      view.dispatch({ selection: { anchor: 20, head: 20 } })
-    })
+    expect(result).not.toBeNull()
 
-    // After the transactionExtender runs, the committed transaction's
-    // effects should include the scroll-into-view effect for the new
-    // cursor head. We read it off the last-applied transaction via the
-    // view's recorded selection — effects aren't queryable post-commit,
-    // so we assert the behavioral outcome: the selection actually moved
-    // to the requested offset, proving the extender didn't swallow it
-    // while also scheduling the scroll on the same transaction.
-    expect(view.state.selection.main.head).toBe(20)
+    // `effects` may be a single effect or an array. Normalize and verify
+    // at least one is a `StateEffect` instance (every `scrollIntoView`
+    // effect is one).
+    const effects = result?.effects
+
+    const effectArray = Array.isArray(effects)
+      ? effects
+      : effects !== undefined
+        ? [effects]
+        : []
+
+    expect(effectArray.length).toBeGreaterThan(0)
+    expect(effectArray[0]).toBeInstanceOf(StateEffect)
   })
 
-  test('does not attach scroll effect on doc change (insert mode)', () => {
-    const { result } = renderHook(() =>
-      useCodeMirror({
-        initialContent: 'hello',
-        language: null,
-        onSave: vi.fn(),
-      })
-    )
-
-    act(() => {
-      result.current.setContainer(containerDiv)
+  test('uses the new main cursor head position, not the old one', () => {
+    // Move selection from 0 → 20 and make sure the extender reads
+    // `tr.newSelection.main.head` (post-transaction state), not
+    // `tr.startState.selection.main.head` (pre-transaction state).
+    // Regression guard against anyone tempted to "simplify" the guard
+    // and accidentally target the wrong selection reference.
+    const state = EditorState.create({
+      doc: 'line one\nline two\nline three\nline four',
     })
+    const tr = state.update({ selection: { anchor: 20, head: 20 } })
 
-    const view = result.current.editorView
-    if (!view) {
-      throw new Error('editor view not initialized')
-    }
+    expect(tr.newSelection.main.head).toBe(20)
+    expect(tr.startState.selection.main.head).toBe(0)
 
-    // Sanity check: a doc-change transaction must still commit without
-    // the extender interfering. Insert mode uses CodeMirror's built-in
-    // scroll path; our extender must early-return for these so we don't
-    // double-scroll or clobber existing scroll effects.
-    act(() => {
-      view.dispatch({ changes: { from: 5, insert: ' world' } })
-    })
+    const result = scrollCursorOnVimMotion(tr)
 
-    expect(view.state.doc.toString()).toBe('hello world')
+    expect(result).not.toBeNull()
+  })
+
+  test('returns null for doc change (insert mode path)', () => {
+    // Insert mode typing uses CodeMirror's built-in scroll path because
+    // every keystroke is a doc change. The extender MUST early-return
+    // here so we don't duplicate the built-in scroll or fight with it.
+    const state = EditorState.create({ doc: 'hello' })
+    const tr = state.update({ changes: { from: 5, insert: ' world' } })
+
+    const result = scrollCursorOnVimMotion(tr)
+
+    expect(result).toBeNull()
+  })
+
+  test('returns null for effect-only transaction (no selection change)', () => {
+    // Transactions that carry only effects (e.g. language reconfiguration
+    // via the language compartment) have no selection spec. The extender
+    // must early-return so it doesn't accidentally schedule a scroll on
+    // every unrelated effect that flows through the state.
+    const state = EditorState.create({ doc: 'hello' })
+    const noopEffect = StateEffect.define<number>()
+    const tr = state.update({ effects: noopEffect.of(1) })
+
+    const result = scrollCursorOnVimMotion(tr)
+
+    expect(result).toBeNull()
   })
 })

--- a/src/features/editor/hooks/useCodeMirror.test.ts
+++ b/src/features/editor/hooks/useCodeMirror.test.ts
@@ -30,13 +30,22 @@ import { EditorState, StateEffect } from '@codemirror/state'
  * a different `StateEffect` type whose `.value` also has a
  * `range.head: number` field, this helper will happily extract it and
  * the regression test would pass even on a different (wrong) effect.
- * The test's upstream assertion
- * (`effects[0] instanceof StateEffect`) is too weak to distinguish
- * effect types — `StateEffect` is the common base class of every CM6
- * effect. If you ever suspect this test is passing on the wrong
- * effect, strengthen it by matching the effect against
- * `EditorView.scrollIntoView` directly (it IS a `StateEffectType`
- * comparable via `effect.is(scrollIntoView)`).
+ * The upstream `instanceof StateEffect` check is too weak to catch
+ * this — `StateEffect` is the common base class of every CM6 effect.
+ *
+ * Strong-typing the comparison is awkward because CM6 does NOT
+ * publicly export the `StateEffectType` for scroll. `EditorView.
+ * scrollIntoView` itself is a factory function with signature
+ * `(pos, options?) => StateEffect<ScrollTarget>`, not a
+ * `StateEffectType`, so `effect.is(EditorView.scrollIntoView)` would
+ * fail to type-check. The only way to get the underlying type is to
+ * create a throwaway instance and read its `.type`
+ * (`EditorView.scrollIntoView(0).type`), which can then be compared
+ * via `effects[0].is(...)`. If this test ever starts producing
+ * suspicious false positives, that's the escape hatch — but the
+ * cleaner remediation is usually to update `readScrollTargetPos`'s
+ * duck-type to whatever new shape CM6 introduced, not to harden the
+ * type comparison.
  */
 const readScrollTargetPos = (
   effect: StateEffect<unknown>

--- a/src/features/editor/hooks/useCodeMirror.test.ts
+++ b/src/features/editor/hooks/useCodeMirror.test.ts
@@ -25,6 +25,18 @@ import { EditorState, StateEffect } from '@codemirror/state'
  * update this helper accordingly — the extender itself is
  * a one-liner using `tr.newSelection.main.head` so the production
  * code almost certainly doesn't need to change.
+ *
+ * **False-positive failure mode:** if a future CM6 version introduces
+ * a different `StateEffect` type whose `.value` also has a
+ * `range.head: number` field, this helper will happily extract it and
+ * the regression test would pass even on a different (wrong) effect.
+ * The test's upstream assertion
+ * (`effects[0] instanceof StateEffect`) is too weak to distinguish
+ * effect types — `StateEffect` is the common base class of every CM6
+ * effect. If you ever suspect this test is passing on the wrong
+ * effect, strengthen it by matching the effect against
+ * `EditorView.scrollIntoView` directly (it IS a `StateEffectType`
+ * comparable via `effect.is(scrollIntoView)`).
  */
 const readScrollTargetPos = (
   effect: StateEffect<unknown>
@@ -268,8 +280,46 @@ describe('scrollCursorOnSelectionChange', () => {
     // Insert mode typing uses CodeMirror's built-in scroll path because
     // every keystroke is a doc change. The extender MUST early-return
     // here so we don't duplicate the built-in scroll or fight with it.
+    //
+    // This transaction has `docChanged=true` AND `tr.selection ===
+    // undefined`, so the early return fires via the `!tr.selection`
+    // branch of the guard. Vim mutation commands (`dd`, `dw`, etc.)
+    // exercise the OTHER branch (`tr.docChanged` with a defined
+    // selection); see the test below.
     const state = EditorState.create({ doc: 'hello' })
     const tr = state.update({ changes: { from: 5, insert: ' world' } })
+
+    const result = scrollCursorOnSelectionChange(tr)
+
+    expect(result).toBeNull()
+  })
+
+  test('returns null for doc change that also sets selection (vim mutation path)', () => {
+    // Vim mutation commands like `dd`, `dw`, `cc`, `x`, `r` dispatch
+    // transactions that are BOTH a doc change AND an explicit
+    // selection change — the document mutates and the cursor lands on
+    // a new position in one atomic transaction. These have
+    // `docChanged=true` AND `tr.selection !== undefined`, so the
+    // guard's `|| tr.docChanged` branch is what early-returns them.
+    // Insert-mode typing (previous test) hits the `!tr.selection`
+    // branch instead.
+    //
+    // Without this test, a future refactor that flips the guard from
+    // `||` to `&&` would break silently: insert mode would still be
+    // skipped (via `!tr.selection`), but vim mutations would start
+    // firing the extender, double-scrolling on top of CM6's built-in
+    // doc-change scroll and causing jitter / fighting behavior.
+    const state = EditorState.create({
+      doc: 'line one\nline two\nline three',
+    })
+
+    const tr = state.update({
+      changes: { from: 0, to: 9 }, // delete first line ("line one\n")
+      selection: { anchor: 0, head: 0 }, // cursor lands on new first line
+    })
+
+    expect(tr.docChanged).toBe(true)
+    expect(tr.selection).toBeDefined()
 
     const result = scrollCursorOnSelectionChange(tr)
 

--- a/src/features/editor/hooks/useCodeMirror.test.ts
+++ b/src/features/editor/hooks/useCodeMirror.test.ts
@@ -1,8 +1,30 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { useCodeMirror, scrollCursorOnVimMotion } from './useCodeMirror'
+import { useCodeMirror, scrollCursorOnSelectionChange } from './useCodeMirror'
 import { EditorView } from '@codemirror/view'
 import { EditorState, StateEffect } from '@codemirror/state'
+
+/**
+ * Read the target position out of an `EditorView.scrollIntoView` effect.
+ *
+ * CodeMirror's `scrollIntoView` effect is a `StateEffect<ScrollTarget>`
+ * where `ScrollTarget` is an internal class with shape
+ * `{ range: SelectionRange, y, x, yMargin, xMargin, isSnapshot }`.
+ * The type isn't exported, so we duck-type it: look for a `range.head`
+ * field and return it. Returns `undefined` if the effect isn't a scroll
+ * effect or the shape doesn't match.
+ */
+const readScrollTargetPos = (
+  effect: StateEffect<unknown>
+): number | undefined => {
+  const value = effect.value as
+    | { range?: { head?: unknown } }
+    | null
+    | undefined
+  const head = value?.range?.head
+
+  return typeof head === 'number' ? head : undefined
+}
 
 describe('useCodeMirror', () => {
   let containerDiv: HTMLDivElement
@@ -168,7 +190,7 @@ describe('useCodeMirror', () => {
   })
 })
 
-describe('scrollCursorOnVimMotion', () => {
+describe('scrollCursorOnSelectionChange', () => {
   // These tests exercise the transactionExtender as a PURE FUNCTION,
   // not through a mounted EditorView. jsdom has no layout pass so we
   // can't observe `scrollTop` on `.cm-scroller`; the most reliable way
@@ -176,37 +198,43 @@ describe('scrollCursorOnVimMotion', () => {
   // invoke it directly on a synthetic transaction and inspect the
   // returned TransactionSpec.
 
-  test('returns a scroll effect for a pure selection change (vim motion)', () => {
+  const getScrollEffects = (
+    spec: ReturnType<typeof scrollCursorOnSelectionChange>
+  ): StateEffect<unknown>[] => {
+    const effects = spec?.effects
+
+    if (Array.isArray(effects)) {
+      return effects as StateEffect<unknown>[]
+    }
+
+    return effects !== undefined ? [effects as StateEffect<unknown>] : []
+  }
+
+  test('returns a scroll effect for a pure selection change', () => {
     const state = EditorState.create({
       doc: 'line one\nline two\nline three\nline four',
     })
     const tr = state.update({ selection: { anchor: 20, head: 20 } })
 
-    const result = scrollCursorOnVimMotion(tr)
+    const result = scrollCursorOnSelectionChange(tr)
+    const effects = getScrollEffects(result)
 
     expect(result).not.toBeNull()
-
-    // `effects` may be a single effect or an array. Normalize and verify
-    // at least one is a `StateEffect` instance (every `scrollIntoView`
-    // effect is one).
-    const effects = result?.effects
-
-    const effectArray = Array.isArray(effects)
-      ? effects
-      : effects !== undefined
-        ? [effects]
-        : []
-
-    expect(effectArray.length).toBeGreaterThan(0)
-    expect(effectArray[0]).toBeInstanceOf(StateEffect)
+    expect(effects.length).toBeGreaterThan(0)
+    expect(effects[0]).toBeInstanceOf(StateEffect)
   })
 
-  test('uses the new main cursor head position, not the old one', () => {
-    // Move selection from 0 → 20 and make sure the extender reads
-    // `tr.newSelection.main.head` (post-transaction state), not
-    // `tr.startState.selection.main.head` (pre-transaction state).
-    // Regression guard against anyone tempted to "simplify" the guard
-    // and accidentally target the wrong selection reference.
+  test('targets the NEW cursor head position, not the old one', () => {
+    // Move selection from 0 → 20 and verify the scroll effect's target
+    // position is 20 (new head), not 0 (old head). Regression guard
+    // against anyone swapping `tr.newSelection.main.head` for
+    // `tr.startState.selection.main.head` — exactly the kind of subtle
+    // bug that would resurrect the original "cursor leaves viewport"
+    // problem in a form that passes every selection-doesn't-move test.
+    //
+    // We inspect the scroll effect's value directly (via
+    // `readScrollTargetPos`) so the assertion catches the regression
+    // even when the selection itself commits to the right offset.
     const state = EditorState.create({
       doc: 'line one\nline two\nline three\nline four',
     })
@@ -215,9 +243,13 @@ describe('scrollCursorOnVimMotion', () => {
     expect(tr.newSelection.main.head).toBe(20)
     expect(tr.startState.selection.main.head).toBe(0)
 
-    const result = scrollCursorOnVimMotion(tr)
+    const result = scrollCursorOnSelectionChange(tr)
+    const effects = getScrollEffects(result)
 
-    expect(result).not.toBeNull()
+    const targetPos =
+      effects.length > 0 ? readScrollTargetPos(effects[0]) : undefined
+
+    expect(targetPos).toBe(20)
   })
 
   test('returns null for doc change (insert mode path)', () => {
@@ -227,7 +259,7 @@ describe('scrollCursorOnVimMotion', () => {
     const state = EditorState.create({ doc: 'hello' })
     const tr = state.update({ changes: { from: 5, insert: ' world' } })
 
-    const result = scrollCursorOnVimMotion(tr)
+    const result = scrollCursorOnSelectionChange(tr)
 
     expect(result).toBeNull()
   })
@@ -241,7 +273,7 @@ describe('scrollCursorOnVimMotion', () => {
     const noopEffect = StateEffect.define<number>()
     const tr = state.update({ effects: noopEffect.of(1) })
 
-    const result = scrollCursorOnVimMotion(tr)
+    const result = scrollCursorOnSelectionChange(tr)
 
     expect(result).toBeNull()
   })

--- a/src/features/editor/hooks/useCodeMirror.test.ts
+++ b/src/features/editor/hooks/useCodeMirror.test.ts
@@ -2,54 +2,63 @@ import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useCodeMirror, scrollCursorOnSelectionChange } from './useCodeMirror'
 import { EditorView } from '@codemirror/view'
-import { EditorState, StateEffect } from '@codemirror/state'
+import {
+  EditorState,
+  StateEffect,
+  type StateEffectType,
+} from '@codemirror/state'
 
 /**
  * Read the target position out of an `EditorView.scrollIntoView` effect.
  *
+ * Gates on `effect.is(scrollIntoViewType)` so the duck-type access is
+ * ONLY applied when the input is genuinely a scrollIntoView effect —
+ * this rules out the false-positive failure mode where an unrelated
+ * `StateEffect` subclass happens to have a `range.head: number` field.
+ *
  * CodeMirror's `scrollIntoView` effect is a `StateEffect<ScrollTarget>`
  * where `ScrollTarget` is an internal class with shape
  * `{ range: SelectionRange, y, x, yMargin, xMargin, isSnapshot }`.
- * The type isn't exported, so we duck-type it: look for a `range.head`
- * field and return it. Returns `undefined` if the effect isn't a scroll
- * effect or the shape doesn't match.
+ * The type isn't exported, so we duck-type the `.range.head` field
+ * after the effect-type gate. Returns `undefined` if the effect isn't
+ * a scroll effect or its shape doesn't match.
  *
  * **Brittleness note:** the `.range.head` access is verified against
  * `@codemirror/view` 6.41.0 (the version pinned in this repo). If a
  * future CM6 bump renames or restructures `ScrollTarget`, this helper
- * will silently return `undefined` and the regression-guard test below
- * (`targets the NEW cursor head position, not the old one`) will fail
- * with `expect(undefined).toBe(20)`. If you see that failure after a
- * CodeMirror upgrade, the fix is to re-inspect the
- * `@codemirror/view` source for the new `ScrollTarget` shape and
- * update this helper accordingly — the extender itself is
- * a one-liner using `tr.newSelection.main.head` so the production
+ * will silently return `undefined` for real scroll effects and the
+ * regression-guard test below (`targets the NEW cursor head position,
+ * not the old one`) will fail with `expect(undefined).toBe(20)`. If
+ * you see that failure after a CodeMirror upgrade, the fix is to
+ * re-inspect the `@codemirror/view` source for the new `ScrollTarget`
+ * shape and update this helper accordingly — the extender itself is
+ * a one-liner using `tr.newSelection.main.head`, so the production
  * code almost certainly doesn't need to change.
- *
- * **False-positive failure mode:** if a future CM6 version introduces
- * a different `StateEffect` type whose `.value` also has a
- * `range.head: number` field, this helper will happily extract it and
- * the regression test would pass even on a different (wrong) effect.
- * The upstream `instanceof StateEffect` check is too weak to catch
- * this — `StateEffect` is the common base class of every CM6 effect.
- *
- * Strong-typing the comparison is awkward because CM6 does NOT
- * publicly export the `StateEffectType` for scroll. `EditorView.
- * scrollIntoView` itself is a factory function with signature
- * `(pos, options?) => StateEffect<ScrollTarget>`, not a
- * `StateEffectType`, so `effect.is(EditorView.scrollIntoView)` would
- * fail to type-check. The only way to get the underlying type is to
- * create a throwaway instance and read its `.type`
- * (`EditorView.scrollIntoView(0).type`), which can then be compared
- * via `effects[0].is(...)`. If this test ever starts producing
- * suspicious false positives, that's the escape hatch — but the
- * cleaner remediation is usually to update `readScrollTargetPos`'s
- * duck-type to whatever new shape CM6 introduced, not to harden the
- * type comparison.
  */
+// Strong type comparator for scrollIntoView effects. CM6 doesn't
+// publicly export the underlying `StateEffectType` for scroll, so we
+// construct a throwaway effect at module load and read its `.type`
+// field — that's the only way to get a reference to the type we can
+// pass to `effect.is(...)`. The `.type` property exists at runtime but
+// isn't in the public `@codemirror/state` type declarations, hence the
+// cast. Using this comparator lets `readScrollTargetPos` gate its
+// duck-type access on "is this actually a scroll effect" rather than
+// accepting any `StateEffect` that happens to have a
+// `range.head: number` field (the false-positive failure mode
+// documented below).
+const scrollIntoViewType = (
+  EditorView.scrollIntoView(0) as unknown as {
+    type: StateEffectType<unknown>
+  }
+).type
+
 const readScrollTargetPos = (
   effect: StateEffect<unknown>
 ): number | undefined => {
+  if (!effect.is(scrollIntoViewType)) {
+    return undefined
+  }
+
   const value = effect.value as
     | { range?: { head?: unknown } }
     | null
@@ -254,7 +263,15 @@ describe('scrollCursorOnSelectionChange', () => {
 
     expect(result).not.toBeNull()
     expect(effects.length).toBeGreaterThan(0)
-    expect(effects[0]).toBeInstanceOf(StateEffect)
+
+    // `readScrollTargetPos` gates on `effect.is(scrollIntoViewType)`
+    // — returning a number proves the effect is genuinely a CM6
+    // `scrollIntoView` effect, not just any `StateEffect` subclass.
+    // Using `toBeInstanceOf(StateEffect)` here would be too weak: it
+    // would pass for any effect type (compartment reconfiguration,
+    // etc.) and leave a refactor that swapped `scrollIntoView(...)`
+    // for a no-op effect undetected.
+    expect(readScrollTargetPos(effects[0])).toEqual(expect.any(Number))
   })
 
   test('targets the NEW cursor head position, not the old one', () => {

--- a/src/features/editor/hooks/useCodeMirror.test.ts
+++ b/src/features/editor/hooks/useCodeMirror.test.ts
@@ -165,4 +165,76 @@ describe('useCodeMirror', () => {
 
     expect(result.current.editorView).toBeInstanceOf(EditorView)
   })
+
+  test('dispatches scrollIntoView effect on pure selection change (vim motion)', () => {
+    const { result } = renderHook(() =>
+      useCodeMirror({
+        initialContent: 'line one\nline two\nline three\nline four',
+        language: null,
+        onSave: vi.fn(),
+      })
+    )
+
+    act(() => {
+      result.current.setContainer(containerDiv)
+    })
+
+    const view = result.current.editorView
+    if (!view) {
+      throw new Error('editor view not initialized')
+    }
+
+    const dispatchSpy = vi.spyOn(view, 'dispatch')
+
+    // Simulate a vim normal-mode motion: pure selection change, no doc
+    // change. Move the cursor into the third line.
+    act(() => {
+      view.dispatch({ selection: { anchor: 20, head: 20 } })
+    })
+
+    // The listener should follow-up with a dispatch carrying the
+    // scrollIntoView effect for the new cursor head.
+    const scrollCall = dispatchSpy.mock.calls.find((call) => {
+      const tx = call[0] as { effects?: unknown }
+
+      return tx.effects !== undefined
+    })
+
+    expect(scrollCall).toBeDefined()
+  })
+
+  test('does not dispatch extra scroll transaction on doc change (insert mode)', () => {
+    const { result } = renderHook(() =>
+      useCodeMirror({
+        initialContent: 'hello',
+        language: null,
+        onSave: vi.fn(),
+      })
+    )
+
+    act(() => {
+      result.current.setContainer(containerDiv)
+    })
+
+    const view = result.current.editorView
+    if (!view) {
+      throw new Error('editor view not initialized')
+    }
+
+    const dispatchSpy = vi.spyOn(view, 'dispatch')
+
+    // Simulate insert-mode typing: docChanged, so CodeMirror's built-in
+    // scroll path already fires and our listener must not duplicate it.
+    act(() => {
+      view.dispatch({ changes: { from: 5, insert: ' world' } })
+    })
+
+    const scrollCall = dispatchSpy.mock.calls.find((call) => {
+      const tx = call[0] as { effects?: unknown }
+
+      return tx.effects !== undefined
+    })
+
+    expect(scrollCall).toBeUndefined()
+  })
 })

--- a/src/features/editor/hooks/useCodeMirror.ts
+++ b/src/features/editor/hooks/useCodeMirror.ts
@@ -1,9 +1,54 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { EditorView, ViewUpdate, drawSelection } from '@codemirror/view'
-import { EditorState, type Extension, Compartment } from '@codemirror/state'
+import {
+  EditorState,
+  type Extension,
+  type Transaction,
+  type TransactionSpec,
+  Compartment,
+} from '@codemirror/state'
 import { history } from '@codemirror/commands'
 import { vim, Vim } from '@replit/codemirror-vim'
 import { catppuccinMocha } from '../theme/catppuccin'
+
+/**
+ * Scroll the viewport to follow the cursor during vim NORMAL-mode motions
+ * (j/k/G/gg/Ctrl-d/etc.). Exported so it can be unit-tested in isolation
+ * without having to measure `scrollTop` inside jsdom (jsdom doesn't lay
+ * out the DOM, so DOM-level scroll position is unobservable in tests).
+ *
+ * Why transactionExtender instead of updateListener: the scroll effect
+ * rides on the SAME transaction as the selection change, so CodeMirror
+ * sees one atomic update (selection moved + scrollIntoView) and its
+ * measure pass always reflects the new cursor position. Dispatching
+ * from an update listener ran after CM had already measured with stale
+ * cursor coordinates, producing the "scrolls exactly one row then
+ * silently no-ops forever" bug.
+ *
+ * Why `!tr.selection || tr.docChanged` guard: we only want to intercept
+ * PURE-selection changes (vim normal-mode motions). Doc changes (insert
+ * mode typing) already hit CodeMirror's built-in scroll path, and
+ * effect-only dispatches (language reconfiguration, scroll dispatches
+ * from elsewhere) aren't selection moves at all — skipping both keeps
+ * us from clobbering existing scroll behavior or double-scrolling.
+ *
+ * Why `y: 'nearest'`: matches native vim. Only scrolls when the cursor
+ * actually leaves the viewport, so short in-viewport motions don't
+ * recenter the buffer on every keystroke.
+ */
+export const scrollCursorOnVimMotion = (
+  tr: Transaction
+): TransactionSpec | null => {
+  if (!tr.selection || tr.docChanged) {
+    return null
+  }
+
+  return {
+    effects: EditorView.scrollIntoView(tr.newSelection.main.head, {
+      y: 'nearest',
+    }),
+  }
+}
 
 // `Vim.defineEx` writes into a GLOBAL registry shared across every
 // `@replit/codemirror-vim` instance in the process. Register it exactly
@@ -121,39 +166,10 @@ export function useCodeMirror(
           onChangeRef.current(content)
         }
       }),
-      // Scroll the viewport to follow the cursor during vim NORMAL-mode
-      // motions (j/k/G/gg/Ctrl-d/etc.). CodeMirror 6 auto-scrolls when a
-      // selection-changing transaction either carries a
-      // `scrollIntoView` effect or an `"select"` userEvent annotation,
-      // but @replit/codemirror-vim dispatches motion transactions with
-      // neither. The result is that INSERT-mode typing scrolls
-      // (because doc changes trigger the built-in scroll path) while
-      // NORMAL-mode motions silently park the cursor off-screen.
-      //
-      // We use `transactionExtender` (NOT an `updateListener`) so the
-      // scroll effect rides on the SAME transaction as the selection
-      // change. Dispatching from an update listener ran after CM's
-      // measure pass had already captured stale cursor coordinates,
-      // which caused the bug where j/k scrolled exactly one row and
-      // then silently no-oped forever after. Baking the effect into
-      // the original transaction means CM sees a single atomic update
-      // (selection moved + scrollIntoView) and its measurement always
-      // reflects the new cursor position.
-      //
-      // `y: 'nearest'` is deliberate: it only scrolls when the cursor
-      // leaves the viewport, matching native vim so short in-viewport
-      // motions don't recenter the buffer.
-      EditorState.transactionExtender.of((tr) => {
-        if (!tr.selection || tr.docChanged) {
-          return null
-        }
-
-        return {
-          effects: EditorView.scrollIntoView(tr.newSelection.main.head, {
-            y: 'nearest',
-          }),
-        }
-      }),
+      // Vim NORMAL-mode scroll-follow. See `scrollCursorOnVimMotion`
+      // above for the full rationale (why transactionExtender vs
+      // updateListener, why `y: 'nearest'`, etc.).
+      EditorState.transactionExtender.of(scrollCursorOnVimMotion),
     ]
 
     const state = EditorState.create({

--- a/src/features/editor/hooks/useCodeMirror.ts
+++ b/src/features/editor/hooks/useCodeMirror.ts
@@ -121,6 +121,31 @@ export function useCodeMirror(
           onChangeRef.current(content)
         }
       }),
+      // Scroll the viewport to follow the cursor during vim NORMAL-mode
+      // motions (j/k/G/gg/Ctrl-d/etc.). CodeMirror 6 auto-scrolls when a
+      // selection-changing transaction either carries a
+      // `scrollIntoView` effect or an `"select"` userEvent annotation,
+      // but @replit/codemirror-vim dispatches motion transactions with
+      // neither. The result is that INSERT-mode typing scrolls
+      // (because doc changes trigger the built-in scroll path) while
+      // NORMAL-mode motions silently park the cursor off-screen.
+      //
+      // We catch any pure-selection change (no doc change) and
+      // re-dispatch a `scrollIntoView` effect for the main cursor head.
+      // `y: 'nearest'` is deliberate: it only scrolls when the cursor
+      // leaves the viewport, matching native vim behavior so small
+      // in-viewport motions don't repeatedly recenter the buffer.
+      EditorView.updateListener.of((update: ViewUpdate) => {
+        if (!update.selectionSet || update.docChanged) {
+          return
+        }
+
+        update.view.dispatch({
+          effects: EditorView.scrollIntoView(update.state.selection.main.head, {
+            y: 'nearest',
+          }),
+        })
+      }),
     ]
 
     const state = EditorState.create({

--- a/src/features/editor/hooks/useCodeMirror.ts
+++ b/src/features/editor/hooks/useCodeMirror.ts
@@ -12,10 +12,18 @@ import { vim, Vim } from '@replit/codemirror-vim'
 import { catppuccinMocha } from '../theme/catppuccin'
 
 /**
- * Scroll the viewport to follow the cursor during vim NORMAL-mode motions
- * (j/k/G/gg/Ctrl-d/etc.). Exported so it can be unit-tested in isolation
- * without having to measure `scrollTop` inside jsdom (jsdom doesn't lay
- * out the DOM, so DOM-level scroll position is unobservable in tests).
+ * Scroll the viewport to follow the cursor on any PURE-selection change
+ * (no doc mutation). This is what enables vim NORMAL-mode scroll-follow
+ * for `j/k/G/gg/Ctrl-d/etc.`, but it also fires for mouse clicks that
+ * move the cursor, arrow-key navigation, and programmatic selection
+ * changes from other extensions. That's deliberately inclusive — every
+ * such transaction is a cursor move that the user expects the viewport
+ * to follow, and CM6 has no general-purpose "vim-only" transaction
+ * marker we could gate on.
+ *
+ * Exported so it can be unit-tested in isolation without having to
+ * measure `scrollTop` inside jsdom (jsdom doesn't lay out the DOM, so
+ * DOM-level scroll position is unobservable in tests).
  *
  * Why transactionExtender instead of updateListener: the scroll effect
  * rides on the SAME transaction as the selection change, so CodeMirror
@@ -23,20 +31,21 @@ import { catppuccinMocha } from '../theme/catppuccin'
  * measure pass always reflects the new cursor position. Dispatching
  * from an update listener ran after CM had already measured with stale
  * cursor coordinates, producing the "scrolls exactly one row then
- * silently no-ops forever" bug.
+ * silently no-ops forever" bug that motivated this fix.
  *
  * Why `!tr.selection || tr.docChanged` guard: we only want to intercept
- * PURE-selection changes (vim normal-mode motions). Doc changes (insert
- * mode typing) already hit CodeMirror's built-in scroll path, and
- * effect-only dispatches (language reconfiguration, scroll dispatches
- * from elsewhere) aren't selection moves at all — skipping both keeps
- * us from clobbering existing scroll behavior or double-scrolling.
+ * pure-selection changes. Doc changes (insert-mode typing) already hit
+ * CodeMirror's built-in scroll path, and effect-only dispatches
+ * (language reconfiguration, scroll dispatches from elsewhere) aren't
+ * selection moves — skipping both keeps us from clobbering existing
+ * scroll behavior or double-scrolling.
  *
  * Why `y: 'nearest'`: matches native vim. Only scrolls when the cursor
  * actually leaves the viewport, so short in-viewport motions don't
- * recenter the buffer on every keystroke.
+ * recenter the buffer on every keystroke. Also harmless for mouse
+ * clicks and arrow-key moves that stay in view.
  */
-export const scrollCursorOnVimMotion = (
+export const scrollCursorOnSelectionChange = (
   tr: Transaction
 ): TransactionSpec | null => {
   if (!tr.selection || tr.docChanged) {
@@ -166,10 +175,13 @@ export function useCodeMirror(
           onChangeRef.current(content)
         }
       }),
-      // Vim NORMAL-mode scroll-follow. See `scrollCursorOnVimMotion`
-      // above for the full rationale (why transactionExtender vs
-      // updateListener, why `y: 'nearest'`, etc.).
-      EditorState.transactionExtender.of(scrollCursorOnVimMotion),
+      // Scroll the viewport to follow the cursor on any pure-selection
+      // transaction. This is what enables vim NORMAL-mode scroll-follow
+      // (j/k/G/gg/Ctrl-d/etc.) but also covers mouse clicks and arrow
+      // keys. See `scrollCursorOnSelectionChange` above for the full
+      // rationale (why transactionExtender vs updateListener, why
+      // `y: 'nearest'`, etc.).
+      EditorState.transactionExtender.of(scrollCursorOnSelectionChange),
     ]
 
     const state = EditorState.create({

--- a/src/features/editor/hooks/useCodeMirror.ts
+++ b/src/features/editor/hooks/useCodeMirror.ts
@@ -130,21 +130,29 @@ export function useCodeMirror(
       // (because doc changes trigger the built-in scroll path) while
       // NORMAL-mode motions silently park the cursor off-screen.
       //
-      // We catch any pure-selection change (no doc change) and
-      // re-dispatch a `scrollIntoView` effect for the main cursor head.
+      // We use `transactionExtender` (NOT an `updateListener`) so the
+      // scroll effect rides on the SAME transaction as the selection
+      // change. Dispatching from an update listener ran after CM's
+      // measure pass had already captured stale cursor coordinates,
+      // which caused the bug where j/k scrolled exactly one row and
+      // then silently no-oped forever after. Baking the effect into
+      // the original transaction means CM sees a single atomic update
+      // (selection moved + scrollIntoView) and its measurement always
+      // reflects the new cursor position.
+      //
       // `y: 'nearest'` is deliberate: it only scrolls when the cursor
-      // leaves the viewport, matching native vim behavior so small
-      // in-viewport motions don't repeatedly recenter the buffer.
-      EditorView.updateListener.of((update: ViewUpdate) => {
-        if (!update.selectionSet || update.docChanged) {
-          return
+      // leaves the viewport, matching native vim so short in-viewport
+      // motions don't recenter the buffer.
+      EditorState.transactionExtender.of((tr) => {
+        if (!tr.selection || tr.docChanged) {
+          return null
         }
 
-        update.view.dispatch({
-          effects: EditorView.scrollIntoView(update.state.selection.main.head, {
+        return {
+          effects: EditorView.scrollIntoView(tr.newSelection.main.head, {
             y: 'nearest',
           }),
-        })
+        }
       }),
     ]
 

--- a/src/features/editor/theme/catppuccin.ts
+++ b/src/features/editor/theme/catppuccin.ts
@@ -37,9 +37,23 @@ const colors = {
  */
 const theme = EditorView.theme(
   {
+    // `&` targets `.cm-editor`. `height: 100%` is load-bearing:
+    // without it, CodeMirror sizes `.cm-editor` to its content, which
+    // makes `.cm-scroller` the same height as the full document. The
+    // scroller then has no overflow, so no scrollbar appears, mouse
+    // wheel does nothing, and any `scrollIntoView` effect (including
+    // the one our transactionExtender dispatches for vim normal-mode
+    // motions) has no scrollable ancestor to act on. Pairing this
+    // with `.cm-scroller { overflow: auto }` is the canonical CM6
+    // "fill container" recipe, required for the surrounding flex
+    // chain's bounded height to actually reach the editor viewport.
     '&': {
       backgroundColor: colors.surface,
       color: colors.text,
+      height: '100%',
+    },
+    '.cm-scroller': {
+      overflow: 'auto',
     },
     '.cm-content': {
       caretColor: colors.primary,

--- a/src/features/workspace/components/BottomDrawer.tsx
+++ b/src/features/workspace/components/BottomDrawer.tsx
@@ -186,9 +186,22 @@ const BottomDrawer = ({
       </div>
 
       {/* Content Area */}
-      <div className="flex-1 flex overflow-hidden">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         {activeTab === 'editor' ? (
-          <div data-testid="editor-panel" className="flex flex-1">
+          // `min-h-0` + `overflow-hidden` on the editor wrapper is load-
+          // bearing: without them this flex child defaults to
+          // `min-height: auto`, which grows to the full CodeMirror
+          // content height and defeats CodeMirror's internal
+          // `.cm-scroller`. The cursor moves with h/j/k/l but the
+          // editor never needs to scroll because its container is
+          // always big enough to show the entire file. Bounding the
+          // wrapper is what lets `h-full` on `codemirror-container`
+          // resolve to a real pixel height and enables internal scroll
+          // follow.
+          <div
+            data-testid="editor-panel"
+            className="flex min-h-0 flex-1 overflow-hidden"
+          >
             <CodeEditor
               filePath={selectedFilePath}
               content={content}

--- a/src/features/workspace/components/BottomDrawer.tsx
+++ b/src/features/workspace/components/BottomDrawer.tsx
@@ -212,7 +212,18 @@ const BottomDrawer = ({
             />
           </div>
         ) : (
-          <div data-testid="diff-panel" className="flex-1 flex">
+          // Same `min-h-0 overflow-hidden` treatment as the editor
+          // wrapper above. `DiffContent` is currently a static two-
+          // line placeholder, so nothing overflows today — but when
+          // it's replaced with a real diff viewer (CodeMirror merge
+          // view or similar), an unbounded `flex flex-1` wrapper
+          // would immediately re-trigger the same `min-height: auto`
+          // flex issue we're fixing here for the editor. Cheaper to
+          // apply symmetry now than to rediscover the bug later.
+          <div
+            data-testid="diff-panel"
+            className="flex min-h-0 flex-1 overflow-hidden"
+          >
             <DiffContent />
           </div>
         )}


### PR DESCRIPTION
## Summary

The code editor's cursor moved with `h/j/k/l` but the editor never scrolled to follow it. Root cause was a classic flex layout gotcha in the wrapper chain from `BottomDrawer` down to CodeMirror:

```
BottomDrawer content area (flex-1 overflow-hidden)
└─ editor-panel wrapper (flex flex-1)              ← no min-h-0
   └─ CodeEditor root (flex-1 flex-col overflow-hidden)
      └─ relative wrapper (flex-1 overflow-hidden)
         └─ codemirror-container (h-full w-full)
```

The `editor-panel` wrapper had neither `overflow-hidden` nor `min-h-0`, so its implicit `min-height: auto` grew to CodeMirror's full content height. With the wrapper unbounded, `h-full` on the CodeMirror container resolved to the entire file height, `cm-editor` became as tall as the document, and `cm-scroller` never needed to scroll. Result: vim `hjkl` moved the cursor but the viewport never followed.

## Fix

- Add `min-h-0` + `overflow-hidden` to the `editor-panel` wrapper in `BottomDrawer`, so the drawer's fixed pixel height propagates down past it.
- Add `min-h-0` to `CodeEditor`'s own `flex-1` children for defense in depth.

Now the wrapper clips at the drawer's height, CodeMirror gets a bounded container, and `cm-scroller` scrolls to follow the vim cursor.

## Test plan

- [x] `npm test` — 1281 passing, 0 failing
- [x] `npm run type-check`
- [x] `npm run lint`
- [ ] Manual: open a file longer than the drawer, enter the editor, press `j` repeatedly past the visible bottom, confirm the content scrolls to follow the cursor
- [ ] Manual: same with `k` past the visible top
- [ ] Manual: resize the drawer smaller, confirm the editor re-clips and scroll still follows