### PR TITLE
docs: reflect codex adapter support in README + agent module README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 </div>
 
-> A Tauri desktop app that unifies terminal sessions, file explorer, code editor, and git diff into a single workspace — purpose-built for AI coding agents like Claude Code.
+> A Tauri desktop app that unifies terminal sessions, file explorer, code editor, and git diff into a single workspace — purpose-built for AI coding agents like Claude Code and Codex.
 
 Vimeflow is a **CLI coding agent control plane** built with Tauri 2 (Rust + React/TypeScript). It gives you one window to manage terminal sessions where AI agents work, browse files, review diffs, and edit code — all with vim-style keybindings and a dark atmospheric UI.
 
@@ -48,21 +48,23 @@ A 4-zone grid layout inspired by IDE + terminal multiplexer patterns:
 
 ### Agent Status Sidebar (Phase 4 — Latest)
 
-Real-time agent observability panel that auto-detects running AI coding agents in terminal sessions:
+Real-time agent observability panel that auto-detects running AI coding agents in terminal sessions. Supports **Claude Code** and **Codex** (since [#154](https://github.com/winoooops/vimeflow/pull/154)) with one shared frontend:
 
-- **Rust backend** — `src-tauri/src/agent/` module with agent detector (process tree polling), statusline file watcher (`notify` crate), and transcript JSONL parser for tool call tracking
-- **Statusline bridge** — per-session shell script pipes Claude Code's statusline JSON to a watched file; Rust parses and emits Tauri events (`agent-detected`, `agent-status`, `agent-tool-call`, `agent-disconnected`)
-- **Frontend panel** — `src/features/agent-status/` with `useAgentStatus` hook subscribing to Tauri events, plus components: StatusCard (identity + model badge), BudgetMetrics (adaptive API key vs subscriber layout), ContextBucket (fill gauge + progress bar), ToolCallSummary (aggregated chips), RecentToolCalls, FilesChanged, TestResults, and ActivityFooter
+- **`AgentAdapter` trait** — `src-tauri/src/agent/adapter/` defines a single trait (`status_source` / `parse_status` / `validate_transcript` / `tail_transcript`) that each agent's adapter implements; the watcher pipeline, frontend events, and panel UI are agent-agnostic
+- **Claude Code adapter** (`adapter/claude_code/`) — per-session shell script pipes Claude's statusline JSON to a watched file; the adapter parses it and emits Tauri events (`agent-detected`, `agent-status`, `agent-tool-call`, `agent-disconnected`)
+- **Codex adapter** (`adapter/codex/`) — schema-driven SQLite locator over `~/.codex/*.sqlite` (logs DB → thread_id, threads DB → rollout JSONL path) with `/proc`-driven Linux fast-paths and FS-scan fallback; fold `event_msg.token_count` into the same `AgentStatusEvent` shape Claude emits
+- **Rust backend orchestration** — `src-tauri/src/agent/` adds the agent detector (process tree polling), the `base::start_for` watcher driver (file-change notify + polling fallback), and per-adapter transcript JSONL tailers for tool-call / turn / test-run signals
+- **Frontend panel** — `src/features/agent-status/` with `useAgentStatus` hook subscribing to the Tauri event bus, plus components: StatusCard (identity + model badge), BudgetMetrics (adaptive ApiKey/Subscriber/Fallback layout — Codex sessions render Subscriber with rate-limit bars; Claude API-key sessions render the Cost cell), ContextBucket (fill gauge + progress bar driven by `last_token_usage` for Codex, `total_input_tokens` for Claude), ToolCallSummary (aggregated chips), RecentToolCalls, FilesChanged, TestResults, and ActivityFooter
 - **Auto-collapse** — panel is 0px when no agent detected, animates to 280px on detection, holds final state for 5s after disconnect
-- **ts-rs type codegen** — Rust types exported to `src/bindings/` for type-safe frontend consumption
+- **ts-rs type codegen** — Rust types exported to `src/bindings/` for type-safe frontend consumption (`CostMetrics.totalCostUsd: number | null` distinguishes Codex's no-cost surface from Claude's reported cost)
 
-Design spec: [`docs/superpowers/specs/2026-04-12-agent-status-sidebar/`](docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md)
+Design specs: [`2026-04-12-agent-status-sidebar/`](docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md) (panel) · [`2026-05-02-claude-adapter-refactor-design.md`](docs/superpowers/specs/2026-05-02-claude-adapter-refactor-design.md) (trait abstraction, Stage 1) · [`2026-05-03-codex-adapter-stage-2-design.md`](docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md) (Codex adapter, Stage 2) · [`2026-05-04-codex-adapter-stage-2-scope-expansion.md`](docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md) (ratified deviations)
 
 <p align="center">
   <img src="docs/media/agent-status-sidebar.png" alt="Agent Status Sidebar — Current Context gauge, Token Cache block, Activity feed, Files Changed, Tests panel" width="280" />
 </p>
 
-<p align="center"><sub>Right panel close-up — Context gauge, Token Cache, Activity feed, Files Changed, and Tests panel populated by a live Claude Code session.</sub></p>
+<p align="center"><sub>Right panel close-up — Context gauge, Token Cache, Activity feed, Files Changed, and Tests panel. Driven by either a Claude Code or Codex session via the shared <code>AgentAdapter</code> trait.</sub></p>
 
 ### Feature Modules
 
@@ -73,7 +75,7 @@ Design spec: [`docs/superpowers/specs/2026-04-12-agent-status-sidebar/`](docs/su
 | **diff**            | Lazygit-style git diff viewer (side-by-side + unified, hunk navigation, stage/discard)                                      |
 | **files**           | File explorer tree with breadcrumbs, git status badges (M/A/D/U), drag-and-drop                                             |
 | **command-palette** | Vim-style `:` palette (global shortcut, fuzzy match, namespace drill-in) — built-in command registry shipping incrementally |
-| **agent-status**    | Real-time agent observability panel (statusline bridge + transcript parsing)                                                |
+| **agent-status**    | Real-time agent observability panel — multi-agent (Claude Code + Codex) via the `AgentAdapter` trait                        |
 | **workspace**       | Layout shell composing all zones above                                                                                      |
 
 ![Editor with vim mode — `:w` typed, status bar shows -- NORMAL --](docs/media/editor-vim.png)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,7 @@
 
 </div>
 
-> 一个 Tauri 桌面应用，将终端会话、文件浏览器、代码编辑器和 Git Diff 统一到一个工作空间 — 专为 Claude Code 等 AI 编码代理打造。
+> 一个 Tauri 桌面应用，将终端会话、文件浏览器、代码编辑器和 Git Diff 统一到一个工作空间 — 专为 Claude Code、Codex 等 AI 编码代理打造。
 
 Vimeflow 是一个 **CLI 编码代理控制面板**，基于 Tauri 2（Rust + React/TypeScript）构建。它在一个窗口内管理 AI 代理工作的终端会话、浏览文件、审查 Diff 和编辑代码 — 全部配备 Vim 风格快捷键和暗色氛围 UI。
 
@@ -48,21 +48,23 @@ Vimeflow 是一个 **CLI 编码代理控制面板**，基于 Tauri 2（Rust + Re
 
 ### 代理状态侧边栏（第 4 阶段 — 最新）
 
-实时代理可观察性面板，自动检测终端会话中运行的 AI 编码代理：
+实时代理可观察性面板，自动检测终端会话中运行的 AI 编码代理。自 [#154](https://github.com/winoooops/vimeflow/pull/154) 起同时支持 **Claude Code** 与 **Codex**，共用一套前端：
 
-- **Rust 后端** — `src-tauri/src/agent/` 模块包含代理检测器（进程树轮询）、statusline 文件监听器（`notify` crate）和 JSONL transcript 解析器用于工具调用跟踪
-- **Statusline 桥接** — 每会话 shell 脚本将 Claude Code 的 statusline JSON 输出到被监听文件；Rust 解析并通过 Tauri 事件发送（`agent-detected`、`agent-status`、`agent-tool-call`、`agent-disconnected`）
-- **前端面板** — `src/features/agent-status/` 包含订阅 Tauri 事件的 `useAgentStatus` hook，以及组件：StatusCard（身份 + 模型徽章）、BudgetMetrics（自适应 API Key / 订阅者布局）、ContextBucket（填充仪表 + 进度条）、ToolCallSummary（聚合芯片）、RecentToolCalls、FilesChanged、TestResults 和 ActivityFooter
+- **`AgentAdapter` trait** — `src-tauri/src/agent/adapter/` 定义统一接口（`status_source` / `parse_status` / `validate_transcript` / `tail_transcript`），每种代理各自实现；监听管道、前端事件与面板 UI 与具体代理无关
+- **Claude Code 适配器**（`adapter/claude_code/`）— 每会话 shell 脚本把 Claude 的 statusline JSON 写入被监听文件；适配器解析后通过 Tauri 事件发送（`agent-detected`、`agent-status`、`agent-tool-call`、`agent-disconnected`）
+- **Codex 适配器**（`adapter/codex/`）— 基于 schema 探测的 SQLite 定位器扫描 `~/.codex/*.sqlite`（logs DB → thread_id，threads DB → rollout JSONL 路径），辅以 Linux `/proc` 快速路径与 FS 扫描回退；将 `event_msg.token_count` 折叠为与 Claude 一致的 `AgentStatusEvent` 形状
+- **Rust 后端编排** — `src-tauri/src/agent/` 提供代理检测器（进程树轮询）、`base::start_for` 监听驱动（notify 文件变更 + 轮询回退），以及各适配器的 transcript JSONL tailer（用于工具调用 / 轮次 / 测试运行信号）
+- **前端面板** — `src/features/agent-status/` 包含订阅 Tauri 事件总线的 `useAgentStatus` hook，以及组件：StatusCard（身份 + 模型徽章）、BudgetMetrics（自适应 ApiKey / Subscriber / Fallback 布局 — Codex 会话渲染 Subscriber 显示速率限额条；Claude API-key 会话渲染 Cost 单元）、ContextBucket（填充仪表 + 进度条；Codex 由 `last_token_usage` 驱动，Claude 由 `total_input_tokens` 驱动）、ToolCallSummary（聚合芯片）、RecentToolCalls、FilesChanged、TestResults 和 ActivityFooter
 - **自动折叠** — 未检测到代理时面板为 0px，检测到时动画展开到 280px，断开后保留最终状态 5 秒
-- **ts-rs 类型代码生成** — Rust 类型自动导出到 `src/bindings/`，前端可类型安全消费
+- **ts-rs 类型代码生成** — Rust 类型自动导出到 `src/bindings/`，前端可类型安全消费（`CostMetrics.totalCostUsd: number | null` 用以区分 Codex 不暴露 cost 的语义与 Claude 上报的实际花费）
 
-设计规格：[`docs/superpowers/specs/2026-04-12-agent-status-sidebar/`](docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md)
+设计规格：[`2026-04-12-agent-status-sidebar/`](docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md)（面板）· [`2026-05-02-claude-adapter-refactor-design.md`](docs/superpowers/specs/2026-05-02-claude-adapter-refactor-design.md)（trait 抽象，Stage 1）· [`2026-05-03-codex-adapter-stage-2-design.md`](docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md)（Codex 适配器，Stage 2）· [`2026-05-04-codex-adapter-stage-2-scope-expansion.md`](docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md)（已记录的偏离）
 
 <p align="center">
   <img src="docs/media/agent-status-sidebar.png" alt="代理状态侧边栏 — 上下文计量器、Token 缓存、活动事件流、变更文件、测试面板" width="280" />
 </p>
 
-<p align="center"><sub>右侧面板特写 — 上下文计量器、Token 缓存、活动事件流、变更文件和测试面板，由实时 Claude Code 会话填充。</sub></p>
+<p align="center"><sub>右侧面板特写 — 上下文计量器、Token 缓存、活动事件流、变更文件和测试面板。可由 Claude Code 或 Codex 会话经共享 <code>AgentAdapter</code> trait 驱动。</sub></p>
 
 ### 功能模块
 
@@ -73,7 +75,7 @@ Vimeflow 是一个 **CLI 编码代理控制面板**，基于 Tauri 2（Rust + Re
 | **diff**            | Lazygit 风格 Git Diff 查看器（并排 + 统一视图，hunk 导航，暂存/丢弃）                 |
 | **files**           | 文件浏览树，面包屑导航，Git 状态徽章（M/A/D/U），拖放支持                             |
 | **command-palette** | Vim 风格 `:` 命令面板（全局快捷键、模糊匹配、命名空间下钻）— 内置命令注册表陆续交付中 |
-| **agent-status**    | 实时代理可观察性面板（statusline 桥接 + transcript 解析）                             |
+| **agent-status**    | 实时代理可观察性面板 — 通过 `AgentAdapter` trait 同时支持 Claude Code 与 Codex        |
 | **workspace**       | 组合以上所有区域的布局外壳                                                            |
 
 ![编辑器与 Vim 模式 — 输入 `:w`，状态栏显示 -- NORMAL --](docs/media/editor-vim.png)

--- a/src-tauri/src/agent/README.md
+++ b/src-tauri/src/agent/README.md
@@ -1,6 +1,14 @@
 # `agent` — Vimeflow Backend Agent Module
 
-This module owns everything that detects a CLI coding agent inside a PTY session, extracts its status / transcript / tool-call data, and emits Tauri events the frontend agent panel listens for. After the **Stage 1 refactor** (spec at `docs/superpowers/specs/2026-05-02-claude-adapter-refactor-design.md`, plan at `docs/superpowers/plans/2026-05-03-claude-adapter-refactor-stage-1.md`), the design is centred on a single `AgentAdapter<R>` trait that lets each supported agent (Claude Code today, Codex / Aider / etc. later) plug into a shared watcher pipeline.
+This module owns everything that detects a CLI coding agent inside a PTY session, extracts its status / transcript / tool-call data, and emits Tauri events the frontend agent panel listens for. The design is centred on a single `AgentAdapter<R>` trait that lets each supported agent plug into a shared watcher pipeline.
+
+**Supported today:** Claude Code (Stage 1, [#152](https://github.com/winoooops/vimeflow/pull/152)) and Codex (Stage 2, [#154](https://github.com/winoooops/vimeflow/pull/154)). Aider / etc. are future stages — adding a new adapter is purely additive against the trait.
+
+Stage history:
+
+- Stage 1 — `2026-05-02-claude-adapter-refactor-design.md` introduces the trait and migrates Claude behind it.
+- Stage 2 — `2026-05-03-codex-adapter-stage-2-design.md` adds `CodexAdapter` against the trait.
+- Stage 2 scope expansion — `docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md` ratifies three implementation deviations (transcript tailer landed in v1, `/proc` upgraded from verifier to fallback chooser, `BindContext.pid` is the detected agent PID).
 
 This README is the **interface map**. For _why_ the design is shaped the way it is, read the spec; for _how_ to implement the refactor, read the plan; the README is the reference you pull up when you want to know "what does the trait look like, who implements it, and which type goes where."
 
@@ -56,12 +64,17 @@ src-tauri/src/agent/
     │   ├── path_security.rs ← StatusSource trust_root enforcement
     │   ├── transcript_state.rs ← TranscriptState/Handle/StartStatus registry
     │   └── watcher_runtime.rs  ← notify watcher, inline read, polling fallback, WatcherHandle
-    ├── types.rs             ← StatusSource, ParsedStatus
-    └── claude_code/
-        ├── mod.rs           ← ClaudeCodeAdapter (impl AgentAdapter<R>)
-        ├── statusline.rs    ← Claude's status.json parser
-        ├── transcript.rs    ← Claude's JSONL tail loop + per-line parsing
-        └── test_runners/    ← vitest / cargo-test parser ecosystem
+    ├── types.rs             ← StatusSource, ParsedStatus, BindContext, BindError, ValidateTranscriptError
+    ├── claude_code/
+    │   ├── mod.rs           ← ClaudeCodeAdapter (impl AgentAdapter<R>)
+    │   ├── statusline.rs    ← Claude's status.json parser
+    │   ├── transcript.rs    ← Claude's JSONL tail loop + per-line parsing
+    │   └── test_runners/    ← vitest / cargo-test parser ecosystem
+    └── codex/
+        ├── mod.rs           ← CodexAdapter (impl AgentAdapter<R>); per-attach Mutex<Option<PathBuf>> threads the rollout path from status_source to the transcript tailer
+        ├── locator.rs       ← CodexSessionLocator: schema-driven SQLite discovery (logs DB → thread_id, threads DB → rollout_path) + Linux /proc fast-paths (resume cmdline, fd cohort, recent state) + FS-scan fallback
+        ├── parser.rs        ← Codex rollout JSONL fold: session_meta + turn_context + event_msg.{task_started, task_complete, token_count} → AgentStatusEvent (driven by last_token_usage, not lifetime totals)
+        └── transcript.rs    ← Codex rollout JSONL tail loop; reuses claude_code/test_runners/* to emit AgentToolCallEvent / AgentTurnEvent / test-run signals
 ```
 
 ---
@@ -76,7 +89,13 @@ Everything outside `agent::adapter::*` interacts with the agent module through t
 pub fn for_type(agent_type: AgentType) -> Result<Arc<Self>, String>
 ```
 
-Constructs the right adapter for a detected agent type. Returns `Arc<dyn AgentAdapter<R>>`. Stage 1 returns `ClaudeCodeAdapter` for `AgentType::ClaudeCode` and `NoOpAdapter::new(t)` for everything else; Stage 2 replaces the `Codex` arm with `CodexAdapter`.
+Constructs the right adapter for a detected agent type. Returns `Arc<dyn AgentAdapter<R>>`:
+
+- `AgentType::ClaudeCode` → `ClaudeCodeAdapter`
+- `AgentType::Codex` → `CodexAdapter::new()`
+- everything else → `NoOpAdapter::new(t)` (returns errors from `parse_status` / `validate_transcript` / `tail_transcript`; `status_source` returns a `.vimeflow/sessions/{sid}/status.json` placeholder)
+
+> **Follow-up tracking:** issue [#156](https://github.com/winoooops/vimeflow/issues/156) collapses `BindContext` and the central retry into `CodexAdapter::new(pid, pty_start)`. After that lands, `for_type` becomes `for_attach(ctx)` and the Claude impl drops the unused `ctx` parameter from `status_source`.
 
 ### `<dyn AgentAdapter<R>>::start`
 
@@ -86,11 +105,15 @@ pub fn start(
     app: AppHandle<R>,
     session_id: String,
     cwd: PathBuf,
+    pid: u32,
+    pty_start: SystemTime,
     state: AgentWatcherState,
 ) -> Result<(), String>
 ```
 
 Starts the watcher pipeline for a PTY session. **Owns the full lifecycle:** removes any pre-existing handle for `session_id`, logs the active-watcher count, builds the new pipeline, inserts the resulting `WatcherHandle` into `state`. The Tauri command never touches `state` directly — that's the deep-module property.
+
+`pid` is the detected agent PID (returned by `detector::detect_agent`), not the shell PID at the PTY root — Codex's `logs.process_uuid` indexes by the codex child PID. `pty_start` is captured at PTY spawn (`ManagedSession.started_at`) so the logs query can filter out PID-reuse and stale-loaded-thread matches. Both arguments are passed through to the adapter as fields of `BindContext` (delegated through `base::start_for` → `resolve_status_source_with_retry` → `adapter.status_source(&ctx)`). Claude's impl ignores them; Codex's locator depends on them.
 
 ### `<dyn AgentAdapter<R>>::stop`
 


### PR DESCRIPTION
## Summary

- Updates `README.md` and `README.zh-CN.md` to reflect that the Agent Status Sidebar (Phase 4) now supports both **Claude Code** and **Codex** since [#154](https://github.com/winoooops/vimeflow/pull/154). Tagline, Phase 4 section, panel caption, and module table all updated.
- Updates `src-tauri/src/agent/README.md` so the interface map matches the merged `AgentAdapter` contract — adds the `codex/` subtree to the module map, fixes the `for_type` description (was "Stage 2 pending"), and reflects the current `start` signature (`pid`, `pty_start` added in Stage 2).
- Cross-links to the Stage 1 / Stage 2 specs and the scope-expansion ADR so future readers can trace from README → spec → ADR without re-discovering them.

Per [`rules/common/pr-scope.md`](https://github.com/winoooops/vimeflow/blob/main/rules/common/pr-scope.md), this is its own PR — not appended to #154 (which is already merged) or #155 (the rule itself). Single question answered: bring user-facing docs in line with what shipped.

## What stayed out of scope

- **`src-tauri/src/agent/architecture.puml`** — the PlantUML class diagram. Adding a Codex column is real work (regenerating PNG/SVG, re-validating shape) and worth its own follow-up. README's module tree carries the textual map until then.
- **`docs/decisions/CLAUDE.md` ADR index** — already updated as part of #154.
- **`CLAUDE.md` root** — its mention of "AI coding agents like Claude Code" is already broad enough; no edit needed.
- **Issue [#156](https://github.com/winoooops/vimeflow/issues/156) refactor** — explicitly noted as a pending follow-up in the agent README's `for_type` section so future readers know the current shape isn't the final shape.

## Test plan

- [ ] `npx prettier --check README.md README.zh-CN.md src-tauri/src/agent/README.md` clean.
- [ ] All cross-links resolve: `2026-04-12-agent-status-sidebar/`, `2026-05-02-claude-adapter-refactor-design.md`, `2026-05-03-codex-adapter-stage-2-design.md`, `2026-05-04-codex-adapter-stage-2-scope-expansion.md`, [#156](https://github.com/winoooops/vimeflow/issues/156).
- [ ] English/Chinese READMEs say the same things.
- [ ] Backend `agent/README.md` `for_type` and `start` code blocks match the actual function signatures in `src-tauri/src/agent/adapter/mod.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)