### PR TITLE
refactor(agent/adapter): collapse codex bind context (#156)

### DIFF
--- a/docs/decisions/2026-05-05-codex-adapter-trait-simplification.md
+++ b/docs/decisions/2026-05-05-codex-adapter-trait-simplification.md
@@ -1,0 +1,62 @@
+# Codex adapter trait simplification - collapse BindContext + retry into CodexAdapter
+
+**Date:** 2026-05-05
+**Status:** Accepted
+**Scope:** Round-3 review on PR #154 flagged that `BindContext` and the bounded retry inside `base::start_for` leak codex-only requirements through the `AgentAdapter` trait surface. This ADR records the decision to move both pieces into `CodexAdapter` itself, supersedes parts of the Stage 2 spec, and inherits the three deviations recorded in the 2026-05-04 scope-expansion ADR.
+
+**Predecessors (still load-bearing):**
+
+- [`docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`](../superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md) - Stage 2 spec.
+- [`docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md`](./2026-05-04-codex-adapter-stage-2-scope-expansion.md) - Stage 2 deviations (transcript tailer, `/proc` fast-paths, agent-PID bind).
+
+**Spec mandating this ADR:** [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](../superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md).
+
+## Context
+
+Stage 2 (PR #154) introduced `BindContext { session_id, cwd, pid, pty_start }` as the parameter to `AgentAdapter::status_source`, plus a bounded retry inside `base::start_for` that loops on `BindError::Pending` for up to 5 x 100ms = 500ms. Both pieces existed solely to support codex's SQLite-logs cold-start race (the `logs` row arrives ~300ms after the rollout file opens). Claude's adapter ignores `pid`/`pty_start` and never returns `Pending`. Round-3 review on PR #154 ([discussion_r3181677311](https://github.com/winoooops/vimeflow/pull/154#discussion_r3181677311), [discussion_r3181691871](https://github.com/winoooops/vimeflow/pull/154#discussion_r3181691871)) called the leak out as a finding, not a stylistic preference.
+
+## Options Considered
+
+1. **Leave as-is** - accept the trait-surface leak.
+2. **Move `pid`/`pty_start` to the codex adapter, keep the bounded retry in `base::start_for`** - half-fix.
+3. **Move both pieces into `CodexAdapter` itself** - this ADR's choice.
+
+## Decision
+
+Choose option 3.
+
+The trait method becomes `status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>`. `BindContext` and `BindError` are deleted from `agent/adapter/types.rs`. `CodexAdapter` gains `pid`, `pty_start`, and `codex_home` fields plus a `retry_locator` helper that runs the cold-start race privately. `base::start_for` becomes a single-call orchestrator with zero retry/sleep code. The factory renames from `for_type(agent_type)` to `for_attach(agent_type, pid, pty_start)`.
+
+## Justification
+
+1. **Single responsibility.** The trait describes what an agent adapter does; codex's cold-start race is how the codex adapter does it, not part of the contract.
+2. **Future adapters.** Aider, Generic, and other adapters should not need to learn about `BindContext` to implement `status_source`.
+3. **Calibration locality.** The retry budget (5 x 100ms) is calibrated against codex-specific commit timings; it does not generalize. Hosting it inside the codex adapter keeps the calibration close to the rationale.
+4. **Pure internal refactor.** No IPC, no user-visible behavior change, no scope expansion. Sleep budget shrinks marginally (5 x 100ms to 4 x 100ms because the final-attempt sleep is skipped), still well under the 500ms safety margin.
+
+## Alternatives Rejected
+
+### Option 1 - Leave as-is
+
+Rejected because round-3 review explicitly flagged the leak as a finding, not a stylistic preference. The cost of the leak grows with each new adapter.
+
+### Option 2 - Half-fix
+
+Rejected because the retry budget still has nowhere coherent to live. `base::start_for` would still be branching on a `Pending`/`Fatal` distinction that only one adapter ever produces. The trait surface would be cleaner but the orchestration layer would carry a codex-shaped contract.
+
+## Known Risks & Mitigations
+
+- **Risk:** A second adapter eventually needs the same retry shape and re-introduces a parallel-but-divergent retry helper.
+  **Mitigation:** The `retry_locator` helper is internal to codex and small; if a second adapter needs the same shape, promote a generic `retry_with_budget` to a shared `agent/adapter/util.rs` at that point.
+
+- **Risk:** Sleep-budget tightening from 5 x 100ms to 4 x 100ms is a real behavior change.
+  **Mitigation:** The cold-start window is typically ~300ms (per the 2026-05-04 ADR's `/proc` fast-path rationale), well below 400ms. The exhaustion path rarely fires in practice, and the 500ms safety margin against the 2000ms detection re-poll is preserved.
+
+## References
+
+- Issue [#156](https://github.com/winoooops/vimeflow/issues/156).
+- PR [#154](https://github.com/winoooops/vimeflow/pull/154) - Stage 2 implementation.
+- Round-3 review threads: [r1](https://github.com/winoooops/vimeflow/pull/154#discussion_r3181677311), [r2](https://github.com/winoooops/vimeflow/pull/154#discussion_r3181691871).
+- 2026-05-03 spec: [`docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`](../superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md).
+- 2026-05-04 ADR: [`docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md`](./2026-05-04-codex-adapter-stage-2-scope-expansion.md).
+- 2026-05-05 spec: [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](../superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md).

--- a/docs/decisions/CLAUDE.md
+++ b/docs/decisions/CLAUDE.md
@@ -12,6 +12,7 @@ This file is an index. Each linked record is self-contained. Read only what you 
 
 | Date       | Decision                                                                                       | Status   |
 | ---------- | ---------------------------------------------------------------------------------------------- | -------- |
+| 2026-05-05 | [Codex adapter trait simplification](./2026-05-05-codex-adapter-trait-simplification.md)       | Accepted |
 | 2026-05-04 | [Codex adapter Stage 2 scope expansion](./2026-05-04-codex-adapter-stage-2-scope-expansion.md) | Accepted |
 | 2026-05-03 | [Claude parser JSON boundary](./2026-05-03-claude-parser-json-boundary.md)                     | Accepted |
 | 2026-04-22 | [Tooltip library: `@floating-ui/react`](./2026-04-22-tooltip-library.md)                       | Accepted |

--- a/docs/superpowers/plans/2026-05-05-codex-adapter-trait-simplification.md
+++ b/docs/superpowers/plans/2026-05-05-codex-adapter-trait-simplification.md
@@ -2065,3 +2065,5 @@ git diff -w --stat main..HEAD
 ```
 
 Expected: whitespace-stripped delta close to the regular delta. Any large gap is a formatting drive-by — surface and revert before opening the PR.
+
+<!-- codex-reviewed: 2026-05-06T05:22:40Z -->

--- a/docs/superpowers/plans/2026-05-05-codex-adapter-trait-simplification.md
+++ b/docs/superpowers/plans/2026-05-05-codex-adapter-trait-simplification.md
@@ -1,0 +1,1839 @@
+# Codex Adapter Trait Simplification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor the `AgentAdapter` trait so codex-only requirements (`BindContext`, `BindError`, the bounded retry inside `base::start_for`) no longer leak through the trait surface. After the refactor, the trait method is `status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>`, the factory becomes `for_attach(agent_type, pid, pty_start)`, and codex's cold-start retry lives inside `CodexAdapter` itself.
+
+**Architecture:** Move codex-only state (`pid`, `pty_start`, `codex_home`) onto the `CodexAdapter` struct. Introduce a private `pub(super) struct BindContext { cwd, pid, pty_start }` inside `agent/adapter/codex/types.rs` (no `session_id`; the codex locator never reads it). Add a `retry_locator` helper that takes a closure and runs the existing 5-attempt × 100ms-sleep budget (with the trailing sleep skipped, giving a 400ms sleep budget on full exhaustion). Delete `BindContext` + `BindError` from public `agent/adapter/types.rs`. `base::start_for` becomes a single-call orchestrator with no retry/sleep code.
+
+**Tech Stack:** Rust 2021, Tauri, `rusqlite` (read-only feature, already a dep), `tempfile` for tests, `notify` for the file watcher (no change), `tauri::test::MockRuntime` for adapter unit tests.
+
+**Spec reference:** [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](../specs/2026-05-05-codex-adapter-trait-simplification-design.md)
+
+**Issue:** [#156](https://github.com/winoooops/vimeflow/issues/156)
+
+---
+
+## File Structure
+
+| File                                                                | Status   | Responsibility                                                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src-tauri/src/agent/adapter/codex/types.rs`                        | Created  | Private `BindContext` struct; visible only inside the `codex/` module tree                                                                                                                                                                                                                               |
+| `src-tauri/src/agent/adapter/codex/mod.rs`                          | Modified | New `pid`/`pty_start`/`codex_home` adapter fields; `new(pid, pty_start)` + `#[cfg(test)] with_home`; `default_codex_home()` free fn; `retry_locator` helper + `retry_locator_tests`; new `status_source_tests`; trait impl uses new sig; private BindContext consumed via `use self::types::BindContext` |
+| `src-tauri/src/agent/adapter/codex/locator.rs`                      | Modified | Single import edit: `crate::agent::adapter::types::BindContext` → `super::types::BindContext`. No body changes                                                                                                                                                                                           |
+| `src-tauri/src/agent/adapter/types.rs`                              | Modified | Delete public `BindContext` struct + `BindError` enum + their Display impls + their pinned-format tests                                                                                                                                                                                                  |
+| `src-tauri/src/agent/adapter/mod.rs`                                | Modified | Trait sig change (`(cwd, sid) -> Result<_, String>`); rename `for_type` → `for_attach(agent_type, pid, pty_start)`; `start` drops pid/pty_start; `start_agent_watcher` uses new factory; rewrite `NoOpAdapter::status_source`; rename `for_type_returns_real_codex_adapter` test                         |
+| `src-tauri/src/agent/adapter/claude_code/mod.rs`                    | Modified | Trait impl sig change; rewrite `status_source` body to use direct `(cwd, sid)` params; update test                                                                                                                                                                                                       |
+| `src-tauri/src/agent/adapter/base/mod.rs`                           | Modified | Drop `resolve_status_source_with_retry`; drop `BIND_RETRY_*` constants; simplify `start_for` body to single status_source call; delete `start_for_retry_tests` module                                                                                                                                    |
+| `src-tauri/src/agent/adapter/base/transcript_state.rs`              | Modified | Update `OrderingAdapter` mock's `status_source` impl signature only (FQN-style refs; `unreachable!()` body unchanged)                                                                                                                                                                                    |
+| `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md`   | Created  | New ADR recording the decision and what spec sections it supersedes                                                                                                                                                                                                                                      |
+| `docs/decisions/CLAUDE.md`                                          | Modified | Append the new ADR to the index table                                                                                                                                                                                                                                                                    |
+| `docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md` | Modified | Add `Amended further by:` pointer at top + inline supersede markers                                                                                                                                                                                                                                      |
+| `src-tauri/src/agent/README.md`                                     | Modified | Lines 67, 98, 116 updated to describe the post-2026-05-05 flow                                                                                                                                                                                                                                           |
+
+**Total:** 7 modified Rust files, 1 added Rust file, 1 added doc, 3 modified docs.
+
+---
+
+## Task 1: Add private codex `BindContext` types module
+
+Spec section 3.1.
+
+**Files:**
+
+- Create: `src-tauri/src/agent/adapter/codex/types.rs`
+- Modify: `src-tauri/src/agent/adapter/codex/mod.rs:1-19` (top-of-file module declarations)
+
+The new types module is dead code until Task 3 wires it. Adding it first lets later tasks reference `super::types::BindContext` from inside `codex/locator.rs` without a forward-declaration dance.
+
+- [ ] **Step 1: Create `codex/types.rs` with the private struct**
+
+```rust
+//! Private codex-internal types. Visibility intentionally `pub(super)` so
+//! these types do not leak through the `AgentAdapter` trait surface.
+
+use std::path::Path;
+use std::time::SystemTime;
+
+/// Bag of attach-time facts the codex locator needs. Built fresh on each
+/// `status_source` call from the adapter's stored `pid`/`pty_start` plus
+/// the trait method's `cwd` parameter.
+///
+/// Note: `session_id` is intentionally not a field. The codex locator
+/// gates queries by `pid` + `pty_start` + `cwd` only. Carrying `session_id`
+/// here would trigger `cargo clippy --all-targets -- -D warnings` to flag
+/// the field as dead code. The trait method still receives `session_id`;
+/// the codex adapter binds it to `_session_id`.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct BindContext<'a> {
+    pub(super) cwd: &'a Path,
+    pub(super) pid: u32,
+    pub(super) pty_start: SystemTime,
+}
+```
+
+- [ ] **Step 2: Add `mod types;` to `codex/mod.rs`**
+
+Edit the existing module-declarations block at the top of the file. Before:
+
+```rust
+mod locator;
+mod parser;
+mod transcript;
+```
+
+After:
+
+```rust
+mod locator;
+mod parser;
+mod transcript;
+mod types;
+```
+
+- [ ] **Step 3: Verify the workspace builds**
+
+Run: `cargo build --manifest-path src-tauri/Cargo.toml`
+Expected: build succeeds. The new `types` module is unused, so rustc may warn `unused module` — acceptable for this intermediate state; Task 3 wires it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/agent/adapter/codex/types.rs \
+        src-tauri/src/agent/adapter/codex/mod.rs
+git commit -m "refactor(agent/adapter): add private codex types module
+
+Empty scaffolding for the upcoming trait simplification (issue #156).
+The new BindContext is pub(super) so it cannot leak through the
+AgentAdapter trait surface. session_id is intentionally omitted —
+codex's locator never reads it.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add `retry_locator` helper and its unit tests
+
+Spec section 3.3 + 4.3.
+
+**Files:**
+
+- Modify: `src-tauri/src/agent/adapter/codex/mod.rs` (add helper + test module)
+
+The helper is currently unused — Task 3 wires it into `CodexAdapter::status_source`. Adding it standalone first lets us TDD it without touching the trait signature yet.
+
+- [ ] **Step 1: Add module-level constants and import additions**
+
+Insert near the top of `codex/mod.rs`, immediately after the existing `use self::locator::{...}` statement:
+
+```rust
+use self::locator::{CodexSessionLocator, CompositeLocator, LocatorError, RolloutLocation};
+```
+
+(The previous version of that line did not include `RolloutLocation` — `retry_locator` returns it, so add it now.)
+
+Add these constants near the top of the impl block (or as free constants right after the imports):
+
+```rust
+const CODEX_BIND_RETRY_INTERVAL_MS: u64 = 100;
+const CODEX_BIND_RETRY_MAX_ATTEMPTS: u32 = 5;
+```
+
+- [ ] **Step 2: Add the `retry_locator` helper as a free function**
+
+Add this `fn` to `codex/mod.rs`, after `CodexAdapter`'s `impl` blocks but before the `#[cfg(test)] mod adapter_tests`:
+
+```rust
+/// Retry a codex locator resolution up to the bind budget. Returns the
+/// resolved location on success, or a formatted error string on:
+///
+/// - The first non-`NotYetReady` error from the closure (Fatal /
+///   Unresolved → bubble up immediately, no further attempts).
+/// - Budget exhaustion (`CODEX_BIND_RETRY_MAX_ATTEMPTS` consecutive
+///   `NotYetReady` returns).
+///
+/// The trailing sleep on the final attempt is skipped — exhaustion would
+/// follow immediately so the additional sleep only inflates wall clock.
+/// Sleep budget on full exhaustion: `(MAX_ATTEMPTS - 1) * INTERVAL_MS` =
+/// 400ms with the current constants.
+fn retry_locator<F>(mut resolve: F) -> Result<RolloutLocation, String>
+where
+    F: FnMut() -> Result<RolloutLocation, LocatorError>,
+{
+    let started = std::time::Instant::now();
+    let mut last_reason = String::from("no attempts");
+
+    for attempt in 0..CODEX_BIND_RETRY_MAX_ATTEMPTS {
+        match resolve() {
+            Ok(location) => return Ok(location),
+            Err(LocatorError::NotYetReady) => {
+                last_reason = format!("not yet ready (attempt {})", attempt + 1);
+                if attempt + 1 < CODEX_BIND_RETRY_MAX_ATTEMPTS {
+                    std::thread::sleep(std::time::Duration::from_millis(
+                        CODEX_BIND_RETRY_INTERVAL_MS,
+                    ));
+                }
+            }
+            Err(LocatorError::Unresolved(reason))
+            | Err(LocatorError::Fatal(reason)) => {
+                return Err(format!("codex bind fatal: {}", reason));
+            }
+        }
+    }
+
+    log::warn!(
+        "codex bind retry exhausted after {} attempts (elapsed={:?})",
+        CODEX_BIND_RETRY_MAX_ATTEMPTS,
+        started.elapsed()
+    );
+    Err(format!("codex bind retry exhausted: {}", last_reason))
+}
+```
+
+- [ ] **Step 3: Add `retry_locator_tests` test module**
+
+Append this `#[cfg(test)] mod` to the bottom of `codex/mod.rs`:
+
+```rust
+#[cfg(test)]
+mod retry_locator_tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn retries_on_not_yet_ready_then_succeeds() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_locator(|| {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            if n < 3 {
+                Err(LocatorError::NotYetReady)
+            } else {
+                Ok(RolloutLocation {
+                    rollout_path: PathBuf::from("/tmp/rollout.jsonl"),
+                    thread_id: "tid".to_string(),
+                    state_updated_at_ms: 0,
+                })
+            }
+        });
+        assert!(result.is_ok(), "expected Ok after 4th attempt: {:?}", result);
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn returns_err_when_retry_budget_exhausted() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_locator(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LocatorError::NotYetReady)
+        });
+        assert!(result.is_err());
+        assert!(
+            result.as_ref().unwrap_err().contains("retry exhausted"),
+            "expected 'retry exhausted' in: {:?}",
+            result
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            CODEX_BIND_RETRY_MAX_ATTEMPTS as usize,
+        );
+    }
+
+    #[test]
+    fn fatal_short_circuits_immediately() {
+        let calls = AtomicUsize::new(0);
+        let started = std::time::Instant::now();
+        let result = retry_locator(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LocatorError::Fatal("permission denied".to_string()))
+        });
+        assert!(result.is_err());
+        assert!(result.as_ref().unwrap_err().contains("codex bind fatal"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        // Generous bound — fatal should not sleep at all (~0ms in
+        // practice). 100ms covers loaded-CI scheduler delay.
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(100),
+            "fatal should short-circuit: elapsed {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn unresolved_short_circuits_immediately() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_locator(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LocatorError::Unresolved("ambiguous candidates".to_string()))
+        });
+        assert!(result.is_err());
+        assert!(result.as_ref().unwrap_err().contains("codex bind fatal"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml retry_locator_tests`
+Expected: `4 passed`. Each test validates one of the four exit paths (Ok, exhaustion, Fatal, Unresolved).
+
+- [ ] **Step 5: Run the full crate's tests to confirm no collateral damage**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::adapter`
+Expected: all existing tests pass; only the new `retry_locator_tests` add to the count.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/agent/adapter/codex/mod.rs
+git commit -m "feat(agent/adapter): add codex retry_locator helper
+
+Pure addition. Helper is unused by production code in this commit;
+Task 3 of the trait-simplification refactor wires it into
+CodexAdapter::status_source. Sleep budget on full exhaustion is
+4 × 100ms = 400ms (final-attempt sleep skipped). Fatal/Unresolved
+short-circuit immediately.
+
+Tests cover all four exit paths via synthesized closures — no real
+~/.codex setup required.
+
+Issue #156. See spec section 3.3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Atomic trait simplification
+
+Spec sections 2.1–2.7, 3.2, 3.4, 3.5, 4.1, 4.2.
+
+This is the meat of the refactor. The trait signature change is atomic at the compile boundary — every `impl AgentAdapter` and every callsite must update together. Steps within this task may leave the workspace transiently non-compiling; the final step verifies a clean build + green test suite before commit.
+
+**Files:**
+
+- Modify: `src-tauri/src/agent/adapter/mod.rs` (trait + factory + start + start_agent_watcher + NoOp impl + tests)
+- Modify: `src-tauri/src/agent/adapter/claude_code/mod.rs` (impl + test)
+- Modify: `src-tauri/src/agent/adapter/codex/mod.rs` (struct fields, new constructors, status_source body, locator() body, adapter_tests)
+- Modify: `src-tauri/src/agent/adapter/codex/locator.rs` (one import edit)
+- Modify: `src-tauri/src/agent/adapter/base/mod.rs` (start_for body + delete retry helpers + delete retry tests)
+- Modify: `src-tauri/src/agent/adapter/base/transcript_state.rs` (mock impl signature)
+
+- [ ] **Step 1: Update the `AgentAdapter` trait signature in `mod.rs`**
+
+Replace the trait declaration. Find:
+
+```rust
+pub trait AgentAdapter<R: tauri::Runtime>: Send + Sync + 'static {
+    fn agent_type(&self) -> AgentType;
+
+    fn status_source(&self, ctx: &BindContext<'_>) -> Result<StatusSource, BindError>;
+
+    fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String>;
+    ...
+```
+
+Replace with:
+
+```rust
+pub trait AgentAdapter<R: tauri::Runtime>: Send + Sync + 'static {
+    fn agent_type(&self) -> AgentType;
+
+    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>;
+
+    fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String>;
+    ...
+```
+
+(Other trait methods unchanged.)
+
+- [ ] **Step 2: Update top-of-file imports in `mod.rs`**
+
+In `agent/adapter/mod.rs`, change the imports near the top of the file. Find:
+
+```rust
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use tauri::AppHandle;
+
+pub use base::AgentWatcherState;
+
+use crate::agent::detector::detect_agent;
+use crate::agent::types::AgentType;
+use crate::terminal::types::SessionId;
+use crate::terminal::PtyState;
+use base::TranscriptHandle;
+use claude_code::ClaudeCodeAdapter;
+use codex::CodexAdapter;
+use types::{BindContext, BindError, ParsedStatus, StatusSource, ValidateTranscriptError};
+```
+
+Replace with:
+
+```rust
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use tauri::AppHandle;
+
+pub use base::AgentWatcherState;
+
+use crate::agent::detector::detect_agent;
+use crate::agent::types::AgentType;
+use crate::terminal::types::SessionId;
+use crate::terminal::PtyState;
+use base::TranscriptHandle;
+use claude_code::ClaudeCodeAdapter;
+use codex::CodexAdapter;
+use types::{ParsedStatus, StatusSource, ValidateTranscriptError};
+```
+
+(Two diffs: add `Path` to the `std::path` import; drop `BindContext, BindError` from the `types` import.)
+
+- [ ] **Step 3: Rename `for_type` → `for_attach` and update `start`**
+
+Find the `impl<R: tauri::Runtime> dyn AgentAdapter<R>` block. Replace:
+
+```rust
+impl<R: tauri::Runtime> dyn AgentAdapter<R> {
+    pub fn for_type(agent_type: AgentType) -> Result<Arc<Self>, String> {
+        match agent_type {
+            AgentType::ClaudeCode => Ok(Arc::new(ClaudeCodeAdapter)),
+            AgentType::Codex => Ok(Arc::new(CodexAdapter::new())),
+            other => Ok(Arc::new(NoOpAdapter::new(other))),
+        }
+    }
+
+    pub fn start(
+        self: Arc<Self>,
+        app: AppHandle<R>,
+        session_id: String,
+        cwd: PathBuf,
+        pid: u32,
+        pty_start: SystemTime,
+        state: AgentWatcherState,
+    ) -> Result<(), String> {
+        base::start_for(self, app, session_id, cwd, pid, pty_start, state)
+    }
+
+    pub fn stop(state: &AgentWatcherState, session_id: &str) -> bool {
+        state.remove(session_id)
+    }
+}
+```
+
+with:
+
+```rust
+impl<R: tauri::Runtime> dyn AgentAdapter<R> {
+    pub fn for_attach(
+        agent_type: AgentType,
+        pid: u32,
+        pty_start: SystemTime,
+    ) -> Result<Arc<Self>, String> {
+        match agent_type {
+            AgentType::ClaudeCode => Ok(Arc::new(ClaudeCodeAdapter)),
+            AgentType::Codex => Ok(Arc::new(CodexAdapter::new(pid, pty_start))),
+            other => Ok(Arc::new(NoOpAdapter::new(other))),
+        }
+    }
+
+    pub fn start(
+        self: Arc<Self>,
+        app: AppHandle<R>,
+        session_id: String,
+        cwd: PathBuf,
+        state: AgentWatcherState,
+    ) -> Result<(), String> {
+        base::start_for(self, app, session_id, cwd, state)
+    }
+
+    pub fn stop(state: &AgentWatcherState, session_id: &str) -> bool {
+        state.remove(session_id)
+    }
+}
+```
+
+- [ ] **Step 4: Rewrite `NoOpAdapter::status_source` impl**
+
+Find the `NoOpAdapter` impl block. Replace its `status_source` method:
+
+```rust
+fn status_source(&self, ctx: &BindContext<'_>) -> Result<StatusSource, BindError> {
+    Ok(StatusSource {
+        path: ctx
+            .cwd
+            .join(".vimeflow")
+            .join("sessions")
+            .join(ctx.session_id)
+            .join("status.json"),
+        trust_root: ctx.cwd.to_path_buf(),
+    })
+}
+```
+
+with:
+
+```rust
+fn status_source(
+    &self,
+    cwd: &Path,
+    session_id: &str,
+) -> Result<StatusSource, String> {
+    Ok(StatusSource {
+        path: cwd
+            .join(".vimeflow")
+            .join("sessions")
+            .join(session_id)
+            .join("status.json"),
+        trust_root: cwd.to_path_buf(),
+    })
+}
+```
+
+(Other `NoOpAdapter` methods unchanged.)
+
+- [ ] **Step 5: Rewire `start_agent_watcher` to use `for_attach` + drop pid/pty_start from adapter.start()**
+
+Find the `start_agent_watcher` Tauri command. Replace:
+
+```rust
+#[tauri::command]
+pub async fn start_agent_watcher(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, AgentWatcherState>,
+    pty_state: tauri::State<'_, PtyState>,
+    session_id: String,
+) -> Result<(), String> {
+    let (cwd, _shell_pid, pty_start, agent_type, agent_pid) =
+        resolve_bind_inputs(&pty_state, &session_id, detect_agent)?;
+
+    let adapter = <dyn AgentAdapter<tauri::Wry>>::for_type(agent_type)?;
+    let owned_state = (*state).clone();
+    let cwd_path = PathBuf::from(cwd);
+    // `adapter.start(...)` walks into `base::start_for`, which calls
+    // `resolve_status_source_with_retry`. The retry uses
+    // `std::thread::sleep` (up to 5 × 100 ms = 500 ms) and
+    // `path_security::ensure_status_source_under_trust_root` does
+    // synchronous `canonicalize` filesystem I/O. Running that on a
+    // tokio worker thread starves other futures scheduled on the same
+    // worker; mirror the pattern at `src/git/watcher.rs:399` and hop
+    // onto the blocking pool so the async thread returns immediately.
+    tokio::task::spawn_blocking(move || {
+        adapter.start(
+            app_handle,
+            session_id,
+            cwd_path,
+            agent_pid,
+            pty_start,
+            owned_state,
+        )
+    })
+    .await
+    .map_err(|e| format!("start_agent_watcher task panicked: {}", e))?
+}
+```
+
+with:
+
+```rust
+#[tauri::command]
+pub async fn start_agent_watcher(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, AgentWatcherState>,
+    pty_state: tauri::State<'_, PtyState>,
+    session_id: String,
+) -> Result<(), String> {
+    let (cwd, _shell_pid, pty_start, agent_type, agent_pid) =
+        resolve_bind_inputs(&pty_state, &session_id, detect_agent)?;
+
+    let adapter =
+        <dyn AgentAdapter<tauri::Wry>>::for_attach(agent_type, agent_pid, pty_start)?;
+    let owned_state = (*state).clone();
+    let cwd_path = PathBuf::from(cwd);
+    // `adapter.start(...)` walks into `base::start_for`, which calls
+    // `adapter.status_source(...)`. For codex sessions, that call runs a
+    // bounded retry (up to 5 attempts × 100 ms inter-attempt sleeps)
+    // using `std::thread::sleep` because codex commits its `logs` row
+    // ~300ms after the rollout file opens.
+    // `path_security::ensure_status_source_under_trust_root` also does
+    // synchronous `canonicalize` filesystem I/O. Running either on a
+    // tokio worker thread starves other futures scheduled on the same
+    // worker; mirror the pattern at `src/git/watcher.rs:399` and hop
+    // onto the blocking pool so the async thread returns immediately.
+    tokio::task::spawn_blocking(move || {
+        adapter.start(app_handle, session_id, cwd_path, owned_state)
+    })
+    .await
+    .map_err(|e| format!("start_agent_watcher task panicked: {}", e))?
+}
+```
+
+(Diffs: factory call uses `for_attach`; comment updated to attribute retry to the codex adapter; `adapter.start(...)` drops `agent_pid` and `pty_start` args.)
+
+- [ ] **Step 6: Update `noop_tests` in `mod.rs`**
+
+Find `mod noop_tests { ... }`. Two test edits:
+
+(a) Rename `for_type_returns_real_codex_adapter` → `for_attach_returns_real_codex_adapter` and update its body. Replace:
+
+```rust
+#[test]
+fn for_type_returns_real_codex_adapter() {
+    let adapter = <dyn AgentAdapter<MockRuntime>>::for_type(AgentType::Codex)
+        .expect("codex adapter should construct");
+    let raw = r#"{"timestamp":"...","type":"session_meta","payload":{"id":"sess","cli_version":"0.128.0"}}
+"#;
+
+    let parsed = adapter
+        .parse_status("pty-codex", raw)
+        .expect("real codex adapter should parse rollout JSONL");
+    assert_eq!(parsed.event.agent_session_id, "sess");
+}
+```
+
+with:
+
+```rust
+#[test]
+fn for_attach_returns_real_codex_adapter() {
+    use std::time::SystemTime;
+
+    let adapter = <dyn AgentAdapter<MockRuntime>>::for_attach(
+        AgentType::Codex,
+        12345,
+        SystemTime::UNIX_EPOCH,
+    )
+    .expect("codex adapter should construct");
+    let raw = r#"{"timestamp":"...","type":"session_meta","payload":{"id":"sess","cli_version":"0.128.0"}}
+"#;
+
+    let parsed = adapter
+        .parse_status("pty-codex", raw)
+        .expect("real codex adapter should parse rollout JSONL");
+    assert_eq!(parsed.event.agent_session_id, "sess");
+}
+```
+
+(b) Update `status_source_uses_claude_shaped_path` to drop the BindContext literal. Replace:
+
+```rust
+#[test]
+fn status_source_uses_claude_shaped_path() {
+    use std::time::SystemTime;
+
+    let adapter = NoOpAdapter::new(AgentType::Aider);
+    let cwd = PathBuf::from("/tmp/ws");
+    let ctx = BindContext {
+        session_id: "sid",
+        cwd: &cwd,
+        pid: 0,
+        pty_start: SystemTime::UNIX_EPOCH,
+    };
+    let src = <NoOpAdapter as AgentAdapter<MockRuntime>>::status_source(&adapter, &ctx)
+        .expect("noop adapter always resolves a status source");
+    assert_eq!(
+        src.path,
+        cwd.join(".vimeflow")
+            .join("sessions")
+            .join("sid")
+            .join("status.json")
+    );
+    assert_eq!(src.trust_root, cwd);
+}
+```
+
+with:
+
+```rust
+#[test]
+fn status_source_uses_claude_shaped_path() {
+    let adapter = NoOpAdapter::new(AgentType::Aider);
+    let cwd = PathBuf::from("/tmp/ws");
+    let src = <NoOpAdapter as AgentAdapter<MockRuntime>>::status_source(
+        &adapter, &cwd, "sid",
+    )
+    .expect("noop adapter always resolves a status source");
+    assert_eq!(
+        src.path,
+        cwd.join(".vimeflow")
+            .join("sessions")
+            .join("sid")
+            .join("status.json")
+    );
+    assert_eq!(src.trust_root, cwd);
+}
+```
+
+(Other tests in `noop_tests` are unchanged.)
+
+- [ ] **Step 7: Update `ClaudeCodeAdapter::status_source` impl + test**
+
+In `agent/adapter/claude_code/mod.rs`:
+
+(a) Update the imports near the top of the file. Find:
+
+```rust
+use std::path::PathBuf;
+
+use tauri::AppHandle;
+
+use crate::agent::adapter::base::TranscriptHandle;
+use crate::agent::adapter::types::{
+    BindContext, BindError, ParsedStatus, StatusSource, ValidateTranscriptError,
+};
+use crate::agent::adapter::AgentAdapter;
+use crate::agent::types::AgentType;
+```
+
+Replace with:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use tauri::AppHandle;
+
+use crate::agent::adapter::base::TranscriptHandle;
+use crate::agent::adapter::types::{
+    ParsedStatus, StatusSource, ValidateTranscriptError,
+};
+use crate::agent::adapter::AgentAdapter;
+use crate::agent::types::AgentType;
+```
+
+(b) Update the `status_source` impl method:
+
+```rust
+fn status_source(&self, ctx: &BindContext<'_>) -> Result<StatusSource, BindError> {
+    Ok(StatusSource {
+        path: ctx
+            .cwd
+            .join(".vimeflow")
+            .join("sessions")
+            .join(ctx.session_id)
+            .join("status.json"),
+        trust_root: ctx.cwd.to_path_buf(),
+    })
+}
+```
+
+→
+
+```rust
+fn status_source(
+    &self,
+    cwd: &Path,
+    session_id: &str,
+) -> Result<StatusSource, String> {
+    Ok(StatusSource {
+        path: cwd
+            .join(".vimeflow")
+            .join("sessions")
+            .join(session_id)
+            .join("status.json"),
+        trust_root: cwd.to_path_buf(),
+    })
+}
+```
+
+(c) Update the test `status_source_returns_claude_path_under_cwd`. Replace:
+
+```rust
+#[test]
+fn status_source_returns_claude_path_under_cwd() {
+    use std::time::SystemTime;
+
+    let adapter = ClaudeCodeAdapter;
+    let cwd = PathBuf::from("/tmp/ws");
+    let ctx = BindContext {
+        session_id: "sess-1",
+        cwd: &cwd,
+        pid: 0,
+        pty_start: SystemTime::UNIX_EPOCH,
+    };
+    let src = <ClaudeCodeAdapter as AgentAdapter<MockRuntime>>::status_source(&adapter, &ctx)
+        .expect("claude status source is infallible");
+    assert_eq!(
+        src.path,
+        cwd.join(".vimeflow")
+            .join("sessions")
+            .join("sess-1")
+            .join("status.json")
+    );
+    assert_eq!(src.trust_root, cwd);
+}
+```
+
+with:
+
+```rust
+#[test]
+fn status_source_returns_claude_path_under_cwd() {
+    let adapter = ClaudeCodeAdapter;
+    let cwd = PathBuf::from("/tmp/ws");
+    let src = <ClaudeCodeAdapter as AgentAdapter<MockRuntime>>::status_source(
+        &adapter, &cwd, "sess-1",
+    )
+    .expect("claude status source is infallible");
+    assert_eq!(
+        src.path,
+        cwd.join(".vimeflow")
+            .join("sessions")
+            .join("sess-1")
+            .join("status.json")
+    );
+    assert_eq!(src.trust_root, cwd);
+}
+```
+
+- [ ] **Step 8: Refactor `CodexAdapter` struct in `codex/mod.rs`**
+
+Find the existing struct + impl block:
+
+```rust
+pub struct CodexAdapter {
+    locator_cache: OnceLock<CompositeLocator>,
+    resolved_rollout_path: Mutex<Option<PathBuf>>,
+}
+
+impl CodexAdapter {
+    pub fn new() -> Self {
+        Self {
+            locator_cache: OnceLock::new(),
+            resolved_rollout_path: Mutex::new(None),
+        }
+    }
+
+    fn locator(&self) -> &CompositeLocator {
+        self.locator_cache.get_or_init(|| {
+            let codex_home = Self::codex_home();
+            log::info!(
+                "codex adapter: locator cache initialized (codex_home={})",
+                codex_home.display()
+            );
+            CompositeLocator::new(codex_home)
+        })
+    }
+
+    fn codex_home() -> PathBuf {
+        dirs::home_dir()
+            .map(|home| home.join(".codex"))
+            .unwrap_or_else(|| PathBuf::from(".codex"))
+    }
+}
+```
+
+Replace with:
+
+```rust
+pub struct CodexAdapter {
+    pid: u32,
+    pty_start: SystemTime,
+    codex_home: PathBuf,
+    locator_cache: OnceLock<CompositeLocator>,
+    resolved_rollout_path: Mutex<Option<PathBuf>>,
+}
+
+impl CodexAdapter {
+    pub fn new(pid: u32, pty_start: SystemTime) -> Self {
+        Self {
+            pid,
+            pty_start,
+            codex_home: default_codex_home(),
+            locator_cache: OnceLock::new(),
+            resolved_rollout_path: Mutex::new(None),
+        }
+    }
+
+    /// Test-only constructor that accepts an explicit `codex_home`. Lets
+    /// `status_source_tests` (Task 4) seed a temp `~/.codex` mock without
+    /// touching the user's real home. Field initializers duplicate `new`;
+    /// the duplication is intentional so the test seam is fully gated and
+    /// production builds carry no test-shaped code.
+    #[cfg(test)]
+    pub(crate) fn with_home(
+        pid: u32,
+        pty_start: SystemTime,
+        codex_home: PathBuf,
+    ) -> Self {
+        Self {
+            pid,
+            pty_start,
+            codex_home,
+            locator_cache: OnceLock::new(),
+            resolved_rollout_path: Mutex::new(None),
+        }
+    }
+
+    fn locator(&self) -> &CompositeLocator {
+        self.locator_cache.get_or_init(|| {
+            log::info!(
+                "codex adapter: locator cache initialized (codex_home={})",
+                self.codex_home.display()
+            );
+            CompositeLocator::new(self.codex_home.clone())
+        })
+    }
+}
+
+fn default_codex_home() -> PathBuf {
+    dirs::home_dir()
+        .map(|home| home.join(".codex"))
+        .unwrap_or_else(|| PathBuf::from(".codex"))
+}
+```
+
+(Note: the static `Self::codex_home()` method is replaced by the free function `default_codex_home()` plus the per-instance `self.codex_home` field.)
+
+- [ ] **Step 9: Update `codex/mod.rs` imports**
+
+Find the top-of-file imports. Replace:
+
+```rust
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use tauri::AppHandle;
+
+use crate::agent::adapter::base::TranscriptHandle;
+use crate::agent::adapter::types::{
+    BindContext, BindError, ParsedStatus, StatusSource, ValidateTranscriptError,
+};
+use crate::agent::adapter::AgentAdapter;
+use crate::agent::types::AgentType;
+
+use self::locator::{CodexSessionLocator, CompositeLocator, LocatorError, RolloutLocation};
+```
+
+with:
+
+```rust
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
+
+use tauri::AppHandle;
+
+use crate::agent::adapter::base::TranscriptHandle;
+use crate::agent::adapter::types::{
+    ParsedStatus, StatusSource, ValidateTranscriptError,
+};
+use crate::agent::adapter::AgentAdapter;
+use crate::agent::types::AgentType;
+
+use self::locator::{CodexSessionLocator, CompositeLocator, LocatorError, RolloutLocation};
+use self::types::BindContext;
+```
+
+(Diffs: add `Path` to `std::path`; add `std::time::SystemTime`; drop `BindContext, BindError` from public types import; add `use self::types::BindContext;`.)
+
+- [ ] **Step 10: Update `CodexAdapter::status_source` impl body**
+
+Find the `impl<R: tauri::Runtime> AgentAdapter<R> for CodexAdapter` block. Replace:
+
+```rust
+fn status_source(&self, ctx: &BindContext<'_>) -> Result<StatusSource, BindError> {
+    match self.locator().resolve_rollout(ctx) {
+        Ok(location) => {
+            let rollout_path = location.rollout_path;
+            if let Ok(mut slot) = self.resolved_rollout_path.lock() {
+                *slot = Some(rollout_path.clone());
+            }
+
+            Ok(StatusSource {
+                path: rollout_path,
+                trust_root: Self::codex_home(),
+            })
+        }
+        Err(LocatorError::NotYetReady) => Err(BindError::Pending(
+            "codex session row not yet committed".to_string(),
+        )),
+        Err(LocatorError::Unresolved(reason)) | Err(LocatorError::Fatal(reason)) => {
+            Err(BindError::Fatal(reason))
+        }
+    }
+}
+```
+
+with:
+
+```rust
+fn status_source(
+    &self,
+    cwd: &Path,
+    _session_id: &str,
+) -> Result<StatusSource, String> {
+    // `session_id` is part of the trait contract (Claude / NoOp use it)
+    // but the codex locator never reads it — bind to `_session_id` to
+    // satisfy `-D warnings`.
+    let ctx = BindContext {
+        cwd,
+        pid: self.pid,
+        pty_start: self.pty_start,
+    };
+
+    let location = retry_locator(|| self.locator().resolve_rollout(&ctx))?;
+
+    if let Ok(mut slot) = self.resolved_rollout_path.lock() {
+        *slot = Some(location.rollout_path.clone());
+    }
+
+    Ok(StatusSource {
+        path: location.rollout_path,
+        trust_root: self.codex_home.clone(),
+    })
+}
+```
+
+- [ ] **Step 11: Update existing `adapter_tests` to pass sentinel construction args**
+
+In `codex/mod.rs::adapter_tests`, find the three tests that call `CodexAdapter::new()`. Each call must change to `CodexAdapter::new(12345, SystemTime::UNIX_EPOCH)`. Add `use std::time::SystemTime;` (and `use std::path::PathBuf;` if not already imported) at the top of the test module.
+
+Concretely:
+
+```rust
+let adapter = CodexAdapter::new();
+```
+
+→
+
+```rust
+let adapter = CodexAdapter::new(12345, SystemTime::UNIX_EPOCH);
+```
+
+Three call sites: `parse_status_delegates_to_parser_with_transcript_path_none`, `parse_status_includes_resolved_rollout_path_when_available`, and `validate_transcript_rejects_outside_codex_root`. Assertion bodies are unchanged — these tests don't exercise `status_source`.
+
+- [ ] **Step 12: Switch `codex/locator.rs` import to private types**
+
+Find line 3 of `codex/locator.rs`:
+
+```rust
+use crate::agent::adapter::types::BindContext;
+```
+
+Replace with:
+
+```rust
+use super::types::BindContext;
+```
+
+No other body changes in locator.rs. The `&BindContext<'_>` parameter types in all locator methods now refer to the private codex struct (which has the same `cwd, pid, pty_start` shape as the deleted public one, minus `session_id` which the locator never read).
+
+- [ ] **Step 13: Locator-side test fixture `ctx<'a>` helper updates**
+
+In `codex/locator.rs::tests` there are two `fn ctx<'a>(...)` helpers (around lines 759 and 997 of the pre-refactor file). Both build a `BindContext` literal with all four fields including `session_id`. Update both to drop `session_id`:
+
+```rust
+fn ctx<'a>(cwd: &'a Path, pid: u32, pty_start: SystemTime) -> BindContext<'a> {
+    BindContext {
+        session_id: "sid",
+        cwd,
+        pid,
+        pty_start,
+    }
+}
+```
+
+→
+
+```rust
+fn ctx<'a>(cwd: &'a Path, pid: u32, pty_start: SystemTime) -> BindContext<'a> {
+    BindContext {
+        cwd,
+        pid,
+        pty_start,
+    }
+}
+```
+
+(Same edit for the second helper around line 997.) Also adjust the test-module imports if `BindContext` was imported via the old public path — change to `use super::super::types::BindContext;` or `use crate::agent::adapter::codex::types::BindContext;`. The existing `super::*;` import may already cover it depending on the file's structure; adjust as needed for compile.
+
+- [ ] **Step 14: Simplify `base::start_for` body**
+
+In `agent/adapter/base/mod.rs`, find `start_for`:
+
+```rust
+pub(crate) fn start_for<R: tauri::Runtime>(
+    adapter: Arc<dyn AgentAdapter<R>>,
+    app_handle: tauri::AppHandle<R>,
+    session_id: String,
+    cwd: PathBuf,
+    pid: u32,
+    pty_start: std::time::SystemTime,
+    state: AgentWatcherState,
+) -> Result<(), String> {
+    let source =
+        resolve_status_source_with_retry(adapter.as_ref(), &session_id, &cwd, pid, pty_start)?;
+    path_security::ensure_status_source_under_trust_root(&source.path, &source.trust_root)?;
+
+    log::debug!(
+        "Watcher startup detail: session={}, cwd={}, path={}",
+        session_id,
+        cwd.display(),
+        source.path.display()
+    );
+
+    state.remove(&session_id);
+
+    log::info!(
+        "Starting agent watcher: session={}, path={}, active_watchers={}",
+        session_id,
+        source.path.display(),
+        state.active_count(),
+    );
+
+    let handle =
+        watcher_runtime::start_watching(adapter, app_handle, session_id.clone(), source.path)?;
+    state.insert(session_id, handle);
+
+    Ok(())
+}
+```
+
+Replace with:
+
+```rust
+pub(crate) fn start_for<R: tauri::Runtime>(
+    adapter: Arc<dyn AgentAdapter<R>>,
+    app_handle: tauri::AppHandle<R>,
+    session_id: String,
+    cwd: PathBuf,
+    state: AgentWatcherState,
+) -> Result<(), String> {
+    let source = adapter.status_source(&cwd, &session_id)?;
+    path_security::ensure_status_source_under_trust_root(&source.path, &source.trust_root)?;
+
+    log::debug!(
+        "Watcher startup detail: session={}, cwd={}, path={}",
+        session_id,
+        cwd.display(),
+        source.path.display()
+    );
+
+    state.remove(&session_id);
+
+    log::info!(
+        "Starting agent watcher: session={}, path={}, active_watchers={}",
+        session_id,
+        source.path.display(),
+        state.active_count(),
+    );
+
+    let handle =
+        watcher_runtime::start_watching(adapter, app_handle, session_id.clone(), source.path)?;
+    state.insert(session_id, handle);
+
+    Ok(())
+}
+```
+
+(Diffs: drop `pid` and `pty_start` parameters; replace `resolve_status_source_with_retry(...)` with a single `adapter.status_source(&cwd, &session_id)?` call.)
+
+- [ ] **Step 15: Delete `resolve_status_source_with_retry`, `BIND_RETRY_*` constants, and `start_for_retry_tests` from `base/mod.rs`**
+
+Delete the constants at the top of `base/mod.rs`:
+
+```rust
+const BIND_RETRY_INTERVAL_MS: u64 = 100;
+const BIND_RETRY_MAX_ATTEMPTS: u32 = 5;
+```
+
+Delete the entire `fn resolve_status_source_with_retry` function (~37 lines).
+
+Delete the entire `#[cfg(test)] mod start_for_retry_tests { ... }` block (~138 lines, including the `PendingThenOkAdapter` mock and both retry tests).
+
+- [ ] **Step 16: Update `base/mod.rs` imports**
+
+Find:
+
+```rust
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::agent::adapter::types::{BindContext, BindError, StatusSource};
+use crate::agent::adapter::AgentAdapter;
+```
+
+Replace with:
+
+```rust
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::agent::adapter::AgentAdapter;
+```
+
+(Drop `std::time::{Duration, Instant}` — both were only used by the retry helper. Drop the `types` import line entirely — `BindContext`/`BindError` are gone, and `StatusSource` is no longer named in `start_for`'s body.)
+
+- [ ] **Step 17: Update the `OrderingAdapter` mock in `base/transcript_state.rs`**
+
+Find the `impl<R: tauri::Runtime> AgentAdapter<R> for OrderingAdapter` block (around line 451). Replace its `status_source` method:
+
+```rust
+fn status_source(
+    &self,
+    _ctx: &crate::agent::adapter::types::BindContext<'_>,
+) -> Result<
+    crate::agent::adapter::types::StatusSource,
+    crate::agent::adapter::types::BindError,
+> {
+    unreachable!("status_source not exercised in this test")
+}
+```
+
+with:
+
+```rust
+fn status_source(
+    &self,
+    _cwd: &std::path::Path,
+    _session_id: &str,
+) -> Result<crate::agent::adapter::types::StatusSource, String> {
+    unreachable!("status_source not exercised in this test")
+}
+```
+
+(All other types in this mock impl already use FQN, so no further import edits needed.)
+
+- [ ] **Step 18: Verify the workspace builds and all tests pass**
+
+Run: `cargo build --manifest-path src-tauri/Cargo.toml`
+Expected: build succeeds. If there are unused-import warnings, audit and clean before committing.
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::adapter`
+Expected: all tests pass. The `start_for_retry_tests` module is gone (deleted in Step 15); `retry_locator_tests` (added in Task 2) covers equivalent semantics.
+
+Run: `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
+Expected: no warnings. If clippy flags `_session_id` as unused, the underscore prefix should already silence it; if not, add `#[allow(unused_variables)]` only on the codex impl method as a last resort.
+
+- [ ] **Step 19: Commit**
+
+```bash
+git add src-tauri/src/agent/adapter/mod.rs \
+        src-tauri/src/agent/adapter/claude_code/mod.rs \
+        src-tauri/src/agent/adapter/codex/mod.rs \
+        src-tauri/src/agent/adapter/codex/locator.rs \
+        src-tauri/src/agent/adapter/base/mod.rs \
+        src-tauri/src/agent/adapter/base/transcript_state.rs
+git commit -m "refactor(agent/adapter): collapse BindContext+retry into CodexAdapter
+
+Trait method status_source returns to (cwd, sid) -> Result<_, String>.
+Factory renames for_type → for_attach(agent_type, pid, pty_start).
+Codex's pid/pty_start/codex_home move onto CodexAdapter struct;
+codex's cold-start retry moves into status_source via the
+retry_locator helper added in the previous commit.
+
+base::start_for is now a single-call orchestrator: zero retry/sleep
+code, no BindContext construction. start_for_retry_tests is deleted;
+retry_locator_tests covers equivalent semantics in isolation.
+
+ClaudeCodeAdapter and NoOpAdapter rewritten for the new sig (drop the
+ctx wrapper, use direct cwd/session_id params). Mock OrderingAdapter
+in base::transcript_state likewise. Codex's private BindContext
+(without session_id, which the locator never read) is wired via
+super::types.
+
+No user-visible behavior change. Sleep budget on full exhaustion
+shrinks marginally from 5×100ms (current) to 4×100ms (final-attempt
+sleep skipped); cold-start window is otherwise identical.
+
+Issue #156. See spec sections 2.1–2.7, 3.2, 3.4, 3.5, 4.1, 4.2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Add `status_source_tests` for `CodexAdapter`
+
+Spec section 4.3.
+
+**Files:**
+
+- Modify: `src-tauri/src/agent/adapter/codex/mod.rs` (add new `#[cfg(test)] mod status_source_tests`)
+
+The new test module exercises the post-Task-3 `(cwd, sid)` trait method body using `CodexAdapter::with_home` (the `#[cfg(test)]` constructor from Task 3) so the test isolates from the user's real `~/.codex`. The SQLite seeding helper is duplicated inline (~30 LOC) — see spec section 4.3 for the rationale (vs. extracting a shared fixtures module).
+
+- [ ] **Step 1: Write the failing happy-path test**
+
+Append this test module to `codex/mod.rs` after the existing `retry_locator_tests` module:
+
+```rust
+#[cfg(test)]
+mod status_source_tests {
+    use super::*;
+    use rusqlite::{params, Connection};
+    use std::path::Path;
+    use std::time::{Duration, SystemTime};
+    use tauri::test::MockRuntime;
+
+    /// Seeds a tempdir with the SQLite logs/threads schema + a thread row
+    /// for the given (pid, pty_start) pointing at a writable rollout
+    /// path. Returns the rollout path so the test can assert it.
+    ///
+    /// Inline duplicate of the helper used in `locator::tests`. If a
+    /// third call site ever needs this, promote to a shared
+    /// `codex/test_fixtures.rs` module then.
+    fn seed_codex_home_with_thread(
+        codex_home: &Path,
+        pid: u32,
+        pty_start: SystemTime,
+    ) -> std::path::PathBuf {
+        // Compute rollout path: ~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<pid>.jsonl
+        let rollout_path = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("05")
+            .join(format!("rollout-{}.jsonl", pid));
+        std::fs::create_dir_all(rollout_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&rollout_path, b"").expect("seed empty rollout");
+
+        // Compute pty_start as Unix seconds + nanoseconds for the logs row.
+        let since_epoch = pty_start
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("pty_start ≥ epoch");
+        let secs = since_epoch.as_secs() as i64;
+        let nanos = since_epoch.subsec_nanos() as i64;
+
+        // logs DB at codex_home/logs.sqlite
+        let logs_db = codex_home.join("logs.sqlite");
+        let logs = Connection::open(&logs_db).expect("open logs db");
+        logs.execute_batch(
+            "CREATE TABLE logs (
+                id INTEGER PRIMARY KEY,
+                ts INTEGER NOT NULL,
+                ts_nanos INTEGER NOT NULL,
+                process_uuid TEXT NOT NULL,
+                thread_id TEXT
+            );
+            CREATE INDEX idx_logs_ts ON logs(ts DESC, ts_nanos DESC, id DESC);",
+        )
+        .expect("logs schema");
+        logs.execute(
+            "INSERT INTO logs (ts, ts_nanos, process_uuid, thread_id) \
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                secs + 1,
+                nanos,
+                format!("pid:{}:abc", pid),
+                "tid-test",
+            ],
+        )
+        .expect("insert log row");
+
+        // state DB at codex_home/state.sqlite
+        let state_db = codex_home.join("state.sqlite");
+        let state = Connection::open(&state_db).expect("open state db");
+        state
+            .execute_batch(
+                "CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    rollout_path TEXT NOT NULL,
+                    cwd TEXT,
+                    updated_at_ms INTEGER NOT NULL
+                );",
+            )
+            .expect("threads schema");
+        state
+            .execute(
+                "INSERT INTO threads (id, rollout_path, cwd, updated_at_ms) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    "tid-test",
+                    rollout_path.to_str().expect("utf-8 path"),
+                    codex_home.to_str().expect("utf-8 home"),
+                    secs * 1000 + nanos / 1_000_000,
+                ],
+            )
+            .expect("insert thread row");
+
+        rollout_path
+    }
+
+    #[test]
+    fn status_source_returns_resolved_rollout_on_happy_path() {
+        let codex_home = tempfile::tempdir().expect("tempdir");
+        let pty_start = SystemTime::now() - Duration::from_secs(5);
+        let rollout_path = seed_codex_home_with_thread(
+            codex_home.path(),
+            999,
+            pty_start,
+        );
+
+        let adapter = CodexAdapter::with_home(
+            999,
+            pty_start,
+            codex_home.path().to_path_buf(),
+        );
+        let cwd = codex_home.path().to_path_buf();
+
+        let src = <CodexAdapter as AgentAdapter<MockRuntime>>::status_source(
+            &adapter, &cwd, "sid",
+        )
+        .expect("status_source should resolve");
+
+        assert_eq!(src.path, rollout_path);
+        assert_eq!(src.trust_root, codex_home.path());
+    }
+
+    #[test]
+    fn status_source_returns_err_on_retry_exhausted() {
+        // Empty codex_home → both DB discovery returns Ok(None) → FS
+        // fallback also empty → repeated NotYetReady → retry exhausted.
+        let codex_home = tempfile::tempdir().expect("tempdir");
+        let adapter = CodexAdapter::with_home(
+            999,
+            SystemTime::now(),
+            codex_home.path().to_path_buf(),
+        );
+        let cwd = codex_home.path().to_path_buf();
+
+        let err = <CodexAdapter as AgentAdapter<MockRuntime>>::status_source(
+            &adapter, &cwd, "sid",
+        )
+        .expect_err("empty codex_home should exhaust retry");
+        assert!(err.contains("retry exhausted"), "got: {}", err);
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they pass**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml status_source_tests`
+Expected: 2 passed. Both tests construct via `with_home` so they bypass `dirs::home_dir()`.
+
+If `status_source_returns_resolved_rollout_on_happy_path` fails because the locator's SQLite query doesn't match the seeded rows, audit the seed helper against `codex/locator.rs`'s actual query:
+
+- The `logs` query gates by `process_uuid LIKE 'pid:' || :pid || ':%'` AND `(ts > pty_start_secs OR (ts = pty_start_secs AND ts_nanos >= pty_start_nanos))`.
+- The seed inserts `process_uuid = "pid:999:abc"` and `ts = secs + 1`, so the gate is satisfied.
+
+If the test still fails, log `LocatorError` variants from inside `retry_locator` (temporary) to identify which step (logs vs threads vs FS fallback) is unhappy.
+
+- [ ] **Step 3: Run the full crate's tests to confirm no regressions**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::adapter`
+Expected: all tests pass. New test count should increase by 2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/agent/adapter/codex/mod.rs
+git commit -m "test(agent/adapter): add codex status_source_tests
+
+Two tests exercise the new (cwd, sid) trait-method shape on
+CodexAdapter: a happy path that seeds an in-memory ~/.codex via
+with_home and asserts the resolved rollout path, and an exhaustion
+path that uses an empty codex_home and asserts the retry-exhausted
+error string.
+
+The SQLite seed helper is inlined (~30 LOC) per the spec's section
+4.3 rationale: only two call sites today (locator tests have their
+own private helper). Promote to a shared module if a third call
+site emerges.
+
+Issue #156. See spec section 4.3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Delete public `BindContext` and `BindError` from `agent/adapter/types.rs`
+
+Spec section 2.6.
+
+This task removes the now-orphaned public types. After Task 3, no production code references them; this finishes the cleanup so `cargo clippy` doesn't warn about unused public types.
+
+**Files:**
+
+- Modify: `src-tauri/src/agent/adapter/types.rs`
+
+- [ ] **Step 1: Delete the `BindContext` struct + its `Display` and `Error` impls**
+
+In `src-tauri/src/agent/adapter/types.rs`, delete these blocks:
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub struct BindContext<'a> {
+    pub session_id: &'a str,
+    pub cwd: &'a Path,
+    pub pid: u32,
+    pub pty_start: SystemTime,
+}
+
+#[derive(Debug, Clone)]
+pub enum BindError {
+    Pending(String),
+    Fatal(String),
+}
+
+impl std::fmt::Display for BindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending(reason) => write!(f, "bind pending: {}", reason),
+            Self::Fatal(reason) => write!(f, "bind fatal: {}", reason),
+        }
+    }
+}
+
+impl std::error::Error for BindError {}
+```
+
+- [ ] **Step 2: Delete the `BindError` Display tests**
+
+In the `#[cfg(test)] mod display_tests` at the bottom of `types.rs`, delete:
+
+```rust
+#[test]
+fn bind_error_display_pending_format() {
+    let e = BindError::Pending("logs row not yet committed".to_string());
+    assert_eq!(e.to_string(), "bind pending: logs row not yet committed");
+}
+
+#[test]
+fn bind_error_display_fatal_format() {
+    let e = BindError::Fatal("permission denied on ~/.codex".to_string());
+    assert_eq!(e.to_string(), "bind fatal: permission denied on ~/.codex");
+}
+```
+
+(Other tests in `display_tests` — `display_invalid_path_has_stable_security_prefix`, `display_other_remains_bare_message`, `display_invalid_path_and_other_are_structurally_distinguishable`, `display_not_found_and_outside_root_unchanged` — are about `ValidateTranscriptError` and stay.)
+
+- [ ] **Step 3: Update `types.rs` imports**
+
+The `use std::time::SystemTime;` at the top of the file may be unused after deletion. Check:
+
+```bash
+grep -n "SystemTime" src-tauri/src/agent/adapter/types.rs
+```
+
+If no remaining matches, delete that `use` line. Same for any `use std::path::Path;` that was only there for `BindContext`.
+
+- [ ] **Step 4: Verify the workspace builds and tests pass**
+
+Run: `cargo build --manifest-path src-tauri/Cargo.toml`
+Expected: success.
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml agent::adapter`
+Expected: all tests pass. Test count drops by 2 (the deleted `bind_error_display_*` tests).
+
+Run: `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
+Expected: no warnings.
+
+Run the issue's acceptance verification:
+
+```bash
+grep -rn 'BindContext\|BindError' src-tauri/src/ --include='*.rs'
+```
+
+Expected: matches only inside `src-tauri/src/agent/adapter/codex/types.rs` (private struct definition), `codex/locator.rs` (the import + parameter types), and `codex/mod.rs` (the import + construction in `status_source`). No matches in `agent/adapter/types.rs`, `agent/adapter/mod.rs`, `claude_code/mod.rs`, `base/mod.rs`, `base/transcript_state.rs`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/agent/adapter/types.rs
+git commit -m "refactor(agent/adapter): delete public BindContext + BindError
+
+Both types are now codex-private (BindContext lives in
+agent/adapter/codex/types.rs as pub(super); BindError no longer
+exists at all because the trait method's error type is plain
+String). Verified via grep: no production code outside codex/
+references these names.
+
+Drops the BindError Display pinned-format tests; the
+ValidateTranscriptError tests in the same module are unaffected.
+
+Issue #156. See spec section 2.6. Acceptance criterion 'BindContext
+and BindError no longer appear in agent/adapter/types.rs' satisfied.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Documentation updates
+
+Spec section 5 + 6.2.
+
+**Files:**
+
+- Create: `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md`
+- Modify: `docs/decisions/CLAUDE.md` (index table)
+- Modify: `docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md` (top header + 2 inline supersede notes)
+- Modify: `src-tauri/src/agent/README.md` (lines 67, 98, 116)
+
+- [ ] **Step 1: Write the new ADR**
+
+Create `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md` with this content:
+
+```markdown
+# Codex adapter trait simplification — collapse BindContext + retry into CodexAdapter
+
+**Date:** 2026-05-05
+**Status:** Accepted
+**Scope:** Round-3 review on PR #154 flagged that `BindContext` and the bounded retry inside `base::start_for` leak codex-only requirements through the `AgentAdapter` trait surface. This ADR records the decision to move both pieces into `CodexAdapter` itself, supersedes parts of the Stage 2 spec, and inherits (does not re-litigate) the three deviations recorded in the 2026-05-04 scope-expansion ADR.
+
+**Predecessors (still load-bearing):**
+
+- [`docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`](../superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md) — Stage 2 spec.
+- [`docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md`](./2026-05-04-codex-adapter-stage-2-scope-expansion.md) — Stage 2 deviations (transcript tailer, /proc fast-paths, agent-PID bind).
+
+**Spec mandating this ADR:** [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](../superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md).
+
+## Context
+
+Stage 2 (PR #154) introduced `BindContext { session_id, cwd, pid, pty_start }` as the parameter to `AgentAdapter::status_source`, plus a bounded retry inside `base::start_for` that loops on `BindError::Pending` for up to 5 × 100ms = 500ms. Both pieces existed solely to support codex's SQLite-logs cold-start race (the `logs` row arrives ~300ms after the rollout file opens). Claude's adapter ignores `pid`/`pty_start` and never returns `Pending`. Round-3 review on PR #154 ([discussion_r3181677311](https://github.com/winoooops/vimeflow/pull/154#discussion_r3181677311), [discussion_r3181691871](https://github.com/winoooops/vimeflow/pull/154#discussion_r3181691871)) called the leak out as a finding, not a stylistic preference.
+
+## Options considered
+
+1. **Leave as-is** — accept the trait-surface leak.
+2. **Move `pid`/`pty_start` to the codex adapter, keep the bounded retry in `base::start_for`** — half-fix.
+3. **Move both pieces into `CodexAdapter` itself** — this ADR's choice.
+
+## Decision
+
+Choose option 3.
+
+The trait method becomes `status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>`. `BindContext` and `BindError` are deleted from `agent/adapter/types.rs`. `CodexAdapter` gains `pid`, `pty_start`, and `codex_home` fields plus a `retry_locator` helper that runs the cold-start race privately. `base::start_for` becomes a single-call orchestrator with zero retry/sleep code. The factory renames from `for_type(agent_type)` to `for_attach(agent_type, pid, pty_start)`.
+
+## Justification
+
+1. **Single-responsibility.** The trait describes "what an agent adapter does"; codex's cold-start race is "how the codex adapter does it", not part of the contract.
+2. **Future adapters.** Aider, Generic, and other adapters shouldn't need to learn about `BindContext` to implement `status_source`.
+3. **Calibration locality.** The retry budget (5 × 100ms) is calibrated against codex-specific commit timings; it doesn't generalize. Hosting it inside the codex adapter keeps the calibration close to the rationale.
+4. **Pure internal refactor.** No IPC, no user-visible behavior change, no scope expansion. Sleep-budget shrinks marginally (5 × 100ms → 4 × 100ms — final-attempt sleep skipped), still well under the 500ms safety margin.
+
+## Alternatives rejected
+
+### Option 1 — Leave as-is
+
+Rejected because round-3 review explicitly flagged the leak as a finding, not a stylistic preference. The cost of the leak grows with each new adapter.
+
+### Option 2 — Half-fix
+
+Rejected because the retry budget still has nowhere coherent to live. `base::start_for` would still be branching on a `Pending`/`Fatal` distinction that only one adapter ever produces. The trait surface would be cleaner but the orchestration layer would carry a codex-shaped contract.
+
+## Known risks & mitigations
+
+- **Risk:** A second adapter eventually needs the same retry shape and re-introduces a parallel-but-divergent retry helper.
+  **Mitigation:** the `retry_locator` helper is internal to codex and trivially small; if a second adapter needs the same shape, promote a generic `retry_with_budget` to a shared `agent/adapter/util.rs` at that point. Don't preempt.
+
+- **Risk:** Sleep-budget tightening from 5 × 100ms to 4 × 100ms is a real behavior change.
+  **Mitigation:** the cold-start window is typically ~300ms (per the 2026-05-04 ADR's `/proc` fast-path rationale), well below 400ms. The exhaustion path rarely fires in practice, and the 500ms safety margin against the 2000ms detection re-poll is preserved.
+
+## References
+
+- Issue [#156](https://github.com/winoooops/vimeflow/issues/156).
+- PR [#154](https://github.com/winoooops/vimeflow/pull/154) — Stage 2 implementation.
+- Round-3 review threads: [r1](https://github.com/winoooops/vimeflow/pull/154#discussion_r3181677311), [r2](https://github.com/winoooops/vimeflow/pull/154#discussion_r3181691871).
+- 2026-05-03 spec: [`docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`](../superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md).
+- 2026-05-04 ADR: [`docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md`](./2026-05-04-codex-adapter-stage-2-scope-expansion.md).
+- 2026-05-05 spec: [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](../superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md).
+```
+
+- [ ] **Step 2: Append the new ADR to the index in `docs/decisions/CLAUDE.md`**
+
+Find the records table (around line 13). Insert a new row at the top:
+
+```markdown
+| 2026-05-05 | [Codex adapter trait simplification](./2026-05-05-codex-adapter-trait-simplification.md) | Accepted |
+```
+
+The full table after the edit:
+
+```markdown
+| Date       | Decision                                                                                       | Status   |
+| ---------- | ---------------------------------------------------------------------------------------------- | -------- |
+| 2026-05-05 | [Codex adapter trait simplification](./2026-05-05-codex-adapter-trait-simplification.md)       | Accepted |
+| 2026-05-04 | [Codex adapter Stage 2 scope expansion](./2026-05-04-codex-adapter-stage-2-scope-expansion.md) | Accepted |
+| 2026-05-03 | [Claude parser JSON boundary](./2026-05-03-claude-parser-json-boundary.md)                     | Accepted |
+| 2026-04-22 | [Tooltip library: `@floating-ui/react`](./2026-04-22-tooltip-library.md)                       | Accepted |
+```
+
+- [ ] **Step 3: Add the `Amended further by:` line to the Stage 2 spec header**
+
+In `docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`, find line 7:
+
+```markdown
+**Amended by:** `docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md` — the implementation expanded past three of this spec's locked rules (Codex transcript tailer, `/proc`-as-chooser, `BindContext.pid` semantics). Where this spec and that ADR conflict, the ADR wins for those three items only; the rest of this spec stands.
+```
+
+Insert a new line directly after it:
+
+```markdown
+**Amended further by:** `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md` — the trait signature change at "Architecture > Trait signature change" and the `start_for` retry rules at "Architecture > `start_for` retry loop" are superseded. The codex-adapter-internal retry, the `(cwd, sid)` trait method, and the `for_attach(agent_type, pid, pty_start)` factory replace those rules. Everything else in this spec stands.
+```
+
+- [ ] **Step 4: Add inline supersede markers to Stage 2 spec sections**
+
+In `docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`, find the "Trait signature change" subsection (around line 213). It starts with the subheading `### Trait signature change`. Insert this italicised note immediately after the heading, before the existing prose:
+
+```markdown
+> _Superseded by [`docs/decisions/2026-05-05-codex-adapter-trait-simplification.md`](../../decisions/2026-05-05-codex-adapter-trait-simplification.md) — the trait method is now `(cwd: &Path, session_id: &str) -> Result<StatusSource, String>`. The discussion below describes the Stage 2 surface as shipped; the current surface is in the [2026-05-05 spec](./2026-05-05-codex-adapter-trait-simplification-design.md)._
+```
+
+Find the `start_for` retry loop subsection (around line 225, heading `### \`start_for\` retry loop`). Insert directly after the heading:
+
+```markdown
+> _Superseded by [`docs/decisions/2026-05-05-codex-adapter-trait-simplification.md`](../../decisions/2026-05-05-codex-adapter-trait-simplification.md) — the retry now lives inside `CodexAdapter::status_source` (helper: `retry_locator`). `base::start_for` has zero retry code post-2026-05-05._
+```
+
+- [ ] **Step 5: Update `src-tauri/src/agent/README.md` lines 67, 98, 116**
+
+In `src-tauri/src/agent/README.md`:
+
+(a) Line 67 — file-tree comment for `types.rs`. Find:
+
+```
+    ├── types.rs             ← StatusSource, ParsedStatus, BindContext, BindError, ValidateTranscriptError
+```
+
+Replace with:
+
+```
+    ├── types.rs             ← StatusSource, ParsedStatus, ValidateTranscriptError
+```
+
+(b) Line 98 — follow-up tracking blockquote. Find:
+
+```markdown
+> **Follow-up tracking:** issue [#156](https://github.com/winoooops/vimeflow/issues/156) collapses `BindContext` and the central retry into `CodexAdapter::new(pid, pty_start)`. After that lands, `for_type` becomes `for_attach(ctx)` and the Claude impl drops the unused `ctx` parameter from `status_source`.
+```
+
+Replace with:
+
+```markdown
+> **Resolved 2026-05-05** by [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](../../docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md) (issue [#156](https://github.com/winoooops/vimeflow/issues/156)): `BindContext` is now private to `codex/`, `BindError` is deleted, the trait method is `status_source(cwd, sid) -> Result<_, String>`, and codex's cold-start retry lives inside `CodexAdapter::status_source` via the `retry_locator` helper.
+```
+
+(c) Line 116 — description of the bind flow. Find:
+
+```markdown
+`pid` is the detected agent PID (returned by `detector::detect_agent`), not the shell PID at the PTY root — Codex's `logs.process_uuid` indexes by the codex child PID. `pty_start` is captured at PTY spawn (`ManagedSession.started_at`) so the logs query can filter out PID-reuse and stale-loaded-thread matches. Both arguments are passed through to the adapter as fields of `BindContext` (delegated through `base::start_for` → `resolve_status_source_with_retry` → `adapter.status_source(&ctx)`). Claude's impl ignores them; Codex's locator depends on them.
+```
+
+Replace with:
+
+```markdown
+`pid` is the detected agent PID (returned by `detector::detect_agent`), not the shell PID at the PTY root — Codex's `logs.process_uuid` indexes by the codex child PID. `pty_start` is captured at PTY spawn (`ManagedSession.started_at`) so the logs query can filter out PID-reuse and stale-loaded-thread matches. Both arguments are stored on `CodexAdapter` at construction (`CodexAdapter::new(pid, pty_start)` via the `for_attach(agent_type, pid, pty_start)` factory). The codex adapter wraps them in a private `BindContext` for its locator on each `status_source` call. `base::start_for` invokes `adapter.status_source(cwd, session_id)` once and codex's internal retry lives in `retry_locator` (5 attempts, 4 × 100ms inter-attempt sleeps, 400ms sleep budget on full exhaustion). Claude's impl ignores these fields — Claude's `status_source(cwd, sid)` is infallible.
+```
+
+(Line 11 — the scope-expansion ADR pointer — stays unchanged. It's a historical reference that remains accurate.)
+
+- [ ] **Step 6: Verify links resolve and prose reads correctly**
+
+Spot-check the new ADR loads in a markdown viewer (or `glow docs/decisions/2026-05-05-codex-adapter-trait-simplification.md` if available). Open `src-tauri/src/agent/README.md` and verify the three line-targeted edits read coherently.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/decisions/2026-05-05-codex-adapter-trait-simplification.md \
+        docs/decisions/CLAUDE.md \
+        docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md \
+        src-tauri/src/agent/README.md
+git commit -m "docs: add 2026-05-05 trait-simplification ADR + amend Stage 2 spec
+
+New ADR records the decision to collapse BindContext + retry into
+CodexAdapter (issue #156). Index updated. Stage 2 spec gains an
+'Amended further by' header pointer plus inline supersede notes on
+the trait-signature-change and start_for-retry-loop subsections.
+
+agent/README.md lines 67, 98, 116 updated to describe the
+post-2026-05-05 flow: trait method is (cwd, sid) -> Result<_, String>,
+codex's pid/pty_start/codex_home live on CodexAdapter, retry_locator
+helper handles the cold-start race. Line 11's scope-expansion ADR
+pointer is a historical record and stays.
+
+Historical docs (CHANGELOG.md/.zh-CN.md, scope-expansion ADR, Stage 2
+plan) are deliberately not edited — their references describe past
+state, not current state.
+
+Issue #156. See spec section 5.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final Verification
+
+After all six tasks land, run the issue #156 acceptance checklist (spec section 6.1):
+
+- [ ] **Verify trait signature**
+
+```bash
+grep -rn 'fn status_source' src-tauri/src/agent/adapter/
+```
+
+Expected output (one line per file, all showing the `(cwd: &Path, session_id: &str) -> Result<StatusSource, String>` shape):
+
+```
+src-tauri/src/agent/adapter/mod.rs:    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>;
+src-tauri/src/agent/adapter/mod.rs:    fn status_source(...) [NoOpAdapter impl]
+src-tauri/src/agent/adapter/claude_code/mod.rs:    fn status_source(...) [Claude impl]
+src-tauri/src/agent/adapter/codex/mod.rs:    fn status_source(...) [Codex impl]
+src-tauri/src/agent/adapter/base/transcript_state.rs:    fn status_source(...) [OrderingAdapter mock]
+```
+
+- [ ] **Verify type removal**
+
+```bash
+grep -rn 'BindContext\|BindError' src-tauri/src/ --include='*.rs'
+```
+
+Expected: matches only inside `src-tauri/src/agent/adapter/codex/types.rs`, `codex/mod.rs`, and `codex/locator.rs`. No matches outside `codex/`.
+
+- [ ] **Verify start_for has no retry/sleep code**
+
+```bash
+grep -n 'sleep\|retry\|RETRY' src-tauri/src/agent/adapter/base/mod.rs
+```
+
+Expected: no matches.
+
+- [ ] **Run the full test suite**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Expected: all tests pass. Test count delta vs. pre-refactor: -2 (deleted `bind_error_display_*` tests) +4 (`retry_locator_tests`) +2 (`status_source_tests`) = net +4. Plus -2 (deleted `start_for_retry_tests`) = net +2.
+
+- [ ] **Run clippy**
+
+```bash
+cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Manual end-to-end check**
+
+Per spec section 4.5:
+
+1. `npm run tauri dev`, open a terminal in the app.
+2. Run `codex` in the PTY → wait one turn → status panel populates within ~1s.
+3. Run `codex resume --last` in another fresh terminal → status panel populates immediately.
+4. Run `claude` in a third terminal → Claude path unaffected.
+5. Trigger an artificial bind-fatal: `chmod 000 ~/.codex` temporarily → frontend stays in silent-retry; restore permissions; next 2000ms re-poll resolves.
+
+- [ ] **Confirm PR-scope discipline (per spec section 6.3)**
+
+```bash
+git diff --stat main..HEAD
+```
+
+Expected: only the 11 files in the spec's File touch list (Section 6.2) — 7 modified Rust + 1 added Rust + 1 added doc + 3 modified docs. If any other file appears, audit and either justify in the PR description or split into a separate `chore(fmt):` commit per the PR-scope rule (PR #155).
+
+```bash
+git diff -w --stat main..HEAD
+```
+
+Expected: whitespace-stripped delta close to the regular delta. Any large gap is a formatting drive-by — surface and revert before opening the PR.

--- a/docs/superpowers/plans/2026-05-05-codex-adapter-trait-simplification.md
+++ b/docs/superpowers/plans/2026-05-05-codex-adapter-trait-simplification.md
@@ -1671,6 +1671,48 @@ Insert a new line directly after it:
 **Amended further by:** `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md` — the trait signature change at "Architecture > Trait signature change" and the `start_for` retry rules at "Architecture > `start_for` retry loop" are superseded. The codex-adapter-internal retry, the `(cwd, sid)` trait method, and the `for_attach(agent_type, pid, pty_start)` factory replace those rules. Everything else in this spec stands.
 ```
 
+- [ ] **Step 4a: Append post-2026-05-05 notes to Stage 2 spec File touch list rows**
+
+In `docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`, find the "File touch list (step 1 only)" section (around line 549). Several rows describe Stage 2 deltas to files this refactor also touches. Append a one-line italicised note under the affected rows pointing readers at the post-2026-05-05 spec.
+
+For the `mod.rs` row, after:
+
+```markdown
+- `src-tauri/src/agent/adapter/mod.rs` — trait sig update; `start_for` retry on Pending; `start_agent_watcher` builds `BindContext` from `PtyState`.
+```
+
+Insert (no replacement; append a continuation line indented 2 spaces):
+
+```markdown
+- _Post-2026-05-05 mechanics differ; see [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](./2026-05-05-codex-adapter-trait-simplification-design.md)._
+```
+
+Same shape under the `base/mod.rs` row, after:
+
+```markdown
+- `src-tauri/src/agent/adapter/base/mod.rs` — `start_for` retry loop, error propagation.
+```
+
+Append:
+
+```markdown
+- _Post-2026-05-05 mechanics differ; the retry moves into `CodexAdapter`. See the [trait simplification spec](./2026-05-05-codex-adapter-trait-simplification-design.md)._
+```
+
+And under the `types.rs` row, after:
+
+```markdown
+- `src-tauri/src/agent/adapter/types.rs` — add `BindContext`, `BindError`.
+```
+
+Append:
+
+```markdown
+- _Post-2026-05-05: both types are deleted. `BindContext` lives privately in `agent/adapter/codex/types.rs`; `BindError` is gone (trait method returns `Result<_, String>`). See the [trait simplification spec](./2026-05-05-codex-adapter-trait-simplification-design.md).\_
+```
+
+The Stage 2 row text itself stays — it's a historical record of what Stage 2 added; the appended note tells readers where the current contract lives. This is the "File touch list rows" amendment mandated by spec section 5.2.
+
 - [ ] **Step 4: Add inline supersede markers to Stage 2 spec sections**
 
 In `docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`, find the "Trait signature change" subsection (around line 213). It starts with the subheading `### Trait signature change`. Insert this italicised note immediately after the heading, before the existing prose:
@@ -1685,11 +1727,11 @@ Find the `start_for` retry loop subsection (around line 225, heading `### \`star
 > _Superseded by [`docs/decisions/2026-05-05-codex-adapter-trait-simplification.md`](../../decisions/2026-05-05-codex-adapter-trait-simplification.md) — the retry now lives inside `CodexAdapter::status_source` (helper: `retry_locator`). `base::start_for` has zero retry code post-2026-05-05._
 ```
 
-- [ ] **Step 5: Update `src-tauri/src/agent/README.md` lines 67, 98, 116**
+- [ ] **Step 5: Update `src-tauri/src/agent/README.md` (sweep all stale references)**
 
-In `src-tauri/src/agent/README.md`:
+The README has stale references to the pre-refactor contract beyond the three lines flagged in spec section 5.3. The plan expands the sweep to keep the README consistent with the post-2026-05-05 contract — line numbers approximate; locate by anchor text.
 
-(a) Line 67 — file-tree comment for `types.rs`. Find:
+**(a) Line ~67 — file-tree comment for `types.rs`.** Find:
 
 ```
     ├── types.rs             ← StatusSource, ParsedStatus, BindContext, BindError, ValidateTranscriptError
@@ -1701,19 +1743,75 @@ Replace with:
     ├── types.rs             ← StatusSource, ParsedStatus, ValidateTranscriptError
 ```
 
-(b) Line 98 — follow-up tracking blockquote. Find:
+**(b) Lines ~86-99 — `<dyn AgentAdapter<R>>::for_type` heading + code block + bullets + follow-up blockquote.** Find the entire section starting at the heading and ending at the blockquote:
 
-```markdown
+````markdown
+### `<dyn AgentAdapter<R>>::for_type`
+
+```rust
+pub fn for_type(agent_type: AgentType) -> Result<Arc<Self>, String>
+```
+
+Constructs the right adapter for a detected agent type. Returns `Arc<dyn AgentAdapter<R>>`:
+
+- `AgentType::ClaudeCode` → `ClaudeCodeAdapter`
+- `AgentType::Codex` → `CodexAdapter::new()`
+- everything else → `NoOpAdapter::new(t)` (returns errors from `parse_status` / `validate_transcript` / `tail_transcript`; `status_source` returns a `.vimeflow/sessions/{sid}/status.json` placeholder)
+
 > **Follow-up tracking:** issue [#156](https://github.com/winoooops/vimeflow/issues/156) collapses `BindContext` and the central retry into `CodexAdapter::new(pid, pty_start)`. After that lands, `for_type` becomes `for_attach(ctx)` and the Claude impl drops the unused `ctx` parameter from `status_source`.
+````
+
+Replace with:
+
+````markdown
+### `<dyn AgentAdapter<R>>::for_attach`
+
+```rust
+pub fn for_attach(
+    agent_type: AgentType,
+    pid: u32,
+    pty_start: SystemTime,
+) -> Result<Arc<Self>, String>
+```
+
+Constructs the right adapter for a detected agent type. Returns `Arc<dyn AgentAdapter<R>>`:
+
+- `AgentType::ClaudeCode` → `ClaudeCodeAdapter` (`pid`/`pty_start` discarded)
+- `AgentType::Codex` → `CodexAdapter::new(pid, pty_start)`
+- everything else → `NoOpAdapter::new(t)` (returns errors from `parse_status` / `validate_transcript` / `tail_transcript`; `status_source` returns a `.vimeflow/sessions/{sid}/status.json` placeholder; `pid`/`pty_start` discarded)
+
+> **Resolved 2026-05-05** by [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](../../docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md) (issue [#156](https://github.com/winoooops/vimeflow/issues/156)): `BindContext` is now private to `codex/`, `BindError` is deleted, the trait method is `status_source(cwd, sid) -> Result<_, String>`, and codex's cold-start retry lives inside `CodexAdapter::status_source` via the `retry_locator` helper.
+````
+
+**(c) Lines ~102-112 — `<dyn AgentAdapter<R>>::start` code block.** Find:
+
+```rust
+pub fn start(
+    self: Arc<Self>,
+    app: AppHandle<R>,
+    session_id: String,
+    cwd: PathBuf,
+    pid: u32,
+    pty_start: SystemTime,
+    state: AgentWatcherState,
+) -> Result<(), String>
 ```
 
 Replace with:
 
-```markdown
-> **Resolved 2026-05-05** by [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](../../docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md) (issue [#156](https://github.com/winoooops/vimeflow/issues/156)): `BindContext` is now private to `codex/`, `BindError` is deleted, the trait method is `status_source(cwd, sid) -> Result<_, String>`, and codex's cold-start retry lives inside `CodexAdapter::status_source` via the `retry_locator` helper.
+```rust
+pub fn start(
+    self: Arc<Self>,
+    app: AppHandle<R>,
+    session_id: String,
+    cwd: PathBuf,
+    state: AgentWatcherState,
+) -> Result<(), String>
 ```
 
-(c) Line 116 — description of the bind flow. Find:
+(Drops `pid` and `pty_start` parameters — these now live on `CodexAdapter` from `for_attach`.)
+
+**(d) Line ~116 — bind-flow description.** Find:
 
 ```markdown
 `pid` is the detected agent PID (returned by `detector::detect_agent`), not the shell PID at the PTY root — Codex's `logs.process_uuid` indexes by the codex child PID. `pty_start` is captured at PTY spawn (`ManagedSession.started_at`) so the logs query can filter out PID-reuse and stale-loaded-thread matches. Both arguments are passed through to the adapter as fields of `BindContext` (delegated through `base::start_for` → `resolve_status_source_with_retry` → `adapter.status_source(&ctx)`). Claude's impl ignores them; Codex's locator depends on them.
@@ -1725,7 +1823,123 @@ Replace with:
 `pid` is the detected agent PID (returned by `detector::detect_agent`), not the shell PID at the PTY root — Codex's `logs.process_uuid` indexes by the codex child PID. `pty_start` is captured at PTY spawn (`ManagedSession.started_at`) so the logs query can filter out PID-reuse and stale-loaded-thread matches. Both arguments are stored on `CodexAdapter` at construction (`CodexAdapter::new(pid, pty_start)` via the `for_attach(agent_type, pid, pty_start)` factory). The codex adapter wraps them in a private `BindContext` for its locator on each `status_source` call. `base::start_for` invokes `adapter.status_source(cwd, session_id)` once and codex's internal retry lives in `retry_locator` (5 attempts, 4 × 100ms inter-attempt sleeps, 400ms sleep budget on full exhaustion). Claude's impl ignores these fields — Claude's `status_source(cwd, sid)` is infallible.
 ```
 
-(Line 11 — the scope-expansion ADR pointer — stays unchanged. It's a historical reference that remains accurate.)
+**(e) Line ~147 — trait declaration in "The trait (provider hooks)" section.** Find:
+
+```rust
+    fn status_source(&self, cwd: &Path, session_id: &str) -> StatusSource;
+```
+
+Replace with:
+
+```rust
+    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>;
+```
+
+**(f) Line ~165 — `status_source` row in the trait-hook table.** Find:
+
+```markdown
+| `status_source` | `StatusSource { path, trust_root }` | Where the agent writes its status snapshot, plus the trust root the path must canonicalize under. |
+```
+
+Replace with:
+
+```markdown
+| `status_source` | `Result<StatusSource, String>` | Where the agent writes its status snapshot, plus the trust root the path must canonicalize under. Failures (codex bind retry exhausted; codex locator fatal) surface as `Err(String)`. |
+```
+
+**(g) Lines ~183-188 — `ClaudeCodeAdapter::status_source` example body.** Find inside the `impl ... for ClaudeCodeAdapter` code block:
+
+```rust
+    fn status_source(&self, cwd, sid) -> StatusSource {
+        StatusSource {
+            path: cwd.join(".vimeflow/sessions").join(sid).join("status.json"),
+            trust_root: cwd.to_path_buf(),
+        }
+    }
+```
+
+Replace with:
+
+```rust
+    fn status_source(&self, cwd, sid) -> Result<StatusSource, String> {
+        Ok(StatusSource {
+            path: cwd.join(".vimeflow/sessions").join(sid).join("status.json"),
+            trust_root: cwd.to_path_buf(),
+        })
+    }
+```
+
+**(h) Lines ~218-225 — `NoOpAdapter::status_source` example body.** Find inside the `impl ... for NoOpAdapter` code block:
+
+```rust
+    fn status_source(&self, cwd, sid) -> StatusSource {
+        // Same path Claude uses → watcher's create_dir_all + watch
+        // matches today's silent-no-op UX for unsupported agents.
+        StatusSource {
+            path: cwd.join(".vimeflow/sessions").join(sid).join("status.json"),
+            trust_root: cwd.to_path_buf(),
+        }
+    }
+```
+
+Replace with:
+
+```rust
+    fn status_source(&self, cwd, sid) -> Result<StatusSource, String> {
+        // Same path Claude uses → watcher's create_dir_all + watch
+        // matches today's silent-no-op UX for unsupported agents.
+        Ok(StatusSource {
+            path: cwd.join(".vimeflow/sessions").join(sid).join("status.json"),
+            trust_root: cwd.to_path_buf(),
+        })
+    }
+```
+
+**(i) Line ~232 — "Why this exists" prose for NoOpAdapter.** Two `for_type` mentions to update. Find:
+
+```markdown
+**Why this exists:** if `for_type` returned `Err` for unsupported variants, the frontend's exit-collapse path (`useAgentStatus.ts:139-154`, gated on `watcherStartedRef.current`) would never run after a Codex / Aider session exits — the panel would stay in `isActive: true` indefinitely. `NoOpAdapter` returns Claude's status path so the watcher starts successfully (no events ever fire because nothing writes to that path under non-Claude agents), `watcherStartedRef.current` flips to `true`, and exit-collapse runs naturally. See spec IDEA "NoOpAdapter for non-Claude agents in for_type" for the full rationale.
+```
+
+Replace with:
+
+```markdown
+**Why this exists:** if `for_attach` returned `Err` for unsupported variants, the frontend's exit-collapse path (`useAgentStatus.ts:139-154`, gated on `watcherStartedRef.current`) would never run after a Codex / Aider session exits — the panel would stay in `isActive: true` indefinitely. `NoOpAdapter` returns Claude's status path so the watcher starts successfully (no events ever fire because nothing writes to that path under non-Claude agents), `watcherStartedRef.current` flips to `true`, and exit-collapse runs naturally. See spec IDEA "NoOpAdapter for non-Claude agents in for_attach" for the full rationale.
+```
+
+**(j) Line ~400 — detector dispatch reference.** Find:
+
+```markdown
+`detector.rs` is shared across every adapter — it inspects the PTY process tree and matches the bare binary name (`claude`, `codex`, `aider`) against `AgentType` variants. No adapter-specific logic; the result feeds `<dyn AgentAdapter<R>>::for_type`.
+```
+
+Replace with:
+
+```markdown
+`detector.rs` is shared across every adapter — it inspects the PTY process tree and matches the bare binary name (`claude`, `codex`, `aider`) against `AgentType` variants. No adapter-specific logic; the result feeds `<dyn AgentAdapter<R>>::for_attach`.
+```
+
+(Line ~11 — the scope-expansion ADR pointer — stays unchanged. It's a historical reference that remains accurate. Line ~60's file-tree comment for `mod.rs` also stays; the description still applies post-refactor.)
+
+After the sweep, run sanity greps:
+
+```bash
+grep -n 'for_type\b' src-tauri/src/agent/README.md
+```
+
+Expected: no matches.
+
+```bash
+grep -n 'BindError' src-tauri/src/agent/README.md
+```
+
+Expected: no matches.
+
+```bash
+grep -n 'status_source.*-> StatusSource\b' src-tauri/src/agent/README.md
+```
+
+Expected: no matches (all four `status_source` mentions now show `Result<StatusSource, String>`).
 
 - [ ] **Step 6: Verify links resolve and prose reads correctly**
 
@@ -1741,19 +1955,24 @@ git add docs/decisions/2026-05-05-codex-adapter-trait-simplification.md \
 git commit -m "docs: add 2026-05-05 trait-simplification ADR + amend Stage 2 spec
 
 New ADR records the decision to collapse BindContext + retry into
-CodexAdapter (issue #156). Index updated. Stage 2 spec gains an
-'Amended further by' header pointer plus inline supersede notes on
-the trait-signature-change and start_for-retry-loop subsections.
+CodexAdapter (issue #156). decisions/CLAUDE.md index updated.
 
-agent/README.md lines 67, 98, 116 updated to describe the
-post-2026-05-05 flow: trait method is (cwd, sid) -> Result<_, String>,
-codex's pid/pty_start/codex_home live on CodexAdapter, retry_locator
-helper handles the cold-start race. Line 11's scope-expansion ADR
-pointer is a historical record and stays.
+Stage 2 spec gains an 'Amended further by' header pointer, inline
+supersede notes on the trait-signature-change and start_for-retry-loop
+subsections, plus continuation lines under three File touch list rows
+(mod.rs, base/mod.rs, types.rs) so future readers find the current
+contract via the post-2026-05-05 spec.
 
-Historical docs (CHANGELOG.md/.zh-CN.md, scope-expansion ADR, Stage 2
-plan) are deliberately not edited — their references describe past
-state, not current state.
+agent/README.md updated across nine line-targeted edits (file-tree
+types row; for_attach section incl. heading + signature; start
+section signature; bind-flow paragraph; trait declaration; hook
+table row; ClaudeCodeAdapter and NoOpAdapter examples; NoOp
+'Why this exists' paragraph; detector dispatch reference). Line 11
+historical pointer + line 60 file-tree mod.rs description stay.
+
+Historical docs (CHANGELOG.md/.zh-CN.md, scope-expansion ADR,
+Stage 2 plan) are deliberately not edited — their references
+describe past state, not current state.
 
 Issue #156. See spec section 5.
 
@@ -1814,6 +2033,15 @@ cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 
 Expected: no warnings.
 
+- [ ] **Run formatting checks**
+
+```bash
+cargo fmt --check --manifest-path src-tauri/Cargo.toml
+npm run format:check
+```
+
+Expected: both commands succeed with no output (or "All matched files use Prettier code style!" for the JS side). The pre-commit hook (lint-staged + prettier) handles incremental formatting on staged files, but per `rules/rust/hooks.md` `cargo fmt --check` is the authoritative Rust-side gate; CI runs `npm run format:check` for the workspace-wide check.
+
 - [ ] **Manual end-to-end check**
 
 Per spec section 4.5:
@@ -1830,7 +2058,7 @@ Per spec section 4.5:
 git diff --stat main..HEAD
 ```
 
-Expected: only the 11 files in the spec's File touch list (Section 6.2) — 7 modified Rust + 1 added Rust + 1 added doc + 3 modified docs. If any other file appears, audit and either justify in the PR description or split into a separate `chore(fmt):` commit per the PR-scope rule (PR #155).
+Expected: only the 12 files in the spec's File touch list (Section 6.2) — 7 modified Rust + 1 added Rust + 1 added doc + 3 modified docs = 12 total. If any other file appears, audit and either justify in the PR description or split into a separate `chore(fmt):` commit per the PR-scope rule (PR #155).
 
 ```bash
 git diff -w --stat main..HEAD

--- a/docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md
+++ b/docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md
@@ -5,6 +5,7 @@
 **Scope:** Implement `CodexAdapter` against the `AgentAdapter` trait introduced in Stage 1 (`docs/superpowers/specs/2026-05-02-claude-adapter-refactor-design.md`, PRs #152, #153). Plus a deferred refactor pass to extract genuinely-shared parser helpers across both adapters once duplication is observed.
 **Predecessor ADR:** `docs/decisions/2026-05-03-claude-parser-json-boundary.md` — explicitly defers cross-adapter helper promotion until "another adapter proves the abstraction is useful". Step 2 of this spec is that proof.
 **Amended by:** `docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md` — the implementation expanded past three of this spec's locked rules (Codex transcript tailer, `/proc`-as-chooser, `BindContext.pid` semantics). Where this spec and that ADR conflict, the ADR wins for those three items only; the rest of this spec stands.
+**Amended further by:** `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md` — the trait signature change at "Architecture > Trait signature change" and the `start_for` retry rules at "Architecture > `start_for` retry loop" are superseded. The codex-adapter-internal retry, the `(cwd, sid)` trait method, and the `for_attach(agent_type, pid, pty_start)` factory replace those rules. Everything else in this spec stands.
 
 ---
 
@@ -211,6 +212,8 @@ pub enum BindError {
 
 ### Trait signature change
 
+> _Superseded by [`docs/decisions/2026-05-05-codex-adapter-trait-simplification.md`](../../decisions/2026-05-05-codex-adapter-trait-simplification.md) — the trait method is now `(cwd: &Path, session_id: &str) -> Result<StatusSource, String>`. The discussion below describes the Stage 2 surface as shipped; the current surface is in the [2026-05-05 spec](./2026-05-05-codex-adapter-trait-simplification-design.md)._
+
 ```rust
 // Before (Stage 1)
 fn status_source(&self, cwd: &Path, session_id: &str) -> StatusSource;
@@ -222,6 +225,8 @@ fn status_source(&self, ctx: &BindContext) -> Result<StatusSource, BindError>;
 `ClaudeCodeAdapter::status_source` and `NoOpAdapter::status_source` ignore `pid` and `pty_start`, always return `Ok(...)`. The change is mechanical for those two impls.
 
 ### `start_for` retry loop
+
+> _Superseded by [`docs/decisions/2026-05-05-codex-adapter-trait-simplification.md`](../../decisions/2026-05-05-codex-adapter-trait-simplification.md) — the retry now lives inside `CodexAdapter::status_source` (helper: `retry_locator`). `base::start_for` has zero retry code post-2026-05-05._
 
 `base::start_for` switches from one synchronous `adapter.status_source(...)` call to a bounded retry on `BindError::Pending`:
 
@@ -550,8 +555,11 @@ Backend (Rust):
 
 - `src-tauri/src/agent/types.rs` — `CostMetrics.total_cost_usd: Option<f64>`.
 - `src-tauri/src/agent/adapter/types.rs` — add `BindContext`, `BindError`.
+  - _Post-2026-05-05: both types are deleted. `BindContext` lives privately in `agent/adapter/codex/types.rs`; `BindError` is gone (trait method returns `Result<_, String>`). See the [trait simplification spec](./2026-05-05-codex-adapter-trait-simplification-design.md)._
 - `src-tauri/src/agent/adapter/mod.rs` — trait sig update; `start_for` retry on Pending; `start_agent_watcher` builds `BindContext` from `PtyState`.
+  - _Post-2026-05-05 mechanics differ; see [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](./2026-05-05-codex-adapter-trait-simplification-design.md)._
 - `src-tauri/src/agent/adapter/base/mod.rs` — `start_for` retry loop, error propagation.
+  - _Post-2026-05-05 mechanics differ; the retry moves into `CodexAdapter`. See the [trait simplification spec](./2026-05-05-codex-adapter-trait-simplification-design.md)._
 - `src-tauri/src/agent/adapter/claude_code/mod.rs` — `status_source` impl signature update (still infallible Ok).
 - `src-tauri/src/agent/adapter/claude_code/statusline.rs` — `parse_cost_metrics` returns `Option<f64>` for missing cost block.
 - `src-tauri/src/agent/adapter/codex/mod.rs` — new: `CodexAdapter` impl.

--- a/docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md
+++ b/docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md
@@ -555,7 +555,7 @@ Backend (Rust):
 
 - `src-tauri/src/agent/types.rs` — `CostMetrics.total_cost_usd: Option<f64>`.
 - `src-tauri/src/agent/adapter/types.rs` — add `BindContext`, `BindError`.
-  - _Post-2026-05-05: both types are deleted. `BindContext` lives privately in `agent/adapter/codex/types.rs`; `BindError` is gone (trait method returns `Result<_, String>`). See the [trait simplification spec](./2026-05-05-codex-adapter-trait-simplification-design.md)._
+  - _Post-2026-05-05: both types are deleted. `BindContext` lives privately in `agent/adapter/codex/types.rs`; `BindError` is gone (trait method returns `Result<_, String>`). See the [trait simplification spec](./2026-05-05-codex-adapter-trait-simplification-design.md).\_
 - `src-tauri/src/agent/adapter/mod.rs` — trait sig update; `start_for` retry on Pending; `start_agent_watcher` builds `BindContext` from `PtyState`.
   - _Post-2026-05-05 mechanics differ; see [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](./2026-05-05-codex-adapter-trait-simplification-design.md)._
 - `src-tauri/src/agent/adapter/base/mod.rs` — `start_for` retry loop, error propagation.

--- a/docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md
+++ b/docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md
@@ -1371,3 +1371,5 @@ literally:
    Whitespace-stripped delta should match the regular delta closely; any
    gap is a formatting drive-by to drop.
 4. Drive-by formatting → separate commit / PR.
+
+<!-- codex-reviewed: 2026-05-06T04:24:57Z -->

--- a/docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md
+++ b/docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md
@@ -1,0 +1,1347 @@
+# Codex adapter trait simplification — collapse BindContext + retry into CodexAdapter
+
+**Date:** 2026-05-05
+**Status:** Design
+**Issue:** [#156](https://github.com/winoooops/vimeflow/issues/156)
+**Scope:** Collapse the bind-time orchestration introduced in Stage 2 (PR #154)
+— `BindContext` parameterization of `AgentAdapter::status_source` plus the
+bounded retry inside `base::start_for` — back into the codex adapter, where the
+requirement originates. The trait method returns to `(&Path, &str)` and
+`base::start_for` becomes a single-call orchestrator.
+
+**Predecessors (still load-bearing):**
+
+- `docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md` — Stage 2
+  spec. This design supersedes the trait-signature change at "Architecture >
+  Trait signature change" (line ~213) and the `start_for` retry section at
+  "Architecture > `start_for` retry loop" (line ~225); everything else stands.
+- `docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md` —
+  Stage 2 scope-expansion ADR (transcript tailer, /proc fast-paths, agent-PID
+  bind). All three deviations remain in force; this refactor inherits them.
+
+**Successor (mandated by this spec):**
+
+- `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md` — new ADR
+  recording the trait-simplification decision and the spec sections it
+  supersedes.
+
+## Goal
+
+`AgentAdapter::status_source` should not encode codex-only requirements.
+Currently the trait signature carries `BindContext { session_id, cwd, pid,
+pty_start }` and a `BindError { Pending, Fatal }` retry contract — both exist
+solely to support codex's SQLite-logs cold-start race. Claude's
+`status_source` ignores `pid`/`pty_start` and never returns `Pending`.
+
+Round-3 review on PR #154 ([discussion_r3181677311][r1],
+[discussion_r3181691871][r2]) flagged the leak. This spec moves both pieces
+out of the trait surface:
+
+1. Drop `BindContext` from the trait. `status_source(&self, cwd: &Path,
+session_id: &str) -> Result<StatusSource, String>`. Adapters that need
+   richer context construct it privately.
+2. Drop the bounded retry from `base::start_for`. `CodexAdapter` runs its own
+   internal retry loop. **Sleep budget on full exhaustion: 400ms** (5
+   attempts × 100ms inter-attempt sleep, with the trailing sleep skipped —
+   see Section 3.3 for the loop). **Total wall clock**: sleep budget plus
+   5 × per-attempt `resolve()` overhead, ~10ms in practice. Marginally
+   under the current implementation's 500ms sleep / ~510ms wall clock;
+   neither threatens the frontend's 2000ms re-poll. Retry uses `pid` and
+   `pty_start` stored on the adapter struct.
+3. Rename `for_type(agent_type)` → `for_attach(agent_type, pid, pty_start)`
+   so the factory threads codex's bind facts at construction time. Claude
+   and `NoOpAdapter` constructors discard the codex-only fields.
+
+User-visible behavior is unchanged. Codex still binds within ~500ms; Claude's
+status panel populates identically; no IPC bump; no frontend change.
+
+## Non-goals
+
+- **No change to user-visible behavior.** The cold-start binding window
+  (well under the frontend's 2000ms detection re-poll), error surfacing
+  (silent retry), and the success/failure shape stay identical. The only
+  sub-budget change is full-exhaustion sleep total shrinking from 500ms to
+  400ms (sleep total; wall-clock total is sleep + 5 × per-attempt
+  `resolve()` overhead — see Section 3.3 for the precise figures).
+  Invisible to users because in practice codex commits its `logs` row well
+  before 400ms, so the exhaustion path rarely fires (cf. 2026-05-04 ADR's
+  `/proc` fast-path rationale).
+- **No new error type on the trait.** `Result<StatusSource, String>` matches
+  the existing `parse_status` / `tail_transcript` shape. Codex's internal
+  retry distinguishes Fatal from retry-exhausted in the message string;
+  callers (`base::start_for`) propagate verbatim and don't branch on
+  variants.
+- **No revisit of the 2026-05-04 ADR's three deviations.** Codex transcript
+  tailer, `/proc`-as-chooser-when-SQLite-empty, and agent-PID-as-`BindContext.pid`
+  remain in force. This refactor inherits them.
+- **No change to `CodexSessionLocator`'s external semantics.** It still
+  resolves `RolloutLocation` from `(cwd, sid, pid, pty_start)` and still
+  emits `LocatorError::{NotYetReady, Unresolved, Fatal}`. The only
+  locator-side change is that internal method signatures may take individual
+  params instead of `&BindContext` — see Section 3.
+- **No removal of the `spawn_blocking` wrap in `start_agent_watcher`.** The
+  codex internal retry still uses `std::thread::sleep`, and
+  `path_security::ensure_status_source_under_trust_root` still does sync
+  `canonicalize` I/O. Both still need to run off the tokio worker.
+- **No bundling of unrelated changes.** Per the PR-scope discipline tracked
+  in [PR #155][pr155], this PR's diff answers "what does issue #156 say to
+  do?" and nothing else. Drive-by formatting, comment polish, or other
+  improvements go in separate commits. (PR #155 is OPEN as of this spec's
+  write date; once merged, the canonical home is `rules/common/pr-scope.md`.
+  Until then, reference the PR.)
+
+## References
+
+- Issue: [#156](https://github.com/winoooops/vimeflow/issues/156)
+- Stage 2 PR: [#154](https://github.com/winoooops/vimeflow/pull/154)
+- Round-3 review threads: [r1][r1], [r2][r2]
+- PR-scope discipline (in flight): [PR #155][pr155]
+- Stage 2 spec: [`docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`](./2026-05-03-codex-adapter-stage-2-design.md)
+- Stage 2 scope-expansion ADR: [`docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md`](../../decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md)
+
+[r1]: https://github.com/winoooops/vimeflow/pull/154#discussion_r3181677311
+[r2]: https://github.com/winoooops/vimeflow/pull/154#discussion_r3181691871
+[pr155]: https://github.com/winoooops/vimeflow/pull/155
+
+## Public surface changes
+
+### 2.1 Trait `AgentAdapter::status_source`
+
+Before (current, post-PR #154):
+
+```rust
+pub trait AgentAdapter<R: tauri::Runtime>: Send + Sync + 'static {
+    fn agent_type(&self) -> AgentType;
+    fn status_source(&self, ctx: &BindContext<'_>) -> Result<StatusSource, BindError>;
+    fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String>;
+    fn validate_transcript(&self, raw: &str) -> Result<PathBuf, ValidateTranscriptError>;
+    fn tail_transcript(
+        &self,
+        app: AppHandle<R>,
+        session_id: String,
+        cwd: Option<PathBuf>,
+        transcript_path: PathBuf,
+    ) -> Result<TranscriptHandle, String>;
+}
+```
+
+After:
+
+```rust
+pub trait AgentAdapter<R: tauri::Runtime>: Send + Sync + 'static {
+    fn agent_type(&self) -> AgentType;
+    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>;
+    fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String>;
+    fn validate_transcript(&self, raw: &str) -> Result<PathBuf, ValidateTranscriptError>;
+    fn tail_transcript(
+        &self,
+        app: AppHandle<R>,
+        session_id: String,
+        cwd: Option<PathBuf>,
+        transcript_path: PathBuf,
+    ) -> Result<TranscriptHandle, String>;
+}
+```
+
+Two changes from current:
+
+- `(ctx: &BindContext<'_>)` → `(cwd: &Path, session_id: &str)`. The two facts
+  every adapter actually consumes are surfaced as separate params. Codex's
+  `pid` and `pty_start` move to the `CodexAdapter` struct (Section 3).
+- `Result<StatusSource, BindError>` → `Result<StatusSource, String>`.
+  `BindError` is deleted from `agent/adapter/types.rs`. There is no longer
+  a Pending/Fatal distinction at the trait surface — the only consumer of
+  that distinction was `base::start_for`'s retry loop, which moves into
+  `CodexAdapter` (Section 3).
+
+### 2.2 Factory `dyn AgentAdapter<R>::for_attach`
+
+Before:
+
+```rust
+impl<R: tauri::Runtime> dyn AgentAdapter<R> {
+    pub fn for_type(agent_type: AgentType) -> Result<Arc<Self>, String> {
+        match agent_type {
+            AgentType::ClaudeCode => Ok(Arc::new(ClaudeCodeAdapter)),
+            AgentType::Codex => Ok(Arc::new(CodexAdapter::new())),
+            other => Ok(Arc::new(NoOpAdapter::new(other))),
+        }
+    }
+    // ... start, stop
+}
+```
+
+After:
+
+```rust
+impl<R: tauri::Runtime> dyn AgentAdapter<R> {
+    pub fn for_attach(
+        agent_type: AgentType,
+        pid: u32,
+        pty_start: SystemTime,
+    ) -> Result<Arc<Self>, String> {
+        match agent_type {
+            AgentType::ClaudeCode => Ok(Arc::new(ClaudeCodeAdapter)),
+            AgentType::Codex => Ok(Arc::new(CodexAdapter::new(pid, pty_start))),
+            other => Ok(Arc::new(NoOpAdapter::new(other))),
+        }
+    }
+    // ... start, stop
+}
+```
+
+`pid` and `pty_start` are passed through to `CodexAdapter::new`. Claude and
+NoOp constructors discard them; the cost is two ignored arguments at one
+call site, which is cheaper than a parallel factory.
+
+### 2.3 `dyn AgentAdapter<R>::start` simplification
+
+Before:
+
+```rust
+pub fn start(
+    self: Arc<Self>,
+    app: AppHandle<R>,
+    session_id: String,
+    cwd: PathBuf,
+    pid: u32,
+    pty_start: SystemTime,
+    state: AgentWatcherState,
+) -> Result<(), String> {
+    base::start_for(self, app, session_id, cwd, pid, pty_start, state)
+}
+```
+
+After:
+
+```rust
+pub fn start(
+    self: Arc<Self>,
+    app: AppHandle<R>,
+    session_id: String,
+    cwd: PathBuf,
+    state: AgentWatcherState,
+) -> Result<(), String> {
+    base::start_for(self, app, session_id, cwd, state)
+}
+```
+
+`pid` and `pty_start` drop from the parameter list — they no longer flow
+through the orchestration layer because they're already baked into the
+codex adapter at construction time.
+
+### 2.4 `base::start_for` collapse
+
+Before (excerpt):
+
+```rust
+pub(crate) fn start_for<R: tauri::Runtime>(
+    adapter: Arc<dyn AgentAdapter<R>>,
+    app_handle: tauri::AppHandle<R>,
+    session_id: String,
+    cwd: PathBuf,
+    pid: u32,
+    pty_start: SystemTime,
+    state: AgentWatcherState,
+) -> Result<(), String> {
+    let source =
+        resolve_status_source_with_retry(adapter.as_ref(), &session_id, &cwd, pid, pty_start)?;
+    path_security::ensure_status_source_under_trust_root(&source.path, &source.trust_root)?;
+    // ... watcher startup
+}
+
+fn resolve_status_source_with_retry<R: tauri::Runtime>(...) -> Result<StatusSource, String> {
+    // 5 × 100ms loop on BindError::Pending
+    // ...
+}
+
+const BIND_RETRY_INTERVAL_MS: u64 = 100;
+const BIND_RETRY_MAX_ATTEMPTS: u32 = 5;
+```
+
+After:
+
+```rust
+pub(crate) fn start_for<R: tauri::Runtime>(
+    adapter: Arc<dyn AgentAdapter<R>>,
+    app_handle: tauri::AppHandle<R>,
+    session_id: String,
+    cwd: PathBuf,
+    state: AgentWatcherState,
+) -> Result<(), String> {
+    let source = adapter.status_source(&cwd, &session_id)?;
+    path_security::ensure_status_source_under_trust_root(&source.path, &source.trust_root)?;
+    // ... watcher startup unchanged
+}
+```
+
+`resolve_status_source_with_retry` is deleted. The `BIND_RETRY_INTERVAL_MS`
+and `BIND_RETRY_MAX_ATTEMPTS` constants move into `codex/mod.rs` as
+`CODEX_BIND_RETRY_INTERVAL_MS` / `CODEX_BIND_RETRY_MAX_ATTEMPTS` (Section 3).
+
+Imports removed from `base/mod.rs`:
+
+- `std::time::Duration` — only used by `std::thread::sleep` in the deleted
+  retry helper.
+- `std::time::Instant` — only used to log retry-budget elapsed time in the
+  deleted helper.
+- `BindContext`, `BindError` — both gone with the helper.
+- `StatusSource` — `start_for` references `source.path` / `source.trust_root`
+  via field access, so the type name is no longer named in this file once the
+  retry helper and its `start_for_retry_tests` mocks are removed.
+
+The remaining imports (`std::path::PathBuf`, `std::sync::Arc`, the
+`AgentAdapter` trait, the `path_security` / `transcript_state` /
+`watcher_runtime` submodules) are unaffected.
+
+### 2.5 `start_agent_watcher` rewire
+
+The Tauri command at `agent/adapter/mod.rs:130-164` keeps its existing shape
+but threads the agent PID + pty_start through the new factory:
+
+```rust
+#[tauri::command]
+pub async fn start_agent_watcher(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, AgentWatcherState>,
+    pty_state: tauri::State<'_, PtyState>,
+    session_id: String,
+) -> Result<(), String> {
+    let (cwd, _shell_pid, pty_start, agent_type, agent_pid) =
+        resolve_bind_inputs(&pty_state, &session_id, detect_agent)?;
+
+    let adapter =
+        <dyn AgentAdapter<tauri::Wry>>::for_attach(agent_type, agent_pid, pty_start)?;
+    let owned_state = (*state).clone();
+    let cwd_path = PathBuf::from(cwd);
+
+    // `adapter.start(...)` walks into `base::start_for`, which calls
+    // `adapter.status_source(...)`. For codex sessions, that call runs a
+    // bounded retry (5 × 100 ms) using `std::thread::sleep` because
+    // codex commits its `logs` row ~300ms after the rollout file opens.
+    // `path_security::ensure_status_source_under_trust_root` also does
+    // synchronous `canonicalize` filesystem I/O. Running either on a
+    // tokio worker thread starves other futures scheduled on the same
+    // worker; mirror the pattern at `src/git/watcher.rs:399` and hop
+    // onto the blocking pool so the async thread returns immediately.
+    tokio::task::spawn_blocking(move || {
+        adapter.start(app_handle, session_id, cwd_path, owned_state)
+    })
+    .await
+    .map_err(|e| format!("start_agent_watcher task panicked: {}", e))?
+}
+```
+
+Two surface deltas from current:
+
+- `for_type(agent_type)?` → `for_attach(agent_type, agent_pid, pty_start)?`.
+  The `agent_pid` is the codex child PID returned by `detect_agent` (per the
+  2026-05-04 ADR), not the shell PID at the PTY root.
+- `adapter.start(...)` drops the `pid` and `pty_start` arguments.
+- The rationale comment is updated to attribute the retry to the codex
+  adapter rather than to `start_for`. Functional content (sleep + sync I/O
+  → spawn_blocking) is unchanged.
+
+`resolve_bind_inputs` is unchanged: it still returns `(cwd, shell_pid,
+pty_start, agent_type, agent_pid)` and the test at
+`agent/adapter/mod.rs:298` still asserts the agent-PID-not-shell-PID
+invariant.
+
+### 2.6 Removed types
+
+`agent/adapter/types.rs` loses two public types:
+
+- `pub struct BindContext<'a>` — deleted. (May be reintroduced as a
+  `pub(super)`/private struct inside `codex/`; see Section 3.)
+- `pub enum BindError` — deleted along with its `Display` and `Error` impls.
+  No external callers depend on `BindError::{Pending, Fatal}` discrimination
+  after `base::start_for` stops branching on it.
+
+Two pinned-format regression tests at `types.rs:135-145`
+(`bind_error_display_pending_format`, `bind_error_display_fatal_format`) are
+deleted with `BindError`. The `ValidateTranscriptError` Display tests
+(`types.rs:93-133`) are unaffected.
+
+**NoOpAdapter rewrite** (`agent/adapter/mod.rs`). The current impl threads
+`ctx.cwd` / `ctx.session_id` through; the new impl receives them directly:
+
+```rust
+impl<R: tauri::Runtime> AgentAdapter<R> for NoOpAdapter {
+    fn agent_type(&self) -> AgentType { self.agent_type.clone() }
+
+    fn status_source(
+        &self,
+        cwd: &Path,
+        session_id: &str,
+    ) -> Result<StatusSource, String> {
+        Ok(StatusSource {
+            path: cwd
+                .join(".vimeflow")
+                .join("sessions")
+                .join(session_id)
+                .join("status.json"),
+            trust_root: cwd.to_path_buf(),
+        })
+    }
+
+    // parse_status / validate_transcript / tail_transcript bodies unchanged
+}
+```
+
+The corresponding test (`mod.rs:222-243`,
+`status_source_uses_claude_shaped_path`) drops the `BindContext` literal
+and calls the trait method with `(&cwd, "sid")` directly. Assertions on
+`src.path` / `src.trust_root` are unchanged.
+
+**ClaudeCodeAdapter rewrite** (`agent/adapter/claude_code/mod.rs`).
+Identical mechanical edit — body still uses `cwd` / `session_id`, the
+former `ctx.cwd` / `ctx.session_id` accesses become the parameter names
+directly:
+
+```rust
+impl<R: tauri::Runtime> AgentAdapter<R> for ClaudeCodeAdapter {
+    fn agent_type(&self) -> AgentType { AgentType::ClaudeCode }
+
+    fn status_source(
+        &self,
+        cwd: &Path,
+        session_id: &str,
+    ) -> Result<StatusSource, String> {
+        Ok(StatusSource {
+            path: cwd
+                .join(".vimeflow")
+                .join("sessions")
+                .join(session_id)
+                .join("status.json"),
+            trust_root: cwd.to_path_buf(),
+        })
+    }
+
+    // parse_status / validate_transcript / tail_transcript bodies unchanged
+}
+```
+
+The Claude test (`claude_code/mod.rs:74-96`,
+`status_source_returns_claude_path_under_cwd`) drops its `BindContext`
+literal the same way. The `pid: 0, pty_start: SystemTime::UNIX_EPOCH`
+filler that the test currently passes goes away — those fields no longer
+exist in the trait input.
+
+### 2.7 Import deltas across adapter files
+
+Two `use`-statement edits propagate through every file that previously
+imported `BindContext` / `BindError`. Per-file enumeration:
+
+- **`agent/adapter/mod.rs`**:
+  - `use std::path::PathBuf;` → `use std::path::{Path, PathBuf};` (trait sig
+    now names `Path`).
+  - `use types::{BindContext, BindError, ParsedStatus, StatusSource,
+ValidateTranscriptError};` →
+    `use types::{ParsedStatus, StatusSource, ValidateTranscriptError};`.
+  - `use std::time::SystemTime;` retained — `for_attach` still names it.
+- **`agent/adapter/claude_code/mod.rs`**:
+  - `use std::path::PathBuf;` → `use std::path::{Path, PathBuf};`.
+  - Drop `BindContext`, `BindError` from the types import.
+- **`agent/adapter/codex/mod.rs`**:
+  - `use std::path::PathBuf;` → `use std::path::{Path, PathBuf};` (the new
+    `status_source(&self, cwd: &Path, …)` trait method names `Path`).
+  - Add `use std::time::SystemTime;` (the `pty_start: SystemTime` adapter
+    field names it).
+  - Drop `BindContext`, `BindError` from the existing
+    `use crate::agent::adapter::types::{…}` import.
+  - Add `mod types;` declaration alongside the existing `mod locator;` /
+    `mod parser;` / `mod transcript;` lines, plus
+    `use self::types::BindContext;`.
+  - Update the locator import:
+    `use self::locator::{CodexSessionLocator, CompositeLocator, LocatorError};`
+    becomes `use self::locator::{CodexSessionLocator, CompositeLocator,
+LocatorError, RolloutLocation};` (the new `retry_locator` helper names
+    `RolloutLocation`).
+- **`agent/adapter/codex/locator.rs`**:
+  - `use crate::agent::adapter::types::BindContext;` →
+    `use super::types::BindContext;`.
+  - All `&BindContext<'_>` parameter types remain unchanged.
+- **`agent/adapter/base/mod.rs`** — see the import list under Section 2.4.
+- **`agent/adapter/base/transcript_state.rs`** — the `OrderingAdapter` mock
+  at `base/transcript_state.rs:458` updates its `status_source` impl
+  signature from
+  `(&self, _ctx: &crate::agent::adapter::types::BindContext<'_>) -> Result<crate::agent::adapter::types::StatusSource, crate::agent::adapter::types::BindError>`
+  to `(&self, _cwd: &std::path::Path, _session_id: &str) -> Result<crate::agent::adapter::types::StatusSource, String>`.
+  Body stays `unreachable!()`. Other types in this mock impl (`ParsedStatus`,
+  `ValidateTranscriptError`) are already fully-qualified so no further
+  import edits are needed.
+
+Both common-rules (`rules/common/coding-style.md`) and Rust-specific style
+(`rules/rust/coding-style.md`) flag unused imports. The edits above are
+mechanical; CI will surface any drift.
+
+## Codex internals
+
+### 3.1 Private `BindContext` inside `codex/`
+
+`BindContext` is removed from `agent/adapter/types.rs` (Section 2.6) but the
+locator's internal API still benefits from a single bag-of-attach-facts
+parameter (10+ method signatures take `&BindContext<'_>` today). Reintroduce
+it as a private codex-internal struct at `agent/adapter/codex/types.rs`:
+
+```rust
+// agent/adapter/codex/types.rs (new file)
+
+use std::path::Path;
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct BindContext<'a> {
+    pub(super) session_id: &'a str,
+    pub(super) cwd: &'a Path,
+    pub(super) pid: u32,
+    pub(super) pty_start: SystemTime,
+}
+```
+
+Field shape and `Copy`/`Clone` semantics match the deleted public type
+verbatim, so `codex/locator.rs` body changes are minimal — only the import
+path moves (`use crate::agent::adapter::types::BindContext` →
+`use super::types::BindContext`).
+
+Visibility is `pub(super)`, restricting the struct to the `codex/` module
+tree. External callers cannot construct or observe it.
+
+**Module wiring (mechanical, three edits):**
+
+- `codex/mod.rs` adds `mod types;` alongside the existing `mod locator;` /
+  `mod parser;` / `mod transcript;` declarations.
+- `codex/mod.rs` adds `use self::types::BindContext;` to bring the private
+  type into scope for `CodexAdapter::status_source` (Section 3.4).
+- `codex/locator.rs` switches its existing
+  `use crate::agent::adapter::types::BindContext;` to
+  `use super::types::BindContext;`. No locator method body changes.
+
+The new `types.rs` is the only added file in this section. It is two
+imports + one struct declaration, ~12 lines total.
+
+### 3.2 `CodexAdapter` struct
+
+Before:
+
+```rust
+pub struct CodexAdapter {
+    locator_cache: OnceLock<CompositeLocator>,
+    resolved_rollout_path: Mutex<Option<PathBuf>>,
+}
+
+impl CodexAdapter {
+    pub fn new() -> Self {
+        Self {
+            locator_cache: OnceLock::new(),
+            resolved_rollout_path: Mutex::new(None),
+        }
+    }
+    // ...
+}
+```
+
+After:
+
+```rust
+pub struct CodexAdapter {
+    pid: u32,
+    pty_start: SystemTime,
+    codex_home: PathBuf,
+    locator_cache: OnceLock<CompositeLocator>,
+    resolved_rollout_path: Mutex<Option<PathBuf>>,
+}
+
+impl CodexAdapter {
+    pub fn new(pid: u32, pty_start: SystemTime) -> Self {
+        Self {
+            pid,
+            pty_start,
+            codex_home: default_codex_home(),
+            locator_cache: OnceLock::new(),
+            resolved_rollout_path: Mutex::new(None),
+        }
+    }
+
+    /// Test-only constructor that accepts an explicit `codex_home`. Lets
+    /// `status_source_tests` seed a temp `~/.codex` mock without touching
+    /// the user's real home. Field initializers duplicate `new`; the
+    /// duplication is intentional so the test seam is fully gated and
+    /// production builds carry no test-shaped code.
+    #[cfg(test)]
+    pub(crate) fn with_home(
+        pid: u32,
+        pty_start: SystemTime,
+        codex_home: PathBuf,
+    ) -> Self {
+        Self {
+            pid,
+            pty_start,
+            codex_home,
+            locator_cache: OnceLock::new(),
+            resolved_rollout_path: Mutex::new(None),
+        }
+    }
+
+    fn locator(&self) -> &CompositeLocator {
+        self.locator_cache.get_or_init(|| {
+            log::info!(
+                "codex adapter: locator cache initialized (codex_home={})",
+                self.codex_home.display()
+            );
+            CompositeLocator::new(self.codex_home.clone())
+        })
+    }
+    // ...
+}
+
+fn default_codex_home() -> PathBuf {
+    dirs::home_dir()
+        .map(|home| home.join(".codex"))
+        .unwrap_or_else(|| PathBuf::from(".codex"))
+}
+```
+
+Two changes from current beyond the `pid`/`pty_start` addition:
+
+- New field `codex_home: PathBuf`. Resolved once in `new()` via
+  `default_codex_home()`; stored on the adapter so `status_source` and the
+  locator can both reference `self.codex_home` rather than the static
+  `Self::codex_home()` getter.
+- The current `fn codex_home() -> PathBuf` static method is replaced by the
+  free function `default_codex_home()` (used only in `new()`). The static
+  method is deleted; all in-impl call sites switch to `&self.codex_home` /
+  `self.codex_home.clone()`.
+- The release build path is unchanged: `new()` continues to derive the
+  codex home from `dirs::home_dir()`. The `with_home` constructor exists
+  only under `#[cfg(test)]`, so production has no extra branch.
+
+`pid`, `pty_start`, and `codex_home` are owned by the adapter for its
+lifetime — one attach. The cache scoping reasoning from the 2026-05-03
+stage-2 spec ("`<dyn AgentAdapter<R>>::for_type(...)` constructs a fresh
+`Arc<CodexAdapter>`, so the cache scope is 'one attach'; across attaches,
+discovery re-runs against a new instance") still holds — substituting
+`for_type` (Stage 2's name) with `for_attach` (this spec's rename) is a
+mechanical change. Each new attach produces a fresh `CodexAdapter` with
+its own snapshot, so there's no cross-session state to invalidate.
+
+`CodexAdapter::new()` becomes `CodexAdapter::new(pid, pty_start)`. Tests
+that previously called `CodexAdapter::new()` (e.g. the `adapter_tests`
+module at `codex/mod.rs:104-153`) update their construction sites to pass
+test-shaped `pid` / `pty_start` values; tests that need to exercise
+`status_source` or trust-root assertions use `with_home(pid, pty_start,
+temp_dir.path().to_path_buf())` instead.
+
+### 3.3 Internal retry helper
+
+The retry logic moves from `base::resolve_status_source_with_retry` into a
+small private helper inside `codex/mod.rs`. It takes a closure that returns
+`Result<RolloutLocation, LocatorError>` (the existing locator error shape),
+so tests can drive it without constructing a real `CompositeLocator`:
+
+```rust
+// agent/adapter/codex/mod.rs
+
+const CODEX_BIND_RETRY_INTERVAL_MS: u64 = 100;
+const CODEX_BIND_RETRY_MAX_ATTEMPTS: u32 = 5;
+
+/// Retry a codex locator resolution up to the bind budget. Returns the
+/// resolved location on success, or a formatted error string on:
+///
+/// - The first non-`NotYetReady` error from the closure (Fatal /
+///   Unresolved → bubble up immediately, no further attempts).
+/// - Budget exhaustion (`CODEX_BIND_RETRY_MAX_ATTEMPTS` consecutive
+///   `NotYetReady` returns).
+fn retry_locator<F>(mut resolve: F) -> Result<RolloutLocation, String>
+where
+    F: FnMut() -> Result<RolloutLocation, LocatorError>,
+{
+    let started = std::time::Instant::now();
+    let mut last_reason = String::from("no attempts");
+
+    for attempt in 0..CODEX_BIND_RETRY_MAX_ATTEMPTS {
+        match resolve() {
+            Ok(location) => return Ok(location),
+            Err(LocatorError::NotYetReady) => {
+                last_reason = format!("not yet ready (attempt {})", attempt + 1);
+                // Skip the trailing sleep on the final attempt — we are
+                // about to bail with `retry exhausted` anyway, so an
+                // additional `sleep` only inflates wall clock without
+                // giving codex more time to commit its row.
+                if attempt + 1 < CODEX_BIND_RETRY_MAX_ATTEMPTS {
+                    std::thread::sleep(std::time::Duration::from_millis(
+                        CODEX_BIND_RETRY_INTERVAL_MS,
+                    ));
+                }
+            }
+            Err(LocatorError::Unresolved(reason))
+            | Err(LocatorError::Fatal(reason)) => {
+                return Err(format!("codex bind fatal: {}", reason));
+            }
+        }
+    }
+
+    log::warn!(
+        "codex bind retry exhausted after {} attempts (elapsed={:?})",
+        CODEX_BIND_RETRY_MAX_ATTEMPTS,
+        started.elapsed()
+    );
+    Err(format!("codex bind retry exhausted: {}", last_reason))
+}
+```
+
+Key invariants preserved from the deleted `resolve_status_source_with_retry`:
+
+- **Sleep budget = 400ms on full exhaustion.** 5 attempts with a sleep
+  _between_ attempts (skipped after the final attempt — see the
+  `attempt + 1 < CODEX_BIND_RETRY_MAX_ATTEMPTS` guard above) gives 4 ×
+  100ms = 400ms of sleep on the worst-case exhaustion path. The deleted
+  `resolve_status_source_with_retry` slept after every attempt for 5 ×
+  100ms = 500ms of sleep — both budgets are about the _sleep_ total, not
+  the total wall clock.
+- **Total wall clock = sleep + 5 × `resolve()` overhead.** Each
+  `resolve()` call performs SQLite reads (typically a few ms each). New
+  worst case: ~400ms + ~10ms = ~410ms. Old worst case: ~500ms + ~10ms =
+  ~510ms. Both fit under `DETECTION_POLL_MS / 2 = 1000ms` (a much wider
+  margin than the spec's 500ms claim implies, but neither implementation
+  threatens the frontend's 2000ms re-poll cadence at
+  `useAgentStatus.ts:19`). The new helper trims roughly 100ms off the
+  exhaustion-case wall clock; in practice the cold-start race resolves in
+  <300ms anyway, so users almost never see exhaustion.
+- **Pending-only retries.** `LocatorError::NotYetReady` is the sole retry
+  trigger. Both `Unresolved` and `Fatal` short-circuit immediately — they
+  represent structural failures that will not resolve by waiting.
+- **Diagnostic warn on exhaustion.** A `log::warn!` line includes the
+  attempt count and elapsed time, matching the existing diagnostic at
+  `base/mod.rs:92-96`.
+- **Error string format.** "codex bind fatal: <reason>" and "codex bind
+  retry exhausted: <last>" are the two shapes. Both flow through
+  `start_for`'s error propagation to the frontend's silent-retry path
+  unchanged.
+
+The helper is `fn` not method-on-`Self` so it can be tested in isolation
+with synthesized closures. It does not need access to adapter state.
+
+### 3.4 `CodexAdapter::status_source` body
+
+```rust
+impl<R: tauri::Runtime> AgentAdapter<R> for CodexAdapter {
+    fn agent_type(&self) -> AgentType {
+        AgentType::Codex
+    }
+
+    fn status_source(
+        &self,
+        cwd: &Path,
+        session_id: &str,
+    ) -> Result<StatusSource, String> {
+        let ctx = BindContext {
+            session_id,
+            cwd,
+            pid: self.pid,
+            pty_start: self.pty_start,
+        };
+
+        let location = retry_locator(|| self.locator().resolve_rollout(&ctx))?;
+
+        if let Ok(mut slot) = self.resolved_rollout_path.lock() {
+            *slot = Some(location.rollout_path.clone());
+        }
+
+        Ok(StatusSource {
+            path: location.rollout_path,
+            trust_root: self.codex_home.clone(),
+        })
+    }
+
+    // parse_status, validate_transcript, tail_transcript: unchanged
+}
+```
+
+The `BindContext` constructed inside `status_source` uses the adapter's
+stored `pid`/`pty_start` for the codex-only fields and the trait-method
+params for `cwd`/`session_id`. The `&ctx` reference is captured by the
+closure passed to `retry_locator`.
+
+Mutex update of `resolved_rollout_path` happens once on success, identical
+to the current implementation. The 2026-05-04 ADR's "lifecycle invariant
+that `parse_status` must run after `status_source`" remains in force; the
+`Arc<CodexAdapter>` lifetime is one attach, and the slot is only ever
+written once before any `parse_status` call could observe it.
+
+### 3.5 Locator integration
+
+`agent/adapter/codex/locator.rs` keeps its existing trait, struct shapes,
+and method bodies. The only diff is the import:
+
+```rust
+// before
+use crate::agent::adapter::types::BindContext;
+
+// after
+use super::types::BindContext;
+```
+
+Internal method signatures (`fn resolve_rollout(&self, ctx: &BindContext<'_>)
+-> Result<RolloutLocation, LocatorError>` and the various `pub(super)`
+helpers that take `&BindContext<'_>`) are unchanged because the private
+struct's field shape matches the deleted public type. `LocatorError` is
+unchanged (the trait still distinguishes `NotYetReady` / `Unresolved` /
+`Fatal`; the discrimination is consumed by the new `retry_locator` helper
+above).
+
+The ~30+ test fixtures in `locator.rs::tests` that build a `BindContext`
+literal also keep working with one mechanical edit (the `use` path), since
+field names and types match. Test-module imports use either
+`super::super::types::BindContext` (because from inside `locator.rs::tests`,
+`super` is the `locator` module and `super::super` is `codex`) or the
+fully-qualified `crate::agent::adapter::codex::types::BindContext`.
+The non-test top-of-file `use super::types::BindContext;` (where `super`
+is `codex`) does not apply inside the nested test submodule.
+
+## Tests migration plan
+
+The bind-retry test surface has three buckets after this refactor: tests
+deleted, tests adapted, tests added. Total is roughly net-zero — no
+coverage regression, no new heavy fixtures.
+
+### 4.1 Tests deleted
+
+Two test modules / blocks go away because the symbols they exercise are
+deleted:
+
+- **`agent/adapter/base/mod.rs::start_for_retry_tests`** (lines 103-240,
+  ~138 LOC). The `start_for_retries_on_pending_then_succeeds_under_budget`
+  and `start_for_returns_err_when_pending_budget_exhausted` tests assert
+  retry semantics on `start_for`. After the refactor `start_for` has zero
+  retry code; the assertions become tautological. Equivalent coverage
+  moves to `codex/mod.rs::retry_locator_tests` (Section 4.3).
+- **`agent/adapter/types.rs::display_tests::bind_error_display_pending_format`
+  / `bind_error_display_fatal_format`** (lines 135-145). `BindError` is
+  deleted; its Display impl goes with it. The `ValidateTranscriptError`
+  Display tests in the same module (lines 93-133) stay.
+
+Net deletion: ~2 test modules, ~150 LOC.
+
+### 4.2 Tests adapted
+
+Mechanical sig + literal updates. No assertion changes:
+
+- **`agent/adapter/mod.rs::noop_tests::status_source_uses_claude_shaped_path`**
+  (lines 222-243) — drop the `BindContext` literal; pass `(&cwd, "sid")`
+  to the trait method. Assertions on `src.path` / `src.trust_root`
+  unchanged.
+- **`agent/adapter/claude_code/mod.rs::tests::status_source_returns_claude_path_under_cwd`**
+  (lines 74-96) — same shape edit. Drop the `pid: 0, pty_start: UNIX_EPOCH`
+  filler that no longer has any analog in the new sig.
+- **`agent/adapter/mod.rs::noop_tests::for_type_returns_real_codex_adapter`**
+  (lines 257-267) — renames to `for_attach_returns_real_codex_adapter` and
+  updates the call site to
+  `<dyn AgentAdapter<MockRuntime>>::for_attach(AgentType::Codex, 12345,
+SystemTime::UNIX_EPOCH)`. The `parse_status` round-trip assertion stays
+  unchanged.
+- **`agent/adapter/codex/mod.rs::adapter_tests`** (lines 104-153) — the
+  three existing tests construct `CodexAdapter::new()` and drive
+  `parse_status` / `validate_transcript`. Update construction to
+  `CodexAdapter::new(test_pid, test_pty_start)`. Test pid/pty_start values
+  can be sentinel: `CodexAdapter::new(12345, SystemTime::UNIX_EPOCH)`.
+  No assertion changes — these tests don't exercise `status_source`.
+- **`agent/adapter/codex/locator.rs::tests`** (~30+ tests, the `ctx<'a>`
+  helper at lines 759-770 and 997-1008). The helper builds a
+  `BindContext` literal; only the `use` statement at the top of the test
+  module changes (`use crate::agent::adapter::types::BindContext` →
+  `use super::super::types::BindContext` or equivalent path-relative
+  import). Field shapes are identical so the literal builders compile
+  unchanged.
+- **`agent/adapter/base/transcript_state.rs::replace_on_cwd_change_stops_old_before_spawning_new`'s
+  `OrderingAdapter`** (lines 446-464) — the `unreachable!` mock impl's
+  signature updates from
+  `(&self, _ctx: &BindContext<'_>) -> Result<StatusSource, BindError>`
+  to `(&self, _cwd: &Path, _session_id: &str) -> Result<StatusSource, String>`.
+  Body stays `unreachable!()`.
+
+Net adaptation: ~6 tests + 1 mock-adapter sig + 1 import path. All edits
+are mechanical and lint-checkable.
+
+### 4.3 Tests added
+
+Two new test groups in `agent/adapter/codex/mod.rs`. They cover the retry
+semantics that move out of `base/start_for_retry_tests`, plus the new
+trait-method signature on `CodexAdapter`:
+
+**`retry_locator_tests`** — drives the new `retry_locator` helper directly
+with synthesized closures, no real `CompositeLocator` needed:
+
+```rust
+#[cfg(test)]
+mod retry_locator_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn retries_on_not_yet_ready_then_succeeds() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_locator(|| {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            if n < 3 {
+                Err(LocatorError::NotYetReady)
+            } else {
+                Ok(RolloutLocation {
+                    rollout_path: PathBuf::from("/tmp/rollout.jsonl"),
+                    thread_id: "tid".to_string(),
+                    state_updated_at_ms: 0,
+                })
+            }
+        });
+        assert!(result.is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn returns_err_when_retry_budget_exhausted() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_locator(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LocatorError::NotYetReady)
+        });
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("retry exhausted"));
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            CODEX_BIND_RETRY_MAX_ATTEMPTS as usize,
+        );
+    }
+
+    #[test]
+    fn fatal_short_circuits_immediately() {
+        let calls = AtomicUsize::new(0);
+        let started = std::time::Instant::now();
+        let result = retry_locator(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LocatorError::Fatal("permission denied".to_string()))
+        });
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("codex bind fatal"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        // Generous bound — fatal should not sleep at all, so ~0ms in
+        // practice; 100ms covers loaded-CI scheduler delay.
+        assert!(started.elapsed() < std::time::Duration::from_millis(100));
+    }
+
+    #[test]
+    fn unresolved_short_circuits_immediately() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_locator(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LocatorError::Unresolved("ambiguous candidates".to_string()))
+        });
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("codex bind fatal"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}
+```
+
+Coverage: retry call-count discipline + Pending/Fatal/Unresolved
+discrimination, all without touching the filesystem or constructing a real
+`CompositeLocator`. Wall-clock assertions are dropped from the
+budget-exhaustion tests because scheduler delay on loaded CI runners can
+push 4 × `thread::sleep(100ms)` past tight bounds without a behavior
+regression — call count is the load-bearing assertion, time is incidental.
+The fatal short-circuit keeps a `< 100ms` bound because that path takes
+zero sleeps and a wall-clock check protects against an accidental sleep
+being added to the no-retry branches.
+
+**`status_source_tests`** — covers the new `(cwd, sid)` trait-method
+signature on `CodexAdapter`. Uses `CodexAdapter::with_home` (Section 3.2,
+`#[cfg(test)]` constructor) to inject a tempdir-backed codex home so the
+test isolates from the user's real `~/.codex`:
+
+```rust
+#[cfg(test)]
+mod status_source_tests {
+    use super::*;
+    use tauri::test::MockRuntime;
+
+    /// Seeds a tempdir with the SQLite logs/threads schema + a thread row
+    /// for the given (pid, pty_start) pointing at a writable rollout
+    /// path. Returns the rollout path so the test can assert it.
+    /// Existing helpers in `locator::tests::fixtures` model what to
+    /// reuse / extract into a shared test module here.
+    fn seed_codex_home_with_thread(
+        codex_home: &Path,
+        pid: u32,
+        pty_start: SystemTime,
+    ) -> PathBuf { /* ... */ }
+
+    #[test]
+    fn status_source_returns_resolved_rollout_on_happy_path() {
+        let codex_home = tempfile::tempdir().expect("tempdir");
+        let pty_start = SystemTime::now() - std::time::Duration::from_secs(5);
+        let rollout_path = seed_codex_home_with_thread(
+            codex_home.path(),
+            999,
+            pty_start,
+        );
+
+        let adapter = CodexAdapter::with_home(
+            999,
+            pty_start,
+            codex_home.path().to_path_buf(),
+        );
+        let cwd = codex_home.path().to_path_buf();
+
+        let src = <CodexAdapter as AgentAdapter<MockRuntime>>::status_source(
+            &adapter, &cwd, "sid",
+        )
+        .expect("status_source should resolve");
+
+        assert_eq!(src.path, rollout_path);
+        assert_eq!(src.trust_root, codex_home.path());
+    }
+
+    #[test]
+    fn status_source_returns_err_on_retry_exhausted() {
+        // Empty codex_home → both DB discovery returns Ok(None) → FS
+        // fallback also empty → repeated NotYetReady → retry exhausted.
+        let codex_home = tempfile::tempdir().expect("tempdir");
+        let adapter = CodexAdapter::with_home(
+            999,
+            SystemTime::now(),
+            codex_home.path().to_path_buf(),
+        );
+        let cwd = codex_home.path().to_path_buf();
+
+        let err = <CodexAdapter as AgentAdapter<MockRuntime>>::status_source(
+            &adapter, &cwd, "sid",
+        )
+        .expect_err("empty codex_home should exhaust retry");
+        assert!(err.contains("retry exhausted"), "got: {}", err);
+    }
+}
+```
+
+Net addition: 1 retry helper test module (~80 LOC `retry_locator_tests`) +
+1 trait-method shape test module (~50 LOC `status_source_tests`).
+Counterbalances the deletion of `start_for_retry_tests`.
+
+### 4.4 Coverage target
+
+Per `rules/rust/testing.md` (which inherits the 80% target from
+`rules/common/testing.md`): every new code path needs ≥80% line coverage.
+
+- The `retry_locator` helper is small (~25 LOC); the four `retry_locator_tests`
+  above cover all four exit paths (Ok, NotYetReady-exhaustion, Fatal,
+  Unresolved). Line coverage ≥95%.
+- `CodexAdapter::new(pid, pty_start)` and `with_home(pid, pty_start, codex_home)`
+  are constructors; coverage flows from any test that calls them. `new` is
+  exercised by `adapter_tests` (sentinel-arg construction); `with_home` is
+  exercised by `status_source_tests`.
+- `CodexAdapter::status_source(cwd, sid)` is exercised by the
+  `status_source_tests` above (happy + retry-exhausted). Line coverage ≥80%.
+- The mechanical adapter rewrites in NoOp / Claude have existing tests that
+  cover their bodies; coverage is unaffected.
+
+### 4.5 Manual verification (dev-time, before opening PR)
+
+1. `npm run tauri dev`, open a terminal in the app.
+2. Run `codex` in the PTY → wait one turn → status panel populates within
+   ~1s. Check the dev-tools console for any errors mentioning bind /
+   retry. (No regressions vs. PR #154's manual-verification step.)
+3. Run `codex resume --last` in another fresh terminal → status panel
+   populates immediately from the rolled-up history.
+4. Spawn a third terminal; run `claude` → Claude path unaffected, no cost
+   regressions.
+5. Trigger an artificial bind-fatal (most reliable: chmod 000 ~/.codex
+   temporarily) → verify the frontend stays in the silent-retry loop and
+   does not crash. Restore permissions; the next 2000ms re-poll resolves
+   normally.
+6. Run `cargo test --manifest-path src-tauri/Cargo.toml --package vimeflow
+agent::adapter` (from the repo root) and confirm all listed migrations
+   / additions pass. The `--manifest-path` flag is required because the
+   crate's `Cargo.toml` lives under `src-tauri/`, not at the repo root.
+
+## Documentation changes
+
+The doc trail mirrors the 2026-05-04 scope-expansion ADR pattern: a new
+ADR records the decision and what spec sections it supersedes; the stage-2
+spec is amended in place with an "Amended by" pointer at the top + inline
+supersede notes on the affected sections.
+
+### 5.1 New ADR — `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md`
+
+File added under `docs/decisions/`. Structure follows the dated-record
+template documented at `docs/decisions/CLAUDE.md` (Context → Options →
+Decision → Justification → Alternatives rejected → Known risks →
+References). Concrete outline:
+
+- **Context**: Round-3 review on PR #154 flagged that `BindContext` and the
+  `start_for` retry leak codex-only requirements through the trait
+  surface. Quote the two relevant review threads. Note that this ADR is a
+  partial reversal of decisions made in the 2026-05-03 stage-2 spec, but
+  not of the scope-expansion deviations recorded in the 2026-05-04 ADR
+  (transcript tailer, `/proc` fast-paths, agent-PID bind — those stay).
+- **Options considered**:
+  1. Leave as-is — accept the trait-surface leak.
+  2. Move `pid`/`pty_start` to the codex adapter, but keep the bounded
+     retry in `start_for`. Half-fix.
+  3. Move both pieces into the codex adapter (this spec's choice).
+- **Decision**: Choose option 3.
+- **Justification** (numbered list, drawing on the same arguments as
+  Section 1 of this spec):
+  1. Single-responsibility: the trait describes "what an agent adapter
+     does"; codex's cold-start race is "how the codex adapter does it",
+     not part of the contract.
+  2. Future adapters (Aider, Generic, etc.) shouldn't need to learn about
+     `BindContext` to implement `status_source`.
+  3. The retry budget is calibrated against codex-specific commit
+     timings; it doesn't generalize. Hosting it inside the codex adapter
+     keeps the calibration close to the rationale.
+  4. The change is a pure internal refactor — no IPC, no user-visible
+     behavior change, no scope expansion.
+- **Alternatives rejected**:
+  - Option 1: leaves the leak; round-3 review explicitly called this out
+    as a finding, not a stylistic preference.
+  - Option 2: half-fix. The retry budget still has nowhere coherent to
+    live — `start_for` would still be branching on a Pending/Fatal
+    distinction that only one adapter ever produces.
+- **Known risks & mitigations**:
+  - **Risk:** A second adapter eventually needs the same retry shape and
+    will re-introduce a parallel-but-divergent retry helper. **Mitigation:**
+    the `retry_locator` helper is internal to codex and trivially small;
+    if a second adapter needs the same shape, promote a generic
+    `retry_with_budget` to a shared `agent/adapter/util.rs` at that point,
+    not preemptively.
+  - **Risk:** Sleep-budget tightening from 5 × 100ms to 4 × 100ms is a
+    real behavior change. **Mitigation:** the cold-start window is
+    typically ~300ms (per the 2026-05-04 ADR's `/proc` fast-path
+    rationale), well below 400ms. The exhaustion path is rare in practice.
+- **References**:
+  - Issue #156, PR #154, round-3 threads
+  - 2026-05-03 stage-2 spec
+  - 2026-05-04 scope-expansion ADR
+  - This new spec (2026-05-05 trait simplification)
+
+The ADR is committed in the same PR as the spec (and code), per the
+template at `docs/decisions/CLAUDE.md`.
+
+### 5.2 Stage-2 spec amendment
+
+`docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md` is
+already marked "Implemented (with documented scope expansion)" with an
+"Amended by" line at the top pointing to the 2026-05-04 ADR. Add a second
+"Amended by" line for this refactor:
+
+```diff
+ **Amended by:** `docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md` — the implementation expanded past three of this spec's locked rules (Codex transcript tailer, `/proc`-as-chooser, `BindContext.pid` semantics). Where this spec and that ADR conflict, the ADR wins for those three items only; the rest of this spec stands.
++**Amended further by:** `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md` — the trait signature change at "Architecture > Trait signature change" and the `start_for` retry rules at "Architecture > `start_for` retry loop" are superseded by the new ADR. The codex-adapter-internal retry, the `(cwd, sid)` trait method, and the `for_attach(agent_type, pid, pty_start)` factory replace those rules. Everything else in this spec stands.
+```
+
+Specific spec lines that get inline supersede markers (HTML comments + a
+strikethrough is overkill; a single italic-prefixed sentence works):
+
+- Line ~213 ("Architecture > Trait signature change", showing the
+  `(ctx: &BindContext)` sig): prepend an italicised note: _Superseded by
+  `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md` —
+  the trait method is now `(cwd: &Path, session_id: &str) -> Result<…,
+String>`. The discussion below describes the Stage 2 surface as
+  shipped; current surface is in the new spec._
+- Line ~225 ("Architecture > `start_for` retry loop"): same shape note
+  — _Superseded; the retry now lives inside `CodexAdapter`. `start_for`
+  has zero retry code post-2026-05-05._
+- "File touch list" section's `mod.rs` and `base/mod.rs` rows: append a
+  note that the post-2026-05-05 mechanics differ; the original rows
+  stand for Stage 2's history.
+
+Per `rules/common/coding-style.md`'s "documentation accuracy" pattern (and
+the `docs/reviews/` review-knowledge-base), broken doc references trigger
+LOW-severity review findings; the supersede markers are the cheapest way
+to keep the historical spec text intact while making the current contract
+discoverable.
+
+### 5.3 `src-tauri/src/agent/README.md` updates
+
+The agent module's README documents the current state of the code, so it
+must update alongside the code (unlike the historical CHANGELOG entries
+or the 2026-05-04 ADR/plan, which record what was true at their dates and
+must not be edited). Three line-targeted edits:
+
+- **Line 67** (file-tree comment for `types.rs`):
+  - Current: `├── types.rs             ← StatusSource, ParsedStatus, BindContext, BindError, ValidateTranscriptError`
+  - New: `├── types.rs             ← StatusSource, ParsedStatus, ValidateTranscriptError`
+  - Reason: `BindContext` and `BindError` are deleted from `types.rs`
+    (Section 2.6).
+- **Line 98** (follow-up tracking blockquote):
+  - Current: `> **Follow-up tracking:** issue [#156] collapses BindContext and the central retry into CodexAdapter::new(pid, pty_start)…`
+  - New: `> **Resolved 2026-05-05** by [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`] (issue [#156] / PR #<TBD>): BindContext is now private to codex/, BindError is deleted, the trait method is `(cwd, sid) -> Result<\_, String>`, and codex's cold-start retry lives in CodexAdapter::status_source.`
+  - Reason: this spec is the resolution of that follow-up, so the
+    blockquote shifts from "tracking" to "resolved" once this PR merges.
+- **Line 116** (description of the bind flow):
+  - Current: `…both arguments are passed through to the adapter as fields of BindContext (delegated through base::start_for → resolve_status_source_with_retry → adapter.status_source(&ctx))…`
+  - New: `…both arguments are stored on CodexAdapter at construction (CodexAdapter::new(pid, pty_start)). The codex adapter wraps them in a private BindContext for its locator on each status_source call. base::start_for invokes adapter.status_source(cwd, session_id) once and the codex internal retry lives in retry_locator (5 attempts, 4 × 100ms inter-attempt sleeps, total 400ms sleep budget).`
+  - Reason: factually describes the post-2026-05-05 flow.
+
+Line 11 stays unchanged. It's a pointer to the 2026-05-04 scope-expansion
+ADR; that ADR's mention of `BindContext.pid` semantics is a historical
+deviation record (one of the three Stage 2 spec rules the implementation
+relaxed). The historical mention is still accurate; this spec doesn't
+re-litigate it.
+
+### 5.4 No CHANGELOG entry yet
+
+Per `CHANGELOG.md` / `CHANGELOG.zh-CN.md` convention (one entry per merged
+PR, paired with review patterns), the CHANGELOG entry lands at PR-merge
+time, not at spec-write time. The bilingual entry mirrors the standard
+template:
+
+```
+- **refactor(agent/adapter)**: collapse BindContext + retry into CodexAdapter (#<pr-number>).
+  Trait method is `(cwd, sid) -> Result<_, String>` again; codex's
+  cold-start retry lives inside the adapter. No user-visible change.
+  Spec: `2026-05-05-codex-adapter-trait-simplification-design.md`. ADR:
+  `2026-05-05-codex-adapter-trait-simplification.md`.
+```
+
+The Chinese mirror is added in the same commit. PR template fills in
+`<pr-number>` post-merge.
+
+## Acceptance criteria & file touch list
+
+### 6.1 Acceptance criteria checklist
+
+Reproduces the issue #156 criteria as a verifiable checklist. Each item is
+a build/test/lint pass that gates PR merge:
+
+- [ ] `AgentAdapter::status_source` signature is
+      `fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>`.
+      Verified by `grep -rn 'fn status_source' src-tauri/src/agent/adapter/`
+      showing the new shape across mod.rs, claude_code/mod.rs, codex/mod.rs.
+- [ ] `BindContext` and `BindError` no longer appear in `agent/adapter/types.rs`.
+      Verified by
+      `grep -rn 'BindContext\|BindError' src-tauri/src/ --include='*.rs'`
+      returning matches only inside `agent/adapter/codex/` (the private
+      codex-internal `BindContext`). The `--include='*.rs'` flag scopes the
+      check to source so the README's prose mentions of those former type
+      names (which Section 5.3 rewrites) don't pollute the result.
+- [ ] `base::start_for` body has zero retry/sleep code. Verified by
+      `grep -n 'sleep\|retry\|RETRY' src-tauri/src/agent/adapter/base/mod.rs`
+      returning no matches.
+- [ ] All existing PR #154 functionality preserved:
+  - Codex cold-start still binds within ~500ms (manual-verification step
+    2 in Section 4.5).
+  - Claude's status panel populates the same way (manual-verification
+    step 4).
+  - No IPC bump (`src/bindings/` regeneration produces no diff beyond
+    what the rust struct field names emit).
+- [ ] New ADR `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md`
+      exists and supersedes the relevant sections of the stage-2 spec. Stage-2
+      spec has the `Amended further by:` line at top + inline supersede
+      markers (Section 5.2).
+- [ ] Tests pass: `cargo test --manifest-path src-tauri/Cargo.toml
+agent::adapter`. The `start_for_retry_tests` module no longer exists;
+      `codex/mod.rs::retry_locator_tests` and `status_source_tests` exist and
+      pass.
+- [ ] Lint clean: `cargo clippy --manifest-path src-tauri/Cargo.toml
+--all-targets -- -D warnings` with no unused-import findings.
+
+### 6.2 File touch list
+
+Per `rules/common/coding-style.md`'s "explicit file touch list" pattern
+(also reflected in stage-2 spec's File touch list section). Each row
+answers: "what does this file change implement, per Section X of this
+spec?"
+
+**Backend (Rust) — modified:**
+
+| File                                                   | Change                                                                                                                                                                                                                                                                                                                                                                                                                                       | Section                      |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `src-tauri/src/agent/adapter/types.rs`                 | Delete `BindContext` struct + `BindError` enum + their Display tests                                                                                                                                                                                                                                                                                                                                                                         | 2.6                          |
+| `src-tauri/src/agent/adapter/mod.rs`                   | Trait sig change; rename `for_type` → `for_attach` taking `(agent_type, pid, pty_start)`; `start` drops `pid`/`pty_start` params; `start_agent_watcher` uses new factory; rewrite `NoOpAdapter::status_source`; update tests; import `Path`+`SystemTime` already present                                                                                                                                                                     | 2.1, 2.2, 2.3, 2.5, 2.6, 4.2 |
+| `src-tauri/src/agent/adapter/base/mod.rs`              | Delete `resolve_status_source_with_retry`; delete `BIND_RETRY_*` constants; simplify `start_for` body; delete `start_for_retry_tests` module; clean unused imports                                                                                                                                                                                                                                                                           | 2.4, 4.1                     |
+| `src-tauri/src/agent/adapter/base/transcript_state.rs` | Update `OrderingAdapter` mock `status_source` impl signature only (FQN-style refs)                                                                                                                                                                                                                                                                                                                                                           | 2.7, 4.2                     |
+| `src-tauri/src/agent/adapter/claude_code/mod.rs`       | Trait sig change in impl block; rewrite `status_source` body to use direct `cwd`/`session_id` params; update `status_source_returns_claude_path_under_cwd` test                                                                                                                                                                                                                                                                              | 2.1, 4.2                     |
+| `src-tauri/src/agent/adapter/codex/mod.rs`             | Add `pid`/`pty_start`/`codex_home` fields; `new(pid, pty_start)` + `#[cfg(test)] with_home`; `default_codex_home()` free fn; private `BindContext` import via `use self::types::BindContext`; new `retry_locator` helper + tests; new `status_source_tests`; trait impl uses new sig; locator import gains `RolloutLocation`; existing `adapter_tests` updated to pass sentinel construction args; delete static `Self::codex_home()` method | 3.2, 3.3, 3.4, 4.2, 4.3      |
+| `src-tauri/src/agent/adapter/codex/locator.rs`         | Single import edit: `crate::agent::adapter::types::BindContext` → `super::types::BindContext`. No body changes                                                                                                                                                                                                                                                                                                                               | 3.5, 2.7                     |
+
+**Backend (Rust) — added:**
+
+| File                                         | Purpose                                                               | Section |
+| -------------------------------------------- | --------------------------------------------------------------------- | ------- |
+| `src-tauri/src/agent/adapter/codex/types.rs` | Private `pub(super) struct BindContext` + supporting imports. ~12 LOC | 3.1     |
+
+**Documentation — added:**
+
+| File                                                                             | Purpose   | Section |
+| -------------------------------------------------------------------------------- | --------- | ------- |
+| `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md`                | New ADR   | 5.1     |
+| `docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md` | This spec | n/a     |
+
+**Documentation — modified:**
+
+| File                                                                | Change                                                                                                                                                                                                                                | Section                       |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md` | Add `Amended further by:` line at top; inline supersede notes on the trait-sig and `start_for` retry sections                                                                                                                         | 5.2                           |
+| `docs/decisions/CLAUDE.md`                                          | Append the new ADR to the index table (date, decision title, status `Accepted`)                                                                                                                                                       | n/a (mechanical index update) |
+| `src-tauri/src/agent/README.md`                                     | Lines 67, 98, 116 updated to describe the post-2026-05-05 flow (private codex BindContext; trait method `(cwd, sid)`; CodexAdapter::new takes pid/pty_start). Line 11 stays — the scope-expansion ADR pointer is a historical record. | 5.3                           |
+
+**Historical docs deliberately NOT touched** (the references they carry
+are accurate descriptions of past state):
+
+- `CHANGELOG.md`, `CHANGELOG.zh-CN.md` — Stage 2 entry mentions `BindContext` /
+  `BindError` as part of what shipped at that time. Editing it rewrites
+  history.
+- `docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md` —
+  scope-expansion ADR; its references to `BindContext.pid` describe Stage
+  2's deviation from the spec, not the current code state.
+- `docs/superpowers/plans/2026-05-04-codex-adapter-stage-2.md` — Stage 2
+  implementation plan; its task lists describe what was implemented at
+  that time. The plan-side "Resolved by 2026-05-05" pointer (if any) goes
+  in the new ADR or in this spec's Section 5.2, not by editing the plan.
+
+**Frontend (TypeScript):** none. This refactor is backend-only with no IPC
+shape changes.
+
+**Tests touched:** all enumerated under Section 4 (deleted, adapted,
+added). No new fixture files. No new helper crates.
+
+### 6.3 PR-scope discipline
+
+This refactor is exactly one of the two cases the [PR-scope rule][pr155]
+admits as in-scope: the spec / plan / issue says to do it. The diff
+answers "what does issue #156 say to do?":
+
+- The 7 modified Rust files all implement Sections 2–4 of this spec.
+- The 1 added Rust file (`codex/types.rs`) is named in Section 3.1.
+- The 1 added doc file (the new ADR) is named in Section 5.1 and is
+  required by issue #156's acceptance criteria.
+- The 2 modified doc files are the standard amendment shape from the
+  2026-05-04 ADR pattern.
+
+Out of scope, explicitly listed here so the PR review can rule them out at
+a glance:
+
+- No `cargo fmt` reflows on unrelated files. If the formatter touches
+  files outside the touch list above, those edits go in a separate
+  `chore(fmt):` precursor commit on `main`, not this PR.
+- No drive-by comment polish in `agent/adapter/` or anywhere else. The
+  rationale comment in `start_agent_watcher` (Section 2.5) is the one
+  comment edit this PR does include — it's a forced consequence of
+  moving the retry, not a drive-by.
+- No new dependencies. `tempfile`, `dirs`, `rusqlite` are all already
+  pulled by the existing `codex/` module.
+- No additional refactors that "feel related" — e.g. promoting
+  `LocatorError::Fatal`'s shape to `thiserror`, or unifying the
+  `Result<_, String>` pattern across the adapter trait. Track those as
+  separate follow-up issues if desired.
+
+The pre-PR checklist from PR #155's `pr-scope.md` (sections 1–4) applies
+literally:
+
+1. Re-read this spec's Goal section. Walk the diff. Each file's diff
+   should map to one of the sections above.
+2. `git diff --stat <base>..HEAD`. Files appearing here that aren't in the
+   File touch list above need an explicit answer.
+3. `git diff -w <base>..HEAD --stat` alongside `git diff --stat`.
+   Whitespace-stripped delta should match the regular delta closely; any
+   gap is a formatting drive-by to drop.
+4. Drive-by formatting → separate commit / PR.

--- a/docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md
+++ b/docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md
@@ -492,17 +492,25 @@ use std::time::SystemTime;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct BindContext<'a> {
-    pub(super) session_id: &'a str,
     pub(super) cwd: &'a Path,
     pub(super) pid: u32,
     pub(super) pty_start: SystemTime,
 }
 ```
 
-Field shape and `Copy`/`Clone` semantics match the deleted public type
-verbatim, so `codex/locator.rs` body changes are minimal — only the import
-path moves (`use crate::agent::adapter::types::BindContext` →
-`use super::types::BindContext`).
+Field shape narrows from the deleted public type: `session_id` is dropped
+because the codex locator never reads it (verified via
+`grep -rn 'ctx.session_id\|\.session_id' codex/locator.rs` returning zero
+matches). Carrying it would trigger `cargo clippy --all-targets -- -D
+warnings` to flag dead-code on the field. The trait method still receives
+`session_id`; the codex impl binds it to `_session_id` to mark intentional
+non-use.
+
+`codex/locator.rs` body changes are minimal — only the import path moves
+(`use crate::agent::adapter::types::BindContext` →
+`use super::types::BindContext`). Method signatures still take
+`&BindContext<'_>`; the dropped field is invisible to them because they
+never accessed it.
 
 Visibility is `pub(super)`, restricting the struct to the `codex/` module
 tree. External callers cannot construct or observe it.
@@ -733,10 +741,12 @@ impl<R: tauri::Runtime> AgentAdapter<R> for CodexAdapter {
     fn status_source(
         &self,
         cwd: &Path,
-        session_id: &str,
+        _session_id: &str,
     ) -> Result<StatusSource, String> {
+        // `session_id` is part of the trait contract (Claude / NoOp use it)
+        // but the codex locator never reads it — bind to `_session_id` to
+        // satisfy `-D warnings`.
         let ctx = BindContext {
-            session_id,
             cwd,
             pid: self.pid,
             pty_start: self.pty_start,
@@ -760,7 +770,7 @@ impl<R: tauri::Runtime> AgentAdapter<R> for CodexAdapter {
 
 The `BindContext` constructed inside `status_source` uses the adapter's
 stored `pid`/`pty_start` for the codex-only fields and the trait-method
-params for `cwd`/`session_id`. The `&ctx` reference is captured by the
+`cwd` param for the cwd field. The `&ctx` reference is captured by the
 closure passed to `retry_locator`.
 
 Mutex update of `resolved_rollout_path` happens once on success, identical
@@ -955,7 +965,17 @@ being added to the no-retry branches.
 **`status_source_tests`** — covers the new `(cwd, sid)` trait-method
 signature on `CodexAdapter`. Uses `CodexAdapter::with_home` (Section 3.2,
 `#[cfg(test)]` constructor) to inject a tempdir-backed codex home so the
-test isolates from the user's real `~/.codex`:
+test isolates from the user's real `~/.codex`.
+
+The SQLite seeding helper is **duplicated inline** inside
+`status_source_tests` (~30 LOC) rather than extracted into a shared
+fixtures module. Rationale: only two places need the helper today
+(`locator::tests` and these new `status_source_tests`); a shared module
+would touch one more file (`codex/locator.rs` or a new
+`codex/test_fixtures.rs`) and expand the PR scope. If a third call site
+emerges later, promote the helper at that point. The locator-side tests
+keep their existing private helper unchanged; the adapter-side tests
+carry an inline copy.
 
 ```rust
 #[cfg(test)]
@@ -966,13 +986,17 @@ mod status_source_tests {
     /// Seeds a tempdir with the SQLite logs/threads schema + a thread row
     /// for the given (pid, pty_start) pointing at a writable rollout
     /// path. Returns the rollout path so the test can assert it.
-    /// Existing helpers in `locator::tests::fixtures` model what to
-    /// reuse / extract into a shared test module here.
+    ///
+    /// Inline duplicate of the helper used in `locator::tests`; the two
+    /// copies should stay in sync. If a third call site emerges, promote
+    /// to a shared `codex/test_fixtures.rs` module then.
     fn seed_codex_home_with_thread(
         codex_home: &Path,
         pid: u32,
         pty_start: SystemTime,
-    ) -> PathBuf { /* ... */ }
+    ) -> PathBuf { /* ~30 LOC: open sqlite, create logs+threads tables,
+                       insert a row with thread_id pointing at a fresh
+                       rollout-*.jsonl under codex_home/sessions/... */ }
 
     #[test]
     fn status_source_returns_resolved_rollout_on_happy_path() {
@@ -1314,8 +1338,10 @@ answers "what does issue #156 say to do?":
 - The 1 added Rust file (`codex/types.rs`) is named in Section 3.1.
 - The 1 added doc file (the new ADR) is named in Section 5.1 and is
   required by issue #156's acceptance criteria.
-- The 2 modified doc files are the standard amendment shape from the
-  2026-05-04 ADR pattern.
+- The 3 modified doc files are: the Stage 2 spec (Section 5.2 supersede
+  markers), `docs/decisions/CLAUDE.md` (mechanical index update for the
+  new ADR), and `src-tauri/src/agent/README.md` (Section 5.3 line-targeted
+  updates). All three are forced consequences of the refactor.
 
 Out of scope, explicitly listed here so the PR review can rule them out at
 a glance:

--- a/src-tauri/src/agent/README.md
+++ b/src-tauri/src/agent/README.md
@@ -161,13 +161,13 @@ pub trait AgentAdapter<R: tauri::Runtime>: Send + Sync + 'static {
 
 Each method is a "provider hook" — every concrete adapter implements all five. The trait is generic over `R: tauri::Runtime` so production (`R = Wry`) and `tauri::test::mock_builder()`-driven integration tests (`R = MockRuntime`) share a single contract.
 
-| Hook                  | Returns                             | Responsibility                                                                                         |
-| --------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `agent_type`          | `AgentType`                         | Self-identification — used in logs and event payloads.                                                 |
-| `status_source`       | `Result<StatusSource, String>`      | Where the agent writes its status snapshot, plus the trust root the path must canonicalize under. Failures surface as `Err(String)`. |
-| `parse_status`        | `Result<ParsedStatus, String>`      | Parse one status snapshot into the typed `AgentStatusEvent` IPC payload. Optional transcript path.     |
-| `validate_transcript` | `Result<PathBuf, String>`           | Canonicalize and reject any transcript path outside this provider's trust root.                        |
-| `tail_transcript`     | `Result<TranscriptHandle, String>`  | Spawn the per-line tail loop end-to-end — including in-flight tool-call tracking and `TestRunEmitter`. |
+| Hook                  | Returns                            | Responsibility                                                                                                                       |
+| --------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `agent_type`          | `AgentType`                        | Self-identification — used in logs and event payloads.                                                                               |
+| `status_source`       | `Result<StatusSource, String>`     | Where the agent writes its status snapshot, plus the trust root the path must canonicalize under. Failures surface as `Err(String)`. |
+| `parse_status`        | `Result<ParsedStatus, String>`     | Parse one status snapshot into the typed `AgentStatusEvent` IPC payload. Optional transcript path.                                   |
+| `validate_transcript` | `Result<PathBuf, String>`          | Canonicalize and reject any transcript path outside this provider's trust root.                                                      |
+| `tail_transcript`     | `Result<TranscriptHandle, String>` | Spawn the per-line tail loop end-to-end — including in-flight tool-call tracking and `TestRunEmitter`.                               |
 
 `TranscriptHandle::Drop` only signals stop (sets `stop_flag`); explicit `TranscriptHandle::stop(self)` joins. This matches today's `transcript.rs:94-108` behavior — Stage 1 preserves it.
 

--- a/src-tauri/src/agent/README.md
+++ b/src-tauri/src/agent/README.md
@@ -64,7 +64,7 @@ src-tauri/src/agent/
     │   ├── path_security.rs ← StatusSource trust_root enforcement
     │   ├── transcript_state.rs ← TranscriptState/Handle/StartStatus registry
     │   └── watcher_runtime.rs  ← notify watcher, inline read, polling fallback, WatcherHandle
-    ├── types.rs             ← StatusSource, ParsedStatus, BindContext, BindError, ValidateTranscriptError
+    ├── types.rs             ← StatusSource, ParsedStatus, ValidateTranscriptError
     ├── claude_code/
     │   ├── mod.rs           ← ClaudeCodeAdapter (impl AgentAdapter<R>)
     │   ├── statusline.rs    ← Claude's status.json parser
@@ -83,19 +83,23 @@ src-tauri/src/agent/
 
 Everything outside `agent::adapter::*` interacts with the agent module through three calls — that's it.
 
-### `<dyn AgentAdapter<R>>::for_type`
+### `<dyn AgentAdapter<R>>::for_attach`
 
 ```rust
-pub fn for_type(agent_type: AgentType) -> Result<Arc<Self>, String>
+pub fn for_attach(
+    agent_type: AgentType,
+    pid: u32,
+    pty_start: SystemTime,
+) -> Result<Arc<Self>, String>
 ```
 
 Constructs the right adapter for a detected agent type. Returns `Arc<dyn AgentAdapter<R>>`:
 
-- `AgentType::ClaudeCode` → `ClaudeCodeAdapter`
-- `AgentType::Codex` → `CodexAdapter::new()`
-- everything else → `NoOpAdapter::new(t)` (returns errors from `parse_status` / `validate_transcript` / `tail_transcript`; `status_source` returns a `.vimeflow/sessions/{sid}/status.json` placeholder)
+- `AgentType::ClaudeCode` → `ClaudeCodeAdapter` (`pid`/`pty_start` discarded)
+- `AgentType::Codex` → `CodexAdapter::new(pid, pty_start)`
+- everything else → `NoOpAdapter::new(t)` (returns errors from `parse_status` / `validate_transcript` / `tail_transcript`; `status_source` returns a `.vimeflow/sessions/{sid}/status.json` placeholder; `pid`/`pty_start` discarded)
 
-> **Follow-up tracking:** issue [#156](https://github.com/winoooops/vimeflow/issues/156) collapses `BindContext` and the central retry into `CodexAdapter::new(pid, pty_start)`. After that lands, `for_type` becomes `for_attach(ctx)` and the Claude impl drops the unused `ctx` parameter from `status_source`.
+> **Resolved 2026-05-05** by [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](../../../docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md) (issue [#156](https://github.com/winoooops/vimeflow/issues/156)): `BindContext` is now private to `codex/`, the old bind error type is deleted, the trait method is `status_source(cwd, sid) -> Result<_, String>`, and codex's cold-start retry lives inside `CodexAdapter::status_source` via the `retry_locator` helper.
 
 ### `<dyn AgentAdapter<R>>::start`
 
@@ -105,15 +109,13 @@ pub fn start(
     app: AppHandle<R>,
     session_id: String,
     cwd: PathBuf,
-    pid: u32,
-    pty_start: SystemTime,
     state: AgentWatcherState,
 ) -> Result<(), String>
 ```
 
 Starts the watcher pipeline for a PTY session. **Owns the full lifecycle:** removes any pre-existing handle for `session_id`, logs the active-watcher count, builds the new pipeline, inserts the resulting `WatcherHandle` into `state`. The Tauri command never touches `state` directly — that's the deep-module property.
 
-`pid` is the detected agent PID (returned by `detector::detect_agent`), not the shell PID at the PTY root — Codex's `logs.process_uuid` indexes by the codex child PID. `pty_start` is captured at PTY spawn (`ManagedSession.started_at`) so the logs query can filter out PID-reuse and stale-loaded-thread matches. Both arguments are passed through to the adapter as fields of `BindContext` (delegated through `base::start_for` → `resolve_status_source_with_retry` → `adapter.status_source(&ctx)`). Claude's impl ignores them; Codex's locator depends on them.
+`pid` is the detected agent PID (returned by `detector::detect_agent`), not the shell PID at the PTY root — Codex's `logs.process_uuid` indexes by the codex child PID. `pty_start` is captured at PTY spawn (`ManagedSession.started_at`) so the logs query can filter out PID-reuse and stale-loaded-thread matches. Both arguments are stored on `CodexAdapter` at construction (`CodexAdapter::new(pid, pty_start)` via the `for_attach(agent_type, pid, pty_start)` factory). The codex adapter wraps them in a private `BindContext` for its locator on each `status_source` call. `base::start_for` invokes `adapter.status_source(cwd, session_id)` once and codex's internal retry lives in `retry_locator` (5 attempts, 4 × 100ms inter-attempt sleeps, 400ms sleep budget on full exhaustion). Claude's impl ignores these fields — Claude's `status_source(cwd, sid)` is infallible.
 
 ### `<dyn AgentAdapter<R>>::stop`
 
@@ -144,7 +146,7 @@ Backend re-runs detection (`pty_state.get_pid` + `detector::detect_agent`) so th
 ```rust
 pub trait AgentAdapter<R: tauri::Runtime>: Send + Sync + 'static {
     fn agent_type(&self) -> AgentType;
-    fn status_source(&self, cwd: &Path, session_id: &str) -> StatusSource;
+    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>;
     fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String>;
     fn validate_transcript(&self, raw: &str) -> Result<PathBuf, String>;
     fn tail_transcript(
@@ -162,7 +164,7 @@ Each method is a "provider hook" — every concrete adapter implements all five.
 | Hook                  | Returns                             | Responsibility                                                                                         |
 | --------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `agent_type`          | `AgentType`                         | Self-identification — used in logs and event payloads.                                                 |
-| `status_source`       | `StatusSource { path, trust_root }` | Where the agent writes its status snapshot, plus the trust root the path must canonicalize under.      |
+| `status_source`       | `Result<StatusSource, String>`      | Where the agent writes its status snapshot, plus the trust root the path must canonicalize under. Failures surface as `Err(String)`. |
 | `parse_status`        | `Result<ParsedStatus, String>`      | Parse one status snapshot into the typed `AgentStatusEvent` IPC payload. Optional transcript path.     |
 | `validate_transcript` | `Result<PathBuf, String>`           | Canonicalize and reject any transcript path outside this provider's trust root.                        |
 | `tail_transcript`     | `Result<TranscriptHandle, String>`  | Spawn the per-line tail loop end-to-end — including in-flight tool-call tracking and `TestRunEmitter`. |
@@ -180,11 +182,11 @@ Stateless struct (zero fields). Each hook delegates to a sibling module under `c
 ```rust
 impl<R: tauri::Runtime> AgentAdapter<R> for ClaudeCodeAdapter {
     fn agent_type(&self) -> AgentType { AgentType::ClaudeCode }
-    fn status_source(&self, cwd, sid) -> StatusSource {
-        StatusSource {
+    fn status_source(&self, cwd, sid) -> Result<StatusSource, String> {
+        Ok(StatusSource {
             path: cwd.join(".vimeflow/sessions").join(sid).join("status.json"),
             trust_root: cwd.to_path_buf(),
-        }
+        })
     }
     fn parse_status(&self, sid, raw) -> Result<ParsedStatus, String> {
         statusline::parse_statusline(sid, raw)  // shaped to ParsedStatus
@@ -215,13 +217,13 @@ pub(crate) struct NoOpAdapter {
 
 impl<R: tauri::Runtime> AgentAdapter<R> for NoOpAdapter {
     fn agent_type(&self) -> AgentType { self.agent_type.clone() }
-    fn status_source(&self, cwd, sid) -> StatusSource {
+    fn status_source(&self, cwd, sid) -> Result<StatusSource, String> {
         // Same path Claude uses → watcher's create_dir_all + watch
         // matches today's silent-no-op UX for unsupported agents.
-        StatusSource {
+        Ok(StatusSource {
             path: cwd.join(".vimeflow/sessions").join(sid).join("status.json"),
             trust_root: cwd.to_path_buf(),
-        }
+        })
     }
     fn parse_status(&self, _, _) -> Result<ParsedStatus, String>  { Err("…no status parser".into()) }
     fn validate_transcript(&self, _) -> Result<PathBuf, String>    { Err("…no transcript validator".into()) }
@@ -229,7 +231,7 @@ impl<R: tauri::Runtime> AgentAdapter<R> for NoOpAdapter {
 }
 ```
 
-**Why this exists:** if `for_type` returned `Err` for unsupported variants, the frontend's exit-collapse path (`useAgentStatus.ts:139-154`, gated on `watcherStartedRef.current`) would never run after a Codex / Aider session exits — the panel would stay in `isActive: true` indefinitely. `NoOpAdapter` returns Claude's status path so the watcher starts successfully (no events ever fire because nothing writes to that path under non-Claude agents), `watcherStartedRef.current` flips to `true`, and exit-collapse runs naturally. See spec IDEA "NoOpAdapter for non-Claude agents in for_type" for the full rationale.
+**Why this exists:** if `for_attach` returned `Err` for unsupported variants, the frontend's exit-collapse path (`useAgentStatus.ts:139-154`, gated on `watcherStartedRef.current`) would never run after a Codex / Aider session exits — the panel would stay in `isActive: true` indefinitely. `NoOpAdapter` returns Claude's status path so the watcher starts successfully (no events ever fire because nothing writes to that path under non-Claude agents), `watcherStartedRef.current` flips to `true`, and exit-collapse runs naturally. See spec IDEA "NoOpAdapter for non-Claude agents in for_attach" for the full rationale.
 
 ---
 
@@ -397,7 +399,7 @@ Full rationale and rejected alternatives in [`docs/decisions/2026-05-03-claude-p
 
 ## Detection (agent-agnostic)
 
-`detector.rs` is shared across every adapter — it inspects the PTY process tree and matches the bare binary name (`claude`, `codex`, `aider`) against `AgentType` variants. No adapter-specific logic; the result feeds `<dyn AgentAdapter<R>>::for_type`.
+`detector.rs` is shared across every adapter — it inspects the PTY process tree and matches the bare binary name (`claude`, `codex`, `aider`) against `AgentType` variants. No adapter-specific logic; the result feeds `<dyn AgentAdapter<R>>::for_attach`.
 
 `commands.rs::detect_agent_in_session` is the Tauri command the frontend polls every 2s.
 

--- a/src-tauri/src/agent/adapter/base/mod.rs
+++ b/src-tauri/src/agent/adapter/base/mod.rs
@@ -12,28 +12,20 @@ mod watcher_runtime;
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
-use crate::agent::adapter::types::{BindContext, BindError, StatusSource};
 use crate::agent::adapter::AgentAdapter;
 
 pub use transcript_state::{TranscriptHandle, TranscriptStartStatus, TranscriptState};
 pub use watcher_runtime::{AgentWatcherState, WatcherHandle};
-
-const BIND_RETRY_INTERVAL_MS: u64 = 100;
-const BIND_RETRY_MAX_ATTEMPTS: u32 = 5;
 
 pub(crate) fn start_for<R: tauri::Runtime>(
     adapter: Arc<dyn AgentAdapter<R>>,
     app_handle: tauri::AppHandle<R>,
     session_id: String,
     cwd: PathBuf,
-    pid: u32,
-    pty_start: std::time::SystemTime,
     state: AgentWatcherState,
 ) -> Result<(), String> {
-    let source =
-        resolve_status_source_with_retry(adapter.as_ref(), &session_id, &cwd, pid, pty_start)?;
+    let source = adapter.status_source(&cwd, &session_id)?;
     path_security::ensure_status_source_under_trust_root(&source.path, &source.trust_root)?;
 
     log::debug!(
@@ -60,181 +52,4 @@ pub(crate) fn start_for<R: tauri::Runtime>(
     state.insert(session_id, handle);
 
     Ok(())
-}
-
-fn resolve_status_source_with_retry<R: tauri::Runtime>(
-    adapter: &dyn AgentAdapter<R>,
-    session_id: &str,
-    cwd: &std::path::Path,
-    pid: u32,
-    pty_start: std::time::SystemTime,
-) -> Result<StatusSource, String> {
-    let ctx = BindContext {
-        session_id,
-        cwd,
-        pid,
-        pty_start,
-    };
-    let started = Instant::now();
-    let mut last_err: Option<BindError> = None;
-
-    for _ in 0..BIND_RETRY_MAX_ATTEMPTS {
-        match adapter.status_source(&ctx) {
-            Ok(source) => return Ok(source),
-            Err(BindError::Fatal(reason)) => return Err(format!("bind fatal: {}", reason)),
-            Err(pending @ BindError::Pending(_)) => {
-                last_err = Some(pending);
-                std::thread::sleep(Duration::from_millis(BIND_RETRY_INTERVAL_MS));
-            }
-        }
-    }
-
-    log::warn!(
-        "start_for: bind retry budget exhausted for session={} (elapsed={:?})",
-        session_id,
-        started.elapsed()
-    );
-
-    Err(last_err
-        .unwrap_or_else(|| BindError::Pending("no attempts".to_string()))
-        .to_string())
-}
-
-#[cfg(test)]
-mod start_for_retry_tests {
-    use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::time::SystemTime;
-    use tauri::test::{mock_builder, MockRuntime};
-    use tauri::AppHandle;
-
-    use crate::agent::adapter::types::{ParsedStatus, ValidateTranscriptError};
-
-    struct PendingThenOkAdapter {
-        calls: AtomicUsize,
-        flip_after: usize,
-        path: PathBuf,
-    }
-
-    impl AgentAdapter<MockRuntime> for PendingThenOkAdapter {
-        fn agent_type(&self) -> crate::agent::types::AgentType {
-            crate::agent::types::AgentType::Codex
-        }
-
-        fn status_source(&self, _ctx: &BindContext<'_>) -> Result<StatusSource, BindError> {
-            let n = self.calls.fetch_add(1, Ordering::SeqCst);
-            if n < self.flip_after {
-                Err(BindError::Pending(format!("attempt {}", n)))
-            } else {
-                Ok(StatusSource {
-                    path: self.path.clone(),
-                    trust_root: self.path.parent().expect("status parent").to_path_buf(),
-                })
-            }
-        }
-
-        fn parse_status(&self, _: &str, _: &str) -> Result<ParsedStatus, String> {
-            Err("not used".to_string())
-        }
-
-        fn validate_transcript(&self, _: &str) -> Result<PathBuf, ValidateTranscriptError> {
-            Err(ValidateTranscriptError::Other("not used".to_string()))
-        }
-
-        fn tail_transcript(
-            &self,
-            _: AppHandle<MockRuntime>,
-            _: String,
-            _: Option<PathBuf>,
-            _: PathBuf,
-        ) -> Result<TranscriptHandle, String> {
-            Err("not used".to_string())
-        }
-    }
-
-    #[test]
-    fn start_for_retries_on_pending_then_succeeds_under_budget() {
-        let app = mock_builder()
-            .manage(crate::terminal::PtyState::new())
-            .manage(TranscriptState::new())
-            .build(tauri::generate_context!())
-            .expect("mock app build");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("rollout.jsonl");
-        std::fs::write(&path, "").expect("seed status file");
-
-        let adapter: Arc<dyn AgentAdapter<MockRuntime>> = Arc::new(PendingThenOkAdapter {
-            calls: AtomicUsize::new(0),
-            flip_after: 3,
-            path,
-        });
-
-        let state = AgentWatcherState::new();
-        let started = Instant::now();
-        let result = start_for(
-            adapter,
-            app.handle().clone(),
-            "test-sid".to_string(),
-            dir.path().to_path_buf(),
-            12345,
-            SystemTime::now(),
-            state,
-        );
-        let elapsed = started.elapsed();
-
-        assert!(
-            result.is_ok(),
-            "start_for should succeed after retries: {:?}",
-            result
-        );
-        assert!(
-            elapsed < Duration::from_millis(900),
-            "retry budget exceeded: {:?}",
-            elapsed
-        );
-    }
-
-    #[test]
-    fn start_for_returns_err_when_pending_budget_exhausted() {
-        let app = mock_builder()
-            .manage(crate::terminal::PtyState::new())
-            .manage(TranscriptState::new())
-            .build(tauri::generate_context!())
-            .expect("mock app build");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("rollout.jsonl");
-        std::fs::write(&path, "").expect("seed status file");
-
-        let adapter: Arc<dyn AgentAdapter<MockRuntime>> = Arc::new(PendingThenOkAdapter {
-            calls: AtomicUsize::new(0),
-            flip_after: usize::MAX,
-            path,
-        });
-
-        let state = AgentWatcherState::new();
-        let started = Instant::now();
-        let result = start_for(
-            adapter,
-            app.handle().clone(),
-            "exhausted-sid".to_string(),
-            dir.path().to_path_buf(),
-            12345,
-            SystemTime::now(),
-            state,
-        );
-        let elapsed = started.elapsed();
-
-        assert!(result.is_err(), "expected Err on exhausted retries");
-        assert!(
-            result
-                .expect_err("bind should fail after exhausted retries")
-                .contains("bind pending"),
-            "error string should mention bind pending"
-        );
-        assert!(
-            elapsed < Duration::from_millis(900),
-            "retry budget exceeded on exhaustion path: {:?}",
-            elapsed
-        );
-    }
 }

--- a/src-tauri/src/agent/adapter/base/transcript_state.rs
+++ b/src-tauri/src/agent/adapter/base/transcript_state.rs
@@ -455,11 +455,9 @@ mod tests {
 
             fn status_source(
                 &self,
-                _ctx: &crate::agent::adapter::types::BindContext<'_>,
-            ) -> Result<
-                crate::agent::adapter::types::StatusSource,
-                crate::agent::adapter::types::BindError,
-            > {
+                _cwd: &std::path::Path,
+                _session_id: &str,
+            ) -> Result<crate::agent::adapter::types::StatusSource, String> {
                 unreachable!("status_source not exercised in this test")
             }
 

--- a/src-tauri/src/agent/adapter/claude_code/mod.rs
+++ b/src-tauri/src/agent/adapter/claude_code/mod.rs
@@ -1,13 +1,11 @@
 //! Claude Code adapter implementation.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tauri::AppHandle;
 
 use crate::agent::adapter::base::TranscriptHandle;
-use crate::agent::adapter::types::{
-    BindContext, BindError, ParsedStatus, StatusSource, ValidateTranscriptError,
-};
+use crate::agent::adapter::types::{ParsedStatus, StatusSource, ValidateTranscriptError};
 use crate::agent::adapter::AgentAdapter;
 use crate::agent::types::AgentType;
 
@@ -22,15 +20,14 @@ impl<R: tauri::Runtime> AgentAdapter<R> for ClaudeCodeAdapter {
         AgentType::ClaudeCode
     }
 
-    fn status_source(&self, ctx: &BindContext<'_>) -> Result<StatusSource, BindError> {
+    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String> {
         Ok(StatusSource {
-            path: ctx
-                .cwd
+            path: cwd
                 .join(".vimeflow")
                 .join("sessions")
-                .join(ctx.session_id)
+                .join(session_id)
                 .join("status.json"),
-            trust_root: ctx.cwd.to_path_buf(),
+            trust_root: cwd.to_path_buf(),
         })
     }
 
@@ -73,18 +70,12 @@ mod tests {
 
     #[test]
     fn status_source_returns_claude_path_under_cwd() {
-        use std::time::SystemTime;
-
         let adapter = ClaudeCodeAdapter;
         let cwd = PathBuf::from("/tmp/ws");
-        let ctx = BindContext {
-            session_id: "sess-1",
-            cwd: &cwd,
-            pid: 0,
-            pty_start: SystemTime::UNIX_EPOCH,
-        };
-        let src = <ClaudeCodeAdapter as AgentAdapter<MockRuntime>>::status_source(&adapter, &ctx)
-            .expect("claude status source is infallible");
+        let src = <ClaudeCodeAdapter as AgentAdapter<MockRuntime>>::status_source(
+            &adapter, &cwd, "sess-1",
+        )
+        .expect("claude status source is infallible");
         assert_eq!(
             src.path,
             cwd.join(".vimeflow")

--- a/src-tauri/src/agent/adapter/codex/locator.rs
+++ b/src-tauri/src/agent/adapter/codex/locator.rs
@@ -1,6 +1,6 @@
 //! Codex session locator.
 
-use crate::agent::adapter::types::BindContext;
+use super::types::BindContext;
 use chrono::{Datelike, Duration as ChronoDuration, Local};
 use rusqlite::{named_params, Connection, OpenFlags};
 use serde_json::Value;
@@ -758,7 +758,6 @@ mod sqlite_first_tests {
 
     fn ctx<'a>(cwd: &'a Path, pid: u32, pty_start: SystemTime) -> BindContext<'a> {
         BindContext {
-            session_id: "sid-test",
             cwd,
             pid,
             pty_start,
@@ -996,7 +995,6 @@ mod fs_fallback_tests {
 
     fn ctx<'a>(cwd: &'a Path, pty_start: SystemTime) -> BindContext<'a> {
         BindContext {
-            session_id: "sid",
             cwd,
             pid: 0,
             pty_start,

--- a/src-tauri/src/agent/adapter/codex/mod.rs
+++ b/src-tauri/src/agent/adapter/codex/mod.rs
@@ -3,29 +3,50 @@
 mod locator;
 mod parser;
 mod transcript;
+mod types;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
 
 use tauri::AppHandle;
 
 use crate::agent::adapter::base::TranscriptHandle;
-use crate::agent::adapter::types::{
-    BindContext, BindError, ParsedStatus, StatusSource, ValidateTranscriptError,
-};
+use crate::agent::adapter::types::{ParsedStatus, StatusSource, ValidateTranscriptError};
 use crate::agent::adapter::AgentAdapter;
 use crate::agent::types::AgentType;
 
-use self::locator::{CodexSessionLocator, CompositeLocator, LocatorError};
+use self::locator::{CodexSessionLocator, CompositeLocator, LocatorError, RolloutLocation};
+use self::types::BindContext;
+
+const CODEX_BIND_RETRY_INTERVAL_MS: u64 = 100;
+const CODEX_BIND_RETRY_MAX_ATTEMPTS: u32 = 5;
 
 pub struct CodexAdapter {
+    pid: u32,
+    pty_start: SystemTime,
+    codex_home: PathBuf,
     locator_cache: OnceLock<CompositeLocator>,
     resolved_rollout_path: Mutex<Option<PathBuf>>,
 }
 
 impl CodexAdapter {
-    pub fn new() -> Self {
+    pub fn new(pid: u32, pty_start: SystemTime) -> Self {
         Self {
+            pid,
+            pty_start,
+            codex_home: default_codex_home(),
+            locator_cache: OnceLock::new(),
+            resolved_rollout_path: Mutex::new(None),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_home(pid: u32, pty_start: SystemTime, codex_home: PathBuf) -> Self {
+        Self {
+            pid,
+            pty_start,
+            codex_home,
             locator_cache: OnceLock::new(),
             resolved_rollout_path: Mutex::new(None),
         }
@@ -33,20 +54,19 @@ impl CodexAdapter {
 
     fn locator(&self) -> &CompositeLocator {
         self.locator_cache.get_or_init(|| {
-            let codex_home = Self::codex_home();
             log::info!(
                 "codex adapter: locator cache initialized (codex_home={})",
-                codex_home.display()
+                self.codex_home.display()
             );
-            CompositeLocator::new(codex_home)
+            CompositeLocator::new(self.codex_home.clone())
         })
     }
+}
 
-    fn codex_home() -> PathBuf {
-        dirs::home_dir()
-            .map(|home| home.join(".codex"))
-            .unwrap_or_else(|| PathBuf::from(".codex"))
-    }
+fn default_codex_home() -> PathBuf {
+    dirs::home_dir()
+        .map(|home| home.join(".codex"))
+        .unwrap_or_else(|| PathBuf::from(".codex"))
 }
 
 impl<R: tauri::Runtime> AgentAdapter<R> for CodexAdapter {
@@ -54,26 +74,23 @@ impl<R: tauri::Runtime> AgentAdapter<R> for CodexAdapter {
         AgentType::Codex
     }
 
-    fn status_source(&self, ctx: &BindContext<'_>) -> Result<StatusSource, BindError> {
-        match self.locator().resolve_rollout(ctx) {
-            Ok(location) => {
-                let rollout_path = location.rollout_path;
-                if let Ok(mut slot) = self.resolved_rollout_path.lock() {
-                    *slot = Some(rollout_path.clone());
-                }
+    fn status_source(&self, cwd: &Path, _session_id: &str) -> Result<StatusSource, String> {
+        let ctx = BindContext {
+            cwd,
+            pid: self.pid,
+            pty_start: self.pty_start,
+        };
 
-                Ok(StatusSource {
-                    path: rollout_path,
-                    trust_root: Self::codex_home(),
-                })
-            }
-            Err(LocatorError::NotYetReady) => Err(BindError::Pending(
-                "codex session row not yet committed".to_string(),
-            )),
-            Err(LocatorError::Unresolved(reason)) | Err(LocatorError::Fatal(reason)) => {
-                Err(BindError::Fatal(reason))
-            }
+        let location = retry_locator(|| self.locator().resolve_rollout(&ctx))?;
+
+        if let Ok(mut slot) = self.resolved_rollout_path.lock() {
+            *slot = Some(location.rollout_path.clone());
         }
+
+        Ok(StatusSource {
+            path: location.rollout_path,
+            trust_root: self.codex_home.clone(),
+        })
     }
 
     fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String> {
@@ -101,14 +118,48 @@ impl<R: tauri::Runtime> AgentAdapter<R> for CodexAdapter {
     }
 }
 
+/// Retry a codex locator resolution up to the bind budget.
+fn retry_locator<F>(mut resolve: F) -> Result<RolloutLocation, String>
+where
+    F: FnMut() -> Result<RolloutLocation, LocatorError>,
+{
+    let started = std::time::Instant::now();
+    let mut last_reason = String::from("no attempts");
+
+    for attempt in 0..CODEX_BIND_RETRY_MAX_ATTEMPTS {
+        match resolve() {
+            Ok(location) => return Ok(location),
+            Err(LocatorError::NotYetReady) => {
+                last_reason = format!("not yet ready (attempt {})", attempt + 1);
+                if attempt + 1 < CODEX_BIND_RETRY_MAX_ATTEMPTS {
+                    std::thread::sleep(std::time::Duration::from_millis(
+                        CODEX_BIND_RETRY_INTERVAL_MS,
+                    ));
+                }
+            }
+            Err(LocatorError::Unresolved(reason)) | Err(LocatorError::Fatal(reason)) => {
+                return Err(format!("codex bind fatal: {}", reason));
+            }
+        }
+    }
+
+    log::warn!(
+        "codex bind retry exhausted after {} attempts (elapsed={:?})",
+        CODEX_BIND_RETRY_MAX_ATTEMPTS,
+        started.elapsed()
+    );
+    Err(format!("codex bind retry exhausted: {}", last_reason))
+}
+
 #[cfg(test)]
 mod adapter_tests {
     use super::*;
+    use std::time::SystemTime;
     use tauri::test::MockRuntime;
 
     #[test]
     fn parse_status_delegates_to_parser_with_transcript_path_none() {
-        let adapter = CodexAdapter::new();
+        let adapter = CodexAdapter::new(12345, SystemTime::UNIX_EPOCH);
         let raw = r#"{"timestamp":"...","type":"session_meta","payload":{"id":"sess","cli_version":"0.128.0"}}
 "#;
         let parsed =
@@ -121,7 +172,7 @@ mod adapter_tests {
 
     #[test]
     fn parse_status_includes_resolved_rollout_path_when_available() {
-        let adapter = CodexAdapter::new();
+        let adapter = CodexAdapter::new(12345, SystemTime::UNIX_EPOCH);
         {
             let mut slot = adapter
                 .resolved_rollout_path
@@ -144,11 +195,193 @@ mod adapter_tests {
 
     #[test]
     fn validate_transcript_rejects_outside_codex_root() {
-        let adapter = CodexAdapter::new();
+        let adapter = CodexAdapter::new(12345, SystemTime::UNIX_EPOCH);
         assert!(
             <CodexAdapter as AgentAdapter<MockRuntime>>::validate_transcript(&adapter, "/tmp/t")
                 .is_err(),
             "path outside ~/.codex should be rejected"
         );
+    }
+}
+
+#[cfg(test)]
+mod retry_locator_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn retries_on_not_yet_ready_then_succeeds() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_locator(|| {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            if n < 3 {
+                Err(LocatorError::NotYetReady)
+            } else {
+                Ok(RolloutLocation {
+                    rollout_path: PathBuf::from("/tmp/rollout.jsonl"),
+                    thread_id: "tid".to_string(),
+                    state_updated_at_ms: 0,
+                })
+            }
+        });
+
+        assert!(
+            result.is_ok(),
+            "expected Ok after 4th attempt: {:?}",
+            result
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn returns_err_when_retry_budget_exhausted() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_locator(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LocatorError::NotYetReady)
+        });
+
+        assert!(result.is_err());
+        assert!(
+            result.as_ref().unwrap_err().contains("retry exhausted"),
+            "expected 'retry exhausted' in: {:?}",
+            result
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            CODEX_BIND_RETRY_MAX_ATTEMPTS as usize,
+        );
+    }
+
+    #[test]
+    fn fatal_short_circuits_immediately() {
+        let calls = AtomicUsize::new(0);
+        let started = std::time::Instant::now();
+        let result = retry_locator(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LocatorError::Fatal("permission denied".to_string()))
+        });
+
+        assert!(result.is_err());
+        assert!(result.as_ref().unwrap_err().contains("codex bind fatal"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(100),
+            "fatal should short-circuit: elapsed {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn unresolved_short_circuits_immediately() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_locator(|| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LocatorError::Unresolved("ambiguous candidates".to_string()))
+        });
+
+        assert!(result.is_err());
+        assert!(result.as_ref().unwrap_err().contains("codex bind fatal"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[cfg(test)]
+mod status_source_tests {
+    use super::*;
+    use rusqlite::{params, Connection};
+    use std::time::{Duration, SystemTime};
+    use tauri::test::MockRuntime;
+
+    fn seed_codex_home_with_thread(codex_home: &Path, pid: u32, pty_start: SystemTime) -> PathBuf {
+        let rollout_path = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("05")
+            .join(format!("rollout-{}.jsonl", pid));
+        std::fs::create_dir_all(rollout_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&rollout_path, b"").expect("seed empty rollout");
+
+        let since_epoch = pty_start
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("pty_start after epoch");
+        let secs = since_epoch.as_secs() as i64;
+        let nanos = since_epoch.subsec_nanos() as i64;
+
+        let logs = Connection::open(codex_home.join("logs.sqlite")).expect("open logs db");
+        logs.execute_batch(
+            "CREATE TABLE logs (
+                id INTEGER PRIMARY KEY,
+                ts INTEGER NOT NULL,
+                ts_nanos INTEGER NOT NULL,
+                level TEXT,
+                target TEXT,
+                process_uuid TEXT NOT NULL,
+                thread_id TEXT
+            );
+            CREATE INDEX idx_logs_ts ON logs(ts DESC, ts_nanos DESC, id DESC);",
+        )
+        .expect("logs schema");
+        logs.execute(
+            "INSERT INTO logs (ts, ts_nanos, level, target, process_uuid, thread_id)
+             VALUES (?1, ?2, 'INFO', 'test', ?3, ?4)",
+            params![secs + 1, nanos, format!("pid:{}:abc", pid), "tid-test"],
+        )
+        .expect("insert log row");
+
+        let state = Connection::open(codex_home.join("state.sqlite")).expect("open state db");
+        state
+            .execute_batch(
+                "CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    rollout_path TEXT NOT NULL,
+                    cwd TEXT,
+                    updated_at_ms INTEGER NOT NULL
+                );",
+            )
+            .expect("threads schema");
+        state
+            .execute(
+                "INSERT INTO threads (id, rollout_path, cwd, updated_at_ms)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    "tid-test",
+                    rollout_path.to_str().expect("utf-8 path"),
+                    codex_home.to_str().expect("utf-8 home"),
+                    secs * 1000 + nanos / 1_000_000,
+                ],
+            )
+            .expect("insert thread row");
+
+        rollout_path
+    }
+
+    #[test]
+    fn status_source_returns_resolved_rollout_on_happy_path() {
+        let codex_home = tempfile::tempdir().expect("tempdir");
+        let pty_start = SystemTime::now() - Duration::from_secs(5);
+        let rollout_path = seed_codex_home_with_thread(codex_home.path(), 999, pty_start);
+
+        let adapter = CodexAdapter::with_home(999, pty_start, codex_home.path().to_path_buf());
+        let cwd = codex_home.path().to_path_buf();
+
+        let src = <CodexAdapter as AgentAdapter<MockRuntime>>::status_source(&adapter, &cwd, "sid")
+            .expect("status_source should resolve");
+
+        assert_eq!(src.path, rollout_path);
+        assert_eq!(src.trust_root, codex_home.path());
+    }
+
+    #[test]
+    fn status_source_returns_err_on_retry_exhausted() {
+        let codex_home = tempfile::tempdir().expect("tempdir");
+        let adapter =
+            CodexAdapter::with_home(999, SystemTime::now(), codex_home.path().to_path_buf());
+        let cwd = codex_home.path().to_path_buf();
+
+        let err = <CodexAdapter as AgentAdapter<MockRuntime>>::status_source(&adapter, &cwd, "sid")
+            .expect_err("empty codex_home should exhaust retry");
+        assert!(err.contains("retry exhausted"), "got: {}", err);
     }
 }

--- a/src-tauri/src/agent/adapter/codex/types.rs
+++ b/src-tauri/src/agent/adapter/codex/types.rs
@@ -1,0 +1,18 @@
+//! Private codex-internal types. Visibility intentionally `pub(super)` so
+//! these types do not leak through the `AgentAdapter` trait surface.
+
+use std::path::Path;
+use std::time::SystemTime;
+
+/// Bag of attach-time facts the codex locator needs. Built fresh on each
+/// `status_source` call from the adapter's stored `pid`/`pty_start` plus
+/// the trait method's `cwd` parameter.
+///
+/// Note: `session_id` is intentionally not a field. The codex locator gates
+/// queries by `pid` + `pty_start` + `cwd` only.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct BindContext<'a> {
+    pub(super) cwd: &'a Path,
+    pub(super) pid: u32,
+    pub(super) pty_start: SystemTime,
+}

--- a/src-tauri/src/agent/adapter/mod.rs
+++ b/src-tauri/src/agent/adapter/mod.rs
@@ -9,7 +9,7 @@ pub mod claude_code;
 pub mod codex;
 pub mod types;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -24,13 +24,13 @@ use crate::terminal::PtyState;
 use base::TranscriptHandle;
 use claude_code::ClaudeCodeAdapter;
 use codex::CodexAdapter;
-use types::{BindContext, BindError, ParsedStatus, StatusSource, ValidateTranscriptError};
+use types::{ParsedStatus, StatusSource, ValidateTranscriptError};
 
 /// Provider hooks for one CLI coding agent.
 pub trait AgentAdapter<R: tauri::Runtime>: Send + Sync + 'static {
     fn agent_type(&self) -> AgentType;
 
-    fn status_source(&self, ctx: &BindContext<'_>) -> Result<StatusSource, BindError>;
+    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>;
 
     fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String>;
 
@@ -46,10 +46,14 @@ pub trait AgentAdapter<R: tauri::Runtime>: Send + Sync + 'static {
 }
 
 impl<R: tauri::Runtime> dyn AgentAdapter<R> {
-    pub fn for_type(agent_type: AgentType) -> Result<Arc<Self>, String> {
+    pub fn for_attach(
+        agent_type: AgentType,
+        pid: u32,
+        pty_start: SystemTime,
+    ) -> Result<Arc<Self>, String> {
         match agent_type {
             AgentType::ClaudeCode => Ok(Arc::new(ClaudeCodeAdapter)),
-            AgentType::Codex => Ok(Arc::new(CodexAdapter::new())),
+            AgentType::Codex => Ok(Arc::new(CodexAdapter::new(pid, pty_start))),
             other => Ok(Arc::new(NoOpAdapter::new(other))),
         }
     }
@@ -59,11 +63,9 @@ impl<R: tauri::Runtime> dyn AgentAdapter<R> {
         app: AppHandle<R>,
         session_id: String,
         cwd: PathBuf,
-        pid: u32,
-        pty_start: SystemTime,
         state: AgentWatcherState,
     ) -> Result<(), String> {
-        base::start_for(self, app, session_id, cwd, pid, pty_start, state)
+        base::start_for(self, app, session_id, cwd, state)
     }
 
     pub fn stop(state: &AgentWatcherState, session_id: &str) -> bool {
@@ -87,15 +89,14 @@ impl<R: tauri::Runtime> AgentAdapter<R> for NoOpAdapter {
         self.agent_type.clone()
     }
 
-    fn status_source(&self, ctx: &BindContext<'_>) -> Result<StatusSource, BindError> {
+    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String> {
         Ok(StatusSource {
-            path: ctx
-                .cwd
+            path: cwd
                 .join(".vimeflow")
                 .join("sessions")
-                .join(ctx.session_id)
+                .join(session_id)
                 .join("status.json"),
-            trust_root: ctx.cwd.to_path_buf(),
+            trust_root: cwd.to_path_buf(),
         })
     }
 
@@ -138,26 +139,21 @@ pub async fn start_agent_watcher(
     let (cwd, _shell_pid, pty_start, agent_type, agent_pid) =
         resolve_bind_inputs(&pty_state, &session_id, detect_agent)?;
 
-    let adapter = <dyn AgentAdapter<tauri::Wry>>::for_type(agent_type)?;
+    let adapter = <dyn AgentAdapter<tauri::Wry>>::for_attach(agent_type, agent_pid, pty_start)?;
     let owned_state = (*state).clone();
     let cwd_path = PathBuf::from(cwd);
     // `adapter.start(...)` walks into `base::start_for`, which calls
-    // `resolve_status_source_with_retry`. The retry uses
-    // `std::thread::sleep` (up to 5 × 100 ms = 500 ms) and
+    // `adapter.status_source(...)`. For codex sessions, that call runs a
+    // bounded retry (up to 5 attempts × 100 ms inter-attempt sleeps)
+    // using `std::thread::sleep` because codex commits its `logs` row
+    // ~300ms after the rollout file opens.
     // `path_security::ensure_status_source_under_trust_root` does
-    // synchronous `canonicalize` filesystem I/O. Running that on a
+    // synchronous `canonicalize` filesystem I/O. Running either on a
     // tokio worker thread starves other futures scheduled on the same
     // worker; mirror the pattern at `src/git/watcher.rs:399` and hop
     // onto the blocking pool so the async thread returns immediately.
     tokio::task::spawn_blocking(move || {
-        adapter.start(
-            app_handle,
-            session_id,
-            cwd_path,
-            agent_pid,
-            pty_start,
-            owned_state,
-        )
+        adapter.start(app_handle, session_id, cwd_path, owned_state)
     })
     .await
     .map_err(|e| format!("start_agent_watcher task panicked: {}", e))?
@@ -222,17 +218,9 @@ mod noop_tests {
 
     #[test]
     fn status_source_uses_claude_shaped_path() {
-        use std::time::SystemTime;
-
         let adapter = NoOpAdapter::new(AgentType::Aider);
         let cwd = PathBuf::from("/tmp/ws");
-        let ctx = BindContext {
-            session_id: "sid",
-            cwd: &cwd,
-            pid: 0,
-            pty_start: SystemTime::UNIX_EPOCH,
-        };
-        let src = <NoOpAdapter as AgentAdapter<MockRuntime>>::status_source(&adapter, &ctx)
+        let src = <NoOpAdapter as AgentAdapter<MockRuntime>>::status_source(&adapter, &cwd, "sid")
             .expect("noop adapter always resolves a status source");
         assert_eq!(
             src.path,
@@ -254,9 +242,13 @@ mod noop_tests {
     }
 
     #[test]
-    fn for_type_returns_real_codex_adapter() {
-        let adapter = <dyn AgentAdapter<MockRuntime>>::for_type(AgentType::Codex)
-            .expect("codex adapter should construct");
+    fn for_attach_returns_real_codex_adapter() {
+        let adapter = <dyn AgentAdapter<MockRuntime>>::for_attach(
+            AgentType::Codex,
+            12345,
+            SystemTime::UNIX_EPOCH,
+        )
+        .expect("codex adapter should construct");
         let raw = r#"{"timestamp":"...","type":"session_meta","payload":{"id":"sess","cli_version":"0.128.0"}}
 "#;
 

--- a/src-tauri/src/agent/adapter/types.rs
+++ b/src-tauri/src/agent/adapter/types.rs
@@ -1,7 +1,6 @@
 //! Provider-hook types used by `AgentAdapter` implementations.
 
-use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::path::PathBuf;
 
 use crate::agent::types::AgentStatusEvent;
 
@@ -16,31 +15,6 @@ pub struct ParsedStatus {
     pub event: AgentStatusEvent,
     pub transcript_path: Option<String>,
 }
-
-#[derive(Debug, Clone, Copy)]
-pub struct BindContext<'a> {
-    pub session_id: &'a str,
-    pub cwd: &'a Path,
-    pub pid: u32,
-    pub pty_start: SystemTime,
-}
-
-#[derive(Debug, Clone)]
-pub enum BindError {
-    Pending(String),
-    Fatal(String),
-}
-
-impl std::fmt::Display for BindError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Pending(reason) => write!(f, "bind pending: {}", reason),
-            Self::Fatal(reason) => write!(f, "bind fatal: {}", reason),
-        }
-    }
-}
-
-impl std::error::Error for BindError {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidateTranscriptError {
@@ -130,17 +104,5 @@ mod display_tests {
         let s = outside.to_string();
         assert!(s.starts_with("transcript path is outside Claude directory: "));
         assert!(s.contains(" not under "));
-    }
-
-    #[test]
-    fn bind_error_display_pending_format() {
-        let e = BindError::Pending("logs row not yet committed".to_string());
-        assert_eq!(e.to_string(), "bind pending: logs row not yet committed");
-    }
-
-    #[test]
-    fn bind_error_display_fatal_format() {
-        let e = BindError::Fatal("permission denied on ~/.codex".to_string());
-        assert_eq!(e.to_string(), "bind fatal: permission denied on ~/.codex");
     }
 }


### PR DESCRIPTION
## Summary

- Refactor `AgentAdapter` so codex-only requirements (`BindContext`, `BindError`, the bounded retry inside `base::start_for`) no longer leak through the trait surface.
- Trait method returns to `status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>`. Factory renames `for_type` → `for_attach(agent_type, pid, pty_start)`. Codex's cold-start retry moves into `CodexAdapter::status_source` via a private `retry_locator` helper.
- No user-visible behavior change. Sleep budget on full exhaustion shrinks marginally from 5×100ms to 4×100ms (final-attempt sleep skipped); cold-start binding window otherwise identical.

Resolves #156.

## What changed

**Public surface (`AgentAdapter` trait)**
- `status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>` — drops `BindContext` parameter, returns plain `String` errors instead of `BindError`.
- `<dyn AgentAdapter<R>>::for_attach(agent_type, pid, pty_start)` replaces `for_type(agent_type)`. Claude/NoOp constructors discard the codex-only fields.
- `dyn AgentAdapter<R>::start` and `base::start_for` drop the `pid`/`pty_start` parameters — they're now baked into `CodexAdapter` at construction.
- `base::start_for` has zero retry/sleep code; it's a single-call orchestrator.

**Codex internals**
- `CodexAdapter` gains `pid`, `pty_start`, `codex_home` fields. New `CodexAdapter::new(pid, pty_start)` constructor; `#[cfg(test)] with_home(pid, pty_start, codex_home)` for test isolation from the user's real `~/.codex`.
- New private `BindContext` in `agent/adapter/codex/types.rs` (no `session_id` — the codex locator never reads it; carrying it would trigger `clippy -D warnings` to flag dead code).
- New `retry_locator` helper takes a closure returning `Result<RolloutLocation, LocatorError>`; runs the cold-start race privately. 5 attempts × 100ms inter-attempt sleeps, with the trailing sleep skipped → 400ms sleep budget on full exhaustion.
- `CodexSessionLocator::resolve_rollout` body unchanged; only the import path moves (public types → `super::types::BindContext`).

**Deleted public types**
- `BindContext` and `BindError` removed from `agent/adapter/types.rs`. Their `Display` regression tests removed.

**Tests**
- `start_for_retry_tests` deleted (~138 LOC). Equivalent coverage replaced by 4 new `retry_locator_tests` in `codex/mod.rs` that drive the helper directly via synthesized closures.
- 2 new `status_source_tests` (happy-path with seeded SQLite + retry-exhausted) using `with_home` to isolate from the user's real codex home.
- Existing tests in `claude_code/mod.rs`, `agent/adapter/mod.rs::noop_tests`, `codex/mod.rs::adapter_tests`, and `base/transcript_state.rs::OrderingAdapter` mock all updated for the new sig.

**Documentation**
- New ADR `docs/decisions/2026-05-05-codex-adapter-trait-simplification.md` records the decision; index updated in `docs/decisions/CLAUDE.md`.
- Stage 2 spec gains an `Amended further by:` header pointer + inline supersede notes on the trait-signature-change and `start_for`-retry-loop subsections.
- `src-tauri/src/agent/README.md` swept for stale references (file-tree, `for_attach` section + signature, `start` signature, bind-flow paragraph, trait declaration, hook table row, ClaudeCodeAdapter and NoOpAdapter examples, NoOpAdapter "Why this exists" prose, detector dispatch reference).

**Spec / plan (codex-reviewed before implementation, both included in this PR)**
- `docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md` — design spec, per-section + whole-spec codex review applied.
- `docs/superpowers/plans/2026-05-05-codex-adapter-trait-simplification.md` — implementation plan, plan-complete codex review applied.

## File touch list

**Backend (Rust) — modified (7):** `agent/adapter/types.rs`, `agent/adapter/mod.rs`, `agent/adapter/base/mod.rs`, `agent/adapter/base/transcript_state.rs`, `agent/adapter/claude_code/mod.rs`, `agent/adapter/codex/mod.rs`, `agent/adapter/codex/locator.rs`.

**Backend (Rust) — added (1):** `agent/adapter/codex/types.rs` (private `BindContext`, ~12 LOC).

**Documentation — added (3):** new ADR + design spec + implementation plan.

**Documentation — modified (3):** Stage 2 spec, `docs/decisions/CLAUDE.md`, `src-tauri/src/agent/README.md`.

## Verification

| Check | Result |
| --- | --- |
| `cargo build` | ✓ clean |
| `cargo test agent::adapter` | ✓ 226 tests pass (4 new `retry_locator_tests`, 2 new `status_source_tests`) |
| Full test suite | ✓ 1632 passed, 3 skipped (vitest run from pre-push hook) |
| `cargo clippy --all-targets -- -D warnings` | ⚠ Fails on **15 pre-existing errors** in unrelated files (`src/git/mod.rs`, `src/filesystem/list.rs`, `src/terminal/commands.rs`, `src/agent/detector.rs`, `claude_code/test_runners/*`). Verified equal-or-fewer to `main` — main has 16 errors; this branch has 15. The refactor removed one (`Default impl for CodexAdapter` warning). |
| `cargo fmt --check` | ⚠ Fails on **~10 pre-existing fmt diffs** in `claude_code/test_runners/*`, `base/watcher_runtime.rs`, `codex/transcript.rs`. Same files, same offsets as `main`. |

The pre-existing clippy/fmt failures are out of scope for this PR per `rules/common/pr-scope.md` (PR #155, in flight). Track them as separate `chore(lint):` / `chore(fmt):` follow-ups.

**Note on the initial commit:** the codex implementer's first push used `--no-verify` because the worktree didn't have `node_modules/` (prettier and vitest hooks unavailable). Running `npm ci` in the worktree resolved both — this PR's push went through pre-push hooks normally with all 1632 tests passing.

## Acceptance criteria (spec section 6.1)

- [x] **Trait signature.** `grep -rn 'fn status_source' src-tauri/src/agent/adapter/` shows the new `(cwd: &Path, session_id: &str) -> Result<StatusSource, String>` shape across `mod.rs`, `claude_code/mod.rs`, `codex/mod.rs`, and `base/transcript_state.rs` (mock).
- [x] **`BindContext`/`BindError` removed from public types.** `grep -rn 'BindContext\|BindError' src-tauri/src/ --include='*.rs'` returns matches only inside `agent/adapter/codex/` (private struct, locator import, `status_source` construction).
- [x] **`base::start_for` has zero retry/sleep code.** `grep -n 'sleep\|retry\|RETRY' src-tauri/src/agent/adapter/base/mod.rs` returns no matches.
- [x] **All PR #154 functionality preserved.** Codex still binds within ~500ms; Claude's status panel populates identically; no IPC bump.
- [x] **New ADR exists and supersedes the relevant Stage 2 spec sections.** Stage 2 spec carries `Amended further by:` + inline supersede markers on trait-sig-change and `start_for`-retry-loop subsections + continuation-line pointers under three File touch list rows (`mod.rs`, `base/mod.rs`, `types.rs`).

## Test plan

- [ ] Reviewer pulls the branch and runs `cargo test --manifest-path src-tauri/Cargo.toml agent::adapter` to confirm 226 tests pass.
- [ ] Manual end-to-end (per spec section 4.5): `npm run tauri dev`; spawn `codex` in a PTY → status panel populates within ~1s; spawn `codex resume --last` in another fresh PTY → panel populates immediately from rolled-up history; spawn `claude` in a third PTY → Claude path unaffected.
- [ ] Reviewer confirms `cargo clippy --all-targets -- -D warnings` failures are equal-or-fewer to `main`.
- [ ] Reviewer audits the doc updates: new ADR reads coherently; Stage 2 spec amendment is non-destructive (existing prose preserved with supersede markers); `agent/README.md` references the post-2026-05-05 contract throughout.

## References

- Issue: #156
- Spec: \`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-05-codex-adapter-trait-simplification.md\`
- New ADR: \`docs/decisions/2026-05-05-codex-adapter-trait-simplification.md\`
- Stage 2 PR (predecessor): #154
- Stage 2 scope-expansion ADR (still in force): \`docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)