### PR TITLE
fix(agent-status): store resolved CWD in PtyState for watcher path derivation

### DIFF
--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -251,6 +251,31 @@ pub async fn start_agent_watcher(
         path.display()
     );
 
+    // Debug-only file log for diagnosing watcher startup
+    #[cfg(debug_assertions)]
+    {
+        use std::io::Write;
+        use std::time::SystemTime;
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("/tmp/vimeflow-debug.log")
+        {
+            let secs = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let _ = writeln!(
+                f,
+                "[{}] [watcher] start: session={}, cwd={}, path={}",
+                secs,
+                session_id,
+                cwd,
+                path.display()
+            );
+        }
+    }
+
     // Stop any existing watcher for this session
     state.remove(&session_id);
 

--- a/src-tauri/src/terminal/commands.rs
+++ b/src-tauri/src/terminal/commands.rs
@@ -7,6 +7,28 @@ use tauri::{AppHandle, Emitter, State};
 use super::state::{ManagedSession, PtyState};
 use super::types::*;
 
+/// Debug-only file logger. Compiles to no-op in release builds.
+/// Writes to /tmp/vimeflow-debug.log for diagnosing IPC and bridge issues.
+#[cfg(debug_assertions)]
+fn debug_log(tag: &str, msg: &str) {
+    use std::io::Write;
+    use std::time::SystemTime;
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("/tmp/vimeflow-debug.log")
+    {
+        let secs = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let _ = writeln!(f, "[{secs}] [{tag}] {msg}");
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn debug_log(_tag: &str, _msg: &str) {}
+
 /// Spawn a new PTY session with a shell
 #[tauri::command]
 pub async fn spawn_pty<R: tauri::Runtime>(
@@ -14,6 +36,13 @@ pub async fn spawn_pty<R: tauri::Runtime>(
     state: State<'_, PtyState>,
     request: SpawnPtyRequest,
 ) -> Result<PtySession, String> {
+    debug_log(
+        "pty",
+        &format!(
+            "spawn_pty: id={}, cwd={}, bridge={}",
+            request.session_id, request.cwd, request.enable_agent_bridge
+        ),
+    );
     log::info!(
         "Spawning PTY session: {} in {}",
         request.session_id,
@@ -93,7 +122,17 @@ pub async fn spawn_pty<R: tauri::Runtime>(
             &dir.to_string_lossy(),
             &request.session_id,
         ) {
-            Ok(files) => Some(files),
+            Ok(files) => {
+                debug_log(
+                    "bridge",
+                    &format!(
+                        "created: status={}, init={}",
+                        files.status_file_path.display(),
+                        files.shell_init_path.display()
+                    ),
+                );
+                Some(files)
+            }
             Err(e) => {
                 log::warn!(
                     "Failed to generate statusline bridge for session {}: {}",
@@ -196,10 +235,19 @@ pub async fn spawn_pty<R: tauri::Runtime>(
         master: pty_pair.master,
         writer,
         child,
-        cwd: request.cwd.clone(),
+        cwd: cwd.to_string_lossy().to_string(),
         generation,
     };
     state.insert(request.session_id.clone(), session);
+    debug_log(
+        "pty",
+        &format!(
+            "session stored: id={}, cwd={}, pid={}",
+            request.session_id,
+            cwd.display(),
+            pid
+        ),
+    );
 
     // Spawn blocking thread for PTY read loop (avoids starving async runtime)
     let session_id = request.session_id.clone();


### PR DESCRIPTION
## Summary

- Fix: `ManagedSession.cwd` now stores the canonicalized path instead of the raw `request.cwd` (`~`). This fixes `start_agent_watcher` deriving a literal `~/.vimeflow/...` path that doesn't match the actual bridge files.
- Restore debug file logging gated behind `cfg(debug_assertions)` — compiles to no-ops in release builds, logs to `/tmp/vimeflow-debug.log` for PTY spawn, bridge creation, and watcher startup.

## Root cause

In `spawn_pty`, the `cwd` variable is canonicalized (line 97: `std::fs::canonicalize`), but `ManagedSession` stored `request.cwd.clone()` (the raw IPC value, typically `~`). When `start_agent_watcher` later called `pty_state.get_cwd()`, it got `~` and built a path like `~/.vimeflow/sessions/<id>/status.json` — a literal tilde, not the expanded home directory.

## Test plan

- [x] `cargo test` — 105 passed
- [x] `cargo build` — clean
- [ ] Manual: `npm run tauri dev` → launch `claude` → sidebar shows model name + context %