### PR TITLE
refactor(diff): share watched git status

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,7 +43,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 18       | 11   | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 19       | 12   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 36       | 11   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,7 +43,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 20       | 13   | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 22       | 14   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 36       | 11   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,7 +43,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 19       | 12   | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 20       | 13   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 36       | 11   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,7 +43,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 17       | 10   | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 18       | 11   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 36       | 11   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 12
+ref_count: 13
 ---
 
 # Testing Gaps
@@ -187,3 +187,12 @@ filesystem scope restrictions).
 - **Finding:** Round-1 fixed the parent's `enabled: true` assertion (#18) but two related gaps remained: (a) `AgentStatusPanel.test.tsx`'s "uses shared git status when provided by the parent" test verified UI output but never asserted that the internal `useGitStatus` was called with `enabled: false` — the load-bearing watcher-deduplication invariant of the lifted-state refactor. The sibling `DiffPanelContent.test.tsx` already used `vi.spyOn(useGitStatusModule, 'useGitStatus')` correctly; AgentStatusPanel's mock was a plain factory with no spy reference. A regression that dropped `gitStatus === undefined &&` from the internal enabled condition would silently start two simultaneous watchers per cwd while every test stayed green. (b) The parent's round-1 `enabled: true` test only covered the `isActive` arm of the OR-condition (`agentStatus.isActive || bottomDrawerTab === 'diff'`); since `useAgentStatus` always returned `isActive: true`, the diff-tab arm was structurally impossible to exercise. Removing `|| bottomDrawerTab === 'diff'` would still satisfy the assertion. Both gaps follow the same theme as #18 (a lifted-state assertion that doesn't actually constrain the contract it's named after).
 - **Fix:** (a) Restructured `AgentStatusPanel.test.tsx` to import `* as useGitStatusModule` and call `vi.spyOn` on the test-by-test, asserting `expect(useGitStatusSpy).toHaveBeenCalledWith('/tmp/repo', expect.objectContaining({ enabled: false }))`. (b) Extended the BottomDrawer mock in `WorkspaceView.subscription.test.tsx` with a test-only "switch to diff" button bound to `onTabChange`, and added a sibling test using `vi.mocked(useAgentStatus).mockImplementation(() => idleAgentStatus)` so the agent stays idle across the tab-switch re-render. Codex verify v1 caught a `mockReturnValueOnce` bug here: the override only applied to the first render, letting the re-render fall back to the active default and passing the assertion via the wrong branch. v2 uses `mockImplementation` + `getMockImplementation` save-and-restore in a `finally` block.
 - **Commit:** _(see git log for the round-2 fix commit; v1→v2 codex-verify retry documented in `.harness-github-review/cycle-2-verify-result-v{1,2}.json`)_
+
+### 20. Inline `vi.spyOn` without `try/finally` leaks on assertion failure, polluting subsequent tests
+
+- **Source:** github-claude | PR #125 round 3 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src/features/agent-status/components/AgentStatusPanel.test.tsx`
+- **Finding:** Round-2 added an inline `const useGitStatusSpy = vi.spyOn(useGitStatusModule, 'useGitStatus')` to assert `enabled: false` was passed to the internal hook. The matching `useGitStatusSpy.mockRestore()` lived at the bottom of the test, with no try/finally guard. If `render()` or any `expect(...)` between the spy creation and the restore throws, `mockRestore()` is skipped and the spy permanently wraps the module export for the rest of the test file. The next test (`'renders ToolCallSummary and ActivityFeed inside the scrollable region'`) calls the same hook through the leaked spy, so call counts accumulate on a spy that nothing tracks. Worst case for `toHaveBeenCalled`-shape assertions later in the file: inflated totals → false positives. The module-level mock is a plain factory (not vi.fn), so the leaked spy can't be inspected or cleared without manual intervention. Same finding-class as #18+#19 (lifted-state assertions that don't constrain what they claim) only at the test-hygiene level: the cleanup invariant is named ("restore the spy") but not enforced by structure.
+- **Fix:** Wrapped the test body in `try { render + asserts } finally { useGitStatusSpy.mockRestore() }`. Cleanup now fires even if any assertion throws. Alternative considered: enable `restoreMocks: true` globally in `vitest.config.ts` — rejected for this PR because it would change behavior across the whole suite (every spy auto-restores), which is a separate refactor with its own review cycle.
+- **Commit:** _(see git log for the round-3 fix commit)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 10
+ref_count: 11
 ---
 
 # Testing Gaps
@@ -169,3 +169,12 @@ filesystem scope restrictions).
 - **Finding:** Round-2's regression test for the inner-loop stop_flag check (added in round-1 to fix a 10s thread-pin) asserted "no spurious emit fires when stop_flag is set mid-burst." But emit() in `spawn_trailing_debounce_thread` is reached only via the Timeout arm, which already independently guards against stop_flag. So an Ok-arm regression — the very thing the round-1 fix introduced — couldn't change the emit-side observation: the Timeout arm's own guard would still suppress the emit. The test verified a real property (no spurious teardown emit) but couldn't catch the regression it was named after. The actual production risk (resource pinning ≤300ms after teardown until the burst dries up) was unobservable from the channel side. Same finding-class as #6 (regression-guard test that didn't actually verify the property it claimed to guard) — round-3 is the second instance in this codebase where assertion-on-side-effect failed to catch the regression on the guarded path.
 - **Fix:** Restructured `spawn_trailing_debounce_thread` to return `(Sender<()>, Arc<AtomicBool>)`, where the bool is set from a `Drop` guard inside the spawn closure. The completion flag flips on every exit path (any return + panic), giving tests a direct observation of "thread really gone." Production caller ignores the flag (`let (tx, _completed) = ...`). The regression test now observes the flag with a `IDLE_CHECK_MS + 200ms` deadline; under the regressed path, the inner loop stays in `recv_timeout(delay)` per burst event and the deadline expires before the flag flips. Lesson: when a fix lives in branch X of a multi-branch decision, the regression test must observe a property that branch X uniquely affects — not a downstream side-effect that other branches independently produce.
 - **Commit:** _(see git log for the round-3 fix commit)_
