### PR TITLE
feat(orchestrator): expose tauri commands

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,10 @@ use agent::{
 };
 use filesystem::{list_dir, read_file, write_file};
 use git::{get_git_diff, git_status, watcher::{start_git_watcher, stop_git_watcher, GitWatcherState}};
+use orchestrator::{
+    dispatch_orchestrator_once, load_orchestrator_workflow, refresh_orchestrator_snapshot,
+    set_orchestrator_paused, OrchestratorCommandState,
+};
 use std::sync::Arc;
 use tauri::Manager;
 use terminal::{
@@ -75,7 +79,8 @@ pub fn run() {
         .manage(PtyState::new())
         .manage(AgentWatcherState::new())
         .manage(TranscriptState::new())
-        .manage(GitWatcherState::new());
+        .manage(GitWatcherState::new())
+        .manage(OrchestratorCommandState::new());
 
     #[cfg(not(feature = "e2e-test"))]
     let builder = builder.invoke_handler(tauri::generate_handler![
@@ -98,7 +103,11 @@ pub fn run() {
         git_status,
         get_git_diff,
         start_git_watcher,
-        stop_git_watcher
+        stop_git_watcher,
+        load_orchestrator_workflow,
+        refresh_orchestrator_snapshot,
+        set_orchestrator_paused,
+        dispatch_orchestrator_once
     ]);
 
     #[cfg(feature = "e2e-test")]
@@ -123,6 +132,10 @@ pub fn run() {
         get_git_diff,
         start_git_watcher,
         stop_git_watcher,
+        load_orchestrator_workflow,
+        refresh_orchestrator_snapshot,
+        set_orchestrator_paused,
+        dispatch_orchestrator_once,
         terminal::test_commands::list_active_pty_sessions
     ]);
 

--- a/src-tauri/src/orchestrator/commands.rs
+++ b/src-tauri/src/orchestrator/commands.rs
@@ -1,0 +1,242 @@
+use std::path::{Component, Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::{SecondsFormat, Utc};
+use serde::Deserialize;
+use tauri::{AppHandle, Emitter, Runtime, State};
+
+use crate::orchestrator::{
+    load_workflow_from_path, CommandAgentRunner, DispatchBatch, GithubIssuesTracker,
+    OrchestratorRuntime, OrchestratorSnapshot, WorkspaceManager,
+};
+
+const ORCHESTRATOR_EVENT: &str = "orchestrator:event";
+const WORKFLOW_FILE_NAME: &str = "WORKFLOW.md";
+const NOT_LOADED_ERROR: &str = "orchestrator workflow is not loaded";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoadOrchestratorWorkflowRequest {
+    pub workflow_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetOrchestratorPausedRequest {
+    pub paused: bool,
+}
+
+pub struct OrchestratorCommandState {
+    service: Mutex<Option<OrchestratorService>>,
+}
+
+struct OrchestratorService {
+    runtime: OrchestratorRuntime<GithubIssuesTracker>,
+    workspace_manager: WorkspaceManager,
+    runner: CommandAgentRunner,
+}
+
+impl OrchestratorCommandState {
+    pub fn new() -> Self {
+        Self {
+            service: Mutex::new(None),
+        }
+    }
+
+    fn replace_service(&self, service: OrchestratorService) -> Result<(), String> {
+        let mut guard = self.lock_service()?;
+        *guard = Some(service);
+        Ok(())
+    }
+
+    fn with_service<F, T>(&self, callback: F) -> Result<T, String>
+    where
+        F: FnOnce(&mut OrchestratorService) -> Result<T, String>,
+    {
+        let mut guard = self.lock_service()?;
+        let Some(service) = guard.as_mut() else {
+            return Err(NOT_LOADED_ERROR.to_string());
+        };
+
+        callback(service)
+    }
+
+    fn lock_service(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, Option<OrchestratorService>>, String> {
+        self.service
+            .lock()
+            .map_err(|_| "orchestrator command state lock is poisoned".to_string())
+    }
+}
+
+impl Default for OrchestratorCommandState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OrchestratorService {
+    fn from_workflow_path(path: &Path) -> Result<Self, String> {
+        let workflow = load_workflow_from_path(path).map_err(|error| error.to_string())?;
+        let workspace_manager =
+            WorkspaceManager::from_workflow(&workflow).map_err(|error| error.to_string())?;
+        let tracker = GithubIssuesTracker::from_workflow(&workflow);
+        let runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        Ok(Self {
+            runtime,
+            workspace_manager,
+            runner: CommandAgentRunner,
+        })
+    }
+
+    fn snapshot(&self) -> Result<OrchestratorSnapshot, String> {
+        self.runtime.snapshot().map_err(|error| error.to_string())
+    }
+
+    fn set_paused(&mut self, paused: bool) {
+        self.runtime.set_paused(paused);
+    }
+
+    fn dispatch_once(&mut self, timestamp: &str) -> Result<DispatchBatch, String> {
+        self.runtime
+            .dispatch_ready(&self.workspace_manager, &self.runner, timestamp)
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[tauri::command]
+pub async fn load_orchestrator_workflow(
+    state: State<'_, OrchestratorCommandState>,
+    request: LoadOrchestratorWorkflowRequest,
+) -> Result<OrchestratorSnapshot, String> {
+    let workflow_path = validate_workflow_path(&request.workflow_path)?;
+    let service = OrchestratorService::from_workflow_path(&workflow_path)?;
+    let snapshot = service.snapshot()?;
+    state.replace_service(service)?;
+
+    Ok(snapshot)
+}
+
+#[tauri::command]
+pub async fn refresh_orchestrator_snapshot(
+    state: State<'_, OrchestratorCommandState>,
+) -> Result<OrchestratorSnapshot, String> {
+    state.with_service(|service| service.snapshot())
+}
+
+#[tauri::command]
+pub async fn set_orchestrator_paused(
+    state: State<'_, OrchestratorCommandState>,
+    request: SetOrchestratorPausedRequest,
+) -> Result<OrchestratorSnapshot, String> {
+    state.with_service(|service| {
+        service.set_paused(request.paused);
+        service.snapshot()
+    })
+}
+
+#[tauri::command]
+pub async fn dispatch_orchestrator_once<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, OrchestratorCommandState>,
+) -> Result<DispatchBatch, String> {
+    let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+    let batch = state.with_service(|service| service.dispatch_once(&timestamp))?;
+
+    for event in &batch.events {
+        if let Err(error) = app.emit(ORCHESTRATOR_EVENT, event) {
+            log::warn!("failed to emit orchestrator event: {error}");
+        }
+    }
+
+    Ok(batch)
+}
+
+fn validate_workflow_path(raw_path: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(raw_path);
+    if !path.is_absolute() {
+        return Err("workflow path must be absolute".to_string());
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err("workflow path must not contain parent references".to_string());
+    }
+    if path.file_name().and_then(|name| name.to_str()) != Some(WORKFLOW_FILE_NAME) {
+        return Err(format!("workflow path must point to {WORKFLOW_FILE_NAME}"));
+    }
+
+    let canonical = path
+        .canonicalize()
+        .map_err(|error| format!("workflow path is not readable: {error}"))?;
+    if canonical.file_name().and_then(|name| name.to_str()) != Some(WORKFLOW_FILE_NAME) {
+        return Err(format!(
+            "workflow path must resolve to {WORKFLOW_FILE_NAME}"
+        ));
+    }
+    if !canonical.is_file() {
+        return Err("workflow path must be a file".to_string());
+    }
+
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn validate_workflow_path_accepts_absolute_workflow_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("WORKFLOW.md");
+        fs::write(&path, "---\n---\nPrompt").unwrap();
+
+        let resolved = validate_workflow_path(&path.display().to_string()).unwrap();
+
+        assert_eq!(resolved, path.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn validate_workflow_path_rejects_relative_paths() {
+        let error = validate_workflow_path("WORKFLOW.md").unwrap_err();
+
+        assert!(error.contains("absolute"));
+    }
+
+    #[test]
+    fn validate_workflow_path_rejects_non_workflow_filename() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("OTHER.md");
+        fs::write(&path, "---\n---\nPrompt").unwrap();
+
+        let error = validate_workflow_path(&path.display().to_string()).unwrap_err();
+
+        assert!(error.contains("WORKFLOW.md"));
+    }
+
+    #[test]
+    fn validate_workflow_path_rejects_parent_references() {
+        let path = PathBuf::from("/tmp/repo/../WORKFLOW.md");
+
+        let error = validate_workflow_path(&path.display().to_string()).unwrap_err();
+
+        assert!(error.contains("parent references"));
+    }
+
+    #[test]
+    fn command_state_requires_loaded_service() {
+        let state = OrchestratorCommandState::new();
+
+        let error = state.with_service(|_| Ok(())).unwrap_err();
+
+        assert_eq!(error, "orchestrator workflow is not loaded");
+    }
+}

--- a/src-tauri/src/orchestrator/mod.rs
+++ b/src-tauri/src/orchestrator/mod.rs
@@ -1,3 +1,4 @@
+pub mod commands;
 pub mod runner;
 pub mod runtime;
 pub mod state;
@@ -5,6 +6,10 @@ pub mod tracker;
 pub mod workflow;
 pub mod workspace;
 
+pub use commands::{
+    dispatch_orchestrator_once, load_orchestrator_workflow, refresh_orchestrator_snapshot,
+    set_orchestrator_paused, OrchestratorCommandState,
+};
 pub use runner::{AgentRun, AgentRunRequest, AgentRunner, AgentRunnerError, CommandAgentRunner};
 pub use runtime::{
     ClaimBatch, DispatchBatch, DispatchFailure, DispatchedRun, OrchestratorRuntime,


### PR DESCRIPTION
## Summary

This is stacked on #141 and targets `feat/108-agent-dispatcher` so the review only covers the Tauri command surface for #108.

- Adds `OrchestratorCommandState` as the single in-process owner for a loaded orchestrator runtime.
- Adds Tauri commands for loading a `WORKFLOW.md`, refreshing the snapshot, pausing/resuming, and dispatching one orchestration tick.
- Emits structured `orchestrator:event` events for dispatch lifecycle updates.
- Validates workflow paths as absolute, readable `WORKFLOW.md` files without parent references before loading.
- Registers the commands in both normal and e2e Tauri invoke handlers.

Refs #108.

## Validation

- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml orchestrator::commands -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml orchestrator:: -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo check --manifest-path src-tauri/Cargo.toml`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml`
- `rustfmt --edition 2021 --check src-tauri/src/orchestrator/mod.rs src-tauri/src/orchestrator/commands.rs`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- pre-push `npm test`
