### PR TITLE
feat(harness): pass visual references to coder prompts

### DIFF
--- a/harness/agent.py
+++ b/harness/agent.py
@@ -263,9 +263,9 @@ async def run_feature_iteration(
     if prompt_override:
         prompt = prompt_override
     elif findings:
-        prompt = get_coding_prompt_with_findings(findings)
+        prompt = get_coding_prompt_with_findings(findings, feature)
     else:
-        prompt = get_coding_prompt()
+        prompt = get_coding_prompt(feature)
 
     async with session:
         status, response = await run_agent_session(session, prompt, project_dir, role="coder")
@@ -431,7 +431,7 @@ async def run_autonomous_agent(
                     client_kind, role="coder",
                     project_dir=project_dir, model=model, sandbox=sandbox,
                 )
-                prompt = get_coding_prompt()
+                prompt = get_coding_prompt(feature)
 
                 async with session:
                     status, response = await run_agent_session(session, prompt, project_dir, role="coder")

--- a/harness/prompts.py
+++ b/harness/prompts.py
@@ -20,8 +20,101 @@ def get_initializer_prompt() -> str:
     return load_prompt("initializer_prompt")
 
 
-def get_coding_prompt() -> str:
-    return load_prompt("coding_prompt")
+def _list_items(values: object) -> list[str]:
+    if not isinstance(values, list):
+        return []
+
+    return [value.strip() for value in values if isinstance(value, str) and value.strip()]
+
+
+def get_visual_reference_section(feature: dict | None) -> str:
+    """Build the optional visual-reference section for a selected feature."""
+    if not feature:
+        return ""
+
+    design_ref = feature.get("design_ref")
+    if not isinstance(design_ref, dict):
+        return ""
+
+    spec_paths = _list_items(design_ref.get("spec_paths"))
+    screenshot_paths = _list_items(design_ref.get("screenshot_paths"))
+    prototype_url = design_ref.get("prototype_url")
+    surface = design_ref.get("surface")
+
+    visual_review = feature.get("visual_review")
+    fixture_url = None
+    viewports: list[str] = []
+    if isinstance(visual_review, dict):
+        maybe_fixture_url = visual_review.get("fixture_url")
+        if isinstance(maybe_fixture_url, str) and maybe_fixture_url.strip():
+            fixture_url = maybe_fixture_url
+
+        maybe_viewports = visual_review.get("viewports")
+        if isinstance(maybe_viewports, list):
+            for viewport in maybe_viewports:
+                if isinstance(viewport, dict):
+                    name = viewport.get("name")
+                    width = viewport.get("width")
+                    height = viewport.get("height")
+                    if (
+                        isinstance(name, str)
+                        and isinstance(width, int)
+                        and isinstance(height, int)
+                    ):
+                        viewports.append(f"{name} ({width}x{height})")
+                    elif isinstance(name, str):
+                        viewports.append(name)
+
+    if not (
+        spec_paths
+        or screenshot_paths
+        or prototype_url
+        or surface
+        or fixture_url
+        or viewports
+    ):
+        return ""
+
+    lines = [
+        "## Visual reference",
+        "",
+        "This feature has a visual target. Before implementing, inspect the relevant local assets.",
+    ]
+
+    if isinstance(surface, str) and surface.strip():
+        lines.extend(["", f"- Surface: `{surface}`"])
+
+    if isinstance(prototype_url, str) and prototype_url.strip():
+        lines.extend(["", f"- Prototype URL: {prototype_url}"])
+
+    if spec_paths:
+        lines.extend(["", "- Design specs:"])
+        lines.extend(f"  - `{path}`" for path in spec_paths)
+
+    if screenshot_paths:
+        lines.extend(["", "- Reference screenshots:"])
+        lines.extend(f"  - `{path}`" for path in screenshot_paths)
+
+    if fixture_url:
+        lines.extend(["", f"- Visual fixture URL: `{fixture_url}`"])
+
+    if viewports:
+        lines.extend(["", "- Visual review viewports:"])
+        lines.extend(f"  - {viewport}" for viewport in viewports)
+
+    lines.extend(
+        [
+            "",
+            "Use these assets as ground truth for spacing, hierarchy, depth, "
+            "and state. Do not rely only on prose in app_spec.md.",
+        ]
+    )
+
+    return "\n".join(lines) + "\n\n---\n\n"
+
+
+def get_coding_prompt(feature: dict | None = None) -> str:
+    return get_visual_reference_section(feature) + load_prompt("coding_prompt")
 
 
 def get_reviewer_prompt(findings: str) -> str:
@@ -30,9 +123,9 @@ def get_reviewer_prompt(findings: str) -> str:
     return template.replace("{findings}", findings)
 
 
-def get_coding_prompt_with_findings(findings: str) -> str:
+def get_coding_prompt_with_findings(findings: str, feature: dict | None = None) -> str:
     """Load coding prompt with review findings appended for fix iterations."""
-    base = load_prompt("coding_prompt")
+    base = get_coding_prompt(feature)
     review_section = (
         "\n\n---\n\n"
         "## REVIEW FINDINGS FROM PREVIOUS ITERATION\n\n"

--- a/harness/prompts/initializer_prompt.md
+++ b/harness/prompts/initializer_prompt.md
@@ -29,6 +29,31 @@ Based on `app_spec.md`, create `feature_list.json` with detailed, phased feature
 ]
 ```
 
+For UI features, add optional visual metadata so later Coder and Visual Reviewer sessions receive the same visual target:
+
+```json
+{
+  "design_ref": {
+    "surface": "agent_status_sidebar",
+    "prototype_url": "https://example.invalid/prototype",
+    "spec_paths": [
+      "docs/design/UNIFIED.md",
+      "docs/design/agent_status_sidebar/code.html"
+    ],
+    "screenshot_paths": [
+      "docs/design/agent_status_sidebar/references/test-results/desktop-1440x900.png"
+    ]
+  },
+  "visual_review": {
+    "mode": "required",
+    "fixture_url": "/__visual__/agent-status/test-results",
+    "viewports": [{ "name": "desktop-1440x900", "width": 1440, "height": 900 }],
+    "max_changed_ratio": 0.1,
+    "allow_model_only": false
+  }
+}
+```
+
 **Phase ordering depends on what app_spec.md describes.** Typical phases:
 
 1. **Scaffold** — Project setup, configs, dependencies
@@ -46,6 +71,9 @@ Based on `app_spec.md`, create `feature_list.json` with detailed, phased feature
 - ALL features start with `"passes": false`
 - Each feature should be completable in one agent session
 - Cover every feature in app_spec.md
+- If a feature renders user-visible UI, set `visual_review.mode` to `"required"` and populate `design_ref` from matching local files under `docs/design/`
+- If a frontend feature has no rendered visual surface, set `visual_review.mode` to `"advisory"` or `"skip"` and include a short `reason`
+- If any feature has required or advisory visual review, append one final synthetic `"Design coherence pass"` feature that depends on all visual UI features and compares the composed screen as a whole
 
 **CRITICAL:** Never remove or edit features in future sessions. Features can ONLY have their `passes` field changed to `true`.
 

--- a/harness/test_prompts.py
+++ b/harness/test_prompts.py
@@ -1,0 +1,66 @@
+"""Tests for harness prompt assembly."""
+
+from __future__ import annotations
+
+from prompts import get_coding_prompt, get_coding_prompt_with_findings
+
+
+def test_get_coding_prompt_omits_visual_section_without_design_ref() -> None:
+    prompt = get_coding_prompt({"id": 1, "description": "Backend feature"})
+
+    assert not prompt.startswith("## Visual reference")
+    assert "## YOUR ROLE - CODING AGENT" in prompt
+
+
+def test_get_coding_prompt_prepends_visual_reference_section() -> None:
+    feature = {
+        "id": 8,
+        "description": "Visual feature",
+        "design_ref": {
+            "surface": "agent_status_sidebar",
+            "prototype_url": "https://example.invalid/prototype",
+            "spec_paths": [
+                "docs/design/UNIFIED.md",
+                "docs/design/agent_status_sidebar/code.html",
+            ],
+            "screenshot_paths": [
+                "docs/design/agent_status_sidebar/references/test-results/desktop-1440x900.png",
+            ],
+        },
+        "visual_review": {
+            "fixture_url": "/__visual__/agent-status/test-results",
+            "viewports": [
+                {"name": "desktop-1440x900", "width": 1440, "height": 900},
+            ],
+        },
+    }
+
+    prompt = get_coding_prompt(feature)
+
+    assert prompt.startswith("## Visual reference")
+    assert "- Surface: `agent_status_sidebar`" in prompt
+    assert "- Prototype URL: https://example.invalid/prototype" in prompt
+    assert "- `docs/design/UNIFIED.md`" in prompt
+    assert "- `docs/design/agent_status_sidebar/code.html`" in prompt
+    assert (
+        "- `docs/design/agent_status_sidebar/references/test-results/desktop-1440x900.png`"
+        in prompt
+    )
+    assert "- Visual fixture URL: `/__visual__/agent-status/test-results`" in prompt
+    assert "  - desktop-1440x900 (1440x900)" in prompt
+    assert "## YOUR ROLE - CODING AGENT" in prompt
+
+
+def test_get_coding_prompt_with_findings_keeps_visual_reference_first() -> None:
+    feature = {
+        "design_ref": {
+            "screenshot_paths": ["docs/design/chat_or_main/screen.png"],
+        },
+    }
+
+    prompt = get_coding_prompt_with_findings("VIS-1: spacing mismatch", feature)
+
+    assert prompt.startswith("## Visual reference")
+    assert "- `docs/design/chat_or_main/screen.png`" in prompt
+    assert "## REVIEW FINDINGS FROM PREVIOUS ITERATION" in prompt
+    assert "VIS-1: spacing mismatch" in prompt


### PR DESCRIPTION
## Summary

- Add optional `design_ref` and `visual_review` metadata guidance to the harness initializer prompt.
- Prepend a generated Visual reference section to coder prompts when the selected feature carries design reference metadata.
- Keep the visual reference ahead of review findings on retry prompts so visual context remains first.
- Add prompt assembly tests for no-reference, visual-reference, and findings-retry paths.

## Validation

- `python3 -m pytest harness/test_prompts.py harness/test_run_autonomous_agent.py`
- `python3 -m pytest harness`
- `python3 -m pytest harness/test_prompts.py`
- `npm run format:check`
- `npm run lint`
- `python3 -m compileall harness`
- `git diff --check`
- Pre-push `npm test` passed: 108 test files, 1524 passed, 3 skipped.

Refs #76