### PR TITLE
feat(orchestrator): add frontend ipc client

### DIFF
--- a/src/features/orchestrator/services/orchestratorService.test.ts
+++ b/src/features/orchestrator/services/orchestratorService.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, test, vi, type Mock } from 'vitest'
+import { TauriOrchestratorService } from './orchestratorService'
+import type { OrchestratorEvent, OrchestratorSnapshot } from '../types'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+type EventCallback = (event: { payload: unknown }) => void
+const eventListeners = new Map<string, EventCallback[]>()
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(
+    (eventName: string, callback: EventCallback): Promise<() => void> => {
+      const existing = eventListeners.get(eventName) ?? []
+      existing.push(callback)
+      eventListeners.set(eventName, existing)
+
+      return Promise.resolve(() => {
+        const callbacks = eventListeners.get(eventName) ?? []
+        const index = callbacks.indexOf(callback)
+        if (index > -1) {
+          callbacks.splice(index, 1)
+        }
+      })
+    }
+  ),
+}))
+
+const { invoke } = await import('@tauri-apps/api/core')
+const { listen } = await import('@tauri-apps/api/event')
+
+const snapshot: OrchestratorSnapshot = {
+  paused: false,
+  queue: [],
+  running: [],
+  retryQueue: [],
+}
+
+const event: OrchestratorEvent = {
+  timestamp: '2026-05-02T08:00:00Z',
+  workflowPath: '/repo/WORKFLOW.md',
+  issueId: 'github:owner/repo#108',
+  issueIdentifier: '#108',
+  runId: 'run-108',
+  attemptNumber: 1,
+  status: 'running',
+  workspacePath: '/tmp/workspace',
+  message: 'agent run started',
+  error: null,
+}
+
+const emitTauriEvent = (eventName: string, payload: unknown): void => {
+  const callbacks = eventListeners.get(eventName) ?? []
+  callbacks.forEach((callback) => callback({ payload }))
+}
+
+describe('TauriOrchestratorService', () => {
+  let service: TauriOrchestratorService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    eventListeners.clear()
+    service = new TauriOrchestratorService()
+  })
+
+  test('loadWorkflow invokes load_orchestrator_workflow with workflowPath request', async () => {
+    ;(invoke as Mock).mockResolvedValueOnce(snapshot)
+
+    const result = await service.loadWorkflow('/repo/WORKFLOW.md')
+
+    expect(invoke).toHaveBeenCalledWith('load_orchestrator_workflow', {
+      request: { workflowPath: '/repo/WORKFLOW.md' },
+    })
+    expect(result).toBe(snapshot)
+  })
+
+  test('refreshSnapshot invokes refresh_orchestrator_snapshot', async () => {
+    ;(invoke as Mock).mockResolvedValueOnce(snapshot)
+
+    const result = await service.refreshSnapshot()
+
+    expect(invoke).toHaveBeenCalledWith('refresh_orchestrator_snapshot')
+    expect(result).toBe(snapshot)
+  })
+
+  test('setPaused invokes set_orchestrator_paused with paused request', async () => {
+    ;(invoke as Mock).mockResolvedValueOnce({ ...snapshot, paused: true })
+
+    const result = await service.setPaused(true)
+
+    expect(invoke).toHaveBeenCalledWith('set_orchestrator_paused', {
+      request: { paused: true },
+    })
+    expect(result.paused).toBe(true)
+  })
+
+  test('dispatchOnce invokes dispatch_orchestrator_once', async () => {
+    const batch = { snapshot, claimed: [], started: [], failed: [], events: [] }
+    ;(invoke as Mock).mockResolvedValueOnce(batch)
+
+    const result = await service.dispatchOnce()
+
+    expect(invoke).toHaveBeenCalledWith('dispatch_orchestrator_once')
+    expect(result).toBe(batch)
+  })
+
+  test('onEvent subscribes to orchestrator:event and returns unlisten', async () => {
+    const callback = vi.fn()
+
+    const unlisten = await service.onEvent(callback)
+    emitTauriEvent('orchestrator:event', event)
+    unlisten()
+    emitTauriEvent('orchestrator:event', { ...event, status: 'failed' })
+
+    expect(listen).toHaveBeenCalledWith(
+      'orchestrator:event',
+      expect.any(Function)
+    )
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith(event)
+  })
+
+  test('loadWorkflow wraps Tauri string errors with command context', async () => {
+    ;(invoke as Mock).mockRejectedValueOnce('tracker unavailable')
+
+    await expect(service.loadWorkflow('/repo/WORKFLOW.md')).rejects.toThrow(
+      'Failed to load orchestrator workflow: tracker unavailable'
+    )
+  })
+})

