### PR TITLE
perf(terminal): avoid global lock on pty output

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -53,7 +53,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                   | security       | 3        | 1    | 2026-04-20   |
 | [Preflight Checks](patterns/preflight-checks.md)                     | error-handling | 1        | 0    | 2026-04-20   |
 | [CSP Configuration](patterns/csp-configuration.md)                   | security       | 2        | 1    | 2026-04-09   |
-| [PTY Session Management](patterns/pty-session-management.md)         | backend        | 5        | 1    | 2026-04-09   |
+| [PTY Session Management](patterns/pty-session-management.md)         | backend        | 6        | 2    | 2026-05-02   |
 | [Git Operations](patterns/git-operations.md)                         | correctness    | 12       | 2    | 2026-04-29   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor         | 12       | 0    | 2026-04-11   |
 | [Error Surfacing](patterns/error-surfacing.md)                       | error-handling | 19       | 3    | 2026-04-30   |

--- a/docs/reviews/patterns/pty-session-management.md
+++ b/docs/reviews/patterns/pty-session-management.md
@@ -2,8 +2,8 @@
 id: pty-session-management
 category: backend
 created: 2026-04-09
-last_updated: 2026-04-09
-ref_count: 1
+last_updated: 2026-05-02
+ref_count: 2
 ---
 
 # PTY Session Management
@@ -60,3 +60,12 @@ never log terminal input (may contain secrets).
 - **Finding:** `write_pty` logs full terminal input via `log::debug!` — credentials and tokens exposed in logs
 - **Fix:** Log only metadata (session ID, byte length), not payload
 - **Commit:** `ba395c7 feat: Phase 2 workspace layout shell with v2 design (#31)`
+
+### 6. Read loop's session-liveness side-channel removed without explicit cancellation, leaving ignore-SIGTERM children unreclaimed
+
+- **Source:** github-claude (LOW) + github-codex-connector (P1) | PR #123 round 1 | 2026-05-02
+- **Severity:** MEDIUM (matched at the higher of the two reviewer severities — Codex P1)
+- **File:** `src-tauri/src/terminal/commands.rs`, `src-tauri/src/terminal/state.rs`
+- **Finding:** PR #123's perf optimization decoupled `read_pty_output` from the global `sessions` map (`Arc<Mutex<RingBuffer>>` cloned out, no per-chunk lock). The implicit "break on `sessions.get(session_id) == None`" guard that came along for free with the old per-chunk lock was eliminated without a replacement. After `kill_pty` removes a session, the read thread keeps reading and emitting `pty-data` until eventual EOF — fine for SIGTERM-honoring children, but a process that ignores SIGTERM keeps the read thread, the ring `Arc`, and the event flow alive indefinitely. The frontend buffers unknown-session `pty-data` optimistically, so the post-removal flow becomes unbounded memory growth on the JS side too.
+- **Fix:** Added `cancelled: Arc<AtomicBool>` to `ManagedSession` plus a `PtyState::set_cancelled(session_id)` method. `kill_pty` flips the flag AFTER the successful-kill / already-gone branches (NOT on the `KillError::KillFailed` path — flipping there would let a later read trip `remove_if_generation` and orphan a still-alive child from app state, breaking the retry contract). The read loop checks the flag at the TOP of the `Ok(n)` branch, BEFORE appending to the ring or emitting `pty-data` — checking after would leak one chunk per kill_pty. Codex verify caught both ordering bugs across two retry cycles before the third pass landed clean.
+- **Commit:** _(see git log for the round-1 fix commit; v1→v2→v3 codex-verify retries documented in `.harness-github-review/cycle-1-verify-result-v{1,2,3}.json`)_

--- a/src-tauri/src/terminal/commands.rs
+++ b/src-tauri/src/terminal/commands.rs
@@ -2,9 +2,10 @@
 
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::io::Read;
+use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, State};
 
-use super::state::{ManagedSession, PtyState};
+use super::state::{ManagedSession, PtyState, RingBuffer};
 use super::types::*;
 
 /// Debug-only file logger. Compiles to no-op in release builds.
@@ -263,13 +264,15 @@ pub async fn spawn_pty<R: tauri::Runtime>(
     // whenever spawn_pty returns Err, no orphan child remains in
     // PtyState — independent of which step failed.
     let generation = state.next_generation();
+    let ring = Arc::new(Mutex::new(RingBuffer::new(65536)));
+    let read_ring = Arc::clone(&ring);
     let session = ManagedSession {
         master: pty_pair.master,
         writer,
         child,
         cwd: cwd.to_string_lossy().to_string(),
         generation,
-        ring: std::sync::Mutex::new(crate::terminal::state::RingBuffer::new(65536)),
+        ring,
     };
     if let Err((reason, mut rejected)) =
         state.try_insert(request.session_id.clone(), session, 64)
@@ -347,6 +350,7 @@ pub async fn spawn_pty<R: tauri::Runtime>(
             cache_clone,
             session_id,
             generation,
+            read_ring,
         )) {
             log::error!("PTY output reader error: {}", e);
         }
