### PR TITLE
feat(orchestrator): recover existing workspaces

### DIFF
--- a/src-tauri/src/orchestrator/commands.rs
+++ b/src-tauri/src/orchestrator/commands.rs
@@ -116,6 +116,12 @@ impl OrchestratorService {
             .map_err(|error| error.to_string())
     }
 
+    fn recover_existing_workspaces(&mut self, timestamp: &str) -> Result<ControlBatch, String> {
+        self.runtime
+            .recover_existing_workspaces(&self.workspace_manager, timestamp)
+            .map_err(|error| error.to_string())
+    }
+
     fn stop_run(&mut self, issue_id: &str, timestamp: &str) -> Result<ControlBatch, String> {
         self.runtime
             .stop_run(&self.runner, issue_id, timestamp)
@@ -137,6 +143,7 @@ pub async fn load_orchestrator_workflow(
     let workflow_path = validate_workflow_path(&request.workflow_path)?;
     let mut service = OrchestratorService::from_workflow_path(&workflow_path)?;
     let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+    service.recover_existing_workspaces(&timestamp)?;
     let batch = service.snapshot(&timestamp)?;
     state.replace_service(service)?;
 

--- a/src-tauri/src/orchestrator/runtime.rs
+++ b/src-tauri/src/orchestrator/runtime.rs
@@ -10,8 +10,11 @@ use crate::orchestrator::{
     AgentRunnerError, AttemptTemplateContext, OrchestratorEvent, OrchestratorIssue,
     OrchestratorRun, OrchestratorSnapshot, OrchestratorState, PromptTemplateContext, QueueIssue,
     RetryEntry, RunStatus, StateError, TrackerClient, TrackerError, WorkflowDefinition,
-    WorkspaceManager, WorkspacePlan, WorkspaceTemplateContext,
+    WorkspaceError, WorkspaceManager, WorkspacePlan, WorkspaceTemplateContext,
 };
+
+const RESTART_RECOVERY_MESSAGE: &str =
+    "existing workspace recovered after restart; waiting for operator retry";
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum OrchestratorRuntimeError {
@@ -21,6 +24,8 @@ pub enum OrchestratorRuntimeError {
     State(#[from] StateError),
     #[error(transparent)]
     Runner(#[from] AgentRunnerError),
+    #[error(transparent)]
+    Workspace(#[from] WorkspaceError),
     #[error("no orchestrator concurrency slots are available for issue: {issue_id}")]
     NoAvailableSlots { issue_id: String },
     #[error("invalid orchestrator timestamp {value}: {message}")]
@@ -109,6 +114,43 @@ where
     pub fn claim_ready(&mut self, timestamp: &str) -> Result<ClaimBatch, OrchestratorRuntimeError> {
         let issues = self.tracker.fetch_issues()?;
         self.claim_ready_from_issues(issues, timestamp)
+    }
+
+    pub fn recover_existing_workspaces(
+        &mut self,
+        workspace_manager: &WorkspaceManager,
+        timestamp: &str,
+    ) -> Result<ControlBatch, OrchestratorRuntimeError> {
+        let issues = self.tracker.fetch_issues()?;
+        let mut events = Vec::new();
+
+        for issue in &issues {
+            if !self.is_active_issue(issue) {
+                continue;
+            }
+
+            if self.state.is_issue_active(&issue.id)
+                || self.state.terminal_status(&issue.id).is_some()
+            {
+                continue;
+            }
+
+            let Some(workspace) = workspace_manager.recover_workspace(issue)? else {
+                continue;
+            };
+            self.state.record_terminal_issue(
+                issue,
+                RunStatus::Stopped,
+                Some(1),
+                Some(RESTART_RECOVERY_MESSAGE.to_string()),
+            )?;
+            events.push(self.workspace_recovery_event(issue, &workspace, timestamp));
+        }
+
+        Ok(ControlBatch {
+            snapshot: self.state.snapshot(issues),
+            events,
+        })
     }
 
     pub fn reconcile_finished_runs<R>(
@@ -743,6 +785,24 @@ where
         }
     }
 
+    fn workspace_recovery_event(
+        &self,
+        issue: &OrchestratorIssue,
+        workspace: &WorkspacePlan,
+        timestamp: &str,
+    ) -> OrchestratorEvent {
+        self.issue_event(
+            issue,
+            timestamp,
+            RunStatus::Stopped,
+            None,
+            Some(1),
+            Some(workspace.path.clone()),
+            Some(RESTART_RECOVERY_MESSAGE.to_string()),
+            None,
+        )
+    }
+
     fn issue_event(
         &self,
         issue: &OrchestratorIssue,
@@ -1013,6 +1073,59 @@ mod tests {
 
         assert_eq!(snapshot.queue[0].status, RunStatus::Released);
         assert_eq!(runtime.in_flight_count(), 0);
+    }
+
+    #[test]
+    fn recover_existing_workspaces_marks_active_workspace_stopped() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let issue = issue("issue-108", "#108", "open");
+        let workspace = workspace_manager.prepare_workspace(&issue).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue]);
+        let runner = RecordingRunner::with_run("run-108");
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        let recovered = runtime
+            .recover_existing_workspaces(&workspace_manager, "2026-05-02T08:14:00Z")
+            .unwrap();
+        let dispatched = runtime
+            .dispatch_ready(&workspace_manager, &runner, "2026-05-02T08:15:00Z")
+            .unwrap();
+
+        assert_eq!(recovered.events.len(), 1);
+        assert_eq!(recovered.events[0].status, RunStatus::Stopped);
+        assert_eq!(
+            recovered.events[0].message.as_deref(),
+            Some(RESTART_RECOVERY_MESSAGE)
+        );
+        assert_eq!(
+            recovered.events[0].workspace_path.as_ref(),
+            Some(&workspace.path)
+        );
+        assert_eq!(recovered.snapshot.queue[0].status, RunStatus::Stopped);
+        assert_eq!(recovered.snapshot.queue[0].attempt_number, Some(1));
+        assert_eq!(
+            recovered.snapshot.queue[0].last_error.as_deref(),
+            Some(RESTART_RECOVERY_MESSAGE)
+        );
+        assert!(dispatched.claimed.is_empty());
+        assert!(dispatched.started.is_empty());
+        assert_eq!(dispatched.snapshot.queue[0].status, RunStatus::Stopped);
+    }
+
+    #[test]
+    fn recover_existing_workspaces_leaves_missing_workspace_queued() {
+        let (_dir, workflow) = workflow_fixture(1);
+        let workspace_manager = WorkspaceManager::from_workflow(&workflow).unwrap();
+        let tracker = StaticTracker::with_issues(vec![issue("issue-108", "#108", "open")]);
+        let mut runtime = OrchestratorRuntime::new(workflow, tracker);
+
+        let batch = runtime
+            .recover_existing_workspaces(&workspace_manager, "2026-05-02T08:14:00Z")
+            .unwrap();
+
+        assert!(batch.events.is_empty());
+        assert_eq!(batch.snapshot.queue[0].status, RunStatus::Queued);
     }
 
     #[test]

--- a/src-tauri/src/orchestrator/state.rs
+++ b/src-tauri/src/orchestrator/state.rs
@@ -407,6 +407,31 @@ impl OrchestratorState {
             .insert(issue_id.to_string(), terminal);
     }
 
+    pub fn record_terminal_issue(
+        &mut self,
+        issue: &OrchestratorIssue,
+        status: RunStatus,
+        attempt_number: Option<u32>,
+        last_error: Option<String>,
+    ) -> Result<(), StateError> {
+        if self.is_issue_active(&issue.id) {
+            return Err(StateError::IssueAlreadyActive {
+                issue_id: issue.id.clone(),
+            });
+        }
+
+        self.terminal_statuses.insert(
+            issue.id.clone(),
+            TerminalEntry {
+                status,
+                attempt_number,
+                last_error,
+            },
+        );
+
+        Ok(())
+    }
+
     pub fn snapshot(&self, issues: Vec<OrchestratorIssue>) -> OrchestratorSnapshot {
         let mut running: Vec<_> = self.running.values().cloned().collect();
         running.sort_by(|left, right| left.issue_identifier.cmp(&right.issue_identifier));

--- a/src-tauri/src/orchestrator/workspace.rs
+++ b/src-tauri/src/orchestrator/workspace.rs
@@ -142,6 +142,44 @@ impl WorkspaceManager {
             ..plan
         })
     }
+
+    pub fn recover_workspace(
+        &self,
+        issue: &OrchestratorIssue,
+    ) -> Result<Option<WorkspacePlan>, WorkspaceError> {
+        let plan = self.plan_for_issue(issue)?;
+        if !plan.path.exists() {
+            return Ok(None);
+        }
+
+        let workspace_path = plan.path.canonicalize().map_err(|error| {
+            WorkspaceError::InvalidConfig(format!(
+                "workspace directory must be canonicalizable: {error}"
+            ))
+        })?;
+        ensure_within_root(&workspace_path, &self.root)?;
+        if !workspace_path.is_dir() {
+            return Err(WorkspaceError::InvalidConfig(format!(
+                "workspace path must be a directory: {}",
+                workspace_path.display()
+            )));
+        }
+
+        let prompt_file = PROMPT_DIR
+            .iter()
+            .fold(workspace_path.clone(), |parent, segment| {
+                parent.join(segment)
+            })
+            .join(PROMPT_FILE_NAME);
+        ensure_no_parent_refs(&prompt_file)?;
+        ensure_within_root(&prompt_file, &workspace_path)?;
+
+        Ok(Some(WorkspacePlan {
+            path: workspace_path,
+            prompt_file,
+            ..plan
+        }))
+    }
 }
 
 fn workflow_default_root(workflow: &WorkflowDefinition) -> Result<PathBuf, WorkspaceError> {
@@ -359,6 +397,22 @@ mod tests {
         assert!(prepared.prompt_file.starts_with(&prepared.path));
     }
 
+    #[test]
+    fn recover_workspace_returns_existing_workspace_without_creating_missing_one() {
+        let root = TempDir::new().unwrap();
+        let manager = WorkspaceManager::new(root.path(), "main", "agent").unwrap();
+        let issue = issue("issue-108", "#108");
+
+        assert!(manager.recover_workspace(&issue).unwrap().is_none());
+
+        let prepared = manager.prepare_workspace(&issue).unwrap();
+        let recovered = manager.recover_workspace(&issue).unwrap().unwrap();
+
+        assert_eq!(recovered.workspace_slug, prepared.workspace_slug);
+        assert_eq!(recovered.path, prepared.path);
+        assert_eq!(recovered.prompt_file, prepared.prompt_file);
+    }
+
     #[cfg(unix)]
     #[test]
     fn prepare_workspace_rejects_existing_symlink_escape() {
@@ -372,6 +426,23 @@ mod tests {
         symlink(outside.path(), &plan.path).unwrap();
 
         let error = manager.prepare_workspace(&issue).unwrap_err();
+
+        assert!(matches!(error, WorkspaceError::PathEscape { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recover_workspace_rejects_existing_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let manager = WorkspaceManager::new(root.path(), "main", "agent").unwrap();
+        let issue = issue("issue-108", "#108");
+        let plan = manager.plan_for_issue(&issue).unwrap();
+        symlink(outside.path(), &plan.path).unwrap();
+
+        let error = manager.recover_workspace(&issue).unwrap_err();
 
         assert!(matches!(error, WorkspaceError::PathEscape { .. }));
     }


### PR DESCRIPTION
## Summary

This is stacked on #150 and targets `feat/108-terminal-retry` so the review only covers the restart/workspace recovery slice for #108.

- Adds non-creating recovery of deterministic per-issue workspaces with the same containment checks as workspace preparation.
- Marks active issues with existing recovered workspaces as `Stopped` during workflow load, preserving retry context for the operator.
- Prevents recovered workspace rows from being auto-dispatched immediately after restart.
- Covers missing-workspace and symlink-escape recovery cases with Rust tests.

Refs #108.

## Validation

- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml orchestrator:: -- --nocapture`
- `rustfmt --edition 2021 src-tauri/src/orchestrator/commands.rs src-tauri/src/orchestrator/runtime.rs src-tauri/src/orchestrator/state.rs src-tauri/src/orchestrator/workspace.rs`
- `CARGO_NET_OFFLINE=true cargo check --manifest-path src-tauri/Cargo.toml`
- `CARGO_NET_OFFLINE=true cargo test --manifest-path src-tauri/Cargo.toml`
- `npm run lint`
- `npm run format:check`
- `npm run type-check`
- `rustfmt --edition 2021 --check src-tauri/src/orchestrator/commands.rs src-tauri/src/orchestrator/runtime.rs src-tauri/src/orchestrator/state.rs src-tauri/src/orchestrator/workspace.rs`
- `git diff --check`
- `npm test`