### PR TITLE
feat(workspace): move StatusCard to sidebar header; git-diff lines in footer

### DIFF
--- a/docs/superpowers/plans/2026-04-30-sidebar-status-header-plan.md
+++ b/docs/superpowers/plans/2026-04-30-sidebar-status-header-plan.md
@@ -515,21 +515,51 @@ Add `agentStatus={inactiveAgentStatus}` to every other `render(<Sidebar … />)`
 
 - [ ] **Step 3: Update `AgentStatusPanel.test.tsx`**
 
-Drop any `vi.mock('../hooks/useAgentStatus')` block.
+The existing test file (verified at the time of writing the plan) mocks `useAgentStatus` at module scope and overrides it per-test via `vi.mocked(useAgentStatus).mockReturnValue(...)` to flip `isActive` between true/false for the 0px-width / 280px-width / ease-in / ease-out cases. There is also a `passes sessionId to useAgentStatus` test (around lines 112-119). All of this becomes obsolete because the panel no longer calls the hook — it accepts `agentStatus` as a prop.
 
-Add the active-status fixture at the top:
+Make the following edits:
+
+**a)** Delete the module-level `vi.mock('../hooks/useAgentStatus', …)` block and the `defaultStatus` fixture's reuse. The hook is no longer called from this component.
+
+**b)** Delete the `passes sessionId to useAgentStatus` test entirely. It asserts a hook call that no longer happens.
+
+**c)** Replace `defaultProps`. Drop the `sessionId` field; the prop no longer exists. Other props are unchanged:
+
+```tsx
+const defaultProps = {
+  cwd: '/test',
+  onOpenDiff: vi.fn(),
+}
+```
+
+**d)** Add **two** fixtures (active and inactive — both are needed because existing tests cover both states):
 
 ```tsx
 import type { AgentStatus } from '../types'
 
+const inactiveAgentStatus: AgentStatus = {
+  isActive: false,
+  agentType: null,
+  modelId: null,
+  modelDisplayName: null,
+  version: null,
+  sessionId: null,
+  agentSessionId: null,
+  contextWindow: null,
+  cost: null,
+  rateLimits: null,
+  toolCalls: { total: 0, byType: {}, active: null },
+  recentToolCalls: [],
+  testRun: null,
+}
+
 const activeAgentStatus: AgentStatus = {
+  ...inactiveAgentStatus,
   isActive: true,
   agentType: 'claude-code',
   modelId: 'claude-3-5-sonnet-20241022',
   modelDisplayName: 'Claude 3.5 Sonnet',
-  version: null,
   sessionId: 'sess-1',
-  agentSessionId: null,
   contextWindow: {
     usedPercentage: 12,
     contextWindowSize: 200_000,
@@ -544,14 +574,58 @@ const activeAgentStatus: AgentStatus = {
     totalLinesAdded: 0,
     totalLinesRemoved: 0,
   },
-  rateLimits: null,
-  toolCalls: { total: 0, byType: {}, active: null },
-  recentToolCalls: [],
-  testRun: null,
 }
 ```
 
-Replace any `sessionId="…"` prop on `<AgentStatusPanel>` with `agentStatus={activeAgentStatus}` (drop `sessionId` — the panel no longer accepts it).
+**e)** Convert each existing test that previously called `vi.mocked(useAgentStatus).mockReturnValue(...)` to instead pass `agentStatus={…}` directly. Mapping:
+
+| Old pattern                                                                                                                         | New pattern                         |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `mockReturnValue({ ...defaultStatus, isActive: false })` + `sessionId={null}`                                                       | `agentStatus={inactiveAgentStatus}` |
+| `mockReturnValue({ ...defaultStatus, isActive: true, agentType: 'claude-code', sessionId: 'session-1' })` + `sessionId="session-1"` | `agentStatus={activeAgentStatus}`   |
+| `mockReturnValue(defaultStatus)` (the default — inactive) + any `sessionId`                                                         | `agentStatus={inactiveAgentStatus}` |
+
+Concretely, after editing, the existing tests look like:
+
+```tsx
+test('renders at 0px width when agent is not active', () => {
+  render(
+    <AgentStatusPanel {...defaultProps} agentStatus={inactiveAgentStatus} />
+  )
+  const panel = screen.getByTestId('agent-status-panel')
+  expect(panel.style.width).toBe('0px')
+})
+
+test('renders at 280px width when agent is active', () => {
+  render(<AgentStatusPanel {...defaultProps} agentStatus={activeAgentStatus} />)
+  const panel = screen.getByTestId('agent-status-panel')
+  expect(panel.style.width).toBe('280px')
+})
+
+test('applies ease-out transition when collapsing', () => {
+  render(
+    <AgentStatusPanel {...defaultProps} agentStatus={inactiveAgentStatus} />
+  )
+  const panel = screen.getByTestId('agent-status-panel')
+  expect(panel.style.transition).toBe('width 200ms ease-out')
+})
+
+test('applies ease-in transition when expanding', () => {
+  render(<AgentStatusPanel {...defaultProps} agentStatus={activeAgentStatus} />)
+  const panel = screen.getByTestId('agent-status-panel')
+  expect(panel.style.transition).toBe('width 200ms ease-in')
+})
+
+test('has overflow-hidden to clip content during collapse', () => {
+  render(
+    <AgentStatusPanel {...defaultProps} agentStatus={inactiveAgentStatus} />
+  )
+  const panel = screen.getByTestId('agent-status-panel')
+  expect(panel).toHaveClass('overflow-hidden')
+})
+```
+
+The tests are now synchronous (no `await import`, no per-test mock setup), which is a side benefit.
 
 Mock `useGitStatus` (which the panel still calls):
 
@@ -917,14 +991,16 @@ export interface SidebarProps {
 
 **b)** Destructure `agentStatus` in the component signature, alongside the other props.
 
-**c)** Import `SidebarStatusHeader` and replace the hardcoded "Agent header" block (lines roughly 222-240, the `<div className="flex items-center gap-3 px-4 py-4">…"Agent Alpha"…"System Idle"…</div>`):
+**c)** Add the `SidebarStatusHeader` import alongside the existing imports at the top of `Sidebar.tsx`:
 
 ```tsx
 import { SidebarStatusHeader } from './SidebarStatusHeader'
+```
 
-// …
+**d)** Replace the hardcoded "Agent header" block (lines roughly 222-240, the `<div className="flex items-center gap-3 px-4 py-4">…"Agent Alpha"…"System Idle"…</div>`) with this JSX inside the existing return statement (no leading semicolon — this is JSX nested inside the existing return, not a new top-level statement):
 
-;<div className="px-3 pt-3 pb-2">
+```jsx
+<div className="px-3 pt-3 pb-2">
   <SidebarStatusHeader
     status={agentStatus}
     activeSessionName={
@@ -935,6 +1011,8 @@ import { SidebarStatusHeader } from './SidebarStatusHeader'
 ```
 
 The `"Active Sessions"` heading + `<Reorder.Group>` + everything below remain unchanged.
+
+> **Heads-up on prettier behavior:** the project uses no-semi prettier. If you copy a code-fenced block that starts with a JSX element into a TS source file at top-level, prettier may insert a leading semicolon (`;<div>…</div>`) to disambiguate from the previous statement. That's a hint your paste landed at the wrong scope — this snippet is meant to be placed _inside_ `Sidebar`'s existing return JSX, not as a top-level statement. If you see prettier add a leading `;`, undo and re-paste at the correct nesting level.
 
 - [ ] **Step 9: Update `AgentStatusPanel.tsx`**
 
@@ -1143,7 +1221,7 @@ git add \
   src/features/workspace/WorkspaceView.test.tsx \
   src/features/workspace/WorkspaceView.subscription.test.tsx
 git commit -m "$(cat <<'EOF'
