### PR TITLE
fix(terminal): guard fit() against zero-width containers to prevent scrollback re-wrapping

### DIFF
--- a/src/features/terminal/components/TerminalPane.test.tsx
+++ b/src/features/terminal/components/TerminalPane.test.tsx
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
-import { TerminalPane, clearTerminalCache } from './TerminalPane'
+import { TerminalPane, clearTerminalCache, terminalCache } from './TerminalPane'
 import { useTerminal, type UseTerminalReturn } from '../hooks/useTerminal'
 
 // Mock xterm modules
@@ -372,6 +372,41 @@ describe('TerminalPane', () => {
 
       // fitAddon SHOULD fire now that the container has real dimensions
       expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+    })
+
+    test('regression #81: cached terminal reuse skips fit in zero-width container', async () => {
+      // Seed the module-level cache to force the reuse branch
+      const cachedFitAddon = { fit: vi.fn() }
+
+      const cachedTerminal = {
+        open: vi.fn(),
+        cols: 80,
+        rows: 24,
+        onResize: vi.fn(() => ({ dispose: vi.fn() })),
+        parser: { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) },
+      }
+
+      terminalCache.set('cached-session', {
+        terminal: cachedTerminal as unknown as Terminal,
+        fitAddon: cachedFitAddon as unknown as FitAddon,
+      })
+
+      // Simulate hidden container (display:none → offsetWidth = 0)
+      const offsetSpy = vi
+        .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockReturnValue(0)
+
+      render(<TerminalPane sessionId="cached-session" cwd="/home/user" />)
+
+      await waitFor(() => {
+        expect(cachedTerminal.open).toHaveBeenCalled()
+      })
+
+      // fitAddon.fit must be suppressed on the reuse path when width is 0
+      expect(cachedFitAddon.fit).not.toHaveBeenCalled()
+
+      offsetSpy.mockRestore()
+      terminalCache.delete('cached-session')
     })
 
     test('regression #81: onResize does not forward tiny dimensions to PTY when container is hidden', async () => {

--- a/src/features/terminal/components/TerminalPane.test.tsx
+++ b/src/features/terminal/components/TerminalPane.test.tsx
@@ -284,6 +284,12 @@ describe('TerminalPane', () => {
       // Simulate container resize
       const container = screen.getByTestId('terminal-pane')
 
+      // Give container a real width so the guard passes
+      Object.defineProperty(container, 'offsetWidth', {
+        value: 800,
+        configurable: true,
+      })
+
       const mockEntry = {
         target: container,
         contentRect: {
@@ -310,6 +316,103 @@ describe('TerminalPane', () => {
       await waitFor(() => {
         expect(mockFitAddon.fit).toHaveBeenCalled()
       })
+    })
+
+    test('regression #81: ResizeObserver skips fit when container is hidden (width=0)', async () => {
+      let resizeCallback: ResizeObserverCallback | undefined
+      const mockObserve = vi.fn()
+      const mockDisconnect = vi.fn()
+
+      global.ResizeObserver = vi
+        .fn()
+        .mockImplementation((callback: ResizeObserverCallback) => {
+          resizeCallback = callback
+
+          return {
+            observe: mockObserve,
+            unobserve: vi.fn(),
+            disconnect: mockDisconnect,
+          }
+        })
+
+      render(<TerminalPane sessionId="test-session" cwd="/home/user" />)
+
+      await waitFor(() => {
+        expect(global.ResizeObserver).toHaveBeenCalled()
+        expect(mockObserve).toHaveBeenCalled()
+      })
+
+      // Clear fit calls from initial render
+      mockFitAddon.fit.mockClear()
+
+      const container = screen.getByTestId('terminal-pane')
+
+      // Simulate hidden tab: offsetWidth === 0 (display:none collapses container)
+      Object.defineProperty(container, 'offsetWidth', {
+        value: 0,
+        configurable: true,
+      })
+
+      if (resizeCallback) {
+        resizeCallback([], {} as ResizeObserver)
+      }
+
+      // fitAddon must NOT fire — this is the exact bug path that squashes scrollback
+      expect(mockFitAddon.fit).not.toHaveBeenCalled()
+
+      // Simulate tab becoming visible again: offsetWidth > 0
+      Object.defineProperty(container, 'offsetWidth', {
+        value: 800,
+        configurable: true,
+      })
+
+      if (resizeCallback) {
+        resizeCallback([], {} as ResizeObserver)
+      }
+
+      // fitAddon SHOULD fire now that the container has real dimensions
+      expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+    })
+
+    test('regression #81: onResize does not forward tiny dimensions to PTY when container is hidden', async () => {
+      render(<TerminalPane sessionId="test-session" cwd="/home/user" />)
+
+      await waitFor(() => {
+        expect(mockTerminal.onResize).toHaveBeenCalled()
+      })
+
+      // Clear mocks from initial render
+      mockFitAddon.fit.mockClear()
+      vi.mocked(mockUseTerminal.resize).mockClear()
+
+      const container = screen.getByTestId('terminal-pane')
+
+      const onResizeCallback = mockTerminal.onResize.mock
+        .calls[0][0] as (size: { cols: number; rows: number }) => void
+
+      // Hidden tab path: container width === 0
+      Object.defineProperty(container, 'offsetWidth', {
+        value: 0,
+        configurable: true,
+      })
+
+      onResizeCallback({ cols: 1, rows: 24 })
+
+      // Neither fit() nor PTY resize should run at zero width
+      expect(mockFitAddon.fit).not.toHaveBeenCalled()
+      expect(mockUseTerminal.resize).not.toHaveBeenCalled()
+
+      // Visible tab path: container width > 0
+      Object.defineProperty(container, 'offsetWidth', {
+        value: 800,
+        configurable: true,
+      })
+
+      onResizeCallback({ cols: 80, rows: 24 })
+
+      // Both should fire now
+      expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      expect(mockUseTerminal.resize).toHaveBeenCalledTimes(1)
     })
 
     test('P2: disposes old session terminal when switching to different sessionId', async () => {

--- a/src/features/terminal/components/TerminalPane.test.tsx
+++ b/src/features/terminal/components/TerminalPane.test.tsx
@@ -145,11 +145,17 @@ describe('TerminalPane', () => {
   })
 
   test('fits terminal to container after opening', async () => {
+    const offsetSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockReturnValue(800)
+
     render(<TerminalPane sessionId="test-session" cwd="/home/user" />)
 
     await waitFor(() => {
       expect(mockFitAddon.fit).toHaveBeenCalled()
     })
+
+    offsetSpy.mockRestore()
   })
 
   test('handles terminal resize events', async () => {
@@ -380,6 +386,7 @@ describe('TerminalPane', () => {
 
       const cachedTerminal = {
         open: vi.fn(),
+        dispose: vi.fn(),
         cols: 80,
         rows: 24,
         onResize: vi.fn(() => ({ dispose: vi.fn() })),
@@ -396,17 +403,19 @@ describe('TerminalPane', () => {
         .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
         .mockReturnValue(0)
 
-      render(<TerminalPane sessionId="cached-session" cwd="/home/user" />)
+      try {
+        render(<TerminalPane sessionId="cached-session" cwd="/home/user" />)
 
-      await waitFor(() => {
-        expect(cachedTerminal.open).toHaveBeenCalled()
-      })
+        await waitFor(() => {
+          expect(cachedTerminal.open).toHaveBeenCalled()
+        })
 
-      // fitAddon.fit must be suppressed on the reuse path when width is 0
-      expect(cachedFitAddon.fit).not.toHaveBeenCalled()
-
-      offsetSpy.mockRestore()
-      terminalCache.delete('cached-session')
+        // fitAddon.fit must be suppressed on the reuse path when width is 0
+        expect(cachedFitAddon.fit).not.toHaveBeenCalled()
+      } finally {
+        offsetSpy.mockRestore()
+        terminalCache.delete('cached-session')
+      }
     })
 
     test('regression #81: onResize does not forward tiny dimensions to PTY when container is hidden', async () => {

--- a/src/features/terminal/components/TerminalPane.tsx
+++ b/src/features/terminal/components/TerminalPane.tsx
@@ -176,8 +176,13 @@ export const TerminalPane = ({
       // Re-open terminal in the new container
       newTerminal.open(containerRef.current)
 
-      // Re-fit to new container
-      fitAddon.fit()
+      // Re-fit to new container — guard against hidden (display:none) containers
+      // where offsetWidth is 0. Fitting at zero width tells xterm cols≈1,
+      // which causes the PTY to re-wrap scrollback into a narrow column.
+      const width = containerRef.current.offsetWidth
+      if (width > 0) {
+        fitAddon.fit()
+      }
     } else {
       // Create new terminal instance
       newTerminal = new Terminal({
@@ -235,18 +240,28 @@ export const TerminalPane = ({
 
     // Handle resize events - notify PTY of terminal size changes
     const resizeDisposable = newTerminal.onResize(({ cols, rows }) => {
-      // Fit terminal to container
-      fitAddon.fit()
+      // Guard: don't forward resize when container is hidden (display:none).
+      // Otherwise the PTY receives cols≈1 and re-wraps scrollback.
+      const width = containerRef.current?.offsetWidth ?? 0
+      if (width > 0) {
+        // Fit terminal to container
+        fitAddon.fit()
 
-      // Notify PTY service of size change using ref (stable across renders)
-      resizeRef.current(cols, rows)
+        // Notify PTY service of size change using ref (stable across renders)
+        resizeRef.current(cols, rows)
+      }
     })
 
     // P2 Fix: Add ResizeObserver to detect container size changes
     // When the container resizes (e.g., window resize, panel collapse),
-    // fit the terminal which will trigger the onResize event above
+    // fit the terminal which will trigger the onResize event above.
+    // Guard: skip fit when container is hidden (display:none → width=0)
+    // to avoid PTY scrollback re-wrapping at a narrow column count.
     const resizeObserver = new ResizeObserver(() => {
-      fitAddon.fit()
+      const width = containerRef.current?.offsetWidth ?? 0
+      if (width > 0) {
+        fitAddon.fit()
+      }
     })
     resizeObserver.observe(containerRef.current)
 

--- a/src/features/terminal/components/TerminalPane.tsx
+++ b/src/features/terminal/components/TerminalPane.tsx
@@ -203,8 +203,11 @@ export const TerminalPane = ({
       // Open terminal in container
       newTerminal.open(containerRef.current)
 
-      // Fit terminal to container
-      fitAddon.fit()
+      // Fit terminal to container — guard against hidden (display:none) containers
+      const width = containerRef.current.offsetWidth
+      if (width > 0) {
+        fitAddon.fit()
+      }
 
       // Register OSC 7 handler for cwd tracking
       // Shells emit: \e]7;file://hostname/path\a on every cd

--- a/src/features/terminal/components/TerminalPane.tsx
+++ b/src/features/terminal/components/TerminalPane.tsx
@@ -16,7 +16,7 @@ import '@xterm/xterm/css/xterm.css'
 
 // P2 Fix: Global cache of terminal instances per sessionId
 // This allows terminals to persist when switching between sessions
-const terminalCache = new Map<
+export const terminalCache = new Map<
   string,
   { terminal: Terminal; fitAddon: FitAddon }
 >()


### PR DESCRIPTION
Fixes #81

## Problem
When a terminal tab is hidden via +display:none+ (e.g. switching to another tab), its container collapses to width=0. The ResizeObserver fires and +fitAddon.fit()+ computes cols≈1, which causes the PTY to re-wrap all scrollback into a narrow column. When the user switches back, the old scrollback stays squashed.

## Changes
- Skip +fit()+ and PTY resize forwarding when +container.offsetWidth === 0+ in three places:
  1. ResizeObserver callback
  2. +onResize+ handler
  3. Cached terminal reuse path
- Add 2 regression tests that verify fit/resize are suppressed at zero width and resume at normal width.

## Test plan
- [x] +npx vitest run src/features/terminal/components/TerminalPane.test.tsx+ → 22 passed
- [x] +npx vitest run src/features/workspace/components/TerminalZone.test.tsx+ → 21 passed
- [x] +npx tsc --noEmit+ → clean
- [x] ESLint pre-commit → clean