### PR TITLE
docs(worktrees): allow main agent on feature branch in primary checkout

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,7 @@ export default defineConfig([
       'playwright-report',
       'vite-plugin-*.ts',
       'src-tauri/target',
+      '.claude/**',
     ],
   },
   {

--- a/rules/common/git-workflow.md
+++ b/rules/common/git-workflow.md
@@ -36,20 +36,26 @@ When creating PRs:
 6. Merge with `--squash` only
 7. **Stay on the branch** — do not switch back to `main` after creating the PR
 
+## Branching
+
+- **Never commit to `main`** — always work on a feature branch (`feat/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`, `perf/`, `ci/`).
+- The **interactive main agent** checks out a feature branch in the **primary checkout** (`git checkout -b feat/<name>`). It does not create a worktree for itself — the user's diff viewer depends on seeing live edits in the primary checkout.
+- **Subagents and the autonomous harness** (`/harness-plugin:loop`, dispatched parallel agents) must isolate themselves in a dedicated worktree under `.claude/worktrees/<branch>/`. See [worktrees.md](./worktrees.md).
+
 ## Post-PR Protocol
 
-After creating a PR, the agent remains on the feature branch/worktree until the PR is resolved:
+After creating a PR, the agent remains on the feature branch until the PR is resolved:
 
-1. **Stay**: remain in the worktree/branch — do not return to `main`
+1. **Stay**: remain on the feature branch (primary checkout for main agent, linked worktree for subagents) — do not return to `main`
 2. **Review-fix loop**: run `/harness-plugin:github-review` to fetch and address code review findings
 3. **Push fixes**: commit and push from the same branch
 4. **Repeat**: wait for next review cycle, fix, push
 5. **Done**: only the user merges or closes the PR
-6. **Cleanup**: after merge, return to main and clean up the worktree/branch (see [worktrees.md](./worktrees.md))
+6. **Cleanup**: after merge, return to `main` and delete the local branch (and remove the worktree if one was used — see [worktrees.md](./worktrees.md))
 
 > For the full development process (planning, TDD, code review) before git operations,
 > see [development-workflow.md](./development-workflow.md).
 
 ## Multi-Agent Workflows
 
-When multiple agents work simultaneously, each must use a dedicated git worktree. See [worktrees.md](./worktrees.md) for lifecycle, lock contention guardrails, and cleanup procedures.
+When multiple agents work simultaneously, each subagent must use a dedicated git worktree. The interactive main agent stays in the primary checkout. See [worktrees.md](./worktrees.md) for lifecycle, lock contention guardrails, and cleanup procedures.

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -64,7 +64,7 @@ Agent works normally — edit, commit, push, create PR. Whether this happens in 
 
 **Once a PR is created, the agent stays on that branch (or in that worktree) until the PR is resolved.** Do not switch back to `main` between creating the PR and the PR being merged or closed. This ensures review-fix cycles (`/harness-plugin:github-review`) happen in the correct working directory without branch switching.
 
-The PR lifecycle within a worktree:
+The PR lifecycle (primary checkout or linked worktree):
 
 ```
 create PR → wait for review → fix findings → push → wait for review → ... → merged/closed

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -2,47 +2,67 @@
 
 ## Principles
 
-1. **Main worktree is sacred** — it stays on `main`, always clean, never committed to directly. It is the launchpad from which agents create worktrees.
-2. **All code changes happen in worktrees** — any work that produces commits (`feat/`, `fix/`, `refactor/`, `docs/`, `test/`) must use a dedicated worktree.
-3. **Read-only tasks skip worktrees** — research, exploration, and answering questions can use the main worktree.
-4. **Harness always uses a worktree** — autonomous loops (`/init`) must be fully isolated.
+1. **`main` branch is sacred** — never commit directly to `main`. The primary checkout is allowed (and expected) to be on a feature branch during active work.
+2. **Main agent works on a feature branch in the primary checkout** — the interactive Claude Code agent checks out `feat/<name>` (or `fix/`, `refactor/`, etc.) in the primary checkout and commits there. It does **not** create a worktree for itself.
+   - **Why:** the user runs the Vimeflow app from the primary checkout and watches the diff viewer live. Edits inside `.claude/worktrees/` are invisible to that view because the diff viewer only reflects its own cwd's working tree.
+3. **Subagents and harness always use a worktree** — any autonomous or parallel agent (`/harness-plugin:loop`, dispatched parallel agents) must be fully isolated under `.claude/worktrees/<branch>/` so it does not fight the user or the main agent for the working tree.
+4. **Read-only tasks skip branching** — research, exploration, and answering questions can happen on `main` in the primary checkout. No branch needed.
 5. **Git commands start with `git`** — always invoke git as the first token in the command (e.g., `git push`, not `ENV=val git push` or `cd repo && git push`). This ensures the PreToolUse hook can reliably detect and guard git operations. This framework is designed for agents, not humans — compound shell expressions are unnecessary.
+
+## Who Works Where
+
+| Actor                               | Location                      | Branch                        |
+| ----------------------------------- | ----------------------------- | ----------------------------- |
+| Interactive main agent              | Primary checkout (repo root)  | Feature branch (never `main`) |
+| `/harness-plugin:loop` (autonomous) | `.claude/worktrees/<branch>/` | Feature branch                |
+| Dispatched parallel subagents       | `.claude/worktrees/<branch>/` | Feature branch                |
+| Read-only research                  | Primary checkout              | `main` is fine                |
 
 ## Worktree Location
 
-All worktrees live under `.claude/worktrees/` (gitignored, local-only):
+All subagent/harness worktrees live under `.claude/worktrees/` (gitignored, local-only):
 
 ```
-Vimeflow/                          ← main worktree (stays on main)
+Vimeflow/                          ← primary checkout (main agent works here on feat/* branch)
 ├── .claude/
 │   ├── skills/                    ← tracked in git (pushed to repo)
 │   └── worktrees/                 ← gitignored (local-only)
-│       ├── feat-chat-history/     ← agent 1's full checkout
-│       └── fix-layout-bug/        ← agent 2's full checkout
+│       ├── feat-harness-retry/    ← harness loop's full checkout
+│       └── refactor-parallel-a/   ← dispatched subagent's full checkout
 ├── src/
 └── ...
 ```
 
-Each worktree is a complete working directory with its own `src/`, `node_modules/`, etc. They share only the `.git` object database with the main repo.
+Each worktree is a complete working directory with its own `src/`, `node_modules/`, etc. They share only the `.git` object database with the primary checkout.
 
 ## Lifecycle
 
-### CREATE
+### Main agent (interactive) — feature branch in primary checkout
 
 ```bash
-# From the main worktree (root project dir)
+# From the primary checkout, starting on main
+git checkout -b feat/<name>
+# edit, commit, push, create PR — all from the primary checkout
+```
+
+Do **not** run `EnterWorktree` reflexively at the start of an interactive task. Check out a feature branch instead so the user's diff viewer reflects your live edits.
+
+### Subagent / harness — dedicated worktree
+
+```bash
+# From the primary checkout
 git worktree add .claude/worktrees/<branch-name> -b <branch-name>
 cd .claude/worktrees/<branch-name>
 npm install
 ```
 
-Or use Claude Code's built-in: `EnterWorktree` (creates under `.claude/worktrees/` by default).
+Or use Claude Code's built-in: `EnterWorktree` (creates under `.claude/worktrees/` by default). This path applies to `/harness-plugin:loop` and any parallel dispatched agents.
 
 ### ACTIVE
 
-Agent works normally — edit, commit, push, create PR. The worktree is a fully independent working directory.
+Agent works normally — edit, commit, push, create PR. Whether this happens in the primary checkout (main agent) or a linked worktree (subagent), the PR lifecycle is the same.
 
-**Once a PR is created, the agent stays in the worktree/branch until the PR is resolved.** Do not switch back to `main` between creating the PR and the PR being merged or closed. This ensures review-fix cycles (`/harness-plugin:github-review`) happen in the correct working directory without branch switching.
+**Once a PR is created, the agent stays on that branch (or in that worktree) until the PR is resolved.** Do not switch back to `main` between creating the PR and the PR being merged or closed. This ensures review-fix cycles (`/harness-plugin:github-review`) happen in the correct working directory without branch switching.
 
 The PR lifecycle within a worktree:
 
@@ -56,8 +76,18 @@ Only the **user** decides when a PR is merged. Agents do not merge PRs unless ex
 
 After the user merges or closes the PR:
 
+**Main agent (feature branch in primary checkout):**
+
 ```bash
-# From the main worktree
+git checkout main
+git pull
+git branch -d <branch-name>       # delete local branch (use -D if abandoned)
+```
+
+**Subagent / harness (linked worktree):**
+
+```bash
+# From the primary checkout
 git worktree remove .claude/worktrees/<branch-name>
 git branch -d <branch-name>       # delete local branch (use -D if unmerged and abandoned)
 git worktree prune                 # clean up stale worktree metadata
@@ -145,10 +175,10 @@ git branch --merged main | grep -v '^\*\|main' | xargs -r git branch -d
 
 Two hooks support the worktree workflow:
 
-| Hook               | Type        | Script                               | Purpose                                                                      |
-| ------------------ | ----------- | ------------------------------------ | ---------------------------------------------------------------------------- |
-| Block main commits | PreToolUse  | `scripts/hooks/block-main-commit.sh` | Prevents `git commit`/`git push` on the main worktree                        |
-| Post-push review   | PostToolUse | `scripts/hooks/post-push-review.sh`  | After `git push` or `gh pr create`, triggers `/harness-plugin:github-review` |
+| Hook               | Type        | Script                               | Purpose                                                                               |
+| ------------------ | ----------- | ------------------------------------ | ------------------------------------------------------------------------------------- |
+| Block main commits | PreToolUse  | `scripts/hooks/block-main-commit.sh` | Prevents `git commit`/`git push` when the `main` branch is checked out (any worktree) |
+| Post-push review   | PostToolUse | `scripts/hooks/post-push-review.sh`  | After `git push` or `gh pr create`, triggers `/harness-plugin:github-review`          |
 
 To register both hooks, add to `.claude/settings.local.json`:
 

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -81,7 +81,7 @@ After the user merges or closes the PR:
 ```bash
 git checkout main
 git pull
-git branch -d <branch-name>       # delete local branch (use -D if abandoned)
+git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
 ```
 
 **Subagent / harness (linked worktree):**
@@ -89,9 +89,11 @@ git branch -d <branch-name>       # delete local branch (use -D if abandoned)
 ```bash
 # From the primary checkout
 git worktree remove .claude/worktrees/<branch-name>
-git branch -d <branch-name>       # delete local branch (use -D if unmerged and abandoned)
+git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
 git worktree prune                 # clean up stale worktree metadata
 ```
+
+> **Why `-D` not `-d`:** Because this repo mandates squash-and-merge, the feature branch's individual commits never become ancestors of `main` — only the single squash commit does. `git branch -d` refuses to delete a branch it considers "not fully merged" and will fail on every normal cleanup. Use `-D` unconditionally.
 
 ## Lock Contention Guardrails
 

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -70,23 +70,30 @@ if [ "$subcmd" != "commit" ] && [ "$subcmd" != "push" ]; then
   exit 0
 fi
 
-# For `git push`, inspect every remaining token as a potential refspec and
-# block if any destination resolves to `main`. This catches bypass attempts
-# like `git push origin HEAD:main` or `git push origin feat/x:main` that would
-# otherwise slip through the branch check below.
+# For `git push`, block three bypass classes before falling through to the
+# branch check:
 #
-# Refspec grammar: [+]<src>:<dst>, or [+]<ref> as shorthand for <ref>:<ref>.
-# We strip the optional leading '+' (force), take the destination (after the
-# last ':' if present, otherwise the whole token), and match against `main`
-# or `refs/heads/main`.
+#   1. `--all` / `--mirror` push every local branch/ref to the remote. If
+#      the local `main` ever has commits ahead of origin, they land on
+#      `origin/main` without passing through the refspec loop (both flags
+#      start with '-' and would otherwise be skipped). Block unconditionally.
+#   2. Every remaining non-flag token is treated as a potential refspec.
+#      Refspec grammar: [+]<src>:<dst>, or [+]<ref> as shorthand for
+#      <ref>:<ref>. Strip the optional leading '+' (force), take the
+#      destination (after the last ':' if present, otherwise the whole
+#      token), and block if it resolves to `main` or `refs/heads/main`.
+#      Catches `git push origin HEAD:main`, `git push origin feat/x:main`,
+#      `git push origin main`, etc.
 if [ "$subcmd" = "push" ]; then
   j=$((subcmd_idx + 1))
   while [ $j -lt ${#git_tokens[@]} ]; do
     arg="${git_tokens[$j]}"
     j=$((j + 1))
-    # Skip option flags; we don't track which ones take values since any value
-    # that happens to equal `main` should fail closed anyway.
     case "$arg" in
+      --all|--mirror)
+        echo "BLOCKED: 'git push $arg' pushes every local branch/ref and may land commits on 'main'. Push a specific refspec instead." >&2
+        exit 2
+        ;;
       -*) continue ;;
     esac
     refspec="${arg#+}"

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -84,6 +84,13 @@ fi
 #      token), and block if it resolves to `main` or `refs/heads/main`.
 #      Catches `git push origin HEAD:main`, `git push origin feat/x:main`,
 #      `git push origin main`, etc.
+#
+# Known limitation: the loop does not distinguish the remote-name positional
+# (e.g. `origin` in `git push origin feat/x`) from actual refspec arguments.
+# A repository whose remote is literally named `main` (extremely unusual)
+# would therefore false-block every push to that remote. We accept this
+# trade-off to keep the parser simple — renaming such a remote is trivial
+# and this framework uses conventional remote names (`origin`, `upstream`).
 if [ "$subcmd" = "push" ]; then
   j=$((subcmd_idx + 1))
   while [ $j -lt ${#git_tokens[@]} ]; do

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -28,51 +28,79 @@ if [ -z "$command" ]; then
   exit 0
 fi
 
-# Extract the git subcommand and any -C/--work-tree target, skipping flags and their values.
+# Parse the git command into an array of tokens (everything after the leading "git").
+# Then locate the subcommand, any -C/--work-tree target, and keep the remaining
+# tokens so we can later inspect push refspecs.
+#
 # Known git flags that consume the next token as a value:
 #   -C, -c, --git-dir, --work-tree, --namespace, --super-prefix
+read -r -a git_tokens <<<"$(echo "$command" | sed -n 's/^\s*git\s\+//p')"
+
 subcmd=""
 git_target_dir=""
-next_is_target=false
-skip_next=false
-for token in $(echo "$command" | sed -n 's/^\s*git\s\+//p'); do
-  if $next_is_target; then
-    git_target_dir="$token"
-    next_is_target=false
-    continue
-  fi
-  if $skip_next; then
-    skip_next=false
-    continue
-  fi
+subcmd_idx=-1
+i=0
+while [ $i -lt ${#git_tokens[@]} ]; do
+  token="${git_tokens[$i]}"
   case "$token" in
     -C|--work-tree)
-      next_is_target=true
-      continue
+      i=$((i + 1))
+      git_target_dir="${git_tokens[$i]:-}"
       ;;
     --work-tree=*)
       git_target_dir="${token#*=}"
-      continue
       ;;
     -c|--git-dir|--namespace|--super-prefix)
-      skip_next=true
-      continue
+      i=$((i + 1))
       ;;
     --git-dir=*|--namespace=*|--super-prefix=*)
-      continue
       ;;
     -*)
-      continue
       ;;
     *)
       subcmd="$token"
+      subcmd_idx=$i
       break
       ;;
   esac
+  i=$((i + 1))
 done
 
 if [ "$subcmd" != "commit" ] && [ "$subcmd" != "push" ]; then
   exit 0
+fi
+
+# For `git push`, inspect every remaining token as a potential refspec and
+# block if any destination resolves to `main`. This catches bypass attempts
+# like `git push origin HEAD:main` or `git push origin feat/x:main` that would
+# otherwise slip through the branch check below.
+#
+# Refspec grammar: [+]<src>:<dst>, or [+]<ref> as shorthand for <ref>:<ref>.
+# We strip the optional leading '+' (force), take the destination (after the
+# last ':' if present, otherwise the whole token), and match against `main`
+# or `refs/heads/main`.
+if [ "$subcmd" = "push" ]; then
+  j=$((subcmd_idx + 1))
+  while [ $j -lt ${#git_tokens[@]} ]; do
+    arg="${git_tokens[$j]}"
+    j=$((j + 1))
+    # Skip option flags; we don't track which ones take values since any value
+    # that happens to equal `main` should fail closed anyway.
+    case "$arg" in
+      -*) continue ;;
+    esac
+    refspec="${arg#+}"
+    case "$refspec" in
+      *:*) dst="${refspec##*:}" ;;
+      *)   dst="$refspec" ;;
+    esac
+    case "$dst" in
+      main|refs/heads/main)
+        echo "BLOCKED: 'git push' targets 'main' (refspec '$arg'). Open a PR instead." >&2
+        exit 2
+        ;;
+    esac
+  done
 fi
 
 # Check the currently checked-out branch. Block iff it is `main`.
@@ -97,5 +125,5 @@ if [ "$current_branch" = "main" ]; then
   exit 2
 fi
 
-# On a feature branch — allow (in primary checkout or any linked worktree)
+# On a feature branch, with no push refspec targeting main — allow.
 exit 0

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-# PreToolUse hook: block git commit/push on the main worktree.
+# PreToolUse hook: block git commit/push when the main branch is checked out.
 #
-# Returns exit 2 (block) if the agent is trying to commit or push
-# from the main worktree, regardless of which branch is checked out.
-# Returns exit 0 (allow) otherwise.
+# Returns exit 2 (block) if the agent is trying to commit or push while
+# the current HEAD is on `main`, regardless of whether this is the primary
+# checkout or a linked worktree.
+# Returns exit 0 (allow) otherwise — feature branches are fine anywhere.
+#
+# Policy (see rules/common/worktrees.md):
+#   - Main agent works on a feature branch in the primary checkout.
+#   - Subagents / harness work on a feature branch in a linked worktree.
+#   - Nobody commits to `main`, ever.
 #
 # Hook input (JSON on stdin) contains the tool parameters.
 # We check the Bash command for git commit/push patterns.
@@ -69,37 +75,27 @@ if [ "$subcmd" != "commit" ] && [ "$subcmd" != "push" ]; then
   exit 0
 fi
 
-# Check if we're in the main worktree (not a linked worktree).
-# Block regardless of branch — the main worktree should never be committed to.
+# Check the currently checked-out branch. Block iff it is `main`.
 #
-# If -C or --git-dir was used, run the check from that directory instead
+# If -C or --work-tree was used, run the check against that directory instead
 # of the current working directory — this prevents false positives when
-# agents use git -C .claude/worktrees/<branch> commit from the main worktree.
-#
-# git rev-parse --git-common-dir returns the shared .git dir
-# git rev-parse --git-dir returns the per-worktree .git dir (or .git file for linked worktrees)
-# In the main worktree, both resolve to the same path.
-# In a linked worktree, --git-dir points to .git/worktrees/<name>.
+# agents use git -C .claude/worktrees/<branch> commit from the primary checkout.
 if [ -n "$git_target_dir" ]; then
-  git_dir=$(git -C "$git_target_dir" rev-parse --git-dir 2>/dev/null || echo "")
-  git_common_dir=$(git -C "$git_target_dir" rev-parse --git-common-dir 2>/dev/null || echo "")
+  current_branch=$(git -C "$git_target_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 else
-  git_dir=$(git rev-parse --git-dir 2>/dev/null || echo "")
-  git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 fi
 
-# Guard against empty paths — if git rev-parse failed, allow the command
-if [ -z "$git_dir" ] || [ -z "$git_common_dir" ]; then
+# Guard against empty output — if git rev-parse failed, allow the command
+if [ -z "$current_branch" ]; then
   exit 0
 fi
 
-resolved_git_dir=$(cd "$git_dir" 2>/dev/null && pwd || echo "")
-resolved_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd || echo "")
-
-if [ "$resolved_git_dir" = "$resolved_common_dir" ]; then
-  echo "BLOCKED: Cannot commit/push from the main worktree. Create a worktree first: git worktree add .claude/worktrees/<branch-name> -b <branch-name>" >&2
+if [ "$current_branch" = "main" ]; then
+  echo "BLOCKED: Cannot commit/push while on 'main'. Check out a feature branch first: git checkout -b feat/<name>" >&2
+  echo "        (Subagents / harness should create a worktree: git worktree add .claude/worktrees/<branch> -b <branch>)" >&2
   exit 2
 fi
 
-# We're in a linked worktree — allow
+# On a feature branch — allow (in primary checkout or any linked worktree)
 exit 0

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     css: true,
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/cypress/**',
+      '**/.{idea,git,cache,output,temp}/**',
+      '**/{karma,rollup,webpack,vite,vitest,jest,ash,nyc,cypress,tsup,build,eslint,prettier}.config.*',
+      '.claude/**',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       '**/dist/**',
       '**/cypress/**',
       '**/.{idea,git,cache,output,temp}/**',
-      '**/{karma,rollup,webpack,vite,vitest,jest,ash,nyc,cypress,tsup,build,eslint,prettier}.config.*',
+      '**/{karma,rollup,webpack,vite,vitest,jest,ava,nyc,cypress,tsup,build,eslint,prettier}.config.*',
       '.claude/**',
     ],
     coverage: {


### PR DESCRIPTION
## Summary

Shift the worktree policy from "main worktree is sacred" to "`main` branch is sacred". The interactive main agent now works on a feature branch in the primary checkout so the user's live diff viewer reflects its edits; subagents and the autonomous harness continue to isolate under `.claude/worktrees/<branch>/`.

- **`rules/common/worktrees.md`** — rewrote principles, added a "Who Works Where" table, split the lifecycle/cleanup sections into main-agent (primary checkout) vs. subagent (linked worktree) paths.
- **`rules/common/git-workflow.md`** — added a Branching section and refreshed the Post-PR / Multi-Agent sections to match.
- **`scripts/hooks/block-main-commit.sh`** — PreToolUse hook now blocks based on the checked-out branch being `main` (any worktree) instead of blocking every commit in the primary checkout. Feature branches allowed everywhere; `main` forbidden everywhere.
- **`vitest.config.ts` + `eslint.config.js`** — add `.claude/**` to vitest `test.exclude` and eslint `ignores`. Without this, every time a subagent follows the new policy and creates a worktree under `.claude/worktrees/`, pre-push vitest and pre-commit lint would pick up its full tree and produce spurious failures. This gap already produced 573 failing tests and 11 lint errors on `main` before the fix.

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run lint` — clean (was 11 errors from stale worktrees)
- [x] `npx vitest run` — 93 files / 1286 tests pass (was 41 files / 573 tests failing from stale worktrees)
- [x] `bash -n scripts/hooks/block-main-commit.sh` — syntax OK
- [x] Hook smoke test on `main` branch: `git commit` → blocked (exit 2), `git status` → allowed
- [x] Hook smoke test on feature branch in a linked worktree: `git commit` → allowed
- [x] Pre-commit hook (lint-staged + prettier + tsc) — passed on both commits
- [x] Pre-push hook (vitest run) — passed