### PR TITLE
feat(orchestrator): retry terminal runs

### DIFF
--- a/src-tauri/src/orchestrator/runtime.rs
+++ b/src-tauri/src/orchestrator/runtime.rs
@@ -130,7 +130,11 @@ where
             } else {
                 RunStatus::Failed
             };
-            self.state.release_issue(&run.issue_id, status);
+            self.state.release_issue_with_error(
+                &run.issue_id,
+                status,
+                (!exit.success).then(|| exit.message.clone()),
+            );
             events.push(self.run_exit_event(&run, &exit, timestamp, status));
         }
 
@@ -185,7 +189,11 @@ where
     {
         let run = self.state.running_run(issue_id)?;
         runner.stop(&run)?;
-        self.state.release_issue(issue_id, RunStatus::Stopped);
+        self.state.release_issue_with_error(
+            issue_id,
+            RunStatus::Stopped,
+            Some("operator stopped agent run".to_string()),
+        );
 
         let issues = self.tracker.fetch_issues()?;
         let mut events = vec![self.stop_event(&issues, &run, timestamp)];
@@ -211,7 +219,7 @@ where
         let mut events = self.reconcile_finished_runs(runner, timestamp);
         self.reconcile_ineligible_work(&issues, Some(timestamp), &mut events);
 
-        self.state.retry_entry(issue_id)?;
+        self.state.ensure_issue_retryable(issue_id)?;
         let issue = issues
             .iter()
             .find(|issue| issue.id == issue_id && self.is_active_issue(issue))
@@ -225,7 +233,7 @@ where
             });
         }
 
-        let claim = self.state.claim_retry(&issue)?;
+        let claim = self.state.claim_manual_retry(&issue)?;
         events.push(self.retry_claim_event(&issue, &claim, timestamp));
 
         let mut started = Vec::new();
@@ -485,7 +493,8 @@ where
                 Some(error.clone()),
             ));
         } else {
-            self.state.release_issue(&issue.id, RunStatus::Failed);
+            self.state
+                .release_issue_with_error(&issue.id, RunStatus::Failed, Some(error.clone()));
             events.push(self.issue_event(
                 issue,
                 timestamp,
@@ -1323,6 +1332,94 @@ mod tests {
             .events
             .iter()
             .any(|event| event.message.as_deref() == Some("retry claimed for dispatch")));
+    }
+
+    #[test]
+    fn retry_issue_now_dispatches_failed_terminal_issue() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let runner = RecordingRunner::with_run("run-108");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        runtime
+            .dispatch_ready(&workspace_manager, &runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+        runner.push_exit(AgentRunExit {
+            run_id: "run-108".to_string(),
+            success: false,
+            exit_code: Some(1),
+            message: "agent process exited with status 1".to_string(),
+        });
+        let retried = runtime
+            .retry_issue_now(
+                &workspace_manager,
+                &runner,
+                "issue-108",
+                "2026-05-02T08:16:00Z",
+            )
+            .unwrap();
+
+        assert_eq!(retried.claimed.len(), 1);
+        assert_eq!(retried.claimed[0].attempt_number, Some(2));
+        assert_eq!(
+            retried.claimed[0].last_error.as_deref(),
+            Some("agent process exited with status 1")
+        );
+        assert_eq!(retried.started.len(), 1);
+        assert_eq!(retried.started[0].attempt_number, 2);
+        assert_eq!(retried.snapshot.queue[0].status, RunStatus::Running);
+        assert!(retried.events.iter().any(|event| {
+            event.status == RunStatus::Failed
+                && event.error.as_deref() == Some("agent process exited with status 1")
+        }));
+
+        let requests = runner.requests.borrow();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[1]
+            .prompt
+            .contains("Previous error: agent process exited with status 1"));
+    }
+
+    #[test]
+    fn retry_issue_now_dispatches_stopped_terminal_issue() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let running_runner = RecordingRunner::with_run("run-108");
+        let retry_runner = RecordingRunner::with_run("run-108-manual-retry");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        runtime
+            .dispatch_ready(&workspace_manager, &running_runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+        runtime
+            .stop_run(&running_runner, "issue-108", "2026-05-02T08:15:30Z")
+            .unwrap();
+        let retried = runtime
+            .retry_issue_now(
+                &workspace_manager,
+                &retry_runner,
+                "issue-108",
+                "2026-05-02T08:16:00Z",
+            )
+            .unwrap();
+
+        assert_eq!(retried.claimed.len(), 1);
+        assert_eq!(retried.claimed[0].attempt_number, Some(2));
+        assert_eq!(
+            retried.claimed[0].last_error.as_deref(),
+            Some("operator stopped agent run")
+        );
+        assert_eq!(retried.started.len(), 1);
+        assert_eq!(retried.started[0].attempt_number, 2);
+        assert_eq!(retried.snapshot.queue[0].status, RunStatus::Running);
+
+        let requests = retry_runner.requests.borrow();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0]
+            .prompt
+            .contains("Previous error: operator stopped agent run"));
     }
 
     #[test]

