### PR TITLE
fix(scripts): disable WebKitGTK DMA-BUF renderer in tauri:dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ This file covers what you need to start working. For deeper topics, read the lin
 | Codex feedback loop design spec                          | `docs/superpowers/specs/2026-04-03-codex-feedback-loop-design.md` |
 | Progress tracking (roadmap status)                       | `docs/roadmap/progress.yaml`                                      |
 | Shell OSC 7 setup (file explorer cwd sync)               | `README.md` → "Shell Setup (OSC 7)"                               |
+| Linux/Wayland WebKitGTK renderer flag (tauri:dev)        | `README.md` → "Linux / Wayland: WebKitGTK Renderer"               |
 | Review knowledge base (patterns from past reviews)       | `docs/reviews/CLAUDE.md`                                          |
 
 ## Harness Plugin Setup

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ Or add manually to `~/.bashrc`:
 PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}"'printf "\e]7;file://%s%s\a" "$HOSTNAME" "$PWD"'
 ```
 
+### Linux / Wayland: WebKitGTK Renderer
+
+The `tauri:dev` script sets `WEBKIT_DISABLE_DMABUF_RENDERER=1`. WebKitGTK's DMA-BUF renderer crashes on many Wayland compositor + driver combos with `Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display`. Disabling DMA-BUF falls back to a renderer that works reliably across setups.
+
+The variable is harmless on macOS (no WebKitGTK) but the inline shell syntax does not work on Windows `cmd.exe`. If Windows support is needed, swap in [`cross-env`](https://www.npmjs.com/package/cross-env).
+
 ## Repository Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "tauri:dev": "tauri dev",
+    "tauri:dev": "WEBKIT_DISABLE_DMABUF_RENDERER=1 tauri dev",
     "tauri:build": "tauri build",
     "prepare": "husky",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary

- `npm run tauri:dev` now sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` automatically, fixing `Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display` crashes on Linux/Wayland setups where WebKitGTK's DMA-BUF renderer trips on the compositor + driver combo.
- Added a "Linux / Wayland: WebKitGTK Renderer" subsection to `README.md` explaining the flag, plus a one-line index entry in `CLAUDE.md` so the finding is discoverable.
- Documented the Windows caveat: the env var itself is harmless on macOS/Windows (no WebKitGTK), but the inline POSIX shell syntax (`VAR=value cmd`) breaks on `cmd.exe`. If/when Windows support is needed, swap to [`cross-env`](https://www.npmjs.com/package/cross-env).

## Test plan

- [x] Verified `WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri:dev` launches the Tauri window successfully on Nobara/Fedora 43 (Wayland) — confirmed manually before this PR
- [x] Pre-push hook ran full Vitest suite: 1399 passed, 3 skipped
- [ ] (macOS) `npm run tauri:dev` still launches normally — env var should be a no-op
- [ ] (Windows, if attempted) Expect failure on `cmd.exe`; resolution is to swap in `cross-env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)