### PR TITLE
fix(git): restore failed pre-repo upgrades

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,9 +43,9 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 23       | 15   | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 24       | 16   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 38       | 13   | 2026-05-02   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 39       | 14   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 20       | 7    | 2026-05-02   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 5        | 1    | 2026-04-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 23       | 15   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 37       | 12   | 2026-05-02   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 38       | 13   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 20       | 7    | 2026-05-02   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 5        | 1    | 2026-04-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 23       | 15   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 36       | 11   | 2026-05-02   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 37       | 12   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 20       | 7    | 2026-05-02   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 5        | 1    | 2026-04-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,11 +43,11 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 22       | 14   | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 23       | 15   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 36       | 11   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |
-| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 19       | 6    | 2026-05-02   |
+| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 20       | 7    | 2026-05-02   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 5        | 1    | 2026-04-20   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)             | security       | 15       | 2    | 2026-04-20   |
 | [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                   | security       | 3        | 1    | 2026-04-20   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -3,7 +3,7 @@ id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-04-29
-ref_count: 4
+ref_count: 5
 ---
 
 # Async Race Conditions
@@ -191,4 +191,13 @@ prevent showing previous data.
 - **File:** `src-tauri/src/git/watcher.rs`
 - **Finding:** `spawn_trailing_debounce_thread`'s inner `Ok(()) => continue` arm (which drains a rapid filesystem-event burst before resetting the quiet timer) never inspected `stop_flag`. After `RepoWatcher` was dropped, the thread's only escapes from the inner loop were a 60ms quiet period (correctly skipping the emit) or `Disconnected`. `Disconnected` only fires when EVERY `Sender` clone drops — but the clone living inside the `RecommendedWatcher` notify-callback closure is held behind `Arc<Mutex<RecommendedWatcher>>`, shared with the polling thread. That Arc lives until the polling thread sees its own `stop_flag` check (up to `POLL_INTERVAL_SECS = 10s` later). Net effect: a continuous filesystem burst at watcher teardown could pin the debounce thread (and its captured `app_handle` / `state` / `toplevel` Arcs) for up to 10 seconds. No incorrect emits — `stop_flag` already guarded the emit path — but resource cleanup was substantially delayed and the thread's lingering Arcs blocked observable shutdown ordering.
 - **Fix:** Added `if stop_flag.load(Ordering::Relaxed) { return; }` to the `Ok(()) => continue` branch (renamed to a block to host the check). One-line semantic addition; the inner loop now exits within one `recv_timeout(delay)` of the flag flipping, regardless of the polling-thread cleanup cadence. Same finding-class as #16 (subprocess stdout read with no deadline hangs forever) — both are "shutdown signal that doesn't propagate through every loop branch".
+- **Commit:** _(see git log for the round-1 fix commit)_
+
+### 20. Restore-after-failure path spawns a poll thread that immediately re-fires the same failure, looping forever
+
+- **Source:** github-claude | PR #126 round 1 | 2026-05-02
+- **Severity:** MEDIUM
+- **File:** `src-tauri/src/git/watcher.rs`
+- **Finding:** `restore_pre_repo_subscribers` is called after `upgrade_to_repo_watcher` succeeds for at least one subscriber on `safe_cwd` — meaning `safe_cwd` is, by construction, already a git repository at the moment of the restore. The original implementation unconditionally spawned a `spawn_pre_repo_poll_thread` whose loop body wakes every `POLL_INTERVAL_SECS` (10 s), checks `resolve_toplevel(&safe_cwd).is_ok()`, and re-runs `upgrade_to_repo_watcher` if so. Result: the poll thread always sees the parent path as a repo, always re-fires the upgrade, always fails for the same permanently-invalid subscriber paths, calls `restore_pre_repo_subscribers` again, and spawns the next thread. At steady state: one thread create/destroy + one `git rev-parse` subprocess + one `log::error!` per 10 s, indefinitely, per stranded subscriber. No state corruption, but unbounded log churn and CPU waste in long-running sessions. Same finding-class as #16 (subprocess stdout read with no deadline hangs forever) — a loop whose termination condition cannot be reached because the precondition is mis-modeled.
+- **Fix:** Before calling `spawn_pre_repo_poll_thread` in the restore path, check `resolve_toplevel(&safe_cwd).is_ok()`. If yes, the parent is already a repo and the failed subscribers cannot become valid via the "directory becomes a repo" pathway — log a one-shot `log::warn!` documenting the terminal-stranded state and skip the spawn. The pre-repo entry remains so refcount accounting stays consistent; only the futile poll thread is suppressed. Lesson: any retry loop needs a termination condition that genuinely could fail at retry time, not one whose precondition was already true at spawn time.
 - **Commit:** _(see git log for the round-1 fix commit)_

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -3,7 +3,7 @@ id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
 last_updated: 2026-04-30
-ref_count: 12
+ref_count: 13
 ---
 
 # Documentation Accuracy
@@ -348,3 +348,12 @@ Stale documentation misleads future contributors and review agents.
 - **Finding:** `upgrade_to_repo_watcher`'s error accumulator `errors: Vec<String>` was the natural sink for two distinct failure classes: (a) per-subscriber upgrade failures inside the for-loop (subscribers that need restoring), and (b) the restore-path's own failure (a lock-poisoning state-level event that affects no specific subscriber). The combined Err message read `"{} subscriber(s) failed to upgrade"` with `errors.len()` — but that count includes both classes. If a state-level restore failure occurred, the count over-reports subscriber failures by one, misleading any tooling or human that parses the count as authoritative. The full text was always present in the trailing `errors.join("; ")`, so information wasn't lost — only the headline lied. Same finding-class as #6 (`DRAWER_MAX` comment claimed dynamic ratio for a constant): the surface around the value implies a guarantee the value doesn't actually provide.
 - **Fix:** Added a dedicated `subscriber_failures: usize` counter, incremented only at the loop's `start_git_watcher_inner` failure site (the same site that pushes to `failed_subscribers`). Format string updated to `"{} subscriber(s) failed to upgrade ({} total error(s)): {}"` — headline reflects subscriber-level reality, parenthetical preserves the total-error context, full body keeps the unredacted error text. Restore-path errors continue to flow through the same `errors` vec but no longer inflate the headline.
 - **Commit:** _(see git log for the round-2 fix commit)_
+
+### 38. Restore-path entry leaks across pre-repo→repo transition because cleanup contract was unilateral
+
+- **Source:** github-claude | PR #126 round 3 | 2026-05-02
+- **Severity:** LOW (in production code) / HIGH transient (codex verify caught a refcount-loss bug in v1 of the fix)
+- **File:** `src-tauri/src/git/watcher.rs` `start_git_watcher_inner` opportunistic cleanup
+- **Finding:** PR #126's restore path inserted a new `pre_repo_watchers[safe_cwd].subscribers[missing_cwd]` row for terminally-stranded subscribers, but `start_git_watcher_inner`'s opportunistic cleanup block was unchanged from the pre-PR contract: it only removes `cwd_to_safe_pre_repo[cwd]`, not the matching `pre_repo_watchers[safe_cwd].subscribers[cwd]`. When a stranded subscriber's path eventually becomes a real repo and re-subscription routes through `start_git_watcher_inner` → repo path, the pre-repo entry is orphaned. Subsequent stop calls follow `cwd_to_toplevel` and never revisit `pre_repo_watchers`, so the bucket can't be GC'd. Same finding-class as #28 / #34 (paired surfaces drift when one is edited without the other) — the restore path added a new map row without extending the cleanup contract that consumes it.
+- **Fix:** Captured `prior_pre_repo_safe_cwd` from the existing `cwd_to_safe_pre_repo.remove(cwd)`, then ran the matching `pre_repo_watchers` removal AFTER `resolve_toplevel(&safe_cwd).is_ok()` — i.e., only on the actual repo-transition path. **Codex verify v1 caught a HIGH refcount-loss regression in an earlier draft that ran the twin cleanup unconditionally:** on a still-pre-repo re-subscription (with duplicate subscriptions raising the refcount above 1), unconditional cleanup would drop the entry, then `start_pre_repo_watcher_inner` would see no existing bucket and recreate with `refcount=1`, silently losing N-1 subscriptions. Final fix gates the cleanup behind the repo-transition outcome so the still-pre-repo path is untouched.
+- **Commit:** _(see git log for the round-3 fix commit; v1→v2 codex-verify retry documented in `.harness-github-review/cycle-3-verify-result-v{1,2}.json`)_

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -3,7 +3,7 @@ id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
 last_updated: 2026-04-30
-ref_count: 13
+ref_count: 14
 ---
 
 # Documentation Accuracy
@@ -357,3 +357,12 @@ Stale documentation misleads future contributors and review agents.
 - **Finding:** PR #126's restore path inserted a new `pre_repo_watchers[safe_cwd].subscribers[missing_cwd]` row for terminally-stranded subscribers, but `start_git_watcher_inner`'s opportunistic cleanup block was unchanged from the pre-PR contract: it only removes `cwd_to_safe_pre_repo[cwd]`, not the matching `pre_repo_watchers[safe_cwd].subscribers[cwd]`. When a stranded subscriber's path eventually becomes a real repo and re-subscription routes through `start_git_watcher_inner` → repo path, the pre-repo entry is orphaned. Subsequent stop calls follow `cwd_to_toplevel` and never revisit `pre_repo_watchers`, so the bucket can't be GC'd. Same finding-class as #28 / #34 (paired surfaces drift when one is edited without the other) — the restore path added a new map row without extending the cleanup contract that consumes it.
 - **Fix:** Captured `prior_pre_repo_safe_cwd` from the existing `cwd_to_safe_pre_repo.remove(cwd)`, then ran the matching `pre_repo_watchers` removal AFTER `resolve_toplevel(&safe_cwd).is_ok()` — i.e., only on the actual repo-transition path. **Codex verify v1 caught a HIGH refcount-loss regression in an earlier draft that ran the twin cleanup unconditionally:** on a still-pre-repo re-subscription (with duplicate subscriptions raising the refcount above 1), unconditional cleanup would drop the entry, then `start_pre_repo_watcher_inner` would see no existing bucket and recreate with `refcount=1`, silently losing N-1 subscriptions. Final fix gates the cleanup behind the repo-transition outcome so the still-pre-repo path is untouched.
 - **Commit:** _(see git log for the round-3 fix commit; v1→v2 codex-verify retry documented in `.harness-github-review/cycle-3-verify-result-v{1,2}.json`)_
+
+### 39. Eager `Arc<AtomicBool>` allocation hoisted before lock scope confuses ownership flow
+
+- **Source:** github-claude | PR #126 round 4 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/git/watcher.rs` `restore_pre_repo_subscribers`
+- **Finding:** `stop_flag = Arc::new(AtomicBool::new(false))` was hoisted before the `pre_repo_watchers` lock so the `else` branch could move it into the inserted watcher AND the later `spawn_pre_repo_poll_thread` call without cloning twice. But on the if-branch (existing watcher found), the local Arc was created, never stored, and silently dropped — dead allocation. Worse, a future maintainer reading the function would see a `stop_flag` in scope after the lock and might write code that observes it expecting it to match the watcher's flag — which is wrong on the if-branch where the watcher kept its own. Same finding-class as #6 / #36 — surface that suggests a guarantee the value doesn't actually provide.
+- **Fix:** Replaced the eager `Arc::new(...)` with `let mut new_watcher_stop_flag: Option<Arc<AtomicBool>> = None;`. The `else` branch creates a fresh Arc, stores one clone in the inserted watcher, and saves the other in the Option. The poll-thread spawn block then uses `if let Some(stop_flag) = new_watcher_stop_flag` to act only when there's a new watcher to govern. No silent drops; the lifetime-and-ownership story is now explicit.
+- **Commit:** _(see git log for the round-4 fix commit)_

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -3,7 +3,7 @@ id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
 last_updated: 2026-04-30
-ref_count: 11
+ref_count: 12
 ---
 
 # Documentation Accuracy
@@ -338,4 +338,13 @@ Stale documentation misleads future contributors and review agents.
 - **File:** `src-tauri/src/git/watcher.rs`
 - **Finding:** `spawn_trailing_debounce_thread` used `Duration::from_millis(100)` inline for the outer-loop `recv_timeout` value. That 100ms knob bounds shutdown latency from `stop_flag` set → thread exit when no burst is in flight, but it sat unnamed next to two top-level constants (`DEBOUNCE_MS`, `POLL_INTERVAL_SECS`) that had explanatory comments documenting their role. A future maintainer changing `DEBOUNCE_MS` for tuning could easily wonder why shutdown latency didn't change, or pick an arbitrary tweak to this third value without realizing what it controls. Same finding-class as #6 (`DRAWER_MAX` comment claimed dynamic ratio for a hardcoded constant): the magnitude of the value is right but the surface around it doesn't communicate intent.
 - **Fix:** Extracted `const IDLE_CHECK_MS: u64 = 100;` next to the existing constants with a comment explaining: "Outer-loop poll interval for the debounce thread — bounds the latency from `stop_flag` being set to thread exit when idle. 100 ms is roughly one Linux scheduler quantum." `recv_timeout` now reads `Duration::from_millis(IDLE_CHECK_MS)`. Same surface area, but the relationship between the value and its purpose is now explicit.
+- **Commit:** _(see git log for the round-2 fix commit)_
+
+### 37. Error-message count conflates two failure classes routed through the same accumulator
+
+- **Source:** github-claude | PR #126 round 2 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/git/watcher.rs`
+- **Finding:** `upgrade_to_repo_watcher`'s error accumulator `errors: Vec<String>` was the natural sink for two distinct failure classes: (a) per-subscriber upgrade failures inside the for-loop (subscribers that need restoring), and (b) the restore-path's own failure (a lock-poisoning state-level event that affects no specific subscriber). The combined Err message read `"{} subscriber(s) failed to upgrade"` with `errors.len()` — but that count includes both classes. If a state-level restore failure occurred, the count over-reports subscriber failures by one, misleading any tooling or human that parses the count as authoritative. The full text was always present in the trailing `errors.join("; ")`, so information wasn't lost — only the headline lied. Same finding-class as #6 (`DRAWER_MAX` comment claimed dynamic ratio for a constant): the surface around the value implies a guarantee the value doesn't actually provide.
+- **Fix:** Added a dedicated `subscriber_failures: usize` counter, incremented only at the loop's `start_git_watcher_inner` failure site (the same site that pushes to `failed_subscribers`). Format string updated to `"{} subscriber(s) failed to upgrade ({} total error(s)): {}"` — headline reflects subscriber-level reality, parenthetical preserves the total-error context, full body keeps the unredacted error text. Restore-path errors continue to flow through the same `errors` vec but no longer inflate the headline.
 - **Commit:** _(see git log for the round-2 fix commit)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 15
+ref_count: 16
 ---
 
 # Testing Gaps
@@ -223,3 +223,12 @@ filesystem scope restrictions).
 - **Finding:** The new test verified the in-memory state invariants of the restore path (subscriber refcounts, side-map entries, repo-watcher composition) but never registered a `git-status-changed` listener and never asserted the emit. `restore_pre_repo_subscribers` always calls `emit_git_status_changed(&app_handle, subscriber_cwds)`; if that call were accidentally removed or scoped to the wrong slice during a future refactor, the frontend's panel for the restored subscriber would stay stale (correct internal state but no initial-state refresh) and this test would still pass green. The sibling test `upgrade_to_repo_watcher_emits_once_for_duplicate_original_cwd` already demonstrated the listener-plus-sleep pattern; the new test simply didn't replicate it. Same finding-class as #6/#17 (regression-guard tests that didn't actually verify the property they claimed to guard) — internal-state coverage is necessary but not sufficient for a contract whose UI consumer is event-driven.
 - **Fix:** Registered an `app.handle().listen("git-status-changed", ...)` collector mirroring the sibling test's pattern, slept 100 ms after the upgrade call, then asserted that at least one collected payload contains `missing_cwd`. Used `events.iter().any(...)` rather than `events.len() == 1` because the upgrade phase emits independently before the restore phase, so the restored subscriber's emit may be the second of multiple events on the channel.
 - **Commit:** _(see git log for the round-1 fix commit)_
