### PR TITLE
fix(git): debounce watcher events on trailing edge

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,7 +43,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 16       | 9    | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 17       | 10   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 36       | 11   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,9 +43,9 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 15       | 8    | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 16       | 9    | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 35       | 10   | 2026-05-01   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 36       | 11   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 19       | 6    | 2026-05-02   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 5        | 1    | 2026-04-20   |
@@ -61,4 +61,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process | 5        | 0    | 2026-04-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing    | 9        | 1    | 2026-04-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality   | 1        | 0    | 2026-04-30   |
-| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality   | 6        | 1    | 2026-04-30   |
+| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality   | 7        | 2    | 2026-05-02   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,11 +43,11 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 14       | 7    | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 15       | 8    | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 35       | 10   | 2026-05-01   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |
-| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 18       | 5    | 2026-04-29   |
+| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 19       | 6    | 2026-05-02   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 5        | 1    | 2026-04-20   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)             | security       | 15       | 2    | 2026-04-20   |
 | [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                   | security       | 3        | 1    | 2026-04-20   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -3,7 +3,7 @@ id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-04-29
-ref_count: 3
+ref_count: 4
 ---
 
 # Async Race Conditions
@@ -183,3 +183,12 @@ prevent showing previous data.
 - **Fix:** Removed the duplicate `void handleDetection(sessionId)` from the polling `useEffect`. The subscribe `useEffect` already fires the initial detection after listeners are attached (and a comment in the file explicitly documented that intent). The `attaches test-run listener BEFORE invoking start_agent_watcher` regression test (added in the same task) caught the race on its first run with `expected 4 to be less than 2` — exactly the assertion shape it was designed to enforce.
 - **Lesson:** in a "subscribe + then trigger the publisher" flow, having TWO triggers from independent effects is structurally fragile, even if one is "polling" and the other is "init". Pick a single trigger source. Also: the load-bearing regression test was the right shape — it asserted the call ORDER recorded by mocks, not the eventual outcome.
 - **Commit:** `d7df1e5 feat(agent-status): test-run listener + ordering regression test`
+
+### 19. Inner burst-drain loop missed `stop_flag`, delaying thread shutdown by up to a polling cycle (10s)
+
+- **Source:** github-claude | PR #124 round 1 | 2026-05-02
+- **Severity:** MEDIUM
+- **File:** `src-tauri/src/git/watcher.rs`
+- **Finding:** `spawn_trailing_debounce_thread`'s inner `Ok(()) => continue` arm (which drains a rapid filesystem-event burst before resetting the quiet timer) never inspected `stop_flag`. After `RepoWatcher` was dropped, the thread's only escapes from the inner loop were a 60ms quiet period (correctly skipping the emit) or `Disconnected`. `Disconnected` only fires when EVERY `Sender` clone drops — but the clone living inside the `RecommendedWatcher` notify-callback closure is held behind `Arc<Mutex<RecommendedWatcher>>`, shared with the polling thread. That Arc lives until the polling thread sees its own `stop_flag` check (up to `POLL_INTERVAL_SECS = 10s` later). Net effect: a continuous filesystem burst at watcher teardown could pin the debounce thread (and its captured `app_handle` / `state` / `toplevel` Arcs) for up to 10 seconds. No incorrect emits — `stop_flag` already guarded the emit path — but resource cleanup was substantially delayed and the thread's lingering Arcs blocked observable shutdown ordering.
+- **Fix:** Added `if stop_flag.load(Ordering::Relaxed) { return; }` to the `Ok(()) => continue` branch (renamed to a block to host the check). One-line semantic addition; the inner loop now exits within one `recv_timeout(delay)` of the flag flipping, regardless of the polling-thread cleanup cadence. Same finding-class as #16 (subprocess stdout read with no deadline hangs forever) — both are "shutdown signal that doesn't propagate through every loop branch".
+- **Commit:** _(see git log for the round-1 fix commit)_

--- a/docs/reviews/patterns/diagnostic-instrumentation.md
+++ b/docs/reviews/patterns/diagnostic-instrumentation.md
@@ -3,7 +3,7 @@ id: diagnostic-instrumentation
 category: code-quality
 created: 2026-04-30
 last_updated: 2026-04-30
-ref_count: 1
+ref_count: 2
 ---
 
 # Diagnostic Instrumentation
@@ -89,3 +89,12 @@ The discipline:
 - **Finding:** The `TxOutcome::Missing` classification depended on `e.contains("No such file")` — the Linux text for ENOENT, forwarded from `validate_transcript_path` via `format!("invalid transcript path '{}': {}", ..., io_error)`. Windows reports a missing path with different OS-localized text ("The system cannot find the file specified"), as does macOS in some locales and any non-English Linux locale. On those platforms a missing transcript would fall through the substring match and be classified as `TxOutcome::NotFile`, defeating the diagnostic during the speculative-path window it exists to capture. The "access denied" substring, by contrast, is a CUSTOM string from `validate_transcript_path` itself (not OS-localized), so it remains safe.
 - **Fix:** Replaced the `e.contains("No such file")` substring match with `std::path::Path::new(transcript_path).exists()`. Linux ENOENT, Windows ERROR_FILE_NOT_FOUND, macOS in any locale, and any future OS variant now classify uniformly as `TxOutcome::Missing`. Comment near the call site explains why the missing case uses path-existence (platform-neutral) while the access-denied case keeps substring matching (project-owned string). The lesson: when classifying errors that originate from the OS, use platform-neutral primitives like `Path::exists()` / `ErrorKind::NotFound`, not substring matching on forwarded error text.
 - **Commit:** _(see git log for the round-3 fix commit)_
+
+### 7. Detached `JoinHandle` swallows test-thread panics, obscuring failure attribution
+
+- **Source:** github-claude | PR #124 round 2 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/git/watcher.rs`
+- **Finding:** `spawn_trailing_debounce_thread` calls `std::thread::spawn(...)` and discards the returned `JoinHandle`. In production the emit closure only calls `emit_for_all_subscribers`, which logs errors rather than panicking, so the swallowed-panic path is unreachable. In tests, however, the closure was `move || { emitted_tx.send(()).expect("failed to record debounce emit"); }` — and if the receiver dropped first (test cleanup ordering races), `.expect` would panic inside the detached thread. The panic was invisible: the next test assertion (`recv_timeout(...).expect("debounce should emit")`) would fire instead, attributing the failure to "no emit" when the real cause was "the emit closure panicked." Same finding-class as #5 (structurally-zero `dt` produces misleading log values) — both are diagnostics that point an investigator at the wrong cause.
+- **Fix:** Tests now use `let _ = emitted_tx.send(())` instead of `.expect(...)`, swallowing send errors so the detached thread can never panic. The positive `recv_timeout(...).expect("debounce should emit")` assertion remains the canonical failure signal, with no false-attribution interference from the worker thread. Returning the `JoinHandle` and exposing it for tests was considered but rejected: the fire-and-forget API is the right shape for production callers, and `catch_unwind` machinery would be heavy for the low-risk scenario.
+- **Commit:** _(see git log for the round-2 fix commit)_

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -3,7 +3,7 @@ id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
 last_updated: 2026-04-30
-ref_count: 10
+ref_count: 11
 ---
 
 # Documentation Accuracy
@@ -330,3 +330,12 @@ Stale documentation misleads future contributors and review agents.
 - **Finding:** `Number(event.payload.numTurns)` wrapped a value already typed `number` in the `AgentTurnEvent` ts-rs binding. Other `Number()` calls in this file are deliberate u64/i64 normalizations (where serde-json may emit values past `Number.MAX_SAFE_INTEGER`); applying the same pattern to a u32 field falsely implies the same hazard exists. A future reviewer might either (a) propagate the no-op pattern to other genuinely-`number` fields for "consistency" or (b) "fix" the apparent confusion by removing the legitimate u64 coercions elsewhere. Either path harms the codebase. Same finding-class as #6 (DRAWER_MAX comment claimed dynamic ratio but value was constant): a mechanism's adjacent doc/code suggests guarantees it doesn't actually provide.
 - **Fix:** Removed the `Number()` wrapper and added an inline comment explaining why u32 fields don't need bigint coercion (`u32` tops out at ~4.3 billion, well within JS safe-integer space). Pattern now is: u64/i64 → coerce; u32/i32/smaller → use directly.
 - **Commit:** _(see git log for the round-3 fix commit)_
+
+### 36. Inline magic-number bound for shutdown latency had no name in a file with named timing peers
+
+- **Source:** github-claude | PR #124 round 2 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/git/watcher.rs`
+- **Finding:** `spawn_trailing_debounce_thread` used `Duration::from_millis(100)` inline for the outer-loop `recv_timeout` value. That 100ms knob bounds shutdown latency from `stop_flag` set → thread exit when no burst is in flight, but it sat unnamed next to two top-level constants (`DEBOUNCE_MS`, `POLL_INTERVAL_SECS`) that had explanatory comments documenting their role. A future maintainer changing `DEBOUNCE_MS` for tuning could easily wonder why shutdown latency didn't change, or pick an arbitrary tweak to this third value without realizing what it controls. Same finding-class as #6 (`DRAWER_MAX` comment claimed dynamic ratio for a hardcoded constant): the magnitude of the value is right but the surface around it doesn't communicate intent.
+- **Fix:** Extracted `const IDLE_CHECK_MS: u64 = 100;` next to the existing constants with a comment explaining: "Outer-loop poll interval for the debounce thread — bounds the latency from `stop_flag` being set to thread exit when idle. 100 ms is roughly one Linux scheduler quantum." `recv_timeout` now reads `Duration::from_millis(IDLE_CHECK_MS)`. Same surface area, but the relationship between the value and its purpose is now explicit.
+- **Commit:** _(see git log for the round-2 fix commit)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 9
+ref_count: 10
 ---
 
 # Testing Gaps
@@ -160,3 +160,12 @@ filesystem scope restrictions).
 - **Finding:** The `trailing_debounce_emits_once_after_final_burst_event` test sent three events with `sleep(20ms)` gaps against a 60ms debounce window — 35ms of scheduler-jitter margin. On a saturated CI runner `sleep(20ms)` realistically overshoots to 50–100ms. Any single sleep exceeding 60ms splits the burst into independent debounce windows, triggering an early emit and tripping the `recv_timeout(25ms).is_err()` assertion on line 1169. Both sleeps overshooting also breaks the "exactly one emit" assertion at line 1177. The 20/60/35 ratio sat at roughly one Linux scheduler quantum, where typical CI noise routinely violates assumptions. Same finding-class as #11 (sleep-based synchronization in Rust integration test makes timing flaky) — both are absolute-time assertions against the SUT without enough margin to absorb scheduler jitter.
 - **Fix:** Doubled timing budgets: 120ms debounce window, 30ms inter-event sleeps, 50ms negative-window receive, 400ms positive-window receive. Now ~60ms scheduler margin (2× sleep) on the burst-quietness assertion. Adds ~60ms to test runtime in exchange for resilience against typical CI jitter; cheap compared to the alternative of a full event-driven synchronization mechanism.
 - **Commit:** _(see git log for the round-1 fix commit)_
