### PR TITLE
feat(orchestrator): reconcile completed runs

### DIFF
--- a/src-tauri/src/orchestrator/commands.rs
+++ b/src-tauri/src/orchestrator/commands.rs
@@ -93,12 +93,17 @@ impl OrchestratorService {
         Ok(Self {
             runtime,
             workspace_manager,
-            runner: CommandAgentRunner,
+            runner: CommandAgentRunner::default(),
         })
     }
 
-    fn snapshot(&mut self) -> Result<OrchestratorSnapshot, String> {
-        self.runtime.snapshot().map_err(|error| error.to_string())
+    fn snapshot(&mut self, timestamp: &str) -> Result<ControlBatch, String> {
+        let events = self
+            .runtime
+            .reconcile_finished_runs(&self.runner, timestamp);
+        let snapshot = self.runtime.snapshot().map_err(|error| error.to_string())?;
+
+        Ok(ControlBatch { snapshot, events })
     }
 
     fn set_paused(&mut self, paused: bool) {
@@ -131,28 +136,41 @@ pub async fn load_orchestrator_workflow(
 ) -> Result<OrchestratorSnapshot, String> {
     let workflow_path = validate_workflow_path(&request.workflow_path)?;
     let mut service = OrchestratorService::from_workflow_path(&workflow_path)?;
-    let snapshot = service.snapshot()?;
+    let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+    let batch = service.snapshot(&timestamp)?;
     state.replace_service(service)?;
 
-    Ok(snapshot)
+    Ok(batch.snapshot)
 }
 
 #[tauri::command]
-pub async fn refresh_orchestrator_snapshot(
+pub async fn refresh_orchestrator_snapshot<R: Runtime>(
+    app: AppHandle<R>,
     state: State<'_, OrchestratorCommandState>,
-) -> Result<OrchestratorSnapshot, String> {
-    state.with_service(|service| service.snapshot())
+) -> Result<ControlBatch, String> {
+    let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+    let batch = state.with_service(|service| service.snapshot(&timestamp))?;
+
+    emit_orchestrator_events(&app, &batch.events);
+
+    Ok(batch)
 }
 
 #[tauri::command]
-pub async fn set_orchestrator_paused(
+pub async fn set_orchestrator_paused<R: Runtime>(
+    app: AppHandle<R>,
     state: State<'_, OrchestratorCommandState>,
     request: SetOrchestratorPausedRequest,
-) -> Result<OrchestratorSnapshot, String> {
-    state.with_service(|service| {
+) -> Result<ControlBatch, String> {
+    let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+    let batch = state.with_service(|service| {
         service.set_paused(request.paused);
-        service.snapshot()
-    })
+        service.snapshot(&timestamp)
+    })?;
+
+    emit_orchestrator_events(&app, &batch.events);
+
+    Ok(batch)
 }
 
 #[tauri::command]

--- a/src-tauri/src/orchestrator/mod.rs
+++ b/src-tauri/src/orchestrator/mod.rs
@@ -11,7 +11,9 @@ pub use commands::{
     retry_orchestrator_issue, set_orchestrator_paused, stop_orchestrator_run,
     OrchestratorCommandState,
 };
-pub use runner::{AgentRun, AgentRunRequest, AgentRunner, AgentRunnerError, CommandAgentRunner};
+pub use runner::{
+    AgentRun, AgentRunExit, AgentRunRequest, AgentRunner, AgentRunnerError, CommandAgentRunner,
+};
 pub use runtime::{
     ClaimBatch, ControlBatch, DispatchBatch, DispatchFailure, DispatchedRun, OrchestratorRuntime,
     OrchestratorRuntimeError,

--- a/src-tauri/src/orchestrator/runner.rs
+++ b/src-tauri/src/orchestrator/runner.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use serde::Serialize;
@@ -30,6 +32,15 @@ pub struct AgentRun {
     pub stderr_log_path: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRunExit {
+    pub run_id: String,
+    pub success: bool,
+    pub exit_code: Option<i32>,
+    pub message: String,
+}
+
 pub trait AgentRunner {
     fn start(&self, request: AgentRunRequest) -> Result<AgentRun, AgentRunnerError>;
 
@@ -39,10 +50,16 @@ pub trait AgentRunner {
             message: "agent runner does not support stop".to_string(),
         })
     }
+
+    fn take_finished(&self, _run_id: &str) -> Option<AgentRunExit> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct CommandAgentRunner;
+pub struct CommandAgentRunner {
+    finished_runs: Arc<Mutex<HashMap<String, AgentRunExit>>>,
+}
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum AgentRunnerError {
@@ -105,14 +122,33 @@ impl AgentRunner for CommandAgentRunner {
         drop(stdin);
 
         let process_id = child.id();
+        let run_id = format!("{}:process-{process_id}", request.issue.id);
+        let finished_runs = Arc::clone(&self.finished_runs);
+        let thread_run_id = run_id.clone();
         thread::spawn(move || {
-            if let Err(error) = child.wait() {
-                log::warn!("failed to wait for orchestrator agent process: {error}");
+            let exit = match child.wait() {
+                Ok(status) => AgentRunExit::from_status(thread_run_id, status),
+                Err(error) => {
+                    let message = format!("failed to wait for agent process: {error}");
+                    log::warn!("{message}");
+                    AgentRunExit {
+                        run_id: thread_run_id,
+                        success: false,
+                        exit_code: None,
+                        message,
+                    }
+                }
+            };
+
+            if let Ok(mut guard) = finished_runs.lock() {
+                guard.insert(exit.run_id.clone(), exit);
+            } else {
+                log::warn!("failed to record completed orchestrator agent process");
             }
         });
 
         Ok(AgentRun {
-            run_id: format!("{}:process-{process_id}", request.issue.id),
+            run_id,
             process_id: Some(process_id),
             stdout_log_path: Some(stdout_log_path),
             stderr_log_path: Some(stderr_log_path),
@@ -128,6 +164,35 @@ impl AgentRunner for CommandAgentRunner {
         };
 
         stop_process(process_id, &run.run_id)
+    }
+
+    fn take_finished(&self, run_id: &str) -> Option<AgentRunExit> {
+        self.finished_runs
+            .lock()
+            .map(|mut guard| guard.remove(run_id))
+            .unwrap_or_else(|_| {
+                log::warn!("failed to read completed orchestrator agent process");
+                None
+            })
+    }
+}
+
+impl AgentRunExit {
+    fn from_status(run_id: String, status: ExitStatus) -> Self {
+        let success = status.success();
+        let exit_code = status.code();
+        let message = if success {
+            "agent process exited successfully".to_string()
+        } else {
+            format!("agent process exited with status {status}")
+        };
+
+        Self {
+            run_id,
+            success,
+            exit_code,
+            message,
+        }
     }
 }
 
@@ -208,7 +273,8 @@ mod tests {
             prompt_file: prompt_file.clone(),
         };
 
-        let run = CommandAgentRunner.start(request).unwrap();
+        let runner = CommandAgentRunner::default();
+        let run = runner.start(request).unwrap();
         wait_for_file(&workspace_dir.path().join("prompt-env.txt"));
 
         assert_eq!(
@@ -239,6 +305,43 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn command_agent_runner_reports_completed_process() {
+        let workspace_dir = TempDir::new().unwrap();
+        let prompt_file = workspace_dir
+            .path()
+            .join(".vimeflow/orchestrator/prompt.md");
+        fs::create_dir_all(prompt_file.parent().unwrap()).unwrap();
+        let runner = CommandAgentRunner::default();
+        let request = AgentRunRequest {
+            issue: issue("issue-108", "#108"),
+            attempt_number: 1,
+            workspace: WorkspacePlan {
+                issue_id: "issue-108".to_string(),
+                issue_identifier: "#108".to_string(),
+                workspace_slug: "108".to_string(),
+                path: workspace_dir.path().to_path_buf(),
+                base_ref: "main".to_string(),
+                branch_name: "agent/108".to_string(),
+                prompt_file: prompt_file.clone(),
+            },
+            command: "sh".to_string(),
+            args: vec!["-c".to_string(), "exit 7".to_string()],
+            prompt: "Fix #108".to_string(),
+            prompt_file,
+        };
+
+        let run = runner.start(request).unwrap();
+        let exit = wait_for_exit(&runner, &run.run_id);
+
+        assert_eq!(exit.run_id, run.run_id);
+        assert!(!exit.success);
+        assert_eq!(exit.exit_code, Some(7));
+        assert!(exit.message.contains("status"));
+        assert!(runner.take_finished(&run.run_id).is_none());
+    }
+
     fn issue(id: &str, identifier: &str) -> OrchestratorIssue {
         OrchestratorIssue {
             id: id.to_string(),
@@ -262,5 +365,16 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
         panic!("timed out waiting for {}", path.display());
+    }
+
+    fn wait_for_exit(runner: &CommandAgentRunner, run_id: &str) -> AgentRunExit {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if let Some(exit) = runner.take_finished(run_id) {
+                return exit;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("timed out waiting for exit {run_id}");
     }
 }

--- a/src-tauri/src/orchestrator/runtime.rs
+++ b/src-tauri/src/orchestrator/runtime.rs
@@ -6,11 +6,11 @@ use serde::Serialize;
 use thiserror::Error;
 
 use crate::orchestrator::{
-    render_prompt, ActiveWork, AgentRun, AgentRunRequest, AgentRunner, AgentRunnerError,
-    AttemptTemplateContext, OrchestratorEvent, OrchestratorIssue, OrchestratorRun,
-    OrchestratorSnapshot, OrchestratorState, PromptTemplateContext, QueueIssue, RetryEntry,
-    RunStatus, StateError, TrackerClient, TrackerError, WorkflowDefinition, WorkspaceManager,
-    WorkspacePlan, WorkspaceTemplateContext,
+    render_prompt, ActiveWork, AgentRun, AgentRunExit, AgentRunRequest, AgentRunner,
+    AgentRunnerError, AttemptTemplateContext, OrchestratorEvent, OrchestratorIssue,
+    OrchestratorRun, OrchestratorSnapshot, OrchestratorState, PromptTemplateContext, QueueIssue,
+    RetryEntry, RunStatus, StateError, TrackerClient, TrackerError, WorkflowDefinition,
+    WorkspaceManager, WorkspacePlan, WorkspaceTemplateContext,
 };
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -111,6 +111,32 @@ where
         self.claim_ready_from_issues(issues, timestamp)
     }
 
+    pub fn reconcile_finished_runs<R>(
+        &mut self,
+        runner: &R,
+        timestamp: &str,
+    ) -> Vec<OrchestratorEvent>
+    where
+        R: AgentRunner,
+    {
+        let mut events = Vec::new();
+
+        for run in self.state.running_runs() {
+            let Some(exit) = runner.take_finished(&run.run_id) else {
+                continue;
+            };
+            let status = if exit.success {
+                RunStatus::Succeeded
+            } else {
+                RunStatus::Failed
+            };
+            self.state.release_issue(&run.issue_id, status);
+            events.push(self.run_exit_event(&run, &exit, timestamp, status));
+        }
+
+        events
+    }
+
     pub fn dispatch_ready<R>(
         &mut self,
         workspace_manager: &WorkspaceManager,
@@ -120,9 +146,10 @@ where
     where
         R: AgentRunner,
     {
+        let mut events = self.reconcile_finished_runs(runner, timestamp);
         let issues = self.tracker.fetch_issues()?;
         let claim_batch = self.claim_ready_from_issues(issues.clone(), timestamp)?;
-        let mut events = claim_batch.events.clone();
+        events.extend(claim_batch.events.clone());
         let mut started = Vec::new();
         let mut failed = Vec::new();
 
@@ -181,7 +208,7 @@ where
         R: AgentRunner,
     {
         let issues = self.tracker.fetch_issues()?;
-        let mut events = Vec::new();
+        let mut events = self.reconcile_finished_runs(runner, timestamp);
         self.reconcile_ineligible_work(&issues, Some(timestamp), &mut events);
 
         self.state.retry_entry(issue_id)?;
@@ -247,8 +274,7 @@ where
 
             let claimable: Vec<_> = issues
                 .iter()
-                .filter(|issue| self.is_active_issue(issue))
-                .filter(|issue| !self.state.is_issue_active(&issue.id))
+                .filter(|issue| self.is_auto_claimable_issue(issue))
                 .take(available_slots)
                 .cloned()
                 .collect();
@@ -600,6 +626,15 @@ where
             .any(|state| state == &issue.state)
     }
 
+    fn is_auto_claimable_issue(&self, issue: &OrchestratorIssue) -> bool {
+        self.is_active_issue(issue)
+            && !self.state.is_issue_active(&issue.id)
+            && !matches!(
+                self.state.terminal_status(&issue.id),
+                Some(RunStatus::Succeeded | RunStatus::Failed | RunStatus::Stopped)
+            )
+    }
+
     fn claim_event(&self, issue: &OrchestratorIssue, timestamp: &str) -> OrchestratorEvent {
         self.issue_event(
             issue,
@@ -678,6 +713,27 @@ where
         }
     }
 
+    fn run_exit_event(
+        &self,
+        run: &OrchestratorRun,
+        exit: &AgentRunExit,
+        timestamp: &str,
+        status: RunStatus,
+    ) -> OrchestratorEvent {
+        OrchestratorEvent {
+            timestamp: timestamp.to_string(),
+            workflow_path: self.workflow.path.clone(),
+            issue_id: run.issue_id.clone(),
+            issue_identifier: run.issue_identifier.clone(),
+            run_id: Some(run.run_id.clone()),
+            attempt_number: Some(run.attempt_number),
+            status,
+            workspace_path: Some(run.workspace_path.clone()),
+            message: Some(exit.message.clone()),
+            error: (!exit.success).then(|| exit.message.clone()),
+        }
+    }
+
     fn issue_event(
         &self,
         issue: &OrchestratorIssue,
@@ -723,9 +779,9 @@ mod tests {
 
     use super::*;
     use crate::orchestrator::{
-        load_workflow_from_path_with_env, AgentRun, AgentRunRequest, AgentRunner, AgentRunnerError,
-        OrchestratorIssue, RunStatus, TrackerClient, TrackerError, WorkflowDefinition,
-        WorkspaceManager,
+        load_workflow_from_path_with_env, AgentRun, AgentRunExit, AgentRunRequest, AgentRunner,
+        AgentRunnerError, OrchestratorIssue, RunStatus, TrackerClient, TrackerError,
+        WorkflowDefinition, WorkspaceManager,
     };
 
     #[derive(Debug, Clone)]
@@ -763,6 +819,7 @@ mod tests {
     struct RecordingRunner {
         requests: Rc<RefCell<Vec<AgentRunRequest>>>,
         stopped_runs: Rc<RefCell<Vec<String>>>,
+        exits: Rc<RefCell<Vec<AgentRunExit>>>,
         result: Result<AgentRun, AgentRunnerError>,
         stop_result: Result<(), AgentRunnerError>,
     }
@@ -772,6 +829,7 @@ mod tests {
             Self {
                 requests: Rc::new(RefCell::new(Vec::new())),
                 stopped_runs: Rc::new(RefCell::new(Vec::new())),
+                exits: Rc::new(RefCell::new(Vec::new())),
                 result: Ok(AgentRun {
                     run_id: run_id.to_string(),
                     process_id: Some(42),
@@ -786,11 +844,16 @@ mod tests {
             Self {
                 requests: Rc::new(RefCell::new(Vec::new())),
                 stopped_runs: Rc::new(RefCell::new(Vec::new())),
+                exits: Rc::new(RefCell::new(Vec::new())),
                 result: Err(AgentRunnerError::Start {
                     message: message.to_string(),
                 }),
                 stop_result: Ok(()),
             }
+        }
+
+        fn push_exit(&self, exit: AgentRunExit) {
+            self.exits.borrow_mut().push(exit);
         }
     }
 
@@ -803,6 +866,13 @@ mod tests {
         fn stop(&self, run: &OrchestratorRun) -> Result<(), AgentRunnerError> {
             self.stopped_runs.borrow_mut().push(run.run_id.clone());
             self.stop_result.clone()
+        }
+
+        fn take_finished(&self, run_id: &str) -> Option<AgentRunExit> {
+            let mut exits = self.exits.borrow_mut();
+            let index = exits.iter().position(|exit| exit.run_id == run_id)?;
+
+            Some(exits.remove(index))
         }
     }
 
@@ -1035,6 +1105,70 @@ mod tests {
             })
         );
         assert!(runner.stopped_runs.borrow().is_empty());
+    }
+
+    #[test]
+    fn reconcile_finished_runs_marks_successful_run_succeeded() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let runner = RecordingRunner::with_run("run-108");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        runtime
+            .dispatch_ready(&workspace_manager, &runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+        runner.push_exit(AgentRunExit {
+            run_id: "run-108".to_string(),
+            success: true,
+            exit_code: Some(0),
+            message: "agent process exited successfully".to_string(),
+        });
+        let events = runtime.reconcile_finished_runs(&runner, "2026-05-02T08:16:00Z");
+        let snapshot = runtime.snapshot().unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].status, RunStatus::Succeeded);
+        assert_eq!(events[0].error, None);
+        assert_eq!(snapshot.queue[0].status, RunStatus::Succeeded);
+        assert!(snapshot.running.is_empty());
+        assert_eq!(runtime.in_flight_count(), 0);
+    }
+
+    #[test]
+    fn dispatch_ready_reconciles_failed_runs_before_claiming_new_work() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![
+            issue("issue-108", "#108", "open"),
+            issue("issue-109", "#109", "open"),
+        ]);
+        let runner = RecordingRunner::with_run("run-108");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        runtime
+            .dispatch_ready(&workspace_manager, &runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+        runner.push_exit(AgentRunExit {
+            run_id: "run-108".to_string(),
+            success: false,
+            exit_code: Some(1),
+            message: "agent process exited with status 1".to_string(),
+        });
+        let batch = runtime
+            .dispatch_ready(&workspace_manager, &runner, "2026-05-02T08:16:00Z")
+            .unwrap();
+
+        assert_eq!(batch.claimed.len(), 1);
+        assert_eq!(batch.claimed[0].issue.identifier, "#109");
+        assert_eq!(batch.started[0].issue.identifier, "#109");
+        assert_eq!(batch.events[0].status, RunStatus::Failed);
+        assert_eq!(
+            batch.events[0].error.as_deref(),
+            Some("agent process exited with status 1")
+        );
+        assert_eq!(batch.snapshot.queue[0].status, RunStatus::Failed);
+        assert_eq!(batch.snapshot.queue[1].status, RunStatus::Running);
     }
 
     #[test]

--- a/src-tauri/src/orchestrator/state.rs
+++ b/src-tauri/src/orchestrator/state.rs
@@ -266,6 +266,12 @@ impl OrchestratorState {
             })
     }
 
+    pub fn running_runs(&self) -> Vec<OrchestratorRun> {
+        let mut runs: Vec<_> = self.running.values().cloned().collect();
+        runs.sort_by(|left, right| left.issue_identifier.cmp(&right.issue_identifier));
+        runs
+    }
+
     pub fn retry_entry(&self, issue_id: &str) -> Result<RetryEntry, StateError> {
         self.retry_queue
             .get(issue_id)
@@ -273,6 +279,10 @@ impl OrchestratorState {
             .ok_or_else(|| StateError::IssueNotRetrying {
                 issue_id: issue_id.to_string(),
             })
+    }
+
+    pub fn terminal_status(&self, issue_id: &str) -> Option<RunStatus> {
+        self.terminal_statuses.get(issue_id).copied()
     }
 
     pub fn active_work(&self) -> Vec<ActiveWork> {

--- a/src/features/orchestrator/components/OrchestratorPanel.test.tsx
+++ b/src/features/orchestrator/components/OrchestratorPanel.test.tsx
@@ -84,11 +84,18 @@ const createService = (
       (): Promise<OrchestratorSnapshot> => Promise.resolve(snapshot)
     ),
     refreshSnapshot: vi.fn(
-      (): Promise<OrchestratorSnapshot> => Promise.resolve(snapshot)
+      (): Promise<{
+        snapshot: OrchestratorSnapshot
+        events: OrchestratorEvent[]
+      }> => Promise.resolve({ snapshot, events: [] })
     ),
     setPaused: vi.fn(
-      (paused: boolean): Promise<OrchestratorSnapshot> =>
-        Promise.resolve({ ...snapshot, paused })
+      (
+        paused: boolean
+      ): Promise<{
+        snapshot: OrchestratorSnapshot
+        events: OrchestratorEvent[]
+      }> => Promise.resolve({ snapshot: { ...snapshot, paused }, events: [] })
     ),
     dispatchOnce: vi.fn(
       (): Promise<DispatchBatch> =>

--- a/src/features/orchestrator/services/orchestratorService.test.ts
+++ b/src/features/orchestrator/services/orchestratorService.test.ts
@@ -76,23 +76,25 @@ describe('TauriOrchestratorService', () => {
   })
 
   test('refreshSnapshot invokes refresh_orchestrator_snapshot', async () => {
-    ;(invoke as Mock).mockResolvedValueOnce(snapshot)
+    const batch = { snapshot, events: [] }
+    ;(invoke as Mock).mockResolvedValueOnce(batch)
 
     const result = await service.refreshSnapshot()
 
     expect(invoke).toHaveBeenCalledWith('refresh_orchestrator_snapshot')
-    expect(result).toBe(snapshot)
+    expect(result).toBe(batch)
   })
 
   test('setPaused invokes set_orchestrator_paused with paused request', async () => {
-    ;(invoke as Mock).mockResolvedValueOnce({ ...snapshot, paused: true })
+    const batch = { snapshot: { ...snapshot, paused: true }, events: [] }
+    ;(invoke as Mock).mockResolvedValueOnce(batch)
 
     const result = await service.setPaused(true)
 
     expect(invoke).toHaveBeenCalledWith('set_orchestrator_paused', {
       request: { paused: true },
     })
-    expect(result.paused).toBe(true)
+    expect(result.snapshot.paused).toBe(true)
   })
 
   test('dispatchOnce invokes dispatch_orchestrator_once', async () => {

--- a/src/features/orchestrator/services/orchestratorService.ts
+++ b/src/features/orchestrator/services/orchestratorService.ts
@@ -18,8 +18,8 @@ const EMPTY_SNAPSHOT: OrchestratorSnapshot = {
 
 export interface OrchestratorService {
   loadWorkflow(workflowPath: string): Promise<OrchestratorSnapshot>
-  refreshSnapshot(): Promise<OrchestratorSnapshot>
-  setPaused(paused: boolean): Promise<OrchestratorSnapshot>
+  refreshSnapshot(): Promise<ControlBatch>
+  setPaused(paused: boolean): Promise<ControlBatch>
   dispatchOnce(): Promise<DispatchBatch>
   stopRun(issueId: string): Promise<ControlBatch>
   retryIssue(issueId: string): Promise<DispatchBatch>
@@ -37,17 +37,17 @@ export class TauriOrchestratorService implements OrchestratorService {
     }
   }
 
-  async refreshSnapshot(): Promise<OrchestratorSnapshot> {
+  async refreshSnapshot(): Promise<ControlBatch> {
     try {
-      return await invoke<OrchestratorSnapshot>('refresh_orchestrator_snapshot')
+      return await invoke<ControlBatch>('refresh_orchestrator_snapshot')
     } catch (error) {
       throw commandError('refresh orchestrator snapshot', error)
     }
   }
 
-  async setPaused(paused: boolean): Promise<OrchestratorSnapshot> {
+  async setPaused(paused: boolean): Promise<ControlBatch> {
     try {
-      return await invoke<OrchestratorSnapshot>('set_orchestrator_paused', {
+      return await invoke<ControlBatch>('set_orchestrator_paused', {
         request: { paused },
       })
     } catch (error) {
@@ -116,14 +116,20 @@ export class MockOrchestratorService implements OrchestratorService {
     return Promise.resolve(this.snapshot)
   }
 
-  refreshSnapshot(): Promise<OrchestratorSnapshot> {
-    return Promise.resolve(this.snapshot)
+  refreshSnapshot(): Promise<ControlBatch> {
+    return Promise.resolve({
+      snapshot: this.snapshot,
+      events: [],
+    })
   }
 
-  setPaused(paused: boolean): Promise<OrchestratorSnapshot> {
+  setPaused(paused: boolean): Promise<ControlBatch> {
     this.snapshot = { ...this.snapshot, paused }
 
-    return Promise.resolve(this.snapshot)
+    return Promise.resolve({
+      snapshot: this.snapshot,
+      events: [],
+    })
   }
 
   dispatchOnce(): Promise<DispatchBatch> {


### PR DESCRIPTION
## Summary

This is stacked on #147 and targets `feat/108-manual-run-controls` so the review only covers the completed-run reconciliation slice for #108.

- Records child-process completion from `CommandAgentRunner` and exposes completed exits through the runner interface.
- Reconciles finished running work into `Succeeded` or `Failed` lifecycle state before refresh, pause/resume, dispatch, and manual retry paths.
- Emits completion lifecycle events through refresh and pause/resume command responses.
- Prevents terminal `Succeeded`, `Failed`, and `Stopped` issues from being auto-claimed again while still open.
- Updates the frontend orchestrator service contract so refresh/pause responses can carry events alongside snapshots.

Refs #108.

## Validation

- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml orchestrator::runtime -- --nocapture`
- `npm test -- src/features/orchestrator --run`
- `CARGO_NET_OFFLINE=true cargo check --manifest-path src-tauri/Cargo.toml`
- `rustfmt --edition 2021 --check src-tauri/src/orchestrator/mod.rs src-tauri/src/orchestrator/commands.rs src-tauri/src/orchestrator/runner.rs src-tauri/src/orchestrator/runtime.rs src-tauri/src/orchestrator/state.rs`
- `rustfmt --edition 2021 --config skip_children=true --check src-tauri/src/lib.rs`
- `npm run lint`
- `npm run format:check`
- `npm run type-check`
- `git diff --check`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml terminal::commands::tests::read_loop_eof_marks_cache_exited -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml`
- `npm test`
- pre-push `npm test`