### PR TITLE
docs(reviews): retrospective + pattern updates for #109 tests panel cycle

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -19,7 +19,7 @@ ingestion protocol.
 
 | Pattern                                                        | Category       | Findings | Refs | Last Updated |
 | -------------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
-| [Filesystem Scope](patterns/filesystem-scope.md)               | security       | 15       | 2    | 2026-04-14   |
+| [Filesystem Scope](patterns/filesystem-scope.md)               | security       | 20       | 2    | 2026-04-29   |
 | [React Lifecycle](patterns/react-lifecycle.md)                 | react-patterns | 6        | 1    | 2026-04-10   |
 | [Resource Cleanup](patterns/resource-cleanup.md)               | react-patterns | 2        | 3    | 2026-04-14   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)       | cross-platform | 2        | 1    | 2026-04-10   |
@@ -29,7 +29,7 @@ ingestion protocol.
 | [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 10       | 2    | 2026-04-14   |
 | [Accessibility](patterns/accessibility.md)                     | a11y           | 11       | 1    | 2026-04-10   |
-| [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 17       | 5    | 2026-04-20   |
+| [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 18       | 5    | 2026-04-29   |
 | [Command Injection](patterns/command-injection.md)             | security       | 5        | 1    | 2026-04-20   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)       | security       | 15       | 2    | 2026-04-20   |
 | [Fail-Closed Hooks](patterns/fail-closed-hooks.md)             | security       | 3        | 1    | 2026-04-20   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,7 +2,7 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-04-20
+last_updated: 2026-04-29
 ref_count: 3
 ---
 
@@ -173,3 +173,13 @@ prevent showing previous data.
 - **Finding:** `run_agent_session` printed `[result: error]` when the terminal stream event carried `is_error=True` but still returned `('continue', response_text)`. Non-zero subprocess exit was already escalated via `RuntimeError`; clean-exit-but-session-errored (max-turns, rate-limit abort, transient tool failure) wasn't. Orchestrator would then run the reviewer against stalled output and burn a per-feature iteration.
 - **Fix:** Track `result_errored = False` before the event loop; set it True in the `isinstance(event, ResultEvent) and event.is_error` branch; return `('error' if result_errored else 'continue', response_text)`. Added two regression tests with a `_FakeCliSession` subclass that scripts events (one error, one success).
 - **Commit:** (round 11)
+
+### 18. Listener-attach race in `useAgentStatus` — duplicate `handleDetection` fires `start_agent_watcher` before listeners are attached
+
+- **Source:** local-handed-back during sub-agent task | PR #109 round 7 (Task 7) | 2026-04-29
+- **Severity:** HIGH (load-bearing for v1's no-cache design)
+- **File:** `src/features/agent-status/hooks/useAgentStatus.ts`
+- **Finding:** The hook had two `useEffect`s that both fired `handleDetection(sessionId)` on mount — one in the polling effect's "Run immediately on mount" line, and one in the subscribe effect's IIFE after `await subscribe()`. The polling-side call raced with subscribe and could fire `invoke('start_agent_watcher', …)` BEFORE `listen('test-run', …)` had attached. With v1 having no backend snapshot cache, the latest-of-replay batched emit fires once at the transcript watcher's first EOF and is gone — losing it to the race meant the panel stayed at `no runs yet` until the next live test run.
+- **Fix:** Removed the duplicate `void handleDetection(sessionId)` from the polling `useEffect`. The subscribe `useEffect` already fires the initial detection after listeners are attached (and a comment in the file explicitly documented that intent). The `attaches test-run listener BEFORE invoking start_agent_watcher` regression test (added in the same task) caught the race on its first run with `expected 4 to be less than 2` — exactly the assertion shape it was designed to enforce.
+- **Lesson:** in a "subscribe + then trigger the publisher" flow, having TWO triggers from independent effects is structurally fragile, even if one is "polling" and the other is "init". Pick a single trigger source. Also: the load-bearing regression test was the right shape — it asserted the call ORDER recorded by mocks, not the eventual outcome.
+- **Commit:** `d7df1e5 feat(agent-status): test-run listener + ordering regression test`

--- a/docs/reviews/patterns/filesystem-scope.md
+++ b/docs/reviews/patterns/filesystem-scope.md
@@ -2,7 +2,7 @@
 id: filesystem-scope
 category: security
 created: 2026-04-09
-last_updated: 2026-04-14
+last_updated: 2026-04-29
 ref_count: 2
 ---
 
@@ -151,3 +151,52 @@ enumerate sensitive directories without scope restrictions.
 - **Fix:** Add a shared transcript-path validator that canonicalizes the file and requires it to resolve under the canonical `~/.claude` root before tailing. Use it from both `maybe_start_transcript` and the direct `start_transcript_watcher` IPC command.
 - **Verification:** Added `validate_transcript_path_rejects_path_outside_claude_root`; `cargo test --lib agent::transcript -j1`.
 - **Commit:** (pending — agent-status-sidebar PR)
+
+### 16. `start_transcript_watcher` IPC accepted renderer-controlled cwd
+
+- **Source:** local-handed-back | PR #109 round 0 | 2026-04-29
+- **Severity:** HIGH
+- **File:** `src-tauri/src/agent/transcript.rs`
+- **Finding:** `start_transcript_watcher` Tauri command's `cwd: Option<String>` parameter came from the renderer and was passed straight into the watcher. The test-runner parser then used it to read `package.json` for npm-script alias resolution and to canonicalize per-file test paths. Renderer-controlled filesystem influence on which workspace gets read.
+- **Fix:** Remove the `cwd` parameter from the IPC. The command now derives cwd server-side from `PtyState::get_cwd(session_id)`. Backend-internal callers (the statusline bridge in `watcher.rs`) keep using the inner `start_or_replace` API directly.
+- **Verification:** Existing tests + new `transcript_state_threads_cwd_through`.
+- **Commit:** `006be43 fix(agent): close cwd data-flow gaps in TranscriptWatcher`
+
+### 17. `TranscriptState::start_or_replace` ignored cwd in identity check (stale workspace)
+
+- **Source:** local-handed-back | PR #109 round 0 | 2026-04-29
+- **Severity:** HIGH
+- **File:** `src-tauri/src/agent/transcript.rs`
+- **Finding:** Identity check compared only `transcript_path`, so a same-transcript-different-cwd start returned `AlreadyRunning` and the tail thread kept its stale snapshot. Test-runner parser then resolved aliases and per-file paths against the previous workspace. The `TranscriptWatcher.cwd` field carried a `#[allow(dead_code)]` annotation that silenced the lint without fixing the bug.
+- **Fix:** Identity check became `(transcript_path, cwd)` — either changing forces a Replace. Removed the dead_code annotation; the field is now load-bearing state. Docstring rewritten to explain why.
+- **Verification:** Added `transcript_state_replaces_when_only_cwd_changes`.
+- **Commit:** `006be43 fix(agent): close cwd data-flow gaps in TranscriptWatcher`
+
+### 18. `start_watching` captured cwd snapshot — stale after `cd`
+
+- **Source:** github-codex (chatgpt-codex-connector) | PR #109 round 5 | 2026-04-29
+- **Severity:** P1 / HIGH
+- **File:** `src-tauri/src/agent/watcher.rs`
+- **Finding:** Notify closure, initial-read block, and polling fallback all held a `cwd: PathBuf` snapshot taken at `start_watching` call time. After the user `cd`'d in the PTY, `maybe_start_transcript` kept passing the OLD cwd to `TranscriptState::start_or_replace`, so npm-script alias resolution and per-file path containment kept running against the previous workspace.
+- **Fix:** `maybe_start_transcript` queries cwd FRESH from `PtyState` at every call. The cwd parameter was removed from `start_watching` and from its caller `start_agent_watcher`. Combined with the `(transcript_path, cwd)` identity check, a mid-session `cd` now triggers a Replace of the tail thread on the next statusline event.
+- **Verification:** existing transcript and watcher tests.
+- **Commit:** `99dbfe9 fix(agent): address codex review findings on PR #109`
+
+### 19. `process_tool_result` defaulted to `Path::new(".")` when no PTY cwd
+
+- **Source:** github-codex (chatgpt-codex-connector) | PR #109 round 6 | 2026-04-29
+- **Severity:** P2 / MEDIUM
+- **File:** `src-tauri/src/agent/transcript.rs`
+- **Finding:** When `PtyState::get_cwd(session_id)` returned None, `process_tool_result` substituted `Path::new(".")` as the cwd for the test-runner snapshot builder. `Path::new(".")` canonicalizes to the Tauri app process's cwd — NOT the user's workspace — so per-file test groups would silently resolve against the wrong directory (producing non-clickable rows or rows pointing to unrelated files in the app dir).
+- **Fix:** Skip the test-run snapshot entirely when no workspace cwd is available; log at `debug!`. The standard `agent-tool-call` event still fires unconditionally; only the structured snapshot is gated. Three integration fixtures updated to pass a valid temp cwd (they previously relied on the now-removed fallback).
+- **Verification:** `transcript_vitest_e2e`, `transcript_vitest_replay`, `transcript_cargo_e2e`.
+- **Commit:** `a02be27 fix(agent): round-6 fixes — cwd fallback, content joining, overflow`
+
+### 20. Debug log to fixed `/tmp` path vulnerable to symlink attack
+
+- **Source:** github-claude | PR #109 round 5 | 2026-04-29
+- **Severity:** MEDIUM (security)
+- **File:** `src-tauri/src/agent/watcher.rs`
+- **Finding:** `OpenOptions::new().create(true).append(true).open("/tmp/vimeflow-debug.log")` follows symlinks on Unix. A local actor on a shared system (cloud dev VMs, Codespaces, Gitpod) can pre-create the path as a symlink to redirect appends. Linux's default umask 022 also leaves the file world-readable. The block was inside `cfg(debug_assertions)` so debug builds shipped with this. Logged values include workspace paths and session IDs.
+- **Fix:** Drop the file-log block entirely; use the existing structured `log::debug!` macro (already configured for the rest of the file). Run with `RUST_LOG=debug` to see startup diagnostics.
+- **Commit:** `ea6b1ea fix(agent): round-5 review findings — security, polish, runner coverage`

--- a/docs/reviews/retrospectives/2026-04-29-tests-panel-bridge-session.md
+++ b/docs/reviews/retrospectives/2026-04-29-tests-panel-bridge-session.md
@@ -1,0 +1,180 @@
+---
+id: 2026-04-29-tests-panel-bridge-session
+type: retrospective
+status: shipped — PR #109 merged as 27f82aa, 6 review-fix rounds, 0 follow-ups filed (1 LOW deferred with rationale)
+date: 2026-04-29
+---
+
+# Retrospective: Tests Panel & Claude Code Bridge — Six-Round Review Cycle
+
+## Context
+
+**Goal:** wire the always-zero `<TestResults>` placeholder in the right-hand activity panel into a real, activity-driven panel that surfaces test runs and test-file creation from the integrated coding agent (Claude Code). Reuse the existing transcript-watcher pipeline (#56/#63); no new chat surfaces, no command hijacking, no extra Claude Code config.
+
+**Outcome shipped:** PR #109, 32 commits squash-merged into `27f82aa`. Final Claude Code Review verdict: ✅ "patch is correct" (88% confidence). All Codex P1/P2 inline threads replied + resolved. One LOW intentionally deferred (`emitter.rs` `thread::sleep` — reviewer marked "no current correctness impact" because Tauri mock runtime dispatches synchronously). 0 follow-up issues filed.
+
+**Scale:** 6 review-fix rounds. Two reviewers in parallel (Claude Code Review GitHub Action + Codex via `chatgpt-codex-connector`), 5 distinct Codex inline threads + 6 Claude top-level reviews processed end-to-end. 277 Rust unit tests + 3 integration tests + 1474 TS tests at the end. ~5,200 lines of spec+plan checked in.
+
+This retrospective focuses on the **process** — the harness experience, the missed-Codex-comments incident, and the sub-agent driven recovery — so the next agent-led PR doesn't re-learn them.
+
+## Architecture decisions that earned their cost
+
+### 1. Six brainstorming questions before any code
+
+- **What happened:** Before invoking writing-plans, I ran `superpowers:brainstorming` for six rounds: (Q1) when does the panel appear → lazy/activity-driven; (Q2) bridge mechanism → passive transcript parsing; (Q3) command identification → strict allowlist with package.json script resolution; (Q4) expanded panel depth → per-file/group with click-to-open; (Q5) detection trigger → first matched test run; (Q6) first-time UX → slim placeholder line, defer ask-Claude CTA. Plus four delta passes on the spec where the user pushed back on details (session-id ambiguity, Option<T> serde defaults, listener-attach ordering, etc.).
+- **Why it earned its cost:** the resulting plan was concrete enough that 11 task subagents could implement it largely without further design decisions. The harness's first run completed Task 1 cleanly using the plan as the contract. The sub-agents that followed each made one or two small judgment calls but never had to re-design.
+- **Lesson:** brainstorming time is implementation insurance. The 4-round delta pass on the spec specifically caught issues that would otherwise have been multi-round review findings (Option<T> serializing as `null` not omitted; listener-attach ordering being load-bearing for v1's no-cache design).
+
+### 2. Sub-agent per task, not per round
+
+- **What happened:** When the harness died mid-Task-2 (and again on the stale-stamp check), I switched to dispatching one general-purpose subagent per remaining task. Each subagent got a self-contained brief: "Task N from the plan, here's the current state, here's what to skip, here are the rules to follow, report back when done." Tasks 3 → 11 each ran as one subagent dispatch.
+- **Why it earned its cost:** subagents have fresh context (no harness-noise burnout); each can read the plan section it needs at the right offset/limit; they make focused commits and report concretely. Three caught real issues during their runs:
+  - Task 7 sub-agent caught a pre-existing race: duplicate `handleDetection` invocation in the polling effect was firing `start_agent_watcher` BEFORE listeners attached. The load-bearing ordering test it just wrote caught it on first run.
+  - Task 8 sub-agent caught a contradiction in my plan's example test code (asserted `<button>` for a row rendered without `onOpenFile`, but the component code only renders a button when `onOpenFile` is defined). Fixed by adding `onOpenFile={vi.fn()}` to that one test.
+  - Task 11 sub-agent caught a TypeScript narrowing issue when placing `isTestFile?` on the `ToolActivityEvent` variant only — moved to `BaseActivityEvent` so consumers don't need to narrow.
+- **Lesson:** when an automated agent harness fails, sub-agents per discrete task are the right next step. Cheap recovery, parallel by-default if you want it (I went serial for verification), and the sub-agent's "I caught a real issue" reports are gold — the main agent can verify and merge.
+
+### 3. Server-derived cwd, then identity-based watcher key
+
+- **What happened:** Initial design had `cwd` flowing through the IPC and snapshot-cached at watcher start. Two HIGH findings in round 0 fixed both: (a) IPC removed renderer-controlled cwd in favor of `PtyState::get_cwd(session_id)` lookup; (b) `TranscriptState::start_or_replace` identity check became `(transcript_path, cwd)` so a `cd` triggered Replace. Then round 5 Codex's P1 caught the third related bug: the snapshot CWD inside the watcher closures was still stale across `cd`. Fixed by querying `PtyState` fresh inside `maybe_start_transcript` and dropping the cwd parameter from `start_watching` entirely.
+- **Lesson:** when state is renderer-supplied, snapshotted, AND read at multiple call sites, the security review will find the trust gap, the correctness review will find the staleness gap, and the design will need three rounds to reach steady state. Centralize the read at use time, not at spawn time. Captured below in `patterns/filesystem-scope.md`.
+
+### 4. Bifurcated sanitiser scope (round 5 LOW + round 4 same finding)
+
+- **What happened:** Initial sanitiser used one regex set with a broad `\b[A-Z][A-Z0-9_]{2,}=\S+` env-var rule applied to both `command_preview` and `output_excerpt`. Reviewer flagged over-redaction for benign vars (`NODE_ENV=test`, `VITEST_POOL_ID=1`, `CI=true`). Round 5 split into `sanitize_for_command` (narrow — only known-secret-prefix env vars + bearer/jwt/sk*/pk*) and `sanitize_for_output` (broad — adds the catch-all KEY=VALUE rule). Round 6 caught two more sanitiser bugs in the same file: Authorization regex only consumed first token (`\S+` instead of `[^\r\n]+`); Bearer charset missed base64 chars (`+`, `/`, `=`).
+- **Lesson:** sanitisers are a "two surfaces, two policies" problem disguised as one regex set. The first reviewer caught the over-redaction in round 4; I deferred with rationale; the same reviewer raised it again with a sharper alternative in round 5. Lesson: when the same finding returns with a more concrete fix, take it — the reviewer is right that the trade-off changed enough to act.
+
+## The harness experience
+
+### What the harness did well
+
+- **Phase 1 Initializer succeeded cleanly.** Read `app_spec.md` (which pointed at the spec + plan), generated `feature_list.json` with 11 features mirroring the plan's task numbers verbatim, committed it, and started Task 1. Task 1 (`feat(agent): scaffold test_runners module with type skeleton`, `de34e86`) was the only feature the harness fully landed on its own.
+
+### What the harness failed at — and why
+
+- **Run 1 (`autonomous_agent_demo.py --clean --max-iterations 10 --skip-relay`) died mid-Task-2.** The Coder session was 80% through threading `cwd` parameter changes through `transcript.rs` and `watcher.rs` when the session ended with `Error during initializer session: Initializer failed.` No specific cause; likely a subprocess timeout or context limit. Working tree was dirty with uncommitted (but mostly correct) Task 2 code.
+- **Run 2 (`--max-iterations 10 --skip-relay`, no `--clean`) refused to start.** Exited immediately with `ERROR: feature_list.json may be stale. no .feature_list_stamp.json found beside feature_list.json.` The first run's `--clean` had wiped the stamp file but the harness's stale-list check couldn't tell that the current `feature_list.json` was the one this run had just generated. Recovery would need `--ignore-stale-list` or wipe-and-regenerate, but at this point I'd hit the user's "if thing happened again, dispatch a subagent" instruction.
+- **Plan bugs that bit the harness:** my plan referenced `cargo test --manifest-path src-tauri/Cargo.toml -p vimeflow_lib …` 19 times. The package is `vimeflow`; the lib name is `vimeflow_lib`, but `-p` takes the package name. The harness Coder worked around it by dropping `-p` once and proceeding. I globally stripped the bad flag from the plan before launching the second run. Also: my plan's Task 1 commit included `Cargo.lock` in `git add`, but `src-tauri/Cargo.lock` is gitignored — the Coder removed it from the add list and proceeded. Both issues taught me to validate command shells in the plan against the actual repo before handing it off.
+
+### Net cost
+
+- **Two harness launches → one feature shipped (Task 1).** Tasks 2–11 done by sub-agents, one per task. Total: 6 commits from harness path (Init + Task 1 + their two `chore: mark complete` commits + my recovery commits for Task 2), ~22 commits from sub-agents.
+- **Net lesson:** the harness's per-feature loop is a real productivity multiplier WHEN it works, and falls back gracefully to sub-agent dispatch WHEN it doesn't. The stale-stamp check should learn to detect "the current file is from a `--clean` run that just happened" — a simple "did we generate this feature_list during this process tree?" check would unblock that recovery path.
+
+## The missed-Codex-comments incident
+
+This is the biggest single process improvement available for the next PR.
+
+- **What happened:** For rounds 0 → 4, I was processing only Claude Code Review findings, believing Codex was completely down due to OpenAI quota exhaustion (the Codex GitHub Action visibly failed at 18-23 seconds on every push with `ERROR: Quota exceeded. Check your plan and billing details.`). After the user prompted "while you wait... try to resolve the codex review comments in the pr", I ran a wider check via three GitHub APIs:
+  - `repos/.../issues/.../comments` — what the `harness-plugin:github-review` skill polls
+  - `repos/.../pulls/.../reviews` — PR-level review summaries
+  - `repos/.../pulls/.../comments` — inline file-level review comments
+
+  Codex was posting via the latter two (`chatgpt-codex-connector[bot]`), NOT as issue comments. The Action that was visibly failing on quota is a separate Codex setup; the `chatgpt-codex-connector` Codex was working all along. I'd been ignoring 7 P1/P2 findings (`match_command` cycle, sanitiser holes, Windows separators, stale cwd, etc.) for four rounds.
+
+- **Severity:** medium. None of the missed findings were CRITICAL, and the Claude reviews were also catching most of them in parallel (the alias-recursion P1 was caught by both reviewers in round 1; the cwd-staleness P1 was caught by both in different forms). The finding I hadn't seen and would have NEVER caught locally was Codex's P1 about `Authorization:\s*\S+` only redacting the first token — a real credential-leak class.
+
+- **Skill bug:** `harness-plugin:github-review`'s Step 2 is:
+
+  ```bash
+  gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+    --jq '[.[] | select(.body | contains("## Codex Code Review"))] | last | {id, body}'
+  ```
+
+  This filters the wrong endpoint AND looks for the wrong header. The `chatgpt-codex-connector` Codex posts PR reviews (with body `### 💡 Codex Review`) and inline file comments (with `**P1/P2 Badge** Title`). The skill needs to query both `/pulls/.../reviews` and `/pulls/.../comments`, filter by `user.login == "chatgpt-codex-connector[bot]"`, and surface inline findings as the actionable items (the PR-review body is just a wrapper).
+
+- **Recovery:** once I figured this out (round 0 of the second pass) I:
+  1. Read all unresolved Codex inline threads via `pulls/.../comments`
+  2. Cross-referenced with what was already fixed (alias cycle was already done in round 1 from Claude)
+  3. Fixed the new ones (4 P1/P2 findings)
+  4. Posted REPLY to each inline thread via `gh api -X POST repos/.../pulls/comments/<id>/replies` citing the fix commit SHA
+  5. RESOLVED each thread via GraphQL `resolveReviewThread` mutation (REST has no resolve-thread endpoint)
+
+- **Lesson — captured for future PRs:**
+  - The `harness-plugin:github-review` skill needs a fix to query the right endpoints. Filed as a follow-up.
+  - When a CI check named "Codex Code Review" is failing on quota, that does NOT necessarily mean Codex review is unavailable — there can be parallel Codex configurations (the user's project has both an Action and a `chatgpt-codex-connector` integration). Always check the inline-comments surface independently.
+  - Resolving review threads requires GraphQL; I'm now familiar with the `reviewThreads` query → `resolveReviewThread` mutation pattern. Worth captured here for re-use.
+
+## Recurring patterns the reviewers kept finding
+
+| Theme                                                                                  | Findings across rounds                                                                                                                                                                                            | Pattern file                                                                |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Filesystem scope (renderer-controlled paths, snapshot vs fresh-read cwd, /tmp symlink) | round 0 (cwd IPC), round 0 (cwd identity), round 5 (`/tmp/vimeflow-debug.log`), round 5 Codex (snapshot-vs-fresh cwd), round 6 Codex (`Path::new(".")` fallback)                                                  | `patterns/filesystem-scope.md` (4 new findings — see appended below)        |
+| Async race conditions (listener-attach ordering — load-bearing for v1)                 | round 7 (duplicate `handleDetection` racing `start_agent_watcher` before listeners attached) — the load-bearing regression test caught it on first run                                                            | `patterns/async-race-conditions.md` (1 new finding — see appended below)    |
+| Cross-platform paths                                                                   | round 0 Codex P2 (`is_test_file` only handled `/`, regressed Windows test detection)                                                                                                                              | `patterns/cross-platform-paths.md`                                          |
+| Accessibility (color-only state)                                                       | round 4 (collapsed TESTS header for `error`/`noTests` was distinguished only by dot color; status dot is `aria-hidden`)                                                                                           | `patterns/accessibility.md`                                                 |
+| Debug artifacts (file-log to predictable /tmp path)                                    | round 5 Claude MEDIUM (security) — `OpenOptions::new().create(true).append(true).open("/tmp/vimeflow-debug.log")` follows symlinks, world-readable under default umask                                            | `patterns/debug-artifacts.md` (also overlaps with filesystem-scope)         |
+| Generated artifacts drift (`cargo test` regenerates `src/bindings/`)                   | every round + at merge-time — `gh pr merge --squash` aborted on dirty bindings; needed `git stash` then retry                                                                                                     | `patterns/generated-artifacts.md` (recurring; same pain as PTY-reattach PR) |
+| Documentation accuracy                                                                 | round 5 (test name `alias_loop_bounded_to_depth_3` was misleading — only verified termination, not cycle detection); round 5 (`derive_status` comment claimed an arm was filtered when it was reachable directly) | `patterns/documentation-accuracy.md`                                        |
+
+## Process hiccups — by cost
+
+### 1. Codex Action OpenAI quota — recurrent and same as PTY-reattach PR
+
+- **What happened:** Every CI cycle showed `Codex Code Review` failing at 18-23s on `Quota exceeded. Check your plan and billing details.` This is a separate failure from the `chatgpt-codex-connector` Codex (which ran fine). All other CI checks green throughout.
+- **Cost:** noise floor only — but combined with my mistaken-belief that "Codex is broken" caused the missed-comments incident above.
+- **Captured (already in PTY-reattach retro):** OpenAI plan budget on the Action, distinct from the connector Codex. Need to either top up OpenAI billing or treat the Action as permanently advisory and rely on `chatgpt-codex-connector` reviews.
+
+### 2. Watch-task exited early after each push — needed re-run twice
+
+- **What happened:** `gh pr checks 109 --watch --interval 30` returned cleanly (exit 0) twice when the OLD workflow had completed but the NEW workflow (just triggered by push) hadn't yet registered. The watcher saw no in-progress checks and exited. Each time I had to re-run the watch.
+- **Cost:** ~5 minutes of recovery wall-clock per occurrence; happened twice.
+- **Suggested fix:** sleep ~30 seconds after push before starting the watch, OR use the workflow-run id to scope the watch to the just-pushed-triggered run.
+
+### 3. Plan errors (cargo `-p` flag, `Cargo.lock` in `git add`)
+
+- **What happened:** Plan referenced `-p vimeflow_lib` (wrong; package is `vimeflow`, lib is `vimeflow_lib`) 19 times. Plan's Task 1 commit step `git add Cargo.lock` for a gitignored file. Both surfaced during the harness's Task 1 → Task 2 work. I global-replaced `-p vimeflow_lib ` away and removed the `Cargo.lock` line before launching the second harness run.
+- **Cost:** ~3 harness iterations of recovery work.
+- **Lesson:** before handing a plan to the harness, run a single `cargo test --manifest-path …` from the plan and a `git add …` of the proposed file list against a clean checkout. Either would have caught these.
+
+### 4. `/tmp/vimeflow-debug.log` slipped in via earlier session
+
+- **What happened:** A `cfg(debug_assertions)` block in `start_agent_watcher` was added during an earlier session for diagnosing the cwd data flow. It opened `/tmp/vimeflow-debug.log` with `OpenOptions::new().create(true).append(true)` — symlink-vulnerable + world-readable. Round 5 reviewer caught it as MEDIUM (security).
+- **Cost:** trivial fix (1 commit), but a real security finding that stayed shipped through 5 rounds of reviews because none of them got that deep until round 5.
+- **Lesson:** debug file logs to predictable `/tmp` paths are a security smell even under `cfg(debug_assertions)`. Use the existing `log::debug!` macro or randomise the path with `std::process::id()`.
+
+### 5. ts-rs bindings drift blocked merge
+
+- **What happened:** Two pushes after `cargo test`, the regenerated `src/bindings/*.ts` files were dirty in raw ts-rs format (no semicolons in committed; with semicolons after regen). `gh pr merge --squash --delete-branch` failed with `Your local changes to the following files would be overwritten by checkout: src/bindings/AgentToolCallEvent.ts`. Stashed bindings, retried, succeeded.
+- **Cost:** trivial recovery (1 stash + retry).
+- **Lesson:** same as PTY-reattach retro — ts-rs should emit prettier-formatted output, or a post-cargo-test git hook should restore bindings. This is the second PR where it bit.
+
+### 6. `gh pr merge --delete-branch` quietly failed to delete the remote branch
+
+- **What happened:** `gh pr merge 109 --squash --delete-branch` reported success but left the remote `feat/tests-panel-bridge` ref alive on GitHub. `git remote prune origin` didn't help because the branch genuinely still existed remotely. Had to `git push origin --delete feat/tests-panel-bridge` explicitly.
+- **Cost:** trivial.
+- **Lesson:** verify deletion via `git ls-remote --heads origin <branch>` after a `--delete-branch` merge. The flag is best-effort.
+
+### 7. `commitlint` rejected uppercase TESTS in subject
+
+- **What happened:** Wrote `fix(agent-status): TESTS header carries error/noTests in text + aria-label`. Commitlint rejected with `subject must not be sentence-case, start-case, pascal-case, upper-case`. Lowercased to `tests header...`.
+- **Cost:** trivial. Mentioning because commitlint is lossy on word-boundary detection — `TESTS` is one word, but the rule sees consecutive caps and trips.
+- **Lesson:** lowercase any acronym in commit subjects to avoid commitlint friction.
+
+## What worked well
+
+- **Brainstorming → spec → plan flow.** Six brainstorming rounds + four delta passes on the spec produced a plan concrete enough that 11 sub-agents could implement it largely independently. Three sub-agents found real issues during their runs and fixed them with minimal main-agent intervention.
+- **Sub-agent per task as harness-failure recovery.** Each sub-agent got a focused task, fresh context, the plan section it needed, and report-back instructions. Atomic per-task commits + verification between each. Worked smoothly through 9 tasks.
+- **Reply + resolve pattern on EVERY review thread.** GraphQL `resolveReviewThread` mutation is straightforward; once you have the thread ID (one extra GraphQL query), each resolve is one HTTP call. Future readers can trace each finding to its fix without grepping commit messages.
+- **The IDEA framework on review findings.** Several rounds where I pushed back on a LOW with explicit IDEA reasoning ("the env-var prefix is already stripped before sanitiser runs; the reviewer's example would actually appear as `vitest run`") kept the loop from spinning on borderline items. The reviewer then either accepted the rationale or came back with a sharper variant; either way the conversation converged.
+- **Calling the loop done at round 6.** Per `agents/code-reviewer.md`'s anti-rabbit-hole guidance, when verdict flipped to ✅ "patch is correct" with only LOW findings I stopped, didn't chase the deferred LOW about emitter sleeps. The 6-round budget was enough.
+
+## Recommendations
+
+For the next agent-led PR (>5 review rounds expected):
+
+1. **Read the relevant pattern files first.** `filesystem-scope.md`, `async-race-conditions.md`, `accessibility.md`, `debug-artifacts.md`. Bumps `ref_count` and saves rounds.
+2. **Validate plan command-shells against the actual repo before launching the harness.** A 30-second smoke test of one `cargo test …` invocation and one `git add …` line from the plan would have caught the `-p vimeflow_lib` and `Cargo.lock` bugs.
+3. **Always check both Codex surfaces — issue comments AND PR-review/inline comments.** The `harness-plugin:github-review` skill currently only polls the issue-comments surface; if your project has the `chatgpt-codex-connector` integration (separate from the GitHub Action), the actionable findings are inline.
+4. **`gh pr checks --watch` may exit early after a push** because the new workflow takes a moment to register. If the watch returns and the PR has just been pushed to, re-watch.
+5. **When a code review's same finding recurs with a sharper alternative, take the alternative.** The reviewer signals they care; the cheaper fix is now visible.
+6. **Cap rounds explicitly and stop at ✅ verdict.** Round 6 had a clear ✅ "patch is correct"; the deferred LOW (emitter sleep) was reviewer-acknowledged as no-impact. Stopping there avoided a round-7 rabbit hole on cosmetic work.
+7. **Verify `gh pr merge --delete-branch` actually deleted the remote.** `git ls-remote --heads origin <branch>` should return empty.
+
+## Auto-memory captured during this cycle
+
+No NEW auto-memories captured in this cycle (the memory base from PTY-reattach was already comprehensive enough — most of the patterns this PR surfaced overlap with existing memories on filesystem cache, lazy reconciliation, and offset/cursor protocol).
+
+The one item worth adding to memory — and worth filing as a process improvement — is:
+
+- **Codex review surface mismatch in `harness-plugin:github-review`.** The skill's `gh api "repos/.../issues/.../comments"` filter misses the `chatgpt-codex-connector` integration entirely. Future fix: query both `/pulls/.../reviews` and `/pulls/.../comments` with `user.login` filter; the Codex inline comments are the actionable units.


### PR DESCRIPTION
## Summary

- Adds retrospective for the 6-round review-fix cycle that shipped PR #109 (tests panel + Claude Code bridge): brainstorming → spec → plan → harness → sub-agent recovery → 6 rounds of Claude+Codex reviews → ✅ "patch is correct" verdict.
- Appends 5 new findings (#16–#20) to `patterns/filesystem-scope.md` covering the cwd data-flow theme that dominated the review cycle: IPC trust boundary, watcher identity-based key, snapshot-vs-fresh-read staleness, `Path::new(\".\")` fallback misdirecting parsers, and a `/tmp/vimeflow-debug.log` symlink-attack surface in a `cfg(debug_assertions)` block.
- Appends 1 new finding (#18) to `patterns/async-race-conditions.md` documenting the load-bearing `useAgentStatus` listener-attach race that the regression test (added in the same task) caught on its first run with `expected 4 to be less than 2`.
- Updates `CLAUDE.md` index for both pattern files (Findings: 15→20, 17→18; Last Updated bumped).

## What the retrospective documents

| Theme | Highlight |
|---|---|
| **Architecture decisions that earned their cost** | Six brainstorming questions before any code; sub-agent per task as harness-failure recovery; server-derived cwd then identity-based watcher key; bifurcated sanitiser scope |
| **The harness experience** | Phase 1 Initializer + Task 1 succeeded; Run 2 refused on stale-stamp check; documents the recovery path |
| **The missed-Codex-comments incident** | `harness-plugin:github-review` polls `/issues/.../comments` but the `chatgpt-codex-connector` integration posts to `/pulls/.../reviews` and `/pulls/.../comments`. Four rounds of P1/P2 inline findings were silently ignored until I queried the wider surface |
| **Process hiccups by cost** | Codex Action OpenAI quota recurrence; `gh pr checks --watch` exiting before the new workflow registered; plan command-shell errors; ts-rs bindings drift blocking merge |
| **What worked well** | Brainstorm → spec → plan flow; sub-agent per task; reply+resolve on every Codex thread; calling the loop done at round 6 |

## Follow-up surfaced

The retrospective explicitly flags one process improvement worth opening as its own issue: **`harness-plugin:github-review` needs to query both pull-request review surfaces (`/pulls/.../reviews` + `/pulls/.../comments` filtered by `user.login == \"chatgpt-codex-connector[bot]\"`) — not just issue comments.** The PR-review wrapper carries the summary; the inline file comments carry the actionable P1/P2 findings.

## Test plan

- [x] No code changes — docs-only PR
- [x] Pre-commit (lint-staged + Prettier) ran on the retrospective markdown without changes
- [x] Pre-push hook (vitest run) ran clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)