### PR TITLE
feat(agent-status): wire transcript parser for tool call tracking (#56)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -14,16 +14,16 @@ ingestion protocol.
 
 | Pattern                                                        | Category       | Findings | Refs | Last Updated |
 | -------------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
-| [Filesystem Scope](patterns/filesystem-scope.md)               | security       | 14       | 0    | 2026-04-10   |
+| [Filesystem Scope](patterns/filesystem-scope.md)               | security       | 14       | 1    | 2026-04-10   |
 | [React Lifecycle](patterns/react-lifecycle.md)                 | react-patterns | 6        | 0    | 2026-04-10   |
-| [Resource Cleanup](patterns/resource-cleanup.md)               | react-patterns | 1        | 0    | 2026-04-09   |
+| [Resource Cleanup](patterns/resource-cleanup.md)               | react-patterns | 1        | 1    | 2026-04-09   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)       | cross-platform | 2        | 0    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                 | code-quality   | 4        | 0    | 2026-04-12   |
 | [Testing Gaps](patterns/testing-gaps.md)                       | testing        | 8        | 0    | 2026-04-11   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 0    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 9        | 0    | 2026-04-11   |
 | [Accessibility](patterns/accessibility.md)                     | a11y           | 11       | 0    | 2026-04-10   |
-| [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 10       | 0    | 2026-04-12   |
+| [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 11       | 1    | 2026-04-14   |
 | [Command Injection](patterns/command-injection.md)             | security       | 4        | 0    | 2026-04-09   |
 | [CSP Configuration](patterns/csp-configuration.md)             | security       | 2        | 0    | 2026-04-09   |
 | [PTY Session Management](patterns/pty-session-management.md)   | backend        | 5        | 0    | 2026-04-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -14,16 +14,17 @@ ingestion protocol.
 
 | Pattern                                                        | Category       | Findings | Refs | Last Updated |
 | -------------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
-| [Filesystem Scope](patterns/filesystem-scope.md)               | security       | 14       | 1    | 2026-04-10   |
+| [Filesystem Scope](patterns/filesystem-scope.md)               | security       | 15       | 2    | 2026-04-14   |
 | [React Lifecycle](patterns/react-lifecycle.md)                 | react-patterns | 6        | 0    | 2026-04-10   |
-| [Resource Cleanup](patterns/resource-cleanup.md)               | react-patterns | 1        | 1    | 2026-04-09   |
+| [Resource Cleanup](patterns/resource-cleanup.md)               | react-patterns | 2        | 2    | 2026-04-14   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)       | cross-platform | 2        | 0    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                 | code-quality   | 4        | 0    | 2026-04-12   |
+| [Generated Artifacts](patterns/generated-artifacts.md)         | code-quality   | 1        | 0    | 2026-04-14   |
 | [Testing Gaps](patterns/testing-gaps.md)                       | testing        | 8        | 0    | 2026-04-11   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 0    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 9        | 0    | 2026-04-11   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 10       | 1    | 2026-04-14   |
 | [Accessibility](patterns/accessibility.md)                     | a11y           | 11       | 0    | 2026-04-10   |
-| [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 11       | 1    | 2026-04-14   |
+| [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 12       | 2    | 2026-04-14   |
 | [Command Injection](patterns/command-injection.md)             | security       | 4        | 0    | 2026-04-09   |
 | [CSP Configuration](patterns/csp-configuration.md)             | security       | 2        | 0    | 2026-04-09   |
 | [PTY Session Management](patterns/pty-session-management.md)   | backend        | 5        | 0    | 2026-04-09   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,8 +2,8 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-04-12
-ref_count: 0
+last_updated: 2026-04-14
+ref_count: 1
 ---
 
 # Async Race Conditions
@@ -105,4 +105,15 @@ prevent showing previous data.
 - **File:** `src/features/agent-status/hooks/useAgentStatus.ts`
 - **Finding:** The `setTimeout` in the exit detection path schedules `isActive` to flip to false after 5s, but there is no cancellation when the agent is detected again in that window. If the detection poll briefly misses the agent or it restarts quickly, the pending timeout fires and collapses the panel while the agent is still running.
 - **Fix:** Store the timeout ID in `collapseTimeoutRef` and clear it on subsequent detections or session change.
+- **Commit:** (pending — agent-status-sidebar PR)
+
+### 11. Transcript watcher ignores updated transcript paths
+
+- **Source:** local-codex | feat/agent-status-sidebar | 2026-04-14
+- **Severity:** HIGH
+- **File:** `src-tauri/src/agent/transcript.rs`
+- **Finding:** `TranscriptState` keyed active transcript tailers only by PTY session ID. Once a watcher started for a session, later statusline updates with a different `transcript_path` were ignored, leaving the backend tailing a stale Claude transcript while the active task wrote tool calls to a new JSONL file.
+- **Fix:** Track the active transcript path alongside each watcher. When statusline reports a different path for the same session, start tailing the new file and stop the old handle.
+- **Runtime evidence:** Active PTY session `bac78089-299d-431d-b0d0-89c2c19bc610` first tailed `f4c8dc90-0091-4943-8fca-5fc397fd59ef.jsonl`, but the current statusline later pointed at `13faa90a-65ec-4e5f-9bf2-481d9f0313a6.jsonl`, which contained the missing `Skill`, `Bash`, and long-running `Agent` tool calls.
+- **Verification:** Added `transcript_state_replaces_changed_path` regression coverage; manual retest confirmed tool calls reappeared after restarting the app.
 - **Commit:** (pending — agent-status-sidebar PR)

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -3,7 +3,7 @@ id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-04-14
-ref_count: 1
+ref_count: 2
 ---
 
 # Async Race Conditions
@@ -116,4 +116,14 @@ prevent showing previous data.
 - **Fix:** Track the active transcript path alongside each watcher. When statusline reports a different path for the same session, start tailing the new file and stop the old handle.
 - **Runtime evidence:** Active PTY session `bac78089-299d-431d-b0d0-89c2c19bc610` first tailed `f4c8dc90-0091-4943-8fca-5fc397fd59ef.jsonl`, but the current statusline later pointed at `13faa90a-65ec-4e5f-9bf2-481d9f0313a6.jsonl`, which contained the missing `Skill`, `Bash`, and long-running `Agent` tool calls.
 - **Verification:** Added `transcript_state_replaces_changed_path` regression coverage; manual retest confirmed tool calls reappeared after restarting the app.
+- **Commit:** (pending — agent-status-sidebar PR)
+
+### 12. Transcript watcher starts tailer while holding registry mutex
+
+- **Source:** github-claude | PR #63 round 2 | 2026-04-14
+- **Severity:** MEDIUM
+- **File:** `src-tauri/src/agent/transcript.rs`
+- **Finding:** `TranscriptState::start_or_replace` called `start_tailing` while holding the `watchers` mutex. Starting the tailer opens the transcript file and spawns a background thread, so concurrent statusline callbacks could block on unrelated filesystem or thread-creation work.
+- **Fix:** Use a double-check flow: check the active path under lock, start the tailer outside the lock, then re-acquire the lock before inserting. If a concurrent caller already registered the same path, stop the redundant new handle; if replacing an old path, stop the old handle outside the lock.
+- **Verification:** `cargo test --lib agent::transcript -j1`, `cargo test --lib agent:: -j1`, `cargo fmt --check`.
 - **Commit:** (pending — agent-status-sidebar PR)

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -2,8 +2,8 @@
 id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
-last_updated: 2026-04-11
-ref_count: 0
+last_updated: 2026-04-14
+ref_count: 1
 ---
 
 # Documentation Accuracy
@@ -96,3 +96,12 @@ Stale documentation misleads future contributors and review agents.
 - **Finding:** A JSDoc brittleness note on the `readScrollTargetPos` test helper advised future maintainers to harden the effect-type check by writing `effect.is(EditorView.scrollIntoView)`, stating it "IS a `StateEffectType` comparable via `effect.is(scrollIntoView)`". This is wrong on two counts: `EditorView.scrollIntoView` is a factory function with signature `(pos, options?) => StateEffect<ScrollTarget>`, not a `StateEffectType`, and `StateEffect.is()` accepts a `StateEffectType`, not a factory. A developer following the comment's guidance would hit a compile error, then waste time investigating why the "correct" fix doesn't work.
 - **Fix:** Rewrite the brittleness note to correctly describe `EditorView.scrollIntoView` as a factory, explain that CM6 does not publicly export the underlying `StateEffectType`, show the actual escape hatch (`EditorView.scrollIntoView(0).type` reads the underlying type off a throwaway instance), and recommend fixing the duck-type shape directly rather than hardening the type comparison in the common case.
 - **Commit:** `21d7c00 docs(editor): fix incorrect StateEffectType comment in round-4 brittleness note`
+
+### 10. Agent status spec names removed transcript function
+
+- **Source:** github-claude | PR #63 round 1 | 2026-04-14
+- **Severity:** LOW
+- **File:** `docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md`
+- **Finding:** The implementation notes referenced `TranscriptState::start_if_not_exists`, but the implementation had moved to `start_or_replace`. The same note described a double-check locking algorithm that the code did not yet implement at the time of review.
+- **Fix:** Update the note to name `start_or_replace` and describe the current double-check flow after the transcript watcher locking fix.
+- **Commit:** (pending — agent-status-sidebar PR)

--- a/docs/reviews/patterns/filesystem-scope.md
+++ b/docs/reviews/patterns/filesystem-scope.md
@@ -2,8 +2,8 @@
 id: filesystem-scope
 category: security
 created: 2026-04-09
-last_updated: 2026-04-10
-ref_count: 1
+last_updated: 2026-04-14
+ref_count: 2
 ---
 
 # Filesystem Scope
@@ -141,3 +141,13 @@ enumerate sensitive directories without scope restrictions.
 - **Finding:** Temp file named `.{file_name}.vimeflow.tmp.{pid}` — PID is constant for the process lifetime, so two concurrent `write_file` IPC calls targeting the same path collide on `create_new(true)` with `EEXIST`. Common trigger: `:w :w` in vim (the save callback fires on every keypress).
 - **Fix:** Add a per-process `AtomicU64` counter and append its value to the temp-file name, giving every invocation a unique path.
 - **Commit:** `38292c7 fix: address Claude review round 15 findings`
+
+### 15. Agent status transcript path not scoped before tailing
+
+- **Source:** github-claude | PR #63 round 1 | 2026-04-14
+- **Severity:** MEDIUM
+- **File:** `src-tauri/src/agent/watcher.rs`
+- **Finding:** `maybe_start_transcript` converted the `transcript_path` string from `status.json` directly into a `PathBuf` and passed it to the transcript tailer. A crafted or injected statusline could make Vimeflow open and tail an arbitrary local file.
+- **Fix:** Add a shared transcript-path validator that canonicalizes the file and requires it to resolve under the canonical `~/.claude` root before tailing. Use it from both `maybe_start_transcript` and the direct `start_transcript_watcher` IPC command.
+- **Verification:** Added `validate_transcript_path_rejects_path_outside_claude_root`; `cargo test --lib agent::transcript -j1`.
+- **Commit:** (pending — agent-status-sidebar PR)

--- a/docs/reviews/patterns/filesystem-scope.md
+++ b/docs/reviews/patterns/filesystem-scope.md
@@ -3,7 +3,7 @@ id: filesystem-scope
 category: security
 created: 2026-04-09
 last_updated: 2026-04-10
-ref_count: 0
+ref_count: 1
 ---
 
 # Filesystem Scope

--- a/docs/reviews/patterns/generated-artifacts.md
+++ b/docs/reviews/patterns/generated-artifacts.md
@@ -1,0 +1,27 @@
+---
+id: generated-artifacts
+category: code-quality
+created: 2026-04-14
+last_updated: 2026-04-14
+ref_count: 0
+---
+
+# Generated Artifacts
+
+## Summary
+
+Generated files must be committed in the same shape CI expects. Run the
+generator and formatter together so checked-in artifacts do not fail format
+checks or leave a regeneration diff.
+
+## Findings
+
+### 1. Generated TypeScript bindings left unformatted
+
+- **Source:** local-codex | feat/agent-status-sidebar | 2026-04-14
+- **Severity:** P2
+- **File:** `src/bindings/AgentDetectedEvent.ts`
+- **Finding:** The generated `src/bindings/*.ts` files had raw ts-rs formatting with trailing whitespace. `npm run format:check` and `git diff --check` failed, and the binding generation job would have left a diff after running Prettier.
+- **Fix:** Regenerate bindings through the narrower `cargo test --lib export_bindings -j1` path in this environment, then run `npx prettier --write src/bindings/`.
+- **Verification:** `cargo test --lib export_bindings -j1`, `npm run format:check`, `git diff --check`.
+- **Commit:** (pending — agent-status-sidebar PR)

--- a/docs/reviews/patterns/resource-cleanup.md
+++ b/docs/reviews/patterns/resource-cleanup.md
@@ -2,8 +2,8 @@
 id: resource-cleanup
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-04-09
-ref_count: 1
+last_updated: 2026-04-14
+ref_count: 2
 ---
 
 # Resource Cleanup
@@ -24,3 +24,13 @@ mount without cleanup causes listener accumulation and duplicate event handling.
 - **Finding:** Each `createTerminalService()` call registers global Tauri listeners with no `dispose()` on unmount — listeners accumulate as panes mount/unmount
 - **Fix:** Made Tauri service a singleton or added dispose call in cleanup
 - **Commit:** `2fc3fa2 feat: Xterm Terminal Core - TauriTerminalService IPC bridge (#34)`
+
+### 2. Transcript tailer handle lacks drop-time stop signal
+
+- **Source:** github-claude | PR #63 round 2 | 2026-04-14
+- **Severity:** LOW
+- **File:** `src-tauri/src/agent/transcript.rs`
+- **Finding:** `TranscriptHandle` exposed an explicit `stop(self)` method, but dropping a handle without calling `stop()` did not set the tail thread's stop flag. Shutdown paths that drop `TranscriptState` directly would leave tail loops running until process exit.
+- **Fix:** Add `Drop` for `TranscriptHandle` to set the stop flag. Keep explicit `stop(self)` for paths that must also join the thread.
+- **Verification:** Added `transcript_handle_drop_sets_stop_flag`; `cargo test --lib agent::transcript -j1`.
+- **Commit:** (pending — agent-status-sidebar PR)

--- a/docs/reviews/patterns/resource-cleanup.md
+++ b/docs/reviews/patterns/resource-cleanup.md
@@ -3,7 +3,7 @@ id: resource-cleanup
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-04-09
-ref_count: 0
+ref_count: 1
 ---
 
 # Resource Cleanup

--- a/docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md
+++ b/docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md
@@ -14,7 +14,7 @@ Key deviations and additions from the original spec during implementation:
 - **Path derivation from PTY state**: `start_agent_watcher` derives the status file path server-side from the PTY session's resolved CWD (stored in `PtyState`), rather than accepting a path from the frontend IPC call. This prevents path traversal attacks from crafted IPC calls.
 - **Env vars for script paths**: `bridge.rs` uses `VIMEFLOW_STATUS_FILE` and `VIMEFLOW_CLAUDE_SETTINGS` env vars instead of embedding absolute paths in the generated shell scripts, avoiding issues with CWD paths that contain quotes or shell metacharacters.
 - **Shell init wrapping**: A `init.sh` script is generated that defines a `claude()` shell function wrapping `command claude --settings ...`, with `unalias claude` to prevent alias expansion errors during function definition.
-- **TOCTOU prevention in transcript**: `TranscriptState::start_if_not_exists` uses double-check locking — checks under lock, creates handle outside lock, then re-checks under lock before inserting to handle concurrent callers.
+- **TOCTOU prevention in transcript**: `TranscriptState::start_or_replace` uses double-check locking: it checks the active path under lock, creates the handle outside the lock, then re-checks under lock before inserting to handle concurrent callers.
 - **Civil calendar without chrono**: `transcript.rs` implements a hand-rolled `days_to_date()` using the civil calendar algorithm to produce ISO 8601 timestamps, avoiding a `chrono` dependency for a single formatting call.
 
 ## Overview

--- a/docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md
+++ b/docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md
@@ -1,8 +1,21 @@
 # Agent Status Sidebar — Design Spec
 
 **Date:** 2026-04-12
+**Updated:** 2026-04-13
 **Status:** Implemented (sub-specs 1–8 complete, integration WIP)
 **Scope:** Real-time agent status panel for the Vimeflow workspace right side
+
+### Implementation Notes (2026-04-13)
+
+Key deviations and additions from the original spec during implementation:
+
+- **WSL2 polling fallback**: `watcher.rs` supplements `notify` file-watching with a 3-second polling thread because WSL2's inotify can miss events and Claude Code may use atomic writes (rename). Both paths emit the same events.
+- **Initial read on watcher start**: The watcher reads the status file immediately after subscribing, to handle the race where `status.json` was written before the watcher started.
+- **Path derivation from PTY state**: `start_agent_watcher` derives the status file path server-side from the PTY session's resolved CWD (stored in `PtyState`), rather than accepting a path from the frontend IPC call. This prevents path traversal attacks from crafted IPC calls.
+- **Env vars for script paths**: `bridge.rs` uses `VIMEFLOW_STATUS_FILE` and `VIMEFLOW_CLAUDE_SETTINGS` env vars instead of embedding absolute paths in the generated shell scripts, avoiding issues with CWD paths that contain quotes or shell metacharacters.
+- **Shell init wrapping**: A `init.sh` script is generated that defines a `claude()` shell function wrapping `command claude --settings ...`, with `unalias claude` to prevent alias expansion errors during function definition.
+- **TOCTOU prevention in transcript**: `TranscriptState::start_if_not_exists` uses double-check locking — checks under lock, creates handle outside lock, then re-checks under lock before inserting to handle concurrent callers.
+- **Civil calendar without chrono**: `transcript.rs` implements a hand-rolled `days_to_date()` using the civil calendar algorithm to produce ISO 8601 timestamps, avoiding a `chrono` dependency for a single formatting call.
 
 ## Overview
 

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -17,5 +17,5 @@ pub use types::{AgentDetectedEvent, AgentDisconnectedEvent, AgentType};
 
 // Re-export Tauri commands
 pub use commands::detect_agent_in_session;
-pub use watcher::{start_agent_watcher, stop_agent_watcher, AgentWatcherState};
 pub use transcript::{start_transcript_watcher, stop_transcript_watcher, TranscriptState};
+pub use watcher::{start_agent_watcher, stop_agent_watcher, AgentWatcherState};

--- a/src-tauri/src/agent/statusline.rs
+++ b/src-tauri/src/agent/statusline.rs
@@ -236,10 +236,7 @@ fn parse_rate_limits(value: Option<&serde_json::Value>) -> RateLimits {
                 .get("used_percentage")
                 .and_then(|v| v.as_f64())
                 .unwrap_or(0.0),
-            resets_at: fh
-                .get("resets_at")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0),
+            resets_at: fh.get("resets_at").and_then(|v| v.as_u64()).unwrap_or(0),
         })
         .unwrap_or(RateLimitInfo {
             used_percentage: 0.0,
@@ -256,10 +253,7 @@ fn parse_rate_limits(value: Option<&serde_json::Value>) -> RateLimits {
                 .get("used_percentage")
                 .and_then(|v| v.as_f64())
                 .unwrap_or(0.0),
-            resets_at: sd
-                .get("resets_at")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0),
+            resets_at: sd.get("resets_at").and_then(|v| v.as_u64()).unwrap_or(0),
         })
     });
 

