### PR TITLE
fix(agent): lock detector to pty tree

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,9 +43,9 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 24       | 16   | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 25       | 17   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 39       | 14   | 2026-05-02   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 40       | 15   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 20       | 7    | 2026-05-02   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 5        | 1    | 2026-04-20   |

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -3,7 +3,7 @@ id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
 last_updated: 2026-04-30
-ref_count: 14
+ref_count: 15
 ---
 
 # Documentation Accuracy
@@ -366,3 +366,12 @@ Stale documentation misleads future contributors and review agents.
 - **Finding:** `stop_flag = Arc::new(AtomicBool::new(false))` was hoisted before the `pre_repo_watchers` lock so the `else` branch could move it into the inserted watcher AND the later `spawn_pre_repo_poll_thread` call without cloning twice. But on the if-branch (existing watcher found), the local Arc was created, never stored, and silently dropped — dead allocation. Worse, a future maintainer reading the function would see a `stop_flag` in scope after the lock and might write code that observes it expecting it to match the watcher's flag — which is wrong on the if-branch where the watcher kept its own. Same finding-class as #6 / #36 — surface that suggests a guarantee the value doesn't actually provide.
 - **Fix:** Replaced the eager `Arc::new(...)` with `let mut new_watcher_stop_flag: Option<Arc<AtomicBool>> = None;`. The `else` branch creates a fresh Arc, stores one clone in the inserted watcher, and saves the other in the Option. The poll-thread spawn block then uses `if let Some(stop_flag) = new_watcher_stop_flag` to act only when there's a new watcher to govern. No silent drops; the lifetime-and-ownership story is now explicit.
 - **Commit:** _(see git log for the round-4 fix commit)_
+
+### 40. `#[cfg(test)] fn` at module level is a rename artifact, not a test helper
+
+- **Source:** github-claude | PR #128 round 1 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/agent/detector.rs`
+- **Finding:** A rename of `read_cmdline` → `read_proc_cmdline` left a `#[cfg(test)] fn read_cmdline(pid) -> Option<Vec<String>> { ProcFsProcessSource.read_cmdline(pid) }` shim at MODULE level (outside `mod tests`) so two pre-existing tests (`reads_self_cmdline`, `handles_missing_pid_gracefully`) didn't need their call sites updated. Future readers see a `#[cfg(test)]` function alongside production code with no production callers and have to reason about whether it's a deprecated API, an internal-test seam, or a forgotten helper. Same finding-class as #28 (unused default export) — surface that does nothing in production but adds reader-overhead.
+- **Fix:** Deleted the shim. Updated the two test call sites to call `read_proc_cmdline` directly. Production and test symbols are now cleanly separated; nothing at module level is gated on `#[cfg(test)]`.
+- **Commit:** _(see git log for the round-1 fix commit)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 16
+ref_count: 17
 ---
 
 # Testing Gaps
@@ -232,3 +232,12 @@ filesystem scope restrictions).
 - **Finding:** The round-1 test added a `git-status-changed` listener that pushed payloads into a `Vec`, then slept 100 ms, then asserted that the vec contained an entry referencing `missing_cwd`. Tauri's mock runtime dispatches event listeners on a separate thread; 100 ms is not a guaranteed bound on dispatch latency. On a saturated CI host (high CPU, GC pauses, slow filesystem) the dispatch thread may not have run within the window, producing a false-negative "missing emit" failure that's hard to reproduce locally. Same finding-class as #11 (sleep-based synchronization in transcript-turns test) — every fixed-deadline assertion against asynchronous dispatch eventually flakes when the runner gets loaded enough.
 - **Fix:** Replaced the `Arc<Mutex<Vec<String>>> + sleep` collector with an `mpsc::channel::<String>()` whose Sender is captured by the listener closure. The test runs an explicit drain loop with `events_rx.recv_timeout(remaining)` and a 1-second deadline. The first event whose payload contains `missing_cwd` flips a `found` flag and breaks the loop early; both `Timeout` and `Disconnected` end the drain. The assertion message names the deadline so a slow CI failure has clear diagnostic value. Pattern matches the existing #11 mpsc-channel fix in `transcript_turns.rs`.
 - **Commit:** _(see git log for the round-4 fix commit)_
