### PR TITLE
feat(review): pair IDEA analysis with each finding

### DIFF
--- a/.github/codex/codex-output-schema.json
+++ b/.github/codex/codex-output-schema.json
@@ -48,6 +48,30 @@
               }
             },
             "required": ["absolute_file_path", "line_range"]
+          },
+          "idea": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "IDEA analysis scoped to THIS finding (not the whole PR).",
+            "properties": {
+              "intent": {
+                "type": "string",
+                "description": "What was the author trying to do at this spot, and does the code match that intent?"
+              },
+              "danger": {
+                "type": "string",
+                "description": "What breaks if this ships? Edge cases, security, bad data, UX — specific to this finding."
+              },
+              "explain": {
+                "type": "string",
+                "description": "Why did the author likely write it this way? Trade-offs or reasoning behind this code."
+              },
+              "alternatives": {
+                "type": "string",
+                "description": "Is there a simpler/safer approach for this specific issue? Would a senior dev push back?"
+              }
+            },
+            "required": ["intent", "danger", "explain", "alternatives"]
           }
         },
         "required": [
@@ -55,32 +79,10 @@
           "body",
           "severity",
           "confidence_score",
-          "code_location"
+          "code_location",
+          "idea"
         ]
       }
-    },
-    "idea": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "intent": {
-          "type": "string",
-          "description": "Does the PR solve the real problem, not just the literal one?"
-        },
-        "danger": {
-          "type": "string",
-          "description": "What breaks? Edge cases, security, bad data?"
-        },
-        "explain": {
-          "type": "string",
-          "description": "Why this approach? What reasoning led here?"
-        },
-        "alternatives": {
-          "type": "string",
-          "description": "Is there a simpler way? Would a senior dev raise an eyebrow?"
-        }
-      },
-      "required": ["intent", "danger", "explain", "alternatives"]
     },
     "overall_correctness": {
       "type": "string",
@@ -97,7 +99,6 @@
   },
   "required": [
     "findings",
-    "idea",
     "overall_correctness",
     "overall_explanation",
     "overall_confidence_score"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,7 +55,7 @@ jobs:
             - For each finding, specify the EXACT file path and narrowest possible line range (start-end). Read the actual lines and pinpoint where the issue is. Never use L1-1 as a placeholder.
             - When reporting control flow bugs (loops, branches, error handling), trace ALL code paths through the construct and report the complete issue in ONE finding. Do not split related paths across multiple findings.
             - Report ALL issues you find in this single review. Assume this is your ONLY chance to review — do not hold back findings for later rounds.
-            - For each finding, explain: (1) what the current code does wrong, (2) the concrete impact, and (3) what the fix should be.
+            - Keep the finding body tight: state what's wrong, the concrete impact, and the fix in a few sentences. Save deeper reasoning (intent, why-this-approach, alternatives) for the paired IDEA block — do not repeat it in the body.
             - If a bug class appears in multiple places (e.g. missing error handling in both skip_review and review paths), report them together in one finding rather than separately.
 
             SCOPE BOUNDARY RULE (MANDATORY):
@@ -70,12 +70,13 @@ jobs:
             Apply confidence-based filtering: only report issues you are >80% confident about.
             Use severity levels: CRITICAL, HIGH, MEDIUM, LOW.
 
-            IDEA ANALYSIS (MANDATORY):
-            Include an "idea" object in your JSON output with these four fields:
-            - intent: Does the PR solve the real problem, not just the literal one?
-            - danger: What breaks? Edge cases, security, bad data?
-            - explain: Why this approach? What reasoning led here?
-            - alternatives: Is there a simpler way? Would a senior dev raise an eyebrow?
+            IDEA ANALYSIS (MANDATORY — per finding):
+            Pair EVERY finding with its own "idea" object. The IDEA block is what makes the finding understandable — the body above should be terse, the IDEA below carries the reasoning.
+            - intent: What was the author trying to do at this specific spot, and does the code match that intent?
+            - danger: What breaks or degrades if this ships — edge cases, security, bad data, UX — scoped to THIS finding?
+            - explain: Why did the author likely write it this way? Trade-offs or reasoning behind this particular code.
+            - alternatives: Is there a simpler/safer approach for this specific issue? Would a senior dev push back?
+            Every IDEA field must be about THIS finding, not the whole PR. Do not produce a PR-level IDEA block.
 
             Return your review as structured JSON matching the provided schema. Do not post any comments directly — the workflow will format and post the findings.
 
@@ -119,27 +120,23 @@ jobs:
                   lines.push(`🎯 Confidence: ${(f.confidence_score * 100).toFixed(0)}%`)
                   lines.push('')
                   lines.push(f.body)
+                  if (f.idea) {
+                    lines.push('')
+                    lines.push('<details><summary>💡 IDEA</summary>')
+                    lines.push('')
+                    lines.push(`- **I — Intent:** ${f.idea.intent}`)
+                    lines.push(`- **D — Danger:** ${f.idea.danger}`)
+                    lines.push(`- **E — Explain:** ${f.idea.explain}`)
+                    lines.push(`- **A — Alternatives:** ${f.idea.alternatives}`)
+                    lines.push('')
+                    lines.push('</details>')
+                  }
                   lines.push('')
                   lines.push('---')
                   lines.push('')
                 }
               } else {
                 lines.push('✅ No issues found.')
-                lines.push('')
-              }
-
-              if (review.idea) {
-                lines.push('### 💡 IDEA Analysis')
-                lines.push('')
-                lines.push(`**I — Intent:** ${review.idea.intent}`)
-                lines.push('')
-                lines.push(`**D — Danger:** ${review.idea.danger}`)
-                lines.push('')
-                lines.push(`**E — Explain:** ${review.idea.explain}`)
-                lines.push('')
-                lines.push(`**A — Alternatives:** ${review.idea.alternatives}`)
-                lines.push('')
-                lines.push('---')
                 lines.push('')
               }
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -46,7 +46,7 @@ jobs:
             - For each finding, specify the EXACT file path and narrowest possible line range (start-end). Read the actual lines and pinpoint where the issue is. Never use L1-1 as a placeholder.
             - When reporting control flow bugs (loops, branches, error handling), trace ALL code paths through the construct and report the complete issue in ONE finding. Do not split related paths across multiple findings.
             - Report ALL issues you find in this single review. Assume this is your ONLY chance to review — do not hold back findings for later rounds.