+
+### 24. Fixed-window `sleep + assert collected events` pattern is inherently racy for Tauri listener dispatch
+
+- **Source:** github-claude | PR #126 round 4 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/git/watcher.rs` test `upgrade_to_repo_watcher_restores_failed_subscribers_for_retry`
+- **Finding:** The round-1 test added a `git-status-changed` listener that pushed payloads into a `Vec`, then slept 100 ms, then asserted that the vec contained an entry referencing `missing_cwd`. Tauri's mock runtime dispatches event listeners on a separate thread; 100 ms is not a guaranteed bound on dispatch latency. On a saturated CI host (high CPU, GC pauses, slow filesystem) the dispatch thread may not have run within the window, producing a false-negative "missing emit" failure that's hard to reproduce locally. Same finding-class as #11 (sleep-based synchronization in transcript-turns test) — every fixed-deadline assertion against asynchronous dispatch eventually flakes when the runner gets loaded enough.
+- **Fix:** Replaced the `Arc<Mutex<Vec<String>>> + sleep` collector with an `mpsc::channel::<String>()` whose Sender is captured by the listener closure. The test runs an explicit drain loop with `events_rx.recv_timeout(remaining)` and a 1-second deadline. The first event whose payload contains `missing_cwd` flips a `found` flag and breaks the loop early; both `Timeout` and `Disconnected` end the drain. The assertion message names the deadline so a slow CI failure has clear diagnostic value. Pattern matches the existing #11 mpsc-channel fix in `transcript_turns.rs`.
+- **Commit:** _(see git log for the round-4 fix commit)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 14
+ref_count: 15
 ---
 
 # Testing Gaps