+
+### 25. Documented `exec claude` invariant (root PID itself is the agent) had no test
+
+- **Source:** github-claude | PR #128 round 1 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/agent/detector.rs`
+- **Finding:** PR #128 explicitly motivated `collect_process_tree` including the root PID to handle `exec claude` (where the user replaces a shell with the agent binary in-place — the PTY's own root PID becomes `claude` with no shell intermediary). The implementation was correct; the comment documented the contract; both new tests (`detects_only_agent_inside_pty_process_tree`, `ignores_agent_outside_pty_process_tree`) exercised in-tree-descendant scenarios but never the root-IS-agent scenario. A future refactor that restored the old skip-root behavior would silently regress the PR's primary motivating use case while passing every existing test. Same finding-class as #6/#16/#17 — a contract documented in code/comments but not pinned by an assertion that fails when the contract breaks.
+- **Fix:** Added `detects_agent_at_pty_root_via_exec` test using a `MockProcessSource` whose root PID 12 maps directly to `claude` cmdlines with no `children` entry. Asserts `detect_agent_with_source(12, &source) == Some((AgentType::ClaudeCode, 12))`. If a future refactor reverts to skip-root, the descendant lookup returns no candidates and the assertion fails on `None`.
+- **Commit:** _(see git log for the round-1 fix commit)_

--- a/src-tauri/src/agent/commands.rs
+++ b/src-tauri/src/agent/commands.rs
@@ -5,11 +5,9 @@ use super::types::AgentDetectedEvent;
 use crate::terminal::PtyState;
 
 /// Escape hatch for E2E (and any future debugging) — skip the /proc scan
-/// and return no detection. The current detector (see #71) is host-global,
-/// which means it attributes unrelated claude processes on the dev box to
-/// whatever PTY is asking. Setting this env var short-circuits detection
-/// so non-agent E2E suites aren't destabilized by real Claude Code CLI
-/// sessions running in other terminals.
+/// and return no detection. The detector is scoped to the queried PTY's
+/// process tree, but this still gives E2E and debugging flows a deterministic
+/// off-switch for machines with unusual /proc behavior.
 fn agent_detection_disabled() -> bool {
     std::env::var_os("VIMEFLOW_DISABLE_AGENT_DETECTION").is_some()
 }

--- a/src-tauri/src/agent/detector.rs
+++ b/src-tauri/src/agent/detector.rs
@@ -120,11 +120,6 @@ fn read_proc_cmdline(pid: u32) -> Option<Vec<String>> {
     }
 }
 
-#[cfg(test)]
-fn read_cmdline(pid: u32) -> Option<Vec<String>> {
-    ProcFsProcessSource.read_cmdline(pid)
-}
-
 /// Extract binary name from cmdline argv[0]
 ///
 /// Handles both absolute paths (/usr/bin/claude) and bare names (claude).
