### PR TITLE
feat(orchestrator): add agent dispatcher

### DIFF
--- a/src-tauri/src/orchestrator/mod.rs
+++ b/src-tauri/src/orchestrator/mod.rs
@@ -1,10 +1,15 @@
+pub mod runner;
 pub mod runtime;
 pub mod state;
 pub mod tracker;
 pub mod workflow;
 pub mod workspace;
 
-pub use runtime::{ClaimBatch, OrchestratorRuntime, OrchestratorRuntimeError};
+pub use runner::{AgentRun, AgentRunRequest, AgentRunner, AgentRunnerError, CommandAgentRunner};
+pub use runtime::{
+    ClaimBatch, DispatchBatch, DispatchFailure, DispatchedRun, OrchestratorRuntime,
+    OrchestratorRuntimeError,
+};
 pub use state::{
     OrchestratorEvent, OrchestratorRun, OrchestratorSnapshot, OrchestratorState, QueueIssue,
     RetryEntry, RunStatus, StateError,

--- a/src-tauri/src/orchestrator/runner.rs
+++ b/src-tauri/src/orchestrator/runner.rs
@@ -1,0 +1,208 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::thread;
+
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::orchestrator::{OrchestratorIssue, WorkspacePlan};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRunRequest {
+    pub issue: OrchestratorIssue,
+    pub attempt_number: u32,
+    pub workspace: WorkspacePlan,
+    pub command: String,
+    pub args: Vec<String>,
+    pub prompt: String,
+    pub prompt_file: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRun {
+    pub run_id: String,
+    pub process_id: Option<u32>,
+    pub stdout_log_path: Option<PathBuf>,
+    pub stderr_log_path: Option<PathBuf>,
+}
+
+pub trait AgentRunner {
+    fn start(&self, request: AgentRunRequest) -> Result<AgentRun, AgentRunnerError>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CommandAgentRunner;
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum AgentRunnerError {
+    #[error("failed to start agent: {message}")]
+    Start { message: String },
+    #[error("failed to write prompt to agent stdin: {message}")]
+    Stdin { message: String },
+}
+
+impl AgentRunner for CommandAgentRunner {
+    fn start(&self, request: AgentRunRequest) -> Result<AgentRun, AgentRunnerError> {
+        let Some(log_dir) = request.prompt_file.parent() else {
+            return Err(AgentRunnerError::Start {
+                message: "prompt file has no parent directory".to_string(),
+            });
+        };
+        let stdout_log_path = log_dir.join("stdout.log");
+        let stderr_log_path = log_dir.join("stderr.log");
+        let stdout_log =
+            File::create(&stdout_log_path).map_err(|error| AgentRunnerError::Start {
+                message: format!("failed to create stdout log: {error}"),
+            })?;
+        let stderr_log =
+            File::create(&stderr_log_path).map_err(|error| AgentRunnerError::Start {
+                message: format!("failed to create stderr log: {error}"),
+            })?;
+
+        let mut child = Command::new(&request.command)
+            .args(&request.args)
+            .current_dir(&request.workspace.path)
+            .env("VIMEFLOW_ISSUE_ID", &request.issue.id)
+            .env("VIMEFLOW_ISSUE_IDENTIFIER", &request.issue.identifier)
+            .env("VIMEFLOW_PROMPT_FILE", &request.prompt_file)
+            .env("VIMEFLOW_WORKSPACE", &request.workspace.path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::from(stdout_log))
+            .stderr(Stdio::from(stderr_log))
+            .spawn()
+            .map_err(|error| AgentRunnerError::Start {
+                message: error.to_string(),
+            })?;
+
+        let Some(mut stdin) = child.stdin.take() else {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(AgentRunnerError::Start {
+                message: "agent stdin unavailable".to_string(),
+            });
+        };
+
+        if let Err(error) = stdin.write_all(request.prompt.as_bytes()) {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(AgentRunnerError::Stdin {
+                message: error.to_string(),
+            });
+        }
+        drop(stdin);
+
+        let process_id = child.id();
+        thread::spawn(move || {
+            if let Err(error) = child.wait() {
+                log::warn!("failed to wait for orchestrator agent process: {error}");
+            }
+        });
+
+        Ok(AgentRun {
+            run_id: format!("{}:process-{process_id}", request.issue.id),
+            process_id: Some(process_id),
+            stdout_log_path: Some(stdout_log_path),
+            stderr_log_path: Some(stderr_log_path),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{Duration, Instant};
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn command_agent_runner_uses_workspace_cwd_prompt_stdin_and_prompt_env() {
+        let workspace_dir = TempDir::new().unwrap();
+        let prompt_file = workspace_dir
+            .path()
+            .join(".vimeflow/orchestrator/prompt.md");
+        fs::create_dir_all(prompt_file.parent().unwrap()).unwrap();
+        let request = AgentRunRequest {
+            issue: issue("issue-108", "#108"),
+            attempt_number: 1,
+            workspace: WorkspacePlan {
+                issue_id: "issue-108".to_string(),
+                issue_identifier: "#108".to_string(),
+                workspace_slug: "108".to_string(),
+                path: workspace_dir.path().to_path_buf(),
+                base_ref: "main".to_string(),
+                branch_name: "agent/108".to_string(),
+                prompt_file: prompt_file.clone(),
+            },
+            command: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "cat > stdin.txt && pwd > cwd.txt && echo agent-out && echo agent-err >&2 && printf '%s' \"$VIMEFLOW_PROMPT_FILE\" > prompt-env.txt"
+                    .to_string(),
+            ],
+            prompt: "Fix #108".to_string(),
+            prompt_file: prompt_file.clone(),
+        };
+
+        let run = CommandAgentRunner.start(request).unwrap();
+        wait_for_file(&workspace_dir.path().join("prompt-env.txt"));
+
+        assert_eq!(
+            run.run_id,
+            format!("issue-108:process-{}", run.process_id.unwrap())
+        );
+        assert_eq!(
+            fs::read_to_string(workspace_dir.path().join("stdin.txt")).unwrap(),
+            "Fix #108"
+        );
+        assert_eq!(
+            fs::read_to_string(workspace_dir.path().join("cwd.txt"))
+                .unwrap()
+                .trim(),
+            workspace_dir.path().display().to_string()
+        );
+        assert_eq!(
+            fs::read_to_string(workspace_dir.path().join("prompt-env.txt")).unwrap(),
+            prompt_file.display().to_string()
+        );
+        assert_eq!(
+            fs::read_to_string(run.stdout_log_path.unwrap()).unwrap(),
+            "agent-out\n"
+        );
+        assert_eq!(
+            fs::read_to_string(run.stderr_log_path.unwrap()).unwrap(),
+            "agent-err\n"
+        );
+    }
+
+    fn issue(id: &str, identifier: &str) -> OrchestratorIssue {
+        OrchestratorIssue {
+            id: id.to_string(),
+            identifier: identifier.to_string(),
+            title: format!("Issue {identifier}"),
+            description: None,
+            state: "open".to_string(),
+            url: None,
+            labels: Vec::new(),
+            priority: None,
+            updated_at: None,
+        }
+    }
+
+    fn wait_for_file(path: &std::path::Path) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if path.exists() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("timed out waiting for {}", path.display());
+    }
+}

--- a/src-tauri/src/orchestrator/runtime.rs
+++ b/src-tauri/src/orchestrator/runtime.rs
@@ -1,9 +1,14 @@
+use std::fs;
+use std::path::PathBuf;
+
 use serde::Serialize;
 use thiserror::Error;
 
 use crate::orchestrator::{
-    OrchestratorEvent, OrchestratorIssue, OrchestratorSnapshot, OrchestratorState, QueueIssue,
-    RunStatus, StateError, TrackerClient, TrackerError, WorkflowDefinition,
+    render_prompt, AgentRun, AgentRunRequest, AgentRunner, AttemptTemplateContext,
+    OrchestratorEvent, OrchestratorIssue, OrchestratorSnapshot, OrchestratorState,
+    PromptTemplateContext, QueueIssue, RunStatus, StateError, TrackerClient, TrackerError,
+    WorkflowDefinition, WorkspaceManager, WorkspacePlan, WorkspaceTemplateContext,
 };
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -20,6 +25,34 @@ pub struct ClaimBatch {
     pub snapshot: OrchestratorSnapshot,
     pub claimed: Vec<QueueIssue>,
     pub events: Vec<OrchestratorEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DispatchBatch {
+    pub snapshot: OrchestratorSnapshot,
+    pub claimed: Vec<QueueIssue>,
+    pub started: Vec<DispatchedRun>,
+    pub failed: Vec<DispatchFailure>,
+    pub events: Vec<OrchestratorEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DispatchedRun {
+    pub issue: OrchestratorIssue,
+    pub attempt_number: u32,
+    pub workspace: WorkspacePlan,
+    pub run: AgentRun,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DispatchFailure {
+    pub issue: OrchestratorIssue,
+    pub attempt_number: u32,
+    pub workspace_path: Option<PathBuf>,
+    pub error: String,
 }
 
 #[derive(Debug, Clone)]
@@ -58,6 +91,50 @@ where
 
     pub fn claim_ready(&mut self, timestamp: &str) -> Result<ClaimBatch, OrchestratorRuntimeError> {
         let issues = self.tracker.fetch_issues()?;
+        self.claim_ready_from_issues(issues, timestamp)
+    }
+
+    pub fn dispatch_ready<R>(
+        &mut self,
+        workspace_manager: &WorkspaceManager,
+        runner: &R,
+        timestamp: &str,
+    ) -> Result<DispatchBatch, OrchestratorRuntimeError>
+    where
+        R: AgentRunner,
+    {
+        let issues = self.tracker.fetch_issues()?;
+        let claim_batch = self.claim_ready_from_issues(issues.clone(), timestamp)?;
+        let mut events = claim_batch.events.clone();
+        let mut started = Vec::new();
+        let mut failed = Vec::new();
+
+        for claim in &claim_batch.claimed {
+            self.dispatch_claim(
+                claim,
+                workspace_manager,
+                runner,
+                timestamp,
+                &mut started,
+                &mut failed,
+                &mut events,
+            )?;
+        }
+
+        Ok(DispatchBatch {
+            snapshot: self.state.snapshot(issues),
+            claimed: claim_batch.claimed,
+            started,
+            failed,
+            events,
+        })
+    }
+
+    fn claim_ready_from_issues(
+        &mut self,
+        issues: Vec<OrchestratorIssue>,
+        timestamp: &str,
+    ) -> Result<ClaimBatch, OrchestratorRuntimeError> {
         let mut claimed = Vec::new();
         let mut events = Vec::new();
 
@@ -85,6 +162,192 @@ where
         })
     }
 
+    fn dispatch_claim<R>(
+        &mut self,
+        claim: &QueueIssue,
+        workspace_manager: &WorkspaceManager,
+        runner: &R,
+        timestamp: &str,
+        started: &mut Vec<DispatchedRun>,
+        failed: &mut Vec<DispatchFailure>,
+        events: &mut Vec<OrchestratorEvent>,
+    ) -> Result<(), OrchestratorRuntimeError>
+    where
+        R: AgentRunner,
+    {
+        let attempt_number = 1;
+        let issue = &claim.issue;
+
+        events.push(self.issue_event(
+            issue,
+            timestamp,
+            RunStatus::PreparingWorkspace,
+            None,
+            Some(attempt_number),
+            None,
+            Some("preparing issue workspace".to_string()),
+            None,
+        ));
+        let workspace = match workspace_manager.prepare_workspace(issue) {
+            Ok(workspace) => workspace,
+            Err(error) => {
+                self.record_dispatch_failure(
+                    issue,
+                    attempt_number,
+                    None,
+                    timestamp,
+                    error.to_string(),
+                    failed,
+                    events,
+                );
+                return Ok(());
+            }
+        };
+
+        events.push(self.issue_event(
+            issue,
+            timestamp,
+            RunStatus::RenderingPrompt,
+            None,
+            Some(attempt_number),
+            Some(workspace.path.clone()),
+            Some("rendering workflow prompt".to_string()),
+            None,
+        ));
+        let prompt = match self.render_prompt_for_issue(issue, attempt_number, &workspace) {
+            Ok(prompt) => prompt,
+            Err(error) => {
+                self.record_dispatch_failure(
+                    issue,
+                    attempt_number,
+                    Some(workspace.path.clone()),
+                    timestamp,
+                    error.to_string(),
+                    failed,
+                    events,
+                );
+                return Ok(());
+            }
+        };
+        if let Err(error) = fs::write(&workspace.prompt_file, &prompt) {
+            self.record_dispatch_failure(
+                issue,
+                attempt_number,
+                Some(workspace.path.clone()),
+                timestamp,
+                format!(
+                    "failed to write prompt file {}: {error}",
+                    workspace.prompt_file.display()
+                ),
+                failed,
+                events,
+            );
+            return Ok(());
+        }
+
+        let request = AgentRunRequest {
+            issue: issue.clone(),
+            attempt_number,
+            workspace: workspace.clone(),
+            command: self.workflow.config.agent.command.clone(),
+            args: self.workflow.config.agent.args.clone(),
+            prompt,
+            prompt_file: workspace.prompt_file.clone(),
+        };
+        let run = match runner.start(request) {
+            Ok(run) => run,
+            Err(error) => {
+                self.record_dispatch_failure(
+                    issue,
+                    attempt_number,
+                    Some(workspace.path.clone()),
+                    timestamp,
+                    error.to_string(),
+                    failed,
+                    events,
+                );
+                return Ok(());
+            }
+        };
+
+        self.state.mark_running(
+            &issue.id,
+            &run.run_id,
+            attempt_number,
+            workspace.path.clone(),
+            timestamp,
+        )?;
+        events.push(self.issue_event(
+            issue,
+            timestamp,
+            RunStatus::Running,
+            Some(run.run_id.clone()),
+            Some(attempt_number),
+            Some(workspace.path.clone()),
+            Some("agent run started".to_string()),
+            None,
+        ));
+        started.push(DispatchedRun {
+            issue: issue.clone(),
+            attempt_number,
+            workspace,
+            run,
+        });
+
+        Ok(())
+    }
+
+    fn render_prompt_for_issue(
+        &self,
+        issue: &OrchestratorIssue,
+        attempt_number: u32,
+        workspace: &WorkspacePlan,
+    ) -> Result<String, crate::orchestrator::WorkflowError> {
+        render_prompt(
+            &self.workflow.prompt_template,
+            &PromptTemplateContext {
+                issue: issue.clone(),
+                attempt: AttemptTemplateContext {
+                    number: attempt_number,
+                    previous_error: None,
+                },
+                workspace: WorkspaceTemplateContext {
+                    path: workspace.path.clone(),
+                },
+                prompt_file: workspace.prompt_file.clone(),
+            },
+        )
+    }
+
+    fn record_dispatch_failure(
+        &mut self,
+        issue: &OrchestratorIssue,
+        attempt_number: u32,
+        workspace_path: Option<PathBuf>,
+        timestamp: &str,
+        error: String,
+        failed: &mut Vec<DispatchFailure>,
+        events: &mut Vec<OrchestratorEvent>,
+    ) {
+        self.state.release_issue(&issue.id, RunStatus::Failed);
+        events.push(self.issue_event(
+            issue,
+            timestamp,
+            RunStatus::Failed,
+            None,
+            Some(attempt_number),
+            workspace_path.clone(),
+            Some("agent dispatch failed".to_string()),
+            Some(error.clone()),
+        ));
+        failed.push(DispatchFailure {
+            issue: issue.clone(),
+            attempt_number,
+            workspace_path,
+            error,
+        });
+    }
+
     fn available_slots(&self) -> usize {
         usize::from(self.workflow.config.agent.max_concurrent)
             .saturating_sub(self.state.in_flight_count())
@@ -100,31 +363,57 @@ where
     }
 
     fn claim_event(&self, issue: &OrchestratorIssue, timestamp: &str) -> OrchestratorEvent {
+        self.issue_event(
+            issue,
+            timestamp,
+            RunStatus::Claimed,
+            None,
+            None,
+            None,
+            Some("issue claimed for dispatch".to_string()),
+            None,
+        )
+    }
+
+    fn issue_event(
+        &self,
+        issue: &OrchestratorIssue,
+        timestamp: &str,
+        status: RunStatus,
+        run_id: Option<String>,
+        attempt_number: Option<u32>,
+        workspace_path: Option<PathBuf>,
+        message: Option<String>,
+        error: Option<String>,
+    ) -> OrchestratorEvent {
         OrchestratorEvent {
             timestamp: timestamp.to_string(),
             workflow_path: self.workflow.path.clone(),
             issue_id: issue.id.clone(),
             issue_identifier: issue.identifier.clone(),
-            run_id: None,
-            attempt_number: None,
-            status: RunStatus::Claimed,
-            workspace_path: None,
-            message: Some("issue claimed for dispatch".to_string()),
-            error: None,
+            run_id,
+            attempt_number,
+            status,
+            workspace_path,
+            message,
+            error,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
     use std::fs;
+    use std::rc::Rc;
 
     use tempfile::TempDir;
 
     use super::*;
     use crate::orchestrator::{
-        load_workflow_from_path_with_env, OrchestratorIssue, RunStatus, TrackerClient,
-        TrackerError, WorkflowDefinition,
+        load_workflow_from_path_with_env, AgentRun, AgentRunRequest, AgentRunner, AgentRunnerError,
+        OrchestratorIssue, RunStatus, TrackerClient, TrackerError, WorkflowDefinition,
+        WorkspaceManager,
     };
 
     #[derive(Debug, Clone)]
@@ -148,6 +437,42 @@ mod tests {
 
     impl TrackerClient for StaticTracker {
         fn fetch_issues(&self) -> Result<Vec<OrchestratorIssue>, TrackerError> {
+            self.result.clone()
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct RecordingRunner {
+        requests: Rc<RefCell<Vec<AgentRunRequest>>>,
+        result: Result<AgentRun, AgentRunnerError>,
+    }
+
+    impl RecordingRunner {
+        fn with_run(run_id: &str) -> Self {
+            Self {
+                requests: Rc::new(RefCell::new(Vec::new())),
+                result: Ok(AgentRun {
+                    run_id: run_id.to_string(),
+                    process_id: Some(42),
+                    stdout_log_path: None,
+                    stderr_log_path: None,
+                }),
+            }
+        }
+
+        fn with_error(message: &str) -> Self {
+            Self {
+                requests: Rc::new(RefCell::new(Vec::new())),
+                result: Err(AgentRunnerError::Start {
+                    message: message.to_string(),
+                }),
+            }
+        }
+    }
+
+    impl AgentRunner for RecordingRunner {
+        fn start(&self, request: AgentRunRequest) -> Result<AgentRun, AgentRunnerError> {
+            self.requests.borrow_mut().push(request);
             self.result.clone()
         }
     }
@@ -246,7 +571,92 @@ mod tests {
         assert_eq!(runtime.in_flight_count(), 0);
     }
 
+    #[test]
+    fn dispatch_ready_prepares_workspace_renders_prompt_and_starts_runner() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let runner = RecordingRunner::with_run("run-108");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        let batch = runtime
+            .dispatch_ready(&workspace_manager, &runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+
+        assert_eq!(batch.claimed.len(), 1);
+        assert_eq!(batch.started.len(), 1);
+        assert!(batch.failed.is_empty());
+        assert_eq!(batch.started[0].run.run_id, "run-108");
+        assert_eq!(batch.started[0].attempt_number, 1);
+        assert_eq!(batch.snapshot.queue[0].status, RunStatus::Running);
+        assert_eq!(batch.snapshot.running[0].run_id, "run-108");
+        assert_eq!(runtime.in_flight_count(), 1);
+
+        let requests = runner.requests.borrow();
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+        assert_eq!(request.issue.identifier, "#108");
+        assert_eq!(request.command, "codex");
+        assert_eq!(request.args, vec!["exec", "--ask-for-approval", "never"]);
+        assert_eq!(request.attempt_number, 1);
+        assert_eq!(request.workspace.path, batch.started[0].workspace.path);
+        assert_eq!(request.prompt_file, batch.started[0].workspace.prompt_file);
+        assert!(request.workspace.path.starts_with(workspace_manager.root()));
+        assert!(request
+            .prompt
+            .contains("Fix #108 from attempt 1 in workspace"));
+        assert!(request
+            .prompt
+            .contains(&request.workspace.path.display().to_string()));
+
+        let prompt = fs::read_to_string(&request.prompt_file).unwrap();
+        assert_eq!(prompt, request.prompt);
+
+        let statuses: Vec<_> = batch.events.iter().map(|event| event.status).collect();
+        assert_eq!(
+            statuses,
+            vec![
+                RunStatus::Claimed,
+                RunStatus::PreparingWorkspace,
+                RunStatus::RenderingPrompt,
+                RunStatus::Running
+            ]
+        );
+    }
+
+    #[test]
+    fn dispatch_ready_releases_issue_as_failed_when_runner_start_fails() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let runner = RecordingRunner::with_error("codex missing");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        let batch = runtime
+            .dispatch_ready(&workspace_manager, &runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+
+        assert!(batch.started.is_empty());
+        assert_eq!(batch.failed.len(), 1);
+        assert_eq!(batch.failed[0].issue.identifier, "#108");
+        assert_eq!(batch.failed[0].attempt_number, 1);
+        assert!(batch.failed[0].error.contains("codex missing"));
+        assert_eq!(batch.snapshot.queue[0].status, RunStatus::Failed);
+        assert!(batch.snapshot.running.is_empty());
+        assert_eq!(runtime.in_flight_count(), 0);
+        assert!(batch
+            .events
+            .iter()
+            .any(|event| event.status == RunStatus::Failed
+                && event.error.as_deref() == Some("failed to start agent: codex missing")));
+    }
+
     fn workflow_with_max_concurrent(max_concurrent: u8) -> WorkflowDefinition {
+        let (_dir, workflow) = workflow_fixture(max_concurrent);
+        workflow
+    }
+
+    fn workflow_fixture(max_concurrent: u8) -> (TempDir, WorkflowDefinition) {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("WORKFLOW.md");
         fs::write(
@@ -264,17 +674,23 @@ tracker:
     - closed
 agent:
   command: codex
+  args:
+    - exec
+    - --ask-for-approval
+    - never
   max_concurrent: {max_concurrent}
 ---
-Fix {{ issue.identifier }}.
+Fix {{{{ issue.identifier }}}} from attempt {{{{ attempt.number }}}} in workspace {{{{ workspace.path }}}}.
 "#
             ),
         )
         .unwrap();
 
-        load_workflow_from_path_with_env(&path, |name| {
+        let workflow = load_workflow_from_path_with_env(&path, |name| {
             (name == "GITHUB_TOKEN").then_some("secret-token".to_string())
         })
-        .unwrap()
+        .unwrap();
+
+        (dir, workflow)
     }
 }

--- a/src-tauri/src/orchestrator/state.rs
+++ b/src-tauri/src/orchestrator/state.rs
@@ -154,6 +154,7 @@ impl OrchestratorState {
             });
         };
 
+        self.claimed.remove(issue_id);
         self.running.insert(
             issue_id.to_string(),
             OrchestratorRun {
@@ -304,6 +305,26 @@ mod tests {
         assert_eq!(snapshot.running[0].run_id, "run-1");
         assert_eq!(snapshot.queue[0].status, RunStatus::Running);
         assert_eq!(snapshot.queue[0].attempt_number, Some(2));
+    }
+
+    #[test]
+    fn mark_running_removes_claimed_entry_from_in_flight_count() {
+        let mut state = OrchestratorState::new();
+        let issue = issue("issue-108", "#108");
+        state.claim_issue(&issue).unwrap();
+
+        state
+            .mark_running(
+                "issue-108",
+                "run-1",
+                1,
+                PathBuf::from("/tmp/workspace"),
+                "2026-05-02T00:00:00Z",
+            )
+            .unwrap();
+
+        assert_eq!(state.in_flight_count(), 1);
+        assert!(state.is_issue_active("issue-108"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This is stacked on #140 and targets `feat/108-queue-runtime` so the review only covers the agent-dispatcher slice for #108.

- Adds an `AgentRunner` interface plus a `CommandAgentRunner` that starts workflow-configured agent commands directly in the prepared workspace.
- Writes rendered workflow prompts to deterministic prompt files and sends the same prompt to agent stdin.
- Routes agent stdout/stderr into deterministic log files under the workspace orchestration directory for later UI/status surfacing.
- Adds `dispatch_ready` to claim eligible issues, prepare workspaces, render prompts, start runners, emit lifecycle events, and record dispatch failures in state.
- Fixes claimed-to-running state accounting so running issues are not double-counted against concurrency.

Refs #108.

## Validation

- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml orchestrator::runner -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml orchestrator:: -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo check --manifest-path src-tauri/Cargo.toml`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml`
- `rustfmt --edition 2021 --check src-tauri/src/orchestrator/mod.rs src-tauri/src/orchestrator/runner.rs src-tauri/src/orchestrator/runtime.rs src-tauri/src/orchestrator/state.rs`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- pre-push `npm test`