+
+### 17. Regression-guard test verified an indirectly-guarded property, not the property the fix added
+
+- **Source:** github-claude | PR #124 round 3 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/git/watcher.rs`
+- **Finding:** Round-2's regression test for the inner-loop stop_flag check (added in round-1 to fix a 10s thread-pin) asserted "no spurious emit fires when stop_flag is set mid-burst." But emit() in `spawn_trailing_debounce_thread` is reached only via the Timeout arm, which already independently guards against stop_flag. So an Ok-arm regression — the very thing the round-1 fix introduced — couldn't change the emit-side observation: the Timeout arm's own guard would still suppress the emit. The test verified a real property (no spurious teardown emit) but couldn't catch the regression it was named after. The actual production risk (resource pinning ≤300ms after teardown until the burst dries up) was unobservable from the channel side. Same finding-class as #6 (regression-guard test that didn't actually verify the property it claimed to guard) — round-3 is the second instance in this codebase where assertion-on-side-effect failed to catch the regression on the guarded path.
+- **Fix:** Restructured `spawn_trailing_debounce_thread` to return `(Sender<()>, Arc<AtomicBool>)`, where the bool is set from a `Drop` guard inside the spawn closure. The completion flag flips on every exit path (any return + panic), giving tests a direct observation of "thread really gone." Production caller ignores the flag (`let (tx, _completed) = ...`). The regression test now observes the flag with a `IDLE_CHECK_MS + 200ms` deadline; under the regressed path, the inner loop stays in `recv_timeout(delay)` per burst event and the deadline expires before the flag flips. Lesson: when a fix lives in branch X of a multi-branch decision, the regression test must observe a property that branch X uniquely affects — not a downstream side-effect that other branches independently produce.
+- **Commit:** _(see git log for the round-3 fix commit)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 7
+ref_count: 8
 ---
 
 # Testing Gaps