@@ -215,7 +210,7 @@ mod tests {
     #[test]
     fn reads_self_cmdline() {
         // /proc/self always exists and points to our own process
-        let cmdline = read_cmdline(std::process::id());
+        let cmdline = read_proc_cmdline(std::process::id());
         assert!(cmdline.is_some(), "Failed to read /proc/self/cmdline");
 
         let cmdline = cmdline.unwrap();
@@ -229,8 +224,30 @@ mod tests {
     #[test]
     fn handles_missing_pid_gracefully() {
         // PID 9999999 is unlikely to exist
-        let cmdline = read_cmdline(9999999);
+        let cmdline = read_proc_cmdline(9999999);
         assert!(cmdline.is_none(), "Should return None for missing PID");
+    }
+
+    #[test]
+    fn detects_agent_at_pty_root_via_exec() {
+        // Locks the `exec claude` contract documented in
+        // `collect_process_tree`'s comment: when the user runs
+        // `exec claude`, the shell process is replaced by the agent
+        // binary in-place, so the PTY's own root PID IS the agent.
+        // The detector must include the root in the candidate set
+        // (not just descendants) for this case to be detected at all.
+        let source = MockProcessSource {
+            children: HashMap::new(),
+            cmdlines: HashMap::from([(12, vec!["claude".to_string()])]),
+        };
+
+        let detected = detect_agent_with_source(12, &source);
+
+        assert!(
+            matches!(detected, Some((AgentType::ClaudeCode, 12))),
+            "expected detection at the PTY root PID for `exec claude`, got {:?}",
+            detected,
+        );
     }
 
     #[test]

--- a/src-tauri/src/agent/detector.rs
+++ b/src-tauri/src/agent/detector.rs
@@ -8,6 +8,23 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
+trait ProcessSource {
+    fn read_children(&self, pid: u32) -> Option<Vec<u32>>;
+    fn read_cmdline(&self, pid: u32) -> Option<Vec<String>>;
+}
+
+struct ProcFsProcessSource;
+
+impl ProcessSource for ProcFsProcessSource {
+    fn read_children(&self, pid: u32) -> Option<Vec<u32>> {
+        read_proc_children(pid)
+    }
+
+    fn read_cmdline(&self, pid: u32) -> Option<Vec<String>> {
+        read_proc_cmdline(pid)
+    }
+}
+
 /// Detect which agent is running under the given PID
 ///
 /// Recursively traverses the process tree to find agent processes.
@@ -20,13 +37,18 @@ use std::path::Path;
 /// * `Some((agent_type, agent_pid))` - If an agent is found
 /// * `None` - If no agent is detected
 pub fn detect_agent(pid: u32) -> Option<(AgentType, u32)> {
-    // Collect all descendant PIDs
-    let descendants = collect_descendants(pid)?;
+    detect_agent_with_source(pid, &ProcFsProcessSource)
+}
 
-    // Check each descendant for agent binaries
-    for &descendant_pid in &descendants {
-        if let Some(agent_type) = detect_agent_from_cmdline(descendant_pid) {
-            return Some((agent_type, descendant_pid));
+fn detect_agent_with_source<S: ProcessSource>(
+    pid: u32,
+    source: &S,
+) -> Option<(AgentType, u32)> {
+    // Check the PTY root plus its descendants. Including the root handles
+    // shells that have been replaced with `exec claude`.
+    for candidate_pid in collect_process_tree(pid, source) {
+        if let Some(agent_type) = detect_agent_from_cmdline(candidate_pid, source) {
+            return Some((agent_type, candidate_pid));
         }
     }
 
@@ -36,7 +58,7 @@ pub fn detect_agent(pid: u32) -> Option<(AgentType, u32)> {
 /// Read the children of a process from /proc filesystem
 ///
 /// On Linux, /proc/<pid>/task/<pid>/children contains space-separated child PIDs.
-fn read_children(pid: u32) -> Option<Vec<u32>> {
+fn read_proc_children(pid: u32) -> Option<Vec<u32>> {
     let children_path = format!("/proc/{}/task/{}/children", pid, pid);
     let content = fs::read_to_string(children_path).ok()?;
 
@@ -48,38 +70,35 @@ fn read_children(pid: u32) -> Option<Vec<u32>> {
     Some(children)
 }
 
-/// Collect all descendant PIDs using iterative DFS
-fn collect_descendants(root_pid: u32) -> Option<Vec<u32>> {
-    let mut descendants = Vec::new();
+/// Collect the root PID and all descendant PIDs using iterative DFS
+fn collect_process_tree<S: ProcessSource>(root_pid: u32, source: &S) -> Vec<u32> {
+    let mut candidates = Vec::new();
     let mut visited = HashSet::new();
     let mut queue = vec![root_pid];
 
     visited.insert(root_pid);
 
     while let Some(pid) = queue.pop() {
+        candidates.push(pid);
+
         // Read children of current PID
-        if let Some(children) = read_children(pid) {
+        if let Some(children) = source.read_children(pid) {
             for child_pid in children {
                 // Avoid cycles (shouldn't happen in process tree, but be safe)
                 if visited.insert(child_pid) {
-                    descendants.push(child_pid);
                     queue.push(child_pid);
                 }
             }
         }
     }
 
-    if descendants.is_empty() {
-        None
-    } else {
-        Some(descendants)
-    }
+    candidates
 }
 
 /// Read and parse /proc/<pid>/cmdline
 ///
 /// The cmdline file contains null-separated arguments. argv[0] is the binary name.
-fn read_cmdline(pid: u32) -> Option<Vec<String>> {
+fn read_proc_cmdline(pid: u32) -> Option<Vec<String>> {
     let cmdline_path = format!("/proc/{}/cmdline", pid);
     let content = fs::read(cmdline_path).ok()?;
 
@@ -101,6 +120,11 @@ fn read_cmdline(pid: u32) -> Option<Vec<String>> {
     }
 }
 
+#[cfg(test)]
+fn read_cmdline(pid: u32) -> Option<Vec<String>> {
+    ProcFsProcessSource.read_cmdline(pid)
+}
+
 /// Extract binary name from cmdline argv[0]
 ///
 /// Handles both absolute paths (/usr/bin/claude) and bare names (claude).
@@ -112,8 +136,8 @@ fn extract_binary_name(cmdline: &[String]) -> Option<String> {
 }
 
 /// Detect agent type from cmdline binary name
-fn detect_agent_from_cmdline(pid: u32) -> Option<AgentType> {
-    let cmdline = read_cmdline(pid)?;
+fn detect_agent_from_cmdline<S: ProcessSource>(pid: u32, source: &S) -> Option<AgentType> {
+    let cmdline = source.read_cmdline(pid)?;
     let binary_name = extract_binary_name(&cmdline)?;
 
     match binary_name.as_str() {
@@ -127,6 +151,66 @@ fn detect_agent_from_cmdline(pid: u32) -> Option<AgentType> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    #[derive(Default)]
+    struct MockProcessSource {
+        children: HashMap<u32, Vec<u32>>,
+        cmdlines: HashMap<u32, Vec<String>>,
+    }
+
+    impl ProcessSource for MockProcessSource {
+        fn read_children(&self, pid: u32) -> Option<Vec<u32>> {
+            self.children.get(&pid).cloned()
+        }
+
+        fn read_cmdline(&self, pid: u32) -> Option<Vec<String>> {
+            self.cmdlines.get(&pid).cloned()
+        }
+    }
+
+    #[test]
+    fn detects_only_agent_inside_pty_process_tree() {
+        let source = MockProcessSource {
+            children: HashMap::from([
+                (10, vec![11]),
+                (11, vec![12]),
+                (20, vec![21]),
+            ]),
+            cmdlines: HashMap::from([
+                (10, vec!["bash".to_string()]),
+                (11, vec!["sh".to_string()]),
+                (12, vec!["claude".to_string()]),
+                (20, vec!["zsh".to_string()]),
+                (21, vec!["claude".to_string()]),
+            ]),
+        };
+
+        let detected = detect_agent_with_source(10, &source);
+
+        assert!(matches!(
+            detected,
+            Some((AgentType::ClaudeCode, 12))
+        ));
+    }
+
+    #[test]
+    fn ignores_agent_outside_pty_process_tree() {
+        let source = MockProcessSource {
+            children: HashMap::from([
+                (10, vec![11]),
+                (20, vec![21]),
+            ]),
+            cmdlines: HashMap::from([
+                (10, vec!["bash".to_string()]),
+                (11, vec!["python".to_string()]),
+                (20, vec!["zsh".to_string()]),
+                (21, vec!["claude".to_string()]),
+            ]),
+        };
+
+        assert!(detect_agent_with_source(10, &source).is_none());
+    }
 
     #[test]
     fn reads_self_cmdline() {


### PR DESCRIPTION
## Summary
- Refactors agent detection behind a small process-source abstraction so scope behavior is unit-testable.
- Keeps production detection on `/proc`, but scans only the queried PTY root and its descendants.
- Adds regression tests proving unrelated host `claude` processes are ignored while PTY-descendant agents are detected.
- Updates the stale E2E escape-hatch comment that still described the detector as host-global.

## Root Cause
The issue tracked host-global attribution risk. Current detection already walks the PTY process tree, but it lacked focused tests for that contract and still had stale documentation claiming host-global behavior. Without a regression test, the detector could drift back to global matching.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml agent::detector::tests`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- pre-push hook: `npm test`
- `git diff --check`

Fixes #71.