### PR TITLE
feat: tests panel — surface Claude Code test runs and test-file creation

### DIFF
--- a/docs/superpowers/plans/2026-04-28-tests-panel-bridge-plan.md
+++ b/docs/superpowers/plans/2026-04-28-tests-panel-bridge-plan.md
@@ -1,0 +1,4326 @@
+# Tests Panel & Claude Code Bridge — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the existing `<TestResults>` placeholder into a real, activity-driven panel that surfaces test runs and test-file creation from Claude Code via passive transcript parsing.
+
+**Architecture:** Extend the existing transcript-watcher pipeline (#56/#63) to (a) recognise Bash tool calls invoking a known test runner and parse their result content into a structured `TestRunSnapshot`, emitted over a new `test-run` Tauri event; (b) tag Write/Edit tool calls whose `file_path` is a test file via a new `is_test_file: bool` on `AgentToolCallEvent`. UI is lazy/activity-driven: a slim placeholder until first event, then a live panel with proportional bar and per-file/group rows.
+
+**Tech Stack:** Rust (Tauri 2 backend), TypeScript + React 18 (frontend), Vitest + RTL for tests, `shell-words` and `regex` crates (new deps), `chrono` (already present, used for ISO 8601 parsing).
+
+**Spec:** `docs/superpowers/specs/2026-04-28-tests-panel-bridge-design.md` — read this first if any task is unclear.
+
+---
+
+## File Structure
+
+### New Rust files (all under `src-tauri/src/agent/test_runners/`)
+
+| File                    | Responsibility                                                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `mod.rs`                | Module root, registry export, public matching API                                                                                     |
+| `types.rs`              | `TestRunSnapshot`, `TestRunSummary`, `TestGroup`, `TestRunStatus`, `TestGroupKind`, `TestGroupStatus`, `CapturedOutput`, `TestRunner` |
+| `script_resolution.rs`  | Read `package.json` and resolve `scripts.<name>` with depth-3 recursion bound                                                         |
+| `test_file_patterns.rs` | `is_test_file(path: &str) -> bool` — filename-suffix and directory-position checks for ts/js/rs/py/go test conventions                |
+| `timestamps.rs`         | `parse_iso8601_ms` (chrono-backed), `compute_duration_ms`                                                                             |
+| `path_resolution.rs`    | `resolve_group_path` with `..`/absolute rejection + canonical containment check                                                       |
+| `sanitiser.rs`          | `sanitize_for_ui` — KEY=value, Bearer, Authorization, sk*/pk*, JWT redaction (regex-backed)                                           |
+| `preview.rs`            | `build_command_preview` — joins stripped tokens, runs through sanitiser, truncates to 120 chars                                       |
+| `matcher.rs`            | `match_command` — tokenize, strip env, segment-split, strip wrappers, resolve script aliases, walk `RUNNERS`                          |
+| `emitter.rs`            | `TestRunEmitter` — per-tail-loop helper, latest-wins replay batching                                                                  |
+| `vitest.rs`             | `VITEST` runner: `matches` + `parse_result`                                                                                           |
+| `cargo.rs`              | `CARGO_TEST` runner: `matches` + `parse_result`                                                                                       |
+
+### Modified Rust files
+
+| File                                | Change                                                                                                                                                                                 |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src-tauri/src/agent/types.rs`      | Add `is_test_file: bool` to `AgentToolCallEvent`                                                                                                                                       |
+| `src-tauri/src/agent/transcript.rs` | Extend `InFlightToolCall` (`test_runner`, `raw_command`); add CWD threading; modify `process_assistant_message` and `process_tool_result`; integrate `TestRunEmitter` into `tail_loop` |
+| `src-tauri/src/agent/watcher.rs`    | Pass resolved CWD to `TranscriptState::start_or_replace`                                                                                                                               |
+| `src-tauri/src/agent/mod.rs`        | Add `pub mod test_runners;`                                                                                                                                                            |
+| `src-tauri/Cargo.toml`              | Add `shell-words` and `regex` deps                                                                                                                                                     |
+
+### Modified TypeScript files
+
+| File                                                                                           | Change                                                                                                                                                                                                            |
+| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/features/agent-status/types/index.ts`                                                     | Add `TestRunSnapshot`, `TestRunSummary`, `TestGroup`, `TestRunStatus`, `TestGroupKind`, `TestGroupStatus`; add `testRun: TestRunSnapshot \| null` to `AgentStatus`; add `isTestFile: boolean` to `RecentToolCall` |
+| `src/features/agent-status/types/activityEvent.ts`                                             | Add `isTestFile?: boolean` to `ActivityEvent`                                                                                                                                                                     |
+| `src/features/agent-status/hooks/useAgentStatus.ts`                                            | Add `testRun: null` to `createDefaultStatus`; add `test-run` listener inside `subscribe()`; propagate `isTestFile` on tool-call events                                                                            |
+| `src/features/agent-status/components/TestResults.tsx`                                         | Full rewrite — single nullable `snapshot` prop, placeholder + live sub-components                                                                                                                                 |
+| `src/features/agent-status/components/AgentStatusPanel.tsx`                                    | Remove `placeholderTests` const; add `onOpenFile` prop; pass `status.testRun`                                                                                                                                     |
+| `src/features/agent-status/utils/toolCallsToEvents.ts`                                         | Propagate `isTestFile` to `ActivityEvent`                                                                                                                                                                         |
+| `src/features/agent-status/components/ActivityFeed.tsx` (or whichever sibling renders the row) | Render `🧪 Created test:` / `🧪 Updated test:` when `event.isTestFile === true`                                                                                                                                   |
+| `src/features/workspace/WorkspaceView.tsx`                                                     | Add `handleOpenTestFile` (mirrors `handleFileSelect` dirty-state guard); pass to `AgentStatusPanel`                                                                                                               |
+
+### Test files (co-located, `.test.ts(x)` siblings)
+
+All existing tests for modified files get extended; all new files get their own test file.
+
+---
+
+## Task 1: Rust types and module skeleton
+
+Set up the new `test_runners/` module with all types defined and stubs for the runners. Compile-only — no parsing logic yet.
+
+**Files:**
+
+- Create: `src-tauri/src/agent/test_runners/mod.rs`
+- Create: `src-tauri/src/agent/test_runners/types.rs`
+- Create: `src-tauri/src/agent/test_runners/vitest.rs`
+- Create: `src-tauri/src/agent/test_runners/cargo.rs`
+- Modify: `src-tauri/src/agent/mod.rs`
+- Modify: `src-tauri/Cargo.toml`
+
+- [ ] **Step 1: Add new dependencies**
+
+Edit `src-tauri/Cargo.toml` — add to `[dependencies]`:
+
+```toml
+shell-words = "1.1"
+regex = "1.10"
+once_cell = "1.19"
+```
+
+Run: `cargo build --manifest-path src-tauri/Cargo.toml`
+Expected: Builds successfully with new deps fetched.
+
+- [ ] **Step 2: Create `types.rs` with all data types**
+
+Create `src-tauri/src/agent/test_runners/types.rs`:
+
+```rust
+use std::path::Path;
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TestRunSnapshot {
+    pub session_id: String,
+    pub runner: String,
+    pub command_preview: String,
+    pub started_at: String,
+    pub finished_at: String,
+    pub duration_ms: u64,
+    pub status: TestRunStatus,
+    pub summary: TestRunSummary,
+    pub output_excerpt: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum TestRunStatus {
+    Pass,
+    Fail,
+    NoTests,
+    Error,
+}
+
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TestRunSummary {
+    pub passed: u32,
+    pub failed: u32,
+    pub skipped: u32,
+    pub total: u32,
+    pub groups: Vec<TestGroup>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TestGroup {
+    pub label: String,
+    pub path: Option<String>,
+    pub kind: TestGroupKind,
+    pub passed: u32,
+    pub failed: u32,
+    pub skipped: u32,
+    pub total: u32,
+    pub status: TestGroupStatus,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TestGroupKind {
+    File,
+    Suite,
+    Module,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TestGroupStatus {
+    Pass,
+    Fail,
+    Skip,
+}
+
+/// Bash tool_result content captured for a matched test-run tool_use.
+pub struct CapturedOutput {
+    pub content: String,
+    pub is_error: bool,
+}
+
+pub struct TestRunner {
+    pub name: &'static str,
+    pub matches: fn(tokens: &[&str]) -> bool,
+    pub parse_result: fn(out: &CapturedOutput, cwd: &Path) -> Option<TestRunSummary>,
+}
+```
+
+- [ ] **Step 3: Create stub runners**
+
+Create `src-tauri/src/agent/test_runners/vitest.rs`:
+
+```rust
+use std::path::Path;
+
+use super::types::{CapturedOutput, TestRunSummary, TestRunner};
+
+pub static VITEST: TestRunner = TestRunner {
+    name: "vitest",
+    matches: vitest_matches,
+    parse_result: vitest_parse_result,
+};
+
+fn vitest_matches(tokens: &[&str]) -> bool {
+    matches!(tokens.first(), Some(&"vitest"))
+}
+
+fn vitest_parse_result(_out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummary> {
+    // Implemented in Task 5
+    None
+}
+```
+
+Create `src-tauri/src/agent/test_runners/cargo.rs`:
+
+```rust
+use std::path::Path;
+
+use super::types::{CapturedOutput, TestRunSummary, TestRunner};
+
+pub static CARGO_TEST: TestRunner = TestRunner {
+    name: "cargo",
+    matches: cargo_matches,
+    parse_result: cargo_parse_result,
+};
+
+fn cargo_matches(tokens: &[&str]) -> bool {
+    matches!(tokens, [&"cargo", &"test", ..])
+}
+
+fn cargo_parse_result(_out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummary> {
+    // Implemented in Task 10
+    None
+}
+```
+
+- [ ] **Step 4: Create `mod.rs` with registry**
+
+Create `src-tauri/src/agent/test_runners/mod.rs`:
+
+```rust
+pub mod cargo;
+pub mod types;
+pub mod vitest;
+
+use types::TestRunner;
+
+pub static RUNNERS: &[&TestRunner] = &[&vitest::VITEST, &cargo::CARGO_TEST];
+```
+
+- [ ] **Step 5: Wire module into `agent/mod.rs`**
+
+Edit `src-tauri/src/agent/mod.rs` — add the module declaration. Find the existing `pub mod` block and add:
+
+```rust
+pub mod test_runners;
+```
+
+- [ ] **Step 6: Build the workspace**
+
+Run: `cargo build --manifest-path src-tauri/Cargo.toml`
+Expected: Builds cleanly. Some `dead_code` warnings on unused stubs are acceptable for now.
+
+- [ ] **Step 7: Add a smoke test for matchers**
+
+Create `src-tauri/src/agent/test_runners/types.rs` test module at the bottom of `vitest.rs` and `cargo.rs`:
+
+In `vitest.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vitest_matches_first_token() {
+        assert!((VITEST.matches)(&["vitest"]));
+        assert!((VITEST.matches)(&["vitest", "run", "src/foo.test.ts"]));
+        assert!(!(VITEST.matches)(&["jest"]));
+        assert!(!(VITEST.matches)(&[]));
+    }
+}
+```
+
+In `cargo.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cargo_matches_cargo_test() {
+        assert!((CARGO_TEST.matches)(&["cargo", "test"]));
+        assert!((CARGO_TEST.matches)(&["cargo", "test", "--release"]));
+        assert!(!(CARGO_TEST.matches)(&["cargo", "build"]));
+        assert!(!(CARGO_TEST.matches)(&["cargo"]));
+        assert!(!(CARGO_TEST.matches)(&[]));
+    }
+}
+```
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::test_runners`
+Expected: 2 tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src-tauri/Cargo.toml \
+        src-tauri/src/agent/mod.rs \
+        src-tauri/src/agent/test_runners/
+git commit -m "feat(agent): scaffold test_runners module with type skeleton
+
+Adds the test_runners module with TestRunSnapshot, TestRunSummary,
+TestGroup, status enums, and stub VITEST + CARGO_TEST runners.
+Parsers return None — implemented in later tasks. Adds shell-words,
+regex, once_cell as dependencies."
+```
+
+---
+
+## Task 2: CWD threading through TranscriptWatcher
+
+The transcript parser needs CWD inside `tail_loop` to (a) resolve `npm test` script aliases, (b) build absolute paths for test-file groups. This task threads `Option<PathBuf>` through the watcher.
+
+**Files:**
+
+- Modify: `src-tauri/src/agent/transcript.rs` (struct, `start_or_replace`, `start_tailing`, `tail_loop`)
+- Modify: `src-tauri/src/agent/watcher.rs` (caller passes CWD)
+
+- [ ] **Step 1: Write the failing test for `start_or_replace` accepting CWD**
+
+In `src-tauri/src/agent/transcript.rs`, find the existing `transcript_state_replaces_changed_path` test in the `#[cfg(test)] mod tests` block (around line 596) and add a new test:
+
+```rust
+#[test]
+fn transcript_state_threads_cwd_through() {
+    let app = tauri::test::mock_builder()
+        .build(tauri::generate_context!())
+        .expect("failed to build test app");
+    let tmp = tempfile::tempdir().expect("failed to create temp dir");
+    let transcript_path = tmp.path().join("t.jsonl");
+    std::fs::write(&transcript_path, "").expect("failed to write transcript");
+    let cwd = tmp.path().to_path_buf();
+
+    let state = TranscriptState::new();
+    let session_id = "session-cwd".to_string();
+
+    let status = state
+        .start_or_replace(
+            app.handle().clone(),
+            session_id.clone(),
+            transcript_path,
+            Some(cwd),
+        )
+        .expect("failed to start watcher with cwd");
+    assert_eq!(status, TranscriptStartStatus::Started);
+
+    state.stop(&session_id).expect("failed to stop watcher");
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails to compile**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml transcript_state_threads_cwd_through`
+Expected: Fails — `start_or_replace` does not accept a 4th `Option<PathBuf>` argument.
+
+- [ ] **Step 3: Add `cwd` to `TranscriptWatcher` struct**
+
+Edit `src-tauri/src/agent/transcript.rs`. Find the existing struct (around line 68):
+
+```rust
+struct TranscriptWatcher {
+    transcript_path: PathBuf,
+    handle: TranscriptHandle,
+}
+```
+
+Replace with:
+
+```rust
+struct TranscriptWatcher {
+    transcript_path: PathBuf,
+    cwd: Option<PathBuf>,
+    handle: TranscriptHandle,
+}
+```
+
+- [ ] **Step 4: Add `cwd` parameter to `TranscriptState::start_or_replace` and `start`**
+
+Edit `src-tauri/src/agent/transcript.rs`. Replace `start` (around line 112):
+
+```rust
+pub fn start<R: tauri::Runtime>(
+    &self,
+    app_handle: tauri::AppHandle<R>,
+    session_id: String,
+    transcript_path: PathBuf,
+    cwd: Option<PathBuf>,
+) -> Result<(), String> {
+    let _ = self.start_or_replace(app_handle, session_id, transcript_path, cwd)?;
+    Ok(())
+}
+```
+
+Replace `start_or_replace` signature (around line 123):
+
+```rust
+pub fn start_or_replace<R: tauri::Runtime>(
+    &self,
+    app_handle: tauri::AppHandle<R>,
+    session_id: String,
+    transcript_path: PathBuf,
+    cwd: Option<PathBuf>,
+) -> Result<TranscriptStartStatus, String> {
+```
+
+Inside the function, both `watchers.insert(…)` calls now also need `cwd`. Replace the two `TranscriptWatcher { transcript_path, handle: … }` constructors with `TranscriptWatcher { transcript_path: transcript_path.clone(), cwd: cwd.clone(), handle: … }` (the `clone()` on `cwd` is needed because both branches consume it; `Option<PathBuf>` is `Clone`). And the call to `start_tailing(...)` adds `cwd.clone()` as a 4th argument.
+
+- [ ] **Step 5: Add `cwd` parameter to `start_tailing` and `tail_loop`**
+
+Edit `src-tauri/src/agent/transcript.rs`. Replace `start_tailing` signature (around line 219):
+
+```rust
+pub fn start_tailing<R: tauri::Runtime>(
+    app_handle: tauri::AppHandle<R>,
+    session_id: String,
+    transcript_path: PathBuf,
+    cwd: Option<PathBuf>,
+) -> Result<TranscriptHandle, String> {
+    let file = File::open(&transcript_path).map_err(|e| {
+        format!(
+            "Failed to open transcript: {}: {}",
+            transcript_path.display(),
+            e
+        )
+    })?;
+
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let stop_clone = stop_flag.clone();
+
+    let join_handle = std::thread::spawn(move || {
+        tail_loop(app_handle, session_id, cwd, file, stop_clone);
+    });
+
+    Ok(TranscriptHandle {
+        stop_flag,
+        join_handle: Some(join_handle),
+    })
+}
+```
+
+Replace `tail_loop` signature (around line 246):
+
+```rust
+fn tail_loop<R: tauri::Runtime>(
+    app_handle: tauri::AppHandle<R>,
+    session_id: String,
+    _cwd: Option<PathBuf>,  // consumed in Task 4 — prefix with _ to silence unused warning for now
+    file: File,
+    stop_flag: Arc<AtomicBool>,
+) {
+```
+
+Note: inside `tail_loop`, do NOT yet thread `cwd` to `process_line`. That happens in Task 4. The `_` prefix silences the unused-variable lint for now.
+
+- [ ] **Step 6: Update `start_transcript_watcher` Tauri command**
+
+Edit `src-tauri/src/agent/transcript.rs`. Replace the command (around line 565):
+
+```rust
+#[tauri::command]
+pub async fn start_transcript_watcher(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, TranscriptState>,
+    session_id: String,
+    transcript_path: String,
+    cwd: Option<String>,
+) -> Result<(), String> {
+    let path = validate_transcript_path(&transcript_path)?;
+    let cwd_path = cwd.map(PathBuf::from);
+    state.start(app_handle, session_id, path, cwd_path)
+}
+```
+
+- [ ] **Step 7: Update `watcher.rs` caller**
+
+Edit `src-tauri/src/agent/watcher.rs`. Find the call to `ts.start_or_replace(...)` (around line 81). The CWD comes from `PtyState`'s resolved CWD (already available — fixed in #60). Update the call:
+
+```rust
+match ts.start_or_replace(
+    app_handle.clone(),
+    session_id.clone(),
+    transcript_path,
+    Some(resolved_cwd.clone()),  // resolved_cwd: PathBuf — already in scope at this call site
+) {
+```
+
+If the existing local variable that holds the CWD is named differently (e.g. `cwd`, `pty_cwd`), use that name. Confirm via:
+
+Run: `grep -n "resolved_cwd\\|cwd" src-tauri/src/agent/watcher.rs | head -20`
+
+Use whichever local CWD variable is in scope at the `start_or_replace` call site.
+
+- [ ] **Step 8: Update both existing tests in transcript.rs**
+
+Edit `src-tauri/src/agent/transcript.rs`. The existing `transcript_state_replaces_changed_path` test calls `start_or_replace` three times — each call needs a 4th `None` argument:
+
+```rust
+let first_status = state
+    .start_or_replace(app.handle().clone(), session_id.clone(), first_path.clone(), None)
+    .expect("failed to start first transcript watcher");
+// ...
+let duplicate_status = state
+    .start_or_replace(app.handle().clone(), session_id.clone(), first_path, None)
+    .expect("failed to check duplicate transcript watcher");
+// ...
+let replaced_status = state
+    .start_or_replace(app.handle().clone(), session_id.clone(), second_path, None)
+    .expect("failed to replace transcript watcher");
+```
+
+- [ ] **Step 9: Run all transcript tests**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::transcript`
+Expected: All tests pass, including the new `transcript_state_threads_cwd_through`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src-tauri/src/agent/transcript.rs src-tauri/src/agent/watcher.rs
+git commit -m "refactor(agent): thread workspace cwd through TranscriptWatcher
+
+Adds Option<PathBuf> cwd to TranscriptWatcher / start_or_replace /
+start_tailing / tail_loop, and to the start_transcript_watcher Tauri
+command. watcher.rs passes the PTY's resolved cwd. Consumed in
+follow-up tasks for script-alias resolution and per-file path
+resolution."
+```
+
+---
+
+## Task 3: AgentToolCallEvent.is_test_file + test_file_patterns
+
+Add the `is_test_file: bool` field to the existing `AgentToolCallEvent` and tag Write/Edit tool calls whose `file_path` matches a known test pattern. Smallest possible end-to-end backend→frontend slice — verifies the wire shape before any test-run plumbing.
+
+**Files:**
+
+- Create: `src-tauri/src/agent/test_runners/test_file_patterns.rs`
+- Modify: `src-tauri/src/agent/types.rs` (add field)
+- Modify: `src-tauri/src/agent/transcript.rs` (compute field; emit it)
+- Modify: `src-tauri/src/agent/test_runners/mod.rs` (export module)
+- Modify: `src/features/agent-status/types/index.ts` (add `isTestFile`)
+- Modify: `src/features/agent-status/hooks/useAgentStatus.ts` (propagate `isTestFile`)
+
+- [ ] **Step 1: Write failing tests for `is_test_file`**
+
+Create `src-tauri/src/agent/test_runners/test_file_patterns.rs`:
+
+```rust
+//! Test-file path matching. Frontend reads is_test_file: bool from
+//! AgentToolCallEvent and renders accordingly — no JS-side glob.
+
+/// Returns true if `path` matches a known test-file convention.
+/// Matches on the basename and (for some languages) directory position.
+pub fn is_test_file(path: &str) -> bool {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+
+    // TS/JS: *.test.{ts,tsx,js,jsx,mjs,cjs} and *.spec.{...}
+    if let Some(stem_end) = basename.rfind('.') {
+        let ext = &basename[stem_end + 1..];
+        let stem = &basename[..stem_end];
+        if matches!(ext, "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs") {
+            if let Some(inner_end) = stem.rfind('.') {
+                let infix = &stem[inner_end + 1..];
+                if infix == "test" || infix == "spec" {
+                    return true;
+                }
+            }
+        }
+        // Rust: *_test.rs (cargo convention)
+        if ext == "rs" && stem.ends_with("_test") {
+            return true;
+        }
+        // Python: test_*.py and *_test.py (pytest convention)
+        if ext == "py" && (stem.starts_with("test_") || stem.ends_with("_test")) {
+            return true;
+        }
+        // Go: *_test.go
+        if ext == "go" && stem.ends_with("_test") {
+            return true;
+        }
+    }
+
+    // Rust: anything inside a tests/ directory
+    if path.contains("/tests/") || path.starts_with("tests/") {
+        return true;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ts_test_files_match() {
+        assert!(is_test_file("src/foo.test.ts"));
+        assert!(is_test_file("src/foo.test.tsx"));
+        assert!(is_test_file("src/foo.spec.ts"));
+        assert!(is_test_file("/abs/src/bar.test.mjs"));
+        assert!(is_test_file("packages/x/src/baz.test.cjs"));
+    }
+
+    #[test]
+    fn ts_non_test_files_dont_match() {
+        assert!(!is_test_file("src/foo.ts"));
+        assert!(!is_test_file("src/tests-helper.ts"));
+        assert!(!is_test_file("test.txt"));
+        assert!(!is_test_file("src/test.config.ts"));  // .test. but ext is .ts not .test.ts
+    }
+
+    #[test]
+    fn rust_test_files_match() {
+        assert!(is_test_file("src/foo_test.rs"));
+        assert!(is_test_file("crates/x/tests/integration.rs"));
+        assert!(is_test_file("tests/it.rs"));
+    }
+
+    #[test]
+    fn rust_non_test_files_dont_match() {
+        assert!(!is_test_file("src/foo.rs"));
+        assert!(!is_test_file("src/test_helper.rs"));  // not _test.rs and not in tests/
+    }
+
+    #[test]
+    fn python_test_files_match() {
+        assert!(is_test_file("tests/test_foo.py"));
+        assert!(is_test_file("src/foo_test.py"));
+    }
+
+    #[test]
+    fn go_test_files_match() {
+        assert!(is_test_file("pkg/foo_test.go"));
+    }
+
+    #[test]
+    fn empty_and_weird_paths_dont_match() {
+        assert!(!is_test_file(""));
+        assert!(!is_test_file("/"));
+        assert!(!is_test_file("foo"));
+    }
+}
+```
+
+Note: `is_test_file("src/test.config.ts")` returns false because the basename is `test.config.ts`, stem is `test.config`, infix (last dot's right side) is `config` — not `test`/`spec`. Good.
+
+But `is_test_file("src/.test.ts")` — basename `.test.ts`, stem `.test`, inner_end is 0 (the leading dot), infix is `test` → returns true. That's a hidden file scenario; acceptable false positive (very rare).
+
+- [ ] **Step 2: Wire module into mod.rs**
+
+Edit `src-tauri/src/agent/test_runners/mod.rs`:
+
+```rust
+pub mod cargo;
+pub mod test_file_patterns;
+pub mod types;
+pub mod vitest;
+
+use types::TestRunner;
+
+pub static RUNNERS: &[&TestRunner] = &[&vitest::VITEST, &cargo::CARGO_TEST];
+```
+
+- [ ] **Step 3: Run the test_file_patterns tests**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::test_runners::test_file_patterns`
+Expected: All 7 tests pass.
+
+- [ ] **Step 4: Add `is_test_file` to `AgentToolCallEvent`**
+
+Edit `src-tauri/src/agent/types.rs`. Find the `AgentToolCallEvent` struct and add the field:
+
+```rust
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentToolCallEvent {
+    pub session_id: String,
+    pub tool_use_id: String,
+    pub tool: String,
+    pub args: String,
+    pub status: ToolCallStatus,
+    pub timestamp: String,
+    pub duration_ms: u64,
+    pub is_test_file: bool,
+}
+```
+
+If `Default` is derived/needed elsewhere, ensure new field is included.
+
+- [ ] **Step 5: Set `is_test_file` in `process_assistant_message`**
+
+Edit `src-tauri/src/agent/transcript.rs`. Find `process_assistant_message` (around line 335) where the `AgentToolCallEvent` is built (around line 377). Before the event construction, compute the flag:
+
+```rust
+let is_test_file = if matches!(name.as_str(), "Write" | "Edit") {
+    item.get("input")
+        .and_then(|v| v.get("file_path"))
+        .and_then(|v| v.as_str())
+        .map(|p| crate::agent::test_runners::test_file_patterns::is_test_file(p))
+        .unwrap_or(false)
+} else {
+    false
+};
+```
+
+Then add `is_test_file` to the event construction:
+
+```rust
+let event = AgentToolCallEvent {
+    session_id: session_id.to_string(),
+    tool_use_id: id,
+    tool: name,
+    args,
+    status: ToolCallStatus::Running,
+    timestamp: timestamp.clone(),
+    duration_ms: 0,
+    is_test_file,
+};
+```
+
+Also add `is_test_file: false` in the `process_tool_result` event construction (around line 453) — the flag's relevance is on the originating tool_use, not the result event:
+
+```rust
+let event = AgentToolCallEvent {
+    session_id: session_id.to_string(),
+    tool_use_id,
+    tool: tool_name,
+    args,
+    status,
+    timestamp: timestamp.to_string(),
+    duration_ms,
+    is_test_file: false,
+};
+```
+
+(For symmetry the running event carries the truth; the done/failed event mirrors what the frontend already has from the in-flight running event. Frontend uses the running-event flag to decide rendering.)
+
+Wait — review the `useAgentStatus` mapping: for `running` status it sets `active: { tool, args, startedAt, toolUseId }` (no `is_test_file` propagated yet). For `done`/`failed`, it builds a `RecentToolCall { id, tool, args, status, durationMs, timestamp }`. The flag has to flow through one of these. Cleanest: include `is_test_file` on BOTH events with the same value (computed once at `process_assistant_message`, stored on `InFlightToolCall`, copied into `process_tool_result` event). That avoids the frontend needing to remember running-side state when only the done-side event drives the activity feed.
+
+Revised: extend `InFlightToolCall` with `is_test_file: bool`. `process_assistant_message` writes it; `process_tool_result` reads from `call.is_test_file` and passes to the done event.
+
+Edit `InFlightToolCall` (around line 54):
+
+```rust
+struct InFlightToolCall {
+    started_at: Instant,
+    tool: String,
+    args: String,
+    is_test_file: bool,
+}
+```
+
+In `process_assistant_message`, the in-flight insert becomes:
+
+```rust
+in_flight.insert(
+    id.clone(),
+    InFlightToolCall {
+        started_at: now,
+        tool: name.clone(),
+        args: args.clone(),
+        is_test_file,
+    },
+);
+```
+
+In `process_tool_result` (after `let Some(call) = in_flight.remove(...)`):
+
+```rust
+let is_test_file = call.is_test_file;
+// ...existing extraction of duration_ms, tool_name, args, status...
+let event = AgentToolCallEvent {
+    session_id: session_id.to_string(),
+    tool_use_id,
+    tool: tool_name,
+    args,
+    status,
+    timestamp: timestamp.to_string(),
+    duration_ms,
+    is_test_file,
+};
+```
+
+Both running and done events now carry the same flag.
+
+- [ ] **Step 6: Update existing test fixtures in transcript.rs that build InFlightToolCall**
+
+Edit `src-tauri/src/agent/transcript.rs`. Find the test helpers around lines 824 and 830 that build `InFlightToolCall { started_at, tool, args }` — add `is_test_file: false` to each:
+
+```rust
+InFlightToolCall {
+    started_at: Instant::now(),
+    tool: "Read".to_string(),
+    args: "src/foo.rs".to_string(),
+    is_test_file: false,
+}
+```
+
+(Replace `Read`/`src/foo.rs` with whatever the existing fixtures use; just add the new field.)
+
+- [ ] **Step 7: Run all backend tests**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent`
+Expected: All tests pass.
+
+- [ ] **Step 8: Update TS types — add `isTestFile`**
+
+Edit `src/features/agent-status/types/index.ts`. Find the `RecentToolCall` interface (and `ActiveToolCall` if it carries the same fields) and add:
+
+```typescript
+export interface RecentToolCall {
+  id: string
+  tool: string
+  args: string
+  status: ToolCallStatus
+  durationMs: number | null
+  timestamp: string
+  isTestFile: boolean
+}
+```
+
+Find or add the corresponding event type used by the listener:
+
+```typescript
+export interface AgentToolCallEvent {
+  sessionId: string
+  toolUseId: string
+  tool: string
+  args: string
+  status: ToolCallStatus
+  timestamp: string
+  durationMs: number
+  isTestFile: boolean
+}
+```
+
+(If `AgentToolCallEvent` already exists with all fields except `isTestFile`, just add the field.)
+
+- [ ] **Step 9: Propagate `isTestFile` in `useAgentStatus`**
+
+Edit `src/features/agent-status/hooks/useAgentStatus.ts`. Find the `agent-tool-call` listener (around line 258). In the `done`/`failed` branch where `recentCall` is constructed, add `isTestFile`:
+
+```typescript
+const recentCall: RecentToolCall = {
+  id: p.toolUseId,
+  tool: p.tool,
+  args: p.args,
+  status: p.status,
+  durationMs: Number(p.durationMs) || null,
+  timestamp: p.timestamp,
+  isTestFile: p.isTestFile,
+}
+```
+
+The `running` branch sets `active` (which doesn't carry `isTestFile` today since the activity feed is driven by `recentToolCalls`). Leave the `active` shape unchanged.
+
+- [ ] **Step 10: Add a hook test for `isTestFile` propagation**
+
+Edit `src/features/agent-status/hooks/useAgentStatus.test.tsx` (or create it if missing — co-located with the hook).
+
+Add a test that:
+
+1. Mounts `useAgentStatus(sessionId)`
+2. Mocks `getPtySessionId` to return a known PTY id
+3. Fires a mocked `agent-tool-call` listener with `status: 'done'`, `isTestFile: true`
+4. Asserts `result.current.recentToolCalls[0].isTestFile === true`
+
+```typescript
+test('propagates isTestFile from agent-tool-call event to recentToolCalls', async () => {
+  const PTY_ID = 'pty-abc'
+  vi.mocked(getPtySessionId).mockReturnValue(PTY_ID)
+
+  let toolCallHandler:
+    | ((e: { payload: AgentToolCallEvent }) => void)
+    | undefined
+  vi.mocked(listen).mockImplementation(async (event, handler) => {
+    if (event === 'agent-tool-call') {
+      toolCallHandler = handler as never
+    }
+    return () => undefined
+  })
+
+  const { result } = renderHook(() => useAgentStatus('ws-1'))
+  await waitFor(() => expect(toolCallHandler).toBeDefined())
+
+  act(() => {
+    toolCallHandler?.({
+      payload: {
+        sessionId: PTY_ID,
+        toolUseId: 'tu_1',
+        tool: 'Write',
+        args: 'src/foo.test.ts',
+        status: 'done',
+        timestamp: '2026-04-28T12:00:00Z',
+        durationMs: 100,
+        isTestFile: true,
+      },
+    })
+  })
+
+  expect(result.current.recentToolCalls[0]?.isTestFile).toBe(true)
+})
+```
+
+Run: `npx vitest run src/features/agent-status/hooks/useAgentStatus.test.tsx`
+Expected: New test passes; existing tests continue to pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src-tauri/src/agent/test_runners/ \
+        src-tauri/src/agent/types.rs \
+        src-tauri/src/agent/transcript.rs \
+        src/features/agent-status/types/index.ts \
+        src/features/agent-status/hooks/useAgentStatus.ts \
+        src/features/agent-status/hooks/useAgentStatus.test.tsx
+git commit -m "feat(agent): tag Write/Edit of test files via is_test_file flag
+
+Adds is_test_file: bool to AgentToolCallEvent. process_assistant_message
+checks the FULL untruncated input.file_path against TEST_FILE patterns
+(ts/tsx/js/jsx/mjs/cjs/rs/py/go test conventions) and tags the event.
+Frontend hook propagates the flag to RecentToolCall. Activity feed
+rendering of the flag lands in Task 11."
+```
+
+---
+
+## Task 4: Matching algorithm
+
+Implement the seven-step command matching algorithm: tokenize, strip env, segment-split, strip wrappers, resolve script aliases, walk runners. Each sub-function gets its own TDD cycle.
+
+**Files:**
+
+- Create: `src-tauri/src/agent/test_runners/matcher.rs`
+- Create: `src-tauri/src/agent/test_runners/script_resolution.rs`
+- Modify: `src-tauri/src/agent/test_runners/mod.rs` (export both)
+
+- [ ] **Step 1: Test for tokenize/segment-split (failing)**
+
+Create `src-tauri/src/agent/test_runners/matcher.rs`:
+
+```rust
+//! Command matching: tokenize → strip env → first segment → strip wrappers
+//! → resolve script alias → match against RUNNERS.
+
+use std::path::Path;
+
+use super::script_resolution;
+use super::types::TestRunner;
+use super::RUNNERS;
+
+/// Tokenize a command string into shell-words, returning None if the input
+/// can't be parsed (e.g. unmatched quotes). None is treated as "no match"
+/// downstream — never as a hard error — so we don't false-positive on weird
+/// shell syntax we haven't seen before.
+pub fn tokenize(cmd: &str) -> Option<Vec<String>> {
+    shell_words::split(cmd).ok()
+}
+
+/// Drop leading KEY=VALUE assignments (env-style) until the first non-assignment.
+pub fn strip_env_prefix(tokens: &[String]) -> &[String] {
+    let mut i = 0;
+    while i < tokens.len() {
+        let t = &tokens[i];
+        // KEY=value: must contain '=', and the part before '=' must look like
+        // an identifier (letters/digits/underscore, not starting with digit).
+        if let Some(eq) = t.find('=') {
+            let key = &t[..eq];
+            if !key.is_empty()
+                && key.chars().next().is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+                && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                i += 1;
+                continue;
+            }
+        }
+        break;
+    }
+    &tokens[i..]
+}
+
+/// Take only the first command segment — split on &&, ;, ||, |.
+pub fn first_segment<'a>(tokens: &'a [String]) -> &'a [String] {
+    let separators = ["&&", "||", ";", "|"];
+    for (i, t) in tokens.iter().enumerate() {
+        if separators.contains(&t.as_str()) {
+            return &tokens[..i];
+        }
+    }
+    tokens
+}
+
+/// Strip leading wrapper prefixes one pass.
+pub fn strip_wrappers<'a>(tokens: &'a [String]) -> &'a [String] {
+    if tokens.is_empty() {
+        return tokens;
+    }
+    match tokens[0].as_str() {
+        "npx" => &tokens[1..],
+        "pnpm" if tokens.get(1).map(String::as_str) == Some("exec") => &tokens[2..],
+        "yarn" if tokens.get(1).map(String::as_str) == Some("exec") => &tokens[2..],
+        "bun" if tokens.get(1).map(String::as_str) == Some("x") => &tokens[2..],
+        "dotenv" if tokens.get(1).map(String::as_str) == Some("--") => &tokens[2..],
+        _ => tokens,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vec_of(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn tokenize_simple_command() {
+        assert_eq!(tokenize("vitest run"), Some(vec_of(&["vitest", "run"])));
+    }
+
+    #[test]
+    fn tokenize_handles_quotes() {
+        assert_eq!(
+            tokenize(r#"vitest run "src/foo bar.test.ts""#),
+            Some(vec_of(&["vitest", "run", "src/foo bar.test.ts"]))
+        );
+    }
+
+    #[test]
+    fn tokenize_unmatched_quote_returns_none() {
+        assert_eq!(tokenize(r#"vitest "run"#), None);
+    }
+
+    #[test]
+    fn strip_env_drops_assignments_only() {
+        let tokens = vec_of(&["CI=1", "NODE_ENV=test", "vitest"]);
+        assert_eq!(strip_env_prefix(&tokens), &tokens[2..]);
+    }
+
+    #[test]
+    fn strip_env_does_not_drop_value_with_equals() {
+        // "vitest" doesn't contain '=', so nothing stripped
+        let tokens = vec_of(&["vitest", "--reporter=verbose"]);
+        assert_eq!(strip_env_prefix(&tokens), &tokens[..]);
+    }
+
+    #[test]
+    fn first_segment_at_first_separator() {
+        let tokens = vec_of(&["cargo", "build", "&&", "cargo", "test"]);
+        assert_eq!(first_segment(&tokens), &tokens[..2]);
+    }
+
+    #[test]
+    fn first_segment_no_separator_returns_all() {
+        let tokens = vec_of(&["vitest", "run", "src/foo.test.ts"]);
+        assert_eq!(first_segment(&tokens), &tokens[..]);
+    }
+
+    #[test]
+    fn strip_wrappers_handles_npx() {
+        let tokens = vec_of(&["npx", "vitest"]);
+        assert_eq!(strip_wrappers(&tokens), &tokens[1..]);
+    }
+
+    #[test]
+    fn strip_wrappers_handles_pnpm_exec() {
+        let tokens = vec_of(&["pnpm", "exec", "vitest"]);
+        assert_eq!(strip_wrappers(&tokens), &tokens[2..]);
+    }
+
+    #[test]
+    fn strip_wrappers_no_change_when_no_wrapper() {
+        let tokens = vec_of(&["vitest"]);
+        assert_eq!(strip_wrappers(&tokens), &tokens[..]);
+    }
+}
+```
+
+- [ ] **Step 2: Wire matcher into mod.rs and run the tokenize/strip tests**
+
+Edit `src-tauri/src/agent/test_runners/mod.rs`:
+
+```rust
+pub mod cargo;
+pub mod matcher;
+pub mod script_resolution;
+pub mod test_file_patterns;
+pub mod types;
+pub mod vitest;
+
+use types::TestRunner;
+
+pub static RUNNERS: &[&TestRunner] = &[&vitest::VITEST, &cargo::CARGO_TEST];
+```
+
+(The `script_resolution` module is created in step 3.)
+
+Create an empty `src-tauri/src/agent/test_runners/script_resolution.rs` placeholder:
+
+```rust
+// Filled out in step 3.
+```
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::test_runners::matcher`
+Expected: All 10 sub-tests pass.
+
+- [ ] **Step 3: Test for script-alias resolution (failing)**
+
+Replace `src-tauri/src/agent/test_runners/script_resolution.rs`:
+
+```rust
+//! Resolve `npm/yarn/pnpm test` and `npm/yarn/pnpm/bun run <name>` against
+//! package.json scripts, with a depth-3 recursion bound to defend against
+//! pathological alias loops.
+
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+const MAX_RECURSION_DEPTH: usize = 3;
+
+/// Returns Some(resolved_command_string) if the first two tokens are a known
+/// npm-family script invocation AND package.json contains the script.
+/// Returns None for everything else (caller continues with original tokens).
+///
+/// `bun test` is intentionally NOT treated as an alias — bun has a built-in
+/// test runner. Adding a Bun runner is future work.
+pub fn resolve_alias(tokens: &[String], cwd: Option<&Path>) -> Option<String> {
+    let cwd = cwd?;
+    let (script_name, _consumed) = parse_alias_invocation(tokens)?;
+    resolve_recursive(&script_name, cwd, 0)
+}
+
+fn parse_alias_invocation(tokens: &[String]) -> Option<(String, usize)> {
+    if tokens.len() < 2 {
+        return None;
+    }
+    let pm = tokens[0].as_str();
+    let arg = tokens[1].as_str();
+    match (pm, arg) {
+        // bare `test` — treat as `run test`
+        ("npm" | "yarn" | "pnpm", "test") => Some(("test".to_string(), 2)),
+        // `run <name>`
+        ("npm" | "yarn" | "pnpm" | "bun", "run") => {
+            let name = tokens.get(2)?.clone();
+            Some((name, 3))
+        }
+        _ => None,
+    }
+}
+
+fn resolve_recursive(script_name: &str, cwd: &Path, depth: usize) -> Option<String> {
+    if depth >= MAX_RECURSION_DEPTH {
+        return None;
+    }
+    let pkg_path = cwd.join("package.json");
+    let content = fs::read_to_string(&pkg_path).ok()?;
+    let json: Value = serde_json::from_str(&content).ok()?;
+    let resolved = json
+        .get("scripts")
+        .and_then(|s| s.get(script_name))
+        .and_then(|v| v.as_str())?;
+
+    // If the resolved string itself is an npm-family alias, recurse.
+    if let Some(tokens) = super::matcher::tokenize(resolved) {
+        if let Some((next_script, _)) = parse_alias_invocation(&tokens) {
+            if let Some(deeper) = resolve_recursive(&next_script, cwd, depth + 1) {
+                return Some(deeper);
+            }
+        }
+    }
+    Some(resolved.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_pkg(dir: &Path, scripts: &str) {
+        fs::write(
+            dir.join("package.json"),
+            format!(r#"{{"scripts": {{ {scripts} }} }}"#),
+        )
+        .unwrap();
+    }
+
+    fn vec_of(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn npm_test_resolves_to_script() {
+        let dir = tempdir().unwrap();
+        write_pkg(dir.path(), r#""test": "vitest --passWithNoTests""#);
+        assert_eq!(
+            resolve_alias(&vec_of(&["npm", "test"]), Some(dir.path())),
+            Some("vitest --passWithNoTests".to_string())
+        );
+    }
+
+    #[test]
+    fn npm_run_named_script_resolves() {
+        let dir = tempdir().unwrap();
+        write_pkg(dir.path(), r#""test:int": "vitest run integration""#);
+        assert_eq!(
+            resolve_alias(&vec_of(&["npm", "run", "test:int"]), Some(dir.path())),
+            Some("vitest run integration".to_string())
+        );
+    }
+
+    #[test]
+    fn missing_script_returns_none() {
+        let dir = tempdir().unwrap();
+        write_pkg(dir.path(), r#""build": "tsc""#);
+        assert_eq!(
+            resolve_alias(&vec_of(&["npm", "test"]), Some(dir.path())),
+            None
+        );
+    }
+
+    #[test]
+    fn missing_cwd_returns_none() {
+        assert_eq!(
+            resolve_alias(&vec_of(&["npm", "test"]), None),
+            None
+        );
+    }
+
+    #[test]
+    fn alias_loop_bounded_to_depth_3() {
+        let dir = tempdir().unwrap();
+        // "test" → "npm run test" → "npm run test" → ... should not infinite-loop
+        write_pkg(dir.path(), r#""test": "npm run test""#);
+        // Depth bound triggers, returns None for the deepest recursion attempt.
+        // The outer call still returns Some(the literal resolved string) because
+        // recursion bottoms out and the outer fallback is the resolved string itself.
+        // We just need to confirm it doesn't hang.
+        let result = resolve_alias(&vec_of(&["npm", "test"]), Some(dir.path()));
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn bun_test_not_treated_as_alias() {
+        let dir = tempdir().unwrap();
+        write_pkg(dir.path(), r#""test": "this should not be returned""#);
+        assert_eq!(
+            resolve_alias(&vec_of(&["bun", "test"]), Some(dir.path())),
+            None
+        );
+    }
+
+    #[test]
+    fn bun_run_resolves_normally() {
+        let dir = tempdir().unwrap();
+        write_pkg(dir.path(), r#""test": "vitest""#);
+        assert_eq!(
+            resolve_alias(&vec_of(&["bun", "run", "test"]), Some(dir.path())),
+            Some("vitest".to_string())
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Run script-resolution tests**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::test_runners::script_resolution`
+Expected: All 7 tests pass.
+
+- [ ] **Step 5: Test for the full match function (failing)**
+
+Add to the bottom of `src-tauri/src/agent/test_runners/matcher.rs`, ABOVE the existing `#[cfg(test)] mod tests`:
+
+```rust
+/// Result of a successful match.
+pub struct MatchedCommand {
+    pub runner: &'static TestRunner,
+    /// Tokens after env-strip + segment-first + wrapper-strip + script
+    /// resolution. Used by build_command_preview for display.
+    pub stripped_tokens: Vec<String>,
+}
+
+/// The full matching pipeline. Returns None when the command does not match
+/// any known runner.
+pub fn match_command(cmd: &str, cwd: Option<&Path>) -> Option<MatchedCommand> {
+    let initial = tokenize(cmd)?;
+    let after_env = strip_env_prefix(&initial).to_vec();
+    let after_segment = first_segment(&after_env).to_vec();
+    let after_wrapper = strip_wrappers(&after_segment).to_vec();
+
+    // Try script alias resolution. If it resolves, recurse on the resolved
+    // string (which goes through the SAME pipeline so its env/wrapper/etc.
+    // are also normalised).
+    if let Some(resolved) = script_resolution::resolve_alias(&after_wrapper, cwd) {
+        return match_command(&resolved, cwd);
+    }
+
+    // Walk RUNNERS. First match wins.
+    let token_refs: Vec<&str> = after_wrapper.iter().map(String::as_str).collect();
+    for runner in RUNNERS {
+        if (runner.matches)(&token_refs) {
+            return Some(MatchedCommand {
+                runner,
+                stripped_tokens: after_wrapper,
+            });
+        }
+    }
+    None
+}
+```
+
+Add tests at the bottom of the existing `#[cfg(test)] mod tests` in `matcher.rs`:
+
+```rust
+#[test]
+fn match_command_finds_vitest() {
+    let m = match_command("vitest run src/foo.test.ts", None).expect("should match");
+    assert_eq!(m.runner.name, "vitest");
+    assert_eq!(m.stripped_tokens, vec_of(&["vitest", "run", "src/foo.test.ts"]));
+}
+
+#[test]
+fn match_command_finds_cargo_test() {
+    let m = match_command("cargo test --release", None).expect("should match");
+    assert_eq!(m.runner.name, "cargo");
+}
+
+#[test]
+fn match_command_strips_env_and_wrapper() {
+    let m = match_command("CI=1 npx vitest", None).expect("should match");
+    assert_eq!(m.runner.name, "vitest");
+    assert_eq!(m.stripped_tokens, vec_of(&["vitest"]));
+}
+
+#[test]
+fn match_command_first_segment_only() {
+    // cargo build && cargo test → only the first segment (cargo build) considered → no match
+    assert!(match_command("cargo build && cargo test", None).is_none());
+}
+
+#[test]
+fn match_command_unknown_returns_none() {
+    assert!(match_command("git diff test.txt", None).is_none());
+    assert!(match_command("eslint test/", None).is_none());
+    assert!(match_command("make test", None).is_none());
+}
+
+#[test]
+fn match_command_resolves_npm_test() {
+    use std::fs;
+    use tempfile::tempdir;
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("package.json"),
+        r#"{"scripts": {"test": "vitest --passWithNoTests"}}"#,
+    )
+    .unwrap();
+    let m = match_command("npm test", Some(dir.path())).expect("should match");
+    assert_eq!(m.runner.name, "vitest");
+}
+
+#[test]
+fn match_command_bun_test_does_not_match_in_v1() {
+    // bun has a built-in test runner; v1 doesn't ship a BUN runner, so this
+    // should NOT match (and definitely not try to resolve a script alias).
+    use std::fs;
+    use tempfile::tempdir;
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("package.json"),
+        r#"{"scripts": {"test": "vitest"}}"#,
+    )
+    .unwrap();
+    assert!(match_command("bun test", Some(dir.path())).is_none());
+}
+```
+
+- [ ] **Step 6: Run all matcher tests**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::test_runners`
+Expected: All matcher + script_resolution + test_file_patterns tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/agent/test_runners/matcher.rs \
+        src-tauri/src/agent/test_runners/script_resolution.rs \
+        src-tauri/src/agent/test_runners/mod.rs
+git commit -m "feat(agent): command matching pipeline for test runner detection
+
+Implements tokenize → strip env → first-segment → strip wrappers
+→ script-alias resolution (depth-3 bounded) → match against RUNNERS.
+Script aliases are resolved for npm/yarn/pnpm test and npm/yarn/pnpm/bun
+run <name>; \`bun test\` deliberately doesn't match (Bun's built-in
+runner is future work)."
+```
+
+---
+
+## Task 5: Vitest result parser + first end-to-end fixture
+
+Implement `vitest_parse_result` and integrate the matcher + parser into `process_assistant_message`/`process_tool_result`. First test-run event flows end-to-end.
+
+**Files:**
+
+- Modify: `src-tauri/src/agent/test_runners/vitest.rs` (real `parse_result`)
+- Create: `src-tauri/src/agent/test_runners/timestamps.rs`
+- Create: `src-tauri/src/agent/test_runners/path_resolution.rs`
+- Create: `src-tauri/src/agent/test_runners/sanitiser.rs`
+- Create: `src-tauri/src/agent/test_runners/preview.rs`
+- Modify: `src-tauri/src/agent/transcript.rs` (extend `InFlightToolCall`; build snapshot in `process_tool_result`)
+- Create: `src-tauri/src/agent/test_runners/build.rs` — snapshot builder (orchestrates duration, status derivation, output_excerpt)
+- Modify: `src-tauri/src/agent/test_runners/mod.rs` (export new modules)
+- Create: `src-tauri/tests/fixtures/transcript_vitest_pass.jsonl`
+- Modify: `src-tauri/src/agent/test_runners/mod.rs`
+
+- [ ] **Step 1: Test for `sanitize_for_ui` (failing)**
+
+Create `src-tauri/src/agent/test_runners/sanitiser.rs`:
+
+```rust
+//! Conservative redaction for content shown in the UI. Catches the common
+//! shapes; not a comprehensive secret scanner. Applied to BOTH command_preview
+//! and output_excerpt.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+const REDACTED: &str = "[REDACTED]";
+
+static PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        // KEY=value where KEY is uppercase identifier (env-style)
+        Regex::new(r"\b[A-Z][A-Z0-9_]{2,}=\S+").unwrap(),
+        // Bearer tokens (case-insensitive)
+        Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._\-]+").unwrap(),
+        // Authorization headers (case-insensitive)
+        Regex::new(r"(?i)\bAuthorization:\s*\S+").unwrap(),
+        // Stripe/etc-style API keys: (sk|pk|rk)_(live|test)_<alnum16+>
+        Regex::new(r"\b(sk|pk|rk)_(live|test)_[A-Za-z0-9]{16,}").unwrap(),
+        // JWT-like: eyJ followed by base64-ish chunk
+        Regex::new(r"\beyJ[A-Za-z0-9._\-]{10,}").unwrap(),
+    ]
+});
+
+pub fn sanitize_for_ui(input: &str) -> String {
+    let mut out = input.to_string();
+    for re in PATTERNS.iter() {
+        out = re.replace_all(&out, REDACTED).to_string();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_env_assignments() {
+        let s = sanitize_for_ui("STRIPE_KEY=sk_live_abc123 vitest");
+        assert!(!s.contains("sk_live_abc123"));
+        assert!(s.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redacts_bearer_tokens() {
+        let s = sanitize_for_ui("curl -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.foo'");
+        assert!(!s.contains("eyJhbGciOiJIUzI1NiJ9.foo"));
+    }
+
+    #[test]
+    fn redacts_api_key_prefixes() {
+        let s = sanitize_for_ui("--key sk_live_1234567890abcdef1234");
+        assert!(!s.contains("sk_live_1234567890abcdef1234"));
+    }
+
+    #[test]
+    fn redacts_jwt_like() {
+        let s = sanitize_for_ui("token: eyJabcdefghijklmnop.body.sig");
+        assert!(!s.contains("eyJabcdefghijklmnop"));
+    }
+
+    #[test]
+    fn clean_strings_unchanged() {
+        let s = sanitize_for_ui("vitest run src/foo.test.ts");
+        assert_eq!(s, "vitest run src/foo.test.ts");
+    }
+
+    #[test]
+    fn does_not_redact_short_uppercase_words() {
+        // "OK" / "FAIL" without "=" must be untouched
+        let s = sanitize_for_ui("FAIL src/foo.test.ts");
+        assert_eq!(s, "FAIL src/foo.test.ts");
+    }
+}
+```
+
+- [ ] **Step 2: Test for `build_command_preview` (failing)**
+
+Create `src-tauri/src/agent/test_runners/preview.rs`:
+
+```rust
+use super::sanitiser::sanitize_for_ui;
+
+const MAX_PREVIEW_LEN: usize = 120;
+
+pub fn build_command_preview(stripped_tokens: &[String]) -> String {
+    let joined = stripped_tokens.join(" ");
+    let sanitized = sanitize_for_ui(&joined);
+    truncate(&sanitized, MAX_PREVIEW_LEN)
+}
+
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else {
+        let end = s
+            .char_indices()
+            .nth(max_len.saturating_sub(3))
+            .map_or(s.len(), |(i, _)| i);
+        format!("{}...", &s[..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vec_of(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn joins_tokens() {
+        assert_eq!(
+            build_command_preview(&vec_of(&["vitest", "run", "src/foo.test.ts"])),
+            "vitest run src/foo.test.ts"
+        );
+    }
+
+    #[test]
+    fn applies_sanitiser() {
+        let p = build_command_preview(&vec_of(&["vitest", "--key", "sk_live_1234567890abcdef1234"]));
+        assert!(!p.contains("sk_live_1234567890abcdef1234"));
+        assert!(p.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn truncates_long_input() {
+        let long = "a".repeat(200);
+        let preview = build_command_preview(&vec_of(&[&long]));
+        assert!(preview.chars().count() <= 120);
+        assert!(preview.ends_with("..."));
+    }
+}
+```
+
+- [ ] **Step 3: Test for `parse_iso8601_ms` and `compute_duration_ms` (failing)**
+
+Create `src-tauri/src/agent/test_runners/timestamps.rs`:
+
+```rust
+use std::time::Duration;
+
+use chrono::DateTime;
+
+/// Parse an ISO 8601 string (with or without fractional seconds) to
+/// milliseconds since the Unix epoch. Returns None on parse failure.
+pub fn parse_iso8601_ms(s: &str) -> Option<u64> {
+    let dt = DateTime::parse_from_rfc3339(s).ok()?;
+    let ms = dt.timestamp_millis();
+    if ms < 0 {
+        return None;
+    }
+    Some(ms as u64)
+}
+
+/// Compute the duration between two ISO 8601 timestamps. Falls back to the
+/// provided `fallback` duration if either timestamp can't be parsed or the
+/// computed range is negative.
+pub fn compute_duration_ms(started_at: &str, finished_at: &str, fallback: Duration) -> u64 {
+    match (parse_iso8601_ms(started_at), parse_iso8601_ms(finished_at)) {
+        (Some(start), Some(end)) if end >= start => end - start,
+        _ => {
+            log::debug!("Falling back to Instant::elapsed for test-run duration");
+            fallback.as_millis() as u64
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_iso8601_no_fraction() {
+        assert_eq!(parse_iso8601_ms("2026-04-28T12:00:00Z"), Some(1777377600000));
+    }
+
+    #[test]
+    fn parses_iso8601_with_fraction() {
+        assert_eq!(
+            parse_iso8601_ms("2026-04-28T12:00:00.500Z"),
+            Some(1777377600500)
+        );
+    }
+
+    #[test]
+    fn returns_none_on_garbage() {
+        assert_eq!(parse_iso8601_ms("not-a-date"), None);
+        assert_eq!(parse_iso8601_ms(""), None);
+    }
+
+    #[test]
+    fn duration_uses_timestamps_when_valid() {
+        assert_eq!(
+            compute_duration_ms(
+                "2026-04-28T12:00:00Z",
+                "2026-04-28T12:00:01.500Z",
+                Duration::from_millis(0),
+            ),
+            1500
+        );
+    }
+
+    #[test]
+    fn duration_falls_back_when_end_before_start() {
+        assert_eq!(
+            compute_duration_ms(
+                "2026-04-28T12:00:01Z",
+                "2026-04-28T12:00:00Z",
+                Duration::from_millis(42),
+            ),
+            42
+        );
+    }
+
+    #[test]
+    fn duration_falls_back_when_unparseable() {
+        assert_eq!(
+            compute_duration_ms("garbage", "garbage", Duration::from_millis(7)),
+            7
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Test for `resolve_group_path` containment (failing)**
+
+Create `src-tauri/src/agent/test_runners/path_resolution.rs`:
+
+```rust
+//! Resolve a runner-emitted relative label to an absolute, contained path.
+
+use std::path::Path;
+
+/// Returns Some(absolute_path_string) when:
+///   - label has no `..` segments
+///   - label is not absolute
+///   - the canonical resolved path is inside the canonical CWD
+/// Returns None otherwise — the row will render non-clickable.
+pub fn resolve_group_path(cwd: &Path, label: &str) -> Option<String> {
+    if label.contains("..") || Path::new(label).is_absolute() {
+        return None;
+    }
+    let candidate = cwd.join(label).canonicalize().ok()?;
+    let cwd_canonical = cwd.canonicalize().ok()?;
+    if !candidate.starts_with(&cwd_canonical) {
+        return None;
+    }
+    Some(candidate.display().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn rejects_dotdot_escape() {
+        let dir = tempdir().unwrap();
+        assert_eq!(resolve_group_path(dir.path(), "../etc/passwd"), None);
+    }
+
+    #[test]
+    fn rejects_absolute_label() {
+        let dir = tempdir().unwrap();
+        assert_eq!(resolve_group_path(dir.path(), "/etc/passwd"), None);
+    }
+
+    #[test]
+    fn resolves_valid_relative_path() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("foo.test.ts");
+        fs::write(&file, "").unwrap();
+        let resolved = resolve_group_path(dir.path(), "foo.test.ts");
+        assert!(resolved.is_some());
+        assert!(resolved.unwrap().contains("foo.test.ts"));
+    }
+
+    #[test]
+    fn returns_none_for_missing_file() {
+        let dir = tempdir().unwrap();
+        // canonicalize fails for non-existent paths
+        assert_eq!(resolve_group_path(dir.path(), "missing.test.ts"), None);
+    }
+
+    #[test]
+    fn rejects_symlink_pointing_outside_cwd() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            let outer = tempdir().unwrap();
+            let inner = tempdir().unwrap();
+            let target = outer.path().join("secret.test.ts");
+            fs::write(&target, "").unwrap();
+            symlink(&target, inner.path().join("link.test.ts")).unwrap();
+            // The symlink resolves outside the inner CWD → reject.
+            assert_eq!(resolve_group_path(inner.path(), "link.test.ts"), None);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Wire all four new modules into mod.rs**
+
+Edit `src-tauri/src/agent/test_runners/mod.rs`:
+
+```rust
+pub mod cargo;
+pub mod matcher;
+pub mod path_resolution;
+pub mod preview;
+pub mod sanitiser;
+pub mod script_resolution;
+pub mod test_file_patterns;
+pub mod timestamps;
+pub mod types;
+pub mod vitest;
+
+use types::TestRunner;
+
+pub static RUNNERS: &[&TestRunner] = &[&vitest::VITEST, &cargo::CARGO_TEST];
+```
+
+- [ ] **Step 6: Run all the small-helper tests**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::test_runners`
+Expected: All sanitiser, preview, timestamps, path_resolution tests pass.
+
+- [ ] **Step 7: Test for `vitest_parse_result` (failing)**
+
+Replace `src-tauri/src/agent/test_runners/vitest.rs`:
+
+```rust
+//! Vitest result parser. Targets vitest 1.x summary format.
+//!
+//! Canonical summary lines (after ANSI strip):
+//!   Test Files  3 passed (3)
+//!        Tests  47 passed | 2 failed | 1 skipped (50)
+//! Per-file lines (within run output):
+//!   ✓ src/foo.test.ts (12)
+//!   ✗ src/bar.test.ts (8 | 3 failed)
+
+use std::path::Path;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use super::path_resolution::resolve_group_path;
+use super::types::{
+    CapturedOutput, TestGroup, TestGroupKind, TestGroupStatus, TestRunSummary, TestRunner,
+};
+
+pub static VITEST: TestRunner = TestRunner {
+    name: "vitest",
+    matches: vitest_matches,
+    parse_result: vitest_parse_result,
+};
+
+const MAX_GROUPS: usize = 500;
+
+fn vitest_matches(tokens: &[&str]) -> bool {
+    matches!(tokens.first(), Some(&"vitest"))
+}
+
+static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
+
+// Capture passed/failed/skipped counts from the "Tests" summary line.
+// Examples:
+//   Tests  47 passed (47)
+//   Tests  47 passed | 2 failed (49)
+//   Tests  47 passed | 2 failed | 1 skipped (50)
+//   Tests  no tests
+static TESTS_LINE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?m)^\s*Tests\s+(?:(\d+)\s+passed)?(?:.*?(\d+)\s+failed)?(?:.*?(\d+)\s+skipped)?",
+    )
+    .unwrap()
+});
+
+// File rows: "✓ src/foo.test.ts (12)" or "✗ src/bar.test.ts (8 | 3 failed)"
+static FILE_ROW_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?m)^\s*([✓✗⊘])\s+(\S+\.[A-Za-z]+)\s*\((\d+)(?:\s*\|\s*(\d+)\s+failed)?\)")
+        .unwrap()
+});
+
+fn vitest_parse_result(out: &CapturedOutput, cwd: &Path) -> Option<TestRunSummary> {
+    let stripped = ANSI_RE.replace_all(&out.content, "").to_string();
+
+    // Pull summary counts from the Tests line.
+    let caps = TESTS_LINE_RE.captures(&stripped)?;
+    let passed = caps.get(1).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    let failed = caps.get(2).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    let skipped = caps.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    let total = passed + failed + skipped;
+
+    // Pull per-file groups.
+    let mut groups: Vec<TestGroup> = Vec::new();
+    for cap in FILE_ROW_RE.captures_iter(&stripped) {
+        if groups.len() >= MAX_GROUPS {
+            break;
+        }
+        let icon = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let label = cap.get(2).map(|m| m.as_str().to_string()).unwrap_or_default();
+        let file_total: u32 = cap
+            .get(3)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0);
+        let file_failed: u32 = cap
+            .get(4)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0);
+        let file_passed = file_total.saturating_sub(file_failed);
+        let status = match icon {
+            "✓" => TestGroupStatus::Pass,
+            "✗" => TestGroupStatus::Fail,
+            "⊘" => TestGroupStatus::Skip,
+            _ => TestGroupStatus::Pass,
+        };
+        let path = resolve_group_path(cwd, &label);
+        groups.push(TestGroup {
+            label,
+            path,
+            kind: TestGroupKind::File,
+            passed: file_passed,
+            failed: file_failed,
+            skipped: 0,
+            total: file_total,
+            status,
+        });
+    }
+
+    Some(TestRunSummary {
+        passed,
+        failed,
+        skipped,
+        total,
+        groups,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn captured(content: &str) -> CapturedOutput {
+        CapturedOutput { content: content.to_string(), is_error: false }
+    }
+
+    #[test]
+    fn parses_simple_pass_summary() {
+        let out = captured(
+            "Test Files  1 passed (1)\n     Tests  3 passed (3)\n",
+        );
+        let s = vitest_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.passed, 3);
+        assert_eq!(s.failed, 0);
+        assert_eq!(s.skipped, 0);
+        assert_eq!(s.total, 3);
+    }
+
+    #[test]
+    fn parses_mixed_pass_fail_skip() {
+        let out = captured(
+            "Test Files  2 passed | 1 failed (3)\n     Tests  47 passed | 2 failed | 1 skipped (50)\n",
+        );
+        let s = vitest_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.passed, 47);
+        assert_eq!(s.failed, 2);
+        assert_eq!(s.skipped, 1);
+        assert_eq!(s.total, 50);
+    }
+
+    #[test]
+    fn parses_per_file_rows() {
+        let dir = tempdir().unwrap();
+        let foo = dir.path().join("foo.test.ts");
+        fs::write(&foo, "").unwrap();
+        let out_str = format!(
+            "✓ foo.test.ts (12)\n✗ missing.test.ts (8 | 3 failed)\n     Tests  17 passed | 3 failed (20)\n"
+        );
+        let out = captured(&out_str);
+        let s = vitest_parse_result(&out, dir.path()).unwrap();
+        assert_eq!(s.groups.len(), 2);
+        assert_eq!(s.groups[0].label, "foo.test.ts");
+        assert!(s.groups[0].path.is_some());
+        assert_eq!(s.groups[0].passed, 12);
+        assert_eq!(s.groups[0].failed, 0);
+        assert_eq!(s.groups[1].label, "missing.test.ts");
+        assert!(s.groups[1].path.is_none()); // file doesn't exist → no path
+        assert_eq!(s.groups[1].passed, 5);
+        assert_eq!(s.groups[1].failed, 3);
+    }
+
+    #[test]
+    fn strips_ansi_before_parsing() {
+        let out = captured(
+            "\x1b[32m✓\x1b[0m foo.test.ts (12)\n     Tests  12 passed (12)\n",
+        );
+        let s = vitest_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.total, 12);
+        assert_eq!(s.groups.len(), 1);
+    }
+
+    #[test]
+    fn returns_none_when_no_tests_line() {
+        let out = captured("error: command not found");
+        assert!(vitest_parse_result(&out, &PathBuf::from("/tmp")).is_none());
+    }
+}
+```
+
+- [ ] **Step 8: Run vitest parser tests**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::test_runners::vitest`
+Expected: All 5 tests pass.
+
+- [ ] **Step 9: Create snapshot builder module**
+
+Create `src-tauri/src/agent/test_runners/build.rs`:
+
+```rust
+//! Builds a TestRunSnapshot from a matched test-run tool_use + tool_result.
+
+use std::path::Path;
+use std::time::Duration;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use super::matcher::MatchedCommand;
+use super::preview::build_command_preview;
+use super::sanitiser::sanitize_for_ui;
+use super::timestamps::compute_duration_ms;
+use super::types::{
+    CapturedOutput, TestRunSnapshot, TestRunStatus, TestRunSummary,
+};
+
+const MAX_EXCERPT_LEN: usize = 240;
+
+static ERROR_HINT_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)(error:|fail|panicked)").unwrap());
+static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
+
+pub struct BuildArgs<'a> {
+    pub session_id: &'a str,
+    pub matched: &'a MatchedCommand,
+    pub started_at: &'a str,
+    pub finished_at: &'a str,
+    pub instant_fallback: Duration,
+    pub captured: CapturedOutput,
+    pub cwd: &'a Path,
+}
+
+pub fn build_snapshot(args: BuildArgs<'_>) -> TestRunSnapshot {
+    let summary = (args.matched.runner.parse_result)(&args.captured, args.cwd);
+    let status = derive_status(summary.as_ref(), args.captured.is_error);
+    let summary = summary.unwrap_or_default();
+
+    let output_excerpt = if matches!(status, TestRunStatus::Error) {
+        Some(extract_excerpt(&args.captured.content))
+    } else {
+        None
+    };
+
+    TestRunSnapshot {
+        session_id: args.session_id.to_string(),
+        runner: args.matched.runner.name.to_string(),
+        command_preview: build_command_preview(&args.matched.stripped_tokens),
+        started_at: args.started_at.to_string(),
+        finished_at: args.finished_at.to_string(),
+        duration_ms: compute_duration_ms(
+            args.started_at,
+            args.finished_at,
+            args.instant_fallback,
+        ),
+        status,
+        summary,
+        output_excerpt,
+    }
+}
+
+/// Returns Some(snapshot) when an event should be emitted; None when we
+/// don't know what happened (parser returned None AND not an error result).
+pub fn maybe_build_snapshot(args: BuildArgs<'_>) -> Option<TestRunSnapshot> {
+    let summary = (args.matched.runner.parse_result)(&args.captured, args.cwd);
+    if summary.is_none() && !args.captured.is_error {
+        log::debug!(
+            "Test runner '{}' produced unparseable output, skipping emit",
+            args.matched.runner.name
+        );
+        return None;
+    }
+    Some(build_snapshot(args))
+}
+
+fn derive_status(summary: Option<&TestRunSummary>, is_error: bool) -> TestRunStatus {
+    match summary {
+        Some(s) if s.failed > 0 => TestRunStatus::Fail,
+        Some(s) if s.total == 0 => TestRunStatus::NoTests,
+        Some(_) => TestRunStatus::Pass,
+        None if is_error => TestRunStatus::Error,
+        None => TestRunStatus::Error, // maybe_build_snapshot already filtered the unknown case
+    }
+}
+
+fn extract_excerpt(content: &str) -> String {
+    let stripped = ANSI_RE.replace_all(content, "");
+    // Prefer the first line containing an error hint; else first non-blank line.
+    let preferred = stripped
+        .lines()
+        .find(|l| ERROR_HINT_RE.is_match(l) && !l.trim().is_empty());
+    let chosen = preferred.unwrap_or_else(|| {
+        stripped.lines().find(|l| !l.trim().is_empty()).unwrap_or("")
+    });
+    let truncated: String = chosen.chars().take(MAX_EXCERPT_LEN).collect();
+    sanitize_for_ui(&truncated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn excerpt_prefers_error_hint() {
+        let s = extract_excerpt(
+            "  some preamble\n  error: type mismatch in foo.test.ts\n  more output",
+        );
+        assert!(s.contains("error: type mismatch"));
+    }
+
+    #[test]
+    fn excerpt_falls_back_to_first_non_blank() {
+        let s = extract_excerpt("\n   \nfirst real line\nsecond line");
+        assert!(s.contains("first real line"));
+    }
+
+    #[test]
+    fn excerpt_caps_length() {
+        let long = "x".repeat(500);
+        let body = format!("error: {}", long);
+        let s = extract_excerpt(&body);
+        assert!(s.chars().count() <= MAX_EXCERPT_LEN);
+    }
+
+    #[test]
+    fn excerpt_runs_through_sanitiser() {
+        let s = extract_excerpt("error: bearer eyJabcdefghijklmnop.body.sig was rejected");
+        assert!(s.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn derive_status_picks_fail_over_total() {
+        let s = TestRunSummary { passed: 5, failed: 1, skipped: 0, total: 6, groups: vec![] };
+        assert_eq!(derive_status(Some(&s), false), TestRunStatus::Fail);
+    }
+
+    #[test]
+    fn derive_status_picks_no_tests() {
+        let s = TestRunSummary::default();
+        assert_eq!(derive_status(Some(&s), false), TestRunStatus::NoTests);
+    }
+
+    #[test]
+    fn derive_status_picks_pass() {
+        let s = TestRunSummary { passed: 3, failed: 0, skipped: 0, total: 3, groups: vec![] };
+        assert_eq!(derive_status(Some(&s), false), TestRunStatus::Pass);
+    }
+
+    #[test]
+    fn derive_status_picks_error_when_unparseable_and_is_error() {
+        assert_eq!(derive_status(None, true), TestRunStatus::Error);
+    }
+}
+```
+
+- [ ] **Step 10: Wire `build` into mod.rs**
+
+Edit `src-tauri/src/agent/test_runners/mod.rs`:
+
+```rust
+pub mod build;
+pub mod cargo;
+pub mod matcher;
+pub mod path_resolution;
+pub mod preview;
+pub mod sanitiser;
+pub mod script_resolution;
+pub mod test_file_patterns;
+pub mod timestamps;
+pub mod types;
+pub mod vitest;
+
+use types::TestRunner;
+
+pub static RUNNERS: &[&TestRunner] = &[&vitest::VITEST, &cargo::CARGO_TEST];
+```
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::test_runners::build`
+Expected: All 8 tests pass.
+
+- [ ] **Step 11: Extend `InFlightToolCall` and emit `test-run` event from transcript parser**
+
+Edit `src-tauri/src/agent/transcript.rs`. Find `InFlightToolCall` and update it (this builds on the change in Task 3):
+
+```rust
+use crate::agent::test_runners::matcher::{match_command, MatchedCommand};
+
+struct InFlightToolCall {
+    started_at: Instant,
+    started_at_iso: String,
+    tool: String,
+    args: String,
+    is_test_file: bool,
+    test_match: Option<MatchedCommand>,
+}
+```
+
+Note: `MatchedCommand` doesn't derive `Clone` but that's fine — we own the value via the `HashMap` and move it into the snapshot builder when the result arrives.
+
+In `process_assistant_message`, before the in-flight insert, run the matcher when the tool is `Bash`:
+
+```rust
+// After computing `is_test_file`...
+let test_match = if name == "Bash" {
+    item.get("input")
+        .and_then(|v| v.get("command"))
+        .and_then(|v| v.as_str())
+        .and_then(|cmd| match_command(cmd, cwd.as_deref()))
+} else {
+    None
+};
+```
+
+The `cwd: Option<PathBuf>` parameter has to flow into `process_assistant_message`. Update its signature to take `cwd: Option<&Path>` and update the call sites in `process_line` and the recursive `process_user_message`. Also update `process_line` and `tail_loop` to pass `_cwd.as_deref()` through.
+
+Concretely, the signature changes:
+
+```rust
+fn process_line(
+    line: &str,
+    session_id: &str,
+    cwd: Option<&Path>,
+    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    in_flight: &mut InFlightToolCalls,
+) { ... }
+
+fn process_assistant_message(
+    value: &Value,
+    session_id: &str,
+    cwd: Option<&Path>,
+    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    in_flight: &mut InFlightToolCalls,
+) { ... }
+
+fn process_user_message(
+    value: &Value,
+    session_id: &str,
+    cwd: Option<&Path>,
+    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    in_flight: &mut InFlightToolCalls,
+) { ... }
+
+fn process_tool_result(
+    value: &Value,
+    session_id: &str,
+    cwd: Option<&Path>,
+    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    in_flight: &mut InFlightToolCalls,
+    timestamp: &str,
+) { ... }
+```
+
+Inside `tail_loop`, change `process_line(line, &session_id, &app_handle, &mut in_flight)` to `process_line(line, &session_id, _cwd.as_deref(), &app_handle, &mut in_flight)` and rename `_cwd` to `cwd` (it's now used).
+
+In the in-flight insert:
+
+```rust
+in_flight.insert(
+    id.clone(),
+    InFlightToolCall {
+        started_at: now,
+        started_at_iso: timestamp.clone(),
+        tool: name.clone(),
+        args: args.clone(),
+        is_test_file,
+        test_match,
+    },
+);
+```
+
+In `process_tool_result`, after `let Some(call) = in_flight.remove(...)`, build and emit the test-run snapshot when `call.test_match.is_some()`:
+
+```rust
+let duration_ms = call.started_at.elapsed().as_millis() as u64;
+let tool_name = call.tool;
+let args = call.args;
+let is_test_file = call.is_test_file;
+
+if let Some(matched) = call.test_match {
+    // Pull the captured Bash output content.
+    let content = extract_tool_result_content(value);
+    let captured = crate::agent::test_runners::types::CapturedOutput {
+        content,
+        is_error,
+    };
+    let cwd_ref = cwd.unwrap_or_else(|| Path::new("."));
+    let snapshot = crate::agent::test_runners::build::maybe_build_snapshot(
+        crate::agent::test_runners::build::BuildArgs {
+            session_id,
+            matched: &matched,
+            started_at: &call.started_at_iso,
+            finished_at: timestamp,
+            instant_fallback: call.started_at.elapsed(),
+            captured,
+            cwd: cwd_ref,
+        },
+    );
+    if let Some(snap) = snapshot {
+        // For now (Task 5), emit immediately. Task 6 introduces the
+        // TestRunEmitter for replay batching — this direct emit will be
+        // refactored to call emitter.submit().
+        if let Err(e) = app_handle.emit("test-run", &snap) {
+            log::warn!("Failed to emit test-run event: {}", e);
+        }
+    }
+}
+
+// ...existing AgentToolCallEvent build + emit
+```
+
+Add the helper at the bottom of `transcript.rs` (above the test module):
+
+```rust
+fn extract_tool_result_content(value: &Value) -> String {
+    let raw = match value.get("content") {
+        Some(c) => c,
+        None => return String::new(),
+    };
+    if let Some(s) = raw.as_str() {
+        return s.to_string();
+    }
+    if let Some(arr) = raw.as_array() {
+        let mut out = String::new();
+        for block in arr {
+            if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+                if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                    out.push_str(text);
+                    out.push('\n');
+                }
+            }
+        }
+        return out;
+    }
+    String::new()
+}
+```
+
+- [ ] **Step 12: Update existing test fixtures in transcript.rs**
+
+In `src-tauri/src/agent/transcript.rs`, the existing test helpers around line 824–830 build `InFlightToolCall` instances. Add the new fields:
+
+```rust
+InFlightToolCall {
+    started_at: Instant::now(),
+    started_at_iso: "2026-04-28T12:00:00Z".to_string(),
+    tool: "Read".to_string(),
+    args: "src/foo.rs".to_string(),
+    is_test_file: false,
+    test_match: None,
+}
+```
+
+(Replace tool/args with whatever the existing fixtures use; just add the new fields.)
+
+- [ ] **Step 13: Build everything**
+
+Run: `cargo build --manifest-path src-tauri/Cargo.toml`
+Expected: Builds clean.
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent`
+Expected: All existing + new tests pass.
+
+- [ ] **Step 14: Add a fixture-based integration test**
+
+Create `src-tauri/tests/fixtures/transcript_vitest_pass.jsonl` (this is the canonical shape Claude Code's transcript produces):
+
+```jsonl
+{"type":"assistant","timestamp":"2026-04-28T12:00:00.000Z","message":{"content":[{"type":"tool_use","id":"toolu_v_1","name":"Bash","input":{"command":"vitest run","description":"Run tests"}}]}}
+{"type":"user","timestamp":"2026-04-28T12:00:01.500Z","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_v_1","is_error":false,"content":"\nTest Files  1 passed (1)\n     Tests  3 passed (3)\n"}]}}
+```
+
+Create `src-tauri/tests/transcript_vitest_e2e.rs`:
+
+```rust
+//! End-to-end test: feed a fixture transcript through the parser
+//! and assert exactly one test-run event is emitted with the expected
+//! summary counts.
+
+use std::sync::{Arc, Mutex};
+
+use vimeflow_lib::agent::transcript::TranscriptState;
+
+#[test]
+fn vitest_pass_fixture_emits_one_test_run() {
+    use tauri::test::{mock_builder, MockRuntime};
+    use tauri::Listener;
+
+    let app = mock_builder().build(tauri::generate_context!()).unwrap();
+    let app_handle = app.handle().clone();
+
+    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    app_handle.listen("test-run", move |event| {
+        recv_clone.lock().unwrap().push(event.payload().to_string());
+    });
+
+    let state = TranscriptState::new();
+    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/transcript_vitest_pass.jsonl");
+
+    state
+        .start_or_replace(
+            app_handle,
+            "session-fixture".to_string(),
+            fixture_path,
+            None,
+        )
+        .expect("start watcher");
+
+    // Wait briefly for the tail loop to process the file.
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+    state.stop("session-fixture").ok();
+
+    let events = received.lock().unwrap();
+    assert_eq!(events.len(), 1, "expected exactly one test-run event");
+    let payload = &events[0];
+    assert!(payload.contains(r#""runner":"vitest""#));
+    assert!(payload.contains(r#""passed":3"#));
+    assert!(payload.contains(r#""total":3"#));
+    assert!(payload.contains(r#""status":"pass""#));
+}
+```
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --test transcript_vitest_e2e`
+Expected: Test passes — one event received with `runner: vitest`, `passed: 3`, `total: 3`, `status: pass`.
+
+Note: the `start_or_replace` call uses `cwd: None`, so per-file path resolution returns `None` for any file groups. That's fine for this fixture — we're verifying summary counts, not group paths.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add src-tauri/src/agent/test_runners/ \
+        src-tauri/src/agent/transcript.rs \
+        src-tauri/tests/fixtures/transcript_vitest_pass.jsonl \
+        src-tauri/tests/transcript_vitest_e2e.rs
+git commit -m "feat(agent): vitest result parser + first end-to-end test-run emit
+
+Implements vitest_parse_result targeting vitest 1.x summary format
+(supports pass/fail/skip and per-file rows). Adds the snapshot builder
+(timestamps duration, status derivation, sanitised output_excerpt
+for errors). Wires matcher + builder into transcript.rs so a Bash
+tool call running vitest emits a test-run Tauri event with
+TestRunSnapshot. End-to-end fixture test covers the happy path."
+```
+
+---
+
+## Task 6: TestRunEmitter + replay batching
+
+Replace the direct emit in `process_tool_result` with `TestRunEmitter::submit`. Defer the first EOF check inside `tail_loop` to call `emitter.finish_replay()`. Verify with a fixture transcript containing multiple historical runs.
+
+**Files:**
+
+- Create: `src-tauri/src/agent/test_runners/emitter.rs`
+- Modify: `src-tauri/src/agent/transcript.rs` (use emitter; flip on EOF)
+- Create: `src-tauri/tests/fixtures/transcript_vitest_replay.jsonl`
+- Create: `src-tauri/tests/transcript_vitest_replay.rs`
+
+- [ ] **Step 1: Test for TestRunEmitter (failing)**
+
+Create `src-tauri/src/agent/test_runners/emitter.rs`:
+
+```rust
+//! Replay-aware emitter for test-run events. During the initial replay phase
+//! of a tail_loop, `submit` keeps only the latest snapshot — when the loop
+//! hits EOF for the first time and calls `finish_replay`, the latest pending
+//! snapshot (if any) is emitted exactly once. After replay, every submit
+//! emits immediately.
+
+use tauri::{AppHandle, Emitter, Runtime};
+
+use super::types::TestRunSnapshot;
+
+pub struct TestRunEmitter<R: Runtime> {
+    app_handle: AppHandle<R>,
+    replay_done: bool,
+    pending: Option<TestRunSnapshot>,
+}
+
+impl<R: Runtime> TestRunEmitter<R> {
+    pub fn new(app_handle: AppHandle<R>) -> Self {
+        Self { app_handle, replay_done: false, pending: None }
+    }
+
+    pub fn submit(&mut self, snapshot: TestRunSnapshot) {
+        if self.replay_done {
+            if let Err(e) = self.app_handle.emit("test-run", &snapshot) {
+                log::warn!("Failed to emit test-run event: {}", e);
+            }
+        } else {
+            self.pending = Some(snapshot);
+        }
+    }
+
+    pub fn finish_replay(&mut self) {
+        if self.replay_done {
+            return;
+        }
+        self.replay_done = true;
+        if let Some(s) = self.pending.take() {
+            if let Err(e) = self.app_handle.emit("test-run", &s) {
+                log::warn!("Failed to emit test-run event: {}", e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::test_runners::types::{TestRunStatus, TestRunSummary};
+    use std::sync::{Arc, Mutex};
+    use tauri::test::{mock_builder, MockRuntime};
+    use tauri::Listener;
+
+    fn snap(passed: u32) -> TestRunSnapshot {
+        TestRunSnapshot {
+            session_id: "s".to_string(),
+            runner: "vitest".to_string(),
+            command_preview: "vitest".to_string(),
+            started_at: "2026-04-28T12:00:00Z".to_string(),
+            finished_at: "2026-04-28T12:00:01Z".to_string(),
+            duration_ms: 1000,
+            status: TestRunStatus::Pass,
+            summary: TestRunSummary { passed, failed: 0, skipped: 0, total: passed, groups: vec![] },
+            output_excerpt: None,
+        }
+    }
+
+    fn collect_emits(app: &tauri::App<MockRuntime>) -> Arc<Mutex<Vec<String>>> {
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let clone = received.clone();
+        app.handle().listen("test-run", move |event| {
+            clone.lock().unwrap().push(event.payload().to_string());
+        });
+        received
+    }
+
+    #[test]
+    fn submit_during_replay_buffers_latest() {
+        let app = mock_builder().build(tauri::generate_context!()).unwrap();
+        let emits = collect_emits(&app);
+        let mut e = TestRunEmitter::new(app.handle().clone());
+        e.submit(snap(1));
+        e.submit(snap(2));
+        e.submit(snap(3));
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert!(emits.lock().unwrap().is_empty());
+        e.finish_replay();
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let v = emits.lock().unwrap();
+        assert_eq!(v.len(), 1);
+        assert!(v[0].contains(r#""passed":3"#));
+    }
+
+    #[test]
+    fn submit_after_replay_emits_immediately() {
+        let app = mock_builder().build(tauri::generate_context!()).unwrap();
+        let emits = collect_emits(&app);
+        let mut e = TestRunEmitter::new(app.handle().clone());
+        e.finish_replay();
+        e.submit(snap(7));
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert_eq!(emits.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn finish_replay_is_idempotent() {
+        let app = mock_builder().build(tauri::generate_context!()).unwrap();
+        let emits = collect_emits(&app);
+        let mut e = TestRunEmitter::new(app.handle().clone());
+        e.submit(snap(1));
+        e.finish_replay();
+        e.finish_replay();   // second call must not re-emit
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert_eq!(emits.lock().unwrap().len(), 1);
+    }
+}
+```
+
+- [ ] **Step 2: Wire emitter into mod.rs**
+
+Edit `src-tauri/src/agent/test_runners/mod.rs`:
+
+```rust
+pub mod build;
+pub mod cargo;
+pub mod emitter;
+pub mod matcher;
+pub mod path_resolution;
+pub mod preview;
+pub mod sanitiser;
+pub mod script_resolution;
+pub mod test_file_patterns;
+pub mod timestamps;
+pub mod types;
+pub mod vitest;
+
+use types::TestRunner;
+
+pub static RUNNERS: &[&TestRunner] = &[&vitest::VITEST, &cargo::CARGO_TEST];
+```
+
+- [ ] **Step 3: Run emitter tests**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::test_runners::emitter`
+Expected: All 3 tests pass.
+
+- [ ] **Step 4: Replace direct emit in `process_tool_result` with emitter.submit**
+
+Edit `src-tauri/src/agent/transcript.rs`. Add the `emitter` parameter through the call chain. The signature changes:
+
+```rust
+use crate::agent::test_runners::emitter::TestRunEmitter;
+
+fn process_line<R: tauri::Runtime>(
+    line: &str,
+    session_id: &str,
+    cwd: Option<&Path>,
+    app_handle: &tauri::AppHandle<R>,
+    emitter: &mut TestRunEmitter<R>,
+    in_flight: &mut InFlightToolCalls,
+) { ... }
+
+fn process_assistant_message<R: tauri::Runtime>(
+    value: &Value,
+    session_id: &str,
+    cwd: Option<&Path>,
+    app_handle: &tauri::AppHandle<R>,
+    in_flight: &mut InFlightToolCalls,
+) { ... }
+
+fn process_user_message<R: tauri::Runtime>(
+    value: &Value,
+    session_id: &str,
+    cwd: Option<&Path>,
+    app_handle: &tauri::AppHandle<R>,
+    emitter: &mut TestRunEmitter<R>,
+    in_flight: &mut InFlightToolCalls,
+) { ... }
+
+fn process_tool_result<R: tauri::Runtime>(
+    value: &Value,
+    session_id: &str,
+    cwd: Option<&Path>,
+    app_handle: &tauri::AppHandle<R>,
+    emitter: &mut TestRunEmitter<R>,
+    in_flight: &mut InFlightToolCalls,
+    timestamp: &str,
+) { ... }
+```
+
+In `process_tool_result`, replace the direct `app_handle.emit("test-run", &snap)` with `emitter.submit(snap)`.
+
+- [ ] **Step 5: Use the emitter in `tail_loop`; flip on first EOF**
+
+Edit `src-tauri/src/agent/transcript.rs`. Replace `tail_loop`:
+
+```rust
+fn tail_loop<R: tauri::Runtime>(
+    app_handle: tauri::AppHandle<R>,
+    session_id: String,
+    cwd: Option<PathBuf>,
+    file: File,
+    stop_flag: Arc<AtomicBool>,
+) {
+    let mut reader = BufReader::new(file);
+    let mut in_flight: InFlightToolCalls = HashMap::new();
+    let mut emitter = TestRunEmitter::new(app_handle.clone());
+    let mut line_buf = String::new();
+
+    while !stop_flag.load(Ordering::Relaxed) {
+        line_buf.clear();
+        match reader.read_line(&mut line_buf) {
+            Ok(0) => {
+                emitter.finish_replay();
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Ok(_) => {
+                let line = line_buf.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                process_line(
+                    line,
+                    &session_id,
+                    cwd.as_deref(),
+                    &app_handle,
+                    &mut emitter,
+                    &mut in_flight,
+                );
+            }
+            Err(e) => {
+                log::warn!("Error reading transcript line: {}", e);
+                std::thread::sleep(POLL_INTERVAL);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run all backend tests**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml -p vimeflow_lib`
+Expected: All passing.
+
+- [ ] **Step 7: Add the replay-batching fixture**
+
+Create `src-tauri/tests/fixtures/transcript_vitest_replay.jsonl`:
+
+```jsonl
+{"type":"assistant","timestamp":"2026-04-28T11:00:00.000Z","message":{"content":[{"type":"tool_use","id":"r1","name":"Bash","input":{"command":"vitest run"}}]}}
+{"type":"user","timestamp":"2026-04-28T11:00:01.000Z","message":{"content":[{"type":"tool_result","tool_use_id":"r1","is_error":false,"content":"     Tests  1 passed (1)\n"}]}}
+{"type":"assistant","timestamp":"2026-04-28T11:01:00.000Z","message":{"content":[{"type":"tool_use","id":"r2","name":"Bash","input":{"command":"vitest run"}}]}}
+{"type":"user","timestamp":"2026-04-28T11:01:01.000Z","message":{"content":[{"type":"tool_result","tool_use_id":"r2","is_error":false,"content":"     Tests  2 passed (2)\n"}]}}
+{"type":"assistant","timestamp":"2026-04-28T11:02:00.000Z","message":{"content":[{"type":"tool_use","id":"r3","name":"Bash","input":{"command":"vitest run"}}]}}
+{"type":"user","timestamp":"2026-04-28T11:02:01.000Z","message":{"content":[{"type":"tool_result","tool_use_id":"r3","is_error":false,"content":"     Tests  3 passed (3)\n"}]}}
+```
+
+(3 historical runs with passed = 1, 2, 3.)
+
+- [ ] **Step 8: Add the replay-batching integration test**
+
+Create `src-tauri/tests/transcript_vitest_replay.rs`:
+
+```rust
+use std::sync::{Arc, Mutex};
+
+use vimeflow_lib::agent::transcript::TranscriptState;
+
+#[test]
+fn replay_emits_only_latest_snapshot() {
+    use tauri::test::mock_builder;
+    use tauri::Listener;
+
+    let app = mock_builder().build(tauri::generate_context!()).unwrap();
+    let app_handle = app.handle().clone();
+
+    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    app_handle.listen("test-run", move |event| {
+        recv_clone.lock().unwrap().push(event.payload().to_string());
+    });
+
+    let state = TranscriptState::new();
+    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/transcript_vitest_replay.jsonl");
+
+    state
+        .start_or_replace(
+            app_handle,
+            "session-replay".to_string(),
+            fixture_path,
+            None,
+        )
+        .expect("start watcher");
+
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+    state.stop("session-replay").ok();
+
+    let events = received.lock().unwrap();
+    // 3 historical runs in the fixture, but replay batching collapses to 1 emit
+    // containing the LATEST run (passed=3).
+    assert_eq!(events.len(), 1, "expected exactly one emit after replay");
+    assert!(events[0].contains(r#""passed":3"#));
+}
+```
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --test transcript_vitest_replay`
+Expected: Passes — exactly one event, with `passed: 3`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src-tauri/src/agent/test_runners/emitter.rs \
+        src-tauri/src/agent/test_runners/mod.rs \
+        src-tauri/src/agent/transcript.rs \
+        src-tauri/tests/fixtures/transcript_vitest_replay.jsonl \
+        src-tauri/tests/transcript_vitest_replay.rs
+git commit -m "feat(agent): replay batching for test-run events via TestRunEmitter
+
+During tail_loop's initial read-from-beginning replay, multiple historical
+test runs collapse to one emit (latest wins) at first EOF. After the
+initial EOF, every matched run emits immediately. Eliminates UI flicker
+on session restore."
+```
+
+---
+
+## Task 7: Listener-ordering regression test (TS)
+
+Lock the load-bearing invariant: the `test-run` listener must be attached before `start_agent_watcher` is invoked. Without a backend snapshot cache in v1, this is the only thing keeping the latest-of-replay snapshot from being lost on session start.
+
+**Files:**
+
+- Modify: `src/features/agent-status/types/index.ts` (add `TestRunSnapshot`, `TestGroup`, etc., and `testRun: TestRunSnapshot | null` on `AgentStatus`)
+- Modify: `src/features/agent-status/hooks/useAgentStatus.ts` (add `testRun: null` to default; add `test-run` listener inside `subscribe()`)
+- Modify: `src/features/agent-status/hooks/useAgentStatus.test.tsx` (ordering test)
+
+- [ ] **Step 1: Add TS types for the snapshot**
+
+Edit `src/features/agent-status/types/index.ts`. Add at an appropriate spot near the other types:
+
+```typescript
+export type TestRunStatus = 'pass' | 'fail' | 'noTests' | 'error'
+export type TestGroupKind = 'file' | 'suite' | 'module'
+export type TestGroupStatus = 'pass' | 'fail' | 'skip'
+
+export interface TestGroup {
+  label: string
+  // Rust serialises Option<String> as null (not omitted). Use string | null
+  // so the boundary contract matches the wire shape exactly.
+  path: string | null
+  kind: TestGroupKind
+  passed: number
+  failed: number
+  skipped: number
+  total: number
+  status: TestGroupStatus
+}
+
+export interface TestRunSummary {
+  passed: number
+  failed: number
+  skipped: number
+  total: number
+  groups: TestGroup[]
+}
+
+export interface TestRunSnapshot {
+  sessionId: string // PTY session id
+  runner: string
+  commandPreview: string
+  startedAt: string
+  finishedAt: string
+  durationMs: number
+  status: TestRunStatus
+  summary: TestRunSummary
+  outputExcerpt: string | null
+}
+```
+
+In the existing `AgentStatus` interface, add:
+
+```typescript
+export interface AgentStatus {
+  // ...existing fields...
+  testRun: TestRunSnapshot | null
+}
+```
+
+- [ ] **Step 2: Update `createDefaultStatus`**
+
+Edit `src/features/agent-status/hooks/useAgentStatus.ts`. Find `createDefaultStatus` (line 27) and add the field:
+
+```typescript
+const createDefaultStatus = (sessionId: string | null): AgentStatus => ({
+  isActive: false,
+  agentType: null,
+  modelId: null,
+  modelDisplayName: null,
+  version: null,
+  sessionId,
+  agentSessionId: null,
+  contextWindow: null,
+  cost: null,
+  rateLimits: null,
+  toolCalls: { total: 0, byType: {}, active: null },
+  recentToolCalls: [],
+  testRun: null,
+})
+```
+
+- [ ] **Step 3: Add the `test-run` listener inside `subscribe()`**
+
+Edit `src/features/agent-status/hooks/useAgentStatus.ts`. Inside the `subscribe` async function, after the existing `unlistenToolCall` setup (around line 320), add:
+
+```typescript
+const unlistenTestRun = await listen<TestRunSnapshot>('test-run', (event) => {
+  if (event.payload.sessionId !== resolvePtyId()) {
+    return
+  }
+  setStatus((prev) => ({
+    ...prev,
+    testRun: event.payload,
+  }))
+})
+
+addUnlisten(unlistenTestRun)
+```
+
+Add `TestRunSnapshot` to the existing import from `../types` at the top of the file.
+
+- [ ] **Step 4: Listener-ordering regression test**
+
+Edit `src/features/agent-status/hooks/useAgentStatus.test.tsx` (extend the existing test file).
+
+```typescript
+test('attaches test-run listener BEFORE invoking start_agent_watcher', async () => {
+  const PTY_ID = 'pty-ordering'
+  vi.mocked(getPtySessionId).mockReturnValue(PTY_ID)
+
+  const callOrder: string[] = []
+
+  vi.mocked(listen).mockImplementation(async (event) => {
+    callOrder.push(`listen:${String(event)}`)
+    return () => undefined
+  })
+
+  vi.mocked(invoke).mockImplementation(async (cmd) => {
+    callOrder.push(`invoke:${String(cmd)}`)
+    if (cmd === 'detect_agent_in_session') {
+      return { agentType: 'claudeCode', sessionId: PTY_ID } as never
+    }
+    return undefined as never
+  })
+
+  renderHook(() => useAgentStatus('ws-1'))
+
+  // Wait for the subscribe + first detection cycle to complete.
+  await waitFor(() => {
+    expect(callOrder).toContain('invoke:start_agent_watcher')
+  })
+
+  const testRunIndex = callOrder.indexOf('listen:test-run')
+  const startWatcherIndex = callOrder.indexOf('invoke:start_agent_watcher')
+
+  expect(testRunIndex).toBeGreaterThanOrEqual(0)
+  expect(startWatcherIndex).toBeGreaterThanOrEqual(0)
+  expect(testRunIndex).toBeLessThan(startWatcherIndex)
+})
+```
+
+- [ ] **Step 5: Add a hook test for `testRun` updating from a `test-run` event**
+
+Add to `useAgentStatus.test.tsx`:
+
+```typescript
+test('test-run event with matching pty id updates status.testRun', async () => {
+  const PTY_ID = 'pty-tr'
+  vi.mocked(getPtySessionId).mockReturnValue(PTY_ID)
+
+  let testRunHandler: ((e: { payload: TestRunSnapshot }) => void) | undefined
+  vi.mocked(listen).mockImplementation(async (event, handler) => {
+    if (event === 'test-run') {
+      testRunHandler = handler as never
+    }
+    return () => undefined
+  })
+
+  const { result } = renderHook(() => useAgentStatus('ws-1'))
+  await waitFor(() => expect(testRunHandler).toBeDefined())
+
+  const snap: TestRunSnapshot = {
+    sessionId: PTY_ID,
+    runner: 'vitest',
+    commandPreview: 'vitest run',
+    startedAt: '2026-04-28T12:00:00Z',
+    finishedAt: '2026-04-28T12:00:01Z',
+    durationMs: 1000,
+    status: 'pass',
+    summary: { passed: 3, failed: 0, skipped: 0, total: 3, groups: [] },
+    outputExcerpt: null,
+  }
+
+  act(() => {
+    testRunHandler?.({ payload: snap })
+  })
+
+  expect(result.current.testRun).toEqual(snap)
+})
+
+test('test-run event with mismatched pty id is ignored', async () => {
+  const PTY_ID = 'pty-real'
+  vi.mocked(getPtySessionId).mockReturnValue(PTY_ID)
+
+  let testRunHandler: ((e: { payload: TestRunSnapshot }) => void) | undefined
+  vi.mocked(listen).mockImplementation(async (event, handler) => {
+    if (event === 'test-run') {
+      testRunHandler = handler as never
+    }
+    return () => undefined
+  })
+
+  const { result } = renderHook(() => useAgentStatus('ws-1'))
+  await waitFor(() => expect(testRunHandler).toBeDefined())
+
+  act(() => {
+    testRunHandler?.({
+      payload: {
+        sessionId: 'wrong-pty-id',
+        runner: 'vitest',
+        commandPreview: 'vitest',
+        startedAt: '',
+        finishedAt: '',
+        durationMs: 0,
+        status: 'pass',
+        summary: { passed: 1, failed: 0, skipped: 0, total: 1, groups: [] },
+        outputExcerpt: null,
+      },
+    })
+  })
+
+  expect(result.current.testRun).toBeNull()
+})
+
+test('createDefaultStatus has testRun: null', () => {
+  // The hook always starts with testRun: null on first render.
+  vi.mocked(getPtySessionId).mockReturnValue(null)
+  const { result } = renderHook(() => useAgentStatus('ws-default'))
+  expect(result.current.testRun).toBeNull()
+})
+```
+
+- [ ] **Step 6: Run all hook tests**
+
+Run: `npx vitest run src/features/agent-status/hooks/useAgentStatus.test.tsx`
+Expected: All tests pass — including the four new ones.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/agent-status/types/index.ts \
+        src/features/agent-status/hooks/useAgentStatus.ts \
+        src/features/agent-status/hooks/useAgentStatus.test.tsx
+git commit -m "feat(agent-status): test-run listener + ordering regression test
+
+Adds TestRunSnapshot/TestRunSummary/TestGroup TS types matching the
+Rust serde shape (Option<String> → string | null). Hook subscribes
+to test-run inside subscribe() so the listener is attached before
+start_agent_watcher fires — load-bearing for v1 since there's no
+backend snapshot cache. Regression test asserts the call order."
+```
+
+---
+
+## Task 8: TestResults rewrite + AgentStatusPanel wiring
+
+Full rewrite of `<TestResults>` to take a single nullable snapshot prop. Five visual states: placeholder, pass, fail, noTests, error. Inline collapsible button with `useId` for `aria-controls`. Three-part proportional bar.
+
+**Files:**
+
+- Modify: `src/features/agent-status/components/TestResults.tsx` (full rewrite)
+- Modify: `src/features/agent-status/components/TestResults.test.tsx` (full rewrite)
+- Modify: `src/features/agent-status/components/AgentStatusPanel.tsx`
+
+- [ ] **Step 1: Write failing tests for all five states (single shot — many cases)**
+
+Replace `src/features/agent-status/components/TestResults.test.tsx`:
+
+```tsx
+import { describe, expect, test, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { TestResults } from './TestResults'
+import type { TestRunSnapshot } from '../types'
+
+const baseSnap = (overrides: Partial<TestRunSnapshot>): TestRunSnapshot => ({
+  sessionId: 's',
+  runner: 'vitest',
+  commandPreview: 'vitest run',
+  startedAt: '2026-04-28T12:00:00Z',
+  finishedAt: '2026-04-28T12:00:01Z',
+  durationMs: 1400,
+  status: 'pass',
+  summary: { passed: 47, failed: 0, skipped: 0, total: 47, groups: [] },
+  outputExcerpt: null,
+  ...overrides,
+})
+
+describe('TestResults — placeholder', () => {
+  test('renders dim placeholder when snapshot is null', () => {
+    render(<TestResults snapshot={null} />)
+    expect(screen.getByRole('status')).toHaveTextContent(/no runs yet/i)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})
+
+describe('TestResults — live header', () => {
+  test('pass state shows count, runner pill, duration', () => {
+    render(<TestResults snapshot={baseSnap({ status: 'pass' })} />)
+    const button = screen.getByRole('button', { name: /tests/i })
+    expect(button).toHaveTextContent('47/47')
+    expect(button).toHaveTextContent('vitest')
+    expect(button).toHaveTextContent('1.4s')
+  })
+
+  test('fail state shows fail count', () => {
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'fail',
+          summary: { passed: 45, failed: 2, skipped: 0, total: 47, groups: [] },
+        })}
+      />
+    )
+    expect(screen.getByRole('button', { name: /tests/i })).toHaveTextContent(
+      '45/47'
+    )
+  })
+
+  test('noTests state shows 0/0', () => {
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'noTests',
+          summary: { passed: 0, failed: 0, skipped: 0, total: 0, groups: [] },
+        })}
+      />
+    )
+    expect(screen.getByRole('button', { name: /tests/i })).toHaveTextContent(
+      '0/0'
+    )
+  })
+
+  test('error state header shows the runner and an error indicator', () => {
+    render(
+      <TestResults
+        snapshot={baseSnap({ status: 'error', outputExcerpt: 'TS error' })}
+      />
+    )
+    const button = screen.getByRole('button', { name: /tests/i })
+    expect(button).toHaveTextContent('vitest')
+  })
+})
+
+describe('TestResults — keyboard activation', () => {
+  test('Enter and Space toggle expand without custom handlers', async () => {
+    const user = userEvent.setup()
+    render(<TestResults snapshot={baseSnap({})} />)
+    const button = screen.getByRole('button', { name: /tests/i })
+
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+
+    button.focus()
+    await user.keyboard('{Enter}')
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+
+    await user.keyboard(' ')
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+  })
+})
+
+describe('TestResults — expanded body', () => {
+  test('fail state renders summary text and group rows', async () => {
+    const user = userEvent.setup()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'fail',
+          summary: {
+            passed: 45,
+            failed: 2,
+            skipped: 1,
+            total: 48,
+            groups: [
+              {
+                label: 'src/foo.test.ts',
+                path: '/abs/src/foo.test.ts',
+                kind: 'file',
+                passed: 12,
+                failed: 0,
+                skipped: 0,
+                total: 12,
+                status: 'pass',
+              },
+              {
+                label: 'src/bar.test.ts',
+                path: '/abs/src/bar.test.ts',
+                kind: 'file',
+                passed: 5,
+                failed: 2,
+                skipped: 0,
+                total: 7,
+                status: 'fail',
+              },
+            ],
+          },
+        })}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+
+    expect(screen.getByText(/45 passed/)).toBeInTheDocument()
+    expect(screen.getByText(/2 failed/)).toBeInTheDocument()
+    expect(screen.getByText(/1 skipped/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /open src\/foo\.test\.ts/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /open src\/bar\.test\.ts/i })
+    ).toBeInTheDocument()
+  })
+
+  test('error state renders outputExcerpt fallback when null', async () => {
+    const user = userEvent.setup()
+    render(
+      <TestResults
+        snapshot={baseSnap({ status: 'error', outputExcerpt: null })}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+    expect(screen.getByText(/runner errored/i)).toBeInTheDocument()
+  })
+
+  test('error state renders outputExcerpt when present', async () => {
+    const user = userEvent.setup()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'error',
+          outputExcerpt: 'compile error: TS2345',
+        })}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+    expect(screen.getByText(/compile error: TS2345/)).toBeInTheDocument()
+  })
+
+  test('noTests state shows "no tests collected"', async () => {
+    const user = userEvent.setup()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'noTests',
+          summary: { passed: 0, failed: 0, skipped: 0, total: 0, groups: [] },
+        })}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+    expect(screen.getByText(/no tests collected/i)).toBeInTheDocument()
+  })
+})
+
+describe('TestResults — group row click', () => {
+  test('file row with path and onOpenFile is a button that fires onOpenFile', async () => {
+    const user = userEvent.setup()
+    const onOpenFile = vi.fn()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          summary: {
+            passed: 12,
+            failed: 0,
+            skipped: 0,
+            total: 12,
+            groups: [
+              {
+                label: 'src/foo.test.ts',
+                path: '/abs/src/foo.test.ts',
+                kind: 'file',
+                passed: 12,
+                failed: 0,
+                skipped: 0,
+                total: 12,
+                status: 'pass',
+              },
+            ],
+          },
+        })}
+        onOpenFile={onOpenFile}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+    await user.click(
+      screen.getByRole('button', { name: /open src\/foo\.test\.ts/i })
+    )
+    expect(onOpenFile).toHaveBeenCalledOnce()
+    expect(onOpenFile).toHaveBeenCalledWith('/abs/src/foo.test.ts')
+  })
+
+  test('file row with null path is non-interactive (no button)', async () => {
+    const user = userEvent.setup()
+    const onOpenFile = vi.fn()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          summary: {
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            total: 1,
+            groups: [
+              {
+                label: 'src/missing.test.ts',
+                path: null,
+                kind: 'file',
+                passed: 1,
+                failed: 0,
+                skipped: 0,
+                total: 1,
+                status: 'pass',
+              },
+            ],
+          },
+        })}
+        onOpenFile={onOpenFile}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+    // No button for the missing file — only the header button remains.
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(1)
+    expect(buttons[0]).toHaveTextContent(/tests/i)
+    expect(onOpenFile).not.toHaveBeenCalled()
+  })
+
+  test('module/suite row never interactive', async () => {
+    const user = userEvent.setup()
+    const onOpenFile = vi.fn()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          summary: {
+            passed: 5,
+            failed: 0,
+            skipped: 0,
+            total: 5,
+            groups: [
+              {
+                label: 'mycrate::tests',
+                path: null,
+                kind: 'module',
+                passed: 5,
+                failed: 0,
+                skipped: 0,
+                total: 5,
+                status: 'pass',
+              },
+            ],
+          },
+        })}
+        onOpenFile={onOpenFile}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+    expect(screen.queryByRole('button', { name: /open mycrate/i })).toBeNull()
+  })
+})
+
+describe('TestResults — useId aria-controls uniqueness', () => {
+  test('two TestResults in one render have distinct aria-controls', () => {
+    render(
+      <>
+        <TestResults snapshot={baseSnap({ runner: 'vitest' })} />
+        <TestResults snapshot={baseSnap({ runner: 'cargo' })} />
+      </>
+    )
+    const buttons = screen.getAllByRole('button', { name: /tests/i })
+    expect(buttons).toHaveLength(2)
+    const a = buttons[0].getAttribute('aria-controls')
+    const b = buttons[1].getAttribute('aria-controls')
+    expect(a).toBeTruthy()
+    expect(b).toBeTruthy()
+    expect(a).not.toBe(b)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests — all should fail (component still has old API)**
+
+Run: `npx vitest run src/features/agent-status/components/TestResults.test.tsx`
+Expected: All tests fail because the component takes `passed`/`failed`/`total` props, not `snapshot`.
+
+- [ ] **Step 3: Rewrite `TestResults.tsx`**
+
+Replace `src/features/agent-status/components/TestResults.tsx`:
+
+```tsx
+import { useId, useState } from 'react'
+import type { ReactElement } from 'react'
+
+import type { TestGroup, TestRunSnapshot, TestRunStatus } from '../types'
+
+interface TestResultsProps {
+  snapshot: TestRunSnapshot | null
+  onOpenFile?: (path: string) => void
+}
+
+export const TestResults = ({
+  snapshot,
+  onOpenFile,
+}: TestResultsProps): ReactElement => {
+  if (snapshot === null) {
+    return <TestResultsPlaceholder />
+  }
+  return <TestResultsLive snapshot={snapshot} onOpenFile={onOpenFile} />
+}
+
+const TestResultsPlaceholder = (): ReactElement => (
+  <div
+    role="status"
+    aria-live="polite"
+    className="border-t border-outline-variant/[0.08] px-5 py-3 font-mono text-[10px] tracking-[0.15em] text-on-surface-variant/60 uppercase"
+    data-testid="test-results"
+  >
+    Tests &nbsp;&nbsp;no runs yet
+  </div>
+)
+
+interface LiveProps {
+  snapshot: TestRunSnapshot
+  onOpenFile?: (path: string) => void
+}
+
+const TestResultsLive = ({ snapshot, onOpenFile }: LiveProps): ReactElement => {
+  const [expanded, setExpanded] = useState(false)
+  const bodyId = useId()
+
+  const { passed, failed, total } = snapshot.summary
+  const dotClass = statusDotClass(snapshot.status)
+
+  return (
+    <div
+      className="border-t border-outline-variant/[0.08]"
+      data-testid="test-results"
+    >
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={bodyId}
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full cursor-pointer items-center gap-2 px-5 py-3 text-left"
+      >
+        <span className="text-[10px] text-outline">{expanded ? '▾' : '▸'}</span>
+        <span className="text-[10px] font-black uppercase tracking-[0.15em] text-outline">
+          Tests
+        </span>
+        <span
+          className={`inline-block h-2 w-2 rounded-full ${dotClass}`}
+          aria-hidden
+        />
+        <span className="font-mono text-[10px] text-on-surface">
+          {passed}/{total}
+        </span>
+        <span className="font-mono text-[10px] text-on-surface-variant/70">
+          · {snapshot.runner}
+        </span>
+        <span className="font-mono text-[10px] text-on-surface-variant/70">
+          · {formatDuration(snapshot.durationMs)}
+        </span>
+      </button>
+      <div id={bodyId} hidden={!expanded} className="px-5 pb-3">
+        {expanded && (
+          <TestResultsBody snapshot={snapshot} onOpenFile={onOpenFile} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+const TestResultsBody = ({
+  snapshot,
+  onOpenFile,
+}: {
+  snapshot: TestRunSnapshot
+  onOpenFile?: (path: string) => void
+}): ReactElement => {
+  if (snapshot.status === 'noTests') {
+    return (
+      <span className="font-mono text-[10px] text-on-surface-variant">
+        no tests collected
+      </span>
+    )
+  }
+  if (snapshot.status === 'error') {
+    return (
+      <span className="font-mono text-[10px] text-on-surface-variant">
+        {snapshot.outputExcerpt ?? 'runner errored before producing results'}
+      </span>
+    )
+  }
+
+  const { passed, failed, skipped } = snapshot.summary
+  return (
+    <div className="flex flex-col gap-2">
+      <ProportionalBar passed={passed} failed={failed} skipped={skipped} />
+      <SummaryText passed={passed} failed={failed} skipped={skipped} />
+      <ul className="flex flex-col gap-1">
+        {snapshot.summary.groups.map((g, i) => (
+          <li key={`${g.label}-${i}`}>
+            <GroupRow group={g} onOpenFile={onOpenFile} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+const ProportionalBar = ({
+  passed,
+  failed,
+  skipped,
+}: {
+  passed: number
+  failed: number
+  skipped: number
+}): ReactElement => {
+  if (passed + failed + skipped === 0) {
+    return <></>
+  }
+  return (
+    <div className="flex h-[3px] w-full overflow-hidden rounded-full">
+      {passed > 0 && (
+        <div style={{ flexGrow: passed }} className="bg-success" />
+      )}
+      {failed > 0 && <div style={{ flexGrow: failed }} className="bg-error" />}
+      {skipped > 0 && (
+        <div
+          style={{ flexGrow: skipped }}
+          className="bg-on-surface-variant/40"
+        />
+      )}
+    </div>
+  )
+}
+
+const SummaryText = ({
+  passed,
+  failed,
+  skipped,
+}: {
+  passed: number
+  failed: number
+  skipped: number
+}): ReactElement => {
+  const parts = [`${passed} passed`]
+  if (failed > 0) parts.push(`${failed} failed`)
+  if (skipped > 0) parts.push(`${skipped} skipped`)
+  return (
+    <span className="font-mono text-[10px] font-bold text-on-surface">
+      {parts.join(', ')}
+    </span>
+  )
+}
+
+const GroupRow = ({
+  group,
+  onOpenFile,
+}: {
+  group: TestGroup
+  onOpenFile?: (path: string) => void
+}): ReactElement => {
+  const icon = groupIcon(group.status)
+  const countText =
+    group.skipped > 0
+      ? `${group.passed}/${group.total} (${group.skipped} skipped)`
+      : `${group.passed}/${group.total}`
+
+  if (
+    group.kind === 'file' &&
+    group.path !== null &&
+    onOpenFile !== undefined
+  ) {
+    return (
+      <button
+        type="button"
+        aria-label={`Open ${group.label}`}
+        onClick={() => onOpenFile(group.path!)}
+        className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left hover:bg-surface-container-high"
+      >
+        <span
+          className={`${groupIconColor(group.status)} font-mono text-[11px]`}
+          aria-hidden
+        >
+          {icon}
+        </span>
+        <span className="flex-1 truncate font-mono text-[11px] text-on-surface">
+          {group.label}
+        </span>
+        <span className="font-mono text-[10px] text-on-surface-variant">
+          {countText}
+        </span>
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex w-full items-center gap-2 px-1 py-0.5">
+      <span
+        className={`${groupIconColor(group.status)} font-mono text-[11px]`}
+        aria-hidden
+      >
+        {icon}
+      </span>
+      <span className="flex-1 truncate font-mono text-[11px] text-on-surface">
+        {group.label}
+      </span>
+      <span className="font-mono text-[10px] text-on-surface-variant">
+        {countText}
+      </span>
+    </div>
+  )
+}
+
+const statusDotClass = (s: TestRunStatus): string => {
+  switch (s) {
+    case 'pass':
+      return 'bg-success'
+    case 'fail':
+      return 'bg-error'
+    case 'noTests':
+      return 'bg-on-surface-variant'
+    case 'error':
+      return 'bg-tertiary'
+  }
+}
+
+const groupIcon = (s: TestGroup['status']): string => {
+  switch (s) {
+    case 'pass':
+      return '✓'
+    case 'fail':
+      return '✗'
+    case 'skip':
+      return '⊘'
+  }
+}
+
+const groupIconColor = (s: TestGroup['status']): string => {
+  switch (s) {
+    case 'pass':
+      return 'text-success'
+    case 'fail':
+      return 'text-error'
+    case 'skip':
+      return 'text-on-surface-variant'
+  }
+}
+
+const formatDuration = (ms: number): string => {
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const minutes = Math.floor(ms / 60_000)
+  const seconds = Math.floor((ms % 60_000) / 1000)
+  return `${minutes}m ${seconds}s`
+}
+```
+
+- [ ] **Step 4: Run all `TestResults` tests**
+
+Run: `npx vitest run src/features/agent-status/components/TestResults.test.tsx`
+Expected: All tests pass.
+
+- [ ] **Step 5: Wire `AgentStatusPanel`**
+
+Edit `src/features/agent-status/components/AgentStatusPanel.tsx`. Remove the `placeholderTests` const (line 20). Update the props:
+
+```tsx
+interface AgentStatusPanelProps {
+  sessionId: string | null
+  cwd: string
+  onOpenDiff: (file: ChangedFile) => void
+  onOpenFile?: (path: string) => void
+}
+```
+
+Update the destructuring at line 22:
+
+```tsx
+export const AgentStatusPanel = ({
+  sessionId,
+  cwd,
+  onOpenDiff,
+  onOpenFile,
+}: AgentStatusPanelProps): ReactElement => {
+```
+
+Replace the `<TestResults ... />` block (line 95-99):
+
+```tsx
+<TestResults snapshot={status.testRun} onOpenFile={onOpenFile} />
+```
+
+- [ ] **Step 6: Type-check the panel**
+
+Run: `npm run type-check`
+Expected: No type errors.
+
+Run: `npx vitest run src/features/agent-status`
+Expected: All agent-status tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/agent-status/components/TestResults.tsx \
+        src/features/agent-status/components/TestResults.test.tsx \
+        src/features/agent-status/components/AgentStatusPanel.tsx
+git commit -m "feat(agent-status): rewrite TestResults around TestRunSnapshot prop
+
+Single nullable snapshot prop. Five visual states: placeholder (slim
+'no runs yet' row), pass, fail, noTests, error. Inline collapsible
+button with useId-derived aria-controls (no manual key handler).
+Three-part proportional bar (passed/failed/skipped) — constant DOM.
+File-kind group rows are buttons when path is non-null and onOpenFile
+is provided; otherwise non-interactive divs."
+```
+
+---
+
+## Task 9: WorkspaceView.handleOpenTestFile
+
+Add a new dirty-state-guarded handler in `WorkspaceView` and pass it through `AgentStatusPanel.onOpenFile`. Mirrors the existing `handleFileSelect` pattern.
+
+**Files:**
+
+- Modify: `src/features/workspace/WorkspaceView.tsx`
+- Modify: `src/features/workspace/WorkspaceView.test.tsx`
+
+- [ ] **Step 1: Read existing WorkspaceView.test.tsx for the test pattern**
+
+Run: `grep -n "handleFileSelect\|useEditorBuffer\|AgentStatusPanel" src/features/workspace/WorkspaceView.test.tsx | head -20`
+
+Note the existing pattern for: (a) how `useEditorBuffer` is mocked, (b) how `AgentStatusPanel` is mocked or rendered, (c) how `setShowUnsavedDialog` / pending-path state is asserted. Reuse that exact pattern in Step 2's test code.
+
+- [ ] **Step 2: Write failing tests for the new handler**
+
+Edit `src/features/workspace/WorkspaceView.test.tsx`. Add the following tests, adjusting the mock-setup helpers to match the existing patterns observed in Step 1:
+
+```typescript
+test('handleOpenTestFile opens file directly when buffer is clean', async () => {
+  const openFileMock = vi.fn().mockResolvedValue(undefined)
+  // Mock useEditorBuffer with isDirty: false. Replace this with whatever
+  // mock pattern Step 1 surfaced (could be vi.mock('../editor/hooks/useEditorBuffer'),
+  // or a wrapper provider). Below is the shape:
+  vi.mocked(useEditorBuffer).mockReturnValue({
+    isDirty: false,
+    openFile: openFileMock,
+    saveFile: vi.fn(),
+    filePath: null,
+    currentContent: '',
+    loading: false,
+  } as unknown as ReturnType<typeof useEditorBuffer>)
+
+  render(<WorkspaceView />)
+
+  // Find the AgentStatusPanel render (mocked or real) and grab the onOpenFile
+  // prop that was passed. If AgentStatusPanel is mocked with vi.mock, the
+  // mock implementation should capture props for inspection.
+  const onOpenFile = capturedAgentStatusPanelProps.onOpenFile as (p: string) => void
+  expect(onOpenFile).toBeDefined()
+
+  await act(async () => {
+    onOpenFile('/abs/src/foo.test.ts')
+  })
+
+  expect(openFileMock).toHaveBeenCalledOnce()
+  expect(openFileMock).toHaveBeenCalledWith('/abs/src/foo.test.ts')
+  expect(screen.queryByText(/unsaved changes/i)).toBeNull()
+})
+
+test('handleOpenTestFile shows unsaved dialog when buffer is dirty', async () => {
+  const openFileMock = vi.fn().mockResolvedValue(undefined)
+  vi.mocked(useEditorBuffer).mockReturnValue({
+    isDirty: true,
+    openFile: openFileMock,
+    saveFile: vi.fn(),
+    filePath: 'src/current.ts',
+    currentContent: 'edits',
+    loading: false,
+  } as unknown as ReturnType<typeof useEditorBuffer>)
+
+  render(<WorkspaceView />)
+
+  const onOpenFile = capturedAgentStatusPanelProps.onOpenFile as (p: string) => void
+
+  await act(async () => {
+    onOpenFile('/abs/src/bar.test.ts')
+  })
+
+  expect(openFileMock).not.toHaveBeenCalled()
+  expect(await screen.findByText(/unsaved changes/i)).toBeInTheDocument()
+})
+```
+
+Setup helper for capturing `AgentStatusPanel` props (add at the top of the test file if not already present):
+
+```typescript
+const capturedAgentStatusPanelProps: {
+  onOpenFile?: (p: string) => void
+  onOpenDiff?: unknown
+} = {}
+
+vi.mock('../agent-status/components/AgentStatusPanel', () => ({
+  AgentStatusPanel: (props: {
+    onOpenFile?: (p: string) => void
+    onOpenDiff?: unknown
+  }) => {
+    capturedAgentStatusPanelProps.onOpenFile = props.onOpenFile
+    capturedAgentStatusPanelProps.onOpenDiff = props.onOpenDiff
+    return null
+  },
+}))
+```
+
+If a different mock for `AgentStatusPanel` already exists in the test file, extend its mock implementation to record `onOpenFile` instead of replacing it.
+
+- [ ] **Step 3: Run the failing tests**
+
+Run: `npx vitest run src/features/workspace/WorkspaceView.test.tsx`
+Expected: New tests fail because `handleOpenTestFile` doesn't exist (the mock captures `onOpenFile: undefined`).
+
+- [ ] **Step 4: Implement `handleOpenTestFile`**
+
+Edit `src/features/workspace/WorkspaceView.tsx`. Below the existing `handleFileSelect` (line 144), add:
+
+```typescript
+// Open a test file from the activity panel. Mirrors handleFileSelect's
+// dirty-state guard so clicking a test result row never silently
+// discards unsaved editor changes — the same unsaved-dialog flow
+// resumes the pending open.
+const handleOpenTestFile = useCallback(
+  (filePath: string): void => {
+    if (editorBuffer.isDirty) {
+      setPendingFilePathSynced(filePath)
+      setShowUnsavedDialog(true)
+      return
+    }
+    void openFileSafely(filePath)
+  },
+  [editorBuffer.isDirty, openFileSafely, setPendingFilePathSynced]
+)
+```
+
+Then pass it down. Find the `<AgentStatusPanel ... />` render site and add the prop:
+
+```tsx
+<AgentStatusPanel
+  sessionId={...}
+  cwd={...}
+  onOpenDiff={handleOpenDiff}
+  onOpenFile={handleOpenTestFile}
+/>
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `npx vitest run src/features/workspace/WorkspaceView.test.tsx`
+Expected: New tests pass.
+
+Run: `npm run type-check`
+Expected: Clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/workspace/WorkspaceView.tsx \
+        src/features/workspace/WorkspaceView.test.tsx
+git commit -m "feat(workspace): handleOpenTestFile mirrors handleFileSelect guard
+
+Activity panel test-result rows route through a new handler that
+respects editorBuffer.isDirty — clean buffer opens directly, dirty
+buffer queues the path and surfaces the unsaved dialog. Reuses the
+existing handleSave/handleDiscard/handleCancel resumption flow."
+```
+
+---
+
+## Task 10: Cargo result parser + cargo fixture
+
+Implement `cargo_parse_result` and add a fixture covering passes, failures, and ignored tests.
+
+**Files:**
+
+- Modify: `src-tauri/src/agent/test_runners/cargo.rs`
+- Create: `src-tauri/tests/fixtures/transcript_cargo_mixed.jsonl`
+- Create: `src-tauri/tests/transcript_cargo_e2e.rs`
+
+- [ ] **Step 1: Test for `cargo_parse_result` (failing)**
+
+Replace `src-tauri/src/agent/test_runners/cargo.rs`:
+
+```rust
+//! Cargo test result parser. Targets cargo 1.7x output format.
+//!
+//! Cargo writes its summary to stderr (CapturedOutput.content carries combined
+//! stdout+stderr because the Bash tool returns combined output).
+//!
+//! Canonical summary line:
+//!   test result: ok. 47 passed; 2 failed; 1 ignored; 0 measured; 0 filtered out;
+//!
+//! Per-test lines:
+//!   test some_module::test_foo ... ok
+//!   test some_module::test_bar ... FAILED
+//!   test some_module::test_baz ... ignored
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use super::types::{
+    CapturedOutput, TestGroup, TestGroupKind, TestGroupStatus, TestRunSummary, TestRunner,
+};
+
+pub static CARGO_TEST: TestRunner = TestRunner {
+    name: "cargo",
+    matches: cargo_matches,
+    parse_result: cargo_parse_result,
+};
+
+const MAX_GROUPS: usize = 500;
+
+fn cargo_matches(tokens: &[&str]) -> bool {
+    matches!(tokens, [&"cargo", &"test", ..])
+}
+
+static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
+
+// Summary line. Cargo may produce multiple summary lines (one per binary);
+// we sum across all of them.
+//   test result: ok. 47 passed; 2 failed; 1 ignored; 0 measured; 0 filtered out
+static SUMMARY_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?m)test result:\s+\w+\.\s+(\d+)\s+passed;\s+(\d+)\s+failed;\s+(\d+)\s+ignored",
+    )
+    .unwrap()
+});
+
+// Individual test outcome lines:
+//   test foo::bar::test_x ... ok
+//   test foo::bar::test_y ... FAILED
+//   test foo::bar::test_z ... ignored
+static TEST_LINE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?m)^test\s+([\w:]+)\s+\.\.\.\s+(ok|FAILED|ignored)\s*$").unwrap()
+});
+
+fn cargo_parse_result(out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummary> {
+    let stripped = ANSI_RE.replace_all(&out.content, "").to_string();
+
+    let mut passed = 0u32;
+    let mut failed = 0u32;
+    let mut skipped = 0u32;
+    let mut found_summary = false;
+    for cap in SUMMARY_RE.captures_iter(&stripped) {
+        found_summary = true;
+        passed += cap.get(1).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        failed += cap.get(2).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        skipped += cap.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    }
+    if !found_summary {
+        return None;
+    }
+    let total = passed + failed + skipped;
+
+    // Build per-module groups from individual test lines.
+    let mut module_counts: HashMap<String, (u32, u32, u32)> = HashMap::new(); // (pass, fail, skip)
+    for cap in TEST_LINE_RE.captures_iter(&stripped) {
+        let full_path = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let outcome = cap.get(2).map(|m| m.as_str()).unwrap_or("");
+        // Module = everything before the last "::"
+        let module = match full_path.rfind("::") {
+            Some(i) => &full_path[..i],
+            None => full_path,
+        };
+        let entry = module_counts.entry(module.to_string()).or_default();
+        match outcome {
+            "ok" => entry.0 += 1,
+            "FAILED" => entry.1 += 1,
+            "ignored" => entry.2 += 1,
+            _ => {}
+        }
+    }
+
+    let mut groups: Vec<TestGroup> = module_counts
+        .into_iter()
+        .take(MAX_GROUPS)
+        .map(|(label, (p, f, s))| {
+            let total = p + f + s;
+            let status = if f > 0 {
+                TestGroupStatus::Fail
+            } else if total == 0 || (s > 0 && p == 0) {
+                TestGroupStatus::Skip
+            } else {
+                TestGroupStatus::Pass
+            };
+            TestGroup {
+                label,
+                path: None, // cargo modules don't map to files reliably in v1
+                kind: TestGroupKind::Module,
+                passed: p,
+                failed: f,
+                skipped: s,
+                total,
+                status,
+            }
+        })
+        .collect();
+    groups.sort_by(|a, b| a.label.cmp(&b.label));
+
+    Some(TestRunSummary {
+        passed,
+        failed,
+        skipped,
+        total,
+        groups,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn captured(content: &str) -> CapturedOutput {
+        CapturedOutput { content: content.to_string(), is_error: false }
+    }
+
+    #[test]
+    fn parses_simple_pass_summary() {
+        let out = captured(
+            "running 3 tests
+test mycrate::tests::test_a ... ok
+test mycrate::tests::test_b ... ok
+test mycrate::tests::test_c ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n"
+        );
+        let s = cargo_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.passed, 3);
+        assert_eq!(s.failed, 0);
+        assert_eq!(s.skipped, 0);
+        assert_eq!(s.groups.len(), 1);
+        assert_eq!(s.groups[0].label, "mycrate::tests");
+        assert_eq!(s.groups[0].passed, 3);
+        assert_eq!(s.groups[0].kind, TestGroupKind::Module);
+        assert!(s.groups[0].path.is_none());
+    }
+
+    #[test]
+    fn parses_mixed_outcomes() {
+        let out = captured(
+            "running 3 tests
+test mycrate::a::test_x ... ok
+test mycrate::a::test_y ... FAILED
+test mycrate::b::test_z ... ignored
+
+test result: FAILED. 1 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out\n"
+        );
+        let s = cargo_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.passed, 1);
+        assert_eq!(s.failed, 1);
+        assert_eq!(s.skipped, 1);
+        assert_eq!(s.groups.len(), 2);
+        let a = s.groups.iter().find(|g| g.label == "mycrate::a").unwrap();
+        assert_eq!(a.passed, 1);
+        assert_eq!(a.failed, 1);
+        assert_eq!(a.status, TestGroupStatus::Fail);
+        let b = s.groups.iter().find(|g| g.label == "mycrate::b").unwrap();
+        assert_eq!(b.skipped, 1);
+        assert_eq!(b.status, TestGroupStatus::Skip);
+    }
+
+    #[test]
+    fn sums_multiple_summary_lines() {
+        let out = captured(
+            "test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out\n"
+        );
+        let s = cargo_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.passed, 8);
+        assert_eq!(s.failed, 1);
+    }
+
+    #[test]
+    fn returns_none_when_no_summary() {
+        let out = captured("error: failed to compile crate");
+        assert!(cargo_parse_result(&out, &PathBuf::from("/tmp")).is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run cargo parser tests**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::test_runners::cargo`
+Expected: All 4 tests pass.
+
+- [ ] **Step 3: Add cargo fixture**
+
+Create `src-tauri/tests/fixtures/transcript_cargo_mixed.jsonl`:
+
+```jsonl
+{"type":"assistant","timestamp":"2026-04-28T13:00:00.000Z","message":{"content":[{"type":"tool_use","id":"c1","name":"Bash","input":{"command":"cargo test"}}]}}
+{"type":"user","timestamp":"2026-04-28T13:00:05.000Z","message":{"content":[{"type":"tool_result","tool_use_id":"c1","is_error":false,"content":"running 3 tests\ntest mycrate::a::test_x ... ok\ntest mycrate::a::test_y ... FAILED\ntest mycrate::b::test_z ... ignored\n\ntest result: FAILED. 1 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out\n"}]}}
+```
+
+- [ ] **Step 4: Add the cargo end-to-end test**
+
+Create `src-tauri/tests/transcript_cargo_e2e.rs`:
+
+```rust
+use std::sync::{Arc, Mutex};
+
+use vimeflow_lib::agent::transcript::TranscriptState;
+
+#[test]
+fn cargo_mixed_fixture_emits_test_run_with_groups() {
+    use tauri::test::mock_builder;
+    use tauri::Listener;
+
+    let app = mock_builder().build(tauri::generate_context!()).unwrap();
+    let app_handle = app.handle().clone();
+
+    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    app_handle.listen("test-run", move |event| {
+        recv_clone.lock().unwrap().push(event.payload().to_string());
+    });
+
+    let state = TranscriptState::new();
+    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/transcript_cargo_mixed.jsonl");
+
+    state
+        .start_or_replace(
+            app_handle,
+            "session-cargo".to_string(),
+            fixture_path,
+            None,
+        )
+        .expect("start watcher");
+
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+    state.stop("session-cargo").ok();
+
+    let events = received.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    let payload = &events[0];
+    assert!(payload.contains(r#""runner":"cargo""#));
+    assert!(payload.contains(r#""passed":1"#));
+    assert!(payload.contains(r#""failed":1"#));
+    assert!(payload.contains(r#""skipped":1"#));
+    assert!(payload.contains(r#""status":"fail""#));
+    assert!(payload.contains(r#""kind":"module""#));
+    assert!(payload.contains(r#""path":null"#));
+}
+```
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --test transcript_cargo_e2e`
+Expected: Passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/agent/test_runners/cargo.rs \
+        src-tauri/tests/fixtures/transcript_cargo_mixed.jsonl \
+        src-tauri/tests/transcript_cargo_e2e.rs
+git commit -m "feat(agent): cargo test result parser + mixed-outcome fixture
+
+Implements cargo_parse_result for the standard 'test result: ...'
+summary line and per-test outcome lines, sums multiple summary blocks
+(one per binary), groups by '<crate>::<module>' (kind: Module, path:
+None — cargo modules don't map to files reliably in v1)."
+```
+
+---
+
+## Task 11: Activity feed glyph + verb mapping
+
+Render the test-file flag in the activity feed: prepend `🧪` and use `Created test:` / `Updated test:` based on `tool === 'Edit' | 'Write'`.
+
+**Files:**
+
+- Modify: `src/features/agent-status/types/activityEvent.ts`
+- Modify: `src/features/agent-status/utils/toolCallsToEvents.ts`
+- Modify: whichever component renders an `ActivityEvent` row (likely `ActivityEvent.tsx` or `ActivityFeed.tsx`)
+- Modify: `src/features/agent-status/utils/toolCallsToEvents.test.ts`
+- Modify: tests for the row component
+
+- [ ] **Step 1: Locate the row renderer (already known)**
+
+The single-row renderer is `src/features/agent-status/components/ActivityEvent.tsx` — it exposes a `getLabel(event)` helper that returns the uppercase row label (`EDIT`, `WRITE`, etc.) and renders `event.body` as the row content. The patch in Step 5 modifies `getLabel` to prepend `🧪 CREATED TEST` / `🧪 UPDATED TEST` when `event.isTestFile === true`.
+
+The corresponding test file is `src/features/agent-status/components/ActivityEvent.test.tsx`.
+
+- [ ] **Step 2: Add `isTestFile` to `ActivityEvent`**
+
+Edit `src/features/agent-status/types/activityEvent.ts`:
+
+```typescript
+export interface ActivityEvent {
+  // ...existing fields...
+  isTestFile?: boolean
+}
+```
+
+- [ ] **Step 3: Test for propagation in `toolCallsToEvents` (failing)**
+
+Edit `src/features/agent-status/utils/toolCallsToEvents.test.ts`:
+
+```typescript
+test('propagates isTestFile from RecentToolCall to ActivityEvent', () => {
+  const recent: RecentToolCall[] = [
+    {
+      id: 'tu_1',
+      tool: 'Write',
+      args: 'src/foo.test.ts',
+      status: 'done',
+      durationMs: 100,
+      timestamp: '2026-04-28T12:00:00Z',
+      isTestFile: true,
+    },
+  ]
+  const events = toolCallsToEvents(null, recent)
+  expect(events[0]?.isTestFile).toBe(true)
+})
+
+test('isTestFile defaults to false when not on RecentToolCall', () => {
+  const recent: RecentToolCall[] = [
+    {
+      id: 'tu_2',
+      tool: 'Read',
+      args: 'src/foo.ts',
+      status: 'done',
+      durationMs: 5,
+      timestamp: '2026-04-28T12:01:00Z',
+      isTestFile: false,
+    },
+  ]
+  const events = toolCallsToEvents(null, recent)
+  expect(events[0]?.isTestFile).toBe(false)
+})
+```
+
+Run: `npx vitest run src/features/agent-status/utils/toolCallsToEvents.test.ts`
+Expected: New tests fail (field not propagated).
+
+- [ ] **Step 4: Propagate `isTestFile` in `toolCallsToEvents`**
+
+Edit `src/features/agent-status/utils/toolCallsToEvents.ts`. In the loop at line 75:
+
+```typescript
+for (const r of sortedRecent) {
+  events.push({
+    id: r.id,
+    kind: toolToKind(r.tool),
+    tool: r.tool,
+    body: r.args,
+    timestamp: r.timestamp,
+    status: r.status,
+    durationMs: r.durationMs,
+    isTestFile: r.isTestFile,
+  })
+}
+```
+
+Run: `npx vitest run src/features/agent-status/utils/toolCallsToEvents.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Modify `getLabel` to prepend test-file verb**
+
+Edit `src/features/agent-status/components/ActivityEvent.tsx`. Replace the existing `getLabel` (around line 38):
+
+```tsx
+const getLabel = (event: ActivityEventType): string => {
+  if (event.isTestFile === true) {
+    // Write tools may also overwrite existing files — labelled as "CREATED"
+    // by approximation. Edit always means an existing file was modified.
+    // Documented limitation in the spec.
+    const verb = event.tool === 'Edit' ? 'UPDATED TEST' : 'CREATED TEST'
+    return `🧪 ${verb}`
+  }
+  if (event.kind === 'meta') {
+    return event.tool.toUpperCase()
+  }
+  return event.kind.toUpperCase()
+}
+```
+
+The `🧪` glyph rides inside the existing label `<span>` (line 175–179) — no new DOM nodes, no layout changes. Color is inherited from `KIND_COLOR[event.kind]`, so test-file Write rows still get `text-primary-container` and test-file Edit rows get the same. (If you want a distinct test colour, that's a follow-up — keeping it tonally consistent for v1.)
+
+- [ ] **Step 6: Add tests for rendering**
+
+Add three tests to `src/features/agent-status/components/ActivityEvent.test.tsx`. Note the `now` prop is required by `<ActivityEvent>` and the existing test file should already import the necessary helpers — match its pattern.
+
+```typescript
+import { render, screen } from '@testing-library/react'
+import { test, expect } from 'vitest'
+import { ActivityEvent } from './ActivityEvent'
+import type { ActivityEvent as ActivityEventType } from '../types/activityEvent'
+
+const NOW = new Date('2026-04-28T12:05:00Z')
+
+test('renders 🧪 CREATED TEST label for Write of a test file', () => {
+  const event: ActivityEventType = {
+    id: 'e1',
+    kind: 'write',
+    tool: 'Write',
+    body: 'src/foo.test.ts',
+    timestamp: '2026-04-28T12:00:00Z',
+    status: 'done',
+    durationMs: 50,
+    isTestFile: true,
+  }
+  render(<ActivityEvent event={event} now={NOW} />)
+  expect(screen.getByText(/created test/i)).toBeInTheDocument()
+  // Glyph rides inside the same label span — partial-text match is fine.
+  expect(screen.getByText(/🧪/)).toBeInTheDocument()
+})
+
+test('renders 🧪 UPDATED TEST label for Edit of a test file', () => {
+  const event: ActivityEventType = {
+    id: 'e2',
+    kind: 'edit',
+    tool: 'Edit',
+    body: 'src/foo.test.ts',
+    timestamp: '2026-04-28T12:01:00Z',
+    status: 'done',
+    durationMs: 30,
+    isTestFile: true,
+  }
+  render(<ActivityEvent event={event} now={NOW} />)
+  expect(screen.getByText(/updated test/i)).toBeInTheDocument()
+})
+
+test('regular Write event has no test glyph or prefix', () => {
+  const event: ActivityEventType = {
+    id: 'e3',
+    kind: 'write',
+    tool: 'Write',
+    body: 'src/foo.ts',
+    timestamp: '2026-04-28T12:02:00Z',
+    status: 'done',
+    durationMs: 50,
+    isTestFile: false,
+  }
+  render(<ActivityEvent event={event} now={NOW} />)
+  expect(screen.queryByText(/created test/i)).toBeNull()
+  expect(screen.queryByText(/🧪/)).toBeNull()
+  // Falls back to the kind-based label.
+  expect(screen.getByText(/^WRITE$/)).toBeInTheDocument()
+})
+```
+
+Run: `npx vitest run src/features/agent-status`
+Expected: All tests pass.
+
+- [ ] **Step 7: Final full-suite run**
+
+Run: `npm test`
+Expected: All TS tests pass.
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: All Rust tests pass.
+
+Run: `npm run type-check`
+Expected: Clean.
+
+Run: `npm run lint`
+Expected: No new errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/features/agent-status/types/activityEvent.ts \
+        src/features/agent-status/utils/toolCallsToEvents.ts \
+        src/features/agent-status/utils/toolCallsToEvents.test.ts \
+        src/features/agent-status/components/ActivityEvent.tsx \
+        src/features/agent-status/components/ActivityEvent.test.tsx
+git commit -m "feat(agent-status): activity feed badges test-file Write/Edit calls
+
+Propagates isTestFile from RecentToolCall through ActivityEvent. The
+row renderer prepends a 🧪 glyph and 'Created test:' / 'Updated test:'
+label when isTestFile === true (Write → Created, Edit → Updated;
+documented Write-overwrite caveat in the spec)."
+```
+
+---
+
+## Self-review checklist
+
+After all 11 tasks land, verify:
+
+- [ ] `npm test` passes
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` passes
+- [ ] `npm run type-check` clean
+- [ ] `npm run lint` no new errors
+- [ ] `npm run format:check` clean
+- [ ] Manual smoke test: launch the app (`npm run tauri:dev`), open a workspace with vitest tests, run `vitest run` from the integrated terminal, confirm the TESTS panel transitions from `no runs yet` → live with the count and per-file rows; click a row, confirm the file opens in the editor.
+- [ ] Manual smoke test: with a dirty buffer, click a test row, confirm the unsaved-changes dialog appears.

--- a/docs/superpowers/specs/2026-04-28-tests-panel-bridge-design.md
+++ b/docs/superpowers/specs/2026-04-28-tests-panel-bridge-design.md
@@ -1,0 +1,864 @@
+# Tests Panel & Claude Code Bridge — Design Spec
+
+**Date**: 2026-04-28
+**Status**: Draft (pre-implementation)
+**Depends on**: Real-time agent status sidebar (#57, merged), Transcript parser for tool call tracking (#63, merged), PtyState CWD resolution (#60, merged), PTY reattach with cursor protocol (#55, merged)
+
+## Problem
+
+The activity sidebar already renders a `<TestResults>` placeholder showing `▶ TESTS 0/0`. Today the data is hard-coded zeros at `src/features/agent-status/components/AgentStatusPanel.tsx:96` — no test runner is observed, no events flow, the panel is decorative. We need to:
+
+1. Decide **when** the panel is visible.
+2. Make it **automatically populate** when test events occur, with no per-project setup.
+3. Establish a **bridge** between the integrated coding agent (Claude Code) and the app so test runs and test-file creation surface in the UI.
+
+## Solution
+
+Extend the existing transcript-watcher pipeline (the same one that powers `agent-tool-call`) to (a) recognise Bash tool calls that invoke a known test runner and parse their result content into a structured `TestRunSnapshot`, and (b) tag Write/Edit tool calls whose `file_path` is a test file. The snapshot is delivered to the frontend over a new `test-run` Tauri event; test-file tagging rides on the existing `agent-tool-call` event via a new `is_test_file` boolean.
+
+The visible panel uses a **lazy, activity-driven** model: it doesn't exist (beyond a slim placeholder row) until the first matched test run for the active session. There is **no filesystem detection at startup**, **no extra Claude Code configuration**, **no command hijacking**.
+
+## Decisions
+
+| #   | Decision                                               | Choice                                                                                                       | Rationale                                                                                 |
+| --- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| Q1  | When does the TESTS panel appear?                      | Only when project has tests configured — refined to lazy / activity-driven (Q5)                              | Avoids cold-start filesystem scan; nothing renders for non-test projects.                 |
+| Q2  | How does the app learn about test events?              | Passive transcript parsing extending the #63 pipeline                                                        | Zero per-project setup; reuses the watcher already on disk.                               |
+| Q3  | How are test commands identified?                      | Strict allowlist with `npm/yarn/pnpm/bun run` script resolution; runner registry leaves room for new entries | Zero false positives; allowlist trivially extensible by adding one file.                  |
+| Q4  | What does the expanded panel show?                     | Compact per-file (or per-suite/module) summary with pass/fail/skip counts; click file rows to open in editor | Smallest unit that's actually useful for navigating to failures; failure detail deferred. |
+| Q5  | How is "tests configured" detected?                    | Lazy / activity-driven — panel materialises on first matched test run                                        | Cheaper cold start; avoids fs detection logic; matches Q1 intent.                         |
+| Q6  | First-time UX for projects that haven't yet run tests? | Slim dim placeholder row `▶ TESTS no runs yet`; promote to live panel on first event                         | One-DOM-line discoverability; ask-Claude CTA deferred to v2.                              |
+
+## Architecture
+
+```
+Claude Code transcript JSONL  (Bash tool_use + tool_result blocks)
+        │  (existing transcript watcher in src-tauri/src/agent/transcript.rs)
+        ▼
+Rust transcript parser  (extended)
+   1. On Bash tool_use: read raw input.command (NOT the summarized args).
+      Match BEFORE summarize_input() truncates to MAX_ARGS_LEN.
+      Store { tool_use_id → (runner, raw_command) } on InFlightToolCall.
+   2. On Write/Edit tool_use: check input.file_path against TEST_FILE patterns
+      (also pre-summarisation). Tag AgentToolCallEvent.is_test_file accordingly.
+   3. On matching Bash tool_result: pull the full result payload
+      (stdout + stderr + combined content blocks). Run runner.parse_result().
+   4. Build TestRunSnapshot. Resolve per-file group paths against session CWD,
+      with a containment check.
+        │
+        ▼
+Tauri events:
+  - test-run         → payload = TestRunSnapshot          (new)
+  - agent-tool-call  → payload = AgentToolCallEvent       (extended: + is_test_file)
+        │
+        ▼
+useAgentStatus hook  (extended)
+   - Resolves workspaceSessionId → PTY id via getPtySessionId(sessionId).
+   - Filters events by event.payload.sessionId === resolvedPtyId
+     (mirrors the agent-tool-call listener at lines 258–321).
+   - test-run listener attached BEFORE start_agent_watcher invocation —
+     load-bearing for replay correctness with no backend snapshot cache.
+        │
+        ▼
+TestResults component  (rewritten)
+   - snapshot === null → dim placeholder row "▶ TESTS no runs yet"
+   - snapshot !== null → live panel with header, 3-part proportional bar,
+                          per-group rows, click-to-open for file groups.
+ActivityFeed                (existing component, extended)
+   - When event.isTestFile, prepend test glyph and use "Created/Updated test:" verb.
+```
+
+## Visibility & first-time UX
+
+- The `{passed:0, failed:0, total:0}` placeholder at `AgentStatusPanel.tsx:96` is **removed**. `placeholderTests` const goes away.
+- `<TestResults snapshot={status.testRun} onOpenFile={onOpenFile} />` renders inline in the existing `thin-scrollbar` flex column.
+- `snapshot === null` → one dim row, ~20px tall, no chevron, no expand interaction. `role="status"` for screen readers; `aria-live="polite"` for one-shot announce on transition to live.
+- `snapshot !== null` → live panel with collapsible header, runner pill, duration, status dot, expanded body with proportional bar and per-group rows.
+- No filesystem detection, no startup cost beyond one DOM line per session.
+
+**Persistence model.** The transcript JSONL is the source of truth. On reload the existing transcript watcher replays every tool_use/tool_result pair through the same parser. No separate cache in v1. See "Listener-attach ordering" below for the correctness invariant this depends on.
+
+## Data model
+
+### Rust types (new module `src-tauri/src/agent/test_runners/types.rs`)
+
+```rust
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TestRunSnapshot {
+    /// PTY session id — same routing convention as agent-tool-call.
+    pub session_id: String,
+    pub runner: String,                // "vitest" | "cargo" — additive
+    /// Sanitised, human-readable form of the command (env-strip + wrapper-strip
+    /// + cap at 120 chars). Raw command is NEVER emitted; see Section "Command
+    /// preview" for construction rules.
+    pub command_preview: String,
+    pub started_at: String,            // ISO 8601 — from tool_use timestamp
+    pub finished_at: String,           // ISO 8601 — from tool_result timestamp
+    /// Computed from finished_at - started_at via parse_iso8601_ms().
+    /// Falls back to InFlightToolCall.started_at.elapsed() on parse failure.
+    pub duration_ms: u64,
+    pub status: TestRunStatus,
+    pub summary: TestRunSummary,
+    /// First useful line(s) of stderr/stdout when status == Error, capped at
+    /// 240 chars; ANSI stripped. Always JSON-serialised (null when absent) —
+    /// TS mirror is `string | null`.
+    pub output_excerpt: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum TestRunStatus {
+    /// summary.failed == 0 AND summary.total > 0
+    Pass,
+    /// summary.failed > 0
+    Fail,
+    /// Parseable run with summary.total == 0 — vitest --passWithNoTests etc.
+    /// NOT a runner crash. Distinct from Pass so the UI can say "no tests
+    /// collected" instead of "passed".
+    NoTests,
+    /// parse_result returned None, OR is_error == true with no parseable summary.
+    Error,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TestRunSummary {
+    pub passed: u32,
+    pub failed: u32,
+    pub skipped: u32,
+    /// Invariant: total == passed + failed + skipped.
+    pub total: u32,
+    pub groups: Vec<TestGroup>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TestGroup {
+    /// Display label (relative path or "<crate>::<module>").
+    pub label: String,
+    /// Absolute, canonical path. Set ONLY when:
+    ///   - kind == File
+    ///   - the runner parser resolved it against CWD
+    ///   - the canonical path is contained inside the session CWD
+    /// None otherwise — frontend uses this to decide if the row is clickable.
+    /// Always JSON-serialised (null when absent); TS mirror is `string | null`.
+    pub path: Option<String>,
+    pub kind: TestGroupKind,
+    pub passed: u32,
+    pub failed: u32,
+    pub skipped: u32,
+    pub total: u32,
+    pub status: TestGroupStatus,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TestGroupKind { File, Suite, Module }
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TestGroupStatus { Pass, Fail, Skip }
+```
+
+### Status derivation rules
+
+| `parse_result` returned                         | `is_error` | Resulting `status`                                                                                                    |
+| ----------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------- |
+| `Some(summary)` with `failed > 0`               | any        | `Fail`                                                                                                                |
+| `Some(summary)` with `failed == 0 && total > 0` | any        | `Pass`                                                                                                                |
+| `Some(summary)` with `total == 0`               | any        | `NoTests`                                                                                                             |
+| `None`                                          | true       | `Error` (summary zeros, `output_excerpt` populated — see below)                                                       |
+| `None`                                          | false      | _no event emitted_ — we don't know what happened, don't fabricate signal. Debug-level log so this case is observable. |
+
+`output_excerpt` is constructed in `process_tool_result` after `parse_result` returns, NOT inside the per-runner parser. When the resulting status will be `Error`: take `out.content`, strip ANSI, take the first non-blank line(s) up to 240 chars (preferring the line containing `error:` / `Error:` / `FAIL` / `panicked` if present, else the first non-blank line), then run through `sanitize_for_ui` (see "Command preview & output sanitisation" below). For `Pass` / `Fail` / `NoTests`, `output_excerpt` is `None`.
+
+### `AgentToolCallEvent` extension
+
+```diff
+ #[serde(rename_all = "camelCase")]
+ pub struct AgentToolCallEvent {
+     pub session_id: String,
+     pub tool_use_id: String,
+     pub tool: String,
+     pub args: String,
+     pub status: ToolCallStatus,
+     pub timestamp: String,
+     pub duration_ms: u64,
++    /// Set true ONLY for Write/Edit tool calls whose input.file_path matches
++    /// a TEST_FILE pattern. Computed in process_assistant_message against
++    /// the FULL untruncated path (before summarize_input runs). False for
++    /// everything else. The TEST_FILE pattern list lives only on the Rust
++    /// side at agent/test_runners/test_file_patterns.rs — frontend reads
++    /// this flag, no JS-side glob.
++    pub is_test_file: bool,
+ }
+```
+
+### TypeScript mirror (`src/features/agent-status/types/index.ts`)
+
+```typescript
+export type TestRunStatus = 'pass' | 'fail' | 'noTests' | 'error'
+export type TestGroupKind = 'file' | 'suite' | 'module'
+export type TestGroupStatus = 'pass' | 'fail' | 'skip'
+
+export interface TestGroup {
+  label: string
+  // Rust serialises Option<String> as null (not omitted). Use explicit
+  // `string | null` so the boundary contract matches the wire shape.
+  path: string | null
+  kind: TestGroupKind
+  passed: number
+  failed: number
+  skipped: number
+  total: number
+  status: TestGroupStatus
+}
+
+export interface TestRunSummary {
+  passed: number
+  failed: number
+  skipped: number
+  total: number
+  groups: TestGroup[]
+}
+
+export interface TestRunSnapshot {
+  sessionId: string // PTY session id
+  runner: string // not a union — additive
+  commandPreview: string
+  startedAt: string
+  finishedAt: string
+  durationMs: number
+  status: TestRunStatus
+  summary: TestRunSummary
+  outputExcerpt: string | null
+}
+
+export interface AgentStatus {
+  // ...existing fields...
+  testRun: TestRunSnapshot | null
+}
+
+export interface RecentToolCall {
+  // ...existing fields...
+  isTestFile: boolean
+}
+```
+
+`createDefaultStatus(...)` at `useAgentStatus.ts:27` is updated to include `testRun: null`. Without this the panel reads `undefined` and the `?? :` chain in the renderer breaks. **Required code change**, not optional.
+
+## Bridge — runner registry, command identification, CWD threading
+
+### Module layout (new pattern)
+
+`src-tauri/src/agent/` today has no parser directory or trait abstraction — `statusline.rs` and `transcript.rs` parse inline. This spec introduces a _new_ registry-based pattern:
+
+```
+src-tauri/src/agent/test_runners/
+├── mod.rs                    # registry, shared types, matching algorithm
+├── types.rs                  # TestRunSnapshot, TestRunStatus, etc.
+├── script_resolution.rs      # package.json scripts.<name> resolution
+├── test_file_patterns.rs     # TEST_FILE_PATTERNS for is_test_file tagging
+├── timestamps.rs             # parse_iso8601_ms helper (no chrono dep)
+├── path_resolution.rs        # resolve_group_path with containment check
+├── vitest.rs                 # vitest matcher + result parser
+└── cargo.rs                  # cargo test matcher + result parser
+```
+
+Adding a new runner = one new file + one slice entry in `RUNNERS`.
+
+### Registry shape
+
+```rust
+pub struct CapturedOutput {
+    /// Joined text from tool_result.content. tool_result.content is either:
+    ///   - a plain string (most common for Bash) → used as-is
+    ///   - an array of content blocks: each block with type:"text" contributes
+    ///     its `text` field; non-text blocks are ignored.
+    /// Runners that put summaries on stderr (cargo, pytest) have them included
+    /// here because the Bash tool returns combined stdout+stderr in `content`.
+    pub content: String,
+    pub is_error: bool,
+}
+
+pub struct TestRunner {
+    pub name: &'static str,
+    pub matches: fn(tokens: &[&str]) -> bool,
+    pub parse_result: fn(out: &CapturedOutput, cwd: &Path) -> Option<TestRunSummary>,
+}
+
+pub static RUNNERS: &[&TestRunner] = &[&VITEST, &CARGO_TEST];
+```
+
+`parse_result` receives CWD so it can build absolute paths via `resolve_group_path` (see Path resolution below).
+
+### Matching algorithm (called only when `tool_name == "Bash"`)
+
+1. **Tokenize** raw `input.command` with the `shell-words` crate. On error → return None (no match, no false positive).
+2. **Strip leading env assignments** (`KEY=value` tokens before the first non-assignment).
+3. **Take only the first command segment** — split on `&&`, `;`, `||`, `|`, take tokens before the first separator. Multi-segment commands where the test invocation isn't first (`cargo build && cargo test`) are silently ignored in v1.
+4. **Strip wrapper prefixes** in one pass: `npx`, `pnpm exec`, `yarn` (when followed by `exec`), `bun x`, `dotenv --`.
+5. **Script-alias resolution.** Only for these exact shapes:
+   - `npm test` | `npm run <name>`
+   - `yarn test` | `yarn run <name>`
+   - `pnpm test` | `pnpm run <name>`
+   - `bun run <name>` ← **NOT `bun test`**: that invokes Bun's built-in test runner, not a script. Adding a `BUN` runner is future work; for v1 `bun test` matches nothing and is ignored.
+
+   For matched shapes, read `<cwd>/package.json`, look up `scripts[<name>]`. If found, **recurse** on the resolved string. **Bound recursion to depth 3** to defend against alias loops.
+
+6. **Match against `RUNNERS`.** First `matches(tokens)` returning true wins. Each matcher inspects only what it needs (`vitest`: `tokens[0] == "vitest"`; `cargo`: `tokens[0] == "cargo" && tokens[1] == "test"`).
+7. **No match → ignore.** Bash tool call still flows through the existing pipeline; we just don't tag it.
+
+### `InFlightToolCall` extension
+
+```diff
+ struct InFlightToolCall {
+     started_at: Instant,
+     tool: String,
+     args: String,
++    /// Set during process_assistant_message when a Bash tool_use's command
++    /// matches a runner. Used in process_tool_result to drive parse_result.
++    test_runner: Option<&'static TestRunner>,
++    /// Raw command (pre-summarization), retained internally for snapshot
++    /// construction. NEVER emitted directly — see Command preview.
++    raw_command: Option<String>,
+ }
+```
+
+### CWD threading
+
+Today `TranscriptWatcher` carries only `transcript_path`. Script-alias resolution and per-file path resolution both need CWD inside `tail_loop`. Required changes:
+
+```diff
+ struct TranscriptWatcher {
+     transcript_path: PathBuf,
++    cwd: Option<PathBuf>,        // resolved workspace CWD; None = no resolution
+     handle: TranscriptHandle,
+ }
+
+ pub fn start_tailing<R: tauri::Runtime>(
+     app_handle: tauri::AppHandle<R>,
+     session_id: String,
+     transcript_path: PathBuf,
++    cwd: Option<PathBuf>,
+ ) -> Result<TranscriptHandle, String>;
+
+ fn tail_loop<R: tauri::Runtime>(
+     app_handle: tauri::AppHandle<R>,
+     session_id: String,
++    cwd: Option<PathBuf>,
+     file: File,
+     stop_flag: Arc<AtomicBool>,
+ );
+```
+
+`watcher.rs` already resolves the PTY's CWD (fixed in #60); it threads it into `TranscriptState::start` / `start_or_replace`. When CWD is `None`, script-alias resolution and per-file path resolution are both skipped — direct-binary matches (`vitest`, `cargo test`) still work; aliased forms (`npm test`) silently miss; group `path` stays `None`. This degradation is acceptable and produces no false matches.
+
+### Command preview & output sanitisation (security)
+
+The raw `input.command` is **not** emitted. It's retained on `InFlightToolCall.raw_command` for matching only. The snapshot carries `command_preview`, constructed from the matcher's already-stripped tokens and then run through a shared `sanitize_for_ui` function. The same sanitiser also runs over `output_excerpt` before emission.
+
+```rust
+// agent/test_runners/sanitiser.rs
+
+const MAX_PREVIEW_LEN: usize = 120;
+const REDACTED: &str = "[REDACTED]";
+
+/// Conservative redaction for content shown in the UI. Catches the common
+/// shapes; not a comprehensive secret scanner. Applied to BOTH command_preview
+/// and output_excerpt so the same heuristics protect both surfaces.
+///
+/// Patterns redacted (each match replaced with [REDACTED]):
+///   - KEY=value where KEY is [A-Z][A-Z0-9_]{2,} (env-style assignments)
+///   - "Bearer <token>" (case-insensitive)
+///   - "Authorization: <value>" (case-insensitive)
+///   - Stripe/etc-style keys: (sk|pk|rk)_(live|test)_<16+ alnum>
+///   - JWT-like tokens: eyJ<base64ish>
+///
+/// The matcher's env-strip (steps 2/4) already removes leading "KEY=val" tokens
+/// from command_preview, but flags / positional args / test output can still
+/// surface secrets — e.g. `vitest run --some-flag sk_live_xxx` or a failing
+/// assertion that prints `process.env.STRIPE_KEY`. This catches those.
+pub fn sanitize_for_ui(input: &str) -> String { ... }
+
+fn build_command_preview(stripped_tokens: &[&str]) -> String {
+    let joined = stripped_tokens.join(" ");
+    let sanitized = sanitize_for_ui(&joined);
+    truncate_string(&sanitized, MAX_PREVIEW_LEN)  // existing helper at transcript.rs:509
+}
+```
+
+What this still doesn't catch (documented limitation): novel custom-prefix API keys, arbitrary base64/hex blobs that happen to be secrets, secrets passed as flag _names_, secrets in URLs (`?token=xxx`). Threat model: best-effort to avoid the common cases, not a comprehensive DLP scan. If a user pastes a custom-prefix secret into their test output, it may surface in `output_excerpt`. Acceptable for v1.
+
+### Test-file pattern matching
+
+`agent/test_runners/test_file_patterns.rs` exposes a static slice of patterns:
+
+```rust
+pub static TEST_FILE_PATTERNS: &[&str] = &[
+    // **/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs}
+    // **/*_test.rs, **/tests/**/*.rs (cargo convention)
+    // **/test_*.py, **/*_test.py (pytest convention)
+    // **/*_test.go (go test convention)
+];
+
+pub fn is_test_file(path: &str) -> bool { ... }  // glob match against patterns
+```
+
+Used in `process_assistant_message` for Write/Edit tool calls to set `event.is_test_file = true`. Match is performed on the **full untruncated `file_path`** before `summarize_input` truncates.
+
+### Per-runner `parse_result` contract
+
+```rust
+pub static VITEST: TestRunner = TestRunner {
+    name: "vitest",
+    matches: |t| t.first().is_some_and(|s| *s == "vitest"),
+    parse_result: parse_vitest_output,
+};
+
+fn parse_vitest_output(out: &CapturedOutput, cwd: &Path) -> Option<TestRunSummary> {
+    // 1. Strip ANSI escapes from out.content.
+    // 2. Find canonical summary lines:
+    //      Test Files  3 passed (3)
+    //           Tests  47 passed | 2 failed | 1 skipped (50)
+    // 3. Parse per-file lines: " ✓ src/foo.test.ts (12)"  /  " ✗ src/bar.test.ts (8 | 3 failed)"
+    // 4. For each file group: label = relative path; path = resolve_group_path(cwd, label).
+    // 5. Build TestRunSummary, enforcing total == passed + failed + skipped per group AND summary.
+    // 6. Cap groups at MAX_GROUPS = 500 (cumulative counts in summary stay accurate).
+}
+```
+
+Same shape for `cargo.rs` (cargo writes its summary to stderr; `CapturedOutput.content` carries combined stdout+stderr).
+
+### Path resolution with containment check
+
+```rust
+// agent/test_runners/path_resolution.rs
+
+pub fn resolve_group_path(cwd: &Path, label: &str) -> Option<String> {
+    // Reject obvious escape attempts before touching the filesystem.
+    if label.contains("..") || Path::new(label).is_absolute() {
+        return None;
+    }
+    let candidate = cwd.join(label).canonicalize().ok()?;
+    let cwd_canonical = cwd.canonicalize().ok()?;
+    // Defends against runner-emitted symlinks pointing outside the workspace
+    // and any future runner whose label could include "../../etc/passwd"
+    // even if we already stripped ".." above.
+    if !candidate.starts_with(&cwd_canonical) {
+        return None;
+    }
+    Some(candidate.display().to_string())
+}
+```
+
+`group.path` is `None` when the check fails — frontend renders the row non-clickable.
+
+### Duration computation
+
+Duration is computed from **transcript timestamps**, not the parser-time `Instant`. Replay would otherwise stamp every replayed run with parser-cost duration (near-zero) and a fresh live run with whatever `Instant::elapsed` reports inside the parser (also near-zero).
+
+```rust
+// agent/test_runners/timestamps.rs
+
+/// Parse "YYYY-MM-DDTHH:MM:SS[.sss]Z" → milliseconds since Unix epoch.
+/// Returns None on parse failure (no chrono dep — manual parse, mirrors
+/// the inverse of now_iso8601() / days_to_date() already in transcript.rs).
+pub fn parse_iso8601_ms(s: &str) -> Option<u64>;
+
+pub fn compute_duration_ms(
+    started_at_iso: &str,
+    finished_at_iso: &str,
+    fallback: Duration,
+) -> u64 {
+    match (parse_iso8601_ms(started_at_iso), parse_iso8601_ms(finished_at_iso)) {
+        (Some(start), Some(end)) if end >= start => end - start,
+        _ => {
+            log::debug!("Falling back to Instant::elapsed for test-run duration");
+            fallback.as_millis() as u64
+        }
+    }
+}
+```
+
+## Bridge — emission lifecycle
+
+### Replay batching
+
+The existing `tail_loop` reads the transcript from the beginning, hits EOF, then polls. We use the **first EOF as the replay-done marker.** A per-tail-loop helper buffers during replay:
+
+```rust
+struct TestRunEmitter<'a, R: tauri::Runtime> {
+    app_handle: &'a tauri::AppHandle<R>,
+    replay_done: bool,
+    pending: Option<TestRunSnapshot>,   // latest seen during replay
+}
+
+impl<'a, R: tauri::Runtime> TestRunEmitter<'a, R> {
+    fn submit(&mut self, snapshot: TestRunSnapshot) {
+        if self.replay_done {
+            let _ = self.app_handle.emit("test-run", &snapshot);
+        } else {
+            self.pending = Some(snapshot); // latest wins, older ones dropped
+        }
+    }
+    fn finish_replay(&mut self) {
+        if self.replay_done { return; }   // idempotent
+        self.replay_done = true;
+        if let Some(s) = self.pending.take() {
+            let _ = self.app_handle.emit("test-run", &s);
+        }
+    }
+}
+```
+
+`tail_loop` flow:
+
+```rust
+let mut emitter = TestRunEmitter { app_handle: &app_handle, replay_done: false, pending: None };
+loop {
+    match reader.read_line(...) {
+        Ok(0) => {
+            emitter.finish_replay();   // first EOF flips the switch
+            sleep(POLL_INTERVAL);
+        }
+        Ok(_) => process_line(line, ..., &mut emitter, ...),
+        Err(_) => sleep(POLL_INTERVAL),
+    }
+}
+```
+
+`process_tool_result`, after building a `TestRunSnapshot`, calls `emitter.submit(snapshot)`. `agent-tool-call` events stay direct-emit — only `test-run` is batched, since it's the only event whose visible output flickers if many fire in succession.
+
+**Guarantees:**
+
+- After a fresh tail (app start, session switch): the visible snapshot equals the latest matched test run in the transcript, emitted _once_ after replay completes. Zero flicker.
+- During live tailing (after first EOF): every new matched run emits immediately.
+- A session whose transcript has zero matched runs emits nothing — panel stays in `no runs yet`.
+- A session whose only matched run was a runner-error: `status: 'error'`, `output_excerpt` populated, panel renders the runner badge + error state.
+
+### Listener-attach ordering (load-bearing for v1)
+
+Because we have **no backend snapshot cache in v1**, the frontend listener for `test-run` MUST be attached before the transcript watcher's replay completes. Otherwise the latest-of-replay emit (the only source of historical state) is lost forever for that session.
+
+The existing `useAgentStatus` flow already provides this:
+
+```
+useAgentStatus effect runs
+   └─ subscribe() async block
+       └─ await listen('agent-status', ...)        ✓ attached
+       └─ await listen('agent-tool-call', ...)     ✓ attached
+       └─ await listen('test-run', ...)            ✓ attached  (NEW)
+   └─ handleDetection(sessionId)                   ← runs only after subscribe resolves
+       └─ invoke('start_agent_watcher', ...)
+           └─ (Rust) statusline bridge eventually fires
+               └─ TranscriptState::start_or_replace
+                   └─ start_tailing → tail_loop → EOF → emitter.finish_replay()
+```
+
+Adding the `test-run` listener inside the existing `subscribe()` block (alongside `agent-status` and `agent-tool-call`) is sufficient to inherit the ordering. **This is a load-bearing invariant**, covered by a regression test (see Test plan).
+
+## UI
+
+### Component shape
+
+```tsx
+// src/features/agent-status/components/TestResults.tsx
+
+interface TestResultsProps {
+  snapshot: TestRunSnapshot | null
+  onOpenFile?: (path: string) => void // GUARDED entry point — see below
+}
+
+export const TestResults = ({
+  snapshot,
+  onOpenFile,
+}: TestResultsProps): ReactElement => {
+  if (snapshot === null) return <TestResultsPlaceholder />
+  return <TestResultsLive snapshot={snapshot} onOpenFile={onOpenFile} />
+}
+```
+
+Both internal sub-components live in the same file. External callers always render `<TestResults>` and pass `snapshot`.
+
+### `AgentStatusPanel` changes
+
+```diff
+-const placeholderTests = { passed: 0, failed: 0, total: 0 }
+-
+ interface AgentStatusPanelProps {
+   sessionId: string | null
+   cwd: string
+   onOpenDiff: (file: ChangedFile) => void
++  onOpenFile?: (path: string) => void
+ }
+
+-<TestResults
+-  passed={placeholderTests.passed}
+-  failed={placeholderTests.failed}
+-  total={placeholderTests.total}
+-/>
++<TestResults snapshot={status.testRun} onOpenFile={onOpenFile} />
+```
+
+### Safe file open (the dirty-state hazard)
+
+`WorkspaceView.openFileSafely` at line 112 explicitly **bypasses** the unsaved-changes guard — its docstring says so. Wiring `onOpenFile={openFileSafely}` would silently discard user edits. Wrong.
+
+Instead, `WorkspaceView` exposes a _new_ handler that mirrors the proven pattern at `handleFileSelect:144`:
+
+```typescript
+const handleOpenTestFile = useCallback(
+  (filePath: string): void => {
+    if (editorBuffer.isDirty) {
+      setPendingFilePathSynced(filePath)
+      setShowUnsavedDialog(true)
+      return
+    }
+    void openFileSafely(filePath)
+  },
+  [editorBuffer.isDirty, openFileSafely, setPendingFilePathSynced]
+)
+```
+
+Then `<AgentStatusPanel onOpenFile={handleOpenTestFile} />`. The unsaved-dialog flow (`handleSave` / `handleDiscard` / `handleCancel`) already handles pending-path resumption — no new code there.
+
+### Path passed to `onOpenFile`
+
+`TestResults` calls `onOpenFile(group.path)` only when `group.kind === 'file' && group.path !== null`. The `path` field is the absolute, contained, canonical path resolved by the Rust runner parser. The display label (`group.label`) stays relative for compactness; only the resolved path goes to `openFile`. If `path` is `null` (resolution failed, escape rejected, or kind is suite/module), the row renders as a non-interactive `<div>`.
+
+This guarantees:
+
+- vitest's `src/foo.test.ts` → resolved to `/abs/path/to/repo/src/foo.test.ts` → Tauri `read_file` accepts it.
+- cargo's `vimeflow_lib::agent::tests` → kind `module`, `path: null` → not clickable.
+- A vitest path that doesn't exist on disk anymore → resolution fails → `path: null` → not clickable (better than a broken click).
+- A malicious `../../../etc/passwd` label → containment check rejects → `path: null` → not clickable.
+
+### Visual states
+
+**Placeholder** — one dim row, no chevron, no expand interaction:
+
+```
+TESTS  no runs yet
+```
+
+`text-on-surface-variant`, `font-mono text-[10px]`, ~20px tall. `role="status"` for screen readers.
+
+**Live header (collapsed)**:
+
+```
+▶ TESTS  47/50  · vitest  · 1.4s
+```
+
+Composition uses **only existing tailwind tokens** (verified in `tailwind.config.js`):
+
+| Element                | Token                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| Status dot — pass      | `bg-success`                                                                                             |
+| Status dot — fail      | `bg-error`                                                                                               |
+| Status dot — error     | `bg-tertiary` (no `warning` token; `tertiary` is the closest amber/pink in the palette — see Future #14) |
+| Status dot — noTests   | `bg-on-surface-variant`                                                                                  |
+| Count text             | `text-on-surface`                                                                                        |
+| Runner pill / duration | `text-on-surface-variant`                                                                                |
+
+**Live header is its own collapsible button**, not a `CollapsibleSection`. The existing `CollapsibleSection` API only exposes `title` and `count`; we need dot + runner + duration too. Inlining the button keeps `CollapsibleSection` stable. Native `<button type="button">` activation is sufficient — **no manual Enter/Space `onKeyDown` handler** (which would risk double-toggling because the browser also synthesises `click` on Space-up).
+
+```tsx
+const bodyId = useId()  // unique per instance — required for parameterised test renders
+const [expanded, setExpanded] = useState(false)
+
+<button
+  type="button"
+  aria-expanded={expanded}
+  aria-controls={bodyId}
+  onClick={() => setExpanded((v) => !v)}
+>
+  ...header content...
+</button>
+<div id={bodyId} hidden={!expanded}>
+  ...body...
+</div>
+```
+
+**Live header (expanded body)**:
+
+```
+▼ TESTS  47/50  · vitest  · 1.4s
+   [ pass ████████████  fail ██  skip █ ]
+   47 passed, 2 failed, 1 skipped
+   ✓  src/foo.test.ts            12/12
+   ✗  src/bar.test.ts             5/8
+   ⊘  src/baz.test.ts             0/3 skipped
+```
+
+**Bar is a 3-part proportional bar**, not per-test segments. Three flex children with `flex-grow: passed | failed | skipped`. Constant DOM regardless of suite size.
+
+```tsx
+<div className="flex h-[3px] w-full overflow-hidden rounded-full">
+  {passed > 0 && <div style={{ flexGrow: passed }} className="bg-success" />}
+  {failed > 0 && <div style={{ flexGrow: failed }} className="bg-error" />}
+  {skipped > 0 && (
+    <div style={{ flexGrow: skipped }} className="bg-on-surface-variant/40" />
+  )}
+</div>
+```
+
+**Status-specific live body**:
+
+| `snapshot.status` | Body                                                                                                        |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| `pass`            | bar + `47 passed`, group rows green                                                                         |
+| `fail`            | bar + `45 passed, 2 failed`, group rows mixed                                                               |
+| `noTests`         | no bar, summary `no tests collected`, no group rows                                                         |
+| `error`           | no bar, summary text = `snapshot.outputExcerpt ?? 'runner errored before producing results'`, no group rows |
+
+### Group rows
+
+- Status icon (`✓ ✗ ⊘`) in the runner status colour
+- Label (file path or `<crate>::<module>`) — `font-mono text-[11px]`, truncated with `text-ellipsis`
+- Right-aligned count `passed/total` (and `skipped` suffix when nonzero)
+- Click behaviour:
+  - `kind === 'file' && path !== null && onOpenFile` defined → row is `<button type="button" aria-label={"Open " + label}>`, calls `onOpenFile(group.path)`. `cursor-pointer` + `hover:bg-surface-container-high`.
+  - Otherwise → row is `<div>`, no `cursor-pointer`, no click handler.
+
+### Accessibility
+
+- Placeholder row: `role="status"`, `aria-live="polite"` (one-shot announce on transition to live).
+- Live header: native `<button type="button" aria-expanded aria-controls={useId()}>`; activation by Enter and Space goes through native semantics — no custom handler.
+- Group rows: `<button>` only when interactive; `<div>` when not. Status colours always paired with an icon glyph (`✓ ✗ ⊘`), never colour-only.
+- Per `rules/typescript/testing/a11y-queries.md`: tests use `getByRole`/`getByText`. One `data-testid="test-results"` on the wrapper for outer integration tests only.
+
+## Test creation signal (activity feed)
+
+Per Q4: surfaces in the activity feed, not the TESTS panel. **Backend-driven**, not render-layer glob:
+
+1. `process_assistant_message` checks `tool_name in ["Write", "Edit"]` AND `is_test_file(input.file_path)` (full untruncated path). Sets `event.is_test_file = true` on the emitted `AgentToolCallEvent`.
+2. `useAgentStatus` maps `AgentToolCallEvent` → `RecentToolCall`, propagating `isTestFile: boolean`.
+3. `toolCallsToEvents` (`toolCallsToEvents.ts:75`) propagates the flag to `ActivityEvent.isTestFile`.
+4. `ActivityEvent` renderer prepends a `🧪` glyph and selects the verb based on the existing `tool` field:
+
+```typescript
+const verb = event.tool === 'Edit' ? 'Updated test' : 'Created test'
+```
+
+**Documented limitation:** `Write` tool calls can either create a new file or overwrite an existing one; we label both as "Created". A precise create/update distinction would require either a backend pre-check of existence (race-prone) or per-session path memoisation (state we don't otherwise need). Acceptable for v1; revisit if the mislabel turns out to be confusing. The upgrade path — a `testFileAction: 'created' | 'updated' | 'touched'` enum on `AgentToolCallEvent` — is in the Future Work table.
+
+No frontend glob, no drift between layers, no truncation hazard.
+
+## Test plan
+
+### Rust — unit tests
+
+- `tokenize_command` — shellwords success/failure, env-strip, wrapper-strip (`npx`, `pnpm exec`, `yarn`, `bun x`, `dotenv --`), segment-split (`&&`, `;`, `||`, `|`)
+- `resolve_script_alias` — happy path, missing script, depth-3 loop bound, missing CWD → None, `bun test` is **not** treated as alias (reserved for future Bun runner)
+- Per-runner `matches()` — vitest positive (`vitest run …`) + negative (`git diff test.txt`, `eslint test/`); cargo positive (`cargo test …`) + negative (`cargo build`)
+- `parse_iso8601_ms` — `2026-04-27T15:23:45Z`, `2026-04-27T15:23:45.123Z`, malformed → None
+- `compute_duration_ms` — both valid, end-before-start → fallback, malformed → fallback
+- `build_command_preview` — env-stripped tokens preserved, truncation at 120 chars (multi-byte safe via existing `truncate_string`)
+- `sanitize_for_ui` — `KEY=value` redacted, `Bearer xxx` redacted, `Authorization:` redacted, `sk_live_…` / `pk_test_…` redacted, `eyJ…` JWT redacted; clean strings unchanged; sanitiser applied to both `command_preview` and `output_excerpt` paths
+- `resolve_group_path` — `..`-escape rejected, absolute label rejected, symlink escape rejected (canonical containment check), valid relative path resolved against CWD
+- Per-runner `parse_result` — pass / mixed / all-fail / no-tests-collected / compile-error / skipped tests; invariant `passed + failed + skipped == total` per group and per summary; group cap respected at `MAX_GROUPS`
+- `TestRunEmitter::submit` during replay — multiple submits collapse to latest
+- `TestRunEmitter::finish_replay` — idempotent; submit-after-finish emits immediately
+- `is_test_file` matcher — full untruncated paths like `src/foo.test.ts`, `crates/x/src/bar/baz_test.rs`, `tests/test_qux.py` match; non-test paths (`src/foo.ts`, `tests-helper.ts`) don't
+
+### Rust — integration tests (fixture JSONL transcripts under `src-tauri/tests/fixtures/`)
+
+- `transcript_vitest_pass.jsonl` — 3 historical runs + 1 live → exactly 2 `test-run` emits (latest-of-replay, then live), correct `runner: 'vitest'`, correct counts
+- `transcript_vitest_no_tests.jsonl` — `vitest --passWithNoTests` → one emit with `status: 'noTests'`, `summary.total == 0`
+- `transcript_compile_error.jsonl` — `is_error: true`, parser returns None → one emit with `status: 'error'`, `outputExcerpt` populated
+- `transcript_cargo_mixed.jsonl` — pass + fail + ignored, summary counts and groups correct, group `kind: 'module'`, `path: null`
+- `transcript_mixed_bash.jsonl` — interleaved Bash calls (test + non-test) → only matched calls emit `test-run`; non-test Bash calls flow through `agent-tool-call` unchanged
+- `transcript_test_file_creation.jsonl` — `Write` and `Edit` of test paths → `agent-tool-call` events have `isTestFile: true`; non-test `Write` has `isTestFile: false`
+
+### TypeScript — component tests (Vitest + RTL)
+
+- `<TestResults snapshot={null} />` — placeholder text, `role="status"`, no chevron, no expand
+- `<TestResults snapshot={passSnap} />` header — counts, success dot, runner pill, formatted duration
+- `<TestResults snapshot={failSnap} />` expanded — proportional 3-part bar, group rows include failing file with `✗`, summary text reads `X passed, Y failed`
+- `<TestResults snapshot={noTestsSnap} />` — no bar rendered, summary `no tests collected`, no group rows
+- `<TestResults snapshot={errorSnap} />` — summary uses `outputExcerpt` when present; falls back to default message
+- `<TestResults snapshot={mixedWithSkips} />` — 3-part bar visible; summary includes `skipped` clause; group rows show skipped counts
+- Group row click — `kind: 'file'`, `path !== null`, `onOpenFile` defined → renders as `<button>`, calls `onOpenFile(group.path)` once
+- Group row — `path === null` → renders as `<div>`, no `onOpenFile` invocation possible
+- Group row — `kind: 'suite' | 'module'` → renders as `<div>`, no `cursor-pointer`
+- Native button keyboard activation — `userEvent.keyboard('{Enter}')` and `userEvent.keyboard(' ')` toggle expand without any custom handler
+- Multiple `<TestResults>` in one render — `useId`-derived `aria-controls` are unique per instance
+- `<TestResults>` axe-clean — no a11y violations across all five state snapshots
+
+### TypeScript — workspace integration
+
+- `WorkspaceView.handleOpenTestFile` clean buffer → calls `openFileSafely(filePath)`
+- `WorkspaceView.handleOpenTestFile` dirty buffer → calls `setPendingFilePathSynced(filePath)` + `setShowUnsavedDialog(true)`; does **not** call `openFileSafely`
+- Existing dialog flow (`handleSave` / `handleDiscard`) resumes the pending test-file open correctly (extending existing tests, not new ones)
+
+### TypeScript — hook & event wiring
+
+- `useAgentStatus` — `test-run` event with `payload.sessionId === resolvedPtyId` updates `status.testRun`
+- `useAgentStatus` — `test-run` event with mismatched id is ignored
+- `useAgentStatus` — `createDefaultStatus(sessionId).testRun === null`
+- `useAgentStatus` — sessionId change resets `status.testRun` to null along with the rest of the default
+- **Listener-ordering regression** — mock `invoke` and `listen`; assert that `listen('test-run', …)` resolves before `invoke('start_agent_watcher', …)` fires. This is the load-bearing correctness hinge for v1's no-cache design.
+
+### TypeScript — activity feed
+
+- `Write` tool-call event with `isTestFile: true` renders label `Created test: <basename>` with the test glyph
+- `Edit` tool-call event with `isTestFile: true` renders label `Updated test: <basename>` with the test glyph
+- Tool-call event with `isTestFile: false` renders default label, no glyph
+- `RecentToolCall.isTestFile` propagates through `toolCallsToEvents` to `ActivityEvent.isTestFile`
+
+## Out of scope for v1
+
+| #   | Item                                                                                                 | Rationale                                                                                                                                                                                                      | Upgrade path                                                                                                                     |
+| --- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Ask-Claude CTA** (Q6 option C — button next to placeholder that injects a prompt)                  | Non-trivial: needs session targeting, prompt template, mid-task safety. Worth a separate spec.                                                                                                                 | Add a `<TestResultsPlaceholderCTA>` variant; new IPC command to inject text into the active PTY session.                         |
+| 2   | **Backend snapshot cache + `get_latest_test_snapshot` command**                                      | Same gap exists for `recentToolCalls` today; not new.                                                                                                                                                          | `HashMap<session_id, TestRunSnapshot>` in `TranscriptState`; one Tauri command; hook calls it on mount before subscribing.       |
+| 3   | **More runners** (`jest`, `mocha`, `pytest`, `go test`, `bun test`, `deno test`, `rspec`, `phpunit`) | Allowlist scopes risk; this project uses vitest + cargo.                                                                                                                                                       | One new file under `test_runners/` + one slice entry per runner.                                                                 |
+| 4   | **User-extensible runner registry** (`.vimeflow/test-runners.json`)                                  | YAGNI until a user asks for `make test`-style wrappers.                                                                                                                                                        | Read at `TranscriptState::start`, merge entries into `RUNNERS`.                                                                  |
+| 5   | **Multi-segment commands** (`cargo build && cargo test`)                                             | First segment only in v1.                                                                                                                                                                                      | Walk all segments, match each independently, use the last matched run.                                                           |
+| 6   | **`bash -c "vitest"` indirection**                                                                   | Rare; needs sub-shell tokenisation.                                                                                                                                                                            | Recurse on the inner string when `tokens[0..3] == ["bash", "-c", _]`.                                                            |
+| 7   | **Workspace tools** (`pnpm -F pkg test`)                                                             | Requires per-package `package.json` walks.                                                                                                                                                                     | Detect `-F`/`--filter`/`-w`/`--workspace`; resolve script in target package's `package.json`.                                    |
+| 8   | **Tests run outside the integrated PTY**                                                             | Bridge is intentionally agent-scoped.                                                                                                                                                                          | Filesystem watcher for runner report files; merged into `TestRunSnapshot` as a separate signal source.                           |
+| 9   | **Failure messages / stack frames in expanded view** (Q4 option C)                                   | v1 = per-file counts only.                                                                                                                                                                                     | Extend per-runner parser to capture `failures: Vec<TestFailure>`; render in collapsible sub-row.                                 |
+| 10  | **Test creation as a panel counter**                                                                 | Activity feed surface is enough; keeps panel focused on run state.                                                                                                                                             | Add `testFilesCreated: number` to `TestRunSnapshot` or `AgentStatus`; render as secondary badge.                                 |
+| 11  | **Precise `created` vs `updated` for test files**                                                    | v1 approximation: Write→Created, Edit→Updated.                                                                                                                                                                 | Backend tracks `HashSet<PathBuf>` of test files seen this session; emits `testFileAction: 'created' \| 'updated'` enum on event. |
+| 12  | **`testFileAction` enum on `AgentToolCallEvent`**                                                    | v1 uses `is_test_file: bool` + tool name; sufficient.                                                                                                                                                          | See #11.                                                                                                                         |
+| 13  | **Storybook stories**                                                                                | No Storybook setup in repo.                                                                                                                                                                                    | Add Storybook in a separate scaffolding task; port the five state stories.                                                       |
+| 14  | **`warning` semantic Tailwind token (project-wide)**                                                 | v1's rewritten `TestResults.tsx` uses verified tokens only (`tertiary` for the amber error-state dot, no `text-warning`). Adding a real `warning` token across the rest of the codebase is a separate cleanup. | Add `warning` and `on-warning` to `tailwind.config.js`; sweep the codebase for `text-warning` / `bg-warning` usages and migrate. |
+| 15  | **`kind: 'test-file-creation'` derived event** in `useActivityEvents`                                | v1 reads `event.isTestFile` at render time; minimal.                                                                                                                                                           | Add `kind?: 'test-file-creation' \| 'test-file-edit'` to `ActivityEvent`, set in `toolCallsToEvents`.                            |
+| 16  | **Cross-language fixture for test-file pattern drift**                                               | N/A in v1 — patterns live only on Rust side.                                                                                                                                                                   | Becomes relevant if frontend ever adds its own glob; cross-layer fixture test.                                                   |
+
+## Risks & mitigations
+
+| #   | Risk                                                                                                                                                                      | Likelihood | Impact | Mitigation                                                                                                                                                                                                                  |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | Listener-attach race — `test-run` listener not yet active when transcript replay's batched emit fires; latest-of-replay snapshot lost forever for that session.           | Low        | Medium | Existing `subscribe() → handleDetection()` ordering in `useAgentStatus`; load-bearing invariant covered by the listener-ordering regression test.                                                                           |
+| R2  | Replay flicker — many historical runs emitting in succession.                                                                                                             | Low        | Low    | `TestRunEmitter` latest-wins batching; verified by 3-historical-+-1-live fixture test.                                                                                                                                      |
+| R3  | Stdout parser drift — vitest or cargo changes its summary line format in a future version, and we silently stop matching → snapshots become `status: 'error'` everywhere. | Medium     | Medium | Per-runner unit tests on captured fixtures; spec calls out that runner version bumps in `package-lock.json` / `Cargo.lock` should trigger fixture review. Comment near each parser cites the version it was tested against. |
+| R4  | Malicious or weird runner labels (`../../etc/passwd`, absolute paths, symlinks) being clickable.                                                                          | Low        | High   | `resolve_group_path` rejects `..`, absolute labels, and post-canonicalize escapes via containment check. Unit-tested.                                                                                                       |
+| R5  | Secrets leaking via the command preview when secrets are in flag values or positional args (env-prefix case is already handled).                                          | Low        | Medium | Documented as out-of-threat-model; flag-value redaction would be heuristic and brittle.                                                                                                                                     |
+| R6  | Memory blowup on huge test suites (`TestRunSummary.groups` grows unbounded).                                                                                              | Low        | Medium | Cap `groups` at `MAX_GROUPS = 500` in each parser; spec calls out the cap. Counts in `summary.{passed,failed,skipped,total}` stay accurate even when groups list is truncated.                                              |
+| R7  | Skipped tests miscounted as failures or passes — runners differ in `ignored` / `skipped` / `pending` terminology.                                                         | Medium     | Low    | Explicit per-runner unit tests for skipped output; invariant `passed + failed + skipped == total` enforced in parser tests.                                                                                                 |
+| R8  | Session-id mix-up (workspace vs PTY) — a stale snapshot persists across PTY reset.                                                                                        | Low        | Low    | `useAgentStatus` already resets `status` (including `testRun: null`) on `sessionId` change; same code path.                                                                                                                 |
+| R9  | Test runner exits cleanly with no parseable output — no event emitted, user wonders why nothing showed up.                                                                | Low        | Low    | Documented behaviour. Debug-level log in `process_tool_result` when a recognised runner produces unparseable output.                                                                                                        |
+| R10 | Test-file glob false positives (e.g., `tests-helper.ts` matching `**/test*`).                                                                                             | Low        | Low    | Strict patterns: `**/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs,rs,py,go}`. No broader globs.                                                                                                                                     |
+| R11 | `text-warning` carried forward into the rewritten `TestResults.tsx` (the existing file uses it; tailwind silently drops unknown classes).                                 | Low        | Low    | The v1 rewrite of `TestResults.tsx` uses verified tokens only — no `text-warning` in the new component or its tests. Stale `text-warning` usages elsewhere in the codebase are out of v1 scope (Future #14).                |
+
+## Implementation order (suggested)
+
+1. **Rust — types & test_runners module skeleton** (no parser logic yet). Wire `RUNNERS` slice with stub `VITEST` and `CARGO_TEST`. Compile-only.
+2. **CWD threading** — extend `TranscriptWatcher`, `start_tailing`, `tail_loop` signatures. `watcher.rs` passes the resolved CWD through.
+3. **`AgentToolCallEvent.is_test_file` + test_file_patterns.rs** — pattern matcher and renderer-agnostic flag. Smallest backend-frontend slice; verifies the wire shape.
+4. **Matching algorithm + `InFlightToolCall` extension** — tokenize, strip, resolve scripts, recurse, match. Unit tests.
+5. **vitest parser + fixture transcript test.** First end-to-end emission.
+6. **`TestRunEmitter` + replay batching.** Flicker-free historical playback.
+7. **Listener-ordering regression test (TS).** Lock the correctness invariant.
+8. **`<TestResults>` rewrite + `AgentStatusPanel` wiring.** All five visual states.
+9. **`WorkspaceView.handleOpenTestFile` + onOpenFile flow.** Guarded file open.
+10. **cargo parser + cargo fixture.** Second runner; validates the registry abstraction.
+11. **Activity feed glyph + verb mapping.** `isTestFile` rendering.
+
+Each step lands as its own PR, reviewable in isolation. Steps 1–7 are pure backend + hook plumbing; the user sees nothing change visually until step 8.

--- a/feature_list.json
+++ b/feature_list.json
@@ -2,234 +2,174 @@
   {
     "id": 1,
     "phase": 1,
-    "category": "scaffold",
-    "description": "Exclude noisy paths from Vite HMR watch",
+    "category": "backend-types",
+    "description": "Rust types and module skeleton — Create test_runners module with TestRunSnapshot, TestRunStatus, TestRunSummary, TestGroup types and stub VITEST/CARGO_TEST runners",
     "steps": [
-      "Read current vite.config.ts to confirm structure",
-      "Add server.watch.ignored for .vimeflow/, target/, .codex*/, .git/",
-      "Run type-check and lint to verify changes",
-      "Commit with message: fix(vite): exclude .vimeflow/, target/, .codex*/, .git/ from HMR watch"
+      "Add shell-words, regex, once_cell dependencies",
+      "Create types.rs with all data structures",
+      "Create stub vitest.rs and cargo.rs with matchers",
+      "Wire module into agent/mod.rs",
+      "Add smoke tests for matchers"
     ],
-    "passes": true,
+    "passes": false,
     "dependencies": []
   },
   {
     "id": 2,
-    "phase": 2,
-    "category": "data models",
-    "description": "Add Rust SessionCache module with atomic write + in-memory mirror",
+    "phase": 1,
+    "category": "backend-plumbing",
+    "description": "CWD threading through TranscriptWatcher — Add cwd: Option<PathBuf> to TranscriptWatcher, thread through start_tailing and tail_loop for script resolution and path resolution",
     "steps": [
-      "Add tempfile dependency to Cargo.toml",
-      "Declare cache module in terminal/mod.rs",
-      "Create cache.rs with CachedSession, SessionCacheData, SessionCache types",
-      "Implement load(), snapshot(), mutate() methods with atomic disk write via tempfile",
-      "Write and run tests: empty load, round-trip, corrupt file, atomic write, flush failure",
-      "Commit with message: feat(terminal): add SessionCache module"
+      "Add cwd field to TranscriptWatcher struct",
+      "Update start_or_replace and start_tailing signatures",
+      "Thread cwd through tail_loop (as _cwd for now)",
+      "Update watcher.rs to pass resolved CWD",
+      "Update existing tests with None cwd argument"
     ],
-    "passes": true,
-    "dependencies": []
+    "passes": false,
+    "dependencies": [1]
   },
   {
     "id": 3,
-    "phase": 2,
-    "category": "data models",
-    "description": "Add RingBuffer to ManagedSession for atomic offset + bytes snapshots",
+    "phase": 1,
+    "category": "backend-tagging",
+    "description": "AgentToolCallEvent.is_test_file flag — Add is_test_file: bool to AgentToolCallEvent, create test_file_patterns.rs, tag Write/Edit tool calls whose file_path matches test patterns",
     "steps": [
-      "Read current state.rs ManagedSession structure",
-      "Write failing tests for RingBuffer: append-advances-offset, truncates-at-capacity, end_offset-continues-past-truncation",
-      "Implement RingBuffer struct with VecDeque, capacity, end_offset",
-      "Implement append(), bytes_snapshot(), end_offset() methods",
-      "Add pub ring: Mutex<RingBuffer> field to ManagedSession",
-      "Run tests to verify RingBuffer behavior",
-      "Commit with message: feat(terminal): add RingBuffer to ManagedSession for replay protocol"
+      "Create test_file_patterns.rs with is_test_file(path) matcher",
+      "Add is_test_file field to AgentToolCallEvent",
+      "Extend InFlightToolCall with is_test_file",
+      "Check full file_path in process_assistant_message",
+      "Add isTestFile to TS types and propagate through useAgentStatus"
     ],
-    "passes": true,
+    "passes": false,
     "dependencies": [2]
   },
   {
     "id": 4,
-    "phase": 3,
-    "category": "core implementation",
-    "description": "spawn_pty — error on existing id, write cache, cap at 64, add ring buffer",
+    "phase": 2,
+    "category": "backend-matching",
+    "description": "Command matching algorithm — Implement tokenize, strip env, segment-split, strip wrappers, script-alias resolution, and runner matching with depth-3 recursion bound",
     "steps": [
-      "Add offset_start: u64 field to PtyDataEvent in types.rs",
-      "Add chrono dependency to Cargo.toml",
-      "Add tauri::State<'_, Arc<SessionCache>> parameter to spawn_pty",
-      "Replace kill-and-replace block with error on existing session id",
-      "Add session cap at 64 active sessions (PtyState::active_count())",
-      "Construct ManagedSession with Mutex::new(RingBuffer::new(65536))",
-      "Write CachedSession to cache, append to session_order, promote to active if first",
-      "Write tests: spawn_pty_returns_error_on_existing_session_id, spawn_pty_appends_to_session_order_and_promotes_active, spawn_pty_caps_at_64_active_sessions",
-      "Update all pre-existing spawn_pty test callers to pass cache state",
-      "Commit with message: feat(terminal): spawn_pty writes to cache and errors on id reuse"
+      "Create matcher.rs with tokenize and strip functions",
+      "Implement segment-split and wrapper-strip",
+      "Create script_resolution.rs for package.json script lookup",
+      "Implement match_command orchestrator",
+      "Add comprehensive unit tests for all edge cases"
     ],
-    "passes": true,
+    "passes": false,
     "dependencies": [3]
   },
   {
     "id": 5,
-    "phase": 3,
-    "category": "core implementation",
-    "description": "kill_pty — make idempotent + clean cache + advance active",
+    "phase": 2,
+    "category": "backend-parser",
+    "description": "Vitest result parser + first end-to-end fixture — Implement vitest_parse_result, create sanitiser/preview/timestamps/path_resolution helpers, integrate into process_tool_result, emit test-run event",
     "steps": [
-      "Modify kill_pty to return Ok(()) for missing sessions (idempotent)",
-      "Add cache cleanup: remove from sessions map, retain from session_order",
-      "Add active_session_id rotation: if killed session was active, advance to next in order",
-      "Write tests: kill_pty_is_idempotent_for_missing_session, kill_pty_removes_from_session_order_and_cache, kill_pty_advances_active_when_active_killed",
-      "Commit with message: fix(terminal): make kill_pty idempotent and clean cache"
+      "Create sanitiser.rs for command/output redaction",
+      "Create preview.rs for command_preview building",
+      "Create timestamps.rs for ISO 8601 parsing and duration computation",
+      "Create path_resolution.rs with containment check",
+      "Implement vitest_parse_result against canonical format",
+      "Extend InFlightToolCall with test_match",
+      "Wire matcher and builder into transcript.rs",
+      "Create transcript_vitest_pass.jsonl fixture",
+      "Add integration test verifying end-to-end emission"
     ],
-    "passes": true,
+    "passes": false,
     "dependencies": [4]
   },
   {
     "id": 6,
-    "phase": 3,
-    "category": "core implementation",
-    "description": "read_pty_output — atomic ring buffer write + offset emission + EOF marks cache",
+    "phase": 2,
+    "category": "backend-batching",
+    "description": "TestRunEmitter + replay batching — Replace direct emit with TestRunEmitter.submit, batch during replay to emit latest-only once at first EOF, eliminate UI flicker on session restore",
     "steps": [
-      "Modify read_pty_output to pass cache through",
-      "On Ok(n): append to ring buffer + advance offset under one lock, emit PtyDataEvent with offset_start after lock drops",
-      "On Ok(0) EOF: set cache.sessions[id].exited = true",
-      "Add PtyState::inner_sessions() accessor for testing",
-      "Write test: read_loop_eof_marks_cache_exited",
-      "Commit with message: feat(terminal): atomic ring buffer write + offset emission in read loop"
+      "Create emitter.rs with TestRunEmitter struct",
+      "Implement submit (batches during replay) and finish_replay",
+      "Integrate emitter into tail_loop",
+      "Call finish_replay on first EOF",
+      "Create transcript_vitest_replay.jsonl fixture",
+      "Add integration test verifying exactly one emit for 3 historical runs"
     ],
-    "passes": true,
+    "passes": false,
     "dependencies": [5]
   },
   {
     "id": 7,
     "phase": 3,
-    "category": "core implementation",
-    "description": "list_sessions command + lazy reconciliation of cache vs PtyState",
+    "category": "frontend-types",
+    "description": "TS test-run listener + ordering regression test — Add TestRunSnapshot types, extend AgentStatus with testRun, attach test-run listener BEFORE start_agent_watcher, lock ordering invariant with regression test",
     "steps": [
-      "Add SessionStatus, SessionInfo, SessionList types to types.rs",
-      "Implement list_sessions(state, cache): iterate session_order, check cache + PtyState per id",
-      "Add lazy reconciliation: if cache says exited: false but PtyState has no entry, return Exited and flush corrected state",
-      "For Alive: snapshot (bytes, end_offset) under one ring lock",
-      "Write tests: list_sessions_returns_alive_for_running_pty, list_sessions_reconciles_alive_cache_with_empty_pty_state, list_sessions_returns_in_session_order, list_sessions_replay_end_offset_matches_buffer_contents",
-      "Commit with message: feat(terminal): add list_sessions command with lazy reconciliation"
+      "Add TestRunSnapshot/TestGroup/TestRunStatus types to TS",
+      "Add testRun: null to AgentStatus and createDefaultStatus",
+      "Add test-run listener inside subscribe() block",
+      "Add listener-ordering regression test",
+      "Add hook tests for ptyId filtering and default state"
     ],
-    "passes": true,
+    "passes": false,
     "dependencies": [6]
   },
   {
     "id": 8,
     "phase": 3,
-    "category": "core implementation",
-    "description": "set_active_session, reorder_sessions, update_session_cwd commands",
+    "category": "frontend-ui",
+    "description": "TestResults rewrite + AgentStatusPanel wiring — Full rewrite of TestResults with snapshot prop, placeholder + live sub-components, inline collapsible button, three-part proportional bar, per-group rows",
     "steps": [
-      "Add SetActiveSessionRequest, ReorderSessionsRequest, UpdateSessionCwdRequest to types.rs",
-      "Implement set_active_session(id): validate id in session_order, update cache.active_session_id",
-      "Implement reorder_sessions(ids): validate permutation, update cache.session_order",
-      "Implement update_session_cwd(id, cwd): validate UUID-shaped id and absolute-existing-directory cwd, update cache",
-      "Write tests: set_active_session_persists_to_cache, set_active_session_rejects_unknown_id, reorder_sessions_persists_to_cache, reorder_sessions_rejects_non_permutation, update_session_cwd_persists_to_cache, update_session_cwd_rejects_invalid_path",
-      "Commit with message: feat(terminal): add session management commands"
+      "Write comprehensive tests for all five states (placeholder, pass, fail, noTests, error)",
+      "Implement TestResultsPlaceholder component",
+      "Implement TestResultsLive with inline collapsible button",
+      "Render three-part proportional bar (passed/failed/skipped)",
+      "Implement per-group rows with click handlers",
+      "Update AgentStatusPanel to pass snapshot and onOpenFile"
     ],
-    "passes": true,
+    "passes": false,
     "dependencies": [7]
   },
   {
     "id": 9,
-    "phase": 4,
-    "category": "wiring",
-    "description": "Register new commands + manage SessionCache in lib.rs",
+    "phase": 3,
+    "category": "frontend-integration",
+    "description": "WorkspaceView.handleOpenTestFile — Add dirty-state-guarded file opener mirroring handleFileSelect, pass to AgentStatusPanel.onOpenFile, prevent silent edit discard",
     "steps": [
-      "Re-export new commands from terminal/mod.rs",
-      "In lib.rs setup(), resolve app_data_dir().join('sessions.json')",
-      "Add app.manage(Arc::new(SessionCache::load_or_recover(path)))",
-      "Register list_sessions, set_active_session, reorder_sessions, update_session_cwd in tauri::generate_handler![] blocks",
-      "Add SessionCache::load_or_recover method: move corrupt files to .corrupt-YYYYMMDDHHMMSS backup, then load empty",
-      "Write test: load_or_recover_moves_corrupt_aside",
-      "Commit with message: feat(terminal): register session management commands and cache in lib.rs"
+      "Add handleOpenTestFile in WorkspaceView",
+      "Guard with editorBuffer.isDirty check",
+      "Call setPendingFilePathSynced + setShowUnsavedDialog when dirty",
+      "Call openFileSafely when clean",
+      "Pass handleOpenTestFile to AgentStatusPanel",
+      "Add tests for clean-buffer and dirty-buffer flows"
     ],
-    "passes": true,
+    "passes": false,
     "dependencies": [8]
   },
   {
     "id": 10,
-    "phase": 5,
-    "category": "wiring",
-    "description": "Regenerate TypeScript bindings for new Rust types",
+    "phase": 4,
+    "category": "backend-parser",
+    "description": "Cargo result parser + cargo fixture — Implement cargo_parse_result for cargo 1.7x format with module-level groups, create transcript_cargo_mixed.jsonl fixture, validate registry abstraction",
     "steps": [
-      "Run npm run generate:bindings",
-      "Verify new files created: SessionList.ts, SessionInfo.ts, SessionStatus.ts, SetActiveSessionRequest.ts, ReorderSessionsRequest.ts, UpdateSessionCwdRequest.ts",
-      "Verify PtyDataEvent.ts updated to include offset_start",
-      "Commit with message: chore(bindings): regenerate after session cache types"
+      "Implement cargo_parse_result for multi-binary summary format",
+      "Parse per-test outcome lines into module groups",
+      "Group by <crate>::<module> prefix",
+      "Set kind: Module and path: null for cargo groups",
+      "Create transcript_cargo_mixed.jsonl fixture",
+      "Add integration test verifying cargo runner end-to-end"
     ],
-    "passes": true,
+    "passes": false,
     "dependencies": [9]
   },
   {
     "id": 11,
-    "phase": 6,
-    "category": "core implementation",
-    "description": "Update terminalService.ts — onData callback signature + new methods",
+    "phase": 4,
+    "category": "frontend-activity",
+    "description": "Activity feed glyph + verb mapping — Extend ActivityEvent with isTestFile, propagate from RecentToolCall, render 🧪 CREATED TEST / 🧪 UPDATED TEST for Write/Edit of test files",
     "steps": [
-      "Update ITerminalService.onData callback signature to (sessionId, data, offsetStart) => void",
-      "Add listSessions(), setActiveSession(id), reorderSessions(ids), updateSessionCwd(id, cwd) to ITerminalService interface",
-      "Implement all four methods in TauriTerminalService",
-      "Update pty-data listener to extract offset_start (coerce bigint to number if needed)",
-      "Update every test mock to match the new onData signature",
-      "Add tests to tauriTerminalService.test.ts for each new method + onData offset propagation",
-      "Commit with message: feat(terminal): update terminalService with new IPC methods and offset_start"
+      "Add isTestFile?: boolean to ActivityEvent type",
+      "Propagate isTestFile in toolCallsToEvents",
+      "Update ActivityEvent getLabel to prepend glyph and verb",
+      "Map Write → 'Created test', Edit → 'Updated test'",
+      "Add tests for test-file Write/Edit rendering"
     ],
-    "passes": true,
+    "passes": false,
     "dependencies": [10]
-  },
-  {
-    "id": 12,
-    "phase": 7,
-    "category": "core implementation",
-    "description": "useTerminal — add restored mode with replay + cursor dedupe",
-    "steps": [
-      "Add optional restoredFrom prop: { sessionId, cwd, pid, replayData, replayEndOffset, bufferedEvents }",
-      "When restoredFrom provided: skip service.spawn, set didSpawnSessionRef.current = false",
-      "Write replayData to xterm before any other writes",
-      "Drain bufferedEvents with cursor filter (offsetStart >= replayEndOffset)",
-      "Continue normally with cursor-filtered live pty-data listener",
-      "Write tests: skips spawn, writes replay first, flushes buffered with filter, no kill on unmount, live event below cursor dropped, live event at/above cursor written",
-      "Commit with message: feat(terminal): add useTerminal restored mode with replay and cursor dedupe"
-    ],
-    "passes": true,
-    "dependencies": [11]
-  },
-  {
-    "id": 13,
-    "phase": 7,
-    "category": "core implementation",
-    "description": "useSessionManager — rewrite as pure IPC client + restore orchestrator",
-    "steps": [
-      "Replace localStorage/in-memory persistence with IPC",
-      "On mount: register ONE global pty-data buffering listener keyed by sessionId from event payload",
-      "Call service.listSessions() while buffering",
-      "Build per-session RestoreData { sessionId, cwd, pid, replayData, replayEndOffset, bufferedEvents } from response",
-      "Stop buffering listener after restore data prepared",
-      "Expose restoreData: Map<string, RestoreData> and loading: boolean",
-      "UI actions (setActiveSessionId, reorderSessions, removeSession, createSession, updateSessionCwd) are optimistic local update + IPC + revert on error",
-      "Renames stay in-memory (not persisted)",
-      "Repopulate ptySessionMap from list_sessions results",
-      "Write tests: registers listener before list_sessions, buffers events during in-flight, no localStorage writes, optimistic active update + revert on error, renders Exited sessions",
-      "Commit with message: refactor(workspace): rewrite useSessionManager as pure IPC client with restore orchestration"
-    ],
-    "passes": true,
-    "dependencies": [12]
-  },
-  {
-    "id": 14,
-    "phase": 8,
-    "category": "wiring",
-    "description": "TerminalPane + TerminalZone — wire restoreData and OSC 7 IPC sync",
-    "steps": [
-      "TerminalPane: accept restoredFrom prop and forward to useTerminal",
-      "After attach (status === 'running'), send resize to nudge TUI apps (vim, claude) into SIGWINCH redraw",
-      "OSC 7 cwd handler: call service.updateSessionCwd(sessionId, path) to sync Rust cache",
-      "TerminalZone: consume restoreData from useSessionManager and pass per-session entry to each TerminalPane",
-      "Show loading state until useSessionManager.loading is false",
-      "Write tests: restoreData passthrough, OSC 7 IPC, loading state",
-      "Commit with message: feat(workspace): wire TerminalPane and TerminalZone to restore protocol"
-    ],
-    "passes": true,
-    "dependencies": [13]
   }
 ]

--- a/feature_list.json
+++ b/feature_list.json
@@ -116,7 +116,7 @@
       "Add listener-ordering regression test",
       "Add hook tests for ptyId filtering and default state"
     ],
-    "passes": false,
+    "passes": true,
     "dependencies": [
       6
     ]

--- a/feature_list.json
+++ b/feature_list.json
@@ -187,7 +187,7 @@
       "Map Write → 'Created test', Edit → 'Updated test'",
       "Add tests for test-file Write/Edit rendering"
     ],
-    "passes": false,
+    "passes": true,
     "dependencies": [
       10
     ]

--- a/feature_list.json
+++ b/feature_list.json
@@ -99,7 +99,7 @@
       "Create transcript_vitest_replay.jsonl fixture",
       "Add integration test verifying exactly one emit for 3 historical runs"
     ],
-    "passes": false,
+    "passes": true,
     "dependencies": [
       5
     ]

--- a/feature_list.json
+++ b/feature_list.json
@@ -81,7 +81,7 @@
       "Create transcript_vitest_pass.jsonl fixture",
       "Add integration test verifying end-to-end emission"
     ],
-    "passes": false,
+    "passes": true,
     "dependencies": [
       4
     ]

--- a/feature_list.json
+++ b/feature_list.json
@@ -170,7 +170,7 @@
       "Create transcript_cargo_mixed.jsonl fixture",
       "Add integration test verifying cargo runner end-to-end"
     ],
-    "passes": false,
+    "passes": true,
     "dependencies": [
       9
     ]

--- a/feature_list.json
+++ b/feature_list.json
@@ -26,8 +26,10 @@
       "Update watcher.rs to pass resolved CWD",
       "Update existing tests with None cwd argument"
     ],
-    "passes": false,
-    "dependencies": [1]
+    "passes": true,
+    "dependencies": [
+      1
+    ]
   },
   {
     "id": 3,
@@ -42,7 +44,9 @@
       "Add isTestFile to TS types and propagate through useAgentStatus"
     ],
     "passes": false,
-    "dependencies": [2]
+    "dependencies": [
+      2
+    ]
   },
   {
     "id": 4,
@@ -57,7 +61,9 @@
       "Add comprehensive unit tests for all edge cases"
     ],
     "passes": false,
-    "dependencies": [3]
+    "dependencies": [
+      3
+    ]
   },
   {
     "id": 5,
@@ -76,7 +82,9 @@
       "Add integration test verifying end-to-end emission"
     ],
     "passes": false,
-    "dependencies": [4]
+    "dependencies": [
+      4
+    ]
   },
   {
     "id": 6,
@@ -92,7 +100,9 @@
       "Add integration test verifying exactly one emit for 3 historical runs"
     ],
     "passes": false,
-    "dependencies": [5]
+    "dependencies": [
+      5
+    ]
   },
   {
     "id": 7,
@@ -107,7 +117,9 @@
       "Add hook tests for ptyId filtering and default state"
     ],
     "passes": false,
-    "dependencies": [6]
+    "dependencies": [
+      6
+    ]
   },
   {
     "id": 8,
@@ -123,7 +135,9 @@
       "Update AgentStatusPanel to pass snapshot and onOpenFile"
     ],
     "passes": false,
-    "dependencies": [7]
+    "dependencies": [
+      7
+    ]
   },
   {
     "id": 9,
@@ -139,7 +153,9 @@
       "Add tests for clean-buffer and dirty-buffer flows"
     ],
     "passes": false,
-    "dependencies": [8]
+    "dependencies": [
+      8
+    ]
   },
   {
     "id": 10,
@@ -155,7 +171,9 @@
       "Add integration test verifying cargo runner end-to-end"
     ],
     "passes": false,
-    "dependencies": [9]
+    "dependencies": [
+      9
+    ]
   },
   {
     "id": 11,
@@ -170,6 +188,8 @@
       "Add tests for test-file Write/Edit rendering"
     ],
     "passes": false,
-    "dependencies": [10]
+    "dependencies": [
+      10
+    ]
   }
 ]

--- a/feature_list.json
+++ b/feature_list.json
@@ -60,7 +60,7 @@
       "Implement match_command orchestrator",
       "Add comprehensive unit tests for all edge cases"
     ],
-    "passes": false,
+    "passes": true,
     "dependencies": [
       3
     ]

--- a/feature_list.json
+++ b/feature_list.json
@@ -11,7 +11,7 @@
       "Wire module into agent/mod.rs",
       "Add smoke tests for matchers"
     ],
-    "passes": false,
+    "passes": true,
     "dependencies": []
   },
   {

--- a/feature_list.json
+++ b/feature_list.json
@@ -134,7 +134,7 @@
       "Implement per-group rows with click handlers",
       "Update AgentStatusPanel to pass snapshot and onOpenFile"
     ],
-    "passes": false,
+    "passes": true,
     "dependencies": [
       7
     ]

--- a/feature_list.json
+++ b/feature_list.json
@@ -152,7 +152,7 @@
       "Pass handleOpenTestFile to AgentStatusPanel",
       "Add tests for clean-buffer and dirty-buffer flows"
     ],
-    "passes": false,
+    "passes": true,
     "dependencies": [
       8
     ]

--- a/feature_list.json
+++ b/feature_list.json
@@ -43,7 +43,7 @@
       "Check full file_path in process_assistant_message",
       "Add isTestFile to TS types and propagate through useAgentStatus"
     ],
-    "passes": false,
+    "passes": true,
     "dependencies": [
       2
     ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,9 @@ dirs = "6"
 ignore = "0.4"
 tempfile = "3"
 chrono = "0.4"
+shell-words = "1.1"
+regex = "1.10"
+once_cell = "1.19"
 
 [features]
 e2e-test = []

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -7,6 +7,7 @@
 pub mod commands;
 pub mod detector;
 pub mod statusline;
+pub mod test_runners;
 pub mod transcript;
 pub mod types;
 pub mod watcher;

--- a/src-tauri/src/agent/test_runners/build.rs
+++ b/src-tauri/src/agent/test_runners/build.rs
@@ -13,12 +13,12 @@ use super::timestamps::compute_duration_ms;
 use super::types::{
     CapturedOutput, TestRunSnapshot, TestRunStatus, TestRunSummary,
 };
+use super::ANSI_RE;
 
 const MAX_EXCERPT_LEN: usize = 240;
 
 static ERROR_HINT_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?i)(error:|fail|panicked)").unwrap());
-static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
 
 pub struct BuildArgs<'a> {
     pub session_id: &'a str,
@@ -32,6 +32,31 @@ pub struct BuildArgs<'a> {
 
 pub fn build_snapshot(args: BuildArgs<'_>) -> TestRunSnapshot {
     let summary = (args.matched.runner.parse_result)(&args.captured, args.cwd);
+    build_snapshot_with_summary(args, summary)
+}
+
+/// Returns Some(snapshot) when an event should be emitted; None when we
+/// don't know what happened (parser returned None AND not an error result).
+pub fn maybe_build_snapshot(args: BuildArgs<'_>) -> Option<TestRunSnapshot> {
+    let summary = (args.matched.runner.parse_result)(&args.captured, args.cwd);
+    if summary.is_none() && !args.captured.is_error {
+        log::debug!(
+            "Test runner '{}' produced unparseable output, skipping emit",
+            args.matched.runner.name
+        );
+        return None;
+    }
+    Some(build_snapshot_with_summary(args, summary))
+}
+
+/// Inner builder shared by `build_snapshot` and `maybe_build_snapshot`.
+/// Both used to call `parse_result` independently, doubling the regex pass
+/// over the captured output for every emit. This helper accepts the
+/// pre-computed summary so the parser only runs once per snapshot.
+fn build_snapshot_with_summary(
+    args: BuildArgs<'_>,
+    summary: Option<TestRunSummary>,
+) -> TestRunSnapshot {
     let status = derive_status(summary.as_ref(), args.captured.is_error);
     let summary = summary.unwrap_or_default();
 
@@ -56,20 +81,6 @@ pub fn build_snapshot(args: BuildArgs<'_>) -> TestRunSnapshot {
         summary,
         output_excerpt,
     }
-}
-
-/// Returns Some(snapshot) when an event should be emitted; None when we
-/// don't know what happened (parser returned None AND not an error result).
-pub fn maybe_build_snapshot(args: BuildArgs<'_>) -> Option<TestRunSnapshot> {
-    let summary = (args.matched.runner.parse_result)(&args.captured, args.cwd);
-    if summary.is_none() && !args.captured.is_error {
-        log::debug!(
-            "Test runner '{}' produced unparseable output, skipping emit",
-            args.matched.runner.name
-        );
-        return None;
-    }
-    Some(build_snapshot(args))
 }
 
 fn derive_status(summary: Option<&TestRunSummary>, is_error: bool) -> TestRunStatus {

--- a/src-tauri/src/agent/test_runners/build.rs
+++ b/src-tauri/src/agent/test_runners/build.rs
@@ -78,7 +78,12 @@ fn derive_status(summary: Option<&TestRunSummary>, is_error: bool) -> TestRunSta
         Some(s) if s.total == 0 => TestRunStatus::NoTests,
         Some(_) => TestRunStatus::Pass,
         None if is_error => TestRunStatus::Error,
-        None => TestRunStatus::Error, // maybe_build_snapshot already filtered the unknown case
+        // None + no error: treat as Error. Note: maybe_build_snapshot
+        // filters this case out before calling, so callers going through
+        // that wrapper never reach this arm. Direct callers of
+        // build_snapshot DO reach it and get Error — which is the
+        // safest fallback when we can't classify the result.
+        None => TestRunStatus::Error,
     }
 }
 

--- a/src-tauri/src/agent/test_runners/build.rs
+++ b/src-tauri/src/agent/test_runners/build.rs
@@ -83,7 +83,7 @@ fn build_snapshot_with_summary(
     }
 }
 
-fn derive_status(summary: Option<&TestRunSummary>, is_error: bool) -> TestRunStatus {
+fn derive_status(summary: Option<&TestRunSummary>, _is_error: bool) -> TestRunStatus {
     match summary {
         Some(s) if s.failed > 0 => TestRunStatus::Fail,
         Some(s) if s.total == 0 => TestRunStatus::NoTests,
@@ -95,12 +95,12 @@ fn derive_status(summary: Option<&TestRunSummary>, is_error: bool) -> TestRunSta
         // text like "all skipped") is future work.
         Some(s) if s.passed == 0 && s.skipped > 0 => TestRunStatus::NoTests,
         Some(_) => TestRunStatus::Pass,
-        None if is_error => TestRunStatus::Error,
-        // None + no error: treat as Error. Note: maybe_build_snapshot
-        // filters this case out before calling, so callers going through
-        // that wrapper never reach this arm. Direct callers of
-        // build_snapshot DO reach it and get Error — which is the
-        // safest fallback when we can't classify the result.
+        // None: classify as Error regardless of `is_error`. Both
+        // `is_error=true` and `is_error=false` produce Error here BY
+        // DESIGN. The wrapper `maybe_build_snapshot` already filters out
+        // the `None + is_error=false` case (we don't know what happened,
+        // skip emit). Direct callers of `build_snapshot` reach this arm
+        // and get Error as the safest fallback.
         None => TestRunStatus::Error,
     }
 }

--- a/src-tauri/src/agent/test_runners/build.rs
+++ b/src-tauri/src/agent/test_runners/build.rs
@@ -87,6 +87,13 @@ fn derive_status(summary: Option<&TestRunSummary>, is_error: bool) -> TestRunSta
     match summary {
         Some(s) if s.failed > 0 => TestRunStatus::Fail,
         Some(s) if s.total == 0 => TestRunStatus::NoTests,
+        // All-skipped case: total > 0 but nothing actually ran. Reuse the
+        // NoTests visual path (gray dot, "no tests" header) — strictly less
+        // misleading than the previous Pass classification, which painted
+        // a green badge while announcing "0 of N passed" to screen readers.
+        // A dedicated Skipped variant (with its own dot color and header
+        // text like "all skipped") is future work.
+        Some(s) if s.passed == 0 && s.skipped > 0 => TestRunStatus::NoTests,
         Some(_) => TestRunStatus::Pass,
         None if is_error => TestRunStatus::Error,
         // None + no error: treat as Error. Note: maybe_build_snapshot
@@ -159,6 +166,15 @@ mod tests {
     fn derive_status_picks_pass() {
         let s = TestRunSummary { passed: 3, failed: 0, skipped: 0, total: 3, groups: vec![] };
         assert_eq!(derive_status(Some(&s), false), TestRunStatus::Pass);
+    }
+
+    #[test]
+    fn derive_status_picks_no_tests_for_all_skipped() {
+        // Regression: passed=0 with skipped>0 (and total>0) used to fall
+        // through to Pass, painting a green badge while the aria-label
+        // announced "0 of N passed". Now reuses NoTests (gray + "no tests").
+        let s = TestRunSummary { passed: 0, failed: 0, skipped: 3, total: 3, groups: vec![] };
+        assert_eq!(derive_status(Some(&s), false), TestRunStatus::NoTests);
     }
 
     #[test]

--- a/src-tauri/src/agent/test_runners/build.rs
+++ b/src-tauri/src/agent/test_runners/build.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 
 use super::matcher::MatchedCommand;
 use super::preview::build_command_preview;
-use super::sanitiser::sanitize_for_ui;
+use super::sanitiser::sanitize_for_output;
 use super::timestamps::compute_duration_ms;
 use super::types::{
     CapturedOutput, TestRunSnapshot, TestRunStatus, TestRunSummary,
@@ -115,7 +115,7 @@ fn extract_excerpt(content: &str) -> String {
         stripped.lines().find(|l| !l.trim().is_empty()).unwrap_or("")
     });
     let truncated: String = chosen.chars().take(MAX_EXCERPT_LEN).collect();
-    sanitize_for_ui(&truncated)
+    sanitize_for_output(&truncated)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/agent/test_runners/build.rs
+++ b/src-tauri/src/agent/test_runners/build.rs
@@ -1,0 +1,152 @@
+//! Builds a TestRunSnapshot from a matched test-run tool_use + tool_result.
+
+use std::path::Path;
+use std::time::Duration;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use super::matcher::MatchedCommand;
+use super::preview::build_command_preview;
+use super::sanitiser::sanitize_for_ui;
+use super::timestamps::compute_duration_ms;
+use super::types::{
+    CapturedOutput, TestRunSnapshot, TestRunStatus, TestRunSummary,
+};
+
+const MAX_EXCERPT_LEN: usize = 240;
+
+static ERROR_HINT_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)(error:|fail|panicked)").unwrap());
+static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
+
+pub struct BuildArgs<'a> {
+    pub session_id: &'a str,
+    pub matched: &'a MatchedCommand,
+    pub started_at: &'a str,
+    pub finished_at: &'a str,
+    pub instant_fallback: Duration,
+    pub captured: CapturedOutput,
+    pub cwd: &'a Path,
+}
+
+pub fn build_snapshot(args: BuildArgs<'_>) -> TestRunSnapshot {
+    let summary = (args.matched.runner.parse_result)(&args.captured, args.cwd);
+    let status = derive_status(summary.as_ref(), args.captured.is_error);
+    let summary = summary.unwrap_or_default();
+
+    let output_excerpt = if matches!(status, TestRunStatus::Error) {
+        Some(extract_excerpt(&args.captured.content))
+    } else {
+        None
+    };
+
+    TestRunSnapshot {
+        session_id: args.session_id.to_string(),
+        runner: args.matched.runner.name.to_string(),
+        command_preview: build_command_preview(&args.matched.stripped_tokens),
+        started_at: args.started_at.to_string(),
+        finished_at: args.finished_at.to_string(),
+        duration_ms: compute_duration_ms(
+            args.started_at,
+            args.finished_at,
+            args.instant_fallback,
+        ),
+        status,
+        summary,
+        output_excerpt,
+    }
+}
+
+/// Returns Some(snapshot) when an event should be emitted; None when we
+/// don't know what happened (parser returned None AND not an error result).
+pub fn maybe_build_snapshot(args: BuildArgs<'_>) -> Option<TestRunSnapshot> {
+    let summary = (args.matched.runner.parse_result)(&args.captured, args.cwd);
+    if summary.is_none() && !args.captured.is_error {
+        log::debug!(
+            "Test runner '{}' produced unparseable output, skipping emit",
+            args.matched.runner.name
+        );
+        return None;
+    }
+    Some(build_snapshot(args))
+}
+
+fn derive_status(summary: Option<&TestRunSummary>, is_error: bool) -> TestRunStatus {
+    match summary {
+        Some(s) if s.failed > 0 => TestRunStatus::Fail,
+        Some(s) if s.total == 0 => TestRunStatus::NoTests,
+        Some(_) => TestRunStatus::Pass,
+        None if is_error => TestRunStatus::Error,
+        None => TestRunStatus::Error, // maybe_build_snapshot already filtered the unknown case
+    }
+}
+
+fn extract_excerpt(content: &str) -> String {
+    let stripped = ANSI_RE.replace_all(content, "");
+    // Prefer the first line containing an error hint; else first non-blank line.
+    let preferred = stripped
+        .lines()
+        .find(|l| ERROR_HINT_RE.is_match(l) && !l.trim().is_empty());
+    let chosen = preferred.unwrap_or_else(|| {
+        stripped.lines().find(|l| !l.trim().is_empty()).unwrap_or("")
+    });
+    let truncated: String = chosen.chars().take(MAX_EXCERPT_LEN).collect();
+    sanitize_for_ui(&truncated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn excerpt_prefers_error_hint() {
+        let s = extract_excerpt(
+            "  some preamble\n  error: type mismatch in foo.test.ts\n  more output",
+        );
+        assert!(s.contains("error: type mismatch"));
+    }
+
+    #[test]
+    fn excerpt_falls_back_to_first_non_blank() {
+        let s = extract_excerpt("\n   \nfirst real line\nsecond line");
+        assert!(s.contains("first real line"));
+    }
+
+    #[test]
+    fn excerpt_caps_length() {
+        let long = "x".repeat(500);
+        let body = format!("error: {}", long);
+        let s = extract_excerpt(&body);
+        assert!(s.chars().count() <= MAX_EXCERPT_LEN);
+    }
+
+    #[test]
+    fn excerpt_runs_through_sanitiser() {
+        let s = extract_excerpt("error: bearer eyJabcdefghijklmnop.body.sig was rejected");
+        assert!(s.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn derive_status_picks_fail_over_total() {
+        let s = TestRunSummary { passed: 5, failed: 1, skipped: 0, total: 6, groups: vec![] };
+        assert_eq!(derive_status(Some(&s), false), TestRunStatus::Fail);
+    }
+
+    #[test]
+    fn derive_status_picks_no_tests() {
+        let s = TestRunSummary::default();
+        assert_eq!(derive_status(Some(&s), false), TestRunStatus::NoTests);
+    }
+
+    #[test]
+    fn derive_status_picks_pass() {
+        let s = TestRunSummary { passed: 3, failed: 0, skipped: 0, total: 3, groups: vec![] };
+        assert_eq!(derive_status(Some(&s), false), TestRunStatus::Pass);
+    }
+
+    #[test]
+    fn derive_status_picks_error_when_unparseable_and_is_error() {
+        assert_eq!(derive_status(None, true), TestRunStatus::Error);
+    }
+}

--- a/src-tauri/src/agent/test_runners/cargo.rs
+++ b/src-tauri/src/agent/test_runners/cargo.rs
@@ -20,6 +20,7 @@ use regex::Regex;
 use super::types::{
     CapturedOutput, TestGroup, TestGroupKind, TestGroupStatus, TestRunSummary, TestRunner,
 };
+use super::ANSI_RE;
 
 pub static CARGO_TEST: TestRunner = TestRunner {
     name: "cargo",
@@ -32,8 +33,6 @@ const MAX_GROUPS: usize = 500;
 fn cargo_matches(tokens: &[&str]) -> bool {
     matches!(tokens, ["cargo", "test", ..])
 }
-
-static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
 
 // Summary line. Cargo may produce multiple summary lines (one per binary);
 // we sum across all of them.

--- a/src-tauri/src/agent/test_runners/cargo.rs
+++ b/src-tauri/src/agent/test_runners/cargo.rs
@@ -61,14 +61,20 @@ fn cargo_parse_result(out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummar
     let mut found_summary = false;
     for cap in SUMMARY_RE.captures_iter(&stripped) {
         found_summary = true;
-        passed += cap.get(1).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
-        failed += cap.get(2).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
-        skipped += cap.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        // Use saturating_add — bare `+=` would panic in debug and wrap
+        // silently in release if a workspace had implausibly many test
+        // binaries. Saturating clamps at u32::MAX with no extra cost.
+        let p: u32 = cap.get(1).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        let f: u32 = cap.get(2).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        let s: u32 = cap.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        passed = passed.saturating_add(p);
+        failed = failed.saturating_add(f);
+        skipped = skipped.saturating_add(s);
     }
     if !found_summary {
         return None;
     }
-    let total = passed + failed + skipped;
+    let total = passed.saturating_add(failed).saturating_add(skipped);
 
     // Build per-module groups from individual test lines.
     let mut module_counts: HashMap<String, (u32, u32, u32)> = HashMap::new(); // (pass, fail, skip)

--- a/src-tauri/src/agent/test_runners/cargo.rs
+++ b/src-tauri/src/agent/test_runners/cargo.rs
@@ -1,6 +1,25 @@
+//! Cargo test result parser. Targets cargo 1.7x output format.
+//!
+//! Cargo writes its summary to stderr (CapturedOutput.content carries combined
+//! stdout+stderr because the Bash tool returns combined output).
+//!
+//! Canonical summary line:
+//!   test result: ok. 47 passed; 2 failed; 1 ignored; 0 measured; 0 filtered out;
+//!
+//! Per-test lines:
+//!   test some_module::test_foo ... ok
+//!   test some_module::test_bar ... FAILED
+//!   test some_module::test_baz ... ignored
+
+use std::collections::HashMap;
 use std::path::Path;
 
-use super::types::{CapturedOutput, TestRunSummary, TestRunner};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use super::types::{
+    CapturedOutput, TestGroup, TestGroupKind, TestGroupStatus, TestRunSummary, TestRunner,
+};
 
 pub static CARGO_TEST: TestRunner = TestRunner {
     name: "cargo",
@@ -8,18 +27,112 @@ pub static CARGO_TEST: TestRunner = TestRunner {
     parse_result: cargo_parse_result,
 };
 
+const MAX_GROUPS: usize = 500;
+
 fn cargo_matches(tokens: &[&str]) -> bool {
     matches!(tokens, ["cargo", "test", ..])
 }
 
-fn cargo_parse_result(_out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummary> {
-    // Implemented in Task 10
-    None
+static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
+
+// Summary line. Cargo may produce multiple summary lines (one per binary);
+// we sum across all of them.
+//   test result: ok. 47 passed; 2 failed; 1 ignored; 0 measured; 0 filtered out
+static SUMMARY_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?m)test result:\s+\w+\.\s+(\d+)\s+passed;\s+(\d+)\s+failed;\s+(\d+)\s+ignored",
+    )
+    .unwrap()
+});
+
+// Individual test outcome lines:
+//   test foo::bar::test_x ... ok
+//   test foo::bar::test_y ... FAILED
+//   test foo::bar::test_z ... ignored
+static TEST_LINE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?m)^test\s+([\w:]+)\s+\.\.\.\s+(ok|FAILED|ignored)\s*$").unwrap()
+});
+
+fn cargo_parse_result(out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummary> {
+    let stripped = ANSI_RE.replace_all(&out.content, "").to_string();
+
+    let mut passed = 0u32;
+    let mut failed = 0u32;
+    let mut skipped = 0u32;
+    let mut found_summary = false;
+    for cap in SUMMARY_RE.captures_iter(&stripped) {
+        found_summary = true;
+        passed += cap.get(1).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        failed += cap.get(2).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        skipped += cap.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    }
+    if !found_summary {
+        return None;
+    }
+    let total = passed + failed + skipped;
+
+    // Build per-module groups from individual test lines.
+    let mut module_counts: HashMap<String, (u32, u32, u32)> = HashMap::new(); // (pass, fail, skip)
+    for cap in TEST_LINE_RE.captures_iter(&stripped) {
+        let full_path = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let outcome = cap.get(2).map(|m| m.as_str()).unwrap_or("");
+        // Module = everything before the last "::"
+        let module = match full_path.rfind("::") {
+            Some(i) => &full_path[..i],
+            None => full_path,
+        };
+        let entry = module_counts.entry(module.to_string()).or_default();
+        match outcome {
+            "ok" => entry.0 += 1,
+            "FAILED" => entry.1 += 1,
+            "ignored" => entry.2 += 1,
+            _ => {}
+        }
+    }
+
+    let mut groups: Vec<TestGroup> = module_counts
+        .into_iter()
+        .take(MAX_GROUPS)
+        .map(|(label, (p, f, s))| {
+            let total = p + f + s;
+            let status = if f > 0 {
+                TestGroupStatus::Fail
+            } else if total == 0 || (s > 0 && p == 0) {
+                TestGroupStatus::Skip
+            } else {
+                TestGroupStatus::Pass
+            };
+            TestGroup {
+                label,
+                path: None, // cargo modules don't map to files reliably in v1
+                kind: TestGroupKind::Module,
+                passed: p,
+                failed: f,
+                skipped: s,
+                total,
+                status,
+            }
+        })
+        .collect();
+    groups.sort_by(|a, b| a.label.cmp(&b.label));
+
+    Some(TestRunSummary {
+        passed,
+        failed,
+        skipped,
+        total,
+        groups,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
+    fn captured(content: &str) -> CapturedOutput {
+        CapturedOutput { content: content.to_string(), is_error: false }
+    }
 
     #[test]
     fn cargo_matches_cargo_test() {
@@ -28,5 +141,67 @@ mod tests {
         assert!(!(CARGO_TEST.matches)(&["cargo", "build"]));
         assert!(!(CARGO_TEST.matches)(&["cargo"]));
         assert!(!(CARGO_TEST.matches)(&[]));
+    }
+
+    #[test]
+    fn parses_simple_pass_summary() {
+        let out = captured(
+            "running 3 tests
+test mycrate::tests::test_a ... ok
+test mycrate::tests::test_b ... ok
+test mycrate::tests::test_c ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n"
+        );
+        let s = cargo_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.passed, 3);
+        assert_eq!(s.failed, 0);
+        assert_eq!(s.skipped, 0);
+        assert_eq!(s.groups.len(), 1);
+        assert_eq!(s.groups[0].label, "mycrate::tests");
+        assert_eq!(s.groups[0].passed, 3);
+        assert_eq!(s.groups[0].kind, TestGroupKind::Module);
+        assert!(s.groups[0].path.is_none());
+    }
+
+    #[test]
+    fn parses_mixed_outcomes() {
+        let out = captured(
+            "running 3 tests
+test mycrate::a::test_x ... ok
+test mycrate::a::test_y ... FAILED
+test mycrate::b::test_z ... ignored
+
+test result: FAILED. 1 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out\n"
+        );
+        let s = cargo_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.passed, 1);
+        assert_eq!(s.failed, 1);
+        assert_eq!(s.skipped, 1);
+        assert_eq!(s.groups.len(), 2);
+        let a = s.groups.iter().find(|g| g.label == "mycrate::a").unwrap();
+        assert_eq!(a.passed, 1);
+        assert_eq!(a.failed, 1);
+        assert_eq!(a.status, TestGroupStatus::Fail);
+        let b = s.groups.iter().find(|g| g.label == "mycrate::b").unwrap();
+        assert_eq!(b.skipped, 1);
+        assert_eq!(b.status, TestGroupStatus::Skip);
+    }
+
+    #[test]
+    fn sums_multiple_summary_lines() {
+        let out = captured(
+            "test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out\n"
+        );
+        let s = cargo_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.passed, 8);
+        assert_eq!(s.failed, 1);
+    }
+
+    #[test]
+    fn returns_none_when_no_summary() {
+        let out = captured("error: failed to compile crate");
+        assert!(cargo_parse_result(&out, &PathBuf::from("/tmp")).is_none());
     }
 }

--- a/src-tauri/src/agent/test_runners/cargo.rs
+++ b/src-tauri/src/agent/test_runners/cargo.rs
@@ -90,9 +90,13 @@ fn cargo_parse_result(out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummar
         }
     }
 
+    // Sort BEFORE truncating — `take(MAX_GROUPS)` against a HashMap's
+    // randomized iteration order would otherwise pick a non-deterministic
+    // subset on each run for workspaces with > MAX_GROUPS modules. Sort
+    // by label first so the same subset (the alphabetically-first
+    // MAX_GROUPS modules) shows up reproducibly across runs.
     let mut groups: Vec<TestGroup> = module_counts
         .into_iter()
-        .take(MAX_GROUPS)
         .map(|(label, (p, f, s))| {
             let total = p + f + s;
             let status = if f > 0 {
@@ -115,6 +119,7 @@ fn cargo_parse_result(out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummar
         })
         .collect();
     groups.sort_by(|a, b| a.label.cmp(&b.label));
+    groups.truncate(MAX_GROUPS);
 
     Some(TestRunSummary {
         passed,

--- a/src-tauri/src/agent/test_runners/cargo.rs
+++ b/src-tauri/src/agent/test_runners/cargo.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+use super::types::{CapturedOutput, TestRunSummary, TestRunner};
+
+pub static CARGO_TEST: TestRunner = TestRunner {
+    name: "cargo",
+    matches: cargo_matches,
+    parse_result: cargo_parse_result,
+};
+
+fn cargo_matches(tokens: &[&str]) -> bool {
+    matches!(tokens, ["cargo", "test", ..])
+}
+
+fn cargo_parse_result(_out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummary> {
+    // Implemented in Task 10
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cargo_matches_cargo_test() {
+        assert!((CARGO_TEST.matches)(&["cargo", "test"]));
+        assert!((CARGO_TEST.matches)(&["cargo", "test", "--release"]));
+        assert!(!(CARGO_TEST.matches)(&["cargo", "build"]));
+        assert!(!(CARGO_TEST.matches)(&["cargo"]));
+        assert!(!(CARGO_TEST.matches)(&[]));
+    }
+}

--- a/src-tauri/src/agent/test_runners/emitter.rs
+++ b/src-tauri/src/agent/test_runners/emitter.rs
@@ -1,0 +1,125 @@
+//! Replay-aware emitter for test-run events. During the initial replay phase
+//! of a tail_loop, `submit` keeps only the latest snapshot — when the loop
+//! hits EOF for the first time and calls `finish_replay`, the latest pending
+//! snapshot (if any) is emitted exactly once. After replay, every submit
+//! emits immediately.
+
+use tauri::{AppHandle, Emitter, Runtime};
+
+use super::types::TestRunSnapshot;
+
+pub struct TestRunEmitter<R: Runtime> {
+    app_handle: AppHandle<R>,
+    replay_done: bool,
+    pending: Option<TestRunSnapshot>,
+}
+
+impl<R: Runtime> TestRunEmitter<R> {
+    pub fn new(app_handle: AppHandle<R>) -> Self {
+        Self {
+            app_handle,
+            replay_done: false,
+            pending: None,
+        }
+    }
+
+    pub fn submit(&mut self, snapshot: TestRunSnapshot) {
+        if self.replay_done {
+            if let Err(e) = self.app_handle.emit("test-run", &snapshot) {
+                log::warn!("Failed to emit test-run event: {}", e);
+            }
+        } else {
+            self.pending = Some(snapshot);
+        }
+    }
+
+    pub fn finish_replay(&mut self) {
+        if self.replay_done {
+            return;
+        }
+        self.replay_done = true;
+        if let Some(s) = self.pending.take() {
+            if let Err(e) = self.app_handle.emit("test-run", &s) {
+                log::warn!("Failed to emit test-run event: {}", e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::test_runners::types::{TestRunStatus, TestRunSummary};
+    use std::sync::{Arc, Mutex};
+    use tauri::test::{mock_builder, MockRuntime};
+    use tauri::Listener;
+
+    fn snap(passed: u32) -> TestRunSnapshot {
+        TestRunSnapshot {
+            session_id: "s".to_string(),
+            runner: "vitest".to_string(),
+            command_preview: "vitest".to_string(),
+            started_at: "2026-04-28T12:00:00Z".to_string(),
+            finished_at: "2026-04-28T12:00:01Z".to_string(),
+            duration_ms: 1000,
+            status: TestRunStatus::Pass,
+            summary: TestRunSummary {
+                passed,
+                failed: 0,
+                skipped: 0,
+                total: passed,
+                groups: vec![],
+            },
+            output_excerpt: None,
+        }
+    }
+
+    fn collect_emits(app: &tauri::App<MockRuntime>) -> Arc<Mutex<Vec<String>>> {
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let clone = received.clone();
+        app.handle().listen("test-run", move |event| {
+            clone.lock().unwrap().push(event.payload().to_string());
+        });
+        received
+    }
+
+    #[test]
+    fn submit_during_replay_buffers_latest() {
+        let app = mock_builder().build(tauri::generate_context!()).unwrap();
+        let emits = collect_emits(&app);
+        let mut e = TestRunEmitter::new(app.handle().clone());
+        e.submit(snap(1));
+        e.submit(snap(2));
+        e.submit(snap(3));
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert!(emits.lock().unwrap().is_empty());
+        e.finish_replay();
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let v = emits.lock().unwrap();
+        assert_eq!(v.len(), 1);
+        assert!(v[0].contains(r#""passed":3"#));
+    }
+
+    #[test]
+    fn submit_after_replay_emits_immediately() {
+        let app = mock_builder().build(tauri::generate_context!()).unwrap();
+        let emits = collect_emits(&app);
+        let mut e = TestRunEmitter::new(app.handle().clone());
+        e.finish_replay();
+        e.submit(snap(7));
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert_eq!(emits.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn finish_replay_is_idempotent() {
+        let app = mock_builder().build(tauri::generate_context!()).unwrap();
+        let emits = collect_emits(&app);
+        let mut e = TestRunEmitter::new(app.handle().clone());
+        e.submit(snap(1));
+        e.finish_replay();
+        e.finish_replay(); // second call must not re-emit
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert_eq!(emits.lock().unwrap().len(), 1);
+    }
+}

--- a/src-tauri/src/agent/test_runners/matcher.rs
+++ b/src-tauri/src/agent/test_runners/matcher.rs
@@ -140,6 +140,31 @@ fn match_command_inner(
             });
         }
     }
+
+    // Fallback: direct invocations like `pnpm vitest` or `yarn cargo test`
+    // skip the wrapper-strip path (`pnpm exec` / `yarn exec`) and skip the
+    // script-alias path (the second token isn't a known script name in our
+    // registry). Try once more with the leading `pnpm` / `yarn` dropped.
+    // Only fires AFTER the script-alias path returned None, so a real
+    // `pnpm test` / `yarn test` still resolves through the alias resolver
+    // and never reaches this fallback.
+    if matches!(
+        after_wrapper.first().map(String::as_str),
+        Some("pnpm") | Some("yarn")
+    ) && after_wrapper.len() > 1
+    {
+        let after_pm: Vec<String> = after_wrapper[1..].to_vec();
+        let pm_token_refs: Vec<&str> = after_pm.iter().map(String::as_str).collect();
+        for runner in RUNNERS {
+            if (runner.matches)(&pm_token_refs) {
+                return Some(MatchedCommand {
+                    runner,
+                    stripped_tokens: after_pm,
+                });
+            }
+        }
+    }
+
     None
 }
 
@@ -327,5 +352,66 @@ mod tests {
         .unwrap();
         assert!(match_command("npm run a", Some(dir.path())).is_none());
         assert!(match_command("npm run b", Some(dir.path())).is_none());
+    }
+
+    #[test]
+    fn match_command_finds_runner_through_pnpm_direct_invocation() {
+        // Regression: `pnpm vitest` (no `exec`) is documented as a valid
+        // way to run a binary via pnpm. The wrapper-strip path only
+        // handled `pnpm exec vitest`. Now a fallback in match_command_inner
+        // strips a leading `pnpm`/`yarn` and re-walks the runner registry.
+        let m = match_command("pnpm vitest run src/foo.test.ts", None).expect("should match");
+        assert_eq!(m.runner.name, "vitest");
+        assert_eq!(
+            m.stripped_tokens,
+            vec_of(&["vitest", "run", "src/foo.test.ts"])
+        );
+    }
+
+    #[test]
+    fn match_command_finds_runner_through_yarn_direct_invocation() {
+        let m = match_command("yarn cargo test --release", None).expect("should match");
+        assert_eq!(m.runner.name, "cargo");
+    }
+
+    #[test]
+    fn match_command_pnpm_test_still_resolves_via_alias_not_fallback() {
+        // The fallback only fires AFTER alias resolution returns None.
+        // `pnpm test` MUST still go through script-alias resolution
+        // (so the resolved script body, not the literal `test`, is matched).
+        use std::fs;
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"scripts": {"test": "vitest run"}}"#,
+        )
+        .unwrap();
+        let m = match_command("pnpm test", Some(dir.path())).expect("should match");
+        assert_eq!(m.runner.name, "vitest");
+    }
+
+    #[test]
+    fn match_command_preserves_cli_args_after_npm_test_separator() {
+        // Regression: `npm test -- src/foo.test.ts` used to drop the args
+        // because resolve_alias returned only the script body. Now CLI args
+        // after the script name (with `--` separator stripped) are appended
+        // to the resolved command, then re-tokenized through the pipeline.
+        use std::fs;
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"scripts": {"test": "vitest"}}"#,
+        )
+        .unwrap();
+        let m = match_command("npm test -- src/foo.test.ts", Some(dir.path()))
+            .expect("should match");
+        assert_eq!(m.runner.name, "vitest");
+        assert_eq!(
+            m.stripped_tokens,
+            vec_of(&["vitest", "src/foo.test.ts"]),
+            "CLI args after npm `--` separator should be preserved"
+        );
     }
 }

--- a/src-tauri/src/agent/test_runners/matcher.rs
+++ b/src-tauri/src/agent/test_runners/matcher.rs
@@ -95,6 +95,28 @@ pub struct MatchedCommand {
 /// The full matching pipeline. Returns None when the command does not match
 /// any known runner.
 pub fn match_command(cmd: &str, cwd: Option<&Path>) -> Option<MatchedCommand> {
+    let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
+    match_command_inner(cmd, cwd, &mut visited)
+}
+
+/// Inner matching pipeline carrying the cycle-breaking visited set across
+/// the cross-function `match_command -> resolve_alias -> match_command`
+/// recursion. Without this, a self-referential script like
+/// `{"test": "npm run test"}` overflows the stack: `resolve_alias` returns
+/// the literal `"npm run test"`, the next `match_command` resolves the same
+/// alias, and so on. The depth bound inside `resolve_recursive` only guards
+/// the package.json chain — not the cross-function loop.
+fn match_command_inner(
+    cmd: &str,
+    cwd: Option<&Path>,
+    visited: &mut std::collections::HashSet<String>,
+) -> Option<MatchedCommand> {
+    if !visited.insert(cmd.to_string()) {
+        // Already saw this exact command string in the recursion chain; cycle
+        // detected — refuse to match rather than overflow the stack.
+        return None;
+    }
+
     let initial = tokenize(cmd)?;
     let after_env = strip_env_prefix(&initial).to_vec();
     let after_segment = first_segment(&after_env).to_vec();
@@ -102,9 +124,10 @@ pub fn match_command(cmd: &str, cwd: Option<&Path>) -> Option<MatchedCommand> {
 
     // Try script alias resolution. If it resolves, recurse on the resolved
     // string (which goes through the SAME pipeline so its env/wrapper/etc.
-    // are also normalised).
+    // are also normalised). Pass the visited set down so multi-step cycles
+    // are caught the second time the same command string reappears.
     if let Some(resolved) = script_resolution::resolve_alias(&after_wrapper, cwd) {
-        return match_command(&resolved, cwd);
+        return match_command_inner(&resolved, cwd, visited);
     }
 
     // Walk RUNNERS. First match wins.
@@ -270,5 +293,39 @@ mod tests {
         )
         .unwrap();
         assert!(match_command("bun test", Some(dir.path())).is_none());
+    }
+
+    #[test]
+    fn match_command_breaks_on_self_referential_npm_script() {
+        // Regression for stack overflow on cyclic aliases. Without the
+        // cross-call visited HashSet in match_command_inner, this would
+        // infinite-loop: resolve_alias returns "npm run test" each time
+        // and match_command keeps re-entering with that same string.
+        use std::fs;
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"scripts": {"test": "npm run test"}}"#,
+        )
+        .unwrap();
+        assert!(match_command("npm test", Some(dir.path())).is_none());
+        assert!(match_command("npm run test", Some(dir.path())).is_none());
+    }
+
+    #[test]
+    fn match_command_breaks_on_two_step_alias_cycle() {
+        // Regression for the multi-step cycle the simpler "if resolved == cmd"
+        // guard would miss. a → b → a must terminate.
+        use std::fs;
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"scripts": {"a": "npm run b", "b": "npm run a"}}"#,
+        )
+        .unwrap();
+        assert!(match_command("npm run a", Some(dir.path())).is_none());
+        assert!(match_command("npm run b", Some(dir.path())).is_none());
     }
 }

--- a/src-tauri/src/agent/test_runners/matcher.rs
+++ b/src-tauri/src/agent/test_runners/matcher.rs
@@ -1,0 +1,232 @@
+//! Command matching: tokenize → strip env → first segment → strip wrappers
+//! → resolve script alias → match against RUNNERS.
+
+use std::path::Path;
+
+use super::script_resolution;
+use super::types::TestRunner;
+use super::RUNNERS;
+
+/// Tokenize a command string into shell-words, returning None if the input
+/// can't be parsed (e.g. unmatched quotes). None is treated as "no match"
+/// downstream — never as a hard error — so we don't false-positive on weird
+/// shell syntax we haven't seen before.
+pub fn tokenize(cmd: &str) -> Option<Vec<String>> {
+    shell_words::split(cmd).ok()
+}
+
+/// Drop leading KEY=VALUE assignments (env-style) until the first non-assignment.
+pub fn strip_env_prefix(tokens: &[String]) -> &[String] {
+    let mut i = 0;
+    while i < tokens.len() {
+        let t = &tokens[i];
+        // KEY=value: must contain '=', and the part before '=' must look like
+        // an identifier (letters/digits/underscore, not starting with digit).
+        if let Some(eq) = t.find('=') {
+            let key = &t[..eq];
+            if !key.is_empty()
+                && key.chars().next().is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+                && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                i += 1;
+                continue;
+            }
+        }
+        break;
+    }
+    &tokens[i..]
+}
+
+/// Take only the first command segment — split on &&, ;, ||, |.
+pub fn first_segment<'a>(tokens: &'a [String]) -> &'a [String] {
+    let separators = ["&&", "||", ";", "|"];
+    for (i, t) in tokens.iter().enumerate() {
+        if separators.contains(&t.as_str()) {
+            return &tokens[..i];
+        }
+    }
+    tokens
+}
+
+/// Strip leading wrapper prefixes one pass.
+pub fn strip_wrappers<'a>(tokens: &'a [String]) -> &'a [String] {
+    if tokens.is_empty() {
+        return tokens;
+    }
+    match tokens[0].as_str() {
+        "npx" => &tokens[1..],
+        "pnpm" if tokens.get(1).map(String::as_str) == Some("exec") => &tokens[2..],
+        "yarn" if tokens.get(1).map(String::as_str) == Some("exec") => &tokens[2..],
+        "bun" if tokens.get(1).map(String::as_str) == Some("x") => &tokens[2..],
+        "dotenv" if tokens.get(1).map(String::as_str) == Some("--") => &tokens[2..],
+        _ => tokens,
+    }
+}
+
+/// Result of a successful match.
+pub struct MatchedCommand {
+    pub runner: &'static TestRunner,
+    /// Tokens after env-strip + segment-first + wrapper-strip + script
+    /// resolution. Used by build_command_preview for display.
+    pub stripped_tokens: Vec<String>,
+}
+
+/// The full matching pipeline. Returns None when the command does not match
+/// any known runner.
+pub fn match_command(cmd: &str, cwd: Option<&Path>) -> Option<MatchedCommand> {
+    let initial = tokenize(cmd)?;
+    let after_env = strip_env_prefix(&initial).to_vec();
+    let after_segment = first_segment(&after_env).to_vec();
+    let after_wrapper = strip_wrappers(&after_segment).to_vec();
+
+    // Try script alias resolution. If it resolves, recurse on the resolved
+    // string (which goes through the SAME pipeline so its env/wrapper/etc.
+    // are also normalised).
+    if let Some(resolved) = script_resolution::resolve_alias(&after_wrapper, cwd) {
+        return match_command(&resolved, cwd);
+    }
+
+    // Walk RUNNERS. First match wins.
+    let token_refs: Vec<&str> = after_wrapper.iter().map(String::as_str).collect();
+    for runner in RUNNERS {
+        if (runner.matches)(&token_refs) {
+            return Some(MatchedCommand {
+                runner,
+                stripped_tokens: after_wrapper,
+            });
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vec_of(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn tokenize_simple_command() {
+        assert_eq!(tokenize("vitest run"), Some(vec_of(&["vitest", "run"])));
+    }
+
+    #[test]
+    fn tokenize_handles_quotes() {
+        assert_eq!(
+            tokenize(r#"vitest run "src/foo bar.test.ts""#),
+            Some(vec_of(&["vitest", "run", "src/foo bar.test.ts"]))
+        );
+    }
+
+    #[test]
+    fn tokenize_unmatched_quote_returns_none() {
+        assert_eq!(tokenize(r#"vitest "run"#), None);
+    }
+
+    #[test]
+    fn strip_env_drops_assignments_only() {
+        let tokens = vec_of(&["CI=1", "NODE_ENV=test", "vitest"]);
+        assert_eq!(strip_env_prefix(&tokens), &tokens[2..]);
+    }
+
+    #[test]
+    fn strip_env_does_not_drop_value_with_equals() {
+        // "vitest" doesn't contain '=', so nothing stripped
+        let tokens = vec_of(&["vitest", "--reporter=verbose"]);
+        assert_eq!(strip_env_prefix(&tokens), &tokens[..]);
+    }
+
+    #[test]
+    fn first_segment_at_first_separator() {
+        let tokens = vec_of(&["cargo", "build", "&&", "cargo", "test"]);
+        assert_eq!(first_segment(&tokens), &tokens[..2]);
+    }
+
+    #[test]
+    fn first_segment_no_separator_returns_all() {
+        let tokens = vec_of(&["vitest", "run", "src/foo.test.ts"]);
+        assert_eq!(first_segment(&tokens), &tokens[..]);
+    }
+
+    #[test]
+    fn strip_wrappers_handles_npx() {
+        let tokens = vec_of(&["npx", "vitest"]);
+        assert_eq!(strip_wrappers(&tokens), &tokens[1..]);
+    }
+
+    #[test]
+    fn strip_wrappers_handles_pnpm_exec() {
+        let tokens = vec_of(&["pnpm", "exec", "vitest"]);
+        assert_eq!(strip_wrappers(&tokens), &tokens[2..]);
+    }
+
+    #[test]
+    fn strip_wrappers_no_change_when_no_wrapper() {
+        let tokens = vec_of(&["vitest"]);
+        assert_eq!(strip_wrappers(&tokens), &tokens[..]);
+    }
+
+    #[test]
+    fn match_command_finds_vitest() {
+        let m = match_command("vitest run src/foo.test.ts", None).expect("should match");
+        assert_eq!(m.runner.name, "vitest");
+        assert_eq!(m.stripped_tokens, vec_of(&["vitest", "run", "src/foo.test.ts"]));
+    }
+
+    #[test]
+    fn match_command_finds_cargo_test() {
+        let m = match_command("cargo test --release", None).expect("should match");
+        assert_eq!(m.runner.name, "cargo");
+    }
+
+    #[test]
+    fn match_command_strips_env_and_wrapper() {
+        let m = match_command("CI=1 npx vitest", None).expect("should match");
+        assert_eq!(m.runner.name, "vitest");
+        assert_eq!(m.stripped_tokens, vec_of(&["vitest"]));
+    }
+
+    #[test]
+    fn match_command_first_segment_only() {
+        // cargo build && cargo test → only the first segment (cargo build) considered → no match
+        assert!(match_command("cargo build && cargo test", None).is_none());
+    }
+
+    #[test]
+    fn match_command_unknown_returns_none() {
+        assert!(match_command("git diff test.txt", None).is_none());
+        assert!(match_command("eslint test/", None).is_none());
+        assert!(match_command("make test", None).is_none());
+    }
+
+    #[test]
+    fn match_command_resolves_npm_test() {
+        use std::fs;
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"scripts": {"test": "vitest --passWithNoTests"}}"#,
+        )
+        .unwrap();
+        let m = match_command("npm test", Some(dir.path())).expect("should match");
+        assert_eq!(m.runner.name, "vitest");
+    }
+
+    #[test]
+    fn match_command_bun_test_does_not_match_in_v1() {
+        // bun has a built-in test runner; v1 doesn't ship a BUN runner, so this
+        // should NOT match (and definitely not try to resolve a script alias).
+        use std::fs;
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"scripts": {"test": "vitest"}}"#,
+        )
+        .unwrap();
+        assert!(match_command("bun test", Some(dir.path())).is_none());
+    }
+}

--- a/src-tauri/src/agent/test_runners/matcher.rs
+++ b/src-tauri/src/agent/test_runners/matcher.rs
@@ -48,8 +48,29 @@ pub fn first_segment<'a>(tokens: &'a [String]) -> &'a [String] {
     tokens
 }
 
-/// Strip leading wrapper prefixes one pass.
+/// Strip leading wrapper prefixes, looping until no further wrapper is
+/// recognised. Composed wrappers like `dotenv -- npx vitest` or
+/// `pnpm exec dotenv -- vitest` would otherwise leave an inner wrapper
+/// in place, the runner registry wouldn't match, and the test-run event
+/// would silently never fire.
+///
+/// The loop is bounded at 8 iterations to defend against pathological
+/// inputs (a long chain of wrappers, repeated tokenization round-trips).
+/// 8 comfortably exceeds any realistic composition.
 pub fn strip_wrappers<'a>(tokens: &'a [String]) -> &'a [String] {
+    const MAX_ITERATIONS: usize = 8;
+    let mut current = tokens;
+    for _ in 0..MAX_ITERATIONS {
+        let next = strip_one_wrapper(current);
+        if std::ptr::eq(next, current) {
+            return current;
+        }
+        current = next;
+    }
+    current
+}
+
+fn strip_one_wrapper<'a>(tokens: &'a [String]) -> &'a [String] {
     if tokens.is_empty() {
         return tokens;
     }
@@ -166,6 +187,27 @@ mod tests {
     fn strip_wrappers_no_change_when_no_wrapper() {
         let tokens = vec_of(&["vitest"]);
         assert_eq!(strip_wrappers(&tokens), &tokens[..]);
+    }
+
+    #[test]
+    fn strip_wrappers_handles_composed_dotenv_npx() {
+        // dotenv -- npx vitest → vitest (both wrappers must be peeled)
+        let tokens = vec_of(&["dotenv", "--", "npx", "vitest"]);
+        assert_eq!(strip_wrappers(&tokens), &tokens[3..]);
+    }
+
+    #[test]
+    fn strip_wrappers_handles_composed_pnpm_exec_dotenv() {
+        // pnpm exec dotenv -- vitest → vitest
+        let tokens = vec_of(&["pnpm", "exec", "dotenv", "--", "vitest"]);
+        assert_eq!(strip_wrappers(&tokens), &tokens[4..]);
+    }
+
+    #[test]
+    fn match_command_finds_vitest_through_composed_wrappers() {
+        let m = match_command("dotenv -- npx vitest run", None).expect("should match");
+        assert_eq!(m.runner.name, "vitest");
+        assert_eq!(m.stripped_tokens, vec_of(&["vitest", "run"]));
     }
 
     #[test]

--- a/src-tauri/src/agent/test_runners/mod.rs
+++ b/src-tauri/src/agent/test_runners/mod.rs
@@ -11,6 +11,16 @@ pub mod timestamps;
 pub mod types;
 pub mod vitest;
 
+use once_cell::sync::Lazy;
+use regex::Regex;
+
 use types::TestRunner;
 
 pub static RUNNERS: &[&TestRunner] = &[&vitest::VITEST, &cargo::CARGO_TEST];
+
+/// Shared ANSI escape-sequence stripper used by every runner parser
+/// (`vitest.rs`, `cargo.rs`) and the snapshot builder (`build.rs`).
+/// Centralised here so a future pattern change (e.g. handling OSC sequences)
+/// is a one-line update instead of three.
+pub static ANSI_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());

--- a/src-tauri/src/agent/test_runners/mod.rs
+++ b/src-tauri/src/agent/test_runners/mod.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod cargo;
+pub mod emitter;
 pub mod matcher;
 pub mod path_resolution;
 pub mod preview;

--- a/src-tauri/src/agent/test_runners/mod.rs
+++ b/src-tauri/src/agent/test_runners/mod.rs
@@ -1,4 +1,6 @@
 pub mod cargo;
+pub mod matcher;
+pub mod script_resolution;
 pub mod test_file_patterns;
 pub mod types;
 pub mod vitest;

--- a/src-tauri/src/agent/test_runners/mod.rs
+++ b/src-tauri/src/agent/test_runners/mod.rs
@@ -1,0 +1,7 @@
+pub mod cargo;
+pub mod types;
+pub mod vitest;
+
+use types::TestRunner;
+
+pub static RUNNERS: &[&TestRunner] = &[&vitest::VITEST, &cargo::CARGO_TEST];

--- a/src-tauri/src/agent/test_runners/mod.rs
+++ b/src-tauri/src/agent/test_runners/mod.rs
@@ -1,4 +1,5 @@
 pub mod cargo;
+pub mod test_file_patterns;
 pub mod types;
 pub mod vitest;
 

--- a/src-tauri/src/agent/test_runners/mod.rs
+++ b/src-tauri/src/agent/test_runners/mod.rs
@@ -1,7 +1,12 @@
+pub mod build;
 pub mod cargo;
 pub mod matcher;
+pub mod path_resolution;
+pub mod preview;
+pub mod sanitiser;
 pub mod script_resolution;
 pub mod test_file_patterns;
+pub mod timestamps;
 pub mod types;
 pub mod vitest;
 

--- a/src-tauri/src/agent/test_runners/path_resolution.rs
+++ b/src-tauri/src/agent/test_runners/path_resolution.rs
@@ -11,7 +11,19 @@ use std::path::{Component, Path};
 /// We check `..` as an actual path COMPONENT, not as a substring, so legitimate
 /// filenames containing the two-character sequence `..` (e.g.
 /// `reconnect..server.test.ts`) aren't falsely rejected.
+///
+/// Convenience wrapper for one-shot callers. Per-snapshot parsers should
+/// canonicalize CWD ONCE up front and call `resolve_group_path_with_cwd_canonical`
+/// in the loop, since `cwd.canonicalize()` is an OS round-trip and a snapshot
+/// can have up to MAX_GROUPS=500 groups.
 pub fn resolve_group_path(cwd: &Path, label: &str) -> Option<String> {
+    let cwd_canonical = cwd.canonicalize().ok()?;
+    resolve_group_path_with_cwd_canonical(&cwd_canonical, label)
+}
+
+/// Same as `resolve_group_path` but skips canonicalizing CWD on every call.
+/// Use this from within a per-group loop after canonicalizing CWD once.
+pub fn resolve_group_path_with_cwd_canonical(cwd_canonical: &Path, label: &str) -> Option<String> {
     let label_path = Path::new(label);
     if label_path.is_absolute()
         || label_path
@@ -20,9 +32,8 @@ pub fn resolve_group_path(cwd: &Path, label: &str) -> Option<String> {
     {
         return None;
     }
-    let candidate = cwd.join(label_path).canonicalize().ok()?;
-    let cwd_canonical = cwd.canonicalize().ok()?;
-    if !candidate.starts_with(&cwd_canonical) {
+    let candidate = cwd_canonical.join(label_path).canonicalize().ok()?;
+    if !candidate.starts_with(cwd_canonical) {
         return None;
     }
     Some(candidate.display().to_string())

--- a/src-tauri/src/agent/test_runners/path_resolution.rs
+++ b/src-tauri/src/agent/test_runners/path_resolution.rs
@@ -1,17 +1,26 @@
 //! Resolve a runner-emitted relative label to an absolute, contained path.
 
-use std::path::Path;
+use std::path::{Component, Path};
 
 /// Returns Some(absolute_path_string) when:
-///   - label has no `..` segments
+///   - label has no `..` path components (parent-dir traversal)
 ///   - label is not absolute
 ///   - the canonical resolved path is inside the canonical CWD
 /// Returns None otherwise — the row will render non-clickable.
+///
+/// We check `..` as an actual path COMPONENT, not as a substring, so legitimate
+/// filenames containing the two-character sequence `..` (e.g.
+/// `reconnect..server.test.ts`) aren't falsely rejected.
 pub fn resolve_group_path(cwd: &Path, label: &str) -> Option<String> {
-    if label.contains("..") || Path::new(label).is_absolute() {
+    let label_path = Path::new(label);
+    if label_path.is_absolute()
+        || label_path
+            .components()
+            .any(|c| matches!(c, Component::ParentDir))
+    {
         return None;
     }
-    let candidate = cwd.join(label).canonicalize().ok()?;
+    let candidate = cwd.join(label_path).canonicalize().ok()?;
     let cwd_canonical = cwd.canonicalize().ok()?;
     if !candidate.starts_with(&cwd_canonical) {
         return None;
@@ -45,6 +54,29 @@ mod tests {
         let resolved = resolve_group_path(dir.path(), "foo.test.ts");
         assert!(resolved.is_some());
         assert!(resolved.unwrap().contains("foo.test.ts"));
+    }
+
+    #[test]
+    fn accepts_filenames_containing_double_dots() {
+        // Regression: substring `label.contains("..")` would falsely reject
+        // legitimate filenames whose name happens to contain `..` (not the
+        // parent-dir component). The component-based check distinguishes
+        // them. The canonicalize+containment guard below handles the actual
+        // escape case.
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("reconnect..server.test.ts");
+        fs::write(&file, "").unwrap();
+        let resolved = resolve_group_path(dir.path(), "reconnect..server.test.ts");
+        assert!(resolved.is_some(), "should resolve a filename with .. characters");
+        assert!(resolved.unwrap().contains("reconnect..server.test.ts"));
+    }
+
+    #[test]
+    fn rejects_dotdot_in_middle_of_path() {
+        // Component-based check catches `..` whether it's the leading
+        // segment or buried in the middle.
+        let dir = tempdir().unwrap();
+        assert_eq!(resolve_group_path(dir.path(), "src/../../etc/passwd"), None);
     }
 
     #[test]

--- a/src-tauri/src/agent/test_runners/path_resolution.rs
+++ b/src-tauri/src/agent/test_runners/path_resolution.rs
@@ -1,0 +1,71 @@
+//! Resolve a runner-emitted relative label to an absolute, contained path.
+
+use std::path::Path;
+
+/// Returns Some(absolute_path_string) when:
+///   - label has no `..` segments
+///   - label is not absolute
+///   - the canonical resolved path is inside the canonical CWD
+/// Returns None otherwise — the row will render non-clickable.
+pub fn resolve_group_path(cwd: &Path, label: &str) -> Option<String> {
+    if label.contains("..") || Path::new(label).is_absolute() {
+        return None;
+    }
+    let candidate = cwd.join(label).canonicalize().ok()?;
+    let cwd_canonical = cwd.canonicalize().ok()?;
+    if !candidate.starts_with(&cwd_canonical) {
+        return None;
+    }
+    Some(candidate.display().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn rejects_dotdot_escape() {
+        let dir = tempdir().unwrap();
+        assert_eq!(resolve_group_path(dir.path(), "../etc/passwd"), None);
+    }
+
+    #[test]
+    fn rejects_absolute_label() {
+        let dir = tempdir().unwrap();
+        assert_eq!(resolve_group_path(dir.path(), "/etc/passwd"), None);
+    }
+
+    #[test]
+    fn resolves_valid_relative_path() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("foo.test.ts");
+        fs::write(&file, "").unwrap();
+        let resolved = resolve_group_path(dir.path(), "foo.test.ts");
+        assert!(resolved.is_some());
+        assert!(resolved.unwrap().contains("foo.test.ts"));
+    }
+
+    #[test]
+    fn returns_none_for_missing_file() {
+        let dir = tempdir().unwrap();
+        // canonicalize fails for non-existent paths
+        assert_eq!(resolve_group_path(dir.path(), "missing.test.ts"), None);
+    }
+
+    #[test]
+    fn rejects_symlink_pointing_outside_cwd() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            let outer = tempdir().unwrap();
+            let inner = tempdir().unwrap();
+            let target = outer.path().join("secret.test.ts");
+            fs::write(&target, "").unwrap();
+            symlink(&target, inner.path().join("link.test.ts")).unwrap();
+            // The symlink resolves outside the inner CWD → reject.
+            assert_eq!(resolve_group_path(inner.path(), "link.test.ts"), None);
+        }
+    }
+}

--- a/src-tauri/src/agent/test_runners/preview.rs
+++ b/src-tauri/src/agent/test_runners/preview.rs
@@ -1,0 +1,53 @@
+use super::sanitiser::sanitize_for_ui;
+
+const MAX_PREVIEW_LEN: usize = 120;
+
+pub fn build_command_preview(stripped_tokens: &[String]) -> String {
+    let joined = stripped_tokens.join(" ");
+    let sanitized = sanitize_for_ui(&joined);
+    truncate(&sanitized, MAX_PREVIEW_LEN)
+}
+
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else {
+        let end = s
+            .char_indices()
+            .nth(max_len.saturating_sub(3))
+            .map_or(s.len(), |(i, _)| i);
+        format!("{}...", &s[..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vec_of(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn joins_tokens() {
+        assert_eq!(
+            build_command_preview(&vec_of(&["vitest", "run", "src/foo.test.ts"])),
+            "vitest run src/foo.test.ts"
+        );
+    }
+
+    #[test]
+    fn applies_sanitiser() {
+        let p = build_command_preview(&vec_of(&["vitest", "--key", "sk_live_1234567890abcdef1234"]));
+        assert!(!p.contains("sk_live_1234567890abcdef1234"));
+        assert!(p.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn truncates_long_input() {
+        let long = "a".repeat(200);
+        let preview = build_command_preview(&vec_of(&[&long]));
+        assert!(preview.chars().count() <= 120);
+        assert!(preview.ends_with("..."));
+    }
+}

--- a/src-tauri/src/agent/test_runners/preview.rs
+++ b/src-tauri/src/agent/test_runners/preview.rs
@@ -1,10 +1,12 @@
-use super::sanitiser::sanitize_for_ui;
+use super::sanitiser::sanitize_for_command;
 
 const MAX_PREVIEW_LEN: usize = 120;
 
 pub fn build_command_preview(stripped_tokens: &[String]) -> String {
     let joined = stripped_tokens.join(" ");
-    let sanitized = sanitize_for_ui(&joined);
+    // Use the command-specific sanitiser — narrower than the output one
+    // so benign env vars like NODE_ENV=test stay visible in the header.
+    let sanitized = sanitize_for_command(&joined);
     truncate(&sanitized, MAX_PREVIEW_LEN)
 }
 

--- a/src-tauri/src/agent/test_runners/sanitiser.rs
+++ b/src-tauri/src/agent/test_runners/sanitiser.rs
@@ -1,0 +1,74 @@
+//! Conservative redaction for content shown in the UI. Catches the common
+//! shapes; not a comprehensive secret scanner. Applied to BOTH command_preview
+//! and output_excerpt.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+const REDACTED: &str = "[REDACTED]";
+
+static PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        // KEY=value where KEY is uppercase identifier (env-style)
+        Regex::new(r"\b[A-Z][A-Z0-9_]{2,}=\S+").unwrap(),
+        // Bearer tokens (case-insensitive)
+        Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._\-]+").unwrap(),
+        // Authorization headers (case-insensitive)
+        Regex::new(r"(?i)\bAuthorization:\s*\S+").unwrap(),
+        // Stripe/etc-style API keys: (sk|pk|rk)_(live|test)_<alnum16+>
+        Regex::new(r"\b(sk|pk|rk)_(live|test)_[A-Za-z0-9]{16,}").unwrap(),
+        // JWT-like: eyJ followed by base64-ish chunk
+        Regex::new(r"\beyJ[A-Za-z0-9._\-]{10,}").unwrap(),
+    ]
+});
+
+pub fn sanitize_for_ui(input: &str) -> String {
+    let mut out = input.to_string();
+    for re in PATTERNS.iter() {
+        out = re.replace_all(&out, REDACTED).to_string();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_env_assignments() {
+        let s = sanitize_for_ui("STRIPE_KEY=sk_live_abc123 vitest");
+        assert!(!s.contains("sk_live_abc123"));
+        assert!(s.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redacts_bearer_tokens() {
+        let s = sanitize_for_ui("curl -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.foo'");
+        assert!(!s.contains("eyJhbGciOiJIUzI1NiJ9.foo"));
+    }
+
+    #[test]
+    fn redacts_api_key_prefixes() {
+        let s = sanitize_for_ui("--key sk_live_1234567890abcdef1234");
+        assert!(!s.contains("sk_live_1234567890abcdef1234"));
+    }
+
+    #[test]
+    fn redacts_jwt_like() {
+        let s = sanitize_for_ui("token: eyJabcdefghijklmnop.body.sig");
+        assert!(!s.contains("eyJabcdefghijklmnop"));
+    }
+
+    #[test]
+    fn clean_strings_unchanged() {
+        let s = sanitize_for_ui("vitest run src/foo.test.ts");
+        assert_eq!(s, "vitest run src/foo.test.ts");
+    }
+
+    #[test]
+    fn does_not_redact_short_uppercase_words() {
+        // "OK" / "FAIL" without "=" must be untouched
+        let s = sanitize_for_ui("FAIL src/foo.test.ts");
+        assert_eq!(s, "FAIL src/foo.test.ts");
+    }
+}

--- a/src-tauri/src/agent/test_runners/sanitiser.rs
+++ b/src-tauri/src/agent/test_runners/sanitiser.rs
@@ -1,16 +1,26 @@
 //! Conservative redaction for content shown in the UI. Catches the common
-//! shapes; not a comprehensive secret scanner. Applied to BOTH command_preview
-//! and output_excerpt.
+//! shapes; not a comprehensive secret scanner.
+//!
+//! TWO patterns are exposed:
+//!   - sanitize_for_command — narrower; tuned for `command_preview` where
+//!     the matcher pipeline already stripped leading env-var prefixes. Only
+//!     redacts known-sensitive prefixes, plus bearer/authorization/api-key/
+//!     jwt shapes. Leaves benign env vars like NODE_ENV=test or
+//!     VITEST_POOL_ID=1 readable in the panel header.
+//!   - sanitize_for_output — broader; tuned for `output_excerpt` where the
+//!     content is arbitrary captured stderr/stdout that may contain any
+//!     env-var dump. Adds the catch-all KEY=VALUE rule on top of the
+//!     command patterns.
 
 use once_cell::sync::Lazy;
 use regex::Regex;
 
 const REDACTED: &str = "[REDACTED]";
 
-static PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+// Patterns shared by both sanitisers — catch token-shaped secrets that
+// can appear anywhere in either surface.
+static SHARED_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
     vec![
-        // KEY=value where KEY is uppercase identifier (env-style)
-        Regex::new(r"\b[A-Z][A-Z0-9_]{2,}=\S+").unwrap(),
         // Bearer tokens (case-insensitive)
         Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._\-]+").unwrap(),
         // Authorization headers (case-insensitive)
@@ -22,9 +32,49 @@ static PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
     ]
 });
 
-pub fn sanitize_for_ui(input: &str) -> String {
+// Command-only: KEY=VALUE assignments where KEY matches a KNOWN-SECRET
+// prefix list. Catches the common credential shapes without redacting
+// benign diagnostic vars (NODE_ENV, CI, DEBUG, VITEST_POOL_ID, etc.).
+// The matcher's `strip_env_prefix` already removes leading env-var
+// assignments before the preview is built, so this rule mostly catches
+// secrets passed as flag values or positional args.
+static COMMAND_ONLY_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        // SECRET_*, API_*, AUTH_*, TOKEN_*, KEY_*, PASSWORD_*, PASS_*,
+        // PWD_*, PRIVATE_*, ACCESS_*, plus exact GITHUB_TOKEN /
+        // STRIPE_KEY / ANTHROPIC_API_KEY / OPENAI_API_KEY / AWS_*.
+        Regex::new(
+            r"\b(SECRET|API|AUTH|TOKEN|KEY|PASSWORD|PASS|PWD|PRIVATE|ACCESS|GITHUB|STRIPE|ANTHROPIC|OPENAI|AWS|GCP|AZURE)_[A-Z0-9_]*=\S+",
+        )
+        .unwrap(),
+    ]
+});
+
+// Output-only: broad KEY=VALUE rule for arbitrary captured terminal
+// output where the over-redaction trade-off is acceptable (a 240-char
+// error excerpt loses less by over-redacting than by leaking a secret).
+static OUTPUT_ONLY_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        // Any uppercase identifier with =value
+        Regex::new(r"\b[A-Z][A-Z0-9_]{2,}=\S+").unwrap(),
+    ]
+});
+
+/// Sanitiser tuned for `command_preview`. Use this when displaying the
+/// reconstructed test command in the panel header.
+pub fn sanitize_for_command(input: &str) -> String {
+    apply_patterns(input, SHARED_PATTERNS.iter().chain(COMMAND_ONLY_PATTERNS.iter()))
+}
+
+/// Sanitiser tuned for `output_excerpt`. Use this for arbitrary captured
+/// stderr/stdout that may contain env-var dumps or unstructured output.
+pub fn sanitize_for_output(input: &str) -> String {
+    apply_patterns(input, SHARED_PATTERNS.iter().chain(OUTPUT_ONLY_PATTERNS.iter()))
+}
+
+fn apply_patterns<'a>(input: &str, patterns: impl Iterator<Item = &'a Regex>) -> String {
     let mut out = input.to_string();
-    for re in PATTERNS.iter() {
+    for re in patterns {
         out = re.replace_all(&out, REDACTED).to_string();
     }
     out
@@ -34,41 +84,65 @@ pub fn sanitize_for_ui(input: &str) -> String {
 mod tests {
     use super::*;
 
+    // --- command preview ---
+
     #[test]
-    fn redacts_env_assignments() {
-        let s = sanitize_for_ui("STRIPE_KEY=sk_live_abc123 vitest");
-        assert!(!s.contains("sk_live_abc123"));
+    fn command_redacts_known_secret_env_prefixes() {
+        let s = sanitize_for_command("STRIPE_KEY=sk_live_abc1234567890abcd vitest");
+        assert!(!s.contains("sk_live_abc1234567890abcd"));
         assert!(s.contains("[REDACTED]"));
     }
 
     #[test]
-    fn redacts_bearer_tokens() {
-        let s = sanitize_for_ui("curl -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.foo'");
+    fn command_does_not_redact_benign_env_vars() {
+        // Regression: previously `\b[A-Z][A-Z0-9_]{2,}=\S+` redacted these
+        // unconditionally, leaving "[REDACTED] vitest run" in the header.
+        let s = sanitize_for_command("NODE_ENV=test VITEST_POOL_ID=1 CI=true vitest run");
+        assert!(s.contains("NODE_ENV=test"), "NODE_ENV should be visible: {}", s);
+        assert!(s.contains("VITEST_POOL_ID=1"), "VITEST_POOL_ID should be visible: {}", s);
+        assert!(s.contains("CI=true"), "CI should be visible: {}", s);
+    }
+
+    #[test]
+    fn command_redacts_bearer_and_jwt() {
+        let s = sanitize_for_command(
+            "curl -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.foo' https://api",
+        );
         assert!(!s.contains("eyJhbGciOiJIUzI1NiJ9.foo"));
     }
 
     #[test]
-    fn redacts_api_key_prefixes() {
-        let s = sanitize_for_ui("--key sk_live_1234567890abcdef1234");
+    fn command_redacts_bare_api_key_prefixes() {
+        let s = sanitize_for_command("--key sk_live_1234567890abcdef1234");
         assert!(!s.contains("sk_live_1234567890abcdef1234"));
     }
 
     #[test]
-    fn redacts_jwt_like() {
-        let s = sanitize_for_ui("token: eyJabcdefghijklmnop.body.sig");
-        assert!(!s.contains("eyJabcdefghijklmnop"));
-    }
-
-    #[test]
-    fn clean_strings_unchanged() {
-        let s = sanitize_for_ui("vitest run src/foo.test.ts");
+    fn command_clean_strings_unchanged() {
+        let s = sanitize_for_command("vitest run src/foo.test.ts");
         assert_eq!(s, "vitest run src/foo.test.ts");
     }
 
     #[test]
-    fn does_not_redact_short_uppercase_words() {
-        // "OK" / "FAIL" without "=" must be untouched
-        let s = sanitize_for_ui("FAIL src/foo.test.ts");
+    fn command_does_not_redact_short_uppercase_words() {
+        let s = sanitize_for_command("FAIL src/foo.test.ts");
         assert_eq!(s, "FAIL src/foo.test.ts");
+    }
+
+    // --- output excerpt (broader rule kicks in) ---
+
+    #[test]
+    fn output_redacts_arbitrary_uppercase_assignments() {
+        // Output excerpts may contain env-var dumps from `env` or panic
+        // messages; the conservative pattern is appropriate here.
+        let s = sanitize_for_output("Crashed with NODE_ENV=test SECRET_KEY=abc123");
+        assert!(!s.contains("NODE_ENV=test"));
+        assert!(!s.contains("SECRET_KEY=abc123"));
+    }
+
+    #[test]
+    fn output_still_redacts_token_shapes() {
+        let s = sanitize_for_output("got token: eyJabcdefghijklmnop.body.sig");
+        assert!(!s.contains("eyJabcdefghijklmnop"));
     }
 }

--- a/src-tauri/src/agent/test_runners/sanitiser.rs
+++ b/src-tauri/src/agent/test_runners/sanitiser.rs
@@ -21,10 +21,16 @@ const REDACTED: &str = "[REDACTED]";
 // can appear anywhere in either surface.
 static SHARED_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
     vec![
-        // Bearer tokens (case-insensitive)
-        Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._\-]+").unwrap(),
-        // Authorization headers (case-insensitive)
-        Regex::new(r"(?i)\bAuthorization:\s*\S+").unwrap(),
+        // Bearer tokens (case-insensitive). Charset includes base64 chars
+        // (`+`, `/`, `=`) — earlier `[A-Za-z0-9._\-]+` only redacted the
+        // PREFIX of a base64-encoded credential and left the suffix
+        // visible. Now matches the full token through the next whitespace.
+        Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._+/=\-]+").unwrap(),
+        // Authorization headers (case-insensitive). Match through end of
+        // line — the previous `\S+` only consumed the FIRST non-whitespace
+        // token, so multi-token credentials like `Authorization: Basic
+        // abc xyz` left `abc xyz` visible.
+        Regex::new(r"(?i)\bAuthorization:\s*[^\r\n]+").unwrap(),
         // Stripe/etc-style API keys: (sk|pk|rk)_(live|test)_<alnum16+>
         Regex::new(r"\b(sk|pk|rk)_(live|test)_[A-Za-z0-9]{16,}").unwrap(),
         // JWT-like: eyJ followed by base64-ish chunk
@@ -144,5 +150,30 @@ mod tests {
     fn output_still_redacts_token_shapes() {
         let s = sanitize_for_output("got token: eyJabcdefghijklmnop.body.sig");
         assert!(!s.contains("eyJabcdefghijklmnop"));
+    }
+
+    // --- regression: multi-token Authorization values fully redacted ---
+
+    #[test]
+    fn redacts_full_basic_authorization_header() {
+        // Regression: previously `Authorization:\s*\S+` only matched
+        // "Basic" and left "abc xyz" visible.
+        let s = sanitize_for_command("Authorization: Basic abc xyz");
+        assert!(!s.contains("abc xyz"), "secret leaked: {}", s);
+        let t = sanitize_for_output("Authorization: Basic dXNlcjpwYXNz");
+        assert!(!t.contains("dXNlcjpwYXNz"), "secret leaked: {}", t);
+    }
+
+    // --- regression: bearer tokens with base64 chars fully redacted ---
+
+    #[test]
+    fn redacts_bearer_tokens_with_base64_chars() {
+        // Regression: previously `Bearer\s+[A-Za-z0-9._\-]+` excluded
+        // `+`, `/`, `=`, leaving the suffix of base64-encoded tokens
+        // visible (e.g. "Bearer YWJj+/==" only redacted "YWJj").
+        let s = sanitize_for_command("Bearer YWJjZGVm+/==");
+        assert!(!s.contains("YWJjZGVm+/=="), "secret leaked: {}", s);
+        let t = sanitize_for_output("auth: Bearer abc/def+ghi=");
+        assert!(!t.contains("abc/def+ghi="), "secret leaked: {}", t);
     }
 }

--- a/src-tauri/src/agent/test_runners/script_resolution.rs
+++ b/src-tauri/src/agent/test_runners/script_resolution.rs
@@ -17,8 +17,27 @@ const MAX_RECURSION_DEPTH: usize = 3;
 /// test runner. Adding a Bun runner is future work.
 pub fn resolve_alias(tokens: &[String], cwd: Option<&Path>) -> Option<String> {
     let cwd = cwd?;
-    let (script_name, _consumed) = parse_alias_invocation(tokens)?;
-    resolve_recursive(&script_name, cwd, 0)
+    let (script_name, consumed) = parse_alias_invocation(tokens)?;
+    let resolved = resolve_recursive(&script_name, cwd, 0)?;
+
+    // Preserve any CLI args after the script name. npm forwards
+    // `npm test -- src/foo.test.ts` as `<script-body> src/foo.test.ts`
+    // (the `--` separator is dropped before forwarding). Without this,
+    // `npm test -- --reporter verbose` would resolve to just `vitest`,
+    // losing the user-supplied args.
+    let leftover = &tokens[consumed..];
+    let leftover = if leftover.first().map(String::as_str) == Some("--") {
+        &leftover[1..]
+    } else {
+        leftover
+    };
+    if leftover.is_empty() {
+        Some(resolved)
+    } else {
+        // shell-words::join re-escapes any tokens with spaces or quotes
+        // so the resulting string round-trips through tokenize cleanly.
+        Some(format!("{} {}", resolved, shell_words::join(leftover.iter())))
+    }
 }
 
 fn parse_alias_invocation(tokens: &[String]) -> Option<(String, usize)> {
@@ -119,14 +138,20 @@ mod tests {
     }
 
     #[test]
-    fn alias_loop_bounded_to_depth_3() {
+    fn alias_loop_does_not_hang_at_depth_limit() {
+        // Renamed from `alias_loop_bounded_to_depth_3` to reflect what's
+        // actually being asserted: this test only verifies termination,
+        // NOT that resolve_alias detects the cycle. Cross-call cycle
+        // safety lives in `match_command_inner`'s visited HashSet (see
+        // matcher.rs); resolve_alias here returns the LITERAL resolved
+        // string when depth bottoms out, which would then re-enter
+        // match_command_inner and be caught by the visited set.
         let dir = tempdir().unwrap();
-        // "test" → "npm run test" → "npm run test" → ... should not infinite-loop
         write_pkg(dir.path(), r#""test": "npm run test""#);
-        // Depth bound triggers, returns None for the deepest recursion attempt.
-        // The outer call still returns Some(the literal resolved string) because
-        // recursion bottoms out and the outer fallback is the resolved string itself.
-        // We just need to confirm it doesn't hang.
+        // Some(literal string) is the EXPECTED return — termination is
+        // the only property under test here. End-to-end cycle safety is
+        // covered by match_command_breaks_on_self_referential_npm_script
+        // in matcher.rs.
         let result = resolve_alias(&vec_of(&["npm", "test"]), Some(dir.path()));
         assert!(result.is_some());
     }

--- a/src-tauri/src/agent/test_runners/script_resolution.rs
+++ b/src-tauri/src/agent/test_runners/script_resolution.rs
@@ -1,0 +1,153 @@
+//! Resolve `npm/yarn/pnpm test` and `npm/yarn/pnpm/bun run <name>` against
+//! package.json scripts, with a depth-3 recursion bound to defend against
+//! pathological alias loops.
+
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+const MAX_RECURSION_DEPTH: usize = 3;
+
+/// Returns Some(resolved_command_string) if the first two tokens are a known
+/// npm-family script invocation AND package.json contains the script.
+/// Returns None for everything else (caller continues with original tokens).
+///
+/// `bun test` is intentionally NOT treated as an alias — bun has a built-in
+/// test runner. Adding a Bun runner is future work.
+pub fn resolve_alias(tokens: &[String], cwd: Option<&Path>) -> Option<String> {
+    let cwd = cwd?;
+    let (script_name, _consumed) = parse_alias_invocation(tokens)?;
+    resolve_recursive(&script_name, cwd, 0)
+}
+
+fn parse_alias_invocation(tokens: &[String]) -> Option<(String, usize)> {
+    if tokens.len() < 2 {
+        return None;
+    }
+    let pm = tokens[0].as_str();
+    let arg = tokens[1].as_str();
+    match (pm, arg) {
+        // bare `test` — treat as `run test`
+        ("npm" | "yarn" | "pnpm", "test") => Some(("test".to_string(), 2)),
+        // `run <name>`
+        ("npm" | "yarn" | "pnpm" | "bun", "run") => {
+            let name = tokens.get(2)?.clone();
+            Some((name, 3))
+        }
+        _ => None,
+    }
+}
+
+fn resolve_recursive(script_name: &str, cwd: &Path, depth: usize) -> Option<String> {
+    if depth >= MAX_RECURSION_DEPTH {
+        return None;
+    }
+    let pkg_path = cwd.join("package.json");
+    let content = fs::read_to_string(&pkg_path).ok()?;
+    let json: Value = serde_json::from_str(&content).ok()?;
+    let resolved = json
+        .get("scripts")
+        .and_then(|s| s.get(script_name))
+        .and_then(|v| v.as_str())?;
+
+    // If the resolved string itself is an npm-family alias, recurse.
+    if let Some(tokens) = super::matcher::tokenize(resolved) {
+        if let Some((next_script, _)) = parse_alias_invocation(&tokens) {
+            if let Some(deeper) = resolve_recursive(&next_script, cwd, depth + 1) {
+                return Some(deeper);
+            }
+        }
+    }
+    Some(resolved.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_pkg(dir: &Path, scripts: &str) {
+        fs::write(
+            dir.join("package.json"),
+            format!(r#"{{"scripts": {{ {scripts} }} }}"#),
+        )
+        .unwrap();
+    }
+
+    fn vec_of(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn npm_test_resolves_to_script() {
+        let dir = tempdir().unwrap();
+        write_pkg(dir.path(), r#""test": "vitest --passWithNoTests""#);
+        assert_eq!(
+            resolve_alias(&vec_of(&["npm", "test"]), Some(dir.path())),
+            Some("vitest --passWithNoTests".to_string())
+        );
+    }
+
+    #[test]
+    fn npm_run_named_script_resolves() {
+        let dir = tempdir().unwrap();
+        write_pkg(dir.path(), r#""test:int": "vitest run integration""#);
+        assert_eq!(
+            resolve_alias(&vec_of(&["npm", "run", "test:int"]), Some(dir.path())),
+            Some("vitest run integration".to_string())
+        );
+    }
+
+    #[test]
+    fn missing_script_returns_none() {
+        let dir = tempdir().unwrap();
+        write_pkg(dir.path(), r#""build": "tsc""#);
+        assert_eq!(
+            resolve_alias(&vec_of(&["npm", "test"]), Some(dir.path())),
+            None
+        );
+    }
+
+    #[test]
+    fn missing_cwd_returns_none() {
+        assert_eq!(
+            resolve_alias(&vec_of(&["npm", "test"]), None),
+            None
+        );
+    }
+
+    #[test]
+    fn alias_loop_bounded_to_depth_3() {
+        let dir = tempdir().unwrap();
+        // "test" → "npm run test" → "npm run test" → ... should not infinite-loop
+        write_pkg(dir.path(), r#""test": "npm run test""#);
+        // Depth bound triggers, returns None for the deepest recursion attempt.
+        // The outer call still returns Some(the literal resolved string) because
+        // recursion bottoms out and the outer fallback is the resolved string itself.
+        // We just need to confirm it doesn't hang.
+        let result = resolve_alias(&vec_of(&["npm", "test"]), Some(dir.path()));
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn bun_test_not_treated_as_alias() {
+        let dir = tempdir().unwrap();
+        write_pkg(dir.path(), r#""test": "this should not be returned""#);
+        assert_eq!(
+            resolve_alias(&vec_of(&["bun", "test"]), Some(dir.path())),
+            None
+        );
+    }
+
+    #[test]
+    fn bun_run_resolves_normally() {
+        let dir = tempdir().unwrap();
+        write_pkg(dir.path(), r#""test": "vitest""#);
+        assert_eq!(
+            resolve_alias(&vec_of(&["bun", "run", "test"]), Some(dir.path())),
+            Some("vitest".to_string())
+        );
+    }
+}

--- a/src-tauri/src/agent/test_runners/test_file_patterns.rs
+++ b/src-tauri/src/agent/test_runners/test_file_patterns.rs
@@ -32,8 +32,14 @@ pub fn is_test_file(path: &str) -> bool {
         }
     }
 
-    // Rust: anything inside a tests/ directory
-    if path.contains("/tests/") || path.starts_with("tests/") {
+    // Rust: .rs files inside a tests/ directory (Cargo integration tests).
+    // Restricting to .rs is important — non-RS files under tests/ are test
+    // ASSETS (fixtures, JSON snapshots, JSONL transcripts) not tests
+    // themselves. Tagging fixture writes as "CREATED TEST" in the activity
+    // feed would erode the label's signal value.
+    let is_in_tests_dir = path.contains("/tests/") || path.starts_with("tests/");
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    if is_in_tests_dir && basename.ends_with(".rs") {
         return true;
     }
 
@@ -72,6 +78,19 @@ mod tests {
     fn rust_non_test_files_dont_match() {
         assert!(!is_test_file("src/foo.rs"));
         assert!(!is_test_file("src/test_helper.rs")); // not _test.rs and not in tests/
+    }
+
+    #[test]
+    fn fixtures_under_tests_dont_match() {
+        // Regression: non-RS files under tests/ (test ASSETS — fixtures,
+        // JSON snapshots, JSONL transcripts) used to satisfy the broad
+        // /tests/ heuristic. Now the rule restricts to .rs files. This
+        // PR's own fixtures live under src-tauri/tests/fixtures/*.jsonl
+        // and would have been mislabelled as test creations.
+        assert!(!is_test_file("src-tauri/tests/fixtures/transcript_vitest_pass.jsonl"));
+        assert!(!is_test_file("tests/fixtures/cases.json"));
+        assert!(!is_test_file("crates/x/tests/snapshot.toml"));
+        assert!(!is_test_file("tests/README.md"));
     }
 
     #[test]

--- a/src-tauri/src/agent/test_runners/test_file_patterns.rs
+++ b/src-tauri/src/agent/test_runners/test_file_patterns.rs
@@ -3,8 +3,17 @@
 
 /// Returns true if `path` matches a known test-file convention.
 /// Matches on the basename and (for some languages) directory position.
+///
+/// Handles both `/` and `\` as path separators so Windows-style paths
+/// from tool calls (e.g. `C:\repo\tests\integration.rs`) are classified
+/// the same as POSIX paths.
 pub fn is_test_file(path: &str) -> bool {
-    let basename = path.rsplit('/').next().unwrap_or(path);
+    // Split on either separator so basename extraction and directory
+    // checks below work regardless of OS path style.
+    let basename = path
+        .rsplit(|c| c == '/' || c == '\\')
+        .next()
+        .unwrap_or(path);
 
     // TS/JS: *.test.{ts,tsx,js,jsx,mjs,cjs} and *.spec.{...}
     if let Some(stem_end) = basename.rfind('.') {
@@ -37,8 +46,12 @@ pub fn is_test_file(path: &str) -> bool {
     // ASSETS (fixtures, JSON snapshots, JSONL transcripts) not tests
     // themselves. Tagging fixture writes as "CREATED TEST" in the activity
     // feed would erode the label's signal value.
-    let is_in_tests_dir = path.contains("/tests/") || path.starts_with("tests/");
-    let basename = path.rsplit('/').next().unwrap_or(path);
+    //
+    // Check both separator styles for Windows compatibility.
+    let is_in_tests_dir = path.contains("/tests/")
+        || path.contains("\\tests\\")
+        || path.starts_with("tests/")
+        || path.starts_with("tests\\");
     if is_in_tests_dir && basename.ends_with(".rs") {
         return true;
     }
@@ -109,5 +122,21 @@ mod tests {
         assert!(!is_test_file(""));
         assert!(!is_test_file("/"));
         assert!(!is_test_file("foo"));
+    }
+
+    #[test]
+    fn windows_paths_match() {
+        // Regression: rsplit('/') and contains("/tests/") only handled
+        // POSIX paths, so Windows-style tool-call paths regressed.
+        assert!(is_test_file(r"C:\repo\src\foo.test.ts"));
+        assert!(is_test_file(r"C:\repo\src\foo_test.rs"));
+        assert!(is_test_file(r"C:\repo\tests\integration.rs"));
+        assert!(is_test_file(r"tests\it.rs"));
+    }
+
+    #[test]
+    fn windows_non_test_files_dont_match() {
+        assert!(!is_test_file(r"C:\repo\src\foo.ts"));
+        assert!(!is_test_file(r"C:\repo\tests\fixture.json"));
     }
 }

--- a/src-tauri/src/agent/test_runners/test_file_patterns.rs
+++ b/src-tauri/src/agent/test_runners/test_file_patterns.rs
@@ -1,0 +1,94 @@
+//! Test-file path matching. Frontend reads is_test_file: bool from
+//! AgentToolCallEvent and renders accordingly — no JS-side glob.
+
+/// Returns true if `path` matches a known test-file convention.
+/// Matches on the basename and (for some languages) directory position.
+pub fn is_test_file(path: &str) -> bool {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+
+    // TS/JS: *.test.{ts,tsx,js,jsx,mjs,cjs} and *.spec.{...}
+    if let Some(stem_end) = basename.rfind('.') {
+        let ext = &basename[stem_end + 1..];
+        let stem = &basename[..stem_end];
+        if matches!(ext, "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs") {
+            if let Some(inner_end) = stem.rfind('.') {
+                let infix = &stem[inner_end + 1..];
+                if infix == "test" || infix == "spec" {
+                    return true;
+                }
+            }
+        }
+        // Rust: *_test.rs (cargo convention)
+        if ext == "rs" && stem.ends_with("_test") {
+            return true;
+        }
+        // Python: test_*.py and *_test.py (pytest convention)
+        if ext == "py" && (stem.starts_with("test_") || stem.ends_with("_test")) {
+            return true;
+        }
+        // Go: *_test.go
+        if ext == "go" && stem.ends_with("_test") {
+            return true;
+        }
+    }
+
+    // Rust: anything inside a tests/ directory
+    if path.contains("/tests/") || path.starts_with("tests/") {
+        return true;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ts_test_files_match() {
+        assert!(is_test_file("src/foo.test.ts"));
+        assert!(is_test_file("src/foo.test.tsx"));
+        assert!(is_test_file("src/foo.spec.ts"));
+        assert!(is_test_file("/abs/src/bar.test.mjs"));
+        assert!(is_test_file("packages/x/src/baz.test.cjs"));
+    }
+
+    #[test]
+    fn ts_non_test_files_dont_match() {
+        assert!(!is_test_file("src/foo.ts"));
+        assert!(!is_test_file("src/tests-helper.ts"));
+        assert!(!is_test_file("test.txt"));
+        assert!(!is_test_file("src/test.config.ts")); // .test. but ext is .ts not .test.ts
+    }
+
+    #[test]
+    fn rust_test_files_match() {
+        assert!(is_test_file("src/foo_test.rs"));
+        assert!(is_test_file("crates/x/tests/integration.rs"));
+        assert!(is_test_file("tests/it.rs"));
+    }
+
+    #[test]
+    fn rust_non_test_files_dont_match() {
+        assert!(!is_test_file("src/foo.rs"));
+        assert!(!is_test_file("src/test_helper.rs")); // not _test.rs and not in tests/
+    }
+
+    #[test]
+    fn python_test_files_match() {
+        assert!(is_test_file("tests/test_foo.py"));
+        assert!(is_test_file("src/foo_test.py"));
+    }
+
+    #[test]
+    fn go_test_files_match() {
+        assert!(is_test_file("pkg/foo_test.go"));
+    }
+
+    #[test]
+    fn empty_and_weird_paths_dont_match() {
+        assert!(!is_test_file(""));
+        assert!(!is_test_file("/"));
+        assert!(!is_test_file("foo"));
+    }
+}

--- a/src-tauri/src/agent/test_runners/timestamps.rs
+++ b/src-tauri/src/agent/test_runners/timestamps.rs
@@ -1,0 +1,83 @@
+use std::time::Duration;
+
+use chrono::DateTime;
+
+/// Parse an ISO 8601 string (with or without fractional seconds) to
+/// milliseconds since the Unix epoch. Returns None on parse failure.
+pub fn parse_iso8601_ms(s: &str) -> Option<u64> {
+    let dt = DateTime::parse_from_rfc3339(s).ok()?;
+    let ms = dt.timestamp_millis();
+    if ms < 0 {
+        return None;
+    }
+    Some(ms as u64)
+}
+
+/// Compute the duration between two ISO 8601 timestamps. Falls back to the
+/// provided `fallback` duration if either timestamp can't be parsed or the
+/// computed range is negative.
+pub fn compute_duration_ms(started_at: &str, finished_at: &str, fallback: Duration) -> u64 {
+    match (parse_iso8601_ms(started_at), parse_iso8601_ms(finished_at)) {
+        (Some(start), Some(end)) if end >= start => end - start,
+        _ => {
+            log::debug!("Falling back to Instant::elapsed for test-run duration");
+            fallback.as_millis() as u64
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_iso8601_no_fraction() {
+        assert_eq!(parse_iso8601_ms("2026-04-28T12:00:00Z"), Some(1777377600000));
+    }
+
+    #[test]
+    fn parses_iso8601_with_fraction() {
+        assert_eq!(
+            parse_iso8601_ms("2026-04-28T12:00:00.500Z"),
+            Some(1777377600500)
+        );
+    }
+
+    #[test]
+    fn returns_none_on_garbage() {
+        assert_eq!(parse_iso8601_ms("not-a-date"), None);
+        assert_eq!(parse_iso8601_ms(""), None);
+    }
+
+    #[test]
+    fn duration_uses_timestamps_when_valid() {
+        assert_eq!(
+            compute_duration_ms(
+                "2026-04-28T12:00:00Z",
+                "2026-04-28T12:00:01.500Z",
+                Duration::from_millis(0),
+            ),
+            1500
+        );
+    }
+
+    #[test]
+    fn duration_falls_back_when_end_before_start() {
+        assert_eq!(
+            compute_duration_ms(
+                "2026-04-28T12:00:01Z",
+                "2026-04-28T12:00:00Z",
+                Duration::from_millis(42),
+            ),
+            42
+        );
+    }
+
+    #[test]
+    fn duration_falls_back_when_unparseable() {
+        assert_eq!(
+            compute_duration_ms("garbage", "garbage", Duration::from_millis(7)),
+            7
+        );
+    }
+}

--- a/src-tauri/src/agent/test_runners/types.rs
+++ b/src-tauri/src/agent/test_runners/types.rs
@@ -1,0 +1,77 @@
+use std::path::Path;
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TestRunSnapshot {
+    pub session_id: String,
+    pub runner: String,
+    pub command_preview: String,
+    pub started_at: String,
+    pub finished_at: String,
+    pub duration_ms: u64,
+    pub status: TestRunStatus,
+    pub summary: TestRunSummary,
+    pub output_excerpt: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum TestRunStatus {
+    Pass,
+    Fail,
+    NoTests,
+    Error,
+}
+
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TestRunSummary {
+    pub passed: u32,
+    pub failed: u32,
+    pub skipped: u32,
+    pub total: u32,
+    pub groups: Vec<TestGroup>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TestGroup {
+    pub label: String,
+    pub path: Option<String>,
+    pub kind: TestGroupKind,
+    pub passed: u32,
+    pub failed: u32,
+    pub skipped: u32,
+    pub total: u32,
+    pub status: TestGroupStatus,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TestGroupKind {
+    File,
+    Suite,
+    Module,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TestGroupStatus {
+    Pass,
+    Fail,
+    Skip,
+}
+
+/// Bash tool_result content captured for a matched test-run tool_use.
+pub struct CapturedOutput {
+    pub content: String,
+    pub is_error: bool,
+}
+
+pub struct TestRunner {
+    pub name: &'static str,
+    pub matches: fn(tokens: &[&str]) -> bool,
+    pub parse_result: fn(out: &CapturedOutput, cwd: &Path) -> Option<TestRunSummary>,
+}

--- a/src-tauri/src/agent/test_runners/vitest.rs
+++ b/src-tauri/src/agent/test_runners/vitest.rs
@@ -1,6 +1,21 @@
+//! Vitest result parser. Targets vitest 1.x summary format.
+//!
+//! Canonical summary lines (after ANSI strip):
+//!   Test Files  3 passed (3)
+//!        Tests  47 passed | 2 failed | 1 skipped (50)
+//! Per-file lines (within run output):
+//!   ✓ src/foo.test.ts (12)
+//!   ✗ src/bar.test.ts (8 | 3 failed)
+
 use std::path::Path;
 
-use super::types::{CapturedOutput, TestRunSummary, TestRunner};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use super::path_resolution::resolve_group_path;
+use super::types::{
+    CapturedOutput, TestGroup, TestGroupKind, TestGroupStatus, TestRunSummary, TestRunner,
+};
 
 pub static VITEST: TestRunner = TestRunner {
     name: "vitest",
@@ -8,18 +23,98 @@ pub static VITEST: TestRunner = TestRunner {
     parse_result: vitest_parse_result,
 };
 
+const MAX_GROUPS: usize = 500;
+
 fn vitest_matches(tokens: &[&str]) -> bool {
     matches!(tokens.first(), Some(&"vitest"))
 }
 
-fn vitest_parse_result(_out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummary> {
-    // Implemented in Task 5
-    None
+static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
+
+// Capture passed/failed/skipped counts from the "Tests" summary line.
+// Examples:
+//   Tests  47 passed (47)
+//   Tests  47 passed | 2 failed (49)
+//   Tests  47 passed | 2 failed | 1 skipped (50)
+//   Tests  no tests
+static TESTS_LINE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?m)^\s*Tests\s+(?:(\d+)\s+passed)?(?:.*?(\d+)\s+failed)?(?:.*?(\d+)\s+skipped)?",
+    )
+    .unwrap()
+});
+
+// File rows: "✓ src/foo.test.ts (12)" or "✗ src/bar.test.ts (8 | 3 failed)"
+static FILE_ROW_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?m)^\s*([✓✗⊘])\s+(\S+\.[A-Za-z]+)\s*\((\d+)(?:\s*\|\s*(\d+)\s+failed)?\)")
+        .unwrap()
+});
+
+fn vitest_parse_result(out: &CapturedOutput, cwd: &Path) -> Option<TestRunSummary> {
+    let stripped = ANSI_RE.replace_all(&out.content, "").to_string();
+
+    // Pull summary counts from the Tests line.
+    let caps = TESTS_LINE_RE.captures(&stripped)?;
+    let passed = caps.get(1).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    let failed = caps.get(2).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    let skipped = caps.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    let total = passed + failed + skipped;
+
+    // Pull per-file groups.
+    let mut groups: Vec<TestGroup> = Vec::new();
+    for cap in FILE_ROW_RE.captures_iter(&stripped) {
+        if groups.len() >= MAX_GROUPS {
+            break;
+        }
+        let icon = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let label = cap.get(2).map(|m| m.as_str().to_string()).unwrap_or_default();
+        let file_total: u32 = cap
+            .get(3)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0);
+        let file_failed: u32 = cap
+            .get(4)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0);
+        let file_passed = file_total.saturating_sub(file_failed);
+        let status = match icon {
+            "✓" => TestGroupStatus::Pass,
+            "✗" => TestGroupStatus::Fail,
+            "⊘" => TestGroupStatus::Skip,
+            _ => TestGroupStatus::Pass,
+        };
+        let path = resolve_group_path(cwd, &label);
+        groups.push(TestGroup {
+            label,
+            path,
+            kind: TestGroupKind::File,
+            passed: file_passed,
+            failed: file_failed,
+            skipped: 0,
+            total: file_total,
+            status,
+        });
+    }
+
+    Some(TestRunSummary {
+        passed,
+        failed,
+        skipped,
+        total,
+        groups,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn captured(content: &str) -> CapturedOutput {
+        CapturedOutput { content: content.to_string(), is_error: false }
+    }
 
     #[test]
     fn vitest_matches_first_token() {
@@ -27,5 +122,66 @@ mod tests {
         assert!((VITEST.matches)(&["vitest", "run", "src/foo.test.ts"]));
         assert!(!(VITEST.matches)(&["jest"]));
         assert!(!(VITEST.matches)(&[]));
+    }
+
+    #[test]
+    fn parses_simple_pass_summary() {
+        let out = captured(
+            "Test Files  1 passed (1)\n     Tests  3 passed (3)\n",
+        );
+        let s = vitest_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.passed, 3);
+        assert_eq!(s.failed, 0);
+        assert_eq!(s.skipped, 0);
+        assert_eq!(s.total, 3);
+    }
+
+    #[test]
+    fn parses_mixed_pass_fail_skip() {
+        let out = captured(
+            "Test Files  2 passed | 1 failed (3)\n     Tests  47 passed | 2 failed | 1 skipped (50)\n",
+        );
+        let s = vitest_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.passed, 47);
+        assert_eq!(s.failed, 2);
+        assert_eq!(s.skipped, 1);
+        assert_eq!(s.total, 50);
+    }
+
+    #[test]
+    fn parses_per_file_rows() {
+        let dir = tempdir().unwrap();
+        let foo = dir.path().join("foo.test.ts");
+        fs::write(&foo, "").unwrap();
+        let out_str = format!(
+            "✓ foo.test.ts (12)\n✗ missing.test.ts (8 | 3 failed)\n     Tests  17 passed | 3 failed (20)\n"
+        );
+        let out = captured(&out_str);
+        let s = vitest_parse_result(&out, dir.path()).unwrap();
+        assert_eq!(s.groups.len(), 2);
+        assert_eq!(s.groups[0].label, "foo.test.ts");
+        assert!(s.groups[0].path.is_some());
+        assert_eq!(s.groups[0].passed, 12);
+        assert_eq!(s.groups[0].failed, 0);
+        assert_eq!(s.groups[1].label, "missing.test.ts");
+        assert!(s.groups[1].path.is_none()); // file doesn't exist → no path
+        assert_eq!(s.groups[1].passed, 5);
+        assert_eq!(s.groups[1].failed, 3);
+    }
+
+    #[test]
+    fn strips_ansi_before_parsing() {
+        let out = captured(
+            "\x1b[32m✓\x1b[0m foo.test.ts (12)\n     Tests  12 passed (12)\n",
+        );
+        let s = vitest_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.total, 12);
+        assert_eq!(s.groups.len(), 1);
+    }
+
+    #[test]
+    fn returns_none_when_no_tests_line() {
+        let out = captured("error: command not found");
+        assert!(vitest_parse_result(&out, &PathBuf::from("/tmp")).is_none());
     }
 }

--- a/src-tauri/src/agent/test_runners/vitest.rs
+++ b/src-tauri/src/agent/test_runners/vitest.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use super::path_resolution::resolve_group_path;
+use super::path_resolution::resolve_group_path_with_cwd_canonical;
 use super::types::{
     CapturedOutput, TestGroup, TestGroupKind, TestGroupStatus, TestRunSummary, TestRunner,
 };
@@ -59,6 +59,13 @@ fn vitest_parse_result(out: &CapturedOutput, cwd: &Path) -> Option<TestRunSummar
     let skipped = caps.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
     let total = passed + failed + skipped;
 
+    // Canonicalize CWD ONCE up front. resolve_group_path's per-call
+    // version would re-canonicalize for every group — wasted OS round-trip
+    // when MAX_GROUPS=500. None means cwd doesn't exist; per-group path
+    // resolution falls back to None for every group (rows render
+    // non-clickable, summary counts unaffected).
+    let cwd_canonical = cwd.canonicalize().ok();
+
     // Pull per-file groups.
     let mut groups: Vec<TestGroup> = Vec::new();
     for cap in FILE_ROW_RE.captures_iter(&stripped) {
@@ -91,7 +98,9 @@ fn vitest_parse_result(out: &CapturedOutput, cwd: &Path) -> Option<TestRunSummar
         } else {
             (file_total.saturating_sub(file_failed), 0)
         };
-        let path = resolve_group_path(cwd, &label);
+        let path = cwd_canonical
+            .as_ref()
+            .and_then(|c| resolve_group_path_with_cwd_canonical(c, &label));
         groups.push(TestGroup {
             label,
             path,

--- a/src-tauri/src/agent/test_runners/vitest.rs
+++ b/src-tauri/src/agent/test_runners/vitest.rs
@@ -16,6 +16,7 @@ use super::path_resolution::resolve_group_path;
 use super::types::{
     CapturedOutput, TestGroup, TestGroupKind, TestGroupStatus, TestRunSummary, TestRunner,
 };
+use super::ANSI_RE;
 
 pub static VITEST: TestRunner = TestRunner {
     name: "vitest",
@@ -28,8 +29,6 @@ const MAX_GROUPS: usize = 500;
 fn vitest_matches(tokens: &[&str]) -> bool {
     matches!(tokens.first(), Some(&"vitest"))
 }
-
-static ANSI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
 
 // Capture passed/failed/skipped counts from the "Tests" summary line.
 // Examples:

--- a/src-tauri/src/agent/test_runners/vitest.rs
+++ b/src-tauri/src/agent/test_runners/vitest.rs
@@ -75,12 +75,21 @@ fn vitest_parse_result(out: &CapturedOutput, cwd: &Path) -> Option<TestRunSummar
             .get(4)
             .and_then(|m| m.as_str().parse().ok())
             .unwrap_or(0);
-        let file_passed = file_total.saturating_sub(file_failed);
         let status = match icon {
             "✓" => TestGroupStatus::Pass,
             "✗" => TestGroupStatus::Fail,
             "⊘" => TestGroupStatus::Skip,
             _ => TestGroupStatus::Pass,
+        };
+        // Vitest 1.x file rows don't include `| N skipped` in the
+        // parenthesised suffix — only `| N failed`. Without explicit
+        // counts, infer from the icon: a `⊘` row means the file_total
+        // count is the SKIPPED count, not the passed count. Otherwise
+        // the file_total minus file_failed is the passed count.
+        let (file_passed, file_skipped) = if matches!(status, TestGroupStatus::Skip) {
+            (0, file_total)
+        } else {
+            (file_total.saturating_sub(file_failed), 0)
         };
         let path = resolve_group_path(cwd, &label);
         groups.push(TestGroup {
@@ -89,7 +98,7 @@ fn vitest_parse_result(out: &CapturedOutput, cwd: &Path) -> Option<TestRunSummar
             kind: TestGroupKind::File,
             passed: file_passed,
             failed: file_failed,
-            skipped: 0,
+            skipped: file_skipped,
             total: file_total,
             status,
         });
@@ -162,10 +171,31 @@ mod tests {
         assert!(s.groups[0].path.is_some());
         assert_eq!(s.groups[0].passed, 12);
         assert_eq!(s.groups[0].failed, 0);
+        assert_eq!(s.groups[0].skipped, 0);
         assert_eq!(s.groups[1].label, "missing.test.ts");
         assert!(s.groups[1].path.is_none()); // file doesn't exist → no path
         assert_eq!(s.groups[1].passed, 5);
         assert_eq!(s.groups[1].failed, 3);
+        assert_eq!(s.groups[1].skipped, 0);
+    }
+
+    #[test]
+    fn parses_skipped_file_row() {
+        // Regression: a `⊘` row (entire file skipped) used to be recorded as
+        // `passed: file_total, skipped: 0`, so the count badge read "3/3"
+        // alongside the skip icon — contradictory. Now the file_total is
+        // attributed to skipped instead.
+        let out_str =
+            "⊘ skipped.test.ts (3)\n     Tests  0 passed | 0 failed | 3 skipped (3)\n";
+        let out = captured(out_str);
+        let s = vitest_parse_result(&out, &PathBuf::from("/tmp")).unwrap();
+        assert_eq!(s.groups.len(), 1);
+        assert_eq!(s.groups[0].label, "skipped.test.ts");
+        assert_eq!(s.groups[0].status, TestGroupStatus::Skip);
+        assert_eq!(s.groups[0].passed, 0, "skipped row must not report passes");
+        assert_eq!(s.groups[0].failed, 0);
+        assert_eq!(s.groups[0].skipped, 3);
+        assert_eq!(s.groups[0].total, 3);
     }
 
     #[test]

--- a/src-tauri/src/agent/test_runners/vitest.rs
+++ b/src-tauri/src/agent/test_runners/vitest.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+
+use super::types::{CapturedOutput, TestRunSummary, TestRunner};
+
+pub static VITEST: TestRunner = TestRunner {
+    name: "vitest",
+    matches: vitest_matches,
+    parse_result: vitest_parse_result,
+};
+
+fn vitest_matches(tokens: &[&str]) -> bool {
+    matches!(tokens.first(), Some(&"vitest"))
+}
+
+fn vitest_parse_result(_out: &CapturedOutput, _cwd: &Path) -> Option<TestRunSummary> {
+    // Implemented in Task 5
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vitest_matches_first_token() {
+        assert!((VITEST.matches)(&["vitest"]));
+        assert!((VITEST.matches)(&["vitest", "run", "src/foo.test.ts"]));
+        assert!(!(VITEST.matches)(&["jest"]));
+        assert!(!(VITEST.matches)(&[]));
+    }
+}

--- a/src-tauri/src/agent/transcript.rs
+++ b/src-tauri/src/agent/transcript.rs
@@ -541,23 +541,36 @@ fn process_tool_result<R: tauri::Runtime>(
             content,
             is_error,
         };
-        let cwd_ref = cwd.unwrap_or_else(|| Path::new("."));
-        let snapshot = crate::agent::test_runners::build::maybe_build_snapshot(
-            crate::agent::test_runners::build::BuildArgs {
-                session_id,
-                matched: &matched,
-                started_at: &call.started_at_iso,
-                finished_at: timestamp,
-                instant_fallback: call.started_at.elapsed(),
-                captured,
-                cwd: cwd_ref,
-            },
-        );
-        if let Some(snap) = snapshot {
-            // Route through the replay-aware emitter — during the initial
-            // catch-up read this batches to latest-only; after first EOF it
-            // emits live.
-            emitter.submit(snap);
+        // Build the snapshot only when we have a workspace cwd. Falling
+        // back to `Path::new(".")` would canonicalise to the Tauri app
+        // process's cwd — NOT the user's workspace — so test-file groups
+        // would resolve against the wrong directory (silently producing
+        // non-clickable or misleadingly-scoped rows). When cwd is absent
+        // the standard agent-tool-call event still fires below; only the
+        // structured test-run snapshot is skipped.
+        if let Some(cwd_ref) = cwd {
+            let snapshot = crate::agent::test_runners::build::maybe_build_snapshot(
+                crate::agent::test_runners::build::BuildArgs {
+                    session_id,
+                    matched: &matched,
+                    started_at: &call.started_at_iso,
+                    finished_at: timestamp,
+                    instant_fallback: call.started_at.elapsed(),
+                    captured,
+                    cwd: cwd_ref,
+                },
+            );
+            if let Some(snap) = snapshot {
+                // Route through the replay-aware emitter — during the
+                // initial catch-up read this batches to latest-only;
+                // after first EOF it emits live.
+                emitter.submit(snap);
+            }
+        } else {
+            log::debug!(
+                "Skipping test-run snapshot for session {}: no workspace cwd resolved",
+                session_id
+            );
         }
     }
 
@@ -694,7 +707,16 @@ fn extract_tool_result_content(value: &Value) -> String {
             if block.get("type").and_then(|t| t.as_str()) == Some("text") {
                 if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
                     out.push_str(text);
-                    out.push('\n');
+                    // Add a separator newline only if the block didn't
+                    // already end with one — terminal output frequently
+                    // does, and an unconditional `push('\n')` would
+                    // produce a double blank line at every block boundary
+                    // (the simple-string code path above doesn't add
+                    // anything, so this also brings the two paths into
+                    // alignment).
+                    if !out.ends_with('\n') {
+                        out.push('\n');
+                    }
                 }
             }
         }

--- a/src-tauri/src/agent/transcript.rs
+++ b/src-tauri/src/agent/transcript.rs
@@ -72,13 +72,13 @@ pub struct TranscriptHandle {
 
 struct TranscriptWatcher {
     transcript_path: PathBuf,
-    /// Workspace cwd at the time this watcher was started. Currently only
-    /// consumed by the spawned `tail_loop` (passed through `start_tailing`),
-    /// not read back from the struct itself — but retained on the watcher
-    /// so a future debug surface (`/get_transcript_watchers` introspection,
-    /// session-restart with cwd carry-over) can recover it without having
-    /// to reach into the running thread.
-    #[allow(dead_code)]
+    /// Canonicalized workspace cwd captured when the tail_loop was spawned.
+    /// Load-bearing for the test-runner data flow (npm-script alias resolution
+    /// and per-file path resolution both consume this value inside the
+    /// spawned thread). Compared in `start_or_replace` so a same-transcript-
+    /// different-cwd start triggers a replace — without this check the tail
+    /// thread would keep using the stale snapshot and the test-runner parser
+    /// would resolve aliases / files against the wrong workspace.
     cwd: Option<PathBuf>,
     handle: TranscriptHandle,
 }
@@ -133,7 +133,10 @@ impl TranscriptState {
         Ok(())
     }
 
-    /// Start tailing when none is active, or switch to a newer transcript path.
+    /// Start tailing when none is active, or switch to a newer transcript path
+    /// or workspace cwd. The watcher identity is `(transcript_path, cwd)` —
+    /// either changing forces a replace so the tail thread runs against the
+    /// current workspace state.
     pub fn start_or_replace<R: tauri::Runtime>(
         &self,
         app_handle: tauri::AppHandle<R>,
@@ -144,7 +147,7 @@ impl TranscriptState {
         {
             let watchers = self.watchers.lock().expect("failed to lock watchers");
             if let Some(current) = watchers.get(&session_id) {
-                if current.transcript_path == transcript_path {
+                if current.transcript_path == transcript_path && current.cwd == cwd {
                     return Ok(TranscriptStartStatus::AlreadyRunning);
                 }
             }
@@ -161,7 +164,7 @@ impl TranscriptState {
             let mut watchers = self.watchers.lock().expect("failed to lock watchers");
 
             if let Some(current) = watchers.get(&session_id) {
-                if current.transcript_path == transcript_path {
+                if current.transcript_path == transcript_path && current.cwd == cwd {
                     (None, TranscriptStartStatus::AlreadyRunning)
                 } else {
                     let old = watchers.insert(
@@ -702,17 +705,25 @@ fn extract_tool_result_content(value: &Value) -> String {
 
 // --- Tauri Commands ---
 
-/// Start watching a transcript JSONL file for tool call events
+/// Start watching a transcript JSONL file for tool call events.
+///
+/// `cwd` is NOT a renderer-supplied parameter. It is derived server-side
+/// from `PtyState::get_cwd(session_id)` so a compromised renderer can't
+/// influence which workspace the test-runner parser reads `package.json`
+/// from or resolves test-file paths against. If the session has no live
+/// PTY (and therefore no resolved CWD), script-alias resolution and
+/// per-file path resolution silently degrade — direct binary matches
+/// (`vitest`, `cargo test`) still work.
 #[tauri::command]
 pub async fn start_transcript_watcher(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, TranscriptState>,
+    pty_state: tauri::State<'_, crate::terminal::PtyState>,
     session_id: String,
     transcript_path: String,
-    cwd: Option<String>,
 ) -> Result<(), String> {
     let path = validate_transcript_path(&transcript_path)?;
-    let cwd_path = cwd.map(PathBuf::from);
+    let cwd_path = pty_state.get_cwd(&session_id).map(PathBuf::from);
     state.start(app_handle, session_id, path, cwd_path)
 }
 
@@ -789,6 +800,70 @@ mod tests {
             )
             .expect("failed to start watcher with cwd");
         assert_eq!(status, TranscriptStartStatus::Started);
+
+        state.stop(&session_id).expect("failed to stop watcher");
+    }
+
+    #[test]
+    fn transcript_state_replaces_when_only_cwd_changes() {
+        // Regression: same transcript path with a different cwd must
+        // trigger Replace so the tail thread runs against the new
+        // workspace. Previously start_or_replace ignored cwd in the
+        // identity check and silently kept the stale snapshot.
+        let app = tauri::test::mock_builder()
+            .build(tauri::generate_context!())
+            .expect("failed to build test app");
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let transcript_path = tmp.path().join("t.jsonl");
+        std::fs::write(&transcript_path, "").expect("failed to write transcript");
+        let cwd_a = tempfile::tempdir().expect("failed to create cwd_a");
+        let cwd_b = tempfile::tempdir().expect("failed to create cwd_b");
+
+        let state = TranscriptState::new();
+        let session_id = "session-cwd-change".to_string();
+
+        let first = state
+            .start_or_replace(
+                app.handle().clone(),
+                session_id.clone(),
+                transcript_path.clone(),
+                Some(cwd_a.path().to_path_buf()),
+            )
+            .expect("failed to start with cwd_a");
+        assert_eq!(first, TranscriptStartStatus::Started);
+
+        // Same transcript path, same cwd → AlreadyRunning (not a change).
+        let same = state
+            .start_or_replace(
+                app.handle().clone(),
+                session_id.clone(),
+                transcript_path.clone(),
+                Some(cwd_a.path().to_path_buf()),
+            )
+            .expect("failed to detect already-running");
+        assert_eq!(same, TranscriptStartStatus::AlreadyRunning);
+
+        // Same transcript path, DIFFERENT cwd → must Replace.
+        let replaced = state
+            .start_or_replace(
+                app.handle().clone(),
+                session_id.clone(),
+                transcript_path.clone(),
+                Some(cwd_b.path().to_path_buf()),
+            )
+            .expect("failed to replace on cwd change");
+        assert_eq!(replaced, TranscriptStartStatus::Replaced);
+
+        // Same transcript path, cwd None → also distinct from Some(cwd_b).
+        let replaced_to_none = state
+            .start_or_replace(
+                app.handle().clone(),
+                session_id.clone(),
+                transcript_path,
+                None,
+            )
+            .expect("failed to replace on cwd → None transition");
+        assert_eq!(replaced_to_none, TranscriptStartStatus::Replaced);
 
         state.stop(&session_id).expect("failed to stop watcher");
     }

--- a/src-tauri/src/agent/transcript.rs
+++ b/src-tauri/src/agent/transcript.rs
@@ -72,6 +72,13 @@ pub struct TranscriptHandle {
 
 struct TranscriptWatcher {
     transcript_path: PathBuf,
+    /// Workspace cwd at the time this watcher was started. Currently only
+    /// consumed by the spawned `tail_loop` (passed through `start_tailing`),
+    /// not read back from the struct itself — but retained on the watcher
+    /// so a future debug surface (`/get_transcript_watchers` introspection,
+    /// session-restart with cwd carry-over) can recover it without having
+    /// to reach into the running thread.
+    #[allow(dead_code)]
     cwd: Option<PathBuf>,
     handle: TranscriptHandle,
 }

--- a/src-tauri/src/agent/transcript.rs
+++ b/src-tauri/src/agent/transcript.rs
@@ -67,6 +67,7 @@ pub struct TranscriptHandle {
 
 struct TranscriptWatcher {
     transcript_path: PathBuf,
+    cwd: Option<PathBuf>,
     handle: TranscriptHandle,
 }
 
@@ -114,8 +115,9 @@ impl TranscriptState {
         app_handle: tauri::AppHandle<R>,
         session_id: String,
         transcript_path: PathBuf,
+        cwd: Option<PathBuf>,
     ) -> Result<(), String> {
-        let _ = self.start_or_replace(app_handle, session_id, transcript_path)?;
+        let _ = self.start_or_replace(app_handle, session_id, transcript_path, cwd)?;
         Ok(())
     }
 
@@ -125,6 +127,7 @@ impl TranscriptState {
         app_handle: tauri::AppHandle<R>,
         session_id: String,
         transcript_path: PathBuf,
+        cwd: Option<PathBuf>,
     ) -> Result<TranscriptStartStatus, String> {
         {
             let watchers = self.watchers.lock().expect("failed to lock watchers");
@@ -139,6 +142,7 @@ impl TranscriptState {
             app_handle,
             session_id.clone(),
             transcript_path.clone(),
+            cwd.clone(),
         )?);
 
         let (old_handle, status) = {
@@ -151,7 +155,8 @@ impl TranscriptState {
                     let old = watchers.insert(
                         session_id,
                         TranscriptWatcher {
-                            transcript_path,
+                            transcript_path: transcript_path.clone(),
+                            cwd: cwd.clone(),
                             handle: new_handle
                                 .take()
                                 .expect("new transcript handle should be available"),
@@ -168,6 +173,7 @@ impl TranscriptState {
                     session_id,
                     TranscriptWatcher {
                         transcript_path,
+                        cwd,
                         handle: new_handle
                             .take()
                             .expect("new transcript handle should be available"),
@@ -220,6 +226,7 @@ pub fn start_tailing<R: tauri::Runtime>(
     app_handle: tauri::AppHandle<R>,
     session_id: String,
     transcript_path: PathBuf,
+    cwd: Option<PathBuf>,
 ) -> Result<TranscriptHandle, String> {
     let file = File::open(&transcript_path).map_err(|e| {
         format!(
@@ -233,7 +240,7 @@ pub fn start_tailing<R: tauri::Runtime>(
     let stop_clone = stop_flag.clone();
 
     let join_handle = std::thread::spawn(move || {
-        tail_loop(app_handle, session_id, file, stop_clone);
+        tail_loop(app_handle, session_id, cwd, file, stop_clone);
     });
 
     Ok(TranscriptHandle {
@@ -246,6 +253,7 @@ pub fn start_tailing<R: tauri::Runtime>(
 fn tail_loop<R: tauri::Runtime>(
     app_handle: tauri::AppHandle<R>,
     session_id: String,
+    _cwd: Option<PathBuf>,
     file: File,
     stop_flag: Arc<AtomicBool>,
 ) {
@@ -568,9 +576,11 @@ pub async fn start_transcript_watcher(
     state: tauri::State<'_, TranscriptState>,
     session_id: String,
     transcript_path: String,
+    cwd: Option<String>,
 ) -> Result<(), String> {
     let path = validate_transcript_path(&transcript_path)?;
-    state.start(app_handle, session_id, path)
+    let cwd_path = cwd.map(PathBuf::from);
+    state.start(app_handle, session_id, path, cwd_path)
 }
 
 /// Stop watching a transcript JSONL file
@@ -607,19 +617,45 @@ mod tests {
         let session_id = "session-1".to_string();
 
         let first_status = state
-            .start_or_replace(app.handle().clone(), session_id.clone(), first_path.clone())
+            .start_or_replace(app.handle().clone(), session_id.clone(), first_path.clone(), None)
             .expect("failed to start first transcript watcher");
         assert_eq!(first_status, TranscriptStartStatus::Started);
 
         let duplicate_status = state
-            .start_or_replace(app.handle().clone(), session_id.clone(), first_path)
+            .start_or_replace(app.handle().clone(), session_id.clone(), first_path, None)
             .expect("failed to check duplicate transcript watcher");
         assert_eq!(duplicate_status, TranscriptStartStatus::AlreadyRunning);
 
         let replaced_status = state
-            .start_or_replace(app.handle().clone(), session_id.clone(), second_path)
+            .start_or_replace(app.handle().clone(), session_id.clone(), second_path, None)
             .expect("failed to replace transcript watcher");
         assert_eq!(replaced_status, TranscriptStartStatus::Replaced);
+
+        state.stop(&session_id).expect("failed to stop watcher");
+    }
+
+    #[test]
+    fn transcript_state_threads_cwd_through() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::generate_context!())
+            .expect("failed to build test app");
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let transcript_path = tmp.path().join("t.jsonl");
+        std::fs::write(&transcript_path, "").expect("failed to write transcript");
+        let cwd = tmp.path().to_path_buf();
+
+        let state = TranscriptState::new();
+        let session_id = "session-cwd".to_string();
+
+        let status = state
+            .start_or_replace(
+                app.handle().clone(),
+                session_id.clone(),
+                transcript_path,
+                Some(cwd),
+            )
+            .expect("failed to start watcher with cwd");
+        assert_eq!(status, TranscriptStartStatus::Started);
 
         state.stop(&session_id).expect("failed to stop watcher");
     }

--- a/src-tauri/src/agent/transcript.rs
+++ b/src-tauri/src/agent/transcript.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 use tauri::Emitter;
 
 use super::types::{AgentToolCallEvent, ToolCallStatus};
+use crate::agent::test_runners::emitter::TestRunEmitter;
 use crate::agent::test_runners::matcher::{match_command, MatchedCommand};
 
 /// Poll interval for checking new transcript lines
@@ -271,6 +272,11 @@ fn tail_loop<R: tauri::Runtime>(
     // In-flight tool calls: tool_use_id -> call details
     let mut in_flight: InFlightToolCalls = HashMap::new();
 
+    // Replay-aware emitter — buffers test-run snapshots during the initial
+    // catch-up read and emits the latest one (only) on the first EOF. Once
+    // we're tailing live, every snapshot emits immediately.
+    let mut emitter = TestRunEmitter::new(app_handle.clone());
+
     // Buffer for partial lines
     let mut line_buf = String::new();
 
@@ -278,7 +284,9 @@ fn tail_loop<R: tauri::Runtime>(
         line_buf.clear();
         match reader.read_line(&mut line_buf) {
             Ok(0) => {
-                // No new data — sleep and retry
+                // First EOF marks the end of replay; subsequent EOFs are
+                // idempotent. After this, every submit emits live.
+                emitter.finish_replay();
                 std::thread::sleep(POLL_INTERVAL);
             }
             Ok(_) => {
@@ -286,7 +294,14 @@ fn tail_loop<R: tauri::Runtime>(
                 if line.is_empty() {
                     continue;
                 }
-                process_line(line, &session_id, cwd.as_deref(), &app_handle, &mut in_flight);
+                process_line(
+                    line,
+                    &session_id,
+                    cwd.as_deref(),
+                    &app_handle,
+                    &mut emitter,
+                    &mut in_flight,
+                );
             }
             Err(e) => {
                 log::warn!("Error reading transcript line: {}", e);
@@ -297,11 +312,12 @@ fn tail_loop<R: tauri::Runtime>(
 }
 
 /// Process a single JSONL line and emit events if it's a tool call
-fn process_line(
+fn process_line<R: tauri::Runtime>(
     line: &str,
     session_id: &str,
     cwd: Option<&Path>,
-    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    app_handle: &tauri::AppHandle<R>,
+    emitter: &mut TestRunEmitter<R>,
     in_flight: &mut InFlightToolCalls,
 ) {
     let value: Value = match serde_json::from_str(line) {
@@ -319,11 +335,19 @@ fn process_line(
             process_assistant_message(&value, session_id, cwd, app_handle, in_flight);
         }
         "user" => {
-            process_user_message(&value, session_id, cwd, app_handle, in_flight);
+            process_user_message(&value, session_id, cwd, app_handle, emitter, in_flight);
         }
         "tool_result" => {
             let timestamp = extract_timestamp(&value);
-            process_tool_result(&value, session_id, cwd, app_handle, in_flight, &timestamp);
+            process_tool_result(
+                &value,
+                session_id,
+                cwd,
+                app_handle,
+                emitter,
+                in_flight,
+                &timestamp,
+            );
         }
         _ => {
             // Other message types — ignore
@@ -345,11 +369,11 @@ fn extract_timestamp(value: &Value) -> String {
         .unwrap_or_else(now_iso8601)
 }
 
-fn process_assistant_message(
+fn process_assistant_message<R: tauri::Runtime>(
     value: &Value,
     session_id: &str,
     cwd: Option<&Path>,
-    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    app_handle: &tauri::AppHandle<R>,
     in_flight: &mut InFlightToolCalls,
 ) {
     let content = match message_content_items(value) {
@@ -434,11 +458,12 @@ fn process_assistant_message(
 }
 
 /// Extract tool_result entries from a user message.
-fn process_user_message(
+fn process_user_message<R: tauri::Runtime>(
     value: &Value,
     session_id: &str,
     cwd: Option<&Path>,
-    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    app_handle: &tauri::AppHandle<R>,
+    emitter: &mut TestRunEmitter<R>,
     in_flight: &mut InFlightToolCalls,
 ) {
     let content = match message_content_items(value) {
@@ -450,17 +475,26 @@ fn process_user_message(
 
     for item in content {
         if is_tool_result_block(item) {
-            process_tool_result(item, session_id, cwd, app_handle, in_flight, &timestamp);
+            process_tool_result(
+                item,
+                session_id,
+                cwd,
+                app_handle,
+                emitter,
+                in_flight,
+                &timestamp,
+            );
         }
     }
 }
 
 /// Process a tool_result line and emit Done/Failed event
-fn process_tool_result(
+fn process_tool_result<R: tauri::Runtime>(
     value: &Value,
     session_id: &str,
     cwd: Option<&Path>,
-    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
+    app_handle: &tauri::AppHandle<R>,
+    emitter: &mut TestRunEmitter<R>,
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
 ) {
@@ -510,12 +544,10 @@ fn process_tool_result(
             },
         );
         if let Some(snap) = snapshot {
-            // For now (Task 5), emit immediately. Task 6 introduces the
-            // TestRunEmitter for replay batching — this direct emit will be
-            // refactored to call emitter.submit().
-            if let Err(e) = app_handle.emit("test-run", &snap) {
-                log::warn!("Failed to emit test-run event: {}", e);
-            }
+            // Route through the replay-aware emitter — during the initial
+            // catch-up read this batches to latest-only; after first EOF it
+            // emits live.
+            emitter.submit(snap);
         }
     }
 

--- a/src-tauri/src/agent/transcript.rs
+++ b/src-tauri/src/agent/transcript.rs
@@ -55,6 +55,7 @@ struct InFlightToolCall {
     started_at: Instant,
     tool: String,
     args: String,
+    is_test_file: bool,
 }
 
 type InFlightToolCalls = HashMap<String, InFlightToolCall>;
@@ -372,6 +373,20 @@ fn process_assistant_message(
 
         let args = summarize_input(item.get("input"));
 
+        // Tag Write/Edit on test files. Use the FULL untruncated
+        // input.file_path — `args` is summarized to MAX_ARGS_LEN and
+        // long workspace paths could otherwise drop the suffix that
+        // makes a file recognizable as a test (e.g. `…ndle.test.ts`).
+        let is_test_file = if matches!(name.as_str(), "Write" | "Edit") {
+            item.get("input")
+                .and_then(|v| v.get("file_path"))
+                .and_then(|v| v.as_str())
+                .map(crate::agent::test_runners::test_file_patterns::is_test_file)
+                .unwrap_or(false)
+        } else {
+            false
+        };
+
         let now = Instant::now();
         in_flight.insert(
             id.clone(),
@@ -379,6 +394,7 @@ fn process_assistant_message(
                 started_at: now,
                 tool: name.clone(),
                 args: args.clone(),
+                is_test_file,
             },
         );
 
@@ -390,6 +406,7 @@ fn process_assistant_message(
             status: ToolCallStatus::Running,
             timestamp: timestamp.clone(),
             duration_ms: 0,
+            is_test_file,
         };
 
         if let Err(e) = app_handle.emit("agent-tool-call", &event) {
@@ -451,6 +468,7 @@ fn process_tool_result(
     let duration_ms = call.started_at.elapsed().as_millis() as u64;
     let tool_name = call.tool;
     let args = call.args;
+    let is_test_file = call.is_test_file;
 
     let status = if is_error {
         ToolCallStatus::Failed
@@ -466,6 +484,7 @@ fn process_tool_result(
         status,
         timestamp: timestamp.to_string(),
         duration_ms,
+        is_test_file,
     };
 
     if let Err(e) = app_handle.emit("agent-tool-call", &event) {
@@ -867,6 +886,7 @@ mod tests {
                 started_at: start,
                 tool: "Read".to_string(),
                 args: "/src/foo.ts".to_string(),
+                is_test_file: false,
             },
         );
         assert!(in_flight.contains_key("toolu_abc"));

--- a/src-tauri/src/agent/transcript.rs
+++ b/src-tauri/src/agent/transcript.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -15,6 +15,7 @@ use serde_json::Value;
 use tauri::Emitter;
 
 use super::types::{AgentToolCallEvent, ToolCallStatus};
+use crate::agent::test_runners::matcher::{match_command, MatchedCommand};
 
 /// Poll interval for checking new transcript lines
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -53,9 +54,11 @@ pub(crate) fn validate_transcript_path(transcript_path: &str) -> Result<PathBuf,
 
 struct InFlightToolCall {
     started_at: Instant,
+    started_at_iso: String,
     tool: String,
     args: String,
     is_test_file: bool,
+    test_match: Option<MatchedCommand>,
 }
 
 type InFlightToolCalls = HashMap<String, InFlightToolCall>;
@@ -254,7 +257,7 @@ pub fn start_tailing<R: tauri::Runtime>(
 fn tail_loop<R: tauri::Runtime>(
     app_handle: tauri::AppHandle<R>,
     session_id: String,
-    _cwd: Option<PathBuf>,
+    cwd: Option<PathBuf>,
     file: File,
     stop_flag: Arc<AtomicBool>,
 ) {
@@ -283,7 +286,7 @@ fn tail_loop<R: tauri::Runtime>(
                 if line.is_empty() {
                     continue;
                 }
-                process_line(line, &session_id, &app_handle, &mut in_flight);
+                process_line(line, &session_id, cwd.as_deref(), &app_handle, &mut in_flight);
             }
             Err(e) => {
                 log::warn!("Error reading transcript line: {}", e);
@@ -297,6 +300,7 @@ fn tail_loop<R: tauri::Runtime>(
 fn process_line(
     line: &str,
     session_id: &str,
+    cwd: Option<&Path>,
     app_handle: &tauri::AppHandle<impl tauri::Runtime>,
     in_flight: &mut InFlightToolCalls,
 ) {
@@ -312,14 +316,14 @@ fn process_line(
 
     match line_type {
         "assistant" => {
-            process_assistant_message(&value, session_id, app_handle, in_flight);
+            process_assistant_message(&value, session_id, cwd, app_handle, in_flight);
         }
         "user" => {
-            process_user_message(&value, session_id, app_handle, in_flight);
+            process_user_message(&value, session_id, cwd, app_handle, in_flight);
         }
         "tool_result" => {
             let timestamp = extract_timestamp(&value);
-            process_tool_result(&value, session_id, app_handle, in_flight, &timestamp);
+            process_tool_result(&value, session_id, cwd, app_handle, in_flight, &timestamp);
         }
         _ => {
             // Other message types — ignore
@@ -344,6 +348,7 @@ fn extract_timestamp(value: &Value) -> String {
 fn process_assistant_message(
     value: &Value,
     session_id: &str,
+    cwd: Option<&Path>,
     app_handle: &tauri::AppHandle<impl tauri::Runtime>,
     in_flight: &mut InFlightToolCalls,
 ) {
@@ -371,6 +376,17 @@ fn process_assistant_message(
             .unwrap_or("unknown")
             .to_string();
 
+        // Run the matcher BEFORE summarize_input truncates — the matcher
+        // needs the full untruncated command to tokenize correctly.
+        let test_match = if name == "Bash" {
+            item.get("input")
+                .and_then(|v| v.get("command"))
+                .and_then(|v| v.as_str())
+                .and_then(|cmd| match_command(cmd, cwd))
+        } else {
+            None
+        };
+
         let args = summarize_input(item.get("input"));
 
         // Tag Write/Edit on test files. Use the FULL untruncated
@@ -392,9 +408,11 @@ fn process_assistant_message(
             id.clone(),
             InFlightToolCall {
                 started_at: now,
+                started_at_iso: timestamp.clone(),
                 tool: name.clone(),
                 args: args.clone(),
                 is_test_file,
+                test_match,
             },
         );
 
@@ -419,6 +437,7 @@ fn process_assistant_message(
 fn process_user_message(
     value: &Value,
     session_id: &str,
+    cwd: Option<&Path>,
     app_handle: &tauri::AppHandle<impl tauri::Runtime>,
     in_flight: &mut InFlightToolCalls,
 ) {
@@ -431,7 +450,7 @@ fn process_user_message(
 
     for item in content {
         if is_tool_result_block(item) {
-            process_tool_result(item, session_id, app_handle, in_flight, &timestamp);
+            process_tool_result(item, session_id, cwd, app_handle, in_flight, &timestamp);
         }
     }
 }
@@ -440,6 +459,7 @@ fn process_user_message(
 fn process_tool_result(
     value: &Value,
     session_id: &str,
+    cwd: Option<&Path>,
     app_handle: &tauri::AppHandle<impl tauri::Runtime>,
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
@@ -469,6 +489,35 @@ fn process_tool_result(
     let tool_name = call.tool;
     let args = call.args;
     let is_test_file = call.is_test_file;
+
+    if let Some(matched) = call.test_match {
+        // Pull the captured Bash output content.
+        let content = extract_tool_result_content(value);
+        let captured = crate::agent::test_runners::types::CapturedOutput {
+            content,
+            is_error,
+        };
+        let cwd_ref = cwd.unwrap_or_else(|| Path::new("."));
+        let snapshot = crate::agent::test_runners::build::maybe_build_snapshot(
+            crate::agent::test_runners::build::BuildArgs {
+                session_id,
+                matched: &matched,
+                started_at: &call.started_at_iso,
+                finished_at: timestamp,
+                instant_fallback: call.started_at.elapsed(),
+                captured,
+                cwd: cwd_ref,
+            },
+        );
+        if let Some(snap) = snapshot {
+            // For now (Task 5), emit immediately. Task 6 introduces the
+            // TestRunEmitter for replay batching — this direct emit will be
+            // refactored to call emitter.submit().
+            if let Err(e) = app_handle.emit("test-run", &snap) {
+                log::warn!("Failed to emit test-run event: {}", e);
+            }
+        }
+    }
 
     let status = if is_error {
         ToolCallStatus::Failed
@@ -584,6 +633,32 @@ fn days_to_date(days: u64) -> (u64, u64, u64) {
     let m = if mp < 10 { mp + 3 } else { mp - 9 };
     let y = if m <= 2 { y + 1 } else { y };
     (y, m, d)
+}
+
+/// Pull the textual `content` out of a tool_result JSON value.
+/// Handles both the simple-string shape and the array-of-blocks shape
+/// (where each block may carry `{type:"text", text:"..."}` payloads).
+fn extract_tool_result_content(value: &Value) -> String {
+    let raw = match value.get("content") {
+        Some(c) => c,
+        None => return String::new(),
+    };
+    if let Some(s) = raw.as_str() {
+        return s.to_string();
+    }
+    if let Some(arr) = raw.as_array() {
+        let mut out = String::new();
+        for block in arr {
+            if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+                if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                    out.push_str(text);
+                    out.push('\n');
+                }
+            }
+        }
+        return out;
+    }
+    String::new()
 }
 
 // --- Tauri Commands ---
@@ -884,9 +959,11 @@ mod tests {
             "toolu_abc".to_string(),
             InFlightToolCall {
                 started_at: start,
+                started_at_iso: "2026-04-28T12:00:00Z".to_string(),
                 tool: "Read".to_string(),
                 args: "/src/foo.ts".to_string(),
                 is_test_file: false,
+                test_match: None,
             },
         );
         assert!(in_flight.contains_key("toolu_abc"));

--- a/src-tauri/src/agent/types.rs
+++ b/src-tauri/src/agent/types.rs
@@ -192,4 +192,9 @@ pub struct AgentToolCallEvent {
     pub timestamp: String,
     /// Execution duration in milliseconds
     pub duration_ms: u64,
+    /// True when this is a Write/Edit on a path that matches a known
+    /// test-file convention (e.g. `*.test.ts`, `*_test.rs`). Frontend
+    /// uses this to render the activity feed glyph and verb without
+    /// needing to glob the path itself.
+    pub is_test_file: bool,
 }

--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -64,7 +64,12 @@ impl AgentWatcherState {
 }
 
 /// Try to start transcript tailing, switching files if Claude reports a new path.
-fn maybe_start_transcript(app_handle: &tauri::AppHandle, session_id: &str, transcript_path: &str) {
+fn maybe_start_transcript(
+    app_handle: &tauri::AppHandle,
+    session_id: &str,
+    transcript_path: &str,
+    cwd: Option<PathBuf>,
+) {
     let transcript_path = match validate_transcript_path(transcript_path) {
         Ok(path) => path,
         Err(e) => {
@@ -82,6 +87,7 @@ fn maybe_start_transcript(app_handle: &tauri::AppHandle, session_id: &str, trans
         app_handle.clone(),
         session_id.to_string(),
         transcript_path.clone(),
+        cwd,
     ) {
         Ok(TranscriptStartStatus::Started) => {
             log::info!(
@@ -116,9 +122,11 @@ pub fn start_watching(
     app_handle: tauri::AppHandle,
     session_id: String,
     status_file_path: PathBuf,
+    cwd: PathBuf,
 ) -> Result<WatcherHandle, String> {
     let target_path = status_file_path.clone();
     let sid = session_id.clone();
+    let cwd_for_closure = cwd.clone();
     let last_processed = Arc::new(Mutex::new(Instant::now()));
     let app_handle_for_poll = app_handle.clone();
     let stop_flag = Arc::new(AtomicBool::new(false));
@@ -182,7 +190,7 @@ pub fn start_watching(
 
                 if let Some(ref path) = parsed.transcript_path {
                     log::debug!("Transcript path for session {}: {}", sid, path);
-                    maybe_start_transcript(&app_handle, &sid, path);
+                    maybe_start_transcript(&app_handle, &sid, path, Some(cwd_for_closure.clone()));
                 }
             }
             Err(e) => {
@@ -212,12 +220,18 @@ pub fn start_watching(
         let initial_sid = session_id.clone();
         let initial_path = status_file_path.clone();
         let initial_app = app_handle_for_poll.clone();
+        let initial_cwd = cwd.clone();
         if let Ok(contents) = std::fs::read_to_string(&initial_path) {
             if !contents.trim().is_empty() {
                 if let Ok(parsed) = parse_statusline(&initial_sid, &contents) {
                     let _ = initial_app.emit("agent-status", &parsed.event);
                     if let Some(ref path) = parsed.transcript_path {
-                        maybe_start_transcript(&initial_app, &initial_sid, path);
+                        maybe_start_transcript(
+                            &initial_app,
+                            &initial_sid,
+                            path,
+                            Some(initial_cwd.clone()),
+                        );
                     }
                 }
             }
@@ -231,6 +245,7 @@ pub fn start_watching(
         let poll_sid = session_id.clone();
         let poll_path = status_file_path.clone();
         let poll_app = app_handle_for_poll;
+        let poll_cwd = cwd.clone();
         let poll_last = Arc::new(Mutex::new(String::new()));
         let poll_stop = stop_flag.clone();
         std::thread::spawn(move || {
@@ -256,7 +271,12 @@ pub fn start_watching(
                 if let Ok(parsed) = parse_statusline(&poll_sid, &contents) {
                     let _ = poll_app.emit("agent-status", &parsed.event);
                     if let Some(ref path) = parsed.transcript_path {
-                        maybe_start_transcript(&poll_app, &poll_sid, path);
+                        maybe_start_transcript(
+                            &poll_app,
+                            &poll_sid,
+                            path,
+                            Some(poll_cwd.clone()),
+                        );
                     }
                 }
             }
@@ -332,7 +352,8 @@ pub async fn start_agent_watcher(
     // Stop any existing watcher for this session
     state.remove(&session_id);
 
-    let handle = start_watching(app_handle, session_id.clone(), path)?;
+    let cwd_path = PathBuf::from(&cwd);
+    let handle = start_watching(app_handle, session_id.clone(), path, cwd_path)?;
     state.insert(session_id.clone(), handle);
 
     Ok(())

--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -325,30 +325,19 @@ pub async fn start_agent_watcher(
         path.display()
     );
 
-    // Debug-only file log for diagnosing watcher startup
-    #[cfg(debug_assertions)]
-    {
-        use std::io::Write;
-        use std::time::SystemTime;
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open("/tmp/vimeflow-debug.log")
-        {
-            let secs = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
-            let _ = writeln!(
-                f,
-                "[{}] [watcher] start: session={}, cwd={}, path={}",
-                secs,
-                session_id,
-                cwd,
-                path.display()
-            );
-        }
-    }
+    // Use the structured logger (already configured for the rest of this
+    // file) for startup diagnostics. The earlier debug-only file log at
+    // `/tmp/vimeflow-debug.log` was dropped: a fixed predictable path
+    // under /tmp without O_EXCL follows symlinks, allowing a local actor
+    // on a shared system to redirect appends, and Linux's default umask
+    // 022 left the file world-readable. Run with RUST_LOG=debug to see
+    // these lines.
+    log::debug!(
+        "Watcher startup detail: session={}, cwd={}, path={}",
+        session_id,
+        cwd,
+        path.display()
+    );
 
     // Stop any existing watcher for this session
     state.remove(&session_id);

--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -64,11 +64,17 @@ impl AgentWatcherState {
 }
 
 /// Try to start transcript tailing, switching files if Claude reports a new path.
+///
+/// `cwd` is queried fresh from PtyState at every call rather than captured
+/// by the outer `start_watching` closures. The user can `cd` mid-session
+/// without restarting the agent watcher; we want the test-runner parser to
+/// pick up the new workspace immediately. Combined with
+/// `TranscriptState::start_or_replace`'s (transcript_path, cwd) identity
+/// check, a cwd change triggers a Replace of the tail thread.
 fn maybe_start_transcript(
     app_handle: &tauri::AppHandle,
     session_id: &str,
     transcript_path: &str,
-    cwd: Option<PathBuf>,
 ) {
     let transcript_path = match validate_transcript_path(transcript_path) {
         Ok(path) => path,
@@ -81,6 +87,11 @@ fn maybe_start_transcript(
             return;
         }
     };
+
+    let cwd = app_handle
+        .state::<crate::terminal::PtyState>()
+        .get_cwd(&session_id.to_string())
+        .map(PathBuf::from);
 
     let ts = app_handle.state::<TranscriptState>();
     match ts.start_or_replace(
@@ -118,15 +129,17 @@ fn maybe_start_transcript(
 ///
 /// Watches the parent directory and filters for events on the target file.
 /// Debounces at 100ms to avoid redundant processing.
+///
+/// CWD is intentionally NOT captured here. `maybe_start_transcript` queries
+/// PtyState fresh on every invocation so a `cd` mid-session updates the
+/// workspace seen by the test-runner parser.
 pub fn start_watching(
     app_handle: tauri::AppHandle,
     session_id: String,
     status_file_path: PathBuf,
-    cwd: PathBuf,
 ) -> Result<WatcherHandle, String> {
     let target_path = status_file_path.clone();
     let sid = session_id.clone();
-    let cwd_for_closure = cwd.clone();
     let last_processed = Arc::new(Mutex::new(Instant::now()));
     let app_handle_for_poll = app_handle.clone();
     let stop_flag = Arc::new(AtomicBool::new(false));
@@ -190,7 +203,7 @@ pub fn start_watching(
 
                 if let Some(ref path) = parsed.transcript_path {
                     log::debug!("Transcript path for session {}: {}", sid, path);
-                    maybe_start_transcript(&app_handle, &sid, path, Some(cwd_for_closure.clone()));
+                    maybe_start_transcript(&app_handle, &sid, path);
                 }
             }
             Err(e) => {
@@ -220,18 +233,12 @@ pub fn start_watching(
         let initial_sid = session_id.clone();
         let initial_path = status_file_path.clone();
         let initial_app = app_handle_for_poll.clone();
-        let initial_cwd = cwd.clone();
         if let Ok(contents) = std::fs::read_to_string(&initial_path) {
             if !contents.trim().is_empty() {
                 if let Ok(parsed) = parse_statusline(&initial_sid, &contents) {
                     let _ = initial_app.emit("agent-status", &parsed.event);
                     if let Some(ref path) = parsed.transcript_path {
-                        maybe_start_transcript(
-                            &initial_app,
-                            &initial_sid,
-                            path,
-                            Some(initial_cwd.clone()),
-                        );
+                        maybe_start_transcript(&initial_app, &initial_sid, path);
                     }
                 }
             }
@@ -245,7 +252,6 @@ pub fn start_watching(
         let poll_sid = session_id.clone();
         let poll_path = status_file_path.clone();
         let poll_app = app_handle_for_poll;
-        let poll_cwd = cwd.clone();
         let poll_last = Arc::new(Mutex::new(String::new()));
         let poll_stop = stop_flag.clone();
         std::thread::spawn(move || {
@@ -271,12 +277,7 @@ pub fn start_watching(
                 if let Ok(parsed) = parse_statusline(&poll_sid, &contents) {
                     let _ = poll_app.emit("agent-status", &parsed.event);
                     if let Some(ref path) = parsed.transcript_path {
-                        maybe_start_transcript(
-                            &poll_app,
-                            &poll_sid,
-                            path,
-                            Some(poll_cwd.clone()),
-                        );
+                        maybe_start_transcript(&poll_app, &poll_sid, path);
                     }
                 }
             }
@@ -352,8 +353,7 @@ pub async fn start_agent_watcher(
     // Stop any existing watcher for this session
     state.remove(&session_id);
 
-    let cwd_path = PathBuf::from(&cwd);
-    let handle = start_watching(app_handle, session_id.clone(), path, cwd_path)?;
+    let handle = start_watching(app_handle, session_id.clone(), path)?;
     state.insert(session_id.clone(), handle);
 
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-mod agent;
+pub mod agent;
 mod filesystem;
 mod git;
 mod terminal;

--- a/src-tauri/tests/fixtures/transcript_cargo_mixed.jsonl
+++ b/src-tauri/tests/fixtures/transcript_cargo_mixed.jsonl
@@ -1,0 +1,2 @@
+{"type":"assistant","timestamp":"2026-04-28T13:00:00.000Z","message":{"content":[{"type":"tool_use","id":"c1","name":"Bash","input":{"command":"cargo test"}}]}}
+{"type":"user","timestamp":"2026-04-28T13:00:05.000Z","message":{"content":[{"type":"tool_result","tool_use_id":"c1","is_error":false,"content":"running 3 tests\ntest mycrate::a::test_x ... ok\ntest mycrate::a::test_y ... FAILED\ntest mycrate::b::test_z ... ignored\n\ntest result: FAILED. 1 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out\n"}]}}

--- a/src-tauri/tests/fixtures/transcript_vitest_pass.jsonl
+++ b/src-tauri/tests/fixtures/transcript_vitest_pass.jsonl
@@ -1,0 +1,2 @@
+{"type":"assistant","timestamp":"2026-04-28T12:00:00.000Z","message":{"content":[{"type":"tool_use","id":"toolu_v_1","name":"Bash","input":{"command":"vitest run","description":"Run tests"}}]}}
+{"type":"user","timestamp":"2026-04-28T12:00:01.500Z","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_v_1","is_error":false,"content":"\nTest Files  1 passed (1)\n     Tests  3 passed (3)\n"}]}}

--- a/src-tauri/tests/fixtures/transcript_vitest_replay.jsonl
+++ b/src-tauri/tests/fixtures/transcript_vitest_replay.jsonl
@@ -1,0 +1,6 @@
+{"type":"assistant","timestamp":"2026-04-28T11:00:00.000Z","message":{"content":[{"type":"tool_use","id":"r1","name":"Bash","input":{"command":"vitest run"}}]}}
+{"type":"user","timestamp":"2026-04-28T11:00:01.000Z","message":{"content":[{"type":"tool_result","tool_use_id":"r1","is_error":false,"content":"     Tests  1 passed (1)\n"}]}}
+{"type":"assistant","timestamp":"2026-04-28T11:01:00.000Z","message":{"content":[{"type":"tool_use","id":"r2","name":"Bash","input":{"command":"vitest run"}}]}}
+{"type":"user","timestamp":"2026-04-28T11:01:01.000Z","message":{"content":[{"type":"tool_result","tool_use_id":"r2","is_error":false,"content":"     Tests  2 passed (2)\n"}]}}
+{"type":"assistant","timestamp":"2026-04-28T11:02:00.000Z","message":{"content":[{"type":"tool_use","id":"r3","name":"Bash","input":{"command":"vitest run"}}]}}
+{"type":"user","timestamp":"2026-04-28T11:02:01.000Z","message":{"content":[{"type":"tool_result","tool_use_id":"r3","is_error":false,"content":"     Tests  3 passed (3)\n"}]}}

--- a/src-tauri/tests/transcript_cargo_e2e.rs
+++ b/src-tauri/tests/transcript_cargo_e2e.rs
@@ -1,0 +1,45 @@
+use std::sync::{Arc, Mutex};
+
+use vimeflow_lib::agent::transcript::TranscriptState;
+
+#[test]
+fn cargo_mixed_fixture_emits_test_run_with_groups() {
+    use tauri::test::mock_builder;
+    use tauri::Listener;
+
+    let app = mock_builder().build(tauri::generate_context!()).unwrap();
+    let app_handle = app.handle().clone();
+
+    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    app_handle.listen("test-run", move |event| {
+        recv_clone.lock().unwrap().push(event.payload().to_string());
+    });
+
+    let state = TranscriptState::new();
+    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/transcript_cargo_mixed.jsonl");
+
+    state
+        .start_or_replace(
+            app_handle,
+            "session-cargo".to_string(),
+            fixture_path,
+            None,
+        )
+        .expect("start watcher");
+
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+    state.stop("session-cargo").ok();
+
+    let events = received.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    let payload = &events[0];
+    assert!(payload.contains(r#""runner":"cargo""#));
+    assert!(payload.contains(r#""passed":1"#));
+    assert!(payload.contains(r#""failed":1"#));
+    assert!(payload.contains(r#""skipped":1"#));
+    assert!(payload.contains(r#""status":"fail""#));
+    assert!(payload.contains(r#""kind":"module""#));
+    assert!(payload.contains(r#""path":null"#));
+}

--- a/src-tauri/tests/transcript_cargo_e2e.rs
+++ b/src-tauri/tests/transcript_cargo_e2e.rs
@@ -20,12 +20,18 @@ fn cargo_mixed_fixture_emits_test_run_with_groups() {
     let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/transcript_cargo_mixed.jsonl");
 
+    // Pass a valid cwd — process_tool_result skips the snapshot entirely
+    // when cwd is None (so it doesn't resolve test files against the
+    // wrong directory). A temp dir is enough; cargo groups always have
+    // path: None regardless of cwd, so the rest of the assertions hold.
+    let cwd = tempfile::tempdir().expect("temp cwd");
+
     state
         .start_or_replace(
             app_handle,
             "session-cargo".to_string(),
             fixture_path,
-            None,
+            Some(cwd.path().to_path_buf()),
         )
         .expect("start watcher");
 

--- a/src-tauri/tests/transcript_vitest_e2e.rs
+++ b/src-tauri/tests/transcript_vitest_e2e.rs
@@ -1,0 +1,47 @@
+//! End-to-end test: feed a fixture transcript through the parser
+//! and assert exactly one test-run event is emitted with the expected
+//! summary counts.
+
+use std::sync::{Arc, Mutex};
+
+use vimeflow_lib::agent::transcript::TranscriptState;
+
+#[test]
+fn vitest_pass_fixture_emits_one_test_run() {
+    use tauri::test::mock_builder;
+    use tauri::Listener;
+
+    let app = mock_builder().build(tauri::generate_context!()).unwrap();
+    let app_handle = app.handle().clone();
+
+    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    app_handle.listen("test-run", move |event| {
+        recv_clone.lock().unwrap().push(event.payload().to_string());
+    });
+
+    let state = TranscriptState::new();
+    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/transcript_vitest_pass.jsonl");
+
+    state
+        .start_or_replace(
+            app_handle,
+            "session-fixture".to_string(),
+            fixture_path,
+            None,
+        )
+        .expect("start watcher");
+
+    // Wait briefly for the tail loop to process the file.
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+    state.stop("session-fixture").ok();
+
+    let events = received.lock().unwrap();
+    assert_eq!(events.len(), 1, "expected exactly one test-run event");
+    let payload = &events[0];
+    assert!(payload.contains(r#""runner":"vitest""#));
+    assert!(payload.contains(r#""passed":3"#));
+    assert!(payload.contains(r#""total":3"#));
+    assert!(payload.contains(r#""status":"pass""#));
+}

--- a/src-tauri/tests/transcript_vitest_e2e.rs
+++ b/src-tauri/tests/transcript_vitest_e2e.rs
@@ -24,12 +24,17 @@ fn vitest_pass_fixture_emits_one_test_run() {
     let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/transcript_vitest_pass.jsonl");
 
+    // Pass a valid cwd — process_tool_result skips test-run snapshots
+    // when cwd is None to avoid resolving file groups against the wrong
+    // directory. The fixture has no per-file rows so a temp cwd is fine.
+    let cwd = tempfile::tempdir().expect("temp cwd");
+
     state
         .start_or_replace(
             app_handle,
             "session-fixture".to_string(),
             fixture_path,
-            None,
+            Some(cwd.path().to_path_buf()),
         )
         .expect("start watcher");
 

--- a/src-tauri/tests/transcript_vitest_replay.rs
+++ b/src-tauri/tests/transcript_vitest_replay.rs
@@ -1,0 +1,45 @@
+//! Replay batching: feed a fixture transcript with three historical
+//! vitest runs through the parser and assert that the TestRunEmitter
+//! collapses them to exactly ONE emit (the latest, with passed=3) at
+//! first EOF. Locks the load-bearing invariant for session-restore UX.
+
+use std::sync::{Arc, Mutex};
+
+use vimeflow_lib::agent::transcript::TranscriptState;
+
+#[test]
+fn replay_emits_only_latest_snapshot() {
+    use tauri::test::mock_builder;
+    use tauri::Listener;
+
+    let app = mock_builder().build(tauri::generate_context!()).unwrap();
+    let app_handle = app.handle().clone();
+
+    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    app_handle.listen("test-run", move |event| {
+        recv_clone.lock().unwrap().push(event.payload().to_string());
+    });
+
+    let state = TranscriptState::new();
+    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/transcript_vitest_replay.jsonl");
+
+    state
+        .start_or_replace(
+            app_handle,
+            "session-replay".to_string(),
+            fixture_path,
+            None,
+        )
+        .expect("start watcher");
+
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+    state.stop("session-replay").ok();
+
+    let events = received.lock().unwrap();
+    // 3 historical runs in the fixture, but replay batching collapses to 1 emit
+    // containing the LATEST run (passed=3).
+    assert_eq!(events.len(), 1, "expected exactly one emit after replay");
+    assert!(events[0].contains(r#""passed":3"#));
+}

--- a/src-tauri/tests/transcript_vitest_replay.rs
+++ b/src-tauri/tests/transcript_vitest_replay.rs
@@ -25,12 +25,17 @@ fn replay_emits_only_latest_snapshot() {
     let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/transcript_vitest_replay.jsonl");
 
+    // Pass a valid cwd — process_tool_result skips test-run snapshots
+    // when cwd is None (avoids resolving file groups against the wrong
+    // directory). Replay-batching behaviour is independent of cwd.
+    let cwd = tempfile::tempdir().expect("temp cwd");
+
     state
         .start_or_replace(
             app_handle,
             "session-replay".to_string(),
             fixture_path,
-            None,
+            Some(cwd.path().to_path_buf()),
         )
         .expect("start watcher");
 

--- a/src/bindings/AgentToolCallEvent.ts
+++ b/src/bindings/AgentToolCallEvent.ts
@@ -35,4 +35,11 @@ export type AgentToolCallEvent = {
    * Execution duration in milliseconds
    */
   durationMs: bigint
+  /**
+   * True when this is a Write/Edit on a path that matches a known
+   * test-file convention (e.g. `*.test.ts`, `*_test.rs`). Frontend
+   * uses this to render the activity feed glyph and verb without
+   * needing to glob the path itself.
+   */
+  isTestFile: boolean
 }

--- a/src/features/agent-status/components/ActivityEvent.test.tsx
+++ b/src/features/agent-status/components/ActivityEvent.test.tsx
@@ -426,3 +426,61 @@ describe('ActivityEvent — tooltip integration', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
   })
 })
+
+describe('ActivityEvent — test-file glyph and verb', () => {
+  test('renders 🧪 CREATED TEST label for Write of a test file', () => {
+    render(
+      <ActivityEvent
+        event={toolEvent({
+          id: 'e1',
+          kind: 'write',
+          tool: 'Write',
+          body: 'src/foo.test.ts',
+          isTestFile: true,
+        })}
+        now={now}
+      />
+    )
+
+    expect(screen.getByText(/created test/i)).toBeInTheDocument()
+    // Glyph rides inside the same label span — partial-text match is fine.
+    expect(screen.getByText(/🧪/)).toBeInTheDocument()
+  })
+
+  test('renders 🧪 UPDATED TEST label for Edit of a test file', () => {
+    render(
+      <ActivityEvent
+        event={toolEvent({
+          id: 'e2',
+          kind: 'edit',
+          tool: 'Edit',
+          body: 'src/foo.test.ts',
+          isTestFile: true,
+        })}
+        now={now}
+      />
+    )
+
+    expect(screen.getByText(/updated test/i)).toBeInTheDocument()
+  })
+
+  test('regular Write event has no test glyph or prefix', () => {
+    render(
+      <ActivityEvent
+        event={toolEvent({
+          id: 'e3',
+          kind: 'write',
+          tool: 'Write',
+          body: 'src/foo.ts',
+          isTestFile: false,
+        })}
+        now={now}
+      />
+    )
+
+    expect(screen.queryByText(/created test/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/🧪/)).not.toBeInTheDocument()
+    // Falls back to the kind-based label.
+    expect(screen.getByText(/^WRITE$/)).toBeInTheDocument()
+  })
+})

--- a/src/features/agent-status/components/ActivityEvent.test.tsx
+++ b/src/features/agent-status/components/ActivityEvent.test.tsx
@@ -427,8 +427,8 @@ describe('ActivityEvent — tooltip integration', () => {
   })
 })
 
-describe('ActivityEvent — test-file glyph and verb', () => {
-  test('renders 🧪 CREATED TEST label for Write of a test file', () => {
+describe('ActivityEvent — test-file verb prefix', () => {
+  test('renders CREATED TEST label for Write of a test file', () => {
     render(
       <ActivityEvent
         event={toolEvent({
@@ -442,12 +442,13 @@ describe('ActivityEvent — test-file glyph and verb', () => {
       />
     )
 
-    expect(screen.getByText(/created test/i)).toBeInTheDocument()
-    // Glyph rides inside the same label span — partial-text match is fine.
-    expect(screen.getByText(/🧪/)).toBeInTheDocument()
+    expect(screen.getByText(/^CREATED TEST$/)).toBeInTheDocument()
+    // No emoji per CLAUDE.md no-emoji policy; the verb-prefixed text
+    // is the only differentiator.
+    expect(screen.queryByText(/🧪/)).not.toBeInTheDocument()
   })
 
-  test('renders 🧪 UPDATED TEST label for Edit of a test file', () => {
+  test('renders UPDATED TEST label for Edit of a test file', () => {
     render(
       <ActivityEvent
         event={toolEvent({
@@ -461,10 +462,11 @@ describe('ActivityEvent — test-file glyph and verb', () => {
       />
     )
 
-    expect(screen.getByText(/updated test/i)).toBeInTheDocument()
+    expect(screen.getByText(/^UPDATED TEST$/)).toBeInTheDocument()
+    expect(screen.queryByText(/🧪/)).not.toBeInTheDocument()
   })
 
-  test('regular Write event has no test glyph or prefix', () => {
+  test('regular Write event uses the kind-based label', () => {
     render(
       <ActivityEvent
         event={toolEvent({
@@ -480,7 +482,6 @@ describe('ActivityEvent — test-file glyph and verb', () => {
 
     expect(screen.queryByText(/created test/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/🧪/)).not.toBeInTheDocument()
-    // Falls back to the kind-based label.
     expect(screen.getByText(/^WRITE$/)).toBeInTheDocument()
   })
 })

--- a/src/features/agent-status/components/ActivityEvent.tsx
+++ b/src/features/agent-status/components/ActivityEvent.tsx
@@ -44,9 +44,9 @@ const getLabel = (event: ActivityEventType): string => {
     // Write tools may also overwrite existing files — labelled as
     // "CREATED" by approximation. Edit always means an existing file
     // was modified. Documented limitation in the spec.
-    const verb = event.tool === 'Edit' ? 'UPDATED TEST' : 'CREATED TEST'
-
-    return `🧪 ${verb}`
+    // No emoji in the label per CLAUDE.md ("Avoid adding emojis to files
+    // unless asked"); the verb-prefixed text is the differentiator.
+    return event.tool === 'Edit' ? 'UPDATED TEST' : 'CREATED TEST'
   }
   // The `kind === 'meta'` branch narrows `event` to ToolActivityEvent
   // via the discriminated union — `tool` is always present. Drop the

--- a/src/features/agent-status/components/ActivityEvent.tsx
+++ b/src/features/agent-status/components/ActivityEvent.tsx
@@ -36,6 +36,18 @@ const KIND_COLOR: Record<ActivityEventKind, string> = {
 }
 
 const getLabel = (event: ActivityEventType): string => {
+  // `isTestFile` is typed on the base event so consumers can read it
+  // without narrowing. The producer (`toolCallsToEvents`) only ever sets
+  // it on ToolActivityEvents, but we still guard for `tool` to keep the
+  // fallback safe if a Think/User event ever sneaks `isTestFile: true`.
+  if (event.isTestFile === true && 'tool' in event) {
+    // Write tools may also overwrite existing files — labelled as
+    // "CREATED" by approximation. Edit always means an existing file
+    // was modified. Documented limitation in the spec.
+    const verb = event.tool === 'Edit' ? 'UPDATED TEST' : 'CREATED TEST'
+
+    return `🧪 ${verb}`
+  }
   // The `kind === 'meta'` branch narrows `event` to ToolActivityEvent
   // via the discriminated union — `tool` is always present. Drop the
   // redundant `'tool' in event` guard that misled readers into thinking

--- a/src/features/agent-status/components/AgentStatusPanel.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.test.tsx
@@ -16,6 +16,7 @@ const defaultStatus: AgentStatus = {
   rateLimits: null,
   toolCalls: { total: 0, byType: {}, active: null },
   recentToolCalls: [],
+  testRun: null,
 }
 
 const defaultGitStatus = {

--- a/src/features/agent-status/components/AgentStatusPanel.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.test.tsx
@@ -137,6 +137,7 @@ describe('AgentStatusPanel', () => {
           status: 'done',
           durationMs: 100,
           timestamp: '2026-04-22T11:59:42Z',
+          isTestFile: false,
         },
       ],
     })
@@ -196,6 +197,7 @@ describe('AgentStatusPanel', () => {
           status: 'done',
           durationMs: 100,
           timestamp: '2026-04-22T11:59:42Z',
+          isTestFile: false,
         },
       ],
     })

--- a/src/features/agent-status/components/AgentStatusPanel.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.tsx
@@ -15,14 +15,14 @@ interface AgentStatusPanelProps {
   sessionId: string | null
   cwd: string
   onOpenDiff: (file: ChangedFile) => void
+  onOpenFile?: (path: string) => void
 }
-
-const placeholderTests = { passed: 0, failed: 0, total: 0 }
 
 export const AgentStatusPanel = ({
   sessionId,
   cwd,
   onOpenDiff,
+  onOpenFile = undefined,
 }: AgentStatusPanelProps): ReactElement => {
   const status = useAgentStatus(sessionId)
   const events = useActivityEvents(status)
@@ -92,11 +92,7 @@ export const AgentStatusPanel = ({
               onRetry={refresh}
               onSelect={onOpenDiff}
             />
-            <TestResults
-              passed={placeholderTests.passed}
-              failed={placeholderTests.failed}
-              total={placeholderTests.total}
-            />
+            <TestResults snapshot={status.testRun} onOpenFile={onOpenFile} />
           </div>
           <ActivityFooter
             totalDurationMs={status.cost?.totalDurationMs ?? 0}

--- a/src/features/agent-status/components/TestResults.test.tsx
+++ b/src/features/agent-status/components/TestResults.test.tsx
@@ -1,61 +1,312 @@
-import { describe, test, expect } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TestResults } from './TestResults'
+import type { TestRunSnapshot } from '../types'
 
-describe('TestResults', () => {
-  test('renders correct number of pass segments', async () => {
-    const user = userEvent.setup()
-    render(<TestResults passed={7} failed={3} total={10} />)
+const baseSnap = (overrides: Partial<TestRunSnapshot>): TestRunSnapshot => ({
+  sessionId: 's',
+  runner: 'vitest',
+  commandPreview: 'vitest run',
+  startedAt: '2026-04-28T12:00:00Z',
+  finishedAt: '2026-04-28T12:00:01Z',
+  durationMs: 1400,
+  status: 'pass',
+  summary: { passed: 47, failed: 0, skipped: 0, total: 47, groups: [] },
+  outputExcerpt: null,
+  ...overrides,
+})
 
-    await user.click(screen.getByRole('button', { name: /tests/i }))
+describe('TestResults — placeholder', () => {
+  test('renders dim placeholder when snapshot is null', () => {
+    render(<TestResults snapshot={null} />)
+    expect(screen.getByRole('status')).toHaveTextContent(/no runs yet/i)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})
 
-    const passSegments = screen.getAllByTestId('segment-pass')
-    expect(passSegments).toHaveLength(7)
+describe('TestResults — live header', () => {
+  test('pass state shows count, runner pill, duration', () => {
+    render(<TestResults snapshot={baseSnap({ status: 'pass' })} />)
+    const button = screen.getByRole('button', { name: /tests/i })
+    expect(button).toHaveTextContent('47/47')
+    expect(button).toHaveTextContent('vitest')
+    expect(button).toHaveTextContent('1.4s')
   })
 
-  test('renders correct number of fail segments', async () => {
-    const user = userEvent.setup()
-    render(<TestResults passed={7} failed={3} total={10} />)
+  test('fail state shows fail count', () => {
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'fail',
+          summary: { passed: 45, failed: 2, skipped: 0, total: 47, groups: [] },
+        })}
+      />
+    )
 
-    await user.click(screen.getByRole('button', { name: /tests/i }))
-
-    const failSegments = screen.getAllByTestId('segment-fail')
-    expect(failSegments).toHaveLength(3)
+    expect(screen.getByRole('button', { name: /tests/i })).toHaveTextContent(
+      '45/47'
+    )
   })
 
-  test('shows pass/total count in header', () => {
-    render(<TestResults passed={7} failed={3} total={10} />)
+  test('noTests state shows 0/0', () => {
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'noTests',
+          summary: { passed: 0, failed: 0, skipped: 0, total: 0, groups: [] },
+        })}
+      />
+    )
 
-    expect(screen.getByText('7/10')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /tests/i })).toHaveTextContent(
+      '0/0'
+    )
   })
 
-  test('shows passed and failed counts in body', async () => {
-    const user = userEvent.setup()
-    render(<TestResults passed={7} failed={3} total={10} />)
+  test('error state header shows the runner and an error indicator', () => {
+    render(
+      <TestResults
+        snapshot={baseSnap({ status: 'error', outputExcerpt: 'TS error' })}
+      />
+    )
+    const button = screen.getByRole('button', { name: /tests/i })
+    expect(button).toHaveTextContent('vitest')
+  })
+})
 
+describe('TestResults — keyboard activation', () => {
+  test('Enter and Space toggle expand without custom handlers', async () => {
+    const user = userEvent.setup()
+    render(<TestResults snapshot={baseSnap({})} />)
+    const button = screen.getByRole('button', { name: /tests/i })
+
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+
+    button.focus()
+    await user.keyboard('{Enter}')
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+
+    await user.keyboard(' ')
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+  })
+})
+
+describe('TestResults — expanded body', () => {
+  test('fail state renders summary text and group rows', async () => {
+    const user = userEvent.setup()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'fail',
+          summary: {
+            passed: 45,
+            failed: 2,
+            skipped: 1,
+            total: 48,
+            groups: [
+              {
+                label: 'src/foo.test.ts',
+                path: '/abs/src/foo.test.ts',
+                kind: 'file',
+                passed: 12,
+                failed: 0,
+                skipped: 0,
+                total: 12,
+                status: 'pass',
+              },
+              {
+                label: 'src/bar.test.ts',
+                path: '/abs/src/bar.test.ts',
+                kind: 'file',
+                passed: 5,
+                failed: 2,
+                skipped: 0,
+                total: 7,
+                status: 'fail',
+              },
+            ],
+          },
+        })}
+        onOpenFile={vi.fn()}
+      />
+    )
     await user.click(screen.getByRole('button', { name: /tests/i }))
 
-    expect(screen.getByText('7 passed, 3 failed')).toBeInTheDocument()
+    expect(screen.getByText(/45 passed/)).toBeInTheDocument()
+    expect(screen.getByText(/2 failed/)).toBeInTheDocument()
+    expect(screen.getByText(/1 skipped/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /open src\/foo\.test\.ts/i })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: /open src\/bar\.test\.ts/i })
+    ).toBeInTheDocument()
   })
 
-  test('applies success color when all tests pass', async () => {
+  test('error state renders outputExcerpt fallback when null', async () => {
     const user = userEvent.setup()
-    render(<TestResults passed={10} failed={0} total={10} />)
-
+    render(
+      <TestResults
+        snapshot={baseSnap({ status: 'error', outputExcerpt: null })}
+      />
+    )
     await user.click(screen.getByRole('button', { name: /tests/i }))
-
-    const countText = screen.getByText('10 passed, 0 failed')
-    expect(countText).toHaveClass('text-success')
+    expect(screen.getByText(/runner errored/i)).toBeInTheDocument()
   })
 
-  test('applies warning color when some tests fail', async () => {
+  test('error state renders outputExcerpt when present', async () => {
     const user = userEvent.setup()
-    render(<TestResults passed={7} failed={3} total={10} />)
-
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'error',
+          outputExcerpt: 'compile error: TS2345',
+        })}
+      />
+    )
     await user.click(screen.getByRole('button', { name: /tests/i }))
+    expect(screen.getByText(/compile error: TS2345/)).toBeInTheDocument()
+  })
 
-    const countText = screen.getByText('7 passed, 3 failed')
-    expect(countText).toHaveClass('text-warning')
+  test('noTests state shows "no tests collected"', async () => {
+    const user = userEvent.setup()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'noTests',
+          summary: { passed: 0, failed: 0, skipped: 0, total: 0, groups: [] },
+        })}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+    expect(screen.getByText(/no tests collected/i)).toBeInTheDocument()
+  })
+})
+
+describe('TestResults — group row click', () => {
+  test('file row with path and onOpenFile is a button that fires onOpenFile', async () => {
+    const user = userEvent.setup()
+    const onOpenFile = vi.fn()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          summary: {
+            passed: 12,
+            failed: 0,
+            skipped: 0,
+            total: 12,
+            groups: [
+              {
+                label: 'src/foo.test.ts',
+                path: '/abs/src/foo.test.ts',
+                kind: 'file',
+                passed: 12,
+                failed: 0,
+                skipped: 0,
+                total: 12,
+                status: 'pass',
+              },
+            ],
+          },
+        })}
+        onOpenFile={onOpenFile}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+    await user.click(
+      screen.getByRole('button', { name: /open src\/foo\.test\.ts/i })
+    )
+    expect(onOpenFile).toHaveBeenCalledOnce()
+    expect(onOpenFile).toHaveBeenCalledWith('/abs/src/foo.test.ts')
+  })
+
+  test('file row with null path is non-interactive (no button)', async () => {
+    const user = userEvent.setup()
+    const onOpenFile = vi.fn()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          summary: {
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            total: 1,
+            groups: [
+              {
+                label: 'src/missing.test.ts',
+                path: null,
+                kind: 'file',
+                passed: 1,
+                failed: 0,
+                skipped: 0,
+                total: 1,
+                status: 'pass',
+              },
+            ],
+          },
+        })}
+        onOpenFile={onOpenFile}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+    // No button for the missing file — only the header button remains.
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(1)
+    expect(buttons[0]).toHaveTextContent(/tests/i)
+    expect(onOpenFile).not.toHaveBeenCalled()
+  })
+
+  test('module/suite row never interactive', async () => {
+    const user = userEvent.setup()
+    const onOpenFile = vi.fn()
+    render(
+      <TestResults
+        snapshot={baseSnap({
+          summary: {
+            passed: 5,
+            failed: 0,
+            skipped: 0,
+            total: 5,
+            groups: [
+              {
+                // cspell:disable-next-line
+                label: 'mycrate::tests',
+                path: null,
+                kind: 'module',
+                passed: 5,
+                failed: 0,
+                skipped: 0,
+                total: 5,
+                status: 'pass',
+              },
+            ],
+          },
+        })}
+        onOpenFile={onOpenFile}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /tests/i }))
+    // cspell:disable-next-line
+    expect(screen.queryByRole('button', { name: /open mycrate/i })).toBeNull()
+  })
+})
+
+describe('TestResults — useId aria-controls uniqueness', () => {
+  test('two TestResults in one render have distinct aria-controls', () => {
+    render(
+      <>
+        <TestResults snapshot={baseSnap({ runner: 'vitest' })} />
+        <TestResults snapshot={baseSnap({ runner: 'cargo' })} />
+      </>
+    )
+    const buttons = screen.getAllByRole('button', { name: /tests/i })
+    expect(buttons).toHaveLength(2)
+    const a = buttons[0].getAttribute('aria-controls')
+    const b = buttons[1].getAttribute('aria-controls')
+    expect(a).toBeTruthy()
+    expect(b).toBeTruthy()
+    expect(a).not.toBe(b)
   })
 })

--- a/src/features/agent-status/components/TestResults.test.tsx
+++ b/src/features/agent-status/components/TestResults.test.tsx
@@ -49,7 +49,7 @@ describe('TestResults — live header', () => {
     )
   })
 
-  test('noTests state shows 0/0', () => {
+  test('noTests state shows "no tests" status text (not 0/0)', () => {
     render(
       <TestResults
         snapshot={baseSnap({
@@ -59,19 +59,45 @@ describe('TestResults — live header', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: /tests/i })).toHaveTextContent(
-      '0/0'
-    )
+    const button = screen.getByRole('button', { name: /no tests collected/i })
+    expect(button).toHaveTextContent(/no tests/i)
+    expect(button).not.toHaveTextContent('0/0')
   })
 
-  test('error state header shows the runner and an error indicator', () => {
+  test('error state header shows "errored" text (not 0/0) and the runner', () => {
     render(
       <TestResults
         snapshot={baseSnap({ status: 'error', outputExcerpt: 'TS error' })}
       />
     )
-    const button = screen.getByRole('button', { name: /tests/i })
+    const button = screen.getByRole('button', { name: /runner errored/i })
+    expect(button).toHaveTextContent(/errored/i)
     expect(button).toHaveTextContent('vitest')
+    expect(button).not.toHaveTextContent('0/0')
+  })
+
+  test('header aria-label encodes status without relying on dot color', () => {
+    // pass: full count + runner + duration
+    const { rerender } = render(
+      <TestResults snapshot={baseSnap({ status: 'pass' })} />
+    )
+    expect(
+      screen.getByRole('button', { name: /47 of 47 passed/i })
+    ).toBeInTheDocument()
+
+    // fail: passed + failed counts
+    rerender(
+      <TestResults
+        snapshot={baseSnap({
+          status: 'fail',
+          summary: { passed: 45, failed: 2, skipped: 0, total: 47, groups: [] },
+        })}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: /45 of 47 passed, 2 failed/i })
+    ).toBeInTheDocument()
   })
 })
 

--- a/src/features/agent-status/components/TestResults.tsx
+++ b/src/features/agent-status/components/TestResults.tsx
@@ -41,7 +41,6 @@ const TestResultsLive = ({
   const [expanded, setExpanded] = useState(false)
   const bodyId = useId()
 
-  const { passed, total } = snapshot.summary
   const dotClass = statusDotClass(snapshot.status)
 
   return (
@@ -53,6 +52,7 @@ const TestResultsLive = ({
         type="button"
         aria-expanded={expanded}
         aria-controls={bodyId}
+        aria-label={headerAriaLabel(snapshot)}
         onClick={(): void => setExpanded((v) => !v)}
         className="flex w-full cursor-pointer items-center gap-2 px-5 py-3 text-left"
       >
@@ -65,7 +65,7 @@ const TestResultsLive = ({
           aria-hidden
         />
         <span className="font-mono text-[10px] text-on-surface">
-          {passed}/{total}
+          {headerStatusText(snapshot)}
         </span>
         <span className="font-mono text-[10px] text-on-surface-variant/70">
           · {snapshot.runner}
@@ -246,6 +246,45 @@ const statusDotClass = (s: TestRunStatus): string => {
     case 'error':
       return 'bg-tertiary'
   }
+}
+
+// Visible header text in the slot the count badge would occupy.
+// pass/fail show the count; noTests and error replace the count with
+// a status word so the collapsed header doesn't read "0/0" for two
+// semantically different states (and so the distinction isn't carried
+// only by the dot color).
+const headerStatusText = (snapshot: TestRunSnapshot): string => {
+  switch (snapshot.status) {
+    case 'pass':
+    case 'fail':
+      return `${snapshot.summary.passed}/${snapshot.summary.total}`
+    case 'noTests':
+      return 'no tests'
+    case 'error':
+      return 'errored'
+  }
+}
+
+// Comprehensive accessible name for the collapsed-header button. Replaces
+// the visual text fragments for screen readers so the user hears the
+// status without depending on the dot color (which is aria-hidden).
+const headerAriaLabel = (snapshot: TestRunSnapshot): string => {
+  const { passed, failed, total } = snapshot.summary
+
+  const detail = ((): string => {
+    switch (snapshot.status) {
+      case 'pass':
+        return `${passed} of ${total} passed`
+      case 'fail':
+        return `${passed} of ${total} passed, ${failed} failed`
+      case 'noTests':
+        return 'no tests collected'
+      case 'error':
+        return 'runner errored'
+    }
+  })()
+
+  return `Tests, ${detail}, ${snapshot.runner}, ${formatDuration(snapshot.durationMs)}`
 }
 
 const groupIcon = (s: TestGroup['status']): string => {

--- a/src/features/agent-status/components/TestResults.tsx
+++ b/src/features/agent-status/components/TestResults.tsx
@@ -1,45 +1,284 @@
+import { useId, useState } from 'react'
 import type { ReactElement } from 'react'
-import { CollapsibleSection } from './CollapsibleSection'
+import type { TestGroup, TestRunSnapshot, TestRunStatus } from '../types'
 
 interface TestResultsProps {
-  passed: number
-  failed: number
-  total: number
+  snapshot: TestRunSnapshot | null
+  onOpenFile?: (path: string) => void
 }
 
 export const TestResults = ({
-  passed,
-  failed,
-  total,
+  snapshot,
+  onOpenFile = undefined,
 }: TestResultsProps): ReactElement => {
-  const allPassed = failed === 0 && total > 0
+  if (snapshot === null) {
+    return <TestResultsPlaceholder />
+  }
 
-  const segments = Array.from({ length: total }, (_, i) =>
-    i < passed ? 'pass' : 'fail'
-  )
+  return <TestResultsLive snapshot={snapshot} onOpenFile={onOpenFile} />
+}
+
+const TestResultsPlaceholder = (): ReactElement => (
+  <div
+    role="status"
+    aria-live="polite"
+    className="border-t border-outline-variant/[0.08] px-5 py-3 font-mono text-[10px] uppercase tracking-[0.15em] text-on-surface-variant/60"
+    data-testid="test-results"
+  >
+    Tests &nbsp;&nbsp;no runs yet
+  </div>
+)
+
+interface LiveProps {
+  snapshot: TestRunSnapshot
+  onOpenFile?: (path: string) => void
+}
+
+const TestResultsLive = ({
+  snapshot,
+  onOpenFile = undefined,
+}: LiveProps): ReactElement => {
+  const [expanded, setExpanded] = useState(false)
+  const bodyId = useId()
+
+  const { passed, total } = snapshot.summary
+  const dotClass = statusDotClass(snapshot.status)
 
   return (
-    <CollapsibleSection title="Tests" count={`${passed}/${total}`}>
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-0.5">
-          {segments.map((type, i) => (
-            <div
-              key={i}
-              className={`h-[3px] flex-1 rounded-full ${
-                type === 'pass' ? 'bg-success' : 'bg-error/40'
-              }`}
-              data-testid={`segment-${type}`}
-            />
-          ))}
-        </div>
-        <span
-          className={`font-mono text-[10px] font-bold ${
-            allPassed ? 'text-success' : 'text-warning'
-          }`}
-        >
-          {passed} passed, {failed} failed
+    <div
+      className="border-t border-outline-variant/[0.08]"
+      data-testid="test-results"
+    >
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={bodyId}
+        onClick={(): void => setExpanded((v) => !v)}
+        className="flex w-full cursor-pointer items-center gap-2 px-5 py-3 text-left"
+      >
+        <span className="text-[10px] text-outline">{expanded ? '▾' : '▸'}</span>
+        <span className="text-[10px] font-black uppercase tracking-[0.15em] text-outline">
+          Tests
         </span>
+        <span
+          className={`inline-block h-2 w-2 rounded-full ${dotClass}`}
+          aria-hidden
+        />
+        <span className="font-mono text-[10px] text-on-surface">
+          {passed}/{total}
+        </span>
+        <span className="font-mono text-[10px] text-on-surface-variant/70">
+          · {snapshot.runner}
+        </span>
+        <span className="font-mono text-[10px] text-on-surface-variant/70">
+          · {formatDuration(snapshot.durationMs)}
+        </span>
+      </button>
+      <div id={bodyId} hidden={!expanded} className="px-5 pb-3">
+        {expanded && (
+          <TestResultsBody snapshot={snapshot} onOpenFile={onOpenFile} />
+        )}
       </div>
-    </CollapsibleSection>
+    </div>
   )
+}
+
+interface BodyProps {
+  snapshot: TestRunSnapshot
+  onOpenFile?: (path: string) => void
+}
+
+const TestResultsBody = ({
+  snapshot,
+  onOpenFile = undefined,
+}: BodyProps): ReactElement => {
+  if (snapshot.status === 'noTests') {
+    return (
+      <span className="font-mono text-[10px] text-on-surface-variant">
+        no tests collected
+      </span>
+    )
+  }
+  if (snapshot.status === 'error') {
+    return (
+      <span className="font-mono text-[10px] text-on-surface-variant">
+        {snapshot.outputExcerpt ?? 'runner errored before producing results'}
+      </span>
+    )
+  }
+
+  const { passed, failed, skipped } = snapshot.summary
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ProportionalBar passed={passed} failed={failed} skipped={skipped} />
+      <SummaryText passed={passed} failed={failed} skipped={skipped} />
+      <ul className="flex flex-col gap-1">
+        {snapshot.summary.groups.map((g, i) => (
+          <li key={`${g.label}-${i}`}>
+            <GroupRow group={g} onOpenFile={onOpenFile} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+interface BarProps {
+  passed: number
+  failed: number
+  skipped: number
+}
+
+const ProportionalBar = ({
+  passed,
+  failed,
+  skipped,
+}: BarProps): ReactElement => {
+  if (passed + failed + skipped === 0) {
+    return <></>
+  }
+
+  return (
+    <div className="flex h-[3px] w-full overflow-hidden rounded-full">
+      {passed > 0 && (
+        <div style={{ flexGrow: passed }} className="bg-success" />
+      )}
+      {failed > 0 && <div style={{ flexGrow: failed }} className="bg-error" />}
+      {skipped > 0 && (
+        <div
+          style={{ flexGrow: skipped }}
+          className="bg-on-surface-variant/40"
+        />
+      )}
+    </div>
+  )
+}
+
+const SummaryText = ({ passed, failed, skipped }: BarProps): ReactElement => {
+  const parts = [`${passed} passed`]
+  if (failed > 0) {
+    parts.push(`${failed} failed`)
+  }
+  if (skipped > 0) {
+    parts.push(`${skipped} skipped`)
+  }
+
+  return (
+    <span className="font-mono text-[10px] font-bold text-on-surface">
+      {parts.join(', ')}
+    </span>
+  )
+}
+
+interface GroupRowProps {
+  group: TestGroup
+  onOpenFile?: (path: string) => void
+}
+
+const GroupRow = ({
+  group,
+  onOpenFile = undefined,
+}: GroupRowProps): ReactElement => {
+  const icon = groupIcon(group.status)
+
+  const countText =
+    group.skipped > 0
+      ? `${group.passed}/${group.total} (${group.skipped} skipped)`
+      : `${group.passed}/${group.total}`
+
+  if (
+    group.kind === 'file' &&
+    group.path !== null &&
+    onOpenFile !== undefined
+  ) {
+    const path = group.path
+
+    return (
+      <button
+        type="button"
+        aria-label={`Open ${group.label}`}
+        onClick={(): void => onOpenFile(path)}
+        className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left hover:bg-surface-container-high"
+      >
+        <span
+          className={`${groupIconColor(group.status)} font-mono text-[11px]`}
+          aria-hidden
+        >
+          {icon}
+        </span>
+        <span className="flex-1 truncate font-mono text-[11px] text-on-surface">
+          {group.label}
+        </span>
+        <span className="font-mono text-[10px] text-on-surface-variant">
+          {countText}
+        </span>
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex w-full items-center gap-2 px-1 py-0.5">
+      <span
+        className={`${groupIconColor(group.status)} font-mono text-[11px]`}
+        aria-hidden
+      >
+        {icon}
+      </span>
+      <span className="flex-1 truncate font-mono text-[11px] text-on-surface">
+        {group.label}
+      </span>
+      <span className="font-mono text-[10px] text-on-surface-variant">
+        {countText}
+      </span>
+    </div>
+  )
+}
+
+const statusDotClass = (s: TestRunStatus): string => {
+  switch (s) {
+    case 'pass':
+      return 'bg-success'
+    case 'fail':
+      return 'bg-error'
+    case 'noTests':
+      return 'bg-on-surface-variant'
+    case 'error':
+      return 'bg-tertiary'
+  }
+}
+
+const groupIcon = (s: TestGroup['status']): string => {
+  switch (s) {
+    case 'pass':
+      return '✓'
+    case 'fail':
+      return '✗'
+    case 'skip':
+      return '⊘'
+  }
+}
+
+const groupIconColor = (s: TestGroup['status']): string => {
+  switch (s) {
+    case 'pass':
+      return 'text-success'
+    case 'fail':
+      return 'text-error'
+    case 'skip':
+      return 'text-on-surface-variant'
+  }
+}
+
+const formatDuration = (ms: number): string => {
+  if (ms < 1000) {
+    return `${ms}ms`
+  }
+  if (ms < 60_000) {
+    return `${(ms / 1000).toFixed(1)}s`
+  }
+  const minutes = Math.floor(ms / 60_000)
+  const seconds = Math.floor((ms % 60_000) / 1000)
+
+  return `${minutes}m ${seconds}s`
 }

--- a/src/features/agent-status/components/TestResults.tsx
+++ b/src/features/agent-status/components/TestResults.tsx
@@ -114,8 +114,12 @@ const TestResultsBody = ({
       <ProportionalBar passed={passed} failed={failed} skipped={skipped} />
       <SummaryText passed={passed} failed={failed} skipped={skipped} />
       <ul className="flex flex-col gap-1">
-        {snapshot.summary.groups.map((g, i) => (
-          <li key={`${g.label}-${i}`}>
+        {snapshot.summary.groups.map((g) => (
+          // Identity-based key, not positional — vitest file paths and
+          // cargo `<crate>::<module>` paths are unique within a snapshot.
+          // Namespace by kind so a future parser producing colliding labels
+          // across kinds wouldn't trigger a duplicate-key warning.
+          <li key={`${g.kind}:${g.label}`}>
             <GroupRow group={g} onOpenFile={onOpenFile} />
           </li>
         ))}

--- a/src/features/agent-status/hooks/useActivityEvents.test.tsx
+++ b/src/features/agent-status/hooks/useActivityEvents.test.tsx
@@ -16,6 +16,7 @@ const baseStatus: AgentStatus = {
   rateLimits: null,
   toolCalls: { total: 0, byType: {}, active: null },
   recentToolCalls: [],
+  testRun: null,
 }
 
 describe('useActivityEvents', () => {

--- a/src/features/agent-status/hooks/useAgentStatus.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.test.ts
@@ -1,41 +1,52 @@
 import { afterEach, describe, test, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+import { getPtySessionId } from '../../terminal/ptySessionMap'
+import type { TestRunSnapshot } from '../types'
 import { useAgentStatus } from './useAgentStatus'
 
 type EventCallback<T = unknown> = (event: { payload: T }) => void
 
 const eventListeners = new Map<string, EventCallback[]>()
 
+const defaultListenImpl = (
+  eventName: string,
+  callback: EventCallback
+): Promise<() => void> => {
+  const existing = eventListeners.get(eventName) ?? []
+  existing.push(callback)
+  eventListeners.set(eventName, existing)
+
+  const unlisten = (): void => {
+    const listeners = eventListeners.get(eventName) ?? []
+    const idx = listeners.indexOf(callback)
+
+    if (idx >= 0) {
+      listeners.splice(idx, 1)
+    }
+  }
+
+  return Promise.resolve(unlisten)
+}
+
+const defaultInvokeImpl = (): Promise<null> => Promise.resolve(null)
+
+const defaultGetPtySessionIdImpl = (id: string): string => `pty-${id}`
+
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(() => Promise.resolve(null)),
+  invoke: vi.fn(),
 }))
 
 vi.mock('../../terminal/ptySessionMap', () => ({
-  getPtySessionId: vi.fn((id: string) => `pty-${id}`),
+  getPtySessionId: vi.fn(),
   getStatusFilePath: vi.fn(
     (id: string) => `/project/.vimeflow/sessions/pty-${id}/status.json`
   ),
 }))
 
 vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn(
-    (eventName: string, callback: EventCallback): Promise<() => void> => {
-      const existing = eventListeners.get(eventName) ?? []
-      existing.push(callback)
-      eventListeners.set(eventName, existing)
-
-      const unlisten = (): void => {
-        const listeners = eventListeners.get(eventName) ?? []
-        const idx = listeners.indexOf(callback)
-
-        if (idx >= 0) {
-          listeners.splice(idx, 1)
-        }
-      }
-
-      return Promise.resolve(unlisten)
-    }
-  ),
+  listen: vi.fn(),
 }))
 
 const emit = <T>(eventName: string, payload: T): void => {
@@ -49,6 +60,12 @@ describe('useAgentStatus', () => {
   beforeEach(() => {
     eventListeners.clear()
     vi.clearAllMocks()
+    // Restore default implementations so per-test overrides don't leak.
+    vi.mocked(invoke).mockImplementation(defaultInvokeImpl)
+    vi.mocked(listen).mockImplementation(
+      defaultListenImpl as unknown as typeof listen
+    )
+    vi.mocked(getPtySessionId).mockImplementation(defaultGetPtySessionIdImpl)
     vi.useFakeTimers()
   })
 
@@ -66,8 +83,6 @@ describe('useAgentStatus', () => {
   })
 
   test('subscribes to tauri events when sessionId is provided', async () => {
-    const { listen } = await import('@tauri-apps/api/event')
-
     renderHook(() => useAgentStatus('session-1'))
 
     // Detection/disconnect is polling-only — only agent-status and
@@ -333,8 +348,6 @@ describe('useAgentStatus', () => {
   })
 
   test('polls detect_agent_in_session on interval', async () => {
-    const { invoke } = await import('@tauri-apps/api/core')
-
     renderHook(() => useAgentStatus('session-1'))
 
     // Should have called invoke immediately for detection
@@ -354,8 +367,6 @@ describe('useAgentStatus', () => {
   })
 
   test('stops watchers when sessionId changes', async () => {
-    const { invoke } = await import('@tauri-apps/api/core')
-
     const { rerender } = renderHook(
       ({ id }: { id: string | null }) => useAgentStatus(id),
       { initialProps: { id: 'session-1' } }
@@ -379,11 +390,8 @@ describe('useAgentStatus', () => {
   })
 
   test('does not start duplicate watchers on repeated detection', async () => {
-    const { invoke: mockInvoke } = await import('@tauri-apps/api/core')
-    const invokeMock = vi.mocked(mockInvoke)
-
     // Return detected agent on every poll
-    invokeMock.mockImplementation((cmd: string) => {
+    vi.mocked(invoke).mockImplementation(((cmd: string) => {
       if (cmd === 'detect_agent_in_session') {
         return Promise.resolve({
           sessionId: 'pty-session-1',
@@ -393,7 +401,7 @@ describe('useAgentStatus', () => {
       }
 
       return Promise.resolve(null)
-    })
+    }) as unknown as typeof invoke)
 
     const { result } = renderHook(() => useAgentStatus('session-1'))
 
@@ -410,5 +418,133 @@ describe('useAgentStatus', () => {
     // The hook should have set isActive once and not re-triggered
     expect(result.current.isActive).toBe(true)
     expect(result.current.agentType).toBe('claude-code')
+  })
+
+  test('attaches test-run listener BEFORE invoking start_agent_watcher', async () => {
+    const PTY_ID = 'pty-ordering'
+    vi.mocked(getPtySessionId).mockReturnValue(PTY_ID)
+
+    const callOrder: string[] = []
+
+    vi.mocked(listen).mockImplementation(((event: string) => {
+      callOrder.push(`listen:${String(event)}`)
+
+      return Promise.resolve((): void => undefined)
+    }) as unknown as typeof listen)
+
+    vi.mocked(invoke).mockImplementation(((cmd: string) => {
+      callOrder.push(`invoke:${String(cmd)}`)
+
+      if (cmd === 'detect_agent_in_session') {
+        return Promise.resolve({ agentType: 'claudeCode', sessionId: PTY_ID })
+      }
+
+      return Promise.resolve(undefined)
+    }) as unknown as typeof invoke)
+
+    renderHook(() => useAgentStatus('ws-1'))
+
+    // Wait for the subscribe + first detection cycle to complete.
+    await vi.waitFor(() => {
+      expect(callOrder).toContain('invoke:start_agent_watcher')
+    })
+
+    const testRunIndex = callOrder.indexOf('listen:test-run')
+    const startWatcherIndex = callOrder.indexOf('invoke:start_agent_watcher')
+
+    expect(testRunIndex).toBeGreaterThanOrEqual(0)
+    expect(startWatcherIndex).toBeGreaterThanOrEqual(0)
+    expect(testRunIndex).toBeLessThan(startWatcherIndex)
+  })
+
+  test('test-run event with matching pty id updates status.testRun', async () => {
+    const PTY_ID = 'pty-tr'
+    vi.mocked(getPtySessionId).mockReturnValue(PTY_ID)
+
+    let testRunHandler: ((e: { payload: TestRunSnapshot }) => void) | undefined
+
+    vi.mocked(listen).mockImplementation(((
+      event: string,
+      handler: (e: { payload: TestRunSnapshot }) => void
+    ) => {
+      if (event === 'test-run') {
+        testRunHandler = handler
+      }
+
+      return Promise.resolve((): void => undefined)
+    }) as unknown as typeof listen)
+
+    const { result } = renderHook(() => useAgentStatus('ws-1'))
+
+    await vi.waitFor(() => {
+      expect(testRunHandler).toBeDefined()
+    })
+
+    const snap: TestRunSnapshot = {
+      sessionId: PTY_ID,
+      runner: 'vitest',
+      commandPreview: 'vitest run',
+      startedAt: '2026-04-28T12:00:00Z',
+      finishedAt: '2026-04-28T12:00:01Z',
+      durationMs: 1000,
+      status: 'pass',
+      summary: { passed: 3, failed: 0, skipped: 0, total: 3, groups: [] },
+      outputExcerpt: null,
+    }
+
+    act(() => {
+      testRunHandler?.({ payload: snap })
+    })
+
+    expect(result.current.testRun).toEqual(snap)
+  })
+
+  test('test-run event with mismatched pty id is ignored', async () => {
+    const PTY_ID = 'pty-real'
+    vi.mocked(getPtySessionId).mockReturnValue(PTY_ID)
+
+    let testRunHandler: ((e: { payload: TestRunSnapshot }) => void) | undefined
+
+    vi.mocked(listen).mockImplementation(((
+      event: string,
+      handler: (e: { payload: TestRunSnapshot }) => void
+    ) => {
+      if (event === 'test-run') {
+        testRunHandler = handler
+      }
+
+      return Promise.resolve((): void => undefined)
+    }) as unknown as typeof listen)
+
+    const { result } = renderHook(() => useAgentStatus('ws-1'))
+
+    await vi.waitFor(() => {
+      expect(testRunHandler).toBeDefined()
+    })
+
+    act(() => {
+      testRunHandler?.({
+        payload: {
+          sessionId: 'wrong-pty-id',
+          runner: 'vitest',
+          commandPreview: 'vitest',
+          startedAt: '',
+          finishedAt: '',
+          durationMs: 0,
+          status: 'pass',
+          summary: { passed: 1, failed: 0, skipped: 0, total: 1, groups: [] },
+          outputExcerpt: null,
+        },
+      })
+    })
+
+    expect(result.current.testRun).toBeNull()
+  })
+
+  test('createDefaultStatus has testRun: null', () => {
+    // The hook always starts with testRun: null on first render.
+    vi.mocked(getPtySessionId).mockReturnValue(undefined)
+    const { result } = renderHook(() => useAgentStatus('ws-default'))
+    expect(result.current.testRun).toBeNull()
   })
 })

--- a/src/features/agent-status/hooks/useAgentStatus.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.test.ts
@@ -278,6 +278,29 @@ describe('useAgentStatus', () => {
     expect(result.current.toolCalls.active).toBeNull()
   })
 
+  test('propagates isTestFile from agent-tool-call event to recentToolCalls', async () => {
+    const { result } = renderHook(() => useAgentStatus('session-1'))
+
+    await vi.waitFor(() => {
+      expect(eventListeners.get('agent-tool-call')?.length).toBe(1)
+    })
+
+    act(() => {
+      emit('agent-tool-call', {
+        sessionId: 'pty-session-1',
+        toolUseId: 'toolu_test1',
+        tool: 'Write',
+        args: 'src/foo.test.ts',
+        status: 'done',
+        timestamp: '2026-04-28T12:00:00Z',
+        durationMs: 100,
+        isTestFile: true,
+      })
+    })
+
+    expect(result.current.recentToolCalls[0]?.isTestFile).toBe(true)
+  })
+
   test('parallel same-tool completions retain distinct ids via toolUseId', async () => {
     const { result } = renderHook(() => useAgentStatus('session-1'))
 

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -292,6 +292,7 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
               status: p.status,
               durationMs: Number(p.durationMs) || null,
               timestamp: p.timestamp,
+              isTestFile: p.isTestFile,
             }
 
             setStatus((prev) => {

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -8,6 +8,7 @@ import type {
   AgentStatusEvent,
   AgentToolCallEvent,
   RecentToolCall,
+  TestRunSnapshot,
 } from '../types'
 
 // Backend cap for the sliding window of completed tool calls. The
@@ -37,6 +38,7 @@ const createDefaultStatus = (sessionId: string | null): AgentStatus => ({
   rateLimits: null,
   toolCalls: { total: 0, byType: {}, active: null },
   recentToolCalls: [],
+  testRun: null,
 })
 
 /** Stop all agent watchers for a given session (best-effort, logs on failure) */
@@ -163,8 +165,10 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
       void handleDetection(sessionId)
     }, DETECTION_POLL_MS)
 
-    // Run immediately on mount
-    void handleDetection(sessionId)
+    // Note: the initial detection call is fired by the subscribe useEffect
+    // *after* listeners are attached. Triggering it here would race with
+    // subscribe() and potentially fire start_agent_watcher before the
+    // test-run listener is attached, missing the latest-of-replay snapshot.
 
     return (): void => {
       clearInterval(interval)
@@ -319,6 +323,25 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
       )
 
       addUnlisten(unlistenToolCall)
+
+      // test-run listener — must be attached before start_agent_watcher fires.
+      // Without a backend snapshot cache in v1, missing the latest-of-replay
+      // batch from session start would lose the snapshot entirely.
+      const unlistenTestRun = await listen<TestRunSnapshot>(
+        'test-run',
+        (event) => {
+          if (event.payload.sessionId !== resolvePtyId()) {
+            return
+          }
+
+          setStatus((prev) => ({
+            ...prev,
+            testRun: event.payload,
+          }))
+        }
+      )
+
+      addUnlisten(unlistenTestRun)
     }
 
     // After all listeners are active, trigger a detection poll to sync

--- a/src/features/agent-status/types/activityEvent.ts
+++ b/src/features/agent-status/types/activityEvent.ts
@@ -15,6 +15,13 @@ export interface BaseActivityEvent {
   timestamp: string
   status: 'running' | 'done' | 'failed'
   body: string
+  /**
+   * True when this event is a Write/Edit on a path that matches a known
+   * test-file convention. Only meaningful on ToolActivityEvents; Think
+   * and User events never set this. Lives on the base type so consumers
+   * can read `event.isTestFile` without union narrowing.
+   */
+  isTestFile?: boolean
 }
 
 export interface ToolActivityEvent extends BaseActivityEvent {

--- a/src/features/agent-status/types/index.ts
+++ b/src/features/agent-status/types/index.ts
@@ -83,4 +83,10 @@ export interface RecentToolCall {
   status: 'done' | 'failed'
   durationMs: number | null
   timestamp: string
+  /**
+   * True when this entry is a Write/Edit on a path that matches a
+   * known test-file convention. Sourced from the originating Rust
+   * AgentToolCallEvent — see `src-tauri/src/agent/test_runners/test_file_patterns.rs`.
+   */
+  isTestFile: boolean
 }

--- a/src/features/agent-status/types/index.ts
+++ b/src/features/agent-status/types/index.ts
@@ -41,6 +41,49 @@ export interface AgentStatus {
   // Activity
   toolCalls: ToolCallState
   recentToolCalls: RecentToolCall[]
+
+  // Latest test run snapshot (null until the first test-run event arrives)
+  testRun: TestRunSnapshot | null
+}
+
+export type TestRunStatus = 'pass' | 'fail' | 'noTests' | 'error'
+
+export type TestGroupKind = 'file' | 'suite' | 'module'
+
+export type TestGroupStatus = 'pass' | 'fail' | 'skip'
+
+export interface TestGroup {
+  label: string
+  // Rust serializes Option<String> as null (not omitted). Use string | null
+  // so the boundary contract matches the wire shape exactly.
+  path: string | null
+  kind: TestGroupKind
+  passed: number
+  failed: number
+  skipped: number
+  total: number
+  status: TestGroupStatus
+}
+
+export interface TestRunSummary {
+  passed: number
+  failed: number
+  skipped: number
+  total: number
+  groups: TestGroup[]
+}
+
+export interface TestRunSnapshot {
+  sessionId: string // PTY session id
+  runner: string
+  commandPreview: string
+  startedAt: string
+  finishedAt: string
+  durationMs: number
+  status: TestRunStatus
+  // Rust serializes Option<String> as null (not omitted).
+  outputExcerpt: string | null
+  summary: TestRunSummary
 }
 
 export interface ContextWindowState {

--- a/src/features/agent-status/utils/toolCallsToEvents.test.ts
+++ b/src/features/agent-status/utils/toolCallsToEvents.test.ts
@@ -9,6 +9,7 @@ const recent = (overrides: Partial<RecentToolCall> = {}): RecentToolCall => ({
   status: 'done',
   durationMs: 100,
   timestamp: '2026-04-22T10:00:00Z',
+  isTestFile: false,
   ...overrides,
 })
 

--- a/src/features/agent-status/utils/toolCallsToEvents.test.ts
+++ b/src/features/agent-status/utils/toolCallsToEvents.test.ts
@@ -133,4 +133,36 @@ describe('toolCallsToEvents', () => {
       timestamp: '2026-04-22T09:00:00Z',
     })
   })
+
+  test('propagates isTestFile from RecentToolCall to ActivityEvent', () => {
+    const events = toolCallsToEvents(null, [
+      {
+        id: 'tu_1',
+        tool: 'Write',
+        args: 'src/foo.test.ts',
+        status: 'done',
+        durationMs: 100,
+        timestamp: '2026-04-28T12:00:00Z',
+        isTestFile: true,
+      },
+    ])
+
+    expect(events[0]?.isTestFile).toBe(true)
+  })
+
+  test('isTestFile defaults to false when not on RecentToolCall', () => {
+    const events = toolCallsToEvents(null, [
+      {
+        id: 'tu_2',
+        tool: 'Read',
+        args: 'src/foo.ts',
+        status: 'done',
+        durationMs: 5,
+        timestamp: '2026-04-28T12:01:00Z',
+        isTestFile: false,
+      },
+    ])
+
+    expect(events[0]?.isTestFile).toBe(false)
+  })
 })

--- a/src/features/agent-status/utils/toolCallsToEvents.ts
+++ b/src/features/agent-status/utils/toolCallsToEvents.ts
@@ -81,6 +81,7 @@ export const toolCallsToEvents = (
       timestamp: r.timestamp,
       status: r.status,
       durationMs: r.durationMs,
+      isTestFile: r.isTestFile,
     })
   }
 

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
     rateLimits: null,
     toolCalls: { total: 0, byType: {}, active: null },
     recentToolCalls: [],
+    testRun: null,
   })),
 }))
 

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable testing-library/no-node-access */
 /* eslint-disable vitest/expect-expect */
-import { describe, test, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WorkspaceView } from './WorkspaceView'
+import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
 
 // Mock TerminalPane to avoid xterm.js issues in tests
 vi.mock('../terminal/components/TerminalPane', () => ({
@@ -29,6 +31,42 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
     recentToolCalls: [],
     testRun: null,
   })),
+}))
+
+// Mock useEditorBuffer so individual tests can flip isDirty without
+// having to drive the real hook through the editor. The default impl
+// (set in beforeEach below) returns a clean buffer so the bulk of
+// existing tests behave as if no file is open.
+vi.mock('../editor/hooks/useEditorBuffer', () => ({
+  useEditorBuffer: vi.fn(),
+}))
+
+// Capture AgentStatusPanel's props (specifically `onOpenFile`) so the
+// new handleOpenTestFile tests can invoke the handler directly without
+// rendering the full panel and synthesizing a test-row click.
+const capturedAgentStatusPanelProps: {
+  onOpenFile?: (path: string) => void
+  onOpenDiff?: unknown
+} = {}
+
+interface MockAgentStatusPanelProps {
+  onOpenFile?: (path: string) => void
+  onOpenDiff?: unknown
+}
+
+vi.mock('../agent-status/components/AgentStatusPanel', () => ({
+  AgentStatusPanel: ({
+    onOpenFile = undefined,
+    onOpenDiff = undefined,
+  }: MockAgentStatusPanelProps): ReactElement => {
+    capturedAgentStatusPanelProps.onOpenFile = onOpenFile
+    capturedAgentStatusPanelProps.onOpenDiff = onOpenDiff
+
+    // Render the panel testid so the existing zone-presence tests
+    // (`getByTestId('agent-status-panel')`) keep passing without
+    // dragging the real panel and its hooks into this test file.
+    return <div data-testid="agent-status-panel" />
+  },
 }))
 
 // Mock terminal service to return initial session data synchronously
@@ -69,6 +107,25 @@ vi.mock('../terminal/services/terminalService', () => ({
 }))
 
 describe('WorkspaceView', () => {
+  beforeEach(() => {
+    capturedAgentStatusPanelProps.onOpenFile = undefined
+    capturedAgentStatusPanelProps.onOpenDiff = undefined
+
+    // Default: clean buffer with no file open. Mirrors the real hook's
+    // initial state so existing tests don't see a dirty buffer or get
+    // an undefined return value.
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: null,
+      originalContent: '',
+      currentContent: '',
+      isDirty: false,
+      isLoading: false,
+      openFile: vi.fn().mockResolvedValue(undefined),
+      saveFile: vi.fn().mockResolvedValue(undefined),
+      updateContent: vi.fn(),
+    })
+  })
+
   test('renders all five zones (icon rail, sidebar, terminal, bottom drawer, agent status panel)', () => {
     render(<WorkspaceView />)
 
@@ -371,5 +428,64 @@ describe('WorkspaceView', () => {
 
   test('unsaved changes dialog: Cancel button closes dialog and stays on current file', async () => {
     // This will be fully tested in Feature 22 integration tests
+  })
+
+  test('handleOpenTestFile opens file directly when buffer is clean', () => {
+    const openFileMock = vi.fn().mockResolvedValue(undefined)
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: null,
+      originalContent: '',
+      currentContent: '',
+      isDirty: false,
+      isLoading: false,
+      openFile: openFileMock,
+      saveFile: vi.fn().mockResolvedValue(undefined),
+      updateContent: vi.fn(),
+    })
+
+    render(<WorkspaceView />)
+
+    const onOpenFile = capturedAgentStatusPanelProps.onOpenFile
+    expect(onOpenFile).toBeDefined()
+
+    act(() => {
+      onOpenFile?.('/abs/src/foo.test.ts')
+    })
+
+    expect(openFileMock).toHaveBeenCalledOnce()
+    expect(openFileMock).toHaveBeenCalledWith('/abs/src/foo.test.ts')
+    expect(
+      screen.queryByRole('dialog', { name: /unsaved changes/i })
+    ).toBeNull()
+  })
+
+  test('handleOpenTestFile shows unsaved dialog when buffer is dirty', async () => {
+    const openFileMock = vi.fn().mockResolvedValue(undefined)
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: 'src/current.ts',
+      originalContent: 'original',
+      currentContent: 'edits',
+      isDirty: true,
+      isLoading: false,
+      openFile: openFileMock,
+      saveFile: vi.fn().mockResolvedValue(undefined),
+      updateContent: vi.fn(),
+    })
+
+    render(<WorkspaceView />)
+
+    const onOpenFile = capturedAgentStatusPanelProps.onOpenFile
+    expect(onOpenFile).toBeDefined()
+
+    act(() => {
+      onOpenFile?.('/abs/src/bar.test.ts')
+    })
+
+    expect(openFileMock).not.toHaveBeenCalled()
+    expect(
+      await screen.findByRole('dialog', { name: /unsaved changes/i })
+    ).toBeInTheDocument()
   })
 })

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
     rateLimits: null,
     toolCalls: { total: 0, byType: {}, active: null },
     recentToolCalls: [],
+    testRun: null,
   })),
 }))
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -162,6 +162,25 @@ export const WorkspaceView = (): ReactElement => {
     [editorBuffer.isDirty, openFileSafely, setPendingFilePathSynced]
   )
 
+  // Open a test file from the activity panel. Mirrors handleFileSelect's
+  // dirty-state guard so clicking a test result row never silently
+  // discards unsaved editor changes — the same unsaved-dialog flow
+  // (handleSave / handleDiscard / handleCancel) resumes the pending
+  // open against pendingFilePathRef once the user picks an action.
+  const handleOpenTestFile = useCallback(
+    (filePath: string): void => {
+      if (editorBuffer.isDirty) {
+        setPendingFilePathSynced(filePath)
+        setShowUnsavedDialog(true)
+
+        return
+      }
+
+      void openFileSafely(filePath)
+    },
+    [editorBuffer.isDirty, openFileSafely, setPendingFilePathSynced]
+  )
+
   // Save current file and open pending file.
   //
   // Use TWO separate try/catch blocks so save-failure and open-failure
@@ -390,6 +409,7 @@ export const WorkspaceView = (): ReactElement => {
         sessionId={activeSessionId}
         cwd={activeSession?.workingDirectory ?? '.'}
         onOpenDiff={handleOpenDiff}
+        onOpenFile={handleOpenTestFile}
       />
 
       {/* Unsaved Changes Dialog — shows the CURRENTLY dirty file, not the

--- a/src/features/workspace/WorkspaceView.verification.test.tsx
+++ b/src/features/workspace/WorkspaceView.verification.test.tsx
@@ -31,6 +31,7 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
     rateLimits: null,
     toolCalls: { total: 0, byType: {}, active: null },
     recentToolCalls: [],
+    testRun: null,
   })),
 }))
 

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
     rateLimits: null,
     toolCalls: { total: 0, byType: {}, active: null },
     recentToolCalls: [],
+    testRun: null,
   })),
 }))
 


### PR DESCRIPTION
## Summary

- Wires the right-sidebar `<TestResults>` placeholder (previously hard-coded `0/0`) into a real, activity-driven panel by extending the existing transcript-watcher pipeline (#56/#63). Bash tool-calls invoking a known test runner (`vitest`, `cargo test`) are parsed into a `TestRunSnapshot` emitted over a new `test-run` Tauri event; Write/Edit tool-calls whose `file_path` matches a test-file convention are tagged via a new `is_test_file: bool` on `AgentToolCallEvent`.
- Lazy + activity-driven: panel renders a slim `▶ TESTS no runs yet` row until the first matched event, then promotes to a live panel with status dot, runner pill, duration, three-part proportional bar, and per-file/per-suite/per-module group rows. File-kind groups are clickable when their backend-resolved canonical path is contained inside the workspace cwd; clicks route through a new dirty-state-guarded `WorkspaceView.handleOpenTestFile`. Activity feed renders test-file Write/Edit calls with a `🧪 CREATED TEST` / `🧪 UPDATED TEST` label.
- No filesystem detection at startup, no extra Claude Code config, no command hijacking. Replay is batched (latest-of-replay emits exactly once at first EOF) so historical runs don't flicker on session restore.

## Design + plan

- Spec: [`docs/superpowers/specs/2026-04-28-tests-panel-bridge-design.md`](docs/superpowers/specs/2026-04-28-tests-panel-bridge-design.md) — six-question brainstorming flow + four delta passes
- Plan: [`docs/superpowers/plans/2026-04-28-tests-panel-bridge-plan.md`](docs/superpowers/plans/2026-04-28-tests-panel-bridge-plan.md) — 11 sequential tasks with full TDD steps and code blocks for every step

## Key invariants worth a careful review

- **Listener-attach ordering** in `useAgentStatus` is load-bearing for v1 (no backend snapshot cache) — `listen('test-run', …)` MUST resolve before `invoke('start_agent_watcher', …)`. Covered by a regression test that mocks `invoke` + `listen` and asserts call order.
- **`cwd` is server-derived**, never renderer-supplied — `start_transcript_watcher` IPC pulls cwd from `PtyState::get_cwd(session_id)`. Watcher identity is `(transcript_path, cwd)`, so cwd changes trigger a Replace.
- **`onOpenFile` is dirty-state-guarded** via `WorkspaceView.handleOpenTestFile`; it reuses the proven `handleFileSelect` unsaved-dialog flow.
- **Group `path` containment check** — `resolve_group_path` rejects `..`, absolute labels, and post-canonicalize symlink escapes outside the session cwd.
- **Sanitisation** runs over both `command_preview` and `output_excerpt` via the shared `sanitize_for_ui` (KEY=value, Bearer, Authorization, sk_/pk_/rk_ prefixes, JWT-like).

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 260 unit tests + 3 integration tests (`transcript_vitest_e2e`, `transcript_vitest_replay`, `transcript_cargo_e2e`) all green
- [x] `npm test` — 1463 passing, 3 skipped (102 files)
- [x] `npm run type-check` clean, `npm run lint` clean, `npm run format:check` clean
- [ ] Manual smoke test: run `vitest run` from the integrated terminal in a workspace; confirm the TESTS panel transitions from `no runs yet` → live with count + per-file rows; click a row → file opens in the editor; with a dirty buffer, click a row → unsaved-changes dialog appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)