+
+### 18. Idle-shaped hook mock + missing arg assertion masks `enabled: false` regression on lifted-state contract
+
+- **Source:** github-claude | PR #125 round 1 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src/features/workspace/WorkspaceView.subscription.test.tsx`
+- **Finding:** The subscription test mocked `useGitStatus` to return a constant `{ idle: true, ... }` shape regardless of the options object the parent passed. With `agentStatus.isActive = true` the production code computes `enabled: true` and starts a watcher; the mock returned the same idle-state object whether `enabled` was true or false. Worse: the test never called `expect(useGitStatusMock).toHaveBeenCalledWith(..., expect.objectContaining({ enabled: true }))`. A regression that passed `enabled: false` (e.g. an accidental flip of the activation OR-condition, or a misread of `agentStatus.isActive`) would still satisfy the existing reference-equality assertions on the captured props (panel + bottom drawer would each receive the same idle object). Watcher would never start in production; UI would show a permanent empty state. Same finding-class as #6 (regression-guard test that didn't actually verify the property it claimed to guard) — a reference-equality assertion is not a substitute for asserting the input that drives the mechanism.
+- **Fix:** Mock factory now reads `options.enabled` and returns `idle: !enabled`, mirroring the real hook's contract (idle iff disabled). Added a new test `WorkspaceView calls useGitStatus with enabled: true when an agent is active` that asserts `expect(useGitStatus).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ watch: true, enabled: true }))`. The pre-existing reference-equality test stays — they cover orthogonal contracts (one hook call vs. correct args).
+- **Commit:** _(see git log for the round-1 fix commit)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 13
+ref_count: 14
 ---
 
 # Testing Gaps
@@ -196,3 +196,21 @@ filesystem scope restrictions).
 - **Finding:** Round-2 added an inline `const useGitStatusSpy = vi.spyOn(useGitStatusModule, 'useGitStatus')` to assert `enabled: false` was passed to the internal hook. The matching `useGitStatusSpy.mockRestore()` lived at the bottom of the test, with no try/finally guard. If `render()` or any `expect(...)` between the spy creation and the restore throws, `mockRestore()` is skipped and the spy permanently wraps the module export for the rest of the test file. The next test (`'renders ToolCallSummary and ActivityFeed inside the scrollable region'`) calls the same hook through the leaked spy, so call counts accumulate on a spy that nothing tracks. Worst case for `toHaveBeenCalled`-shape assertions later in the file: inflated totals → false positives. The module-level mock is a plain factory (not vi.fn), so the leaked spy can't be inspected or cleared without manual intervention. Same finding-class as #18+#19 (lifted-state assertions that don't constrain what they claim) only at the test-hygiene level: the cleanup invariant is named ("restore the spy") but not enforced by structure.
 - **Fix:** Wrapped the test body in `try { render + asserts } finally { useGitStatusSpy.mockRestore() }`. Cleanup now fires even if any assertion throws. Alternative considered: enable `restoreMocks: true` globally in `vitest.config.ts` — rejected for this PR because it would change behavior across the whole suite (every spy auto-restores), which is a separate refactor with its own review cycle.
 - **Commit:** _(see git log for the round-3 fix commit)_
+
+### 21. `toHaveBeenCalledWith` against accumulated mock history is vacuous unless `mockClear()` resets per-test
+
+- **Source:** github-claude | PR #125 round 4 | 2026-05-02
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.subscription.test.tsx`
+- **Finding:** `vi.fn()` mocks accumulate call history across tests by default. The round-1 assertion `expect(useGitStatus).toHaveBeenCalledWith(..., { enabled: true })` was structurally correct for the test's goal — but `tests 1+2 already triggered `useGitStatus({ enabled: true })`calls during their own renders. By the time the assertion executed, the mock's history already contained satisfying calls regardless of what the round-3 test's own render computed. A regression that flipped`enabled`to`false`in WorkspaceView's computation would leave the assertion green, defeating the round-1 fix entirely. Pairs with the prior round's test 4 which DID use mid-test`mockClear()` correctly — the discipline was named but not applied at the start of every test.
+- **Fix:** Added `vi.mocked(useGitStatus).mockClear()` to the test suite's `beforeEach` block alongside the existing prop-bag resets. Every test now starts with a fresh history, and `toHaveBeenCalledWith` assertions can only pass via the current test's render path.
+- **Commit:** _(see git log for the round-4 fix commit)_
+
+### 22. Pass-through prop forwarding: each render-site branch needs its own coverage
+
+- **Source:** github-claude | PR #125 round 4 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/BottomDrawer.test.tsx`
+- **Finding:** BottomDrawer accepts `gitStatus?` and forwards it to TWO `<DiffPanelContent>` render sites (controlled-with-selectedDiffFile branch and unselected-fallback branch). Round-1 added a single test covering the unselected branch. The selected-file branch — reachable when a user has opened a specific diff file — was not covered by any test in `BottomDrawer.test.tsx`, so a regression that dropped `gitStatus={gitStatus}` from that branch (e.g. during a selectedDiffFile ternary refactor) would silently re-introduce the duplicate-watcher IPC. Codex verify caught this in v1 of round 4. Same finding-class as #7 (uncovered guard branch on doc-change-plus-selection): a multi-branch decision needs coverage for each branch the regression-class can hit, not just the one the author thought about.
+- **Fix:** Split the round-1 test into two siblings — one rendering BottomDrawer without `selectedDiffFile` (unselected branch), one with a synthetic `selectedDiffFile` (controlled branch). Both assert `useGitStatus` was called with `enabled: false`. A regression dropping `gitStatus={gitStatus}` from EITHER `<DiffPanelContent>` render site is now caught.
+- **Commit:** _(see git log for the round-4 fix commit, plus the v1→v2 codex-verify retry that closed the second-branch gap)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 11
+ref_count: 12
 ---
 
 # Testing Gaps
