### PR TITLE
chore(agent-watcher): dev-only diagnostic logs for transcript-path freeze investigation

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,7 +43,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 9        | 2    | 2026-04-30   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 10       | 3    | 2026-04-30   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 28       | 5    | 2026-04-30   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -61,4 +61,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process | 5        | 0    | 2026-04-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing    | 9        | 1    | 2026-04-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality   | 1        | 0    | 2026-04-30   |
-| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality   | 3        | 0    | 2026-04-30   |
+| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality   | 6        | 1    | 2026-04-30   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -35,29 +35,30 @@ When appending findings to a pattern file, label the source so future readers ca
 - `local-codex` — local `codex exec` runs (e.g. `npm run review` or post-fix verify in the
   github-review skill).
 
-| Pattern                                                        | Category       | Findings | Refs | Last Updated |
-| -------------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
-| [Filesystem Scope](patterns/filesystem-scope.md)               | security       | 20       | 2    | 2026-04-29   |
-| [React Lifecycle](patterns/react-lifecycle.md)                 | react-patterns | 6        | 1    | 2026-04-10   |
-| [Resource Cleanup](patterns/resource-cleanup.md)               | react-patterns | 2        | 3    | 2026-04-14   |
-| [Cross-Platform Paths](patterns/cross-platform-paths.md)       | cross-platform | 2        | 1    | 2026-04-10   |
-| [Debug Artifacts](patterns/debug-artifacts.md)                 | code-quality   | 4        | 0    | 2026-04-12   |
-| [Generated Artifacts](patterns/generated-artifacts.md)         | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                       | testing        | 9        | 2    | 2026-04-30   |
-| [Terminal Input Handling](patterns/terminal-input-handling.md) | terminal       | 3        | 1    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)   | code-quality   | 28       | 5    | 2026-04-30   |
-| [Accessibility](patterns/accessibility.md)                     | a11y           | 12       | 2    | 2026-04-30   |
-| [Async Race Conditions](patterns/async-race-conditions.md)     | react-patterns | 18       | 5    | 2026-04-29   |
-| [Command Injection](patterns/command-injection.md)             | security       | 5        | 1    | 2026-04-20   |
-| [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)       | security       | 15       | 2    | 2026-04-20   |
-| [Fail-Closed Hooks](patterns/fail-closed-hooks.md)             | security       | 3        | 1    | 2026-04-20   |
-| [Preflight Checks](patterns/preflight-checks.md)               | error-handling | 1        | 0    | 2026-04-20   |
-| [CSP Configuration](patterns/csp-configuration.md)             | security       | 2        | 1    | 2026-04-09   |
-| [PTY Session Management](patterns/pty-session-management.md)   | backend        | 5        | 1    | 2026-04-09   |
-| [Git Operations](patterns/git-operations.md)                   | correctness    | 12       | 2    | 2026-04-29   |
-| [CodeMirror Integration](patterns/codemirror-integration.md)   | editor         | 12       | 0    | 2026-04-11   |
-| [Error Surfacing](patterns/error-surfacing.md)                 | error-handling | 19       | 3    | 2026-04-30   |
-| [File Tree Paths](patterns/file-tree-paths.md)                 | files          | 4        | 0    | 2026-04-10   |
-| [Scope Boundary](patterns/scope-boundary.md)                   | review-process | 5        | 0    | 2026-04-12   |
-| [E2E Testing](patterns/e2e-testing.md)                         | e2e-testing    | 9        | 1    | 2026-04-19   |
-| [Module Boundaries](patterns/module-boundaries.md)             | code-quality   | 1        | 0    | 2026-04-30   |
+| Pattern                                                              | Category       | Findings | Refs | Last Updated |
+| -------------------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
+| [Filesystem Scope](patterns/filesystem-scope.md)                     | security       | 20       | 2    | 2026-04-29   |
+| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns | 6        | 1    | 2026-04-10   |
+| [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns | 2        | 3    | 2026-04-14   |
+| [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
+| [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
+| [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 9        | 2    | 2026-04-30   |
+| [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 28       | 5    | 2026-04-30   |
+| [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |
+| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 18       | 5    | 2026-04-29   |
+| [Command Injection](patterns/command-injection.md)                   | security       | 5        | 1    | 2026-04-20   |
+| [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)             | security       | 15       | 2    | 2026-04-20   |
+| [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                   | security       | 3        | 1    | 2026-04-20   |
+| [Preflight Checks](patterns/preflight-checks.md)                     | error-handling | 1        | 0    | 2026-04-20   |
+| [CSP Configuration](patterns/csp-configuration.md)                   | security       | 2        | 1    | 2026-04-09   |
+| [PTY Session Management](patterns/pty-session-management.md)         | backend        | 5        | 1    | 2026-04-09   |
+| [Git Operations](patterns/git-operations.md)                         | correctness    | 12       | 2    | 2026-04-29   |
+| [CodeMirror Integration](patterns/codemirror-integration.md)         | editor         | 12       | 0    | 2026-04-11   |
+| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling | 19       | 3    | 2026-04-30   |
+| [File Tree Paths](patterns/file-tree-paths.md)                       | files          | 4        | 0    | 2026-04-10   |
+| [Scope Boundary](patterns/scope-boundary.md)                         | review-process | 5        | 0    | 2026-04-12   |
+| [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing    | 9        | 1    | 2026-04-19   |
+| [Module Boundaries](patterns/module-boundaries.md)                   | code-quality   | 1        | 0    | 2026-04-30   |
+| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality   | 3        | 0    | 2026-04-30   |

--- a/docs/reviews/patterns/diagnostic-instrumentation.md
+++ b/docs/reviews/patterns/diagnostic-instrumentation.md
@@ -3,7 +3,7 @@ id: diagnostic-instrumentation
 category: code-quality
 created: 2026-04-30
 last_updated: 2026-04-30
-ref_count: 0
+ref_count: 1
 ---
 
 # Diagnostic Instrumentation
@@ -62,3 +62,30 @@ The discipline:
 - **Finding:** The `Starting agent watcher: ... active_watchers={}` log captured `state.active_count()` BEFORE the call to `state.remove(&session_id)` that drops any existing watcher for the same session. So restarting an already-active session would log an inflated count that includes the about-to-be-removed self-watcher. Since the diagnostic uses this count as a leak signal (high counts = old watchers from prior sessions still alive), false positives during normal restart flows directly undermine its purpose.
 - **Fix:** Reordered the function: `state.remove(&session_id)` now runs BEFORE the `log::info!` call, so the logged count reflects watchers from OTHER sessions only — the actually-useful leak signal. Comment explains the ordering invariant so future contributors don't innocently move the log back to the top of the function.
 - **Commit:** _(see git log for the round-1 fix commit)_
+
+### 4. Debug-only struct field allocated unconditionally in release builds — `cfg!()` runtime guard does not gate the storage
+
+- **Source:** github-claude | PR #116 round 3 | 2026-04-30
+- **Severity:** LOW
+- **File:** `src-tauri/src/agent/watcher.rs` `WatcherHandle.session_id`
+- **Finding:** The `WatcherHandle` struct stored `session_id: String` for use in a `Drop` log. The Drop body was correctly gated with `if cfg!(debug_assertions) { log::info!(...) }` — but the `cfg!()` macro is a runtime conditional that returns a bool without affecting compilation. The FIELD itself was unconditional, so `session_id: session_id.clone()` ran in release builds too, producing a heap allocation per `start_watching` call that release-build code never reads. The PR's framing was "zero release-build overhead", which the field broke.
+- **Fix:** Annotated the field declaration with `#[cfg(debug_assertions)]` (a compile-time conditional that physically removes the field in release) AND mirrored the same attribute on the struct-literal assignment in the constructor. Switched the Drop body from `if cfg!(debug_assertions)` to a `#[cfg(debug_assertions)]` ATTRIBUTE on the `log::info!` statement, since `self.session_id` access must also be removed when the field is removed. Verified `cargo check --release` passes. The lesson: `cfg!()` (macro, runtime) gates code branches; `#[cfg(...)]` (attribute, compile-time) gates code existence — they are not interchangeable when the goal is to physically remove storage from a release binary.
+- **Commit:** _(see git log for the round-3 fix commit)_
+
+### 5. Structurally-zero `dt` for one-shot source produces misleading log values
+
+- **Source:** github-claude | PR #116 round 3 | 2026-04-30
+- **Severity:** LOW
+- **File:** `src-tauri/src/agent/watcher.rs` `record_event_diag` + `inline_timing`
+- **Finding:** The `inline_timing: Arc<Mutex<EventTiming>>` was created and passed to `record_event_diag` for the inline-init source — but inline only fires once per watcher start, so `last_event_at` was always None at the only call site, and `dt` always evaluated to `Duration::ZERO`. The log line emitted `dt=0ms source=inline` alongside real-valued dt for notify and poll. A reader investigating a freeze would compare `dt=4501ms source=notify` against `dt=0ms source=inline` and reasonably assume the inline event happened "right after" the notify event — when the truth is "this is the first and only event for this source". A constant value masquerading as a measurement is worse than no measurement.
+- **Fix:** Changed the `record_event_diag` `timing` parameter type from `&Mutex<EventTiming>` to `Option<&Mutex<EventTiming>>`. notify and poll callers pass `Some(&timing)`; the inline-init caller passes `None`. When `None`, the log emits `dt=n/a` instead of computing a structurally-zero delta. The `inline_timing` allocation was removed entirely (it had been pure overhead). The lesson: a measurement field that has no meaningful value for some call sites should be optional, not always-zero — `n/a` is more honest than `0`.
+- **Commit:** _(see git log for the round-3 fix commit)_
+
+### 6. Platform-specific OS error string used as a classification key — incorrect on non-Linux platforms
+
+- **Source:** github-codex-connector | PR #116 round 3 | 2026-04-30
+- **Severity:** P2 (≈ MEDIUM)
+- **File:** `src-tauri/src/agent/watcher.rs` `maybe_start_transcript`
+- **Finding:** The `TxOutcome::Missing` classification depended on `e.contains("No such file")` — the Linux text for ENOENT, forwarded from `validate_transcript_path` via `format!("invalid transcript path '{}': {}", ..., io_error)`. Windows reports a missing path with different OS-localized text ("The system cannot find the file specified"), as does macOS in some locales and any non-English Linux locale. On those platforms a missing transcript would fall through the substring match and be classified as `TxOutcome::NotFile`, defeating the diagnostic during the speculative-path window it exists to capture. The "access denied" substring, by contrast, is a CUSTOM string from `validate_transcript_path` itself (not OS-localized), so it remains safe.
+- **Fix:** Replaced the `e.contains("No such file")` substring match with `std::path::Path::new(transcript_path).exists()`. Linux ENOENT, Windows ERROR_FILE_NOT_FOUND, macOS in any locale, and any future OS variant now classify uniformly as `TxOutcome::Missing`. Comment near the call site explains why the missing case uses path-existence (platform-neutral) while the access-denied case keeps substring matching (project-owned string). The lesson: when classifying errors that originate from the OS, use platform-neutral primitives like `Path::exists()` / `ErrorKind::NotFound`, not substring matching on forwarded error text.
+- **Commit:** _(see git log for the round-3 fix commit)_

--- a/docs/reviews/patterns/diagnostic-instrumentation.md
+++ b/docs/reviews/patterns/diagnostic-instrumentation.md
@@ -1,0 +1,64 @@
+---
+id: diagnostic-instrumentation
+category: code-quality
+created: 2026-04-30
+last_updated: 2026-04-30
+ref_count: 0
+---
+
+# Diagnostic Instrumentation
+
+## Summary
+
+Runtime diagnostic logs (timing, counters, state-tracking) are only as
+useful as their _accuracy_. A diagnostic that measures inconsistently
+across sources, doesn't reset state on natural break points, or captures
+its values at the wrong moment in a lifecycle silently produces
+misleading numbers — and the investigator who relies on them draws
+wrong conclusions about the system. A wrong diagnostic is worse than no
+diagnostic, because it adds confidence to bad reasoning.
+
+The discipline:
+
+- **Equivalent measurement across sources.** When the same metric is
+  recorded from multiple call paths, capture timing/identity at the
+  same logical moment in each — usually before any I/O or state lookup
+  the metric is meant to cover.
+- **Reset state on natural break points.** Per-source counters and
+  identity caches should reset when the underlying observation breaks
+  (a no-path event, a session boundary, a stop/restart) — otherwise
+  consecutive-occurrence counters span across breaks and report
+  streaks that don't exist.
+- **Capture at the right moment in the lifecycle.** Counts and totals
+  should be sampled at the lifecycle phase that makes the metric
+  semantically true. If the metric represents "active watchers from
+  OTHER sessions", capture it AFTER `state.remove(self)`.
+
+## Findings
+
+### 1. Timer placed after I/O for one source, before for others — total non-comparable across sources
+
+- **Source:** github-claude | PR #116 round 1 | 2026-04-30
+- **Severity:** MEDIUM
+- **File:** `src-tauri/src/agent/watcher.rs` (poll-fallback thread)
+- **Finding:** The notify callback and the inline-init read both captured `let started = Instant::now()` BEFORE their respective `std::fs::read_to_string` calls, so `total` for `"notify"` and `"inline"` events included file-I/O time. The poll-fallback thread captured `started` AFTER its `read_to_string` and the dedup-equality check, so `total` for `"poll"` events systematically excluded I/O. On WSL2 / virtio-fs a 40 ms read would push notify/inline over the 50 ms `watcher.slow_event` threshold while poll would still log `total=2ms` for an identical operation — making poll appear fast even when the I/O bottleneck is shared. Since the diagnostic exists specifically to identify cross-source slow events, a systematic bias in one source's measurement undermines the primary signal.
+- **Fix:** Moved `let started = Instant::now();` to the top of each iteration in the poll thread, BEFORE `read_to_string`. The dedup-skip `continue` paths short-circuit before `record_event_diag`, so unchanged-content polls still don't log a number — no noise. Comment explains why the I/O is now inside `total`. All three sources now measure the same thing.
+- **Commit:** _(see git log for the round-1 fix commit)_
+
+### 2. Counter not reset on the natural break event — counts streaks across an interlude
+
+- **Source:** github-codex-connector | PR #116 round 1 | 2026-04-30
+- **Severity:** P2 (≈ MEDIUM)
+- **File:** `src-tauri/src/agent/watcher.rs` `record_event_diag` `(None, _)` arm
+- **Finding:** The transcript-path-tracking match in `record_event_diag` handled three explicit cases (different path, first observation, same path) and a catch-all `(None, _)` arm that returned `None` without touching `last_tx_path` or `same_path_repeat`. So when an event had no `transcript_path` field, the previous path's identity and repeat counter persisted untouched. A sequence like `[tx_path=A, no-path-event, tx_path=A]` would log the second A with `repeat=2` (treated as a consecutive observation) — even though there was a no-path interlude that should have broken the streak. This is precisely the speculative/missing-path window the patch was meant to diagnose, and the misleading repeat count makes that diagnosis harder.
+- **Fix:** In the `(None, _)` arm, reset `last_tx_path = None` and `same_path_repeat = 0` so the next path-bearing event is treated as a fresh observation (path-change fires, repeat starts at 1). Comment captures the reasoning so future maintainers don't undo the reset thinking it's a no-op.
+- **Commit:** _(see git log for the round-1 fix commit)_
+
+### 3. Count captured at wrong lifecycle phase — restarting same session inflates the metric
+
+- **Source:** github-codex-connector | PR #116 round 1 | 2026-04-30
+- **Severity:** P2 (≈ MEDIUM)
+- **File:** `src-tauri/src/agent/watcher.rs` `start_agent_watcher`
+- **Finding:** The `Starting agent watcher: ... active_watchers={}` log captured `state.active_count()` BEFORE the call to `state.remove(&session_id)` that drops any existing watcher for the same session. So restarting an already-active session would log an inflated count that includes the about-to-be-removed self-watcher. Since the diagnostic uses this count as a leak signal (high counts = old watchers from prior sessions still alive), false positives during normal restart flows directly undermine its purpose.
+- **Fix:** Reordered the function: `state.remove(&session_id)` now runs BEFORE the `log::info!` call, so the logged count reflects watchers from OTHER sessions only — the actually-useful leak signal. Comment explains the ordering invariant so future contributors don't innocently move the log back to the top of the function.
+- **Commit:** _(see git log for the round-1 fix commit)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-04-30
-ref_count: 2
+ref_count: 3
 ---
 
 # Testing Gaps
@@ -97,3 +97,12 @@ filesystem scope restrictions).
 - **Finding:** Round-1 review-fix promoted `formatTokens` from `BudgetMetrics.tsx` into a new `src/features/agent-status/utils/format.ts` to fix a module-boundary issue. The new file shipped **without** a sibling `format.test.ts`, even though the project rule (`CLAUDE.md`: "every .tsx/.ts file has a sibling .test.tsx/.test.ts file") is unconditional. The function was still exercised indirectly by `BudgetMetrics.test.tsx` (which kept a `describe('formatTokens', ...)` block that imported from the new path), but that test file is owned by a different module and can't be the canonical coverage owner for `format.ts`. If a later refactor of `BudgetMetrics` removed that import, `formatTokens` would silently lose all coverage with no compile-time signal.
 - **Fix:** Created `src/features/agent-status/utils/format.test.ts` and **moved** the existing `describe('formatTokens', ...)` block out of `BudgetMetrics.test.tsx` into the new sibling. Avoids duplicating the cases (round-2 reviewer suggested the move, not a copy) and keeps `BudgetMetrics.test.tsx` focused on `BudgetMetrics` behaviour.
 - **Commit:** `eadee9c fix(agent-status): address Claude review on TokenCache (PR #115 round 2)`
+
+### 10. Diagnostic state machine inlined into a side-effecting function — no regression-guard tests
+
+- **Source:** github-claude | PR #116 round 2 | 2026-04-30
+- **Severity:** LOW
+- **File:** `src-tauri/src/agent/watcher.rs`
+- **Finding:** The `PathHistory` four-arm match (path-change, first observation, same path, no-path-reset) lived inline inside `record_event_diag`, which itself early-returns under `cfg!(debug_assertions)` and emits log side effects. There was no way to exercise the state machine in a unit test without a `Mutex`, a logger, and a `cfg!(debug_assertions)` build. The round-1 `(None, _)` reset arm — added because the original implementation counted streaks across no-path interludes — was caught by code review only, not by CI. If a later contributor "simplified" the wildcard arm thinking it was a no-op, the streak-across-interlude bug would silently regress: `repeat=N` values during a speculative-path investigation would lie, the diagnostic feature itself would mis-report, and there would be no test failure to flag it. `short_sid`, `short_path`, and `TxOutcome::label()` were also untested pure functions despite being on every diagnostic line's hot path.
+- **Fix:** Extracted the state machine from `record_event_diag` into `PathHistory::observe(tx_path: Option<&str>) -> Option<String>` so each arm is unit-testable directly with no logging, no Mutex, no cfg gate. `record_event_diag` now calls `h.observe(tx_path)` and reads `h.same_path_repeat` afterwards (no behavior change). Added 11 unit tests covering: first observation, repeat increments, path-change-returns-old-and-resets-counter, **no-path-resets-streak-after-repeat (the explicit regression guard for the round-1 `(None, _)` bug)**, idempotent no-path-when-already-no-path, `short_sid` truncation / passthrough / UUID form, `short_path` basename / truncation / no-basename fallback, and `TxOutcome::label` exhaustively across all 9 variants. All 14 tests in `agent::watcher::tests` pass.
+- **Commit:** _(see git log for the round-2 fix commit)_

--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -63,13 +63,27 @@ impl TxOutcome {
     }
 }
 
+/// Per-source timing state. Each source (notify, inline-init, poll-fallback)
+/// gets its own instance so we can correlate inter-event delta with the
+/// source that fired it.
 #[derive(Default)]
-struct EventDiag {
+struct EventTiming {
     last_event_at: Option<Instant>,
+}
+
+/// Cross-source transcript-path history. SHARED across all event sources
+/// in a watcher, so the speculative→resolved flip is detected even when
+/// the speculative path was first seen by the inline read and the
+/// resolved path is later picked up by notify or the poll fallback.
+/// Without this sharing, each source starts with `last_tx_path = None`
+/// and never observes the flip — `watcher.tx_path_change` would never
+/// fire for the cross-source case it is meant to diagnose.
+#[derive(Default)]
+struct PathHistory {
     last_tx_path: Option<String>,
     /// How many consecutive events have had the SAME transcript path
-    /// (with the SAME outcome) — high values indicate the bridge is
-    /// stuck waiting for Claude Code to resolve a speculative path.
+    /// across ALL sources — high values indicate the bridge is stuck
+    /// waiting for Claude Code to resolve a speculative path.
     same_path_repeat: u32,
 }
 
@@ -86,10 +100,15 @@ fn short_path(path: &str) -> String {
 }
 
 /// Emit the per-event diagnostic line. Gated by `cfg!(debug_assertions)`.
-/// Also tracks the running `last_tx_path` for path-flip detection and
-/// `same_path_repeat` for stuck-bridge visibility.
+///
+/// Reads per-source timing from `timing` and the cross-source path
+/// history from `path_history` (shared across all sources). The path
+/// history MUST be shared so the speculative→resolved flip — which
+/// frequently spans sources (e.g. inline reads the speculative path,
+/// notify sees the resolved one) — is detected.
 fn record_event_diag(
-    diag: &Mutex<EventDiag>,
+    timing: &Mutex<EventTiming>,
+    path_history: &Mutex<PathHistory>,
     source: &'static str,
     sid: &str,
     total: Duration,
@@ -101,33 +120,37 @@ fn record_event_diag(
     }
 
     let now = Instant::now();
-    let (dt, path_change, repeat) = {
-        let mut d = diag.lock().expect("watcher diag lock");
-        let dt = d
+    let dt = {
+        let mut t = timing.lock().expect("watcher timing lock");
+        let dt = t
             .last_event_at
             .map(|prev| now.duration_since(prev))
             .unwrap_or(Duration::ZERO);
-        d.last_event_at = Some(now);
+        t.last_event_at = Some(now);
+        dt
+    };
 
-        let path_change = match (tx_path, d.last_tx_path.as_deref()) {
+    let (path_change, repeat) = {
+        let mut h = path_history.lock().expect("watcher path-history lock");
+        let path_change = match (tx_path, h.last_tx_path.as_deref()) {
             (Some(new), Some(old)) if new != old => {
                 let old_owned = old.to_string();
-                d.last_tx_path = Some(new.to_string());
-                d.same_path_repeat = 1;
+                h.last_tx_path = Some(new.to_string());
+                h.same_path_repeat = 1;
                 Some(old_owned)
             }
             (Some(new), None) => {
-                d.last_tx_path = Some(new.to_string());
-                d.same_path_repeat = 1;
+                h.last_tx_path = Some(new.to_string());
+                h.same_path_repeat = 1;
                 None
             }
             (Some(_), Some(_)) => {
-                d.same_path_repeat = d.same_path_repeat.saturating_add(1);
+                h.same_path_repeat = h.same_path_repeat.saturating_add(1);
                 None
             }
             (None, _) => None,
         };
-        (dt, path_change, d.same_path_repeat)
+        (path_change, h.same_path_repeat)
     };
 
     if let Some(old) = path_change {
@@ -324,13 +347,18 @@ pub fn start_watching(
     let app_handle_for_poll = app_handle.clone();
     let stop_flag = Arc::new(AtomicBool::new(false));
 
-    // Diagnostic state — one EventDiag per source so we can correlate
-    // notify-vs-poll-vs-inline patterns in the log.
-    let notify_diag = Arc::new(Mutex::new(EventDiag::default()));
-    let poll_diag = Arc::new(Mutex::new(EventDiag::default()));
-    let inline_diag = Arc::new(Mutex::new(EventDiag::default()));
+    // Diagnostic state — per-source timing so we can correlate
+    // notify-vs-poll-vs-inline patterns in the log, and a SHARED
+    // path history so the speculative→resolved transcript-path flip is
+    // detected even when it spans sources (e.g. inline saw the
+    // speculative path, notify sees the resolved one).
+    let notify_timing = Arc::new(Mutex::new(EventTiming::default()));
+    let poll_timing = Arc::new(Mutex::new(EventTiming::default()));
+    let inline_timing = Arc::new(Mutex::new(EventTiming::default()));
+    let path_history = Arc::new(Mutex::new(PathHistory::default()));
 
-    let notify_diag_for_cb = notify_diag.clone();
+    let notify_timing_for_cb = notify_timing.clone();
+    let path_history_for_cb = path_history.clone();
 
     // Debounce interval — ignore events within 100ms of the last processed one
     let debounce_ms = 100;
@@ -405,7 +433,8 @@ pub fn start_watching(
         };
 
         record_event_diag(
-            &notify_diag_for_cb,
+            &notify_timing_for_cb,
+            &path_history_for_cb,
             "notify",
             &sid,
             started.elapsed(),
@@ -453,7 +482,8 @@ pub fn start_watching(
                     }
                 }
                 record_event_diag(
-                    &inline_diag,
+                    &inline_timing,
+                    &path_history,
                     "inline",
                     &initial_sid,
                     started.elapsed(),
@@ -473,7 +503,8 @@ pub fn start_watching(
         let poll_app = app_handle_for_poll;
         let poll_last = Arc::new(Mutex::new(String::new()));
         let poll_stop = stop_flag.clone();
-        let poll_diag_for_thread = poll_diag.clone();
+        let poll_timing_for_thread = poll_timing.clone();
+        let path_history_for_poll = path_history.clone();
         std::thread::spawn(move || {
             while !poll_stop.load(Ordering::Relaxed) {
                 std::thread::sleep(std::time::Duration::from_secs(3));
@@ -509,7 +540,8 @@ pub fn start_watching(
                 };
 
                 record_event_diag(
-                    &poll_diag_for_thread,
+                    &poll_timing_for_thread,
+                    &path_history_for_poll,
                     "poll",
                     &poll_sid,
                     started.elapsed(),

--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -148,13 +148,15 @@ fn short_path(path: &str) -> String {
 
 /// Emit the per-event diagnostic line. Gated by `cfg!(debug_assertions)`.
 ///
-/// Reads per-source timing from `timing` and the cross-source path
-/// history from `path_history` (shared across all sources). The path
-/// history MUST be shared so the speculative→resolved flip — which
-/// frequently spans sources (e.g. inline reads the speculative path,
-/// notify sees the resolved one) — is detected.
+/// Reads per-source timing from `timing` (None for one-shot sources
+/// like the inline-init read, where `dt` would be structurally zero
+/// and misleading) and the cross-source path history from
+/// `path_history` (shared across all sources). The path history MUST
+/// be shared so the speculative→resolved flip — which frequently
+/// spans sources (e.g. inline reads the speculative path, notify
+/// sees the resolved one) — is detected.
 fn record_event_diag(
-    timing: &Mutex<EventTiming>,
+    timing: Option<&Mutex<EventTiming>>,
     path_history: &Mutex<PathHistory>,
     source: &'static str,
     sid: &str,
@@ -166,15 +168,25 @@ fn record_event_diag(
         return;
     }
 
-    let now = Instant::now();
-    let dt = {
-        let mut t = timing.lock().expect("watcher timing lock");
-        let dt = t
-            .last_event_at
-            .map(|prev| now.duration_since(prev))
-            .unwrap_or(Duration::ZERO);
-        t.last_event_at = Some(now);
-        dt
+    // `dt` is only meaningful for sources that fire repeatedly. The
+    // inline-init source runs once per watcher start, so its `dt`
+    // would always be `Duration::ZERO` (the default for a None
+    // `last_event_at`) — emitting `dt=0ms` for inline alongside real
+    // dt values from notify/poll lets a reader misread the zero as
+    // recency. `None` here means "this source is one-shot, log dt as
+    // n/a so the reader doesn't compare it against real deltas."
+    let dt_label = match timing {
+        Some(t) => {
+            let now = Instant::now();
+            let mut t = t.lock().expect("watcher timing lock");
+            let dt = t
+                .last_event_at
+                .map(|prev| now.duration_since(prev))
+                .unwrap_or(Duration::ZERO);
+            t.last_event_at = Some(now);
+            format!("dt={}ms", dt.as_millis())
+        }
+        None => "dt=n/a".to_string(),
     };
 
     let (path_change, repeat) = {
@@ -196,10 +208,10 @@ fn record_event_diag(
     let tx_path_short = tx_path.map(short_path).unwrap_or_else(|| "(none)".into());
     if total_ms > 50 {
         log::warn!(
-            "watcher.slow_event source={} session={} dt={}ms total={}ms tx_status={} tx_path={} repeat={}",
+            "watcher.slow_event source={} session={} {} total={}ms tx_status={} tx_path={} repeat={}",
             source,
             short_sid(sid),
-            dt.as_millis(),
+            dt_label,
             total_ms,
             outcome.label(),
             tx_path_short,
@@ -207,10 +219,10 @@ fn record_event_diag(
         );
     } else {
         log::info!(
-            "watcher.event source={} session={} dt={}ms total={}ms tx_status={} tx_path={} repeat={}",
+            "watcher.event source={} session={} {} total={}ms tx_status={} tx_path={} repeat={}",
             source,
             short_sid(sid),
-            dt.as_millis(),
+            dt_label,
             total_ms,
             outcome.label(),
             tx_path_short,
@@ -224,19 +236,27 @@ pub struct WatcherHandle {
     _watcher: RecommendedWatcher,
     /// Signals the polling fallback thread to exit
     stop_flag: Arc<AtomicBool>,
-    /// Captured for diagnostic logging on drop (dev builds only)
+    /// Captured for diagnostic logging on drop. `#[cfg(debug_assertions)]`
+    /// gates the FIELD itself so release builds skip the `String::clone`
+    /// in the constructor — `cfg!()` on the read site alone left the
+    /// allocation in release. Conditional struct fields are part of
+    /// stable Rust.
+    #[cfg(debug_assertions)]
     session_id: String,
 }
 
 impl Drop for WatcherHandle {
     fn drop(&mut self) {
         self.stop_flag.store(true, Ordering::Relaxed);
-        if cfg!(debug_assertions) {
-            log::info!(
-                "watcher.handle.dropped session={}",
-                short_sid(&self.session_id)
-            );
-        }
+        // `#[cfg(...)]` (attribute) on a statement, NOT `if cfg!(...)`
+        // (runtime). The attribute physically removes both the
+        // statement and the `self.session_id` access in release builds,
+        // matching the field's `#[cfg(...)]` gate above.
+        #[cfg(debug_assertions)]
+        log::info!(
+            "watcher.handle.dropped session={}",
+            short_sid(&self.session_id)
+        );
     }
 }
 
@@ -304,11 +324,19 @@ fn maybe_start_transcript(
                 session_id,
                 e
             );
-            // Classify the failure for diagnostic logs. Substring matching
-            // mirrors the error strings in `validate_transcript_path`; if
-            // those strings change, this fallback returns NotFile rather
-            // than misclassifying.
-            return if e.contains("No such file") {
+            // Classify the failure for diagnostic logs. The
+            // missing-file case uses `Path::exists()` for
+            // platform-neutrality — Linux's "No such file or
+            // directory" string is forwarded by
+            // `validate_transcript_path`, but Windows reports a
+            // different OS-localized message for ENOENT (and other
+            // platforms vary too). `Path::exists()` returns false
+            // uniformly across platforms for a non-existent path, so
+            // it's the right primary signal. The "access denied"
+            // substring is a CUSTOM string from
+            // `validate_transcript_path` (not OS-localized), so it's
+            // safe to substring-match.
+            return if !std::path::Path::new(transcript_path).exists() {
                 TxOutcome::Missing
             } else if e.contains("access denied") {
                 TxOutcome::OutsidePath
@@ -377,14 +405,16 @@ pub fn start_watching(
     let app_handle_for_poll = app_handle.clone();
     let stop_flag = Arc::new(AtomicBool::new(false));
 
-    // Diagnostic state — per-source timing so we can correlate
-    // notify-vs-poll-vs-inline patterns in the log, and a SHARED
-    // path history so the speculative→resolved transcript-path flip is
-    // detected even when it spans sources (e.g. inline saw the
-    // speculative path, notify sees the resolved one).
+    // Diagnostic state — per-source timing for sources that fire
+    // repeatedly (notify, poll), and a SHARED path history so the
+    // speculative→resolved transcript-path flip is detected even when
+    // it spans sources (e.g. inline saw the speculative path, notify
+    // sees the resolved one). The inline-init source has NO timing
+    // mutex: it's one-shot and `dt` would be structurally zero —
+    // record_event_diag accepts `Option<&Mutex<EventTiming>>` and
+    // logs `dt=n/a` when None.
     let notify_timing = Arc::new(Mutex::new(EventTiming::default()));
     let poll_timing = Arc::new(Mutex::new(EventTiming::default()));
-    let inline_timing = Arc::new(Mutex::new(EventTiming::default()));
     let path_history = Arc::new(Mutex::new(PathHistory::default()));
 
     let notify_timing_for_cb = notify_timing.clone();
@@ -463,7 +493,7 @@ pub fn start_watching(
         };
 
         record_event_diag(
-            &notify_timing_for_cb,
+            Some(&notify_timing_for_cb),
             &path_history_for_cb,
             "notify",
             &sid,
@@ -512,7 +542,7 @@ pub fn start_watching(
                     }
                 }
                 record_event_diag(
-                    &inline_timing,
+                    None,
                     &path_history,
                     "inline",
                     &initial_sid,
@@ -579,7 +609,7 @@ pub fn start_watching(
                 };
 
                 record_event_diag(
-                    &poll_timing_for_thread,
+                    Some(&poll_timing_for_thread),
                     &path_history_for_poll,
                     "poll",
                     &poll_sid,
@@ -600,6 +630,7 @@ pub fn start_watching(
     Ok(WatcherHandle {
         _watcher: watcher,
         stop_flag,
+        #[cfg(debug_assertions)]
         session_id: session_id.clone(),
     })
 }

--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -148,7 +148,18 @@ fn record_event_diag(
                 h.same_path_repeat = h.same_path_repeat.saturating_add(1);
                 None
             }
-            (None, _) => None,
+            // No transcript_path on this event — break the streak. Without
+            // this reset, a sequence like [path=A, no-path, path=A] would
+            // log the second A with repeat=2 (treated as consecutive),
+            // making the counter misleading during exactly the
+            // speculative/missing-path windows this diagnostic is meant
+            // to capture. Resetting both fields treats the next
+            // path-bearing event as a fresh observation.
+            (None, _) => {
+                h.last_tx_path = None;
+                h.same_path_repeat = 0;
+                None
+            }
         };
         (path_change, h.same_path_repeat)
     };
@@ -512,6 +523,16 @@ pub fn start_watching(
                     break;
                 }
 
+                // Capture `started` BEFORE the read so `total` covers file
+                // I/O the same way the notify and inline sources do —
+                // otherwise WSL2/virtio-fs read latency is silently
+                // excluded from poll's number, making cross-source
+                // comparison unsound and biasing the freeze diagnosis
+                // toward notify. Dedup-skip `continue` paths run before
+                // `record_event_diag`, so unchanged-content polls never
+                // log a number — no noise.
+                let started = Instant::now();
+
                 let contents = match std::fs::read_to_string(&poll_path) {
                     Ok(c) if !c.trim().is_empty() => c,
                     _ => continue,
@@ -525,7 +546,6 @@ pub fn start_watching(
                     *last = contents.clone();
                 }
 
-                let started = Instant::now();
                 let (outcome, tx_path) = match parse_statusline(&poll_sid, &contents) {
                     Ok(parsed) => {
                         let _ = poll_app.emit("agent-status", &parsed.event);
@@ -588,13 +608,6 @@ pub async fn start_agent_watcher(
         .join(&session_id)
         .join("status.json");
 
-    log::info!(
-        "Starting agent watcher: session={}, path={}, active_watchers={}",
-        session_id,
-        path.display(),
-        state.active_count(),
-    );
-
     // Use the structured logger (already configured for the rest of this
     // file) for startup diagnostics. The earlier debug-only file log at
     // `/tmp/vimeflow-debug.log` was dropped: a fixed predictable path
@@ -609,8 +622,19 @@ pub async fn start_agent_watcher(
         path.display()
     );
 
-    // Stop any existing watcher for this session
+    // Stop any existing watcher for this session BEFORE counting active
+    // watchers — restarting the same session would otherwise inflate the
+    // count and produce a false "leaked watcher" signal. The post-remove
+    // count reflects watchers from OTHER sessions only, which is the
+    // useful leak signal for this log.
     state.remove(&session_id);
+
+    log::info!(
+        "Starting agent watcher: session={}, path={}, active_watchers={}",
+        session_id,
+        path.display(),
+        state.active_count(),
+    );
 
     let handle = start_watching(app_handle, session_id.clone(), path)?;
     state.insert(session_id.clone(), handle);

--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -87,6 +87,53 @@ struct PathHistory {
     same_path_repeat: u32,
 }
 
+impl PathHistory {
+    /// Record one event's observation of the transcript-path field and
+    /// update the streak counter. Returns `Some(old)` when the path
+    /// changed (caller logs `watcher.tx_path_change`), `None` otherwise.
+    ///
+    /// Extracted as a method so the state machine is unit-testable
+    /// without driving the surrounding `record_event_diag` (which
+    /// otherwise needs a `Mutex` + a logger to be exercised). The four
+    /// arms encode:
+    ///
+    ///   1. Path differs from the last seen → log a path_change, reset
+    ///      the streak counter to 1, return the old path.
+    ///   2. First observation (no prior path) → set, repeat=1.
+    ///   3. Same path as last → increment streak counter.
+    ///   4. No path on this event → reset BOTH `last_tx_path` AND
+    ///      `same_path_repeat`. Without this reset, a sequence
+    ///      `[path=A, no-path, path=A]` would log the second A with
+    ///      `repeat=2` (treated as a consecutive observation across
+    ///      the no-path interlude), which is precisely the
+    ///      speculative/missing-path window this diagnostic exists
+    ///      to capture.
+    fn observe(&mut self, tx_path: Option<&str>) -> Option<String> {
+        match (tx_path, self.last_tx_path.as_deref()) {
+            (Some(new), Some(old)) if new != old => {
+                let old_owned = old.to_string();
+                self.last_tx_path = Some(new.to_string());
+                self.same_path_repeat = 1;
+                Some(old_owned)
+            }
+            (Some(new), None) => {
+                self.last_tx_path = Some(new.to_string());
+                self.same_path_repeat = 1;
+                None
+            }
+            (Some(_), Some(_)) => {
+                self.same_path_repeat = self.same_path_repeat.saturating_add(1);
+                None
+            }
+            (None, _) => {
+                self.last_tx_path = None;
+                self.same_path_repeat = 0;
+                None
+            }
+        }
+    }
+}
+
 fn short_sid(sid: &str) -> &str {
     sid.get(..8).unwrap_or(sid)
 }
@@ -132,35 +179,7 @@ fn record_event_diag(
 
     let (path_change, repeat) = {
         let mut h = path_history.lock().expect("watcher path-history lock");
-        let path_change = match (tx_path, h.last_tx_path.as_deref()) {
-            (Some(new), Some(old)) if new != old => {
-                let old_owned = old.to_string();
-                h.last_tx_path = Some(new.to_string());
-                h.same_path_repeat = 1;
-                Some(old_owned)
-            }
-            (Some(new), None) => {
-                h.last_tx_path = Some(new.to_string());
-                h.same_path_repeat = 1;
-                None
-            }
-            (Some(_), Some(_)) => {
-                h.same_path_repeat = h.same_path_repeat.saturating_add(1);
-                None
-            }
-            // No transcript_path on this event — break the streak. Without
-            // this reset, a sequence like [path=A, no-path, path=A] would
-            // log the second A with repeat=2 (treated as consecutive),
-            // making the counter misleading during exactly the
-            // speculative/missing-path windows this diagnostic is meant
-            // to capture. Resetting both fields treats the next
-            // path-bearing event as a fresh observation.
-            (None, _) => {
-                h.last_tx_path = None;
-                h.same_path_repeat = 0;
-                None
-            }
-        };
+        let path_change = h.observe(tx_path);
         (path_change, h.same_path_repeat)
     };
 
@@ -670,5 +689,159 @@ mod tests {
     fn remove_returns_false_for_missing_session() {
         let state = AgentWatcherState::new();
         assert!(!state.remove("nonexistent"));
+    }
+
+    // -- PathHistory state machine ----------------------------------
+    //
+    // These tests cover all four arms of `PathHistory::observe` and act
+    // as regression guards for the round-1 `(None, _)` reset and the
+    // round-1 fix that ensured `same_path_repeat = 1` (not 0) on a
+    // path change. They run against the extracted method rather than
+    // driving `record_event_diag` end-to-end, which is the only
+    // production caller — that function early-returns under
+    // `cfg!(debug_assertions)` and emits log side effects, both of
+    // which make end-to-end testing noisier than necessary for a pure
+    // state-machine check.
+
+    #[test]
+    fn path_history_first_observation_sets_path_and_repeat_1() {
+        let mut h = PathHistory::default();
+        let r = h.observe(Some("path-a"));
+        assert!(r.is_none(), "first observation must not report a path change");
+        assert_eq!(h.last_tx_path.as_deref(), Some("path-a"));
+        assert_eq!(h.same_path_repeat, 1);
+    }
+
+    #[test]
+    fn path_history_repeat_increments_on_same_path() {
+        let mut h = PathHistory::default();
+        h.observe(Some("path-a"));
+        h.observe(Some("path-a"));
+        assert_eq!(h.same_path_repeat, 2);
+
+        let r = h.observe(Some("path-a"));
+        assert!(
+            r.is_none(),
+            "same-path observation must not report a path change"
+        );
+        assert_eq!(h.same_path_repeat, 3);
+    }
+
+    #[test]
+    fn path_history_path_change_returns_old_and_resets_repeat() {
+        let mut h = PathHistory::default();
+        h.observe(Some("path-a"));
+        h.observe(Some("path-a"));
+        assert_eq!(h.same_path_repeat, 2);
+
+        let r = h.observe(Some("path-b"));
+        assert_eq!(
+            r.as_deref(),
+            Some("path-a"),
+            "path change must return the previous value"
+        );
+        assert_eq!(h.last_tx_path.as_deref(), Some("path-b"));
+        assert_eq!(
+            h.same_path_repeat, 1,
+            "streak counter resets to 1 on a fresh path"
+        );
+    }
+
+    #[test]
+    fn path_history_no_path_resets_streak_after_repeat() {
+        // Regression guard for the round-1 `(None, _)` bug. The
+        // sequence [path=A, no-path, path=A] MUST NOT report the
+        // second A as repeat=2 — the no-path interlude breaks the
+        // streak, and the next path-bearing event is fresh.
+        let mut h = PathHistory::default();
+        h.observe(Some("path-a"));
+        h.observe(Some("path-a"));
+        assert_eq!(h.same_path_repeat, 2);
+
+        let r = h.observe(None);
+        assert!(r.is_none());
+        assert_eq!(h.last_tx_path, None, "no-path must clear the path cache");
+        assert_eq!(h.same_path_repeat, 0, "no-path must reset the streak");
+
+        let r = h.observe(Some("path-a"));
+        assert!(
+            r.is_none(),
+            "the next path-bearing event after a no-path is treated as fresh — \
+             it does not report a change against the cleared cache"
+        );
+        assert_eq!(h.same_path_repeat, 1, "streak starts at 1, not 3");
+    }
+
+    #[test]
+    fn path_history_no_path_when_already_no_path_is_idempotent() {
+        let mut h = PathHistory::default();
+        let r = h.observe(None);
+        assert!(r.is_none());
+        assert_eq!(h.last_tx_path, None);
+        assert_eq!(h.same_path_repeat, 0);
+    }
+
+    // -- short_sid / short_path / TxOutcome::label -------------------
+
+    #[test]
+    fn short_sid_truncates_long_to_8_chars() {
+        assert_eq!(short_sid("abcdefghijklmnop"), "abcdefgh");
+    }
+
+    #[test]
+    fn short_sid_returns_input_unchanged_when_short() {
+        assert_eq!(short_sid("abc"), "abc");
+        assert_eq!(short_sid(""), "");
+    }
+
+    #[test]
+    fn short_sid_handles_uuid_form() {
+        // Real session IDs are UUIDs; the canonical 8-char prefix is
+        // what the diagnostic logs render.
+        assert_eq!(
+            short_sid("ddb8d9f1-30b1-43dc-a1a2-405aaaf95e14"),
+            "ddb8d9f1"
+        );
+    }
+
+    #[test]
+    fn short_path_extracts_basename_without_extension() {
+        assert_eq!(
+            short_path("/home/x/projects/abcdefghijklm.jsonl"),
+            "abcdefgh",
+            "basename file_stem truncated to 8 chars"
+        );
+        assert_eq!(short_path("/x/y/short.jsonl"), "short");
+    }
+
+    #[test]
+    fn short_path_handles_input_without_directory() {
+        assert_eq!(short_path("nofileonly.jsonl"), "nofileon");
+    }
+
+    #[test]
+    fn short_path_returns_question_mark_when_no_basename() {
+        assert_eq!(
+            short_path("/"),
+            "?",
+            "root path has no file_stem — fall back to ? sentinel"
+        );
+    }
+
+    #[test]
+    fn tx_outcome_label_covers_every_variant() {
+        // Drives every match arm so adding a new variant without a
+        // label causes this test to fail to compile (exhaustive match
+        // by construction in TxOutcome::label, plus this test reads
+        // every variant).
+        assert_eq!(TxOutcome::Started.label(), "started");
+        assert_eq!(TxOutcome::Replaced.label(), "replaced");
+        assert_eq!(TxOutcome::AlreadyRunning.label(), "already_running");
+        assert_eq!(TxOutcome::Missing.label(), "missing");
+        assert_eq!(TxOutcome::OutsidePath.label(), "outside_path");
+        assert_eq!(TxOutcome::NotFile.label(), "not_file");
+        assert_eq!(TxOutcome::StartFailed.label(), "start_failed");
+        assert_eq!(TxOutcome::NoPath.label(), "no_path");
+        assert_eq!(TxOutcome::ParseError.label(), "parse_error");
     }
 }

--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use tauri::{Emitter, Manager};
@@ -16,16 +16,174 @@ use tauri::{Emitter, Manager};
 use super::statusline::parse_statusline;
 use super::transcript::{validate_transcript_path, TranscriptStartStatus, TranscriptState};
 
+// ----------------------------------------------------------------------
+// Diagnostic logging (dev/debug builds only)
+//
+// Every event-processing callback emits a structured INFO line that
+// surrounds the existing WARN ("Skipping transcript tailing ...") with
+// enough context to diagnose freezes from `Vimeflow.log` alone:
+// source, inter-event delta, total processing duration, transcript-path
+// status, and a same-path repeat counter that captures Claude Code's
+// "speculative path → resolved path" flip pattern.
+//
+// Gated by `cfg!(debug_assertions)` so packaged release builds emit zero
+// extra log volume. The real WARN stays at WARN level untouched per the
+// user's directive that the warning frequency itself is signal.
+// ----------------------------------------------------------------------
+
+/// Outcome of a `maybe_start_transcript` call. Returned so the caller
+/// can record an accurate `tx_status` in the diagnostic log without
+/// re-walking the path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TxOutcome {
+    Started,
+    Replaced,
+    AlreadyRunning,
+    Missing,
+    OutsidePath,
+    NotFile,
+    StartFailed,
+    NoPath,
+    ParseError,
+}
+
+impl TxOutcome {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Started => "started",
+            Self::Replaced => "replaced",
+            Self::AlreadyRunning => "already_running",
+            Self::Missing => "missing",
+            Self::OutsidePath => "outside_path",
+            Self::NotFile => "not_file",
+            Self::StartFailed => "start_failed",
+            Self::NoPath => "no_path",
+            Self::ParseError => "parse_error",
+        }
+    }
+}
+
+#[derive(Default)]
+struct EventDiag {
+    last_event_at: Option<Instant>,
+    last_tx_path: Option<String>,
+    /// How many consecutive events have had the SAME transcript path
+    /// (with the SAME outcome) — high values indicate the bridge is
+    /// stuck waiting for Claude Code to resolve a speculative path.
+    same_path_repeat: u32,
+}
+
+fn short_sid(sid: &str) -> &str {
+    sid.get(..8).unwrap_or(sid)
+}
+
+fn short_path(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(|s| s.get(..8).unwrap_or(s).to_string())
+        .unwrap_or_else(|| "?".to_string())
+}
+
+/// Emit the per-event diagnostic line. Gated by `cfg!(debug_assertions)`.
+/// Also tracks the running `last_tx_path` for path-flip detection and
+/// `same_path_repeat` for stuck-bridge visibility.
+fn record_event_diag(
+    diag: &Mutex<EventDiag>,
+    source: &'static str,
+    sid: &str,
+    total: Duration,
+    outcome: TxOutcome,
+    tx_path: Option<&str>,
+) {
+    if !cfg!(debug_assertions) {
+        return;
+    }
+
+    let now = Instant::now();
+    let (dt, path_change, repeat) = {
+        let mut d = diag.lock().expect("watcher diag lock");
+        let dt = d
+            .last_event_at
+            .map(|prev| now.duration_since(prev))
+            .unwrap_or(Duration::ZERO);
+        d.last_event_at = Some(now);
+
+        let path_change = match (tx_path, d.last_tx_path.as_deref()) {
+            (Some(new), Some(old)) if new != old => {
+                let old_owned = old.to_string();
+                d.last_tx_path = Some(new.to_string());
+                d.same_path_repeat = 1;
+                Some(old_owned)
+            }
+            (Some(new), None) => {
+                d.last_tx_path = Some(new.to_string());
+                d.same_path_repeat = 1;
+                None
+            }
+            (Some(_), Some(_)) => {
+                d.same_path_repeat = d.same_path_repeat.saturating_add(1);
+                None
+            }
+            (None, _) => None,
+        };
+        (dt, path_change, d.same_path_repeat)
+    };
+
+    if let Some(old) = path_change {
+        log::info!(
+            "watcher.tx_path_change session={} from={} to={}",
+            short_sid(sid),
+            short_path(&old),
+            tx_path.map(short_path).unwrap_or_else(|| "(none)".into()),
+        );
+    }
+
+    let total_ms = total.as_millis();
+    let tx_path_short = tx_path.map(short_path).unwrap_or_else(|| "(none)".into());
+    if total_ms > 50 {
+        log::warn!(
+            "watcher.slow_event source={} session={} dt={}ms total={}ms tx_status={} tx_path={} repeat={}",
+            source,
+            short_sid(sid),
+            dt.as_millis(),
+            total_ms,
+            outcome.label(),
+            tx_path_short,
+            repeat,
+        );
+    } else {
+        log::info!(
+            "watcher.event source={} session={} dt={}ms total={}ms tx_status={} tx_path={} repeat={}",
+            source,
+            short_sid(sid),
+            dt.as_millis(),
+            total_ms,
+            outcome.label(),
+            tx_path_short,
+            repeat,
+        );
+    }
+}
+
 /// Handle to a running watcher — dropping it stops the watcher and polling thread
 pub struct WatcherHandle {
     _watcher: RecommendedWatcher,
     /// Signals the polling fallback thread to exit
     stop_flag: Arc<AtomicBool>,
+    /// Captured for diagnostic logging on drop (dev builds only)
+    session_id: String,
 }
 
 impl Drop for WatcherHandle {
     fn drop(&mut self) {
         self.stop_flag.store(true, Ordering::Relaxed);
+        if cfg!(debug_assertions) {
+            log::info!(
+                "watcher.handle.dropped session={}",
+                short_sid(&self.session_id)
+            );
+        }
     }
 }
 
@@ -61,6 +219,15 @@ impl AgentWatcherState {
         let watchers = self.watchers.lock().expect("failed to lock watchers");
         watchers.contains_key(session_id)
     }
+
+    /// Number of active watchers across all sessions. Used for the
+    /// diagnostic "active_watchers=N" log line — surfaces leaked
+    /// watchers from prior sessions that are still polling old
+    /// status.json files in the background.
+    fn active_count(&self) -> usize {
+        let watchers = self.watchers.lock().expect("failed to lock watchers");
+        watchers.len()
+    }
 }
 
 /// Try to start transcript tailing, switching files if Claude reports a new path.
@@ -75,8 +242,8 @@ fn maybe_start_transcript(
     app_handle: &tauri::AppHandle,
     session_id: &str,
     transcript_path: &str,
-) {
-    let transcript_path = match validate_transcript_path(transcript_path) {
+) -> TxOutcome {
+    let canonical = match validate_transcript_path(transcript_path) {
         Ok(path) => path,
         Err(e) => {
             log::warn!(
@@ -84,7 +251,17 @@ fn maybe_start_transcript(
                 session_id,
                 e
             );
-            return;
+            // Classify the failure for diagnostic logs. Substring matching
+            // mirrors the error strings in `validate_transcript_path`; if
+            // those strings change, this fallback returns NotFile rather
+            // than misclassifying.
+            return if e.contains("No such file") {
+                TxOutcome::Missing
+            } else if e.contains("access denied") {
+                TxOutcome::OutsidePath
+            } else {
+                TxOutcome::NotFile
+            };
         }
     };
 
@@ -97,30 +274,33 @@ fn maybe_start_transcript(
     match ts.start_or_replace(
         app_handle.clone(),
         session_id.to_string(),
-        transcript_path.clone(),
+        canonical.clone(),
         cwd,
     ) {
         Ok(TranscriptStartStatus::Started) => {
             log::info!(
                 "Started transcript tailing for session {}: {}",
                 session_id,
-                transcript_path.display()
+                canonical.display()
             );
+            TxOutcome::Started
         }
         Ok(TranscriptStartStatus::Replaced) => {
             log::info!(
                 "Switched transcript tailing for session {}: {}",
                 session_id,
-                transcript_path.display()
+                canonical.display()
             );
+            TxOutcome::Replaced
         }
-        Ok(TranscriptStartStatus::AlreadyRunning) => {}
+        Ok(TranscriptStartStatus::AlreadyRunning) => TxOutcome::AlreadyRunning,
         Err(e) => {
             log::warn!(
                 "Failed to start transcript tailing for session {}: {}",
                 session_id,
                 e
             );
+            TxOutcome::StartFailed
         }
     }
 }
@@ -143,6 +323,14 @@ pub fn start_watching(
     let last_processed = Arc::new(Mutex::new(Instant::now()));
     let app_handle_for_poll = app_handle.clone();
     let stop_flag = Arc::new(AtomicBool::new(false));
+
+    // Diagnostic state — one EventDiag per source so we can correlate
+    // notify-vs-poll-vs-inline patterns in the log.
+    let notify_diag = Arc::new(Mutex::new(EventDiag::default()));
+    let poll_diag = Arc::new(Mutex::new(EventDiag::default()));
+    let inline_diag = Arc::new(Mutex::new(EventDiag::default()));
+
+    let notify_diag_for_cb = notify_diag.clone();
 
     // Debounce interval — ignore events within 100ms of the last processed one
     let debounce_ms = 100;
@@ -182,6 +370,8 @@ pub fn start_watching(
             *last = now;
         }
 
+        let started = Instant::now();
+
         // Read and parse the status file
         let contents = match std::fs::read_to_string(&target_path) {
             Ok(c) => c,
@@ -195,21 +385,33 @@ pub fn start_watching(
             return;
         }
 
-        match parse_statusline(&sid, &contents) {
+        let (outcome, tx_path) = match parse_statusline(&sid, &contents) {
             Ok(parsed) => {
                 if let Err(e) = app_handle.emit("agent-status", &parsed.event) {
                     log::error!("Failed to emit agent-status event: {}", e);
                 }
 
                 if let Some(ref path) = parsed.transcript_path {
-                    log::debug!("Transcript path for session {}: {}", sid, path);
-                    maybe_start_transcript(&app_handle, &sid, path);
+                    let outcome = maybe_start_transcript(&app_handle, &sid, path);
+                    (outcome, Some(path.clone()))
+                } else {
+                    (TxOutcome::NoPath, None)
                 }
             }
             Err(e) => {
                 log::warn!("Failed to parse statusline for session {}: {}", sid, e);
+                (TxOutcome::ParseError, None)
             }
-        }
+        };
+
+        record_event_diag(
+            &notify_diag_for_cb,
+            "notify",
+            &sid,
+            started.elapsed(),
+            outcome,
+            tx_path.as_deref(),
+        );
     })
     .map_err(|e| format!("failed to create watcher: {}", e))?;
 
@@ -233,14 +435,31 @@ pub fn start_watching(
         let initial_sid = session_id.clone();
         let initial_path = status_file_path.clone();
         let initial_app = app_handle_for_poll.clone();
+        let started = Instant::now();
+        let mut outcome = TxOutcome::NoPath;
+        let mut inline_tx_path: Option<String> = None;
         if let Ok(contents) = std::fs::read_to_string(&initial_path) {
             if !contents.trim().is_empty() {
-                if let Ok(parsed) = parse_statusline(&initial_sid, &contents) {
-                    let _ = initial_app.emit("agent-status", &parsed.event);
-                    if let Some(ref path) = parsed.transcript_path {
-                        maybe_start_transcript(&initial_app, &initial_sid, path);
+                match parse_statusline(&initial_sid, &contents) {
+                    Ok(parsed) => {
+                        let _ = initial_app.emit("agent-status", &parsed.event);
+                        if let Some(ref path) = parsed.transcript_path {
+                            outcome = maybe_start_transcript(&initial_app, &initial_sid, path);
+                            inline_tx_path = Some(path.clone());
+                        }
+                    }
+                    Err(_) => {
+                        outcome = TxOutcome::ParseError;
                     }
                 }
+                record_event_diag(
+                    &inline_diag,
+                    "inline",
+                    &initial_sid,
+                    started.elapsed(),
+                    outcome,
+                    inline_tx_path.as_deref(),
+                );
             }
         }
     }
@@ -254,6 +473,7 @@ pub fn start_watching(
         let poll_app = app_handle_for_poll;
         let poll_last = Arc::new(Mutex::new(String::new()));
         let poll_stop = stop_flag.clone();
+        let poll_diag_for_thread = poll_diag.clone();
         std::thread::spawn(move || {
             while !poll_stop.load(Ordering::Relaxed) {
                 std::thread::sleep(std::time::Duration::from_secs(3));
@@ -274,12 +494,28 @@ pub fn start_watching(
                     *last = contents.clone();
                 }
 
-                if let Ok(parsed) = parse_statusline(&poll_sid, &contents) {
-                    let _ = poll_app.emit("agent-status", &parsed.event);
-                    if let Some(ref path) = parsed.transcript_path {
-                        maybe_start_transcript(&poll_app, &poll_sid, path);
+                let started = Instant::now();
+                let (outcome, tx_path) = match parse_statusline(&poll_sid, &contents) {
+                    Ok(parsed) => {
+                        let _ = poll_app.emit("agent-status", &parsed.event);
+                        if let Some(ref path) = parsed.transcript_path {
+                            let outcome = maybe_start_transcript(&poll_app, &poll_sid, path);
+                            (outcome, Some(path.clone()))
+                        } else {
+                            (TxOutcome::NoPath, None)
+                        }
                     }
-                }
+                    Err(_) => (TxOutcome::ParseError, None),
+                };
+
+                record_event_diag(
+                    &poll_diag_for_thread,
+                    "poll",
+                    &poll_sid,
+                    started.elapsed(),
+                    outcome,
+                    tx_path.as_deref(),
+                );
             }
         });
     }
@@ -293,6 +529,7 @@ pub fn start_watching(
     Ok(WatcherHandle {
         _watcher: watcher,
         stop_flag,
+        session_id: session_id.clone(),
     })
 }
 
@@ -320,9 +557,10 @@ pub async fn start_agent_watcher(
         .join("status.json");
 
     log::info!(
-        "Starting agent watcher: session={}, path={}",
+        "Starting agent watcher: session={}, path={}, active_watchers={}",
         session_id,
-        path.display()
+        path.display(),
+        state.active_count(),
     );
 
     // Use the structured logger (already configured for the rest of this


### PR DESCRIPTION
## Summary

When the user invokes `claude` in a vimeflow PTY, Claude Code 2.1.123 declares a *speculative* transcript path in `status.json` BEFORE creating the file (and often resolves it to a *different* path entirely if a session is being resumed). Vimeflow's watcher fires on each `status.json` modify and logs `WARN — Skipping transcript tailing` until the path resolves. Sometimes a freeze accompanies the WARN window — the actual root cause is unclear, and the existing log line carries no context to diagnose from.

This branch ADDS structured diagnostic logs around every event-processing site in the watcher so the failure becomes self-documenting in `Vimeflow.log`. **No behavior change**, **release builds emit zero extra log volume** (every diagnostic is gated by `cfg!(debug_assertions)`), the existing `WARN — Skipping transcript tailing` line is unchanged.

What's new in the log when a freeze happens:

```
[INFO] watcher.event source=notify session=<sid8> dt=4501ms total=3ms tx_status=missing tx_path=eaa3588b repeat=2
[WARN] Skipping transcript tailing for session ...    ← unchanged
[INFO] watcher.tx_path_change session=<sid8> from=eaa3588b to=11185848  ← speculative→resolved flip
[INFO] watcher.event source=notify session=<sid8> dt=7000ms total=18ms tx_status=started tx_path=11185848 repeat=1
[INFO] Started transcript tailing for session ...
[INFO] watcher.handle.dropped session=<sid8>
[INFO] Starting agent watcher: session=..., active_watchers=2  ← leak signal
```

`watcher.slow_event` (WARN) replaces `watcher.event` when total processing time exceeds 50ms — the signature of a JS-main-thread freeze if it's in this code path. If the freeze persists with only 1–10ms `watcher.event` lines, the freeze is somewhere else (xterm.js, React, Tauri IPC) and we'll need to look outside the watcher.

## Commits

1. `eb488c4 chore(agent-watcher): add dev-only diagnostic logs around the warn` — initial patch with one `EventDiag` per source.
2. `2accdbf fix(agent-watcher): share transcript-path history across event sources` — split into per-source `EventTiming` and a SHARED `PathHistory`, so the speculative→resolved flip is detected even when it spans sources (e.g. inline reader saw the speculative path, notify sees the resolved one). Without this share, `watcher.tx_path_change` would never fire for the cross-source case it is meant to diagnose.

## Test plan

- [x] `cargo check` clean
- [x] `cargo test --lib agent::watcher` — 2 tests pass
- [ ] Rebuild via `npm run tauri:dev`, reproduce the freeze, confirm `Vimeflow.log` carries the new lines
- [ ] Confirm release build (`npm run tauri:build`) emits zero diagnostic lines (the `cfg!(debug_assertions)` guard is the contract)

## Out of scope

- Fixing the freeze. This patch is observability-only — its purpose is to gather data for the next iteration. The existing WARN frequency is intentionally preserved per project owner directive ("the warning frequency itself is signal").
- Lowering the WARN to DEBUG. Same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)