### PR TITLE
test: smoke-test per-finding IDEA review rendering

### DIFF
--- a/src/lib/formatBytes.test.ts
+++ b/src/lib/formatBytes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+import { formatBytes } from './formatBytes'
+
+describe('formatBytes', () => {
+  test('formats zero bytes', () => {
+    expect(formatBytes(0)).toBe('0 B')
+  })
+
+  test('formats bytes below 1 KB', () => {
+    expect(formatBytes(512)).toBe('512.00 B')
+  })
+
+  test('formats kilobytes', () => {
+    expect(formatBytes(1536)).toBe('1.50 KB')
+  })
+
+  test('formats exact megabyte', () => {
+    expect(formatBytes(1_048_576)).toBe('1.00 MB')
+  })
+
+  test('respects decimals parameter', () => {
+    expect(formatBytes(1_234_567, 0)).toBe('1 MB')
+    expect(formatBytes(1_234_567, 3)).toBe('1.177 MB')
+  })
+})

--- a/src/lib/formatBytes.ts
+++ b/src/lib/formatBytes.ts
@@ -1,0 +1,17 @@
+/**
+ * Format a byte count as a human-readable string (e.g. "1.50 MB").
+ *
+ * @param bytes - the byte count to format
+ * @param decimals - number of decimal places to include (default 2)
+ * @returns formatted string with unit suffix
+ */
+export const formatBytes = (bytes: number, decimals = 2): string => {
+  if (bytes === 0) {
+    return '0 B'
+  }
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+  const i = Math.floor(Math.log(bytes) / Math.log(1024))
+  const value = bytes / Math.pow(1024, i)
+
+  return `${value.toFixed(decimals)} ${units[i]}`
+}


### PR DESCRIPTION
## Summary

Dummy PR to verify the new per-finding IDEA rendering landed in #78 actually works end-to-end with Codex and Claude reviewers.

Adds a small `formatBytes` utility under `src/lib/` with co-located tests. The implementation is intentionally left with a few real quality gaps (unguarded negative input, no bound check when the byte count exceeds PB, `decimals` can be negative and throw) so the reviewers have something to flag — which is exactly what we need to see the IDEA block render under each finding.

## What to look for in the review comments

- [ ] Each finding shows its own collapsible `💡 IDEA` `<details>` block directly under the body.
- [ ] IDEA fields (I / D / E / A) are scoped to that specific finding, not the whole PR.
- [ ] No standalone "IDEA Analysis" section at the bottom of the comment.
- [ ] Finding bodies are noticeably shorter than past reviews — the reasoning lives in IDEA now.
- [ ] Codex and Claude both render symmetrically (same schema, near-identical renderer).

If the rendering looks right, this PR can be closed without merging — it exists only as a review-system smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)