@@ -178,3 +178,12 @@ filesystem scope restrictions).
 - **Finding:** The subscription test mocked `useGitStatus` to return a constant `{ idle: true, ... }` shape regardless of the options object the parent passed. With `agentStatus.isActive = true` the production code computes `enabled: true` and starts a watcher; the mock returned the same idle-state object whether `enabled` was true or false. Worse: the test never called `expect(useGitStatusMock).toHaveBeenCalledWith(..., expect.objectContaining({ enabled: true }))`. A regression that passed `enabled: false` (e.g. an accidental flip of the activation OR-condition, or a misread of `agentStatus.isActive`) would still satisfy the existing reference-equality assertions on the captured props (panel + bottom drawer would each receive the same idle object). Watcher would never start in production; UI would show a permanent empty state. Same finding-class as #6 (regression-guard test that didn't actually verify the property it claimed to guard) — a reference-equality assertion is not a substitute for asserting the input that drives the mechanism.
 - **Fix:** Mock factory now reads `options.enabled` and returns `idle: !enabled`, mirroring the real hook's contract (idle iff disabled). Added a new test `WorkspaceView calls useGitStatus with enabled: true when an agent is active` that asserts `expect(useGitStatus).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ watch: true, enabled: true }))`. The pre-existing reference-equality test stays — they cover orthogonal contracts (one hook call vs. correct args).
 - **Commit:** _(see git log for the round-1 fix commit)_
