### PR TITLE
feat(orchestrator): add manual run controls

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,16 +9,20 @@ use agent::{
     stop_transcript_watcher, AgentWatcherState, TranscriptState,
 };
 use filesystem::{list_dir, read_file, write_file};
-use git::{get_git_diff, git_status, watcher::{start_git_watcher, stop_git_watcher, GitWatcherState}};
+use git::{
+    get_git_diff, git_status,
+    watcher::{start_git_watcher, stop_git_watcher, GitWatcherState},
+};
 use orchestrator::{
     dispatch_orchestrator_once, load_orchestrator_workflow, refresh_orchestrator_snapshot,
-    set_orchestrator_paused, OrchestratorCommandState,
+    retry_orchestrator_issue, set_orchestrator_paused, stop_orchestrator_run,
+    OrchestratorCommandState,
 };
 use std::sync::Arc;
 use tauri::Manager;
 use terminal::{
-    cache::SessionCache, kill_pty, list_sessions, reorder_sessions, resize_pty,
-    set_active_session, spawn_pty, update_session_cwd, write_pty, PtyState,
+    cache::SessionCache, kill_pty, list_sessions, reorder_sessions, resize_pty, set_active_session,
+    spawn_pty, update_session_cwd, write_pty, PtyState,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -34,7 +38,10 @@ pub fn run() {
             }
 
             // Initialize session cache in app_data_dir
-            let app_data_dir = app.path().app_data_dir().expect("failed to get app_data_dir");
+            let app_data_dir = app
+                .path()
+                .app_data_dir()
+                .expect("failed to get app_data_dir");
             let cache_path = app_data_dir.join("sessions.json");
 
             // E2E test mode: wipe the cache on every launch.
@@ -107,7 +114,9 @@ pub fn run() {
         load_orchestrator_workflow,
         refresh_orchestrator_snapshot,
         set_orchestrator_paused,
-        dispatch_orchestrator_once
+        dispatch_orchestrator_once,
+        stop_orchestrator_run,
+        retry_orchestrator_issue
     ]);
 
     #[cfg(feature = "e2e-test")]
@@ -136,6 +145,8 @@ pub fn run() {
         refresh_orchestrator_snapshot,
         set_orchestrator_paused,
         dispatch_orchestrator_once,
+        stop_orchestrator_run,
+        retry_orchestrator_issue,
         terminal::test_commands::list_active_pty_sessions
     ]);
 

--- a/src-tauri/src/orchestrator/commands.rs
+++ b/src-tauri/src/orchestrator/commands.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use tauri::{AppHandle, Emitter, Runtime, State};
 
 use crate::orchestrator::{
-    load_workflow_from_path, CommandAgentRunner, DispatchBatch, GithubIssuesTracker,
-    OrchestratorRuntime, OrchestratorSnapshot, WorkspaceManager,
+    load_workflow_from_path, CommandAgentRunner, ControlBatch, DispatchBatch, GithubIssuesTracker,
+    OrchestratorEvent, OrchestratorRuntime, OrchestratorSnapshot, WorkspaceManager,
 };
 
 const ORCHESTRATOR_EVENT: &str = "orchestrator:event";