@@ -467,25 +471,35 @@ pub fn list_sessions(
         };
 
         // Round 12, Finding 3 (claude LOW): acquire the PtyState sessions
-        // lock once per id and snapshot pid + ring + end_offset together.
+        // lock once per id and snapshot pid + ring handle together.
         // The previous code called `state.get_pid()` (lock #1) then
         // `state.inner_sessions().lock()` (lock #2) — same data under two
         // locks, with a race window between them that the original code
-        // had to detect and demote to Exited. Reading both fields under
-        // a single guard collapses that window and the redundant work.
+        // had to detect and demote to Exited. Reading both fields under a
+        // single short guard collapses that window and the redundant work.
+        //
+        // Issue #100: clone the per-session ring Arc while holding the global
+        // sessions lock, then read bytes/end_offset after dropping it. That
+        // preserves the ring snapshot invariant without serializing
+        // list_sessions behind read-loop appends.
         let status = if cached.exited {
             SessionStatus::Exited {
                 last_exit_code: cached.last_exit_code,
             }
         } else {
-            let sessions_lock = state.inner_sessions().lock().expect("poisoned");
-            if let Some(session) = sessions_lock.get(id) {
-                let pid = session.child.process_id().unwrap_or(0);
-                let ring_guard = session.ring.lock().expect("ring poisoned");
+            let live_session = {
+                let sessions_lock = state.inner_sessions().lock().expect("poisoned");
+                sessions_lock.get(id).map(|session| {
+                    let pid = session.child.process_id().unwrap_or(0);
+                    let ring = Arc::clone(&session.ring);
+                    (pid, ring)
+                })
+            };
+
+            if let Some((pid, ring)) = live_session {
+                let ring_guard = ring.lock().expect("ring poisoned");
                 let bytes = ring_guard.bytes_snapshot();
                 let end_offset = ring_guard.end_offset();
-                drop(ring_guard);
-                drop(sessions_lock);
                 let replay_data = String::from_utf8_lossy(&bytes).to_string();
                 SessionStatus::Alive {
                     pid,
@@ -693,6 +707,7 @@ async fn read_pty_output<R: tauri::Runtime>(
     cache: std::sync::Arc<crate::terminal::cache::SessionCache>,
     session_id: SessionId,
     generation: u64,
+    ring: Arc<Mutex<RingBuffer>>,
 ) -> anyhow::Result<()> {
     log::info!("Starting PTY output reader for session: {}", session_id);
 
@@ -730,14 +745,8 @@ async fn read_pty_output<R: tauri::Runtime>(
             Ok(n) => {
                 // Atomically: append to ring buffer, get chunk_start, drop the lock
                 let chunk_start = {
-                    let sessions = state.inner_sessions().lock().expect("poisoned");
-                    if let Some(session) = sessions.get(&session_id) {
-                        let mut ring = session.ring.lock().expect("ring poisoned");
-                        ring.append(&buf[..n])
-                    } else {
-                        // Session was removed mid-read — exit loop
-                        break;
-                    }
+                    let mut ring = ring.lock().expect("ring poisoned");
+                    ring.append(&buf[..n])
                 };
                 let data = String::from_utf8_lossy(&buf[..n]).to_string();
                 app.emit(
@@ -787,7 +796,7 @@ async fn read_pty_output<R: tauri::Runtime>(
 mod tests {
     use super::*;
     use crate::terminal::cache::SessionCache;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use tauri::test::{mock_builder, MockRuntime};
     use tauri::Manager;
     use tempfile::TempDir;
@@ -1229,7 +1238,6 @@ mod tests {
     fn make_failing_kill_session() -> crate::terminal::state::ManagedSession {
         use crate::terminal::state::{ManagedSession, RingBuffer};
         use portable_pty::{native_pty_system, CommandBuilder, PtySize};
-        use std::sync::Mutex;
         let pty_system = native_pty_system();
         let pty_pair = pty_system
             .openpty(PtySize {
@@ -1252,7 +1260,7 @@ mod tests {
             child: Box::new(FailingKillChild),
             cwd: "/tmp".into(),
             generation: 0,
-            ring: Mutex::new(RingBuffer::new(64)),
+            ring: Arc::new(Mutex::new(RingBuffer::new(64))),
         }
     }
 

--- a/src-tauri/src/terminal/commands.rs
+++ b/src-tauri/src/terminal/commands.rs
@@ -2,6 +2,7 @@
 
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::io::Read;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, State};
 
@@ -266,6 +267,8 @@ pub async fn spawn_pty<R: tauri::Runtime>(
     let generation = state.next_generation();
     let ring = Arc::new(Mutex::new(RingBuffer::new(65536)));
     let read_ring = Arc::clone(&ring);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let read_cancelled = Arc::clone(&cancelled);
     let session = ManagedSession {
         master: pty_pair.master,
         writer,
@@ -273,6 +276,7 @@ pub async fn spawn_pty<R: tauri::Runtime>(
         cwd: cwd.to_string_lossy().to_string(),
         generation,
         ring,
+        cancelled,
     };
     if let Err((reason, mut rejected)) =
         state.try_insert(request.session_id.clone(), session, 64)
@@ -351,6 +355,7 @@ pub async fn spawn_pty<R: tauri::Runtime>(
             session_id,
             generation,
             read_ring,
+            read_cancelled,
         )) {
             log::error!("PTY output reader error: {}", e);
         }
@@ -422,12 +427,24 @@ pub fn kill_pty(
         Err(super::state::KillError::KillFailed(msg)) => {
             // Child may still be alive. Preserve PtyState + cache so a
             // retry can find the session, and surface the failure.
+            // IMPORTANT: must NOT touch the cancellation flag on this
+            // path — if we did, the still-alive child's next read would
+            // trip the flag and `remove_if_generation` would drop the
+            // session entry, orphaning the live process from app state.
             return Err(format!(
                 "kill_pty: failed to kill child for session {}: {}",
                 request.session_id, msg
             ));
         }
     }
+
+    // Signal the read loop to break out promptly even if the child ignores
+    // SIGTERM. Only set on the successful-kill / already-gone branches
+    // above so the `KillFailed` retry contract is preserved (a live child
+    // must not be cleaned up by the reader). Without this signal, an
+    // ignore-SIGTERM process would keep the read thread alive (and
+    // emitting `pty-data` for a removed session) until eventual EOF.
+    state.set_cancelled(&request.session_id);
 
     // Remove from state (no-op if NotPresent, the safe path above).
     state.remove(&request.session_id);
@@ -708,6 +725,7 @@ async fn read_pty_output<R: tauri::Runtime>(
     session_id: SessionId,
     generation: u64,
     ring: Arc<Mutex<RingBuffer>>,
+    cancelled: Arc<AtomicBool>,
 ) -> anyhow::Result<()> {
     log::info!("Starting PTY output reader for session: {}", session_id);
 
@@ -743,6 +761,21 @@ async fn read_pty_output<R: tauri::Runtime>(
                 break;
             }
             Ok(n) => {
+                // Honor a `kill_pty`-driven cancellation BEFORE appending
+                // or emitting. Checking after emit would let the first
+                // post-kill chunk leak to the UI; checking here drops it
+                // along with any further data so the contract "no
+                // pty-data after kill_pty completes" holds. Ignore-SIGTERM
+                // children would otherwise keep the read thread alive
+                // indefinitely.
+                if cancelled.load(Ordering::Relaxed) {
+                    log::info!(
+                        "PTY session {} read loop exiting (cancelled by kill_pty)",
+                        session_id
+                    );
+                    break;
+                }
+
                 // Atomically: append to ring buffer, get chunk_start, drop the lock
                 let chunk_start = {
                     let mut ring = ring.lock().expect("ring poisoned");
@@ -1261,6 +1294,7 @@ mod tests {
             cwd: "/tmp".into(),
             generation: 0,
             ring: Arc::new(Mutex::new(RingBuffer::new(64))),
+            cancelled: Arc::new(AtomicBool::new(false)),
         }
     }
 

--- a/src-tauri/src/terminal/state.rs
+++ b/src-tauri/src/terminal/state.rs
@@ -12,9 +12,9 @@ static GENERATION: AtomicU64 = AtomicU64::new(0);
 
 /// Bounded circular byte buffer paired with a monotonic byte offset.
 ///
-/// Both fields advance under the same mutex (the one wrapping `RingBuffer`
-/// inside `ManagedSession`), so a snapshot always returns `(bytes, end_offset)`
-/// where `end_offset == start_offset + bytes.len()`. Required for the
+/// Both fields advance under the same mutex, so a snapshot always returns
+/// `(bytes, end_offset)` where `end_offset == start_offset + bytes.len()`.
+/// Required for the
 /// replay/cursor protocol — see docs/superpowers/specs/2026-04-25-pty-reattach-on-reload-design.md
 /// "Replay Buffer + Offset Cursor".
 pub struct RingBuffer {
@@ -76,7 +76,7 @@ pub struct ManagedSession {
     /// Generation counter — distinguishes old vs new session on ID reuse
     pub generation: u64,
     /// Ring buffer for recent output + monotonic offset (replay protocol)
-    pub ring: Mutex<RingBuffer>,
+    pub ring: Arc<Mutex<RingBuffer>>,
 }
 
 /// Thread-safe PTY session state
@@ -339,8 +339,8 @@ impl PtyState {
     }
 
     /// Internal terminal-module accessor for code that must lock sessions
-    /// directly. Callers must take locks in sessions -> ring order and must
-    /// not call other `PtyState` methods while holding the sessions lock.
+    /// directly. Callers should keep this global lock short-lived; clone
+    /// per-session Arcs out of it before doing ring-buffer work.
     pub(crate) fn inner_sessions(&self) -> &Arc<Mutex<HashMap<SessionId, ManagedSession>>> {
         &self.sessions
     }
@@ -444,7 +444,7 @@ mod tests {
             child,
             cwd: "/tmp".into(),
             generation: 0,
-            ring: Mutex::new(super::RingBuffer::new(64)),
+            ring: Arc::new(Mutex::new(super::RingBuffer::new(64))),
         }
     }
 
@@ -514,7 +514,7 @@ mod tests {
             child: Box::new(FailingKillChild),
             cwd: "/tmp".into(),
             generation: 0,
-            ring: Mutex::new(super::RingBuffer::new(64)),
+            ring: Arc::new(Mutex::new(super::RingBuffer::new(64))),
         }
     }
 

--- a/src-tauri/src/terminal/state.rs
+++ b/src-tauri/src/terminal/state.rs
@@ -2,7 +2,7 @@
 
 use portable_pty::{Child, MasterPty};
 use std::collections::{HashMap, VecDeque};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use super::types::SessionId;
@@ -77,6 +77,13 @@ pub struct ManagedSession {
     pub generation: u64,
     /// Ring buffer for recent output + monotonic offset (replay protocol)
     pub ring: Arc<Mutex<RingBuffer>>,
+    /// Cancellation flag observed by the read loop. Set by `kill_pty` so the
+    /// background reader can break out even if the child ignores SIGTERM —
+    /// without it, a long-lived process would keep the read thread alive
+    /// (and emitting `pty-data` for a removed session) until eventual EOF.
+    /// The Arc is shared with the read thread; `kill_pty` flips the flag
+    /// before the session entry is removed from `PtyState`.
+    pub cancelled: Arc<AtomicBool>,
 }
 
 /// Thread-safe PTY session state
@@ -319,6 +326,18 @@ impl PtyState {
         Ok(())
     }
 
+    /// Flip the read-loop cancellation flag for a session, if present.
+    /// Idempotent and lock-light (acquires `sessions` only long enough to
+    /// look up the session and set the AtomicBool). Called by `kill_pty`
+    /// so the read loop can break out promptly even when the child
+    /// ignores SIGTERM and never produces EOF.
+    pub fn set_cancelled(&self, session_id: &SessionId) {
+        let sessions = self.sessions.lock().expect("failed to lock sessions");
+        if let Some(session) = sessions.get(session_id) {
+            session.cancelled.store(true, Ordering::Relaxed);
+        }
+    }
+
     /// Clone the PTY reader for a session while keeping the session in state
     ///
     /// This avoids the race condition where removing/reinserting the session
@@ -445,6 +464,7 @@ mod tests {
             cwd: "/tmp".into(),
             generation: 0,
             ring: Arc::new(Mutex::new(super::RingBuffer::new(64))),
+            cancelled: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -515,6 +535,7 @@ mod tests {
             cwd: "/tmp".into(),
             generation: 0,
             ring: Arc::new(Mutex::new(super::RingBuffer::new(64))),
+            cancelled: Arc::new(AtomicBool::new(false)),
         }
     }
 


### PR DESCRIPTION
## Summary
- Stores each terminal replay ring as `Arc<Mutex<RingBuffer>>`.
- Clones the ring into the PTY read loop so output appends no longer take the global sessions mutex.
- Updates `list_sessions` to clone the ring handle under the sessions lock and read `(bytes, end_offset)` under the ring lock after the global lock is dropped.

## Root Cause
`read_pty_output` locked the global sessions map for every PTY output chunk just to reach the per-session ring buffer. High-output sessions could serialize other readers and session commands behind that global mutex.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml terminal::commands::tests::list_sessions_replay_end_offset_matches_buffer_contents`
- `cargo test --manifest-path src-tauri/Cargo.toml terminal::state::tests`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `CI=true npm test`
- `git diff --check`
- pre-push hook: `npm test`

Fixes #100.
