### PR TITLE
fix(cleanup): batch low-severity issue fixes (#95, #97, #101, #102, #103, #105, #106)

### DIFF
--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -153,20 +153,18 @@ fn parse_numstat(output: &[u8]) -> HashMap<String, (u32, u32)> {
         // Parse insertions and deletions
         let insertions_str = String::from_utf8_lossy(parts[0]);
         let deletions_str = String::from_utf8_lossy(parts[1]);
+        let is_binary = insertions_str == "-" || deletions_str == "-";
+        let is_rename = parts[2].is_empty();
 
-        // Skip binary files (marked as "-\t-\t...")
-        if insertions_str == "-" || deletions_str == "-" {
-            i += 1;
-            continue;
-        }
+        if is_rename {
+            if is_binary {
+                i += 3;
+                continue;
+            }
 
-        let insertions = insertions_str.parse::<u32>().unwrap_or(0);
-        let deletions = deletions_str.parse::<u32>().unwrap_or(0);
+            let insertions = insertions_str.parse::<u32>().unwrap_or(0);
+            let deletions = deletions_str.parse::<u32>().unwrap_or(0);
 
-        // Check if this is a rename (third field is empty)
-        let path_field = String::from_utf8_lossy(parts[2]);
-
-        if path_field.is_empty() {
             // Rename format: next two NUL-separated tokens are src and dst
             i += 1;
             let _src_path = records.get(i).map(|b| String::from_utf8_lossy(b));
@@ -178,6 +176,16 @@ fn parse_numstat(output: &[u8]) -> HashMap<String, (u32, u32)> {
                 }
             }
         } else {
+            // Skip binary files (marked as "-\t-\t...")
+            if is_binary {
+                i += 1;
+                continue;
+            }
+
+            let insertions = insertions_str.parse::<u32>().unwrap_or(0);
+            let deletions = deletions_str.parse::<u32>().unwrap_or(0);
+            let path_field = String::from_utf8_lossy(parts[2]);
+
             // Non-rename: path is in the third field. Reject brace-compressed
             // text form (like "src/{A.tsx => B.tsx}") which only appears in
             // the non-`-z` output. `-z` uses NUL separators for renames —
@@ -986,6 +994,20 @@ mod tests {
         assert_eq!(stats.len(), 1);
         assert_eq!(stats.get("text.rs"), Some(&(5, 3)));
         assert_eq!(stats.get("binary.png"), None);
+    }
+
+    #[test]
+    fn test_parse_numstat_binary_rename_consumes_src_and_dst_tokens() {
+        // Binary rename format: -\t-\t\0<src>\0<dst>\0. The source path may
+        // legally contain tabs; it must still be consumed as a path token, not
+        // reinterpreted as a standalone numstat record.
+        let output = b"-\t-\t\05\t3\tbogus.rs\0dst.bin\07\t2\ttext.rs\0";
+        let stats = parse_numstat(output);
+
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats.get("text.rs"), Some(&(7, 2)));
+        assert_eq!(stats.get("bogus.rs"), None);
+        assert_eq!(stats.get("dst.bin"), None);
     }
 
     #[test]

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -40,6 +40,14 @@ const POLL_INTERVAL_SECS: u64 = 10;
 /// leaks along with every `Arc` it holds.
 const SYNC_GIT_TIMEOUT: Duration = Duration::from_secs(10);
 
+fn is_notify_not_found(error: &notify::Error) -> bool {
+    matches!(error.kind, notify::ErrorKind::PathNotFound)
+        || matches!(
+            &error.kind,
+            notify::ErrorKind::Io(e) if e.kind() == std::io::ErrorKind::NotFound
+        )
+}
+
 /// Run a `std::process::Command` synchronously with a deadline. On timeout,
 /// kill the child and return an error. Used from the polling thread (which
 /// lives in `std::thread::spawn`, NOT a tokio task, so `run_git_with_timeout`
@@ -559,11 +567,20 @@ fn start_git_watcher_inner(
                     .lock()
                     .expect("failed to lock watched_dirs");
                 for dir in new_dirs {
-                    if let Err(e) = watcher_guard.watch(&dir, RecursiveMode::NonRecursive) {
-                        log::warn!("Failed to watch new dir {}: {}", dir.display(), e);
-                        continue;
+                    match watcher_guard.watch(&dir, RecursiveMode::NonRecursive) {
+                        Ok(()) => {
+                            dirs_guard.insert(dir);
+                        }
+                        Err(e) if is_notify_not_found(&e) => {
+                            log::debug!(
+                                "New git watcher dir vanished before registration: {}",
+                                dir.display()
+                            );
+                        }
+                        Err(e) => {
+                            log::warn!("Failed to watch new dir {}: {}", dir.display(), e);
+                        }
                     }
-                    dirs_guard.insert(dir);
                 }
             }
         }
@@ -985,6 +1002,30 @@ mod tests {
             .expect("failed to configure git");
 
         temp
+    }
+
+    #[test]
+    fn notify_not_found_classifier_matches_path_not_found() {
+        let error = notify::Error::path_not_found();
+
+        assert!(is_notify_not_found(&error));
+    }
+
+    #[test]
+    fn notify_not_found_classifier_matches_io_not_found() {
+        let error = notify::Error::io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "gone",
+        ));
+
+        assert!(is_notify_not_found(&error));
+    }
+
+    #[test]
+    fn notify_not_found_classifier_rejects_other_errors() {
+        let error = notify::Error::new(notify::ErrorKind::MaxFilesWatch);
+
+        assert!(!is_notify_not_found(&error));
     }
 
     #[test]

