### PR TITLE
test: reduce git timeout to validate scope boundary reviews

### DIFF
--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -7,7 +7,7 @@ use crate::filesystem::scope::{ensure_within_home, expand_home, home_canonical, 
 
 /// Timeout for git subprocess calls. Prevents indefinite blocking on
 /// hung NFS mounts, slow hooks, or unresponsive credential helpers.
-const GIT_TIMEOUT: Duration = Duration::from_secs(30);
+const GIT_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Run a git command with a timeout. Spawns the process first so the
 /// child handle is available for killing on timeout — prevents orphaned


### PR DESCRIPTION
## Summary

- Change `GIT_TIMEOUT` from 30s to 15s in `src-tauri/src/git/mod.rs`

## Purpose

**This is a test PR to validate the scope boundary principle** added in PR #52.

The file `git/mod.rs` contains known pre-existing issues (rename parsing bug, MM status flag). If the scope boundary rule is working, Claude and Codex reviewers should:
- Only comment on the timeout change (the single diff line)
- NOT flag the pre-existing rename parsing or MM status bugs
- Place any observations about untouched code in an "Out-of-Scope Observations" section

**Revert after validation.**

## Test plan

- [ ] Claude review stays scoped to the timeout change
- [ ] Codex review stays scoped to the timeout change
- [ ] No CRITICAL/HIGH findings on pre-existing code