### PR TITLE
docs: establish scope boundary principle for reviews and agents

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -58,9 +58,17 @@ jobs:
             - For each finding, explain: (1) what the current code does wrong, (2) the concrete impact, and (3) what the fix should be.
             - If a bug class appears in multiple places (e.g. missing error handling in both skip_review and review paths), report them together in one finding rather than separately.
 
+            SCOPE BOUNDARY RULE (MANDATORY):
+            Your review scope is ONLY the lines added or modified in the PR diff.
+            - Do NOT flag pre-existing bugs in unchanged code.
+            - Do NOT suggest improvements to adjacent untouched code.
+            - Do NOT cascade into related files that weren't part of the diff.
+            - If you notice a real issue in untouched code, put it in a separate "Out-of-Scope Observations" section — NOT as a finding with severity.
+            - Never block or warn based on out-of-scope observations.
+            - Exception: actively exploitable CRITICAL security vulnerabilities.
+
             Apply confidence-based filtering: only report issues you are >80% confident about.
             Use severity levels: CRITICAL, HIGH, MEDIUM, LOW.
-            Focus on issues introduced by this PR — do not flag pre-existing problems.
 
             Return your review as structured JSON matching the provided schema. Do not post any comments directly — the workflow will format and post the findings.
 
@@ -114,6 +122,7 @@ jobs:
               }
 
               const verdict = review.overall_correctness === 'patch is correct' ? '✅' : '⚠️'
+              lines.push('')
               lines.push(`**Overall: ${verdict} ${review.overall_correctness}** (confidence: ${(review.overall_confidence_score * 100).toFixed(0)}%)`)
               lines.push('')
               lines.push(`> ${review.overall_explanation}`)

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -49,9 +49,17 @@ jobs:
             - For each finding, explain: (1) what the current code does wrong, (2) the concrete impact, and (3) what the fix should be.
             - If a bug class appears in multiple places (e.g. missing error handling in both skip_review and review paths), report them together in one finding rather than separately.
 
+            SCOPE BOUNDARY RULE (MANDATORY):
+            Your review scope is ONLY the lines added or modified in the PR diff.
+            - Do NOT flag pre-existing bugs in unchanged code.
+            - Do NOT suggest improvements to adjacent untouched code.
+            - Do NOT cascade into related files that weren't part of the diff.
+            - If you notice a real issue in untouched code, put it in a separate "Out-of-Scope Observations" section — NOT as a finding with severity.
+            - Never block or warn based on out-of-scope observations.
+            - Exception: actively exploitable CRITICAL security vulnerabilities.
+
             Apply confidence-based filtering: only report issues you are >80% confident about.
             Use severity levels: CRITICAL, HIGH, MEDIUM, LOW.
-            Focus on issues introduced by this PR — do not flag pre-existing problems.
 
             Pull request title and body:
             ----
@@ -105,6 +113,7 @@ jobs:
               }
 
               const verdict = review.overall_correctness === 'patch is correct' ? '✅' : '⚠️';
+              lines.push('');
               lines.push(`**Overall: ${verdict} ${review.overall_correctness}** (confidence: ${(review.overall_confidence_score * 100).toFixed(0)}%)`);
               lines.push('');
               lines.push(`> ${review.overall_explanation}`);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Follow the review process and checklist defined in `agents/code-reviewer.md`. Ke
 
 ## Review Guidelines
 
-- Focus only on issues **introduced by the PR diff** — do not flag pre-existing problems
+- **Scope boundary (mandatory)**: Review ONLY the lines added or modified in the diff. Pre-existing bugs in unchanged code are out of scope — note them as follow-ups in a separate "Out-of-Scope Observations" section, never as findings with severity. Do not cascade into related files or chase increasingly niche edge cases in working code. Exception: actively exploitable CRITICAL security vulnerabilities.
 - Severity levels: CRITICAL (security/data loss), HIGH (bugs), MEDIUM (maintainability), LOW (style)
 - Flag any hardcoded secrets, `console.log` statements, or `any` types
 - Approval: no CRITICAL/HIGH = approve; HIGH only = warn; CRITICAL = block

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -27,6 +27,20 @@ When invoked:
 - **Consolidate** similar issues (e.g., "5 functions missing error handling" not 5 separate findings)
 - **Prioritize** issues that could cause bugs, security vulnerabilities, or data loss
 
+## Scope Boundary (MANDATORY)
+
+Your review scope is the diff — nothing more.
+
+- **In scope**: Lines added or modified in the diff, and behavior changes directly caused by those lines
+- **Out of scope**: Pre-existing bugs in unchanged code, adjacent "improvements", cascading into related files, increasingly niche edge cases in working code
+
+**If you find a real issue in untouched code:**
+Do NOT report it as a finding with severity. Instead, add it to an **Out-of-Scope Observations** section at the end — framed as "Consider filing a follow-up for: [description]". Never block or warn based on out-of-scope observations.
+
+**Exception:** Actively exploitable CRITICAL security vulnerabilities may be flagged regardless of diff scope.
+
+**Anti-pattern to avoid:** Review rabbit-holes — where round N finds an issue, the fix in round N+1 triggers a new niche finding in the same area, spiraling into 5+ rounds on code that was already working. If the original PR goal is achieved and tests pass, stop.
+
 ## Review Checklist
 
 ### Security (CRITICAL)

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -31,3 +31,4 @@ ingestion protocol.
 | [CodeMirror Integration](patterns/codemirror-integration.md)   | editor         | 12       | 0    | 2026-04-11   |
 | [Error Surfacing](patterns/error-surfacing.md)                 | error-handling | 7        | 0    | 2026-04-10   |
 | [File Tree Paths](patterns/file-tree-paths.md)                 | files          | 4        | 0    | 2026-04-10   |