-feat(workspace): move StatusCard render-site to Sidebar; re-source ActivityFooter lines from git diff
+feat(workspace): move StatusCard to sidebar header; git-diff lines in footer
 
 - Lift useAgentStatus to WorkspaceView; pass agentStatus to both Sidebar
   and AgentStatusPanel (one Tauri subscription, asserted via reference

--- a/docs/superpowers/plans/2026-04-30-sidebar-status-header-plan.md
+++ b/docs/superpowers/plans/2026-04-30-sidebar-status-header-plan.md
@@ -1,0 +1,1273 @@
+# Sidebar Status Header Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the live `<StatusCard>` render-site from `<AgentStatusPanel>` (right side) into a new `<SidebarStatusHeader>` at the top of the left Sidebar; re-source `<ActivityFooter>` line totals from the same git-diff data that powers `<FilesChanged>`; drop the hardcoded `0 turns` span.
+
+**Architecture:** Lift `useAgentStatus(activeSessionId)` from `<AgentStatusPanel>` to `<WorkspaceView>` so both the new sidebar header and the activity panel read from one Tauri subscription. New `<SidebarStatusHeader>` (in `workspace/components/`) renders the existing `<StatusCard>` (which stays in `agent-status/components/`) when the agent is active, and an idle-state placeholder when not. Footer line totals computed via a new pure `sumLines` util over `useGitStatus`'s `effectiveFiles`. Raise `SIDEBAR_MIN` from 180 → 240 so the StatusCard's fixed `grid-cols-2` `<BudgetMetrics>` does not overflow at the narrowest sidebar width.
+
+**Tech Stack:** React 19, TypeScript, Vitest + testing-library, Tailwind (Catppuccin tokens), Tauri (event subscriptions, no Rust changes in this plan).
+
+**Spec:** `docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+
+- `src/features/diff/utils/sumLines.ts` — pure util summing `insertions` / `deletions` across `ChangedFile[]`
+- `src/features/diff/utils/sumLines.test.ts` — unit tests for the util
+- `src/features/workspace/components/SidebarStatusHeader.tsx` — switches between `<StatusCard>` and an idle placeholder
+- `src/features/workspace/components/SidebarStatusHeader.test.tsx` — tests both states + the null-session fallback
+
+**Modified files:**
+
+- `src/features/agent-status/components/ActivityFooter.tsx` — drop `turnCount` prop, render two cells (duration + lines)
+- `src/features/agent-status/components/ActivityFooter.test.tsx` — drop turnCount fixtures and assertions
+- `src/features/workspace/components/Sidebar.tsx` — accept `agentStatus`, render `<SidebarStatusHeader>` in place of the hardcoded "Agent Alpha" block
+- `src/features/workspace/components/Sidebar.test.tsx` — replace "Agent Alpha" assertions with header-delegation assertions
+- `src/features/agent-status/components/AgentStatusPanel.tsx` — accept `agentStatus` prop instead of calling `useAgentStatus`; drop `<StatusCard>` render; pipe `effectiveFiles` through `sumLines` into the footer
+- `src/features/agent-status/components/AgentStatusPanel.test.tsx` — pass `agentStatus` as a prop instead of mocking the hook; assert `<StatusCard>` is no longer rendered inside the panel; assert footer line totals from a mock `useGitStatus`
+- `src/features/workspace/WorkspaceView.tsx` — call `useAgentStatus(activeSessionId)` once, fan out to both `<Sidebar>` and `<AgentStatusPanel>`; raise `SIDEBAR_MIN` from 180 to 240
+- `src/features/workspace/WorkspaceView.test.tsx` — assert the lifted hook's latest-call arg and prop fan-out
+
+**Untouched (verification only):**
+
+- `src/features/agent-status/components/StatusCard.tsx` — no source edit, no file move
+- `src/features/agent-status/components/StatusCard.test.tsx` — no change
+- `src/features/agent-status/components/BudgetMetrics.tsx` / `.test.tsx` — no change
+- `src/features/agent-status/hooks/useAgentStatus.ts` — no change
+
+---
+
+## Task 1: `sumLines` util
+
+**Files:**
+
+- Create: `src/features/diff/utils/sumLines.ts`
+- Create: `src/features/diff/utils/sumLines.test.ts`
+
+- [ ] **Step 1: Make the `utils` directory and write the failing test**
+
+```bash
+mkdir -p src/features/diff/utils
+```
+
+Write `src/features/diff/utils/sumLines.test.ts`:
+
+```ts
+import { describe, expect, test } from 'vitest'
+import type { ChangedFile } from '../types'
+import { sumLines } from './sumLines'
+
+const file = (overrides: Partial<ChangedFile>): ChangedFile => ({
+  path: 'src/x.ts',
+  status: 'modified',
+  staged: false,
+  ...overrides,
+})
+
+describe('sumLines', () => {
+  test('returns zeros for an empty list', () => {
+    expect(sumLines([])).toEqual({ added: 0, removed: 0 })
+  })
+
+  test('sums insertions and deletions across files', () => {
+    const files: ChangedFile[] = [
+      file({ insertions: 12, deletions: 3 }),
+      file({ insertions: 0, deletions: 8 }),
+      file({ insertions: 4, deletions: 4 }),
+    ]
+    expect(sumLines(files)).toEqual({ added: 16, removed: 15 })
+  })
+
+  test('treats undefined insertions / deletions as zero', () => {
+    const files: ChangedFile[] = [
+      file({ insertions: 5, deletions: 2 }),
+      file({}), // both stat counts absent (untracked file with no diff stat)
+      file({ insertions: undefined, deletions: 7 }),
+    ]
+    expect(sumLines(files)).toEqual({ added: 5, removed: 9 })
+  })
+
+  test('handles a single file', () => {
+    expect(sumLines([file({ insertions: 9, deletions: 1 })])).toEqual({
+      added: 9,
+      removed: 1,
+    })
+  })
+
+  test('large counts sum without precision issues', () => {
+    const files: ChangedFile[] = Array.from({ length: 200 }, () =>
+      file({ insertions: 10_000, deletions: 5_000 })
+    )
+    expect(sumLines(files)).toEqual({ added: 2_000_000, removed: 1_000_000 })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run src/features/diff/utils/sumLines.test.ts
+```
+
+Expected: FAIL with `Cannot find module './sumLines'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Write `src/features/diff/utils/sumLines.ts`:
+
+```ts
+import type { ChangedFile } from '../types'
+
+export interface LineTotals {
+  added: number
+  removed: number
+}
+
+export const sumLines = (files: ChangedFile[]): LineTotals =>
+  files.reduce<LineTotals>(
+    (acc, f) => ({
+      added: acc.added + (f.insertions ?? 0),
+      removed: acc.removed + (f.deletions ?? 0),
+    }),
+    { added: 0, removed: 0 }
+  )
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run src/features/diff/utils/sumLines.test.ts
+```
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/utils/sumLines.ts src/features/diff/utils/sumLines.test.ts
+git commit -m "feat(diff): add sumLines util for aggregating ChangedFile insertions/deletions"
+```
+
+---
+
+## Task 2: Drop `turnCount` from `<ActivityFooter>`
+
+**Files:**
+
+- Modify: `src/features/agent-status/components/ActivityFooter.tsx`
+- Modify: `src/features/agent-status/components/ActivityFooter.test.tsx`
+
+- [ ] **Step 1: Read the existing test file**
+
+```bash
+cat src/features/agent-status/components/ActivityFooter.test.tsx
+```
+
+Note the existing assertions involving `turnCount` and `12 turns`.
+
+- [ ] **Step 2: Update the test file to drop turnCount**
+
+Rewrite `src/features/agent-status/components/ActivityFooter.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import { ActivityFooter, formatDuration } from './ActivityFooter'
+
+describe('ActivityFooter', () => {
+  test('renders duration and line totals', () => {
+    render(
+      <ActivityFooter
+        totalDurationMs={90_000}
+        linesAdded={42}
+        linesRemoved={9}
+      />
+    )
+
+    expect(screen.getByText('1m')).toBeInTheDocument()
+    expect(screen.getByText('+42 / -9')).toBeInTheDocument()
+  })
+
+  test('does not render a turns cell', () => {
+    render(
+      <ActivityFooter totalDurationMs={0} linesAdded={0} linesRemoved={0} />
+    )
+
+    expect(screen.queryByText(/turns?/i)).not.toBeInTheDocument()
+  })
+
+  test('localizes large line counts', () => {
+    render(
+      <ActivityFooter
+        totalDurationMs={0}
+        linesAdded={12_345}
+        linesRemoved={6_789}
+      />
+    )
+
+    expect(screen.getByText('+12,345 / -6,789')).toBeInTheDocument()
+  })
+})
+
+describe('formatDuration', () => {
+  test('renders minutes only when under one hour', () => {
+    expect(formatDuration(45_000)).toBe('0m')
+    expect(formatDuration(90_000)).toBe('1m')
+  })
+
+  test('renders hours and zero-padded minutes when over one hour', () => {
+    expect(formatDuration(3_900_000)).toBe('1h 05m')
+  })
+})
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+npx vitest run src/features/agent-status/components/ActivityFooter.test.tsx
+```
+
+Expected: FAIL — `linesAdded` / `linesRemoved` props in current code, but `turnCount` is also required by the existing component, so old fixtures may pass while new tests fail on missing `turnCount`. Actual failure mode depends on TypeScript strictness; a missing-prop type error is acceptable.
+
+- [ ] **Step 4: Update the implementation**
+
+Rewrite `src/features/agent-status/components/ActivityFooter.tsx`:
+
+```tsx
+import type { ReactElement } from 'react'
+
+interface ActivityFooterProps {
+  totalDurationMs: number
+  linesAdded: number
+  linesRemoved: number
+}
+
+const formatDuration = (ms: number): string => {
+  const hours = Math.floor(ms / 3_600_000)
+  const minutes = Math.floor((ms % 3_600_000) / 60_000)
+
+  if (hours > 0) {
+    return `${hours}h ${minutes.toString().padStart(2, '0')}m`
+  }
+
+  return `${minutes}m`
+}
+
+const formatLines = (n: number): string => n.toLocaleString('en-US')
+
+export const ActivityFooter = ({
+  totalDurationMs,
+  linesAdded,
+  linesRemoved,
+}: ActivityFooterProps): ReactElement => (
+  <div className="mt-auto bg-surface-container-low/40 px-5 py-3">
+    <div className="flex items-center justify-between font-mono text-[9px] text-outline">
+      <span>{formatDuration(totalDurationMs)}</span>
+      <span>
+        +{formatLines(linesAdded)} / -{formatLines(linesRemoved)}
+      </span>
+    </div>
+  </div>
+)
+
+export { formatDuration }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+npx vitest run src/features/agent-status/components/ActivityFooter.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Type-check the whole project**
+
+```bash
+npm run type-check
+```
+
+Expected: ONE error in `AgentStatusPanel.tsx` — it still passes `turnCount={0}` to `<ActivityFooter>`, which now rejects unknown props. This is intentional; Task 5 fixes it. Do NOT proceed to commit until you verify the only remaining errors are in `AgentStatusPanel.tsx`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/agent-status/components/ActivityFooter.tsx \
+        src/features/agent-status/components/ActivityFooter.test.tsx
+git commit -m "refactor(activity-footer): drop turnCount, render duration + line totals only"
+```
+
+> **Note on the intermediate type-error window:** Task 6 (`npm run type-check`) currently flags `AgentStatusPanel.tsx` because it still passes `turnCount={0}`. That's an intentional cross-task delta — Task 5 fixes it. The pre-push hook only runs `vitest run` (which uses Vite's esbuild, stripping types), not `tsc`, so the commit and push are not blocked. Do **not** push to a remote that runs `tsc` in CI between Tasks 2 and 5; ideally land all of Tasks 2-6 before pushing. If you must push partway through, use a local branch.
+
+---
+
+## Task 3: `<SidebarStatusHeader>` component
+
+**Files:**
+
+- Create: `src/features/workspace/components/SidebarStatusHeader.tsx`
+- Create: `src/features/workspace/components/SidebarStatusHeader.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `src/features/workspace/components/SidebarStatusHeader.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import type { AgentStatus } from '../../agent-status/types'
+import { SidebarStatusHeader } from './SidebarStatusHeader'
+
+const inactiveStatus: AgentStatus = {
+  isActive: false,
+  agentType: null,
+  modelId: null,
+  modelDisplayName: null,
+  version: null,
+  sessionId: null,
+  agentSessionId: null,
+  contextWindow: null,
+  cost: null,
+  rateLimits: null,
+  toolCalls: { total: 0, byType: {}, active: null },
+  recentToolCalls: [],
+  testRun: null,
+}
+
+const activeStatus: AgentStatus = {
+  ...inactiveStatus,
+  isActive: true,
+  agentType: 'claude-code',
+  modelId: 'claude-3-5-sonnet-20241022',
+  modelDisplayName: 'Claude 3.5 Sonnet',
+  sessionId: 'session-1',
+  contextWindow: {
+    usedPercentage: 12,
+    contextWindowSize: 200_000,
+    totalInputTokens: 1_234,
+    totalOutputTokens: 567,
+    currentUsage: null,
+  },
+}
+
+describe('SidebarStatusHeader', () => {
+  test('renders the live StatusCard when an agent is active', () => {
+    render(
+      <SidebarStatusHeader
+        status={activeStatus}
+        activeSessionName="my session"
+      />
+    )
+
+    expect(screen.getByTestId('agent-status-card')).toBeInTheDocument()
+    expect(screen.getByText('Claude Code')).toBeInTheDocument()
+    expect(screen.getByText('Running')).toBeInTheDocument()
+  })
+
+  test('renders the idle placeholder with the active session name', () => {
+    render(
+      <SidebarStatusHeader
+        status={inactiveStatus}
+        activeSessionName="my session"
+      />
+    )
+
+    expect(screen.queryByTestId('agent-status-card')).not.toBeInTheDocument()
+    expect(screen.getByText('my session')).toBeInTheDocument()
+    expect(screen.getByText('Idle')).toBeInTheDocument()
+  })
+
+  test('falls back to "No session" when there is no active session', () => {
+    render(
+      <SidebarStatusHeader status={inactiveStatus} activeSessionName={null} />
+    )
+
+    expect(screen.getByText('No session')).toBeInTheDocument()
+    expect(screen.getByText('Idle')).toBeInTheDocument()
+  })
+
+  test('treats agent-detected-but-no-agentType as idle', () => {
+    // Defensive case: if isActive flips true before agentType arrives, the
+    // header should not crash and should keep rendering the idle layout.
+    render(
+      <SidebarStatusHeader
+        status={{ ...inactiveStatus, isActive: true, agentType: null }}
+        activeSessionName="my session"
+      />
+    )
+
+    expect(screen.queryByTestId('agent-status-card')).not.toBeInTheDocument()
+    expect(screen.getByText('my session')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run src/features/workspace/components/SidebarStatusHeader.test.tsx
+```
+
+Expected: FAIL with `Cannot find module './SidebarStatusHeader'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Write `src/features/workspace/components/SidebarStatusHeader.tsx`:
+
+```tsx
+import type { ReactElement } from 'react'
+import { StatusCard } from '../../agent-status/components/StatusCard'
+import type {
+  AgentStatus,
+  CostState,
+  RateLimitsState,
+} from '../../agent-status/types'
+
+export interface SidebarStatusHeaderProps {
+  status: AgentStatus
+  activeSessionName: string | null
+}
+
+interface ActiveCardProps {
+  agentType: 'claude-code' | 'codex' | 'aider' | 'generic'
+  modelId: string | null
+  modelDisplayName: string | null
+  status: 'running' | 'paused' | 'completed' | 'errored'
+  cost: CostState | null
+  rateLimits: RateLimitsState | null
+  totalInputTokens: number
+  totalOutputTokens: number
+}
+
+const mapStatusToCardProps = (
+  status: AgentStatus & {
+    agentType: 'claude-code' | 'codex' | 'aider' | 'generic'
+  }
+): ActiveCardProps => ({
+  agentType: status.agentType,
+  modelId: status.modelId,
+  modelDisplayName: status.modelDisplayName,
+  // The StatusType discriminator does not yet have a feed from
+  // AgentStatus — see spec section 5.1. Hard-coded to 'running' to
+  // mirror the existing AgentStatusPanel behavior.
+  status: 'running',
+  cost: status.cost,
+  rateLimits: status.rateLimits,
+  totalInputTokens: status.contextWindow?.totalInputTokens ?? 0,
+  totalOutputTokens: status.contextWindow?.totalOutputTokens ?? 0,
+})
+
+export const SidebarStatusHeader = ({
+  status,
+  activeSessionName,
+}: SidebarStatusHeaderProps): ReactElement => {
+  if (status.isActive && status.agentType) {
+    return (
+      <StatusCard
+        {...mapStatusToCardProps({ ...status, agentType: status.agentType })}
+      />
+    )
+  }
+
+  const title = activeSessionName ?? 'No session'
+
+  return (
+    <div
+      data-testid="sidebar-status-header-idle"
+      className="flex flex-col gap-3 rounded-xl bg-surface-container-high p-3"
+    >
+      <div className="flex items-center gap-2.5">
+        <div className="h-8 w-8 shrink-0 rounded-lg bg-gradient-to-br from-primary-container to-secondary" />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="truncate font-headline text-sm font-[800] text-on-surface">
+            {title}
+          </span>
+          <div className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-on-surface/30" />
+            <span className="text-[10px] font-medium text-outline">Idle</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run src/features/workspace/components/SidebarStatusHeader.test.tsx
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/workspace/components/SidebarStatusHeader.tsx \
+        src/features/workspace/components/SidebarStatusHeader.test.tsx
+git commit -m "feat(workspace): add SidebarStatusHeader component"
+```
+
+---
+
+## Task 4: Wire `<SidebarStatusHeader>` into `<Sidebar>`
+
+**Files:**
+
+- Modify: `src/features/workspace/components/Sidebar.tsx`
+- Modify: `src/features/workspace/components/Sidebar.test.tsx`
+
+- [ ] **Step 1: Read the existing Sidebar test**
+
+```bash
+cat src/features/workspace/components/Sidebar.test.tsx
+```
+
+Note any tests that assert on the literal strings "Agent Alpha" or "SYSTEM IDLE". Those become invalid after this task.
+
+- [ ] **Step 2: Update the Sidebar test**
+
+Three changes:
+
+**a)** Add the agent-status fixture at the top of the file (after existing imports / fixtures):
+
+```tsx
+import type { AgentStatus } from '../../agent-status/types'
+
+const inactiveAgentStatus: AgentStatus = {
+  isActive: false,
+  agentType: null,
+  modelId: null,
+  modelDisplayName: null,
+  version: null,
+  sessionId: null,
+  agentSessionId: null,
+  contextWindow: null,
+  cost: null,
+  rateLimits: null,
+  toolCalls: { total: 0, byType: {}, active: null },
+  recentToolCalls: [],
+  testRun: null,
+}
+```
+
+**b)** Replace the existing "renders agent header with name and status" test at lines 113-124 of `Sidebar.test.tsx`:
+
+```tsx
+test('renders the sidebar status header in the top slot', () => {
+  render(
+    <Sidebar
+      sessions={mockSessions}
+      activeSessionId="sess-1"
+      onSessionClick={mockOnSessionClick}
+      agentStatus={inactiveAgentStatus}
+    />
+  )
+
+  // Idle SidebarStatusHeader renders this testid; the active variant
+  // would render the StatusCard testid instead. Either path proves
+  // delegation succeeded.
+  expect(screen.getByTestId('sidebar-status-header-idle')).toBeInTheDocument()
+  // The hardcoded "Agent Alpha" / "System Idle" strings no longer exist.
+  expect(screen.queryByText('Agent Alpha')).not.toBeInTheDocument()
+  expect(screen.queryByText('System Idle')).not.toBeInTheDocument()
+})
+```
+
+**c)** Add `agentStatus={inactiveAgentStatus}` to every other `render(<Sidebar … />)` call site in the file. The prop is required, so every test that omits it will fail TypeScript and runtime. Use a recursive search/replace if the file is large.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+npx vitest run src/features/workspace/components/Sidebar.test.tsx
+```
+
+Expected: FAIL — `agentStatus` is not yet a prop on Sidebar (TypeScript), or the new "renders header" test fails because the header isn't rendered yet.
+
+- [ ] **Step 4: Update `Sidebar.tsx`**
+
+Modify `src/features/workspace/components/Sidebar.tsx`:
+
+1. Add `agentStatus` to `SidebarProps`:
+
+```tsx
+import type { AgentStatus } from '../../agent-status/types'
+
+export interface SidebarProps {
+  sessions: Session[]
+  activeSessionId: string | null
+  activeCwd?: string
+  onSessionClick: (sessionId: string) => void
+  onNewInstance?: () => void
+  onRemoveSession?: (sessionId: string) => void
+  onRenameSession?: (sessionId: string, name: string) => void
+  onReorderSessions?: (sessions: Session[]) => void
+  onFileSelect?: (node: FileNode) => void
+  agentStatus: AgentStatus
+}
+```
+
+2. Add `agentStatus` to the destructure in the component signature.
+
+3. Import `SidebarStatusHeader`:
+
+```tsx
+import { SidebarStatusHeader } from './SidebarStatusHeader'
+```
+
+4. Replace the entire hardcoded "Agent header" block (lines roughly 222-240, the `<div className="flex items-center gap-3 px-4 py-4">…"Agent Alpha"…"System Idle"…</div>` block) with:
+
+```tsx
+<div className="px-3 pt-3 pb-2">
+  <SidebarStatusHeader
+    status={agentStatus}
+    activeSessionName={
+      sessions.find((s) => s.id === activeSessionId)?.name ?? null
+    }
+  />
+</div>
+```
+
+The `"Active Sessions"` heading + `<Reorder.Group>` + everything below remain unchanged.
+
+- [ ] **Step 5: Run Sidebar tests to verify they pass**
+
+```bash
+npx vitest run src/features/workspace/components/Sidebar.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: TypeScript errors in `WorkspaceView.tsx` (it doesn't pass `agentStatus`) and still in `AgentStatusPanel.tsx` (still passes `turnCount`). Both intentional; Tasks 5 and 6 fix them.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/workspace/components/Sidebar.tsx \
+        src/features/workspace/components/Sidebar.test.tsx
+git commit -m "feat(workspace): render SidebarStatusHeader in Sidebar top slot"
+```
+
+> Same rationale as Task 2: the type-check window between tasks doesn't block the pre-push hook. Local commits are fine.
+
+---
+
+## Task 5: Refactor `<AgentStatusPanel>` to take `agentStatus` prop, drop `<StatusCard>`, use `sumLines`
+
+**Files:**
+
+- Modify: `src/features/agent-status/components/AgentStatusPanel.tsx`
+- Modify: `src/features/agent-status/components/AgentStatusPanel.test.tsx`
+
+- [ ] **Step 1: Read the existing AgentStatusPanel test**
+
+```bash
+cat src/features/agent-status/components/AgentStatusPanel.test.tsx
+```
+
+Note how `useAgentStatus` is currently mocked.
+
+- [ ] **Step 2: Update the AgentStatusPanel test**
+
+Update the test file:
+
+1. Drop the `vi.mock('../hooks/useAgentStatus')` block if it exists. The panel no longer calls the hook.
+2. Add the `activeAgentStatus` fixture at the top of the file:
+
+```tsx
+import type { AgentStatus } from '../types'
+
+const activeAgentStatus: AgentStatus = {
+  isActive: true,
+  agentType: 'claude-code',
+  modelId: 'claude-3-5-sonnet-20241022',
+  modelDisplayName: 'Claude 3.5 Sonnet',
+  version: null,
+  sessionId: 'sess-1',
+  agentSessionId: null,
+  contextWindow: {
+    usedPercentage: 12,
+    contextWindowSize: 200_000,
+    totalInputTokens: 1_234,
+    totalOutputTokens: 567,
+    currentUsage: null,
+  },
+  cost: {
+    totalCostUsd: 0.05,
+    totalDurationMs: 60_000,
+    totalApiDurationMs: 30_000,
+    totalLinesAdded: 0,
+    totalLinesRemoved: 0,
+  },
+  rateLimits: null,
+  toolCalls: { total: 0, byType: {}, active: null },
+  recentToolCalls: [],
+  testRun: null,
+}
+```
+
+3. Pass `agentStatus` directly as a prop in every `render(<AgentStatusPanel … />)` call. Drop any `sessionId` prop (it no longer exists on the panel).
+4. Add a test asserting `<StatusCard>` is no longer rendered inside the panel:
+
+```tsx
+test('does not render StatusCard inside the panel', () => {
+  render(
+    <AgentStatusPanel
+      agentStatus={activeAgentStatus}
+      cwd="/tmp/repo"
+      onOpenDiff={() => {}}
+    />
+  )
+
+  expect(screen.queryByTestId('agent-status-card')).not.toBeInTheDocument()
+})
+```
+
+4. Add a test asserting footer line totals come from git-diff data. Mock `useGitStatus` to return changed files with insertions/deletions:
+
+```tsx
+import { vi } from 'vitest'
+
+vi.mock('../../diff/hooks/useGitStatus', () => ({
+  useGitStatus: () => ({
+    files: [
+      {
+        path: 'a.ts',
+        status: 'modified',
+        insertions: 5,
+        deletions: 2,
+        staged: false,
+      },
+      {
+        path: 'b.ts',
+        status: 'modified',
+        insertions: 7,
+        deletions: 1,
+        staged: false,
+      },
+    ],
+    filesCwd: '/tmp/repo',
+    loading: false,
+    error: null,
+    refresh: () => {},
+    idle: false,
+  }),
+}))
+
+test('footer renders aggregated git-diff line totals', () => {
+  render(
+    <AgentStatusPanel
+      agentStatus={activeAgentStatus}
+      cwd="/tmp/repo"
+      onOpenDiff={() => {}}
+    />
+  )
+
+  expect(screen.getByText('+12 / -3')).toBeInTheDocument()
+})
+```
+
+Use the same `activeAgentStatus` fixture shape from Task 3, but with `cost`, `rateLimits`, etc. populated to satisfy `<ContextBucket>` / `<TokenCache>` rendering (or update those mocks if they crash on null).
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+npx vitest run src/features/agent-status/components/AgentStatusPanel.test.tsx
+```
+
+Expected: FAIL — the panel still calls `useAgentStatus` internally and still renders `<StatusCard>`.
+
+- [ ] **Step 4: Update `AgentStatusPanel.tsx`**
+
+Rewrite the component:
+
+```tsx
+import { useMemo, type ReactElement } from 'react'
+import type { AgentStatus } from '../types'
+import { ContextBucket } from './ContextBucket'
+import { TokenCache } from './TokenCache'
+import { ToolCallSummary } from './ToolCallSummary'
+import { FilesChanged } from './FilesChanged'
+import { TestResults } from './TestResults'
+import { ActivityFooter } from './ActivityFooter'
+import { ActivityFeed } from './ActivityFeed'
+import { useActivityEvents } from '../hooks/useActivityEvents'
+import { useGitStatus } from '../../diff/hooks/useGitStatus'
+import { sumLines } from '../../diff/utils/sumLines'
+import type { ChangedFile } from '../../diff/types'
+
+interface AgentStatusPanelProps {
+  agentStatus: AgentStatus
+  cwd: string
+  onOpenDiff: (file: ChangedFile) => void
+  onOpenFile?: (path: string) => void
+}
+
+export const AgentStatusPanel = ({
+  agentStatus,
+  cwd,
+  onOpenDiff,
+  onOpenFile = undefined,
+}: AgentStatusPanelProps): ReactElement => {
+  const status = agentStatus
+  const events = useActivityEvents(status)
+
+  const { files, filesCwd, loading, error, refresh, idle } = useGitStatus(cwd, {
+    watch: true,
+    enabled: status.isActive,
+  })
+
+  const filesAreFresh = filesCwd === cwd
+  const effectiveFiles = filesAreFresh ? files : []
+
+  const effectiveLoading =
+    !idle && (loading || (!filesAreFresh && error === null))
+
+  const lineTotals = useMemo(() => sumLines(effectiveFiles), [effectiveFiles])
+
+  return (
+    <div
+      data-testid="agent-status-panel"
+      className="flex h-full flex-col overflow-hidden bg-surface-container"
+      style={{
+        width: status.isActive ? '280px' : '0px',
+        transition: status.isActive
+          ? 'width 200ms ease-in'
+          : 'width 200ms ease-out',
+      }}
+    >
+      {status.isActive && status.agentType ? (
+        <>
+          <div className="flex flex-col gap-2 p-2">
+            <ContextBucket
+              usedPercentage={status.contextWindow?.usedPercentage ?? null}
+              contextWindowSize={
+                status.contextWindow?.contextWindowSize ?? 200_000
+              }
+              totalInputTokens={status.contextWindow?.totalInputTokens ?? 0}
+              totalOutputTokens={status.contextWindow?.totalOutputTokens ?? 0}
+            />
+            <TokenCache usage={status.contextWindow?.currentUsage ?? null} />
+          </div>
+
+          <div className="thin-scrollbar flex-1 overflow-y-auto">
+            <ToolCallSummary
+              total={status.toolCalls.total}
+              byType={status.toolCalls.byType}
+              active={status.toolCalls.active}
+            />
+            <ActivityFeed events={events} />
+            <FilesChanged
+              files={effectiveFiles}
+              loading={effectiveLoading}
+              error={error}
+              onRetry={refresh}
+              onSelect={onOpenDiff}
+            />
+            <TestResults snapshot={status.testRun} onOpenFile={onOpenFile} />
+          </div>
+          <ActivityFooter
+            totalDurationMs={status.cost?.totalDurationMs ?? 0}
+            linesAdded={lineTotals.added}
+            linesRemoved={lineTotals.removed}
+          />
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+export default AgentStatusPanel
+```
+
+Key changes vs. before:
+
+1. The `sessionId: string | null` prop is gone; the parent now owns the hook.
+2. `agentStatus: AgentStatus` is the new prop.
+3. The internal `useAgentStatus(sessionId)` call is removed.
+4. `<StatusCard>` is no longer rendered.
+5. `lineTotals = useMemo(() => sumLines(effectiveFiles), …)` feeds the footer.
+6. `<ActivityFooter>` no longer receives `turnCount`.
+
+- [ ] **Step 5: Run the AgentStatusPanel tests to verify they pass**
+
+```bash
+npx vitest run src/features/agent-status/components/AgentStatusPanel.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: TypeScript errors in `WorkspaceView.tsx` only — it still passes `sessionId` and does not pass `agentStatus`. Task 6 fixes those.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/agent-status/components/AgentStatusPanel.tsx \
+        src/features/agent-status/components/AgentStatusPanel.test.tsx
+git commit -m "refactor(agent-status): take agentStatus as prop, drop StatusCard render, use sumLines for footer"
+```
+
+> After this task lands, `npm run type-check` still fails on `WorkspaceView.tsx` (sessionId/agentStatus mismatch). Task 6 fixes the last error.
+
+---
+
+## Task 6: Lift `useAgentStatus` to `<WorkspaceView>` + bump `SIDEBAR_MIN`
+
+**Files:**
+
+- Modify: `src/features/workspace/WorkspaceView.tsx`
+- Modify: `src/features/workspace/WorkspaceView.test.tsx`
+
+- [ ] **Step 1: Read the existing WorkspaceView test**
+
+```bash
+cat src/features/workspace/WorkspaceView.test.tsx
+```
+
+Note any existing `useAgentStatus` mocks.
+
+- [ ] **Step 2: Update the WorkspaceView test**
+
+The test file already mocks `useAgentStatus` at module scope (`vi.mock('../agent-status/hooks/useAgentStatus', () => ({ useAgentStatus: vi.fn(() => …) }))`) and already mocks `AgentStatusPanel` with a `capturedAgentStatusPanelProps` capture object. We extend both.
+
+**a)** Add `agentStatus` to the captured-props object near the existing capture (around line 47-50 of the file):
+
+```tsx
+import type { AgentStatus } from '../agent-status/types'
+
+const capturedAgentStatusPanelProps: {
+  onOpenFile?: (path: string) => void
+  onOpenDiff?: unknown
+  agentStatus?: AgentStatus // NEW
+} = {}
+
+interface MockAgentStatusPanelProps {
+  onOpenFile?: (path: string) => void
+  onOpenDiff?: unknown
+  agentStatus?: AgentStatus // NEW
+}
+```
+
+**b)** Capture the new prop inside the mock factory (around line 57-69):
+
+```tsx
+vi.mock('../agent-status/components/AgentStatusPanel', () => ({
+  AgentStatusPanel: ({
+    onOpenFile = undefined,
+    onOpenDiff = undefined,
+    agentStatus = undefined, // NEW
+  }: MockAgentStatusPanelProps): ReactElement => {
+    capturedAgentStatusPanelProps.onOpenFile = onOpenFile
+    capturedAgentStatusPanelProps.onOpenDiff = onOpenDiff
+    capturedAgentStatusPanelProps.agentStatus = agentStatus // NEW
+
+    return <div data-testid="agent-status-panel" />
+  },
+}))
+```
+
+**c)** Reset the new field in `beforeEach`:
+
+```tsx
+beforeEach(() => {
+  capturedAgentStatusPanelProps.onOpenFile = undefined
+  capturedAgentStatusPanelProps.onOpenDiff = undefined
+  capturedAgentStatusPanelProps.agentStatus = undefined // NEW
+
+  // … existing useEditorBuffer mock setup …
+})
+```
+
+**d)** Add a top-level import to grab the mock reference:
+
+```tsx
+import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
+```
+
+**e)** Add the new tests inside the `describe('WorkspaceView', …)` block:
+
+```tsx
+test('lifts useAgentStatus and forwards the latest activeSessionId', async () => {
+  render(<WorkspaceView />)
+
+  // Wait for session restore to settle (existing tests use this pattern —
+  // findByRole on the session button proves activeSessionId is non-null).
+  await screen.findByRole('button', { name: 'session 1' })
+
+  const useAgentStatusMock = vi.mocked(useAgentStatus)
+  const calls = useAgentStatusMock.mock.calls
+  const lastArg = calls[calls.length - 1]?.[0] as string | null
+
+  // The exact id depends on the listSessions mock above (currently 'sess-1').
+  // The point of this assertion is the LATEST call arg, not the call count —
+  // activeSessionId flips from null to the restored id, and React may
+  // re-render multiple times, so call count is not stable.
+  expect(lastArg).toBe('sess-1')
+})
+
+test('passes agentStatus to AgentStatusPanel', async () => {
+  render(<WorkspaceView />)
+
+  await screen.findByRole('button', { name: 'session 1' })
+
+  // The mocked useAgentStatus returns an object with isActive: true,
+  // agentType: 'claude-code'. Verify AgentStatusPanel receives that exact
+  // shape (proving the prop drill works).
+  expect(capturedAgentStatusPanelProps.agentStatus).toMatchObject({
+    isActive: true,
+    agentType: 'claude-code',
+  })
+})
+```
+
+> Note: the existing `useAgentStatus` mock at module scope is `vi.fn(() => ({ isActive: true, agentType: 'claude-code', … }))`. Calling `vi.mocked(useAgentStatus).mock.calls` reads the call log directly. No restructuring of the existing mock is needed.
+
+> The "both children receive the same `agentStatus` reference" assertion from the spec test plan is satisfied by TypeScript: the same `agentStatus` const is passed to both `<Sidebar>` and `<AgentStatusPanel>`. Asserting it again at runtime would require also mocking `<Sidebar>`, which the existing test file leaves real. We assert only the AgentStatusPanel side here; if a future regression makes the Sidebar receive a different reference, type-check would catch it before tests run.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+npx vitest run src/features/workspace/WorkspaceView.test.tsx
+```
+
+Expected: FAIL — `useAgentStatus` is not yet called from WorkspaceView.
+
+- [ ] **Step 4: Update `WorkspaceView.tsx`**
+
+1. Bump `SIDEBAR_MIN` from `180` to `240`:
+
+```ts
+const SIDEBAR_MIN = 240
+```
+
+2. Add the import:
+
+```ts
+import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
+```
+
+3. Inside the component, near the other hook calls (after `useSessionManager`, before or after `useResizable` — order doesn't matter for behavior):
+
+```ts
+const agentStatus = useAgentStatus(activeSessionId)
+```
+
+4. In the `<Sidebar … />` JSX, add the prop:
+
+```tsx
+<Sidebar
+  sessions={sessions}
+  activeSessionId={activeSessionId}
+  activeCwd={activeSession?.workingDirectory ?? '~'}
+  onSessionClick={setActiveSessionId}
+  onNewInstance={createSession}
+  onRemoveSession={removeSession}
+  onRenameSession={renameSession}
+  onReorderSessions={reorderSessions}
+  onFileSelect={handleFileSelect}
+  agentStatus={agentStatus}
+/>
+```
+
+5. In the `<AgentStatusPanel … />` JSX, replace `sessionId={activeSessionId}` with `agentStatus={agentStatus}`:
+
+```tsx
+<AgentStatusPanel
+  agentStatus={agentStatus}
+  cwd={activeSession?.workingDirectory ?? '.'}
+  onOpenDiff={handleOpenDiff}
+  onOpenFile={handleOpenTestFile}
+/>
+```
+
+- [ ] **Step 5: Run the WorkspaceView test to verify it passes**
+
+```bash
+npx vitest run src/features/workspace/WorkspaceView.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Type-check the whole project**
+
+```bash
+npm run type-check
+```
+
+Expected: PASS, no errors.
+
+- [ ] **Step 7: Run the full test suite**
+
+```bash
+npm run test
+```
+
+Expected: PASS. If any test fails because it depended on the old `<StatusCard>` location inside the panel or the old footer signature, fix it now — those failures belong to this task.
+
+- [ ] **Step 8: Run lint + format**
+
+```bash
+npm run lint
+npm run format:check
+```
+
+Expected: PASS. Run `npm run lint:fix` and `npm run format` if anything fails.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/features/workspace/WorkspaceView.tsx \
+        src/features/workspace/WorkspaceView.test.tsx
+git commit -m "feat(workspace): lift useAgentStatus to WorkspaceView; bump SIDEBAR_MIN to 240"
+```
+
+(No `--no-verify` here — the tree should now be fully green, so pre-push must pass.)
+
+---
+
+## Task 7: Visual verification at narrow sidebar width
+
+**Files:** None (manual verification per spec section 5.2.1)
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+npm run tauri:dev
+```
+
+(Or `npm run dev` if Tauri is unavailable in your environment — the layout tests can be done in the browser preview.)
+
+- [ ] **Step 2: Drag the sidebar to its minimum width**
+
+Drag the right edge of the sidebar all the way left. Verify the resize stops at the new minimum (240px). The `<SidebarStatusHeader>` should render the `<StatusCard>` (if an agent is attached in the session) without horizontal overflow.
+
+- [ ] **Step 3: Verify worst-case `<BudgetMetrics>` variants**
+
+Test all three variants of `<BudgetMetrics>` at 240px:
+
+- **`SubscriberVariant`** — both 5h + 7d rate-limit bars + the "API Time" / "Tokens" cells. Trigger by attaching a Claude Code session that returns `rate_limits` in its statusline JSON.
+- **`ApiKeyVariant`** — Cost / API Time / Tokens In / Tokens Out grid. Trigger by attaching a Claude Code session running with `ANTHROPIC_API_KEY` (no rate-limit data).
+- **`FallbackVariant`** — Tokens In / Tokens Out only. Trigger by attaching a session that emits a context-window event but no cost or rate-limits yet.
+
+If you cannot reproduce all three with real agents, render the panel with worst-case mock data:
+
+```tsx
+// Worst-case fixtures to drop into the dev server temporarily:
+//   cost.totalCostUsd        = 9999.99   → "$9999.99"
+//   cost.totalApiDurationMs  = 9_999_000 → "9999.0s"
+//   totalInputTokens         = 9_999_999 → "10.0M" (whichever formatTokens produces)
+//   rateLimits.fiveHour      = 99.99%
+```
+
+- [ ] **Step 4: Inspect for horizontal overflow**
+
+Open DevTools, hover the StatusCard, look for clipped or wrapped text inside the `MetricCell` values. Use `overflow: visible` temporarily on the outer card to confirm.
+
+- [ ] **Step 5: Decide**
+
+- **If no overflow at 240px** → `SIDEBAR_MIN = 240` is correct. Continue to Step 6.
+- **If overflow at 240px** → raise `SIDEBAR_MIN` further (try 260, then 280) and re-verify. Update Task 6's commit (or add a follow-up commit) accordingly. Document the final value in the PR description.
+
+- [ ] **Step 6: Verify the `<SidebarStatusHeader>` idle state**
+
+Reload the app. Before any agent is attached to the active session, confirm the idle placeholder renders: gradient avatar + active session name (or "No session" if none) + neutral dot + "Idle" label. Drag the sidebar to its minimum and confirm the idle layout also fits without overflow.
+
+- [ ] **Step 7: Commit (only if SIDEBAR_MIN was raised above 240)**
+
+```bash
+git add src/features/workspace/WorkspaceView.tsx
+git commit -m "fix(workspace): raise SIDEBAR_MIN to <verified-value> after empirical check"
+```
+
+---
+
+## Task 8: File the deferred-`turnCount` issue
+
+**Files:** None (filed via `gh issue create`)
+
+- [ ] **Step 1: Confirm the GitHub remote is configured**
+
+```bash
+gh repo view --json url -q .url
+```
+
+Expected: a github.com URL.
+
+- [ ] **Step 2: File the issue**
+
+```bash
+gh issue create \
+  --title "feat(agent-status): wire real turnCount in ActivityFooter" \
+  --body "$(cat <<'EOF'
+The previous \`<ActivityFooter>\` displayed \`{turnCount} turns\` with \`turnCount\` hardcoded to \`0\`. This was misleading — there is no turn counter anywhere in the system today.
+
+The PR that adds \`<SidebarStatusHeader>\` (see \`docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md\`) dropped the turns cell entirely rather than continue showing a fake number. This issue tracks restoring the cell with a real, accurate value.
+
+## Approach (from the spec)
+
+Count is sourced from the Claude Code transcript file, which is already tailed by \`src-tauri/src/agent/transcript.rs\`. Add:
+
+1. \`AgentTurnEvent { session_id, num_turns }\` in \`src-tauri/src/agent/types.rs\` with \`#[ts(export)]\` so the binding regenerates.
+2. A per-session \`num_turns: u32\` local in \`tail_loop\`, threaded through \`process_line\` → \`process_user_message\`.
+3. \`is_user_prompt(content)\` helper that returns true iff the user-message content is not exclusively \`tool_result\` blocks (real prompt vs synthetic tool-result wrapper).
+4. Frontend listener in \`useAgentStatus\` for \`agent-turn\`; reducer takes \`Math.max(prev.numTurns, e.payload.numTurns)\` so historical replay collapses to the final value.
+5. Wire \`numTurns\` back into \`<ActivityFooter>\` as a third cell.
+
+## Spec reference
+
+\`docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md\` § 2 (out of scope) and § 8 (follow-up issues).
+EOF
+)"
+```
+
+If `gh` is not configured or the remote is missing, ask the user to file the issue manually using the body above. Do not block the rest of the work on this task.
+
+- [ ] **Step 3: Mark this task complete**
+
+No commit — `gh issue create` does not modify the working tree.
+
+---
+
+## Done criteria
+
+- All tests pass: `npm run test`
+- TypeScript clean: `npm run type-check`
+- Lint clean: `npm run lint`
+- Format clean: `npm run format:check`
+- Manual: at the narrowest sidebar width, `<StatusCard>` and the idle header both render without horizontal overflow across all three `<BudgetMetrics>` variants
+- The deferred-`turnCount` issue is filed (or the user has been notified to file it)
+- The PR description references this plan and the spec
+
+## Self-review notes (post-write)
+
+- Spec § 5.1 (`<SidebarStatusHeader>`): Task 3 covers the active branch (delegates to `<StatusCard>`) and idle branch (inline JSX matching StatusCard chrome).
+- Spec § 5.2 (`<StatusCard>` stays put): No source edit; only Task 3 imports it from its existing location.
+- Spec § 5.2.1 (`SIDEBAR_MIN` bump): Task 6 raises the const; Task 7 verifies and re-bumps if needed.
+- Spec § 5.3 (Sidebar accepts `agentStatus`): Task 4.
+- Spec § 5.4 (AgentStatusPanel takes prop, drops StatusCard, uses sumLines): Task 5.
+- Spec § 5.5 (ActivityFooter drops turnCount): Task 2.
+- Spec § 5.6 (sumLines util): Task 1.
+- Spec § 5.7 (WorkspaceView lifts hook + bumps SIDEBAR_MIN): Task 6.
+- Spec § 6 (test plan): each row mapped to the corresponding task above.
+- Spec § 8 (follow-up): Task 8 files the deferred-turnCount issue.
+
+The plan accepts a brief `tsc` red window between Tasks 2 and 6 — the ActivityFooter and Sidebar/AgentStatusPanel signatures shift before `WorkspaceView` is updated, leaving the project type-error-positive but test-green (vitest uses Vite's esbuild, which strips types). Local commits during Tasks 2-5 succeed; the pre-push hook only runs `vitest run`, not `tsc`. Task 6 closes the type window.
+
+> **Push gate:** CI (`.github/workflows/ci-checks.yml`) runs `npm run type-check` on push. **Do not push to GitHub until Task 6 is committed.** Push only after Task 6, ideally after Task 7 (visual verification) too. Tasks 1-6 are local-only commits.

--- a/docs/superpowers/plans/2026-04-30-sidebar-status-header-plan.md
+++ b/docs/superpowers/plans/2026-04-30-sidebar-status-header-plan.md
@@ -20,6 +20,7 @@
 - `src/features/diff/utils/sumLines.test.ts` — unit tests for the util
 - `src/features/workspace/components/SidebarStatusHeader.tsx` — switches between `<StatusCard>` and an idle placeholder
 - `src/features/workspace/components/SidebarStatusHeader.test.tsx` — tests both states + the null-session fallback
+- `src/features/workspace/WorkspaceView.subscription.test.tsx` — focused test that mocks **both** `<Sidebar>` and `<AgentStatusPanel>`, captures their `agentStatus` props, and asserts reference equality (proving one Tauri subscription, not two)
 
 **Modified files:**
 
@@ -30,7 +31,7 @@
 - `src/features/agent-status/components/AgentStatusPanel.tsx` — accept `agentStatus` prop instead of calling `useAgentStatus`; drop `<StatusCard>` render; pipe `effectiveFiles` through `sumLines` into the footer
 - `src/features/agent-status/components/AgentStatusPanel.test.tsx` — pass `agentStatus` as a prop instead of mocking the hook; assert `<StatusCard>` is no longer rendered inside the panel; assert footer line totals from a mock `useGitStatus`
 - `src/features/workspace/WorkspaceView.tsx` — call `useAgentStatus(activeSessionId)` once, fan out to both `<Sidebar>` and `<AgentStatusPanel>`; raise `SIDEBAR_MIN` from 180 to 240
-- `src/features/workspace/WorkspaceView.test.tsx` — assert the lifted hook's latest-call arg and prop fan-out
+- `src/features/workspace/WorkspaceView.test.tsx` — capture `agentStatus` on the existing `AgentStatusPanel` mock; assert latest `useAgentStatus` call arg
 
 **Untouched (verification only):**
 
@@ -38,6 +39,23 @@
 - `src/features/agent-status/components/StatusCard.test.tsx` — no change
 - `src/features/agent-status/components/BudgetMetrics.tsx` / `.test.tsx` — no change
 - `src/features/agent-status/hooks/useAgentStatus.ts` — no change
+
+---
+
+## Commit Strategy (read before starting)
+
+The pre-commit hook runs `lint-staged`, which runs `tsc --noEmit` over the whole project for any staged `.ts` / `.tsx` file (`lint-staged.config.js:3`). Pre-commit blocks any commit while the tree has type errors anywhere.
+
+This forces us to either keep every commit type-clean, or land every interdependent change in one atomic commit. We pick atomic commits:
+
+| Commit | Tasks             | Why atomic                                                                                                                                                                                                                                                                                                                                         |
+| ------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **C1** | Task 1            | `sumLines` util — additive, no other file changes                                                                                                                                                                                                                                                                                                  |
+| **C2** | Task 2            | `<SidebarStatusHeader>` — additive new component, doesn't touch any existing render path                                                                                                                                                                                                                                                           |
+| **C3** | Task 3            | All component-signature changes land together: `<ActivityFooter>` drops `turnCount`; `<Sidebar>` and `<AgentStatusPanel>` switch to prop-based agent status; `<WorkspaceView>` lifts the hook and bumps `SIDEBAR_MIN`. Each component depends on its caller being updated; splitting causes cross-file type errors that block the pre-commit hook. |
+| **C4** | (optional) Task 4 | Empirical SIDEBAR_MIN bump if 240px doesn't fit                                                                                                                                                                                                                                                                                                    |
+
+Tasks 5 and 6 (visual verification and issue filing) don't touch the working tree.
 
 ---
 
@@ -145,167 +163,24 @@ npx vitest run src/features/diff/utils/sumLines.test.ts
 
 Expected: PASS, 5 tests.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Type-check and commit**
+
+```bash
+npm run type-check
+```
+
+Expected: PASS.
 
 ```bash
 git add src/features/diff/utils/sumLines.ts src/features/diff/utils/sumLines.test.ts
 git commit -m "feat(diff): add sumLines util for aggregating ChangedFile insertions/deletions"
 ```
 
----
-
-## Task 2: Drop `turnCount` from `<ActivityFooter>`
-
-**Files:**
-
-- Modify: `src/features/agent-status/components/ActivityFooter.tsx`
-- Modify: `src/features/agent-status/components/ActivityFooter.test.tsx`
-
-- [ ] **Step 1: Read the existing test file**
-
-```bash
-cat src/features/agent-status/components/ActivityFooter.test.tsx
-```
-
-Note the existing assertions involving `turnCount` and `12 turns`.
-
-- [ ] **Step 2: Update the test file to drop turnCount**
-
-Rewrite `src/features/agent-status/components/ActivityFooter.test.tsx`:
-
-```tsx
-import { render, screen } from '@testing-library/react'
-import { describe, expect, test } from 'vitest'
-import { ActivityFooter, formatDuration } from './ActivityFooter'
-
-describe('ActivityFooter', () => {
-  test('renders duration and line totals', () => {
-    render(
-      <ActivityFooter
-        totalDurationMs={90_000}
-        linesAdded={42}
-        linesRemoved={9}
-      />
-    )
-
-    expect(screen.getByText('1m')).toBeInTheDocument()
-    expect(screen.getByText('+42 / -9')).toBeInTheDocument()
-  })
-
-  test('does not render a turns cell', () => {
-    render(
-      <ActivityFooter totalDurationMs={0} linesAdded={0} linesRemoved={0} />
-    )
-
-    expect(screen.queryByText(/turns?/i)).not.toBeInTheDocument()
-  })
-
-  test('localizes large line counts', () => {
-    render(
-      <ActivityFooter
-        totalDurationMs={0}
-        linesAdded={12_345}
-        linesRemoved={6_789}
-      />
-    )
-
-    expect(screen.getByText('+12,345 / -6,789')).toBeInTheDocument()
-  })
-})
-
-describe('formatDuration', () => {
-  test('renders minutes only when under one hour', () => {
-    expect(formatDuration(45_000)).toBe('0m')
-    expect(formatDuration(90_000)).toBe('1m')
-  })
-
-  test('renders hours and zero-padded minutes when over one hour', () => {
-    expect(formatDuration(3_900_000)).toBe('1h 05m')
-  })
-})
-```
-
-- [ ] **Step 3: Run the test to verify it fails**
-
-```bash
-npx vitest run src/features/agent-status/components/ActivityFooter.test.tsx
-```
-
-Expected: FAIL — `linesAdded` / `linesRemoved` props in current code, but `turnCount` is also required by the existing component, so old fixtures may pass while new tests fail on missing `turnCount`. Actual failure mode depends on TypeScript strictness; a missing-prop type error is acceptable.
-
-- [ ] **Step 4: Update the implementation**
-
-Rewrite `src/features/agent-status/components/ActivityFooter.tsx`:
-
-```tsx
-import type { ReactElement } from 'react'
-
-interface ActivityFooterProps {
-  totalDurationMs: number
-  linesAdded: number
-  linesRemoved: number
-}
-
-const formatDuration = (ms: number): string => {
-  const hours = Math.floor(ms / 3_600_000)
-  const minutes = Math.floor((ms % 3_600_000) / 60_000)
-
-  if (hours > 0) {
-    return `${hours}h ${minutes.toString().padStart(2, '0')}m`
-  }
-
-  return `${minutes}m`
-}
-
-const formatLines = (n: number): string => n.toLocaleString('en-US')
-
-export const ActivityFooter = ({
-  totalDurationMs,
-  linesAdded,
-  linesRemoved,
-}: ActivityFooterProps): ReactElement => (
-  <div className="mt-auto bg-surface-container-low/40 px-5 py-3">
-    <div className="flex items-center justify-between font-mono text-[9px] text-outline">
-      <span>{formatDuration(totalDurationMs)}</span>
-      <span>
-        +{formatLines(linesAdded)} / -{formatLines(linesRemoved)}
-      </span>
-    </div>
-  </div>
-)
-
-export { formatDuration }
-```
-
-- [ ] **Step 5: Run the test to verify it passes**
-
-```bash
-npx vitest run src/features/agent-status/components/ActivityFooter.test.tsx
-```
-
-Expected: PASS.
-
-- [ ] **Step 6: Type-check the whole project**
-
-```bash
-npm run type-check
-```
-
-Expected: ONE error in `AgentStatusPanel.tsx` — it still passes `turnCount={0}` to `<ActivityFooter>`, which now rejects unknown props. This is intentional; Task 5 fixes it. Do NOT proceed to commit until you verify the only remaining errors are in `AgentStatusPanel.tsx`.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add src/features/agent-status/components/ActivityFooter.tsx \
-        src/features/agent-status/components/ActivityFooter.test.tsx
-git commit -m "refactor(activity-footer): drop turnCount, render duration + line totals only"
-```
-
-> **Note on the intermediate type-error window:** Task 6 (`npm run type-check`) currently flags `AgentStatusPanel.tsx` because it still passes `turnCount={0}`. That's an intentional cross-task delta — Task 5 fixes it. The pre-push hook only runs `vitest run` (which uses Vite's esbuild, stripping types), not `tsc`, so the commit and push are not blocked. Do **not** push to a remote that runs `tsc` in CI between Tasks 2 and 5; ideally land all of Tasks 2-6 before pushing. If you must push partway through, use a local branch.
+Expected: pre-commit passes (only the new util is staged; tsc clean).
 
 ---
 
-## Task 3: `<SidebarStatusHeader>` component
+## Task 2: `<SidebarStatusHeader>` component
 
 **Files:**
 
@@ -391,8 +266,6 @@ describe('SidebarStatusHeader', () => {
   })
 
   test('treats agent-detected-but-no-agentType as idle', () => {
-    // Defensive case: if isActive flips true before agentType arrives, the
-    // header should not crash and should keep rendering the idle layout.
     render(
       <SidebarStatusHeader
         status={{ ...inactiveStatus, isActive: true, agentType: null }}
@@ -505,7 +378,13 @@ npx vitest run src/features/workspace/components/SidebarStatusHeader.test.tsx
 
 Expected: PASS, 4 tests.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Type-check and commit**
+
+```bash
+npm run type-check
+```
+
+Expected: PASS. (`<SidebarStatusHeader>` is not yet rendered anywhere, so no caller is affected.)
 
 ```bash
 git add src/features/workspace/components/SidebarStatusHeader.tsx \
@@ -515,26 +394,83 @@ git commit -m "feat(workspace): add SidebarStatusHeader component"
 
 ---
 
-## Task 4: Wire `<SidebarStatusHeader>` into `<Sidebar>`
+## Task 3: Atomic component refactor
 
-**Files:**
+**Why one task / one commit:** every signature change in this task depends on its caller being updated in the same diff. Splitting causes intermediate type errors that block the pre-commit hook.
 
+**Files (all in one commit):**
+
+- Modify: `src/features/agent-status/components/ActivityFooter.tsx`
+- Modify: `src/features/agent-status/components/ActivityFooter.test.tsx`
 - Modify: `src/features/workspace/components/Sidebar.tsx`
 - Modify: `src/features/workspace/components/Sidebar.test.tsx`
+- Modify: `src/features/agent-status/components/AgentStatusPanel.tsx`
+- Modify: `src/features/agent-status/components/AgentStatusPanel.test.tsx`
+- Modify: `src/features/workspace/WorkspaceView.tsx`
+- Modify: `src/features/workspace/WorkspaceView.test.tsx`
+- Create: `src/features/workspace/WorkspaceView.subscription.test.tsx`
 
-- [ ] **Step 1: Read the existing Sidebar test**
+### 3.1 Write failing tests first (TDD)
 
-```bash
-cat src/features/workspace/components/Sidebar.test.tsx
+- [ ] **Step 1: Rewrite `ActivityFooter.test.tsx`**
+
+Replace the file contents:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import { ActivityFooter, formatDuration } from './ActivityFooter'
+
+describe('ActivityFooter', () => {
+  test('renders duration and line totals', () => {
+    render(
+      <ActivityFooter
+        totalDurationMs={90_000}
+        linesAdded={42}
+        linesRemoved={9}
+      />
+    )
+
+    expect(screen.getByText('1m')).toBeInTheDocument()
+    expect(screen.getByText('+42 / -9')).toBeInTheDocument()
+  })
+
+  test('does not render a turns cell', () => {
+    render(
+      <ActivityFooter totalDurationMs={0} linesAdded={0} linesRemoved={0} />
+    )
+
+    expect(screen.queryByText(/turns?/i)).not.toBeInTheDocument()
+  })
+
+  test('localizes large line counts', () => {
+    render(
+      <ActivityFooter
+        totalDurationMs={0}
+        linesAdded={12_345}
+        linesRemoved={6_789}
+      />
+    )
+
+    expect(screen.getByText('+12,345 / -6,789')).toBeInTheDocument()
+  })
+})
+
+describe('formatDuration', () => {
+  test('renders minutes only when under one hour', () => {
+    expect(formatDuration(45_000)).toBe('0m')
+    expect(formatDuration(90_000)).toBe('1m')
+  })
+
+  test('renders hours and zero-padded minutes when over one hour', () => {
+    expect(formatDuration(3_900_000)).toBe('1h 05m')
+  })
+})
 ```
 
-Note any tests that assert on the literal strings "Agent Alpha" or "SYSTEM IDLE". Those become invalid after this task.
+- [ ] **Step 2: Update `Sidebar.test.tsx`**
 
-- [ ] **Step 2: Update the Sidebar test**
-
-Three changes:
-
-**a)** Add the agent-status fixture at the top of the file (after existing imports / fixtures):
+Add the agent-status fixture at the top of the file (after existing imports):
 
 ```tsx
 import type { AgentStatus } from '../../agent-status/types'
@@ -556,7 +492,7 @@ const inactiveAgentStatus: AgentStatus = {
 }
 ```
 
-**b)** Replace the existing "renders agent header with name and status" test at lines 113-124 of `Sidebar.test.tsx`:
+Replace the existing "renders agent header with name and status" test (Sidebar.test.tsx:113-124) with:
 
 ```tsx
 test('renders the sidebar status header in the top slot', () => {
@@ -569,121 +505,19 @@ test('renders the sidebar status header in the top slot', () => {
     />
   )
 
-  // Idle SidebarStatusHeader renders this testid; the active variant
-  // would render the StatusCard testid instead. Either path proves
-  // delegation succeeded.
   expect(screen.getByTestId('sidebar-status-header-idle')).toBeInTheDocument()
-  // The hardcoded "Agent Alpha" / "System Idle" strings no longer exist.
   expect(screen.queryByText('Agent Alpha')).not.toBeInTheDocument()
   expect(screen.queryByText('System Idle')).not.toBeInTheDocument()
 })
 ```
 
-**c)** Add `agentStatus={inactiveAgentStatus}` to every other `render(<Sidebar … />)` call site in the file. The prop is required, so every test that omits it will fail TypeScript and runtime. Use a recursive search/replace if the file is large.
+Add `agentStatus={inactiveAgentStatus}` to every other `render(<Sidebar … />)` call in the file. The prop is required.
 
-- [ ] **Step 3: Run the test to verify it fails**
+- [ ] **Step 3: Update `AgentStatusPanel.test.tsx`**
 
-```bash
-npx vitest run src/features/workspace/components/Sidebar.test.tsx
-```
+Drop any `vi.mock('../hooks/useAgentStatus')` block.
 
-Expected: FAIL — `agentStatus` is not yet a prop on Sidebar (TypeScript), or the new "renders header" test fails because the header isn't rendered yet.
-
-- [ ] **Step 4: Update `Sidebar.tsx`**
-
-Modify `src/features/workspace/components/Sidebar.tsx`:
-
-1. Add `agentStatus` to `SidebarProps`:
-
-```tsx
-import type { AgentStatus } from '../../agent-status/types'
-
-export interface SidebarProps {
-  sessions: Session[]
-  activeSessionId: string | null
-  activeCwd?: string
-  onSessionClick: (sessionId: string) => void
-  onNewInstance?: () => void
-  onRemoveSession?: (sessionId: string) => void
-  onRenameSession?: (sessionId: string, name: string) => void
-  onReorderSessions?: (sessions: Session[]) => void
-  onFileSelect?: (node: FileNode) => void
-  agentStatus: AgentStatus
-}
-```
-
-2. Add `agentStatus` to the destructure in the component signature.
-
-3. Import `SidebarStatusHeader`:
-
-```tsx
-import { SidebarStatusHeader } from './SidebarStatusHeader'
-```
-
-4. Replace the entire hardcoded "Agent header" block (lines roughly 222-240, the `<div className="flex items-center gap-3 px-4 py-4">…"Agent Alpha"…"System Idle"…</div>` block) with:
-
-```tsx
-<div className="px-3 pt-3 pb-2">
-  <SidebarStatusHeader
-    status={agentStatus}
-    activeSessionName={
-      sessions.find((s) => s.id === activeSessionId)?.name ?? null
-    }
-  />
-</div>
-```
-
-The `"Active Sessions"` heading + `<Reorder.Group>` + everything below remain unchanged.
-
-- [ ] **Step 5: Run Sidebar tests to verify they pass**
-
-```bash
-npx vitest run src/features/workspace/components/Sidebar.test.tsx
-```
-
-Expected: PASS.
-
-- [ ] **Step 6: Type-check**
-
-```bash
-npm run type-check
-```
-
-Expected: TypeScript errors in `WorkspaceView.tsx` (it doesn't pass `agentStatus`) and still in `AgentStatusPanel.tsx` (still passes `turnCount`). Both intentional; Tasks 5 and 6 fix them.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add src/features/workspace/components/Sidebar.tsx \
-        src/features/workspace/components/Sidebar.test.tsx
-git commit -m "feat(workspace): render SidebarStatusHeader in Sidebar top slot"
-```
-
-> Same rationale as Task 2: the type-check window between tasks doesn't block the pre-push hook. Local commits are fine.
-
----
-
-## Task 5: Refactor `<AgentStatusPanel>` to take `agentStatus` prop, drop `<StatusCard>`, use `sumLines`
-
-**Files:**
-
-- Modify: `src/features/agent-status/components/AgentStatusPanel.tsx`
-- Modify: `src/features/agent-status/components/AgentStatusPanel.test.tsx`
-
-- [ ] **Step 1: Read the existing AgentStatusPanel test**
-
-```bash
-cat src/features/agent-status/components/AgentStatusPanel.test.tsx
-```
-
-Note how `useAgentStatus` is currently mocked.
-
-- [ ] **Step 2: Update the AgentStatusPanel test**
-
-Update the test file:
-
-1. Drop the `vi.mock('../hooks/useAgentStatus')` block if it exists. The panel no longer calls the hook.
-2. Add the `activeAgentStatus` fixture at the top of the file:
+Add the active-status fixture at the top:
 
 ```tsx
 import type { AgentStatus } from '../types'
@@ -717,28 +551,11 @@ const activeAgentStatus: AgentStatus = {
 }
 ```
 
-3. Pass `agentStatus` directly as a prop in every `render(<AgentStatusPanel … />)` call. Drop any `sessionId` prop (it no longer exists on the panel).
-4. Add a test asserting `<StatusCard>` is no longer rendered inside the panel:
+Replace any `sessionId="…"` prop on `<AgentStatusPanel>` with `agentStatus={activeAgentStatus}` (drop `sessionId` — the panel no longer accepts it).
+
+Mock `useGitStatus` (which the panel still calls):
 
 ```tsx
-test('does not render StatusCard inside the panel', () => {
-  render(
-    <AgentStatusPanel
-      agentStatus={activeAgentStatus}
-      cwd="/tmp/repo"
-      onOpenDiff={() => {}}
-    />
-  )
-
-  expect(screen.queryByTestId('agent-status-card')).not.toBeInTheDocument()
-})
-```
-
-4. Add a test asserting footer line totals come from git-diff data. Mock `useGitStatus` to return changed files with insertions/deletions:
-
-```tsx
-import { vi } from 'vitest'
-
 vi.mock('../../diff/hooks/useGitStatus', () => ({
   useGitStatus: () => ({
     files: [
@@ -764,6 +581,22 @@ vi.mock('../../diff/hooks/useGitStatus', () => ({
     idle: false,
   }),
 }))
+```
+
+Add two new tests:
+
+```tsx
+test('does not render StatusCard inside the panel', () => {
+  render(
+    <AgentStatusPanel
+      agentStatus={activeAgentStatus}
+      cwd="/tmp/repo"
+      onOpenDiff={() => {}}
+    />
+  )
+
+  expect(screen.queryByTestId('agent-status-card')).not.toBeInTheDocument()
+})
 
 test('footer renders aggregated git-diff line totals', () => {
   render(
@@ -774,23 +607,338 @@ test('footer renders aggregated git-diff line totals', () => {
     />
   )
 
+  // From the useGitStatus mock above: 5+7 added, 2+1 removed.
   expect(screen.getByText('+12 / -3')).toBeInTheDocument()
 })
 ```
 
-Use the same `activeAgentStatus` fixture shape from Task 3, but with `cost`, `rateLimits`, etc. populated to satisfy `<ContextBucket>` / `<TokenCache>` rendering (or update those mocks if they crash on null).
+- [ ] **Step 4: Update `WorkspaceView.test.tsx`**
 
-- [ ] **Step 3: Run the test to verify it fails**
+The existing file mocks `useAgentStatus` at module scope (around lines 18-34) and `<AgentStatusPanel>` with a `capturedAgentStatusPanelProps` capture object (around lines 47-70). Extend the capture to include `agentStatus`.
 
-```bash
-npx vitest run src/features/agent-status/components/AgentStatusPanel.test.tsx
+Add the `AgentStatus` import near the top:
+
+```tsx
+import type { AgentStatus } from '../agent-status/types'
+import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 ```
 
-Expected: FAIL — the panel still calls `useAgentStatus` internally and still renders `<StatusCard>`.
+Update `capturedAgentStatusPanelProps` and the mock factory:
 
-- [ ] **Step 4: Update `AgentStatusPanel.tsx`**
+```tsx
+const capturedAgentStatusPanelProps: {
+  onOpenFile?: (path: string) => void
+  onOpenDiff?: unknown
+  agentStatus?: AgentStatus // NEW
+} = {}
 
-Rewrite the component:
+interface MockAgentStatusPanelProps {
+  onOpenFile?: (path: string) => void
+  onOpenDiff?: unknown
+  agentStatus?: AgentStatus // NEW
+}
+
+vi.mock('../agent-status/components/AgentStatusPanel', () => ({
+  AgentStatusPanel: ({
+    onOpenFile = undefined,
+    onOpenDiff = undefined,
+    agentStatus = undefined, // NEW
+  }: MockAgentStatusPanelProps): ReactElement => {
+    capturedAgentStatusPanelProps.onOpenFile = onOpenFile
+    capturedAgentStatusPanelProps.onOpenDiff = onOpenDiff
+    capturedAgentStatusPanelProps.agentStatus = agentStatus // NEW
+    return <div data-testid="agent-status-panel" />
+  },
+}))
+```
+
+Reset the new field in `beforeEach`:
+
+```tsx
+capturedAgentStatusPanelProps.agentStatus = undefined
+```
+
+Add a new test inside the `describe('WorkspaceView', …)` block:
+
+```tsx
+test('lifts useAgentStatus and forwards the latest activeSessionId', async () => {
+  render(<WorkspaceView />)
+
+  // Wait for session restore to settle (the listSessions mock resolves
+  // sess-1, so this proves activeSessionId is non-null).
+  await screen.findByRole('button', { name: 'session 1' })
+
+  const useAgentStatusMock = vi.mocked(useAgentStatus)
+  const calls = useAgentStatusMock.mock.calls
+  const lastArg = calls[calls.length - 1]?.[0] as string | null
+
+  // Latest call arg, not call count — activeSessionId flips from null
+  // to the restored id during mount, and React may re-render multiple
+  // times. We assert the *value* of the most-recent call.
+  expect(lastArg).toBe('sess-1')
+})
+
+test('passes the lifted agentStatus to AgentStatusPanel', async () => {
+  render(<WorkspaceView />)
+
+  await screen.findByRole('button', { name: 'session 1' })
+
+  // The mocked useAgentStatus returns isActive: true / agentType: 'claude-code'.
+  expect(capturedAgentStatusPanelProps.agentStatus).toMatchObject({
+    isActive: true,
+    agentType: 'claude-code',
+  })
+})
+```
+
+- [ ] **Step 5: Create `WorkspaceView.subscription.test.tsx`**
+
+This is a separate file because it mocks `<Sidebar>` (the existing `WorkspaceView.test.tsx` keeps the real Sidebar so its session-list assertions still work).
+
+```tsx
+import type { ReactElement } from 'react'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { WorkspaceView } from './WorkspaceView'
+import type { AgentStatus } from '../agent-status/types'
+
+// Mock TerminalPane / TerminalZone deps to avoid xterm.js in jsdom
+vi.mock('../terminal/components/TerminalPane', () => ({
+  TerminalPane: vi.fn(() => <div data-testid="terminal-pane-mock" />),
+}))
+
+vi.mock('../editor/hooks/useEditorBuffer', () => ({
+  useEditorBuffer: () => ({
+    filePath: null,
+    originalContent: '',
+    currentContent: '',
+    isDirty: false,
+    isLoading: false,
+    openFile: vi.fn().mockResolvedValue(undefined),
+    saveFile: vi.fn().mockResolvedValue(undefined),
+    updateContent: vi.fn(),
+  }),
+}))
+
+vi.mock('../terminal/services/terminalService', () => ({
+  createTerminalService: vi.fn(() => ({
+    spawn: vi.fn().mockResolvedValue({ sessionId: 'new-id', pid: 999 }),
+    write: vi.fn().mockResolvedValue(undefined),
+    resize: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(() => Promise.resolve(() => {})),
+    onExit: vi.fn(() => () => {}),
+    onError: vi.fn(() => () => {}),
+    listSessions: vi.fn().mockResolvedValue({
+      activeSessionId: 'sess-1',
+      sessions: [
+        {
+          id: 'sess-1',
+          cwd: '~',
+          status: {
+            kind: 'Alive',
+            pid: 1234,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    }),
+    setActiveSession: vi.fn().mockResolvedValue(undefined),
+    reorderSessions: vi.fn().mockResolvedValue(undefined),
+    updateSessionCwd: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+// CRITICAL: this mock returns a fresh object per call so reference
+// equality distinguishes "one hook call shared by both children" from
+// "one hook call per child". The previous WorkspaceView.test.tsx mock
+// returns a singleton, which would defeat this assertion.
+vi.mock('../agent-status/hooks/useAgentStatus', () => ({
+  useAgentStatus: vi.fn(
+    (): AgentStatus => ({
+      isActive: true,
+      agentType: 'claude-code',
+      modelId: null,
+      modelDisplayName: null,
+      version: null,
+      sessionId: null,
+      agentSessionId: null,
+      contextWindow: null,
+      cost: null,
+      rateLimits: null,
+      toolCalls: { total: 0, byType: {}, active: null },
+      recentToolCalls: [],
+      testRun: null,
+    })
+  ),
+}))
+
+const capturedSidebarProps: { agentStatus?: AgentStatus } = {}
+const capturedPanelProps: { agentStatus?: AgentStatus } = {}
+
+interface MockSidebarProps {
+  agentStatus?: AgentStatus
+}
+interface MockPanelProps {
+  agentStatus?: AgentStatus
+}
+
+vi.mock('./components/Sidebar', () => ({
+  Sidebar: ({ agentStatus = undefined }: MockSidebarProps): ReactElement => {
+    capturedSidebarProps.agentStatus = agentStatus
+    return <div data-testid="sidebar-mock" />
+  },
+}))
+
+vi.mock('../agent-status/components/AgentStatusPanel', () => ({
+  AgentStatusPanel: ({
+    agentStatus = undefined,
+  }: MockPanelProps): ReactElement => {
+    capturedPanelProps.agentStatus = agentStatus
+    return <div data-testid="agent-status-panel-mock" />
+  },
+}))
+
+describe('WorkspaceView lifted-subscription contract', () => {
+  beforeEach(() => {
+    capturedSidebarProps.agentStatus = undefined
+    capturedPanelProps.agentStatus = undefined
+  })
+
+  test('Sidebar and AgentStatusPanel receive agentStatus from a single hook call', async () => {
+    render(<WorkspaceView />)
+
+    // Wait for the children to be rendered with their props captured.
+    await screen.findByTestId('sidebar-mock')
+    await screen.findByTestId('agent-status-panel-mock')
+
+    expect(capturedSidebarProps.agentStatus).toBeDefined()
+    expect(capturedPanelProps.agentStatus).toBeDefined()
+
+    // Reference equality. Because the useAgentStatus mock above returns
+    // a FRESH object per call (the factory runs anew each invocation),
+    // two separate hook calls would yield two distinct objects, and
+    // `toBe` would fail. A single hook call shared by both children
+    // yields the same object reference and `toBe` passes.
+    expect(capturedSidebarProps.agentStatus).toBe(
+      capturedPanelProps.agentStatus
+    )
+  })
+})
+```
+
+- [ ] **Step 6: Run all the new/changed tests to verify they fail**
+
+```bash
+npx vitest run \
+  src/features/agent-status/components/ActivityFooter.test.tsx \
+  src/features/workspace/components/Sidebar.test.tsx \
+  src/features/agent-status/components/AgentStatusPanel.test.tsx \
+  src/features/workspace/WorkspaceView.test.tsx \
+  src/features/workspace/WorkspaceView.subscription.test.tsx
+```
+
+Expected: FAIL across all five files. Possible failure modes:
+
+- `ActivityFooter` still requires `turnCount` → type/runtime error
+- `Sidebar` doesn't accept `agentStatus` → type error; `<SidebarStatusHeader>` testid not in DOM
+- `AgentStatusPanel` doesn't accept `agentStatus` → type error; `<StatusCard>` still rendered
+- `WorkspaceView` doesn't lift `useAgentStatus` → captured props undefined
+
+### 3.2 Update implementations
+
+- [ ] **Step 7: Update `ActivityFooter.tsx`**
+
+Replace the file contents:
+
+```tsx
+import type { ReactElement } from 'react'
+
+interface ActivityFooterProps {
+  totalDurationMs: number
+  linesAdded: number
+  linesRemoved: number
+}
+
+const formatDuration = (ms: number): string => {
+  const hours = Math.floor(ms / 3_600_000)
+  const minutes = Math.floor((ms % 3_600_000) / 60_000)
+
+  if (hours > 0) {
+    return `${hours}h ${minutes.toString().padStart(2, '0')}m`
+  }
+
+  return `${minutes}m`
+}
+
+const formatLines = (n: number): string => n.toLocaleString('en-US')
+
+export const ActivityFooter = ({
+  totalDurationMs,
+  linesAdded,
+  linesRemoved,
+}: ActivityFooterProps): ReactElement => (
+  <div className="mt-auto bg-surface-container-low/40 px-5 py-3">
+    <div className="flex items-center justify-between font-mono text-[9px] text-outline">
+      <span>{formatDuration(totalDurationMs)}</span>
+      <span>
+        +{formatLines(linesAdded)} / -{formatLines(linesRemoved)}
+      </span>
+    </div>
+  </div>
+)
+
+export { formatDuration }
+```
+
+- [ ] **Step 8: Update `Sidebar.tsx`**
+
+Three edits:
+
+**a)** Add the `agentStatus` prop to `SidebarProps`:
+
+```tsx
+import type { AgentStatus } from '../../agent-status/types'
+
+export interface SidebarProps {
+  sessions: Session[]
+  activeSessionId: string | null
+  activeCwd?: string
+  onSessionClick: (sessionId: string) => void
+  onNewInstance?: () => void
+  onRemoveSession?: (sessionId: string) => void
+  onRenameSession?: (sessionId: string, name: string) => void
+  onReorderSessions?: (sessions: Session[]) => void
+  onFileSelect?: (node: FileNode) => void
+  agentStatus: AgentStatus
+}
+```
+
+**b)** Destructure `agentStatus` in the component signature, alongside the other props.
+
+**c)** Import `SidebarStatusHeader` and replace the hardcoded "Agent header" block (lines roughly 222-240, the `<div className="flex items-center gap-3 px-4 py-4">…"Agent Alpha"…"System Idle"…</div>`):
+
+```tsx
+import { SidebarStatusHeader } from './SidebarStatusHeader'
+
+// …
+
+;<div className="px-3 pt-3 pb-2">
+  <SidebarStatusHeader
+    status={agentStatus}
+    activeSessionName={
+      sessions.find((s) => s.id === activeSessionId)?.name ?? null
+    }
+  />
+</div>
+```
+
+The `"Active Sessions"` heading + `<Reorder.Group>` + everything below remain unchanged.
+
+- [ ] **Step 9: Update `AgentStatusPanel.tsx`**
+
+Replace the file contents:
 
 ```tsx
 import { useMemo, type ReactElement } from 'react'
@@ -891,185 +1039,29 @@ export const AgentStatusPanel = ({
 export default AgentStatusPanel
 ```
 
-Key changes vs. before:
+- [ ] **Step 10: Update `WorkspaceView.tsx`**
 
-1. The `sessionId: string | null` prop is gone; the parent now owns the hook.
-2. `agentStatus: AgentStatus` is the new prop.
-3. The internal `useAgentStatus(sessionId)` call is removed.
-4. `<StatusCard>` is no longer rendered.
-5. `lineTotals = useMemo(() => sumLines(effectiveFiles), …)` feeds the footer.
-6. `<ActivityFooter>` no longer receives `turnCount`.
+Five edits:
 
-- [ ] **Step 5: Run the AgentStatusPanel tests to verify they pass**
-
-```bash
-npx vitest run src/features/agent-status/components/AgentStatusPanel.test.tsx
-```
-
-Expected: PASS.
-
-- [ ] **Step 6: Type-check**
-
-```bash
-npm run type-check
-```
-
-Expected: TypeScript errors in `WorkspaceView.tsx` only — it still passes `sessionId` and does not pass `agentStatus`. Task 6 fixes those.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add src/features/agent-status/components/AgentStatusPanel.tsx \
-        src/features/agent-status/components/AgentStatusPanel.test.tsx
-git commit -m "refactor(agent-status): take agentStatus as prop, drop StatusCard render, use sumLines for footer"
-```
-
-> After this task lands, `npm run type-check` still fails on `WorkspaceView.tsx` (sessionId/agentStatus mismatch). Task 6 fixes the last error.
-
----
-
-## Task 6: Lift `useAgentStatus` to `<WorkspaceView>` + bump `SIDEBAR_MIN`
-
-**Files:**
-
-- Modify: `src/features/workspace/WorkspaceView.tsx`
-- Modify: `src/features/workspace/WorkspaceView.test.tsx`
-
-- [ ] **Step 1: Read the existing WorkspaceView test**
-
-```bash
-cat src/features/workspace/WorkspaceView.test.tsx
-```
-
-Note any existing `useAgentStatus` mocks.
-
-- [ ] **Step 2: Update the WorkspaceView test**
-
-The test file already mocks `useAgentStatus` at module scope (`vi.mock('../agent-status/hooks/useAgentStatus', () => ({ useAgentStatus: vi.fn(() => …) }))`) and already mocks `AgentStatusPanel` with a `capturedAgentStatusPanelProps` capture object. We extend both.
-
-**a)** Add `agentStatus` to the captured-props object near the existing capture (around line 47-50 of the file):
-
-```tsx
-import type { AgentStatus } from '../agent-status/types'
-
-const capturedAgentStatusPanelProps: {
-  onOpenFile?: (path: string) => void
-  onOpenDiff?: unknown
-  agentStatus?: AgentStatus // NEW
-} = {}
-
-interface MockAgentStatusPanelProps {
-  onOpenFile?: (path: string) => void
-  onOpenDiff?: unknown
-  agentStatus?: AgentStatus // NEW
-}
-```
-
-**b)** Capture the new prop inside the mock factory (around line 57-69):
-
-```tsx
-vi.mock('../agent-status/components/AgentStatusPanel', () => ({
-  AgentStatusPanel: ({
-    onOpenFile = undefined,
-    onOpenDiff = undefined,
-    agentStatus = undefined, // NEW
-  }: MockAgentStatusPanelProps): ReactElement => {
-    capturedAgentStatusPanelProps.onOpenFile = onOpenFile
-    capturedAgentStatusPanelProps.onOpenDiff = onOpenDiff
-    capturedAgentStatusPanelProps.agentStatus = agentStatus // NEW
-
-    return <div data-testid="agent-status-panel" />
-  },
-}))
-```
-
-**c)** Reset the new field in `beforeEach`:
-
-```tsx
-beforeEach(() => {
-  capturedAgentStatusPanelProps.onOpenFile = undefined
-  capturedAgentStatusPanelProps.onOpenDiff = undefined
-  capturedAgentStatusPanelProps.agentStatus = undefined // NEW
-
-  // … existing useEditorBuffer mock setup …
-})
-```
-
-**d)** Add a top-level import to grab the mock reference:
-
-```tsx
-import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
-```
-
-**e)** Add the new tests inside the `describe('WorkspaceView', …)` block:
-
-```tsx
-test('lifts useAgentStatus and forwards the latest activeSessionId', async () => {
-  render(<WorkspaceView />)
-
-  // Wait for session restore to settle (existing tests use this pattern —
-  // findByRole on the session button proves activeSessionId is non-null).
-  await screen.findByRole('button', { name: 'session 1' })
-
-  const useAgentStatusMock = vi.mocked(useAgentStatus)
-  const calls = useAgentStatusMock.mock.calls
-  const lastArg = calls[calls.length - 1]?.[0] as string | null
-
-  // The exact id depends on the listSessions mock above (currently 'sess-1').
-  // The point of this assertion is the LATEST call arg, not the call count —
-  // activeSessionId flips from null to the restored id, and React may
-  // re-render multiple times, so call count is not stable.
-  expect(lastArg).toBe('sess-1')
-})
-
-test('passes agentStatus to AgentStatusPanel', async () => {
-  render(<WorkspaceView />)
-
-  await screen.findByRole('button', { name: 'session 1' })
-
-  // The mocked useAgentStatus returns an object with isActive: true,
-  // agentType: 'claude-code'. Verify AgentStatusPanel receives that exact
-  // shape (proving the prop drill works).
-  expect(capturedAgentStatusPanelProps.agentStatus).toMatchObject({
-    isActive: true,
-    agentType: 'claude-code',
-  })
-})
-```
-
-> Note: the existing `useAgentStatus` mock at module scope is `vi.fn(() => ({ isActive: true, agentType: 'claude-code', … }))`. Calling `vi.mocked(useAgentStatus).mock.calls` reads the call log directly. No restructuring of the existing mock is needed.
-
-> The "both children receive the same `agentStatus` reference" assertion from the spec test plan is satisfied by TypeScript: the same `agentStatus` const is passed to both `<Sidebar>` and `<AgentStatusPanel>`. Asserting it again at runtime would require also mocking `<Sidebar>`, which the existing test file leaves real. We assert only the AgentStatusPanel side here; if a future regression makes the Sidebar receive a different reference, type-check would catch it before tests run.
-
-- [ ] **Step 3: Run the test to verify it fails**
-
-```bash
-npx vitest run src/features/workspace/WorkspaceView.test.tsx
-```
-
-Expected: FAIL — `useAgentStatus` is not yet called from WorkspaceView.
-
-- [ ] **Step 4: Update `WorkspaceView.tsx`**
-
-1. Bump `SIDEBAR_MIN` from `180` to `240`:
+**a)** Bump `SIDEBAR_MIN`:
 
 ```ts
 const SIDEBAR_MIN = 240
 ```
 
-2. Add the import:
+**b)** Import the hook:
 
 ```ts
 import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 ```
 
-3. Inside the component, near the other hook calls (after `useSessionManager`, before or after `useResizable` — order doesn't matter for behavior):
+**c)** Inside the component, after `useSessionManager`:
 
 ```ts
 const agentStatus = useAgentStatus(activeSessionId)
 ```
 
-4. In the `<Sidebar … />` JSX, add the prop:
+**d)** Pass `agentStatus` to `<Sidebar>`:
 
 ```tsx
 <Sidebar
@@ -1086,7 +1078,7 @@ const agentStatus = useAgentStatus(activeSessionId)
 />
 ```
 
-5. In the `<AgentStatusPanel … />` JSX, replace `sessionId={activeSessionId}` with `agentStatus={agentStatus}`:
+**e)** Replace `sessionId={activeSessionId}` on `<AgentStatusPanel>` with `agentStatus={agentStatus}`:
 
 ```tsx
 <AgentStatusPanel
@@ -1097,15 +1089,22 @@ const agentStatus = useAgentStatus(activeSessionId)
 />
 ```
 
-- [ ] **Step 5: Run the WorkspaceView test to verify it passes**
+### 3.3 Verify and commit
+
+- [ ] **Step 11: Run all the changed test files**
 
 ```bash
-npx vitest run src/features/workspace/WorkspaceView.test.tsx
+npx vitest run \
+  src/features/agent-status/components/ActivityFooter.test.tsx \
+  src/features/workspace/components/Sidebar.test.tsx \
+  src/features/agent-status/components/AgentStatusPanel.test.tsx \
+  src/features/workspace/WorkspaceView.test.tsx \
+  src/features/workspace/WorkspaceView.subscription.test.tsx
 ```
 
-Expected: PASS.
+Expected: PASS across all five files.
 
-- [ ] **Step 6: Type-check the whole project**
+- [ ] **Step 12: Type-check**
 
 ```bash
 npm run type-check
@@ -1113,15 +1112,15 @@ npm run type-check
 
 Expected: PASS, no errors.
 
-- [ ] **Step 7: Run the full test suite**
+- [ ] **Step 13: Run the full test suite**
 
 ```bash
 npm run test
 ```
 
-Expected: PASS. If any test fails because it depended on the old `<StatusCard>` location inside the panel or the old footer signature, fix it now — those failures belong to this task.
+Expected: PASS. If anything else regresses (other tests assumed `<StatusCard>` was inside the panel, or the old footer signature), fix it now and add the fix to this commit.
 
-- [ ] **Step 8: Run lint + format**
+- [ ] **Step 14: Lint and format**
 
 ```bash
 npm run lint
@@ -1130,19 +1129,44 @@ npm run format:check
 
 Expected: PASS. Run `npm run lint:fix` and `npm run format` if anything fails.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 15: Stage everything and commit**
 
 ```bash
-git add src/features/workspace/WorkspaceView.tsx \
-        src/features/workspace/WorkspaceView.test.tsx
-git commit -m "feat(workspace): lift useAgentStatus to WorkspaceView; bump SIDEBAR_MIN to 240"
+git add \
+  src/features/agent-status/components/ActivityFooter.tsx \
+  src/features/agent-status/components/ActivityFooter.test.tsx \
+  src/features/workspace/components/Sidebar.tsx \
+  src/features/workspace/components/Sidebar.test.tsx \
+  src/features/agent-status/components/AgentStatusPanel.tsx \
+  src/features/agent-status/components/AgentStatusPanel.test.tsx \
+  src/features/workspace/WorkspaceView.tsx \
+  src/features/workspace/WorkspaceView.test.tsx \
+  src/features/workspace/WorkspaceView.subscription.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(workspace): move StatusCard render-site to Sidebar; re-source ActivityFooter lines from git diff
+
+- Lift useAgentStatus to WorkspaceView; pass agentStatus to both Sidebar
+  and AgentStatusPanel (one Tauri subscription, asserted via reference
+  equality in WorkspaceView.subscription.test.tsx).
+- Sidebar replaces hardcoded "Agent Alpha" header with <SidebarStatusHeader>;
+  AgentStatusPanel drops <StatusCard>, takes agentStatus as a prop.
+- ActivityFooter renders two cells (duration + lines); turnCount removed
+  pending real turn-counting (separate issue).
+- Lines now sum from useGitStatus's effectiveFiles via sumLines, matching
+  the per-file numbers shown in <FilesChanged>.
+- Bump SIDEBAR_MIN from 180 to 240 so StatusCard's grid-cols-2
+  BudgetMetrics doesn't overflow at the narrowest sidebar width.
+
+Spec: docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md
+EOF
+)"
 ```
 
-(No `--no-verify` here — the tree should now be fully green, so pre-push must pass.)
+Expected: pre-commit passes (lint-staged → eslint + tsc clean), commit succeeds.
 
 ---
 
-## Task 7: Visual verification at narrow sidebar width
+## Task 4: Visual verification at narrow sidebar width
 
 **Files:** None (manual verification per spec section 5.2.1)
 
@@ -1152,11 +1176,11 @@ git commit -m "feat(workspace): lift useAgentStatus to WorkspaceView; bump SIDEB
 npm run tauri:dev
 ```
 
-(Or `npm run dev` if Tauri is unavailable in your environment — the layout tests can be done in the browser preview.)
+(Or `npm run dev` if Tauri is unavailable.)
 
 - [ ] **Step 2: Drag the sidebar to its minimum width**
 
-Drag the right edge of the sidebar all the way left. Verify the resize stops at the new minimum (240px). The `<SidebarStatusHeader>` should render the `<StatusCard>` (if an agent is attached in the session) without horizontal overflow.
+Drag the right edge of the sidebar all the way left. Verify the resize stops at the new minimum (240px). The `<SidebarStatusHeader>` should render the `<StatusCard>` (when an agent is attached) without horizontal overflow.
 
 - [ ] **Step 3: Verify worst-case `<BudgetMetrics>` variants**
 
@@ -1168,12 +1192,11 @@ Test all three variants of `<BudgetMetrics>` at 240px:
 
 If you cannot reproduce all three with real agents, render the panel with worst-case mock data:
 
-```tsx
-// Worst-case fixtures to drop into the dev server temporarily:
-//   cost.totalCostUsd        = 9999.99   → "$9999.99"
-//   cost.totalApiDurationMs  = 9_999_000 → "9999.0s"
-//   totalInputTokens         = 9_999_999 → "10.0M" (whichever formatTokens produces)
-//   rateLimits.fiveHour      = 99.99%
+```
+cost.totalCostUsd        = 9999.99   → "$9999.99"
+cost.totalApiDurationMs  = 9_999_000 → "9999.0s"
+totalInputTokens         = 9_999_999 → "10.0M" (whichever formatTokens produces)
+rateLimits.fiveHour      = 99.99%
 ```
 
 - [ ] **Step 4: Inspect for horizontal overflow**
@@ -1183,7 +1206,7 @@ Open DevTools, hover the StatusCard, look for clipped or wrapped text inside the
 - [ ] **Step 5: Decide**
 
 - **If no overflow at 240px** → `SIDEBAR_MIN = 240` is correct. Continue to Step 6.
-- **If overflow at 240px** → raise `SIDEBAR_MIN` further (try 260, then 280) and re-verify. Update Task 6's commit (or add a follow-up commit) accordingly. Document the final value in the PR description.
+- **If overflow at 240px** → raise `SIDEBAR_MIN` further (try 260, then 280) and re-verify. Add the bump as a small follow-up commit.
 
 - [ ] **Step 6: Verify the `<SidebarStatusHeader>` idle state**
 
@@ -1198,7 +1221,7 @@ git commit -m "fix(workspace): raise SIDEBAR_MIN to <verified-value> after empir
 
 ---
 
-## Task 8: File the deferred-`turnCount` issue
+## Task 5: File the deferred-`turnCount` issue
 
 **Files:** None (filed via `gh issue create`)
 
@@ -1257,17 +1280,18 @@ No commit — `gh issue create` does not modify the working tree.
 
 ## Self-review notes (post-write)
 
-- Spec § 5.1 (`<SidebarStatusHeader>`): Task 3 covers the active branch (delegates to `<StatusCard>`) and idle branch (inline JSX matching StatusCard chrome).
-- Spec § 5.2 (`<StatusCard>` stays put): No source edit; only Task 3 imports it from its existing location.
-- Spec § 5.2.1 (`SIDEBAR_MIN` bump): Task 6 raises the const; Task 7 verifies and re-bumps if needed.
-- Spec § 5.3 (Sidebar accepts `agentStatus`): Task 4.
-- Spec § 5.4 (AgentStatusPanel takes prop, drops StatusCard, uses sumLines): Task 5.
-- Spec § 5.5 (ActivityFooter drops turnCount): Task 2.
-- Spec § 5.6 (sumLines util): Task 1.
-- Spec § 5.7 (WorkspaceView lifts hook + bumps SIDEBAR_MIN): Task 6.
-- Spec § 6 (test plan): each row mapped to the corresponding task above.
-- Spec § 8 (follow-up): Task 8 files the deferred-turnCount issue.
+- **Spec coverage:**
+  - § 5.1 (`<SidebarStatusHeader>`): Task 2 covers the active branch (delegates to `<StatusCard>`) and idle branch (inline JSX matching StatusCard chrome).
+  - § 5.2 (`<StatusCard>` stays put): Verified — Task 2 imports from existing path; no source edit.
+  - § 5.2.1 (`SIDEBAR_MIN` bump): Task 3 bumps to 240; Task 4 verifies and re-bumps if needed.
+  - § 5.3 (Sidebar accepts `agentStatus`): Task 3, sub-step 8.
+  - § 5.4 (AgentStatusPanel takes prop, drops StatusCard, uses sumLines): Task 3, sub-step 9.
+  - § 5.5 (ActivityFooter drops turnCount): Task 3, sub-step 7.
+  - § 5.6 (sumLines util): Task 1.
+  - § 5.7 (WorkspaceView lifts hook + bumps SIDEBAR_MIN): Task 3, sub-step 10.
+  - § 6 (test plan): each row mapped to the corresponding sub-step.
+  - § 8 (follow-up): Task 5 files the deferred-turnCount issue.
 
-The plan accepts a brief `tsc` red window between Tasks 2 and 6 — the ActivityFooter and Sidebar/AgentStatusPanel signatures shift before `WorkspaceView` is updated, leaving the project type-error-positive but test-green (vitest uses Vite's esbuild, which strips types). Local commits during Tasks 2-5 succeed; the pre-push hook only runs `vitest run`, not `tsc`. Task 6 closes the type window.
+- **Architectural assertion:** the "one Tauri subscription, not two" goal is asserted at runtime by `WorkspaceView.subscription.test.tsx`. The mock returns a fresh `AgentStatus` object per call, so reference equality across captured Sidebar / AgentStatusPanel props proves a single hook invocation feeds both children. TypeScript alone does not catch a regression where `useAgentStatus` is called twice with the same id.
 
-> **Push gate:** CI (`.github/workflows/ci-checks.yml`) runs `npm run type-check` on push. **Do not push to GitHub until Task 6 is committed.** Push only after Task 6, ideally after Task 7 (visual verification) too. Tasks 1-6 are local-only commits.
+- **Pre-commit hook compatibility:** Tasks 1, 2, and 3 each end in a type-clean tree. The pre-commit hook (`lint-staged` → `tsc --noEmit`) passes after every commit. There is no intermediate "type-error window" — the four files that change signature in Task 3 are all updated together in one commit.

--- a/docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md
+++ b/docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md
@@ -146,9 +146,21 @@ import { StatusCard } from '../../agent-status/components/StatusCard'
 
 This is a workspace → agent-status cross-feature import. The agent-status feature owns the `StatusCard` widget, its dependencies (`BudgetMetrics`, `CostState`, `RateLimitsState`), and its tests. The workspace feature only owns _where_ it renders, not the widget itself.
 
-Earlier draft proposed moving `StatusCard.tsx` into `workspace/components/`. Rejected after review (`docs/reviews/...`): physically relocating a component while it still depends on `BudgetMetrics` and agent-status types widens the feature boundary for no UX benefit. The component renders identically in either location; only the file path changes. Keeping it next to its dependencies is cleaner.
+Earlier draft proposed moving `StatusCard.tsx` into `workspace/components/`. Rejected during brainstorming review: physically relocating a component while it still depends on `BudgetMetrics` and agent-status types widens the feature boundary for no UX benefit. The component renders identically in either location; only the file path changes. Keeping it next to its dependencies is cleaner.
 
 `<BudgetMetrics>` and the existing `StatusCard.test.tsx` are unchanged.
+
+#### 5.2.1 Width constraint — `SIDEBAR_MIN` must accommodate StatusCard
+
+The activity panel was a fixed 280px column. The sidebar is resizable: `SIDEBAR_MIN = 180`, `SIDEBAR_DEFAULT = 340`, `SIDEBAR_MAX = 560` (`src/features/workspace/WorkspaceView.tsx:17-19`). Rendering `<StatusCard>` inside the sidebar exposes it to widths it was not designed for.
+
+`BudgetMetrics` uses fixed `grid-cols-2` cells with `px-2.5 py-2` padding and `text-sm` mono values (`src/features/agent-status/components/BudgetMetrics.tsx:26-33`). At `SIDEBAR_MIN = 180`, content area inside the StatusCard's `p-3` shrinks to ~132px, giving each metric cell ~62px, of which ~42px is value-text width. Long values like `"$1234.56"` or `"123.4K"` are at risk of overflow.
+
+**Spec requirement:** `SIDEBAR_MIN` must be raised to a value where `<StatusCard>` renders without horizontal overflow at the narrowest sidebar width, across all `BudgetMetrics` variants (`SubscriberVariant`, `ApiKeyVariant`, `FallbackVariant`) and all realistic value lengths.
+
+- **Initial proposal:** raise `SIDEBAR_MIN` from `180` to `240`.
+- **Verification gate:** during implementation, render the StatusCard at `SIDEBAR_MIN` with worst-case mock data (`totalCostUsd: 9999.99`, large token counts, both 5h+7d rate-limit bars) and confirm no horizontal overflow. If 240px is insufficient, raise further. If 240px is more than needed, the spec's intent is satisfied — leave it at 240 unless the user pushes back.
+- **Out of scope:** making `<StatusCard>` / `<BudgetMetrics>` responsive (container queries, narrow-mode grid-cols-1, font-size scaling). Tracked as a follow-up — see section 8.
 
 ### 5.3 `<Sidebar>` — modified
 
@@ -259,7 +271,8 @@ Pure, deterministic, unit-testable. Lives under `diff/utils/` because `ChangedFi
 
 **File:** `src/features/workspace/WorkspaceView.tsx`
 
-Add `useAgentStatus(activeSessionId)` call. Pass the resulting `AgentStatus` to both `<Sidebar agentStatus={…} />` and `<AgentStatusPanel agentStatus={…} />`.
+- Add `useAgentStatus(activeSessionId)` call. Pass the resulting `AgentStatus` to both `<Sidebar agentStatus={…} />` and `<AgentStatusPanel agentStatus={…} />`.
+- Raise `SIDEBAR_MIN` from `180` to `240` (or to the empirically-verified value per section 5.2.1). `SIDEBAR_DEFAULT` and `SIDEBAR_MAX` unchanged.
 
 ## 6. Test plan
 
@@ -293,6 +306,7 @@ No Rust changes. No new Tauri events. No bindings to regenerate.
 
 - **`feat(agent-status): wire real turnCount in ActivityFooter`** — restore the turns cell using a Rust transcript-watcher counter. References this spec for the deferred decision.
 - **`refactor(diff): consolidate duplicate useGitStatus subscriptions`** — `AgentStatusPanel` and `DiffPanelContent` independently call `useGitStatus(cwd)` for the same cwd, creating two file-watchers. Lift to a shared context or memoize at WorkspaceView.
+- **`feat(agent-status): make StatusCard / BudgetMetrics responsive at narrow widths`** — section 5.2.1 of this spec sidesteps the narrow-width problem by raising `SIDEBAR_MIN`. A more flexible fix is for `<BudgetMetrics>` to drop to `grid-cols-1` (or use container queries) below a threshold, allowing `SIDEBAR_MIN` to return to `180`. Out of scope here.
 
 ## 9. Open questions
 

--- a/docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md
+++ b/docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md
@@ -16,7 +16,7 @@ A separate, smaller problem in the same panel:
 
 3. **`ActivityFooter` lies about lines added/removed.** It sources `linesAdded` / `linesRemoved` from `status.cost?.totalLinesAdded / totalLinesRemoved` — fields populated only when Claude Code emits cost-metrics events (typically on turn-end). Until then the footer shows `+0 / -0` even when files have been edited. Meanwhile, the sibling `<FilesChanged>` panel one tier above already shows the _real_ per-file insertions/deletions from `useGitStatus`. Two readings of the same concept, one wrong.
 
-This spec moves the StatusCard to the Sidebar (problem 1+2) and re-sources the footer's line totals from the same git-diff data that powers FilesChanged (problem 3).
+This spec relocates the StatusCard's render-site to the Sidebar (problem 1+2) — the file itself stays in `agent-status/components/`, only the parent that mounts it changes — and re-sources the footer's line totals from the same git-diff data that powers FilesChanged (problem 3).
 
 ## 2. Out of scope
 
@@ -66,7 +66,7 @@ WorkspaceView
        ├── <Sidebar agentStatus={status} … />
        │     └── <SidebarStatusHeader status={status}
        │                              activeSessionName={…} />   ← new
-       │           ├── if status.isActive: <StatusCard … />     ← moved here
+       │           ├── if status.isActive: <StatusCard … />     ← rendered here, file stays in agent-status/
        │           └── else:                inline idle JSX (avatar + name + "Idle" dot)
        │
        └── <AgentStatusPanel agentStatus={status} … />          ← prop, no longer hook
@@ -134,20 +134,21 @@ The `status="running"` literal currently flows from `AgentStatusPanel.tsx:67`. S
 
 No `<BudgetMetrics>` row in idle state — there's no data to show. The idle card is shorter than the active card (no metrics, no model name, no token cells). This vertical-jiggle on attach is intentional; layout-stability matters at the avatar/title row, not at the metrics row that only exists when there's data.
 
-### 5.2 `<StatusCard>` — moved, no behavior change
+### 5.2 `<StatusCard>` — stays put, only the render-site moves
 
-**From:** `src/features/agent-status/components/StatusCard.tsx`
-**To:** `src/features/workspace/components/StatusCard.tsx`
+**File:** `src/features/agent-status/components/StatusCard.tsx` — **no file move, no source edit**.
 
-Test file moves alongside (`StatusCard.test.tsx`).
+`<SidebarStatusHeader>` (in `src/features/workspace/components/`) imports it as:
 
-Imports updated:
+```ts
+import { StatusCard } from '../../agent-status/components/StatusCard'
+```
 
-- `import { BudgetMetrics } from './BudgetMetrics'` → `import { BudgetMetrics } from '../../agent-status/components/BudgetMetrics'`
-- `import type { CostState, RateLimitsState } from '../types'` → `import type { CostState, RateLimitsState } from '../../agent-status/types'`
-- `import { Tooltip } from '../../../components/Tooltip'` — depth unchanged, no edit
+This is a workspace → agent-status cross-feature import. The agent-status feature owns the `StatusCard` widget, its dependencies (`BudgetMetrics`, `CostState`, `RateLimitsState`), and its tests. The workspace feature only owns _where_ it renders, not the widget itself.
 
-`<BudgetMetrics>` stays at `src/features/agent-status/components/BudgetMetrics.tsx`. The agent-status feature still owns the budget-metrics concept; the workspace feature owns the rendering of the agent identity card. Cross-feature import (workspace → agent-status) is the price for this split, and it's already the pattern for type imports.
+Earlier draft proposed moving `StatusCard.tsx` into `workspace/components/`. Rejected after review (`docs/reviews/...`): physically relocating a component while it still depends on `BudgetMetrics` and agent-status types widens the feature boundary for no UX benefit. The component renders identically in either location; only the file path changes. Keeping it next to its dependencies is cleaner.
+
+`<BudgetMetrics>` and the existing `StatusCard.test.tsx` are unchanged.
 
 ### 5.3 `<Sidebar>` — modified
 
@@ -262,15 +263,15 @@ Add `useAgentStatus(activeSessionId)` call. Pass the resulting `AgentStatus` to 
 
 ## 6. Test plan
 
-| File                                                                                 | Coverage                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/features/workspace/components/SidebarStatusHeader.test.tsx` (new)               | Active state delegates to `<StatusCard>` with mapped props; idle state renders gradient avatar + session name + "Idle"; idle fallback when `activeSessionName` is `null` shows "No session"             |
-| `src/features/workspace/components/StatusCard.test.tsx` (moved)                      | Existing assertions preserved; only the file path moves                                                                                                                                                 |
-| `src/features/workspace/components/Sidebar.test.tsx` (existing — update)             | Replace assertions about "Agent Alpha" / "SYSTEM IDLE" with assertions that delegate to `<SidebarStatusHeader>` (or test the rendered output for both active and idle props)                            |
-| `src/features/diff/utils/sumLines.test.ts` (new)                                     | Empty input → `{0, 0}`; mixed `insertions` / `deletions` (some `undefined`) sum correctly; large numbers don't overflow; single-file case                                                               |
-| `src/features/agent-status/components/ActivityFooter.test.tsx` (existing — update)   | Drop the `turnCount` test cases; assert two cells (duration + lines) only; remove `turnCount` from `ActivityFooterProps` test fixtures                                                                  |
-| `src/features/agent-status/components/AgentStatusPanel.test.tsx` (existing — update) | Pass `agentStatus` as a prop instead of mocking the hook; assert footer receives `linesAdded` / `linesRemoved` from a mock `useGitStatus`; assert `<StatusCard>` is no longer rendered inside the panel |
-| `src/features/workspace/WorkspaceView.test.tsx` (new or update)                      | Lifted `useAgentStatus` is called once with `activeSessionId`; both child components receive the same `agentStatus` reference                                                                           |
+| File                                                                                 | Coverage                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/features/workspace/components/SidebarStatusHeader.test.tsx` (new)               | Active state delegates to `<StatusCard>` with mapped props; idle state renders gradient avatar + session name + "Idle"; idle fallback when `activeSessionName` is `null` shows "No session"                                                                |
+| `src/features/agent-status/components/StatusCard.test.tsx` (existing — unchanged)    | No change. StatusCard stays in agent-status.                                                                                                                                                                                                               |
+| `src/features/workspace/components/Sidebar.test.tsx` (existing — update)             | Replace assertions about "Agent Alpha" / "SYSTEM IDLE" with assertions that delegate to `<SidebarStatusHeader>` (or test the rendered output for both active and idle props)                                                                               |
+| `src/features/diff/utils/sumLines.test.ts` (new)                                     | Empty input → `{0, 0}`; mixed `insertions` / `deletions` (some `undefined`) sum correctly; large numbers don't overflow; single-file case                                                                                                                  |
+| `src/features/agent-status/components/ActivityFooter.test.tsx` (existing — update)   | Drop the `turnCount` test cases; assert two cells (duration + lines) only; remove `turnCount` from `ActivityFooterProps` test fixtures                                                                                                                     |
+| `src/features/agent-status/components/AgentStatusPanel.test.tsx` (existing — update) | Pass `agentStatus` as a prop instead of mocking the hook; assert footer receives `linesAdded` / `linesRemoved` from a mock `useGitStatus`; assert `<StatusCard>` is no longer rendered inside the panel                                                    |
+| `src/features/workspace/WorkspaceView.test.tsx` (new or update)                      | Assert `useAgentStatus` receives the **latest** `activeSessionId` (not call count — the value flips from `null` to a real id during session restore, so call counts are not stable); assert both child components receive the same `agentStatus` reference |
 
 No Rust changes. No new Tauri events. No bindings to regenerate.
 
@@ -283,7 +284,7 @@ No Rust changes. No new Tauri events. No bindings to regenerate.
 
 **Behavioral regressions:**
 
-- The lifted `useAgentStatus` call now happens at `WorkspaceView` regardless of whether `<AgentStatusPanel>` is collapsed. The hook is cheap (one Tauri listener, derived state) — this is a wash.
+- `useAgentStatus` subscription owner moves from `<AgentStatusPanel>` to `<WorkspaceView>`. Mount/unmount semantics are unchanged: `AgentStatusPanel` is already permanently mounted (the width=0 collapse hides it visually but does not unmount), so it was already running the hook regardless of visibility. This is a refactor of where the hook is called, not a change in how often.
 - `ActivityFooter` lines numbers will differ from before. Previously they reflected agent-reported cumulative cost (which only includes agent-driven edits and only updates on cost events). Now they reflect git-diff working-tree state (includes manual edits, updates as files change). This is the _correct_ behavior; some users may notice the numbers move differently from what they remember.
 
 **Rollback:** No data migration, no persisted state, no schema changes. Reverting the PR fully restores the prior behavior.

--- a/docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md
+++ b/docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md
@@ -1,0 +1,298 @@
+# Sidebar Status Header — Design Spec
+
+**Date:** 2026-04-30
+**Status:** Draft (brainstorming complete; pending user review)
+**Author:** Claude (with Will)
+**Related:** Token Cache Block (`2026-04-30-token-cache-block-design.md`), Activity Feed (`2026-04-22-activity-feed-design.md`), Files Changed Panel (`2026-04-23-files-changed-panel-design.md`)
+
+## 1. Why
+
+Two problems in the current workspace shell:
+
+1. **The Sidebar's top header is dead UI.** It hardcodes `"Agent Alpha"` with a static `"SYSTEM IDLE"` label (`src/features/workspace/components/Sidebar.tsx:222-240`). The string never changes, never reflects the real agent, never updates when an agent attaches or disconnects.
+2. **`AgentStatusPanel`'s `<StatusCard>` already shows live agent identity** — name, model, running/paused/completed/errored dot, and token totals (`src/features/agent-status/components/StatusCard.tsx`). But it lives on the right side of the screen, where the activity stream is. The natural place for "who is the agent" is the left sidebar — the same column that lists the active sessions.
+
+A separate, smaller problem in the same panel:
+
+3. **`ActivityFooter` lies about lines added/removed.** It sources `linesAdded` / `linesRemoved` from `status.cost?.totalLinesAdded / totalLinesRemoved` — fields populated only when Claude Code emits cost-metrics events (typically on turn-end). Until then the footer shows `+0 / -0` even when files have been edited. Meanwhile, the sibling `<FilesChanged>` panel one tier above already shows the _real_ per-file insertions/deletions from `useGitStatus`. Two readings of the same concept, one wrong.
+
+This spec moves the StatusCard to the Sidebar (problem 1+2) and re-sources the footer's line totals from the same git-diff data that powers FilesChanged (problem 3).
+
+## 2. Out of scope
+
+- **`turnCount` in `ActivityFooter`** — currently hardcoded to `0` at `AgentStatusPanel.tsx:101`. There is no turn counter anywhere in the system. Adding one requires Rust transcript-watcher work (count `"user"` lines that aren't tool_result wrappers) plus a new event type. **Deferred to a follow-up issue.** This spec drops the `0 turns` span entirely rather than continue showing a fake number.
+- **Consolidating the duplicate `useGitStatus` subscriptions** in `AgentStatusPanel` and `DiffPanelContent`. Two file-watchers for the same cwd is a known duplication unrelated to this work.
+- **Multi-session agent identity** — when the user has multiple sessions, only the _active_ session's status is shown in the sidebar. Per-session status indicators on the session list rows are a separate feature.
+
+## 3. Existing data flow
+
+```
+Statusline JSON
+  └── parse_statusline()  ── src-tauri/src/agent/statusline.rs
+       └── tauri.emit("agent-status", AgentStatusEvent)
+
+useAgentStatus(sessionId)  ── src/features/agent-status/hooks/useAgentStatus.ts
+  └── AgentStatus { isActive, agentType, modelId, contextWindow, cost, rateLimits, … }
+
+WorkspaceView  ── src/features/workspace/WorkspaceView.tsx
+  ├── <Sidebar>                           hardcoded "Agent Alpha" header
+  ├── main panel                          terminal + drawer
+  └── <AgentStatusPanel sessionId>        calls useAgentStatus locally
+        ├── <StatusCard …status props>     ← will move
+        ├── <ContextBucket />
+        ├── <TokenCache />
+        ├── <ToolCallSummary />
+        ├── <ActivityFeed />
+        ├── <FilesChanged files=effectiveFiles />   ← already git-diff-sourced
+        ├── <TestResults />
+        └── <ActivityFooter
+              linesAdded={status.cost?.totalLinesAdded ?? 0}    ← will re-source
+              linesRemoved={status.cost?.totalLinesRemoved ?? 0}
+              turnCount={0}                                       ← will be removed
+              totalDurationMs={status.cost?.totalDurationMs ?? 0} />
+
+useGitStatus(cwd)  ── src/features/diff/hooks/useGitStatus.ts
+  └── { files: ChangedFile[], filesCwd, loading, error, refresh, idle }
+        └── ChangedFile { path, status, insertions?, deletions?, staged }
+```
+
+`StatusCard` is rendered at the top of `AgentStatusPanel`'s flex column. The Sidebar header above is unrelated and uses no agent-status state.
+
+## 4. Target data flow
+
+```
+WorkspaceView
+  └── const status = useAgentStatus(activeSessionId)            ← lifted up
+       ├── <Sidebar agentStatus={status} … />
+       │     └── <SidebarStatusHeader status={status}
+       │                              activeSessionName={…} />   ← new
+       │           ├── if status.isActive: <StatusCard … />     ← moved here
+       │           └── else:                inline idle JSX (avatar + name + "Idle" dot)
+       │
+       └── <AgentStatusPanel agentStatus={status} … />          ← prop, no longer hook
+             ├── <ContextBucket />
+             ├── <TokenCache />
+             ├── <ToolCallSummary />
+             ├── <ActivityFeed />
+             ├── <FilesChanged files=effectiveFiles />
+             ├── <TestResults />
+             └── <ActivityFooter
+                   linesAdded={totals.added}                    ← from sumLines
+                   linesRemoved={totals.removed}
+                   totalDurationMs={status.cost?.totalDurationMs ?? 0} />
+
+const totals = useMemo(() => sumLines(effectiveFiles), [effectiveFiles])
+```
+
+`useAgentStatus` lifts to `WorkspaceView` so the Sidebar header and the AgentStatusPanel share one Tauri subscription. `useGitStatus` stays where it is (`AgentStatusPanel`) — the sumLines totals are derived from the same `effectiveFiles` array that already feeds `<FilesChanged>`. Single source of truth within the panel.
+
+## 5. Component anatomy
+
+### 5.1 `<SidebarStatusHeader>` — new
+
+**Location:** `src/features/workspace/components/SidebarStatusHeader.tsx`
+
+```ts
+interface SidebarStatusHeaderProps {
+  status: AgentStatus
+  activeSessionName: string | null
+}
+```
+
+**Render contract** (no separate `IdleHeader` component — both branches are inline JSX inside `<SidebarStatusHeader>`):
+
+```tsx
+if (status.isActive && status.agentType) {
+  return <StatusCard {...mapStatusToCardProps(status)} status="running" />
+}
+// idle: inline JSX matching StatusCard chrome — see layout below
+return (
+  <div className="flex flex-col gap-3 rounded-xl bg-surface-container-high p-3">
+    {/* gradient avatar + (activeSessionName ?? 'No session') + dot + 'Idle' */}
+  </div>
+)
+```
+
+`mapStatusToCardProps(status)` is a small local helper that translates `AgentStatus` (`agentType`, `modelId`, `modelDisplayName`, `cost`, `rateLimits`, `contextWindow.totalInputTokens / totalOutputTokens`) into the `StatusCardProps` shape. Same field-by-field mapping that `AgentStatusPanel.tsx:62-71` does today.
+
+The `status="running"` literal currently flows from `AgentStatusPanel.tsx:67`. Same value here — the `StatusType` discriminator inside `<StatusCard>` (`'running' | 'paused' | 'completed' | 'errored'`) does not yet have a feed from `AgentStatus`; that's an existing limitation, not introduced by this spec.
+
+**Idle fallback layout (matches StatusCard chrome to avoid jiggle on attach/detach):**
+
+```
+┌──────────────────────────────────────┐
+│ [▦ avatar 32]  <session name | "No   │
+│                 session">             │
+│                ● Idle                 │
+└──────────────────────────────────────┘
+```
+
+- Outer: `flex flex-col gap-3 rounded-xl bg-surface-container-high p-3` (identical to StatusCard outer)
+- Avatar: `h-8 w-8 rounded-lg bg-gradient-to-br from-primary-container to-secondary` (identical to StatusCard avatar)
+- Title: `font-headline text-sm font-[800] text-on-surface` — `activeSessionName` or `"No session"` if null
+- Status row: dot `h-2 w-2 rounded-full bg-on-surface/30` (no glow) + label `"Idle"` in `text-[10px] font-medium text-outline`
+
+No `<BudgetMetrics>` row in idle state — there's no data to show. The idle card is shorter than the active card (no metrics, no model name, no token cells). This vertical-jiggle on attach is intentional; layout-stability matters at the avatar/title row, not at the metrics row that only exists when there's data.
+
+### 5.2 `<StatusCard>` — moved, no behavior change
+
+**From:** `src/features/agent-status/components/StatusCard.tsx`
+**To:** `src/features/workspace/components/StatusCard.tsx`
+
+Test file moves alongside (`StatusCard.test.tsx`).
+
+Imports updated:
+
+- `import { BudgetMetrics } from './BudgetMetrics'` → `import { BudgetMetrics } from '../../agent-status/components/BudgetMetrics'`
+- `import type { CostState, RateLimitsState } from '../types'` → `import type { CostState, RateLimitsState } from '../../agent-status/types'`
+- `import { Tooltip } from '../../../components/Tooltip'` — depth unchanged, no edit
+
+`<BudgetMetrics>` stays at `src/features/agent-status/components/BudgetMetrics.tsx`. The agent-status feature still owns the budget-metrics concept; the workspace feature owns the rendering of the agent identity card. Cross-feature import (workspace → agent-status) is the price for this split, and it's already the pattern for type imports.
+
+### 5.3 `<Sidebar>` — modified
+
+**File:** `src/features/workspace/components/Sidebar.tsx`
+
+```ts
+interface SidebarProps {
+  // existing props unchanged
+  sessions: Session[]
+  activeSessionId: string | null
+  // … etc.
+  agentStatus: AgentStatus // NEW
+}
+```
+
+The hardcoded header block at `Sidebar.tsx:222-240` is replaced with:
+
+```tsx
+<div className="px-3 pt-3 pb-2">
+  <SidebarStatusHeader
+    status={agentStatus}
+    activeSessionName={
+      sessions.find((s) => s.id === activeSessionId)?.name ?? null
+    }
+  />
+</div>
+```
+
+The `"Active Sessions"` heading and session list below are unchanged. The new `<SidebarStatusHeader>` is wrapped in `px-3 pt-3 pb-2` so the rounded card sits inset from the sidebar edge.
+
+### 5.4 `<AgentStatusPanel>` — modified
+
+**File:** `src/features/agent-status/components/AgentStatusPanel.tsx`
+
+Changes:
+
+- Remove `useAgentStatus(sessionId)` call. Replace with `agentStatus` prop.
+- Remove `<StatusCard />` render — the entire first child of the inner flex column.
+- The wrapping `<div className="flex flex-col gap-2 p-2">` keeps `<ContextBucket />` and `<TokenCache />`.
+- Pass `effectiveFiles` through `sumLines` (memoized) and feed the result to `<ActivityFooter>`.
+- Drop `turnCount={0}` from the footer call.
+
+```tsx
+const totals = useMemo(() => sumLines(effectiveFiles), [effectiveFiles])
+// …
+<ActivityFooter
+  totalDurationMs={status.cost?.totalDurationMs ?? 0}
+  linesAdded={totals.added}
+  linesRemoved={totals.removed}
+/>
+```
+
+The visibility gate (`status.isActive ? '280px' : '0px'`) stays. When no agent is active, the right panel collapses; the Sidebar still shows the idle header.
+
+### 5.5 `<ActivityFooter>` — modified
+
+**File:** `src/features/agent-status/components/ActivityFooter.tsx`
+
+```ts
+interface ActivityFooterProps {
+  totalDurationMs: number
+  linesAdded: number
+  linesRemoved: number
+  // turnCount: number   ← REMOVED
+}
+```
+
+Render:
+
+```tsx
+<div className="mt-auto bg-surface-container-low/40 px-5 py-3">
+  <div className="flex items-center justify-between font-mono text-[9px] text-outline">
+    <span>{formatDuration(totalDurationMs)}</span>
+    <span>
+      +{formatLines(linesAdded)} / -{formatLines(linesRemoved)}
+    </span>
+  </div>
+</div>
+```
+
+Two cells now instead of three. The `<span>{turnCount} turns</span>` middle cell is removed. The two remaining cells redistribute via `justify-between` — duration left, line totals right.
+
+### 5.6 `sumLines` util — new
+
+**File:** `src/features/diff/utils/sumLines.ts`
+
+```ts
+import type { ChangedFile } from '../types'
+
+export interface LineTotals {
+  added: number
+  removed: number
+}
+
+export const sumLines = (files: ChangedFile[]): LineTotals =>
+  files.reduce<LineTotals>(
+    (acc, f) => ({
+      added: acc.added + (f.insertions ?? 0),
+      removed: acc.removed + (f.deletions ?? 0),
+    }),
+    { added: 0, removed: 0 }
+  )
+```
+
+Pure, deterministic, unit-testable. Lives under `diff/utils/` because `ChangedFile` is the diff-feature type.
+
+### 5.7 `WorkspaceView` — modified
+
+**File:** `src/features/workspace/WorkspaceView.tsx`
+
+Add `useAgentStatus(activeSessionId)` call. Pass the resulting `AgentStatus` to both `<Sidebar agentStatus={…} />` and `<AgentStatusPanel agentStatus={…} />`.
+
+## 6. Test plan
+
+| File                                                                                 | Coverage                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/features/workspace/components/SidebarStatusHeader.test.tsx` (new)               | Active state delegates to `<StatusCard>` with mapped props; idle state renders gradient avatar + session name + "Idle"; idle fallback when `activeSessionName` is `null` shows "No session"             |
+| `src/features/workspace/components/StatusCard.test.tsx` (moved)                      | Existing assertions preserved; only the file path moves                                                                                                                                                 |
+| `src/features/workspace/components/Sidebar.test.tsx` (existing — update)             | Replace assertions about "Agent Alpha" / "SYSTEM IDLE" with assertions that delegate to `<SidebarStatusHeader>` (or test the rendered output for both active and idle props)                            |
+| `src/features/diff/utils/sumLines.test.ts` (new)                                     | Empty input → `{0, 0}`; mixed `insertions` / `deletions` (some `undefined`) sum correctly; large numbers don't overflow; single-file case                                                               |
+| `src/features/agent-status/components/ActivityFooter.test.tsx` (existing — update)   | Drop the `turnCount` test cases; assert two cells (duration + lines) only; remove `turnCount` from `ActivityFooterProps` test fixtures                                                                  |
+| `src/features/agent-status/components/AgentStatusPanel.test.tsx` (existing — update) | Pass `agentStatus` as a prop instead of mocking the hook; assert footer receives `linesAdded` / `linesRemoved` from a mock `useGitStatus`; assert `<StatusCard>` is no longer rendered inside the panel |
+| `src/features/workspace/WorkspaceView.test.tsx` (new or update)                      | Lifted `useAgentStatus` is called once with `activeSessionId`; both child components receive the same `agentStatus` reference                                                                           |
+
+No Rust changes. No new Tauri events. No bindings to regenerate.
+
+## 7. Risk + rollout
+
+**Visual regressions:**
+
+- Sidebar's top area is now taller when an agent is attached (StatusCard ~96-120px) vs the previous header (~72px). The session list compresses by that delta. Acceptable — the StatusCard is a meaningful addition.
+- The activity panel's top is now `<ContextBucket>` instead of `<StatusCard>`. The agent identity is no longer visible while looking at the activity stream. The trade-off is that the identity moves to a more persistent surface (sidebar visible whenever workspace is) and the activity panel becomes denser with stream-relevant content.
+
+**Behavioral regressions:**
+
+- The lifted `useAgentStatus` call now happens at `WorkspaceView` regardless of whether `<AgentStatusPanel>` is collapsed. The hook is cheap (one Tauri listener, derived state) — this is a wash.
+- `ActivityFooter` lines numbers will differ from before. Previously they reflected agent-reported cumulative cost (which only includes agent-driven edits and only updates on cost events). Now they reflect git-diff working-tree state (includes manual edits, updates as files change). This is the _correct_ behavior; some users may notice the numbers move differently from what they remember.
+
+**Rollback:** No data migration, no persisted state, no schema changes. Reverting the PR fully restores the prior behavior.
+
+## 8. Follow-up issues
+
+- **`feat(agent-status): wire real turnCount in ActivityFooter`** — restore the turns cell using a Rust transcript-watcher counter. References this spec for the deferred decision.
+- **`refactor(diff): consolidate duplicate useGitStatus subscriptions`** — `AgentStatusPanel` and `DiffPanelContent` independently call `useGitStatus(cwd)` for the same cwd, creating two file-watchers. Lift to a shared context or memoize at WorkspaceView.
+
+## 9. Open questions
+
+None — all decisions confirmed during brainstorming on 2026-04-30.

--- a/src/features/agent-status/components/ActivityFooter.test.tsx
+++ b/src/features/agent-status/components/ActivityFooter.test.tsx
@@ -1,66 +1,49 @@
-import { describe, test, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
 import { ActivityFooter, formatDuration } from './ActivityFooter'
 
-describe('formatDuration', () => {
-  test('formats 0 as "0m"', () => {
-    expect(formatDuration(0)).toBe('0m')
+describe('ActivityFooter', () => {
+  test('renders duration and line totals', () => {
+    render(
+      <ActivityFooter
+        totalDurationMs={90_000}
+        linesAdded={42}
+        linesRemoved={9}
+      />
+    )
+
+    expect(screen.getByText('1m')).toBeInTheDocument()
+    expect(screen.getByText('+42 / -9')).toBeInTheDocument()
   })
 
-  test('formats minutes only', () => {
-    expect(formatDuration(300_000)).toBe('5m')
+  test('does not render a turns cell', () => {
+    render(
+      <ActivityFooter totalDurationMs={0} linesAdded={0} linesRemoved={0} />
+    )
+
+    expect(screen.queryByText(/turns?/i)).not.toBeInTheDocument()
   })
 
-  test('formats hours and minutes', () => {
-    expect(formatDuration(9_900_000)).toBe('2h 45m')
-  })
+  test('localizes large line counts', () => {
+    render(
+      <ActivityFooter
+        totalDurationMs={0}
+        linesAdded={12_345}
+        linesRemoved={6_789}
+      />
+    )
 
-  test('pads minutes with leading zero', () => {
-    expect(formatDuration(3_660_000)).toBe('1h 01m')
-  })
-
-  test('formats 165 minutes correctly', () => {
-    expect(formatDuration(165 * 60_000)).toBe('2h 45m')
+    expect(screen.getByText('+12,345 / -6,789')).toBeInTheDocument()
   })
 })
 
-describe('ActivityFooter', () => {
-  test('renders formatted duration', () => {
-    render(
-      <ActivityFooter
-        totalDurationMs={9_900_000}
-        turnCount={12}
-        linesAdded={1500}
-        linesRemoved={300}
-      />
-    )
-
-    expect(screen.getByText('2h 45m')).toBeInTheDocument()
+describe('formatDuration', () => {
+  test('renders minutes only when under one hour', () => {
+    expect(formatDuration(45_000)).toBe('0m')
+    expect(formatDuration(90_000)).toBe('1m')
   })
 
-  test('renders turn count', () => {
-    render(
-      <ActivityFooter
-        totalDurationMs={0}
-        turnCount={12}
-        linesAdded={0}
-        linesRemoved={0}
-      />
-    )
-
-    expect(screen.getByText('12 turns')).toBeInTheDocument()
-  })
-
-  test('renders formatted line counts with commas', () => {
-    render(
-      <ActivityFooter
-        totalDurationMs={0}
-        turnCount={0}
-        linesAdded={1500}
-        linesRemoved={300}
-      />
-    )
-
-    expect(screen.getByText('+1,500 / -300')).toBeInTheDocument()
+  test('renders hours and zero-padded minutes when over one hour', () => {
+    expect(formatDuration(3_900_000)).toBe('1h 05m')
   })
 })

--- a/src/features/agent-status/components/ActivityFooter.tsx
+++ b/src/features/agent-status/components/ActivityFooter.tsx
@@ -2,7 +2,6 @@ import type { ReactElement } from 'react'
 
 interface ActivityFooterProps {
   totalDurationMs: number
-  turnCount: number
   linesAdded: number
   linesRemoved: number
 }
@@ -22,14 +21,12 @@ const formatLines = (n: number): string => n.toLocaleString('en-US')
 
 export const ActivityFooter = ({
   totalDurationMs,
-  turnCount,
   linesAdded,
   linesRemoved,
 }: ActivityFooterProps): ReactElement => (
   <div className="mt-auto bg-surface-container-low/40 px-5 py-3">
     <div className="flex items-center justify-between font-mono text-[9px] text-outline">
       <span>{formatDuration(totalDurationMs)}</span>
-      <span>{turnCount} turns</span>
       <span>
         +{formatLines(linesAdded)} / -{formatLines(linesRemoved)}
       </span>

--- a/src/features/agent-status/components/AgentStatusPanel.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { AgentStatusPanel } from './AgentStatusPanel'
 import type { AgentStatus } from '../types'
 
-const defaultStatus: AgentStatus = {
+const inactiveAgentStatus: AgentStatus = {
   isActive: false,
   agentType: null,
   modelId: null,
@@ -19,283 +19,287 @@ const defaultStatus: AgentStatus = {
   testRun: null,
 }
 
-const defaultGitStatus = {
-  files: [],
-  filesCwd: '/test',
-  loading: false,
-  error: null,
-  refresh: vi.fn(),
-  idle: false,
+const activeAgentStatus: AgentStatus = {
+  ...inactiveAgentStatus,
+  isActive: true,
+  agentType: 'claude-code',
+  modelId: 'claude-3-5-sonnet-20241022',
+  modelDisplayName: 'Claude 3.5 Sonnet',
+  sessionId: 'sess-1',
+  contextWindow: {
+    usedPercentage: 12,
+    contextWindowSize: 200_000,
+    totalInputTokens: 1_234,
+    totalOutputTokens: 567,
+    currentUsage: null,
+  },
+  cost: {
+    totalCostUsd: 0.05,
+    totalDurationMs: 60_000,
+    totalApiDurationMs: 30_000,
+    totalLinesAdded: 0,
+    totalLinesRemoved: 0,
+  },
 }
 
-vi.mock('../hooks/useAgentStatus', () => ({
-  useAgentStatus: vi.fn(() => defaultStatus),
-}))
-
 vi.mock('../../diff/hooks/useGitStatus', () => ({
-  useGitStatus: vi.fn(() => defaultGitStatus),
+  useGitStatus: (): {
+    files: {
+      path: string
+      status: string
+      insertions: number
+      deletions: number
+      staged: boolean
+    }[]
+    filesCwd: string
+    loading: boolean
+    error: null
+    refresh: () => void
+    idle: boolean
+  } => ({
+    files: [
+      {
+        path: 'a.ts',
+        status: 'modified',
+        insertions: 5,
+        deletions: 2,
+        staged: false,
+      },
+      {
+        path: 'b.ts',
+        status: 'modified',
+        insertions: 7,
+        deletions: 1,
+        staged: false,
+      },
+    ],
+    filesCwd: '/tmp/repo',
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    idle: false,
+  }),
 }))
 
 const defaultProps = {
-  sessionId: null as string | null,
   cwd: '/test',
   onOpenDiff: vi.fn(),
 }
 
 describe('AgentStatusPanel', () => {
-  test('renders at 0px width when agent is not active', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue({
-      ...defaultStatus,
-      isActive: false,
-    })
-
-    render(<AgentStatusPanel {...defaultProps} sessionId={null} />)
-
+  test('renders at 0px width when agent is not active', () => {
+    render(
+      <AgentStatusPanel {...defaultProps} agentStatus={inactiveAgentStatus} />
+    )
     const panel = screen.getByTestId('agent-status-panel')
     expect(panel.style.width).toBe('0px')
   })
 
-  test('renders at 280px width when agent is active', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue({
-      ...defaultStatus,
-      isActive: true,
-      agentType: 'claude-code',
-      sessionId: 'session-1',
-    })
-
-    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
-
+  test('renders at 280px width when agent is active', () => {
+    render(
+      <AgentStatusPanel {...defaultProps} agentStatus={activeAgentStatus} />
+    )
     const panel = screen.getByTestId('agent-status-panel')
     expect(panel.style.width).toBe('280px')
   })
 
-  test('applies ease-out transition when collapsing', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue({
-      ...defaultStatus,
-      isActive: false,
-    })
-
-    render(<AgentStatusPanel {...defaultProps} sessionId={null} />)
-
+  test('applies ease-out transition when collapsing', () => {
+    render(
+      <AgentStatusPanel {...defaultProps} agentStatus={inactiveAgentStatus} />
+    )
     const panel = screen.getByTestId('agent-status-panel')
     expect(panel.style.transition).toBe('width 200ms ease-out')
   })
 
-  test('applies ease-in transition when expanding', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue({
-      ...defaultStatus,
-      isActive: true,
-      agentType: 'claude-code',
-      sessionId: 'session-1',
-    })
-
-    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
-
+  test('applies ease-in transition when expanding', () => {
+    render(
+      <AgentStatusPanel {...defaultProps} agentStatus={activeAgentStatus} />
+    )
     const panel = screen.getByTestId('agent-status-panel')
     expect(panel.style.transition).toBe('width 200ms ease-in')
   })
 
-  test('has overflow-hidden to clip content during collapse', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue(defaultStatus)
-
-    render(<AgentStatusPanel {...defaultProps} sessionId={null} />)
-
+  test('has overflow-hidden to clip content during collapse', () => {
+    render(
+      <AgentStatusPanel {...defaultProps} agentStatus={inactiveAgentStatus} />
+    )
     const panel = screen.getByTestId('agent-status-panel')
     expect(panel).toHaveClass('overflow-hidden')
   })
 
-  test('passes sessionId to useAgentStatus', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue(defaultStatus)
+  test('does not render StatusCard inside the panel', () => {
+    render(
+      <AgentStatusPanel
+        agentStatus={activeAgentStatus}
+        cwd="/tmp/repo"
+        onOpenDiff={vi.fn()}
+      />
+    )
 
-    render(<AgentStatusPanel {...defaultProps} sessionId="session-42" />)
-
-    expect(useAgentStatus).toHaveBeenCalledWith('session-42')
+    expect(screen.queryByTestId('agent-status-card')).not.toBeInTheDocument()
   })
 
-  test('renders ToolCallSummary and ActivityFeed inside the scrollable region', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue({
-      ...defaultStatus,
-      isActive: true,
-      agentType: 'claude-code',
-      sessionId: 'session-1',
-      toolCalls: {
-        total: 1,
-        byType: { Edit: 1 },
-        active: null,
-      },
-      recentToolCalls: [
-        {
-          id: 'r-1',
-          tool: 'Edit',
-          args: 'src/foo.ts',
-          status: 'done',
-          durationMs: 100,
-          timestamp: '2026-04-22T11:59:42Z',
-          isTestFile: false,
-        },
-      ],
-    })
+  test('footer renders aggregated git-diff line totals', () => {
+    render(
+      <AgentStatusPanel
+        agentStatus={activeAgentStatus}
+        cwd="/tmp/repo"
+        onOpenDiff={vi.fn()}
+      />
+    )
 
-    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
+    // From the useGitStatus mock above: 5+7 added, 2+1 removed.
+    expect(screen.getByText('+12 / -3')).toBeInTheDocument()
+  })
+
+  test('renders ToolCallSummary and ActivityFeed inside the scrollable region', () => {
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={{
+          ...activeAgentStatus,
+          toolCalls: {
+            total: 1,
+            byType: { Edit: 1 },
+            active: null,
+          },
+          recentToolCalls: [
+            {
+              id: 'r-1',
+              tool: 'Edit',
+              args: 'src/foo.ts',
+              status: 'done',
+              durationMs: 100,
+              timestamp: '2026-04-22T11:59:42Z',
+              isTestFile: false,
+            },
+          ],
+        }}
+      />
+    )
 
     const toolCallsHeader = screen.getByRole('button', { name: /tool calls/i })
     const activityHeader = screen.getByRole('button', { name: /activity/i })
 
-    // Current order: ToolCallSummary header appears before the ActivityFeed
-    // header. Both are now CollapsibleSection buttons so they share the same
-    // visual rhythm as FilesChanged and Tests below.
     expect(toolCallsHeader.compareDocumentPosition(activityHeader)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     )
   })
 
-  test('scrollable content area uses the thin-scrollbar convention', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue({
-      ...defaultStatus,
-      isActive: true,
-      agentType: 'claude-code',
-      sessionId: 'session-1',
-    })
-
+  test('scrollable content area uses the thin-scrollbar convention', () => {
     const { container } = render(
-      <AgentStatusPanel {...defaultProps} sessionId="session-1" />
+      <AgentStatusPanel {...defaultProps} agentStatus={activeAgentStatus} />
     )
 
-    // The scroll region wraps ActivityFeed + ToolCallSummary + FilesChanged +
-    // TestResults so the lower sections remain reachable when the ActivityFeed
-    // grows. Must use thin-scrollbar per rules convention (see
-    // src/features/editor/components/ExplorerPane.tsx:74).
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     const scrollableDiv = container.querySelector('.overflow-y-auto')
     expect(scrollableDiv).toHaveClass('thin-scrollbar')
   })
 
-  test('keeps ToolCallSummary consumer mounted alongside the ActivityFeed', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue({
-      ...defaultStatus,
-      isActive: true,
-      agentType: 'claude-code',
-      sessionId: 'session-1',
-      toolCalls: {
-        total: 1,
-        byType: { Edit: 1 },
-        active: null,
-      },
-      recentToolCalls: [
-        {
-          id: 'r-1',
-          tool: 'Edit',
-          args: 'src/foo.ts',
-          status: 'done',
-          durationMs: 100,
-          timestamp: '2026-04-22T11:59:42Z',
-          isTestFile: false,
-        },
-      ],
-    })
+  test('keeps ToolCallSummary consumer mounted alongside the ActivityFeed', () => {
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={{
+          ...activeAgentStatus,
+          toolCalls: {
+            total: 1,
+            byType: { Edit: 1 },
+            active: null,
+          },
+          recentToolCalls: [
+            {
+              id: 'r-1',
+              tool: 'Edit',
+              args: 'src/foo.ts',
+              status: 'done',
+              durationMs: 100,
+              timestamp: '2026-04-22T11:59:42Z',
+              isTestFile: false,
+            },
+          ],
+        }}
+      />
+    )
 
-    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
-
-    // ToolCallSummary: renders the byType chip label "Edit".
     expect(screen.getAllByText('Edit').length).toBeGreaterThan(0)
-    // ActivityFeed: collapsible header exists.
     expect(
       screen.getByRole('button', { name: /activity/i })
     ).toBeInTheDocument()
   })
 
-  test('renders TokenCache populated with the canonical hit rate', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue({
-      ...defaultStatus,
-      isActive: true,
-      agentType: 'claude-code',
-      sessionId: 'session-1',
-      contextWindow: {
-        usedPercentage: 10,
-        contextWindowSize: 200000,
-        totalInputTokens: 0,
-        totalOutputTokens: 0,
-        currentUsage: {
-          inputTokens: 700,
-          outputTokens: 0,
-          cacheCreationInputTokens: 1800,
-          cacheReadInputTokens: 7500,
-        },
-      },
-    })
-
-    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
+  test('renders TokenCache populated with the canonical hit rate', () => {
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={{
+          ...activeAgentStatus,
+          contextWindow: {
+            usedPercentage: 10,
+            contextWindowSize: 200000,
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+            currentUsage: {
+              inputTokens: 700,
+              outputTokens: 0,
+              cacheCreationInputTokens: 1800,
+              cacheReadInputTokens: 7500,
+            },
+          },
+        }}
+      />
+    )
 
     const percent = screen.getByTestId('token-cache-percent')
     expect(percent).toHaveTextContent('75%')
   })
 
-  test('renders TokenCache empty state when currentUsage is null', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue({
-      ...defaultStatus,
-      isActive: true,
-      agentType: 'claude-code',
-      sessionId: 'session-1',
-      contextWindow: null,
-    })
-
-    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
+  test('renders TokenCache empty state when currentUsage is null', () => {
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={{
+          ...activeAgentStatus,
+          contextWindow: null,
+        }}
+      />
+    )
 
     expect(screen.getByText(/no data yet/i)).toBeInTheDocument()
   })
 
-  test('mounts TokenCache between ContextBucket and the scrollable region', async () => {
-    const { useAgentStatus } = await import('../hooks/useAgentStatus')
-    vi.mocked(useAgentStatus).mockReturnValue({
-      ...defaultStatus,
-      isActive: true,
-      agentType: 'claude-code',
-      sessionId: 'session-1',
-      contextWindow: {
-        usedPercentage: 10,
-        contextWindowSize: 200000,
-        totalInputTokens: 0,
-        totalOutputTokens: 0,
-        currentUsage: {
-          inputTokens: 700,
-          outputTokens: 0,
-          cacheCreationInputTokens: 1800,
-          cacheReadInputTokens: 7500,
-        },
-      },
-    })
-
-    render(<AgentStatusPanel {...defaultProps} sessionId="session-1" />)
+  test('mounts TokenCache between ContextBucket and the scrollable region', () => {
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={{
+          ...activeAgentStatus,
+          contextWindow: {
+            usedPercentage: 10,
+            contextWindowSize: 200000,
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+            currentUsage: {
+              inputTokens: 700,
+              outputTokens: 0,
+              cacheCreationInputTokens: 1800,
+              cacheReadInputTokens: 7500,
+            },
+          },
+        }}
+      />
+    )
 
     const panel = screen.getByTestId('agent-status-panel')
     const tokenCache = screen.getByTestId('token-cache')
 
-    // DOM-order requirements from the design spec:
-    //   StatusCard → ContextBucket → TokenCache  (static top region, in this order)
-    //                                ↓
-    //                         scrollable region
-
     /* eslint-disable testing-library/no-node-access */
     const scrollable = panel.querySelector('.thin-scrollbar')
 
-    // 1. TokenCache must be the LAST child of the static top region
-    //    (i.e., it follows StatusCard and ContextBucket, never precedes them).
     const staticTop = panel.firstElementChild
     expect(staticTop).not.toBeNull()
     expect(staticTop?.lastElementChild).toBe(tokenCache)
 
-    // 2. TokenCache must precede the scrollable region in document order.
     expect(scrollable).not.toBeNull()
 
     const positionRelativeToScrollable = tokenCache.compareDocumentPosition(

--- a/src/features/agent-status/components/AgentStatusPanel.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.tsx
@@ -1,6 +1,5 @@
-import type { ReactElement } from 'react'
-import { useAgentStatus } from '../hooks/useAgentStatus'
-import { StatusCard } from './StatusCard'
+import { useMemo, type ReactElement } from 'react'
+import type { AgentStatus } from '../types'
 import { ContextBucket } from './ContextBucket'
 import { TokenCache } from './TokenCache'
 import { ToolCallSummary } from './ToolCallSummary'
@@ -10,40 +9,45 @@ import { ActivityFooter } from './ActivityFooter'
 import { ActivityFeed } from './ActivityFeed'
 import { useActivityEvents } from '../hooks/useActivityEvents'
 import { useGitStatus } from '../../diff/hooks/useGitStatus'
+import { sumLines } from '../../diff/utils/sumLines'
 import type { ChangedFile } from '../../diff/types'
 
 interface AgentStatusPanelProps {
-  sessionId: string | null
+  agentStatus: AgentStatus
   cwd: string
   onOpenDiff: (file: ChangedFile) => void
   onOpenFile?: (path: string) => void
 }
 
 export const AgentStatusPanel = ({
-  sessionId,
+  agentStatus,
   cwd,
   onOpenDiff,
   onOpenFile = undefined,
 }: AgentStatusPanelProps): ReactElement => {
-  const status = useAgentStatus(sessionId)
+  const status = agentStatus
   const events = useActivityEvents(status)
 
-  // Git status with file-system watcher
   const { files, filesCwd, loading, error, refresh, idle } = useGitStatus(cwd, {
     watch: true,
     enabled: status.isActive,
   })
 
-  // Freshness check — files are only valid if they came from the current cwd
   const filesAreFresh = filesCwd === cwd
-  const effectiveFiles = filesAreFresh ? files : []
 
-  // Gate the transitional-loading arm on the hook actually running. When
-  // `idle` is true (hook short-circuited because enabled=false or cwd is
-  // a fallback), `filesCwd` stays null forever and `!filesAreFresh` would
-  // otherwise spin "Loading…" indefinitely. An idle hook never loads.
+  // Memoize the effective files array so its identity is stable across
+  // renders when the underlying data didn't change. Without this, the
+  // ternary creates a fresh array literal on every render and downstream
+  // useMemos depending on it (lineTotals) re-run unnecessarily.
+  const effectiveFiles = useMemo(
+    () => (filesAreFresh ? files : []),
+    [filesAreFresh, files]
+  )
+
   const effectiveLoading =
     !idle && (loading || (!filesAreFresh && error === null))
+
+  const lineTotals = useMemo(() => sumLines(effectiveFiles), [effectiveFiles])
 
   return (
     <div
@@ -59,16 +63,6 @@ export const AgentStatusPanel = ({
       {status.isActive && status.agentType ? (
         <>
           <div className="flex flex-col gap-2 p-2">
-            <StatusCard
-              agentType={status.agentType}
-              modelId={status.modelId}
-              modelDisplayName={status.modelDisplayName}
-              status="running"
-              cost={status.cost}
-              rateLimits={status.rateLimits}
-              totalInputTokens={status.contextWindow?.totalInputTokens ?? 0}
-              totalOutputTokens={status.contextWindow?.totalOutputTokens ?? 0}
-            />
             <ContextBucket
               usedPercentage={status.contextWindow?.usedPercentage ?? null}
               contextWindowSize={
@@ -98,9 +92,8 @@ export const AgentStatusPanel = ({
           </div>
           <ActivityFooter
             totalDurationMs={status.cost?.totalDurationMs ?? 0}
-            turnCount={0}
-            linesAdded={status.cost?.totalLinesAdded ?? 0}
-            linesRemoved={status.cost?.totalLinesRemoved ?? 0}
+            linesAdded={lineTotals.added}
+            linesRemoved={lineTotals.removed}
           />
         </>
       ) : null}

--- a/src/features/diff/utils/sumLines.test.ts
+++ b/src/features/diff/utils/sumLines.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest'
+import type { ChangedFile } from '../types'
+import { sumLines } from './sumLines'
+
+const file = (overrides: Partial<ChangedFile>): ChangedFile => ({
+  path: 'src/x.ts',
+  status: 'modified',
+  staged: false,
+  ...overrides,
+})
+
+describe('sumLines', () => {
+  test('returns zeros for an empty list', () => {
+    expect(sumLines([])).toEqual({ added: 0, removed: 0 })
+  })
+
+  test('sums insertions and deletions across files', () => {
+    const files: ChangedFile[] = [
+      file({ insertions: 12, deletions: 3 }),
+      file({ insertions: 0, deletions: 8 }),
+      file({ insertions: 4, deletions: 4 }),
+    ]
+    expect(sumLines(files)).toEqual({ added: 16, removed: 15 })
+  })
+
+  test('treats undefined insertions / deletions as zero', () => {
+    const files: ChangedFile[] = [
+      file({ insertions: 5, deletions: 2 }),
+      file({}), // both stat counts absent (untracked file with no diff stat)
+      file({ insertions: undefined, deletions: 7 }),
+    ]
+    expect(sumLines(files)).toEqual({ added: 5, removed: 9 })
+  })
+
+  test('handles a single file', () => {
+    expect(sumLines([file({ insertions: 9, deletions: 1 })])).toEqual({
+      added: 9,
+      removed: 1,
+    })
+  })
+
+  test('large counts sum without precision issues', () => {
+    const files: ChangedFile[] = Array.from({ length: 200 }, () =>
+      file({ insertions: 10_000, deletions: 5_000 })
+    )
+    expect(sumLines(files)).toEqual({ added: 2_000_000, removed: 1_000_000 })
+  })
+})

--- a/src/features/diff/utils/sumLines.ts
+++ b/src/features/diff/utils/sumLines.ts
@@ -1,0 +1,15 @@
+import type { ChangedFile } from '../types'
+
+export interface LineTotals {
+  added: number
+  removed: number
+}
+
+export const sumLines = (files: ChangedFile[]): LineTotals =>
+  files.reduce<LineTotals>(
+    (acc, f) => ({
+      added: acc.added + (f.insertions ?? 0),
+      removed: acc.removed + (f.deletions ?? 0),
+    }),
+    { added: 0, removed: 0 }
+  )

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -1,0 +1,153 @@
+import type { ReactElement } from 'react'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { WorkspaceView } from './WorkspaceView'
+import type { AgentStatus } from '../agent-status/types'
+
+// Mock TerminalPane / TerminalZone deps to avoid xterm.js in jsdom
+vi.mock('../terminal/components/TerminalPane', () => ({
+  TerminalPane: vi.fn(() => <div data-testid="terminal-pane-mock" />),
+}))
+
+interface MockEditorBuffer {
+  filePath: string | null
+  originalContent: string
+  currentContent: string
+  isDirty: boolean
+  isLoading: boolean
+  openFile: ReturnType<typeof vi.fn>
+  saveFile: ReturnType<typeof vi.fn>
+  updateContent: ReturnType<typeof vi.fn>
+}
+
+vi.mock('../editor/hooks/useEditorBuffer', () => ({
+  useEditorBuffer: (): MockEditorBuffer => ({
+    filePath: null,
+    originalContent: '',
+    currentContent: '',
+    isDirty: false,
+    isLoading: false,
+    openFile: vi.fn().mockResolvedValue(undefined),
+    saveFile: vi.fn().mockResolvedValue(undefined),
+    updateContent: vi.fn(),
+  }),
+}))
+
+vi.mock('../terminal/services/terminalService', () => ({
+  createTerminalService: vi.fn(() => ({
+    spawn: vi.fn().mockResolvedValue({ sessionId: 'new-id', pid: 999 }),
+    write: vi.fn().mockResolvedValue(undefined),
+    resize: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(
+      (): Promise<() => void> =>
+        Promise.resolve((): void => {
+          /* noop */
+        })
+    ),
+    onExit: vi.fn((): (() => void) => (): void => {
+      /* noop */
+    }),
+    onError: vi.fn((): (() => void) => (): void => {
+      /* noop */
+    }),
+    listSessions: vi.fn().mockResolvedValue({
+      activeSessionId: 'sess-1',
+      sessions: [
+        {
+          id: 'sess-1',
+          cwd: '~',
+          status: {
+            kind: 'Alive',
+            pid: 1234,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    }),
+    setActiveSession: vi.fn().mockResolvedValue(undefined),
+    reorderSessions: vi.fn().mockResolvedValue(undefined),
+    updateSessionCwd: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+// CRITICAL: this mock returns a fresh object per call so reference
+// equality distinguishes "one hook call shared by both children" from
+// "one hook call per child". The previous WorkspaceView.test.tsx mock
+// returns a singleton, which would defeat this assertion.
+vi.mock('../agent-status/hooks/useAgentStatus', () => ({
+  useAgentStatus: vi.fn(
+    (): AgentStatus => ({
+      isActive: true,
+      agentType: 'claude-code',
+      modelId: null,
+      modelDisplayName: null,
+      version: null,
+      sessionId: null,
+      agentSessionId: null,
+      contextWindow: null,
+      cost: null,
+      rateLimits: null,
+      toolCalls: { total: 0, byType: {}, active: null },
+      recentToolCalls: [],
+      testRun: null,
+    })
+  ),
+}))
+
+const capturedSidebarProps: { agentStatus?: AgentStatus } = {}
+const capturedPanelProps: { agentStatus?: AgentStatus } = {}
+
+interface MockSidebarProps {
+  agentStatus?: AgentStatus
+}
+
+interface MockPanelProps {
+  agentStatus?: AgentStatus
+}
+
+vi.mock('./components/Sidebar', () => ({
+  Sidebar: ({ agentStatus = undefined }: MockSidebarProps): ReactElement => {
+    capturedSidebarProps.agentStatus = agentStatus
+
+    return <div data-testid="sidebar-mock" />
+  },
+}))
+
+vi.mock('../agent-status/components/AgentStatusPanel', () => ({
+  AgentStatusPanel: ({
+    agentStatus = undefined,
+  }: MockPanelProps): ReactElement => {
+    capturedPanelProps.agentStatus = agentStatus
+
+    return <div data-testid="agent-status-panel-mock" />
+  },
+}))
+
+describe('WorkspaceView lifted-subscription contract', () => {
+  beforeEach(() => {
+    capturedSidebarProps.agentStatus = undefined
+    capturedPanelProps.agentStatus = undefined
+  })
+
+  test('Sidebar and AgentStatusPanel receive agentStatus from a single hook call', async () => {
+    render(<WorkspaceView />)
+
+    // Wait for the children to be rendered with their props captured.
+    await screen.findByTestId('sidebar-mock')
+    await screen.findByTestId('agent-status-panel-mock')
+
+    expect(capturedSidebarProps.agentStatus).toBeDefined()
+    expect(capturedPanelProps.agentStatus).toBeDefined()
+
+    // Reference equality. Because the useAgentStatus mock above returns
+    // a FRESH object per call (the factory runs anew each invocation),
+    // two separate hook calls would yield two distinct objects, and
+    // `toBe` would fail. A single hook call shared by both children
+    // yields the same object reference and `toBe` passes.
+    expect(capturedSidebarProps.agentStatus).toBe(
+      capturedPanelProps.agentStatus
+    )
+  })
+})

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -6,6 +6,8 @@ import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WorkspaceView } from './WorkspaceView'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
+import type { AgentStatus } from '../agent-status/types'
+import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 
 // Mock TerminalPane to avoid xterm.js issues in tests
 vi.mock('../terminal/components/TerminalPane', () => ({
@@ -47,20 +49,24 @@ vi.mock('../editor/hooks/useEditorBuffer', () => ({
 const capturedAgentStatusPanelProps: {
   onOpenFile?: (path: string) => void
   onOpenDiff?: unknown
+  agentStatus?: AgentStatus
 } = {}
 
 interface MockAgentStatusPanelProps {
   onOpenFile?: (path: string) => void
   onOpenDiff?: unknown
+  agentStatus?: AgentStatus
 }
 
 vi.mock('../agent-status/components/AgentStatusPanel', () => ({
   AgentStatusPanel: ({
     onOpenFile = undefined,
     onOpenDiff = undefined,
+    agentStatus = undefined,
   }: MockAgentStatusPanelProps): ReactElement => {
     capturedAgentStatusPanelProps.onOpenFile = onOpenFile
     capturedAgentStatusPanelProps.onOpenDiff = onOpenDiff
+    capturedAgentStatusPanelProps.agentStatus = agentStatus
 
     // Render the panel testid so the existing zone-presence tests
     // (`getByTestId('agent-status-panel')`) keep passing without
@@ -110,6 +116,7 @@ describe('WorkspaceView', () => {
   beforeEach(() => {
     capturedAgentStatusPanelProps.onOpenFile = undefined
     capturedAgentStatusPanelProps.onOpenDiff = undefined
+    capturedAgentStatusPanelProps.agentStatus = undefined
 
     // Default: clean buffer with no file open. Mirrors the real hook's
     // initial state so existing tests don't see a dirty buffer or get
@@ -487,5 +494,34 @@ describe('WorkspaceView', () => {
     expect(
       await screen.findByRole('dialog', { name: /unsaved changes/i })
     ).toBeInTheDocument()
+  })
+
+  test('lifts useAgentStatus and forwards the latest activeSessionId', async () => {
+    render(<WorkspaceView />)
+
+    // Wait for session restore to settle (the listSessions mock resolves
+    // sess-1, so this proves activeSessionId is non-null).
+    await screen.findByRole('button', { name: 'session 1' })
+
+    const useAgentStatusMock = vi.mocked(useAgentStatus)
+    const calls = useAgentStatusMock.mock.calls
+    const lastArg = calls[calls.length - 1]?.[0]
+
+    // Latest call arg, not call count — activeSessionId flips from null
+    // to the restored id during mount, and React may re-render multiple
+    // times. We assert the *value* of the most-recent call.
+    expect(lastArg).toBe('sess-1')
+  })
+
+  test('passes the lifted agentStatus to AgentStatusPanel', async () => {
+    render(<WorkspaceView />)
+
+    await screen.findByRole('button', { name: 'session 1' })
+
+    // The mocked useAgentStatus returns isActive: true / agentType: 'claude-code'.
+    expect(capturedAgentStatusPanelProps.agentStatus).toMatchObject({
+      isActive: true,
+      agentType: 'claude-code',
+    })
   })
 })

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -12,9 +12,10 @@ import { useResizable } from './hooks/useResizable'
 import { createFileSystemService } from '../files/services/fileSystemService'
 import { createTerminalService } from '../terminal/services/terminalService'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
+import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 import type { ChangedFile, SelectedDiffFile } from '../diff/types'
 
-const SIDEBAR_MIN = 180
+const SIDEBAR_MIN = 240
 const SIDEBAR_MAX = 560
 const SIDEBAR_DEFAULT = 340
 
@@ -43,6 +44,8 @@ export const WorkspaceView = (): ReactElement => {
     loading,
     notifyPaneReady,
   } = useSessionManager(terminalService)
+
+  const agentStatus = useAgentStatus(activeSessionId)
 
   const {
     size: sidebarWidth,
@@ -323,6 +326,7 @@ export const WorkspaceView = (): ReactElement => {
           onRenameSession={renameSession}
           onReorderSessions={reorderSessions}
           onFileSelect={handleFileSelect}
+          agentStatus={agentStatus}
         />
 
         {/* Resize handle */}
@@ -406,7 +410,7 @@ export const WorkspaceView = (): ReactElement => {
 
       {/* Agent Status Panel — self-manages width (0↔280px) */}
       <AgentStatusPanel
-        sessionId={activeSessionId}
+        agentStatus={agentStatus}
         cwd={activeSession?.workingDirectory ?? '.'}
         onOpenDiff={handleOpenDiff}
         onOpenFile={handleOpenTestFile}

--- a/src/features/workspace/components/Sidebar.test.tsx
+++ b/src/features/workspace/components/Sidebar.test.tsx
@@ -4,6 +4,23 @@ import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Sidebar } from './Sidebar'
 import type { Session } from '../types'
+import type { AgentStatus } from '../../agent-status/types'
+
+const inactiveAgentStatus: AgentStatus = {
+  isActive: false,
+  agentType: null,
+  modelId: null,
+  modelDisplayName: null,
+  version: null,
+  sessionId: null,
+  agentSessionId: null,
+  contextWindow: null,
+  cost: null,
+  rateLimits: null,
+  toolCalls: { total: 0, byType: {}, active: null },
+  recentToolCalls: [],
+  testRun: null,
+}
 
 const mockSessions: Session[] = [
   {
@@ -102,6 +119,7 @@ describe('Sidebar', () => {
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
         onNewInstance={mockOnNewInstance}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -110,17 +128,19 @@ describe('Sidebar', () => {
     expect(sidebar).toHaveClass('w-full')
   })
 
-  test('renders agent header with name and status', () => {
+  test('renders the sidebar status header in the top slot', () => {
     render(
       <Sidebar
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
-    expect(screen.getByText('Agent Alpha')).toBeInTheDocument()
-    expect(screen.getByText('System Idle')).toBeInTheDocument()
+    expect(screen.getByTestId('sidebar-status-header-idle')).toBeInTheDocument()
+    expect(screen.queryByText('Agent Alpha')).not.toBeInTheDocument()
+    expect(screen.queryByText('System Idle')).not.toBeInTheDocument()
   })
 
   test('renders "Active Sessions" header with add button', () => {
@@ -129,6 +149,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -144,6 +165,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -160,6 +182,7 @@ describe('Sidebar', () => {
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
         onNewInstance={mockOnNewInstance}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -175,12 +198,19 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
-    expect(screen.getByText('auth middleware')).toBeInTheDocument()
-    expect(screen.getByText('fix: login bug')).toBeInTheDocument()
-    expect(screen.getByText('refactor: api layer')).toBeInTheDocument()
+    // The active session's name now also renders in the SidebarStatusHeader
+    // (idle state), so query within the session list to avoid duplicate
+    // matches on the active session's name.
+    const sessionList = screen.getByTestId('session-list')
+    expect(within(sessionList).getByText('auth middleware')).toBeInTheDocument()
+    expect(within(sessionList).getByText('fix: login bug')).toBeInTheDocument()
+    expect(
+      within(sessionList).getByText('refactor: api layer')
+    ).toBeInTheDocument()
   })
 
   test('active session has smart_toy icon', () => {
@@ -189,6 +219,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -204,6 +235,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -219,6 +251,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -236,6 +269,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -254,6 +288,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -269,6 +304,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -282,6 +318,7 @@ describe('Sidebar', () => {
         sessions={[]}
         activeSessionId={null}
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -294,6 +331,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -308,6 +346,7 @@ describe('Sidebar', () => {
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
         onNewInstance={mockOnNewInstance}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -327,6 +366,7 @@ describe('Sidebar', () => {
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
         onNewInstance={mockOnNewInstance}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -345,6 +385,7 @@ describe('Sidebar', () => {
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
         onNewInstance={mockOnNewInstance}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -363,6 +404,7 @@ describe('Sidebar', () => {
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
         onNewInstance={mockOnNewInstance}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -379,6 +421,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId={null}
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 
@@ -401,6 +444,7 @@ describe('Sidebar', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
       />
     )
 

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -8,7 +8,9 @@ import {
 import { Reorder } from 'framer-motion'
 import type { Session } from '../types'
 import type { FileNode } from '../../files/types'
+import type { AgentStatus } from '../../agent-status/types'
 import { FileExplorer } from './panels/FileExplorer'
+import { SidebarStatusHeader } from './SidebarStatusHeader'
 
 export interface SidebarProps {
   sessions: Session[]
@@ -20,6 +22,7 @@ export interface SidebarProps {
   onRenameSession?: (sessionId: string, name: string) => void
   onReorderSessions?: (sessions: Session[]) => void
   onFileSelect?: (node: FileNode) => void
+  agentStatus: AgentStatus
 }
 
 const FILE_EXPLORER_MIN = 100
@@ -167,6 +170,7 @@ export const Sidebar = ({
   onRenameSession = undefined,
   onReorderSessions = undefined,
   onFileSelect = undefined,
+  agentStatus,
 }: SidebarProps): ReactElement => {
   const [explorerHeight, setExplorerHeight] = useState(FILE_EXPLORER_DEFAULT)
   const [isDraggingSplit, setIsDraggingSplit] = useState(false)
@@ -219,24 +223,13 @@ export const Sidebar = ({
       className="flex h-full w-full flex-col bg-surface-container-low"
       data-testid="sidebar"
     >
-      {/* Agent header */}
-      <div className="flex items-center gap-3 px-4 py-4">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-purple-600">
-          <span className="material-symbols-outlined text-lg text-white">
-            smart_toy
-          </span>
-        </div>
-        <div className="min-w-0">
-          <div className="truncate font-label text-sm font-bold text-on-surface">
-            Agent Alpha
-          </div>
-          <div className="flex items-center gap-1.5">
-            <span className="inline-block h-2 w-2 rounded-full bg-emerald-400" />
-            <span className="font-label text-xs uppercase tracking-wider text-on-surface/50">
-              System Idle
-            </span>
-          </div>
-        </div>
+      <div className="px-3 pt-3 pb-2">
+        <SidebarStatusHeader
+          status={agentStatus}
+          activeSessionName={
+            sessions.find((s) => s.id === activeSessionId)?.name ?? null
+          }
+        />
       </div>
 
       {/* Sessions section header */}

--- a/src/features/workspace/components/SidebarStatusHeader.test.tsx
+++ b/src/features/workspace/components/SidebarStatusHeader.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import type { AgentStatus } from '../../agent-status/types'
+import { SidebarStatusHeader } from './SidebarStatusHeader'
+
+const inactiveStatus: AgentStatus = {
+  isActive: false,
+  agentType: null,
+  modelId: null,
+  modelDisplayName: null,
+  version: null,
+  sessionId: null,
+  agentSessionId: null,
+  contextWindow: null,
+  cost: null,
+  rateLimits: null,
+  toolCalls: { total: 0, byType: {}, active: null },
+  recentToolCalls: [],
+  testRun: null,
+}
+
+const activeStatus: AgentStatus = {
+  ...inactiveStatus,
+  isActive: true,
+  agentType: 'claude-code',
+  modelId: 'claude-3-5-sonnet-20241022',
+  modelDisplayName: 'Claude 3.5 Sonnet',
+  sessionId: 'session-1',
+  contextWindow: {
+    usedPercentage: 12,
+    contextWindowSize: 200_000,
+    totalInputTokens: 1_234,
+    totalOutputTokens: 567,
+    currentUsage: null,
+  },
+}
+
+describe('SidebarStatusHeader', () => {
+  test('renders the live StatusCard when an agent is active', () => {
+    render(
+      <SidebarStatusHeader
+        status={activeStatus}
+        activeSessionName="my session"
+      />
+    )
+
+    expect(screen.getByTestId('agent-status-card')).toBeInTheDocument()
+    expect(screen.getByText('Claude Code')).toBeInTheDocument()
+    expect(screen.getByText('Running')).toBeInTheDocument()
+  })
+
+  test('renders the idle placeholder with the active session name', () => {
+    render(
+      <SidebarStatusHeader
+        status={inactiveStatus}
+        activeSessionName="my session"
+      />
+    )
+
+    expect(screen.queryByTestId('agent-status-card')).not.toBeInTheDocument()
+    expect(screen.getByText('my session')).toBeInTheDocument()
+    expect(screen.getByText('Idle')).toBeInTheDocument()
+  })
+
+  test('falls back to "No session" when there is no active session', () => {
+    render(
+      <SidebarStatusHeader status={inactiveStatus} activeSessionName={null} />
+    )
+
+    expect(screen.getByText('No session')).toBeInTheDocument()
+    expect(screen.getByText('Idle')).toBeInTheDocument()
+  })
+
+  test('treats agent-detected-but-no-agentType as idle', () => {
+    render(
+      <SidebarStatusHeader
+        status={{ ...inactiveStatus, isActive: true, agentType: null }}
+        activeSessionName="my session"
+      />
+    )
+
+    expect(screen.queryByTestId('agent-status-card')).not.toBeInTheDocument()
+    expect(screen.getByText('my session')).toBeInTheDocument()
+  })
+})

--- a/src/features/workspace/components/SidebarStatusHeader.tsx
+++ b/src/features/workspace/components/SidebarStatusHeader.tsx
@@ -1,0 +1,76 @@
+import type { ReactElement } from 'react'
+import { StatusCard } from '../../agent-status/components/StatusCard'
+import type {
+  AgentStatus,
+  CostState,
+  RateLimitsState,
+} from '../../agent-status/types'
+
+export interface SidebarStatusHeaderProps {
+  status: AgentStatus
+  activeSessionName: string | null
+}
+
+interface ActiveCardProps {
+  agentType: 'claude-code' | 'codex' | 'aider' | 'generic'
+  modelId: string | null
+  modelDisplayName: string | null
+  status: 'running' | 'paused' | 'completed' | 'errored'
+  cost: CostState | null
+  rateLimits: RateLimitsState | null
+  totalInputTokens: number
+  totalOutputTokens: number
+}
+
+const mapStatusToCardProps = (
+  status: AgentStatus & {
+    agentType: 'claude-code' | 'codex' | 'aider' | 'generic'
+  }
+): ActiveCardProps => ({
+  agentType: status.agentType,
+  modelId: status.modelId,
+  modelDisplayName: status.modelDisplayName,
+  // The StatusType discriminator does not yet have a feed from
+  // AgentStatus — see spec section 5.1. Hard-coded to 'running' to
+  // mirror the existing AgentStatusPanel behavior.
+  status: 'running',
+  cost: status.cost,
+  rateLimits: status.rateLimits,
+  totalInputTokens: status.contextWindow?.totalInputTokens ?? 0,
+  totalOutputTokens: status.contextWindow?.totalOutputTokens ?? 0,
+})
+
+export const SidebarStatusHeader = ({
+  status,
+  activeSessionName,
+}: SidebarStatusHeaderProps): ReactElement => {
+  if (status.isActive && status.agentType) {
+    return (
+      <StatusCard
+        {...mapStatusToCardProps({ ...status, agentType: status.agentType })}
+      />
+    )
+  }
+
+  const title = activeSessionName ?? 'No session'
+
+  return (
+    <div
+      data-testid="sidebar-status-header-idle"
+      className="flex flex-col gap-3 rounded-xl bg-surface-container-high p-3"
+    >
+      <div className="flex items-center gap-2.5">
+        <div className="h-8 w-8 shrink-0 rounded-lg bg-gradient-to-br from-primary-container to-secondary" />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="truncate font-headline text-sm font-[800] text-on-surface">
+            {title}
+          </span>
+          <div className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-on-surface/30" />
+            <span className="text-[10px] font-medium text-outline">Idle</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Move the live `<StatusCard>` (agent identity + token totals) from the right `<AgentStatusPanel>` into a new `<SidebarStatusHeader>` at the top of the left Sidebar; replaces the hardcoded "Agent Alpha" / "SYSTEM IDLE" placeholder.
- Re-source `<ActivityFooter>`'s lines added/removed from `useGitStatus`'s `effectiveFiles` (matches the per-file numbers shown in `<FilesChanged>`) instead of agent-reported cost-metrics events.
- Drop the hardcoded `0 turns` span until real turn-counting infrastructure exists (tracked in #119).
- Lift `useAgentStatus(activeSessionId)` to `<WorkspaceView>` so both the new sidebar header and the activity panel share one Tauri subscription. Reference equality enforced at runtime in a new focused test file.
- Bump `SIDEBAR_MIN` from 180 to 240 so `<StatusCard>`'s fixed `grid-cols-2` `<BudgetMetrics>` doesn't overflow at the narrowest sidebar width.

## Why

`<Sidebar>`'s top header was dead UI hardcoding "Agent Alpha". `<StatusCard>` already showed live agent identity but lived in the activity panel — wrong column for "who is the agent". `<ActivityFooter>` was reporting `+0 / -0` even when files had been edited because the source (cost metrics) only updates on agent turn-end. Single-source the line totals to git-diff and the footer matches what the user sees in `<FilesChanged>`.

## Architecture

```
WorkspaceView
  └── const status = useAgentStatus(activeSessionId)   ← lifted
       ├── <Sidebar agentStatus={status}>
       │     └── <SidebarStatusHeader>                    ← new
       │           ├── active: <StatusCard>              (file unchanged, lives in agent-status/)
       │           └── idle: avatar + session name + "Idle"
       └── <AgentStatusPanel agentStatus={status}>      ← prop, no longer hook
             └── <ActivityFooter
                   linesAdded={sumLines(effectiveFiles).added}
                   linesRemoved={sumLines(effectiveFiles).removed} />
```

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-04-30-sidebar-status-header-design.md`
- Plan: `docs/superpowers/plans/2026-04-30-sidebar-status-header-plan.md`

## Test plan

- [x] `npm run test` — 1522 passed, 3 skipped
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Visual: `<StatusCard>` renders without horizontal overflow at SIDEBAR_MIN=240 (user-confirmed via tauri:dev). Text wrapping on agent name and model truncation are expected and acceptable.
- [x] Reference-equality assertion in `WorkspaceView.subscription.test.tsx` proves single Tauri subscription shared across both children.

## Out of scope (follow-ups)

- #119 — restore real `turnCount` in `<ActivityFooter>` (Rust transcript-watcher counter).
- `useGitStatus` consolidation (currently called twice — `<AgentStatusPanel>` and `<DiffPanelContent>`).
- Making `<StatusCard>` / `<BudgetMetrics>` responsive at narrow widths so `SIDEBAR_MIN` can return to 180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)