### PR TITLE
feat(files-changed): wire sidebar panel to real git state

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -58,6 +58,7 @@ words:
   - sess # session
   - proj # project
   - terminalPid # terminal process ID
+  - cwds # current working directories (plural of cwd)
 
   # Syntax Highlighting
   - shiki

--- a/docs/superpowers/specs/2026-04-23-files-changed-panel-design.md
+++ b/docs/superpowers/specs/2026-04-23-files-changed-panel-design.md
@@ -1,0 +1,697 @@
+# Files Changed Panel — Design Spec
+
+**Date**: 2026-04-23
+**Status**: Draft (awaiting user review)
+**Audience**: Both humans (top half, reader's overview) and implementation agents (bottom half, technical reference). Both halves are authoritative — if they disagree, it's a bug in the spec; please flag it.
+
+**Depends on**:
+
+- `src-tauri/src/git/mod.rs` — existing `git_status` / `get_git_diff` Tauri commands
+- `src/features/diff/` — existing `ChangedFile` type, `TauriGitService`, `useGitStatus`, `useFileDiff`, `DiffPanelContent`, `DiffViewer`
+- `src-tauri/src/agent/watcher.rs` — reference pattern for `notify`-based watchers with polling fallback
+
+---
+
+# Part 1 — Reader's Overview
+
+## In one paragraph
+
+The right-hand agent sidebar has a **FILES CHANGED** section that always says `0` because nothing feeds it. This feature lights it up by reading the real output of `git status`, showing one row per modified file with its `+N / -N` line counts, and refreshing automatically whenever any process (an agent in this tab, an agent in another tab, or the user's own editor) changes the working tree. Clicking a row opens that file in the diff viewer that already lives in the bottom drawer.
+
+## What you see today vs. what you'll see after
+
+```
+TODAY                                 AFTER
+─────                                 ─────
+▼ FILES CHANGED  0                    ▾ FILES CHANGED  4
+                                        ~ src/features/diff/FilesChanged.tsx    +8 / -1  STAGED EDIT
+▶ TESTS 0/0                             ~ src/features/diff/FilesChanged.tsx    +4 / -2  EDIT
+                                        ~ src/features/workspace/WorkspaceView.tsx +4 / -4 EDIT
+                                        + src/hooks/useGitStatusRefresh.ts      +47 / -0 NEW
+
+0m     0 turns     +0 / -0            ▸ TESTS 0/0                 ← unchanged (out of scope)
+
+                                      0m     0 turns     +0 / -0  ← unchanged (agent-sourced)
+```
+
+(The two `FilesChanged.tsx` rows illustrate the MM dual-entry pattern — the file is staged with 8 lines added, then edited further in the working tree with 4 more added. Each row routes to the correct half of the diff when clicked.)
+
+Clicking any row opens the bottom drawer's **Diff** tab with that file selected.
+
+## The four key choices
+
+Each was a fork — we could have gone the other way. The reasoning is recorded here so future-us (or a reviewer) doesn't re-litigate it.
+
+### 1. Show real git, not agent-reported, changes
+
+The agent reports `totalLinesAdded / totalLinesRemoved` as part of its cost metrics. We don't use those, because:
+
+- The user will ultimately `git commit` — and `git` is what `git commit` sees. If an agent silently reverts its own work, the agent still counts the churn; git shows zero.
+- The user also edits files outside the agent (vim, VS Code, manual `rm`). Those never reach the agent's tool-call stream.
+
+**Side effect worth knowing:** the footer `+N / -N` stays agent-sourced on purpose. The list answers _"what's in my working tree"_; the footer answers _"what did this chat do."_ When they disagree, you learn something (agent reverted, user edited, etc.).
+
+### 2. Watch the filesystem; don't refresh on agent events
+
+The natural first instinct is "the agent just finished a Write — refresh." That breaks the moment a second agent is running. Vimeflow's value prop is being a **control plane for multiple coding agents**, so any design that only works with one agent is a trap.
+
+The watcher also catches edits made outside any agent — fixing a typo in vim updates the panel without anyone asking.
+
+**Cost:** some Rust plumbing and one new Cargo dependency (`ignore`, the same crate `ripgrep` uses to honor `.gitignore`). Worth it — adding a watcher later would be a bigger refactor than baking it in now.
+
+### 3. Only show the panel when an agent is active (for now)
+
+We considered "always show uncommitted changes, even with no agent." Rejected — it requires moving `FilesChanged` out of `AgentStatusPanel` into a higher layout slot. That's a meaningful refactor and not what the user asked for. The backend watcher is panel-agnostic, so this can be revisited later without backend changes.
+
+### 4. Per-file `+N / -N` badges are worth one extra git call
+
+Each refresh now runs three git subprocesses instead of one: `git status --porcelain=v1 -z`, `git diff --numstat`, and `git diff --cached --numstat`. Git is fast on a warm cache (tens of milliseconds), and the numbers turn a plain list into something useful at a glance. Binary files report `-` in `--numstat`; those rows omit the badge.
+
+## Architecture in plain English
+
+```
+                 ┌──────────────────────┐
+                 │   React components    │
+                 │  (sidebar panel,      │
+                 │   bottom-drawer diff  │
+                 │   viewer)             │
+                 └──────────┬────────────┘
+                            │ useGitStatus(cwd, { watch: true })
+                            ▼
+                 ┌──────────────────────┐
+                 │  Tauri invoke layer   │
+                 └──────────┬────────────┘
+                            │
+       ┌────────────────────┼────────────────────┐
+       ▼                    ▼                    ▼
+┌────────────┐      ┌────────────┐      ┌────────────────┐
+│ git_status │      │ start_git_ │      │ stop_git_      │
+│  (extended │      │  watcher   │      │  watcher       │
+│  with      │      │ (new)      │      │ (new)          │
+│  numstat)  │      │            │      │                │
+└────────────┘      └──────┬─────┘      └────────────────┘
+                           │
+                           ▼
+                 ┌──────────────────────┐
+                 │  notify (NonRecursive │
+                 │  per non-ignored dir) │
+                 │  + ignore-filtered    │
+                 │  walker               │
+                 │  + polling fallback   │
+                 │  keyed by repo        │
+                 │  toplevel (refcount)  │
+                 └──────────┬────────────┘
+                            │ emits
+                            ▼
+              `git-status-changed { cwds: string[] }`
+                            │
+                            ▼ (frontend listener matches if its
+                              input cwd ∈ cwds, calls refresh)
+                    → another git_status round
+                    → <~100ms total → UI updates
+```
+
+### Why the watcher keys on repo toplevel, with per-cwd refcounts inside
+
+Two things are refcounted, and they operate on different axes:
+
+1. **Outer key: repo toplevel.** Terminal cwd (via OSC 7) can be any subdirectory of a repo. If we keyed the watcher map on raw cwd, two tabs at `/repo/src/a` and `/repo/src/b` would each spin up their own full notify registration on the same repo — wasteful, doubles the inotify budget, and makes the non-repo check false-positive when `.git/` is two levels up from the cwd. Resolving `git rev-parse --show-toplevel` first means both tabs map to `/repo` and share one notify handle.
+2. **Inner refcount: per input cwd.** Inside a single toplevel watcher, each input cwd has its own refcount. Why: the sidebar and the bottom-drawer diff viewer both subscribe `useGitStatus(activeSessionCwd, { watch: true })` on the same cwd. Two hooks, one cwd, two refcount increments — unmounting the drawer drops the refcount to 1, the watcher stays live for the sidebar; unmounting the sidebar drops it to 0, the watcher tears down. A simple set-of-cwds would collapse both hooks to one entry and the first unmount would break the other.
+
+A tab whose cwd is outside any repo takes the pre-repo path: its own refcount (no toplevel yet), polling thread that upgrades the entry to a real repo watcher as soon as `git init` happens.
+
+### Why we honor `.gitignore`
+
+A recursive watch on a typical JS/Rust repo would try to subscribe to every file under `node_modules/` and `target/`. Linux's default `fs.inotify.max_user_watches` is around 8192 on most distros; a single medium-sized `node_modules` can blow right past that. Importantly, a _recursive_ inotify watch on the repo root registers all of those subdirectories regardless of any walker we ran first — recursive means the kernel does it for us. So we don't use a recursive watch: the `ignore` crate walks the tree itself, and we register each non-ignored directory individually as a non-recursive watch. Ignored subtrees never consume a watch slot.
+
+### Why the polling fallback exists
+
+On WSL2, SMB, and NFS, `inotify` sometimes misses events — especially when an editor saves via "write temp → rename" (an atomic swap). The polling fallback re-reads `HEAD` and `index` OIDs every 10 seconds and fires a synthetic event if anything moved. It's a safety net, not the main mechanism.
+
+## User flows
+
+### Flow A — Agent edits three files
+
+1. Agent runs `Write` on file A, `Edit` on file B, `Bash: rm file-C`.
+2. `notify` fires a burst of events; the watcher's 300ms debounce coalesces them into one.
+3. Backend emits `git-status-changed { cwds: [currentSubscribedCwdsOnThisToplevel] }`.
+4. Every mounted `useGitStatus` hook whose input cwd appears in `cwds` calls `refresh()`.
+5. `git_status` runs; `FilesChanged` re-renders with three rows.
+6. Typical time from last write to UI update: under 400ms.
+
+### Flow B — Two agents on the same repo, different subdirs
+
+1. Agent A in tab 1 (cwd `/repo/src/a`) writes file X. Agent B in tab 2 (cwd `/repo/src/b`) writes file Y.
+2. Both cwds resolved to the same toplevel `/repo` by `start_git_watcher`, so both subscriptions share one repo watcher — per-cwd refcounts in the `subscribers` map.
+3. A write to either file triggers the shared notify handle. One debounced event fires with `cwds: ["/repo/src/a", "/repo/src/b"]`; both hooks match and refresh.
+4. Each tab's sidebar shows both changes (sorted by path). Two tabs on the **same** cwd work identically — both subscriptions are independent refcounts on the same key.
+
+### Flow C — User edits in VS Code while an agent is running
+
+1. User saves a file in VS Code; it does a temp-write + rename.
+2. On Linux, `notify` sees the rename. On WSL2, it might miss it — in which case the 10s polling fallback catches the OID change.
+3. `git-status-changed` fires; list updates.
+
+### Flow D — Clicking a file
+
+1. User clicks a row in `FilesChanged`.
+2. `onSelect(file)` bubbles up the full `ChangedFile` through `AgentStatusPanel.onOpenDiff` to `WorkspaceView.handleOpenDiff`.
+3. `WorkspaceView` sets three pieces of state at once: `bottomDrawerTab = 'diff'`, `selectedDiffFile = { path, staged, cwd }` (tagged with the current cwd so a later session switch can be detected at render time), `isBottomDrawerCollapsed = false`.
+4. `BottomDrawer` (controlled) switches tabs and uncollapses; `DiffPanelContent` (controlled) checks `selectedDiffFile.cwd === cwd` at render time, passes the `staged` flag to `useFileDiff`, and shows the correct half of an MM/AM pair.
+
+## What's staying and what's moving
+
+| Thing                                                    | Status                                                                                                     | Where it lives                                        |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `src-tauri/src/git/mod.rs` `git_status` + `get_git_diff` | Extended — numstat merged in                                                                               | Same file                                             |
+| `src-tauri/src/git/watcher.rs`                           | **New**                                                                                                    | New file, modeled on `src-tauri/src/agent/watcher.rs` |
+| `ChangedFile` Rust struct                                | Extended — adds `insertions`/`deletions` fields                                                            | Same file                                             |
+| `src/features/diff/types/ChangedFile` TS type            | Unchanged — optional fields already there                                                                  | Same file                                             |
+| `src/features/diff/hooks/useGitStatus`                   | Extended — optional `watch: true` mode                                                                     | Same file                                             |
+| `src/features/diff/services/gitService.ts`               | Unchanged                                                                                                  | —                                                     |
+| `src/features/diff/components/DiffPanelContent`          | Accepts controlled `selectedFile` as `SelectedDiffFile` (`{ path, staged, cwd }`); opts into `watch: true` | Same file                                             |
+| `src/features/workspace/components/BottomDrawer`         | Accepts controlled `activeTab` / `selectedDiffFile` / `isCollapsed`                                        | Same file                                             |
+| `src/features/workspace/WorkspaceView`                   | Lifts tab + selected-file state; wires `onOpenDiff`                                                        | Same file                                             |
+| `src/features/agent-status/components/FilesChanged`      | Refactored to consume `ChangedFile[]`; adds `onSelect`; renders `+N/-N`                                    | Same file                                             |
+| `src/features/agent-status/components/AgentStatusPanel`  | Replaces placeholder with real hook; forwards `onOpenDiff`                                                 | Same file                                             |
+| `src/features/agent-status/components/ActivityFooter`    | Unchanged                                                                                                  | —                                                     |
+| `src/features/agent-status/components/TestResults`       | Unchanged — wiring is a separate feature                                                                   | —                                                     |
+
+---
+
+# Part 2 — Technical Reference
+
+## Backend changes
+
+### `src-tauri/Cargo.toml`
+
+Add one new crate: `ignore = "0.4"`. It is a **different crate** from `notify = "6"` (which is already in `Cargo.toml` and stays as-is); the version numbers `"0.4"` and `"6"` belong to each crate independently and are unrelated.
+
+The two crates collaborate with distinct jobs:
+
+| Crate                                                | Role in this feature                                                                                                                                                                                |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `notify = "6"` _(existing)_                          | Subscribes to kernel filesystem events (inotify on Linux, FSEvents on macOS, ReadDirectoryChangesW on Windows) and tells us "the file at this path just changed." Does not know anything about git. |
+| `ignore = "0.4"` _(new — same crate `ripgrep` uses)_ | Parses `.gitignore`, `.git/info/exclude`, and nested gitignores and filters the path list before we hand it to `notify`. Does not watch anything.                                                   |
+
+Without `ignore`, a recursive watch on a typical repo would try to subscribe to every file under `node_modules/`, `target/`, and `.git/objects/`. Linux's default `fs.inotify.max_user_watches` (~8192) can't cover that; the watcher silently stops catching events once exhausted. With `ignore`, we walk the tree, drop any path excluded by a `.gitignore`, and hand `notify` only the "real source" paths.
+
+### `src-tauri/src/git/mod.rs`
+
+**Extend `ChangedFile`:**
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangedFile {
+    pub path: String,
+    pub status: ChangedFileStatus,
+    pub staged: bool,
+    pub insertions: Option<u32>,   // NEW — None for binary files and untracked
+    pub deletions: Option<u32>,    // NEW
+}
+```
+
+**Add a `parse_numstat` helper (NUL-terminated format):**
+
+```rust
+/// Parse `git diff --numstat -z` output into a path → (added, removed) map.
+///
+/// Format (NUL-separated, LF-stripped inside records):
+///   non-rename: "<added>\t<deleted>\t<path>\0"
+///   rename:     "<added>\t<deleted>\t\0<src-path>\0<dst-path>\0"
+///
+/// Binary files report "-\t-\t..." and are omitted from the map.
+/// Renames are keyed on the **dst** path (matches ChangedFile.path, which
+/// porcelain -z also sets to the dst). The `-z` form is mandatory — the
+/// default text form uses brace-compressed renames like
+/// `src/{Foo.tsx => Bar.tsx}` that would not match ChangedFile.path and
+/// would drop +N/-N badges on every renamed row.
+fn parse_numstat(output: &[u8]) -> HashMap<String, (u32, u32)>
+```
+
+**Extend `git_status`:**
+
+0. **Resolve the repo root (NEW).** Run `git -C <cwd> rev-parse --show-toplevel`. If this exits non-zero (typical error: `fatal: not a git repository`), the cwd is outside any repo — return `Ok(vec![])` and skip all subsequent subprocess calls. On success, use the canonicalized toplevel as the working directory for every following git call in this command. Rationale: `session.workingDirectory` is the terminal's live OSC-7 cwd, which can be any subdirectory (`cd src/foo`); running `git status` from there still works, but `<cwd>/.git` would miss and our old pre-check would incorrectly flag it as a non-repo. Resolving to toplevel fixes both the non-repo check and the watcher keying below.
+1. Run `git status --porcelain=v1 -z` **from the toplevel** — authoritative list and staging state.
+2. Run `git diff --numstat -z` and `git diff --cached --numstat -z` **from the toplevel** (NEW) — in parallel via `tokio::join!`, both wrapped in the existing `run_git_with_timeout`.
+3. For each `ChangedFile`, look up the numstat entry in the matching map (staged entries → cached map; unstaged entries → working-tree map). Leave `None` for untracked or missing entries.
+
+**MM / AM dual-entry behavior (NEW — replaces single-entry default).** The existing `parse_git_status` collapses MM (modified in both index and worktree) and AM (added in index, modified in worktree) into a single `ChangedFile` with `staged: false`, silently hiding the staged half. In this feature, emit **two** entries per MM/AM path:
+
+```
+MM  foo.ts    →   { path: foo.ts, status: Modified, staged: true,  insertions/deletions from cached numstat }
+                  { path: foo.ts, status: Modified, staged: false, insertions/deletions from working-tree numstat }
+
+AM  bar.ts    →   { path: bar.ts, status: Added,    staged: true,  insertions/deletions from cached numstat }
+                  { path: bar.ts, status: Modified, staged: false, insertions/deletions from working-tree numstat }
+```
+
+Each half renders as its own row in `FilesChanged` (the staged row shows a `STAGED` badge variant — see Frontend changes below). Clicking either row opens the correct half in `DiffPanelContent` because `useFileDiff(path, staged, cwd)` already accepts the staged flag. This intentionally trades a little visual duplication for correct representation — the alternative (single-flag with one half silently hidden) is a user-observable data loss, not a formatting choice.
+
+This does **not** require the dual-flag `ChangedFile` model in [`2026-04-11-mm-staged-unstaged-design.md`](./2026-04-11-mm-staged-unstaged-design.md); the single-flag shape is preserved. That larger rewrite is still the right long-term move (it would eliminate the row duplication), but it can land separately.
+
+**Timeout policy:** if any of the three subprocesses (status, diff-numstat, diff-cached-numstat) times out, the whole `git_status` call fails and the frontend shows its error state with a Retry button. The 30s budget is already very loose; a real timeout signals something is seriously wrong (hung filesystem, pathological repo state), and quietly returning partial data would mask that. The `rev-parse` call in step 0 is fast enough to share the same budget.
+
+**Extend `get_git_diff` with the same toplevel resolution.** `ChangedFile.path` is toplevel-relative (porcelain `-z` emits it that way), but `get_git_diff(cwd, file, staged)` currently runs `git -C <cwd> diff -- <file>`. For a session whose cwd is `/repo/src/foo`, running `git -C /repo/src/foo diff -- src/components/Bar.tsx` looks for the file relative to `/repo/src/foo` and returns an empty diff — the click-to-open flow would show blank content for every row in a subdir session. Mirror the `git_status` fix:
+
+0. Run `git -C <cwd> rev-parse --show-toplevel`. If it fails, return a `FileDiff` with empty `hunks` (the frontend already handles this as "nothing to show"). On success, use the canonicalized toplevel as the working directory for the subsequent `git diff` call.
+1. `git -C <toplevel> diff [--cached] -- <file>` (unchanged beyond the working-dir swap).
+
+Same `validate_cwd` protection on both the input `cwd` and the resolved toplevel. Existing `validate_file_path` stays — `ChangedFile.path` is repo-relative and must remain so.
+
+### `src-tauri/src/git/watcher.rs` (new module)
+
+Model on `src-tauri/src/agent/watcher.rs`. Key properties:
+
+- **Two state maps, one lifecycle.** State has two fields:
+  ```rust
+  pub struct GitWatcherState {
+      repo_watchers: Mutex<HashMap<Toplevel, RepoWatcher>>,
+      //                            ↓
+      //    RepoWatcher {
+      //        subscribers: HashMap<InputCwd, u32>,   // cwd → refcount (NOT a HashSet — see below)
+      //        notify_handles: …,
+      //        poll_stop: Arc<AtomicBool>,
+      //    }
+      pre_repo_watchers: Mutex<HashMap<InputCwd, PreRepoWatcher>>,
+      //                            ↓
+      //    PreRepoWatcher {
+      //        refcount: u32,
+      //        poll_stop: Arc<AtomicBool>,
+      //    }
+  }
+  ```
+  Every `start_git_watcher(cwd)` call lands in exactly one map entry based on whether `git rev-parse --show-toplevel` succeeds for that cwd.
+- **Subscribers are refcounted per cwd, not deduped.** `subscribers: HashMap<InputCwd, u32>` — each `start_git_watcher(cwd)` call **increments** the counter for that cwd; each `stop_git_watcher(cwd)` **decrements**. A key is removed from the map only when its counter hits 0; the watcher's notify handles are dropped only when the whole map is empty. This matters because multiple live hooks on the **same** cwd is a normal state: `AgentStatusPanel` subscribes on the active session's cwd while `DiffPanelContent` (inside the bottom drawer's diff tab) also subscribes on that same cwd. If subscribers were a `HashSet<InputCwd>`, both hooks would collapse to one entry, and the first unmount (user switches the drawer tab from diff to editor) would tear down the watcher while the sidebar is still using it. The refcount preserves the mapping "N live subscribers → 1 shared notify handle, unsubscribe drops refcount by 1" across all common subscription patterns.
+- **Repo path (toplevel resolved).** Get or insert `repo_watchers[toplevel]`; bump `subscribers[cwd]` counter by 1. If the entry was new, build its notify handles and polling thread.
+- **Pre-repo path (not in a repo yet).** Get or insert `pre_repo_watchers[cwd]`; bump its `refcount` by 1 (so sidebar + drawer both watching a non-repo cwd share the pre-repo handle correctly). If the entry was new, spawn its polling thread. The entry has **no notify watches** (there's nothing to watch yet and we don't want to guess). The polling thread runs `rev-parse --show-toplevel` every 10s. On transition (user runs `git init`): take the pre-repo entry (carrying its refcount), insert/bump `repo_watchers[new_toplevel].subscribers[cwd]` by that refcount, build or reuse the repo watcher's notify handles, drop the pre-repo entry, and emit `git-status-changed { cwds: [cwd] }`. This is the "auto-upgrade" path — subscribers get the refresh they expect without any frontend action.
+- **Non-recursive notify watches built from a filtered walk.** For every repo watcher, we do **not** use `RecursiveMode::Recursive` on the toplevel, because on Linux inotify a recursive watch auto-registers every subdirectory — including `node_modules/`, `target/`, and `.git/objects/` — regardless of any walker we ran first. The `ignore` crate only helps if we drive registration ourselves:
+  1. Use `ignore::WalkBuilder::new(toplevel).follow_links(false).build()` to enumerate the tree with `.gitignore` / `.git/info/exclude` / nested gitignores honored.
+  2. For each enumerated **directory**, call `watcher.watch(dir, RecursiveMode::NonRecursive)` — one inotify slot per directory, ignored subtrees never registered.
+  3. When a `Create(Folder)` event fires on a watched dir, consult `ignore::gitignore::Gitignore` for the new path; if not ignored, register it `NonRecursive` so newly-created source directories are covered automatically. No runtime add needed for ignored dirs.
+  4. Also register `<toplevel>/.git/index` and `<toplevel>/.git/HEAD` individually with `NonRecursive` so staging ops and commits fire events. Do not recursively watch `.git/` — `.git/objects/` alone can explode the watch count.
+- **Event payload fans out subscribers.** The Tauri event is `git-status-changed { cwds: string[] }` — `cwds` is `subscribers.keys().collect()` for the triggering watcher (unique input cwds, refcount ignored for payload purposes — the frontend just needs to know "did my cwd get refreshed?"), or `[input_cwd]` for a pre-repo upgrade. Frontend listener matches if its input cwd appears in `event.cwds` and calls `refresh()`. This is what makes a shared repo watcher correctly fan out to every subscribed tab; without it, a single event payload couldn't serve both `/repo/src/a` and `/repo/src/b` simultaneously.
+- **Debounce at 300ms** — coalesces a flood of writes from `npm install` or a large `Edit` call into one event. Snapshot the subscribers set at emission time so a subscriber who unsubscribes during the debounce window isn't included.
+- **Polling fallback at 10s.** For repo watchers: re-stats `HEAD` / `index` OIDs and working-tree `mtime` max; fires a synthetic `git-status-changed { cwds: <current subscribers> }` if anything differs. For pre-repo watchers: re-runs `rev-parse --show-toplevel`; on success, triggers the upgrade path described above. Same stop-flag pattern the agent watcher uses.
+- **Validate cwd under home** — reuse `validate_cwd` from `git/mod.rs`. Apply it to the input `cwd` **and** to the resolved toplevel (a malicious symlink inside the project could otherwise point `rev-parse --show-toplevel` outside `$HOME`).
+- **Initial-fire on start** — emit one `git-status-changed { cwds: [input_cwd] }` immediately after `start_git_watcher` returns so the frontend's first fetch happens without waiting for a real event. Using a singleton `cwds` array keeps the event shape consistent between initial-fire, real-event, and upgrade paths.
+- **Unsubscribe semantics.** `stop_git_watcher(cwd)` decrements the refcount for `cwd` in whichever map has it. For repo watchers: if `subscribers[cwd]` hits 0, the key is removed; if the whole `subscribers` map is then empty, drop the notify handles and stop the polling thread. For pre-repo watchers: if the entry's refcount hits 0, drop the entry (stopping its polling thread). A stray `stop_git_watcher` for a cwd not in either map is a warning-logged no-op — it's harmless and probably means the frontend fired cleanup twice during a teardown race.
+
+**Tauri commands:**
+
+```rust
+#[tauri::command]
+pub async fn start_git_watcher(
+    cwd: String,
+    state: tauri::State<'_, GitWatcherState>,
+    app: tauri::AppHandle,
+) -> Result<(), String>
+
+#[tauri::command]
+pub async fn stop_git_watcher(
+    cwd: String,
+    state: tauri::State<'_, GitWatcherState>,
+) -> Result<(), String>
+```
+
+Register `GitWatcherState::default()` and both commands in `src-tauri/src/lib.rs`.
+
+## Frontend changes
+
+### `src/features/diff/hooks/useGitStatus.ts`
+
+Signature becomes `useGitStatus(cwd: string, options?: { watch?: boolean; enabled?: boolean })`. Both options default to `true` only together — i.e. `enabled` defaults to `true` to preserve behavior for current callers; `watch` defaults to `false`.
+
+**Return shape adds `filesCwd: string | null`.** This is the cwd for which the current `files` array was last successfully fetched. It's `null` before the first successful fetch, and changes ONLY on successful fetch completion (never on fetch start, so during a cwd change `filesCwd` keeps pointing at the old cwd while `files` still holds the old list — until the new fetch lands). Consumers use it as a freshness predicate: `const filesAreFresh = filesCwd === cwd`. Without this, an auto-select effect that fires during a cwd change would see the **old** `files` array, pick its first entry, tag it with the **new** cwd, and hand `useFileDiff` a broken `(oldPath, newCwd)` pair — which is exactly the regression the reviewer flagged after the `{ path, staged, cwd }` guard was added.
+
+- **`enabled: false`** — the hook returns `{ files: [], filesCwd: null, loading: false, error: null, refresh: () => void }` and performs **no** IPC, no event subscription, and no watcher lifecycle call. Existing consumers pass no `enabled` and are unaffected.
+- **`watch: true` (requires `enabled: true` to take effect)** — lifecycle ordered to close the listen-attach race (see Async Race Conditions pattern at `docs/reviews/patterns/async-race-conditions.md`). On mount (and on `cwd` change):
+  1. `const unlisten = await listen<{ cwds: string[] }>('git-status-changed', handler)` — **attach listener first**. Handler matches if `event.payload.cwds.includes(myCwd)` and calls `refresh()`.
+  2. `await invoke('start_git_watcher', { cwd })` — watcher startup. The backend's initial-fire emits the first `git-status-changed` event during this call; the listener is already attached and catches it.
+  3. `refresh()` — explicit belt-and-suspenders fetch AFTER both above. This covers any filesystem change that landed between listener-attach (step 1) and watcher startup (step 2) without being witnessed by either, and is idempotent with the listener-triggered refresh from step 2's initial-fire. Reversing the listener/start order is what turns "we might miss the initial fire" into "we can't miss it."
+  4. Return the hook state; future events route through the listener.
+
+  On unmount (or `enabled` flipping false, or `cwd` changing):
+  1. `unlisten()` — detach listener first so a late in-flight event can't call `refresh()` on a torn-down hook.
+  2. `await invoke('stop_git_watcher', { cwd })` — decrement backend refcount.
+
+  The `cwds` array is what lets a single event fan out to multiple subscribers sharing the same underlying repo watcher — two hooks on `/repo/src/a` and `/repo/src/b` both match the same event because both cwds appear in its payload.
+
+- The non-watched path stays unchanged so existing consumers (and their tests) keep working.
+
+The `enabled` gate exists so `AgentStatusPanel` — which is always mounted — can keep the watcher idle for inactive agent sessions without conditionally-mounting a child component (which would churn watcher start/stop on every `status.isActive` flap).
+
+### `src/features/agent-status/components/FilesChanged.tsx`
+
+- Delete the local `FileChangeItem` type. Import `ChangedFile` from `src/features/diff/types`.
+- New props:
+  ```ts
+  interface FilesChangedProps {
+    files: ChangedFile[]
+    loading: boolean
+    error: Error | null
+    onRetry: () => void
+    onSelect: (file: ChangedFile) => void
+  }
+  ```
+  `loading` / `error` / `onRetry` come straight from `useGitStatus`'s return shape via `AgentStatusPanel`. Without them in the contract, the loading-and-error rows in the UI states table have no path into the component that renders the `CollapsibleSection` body.
+- `onSelect` receives the whole `ChangedFile` (not just the path) so the caller can route on the `staged` flag — that's what distinguishes the two halves of an MM/AM pair.
+- Body rendering rules inside the `CollapsibleSection`, split by whether we have rows:
+  - **`files.length === 0` (no rows to fall back on)**
+    - `loading` → `<div>Loading…</div>` in `text-on-surface-variant` (neutral text, not a spinner).
+    - `error && !loading` → error message in `text-error` + a `Retry` `<button>` that calls `onRetry`. Both share a single `role="alert"` container.
+    - `!loading && !error` → "No uncommitted changes" in `text-on-surface-variant`.
+  - **`files.length > 0` (rows available)** — always render the populated row list (see below), preserving stale rows across refreshes to avoid a "blinking empty state." On top of the rows:
+    - `loading` → no visual change (stale rows stay; no spinner).
+    - `error` → a compact inline banner **above the row list**: `Refresh failed: {error.message}` in `text-error` with a small `Retry` `<button>` that calls `onRetry`. The banner uses `role="alert"`. Visibility tracks the hook's `error` field directly: `useGitStatus` clears `error` at the start of every retry (see `useGitStatus.ts:41`), so the banner disappears when the retry begins; if the retry succeeds, the banner stays gone; if the retry fails, the banner reappears with the new error. This produces a brief loading flash where the banner disappears while the retry is in flight — that's the intended signal that the retry is happening, and matches how every other component in the app reads `useGitStatus().error`. Without this banner, a second-fetch failure (e.g. a transient timeout) would silently leave the list stale with no affordance to retry.
+- Row becomes a `<button>` so keyboard nav works; `onClick → onSelect(file)`. Row key is `${file.path}:${file.staged}` to give React stable identity across the two halves of an MM/AM pair.
+- Status → prefix/badge map: `modified → ~ / EDIT`, `added → + / NEW`, `deleted → - / DEL`, `renamed → → / MOVE`, `untracked → ? / UNT`.
+- Staged vs unstaged visual: staged rows append a subtle `STAGED` label (same typographic treatment as the existing status badge, different color — `text-secondary` rather than `text-outline`) so the two MM/AM rows for the same path are instantly distinguishable. Unstaged rows carry no extra label.
+- Row order: staged-group first, then unstaged-group (handled by the backend; the component renders in the order received).
+- When both `insertions` and `deletions` are numbers, render `+{insertions} / -{deletions}` (dimmed if both zero; omitted entirely if either is `undefined`, which covers binary and untracked).
+
+The `CollapsibleSection` header `count` reflects `files.length` (not "changed while loading" — the count follows what's actually rendered). Empty / loading / error states still render the section header so the user can expand/collapse consistently.
+
+**Default expanded.** Pass `defaultExpanded={true}` to `CollapsibleSection`. The base component defaults to collapsed (`defaultExpanded = false` at `CollapsibleSection.tsx:13`), which would hide the rows behind a user-click — incompatible with both the AFTER mockup (shown as `▾` expanded) and the row-click flow documented in Flow D. Users can still collapse/expand via the header button if they want; this only sets the initial state.
+
+### `src/features/agent-status/components/AgentStatusPanel.tsx`
+
+- Remove `placeholderFiles`. Leave `placeholderTests` and its `TODO: derive from tool calls…` comment untouched — wiring `TESTS` is out of scope.
+- New props: `cwd: string`, `onOpenDiff: (file: ChangedFile) => void`. The whole `ChangedFile` goes up so the MM/AM `staged` flag is preserved through the click handler.
+- Call `useGitStatus(cwd, { watch: true, enabled: status.isActive })` — the `enabled` gate is what keeps idle sessions from starting watchers. Derive freshness and feed `FilesChanged` values that always belong to the current cwd, while keeping a current-cwd fetch **failure** visible instead of hiding it behind a permanent loading state:
+
+  ```tsx
+  const { files, filesCwd, loading, error, refresh } = useGitStatus(cwd, {...})
+  const filesAreFresh = filesCwd === cwd
+  const effectiveFiles = filesAreFresh ? files : []
+
+  // `filesCwd` is a last-SUCCESS marker, not a request-settled marker.
+  // On a failed fetch (initial or after cwd change), filesCwd stays at
+  // its prior value (or null), so `!filesAreFresh` would remain true
+  // indefinitely. Only use freshness to synthesize a loading state when
+  // there's no error to report — otherwise a real failure would render
+  // as "Loading…" forever instead of reaching the error + Retry state.
+  const effectiveLoading = loading || (!filesAreFresh && error === null)
+  ```
+
+  Forward `files: effectiveFiles`, `loading: effectiveLoading`, `error`, `onRetry: refresh`, `onSelect: onOpenDiff` to `FilesChanged` (inside the existing `status.isActive && status.agentType` branch, which stays). Behavior summary:
+  - Cwd change, new fetch in flight, no error → `effectiveLoading: true`, `effectiveFiles: []` → Loading body (hides old-repo rows).
+  - Cwd change, new fetch failed → `loading: false`, `!filesAreFresh: true`, `error: Error` → `effectiveLoading: false`, `effectiveFiles: []` → error + Retry (the failure is visible).
+  - Initial fetch failed (filesCwd still null) → same as above.
+  - Same cwd, refresh succeeded → `filesAreFresh: true`, rows render normally.
+  - Same cwd, refresh failed → `filesAreFresh: true`, `effectiveFiles: files` (stale), `effectiveLoading: false`, error set → stale-rows-with-error-banner (unchanged from earlier spec).
+
+- Do not add any `useEffect([status.toolCalls.total])` refresh hook — the watcher owns refresh.
+
+### `src/features/workspace/WorkspaceView.tsx`
+
+- Selection carries its owning cwd so a stale selection from a different repo can be detected at **render time**, not just in a post-commit effect. Add local state:
+
+  ```tsx
+  type SelectedDiffFile = { path: string; staged: boolean; cwd: string }
+
+  const [bottomDrawerTab, setBottomDrawerTab] = useState<'editor' | 'diff'>(
+    'editor'
+  )
+  const [selectedDiffFile, setSelectedDiffFile] =
+    useState<SelectedDiffFile | null>(null)
+  const [isBottomDrawerCollapsed, setIsBottomDrawerCollapsed] = useState(false)
+
+  const cwd = activeSession?.workingDirectory ?? '.'
+  ```
+
+  Tagging with `cwd` is what lets `DiffPanelContent` throw the selection away synchronously on cwd change (see its section below). Without the tag, the only defense would be a post-commit `useEffect`, and the reviewer's finding holds: the render BETWEEN cwd change and the effect would still drive `useFileDiff` with the stale `(oldPath, newCwd)` pair. `{ path, staged, cwd }` turns the guard into a pure `raw.cwd === cwd` check during render.
+
+- `handleOpenDiff = useCallback((file: ChangedFile) => { setSelectedDiffFile({ path: file.path, staged: file.staged, cwd }); setBottomDrawerTab('diff'); setIsBottomDrawerCollapsed(false) }, [cwd])` — tag the new selection with the current cwd; also uncollapse the drawer.
+- **Belt-and-suspenders effect-based cleanup.** The render-time guard in `DiffPanelContent` is the correctness fix; this effect exists only to prevent stale selection from lingering as GC-visible state if the user never clicks again:
+  ```tsx
+  useEffect(() => {
+    setSelectedDiffFile(null)
+  }, [cwd])
+  ```
+  Don't clear `bottomDrawerTab` or `isBottomDrawerCollapsed` — those are user-facing layout preferences that should persist across session switches; only the pinned file gets invalidated.
+- Pass `cwd={cwd}` + `onOpenDiff={handleOpenDiff}` to `<AgentStatusPanel>`.
+- Pass `cwd={cwd}`, `activeTab={bottomDrawerTab}`, `onTabChange={setBottomDrawerTab}`, `selectedDiffFile={selectedDiffFile}`, `onSelectedDiffFileChange={setSelectedDiffFile}`, `isCollapsed={isBottomDrawerCollapsed}`, `onCollapsedChange={setIsBottomDrawerCollapsed}` to `<BottomDrawer>`.
+
+### `src/features/workspace/components/BottomDrawer.tsx` + `src/features/diff/components/DiffPanelContent.tsx`
+
+Both accept optional controlled props:
+
+- `BottomDrawer`: `activeTab` / `onTabChange`, `isCollapsed` / `onCollapsedChange`, and (forwarded to `DiffPanelContent`) `selectedDiffFile` / `onSelectedDiffFileChange`.
+- `DiffPanelContent`: `selectedFile` / `onSelectedFileChange` — carries the full `SelectedDiffFile` shape `{ path, staged, cwd }` (not just `{ path, staged }` — the `cwd` tag is what powers the render-time staleness guard; stripping it in the prop contract would silently defeat the guard). Opening the staged half of an MM/AM pair shows the staged diff; the cwd tag ensures a lingering selection from a previous repo doesn't fire against the new one.
+
+When the controlled prop is provided, use it; otherwise fall back to existing local state so standalone/test usage still works. The existing in-drawer collapse/expand button wires to `onCollapsedChange(!isCollapsed)`.
+
+**Stale-selection invalidation (DiffPanelContent).** Two layers:
+
+1. **Render-time cwd guard (synchronous, primary fix).** The selection shape is `{ path, staged, cwd }`; a selection from a different cwd is ignored during render before it can reach `useFileDiff`. `useEffect` runs post-commit and can't protect the render that already called the hook — the render-time filter closes the window that effect-only invalidation leaves open.
+2. **Effect-driven auto-select / re-select after refresh (secondary).** Same as before: when the effective selection disappears from `files` after a refresh, pick first-valid or clear.
+
+```tsx
+// Same shape as WorkspaceView's SelectedDiffFile type — imported
+// or re-declared; the important thing is consistency with the
+// controlled prop contract.
+type SelectedDiffFile = { path: string; staged: boolean; cwd: string }
+
+const isControlled = onSelectedFileChange !== undefined
+const [localSelectedFile, setLocalSelectedFile] =
+  useState<SelectedDiffFile | null>(null)
+const rawSelection = isControlled ? (selectedFile ?? null) : localSelectedFile
+
+// Render-time guard. If the selection was tagged for a different cwd
+// (session/repo switch in flight), treat it as absent NOW, not after
+// the next commit. This is what prevents useFileDiff from firing with
+// (oldPath, newCwd) on the first render under the new cwd.
+const effectiveSelectedFile =
+  rawSelection !== null && rawSelection.cwd === cwd ? rawSelection : null
+
+const commitSelection = useCallback(
+  (next: { path: string; staged: boolean } | null): void => {
+    // Always tag with the CURRENT cwd at the moment of the click.
+    const tagged = next === null ? null : { ...next, cwd }
+    if (isControlled) {
+      onSelectedFileChange?.(tagged)
+    } else {
+      setLocalSelectedFile(tagged)
+    }
+  },
+  [isControlled, onSelectedFileChange, cwd]
+)
+
+// Auto-select-first + stale-selection invalidation after refresh.
+// Runs on `effectiveFiles`, which is already [] when filesCwd !== cwd,
+// so the freshness gate is automatic. statusLoading still guards against
+// committing during an in-flight fetch for the same cwd.
+useEffect(() => {
+  if (statusLoading) return
+  const selectionValid =
+    effectiveSelectedFile !== null &&
+    effectiveFiles.some(
+      (f) =>
+        f.path === effectiveSelectedFile.path &&
+        f.staged === effectiveSelectedFile.staged
+    )
+  if (effectiveFiles.length > 0 && !selectionValid) {
+    const next = effectiveFiles[0]
+    commitSelection({ path: next.path, staged: next.staged })
+  } else if (effectiveFiles.length === 0 && effectiveSelectedFile !== null) {
+    commitSelection(null)
+  }
+}, [effectiveFiles, effectiveSelectedFile, statusLoading, commitSelection])
+```
+
+The three-gate invariant — render-time cwd guard on the selection + `effectiveFiles` freshness filter on the rendered rows / lookup / auto-select + `selectedFileEntry`-based fetch gating — is what closes the stale-IPC window across every path. The selection can't reach `useFileDiff` from a different cwd, the auto-select effect can't resurrect a fresh-looking selection from stale files, and a manual click on a stale row can't happen because there ARE no stale rows to click.
+
+No separate `useEffect(() => setLocalSelectedFile(null), [cwd])` is needed — the render-time guard already makes the stale selection invisible to `useFileDiff` and to the selection-valid check.
+
+Two behaviors this covers:
+
+- User commits or reverts the selected file → next refresh drops it from `files` → effect picks `files[0]` (or clears to null if the list is empty) → controlled parent's state is updated via `onSelectedFileChange` → drawer shows the correct next file.
+- Selection `staged` doesn't match any entry (edge case: user staged or unstaged the file out-of-band) → same "pick first" behavior.
+
+Selection match key is `(path, staged)` — matching on path alone would treat the two halves of an MM/AM pair as interchangeable, which they are not.
+
+**Freshness derivation (same pattern AgentStatusPanel uses).** Before any lookup, render, or fetch path, derive `effectiveFiles` from the freshness check so the rest of the component never sees old-repo rows during a cwd transition:
+
+```tsx
+const {
+  files,
+  filesCwd,
+  loading: statusLoading,
+  error: statusError,
+  refresh,
+} = useGitStatus(cwd, { watch: true })
+
+const filesAreFresh = filesCwd === cwd
+const effectiveFiles = filesAreFresh ? files : []
+const effectiveStatusLoading =
+  statusLoading || (!filesAreFresh && statusError === null)
+```
+
+`effectiveFiles` — not `files` — feeds **every** downstream consumer inside `DiffPanelContent`: the `ChangedFilesList` it renders, the `selectedFileEntry` lookup, the empty/loading/error state branches, and the auto-select effect. Without this, the drawer would keep showing old-repo rows during a cwd switch; a manual click on any of them would call `commitSelection` with a stale `ChangedFile`, the render-time guard would pass (new cwd tag), `selectedFileEntry` would still find it in the raw stale `files`, and `useFileDiff` would fire `(oldPath, newCwd)` — re-creating the exact bug the top-level guard was designed to prevent. Empty rows during the brief stale window is correct behavior; the Loading body covers it.
+
+**`selectedFileEntry` lookup (keeps untracked handling and gates the diff fetch).** `effectiveSelectedFile` is `SelectedDiffFile` (`{ path, staged, cwd }`); it still doesn't carry the full `ChangedFile.status`, which `DiffPanelContent` needs to keep rendering the existing "New file — not yet tracked" placeholder for `untracked` rows (see `DiffPanelContent.tsx:52-55,124-132` — a pre-existing UX that my earlier draft dropped by accident). Resolve the full entry from `effectiveFiles` and use it for three purposes:
+
+```tsx
+// Resolve the selected entry from the CURRENT-cwd files list. Looking
+// it up in `effectiveFiles` (not raw `files`) is what makes the stale
+// window self-healing: during a cwd change, effectiveFiles === [],
+// selectedFileEntry === null, useFileDiff receives null. Three jobs:
+//   1. untracked detection (keeps the "New file — not yet tracked" view)
+//   2. gates the diff fetch — when the selection doesn't match any row
+//      (cwd change in-flight, committed/reverted, or stale window),
+//      useFileDiff receives null and skips the IPC
+//   3. status metadata the SelectedDiffFile shape doesn't carry
+const selectedFileEntry =
+  effectiveSelectedFile !== null
+    ? (effectiveFiles.find(
+        (f) =>
+          f.path === effectiveSelectedFile.path &&
+          f.staged === effectiveSelectedFile.staged
+      ) ?? null)
+    : null
+
+const selectedFileIsUntracked = selectedFileEntry?.status === 'untracked'
+
+const {
+  diff,
+  loading: diffLoading,
+  error: diffError,
+} = useFileDiff(
+  selectedFileEntry?.path ?? null, // null on stale selection → useFileDiff no-ops
+  effectiveSelectedFile?.staged ?? false,
+  cwd
+)
+```
+
+The fetch-gating via `selectedFileEntry?.path ?? null` — combined with the `effectiveFiles` filter above — closes the cwd-change transient on **both** the auto-select and manual-click paths. During the window between "new cwd prop" and "useGitStatus returns new files", `effectiveFiles === []`, no selection can be resolved, the hook receives `null`, and no IPC fires against `(oldPath, newCwd)`.
+
+Click handlers that update selection still go through `commitSelection`, keeping the controlled/uncontrolled branch in exactly one place.
+
+**No separate cwd-reset effect needed.** The render-time cwd guard on `effectiveSelectedFile` covers both controlled and uncontrolled modes synchronously. The controlled parent's `useEffect([cwd])` cleanup is purely to prevent stale selection from sitting in `WorkspaceView` state; it's not a correctness requirement for `DiffPanelContent`.
+
+### `src/features/diff/components/ChangedFilesList.tsx`
+
+The new `{ path, staged }` selection model has to flow all the way through the drawer's file-list component, not stop at `DiffPanelContent`. Today `ChangedFilesList` has a path-only contract — `selectedPath: string | null`, `onSelectFile: (path: string) => void`, `isActive = file.path === selectedPath`, row key `file.path` — which for an MM/AM pair would highlight both rows as selected simultaneously and lose the `staged` bit on click. Three changes:
+
+- Props:
+  ```ts
+  interface ChangedFilesListProps {
+    files: ChangedFile[]
+    selectedFile: { path: string; staged: boolean } | null
+    onSelectFile: (file: ChangedFile) => void
+  }
+  ```
+- `isActive = selectedFile?.path === file.path && selectedFile?.staged === file.staged` — both conditions required so the two halves of an MM/AM pair never both highlight.
+- Row `key={\`${file.path}:${file.staged}\`}`to give React stable identity across the pair (matches the sidebar`FilesChanged` keying so the two components stay consistent).
+- `onClick={(): void => onSelectFile(file)}` — pass the whole `ChangedFile` up so the staged flag makes it into `DiffPanelContent.commitSelection`.
+
+`DiffPanelContent` calls `<ChangedFilesList files={effectiveFiles} selectedFile={effectiveSelectedFile} onSelectFile={commitSelection} />`. Passing `effectiveFiles` (not raw `files`) is what prevents stale old-repo rows from being rendered or clickable during a cwd switch — a manual click on a stale row was the last path that could slip through the render-time selection guard. Existing `ChangedFilesList.test.tsx` cases need updates to pass the new prop shape and assert MM/AM disambiguation (see Tests).
+
+`DiffPanelContent` already uses `useGitStatus(cwd)` internally; flip its call to `useGitStatus(cwd, { watch: true })` so the drawer view also stays live. The per-cwd refcount in the backend watcher means the sidebar and the drawer both subscribing on the same active-session cwd produces two independent refcount increments on the same key — one notify handle shared, clean teardown when either unmounts.
+
+## UI states
+
+| State                                          | Rendering                                                                                                                                                                                                                                                                                                    |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Agent inactive                                 | Panel collapses to 0px width (existing behavior). `useGitStatus` is mounted with `enabled: false` so no watcher starts, no IPC fires, no background work happens.                                                                                                                                            |
+| Agent active, first fetch in flight            | Section body shows "Loading…" (neutral text, not a spinner — xterm already has motion in the terminal zone).                                                                                                                                                                                                 |
+| Agent active, cwd has no `.git/` yet           | `git_status` returns `Ok(vec![])` via the non-repo pre-check → panel shows the zero-changes empty state, not the error state. Watcher is already running; once `git init` creates `.git/`, the next event triggers a refresh.                                                                                |
+| Agent active, fetch error, no rows yet         | Section body shows the error message in `text-error` with a Retry button wired to `useGitStatus().refresh()`.                                                                                                                                                                                                |
+| Agent active, fetch error, rows already loaded | Row list stays (stale); a compact `role="alert"` banner appears **above** the rows showing `Refresh failed: {message}` with a Retry button. Banner visibility follows `useGitStatus().error` — clears when the next retry starts (brief flash during the loading window), and reappears if that retry fails. |
+| Agent active, zero changes                     | Header reads `FILES CHANGED 0`. Expanded body shows "No uncommitted changes" in `text-on-surface-variant`.                                                                                                                                                                                                   |
+| Agent active, N changes                        | Rows as in the After mockup: prefix glyph · truncated path · `+N / -N` badge · status badge. Order: staged first, then unstaged; stable sort by path within each group.                                                                                                                                      |
+
+## Tests
+
+Co-located `.test.tsx` / `.test.ts` beside each file, per project convention. TDD-style — failing test first for each unit.
+
+### Backend (`cargo test`)
+
+- `git/mod.rs`
+  - `parse_numstat` — `-z` format parser: non-rename record (`<ins>\t<del>\t<path>\0`), rename record (`<ins>\t<del>\t\0<src>\0<dst>\0` → keyed on dst), binary record (`-\t-\t...` → skipped), multiple records in one buffer, empty input
+  - `parse_numstat` brace-format regression — the parser is fed a plain (non-`-z`) output containing `src/{A.tsx => B.tsx}` and asserts we do NOT silently match the wrong path (the parser assumes `-z` input; the assertion documents the contract)
+  - `parse_git_status` MM/AM dual-entry — input `"MM foo.ts\0"` produces two entries with the same `path` and opposite `staged` flags; same for `AM bar.ts\0`
+  - `git_status` integration — end-to-end test on a `tempdir` git repo with staged + unstaged + binary files + an MM file + a rename, asserting the MM file appears as two entries each with their own numstat from the matching map
+  - `git_status` resolves repo root — tempdir layout `repo/.git/ + repo/sub/foo.ts (modified)`; calling `git_status(cwd = repo/sub)` returns the modified file just like `cwd = repo` would; calling `git_status(cwd = /tmp/not-a-repo)` returns `Ok(vec![])`
+  - `git_status` non-repo — cwd outside any repo returns `Ok(vec![])` (not an error)
+  - `git_status` timeout — one subprocess times out → whole call returns error (no partial data)
+  - `get_git_diff` resolves repo root — same tempdir layout as above; calling `get_git_diff(cwd = repo/sub, file = "sub/foo.ts", staged = false)` returns a populated `FileDiff.hunks` (not empty), matching what `cwd = repo` would return
+  - `get_git_diff` non-repo — `cwd` outside any repo returns a `FileDiff` with empty `hunks` (not an error)
+- `git/watcher.rs`
+  - `GitWatcherState` subscribers per toplevel, keyed by cwd with a **refcount** — calling `start_git_watcher` with `cwd=repo/src/a` and again with `cwd=repo/src/b` stores both cwds as separate keys each with refcount 1; `stop_git_watcher(repo/src/a)` removes that key but leaves the watcher live with the `/repo/src/b` subscriber; a second stop drops the entry.
+  - **Same-cwd refcount (the sidebar + drawer case)**: calling `start_git_watcher("/repo")` twice stores one key with refcount 2; `stop_git_watcher("/repo")` decrements to 1 — watcher stays live (the sidebar is still mounted); a second stop drops to 0, the key is removed, the empty subscribers map triggers teardown of notify handles. This is the regression test for the HashSet-dedup bug that would have torn the watcher down on the first unmount.
+  - **Same-cwd refcount for pre-repo entries**: calling `start_git_watcher("/tmp/scaffold")` twice (non-repo) bumps `pre_repo_watchers["/tmp/scaffold"].refcount` to 2; a single `stop` decrements to 1, entry stays; second `stop` drops.
+  - Event fan-out — when the watcher fires (notify event or polling), the emitted `git-status-changed` payload has `cwds: ["repo/src/a", "repo/src/b"]` containing every current subscriber, not just one. Unsubscribing mid-debounce removes the cwd from the next snapshot.
+  - Debounce: 10 rapid writes produce ≤ 2 emitted events within a 1s window
+  - Initial fire: `start_git_watcher` emits one event before returning, with the input cwd in the singleton `cwds` array
+  - Pre-repo handle: `start_git_watcher` on a non-repo dir succeeds and stores a `pre_repo_watchers[cwd]` entry whose only live component is the 10s polling thread. No notify watches are registered yet.
+  - Auto-upgrade on `git init`: starting from the pre-repo state above, running `git init` in the dir is detected by the poller on its next 10s tick. The entry moves from `pre_repo_watchers` to `repo_watchers[toplevel].subscribers`, the notify registrations come up (filtered walk + `.git/index` + `.git/HEAD`), and a `git-status-changed { cwds: [input_cwd] }` event fires.
+  - Ignored subtrees are not watched — a tempdir with `.gitignore` excluding `ignored/` should register zero watch slots under `ignored/`, even if the directory has many files (probe via `notify::Watcher::watch()` being called only with non-ignored paths — mock out the notify crate for this)
+  - Dynamic directory registration — a `mkdir src/new_subdir` under the watched tree triggers a new `NonRecursive` registration for that path (observable via the mocked watcher)
+  - Polling fallback: with the notify watcher stubbed out, a manual OID change still produces an event within 15s
+
+### Frontend (Vitest + Testing Library)
+
+- `FilesChanged.test.tsx`
+  - **Default expanded**: with one or more files, the body is visible on initial mount without a user click (`defaultExpanded={true}` passthrough). Compare against `CollapsibleSection`'s isolated default to guard against the default ever flipping back.
+  - Empty state (loading=false, error=null, files=[]) → "No uncommitted changes" rendered
+  - **Loading with empty files** (loading=true, files=[]) → "Loading…" body rendered, no Retry button
+  - **Loading with populated files** (loading=true, files=[A, B]) → rows A and B still render (stale list preserved across refreshes); no Loading body
+  - **Error with no rows** (error=Error, files=[]) → error message rendered with Retry button; clicking Retry calls `onRetry`
+  - **Error with stale rows** (error=Error, files=[A, B]) → rows A and B still render; a `role="alert"` banner appears above the row list with the error message and a Retry button; clicking Retry calls `onRetry`. When the prop flips (error=null, files=[A, B]) the banner disappears while the rows remain. When the prop flips again (error=Error, files=[A, B]) the banner reappears. This mirrors how `useGitStatus` resets `error` at retry-start.
+  - Populated → each `ChangedFile` renders prefix, path, status badge
+  - `insertions` / `deletions` present → `+N / -N` rendered; absent → badge omitted
+  - Click a row → `onSelect(file)` fires with the full `ChangedFile` (not just the path)
+  - MM/AM pair → two entries with the same `path` and opposite `staged` render as two distinct rows, the staged row carries the `STAGED` label, the unstaged row does not, and each click routes with the correct `staged` value
+- `useGitStatus.test.ts`
+  - Non-watch mode: existing tests still pass
+  - Watch mode: mount calls `start_git_watcher` invoke; incoming event with `cwds` including myCwd triggers refresh; incoming event whose `cwds` does NOT include myCwd is ignored; unmount calls `stop_git_watcher`
+  - **Mount ordering (race-free)**: `listen('git-status-changed', ...)` resolves BEFORE `invoke('start_git_watcher', ...)` is called; after both complete, an explicit third `refresh()` fires. Verified via mock call-order assertions on listen/invoke; a mid-sequence synthetic event (fired after listen attach but before start_git_watcher returns) is caught by the handler.
+  - **Unmount ordering**: `unlisten()` is called before `invoke('stop_git_watcher', ...)` so a late in-flight event can't call refresh on a torn-down hook.
+  - Shared-watcher fan-out: two hooks at `/repo/src/a` and `/repo/src/b` both refresh when a single event with `cwds: ["/repo/src/a", "/repo/src/b"]` arrives
+  - **`filesCwd` freshness tracking**: mount with `cwd="/a"` → before first fetch resolves, `filesCwd` is `null`; after resolve, `filesCwd === "/a"`. Change `cwd` to `/b` → during the in-flight fetch for `/b`, `filesCwd` is still `"/a"` (the last successful cwd); after `/b`'s fetch resolves, `filesCwd === "/b"`. If `/b`'s fetch fails, `filesCwd` remains `"/a"` (only success updates it).
+  - `enabled: false` — hook returns `{ files: [], filesCwd: null, loading: false, error: null, refresh }` with no invoke and no listener attach; flipping `enabled` to `true` starts the watcher; flipping back to `false` tears it down
+- `ChangedFilesList.test.tsx` (update existing cases for new prop shape)
+  - Existing selection tests: swap `selectedPath: "foo.ts"` for `selectedFile: { path: "foo.ts", staged: false }`; `onSelectFile` receives the full `ChangedFile`
+  - **MM/AM disambiguation**: with `files = [{ path: "foo.ts", staged: true, ... }, { path: "foo.ts", staged: false, ... }]` and `selectedFile = { path: "foo.ts", staged: true }` → only the staged row has the active style; clicking the unstaged row fires `onSelectFile` with its `staged: false` file
+  - **Row keys are unique across MM/AM pairs**: rendering an MM pair produces two distinct React keys (no duplicate-key warning in the test console)
+- `AgentStatusPanel.test.tsx`
+  - With `sessionId` and `cwd`, renders `FilesChanged` with files from the mocked `useGitStatus`
+  - Click a file bubbles to `onOpenDiff` with the full `ChangedFile` (path, status, and `staged` flag preserved so the MM/AM routing works)
+  - When `sessionId` is null, renders nothing (preserve collapsed-width existing behavior)
+  - When `status.isActive === false`, `useGitStatus` is mounted with `enabled: false` (assert via the mocked hook receiving the option)
+  - **Stale filesCwd renders loading, not old rows**: mock `useGitStatus` returns `{ files: [A, B], filesCwd: '/old', loading: false, error: null }` while the component's `cwd` prop is `/new` → `FilesChanged` is passed `loading: true` and `files: []` (not the stale rows). Once the mock flips to `filesCwd: '/new'`, the real rows flow through.
+  - **Cwd-change fetch failure still reaches error state**: mock `useGitStatus` returns `{ files: [], filesCwd: '/old', loading: false, error: Error('boom') }` while the component's `cwd` prop is `/new` → `FilesChanged` is passed `loading: false`, `files: []`, and the error; the error + Retry body renders (not the Loading body). Guards against the `filesCwd`-is-last-success-marker footgun where a failed initial fetch or failed post-cwd-change fetch would otherwise be hidden behind a permanent loading state.
+- `WorkspaceView.integration.test.tsx`
+  - Clicking a file in the sidebar panel switches `BottomDrawer` to the diff tab AND `DiffPanelContent` shows that file
+  - Clicking a file while the drawer is collapsed also **uncollapses** it (drawer height > 48px after the click)
+  - Clicking the **staged** half of an MM/AM pair opens `DiffPanelContent` with `staged=true` (verified via the mocked `useFileDiff` receiving `staged: true` in its args); clicking the unstaged half opens it with `staged: false`
+  - **Session-switch selection reset**: open a file, then switch active session (cwd changes) → `selectedDiffFile` is cleared (belt-and-suspenders effect in `WorkspaceView`); `bottomDrawerTab` and `isBottomDrawerCollapsed` are **not** cleared (layout prefs persist)
+  - **Render-time cwd guard (primary fix for stale diff request)**: set up `DiffPanelContent` with `selectedFile = { path: 'a/foo.ts', staged: false, cwd: '/repo/a' }`, re-render with a new `cwd = '/repo/b'` prop (and the stale selection still passed in for this render — simulating the single render between a cwd change and the parent's cleanup effect). Assert that on that render, the mocked `useFileDiff` is called with `filePath: null`, not `'a/foo.ts'`. This is the core assertion closing the HIGH finding on render-time staleness.
+  - **Auto-select gated on `filesCwd === cwd` (follow-up fix)**: configure the `useGitStatus` mock to return `{ files: [A, B], filesCwd: '/repo/a', loading: false }` while the component's `cwd` prop is `/repo/b` (simulating "cwd already changed, old files still in place, no loading flag yet"). Assert that the auto-select effect does **not** call `onSelectedFileChange` during this render. Then advance the mock to `{ files: [C, D], filesCwd: '/repo/b', loading: false }` and assert auto-select now commits `{ path: C.path, staged: C.staged, cwd: '/repo/b' }`. This is the test the reviewer specifically asked for — switching cwd while old rows are still present and loading is false.
+  - **Stale rows are not rendered or clickable (manual-click regression)**: same setup as above (`filesCwd: '/repo/a'`, `cwd: '/repo/b'`, `loading: false`). Assert `ChangedFilesList` is rendered with `files={[]}` — no row for `A` or `B` is in the DOM, so the user cannot click one. Then simulate a `fireEvent.click` against a hypothetical stale-row selector and assert nothing changes (no call to `onSelectedFileChange`, no IPC fires via the mocked `useFileDiff`). Guards the path the reviewer flagged: even if the user were fast enough to click mid-transition, there are no stale rows to click.
+  - **Auto-select after refresh**: with a stale selection ignored (because cwd mismatch), the auto-select-first effect should fire once `useGitStatus` returns `files` for the new cwd; `DiffPanelContent` calls `onSelectedFileChange` with `{ path, staged, cwd: newCwd }` (tagged with the new cwd).
+  - **commitSelection tags with current cwd**: click a file inside `DiffPanelContent` while `cwd = '/repo/b'` → `onSelectedFileChange` receives `{ path, staged, cwd: '/repo/b' }`, not a plain `{ path, staged }`.
+  - **Stale-selection invalidation via refresh (commit/revert)**: with selection pinned and tagged for the current cwd, simulate a `useGitStatus` refresh whose new `files` no longer contains that selection → `DiffPanelContent` calls `onSelectedFileChange` with the first remaining file (or `null` if empty). This is the same-cwd analogue of the cwd-guard test.
+  - **Uncontrolled fallback**: mount `DiffPanelContent` without `selectedFile`/`onSelectedFileChange` props → auto-select-first still happens (via local state, with local selection tagged with the current cwd); committing a selected file out of `files` still triggers a re-select via local setter.
+  - **Uncontrolled cwd guard**: in uncontrolled mode, click a file at `cwd = '/repo/a'`; change the `cwd` prop to `/repo/b`. On the render under the new cwd, `useFileDiff` observed to be called with `filePath: null` (render-time guard hides the old selection); the subsequent auto-select-first effect re-selects against `/repo/b`'s `files` once they arrive.
+  - **Untracked file regression guard**: with `files = [{ path: "new.ts", status: "untracked", ... }]` and the row selected, `DiffPanelContent` renders the existing "New file — not yet tracked" placeholder (not `DiffViewer`, not an error). `useFileDiff` is called with `filePath: "new.ts"` per the existing pattern, but the render branch on `selectedFileIsUntracked` short-circuits to the placeholder. Matches `DiffPanelContent.tsx:124-132`'s current behavior.
+
+## Dependencies added
+
+- Rust: `ignore = "0.4"` (new Cargo dep)
+- npm: none
+
+## Out of scope
+
+- **`ChangedFile` dual-flag rewrite** — this spec emits two `ChangedFile` entries for MM/AM paths to represent both halves without changing the type. A richer single-record representation (e.g. `{ staged: { ins, del }, unstaged: { ins, del } }` on one entry, eliminating the row duplication) is the subject of [`2026-04-11-mm-staged-unstaged-design.md`](./2026-04-11-mm-staged-unstaged-design.md) and can land separately. The dual-entry approach here is correct but visually duplicates the path for MM/AM rows; the future rewrite would collapse them into one row with both numstats on it.
+- Staging / unstaging from the panel — needs `stage_file` / `unstage_file` Tauri commands
+- Per-session "base SHA" filter ("since session start") — user picked full uncommitted state
+- Changing the footer `+N / -N` to git-sourced numbers (stays agent-sourced on purpose)
+- Cross-cwd aggregation (watcher is per-cwd; no "all repos" view)
+- Honoring `.ignore` (ripgrep-specific) — v1 honors `.gitignore` + `.git/info/exclude` + nested gitignores via the `ignore` crate's defaults
+- Diff line highlighting / word-level diff — `DiffViewer` already does what it does
+- Surfacing a "new commit" notification when `.git/HEAD` changes — the watcher fires `git-status-changed`, the refresh clears the list, done
+- `TestResults` wiring — placeholder stays placeholder; separate feature

--- a/harness/cli_client.py
+++ b/harness/cli_client.py
@@ -20,6 +20,16 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 
+# asyncio's StreamReader defaults to a 64 KB line buffer. `claude -p` emits
+# one stream-JSON message per line, and a single tool result (e.g. Read of
+# a long markdown spec, ls -la of a deep tree, or a big git log) can easily
+# exceed that and crash the parser with
+# `LimitOverrunError: Separator is not found, and chunk exceed the limit`.
+# 10 MB is generous enough to cover any realistic single message without
+# letting a runaway process chew unbounded memory before the pipe closes.
+STREAM_BUFFER_LIMIT = 10 * 1024 * 1024
+
+
 @dataclass
 class TextBlock:
     text: str
@@ -198,6 +208,7 @@ class ClaudeCliSession:
             cwd=str(self.project_dir),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            limit=STREAM_BUFFER_LIMIT,
         )
         # Set _started after a successful spawn. If create_subprocess_exec
         # raises (e.g. `claude` not on PATH), the flag stays False and a

--- a/harness/test_cli_client.py
+++ b/harness/test_cli_client.py
@@ -190,6 +190,73 @@ def test_query_drains_stderr_without_deadlock(tmp_path, monkeypatch):
     assert len(result_events) == 1 and not result_events[0].is_error
 
 
+def test_query_reads_stream_lines_over_64kb(tmp_path, monkeypatch):
+    """A single stream-JSON line larger than asyncio's default 64 KB
+    StreamReader limit must not crash the parser.
+
+    Pre-fix: create_subprocess_exec used the default `limit` of 64 KB,
+    so reading any tool result that serialized to a line bigger than
+    that raised `LimitOverrunError: Separator is not found, and chunk
+    exceed the limit`. This happened in practice when the initializer
+    Read-tool result for a long markdown spec came back as one JSON
+    line. Post-fix: we pass `limit=STREAM_BUFFER_LIMIT` (10 MB) so the
+    parser can absorb realistic single-message payloads.
+
+    Stubs _build_args to a Python one-liner that emits one JSON line
+    containing a ~500 KB text block, followed by a normal result line.
+    """
+    import asyncio
+    import sys
+
+    settings = tmp_path / "settings.json"
+    settings.write_text("{}")
+    session = ClaudeCliSession(
+        role="big-line",
+        project_dir=tmp_path,
+        model="claude-sonnet-4-5-20250929",
+        settings_path=settings,
+        allowed_tools=["Read"],
+    )
+
+    # 500 KB — well above the old 64 KB ceiling, well under the new 10 MB.
+    # Emit as an assistant text block so the parser has something concrete
+    # to yield; then a normal result line.
+    payload = (
+        "import json,sys\n"
+        "msg = {\"type\": \"assistant\", \"message\": {\"content\": ["
+        "{\"type\": \"text\", \"text\": \"X\" * 500_000}"
+        "]}}\n"
+        "print(json.dumps(msg))\n"
+        "print('{\"type\":\"result\",\"subtype\":\"success\","
+        "\"session_id\":\"x\",\"is_error\":false}')\n"
+        "sys.exit(0)"
+    )
+    monkeypatch.setattr(
+        session,
+        "_build_args",
+        lambda prompt, resume: [sys.executable, "-c", payload],
+    )
+
+    async def run():
+        events = []
+        async for event in session.query("ignored"):
+            events.append(event)
+        return events
+
+    events = asyncio.run(asyncio.wait_for(run(), timeout=10))
+
+    # We should get one AssistantMessage (the big text) and one ResultEvent.
+    # Pre-fix, this raised LimitOverrunError before either event was yielded.
+    assistant_events = [e for e in events if isinstance(e, AssistantMessage)]
+    result_events = [e for e in events if isinstance(e, ResultEvent)]
+    assert len(assistant_events) == 1
+    assert len(result_events) == 1 and not result_events[0].is_error
+
+    # Sanity-check the payload actually round-tripped at its full size.
+    assert isinstance(assistant_events[0].content[0], TextBlock)
+    assert len(assistant_events[0].content[0].text) == 500_000
+
+
 def test_query_times_out_on_stalled_subprocess(tmp_path, monkeypatch):
     """A `claude -p` that never closes stdout (network hang / auth expiry
     mid-stream) must NOT hang the harness forever. Pre-fix: query() had

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ tauri-plugin-log = "2"
 portable-pty = "0.8"
 anyhow = "1.0"
 thiserror = "2.0"
-tokio = { version = "1", features = ["sync", "io-util", "time", "rt"] }
+tokio = { version = "1", features = ["sync", "io-util", "time", "rt", "macros"] }
 notify = "6"
 dirs = "6"
 ignore = "0.4"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "2.0"
 tokio = { version = "1", features = ["sync", "io-util", "time", "rt"] }
 notify = "6"
 dirs = "6"
+ignore = "0.4"
 
 [features]
 e2e-test = []

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -643,6 +643,71 @@ pub async fn git_status(cwd: String) -> Result<Vec<ChangedFile>, String> {
     Ok(files)
 }
 
+/// Check whether a repo-relative file path is untracked under the given
+/// toplevel. Uses `git ls-files --error-unmatch`: exit 0 = tracked, non-zero
+/// = untracked (or the path doesn't exist, or some other git error — all
+/// treated as "not tracked" which is the safe fallback for the caller).
+async fn is_file_untracked(toplevel: &Path, file: &str) -> Result<bool, String> {
+    let mut cmd = Command::new("git");
+    cmd.arg("-C")
+        .arg(toplevel)
+        .arg("ls-files")
+        .arg("--error-unmatch")
+        .arg("--")
+        .arg(file)
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    let output = run_git_with_timeout(cmd).await?;
+    Ok(!output.status.success())
+}
+
+/// Platform-portable path to the null device for `git diff --no-index`.
+/// On Unix this is `/dev/null`; on Windows, `NUL`. Git accepts both on
+/// their respective platforms but not cross-platform, so cfg-dispatch.
+#[cfg(windows)]
+const NULL_DEVICE: &str = "NUL";
+#[cfg(not(windows))]
+const NULL_DEVICE: &str = "/dev/null";
+
+/// Run `git diff --no-index /dev/null <file>` to synthesize an "all new"
+/// diff for an untracked file. The regular `git diff -- <file>` produces
+/// empty output for untracked paths (git won't diff against the index
+/// because the file isn't in it), which made the diff viewer unable to
+/// show content for new-but-not-yet-staged files. This fallback shows the
+/// full file content as one big set of added lines.
+///
+/// `git diff --no-index` exits 0 when files are identical, 1 when they
+/// differ (expected here since the comparison is against an empty file),
+/// and other codes for genuine errors.
+async fn get_untracked_diff(toplevel: &Path, file: &str) -> Result<String, String> {
+    let file_abs = toplevel.join(file);
+
+    let mut cmd = Command::new("git");
+    cmd.arg("-C")
+        .arg(toplevel)
+        .arg("diff")
+        .arg("--no-index")
+        .arg("--no-color")
+        .arg("--")
+        .arg(NULL_DEVICE)
+        .arg(&file_abs)
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    let output = run_git_with_timeout(cmd).await?;
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    if exit_code != 0 && exit_code != 1 {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(if stderr.trim().is_empty() {
+            format!("git diff --no-index failed with exit code {}", output.status)
+        } else {
+            format!("git diff --no-index failed: {}", stderr.trim())
+        });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 /// Tauri command: Get diff for a specific file
 #[tauri::command]
 pub async fn get_git_diff(cwd: String, file: String, staged: bool) -> Result<FileDiff, String> {
@@ -702,7 +767,27 @@ pub async fn get_git_diff(cwd: String, file: String, staged: bool) -> Result<Fil
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(parse_git_diff(&stdout, &file))
+    let parsed = parse_git_diff(&stdout, &file);
+
+    // Fallback for untracked files: the regular `git diff -- <file>`
+    // produces empty output because untracked paths aren't in the index.
+    // When that's the case AND we're asking for the working-tree side
+    // (staged == false), try `git diff --no-index /dev/null <file>` to
+    // synthesize a full-content diff so the viewer can show it as "all
+    // new lines" instead of a blank pane.
+    //
+    // Skipped for staged == true: staged new files show up as status "A"
+    // and `git diff --cached -- <file>` already produces correct output
+    // for them. Only the untracked (status "??") path needs the fallback.
+    if parsed.hunks.is_empty()
+        && !staged
+        && is_file_untracked(&canonical_toplevel, &file).await?
+    {
+        let untracked_stdout = get_untracked_diff(&canonical_toplevel, &file).await?;
+        return Ok(parse_git_diff(&untracked_stdout, &file));
+    }
+
+    Ok(parsed)
 }
 
 #[cfg(test)]
@@ -1240,5 +1325,55 @@ mod tests {
         let diff = result.unwrap();
         assert_eq!(diff.file_path, "foo.txt");
         assert_eq!(diff.hunks.len(), 0, "non-repo should return empty hunks");
+    }
+
+    #[tokio::test]
+    async fn test_get_git_diff_untracked_file_returns_all_added() {
+        // An untracked file (never staged, never committed) produces zero
+        // output from plain `git diff -- <file>`. The fallback via
+        // `git diff --no-index /dev/null <file>` should synthesize a diff
+        // where every line of the file content appears as a DiffLineType::Added.
+        use std::fs;
+        use std::process::Command;
+
+        let tmp = home_tempdir();
+        let repo_path = tmp.path();
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git init failed");
+
+        // Create an untracked file — do NOT `git add` it.
+        let untracked = repo_path.join("untracked.txt");
+        fs::write(&untracked, "alpha\nbeta\ngamma\n").expect("failed to write");
+
+        let repo_str = repo_path.to_string_lossy().to_string();
+        let result = get_git_diff(repo_str, "untracked.txt".to_string(), false).await;
+
+        assert!(
+            result.is_ok(),
+            "get_git_diff on untracked file should succeed (fallback to --no-index)"
+        );
+        let diff = result.unwrap();
+        assert_eq!(diff.file_path, "untracked.txt");
+        assert_eq!(
+            diff.hunks.len(),
+            1,
+            "untracked file should produce one hunk (whole-file)"
+        );
+
+        let hunk = &diff.hunks[0];
+        assert_eq!(hunk.lines.len(), 3, "three lines of content");
+        for line in &hunk.lines {
+            assert!(
+                matches!(line.line_type, DiffLineType::Added),
+                "every line of an untracked file should be Added"
+            );
+        }
+        assert_eq!(hunk.lines[0].content, "alpha");
+        assert_eq!(hunk.lines[1].content, "beta");
+        assert_eq!(hunk.lines[2].content, "gamma");
     }
 }

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -578,12 +578,18 @@ pub async fn git_status(cwd: String) -> Result<Vec<ChangedFile>, String> {
         .arg("-z")
         .env("GIT_TERMINAL_PROMPT", "0");
 
-    // Run status and both diff commands (diffs in parallel)
-    let status_output = run_git_with_timeout(status_cmd).await?;
+    // Run status + both diff commands in parallel. The three subprocesses
+    // are independent; the earlier revision awaited status serially before
+    // the diffs, adding unnecessary latency to every watcher-triggered
+    // refresh. With all three in one `join!`, wall-clock time is the max
+    // of the three rather than the sum of one + max of two.
+    let (status_output, diff_output, cached_diff_output) = tokio::join!(
+        run_git_with_timeout(status_cmd),
+        run_git_with_timeout(diff_cmd),
+        run_git_with_timeout(cached_diff_cmd),
+    );
 
-    let (diff_output, cached_diff_output) =
-        tokio::join!(run_git_with_timeout(diff_cmd), run_git_with_timeout(cached_diff_cmd));
-
+    let status_output = status_output?;
     let diff_output = diff_output?;
     let cached_diff_output = cached_diff_output?;
 

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -897,6 +897,23 @@ mod tests {
             .expect("failed to create temp dir under $HOME")
     }
 
+    /// Configure `user.email` and `user.name` on a fresh git repo so
+    /// `git commit` doesn't fail on CI runners without a global git
+    /// config. Call this after `git init`, before any `git commit`.
+    fn configure_test_git(repo_path: &std::path::Path) {
+        use std::process::Command;
+        for (key, val) in &[
+            ("user.email", "test@example.com"),
+            ("user.name", "Test User"),
+        ] {
+            Command::new("git")
+                .args(["config", key, val])
+                .current_dir(repo_path)
+                .output()
+                .expect("git config failed");
+        }
+    }
+
     // parse_numstat tests
 
     #[test]
@@ -1252,12 +1269,13 @@ mod tests {
         let tmp = home_tempdir();
         let repo_path = tmp.path();
 
-        // Initialize git repo
+        // Initialize git repo and configure so commits work on CI runners
         Command::new("git")
             .args(["init"])
             .current_dir(repo_path)
             .output()
             .expect("git init failed");
+        configure_test_git(repo_path);
 
         // Create and commit initial file
         let file = repo_path.join("test.txt");
@@ -1269,11 +1287,16 @@ mod tests {
             .output()
             .expect("git add failed");
 
-        Command::new("git")
+        let commit_out = Command::new("git")
             .args(["commit", "-m", "initial"])
             .current_dir(repo_path)
             .output()
             .expect("git commit failed");
+        assert!(
+            commit_out.status.success(),
+            "git commit must succeed: {}",
+            String::from_utf8_lossy(&commit_out.stderr)
+        );
 
         // Modify and stage (adds line 3)
         fs::write(&file, "line 1\nline 2\nline 3\n").expect("failed to write");
@@ -1357,6 +1380,8 @@ mod tests {
             .expect("git init failed");
 
         // Create subdirectory
+        configure_test_git(repo_path);
+
         let subdir = repo_path.join("sub");
         fs::create_dir(&subdir).expect("failed to create subdir");
 
@@ -1370,11 +1395,16 @@ mod tests {
             .output()
             .expect("git add failed");
 
-        Command::new("git")
+        let commit_out = Command::new("git")
             .args(["commit", "-m", "initial"])
             .current_dir(repo_path)
             .output()
             .expect("git commit failed");
+        assert!(
+            commit_out.status.success(),
+            "git commit must succeed: {}",
+            String::from_utf8_lossy(&commit_out.stderr)
+        );
 
         // Modify the file
         fs::write(&file_path, "line 1\nline 2\nline 3\n").expect("failed to write");

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -646,13 +646,34 @@ pub async fn git_status(cwd: String) -> Result<Vec<ChangedFile>, String> {
     // `git diff --no-index /dev/null <file>` so the sidebar `+N / -0`
     // badge reflects the file's actual line count. Skips binary files
     // (helper returns None) so they stay badge-less.
-    for file in &mut files {
-        if matches!(file.status, ChangedFileStatus::Untracked) {
-            if let Ok(Some((insertions, deletions))) =
-                get_untracked_numstat(&canonical_toplevel, &file.path).await
-            {
-                file.insertions = Some(insertions);
-                file.deletions = Some(deletions);
+    //
+    // Parallelized via `tokio::task::JoinSet` — a repo with many untracked
+    // files (freshly scaffolded, post-`git stash pop`, etc.) would
+    // serialize as ~5-15 ms per subprocess, producing seconds of latency
+    // on every watcher-triggered refresh. JoinSet runs them concurrently
+    // with no explicit cap; Tokio's blocking pool and the OS's fork/spawn
+    // throughput naturally gate the concurrency.
+    let untracked_indices: Vec<(usize, String)> = files
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| matches!(f.status, ChangedFileStatus::Untracked))
+        .map(|(i, f)| (i, f.path.clone()))
+        .collect();
+
+    if !untracked_indices.is_empty() {
+        let mut set = tokio::task::JoinSet::new();
+        for (idx, path) in untracked_indices {
+            let toplevel = canonical_toplevel.clone();
+            set.spawn(async move {
+                let counts = get_untracked_numstat(&toplevel, &path).await.ok().flatten();
+                (idx, counts)
+            });
+        }
+
+        while let Some(join_result) = set.join_next().await {
+            if let Ok((idx, Some((insertions, deletions)))) = join_result {
+                files[idx].insertions = Some(insertions);
+                files[idx].deletions = Some(deletions);
             }
         }
     }

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -637,7 +637,24 @@ pub async fn git_status(cwd: String) -> Result<Vec<ChangedFile>, String> {
                 file.deletions = Some(*deletions);
             }
         }
-        // Leave None for untracked or binary files
+        // Untracked rows need a separate pass (see below) — the two numstat
+        // maps above don't include them because untracked paths aren't in
+        // the index.
+    }
+
+    // Second pass: synthesize numstat for untracked files via
+    // `git diff --no-index /dev/null <file>` so the sidebar `+N / -0`
+    // badge reflects the file's actual line count. Skips binary files
+    // (helper returns None) so they stay badge-less.
+    for file in &mut files {
+        if matches!(file.status, ChangedFileStatus::Untracked) {
+            if let Ok(Some((insertions, deletions))) =
+                get_untracked_numstat(&canonical_toplevel, &file.path).await
+            {
+                file.insertions = Some(insertions);
+                file.deletions = Some(deletions);
+            }
+        }
     }
 
     Ok(files)
@@ -706,6 +723,78 @@ async fn get_untracked_diff(toplevel: &Path, file: &str) -> Result<String, Strin
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Run `git diff --no-index --numstat -z /dev/null <file>` to get numstat
+/// counts for an untracked file. Returns `Some((insertions, deletions))`
+/// for a text file (deletions is always 0 for an all-new file), `None`
+/// for binary files or on any soft failure (caller treats it as "no
+/// numstat available" and leaves the sidebar badge off).
+///
+/// Invoked per untracked file from `git_status`. The regular `git diff
+/// --numstat` run from `git_status` doesn't see untracked paths because
+/// they aren't in the index, so without this fallback the sidebar
+/// `+N / -N` badge would never render for untracked rows — even though
+/// the row click now successfully shows the full-content diff in the
+/// viewer via `get_untracked_diff`.
+async fn get_untracked_numstat(
+    toplevel: &Path,
+    file: &str,
+) -> Result<Option<(u32, u32)>, String> {
+    let file_abs = toplevel.join(file);
+
+    let mut cmd = Command::new("git");
+    cmd.arg("-C")
+        .arg(toplevel)
+        .arg("diff")
+        .arg("--no-index")
+        .arg("--numstat")
+        .arg("-z")
+        .arg("--")
+        .arg(NULL_DEVICE)
+        .arg(&file_abs)
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    let output = run_git_with_timeout(cmd).await?;
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    // Exit 1 is normal for --no-index when files differ.
+    // Exit 0 means they were identical (empty untracked file vs /dev/null).
+    // Anything else is a genuine error; soft-fail rather than poisoning the
+    // whole git_status response.
+    if exit_code != 0 && exit_code != 1 {
+        return Ok(None);
+    }
+
+    // First record has shape `<ins>\t<del>\t<path>\0`. We only care about the
+    // first two fields; the path is the absolute one we passed in so there's
+    // nothing useful to parse from it.
+    let first_record: &[u8] = output
+        .stdout
+        .split(|&b| b == b'\0')
+        .next()
+        .unwrap_or(&[]);
+    let parts: Vec<&[u8]> = first_record.split(|&b| b == b'\t').collect();
+
+    if parts.len() < 2 {
+        return Ok(None);
+    }
+
+    let ins_str = String::from_utf8_lossy(parts[0]);
+    let del_str = String::from_utf8_lossy(parts[1]);
+
+    // Binary files report `-\t-\t<path>`.
+    if ins_str == "-" || del_str == "-" {
+        return Ok(None);
+    }
+
+    let insertions = ins_str.parse::<u32>().ok();
+    let deletions = del_str.parse::<u32>().ok();
+
+    match (insertions, deletions) {
+        (Some(i), Some(d)) => Ok(Some((i, d))),
+        _ => Ok(None),
+    }
 }
 
 /// Tauri command: Get diff for a specific file
@@ -1325,6 +1414,53 @@ mod tests {
         let diff = result.unwrap();
         assert_eq!(diff.file_path, "foo.txt");
         assert_eq!(diff.hunks.len(), 0, "non-repo should return empty hunks");
+    }
+
+    #[tokio::test]
+    async fn test_git_status_untracked_file_has_line_count_numstat() {
+        // An untracked file should carry `insertions == <line count>` and
+        // `deletions == 0` so the sidebar `+N / -0` badge renders. Verifies
+        // the second-pass `git diff --no-index --numstat` synthesizer.
+        use std::fs;
+        use std::process::Command;
+
+        let tmp = home_tempdir();
+        let repo_path = tmp.path();
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git init failed");
+
+        // Create an untracked 4-line file.
+        let untracked = repo_path.join("fresh.txt");
+        fs::write(&untracked, "one\ntwo\nthree\nfour\n").expect("write failed");
+
+        let repo_str = repo_path.to_string_lossy().to_string();
+        let result = git_status(repo_str).await;
+
+        assert!(result.is_ok(), "git_status should succeed");
+        let files = result.unwrap();
+        let untracked_entry = files
+            .iter()
+            .find(|f| f.path == "fresh.txt")
+            .expect("untracked file should appear in status");
+
+        assert!(matches!(
+            untracked_entry.status,
+            ChangedFileStatus::Untracked
+        ));
+        assert_eq!(
+            untracked_entry.insertions,
+            Some(4),
+            "insertions should equal the file's line count"
+        );
+        assert_eq!(
+            untracked_entry.deletions,
+            Some(0),
+            "deletions should be 0 for an untracked file (nothing to remove)"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -517,27 +517,120 @@ fn parse_hunk_range(range: &str) -> (u32, u32) {
 pub async fn git_status(cwd: String) -> Result<Vec<ChangedFile>, String> {
     let safe_cwd = validate_cwd(&cwd)?;
 
-    let mut cmd = Command::new("git");
-    cmd.arg("-C")
+    // Resolve repo toplevel — if not in a repo, return empty list
+    let mut toplevel_cmd = Command::new("git");
+    toplevel_cmd
+        .arg("-C")
         .arg(&safe_cwd)
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    let toplevel_output = run_git_with_timeout(toplevel_cmd).await?;
+
+    if !toplevel_output.status.success() {
+        // Not a git repo — return empty list (no error state)
+        return Ok(vec![]);
+    }
+
+    let toplevel_str = String::from_utf8_lossy(&toplevel_output.stdout);
+    let toplevel_path = toplevel_str.trim();
+
+    // Canonicalize and validate toplevel is under $HOME
+    let canonical_toplevel = validate_cwd(toplevel_path)?;
+
+    // Run git status and numstat commands from toplevel
+    let mut status_cmd = Command::new("git");
+    status_cmd
+        .arg("-C")
+        .arg(&canonical_toplevel)
         .arg("status")
         .arg("--porcelain=v1")
         .arg("-z")
         .env("GIT_TERMINAL_PROMPT", "0");
 
-    let output = run_git_with_timeout(cmd).await?;
+    let mut diff_cmd = Command::new("git");
+    diff_cmd
+        .arg("-C")
+        .arg(&canonical_toplevel)
+        .arg("diff")
+        .arg("--numstat")
+        .arg("-z")
+        .env("GIT_TERMINAL_PROMPT", "0");
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    let mut cached_diff_cmd = Command::new("git");
+    cached_diff_cmd
+        .arg("-C")
+        .arg(&canonical_toplevel)
+        .arg("diff")
+        .arg("--cached")
+        .arg("--numstat")
+        .arg("-z")
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    // Run status and both diff commands (diffs in parallel)
+    let status_output = run_git_with_timeout(status_cmd).await?;
+
+    let (diff_output, cached_diff_output) =
+        tokio::join!(run_git_with_timeout(diff_cmd), run_git_with_timeout(cached_diff_cmd));
+
+    let diff_output = diff_output?;
+    let cached_diff_output = cached_diff_output?;
+
+    // Check all commands succeeded
+    if !status_output.status.success() {
+        let stderr = String::from_utf8_lossy(&status_output.stderr);
         return Err(if stderr.trim().is_empty() {
-            format!("git status failed with exit code {}", output.status)
+            format!("git status failed with exit code {}", status_output.status)
         } else {
             format!("git status failed: {}", stderr.trim())
         });
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(parse_git_status(&stdout))
+    if !diff_output.status.success() {
+        let stderr = String::from_utf8_lossy(&diff_output.stderr);
+        return Err(if stderr.trim().is_empty() {
+            format!("git diff failed with exit code {}", diff_output.status)
+        } else {
+            format!("git diff failed: {}", stderr.trim())
+        });
+    }
+
+    if !cached_diff_output.status.success() {
+        let stderr = String::from_utf8_lossy(&cached_diff_output.stderr);
+        return Err(if stderr.trim().is_empty() {
+            format!("git diff --cached failed with exit code {}", cached_diff_output.status)
+        } else {
+            format!("git diff --cached failed: {}", stderr.trim())
+        });
+    }
+
+    // Parse outputs
+    let status_stdout = String::from_utf8_lossy(&status_output.stdout);
+    let mut files = parse_git_status(&status_stdout);
+
+    let working_tree_stats = parse_numstat(&diff_output.stdout);
+    let cached_stats = parse_numstat(&cached_diff_output.stdout);
+
+    // Merge numstat data into ChangedFile entries
+    for file in &mut files {
+        if file.staged {
+            // Staged entries look up cached map
+            if let Some((insertions, deletions)) = cached_stats.get(&file.path) {
+                file.insertions = Some(*insertions);
+                file.deletions = Some(*deletions);
+            }
+        } else {
+            // Unstaged entries look up working-tree map
+            if let Some((insertions, deletions)) = working_tree_stats.get(&file.path) {
+                file.insertions = Some(*insertions);
+                file.deletions = Some(*deletions);
+            }
+        }
+        // Leave None for untracked or binary files
+    }
+
+    Ok(files)
 }
 
 /// Tauri command: Get diff for a specific file
@@ -546,9 +639,37 @@ pub async fn get_git_diff(cwd: String, file: String, staged: bool) -> Result<Fil
     let safe_cwd = validate_cwd(&cwd)?;
     validate_file_path(&file)?;
 
+    // Resolve repo toplevel — if not in a repo, return empty hunks
+    let mut toplevel_cmd = Command::new("git");
+    toplevel_cmd
+        .arg("-C")
+        .arg(&safe_cwd)
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    let toplevel_output = run_git_with_timeout(toplevel_cmd).await?;
+
+    if !toplevel_output.status.success() {
+        // Not a git repo — return empty FileDiff
+        return Ok(FileDiff {
+            file_path: file.clone(),
+            old_path: None,
+            new_path: None,
+            hunks: vec![],
+        });
+    }
+
+    let toplevel_str = String::from_utf8_lossy(&toplevel_output.stdout);
+    let toplevel_path = toplevel_str.trim();
+
+    // Canonicalize and validate toplevel is under $HOME
+    let canonical_toplevel = validate_cwd(toplevel_path)?;
+
+    // Run git diff from toplevel
     let mut cmd = Command::new("git");
     cmd.arg("-C")
-        .arg(&safe_cwd)
+        .arg(&canonical_toplevel)
         .arg("diff")
         .arg("--no-color")
         .env("GIT_TERMINAL_PROMPT", "0");
@@ -861,5 +982,239 @@ mod tests {
         assert_eq!(parse_hunk_range("+102,6"), (102, 6));
         assert_eq!(parse_hunk_range("-1,1"), (1, 1));
         assert_eq!(parse_hunk_range("+1"), (1, 1));
+    }
+
+    // Integration tests for git_status command (Feature 4)
+
+    #[tokio::test]
+    async fn test_git_status_subdir_cwd_returns_repo_level_changes() {
+        // Test that calling git_status from a subdirectory returns repo-level
+        // changes (via rev-parse --show-toplevel resolution)
+        use std::fs;
+        use std::process::Command;
+
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let repo_path = tmp.path();
+
+        // Initialize git repo
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git init failed");
+
+        // Create a subdirectory
+        let subdir = repo_path.join("src");
+        fs::create_dir(&subdir).expect("failed to create subdir");
+
+        // Create and stage a file at repo root
+        let root_file = repo_path.join("root.txt");
+        fs::write(&root_file, "root file").expect("failed to write root file");
+
+        Command::new("git")
+            .args(["add", "root.txt"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git add failed");
+
+        // Call git_status from the subdirectory
+        let subdir_str = subdir.to_string_lossy().to_string();
+        let result = git_status(subdir_str).await;
+
+        assert!(result.is_ok(), "git_status should succeed from subdir");
+        let files = result.unwrap();
+
+        // Should see root.txt even though we called from src/
+        assert_eq!(files.len(), 1, "should return repo-level changes");
+        assert_eq!(files[0].path, "root.txt");
+        assert!(files[0].staged);
+    }
+
+    #[tokio::test]
+    async fn test_git_status_non_repo_returns_empty() {
+        // Test that calling git_status from a non-repo directory returns
+        // empty vec (not an error)
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let non_repo = tmp.path().to_string_lossy().to_string();
+
+        let result = git_status(non_repo).await;
+
+        assert!(result.is_ok(), "non-repo should return Ok, not error");
+        let files = result.unwrap();
+        assert_eq!(files.len(), 0, "non-repo should return empty vec");
+    }
+
+    #[tokio::test]
+    async fn test_git_status_mm_file_has_both_halves_with_numstat() {
+        // Test that an MM file (modified in index and worktree) produces
+        // two entries, and both have their respective numstat counts.
+        use std::fs;
+        use std::process::Command;
+
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let repo_path = tmp.path();
+
+        // Initialize git repo
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git init failed");
+
+        // Create and commit initial file
+        let file = repo_path.join("test.txt");
+        fs::write(&file, "line 1\nline 2\n").expect("failed to write file");
+
+        Command::new("git")
+            .args(["add", "test.txt"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git add failed");
+
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git commit failed");
+
+        // Modify and stage (adds line 3)
+        fs::write(&file, "line 1\nline 2\nline 3\n").expect("failed to write");
+
+        Command::new("git")
+            .args(["add", "test.txt"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git add failed");
+
+        // Modify again unstaged (adds line 4)
+        fs::write(&file, "line 1\nline 2\nline 3\nline 4\n")
+            .expect("failed to write");
+
+        // Now we have MM: staged +1 line, unstaged +1 line
+        let repo_str = repo_path.to_string_lossy().to_string();
+        let result = git_status(repo_str).await;
+
+        assert!(result.is_ok(), "git_status should succeed");
+        let files = result.unwrap();
+
+        assert_eq!(files.len(), 2, "MM should produce two entries");
+
+        // Find staged and unstaged entries
+        let staged = files
+            .iter()
+            .find(|f| f.staged)
+            .expect("should have staged entry");
+        let unstaged = files
+            .iter()
+            .find(|f| !f.staged)
+            .expect("should have unstaged entry");
+
+        assert_eq!(staged.path, "test.txt");
+        assert_eq!(unstaged.path, "test.txt");
+
+        // Both should have numstat data
+        assert!(
+            staged.insertions.is_some(),
+            "staged entry should have insertions count"
+        );
+        assert!(
+            staged.deletions.is_some(),
+            "staged entry should have deletions count"
+        );
+        assert!(
+            unstaged.insertions.is_some(),
+            "unstaged entry should have insertions count"
+        );
+        assert!(
+            unstaged.deletions.is_some(),
+            "unstaged entry should have deletions count"
+        );
+
+        // Staged should show +1/-0 (added line 3)
+        assert_eq!(staged.insertions, Some(1));
+        assert_eq!(staged.deletions, Some(0));
+
+        // Unstaged should show +1/-0 (added line 4)
+        assert_eq!(unstaged.insertions, Some(1));
+        assert_eq!(unstaged.deletions, Some(0));
+    }
+
+    // Integration test for get_git_diff command (Feature 5)
+
+    #[tokio::test]
+    async fn test_get_git_diff_subdir_cwd_returns_populated_hunks() {
+        // Test that calling get_git_diff from a subdirectory works correctly
+        // (via rev-parse --show-toplevel resolution)
+        use std::fs;
+        use std::process::Command;
+
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let repo_path = tmp.path();
+
+        // Initialize git repo
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git init failed");
+
+        // Create subdirectory
+        let subdir = repo_path.join("sub");
+        fs::create_dir(&subdir).expect("failed to create subdir");
+
+        // Create and commit file in subdirectory
+        let file_path = subdir.join("foo.ts");
+        fs::write(&file_path, "line 1\nline 2\n").expect("failed to write file");
+
+        Command::new("git")
+            .args(["add", "sub/foo.ts"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git add failed");
+
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git commit failed");
+
+        // Modify the file
+        fs::write(&file_path, "line 1\nline 2\nline 3\n").expect("failed to write");
+
+        // Call get_git_diff from the subdirectory with file path "sub/foo.ts"
+        let subdir_str = subdir.to_string_lossy().to_string();
+        let result = get_git_diff(subdir_str, "sub/foo.ts".to_string(), false).await;
+
+        assert!(result.is_ok(), "get_git_diff should succeed from subdir");
+        let diff = result.unwrap();
+
+        assert_eq!(diff.file_path, "sub/foo.ts");
+        assert!(!diff.hunks.is_empty(), "should have populated hunks");
+
+        // Verify the diff shows the added line
+        let hunk = &diff.hunks[0];
+        let added_lines: Vec<_> = hunk
+            .lines
+            .iter()
+            .filter(|l| matches!(l.line_type, DiffLineType::Added))
+            .collect();
+
+        assert_eq!(added_lines.len(), 1, "should have one added line");
+        assert_eq!(added_lines[0].content, "line 3");
+    }
+
+    #[tokio::test]
+    async fn test_get_git_diff_non_repo_returns_empty_hunks() {
+        // Test that calling get_git_diff from a non-repo directory returns
+        // FileDiff with empty hunks (not an error)
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let non_repo = tmp.path().to_string_lossy().to_string();
+
+        let result = get_git_diff(non_repo, "foo.txt".to_string(), false).await;
+
+        assert!(result.is_ok(), "non-repo should return Ok, not error");
+        let diff = result.unwrap();
+        assert_eq!(diff.file_path, "foo.txt");
+        assert_eq!(diff.hunks.len(), 0, "non-repo should return empty hunks");
     }
 }

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -653,12 +653,16 @@ pub async fn git_status(cwd: String) -> Result<Vec<ChangedFile>, String> {
     // badge reflects the file's actual line count. Skips binary files
     // (helper returns None) so they stay badge-less.
     //
-    // Parallelized via `tokio::task::JoinSet` — a repo with many untracked
-    // files (freshly scaffolded, post-`git stash pop`, etc.) would
-    // serialize as ~5-15 ms per subprocess, producing seconds of latency
-    // on every watcher-triggered refresh. JoinSet runs them concurrently
-    // with no explicit cap; Tokio's blocking pool and the OS's fork/spawn
-    // throughput naturally gate the concurrency.
+    // Parallelized via `tokio::task::JoinSet` with a Semaphore-bounded
+    // fan-out. `run_git_with_timeout` fork+execs synchronously on the
+    // task thread before its first await, so without the semaphore a
+    // repo with many untracked files (freshly scaffolded, post-`git
+    // stash pop`, pre-first-commit builds) would instantly fork N git
+    // processes — blowing out the process table and Tokio worker threads.
+    // A cap of 8 matches typical disk-I/O parallelism while preserving
+    // nearly all of the latency win over fully-serial execution.
+    const UNTRACKED_NUMSTAT_MAX_CONCURRENCY: usize = 8;
+
     let untracked_indices: Vec<(usize, String)> = files
         .iter()
         .enumerate()
@@ -667,10 +671,19 @@ pub async fn git_status(cwd: String) -> Result<Vec<ChangedFile>, String> {
         .collect();
 
     if !untracked_indices.is_empty() {
+        let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(
+            UNTRACKED_NUMSTAT_MAX_CONCURRENCY,
+        ));
         let mut set = tokio::task::JoinSet::new();
         for (idx, path) in untracked_indices {
             let toplevel = canonical_toplevel.clone();
+            let sem = sem.clone();
             set.spawn(async move {
+                // Acquire a permit BEFORE the blocking fork+exec in
+                // `run_git_with_timeout` (called inside the helper).
+                // `.expect` is safe: the Semaphore is owned by this
+                // function and never closed.
+                let _permit = sem.acquire_owned().await.expect("semaphore closed");
                 let counts = get_untracked_numstat(&toplevel, &path).await.ok().flatten();
                 (idx, counts)
             });

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
@@ -106,6 +107,83 @@ pub struct ChangedFile {
     pub path: String,
     pub status: ChangedFileStatus,
     pub staged: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub insertions: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deletions: Option<u32>,
+}
+
+/// Parse `git diff --numstat -z` output into a path → (added, removed) map.
+///
+/// Format (NUL-separated, LF-stripped inside records):
+///   non-rename: "<added>\t<deleted>\t<path>\0"
+///   rename:     "<added>\t<deleted>\t\0<src-path>\0<dst-path>\0"
+///
+/// Binary files report "-\t-\t..." and are omitted from the map.
+/// Renames are keyed on the **dst** path (matches ChangedFile.path, which
+/// porcelain -z also sets to the dst). The `-z` form is mandatory — the
+/// default text form uses brace-compressed renames like
+/// `src/{Foo.tsx => Bar.tsx}` that would not match ChangedFile.path and
+/// would drop +N/-N badges on every renamed row.
+fn parse_numstat(output: &[u8]) -> HashMap<String, (u32, u32)> {
+    let mut stats = HashMap::new();
+    let records: Vec<&[u8]> = output.split(|&b| b == b'\0').collect();
+    let mut i = 0;
+
+    while i < records.len() {
+        let record = records[i];
+
+        // Skip empty records (trailing NUL produces one)
+        if record.is_empty() {
+            i += 1;
+            continue;
+        }
+
+        // Parse the tab-separated fields
+        let parts: Vec<&[u8]> = record.split(|&b| b == b'\t').collect();
+
+        if parts.len() < 3 {
+            // Malformed record, skip
+            i += 1;
+            continue;
+        }
+
+        // Parse insertions and deletions
+        let insertions_str = String::from_utf8_lossy(parts[0]);
+        let deletions_str = String::from_utf8_lossy(parts[1]);
+
+        // Skip binary files (marked as "-\t-\t...")
+        if insertions_str == "-" || deletions_str == "-" {
+            i += 1;
+            continue;
+        }
+
+        let insertions = insertions_str.parse::<u32>().unwrap_or(0);
+        let deletions = deletions_str.parse::<u32>().unwrap_or(0);
+
+        // Check if this is a rename (third field is empty)
+        let path_field = String::from_utf8_lossy(parts[2]);
+
+        if path_field.is_empty() {
+            // Rename format: next two NUL-separated tokens are src and dst
+            i += 1;
+            let _src_path = records.get(i).map(|b| String::from_utf8_lossy(b));
+            i += 1;
+            if let Some(dst_bytes) = records.get(i) {
+                let dst_path = String::from_utf8_lossy(dst_bytes).to_string();
+                if !dst_path.is_empty() {
+                    stats.insert(dst_path, (insertions, deletions));
+                }
+            }
+        } else {
+            // Non-rename: path is in the third field
+            stats.insert(path_field.to_string(), (insertions, deletions));
+        }
+
+        i += 1;
+    }
+
+    stats
 }
 
 /// Diff line type — variant names match TS `DiffLine.type` via
@@ -182,50 +260,143 @@ fn parse_git_status(output: &str) -> Vec<ChangedFile> {
 
         // Parse XY status codes
         // X = index status, Y = worktree status
-        let (status, staged) = match xy {
-            "??" => (ChangedFileStatus::Untracked, false),
-            "M " => (ChangedFileStatus::Modified, true),
-            " M" => (ChangedFileStatus::Modified, false),
-            // MM = modified in both index and worktree. A single boolean
-            // can't represent both states — see the dual-flag spec at
-            // docs/superpowers/specs/2026-04-11-mm-staged-unstaged-design.md
-            // For v1, default to unstaged (shows working-tree changes the
-            // user hasn't reviewed yet; staged changes were already reviewed
-            // when the user staged them).
-            "MM" => (ChangedFileStatus::Modified, false),
-            "A " => (ChangedFileStatus::Added, true),
-            " A" => (ChangedFileStatus::Added, false),
-            // AM = added in index, then modified in worktree. Same
-            // rationale as MM — default to unstaged to show unreviewed edits.
-            "AM" => (ChangedFileStatus::Added, false),
-            "D " => (ChangedFileStatus::Deleted, true),
-            " D" => (ChangedFileStatus::Deleted, false),
-            s if s.starts_with('R') => (ChangedFileStatus::Renamed, true), // renames are index ops
-            s if s.starts_with('C') => (ChangedFileStatus::Renamed, true), // copies are index ops (no separate variant)
-            // Merge conflict codes — no dedicated variant yet, show as
-            // unstaged modified so the file at least appears in the list.
-            "UU" | "AA" | "DD" | "AU" | "UA" | "DU" | "UD" => (ChangedFileStatus::Modified, false),
-            _ => {
-                // Default to modified unstaged for truly unknown codes
-                (ChangedFileStatus::Modified, false)
+        // For MM and AM, emit TWO entries to represent both halves
+        match xy {
+            "??" => {
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Untracked,
+                    staged: false,
+                    insertions: None,
+                    deletions: None,
+                });
             }
-        };
+            "M " => {
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Modified,
+                    staged: true,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+            " M" => {
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Modified,
+                    staged: false,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+            "MM" => {
+                // Emit TWO entries: staged Modified + unstaged Modified
+                files.push(ChangedFile {
+                    path: path.clone(),
+                    status: ChangedFileStatus::Modified,
+                    staged: true,
+                    insertions: None,
+                    deletions: None,
+                });
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Modified,
+                    staged: false,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+            "A " => {
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Added,
+                    staged: true,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+            " A" => {
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Added,
+                    staged: false,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+            "AM" => {
+                // Emit TWO entries: staged Added + unstaged Modified
+                files.push(ChangedFile {
+                    path: path.clone(),
+                    status: ChangedFileStatus::Added,
+                    staged: true,
+                    insertions: None,
+                    deletions: None,
+                });
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Modified,
+                    staged: false,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+            "D " => {
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Deleted,
+                    staged: true,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+            " D" => {
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Deleted,
+                    staged: false,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+            s if s.starts_with('R') || s.starts_with('C') => {
+                // Renames and copies are index operations
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Renamed,
+                    staged: true,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+            "UU" | "AA" | "DD" | "AU" | "UA" | "DU" | "UD" => {
+                // Merge conflict codes — show as unstaged modified
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Modified,
+                    staged: false,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+            _ => {
+                // Default to modified unstaged for unknown codes
+                files.push(ChangedFile {
+                    path,
+                    status: ChangedFileStatus::Modified,
+                    staged: false,
+                    insertions: None,
+                    deletions: None,
+                });
+            }
+        }
 
         // For renames/copies, consume the next NUL-separated token as old path
-        let old_path = if is_rename_or_copy {
+        if is_rename_or_copy {
             i += 1;
-            entries.get(i).map(|s| s.to_string())
-        } else {
-            None
-        };
-
-        let _ = old_path; // old_path not surfaced in ChangedFile yet — tracked in FileDiff
-
-        files.push(ChangedFile {
-            path,
-            status,
-            staged,
-        });
+            let _old_path = entries.get(i).map(|s| s.to_string());
+            // old_path not surfaced in ChangedFile yet — tracked in FileDiff
+        }
 
         i += 1;
     }
@@ -407,6 +578,74 @@ pub async fn get_git_diff(cwd: String, file: String, staged: bool) -> Result<Fil
 mod tests {
     use super::*;
 
+    // parse_numstat tests
+
+    #[test]
+    fn test_parse_numstat_non_rename() {
+        let output = b"5\t3\tsrc/main.rs\0";
+        let stats = parse_numstat(output);
+
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats.get("src/main.rs"), Some(&(5, 3)));
+    }
+
+    #[test]
+    fn test_parse_numstat_rename() {
+        // Rename format: <ins>\t<del>\t\0<src>\0<dst>\0
+        // Keyed on dst (destination path)
+        let output = b"10\t2\t\0old/path.rs\0new/path.rs\0";
+        let stats = parse_numstat(output);
+
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats.get("new/path.rs"), Some(&(10, 2)));
+        assert_eq!(stats.get("old/path.rs"), None);
+    }
+
+    #[test]
+    fn test_parse_numstat_binary_skipped() {
+        // Binary files report "-\t-\t..." and should be skipped
+        let output = b"-\t-\tbinary.png\05\t3\ttext.rs\0";
+        let stats = parse_numstat(output);
+
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats.get("text.rs"), Some(&(5, 3)));
+        assert_eq!(stats.get("binary.png"), None);
+    }
+
+    #[test]
+    fn test_parse_numstat_multiple_records() {
+        let output = b"5\t3\tsrc/main.rs\010\t0\tsrc/new.rs\00\t7\tsrc/deleted.rs\0";
+        let stats = parse_numstat(output);
+
+        assert_eq!(stats.len(), 3);
+        assert_eq!(stats.get("src/main.rs"), Some(&(5, 3)));
+        assert_eq!(stats.get("src/new.rs"), Some(&(10, 0)));
+        assert_eq!(stats.get("src/deleted.rs"), Some(&(0, 7)));
+    }
+
+    #[test]
+    fn test_parse_numstat_empty_input() {
+        let output = b"";
+        let stats = parse_numstat(output);
+
+        assert_eq!(stats.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_numstat_brace_format_regression() {
+        // Regression test: parser assumes -z input; plain text form uses
+        // brace-compressed renames like "src/{A.tsx => B.tsx}" which we
+        // must NOT silently match. The parser should either skip this or
+        // treat it as a malformed record (both are acceptable failure modes).
+        let output = b"5\t3\tsrc/{A.tsx => B.tsx}\0";
+        let stats = parse_numstat(output);
+
+        // Parser should NOT create an entry for the brace-compressed form
+        assert!(stats.get("src/{A.tsx => B.tsx}").is_none());
+        assert!(stats.get("src/A.tsx").is_none());
+        assert!(stats.get("src/B.tsx").is_none());
+    }
+
     #[test]
     fn test_parse_git_status_modified() {
         let output = "M  src/main.rs\0";
@@ -470,16 +709,43 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_git_status_mm_defaults_to_unstaged() {
-        // MM = modified in both index and worktree. v1 defaults to
-        // unstaged so the working-tree diff is shown. See the dual-flag
-        // spec for the v2 model that surfaces both states.
+    fn test_parse_git_status_mm_dual_entry() {
+        // MM = modified in both index and worktree.
+        // New behavior: emit TWO entries, one staged and one unstaged.
         let output = "MM both_modified.rs\0";
         let files = parse_git_status(output);
 
-        assert_eq!(files.len(), 1);
+        assert_eq!(files.len(), 2, "MM should produce two entries");
+
+        // First entry: staged half
+        assert_eq!(files[0].path, "both_modified.rs");
         assert!(matches!(files[0].status, ChangedFileStatus::Modified));
-        assert!(!files[0].staged, "MM should default to unstaged in v1");
+        assert!(files[0].staged, "First MM entry should be staged");
+
+        // Second entry: unstaged half
+        assert_eq!(files[1].path, "both_modified.rs");
+        assert!(matches!(files[1].status, ChangedFileStatus::Modified));
+        assert!(!files[1].staged, "Second MM entry should be unstaged");
+    }
+
+    #[test]
+    fn test_parse_git_status_am_dual_entry() {
+        // AM = added in index, modified in worktree.
+        // Emit TWO entries: staged Added, unstaged Modified.
+        let output = "AM new_file.rs\0";
+        let files = parse_git_status(output);
+
+        assert_eq!(files.len(), 2, "AM should produce two entries");
+
+        // First entry: staged (Added)
+        assert_eq!(files[0].path, "new_file.rs");
+        assert!(matches!(files[0].status, ChangedFileStatus::Added));
+        assert!(files[0].staged, "First AM entry should be staged");
+
+        // Second entry: unstaged (Modified)
+        assert_eq!(files[1].path, "new_file.rs");
+        assert!(matches!(files[1].status, ChangedFileStatus::Modified));
+        assert!(!files[1].staged, "Second AM entry should be unstaged");
     }
 
     #[test]

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -178,7 +178,15 @@ fn parse_numstat(output: &[u8]) -> HashMap<String, (u32, u32)> {
                 }
             }
         } else {
-            // Non-rename: path is in the third field
+            // Non-rename: path is in the third field. Reject brace-compressed
+            // text form (like "src/{A.tsx => B.tsx}") which only appears in
+            // the non-`-z` output. `-z` uses NUL separators for renames —
+            // an inline " => " inside the path field means we're being fed
+            // text form, which would silently mismatch every ChangedFile.path.
+            if path_field.contains(" => ") {
+                i += 1;
+                continue;
+            }
             stats.insert(path_field.to_string(), (insertions, deletions));
         }
 
@@ -701,6 +709,20 @@ pub async fn get_git_diff(cwd: String, file: String, staged: bool) -> Result<Fil
 mod tests {
     use super::*;
 
+    /// Create a tempdir inside `$HOME` so `validate_cwd`'s
+    /// `ensure_within_home` check passes. The default `tempfile::tempdir()`
+    /// lives in `/tmp` which is outside `$HOME` on every supported platform,
+    /// and the validation in production code would reject the path before
+    /// any git subprocess runs. Tests that exercise the `git_status` /
+    /// `get_git_diff` commands must use this helper instead.
+    fn home_tempdir() -> tempfile::TempDir {
+        let home = dirs::home_dir().expect("no home directory");
+        tempfile::Builder::new()
+            .prefix("vimeflow-git-test-")
+            .tempdir_in(&home)
+            .expect("failed to create temp dir under $HOME")
+    }
+
     // parse_numstat tests
 
     #[test]
@@ -995,7 +1017,7 @@ mod tests {
         use std::fs;
         use std::process::Command;
 
-        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let tmp = home_tempdir();
         let repo_path = tmp.path();
 
         // Initialize git repo
@@ -1036,7 +1058,7 @@ mod tests {
     async fn test_git_status_non_repo_returns_empty() {
         // Test that calling git_status from a non-repo directory returns
         // empty vec (not an error)
-        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let tmp = home_tempdir();
         let non_repo = tmp.path().to_string_lossy().to_string();
 
         let result = git_status(non_repo).await;
@@ -1053,7 +1075,7 @@ mod tests {
         use std::fs;
         use std::process::Command;
 
-        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let tmp = home_tempdir();
         let repo_path = tmp.path();
 
         // Initialize git repo
@@ -1150,7 +1172,7 @@ mod tests {
         use std::fs;
         use std::process::Command;
 
-        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let tmp = home_tempdir();
         let repo_path = tmp.path();
 
         // Initialize git repo
@@ -1209,7 +1231,7 @@ mod tests {
     async fn test_get_git_diff_non_repo_returns_empty_hunks() {
         // Test that calling get_git_diff from a non-repo directory returns
         // FileDiff with empty hunks (not an error)
-        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let tmp = home_tempdir();
         let non_repo = tmp.path().to_string_lossy().to_string();
 
         let result = get_git_diff(non_repo, "foo.txt".to_string(), false).await;

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,3 +1,5 @@
+pub mod watcher;
+
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -64,7 +66,7 @@ async fn run_git_with_timeout(mut cmd: Command) -> Result<std::process::Output, 
 }
 
 /// Validate that `cwd` resolves to a path inside the user's home directory.
-fn validate_cwd(cwd: &str) -> Result<std::path::PathBuf, String> {
+pub(crate) fn validate_cwd(cwd: &str) -> Result<std::path::PathBuf, String> {
     let expanded = expand_home(cwd);
     reject_parent_refs(&expanded)?;
     let home = home_canonical()?;

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -1,0 +1,584 @@
+//! Git repository watcher for file system changes
+//!
+//! Watches git repositories for file system changes and emits Tauri events
+//! when the working tree is modified. Uses the `notify` crate for cross-platform
+//! file system notifications and the `ignore` crate to respect `.gitignore` rules.
+//!
+//! Key features:
+//! - Per-repository subscriber refcounting (multiple tabs can watch the same repo)
+//! - Pre-repo handling (watching a directory that becomes a repo after `git init`)
+//! - Auto-upgrade from pre-repo to repo state when `.git/` appears
+//! - Event fan-out (all subscribers to a repo get notified on one change)
+//! - 300ms debounce to avoid redundant processing
+//! - 10s polling fallback for systems where inotify/FSEvents is unreliable
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use ignore::WalkBuilder;
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tauri::{Emitter, Manager};
+
+use super::validate_cwd;
+
+/// Debounce interval — ignore events within 300ms of the last processed one
+const DEBOUNCE_MS: u64 = 300;
+
+/// Polling fallback interval — check for changes every 10 seconds
+const POLL_INTERVAL_SECS: u64 = 10;
+
+/// Handle to a running watcher for a git repository
+struct RepoWatcher {
+    /// Map from input cwd to refcount — multiple subscribers can watch the same repo
+    /// from different subdirectories. Each subscription increments the count; each
+    /// unsubscribe decrements it. When the map is empty, the watcher is torn down.
+    subscribers: HashMap<PathBuf, u32>,
+
+    /// The notify watcher instance
+    _watcher: RecommendedWatcher,
+
+    /// Signals the polling fallback thread to exit
+    stop_flag: Arc<AtomicBool>,
+
+    /// Last OID of HEAD for polling fallback
+    last_head_oid: Arc<Mutex<String>>,
+}
+
+/// Handle to a pre-repo watcher (watching a directory that is not yet a git repo)
+struct PreRepoWatcher {
+    /// Refcount — multiple subscribers can watch the same pre-repo dir
+    refcount: u32,
+
+    /// Signals the polling thread to exit
+    stop_flag: Arc<AtomicBool>,
+}
+
+impl Drop for RepoWatcher {
+    fn drop(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Drop for PreRepoWatcher {
+    fn drop(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Thread-safe state for managing git watchers
+#[derive(Default, Clone)]
+pub struct GitWatcherState {
+    /// Watchers for actual git repositories, keyed by canonical toplevel path
+    repo_watchers: Arc<Mutex<HashMap<PathBuf, RepoWatcher>>>,
+
+    /// Watchers for directories that are not yet repos (but might become one),
+    /// keyed by canonical input cwd
+    pre_repo_watchers: Arc<Mutex<HashMap<PathBuf, PreRepoWatcher>>>,
+}
+
+impl GitWatcherState {
+    /// Create a new empty watcher state
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Payload emitted when git status changes
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GitStatusChangedPayload {
+    /// List of input cwds that should refresh
+    cwds: Vec<String>,
+}
+
+/// Resolve the git toplevel for a given cwd
+fn resolve_toplevel(cwd: &std::path::Path) -> Result<PathBuf, String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .map_err(|e| format!("Failed to run git: {}", e))?;
+
+    if !output.status.success() {
+        return Err("Not a git repository".to_string());
+    }
+
+    let toplevel_str = String::from_utf8_lossy(&output.stdout);
+    let toplevel = toplevel_str.trim();
+
+    Ok(PathBuf::from(toplevel))
+}
+
+/// Get the current HEAD OID for a repo
+fn get_head_oid(toplevel: &std::path::Path) -> Result<String, String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(toplevel)
+        .arg("rev-parse")
+        .arg("HEAD")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .map_err(|e| format!("Failed to run git: {}", e))?;
+
+    if !output.status.success() {
+        return Err("Failed to get HEAD OID".to_string());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Enumerate non-ignored directories in a git repository using ignore::WalkBuilder
+fn enumerate_dirs(toplevel: &std::path::Path) -> Vec<PathBuf> {
+    let mut dirs = vec![];
+
+    let walker = WalkBuilder::new(toplevel)
+        .follow_links(false)
+        .build();
+
+    for entry in walker {
+        if let Ok(entry) = entry {
+            if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                dirs.push(entry.path().to_path_buf());
+            }
+        }
+    }
+
+    dirs
+}
+
+/// Start watching a git repository
+///
+/// If `cwd` is a subdirectory of a repo, resolves to the toplevel and adds
+/// the input cwd as a subscriber. Multiple calls with different subdirs of
+/// the same repo increment the refcount.
+#[tauri::command]
+pub async fn start_git_watcher(
+    cwd: String,
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, GitWatcherState>,
+) -> Result<(), String> {
+    let safe_cwd = validate_cwd(&cwd)?;
+
+    // Try to resolve repo toplevel
+    let toplevel = match resolve_toplevel(&safe_cwd) {
+        Ok(tl) => {
+            let canonical = validate_cwd(&tl.to_string_lossy())?;
+            canonical
+        }
+        Err(_) => {
+            // Not a repo yet — start pre-repo watcher
+            return start_pre_repo_watcher(safe_cwd, app_handle, state).await;
+        }
+    };
+
+    let mut repo_watchers = state.repo_watchers.lock()
+        .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
+
+    if let Some(watcher) = repo_watchers.get_mut(&toplevel) {
+        // Watcher exists — increment refcount
+        *watcher.subscribers.entry(safe_cwd.clone()).or_insert(0) += 1;
+
+        // Emit initial event for this subscriber
+        emit_git_status_changed(&app_handle, vec![safe_cwd.to_string_lossy().to_string()]);
+
+        return Ok(());
+    }
+
+    // Create new watcher
+    let toplevel_clone = toplevel.clone();
+    let app_handle_clone = app_handle.clone();
+    let state_clone = state.inner().clone();
+    let last_head_oid = Arc::new(Mutex::new(
+        get_head_oid(&toplevel).unwrap_or_default()
+    ));
+    let last_processed = Arc::new(Mutex::new(Instant::now()));
+    let stop_flag = Arc::new(AtomicBool::new(false));
+
+    // Create notify watcher
+    let notify_watcher = {
+        let toplevel = toplevel.clone();
+        let app_handle = app_handle.clone();
+        let state = state_clone.clone();
+        let last_processed = last_processed.clone();
+
+        notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
+            let event = match res {
+                Ok(ev) => ev,
+                Err(e) => {
+                    log::error!("Watcher error for {}: {}", toplevel.display(), e);
+                    return;
+                }
+            };
+
+            // Only react to modifications or creations
+            let relevant = matches!(
+                event.kind,
+                EventKind::Modify(_) | EventKind::Create(_)
+            );
+            if !relevant {
+                return;
+            }
+
+            // Debounce
+            {
+                let mut last = last_processed.lock().expect("failed to lock last_processed");
+                let now = Instant::now();
+                if now.duration_since(*last) < Duration::from_millis(DEBOUNCE_MS) {
+                    return;
+                }
+                *last = now;
+            }
+
+            // Emit event for all subscribers
+            emit_for_all_subscribers(&app_handle, &state, &toplevel);
+        })
+        .map_err(|e| format!("Failed to create watcher: {}", e))?
+    };
+
+    // Register watches for all non-ignored directories
+    let dirs = enumerate_dirs(&toplevel);
+    let mut watcher = notify_watcher;
+
+    for dir in dirs {
+        if let Err(e) = watcher.watch(&dir, RecursiveMode::NonRecursive) {
+            log::warn!("Failed to watch {}: {}", dir.display(), e);
+        }
+    }
+
+    // Also watch .git/index and .git/HEAD
+    let git_index = toplevel.join(".git/index");
+    if git_index.exists() {
+        if let Err(e) = watcher.watch(&git_index, RecursiveMode::NonRecursive) {
+            log::warn!("Failed to watch .git/index: {}", e);
+        }
+    }
+
+    let git_head = toplevel.join(".git/HEAD");
+    if git_head.exists() {
+        if let Err(e) = watcher.watch(&git_head, RecursiveMode::NonRecursive) {
+            log::warn!("Failed to watch .git/HEAD: {}", e);
+        }
+    }
+
+    // Start polling fallback thread
+    let poll_toplevel = toplevel.clone();
+    let poll_app_handle = app_handle.clone();
+    let poll_state = state_clone.clone();
+    let poll_stop_flag = stop_flag.clone();
+    let poll_last_head_oid = last_head_oid.clone();
+
+    std::thread::spawn(move || {
+        while !poll_stop_flag.load(Ordering::Relaxed) {
+            std::thread::sleep(Duration::from_secs(POLL_INTERVAL_SECS));
+
+            if poll_stop_flag.load(Ordering::Relaxed) {
+                break;
+            }
+
+            // Check if HEAD changed
+            if let Ok(current_oid) = get_head_oid(&poll_toplevel) {
+                let last = poll_last_head_oid.lock().expect("failed to lock last_head_oid");
+                if *last != current_oid {
+                    drop(last);
+                    *poll_last_head_oid.lock().expect("failed to lock") = current_oid;
+                    emit_for_all_subscribers(&poll_app_handle, &poll_state, &poll_toplevel);
+                }
+            }
+        }
+    });
+
+    // Insert watcher with initial subscriber
+    let mut subscribers = HashMap::new();
+    subscribers.insert(safe_cwd.clone(), 1);
+
+    let repo_watcher = RepoWatcher {
+        subscribers,
+        _watcher: watcher,
+        stop_flag,
+        last_head_oid,
+    };
+
+    repo_watchers.insert(toplevel, repo_watcher);
+
+    // Emit initial event
+    emit_git_status_changed(&app_handle, vec![safe_cwd.to_string_lossy().to_string()]);
+
+    Ok(())
+}
+
+/// Start a pre-repo watcher (for directories that are not yet git repos)
+async fn start_pre_repo_watcher(
+    cwd: PathBuf,
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, GitWatcherState>,
+) -> Result<(), String> {
+    let mut pre_repo_watchers = state.pre_repo_watchers.lock()
+        .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
+
+    if let Some(watcher) = pre_repo_watchers.get_mut(&cwd) {
+        // Pre-repo watcher exists — increment refcount
+        watcher.refcount += 1;
+
+        // Emit initial event
+        emit_git_status_changed(&app_handle, vec![cwd.to_string_lossy().to_string()]);
+
+        return Ok(());
+    }
+
+    // Create new pre-repo watcher with polling
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let poll_cwd = cwd.clone();
+    let poll_app_handle = app_handle.clone();
+    let poll_state = state.inner().clone();
+    let poll_stop_flag = stop_flag.clone();
+
+    std::thread::spawn(move || {
+        while !poll_stop_flag.load(Ordering::Relaxed) {
+            std::thread::sleep(Duration::from_secs(POLL_INTERVAL_SECS));
+
+            if poll_stop_flag.load(Ordering::Relaxed) {
+                break;
+            }
+
+            // Check if this became a repo
+            if resolve_toplevel(&poll_cwd).is_ok() {
+                // Upgrade to repo watcher
+                if let Err(e) = upgrade_to_repo_watcher(poll_cwd.clone(), poll_app_handle.clone(), poll_state.clone()) {
+                    log::error!("Failed to upgrade to repo watcher: {}", e);
+                }
+                break;
+            }
+
+            // Still not a repo — emit event anyway (git_status will return empty)
+            emit_git_status_changed(&poll_app_handle, vec![poll_cwd.to_string_lossy().to_string()]);
+        }
+    });
+
+    let pre_repo_watcher = PreRepoWatcher {
+        refcount: 1,
+        stop_flag,
+    };
+
+    pre_repo_watchers.insert(cwd.clone(), pre_repo_watcher);
+
+    // Emit initial event
+    emit_git_status_changed(&app_handle, vec![cwd.to_string_lossy().to_string()]);
+
+    Ok(())
+}
+
+/// Upgrade a pre-repo watcher to a full repo watcher
+fn upgrade_to_repo_watcher(
+    cwd: PathBuf,
+    app_handle: tauri::AppHandle,
+    state: GitWatcherState,
+) -> Result<(), String> {
+    let refcount = {
+        let mut pre_repo_watchers = state.pre_repo_watchers.lock()
+            .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
+
+        if let Some(watcher) = pre_repo_watchers.remove(&cwd) {
+            watcher.refcount
+        } else {
+            return Err("Pre-repo watcher not found".to_string());
+        }
+    };
+
+    // Start a proper repo watcher (this will handle the refcount internally)
+    let state_handle = tauri::State::from(&state);
+    for _ in 0..refcount {
+        futures::executor::block_on(start_git_watcher(
+            cwd.to_string_lossy().to_string(),
+            app_handle.clone(),
+            state_handle.clone(),
+        ))?;
+    }
+
+    Ok(())
+}
+
+/// Stop watching a git repository
+#[tauri::command]
+pub async fn stop_git_watcher(
+    cwd: String,
+    state: tauri::State<'_, GitWatcherState>,
+) -> Result<(), String> {
+    let safe_cwd = validate_cwd(&cwd)?;
+
+    // Try repo watchers first
+    let toplevel = resolve_toplevel(&safe_cwd).ok();
+
+    if let Some(toplevel) = toplevel {
+        let canonical = validate_cwd(&toplevel.to_string_lossy())?;
+
+        let mut repo_watchers = state.repo_watchers.lock()
+            .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
+
+        if let Some(watcher) = repo_watchers.get_mut(&canonical) {
+            if let Some(count) = watcher.subscribers.get_mut(&safe_cwd) {
+                *count = count.saturating_sub(1);
+
+                if *count == 0 {
+                    watcher.subscribers.remove(&safe_cwd);
+                }
+            }
+
+            // If no more subscribers, remove the watcher
+            if watcher.subscribers.is_empty() {
+                repo_watchers.remove(&canonical);
+            }
+
+            return Ok(());
+        }
+    }
+
+    // Try pre-repo watchers
+    let mut pre_repo_watchers = state.pre_repo_watchers.lock()
+        .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
+
+    if let Some(watcher) = pre_repo_watchers.get_mut(&safe_cwd) {
+        watcher.refcount = watcher.refcount.saturating_sub(1);
+
+        if watcher.refcount == 0 {
+            pre_repo_watchers.remove(&safe_cwd);
+        }
+
+        return Ok(());
+    }
+
+    // Watcher not found — this is ok (idempotent stop)
+    Ok(())
+}
+
+/// Emit git-status-changed event for all subscribers of a repo
+fn emit_for_all_subscribers(
+    app_handle: &tauri::AppHandle,
+    state: &GitWatcherState,
+    toplevel: &std::path::Path,
+) {
+    let cwds = {
+        let repo_watchers = state.repo_watchers.lock().expect("failed to lock repo_watchers");
+
+        if let Some(watcher) = repo_watchers.get(toplevel) {
+            watcher.subscribers.keys()
+                .map(|p| p.to_string_lossy().to_string())
+                .collect()
+        } else {
+            vec![]
+        }
+    };
+
+    if !cwds.is_empty() {
+        emit_git_status_changed(app_handle, cwds);
+    }
+}
+
+/// Emit a git-status-changed event
+fn emit_git_status_changed(app_handle: &tauri::AppHandle, cwds: Vec<String>) {
+    let payload = GitStatusChangedPayload { cwds };
+
+    if let Err(e) = app_handle.emit("git-status-changed", payload) {
+        log::error!("Failed to emit git-status-changed: {}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    /// Create a temp git repo for testing
+    fn create_temp_repo() -> TempDir {
+        let temp = TempDir::new().expect("failed to create temp dir");
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(temp.path())
+            .output()
+            .expect("failed to run git init");
+
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(temp.path())
+            .output()
+            .expect("failed to configure git");
+
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(temp.path())
+            .output()
+            .expect("failed to configure git");
+
+        temp
+    }
+
+    #[test]
+    fn test_resolve_toplevel() {
+        let temp = create_temp_repo();
+        let toplevel = resolve_toplevel(temp.path()).expect("failed to resolve toplevel");
+
+        // Normalize paths for comparison
+        let expected = fs::canonicalize(temp.path()).expect("failed to canonicalize");
+        let actual = fs::canonicalize(&toplevel).expect("failed to canonicalize");
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_resolve_toplevel_subdir() {
+        let temp = create_temp_repo();
+        let subdir = temp.path().join("src");
+        fs::create_dir(&subdir).expect("failed to create subdir");
+
+        let toplevel = resolve_toplevel(&subdir).expect("failed to resolve toplevel");
+
+        let expected = fs::canonicalize(temp.path()).expect("failed to canonicalize");
+        let actual = fs::canonicalize(&toplevel).expect("failed to canonicalize");
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_resolve_toplevel_non_repo() {
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let result = resolve_toplevel(temp.path());
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Not a git repository"));
+    }
+
+    #[test]
+    fn test_enumerate_dirs() {
+        let temp = create_temp_repo();
+
+        // Create some directories
+        fs::create_dir(temp.path().join("src")).expect("failed to create src");
+        fs::create_dir(temp.path().join("src/components")).expect("failed to create components");
+        fs::create_dir(temp.path().join("tests")).expect("failed to create tests");
+
+        // Create .gitignore to ignore a directory
+        fs::write(temp.path().join(".gitignore"), "ignored/\n").expect("failed to write .gitignore");
+        fs::create_dir(temp.path().join("ignored")).expect("failed to create ignored");
+
+        let dirs = enumerate_dirs(temp.path());
+
+        // Should include root, src, src/components, tests, but NOT ignored
+        let dir_names: Vec<_> = dirs.iter()
+            .map(|p| p.file_name().and_then(|n| n.to_str()).unwrap_or(""))
+            .collect();
+
+        assert!(dirs.iter().any(|p| p == temp.path()), "should include root");
+        assert!(dir_names.contains(&"src"), "should include src");
+        assert!(dir_names.contains(&"components"), "should include components");
+        assert!(dir_names.contains(&"tests"), "should include tests");
+        assert!(!dir_names.contains(&"ignored"), "should NOT include ignored");
+    }
+}

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -726,13 +726,36 @@ fn upgrade_to_repo_watcher(
     // entry. This keeps every subscriber's identity intact across the
     // upgrade — the Files Changed panel continues receiving events on the
     // exact string it subscribed with, so its exact-string filter matches.
+    //
+    // Collect errors instead of bailing on the first failure. The previous
+    // revision used `?`, which meant one bad subscriber (e.g. cwd deleted
+    // between pre-repo registration and upgrade) stranded every subsequent
+    // subscriber: the pre-repo entry was already removed, so subsequent
+    // stops would silent-no-op and the frontend panel would go permanently
+    // stale with no surfaced error. Per-subscriber errors are now
+    // accumulated; each surviving subscriber still gets its repo watcher,
+    // and the caller sees a combined error describing all failures.
+    let mut errors: Vec<String> = Vec::new();
     for (original_cwd, refcount) in subscribers {
         for _ in 0..refcount {
-            start_git_watcher_inner(&original_cwd, app_handle.clone(), &state)?;
+            if let Err(e) =
+                start_git_watcher_inner(&original_cwd, app_handle.clone(), &state)
+            {
+                errors.push(format!("{}: {}", original_cwd, e));
+                break; // don't retry the same cwd if it's fundamentally broken
+            }
         }
     }
 
-    Ok(())
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "upgrade_to_repo_watcher: {} subscriber(s) failed to upgrade: {}",
+            errors.len(),
+            errors.join("; ")
+        ))
+    }
 }
 
 /// Stop watching a git repository

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -70,8 +70,12 @@ struct RepoWatcher {
 
 /// Handle to a pre-repo watcher (watching a directory that is not yet a git repo)
 struct PreRepoWatcher {
-    /// Refcount — multiple subscribers can watch the same pre-repo dir
-    refcount: u32,
+    /// Map from **original** frontend cwd string → refcount. Same
+    /// shape as `RepoWatcher.subscribers` so the pre-repo → repo
+    /// upgrade path can transfer identities without re-canonicalizing.
+    /// Key is the exact string the frontend passed to
+    /// `start_git_watcher` — that's what its event listener matches on.
+    subscribers: HashMap<String, u32>,
 
     /// Signals the polling thread to exit
     stop_flag: Arc<AtomicBool>,
@@ -217,8 +221,14 @@ fn start_git_watcher_inner(
             canonical
         }
         Err(_) => {
-            // Not a repo yet — start pre-repo watcher
-            return start_pre_repo_watcher_inner(safe_cwd, app_handle, state);
+            // Not a repo yet — start pre-repo watcher.
+            // Pass both the frontend's original cwd string AND the
+            // canonicalized PathBuf: the string becomes the subscriber
+            // identity (so events match the listener's exact-string
+            // filter), the PathBuf is the map key (so two calls for
+            // the same dir via different spellings share one poll
+            // thread).
+            return start_pre_repo_watcher_inner(cwd, safe_cwd, app_handle, state);
         }
     };
 
@@ -264,10 +274,13 @@ fn start_git_watcher_inner(
                 }
             };
 
-            // Only react to modifications or creations
+            // Accept Modify, Create, AND Remove. Deletes and untracked-file
+            // removals change git status too; filtering them out stranded
+            // those workflows on the 10s polling fallback even when notify
+            // was otherwise healthy.
             let relevant = matches!(
                 event.kind,
-                EventKind::Modify(_) | EventKind::Create(_)
+                EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
             );
             if !relevant {
                 return;
@@ -418,29 +431,35 @@ fn start_git_watcher_inner(
 
 /// Start a pre-repo watcher (for directories that are not yet git repos).
 ///
-/// Takes an owned `&GitWatcherState` (cheap: the state is `Arc`-backed) so it
-/// can be called both from the Tauri command path and from the upgrade path.
+/// Takes both the frontend's original `cwd` string (subscriber identity,
+/// used in event payloads) and the canonicalized `safe_cwd` PathBuf (map
+/// key, used for dedup when multiple callers watch the same dir via
+/// different spellings).
 fn start_pre_repo_watcher_inner(
-    cwd: PathBuf,
+    cwd: &str,
+    safe_cwd: PathBuf,
     app_handle: tauri::AppHandle,
     state: &GitWatcherState,
 ) -> Result<(), String> {
     let mut pre_repo_watchers = state.pre_repo_watchers.lock()
         .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
 
-    if let Some(watcher) = pre_repo_watchers.get_mut(&cwd) {
-        // Pre-repo watcher exists — increment refcount
-        watcher.refcount += 1;
+    if let Some(watcher) = pre_repo_watchers.get_mut(&safe_cwd) {
+        // Pre-repo watcher exists — add this subscription. Same cwd
+        // string bumps its refcount; a new cwd string (e.g. a different
+        // symlink spelling of the same canonical path) becomes a new
+        // subscriber entry. Either way, this subscriber receives events
+        // under its own original string.
+        *watcher.subscribers.entry(cwd.to_string()).or_insert(0) += 1;
 
-        // Emit initial event
-        emit_git_status_changed(&app_handle, vec![cwd.to_string_lossy().to_string()]);
+        emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
 
         return Ok(());
     }
 
     // Create new pre-repo watcher with polling
     let stop_flag = Arc::new(AtomicBool::new(false));
-    let poll_cwd = cwd.clone();
+    let poll_safe_cwd = safe_cwd.clone();
     let poll_app_handle = app_handle.clone();
     let poll_state = state.clone();
     let poll_stop_flag = stop_flag.clone();
@@ -454,58 +473,93 @@ fn start_pre_repo_watcher_inner(
             }
 
             // Check if this became a repo
-            if resolve_toplevel(&poll_cwd).is_ok() {
-                // Upgrade to repo watcher
-                if let Err(e) = upgrade_to_repo_watcher(poll_cwd.clone(), poll_app_handle.clone(), poll_state.clone()) {
+            if resolve_toplevel(&poll_safe_cwd).is_ok() {
+                // Upgrade to repo watcher — transfers the subscriber map
+                // (with original cwd strings intact) into repo_watchers.
+                if let Err(e) = upgrade_to_repo_watcher(
+                    poll_safe_cwd.clone(),
+                    poll_app_handle.clone(),
+                    poll_state.clone(),
+                ) {
                     log::error!("Failed to upgrade to repo watcher: {}", e);
                 }
                 break;
             }
 
-            // Still not a repo — emit event anyway (git_status will return empty)
-            emit_git_status_changed(&poll_app_handle, vec![poll_cwd.to_string_lossy().to_string()]);
+            // Still not a repo — emit event using each subscriber's
+            // original cwd string so the frontend exact-string listeners
+            // match. Snapshot under lock.
+            let cwds: Vec<String> = {
+                let watchers = poll_state
+                    .pre_repo_watchers
+                    .lock()
+                    .expect("failed to lock pre_repo_watchers");
+                watchers
+                    .get(&poll_safe_cwd)
+                    .map(|w| w.subscribers.keys().cloned().collect())
+                    .unwrap_or_default()
+            };
+            if !cwds.is_empty() {
+                emit_git_status_changed(&poll_app_handle, cwds);
+            }
         }
     });
 
+    let mut subscribers = HashMap::new();
+    subscribers.insert(cwd.to_string(), 1);
+
     let pre_repo_watcher = PreRepoWatcher {
-        refcount: 1,
+        subscribers,
         stop_flag,
     };
 
-    pre_repo_watchers.insert(cwd.clone(), pre_repo_watcher);
+    pre_repo_watchers.insert(safe_cwd, pre_repo_watcher);
 
-    // Emit initial event
-    emit_git_status_changed(&app_handle, vec![cwd.to_string_lossy().to_string()]);
+    // Emit initial event with the frontend's original cwd string
+    emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
 
     Ok(())
 }
 
 /// Upgrade a pre-repo watcher to a full repo watcher.
 ///
-/// Removes the pre-repo entry and re-invokes the repo-watcher bootstrap the
-/// same number of times as the prior refcount so subscribers keep their grip.
-/// Calls the synchronous inner helper directly — no `tauri::State` fabrication
-/// and no blocking executor needed.
+/// Removes the pre-repo entry, then re-invokes the repo-watcher bootstrap
+/// for each of its subscribers using their ORIGINAL cwd string so the
+/// subscriber-identity (and thus event-matching) is preserved across
+/// the upgrade. Previously this used `cwd.to_string_lossy()` (the
+/// canonical form), stranding any frontend that had subscribed with a
+/// symlinked or non-canonical path.
 fn upgrade_to_repo_watcher(
-    cwd: PathBuf,
+    safe_cwd: PathBuf,
     app_handle: tauri::AppHandle,
     state: GitWatcherState,
 ) -> Result<(), String> {
-    let refcount = {
+    // Collect the subscribers (original-cwd → refcount) from the pre-repo
+    // entry and drop it.
+    let subscribers: HashMap<String, u32> = {
         let mut pre_repo_watchers = state.pre_repo_watchers.lock()
             .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
 
-        if let Some(watcher) = pre_repo_watchers.remove(&cwd) {
-            watcher.refcount
+        if let Some(mut watcher) = pre_repo_watchers.remove(&safe_cwd) {
+            // `PreRepoWatcher` impls `Drop` (sets stop_flag), so we can't
+            // move `subscribers` out by field. `mem::take` swaps it with
+            // HashMap::default() (empty map), which is fine because the
+            // watcher is about to be dropped anyway.
+            std::mem::take(&mut watcher.subscribers)
         } else {
             return Err("Pre-repo watcher not found".to_string());
         }
     };
 
-    // Start a proper repo watcher (this will handle the refcount internally)
-    let cwd_str = cwd.to_string_lossy().to_string();
-    for _ in 0..refcount {
-        start_git_watcher_inner(&cwd_str, app_handle.clone(), &state)?;
+    // Start a proper repo watcher once per subscribed original-cwd string,
+    // bumping the refcount the same number of times it had in the pre-repo
+    // entry. This keeps every subscriber's identity intact across the
+    // upgrade — the Files Changed panel continues receiving events on the
+    // exact string it subscribed with, so its exact-string filter matches.
+    for (original_cwd, refcount) in subscribers {
+        for _ in 0..refcount {
+            start_git_watcher_inner(&original_cwd, app_handle.clone(), &state)?;
+        }
     }
 
     Ok(())
@@ -549,14 +603,21 @@ pub async fn stop_git_watcher(
         }
     }
 
-    // Try pre-repo watchers
+    // Try pre-repo watchers (keyed on canonical PathBuf, values now
+    // have a subscribers map like repo watchers)
     let mut pre_repo_watchers = state.pre_repo_watchers.lock()
         .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
 
     if let Some(watcher) = pre_repo_watchers.get_mut(&safe_cwd) {
-        watcher.refcount = watcher.refcount.saturating_sub(1);
+        if let Some(count) = watcher.subscribers.get_mut(&cwd) {
+            *count = count.saturating_sub(1);
 
-        if watcher.refcount == 0 {
+            if *count == 0 {
+                watcher.subscribers.remove(&cwd);
+            }
+        }
+
+        if watcher.subscribers.is_empty() {
             pre_repo_watchers.remove(&safe_cwd);
         }
 

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -32,6 +32,55 @@ const DEBOUNCE_MS: u64 = 300;
 /// Polling fallback interval — check for changes every 10 seconds
 const POLL_INTERVAL_SECS: u64 = 10;
 
+/// Timeout for sync git subprocesses called from the polling thread.
+/// Guards against hangs on NFS/FUSE, stale `.git/index.lock`, or corrupted
+/// packs. `Command::output()` without this would block the polling thread
+/// for the lifetime of the hung child; the stop_flag is only read at the
+/// loop head, so a thread parked inside `output()` never reaches it and
+/// leaks along with every `Arc` it holds.
+const SYNC_GIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Run a `std::process::Command` synchronously with a deadline. On timeout,
+/// kill the child and return an error. Used from the polling thread (which
+/// lives in `std::thread::spawn`, NOT a tokio task, so `run_git_with_timeout`
+/// from `mod.rs` — which is async — isn't directly callable here without
+/// an owned runtime handle). The busy-wait loop polls every 50ms; at 10s
+/// timeout that's ~200 polls max, cheap compared to the subprocess itself.
+fn run_sync_with_timeout(
+    mut cmd: std::process::Command,
+    timeout: Duration,
+) -> Result<std::process::Output, String> {
+    use std::process::Stdio;
+
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("spawn failed: {}", e))?;
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                // Exited — drain stdio and return the full Output.
+                return child
+                    .wait_with_output()
+                    .map_err(|e| format!("wait_with_output failed: {}", e));
+            }
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    // Kill and reap so we don't leak a zombie.
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(format!("git command timed out after {:?}", timeout));
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => return Err(format!("try_wait failed: {}", e)),
+        }
+    }
+}
+
 /// Handle to a running watcher for a git repository
 struct RepoWatcher {
     /// Map from **input** cwd string (exactly what the frontend passed) to
@@ -119,16 +168,18 @@ struct GitStatusChangedPayload {
     cwds: Vec<String>,
 }
 
-/// Resolve the git toplevel for a given cwd
+/// Resolve the git toplevel for a given cwd. Uses `run_sync_with_timeout`
+/// so a hung `git rev-parse` (NFS stall, `.git/index.lock` held by a
+/// crashed process, etc.) can't park the polling thread forever.
 fn resolve_toplevel(cwd: &std::path::Path) -> Result<PathBuf, String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C")
         .arg(cwd)
         .arg("rev-parse")
         .arg("--show-toplevel")
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .output()
-        .map_err(|e| format!("Failed to run git: {}", e))?;
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    let output = run_sync_with_timeout(cmd, SYNC_GIT_TIMEOUT)?;
 
     if !output.status.success() {
         return Err("Not a git repository".to_string());
@@ -148,15 +199,16 @@ fn resolve_toplevel(cwd: &std::path::Path) -> Result<PathBuf, String> {
 /// unstaging, editing tracked files, creating/deleting untracked files,
 /// etc. Returns the hash so the poller can cheaply detect "any change".
 fn hash_git_status(toplevel: &Path) -> Result<u64, String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C")
         .arg(toplevel)
         .arg("status")
         .arg("--porcelain=v1")
         .arg("-z")
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .output()
-        .map_err(|e| format!("Failed to run git status: {}", e))?;
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    // Timed-out sync call — same reasoning as `resolve_toplevel`.
+    let output = run_sync_with_timeout(cmd, SYNC_GIT_TIMEOUT)?;
 
     if !output.status.success() {
         return Err("git status failed".to_string());

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -233,19 +233,39 @@ fn hash_git_status(toplevel: &Path) -> Result<u64, String> {
     Ok(hasher.finish())
 }
 
-/// Enumerate non-ignored directories in a git repository using ignore::WalkBuilder
+/// Enumerate non-ignored directories in a git repository using ignore::WalkBuilder.
+///
+/// Explicitly excludes the `.git/` directory and everything under it. The
+/// `ignore` crate respects `.gitignore` patterns, but `.git/` is NOT a
+/// gitignore entry — git itself treats it as opaque metadata. Without this
+/// filter the walker descends into `.git/objects/`, `.git/refs/`, `.git/logs/`,
+/// etc., and every directory there gets passed to `watcher.watch()`. That's
+/// bad on two axes:
+///   1. Every `git commit`, `git fetch`, `git rebase`, etc. updates
+///      `.git/refs/` and `.git/logs/`, firing spurious `git-status-changed`
+///      events through the debounce.
+///   2. The 10s polling thread re-enumerates dirs and registers newly-
+///      observed ones. As loose objects accumulate in `.git/objects/XX/`,
+///      inotify watch descriptors accumulate until `max_user_watches` is
+///      exhausted.
+///
+/// The explicit `.git/index` and `.git/HEAD` additions in
+/// `start_git_watcher_inner` (which DO need to be watched so staging /
+/// commits fire events) are the ONLY `.git/*` paths that should end up
+/// registered with notify.
 fn enumerate_dirs(toplevel: &std::path::Path) -> Vec<PathBuf> {
+    use std::ffi::OsStr;
+
     let mut dirs = vec![];
 
     let walker = WalkBuilder::new(toplevel)
         .follow_links(false)
+        .filter_entry(|e| e.file_name() != OsStr::new(".git"))
         .build();
 
-    for entry in walker {
-        if let Ok(entry) = entry {
-            if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
-                dirs.push(entry.path().to_path_buf());
-            }
+    for entry in walker.flatten() {
+        if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+            dirs.push(entry.path().to_path_buf());
         }
     }
 
@@ -891,6 +911,20 @@ mod tests {
         assert!(dir_names.contains(&"components"), "should include components");
         assert!(dir_names.contains(&"tests"), "should include tests");
         assert!(!dir_names.contains(&"ignored"), "should NOT include ignored");
+        // Regression guard for the .git/ exclusion — without `.filter_entry`
+        // on the WalkBuilder, enumerate_dirs would recurse into `.git/`
+        // and its subdirs (objects/, refs/, logs/ etc.), causing spurious
+        // notify events and steady inotify FD growth.
+        assert!(
+            !dir_names.contains(&".git"),
+            "should NOT include .git directory"
+        );
+        assert!(
+            !dirs
+                .iter()
+                .any(|p| p.components().any(|c| c.as_os_str() == ".git")),
+            "should NOT include any path under .git/"
+        );
     }
 
     #[test]

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -175,6 +175,18 @@ pub struct GitWatcherState {
     /// skipped, and the polling thread (kept alive by the un-removed
     /// RepoWatcher) would keep firing `hash_git_status` forever.
     cwd_to_toplevel: Arc<Mutex<HashMap<String, PathBuf>>>,
+
+    /// Side-map: frontend's original cwd string → canonicalized PathBuf
+    /// for **pre-repo** entries. Same role as `cwd_to_toplevel` but for
+    /// the non-repo path: populated by `start_pre_repo_watcher_inner`,
+    /// consumed by `stop_git_watcher_inner` to find the `pre_repo_watchers`
+    /// bucket without re-running `validate_cwd`.
+    ///
+    /// Without this, a session watching a non-repo directory whose path
+    /// is then deleted (agent runs `rm -rf` on its working dir) would leak
+    /// its PreRepoWatcher: stop-time `validate_cwd` fails on `canonicalize`,
+    /// the early-return fires, and the polling thread runs forever.
+    cwd_to_safe_pre_repo: Arc<Mutex<HashMap<String, PathBuf>>>,
 }
 
 impl GitWatcherState {
@@ -317,6 +329,21 @@ fn start_git_watcher_inner(
     state: &GitWatcherState,
 ) -> Result<(), String> {
     let safe_cwd = validate_cwd(cwd)?;
+
+    // Opportunistically clear any stale pre-repo side-map entry for this
+    // cwd. If we're transitioning from pre-repo to repo (called via
+    // `upgrade_to_repo_watcher`, or just a re-subscription after `git init`),
+    // the old `cwd_to_safe_pre_repo` mapping is now obsolete. Leaving it
+    // would just be a tiny memory leak — stop_git_watcher_inner consults
+    // `cwd_to_toplevel` first so the stale entry can't cause incorrect
+    // routing — but tidiness wins.
+    {
+        let mut pre_repo_map = state
+            .cwd_to_safe_pre_repo
+            .lock()
+            .expect("failed to lock cwd_to_safe_pre_repo");
+        pre_repo_map.remove(cwd);
+    }
 
     // Try to resolve repo toplevel
     let toplevel = match resolve_toplevel(&safe_cwd) {
@@ -630,6 +657,15 @@ fn start_pre_repo_watcher_inner(
         // under its own original string.
         *watcher.subscribers.entry(cwd.to_string()).or_insert(0) += 1;
 
+        // Record cwd → safe_cwd in the side-map so stop_git_watcher_inner
+        // can find this bucket without re-running validate_cwd at stop time
+        // (which fails if the directory has since been deleted).
+        state
+            .cwd_to_safe_pre_repo
+            .lock()
+            .expect("failed to lock cwd_to_safe_pre_repo")
+            .insert(cwd.to_string(), safe_cwd.clone());
+
         emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
 
         return Ok(());
@@ -683,7 +719,15 @@ fn start_pre_repo_watcher_inner(
         stop_flag,
     };
 
-    pre_repo_watchers.insert(safe_cwd, pre_repo_watcher);
+    pre_repo_watchers.insert(safe_cwd.clone(), pre_repo_watcher);
+
+    // Record cwd → safe_cwd in the side-map (see field doc on
+    // GitWatcherState.cwd_to_safe_pre_repo).
+    state
+        .cwd_to_safe_pre_repo
+        .lock()
+        .expect("failed to lock cwd_to_safe_pre_repo")
+        .insert(cwd.to_string(), safe_cwd);
 
     // Emit initial event with the frontend's original cwd string
     emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
@@ -824,13 +868,34 @@ fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), Str
         // entry; the map-removal above already cleaned up).
     }
 
-    // No recorded toplevel → pre-repo watcher path. We still need the
-    // canonical `safe_cwd` PathBuf to look up the pre-repo map.
-    // `validate_cwd` may itself fail if the cwd has been deleted, in
-    // which case there's nothing we can clean up from here and
-    // idempotent-stop is the right answer.
-    let Ok(safe_cwd) = validate_cwd(&cwd) else {
-        return Ok(());
+    // No recorded toplevel → pre-repo watcher path. Look up the canonical
+    // PathBuf from the pre-repo side-map first. Falls back to live
+    // `validate_cwd` only if the side-map has no record (defensive — covers
+    // pre-existing watchers from before this side-map existed in long-
+    // running sessions, though there shouldn't be any in practice).
+    //
+    // The side-map removal here is symmetric with `cwd_to_toplevel.remove`
+    // above: it cleans up the map regardless of whether we successfully
+    // stop the watcher, so a future idempotent stop is a pure no-op.
+    let recorded_pre_repo: Option<PathBuf> = {
+        let mut map = state
+            .cwd_to_safe_pre_repo
+            .lock()
+            .map_err(|e| format!("Failed to lock cwd_to_safe_pre_repo: {}", e))?;
+        map.remove(&cwd)
+    };
+
+    let safe_cwd = match recorded_pre_repo {
+        Some(p) => p,
+        None => {
+            // No recorded mapping. Try live validation as a last resort;
+            // if even that fails (cwd no longer exists), there's truly
+            // nothing we can do from here and idempotent-stop is correct.
+            let Ok(p) = validate_cwd(&cwd) else {
+                return Ok(());
+            };
+            p
+        }
     };
 
     let mut pre_repo_watchers = state

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -12,8 +12,10 @@
 //! - 300ms debounce to avoid redundant processing
 //! - 10s polling fallback for systems where inotify/FSEvents is unreliable
 
-use std::collections::HashMap;
-use std::path::PathBuf;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -32,22 +34,38 @@ const POLL_INTERVAL_SECS: u64 = 10;
 
 /// Handle to a running watcher for a git repository
 struct RepoWatcher {
-    /// Map from input cwd to refcount — multiple subscribers can watch the same repo
-    /// from different subdirectories. Each subscription increments the count; each
-    /// unsubscribe decrements it. When the map is empty, the watcher is torn down.
-    subscribers: HashMap<PathBuf, u32>,
+    /// Map from **input** cwd string (exactly what the frontend passed) to
+    /// refcount. Multiple subscribers can watch the same repo from different
+    /// subdirectories; each subscription increments its own entry's count.
+    ///
+    /// Keyed on the raw input string (not canonicalized) so the event payload
+    /// the frontend receives matches the cwd it subscribed with. The
+    /// canonical form is used only to find the correct `repo_watchers`
+    /// bucket (the outer map) — dedup of "same repo via different strings"
+    /// happens at the watcher level, not at the subscriber level.
+    subscribers: HashMap<String, u32>,
 
-    /// The notify watcher instance
-    _watcher: RecommendedWatcher,
+    /// The notify watcher instance. Wrapped in `Arc<Mutex<_>>` so the
+    /// polling thread can dynamically register newly-created directories
+    /// as `NonRecursive` watches (non-recursive inotify does NOT extend
+    /// into directories created after startup).
+    _watcher: Arc<Mutex<RecommendedWatcher>>,
+
+    /// Set of directories currently registered with the notify watcher.
+    /// The polling thread diffs this against the current `ignore`-filtered
+    /// walk and registers any additions. Shared with the polling thread.
+    _watched_dirs: Arc<Mutex<HashSet<PathBuf>>>,
 
     /// Signals the polling fallback thread to exit
     stop_flag: Arc<AtomicBool>,
 
-    /// Last OID of HEAD for polling fallback. The active reader is the
-    /// polling thread (via its own `Arc` clone); this field keeps the
-    /// `Arc` rooted on the owning watcher so the thread can keep reading
-    /// after `RepoWatcher` moves into the state map.
-    _last_head_oid: Arc<Mutex<String>>,
+    /// Hash of the last-seen `git status --porcelain=v1 -z` output.
+    /// Changes on any staging/unstaging/edit/delete/add — everything that
+    /// would cause a panel row to change. The HEAD-only comparison in the
+    /// previous revision missed staging ops and plain file edits because
+    /// HEAD only moves on commit/checkout. The active reader is the
+    /// polling thread; this field roots the Arc.
+    _last_status_hash: Arc<Mutex<Option<u64>>>,
 }
 
 /// Handle to a pre-repo watcher (watching a directory that is not yet a git repo)
@@ -118,22 +136,31 @@ fn resolve_toplevel(cwd: &std::path::Path) -> Result<PathBuf, String> {
     Ok(PathBuf::from(toplevel))
 }
 
-/// Get the current HEAD OID for a repo
-fn get_head_oid(toplevel: &std::path::Path) -> Result<String, String> {
+/// Hash the current `git status --porcelain=v1 -z` output.
+///
+/// Used by the polling fallback as the change-detection signal. Unlike
+/// HEAD-only comparison (which only moves on commit/checkout), this
+/// captures every state that affects the Files Changed panel: staging,
+/// unstaging, editing tracked files, creating/deleting untracked files,
+/// etc. Returns the hash so the poller can cheaply detect "any change".
+fn hash_git_status(toplevel: &Path) -> Result<u64, String> {
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(toplevel)
-        .arg("rev-parse")
-        .arg("HEAD")
+        .arg("status")
+        .arg("--porcelain=v1")
+        .arg("-z")
         .env("GIT_TERMINAL_PROMPT", "0")
         .output()
-        .map_err(|e| format!("Failed to run git: {}", e))?;
+        .map_err(|e| format!("Failed to run git status: {}", e))?;
 
     if !output.status.success() {
-        return Err("Failed to get HEAD OID".to_string());
+        return Err("git status failed".to_string());
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    let mut hasher = DefaultHasher::new();
+    output.stdout.hash(&mut hasher);
+    Ok(hasher.finish())
 }
 
 /// Enumerate non-ignored directories in a git repository using ignore::WalkBuilder
@@ -199,19 +226,24 @@ fn start_git_watcher_inner(
         .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
 
     if let Some(watcher) = repo_watchers.get_mut(&toplevel) {
-        // Watcher exists — increment refcount
-        *watcher.subscribers.entry(safe_cwd.clone()).or_insert(0) += 1;
+        // Watcher exists — increment refcount keyed on the ORIGINAL cwd
+        // string (NOT the canonical form) so later event fan-out emits
+        // the exact string the frontend subscribed with. Two frontend
+        // strings that canonicalize to the same path still get separate
+        // subscriber entries — they share the notify watcher but each
+        // receives events matching its own input.
+        *watcher.subscribers.entry(cwd.to_string()).or_insert(0) += 1;
 
-        // Emit initial event for this subscriber
-        emit_git_status_changed(&app_handle, vec![safe_cwd.to_string_lossy().to_string()]);
+        // Emit initial event using the frontend's original cwd string.
+        emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
 
         return Ok(());
     }
 
     // Create new watcher
     let state_clone = state.clone();
-    let last_head_oid = Arc::new(Mutex::new(
-        get_head_oid(&toplevel).unwrap_or_default()
+    let last_status_hash = Arc::new(Mutex::new(
+        hash_git_status(&toplevel).ok(),
     ));
     let last_processed = Arc::new(Mutex::new(Instant::now()));
     let stop_flag = Arc::new(AtomicBool::new(false));
@@ -257,37 +289,59 @@ fn start_git_watcher_inner(
         .map_err(|e| format!("Failed to create watcher: {}", e))?
     };
 
-    // Register watches for all non-ignored directories
-    let dirs = enumerate_dirs(&toplevel);
-    let mut watcher = notify_watcher;
+    // Wrap the watcher in Arc<Mutex<_>> so the polling thread can
+    // dynamically register newly-created directories. NonRecursive inotify
+    // does NOT extend into subdirs created after startup, so without this
+    // a new feature folder would become invisible to notify.
+    let watcher_arc = Arc::new(Mutex::new(notify_watcher));
+    let watched_dirs: Arc<Mutex<HashSet<PathBuf>>> = Arc::new(Mutex::new(HashSet::new()));
 
-    for dir in dirs {
-        if let Err(e) = watcher.watch(&dir, RecursiveMode::NonRecursive) {
-            log::warn!("Failed to watch {}: {}", dir.display(), e);
+    // Register initial watches for all non-ignored directories, tracking
+    // them in `watched_dirs` so the poller's dir-diff knows what's new.
+    {
+        let mut watcher_guard = watcher_arc.lock().expect("failed to lock watcher");
+        let mut dirs_guard = watched_dirs.lock().expect("failed to lock watched_dirs");
+
+        for dir in enumerate_dirs(&toplevel) {
+            if let Err(e) = watcher_guard.watch(&dir, RecursiveMode::NonRecursive) {
+                log::warn!("Failed to watch {}: {}", dir.display(), e);
+                continue;
+            }
+            dirs_guard.insert(dir);
+        }
+
+        // Also watch .git/index and .git/HEAD (non-recursive — never recurse
+        // into .git/ because .git/objects/ would explode the watch count).
+        let git_index = toplevel.join(".git/index");
+        if git_index.exists() {
+            if let Err(e) = watcher_guard.watch(&git_index, RecursiveMode::NonRecursive) {
+                log::warn!("Failed to watch .git/index: {}", e);
+            }
+        }
+
+        let git_head = toplevel.join(".git/HEAD");
+        if git_head.exists() {
+            if let Err(e) = watcher_guard.watch(&git_head, RecursiveMode::NonRecursive) {
+                log::warn!("Failed to watch .git/HEAD: {}", e);
+            }
         }
     }
 
-    // Also watch .git/index and .git/HEAD
-    let git_index = toplevel.join(".git/index");
-    if git_index.exists() {
-        if let Err(e) = watcher.watch(&git_index, RecursiveMode::NonRecursive) {
-            log::warn!("Failed to watch .git/index: {}", e);
-        }
-    }
-
-    let git_head = toplevel.join(".git/HEAD");
-    if git_head.exists() {
-        if let Err(e) = watcher.watch(&git_head, RecursiveMode::NonRecursive) {
-            log::warn!("Failed to watch .git/HEAD: {}", e);
-        }
-    }
-
-    // Start polling fallback thread
+    // Start polling fallback thread with two jobs on the same 10s tick:
+    //   (1) Change detection — hashes `git status --porcelain=v1 -z`
+    //       output. Unlike HEAD-only comparison, this catches every
+    //       panel-visible change: staging, unstaging, editing tracked
+    //       files, creating/deleting untracked files.
+    //   (2) Dynamic dir registration — re-enumerates non-ignored dirs and
+    //       registers any not yet watched. Compensates for non-recursive
+    //       inotify's inability to extend into post-startup directories.
     let poll_toplevel = toplevel.clone();
     let poll_app_handle = app_handle.clone();
     let poll_state = state_clone.clone();
     let poll_stop_flag = stop_flag.clone();
-    let poll_last_head_oid = last_head_oid.clone();
+    let poll_last_status_hash = last_status_hash.clone();
+    let poll_watcher = watcher_arc.clone();
+    let poll_watched_dirs = watched_dirs.clone();
 
     std::thread::spawn(move || {
         while !poll_stop_flag.load(Ordering::Relaxed) {
@@ -297,33 +351,67 @@ fn start_git_watcher_inner(
                 break;
             }
 
-            // Check if HEAD changed
-            if let Ok(current_oid) = get_head_oid(&poll_toplevel) {
-                let last = poll_last_head_oid.lock().expect("failed to lock last_head_oid");
-                if *last != current_oid {
-                    drop(last);
-                    *poll_last_head_oid.lock().expect("failed to lock") = current_oid;
+            // (1) Change detection via status hash.
+            if let Ok(current_hash) = hash_git_status(&poll_toplevel) {
+                let changed = {
+                    let mut last = poll_last_status_hash
+                        .lock()
+                        .expect("failed to lock last_status_hash");
+                    let changed = last.map_or(true, |h| h != current_hash);
+                    if changed {
+                        *last = Some(current_hash);
+                    }
+                    changed
+                };
+                if changed {
                     emit_for_all_subscribers(&poll_app_handle, &poll_state, &poll_toplevel);
+                }
+            }
+
+            // (2) Register any newly-created non-ignored directories.
+            let new_dirs: Vec<PathBuf> = {
+                let current = enumerate_dirs(&poll_toplevel);
+                let watched = poll_watched_dirs
+                    .lock()
+                    .expect("failed to lock watched_dirs");
+                current
+                    .into_iter()
+                    .filter(|d| !watched.contains(d))
+                    .collect()
+            };
+
+            if !new_dirs.is_empty() {
+                let mut watcher_guard = poll_watcher.lock().expect("failed to lock watcher");
+                let mut dirs_guard = poll_watched_dirs
+                    .lock()
+                    .expect("failed to lock watched_dirs");
+                for dir in new_dirs {
+                    if let Err(e) = watcher_guard.watch(&dir, RecursiveMode::NonRecursive) {
+                        log::warn!("Failed to watch new dir {}: {}", dir.display(), e);
+                        continue;
+                    }
+                    dirs_guard.insert(dir);
                 }
             }
         }
     });
 
-    // Insert watcher with initial subscriber
+    // Insert watcher with initial subscriber (keyed on original cwd string)
     let mut subscribers = HashMap::new();
-    subscribers.insert(safe_cwd.clone(), 1);
+    subscribers.insert(cwd.to_string(), 1);
 
     let repo_watcher = RepoWatcher {
         subscribers,
-        _watcher: watcher,
+        _watcher: watcher_arc,
+        _watched_dirs: watched_dirs,
         stop_flag,
-        _last_head_oid: last_head_oid,
+        _last_status_hash: last_status_hash,
     };
 
     repo_watchers.insert(toplevel, repo_watcher);
 
-    // Emit initial event
-    emit_git_status_changed(&app_handle, vec![safe_cwd.to_string_lossy().to_string()]);
+    // Emit initial event using the frontend's original cwd string
+    emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
 
     Ok(())
 }
@@ -441,11 +529,14 @@ pub async fn stop_git_watcher(
             .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
 
         if let Some(watcher) = repo_watchers.get_mut(&canonical) {
-            if let Some(count) = watcher.subscribers.get_mut(&safe_cwd) {
+            // Subscribers are now keyed on the frontend's ORIGINAL cwd
+            // string (F3 fix) so the same cwd the caller passed is the
+            // lookup key here — not safe_cwd.
+            if let Some(count) = watcher.subscribers.get_mut(&cwd) {
                 *count = count.saturating_sub(1);
 
                 if *count == 0 {
-                    watcher.subscribers.remove(&safe_cwd);
+                    watcher.subscribers.remove(&cwd);
                 }
             }
 
@@ -482,13 +573,13 @@ fn emit_for_all_subscribers(
     state: &GitWatcherState,
     toplevel: &std::path::Path,
 ) {
-    let cwds = {
+    let cwds: Vec<String> = {
         let repo_watchers = state.repo_watchers.lock().expect("failed to lock repo_watchers");
 
         if let Some(watcher) = repo_watchers.get(toplevel) {
-            watcher.subscribers.keys()
-                .map(|p| p.to_string_lossy().to_string())
-                .collect()
+            // Subscriber keys are the frontend's original cwd strings — emit
+            // them as-is so listener's `event.cwds.includes(myCwd)` matches.
+            watcher.subscribers.keys().cloned().collect()
         } else {
             vec![]
         }
@@ -600,5 +691,57 @@ mod tests {
         assert!(dir_names.contains(&"components"), "should include components");
         assert!(dir_names.contains(&"tests"), "should include tests");
         assert!(!dir_names.contains(&"ignored"), "should NOT include ignored");
+    }
+
+    #[test]
+    fn test_hash_git_status_detects_changes() {
+        // Regression test for F1 (HIGH): the polling fallback must detect
+        // any change that affects `git status`, not just HEAD movement.
+        // Hash must differ after staging, after editing tracked files,
+        // and after creating untracked files.
+        let temp = create_temp_repo();
+        let repo = temp.path();
+
+        // Empty repo: hash is stable across two consecutive calls
+        let h0 = hash_git_status(repo).expect("h0 failed");
+        let h0_again = hash_git_status(repo).expect("h0_again failed");
+        assert_eq!(h0, h0_again, "idempotent when nothing changed");
+
+        // Create an untracked file — hash must change (HEAD didn't move)
+        fs::write(repo.join("untracked.txt"), "hello\n").expect("write failed");
+        let h1 = hash_git_status(repo).expect("h1 failed");
+        assert_ne!(
+            h1, h0,
+            "hash must change when untracked file is created"
+        );
+
+        // Stage the file — hash must change again (HEAD still didn't move)
+        Command::new("git")
+            .args(["add", "untracked.txt"])
+            .current_dir(repo)
+            .output()
+            .expect("git add failed");
+        let h2 = hash_git_status(repo).expect("h2 failed");
+        assert_ne!(
+            h2, h1,
+            "hash must change when file is staged (previous HEAD-only poll missed this)"
+        );
+
+        // Commit — HEAD moves, working tree becomes clean
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(repo)
+            .output()
+            .expect("git commit failed");
+        let h3 = hash_git_status(repo).expect("h3 failed");
+        assert_ne!(h3, h2, "hash must change after commit (clean status now)");
+
+        // Modify the committed file — hash must change
+        fs::write(repo.join("untracked.txt"), "hello\nworld\n").expect("write failed");
+        let h4 = hash_git_status(repo).expect("h4 failed");
+        assert_ne!(
+            h4, h3,
+            "hash must change when a tracked file is edited (previous HEAD-only poll missed this)"
+        );
     }
 }

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -151,6 +151,20 @@ pub struct GitWatcherState {
     /// Watchers for directories that are not yet repos (but might become one),
     /// keyed by canonical input cwd
     pre_repo_watchers: Arc<Mutex<HashMap<PathBuf, PreRepoWatcher>>>,
+
+    /// Side-map: frontend's original cwd string → canonical repo toplevel.
+    /// Populated on every successful `start_git_watcher_inner` repo-path
+    /// insertion; consumed by `stop_git_watcher_inner` to find the right
+    /// `repo_watchers` bucket without re-running `rev-parse --show-toplevel`
+    /// at stop time.
+    ///
+    /// Without this map, a session that starts with `.git` present and stops
+    /// after `.git` is removed (e.g. agent running `rm -rf .git`, force-reset,
+    /// `git filter-repo` rewrite) would leak its RepoWatcher: the stop-time
+    /// `resolve_toplevel` would fail, the repo-bucket lookup would be
+    /// skipped, and the polling thread (kept alive by the un-removed
+    /// RepoWatcher) would keep firing `hash_git_status` forever.
+    cwd_to_toplevel: Arc<Mutex<HashMap<String, PathBuf>>>,
 }
 
 impl GitWatcherState {
@@ -303,6 +317,14 @@ fn start_git_watcher_inner(
         // subscriber entries — they share the notify watcher but each
         // receives events matching its own input.
         *watcher.subscribers.entry(cwd.to_string()).or_insert(0) += 1;
+
+        // Record the cwd → toplevel mapping so stop_git_watcher_inner can
+        // find this bucket without re-running `rev-parse` at stop time.
+        state
+            .cwd_to_toplevel
+            .lock()
+            .expect("failed to lock cwd_to_toplevel")
+            .insert(cwd.to_string(), toplevel.clone());
 
         // Emit initial event using the frontend's original cwd string.
         emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
@@ -481,7 +503,17 @@ fn start_git_watcher_inner(
         _last_status_hash: last_status_hash,
     };
 
-    repo_watchers.insert(toplevel, repo_watcher);
+    repo_watchers.insert(toplevel.clone(), repo_watcher);
+
+    // Record cwd → toplevel mapping (see cwd_to_toplevel doc comment).
+    // Drop the repo_watchers guard before acquiring the side-map lock to
+    // avoid needlessly widening the lock scope.
+    drop(repo_watchers);
+    state
+        .cwd_to_toplevel
+        .lock()
+        .expect("failed to lock cwd_to_toplevel")
+        .insert(cwd.to_string(), toplevel);
 
     // Emit initial event using the frontend's original cwd string
     emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
@@ -635,21 +667,32 @@ pub async fn stop_git_watcher(
 /// Synchronous core of `stop_git_watcher`. Owns its state clone so it can
 /// be called from the blocking pool.
 fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), String> {
-    let safe_cwd = validate_cwd(&cwd)?;
+    // First: look up the repo-toplevel from the side-map populated by
+    // `start_git_watcher_inner`. This is critical — re-running
+    // `resolve_toplevel(&safe_cwd)` at stop time would fail if `.git`
+    // was removed mid-session (agent ran `rm -rf .git`, force-reset,
+    // `git filter-repo` etc.), silently skipping the repo-watcher
+    // removal and leaking the polling thread. Using the recorded
+    // mapping is correct even when the repo no longer resolves.
+    let recorded_toplevel: Option<PathBuf> = {
+        let mut map = state
+            .cwd_to_toplevel
+            .lock()
+            .map_err(|e| format!("Failed to lock cwd_to_toplevel: {}", e))?;
+        // `remove` here is optimistic: if the later repo-watcher lookup
+        // finds nothing, we've also cleaned up the side-map so a future
+        // idempotent stop is a pure no-op. If we stopped the watcher
+        // successfully, the map entry is no longer needed either.
+        map.remove(&cwd)
+    };
 
-    // Try repo watchers first
-    let toplevel = resolve_toplevel(&safe_cwd).ok();
-
-    if let Some(toplevel) = toplevel {
-        let canonical = validate_cwd(&toplevel.to_string_lossy())?;
-
-        let mut repo_watchers = state.repo_watchers.lock()
+    if let Some(canonical) = recorded_toplevel {
+        let mut repo_watchers = state
+            .repo_watchers
+            .lock()
             .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
 
         if let Some(watcher) = repo_watchers.get_mut(&canonical) {
-            // Subscribers are now keyed on the frontend's ORIGINAL cwd
-            // string (F3 fix) so the same cwd the caller passed is the
-            // lookup key here — not safe_cwd.
             if let Some(count) = watcher.subscribers.get_mut(&cwd) {
                 *count = count.saturating_sub(1);
 
@@ -658,18 +701,32 @@ fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), Str
                 }
             }
 
-            // If no more subscribers, remove the watcher
+            // If no more subscribers, remove the watcher (its Drop fires
+            // the stop_flag, which the polling thread observes on its
+            // next wake).
             if watcher.subscribers.is_empty() {
                 repo_watchers.remove(&canonical);
             }
 
             return Ok(());
         }
+        // Recorded mapping but no watcher — fall through (possible if
+        // upgrade/teardown race removed the watcher but not the map
+        // entry; the map-removal above already cleaned up).
     }
 
-    // Try pre-repo watchers (keyed on canonical PathBuf, values now
-    // have a subscribers map like repo watchers)
-    let mut pre_repo_watchers = state.pre_repo_watchers.lock()
+    // No recorded toplevel → pre-repo watcher path. We still need the
+    // canonical `safe_cwd` PathBuf to look up the pre-repo map.
+    // `validate_cwd` may itself fail if the cwd has been deleted, in
+    // which case there's nothing we can clean up from here and
+    // idempotent-stop is the right answer.
+    let Ok(safe_cwd) = validate_cwd(&cwd) else {
+        return Ok(());
+    };
+
+    let mut pre_repo_watchers = state
+        .pre_repo_watchers
+        .lock()
         .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
 
     if let Some(watcher) = pre_repo_watchers.get_mut(&safe_cwd) {

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -336,40 +336,43 @@ fn start_git_watcher_inner(
         }
     };
 
-    let mut repo_watchers = state.repo_watchers.lock()
-        .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
-
-    if let Some(watcher) = repo_watchers.get_mut(&toplevel) {
-        // Watcher exists — increment refcount keyed on the ORIGINAL cwd
-        // string (NOT the canonical form) so later event fan-out emits
-        // the exact string the frontend subscribed with. Two frontend
-        // strings that canonicalize to the same path still get separate
-        // subscriber entries — they share the notify watcher but each
-        // receives events matching its own input.
-        *watcher.subscribers.entry(cwd.to_string()).or_insert(0) += 1;
-
-        // Release `repo_watchers` (lock A) BEFORE acquiring `cwd_to_toplevel`
-        // (lock B). `stop_git_watcher_inner` acquires B first then A, so
-        // holding both here simultaneously would open a deadlock path
-        // against a future caller that reverses the order. Matching the
-        // new-watcher branch below which also releases A before B.
-        drop(repo_watchers);
-
-        // Record the cwd → toplevel mapping so stop_git_watcher_inner can
-        // find this bucket without re-running `rev-parse` at stop time.
-        state
-            .cwd_to_toplevel
+    // ── Phase 1: short check under lock A ─────────────────────────────
+    //
+    // Only check whether a watcher already exists for this toplevel. The
+    // expensive setup work (`hash_git_status`, notify watcher creation,
+    // `enumerate_dirs` filesystem walk, polling-thread spawn) used to run
+    // while this lock was held — up to 10s under NFS/FUSE stalls or held
+    // `.git/index.lock`s — blocking the notify callback's
+    // `emit_for_all_subscribers` (which also locks `repo_watchers`) for
+    // every other repo's events. Phase 2 below builds all that state
+    // lock-free; phase 3 re-acquires A only for the final
+    // check-then-insert.
+    //
+    // While holding A here, ALSO insert into `cwd_to_toplevel` (lock B).
+    // `stop_git_watcher_inner` always releases B before acquiring A, so
+    // start holding A→B simultaneously is deadlock-free. Without the A+B
+    // overlap, a concurrent stop could slip in between A's release and
+    // B's acquire and miss the watcher (TOCTOU leak).
+    {
+        let mut repo_watchers = state
+            .repo_watchers
             .lock()
-            .expect("failed to lock cwd_to_toplevel")
-            .insert(cwd.to_string(), toplevel.clone());
+            .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
 
-        // Emit initial event using the frontend's original cwd string.
-        emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
-
-        return Ok(());
+        if let Some(watcher) = repo_watchers.get_mut(&toplevel) {
+            *watcher.subscribers.entry(cwd.to_string()).or_insert(0) += 1;
+            state
+                .cwd_to_toplevel
+                .lock()
+                .expect("failed to lock cwd_to_toplevel")
+                .insert(cwd.to_string(), toplevel.clone());
+            drop(repo_watchers);
+            emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
+            return Ok(());
+        }
     }
 
-    // Create new watcher
+    // ── Phase 2: build watcher state OUTSIDE locks ────────────────────
     let state_clone = state.clone();
     let last_status_hash = Arc::new(Mutex::new(
         hash_git_status(&toplevel).ok(),
@@ -539,7 +542,7 @@ fn start_git_watcher_inner(
         }
     });
 
-    // Insert watcher with initial subscriber (keyed on original cwd string)
+    // Build the locally-owned RepoWatcher with its initial subscriber.
     let mut subscribers = HashMap::new();
     subscribers.insert(cwd.to_string(), 1);
 
@@ -551,19 +554,54 @@ fn start_git_watcher_inner(
         _last_status_hash: last_status_hash,
     };
 
-    repo_watchers.insert(toplevel.clone(), repo_watcher);
+    // ── Phase 3: re-check and insert under lock A ─────────────────────
+    //
+    // Re-acquire `repo_watchers` to publish the new watcher. The brief
+    // hold here covers two cases:
+    //   (a) Another thread inserted a watcher for the same toplevel
+    //       between phase 1 and now (TOCTOU race). We discard our
+    //       locally-built `repo_watcher` — its `Drop` fires `stop_flag`,
+    //       which our just-spawned polling thread observes on its next
+    //       tick and exits cleanly. Then we bump the existing watcher's
+    //       refcount as if we were a phase-1 hit.
+    //   (b) Common case: no race; insert the new watcher.
+    //
+    // `cwd_to_toplevel.insert` happens while lock A is still held, same
+    // reasoning as phase 1 — closes the TOCTOU window where a concurrent
+    // stop could read empty B, then read empty A, and silently leak the
+    // watcher.
+    {
+        let mut repo_watchers = state
+            .repo_watchers
+            .lock()
+            .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
 
-    // Record cwd → toplevel mapping (see cwd_to_toplevel doc comment).
-    // Drop the repo_watchers guard before acquiring the side-map lock to
-    // avoid needlessly widening the lock scope.
-    drop(repo_watchers);
-    state
-        .cwd_to_toplevel
-        .lock()
-        .expect("failed to lock cwd_to_toplevel")
-        .insert(cwd.to_string(), toplevel);
+        if let Some(existing) = repo_watchers.get_mut(&toplevel) {
+            // Race: someone else won. Bump THEIR subscribers; our local
+            // `repo_watcher` will be dropped when this scope ends,
+            // which fires its stop_flag and shuts down our poll thread.
+            *existing.subscribers.entry(cwd.to_string()).or_insert(0) += 1;
+            state
+                .cwd_to_toplevel
+                .lock()
+                .expect("failed to lock cwd_to_toplevel")
+                .insert(cwd.to_string(), toplevel.clone());
+            drop(repo_watchers);
+            // `repo_watcher` (local) drops here.
+            emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
+            return Ok(());
+        }
 
-    // Emit initial event using the frontend's original cwd string
+        repo_watchers.insert(toplevel.clone(), repo_watcher);
+        state
+            .cwd_to_toplevel
+            .lock()
+            .expect("failed to lock cwd_to_toplevel")
+            .insert(cwd.to_string(), toplevel);
+        drop(repo_watchers);
+    }
+
+    // Emit initial event using the frontend's original cwd string.
     emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
 
     Ok(())

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -494,22 +494,14 @@ fn start_pre_repo_watcher_inner(
                 break;
             }
 
-            // Still not a repo — emit event using each subscriber's
-            // original cwd string so the frontend exact-string listeners
-            // match. Snapshot under lock.
-            let cwds: Vec<String> = {
-                let watchers = poll_state
-                    .pre_repo_watchers
-                    .lock()
-                    .expect("failed to lock pre_repo_watchers");
-                watchers
-                    .get(&poll_safe_cwd)
-                    .map(|w| w.subscribers.keys().cloned().collect())
-                    .unwrap_or_default()
-            };
-            if !cwds.is_empty() {
-                emit_git_status_changed(&poll_app_handle, cwds);
-            }
+            // Still not a repo — intentionally NO emit on this tick.
+            // The previous revision fired `git-status-changed` on every
+            // 10-second tick for every pre-repo subscriber, which caused
+            // the frontend to run a useless `git_status` round-trip that
+            // always returns []. Subscribers already hold the correct
+            // empty state from their initial fetch; nothing to refresh
+            // until the dir becomes a repo (upgrade path emits its own
+            // initial event).
         }
     });
 

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -76,7 +76,17 @@ fn run_sync_with_timeout(
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
-            Err(e) => return Err(format!("try_wait failed: {}", e)),
+            Err(e) => {
+                // Mirror the timeout-arm cleanup: a `try_wait` error can
+                // leave the child running (EINTR) or as a zombie. Without
+                // this the subprocess + its piped stdout/stderr fds leak
+                // until process exit, which accumulates under rapid
+                // repo-switch workloads where the polling thread hits
+                // this path repeatedly.
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("try_wait failed: {}", e));
+            }
         }
     }
 }

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -20,7 +20,7 @@ use std::time::{Duration, Instant};
 
 use ignore::WalkBuilder;
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use tauri::{Emitter, Manager};
+use tauri::Emitter;
 
 use super::validate_cwd;
 
@@ -43,8 +43,11 @@ struct RepoWatcher {
     /// Signals the polling fallback thread to exit
     stop_flag: Arc<AtomicBool>,
 
-    /// Last OID of HEAD for polling fallback
-    last_head_oid: Arc<Mutex<String>>,
+    /// Last OID of HEAD for polling fallback. The active reader is the
+    /// polling thread (via its own `Arc` clone); this field keeps the
+    /// `Arc` rooted on the owning watcher so the thread can keep reading
+    /// after `RepoWatcher` moves into the state map.
+    _last_head_oid: Arc<Mutex<String>>,
 }
 
 /// Handle to a pre-repo watcher (watching a directory that is not yet a git repo)
@@ -163,7 +166,22 @@ pub async fn start_git_watcher(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, GitWatcherState>,
 ) -> Result<(), String> {
-    let safe_cwd = validate_cwd(&cwd)?;
+    // The underlying watcher setup is entirely synchronous (notify + std::thread),
+    // so we delegate to a helper that works against the owned state. This also lets
+    // `upgrade_to_repo_watcher` call the same code path without fabricating a
+    // `tauri::State`, which cannot be constructed from an owned value.
+    start_git_watcher_inner(&cwd, app_handle, state.inner())
+}
+
+/// Synchronous core of `start_git_watcher`. Called by both the Tauri command and
+/// the pre-repo upgrade path — works against a cloneable `&GitWatcherState` so it
+/// doesn't require a `tauri::State` handle.
+fn start_git_watcher_inner(
+    cwd: &str,
+    app_handle: tauri::AppHandle,
+    state: &GitWatcherState,
+) -> Result<(), String> {
+    let safe_cwd = validate_cwd(cwd)?;
 
     // Try to resolve repo toplevel
     let toplevel = match resolve_toplevel(&safe_cwd) {
@@ -173,7 +191,7 @@ pub async fn start_git_watcher(
         }
         Err(_) => {
             // Not a repo yet — start pre-repo watcher
-            return start_pre_repo_watcher(safe_cwd, app_handle, state).await;
+            return start_pre_repo_watcher_inner(safe_cwd, app_handle, state);
         }
     };
 
@@ -191,9 +209,7 @@ pub async fn start_git_watcher(
     }
 
     // Create new watcher
-    let toplevel_clone = toplevel.clone();
-    let app_handle_clone = app_handle.clone();
-    let state_clone = state.inner().clone();
+    let state_clone = state.clone();
     let last_head_oid = Arc::new(Mutex::new(
         get_head_oid(&toplevel).unwrap_or_default()
     ));
@@ -301,7 +317,7 @@ pub async fn start_git_watcher(
         subscribers,
         _watcher: watcher,
         stop_flag,
-        last_head_oid,
+        _last_head_oid: last_head_oid,
     };
 
     repo_watchers.insert(toplevel, repo_watcher);
@@ -312,11 +328,14 @@ pub async fn start_git_watcher(
     Ok(())
 }
 
-/// Start a pre-repo watcher (for directories that are not yet git repos)
-async fn start_pre_repo_watcher(
+/// Start a pre-repo watcher (for directories that are not yet git repos).
+///
+/// Takes an owned `&GitWatcherState` (cheap: the state is `Arc`-backed) so it
+/// can be called both from the Tauri command path and from the upgrade path.
+fn start_pre_repo_watcher_inner(
     cwd: PathBuf,
     app_handle: tauri::AppHandle,
-    state: tauri::State<'_, GitWatcherState>,
+    state: &GitWatcherState,
 ) -> Result<(), String> {
     let mut pre_repo_watchers = state.pre_repo_watchers.lock()
         .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
@@ -335,7 +354,7 @@ async fn start_pre_repo_watcher(
     let stop_flag = Arc::new(AtomicBool::new(false));
     let poll_cwd = cwd.clone();
     let poll_app_handle = app_handle.clone();
-    let poll_state = state.inner().clone();
+    let poll_state = state.clone();
     let poll_stop_flag = stop_flag.clone();
 
     std::thread::spawn(move || {
@@ -373,7 +392,12 @@ async fn start_pre_repo_watcher(
     Ok(())
 }
 
-/// Upgrade a pre-repo watcher to a full repo watcher
+/// Upgrade a pre-repo watcher to a full repo watcher.
+///
+/// Removes the pre-repo entry and re-invokes the repo-watcher bootstrap the
+/// same number of times as the prior refcount so subscribers keep their grip.
+/// Calls the synchronous inner helper directly — no `tauri::State` fabrication
+/// and no blocking executor needed.
 fn upgrade_to_repo_watcher(
     cwd: PathBuf,
     app_handle: tauri::AppHandle,
@@ -391,13 +415,9 @@ fn upgrade_to_repo_watcher(
     };
 
     // Start a proper repo watcher (this will handle the refcount internally)
-    let state_handle = tauri::State::from(&state);
+    let cwd_str = cwd.to_string_lossy().to_string();
     for _ in 0..refcount {
-        futures::executor::block_on(start_git_watcher(
-            cwd.to_string_lossy().to_string(),
-            app_handle.clone(),
-            state_handle.clone(),
-        ))?;
+        start_git_watcher_inner(&cwd_str, app_handle.clone(), &state)?;
     }
 
     Ok(())

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -318,6 +318,13 @@ fn start_git_watcher_inner(
         // receives events matching its own input.
         *watcher.subscribers.entry(cwd.to_string()).or_insert(0) += 1;
 
+        // Release `repo_watchers` (lock A) BEFORE acquiring `cwd_to_toplevel`
+        // (lock B). `stop_git_watcher_inner` acquires B first then A, so
+        // holding both here simultaneously would open a deadlock path
+        // against a future caller that reverses the order. Matching the
+        // new-watcher branch below which also releases A before B.
+        drop(repo_watchers);
+
         // Record the cwd → toplevel mapping so stop_git_watcher_inner can
         // find this bucket without re-running `rev-parse` at stop time.
         state
@@ -337,7 +344,14 @@ fn start_git_watcher_inner(
     let last_status_hash = Arc::new(Mutex::new(
         hash_git_status(&toplevel).ok(),
     ));
-    let last_processed = Arc::new(Mutex::new(Instant::now()));
+    // Debounce timestamp starts as `None` so the FIRST real notify event
+    // always passes. Initializing to `Instant::now()` at construction
+    // (the previous revision) would swallow any filesystem change within
+    // the DEBOUNCE_MS window of watcher startup — visible as up-to-10s
+    // stale state when a fast agent edits files right after subscription
+    // (the 10s polling fallback is the only recovery). `None` ≡ "no prior
+    // event, always pass"; after the first match it becomes `Some(now)`.
+    let last_processed: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
     let stop_flag = Arc::new(AtomicBool::new(false));
 
     // Create notify watcher
@@ -370,12 +384,16 @@ fn start_git_watcher_inner(
 
             // Debounce
             {
-                let mut last = last_processed.lock().expect("failed to lock last_processed");
+                let mut last = last_processed
+                    .lock()
+                    .expect("failed to lock last_processed");
                 let now = Instant::now();
-                if now.duration_since(*last) < Duration::from_millis(DEBOUNCE_MS) {
-                    return;
+                if let Some(prev) = *last {
+                    if now.duration_since(prev) < Duration::from_millis(DEBOUNCE_MS) {
+                        return;
+                    }
                 }
-                *last = now;
+                *last = Some(now);
             }
 
             // Emit event for all subscribers

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -197,11 +197,19 @@ pub async fn start_git_watcher(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, GitWatcherState>,
 ) -> Result<(), String> {
-    // The underlying watcher setup is entirely synchronous (notify + std::thread),
-    // so we delegate to a helper that works against the owned state. This also lets
-    // `upgrade_to_repo_watcher` call the same code path without fabricating a
-    // `tauri::State`, which cannot be constructed from an owned value.
-    start_git_watcher_inner(&cwd, app_handle, state.inner())
+    // The inner helper runs blocking `std::process::Command` calls
+    // (rev-parse, git status) and constructs `notify` watchers that do
+    // their own filesystem I/O. Running that work directly on the async
+    // runtime would tie up a Tokio worker thread for the full duration
+    // of the setup — harmful on the bounded Tauri IPC pool. Hop onto the
+    // blocking pool via `spawn_blocking` so the async thread returns
+    // immediately and the sync inner can take as long as it needs.
+    let owned_state = state.inner().clone();
+    tokio::task::spawn_blocking(move || {
+        start_git_watcher_inner(&cwd, app_handle, &owned_state)
+    })
+    .await
+    .map_err(|e| format!("start_git_watcher task panicked: {}", e))?
 }
 
 /// Synchronous core of `start_git_watcher`. Called by both the Tauri command and
@@ -571,6 +579,18 @@ pub async fn stop_git_watcher(
     cwd: String,
     state: tauri::State<'_, GitWatcherState>,
 ) -> Result<(), String> {
+    // Same rationale as `start_git_watcher`: `validate_cwd` and
+    // `resolve_toplevel` both spawn sync subprocess calls; hop to the
+    // blocking pool so the async runtime isn't pinned while they run.
+    let owned_state = state.inner().clone();
+    tokio::task::spawn_blocking(move || stop_git_watcher_inner(cwd, owned_state))
+        .await
+        .map_err(|e| format!("stop_git_watcher task panicked: {}", e))?
+}
+
+/// Synchronous core of `stop_git_watcher`. Owns its state clone so it can
+/// be called from the blocking pool.
+fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), String> {
     let safe_cwd = validate_cwd(&cwd)?;
 
     // Try repo watchers first

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ use agent::{
     stop_transcript_watcher, AgentWatcherState, TranscriptState,
 };
 use filesystem::{list_dir, read_file, write_file};
-use git::{get_git_diff, git_status};
+use git::{get_git_diff, git_status, watcher::{start_git_watcher, stop_git_watcher, GitWatcherState}};
 use terminal::{kill_pty, resize_pty, spawn_pty, write_pty, PtyState};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -26,7 +26,8 @@ pub fn run() {
         })
         .manage(PtyState::new())
         .manage(AgentWatcherState::new())
-        .manage(TranscriptState::new());
+        .manage(TranscriptState::new())
+        .manage(GitWatcherState::new());
 
     #[cfg(not(feature = "e2e-test"))]
     let builder = builder.invoke_handler(tauri::generate_handler![
@@ -43,7 +44,9 @@ pub fn run() {
         read_file,
         write_file,
         git_status,
-        get_git_diff
+        get_git_diff,
+        start_git_watcher,
+        stop_git_watcher
     ]);
 
     #[cfg(feature = "e2e-test")]
@@ -62,6 +65,8 @@ pub fn run() {
         write_file,
         git_status,
         get_git_diff,
+        start_git_watcher,
+        stop_git_watcher,
         terminal::test_commands::list_active_pty_sessions
     ]);
 

--- a/src/features/agent-status/components/AgentStatusPanel.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.test.tsx
@@ -18,9 +18,27 @@ const defaultStatus: AgentStatus = {
   recentToolCalls: [],
 }
 
+const defaultGitStatus = {
+  files: [],
+  filesCwd: '/test',
+  loading: false,
+  error: null,
+  refresh: vi.fn(),
+}
+
 vi.mock('../hooks/useAgentStatus', () => ({
   useAgentStatus: vi.fn(() => defaultStatus),
 }))
+
+vi.mock('../../diff/hooks/useGitStatus', () => ({
+  useGitStatus: vi.fn(() => defaultGitStatus),
+}))
+
+const defaultProps = {
+  sessionId: null as string | null,
+  cwd: '/test',
+  onOpenDiff: vi.fn(),
+}
 
 describe('AgentStatusPanel', () => {
   test('renders at 0px width when agent is not active', async () => {
@@ -30,7 +48,7 @@ describe('AgentStatusPanel', () => {
       isActive: false,
     })
 
-    render(<AgentStatusPanel sessionId={null} />)
+    render(<AgentStatusPanel {...defaultProps} sessionId={null} />)
 
     const panel = screen.getByTestId('agent-status-panel')
     expect(panel.style.width).toBe('0px')
@@ -45,7 +63,7 @@ describe('AgentStatusPanel', () => {
       sessionId: 'session-1',
     })
 
-    render(<AgentStatusPanel sessionId="session-1" />)
+    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
 
     const panel = screen.getByTestId('agent-status-panel')
     expect(panel.style.width).toBe('280px')
@@ -58,7 +76,7 @@ describe('AgentStatusPanel', () => {
       isActive: false,
     })
 
-    render(<AgentStatusPanel sessionId={null} />)
+    render(<AgentStatusPanel {...defaultProps} sessionId={null} />)
 
     const panel = screen.getByTestId('agent-status-panel')
     expect(panel.style.transition).toBe('width 200ms ease-out')
@@ -73,7 +91,7 @@ describe('AgentStatusPanel', () => {
       sessionId: 'session-1',
     })
 
-    render(<AgentStatusPanel sessionId="session-1" />)
+    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
 
     const panel = screen.getByTestId('agent-status-panel')
     expect(panel.style.transition).toBe('width 200ms ease-in')
@@ -83,7 +101,7 @@ describe('AgentStatusPanel', () => {
     const { useAgentStatus } = await import('../hooks/useAgentStatus')
     vi.mocked(useAgentStatus).mockReturnValue(defaultStatus)
 
-    render(<AgentStatusPanel sessionId={null} />)
+    render(<AgentStatusPanel {...defaultProps} sessionId={null} />)
 
     const panel = screen.getByTestId('agent-status-panel')
     expect(panel).toHaveClass('overflow-hidden')
@@ -93,7 +111,7 @@ describe('AgentStatusPanel', () => {
     const { useAgentStatus } = await import('../hooks/useAgentStatus')
     vi.mocked(useAgentStatus).mockReturnValue(defaultStatus)
 
-    render(<AgentStatusPanel sessionId="session-42" />)
+    render(<AgentStatusPanel {...defaultProps} sessionId="session-42" />)
 
     expect(useAgentStatus).toHaveBeenCalledWith('session-42')
   })
@@ -122,7 +140,7 @@ describe('AgentStatusPanel', () => {
       ],
     })
 
-    render(<AgentStatusPanel sessionId="session-1" />)
+    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
 
     const toolCallsHeader = screen.getByRole('button', { name: /tool calls/i })
     const activityHeader = screen.getByRole('button', { name: /activity/i })
@@ -144,7 +162,9 @@ describe('AgentStatusPanel', () => {
       sessionId: 'session-1',
     })
 
-    const { container } = render(<AgentStatusPanel sessionId="session-1" />)
+    const { container } = render(
+      <AgentStatusPanel {...defaultProps} sessionId="session-1" />
+    )
 
     // The scroll region wraps ActivityFeed + ToolCallSummary + FilesChanged +
     // TestResults so the lower sections remain reachable when the ActivityFeed
@@ -179,7 +199,7 @@ describe('AgentStatusPanel', () => {
       ],
     })
 
-    render(<AgentStatusPanel sessionId="session-1" />)
+    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
 
     // ToolCallSummary: renders the byType chip label "Edit".
     expect(screen.getAllByText('Edit').length).toBeGreaterThan(0)

--- a/src/features/agent-status/components/AgentStatusPanel.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.test.tsx
@@ -24,6 +24,7 @@ const defaultGitStatus = {
   loading: false,
   error: null,
   refresh: vi.fn(),
+  idle: false,
 }
 
 vi.mock('../hooks/useAgentStatus', () => ({

--- a/src/features/agent-status/components/AgentStatusPanel.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.tsx
@@ -28,7 +28,7 @@ export const AgentStatusPanel = ({
   const events = useActivityEvents(status)
 
   // Git status with file-system watcher
-  const { files, filesCwd, loading, error, refresh } = useGitStatus(cwd, {
+  const { files, filesCwd, loading, error, refresh, idle } = useGitStatus(cwd, {
     watch: true,
     enabled: status.isActive,
   })
@@ -37,7 +37,12 @@ export const AgentStatusPanel = ({
   const filesAreFresh = filesCwd === cwd
   const effectiveFiles = filesAreFresh ? files : []
 
-  const effectiveLoading = loading || (!filesAreFresh && error === null)
+  // Gate the transitional-loading arm on the hook actually running. When
+  // `idle` is true (hook short-circuited because enabled=false or cwd is
+  // a fallback), `filesCwd` stays null forever and `!filesAreFresh` would
+  // otherwise spin "Loading…" indefinitely. An idle hook never loads.
+  const effectiveLoading =
+    !idle && (loading || (!filesAreFresh && error === null))
 
   return (
     <div

--- a/src/features/agent-status/components/AgentStatusPanel.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.tsx
@@ -8,14 +8,11 @@ import { TestResults } from './TestResults'
 import { ActivityFooter } from './ActivityFooter'
 import { ActivityFeed } from './ActivityFeed'
 import { useActivityEvents } from '../hooks/useActivityEvents'
-import type { FileChangeItem } from './FilesChanged'
 
 interface AgentStatusPanelProps {
   sessionId: string | null
 }
 
-// TODO: derive from tool calls in useAgentStatus hook
-const placeholderFiles: FileChangeItem[] = []
 const placeholderTests = { passed: 0, failed: 0, total: 0 }
 
 export const AgentStatusPanel = ({
@@ -65,7 +62,16 @@ export const AgentStatusPanel = ({
               active={status.toolCalls.active}
             />
             <ActivityFeed events={events} />
-            <FilesChanged files={placeholderFiles} />
+            <FilesChanged
+              files={[]}
+              error={null}
+              onRetry={(): void => {
+                // TODO: wire to git status refresh in Feature #12
+              }}
+              onSelect={(): void => {
+                // TODO: wire to diff viewer in Feature #12
+              }}
+            />
             <TestResults
               passed={placeholderTests.passed}
               failed={placeholderTests.failed}

--- a/src/features/agent-status/components/AgentStatusPanel.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.tsx
@@ -8,18 +8,36 @@ import { TestResults } from './TestResults'
 import { ActivityFooter } from './ActivityFooter'
 import { ActivityFeed } from './ActivityFeed'
 import { useActivityEvents } from '../hooks/useActivityEvents'
+import { useGitStatus } from '../../diff/hooks/useGitStatus'
+import type { ChangedFile } from '../../diff/types'
 
 interface AgentStatusPanelProps {
   sessionId: string | null
+  cwd: string
+  onOpenDiff: (file: ChangedFile) => void
 }
 
 const placeholderTests = { passed: 0, failed: 0, total: 0 }
 
 export const AgentStatusPanel = ({
   sessionId,
+  cwd,
+  onOpenDiff,
 }: AgentStatusPanelProps): ReactElement => {
   const status = useAgentStatus(sessionId)
   const events = useActivityEvents(status)
+
+  // Git status with file-system watcher
+  const { files, filesCwd, loading, error, refresh } = useGitStatus(cwd, {
+    watch: true,
+    enabled: status.isActive,
+  })
+
+  // Freshness check — files are only valid if they came from the current cwd
+  const filesAreFresh = filesCwd === cwd
+  const effectiveFiles = filesAreFresh ? files : []
+
+  const effectiveLoading = loading || (!filesAreFresh && error === null)
 
   return (
     <div
@@ -63,14 +81,11 @@ export const AgentStatusPanel = ({
             />
             <ActivityFeed events={events} />
             <FilesChanged
-              files={[]}
-              error={null}
-              onRetry={(): void => {
-                // TODO: wire to git status refresh in Feature #12
-              }}
-              onSelect={(): void => {
-                // TODO: wire to diff viewer in Feature #12
-              }}
+              files={effectiveFiles}
+              loading={effectiveLoading}
+              error={error}
+              onRetry={refresh}
+              onSelect={onOpenDiff}
             />
             <TestResults
               passed={placeholderTests.passed}

--- a/src/features/agent-status/components/FilesChanged.test.tsx
+++ b/src/features/agent-status/components/FilesChanged.test.tsx
@@ -1,82 +1,406 @@
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ChangedFile } from '../../diff/types'
 import { FilesChanged } from './FilesChanged'
-import type { FileChangeItem } from './FilesChanged'
 
-const mockFiles: FileChangeItem[] = [
-  { path: 'src/components/App.tsx', type: 'new' },
-  { path: 'src/utils/helpers.ts', type: 'modified' },
-  { path: 'src/old/legacy.ts', type: 'deleted' },
+const mockFiles: ChangedFile[] = [
+  {
+    path: 'src/components/App.tsx',
+    status: 'added',
+    insertions: 45,
+    deletions: 0,
+    staged: true,
+  },
+  {
+    path: 'src/utils/helpers.ts',
+    status: 'modified',
+    insertions: 12,
+    deletions: 3,
+    staged: false,
+  },
+  {
+    path: 'src/old/legacy.ts',
+    status: 'deleted',
+    insertions: 0,
+    deletions: 18,
+    staged: false,
+  },
 ]
 
 describe('FilesChanged', () => {
-  test('renders correct prefix symbols for each type', async () => {
-    const user = userEvent.setup()
-    render(<FilesChanged files={mockFiles} />)
+  describe('empty states', () => {
+    test('shows "No uncommitted changes" when empty and not loading', (): void => {
+      render(
+        <FilesChanged
+          files={[]}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
 
-    await user.click(screen.getByRole('button', { name: /files changed/i }))
+      expect(screen.getByText('No uncommitted changes')).toBeInTheDocument()
+    })
 
-    expect(screen.getByText('+')).toBeInTheDocument()
-    expect(screen.getByText('~')).toBeInTheDocument()
-    expect(screen.getByText('-')).toBeInTheDocument()
+    test('shows "Loading..." when empty and loading', (): void => {
+      render(
+        <FilesChanged
+          files={[]}
+          loading
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument()
+    })
+
+    test('shows error message and retry button when empty with error', async (): Promise<void> => {
+      const onRetry = vi.fn()
+      const user = userEvent.setup()
+      const error = new Error('Git command failed')
+
+      render(
+        <FilesChanged
+          files={[]}
+          error={error}
+          onRetry={onRetry}
+          onSelect={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('Failed to load git status')).toBeInTheDocument()
+
+      const retryButton = screen.getByRole('button', { name: /retry/i })
+      expect(retryButton).toBeInTheDocument()
+
+      await user.click(retryButton)
+      expect(onRetry).toHaveBeenCalledOnce()
+    })
   })
 
-  test('renders correct badges for each type', async () => {
-    const user = userEvent.setup()
-    render(<FilesChanged files={mockFiles} />)
+  describe('populated states', () => {
+    test('renders file list when loading is true but files exist (stale data)', (): void => {
+      render(
+        <FilesChanged
+          files={mockFiles}
+          loading
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
 
-    await user.click(screen.getByRole('button', { name: /files changed/i }))
+      // Section starts expanded (defaultExpanded)
+      expect(screen.getByText('src/components/App.tsx')).toBeInTheDocument()
+      expect(screen.getByText('src/utils/helpers.ts')).toBeInTheDocument()
+      expect(screen.getByText('src/old/legacy.ts')).toBeInTheDocument()
 
-    expect(screen.getByText('NEW')).toBeInTheDocument()
-    expect(screen.getByText('EDIT')).toBeInTheDocument()
-    expect(screen.getByText('DEL')).toBeInTheDocument()
+      // No need to click to expand (already expanded)
+      // Count is shown
+      expect(screen.getByText('3')).toBeInTheDocument()
+    })
+
+    test('shows error banner when error is set but files exist', (): void => {
+      const error = new Error('Refresh failed')
+
+      render(
+        <FilesChanged
+          files={mockFiles}
+          error={error}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
+
+      const banner = screen.getByRole('alert')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveTextContent('Stale data — refresh failed')
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+
+      // Files are still shown
+      expect(screen.getByText('src/components/App.tsx')).toBeInTheDocument()
+    })
+
+    test('retry button in banner calls onRetry', async (): Promise<void> => {
+      const onRetry = vi.fn()
+      const user = userEvent.setup()
+      const error = new Error('Failed')
+
+      render(
+        <FilesChanged
+          files={mockFiles}
+          error={error}
+          onRetry={onRetry}
+          onSelect={vi.fn()}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /retry/i }))
+      expect(onRetry).toHaveBeenCalledOnce()
+    })
   })
 
-  test('renders file paths', async () => {
-    const user = userEvent.setup()
-    render(<FilesChanged files={mockFiles} />)
+  describe('file row rendering', () => {
+    test('clicking a file row calls onSelect with the ChangedFile', async (): Promise<void> => {
+      const onSelect = vi.fn()
+      const user = userEvent.setup()
 
-    await user.click(screen.getByRole('button', { name: /files changed/i }))
+      render(
+        <FilesChanged
+          files={mockFiles}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={onSelect}
+        />
+      )
 
-    expect(screen.getByText('src/components/App.tsx')).toBeInTheDocument()
-    expect(screen.getByText('src/utils/helpers.ts')).toBeInTheDocument()
-    expect(screen.getByText('src/old/legacy.ts')).toBeInTheDocument()
+      await user.click(screen.getByText('src/utils/helpers.ts'))
+
+      expect(onSelect).toHaveBeenCalledOnce()
+      expect(onSelect).toHaveBeenCalledWith(mockFiles[1])
+    })
+
+    test('renders correct prefix symbols for each status', (): void => {
+      render(
+        <FilesChanged
+          files={mockFiles}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
+
+      // added → +
+      expect(screen.getByText('+')).toBeInTheDocument()
+      // modified → ~
+      expect(screen.getByText('~')).toBeInTheDocument()
+      // deleted → -
+      expect(screen.getByText('-')).toBeInTheDocument()
+    })
+
+    test('renders correct badges for each status', (): void => {
+      render(
+        <FilesChanged
+          files={mockFiles}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('NEW')).toBeInTheDocument()
+      expect(screen.getByText('EDIT')).toBeInTheDocument()
+      expect(screen.getByText('DEL')).toBeInTheDocument()
+    })
+
+    test('renders +N / -N when both insertions and deletions are numbers', (): void => {
+      render(
+        <FilesChanged
+          files={mockFiles}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('+45 / -0')).toBeInTheDocument()
+      expect(screen.getByText('+12 / -3')).toBeInTheDocument()
+      expect(screen.getByText('+0 / -18')).toBeInTheDocument()
+    })
+
+    test('does not render +N / -N when insertions or deletions are undefined', (): void => {
+      // cspell:disable-next-line -- numstat is a git term
+      const filesWithoutNumstat: ChangedFile[] = [
+        {
+          path: 'binary-file.png',
+          status: 'modified',
+          staged: false,
+          // No insertions/deletions (binary file)
+        },
+      ]
+
+      render(
+        <FilesChanged
+          // cspell:disable-next-line -- numstat is a git term
+          files={filesWithoutNumstat}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
+
+      // Should not render +N / -N
+      expect(screen.queryByText(/\+\d+ \/ -\d+/)).not.toBeInTheDocument()
+    })
+
+    test('renders STAGED label for staged files', (): void => {
+      render(
+        <FilesChanged
+          files={mockFiles}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
+
+      // Only one file is staged (App.tsx)
+      expect(screen.getByText('STAGED')).toBeInTheDocument()
+
+      // Count of STAGED labels should be 1
+      const stagedLabels = screen.getAllByText('STAGED')
+      expect(stagedLabels).toHaveLength(1)
+    })
+
+    test('does not render STAGED label for unstaged files', (): void => {
+      const unstagedFiles: ChangedFile[] = [
+        {
+          path: 'src/test.ts',
+          status: 'modified',
+          insertions: 5,
+          deletions: 2,
+          staged: false,
+        },
+      ]
+
+      render(
+        <FilesChanged
+          files={unstagedFiles}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByText('STAGED')).not.toBeInTheDocument()
+    })
   })
 
-  test('shows file count in section header', () => {
-    render(<FilesChanged files={mockFiles} />)
+  describe('MM/AM disambiguation', () => {
+    test('renders two rows for files with same path but different staged flags', async (): Promise<void> => {
+      const mmFiles: ChangedFile[] = [
+        {
+          path: 'src/both.ts',
+          status: 'modified',
+          insertions: 10,
+          deletions: 5,
+          staged: true,
+        },
+        {
+          path: 'src/both.ts',
+          status: 'modified',
+          insertions: 3,
+          deletions: 1,
+          staged: false,
+        },
+      ]
 
-    expect(screen.getByText('3')).toBeInTheDocument()
+      const onSelect = vi.fn()
+      const user = userEvent.setup()
+
+      render(
+        <FilesChanged
+          files={mmFiles}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={onSelect}
+        />
+      )
+
+      // Two rows with the same path
+      const pathElements = screen.getAllByText('src/both.ts')
+      expect(pathElements).toHaveLength(2)
+
+      // One has STAGED label
+      expect(screen.getByText('STAGED')).toBeInTheDocument()
+
+      // Clicking each row calls onSelect with the correct file
+      await user.click(pathElements[0])
+      expect(onSelect).toHaveBeenCalledWith(mmFiles[0])
+
+      await user.click(pathElements[1])
+      expect(onSelect).toHaveBeenCalledWith(mmFiles[1])
+    })
+
+    test('uses unique row keys for MM/AM files', (): void => {
+      const mmFiles: ChangedFile[] = [
+        {
+          path: 'src/both.ts',
+          status: 'modified',
+          insertions: 10,
+          deletions: 5,
+          staged: true,
+        },
+        {
+          path: 'src/both.ts',
+          status: 'modified',
+          insertions: 3,
+          deletions: 1,
+          staged: false,
+        },
+      ]
+
+      render(
+        <FilesChanged
+          files={mmFiles}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
+
+      // Both rows should render (no key collision)
+      // Verify by checking that both path elements are present
+      const pathElements = screen.getAllByText('src/both.ts')
+      expect(pathElements).toHaveLength(2)
+    })
   })
 
-  test('applies green color to new file prefix', async () => {
-    const user = userEvent.setup()
-    render(<FilesChanged files={[{ path: 'new.ts', type: 'new' }]} />)
+  describe('default expanded', () => {
+    test('section is expanded by default', (): void => {
+      render(
+        <FilesChanged
+          files={mockFiles}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
 
-    await user.click(screen.getByRole('button', { name: /files changed/i }))
-
-    const prefix = screen.getByText('+')
-    expect(prefix).toHaveClass('text-success')
+      // Files are visible without needing to click
+      expect(screen.getByText('src/components/App.tsx')).toBeInTheDocument()
+      expect(screen.getByText('src/utils/helpers.ts')).toBeInTheDocument()
+      expect(screen.getByText('src/old/legacy.ts')).toBeInTheDocument()
+    })
   })
 
-  test('applies blue color to modified file prefix', async () => {
-    const user = userEvent.setup()
-    render(<FilesChanged files={[{ path: 'mod.ts', type: 'modified' }]} />)
+  describe('file count', () => {
+    test('shows file count in section header', (): void => {
+      render(
+        <FilesChanged
+          files={mockFiles}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
 
-    await user.click(screen.getByRole('button', { name: /files changed/i }))
+      expect(screen.getByText('3')).toBeInTheDocument()
+    })
 
-    const prefix = screen.getByText('~')
-    expect(prefix).toHaveClass('text-secondary')
-  })
+    test('shows 0 count when no files', (): void => {
+      render(
+        <FilesChanged
+          files={[]}
+          error={null}
+          onRetry={vi.fn()}
+          onSelect={vi.fn()}
+        />
+      )
 
-  test('applies red color to deleted file prefix', async () => {
-    const user = userEvent.setup()
-    render(<FilesChanged files={[{ path: 'del.ts', type: 'deleted' }]} />)
-
-    await user.click(screen.getByRole('button', { name: /files changed/i }))
-
-    const prefix = screen.getByText('-')
-    expect(prefix).toHaveClass('text-error')
+      expect(screen.getByText('0')).toBeInTheDocument()
+    })
   })
 })

--- a/src/features/agent-status/components/FilesChanged.tsx
+++ b/src/features/agent-status/components/FilesChanged.tsx
@@ -103,8 +103,13 @@ export const FilesChanged = ({
                 <span className="min-w-0 flex-1 truncate font-mono text-[10px] text-on-surface-variant">
                   {file.path}
                 </span>
+                {/* Suppress the badge for (0, 0) — e.g. an empty untracked
+                    file where `git diff --no-index` reports no additions
+                    AND no deletions. `+0 / -0` is visually confusing
+                    (looks like a rendering bug) and carries no info. */}
                 {typeof file.insertions === 'number' &&
-                  typeof file.deletions === 'number' && (
+                  typeof file.deletions === 'number' &&
+                  (file.insertions > 0 || file.deletions > 0) && (
                     <span className="text-[9px] text-outline">
                       +{file.insertions} / -{file.deletions}
                     </span>

--- a/src/features/agent-status/components/FilesChanged.tsx
+++ b/src/features/agent-status/components/FilesChanged.tsx
@@ -1,40 +1,133 @@
 import type { ReactElement } from 'react'
+import type { ChangedFile } from '../../diff/types'
 import { CollapsibleSection } from './CollapsibleSection'
 
-export interface FileChangeItem {
-  path: string
-  type: 'new' | 'modified' | 'deleted'
-}
-
 interface FilesChangedProps {
-  files: FileChangeItem[]
+  files: ChangedFile[]
+  loading?: boolean
+  error: Error | null
+  onRetry: () => void
+  onSelect: (file: ChangedFile) => void
 }
 
-const prefixMap: Record<
-  FileChangeItem['type'],
+const statusMap: Record<
+  ChangedFile['status'],
   { symbol: string; color: string; badge: string }
 > = {
-  new: { symbol: '+', color: 'text-success', badge: 'NEW' },
+  added: { symbol: '+', color: 'text-success', badge: 'NEW' },
   modified: { symbol: '~', color: 'text-secondary', badge: 'EDIT' },
   deleted: { symbol: '-', color: 'text-error', badge: 'DEL' },
+  renamed: { symbol: '→', color: 'text-secondary', badge: 'REN' },
+  untracked: { symbol: '?', color: 'text-outline', badge: 'NEW' },
 }
 
-export const FilesChanged = ({ files }: FilesChangedProps): ReactElement => (
-  <CollapsibleSection title="Files Changed" count={files.length}>
-    <div className="flex flex-col gap-1">
-      {files.map((file) => {
-        const { symbol, color, badge } = prefixMap[file.type]
-
+export const FilesChanged = ({
+  files,
+  loading = false,
+  error,
+  onRetry,
+  onSelect,
+}: FilesChangedProps): ReactElement => {
+  const renderContent = (): ReactElement => {
+    // Empty list states
+    if (files.length === 0) {
+      if (loading) {
         return (
-          <div key={file.path} className="flex items-center gap-2">
-            <span className={`font-mono text-[10px] ${color}`}>{symbol}</span>
-            <span className="min-w-0 flex-1 truncate font-mono text-[10px] text-on-surface-variant">
-              {file.path}
-            </span>
-            <span className="text-[9px] text-outline">{badge}</span>
+          <div className="px-3 py-2 text-[10px] text-on-surface-variant">
+            Loading...
           </div>
         )
-      })}
-    </div>
-  </CollapsibleSection>
-)
+      }
+
+      if (error) {
+        return (
+          <div className="flex flex-col gap-2 px-3 py-2">
+            <div className="text-[10px] text-error">
+              Failed to load git status
+            </div>
+            <button
+              onClick={onRetry}
+              className="self-start text-[10px] text-primary hover:underline"
+              type="button"
+            >
+              Retry
+            </button>
+          </div>
+        )
+      }
+
+      return (
+        <div className="px-3 py-2 text-[10px] text-on-surface-variant">
+          No uncommitted changes
+        </div>
+      )
+    }
+
+    // Populated list with optional error banner
+    return (
+      <div className="flex flex-col">
+        {error && (
+          <div
+            role="alert"
+            className="flex items-center justify-between border-b border-outline-variant bg-error-container px-3 py-1.5"
+          >
+            <span className="text-[9px] text-on-error-container">
+              Stale data — refresh failed
+            </span>
+            <button
+              onClick={onRetry}
+              className="text-[9px] text-on-error-container hover:underline"
+              type="button"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        <div className="flex flex-col gap-1 px-3 py-2">
+          {files.map((file) => {
+            const { symbol, color, badge } = statusMap[file.status]
+            const rowKey = `${file.path}:${file.staged}`
+
+            return (
+              <button
+                key={rowKey}
+                onClick={(): void => {
+                  onSelect(file)
+                }}
+                className="flex items-center gap-2 text-left hover:bg-surface-container-high"
+                type="button"
+              >
+                <span className={`font-mono text-[10px] ${color}`}>
+                  {symbol}
+                </span>
+                <span className="min-w-0 flex-1 truncate font-mono text-[10px] text-on-surface-variant">
+                  {file.path}
+                </span>
+                {typeof file.insertions === 'number' &&
+                  typeof file.deletions === 'number' && (
+                    <span className="text-[9px] text-outline">
+                      +{file.insertions} / -{file.deletions}
+                    </span>
+                  )}
+                {file.staged && (
+                  <span className="text-[9px] text-secondary">STAGED</span>
+                )}
+                <span className="text-[9px] text-outline">{badge}</span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <CollapsibleSection
+      title="Files Changed"
+      count={files.length}
+      defaultExpanded
+    >
+      {renderContent()}
+    </CollapsibleSection>
+  )
+}

--- a/src/features/diff/components/ChangedFilesList.test.tsx
+++ b/src/features/diff/components/ChangedFilesList.test.tsx
@@ -33,7 +33,7 @@ describe('ChangedFilesList', () => {
     render(
       <ChangedFilesList
         files={mockFiles}
-        selectedPath={null}
+        selectedFile={null}
         onSelectFile={vi.fn()}
       />
     )
@@ -48,7 +48,7 @@ describe('ChangedFilesList', () => {
     render(
       <ChangedFilesList
         files={mockFiles}
-        selectedPath={null}
+        selectedFile={null}
         onSelectFile={vi.fn()}
       />
     )
@@ -67,7 +67,7 @@ describe('ChangedFilesList', () => {
     render(
       <ChangedFilesList
         files={mockFiles}
-        selectedPath={null}
+        selectedFile={null}
         onSelectFile={vi.fn()}
       />
     )
@@ -87,7 +87,7 @@ describe('ChangedFilesList', () => {
     const { container } = render(
       <ChangedFilesList
         files={mockFiles}
-        selectedPath="src/components/NavBar.tsx"
+        selectedFile={{ path: 'src/components/NavBar.tsx', staged: false }}
         onSelectFile={vi.fn()}
       />
     )
@@ -108,7 +108,7 @@ describe('ChangedFilesList', () => {
     render(
       <ChangedFilesList
         files={mockFiles}
-        selectedPath={null}
+        selectedFile={null}
         onSelectFile={handleSelect}
       />
     )
@@ -117,7 +117,7 @@ describe('ChangedFilesList', () => {
 
     await user.click(navBarFile)
 
-    expect(handleSelect).toHaveBeenCalledWith('src/components/NavBar.tsx')
+    expect(handleSelect).toHaveBeenCalledWith(mockFiles[0])
   })
 
   test('renders files in the order provided (sorting done by parent)', () => {
@@ -148,7 +148,7 @@ describe('ChangedFilesList', () => {
     render(
       <ChangedFilesList
         files={orderedFiles}
-        selectedPath={null}
+        selectedFile={null}
         onSelectFile={vi.fn()}
       />
     )
@@ -167,7 +167,7 @@ describe('ChangedFilesList', () => {
     const { container } = render(
       <ChangedFilesList
         files={mockFiles}
-        selectedPath={null}
+        selectedFile={null}
         onSelectFile={vi.fn()}
       />
     )
@@ -193,7 +193,7 @@ describe('ChangedFilesList', () => {
     render(
       <ChangedFilesList
         files={longPathFile}
-        selectedPath={null}
+        selectedFile={null}
         onSelectFile={vi.fn()}
       />
     )
@@ -206,7 +206,7 @@ describe('ChangedFilesList', () => {
 
   test('renders empty state when no files', () => {
     render(
-      <ChangedFilesList files={[]} selectedPath={null} onSelectFile={vi.fn()} />
+      <ChangedFilesList files={[]} selectedFile={null} onSelectFile={vi.fn()} />
     )
 
     const header = screen.getByText(/Changed Files/i)
@@ -221,7 +221,7 @@ describe('ChangedFilesList', () => {
     const { container } = render(
       <ChangedFilesList
         files={mockFiles}
-        selectedPath={null}
+        selectedFile={null}
         onSelectFile={vi.fn()}
       />
     )
@@ -235,5 +235,79 @@ describe('ChangedFilesList', () => {
     const deletionText = container.querySelector('.text-\\[\\#f38ba8\\]')
 
     expect(deletionText).toBeInTheDocument()
+  })
+
+  test('MM/AM disambiguation: renders two rows for files with same path but different staged flags', async () => {
+    const mmFiles: ChangedFile[] = [
+      {
+        path: 'src/both.ts',
+        status: 'modified',
+        insertions: 10,
+        deletions: 5,
+        staged: true,
+      },
+      {
+        path: 'src/both.ts',
+        status: 'modified',
+        insertions: 3,
+        deletions: 1,
+        staged: false,
+      },
+    ]
+
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ChangedFilesList
+        files={mmFiles}
+        selectedFile={null}
+        onSelectFile={onSelect}
+      />
+    )
+
+    // Two rows with the same filename
+    const fileButtons = screen.getAllByText('both.ts')
+
+    expect(fileButtons).toHaveLength(2)
+
+    // Clicking each row calls onSelect with the correct file
+    await user.click(fileButtons[0])
+    expect(onSelect).toHaveBeenCalledWith(mmFiles[0])
+
+    await user.click(fileButtons[1])
+    expect(onSelect).toHaveBeenCalledWith(mmFiles[1])
+  })
+
+  test('uses unique row keys for MM/AM files (no key collision)', () => {
+    const mmFiles: ChangedFile[] = [
+      {
+        path: 'src/both.ts',
+        status: 'modified',
+        insertions: 10,
+        deletions: 5,
+        staged: true,
+      },
+      {
+        path: 'src/both.ts',
+        status: 'modified',
+        insertions: 3,
+        deletions: 1,
+        staged: false,
+      },
+    ]
+
+    render(
+      <ChangedFilesList
+        files={mmFiles}
+        selectedFile={null}
+        onSelectFile={vi.fn()}
+      />
+    )
+
+    // Both rows should render (no key collision causes React to drop one)
+    const fileButtons = screen.getAllByText('both.ts')
+
+    expect(fileButtons).toHaveLength(2)
   })
 })

--- a/src/features/diff/components/ChangedFilesList.tsx
+++ b/src/features/diff/components/ChangedFilesList.tsx
@@ -3,8 +3,8 @@ import type { ChangedFile } from '../types'
 
 export interface ChangedFilesListProps {
   files: ChangedFile[]
-  selectedPath: string | null
-  onSelectFile: (path: string) => void
+  selectedFile: { path: string; staged: boolean } | null
+  onSelectFile: (file: ChangedFile) => void
 }
 
 /**
@@ -41,7 +41,7 @@ const getFileIcon = (filename: string): string => {
  */
 export const ChangedFilesList = ({
   files,
-  selectedPath,
+  selectedFile,
   onSelectFile,
 }: ChangedFilesListProps): ReactElement => (
   <div className="flex h-full flex-col p-4">
@@ -54,14 +54,16 @@ export const ChangedFilesList = ({
     {/* File List — scrollable with thin scrollbar */}
     <div className="thin-scrollbar flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto pr-1">
       {files.map((file) => {
-        const isActive = file.path === selectedPath
+        const isActive =
+          selectedFile?.path === file.path &&
+          selectedFile.staged === file.staged
         const fileName = file.path.split('/').pop() ?? file.path
         const icon = getFileIcon(fileName)
 
         return (
           <button
-            key={file.path}
-            onClick={(): void => onSelectFile(file.path)}
+            key={`${file.path}:${file.staged}`}
+            onClick={(): void => onSelectFile(file)}
             className={`flex items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors ${
               isActive
                 ? 'bg-surface-container-highest/40'

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -21,6 +21,7 @@ describe('DiffPanelContent', () => {
       loading: true,
       error: null,
       refresh: vi.fn(),
+      idle: false,
     })
 
     vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
@@ -43,6 +44,7 @@ describe('DiffPanelContent', () => {
       loading: false,
       error,
       refresh: vi.fn(),
+      idle: false,
     })
 
     vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
@@ -66,6 +68,7 @@ describe('DiffPanelContent', () => {
       loading: false,
       error: null,
       refresh: vi.fn(),
+      idle: false,
     })
 
     vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
@@ -120,6 +123,7 @@ describe('DiffPanelContent', () => {
       loading: false,
       error: null,
       refresh: vi.fn(),
+      idle: false,
     })
 
     vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
@@ -147,6 +151,7 @@ describe('DiffPanelContent', () => {
         loading: false,
         error: null,
         refresh: vi.fn(),
+        idle: false,
       })
 
     const useFileDiffSpy = vi
@@ -186,6 +191,7 @@ describe('DiffPanelContent', () => {
         loading: false,
         error: null,
         refresh: vi.fn(),
+        idle: false,
       })
 
       const useFileDiffSpy = vi
@@ -224,6 +230,7 @@ describe('DiffPanelContent', () => {
         loading: false,
         error: null,
         refresh: vi.fn(),
+        idle: false,
       })
 
       vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
@@ -265,6 +272,7 @@ describe('DiffPanelContent', () => {
         loading: false,
         error: null,
         refresh: vi.fn(),
+        idle: false,
       })
 
       vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
@@ -305,6 +313,7 @@ describe('DiffPanelContent', () => {
         loading: false,
         error: null,
         refresh: vi.fn(),
+        idle: false,
       })
 
       const mockDiff: FileDiff = {
@@ -362,6 +371,7 @@ describe('DiffPanelContent', () => {
         loading: false,
         error: null,
         refresh: vi.fn(),
+        idle: false,
       })
 
       const untrackedDiff = {
@@ -431,6 +441,7 @@ describe('DiffPanelContent', () => {
         loading: false,
         error: null,
         refresh: vi.fn(),
+        idle: false,
       })
 
       const useFileDiffSpy = vi
@@ -462,6 +473,7 @@ describe('DiffPanelContent', () => {
         loading: false,
         error: null,
         refresh: vi.fn(),
+        idle: false,
       })
 
       const useFileDiffSpy = vi

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -62,7 +62,7 @@ describe('DiffPanelContent', () => {
   test('renders empty state when no changes exist', (): void => {
     vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
       files: [],
-      filesCwd: null,
+      filesCwd: '.',
       loading: false,
       error: null,
       refresh: vi.fn(),
@@ -116,7 +116,7 @@ describe('DiffPanelContent', () => {
 
     vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
       files: mockFiles,
-      filesCwd: '/test/cwd',
+      filesCwd: '.',
       loading: false,
       error: null,
       refresh: vi.fn(),
@@ -159,11 +159,297 @@ describe('DiffPanelContent', () => {
 
     render(<DiffPanelContent cwd="/home/user/project" />)
 
-    expect(useGitStatusSpy).toHaveBeenCalledWith('/home/user/project')
+    expect(useGitStatusSpy).toHaveBeenCalledWith('/home/user/project', {
+      watch: true,
+    })
+
     expect(useFileDiffSpy).toHaveBeenCalledWith(
       null,
       false,
       '/home/user/project'
     )
+  })
+
+  describe('Controlled mode', () => {
+    test('render-time cwd guard: ignores selection from different cwd', (): void => {
+      const mockFiles: ChangedFile[] = [
+        {
+          path: 'src/App.tsx',
+          status: 'modified',
+          staged: false,
+        },
+      ]
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: mockFiles,
+        filesCwd: '/repo/b',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+
+      const useFileDiffSpy = vi
+        .spyOn(useFileDiffModule, 'useFileDiff')
+        .mockReturnValue({
+          diff: null,
+          loading: false,
+          error: null,
+        })
+
+      // selectedFile is from /repo/a but current cwd is /repo/b
+      render(
+        <DiffPanelContent
+          cwd="/repo/b"
+          selectedFile={{ path: 'src/App.tsx', staged: false, cwd: '/repo/a' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      // useFileDiff should be called with null (selection ignored)
+      expect(useFileDiffSpy).toHaveBeenCalledWith(null, false, '/repo/b')
+    })
+
+    test('auto-select gated on filesCwd: only fires when filesCwd matches cwd', (): void => {
+      const mockFiles: ChangedFile[] = [
+        {
+          path: 'src/App.tsx',
+          status: 'modified',
+          staged: false,
+        },
+      ]
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: mockFiles,
+        filesCwd: '/repo/a', // Fresh data
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
+        diff: null,
+        loading: false,
+        error: null,
+      })
+
+      const onSelectedFileChange = vi.fn()
+
+      render(
+        <DiffPanelContent
+          cwd="/repo/a"
+          selectedFile={null}
+          onSelectedFileChange={onSelectedFileChange}
+        />
+      )
+
+      // Should auto-select first file with cwd tag
+      expect(onSelectedFileChange).toHaveBeenCalledWith({
+        path: 'src/App.tsx',
+        staged: false,
+        cwd: '/repo/a',
+      })
+    })
+
+    test('stale rows not rendered when filesCwd !== cwd', (): void => {
+      const mockFiles: ChangedFile[] = [
+        {
+          path: 'src/OldFile.tsx',
+          status: 'modified',
+          staged: false,
+        },
+      ]
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: mockFiles,
+        filesCwd: '/repo/a', // Stale data from old cwd
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
+        diff: null,
+        loading: false,
+        error: null,
+      })
+
+      render(
+        <DiffPanelContent
+          cwd="/repo/b"
+          selectedFile={null}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      // Should show loading state (not stale files)
+      expect(screen.getByText('Loading diff…')).toBeInTheDocument()
+    })
+
+    test('commitSelection tags with current cwd on click', (): void => {
+      const mockFiles: ChangedFile[] = [
+        {
+          path: 'src/App.tsx',
+          status: 'modified',
+          staged: false,
+        },
+        {
+          path: 'src/Other.tsx',
+          status: 'added',
+          staged: true,
+        },
+      ]
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: mockFiles,
+        filesCwd: '/repo/b',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+
+      const mockDiff: FileDiff = {
+        filePath: 'src/App.tsx',
+        oldPath: 'src/App.tsx',
+        newPath: 'src/App.tsx',
+        hunks: [],
+      }
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
+        diff: mockDiff,
+        loading: false,
+        error: null,
+      })
+
+      const onSelectedFileChange = vi.fn()
+
+      render(
+        <DiffPanelContent
+          cwd="/repo/b"
+          selectedFile={{ path: 'src/App.tsx', staged: false, cwd: '/repo/b' }}
+          onSelectedFileChange={onSelectedFileChange}
+        />
+      )
+
+      // Find and click a different file row
+      const otherFileRow = screen.getByText('Other.tsx')
+      otherFileRow.click()
+
+      // Should call with cwd tag
+      expect(onSelectedFileChange).toHaveBeenCalledWith({
+        path: 'src/Other.tsx',
+        staged: true,
+        cwd: '/repo/b',
+      })
+    })
+
+    test('untracked file regression: shows placeholder for untracked files', (): void => {
+      const mockFiles: ChangedFile[] = [
+        {
+          path: 'new.ts',
+          status: 'untracked',
+          staged: false,
+        },
+      ]
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: mockFiles,
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+
+      const useFileDiffSpy = vi
+        .spyOn(useFileDiffModule, 'useFileDiff')
+        .mockReturnValue({
+          diff: null,
+          loading: false,
+          error: null,
+        })
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'new.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      // Should show untracked placeholder
+      expect(screen.getByText('New file — not yet tracked')).toBeInTheDocument()
+      // useFileDiff should still be called with the path
+      expect(useFileDiffSpy).toHaveBeenCalledWith('new.ts', false, '/repo')
+    })
+  })
+
+  describe('Uncontrolled mode fallback', () => {
+    test('auto-select works without controlled props', (): void => {
+      const mockFiles: ChangedFile[] = [
+        {
+          path: 'src/App.tsx',
+          status: 'modified',
+          staged: false,
+        },
+      ]
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: mockFiles,
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+
+      const useFileDiffSpy = vi
+        .spyOn(useFileDiffModule, 'useFileDiff')
+        .mockReturnValue({
+          diff: null,
+          loading: false,
+          error: null,
+        })
+
+      render(<DiffPanelContent cwd="/repo" />)
+
+      // Should auto-select first file (via local state)
+      expect(useFileDiffSpy).toHaveBeenCalledWith('src/App.tsx', false, '/repo')
+    })
+
+    test('cwd guard works in uncontrolled mode', (): void => {
+      const mockFiles: ChangedFile[] = [
+        {
+          path: 'src/App.tsx',
+          status: 'modified',
+          staged: false,
+        },
+      ]
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: mockFiles,
+        filesCwd: '/repo/b',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+
+      const useFileDiffSpy = vi
+        .spyOn(useFileDiffModule, 'useFileDiff')
+        .mockReturnValue({
+          diff: null,
+          loading: false,
+          error: null,
+        })
+
+      const { rerender } = render(<DiffPanelContent cwd="/repo/a" />)
+
+      // Change cwd
+      rerender(<DiffPanelContent cwd="/repo/b" />)
+
+      // Initially should call with null (stale selection from old cwd)
+      // Then after filesCwd updates, should auto-select
+      const calls = useFileDiffSpy.mock.calls
+      // Last call should be with the correct file after auto-select
+      const lastCall = calls[calls.length - 1]
+      expect(lastCall).toEqual(['src/App.tsx', false, '/repo/b'])
+    })
   })
 })

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -17,6 +17,7 @@ describe('DiffPanelContent', () => {
   test('renders loading state while fetching', (): void => {
     vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
       files: [],
+      filesCwd: null,
       loading: true,
       error: null,
       refresh: vi.fn(),
@@ -38,6 +39,7 @@ describe('DiffPanelContent', () => {
 
     vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
       files: [],
+      filesCwd: null,
       loading: false,
       error,
       refresh: vi.fn(),
@@ -60,6 +62,7 @@ describe('DiffPanelContent', () => {
   test('renders empty state when no changes exist', (): void => {
     vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
       files: [],
+      filesCwd: null,
       loading: false,
       error: null,
       refresh: vi.fn(),
@@ -113,6 +116,7 @@ describe('DiffPanelContent', () => {
 
     vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
       files: mockFiles,
+      filesCwd: '/test/cwd',
       loading: false,
       error: null,
       refresh: vi.fn(),
@@ -139,6 +143,7 @@ describe('DiffPanelContent', () => {
       .spyOn(useGitStatusModule, 'useGitStatus')
       .mockReturnValue({
         files: [],
+        filesCwd: null,
         loading: false,
         error: null,
         refresh: vi.fn(),

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -342,7 +342,12 @@ describe('DiffPanelContent', () => {
       })
     })
 
-    test('untracked file regression: shows placeholder for untracked files', (): void => {
+    test('untracked file: renders DiffViewer with synthesized all-added content', (): void => {
+      // Backend now runs `git diff --no-index /dev/null <file>` for untracked
+      // paths, returning a real FileDiff with all-added lines. The frontend
+      // used to short-circuit to a "New file — not yet tracked" placeholder;
+      // that branch is gone. Untracked files render in DiffViewer just like
+      // modified files, so the user can actually see the content.
       const mockFiles: ChangedFile[] = [
         {
           path: 'new.ts',
@@ -359,10 +364,36 @@ describe('DiffPanelContent', () => {
         refresh: vi.fn(),
       })
 
+      const untrackedDiff = {
+        filePath: 'new.ts',
+        hunks: [
+          {
+            id: 'hunk-0',
+            header: '@@ -0,0 +1,2 @@',
+            oldStart: 0,
+            oldLines: 0,
+            newStart: 1,
+            newLines: 2,
+            lines: [
+              {
+                type: 'added' as const,
+                newLineNumber: 1,
+                content: 'alpha',
+              },
+              {
+                type: 'added' as const,
+                newLineNumber: 2,
+                content: 'beta',
+              },
+            ],
+          },
+        ],
+      }
+
       const useFileDiffSpy = vi
         .spyOn(useFileDiffModule, 'useFileDiff')
         .mockReturnValue({
-          diff: null,
+          diff: untrackedDiff,
           loading: false,
           error: null,
         })
@@ -375,9 +406,11 @@ describe('DiffPanelContent', () => {
         />
       )
 
-      // Should show untracked placeholder
-      expect(screen.getByText('New file — not yet tracked')).toBeInTheDocument()
-      // useFileDiff should still be called with the path
+      // Placeholder is gone
+      expect(screen.queryByText('New file — not yet tracked')).toBeNull()
+      // DiffViewer (unified) is rendered instead
+      expect(screen.getByTestId('unified-pane')).toBeInTheDocument()
+      // useFileDiff was called with the path and staged flag
       expect(useFileDiffSpy).toHaveBeenCalledWith('new.ts', false, '/repo')
     })
   })

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -121,7 +121,6 @@ export const DiffPanelContent = ({
       : undefined
   const selectedFilePath = selectedFileEntry?.path ?? null
   const selectedFileStaged = selectedFileEntry?.staged ?? false
-  const selectedFileIsUntracked = selectedFileEntry?.status === 'untracked'
 
   const {
     diff,
@@ -198,18 +197,13 @@ export const DiffPanelContent = ({
         />
       </div>
 
-      {/* Right: Diff viewer (fills remaining space) */}
+      {/* Right: Diff viewer (fills remaining space).
+          Untracked files used to short-circuit here to a placeholder
+          because `git diff -- <file>` returned empty. The backend now
+          falls back to `git diff --no-index /dev/null <file>` so untracked
+          files render as an all-added diff in the normal DiffViewer. */}
       <div className="flex-1 min-w-0 overflow-hidden">
-        {selectedFileIsUntracked ? (
-          <div className="flex h-full items-center justify-center text-on-surface-variant">
-            <div className="text-center space-y-2">
-              <p className="text-sm">New file — not yet tracked</p>
-              <p className="text-xs opacity-60">
-                Stage with git add to see diff against index
-              </p>
-            </div>
-          </div>
-        ) : diffError ? (
+        {diffError ? (
           <div
             className="flex h-full items-center justify-center text-error"
             role="alert"

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -82,9 +82,17 @@ export const DiffPanelContent = ({
   const effectiveSelectedFile = rawSelection?.cwd === cwd ? rawSelection : null
 
   // Shared commitSelection helper that tags with current cwd.
-  // The discriminated union on props guarantees onSelectedFileChange is
-  // defined whenever isControlled is true, so the inner `&& onSelectedFileChange`
-  // guard is no longer needed — TypeScript narrows it across the union.
+  //
+  // The discriminated union on props guarantees callers pair
+  // `selectedFile` with `onSelectedFileChange`. TypeScript 4.4+ aliased-
+  // condition narrowing (which this project relies on elsewhere, e.g.
+  // BottomDrawer) tracks the `isControlled` const back through the
+  // discriminant, so TypeScript narrows `onSelectedFileChange` to its
+  // non-undefined variant inside `if (isControlled)`. Verified: tsc
+  // --strict does NOT emit TS2722 here, and ESLint's
+  // no-unnecessary-condition rule actively rejects an `&& onSelectedFileChange`
+  // guard as provably truthy. Do not add that guard back — the union is
+  // our single source of truth for the invariant.
   const commitSelection = useCallback(
     (newSelection: SelectedDiffFile | null): void => {
       if (isControlled) {

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -36,6 +36,7 @@ export const DiffPanelContent = ({
     filesCwd,
     loading: statusLoading,
     error: statusError,
+    idle,
   } = useGitStatus(cwd, { watch: true })
 
   const [uncontrolledSelectedFile, setUncontrolledSelectedFile] =
@@ -55,8 +56,12 @@ export const DiffPanelContent = ({
     [filesAreFresh, files]
   )
 
+  // Gate the transitional-loading arm on the hook actually running. When
+  // `idle` (hook short-circuited — `.`/`~` cwd, etc.), `filesCwd` never
+  // updates and `!filesAreFresh` would spin "Loading…" forever. An idle
+  // hook never loads, so skip the transitional arm entirely.
   const effectiveStatusLoading =
-    statusLoading || (!filesAreFresh && statusError === null)
+    !idle && (statusLoading || (!filesAreFresh && statusError === null))
 
   // Render-time cwd guard: reject selections from a different cwd
   const effectiveSelectedFile = rawSelection?.cwd === cwd ? rawSelection : null

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -11,14 +11,29 @@ import { ChangedFilesList } from './ChangedFilesList'
 import { DiffViewer } from './DiffViewer'
 import type { ChangedFile, SelectedDiffFile } from '../types'
 
-export interface DiffPanelContentProps {
+/**
+ * Controlled/uncontrolled selection pair as a discriminated union. Forces
+ * callers to pass BOTH `selectedFile` + `onSelectedFileChange` (controlled
+ * mode) or NEITHER (uncontrolled). Without this, a caller that passed only
+ * `selectedFile` would flip `isControlled` to true but hit the
+ * `if (isControlled && onSelectedFileChange)` guard inside `commitSelection`
+ * and get a silently-frozen selection — no auto-select-first, no cwd reset,
+ * no stale-selection invalidation. Same pattern as `BottomDrawerProps`.
+ */
+type DiffPanelSelectionControl =
+  | { selectedFile?: undefined; onSelectedFileChange?: undefined }
+  | {
+      selectedFile: SelectedDiffFile | null
+      onSelectedFileChange: (file: SelectedDiffFile | null) => void
+    }
+
+interface DiffPanelContentBaseProps {
   /** Working directory for git commands */
   cwd?: string
-  /** Controlled selected file (with cwd tag for staleness detection) */
-  selectedFile?: SelectedDiffFile | null
-  /** Controlled selection change handler */
-  onSelectedFileChange?: ((file: SelectedDiffFile | null) => void) | null
 }
+
+export type DiffPanelContentProps = DiffPanelContentBaseProps &
+  DiffPanelSelectionControl
 
 /**
  * DiffPanelContent - Real diff viewer that replaces the placeholder
@@ -28,8 +43,8 @@ export interface DiffPanelContentProps {
  */
 export const DiffPanelContent = ({
   cwd = '.',
-  selectedFile: controlledSelectedFile = undefined,
-  onSelectedFileChange = null,
+  selectedFile: controlledSelectedFile,
+  onSelectedFileChange,
 }: DiffPanelContentProps): ReactElement => {
   const {
     files,
@@ -66,12 +81,15 @@ export const DiffPanelContent = ({
   // Render-time cwd guard: reject selections from a different cwd
   const effectiveSelectedFile = rawSelection?.cwd === cwd ? rawSelection : null
 
-  // Shared commitSelection helper that tags with current cwd
+  // Shared commitSelection helper that tags with current cwd.
+  // The discriminated union on props guarantees onSelectedFileChange is
+  // defined whenever isControlled is true, so the inner `&& onSelectedFileChange`
+  // guard is no longer needed — TypeScript narrows it across the union.
   const commitSelection = useCallback(
     (newSelection: SelectedDiffFile | null): void => {
-      if (isControlled && onSelectedFileChange) {
+      if (isControlled) {
         onSelectedFileChange(newSelection)
-      } else if (!isControlled) {
+      } else {
         setUncontrolledSelectedFile(newSelection)
       }
     },

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -1,55 +1,125 @@
-import { type ReactElement, useState, useEffect } from 'react'
+import {
+  type ReactElement,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+} from 'react'
 import { useGitStatus } from '../hooks/useGitStatus'
 import { useFileDiff } from '../hooks/useFileDiff'
 import { ChangedFilesList } from './ChangedFilesList'
 import { DiffViewer } from './DiffViewer'
+import type { ChangedFile, SelectedDiffFile } from '../types'
 
 export interface DiffPanelContentProps {
   /** Working directory for git commands */
   cwd?: string
+  /** Controlled selected file (with cwd tag for staleness detection) */
+  selectedFile?: SelectedDiffFile | null
+  /** Controlled selection change handler */
+  onSelectedFileChange?: ((file: SelectedDiffFile | null) => void) | null
 }
 
 /**
  * DiffPanelContent - Real diff viewer that replaces the placeholder
  *
- * Fetches git status and displays changed files + diff viewer
+ * Fetches git status and displays changed files + diff viewer.
+ * Supports controlled mode for cross-component selection coordination.
  */
 export const DiffPanelContent = ({
   cwd = '.',
+  selectedFile: controlledSelectedFile = undefined,
+  onSelectedFileChange = null,
 }: DiffPanelContentProps): ReactElement => {
   const {
     files,
+    filesCwd,
     loading: statusLoading,
     error: statusError,
-  } = useGitStatus(cwd)
-  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  } = useGitStatus(cwd, { watch: true })
 
-  // Reset selection when cwd changes (avoids stale path from old repo)
-  useEffect(() => {
-    setSelectedFile(null)
-  }, [cwd])
+  const [uncontrolledSelectedFile, setUncontrolledSelectedFile] =
+    useState<SelectedDiffFile | null>(null)
 
-  // Auto-select first file when status loads. Guarded by
-  // !statusLoading so this doesn't fire on the stale files array
-  // during the loading window after a cwd change. Also re-selects
-  // when the current selection disappears from the list (e.g. file
-  // was committed or reverted).
+  const isControlled = controlledSelectedFile !== undefined
+
+  const rawSelection = isControlled
+    ? controlledSelectedFile
+    : uncontrolledSelectedFile
+
+  // Derive freshness: are the files from the current cwd?
+  const filesAreFresh = filesCwd === cwd
+
+  const effectiveFiles = useMemo(
+    (): ChangedFile[] => (filesAreFresh ? files : []),
+    [filesAreFresh, files]
+  )
+
+  const effectiveStatusLoading =
+    statusLoading || (!filesAreFresh && statusError === null)
+
+  // Render-time cwd guard: reject selections from a different cwd
+  const effectiveSelectedFile = rawSelection?.cwd === cwd ? rawSelection : null
+
+  // Shared commitSelection helper that tags with current cwd
+  const commitSelection = useCallback(
+    (newSelection: SelectedDiffFile | null): void => {
+      if (isControlled && onSelectedFileChange) {
+        onSelectedFileChange(newSelection)
+      } else if (!isControlled) {
+        setUncontrolledSelectedFile(newSelection)
+      }
+    },
+    [isControlled, onSelectedFileChange]
+  )
+
+  // Reset selection when cwd changes (belt-and-suspenders, render guard is primary)
   useEffect(() => {
-    if (statusLoading) {
+    commitSelection(null)
+  }, [cwd, commitSelection])
+
+  // Auto-select first file when effectiveFiles changes. Gated on effectiveFiles
+  // (not raw files) so filesCwd freshness check is automatic.
+  useEffect(() => {
+    if (effectiveStatusLoading) {
       return
     }
 
     const selectionValid =
-      selectedFile !== null && files.some((f) => f.path === selectedFile)
+      effectiveSelectedFile !== null &&
+      effectiveFiles.some(
+        (f) =>
+          f.path === effectiveSelectedFile.path &&
+          f.staged === effectiveSelectedFile.staged
+      )
 
-    if (files.length > 0 && !selectionValid) {
-      setSelectedFile(files[0].path)
-    } else if (files.length === 0) {
-      setSelectedFile(null)
+    if (effectiveFiles.length > 0 && !selectionValid) {
+      commitSelection({
+        path: effectiveFiles[0].path,
+        staged: effectiveFiles[0].staged,
+        cwd,
+      })
+    } else if (effectiveFiles.length === 0 && effectiveSelectedFile !== null) {
+      commitSelection(null)
     }
-  }, [files, selectedFile, statusLoading])
+  }, [
+    effectiveFiles,
+    effectiveSelectedFile,
+    effectiveStatusLoading,
+    cwd,
+    commitSelection,
+  ])
 
-  const selectedFileEntry = files.find((f) => f.path === selectedFile)
+  // Resolve the selected entry from effectiveFiles (not raw files)
+  const selectedFileEntry =
+    effectiveSelectedFile !== null
+      ? effectiveFiles.find(
+          (f) =>
+            f.path === effectiveSelectedFile.path &&
+            f.staged === effectiveSelectedFile.staged
+        )
+      : undefined
+  const selectedFilePath = selectedFileEntry?.path ?? null
   const selectedFileStaged = selectedFileEntry?.staged ?? false
   const selectedFileIsUntracked = selectedFileEntry?.status === 'untracked'
 
@@ -57,10 +127,10 @@ export const DiffPanelContent = ({
     diff,
     loading: diffLoading,
     error: diffError,
-  } = useFileDiff(selectedFile, selectedFileStaged, cwd)
+  } = useFileDiff(selectedFilePath, selectedFileStaged, cwd)
 
   // Loading state
-  if (statusLoading) {
+  if (effectiveStatusLoading) {
     return (
       <div
         className="flex h-full w-full items-center justify-center text-on-surface-variant"
@@ -90,7 +160,7 @@ export const DiffPanelContent = ({
   }
 
   // Empty state (no changes)
-  if (files.length === 0) {
+  if (effectiveFiles.length === 0) {
     return (
       <div
         data-testid="diff-empty-state"
@@ -113,14 +183,17 @@ export const DiffPanelContent = ({
       {/* Left: Changed files list (~240px fixed) */}
       <div className="w-60 shrink-0 border-r border-white/5 overflow-y-auto">
         <ChangedFilesList
-          files={files}
+          files={effectiveFiles}
           selectedFile={
-            selectedFile !== null
-              ? { path: selectedFile, staged: selectedFileStaged }
+            effectiveSelectedFile !== null
+              ? {
+                  path: effectiveSelectedFile.path,
+                  staged: effectiveSelectedFile.staged,
+                }
               : null
           }
-          onSelectFile={(file): void => {
-            setSelectedFile(file.path)
+          onSelectFile={(file: ChangedFile): void => {
+            commitSelection({ path: file.path, staged: file.staged, cwd })
           }}
         />
       </div>

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -114,8 +114,14 @@ export const DiffPanelContent = ({
       <div className="w-60 shrink-0 border-r border-white/5 overflow-y-auto">
         <ChangedFilesList
           files={files}
-          selectedPath={selectedFile}
-          onSelectFile={setSelectedFile}
+          selectedFile={
+            selectedFile !== null
+              ? { path: selectedFile, staged: selectedFileStaged }
+              : null
+          }
+          onSelectFile={(file): void => {
+            setSelectedFile(file.path)
+          }}
         />
       </div>
 

--- a/src/features/diff/hooks/useGitStatus.test.ts
+++ b/src/features/diff/hooks/useGitStatus.test.ts
@@ -1,69 +1,461 @@
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import { useGitStatus } from './useGitStatus'
 import { mockChangedFiles } from '../data/mockDiff'
 
+// Mock Tauri APIs
+const mockInvoke = vi.fn()
+const mockListen = vi.fn()
+const mockUnlisten = vi.fn()
+
+vi.mock('@tauri-apps/api/core', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  invoke: (...args: unknown[]): any => mockInvoke(...args),
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  listen: (...args: unknown[]): any => mockListen(...args),
+}))
+
 describe('useGitStatus', () => {
-  test('fetches files on mount', async () => {
-    const { result } = renderHook(() => useGitStatus('/home/test/project'))
+  beforeEach(() => {
+    mockInvoke.mockReset()
+    mockListen.mockReset()
+    mockUnlisten.mockReset()
 
-    // Initially loading
-    expect(result.current.loading).toBe(true)
-    expect(result.current.files).toEqual([])
-    expect(result.current.error).toBeNull()
+    // Default: listen returns an unlisten function
+    mockListen.mockResolvedValue(mockUnlisten)
 
-    // Wait for fetch to complete
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false)
-    })
-
-    // Should have files from MockGitService
-    expect(result.current.files).toEqual(mockChangedFiles)
-    expect(result.current.error).toBeNull()
+    // Default: start_git_watcher and stop_git_watcher succeed
+    mockInvoke.mockResolvedValue(undefined)
   })
 
-  test('provides refresh function', async () => {
-    const { result } = renderHook(() => useGitStatus('/home/test/project'))
-
-    // Wait for initial load
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false)
-    })
-
-    expect(result.current.files).toEqual(mockChangedFiles)
-
-    // Call refresh (synchronous — bumps refreshKey counter)
-    result.current.refresh()
-
-    // Should still have files
-    expect(result.current.files).toEqual(mockChangedFiles)
-    expect(result.current.error).toBeNull()
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
-  test('handles errors gracefully', async () => {
-    // This test would need a way to inject a failing service
-    // For now, just verify error state structure
-    const { result } = renderHook(() => useGitStatus('/home/test/project'))
+  describe('non-watch mode (existing behavior)', () => {
+    test('fetches files on mount', async () => {
+      const { result } = renderHook(() => useGitStatus('/home/test/project'))
 
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false)
+      // Initially loading
+      expect(result.current.loading).toBe(true)
+      expect(result.current.files).toEqual([])
+      expect(result.current.filesCwd).toBeNull()
+      expect(result.current.error).toBeNull()
+
+      // Wait for fetch to complete
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      // Should have files from MockGitService
+      expect(result.current.files).toEqual(mockChangedFiles)
+      expect(result.current.filesCwd).toBe('/home/test/project')
+      expect(result.current.error).toBeNull()
     })
 
-    // In test mode, MockGitService always succeeds
-    expect(result.current.error).toBeNull()
+    test('provides refresh function', async () => {
+      const { result } = renderHook(() => useGitStatus('/home/test/project'))
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(result.current.files).toEqual(mockChangedFiles)
+
+      // Call refresh (synchronous — bumps refreshKey counter)
+      result.current.refresh()
+
+      // Should still have files
+      expect(result.current.files).toEqual(mockChangedFiles)
+      expect(result.current.error).toBeNull()
+    })
+
+    test('handles errors gracefully', async () => {
+      // This test would need a way to inject a failing service
+      // For now, just verify error state structure
+      const { result } = renderHook(() => useGitStatus('/home/test/project'))
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      // In test mode, MockGitService always succeeds
+      expect(result.current.error).toBeNull()
+    })
+
+    test('returns correct structure with filesCwd', async () => {
+      const { result } = renderHook(() => useGitStatus('/home/test/project'))
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(result.current).toHaveProperty('files')
+      expect(result.current).toHaveProperty('filesCwd')
+      expect(result.current).toHaveProperty('loading')
+      expect(result.current).toHaveProperty('error')
+      expect(result.current).toHaveProperty('refresh')
+      expect(typeof result.current.refresh).toBe('function')
+    })
   })
 
-  test('returns correct structure', async () => {
-    const { result } = renderHook(() => useGitStatus('/home/test/project'))
+  describe('watch mode', () => {
+    test('starts git watcher on mount', async () => {
+      const { result } = renderHook(() =>
+        useGitStatus('/home/test/project', { watch: true })
+      )
 
-    await waitFor(() => {
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      // Should have called listen BEFORE start_git_watcher
+      expect(mockListen).toHaveBeenCalledWith(
+        'git-status-changed',
+        expect.any(Function)
+      )
+
+      expect(mockInvoke).toHaveBeenCalledWith('start_git_watcher', {
+        cwd: '/home/test/project',
+      })
+    })
+
+    test('stops git watcher on unmount', async () => {
+      const { result, unmount } = renderHook(() =>
+        useGitStatus('/home/test/project', { watch: true })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      unmount()
+
+      await waitFor(() => {
+        expect(mockUnlisten).toHaveBeenCalled()
+        expect(mockInvoke).toHaveBeenCalledWith('stop_git_watcher', {
+          cwd: '/home/test/project',
+        })
+      })
+    })
+
+    test('mount ordering is race-free (listen before start_git_watcher)', async (): Promise<void> => {
+      const callOrder: string[] = []
+
+      mockListen.mockImplementation((): Promise<typeof mockUnlisten> => {
+        callOrder.push('listen')
+
+        return Promise.resolve(mockUnlisten)
+      })
+
+      mockInvoke.mockImplementation((cmd: string): Promise<undefined> => {
+        if (cmd === 'start_git_watcher') {
+          callOrder.push('start_git_watcher')
+        }
+
+        return Promise.resolve(undefined)
+      })
+
+      renderHook(() => useGitStatus('/home/test/project', { watch: true }))
+
+      await waitFor(() => {
+        expect(callOrder).toContain('listen')
+        expect(callOrder).toContain('start_git_watcher')
+      })
+
+      // listen must happen before start_git_watcher
+      const listenIndex = callOrder.indexOf('listen')
+      const startIndex = callOrder.indexOf('start_git_watcher')
+      expect(listenIndex).toBeLessThan(startIndex)
+    })
+
+    test('unmount ordering (unlisten before stop_git_watcher)', async (): Promise<void> => {
+      const cleanupOrder: string[] = []
+
+      mockUnlisten.mockImplementation((): void => {
+        cleanupOrder.push('unlisten')
+      })
+
+      mockInvoke.mockImplementation((cmd: string): Promise<undefined> => {
+        if (cmd === 'stop_git_watcher') {
+          cleanupOrder.push('stop_git_watcher')
+        }
+
+        return Promise.resolve(undefined)
+      })
+
+      const { result, unmount } = renderHook(() =>
+        useGitStatus('/home/test/project', { watch: true })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      unmount()
+
+      await waitFor(() => {
+        expect(cleanupOrder).toContain('unlisten')
+        expect(cleanupOrder).toContain('stop_git_watcher')
+      })
+
+      // unlisten must happen before stop_git_watcher
+      const unlistenIndex = cleanupOrder.indexOf('unlisten')
+      const stopIndex = cleanupOrder.indexOf('stop_git_watcher')
+      expect(unlistenIndex).toBeLessThan(stopIndex)
+    })
+
+    // cspell:disable-next-line
+    test('refreshes when event cwds includes current cwd', async (): Promise<void> => {
+      // cspell:disable-next-line
+      let eventHandler:
+        | ((event: { payload: { cwds: string[] } }) => void)
+        | null = null
+
+      mockListen.mockImplementation(
+        (_event: string, handler: unknown): Promise<typeof mockUnlisten> => {
+          // cspell:disable-next-line
+          eventHandler = handler as (event: {
+            payload: { cwds: string[] }
+          }) => void
+
+          return Promise.resolve(mockUnlisten)
+        }
+      )
+
+      const { result } = renderHook(() =>
+        useGitStatus('/home/test/project', { watch: true })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+        expect(eventHandler).not.toBeNull()
+      })
+
+      const initialFiles = result.current.files
+
+      // Fire event with matching cwd
+      // cspell:disable-next-line
+      eventHandler!({ payload: { cwds: ['/home/test/project'] } })
+
+      await waitFor(() => {
+        // refresh() was called, files re-fetched
+        expect(result.current.files).toEqual(initialFiles)
+      })
+    })
+
+    // cspell:disable-next-line
+    test('does not refresh when event cwds does not include current cwd', async (): Promise<void> => {
+      // cspell:disable-next-line
+      let eventHandler:
+        | ((event: { payload: { cwds: string[] } }) => void)
+        | null = null
+
+      mockListen.mockImplementation(
+        (_event: string, handler: unknown): Promise<typeof mockUnlisten> => {
+          // cspell:disable-next-line
+          eventHandler = handler as (event: {
+            payload: { cwds: string[] }
+          }) => void
+
+          return Promise.resolve(mockUnlisten)
+        }
+      )
+
+      const { result } = renderHook(() =>
+        useGitStatus('/home/test/project', { watch: true })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+        expect(eventHandler).not.toBeNull()
+      })
+
+      const initialLoading = result.current.loading
+
+      // Fire event with different cwd
+      // cspell:disable-next-line
+      eventHandler!({ payload: { cwds: ['/other/project'] } })
+
+      // Should not trigger refresh (loading stays false)
+      expect(result.current.loading).toBe(initialLoading)
+    })
+
+    // cspell:disable-next-line
+    test('shared-watcher fan-out (multiple cwds in one event)', async (): Promise<void> => {
+      // cspell:disable-next-line
+      let eventHandler:
+        | ((event: { payload: { cwds: string[] } }) => void)
+        | null = null
+
+      mockListen.mockImplementation(
+        (_event: string, handler: unknown): Promise<typeof mockUnlisten> => {
+          // cspell:disable-next-line
+          eventHandler = handler as (event: {
+            payload: { cwds: string[] }
+          }) => void
+
+          return Promise.resolve(mockUnlisten)
+        }
+      )
+
+      const { result } = renderHook(() =>
+        useGitStatus('/home/test/repo/src/a', { watch: true })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+        expect(eventHandler).not.toBeNull()
+      })
+
+      // Fire event with multiple current working directories including ours
+      // cspell:disable-next-line
+      eventHandler!({
+        // cspell:disable-next-line
+        payload: { cwds: ['/home/test/repo/src/a', '/home/test/repo/src/b'] },
+      })
+
+      await waitFor(() => {
+        // refresh() was called because our cwd is in the list
+        expect(result.current.files).toEqual(mockChangedFiles)
+      })
+    })
+  })
+
+  describe('filesCwd freshness tracking', () => {
+    test('filesCwd is null before first fetch resolves', () => {
+      const { result } = renderHook(() => useGitStatus('/home/test/project'))
+
+      // Before fetch completes
+      expect(result.current.filesCwd).toBeNull()
+    })
+
+    test('filesCwd updates to cwd on successful fetch', async () => {
+      const { result } = renderHook(() => useGitStatus('/home/test/project'))
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(result.current.filesCwd).toBe('/home/test/project')
+    })
+
+    test('filesCwd stays at last successful cwd during new cwd fetch', async () => {
+      const { result, rerender } = renderHook(({ cwd }) => useGitStatus(cwd), {
+        initialProps: { cwd: '/home/test/project-a' },
+      })
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(result.current.filesCwd).toBe('/home/test/project-a')
+
+      // Change cwd
+      rerender({ cwd: '/home/test/project-b' })
+
+      // During the fetch for project-b, filesCwd should still be project-a
+      if (result.current.loading) {
+        expect(result.current.filesCwd).toBe('/home/test/project-a')
+      }
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      // After fetch completes, filesCwd updates to project-b
+      expect(result.current.filesCwd).toBe('/home/test/project-b')
+    })
+
+    test('filesCwd does not update on fetch failure', async () => {
+      // This would need a way to inject a failing service
+      // For now, document the expected behavior
+      const { result } = renderHook(() => useGitStatus('/home/test/project'))
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      // After successful fetch
+      expect(result.current.filesCwd).toBe('/home/test/project')
+
+      // If a subsequent fetch fails (error is set), filesCwd should remain unchanged
+      // This is verified by the implementation — filesCwd is only set in the success path
+    })
+  })
+
+  describe('enabled flag', () => {
+    test('enabled: false returns empty state with no IPC', (): void => {
+      const { result } = renderHook(() =>
+        useGitStatus('/home/test/project', { enabled: false })
+      )
+
+      // Should immediately return empty state
+      expect(result.current.files).toEqual([])
+      expect(result.current.filesCwd).toBeNull()
+      expect(result.current.loading).toBe(false)
+      expect(result.current.error).toBeNull()
+
+      // Should not have called any Tauri APIs
+      expect(mockInvoke).not.toHaveBeenCalled()
+      expect(mockListen).not.toHaveBeenCalled()
+    })
+
+    test('flipping enabled from false to true starts fetch', async () => {
+      const { result, rerender } = renderHook(
+        ({ enabled }) => useGitStatus('/home/test/project', { enabled }),
+        { initialProps: { enabled: false } }
+      )
+
+      // Initially disabled
+      expect(result.current.files).toEqual([])
+      expect(result.current.loading).toBe(false)
+
+      // Enable
+      rerender({ enabled: true })
+
+      expect(result.current.loading).toBe(true)
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(result.current.files).toEqual(mockChangedFiles)
+      expect(result.current.filesCwd).toBe('/home/test/project')
+    })
+
+    test('flipping enabled from true to false clears state', async () => {
+      const { result, rerender } = renderHook(
+        ({ enabled }) => useGitStatus('/home/test/project', { enabled }),
+        { initialProps: { enabled: true } }
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(result.current.files).toEqual(mockChangedFiles)
+
+      // Disable
+      rerender({ enabled: false })
+
+      expect(result.current.files).toEqual([])
+      expect(result.current.filesCwd).toBeNull()
       expect(result.current.loading).toBe(false)
     })
 
-    expect(result.current).toHaveProperty('files')
-    expect(result.current).toHaveProperty('loading')
-    expect(result.current).toHaveProperty('error')
-    expect(result.current).toHaveProperty('refresh')
-    expect(typeof result.current.refresh).toBe('function')
+    test('enabled: false with watch: true does not start watcher', (): void => {
+      renderHook(() =>
+        useGitStatus('/home/test/project', { enabled: false, watch: true })
+      )
+
+      // Should not have started the watcher
+      expect(mockListen).not.toHaveBeenCalled()
+      expect(mockInvoke).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/features/diff/hooks/useGitStatus.ts
+++ b/src/features/diff/hooks/useGitStatus.ts
@@ -23,6 +23,20 @@ interface UseGitStatusReturn {
   loading: boolean
   error: Error | null
   refresh: () => void
+  /**
+   * True when the hook is **deliberately short-circuited** — either `enabled`
+   * is false (caller disabled the hook, e.g. the agent isn't active) or the
+   * `cwd` is a fallback value that would fire IPC against the Tauri process's
+   * own cwd. In either case NO fetch runs and the empty state is permanent
+   * until the conditions change.
+   *
+   * Consumers should use `idle` to gate transitional-loading formulas like
+   * `loading || (!filesAreFresh && error === null)` — without this gate, the
+   * formula fires `true` forever on an idle hook (because `filesCwd` stays
+   * null and `filesCwd === cwd` is false), producing a perpetual loading
+   * spinner when the panel should show "no uncommitted changes".
+   */
+  idle: boolean
 }
 
 /** True when cwd points to a real workspace directory, not a fallback. */
@@ -157,18 +171,31 @@ export const useGitStatus = (
       }
     }
 
-    void setupWatch()
+    // Capture the setup promise so cleanup can await its completion before
+    // attempting to stop the watcher. Without this, cleanup firing between
+    // "listener attached" and "invoke('start_git_watcher') resolved" would
+    // unlisten early and skip the stop call (watcherStarted still false),
+    // leaking an orphan backend subscription once the in-flight invoke
+    // eventually completes.
+    const setupPromise = setupWatch()
 
     return (): void => {
       mounted = false
 
-      // Cleanup in reverse order: unlisten → stop watcher
-      // This prevents late in-flight events from calling refresh on a torn-down hook
       const cleanup = async (): Promise<void> => {
+        // Unlisten first so a late in-flight event can't call refresh on
+        // the torn-down hook.
         if (listenerAttached && unlistenRef.current) {
           unlistenRef.current()
           unlistenRef.current = null
         }
+
+        // Wait for setup to settle before deciding whether to stop. If
+        // setup is still in-flight, this blocks until watcherStarted is
+        // either true (stop is needed) or setup errored (nothing to stop).
+        await setupPromise.catch(() => {
+          // setup errored — nothing to stop
+        })
 
         if (watcherStarted) {
           try {
@@ -183,11 +210,14 @@ export const useGitStatus = (
     }
   }, [cwd, watch, enabled, refresh])
 
+  const idle = !enabled || !isValidCwd(cwd)
+
   return {
     files,
     filesCwd,
     loading,
     error,
     refresh,
+    idle,
   }
 }

--- a/src/features/diff/hooks/useGitStatus.ts
+++ b/src/features/diff/hooks/useGitStatus.ts
@@ -158,8 +158,16 @@ export const useGitStatus = (
 
         // Step 3: Explicit refresh after both listener and watcher are live
         // This ensures we catch events that may have fired between listener
-        // attach and watcher start
-        refresh()
+        // attach and watcher start. Guarded by `mounted` because React
+        // cleanup could have fired during the invoke await — a setState on
+        // an unmounted component is a no-op in React 18 production but
+        // still an anti-pattern (and a wasted fetch in Strict Mode's
+        // double-invocation).
+        //
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (mounted) {
+          refresh()
+        }
       } catch (err) {
         if (mounted) {
           setError(

--- a/src/features/diff/hooks/useGitStatus.ts
+++ b/src/features/diff/hooks/useGitStatus.ts
@@ -1,9 +1,25 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { invoke } from '@tauri-apps/api/core'
 import { createGitService } from '../services/gitService'
 import type { ChangedFile } from '../types'
 
+interface GitStatusChangedPayload {
+  /** List of current working directory paths subscribed to the watcher */
+  cwds: string[]
+}
+
+interface UseGitStatusOptions {
+  /** Enable watch mode — starts a git watcher and refreshes on filesystem events */
+  watch?: boolean
+  /** Enable/disable the hook entirely — when false, returns empty state with no IPC */
+  enabled?: boolean
+}
+
 interface UseGitStatusReturn {
   files: ChangedFile[]
+  /** The cwd of the last successful fetch — never updates on failure or fetch-start */
+  filesCwd: string | null
   loading: boolean
   error: Error | null
   refresh: () => void
@@ -14,23 +30,39 @@ const isValidCwd = (cwd: string): boolean =>
   cwd !== '.' && cwd !== '~' && cwd.length > 0
 
 /** Hook to fetch and manage git status (changed files) */
-export const useGitStatus = (cwd = '.'): UseGitStatusReturn => {
+export const useGitStatus = (
+  cwd = '.',
+  options: UseGitStatusOptions = {}
+): UseGitStatusReturn => {
+  const { watch = false, enabled = true } = options
+
   const [files, setFiles] = useState<ChangedFile[]>([])
-  const [loading, setLoading] = useState(() => isValidCwd(cwd))
+  const [filesCwd, setFilesCwd] = useState<string | null>(null)
+  const [loading, setLoading] = useState(() => enabled && isValidCwd(cwd))
   const [error, setError] = useState<Error | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
+
+  // Track unlisten function for cleanup
+  const unlistenRef = useRef<UnlistenFn | null>(null)
+
+  // Trigger a re-run of the fetch effect
+  const refresh = useCallback((): void => {
+    setRefreshKey((k) => k + 1)
+  }, [])
 
   // Single fetch path with per-invocation cancellation flag.
   // Both initial load and manual refresh go through this effect —
   // refresh() bumps refreshKey which triggers a re-run with a
   // fresh cancelled flag. No separate async path needed.
   //
-  // Skips the fetch entirely when cwd is a fallback value ('.' or '~')
-  // to avoid firing IPC against the Tauri process's CWD, which is
-  // unlikely to be the user's project directory.
+  // Skips the fetch entirely when:
+  // - cwd is a fallback value ('.' or '~') to avoid firing IPC against
+  //   the Tauri process's CWD, which is unlikely to be the user's project directory
+  // - enabled is false (hook is disabled)
   useEffect(() => {
-    if (!isValidCwd(cwd)) {
+    if (!enabled || !isValidCwd(cwd)) {
       setFiles([])
+      setFilesCwd(null)
       setLoading(false)
       setError(null)
 
@@ -48,12 +80,14 @@ export const useGitStatus = (cwd = '.'): UseGitStatusReturn => {
 
         if (!cancelled) {
           setFiles(changedFiles)
+          setFilesCwd(cwd) // Only update on success
         }
       } catch (err) {
         if (!cancelled) {
           setError(
             err instanceof Error ? err : new Error('Failed to fetch git status')
           )
+          // filesCwd is NOT updated on failure — stays at last successful cwd
         }
       } finally {
         if (!cancelled) {
@@ -67,15 +101,91 @@ export const useGitStatus = (cwd = '.'): UseGitStatusReturn => {
     return (): void => {
       cancelled = true
     }
-  }, [cwd, refreshKey])
+  }, [cwd, refreshKey, enabled])
 
-  // Trigger a re-run of the cancellation-safe useEffect
-  const refresh = useCallback((): void => {
-    setRefreshKey((k) => k + 1)
-  }, [])
+  // Watch mode lifecycle: attach listener → start watcher → explicit refresh
+  // Unmount: unlisten → stop watcher
+  useEffect(() => {
+    if (!enabled || !watch || !isValidCwd(cwd)) {
+      return
+    }
+
+    let mounted = true
+    let listenerAttached = false
+    let watcherStarted = false
+
+    const setupWatch = async (): Promise<void> => {
+      try {
+        // Step 1: Attach event listener BEFORE starting watcher (race-free)
+        const unlisten = await listen<GitStatusChangedPayload>(
+          'git-status-changed',
+          (event) => {
+            // Only refresh if this cwd is in the fan-out list
+            // cspell:disable-next-line
+            if (event.payload.cwds.includes(cwd)) {
+              refresh()
+            }
+          }
+        )
+
+        if (!mounted) {
+          // Unmounted before listener attached — clean up immediately
+          unlisten()
+
+          return
+        }
+
+        unlistenRef.current = unlisten
+        listenerAttached = true
+
+        // Step 2: Start the git watcher
+        await invoke('start_git_watcher', { cwd })
+        watcherStarted = true
+
+        // Step 3: Explicit refresh after both listener and watcher are live
+        // This ensures we catch events that may have fired between listener
+        // attach and watcher start
+        refresh()
+      } catch (err) {
+        if (mounted) {
+          setError(
+            err instanceof Error
+              ? err
+              : new Error('Failed to start git watcher')
+          )
+        }
+      }
+    }
+
+    void setupWatch()
+
+    return (): void => {
+      mounted = false
+
+      // Cleanup in reverse order: unlisten → stop watcher
+      // This prevents late in-flight events from calling refresh on a torn-down hook
+      const cleanup = async (): Promise<void> => {
+        if (listenerAttached && unlistenRef.current) {
+          unlistenRef.current()
+          unlistenRef.current = null
+        }
+
+        if (watcherStarted) {
+          try {
+            await invoke('stop_git_watcher', { cwd })
+          } catch {
+            // Best-effort cleanup — swallow errors
+          }
+        }
+      }
+
+      void cleanup()
+    }
+  }, [cwd, watch, enabled, refresh])
 
   return {
     files,
+    filesCwd,
     loading,
     error,
     refresh,

--- a/src/features/diff/types/index.ts
+++ b/src/features/diff/types/index.ts
@@ -12,6 +12,13 @@ export interface ChangedFile {
   staged: boolean // whether file is in the index
 }
 
+/** Selected diff file with cwd tag (for cross-cwd staleness detection) */
+export interface SelectedDiffFile {
+  path: string
+  staged: boolean
+  cwd: string
+}
+
 /** Parsed diff for a single file */
 export interface FileDiff {
   filePath: string

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -11,6 +11,7 @@ import { useSessionManager } from './hooks/useSessionManager'
 import { useResizable } from './hooks/useResizable'
 import { createFileSystemService } from '../files/services/fileSystemService'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
+import type { ChangedFile, SelectedDiffFile } from '../diff/types'
 
 const SIDEBAR_MIN = 180
 const SIDEBAR_MAX = 560
@@ -79,6 +80,16 @@ export const WorkspaceView = (): ReactElement => {
   // General-purpose error banner for non-dialog file ops (direct file open,
   // async load failure inside CodeEditor, vim :w save failure).
   const [fileError, setFileError] = useState<string | null>(null)
+
+  // Bottom drawer controlled state
+  const [bottomDrawerTab, setBottomDrawerTab] = useState<'editor' | 'diff'>(
+    'editor'
+  )
+
+  const [selectedDiffFile, setSelectedDiffFile] =
+    useState<SelectedDiffFile | null>(null)
+
+  const [isBottomDrawerCollapsed, setIsBottomDrawerCollapsed] = useState(false)
 
   // Open a file directly (no unsaved-changes guard). Errors were previously
   // swallowed via `void editorBuffer.openFile(...)`, leaving the user with
@@ -238,6 +249,23 @@ export const WorkspaceView = (): ReactElement => {
     setSaveError(null)
   }, [setPendingFilePathSynced])
 
+  // Handle opening a diff file from AgentStatusPanel
+  const handleOpenDiff = useCallback(
+    (file: ChangedFile): void => {
+      const cwd = activeSession?.workingDirectory ?? '.'
+
+      setBottomDrawerTab('diff')
+      setSelectedDiffFile({ path: file.path, staged: file.staged, cwd })
+      setIsBottomDrawerCollapsed(false)
+    },
+    [activeSession?.workingDirectory]
+  )
+
+  // Belt-and-suspenders: clear selection on cwd change
+  useEffect(() => {
+    setSelectedDiffFile(null)
+  }, [activeSession?.workingDirectory])
+
   return (
     <div
       data-testid="workspace-view"
@@ -306,6 +334,12 @@ export const WorkspaceView = (): ReactElement => {
           isDirty={editorBuffer.isDirty}
           isLoading={editorBuffer.isLoading}
           cwd={activeSession?.workingDirectory ?? '.'}
+          activeTab={bottomDrawerTab}
+          onTabChange={setBottomDrawerTab}
+          isCollapsed={isBottomDrawerCollapsed}
+          onCollapsedChange={setIsBottomDrawerCollapsed}
+          selectedDiffFile={selectedDiffFile}
+          onSelectedDiffFileChange={setSelectedDiffFile}
         />
 
         {/* File error banner — surfaces failures from direct file open
@@ -332,7 +366,11 @@ export const WorkspaceView = (): ReactElement => {
       </div>
 
       {/* Agent Status Panel — self-manages width (0↔280px) */}
-      <AgentStatusPanel sessionId={activeSessionId} />
+      <AgentStatusPanel
+        sessionId={activeSessionId}
+        cwd={activeSession?.workingDirectory ?? '.'}
+        onOpenDiff={handleOpenDiff}
+      />
 
       {/* Unsaved Changes Dialog — shows the CURRENTLY dirty file, not the
           destination the user is switching to. */}

--- a/src/features/workspace/components/BottomDrawer.test.tsx
+++ b/src/features/workspace/components/BottomDrawer.test.tsx
@@ -57,6 +57,7 @@ describe('BottomDrawer', () => {
     // Mock diff hooks to return empty state by default
     vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
       files: [],
+      filesCwd: null,
       loading: false,
       error: null,
       refresh: vi.fn(),

--- a/src/features/workspace/components/BottomDrawer.test.tsx
+++ b/src/features/workspace/components/BottomDrawer.test.tsx
@@ -193,4 +193,138 @@ describe('BottomDrawer', () => {
     const diffTab = screen.getByRole('button', { name: /diff viewer/i })
     expect(within(diffTab).getByText('difference')).toBeInTheDocument()
   })
+
+  describe('Controlled mode', () => {
+    test('controlled activeTab prop overrides internal state', async () => {
+      const user = userEvent.setup()
+      const onTabChange = vi.fn()
+
+      render(
+        <BottomDrawer
+          selectedFilePath={null}
+          content=""
+          activeTab="diff"
+          onTabChange={onTabChange}
+        />
+      )
+
+      // Diff tab should be active (controlled)
+      const diffTab = screen.getByRole('button', { name: /diff viewer/i })
+      expect(diffTab).toHaveClass('text-primary')
+
+      // Clicking Editor tab should call handler
+      const editorTab = screen.getByRole('button', { name: /editor/i })
+      await user.click(editorTab)
+      expect(onTabChange).toHaveBeenCalledWith('editor')
+    })
+
+    test('controlled isCollapsed prop overrides internal state', async () => {
+      const user = userEvent.setup()
+      const onCollapsedChange = vi.fn()
+
+      render(
+        <BottomDrawer
+          selectedFilePath={null}
+          content=""
+          isCollapsed
+          onCollapsedChange={onCollapsedChange}
+        />
+      )
+
+      const drawer = screen.getByTestId('bottom-drawer')
+      expect(drawer).toHaveStyle({ height: '48px' })
+
+      // Clicking collapse toggle should call handler
+      const collapseToggle = screen.getByRole('button', {
+        name: /expand drawer/i,
+      })
+      await user.click(collapseToggle)
+      expect(onCollapsedChange).toHaveBeenCalledWith(false)
+    })
+
+    test('forwards selectedDiffFile to DiffPanelContent', () => {
+      const selectedDiffFile = {
+        path: 'src/test.ts',
+        staged: false,
+        cwd: '/repo',
+      }
+      const onSelectedDiffFileChange = vi.fn()
+
+      render(
+        <BottomDrawer
+          selectedFilePath={null}
+          content=""
+          activeTab="diff"
+          selectedDiffFile={selectedDiffFile}
+          onSelectedDiffFileChange={onSelectedDiffFileChange}
+        />
+      )
+
+      // DiffPanelContent should receive the controlled props
+      expect(screen.getByTestId('diff-panel')).toBeInTheDocument()
+    })
+
+    test('uncontrolled fallback: activeTab works without controlled props', async () => {
+      const user = userEvent.setup()
+
+      render(<BottomDrawer selectedFilePath={null} content="" />)
+
+      // Editor tab active by default
+      const editorTab = screen.getByRole('button', { name: /editor/i })
+      expect(editorTab).toHaveClass('text-primary')
+
+      // Click Diff tab
+      const diffTab = screen.getByRole('button', { name: /diff viewer/i })
+      await user.click(diffTab)
+
+      // Diff tab should now be active
+      expect(diffTab).toHaveClass('text-primary')
+      expect(editorTab).not.toHaveClass('text-primary')
+    })
+
+    test('uncontrolled fallback: isCollapsed works without controlled props', async () => {
+      const user = userEvent.setup()
+
+      render(<BottomDrawer selectedFilePath={null} content="" />)
+
+      const drawer = screen.getByTestId('bottom-drawer')
+      expect(drawer).toHaveStyle({ height: '400px' })
+
+      // Click collapse toggle
+      const collapseToggle = screen.getByRole('button', {
+        name: /collapse drawer/i,
+      })
+      await user.click(collapseToggle)
+
+      // Should now be collapsed
+      expect(drawer).toHaveStyle({ height: '48px' })
+    })
+
+    test('passes through all three controlled prop pairs independently', () => {
+      const onTabChange = vi.fn()
+      const onCollapsedChange = vi.fn()
+      const onSelectedDiffFileChange = vi.fn()
+
+      render(
+        <BottomDrawer
+          selectedFilePath={null}
+          content=""
+          activeTab="diff"
+          onTabChange={onTabChange}
+          onCollapsedChange={onCollapsedChange}
+          selectedDiffFile={{ path: 'test.ts', staged: false, cwd: '/repo' }}
+          onSelectedDiffFileChange={onSelectedDiffFileChange}
+        />
+      )
+
+      // All controlled props should be respected
+      const diffTab = screen.getByRole('button', { name: /diff viewer/i })
+      expect(diffTab).toHaveClass('text-primary')
+
+      const drawer = screen.getByTestId('bottom-drawer')
+      expect(drawer).toHaveStyle({ height: '400px' })
+
+      expect(screen.getByTestId('diff-panel')).toBeInTheDocument()
+    })
+  })
 })

--- a/src/features/workspace/components/BottomDrawer.test.tsx
+++ b/src/features/workspace/components/BottomDrawer.test.tsx
@@ -256,6 +256,7 @@ describe('BottomDrawer', () => {
           selectedFilePath={null}
           content=""
           activeTab="diff"
+          onTabChange={vi.fn()}
           selectedDiffFile={selectedDiffFile}
           onSelectedDiffFileChange={onSelectedDiffFileChange}
         />
@@ -312,6 +313,8 @@ describe('BottomDrawer', () => {
           content=""
           activeTab="diff"
           onTabChange={onTabChange}
+          /* eslint-disable-next-line react/jsx-boolean-value */
+          isCollapsed={false}
           onCollapsedChange={onCollapsedChange}
           selectedDiffFile={{ path: 'test.ts', staged: false, cwd: '/repo' }}
           onSelectedDiffFileChange={onSelectedDiffFileChange}

--- a/src/features/workspace/components/BottomDrawer.test.tsx
+++ b/src/features/workspace/components/BottomDrawer.test.tsx
@@ -57,7 +57,7 @@ describe('BottomDrawer', () => {
     // Mock diff hooks to return empty state by default
     vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
       files: [],
-      filesCwd: null,
+      filesCwd: '.',
       loading: false,
       error: null,
       refresh: vi.fn(),

--- a/src/features/workspace/components/BottomDrawer.test.tsx
+++ b/src/features/workspace/components/BottomDrawer.test.tsx
@@ -61,6 +61,7 @@ describe('BottomDrawer', () => {
       loading: false,
       error: null,
       refresh: vi.fn(),
+      idle: false,
     })
 
     vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({

--- a/src/features/workspace/components/BottomDrawer.tsx
+++ b/src/features/workspace/components/BottomDrawer.tsx
@@ -2,6 +2,7 @@ import { type ReactElement, useState } from 'react'
 import { CodeEditor } from '../../editor/components/CodeEditor'
 import { DiffPanelContent } from '../../diff/components/DiffPanelContent'
 import { useResizable } from '../hooks/useResizable'
+import type { SelectedDiffFile } from '../../diff/types'
 
 type TabType = 'editor' | 'diff'
 
@@ -16,6 +17,18 @@ interface BottomDrawerProps {
   isLoading?: boolean
   /** Working directory for git commands (diff viewer) */
   cwd?: string
+  /** Controlled active tab */
+  activeTab?: TabType
+  /** Tab change handler (controlled mode) */
+  onTabChange?: ((tab: TabType) => void) | null
+  /** Controlled collapsed state */
+  isCollapsed?: boolean
+  /** Collapse change handler (controlled mode) */
+  onCollapsedChange?: ((collapsed: boolean) => void) | null
+  /** Controlled selected diff file (forwarded to DiffPanelContent) */
+  selectedDiffFile?: SelectedDiffFile | null
+  /** Diff file selection handler (forwarded to DiffPanelContent) */
+  onSelectedDiffFileChange?: ((file: SelectedDiffFile | null) => void) | null
 }
 
 /**
@@ -35,10 +48,31 @@ const BottomDrawer = ({
   isDirty = false,
   isLoading = false,
   cwd = '.',
+  activeTab: controlledActiveTab = undefined,
+  onTabChange = null,
+  isCollapsed: controlledIsCollapsed = undefined,
+  onCollapsedChange = null,
+  selectedDiffFile = undefined,
+  onSelectedDiffFileChange = null,
 }: BottomDrawerProps): ReactElement => {
-  const [activeTab, setActiveTab] = useState<TabType>('editor')
-  const [isCollapsed, setIsCollapsed] = useState(false)
+  const [uncontrolledActiveTab, setUncontrolledActiveTab] =
+    useState<TabType>('editor')
+  const [uncontrolledIsCollapsed, setUncontrolledIsCollapsed] = useState(false)
+
   const COLLAPSED_HEIGHT = 48 // Just the tab bar
+
+  // Determine if each prop is controlled
+  const isTabControlled = controlledActiveTab !== undefined
+  const isCollapseControlled = controlledIsCollapsed !== undefined
+
+  // Use controlled value or fallback to uncontrolled
+  const activeTab = isTabControlled
+    ? controlledActiveTab
+    : uncontrolledActiveTab
+
+  const isCollapsed = isCollapseControlled
+    ? controlledIsCollapsed
+    : uncontrolledIsCollapsed
 
   // Drawer sizing is in pixels, not viewport-relative. The 400/150/640
   // constants were chosen to feel roughly right on an 800px workspace
@@ -132,7 +166,11 @@ const BottomDrawer = ({
           <button
             type="button"
             onClick={() => {
-              setActiveTab('editor')
+              if (isTabControlled && onTabChange) {
+                onTabChange('editor')
+              } else if (!isTabControlled) {
+                setUncontrolledActiveTab('editor')
+              }
             }}
             className={`flex items-center space-x-2 font-mono text-xs h-12 px-2 transition-colors ${
               activeTab === 'editor'
@@ -149,7 +187,11 @@ const BottomDrawer = ({
           <button
             type="button"
             onClick={() => {
-              setActiveTab('diff')
+              if (isTabControlled && onTabChange) {
+                onTabChange('diff')
+              } else if (!isTabControlled) {
+                setUncontrolledActiveTab('diff')
+              }
             }}
             className={`flex items-center space-x-2 font-mono text-xs h-12 px-2 transition-colors ${
               activeTab === 'diff'
@@ -180,7 +222,11 @@ const BottomDrawer = ({
             aria-label={isCollapsed ? 'Expand drawer' : 'Collapse drawer'}
             aria-expanded={!isCollapsed}
             onClick={() => {
-              setIsCollapsed((v) => !v)
+              if (isCollapseControlled && onCollapsedChange) {
+                onCollapsedChange(!isCollapsed)
+              } else if (!isCollapseControlled) {
+                setUncontrolledIsCollapsed((v) => !v)
+              }
             }}
             className="material-symbols-outlined text-sm text-outline hover:text-on-surface cursor-pointer transition-colors"
           >
@@ -228,7 +274,11 @@ const BottomDrawer = ({
             data-testid="diff-panel"
             className="flex min-h-0 flex-1 overflow-hidden"
           >
-            <DiffPanelContent cwd={cwd} />
+            <DiffPanelContent
+              cwd={cwd}
+              selectedFile={selectedDiffFile}
+              onSelectedFileChange={onSelectedDiffFileChange}
+            />
           </div>
         )}
       </div>

--- a/src/features/workspace/components/BottomDrawer.tsx
+++ b/src/features/workspace/components/BottomDrawer.tsx
@@ -6,7 +6,36 @@ import type { SelectedDiffFile } from '../../diff/types'
 
 type TabType = 'editor' | 'diff'
 
-interface BottomDrawerProps {
+/**
+ * Controlled/uncontrolled prop pairs for the three pieces of state this
+ * component can be driven by. Discriminated unions force callers to either
+ * pass BOTH `value` + `onChange` (controlled) or NEITHER (uncontrolled).
+ *
+ * Previously the two sides were independent optionals, so a caller could
+ * pass `activeTab='diff'` without `onTabChange` and get a silently-dead
+ * tab bar: clicks hit the `if (isTabControlled && onTabChange)` guard and
+ * fell through with no state update anywhere. The union removes that
+ * pitfall at compile time.
+ */
+type TabControl =
+  | { activeTab?: undefined; onTabChange?: undefined }
+  | { activeTab: TabType; onTabChange: (tab: TabType) => void }
+
+type CollapseControl =
+  | { isCollapsed?: undefined; onCollapsedChange?: undefined }
+  | {
+      isCollapsed: boolean
+      onCollapsedChange: (collapsed: boolean) => void
+    }
+
+type SelectedDiffControl =
+  | { selectedDiffFile?: undefined; onSelectedDiffFileChange?: undefined }
+  | {
+      selectedDiffFile: SelectedDiffFile | null
+      onSelectedDiffFileChange: (file: SelectedDiffFile | null) => void
+    }
+
+interface BottomDrawerBaseProps {
   selectedFilePath: string | null
   /** Current buffer content, owned by the parent `useEditorBuffer`. */
   content: string
@@ -17,19 +46,12 @@ interface BottomDrawerProps {
   isLoading?: boolean
   /** Working directory for git commands (diff viewer) */
   cwd?: string
-  /** Controlled active tab */
-  activeTab?: TabType
-  /** Tab change handler (controlled mode) */
-  onTabChange?: ((tab: TabType) => void) | null
-  /** Controlled collapsed state */
-  isCollapsed?: boolean
-  /** Collapse change handler (controlled mode) */
-  onCollapsedChange?: ((collapsed: boolean) => void) | null
-  /** Controlled selected diff file (forwarded to DiffPanelContent) */
-  selectedDiffFile?: SelectedDiffFile | null
-  /** Diff file selection handler (forwarded to DiffPanelContent) */
-  onSelectedDiffFileChange?: ((file: SelectedDiffFile | null) => void) | null
 }
+
+type BottomDrawerProps = BottomDrawerBaseProps &
+  TabControl &
+  CollapseControl &
+  SelectedDiffControl
 
 /**
  * BottomDrawer - Editor and Diff Viewer panel below terminal
@@ -48,12 +70,12 @@ const BottomDrawer = ({
   isDirty = false,
   isLoading = false,
   cwd = '.',
-  activeTab: controlledActiveTab = undefined,
-  onTabChange = null,
-  isCollapsed: controlledIsCollapsed = undefined,
-  onCollapsedChange = null,
-  selectedDiffFile = undefined,
-  onSelectedDiffFileChange = null,
+  activeTab: controlledActiveTab,
+  onTabChange,
+  isCollapsed: controlledIsCollapsed,
+  onCollapsedChange,
+  selectedDiffFile,
+  onSelectedDiffFileChange,
 }: BottomDrawerProps): ReactElement => {
   const [uncontrolledActiveTab, setUncontrolledActiveTab] =
     useState<TabType>('editor')
@@ -166,9 +188,12 @@ const BottomDrawer = ({
           <button
             type="button"
             onClick={() => {
-              if (isTabControlled && onTabChange) {
+              // Discriminated union guarantees onTabChange is defined
+              // whenever isTabControlled is true; no `&& onTabChange` guard
+              // needed at runtime.
+              if (isTabControlled) {
                 onTabChange('editor')
-              } else if (!isTabControlled) {
+              } else {
                 setUncontrolledActiveTab('editor')
               }
             }}
@@ -187,9 +212,9 @@ const BottomDrawer = ({
           <button
             type="button"
             onClick={() => {
-              if (isTabControlled && onTabChange) {
+              if (isTabControlled) {
                 onTabChange('diff')
-              } else if (!isTabControlled) {
+              } else {
                 setUncontrolledActiveTab('diff')
               }
             }}
@@ -222,9 +247,9 @@ const BottomDrawer = ({
             aria-label={isCollapsed ? 'Expand drawer' : 'Collapse drawer'}
             aria-expanded={!isCollapsed}
             onClick={() => {
-              if (isCollapseControlled && onCollapsedChange) {
+              if (isCollapseControlled) {
                 onCollapsedChange(!isCollapsed)
-              } else if (!isCollapseControlled) {
+              } else {
                 setUncontrolledIsCollapsed((v) => !v)
               }
             }}

--- a/src/features/workspace/components/BottomDrawer.tsx
+++ b/src/features/workspace/components/BottomDrawer.tsx
@@ -299,11 +299,20 @@ const BottomDrawer = ({
             data-testid="diff-panel"
             className="flex min-h-0 flex-1 overflow-hidden"
           >
-            <DiffPanelContent
-              cwd={cwd}
-              selectedFile={selectedDiffFile}
-              onSelectedFileChange={onSelectedDiffFileChange}
-            />
+            {/* DiffPanelContent expects BOTH controlled-selection props
+                together or neither. BottomDrawer's own type is a
+                discriminated union: `selectedDiffFile` undefined implies
+                `onSelectedDiffFileChange` undefined too, so checking one
+                narrows both. */}
+            {selectedDiffFile !== undefined ? (
+              <DiffPanelContent
+                cwd={cwd}
+                selectedFile={selectedDiffFile}
+                onSelectedFileChange={onSelectedDiffFileChange}
+              />
+            ) : (
+              <DiffPanelContent cwd={cwd} />
+            )}
           </div>
         )}
       </div>

--- a/src/features/workspace/components/panels/DiffPanel.tsx
+++ b/src/features/workspace/components/panels/DiffPanel.tsx
@@ -33,7 +33,10 @@ const mockChangedFiles: ChangedFile[] = [
  * Shows files with git status badges (M/A/D) in a scrollable list.
  */
 export const DiffPanel = (): ReactElement => {
-  const [selectedPath, setSelectedPath] = useState<string | null>(null)
+  const [selectedFile, setSelectedFile] = useState<{
+    path: string
+    staged: boolean
+  } | null>(null)
 
   return (
     <div
@@ -42,8 +45,10 @@ export const DiffPanel = (): ReactElement => {
     >
       <ChangedFilesList
         files={mockChangedFiles}
-        selectedPath={selectedPath}
-        onSelectFile={setSelectedPath}
+        selectedFile={selectedFile}
+        onSelectFile={(file): void => {
+          setSelectedFile({ path: file.path, staged: file.staged })
+        }}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

- Wires the right-side `AgentStatusPanel.FILES CHANGED` section to real git state via a new filesystem-watcher + `git status --porcelain=v1 -z` pipeline, instead of the prior `placeholderFiles: []`.
- Extends `git_status` / `get_git_diff` to resolve the repo toplevel so sessions running from subdirectories of a repo work correctly, and to synthesize a full-content diff for untracked files via `git diff --no-index /dev/null <file>` so "new file" rows render their full content as `+` lines instead of a placeholder.
- Adds `src-tauri/src/git/watcher.rs` — a refcounted per-repo notify watcher that honors `.gitignore` via the `ignore` crate (same one `ripgrep` uses), registers directories non-recursively, dynamically picks up new dirs from a 10 s polling fallback, and hashes `git status` output (not just HEAD) so staging / editing / deleting / untracked creation all trigger live refreshes.

## What's in this PR

### Design artifact
- `docs/superpowers/specs/2026-04-23-files-changed-panel-design.md` — 697-line design spec; went through 10+ rounds of review. Authoritative for the three-gate invariant (render-time cwd guard + `filesCwd` freshness filter + `selectedFileEntry` fetch gating).

### Backend (`src-tauri/src/git/`)
- `mod.rs` — toplevel resolution for `git_status` & `get_git_diff`; numstat merging (including `--no-index` fallback for untracked); MM/AM dual-entry in `parse_git_status`; `-z` numstat parser with brace-form regression guard.
- `watcher.rs` (new) — `RepoWatcher` / `PreRepoWatcher` with per-cwd refcounted subscribers, pre-repo → repo auto-upgrade on `git init`, event fan-out (`cwds: string[]`), 300 ms debounce, 10 s status-hash polling fallback, dynamic non-recursive dir registration, Remove/Create/Modify filter.

### Frontend (`src/features/`)
- `diff/hooks/useGitStatus.ts` — new `{ watch, enabled, filesCwd }` options; listen-before-invoke mount ordering to close the initial-fire race.
- `diff/components/ChangedFilesList.tsx` — `{ path, staged }` selection identity so MM/AM pairs disambiguate; row keys `${path}:${staged}`.
- `diff/components/DiffPanelContent.tsx` — controlled `SelectedDiffFile` (`{ path, staged, cwd }`); render-time cwd guard; `filesCwd === cwd` freshness filter on every downstream consumer; `--no-index` untracked fallback path renders in DiffViewer instead of a placeholder.
- `workspace/components/BottomDrawer.tsx` — controlled `activeTab` / `isCollapsed` / `selectedDiffFile`.
- `workspace/WorkspaceView.tsx` — lifts drawer state; `handleOpenDiff` uncollapses the drawer unconditionally; belt-and-suspenders cwd-reset effect.
- `agent-status/components/FilesChanged.tsx` — refactored to consume `ChangedFile[]`; staged-vs-unstaged visual; loading / error / retry / stale-error-banner states; `defaultExpanded: true`.
- `agent-status/components/AgentStatusPanel.tsx` — replaces `placeholderFiles` with `useGitStatus(cwd, { watch: true, enabled: status.isActive })`; derives `effectiveFiles` + `effectiveLoading` from `filesCwd` freshness (while keeping current-cwd failures visible as errors, not a permanent loading state).

### Harness fix (independently valuable)
- `fix(harness): raise StreamReader limit to 10 MB in cli_client` — unblocked Phase 1 initializer for repos with substantial docs; `asyncio` default of 64 KB tripped on the 697-line design spec as a single tool result. Not specific to this feature but found and fixed along the way.

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib git` — 33 passed
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (after pruning the gitignored `src-tauri/bindings/` auto-generated artifacts)
- [x] `npm test -- --run` — 1,379 passed, 3 skipped (pre-existing)
- [ ] Manual smoke: restart `tauri:dev`, confirm the 4 untracked tooling files render as all-`+` diffs on click; modify a tracked file and confirm the real unified diff shows up; verify the `+N / -0` sidebar badge on untracked rows reflects actual line count.

## Follow-ups filed / deferred
- `#85` — `ActivityFooter.turnCount` hardcoded to `0`; out of scope for this PR per the design spec.
- Pre-repo → repo upgrade identity test requires making the watcher generic over `tauri::Runtime` (`AppHandle<Wry>` vs `AppHandle<MockRuntime>`). Code review covers the fix; dedicated unit test deferred until that broader refactor.

## Authoritative references

- Design spec: `docs/superpowers/specs/2026-04-23-files-changed-panel-design.md`
- Pattern alignment: `docs/reviews/patterns/git-operations.md` (finding #5 → untracked `--no-index` fallback), `docs/reviews/patterns/async-race-conditions.md` (listen-before-invoke ordering in `useGitStatus`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)