### PR TITLE
feat(orchestrator): reconcile ineligible work

### DIFF
--- a/src-tauri/src/orchestrator/commands.rs
+++ b/src-tauri/src/orchestrator/commands.rs
@@ -91,7 +91,7 @@ impl OrchestratorService {
         })
     }
 
-    fn snapshot(&self) -> Result<OrchestratorSnapshot, String> {
+    fn snapshot(&mut self) -> Result<OrchestratorSnapshot, String> {
         self.runtime.snapshot().map_err(|error| error.to_string())
     }
 
@@ -112,7 +112,7 @@ pub async fn load_orchestrator_workflow(
     request: LoadOrchestratorWorkflowRequest,
 ) -> Result<OrchestratorSnapshot, String> {
     let workflow_path = validate_workflow_path(&request.workflow_path)?;
-    let service = OrchestratorService::from_workflow_path(&workflow_path)?;
+    let mut service = OrchestratorService::from_workflow_path(&workflow_path)?;
     let snapshot = service.snapshot()?;
     state.replace_service(service)?;
 

--- a/src-tauri/src/orchestrator/mod.rs
+++ b/src-tauri/src/orchestrator/mod.rs
@@ -16,8 +16,8 @@ pub use runtime::{
     OrchestratorRuntimeError,
 };
 pub use state::{
-    OrchestratorEvent, OrchestratorRun, OrchestratorSnapshot, OrchestratorState, QueueIssue,
-    RetryEntry, RunStatus, StateError,
+    ActiveWork, OrchestratorEvent, OrchestratorRun, OrchestratorSnapshot, OrchestratorState,
+    QueueIssue, RetryEntry, RunStatus, StateError,
 };
 pub use tracker::{
     GithubHttpClient, GithubIssuesTracker, GithubRequest, TrackerClient, TrackerError,

--- a/src-tauri/src/orchestrator/runtime.rs
+++ b/src-tauri/src/orchestrator/runtime.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 use crate::orchestrator::{
-    render_prompt, AgentRun, AgentRunRequest, AgentRunner, AttemptTemplateContext,
+    render_prompt, ActiveWork, AgentRun, AgentRunRequest, AgentRunner, AttemptTemplateContext,
     OrchestratorEvent, OrchestratorIssue, OrchestratorSnapshot, OrchestratorState,
     PromptTemplateContext, QueueIssue, RetryEntry, RunStatus, StateError, TrackerClient,
     TrackerError, WorkflowDefinition, WorkspaceManager, WorkspacePlan, WorkspaceTemplateContext,
@@ -87,8 +87,10 @@ impl<T> OrchestratorRuntime<T>
 where
     T: TrackerClient,
 {
-    pub fn snapshot(&self) -> Result<OrchestratorSnapshot, OrchestratorRuntimeError> {
+    pub fn snapshot(&mut self) -> Result<OrchestratorSnapshot, OrchestratorRuntimeError> {
         let issues = self.tracker.fetch_issues()?;
+        self.reconcile_ineligible_work(&issues, None, &mut Vec::new());
+
         Ok(self.state.snapshot(issues))
     }
 
@@ -140,6 +142,7 @@ where
     ) -> Result<ClaimBatch, OrchestratorRuntimeError> {
         let mut claimed = Vec::new();
         let mut events = Vec::new();
+        self.reconcile_ineligible_work(&issues, Some(timestamp), &mut events);
 
         if !self.state.is_paused() {
             let mut available_slots = self.available_slots();
@@ -464,6 +467,35 @@ where
         Ok(parse_timestamp(next_retry_at)? <= parse_timestamp(timestamp)?)
     }
 
+    fn reconcile_ineligible_work(
+        &mut self,
+        issues: &[OrchestratorIssue],
+        timestamp: Option<&str>,
+        events: &mut Vec<OrchestratorEvent>,
+    ) {
+        for work in self.state.active_work() {
+            let issue = issues.iter().find(|issue| issue.id == work.issue_id);
+            if issue.is_some_and(|issue| self.is_active_issue(issue)) {
+                continue;
+            }
+
+            let status = self.release_status_for_work(work.status);
+            self.state.release_issue(&work.issue_id, status);
+
+            if let Some(timestamp) = timestamp {
+                events.push(self.reconciliation_event(issue, &work, timestamp, status));
+            }
+        }
+    }
+
+    fn release_status_for_work(&self, status: RunStatus) -> RunStatus {
+        if status == RunStatus::Running {
+            RunStatus::Stopped
+        } else {
+            RunStatus::Released
+        }
+    }
+
     fn available_slots(&self) -> usize {
         usize::from(self.workflow.config.agent.max_concurrent)
             .saturating_sub(self.state.in_flight_count())
@@ -507,6 +539,29 @@ where
             Some("retry claimed for dispatch".to_string()),
             claim.last_error.clone(),
         )
+    }
+
+    fn reconciliation_event(
+        &self,
+        issue: Option<&OrchestratorIssue>,
+        work: &ActiveWork,
+        timestamp: &str,
+        status: RunStatus,
+    ) -> OrchestratorEvent {
+        OrchestratorEvent {
+            timestamp: timestamp.to_string(),
+            workflow_path: self.workflow.path.clone(),
+            issue_id: work.issue_id.clone(),
+            issue_identifier: issue
+                .map(|issue| issue.identifier.clone())
+                .unwrap_or_else(|| work.issue_identifier.clone()),
+            run_id: work.run_id.clone(),
+            attempt_number: work.attempt_number,
+            status,
+            workspace_path: work.workspace_path.clone(),
+            message: Some("issue no longer eligible; releasing orchestrator work".to_string()),
+            error: work.last_error.clone(),
+        }
     }
 
     fn issue_event(
@@ -561,26 +616,32 @@ mod tests {
 
     #[derive(Debug, Clone)]
     struct StaticTracker {
-        result: Result<Vec<OrchestratorIssue>, TrackerError>,
+        result: Rc<RefCell<Result<Vec<OrchestratorIssue>, TrackerError>>>,
     }
 
     impl StaticTracker {
         fn with_issues(issues: Vec<OrchestratorIssue>) -> Self {
-            Self { result: Ok(issues) }
+            Self {
+                result: Rc::new(RefCell::new(Ok(issues))),
+            }
         }
 
         fn with_error(message: &str) -> Self {
             Self {
-                result: Err(TrackerError::Transient {
+                result: Rc::new(RefCell::new(Err(TrackerError::Transient {
                     message: message.to_string(),
-                }),
+                }))),
             }
+        }
+
+        fn set_issues(&self, issues: Vec<OrchestratorIssue>) {
+            *self.result.borrow_mut() = Ok(issues);
         }
     }
 
     impl TrackerClient for StaticTracker {
         fn fetch_issues(&self) -> Result<Vec<OrchestratorIssue>, TrackerError> {
-            self.result.clone()
+            self.result.borrow().clone()
         }
     }
 
@@ -703,6 +764,28 @@ mod tests {
     }
 
     #[test]
+    fn claim_ready_releases_claimed_work_when_issue_becomes_ineligible() {
+        let workflow = workflow_with_max_concurrent(1);
+        let tracker = StaticTracker::with_issues(vec![issue("issue-1", "#1", "open")]);
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker.clone());
+
+        let first = runtime.claim_ready("2026-05-02T07:55:00Z").unwrap();
+        tracker.set_issues(vec![issue("issue-1", "#1", "closed")]);
+        let second = runtime.claim_ready("2026-05-02T07:56:00Z").unwrap();
+
+        assert_eq!(first.claimed.len(), 1);
+        assert!(second.claimed.is_empty());
+        assert_eq!(second.snapshot.queue[0].status, RunStatus::Released);
+        assert_eq!(runtime.in_flight_count(), 0);
+        assert!(second.events.iter().any(|event| {
+            event.status == RunStatus::Released
+                && event.issue_identifier == "#1"
+                && event.message.as_deref()
+                    == Some("issue no longer eligible; releasing orchestrator work")
+        }));
+    }
+
+    #[test]
     fn claim_ready_surfaces_tracker_errors_without_claiming() {
         let workflow = workflow_with_max_concurrent(1);
         let tracker = StaticTracker::with_error("tracker unavailable");
@@ -711,6 +794,20 @@ mod tests {
         let error = runtime.claim_ready("2026-05-02T07:55:00Z").unwrap_err();
 
         assert!(matches!(error, OrchestratorRuntimeError::Tracker(_)));
+        assert_eq!(runtime.in_flight_count(), 0);
+    }
+
+    #[test]
+    fn snapshot_releases_ineligible_active_work_without_requiring_dispatch() {
+        let workflow = workflow_with_max_concurrent(1);
+        let tracker = StaticTracker::with_issues(vec![issue("issue-1", "#1", "open")]);
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker.clone());
+
+        runtime.claim_ready("2026-05-02T07:55:00Z").unwrap();
+        tracker.set_issues(vec![issue("issue-1", "#1", "closed")]);
+        let snapshot = runtime.snapshot().unwrap();
+
+        assert_eq!(snapshot.queue[0].status, RunStatus::Released);
         assert_eq!(runtime.in_flight_count(), 0);
     }
 
@@ -768,6 +865,31 @@ mod tests {
     }
 
     #[test]
+    fn claim_ready_stops_running_work_when_issue_becomes_ineligible() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let runner = RecordingRunner::with_run("run-108");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker.clone());
+
+        runtime
+            .dispatch_ready(&workspace_manager, &runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+        tracker.set_issues(vec![issue("issue-108", "#108", "closed")]);
+        let batch = runtime.claim_ready("2026-05-02T08:16:00Z").unwrap();
+
+        assert!(batch.claimed.is_empty());
+        assert!(batch.snapshot.running.is_empty());
+        assert_eq!(batch.snapshot.queue[0].status, RunStatus::Stopped);
+        assert_eq!(runtime.in_flight_count(), 0);
+        assert!(batch.events.iter().any(|event| {
+            event.status == RunStatus::Stopped
+                && event.run_id.as_deref() == Some("run-108")
+                && event.workspace_path.is_some()
+        }));
+    }
+
+    #[test]
     fn dispatch_ready_schedules_retry_when_runner_start_fails_before_max_attempts() {
         let (_dir, workflow) = workflow_fixture(1);
         let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
@@ -798,6 +920,29 @@ mod tests {
             .iter()
             .any(|event| event.status == RunStatus::RetryScheduled
                 && event.error.as_deref() == Some("failed to start agent: codex missing")));
+    }
+
+    #[test]
+    fn claim_ready_releases_retry_work_when_issue_becomes_ineligible() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let runner = RecordingRunner::with_error("codex missing");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker.clone());
+
+        runtime
+            .dispatch_ready(&workspace_manager, &runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+        tracker.set_issues(vec![issue("issue-108", "#108", "closed")]);
+        let batch = runtime.claim_ready("2026-05-02T08:16:00Z").unwrap();
+
+        assert!(batch.claimed.is_empty());
+        assert!(batch.snapshot.retry_queue.is_empty());
+        assert_eq!(batch.snapshot.queue[0].status, RunStatus::Released);
+        assert!(batch.events.iter().any(|event| {
+            event.status == RunStatus::Released
+                && event.error.as_deref() == Some("failed to start agent: codex missing")
+        }));
     }
 
     #[test]

--- a/src-tauri/src/orchestrator/state.rs
+++ b/src-tauri/src/orchestrator/state.rs
@@ -79,6 +79,17 @@ pub struct OrchestratorEvent {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveWork {
+    pub issue_id: String,
+    pub issue_identifier: String,
+    pub status: RunStatus,
+    pub run_id: Option<String>,
+    pub attempt_number: Option<u32>,
+    pub workspace_path: Option<PathBuf>,
+    pub last_error: Option<String>,
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum StateError {
     #[error("issue is already claimed, running, or retrying: {issue_id}")]
@@ -231,6 +242,40 @@ impl OrchestratorState {
         let mut entries: Vec<_> = self.retry_queue.values().cloned().collect();
         entries.sort_by(|left, right| left.issue_identifier.cmp(&right.issue_identifier));
         entries
+    }
+
+    pub fn active_work(&self) -> Vec<ActiveWork> {
+        let mut work = Vec::new();
+
+        work.extend(self.claimed.iter().map(|(issue_id, claim)| ActiveWork {
+            issue_id: issue_id.clone(),
+            issue_identifier: claim.issue_identifier.clone(),
+            status: RunStatus::Claimed,
+            run_id: None,
+            attempt_number: Some(claim.attempt_number),
+            workspace_path: None,
+            last_error: claim.previous_error.clone(),
+        }));
+        work.extend(self.running.values().map(|run| ActiveWork {
+            issue_id: run.issue_id.clone(),
+            issue_identifier: run.issue_identifier.clone(),
+            status: RunStatus::Running,
+            run_id: Some(run.run_id.clone()),
+            attempt_number: Some(run.attempt_number),
+            workspace_path: Some(run.workspace_path.clone()),
+            last_error: None,
+        }));
+        work.extend(self.retry_queue.values().map(|retry| ActiveWork {
+            issue_id: retry.issue_id.clone(),
+            issue_identifier: retry.issue_identifier.clone(),
+            status: RunStatus::RetryScheduled,
+            run_id: None,
+            attempt_number: Some(retry.attempt_number),
+            workspace_path: None,
+            last_error: Some(retry.last_error.clone()),
+        }));
+        work.sort_by(|left, right| left.issue_identifier.cmp(&right.issue_identifier));
+        work
     }
 
     pub fn release_issue(&mut self, issue_id: &str, status: RunStatus) {
@@ -463,6 +508,43 @@ mod tests {
         assert!(!state.is_issue_active("issue-108"));
         assert!(snapshot.running.is_empty());
         assert_eq!(snapshot.queue[0].status, RunStatus::Stopped);
+    }
+
+    #[test]
+    fn active_work_lists_claimed_running_and_retry_entries() {
+        let mut state = OrchestratorState::new();
+        let claimed = issue("issue-108", "#108");
+        let running = issue("issue-109", "#109");
+        state.claim_issue(&claimed).unwrap();
+        state.claim_issue(&running).unwrap();
+        state
+            .mark_running(
+                "issue-109",
+                "run-109",
+                1,
+                PathBuf::from("/tmp/workspace-109"),
+                "2026-05-02T00:00:00Z",
+            )
+            .unwrap();
+        state.schedule_retry(RetryEntry {
+            issue_id: "issue-110".to_string(),
+            issue_identifier: "#110".to_string(),
+            attempt_number: 2,
+            next_retry_at: "2026-05-02T00:01:00Z".to_string(),
+            last_error: "agent exited 1".to_string(),
+        });
+
+        let work = state.active_work();
+
+        assert_eq!(work.len(), 3);
+        assert_eq!(work[0].issue_identifier, "#108");
+        assert_eq!(work[0].status, RunStatus::Claimed);
+        assert_eq!(work[1].issue_identifier, "#109");
+        assert_eq!(work[1].status, RunStatus::Running);
+        assert_eq!(work[1].run_id.as_deref(), Some("run-109"));
+        assert_eq!(work[2].issue_identifier, "#110");
+        assert_eq!(work[2].status, RunStatus::RetryScheduled);
+        assert_eq!(work[2].last_error.as_deref(), Some("agent exited 1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This is stacked on #145 and targets `feat/108-retry-runtime` so the review only covers the eligibility-reconciliation slice for #108.

- Adds an active-work projection over claimed, running, and retrying orchestrator state.
- Reconciles fetched tracker issues before snapshot/claim so work whose issue leaves active states is no longer reported as active.
- Marks running work as `Stopped` and claimed/retry work as `Released`, preserving run/workspace/error context in lifecycle events where available.
- Updates the Tauri command service snapshot path to allow reconciliation during refresh.

Refs #108.

## Validation

- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml orchestrator::runtime -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml orchestrator:: -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo check --manifest-path src-tauri/Cargo.toml`
- `rustfmt --edition 2021 --check src-tauri/src/orchestrator/mod.rs src-tauri/src/orchestrator/commands.rs src-tauri/src/orchestrator/runtime.rs src-tauri/src/orchestrator/state.rs`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- pre-push `npm test`