--- a/src/features/orchestrator/services/orchestratorService.ts
+++ b/src/features/orchestrator/services/orchestratorService.ts
@@ -1,0 +1,145 @@
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+import type {
+  DispatchBatch,
+  OrchestratorEvent,
+  OrchestratorSnapshot,
+} from '../types'
+
+const ORCHESTRATOR_EVENT = 'orchestrator:event'
+
+const EMPTY_SNAPSHOT: OrchestratorSnapshot = {
+  paused: false,
+  queue: [],
+  running: [],
+  retryQueue: [],
+}
+
+export interface OrchestratorService {
+  loadWorkflow(workflowPath: string): Promise<OrchestratorSnapshot>
+  refreshSnapshot(): Promise<OrchestratorSnapshot>
+  setPaused(paused: boolean): Promise<OrchestratorSnapshot>
+  dispatchOnce(): Promise<DispatchBatch>
+  onEvent(callback: (event: OrchestratorEvent) => void): Promise<() => void>
+}
+
+export class TauriOrchestratorService implements OrchestratorService {
+  async loadWorkflow(workflowPath: string): Promise<OrchestratorSnapshot> {
+    try {
+      return await invoke<OrchestratorSnapshot>('load_orchestrator_workflow', {
+        request: { workflowPath },
+      })
+    } catch (error) {
+      throw commandError('load orchestrator workflow', error)
+    }
+  }
+
+  async refreshSnapshot(): Promise<OrchestratorSnapshot> {
+    try {
+      return await invoke<OrchestratorSnapshot>('refresh_orchestrator_snapshot')
+    } catch (error) {
+      throw commandError('refresh orchestrator snapshot', error)
+    }
+  }
+
+  async setPaused(paused: boolean): Promise<OrchestratorSnapshot> {
+    try {
+      return await invoke<OrchestratorSnapshot>('set_orchestrator_paused', {
+        request: { paused },
+      })
+    } catch (error) {
+      throw commandError(
+        paused ? 'pause orchestrator' : 'resume orchestrator',
+        error
+      )
+    }
+  }
+
+  async dispatchOnce(): Promise<DispatchBatch> {
+    try {
+      return await invoke<DispatchBatch>('dispatch_orchestrator_once')
+    } catch (error) {
+      throw commandError('dispatch orchestrator work', error)
+    }
+  }
+
+  async onEvent(
+    callback: (event: OrchestratorEvent) => void
+  ): Promise<() => void> {
+    try {
+      const unlisten = await listen<OrchestratorEvent>(
+        ORCHESTRATOR_EVENT,
+        (event) => {
+          callback(event.payload)
+        }
+      )
+
+      return unlisten
+    } catch (error) {
+      throw commandError('listen for orchestrator events', error)
+    }
+  }
+}
+
+export class MockOrchestratorService implements OrchestratorService {
+  private snapshot: OrchestratorSnapshot
+  private callbacks: ((event: OrchestratorEvent) => void)[] = []
+
+  constructor(snapshot: OrchestratorSnapshot = EMPTY_SNAPSHOT) {
+    this.snapshot = snapshot
+  }
+
+  loadWorkflow(): Promise<OrchestratorSnapshot> {
+    return Promise.resolve(this.snapshot)
+  }
+
+  refreshSnapshot(): Promise<OrchestratorSnapshot> {
+    return Promise.resolve(this.snapshot)
+  }
+
+  setPaused(paused: boolean): Promise<OrchestratorSnapshot> {
+    this.snapshot = { ...this.snapshot, paused }
+
+    return Promise.resolve(this.snapshot)
+  }
+
+  dispatchOnce(): Promise<DispatchBatch> {
+    return Promise.resolve({
+      snapshot: this.snapshot,
+      claimed: [],
+      started: [],
+      failed: [],
+      events: [],
+    })
+  }
+
+  onEvent(callback: (event: OrchestratorEvent) => void): Promise<() => void> {
+    this.callbacks.push(callback)
+
+    return Promise.resolve(() => {
+      const index = this.callbacks.indexOf(callback)
+      if (index > -1) {
+        this.callbacks.splice(index, 1)
+      }
+    })
+  }
+
+  emitEventForTests(event: OrchestratorEvent): void {
+    this.callbacks.forEach((callback) => callback(event))
+  }
+}
+
+export const createOrchestratorService = (): OrchestratorService => {
+  if (import.meta.env.MODE === 'test') {
+    return new MockOrchestratorService()
+  }
+
+  if ('__TAURI_INTERNALS__' in window) {
+    return new TauriOrchestratorService()
+  }
+
+  return new MockOrchestratorService()
+}
+
+const commandError = (action: string, error: unknown): Error =>
+  new Error(`Failed to ${action}: ${String(error)}`)