--- a/src-tauri/src/agent/transcript.rs
+++ b/src-tauri/src/agent/transcript.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -22,10 +22,30 @@ const POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// Maximum length for the args summary string
 const MAX_ARGS_LEN: usize = 100;
 
+struct InFlightToolCall {
+    started_at: Instant,
+    tool: String,
+    args: String,
+}
+
+type InFlightToolCalls = HashMap<String, InFlightToolCall>;
+
 /// Handle returned by `start_tailing` to control the background watcher
 pub struct TranscriptHandle {
     stop_flag: Arc<AtomicBool>,
     join_handle: Option<std::thread::JoinHandle<()>>,
+}
+
+struct TranscriptWatcher {
+    transcript_path: PathBuf,
+    handle: TranscriptHandle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranscriptStartStatus {
+    Started,
+    Replaced,
+    AlreadyRunning,
 }
 
 impl TranscriptHandle {
@@ -41,7 +61,7 @@ impl TranscriptHandle {
 /// State shared across transcript watchers, keyed by session ID
 #[derive(Default, Clone)]
 pub struct TranscriptState {
-    watchers: Arc<Mutex<HashMap<String, TranscriptHandle>>>,
+    watchers: Arc<Mutex<HashMap<String, TranscriptWatcher>>>,
 }
 
 impl TranscriptState {
@@ -52,31 +72,75 @@ impl TranscriptState {
     }
 
     /// Start tailing a transcript for the given session.
-    /// If a watcher already exists for this session, it is stopped first.
-    pub fn start(
+    /// If a watcher exists for a different path, replace it after the new
+    /// watcher starts successfully.
+    pub fn start<R: tauri::Runtime>(
         &self,
-        app_handle: tauri::AppHandle,
+        app_handle: tauri::AppHandle<R>,
         session_id: String,
         transcript_path: PathBuf,
     ) -> Result<(), String> {
-        let mut watchers = self.watchers.lock().expect("failed to lock watchers");
+        let _ = self.start_or_replace(app_handle, session_id, transcript_path)?;
+        Ok(())
+    }
 
-        // Stop existing watcher for this session if any
-        if let Some(old) = watchers.remove(&session_id) {
-            old.stop();
+    /// Start tailing when none is active, or switch to a newer transcript path.
+    pub fn start_or_replace<R: tauri::Runtime>(
+        &self,
+        app_handle: tauri::AppHandle<R>,
+        session_id: String,
+        transcript_path: PathBuf,
+    ) -> Result<TranscriptStartStatus, String> {
+        let (old_handle, status) = {
+            let mut watchers = self.watchers.lock().expect("failed to lock watchers");
+
+            if let Some(current) = watchers.get(&session_id) {
+                if current.transcript_path == transcript_path {
+                    return Ok(TranscriptStartStatus::AlreadyRunning);
+                }
+            }
+
+            let handle = start_tailing(app_handle, session_id.clone(), transcript_path.clone())?;
+            let old = watchers.insert(
+                session_id,
+                TranscriptWatcher {
+                    transcript_path,
+                    handle,
+                },
+            );
+            let status = if old.is_some() {
+                TranscriptStartStatus::Replaced
+            } else {
+                TranscriptStartStatus::Started
+            };
+
+            (old.map(|watcher| watcher.handle), status)
+        };
+
+        if let Some(handle) = old_handle {
+            handle.stop();
         }
 
-        let handle = start_tailing(app_handle, session_id.clone(), transcript_path)?;
-        watchers.insert(session_id, handle);
-        Ok(())
+        Ok(status)
+    }
+
+    /// Check if a session already has an active transcript watcher
+    #[allow(dead_code)]
+    pub fn contains(&self, session_id: &str) -> bool {
+        let watchers = self.watchers.lock().expect("failed to lock watchers");
+        watchers.contains_key(session_id)
     }
 
     /// Stop tailing for the given session.
     pub fn stop(&self, session_id: &str) -> Result<(), String> {
-        let mut watchers = self.watchers.lock().expect("failed to lock watchers");
-        match watchers.remove(session_id) {
-            Some(handle) => {
-                handle.stop();
+        // Remove under the lock, join outside to avoid blocking other callers.
+        let handle = {
+            let mut watchers = self.watchers.lock().expect("failed to lock watchers");
+            watchers.remove(session_id)
+        };
+        match handle {
+            Some(watcher) => {
+                watcher.handle.stop();
                 Ok(())
             }
             None => Err(format!("No transcript watcher for session: {}", session_id)),
@@ -85,10 +149,10 @@ impl TranscriptState {
 }
 
 /// Start tailing a transcript JSONL file.
-/// Seeks to end of file on start (don't replay history).
+/// Reads from the beginning to catch up on missed tool calls.
 /// Emits `agent-tool-call` Tauri events for each tool call detected.
-pub fn start_tailing(
-    app_handle: tauri::AppHandle,
+pub fn start_tailing<R: tauri::Runtime>(
+    app_handle: tauri::AppHandle<R>,
     session_id: String,
     transcript_path: PathBuf,
 ) -> Result<TranscriptHandle, String> {
@@ -114,22 +178,21 @@ pub fn start_tailing(
 }
 
 /// Background loop that tails the transcript file
-fn tail_loop(
-    app_handle: tauri::AppHandle,
+fn tail_loop<R: tauri::Runtime>(
+    app_handle: tauri::AppHandle<R>,
     session_id: String,
     file: File,
     stop_flag: Arc<AtomicBool>,
 ) {
     let mut reader = BufReader::new(file);
 
-    // Seek to end — don't replay old entries
-    if let Err(e) = reader.seek(SeekFrom::End(0)) {
-        log::error!("Failed to seek transcript to end: {}", e);
-        return;
-    }
+    // Read from the beginning — each Claude Code session gets a unique JSONL
+    // file, so all lines belong to the current session. Replay catches any
+    // tool calls written before tailing started (the transcript file is often
+    // created seconds after the statusline first reports its path).
 
-    // In-flight tool calls: tool_use_id -> (start_time, tool_name)
-    let mut in_flight: HashMap<String, (Instant, String)> = HashMap::new();
+    // In-flight tool calls: tool_use_id -> call details
+    let mut in_flight: InFlightToolCalls = HashMap::new();
 
     // Buffer for partial lines
     let mut line_buf = String::new();
@@ -160,8 +223,8 @@ fn tail_loop(
 fn process_line(
     line: &str,
     session_id: &str,
-    app_handle: &tauri::AppHandle,
-    in_flight: &mut HashMap<String, (Instant, String)>,
+    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    in_flight: &mut InFlightToolCalls,
 ) {
     let value: Value = match serde_json::from_str(line) {
         Ok(v) => v,
@@ -177,6 +240,9 @@ fn process_line(
         "assistant" => {
             process_assistant_message(&value, session_id, app_handle, in_flight);
         }
+        "user" => {
+            process_user_message(&value, session_id, app_handle, in_flight);
+        }
         "tool_result" => {
             process_tool_result(&value, session_id, app_handle, in_flight);
         }
@@ -190,14 +256,10 @@ fn process_line(
 fn process_assistant_message(
     value: &Value,
     session_id: &str,
-    app_handle: &tauri::AppHandle,
-    in_flight: &mut HashMap<String, (Instant, String)>,
+    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    in_flight: &mut InFlightToolCalls,
 ) {
-    let content = match value
-        .get("message")
-        .and_then(|m| m.get("content"))
-        .and_then(|c| c.as_array())
-    {
+    let content = match message_content_items(value) {
         Some(arr) => arr,
         None => return,
     };
@@ -222,7 +284,14 @@ fn process_assistant_message(
         let args = summarize_input(item.get("input"));
 
         let now = Instant::now();
-        in_flight.insert(id.clone(), (now, name.clone()));
+        in_flight.insert(
+            id,
+            InFlightToolCall {
+                started_at: now,
+                tool: name.clone(),
+                args: args.clone(),
+            },
+        );
 
         let event = AgentToolCallEvent {
             session_id: session_id.to_string(),
@@ -239,12 +308,31 @@ fn process_assistant_message(
     }
 }
 
+/// Extract tool_result entries from a user message.
+fn process_user_message(
+    value: &Value,
+    session_id: &str,
+    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    in_flight: &mut InFlightToolCalls,
+) {
+    let content = match message_content_items(value) {
+        Some(arr) => arr,
+        None => return,
+    };
+
+    for item in content {
+        if is_tool_result_block(item) {
+            process_tool_result(item, session_id, app_handle, in_flight);
+        }
+    }
+}
+
 /// Process a tool_result line and emit Done/Failed event
 fn process_tool_result(
     value: &Value,
     session_id: &str,
-    app_handle: &tauri::AppHandle,
-    in_flight: &mut HashMap<String, (Instant, String)>,
+    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    in_flight: &mut InFlightToolCalls,
 ) {
     let tool_use_id = match value.get("tool_use_id").and_then(|v| v.as_str()) {
         Some(id) => id.to_string(),
@@ -256,14 +344,14 @@ fn process_tool_result(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    let (duration_ms, tool_name) = match in_flight.remove(&tool_use_id) {
-        Some((start, name)) => {
-            let dur = start.elapsed().as_millis() as u64;
-            (dur, name)
+    let (duration_ms, tool_name, args) = match in_flight.remove(&tool_use_id) {
+        Some(call) => {
+            let dur = call.started_at.elapsed().as_millis() as u64;
+            (dur, call.tool, call.args)
         }
         None => {
             // No matching in-flight call — emit with unknown tool name
-            (0, "unknown".to_string())
+            (0, "unknown".to_string(), String::new())
         }
     };
 
@@ -276,7 +364,7 @@ fn process_tool_result(
     let event = AgentToolCallEvent {
         session_id: session_id.to_string(),
         tool: tool_name,
-        args: String::new(),
+        args,
         status,
         timestamp: now_iso8601(),
         duration_ms,
@@ -285,6 +373,18 @@ fn process_tool_result(
     if let Err(e) = app_handle.emit("agent-tool-call", &event) {
         log::warn!("Failed to emit agent-tool-call event: {}", e);
     }
+}
+
+fn message_content_items(value: &Value) -> Option<&[Value]> {
+    value
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+        .map(Vec::as_slice)
+}
+
+fn is_tool_result_block(value: &Value) -> bool {
+    value.get("type").and_then(|t| t.as_str()) == Some("tool_result")
 }
 
 /// Summarize a tool input Value into a short string (~100 chars max)
@@ -400,6 +500,44 @@ mod tests {
     use super::*;
 
     #[test]
+    fn transcript_state_contains_empty() {
+        let state = TranscriptState::new();
+        assert!(!state.contains("any-session"));
+    }
+
+    #[test]
+    fn transcript_state_replaces_changed_path() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::generate_context!())
+            .expect("failed to build test app");
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let first_path = tmp.path().join("first.jsonl");
+        let second_path = tmp.path().join("second.jsonl");
+        std::fs::write(&first_path, "").expect("failed to write first transcript");
+        std::fs::write(&second_path, "").expect("failed to write second transcript");
+
+        let state = TranscriptState::new();
+        let session_id = "session-1".to_string();
+
+        let first_status = state
+            .start_or_replace(app.handle().clone(), session_id.clone(), first_path.clone())
+            .expect("failed to start first transcript watcher");
+        assert_eq!(first_status, TranscriptStartStatus::Started);
+
+        let duplicate_status = state
+            .start_or_replace(app.handle().clone(), session_id.clone(), first_path)
+            .expect("failed to check duplicate transcript watcher");
+        assert_eq!(duplicate_status, TranscriptStartStatus::AlreadyRunning);
+
+        let replaced_status = state
+            .start_or_replace(app.handle().clone(), session_id.clone(), second_path)
+            .expect("failed to replace transcript watcher");
+        assert_eq!(replaced_status, TranscriptStartStatus::Replaced);
+
+        state.stop(&session_id).expect("failed to stop watcher");
+    }
+
+    #[test]
     fn parse_tool_use_from_assistant_line() {
         let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_abc","name":"Read","input":{"file_path":"/src/foo.ts"}}]}}"#;
         let value: Value = serde_json::from_str(line).unwrap();
@@ -430,6 +568,22 @@ mod tests {
         let value: Value = serde_json::from_str(line).unwrap();
 
         assert!(value["is_error"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn parse_nested_tool_result_from_user_message() {
+        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_abc","content":"file contents...","is_error":false}]}}"#;
+        let value: Value = serde_json::from_str(line).unwrap();
+
+        let content = message_content_items(&value).unwrap();
+        let result = content
+            .iter()
+            .find(|item| is_tool_result_block(item))
+            .unwrap();
+
+        assert_eq!(result["type"].as_str().unwrap(), "tool_result");
+        assert_eq!(result["tool_use_id"].as_str().unwrap(), "toolu_abc");
+        assert!(!result["is_error"].as_bool().unwrap());
     }
 
     #[test]
@@ -551,17 +705,25 @@ mod tests {
     #[test]
     fn in_flight_tracking() {
         // Simulate the in-flight map lifecycle
-        let mut in_flight: HashMap<String, (Instant, String)> = HashMap::new();
+        let mut in_flight: InFlightToolCalls = HashMap::new();
 
         // Tool call starts
         let start = Instant::now();
-        in_flight.insert("toolu_abc".to_string(), (start, "Read".to_string()));
+        in_flight.insert(
+            "toolu_abc".to_string(),
+            InFlightToolCall {
+                started_at: start,
+                tool: "Read".to_string(),
+                args: "/src/foo.ts".to_string(),
+            },
+        );
         assert!(in_flight.contains_key("toolu_abc"));
 
         // Tool result arrives
-        let (start_time, tool_name) = in_flight.remove("toolu_abc").unwrap();
-        let duration = start_time.elapsed().as_millis() as u64;
-        assert_eq!(tool_name, "Read");
+        let call = in_flight.remove("toolu_abc").unwrap();
+        let duration = call.started_at.elapsed().as_millis() as u64;
+        assert_eq!(call.tool, "Read");
+        assert_eq!(call.args, "/src/foo.ts");
         assert!(duration < 1000); // Should be near-instant in test
         assert!(in_flight.is_empty());
     }
@@ -569,17 +731,22 @@ mod tests {
     #[test]
     fn tool_result_without_matching_start() {
         // Should handle gracefully when there's no matching in-flight call
-        let mut in_flight: HashMap<String, (Instant, String)> = HashMap::new();
+        let mut in_flight: InFlightToolCalls = HashMap::new();
 
         let result = in_flight.remove("toolu_nonexistent");
         assert!(result.is_none());
 
         // The process_tool_result function handles this with defaults
-        let (duration_ms, tool_name) = match result {
-            Some((start, name)) => (start.elapsed().as_millis() as u64, name),
-            None => (0, "unknown".to_string()),
+        let (duration_ms, tool_name, args) = match result {
+            Some(call) => (
+                call.started_at.elapsed().as_millis() as u64,
+                call.tool,
+                call.args,
+            ),
+            None => (0, "unknown".to_string(), String::new()),
         };
         assert_eq!(duration_ms, 0);
         assert_eq!(tool_name, "unknown");
+        assert!(args.is_empty());
     }
 }

--- a/src-tauri/src/agent/transcript.rs
+++ b/src-tauri/src/agent/transcript.rs
@@ -4,7 +4,7 @@
 //! Emits `agent-tool-call` Tauri events for each tool call start and completion.
 
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -21,6 +21,35 @@ const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Maximum length for the args summary string
 const MAX_ARGS_LEN: usize = 100;
+
+pub(crate) fn validate_transcript_path(transcript_path: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(transcript_path);
+    let canonical = fs::canonicalize(&path)
+        .map_err(|e| format!("invalid transcript path '{}': {}", transcript_path, e))?;
+
+    if !canonical.is_file() {
+        return Err(format!("not a transcript file: {}", canonical.display()));
+    }
+
+    let home = dirs::home_dir().ok_or_else(|| "cannot determine home directory".to_string())?;
+    let claude_root = home.join(".claude");
+    let claude_root = fs::canonicalize(&claude_root).map_err(|e| {
+        format!(
+            "cannot resolve Claude transcript root '{}': {}",
+            claude_root.display(),
+            e
+        )
+    })?;
+
+    if !canonical.starts_with(&claude_root) {
+        return Err(format!(
+            "access denied: transcript path is outside Claude directory: {}",
+            canonical.display()
+        ));
+    }
+
+    Ok(canonical)
+}
 
 struct InFlightToolCall {
     started_at: Instant,
@@ -58,6 +87,12 @@ impl TranscriptHandle {
     }
 }
 
+impl Drop for TranscriptHandle {
+    fn drop(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+    }
+}
+
 /// State shared across transcript watchers, keyed by session ID
 #[derive(Default, Clone)]
 pub struct TranscriptState {
@@ -91,31 +126,61 @@ impl TranscriptState {
         session_id: String,
         transcript_path: PathBuf,
     ) -> Result<TranscriptStartStatus, String> {
-        let (old_handle, status) = {
-            let mut watchers = self.watchers.lock().expect("failed to lock watchers");
-
+        {
+            let watchers = self.watchers.lock().expect("failed to lock watchers");
             if let Some(current) = watchers.get(&session_id) {
                 if current.transcript_path == transcript_path {
                     return Ok(TranscriptStartStatus::AlreadyRunning);
                 }
             }
+        }
 
-            let handle = start_tailing(app_handle, session_id.clone(), transcript_path.clone())?;
-            let old = watchers.insert(
-                session_id,
-                TranscriptWatcher {
-                    transcript_path,
-                    handle,
-                },
-            );
-            let status = if old.is_some() {
-                TranscriptStartStatus::Replaced
+        let mut new_handle = Some(start_tailing(
+            app_handle,
+            session_id.clone(),
+            transcript_path.clone(),
+        )?);
+
+        let (old_handle, status) = {
+            let mut watchers = self.watchers.lock().expect("failed to lock watchers");
+
+            if let Some(current) = watchers.get(&session_id) {
+                if current.transcript_path == transcript_path {
+                    (None, TranscriptStartStatus::AlreadyRunning)
+                } else {
+                    let old = watchers.insert(
+                        session_id,
+                        TranscriptWatcher {
+                            transcript_path,
+                            handle: new_handle
+                                .take()
+                                .expect("new transcript handle should be available"),
+                        },
+                    );
+
+                    (
+                        old.map(|watcher| watcher.handle),
+                        TranscriptStartStatus::Replaced,
+                    )
+                }
             } else {
-                TranscriptStartStatus::Started
-            };
+                watchers.insert(
+                    session_id,
+                    TranscriptWatcher {
+                        transcript_path,
+                        handle: new_handle
+                            .take()
+                            .expect("new transcript handle should be available"),
+                    },
+                );
 
-            (old.map(|watcher| watcher.handle), status)
+                (None, TranscriptStartStatus::Started)
+            }
         };
+
+        if let Some(handle) = new_handle {
+            handle.stop();
+        }
 
         if let Some(handle) = old_handle {
             handle.stop();
@@ -479,10 +544,7 @@ pub async fn start_transcript_watcher(
     session_id: String,
     transcript_path: String,
 ) -> Result<(), String> {
-    let path = PathBuf::from(&transcript_path);
-    if !path.exists() {
-        return Err(format!("Transcript file not found: {}", transcript_path));
-    }
+    let path = validate_transcript_path(&transcript_path)?;
     state.start(app_handle, session_id, path)
 }
 
@@ -535,6 +597,35 @@ mod tests {
         assert_eq!(replaced_status, TranscriptStartStatus::Replaced);
 
         state.stop(&session_id).expect("failed to stop watcher");
+    }
+
+    #[test]
+    fn transcript_handle_drop_sets_stop_flag() {
+        let stop_flag = Arc::new(AtomicBool::new(false));
+
+        {
+            let _handle = TranscriptHandle {
+                stop_flag: Arc::clone(&stop_flag),
+                join_handle: None,
+            };
+        }
+
+        assert!(stop_flag.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn validate_transcript_path_rejects_path_outside_claude_root() {
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let transcript_path = tmp.path().join("transcript.jsonl");
+        std::fs::write(&transcript_path, "").expect("failed to write transcript");
+
+        let result = validate_transcript_path(
+            transcript_path
+                .to_str()
+                .expect("temp transcript path should be UTF-8"),
+        );
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -14,7 +14,7 @@ use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use tauri::{Emitter, Manager};
 
 use super::statusline::parse_statusline;
-use super::transcript::{TranscriptStartStatus, TranscriptState};
+use super::transcript::{validate_transcript_path, TranscriptStartStatus, TranscriptState};
 
 /// Handle to a running watcher — dropping it stops the watcher and polling thread
 pub struct WatcherHandle {
@@ -65,24 +65,36 @@ impl AgentWatcherState {
 
 /// Try to start transcript tailing, switching files if Claude reports a new path.
 fn maybe_start_transcript(app_handle: &tauri::AppHandle, session_id: &str, transcript_path: &str) {
+    let transcript_path = match validate_transcript_path(transcript_path) {
+        Ok(path) => path,
+        Err(e) => {
+            log::warn!(
+                "Skipping transcript tailing for session {}: {}",
+                session_id,
+                e
+            );
+            return;
+        }
+    };
+
     let ts = app_handle.state::<TranscriptState>();
     match ts.start_or_replace(
         app_handle.clone(),
         session_id.to_string(),
-        PathBuf::from(transcript_path),
+        transcript_path.clone(),
     ) {
         Ok(TranscriptStartStatus::Started) => {
             log::info!(
                 "Started transcript tailing for session {}: {}",
                 session_id,
-                transcript_path
+                transcript_path.display()
             );
         }
         Ok(TranscriptStartStatus::Replaced) => {
             log::info!(
                 "Switched transcript tailing for session {}: {}",
                 session_id,
-                transcript_path
+                transcript_path.display()
             );
         }
         Ok(TranscriptStartStatus::AlreadyRunning) => {}

--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -11,9 +11,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 
 use super::statusline::parse_statusline;
+use super::transcript::{TranscriptStartStatus, TranscriptState};
 
 /// Handle to a running watcher — dropping it stops the watcher and polling thread
 pub struct WatcherHandle {
@@ -59,6 +60,39 @@ impl AgentWatcherState {
     pub fn contains(&self, session_id: &str) -> bool {
         let watchers = self.watchers.lock().expect("failed to lock watchers");
         watchers.contains_key(session_id)
+    }
+}
+
+/// Try to start transcript tailing, switching files if Claude reports a new path.
+fn maybe_start_transcript(app_handle: &tauri::AppHandle, session_id: &str, transcript_path: &str) {
+    let ts = app_handle.state::<TranscriptState>();
+    match ts.start_or_replace(
+        app_handle.clone(),
+        session_id.to_string(),
+        PathBuf::from(transcript_path),
+    ) {
+        Ok(TranscriptStartStatus::Started) => {
+            log::info!(
+                "Started transcript tailing for session {}: {}",
+                session_id,
+                transcript_path
+            );
+        }
+        Ok(TranscriptStartStatus::Replaced) => {
+            log::info!(
+                "Switched transcript tailing for session {}: {}",
+                session_id,
+                transcript_path
+            );
+        }
+        Ok(TranscriptStartStatus::AlreadyRunning) => {}
+        Err(e) => {
+            log::warn!(
+                "Failed to start transcript tailing for session {}: {}",
+                session_id,
+                e
+            );
+        }
     }
 }
 
@@ -136,6 +170,7 @@ pub fn start_watching(
 
                 if let Some(ref path) = parsed.transcript_path {
                     log::debug!("Transcript path for session {}: {}", sid, path);
+                    maybe_start_transcript(&app_handle, &sid, path);
                 }
             }
             Err(e) => {
@@ -169,6 +204,9 @@ pub fn start_watching(
             if !contents.trim().is_empty() {
                 if let Ok(parsed) = parse_statusline(&initial_sid, &contents) {
                     let _ = initial_app.emit("agent-status", &parsed.event);
+                    if let Some(ref path) = parsed.transcript_path {
+                        maybe_start_transcript(&initial_app, &initial_sid, path);
+                    }
                 }
             }
         }
@@ -205,6 +243,9 @@ pub fn start_watching(
 
                 if let Ok(parsed) = parse_statusline(&poll_sid, &contents) {
                     let _ = poll_app.emit("agent-status", &parsed.event);
+                    if let Some(ref path) = parsed.transcript_path {
+                        maybe_start_transcript(&poll_app, &poll_sid, path);
+                    }
                 }
             }
         });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ mod git;
 mod terminal;
 
 use agent::{
-    detect_agent_in_session, start_agent_watcher, stop_agent_watcher, start_transcript_watcher,
+    detect_agent_in_session, start_agent_watcher, start_transcript_watcher, stop_agent_watcher,
     stop_transcript_watcher, AgentWatcherState, TranscriptState,
 };
 use filesystem::{list_dir, read_file, write_file};

--- a/src-tauri/src/terminal/bridge.rs
+++ b/src-tauri/src/terminal/bridge.rs
@@ -36,7 +36,10 @@ pub struct BridgeFiles {
 /// # Returns
 /// * `Ok(BridgeFiles)` with paths to generated files
 /// * `Err(String)` if directory creation or file writing fails
-pub fn generate_bridge_files(agent_status_dir: &str, session_id: &str) -> Result<BridgeFiles, String> {
+pub fn generate_bridge_files(
+    agent_status_dir: &str,
+    session_id: &str,
+) -> Result<BridgeFiles, String> {
     let dir = Path::new(agent_status_dir);
 
     // Create the session directory
@@ -121,8 +124,7 @@ pub fn generate_bridge_files(agent_status_dir: &str, session_id: &str) -> Result
 pub fn cleanup_bridge_files(agent_status_dir: &str) -> Result<(), String> {
     let dir = Path::new(agent_status_dir);
     if dir.exists() {
-        fs::remove_dir_all(dir)
-            .map_err(|e| format!("failed to clean up bridge files: {}", e))?;
+        fs::remove_dir_all(dir).map_err(|e| format!("failed to clean up bridge files: {}", e))?;
         log::info!("Cleaned up bridge files: {}", dir.display());
     }
     Ok(())
@@ -149,7 +151,10 @@ mod tests {
         #[cfg(unix)]
         {
             let meta = fs::metadata(&files.script_path).unwrap();
-            assert!(meta.permissions().mode() & 0o111 != 0, "script should be executable");
+            assert!(
+                meta.permissions().mode() & 0o111 != 0,
+                "script should be executable"
+            );
         }
 
         // Script content should reference env var for status file
@@ -190,6 +195,9 @@ mod tests {
     #[test]
     fn cleanup_handles_missing_directory() {
         let result = cleanup_bridge_files("/tmp/nonexistent-vimeflow-dir-12345");
-        assert!(result.is_ok(), "cleanup should succeed for missing directory");
+        assert!(
+            result.is_ok(),
+            "cleanup should succeed for missing directory"
+        );
     }
 }

--- a/src-tauri/src/terminal/commands.rs
+++ b/src-tauri/src/terminal/commands.rs
@@ -118,10 +118,7 @@ pub async fn spawn_pty<R: tauri::Runtime>(
             .join(".vimeflow")
             .join("sessions")
             .join(&request.session_id);
-        match super::bridge::generate_bridge_files(
-            &dir.to_string_lossy(),
-            &request.session_id,
-        ) {
+        match super::bridge::generate_bridge_files(&dir.to_string_lossy(), &request.session_id) {
             Ok(files) => {
                 debug_log(
                     "bridge",
@@ -162,14 +159,8 @@ pub async fn spawn_pty<R: tauri::Runtime>(
         // and $VIMEFLOW_CLAUDE_SETTINGS instead of embedding paths directly,
         // which avoids injection from paths containing quotes or metacharacters.
         cmd.env("BASH_ENV", files.shell_init_path.as_os_str());
-        cmd.env(
-            "VIMEFLOW_CLAUDE_SETTINGS",
-            files.settings_path.as_os_str(),
-        );
-        cmd.env(
-            "VIMEFLOW_STATUS_FILE",
-            files.status_file_path.as_os_str(),
-        );
+        cmd.env("VIMEFLOW_CLAUDE_SETTINGS", files.settings_path.as_os_str());
+        cmd.env("VIMEFLOW_STATUS_FILE", files.status_file_path.as_os_str());
 
         // For interactive bash, generate a combined rcfile that sources
         // both ~/.bashrc (user config) and our init script
@@ -188,10 +179,7 @@ pub async fn spawn_pty<R: tauri::Runtime>(
             cmd.args(["--rcfile", &rcfile_path.to_string_lossy()]);
         }
 
-        log::info!(
-            "Injected claude wrapper for session {}",
-            request.session_id
-        );
+        log::info!("Injected claude wrapper for session {}", request.session_id);
     }
 
     if request.env.is_some() {


### PR DESCRIPTION
## Summary

Connects the statusline watcher to the transcript JSONL parser so tool calls appear in the agent status sidebar in real-time. Closes #56.

- Watcher auto-starts transcript tailing when statusline reports `transcript_path`
- `TranscriptState` tracks active path per session — replaces watcher when Claude Code switches transcript files mid-session
- `TranscriptHandle` Drop impl sets stop flag for clean thread shutdown
- 2 new Rust tests for path replacement state machine

## Test plan

- [x] `cargo test` — 108 Rust tests pass
- [x] `npm run test` — 1399 frontend tests pass
- [x] `npm run type-check` — clean
- [x] `npm run lint` — 0 errors
- [ ] Manual: launch `claude` in Vimeflow → ask it to read a file → tool call appears in sidebar