@@ -142,3 +142,12 @@ filesystem scope restrictions).
 - **Finding:** `is_user_prompt` and `is_non_empty_user_block` had no in-module unit tests. Their behavior was exercised only by the integration test in `tests/transcript_turns.rs` (4–5 message shapes through a real Tauri mock app + watcher). Several edge cases were unverified by any test: whitespace-only string, empty string, empty array, all-tool_result array, mixed `tool_result + text`, unknown block type fallthrough, `text` block missing the `text` field, `text` block with non-string `text` value, block with no `type` field, block with non-string/null `type` field. Reliance on the heavy integration harness alone meant an edge-case regression would only surface when the Tauri mock app could be stood up — not in fast in-module test loops.
 - **Fix:** Added 11 unit tests directly in the existing `#[cfg(test)] mod tests`: 3 string-path tests (whitespace, empty, non-whitespace), 4 array-path tests (empty, only-tool_result, whitespace-only-text, mixed), 1 non-string-content shape, 1 unknown-block-type fallthrough, 1 text-block-missing-text-field, 1 missing/non-string/null `type` fallthrough. All 11 pass; total `agent::transcript::tests` now 38. Verify-cycle-3 caught a subgap (the `type`-field tests originally only covered explicit text-typed blocks); round-4 closes it with the explicit non-string/null type tests.
 - **Commit:** _(see git log for the round-4 fix commit, plus its codex-verify retry that closed the type-field subgap)_
