### PR TITLE
fix(cleanup): batch low-severity issue fixes (#59, #92, #94, #96)

### DIFF
--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -236,6 +236,9 @@ pub struct WatcherHandle {
     _watcher: RecommendedWatcher,
     /// Signals the polling fallback thread to exit
     stop_flag: Arc<AtomicBool>,
+    /// Polling fallback thread. Stored so Drop can join after signalling
+    /// stop, rather than leaving the thread briefly detached.
+    join_handle: Option<std::thread::JoinHandle<()>>,
     /// Captured for diagnostic logging on drop. `#[cfg(debug_assertions)]`
     /// gates the FIELD itself so release builds skip the `String::clone`
     /// in the constructor — `cfg!()` on the read site alone left the
@@ -248,6 +251,9 @@ pub struct WatcherHandle {
 impl Drop for WatcherHandle {
     fn drop(&mut self) {
         self.stop_flag.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.join_handle.take() {
+            let _ = handle.join();
+        }
         // `#[cfg(...)]` (attribute) on a statement, NOT `if cfg!(...)`
         // (runtime). The attribute physically removes both the
         // statement and the `self.session_id` access in release builds,
@@ -503,7 +509,6 @@ pub fn start_watching(
         );
     })
     .map_err(|e| format!("failed to create watcher: {}", e))?;
-
     // Watch the parent directory (notify watches directories, not individual files)
     let parent_dir = status_file_path
         .parent()
@@ -557,7 +562,7 @@ pub fn start_watching(
     // Polling fallback — WSL2's inotify can miss events and Claude Code
     // may use atomic writes (rename). The stop_flag is set when the
     // WatcherHandle is dropped, causing the thread to exit cleanly.
-    {
+    let poll_join_handle = {
         let poll_sid = session_id.clone();
         let poll_path = status_file_path.clone();
         let poll_app = app_handle_for_poll;
@@ -565,7 +570,7 @@ pub fn start_watching(
         let poll_stop = stop_flag.clone();
         let poll_timing_for_thread = poll_timing.clone();
         let path_history_for_poll = path_history.clone();
-        std::thread::spawn(move || {
+        Some(std::thread::spawn(move || {
             while !poll_stop.load(Ordering::Relaxed) {
                 std::thread::sleep(std::time::Duration::from_secs(3));
                 if poll_stop.load(Ordering::Relaxed) {
@@ -618,8 +623,8 @@ pub fn start_watching(
                     tx_path.as_deref(),
                 );
             }
-        });
-    }
+        }))
+    };
 
     log::info!(
         "Started watching statusline for session {}: {}",
@@ -630,6 +635,7 @@ pub fn start_watching(
     Ok(WatcherHandle {
         _watcher: watcher,
         stop_flag,
+        join_handle: poll_join_handle,
         #[cfg(debug_assertions)]
         session_id: session_id.clone(),
     })

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+mod test_helpers;
 pub mod watcher;
 
 use serde::Serialize;
@@ -847,7 +849,12 @@ async fn get_untracked_numstat(
 
 /// Tauri command: Get diff for a specific file
 #[tauri::command]
-pub async fn get_git_diff(cwd: String, file: String, staged: bool) -> Result<FileDiff, String> {
+pub async fn get_git_diff(
+    cwd: String,
+    file: String,
+    staged: bool,
+    untracked: Option<bool>,
+) -> Result<FileDiff, String> {
     let safe_cwd = validate_cwd(&cwd)?;
     validate_file_path(&file)?;
 
@@ -916,10 +923,16 @@ pub async fn get_git_diff(cwd: String, file: String, staged: bool) -> Result<Fil
     // Skipped for staged == true: staged new files show up as status "A"
     // and `git diff --cached -- <file>` already produces correct output
     // for them. Only the untracked (status "??") path needs the fallback.
-    if parsed.hunks.is_empty()
-        && !staged
-        && is_file_untracked(&canonical_toplevel, &file).await?
-    {
+    let should_try_untracked_fallback = if parsed.hunks.is_empty() && !staged {
+        match untracked {
+            Some(value) => value,
+            None => is_file_untracked(&canonical_toplevel, &file).await?,
+        }
+    } else {
+        false
+    };
+
+    if should_try_untracked_fallback {
         let untracked_stdout = get_untracked_diff(&canonical_toplevel, &file).await?;
         return Ok(parse_git_diff(&untracked_stdout, &file));
     }
@@ -929,38 +942,8 @@ pub async fn get_git_diff(cwd: String, file: String, staged: bool) -> Result<Fil
 
 #[cfg(test)]
 mod tests {
+    use super::test_helpers::{configure_test_git, home_tempdir};
     use super::*;
-
-    /// Create a tempdir inside `$HOME` so `validate_cwd`'s
-    /// `ensure_within_home` check passes. The default `tempfile::tempdir()`
-    /// lives in `/tmp` which is outside `$HOME` on every supported platform,
-    /// and the validation in production code would reject the path before
-    /// any git subprocess runs. Tests that exercise the `git_status` /
-    /// `get_git_diff` commands must use this helper instead.
-    fn home_tempdir() -> tempfile::TempDir {
-        let home = dirs::home_dir().expect("no home directory");
-        tempfile::Builder::new()
-            .prefix("vimeflow-git-test-")
-            .tempdir_in(&home)
-            .expect("failed to create temp dir under $HOME")
-    }
-
-    /// Configure `user.email` and `user.name` on a fresh git repo so
-    /// `git commit` doesn't fail on CI runners without a global git
-    /// config. Call this after `git init`, before any `git commit`.
-    fn configure_test_git(repo_path: &std::path::Path) {
-        use std::process::Command;
-        for (key, val) in &[
-            ("user.email", "test@example.com"),
-            ("user.name", "Test User"),
-        ] {
-            Command::new("git")
-                .args(["config", key, val])
-                .current_dir(repo_path)
-                .output()
-                .expect("git config failed");
-        }
-    }
 
     // parse_numstat tests
 
@@ -1473,7 +1456,7 @@ mod tests {
 
         // Call get_git_diff from the subdirectory with file path "sub/foo.ts"
         let subdir_str = subdir.to_string_lossy().to_string();
-        let result = get_git_diff(subdir_str, "sub/foo.ts".to_string(), false).await;
+        let result = get_git_diff(subdir_str, "sub/foo.ts".to_string(), false, None).await;
 
         assert!(result.is_ok(), "get_git_diff should succeed from subdir");
         let diff = result.unwrap();
@@ -1500,7 +1483,7 @@ mod tests {
         let tmp = home_tempdir();
         let non_repo = tmp.path().to_string_lossy().to_string();
 
-        let result = get_git_diff(non_repo, "foo.txt".to_string(), false).await;
+        let result = get_git_diff(non_repo, "foo.txt".to_string(), false, None).await;
 
         assert!(result.is_ok(), "non-repo should return Ok, not error");
         let diff = result.unwrap();
@@ -1578,7 +1561,8 @@ mod tests {
         fs::write(&untracked, "alpha\nbeta\ngamma\n").expect("failed to write");
 
         let repo_str = repo_path.to_string_lossy().to_string();
-        let result = get_git_diff(repo_str, "untracked.txt".to_string(), false).await;
+        let result =
+            get_git_diff(repo_str, "untracked.txt".to_string(), false, Some(true)).await;
 
         assert!(
             result.is_ok(),

--- a/src-tauri/src/git/test_helpers.rs
+++ b/src-tauri/src/git/test_helpers.rs
@@ -1,0 +1,33 @@
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Create a tempdir inside `$HOME` so `validate_cwd`'s
+/// `ensure_within_home` check passes. The default `tempfile::tempdir()`
+/// lives in `/tmp` which is outside `$HOME` on every supported platform,
+/// and the validation in production code would reject the path before
+/// any git subprocess runs. Tests that exercise git Tauri commands must
+/// use this helper instead.
+pub fn home_tempdir() -> TempDir {
+    let home = dirs::home_dir().expect("no home directory");
+    tempfile::Builder::new()
+        .prefix("vimeflow-git-test-")
+        .tempdir_in(&home)
+        .expect("failed to create temp dir under $HOME")
+}
+
+/// Configure `user.email` and `user.name` on a fresh git repo so
+/// `git commit` doesn't fail on CI runners without a global git config.
+pub fn configure_test_git(repo_path: &Path) {
+    for (key, val) in &[
+        ("user.email", "test@example.com"),
+        ("user.name", "Test User"),
+    ] {
+        Command::new("git")
+            .args(["config", key, val])
+            .current_dir(repo_path)
+            .output()
+            .expect("git config failed");
+    }
+}

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -331,9 +331,9 @@ pub async fn start_git_watcher(
 /// Synchronous core of `start_git_watcher`. Called by both the Tauri command and
 /// the pre-repo upgrade path — works against a cloneable `&GitWatcherState` so it
 /// doesn't require a `tauri::State` handle.
-fn start_git_watcher_inner(
+fn start_git_watcher_inner<R: tauri::Runtime>(
     cwd: &str,
-    app_handle: tauri::AppHandle,
+    app_handle: tauri::AppHandle<R>,
     state: &GitWatcherState,
 ) -> Result<(), String> {
     let safe_cwd = validate_cwd(cwd)?;
@@ -657,10 +657,10 @@ fn start_git_watcher_inner(
 /// used in event payloads) and the canonicalized `safe_cwd` PathBuf (map
 /// key, used for dedup when multiple callers watch the same dir via
 /// different spellings).
-fn start_pre_repo_watcher_inner(
+fn start_pre_repo_watcher_inner<R: tauri::Runtime>(
     cwd: &str,
     safe_cwd: PathBuf,
-    app_handle: tauri::AppHandle,
+    app_handle: tauri::AppHandle<R>,
     state: &GitWatcherState,
 ) -> Result<(), String> {
     let mut pre_repo_watchers = state.pre_repo_watchers.lock()
@@ -760,9 +760,9 @@ fn start_pre_repo_watcher_inner(
 /// the upgrade. Previously this used `cwd.to_string_lossy()` (the
 /// canonical form), stranding any frontend that had subscribed with a
 /// symlinked or non-canonical path.
-fn upgrade_to_repo_watcher(
+fn upgrade_to_repo_watcher<R: tauri::Runtime>(
     safe_cwd: PathBuf,
-    app_handle: tauri::AppHandle,
+    app_handle: tauri::AppHandle<R>,
     state: GitWatcherState,
 ) -> Result<(), String> {
     // Collect the subscribers (original-cwd → refcount) from the pre-repo
@@ -798,12 +798,49 @@ fn upgrade_to_repo_watcher(
     // and the caller sees a combined error describing all failures.
     let mut errors: Vec<String> = Vec::new();
     for (original_cwd, refcount) in subscribers {
-        for _ in 0..refcount {
-            if let Err(e) =
-                start_git_watcher_inner(&original_cwd, app_handle.clone(), &state)
-            {
-                errors.push(format!("{}: {}", original_cwd, e));
-                break; // don't retry the same cwd if it's fundamentally broken
+        if refcount == 0 {
+            continue;
+        }
+
+        if let Err(e) = start_git_watcher_inner(&original_cwd, app_handle.clone(), &state) {
+            errors.push(format!("{}: {}", original_cwd, e));
+            continue;
+        }
+
+        // `start_git_watcher_inner` emits an initial refresh event on every
+        // call. During a pre-repo -> repo upgrade, a refcount > 1 means
+        // duplicate subscriptions for the SAME original cwd, not distinct
+        // listeners that need separate bootstrap events. Start once, then
+        // restore the remaining count directly under the repo watcher so
+        // the frontend receives one initial event instead of N.
+        if refcount > 1 {
+            let toplevel = state
+                .cwd_to_toplevel
+                .lock()
+                .map_err(|e| format!("Failed to lock cwd_to_toplevel: {}", e))?
+                .get(&original_cwd)
+                .cloned();
+
+            match toplevel {
+                Some(toplevel) => {
+                    let mut repo_watchers = state
+                        .repo_watchers
+                        .lock()
+                        .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
+                    if let Some(watcher) = repo_watchers.get_mut(&toplevel) {
+                        *watcher.subscribers.entry(original_cwd.clone()).or_insert(0) +=
+                            refcount - 1;
+                    } else {
+                        errors.push(format!(
+                            "{}: repo watcher missing after successful upgrade",
+                            original_cwd
+                        ));
+                    }
+                }
+                None => errors.push(format!(
+                    "{}: toplevel mapping missing after successful upgrade",
+                    original_cwd
+                )),
             }
         }
     }
@@ -941,8 +978,8 @@ fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), Str
 }
 
 /// Emit git-status-changed event for all subscribers of a repo
-fn emit_for_all_subscribers(
-    app_handle: &tauri::AppHandle,
+fn emit_for_all_subscribers<R: tauri::Runtime>(
+    app_handle: &tauri::AppHandle<R>,
     state: &GitWatcherState,
     toplevel: &std::path::Path,
 ) {
@@ -964,7 +1001,10 @@ fn emit_for_all_subscribers(
 }
 
 /// Emit a git-status-changed event
-fn emit_git_status_changed(app_handle: &tauri::AppHandle, cwds: Vec<String>) {
+fn emit_git_status_changed<R: tauri::Runtime>(
+    app_handle: &tauri::AppHandle<R>,
+    cwds: Vec<String>,
+) {
     let payload = GitStatusChangedPayload { cwds };
 
     if let Err(e) = app_handle.emit("git-status-changed", payload) {
@@ -974,14 +1014,17 @@ fn emit_git_status_changed(app_handle: &tauri::AppHandle, cwds: Vec<String>) {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_helpers::{configure_test_git, home_tempdir};
     use super::*;
     use std::fs;
     use std::process::Command;
+    use std::sync::{Arc, Mutex};
+    use tauri::Listener;
     use tempfile::TempDir;
 
     /// Create a temp git repo for testing
     fn create_temp_repo() -> TempDir {
-        let temp = TempDir::new().expect("failed to create temp dir");
+        let temp = home_tempdir();
 
         Command::new("git")
             .args(["init"])
@@ -989,19 +1032,69 @@ mod tests {
             .output()
             .expect("failed to run git init");
 
-        Command::new("git")
-            .args(["config", "user.email", "test@example.com"])
-            .current_dir(temp.path())
-            .output()
-            .expect("failed to configure git");
-
-        Command::new("git")
-            .args(["config", "user.name", "Test User"])
-            .current_dir(temp.path())
-            .output()
-            .expect("failed to configure git");
+        configure_test_git(temp.path());
 
         temp
+    }
+
+    #[test]
+    fn upgrade_to_repo_watcher_emits_once_for_duplicate_original_cwd() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::generate_context!())
+            .expect("failed to build test app");
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let received_for_listener = received.clone();
+
+        app.handle().listen("git-status-changed", move |event| {
+            received_for_listener
+                .lock()
+                .expect("failed to lock received events")
+                .push(event.payload().to_string());
+        });
+
+        let temp = create_temp_repo();
+        let cwd = temp.path().to_string_lossy().to_string();
+        let safe_cwd = validate_cwd(&cwd).expect("cwd should validate");
+        let state = GitWatcherState::new();
+        let mut subscribers = HashMap::new();
+
+        subscribers.insert(cwd.clone(), 3);
+        state
+            .pre_repo_watchers
+            .lock()
+            .expect("failed to lock pre_repo_watchers")
+            .insert(
+                safe_cwd.clone(),
+                PreRepoWatcher {
+                    subscribers,
+                    stop_flag: Arc::new(AtomicBool::new(false)),
+                },
+            );
+
+        let result = upgrade_to_repo_watcher(safe_cwd, app.handle().clone(), state.clone());
+
+        assert!(result.is_ok(), "upgrade should succeed: {:?}", result.err());
+
+        let toplevel = resolve_toplevel(temp.path()).expect("repo should resolve");
+        let toplevel_key =
+            validate_cwd(&toplevel.to_string_lossy()).expect("toplevel should validate");
+        let repo_watchers = state
+            .repo_watchers
+            .lock()
+            .expect("failed to lock repo_watchers");
+        let watcher = repo_watchers
+            .get(&toplevel_key)
+            .expect("repo watcher should exist");
+
+        assert_eq!(watcher.subscribers.get(&cwd), Some(&3));
+        drop(repo_watchers);
+
+        std::thread::sleep(Duration::from_millis(100));
+
+        let events = received.lock().expect("failed to lock received events");
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].contains(&cwd));
     }
 
     #[test]

--- a/src-tauri/src/terminal/commands.rs
+++ b/src-tauri/src/terminal/commands.rs
@@ -185,7 +185,8 @@ pub async fn spawn_pty<R: tauri::Runtime>(
         if let Err(e) = std::fs::write(&rcfile_path, &rcfile_content) {
             log::warn!("Failed to write combined bashrc: {}", e);
         } else if shell.contains("bash") {
-            cmd.args(["--rcfile", &rcfile_path.to_string_lossy()]);
+            cmd.arg("--rcfile");
+            cmd.arg(rcfile_path.as_os_str());
         }
 
         log::info!("Injected claude wrapper for session {}", request.session_id);

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -171,7 +171,8 @@ describe('DiffPanelContent', () => {
     expect(useFileDiffSpy).toHaveBeenCalledWith(
       null,
       false,
-      '/home/user/project'
+      '/home/user/project',
+      undefined
     )
   })
 
@@ -212,7 +213,12 @@ describe('DiffPanelContent', () => {
       )
 
       // useFileDiff should be called with null (selection ignored)
-      expect(useFileDiffSpy).toHaveBeenCalledWith(null, false, '/repo/b')
+      expect(useFileDiffSpy).toHaveBeenCalledWith(
+        null,
+        false,
+        '/repo/b',
+        undefined
+      )
     })
 
     test('auto-select gated on filesCwd: only fires when filesCwd matches cwd', (): void => {
@@ -420,8 +426,13 @@ describe('DiffPanelContent', () => {
       expect(screen.queryByText('New file — not yet tracked')).toBeNull()
       // DiffViewer (unified) is rendered instead
       expect(screen.getByTestId('unified-pane')).toBeInTheDocument()
-      // useFileDiff was called with the path and staged flag
-      expect(useFileDiffSpy).toHaveBeenCalledWith('new.ts', false, '/repo')
+      // useFileDiff was called with the path, staged flag, cwd, and status hint
+      expect(useFileDiffSpy).toHaveBeenCalledWith(
+        'new.ts',
+        false,
+        '/repo',
+        true
+      )
     })
   })
 
@@ -455,7 +466,12 @@ describe('DiffPanelContent', () => {
       render(<DiffPanelContent cwd="/repo" />)
 
       // Should auto-select first file (via local state)
-      expect(useFileDiffSpy).toHaveBeenCalledWith('src/App.tsx', false, '/repo')
+      expect(useFileDiffSpy).toHaveBeenCalledWith(
+        'src/App.tsx',
+        false,
+        '/repo',
+        false
+      )
     })
 
     test('cwd guard works in uncontrolled mode', (): void => {
@@ -494,7 +510,7 @@ describe('DiffPanelContent', () => {
       const calls = useFileDiffSpy.mock.calls
       // Last call should be with the correct file after auto-select
       const lastCall = calls[calls.length - 1]
-      expect(lastCall).toEqual(['src/App.tsx', false, '/repo/b'])
+      expect(lastCall).toEqual(['src/App.tsx', false, '/repo/b', false])
     })
   })
 })

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -153,11 +153,21 @@ export const DiffPanelContent = ({
   const selectedFilePath = selectedFileEntry?.path ?? null
   const selectedFileStaged = selectedFileEntry?.staged ?? false
 
+  const selectedFileUntracked =
+    selectedFileEntry === undefined
+      ? undefined
+      : selectedFileEntry.status === 'untracked'
+
   const {
     diff,
     loading: diffLoading,
     error: diffError,
-  } = useFileDiff(selectedFilePath, selectedFileStaged, cwd)
+  } = useFileDiff(
+    selectedFilePath,
+    selectedFileStaged,
+    cwd,
+    selectedFileUntracked
+  )
 
   // Loading state
   if (effectiveStatusLoading) {

--- a/src/features/diff/hooks/useFileDiff.ts
+++ b/src/features/diff/hooks/useFileDiff.ts
@@ -13,11 +13,13 @@ interface UseFileDiffReturn {
  * @param filePath - Path to the file
  * @param staged - Whether to fetch staged or unstaged diff
  * @param cwd - Working directory for git commands
+ * @param untracked - Whether the selected file is known to be untracked
  */
 export const useFileDiff = (
   filePath: string | null,
   staged = false,
-  cwd = '.'
+  cwd = '.',
+  untracked?: boolean
 ): UseFileDiffReturn => {
   const [diff, setDiff] = useState<FileDiff | null>(null)
   const [loading, setLoading] = useState(false)
@@ -41,7 +43,7 @@ export const useFileDiff = (
         setError(null)
 
         const service = createGitService(cwd)
-        const fileDiff = await service.getDiff(filePath, staged)
+        const fileDiff = await service.getDiff(filePath, staged, untracked)
 
         if (!cancelled) {
           setDiff(fileDiff)
@@ -67,7 +69,7 @@ export const useFileDiff = (
     return (): void => {
       cancelled = true
     }
-  }, [filePath, staged, cwd])
+  }, [filePath, staged, untracked, cwd])
 
   return {
     diff,

--- a/src/features/diff/services/gitService.test.ts
+++ b/src/features/diff/services/gitService.test.ts
@@ -139,6 +139,21 @@ describe('HttpGitService', () => {
       )
     })
 
+    test('includes untracked parameter when provided', async () => {
+      const file = 'src/components/NavBar.tsx'
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockFileDiffs[file]),
+      })
+
+      await service.getDiff(file, false, true)
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/git/diff?file=${encodeURIComponent(file)}&staged=false&untracked=true`
+      )
+    })
+
     test('throws error on failed request', async () => {
       fetchMock.mockResolvedValueOnce({
         ok: false,
@@ -324,6 +339,20 @@ describe('TauriGitService', () => {
         cwd: '/home/user/project',
         file: 'src/components/NavBar.tsx',
         staged: true,
+      })
+    })
+
+    test('passes untracked flag to get_git_diff', async () => {
+      const mockDiff = mockFileDiffs['src/components/NavBar.tsx']
+      invokeMock.mockResolvedValueOnce(mockDiff)
+
+      await service.getDiff('src/components/NavBar.tsx', false, true)
+
+      expect(invokeMock).toHaveBeenCalledWith('get_git_diff', {
+        cwd: '/home/user/project',
+        file: 'src/components/NavBar.tsx',
+        staged: false,
+        untracked: true,
       })
     })
 

--- a/src/features/diff/services/gitService.ts
+++ b/src/features/diff/services/gitService.ts
@@ -8,7 +8,11 @@ export interface GitService {
   getStatus(): Promise<ChangedFile[]>
 
   /** Get diff for a specific file */
-  getDiff(file: string, staged?: boolean): Promise<FileDiff>
+  getDiff(
+    file: string,
+    staged?: boolean,
+    untracked?: boolean
+  ): Promise<FileDiff>
 
   /** Stage a file or specific hunk */
   stageFile(file: string, hunkIndex?: number): Promise<void>
@@ -59,8 +63,15 @@ export class HttpGitService implements GitService {
     return response.json() as Promise<ChangedFile[]>
   }
 
-  async getDiff(file: string, staged = false): Promise<FileDiff> {
+  async getDiff(
+    file: string,
+    staged = false,
+    untracked?: boolean
+  ): Promise<FileDiff> {
     const params = new URLSearchParams({ file, staged: String(staged) })
+    if (untracked !== undefined) {
+      params.set('untracked', String(untracked))
+    }
     const response = await fetch(`/api/git/diff?${params}`)
 
     if (!response.ok) {
@@ -127,13 +138,20 @@ export class TauriGitService implements GitService {
     }
   }
 
-  async getDiff(file: string, staged = false): Promise<FileDiff> {
+  async getDiff(
+    file: string,
+    staged = false,
+    untracked?: boolean
+  ): Promise<FileDiff> {
     try {
-      return await invoke<FileDiff>('get_git_diff', {
+      const args = {
         cwd: this.cwd,
         file,
         staged,
-      })
+        ...(untracked !== undefined ? { untracked } : {}),
+      }
+
+      return await invoke<FileDiff>('get_git_diff', args)
     } catch (error) {
       throw new Error(`Failed to get diff for ${file}: ${String(error)}`)
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -144,6 +144,10 @@ function gitApiPlugin(): Plugin {
           if (pathname === '/api/git/diff' && req.method === 'GET') {
             const file = url.searchParams.get('file')
             const staged = url.searchParams.get('staged') === 'true'
+            const untrackedParam = url.searchParams.get('untracked')
+
+            const untracked =
+              untrackedParam === null ? undefined : untrackedParam === 'true'
 
             if (!file) {
               res.writeHead(400, { 'Content-Type': 'application/json' })
@@ -173,14 +177,18 @@ function gitApiPlugin(): Plugin {
             }
 
             // Handle untracked files — git diff won't show them
-            if (!diff) {
-              const status = await git.status()
-              const fileStatus = status.files.find((f) => f.path === safePath)
+            if (!diff && untracked !== false) {
+              let shouldUseUntrackedFallback = untracked === true
+              if (!shouldUseUntrackedFallback) {
+                const status = await git.status()
+                const fileStatus = status.files.find((f) => f.path === safePath)
 
-              if (
-                fileStatus &&
-                (fileStatus.index === '?' || fileStatus.working_dir === '?')
-              ) {
+                shouldUseUntrackedFallback =
+                  fileStatus !== undefined &&
+                  (fileStatus.index === '?' || fileStatus.working_dir === '?')
+              }
+
+              if (shouldUseUntrackedFallback) {
                 // Generate diff for untracked file using --no-index
                 const { spawnSync } = await import('child_process')
 


### PR DESCRIPTION
## Summary

- join the agent status polling fallback thread on watcher drop and pass bash `--rcfile` as an `OsStr`
- avoid duplicate git watcher bootstrap events when a pre-repo watcher with duplicate refcounts upgrades to a repo watcher
- share git test helpers so watcher tests create repos under `$HOME`
- pass the known untracked status through the diff UI/service/API path to skip redundant runtime `git ls-files` checks

## Issues

Closes #59
Closes #92
Closes #94
Closes #96

## Validation

- `HOME=/tmp/vimeflow-test-home RUSTUP_HOME=/home/will/.rustup CARGO_HOME=/home/will/.cargo cargo test --offline --lib` (`295 passed`)
- `./node_modules/.bin/vitest --run src/features/diff/services/gitService.test.ts src/features/diff/hooks/useFileDiff.test.ts src/features/diff/components/DiffPanelContent.test.tsx` (`54 passed`)
- `./node_modules/.bin/tsc -b`
- targeted ESLint on touched frontend files and `vite.config.ts`
- Prettier check on touched TypeScript files
- `git diff --check`