--- a/src-tauri/src/terminal/commands.rs
+++ b/src-tauri/src/terminal/commands.rs
@@ -29,6 +29,12 @@ fn debug_log(tag: &str, msg: &str) {
 #[cfg(not(debug_assertions))]
 fn debug_log(_tag: &str, _msg: &str) {}
 
+fn cleanup_generated_bridge_dir(dir: Option<&std::path::Path>) {
+    if let Some(dir) = dir {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
 /// Spawn a new PTY session with a shell
 #[tauri::command]
 pub async fn spawn_pty<R: tauri::Runtime>(
@@ -114,11 +120,12 @@ pub async fn spawn_pty<R: tauri::Runtime>(
     }
 
     // Generate statusline bridge files.
-    let bridge_files = if request.enable_agent_bridge {
+    let (bridge_files, bridge_cleanup_dir) = if request.enable_agent_bridge {
         let dir = cwd
             .join(".vimeflow")
             .join("sessions")
             .join(&request.session_id);
+        let cleanup_dir = (!dir.exists()).then_some(dir.clone());
         match super::bridge::generate_bridge_files(&dir.to_string_lossy(), &request.session_id) {
             Ok(files) => {
                 debug_log(
@@ -129,19 +136,20 @@ pub async fn spawn_pty<R: tauri::Runtime>(
                         files.shell_init_path.display()
                     ),
                 );
-                Some(files)
+                (Some(files), cleanup_dir)
             }
             Err(e) => {
+                cleanup_generated_bridge_dir(cleanup_dir.as_deref());
                 log::warn!(
                     "Failed to generate statusline bridge for session {}: {}",
                     request.session_id,
                     e
                 );
-                None
+                (None, None)
             }
         }
     } else {
-        None
+        (None, None)
     };
 
     // Build command — env from IPC is ignored for security (prevents injection)
@@ -165,10 +173,10 @@ pub async fn spawn_pty<R: tauri::Runtime>(
 
         // For interactive bash, generate a combined rcfile that sources
         // both ~/.bashrc (user config) and our init script
-        let init_dir = files
-            .shell_init_path
-            .parent()
-            .ok_or_else(|| "shell init path has no parent directory".to_string())?;
+        let Some(init_dir) = files.shell_init_path.parent() else {
+            cleanup_generated_bridge_dir(bridge_cleanup_dir.as_deref());
+            return Err("shell init path has no parent directory".to_string());
+        };
         let rcfile_path = init_dir.join("bashrc");
         // Use $BASH_ENV (already set above) instead of embedding the path —
         // handles CWDs with apostrophes that would break single-quoted paths.
@@ -197,22 +205,33 @@ pub async fn spawn_pty<R: tauri::Runtime>(
     // there. Without owning the child here, a bail-out would leak the
     // process: alive but unreferenced anywhere, with its stdout buffer
     // eventually filling and the process blocking.
-    let child = pty_pair
-        .slave
-        .spawn_command(cmd)
-        .map_err(|e| format!("failed to spawn shell: {}", e))?;
+    let mut child = match pty_pair.slave.spawn_command(cmd) {
+        Ok(child) => child,
+        Err(e) => {
+            cleanup_generated_bridge_dir(bridge_cleanup_dir.as_deref());
+            return Err(format!("failed to spawn shell: {}", e));
+        }
+    };
 
-    let pid = child
-        .process_id()
-        .ok_or_else(|| "failed to get process ID".to_string())?;
+    let Some(pid) = child.process_id() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        cleanup_generated_bridge_dir(bridge_cleanup_dir.as_deref());
+        return Err("failed to get process ID".to_string());
+    };
 
     log::info!("Spawned shell with PID: {}", pid);
 
     // Get writer from master PTY (call take_writer once and store it)
-    let writer = pty_pair
-        .master
-        .take_writer()
-        .map_err(|e| format!("failed to get PTY writer: {}", e))?;
+    let writer = match pty_pair.master.take_writer() {
+        Ok(writer) => writer,
+        Err(e) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            cleanup_generated_bridge_dir(bridge_cleanup_dir.as_deref());
+            return Err(format!("failed to get PTY writer: {}", e));
+        }
+    };
 
     // Round 7, Finding 3 (claude MEDIUM): atomic check-and-insert against
     // the cap and duplicate id. The previous flow ran three independent
@@ -260,6 +279,7 @@ pub async fn spawn_pty<R: tauri::Runtime>(
         // freshly-spawned shell.
         let _ = rejected.child.kill();
         let _ = rejected.child.wait();
+        cleanup_generated_bridge_dir(bridge_cleanup_dir.as_deref());
         return Err(match reason {
             crate::terminal::state::TryInsertError::AlreadyExists => format!(
                 "session '{}' already exists — cannot spawn duplicate session ID",
@@ -300,6 +320,7 @@ pub async fn spawn_pty<R: tauri::Runtime>(
             let _ = removed.child.kill();
             let _ = removed.child.wait();
         }
+        cleanup_generated_bridge_dir(bridge_cleanup_dir.as_deref());
         return Err(format!("failed to write cache: {}", e));
     }
 
@@ -412,10 +433,14 @@ pub fn kill_pty(
             data.sessions.remove(&request.session_id);
             data.session_order.retain(|id| id != &request.session_id);
 
-            // Advance active_session_id if the killed session was active
+            // Clear active_session_id if the killed session was active.
+            // The frontend owns tab-neighbor selection and persists the
+            // chosen successor via set_active_session after kill_pty returns.
+            // Leaving None during that short window avoids a cache/UI
+            // mismatch where Rust guessed the first remaining tab while React
+            // selected the same-position neighbor.
             if data.active_session_id.as_ref() == Some(&request.session_id) {
-                // Find the next session in order (or None if no more sessions)
-                data.active_session_id = data.session_order.first().cloned();
+                data.active_session_id = None;
             }
             Ok(())
         })
@@ -1105,10 +1130,8 @@ mod tests {
         let state = handle.state::<PtyState>();
         let cache = handle.state::<Arc<SessionCache>>();
 
-        let cwd = std::env::current_dir()
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
+        let cwd_temp_dir = TempDir::new().expect("failed to create cwd temp dir");
+        let cwd = cwd_temp_dir.path().to_string_lossy().to_string();
 
         // Spawn 64 sessions
         for i in 0..64 {
@@ -1131,8 +1154,13 @@ mod tests {
             cwd,
             shell: None,
             env: None,
-            enable_agent_bridge: false,
+            enable_agent_bridge: true,
         };
+        let rejected_bridge_dir = cwd_temp_dir
+            .path()
+            .join(".vimeflow")
+            .join("sessions")
+            .join("session-65");
 
         let result = spawn_pty(handle.clone(), state.clone(), cache.clone(), request_65).await;
         assert!(result.is_err(), "65th spawn should fail due to cap");
@@ -1140,6 +1168,10 @@ mod tests {
         assert!(
             err.contains("maximum") || err.contains("64"),
             "error should mention session cap"
+        );
+        assert!(
+            !rejected_bridge_dir.exists(),
+            "failed spawn should remove generated bridge directory"
         );
 
         // Cleanup: remove all 64 sessions
@@ -1369,7 +1401,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn kill_pty_advances_active_when_active_killed() {
+    async fn kill_pty_clears_active_when_active_killed() {
         let (app, _temp_dir) = create_test_app_with_cache();
         let handle = app.handle();
         let state = handle.state::<PtyState>();
@@ -1426,9 +1458,10 @@ mod tests {
         kill_pty(state.clone(), cache.clone(), kill_request)
             .expect("kill_pty should succeed");
 
-        // Verify active_session_id advanced to session-2
+        // Verify active_session_id is unresolved until the frontend persists
+        // its selected same-position neighbor via set_active_session.
         let snap_after = cache.snapshot();
-        assert_eq!(snap_after.active_session_id.as_deref(), Some("session-2"));
+        assert!(snap_after.active_session_id.is_none());
         assert_eq!(snap_after.session_order, vec!["session-2", "session-3"]);
 
         // Cleanup

--- a/src-tauri/src/terminal/state.rs
+++ b/src-tauri/src/terminal/state.rs
@@ -36,11 +36,20 @@ impl RingBuffer {
     /// the first appended byte in the lifetime stream).
     pub fn append(&mut self, chunk: &[u8]) -> u64 {
         let chunk_start = self.end_offset;
-        self.bytes.extend(chunk.iter().copied());
-        while self.bytes.len() > self.capacity {
-            self.bytes.pop_front();
+
+        let need_drain = self
+            .bytes
+            .len()
+            .saturating_add(chunk.len())
+            .saturating_sub(self.capacity);
+        if need_drain > 0 {
+            let drop_n = need_drain.min(self.bytes.len());
+            self.bytes.drain(..drop_n);
         }
-        self.end_offset += chunk.len() as u64;
+
+        let tail_start = chunk.len().saturating_sub(self.capacity);
+        self.bytes.extend(chunk[tail_start..].iter().copied());
+        self.end_offset = self.end_offset.wrapping_add(chunk.len() as u64);
         chunk_start
     }
 
@@ -329,9 +338,10 @@ impl PtyState {
             .map_err(|e| anyhow::anyhow!("failed to clone PTY reader: {}", e))
     }
 
-    /// Internal accessor for code that needs to take the sessions lock directly
-    /// (e.g., the read loop accessing the ring buffer atomically).
-    pub fn inner_sessions(&self) -> &Arc<Mutex<HashMap<SessionId, ManagedSession>>> {
+    /// Internal terminal-module accessor for code that must lock sessions
+    /// directly. Callers must take locks in sessions -> ring order and must
+    /// not call other `PtyState` methods while holding the sessions lock.
+    pub(crate) fn inner_sessions(&self) -> &Arc<Mutex<HashMap<SessionId, ManagedSession>>> {
         &self.sessions
     }
 }
@@ -389,6 +399,19 @@ mod tests {
         }
         assert_eq!(buf.end_offset(), 20);
         assert_eq!(buf.bytes_snapshot().len(), 4);
+    }
+
+    #[test]
+    fn ring_buffer_keeps_tail_of_oversize_chunk_without_exceeding_capacity() {
+        use super::RingBuffer;
+        let mut buf = RingBuffer::new(4);
+
+        let start = buf.append(b"abcdef");
+
+        assert_eq!(start, 0);
+        assert_eq!(buf.end_offset(), 6);
+        assert_eq!(buf.bytes_snapshot(), b"cdef");
+        assert!(buf.bytes.len() <= buf.capacity);
     }
 
     /// Build a real but ephemeral `ManagedSession` for tests that need

--- a/src/features/terminal/components/TerminalPane.tsx
+++ b/src/features/terminal/components/TerminalPane.tsx
@@ -339,7 +339,7 @@ export const TerminalPane = ({
       setTerminal(null)
       fitAddonRef.current = null
     }
-  }, [sessionId, service, isAwaitingRestart])
+  }, [sessionId, isAwaitingRestart])
 
   // Awaiting-restart: render a Restart affordance instead of an xterm.
   // Per the design spec ("no auto-respawn for Exited" IDEA), the user must

--- a/src/features/workspace/hooks/useSessionManager.test.ts
+++ b/src/features/workspace/hooks/useSessionManager.test.ts
@@ -733,10 +733,10 @@ describe('useSessionManager', () => {
   })
 
   // F4 (round 2): when the user closes the active middle tab, the hook
-  // promotes a neighbor in React state but the previous code never told
-  // Rust about it. Rust's kill_pty path rotates active to the FIRST
-  // remaining tab — so after reload the cache's restored selection
-  // diverged from where the UI actually moved.
+  // promotes a neighbor in React state and must persist that choice to Rust.
+  // Rust clears active_session_id when the active tab is killed, so the
+  // follow-up setActiveSession call is what makes reload restore the same tab
+  // the UI moved to.
   test('F4 (round 2): removeSession persists fallback active id when closing the active tab', async () => {
     const service = createMockService()
     service.listSessions = vi.fn().mockResolvedValue({
@@ -795,9 +795,8 @@ describe('useSessionManager', () => {
     // React state moved active to 'last' (Math.min(removedIndex=1, next.length-1=1)).
     await waitFor(() => expect(result.current.activeSessionId).toBe('last'))
 
-    // The IPC must echo the same choice. Without this, Rust's kill_pty
-    // rotates active to 'first' (cache.session_order[0]) and the next
-    // reload comes back with a different selection than the UI.
+    // The IPC must echo the same choice so reload comes back with the same
+    // selection as the UI.
     await waitFor(() =>
       expect(service.setActiveSession).toHaveBeenCalledWith('last')
     )

--- a/src/features/workspace/hooks/useSessionManager.ts
+++ b/src/features/workspace/hooks/useSessionManager.ts
@@ -771,12 +771,11 @@ export const useSessionManager = (
           unregisterPtySession(id)
 
           // F4 (round 2): when the user closes the ACTIVE tab and the hook
-          // promotes a neighbor, the cache must learn about it too. Without
-          // setActiveSession the Rust kill_pty path rotates active to the
-          // FIRST remaining tab (cache.session_order[0]) — but the React
-          // state moved to the index-aligned neighbor (Math.min(removedIndex,
-          // next.length - 1)). After reload the restored selection diverges
-          // from where the UI actually moved.
+          // promotes a neighbor, the cache must learn about it too. Rust
+          // clears active_session_id when the active tab is killed, while
+          // React state moves to the index-aligned neighbor (Math.min(
+          // removedIndex, next.length - 1)). Persisting the same choice keeps
+          // reload state aligned with where the UI moved.
           //
           // Derive the fallback inside the setSessions updater so the
           // computation matches the React-state branch and races with
@@ -814,8 +813,8 @@ export const useSessionManager = (
                 shouldUpdateActive = true
                 // next.length is 0 when the LAST tab was just removed; that's
                 // the only case fallback is null. Rust's kill_pty already
-                // cleared cache.active_session_id in that branch, so we don't
-                // fire a setActiveSession IPC for null.
+                // cleared cache.active_session_id for an active kill, so we
+                // don't fire a setActiveSession IPC for null.
                 computedFallback =
                   next.length === 0
                     ? null


### PR DESCRIPTION
## Summary

Bundles the seven deferred low-severity issues from past PR #86 / #99 review rounds into a single fix:

- **Closes #95** — `parse_numstat` checks `is_rename` before the binary marker and advances `i += 3` for binary renames so cursor alignment is preserved even if error-recovery is ever tightened.
- **Closes #97** — git watcher demotes `NotFound` errors during new-dir registration to `debug!` (keeps `warn!` for permission/inotify-limit errors).
- **Closes #101** — `kill_pty` sets `active_session_id = None` when the active tab is killed; the frontend remains authoritative for successor selection. Eliminates the cache/UI divergence and the mandatory follow-up IPC race window.
- **Closes #102** — `spawn_pty` cleans up the freshly-generated `.vimeflow/sessions/<uuid>/` directory on every error path (cap reached, duplicate id, write_cache failure, spawn / process-id / take_writer failures, shell-init parent missing).
- **Closes #103** — `RingBuffer::append` uses `drain` + tail-only extend, capping peak memory at `capacity` instead of 2× and replacing per-byte `pop_front` with one pointer-advance.
- **Closes #105** — `TerminalPane` xterm-setup effect drops unused `service` from its dependency array, preventing a future re-render cascade if the prop reference ever becomes unstable.
- **Closes #106** — `PtyState::inner_sessions` is now `pub(crate)` with a lock-ordering doc comment, scoping the deadlock-prone accessor to the terminal module.

## Test plan

- [x] `cargo test --lib` — 294 passed (includes 6 new regression tests covering issues #95, #97, #102, #103 and the renamed #101 test)
- [x] `npm run test` — 1512 passed across 105 test files
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [ ] Manual smoke test of kill-active-tab + reload (verify selection survives)
- [ ] `/harness-plugin:github-review` will run the cloud review cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)