@@ -214,3 +214,12 @@ filesystem scope restrictions).
 - **Finding:** BottomDrawer accepts `gitStatus?` and forwards it to TWO `<DiffPanelContent>` render sites (controlled-with-selectedDiffFile branch and unselected-fallback branch). Round-1 added a single test covering the unselected branch. The selected-file branch — reachable when a user has opened a specific diff file — was not covered by any test in `BottomDrawer.test.tsx`, so a regression that dropped `gitStatus={gitStatus}` from that branch (e.g. during a selectedDiffFile ternary refactor) would silently re-introduce the duplicate-watcher IPC. Codex verify caught this in v1 of round 4. Same finding-class as #7 (uncovered guard branch on doc-change-plus-selection): a multi-branch decision needs coverage for each branch the regression-class can hit, not just the one the author thought about.
 - **Fix:** Split the round-1 test into two siblings — one rendering BottomDrawer without `selectedDiffFile` (unselected branch), one with a synthetic `selectedDiffFile` (controlled branch). Both assert `useGitStatus` was called with `enabled: false`. A regression dropping `gitStatus={gitStatus}` from EITHER `<DiffPanelContent>` render site is now caught.
 - **Commit:** _(see git log for the round-4 fix commit, plus the v1→v2 codex-verify retry that closed the second-branch gap)_
