### PR TITLE
fix: ts-rs cleanup — camelCase consistency and stale binding detection

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -119,7 +119,9 @@ jobs:
         run: npm ci
 
       - name: Generate bindings
-        run: npm run generate:bindings
+        run: |
+          find src/bindings -name '*.ts' ! -name 'index.ts' -delete
+          npm run generate:bindings
 
       - name: Verify bindings are up to date
         run: |

--- a/src-tauri/src/filesystem/types.rs
+++ b/src-tauri/src/filesystem/types.rs
@@ -33,6 +33,7 @@ pub enum EntryType {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
+#[serde(rename_all = "camelCase")]
 pub struct ReadFileRequest {
     pub path: String,
 }
@@ -40,6 +41,7 @@ pub struct ReadFileRequest {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
+#[serde(rename_all = "camelCase")]
 pub struct WriteFileRequest {
     pub path: String,
     pub content: String,


### PR DESCRIPTION
## Summary

Follow-up to #49. Addresses two remaining Claude Code Review findings:

- Add `#[serde(rename_all = "camelCase")]` to `ReadFileRequest` and `WriteFileRequest` for consistency with all other IPC types (no runtime change — fields are single words)
- CI `bindings-check` now wipes generated `.ts` files before regenerating, so stale bindings from deleted Rust types are detected

## Test plan

- [x] `cargo test export_bindings` — 13 export tests pass
- [x] Generated bindings unchanged (single-word fields unaffected by camelCase)
- [x] Pre-commit hooks pass
- [x] Pre-push tests pass (1284 tests)