### PR TITLE
fix(files): make FileExplorer flex column actually scroll

### DIFF
--- a/src/features/workspace/components/panels/FileExplorer.tsx
+++ b/src/features/workspace/components/panels/FileExplorer.tsx
@@ -47,7 +47,10 @@ export const FileExplorer = ({
   const isRoot = currentPath === '~' || currentPath === '/'
 
   return (
-    <div className="flex h-full flex-col px-4 pt-3" data-testid="file-explorer">
+    <div
+      className="flex h-full min-h-0 flex-col px-4 pt-3"
+      data-testid="file-explorer"
+    >
       {/* Header */}
       <div className="mb-1 flex items-center gap-2">
         <span className="material-symbols-outlined text-base text-on-surface/50">
@@ -91,8 +94,13 @@ export const FileExplorer = ({
         </span>
       </div>
 
-      {/* Content */}
-      <div className="flex-1 overflow-y-auto">
+      {/* Content — `min-h-0` is required so this `flex-1` child can shrink
+          below the intrinsic height of its content. Without it, the
+          `overflow-y-auto` never engages because the flex child's default
+          `min-height: auto` forces the container to grow to fit the entire
+          tree, which pushed the scrollbar offscreen and made `scrollIntoView`
+          walk up to the wrong ancestor. */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
         {isLoading && (
           <div className="py-4 text-center font-mono text-xs text-on-surface/40">
             Loading...


### PR DESCRIPTION
## Summary

Latent scroll bug in the sidebar file explorer, spotted while investigating a separate editor scroll issue (see winoooops/vimeflow#43). The content wrapper inside \`FileExplorer\` never actually clipped, so wheel/touchpad scrolling the file tree did nothing when the list was taller than the panel.

Same flex-layout gotcha as the editor fix:

\`\`\`
Sidebar wrapper (style height: 320px, shrink-0)
└─ FileExplorer root (flex h-full flex-col)
   └─ content wrapper (flex-1 overflow-y-auto)     ← no min-h-0
\`\`\`

The \`flex-1\` content wrapper defaulted to \`min-height: auto\`, which forced the container to grow to fit the entire tree and pushed the would-be scrollbar past the panel's 320px height. \`overflow-y-auto\` never engaged because the container was already tall enough to show everything.

## Fix

Add \`min-h-0\` to the root flex column and to the content wrapper. The content wrapper now clips at the panel's pixel height and \`overflow-y-auto\` engages as intended.

## Test plan

- [x] \`npm test\` — 1281 passing, 0 failing
- [x] \`npm run type-check\`
- [x] \`npm run lint\`
- [ ] Manual: open a directory with more files than the file explorer panel can show, confirm a scrollbar appears and wheel/touchpad scroll works
- [ ] Manual: resize the sidebar explorer panel, confirm the scrollable region re-clips correctly

## Notes

This is a latent bug — it has existed since the sidebar was built and is unrelated to the editor scroll issue in winoooops/vimeflow#43. Keeping it in its own PR per the single-purpose rule.