### PR TITLE
feat(orchestrator): add queue status panel

### DIFF
--- a/src/features/orchestrator/components/OrchestratorPanel.test.tsx
+++ b/src/features/orchestrator/components/OrchestratorPanel.test.tsx
@@ -1,0 +1,196 @@
+import { describe, expect, test, vi } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { OrchestratorPanel } from './OrchestratorPanel'
+import type { OrchestratorService } from '../services/orchestratorService'
+import type {
+  DispatchBatch,
+  OrchestratorEvent,
+  OrchestratorSnapshot,
+} from '../types'
+
+const baseSnapshot: OrchestratorSnapshot = {
+  paused: false,
+  queue: [
+    {
+      issue: {
+        id: 'issue-1',
+        identifier: 'VIM-108',
+        title: 'Add orchestration UI',
+        description: null,
+        state: 'Ready',
+        url: 'https://example.test/issues/VIM-108',
+        labels: ['enhancement'],
+        priority: 1,
+        updatedAt: '2026-05-02T07:00:00Z',
+      },
+      status: 'queued',
+      runId: null,
+      attemptNumber: null,
+      nextRetryAt: null,
+      lastError: null,
+    },
+  ],
+  running: [
+    {
+      runId: 'run-1234567890',
+      issueId: 'issue-2',
+      issueIdentifier: 'VIM-109',
+      attemptNumber: 2,
+      status: 'running',
+      workspacePath: '/tmp/vimeflow/VIM-109',
+      startedAt: '2026-05-02T07:05:00Z',
+      lastEvent: 'Agent started',
+    },
+  ],
+  retryQueue: [
+    {
+      issueId: 'issue-3',
+      issueIdentifier: 'VIM-110',
+      attemptNumber: 3,
+      nextRetryAt: '2026-05-02T07:10:00Z',
+      lastError: 'Network timeout',
+    },
+  ],
+}
+
+const dispatchEvent: OrchestratorEvent = {
+  timestamp: '2026-05-02T07:06:00Z',
+  workflowPath: '/repo/WORKFLOW.md',
+  issueId: 'issue-2',
+  issueIdentifier: 'VIM-109',
+  runId: 'run-1234567890',
+  attemptNumber: 2,
+  status: 'running',
+  workspacePath: '/tmp/vimeflow/VIM-109',
+  message: 'Agent running',
+  error: null,
+}
+
+const createService = (
+  snapshot: OrchestratorSnapshot = baseSnapshot
+): OrchestratorService & {
+  emit: (event: OrchestratorEvent) => void
+  cleanup: ReturnType<typeof vi.fn>
+} => {
+  const callbacks: ((event: OrchestratorEvent) => void)[] = []
+  const cleanup = vi.fn()
+
+  return {
+    loadWorkflow: vi.fn(
+      (): Promise<OrchestratorSnapshot> => Promise.resolve(snapshot)
+    ),
+    refreshSnapshot: vi.fn(
+      (): Promise<OrchestratorSnapshot> => Promise.resolve(snapshot)
+    ),
+    setPaused: vi.fn(
+      (paused: boolean): Promise<OrchestratorSnapshot> =>
+        Promise.resolve({ ...snapshot, paused })
+    ),
+    dispatchOnce: vi.fn(
+      (): Promise<DispatchBatch> =>
+        Promise.resolve({
+          snapshot,
+          claimed: [],
+          started: [],
+          failed: [],
+          events: [dispatchEvent],
+        })
+    ),
+    onEvent: vi.fn(
+      (callback: (event: OrchestratorEvent) => void): Promise<() => void> => {
+        callbacks.push(callback)
+
+        return Promise.resolve(cleanup)
+      }
+    ),
+    emit: (event: OrchestratorEvent): void => {
+      callbacks.forEach((callback) => callback(event))
+    },
+    cleanup,
+  }
+}
+
+describe('OrchestratorPanel', () => {
+  test('loads a workflow and renders queue, running, and retry rows', async (): Promise<void> => {
+    const service = createService()
+    const user = userEvent.setup()
+
+    render(<OrchestratorPanel service={service} />)
+
+    await user.type(
+      screen.getByRole('textbox', { name: /workflow path/i }),
+      '/repo/WORKFLOW.md'
+    )
+    await user.click(screen.getByRole('button', { name: 'Load' }))
+
+    await screen.findByText('Add orchestration UI')
+
+    expect(service.loadWorkflow).toHaveBeenCalledWith('/repo/WORKFLOW.md')
+    expect(screen.getByText('/repo/WORKFLOW.md')).toBeInTheDocument()
+    expect(screen.getByText('VIM-108')).toBeInTheDocument()
+    expect(screen.getByText('VIM-109')).toBeInTheDocument()
+    expect(screen.getByText('VIM-110')).toBeInTheDocument()
+    expect(screen.getByText('/tmp/vimeflow/VIM-109')).toBeInTheDocument()
+    expect(screen.getByText('Network timeout')).toBeInTheDocument()
+  })
+
+  test('shows a validation error when loading without a path', async (): Promise<void> => {
+    const service = createService()
+    const user = userEvent.setup()
+
+    render(<OrchestratorPanel service={service} />)
+
+    await user.click(screen.getByRole('button', { name: 'Load' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Workflow path is required'
+    )
+    expect(service.loadWorkflow).not.toHaveBeenCalled()
+  })
+
+  test('refreshes and toggles paused state through the service', async (): Promise<void> => {
+    const service = createService()
+    const user = userEvent.setup()
+
+    render(<OrchestratorPanel service={service} />)
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }))
+    await screen.findByText('Add orchestration UI')
+
+    await user.click(screen.getByRole('button', { name: 'Pause' }))
+    await screen.findByText('Paused')
+
+    expect(service.refreshSnapshot).toHaveBeenCalledOnce()
+    expect(service.setPaused).toHaveBeenCalledWith(true)
+  })
+
+  test('dispatches once and prepends batch events to the event feed', async (): Promise<void> => {
+    const service = createService()
+    const user = userEvent.setup()
+
+    render(<OrchestratorPanel service={service} />)
+
+    await user.click(screen.getByRole('button', { name: 'Dispatch' }))
+
+    await screen.findByText('Agent running')
+    expect(service.dispatchOnce).toHaveBeenCalledOnce()
+  })
+
+  test('subscribes to orchestrator events and cleans up on unmount', async (): Promise<void> => {
+    const service = createService()
+    const { unmount } = render(<OrchestratorPanel service={service} />)
+
+    await waitFor(() => expect(service.onEvent).toHaveBeenCalledOnce())
+
+    act(() => {
+      service.emit(dispatchEvent)
+    })
+
+    expect(screen.getByText('Agent running')).toBeInTheDocument()
+
+    unmount()
+
+    expect(service.cleanup).toHaveBeenCalledOnce()
+  })
+})