--- a/src/features/orchestrator/types/index.test.ts
+++ b/src/features/orchestrator/types/index.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest'
+import { ORCHESTRATOR_RUN_STATUSES, type OrchestratorSnapshot } from './index'
+
+describe('orchestrator types', () => {
+  test('exports the backend run statuses in wire format', () => {
+    expect(ORCHESTRATOR_RUN_STATUSES).toEqual([
+      'queued',
+      'claimed',
+      'preparing_workspace',
+      'rendering_prompt',
+      'running',
+      'retry_scheduled',
+      'succeeded',
+      'failed',
+      'stopped',
+      'released',
+    ])
+  })
+
+  test('snapshot type matches the backend queue shape', () => {
+    const snapshot: OrchestratorSnapshot = {
+      paused: false,
+      queue: [
+        {
+          issue: {
+            id: 'github:owner/repo#108',
+            identifier: '#108',
+            title: 'Build orchestrator',
+            description: null,
+            state: 'open',
+            url: 'https://example.test/repo/issues/108',
+            labels: ['enhancement'],
+            priority: null,
+            updatedAt: '2026-05-02T08:00:00Z',
+          },
+          status: 'running',
+          runId: 'run-108',
+          attemptNumber: 1,
+          nextRetryAt: null,
+          lastError: null,
+        },
+      ],
+      running: [],
+      retryQueue: [],
+    }
+
+    expect(snapshot.queue[0].status).toBe('running')
+  })
+})

--- a/src/features/orchestrator/types/index.ts
+++ b/src/features/orchestrator/types/index.ts
@@ -1,0 +1,113 @@
+export const ORCHESTRATOR_RUN_STATUSES = [
+  'queued',
+  'claimed',
+  'preparing_workspace',
+  'rendering_prompt',
+  'running',
+  'retry_scheduled',
+  'succeeded',
+  'failed',
+  'stopped',
+  'released',
+] as const
+
+export type RunStatus = (typeof ORCHESTRATOR_RUN_STATUSES)[number]
+
+export interface OrchestratorIssue {
+  id: string
+  identifier: string
+  title: string
+  description: string | null
+  state: string
+  url: string | null
+  labels: string[]
+  priority: number | null
+  updatedAt: string | null
+}
+
+export interface QueueIssue {
+  issue: OrchestratorIssue
+  status: RunStatus
+  runId: string | null
+  attemptNumber: number | null
+  nextRetryAt: string | null
+  lastError: string | null
+}
+
+export interface OrchestratorRun {
+  runId: string
+  issueId: string
+  issueIdentifier: string
+  attemptNumber: number
+  status: RunStatus
+  workspacePath: string
+  startedAt: string
+  lastEvent: string | null
+}
+
+export interface RetryEntry {
+  issueId: string
+  issueIdentifier: string
+  attemptNumber: number
+  nextRetryAt: string
+  lastError: string
+}
+
+export interface OrchestratorSnapshot {
+  paused: boolean
+  queue: QueueIssue[]
+  running: OrchestratorRun[]
+  retryQueue: RetryEntry[]
+}
+
+export interface OrchestratorEvent {
+  timestamp: string
+  workflowPath: string
+  issueId: string
+  issueIdentifier: string
+  runId: string | null
+  attemptNumber: number | null
+  status: RunStatus
+  workspacePath: string | null
+  message: string | null
+  error: string | null
+}
+
+export interface WorkspacePlan {
+  issueId: string
+  issueIdentifier: string
+  workspaceSlug: string
+  path: string
+  baseRef: string
+  branchName: string
+  promptFile: string
+}
+
+export interface AgentRun {
+  runId: string
+  processId: number | null
+  stdoutLogPath: string | null
+  stderrLogPath: string | null
+}
+
+export interface DispatchedRun {
+  issue: OrchestratorIssue
+  attemptNumber: number
+  workspace: WorkspacePlan
+  run: AgentRun
+}
+
+export interface DispatchFailure {
+  issue: OrchestratorIssue
+  attemptNumber: number
+  workspacePath: string | null
+  error: string
+}
+
+export interface DispatchBatch {
+  snapshot: OrchestratorSnapshot
+  claimed: QueueIssue[]
+  started: DispatchedRun[]
+  failed: DispatchFailure[]
+  events: OrchestratorEvent[]
+}


### PR DESCRIPTION
## Summary

This is stacked on #142 and targets `feat/108-tauri-commands` so the review only covers the frontend IPC client slice for #108.

- Adds typed frontend wire models for orchestrator snapshots, queue rows, runs, dispatch batches, workspaces, and lifecycle events.
- Adds `TauriOrchestratorService` for the new Tauri commands: load workflow, refresh snapshot, pause/resume, and dispatch one tick.
- Subscribes to the `orchestrator:event` stream behind a typed callback API.
- Adds a `MockOrchestratorService` and factory fallback for tests and non-Tauri browser mode.

Refs #108.

## Validation

- `npm test -- src/features/orchestrator --run`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `git diff --check`
- pre-push `npm test`