### PR TITLE
fix(security): remove inline style csp allowance

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost; font-src 'self'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: asset: https://asset.localhost; font-src 'self'"
     }
   },
   "bundle": {

--- a/src/features/editor/theme/catppuccin.test.ts
+++ b/src/features/editor/theme/catppuccin.test.ts
@@ -1,23 +1,58 @@
-import { describe, test, expect } from 'vitest'
-import { catppuccinMocha } from './catppuccin'
+import { afterEach, describe, test, expect } from 'vitest'
+import { catppuccinMocha, getDocumentCspNonce } from './catppuccin'
+
+const removeNonceElements = (): void => {
+  document
+    .querySelectorAll('[data-testid="csp-nonce-fixture"]')
+    .forEach((element) => element.remove())
+}
+
+const getThemeExtensions = (): readonly unknown[] => {
+  expect(Array.isArray(catppuccinMocha)).toBe(true)
+
+  if (!Array.isArray(catppuccinMocha)) {
+    throw new Error('Expected catppuccinMocha to export an extension array')
+  }
+
+  return catppuccinMocha
+}
 
 describe('catppuccin theme', () => {
+  afterEach(() => {
+    removeNonceElements()
+  })
+
   test('exports a valid extension', () => {
     expect(catppuccinMocha).toBeDefined()
     expect(Array.isArray(catppuccinMocha)).toBe(true)
   })
 
   test('extension array has expected length', () => {
-    expect(catppuccinMocha).toHaveLength(2)
+    expect(getThemeExtensions().length).toBeGreaterThanOrEqual(2)
   })
 
   test('extension is an array of theme components', () => {
-    // Extension is an array of [theme, syntaxHighlighting]
-    // We can't directly index the Extension type, but we can verify structure
-    const extensionArray = catppuccinMocha as unknown[]
+    // Extension is at least [theme, syntaxHighlighting]. Production Tauri
+    // builds add a CodeMirror CSP nonce extension when a nonce is present.
+    const extensionArray = getThemeExtensions()
 
-    expect(extensionArray).toHaveLength(2)
+    expect(extensionArray.length).toBeGreaterThanOrEqual(2)
     expect(extensionArray[0]).toBeDefined()
     expect(extensionArray[1]).toBeDefined()
+  })
+
+  test('reads a document CSP nonce from a script element', () => {
+    const script = document.createElement('script')
+    script.dataset.testid = 'csp-nonce-fixture'
+    script.nonce = 'nonce-from-tauri'
+    document.head.append(script)
+
+    expect(getDocumentCspNonce()).toBe('nonce-from-tauri')
+  })
+
+  test('returns null when no CSP nonce is present', () => {
+    removeNonceElements()
+
+    expect(getDocumentCspNonce()).toBeNull()
   })
 })

--- a/src/features/editor/theme/catppuccin.ts
+++ b/src/features/editor/theme/catppuccin.ts
@@ -127,10 +127,26 @@ const highlightStyle = HighlightStyle.define([
   { tag: t.string, color: colors.green },
 ])
 
+export const getDocumentCspNonce = (): string | null => {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const nonceElement = document.querySelector<HTMLElement>(
+    'script[nonce], style[nonce], link[nonce]'
+  )
+  const nonce = nonceElement?.nonce
+
+  return nonce && nonce.length > 0 ? nonce : null
+}
+
+const cspNonce = getDocumentCspNonce()
+
 /**
  * Combined Catppuccin Mocha theme extension for CodeMirror
  */
 export const catppuccinMocha: Extension = [
   theme,
   syntaxHighlighting(highlightStyle),
+  ...(cspNonce ? [EditorView.cspNonce.of(cspNonce)] : []),
 ]


### PR DESCRIPTION
## Summary
- Removes `unsafe-inline` from the Tauri `style-src` CSP.
- Passes Tauri's generated document nonce into CodeMirror via `EditorView.cspNonce` so runtime style modules can mount under a strict CSP.
- Adds tests for document nonce discovery in the editor theme.

## Root Cause
The original CSP allowed inline styles for Shiki token output. Shiki has since been replaced by CodeMirror, but CodeMirror still mounts runtime style modules; without passing the CSP nonce to CodeMirror, removing `unsafe-inline` would break those generated styles.

## Validation
- `npx vitest run src/features/editor/theme/catppuccin.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `CI=true npx tauri build --debug --no-bundle`
- `npm test`
- `git push -u origin fix/28-csp-inline-styles` (pre-push `npm test`)
- `git diff --check`

Fixes #28.