+
+### 15. Real-time test sleeps with sub-2× margin against the system-under-test's debounce window are CI-fragile
+
+- **Source:** github-claude | PR #124 round 1 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/git/watcher.rs`
+- **Finding:** The `trailing_debounce_emits_once_after_final_burst_event` test sent three events with `sleep(20ms)` gaps against a 60ms debounce window — 35ms of scheduler-jitter margin. On a saturated CI runner `sleep(20ms)` realistically overshoots to 50–100ms. Any single sleep exceeding 60ms splits the burst into independent debounce windows, triggering an early emit and tripping the `recv_timeout(25ms).is_err()` assertion on line 1169. Both sleeps overshooting also breaks the "exactly one emit" assertion at line 1177. The 20/60/35 ratio sat at roughly one Linux scheduler quantum, where typical CI noise routinely violates assumptions. Same finding-class as #11 (sleep-based synchronization in Rust integration test makes timing flaky) — both are absolute-time assertions against the SUT without enough margin to absorb scheduler jitter.
+- **Fix:** Doubled timing budgets: 120ms debounce window, 30ms inter-event sleeps, 50ms negative-window receive, 400ms positive-window receive. Now ~60ms scheduler margin (2× sleep) on the burst-quietness assertion. Adds ~60ms to test runtime in exchange for resilience against typical CI jitter; cheap compared to the alternative of a full event-driven synchronization mechanism.
+- **Commit:** _(see git log for the round-1 fix commit)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 8
+ref_count: 9
 ---
 
 # Testing Gaps
@@ -142,6 +142,15 @@ filesystem scope restrictions).
 - **Finding:** `is_user_prompt` and `is_non_empty_user_block` had no in-module unit tests. Their behavior was exercised only by the integration test in `tests/transcript_turns.rs` (4–5 message shapes through a real Tauri mock app + watcher). Several edge cases were unverified by any test: whitespace-only string, empty string, empty array, all-tool_result array, mixed `tool_result + text`, unknown block type fallthrough, `text` block missing the `text` field, `text` block with non-string `text` value, block with no `type` field, block with non-string/null `type` field. Reliance on the heavy integration harness alone meant an edge-case regression would only surface when the Tauri mock app could be stood up — not in fast in-module test loops.
 - **Fix:** Added 11 unit tests directly in the existing `#[cfg(test)] mod tests`: 3 string-path tests (whitespace, empty, non-whitespace), 4 array-path tests (empty, only-tool_result, whitespace-only-text, mixed), 1 non-string-content shape, 1 unknown-block-type fallthrough, 1 text-block-missing-text-field, 1 missing/non-string/null `type` fallthrough. All 11 pass; total `agent::transcript::tests` now 38. Verify-cycle-3 caught a subgap (the `type`-field tests originally only covered explicit text-typed blocks); round-4 closes it with the explicit non-string/null type tests.
 - **Commit:** _(see git log for the round-4 fix commit, plus its codex-verify retry that closed the type-field subgap)_