-            - For each finding, explain: (1) what the current code does wrong, (2) the concrete impact, and (3) what the fix should be.
+            - Keep the finding body tight: state what's wrong, the concrete impact, and the fix in a few sentences. Save deeper reasoning (intent, why-this-approach, alternatives) for the paired IDEA block — do not repeat it in the body.
             - If a bug class appears in multiple places (e.g. missing error handling in both skip_review and review paths), report them together in one finding rather than separately.
 
             SCOPE BOUNDARY RULE (MANDATORY):
@@ -61,12 +61,13 @@ jobs:
             Apply confidence-based filtering: only report issues you are >80% confident about.
             Use severity levels: CRITICAL, HIGH, MEDIUM, LOW.
 
-            IDEA ANALYSIS (MANDATORY):
-            Include an "idea" object in your JSON output with these four fields:
-            - intent: Does the PR solve the real problem, not just the literal one?
-            - danger: What breaks? Edge cases, security, bad data?
-            - explain: Why this approach? What reasoning led here?
-            - alternatives: Is there a simpler way? Would a senior dev raise an eyebrow?
+            IDEA ANALYSIS (MANDATORY — per finding):
+            Pair EVERY finding with its own "idea" object. The IDEA block is what makes the finding understandable — the body above should be terse, the IDEA below carries the reasoning.
+            - intent: What was the author trying to do at this specific spot, and does the code match that intent?
+            - danger: What breaks or degrades if this ships — edge cases, security, bad data, UX — scoped to THIS finding?
+            - explain: Why did the author likely write it this way? Trade-offs or reasoning behind this particular code.
+            - alternatives: Is there a simpler/safer approach for this specific issue? Would a senior dev push back?
+            Every IDEA field must be about THIS finding, not the whole PR. Do not produce a PR-level IDEA block.
 
             Pull request title and body:
             ----
@@ -110,27 +111,23 @@ jobs:
                   lines.push(`🎯 Confidence: ${(f.confidence_score * 100).toFixed(0)}%`);
                   lines.push('');
                   lines.push(f.body);
