### PR TITLE
chore(ci): pre-create ~/.local/bin for claude-review installer

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,6 +36,16 @@ jobs:
           SCHEMA=$(jq -c . .github/codex/codex-output-schema.json)
           echo "json=$SCHEMA" >> "$GITHUB_OUTPUT"
 
+      # Workaround for anthropics/claude-code-action@v1: the bundled
+      # native installer prints "✔ Claude Code successfully installed!"
+      # but skips placing the binary when ~/.local/bin/ does not yet
+      # exist on the runner. The SDK then fails with
+      # "ReferenceError: Claude Code native binary not found at
+      # /home/runner/.local/bin/claude". Pre-creating the directory
+      # gives the installer a destination it actually writes to.
+      - name: Pre-create ~/.local/bin so the Claude Code installer can place the binary
+        run: mkdir -p ~/.local/bin
+
       - name: Run Claude review
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary

- The `Claude Code Review` workflow has been failing on every PR run with `ReferenceError: Claude Code native binary not found at /home/runner/.local/bin/claude`.
- Root cause: `anthropics/claude-code-action@v1`'s bundled native installer claims success but silently skips placing the binary when `~/.local/bin/` does not pre-exist on the runner.
- Fix: a single `mkdir -p ~/.local/bin` step before the action runs.

## Why this matters

Every PR opened against `main` triggers `Claude PR Review`, which uses `anthropics/claude-code-action@v1`. The action's installer self-reports as successful, but the SDK that follows can't find the binary the installer claimed to write:

```
Installing Claude Code v2.1.129...
Setting up launcher and shell integration...
⚠ Setup notes:
  ● installMethod is native, but directory /home/runner/.local/bin does not exist
  ● installMethod is native, but claude command not found at /home/runner/.local/bin/claude

✔ Claude Code successfully installed!
  Version: 2.1.129
  Location: ~/.local/bin/claude

...

ReferenceError: Claude Code native binary not found at /home/runner/.local/bin/claude.
Please ensure Claude Code is installed via native installer or specify a valid path
with options.pathToClaudeCodeExecutable.
```

The warning ("directory /home/runner/.local/bin does not exist") is the load-bearing signal. The "successful" install message immediately above it is wrong — the installer needs `~/.local/bin/` to already exist and silently skips its work otherwise.

GitHub's `ubuntu-latest` runners do NOT auto-create `~/.local/bin/` for the `runner` user, so the action has been broken on every run for some time. Confirmed on PR #170; logs visible at https://github.com/winoooops/vimeflow/actions/runs/25421649162.

## Fix

```yaml
- name: Pre-create ~/.local/bin so the Claude Code installer can place the binary
  run: mkdir -p ~/.local/bin
```

Inserted in `.github/workflows/claude-review.yml` immediately before the existing `anthropics/claude-code-action@v1` step. 10 added lines (1 step + 7 comment lines + 2 blanks). No other workflow changes.

## Why not pin / disable / report upstream

- **Pin to an older action SHA.** Doesn't help — the underlying installer behavior is what's broken; older v1 SHAs share the bug.
- **Disable the workflow.** Reviewer surface drops to chatgpt-codex-connector + humans only. Workable as a fallback but loses Claude review feedback for every PR.
- **Report upstream.** Worth doing in parallel — the installer should `mkdir -p` its own destination. This PR unblocks our PRs in the meantime.

## File touch list

| File | Change |
| --- | --- |
| `.github/workflows/claude-review.yml` | +10 lines: one `mkdir -p ~/.local/bin` step + a 7-line rationale comment. |

No other files. No code changes. No new dependencies. No test changes (CI workflow change; effect is observable in the next PR's `Claude Code Review` job).

## Test plan

- [ ] Merge this PR.
- [ ] On the next PR opened (or PR #170 once rebased), confirm the `Claude Code Review` job succeeds and posts a `## Claude Code Review` comment.
- [ ] If the binary is still missing, fall back to disabling the workflow until the upstream installer is fixed.

## Related

- Surfaced while triaging CI failures on PR #170 (issue #156, codex adapter trait simplification).
- Upstream action: https://github.com/anthropics/claude-code-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)