+
+### 16. Round-1 safety fix shipped without a regression test for its specific code path
+
+- **Source:** github-claude | PR #124 round 2 | 2026-05-02
+- **Severity:** MEDIUM
+- **File:** `src-tauri/src/git/watcher.rs`
+- **Finding:** Round-1 (PR #124) added a `stop_flag.load(...)` check inside the inner burst-drain loop's `Ok(()) => continue` arm — the load-bearing fix for finding #19 in async-race-conditions.md (thread pinned for ≤10s during continuous bursts at teardown). The only test added in round-1 was the happy-path `trailing_debounce_emits_once_after_final_burst_event`, which exercises the Timeout arm but never the Ok+stop_flag arm. A future refactor that accidentally reverted the check would not surface in CI: production callers don't observe the resource leak directly (just delayed shutdown), and the existing test wouldn't fail. Same finding-class as #6 (regression-guard test that didn't actually verify the property it claimed to guard) — the fix is in production but the contract proving it works isn't pinned by a test.
+- **Fix:** Added `trailing_debounce_inner_loop_breaks_on_stop_flag_during_active_burst` test that flips `stop_flag` mid-burst and asserts no emit fires for a full debounce window. If the inner-loop check regresses, the burst's continuous events keep the inner loop alive past the assertion deadline → emit fires → `recv_timeout(200ms).is_err()` flips to `Ok(())` and the assertion fails. The lesson going forward: every safety fix should ship with the test that would catch its specific regression, not just the test for the original happy path.
+- **Commit:** _(see git log for the round-2 fix commit)_
 
 ### 15. Real-time test sleeps with sub-2× margin against the system-under-test's debounce window are CI-fragile
 

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -63,7 +63,22 @@ where
             match rx.recv_timeout(Duration::from_millis(100)) {
                 Ok(()) => loop {
                     match rx.recv_timeout(delay) {
-                        Ok(()) => continue,
+                        Ok(()) => {
+                            // Honor stop_flag inside the inner burst-drain
+                            // loop too. Without this, a continuous event
+                            // burst keeps the thread alive until either the
+                            // burst ends OR every Sender clone drops — and
+                            // the clone held by the notify-watcher closure
+                            // (behind Arc<Mutex<RecommendedWatcher>>) only
+                            // disconnects when the polling thread also
+                            // exits, which can be up to POLL_INTERVAL_SECS
+                            // (10s) later. Checking here lets the thread
+                            // (and its captured Arcs) drop promptly.
+                            if stop_flag.load(Ordering::Relaxed) {
+                                return;
+                            }
+                            continue;
+                        }
                         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                             if !stop_flag.load(Ordering::Relaxed) {
                                 emit();
@@ -1149,32 +1164,37 @@ mod tests {
 
     #[test]
     fn trailing_debounce_emits_once_after_final_burst_event() {
+        // Margins doubled (debounce 60→120ms, sleep 20→30ms) so the test
+        // tolerates ~60ms scheduler jitter on loaded CI runners. The 60ms
+        // / 35ms previous margin sat at roughly one Linux scheduler quantum
+        // and produced spurious failures when sleep(20ms) overshot 60ms,
+        // splitting the burst into separate windows.
         let stop_flag = Arc::new(AtomicBool::new(false));
         let (emitted_tx, emitted_rx) = mpsc::channel::<()>();
         let debounce_tx = spawn_trailing_debounce_thread(
             stop_flag.clone(),
-            Duration::from_millis(60),
+            Duration::from_millis(120),
             move || {
                 emitted_tx.send(()).expect("failed to record debounce emit");
             },
         );
 
         debounce_tx.send(()).expect("failed to send first event");
-        std::thread::sleep(Duration::from_millis(20));
+        std::thread::sleep(Duration::from_millis(30));
         debounce_tx.send(()).expect("failed to send second event");
-        std::thread::sleep(Duration::from_millis(20));
+        std::thread::sleep(Duration::from_millis(30));
         debounce_tx.send(()).expect("failed to send third event");
 
         assert!(
-            emitted_rx.recv_timeout(Duration::from_millis(25)).is_err(),
+            emitted_rx.recv_timeout(Duration::from_millis(50)).is_err(),
             "debounce emitted before the burst went quiet"
         );
 
         emitted_rx
-            .recv_timeout(Duration::from_millis(300))
+            .recv_timeout(Duration::from_millis(400))
             .expect("debounce should emit after quiet period");
         assert!(
-            emitted_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            emitted_rx.recv_timeout(Duration::from_millis(150)).is_err(),
             "burst should produce exactly one trailing emit"
         );
 

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -32,6 +32,13 @@ const DEBOUNCE_MS: u64 = 300;
 /// Polling fallback interval — check for changes every 10 seconds
 const POLL_INTERVAL_SECS: u64 = 10;
 
+/// Outer-loop poll interval for the debounce thread — bounds the latency
+/// from `stop_flag` being set to thread exit when idle (no burst in
+/// flight). 100 ms is roughly one Linux scheduler quantum: tight enough
+/// to feel instant, loose enough to avoid burning CPU on a thread that
+/// only matters when filesystem events arrive.
+const IDLE_CHECK_MS: u64 = 100;
+
 /// Timeout for sync git subprocesses called from the polling thread.
 /// Guards against hangs on NFS/FUSE, stale `.git/index.lock`, or corrupted
 /// packs. `Command::output()` without this would block the polling thread
@@ -60,7 +67,7 @@ where
 
     std::thread::spawn(move || {
         while !stop_flag.load(Ordering::Relaxed) {
-            match rx.recv_timeout(Duration::from_millis(100)) {
+            match rx.recv_timeout(Duration::from_millis(IDLE_CHECK_MS)) {
                 Ok(()) => loop {
                     match rx.recv_timeout(delay) {
                         Ok(()) => {
@@ -1175,7 +1182,12 @@ mod tests {
             stop_flag.clone(),
             Duration::from_millis(120),
             move || {
-                emitted_tx.send(()).expect("failed to record debounce emit");
+                // Swallow send errors: if the receiver was dropped first
+                // (test cleanup ordering), .expect would panic in the
+                // detached thread and silently swallow the panic. The
+                // positive `recv_timeout(...).expect("debounce should emit")`
+                // assertion below is the canonical failure signal.
+                let _ = emitted_tx.send(());
             },
         );
 
@@ -1199,6 +1211,50 @@ mod tests {
         );
 
         stop_flag.store(true, Ordering::Relaxed);
+        drop(debounce_tx);
+    }
+
+    #[test]
+    fn trailing_debounce_inner_loop_breaks_on_stop_flag_during_active_burst() {
+        // Round-2 regression guard for the round-1 stop_flag check inside
+        // the inner `Ok(())` arm. If a future refactor accidentally
+        // reverts that check, a continuous burst would pin the thread
+        // until its Sender clones disconnected (up to POLL_INTERVAL_SECS
+        // = 10s in production). The test simulates an active burst,
+        // flips stop_flag mid-burst, and asserts NO emit fires for a
+        // full debounce window — proving the inner loop bailed early.
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let (emitted_tx, emitted_rx) = mpsc::channel::<()>();
+        let debounce_tx = spawn_trailing_debounce_thread(
+            stop_flag.clone(),
+            Duration::from_millis(120),
+            move || {
+                let _ = emitted_tx.send(());
+            },
+        );
+
+        // Kick off the burst — first event enters the inner Ok() loop.
+        debounce_tx.send(()).expect("failed to send burst event 1");
+        std::thread::sleep(Duration::from_millis(20));
+        // Mid-burst flip.
+        stop_flag.store(true, Ordering::Relaxed);
+        // Keep feeding events so the inner loop keeps re-entering Ok();
+        // each iteration must observe stop_flag and `return`.
+        for _ in 0..5 {
+            // Sender side: ignore errors — the thread may exit between
+            // sends, dropping its rx, in which case send() returns Err.
+            let _ = debounce_tx.send(());
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        // No trailing emit should land — the inner loop returned before
+        // ever hitting the Timeout arm where emit() lives. Wait the full
+        // debounce window plus margin to be sure.
+        assert!(
+            emitted_rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "stop_flag set mid-burst must suppress the trailing emit"
+        );
+
         drop(debounce_tx);
     }
 

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -26,7 +26,7 @@ use tauri::Emitter;
 
 use super::validate_cwd;
 
-/// Debounce interval — ignore events within 300ms of the last processed one
+/// Debounce interval — emit after filesystem events have been quiet for 300ms.
 const DEBOUNCE_MS: u64 = 300;
 
 /// Polling fallback interval — check for changes every 10 seconds
@@ -46,6 +46,40 @@ fn is_notify_not_found(error: &notify::Error) -> bool {
             &error.kind,
             notify::ErrorKind::Io(e) if e.kind() == std::io::ErrorKind::NotFound
         )
+}
+
+fn spawn_trailing_debounce_thread<F>(
+    stop_flag: Arc<AtomicBool>,
+    delay: Duration,
+    mut emit: F,
+) -> std::sync::mpsc::Sender<()>
+where
+    F: FnMut() + Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::channel::<()>();
+
+    std::thread::spawn(move || {
+        while !stop_flag.load(Ordering::Relaxed) {
+            match rx.recv_timeout(Duration::from_millis(100)) {
+                Ok(()) => loop {
+                    match rx.recv_timeout(delay) {
+                        Ok(()) => continue,
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                            if !stop_flag.load(Ordering::Relaxed) {
+                                emit();
+                            }
+                            break;
+                        }
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+                    }
+                },
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+            }
+        }
+    });
+
+    tx
 }
 
 /// Run a `std::process::Command` synchronously with a deadline. On timeout,
@@ -412,22 +446,24 @@ fn start_git_watcher_inner<R: tauri::Runtime>(
     let last_status_hash = Arc::new(Mutex::new(
         hash_git_status(&toplevel).ok(),
     ));
-    // Debounce timestamp starts as `None` so the FIRST real notify event
-    // always passes. Initializing to `Instant::now()` at construction
-    // (the previous revision) would swallow any filesystem change within
-    // the DEBOUNCE_MS window of watcher startup — visible as up-to-10s
-    // stale state when a fast agent edits files right after subscription
-    // (the 10s polling fallback is the only recovery). `None` ≡ "no prior
-    // event, always pass"; after the first match it becomes `Some(now)`.
-    let last_processed: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
     let stop_flag = Arc::new(AtomicBool::new(false));
+    let debounce_tx = {
+        let app_handle = app_handle.clone();
+        let state = state_clone.clone();
+        let toplevel = toplevel.clone();
+        let stop_flag = stop_flag.clone();
+
+        spawn_trailing_debounce_thread(
+            stop_flag,
+            Duration::from_millis(DEBOUNCE_MS),
+            move || emit_for_all_subscribers(&app_handle, &state, &toplevel),
+        )
+    };
 
     // Create notify watcher
     let notify_watcher = {
         let toplevel = toplevel.clone();
-        let app_handle = app_handle.clone();
-        let state = state_clone.clone();
-        let last_processed = last_processed.clone();
+        let debounce_tx = debounce_tx.clone();
 
         notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
             let event = match res {
@@ -450,22 +486,12 @@ fn start_git_watcher_inner<R: tauri::Runtime>(
                 return;
             }
 
-            // Debounce
-            {
-                let mut last = last_processed
-                    .lock()
-                    .expect("failed to lock last_processed");
-                let now = Instant::now();
-                if let Some(prev) = *last {
-                    if now.duration_since(prev) < Duration::from_millis(DEBOUNCE_MS) {
-                        return;
-                    }
-                }
-                *last = Some(now);
+            if debounce_tx.send(()).is_err() {
+                log::debug!(
+                    "Git watcher debounce thread stopped for {}",
+                    toplevel.display()
+                );
             }
-
-            // Emit event for all subscribers
-            emit_for_all_subscribers(&app_handle, &state, &toplevel);
         })
         .map_err(|e| format!("Failed to create watcher: {}", e))?
     };
@@ -1018,7 +1044,7 @@ mod tests {
     use super::*;
     use std::fs;
     use std::process::Command;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{mpsc, Arc, Mutex};
     use tauri::Listener;
     use tempfile::TempDir;
 
@@ -1119,6 +1145,41 @@ mod tests {
         let error = notify::Error::new(notify::ErrorKind::MaxFilesWatch);
 
         assert!(!is_notify_not_found(&error));
+    }
+
+    #[test]
+    fn trailing_debounce_emits_once_after_final_burst_event() {
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let (emitted_tx, emitted_rx) = mpsc::channel::<()>();
+        let debounce_tx = spawn_trailing_debounce_thread(
+            stop_flag.clone(),
+            Duration::from_millis(60),
+            move || {
+                emitted_tx.send(()).expect("failed to record debounce emit");
+            },
+        );
+
+        debounce_tx.send(()).expect("failed to send first event");
+        std::thread::sleep(Duration::from_millis(20));
+        debounce_tx.send(()).expect("failed to send second event");
+        std::thread::sleep(Duration::from_millis(20));
+        debounce_tx.send(()).expect("failed to send third event");
+
+        assert!(
+            emitted_rx.recv_timeout(Duration::from_millis(25)).is_err(),
+            "debounce emitted before the burst went quiet"
+        );
+
+        emitted_rx
+            .recv_timeout(Duration::from_millis(300))
+            .expect("debounce should emit after quiet period");
+        assert!(
+            emitted_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "burst should produce exactly one trailing emit"
+        );
+
+        stop_flag.store(true, Ordering::Relaxed);
+        drop(debounce_tx);
     }
 
     #[test]

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -55,17 +55,39 @@ fn is_notify_not_found(error: &notify::Error) -> bool {
         )
 }
 
+/// Returns the burst-event Sender plus a completion flag that flips to
+/// `true` exactly when the spawned thread exits (any path: stop_flag
+/// outer break, stop_flag inner break, Disconnected, panic-via-DropGuard).
+/// Production callers drop the flag and rely on `stop_flag` for shutdown;
+/// tests use the flag to observe prompt-exit semantics directly, instead
+/// of inferring exit timing from a side-channel like emit-suppression
+/// (which is independently guaranteed by the Timeout arm and therefore
+/// can't distinguish an Ok-arm regression from a Timeout-arm guard).
 fn spawn_trailing_debounce_thread<F>(
     stop_flag: Arc<AtomicBool>,
     delay: Duration,
     mut emit: F,
-) -> std::sync::mpsc::Sender<()>
+) -> (std::sync::mpsc::Sender<()>, Arc<AtomicBool>)
 where
     F: FnMut() + Send + 'static,
 {
     let (tx, rx) = std::sync::mpsc::channel::<()>();
+    let completed = Arc::new(AtomicBool::new(false));
+    let completed_for_thread = Arc::clone(&completed);
 
     std::thread::spawn(move || {
+        // Drop guard fires on every exit path including panics, so the
+        // completion flag tracks "thread really gone" rather than "thread
+        // chose to exit cleanly". Tests reading the flag get the strict
+        // contract; production callers ignoring it pay nothing extra.
+        struct CompletionGuard(Arc<AtomicBool>);
+        impl Drop for CompletionGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+        let _completion_guard = CompletionGuard(completed_for_thread);
+
         while !stop_flag.load(Ordering::Relaxed) {
             match rx.recv_timeout(Duration::from_millis(IDLE_CHECK_MS)) {
                 Ok(()) => loop {
@@ -101,7 +123,7 @@ where
         }
     });
 
-    tx
+    (tx, completed)
 }
 
 /// Run a `std::process::Command` synchronously with a deadline. On timeout,
@@ -475,11 +497,16 @@ fn start_git_watcher_inner<R: tauri::Runtime>(
         let toplevel = toplevel.clone();
         let stop_flag = stop_flag.clone();
 
-        spawn_trailing_debounce_thread(
+        // Production callers ignore the completion flag — `stop_flag` plus
+        // the Drop semantics of the captured Arcs are enough for shutdown.
+        // The flag exists to give tests a way to observe prompt exit
+        // without inferring it from emit-suppression side-channels.
+        let (tx, _completed) = spawn_trailing_debounce_thread(
             stop_flag,
             Duration::from_millis(DEBOUNCE_MS),
             move || emit_for_all_subscribers(&app_handle, &state, &toplevel),
-        )
+        );
+        tx
     };
 
     // Create notify watcher
@@ -1178,7 +1205,7 @@ mod tests {
         // splitting the burst into separate windows.
         let stop_flag = Arc::new(AtomicBool::new(false));
         let (emitted_tx, emitted_rx) = mpsc::channel::<()>();
-        let debounce_tx = spawn_trailing_debounce_thread(
+        let (debounce_tx, _completed) = spawn_trailing_debounce_thread(
             stop_flag.clone(),
             Duration::from_millis(120),
             move || {
@@ -1216,18 +1243,28 @@ mod tests {
 
     #[test]
     fn trailing_debounce_inner_loop_breaks_on_stop_flag_during_active_burst() {
-        // Round-2 regression guard for the round-1 stop_flag check inside
-        // the inner `Ok(())` arm. If a future refactor accidentally
-        // reverts that check, a continuous burst would pin the thread
-        // until its Sender clones disconnected (up to POLL_INTERVAL_SECS
-        // = 10s in production). The test simulates an active burst,
-        // flips stop_flag mid-burst, and asserts NO emit fires for a
-        // full debounce window — proving the inner loop bailed early.
+        // Round-3 rewrite. The round-2 version asserted "no emit fires"
+        // — but emit suppression is independently guaranteed by the
+        // Timeout arm's own stop_flag guard, so the test couldn't
+        // distinguish an Ok-arm regression from the Timeout-arm guard.
+        // Round-3 observes the contract directly: the spawn function
+        // exposes a `completed` Arc<AtomicBool> set in a Drop guard at
+        // thread exit; the test asserts it flips within
+        // `IDLE_CHECK_MS + delay + margin` of stop_flag being raised
+        // while a burst is still being fed. If the Ok-arm check
+        // regresses, the inner loop drives the thread past every
+        // `recv_timeout(delay)` of the burst, and `completed` doesn't
+        // flip until the burst dries up — which the assertion catches.
         let stop_flag = Arc::new(AtomicBool::new(false));
-        let (emitted_tx, emitted_rx) = mpsc::channel::<()>();
-        let debounce_tx = spawn_trailing_debounce_thread(
+        let (emitted_tx, _emitted_rx) = mpsc::channel::<()>();
+        let (debounce_tx, completed) = spawn_trailing_debounce_thread(
             stop_flag.clone(),
-            Duration::from_millis(120),
+            // Use a longer delay (250ms) so the difference between
+            // "Ok-arm bails immediately" and "Ok-arm regressed and waits
+            // for inner timeout / Disconnected" is observable: a 250ms
+            // delay × 5 events × scheduler jitter would push a regressed
+            // thread past 1s, well outside the 200ms assertion window.
+            Duration::from_millis(250),
             move || {
                 let _ = emitted_tx.send(());
             },
@@ -1238,8 +1275,10 @@ mod tests {
         std::thread::sleep(Duration::from_millis(20));
         // Mid-burst flip.
         stop_flag.store(true, Ordering::Relaxed);
-        // Keep feeding events so the inner loop keeps re-entering Ok();
-        // each iteration must observe stop_flag and `return`.
+        // Keep feeding events so the inner loop keeps re-entering Ok().
+        // Each iteration MUST observe stop_flag and `return`; otherwise
+        // the inner `recv_timeout(250ms)` waits the full delay between
+        // events, postponing thread exit far beyond our assertion window.
         for _ in 0..5 {
             // Sender side: ignore errors — the thread may exit between
             // sends, dropping its rx, in which case send() returns Err.
@@ -1247,12 +1286,25 @@ mod tests {
             std::thread::sleep(Duration::from_millis(20));
         }
 
-        // No trailing emit should land — the inner loop returned before
-        // ever hitting the Timeout arm where emit() lives. Wait the full
-        // debounce window plus margin to be sure.
+        // Wait briefly for the thread to exit. If the Ok-arm stop_flag
+        // check is in place, the thread returns within IDLE_CHECK_MS
+        // of stop_flag being raised. We add a generous margin (200ms)
+        // to absorb scheduler jitter, well below the regressed-path's
+        // expected lower bound (5×20ms send pacing + 250ms delay = ~350ms
+        // minimum to exhaust the burst, longer under load).
+        let deadline = std::time::Instant::now() + Duration::from_millis(200);
+        while std::time::Instant::now() < deadline {
+            if completed.load(Ordering::Acquire) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
         assert!(
-            emitted_rx.recv_timeout(Duration::from_millis(200)).is_err(),
-            "stop_flag set mid-burst must suppress the trailing emit"
+            completed.load(Ordering::Acquire),
+            "thread must exit promptly via the Ok-arm stop_flag check; \
+             still alive after IDLE_CHECK_MS + 200ms margin (the \
+             regressed-path lower bound is delay×N events ≈ 350ms+)"
         );
 
         drop(debounce_tx);


### PR DESCRIPTION
## Summary
- Replaces the git notify callback's leading-edge throttle with a trailing-edge debounce worker.
- Notify events now reset a 300 ms quiet timer, and the watcher emits after the final event in a burst instead of dropping later events.
- Adds a regression test proving a rapid event burst produces exactly one trailing emit.

## Root Cause
The old watcher emitted immediately for the first relevant filesystem event, then ignored subsequent events inside the debounce window. Bulk git operations could therefore refresh the UI from an intermediate working-tree state and miss the final state until the 10 second polling fallback ran.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml git::watcher::tests::trailing_debounce_emits_once_after_final_burst_event`
- `cargo test --manifest-path src-tauri/Cargo.toml git::watcher::tests`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `CI=true npm test`
- `git diff --check`
- pre-push hook: `npm test`

Fixes #93.