+
+### 23. State-invariants test omits assertion on the side-effect that drives the UI
+
+- **Source:** github-claude | PR #126 round 1 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/git/watcher.rs` (`upgrade_to_repo_watcher_restores_failed_subscribers_for_retry`)
+- **Finding:** The new test verified the in-memory state invariants of the restore path (subscriber refcounts, side-map entries, repo-watcher composition) but never registered a `git-status-changed` listener and never asserted the emit. `restore_pre_repo_subscribers` always calls `emit_git_status_changed(&app_handle, subscriber_cwds)`; if that call were accidentally removed or scoped to the wrong slice during a future refactor, the frontend's panel for the restored subscriber would stay stale (correct internal state but no initial-state refresh) and this test would still pass green. The sibling test `upgrade_to_repo_watcher_emits_once_for_duplicate_original_cwd` already demonstrated the listener-plus-sleep pattern; the new test simply didn't replicate it. Same finding-class as #6/#17 (regression-guard tests that didn't actually verify the property they claimed to guard) — internal-state coverage is necessary but not sufficient for a contract whose UI consumer is event-driven.
+- **Fix:** Registered an `app.handle().listen("git-status-changed", ...)` collector mirroring the sibling test's pattern, slept 100 ms after the upgrade call, then asserted that at least one collected payload contains `missing_cwd`. Used `events.iter().any(...)` rather than `events.len() == 1` because the upgrade phase emits independently before the restore phase, so the restored subscriber's emit may be the second of multiple events on the channel.
+- **Commit:** _(see git log for the round-1 fix commit)_

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -877,8 +877,12 @@ fn restore_pre_repo_subscribers<R: tauri::Runtime>(
     }
 
     let subscriber_cwds: Vec<String> = subscribers.keys().cloned().collect();
-    let stop_flag = Arc::new(AtomicBool::new(false));
-    let mut should_spawn_poll_thread = false;
+    // Allocated lazily — only the no-existing-watcher branch needs a
+    // fresh stop_flag. Hoisting before the lock would silently drop
+    // an Arc on the existing-watcher branch, leaving a dead allocation
+    // that confuses readers auditing the watcher lifecycle (which
+    // stop_flag governs which thread?).
+    let mut new_watcher_stop_flag: Option<Arc<AtomicBool>> = None;
 
     {
         let mut pre_repo_watchers = state
@@ -891,6 +895,7 @@ fn restore_pre_repo_subscribers<R: tauri::Runtime>(
                 *watcher.subscribers.entry(cwd).or_insert(0) += refcount;
             }
         } else {
+            let stop_flag = Arc::new(AtomicBool::new(false));
             pre_repo_watchers.insert(
                 safe_cwd.clone(),
                 PreRepoWatcher {
@@ -898,7 +903,7 @@ fn restore_pre_repo_subscribers<R: tauri::Runtime>(
                     stop_flag: stop_flag.clone(),
                 },
             );
-            should_spawn_poll_thread = true;
+            new_watcher_stop_flag = Some(stop_flag);
         }
     }
 