+| [Scope Boundary](patterns/scope-boundary.md)                   | review-process | 5        | 0    | 2026-04-12   |

--- a/docs/reviews/patterns/scope-boundary.md
+++ b/docs/reviews/patterns/scope-boundary.md
@@ -1,0 +1,60 @@
+---
+id: scope-boundary
+category: review-process
+created: 2026-04-12
+last_updated: 2026-04-12
+ref_count: 0
+---
+
+# Scope Boundary
+
+## Summary
+
+Reviews must evaluate only what the diff introduced or modified. Flagging
+pre-existing bugs in unchanged code, suggesting improvements to adjacent
+untouched code, or cascading into related files inflates review cycles and
+obscures the PR's actual intent. Out-of-scope observations belong in a
+separate follow-up section, not as findings with severity.
+
+## Findings
+
+### 1. CI drift check flagged on pre-existing CI gap, not PR-introduced code
+
+- **Source:** claude-code-review | PR #49 | 2026-04-12
+- **Severity:** MEDIUM (should have been OUT-OF-SCOPE)
+- **File:** `.github/workflows/ci-checks.yml`
+- **Finding:** Review flagged that `git diff --exit-code` doesn't catch untracked files — a pre-existing CI behavior, not introduced by the ts-rs integration PR.
+- **Why out of scope:** The CI step existed before the PR. The PR added ts-rs bindings, not the CI verification logic.
+
+### 2. Stale domain types flagged during ts-rs migration
+
+- **Source:** claude-code-review | PR #49 | 2026-04-12
+- **Severity:** MEDIUM (should have been OUT-OF-SCOPE)
+- **File:** `src/features/terminal/types/index.ts`
+- **Finding:** Review flagged stale `PTYExitEvent` with phantom `signal` field. These types pre-dated the PR — the PR replaced their usage but didn't claim to clean them up.
+- **Why out of scope:** Cleanup of legacy types is a separate task from adding automated codegen.
+
+### 3. Auto-select useEffect flagged in diff-viewer wiring PR
+
+- **Source:** claude-code-review | PR #47 | 2026-04-12
+- **Severity:** HIGH (should have been OUT-OF-SCOPE)
+- **File:** `src/features/diff/components/DiffPanelContent.tsx`
+- **Finding:** Review flagged that the auto-select useEffect doesn't re-select when a file leaves the list. This was pre-existing behavior in an untouched component.
+- **Why out of scope:** The PR wired git state to the bottom drawer — it didn't modify DiffPanelContent's selection logic.
+
+### 4. Review rabbit-hole — 5 rounds of test assertion refinement
+
+- **Source:** claude-code-review | PR #43 | 2026-04-11
+- **Severity:** LOW → LOW → LOW → LOW → LOW (should have stopped after round 1)
+- **File:** `src/features/editor/hooks/useCodeMirror.test.ts`
+- **Finding:** The original PR fixed a CSS flex bug and a vim scroll bug. Reviews then spiraled through 5 rounds of increasingly niche test assertion improvements (loose effect check → missing regression guard → uncovered branch → duck-type false positive). Each round's fix introduced the next round's finding.
+- **Why out of scope:** The original tests were sufficient for the PR's goal. The rabbit-hole expanded scope far beyond the flex/scroll fix into CodeMirror internals testing philosophy.
+- **Cross-ref:** `testing-gaps.md` findings #5–#8
+
+### 5. Rename parsing bug flagged in code untouched by diff
+
+- **Source:** codex-review | local | 2026-04-12
+- **Severity:** P2 (should have been OUT-OF-SCOPE)
+- **File:** `src-tauri/src/git/mod.rs`
+- **Finding:** Codex flagged porcelain v1 rename parsing bug and MM staged flag — both in `parse_git_status`, which was not part of the diff being reviewed.
+- **Why out of scope:** The diff only touched `.gitignore` and deleted venv symlinks. The git parsing code was entirely unchanged.


### PR DESCRIPTION
## Summary

- Add mandatory **Scope Boundary Rule** to `agents/code-reviewer.md`, `AGENTS.md`, and both CI review workflow prompts (Claude + Codex)
- Replace the weak one-liner "do not flag pre-existing problems" with a prominent, structured block defining in-scope vs out-of-scope
- Add `scope-boundary` pattern to review knowledge base with 5 documented violations from PRs #49, #47, #43, and local Codex reviews
- Fix review comment formatting: extra `\n` before the Overall verdict for readability

## Context

Agents consistently flag issues outside PR scope — pre-existing bugs in unchanged code, improvements to adjacent untouched files, and review rabbit-holes (PR #43 went 5 rounds of increasingly niche test assertions). This PR codifies the boundary principle at every layer agents touch.

## Test plan

- [ ] Verify CI workflows parse correctly (YAML valid)
- [ ] Open a test PR and confirm Claude/Codex reviews respect scope boundary
- [ ] Verify review comment formatting has visible spacing before Overall verdict