+
+### 19. Lifted-state contract: child-test missing arg assertion + parent-test missing alternate-arm coverage
+
+- **Source:** github-claude | PR #125 round 2 | 2026-05-02
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/components/AgentStatusPanel.test.tsx`, `src/features/workspace/WorkspaceView.subscription.test.tsx`
+- **Finding:** Round-1 fixed the parent's `enabled: true` assertion (#18) but two related gaps remained: (a) `AgentStatusPanel.test.tsx`'s "uses shared git status when provided by the parent" test verified UI output but never asserted that the internal `useGitStatus` was called with `enabled: false` — the load-bearing watcher-deduplication invariant of the lifted-state refactor. The sibling `DiffPanelContent.test.tsx` already used `vi.spyOn(useGitStatusModule, 'useGitStatus')` correctly; AgentStatusPanel's mock was a plain factory with no spy reference. A regression that dropped `gitStatus === undefined &&` from the internal enabled condition would silently start two simultaneous watchers per cwd while every test stayed green. (b) The parent's round-1 `enabled: true` test only covered the `isActive` arm of the OR-condition (`agentStatus.isActive || bottomDrawerTab === 'diff'`); since `useAgentStatus` always returned `isActive: true`, the diff-tab arm was structurally impossible to exercise. Removing `|| bottomDrawerTab === 'diff'` would still satisfy the assertion. Both gaps follow the same theme as #18 (a lifted-state assertion that doesn't actually constrain the contract it's named after).
+- **Fix:** (a) Restructured `AgentStatusPanel.test.tsx` to import `* as useGitStatusModule` and call `vi.spyOn` on the test-by-test, asserting `expect(useGitStatusSpy).toHaveBeenCalledWith('/tmp/repo', expect.objectContaining({ enabled: false }))`. (b) Extended the BottomDrawer mock in `WorkspaceView.subscription.test.tsx` with a test-only "switch to diff" button bound to `onTabChange`, and added a sibling test using `vi.mocked(useAgentStatus).mockImplementation(() => idleAgentStatus)` so the agent stays idle across the tab-switch re-render. Codex verify v1 caught a `mockReturnValueOnce` bug here: the override only applied to the first render, letting the re-render fall back to the active default and passing the assertion via the wrong branch. v2 uses `mockImplementation` + `getMockImplementation` save-and-restore in a `finally` block.
+- **Commit:** _(see git log for the round-2 fix commit; v1→v2 codex-verify retry documented in `.harness-github-review/cycle-2-verify-result-v{1,2}.json`)_

--- a/src/features/agent-status/components/AgentStatusPanel.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.test.tsx
@@ -167,40 +167,46 @@ describe('AgentStatusPanel', () => {
     // module mock for the actual return shape.
     const useGitStatusSpy = vi.spyOn(useGitStatusModule, 'useGitStatus')
 
-    render(
-      <AgentStatusPanel
-        agentStatus={activeAgentStatus}
-        cwd="/tmp/repo"
-        onOpenDiff={vi.fn()}
-        gitStatus={{
-          files: [
-            {
-              path: 'shared.ts',
-              status: 'modified',
-              insertions: 20,
-              deletions: 4,
-              staged: false,
-            },
-          ],
-          filesCwd: '/tmp/repo',
-          loading: false,
-          error: null,
-          refresh: vi.fn(),
-          idle: false,
-        }}
-      />
-    )
+    try {
+      render(
+        <AgentStatusPanel
+          agentStatus={activeAgentStatus}
+          cwd="/tmp/repo"
+          onOpenDiff={vi.fn()}
+          gitStatus={{
+            files: [
+              {
+                path: 'shared.ts',
+                status: 'modified',
+                insertions: 20,
+                deletions: 4,
+                staged: false,
+              },
+            ],
+            filesCwd: '/tmp/repo',
+            loading: false,
+            error: null,
+            refresh: vi.fn(),
+            idle: false,
+          }}
+        />
+      )
 
-    expect(screen.getAllByText('+20 / -4')).toHaveLength(2)
-    // Watcher-deduplication invariant: when parent injects gitStatus,
-    // the internal hook must run with enabled: false so no duplicate
-    // start_git_watcher IPC fires.
-    expect(useGitStatusSpy).toHaveBeenCalledWith(
-      '/tmp/repo',
-      expect.objectContaining({ enabled: false })
-    )
-
-    useGitStatusSpy.mockRestore()
+      expect(screen.getAllByText('+20 / -4')).toHaveLength(2)
+      // Watcher-deduplication invariant: when parent injects gitStatus,
+      // the internal hook must run with enabled: false so no duplicate
+      // start_git_watcher IPC fires.
+      expect(useGitStatusSpy).toHaveBeenCalledWith(
+        '/tmp/repo',
+        expect.objectContaining({ enabled: false })
+      )
+    } finally {
+      // Guarantee spy cleanup even if render() or any expect() above
+      // throws — without this guard, an inline spy leaks past the
+      // failing test and inflates call counts on every subsequent
+      // test that consumes the same module export.
+      useGitStatusSpy.mockRestore()
+    }
   })
 
   test('renders ToolCallSummary and ActivityFeed inside the scrollable region', () => {

--- a/src/features/agent-status/components/AgentStatusPanel.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, test, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { AgentStatusPanel } from './AgentStatusPanel'
 import type { AgentStatus } from '../types'
+import * as useGitStatusModule from '../../diff/hooks/useGitStatus'
 
 const inactiveAgentStatus: AgentStatus = {
   isActive: false,
@@ -156,6 +157,16 @@ describe('AgentStatusPanel', () => {
   })
 
   test('uses shared git status when provided by the parent', () => {
+    // Spy on the internal hook so we can assert it was called with
+    // `enabled: false` — the load-bearing invariant of the lifted-state
+    // refactor (parent-provided gitStatus must disable the child's
+    // own watcher to prevent duplicate `start_git_watcher` IPCs).
+    // The module-level `vi.mock` factory above can't satisfy this
+    // assertion because it is not a `vi.fn()` — vi.spyOn here gives
+    // us a proper call-args record while still falling through to the
+    // module mock for the actual return shape.
+    const useGitStatusSpy = vi.spyOn(useGitStatusModule, 'useGitStatus')
+
     render(
       <AgentStatusPanel
         agentStatus={activeAgentStatus}
@@ -181,6 +192,15 @@ describe('AgentStatusPanel', () => {
     )
 
     expect(screen.getAllByText('+20 / -4')).toHaveLength(2)
+    // Watcher-deduplication invariant: when parent injects gitStatus,
+    // the internal hook must run with enabled: false so no duplicate
+    // start_git_watcher IPC fires.
+    expect(useGitStatusSpy).toHaveBeenCalledWith(
+      '/tmp/repo',
+      expect.objectContaining({ enabled: false })
+    )
+
+    useGitStatusSpy.mockRestore()
   })
 
   test('renders ToolCallSummary and ActivityFeed inside the scrollable region', () => {

--- a/src/features/agent-status/components/AgentStatusPanel.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.test.tsx
@@ -155,6 +155,34 @@ describe('AgentStatusPanel', () => {
     expect(screen.getByText('+12 / -3')).toBeInTheDocument()
   })
 
+  test('uses shared git status when provided by the parent', () => {
+    render(
+      <AgentStatusPanel
+        agentStatus={activeAgentStatus}
+        cwd="/tmp/repo"
+        onOpenDiff={vi.fn()}
+        gitStatus={{
+          files: [
+            {
+              path: 'shared.ts',
+              status: 'modified',
+              insertions: 20,
+              deletions: 4,
+              staged: false,
+            },
+          ],
+          filesCwd: '/tmp/repo',
+          loading: false,
+          error: null,
+          refresh: vi.fn(),
+          idle: false,
+        }}
+      />
+    )
+
+    expect(screen.getAllByText('+20 / -4')).toHaveLength(2)
+  })
+
   test('renders ToolCallSummary and ActivityFeed inside the scrollable region', () => {
     render(
       <AgentStatusPanel

--- a/src/features/agent-status/components/AgentStatusPanel.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.tsx
@@ -8,7 +8,10 @@ import { TestResults } from './TestResults'
 import { ActivityFooter } from './ActivityFooter'
 import { ActivityFeed } from './ActivityFeed'
 import { useActivityEvents } from '../hooks/useActivityEvents'
-import { useGitStatus } from '../../diff/hooks/useGitStatus'
+import {
+  useGitStatus,
+  type UseGitStatusReturn,
+} from '../../diff/hooks/useGitStatus'
 import { sumLines } from '../../diff/utils/sumLines'
 import type { ChangedFile } from '../../diff/types'
 
@@ -17,6 +20,7 @@ interface AgentStatusPanelProps {
   cwd: string
   onOpenDiff: (file: ChangedFile) => void
   onOpenFile?: (path: string) => void
+  gitStatus?: UseGitStatusReturn
 }
 
 export const AgentStatusPanel = ({
@@ -24,14 +28,18 @@ export const AgentStatusPanel = ({
   cwd,
   onOpenDiff,
   onOpenFile = undefined,
+  gitStatus = undefined,
 }: AgentStatusPanelProps): ReactElement => {
   const status = agentStatus
   const events = useActivityEvents(status)
 
-  const { files, filesCwd, loading, error, refresh, idle } = useGitStatus(cwd, {
+  const internalGitStatus = useGitStatus(cwd, {
     watch: true,
-    enabled: status.isActive,
+    enabled: gitStatus === undefined && status.isActive,
   })
+
+  const { files, filesCwd, loading, error, refresh, idle } =
+    gitStatus ?? internalGitStatus
 
   const filesAreFresh = filesCwd === cwd
 

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -166,6 +166,7 @@ describe('DiffPanelContent', () => {
 
     expect(useGitStatusSpy).toHaveBeenCalledWith('/home/user/project', {
       watch: true,
+      enabled: true,
     })
 
     expect(useFileDiffSpy).toHaveBeenCalledWith(
@@ -174,6 +175,60 @@ describe('DiffPanelContent', () => {
       '/home/user/project',
       undefined
     )
+  })
+
+  test('uses external git status without starting an internal watcher', (): void => {
+    const mockFiles: ChangedFile[] = [
+      {
+        path: 'src/App.tsx',
+        status: 'modified',
+        insertions: 5,
+        deletions: 2,
+        staged: false,
+      },
+    ]
+
+    const useGitStatusSpy = vi
+      .spyOn(useGitStatusModule, 'useGitStatus')
+      .mockReturnValue({
+        files: [],
+        filesCwd: null,
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: true,
+      })
+
+    vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
+      diff: {
+        filePath: 'src/App.tsx',
+        oldPath: 'src/App.tsx',
+        newPath: 'src/App.tsx',
+        hunks: [],
+      },
+      loading: false,
+      error: null,
+    })
+
+    render(
+      <DiffPanelContent
+        cwd="/repo"
+        gitStatus={{
+          files: mockFiles,
+          filesCwd: '/repo',
+          loading: false,
+          error: null,
+          refresh: vi.fn(),
+          idle: false,
+        }}
+      />
+    )
+
+    expect(useGitStatusSpy).toHaveBeenCalledWith('/repo', {
+      watch: true,
+      enabled: false,
+    })
+    expect(screen.getByTestId('diff-populated-state')).toBeInTheDocument()
   })
 
   describe('Controlled mode', () => {

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -5,7 +5,7 @@ import {
   useCallback,
   useMemo,
 } from 'react'
-import { useGitStatus } from '../hooks/useGitStatus'
+import { useGitStatus, type UseGitStatusReturn } from '../hooks/useGitStatus'
 import { useFileDiff } from '../hooks/useFileDiff'
 import { ChangedFilesList } from './ChangedFilesList'
 import { DiffViewer } from './DiffViewer'
@@ -30,6 +30,8 @@ type DiffPanelSelectionControl =
 interface DiffPanelContentBaseProps {
   /** Working directory for git commands */
   cwd?: string
+  /** Optional shared git status from a parent-level watcher subscription */
+  gitStatus?: UseGitStatusReturn
 }
 
 export type DiffPanelContentProps = DiffPanelContentBaseProps &
@@ -43,16 +45,22 @@ export type DiffPanelContentProps = DiffPanelContentBaseProps &
  */
 export const DiffPanelContent = ({
   cwd = '.',
+  gitStatus = undefined,
   selectedFile: controlledSelectedFile,
   onSelectedFileChange,
 }: DiffPanelContentProps): ReactElement => {
+  const internalGitStatus = useGitStatus(cwd, {
+    watch: true,
+    enabled: gitStatus === undefined,
+  })
+
   const {
     files,
     filesCwd,
     loading: statusLoading,
     error: statusError,
     idle,
-  } = useGitStatus(cwd, { watch: true })
+  } = gitStatus ?? internalGitStatus
 
   const [uncontrolledSelectedFile, setUncontrolledSelectedFile] =
     useState<SelectedDiffFile | null>(null)

--- a/src/features/diff/hooks/useGitStatus.ts
+++ b/src/features/diff/hooks/useGitStatus.ts
@@ -16,7 +16,7 @@ interface UseGitStatusOptions {
   enabled?: boolean
 }
 
-interface UseGitStatusReturn {
+export interface UseGitStatusReturn {
   files: ChangedFile[]
   /** The cwd of the last successful fetch — never updates on failure or fetch-start */
   filesCwd: string | null

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -3,6 +3,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { WorkspaceView } from './WorkspaceView'
 import type { AgentStatus } from '../agent-status/types'
+import { useGitStatus } from '../diff/hooks/useGitStatus'
 
 // Mock TerminalPane / TerminalZone deps to avoid xterm.js in jsdom
 vi.mock('../terminal/components/TerminalPane', () => ({
@@ -98,14 +99,23 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 }))
 
 vi.mock('../diff/hooks/useGitStatus', () => ({
-  useGitStatus: vi.fn(() => ({
-    files: [],
-    filesCwd: null,
-    loading: false,
-    error: null,
-    refresh: vi.fn(),
-    idle: true,
-  })),
+  // Respect the `enabled` arg so the mock matches real hook semantics
+  // (idle iff disabled). A test that asserts on `enabled: true` later
+  // gets a non-idle return shape, mirroring what the real hook would
+  // return when the parent injects an active subscription.
+  useGitStatus: vi.fn(
+    (
+      _cwd: string | null | undefined,
+      options?: { enabled?: boolean; watch?: boolean }
+    ) => ({
+      files: [],
+      filesCwd: null,
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      idle: options?.enabled === false,
+    })
+  ),
 }))
 
 const capturedSidebarProps: { agentStatus?: AgentStatus } = {}
@@ -193,6 +203,25 @@ describe('WorkspaceView lifted-subscription contract', () => {
     expect(capturedBottomDrawerProps.gitStatus).toBeDefined()
     expect(capturedPanelProps.gitStatus).toBe(
       capturedBottomDrawerProps.gitStatus
+    )
+  })
+
+  test('WorkspaceView calls useGitStatus with enabled: true when an agent is active', async () => {
+    // Locks the activation contract: with `agentStatus.isActive = true`,
+    // WorkspaceView must compute `enabled: true` and pass it into the
+    // shared `useGitStatus` call. Without this assertion, a regression
+    // that flipped `enabled` to `false` (e.g. a misread of `isActive`,
+    // or a typo in the OR-condition with `bottomDrawerTab === 'diff'`)
+    // would silently turn the watcher off — child components would still
+    // render via their `gitStatus !== undefined` fallback path, masking
+    // the regression in the existing reference-equality assertion.
+    render(<WorkspaceView />)
+
+    await screen.findByTestId('agent-status-panel-mock')
+
+    expect(useGitStatus).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ watch: true, enabled: true })
     )
   })
 })

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -1,9 +1,10 @@
 import type { ReactElement } from 'react'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { WorkspaceView } from './WorkspaceView'
 import type { AgentStatus } from '../agent-status/types'
 import { useGitStatus } from '../diff/hooks/useGitStatus'
+import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 
 // Mock TerminalPane / TerminalZone deps to avoid xterm.js in jsdom
 vi.mock('../terminal/components/TerminalPane', () => ({
@@ -135,6 +136,8 @@ interface MockPanelProps {
 
 interface MockBottomDrawerProps {
   gitStatus?: unknown
+  activeTab?: 'editor' | 'diff'
+  onTabChange?: (tab: 'editor' | 'diff') => void
 }
 
 vi.mock('./components/Sidebar', () => ({
@@ -158,10 +161,26 @@ vi.mock('../agent-status/components/AgentStatusPanel', () => ({
 }))
 
 vi.mock('./components/BottomDrawer', () => ({
-  default: ({ gitStatus = undefined }: MockBottomDrawerProps): ReactElement => {
+  default: ({
+    gitStatus = undefined,
+    onTabChange,
+  }: MockBottomDrawerProps): ReactElement => {
     capturedBottomDrawerProps.gitStatus = gitStatus
 
-    return <div data-testid="bottom-drawer-mock" />
+    return (
+      <div data-testid="bottom-drawer-mock">
+        {/* Test-only hook to flip the parent's bottomDrawerTab state.
+            Exposed so the diff-tab branch of WorkspaceView's `enabled`
+            OR-condition can be exercised without rendering the real
+            BottomDrawer's tab UI. */}
+        <button
+          data-testid="mock-switch-to-diff"
+          onClick={() => onTabChange?.('diff')}
+        >
+          switch to diff
+        </button>
+      </div>
+    )
   },
 }))
 
@@ -207,14 +226,14 @@ describe('WorkspaceView lifted-subscription contract', () => {
   })
 
   test('WorkspaceView calls useGitStatus with enabled: true when an agent is active', async () => {
-    // Locks the activation contract: with `agentStatus.isActive = true`,
-    // WorkspaceView must compute `enabled: true` and pass it into the
-    // shared `useGitStatus` call. Without this assertion, a regression
-    // that flipped `enabled` to `false` (e.g. a misread of `isActive`,
-    // or a typo in the OR-condition with `bottomDrawerTab === 'diff'`)
-    // would silently turn the watcher off — child components would still
-    // render via their `gitStatus !== undefined` fallback path, masking
-    // the regression in the existing reference-equality assertion.
+    // Locks the isActive arm of the OR-condition. With
+    // `agentStatus.isActive = true`, WorkspaceView must compute
+    // `enabled: true` and pass it into the shared `useGitStatus` call.
+    // Without this assertion, a regression that flipped `enabled` to
+    // `false` (e.g. a misread of `isActive`) would silently turn the
+    // watcher off — child components would still render via their
+    // `gitStatus !== undefined` fallback path, masking the regression
+    // in the existing reference-equality assertion.
     render(<WorkspaceView />)
 
     await screen.findByTestId('agent-status-panel-mock')
@@ -223,5 +242,79 @@ describe('WorkspaceView lifted-subscription contract', () => {
       expect.anything(),
       expect.objectContaining({ watch: true, enabled: true })
     )
+  })
+
+  test('WorkspaceView passes enabled: true when the diff tab is active even if the agent is idle', async () => {
+    // Locks the diff-tab arm of the OR-condition. With
+    // `agentStatus.isActive = false` AND `bottomDrawerTab = 'diff'`,
+    // `enabled` must still be `true` — otherwise opening the diff tab
+    // on an idle workspace silently runs without a watcher and the
+    // diff panel falls through to its own internal fallback (no visible
+    // breakage, but the lifted-state optimization degrades to pre-PR
+    // behavior). The previous test (always-active agent) couldn't
+    // exercise this path because `true || X` is permanently true.
+    //
+    // CRITICAL: mockReturnValue (persistent), not mockReturnValueOnce.
+    // The tab-switch triggers a WorkspaceView re-render that calls
+    // useAgentStatus again; if the override only covered the first
+    // call, the second render would fall back to the default active-
+    // agent factory and the final assertion would pass through the
+    // isActive arm — leaving the diff-tab arm unverified (the bug
+    // codex caught in round-2 v1).
+    const idleAgentStatus: AgentStatus = {
+      isActive: false,
+      agentType: null,
+      modelId: null,
+      modelDisplayName: null,
+      version: null,
+      sessionId: null,
+      agentSessionId: null,
+      contextWindow: null,
+      cost: null,
+      rateLimits: null,
+      numTurns: 0,
+      toolCalls: { total: 0, byType: {}, active: null },
+      recentToolCalls: [],
+      testRun: null,
+    }
+    const useAgentStatusMock = vi.mocked(useAgentStatus)
+    // Capture the factory's active-agent implementation so we can restore
+    // it after the test — without this, subsequent tests would see the
+    // idle override leaking through.
+    const originalImpl = useAgentStatusMock.getMockImplementation()
+    useAgentStatusMock.mockImplementation(() => idleAgentStatus)
+
+    try {
+      render(<WorkspaceView />)
+      await screen.findByTestId('bottom-drawer-mock')
+
+      // First render: agent idle + tab='editor' → enabled: false
+      expect(useGitStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ watch: true, enabled: false })
+      )
+
+      // Flip the tab to diff via the BottomDrawer mock's exposed button.
+      // After re-render, useGitStatus must be called with enabled: true
+      // — and because the agent is STILL idle (mockImplementation is
+      // persistent across re-renders), that `true` can only come from
+      // the `bottomDrawerTab === 'diff'` arm, which is what this test is
+      // meant to exercise. (Round-2 verify caught a subtle bug here:
+      // mockReturnValueOnce only covered the first call, so the
+      // re-render fell back to the active default and the assertion
+      // passed via the wrong branch — this version uses mockImplementation
+      // to keep the agent idle across all renders within the test.)
+      vi.mocked(useGitStatus).mockClear()
+      fireEvent.click(screen.getByTestId('mock-switch-to-diff'))
+
+      expect(useGitStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ watch: true, enabled: true })
+      )
+    } finally {
+      if (originalImpl) {
+        useAgentStatusMock.mockImplementation(originalImpl)
+      }
+    }
   })
 })

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -97,8 +97,22 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   ),
 }))
 
+vi.mock('../diff/hooks/useGitStatus', () => ({
+  useGitStatus: vi.fn(() => ({
+    files: [],
+    filesCwd: null,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    idle: true,
+  })),
+}))
+
 const capturedSidebarProps: { agentStatus?: AgentStatus } = {}
-const capturedPanelProps: { agentStatus?: AgentStatus } = {}
+
+const capturedPanelProps: { agentStatus?: AgentStatus; gitStatus?: unknown } =
+  {}
+const capturedBottomDrawerProps: { gitStatus?: unknown } = {}
 
 interface MockSidebarProps {
   agentStatus?: AgentStatus
@@ -106,6 +120,11 @@ interface MockSidebarProps {
 
 interface MockPanelProps {
   agentStatus?: AgentStatus
+  gitStatus?: unknown
+}
+
+interface MockBottomDrawerProps {
+  gitStatus?: unknown
 }
 
 vi.mock('./components/Sidebar', () => ({
@@ -119,10 +138,20 @@ vi.mock('./components/Sidebar', () => ({
 vi.mock('../agent-status/components/AgentStatusPanel', () => ({
   AgentStatusPanel: ({
     agentStatus = undefined,
+    gitStatus = undefined,
   }: MockPanelProps): ReactElement => {
     capturedPanelProps.agentStatus = agentStatus
+    capturedPanelProps.gitStatus = gitStatus
 
     return <div data-testid="agent-status-panel-mock" />
+  },
+}))
+
+vi.mock('./components/BottomDrawer', () => ({
+  default: ({ gitStatus = undefined }: MockBottomDrawerProps): ReactElement => {
+    capturedBottomDrawerProps.gitStatus = gitStatus
+
+    return <div data-testid="bottom-drawer-mock" />
   },
 }))
 
@@ -130,6 +159,8 @@ describe('WorkspaceView lifted-subscription contract', () => {
   beforeEach(() => {
     capturedSidebarProps.agentStatus = undefined
     capturedPanelProps.agentStatus = undefined
+    capturedPanelProps.gitStatus = undefined
+    capturedBottomDrawerProps.gitStatus = undefined
   })
 
   test('Sidebar and AgentStatusPanel receive agentStatus from a single hook call', async () => {
@@ -149,6 +180,19 @@ describe('WorkspaceView lifted-subscription contract', () => {
     // yields the same object reference and `toBe` passes.
     expect(capturedSidebarProps.agentStatus).toBe(
       capturedPanelProps.agentStatus
+    )
+  })
+
+  test('AgentStatusPanel and BottomDrawer receive one shared git status object', async () => {
+    render(<WorkspaceView />)
+
+    await screen.findByTestId('agent-status-panel-mock')
+    await screen.findByTestId('bottom-drawer-mock')
+
+    expect(capturedPanelProps.gitStatus).toBeDefined()
+    expect(capturedBottomDrawerProps.gitStatus).toBeDefined()
+    expect(capturedPanelProps.gitStatus).toBe(
+      capturedBottomDrawerProps.gitStatus
     )
   })
 })

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -190,6 +190,13 @@ describe('WorkspaceView lifted-subscription contract', () => {
     capturedPanelProps.agentStatus = undefined
     capturedPanelProps.gitStatus = undefined
     capturedBottomDrawerProps.gitStatus = undefined
+    // Clear the mock between tests so `toHaveBeenCalledWith` assertions
+    // see only the calls from THIS test's render. Without this,
+    // accumulated history from earlier tests can satisfy the assertion
+    // vacuously — e.g. tests 1+2 already trigger `enabled: true` calls,
+    // making test 3's assertion pass even if test 3's own render
+    // computed `enabled: false`.
+    vi.mocked(useGitStatus).mockClear()
   })
 
   test('Sidebar and AgentStatusPanel receive agentStatus from a single hook call', async () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -13,6 +13,7 @@ import { createFileSystemService } from '../files/services/fileSystemService'
 import { createTerminalService } from '../terminal/services/terminalService'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
 import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
+import { useGitStatus } from '../diff/hooks/useGitStatus'
 import type { ChangedFile, SelectedDiffFile } from '../diff/types'
 
 const SIDEBAR_MIN = 240
@@ -60,6 +61,7 @@ export const WorkspaceView = (): ReactElement => {
   const activeSession = activeSessionId
     ? sessions.find((s) => s.id === activeSessionId)
     : undefined
+  const activeCwd = activeSession?.workingDirectory ?? '.'
 
   // File selection state.
   //
@@ -108,6 +110,11 @@ export const WorkspaceView = (): ReactElement => {
     useState<SelectedDiffFile | null>(null)
 
   const [isBottomDrawerCollapsed, setIsBottomDrawerCollapsed] = useState(false)
+
+  const gitStatus = useGitStatus(activeCwd, {
+    watch: true,
+    enabled: agentStatus.isActive || bottomDrawerTab === 'diff',
+  })
 
   // Open a file directly (no unsaved-changes guard). Errors were previously
   // swallowed via `void editorBuffer.openFile(...)`, leaving the user with
@@ -289,19 +296,21 @@ export const WorkspaceView = (): ReactElement => {
   // Handle opening a diff file from AgentStatusPanel
   const handleOpenDiff = useCallback(
     (file: ChangedFile): void => {
-      const cwd = activeSession?.workingDirectory ?? '.'
-
       setBottomDrawerTab('diff')
-      setSelectedDiffFile({ path: file.path, staged: file.staged, cwd })
+      setSelectedDiffFile({
+        path: file.path,
+        staged: file.staged,
+        cwd: activeCwd,
+      })
       setIsBottomDrawerCollapsed(false)
     },
-    [activeSession?.workingDirectory]
+    [activeCwd]
   )
 
   // Belt-and-suspenders: clear selection on cwd change
   useEffect(() => {
     setSelectedDiffFile(null)
-  }, [activeSession?.workingDirectory])
+  }, [activeCwd])
 
   return (
     <div
@@ -376,7 +385,8 @@ export const WorkspaceView = (): ReactElement => {
           }}
           isDirty={editorBuffer.isDirty}
           isLoading={editorBuffer.isLoading}
-          cwd={activeSession?.workingDirectory ?? '.'}
+          cwd={activeCwd}
+          gitStatus={gitStatus}
           activeTab={bottomDrawerTab}
           onTabChange={setBottomDrawerTab}
           isCollapsed={isBottomDrawerCollapsed}
@@ -411,7 +421,8 @@ export const WorkspaceView = (): ReactElement => {
       {/* Agent Status Panel — self-manages width (0↔280px) */}
       <AgentStatusPanel
         agentStatus={agentStatus}
-        cwd={activeSession?.workingDirectory ?? '.'}
+        cwd={activeCwd}
+        gitStatus={gitStatus}
         onOpenDiff={handleOpenDiff}
         onOpenFile={handleOpenTestFile}
       />

--- a/src/features/workspace/components/BottomDrawer.test.tsx
+++ b/src/features/workspace/components/BottomDrawer.test.tsx
@@ -266,6 +266,83 @@ describe('BottomDrawer', () => {
       expect(screen.getByTestId('diff-panel')).toBeInTheDocument()
     })
 
+    test('forwards parent-provided gitStatus to DiffPanelContent on the unselected-file render branch', () => {
+      // Pass-through-only behavior: BottomDrawer must hand the
+      // `gitStatus` prop to its `<DiffPanelContent>` render so
+      // DiffPanelContent's internal `useGitStatus` is called with
+      // `enabled: false` (the watcher-deduplication invariant of the
+      // lifted-state refactor). Endpoint-only coverage in
+      // `DiffPanelContent.test.tsx` would not catch a regression that
+      // dropped `gitStatus={gitStatus}` from this render site.
+      // (See companion test below for the selected-file branch.)
+      vi.mocked(useGitStatusModule.useGitStatus).mockClear()
+
+      const sharedGitStatus = {
+        files: [],
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      }
+
+      render(
+        <BottomDrawer
+          selectedFilePath={null}
+          content=""
+          activeTab="diff"
+          onTabChange={vi.fn()}
+          gitStatus={sharedGitStatus}
+        />
+      )
+
+      // The internal useGitStatus inside DiffPanelContent must be
+      // disabled because the parent already supplies the subscription.
+      expect(vi.mocked(useGitStatusModule.useGitStatus)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ enabled: false })
+      )
+    })
+
+    test('forwards parent-provided gitStatus to DiffPanelContent on the selected-file render branch', () => {
+      // BottomDrawer.tsx has TWO <DiffPanelContent> render sites
+      // (controlled-with-selectedDiffFile and unselected fallback).
+      // The previous test covers the unselected branch; this one
+      // exercises the controlled branch so a regression dropping
+      // `gitStatus={gitStatus}` from EITHER site is caught.
+      vi.mocked(useGitStatusModule.useGitStatus).mockClear()
+
+      const sharedGitStatus = {
+        files: [],
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      }
+
+      render(
+        <BottomDrawer
+          selectedFilePath={null}
+          content=""
+          activeTab="diff"
+          onTabChange={vi.fn()}
+          selectedDiffFile={{
+            path: 'src/test.ts',
+            staged: false,
+            cwd: '/repo',
+          }}
+          onSelectedDiffFileChange={vi.fn()}
+          gitStatus={sharedGitStatus}
+        />
+      )
+
+      expect(vi.mocked(useGitStatusModule.useGitStatus)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ enabled: false })
+      )
+    })
+
     test('uncontrolled fallback: activeTab works without controlled props', async () => {
       const user = userEvent.setup()
 

--- a/src/features/workspace/components/BottomDrawer.tsx
+++ b/src/features/workspace/components/BottomDrawer.tsx
@@ -3,6 +3,7 @@ import { CodeEditor } from '../../editor/components/CodeEditor'
 import { DiffPanelContent } from '../../diff/components/DiffPanelContent'
 import { useResizable } from '../hooks/useResizable'
 import type { SelectedDiffFile } from '../../diff/types'
+import type { UseGitStatusReturn } from '../../diff/hooks/useGitStatus'
 
 type TabType = 'editor' | 'diff'
 
@@ -46,6 +47,8 @@ interface BottomDrawerBaseProps {
   isLoading?: boolean
   /** Working directory for git commands (diff viewer) */
   cwd?: string
+  /** Optional shared git status from WorkspaceView */
+  gitStatus?: UseGitStatusReturn
 }
 
 type BottomDrawerProps = BottomDrawerBaseProps &
@@ -70,6 +73,7 @@ const BottomDrawer = ({
   isDirty = false,
   isLoading = false,
   cwd = '.',
+  gitStatus = undefined,
   activeTab: controlledActiveTab,
   onTabChange,
   isCollapsed: controlledIsCollapsed,
@@ -307,11 +311,12 @@ const BottomDrawer = ({
             {selectedDiffFile !== undefined ? (
               <DiffPanelContent
                 cwd={cwd}
+                gitStatus={gitStatus}
                 selectedFile={selectedDiffFile}
                 onSelectedFileChange={onSelectedDiffFileChange}
               />
             ) : (
-              <DiffPanelContent cwd={cwd} />
+              <DiffPanelContent cwd={cwd} gitStatus={gitStatus} />
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Lifts the watched git status subscription into `WorkspaceView` so the agent sidebar and bottom diff drawer share one `useGitStatus(..., { watch: true })` result.
- Threads optional shared git status through `AgentStatusPanel`, `BottomDrawer`, and `DiffPanelContent` while keeping standalone fallback behavior.
- Disables child-level watcher hooks when shared git status is provided, preventing duplicate `start_git_watcher` subscriptions and duplicate `git_status` refreshes.

## Root Cause
`AgentStatusPanel` and `DiffPanelContent` each started their own watched git status hook for the same cwd. When both were visible, a single filesystem event could fan out into two independent `git_status` IPC calls and duplicate backend subprocess work.

## Validation
- `npx vitest run src/features/diff/components/DiffPanelContent.test.tsx src/features/agent-status/components/AgentStatusPanel.test.tsx src/features/workspace/WorkspaceView.subscription.test.tsx src/features/workspace/components/BottomDrawer.test.tsx`
- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `CI=true npm test`
- `git diff --check`
- commit hook: lint-staged eslint/tsc/prettier
- pre-push hook: `npm test`

Fixes #91.
