### PR TITLE
feat(review): add IDEA analysis framework to code reviews

### DIFF
--- a/.github/codex/codex-output-schema.json
+++ b/.github/codex/codex-output-schema.json
@@ -59,6 +59,29 @@
         ]
       }
     },
+    "idea": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "intent": {
+          "type": "string",
+          "description": "Does the PR solve the real problem, not just the literal one?"
+        },
+        "danger": {
+          "type": "string",
+          "description": "What breaks? Edge cases, security, bad data?"
+        },
+        "explain": {
+          "type": "string",
+          "description": "Why this approach? What reasoning led here?"
+        },
+        "alternatives": {
+          "type": "string",
+          "description": "Is there a simpler way? Would a senior dev raise an eyebrow?"
+        }
+      },
+      "required": ["intent", "danger", "explain", "alternatives"]
+    },
     "overall_correctness": {
       "type": "string",
       "enum": ["patch is correct", "patch has issues"]
@@ -74,6 +97,7 @@
   },
   "required": [
     "findings",
+    "idea",
     "overall_correctness",
     "overall_explanation",
     "overall_confidence_score"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -70,6 +70,13 @@ jobs:
             Apply confidence-based filtering: only report issues you are >80% confident about.
             Use severity levels: CRITICAL, HIGH, MEDIUM, LOW.
 
+            IDEA ANALYSIS (MANDATORY):
+            Include an "idea" object in your JSON output with these four fields:
+            - intent: Does the PR solve the real problem, not just the literal one?
+            - danger: What breaks? Edge cases, security, bad data?
+            - explain: Why this approach? What reasoning led here?
+            - alternatives: Is there a simpler way? Would a senior dev raise an eyebrow?
+
             Return your review as structured JSON matching the provided schema. Do not post any comments directly — the workflow will format and post the findings.
 
             Pull request title and body:
@@ -118,6 +125,21 @@ jobs:
                 }
               } else {
                 lines.push('✅ No issues found.')
+                lines.push('')
+              }
+
+              if (review.idea) {
+                lines.push('### 💡 IDEA Analysis')
+                lines.push('')
+                lines.push(`**I — Intent:** ${review.idea.intent}`)
+                lines.push('')
+                lines.push(`**D — Danger:** ${review.idea.danger}`)
+                lines.push('')
+                lines.push(`**E — Explain:** ${review.idea.explain}`)
+                lines.push('')
+                lines.push(`**A — Alternatives:** ${review.idea.alternatives}`)
+                lines.push('')
+                lines.push('---')
                 lines.push('')
               }
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -61,6 +61,13 @@ jobs:
             Apply confidence-based filtering: only report issues you are >80% confident about.
             Use severity levels: CRITICAL, HIGH, MEDIUM, LOW.
 
+            IDEA ANALYSIS (MANDATORY):
+            Include an "idea" object in your JSON output with these four fields:
+            - intent: Does the PR solve the real problem, not just the literal one?
+            - danger: What breaks? Edge cases, security, bad data?
+            - explain: Why this approach? What reasoning led here?
+            - alternatives: Is there a simpler way? Would a senior dev raise an eyebrow?
+
             Pull request title and body:
             ----
             ${{ github.event.pull_request.title }}
@@ -109,6 +116,21 @@ jobs:
                 }
               } else {
                 lines.push('✅ No issues found.');
+                lines.push('');
+              }
+
+              if (review.idea) {
+                lines.push('### 💡 IDEA Analysis');
+                lines.push('');
+                lines.push(`**I — Intent:** ${review.idea.intent}`);
+                lines.push('');
+                lines.push(`**D — Danger:** ${review.idea.danger}`);
+                lines.push('');
+                lines.push(`**E — Explain:** ${review.idea.explain}`);
+                lines.push('');
+                lines.push(`**A — Alternatives:** ${review.idea.alternatives}`);
+                lines.push('');
+                lines.push('---');
                 lines.push('');
               }
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -233,6 +233,24 @@ End every review with:
 Verdict: WARNING — 2 HIGH issues should be resolved before merge.
 ```
 
+## IDEA Analysis (MANDATORY)
+
+Every review must include an IDEA section after the findings summary. This helps the PR author understand the review holistically, not just as a list of issues.
+
+- **I — Intent**: Does the PR solve the real problem, not just the literal one? Is the goal clear from the diff, or is there a mismatch between what was asked and what was built?
+- **D — Danger**: What breaks? Edge cases, security implications, bad data paths. Focus on risks _introduced by this diff_, not pre-existing ones.
+- **E — Explain**: Can you explain why this approach was chosen? What trade-offs did the author make? If the reasoning isn't obvious from the code, call that out.
+- **A — Alternatives**: Is there a simpler way? Would a senior dev raise an eyebrow at this approach? Suggest alternatives only if they're meaningfully better — not just different.
+
+```
+## 💡 IDEA Analysis
+
+**I — Intent:** [Does this solve the real problem?]
+**D — Danger:** [What could break?]
+**E — Explain:** [Why this approach?]
+**A — Alternatives:** [Simpler options?]
+```
+
 ## Approval Criteria
 
 - **Approve**: No CRITICAL or HIGH issues


### PR DESCRIPTION
## Summary

- Add **IDEA** (Intent, Danger, Explain, Alternatives) analysis as a mandatory section in every code review
- Update output schema with required `idea` object (4 string fields)
- Add `IDEA ANALYSIS (MANDATORY)` instruction block to both Claude and Codex CI review prompts
- Render IDEA section in PR comment formatters (between findings and overall verdict)
- Add IDEA methodology to `agents/code-reviewer.md` agent spec
- Add IDEA section to global `rules/common/code-review.md`

## What is IDEA?

| Letter | Question |
|--------|----------|
| **I — Intent** | Does it solve the real problem, not just the literal one? |
| **D — Danger** | What breaks? Edge cases, security, bad data? |
| **E — Explain** | Why this approach? What reasoning led here? |
| **A — Alternatives** | Is there a simpler way? Would a senior dev raise an eyebrow? |

## Test plan

- [ ] Verify JSON schema is valid
- [ ] Open a test PR and confirm IDEA section renders in review comment
- [ ] Verify IDEA content is substantive, not boilerplate