--- a/src-tauri/src/orchestrator/state.rs
+++ b/src-tauri/src/orchestrator/state.rs
@@ -93,6 +93,13 @@ pub struct ActiveWork {
     pub last_error: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TerminalEntry {
+    status: RunStatus,
+    attempt_number: Option<u32>,
+    last_error: Option<String>,
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum StateError {
     #[error("issue is already claimed, running, or retrying: {issue_id}")]
@@ -117,7 +124,7 @@ pub struct OrchestratorState {
     claimed: HashMap<String, ClaimedAttempt>,
     running: HashMap<String, OrchestratorRun>,
     retry_queue: HashMap<String, RetryEntry>,
-    terminal_statuses: HashMap<String, RunStatus>,
+    terminal_statuses: HashMap<String, TerminalEntry>,
     paused: bool,
 }
 
@@ -202,6 +209,67 @@ impl OrchestratorState {
         })
     }
 
+    pub fn ensure_issue_retryable(&self, issue_id: &str) -> Result<(), StateError> {
+        if self.retry_queue.contains_key(issue_id) {
+            return Ok(());
+        }
+
+        if matches!(
+            self.terminal_statuses
+                .get(issue_id)
+                .map(|entry| entry.status),
+            Some(RunStatus::Failed | RunStatus::Stopped)
+        ) {
+            return Ok(());
+        }
+
+        Err(StateError::IssueNotRetrying {
+            issue_id: issue_id.to_string(),
+        })
+    }
+
+    pub fn claim_manual_retry(
+        &mut self,
+        issue: &OrchestratorIssue,
+    ) -> Result<QueueIssue, StateError> {
+        self.ensure_issue_retryable(&issue.id)?;
+
+        if self.retry_queue.contains_key(&issue.id) {
+            return self.claim_retry(issue);
+        }
+
+        if self.claimed.contains_key(&issue.id) || self.running.contains_key(&issue.id) {
+            return Err(StateError::IssueAlreadyActive {
+                issue_id: issue.id.clone(),
+            });
+        }
+
+        let terminal = self.terminal_statuses.remove(&issue.id).ok_or_else(|| {
+            StateError::IssueNotRetrying {
+                issue_id: issue.id.clone(),
+            }
+        })?;
+        let attempt_number = terminal.attempt_number.unwrap_or(1).saturating_add(1);
+
+        self.claimed.insert(
+            issue.id.clone(),
+            ClaimedAttempt {
+                issue_identifier: issue.identifier.clone(),
+                attempt_number,
+                previous_error: terminal.last_error.clone(),
+            },
+        );
+
+        Ok(QueueIssue {
+            issue: issue.clone(),
+            status: RunStatus::Claimed,
+            run_id: None,
+            attempt_number: Some(attempt_number),
+            next_retry_at: None,
+            last_error: terminal.last_error,
+        })
+    }
+
     pub fn claimed_attempt(&self, issue_id: &str) -> Result<ClaimedAttempt, StateError> {
         self.claimed
             .get(issue_id)
@@ -282,7 +350,9 @@ impl OrchestratorState {
     }
 
     pub fn terminal_status(&self, issue_id: &str) -> Option<RunStatus> {
-        self.terminal_statuses.get(issue_id).copied()
+        self.terminal_statuses
+            .get(issue_id)
+            .map(|entry| entry.status)
     }
 
     pub fn active_work(&self) -> Vec<ActiveWork> {
@@ -320,10 +390,21 @@ impl OrchestratorState {
     }
 
     pub fn release_issue(&mut self, issue_id: &str, status: RunStatus) {
+        self.release_issue_with_error(issue_id, status, None);
+    }
+
+    pub fn release_issue_with_error(
+        &mut self,
+        issue_id: &str,
+        status: RunStatus,
+        last_error: Option<String>,
+    ) {
+        let terminal = self.terminal_context(issue_id, status, last_error);
         self.claimed.remove(issue_id);
         self.running.remove(issue_id);
         self.retry_queue.remove(issue_id);
-        self.terminal_statuses.insert(issue_id.to_string(), status);
+        self.terminal_statuses
+            .insert(issue_id.to_string(), terminal);
     }
 
     pub fn snapshot(&self, issues: Vec<OrchestratorIssue>) -> OrchestratorSnapshot {
@@ -369,23 +450,63 @@ impl OrchestratorState {
             };
         }
 
-        let claimed = self.claimed.get(&issue.id);
+        let issue_id = issue.id.clone();
+        let claimed = self.claimed.get(&issue_id);
         let status = if claimed.is_some() {
             RunStatus::Claimed
         } else {
             self.terminal_statuses
-                .get(&issue.id)
-                .copied()
+                .get(&issue_id)
+                .map(|entry| entry.status)
                 .unwrap_or(RunStatus::Queued)
         };
+        let attempt_number = claimed.map(|claim| claim.attempt_number).or_else(|| {
+            self.terminal_statuses
+                .get(&issue_id)
+                .and_then(|entry| entry.attempt_number)
+        });
+        let last_error = claimed
+            .and_then(|claim| claim.previous_error.clone())
+            .or_else(|| {
+                self.terminal_statuses
+                    .get(&issue_id)
+                    .and_then(|entry| entry.last_error.clone())
+            });
 
         QueueIssue {
             issue,
             status,
             run_id: None,
-            attempt_number: claimed.map(|claim| claim.attempt_number),
+            attempt_number,
             next_retry_at: None,
-            last_error: claimed.and_then(|claim| claim.previous_error.clone()),
+            last_error,
+        }
+    }
+
+    fn terminal_context(
+        &self,
+        issue_id: &str,
+        status: RunStatus,
+        last_error: Option<String>,
+    ) -> TerminalEntry {
+        let claimed = self.claimed.get(issue_id);
+        let running = self.running.get(issue_id);
+        let retry = self.retry_queue.get(issue_id);
+        let terminal = self.terminal_statuses.get(issue_id);
+        let attempt_number = claimed
+            .map(|claim| claim.attempt_number)
+            .or_else(|| running.map(|run| run.attempt_number))
+            .or_else(|| retry.map(|entry| entry.attempt_number))
+            .or_else(|| terminal.and_then(|entry| entry.attempt_number));
+        let last_error = last_error
+            .or_else(|| claimed.and_then(|claim| claim.previous_error.clone()))
+            .or_else(|| retry.map(|entry| entry.last_error.clone()))
+            .or_else(|| terminal.and_then(|entry| entry.last_error.clone()));
+
+        TerminalEntry {
+            status,
+            attempt_number,
+            last_error,
         }
     }
 }
@@ -537,6 +658,61 @@ mod tests {
         assert!(snapshot.retry_queue.is_empty());
         assert_eq!(snapshot.queue[0].status, RunStatus::Claimed);
         assert_eq!(snapshot.queue[0].attempt_number, Some(2));
+    }
+
+    #[test]
+    fn claim_manual_retry_promotes_failed_terminal_attempt() {
+        let mut state = OrchestratorState::new();
+        let issue = issue("issue-108", "#108");
+        state.claim_issue(&issue).unwrap();
+        state
+            .mark_running(
+                "issue-108",
+                "run-1",
+                None,
+                2,
+                PathBuf::from("/tmp/workspace"),
+                None,
+                None,
+                "2026-05-02T00:00:00Z",
+            )
+            .unwrap();
+        state.release_issue_with_error(
+            "issue-108",
+            RunStatus::Failed,
+            Some("agent exited 1".to_string()),
+        );
+
+        let failed = state.snapshot(vec![issue.clone()]);
+        let claimed = state.claim_manual_retry(&issue).unwrap();
+        let attempt = state.claimed_attempt("issue-108").unwrap();
+
+        assert_eq!(failed.queue[0].status, RunStatus::Failed);
+        assert_eq!(failed.queue[0].attempt_number, Some(2));
+        assert_eq!(
+            failed.queue[0].last_error.as_deref(),
+            Some("agent exited 1")
+        );
+        assert_eq!(claimed.status, RunStatus::Claimed);
+        assert_eq!(claimed.attempt_number, Some(3));
+        assert_eq!(claimed.last_error.as_deref(), Some("agent exited 1"));
+        assert_eq!(attempt.previous_error.as_deref(), Some("agent exited 1"));
+    }
+
+    #[test]
+    fn claim_manual_retry_rejects_succeeded_terminal_attempt() {
+        let mut state = OrchestratorState::new();
+        let issue = issue("issue-108", "#108");
+        state.release_issue("issue-108", RunStatus::Succeeded);
+
+        let error = state.claim_manual_retry(&issue).unwrap_err();
+
+        assert_eq!(
+            error,
+            StateError::IssueNotRetrying {
+                issue_id: "issue-108".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/src/features/orchestrator/components/OrchestratorPanel.test.tsx
+++ b/src/features/orchestrator/components/OrchestratorPanel.test.tsx
@@ -125,16 +125,25 @@ const createService = (
           events: [{ ...dispatchEvent, status: 'stopped' }],
         })
     ),
-    retryIssue: vi.fn(
-      (): Promise<DispatchBatch> =>
-        Promise.resolve({
-          snapshot: { ...snapshot, retryQueue: [] },
-          claimed: [],
-          started: [],
-          failed: [],
-          events: [{ ...dispatchEvent, status: 'claimed' }],
-        })
-    ),
+    retryIssue: vi.fn((issueId: string): Promise<DispatchBatch> => {
+      const issue = snapshot.queue.find((entry) => entry.issue.id === issueId)
+
+      return Promise.resolve({
+        snapshot: { ...snapshot, retryQueue: [] },
+        claimed: [],
+        started: [],
+        failed: [],
+        events: [
+          {
+            ...dispatchEvent,
+            issueId,
+            issueIdentifier:
+              issue?.issue.identifier ?? dispatchEvent.issueIdentifier,
+            status: 'claimed',
+          },
+        ],
+      })
+    }),
     onEvent: vi.fn(
       (callback: (event: OrchestratorEvent) => void): Promise<() => void> => {
         callbacks.push(callback)
@@ -232,6 +241,56 @@ describe('OrchestratorPanel', () => {
 
     expect(service.stopRun).toHaveBeenCalledWith('issue-2')
     expect(service.retryIssue).toHaveBeenCalledWith('issue-3')
+  })
+
+  test('retries failed and stopped queue rows from row actions', async (): Promise<void> => {
+    const terminalSnapshot: OrchestratorSnapshot = {
+      ...baseSnapshot,
+      running: [],
+      retryQueue: [],
+      queue: [
+        {
+          ...baseSnapshot.queue[0],
+          issue: {
+            ...baseSnapshot.queue[0].issue,
+            id: 'issue-4',
+            identifier: 'VIM-111',
+            title: 'Fix failed run',
+          },
+          status: 'failed',
+          attemptNumber: 2,
+          lastError: 'agent exited 1',
+        },
+        {
+          ...baseSnapshot.queue[0],
+          issue: {
+            ...baseSnapshot.queue[0].issue,
+            id: 'issue-5',
+            identifier: 'VIM-112',
+            title: 'Restart stopped run',
+          },
+          status: 'stopped',
+          attemptNumber: 1,
+          lastError: 'operator stopped agent run',
+        },
+      ],
+    }
+    const service = createService(terminalSnapshot)
+    const user = userEvent.setup()
+
+    render(<OrchestratorPanel service={service} />)
+
+    await user.type(
+      screen.getByRole('textbox', { name: /workflow path/i }),
+      '/repo/WORKFLOW.md'
+    )
+    await user.click(screen.getByRole('button', { name: 'Load' }))
+
+    await user.click(screen.getByRole('button', { name: 'Retry VIM-111' }))
+    await user.click(screen.getByRole('button', { name: 'Retry VIM-112' }))
+
+    expect(service.retryIssue).toHaveBeenCalledWith('issue-4')
+    expect(service.retryIssue).toHaveBeenCalledWith('issue-5')
   })
 
   test('subscribes to orchestrator events and cleans up on unmount', async (): Promise<void> => {

--- a/src/features/orchestrator/components/OrchestratorPanel.tsx
+++ b/src/features/orchestrator/components/OrchestratorPanel.tsx
@@ -115,7 +115,7 @@ const queueRow = (entry: QueueIssue): QueueRow => ({
   attemptNumber: entry.attemptNumber,
   detail: entry.lastError ?? retryDetail(entry.nextRetryAt),
   canStop: false,
-  canRetry: false,
+  canRetry: entry.status === 'failed' || entry.status === 'stopped',
 })
 
 const retryDetail = (nextRetryAt: string | null): string | null =>

--- a/src/features/orchestrator/services/orchestratorService.ts
+++ b/src/features/orchestrator/services/orchestratorService.ts
@@ -162,8 +162,20 @@ export class MockOrchestratorService implements OrchestratorService {
   }
 
   retryIssue(issueId: string): Promise<DispatchBatch> {
+    const queue = this.snapshot.queue.map((entry) =>
+      entry.issue.id === issueId
+        ? {
+            ...entry,
+            status: 'claimed' as const,
+            attemptNumber: (entry.attemptNumber ?? 0) + 1,
+            nextRetryAt: null,
+          }
+        : entry
+    )
+
     this.snapshot = {
       ...this.snapshot,
+      queue,
       retryQueue: this.snapshot.retryQueue.filter(
         (entry) => entry.issueId !== issueId
       ),


### PR DESCRIPTION
## Summary

This is stacked on #149 and targets `feat/108-run-completion` so the review only covers the terminal manual-retry slice for #108.

- Preserves terminal attempt/error metadata when runs fail, stop, or dispatch fails permanently.
- Allows manual retry from failed and stopped terminal issue rows, while still rejecting succeeded terminal work.
- Carries the previous terminal error/reason into the next attempt prompt context.
- Shows retry actions for failed/stopped queue rows in the orchestrator panel and updates the mock service behavior for those rows.

Refs #108.

## Validation

- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml orchestrator:: -- --nocapture`
- `npm test -- src/features/orchestrator --run`
- `CARGO_NET_OFFLINE=true cargo check --manifest-path src-tauri/Cargo.toml`
- `npm run lint`
- `npm run format:check`
- `npm run type-check`
- `rustfmt --edition 2021 --check src-tauri/src/orchestrator/runtime.rs src-tauri/src/orchestrator/state.rs`
- `git diff --check`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml terminal::commands::tests::read_loop_eof_marks_cache_exited -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml`
- `npm test`

Note: the first full Rust run hit the known flaky `terminal::commands::tests::read_loop_eof_marks_cache_exited`; the targeted rerun passed, and the subsequent full Rust run passed.