--- a/src/features/orchestrator/components/OrchestratorPanel.tsx
+++ b/src/features/orchestrator/components/OrchestratorPanel.tsx
@@ -1,0 +1,487 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+  type ReactElement,
+} from 'react'
+import type {
+  DispatchBatch,
+  OrchestratorEvent,
+  OrchestratorRun,
+  OrchestratorSnapshot,
+  QueueIssue,
+  RetryEntry,
+  RunStatus,
+} from '../types'
+import {
+  createOrchestratorService,
+  type OrchestratorService,
+} from '../services/orchestratorService'
+
+const EMPTY_SNAPSHOT: OrchestratorSnapshot = {
+  paused: false,
+  queue: [],
+  running: [],
+  retryQueue: [],
+}
+
+const MAX_EVENTS = 12
+
+const STATUS_LABELS: Record<RunStatus, string> = {
+  queued: 'Queued',
+  claimed: 'Claimed',
+  preparing_workspace: 'Preparing',
+  rendering_prompt: 'Rendering',
+  running: 'Running',
+  retry_scheduled: 'Retrying',
+  succeeded: 'Succeeded',
+  failed: 'Failed',
+  stopped: 'Stopped',
+  released: 'Released',
+}
+
+const STATUS_TONE: Record<RunStatus, string> = {
+  queued: 'bg-surface-container-high text-on-surface-variant',
+  claimed: 'bg-primary-container/40 text-primary',
+  preparing_workspace: 'bg-primary-container/40 text-primary',
+  rendering_prompt: 'bg-primary-container/40 text-primary',
+  running: 'bg-success/15 text-success',
+  retry_scheduled: 'bg-secondary/15 text-secondary',
+  succeeded: 'bg-success/15 text-success',
+  failed: 'bg-error/15 text-error',
+  stopped: 'bg-error/15 text-error',
+  released: 'bg-surface-container-high text-outline',
+}
+
+interface OrchestratorPanelProps {
+  service?: OrchestratorService
+}
+
+interface QueueRow {
+  key: string
+  identifier: string
+  title: string
+  status: RunStatus
+  state: string | null
+  attemptNumber: number | null
+  detail: string | null
+}
+
+const toQueueRows = (snapshot: OrchestratorSnapshot): QueueRow[] => [
+  ...snapshot.running.map((run) => runningRow(run)),
+  ...snapshot.retryQueue.map((entry) => retryRow(entry)),
+  ...snapshot.queue.map((entry) => queueRow(entry)),
+]
+
+const runningRow = (run: OrchestratorRun): QueueRow => ({
+  key: `running:${run.runId}`,
+  identifier: run.issueIdentifier,
+  title: run.lastEvent ?? shortId(run.runId),
+  status: run.status,
+  state: null,
+  attemptNumber: run.attemptNumber,
+  detail: run.workspacePath,
+})
+
+const retryRow = (entry: RetryEntry): QueueRow => ({
+  key: `retry:${entry.issueId}`,
+  identifier: entry.issueIdentifier,
+  title: entry.lastError,
+  status: 'retry_scheduled',
+  state: null,
+  attemptNumber: entry.attemptNumber,
+  detail: `Retry ${formatTimestamp(entry.nextRetryAt)}`,
+})
+
+const queueRow = (entry: QueueIssue): QueueRow => ({
+  key: `queue:${entry.issue.id}`,
+  identifier: entry.issue.identifier,
+  title: entry.issue.title,
+  status: entry.status,
+  state: entry.issue.state,
+  attemptNumber: entry.attemptNumber,
+  detail: entry.lastError ?? retryDetail(entry.nextRetryAt),
+})
+
+const retryDetail = (nextRetryAt: string | null): string | null =>
+  nextRetryAt ? `Retry ${formatTimestamp(nextRetryAt)}` : null
+
+const shortId = (id: string): string => id.slice(0, 8)
+
+const formatTimestamp = (value: string): string => {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date)
+}
+
+const appendEvents = (
+  previous: OrchestratorEvent[],
+  events: OrchestratorEvent[]
+): OrchestratorEvent[] => [...events, ...previous].slice(0, MAX_EVENTS)
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+export const OrchestratorPanel = ({
+  service: serviceProp = undefined,
+}: OrchestratorPanelProps): ReactElement => {
+  const service = useMemo(
+    () => serviceProp ?? createOrchestratorService(),
+    [serviceProp]
+  )
+  const [snapshot, setSnapshot] = useState<OrchestratorSnapshot>(EMPTY_SNAPSHOT)
+
+  const [workflowPath, setWorkflowPath] = useState('')
+
+  const [loadedWorkflowPath, setLoadedWorkflowPath] = useState<string | null>(
+    null
+  )
+
+  const [loadingAction, setLoadingAction] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [events, setEvents] = useState<OrchestratorEvent[]>([])
+
+  useEffect(() => {
+    let disposed = false
+    let cleanup: (() => void) | null = null
+
+    const subscribe = async (): Promise<void> => {
+      try {
+        const unlisten = await service.onEvent((event) => {
+          setEvents((current) => appendEvents(current, [event]))
+        })
+
+        if (disposed) {
+          unlisten()
+
+          return
+        }
+
+        cleanup = unlisten
+      } catch (subscriptionError: unknown) {
+        if (!disposed) {
+          setError(errorMessage(subscriptionError))
+        }
+      }
+    }
+
+    void subscribe()
+
+    return (): void => {
+      disposed = true
+      cleanup?.()
+    }
+  }, [service])
+
+  const rows = useMemo(() => toQueueRows(snapshot), [snapshot])
+
+  const runAction = useCallback(
+    async (
+      action: string,
+      handler: () => Promise<OrchestratorSnapshot | DispatchBatch>
+    ): Promise<void> => {
+      setLoadingAction(action)
+      setError(null)
+
+      try {
+        const result = await handler()
+        if ('snapshot' in result) {
+          setSnapshot(result.snapshot)
+          setEvents((current) => appendEvents(current, result.events))
+        } else {
+          setSnapshot(result)
+        }
+      } catch (actionError: unknown) {
+        setError(errorMessage(actionError))
+      } finally {
+        setLoadingAction(null)
+      }
+    },
+    []
+  )
+
+  const handleLoadWorkflow = useCallback(
+    (event: FormEvent<HTMLFormElement>): void => {
+      event.preventDefault()
+      const trimmedPath = workflowPath.trim()
+      if (trimmedPath.length === 0) {
+        setError('Workflow path is required')
+
+        return
+      }
+
+      void runAction('load', async () => {
+        const nextSnapshot = await service.loadWorkflow(trimmedPath)
+        setLoadedWorkflowPath(trimmedPath)
+
+        return nextSnapshot
+      })
+    },
+    [runAction, service, workflowPath]
+  )
+
+  const handleRefresh = useCallback((): void => {
+    void runAction('refresh', () => service.refreshSnapshot())
+  }, [runAction, service])
+
+  const handlePauseToggle = useCallback((): void => {
+    void runAction('pause', () => service.setPaused(!snapshot.paused))
+  }, [runAction, service, snapshot.paused])
+
+  const handleDispatch = useCallback((): void => {
+    void runAction('dispatch', () => service.dispatchOnce())
+  }, [runAction, service])
+
+  const busy = loadingAction !== null
+  const workflowDisplay = loadedWorkflowPath ?? 'No workflow loaded'
+
+  return (
+    <aside
+      data-testid="orchestrator-panel"
+      className="flex h-full w-[320px] flex-col overflow-hidden bg-surface-container-low"
+      aria-label="Orchestration"
+    >
+      <div className="flex items-center justify-between px-4 pb-3 pt-4">
+        <div className="min-w-0">
+          <h2 className="font-headline text-sm font-[800] text-on-surface">
+            Orchestration
+          </h2>
+          <p className="truncate text-[10px] text-on-surface-variant">
+            {workflowDisplay}
+          </p>
+        </div>
+        <span
+          className={`rounded-full px-2 py-1 text-[10px] font-semibold uppercase ${
+            snapshot.paused
+              ? 'bg-secondary/15 text-secondary'
+              : 'bg-success/15 text-success'
+          }`}
+        >
+          {snapshot.paused ? 'Paused' : 'Active'}
+        </span>
+      </div>
+
+      <form
+        onSubmit={handleLoadWorkflow}
+        className="flex shrink-0 gap-2 px-3 pb-3"
+      >
+        <label className="sr-only" htmlFor="orchestrator-workflow-path">
+          Workflow path
+        </label>
+        <input
+          id="orchestrator-workflow-path"
+          value={workflowPath}
+          onChange={(event) => setWorkflowPath(event.target.value)}
+          placeholder="/repo/WORKFLOW.md"
+          className="min-w-0 flex-1 rounded-md bg-surface-container-high px-2 py-1.5 font-mono text-[11px] text-on-surface outline-none ring-1 ring-transparent transition focus:ring-primary/60"
+        />
+        <button
+          type="submit"
+          disabled={busy}
+          className="rounded-md bg-primary-container px-3 py-1.5 text-[11px] font-semibold text-primary transition-colors hover:bg-primary-container/80 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Load
+        </button>
+      </form>
+
+      <div className="grid grid-cols-3 gap-2 px-3 pb-3">
+        <Metric label="Queued" value={snapshot.queue.length} />
+        <Metric label="Running" value={snapshot.running.length} />
+        <Metric label="Retrying" value={snapshot.retryQueue.length} />
+      </div>
+
+      <div className="flex shrink-0 gap-2 px-3 pb-3">
+        <IconButton
+          label="Refresh"
+          icon="refresh"
+          disabled={busy}
+          onClick={handleRefresh}
+        />
+        <IconButton
+          label={snapshot.paused ? 'Resume' : 'Pause'}
+          icon={snapshot.paused ? 'play_arrow' : 'pause'}
+          disabled={busy}
+          onClick={handlePauseToggle}
+        />
+        <IconButton
+          label="Dispatch"
+          icon="bolt"
+          disabled={busy}
+          onClick={handleDispatch}
+        />
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mx-3 mb-3 rounded-md bg-error/15 px-3 py-2 text-[11px] text-error"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="thin-scrollbar flex-1 overflow-y-auto">
+        <section className="px-3 pb-4" aria-labelledby="work-queue-heading">
+          <div className="mb-2 flex items-center justify-between">
+            <h3
+              id="work-queue-heading"
+              className="font-label text-[10px] font-semibold uppercase tracking-wider text-on-surface/50"
+            >
+              Work Queue
+            </h3>
+            <span className="text-[10px] text-outline">{rows.length}</span>
+          </div>
+
+          {rows.length === 0 ? (
+            <p className="rounded-lg bg-surface-container px-3 py-3 text-[11px] text-on-surface-variant">
+              No orchestrator work
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {rows.map((row) => (
+                <QueueRowItem key={row.key} row={row} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="px-3 pb-4" aria-labelledby="events-heading">
+          <div className="mb-2 flex items-center justify-between">
+            <h3
+              id="events-heading"
+              className="font-label text-[10px] font-semibold uppercase tracking-wider text-on-surface/50"
+            >
+              Recent Events
+            </h3>
+            <span className="text-[10px] text-outline">{events.length}</span>
+          </div>
+
+          {events.length === 0 ? (
+            <p className="rounded-lg bg-surface-container px-3 py-3 text-[11px] text-on-surface-variant">
+              No events yet
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {events.map((event) => (
+                <EventRow
+                  key={`${event.timestamp}:${event.issueIdentifier}:${event.status}`}
+                  event={event}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </aside>
+  )
+}
+
+const Metric = ({
+  label,
+  value,
+}: {
+  label: string
+  value: number
+}): ReactElement => (
+  <div className="rounded-lg bg-surface-container p-2">
+    <div className="font-mono text-lg font-semibold leading-none text-on-surface">
+      {value}
+    </div>
+    <div className="mt-1 text-[10px] text-on-surface-variant">{label}</div>
+  </div>
+)
+
+const IconButton = ({
+  label,
+  icon,
+  disabled,
+  onClick,
+}: {
+  label: string
+  icon: string
+  disabled: boolean
+  onClick: () => void
+}): ReactElement => (
+  <button
+    type="button"
+    aria-label={label}
+    title={label}
+    disabled={disabled}
+    onClick={onClick}
+    className="flex h-9 flex-1 items-center justify-center rounded-md bg-surface-container-high text-on-surface-variant transition-colors hover:bg-surface-container hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
+  >
+    <span className="material-symbols-outlined text-base">{icon}</span>
+  </button>
+)
+
+const QueueRowItem = ({ row }: { row: QueueRow }): ReactElement => (
+  <article className="rounded-lg bg-surface-container p-3">
+    <div className="flex items-start justify-between gap-2">
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="font-mono text-[11px] font-semibold text-primary">
+            {row.identifier}
+          </span>
+          {row.state && (
+            <span className="truncate text-[10px] text-outline">
+              {row.state}
+            </span>
+          )}
+        </div>
+        <h4 className="mt-1 line-clamp-2 text-xs font-medium text-on-surface">
+          {row.title}
+        </h4>
+      </div>
+      <StatusBadge status={row.status} />
+    </div>
+    <div className="mt-2 flex items-center gap-2 text-[10px] text-on-surface-variant">
+      {row.attemptNumber !== null && <span>Attempt {row.attemptNumber}</span>}
+      {row.detail && <span className="truncate">{row.detail}</span>}
+    </div>
+  </article>
+)
+
+const StatusBadge = ({ status }: { status: RunStatus }): ReactElement => (
+  <span
+    className={`shrink-0 rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase ${STATUS_TONE[status]}`}
+  >
+    {STATUS_LABELS[status]}
+  </span>
+)
+
+const EventRow = ({ event }: { event: OrchestratorEvent }): ReactElement => {
+  const detail = event.error ?? event.message ?? event.workspacePath
+
+  return (
+    <article className="rounded-lg bg-surface-container p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="font-mono text-[11px] font-semibold text-primary">
+              {event.issueIdentifier}
+            </span>
+            <span className="text-[10px] text-outline">
+              {formatTimestamp(event.timestamp)}
+            </span>
+          </div>
+          {detail && (
+            <p className="mt-1 line-clamp-2 text-[11px] text-on-surface-variant">
+              {detail}
+            </p>
+          )}
+        </div>
+        <StatusBadge status={event.status} />
+      </div>
+    </article>
+  )
+}
+
+export default OrchestratorPanel

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -75,6 +75,12 @@ vi.mock('../agent-status/components/AgentStatusPanel', () => ({
   },
 }))
 
+vi.mock('../orchestrator/components/OrchestratorPanel', () => ({
+  OrchestratorPanel: (): ReactElement => (
+    <div data-testid="orchestrator-panel" />
+  ),
+}))
+
 // Mock terminal service to return initial session data synchronously
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => ({
@@ -133,24 +139,27 @@ describe('WorkspaceView', () => {
     })
   })
 
-  test('renders all five zones (icon rail, sidebar, terminal, bottom drawer, agent status panel)', () => {
+  test('renders all six zones (icon rail, sidebar, terminal, bottom drawer, orchestrator, agent status panel)', () => {
     render(<WorkspaceView />)
 
     expect(screen.getByTestId('icon-rail')).toBeInTheDocument()
     expect(screen.getByTestId('sidebar')).toBeInTheDocument()
     expect(screen.getByTestId('terminal-zone')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /editor/i })).toBeInTheDocument() // BottomDrawer
+    expect(screen.getByTestId('orchestrator-panel')).toBeInTheDocument()
     expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
   })
 
-  test('applies correct grid layout with 4 columns (dynamic sidebar width)', () => {
+  test('applies correct grid layout with 5 columns (dynamic sidebar width)', () => {
     render(<WorkspaceView />)
 
     const container = screen.getByTestId('workspace-view')
 
     expect(container).toHaveClass('grid')
-    // Grid columns: 64px icon rail + dynamic sidebar + 1fr main + auto (panel self-manages width)
-    expect(container.style.gridTemplateColumns).toBe('64px 340px 1fr auto')
+    // Grid columns: icon rail + dynamic sidebar + main + orchestrator + agent panel
+    expect(container.style.gridTemplateColumns).toBe(
+      '64px 340px minmax(0, 1fr) 320px auto'
+    )
   })
 
   test('fills viewport height', () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from './components/Sidebar'
 import { TerminalZone } from './components/TerminalZone'
 import BottomDrawer from './components/BottomDrawer'
 import { AgentStatusPanel } from '../agent-status/components/AgentStatusPanel'
+import { OrchestratorPanel } from '../orchestrator/components/OrchestratorPanel'
 import { UnsavedChangesDialog } from '../editor/components/UnsavedChangesDialog'
 import { mockNavigationItems, mockSettingsItem } from './data/mockNavigation'
 import { useSessionManager } from './hooks/useSessionManager'
@@ -308,7 +309,7 @@ export const WorkspaceView = (): ReactElement => {
       data-testid="workspace-view"
       className="grid h-screen overflow-hidden"
       style={{
-        gridTemplateColumns: `64px ${sidebarWidth}px 1fr auto`,
+        gridTemplateColumns: `64px ${sidebarWidth}px minmax(0, 1fr) 320px auto`,
       }}
     >
       {/* Icon Rail - 64px */}
@@ -407,6 +408,8 @@ export const WorkspaceView = (): ReactElement => {
           </div>
         )}
       </div>
+
+      <OrchestratorPanel />
 
       {/* Agent Status Panel — self-manages width (0↔280px) */}
       <AgentStatusPanel

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -89,13 +89,15 @@ import { WorkspaceView } from './WorkspaceView'
  */
 
 describe('WorkspaceView - Visual Verification (Feature #20)', () => {
-  describe('Layout: 5-Zone Architecture (v2)', () => {
-    test('grid layout has correct zone widths (64px, 340px, 1fr, auto)', () => {
+  describe('Layout: 6-Zone Architecture (v3)', () => {
+    test('grid layout has correct zone widths (64px, 340px, minmax main, 320px, auto)', () => {
       render(<WorkspaceView />)
       const workspace = screen.getByTestId('workspace-view')
 
-      // Grid columns: 64px icon rail + 340px sidebar + 1fr main + auto (panel self-manages width)
-      expect(workspace.style.gridTemplateColumns).toBe('64px 340px 1fr auto')
+      // Grid columns: icon rail + sidebar + main + orchestrator + agent panel.
+      expect(workspace.style.gridTemplateColumns).toBe(
+        '64px 340px minmax(0, 1fr) 320px auto'
+      )
     })
 
     test('workspace uses full screen height', () => {


### PR DESCRIPTION
## Summary

This is stacked on #143 and targets `feat/108-orchestrator-ipc-client` so the review only covers the frontend queue/status UI slice for #108.

- Adds an `OrchestratorPanel` that loads a `WORKFLOW.md`, renders queue/running/retry counts, and lists issue/run rows from the typed orchestrator snapshot.
- Subscribes to `orchestrator:event` and shows recent lifecycle events while cleaning up the listener on unmount.
- Adds safe operator actions backed by the IPC client: refresh, pause/resume, and dispatch once.
- Wires the panel into `WorkspaceView` as a dedicated right-side orchestration surface and updates layout/visual tests for the new column.

Refs #108.

## Validation

- `npm test -- src/features/orchestrator --run`
- `npm test -- src/features/workspace/WorkspaceView.visual.test.tsx src/features/workspace/WorkspaceView.test.tsx src/features/orchestrator --run`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- `npm test`
- pre-push `npm test`