### PR TITLE
fix(diff): stabilize hunk ids and rename metadata

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,7 +43,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 1        | 0    | 2026-04-14   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 27       | 19   | 2026-05-02   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 28       | 20   | 2026-05-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 42       | 17   | 2026-05-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 12       | 2    | 2026-04-30   |

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-05-01
-ref_count: 19
+ref_count: 20
 ---
 
 # Testing Gaps
@@ -259,3 +259,12 @@ filesystem scope restrictions).
 - **Finding:** `extractHunkPatch` calls `hunks.shift()` to drop the pre-`@@` header block, then returns `hunks[index]`. The positive test exercised index 1 (a mid-array hunk) and several null-return cases. Index 0 — the most sensitive boundary, where an off-by-one in `shift()` would surface — was not tested. A future refactor that removed the shift (or changed the split shape) would silently return the file-header block as the patch on index-0 calls; `git apply` would either fail or apply garbage. The mid-array test would still pass because `hunks[1]` (now the first real hunk in the regressed layout) would satisfy the existing assertions. Same finding-class as #7 — uncovered branch in a multi-step transform; a positive test for the index-0 path is the small explicit regression guard.
 - **Fix:** Added `extracts the first hunk (index 0) — the boundary case after shift()` test asserting the index-0 patch contains `@@ -1,2 +1,2 @@` and `+added first` (and excludes the second hunk's markers). No new fixture needed — the existing `diffText` already has two hunks. The comment documents WHY the index-0 case is the critical boundary so a future maintainer can't dismiss the test as redundant with the index-1 test.
 - **Commit:** _(see git log for the round-3 fix commit)_
+
+### 28. Symmetric branch added without parallel test fixture
+
+- **Source:** github-claude | PR #131 round 1 | 2026-05-02
+- **Severity:** LOW
+- **File:** `src-tauri/src/git/mod.rs`
+- **Finding:** PR #131 added rename-metadata parsing (`rename from`/`rename to` header pair) AND symmetric copy-metadata parsing (`copy from`/`copy to`) in the same `or_else` arm. The new test only exercised the rename fixture; the structurally-identical copy branch had no parallel fixture, so an edge-case regression in copy-header parsing (e.g. casing, whitespace, future git format change) would silently produce `old_path: None` / `new_path: None` with no failing assertion. Same finding-class as #7 (uncovered guard branch) — adding a sibling case to a multi-branch decision needs sibling test coverage.
+- **Fix:** Added `test_parse_git_diff_copy_metadata` that mirrors the rename test exactly except for the header verbs (`copy from`/`copy to`) and fixture file names (`template.txt` → `copy.txt`). Same assertions on `old_path`, `new_path`, hunk count, and stable hunk id.
+- **Commit:** _(see git log for the round-1 fix commit)_

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1273,13 +1273,7 @@ rename to new_name.txt
 
     #[test]
     fn test_parse_git_diff_copy_metadata() {
-        // Mirror of the rename test for the `copy from`/`copy to`
-        // branch. Git emits this header pair when a file is copied
-        // (typically from `git diff --find-copies-harder` or when
-        // both files are present and content-similar). The structure
-        // is identical to rename, so without this test the parser
-        // could silently regress on edge-case header formats with no
-        // failing assertion.
+        // Guards copy-from/copy-to path — structurally identical to rename but needs its own fixture.
         let diff = r#"diff --git a/template.txt b/copy.txt
 similarity index 92%
 copy from template.txt

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -430,9 +430,21 @@ fn parse_git_diff(output: &str, file_path: &str) -> FileDiff {
     let mut current_hunk: Option<DiffHunk> = None;
     let mut old_line_num = 0u32;
     let mut new_line_num = 0u32;
+    let mut old_path: Option<String> = None;
+    let mut new_path: Option<String> = None;
 
     for line in output.lines() {
-        if line.starts_with("@@") {
+        if let Some(path) = line
+            .strip_prefix("rename from ")
+            .or_else(|| line.strip_prefix("copy from "))
+        {
+            old_path = Some(path.to_string());
+        } else if let Some(path) = line
+            .strip_prefix("rename to ")
+            .or_else(|| line.strip_prefix("copy to "))
+        {
+            new_path = Some(path.to_string());
+        } else if line.starts_with("@@") {
             // Save previous hunk if exists
             if let Some(hunk) = current_hunk.take() {
                 hunks.push(hunk);
@@ -458,7 +470,7 @@ fn parse_git_diff(output: &str, file_path: &str) -> FileDiff {
             new_line_num = new_start;
 
             current_hunk = Some(DiffHunk {
-                id: format!("hunk-{}", hunks.len()),
+                id: format!("hunk-{}-{}", old_start, new_start),
                 header,
                 old_start,
                 old_lines,
@@ -515,8 +527,8 @@ fn parse_git_diff(output: &str, file_path: &str) -> FileDiff {
 
     FileDiff {
         file_path: file_path.to_string(),
-        old_path: None,
-        new_path: None,
+        old_path,
+        new_path,
         hunks,
     }
 }
@@ -1170,6 +1182,7 @@ mod tests {
         assert_eq!(file_diff.hunks.len(), 1);
 
         let hunk = &file_diff.hunks[0];
+        assert_eq!(hunk.id, "hunk-1-1");
         assert_eq!(hunk.old_start, 1);
         assert_eq!(hunk.old_lines, 3);
         assert_eq!(hunk.new_start, 1);
@@ -1202,10 +1215,12 @@ mod tests {
         assert_eq!(file_diff.hunks.len(), 2);
 
         let hunk1 = &file_diff.hunks[0];
+        assert_eq!(hunk1.id, "hunk-1-1");
         assert_eq!(hunk1.old_start, 1);
         assert_eq!(hunk1.lines.len(), 3);
 
         let hunk2 = &file_diff.hunks[1];
+        assert_eq!(hunk2.id, "hunk-10-11");
         assert_eq!(hunk2.old_start, 10);
         assert_eq!(hunk2.lines.len(), 2);
     }
@@ -1234,6 +1249,26 @@ mod tests {
         assert_eq!(hunk.lines.len(), 3);
         assert!(matches!(hunk.lines[1].line_type, DiffLineType::Removed));
         assert_eq!(hunk.lines[1].content, "remove this");
+    }
+
+    #[test]
+    fn test_parse_git_diff_rename_metadata() {
+        let diff = r#"diff --git a/old_name.txt b/new_name.txt
+similarity index 88%
+rename from old_name.txt
+rename to new_name.txt
+@@ -1,2 +1,2 @@
+ line 1
+-old
++new
+"#;
+        let file_diff = parse_git_diff(diff, "new_name.txt");
+
+        assert_eq!(file_diff.file_path, "new_name.txt");
+        assert_eq!(file_diff.old_path, Some("old_name.txt".to_string()));
+        assert_eq!(file_diff.new_path, Some("new_name.txt".to_string()));
+        assert_eq!(file_diff.hunks.len(), 1);
+        assert_eq!(file_diff.hunks[0].id, "hunk-1-1");
     }
 
     #[test]

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1272,6 +1272,33 @@ rename to new_name.txt
     }
 
     #[test]
+    fn test_parse_git_diff_copy_metadata() {
+        // Mirror of the rename test for the `copy from`/`copy to`
+        // branch. Git emits this header pair when a file is copied
+        // (typically from `git diff --find-copies-harder` or when
+        // both files are present and content-similar). The structure
+        // is identical to rename, so without this test the parser
+        // could silently regress on edge-case header formats with no
+        // failing assertion.
+        let diff = r#"diff --git a/template.txt b/copy.txt
+similarity index 92%
+copy from template.txt
+copy to copy.txt
+@@ -1,2 +1,2 @@
+ base line
+-original
++derived
+"#;
+        let file_diff = parse_git_diff(diff, "copy.txt");
+
+        assert_eq!(file_diff.file_path, "copy.txt");
+        assert_eq!(file_diff.old_path, Some("template.txt".to_string()));
+        assert_eq!(file_diff.new_path, Some("copy.txt".to_string()));
+        assert_eq!(file_diff.hunks.len(), 1);
+        assert_eq!(file_diff.hunks[0].id, "hunk-1-1");
+    }
+
+    #[test]
     fn test_parse_hunk_range() {
         assert_eq!(parse_hunk_range("-102,7"), (102, 7));
         assert_eq!(parse_hunk_range("+102,6"), (102, 6));

--- a/src/features/diff/types/index.ts
+++ b/src/features/diff/types/index.ts
@@ -29,7 +29,7 @@ export interface FileDiff {
 
 /** A single hunk within a diff */
 export interface DiffHunk {
-  id: string // unique identifier (e.g. 'hunk-0')
+  id: string // unique identifier (e.g. 'hunk-1-1')
   header: string // @@ -102,7 +102,6 @@
   oldStart: number
   oldLines: number

--- a/src/features/diff/types/index.ts
+++ b/src/features/diff/types/index.ts
@@ -22,8 +22,8 @@ export interface SelectedDiffFile {
 /** Parsed diff for a single file */
 export interface FileDiff {
   filePath: string
-  oldPath?: string // for renames
-  newPath?: string // for renames
+  oldPath?: string // for renames and copies
+  newPath?: string // for renames and copies
   hunks: DiffHunk[]
 }
 


### PR DESCRIPTION
## Summary
- Populates `FileDiff.oldPath` and `newPath` from Git rename/copy metadata lines.
- Derives Rust diff hunk IDs from parsed old/new hunk starts instead of list position.
- Updates the TS diff hunk ID example to match the backend output.

## Root Cause
Issue #50 tracked deferred diff-viewer edge cases from PR #47. Rename metadata was parsed by Git but not surfaced in `FileDiff`, and hunk IDs were positional, so React could reuse rows incorrectly when hunk count stayed stable but content changed.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml test_parse_git_diff`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `git diff --check`
- `git push -u origin fix/50-diff-rename-hunk-ids` (pre-push `npm test`)

Refs #50.