@@ -24,6 +24,12 @@ pub struct LoadOrchestratorWorkflowRequest {
 #[serde(rename_all = "camelCase")]
 pub struct SetOrchestratorPausedRequest {
     pub paused: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrchestratorIssueControlRequest {
+    pub issue_id: String,
 }
 
 pub struct OrchestratorCommandState {
@@ -104,6 +110,18 @@ impl OrchestratorService {
             .dispatch_ready(&self.workspace_manager, &self.runner, timestamp)
             .map_err(|error| error.to_string())
     }
+
+    fn stop_run(&mut self, issue_id: &str, timestamp: &str) -> Result<ControlBatch, String> {
+        self.runtime
+            .stop_run(&self.runner, issue_id, timestamp)
+            .map_err(|error| error.to_string())
+    }
+
+    fn retry_issue(&mut self, issue_id: &str, timestamp: &str) -> Result<DispatchBatch, String> {
+        self.runtime
+            .retry_issue_now(&self.workspace_manager, &self.runner, issue_id, timestamp)
+            .map_err(|error| error.to_string())
+    }
 }
 
 #[tauri::command]
@@ -145,13 +163,45 @@ pub async fn dispatch_orchestrator_once<R: Runtime>(
     let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
     let batch = state.with_service(|service| service.dispatch_once(&timestamp))?;
 
-    for event in &batch.events {
+    emit_orchestrator_events(&app, &batch.events);
+
+    Ok(batch)
+}
+
+#[tauri::command]
+pub async fn stop_orchestrator_run<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, OrchestratorCommandState>,
+    request: OrchestratorIssueControlRequest,
+) -> Result<ControlBatch, String> {
+    let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+    let batch = state.with_service(|service| service.stop_run(&request.issue_id, &timestamp))?;
+
+    emit_orchestrator_events(&app, &batch.events);
+
+    Ok(batch)
+}
+
+#[tauri::command]
+pub async fn retry_orchestrator_issue<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, OrchestratorCommandState>,
+    request: OrchestratorIssueControlRequest,
+) -> Result<DispatchBatch, String> {
+    let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+    let batch = state.with_service(|service| service.retry_issue(&request.issue_id, &timestamp))?;
+
+    emit_orchestrator_events(&app, &batch.events);
+
+    Ok(batch)
+}
+
+fn emit_orchestrator_events<R: Runtime>(app: &AppHandle<R>, events: &[OrchestratorEvent]) {
+    for event in events {
         if let Err(error) = app.emit(ORCHESTRATOR_EVENT, event) {
             log::warn!("failed to emit orchestrator event: {error}");
         }
     }
-
-    Ok(batch)
 }
 
 fn validate_workflow_path(raw_path: &str) -> Result<PathBuf, String> {

--- a/src-tauri/src/orchestrator/mod.rs
+++ b/src-tauri/src/orchestrator/mod.rs
@@ -8,11 +8,12 @@ pub mod workspace;
 
 pub use commands::{
     dispatch_orchestrator_once, load_orchestrator_workflow, refresh_orchestrator_snapshot,
-    set_orchestrator_paused, OrchestratorCommandState,
+    retry_orchestrator_issue, set_orchestrator_paused, stop_orchestrator_run,
+    OrchestratorCommandState,
 };
 pub use runner::{AgentRun, AgentRunRequest, AgentRunner, AgentRunnerError, CommandAgentRunner};
 pub use runtime::{
-    ClaimBatch, DispatchBatch, DispatchFailure, DispatchedRun, OrchestratorRuntime,
+    ClaimBatch, ControlBatch, DispatchBatch, DispatchFailure, DispatchedRun, OrchestratorRuntime,
     OrchestratorRuntimeError,
 };
 pub use state::{

--- a/src-tauri/src/orchestrator/runner.rs
+++ b/src-tauri/src/orchestrator/runner.rs
@@ -7,7 +7,7 @@ use std::thread;
 use serde::Serialize;
 use thiserror::Error;
 
-use crate::orchestrator::{OrchestratorIssue, WorkspacePlan};
+use crate::orchestrator::{OrchestratorIssue, OrchestratorRun, WorkspacePlan};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -32,6 +32,13 @@ pub struct AgentRun {
 
 pub trait AgentRunner {
     fn start(&self, request: AgentRunRequest) -> Result<AgentRun, AgentRunnerError>;
+
+    fn stop(&self, run: &OrchestratorRun) -> Result<(), AgentRunnerError> {
+        Err(AgentRunnerError::Stop {
+            run_id: run.run_id.clone(),
+            message: "agent runner does not support stop".to_string(),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -43,6 +50,8 @@ pub enum AgentRunnerError {
     Start { message: String },
     #[error("failed to write prompt to agent stdin: {message}")]
     Stdin { message: String },
+    #[error("failed to stop agent run {run_id}: {message}")]
+    Stop { run_id: String, message: String },
 }
 
 impl AgentRunner for CommandAgentRunner {
@@ -109,6 +118,55 @@ impl AgentRunner for CommandAgentRunner {
             stderr_log_path: Some(stderr_log_path),
         })
     }
+
+    fn stop(&self, run: &OrchestratorRun) -> Result<(), AgentRunnerError> {
+        let Some(process_id) = run.process_id else {
+            return Err(AgentRunnerError::Stop {
+                run_id: run.run_id.clone(),
+                message: "agent run has no process id".to_string(),
+            });
+        };
+
+        stop_process(process_id, &run.run_id)
+    }
+}
+
+#[cfg(unix)]
+fn stop_process(process_id: u32, run_id: &str) -> Result<(), AgentRunnerError> {
+    let result = unsafe { libc::kill(process_id as libc::pid_t, libc::SIGTERM) };
+    if result == 0 {
+        return Ok(());
+    }
+
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        return Ok(());
+    }
+
+    Err(AgentRunnerError::Stop {
+        run_id: run_id.to_string(),
+        message: error.to_string(),
+    })
+}
+
+#[cfg(windows)]
+fn stop_process(process_id: u32, run_id: &str) -> Result<(), AgentRunnerError> {
+    let status = Command::new("taskkill")
+        .args(["/PID", &process_id.to_string(), "/T", "/F"])
+        .status()
+        .map_err(|error| AgentRunnerError::Stop {
+            run_id: run_id.to_string(),
+            message: error.to_string(),
+        })?;
+
+    if status.success() {
+        return Ok(());
+    }
+
+    Err(AgentRunnerError::Stop {
+        run_id: run_id.to_string(),
+        message: format!("taskkill exited with status {status}"),
+    })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/orchestrator/runtime.rs
+++ b/src-tauri/src/orchestrator/runtime.rs
@@ -6,10 +6,11 @@ use serde::Serialize;
 use thiserror::Error;
 
 use crate::orchestrator::{
-    render_prompt, ActiveWork, AgentRun, AgentRunRequest, AgentRunner, AttemptTemplateContext,
-    OrchestratorEvent, OrchestratorIssue, OrchestratorSnapshot, OrchestratorState,
-    PromptTemplateContext, QueueIssue, RetryEntry, RunStatus, StateError, TrackerClient,
-    TrackerError, WorkflowDefinition, WorkspaceManager, WorkspacePlan, WorkspaceTemplateContext,
+    render_prompt, ActiveWork, AgentRun, AgentRunRequest, AgentRunner, AgentRunnerError,
+    AttemptTemplateContext, OrchestratorEvent, OrchestratorIssue, OrchestratorRun,
+    OrchestratorSnapshot, OrchestratorState, PromptTemplateContext, QueueIssue, RetryEntry,
+    RunStatus, StateError, TrackerClient, TrackerError, WorkflowDefinition, WorkspaceManager,
+    WorkspacePlan, WorkspaceTemplateContext,
 };
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -18,6 +19,10 @@ pub enum OrchestratorRuntimeError {
     Tracker(#[from] TrackerError),
     #[error(transparent)]
     State(#[from] StateError),
+    #[error(transparent)]
+    Runner(#[from] AgentRunnerError),
+    #[error("no orchestrator concurrency slots are available for issue: {issue_id}")]
+    NoAvailableSlots { issue_id: String },
     #[error("invalid orchestrator timestamp {value}: {message}")]
     InvalidTimestamp { value: String, message: String },
 }
@@ -37,6 +42,13 @@ pub struct DispatchBatch {
     pub claimed: Vec<QueueIssue>,
     pub started: Vec<DispatchedRun>,
     pub failed: Vec<DispatchFailure>,
+    pub events: Vec<OrchestratorEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ControlBatch {
+    pub snapshot: OrchestratorSnapshot,
     pub events: Vec<OrchestratorEvent>,
 }
 
@@ -129,6 +141,81 @@ where
         Ok(DispatchBatch {
             snapshot: self.state.snapshot(issues),
             claimed: claim_batch.claimed,
+            started,
+            failed,
+            events,
+        })
+    }
+
+    pub fn stop_run<R>(
+        &mut self,
+        runner: &R,
+        issue_id: &str,
+        timestamp: &str,
+    ) -> Result<ControlBatch, OrchestratorRuntimeError>
+    where
+        R: AgentRunner,
+    {
+        let run = self.state.running_run(issue_id)?;
+        runner.stop(&run)?;
+        self.state.release_issue(issue_id, RunStatus::Stopped);
+
+        let issues = self.tracker.fetch_issues()?;
+        let mut events = vec![self.stop_event(&issues, &run, timestamp)];
+        self.reconcile_ineligible_work(&issues, Some(timestamp), &mut events);
+
+        Ok(ControlBatch {
+            snapshot: self.state.snapshot(issues),
+            events,
+        })
+    }
+
+    pub fn retry_issue_now<R>(
+        &mut self,
+        workspace_manager: &WorkspaceManager,
+        runner: &R,
+        issue_id: &str,
+        timestamp: &str,
+    ) -> Result<DispatchBatch, OrchestratorRuntimeError>
+    where
+        R: AgentRunner,
+    {
+        let issues = self.tracker.fetch_issues()?;
+        let mut events = Vec::new();
+        self.reconcile_ineligible_work(&issues, Some(timestamp), &mut events);
+
+        self.state.retry_entry(issue_id)?;
+        let issue = issues
+            .iter()
+            .find(|issue| issue.id == issue_id && self.is_active_issue(issue))
+            .cloned()
+            .ok_or_else(|| StateError::IssueNotRetrying {
+                issue_id: issue_id.to_string(),
+            })?;
+        if self.available_slots() == 0 {
+            return Err(OrchestratorRuntimeError::NoAvailableSlots {
+                issue_id: issue_id.to_string(),
+            });
+        }
+
+        let claim = self.state.claim_retry(&issue)?;
+        events.push(self.retry_claim_event(&issue, &claim, timestamp));
+
+        let mut started = Vec::new();
+        let mut failed = Vec::new();
+        self.dispatch_claim(
+            &claim,
+            workspace_manager,
+            runner,
+            timestamp,
+            &mut started,
+            &mut failed,
+            &mut events,
+        )?;
+
+        Ok(DispatchBatch {
+            snapshot: self.state.snapshot(issues),
+            claimed: vec![claim],
             started,
             failed,
             events,
@@ -297,8 +384,11 @@ where
         self.state.mark_running(
             &issue.id,
             &run.run_id,
+            run.process_id,
             attempt_number,
             workspace.path.clone(),
+            run.stdout_log_path.clone(),
+            run.stderr_log_path.clone(),
             timestamp,
         )?;
         events.push(self.issue_event(
@@ -564,6 +654,30 @@ where
         }
     }
 
+    fn stop_event(
+        &self,
+        issues: &[OrchestratorIssue],
+        run: &OrchestratorRun,
+        timestamp: &str,
+    ) -> OrchestratorEvent {
+        let issue = issues.iter().find(|issue| issue.id == run.issue_id);
+
+        OrchestratorEvent {
+            timestamp: timestamp.to_string(),
+            workflow_path: self.workflow.path.clone(),
+            issue_id: run.issue_id.clone(),
+            issue_identifier: issue
+                .map(|issue| issue.identifier.clone())
+                .unwrap_or_else(|| run.issue_identifier.clone()),
+            run_id: Some(run.run_id.clone()),
+            attempt_number: Some(run.attempt_number),
+            status: RunStatus::Stopped,
+            workspace_path: Some(run.workspace_path.clone()),
+            message: Some("operator stopped agent run".to_string()),
+            error: None,
+        }
+    }
+
     fn issue_event(
         &self,
         issue: &OrchestratorIssue,
@@ -648,28 +762,34 @@ mod tests {
     #[derive(Debug, Clone)]
     struct RecordingRunner {
         requests: Rc<RefCell<Vec<AgentRunRequest>>>,
+        stopped_runs: Rc<RefCell<Vec<String>>>,
         result: Result<AgentRun, AgentRunnerError>,
+        stop_result: Result<(), AgentRunnerError>,
     }
 
     impl RecordingRunner {
         fn with_run(run_id: &str) -> Self {
             Self {
                 requests: Rc::new(RefCell::new(Vec::new())),
+                stopped_runs: Rc::new(RefCell::new(Vec::new())),
                 result: Ok(AgentRun {
                     run_id: run_id.to_string(),
                     process_id: Some(42),
                     stdout_log_path: None,
                     stderr_log_path: None,
                 }),
+                stop_result: Ok(()),
             }
         }
 
         fn with_error(message: &str) -> Self {
             Self {
                 requests: Rc::new(RefCell::new(Vec::new())),
+                stopped_runs: Rc::new(RefCell::new(Vec::new())),
                 result: Err(AgentRunnerError::Start {
                     message: message.to_string(),
                 }),
+                stop_result: Ok(()),
             }
         }
     }
@@ -678,6 +798,11 @@ mod tests {
         fn start(&self, request: AgentRunRequest) -> Result<AgentRun, AgentRunnerError> {
             self.requests.borrow_mut().push(request);
             self.result.clone()
+        }
+
+        fn stop(&self, run: &OrchestratorRun) -> Result<(), AgentRunnerError> {
+            self.stopped_runs.borrow_mut().push(run.run_id.clone());
+            self.stop_result.clone()
         }
     }
 
@@ -865,6 +990,54 @@ mod tests {
     }
 
     #[test]
+    fn stop_run_marks_running_work_stopped_and_calls_runner() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let runner = RecordingRunner::with_run("run-108");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        runtime
+            .dispatch_ready(&workspace_manager, &runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+        let batch = runtime
+            .stop_run(&runner, "issue-108", "2026-05-02T08:16:00Z")
+            .unwrap();
+
+        assert_eq!(runner.stopped_runs.borrow().as_slice(), ["run-108"]);
+        assert!(batch.snapshot.running.is_empty());
+        assert_eq!(batch.snapshot.queue[0].status, RunStatus::Stopped);
+        assert_eq!(runtime.in_flight_count(), 0);
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(batch.events[0].status, RunStatus::Stopped);
+        assert_eq!(batch.events[0].run_id.as_deref(), Some("run-108"));
+        assert_eq!(
+            batch.events[0].message.as_deref(),
+            Some("operator stopped agent run")
+        );
+    }
+
+    #[test]
+    fn stop_run_rejects_non_running_issue() {
+        let workflow = workflow_with_max_concurrent(1);
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let runner = RecordingRunner::with_run("run-108");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        let error = runtime
+            .stop_run(&runner, "issue-108", "2026-05-02T08:16:00Z")
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            OrchestratorRuntimeError::State(StateError::IssueNotRunning {
+                issue_id: "issue-108".to_string()
+            })
+        );
+        assert!(runner.stopped_runs.borrow().is_empty());
+    }
+
+    #[test]
     fn claim_ready_stops_running_work_when_issue_becomes_ineligible() {
         let (_dir, workflow) = workflow_fixture(1);
         let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
@@ -983,6 +1156,74 @@ mod tests {
             .events
             .iter()
             .any(|event| event.message.as_deref() == Some("retry claimed for dispatch")));
+    }
+
+    #[test]
+    fn retry_issue_now_dispatches_retry_before_due_time() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let failing_runner = RecordingRunner::with_error("codex missing");
+        let success_runner = RecordingRunner::with_run("run-108-manual-retry");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        runtime
+            .dispatch_ready(&workspace_manager, &failing_runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+        let retried = runtime
+            .retry_issue_now(
+                &workspace_manager,
+                &success_runner,
+                "issue-108",
+                "2026-05-02T08:15:05Z",
+            )
+            .unwrap();
+
+        assert_eq!(retried.claimed.len(), 1);
+        assert_eq!(retried.claimed[0].attempt_number, Some(2));
+        assert_eq!(retried.started.len(), 1);
+        assert_eq!(retried.started[0].run.run_id, "run-108-manual-retry");
+        assert!(retried.snapshot.retry_queue.is_empty());
+        assert_eq!(retried.snapshot.queue[0].status, RunStatus::Running);
+        assert!(retried
+            .events
+            .iter()
+            .any(|event| event.message.as_deref() == Some("retry claimed for dispatch")));
+    }
+
+    #[test]
+    fn retry_issue_now_respects_max_concurrent() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![
+            issue("issue-108", "#108", "open"),
+            issue("issue-109", "#109", "open"),
+        ]);
+        let failing_runner = RecordingRunner::with_error("codex missing");
+        let running_runner = RecordingRunner::with_run("run-109");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        runtime
+            .dispatch_ready(&workspace_manager, &failing_runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+        runtime
+            .dispatch_ready(&workspace_manager, &running_runner, "2026-05-02T08:15:05Z")
+            .unwrap();
+        let error = runtime
+            .retry_issue_now(
+                &workspace_manager,
+                &running_runner,
+                "issue-108",
+                "2026-05-02T08:15:06Z",
+            )
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            OrchestratorRuntimeError::NoAvailableSlots {
+                issue_id: "issue-108".to_string()
+            }
+        );
     }
 
     #[test]

--- a/src-tauri/src/orchestrator/state.rs
+++ b/src-tauri/src/orchestrator/state.rs
@@ -36,11 +36,14 @@ pub struct QueueIssue {
 #[serde(rename_all = "camelCase")]
 pub struct OrchestratorRun {
     pub run_id: String,
+    pub process_id: Option<u32>,
     pub issue_id: String,
     pub issue_identifier: String,
     pub attempt_number: u32,
     pub status: RunStatus,
     pub workspace_path: PathBuf,
+    pub stdout_log_path: Option<PathBuf>,
+    pub stderr_log_path: Option<PathBuf>,
     pub started_at: String,
     pub last_event: Option<String>,
 }
@@ -96,6 +99,10 @@ pub enum StateError {
     IssueAlreadyActive { issue_id: String },
     #[error("issue must be claimed before it can run: {issue_id}")]
     IssueNotClaimed { issue_id: String },
+    #[error("issue is not running: {issue_id}")]
+    IssueNotRunning { issue_id: String },
+    #[error("issue is not scheduled for retry: {issue_id}")]
+    IssueNotRetrying { issue_id: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -208,8 +215,11 @@ impl OrchestratorState {
         &mut self,
         issue_id: &str,
         run_id: &str,
+        process_id: Option<u32>,
         attempt_number: u32,
         workspace_path: PathBuf,
+        stdout_log_path: Option<PathBuf>,
+        stderr_log_path: Option<PathBuf>,
         started_at: &str,
     ) -> Result<(), StateError> {
         let claimed_attempt = self.claimed_attempt(issue_id)?;
@@ -219,11 +229,14 @@ impl OrchestratorState {
             issue_id.to_string(),
             OrchestratorRun {
                 run_id: run_id.to_string(),
+                process_id,
                 issue_id: issue_id.to_string(),
                 issue_identifier: claimed_attempt.issue_identifier,
                 attempt_number,
                 status: RunStatus::Running,
                 workspace_path,
+                stdout_log_path,
+                stderr_log_path,
                 started_at: started_at.to_string(),
                 last_event: None,
             },
@@ -242,6 +255,24 @@ impl OrchestratorState {
         let mut entries: Vec<_> = self.retry_queue.values().cloned().collect();
         entries.sort_by(|left, right| left.issue_identifier.cmp(&right.issue_identifier));
         entries
+    }
+
+    pub fn running_run(&self, issue_id: &str) -> Result<OrchestratorRun, StateError> {
+        self.running
+            .get(issue_id)
+            .cloned()
+            .ok_or_else(|| StateError::IssueNotRunning {
+                issue_id: issue_id.to_string(),
+            })
+    }
+
+    pub fn retry_entry(&self, issue_id: &str) -> Result<RetryEntry, StateError> {
+        self.retry_queue
+            .get(issue_id)
+            .cloned()
+            .ok_or_else(|| StateError::IssueNotRetrying {
+                issue_id: issue_id.to_string(),
+            })
     }
 
     pub fn active_work(&self) -> Vec<ActiveWork> {
@@ -395,8 +426,11 @@ mod tests {
             .mark_running(
                 "issue-108",
                 "run-1",
+                Some(42),
                 2,
                 PathBuf::from("/tmp/workspace"),
+                Some(PathBuf::from("/tmp/workspace/stdout.log")),
+                Some(PathBuf::from("/tmp/workspace/stderr.log")),
                 "2026-05-02T00:00:00Z",
             )
             .unwrap();
@@ -405,6 +439,11 @@ mod tests {
 
         assert_eq!(snapshot.running.len(), 1);
         assert_eq!(snapshot.running[0].run_id, "run-1");
+        assert_eq!(snapshot.running[0].process_id, Some(42));
+        assert_eq!(
+            snapshot.running[0].stdout_log_path.as_ref(),
+            Some(&PathBuf::from("/tmp/workspace/stdout.log"))
+        );
         assert_eq!(snapshot.queue[0].status, RunStatus::Running);
         assert_eq!(snapshot.queue[0].attempt_number, Some(2));
     }
@@ -419,8 +458,11 @@ mod tests {
             .mark_running(
                 "issue-108",
                 "run-1",
+                None,
                 1,
                 PathBuf::from("/tmp/workspace"),
+                None,
+                None,
                 "2026-05-02T00:00:00Z",
             )
             .unwrap();
@@ -496,8 +538,11 @@ mod tests {
             .mark_running(
                 "issue-108",
                 "run-1",
+                None,
                 1,
                 PathBuf::from("/tmp/workspace"),
+                None,
+                None,
                 "2026-05-02T00:00:00Z",
             )
             .unwrap();
@@ -521,8 +566,11 @@ mod tests {
             .mark_running(
                 "issue-109",
                 "run-109",
+                Some(109),
                 1,
                 PathBuf::from("/tmp/workspace-109"),
+                Some(PathBuf::from("/tmp/workspace-109/stdout.log")),
+                Some(PathBuf::from("/tmp/workspace-109/stderr.log")),
                 "2026-05-02T00:00:00Z",
             )
             .unwrap();

--- a/src/features/orchestrator/components/OrchestratorPanel.test.tsx
+++ b/src/features/orchestrator/components/OrchestratorPanel.test.tsx
@@ -34,11 +34,14 @@ const baseSnapshot: OrchestratorSnapshot = {
   running: [
     {
       runId: 'run-1234567890',
+      processId: 1234,
       issueId: 'issue-2',
       issueIdentifier: 'VIM-109',
       attemptNumber: 2,
       status: 'running',
       workspacePath: '/tmp/vimeflow/VIM-109',
+      stdoutLogPath: '/tmp/vimeflow/VIM-109/stdout.log',
+      stderrLogPath: '/tmp/vimeflow/VIM-109/stderr.log',
       startedAt: '2026-05-02T07:05:00Z',
       lastEvent: 'Agent started',
     },
@@ -95,6 +98,34 @@ const createService = (
           started: [],
           failed: [],
           events: [dispatchEvent],
+        })
+    ),
+    stopRun: vi.fn(
+      (): Promise<{
+        snapshot: OrchestratorSnapshot
+        events: OrchestratorEvent[]
+      }> =>
+        Promise.resolve({
+          snapshot: {
+            ...snapshot,
+            running: [],
+            queue: snapshot.queue.map((entry) =>
+              entry.issue.id === 'issue-2'
+                ? { ...entry, status: 'stopped' }
+                : entry
+            ),
+          },
+          events: [{ ...dispatchEvent, status: 'stopped' }],
+        })
+    ),
+    retryIssue: vi.fn(
+      (): Promise<DispatchBatch> =>
+        Promise.resolve({
+          snapshot: { ...snapshot, retryQueue: [] },
+          claimed: [],
+          started: [],
+          failed: [],
+          events: [{ ...dispatchEvent, status: 'claimed' }],
         })
     ),
     onEvent: vi.fn(
@@ -175,6 +206,25 @@ describe('OrchestratorPanel', () => {
 
     await screen.findByText('Agent running')
     expect(service.dispatchOnce).toHaveBeenCalledOnce()
+  })
+
+  test('stops running work and retries scheduled work from row actions', async (): Promise<void> => {
+    const service = createService()
+    const user = userEvent.setup()
+
+    render(<OrchestratorPanel service={service} />)
+
+    await user.type(
+      screen.getByRole('textbox', { name: /workflow path/i }),
+      '/repo/WORKFLOW.md'
+    )
+    await user.click(screen.getByRole('button', { name: 'Load' }))
+
+    await user.click(screen.getByRole('button', { name: 'Stop VIM-109' }))
+    await user.click(screen.getByRole('button', { name: 'Retry VIM-110' }))
+
+    expect(service.stopRun).toHaveBeenCalledWith('issue-2')
+    expect(service.retryIssue).toHaveBeenCalledWith('issue-3')
   })
 
   test('subscribes to orchestrator events and cleans up on unmount', async (): Promise<void> => {

--- a/src/features/orchestrator/components/OrchestratorPanel.tsx
+++ b/src/features/orchestrator/components/OrchestratorPanel.tsx
@@ -7,6 +7,7 @@ import {
   type ReactElement,
 } from 'react'
 import type {
+  ControlBatch,
   DispatchBatch,
   OrchestratorEvent,
   OrchestratorRun,
@@ -61,12 +62,15 @@ interface OrchestratorPanelProps {
 
 interface QueueRow {
   key: string
+  issueId: string
   identifier: string
   title: string
   status: RunStatus
   state: string | null
   attemptNumber: number | null
   detail: string | null
+  canStop: boolean
+  canRetry: boolean
 }
 
 const toQueueRows = (snapshot: OrchestratorSnapshot): QueueRow[] => [
@@ -77,32 +81,41 @@ const toQueueRows = (snapshot: OrchestratorSnapshot): QueueRow[] => [
 
 const runningRow = (run: OrchestratorRun): QueueRow => ({
   key: `running:${run.runId}`,
+  issueId: run.issueId,
   identifier: run.issueIdentifier,
   title: run.lastEvent ?? shortId(run.runId),
   status: run.status,
   state: null,
   attemptNumber: run.attemptNumber,
   detail: run.workspacePath,
+  canStop: true,
+  canRetry: false,
 })
 
 const retryRow = (entry: RetryEntry): QueueRow => ({
   key: `retry:${entry.issueId}`,
+  issueId: entry.issueId,
   identifier: entry.issueIdentifier,
   title: entry.lastError,
   status: 'retry_scheduled',
   state: null,
   attemptNumber: entry.attemptNumber,
   detail: `Retry ${formatTimestamp(entry.nextRetryAt)}`,
+  canStop: false,
+  canRetry: true,
 })
 
 const queueRow = (entry: QueueIssue): QueueRow => ({
   key: `queue:${entry.issue.id}`,
+  issueId: entry.issue.id,
   identifier: entry.issue.identifier,
   title: entry.issue.title,
   status: entry.status,
   state: entry.issue.state,
   attemptNumber: entry.attemptNumber,
   detail: entry.lastError ?? retryDetail(entry.nextRetryAt),
+  canStop: false,
+  canRetry: false,
 })
 
 const retryDetail = (nextRetryAt: string | null): string | null =>
@@ -186,7 +199,9 @@ export const OrchestratorPanel = ({
   const runAction = useCallback(
     async (
       action: string,
-      handler: () => Promise<OrchestratorSnapshot | DispatchBatch>
+      handler: () => Promise<
+        OrchestratorSnapshot | DispatchBatch | ControlBatch
+      >
     ): Promise<void> => {
       setLoadingAction(action)
       setError(null)
@@ -239,6 +254,20 @@ export const OrchestratorPanel = ({
   const handleDispatch = useCallback((): void => {
     void runAction('dispatch', () => service.dispatchOnce())
   }, [runAction, service])
+
+  const handleStop = useCallback(
+    (issueId: string): void => {
+      void runAction(`stop:${issueId}`, () => service.stopRun(issueId))
+    },
+    [runAction, service]
+  )
+
+  const handleRetry = useCallback(
+    (issueId: string): void => {
+      void runAction(`retry:${issueId}`, () => service.retryIssue(issueId))
+    },
+    [runAction, service]
+  )
 
   const busy = loadingAction !== null
   const workflowDisplay = loadedWorkflowPath ?? 'No workflow loaded'
@@ -347,7 +376,13 @@ export const OrchestratorPanel = ({
           ) : (
             <div className="flex flex-col gap-2">
               {rows.map((row) => (
-                <QueueRowItem key={row.key} row={row} />
+                <QueueRowItem
+                  key={row.key}
+                  row={row}
+                  disabled={busy}
+                  onStop={handleStop}
+                  onRetry={handleRetry}
+                />
               ))}
             </div>
           )}
@@ -422,7 +457,17 @@ const IconButton = ({
   </button>
 )
 
-const QueueRowItem = ({ row }: { row: QueueRow }): ReactElement => (
+const QueueRowItem = ({
+  row,
+  disabled,
+  onStop,
+  onRetry,
+}: {
+  row: QueueRow
+  disabled: boolean
+  onStop: (issueId: string) => void
+  onRetry: (issueId: string) => void
+}): ReactElement => (
   <article className="rounded-lg bg-surface-container p-3">
     <div className="flex items-start justify-between gap-2">
       <div className="min-w-0">
@@ -446,7 +491,50 @@ const QueueRowItem = ({ row }: { row: QueueRow }): ReactElement => (
       {row.attemptNumber !== null && <span>Attempt {row.attemptNumber}</span>}
       {row.detail && <span className="truncate">{row.detail}</span>}
     </div>
+    {(row.canStop || row.canRetry) && (
+      <div className="mt-3 flex items-center gap-2">
+        {row.canStop && (
+          <RowActionButton
+            label={`Stop ${row.identifier}`}
+            icon="stop_circle"
+            disabled={disabled}
+            onClick={() => onStop(row.issueId)}
+          />
+        )}
+        {row.canRetry && (
+          <RowActionButton
+            label={`Retry ${row.identifier}`}
+            icon="replay"
+            disabled={disabled}
+            onClick={() => onRetry(row.issueId)}
+          />
+        )}
+      </div>
+    )}
   </article>
+)
+
+const RowActionButton = ({
+  label,
+  icon,
+  disabled,
+  onClick,
+}: {
+  label: string
+  icon: string
+  disabled: boolean
+  onClick: () => void
+}): ReactElement => (
+  <button
+    type="button"
+    aria-label={label}
+    title={label}
+    disabled={disabled}
+    onClick={onClick}
+    className="flex h-7 w-7 items-center justify-center rounded-md bg-surface-container-high text-on-surface-variant transition-colors hover:bg-surface-container-highest hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
+  >
+    <span className="material-symbols-outlined text-sm">{icon}</span>
+  </button>
 )
 
 const StatusBadge = ({ status }: { status: RunStatus }): ReactElement => (

--- a/src/features/orchestrator/services/orchestratorService.test.ts
+++ b/src/features/orchestrator/services/orchestratorService.test.ts
@@ -105,6 +105,30 @@ describe('TauriOrchestratorService', () => {
     expect(result).toBe(batch)
   })
 
+  test('stopRun invokes stop_orchestrator_run with issue id request', async () => {
+    const batch = { snapshot, events: [] }
+    ;(invoke as Mock).mockResolvedValueOnce(batch)
+
+    const result = await service.stopRun('issue-108')
+
+    expect(invoke).toHaveBeenCalledWith('stop_orchestrator_run', {
+      request: { issueId: 'issue-108' },
+    })
+    expect(result).toBe(batch)
+  })
+
+  test('retryIssue invokes retry_orchestrator_issue with issue id request', async () => {
+    const batch = { snapshot, claimed: [], started: [], failed: [], events: [] }
+    ;(invoke as Mock).mockResolvedValueOnce(batch)
+
+    const result = await service.retryIssue('issue-108')
+
+    expect(invoke).toHaveBeenCalledWith('retry_orchestrator_issue', {
+      request: { issueId: 'issue-108' },
+    })
+    expect(result).toBe(batch)
+  })
+
   test('onEvent subscribes to orchestrator:event and returns unlisten', async () => {
     const callback = vi.fn()
 

--- a/src/features/orchestrator/services/orchestratorService.ts
+++ b/src/features/orchestrator/services/orchestratorService.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import type {
+  ControlBatch,
   DispatchBatch,
   OrchestratorEvent,
   OrchestratorSnapshot,
@@ -20,6 +21,8 @@ export interface OrchestratorService {
   refreshSnapshot(): Promise<OrchestratorSnapshot>
   setPaused(paused: boolean): Promise<OrchestratorSnapshot>
   dispatchOnce(): Promise<DispatchBatch>
+  stopRun(issueId: string): Promise<ControlBatch>
+  retryIssue(issueId: string): Promise<DispatchBatch>
   onEvent(callback: (event: OrchestratorEvent) => void): Promise<() => void>
 }
 
@@ -60,6 +63,26 @@ export class TauriOrchestratorService implements OrchestratorService {
       return await invoke<DispatchBatch>('dispatch_orchestrator_once')
     } catch (error) {
       throw commandError('dispatch orchestrator work', error)
+    }
+  }
+
+  async stopRun(issueId: string): Promise<ControlBatch> {
+    try {
+      return await invoke<ControlBatch>('stop_orchestrator_run', {
+        request: { issueId },
+      })
+    } catch (error) {
+      throw commandError('stop orchestrator run', error)
+    }
+  }
+
+  async retryIssue(issueId: string): Promise<DispatchBatch> {
+    try {
+      return await invoke<DispatchBatch>('retry_orchestrator_issue', {
+        request: { issueId },
+      })
+    } catch (error) {
+      throw commandError('retry orchestrator issue', error)
     }
   }
 
@@ -111,6 +134,36 @@ export class MockOrchestratorService implements OrchestratorService {
       failed: [],
       events: [],
     })
+  }
+
+  stopRun(issueId: string): Promise<ControlBatch> {
+    const running = this.snapshot.running.filter(
+      (run) => run.issueId !== issueId
+    )
+
+    const queue = this.snapshot.queue.map((entry) =>
+      entry.issue.id === issueId
+        ? { ...entry, status: 'stopped' as const }
+        : entry
+    )
+
+    this.snapshot = { ...this.snapshot, queue, running }
+
+    return Promise.resolve({
+      snapshot: this.snapshot,
+      events: [],
+    })
+  }
+
+  retryIssue(issueId: string): Promise<DispatchBatch> {
+    this.snapshot = {
+      ...this.snapshot,
+      retryQueue: this.snapshot.retryQueue.filter(
+        (entry) => entry.issueId !== issueId
+      ),
+    }
+
+    return this.dispatchOnce()
   }
 
   onEvent(callback: (event: OrchestratorEvent) => void): Promise<() => void> {

--- a/src/features/orchestrator/types/index.ts
+++ b/src/features/orchestrator/types/index.ts
@@ -36,11 +36,14 @@ export interface QueueIssue {
 
 export interface OrchestratorRun {
   runId: string
+  processId: number | null
   issueId: string
   issueIdentifier: string
   attemptNumber: number
   status: RunStatus
   workspacePath: string
+  stdoutLogPath: string | null
+  stderrLogPath: string | null
   startedAt: string
   lastEvent: string | null
 }
@@ -109,5 +112,10 @@ export interface DispatchBatch {
   claimed: QueueIssue[]
   started: DispatchedRun[]
   failed: DispatchFailure[]
+  events: OrchestratorEvent[]
+}
+
+export interface ControlBatch {
+  snapshot: OrchestratorSnapshot
   events: OrchestratorEvent[]
 }


### PR DESCRIPTION
## Summary

This is stacked on #146 and targets `feat/108-eligibility-reconciliation` so the review only covers the manual controls slice for #108.

- Adds backend runtime controls to stop an active agent run and manually retry a scheduled retry issue while preserving concurrency limits.
- Records process id and stdout/stderr log paths on running orchestrator state so stop can target the launched process and later UI can surface logs.
- Exposes `stop_orchestrator_run` and `retry_orchestrator_issue` Tauri commands and emits lifecycle events for those operator actions.
- Adds typed frontend service methods plus row-level stop/retry icon controls in the orchestration panel.

Refs #108.

## Validation

- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml orchestrator:: -- --nocapture`
- `npm test -- src/features/orchestrator --run`
- `CARGO_NET_OFFLINE=true cargo check --manifest-path src-tauri/Cargo.toml`
- `rustfmt --edition 2021 --check src-tauri/src/orchestrator/mod.rs src-tauri/src/orchestrator/commands.rs src-tauri/src/orchestrator/runner.rs src-tauri/src/orchestrator/runtime.rs src-tauri/src/orchestrator/state.rs`
- `rustfmt --edition 2021 --config skip_children=true --check src-tauri/src/lib.rs`
- `npm run lint`
- `npm run format:check`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml`
- `npm test`
- `npm run type-check`
- `git diff --check`
- pre-push `npm test`