### PR TITLE
fix(debug): centralize debug file logging

### DIFF
--- a/src-tauri/src/agent/watcher.rs
+++ b/src-tauri/src/agent/watcher.rs
@@ -665,12 +665,11 @@ pub async fn start_agent_watcher(
         .join("status.json");
 
     // Use the structured logger (already configured for the rest of this
-    // file) for startup diagnostics. The earlier debug-only file log at
-    // `/tmp/vimeflow-debug.log` was dropped: a fixed predictable path
-    // under /tmp without O_EXCL follows symlinks, allowing a local actor
-    // on a shared system to redirect appends, and Linux's default umask
-    // 022 left the file world-readable. Run with RUST_LOG=debug to see
-    // these lines.
+    // file) for startup diagnostics. The earlier ad-hoc debug-only file
+    // append was dropped: a fixed predictable temp path without O_EXCL
+    // follows symlinks, allowing a local actor on a shared system to
+    // redirect appends, and Linux's default umask 022 left the file
+    // world-readable. Run with RUST_LOG=debug to see these lines.
     log::debug!(
         "Watcher startup detail: session={}, cwd={}, path={}",
         session_id,

--- a/src-tauri/src/debug.rs
+++ b/src-tauri/src/debug.rs
@@ -12,14 +12,22 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(debug_assertions)]
 const DEBUG_LOG_NAME: &str = "vimeflow-debug.log";
 #[cfg(debug_assertions)]
-const ROTATED_DEBUG_LOG_NAME: &str = "vimeflow-debug.log.1";
-#[cfg(debug_assertions)]
 const MAX_DEBUG_LOG_BYTES: u64 = 1024 * 1024;
 
 /// Debug-only file logger. Compiles to a no-op in release builds.
 #[cfg(debug_assertions)]
 pub(crate) fn debug_log(tag: &str, msg: &str) {
-    if let Err(error) = append_debug_log(&debug_log_path(), tag, msg, MAX_DEBUG_LOG_BYTES) {
+    let Some(path) = debug_log_path() else {
+        // Fail-closed when no per-user data directory is available. The
+        // previous fallback to `std::env::temp_dir()` recreated a
+        // predictable shared-temp path (`<tmp>/vimeflow/logs/...`) that
+        // a local attacker could pre-seed with a symlink to redirect
+        // append writes — exactly the security regression this PR aims
+        // to remove. Better to drop debug output entirely than to write
+        // it to an attacker-controlled path.
+        return;
+    };
+    if let Err(error) = append_debug_log(&path, tag, msg, MAX_DEBUG_LOG_BYTES) {
         log::warn!("failed to write debug log: {}", error);
     }
 }
@@ -28,12 +36,8 @@ pub(crate) fn debug_log(tag: &str, msg: &str) {
 pub(crate) fn debug_log(_tag: &str, _msg: &str) {}
 
 #[cfg(debug_assertions)]
-fn debug_log_path() -> PathBuf {
-    debug_log_path_from_base(
-        dirs::data_local_dir()
-            .unwrap_or_else(std::env::temp_dir)
-            .as_path(),
-    )
+fn debug_log_path() -> Option<PathBuf> {
+    dirs::data_local_dir().map(|base| debug_log_path_from_base(base.as_path()))
 }
 
 #[cfg(debug_assertions)]
@@ -64,7 +68,20 @@ fn append_debug_log(path: &Path, tag: &str, msg: &str, max_bytes: u64) -> io::Re
         .map(|duration| duration.as_secs())
         .unwrap_or(0);
 
-    writeln!(file, "[{secs}] [{tag}] {msg}")
+    // Sanitize newlines/CRs so a tag or msg containing embedded line
+    // terminators (e.g. a cwd with `\n` — POSIX paths permit any byte
+    // except NUL) can't inject phantom rows or break log-parsing
+    // tooling. Cosmetic protection only since the file is 0600 in a
+    // debug-only build, but the cost is trivial and the corrupted-tail
+    // failure mode is hard to diagnose otherwise.
+    let safe_tag = sanitize_for_log(tag);
+    let safe_msg = sanitize_for_log(msg);
+    writeln!(file, "[{secs}] [{safe_tag}] {safe_msg}")
+}
+
+#[cfg(debug_assertions)]
+fn sanitize_for_log(input: &str) -> String {
+    input.replace('\n', "\\n").replace('\r', "\\r")
 }
 
 #[cfg(debug_assertions)]
@@ -77,7 +94,11 @@ fn rotate_debug_log_if_needed(path: &Path, max_bytes: u64) -> io::Result<()> {
         return Ok(());
     }
 
-    let rotated_path = path.with_file_name(ROTATED_DEBUG_LOG_NAME);
+    // Derive the rotated name from the path itself rather than a
+    // separate constant — eliminates the silent-stale failure mode
+    // where renaming `DEBUG_LOG_NAME` would leave the rotated form
+    // pointing at the old name.
+    let rotated_path = path.with_extension("log.1");
     match fs::remove_file(&rotated_path) {
         Ok(()) => {}
         Err(error) if error.kind() == io::ErrorKind::NotFound => {}
@@ -114,6 +135,24 @@ mod tests {
 
         let content = fs::read_to_string(path).expect("failed to read debug log");
         assert!(content.contains("[pty] spawned"));
+    }
+
+    #[test]
+    fn append_debug_log_sanitizes_newlines_in_tag_and_msg() {
+        // POSIX paths can contain `\n`. A cwd embedded in `msg` could
+        // therefore inject phantom log lines. Sanitizer escapes both
+        // `\n` and `\r` so each call produces exactly one log line.
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let path = temp_dir.path().join("vimeflow-debug.log");
+
+        append_debug_log(&path, "ta\ng", "first\nsecond\rthird", MAX_DEBUG_LOG_BYTES)
+            .expect("failed to append debug log");
+
+        let content = fs::read_to_string(&path).expect("failed to read debug log");
+        // Exactly one trailing newline (from writeln!), no embedded
+        // newlines from the inputs.
+        assert_eq!(content.matches('\n').count(), 1);
+        assert!(content.contains("[ta\\ng] first\\nsecond\\rthird"));
     }
 
     #[test]

--- a/src-tauri/src/debug.rs
+++ b/src-tauri/src/debug.rs
@@ -1,0 +1,137 @@
+//! Shared debug-only file logging utilities.
+
+#[cfg(debug_assertions)]
+use std::fs::{self, OpenOptions};
+#[cfg(debug_assertions)]
+use std::io::{self, Write};
+#[cfg(debug_assertions)]
+use std::path::{Path, PathBuf};
+#[cfg(debug_assertions)]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(debug_assertions)]
+const DEBUG_LOG_NAME: &str = "vimeflow-debug.log";
+#[cfg(debug_assertions)]
+const ROTATED_DEBUG_LOG_NAME: &str = "vimeflow-debug.log.1";
+#[cfg(debug_assertions)]
+const MAX_DEBUG_LOG_BYTES: u64 = 1024 * 1024;
+
+/// Debug-only file logger. Compiles to a no-op in release builds.
+#[cfg(debug_assertions)]
+pub(crate) fn debug_log(tag: &str, msg: &str) {
+    if let Err(error) = append_debug_log(&debug_log_path(), tag, msg, MAX_DEBUG_LOG_BYTES) {
+        log::warn!("failed to write debug log: {}", error);
+    }
+}
+
+#[cfg(not(debug_assertions))]
+pub(crate) fn debug_log(_tag: &str, _msg: &str) {}
+
+#[cfg(debug_assertions)]
+fn debug_log_path() -> PathBuf {
+    debug_log_path_from_base(
+        dirs::data_local_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .as_path(),
+    )
+}
+
+#[cfg(debug_assertions)]
+fn debug_log_path_from_base(base_dir: &Path) -> PathBuf {
+    base_dir.join("vimeflow").join("logs").join(DEBUG_LOG_NAME)
+}
+
+#[cfg(debug_assertions)]
+fn append_debug_log(path: &Path, tag: &str, msg: &str, max_bytes: u64) -> io::Result<()> {
+    rotate_debug_log_if_needed(path, max_bytes)?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(path)?;
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+
+    writeln!(file, "[{secs}] [{tag}] {msg}")
+}
+
+#[cfg(debug_assertions)]
+fn rotate_debug_log_if_needed(path: &Path, max_bytes: u64) -> io::Result<()> {
+    let Ok(metadata) = fs::metadata(path) else {
+        return Ok(());
+    };
+
+    if metadata.len() < max_bytes {
+        return Ok(());
+    }
+
+    let rotated_path = path.with_file_name(ROTATED_DEBUG_LOG_NAME);
+    match fs::remove_file(&rotated_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+
+    fs::rename(path, rotated_path)
+}
+
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_log_path_uses_user_data_vimeflow_logs_file() {
+        let base_dir = Path::new("local-data");
+        let path = debug_log_path_from_base(base_dir);
+
+        assert!(path.starts_with(base_dir));
+        assert!(path.ends_with(
+            Path::new("vimeflow")
+                .join("logs")
+                .join("vimeflow-debug.log")
+        ));
+    }
+
+    #[test]
+    fn append_debug_log_creates_parent_directory_and_line() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let path = temp_dir.path().join("logs").join("vimeflow-debug.log");
+
+        append_debug_log(&path, "pty", "spawned", MAX_DEBUG_LOG_BYTES)
+            .expect("failed to append debug log");
+
+        let content = fs::read_to_string(path).expect("failed to read debug log");
+        assert!(content.contains("[pty] spawned"));
+    }
+
+    #[test]
+    fn append_debug_log_rotates_existing_large_file() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let path = temp_dir.path().join("vimeflow-debug.log");
+        let rotated_path = temp_dir.path().join("vimeflow-debug.log.1");
+        fs::write(&path, "old log").expect("failed to seed debug log");
+
+        append_debug_log(&path, "bridge", "created", 1)
+            .expect("failed to append rotated debug log");
+
+        let rotated_content =
+            fs::read_to_string(rotated_path).expect("failed to read rotated debug log");
+        let current_content = fs::read_to_string(path).expect("failed to read current debug log");
+
+        assert_eq!(rotated_content, "old log");
+        assert!(current_content.contains("[bridge] created"));
+        assert!(!current_content.contains("old log"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+mod debug;
 mod filesystem;
 mod git;
 mod terminal;

--- a/src-tauri/src/terminal/commands.rs
+++ b/src-tauri/src/terminal/commands.rs
@@ -6,30 +6,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, State};
 
+use crate::debug::debug_log;
+
 use super::state::{ManagedSession, PtyState, RingBuffer};
 use super::types::*;
-
-/// Debug-only file logger. Compiles to no-op in release builds.
-/// Writes to /tmp/vimeflow-debug.log for diagnosing IPC and bridge issues.
-#[cfg(debug_assertions)]
-fn debug_log(tag: &str, msg: &str) {
-    use std::io::Write;
-    use std::time::SystemTime;
-    if let Ok(mut f) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("/tmp/vimeflow-debug.log")
-    {
-        let secs = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-        let _ = writeln!(f, "[{secs}] [{tag}] {msg}");
-    }
-}
-
-#[cfg(not(debug_assertions))]
-fn debug_log(_tag: &str, _msg: &str) {}
 
 fn cleanup_generated_bridge_dir(dir: Option<&std::path::Path>) {
     if let Some(dir) = dir {


### PR DESCRIPTION
## Summary
- Adds a shared Rust `debug` module for debug-only file logging.
- Moves terminal debug logging off the hardcoded `/tmp` path into the user-local data directory.
- Adds bounded rotation for `vimeflow-debug.log` and focused tests for path construction, append, and rotation.
- Updates the stale watcher comment that still named the old fixed temp debug log path.

## Root Cause
Issue #61 tracked ad-hoc backend debug logging: terminal commands owned a private `/tmp/vimeflow-debug.log` appender, while watcher diagnostics had already moved to structured logs. That left duplicated policy, a non-portable temp path, and an unbounded file.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml debug`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml --release`
- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `git diff --check`
- `git push -u origin fix/61-shared-debug-logger` (pre-push `npm test`)

Fixes #61.