+                  if (f.idea) {
+                    lines.push('');
+                    lines.push('<details><summary>💡 IDEA</summary>');
+                    lines.push('');
+                    lines.push(`- **I — Intent:** ${f.idea.intent}`);
+                    lines.push(`- **D — Danger:** ${f.idea.danger}`);
+                    lines.push(`- **E — Explain:** ${f.idea.explain}`);
+                    lines.push(`- **A — Alternatives:** ${f.idea.alternatives}`);
+                    lines.push('');
+                    lines.push('</details>');
+                  }
                   lines.push('');
                   lines.push('---');
                   lines.push('');
                 }
               } else {
                 lines.push('✅ No issues found.');
-                lines.push('');
-              }
-
-              if (review.idea) {
-                lines.push('### 💡 IDEA Analysis');
-                lines.push('');
-                lines.push(`**I — Intent:** ${review.idea.intent}`);
-                lines.push('');
-                lines.push(`**D — Danger:** ${review.idea.danger}`);
-                lines.push('');
-                lines.push(`**E — Explain:** ${review.idea.explain}`);
-                lines.push('');
-                lines.push(`**A — Alternatives:** ${review.idea.alternatives}`);
-                lines.push('');
-                lines.push('---');
                 lines.push('');
               }
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -204,16 +204,22 @@ const usersWithPosts = await db.query(`
 
 ## Review Output Format
 
-Organize findings by severity. For each issue:
+Organize findings by severity. Keep the body tight — state what's wrong, the concrete impact, and the fix in a few sentences. The paired IDEA block (below) carries the deeper reasoning, so do not repeat intent/alternatives/trade-offs in the body.
 
 ```
 [CRITICAL] Hardcoded API key in source
 File: src/api/client.ts:42
-Issue: API key "sk-abc..." exposed in source code. This will be committed to git history.
-Fix: Move to environment variable and add to .gitignore/.env.example
+Issue: API key "sk-abc..." is committed to source and will land in git history.
+Fix: Read it from process.env.API_KEY; add API_KEY to .env.example.
 
   const apiKey = "sk-abc123";           // BAD
   const apiKey = process.env.API_KEY;   // GOOD
+
+💡 IDEA
+- I — Intent: Author wanted a quick working client; hardcoding bypassed config wiring.
+- D — Danger: Key is now exposed in git history + any fork/clone; rotation is forced.
+- E — Explain: Likely a debugging shortcut that wasn't reverted before commit.
+- A — Alternatives: Use process.env with a validated config loader; fail fast on missing keys.
 ```
 
 ### Summary Format
@@ -233,23 +239,31 @@ End every review with:
 Verdict: WARNING — 2 HIGH issues should be resolved before merge.
 ```
 
-## IDEA Analysis (MANDATORY)
+## IDEA Analysis (MANDATORY — per finding)
 
-Every review must include an IDEA section after the findings summary. This helps the PR author understand the review holistically, not just as a list of issues.
+Pair **every finding** with its own IDEA block. IDEA is not a global summary anymore; it lives directly under each finding so the reader gets reasoning paired with the code location. Because IDEA carries the "why," the finding body above it can stay short.
 
-- **I — Intent**: Does the PR solve the real problem, not just the literal one? Is the goal clear from the diff, or is there a mismatch between what was asked and what was built?
-- **D — Danger**: What breaks? Edge cases, security implications, bad data paths. Focus on risks _introduced by this diff_, not pre-existing ones.
-- **E — Explain**: Can you explain why this approach was chosen? What trade-offs did the author make? If the reasoning isn't obvious from the code, call that out.
-- **A — Alternatives**: Is there a simpler way? Would a senior dev raise an eyebrow at this approach? Suggest alternatives only if they're meaningfully better — not just different.
+Scope each field to **this specific finding**, not the whole PR:
+
+- **I — Intent**: What was the author trying to do at this spot, and does the code match that intent?
+- **D — Danger**: What breaks or degrades if this ships — edge cases, security, bad data, UX — specifically because of this issue?
+- **E — Explain**: Why did the author likely write it this way? Trade-offs or reasoning behind this particular code.
+- **A — Alternatives**: Is there a simpler/safer approach for this specific issue? Would a senior dev push back? Only suggest alternatives when meaningfully better.
 
 ```
-## 💡 IDEA Analysis
+### [SEVERITY] Finding title
+📍 path/to/file.ts L12-18
 
-**I — Intent:** [Does this solve the real problem?]
-**D — Danger:** [What could break?]
-**E — Explain:** [Why this approach?]
-**A — Alternatives:** [Simpler options?]
+Short body: what's wrong, impact, fix. A few sentences max.
+
+💡 IDEA
+- I — Intent: ...
+- D — Danger: ...
+- E — Explain: ...
+- A — Alternatives: ...
 ```
+
+Do **not** produce a PR-level IDEA block at the end of the review.
 
 ## Approval Criteria
 


### PR DESCRIPTION
## Summary

- Move the IDEA block from a single PR-level section to **per-finding**, so every bug/finding in Codex and Claude PR reviews carries its own Intent / Danger / Explain / Alternatives — scoped to that specific issue, not the whole PR.
- Shorten the finding body since the paired IDEA now carries the reasoning; the body states what's wrong, the concrete impact, and the fix in a few sentences.
- Render IDEA as a collapsible `<details><summary>💡 IDEA</summary>` block under each finding so comments stay scannable.

## What changed

- **`.github/codex/codex-output-schema.json`** — `idea` moved into each finding (required); top-level `idea` removed.
- **`.github/workflows/codex-review.yml`** + **`.github/workflows/claude-review.yml`** — prompt asks for per-finding IDEA + tight body; renderer emits per-finding IDEA block; global IDEA section removed.
- **`agents/code-reviewer.md`** — IDEA section rewritten as per-finding; output-format example shortened to show a short body paired with IDEA bullets.

## Test plan

- [ ] Open this PR and confirm Codex review comment renders a collapsible 💡 IDEA block under each finding.
- [ ] Same for the Claude review comment.
- [ ] Confirm no PR-level IDEA block appears at the bottom of either review.
- [ ] Spot-check: finding bodies are noticeably shorter than on prior PRs (reasoning lives in IDEA now).
- [ ] If Codex emits malformed JSON, the renderer's `catch` still posts the raw text fallback — verify this path isn't triggered on a clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)