@@ -912,7 +917,7 @@ fn restore_pre_repo_subscribers<R: tauri::Runtime>(
         }
     }
 
-    if should_spawn_poll_thread {
+    if let Some(stop_flag) = new_watcher_stop_flag {
         // Guard against a known infinite-retry trap: `restore_pre_repo_subscribers`
         // is called *after* `upgrade_to_repo_watcher` succeeded for at least one
         // subscriber on `safe_cwd`, which means `safe_cwd` is already a git
@@ -1319,18 +1324,15 @@ mod tests {
             .build(tauri::generate_context!())
             .expect("failed to build test app");
 
-        // Listen for git-status-changed so we can assert the restore path
-        // emits an initial-state event for the failed subscriber. Without
-        // this assertion, removing the `emit_git_status_changed` call from
-        // `restore_pre_repo_subscribers` would leave the test green while
-        // the frontend's panel stays stale after restoration.
-        let received = Arc::new(Mutex::new(Vec::new()));
-        let received_for_listener = received.clone();
+        // Listen for git-status-changed and pipe payloads through an
+        // mpsc channel so the assertion below can deterministically wait
+        // for the restored-subscriber event with a generous timeout
+        // instead of guessing a fixed sleep window. A 100 ms sleep on
+        // a saturated CI host can expire before Tauri's listener
+        // dispatch thread is scheduled, producing flaky false negatives.
+        let (events_tx, events_rx) = mpsc::channel::<String>();
         app.handle().listen("git-status-changed", move |event| {
-            received_for_listener
-                .lock()
-                .expect("failed to lock received events")
-                .push(event.payload().to_string());
+            let _ = events_tx.send(event.payload().to_string());
         });
 
         let temp = create_temp_repo();
@@ -1396,18 +1398,34 @@ mod tests {
         assert_eq!(safe_pre_repo.get(&missing_cwd), Some(&safe_cwd));
         drop(safe_pre_repo);
 
-        // Wait for the emit to land on the listener thread, then assert
-        // that an event fired for the restored subscriber. There may be
-        // multiple events (one per emit_git_status_changed call across
-        // the upgrade + restore phases); we only need to verify one
-        // contains the missing_cwd payload.
-        std::thread::sleep(Duration::from_millis(100));
-        let events = received.lock().expect("failed to lock received events");
+        // Drain events with a 1-second deadline, looking for the
+        // payload that mentions `missing_cwd`. The upgrade + restore
+        // phases may emit independently, so we tolerate intervening
+        // events; we only need to confirm one of them references the
+        // restored subscriber. Failing the assertion on
+        // `RecvTimeoutError::Timeout` produces a clear "emit never
+        // arrived" message rather than the ambiguous "vector didn't
+        // contain expected entry" of the prior sleep-then-assert form.
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        let mut found = false;
+        while std::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            match events_rx.recv_timeout(remaining) {
+                Ok(payload) => {
+                    if payload.contains(&missing_cwd) {
+                        found = true;
+                        break;
+                    }
+                    // Not the one we're looking for — keep draining.
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => break,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
         assert!(
-            events.iter().any(|payload| payload.contains(&missing_cwd)),
-            "expected git-status-changed emit for restored subscriber {:?}, got events: {:?}",
+            found,
+            "expected git-status-changed emit for restored subscriber {:?} within 1s",
             missing_cwd,
-            events,
         );
     }
 

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -955,6 +955,13 @@ fn upgrade_to_repo_watcher<R: tauri::Runtime>(
     // and failed subscribers are restored to a pre-repo watcher so they keep
     // a backend subscription and retry path.
     let mut errors: Vec<String> = Vec::new();
+    // Counts only per-subscriber upgrade failures from the loop below —
+    // distinct from `errors.len()`, which may also accumulate restore-path
+    // failures (state-machine-level lock poisoning) that are NOT
+    // subscriber failures. The error-format string uses this counter so
+    // the human-facing "N subscriber(s) failed to upgrade" message
+    // reflects subscriber failures only.
+    let mut subscriber_failures: usize = 0;
     let mut failed_subscribers: HashMap<String, u32> = HashMap::new();
     for (original_cwd, refcount) in subscribers {
         if refcount == 0 {
@@ -964,6 +971,7 @@ fn upgrade_to_repo_watcher<R: tauri::Runtime>(
         if let Err(e) = start_git_watcher_inner(&original_cwd, app_handle.clone(), &state) {
             errors.push(format!("{}: {}", original_cwd, e));
             failed_subscribers.insert(original_cwd, refcount);
+            subscriber_failures += 1;
             continue;
         }
 
@@ -1017,8 +1025,15 @@ fn upgrade_to_repo_watcher<R: tauri::Runtime>(
     if errors.is_empty() {
         Ok(())
     } else {
+        // Use the dedicated counter for the headline so the message
+        // matches reality: only `subscriber_failures` are upgrade
+        // failures whose subscribers need a retry. Other items in
+        // `errors` (post-upgrade state inconsistencies, restore-path
+        // failures) are surfaced in the trailing `errors.join("; ")`
+        // body but don't inflate the headline count.
         Err(format!(
-            "upgrade_to_repo_watcher: {} subscriber(s) failed to upgrade: {}",
+            "upgrade_to_repo_watcher: {} subscriber(s) failed to upgrade ({} total error(s)): {}",
+            subscriber_failures,
             errors.len(),
             errors.join("; ")
         ))

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -765,43 +765,12 @@ fn start_pre_repo_watcher_inner<R: tauri::Runtime>(
 
     // Create new pre-repo watcher with polling
     let stop_flag = Arc::new(AtomicBool::new(false));
-    let poll_safe_cwd = safe_cwd.clone();
-    let poll_app_handle = app_handle.clone();
-    let poll_state = state.clone();
-    let poll_stop_flag = stop_flag.clone();
-
-    std::thread::spawn(move || {
-        while !poll_stop_flag.load(Ordering::Relaxed) {
-            std::thread::sleep(Duration::from_secs(POLL_INTERVAL_SECS));
-
-            if poll_stop_flag.load(Ordering::Relaxed) {
-                break;
-            }
-
-            // Check if this became a repo
-            if resolve_toplevel(&poll_safe_cwd).is_ok() {
-                // Upgrade to repo watcher — transfers the subscriber map
-                // (with original cwd strings intact) into repo_watchers.
-                if let Err(e) = upgrade_to_repo_watcher(
-                    poll_safe_cwd.clone(),
-                    poll_app_handle.clone(),
-                    poll_state.clone(),
-                ) {
-                    log::error!("Failed to upgrade to repo watcher: {}", e);
-                }
-                break;
-            }
-
-            // Still not a repo — intentionally NO emit on this tick.
-            // The previous revision fired `git-status-changed` on every
-            // 10-second tick for every pre-repo subscriber, which caused
-            // the frontend to run a useless `git_status` round-trip that
-            // always returns []. Subscribers already hold the correct
-            // empty state from their initial fetch; nothing to refresh
-            // until the dir becomes a repo (upgrade path emits its own
-            // initial event).
-        }
-    });
+    spawn_pre_repo_poll_thread(
+        safe_cwd.clone(),
+        app_handle.clone(),
+        state.clone(),
+        stop_flag.clone(),
+    );
 
     let mut subscribers = HashMap::new();
     subscribers.insert(cwd.to_string(), 1);
@@ -823,6 +792,99 @@ fn start_pre_repo_watcher_inner<R: tauri::Runtime>(
 
     // Emit initial event with the frontend's original cwd string
     emit_git_status_changed(&app_handle, vec![cwd.to_string()]);
+
+    Ok(())
+}
+
+fn spawn_pre_repo_poll_thread<R: tauri::Runtime>(
+    safe_cwd: PathBuf,
+    app_handle: tauri::AppHandle<R>,
+    state: GitWatcherState,
+    stop_flag: Arc<AtomicBool>,
+) {
+    std::thread::spawn(move || {
+        while !stop_flag.load(Ordering::Relaxed) {
+            std::thread::sleep(Duration::from_secs(POLL_INTERVAL_SECS));
+
+            if stop_flag.load(Ordering::Relaxed) {
+                break;
+            }
+
+            // Check if this became a repo
+            if resolve_toplevel(&safe_cwd).is_ok() {
+                // Upgrade to repo watcher — transfers the subscriber map
+                // (with original cwd strings intact) into repo_watchers.
+                if let Err(e) =
+                    upgrade_to_repo_watcher(safe_cwd.clone(), app_handle.clone(), state.clone())
+                {
+                    log::error!("Failed to upgrade to repo watcher: {}", e);
+                }
+                break;
+            }
+
+            // Still not a repo — intentionally NO emit on this tick.
+            // The previous revision fired `git-status-changed` on every
+            // 10-second tick for every pre-repo subscriber, which caused
+            // the frontend to run a useless `git_status` round-trip that
+            // always returns []. Subscribers already hold the correct
+            // empty state from their initial fetch; nothing to refresh
+            // until the dir becomes a repo (upgrade path emits its own
+            // initial event).
+        }
+    });
+}
+
+fn restore_pre_repo_subscribers<R: tauri::Runtime>(
+    safe_cwd: PathBuf,
+    subscribers: HashMap<String, u32>,
+    app_handle: tauri::AppHandle<R>,
+    state: &GitWatcherState,
+) -> Result<(), String> {
+    if subscribers.is_empty() {
+        return Ok(());
+    }
+
+    let subscriber_cwds: Vec<String> = subscribers.keys().cloned().collect();
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let mut should_spawn_poll_thread = false;
+
+    {
+        let mut pre_repo_watchers = state
+            .pre_repo_watchers
+            .lock()
+            .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
+
+        if let Some(watcher) = pre_repo_watchers.get_mut(&safe_cwd) {
+            for (cwd, refcount) in subscribers {
+                *watcher.subscribers.entry(cwd).or_insert(0) += refcount;
+            }
+        } else {
+            pre_repo_watchers.insert(
+                safe_cwd.clone(),
+                PreRepoWatcher {
+                    subscribers,
+                    stop_flag: stop_flag.clone(),
+                },
+            );
+            should_spawn_poll_thread = true;
+        }
+    }
+
+    {
+        let mut map = state
+            .cwd_to_safe_pre_repo
+            .lock()
+            .map_err(|e| format!("Failed to lock cwd_to_safe_pre_repo: {}", e))?;
+        for cwd in &subscriber_cwds {
+            map.insert(cwd.clone(), safe_cwd.clone());
+        }
+    }
+
+    if should_spawn_poll_thread {
+        spawn_pre_repo_poll_thread(safe_cwd, app_handle.clone(), state.clone(), stop_flag);
+    }
+
+    emit_git_status_changed(&app_handle, subscriber_cwds);
 
     Ok(())
 }
@@ -870,8 +932,10 @@ fn upgrade_to_repo_watcher<R: tauri::Runtime>(
     // stops would silent-no-op and the frontend panel would go permanently
     // stale with no surfaced error. Per-subscriber errors are now
     // accumulated; each surviving subscriber still gets its repo watcher,
-    // and the caller sees a combined error describing all failures.
+    // and failed subscribers are restored to a pre-repo watcher so they keep
+    // a backend subscription and retry path.
     let mut errors: Vec<String> = Vec::new();
+    let mut failed_subscribers: HashMap<String, u32> = HashMap::new();
     for (original_cwd, refcount) in subscribers {
         if refcount == 0 {
             continue;
@@ -879,6 +943,7 @@ fn upgrade_to_repo_watcher<R: tauri::Runtime>(
 
         if let Err(e) = start_git_watcher_inner(&original_cwd, app_handle.clone(), &state) {
             errors.push(format!("{}: {}", original_cwd, e));
+            failed_subscribers.insert(original_cwd, refcount);
             continue;
         }
 
@@ -918,6 +983,15 @@ fn upgrade_to_repo_watcher<R: tauri::Runtime>(
                 )),
             }
         }
+    }
+
+    if let Err(e) = restore_pre_repo_subscribers(
+        safe_cwd,
+        failed_subscribers,
+        app_handle.clone(),
+        &state,
+    ) {
+        errors.push(format!("failed to restore failed subscribers: {}", e));
     }
 
     if errors.is_empty() {
@@ -1170,6 +1244,74 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert!(events[0].contains(&cwd));
+    }
+
+    #[test]
+    fn upgrade_to_repo_watcher_restores_failed_subscribers_for_retry() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::generate_context!())
+            .expect("failed to build test app");
+        let temp = create_temp_repo();
+        let cwd = temp.path().to_string_lossy().to_string();
+        let missing_cwd = temp
+            .path()
+            .join("missing")
+            .to_string_lossy()
+            .to_string();
+        let safe_cwd = validate_cwd(&cwd).expect("cwd should validate");
+        let state = GitWatcherState::new();
+        let mut subscribers = HashMap::new();
+
+        subscribers.insert(missing_cwd.clone(), 1);
+        subscribers.insert(cwd.clone(), 2);
+        state
+            .pre_repo_watchers
+            .lock()
+            .expect("failed to lock pre_repo_watchers")
+            .insert(
+                safe_cwd.clone(),
+                PreRepoWatcher {
+                    subscribers,
+                    stop_flag: Arc::new(AtomicBool::new(false)),
+                },
+            );
+
+        let result = upgrade_to_repo_watcher(safe_cwd.clone(), app.handle().clone(), state.clone());
+
+        assert!(result.is_err(), "missing subscriber should fail upgrade");
+
+        let toplevel = resolve_toplevel(temp.path()).expect("repo should resolve");
+        let toplevel_key =
+            validate_cwd(&toplevel.to_string_lossy()).expect("toplevel should validate");
+        let repo_watchers = state
+            .repo_watchers
+            .lock()
+            .expect("failed to lock repo_watchers");
+        let watcher = repo_watchers
+            .get(&toplevel_key)
+            .expect("valid subscriber should upgrade to repo watcher");
+
+        assert_eq!(watcher.subscribers.get(&cwd), Some(&2));
+        drop(repo_watchers);
+
+        let pre_repo_watchers = state
+            .pre_repo_watchers
+            .lock()
+            .expect("failed to lock pre_repo_watchers");
+        let restored = pre_repo_watchers
+            .get(&safe_cwd)
+            .expect("failed subscriber should be restored to pre-repo watcher");
+
+        assert_eq!(restored.subscribers.get(&missing_cwd), Some(&1));
+        assert!(!restored.subscribers.contains_key(&cwd));
+        drop(pre_repo_watchers);
+
+        let safe_pre_repo = state
+            .cwd_to_safe_pre_repo
+            .lock()
+            .expect("failed to lock cwd_to_safe_pre_repo");
+
+        assert_eq!(safe_pre_repo.get(&missing_cwd), Some(&safe_cwd));
     }
 
     #[test]

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -423,13 +423,22 @@ fn start_git_watcher_inner<R: tauri::Runtime>(
     // would just be a tiny memory leak — stop_git_watcher_inner consults
     // `cwd_to_toplevel` first so the stale entry can't cause incorrect
     // routing — but tidiness wins.
-    {
+    // Capture the prior pre-repo mapping (if any) but do NOT clean up
+    // `pre_repo_watchers` yet. The decision depends on which branch of
+    // `resolve_toplevel` we take below:
+    //   - repo-transition (Ok): also remove cwd from pre_repo_watchers,
+    //     dropping the bucket if empty. This is the stranded-subscriber
+    //     transition the round-3 finding asked about.
+    //   - still-pre-repo (Err): leave the pre_repo_watchers entry alone
+    //     so `start_pre_repo_watcher_inner` below can see and increment
+    //     its existing refcount instead of clobbering it to 1.
+    let prior_pre_repo_safe_cwd = {
         let mut pre_repo_map = state
             .cwd_to_safe_pre_repo
             .lock()
             .expect("failed to lock cwd_to_safe_pre_repo");
-        pre_repo_map.remove(cwd);
-    }
+        pre_repo_map.remove(cwd)
+    };
 
     // Try to resolve repo toplevel
     let toplevel = match resolve_toplevel(&safe_cwd) {
@@ -448,6 +457,29 @@ fn start_git_watcher_inner<R: tauri::Runtime>(
             return start_pre_repo_watcher_inner(cwd, safe_cwd, app_handle, state);
         }
     };
+
+    // Repo-transition path. Only NOW can we safely clean up the prior
+    // `pre_repo_watchers` entry for this cwd: the subscriber is moving
+    // from pre-repo to repo, so any leftover subscriber row under the
+    // old safe_cwd would never be reached again (stop_git_watcher
+    // routes via `cwd_to_toplevel` once we register below). Doing this
+    // BEFORE `resolve_toplevel` would have been wrong for the still-
+    // pre-repo re-subscription case, where `start_pre_repo_watcher_inner`
+    // needs the existing refcount to bump rather than recreate from 1
+    // (caught by codex verify in v1 of this round as a HIGH issue —
+    // refcount loss on duplicate pre-repo subscriptions).
+    if let Some(old_safe_cwd) = prior_pre_repo_safe_cwd {
+        let mut pre_repo_watchers = state
+            .pre_repo_watchers
+            .lock()
+            .expect("failed to lock pre_repo_watchers");
+        if let Some(watcher) = pre_repo_watchers.get_mut(&old_safe_cwd) {
+            watcher.subscribers.remove(cwd);
+            if watcher.subscribers.is_empty() {
+                pre_repo_watchers.remove(&old_safe_cwd);
+            }
+        }
+    }
 
     // ── Phase 1: short check under lock A ─────────────────────────────
     //

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -881,7 +881,27 @@ fn restore_pre_repo_subscribers<R: tauri::Runtime>(
     }
 
     if should_spawn_poll_thread {
-        spawn_pre_repo_poll_thread(safe_cwd, app_handle.clone(), state.clone(), stop_flag);
+        // Guard against a known infinite-retry trap: `restore_pre_repo_subscribers`
+        // is called *after* `upgrade_to_repo_watcher` succeeded for at least one
+        // subscriber on `safe_cwd`, which means `safe_cwd` is already a git
+        // repository. Spawning a poll thread that re-runs `resolve_toplevel(&safe_cwd)`
+        // every 10 s would immediately succeed, re-fire `upgrade_to_repo_watcher`,
+        // fail again for the same permanently-invalid subscriber paths, restore
+        // again, and loop forever. Detect the case here and treat the failed
+        // subscribers as terminally stranded — keep their pre-repo entry as a
+        // record (so refcount accounting stays consistent) but don't poll.
+        if resolve_toplevel(&safe_cwd).is_ok() {
+            log::warn!(
+                "git watcher: subscribers {:?} could not upgrade against repo {:?}; \
+                 paths are not reachable inside the repo and will not be polled \
+                 (the parent path is already a repo, so a poll thread would \
+                 re-fire the failed upgrade indefinitely).",
+                subscriber_cwds,
+                safe_cwd,
+            );
+        } else {
+            spawn_pre_repo_poll_thread(safe_cwd, app_handle.clone(), state.clone(), stop_flag);
+        }
     }
 
     emit_git_status_changed(&app_handle, subscriber_cwds);
@@ -1251,6 +1271,21 @@ mod tests {
         let app = tauri::test::mock_builder()
             .build(tauri::generate_context!())
             .expect("failed to build test app");
+
+        // Listen for git-status-changed so we can assert the restore path
+        // emits an initial-state event for the failed subscriber. Without
+        // this assertion, removing the `emit_git_status_changed` call from
+        // `restore_pre_repo_subscribers` would leave the test green while
+        // the frontend's panel stays stale after restoration.
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let received_for_listener = received.clone();
+        app.handle().listen("git-status-changed", move |event| {
+            received_for_listener
+                .lock()
+                .expect("failed to lock received events")
+                .push(event.payload().to_string());
+        });
+
         let temp = create_temp_repo();
         let cwd = temp.path().to_string_lossy().to_string();
         let missing_cwd = temp
@@ -1312,6 +1347,21 @@ mod tests {
             .expect("failed to lock cwd_to_safe_pre_repo");
 
         assert_eq!(safe_pre_repo.get(&missing_cwd), Some(&safe_cwd));
+        drop(safe_pre_repo);
+
+        // Wait for the emit to land on the listener thread, then assert
+        // that an event fired for the restored subscriber. There may be
+        // multiple events (one per emit_git_status_changed call across
+        // the upgrade + restore phases); we only need to verify one
+        // contains the missing_cwd payload.
+        std::thread::sleep(Duration::from_millis(100));
+        let events = received.lock().expect("failed to lock received events");
+        assert!(
+            events.iter().any(|payload| payload.contains(&missing_cwd)),
+            "expected git-status-changed emit for restored subscriber {:?}, got events: {:?}",
+            missing_cwd,
+            events,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Keeps successful pre-repo subscribers moving to the repo watcher during upgrade.
- Restores subscribers that fail to upgrade back into a pre-repo watcher with a retry poll thread.
- Adds a regression test covering a mixed upgrade where one subscriber path fails and another succeeds with refcount preserved.

## Root Cause
`upgrade_to_repo_watcher` removes the pre-repo entry before starting repo watchers. Current code continues after per-subscriber failures, but failed subscribers are still removed from the backend subscription maps and have no retry path, leaving their frontend listeners stale.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml git::watcher::tests`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- pre-push hook: `npm test`
- `git diff --check`

Fixes #90.