### PR TITLE
feat(ui): step 3 — sidebar sessions list + browser-style session tabs

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -47,7 +47,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 51       | 17   | 2026-05-06   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 17       | 5    | 2026-05-07   |
-| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 34       | 8    | 2026-05-04   |
+| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 35       | 9    | 2026-05-07   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend        | 1        | 0    | 2026-05-04   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 7        | 3    | 2026-05-02   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)             | security       | 15       | 2    | 2026-04-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -40,7 +40,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security       | 21       | 3    | 2026-05-03   |
 | [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns | 10       | 4    | 2026-05-07   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns | 2        | 3    | 2026-04-14   |
-| [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 3        | 2    | 2026-05-06   |
+| [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 4        | 3    | 2026-05-07   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 2        | 0    | 2026-05-04   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 36       | 20   | 2026-05-03   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -38,7 +38,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                              | Category       | Findings | Refs | Last Updated |
 | -------------------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security       | 21       | 3    | 2026-05-03   |
-| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns | 9        | 3    | 2026-05-06   |
+| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns | 10       | 4    | 2026-05-07   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns | 2        | 3    | 2026-04-14   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 3        | 2    | 2026-05-06   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
@@ -46,7 +46,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 36       | 20   | 2026-05-03   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 51       | 17   | 2026-05-06   |
-| [Accessibility](patterns/accessibility.md)                           | a11y           | 16       | 4    | 2026-05-06   |
+| [Accessibility](patterns/accessibility.md)                           | a11y           | 17       | 5    | 2026-05-07   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 34       | 8    | 2026-05-04   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend        | 1        | 0    | 2026-05-04   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 7        | 3    | 2026-05-02   |
@@ -61,5 +61,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files          | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process | 5        | 0    | 2026-04-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing    | 9        | 1    | 2026-04-19   |
-| [Module Boundaries](patterns/module-boundaries.md)                   | code-quality   | 2        | 0    | 2026-05-06   |
+| [Module Boundaries](patterns/module-boundaries.md)                   | code-quality   | 3        | 1    | 2026-05-07   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality   | 7        | 2    | 2026-05-02   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -38,15 +38,15 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                              | Category       | Findings | Refs | Last Updated |
 | -------------------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security       | 21       | 3    | 2026-05-03   |
-| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns | 8        | 2    | 2026-05-05   |
+| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns | 9        | 3    | 2026-05-06   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns | 2        | 3    | 2026-04-14   |
-| [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 2        | 1    | 2026-04-10   |
+| [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 3        | 2    | 2026-05-06   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 4        | 0    | 2026-04-12   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 2        | 0    | 2026-05-04   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 36       | 20   | 2026-05-03   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 51       | 17   | 2026-05-06   |
-| [Accessibility](patterns/accessibility.md)                           | a11y           | 14       | 3    | 2026-05-06   |
+| [Accessibility](patterns/accessibility.md)                           | a11y           | 16       | 4    | 2026-05-06   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 34       | 8    | 2026-05-04   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend        | 1        | 0    | 2026-05-04   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 7        | 3    | 2026-05-02   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -46,7 +46,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 36       | 20   | 2026-05-03   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 51       | 17   | 2026-05-06   |
-| [Accessibility](patterns/accessibility.md)                           | a11y           | 13       | 2    | 2026-05-06   |
+| [Accessibility](patterns/accessibility.md)                           | a11y           | 14       | 3    | 2026-05-06   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 34       | 8    | 2026-05-04   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend        | 1        | 0    | 2026-05-04   |
 | [Command Injection](patterns/command-injection.md)                   | security       | 7        | 3    | 2026-05-02   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,8 +2,8 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-05-06
-ref_count: 4
+last_updated: 2026-05-07
+ref_count: 5
 ---
 
 # Accessibility
@@ -163,3 +163,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** When an active running session exits, its tab stays visible per the "exited active keeps its tab" contract (so the Restart pane in the tabpanel below remains reachable), but the live-status pip is intentionally hidden — and the tab's `aria-label={session.name}` is unchanged. Sighted users see the pip vanish silently with no replacement glyph. Screen-reader users navigating the tablist hear `'auth, tab'` before AND after the session exited and would never know the session needs restart until they Tab into the panel — violating WCAG 2.1 SC 4.1.3 (Status Messages, AA), which requires programmatic exposure of status changes.
 - **Fix:** `aria-label` is now `${session.name} (ended)` for completed and errored statuses; running and paused remain `session.name` only. Zero visual change (the pip-hidden behavior is preserved as the visual heartbeat-only-for-live-sessions pattern). Added a regression test asserting both completed and errored variants of an active tab produce the suffixed accessible name. Code-review heuristic: when an interactive element survives a state transition that hides its only feedback affordance, the alternate state needs a programmatic substitute (`aria-label` suffix, `aria-live` region, etc.) — "silent retention" is an accessibility regression even when the element technically still exists.
 - **Commit:** _(see git log for the cycle-16 fix commit on PR #174)_
+
+### 17. Roving-tabindex condition only handled the `null` activeSessionId case — stale non-null id after `flushSync` left the entire tablist with `tabIndex=-1` for one frame
+
+- **Source:** github-claude | PR #174 round 17 | 2026-05-07
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/components/SessionTabs.tsx`
+- **Finding:** `useSessionManager.removeSession` calls `flushSync` internally, producing an intermediate React commit where `sessions` has dropped the removed session but `activeSessionId` still holds its (now-stale) id. `getVisibleSessions` cannot include the removed id (no longer in `sessions`), so every visible tab evaluates `id === activeSessionId` as false — and the `activeSessionId === null` guard does not fire either because the id is non-null-but-stale. All visible tabs receive `tabIndex=-1`, the WAI-ARIA roving-focus invariant collapses, and the tablist becomes keyboard-unreachable for that render frame. The bug is invisible when React batches the close+select state updates into one render; only the `flushSync` path surfaces it. Same finding-class as #11 (focus restoration) — focus-management code paths must enforce their own invariants because the symptom (focus on `<body>`, no focusable tab) is invisible until a real keyboard user notices.
+- **Fix:** Computed `hasFocusMatch = open.some(s => s.id === activeSessionId)` once at the SessionTabs body. Changed `isFocusEntryPoint` from `id === activeSessionId || (activeSessionId === null && idx === 0)` to `id === activeSessionId || (!hasFocusMatch && idx === 0)`. The new condition collapses three roving-focus cases (initial null, fresh-load no-active, stale flushSync) to a single first-tab fallback; exactly one tab always carries `tabIndex=0` when `open` is non-empty. Added a regression test asserting that a non-null but stale `activeSessionId` still leaves the first visible tab as the entry point. Code-review heuristic: roving-tabindex fallbacks must key on "no tab matches activeSessionId" (a _visible-set property_), NOT on "activeSessionId is null" (a _raw-state property_) — the former covers the latter and also covers the stale-id case that the latter misses.
+- **Commit:** _(see git log for the cycle-17 fix commit on PR #174)_

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-05-06
-ref_count: 2
+ref_count: 3
 ---
 
 # Accessibility
@@ -134,3 +134,14 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The new `StatusBar` placeholder rendered its container as a `<div>` with no ARIA landmark. Persistent bottom chrome is the canonical use case for `role="contentinfo"` (or the implicit landmark on `<footer>`); without it, VoiceOver/NVDA users navigating by landmark cannot reach or skip over the bar, and screen-reader users have no programmatic anchor to identify the region. A "placeholder until step 9" rationale was wrong — the container element is what step 9 inherits, and removing landmarks gives downstream developers a div-only baseline that they then have to retrofit. Same finding-class as #5 (button-styled spans), #6 (drag handle missing role), #11 (focus restoration) — structural a11y omissions on otherwise-correct interactive scaffolding.
 - **Fix:** Swapped the outer `<div>` for `<footer>` with `aria-label="App status"`. `<footer>` directly inside the workspace root (not nested in `<section>`/`<article>`) carries the implicit `role="contentinfo"`, so the bar now appears in landmark navigation. Added a sibling test asserting `getByRole('contentinfo')` resolves with the explicit accessible name. Code-review heuristic: any persistent layout strip — top bar, bottom bar, side rail — should ship with its semantic landmark on day one, not deferred to a "polish" pass; the landmark is part of the scaffolding, not styling.
 - **Commit:** _(see git log for the cycle-2 fix commit on PR #173)_
+
+---
+
+### 14. Focus restoration via raw template-literal CSS attribute selector — silent break or `SyntaxError` on hostile session ids
+
+- **Source:** github-claude | PR #174 round 15 | 2026-05-06
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/components/Sidebar.tsx`
+- **Finding:** `Sidebar.handleRemoveSession` queued a `queueMicrotask` that called `document.querySelector(`[data-session-id="${nextId}"] [data-role="activate"]`)` to restore keyboard focus after closing a session. `nextId` was interpolated raw into a CSS attribute-selector string. The current session-id schema is UUID-only, so no real input today corrupts the selector — but the invariant lived implicitly in the caller, not enforced by the focus-restoration code. A future schema change (e.g. accepting a user-chosen alias as the session id) that allows `"` or `]` would either silently no-op (`querySelector` returns `null` → focus lands on `<body>`) or throw `SyntaxError` from inside the microtask, which is uncaught and observably breaks keyboard nav. Same finding-class as #11 (focus restoration) — focus-management code paths must enforce their own invariants because the symptom (focus on `<body>`) is invisible until a real keyboard user notices.
+- **Fix:** Mirrored the `SessionTabs` pattern (`document.getElementById(`session-tab-${nextId}`)`). Both `SessionRow` and `RecentSessionRow` now render their absolute-overlay activation `<button>` with an explicit `id={`sidebar-activate-${session.id}`}`, and `handleRemoveSession` switched to `document.getElementById(`sidebar-activate-${nextId}`)`. `getElementById` treats its argument as a plain DOMString — no parsing, no escaping, no dependency on session-id character class. The two parallel focus-restoration paths in the workspace now use the same lookup mechanism (consistency that's easier to maintain than two mechanisms). Code-review heuristic: when interpolating any non-static value into a `querySelector` argument, prefer `getElementById` (or wrap with `CSS.escape`) — the security/correctness flavor of "untrusted-string-into-parser" applies to DOM selectors the same way it applies to SQL/shell, even when the current input class is "safe" by accident.
+- **Commit:** _(see git log for the cycle-15 fix commit on PR #174)_

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-05-06
-ref_count: 3
+ref_count: 4
 ---
 
 # Accessibility
@@ -145,3 +145,21 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** `Sidebar.handleRemoveSession` queued a `queueMicrotask` that called `document.querySelector(`[data-session-id="${nextId}"] [data-role="activate"]`)` to restore keyboard focus after closing a session. `nextId` was interpolated raw into a CSS attribute-selector string. The current session-id schema is UUID-only, so no real input today corrupts the selector — but the invariant lived implicitly in the caller, not enforced by the focus-restoration code. A future schema change (e.g. accepting a user-chosen alias as the session id) that allows `"` or `]` would either silently no-op (`querySelector` returns `null` → focus lands on `<body>`) or throw `SyntaxError` from inside the microtask, which is uncaught and observably breaks keyboard nav. Same finding-class as #11 (focus restoration) — focus-management code paths must enforce their own invariants because the symptom (focus on `<body>`) is invisible until a real keyboard user notices.
 - **Fix:** Mirrored the `SessionTabs` pattern (`document.getElementById(`session-tab-${nextId}`)`). Both `SessionRow` and `RecentSessionRow` now render their absolute-overlay activation `<button>` with an explicit `id={`sidebar-activate-${session.id}`}`, and `handleRemoveSession` switched to `document.getElementById(`sidebar-activate-${nextId}`)`. `getElementById` treats its argument as a plain DOMString — no parsing, no escaping, no dependency on session-id character class. The two parallel focus-restoration paths in the workspace now use the same lookup mechanism (consistency that's easier to maintain than two mechanisms). Code-review heuristic: when interpolating any non-static value into a `querySelector` argument, prefer `getElementById` (or wrap with `CSS.escape`) — the security/correctness flavor of "untrusted-string-into-parser" applies to DOM selectors the same way it applies to SQL/shell, even when the current input class is "safe" by accident.
 - **Commit:** _(see git log for the cycle-15 fix commit on PR #174)_
+
+### 15. E2E helper still used raw `${id}` CSS attribute selector after the same cycle fixed it in production code
+
+- **Source:** github-claude | PR #174 round 16 | 2026-05-06
+- **Severity:** LOW
+- **File:** `tests/e2e/terminal/specs/multi-tab-isolation.spec.ts`
+- **Finding:** Cycle 15 fixed `Sidebar.handleRemoveSession`'s raw attribute-selector interpolation by switching to `getElementById` (finding #14 above). The directly analogous helper `getLatestSessionTabId` in the e2e spec — `document.querySelector(`[data-testid="terminal-pane"][data-session-id="${id}"]`)` — was not updated in the same pass. Same correctness invariant: a session id containing `"` or `]` corrupts the selector and either silently returns null OR throws `SyntaxError` from inside `browser.execute` (producing a cryptic test-infrastructure failure rather than an assertion failure). The risk is theoretical today (UUIDs only) but the asymmetry — production is hardened, test infra isn't — is itself a code-smell.
+- **Fix:** Switched to `document.getElementById(`session-panel-${id}`)`. `TerminalZone` already renders every panel wrapper as `id="session-panel-${session.id}"`(added in earlier cycles for`aria-labelledby`linkage), so no production-side change was required. Code-review heuristic: when a production fix moves untrusted-string-into-parser to a safer alternative, scan the WHOLE codebase (especially`tests/`) for the same pattern in the same cycle — review-fix scope is per-finding, but pattern propagation is per-file-class.
+- **Commit:** _(see git log for the cycle-16 fix commit on PR #174)_
+
+### 16. SessionTab `aria-label` did not reflect status change when active session exited (silent on running→completed/errored)
+
+- **Source:** github-claude | PR #174 round 16 | 2026-05-06
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/SessionTabs.tsx`
+- **Finding:** When an active running session exits, its tab stays visible per the "exited active keeps its tab" contract (so the Restart pane in the tabpanel below remains reachable), but the live-status pip is intentionally hidden — and the tab's `aria-label={session.name}` is unchanged. Sighted users see the pip vanish silently with no replacement glyph. Screen-reader users navigating the tablist hear `'auth, tab'` before AND after the session exited and would never know the session needs restart until they Tab into the panel — violating WCAG 2.1 SC 4.1.3 (Status Messages, AA), which requires programmatic exposure of status changes.
+- **Fix:** `aria-label` is now `${session.name} (ended)` for completed and errored statuses; running and paused remain `session.name` only. Zero visual change (the pip-hidden behavior is preserved as the visual heartbeat-only-for-live-sessions pattern). Added a regression test asserting both completed and errored variants of an active tab produce the suffixed accessible name. Code-review heuristic: when an interactive element survives a state transition that hides its only feedback affordance, the alternate state needs a programmatic substitute (`aria-label` suffix, `aria-live` region, etc.) — "silent retention" is an accessibility regression even when the element technically still exists.
+- **Commit:** _(see git log for the cycle-16 fix commit on PR #174)_

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,8 +2,8 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-05-04
-ref_count: 8
+last_updated: 2026-05-07
+ref_count: 9
 ---
 
 # Async Race Conditions
@@ -349,3 +349,12 @@ prevent showing previous data.
 - **Finding:** When `start_agent_watcher` was invoked twice for the same sid (e.g. an exit/re-detect cycle where the agent briefly disappears and re-spawns), the older invocation's await could resolve AFTER the newer one had already registered a backend watcher. The stale-guard branch unconditionally called `stopWatchers(sid, ptySessionId)`. Because `stop_agent_watcher` is keyed only by session ID on the backend, that stop tore down the _current_ (newer) watcher — silencing status / tool-call events until the next detection poll restarted it.
 - **Fix:** Gate the stop on `!newerSameSidSucceeded` where `newerSameSidSucceeded = (currentSessionIdRef.current === sid) && (watcherStartGenerationRef.current !== startGeneration) && watcherStartedRef.current`. The three conjuncts identify "newer same-sid registrant succeeded" and only that case. On every other bail path (sid switch, unmount, agent exit, our own bumped-gen with no successor) the stop must still fire — sid-switch and unmount cleanups can't help when `knownPtyIdRef` is still unset, so the stale-resolution branch is the only place that has the captured `ptySessionId`. The lesson: when a backend resource is keyed by a coarse-grained ID (sid) but the frontend can have multiple parallel registrants for that same ID over time, the stale-cleanup path must distinguish "newer registrant for SAME ID exists" (skip stop) from "different ID" (always stop) — using a ref triple `(id-match, generation-bumped, success-flag-set)` rather than any one of them alone.
 - **Commit:** _(see git log for the round-1 fix commit on PR #154)_
+
+### 35. SessionTab fired redundant `setActiveSession` IPC on already-active tab click — interfered with `useSessionManager` request-supersession rollback
+
+- **Source:** github-codex-connector | PR #174 round 19 | 2026-05-07
+- **Severity:** P2
+- **File:** `src/features/workspace/components/SessionTabs.tsx`
+- **Finding:** `SessionTab` dispatched `onSelect(session.id)` on EVERY pointer click and Enter/Space keypress, regardless of whether the tab was already the active tab. `WorkspaceView` bridges `onSelect` to `setActiveSessionId`, which always issues `service.setActiveSession(...)` — so each idle click on the active tab became a redundant Tauri IPC round-trip. Worse: `useSessionManager` uses the request-supersession pattern (a later request supersedes an earlier in-flight one for transient-failure rollback). A no-op same-id "switch" would supersede a real prior switch attempt, and if the real one transiently failed, the rollback machinery would skip it — leaving the displayed selection out of sync with the backend. Hard to repro without simulated transient IPC failure, but the fix is one guard.
+- **Fix:** Added `if (!isActive)` guard before `onSelect(session.id)` in BOTH activation paths (`onClick` and `handleKeyDown` for Enter/Space). Inactive-tab activation still dispatches normally; close-fallback selection from `SessionTabs.handleClose` is unaffected because it calls the parent `onSelect(nextId)` directly, bypassing the per-tab activation handlers. Comments at both call sites cite the IPC bridge AND the request-supersession rationale so future maintainers don't strip the guard for "clarity". Added regression test asserting click + Enter + Space on the already-active tab all leave `onSelect` un-called. Code-review heuristic: any UI activation gesture that dispatches an IPC must check whether the gesture changes state — the cost of "always dispatch and let downstream debounce" is invisible in steady-state but compounds with retry/supersession patterns under failure.
+- **Commit:** _(see git log for the cycle-19 fix commit on PR #174)_

--- a/docs/reviews/patterns/cross-platform-paths.md
+++ b/docs/reviews/patterns/cross-platform-paths.md
@@ -2,8 +2,8 @@
 id: cross-platform-paths
 category: cross-platform
 created: 2026-04-09
-last_updated: 2026-05-06
-ref_count: 2
+last_updated: 2026-05-07
+ref_count: 3
 ---
 
 # Cross-Platform Paths
@@ -43,3 +43,12 @@ consider using path libraries for cross-platform code.
 - **Finding:** `sessionSubtitle` derived the subtitle line by `workingDirectory.split('/').filter(Boolean)` and returning the last segment. On Windows, Tauri can hand back a native path like `C:\Users\alice\my-repo`; the `/`-only split treats the whole string as one element, the basename derivation returns the entire path, and the row layout regresses for Windows users whenever `currentAction` is empty. The bug had no test coverage because all existing fixtures used POSIX paths.
 - **Fix:** Normalize `\\` → `/` first (`workingDirectory.replace(/\\/g, '/')`), THEN split-and-trim. Per user direction during the same cycle, also widened the basename rule to "last 2 segments joined by `/`" so a shallow path like `/home/will` reads as `home/will` instead of collapsing aggressively to `will`. Single-segment paths return that segment as-is; empty falls back to the raw cwd. Added two regression tests: `C:\Users\alice\my-repo` → `alice/my-repo`, and `/home/will` → `home/will`. Code-review heuristic: any path-derivation that splits on a hardcoded separator is implicitly POSIX-only — desktop apps that ship on Windows (here: a Tauri target) must normalize separators OR use `path.basename`/`std::path::Path` BEFORE any string slicing.
 - **Commit:** _(see git log for the cycle-16 fix commit on PR #174)_
+
+### 4. `sessionSubtitle` empty-string race-window fallback returned `""` despite "never empty" comment
+
+- **Source:** github-claude | PR #174 round 20 | 2026-05-07
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/Sidebar.tsx`
+- **Finding:** The cycle-16 cwd-derivation rewrite for `sessionSubtitle` added a comment claiming the subtitle "is never empty" with the fallback `return session.workingDirectory` for the zero-segments case (`parts.length === 0` after split + filter). But when `workingDirectory` is itself `""` — the brief race-window state between session creation and the first OSC 7 cwd report from Tauri — the fallback returns `""`, the subtitle div renders with empty content, and a visible vertical gap appears between the title and the state pill. The comment's "never empty" guarantee is a lie that a future maintainer might rely on.
+- **Fix:** Single-character change: `return session.workingDirectory || '~'`. `~` is the conventional shell display for an unknown / home cwd. Preserves POSIX root `/` (which is truthy and falls through `||`) and only kicks in for the actual empty-string race-window case. Comment expanded to spell out the race-window rationale explicitly so the next maintainer doesn't need to re-derive why the bare-`workingDirectory` fallback was insufficient. Added regression test asserting an empty-cwd session renders `~` in its row subtitle (scoped via `within(getByTestId('session-row'))` to avoid colliding with the SidebarStatusHeader's separate `~` display). Code-review heuristic: any fallback that promises an invariant in a comment must be testable with an actual edge-case test — comments alone don't enforce invariants, and review-time "looks fine" reading easily misses the chain `'' → split → []` → `[]` → fallback returns `''`.
+- **Commit:** _(see git log for the cycle-20 fix commit on PR #174)_

--- a/docs/reviews/patterns/cross-platform-paths.md
+++ b/docs/reviews/patterns/cross-platform-paths.md
@@ -2,8 +2,8 @@
 id: cross-platform-paths
 category: cross-platform
 created: 2026-04-09
-last_updated: 2026-04-10
-ref_count: 1
+last_updated: 2026-05-06
+ref_count: 2
 ---
 
 # Cross-Platform Paths
@@ -34,3 +34,12 @@ consider using path libraries for cross-platform code.
 - **Finding:** On Unix, `libc::O_NOFOLLOW` passed via `OpenOptionsExt::custom_flags` makes the kernel atomically refuse to follow a symlink at the final path component. The `#[cfg(unix)]` block excluded this flag on Windows, and there was no Windows-side equivalent, leaving a TOCTOU window between `symlink_metadata` and `open`.
 - **Fix:** Under `#[cfg(windows)]`, set `FILE_FLAG_OPEN_REPARSE_POINT` (0x00200000) via `std::os::windows::fs::OpenOptionsExt::custom_flags`. This tells `CreateFileW` to open the reparse point itself rather than following it. Add a post-open metadata check to explicitly reject reparse points (since `CreateFileW` succeeds against them rather than erroring like `ELOOP` on Unix).
 - **Commit:** `28027a5 fix: address Claude review round 5 findings`, `36902f7 fix: address Claude review round 6 findings`
+
+### 3. UI subtitle splits cwd on `/` only — Windows native separators collapse the whole path into one segment
+
+- **Source:** github-codex-connector | PR #174 round 16 | 2026-05-06
+- **Severity:** MEDIUM (P2)
+- **File:** `src/features/workspace/components/Sidebar.tsx`
+- **Finding:** `sessionSubtitle` derived the subtitle line by `workingDirectory.split('/').filter(Boolean)` and returning the last segment. On Windows, Tauri can hand back a native path like `C:\Users\alice\my-repo`; the `/`-only split treats the whole string as one element, the basename derivation returns the entire path, and the row layout regresses for Windows users whenever `currentAction` is empty. The bug had no test coverage because all existing fixtures used POSIX paths.
+- **Fix:** Normalize `\\` → `/` first (`workingDirectory.replace(/\\/g, '/')`), THEN split-and-trim. Per user direction during the same cycle, also widened the basename rule to "last 2 segments joined by `/`" so a shallow path like `/home/will` reads as `home/will` instead of collapsing aggressively to `will`. Single-segment paths return that segment as-is; empty falls back to the raw cwd. Added two regression tests: `C:\Users\alice\my-repo` → `alice/my-repo`, and `/home/will` → `home/will`. Code-review heuristic: any path-derivation that splits on a hardcoded separator is implicitly POSIX-only — desktop apps that ship on Windows (here: a Tauri target) must normalize separators OR use `path.basename`/`std::path::Path` BEFORE any string slicing.
+- **Commit:** _(see git log for the cycle-16 fix commit on PR #174)_

--- a/docs/reviews/patterns/module-boundaries.md
+++ b/docs/reviews/patterns/module-boundaries.md
@@ -2,8 +2,8 @@
 id: module-boundaries
 category: code-quality
 created: 2026-04-30
-last_updated: 2026-05-06
-ref_count: 0
+last_updated: 2026-05-07
+ref_count: 1
 ---
 
 # Module Boundaries
@@ -42,3 +42,12 @@ Don't widen the coupling by adding a second importer.
 - **Finding:** New `StatusBar.tsx` shipped with both `export const StatusBar` and `export default StatusBar` — the latter was dead code (the sole consumer `WorkspaceView.tsx` uses the named import) and inconsistent with sibling components in the same directory: `IconRail` and `Sidebar` are named-only, while `BottomDrawer` is default-only. Adding both forms invites future contributors to follow either convention, multiplying the inconsistency over time. Some bundler tree-shaking paths also treat re-exported defaults differently, so the dual form has a small additional cost. Note (1-line stretch): this fits the broader "module boundaries" theme — what a file exports is part of its module shape, and shape inconsistency across siblings is a coupling smell similar to #1's cross-component utility import.
 - **Fix:** Dropped `export default StatusBar`. Pattern is now: workspace-level chrome (`IconRail`, `Sidebar`, `StatusBar`) ships named-only; legacy components like `BottomDrawer` keep their default export until a future migration normalises. Code-review heuristic: when a new file lands in a directory, scan sibling files for export shape and match — not "support both forms defensively."
 - **Commit:** _(see git log for the cycle-1 fix commit on PR #173)_
+
+### 3. `TerminalZone` re-implemented `getVisibleSessions`'s open-status check inline instead of importing the canonical predicate
+
+- **Source:** github-claude | PR #174 round 17 | 2026-05-07
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/components/TerminalZone.tsx`
+- **Finding:** `TerminalZone` decided whether to wire `aria-labelledby` on each panel by recomputing `isActive || status === 'running' || status === 'paused'` inline. The exact same predicate (modulo the `isActive` half) lives in `pickNextVisibleSessionId.ts` as `isOpenSessionStatus`, which `Sidebar` and `SessionTabs` both consume. Today the two are equivalent, but the moment `isOpenSessionStatus` is widened (e.g. to admit a future `suspended` status), `TerminalZone`'s `hasVisibleTab` would silently lag — panels for the new status would emit `aria-labelledby={undefined}` even though `SessionTabs` would render a visible tab for them, breaking the WAI-ARIA tablist↔tabpanel linkage with no build error and no test failure. Same finding-class as #2 above (sibling-shape mismatch is a coupling smell) but the consequence here is functional, not stylistic.
+- **Fix:** Imported `isOpenSessionStatus` from `../utils/pickNextVisibleSessionId`. Replaced the inline three-line OR with `isActive || isOpenSessionStatus(session.status)`. Updated the comment to state the canonical-predicate consumption rationale ("a future non-open status auto-flows into both visibility surfaces without TerminalZone needing a separate update"). Code-review heuristic: when two files in the same feature directory implement the same predicate inline, ONE of them should host the helper and the other(s) should consume it — and reviewers should flag the duplicate the moment the second copy lands, not after a status-set extension surfaces the drift.
+- **Commit:** _(see git log for the cycle-17 fix commit on PR #174)_

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,8 +2,8 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-05-05
-ref_count: 2
+last_updated: 2026-05-06
+ref_count: 3
 ---
 
 # React Lifecycle
@@ -87,3 +87,12 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** `navigateUp` and `navigateDown` close over `filteredResults` (the full array reference) but declared only `filteredResults.length` in their `useCallback` dep arrays. Currently harmless because both callbacks only read `filteredResults.length` inside their bodies, but `react-hooks/exhaustive-deps` would flag the missing dep, and any future contributor adding item-level access (e.g. reading `filteredResults[index]` to compute the next highlight) would silently inherit a stale-closure bug — the array reference baked into the closure would lag behind the latest `useMemo` result whenever `filteredResults` rebuilt with the same length.
 - **Fix:** Replaced `[filteredResults.length]` with `[filteredResults]` in both callbacks. Re-creation cost is negligible for these small closures, and the dep now matches what the callback actually closes over, so a future item-level read inherits no stale-closure surprise.
 - **Commit:** _(see git log for the round-1 fix commit)_
+
+### 9. `cancelRename` reset of double-fire guard re-enables stale post-Escape `onBlur` to fire `onRename` with user-typed text
+
+- **Source:** github-claude | PR #174 round 16 | 2026-05-06
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/hooks/useRenameState.ts`
+- **Finding:** The committedRef double-fire guard (introduced in cycle 13 to block the trailing onBlur after Enter→commit unmounts the input) was being RESET to `false` in `cancelRename` so that the next rename session could begin clean. But Escape calls `cancelRename` synchronously inside `onKeyDown`, queuing `setIsEditing(false)` → React batches and unmounts the input on flush → the browser fires native `blur` on the detached input → React dispatches the synthetic `onBlur` using the **previous render's** `commitRename` closure, which still captures the user's typed `editValue`. With `committedRef = false` the guard does NOT fire, `commitRename` runs, finds `trimmed !== session.name`, and calls `onRename(id, userTypedText)` — silently renaming the session despite the explicit Escape intent. The existing double-fire test calls `commitRename()` twice directly, NOT `cancelRename()` then `commitRename()`, and jsdom does not fire native blur on DOM removal, so the regression was invisible until a Claude review caught it by static analysis of the closure capture.
+- **Fix:** Set `committedRef.current = true` in `cancelRename` (single character). The "next rename session starts clean" invariant is preserved because `beginEdit` already unconditionally resets the guard to `false` — that's what makes a fresh rename session work, not the reset in cancel. Added regression test that simulates the Escape+stale-blur path by calling `cancelRename()` then `commitRename()` and asserting `onRename` was not invoked. Code-review heuristic: a guard ref that protects against stale-closure re-entry must be armed by _both_ commit AND cancel paths, NOT just commit; future-state cleanup belongs in `beginEdit` (the "I'm starting a fresh editing session" gesture), not in the cancel/commit terminal states.
+- **Commit:** _(see git log for the cycle-16 fix commit on PR #174)_

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,8 +2,8 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-05-06
-ref_count: 3
+last_updated: 2026-05-07
+ref_count: 4
 ---
 
 # React Lifecycle
@@ -96,3 +96,12 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** The committedRef double-fire guard (introduced in cycle 13 to block the trailing onBlur after Enter→commit unmounts the input) was being RESET to `false` in `cancelRename` so that the next rename session could begin clean. But Escape calls `cancelRename` synchronously inside `onKeyDown`, queuing `setIsEditing(false)` → React batches and unmounts the input on flush → the browser fires native `blur` on the detached input → React dispatches the synthetic `onBlur` using the **previous render's** `commitRename` closure, which still captures the user's typed `editValue`. With `committedRef = false` the guard does NOT fire, `commitRename` runs, finds `trimmed !== session.name`, and calls `onRename(id, userTypedText)` — silently renaming the session despite the explicit Escape intent. The existing double-fire test calls `commitRename()` twice directly, NOT `cancelRename()` then `commitRename()`, and jsdom does not fire native blur on DOM removal, so the regression was invisible until a Claude review caught it by static analysis of the closure capture.
 - **Fix:** Set `committedRef.current = true` in `cancelRename` (single character). The "next rename session starts clean" invariant is preserved because `beginEdit` already unconditionally resets the guard to `false` — that's what makes a fresh rename session work, not the reset in cancel. Added regression test that simulates the Escape+stale-blur path by calling `cancelRename()` then `commitRename()` and asserting `onRename` was not invoked. Code-review heuristic: a guard ref that protects against stale-closure re-entry must be armed by _both_ commit AND cancel paths, NOT just commit; future-state cleanup belongs in `beginEdit` (the "I'm starting a fresh editing session" gesture), not in the cancel/commit terminal states.
 - **Commit:** _(see git log for the cycle-16 fix commit on PR #174)_
+
+### 10. Framer Motion `onReorder` inline closure captures stale `recentGroup` slice across mid-drag re-renders
+
+- **Source:** github-claude | PR #174 round 17 | 2026-05-07
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/Sidebar.tsx`
+- **Finding:** `Reorder.Group`'s `onReorder` callback was an inline arrow closing over `recentGroup` computed at render time. The drag-and-drop machinery in Framer Motion can dispatch the callback across multiple frames during a single drag; if a session transitions from `running` to `completed` mid-drag, React re-renders Sidebar with a fresh `recentGroup` slice but Framer Motion may keep dispatching the _original_ closure that captured the pre-transition `recentGroup`. The resulting `onReorderSessions([...reordered, ...staleRecentGroup])` either drops or duplicates the just-transitioned session for one frame, and a session-store that persists eagerly could write the stale array to disk before the next render's correction arrives. The bug is invisible in steady-state testing because session status transitions are rare during drags, but it's a real cross-frame closure freshness issue.
+- **Fix:** Mirrored `recentGroup` into a ref synced via render-body assignment (`recentGroupRef.current = recentGroup` runs every render — cheaper than `useEffect` and runs synchronously, which is the standard React pattern for "always-latest" refs that don't need the commit-phase deferral). The `onReorder` callback now reads `recentGroupRef.current` instead of the closure-captured `recentGroup`. Code-review heuristic: any callback registered with a third-party machinery that may retain it across re-renders (drag-and-drop, gesture recognizers, intersection observers) must read mutable state through a ref, not through the closure-captured render-time snapshot — the closure freshness depends on whether the third-party re-subscribes on each render, which is an implementation detail you usually can't guarantee.
+- **Commit:** _(see git log for the cycle-17 fix commit on PR #174)_

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -140,20 +140,18 @@ describe('WorkspaceView Integration Tests', () => {
       const firstSession = sessionButtons[1]
       await user.click(firstSession)
 
-      // Terminal zone should update its active session
-      const tabBar = within(terminalZone).getByTestId('tab-bar')
-
-      // The active session tab should have visual indicator
-      const sessionTabs = within(tabBar).getAllByRole('button', {
-        name: /^🤖/,
-      })
-
-      // At least one tab wrapper should have the active styling (class is on parent div)
-      const hasActiveTab = sessionTabs.some((tab) =>
-        tab.parentElement?.classList.contains('border-b-primary')
+      // SessionTabs (above the terminal zone) should reflect the click.
+      const tabs = within(screen.getByTestId('session-tabs')).getAllByRole(
+        'tab'
       )
 
+      const hasActiveTab = tabs.some(
+        (tab) => tab.getAttribute('aria-selected') === 'true'
+      )
       expect(hasActiveTab).toBe(true)
+      // Terminal zone is still mounted (sanity check) — its panes follow
+      // activeSessionId via the same useSessionManager hook.
+      expect(terminalZone).toBeInTheDocument()
     })
 
     test('clicking session updates agent status panel', async (): Promise<void> => {
@@ -192,28 +190,23 @@ describe('WorkspaceView Integration Tests', () => {
       const user = userEvent.setup()
       render(<WorkspaceView />)
 
-      // Wait for initial session to load
       await screen.findByRole('button', { name: 'session 1' })
 
       const sidebar = screen.getByTestId('sidebar')
-      const terminalZone = screen.getByTestId('terminal-zone')
 
-      // Click the session
       const sessionList = within(sidebar).getByTestId('session-list')
-      const sessionButtons = within(sessionList).getAllByRole('button')
+
+      const sessionButtons = within(sessionList).getAllByRole('button', {
+        name: /^session \d+$/,
+      })
 
       await user.click(sessionButtons[0])
 
-      // Terminal should update
-      const tabBar = within(terminalZone).getByTestId('tab-bar')
+      const tabs = within(screen.getByTestId('session-tabs')).getAllByRole(
+        'tab'
+      )
+      expect(tabs.length).toBeGreaterThan(0)
 
-      const sessionTabs = within(tabBar).getAllByRole('button', {
-        name: /^🤖/,
-      })
-
-      expect(sessionTabs.length).toBeGreaterThan(0)
-
-      // Agent Status Panel should be present
       expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
     })
   })

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -36,7 +36,9 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 // Mock terminal service to return initial session data synchronously
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => ({
-    spawn: vi.fn().mockResolvedValue({ sessionId: 'new-id', pid: 999 }),
+    spawn: vi
+      .fn()
+      .mockResolvedValue({ sessionId: 'new-id', pid: 999, cwd: '~' }),
     write: vi.fn().mockResolvedValue(undefined),
     resize: vi.fn().mockResolvedValue(undefined),
     kill: vi.fn().mockResolvedValue(undefined),
@@ -124,13 +126,17 @@ describe('WorkspaceView Integration Tests', () => {
       // Wait for second session to appear
       await screen.findByRole('button', { name: 'session 2' })
 
-      // Get session buttons from sidebar (session list contains buttons)
+      // Each row now carries hover-only edit/remove buttons in addition to
+      // the main click target. Filter by `session N` aria-label so the
+      // index is stable regardless of the per-row chrome count.
       const sessionList = within(sidebar).getByTestId('session-list')
-      const sessionButtons = within(sessionList).getAllByRole('button')
+
+      const sessionButtons = within(sessionList).getAllByRole('button', {
+        name: /^session \d+$/,
+      })
 
       expect(sessionButtons.length).toBeGreaterThan(1)
 
-      // Click first session (second is already active after creation)
       const firstSession = sessionButtons[1]
       await user.click(firstSession)
 
@@ -168,13 +174,14 @@ describe('WorkspaceView Integration Tests', () => {
       // Wait for second session to appear
       await screen.findByRole('button', { name: 'session 2' })
 
-      // Get all session buttons from session list
       const sessionList = within(sidebar).getByTestId('session-list')
-      const sessionButtons = within(sessionList).getAllByRole('button')
+
+      const sessionButtons = within(sessionList).getAllByRole('button', {
+        name: /^session \d+$/,
+      })
 
       expect(sessionButtons.length).toBeGreaterThan(1)
 
-      // Click first session button (second is already active after creation)
       await user.click(sessionButtons[1])
 
       // Agent Status Panel should be present (content comes in sub-specs 5-7)

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -37,7 +37,9 @@ vi.mock('../editor/hooks/useEditorBuffer', () => ({
 
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => ({
-    spawn: vi.fn().mockResolvedValue({ sessionId: 'new-id', pid: 999 }),
+    spawn: vi
+      .fn()
+      .mockResolvedValue({ sessionId: 'new-id', pid: 999, cwd: '~' }),
     write: vi.fn().mockResolvedValue(undefined),
     resize: vi.fn().mockResolvedValue(undefined),
     kill: vi.fn().mockResolvedValue(undefined),

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable vitest/expect-expect */
 import type { ReactElement } from 'react'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { act, render, screen } from '@testing-library/react'
+import { act, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WorkspaceView } from './WorkspaceView'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
@@ -184,20 +184,16 @@ describe('WorkspaceView', () => {
     ).toBeInTheDocument()
   })
 
-  test('passes active session to TerminalZone', async () => {
+  test('SessionTabs reflects the active session selection', async () => {
     render(<WorkspaceView />)
 
-    // Wait for session to load
     await screen.findByRole('button', { name: 'session 1' })
 
-    const terminalZone = screen.getByTestId('terminal-zone')
-
-    // TerminalZone should render tab bar with at least one session tab
-    const tabBar = terminalZone.querySelector('[data-testid="tab-bar"]')
-    expect(tabBar).toBeInTheDocument()
-
-    const sessionTabs = tabBar?.querySelectorAll('button[aria-label^="🤖"]')
-    expect(sessionTabs?.length).toBeGreaterThan(0)
+    const tabs = within(screen.getByTestId('session-tabs')).getAllByRole('tab')
+    expect(tabs.length).toBeGreaterThan(0)
+    expect(
+      tabs.some((tab) => tab.getAttribute('aria-selected') === 'true')
+    ).toBe(true)
   })
 
   test('renders AgentStatusPanel', () => {

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -79,7 +79,9 @@ vi.mock('../agent-status/components/AgentStatusPanel', () => ({
 // Mock terminal service to return initial session data synchronously
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => ({
-    spawn: vi.fn().mockResolvedValue({ sessionId: 'new-id', pid: 999 }),
+    spawn: vi
+      .fn()
+      .mockResolvedValue({ sessionId: 'new-id', pid: 999, cwd: '~' }),
     write: vi.fn().mockResolvedValue(undefined),
     resize: vi.fn().mockResolvedValue(undefined),
     kill: vi.fn().mockResolvedValue(undefined),
@@ -222,12 +224,12 @@ describe('WorkspaceView', () => {
   test('defaults to first session as active', async () => {
     render(<WorkspaceView />)
 
-    // Default session should have active styling on the list item wrapper
     const firstSession = await screen.findByRole('button', {
       name: 'session 1',
     })
     const listItem = firstSession.closest('li')!
-    expect(listItem.className).toContain('bg-surface-container-high')
+    // Active row uses lavender-tinted background per handoff §4.2.
+    expect(listItem.className).toContain('bg-primary/10')
     expect(listItem.className).toContain('text-on-surface')
   })
 
@@ -297,35 +299,24 @@ describe('WorkspaceView', () => {
   })
 
   test('handles session switching', async () => {
-    // Test that creating a second session and clicking it switches active
     const user = userEvent.setup()
     render(<WorkspaceView />)
 
-    // Wait for initial session to load from listSessions
     const firstSession = await screen.findByRole('button', {
       name: 'session 1',
     })
-    expect(firstSession.closest('li')!.className).toContain(
-      'bg-surface-container-high'
-    )
+    expect(firstSession.closest('li')!.className).toContain('bg-primary/10')
 
-    // Create a second session via the New Instance button
     const newInstanceButton = screen.getByRole('button', {
       name: 'New Instance',
     })
     await user.click(newInstanceButton)
 
-    // New session should now be active, first should not
     const secondSession = await screen.findByRole('button', {
       name: 'session 2',
     })
-    expect(secondSession.closest('li')!.className).toContain(
-      'bg-surface-container-high'
-    )
-
-    expect(firstSession.closest('li')!.className).not.toContain(
-      'bg-surface-container-high'
-    )
+    expect(secondSession.closest('li')!.className).toContain('bg-primary/10')
+    expect(firstSession.closest('li')!.className).not.toContain('bg-primary/10')
   })
 
   test('handles empty sessions gracefully without crashing', () => {
@@ -351,15 +342,15 @@ describe('WorkspaceView', () => {
     expect(container.style.gridTemplateColumns).toContain('auto')
   })
 
-  test('mounts session-tabs strip placeholder above terminal zone', () => {
+  test('mounts SessionTabs above terminal zone', () => {
     render(<WorkspaceView />)
 
-    const strip = screen.getByTestId('session-tabs-strip')
+    const tabs = screen.getByTestId('session-tabs')
     const terminal = screen.getByTestId('terminal-zone')
 
-    expect(strip).toBeInTheDocument()
+    expect(tabs).toBeInTheDocument()
     expect(
-      strip.compareDocumentPosition(terminal) & Node.DOCUMENT_POSITION_FOLLOWING
+      tabs.compareDocumentPosition(terminal) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
   })
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -417,9 +417,6 @@ export const WorkspaceView = (): ReactElement => {
         <TerminalZone
           sessions={sessions}
           activeSessionId={activeSessionId}
-          onSessionChange={setActiveSessionId}
-          onNewTab={createSession}
-          onCloseTab={removeSession}
           onSessionCwdChange={updateSessionCwd}
           restoreData={restoreData}
           loading={loading}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { IconRail } from './components/IconRail'
+import { SessionTabs } from './components/SessionTabs'
 import { Sidebar } from './components/Sidebar'
 import { StatusBar } from './components/StatusBar'
 import { TerminalZone } from './components/TerminalZone'
@@ -405,10 +406,12 @@ export const WorkspaceView = (): ReactElement => {
           banner's `absolute` positioning is scoped to this column
           rather than climbing to the viewport. */}
       <div className="relative flex flex-col overflow-hidden">
-        <div
-          data-testid="session-tabs-strip"
-          className="h-[38px] shrink-0 border-b border-outline-variant/20 bg-surface-container-lowest"
-          aria-hidden="true"
+        <SessionTabs
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSelect={setActiveSessionId}
+          onClose={removeSession}
+          onNew={createSession}
         />
 
         <TerminalZone

--- a/src/features/workspace/WorkspaceView.verification.test.tsx
+++ b/src/features/workspace/WorkspaceView.verification.test.tsx
@@ -39,7 +39,9 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 // Mock terminal service to return initial session data synchronously
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => ({
-    spawn: vi.fn().mockResolvedValue({ sessionId: 'new-id', pid: 999 }),
+    spawn: vi
+      .fn()
+      .mockResolvedValue({ sessionId: 'new-id', pid: 999, cwd: '~' }),
     write: vi.fn().mockResolvedValue(undefined),
     resize: vi.fn().mockResolvedValue(undefined),
     kill: vi.fn().mockResolvedValue(undefined),

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -236,11 +236,11 @@ describe('WorkspaceView - Visual Verification (Feature #20)', () => {
       expect(terminalContent.className).toContain('bg-surface')
     })
 
-    test('Terminal Zone tab bar uses Level 0.5 surface (surface-container-lowest)', () => {
+    test('SessionTabs strip uses Level 0.5 surface (surface-container-lowest)', () => {
       render(<WorkspaceView />)
-      const tabBar = screen.getByTestId('tab-bar')
+      const tabs = screen.getByTestId('session-tabs')
 
-      expect(tabBar.className).toContain('bg-surface-container-lowest')
+      expect(tabs.className).toContain('bg-surface-container-lowest')
     })
 
     test('Agent Status Panel uses surface-container background', () => {
@@ -298,7 +298,6 @@ describe('WorkspaceView - Visual Verification (Feature #20)', () => {
 
       expect(screen.getByTestId('session-tabs')).toBeInTheDocument()
       expect(screen.getByTestId('terminal-zone')).toBeInTheDocument()
-      expect(screen.getByTestId('tab-bar')).toBeInTheDocument()
       expect(screen.getByTestId('bottom-drawer')).toBeInTheDocument()
       expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
     })

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -35,7 +35,9 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 // Mock terminal service to return initial session data synchronously
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => ({
-    spawn: vi.fn().mockResolvedValue({ sessionId: 'new-id', pid: 999 }),
+    spawn: vi
+      .fn()
+      .mockResolvedValue({ sessionId: 'new-id', pid: 999, cwd: '~' }),
     write: vi.fn().mockResolvedValue(undefined),
     resize: vi.fn().mockResolvedValue(undefined),
     kill: vi.fn().mockResolvedValue(undefined),
@@ -289,22 +291,15 @@ describe('WorkspaceView - Visual Verification (Feature #20)', () => {
     test('all 5 zones render with correct structure (v2)', () => {
       render(<WorkspaceView />)
 
-      // Icon Rail (navigation bookmarks)
       expect(screen.getByTestId('icon-rail')).toBeInTheDocument()
-
-      // Sidebar with sessions and file explorer
       expect(screen.getByTestId('sidebar')).toBeInTheDocument()
-      // Text is "Active Sessions"
-      expect(screen.getByText('Active Sessions')).toBeInTheDocument()
+      // Active group header replaces the prior "Active Sessions" copy.
+      expect(screen.getByTestId('session-group-active')).toBeInTheDocument()
 
-      // Terminal Zone with tab bar
+      expect(screen.getByTestId('session-tabs')).toBeInTheDocument()
       expect(screen.getByTestId('terminal-zone')).toBeInTheDocument()
       expect(screen.getByTestId('tab-bar')).toBeInTheDocument()
-
-      // Bottom Drawer with Editor/Diff tabs
       expect(screen.getByTestId('bottom-drawer')).toBeInTheDocument()
-
-      // Agent Activity panel
       expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
     })
 

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -1,0 +1,170 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SessionTabs } from './SessionTabs'
+import type { Session } from '../types'
+
+const buildSession = (overrides: Partial<Session> = {}): Session => ({
+  id: 'sess-1',
+  projectId: 'proj-1',
+  name: 'auth refactor',
+  status: 'running',
+  workingDirectory: '~',
+  agentType: 'claude-code',
+  createdAt: '2026-05-06T00:00:00Z',
+  lastActivityAt: '2026-05-06T00:00:00Z',
+  activity: {
+    fileChanges: [],
+    toolCalls: [],
+    testResults: [],
+    contextWindow: { used: 0, total: 200_000, percentage: 0, emoji: '😊' },
+    usage: {
+      sessionDuration: 0,
+      turnCount: 0,
+      messages: { sent: 0, limit: 200 },
+      tokens: { input: 0, output: 0, total: 0 },
+    },
+  },
+  ...overrides,
+})
+
+const renderTabs = (
+  sessions: Session[],
+  activeSessionId: string | null,
+  handlers: Partial<{
+    onSelect: (id: string) => void
+    onClose: (id: string) => void
+    onNew: () => void
+  }> = {}
+): ReturnType<typeof render> =>
+  render(
+    <SessionTabs
+      sessions={sessions}
+      activeSessionId={activeSessionId}
+      onSelect={handlers.onSelect ?? vi.fn()}
+      onClose={handlers.onClose ?? vi.fn()}
+      onNew={handlers.onNew ?? vi.fn()}
+    />
+  )
+
+describe('SessionTabs', () => {
+  test('renders the strip at 38px tall per handoff §4.3', () => {
+    renderTabs([buildSession()], 'sess-1')
+    const strip = screen.getByTestId('session-tabs')
+    expect(strip.className).toContain('h-[38px]')
+  })
+
+  test('exposes a tablist for assistive navigation', () => {
+    renderTabs([buildSession()], 'sess-1')
+    expect(screen.getByRole('tablist')).toHaveAccessibleName('Open sessions')
+  })
+
+  test('renders one tab per open session (running + paused)', () => {
+    const sessions: Session[] = [
+      buildSession({ id: 'a', status: 'running', name: 'auth' }),
+      buildSession({ id: 'b', status: 'paused', name: 'tests' }),
+      buildSession({ id: 'c', status: 'completed', name: 'closed' }),
+      buildSession({ id: 'd', status: 'errored', name: 'broken' }),
+    ]
+    renderTabs(sessions, 'a')
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0]).toHaveTextContent('auth')
+    expect(tabs[1]).toHaveTextContent('tests')
+  })
+
+  test('marks the active tab with aria-selected and the lift offset', () => {
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, 'b')
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'false')
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'true')
+    // Active tab uses negative margin-bottom to lift into the canvas below.
+    expect(tabs[1].className).toContain('-mb-px')
+  })
+
+  test('active tab paints the agent accent stripe along the top', () => {
+    const sessions = [buildSession({ id: 'a', agentType: 'codex' })]
+    renderTabs(sessions, 'a')
+    const tab = screen.getByRole('tab')
+
+    const stripe = within(tab)
+      .getAllByText('', { selector: '[aria-hidden="true"]' })
+      .find((el): el is HTMLSpanElement => el.tagName === 'SPAN')
+
+    expect(stripe).toBeDefined()
+    // codex accent #7defa1 → rgb(125,239,161); inline so color follows agent.
+    expect(stripe?.style.background).toBe('rgb(125, 239, 161)')
+  })
+
+  test('clicking a tab calls onSelect with the session id', async () => {
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, 'a', { onSelect })
+    await user.click(screen.getAllByRole('tab')[1])
+    expect(onSelect).toHaveBeenCalledWith('b')
+  })
+
+  test('close button calls onClose without selecting the tab', async () => {
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    const sessions = [buildSession({ id: 'a', name: 'auth' })]
+    renderTabs(sessions, 'a', { onSelect, onClose })
+
+    const closeBtn = within(screen.getByRole('tab')).getByRole('button', {
+      name: /close auth/i,
+    })
+    await user.click(closeBtn)
+    expect(onClose).toHaveBeenCalledWith('a')
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  test('+ button calls onNew', async () => {
+    const onNew = vi.fn()
+    const user = userEvent.setup()
+    renderTabs([buildSession()], 'sess-1', { onNew })
+    await user.click(screen.getByRole('button', { name: 'New session' }))
+    expect(onNew).toHaveBeenCalledTimes(1)
+  })
+
+  test('renders a status pip alongside the running session title', () => {
+    const sessions = [buildSession({ id: 'a', status: 'running' })]
+    renderTabs(sessions, 'a')
+    const tab = screen.getByRole('tab')
+    const pip = within(tab).getByTestId('status-dot')
+    expect(pip).toHaveAttribute('data-status', 'running')
+  })
+
+  test('agent glyph chip shows the registry glyph (claude → ∴)', () => {
+    renderTabs([buildSession({ agentType: 'claude-code' })], 'sess-1')
+    const tab = screen.getByRole('tab')
+    expect(within(tab).getByText('∴')).toBeInTheDocument()
+  })
+
+  test('falls back to shell glyph for unknown agent types (generic)', () => {
+    renderTabs([buildSession({ agentType: 'generic' })], 'sess-1')
+    const tab = screen.getByRole('tab')
+    expect(within(tab).getByText('$')).toBeInTheDocument()
+  })
+
+  test('with no open sessions, only the + button renders', () => {
+    const sessions = [
+      buildSession({ id: 'a', status: 'completed' }),
+      buildSession({ id: 'b', status: 'errored' }),
+    ]
+    renderTabs(sessions, null)
+    expect(screen.queryAllByRole('tab')).toHaveLength(0)
+    expect(
+      screen.getByRole('button', { name: 'New session' })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -212,4 +212,61 @@ describe('SessionTabs', () => {
     expect(tabs[0]).toHaveTextContent('just exited')
     expect(tabs[0]).toHaveAttribute('aria-selected', 'true')
   })
+
+  test('ArrowRight on the active tab cycles selection to the next tab', async () => {
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+      buildSession({ id: 'c', name: 'docs' }),
+    ]
+    renderTabs(sessions, 'a', { onSelect })
+
+    const activeTab = screen.getAllByRole('tab')[0]
+    activeTab.focus()
+    await user.keyboard('{ArrowRight}')
+    expect(onSelect).toHaveBeenLastCalledWith('b')
+  })
+
+  test('ArrowLeft on the active tab wraps to the last tab', async () => {
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+      buildSession({ id: 'c', name: 'docs' }),
+    ]
+    renderTabs(sessions, 'a', { onSelect })
+
+    const activeTab = screen.getAllByRole('tab')[0]
+    activeTab.focus()
+    await user.keyboard('{ArrowLeft}')
+    expect(onSelect).toHaveBeenLastCalledWith('c')
+  })
+
+  test('Enter on a focused close button closes that tab without re-selecting', async () => {
+    // Cycle-3 P2: child key events were bubbling to the parent tab
+    // handler, so Enter on the close X also called onSelect and
+    // prevented the close. Now: tab handler ignores bubbled keys.
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+
+    renderTabs([buildSession({ id: 'a', name: 'auth' })], 'a', {
+      onSelect,
+      onClose,
+    })
+
+    const closeBtn = within(screen.getByRole('tab')).getByRole('button', {
+      name: /close auth/i,
+    })
+    closeBtn.focus()
+    await user.keyboard('{Enter}')
+
+    expect(onClose).toHaveBeenCalledWith('a')
+    expect(onSelect).not.toHaveBeenCalled()
+  })
 })

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -59,6 +59,13 @@ describe('SessionTabs', () => {
     expect(screen.getByRole('tablist')).toHaveAccessibleName('Open sessions')
   })
 
+  test('each tab carries aria-controls + id pointing at its TerminalZone panel', () => {
+    renderTabs([buildSession({ id: 'sess-x' })], 'sess-x')
+    const tab = screen.getByRole('tab')
+    expect(tab).toHaveAttribute('id', 'session-tab-sess-x')
+    expect(tab).toHaveAttribute('aria-controls', 'session-panel-sess-x')
+  })
+
   test('tablist owns ONLY tab children (WAI-ARIA §3.27)', () => {
     // The "+" button and trailing flex spacer must live OUTSIDE the
     // tablist so screen readers don't iterate them in the arrow-key
@@ -280,7 +287,9 @@ describe('SessionTabs', () => {
     expect(tabs[0]).toHaveAttribute('aria-selected', 'true')
   })
 
-  test('ArrowRight on the active tab cycles selection to the next tab', async () => {
+  test('ArrowRight moves DOM focus only — does not switch the active session', async () => {
+    // Manual-activation pattern (WAI-ARIA tabs): arrow keys move focus
+    // for scanning; Enter/Space commits the activation.
     const onSelect = vi.fn()
     const user = userEvent.setup()
 
@@ -291,13 +300,15 @@ describe('SessionTabs', () => {
     ]
     renderTabs(sessions, 'a', { onSelect })
 
-    const activeTab = screen.getAllByRole('tab')[0]
-    activeTab.focus()
+    const tabs = screen.getAllByRole('tab')
+    tabs[0].focus()
     await user.keyboard('{ArrowRight}')
-    expect(onSelect).toHaveBeenLastCalledWith('b')
+
+    expect(tabs[1]).toHaveFocus()
+    expect(onSelect).not.toHaveBeenCalled()
   })
 
-  test('ArrowLeft on the active tab wraps to the last tab', async () => {
+  test('ArrowLeft wraps focus to the last tab without activating it', async () => {
     const onSelect = vi.fn()
     const user = userEvent.setup()
 
@@ -308,10 +319,30 @@ describe('SessionTabs', () => {
     ]
     renderTabs(sessions, 'a', { onSelect })
 
-    const activeTab = screen.getAllByRole('tab')[0]
-    activeTab.focus()
+    const tabs = screen.getAllByRole('tab')
+    tabs[0].focus()
     await user.keyboard('{ArrowLeft}')
-    expect(onSelect).toHaveBeenLastCalledWith('c')
+
+    expect(tabs[2]).toHaveFocus()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  test('Enter on a focused inactive tab activates it (manual activation)', async () => {
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, 'a', { onSelect })
+
+    const tabs = screen.getAllByRole('tab')
+    // Simulate user arrow-keying to inactive tab and pressing Enter.
+    tabs[1].focus()
+    await user.keyboard('{Enter}')
+
+    expect(onSelect).toHaveBeenCalledWith('b')
   })
 
   test('Enter on a focused close button closes that tab without re-selecting', async () => {

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -300,43 +300,26 @@ describe('SessionTabs', () => {
     expect(tabs[0]).toHaveAttribute('aria-selected', 'true')
   })
 
-  test('ArrowRight moves DOM focus only — does not switch the active session', async () => {
-    // Manual-activation pattern (WAI-ARIA tabs): arrow keys move focus
-    // for scanning; Enter/Space commits the activation.
+  test('ArrowLeft / ArrowRight do nothing inside a focused tab', async () => {
+    // Tab-strip arrow cycling belongs on a global keybinding (see the
+    // stub note in SessionTabs.tsx). Removing the in-component handler
+    // keeps the focused tab stable when the user accidentally arrows
+    // while focus is parked on the strip.
     const onSelect = vi.fn()
     const user = userEvent.setup()
 
     const sessions = [
       buildSession({ id: 'a', name: 'auth' }),
       buildSession({ id: 'b', name: 'tests' }),
-      buildSession({ id: 'c', name: 'docs' }),
     ]
     renderTabs(sessions, 'a', { onSelect })
 
     const tabs = screen.getAllByRole('tab')
     tabs[0].focus()
     await user.keyboard('{ArrowRight}')
-
-    expect(tabs[1]).toHaveFocus()
-    expect(onSelect).not.toHaveBeenCalled()
-  })
-
-  test('ArrowLeft wraps focus to the last tab without activating it', async () => {
-    const onSelect = vi.fn()
-    const user = userEvent.setup()
-
-    const sessions = [
-      buildSession({ id: 'a', name: 'auth' }),
-      buildSession({ id: 'b', name: 'tests' }),
-      buildSession({ id: 'c', name: 'docs' }),
-    ]
-    renderTabs(sessions, 'a', { onSelect })
-
-    const tabs = screen.getAllByRole('tab')
-    tabs[0].focus()
     await user.keyboard('{ArrowLeft}')
 
-    expect(tabs[2]).toHaveFocus()
+    expect(tabs[0]).toHaveFocus()
     expect(onSelect).not.toHaveBeenCalled()
   })
 

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -217,17 +217,43 @@ describe('SessionTabs', () => {
     expect(tabs[1]).toHaveAttribute('tabindex', '-1')
   })
 
-  test('inactive tab close button is removed from the natural Tab order', () => {
-    // Roving tabindex must extend to interactive descendants — otherwise
-    // Tab navigation lands on close buttons of tabs the user can't see.
+  test('close buttons are always tabIndex=-1 (single Tab stop in tablist)', () => {
+    // WAI-ARIA tabs §3.27: the entire tablist is exactly one Tab stop.
+    // Interactive descendants (close X) are reached via Delete/Backspace
+    // on the focused tab, not via Tab. Both active AND inactive close
+    // buttons must be tabIndex=-1 so Tab passes through to the tabpanel.
     const sessions = [
       buildSession({ id: 'a', name: 'auth' }),
       buildSession({ id: 'b', name: 'tests' }),
     ]
     renderTabs(sessions, 'a')
     const closeBtns = screen.getAllByRole('button', { name: /^Close / })
-    expect(closeBtns[0]).toHaveAttribute('tabindex', '0')
+    expect(closeBtns[0]).toHaveAttribute('tabindex', '-1')
     expect(closeBtns[1]).toHaveAttribute('tabindex', '-1')
+  })
+
+  test('Delete on the focused tab calls onClose (browser-tab convention)', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    const sessions = [buildSession({ id: 'a', name: 'auth' })]
+    renderTabs(sessions, 'a', { onClose })
+
+    const tab = screen.getByRole('tab')
+    tab.focus()
+    await user.keyboard('{Delete}')
+    expect(onClose).toHaveBeenCalledWith('a')
+  })
+
+  test('Backspace on the focused tab also calls onClose', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    const sessions = [buildSession({ id: 'a', name: 'auth' })]
+    renderTabs(sessions, 'a', { onClose })
+
+    const tab = screen.getByRole('tab')
+    tab.focus()
+    await user.keyboard('{Backspace}')
+    expect(onClose).toHaveBeenCalledWith('a')
   })
 
   test('renders a status pip alongside the running session title', () => {

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -66,6 +66,15 @@ describe('SessionTabs', () => {
     expect(tab).toHaveAttribute('aria-controls', 'session-panel-sess-x')
   })
 
+  test('tab has explicit aria-label so descendant labels do not pollute its name', () => {
+    // Without aria-label on the tab, ARIA name computation accumulates
+    // descendant labels — the close button's "Close <name>" and the
+    // StatusDot's "Status running" would both fold into the tab's
+    // computed name. An explicit aria-label pins it to just session.name.
+    renderTabs([buildSession({ id: 'a', name: 'auth refactor' })], 'a')
+    expect(screen.getByRole('tab')).toHaveAccessibleName('auth refactor')
+  })
+
   test('tablist owns ONLY tab children (WAI-ARIA §3.27)', () => {
     // The "+" button and trailing flex spacer must live OUTSIDE the
     // tablist so screen readers don't iterate them in the arrow-key
@@ -237,6 +246,40 @@ describe('SessionTabs', () => {
     expect(
       screen.getByRole('button', { name: 'New session' })
     ).toBeInTheDocument()
+  })
+
+  test('keyboard close moves DOM focus to the new active tab (WAI-ARIA §4.4.3)', async () => {
+    // Without focus restoration, the browser drops focus to <body> when
+    // the close button is removed mid-render. Keyboard users would have
+    // to re-Tab into the strip after every close.
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, 'a', { onSelect, onClose })
+
+    const tabs = screen.getAllByRole('tab')
+
+    const closeBtn = within(tabs[0]).getByRole('button', {
+      name: /^Close auth/,
+    })
+    closeBtn.focus()
+    await user.keyboard('{Enter}')
+
+    expect(onClose).toHaveBeenCalledWith('a')
+    expect(onSelect).toHaveBeenCalledWith('b')
+    // Wait a microtask for the queueMicrotask focus call.
+    await new Promise<void>((resolve) => {
+      queueMicrotask(resolve)
+    })
+    // The renderer mock leaves 'a' in the tablist (onClose is a vi.fn());
+    // verifying focus by id avoids that mismatch — the new active tab is
+    // 'b' regardless of what the parent does with the closed session.
+    expect(screen.getByRole('tab', { name: 'tests' })).toHaveFocus()
   })
 
   test('closing the active tab pre-selects the next VISIBLE tab', async () => {

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -203,6 +203,20 @@ describe('SessionTabs', () => {
     expect(tabs[1]).toHaveAttribute('tabindex', '-1')
   })
 
+  test('null activeSessionId falls back to the first visible tab (roving entry)', () => {
+    // Without the fallback, every tab gets tabIndex=-1 and keyboard
+    // users skip the entire tablist. The strip must always have one
+    // entry point as long as `open` is non-empty.
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, null)
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs[0]).toHaveAttribute('tabindex', '0')
+    expect(tabs[1]).toHaveAttribute('tabindex', '-1')
+  })
+
   test('inactive tab close button is removed from the natural Tab order', () => {
     // Roving tabindex must extend to interactive descendants — otherwise
     // Tab navigation lands on close buttons of tabs the user can't see.
@@ -306,6 +320,14 @@ describe('SessionTabs', () => {
     // Visible-order next tab is 'A' (B is filtered out of the strip).
     expect(onSelect).toHaveBeenCalledWith('A')
     expect(onClose).toHaveBeenCalledWith('C')
+    // Order matters: useSessionManager.removeSession uses flushSync
+    // internally and applies its own setActiveSessionId mid-call. If
+    // onSelect ran first, that flushSync would overwrite our visible-
+    // order pick. Locking the contract so a refactor can't silently
+    // re-introduce the bug.
+    expect(onClose.mock.invocationCallOrder[0]).toBeLessThan(
+      onSelect.mock.invocationCallOrder[0]
+    )
   })
 
   test('closing an inactive tab does NOT change selection', async () => {

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -194,6 +194,19 @@ describe('SessionTabs', () => {
     expect(tabs[1]).toHaveAttribute('tabindex', '-1')
   })
 
+  test('inactive tab close button is removed from the natural Tab order', () => {
+    // Roving tabindex must extend to interactive descendants — otherwise
+    // Tab navigation lands on close buttons of tabs the user can't see.
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, 'a')
+    const closeBtns = screen.getAllByRole('button', { name: /^Close / })
+    expect(closeBtns[0]).toHaveAttribute('tabindex', '0')
+    expect(closeBtns[1]).toHaveAttribute('tabindex', '-1')
+  })
+
   test('renders a status pip alongside the running session title', () => {
     const sessions = [buildSession({ id: 'a', status: 'running' })]
     renderTabs(sessions, 'a')

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -136,6 +136,36 @@ describe('SessionTabs', () => {
     expect(onNew).toHaveBeenCalledTimes(1)
   })
 
+  test('keyboard activation: Enter/Space on a focused tab calls onSelect', async () => {
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, 'a', { onSelect })
+
+    const inactiveTab = screen.getAllByRole('tab')[1]
+    inactiveTab.focus()
+    await user.keyboard('{Enter}')
+    expect(onSelect).toHaveBeenLastCalledWith('b')
+
+    await user.keyboard(' ')
+    expect(onSelect).toHaveBeenLastCalledWith('b')
+  })
+
+  test('only the active tab carries tabIndex=0 (roving focus)', () => {
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, 'a')
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs[0]).toHaveAttribute('tabindex', '0')
+    expect(tabs[1]).toHaveAttribute('tabindex', '-1')
+  })
+
   test('renders a status pip alongside the running session title', () => {
     const sessions = [buildSession({ id: 'a', status: 'running' })]
     renderTabs(sessions, 'a')

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -59,6 +59,27 @@ describe('SessionTabs', () => {
     expect(screen.getByRole('tablist')).toHaveAccessibleName('Open sessions')
   })
 
+  test('tablist owns ONLY tab children (WAI-ARIA §3.27)', () => {
+    // The "+" button and trailing flex spacer must live OUTSIDE the
+    // tablist so screen readers don't iterate them in the arrow-key
+    // cycle as fourth/fifth tabs.
+    renderTabs(
+      [
+        buildSession({ id: 'a', name: 'auth' }),
+        buildSession({ id: 'b', name: 'tests' }),
+      ],
+      'a'
+    )
+    const tablist = screen.getByRole('tablist')
+    const newSessionBtn = screen.getByRole('button', { name: 'New session' })
+
+    expect(within(tablist).getAllByRole('tab')).toHaveLength(2)
+    expect(
+      within(tablist).queryByRole('button', { name: 'New session' })
+    ).toBeNull()
+    expect(tablist.contains(newSessionBtn)).toBe(false)
+  })
+
   test('renders one tab per open session (running + paused)', () => {
     const sessions: Session[] = [
       buildSession({ id: 'a', status: 'running', name: 'auth' }),

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -261,6 +261,24 @@ describe('SessionTabs', () => {
     expect(tabs[1]).toHaveAttribute('tabindex', '-1')
   })
 
+  test('stale (non-null) activeSessionId after flushSync removeSession also falls back to the first visible tab', () => {
+    // Repro: useSessionManager.removeSession uses flushSync; there's an
+    // intermediate React commit where `sessions` has dropped the removed
+    // session but `activeSessionId` still holds its (now-stale) id. No
+    // visible tab matches activeSessionId, AND the `null` guard does
+    // not fire (id is non-null-but-stale). Without the hasFocusMatch
+    // tie-breaker, every tab gets tabIndex=-1 → tablist becomes
+    // keyboard-unreachable for that frame.
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, 'just-removed-session-x')
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs[0]).toHaveAttribute('tabindex', '0')
+    expect(tabs[1]).toHaveAttribute('tabindex', '-1')
+  })
+
   test('close buttons are always tabIndex=-1 (single Tab stop in tablist)', () => {
     // WAI-ARIA tabs §3.27: the entire tablist is exactly one Tab stop.
     // Interactive descendants (close X) are reached via Delete/Backspace

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -198,6 +198,52 @@ describe('SessionTabs', () => {
     ).toBeInTheDocument()
   })
 
+  test('closing the active tab pre-selects the next VISIBLE tab', async () => {
+    // Without pre-select, useSessionManager's fallback can land on a
+    // hidden completed/errored session that sits between two open
+    // ones in the underlying sessions array. Pre-select keeps the
+    // selection on a tab the user can actually see.
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+
+    const sessions = [
+      buildSession({ id: 'C', status: 'running', name: 'first' }),
+      buildSession({ id: 'B', status: 'completed', name: 'hidden recent' }),
+      buildSession({ id: 'A', status: 'running', name: 'last' }),
+    ]
+    renderTabs(sessions, 'C', { onSelect, onClose })
+
+    const closeC = within(screen.getAllByRole('tab')[0]).getByRole('button', {
+      name: /close first/i,
+    })
+    await user.click(closeC)
+
+    // Visible-order next tab is 'A' (B is filtered out of the strip).
+    expect(onSelect).toHaveBeenCalledWith('A')
+    expect(onClose).toHaveBeenCalledWith('C')
+  })
+
+  test('closing an inactive tab does NOT change selection', async () => {
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, 'a', { onSelect, onClose })
+
+    const closeB = within(screen.getAllByRole('tab')[1]).getByRole('button', {
+      name: /close tests/i,
+    })
+    await user.click(closeB)
+
+    expect(onClose).toHaveBeenCalledWith('b')
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
   test('keeps the active session in the strip even after its PTY exits', () => {
     // useSessionManager keeps activeSessionId on a session whose PTY
     // exited so TerminalZone can show the Restart pane. Dropping that

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -236,6 +236,31 @@ describe('SessionTabs', () => {
     expect(onSelect).toHaveBeenLastCalledWith('b')
   })
 
+  test('clicking the already-active tab does NOT call onSelect (no redundant IPC + no rollback interference)', async () => {
+    // WorkspaceView's onSelect bridges to setActiveSession(IPC). A
+    // redundant call for the already-active tab adds a round-trip AND
+    // can interfere with useSessionManager's request-supersession
+    // rollback under transient failures (a later no-op request can
+    // supersede an earlier real switch).
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+
+    const sessions = [
+      buildSession({ id: 'a', name: 'auth' }),
+      buildSession({ id: 'b', name: 'tests' }),
+    ]
+    renderTabs(sessions, 'a', { onSelect })
+
+    const activeTab = screen.getAllByRole('tab')[0]
+    await user.click(activeTab)
+    expect(onSelect).not.toHaveBeenCalled()
+
+    activeTab.focus()
+    await user.keyboard('{Enter}')
+    await user.keyboard(' ')
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
   test('only the active tab carries tabIndex=0 (roving focus)', () => {
     const sessions = [
       buildSession({ id: 'a', name: 'auth' }),

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -75,6 +75,50 @@ describe('SessionTabs', () => {
     expect(screen.getByRole('tab')).toHaveAccessibleName('auth refactor')
   })
 
+  test('exited active tab appends "(ended)" to the accessible name so screen-reader users hear the status change', () => {
+    // The live-status pip is hidden for exited sessions to keep the
+    // "heartbeat only for live sessions" visual language. Without the
+    // accessible-name suffix, keyboard-only users would hear the same
+    // "auth refactor, tab" before AND after the session exited and
+    // would not know the session needs a restart until they Tab into
+    // the panel below. Per getVisibleSessions, an exited session keeps
+    // a tab only when it is the active session — that's exactly the
+    // 'active session just exited' case Claude flagged.
+    const { rerender } = renderTabs(
+      [
+        buildSession({
+          id: 'a',
+          name: 'completed-session',
+          status: 'completed',
+        }),
+      ],
+      'a'
+    )
+    expect(screen.getByRole('tab')).toHaveAccessibleName(
+      'completed-session (ended)'
+    )
+
+    rerender(
+      <SessionTabs
+        sessions={[
+          buildSession({
+            id: 'a',
+            name: 'errored-session',
+            status: 'errored',
+          }),
+        ]}
+        activeSessionId="a"
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        onNew={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('tab')).toHaveAccessibleName(
+      'errored-session (ended)'
+    )
+  })
+
   test('tablist owns ONLY tab children (WAI-ARIA §3.27)', () => {
     // The "+" button and trailing flex spacer must live OUTSIDE the
     // tablist so screen readers don't iterate them in the arrow-key

--- a/src/features/workspace/components/SessionTabs.test.tsx
+++ b/src/features/workspace/components/SessionTabs.test.tsx
@@ -186,7 +186,7 @@ describe('SessionTabs', () => {
     expect(within(tab).getByText('$')).toBeInTheDocument()
   })
 
-  test('with no open sessions, only the + button renders', () => {
+  test('with no open sessions and no active id, only the + button renders', () => {
     const sessions = [
       buildSession({ id: 'a', status: 'completed' }),
       buildSession({ id: 'b', status: 'errored' }),
@@ -196,5 +196,20 @@ describe('SessionTabs', () => {
     expect(
       screen.getByRole('button', { name: 'New session' })
     ).toBeInTheDocument()
+  })
+
+  test('keeps the active session in the strip even after its PTY exits', () => {
+    // useSessionManager keeps activeSessionId on a session whose PTY
+    // exited so TerminalZone can show the Restart pane. Dropping that
+    // tab would leave the visible pane with no selected tab.
+    const sessions = [
+      buildSession({ id: 'a', status: 'completed', name: 'just exited' }),
+      buildSession({ id: 'b', status: 'running', name: 'still alive' }),
+    ]
+    renderTabs(sessions, 'a')
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0]).toHaveTextContent('just exited')
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -2,7 +2,7 @@ import { type KeyboardEvent, type ReactElement } from 'react'
 import type { Session } from '../types'
 import { agentForSession } from '../utils/agentForSession'
 import {
-  isOpenSessionStatus,
+  getVisibleSessions,
   pickNextVisibleSessionId,
 } from '../utils/pickNextVisibleSessionId'
 import { StatusDot } from './StatusDot'
@@ -22,13 +22,11 @@ export const SessionTabs = ({
   onClose,
   onNew,
 }: SessionTabsProps): ReactElement => {
-  // Keep the active session in the strip even after its PTY exits (status
-  // flips to completed/errored): TerminalZone shows the Restart pane and
-  // useSessionManager keeps activeSessionId pointing at it. Dropping the
-  // tab would leave the visible pane with no selected tab.
-  const open = sessions.filter(
-    (s) => isOpenSessionStatus(s.status) || s.id === activeSessionId
-  )
+  // Single source of truth for "what's visible in the strip" — see
+  // `getVisibleSessions` for the predicate. Both this component and
+  // `pickNextVisibleSessionId` consume it so the visible-set can't
+  // drift between render and close-navigation.
+  const open = getVisibleSessions(sessions, activeSessionId)
 
   // STUB: tab cycling between sessions belongs on a global keybinding
   // (Cmd+Shift+] / [) routed through the command palette — see #177.
@@ -53,12 +51,13 @@ export const SessionTabs = ({
     onClose(sessionId)
     if (nextId !== undefined) {
       onSelect(nextId)
-      // WAI-ARIA Tabs Pattern §4.4.3: after a keyboard close, focus must
-      // move to the newly-selected tab. Removing the close button drops
-      // DOM focus to <body>; queueMicrotask defers until React has
-      // committed the re-render so the new active tab exists in the DOM.
-      // No-op for mouse closes (the focused element was already the
-      // close button, not body).
+      // WAI-ARIA Tabs Pattern §4.4.3: after a close, focus must move
+      // to the newly-selected tab. Removing the close button drops
+      // DOM focus to <body> regardless of input method — the close
+      // button briefly holds focus from mousedown too — so this fires
+      // for both mouse and keyboard closes. queueMicrotask defers
+      // until React has committed the re-render so the new active tab
+      // exists in the DOM.
       queueMicrotask(() => {
         document.getElementById(`session-tab-${nextId}`)?.focus()
       })

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -53,6 +53,23 @@ export const SessionTabs = ({
     queueMicrotask(() => tabRefs.current.get(nextId)?.focus())
   }
 
+  const handleClose = (sessionId: string): void => {
+    // If we're closing the active tab, pre-select the next visible tab
+    // BEFORE delegating to onClose. useSessionManager.removeSession
+    // otherwise picks the fallback by full-sessions-index, which can
+    // land on a hidden completed/errored session (between two open
+    // ones in the underlying array) and leave the strip showing a
+    // selection the user can't see.
+    if (sessionId === activeSessionId && open.length > 1) {
+      const ids = open.map((s) => s.id)
+      const idx = ids.indexOf(sessionId)
+      // Prefer the tab to the right; wrap to left when closing the last.
+      const nextId = idx === ids.length - 1 ? ids[idx - 1] : ids[idx + 1]
+      onSelect(nextId)
+    }
+    onClose(sessionId)
+  }
+
   return (
     <div
       data-testid="session-tabs"
@@ -66,7 +83,7 @@ export const SessionTabs = ({
           session={session}
           isActive={session.id === activeSessionId}
           onSelect={onSelect}
-          onClose={onClose}
+          onClose={handleClose}
           onArrow={focusTabAtOffset}
           registerRef={registerTab}
         />

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -212,6 +212,11 @@ const SessionTab = ({
       )}
       <button
         type="button"
+        // Roving tabindex includes interactive descendants. Without
+        // tabIndex=-1 here, native <button> keeps tabIndex=0 and Tab
+        // navigation lands on close buttons of inactive tabs the user
+        // can't see — risk of dismissing the wrong session.
+        tabIndex={isActive ? 0 : -1}
         onClick={(e) => {
           e.stopPropagation()
           onClose(session.id)

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -28,6 +28,19 @@ export const SessionTabs = ({
   // drift between render and close-navigation.
   const open = getVisibleSessions(sessions, activeSessionId)
 
+  // useSessionManager.removeSession uses `flushSync` internally to apply
+  // its own setActiveSessionId mid-call. There is an intermediate React
+  // commit where `sessions` has dropped the removed session but
+  // `activeSessionId` still holds its id; `getVisibleSessions` cannot
+  // include the removed id (no longer in `sessions`), so without this
+  // fallback every visible tab evaluates `id === activeSessionId` as
+  // false → all tabs get tabIndex=-1 → tablist is keyboard-unreachable
+  // for that frame. The `activeSessionId === null` guard does not fire
+  // either because the id is non-null-but-stale. Compute once per
+  // render and use as a tie-breaker so exactly one tab always carries
+  // tabIndex=0 — the WAI-ARIA roving-focus invariant.
+  const hasFocusMatch = open.some((s) => s.id === activeSessionId)
+
   // STUB: tab cycling between sessions belongs on a global keybinding
   // (Cmd+Shift+] / [) routed through the command palette — see #177.
   // xterm.js holds focus inside the terminal, so in-component
@@ -81,12 +94,17 @@ export const SessionTabs = ({
             key={session.id}
             session={session}
             isActive={session.id === activeSessionId}
-            // Roving-tabindex entry point: when activeSessionId is null
-            // (transient on initial mount), fall back to the first
-            // visible tab so keyboard users still have a focus stop.
+            // Roving-tabindex entry point. Three cases that all collapse
+            // to the same "first visible tab carries tabIndex=0" rule
+            // when no tab matches activeSessionId:
+            //   1. Initial mount: activeSessionId === null.
+            //   2. Sessions list loaded but no active selected yet.
+            //   3. Stale activeSessionId after `flushSync` removeSession
+            //      — the id refers to a session that's already been
+            //      dropped from `sessions`, so nothing in `open` matches.
+            // hasFocusMatch is the single check that covers all three.
             isFocusEntryPoint={
-              session.id === activeSessionId ||
-              (activeSessionId === null && idx === 0)
+              session.id === activeSessionId || (!hasFocusMatch && idx === 0)
             }
             onSelect={onSelect}
             onClose={handleClose}

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -162,8 +162,20 @@ const SessionTab = ({
       // running` and the close button's `Close <name>` would both fold
       // into the tab's announced name. Setting aria-label here pins the
       // computed name to just the session name; descendants stay
-      // independently focusable with their own labels.
-      aria-label={session.name}
+      // independently focusable with their own labels. Exited sessions
+      // (completed | errored) keep their tab so the Restart pane stays
+      // reachable, but the live-status pip is intentionally hidden — so
+      // sighted parity is delivered visually by the Restart pane in the
+      // tabpanel, while screen-reader parity is delivered by appending
+      // `(ended)` to the tab's accessible name. Without this suffix
+      // keyboard-only users would hear the same tab label before and
+      // after the session exited and would not know the session needs a
+      // restart until they Tab into the panel.
+      aria-label={
+        session.status === 'completed' || session.status === 'errored'
+          ? `${session.name} (ended)`
+          : session.name
+      }
       aria-selected={isActive}
       aria-controls={`session-panel-${session.id}`}
       tabIndex={isFocusEntryPoint ? 0 : -1}

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -77,11 +77,18 @@ export const SessionTabs = ({
         aria-label="Open sessions"
         className="flex items-end gap-0.5"
       >
-        {open.map((session) => (
+        {open.map((session, idx) => (
           <SessionTab
             key={session.id}
             session={session}
             isActive={session.id === activeSessionId}
+            // Roving-tabindex entry point: when activeSessionId is null
+            // (transient on initial mount), fall back to the first
+            // visible tab so keyboard users still have a focus stop.
+            isFocusEntryPoint={
+              session.id === activeSessionId ||
+              (activeSessionId === null && idx === 0)
+            }
             onSelect={onSelect}
             onClose={handleClose}
           />
@@ -104,6 +111,13 @@ export const SessionTabs = ({
 interface SessionTabProps {
   session: Session
   isActive: boolean
+  /**
+   * Drives `tabIndex=0` for the roving-focus entry point. Equal to
+   * `isActive` in the steady state; differs only when `activeSessionId`
+   * is null and we fall back to the first visible tab so the keyboard
+   * still has a way into the tablist.
+   */
+  isFocusEntryPoint: boolean
   onSelect: (sessionId: string) => void
   onClose: (sessionId: string) => void
 }
@@ -111,6 +125,7 @@ interface SessionTabProps {
 const SessionTab = ({
   session,
   isActive,
+  isFocusEntryPoint,
   onSelect,
   onClose,
 }: SessionTabProps): ReactElement => {
@@ -144,7 +159,7 @@ const SessionTab = ({
       aria-label={session.name}
       aria-selected={isActive}
       aria-controls={`session-panel-${session.id}`}
-      tabIndex={isActive ? 0 : -1}
+      tabIndex={isFocusEntryPoint ? 0 : -1}
       data-testid="session-tab"
       data-session-id={session.id}
       data-active={isActive}
@@ -195,8 +210,10 @@ const SessionTab = ({
         // Roving tabindex includes interactive descendants. Without
         // tabIndex=-1 here, native <button> keeps tabIndex=0 and Tab
         // navigation lands on close buttons of inactive tabs the user
-        // can't see — risk of dismissing the wrong session.
-        tabIndex={isActive ? 0 : -1}
+        // can't see — risk of dismissing the wrong session. Tracks
+        // isFocusEntryPoint (not isActive) so the null-active fallback
+        // also exposes the close button on the first visible tab.
+        tabIndex={isFocusEntryPoint ? 0 : -1}
         onClick={(e) => {
           e.stopPropagation()
           onClose(session.id)

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -1,6 +1,10 @@
 import { useRef, type KeyboardEvent, type ReactElement } from 'react'
 import type { Session } from '../types'
 import { agentForSession } from '../utils/agentForSession'
+import {
+  isOpenSessionStatus,
+  pickNextVisibleSessionId,
+} from '../utils/pickNextVisibleSessionId'
 import { StatusDot } from './StatusDot'
 
 export interface SessionTabsProps {
@@ -10,9 +14,6 @@ export interface SessionTabsProps {
   onClose: (sessionId: string) => void
   onNew: () => void
 }
-
-const isOpenStatus = (s: Session): boolean =>
-  s.status === 'running' || s.status === 'paused'
 
 export const SessionTabs = ({
   sessions,
@@ -26,7 +27,7 @@ export const SessionTabs = ({
   // useSessionManager keeps activeSessionId pointing at it. Dropping the
   // tab would leave the visible pane with no selected tab.
   const open = sessions.filter(
-    (s) => isOpenStatus(s) || s.id === activeSessionId
+    (s) => isOpenSessionStatus(s.status) || s.id === activeSessionId
   )
 
   const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map())
@@ -60,18 +61,15 @@ export const SessionTabs = ({
     // useSessionManager.removeSession picks its fallback by full-sessions
     // index, which can land on a hidden completed/errored session sitting
     // between two visible ones in the underlying array. We override with
-    // the visible next-tab id from `open`. Order matters: onClose runs
-    // first so removeSession can do its work (kill IPC, drop from list,
-    // pick its own fallback); the trailing onSelect then overrides the
-    // selection to a tab the user can actually see. This way an onClose
-    // failure cannot strand the selection on a removed id.
-    let nextId: string | undefined
-    if (sessionId === activeSessionId && open.length > 1) {
-      const ids = open.map((s) => s.id)
-      const idx = ids.indexOf(sessionId)
-      // Prefer the tab to the right; wrap to left when closing the last.
-      nextId = idx === ids.length - 1 ? ids[idx - 1] : ids[idx + 1]
-    }
+    // the visible next-tab id. Order matters: onClose runs first so
+    // removeSession can do its work (kill IPC, drop from list, pick its
+    // own fallback); the trailing onSelect then overrides the selection
+    // to a tab the user can actually see. This way an onClose failure
+    // cannot strand the selection on a removed id.
+    const nextId =
+      sessionId === activeSessionId
+        ? pickNextVisibleSessionId(sessions, sessionId, activeSessionId)
+        : undefined
     onClose(sessionId)
     if (nextId !== undefined) {
       onSelect(nextId)

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -54,20 +54,25 @@ export const SessionTabs = ({
   }
 
   const handleClose = (sessionId: string): void => {
-    // If we're closing the active tab, pre-select the next visible tab
-    // BEFORE delegating to onClose. useSessionManager.removeSession
-    // otherwise picks the fallback by full-sessions-index, which can
-    // land on a hidden completed/errored session (between two open
-    // ones in the underlying array) and leave the strip showing a
-    // selection the user can't see.
+    // useSessionManager.removeSession picks its fallback by full-sessions
+    // index, which can land on a hidden completed/errored session sitting
+    // between two visible ones in the underlying array. We override with
+    // the visible next-tab id from `open`. Order matters: onClose runs
+    // first so removeSession can do its work (kill IPC, drop from list,
+    // pick its own fallback); the trailing onSelect then overrides the
+    // selection to a tab the user can actually see. This way an onClose
+    // failure cannot strand the selection on a removed id.
+    let nextId: string | undefined
     if (sessionId === activeSessionId && open.length > 1) {
       const ids = open.map((s) => s.id)
       const idx = ids.indexOf(sessionId)
       // Prefer the tab to the right; wrap to left when closing the last.
-      const nextId = idx === ids.length - 1 ? ids[idx - 1] : ids[idx + 1]
-      onSelect(nextId)
+      nextId = idx === ids.length - 1 ? ids[idx - 1] : ids[idx + 1]
     }
     onClose(sessionId)
+    if (nextId !== undefined) {
+      onSelect(nextId)
+    }
   }
 
   return (

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -53,6 +53,15 @@ export const SessionTabs = ({
     onClose(sessionId)
     if (nextId !== undefined) {
       onSelect(nextId)
+      // WAI-ARIA Tabs Pattern §4.4.3: after a keyboard close, focus must
+      // move to the newly-selected tab. Removing the close button drops
+      // DOM focus to <body>; queueMicrotask defers until React has
+      // committed the re-render so the new active tab exists in the DOM.
+      // No-op for mouse closes (the focused element was already the
+      // close button, not body).
+      queueMicrotask(() => {
+        document.getElementById(`session-tab-${nextId}`)?.focus()
+      })
     }
   }
 
@@ -126,6 +135,13 @@ const SessionTab = ({
     <div
       id={`session-tab-${session.id}`}
       role="tab"
+      // Without an explicit name, the ARIA accessible-name algorithm
+      // accumulates labels from descendants — the StatusDot's `Status
+      // running` and the close button's `Close <name>` would both fold
+      // into the tab's announced name. Setting aria-label here pins the
+      // computed name to just the session name; descendants stay
+      // independently focusable with their own labels.
+      aria-label={session.name}
       aria-selected={isActive}
       aria-controls={`session-panel-${session.id}`}
       tabIndex={isActive ? 0 : -1}

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -1,4 +1,4 @@
-import { useRef, type KeyboardEvent, type ReactElement } from 'react'
+import { type KeyboardEvent, type ReactElement } from 'react'
 import type { Session } from '../types'
 import { agentForSession } from '../utils/agentForSession'
 import {
@@ -30,32 +30,13 @@ export const SessionTabs = ({
     (s) => isOpenSessionStatus(s.status) || s.id === activeSessionId
   )
 
-  const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map())
-
-  const registerTab = (id: string, el: HTMLDivElement | null): void => {
-    if (el === null) {
-      tabRefs.current.delete(id)
-    } else {
-      tabRefs.current.set(id, el)
-    }
-  }
-
-  const focusTabAtOffset = (currentId: string, offset: number): void => {
-    const ids = open.map((s) => s.id)
-    const idx = ids.indexOf(currentId)
-    if (idx === -1 || ids.length === 0) {
-      return
-    }
-    const nextIdx = (idx + offset + ids.length) % ids.length
-    const nextId = ids[nextIdx]
-    // Manual-activation pattern (WAI-ARIA tabs): ArrowLeft/Right move DOM
-    // focus only — they do NOT change `activeSessionId`. Activation
-    // happens explicitly on Enter/Space (handled in SessionTab below).
-    // This keeps the visible terminal pane stable while a keyboard user
-    // is scanning adjacent tab labels with the screen reader; switching
-    // mid-scan would tear down the live xterm and reattach.
-    tabRefs.current.get(nextId)?.focus()
-  }
+  // STUB: tab cycling between sessions belongs on a global keybinding
+  // (e.g. Cmd+Shift+] / [) routed through the command palette. While
+  // xterm.js holds focus inside the terminal, in-component arrow-key
+  // handlers on the tab divs never fire — the user can't Tab into the
+  // strip without first leaving the terminal. The previous attempt at
+  // ArrowLeft/Right within SessionTabs was removed for this reason.
+  // See issue tracker for the global-keybinding follow-up.
 
   const handleClose = (sessionId: string): void => {
     // useSessionManager.removeSession picks its fallback by full-sessions
@@ -82,8 +63,7 @@ export const SessionTabs = ({
       className="flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest px-2"
     >
       {/* WAI-ARIA 1.2 §3.27 requires `tablist` to own only `tab` children.
-          Keeping the `+` button and the spacer outside the tablist boundary
-          so screen readers don't iterate them in the arrow-key cycle. */}
+          Keeping the `+` button and the spacer outside the tablist boundary. */}
       <div
         role="tablist"
         aria-label="Open sessions"
@@ -96,8 +76,6 @@ export const SessionTabs = ({
             isActive={session.id === activeSessionId}
             onSelect={onSelect}
             onClose={handleClose}
-            onArrow={focusTabAtOffset}
-            registerRef={registerTab}
           />
         ))}
       </div>
@@ -120,8 +98,6 @@ interface SessionTabProps {
   isActive: boolean
   onSelect: (sessionId: string) => void
   onClose: (sessionId: string) => void
-  onArrow: (currentId: string, offset: number) => void
-  registerRef: (id: string, el: HTMLDivElement | null) => void
 }
 
 const SessionTab = ({
@@ -129,37 +105,26 @@ const SessionTab = ({
   isActive,
   onSelect,
   onClose,
-  onArrow,
-  registerRef,
 }: SessionTabProps): ReactElement => {
   const agent = agentForSession(session)
 
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>): void => {
-    // Don't react to keys that bubbled from a focused descendant (close X).
+    // Ignore key events that bubbled from a focused descendant (close X).
     if (e.target !== e.currentTarget) {
       return
     }
+    // Enter / Space activate the focused tab. Arrow-key cycling between
+    // tabs intentionally not handled here — see the global-keybinding
+    // stub note in SessionTabs above. Without that, in practice xterm
+    // owns focus and the tab strip is mouse-driven.
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       onSelect(session.id)
-
-      return
-    }
-    if (e.key === 'ArrowRight') {
-      e.preventDefault()
-      onArrow(session.id, 1)
-
-      return
-    }
-    if (e.key === 'ArrowLeft') {
-      e.preventDefault()
-      onArrow(session.id, -1)
     }
   }
 
   return (
     <div
-      ref={(el) => registerRef(session.id, el)}
       id={`session-tab-${session.id}`}
       role="tab"
       aria-selected={isActive}

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -21,7 +21,13 @@ export const SessionTabs = ({
   onClose,
   onNew,
 }: SessionTabsProps): ReactElement => {
-  const open = sessions.filter(isOpenStatus)
+  // Keep the active session in the strip even after its PTY exits (status
+  // flips to completed/errored): TerminalZone shows the Restart pane and
+  // useSessionManager keeps activeSessionId pointing at it. Dropping the
+  // tab would leave the visible pane with no selected tab.
+  const open = sessions.filter(
+    (s) => isOpenStatus(s) || s.id === activeSessionId
+  )
 
   return (
     <div

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -78,21 +78,28 @@ export const SessionTabs = ({
   return (
     <div
       data-testid="session-tabs"
-      role="tablist"
-      aria-label="Open sessions"
       className="flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest px-2"
     >
-      {open.map((session) => (
-        <SessionTab
-          key={session.id}
-          session={session}
-          isActive={session.id === activeSessionId}
-          onSelect={onSelect}
-          onClose={handleClose}
-          onArrow={focusTabAtOffset}
-          registerRef={registerTab}
-        />
-      ))}
+      {/* WAI-ARIA 1.2 §3.27 requires `tablist` to own only `tab` children.
+          Keeping the `+` button and the spacer outside the tablist boundary
+          so screen readers don't iterate them in the arrow-key cycle. */}
+      <div
+        role="tablist"
+        aria-label="Open sessions"
+        className="flex items-end gap-0.5"
+      >
+        {open.map((session) => (
+          <SessionTab
+            key={session.id}
+            session={session}
+            isActive={session.id === activeSessionId}
+            onSelect={onSelect}
+            onClose={handleClose}
+            onArrow={focusTabAtOffset}
+            registerRef={registerTab}
+          />
+        ))}
+      </div>
       <button
         type="button"
         onClick={onNew}

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -31,12 +31,11 @@ export const SessionTabs = ({
   )
 
   // STUB: tab cycling between sessions belongs on a global keybinding
-  // (e.g. Cmd+Shift+] / [) routed through the command palette. While
-  // xterm.js holds focus inside the terminal, in-component arrow-key
-  // handlers on the tab divs never fire — the user can't Tab into the
-  // strip without first leaving the terminal. The previous attempt at
-  // ArrowLeft/Right within SessionTabs was removed for this reason.
-  // See issue tracker for the global-keybinding follow-up.
+  // (Cmd+Shift+] / [) routed through the command palette — see #177.
+  // xterm.js holds focus inside the terminal, so in-component
+  // arrow-key handlers on the tab divs never fire; the user can't
+  // Tab into the strip without leaving the terminal first. The
+  // previous in-component handler was removed for that reason.
 
   const handleClose = (sessionId: string): void => {
     // useSessionManager.removeSession picks its fallback by full-sessions

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -1,0 +1,131 @@
+import type { ReactElement } from 'react'
+import type { Session } from '../types'
+import { agentForSession } from '../utils/agentForSession'
+import { StatusDot } from './StatusDot'
+
+export interface SessionTabsProps {
+  sessions: Session[]
+  activeSessionId: string | null
+  onSelect: (sessionId: string) => void
+  onClose: (sessionId: string) => void
+  onNew: () => void
+}
+
+const isOpenStatus = (s: Session): boolean =>
+  s.status === 'running' || s.status === 'paused'
+
+export const SessionTabs = ({
+  sessions,
+  activeSessionId,
+  onSelect,
+  onClose,
+  onNew,
+}: SessionTabsProps): ReactElement => {
+  const open = sessions.filter(isOpenStatus)
+
+  return (
+    <div
+      data-testid="session-tabs"
+      role="tablist"
+      aria-label="Open sessions"
+      className="flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest px-2"
+    >
+      {open.map((session) => (
+        <SessionTab
+          key={session.id}
+          session={session}
+          isActive={session.id === activeSessionId}
+          onSelect={onSelect}
+          onClose={onClose}
+        />
+      ))}
+      <button
+        type="button"
+        onClick={onNew}
+        aria-label="New session"
+        title="New session"
+        className="mb-px ml-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-on-surface-variant transition-colors hover:bg-primary/10 hover:text-primary"
+      >
+        <span className="material-symbols-outlined text-[15px]">add</span>
+      </button>
+      <span className="flex-1" />
+    </div>
+  )
+}
+
+interface SessionTabProps {
+  session: Session
+  isActive: boolean
+  onSelect: (sessionId: string) => void
+  onClose: (sessionId: string) => void
+}
+
+const SessionTab = ({
+  session,
+  isActive,
+  onSelect,
+  onClose,
+}: SessionTabProps): ReactElement => {
+  const agent = agentForSession(session)
+
+  return (
+    <div
+      role="tab"
+      aria-selected={isActive}
+      data-testid="session-tab"
+      data-session-id={session.id}
+      data-active={isActive}
+      onClick={() => onSelect(session.id)}
+      className={`
+        relative flex h-[30px] min-w-[130px] max-w-[220px] cursor-pointer items-center gap-2
+        rounded-t-lg border border-transparent pl-3 pr-2 transition-colors
+        ${
+          isActive
+            ? '-mb-px bg-surface border-outline-variant/30'
+            : 'hover:bg-on-surface/[0.025]'
+        }
+      `}
+    >
+      {isActive && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-x-1.5 top-0 h-0.5 rounded-b-sm"
+          style={{ background: agent.accent }}
+        />
+      )}
+      <span
+        aria-hidden="true"
+        className="flex h-4 w-4 shrink-0 items-center justify-center rounded font-mono text-[10px] font-bold"
+        style={{ background: agent.accentDim, color: agent.accent }}
+      >
+        {agent.glyph}
+      </span>
+      <span
+        className={`
+          min-w-0 flex-1 truncate font-mono text-[11px]
+          ${isActive ? 'font-medium text-on-surface' : 'text-on-surface-variant'}
+        `}
+      >
+        {session.name}
+      </span>
+      {(session.status === 'running' || session.status === 'paused') && (
+        <StatusDot
+          status={session.status}
+          size={5}
+          aria-label={`Status ${session.status}`}
+        />
+      )}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          onClose(session.id)
+        }}
+        aria-label={`Close ${session.name}`}
+        className="flex h-4 w-4 shrink-0 items-center justify-center rounded text-on-surface-variant/70 transition-colors hover:bg-on-surface/[0.06] hover:text-on-surface"
+      >
+        <span className="material-symbols-outlined text-[11px]">close</span>
+      </button>
+    </div>
+  )
+}

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -136,13 +136,21 @@ const SessionTab = ({
     if (e.target !== e.currentTarget) {
       return
     }
-    // Enter / Space activate the focused tab. Arrow-key cycling between
-    // tabs intentionally not handled here — see the global-keybinding
-    // stub note in SessionTabs above. Without that, in practice xterm
-    // owns focus and the tab strip is mouse-driven.
+    // Enter / Space activate the focused tab. Delete / Backspace close
+    // it — same convention as browser tab bars (Cmd+W) and matches the
+    // WAI-ARIA tabs pattern where the close button is reachable via
+    // keyboard shortcut on the focused tab, not as a separate Tab stop.
+    // Arrow-key cycling intentionally not handled here — see the
+    // global-keybinding stub note in SessionTabs above.
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       onSelect(session.id)
+
+      return
+    }
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      e.preventDefault()
+      onClose(session.id)
     }
   }
 
@@ -207,13 +215,12 @@ const SessionTab = ({
       )}
       <button
         type="button"
-        // Roving tabindex includes interactive descendants. Without
-        // tabIndex=-1 here, native <button> keeps tabIndex=0 and Tab
-        // navigation lands on close buttons of inactive tabs the user
-        // can't see — risk of dismissing the wrong session. Tracks
-        // isFocusEntryPoint (not isActive) so the null-active fallback
-        // also exposes the close button on the first visible tab.
-        tabIndex={isFocusEntryPoint ? 0 : -1}
+        // WAI-ARIA tabs §3.27: the entire tablist is one Tab stop;
+        // interactive descendants are reached via shortcut, not Tab.
+        // Always tabIndex=-1 so Tab passes through to the tabpanel
+        // below. Keyboard close lives on the parent tab div via
+        // Delete/Backspace handling in handleKeyDown above.
+        tabIndex={-1}
         onClick={(e) => {
           e.stopPropagation()
           onClose(session.id)

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import { useRef, type KeyboardEvent, type ReactElement } from 'react'
 import type { Session } from '../types'
 import { agentForSession } from '../utils/agentForSession'
 import { StatusDot } from './StatusDot'
@@ -29,6 +29,30 @@ export const SessionTabs = ({
     (s) => isOpenStatus(s) || s.id === activeSessionId
   )
 
+  const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map())
+
+  const registerTab = (id: string, el: HTMLDivElement | null): void => {
+    if (el === null) {
+      tabRefs.current.delete(id)
+    } else {
+      tabRefs.current.set(id, el)
+    }
+  }
+
+  const focusTabAtOffset = (currentId: string, offset: number): void => {
+    const ids = open.map((s) => s.id)
+    const idx = ids.indexOf(currentId)
+    if (idx === -1 || ids.length === 0) {
+      return
+    }
+    const nextIdx = (idx + offset + ids.length) % ids.length
+    const nextId = ids[nextIdx]
+    onSelect(nextId)
+    // Roving-focus pattern: move DOM focus to the newly-selected tab so
+    // arrow-key navigation reads naturally to assistive tech.
+    queueMicrotask(() => tabRefs.current.get(nextId)?.focus())
+  }
+
   return (
     <div
       data-testid="session-tabs"
@@ -43,6 +67,8 @@ export const SessionTabs = ({
           isActive={session.id === activeSessionId}
           onSelect={onSelect}
           onClose={onClose}
+          onArrow={focusTabAtOffset}
+          registerRef={registerTab}
         />
       ))}
       <button
@@ -64,6 +90,8 @@ interface SessionTabProps {
   isActive: boolean
   onSelect: (sessionId: string) => void
   onClose: (sessionId: string) => void
+  onArrow: (currentId: string, offset: number) => void
+  registerRef: (id: string, el: HTMLDivElement | null) => void
 }
 
 const SessionTab = ({
@@ -71,11 +99,37 @@ const SessionTab = ({
   isActive,
   onSelect,
   onClose,
+  onArrow,
+  registerRef,
 }: SessionTabProps): ReactElement => {
   const agent = agentForSession(session)
 
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>): void => {
+    // Don't react to keys that bubbled from a focused descendant (close X).
+    if (e.target !== e.currentTarget) {
+      return
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onSelect(session.id)
+
+      return
+    }
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      onArrow(session.id, 1)
+
+      return
+    }
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      onArrow(session.id, -1)
+    }
+  }
+
   return (
     <div
+      ref={(el) => registerRef(session.id, el)}
       role="tab"
       aria-selected={isActive}
       tabIndex={isActive ? 0 : -1}
@@ -83,12 +137,7 @@ const SessionTab = ({
       data-session-id={session.id}
       data-active={isActive}
       onClick={() => onSelect(session.id)}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onSelect(session.id)
-        }
-      }}
+      onKeyDown={handleKeyDown}
       className={`
         relative flex h-[30px] min-w-[130px] max-w-[220px] cursor-pointer items-center gap-2
         rounded-t-lg border border-transparent pl-3 pr-2 outline-none transition-colors

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -161,7 +161,15 @@ const SessionTab = ({
     // global-keybinding stub note in SessionTabs above.
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
-      onSelect(session.id)
+      // Skip the no-op reselection when the focused tab is already
+      // active. WorkspaceView's onSelect bridges to
+      // setActiveSession(IPC); a redundant call adds an unnecessary
+      // round-trip AND can interfere with useSessionManager's
+      // request-supersession rollback (a later no-op request can
+      // supersede an earlier real switch under transient failures).
+      if (!isActive) {
+        onSelect(session.id)
+      }
 
       return
     }
@@ -200,7 +208,14 @@ const SessionTab = ({
       data-testid="session-tab"
       data-session-id={session.id}
       data-active={isActive}
-      onClick={() => onSelect(session.id)}
+      onClick={() => {
+        // Mirror the keyboard-activation guard in handleKeyDown:
+        // clicking the already-active tab is a no-op user-intent and
+        // must NOT trigger a redundant setActiveSession IPC.
+        if (!isActive) {
+          onSelect(session.id)
+        }
+      }}
       onKeyDown={handleKeyDown}
       className={`
         relative flex h-[30px] min-w-[130px] max-w-[220px] cursor-pointer items-center gap-2

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -47,10 +47,13 @@ export const SessionTabs = ({
     }
     const nextIdx = (idx + offset + ids.length) % ids.length
     const nextId = ids[nextIdx]
-    onSelect(nextId)
-    // Roving-focus pattern: move DOM focus to the newly-selected tab so
-    // arrow-key navigation reads naturally to assistive tech.
-    queueMicrotask(() => tabRefs.current.get(nextId)?.focus())
+    // Manual-activation pattern (WAI-ARIA tabs): ArrowLeft/Right move DOM
+    // focus only — they do NOT change `activeSessionId`. Activation
+    // happens explicitly on Enter/Space (handled in SessionTab below).
+    // This keeps the visible terminal pane stable while a keyboard user
+    // is scanning adjacent tab labels with the screen reader; switching
+    // mid-scan would tear down the live xterm and reattach.
+    tabRefs.current.get(nextId)?.focus()
   }
 
   const handleClose = (sessionId: string): void => {
@@ -159,8 +162,10 @@ const SessionTab = ({
   return (
     <div
       ref={(el) => registerRef(session.id, el)}
+      id={`session-tab-${session.id}`}
       role="tab"
       aria-selected={isActive}
+      aria-controls={`session-panel-${session.id}`}
       tabIndex={isActive ? 0 : -1}
       data-testid="session-tab"
       data-session-id={session.id}

--- a/src/features/workspace/components/SessionTabs.tsx
+++ b/src/features/workspace/components/SessionTabs.tsx
@@ -72,13 +72,21 @@ const SessionTab = ({
     <div
       role="tab"
       aria-selected={isActive}
+      tabIndex={isActive ? 0 : -1}
       data-testid="session-tab"
       data-session-id={session.id}
       data-active={isActive}
       onClick={() => onSelect(session.id)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onSelect(session.id)
+        }
+      }}
       className={`
         relative flex h-[30px] min-w-[130px] max-w-[220px] cursor-pointer items-center gap-2
-        rounded-t-lg border border-transparent pl-3 pr-2 transition-colors
+        rounded-t-lg border border-transparent pl-3 pr-2 outline-none transition-colors
+        focus-visible:ring-2 focus-visible:ring-primary/50
         ${
           isActive
             ? '-mb-px bg-surface border-outline-variant/30'

--- a/src/features/workspace/components/Sidebar.test.tsx
+++ b/src/features/workspace/components/Sidebar.test.tsx
@@ -144,7 +144,7 @@ describe('Sidebar', () => {
     expect(screen.queryByText('System Idle')).not.toBeInTheDocument()
   })
 
-  test('renders "Active Sessions" header with add button', () => {
+  test('renders "Active" group header with add button', () => {
     render(
       <Sidebar
         sessions={mockSessions}
@@ -154,10 +154,29 @@ describe('Sidebar', () => {
       />
     )
 
-    expect(screen.getByText('Active Sessions')).toBeInTheDocument()
+    // Handoff §4.2 sub-header: "ACTIVE" / "RECENT" in JetBrains Mono uppercase.
+    expect(screen.getByTestId('session-group-active')).toHaveTextContent(
+      'Active'
+    )
+
     expect(
       screen.getByRole('button', { name: 'Add session' })
     ).toBeInTheDocument()
+  })
+
+  test('renders "Recent" group header when completed/errored sessions exist', () => {
+    render(
+      <Sidebar
+        sessions={mockSessions}
+        activeSessionId="sess-1"
+        onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
+      />
+    )
+
+    expect(screen.getByTestId('session-group-recent')).toHaveTextContent(
+      'Recent'
+    )
   })
 
   test('add session button changes color on hover', () => {
@@ -193,7 +212,7 @@ describe('Sidebar', () => {
     expect(mockOnNewInstance).toHaveBeenCalledOnce()
   })
 
-  test('renders all sessions', () => {
+  test('renders running/paused sessions in Active list, completed in Recent', () => {
     render(
       <Sidebar
         sessions={mockSessions}
@@ -203,18 +222,23 @@ describe('Sidebar', () => {
       />
     )
 
-    // The active session's name now also renders in the SidebarStatusHeader
-    // (idle state), so query within the session list to avoid duplicate
-    // matches on the active session's name.
-    const sessionList = screen.getByTestId('session-list')
-    expect(within(sessionList).getByText('auth middleware')).toBeInTheDocument()
-    expect(within(sessionList).getByText('fix: login bug')).toBeInTheDocument()
+    // Active group: sess-1 (running) + sess-2 (paused).
+    const activeList = screen.getByTestId('session-list')
+    expect(within(activeList).getByText('auth middleware')).toBeInTheDocument()
+    expect(within(activeList).getByText('fix: login bug')).toBeInTheDocument()
+
+    // Recent group: sess-3 (completed) lives here, NOT in the active list.
+    const recentList = screen.getByTestId('recent-list')
     expect(
-      within(sessionList).getByText('refactor: api layer')
+      within(recentList).getByText('refactor: api layer')
     ).toBeInTheDocument()
+
+    expect(
+      within(activeList).queryByText('refactor: api layer')
+    ).not.toBeInTheDocument()
   })
 
-  test('active session has smart_toy icon', () => {
+  test('each session row carries a StatusDot reflecting its status', () => {
     render(
       <Sidebar
         sessions={mockSessions}
@@ -224,13 +248,22 @@ describe('Sidebar', () => {
       />
     )
 
-    const activeSession = screen.getByRole('button', {
-      name: 'auth middleware',
-    })
-    expect(within(activeSession).getByText('smart_toy')).toBeInTheDocument()
+    const list = screen.getByTestId('session-list')
+
+    const runningRow = within(list).getByText('auth middleware').closest('li')!
+    expect(within(runningRow).getByTestId('status-dot')).toHaveAttribute(
+      'data-status',
+      'running'
+    )
+
+    const pausedRow = within(list).getByText('fix: login bug').closest('li')!
+    expect(within(pausedRow).getByTestId('status-dot')).toHaveAttribute(
+      'data-status',
+      'paused'
+    )
   })
 
-  test('inactive sessions have schedule icon', () => {
+  test('active row paints lavender-tinted background per handoff §4.2', () => {
     render(
       <Sidebar
         sessions={mockSessions}
@@ -240,28 +273,14 @@ describe('Sidebar', () => {
       />
     )
 
-    const inactiveSession = screen.getByRole('button', {
-      name: 'fix: login bug',
-    })
-    expect(within(inactiveSession).getByText('schedule')).toBeInTheDocument()
-  })
+    const list = screen.getByTestId('session-list')
 
-  test('active session item has surface-container-high styling', () => {
-    render(
-      <Sidebar
-        sessions={mockSessions}
-        activeSessionId="sess-1"
-        onSessionClick={mockOnSessionClick}
-        agentStatus={inactiveAgentStatus}
-      />
-    )
-
-    const activeButton = screen.getByRole('button', {
-      name: 'auth middleware',
-    })
-    const listItem = activeButton.closest('li')!
-    expect(listItem.className).toContain('bg-surface-container-high')
-    expect(listItem.className).toContain('text-on-surface')
+    const activeRow = within(list).getByText('auth middleware').closest('li')!
+    expect(activeRow.className).toContain('bg-primary/10')
+    expect(activeRow.className).toContain('text-on-surface')
+    const accent = activeRow.querySelector('[aria-hidden="true"]')
+    expect(accent).not.toBeNull()
+    expect(accent?.className).toContain('bg-primary-container')
   })
 
   test('inactive session items have on-surface-variant styling', () => {
@@ -313,7 +332,7 @@ describe('Sidebar', () => {
     expect(sidebar).toHaveClass('bg-surface-container-low')
   })
 
-  test('renders empty state when no sessions', () => {
+  test('renders empty state when no active sessions', () => {
     render(
       <Sidebar
         sessions={[]}
@@ -323,7 +342,9 @@ describe('Sidebar', () => {
       />
     )
 
-    expect(screen.getByText('No sessions')).toBeInTheDocument()
+    expect(screen.getByTestId('active-empty')).toHaveTextContent(
+      'No active sessions'
+    )
   })
 
   test('renders FileExplorer section', () => {

--- a/src/features/workspace/components/Sidebar.test.tsx
+++ b/src/features/workspace/components/Sidebar.test.tsx
@@ -460,7 +460,9 @@ describe('Sidebar', () => {
     })
   })
 
-  test('session list is scrollable', () => {
+  test('Active + Recent groups share a single scroll region', () => {
+    // Sharing a scroll region means a long Recent group can't push
+    // FileExplorer / New Instance below the fixed sidebar height.
     render(
       <Sidebar
         sessions={mockSessions}
@@ -470,7 +472,12 @@ describe('Sidebar', () => {
       />
     )
 
-    const sessionList = screen.getByTestId('session-list')
-    expect(sessionList).toHaveClass('overflow-y-auto')
+    const scroll = screen.getByTestId('session-scroll')
+    expect(scroll).toHaveClass('overflow-y-auto')
+    expect(scroll).toHaveClass('flex-1')
+    expect(scroll).toHaveClass('min-h-0')
+
+    expect(scroll).toContainElement(screen.getByTestId('session-list'))
+    expect(scroll).toContainElement(screen.getByTestId('recent-list'))
   })
 })

--- a/src/features/workspace/components/Sidebar.test.tsx
+++ b/src/features/workspace/components/Sidebar.test.tsx
@@ -586,4 +586,33 @@ describe('Sidebar', () => {
     )
     expect(screen.getByText('home/will')).toBeInTheDocument()
   })
+
+  test('subtitle falls back to "~" when workingDirectory is empty (race-window safety)', () => {
+    // During the brief window after session creation but before the first
+    // OSC 7 cwd report from Tauri, `workingDirectory` may be seeded as
+    // empty string. The fallback comment promises "never empty"; without
+    // the `|| '~'` guard the raw empty string would render an invisible
+    // subtitle div and a visible gap in the row. `~` is the conventional
+    // shell display for an unknown/home cwd.
+    const emptyCwdSession: Session = {
+      ...mockSessions[0],
+      id: 'sess-empty',
+      name: 'empty cwd',
+      currentAction: undefined,
+      workingDirectory: '',
+    }
+    render(
+      <Sidebar
+        sessions={[emptyCwdSession]}
+        activeSessionId="sess-empty"
+        onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
+      />
+    )
+    // `~` also appears in the SidebarStatusHeader's activeCwd display
+    // (default prop). Scope the assertion to the actual session row to
+    // confirm the subtitle line — not the header — rendered the fallback.
+    const row = screen.getByTestId('session-row')
+    expect(within(row).getByText('~')).toBeInTheDocument()
+  })
 })

--- a/src/features/workspace/components/Sidebar.test.tsx
+++ b/src/features/workspace/components/Sidebar.test.tsx
@@ -501,6 +501,24 @@ describe('Sidebar', () => {
     expect(onRemoveSession).toHaveBeenCalledWith('A')
   })
 
+  test('without onRemoveSession, the remove button is hidden on Recent rows', () => {
+    // RecentSessionRow gates the remove button on `onRemove` truthiness;
+    // when Sidebar receives no onRemoveSession, handleRemoveSession is
+    // undefined too — so neither selection nor removal can fire.
+    render(
+      <Sidebar
+        sessions={mockSessions}
+        activeSessionId="sess-3"
+        onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
+      />
+    )
+    const recentList = screen.getByTestId('recent-list')
+    expect(
+      within(recentList).queryByRole('button', { name: 'Remove session' })
+    ).toBeNull()
+  })
+
   test('Active + Recent groups share a single scroll region', () => {
     // Sharing a scroll region means a long Recent group can't push
     // FileExplorer / New Instance below the fixed sidebar height.

--- a/src/features/workspace/components/Sidebar.test.tsx
+++ b/src/features/workspace/components/Sidebar.test.tsx
@@ -539,4 +539,51 @@ describe('Sidebar', () => {
     expect(scroll).toContainElement(screen.getByTestId('session-list'))
     expect(scroll).toContainElement(screen.getByTestId('recent-list'))
   })
+
+  test('subtitle renders the last 2 segments of the cwd, normalizing Windows backslashes', () => {
+    // Tauri can hand back native path separators; on Windows that means
+    // `C:\Users\alice\my-repo`. After normalizing `\` → `/`, we want the
+    // last TWO segments joined by `/` — so `C:\Users\alice\my-repo` reads
+    // as `alice/my-repo`. The 2-segment rule also handles the shallow
+    // case `/home/will` (renders `home/will` rather than collapsing
+    // aggressively to `will`).
+    const winSession: Session = {
+      ...mockSessions[0],
+      id: 'sess-win',
+      name: 'win path',
+      currentAction: undefined,
+      workingDirectory: 'C:\\Users\\alice\\my-repo',
+    }
+    render(
+      <Sidebar
+        sessions={[winSession]}
+        activeSessionId="sess-win"
+        onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
+      />
+    )
+    expect(screen.getByText('alice/my-repo')).toBeInTheDocument()
+    expect(screen.queryByText(winSession.workingDirectory)).toBeNull()
+  })
+
+  test('subtitle renders 2-segment POSIX cwd as parent/basename (shallow path)', () => {
+    // Per user direction: `/home/will` should show `home/will`, not just
+    // `will`. The basename-only collapse loses too much context.
+    const posixSession: Session = {
+      ...mockSessions[0],
+      id: 'sess-posix',
+      name: 'posix shallow',
+      currentAction: undefined,
+      workingDirectory: '/home/will',
+    }
+    render(
+      <Sidebar
+        sessions={[posixSession]}
+        activeSessionId="sess-posix"
+        onSessionClick={mockOnSessionClick}
+        agentStatus={inactiveAgentStatus}
+      />
+    )
+    expect(screen.getByText('home/will')).toBeInTheDocument()
+  })
 })

--- a/src/features/workspace/components/Sidebar.test.tsx
+++ b/src/features/workspace/components/Sidebar.test.tsx
@@ -460,6 +460,47 @@ describe('Sidebar', () => {
     })
   })
 
+  test('removing the active session pre-selects the next visible Active row', async () => {
+    // Mirrors SessionTabs.handleClose: useSessionManager's full-sessions
+    // index fallback can land on a Recent (completed/errored) session
+    // sandwiched between two running ones. Pre-selecting from the
+    // visible Active group keeps selection on a tab the user can see.
+    const onSessionClick = vi.fn()
+    const onRemoveSession = vi.fn()
+    const user = userEvent.setup()
+
+    const sessions: Session[] = [
+      { ...mockSessions[0], id: 'A', status: 'running', name: 'first-active' },
+      // sess-3 in mockSessions is `completed` — between two actives in array
+      // order — so the manager's full-index fallback would land on it.
+      mockSessions[2],
+      { ...mockSessions[1], id: 'B', status: 'running', name: 'second-active' },
+    ]
+
+    render(
+      <Sidebar
+        sessions={sessions}
+        activeSessionId="A"
+        onSessionClick={onSessionClick}
+        onRemoveSession={onRemoveSession}
+        agentStatus={inactiveAgentStatus}
+      />
+    )
+
+    const list = screen.getByTestId('session-list')
+    const activeRow = within(list).getByText('first-active').closest('li')!
+
+    const removeBtn = within(activeRow).getByRole('button', {
+      name: 'Remove session',
+    })
+
+    await user.click(removeBtn)
+
+    // Pre-selected the next VISIBLE active (B), not the in-between Recent.
+    expect(onSessionClick).toHaveBeenCalledWith('B')
+    expect(onRemoveSession).toHaveBeenCalledWith('A')
+  })
+
   test('Active + Recent groups share a single scroll region', () => {
     // Sharing a scroll region means a long Recent group can't push
     // FileExplorer / New Instance below the fixed sidebar height.

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -147,13 +147,24 @@ const SessionRow = ({
         />
       )}
 
+      {/* Click-to-activate button covers the whole row as an absolute
+          background layer. The foreground content (rendered as plain
+          divs/spans) sits above with `pointer-events-none` so clicks
+          fall through to this button — except for interactive bits
+          (rename input, hover buttons) which opt back in via
+          `pointer-events-auto`. This avoids nesting the rename
+          <input> inside <button>, which the HTML spec forbids and
+          Firefox/Safari mishandle for keyboard focus. */}
       <button
         type="button"
         onClick={() => onSessionClick(session.id)}
-        className="flex w-full flex-col gap-1 text-left"
         aria-label={session.name}
-      >
-        <span className="flex items-center gap-2">
+        className="absolute inset-0 rounded-[8px]"
+        tabIndex={isEditing ? -1 : 0}
+      />
+
+      <div className="pointer-events-none relative flex flex-col gap-1">
+        <div className="flex items-center gap-2">
           <StatusDot status={session.status} />
           {isEditing ? (
             <input
@@ -171,13 +182,17 @@ const SessionRow = ({
                   setIsEditing(false)
                 }
               }}
-              onClick={(e) => e.stopPropagation()}
-              className="min-w-0 flex-1 truncate rounded bg-surface-container-high px-1 font-label text-[13px] font-semibold text-on-surface outline-none ring-1 ring-primary"
+              className="pointer-events-auto min-w-0 flex-1 truncate rounded bg-surface-container-high px-1 font-label text-[13px] font-semibold text-on-surface outline-none ring-1 ring-primary"
               aria-label="Rename session"
             />
           ) : (
+            // Span opts back into pointer events for double-click rename.
+            // Without an explicit onClick, single clicks would NOT bubble
+            // to the sibling absolute button (the button is no longer an
+            // ancestor) — primary row activation would silently break.
             <span
-              className="min-w-0 flex-1 truncate font-label text-[13px] font-semibold text-on-surface"
+              className="pointer-events-auto min-w-0 flex-1 cursor-pointer truncate font-label text-[13px] font-semibold text-on-surface"
+              onClick={() => onSessionClick(session.id)}
               onDoubleClick={(e) => {
                 e.stopPropagation()
                 setEditValue(session.name)
@@ -192,13 +207,13 @@ const SessionRow = ({
           <span className="shrink-0 font-mono text-[10px] text-on-surface-variant/70 transition-opacity group-hover:opacity-0">
             {formatRelativeTime(session.lastActivityAt)}
           </span>
-        </span>
+        </div>
 
-        <span className="block truncate pl-[15px] font-label text-[11.5px] text-on-surface-variant">
+        <div className="block truncate pl-[15px] font-label text-[11.5px] text-on-surface-variant">
           {subtitle}
-        </span>
+        </div>
 
-        <span className="flex items-center gap-2 pl-[15px] font-mono text-[10px]">
+        <div className="flex items-center gap-2 pl-[15px] font-mono text-[10px]">
           <span
             data-testid="state-pill"
             className={`rounded-full px-1.5 py-px uppercase tracking-wide ${STATE_PILL_TONE[session.status]}`}
@@ -214,10 +229,10 @@ const SessionRow = ({
               <span className="text-error">-{removed}</span>
             </span>
           )}
-        </span>
-      </button>
+        </div>
+      </div>
 
-      <div className="absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+      <div className="pointer-events-auto absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
         <button
           type="button"
           onClick={(e) => {
@@ -298,13 +313,17 @@ const RecentSessionRow = ({
           className="absolute inset-y-2 left-0 w-0.5 rounded-r bg-primary-container"
         />
       )}
+      {/* Same overlay pattern as SessionRow — see HTML-validity comment
+          there. <input> can't legally nest inside <button>. */}
       <button
         type="button"
         onClick={() => onSessionClick(session.id)}
-        className="flex w-full flex-col gap-0.5 text-left"
         aria-label={session.name}
-      >
-        <span className="flex items-center gap-2">
+        className="absolute inset-0 rounded-[8px]"
+        tabIndex={isEditing ? -1 : 0}
+      />
+      <div className="pointer-events-none relative flex flex-col gap-0.5">
+        <div className="flex items-center gap-2">
           <StatusDot status={session.status} size={6} dim />
           {isEditing ? (
             <input
@@ -322,13 +341,15 @@ const RecentSessionRow = ({
                   setIsEditing(false)
                 }
               }}
-              onClick={(e) => e.stopPropagation()}
-              className="min-w-0 flex-1 truncate rounded bg-surface-container-high px-1 font-label text-[12.5px] text-on-surface outline-none ring-1 ring-primary"
+              className="pointer-events-auto min-w-0 flex-1 truncate rounded bg-surface-container-high px-1 font-label text-[12.5px] text-on-surface outline-none ring-1 ring-primary"
               aria-label="Rename session"
             />
           ) : (
+            // Same activation+rename split as SessionRow above —
+            // sibling-button overlay needs an explicit onClick here.
             <span
-              className={`min-w-0 flex-1 truncate font-label text-[12.5px] ${isActive ? 'text-on-surface' : 'text-on-surface-variant/60'}`}
+              className={`pointer-events-auto min-w-0 flex-1 cursor-pointer truncate font-label text-[12.5px] ${isActive ? 'text-on-surface' : 'text-on-surface-variant/60'}`}
+              onClick={() => onSessionClick(session.id)}
               onDoubleClick={(e) => {
                 if (!onRename) {
                   return
@@ -346,8 +367,8 @@ const RecentSessionRow = ({
           <span className="shrink-0 font-mono text-[10px] text-on-surface-variant/50 transition-opacity group-hover:opacity-0">
             {formatRelativeTime(session.lastActivityAt)}
           </span>
-        </span>
-        <span className="flex items-center gap-2 pl-[15px] font-mono text-[10px]">
+        </div>
+        <div className="flex items-center gap-2 pl-[15px] font-mono text-[10px]">
           <span
             data-testid="state-pill"
             className={`rounded-full px-1.5 py-px uppercase tracking-wide ${STATE_PILL_TONE_DIM[session.status]}`}
@@ -363,9 +384,9 @@ const RecentSessionRow = ({
           <span className="ml-auto truncate font-label text-[10.5px] text-on-surface-variant/50">
             {subtitle}
           </span>
-        </span>
-      </button>
-      <div className="absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+        </div>
+      </div>
+      <div className="pointer-events-auto absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
         {onRename && (
           <button
             type="button"
@@ -555,12 +576,15 @@ export const Sidebar = ({
           data-testid="session-list"
         >
           {activeGroup.length === 0 ? (
-            <div
+            // Reorder.Group renders as <ul>; HTML requires <li> children
+            // (or <script>/<template>). A bare <div> here is parsed in
+            // quirks mode and breaks list-counting in screen readers.
+            <li
               data-testid="active-empty"
               className="px-3 py-3 text-center font-label text-xs text-on-surface-variant/50"
             >
               No active sessions
-            </div>
+            </li>
           ) : (
             activeGroup.map((session) => (
               <SessionRow

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -233,31 +233,35 @@ const SessionRow = ({
       </div>
 
       <div className="pointer-events-auto absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            setEditValue(session.name)
-            setIsEditing(true)
-          }}
-          className="rounded p-0.5 text-on-surface-variant/60 transition-colors hover:bg-surface-container-high hover:text-on-surface"
-          aria-label="Rename session"
-          title="Rename"
-        >
-          <span className="material-symbols-outlined text-sm">edit</span>
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            onRemove?.(session.id)
-          }}
-          className="rounded p-0.5 text-on-surface-variant/60 transition-colors hover:bg-error/20 hover:text-error"
-          aria-label="Remove session"
-          title="Remove"
-        >
-          <span className="material-symbols-outlined text-sm">close</span>
-        </button>
+        {onRename && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              setEditValue(session.name)
+              setIsEditing(true)
+            }}
+            className="rounded p-0.5 text-on-surface-variant/60 transition-colors hover:bg-surface-container-high hover:text-on-surface"
+            aria-label="Rename session"
+            title="Rename"
+          >
+            <span className="material-symbols-outlined text-sm">edit</span>
+          </button>
+        )}
+        {onRemove && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              onRemove(session.id)
+            }}
+            className="rounded p-0.5 text-on-surface-variant/60 transition-colors hover:bg-error/20 hover:text-error"
+            aria-label="Remove session"
+            title="Remove"
+          >
+            <span className="material-symbols-outlined text-sm">close</span>
+          </button>
+        )}
       </div>
     </Reorder.Item>
   )

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -249,7 +249,7 @@ const RecentSessionRow = ({
       data-session-id={session.id}
       data-active={isActive}
       className={`
-        relative mb-1 rounded-lg px-3 py-2 transition-colors
+        group relative mb-1 rounded-lg px-3 py-2 transition-colors
         ${
           isActive
             ? 'bg-primary/10 text-on-surface'

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -389,19 +389,24 @@ export const Sidebar = ({
   )
 
   // Mirror SessionTabs.handleClose: when the user removes the active
-  // session from the sidebar, pre-select the next visible Active session
-  // before delegating to onRemoveSession. Otherwise useSessionManager's
-  // full-sessions-index fallback can land on a Recent (completed/errored)
-  // session, surfacing it as the active selection in the SessionTabs strip
-  // even though the user just asked to remove a running tab.
+  // session from the sidebar, override the manager's fallback to a
+  // visible Active row. Order matters: useSessionManager.removeSession
+  // uses `flushSync` internally to apply its own setActiveSessionId
+  // mid-call, so any pre-selection we queue BEFORE the remove is wiped
+  // out by the synchronous fallback. We have to remove first, then
+  // override with the visible-order next id — same ordering as
+  // SessionTabs.handleClose for the same reason.
   const handleRemoveSession = (id: string): void => {
+    let nextId: string | undefined
     if (id === activeSessionId && activeGroup.length > 1) {
       const ids = activeGroup.map((s) => s.id)
       const idx = ids.indexOf(id)
-      const nextId = idx === ids.length - 1 ? ids[idx - 1] : ids[idx + 1]
-      onSessionClick(nextId)
+      nextId = idx === ids.length - 1 ? ids[idx - 1] : ids[idx + 1]
     }
     onRemoveSession?.(id)
+    if (nextId !== undefined) {
+      onSessionClick(nextId)
+    }
   }
 
   return (

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -52,8 +52,15 @@ const sessionSubtitle = (session: Session): string => {
   // `/home/will/projects/Vimeflow` reads as `projects/Vimeflow`. One
   // segment when the path only has one. Empty falls back to the raw
   // path string so the subtitle line is never empty.
+  // The empty-string case (workingDirectory === '') falls through to
+  // `||` so the subtitle line is truly never empty — without this the
+  // raw `workingDirectory` ('') would be returned, the comment's
+  // "never empty" claim would lie, and an empty subtitle div would
+  // render between the title and the state pill (a visible gap during
+  // the brief race window after session creation but before the first
+  // OSC 7 cwd report).
   if (parts.length === 0) {
-    return session.workingDirectory
+    return session.workingDirectory || '~'
   }
   if (parts.length === 1) {
     return parts[0]

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -14,7 +14,10 @@ import { SidebarStatusHeader } from './SidebarStatusHeader'
 import { StatusDot } from './StatusDot'
 import { formatRelativeTime } from '../../agent-status/utils/relativeTime'
 import { useRenameState } from '../hooks/useRenameState'
-import { pickNextVisibleSessionId } from '../utils/pickNextVisibleSessionId'
+import {
+  isOpenSessionStatus,
+  pickNextVisibleSessionId,
+} from '../utils/pickNextVisibleSessionId'
 
 export interface SidebarProps {
   sessions: Session[]
@@ -150,6 +153,7 @@ const SessionRow = ({
         type="button"
         onClick={() => onSessionClick(session.id)}
         aria-label={session.name}
+        data-role="activate"
         className="absolute inset-0 rounded-[8px]"
         tabIndex={isEditing ? -1 : 0}
       />
@@ -308,6 +312,7 @@ const RecentSessionRow = ({
         type="button"
         onClick={() => onSessionClick(session.id)}
         aria-label={session.name}
+        data-role="activate"
         className="absolute inset-0 rounded-[8px]"
         tabIndex={isEditing ? -1 : 0}
       />
@@ -476,13 +481,12 @@ export const Sidebar = ({
     }
   }, [isDraggingSplit])
 
-  const activeGroup = sessions.filter(
-    (s) => s.status === 'running' || s.status === 'paused'
-  )
-
-  const recentGroup = sessions.filter(
-    (s) => s.status === 'completed' || s.status === 'errored'
-  )
+  // Active = open statuses (running/paused) per the canonical predicate
+  // in pickNextVisibleSessionId.ts. Recent = the complement so any
+  // future non-open status (e.g. `suspended`) lands in Recent rather
+  // than being silently dropped from both groups.
+  const activeGroup = sessions.filter((s) => isOpenSessionStatus(s.status))
+  const recentGroup = sessions.filter((s) => !isOpenSessionStatus(s.status))
 
   // Mirror SessionTabs.handleClose using the shared visible-order helper.
   // useSessionManager.removeSession uses `flushSync` internally to apply
@@ -514,9 +518,13 @@ export const Sidebar = ({
         if (nextId !== undefined) {
           onSessionClick(nextId)
           queueMicrotask(() => {
+            // Target the overlay activation button explicitly via
+            // data-role rather than `button[aria-label]` so the
+            // selector survives a future DOM reordering that puts the
+            // hover Rename/Remove buttons above the overlay.
             document
               .querySelector<HTMLElement>(
-                `[data-session-id="${nextId}"] button[aria-label]`
+                `[data-session-id="${nextId}"] [data-role="activate"]`
               )
               ?.focus()
           })
@@ -563,16 +571,11 @@ export const Sidebar = ({
           axis="y"
           values={activeGroup}
           onReorder={(reordered) => {
-            // Recompute Recent inside the callback — vimeflow runs AI
-            // agents that can complete a task mid-drag, flipping a
-            // running session to completed. The closure-captured
-            // `recentGroup` would either drop that session or land it in
-            // the wrong slice; reading from `sessions` here is always
-            // current.
-            const freshRecent = sessions.filter(
-              (s) => s.status === 'completed' || s.status === 'errored'
-            )
-            onReorderSessions?.([...reordered, ...freshRecent])
+            // Preserve Recent ordering — only the Active subset reorders.
+            // `recentGroup` is captured at render time alongside `sessions`;
+            // both are equally fresh on this callback, so using the
+            // precomputed group keeps the diff minimal.
+            onReorderSessions?.([...reordered, ...recentGroup])
           }}
           className="flex flex-col px-2"
           data-testid="session-list"

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -113,7 +113,7 @@ const SessionRow = ({
       data-session-id={session.id}
       data-active={isActive}
       className={`
-        relative mb-1 cursor-grab rounded-xl px-3 py-2.5 transition-colors
+        relative mb-1 cursor-grab rounded-[8px] px-3 py-2.5 transition-colors
         active:cursor-grabbing group
         ${
           isActive
@@ -249,7 +249,7 @@ const RecentSessionRow = ({
       data-session-id={session.id}
       data-active={isActive}
       className={`
-        group relative mb-1 rounded-xl px-3 py-2 transition-colors
+        group relative mb-1 rounded-[8px] px-3 py-2 transition-colors
         ${
           isActive
             ? 'bg-primary/10 text-on-surface'
@@ -388,6 +388,22 @@ export const Sidebar = ({
     (s) => s.status === 'completed' || s.status === 'errored'
   )
 
+  // Mirror SessionTabs.handleClose: when the user removes the active
+  // session from the sidebar, pre-select the next visible Active session
+  // before delegating to onRemoveSession. Otherwise useSessionManager's
+  // full-sessions-index fallback can land on a Recent (completed/errored)
+  // session, surfacing it as the active selection in the SessionTabs strip
+  // even though the user just asked to remove a running tab.
+  const handleRemoveSession = (id: string): void => {
+    if (id === activeSessionId && activeGroup.length > 1) {
+      const ids = activeGroup.map((s) => s.id)
+      const idx = ids.indexOf(id)
+      const nextId = idx === ids.length - 1 ? ids[idx - 1] : ids[idx + 1]
+      onSessionClick(nextId)
+    }
+    onRemoveSession?.(id)
+  }
+
   return (
     <div
       className="flex h-full w-full flex-col bg-surface-container-low"
@@ -402,7 +418,10 @@ export const Sidebar = ({
         />
       </div>
 
-      <div className="flex items-center justify-between px-3 pb-1 pt-2">
+      {/* GroupHeader carries its own px-3/pt-2/pb-1; outer flex row only
+          adds the right-side gutter for the Add button so the Active
+          label stays horizontally aligned with the Recent label below. */}
+      <div className="flex items-center justify-between pr-3">
         <GroupHeader label="Active" />
         <button
           type="button"
@@ -444,7 +463,7 @@ export const Sidebar = ({
                 session={session}
                 isActive={session.id === activeSessionId}
                 onSessionClick={onSessionClick}
-                onRemove={onRemoveSession}
+                onRemove={handleRemoveSession}
                 onRename={onRenameSession}
               />
             ))
@@ -461,7 +480,7 @@ export const Sidebar = ({
                   session={session}
                   isActive={session.id === activeSessionId}
                   onSessionClick={onSessionClick}
-                  onRemove={onRemoveSession}
+                  onRemove={handleRemoveSession}
                 />
               ))}
             </ul>

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import {
   useCallback,
   type ReactElement,
 } from 'react'
-import { Reorder } from 'framer-motion'
+import { motion, Reorder } from 'framer-motion'
 import type { Session } from '../types'
 import type { FileNode } from '../../files/types'
 import type { AgentStatus } from '../../agent-status/types'
@@ -415,9 +415,10 @@ export const Sidebar = ({
         </button>
       </div>
 
-      <div
+      <motion.div
         data-testid="session-scroll"
         className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+        layoutScroll
       >
         <Reorder.Group
           axis="y"
@@ -428,7 +429,6 @@ export const Sidebar = ({
           }}
           className="flex flex-col px-2"
           data-testid="session-list"
-          layoutScroll
         >
           {activeGroup.length === 0 ? (
             <div
@@ -467,7 +467,7 @@ export const Sidebar = ({
             </ul>
           </>
         )}
-      </div>
+      </motion.div>
 
       <div
         data-testid="explorer-resize-handle"

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -194,6 +194,9 @@ const SessionRow = ({
               className="pointer-events-auto min-w-0 flex-1 cursor-pointer truncate font-label text-[13px] font-semibold text-on-surface"
               onClick={() => onSessionClick(session.id)}
               onDoubleClick={(e) => {
+                if (!onRename) {
+                  return
+                }
                 e.stopPropagation()
                 setEditValue(session.name)
                 setIsEditing(true)

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -40,9 +40,26 @@ const sessionSubtitle = (session: Session): string => {
   if (session.currentAction !== undefined && session.currentAction !== '') {
     return session.currentAction
   }
-  const parts = session.workingDirectory.split('/').filter(Boolean)
+  // Normalize Windows `\` to `/` first — Tauri can hand back native
+  // separators (e.g. `C:\Users\alice\repo`), and a `/`-only split would
+  // collapse the whole path to one segment and render the full path
+  // instead of the basename.
+  const normalized = session.workingDirectory.replace(/\\/g, '/')
+  const parts = normalized.split('/').filter(Boolean)
+  // Show the last two segments (parent/basename) so a shallow cwd like
+  // `/home/will` reads as `home/will` instead of just `will` (which
+  // collapses too aggressively to be meaningful) and a deeper cwd like
+  // `/home/will/projects/Vimeflow` reads as `projects/Vimeflow`. One
+  // segment when the path only has one. Empty falls back to the raw
+  // path string so the subtitle line is never empty.
+  if (parts.length === 0) {
+    return session.workingDirectory
+  }
+  if (parts.length === 1) {
+    return parts[0]
+  }
 
-  return parts.length > 0 ? parts[parts.length - 1] : session.workingDirectory
+  return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`
 }
 
 const sessionLineDelta = (
@@ -378,7 +395,12 @@ const RecentSessionRow = ({
               <span className="text-error/70">-{removed}</span>
             </span>
           )}
-          <span className="ml-auto truncate font-label text-[10.5px] text-on-surface-variant/50">
+          {/* Right-aligned subtitle competes for the same horizontal
+              slot as the absolute-positioned hover buttons (rename +
+              remove sit at top-right). Hide on hover so the buttons
+              don't visually overlap the cwd text. Same pattern as the
+              timestamp span above and the Active row's timestamp. */}
+          <span className="ml-auto truncate font-label text-[10.5px] text-on-surface-variant/50 transition-opacity group-hover:opacity-0">
             {subtitle}
           </span>
         </div>

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -61,11 +61,22 @@ const STATE_PILL_LABEL: Record<Session['status'], string> = {
   errored: 'errored',
 }
 
+// Bright pills — Active group rows. Vivid bg + saturated text.
 const STATE_PILL_TONE: Record<Session['status'], string> = {
   running: 'text-success bg-success/10',
   paused: 'text-warning bg-warning/10',
   completed: 'text-success-muted bg-success-muted/10',
   errored: 'text-error bg-error/15',
+}
+
+// Dim pills — Recent group rows. Lower bg opacity + softer text so the
+// row reads as historical chrome rather than competing with the Active
+// group above.
+const STATE_PILL_TONE_DIM: Record<Session['status'], string> = {
+  running: 'text-success/70 bg-success/5',
+  paused: 'text-warning/70 bg-warning/5',
+  completed: 'text-success-muted/70 bg-success-muted/5',
+  errored: 'text-error/80 bg-error/8',
 }
 
 interface SessionRowProps {
@@ -176,7 +187,9 @@ const SessionRow = ({
               {session.name}
             </span>
           )}
-          <span className="shrink-0 font-mono text-[10px] text-on-surface-variant/70">
+          {/* Hide on hover so the absolute-positioned edit/close
+              actions in the top-right corner don't overlap it. */}
+          <span className="shrink-0 font-mono text-[10px] text-on-surface-variant/70 transition-opacity group-hover:opacity-0">
             {formatRelativeTime(session.lastActivityAt)}
           </span>
         </span>
@@ -235,16 +248,33 @@ const SessionRow = ({
   )
 }
 
-// Recent rows are read-only — no rename. Narrowing the prop type makes
-// that contract explicit instead of advertising a no-op `onRename`.
-type RecentSessionRowProps = Omit<SessionRowProps, 'onRename'>
-
 const RecentSessionRow = ({
   session,
   isActive,
   onSessionClick,
   onRemove = undefined,
-}: RecentSessionRowProps): ReactElement => {
+  onRename = undefined,
+}: SessionRowProps): ReactElement => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [editValue, setEditValue] = useState(session.name)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isEditing])
+
+  const commitRename = (): void => {
+    setIsEditing(false)
+    if (editValue.trim().length > 0 && editValue.trim() !== session.name) {
+      onRename?.(session.id, editValue.trim())
+    } else {
+      setEditValue(session.name)
+    }
+  }
+
   const { added, removed } = sessionLineDelta(session)
   const subtitle = sessionSubtitle(session)
 
@@ -275,46 +305,97 @@ const RecentSessionRow = ({
         aria-label={session.name}
       >
         <span className="flex items-center gap-2">
-          <StatusDot status={session.status} />
-          <span className="min-w-0 flex-1 truncate font-label text-[12.5px] text-on-surface-variant">
-            {session.name}
-          </span>
-          <span className="shrink-0 font-mono text-[10px] text-on-surface-variant/70">
+          <StatusDot status={session.status} size={6} dim />
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              type="text"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={commitRename}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  commitRename()
+                }
+                if (e.key === 'Escape') {
+                  setEditValue(session.name)
+                  setIsEditing(false)
+                }
+              }}
+              onClick={(e) => e.stopPropagation()}
+              className="min-w-0 flex-1 truncate rounded bg-surface-container-high px-1 font-label text-[12.5px] text-on-surface outline-none ring-1 ring-primary"
+              aria-label="Rename session"
+            />
+          ) : (
+            <span
+              className={`min-w-0 flex-1 truncate font-label text-[12.5px] ${isActive ? 'text-on-surface' : 'text-on-surface-variant/60'}`}
+              onDoubleClick={(e) => {
+                if (!onRename) {
+                  return
+                }
+                e.stopPropagation()
+                setEditValue(session.name)
+                setIsEditing(true)
+              }}
+            >
+              {session.name}
+            </span>
+          )}
+          {/* Same hover treatment as Active rows — the remove button
+              in the top-right shares horizontal space with this. */}
+          <span className="shrink-0 font-mono text-[10px] text-on-surface-variant/50 transition-opacity group-hover:opacity-0">
             {formatRelativeTime(session.lastActivityAt)}
           </span>
         </span>
         <span className="flex items-center gap-2 pl-[15px] font-mono text-[10px]">
           <span
             data-testid="state-pill"
-            className={`rounded-full px-1.5 py-px uppercase tracking-wide ${STATE_PILL_TONE[session.status]}`}
+            className={`rounded-full px-1.5 py-px uppercase tracking-wide ${STATE_PILL_TONE_DIM[session.status]}`}
           >
             {STATE_PILL_LABEL[session.status]}
           </span>
           {(added > 0 || removed > 0) && (
-            <span className="text-on-surface-variant/70">
-              <span className="text-success">+{added}</span>{' '}
-              <span className="text-error">-{removed}</span>
+            <span className="text-on-surface-variant/50">
+              <span className="text-success/70">+{added}</span>{' '}
+              <span className="text-error/70">-{removed}</span>
             </span>
           )}
-          <span className="ml-auto truncate font-label text-[10.5px] text-on-surface-variant/70">
+          <span className="ml-auto truncate font-label text-[10.5px] text-on-surface-variant/50">
             {subtitle}
           </span>
         </span>
       </button>
-      {onRemove && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            onRemove(session.id)
-          }}
-          className="absolute right-2 top-2 rounded p-0.5 text-on-surface-variant/40 opacity-0 transition-all hover:bg-error/20 hover:text-error group-hover:opacity-100"
-          aria-label="Remove session"
-          title="Remove"
-        >
-          <span className="material-symbols-outlined text-sm">close</span>
-        </button>
-      )}
+      <div className="absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+        {onRename && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              setEditValue(session.name)
+              setIsEditing(true)
+            }}
+            className="rounded p-0.5 text-on-surface-variant/60 transition-colors hover:bg-surface-container-high hover:text-on-surface"
+            aria-label="Rename session"
+            title="Rename"
+          >
+            <span className="material-symbols-outlined text-sm">edit</span>
+          </button>
+        )}
+        {onRemove && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              onRemove(session.id)
+            }}
+            className="rounded p-0.5 text-on-surface-variant/40 transition-colors hover:bg-error/20 hover:text-error"
+            aria-label="Remove session"
+            title="Remove"
+          >
+            <span className="material-symbols-outlined text-sm">close</span>
+          </button>
+        )}
+      </div>
     </li>
   )
 }
@@ -459,8 +540,16 @@ export const Sidebar = ({
           axis="y"
           values={activeGroup}
           onReorder={(reordered) => {
-            // Preserve order of recent sessions; only the active subset reorders.
-            onReorderSessions?.([...reordered, ...recentGroup])
+            // Recompute Recent inside the callback — vimeflow runs AI
+            // agents that can complete a task mid-drag, flipping a
+            // running session to completed. The closure-captured
+            // `recentGroup` would either drop that session or land it in
+            // the wrong slice; reading from `sessions` here is always
+            // current.
+            const freshRecent = sessions.filter(
+              (s) => s.status === 'completed' || s.status === 'errored'
+            )
+            onReorderSessions?.([...reordered, ...freshRecent])
           }}
           className="flex flex-col px-2"
           data-testid="session-list"
@@ -497,6 +586,7 @@ export const Sidebar = ({
                   isActive={session.id === activeSessionId}
                   onSessionClick={onSessionClick}
                   onRemove={handleRemoveSession}
+                  onRename={onRenameSession}
                 />
               ))}
             </ul>

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import {
   useState,
-  useRef,
   useEffect,
+  useRef,
   useCallback,
   type ReactElement,
 } from 'react'
@@ -13,6 +13,7 @@ import { FileExplorer } from './panels/FileExplorer'
 import { SidebarStatusHeader } from './SidebarStatusHeader'
 import { StatusDot } from './StatusDot'
 import { formatRelativeTime } from '../../agent-status/utils/relativeTime'
+import { useRenameState } from '../hooks/useRenameState'
 import { pickNextVisibleSessionId } from '../utils/pickNextVisibleSessionId'
 
 export interface SidebarProps {
@@ -94,25 +95,15 @@ const SessionRow = ({
   onRemove = undefined,
   onRename = undefined,
 }: SessionRowProps): ReactElement => {
-  const [isEditing, setIsEditing] = useState(false)
-  const [editValue, setEditValue] = useState(session.name)
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    if (isEditing && inputRef.current) {
-      inputRef.current.focus()
-      inputRef.current.select()
-    }
-  }, [isEditing])
-
-  const commitRename = (): void => {
-    setIsEditing(false)
-    if (editValue.trim().length > 0 && editValue.trim() !== session.name) {
-      onRename?.(session.id, editValue.trim())
-    } else {
-      setEditValue(session.name)
-    }
-  }
+  const {
+    isEditing,
+    editValue,
+    setEditValue,
+    inputRef,
+    beginEdit,
+    commitRename,
+    cancelRename,
+  } = useRenameState(session, onRename)
 
   const { added, removed } = sessionLineDelta(session)
   const subtitle = sessionSubtitle(session)
@@ -178,8 +169,7 @@ const SessionRow = ({
                   commitRename()
                 }
                 if (e.key === 'Escape') {
-                  setEditValue(session.name)
-                  setIsEditing(false)
+                  cancelRename()
                 }
               }}
               className="pointer-events-auto min-w-0 flex-1 truncate rounded bg-surface-container-high px-1 font-label text-[13px] font-semibold text-on-surface outline-none ring-1 ring-primary"
@@ -202,8 +192,7 @@ const SessionRow = ({
                   return
                 }
                 e.stopPropagation()
-                setEditValue(session.name)
-                setIsEditing(true)
+                beginEdit()
               }}
             >
               {session.name}
@@ -245,8 +234,7 @@ const SessionRow = ({
             type="button"
             onClick={(e) => {
               e.stopPropagation()
-              setEditValue(session.name)
-              setIsEditing(true)
+              beginEdit()
             }}
             className="rounded p-0.5 text-on-surface-variant/60 transition-colors hover:bg-surface-container-high hover:text-on-surface"
             aria-label="Rename session"
@@ -281,25 +269,15 @@ const RecentSessionRow = ({
   onRemove = undefined,
   onRename = undefined,
 }: SessionRowProps): ReactElement => {
-  const [isEditing, setIsEditing] = useState(false)
-  const [editValue, setEditValue] = useState(session.name)
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    if (isEditing && inputRef.current) {
-      inputRef.current.focus()
-      inputRef.current.select()
-    }
-  }, [isEditing])
-
-  const commitRename = (): void => {
-    setIsEditing(false)
-    if (editValue.trim().length > 0 && editValue.trim() !== session.name) {
-      onRename?.(session.id, editValue.trim())
-    } else {
-      setEditValue(session.name)
-    }
-  }
+  const {
+    isEditing,
+    editValue,
+    setEditValue,
+    inputRef,
+    beginEdit,
+    commitRename,
+    cancelRename,
+  } = useRenameState(session, onRename)
 
   const { added, removed } = sessionLineDelta(session)
   const subtitle = sessionSubtitle(session)
@@ -348,8 +326,7 @@ const RecentSessionRow = ({
                   commitRename()
                 }
                 if (e.key === 'Escape') {
-                  setEditValue(session.name)
-                  setIsEditing(false)
+                  cancelRename()
                 }
               }}
               className="pointer-events-auto min-w-0 flex-1 truncate rounded bg-surface-container-high px-1 font-label text-[12.5px] text-on-surface outline-none ring-1 ring-primary"
@@ -369,8 +346,7 @@ const RecentSessionRow = ({
                   return
                 }
                 e.stopPropagation()
-                setEditValue(session.name)
-                setIsEditing(true)
+                beginEdit()
               }}
             >
               {session.name}
@@ -406,8 +382,7 @@ const RecentSessionRow = ({
             type="button"
             onClick={(e) => {
               e.stopPropagation()
-              setEditValue(session.name)
-              setIsEditing(true)
+              beginEdit()
             }}
             className="rounded p-0.5 text-on-surface-variant/60 transition-colors hover:bg-surface-container-high hover:text-on-surface"
             aria-label="Rename session"

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -512,6 +512,19 @@ export const Sidebar = ({
   const activeGroup = sessions.filter((s) => isOpenSessionStatus(s.status))
   const recentGroup = sessions.filter((s) => !isOpenSessionStatus(s.status))
 
+  // Mirror `recentGroup` into a ref synchronously on every render so
+  // Framer Motion's `onReorder` callback (which can be invoked mid-drag
+  // across multiple frames) reads the current value rather than the
+  // closure-captured one. Without this ref, a session that transitions
+  // to `completed` mid-drag re-renders Sidebar with a fresh recentGroup
+  // but Framer Motion may keep dispatching the original onReorder
+  // closure that captured the pre-transition recentGroup; the resulting
+  // `[...reordered, ...staleRecentGroup]` would either drop or
+  // duplicate the newly-completed session for one frame, and a
+  // session-store that persists eagerly could write the stale array.
+  const recentGroupRef = useRef(recentGroup)
+  recentGroupRef.current = recentGroup
+
   // Mirror SessionTabs.handleClose using the shared visible-order helper.
   // useSessionManager.removeSession uses `flushSync` internally to apply
   // its own setActiveSessionId mid-call, so we must remove first and
@@ -596,10 +609,12 @@ export const Sidebar = ({
           values={activeGroup}
           onReorder={(reordered) => {
             // Preserve Recent ordering — only the Active subset reorders.
-            // `recentGroup` is captured at render time alongside `sessions`;
-            // both are equally fresh on this callback, so using the
-            // precomputed group keeps the diff minimal.
-            onReorderSessions?.([...reordered, ...recentGroup])
+            // Read recentGroup via the ref (synced every render in the
+            // outer component body) so a mid-drag status transition that
+            // re-renders Sidebar can't leave Framer Motion holding a
+            // stale closure that drops or duplicates the just-transitioned
+            // session.
+            onReorderSessions?.([...reordered, ...recentGroupRef.current])
           }}
           className="flex flex-col px-2"
           data-testid="session-list"

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -498,6 +498,12 @@ export const Sidebar = ({
   // stays a true no-op. Otherwise the trailing onSessionClick(nextId)
   // would silently switch the active session without removing the
   // intended one — a latent bug for callers that omit the prop.
+  //
+  // Focus restoration: removing the focused remove button drops DOM
+  // focus to <body>; queueMicrotask defers until React commits the
+  // re-render, then lands focus on the new active row's overlay
+  // activation button. Mirrors SessionTabs.handleClose §4.4.3 behavior
+  // for keyboard users who navigate via group-focus-within.
   const handleRemoveSession = onRemoveSession
     ? (id: string): void => {
         const nextId =
@@ -507,6 +513,13 @@ export const Sidebar = ({
         onRemoveSession(id)
         if (nextId !== undefined) {
           onSessionClick(nextId)
+          queueMicrotask(() => {
+            document
+              .querySelector<HTMLElement>(
+                `[data-session-id="${nextId}"] button[aria-label]`
+              )
+              ?.focus()
+          })
         }
       }
     : undefined

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import { FileExplorer } from './panels/FileExplorer'
 import { SidebarStatusHeader } from './SidebarStatusHeader'
 import { StatusDot } from './StatusDot'
 import { formatRelativeTime } from '../../agent-status/utils/relativeTime'
+import { pickNextVisibleSessionId } from '../utils/pickNextVisibleSessionId'
 
 export interface SidebarProps {
   sessions: Session[]
@@ -234,12 +235,16 @@ const SessionRow = ({
   )
 }
 
+// Recent rows are read-only — no rename. Narrowing the prop type makes
+// that contract explicit instead of advertising a no-op `onRename`.
+type RecentSessionRowProps = Omit<SessionRowProps, 'onRename'>
+
 const RecentSessionRow = ({
   session,
   isActive,
   onSessionClick,
   onRemove = undefined,
-}: SessionRowProps): ReactElement => {
+}: RecentSessionRowProps): ReactElement => {
   const { added, removed } = sessionLineDelta(session)
   const subtitle = sessionSubtitle(session)
 
@@ -388,21 +393,20 @@ export const Sidebar = ({
     (s) => s.status === 'completed' || s.status === 'errored'
   )
 
-  // Mirror SessionTabs.handleClose: when the user removes the active
-  // session from the sidebar, override the manager's fallback to a
-  // visible Active row. Order matters: useSessionManager.removeSession
-  // uses `flushSync` internally to apply its own setActiveSessionId
-  // mid-call, so any pre-selection we queue BEFORE the remove is wiped
-  // out by the synchronous fallback. We have to remove first, then
-  // override with the visible-order next id — same ordering as
-  // SessionTabs.handleClose for the same reason.
+  // Mirror SessionTabs.handleClose using the shared visible-order helper.
+  // useSessionManager.removeSession uses `flushSync` internally to apply
+  // its own setActiveSessionId mid-call, so we must remove first and
+  // override the selection afterward. Routing through the shared helper
+  // (instead of computing next-id from `activeGroup` only) covers the
+  // exited-active case: when the active session is completed/errored
+  // (so it lives in `recentGroup`, not `activeGroup`), the helper still
+  // produces the visually adjacent tab in the strip — matching what the
+  // tab strip's own close button does for the same scenario.
   const handleRemoveSession = (id: string): void => {
-    let nextId: string | undefined
-    if (id === activeSessionId && activeGroup.length > 1) {
-      const ids = activeGroup.map((s) => s.id)
-      const idx = ids.indexOf(id)
-      nextId = idx === ids.length - 1 ? ids[idx - 1] : ids[idx + 1]
-    }
+    const nextId =
+      id === activeSessionId
+        ? pickNextVisibleSessionId(sessions, id, activeSessionId)
+        : undefined
     onRemoveSession?.(id)
     if (nextId !== undefined) {
       onSessionClick(nextId)

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -11,6 +11,8 @@ import type { FileNode } from '../../files/types'
 import type { AgentStatus } from '../../agent-status/types'
 import { FileExplorer } from './panels/FileExplorer'
 import { SidebarStatusHeader } from './SidebarStatusHeader'
+import { StatusDot } from './StatusDot'
+import { formatRelativeTime } from '../../agent-status/utils/relativeTime'
 
 export interface SidebarProps {
   sessions: Session[]
@@ -29,7 +31,43 @@ const FILE_EXPLORER_MIN = 100
 const FILE_EXPLORER_MAX = 500
 const FILE_EXPLORER_DEFAULT = 320
 
-interface SessionItemProps {
+const sessionSubtitle = (session: Session): string => {
+  if (session.currentAction !== undefined && session.currentAction !== '') {
+    return session.currentAction
+  }
+  const parts = session.workingDirectory.split('/').filter(Boolean)
+
+  return parts.length > 0 ? parts[parts.length - 1] : session.workingDirectory
+}
+
+const sessionLineDelta = (
+  session: Session
+): { added: number; removed: number } => {
+  let added = 0
+  let removed = 0
+  for (const change of session.activity.fileChanges) {
+    added += change.linesAdded
+    removed += change.linesRemoved
+  }
+
+  return { added, removed }
+}
+
+const STATE_PILL_LABEL: Record<Session['status'], string> = {
+  running: 'running',
+  paused: 'awaiting',
+  completed: 'completed',
+  errored: 'errored',
+}
+
+const STATE_PILL_TONE: Record<Session['status'], string> = {
+  running: 'text-success bg-success/10',
+  paused: 'text-warning bg-warning/10',
+  completed: 'text-success-muted bg-success-muted/10',
+  errored: 'text-error bg-error/15',
+}
+
+interface SessionRowProps {
   session: Session
   isActive: boolean
   onSessionClick: (id: string) => void
@@ -37,13 +75,13 @@ interface SessionItemProps {
   onRename?: (id: string, name: string) => void
 }
 
-const SessionItem = ({
+const SessionRow = ({
   session,
   isActive,
   onSessionClick,
   onRemove = undefined,
   onRename = undefined,
-}: SessionItemProps): ReactElement => {
+}: SessionRowProps): ReactElement => {
   const [isEditing, setIsEditing] = useState(false)
   const [editValue, setEditValue] = useState(session.name)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -64,17 +102,23 @@ const SessionItem = ({
     }
   }
 
+  const { added, removed } = sessionLineDelta(session)
+  const subtitle = sessionSubtitle(session)
+
   return (
     <Reorder.Item
       value={session}
       id={session.id}
+      data-testid="session-row"
+      data-session-id={session.id}
+      data-active={isActive}
       className={`
-        flex items-center gap-2 rounded-md px-3 py-2
-        text-left transition-colors relative group cursor-grab active:cursor-grabbing
+        relative mb-1 cursor-grab rounded-lg px-3 py-2.5 transition-colors
+        active:cursor-grabbing group
         ${
           isActive
-            ? 'bg-surface-container-high text-on-surface'
-            : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container'
+            ? 'bg-primary/10 text-on-surface'
+            : 'text-on-surface-variant hover:bg-on-surface/[0.04]'
         }
       `}
       whileDrag={{
@@ -84,52 +128,82 @@ const SessionItem = ({
       }}
       layout="position"
     >
-      {/* Click target */}
+      {isActive && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-2 left-0 w-0.5 rounded-r bg-primary-container"
+        />
+      )}
+
       <button
         type="button"
         onClick={() => onSessionClick(session.id)}
-        className="flex min-w-0 flex-1 items-center gap-2 text-left"
+        className="flex w-full flex-col gap-1 text-left"
         aria-label={session.name}
       >
-        <span className="material-symbols-outlined text-base shrink-0">
-          {isActive ? 'smart_toy' : 'schedule'}
-        </span>
-        {isEditing ? (
-          <input
-            ref={inputRef}
-            type="text"
-            value={editValue}
-            onChange={(e) => setEditValue(e.target.value)}
-            onBlur={commitRename}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                commitRename()
-              }
-              if (e.key === 'Escape') {
+        <span className="flex items-center gap-2">
+          <StatusDot status={session.status} />
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              type="text"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={commitRename}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  commitRename()
+                }
+                if (e.key === 'Escape') {
+                  setEditValue(session.name)
+                  setIsEditing(false)
+                }
+              }}
+              onClick={(e) => e.stopPropagation()}
+              className="min-w-0 flex-1 truncate rounded bg-surface-container-high px-1 font-label text-[13px] font-semibold text-on-surface outline-none ring-1 ring-primary"
+              aria-label="Rename session"
+            />
+          ) : (
+            <span
+              className="min-w-0 flex-1 truncate font-label text-[13px] font-semibold text-on-surface"
+              onDoubleClick={(e) => {
+                e.stopPropagation()
                 setEditValue(session.name)
-                setIsEditing(false)
-              }
-            }}
-            onClick={(e) => e.stopPropagation()}
-            className="min-w-0 flex-1 truncate rounded bg-slate-700 px-1 font-label text-sm font-medium text-on-surface outline-none ring-1 ring-primary"
-            aria-label="Rename session"
-          />
-        ) : (
-          <span
-            className="min-w-0 flex-1 truncate font-label text-sm"
-            onDoubleClick={(e) => {
-              e.stopPropagation()
-              setEditValue(session.name)
-              setIsEditing(true)
-            }}
-          >
-            {session.name}
+                setIsEditing(true)
+              }}
+            >
+              {session.name}
+            </span>
+          )}
+          <span className="shrink-0 font-mono text-[10px] text-on-surface-variant/70">
+            {formatRelativeTime(session.lastActivityAt)}
           </span>
-        )}
+        </span>
+
+        <span className="block truncate pl-[15px] font-label text-[11.5px] text-on-surface-variant">
+          {subtitle}
+        </span>
+
+        <span className="flex items-center gap-2 pl-[15px] font-mono text-[10px]">
+          <span
+            data-testid="state-pill"
+            className={`rounded-full px-1.5 py-px uppercase tracking-wide ${STATE_PILL_TONE[session.status]}`}
+          >
+            {STATE_PILL_LABEL[session.status]}
+          </span>
+          {(added > 0 || removed > 0) && (
+            <span
+              data-testid="line-delta"
+              className="text-on-surface-variant/70"
+            >
+              <span className="text-success">+{added}</span>{' '}
+              <span className="text-error">-{removed}</span>
+            </span>
+          )}
+        </span>
       </button>
 
-      {/* Action buttons — visible on hover */}
-      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+      <div className="absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
         <button
           type="button"
           onClick={(e) => {
@@ -137,7 +211,7 @@ const SessionItem = ({
             setEditValue(session.name)
             setIsEditing(true)
           }}
-          className="rounded p-0.5 text-on-surface/40 transition-colors hover:bg-surface-container-high hover:text-on-surface"
+          className="rounded p-0.5 text-on-surface-variant/60 transition-colors hover:bg-surface-container-high hover:text-on-surface"
           aria-label="Rename session"
           title="Rename"
         >
@@ -149,7 +223,7 @@ const SessionItem = ({
             e.stopPropagation()
             onRemove?.(session.id)
           }}
-          className="rounded p-0.5 text-on-surface/40 transition-colors hover:bg-red-900/50 hover:text-red-400"
+          className="rounded p-0.5 text-on-surface-variant/60 transition-colors hover:bg-error/20 hover:text-error"
           aria-label="Remove session"
           title="Remove"
         >
@@ -159,6 +233,95 @@ const SessionItem = ({
     </Reorder.Item>
   )
 }
+
+const RecentSessionRow = ({
+  session,
+  isActive,
+  onSessionClick,
+  onRemove = undefined,
+}: SessionRowProps): ReactElement => {
+  const { added, removed } = sessionLineDelta(session)
+  const subtitle = sessionSubtitle(session)
+
+  return (
+    <li
+      data-testid="recent-session-row"
+      data-session-id={session.id}
+      data-active={isActive}
+      className={`
+        relative mb-1 rounded-lg px-3 py-2 transition-colors
+        ${
+          isActive
+            ? 'bg-primary/10 text-on-surface'
+            : 'text-on-surface-variant hover:bg-on-surface/[0.04]'
+        }
+      `}
+    >
+      {isActive && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-2 left-0 w-0.5 rounded-r bg-primary-container"
+        />
+      )}
+      <button
+        type="button"
+        onClick={() => onSessionClick(session.id)}
+        className="flex w-full flex-col gap-0.5 text-left"
+        aria-label={session.name}
+      >
+        <span className="flex items-center gap-2">
+          <StatusDot status={session.status} />
+          <span className="min-w-0 flex-1 truncate font-label text-[12.5px] text-on-surface-variant">
+            {session.name}
+          </span>
+          <span className="shrink-0 font-mono text-[10px] text-on-surface-variant/70">
+            {formatRelativeTime(session.lastActivityAt)}
+          </span>
+        </span>
+        <span className="flex items-center gap-2 pl-[15px] font-mono text-[10px]">
+          <span
+            data-testid="state-pill"
+            className={`rounded-full px-1.5 py-px uppercase tracking-wide ${STATE_PILL_TONE[session.status]}`}
+          >
+            {STATE_PILL_LABEL[session.status]}
+          </span>
+          {(added > 0 || removed > 0) && (
+            <span className="text-on-surface-variant/70">
+              <span className="text-success">+{added}</span>{' '}
+              <span className="text-error">-{removed}</span>
+            </span>
+          )}
+          <span className="ml-auto truncate font-label text-[10.5px] text-on-surface-variant/70">
+            {subtitle}
+          </span>
+        </span>
+      </button>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onRemove(session.id)
+          }}
+          className="absolute right-2 top-2 rounded p-0.5 text-on-surface-variant/40 opacity-0 transition-all hover:bg-error/20 hover:text-error group-hover:opacity-100"
+          aria-label="Remove session"
+          title="Remove"
+        >
+          <span className="material-symbols-outlined text-sm">close</span>
+        </button>
+      )}
+    </li>
+  )
+}
+
+const GroupHeader = ({ label }: { label: string }): ReactElement => (
+  <h3
+    data-testid={`session-group-${label.toLowerCase()}`}
+    className="px-3 pb-1 pt-2 font-mono text-[10.5px] uppercase tracking-[0.08em] text-on-surface-variant/70"
+  >
+    {label}
+  </h3>
+)
 
 export const Sidebar = ({
   sessions,
@@ -193,7 +356,6 @@ export const Sidebar = ({
     }
 
     const handleMouseMove = (e: MouseEvent): void => {
-      // Dragging up (negative delta) should increase explorer height
       const delta = startY.current - e.clientY
 
       const newHeight = Math.round(
@@ -218,6 +380,14 @@ export const Sidebar = ({
     }
   }, [isDraggingSplit])
 
+  const activeGroup = sessions.filter(
+    (s) => s.status === 'running' || s.status === 'paused'
+  )
+
+  const recentGroup = sessions.filter(
+    (s) => s.status === 'completed' || s.status === 'errored'
+  )
+
   return (
     <div
       className="flex h-full w-full flex-col bg-surface-container-low"
@@ -232,15 +402,12 @@ export const Sidebar = ({
         />
       </div>
 
-      {/* Sessions section header */}
-      <div className="flex items-center justify-between px-4 pb-1 pt-2">
-        <h2 className="font-label text-xs font-semibold uppercase tracking-wider text-on-surface/50">
-          Active Sessions
-        </h2>
+      <div className="flex items-center justify-between px-3 pb-1 pt-2">
+        <GroupHeader label="Active" />
         <button
           type="button"
           onClick={onNewInstance}
-          className="material-symbols-outlined text-base text-on-surface/50 transition-colors hover:text-primary"
+          className="material-symbols-outlined text-base text-on-surface-variant/60 transition-colors hover:text-primary"
           aria-label="Add session"
           title="Add session"
         >
@@ -248,22 +415,27 @@ export const Sidebar = ({
         </button>
       </div>
 
-      {/* Session list — takes remaining space above file explorer */}
       <Reorder.Group
         axis="y"
-        values={sessions}
-        onReorder={(reordered) => onReorderSessions?.(reordered)}
-        className="flex flex-1 flex-col gap-0.5 overflow-y-auto px-2 py-1"
+        values={activeGroup}
+        onReorder={(reordered) => {
+          // Preserve order of recent sessions; only the active subset reorders.
+          onReorderSessions?.([...reordered, ...recentGroup])
+        }}
+        className="flex flex-col overflow-y-auto px-2"
         data-testid="session-list"
         layoutScroll
       >
-        {sessions.length === 0 ? (
-          <div className="px-3 py-4 text-center text-sm text-on-surface/50">
-            No sessions
+        {activeGroup.length === 0 ? (
+          <div
+            data-testid="active-empty"
+            className="px-3 py-3 text-center font-label text-xs text-on-surface-variant/50"
+          >
+            No active sessions
           </div>
         ) : (
-          sessions.map((session) => (
-            <SessionItem
+          activeGroup.map((session) => (
+            <SessionRow
               key={session.id}
               session={session}
               isActive={session.id === activeSessionId}
@@ -275,7 +447,23 @@ export const Sidebar = ({
         )}
       </Reorder.Group>
 
-      {/* Resize handle — between sessions and file explorer */}
+      {recentGroup.length > 0 && (
+        <>
+          <GroupHeader label="Recent" />
+          <ul data-testid="recent-list" className="flex flex-col px-2 pb-1">
+            {recentGroup.map((session) => (
+              <RecentSessionRow
+                key={session.id}
+                session={session}
+                isActive={session.id === activeSessionId}
+                onSessionClick={onSessionClick}
+                onRemove={onRemoveSession}
+              />
+            ))}
+          </ul>
+        </>
+      )}
+
       <div
         data-testid="explorer-resize-handle"
         role="separator"
@@ -290,12 +478,10 @@ export const Sidebar = ({
         `}
       />
 
-      {/* File Explorer — resizable height */}
       <div style={{ height: explorerHeight }} className="shrink-0">
         <FileExplorer cwd={activeCwd} onFileSelect={onFileSelect} />
       </div>
 
-      {/* New Instance button */}
       <div className="p-3">
         <button
           type="button"
@@ -308,7 +494,6 @@ export const Sidebar = ({
         </button>
       </div>
 
-      {/* Drag overlay — prevents xterm from stealing mouse events */}
       {isDraggingSplit && (
         <div className="fixed inset-0 z-50 cursor-row-resize" />
       )}

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -191,6 +191,10 @@ const SessionRow = ({
             // to the sibling absolute button (the button is no longer an
             // ancestor) — primary row activation would silently break.
             <span
+              // aria-hidden so AT doesn't announce the name twice — the
+              // sibling overlay button already carries aria-label=name.
+              // Subtitle / state pill / line-delta stay traversable.
+              aria-hidden="true"
               className="pointer-events-auto min-w-0 flex-1 cursor-pointer truncate font-label text-[13px] font-semibold text-on-surface"
               onClick={() => onSessionClick(session.id)}
               onDoubleClick={(e) => {
@@ -355,6 +359,9 @@ const RecentSessionRow = ({
             // Same activation+rename split as SessionRow above —
             // sibling-button overlay needs an explicit onClick here.
             <span
+              // Same aria-hidden as SessionRow above — overlay button
+              // owns the name announcement, span owns visual+rename.
+              aria-hidden="true"
               className={`pointer-events-auto min-w-0 flex-1 cursor-pointer truncate font-label text-[12.5px] ${isActive ? 'text-on-surface' : 'text-on-surface-variant/60'}`}
               onClick={() => onSessionClick(session.id)}
               onDoubleClick={(e) => {

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -228,7 +228,7 @@ const SessionRow = ({
         </div>
       </div>
 
-      <div className="pointer-events-auto absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+      <div className="pointer-events-auto absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
         {onRename && (
           <button
             type="button"
@@ -376,7 +376,7 @@ const RecentSessionRow = ({
           </span>
         </div>
       </div>
-      <div className="pointer-events-auto absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+      <div className="pointer-events-auto absolute right-2 top-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
         {onRename && (
           <button
             type="button"

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -113,7 +113,7 @@ const SessionRow = ({
       data-session-id={session.id}
       data-active={isActive}
       className={`
-        relative mb-1 cursor-grab rounded-lg px-3 py-2.5 transition-colors
+        relative mb-1 cursor-grab rounded-xl px-3 py-2.5 transition-colors
         active:cursor-grabbing group
         ${
           isActive
@@ -249,7 +249,7 @@ const RecentSessionRow = ({
       data-session-id={session.id}
       data-active={isActive}
       className={`
-        group relative mb-1 rounded-lg px-3 py-2 transition-colors
+        group relative mb-1 rounded-xl px-3 py-2 transition-colors
         ${
           isActive
             ? 'bg-primary/10 text-on-surface'

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -415,54 +415,59 @@ export const Sidebar = ({
         </button>
       </div>
 
-      <Reorder.Group
-        axis="y"
-        values={activeGroup}
-        onReorder={(reordered) => {
-          // Preserve order of recent sessions; only the active subset reorders.
-          onReorderSessions?.([...reordered, ...recentGroup])
-        }}
-        className="flex flex-col overflow-y-auto px-2"
-        data-testid="session-list"
-        layoutScroll
+      <div
+        data-testid="session-scroll"
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto"
       >
-        {activeGroup.length === 0 ? (
-          <div
-            data-testid="active-empty"
-            className="px-3 py-3 text-center font-label text-xs text-on-surface-variant/50"
-          >
-            No active sessions
-          </div>
-        ) : (
-          activeGroup.map((session) => (
-            <SessionRow
-              key={session.id}
-              session={session}
-              isActive={session.id === activeSessionId}
-              onSessionClick={onSessionClick}
-              onRemove={onRemoveSession}
-              onRename={onRenameSession}
-            />
-          ))
-        )}
-      </Reorder.Group>
-
-      {recentGroup.length > 0 && (
-        <>
-          <GroupHeader label="Recent" />
-          <ul data-testid="recent-list" className="flex flex-col px-2 pb-1">
-            {recentGroup.map((session) => (
-              <RecentSessionRow
+        <Reorder.Group
+          axis="y"
+          values={activeGroup}
+          onReorder={(reordered) => {
+            // Preserve order of recent sessions; only the active subset reorders.
+            onReorderSessions?.([...reordered, ...recentGroup])
+          }}
+          className="flex flex-col px-2"
+          data-testid="session-list"
+          layoutScroll
+        >
+          {activeGroup.length === 0 ? (
+            <div
+              data-testid="active-empty"
+              className="px-3 py-3 text-center font-label text-xs text-on-surface-variant/50"
+            >
+              No active sessions
+            </div>
+          ) : (
+            activeGroup.map((session) => (
+              <SessionRow
                 key={session.id}
                 session={session}
                 isActive={session.id === activeSessionId}
                 onSessionClick={onSessionClick}
                 onRemove={onRemoveSession}
+                onRename={onRenameSession}
               />
-            ))}
-          </ul>
-        </>
-      )}
+            ))
+          )}
+        </Reorder.Group>
+
+        {recentGroup.length > 0 && (
+          <>
+            <GroupHeader label="Recent" />
+            <ul data-testid="recent-list" className="flex flex-col px-2 pb-1">
+              {recentGroup.map((session) => (
+                <RecentSessionRow
+                  key={session.id}
+                  session={session}
+                  isActive={session.id === activeSessionId}
+                  onSessionClick={onSessionClick}
+                  onRemove={onRemoveSession}
+                />
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
 
       <div
         data-testid="explorer-resize-handle"

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -402,16 +402,23 @@ export const Sidebar = ({
   // (so it lives in `recentGroup`, not `activeGroup`), the helper still
   // produces the visually adjacent tab in the strip — matching what the
   // tab strip's own close button does for the same scenario.
-  const handleRemoveSession = (id: string): void => {
-    const nextId =
-      id === activeSessionId
-        ? pickNextVisibleSessionId(sessions, id, activeSessionId)
-        : undefined
-    onRemoveSession?.(id)
-    if (nextId !== undefined) {
-      onSessionClick(nextId)
-    }
-  }
+  //
+  // Early-return when `onRemoveSession` is undefined so this wrapper
+  // stays a true no-op. Otherwise the trailing onSessionClick(nextId)
+  // would silently switch the active session without removing the
+  // intended one — a latent bug for callers that omit the prop.
+  const handleRemoveSession = onRemoveSession
+    ? (id: string): void => {
+        const nextId =
+          id === activeSessionId
+            ? pickNextVisibleSessionId(sessions, id, activeSessionId)
+            : undefined
+        onRemoveSession(id)
+        if (nextId !== undefined) {
+          onSessionClick(nextId)
+        }
+      }
+    : undefined
 
   return (
     <div

--- a/src/features/workspace/components/Sidebar.tsx
+++ b/src/features/workspace/components/Sidebar.tsx
@@ -153,6 +153,7 @@ const SessionRow = ({
         type="button"
         onClick={() => onSessionClick(session.id)}
         aria-label={session.name}
+        id={`sidebar-activate-${session.id}`}
         data-role="activate"
         className="absolute inset-0 rounded-[8px]"
         tabIndex={isEditing ? -1 : 0}
@@ -312,6 +313,7 @@ const RecentSessionRow = ({
         type="button"
         onClick={() => onSessionClick(session.id)}
         aria-label={session.name}
+        id={`sidebar-activate-${session.id}`}
         data-role="activate"
         className="absolute inset-0 rounded-[8px]"
         tabIndex={isEditing ? -1 : 0}
@@ -518,15 +520,15 @@ export const Sidebar = ({
         if (nextId !== undefined) {
           onSessionClick(nextId)
           queueMicrotask(() => {
-            // Target the overlay activation button explicitly via
-            // data-role rather than `button[aria-label]` so the
-            // selector survives a future DOM reordering that puts the
-            // hover Rename/Remove buttons above the overlay.
-            document
-              .querySelector<HTMLElement>(
-                `[data-session-id="${nextId}"] [data-role="activate"]`
-              )
-              ?.focus()
+            // Mirror SessionTabs' `getElementById('session-tab-...')`
+            // pattern: the overlay button carries
+            // `id="sidebar-activate-${session.id}"`, so id-based lookup
+            // is both consistent across the two strips AND avoids the
+            // CSS-attribute-selector escaping path entirely. A session
+            // id containing `"` or `]` would otherwise corrupt the
+            // selector and either silently fail (`querySelector` →
+            // null) or throw `SyntaxError`.
+            document.getElementById(`sidebar-activate-${nextId}`)?.focus()
           })
         }
       }

--- a/src/features/workspace/components/StatusDot.test.tsx
+++ b/src/features/workspace/components/StatusDot.test.tsx
@@ -1,0 +1,57 @@
+import { describe, test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatusDot } from './StatusDot'
+
+describe('StatusDot', () => {
+  test('running status uses success class with pulse animation', () => {
+    render(<StatusDot status="running" />)
+
+    const dot = screen.getByTestId('status-dot')
+    expect(dot).toHaveAttribute('data-status', 'running')
+    expect(dot.className).toContain('bg-success')
+    expect(dot.className).toContain('animate-pulse')
+  })
+
+  test('paused status uses warning amber', () => {
+    render(<StatusDot status="paused" />)
+    expect(screen.getByTestId('status-dot').className).toContain('bg-warning')
+  })
+
+  test('completed status uses success-muted', () => {
+    render(<StatusDot status="completed" />)
+    expect(screen.getByTestId('status-dot').className).toContain(
+      'bg-success-muted'
+    )
+  })
+
+  test('errored status uses error', () => {
+    render(<StatusDot status="errored" />)
+    expect(screen.getByTestId('status-dot').className).toContain('bg-error')
+  })
+
+  test('renders at 7px by default per handoff §4.2', () => {
+    render(<StatusDot status="running" />)
+    const dot = screen.getByTestId('status-dot')
+    expect(dot.style.width).toBe('7px')
+    expect(dot.style.height).toBe('7px')
+  })
+
+  test('size prop overrides the default (e.g. 5px for tab pip)', () => {
+    render(<StatusDot status="running" size={5} />)
+    const dot = screen.getByTestId('status-dot')
+    expect(dot.style.width).toBe('5px')
+  })
+
+  test('aria-label promotes the dot to an img role for screen readers', () => {
+    render(<StatusDot status="running" aria-label="Session running" />)
+    expect(screen.getByRole('img')).toHaveAccessibleName('Session running')
+  })
+
+  test('without aria-label the dot is aria-hidden', () => {
+    render(<StatusDot status="running" />)
+    expect(screen.getByTestId('status-dot')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
+  })
+})

--- a/src/features/workspace/components/StatusDot.tsx
+++ b/src/features/workspace/components/StatusDot.tsx
@@ -4,9 +4,16 @@ import type { SessionStatus } from '../types'
 export interface StatusDotProps {
   status: SessionStatus
   size?: number
+  /**
+   * Visually demote the dot — used in Recent rows so completed/errored
+   * sessions read as secondary chrome instead of competing with the
+   * Active group's bright running dots.
+   */
+  dim?: boolean
   'aria-label'?: string
 }
 
+// Bright tones — used in Active group rows + the SessionTabs strip.
 const TONE_CLASS: Record<SessionStatus, string> = {
   running: 'bg-success shadow-[0_0_4px_theme(colors.success)] animate-pulse',
   paused: 'bg-warning animate-pulse',
@@ -14,18 +21,29 @@ const TONE_CLASS: Record<SessionStatus, string> = {
   errored: 'bg-error',
 }
 
+// Dim tones — used in Recent group rows. No glow, no pulse, hollow
+// outline so the dot reads as a marker rather than a heartbeat.
+const DIM_TONE_CLASS: Record<SessionStatus, string> = {
+  running: 'border border-success/60',
+  paused: 'border border-warning/60',
+  completed: 'border border-success-muted/60',
+  errored: 'border border-error/60',
+}
+
 export const StatusDot = ({
   status,
   size = 7,
+  dim = false,
   'aria-label': ariaLabel,
 }: StatusDotProps): ReactElement => (
   <span
     data-testid="status-dot"
     data-status={status}
+    data-dim={dim || undefined}
     role={ariaLabel ? 'img' : undefined}
     aria-label={ariaLabel}
     aria-hidden={ariaLabel ? undefined : true}
-    className={`inline-block shrink-0 rounded-full ${TONE_CLASS[status]}`}
+    className={`inline-block shrink-0 rounded-full ${dim ? DIM_TONE_CLASS[status] : TONE_CLASS[status]}`}
     style={{ width: size, height: size }}
   />
 )

--- a/src/features/workspace/components/StatusDot.tsx
+++ b/src/features/workspace/components/StatusDot.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement } from 'react'
+import type { SessionStatus } from '../types'
+
+export interface StatusDotProps {
+  status: SessionStatus
+  size?: number
+  'aria-label'?: string
+}
+
+const TONE_CLASS: Record<SessionStatus, string> = {
+  running: 'bg-success shadow-[0_0_4px_theme(colors.success)] animate-pulse',
+  paused: 'bg-warning animate-pulse',
+  completed: 'bg-success-muted',
+  errored: 'bg-error',
+}
+
+export const StatusDot = ({
+  status,
+  size = 7,
+  'aria-label': ariaLabel,
+}: StatusDotProps): ReactElement => (
+  <span
+    data-testid="status-dot"
+    data-status={status}
+    role={ariaLabel ? 'img' : undefined}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    className={`inline-block shrink-0 rounded-full ${TONE_CLASS[status]}`}
+    style={{ width: size, height: size }}
+  />
+)

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -164,7 +164,7 @@ describe('TerminalZone', () => {
 
     // Should show placeholder instead
     expect(
-      screen.getByText(/no active session.*click \+ to create a new terminal/i)
+      screen.getByText(/no active session.*click \+ in the session tab bar/i)
     ).toBeInTheDocument()
   })
 

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable testing-library/no-node-access */
-import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { describe, test, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TerminalZone } from './TerminalZone'
@@ -62,105 +61,11 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
 }))
 
 describe('TerminalZone', () => {
-  const mockOnSessionChange = vi.fn()
-  const mockOnNewTab = vi.fn()
-
-  beforeEach(() => {
-    mockOnSessionChange.mockClear()
-    mockOnNewTab.mockClear()
-  })
-
   const defaultProps = {
     sessions: mockSessions.slice(0, 2), // First two sessions
     activeSessionId: 'sess-1',
-    onSessionChange: mockOnSessionChange,
-    onNewTab: mockOnNewTab,
     service: mockService,
   }
-
-  test('renders tab bar with agent session tabs', () => {
-    render(<TerminalZone {...defaultProps} />)
-
-    // Check that both session tabs render
-    expect(screen.getByText('🤖 auth middleware')).toBeInTheDocument()
-    expect(screen.getByText('🤖 fix: login bug')).toBeInTheDocument()
-  })
-
-  test('renders + new tab button', () => {
-    render(<TerminalZone {...defaultProps} />)
-
-    const newTabButton = screen.getByRole('button', { name: /new tab/i })
-
-    expect(newTabButton).toBeInTheDocument()
-    expect(newTabButton).toHaveTextContent('+')
-  })
-
-  test('applies active tab styling to selected session', () => {
-    render(<TerminalZone {...defaultProps} />)
-
-    const activeTab = screen.getByRole('button', {
-      name: /🤖 auth middleware/i,
-    })
-
-    const inactiveTab = screen.getByRole('button', {
-      name: /🤖 fix: login bug/i,
-    })
-
-    // Styling classes are on the parent div wrapper
-    const activeWrapper = activeTab.parentElement!
-    const inactiveWrapper = inactiveTab.parentElement!
-
-    // Active tab should have primary text color
-    expect(activeWrapper).toHaveClass('text-primary')
-    // Active tab should have purple bottom border
-    expect(activeWrapper).toHaveClass('border-b-primary')
-
-    // Inactive tab should have muted text
-    expect(inactiveWrapper).toHaveClass('text-on-surface/60')
-    // Inactive tab should have transparent border
-    expect(inactiveWrapper).toHaveClass('border-b-transparent')
-  })
-
-  test('calls onSessionChange when clicking inactive tab', async () => {
-    const user = userEvent.setup()
-
-    render(<TerminalZone {...defaultProps} />)
-
-    const inactiveTab = screen.getByRole('button', {
-      name: /🤖 fix: login bug/i,
-    })
-
-    await user.click(inactiveTab)
-
-    expect(mockOnSessionChange).toHaveBeenCalledWith('sess-2')
-    expect(mockOnSessionChange).toHaveBeenCalledTimes(1)
-  })
-
-  test('does not call onSessionChange when clicking active tab', async () => {
-    const user = userEvent.setup()
-
-    render(<TerminalZone {...defaultProps} />)
-
-    const activeTab = screen.getByRole('button', {
-      name: /🤖 auth middleware/i,
-    })
-
-    await user.click(activeTab)
-
-    expect(mockOnSessionChange).not.toHaveBeenCalled()
-  })
-
-  test('calls onNewTab when clicking + button', async () => {
-    const user = userEvent.setup()
-
-    render(<TerminalZone {...defaultProps} />)
-
-    const newTabButton = screen.getByRole('button', { name: /new tab/i })
-
-    await user.click(newTabButton)
-
-    expect(mockOnNewTab).toHaveBeenCalledTimes(1)
-  })
 
   test('renders terminal content area with TerminalPane', () => {
     render(<TerminalZone {...defaultProps} />)
@@ -174,75 +79,12 @@ describe('TerminalZone', () => {
     expect(screen.getAllByTestId('terminal-pane-mock')).toHaveLength(2)
   })
 
-  test('renders with empty sessions array', () => {
-    render(<TerminalZone {...defaultProps} sessions={[]} />)
-
-    // Should still render tab bar
-    expect(screen.getByTestId('tab-bar')).toBeInTheDocument()
-    // Should still render new tab button
-    expect(screen.getByRole('button', { name: /new tab/i })).toBeInTheDocument()
-    // Terminal content should still render
-    expect(screen.getByTestId('terminal-content')).toBeInTheDocument()
-  })
-
-  test('applies correct design tokens to tab bar', () => {
-    render(<TerminalZone {...defaultProps} />)
-
-    const tabBar = screen.getByTestId('tab-bar')
-
-    // Background color from design tokens - deepest recessed areas per spec
-    expect(tabBar).toHaveClass('bg-surface-container-lowest')
-    // Proper spacing
-    expect(tabBar).toHaveClass('px-2')
-    expect(tabBar).toHaveClass('gap-1')
-  })
-
-  test('applies hover state to inactive tabs', () => {
-    render(<TerminalZone {...defaultProps} />)
-
-    const inactiveTab = screen.getByRole('button', {
-      name: /🤖 fix: login bug/i,
-    })
-
-    // Hover classes are on the parent div wrapper
-    const wrapper = inactiveTab.parentElement!
-    expect(wrapper).toHaveClass('hover:bg-surface-container/50')
-    expect(wrapper).toHaveClass('hover:text-on-surface')
-  })
-
   test('renders flex-1 for terminal content to fill available space', () => {
     render(<TerminalZone {...defaultProps} />)
 
     const terminalContent = screen.getByTestId('terminal-content')
 
     expect(terminalContent).toHaveClass('flex-1')
-  })
-
-  test('renders tab bar with proper flex layout', () => {
-    render(<TerminalZone {...defaultProps} />)
-
-    const tabBar = screen.getByTestId('tab-bar')
-
-    expect(tabBar).toHaveClass('flex')
-    expect(tabBar).toHaveClass('items-center')
-  })
-
-  test('renders tabs with font-label class', () => {
-    render(<TerminalZone {...defaultProps} />)
-
-    const tab = screen.getByRole('button', { name: /🤖 auth middleware/i })
-
-    expect(tab).toHaveClass('font-label')
-  })
-
-  test('renders new tab button with correct styling', () => {
-    render(<TerminalZone {...defaultProps} />)
-
-    const newTabButton = screen.getByRole('button', { name: /new tab/i })
-
-    expect(newTabButton).toHaveClass('text-on-surface/60')
-    expect(newTabButton).toHaveClass('hover:text-on-surface')
-    expect(newTabButton).toHaveClass('hover:bg-surface-container/50')
   })
 
   test('component has flex column layout', () => {

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -10,6 +10,7 @@ import type {
   PaneEventHandler,
   NotifyPaneReadyResult,
 } from '../hooks/useSessionManager'
+import { isOpenSessionStatus } from '../utils/pickNextVisibleSessionId'
 
 export interface TerminalZoneProps {
   sessions: Session[]
@@ -116,10 +117,12 @@ export const TerminalZone = ({
           // aria-labelledby would point at a non-existent element. Only
           // wire the linkage when the panel actually has a visible tab
           // (= isActive OR open status). Hidden panels stay aria-clean.
-          const hasVisibleTab =
-            isActive ||
-            session.status === 'running' ||
-            session.status === 'paused'
+          // Use the canonical `isOpenSessionStatus` predicate from the
+          // utility (same source as Sidebar's Active/Recent grouping)
+          // so a future non-open status (e.g. `suspended`) auto-flows
+          // into both visibility surfaces without TerminalZone needing
+          // a separate update.
+          const hasVisibleTab = isActive || isOpenSessionStatus(session.status)
 
           return (
             <div

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -110,6 +110,9 @@ export const TerminalZone = ({
           return (
             <div
               key={session.id}
+              id={`session-panel-${session.id}`}
+              role="tabpanel"
+              aria-labelledby={`session-tab-${session.id}`}
               data-testid="terminal-pane"
               data-session-id={session.id}
               data-cwd={session.workingDirectory}

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -107,12 +107,25 @@ export const TerminalZone = ({
             mode = 'attach'
           }
 
+          // SessionTabs.open keeps a tab for running/paused sessions OR
+          // the active session — completed/errored non-active sessions
+          // exist as panels here but have no corresponding tab id, so
+          // aria-labelledby would point at a non-existent element. Only
+          // wire the linkage when the panel actually has a visible tab
+          // (= isActive OR open status). Hidden panels stay aria-clean.
+          const hasVisibleTab =
+            isActive ||
+            session.status === 'running' ||
+            session.status === 'paused'
+
           return (
             <div
               key={session.id}
               id={`session-panel-${session.id}`}
               role="tabpanel"
-              aria-labelledby={`session-tab-${session.id}`}
+              aria-labelledby={
+                hasVisibleTab ? `session-tab-${session.id}` : undefined
+              }
               data-testid="terminal-pane"
               data-session-id={session.id}
               data-cwd={session.workingDirectory}

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -69,7 +69,10 @@ export const TerminalZone = ({
         </div>
       ) : sessions.length === 0 ? (
         <div className="flex h-full items-center justify-center font-mono text-on-surface/60">
-          <p>No active session. Click + to create a new terminal.</p>
+          <p>
+            No active session. Click + in the session tab bar above to create
+            one.
+          </p>
         </div>
       ) : (
         // Render all sessions but hide inactive ones to keep PTY sessions alive.

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -82,7 +82,7 @@ export const TerminalZone = ({
           const restore = restoreData?.get(session.id)
 
           // Rules (status-first, round 3 Finding 3 / codex P2):
-          //  - status === 'completed' (cached or just-Exited) →
+          //  - Exited statuses (completed OR errored) →
           //    'awaiting-restart'. Render a Restart button; do NOT
           //    auto-spawn. Status check wins over restoreData because
           //    round-2 F1 made restoreData get seeded for every session
@@ -91,12 +91,17 @@ export const TerminalZone = ({
           //    restoreData-first precedence, a shell that terminates
           //    after mount stayed in 'attach' mode forever — the new
           //    Restart UX was unreachable until a full reload.
+          //    Errored peers completed in the SessionStatus union (both
+          //    are visible in the Sidebar Recent group + retained in the
+          //    SessionTabs strip when active) so both must route here;
+          //    skipping errored leaves a zombie attach or silent respawn
+          //    on a dead PTY.
           //  - Has restoreData → 'attach'. Covers Alive restored sessions
           //    AND newly-created sessions (createSession seeds an empty
           //    restoreData slot so the pane attaches instead of spawning).
           //  - Otherwise → 'spawn' (legacy fallback).
           let mode: TerminalPaneMode = 'spawn'
-          if (session.status === 'completed') {
+          if (session.status === 'completed' || session.status === 'errored') {
             mode = 'awaiting-restart'
           } else if (restore) {
             mode = 'attach'

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -14,9 +14,6 @@ import type {
 export interface TerminalZoneProps {
   sessions: Session[]
   activeSessionId: string | null
-  onSessionChange: (sessionId: string) => void
-  onNewTab: () => void
-  onCloseTab?: (sessionId: string) => void
   onSessionCwdChange?: (sessionId: string, cwd: string) => void
   /** Restore data per session id, populated during mount-time restore */
   restoreData?: Map<string, RestoreData>
@@ -45,155 +42,89 @@ export interface TerminalZoneProps {
 export const TerminalZone = ({
   sessions,
   activeSessionId,
-  onSessionChange,
-  onNewTab,
-  onCloseTab = undefined,
   onSessionCwdChange = undefined,
   restoreData = undefined,
   loading = false,
   onPaneReady = undefined,
   onSessionRestart = undefined,
   service,
-}: TerminalZoneProps): ReactElement => {
-  const handleTabClick = (sessionId: string): void => {
-    if (activeSessionId === null || sessionId !== activeSessionId) {
-      onSessionChange(sessionId)
-    }
-  }
+}: TerminalZoneProps): ReactElement => (
+  <div data-testid="terminal-zone" className="flex min-h-0 flex-1 flex-col">
+    {/* DEBUG: zone info (dev only) */}
+    {import.meta.env.DEV && (
+      <div className="bg-yellow-900/50 px-2 py-0.5 text-xs font-mono text-yellow-300">
+        DEBUG TerminalZone: {sessions.length} sessions | active=
+        {activeSessionId ?? 'none'}
+      </div>
+    )}
 
-  return (
-    <div data-testid="terminal-zone" className="flex min-h-0 flex-1 flex-col">
-      {/* Tab bar */}
-      <div
-        data-testid="tab-bar"
-        className="flex items-center gap-1 bg-surface-container-lowest px-2"
-      >
-        {/* Session tabs */}
-        {sessions.map((session) => {
+    {/* Terminal content area — relative + absolute inner to give xterm explicit dimensions */}
+    <div
+      data-testid="terminal-content"
+      className="relative min-h-0 flex-1 bg-surface"
+    >
+      {loading ? (
+        <div className="flex h-full items-center justify-center font-mono text-on-surface/60">
+          <p>Restoring sessions...</p>
+        </div>
+      ) : sessions.length === 0 ? (
+        <div className="flex h-full items-center justify-center font-mono text-on-surface/60">
+          <p>No active session. Click + to create a new terminal.</p>
+        </div>
+      ) : (
+        // Render all sessions but hide inactive ones to keep PTY sessions alive.
+        // Decide explicit mode for this pane. Pinning the lifecycle here
+        // avoids the previous bug (TerminalPane inferred from
+        // restoredFrom===undefined, which spawned a hidden duplicate PTY
+        // for newly-created sessions and resurrected dead ones on reload).
+        sessions.map((session) => {
           const isActive = session.id === activeSessionId
+          const restore = restoreData?.get(session.id)
+
+          // Rules (status-first, round 3 Finding 3 / codex P2):
+          //  - status === 'completed' (cached or just-Exited) →
+          //    'awaiting-restart'. Render a Restart button; do NOT
+          //    auto-spawn. Status check wins over restoreData because
+          //    round-2 F1 made restoreData get seeded for every session
+          //    (so per-session buffering works for newly-created tabs
+          //    too) and nothing clears it when the PTY later exits. With
+          //    restoreData-first precedence, a shell that terminates
+          //    after mount stayed in 'attach' mode forever — the new
+          //    Restart UX was unreachable until a full reload.
+          //  - Has restoreData → 'attach'. Covers Alive restored sessions
+          //    AND newly-created sessions (createSession seeds an empty
+          //    restoreData slot so the pane attaches instead of spawning).
+          //  - Otherwise → 'spawn' (legacy fallback).
+          let mode: TerminalPaneMode = 'spawn'
+          if (session.status === 'completed') {
+            mode = 'awaiting-restart'
+          } else if (restore) {
+            mode = 'attach'
+          }
 
           return (
             <div
               key={session.id}
-              className={`
-                group flex items-center border-b-2 transition-colors
-                ${
-                  isActive
-                    ? 'border-b-primary text-primary'
-                    : 'border-b-transparent text-on-surface/60 hover:bg-surface-container/50 hover:text-on-surface'
-                }
-              `}
+              data-testid="terminal-pane"
+              data-session-id={session.id}
+              data-cwd={session.workingDirectory}
+              data-mode={mode}
+              className={`absolute inset-0 ${isActive ? '' : 'hidden'}`}
             >
-              <button
-                type="button"
-                aria-label={`🤖 ${session.name}`}
-                onClick={() => handleTabClick(session.id)}
-                className="px-3 py-2 font-label text-sm"
-              >
-                🤖 {session.name}
-              </button>
-              <button
-                type="button"
-                aria-label={`Close ${session.name}`}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onCloseTab?.(session.id)
-                }}
-                className="mr-1 rounded p-0.5 opacity-0 transition-opacity hover:bg-surface-container group-hover:opacity-100"
-              >
-                <span className="material-symbols-outlined text-xs">close</span>
-              </button>
+              <TerminalPane
+                sessionId={session.id}
+                cwd={session.workingDirectory}
+                service={service}
+                restoredFrom={restore}
+                mode={mode}
+                onCwdChange={(cwd) => onSessionCwdChange?.(session.id, cwd)}
+                onPaneReady={onPaneReady}
+                onRestart={onSessionRestart}
+              />
             </div>
           )
-        })}
-
-        {/* New tab button */}
-        <button
-          type="button"
-          aria-label="New tab"
-          onClick={onNewTab}
-          className="px-3 py-2 font-label text-sm text-on-surface/60 transition-colors hover:bg-surface-container/50 hover:text-on-surface"
-        >
-          +
-        </button>
-      </div>
-
-      {/* DEBUG: zone info (dev only) */}
-      {import.meta.env.DEV && (
-        <div className="bg-yellow-900/50 px-2 py-0.5 text-xs font-mono text-yellow-300">
-          DEBUG TerminalZone: {sessions.length} sessions | active=
-          {activeSessionId ?? 'none'}
-        </div>
+        })
       )}
-
-      {/* Terminal content area — relative + absolute inner to give xterm explicit dimensions */}
-      <div
-        data-testid="terminal-content"
-        className="relative min-h-0 flex-1 bg-surface"
-      >
-        {loading ? (
-          <div className="flex h-full items-center justify-center font-mono text-on-surface/60">
-            <p>Restoring sessions...</p>
-          </div>
-        ) : sessions.length === 0 ? (
-          <div className="flex h-full items-center justify-center font-mono text-on-surface/60">
-            <p>No active session. Click + to create a new terminal.</p>
-          </div>
-        ) : (
-          // Render all sessions but hide inactive ones to keep PTY sessions alive.
-          // Decide explicit mode for this pane. Pinning the lifecycle here
-          // avoids the previous bug (TerminalPane inferred from
-          // restoredFrom===undefined, which spawned a hidden duplicate PTY
-          // for newly-created sessions and resurrected dead ones on reload).
-          sessions.map((session) => {
-            const isActive = session.id === activeSessionId
-            const restore = restoreData?.get(session.id)
-
-            // Rules (status-first, round 3 Finding 3 / codex P2):
-            //  - status === 'completed' (cached or just-Exited) →
-            //    'awaiting-restart'. Render a Restart button; do NOT
-            //    auto-spawn. Status check wins over restoreData because
-            //    round-2 F1 made restoreData get seeded for every session
-            //    (so per-session buffering works for newly-created tabs
-            //    too) and nothing clears it when the PTY later exits. With
-            //    restoreData-first precedence, a shell that terminates
-            //    after mount stayed in 'attach' mode forever — the new
-            //    Restart UX was unreachable until a full reload.
-            //  - Has restoreData → 'attach'. Covers Alive restored sessions
-            //    AND newly-created sessions (createSession seeds an empty
-            //    restoreData slot so the pane attaches instead of spawning).
-            //  - Otherwise → 'spawn' (legacy fallback).
-            let mode: TerminalPaneMode = 'spawn'
-            if (session.status === 'completed') {
-              mode = 'awaiting-restart'
-            } else if (restore) {
-              mode = 'attach'
-            }
-
-            return (
-              <div
-                key={session.id}
-                data-testid="terminal-pane"
-                data-session-id={session.id}
-                data-cwd={session.workingDirectory}
-                data-mode={mode}
-                className={`absolute inset-0 ${isActive ? '' : 'hidden'}`}
-              >
-                <TerminalPane
-                  sessionId={session.id}
-                  cwd={session.workingDirectory}
-                  service={service}
-                  restoredFrom={restore}
-                  mode={mode}
-                  onCwdChange={(cwd) => onSessionCwdChange?.(session.id, cwd)}
-                  onPaneReady={onPaneReady}
-                  onRestart={onSessionRestart}
-                />
-              </div>
-            )
-          })
-        )}
-      </div>
     </div>
-  )
-}
+  </div>
+)

--- a/src/features/workspace/hooks/useRenameState.test.ts
+++ b/src/features/workspace/hooks/useRenameState.test.ts
@@ -177,4 +177,32 @@ describe('useRenameState', () => {
     expect(result.current.editValue).toBe('auth')
     expect(onRename).not.toHaveBeenCalled()
   })
+
+  test('cancelRename then a trailing commitRename (stale onBlur after Escape) does NOT fire onRename', () => {
+    // Real-DOM repro: pressing Escape calls cancelRename → setIsEditing(false)
+    // → React unmounts the input on flush → browser fires native blur on the
+    // detached node → React dispatches the synthetic onBlur with the
+    // previous render's commitRename closure, which still captures the
+    // user's typed editValue. cancelRename must arm committedRef so that
+    // stale callback no-ops; otherwise onRename(id, userTypedText) fires
+    // and silently renames the session despite the Escape intent. jsdom
+    // does not fire native blur on DOM removal, so we simulate the
+    // post-cancel commitRename call directly.
+    const onRename = vi.fn()
+
+    const { result } = renderHook(() =>
+      useRenameState(buildSession('auth'), onRename)
+    )
+    act(() => {
+      result.current.beginEdit()
+      result.current.setEditValue('mid-edit')
+    })
+
+    act(() => {
+      result.current.cancelRename()
+      result.current.commitRename()
+    })
+    expect(onRename).not.toHaveBeenCalled()
+    expect(result.current.editValue).toBe('auth')
+  })
 })

--- a/src/features/workspace/hooks/useRenameState.test.ts
+++ b/src/features/workspace/hooks/useRenameState.test.ts
@@ -108,6 +108,57 @@ describe('useRenameState', () => {
     expect(result.current.editValue).toBe('auth')
   })
 
+  test('commitRename fires onRename only once even when called twice (Enter then onBlur)', () => {
+    // Enter keydown commits → setIsEditing(false) → input unmounts →
+    // browser fires focusout → onBlur → commitRename re-enters. The
+    // second call must be a no-op so onRename isn't double-fired with
+    // the same args (matters when onRename does an IPC).
+    const onRename = vi.fn()
+
+    const { result } = renderHook(() =>
+      useRenameState(buildSession('auth'), onRename)
+    )
+    act(() => {
+      result.current.beginEdit()
+      result.current.setEditValue('new')
+    })
+
+    act(() => {
+      result.current.commitRename()
+      // Simulate the trailing onBlur after the input unmounts.
+      result.current.commitRename()
+    })
+    expect(onRename).toHaveBeenCalledTimes(1)
+    expect(onRename).toHaveBeenCalledWith('sess-1', 'new')
+  })
+
+  test('beginEdit resets the committed flag for a fresh rename session', () => {
+    const onRename = vi.fn()
+
+    const { result } = renderHook(() =>
+      useRenameState(buildSession('auth'), onRename)
+    )
+    act(() => {
+      result.current.beginEdit()
+      result.current.setEditValue('new1')
+    })
+
+    act(() => {
+      result.current.commitRename()
+    })
+
+    act(() => {
+      result.current.beginEdit()
+      result.current.setEditValue('new2')
+    })
+
+    act(() => {
+      result.current.commitRename()
+    })
+    expect(onRename).toHaveBeenCalledTimes(2)
+    expect(onRename).toHaveBeenLastCalledWith('sess-1', 'new2')
+  })
+
   test('cancelRename exits editing without firing onRename and reverts edit value', () => {
     const onRename = vi.fn()
 

--- a/src/features/workspace/hooks/useRenameState.test.ts
+++ b/src/features/workspace/hooks/useRenameState.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useRenameState } from './useRenameState'
+import type { Session } from '../types'
+
+const buildSession = (name = 'auth'): Session => ({
+  id: 'sess-1',
+  projectId: 'p1',
+  name,
+  status: 'running',
+  workingDirectory: '~',
+  agentType: 'claude-code',
+  createdAt: '2026-05-06T00:00:00Z',
+  lastActivityAt: '2026-05-06T00:00:00Z',
+  activity: {
+    fileChanges: [],
+    toolCalls: [],
+    testResults: [],
+    contextWindow: { used: 0, total: 200_000, percentage: 0, emoji: '😊' },
+    usage: {
+      sessionDuration: 0,
+      turnCount: 0,
+      messages: { sent: 0, limit: 200 },
+      tokens: { input: 0, output: 0, total: 0 },
+    },
+  },
+})
+
+describe('useRenameState', () => {
+  test('starts not editing with editValue seeded from session name', () => {
+    const { result } = renderHook(() =>
+      useRenameState(buildSession('auth'), vi.fn())
+    )
+    expect(result.current.isEditing).toBe(false)
+    expect(result.current.editValue).toBe('auth')
+  })
+
+  test('beginEdit enters editing mode', () => {
+    const { result } = renderHook(() =>
+      useRenameState(buildSession('auth'), vi.fn())
+    )
+    act(() => {
+      result.current.beginEdit()
+    })
+    expect(result.current.isEditing).toBe(true)
+  })
+
+  test('beginEdit is a no-op when onRename is undefined', () => {
+    const { result } = renderHook(() =>
+      useRenameState(buildSession('auth'), undefined)
+    )
+    act(() => {
+      result.current.beginEdit()
+    })
+    expect(result.current.isEditing).toBe(false)
+  })
+
+  test('commitRename fires onRename with the trimmed new value', () => {
+    const onRename = vi.fn()
+
+    const { result } = renderHook(() =>
+      useRenameState(buildSession('auth'), onRename)
+    )
+    act(() => {
+      result.current.beginEdit()
+      result.current.setEditValue('  new name  ')
+    })
+
+    act(() => {
+      result.current.commitRename()
+    })
+    expect(onRename).toHaveBeenCalledWith('sess-1', 'new name')
+    expect(result.current.isEditing).toBe(false)
+  })
+
+  test('commitRename does NOT fire onRename when trimmed value equals current name', () => {
+    const onRename = vi.fn()
+
+    const { result } = renderHook(() =>
+      useRenameState(buildSession('auth'), onRename)
+    )
+    act(() => {
+      result.current.beginEdit()
+      result.current.setEditValue('  auth  ')
+    })
+
+    act(() => {
+      result.current.commitRename()
+    })
+    expect(onRename).not.toHaveBeenCalled()
+  })
+
+  test('commitRename does NOT fire onRename when trimmed value is empty', () => {
+    const onRename = vi.fn()
+
+    const { result } = renderHook(() =>
+      useRenameState(buildSession('auth'), onRename)
+    )
+    act(() => {
+      result.current.beginEdit()
+      result.current.setEditValue('   ')
+    })
+
+    act(() => {
+      result.current.commitRename()
+    })
+    expect(onRename).not.toHaveBeenCalled()
+    expect(result.current.editValue).toBe('auth')
+  })
+
+  test('cancelRename exits editing without firing onRename and reverts edit value', () => {
+    const onRename = vi.fn()
+
+    const { result } = renderHook(() =>
+      useRenameState(buildSession('auth'), onRename)
+    )
+    act(() => {
+      result.current.beginEdit()
+      result.current.setEditValue('mid-edit')
+    })
+
+    act(() => {
+      result.current.cancelRename()
+    })
+    expect(result.current.isEditing).toBe(false)
+    expect(result.current.editValue).toBe('auth')
+    expect(onRename).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/workspace/hooks/useRenameState.ts
+++ b/src/features/workspace/hooks/useRenameState.ts
@@ -35,6 +35,15 @@ export const useRenameState = (
   const [isEditing, setIsEditing] = useState(false)
   const [editValue, setEditValue] = useState(session.name)
   const inputRef = useRef<HTMLInputElement | null>(null)
+  // Prevents double-firing onRename when Enter is pressed: the keydown
+  // handler calls commitRename, which queues setIsEditing(false). React
+  // batches that, but on flush the input unmounts → browser fires
+  // focusout synchronously → React's onBlur listener re-enters
+  // commitRename. Without this ref both paths see the same stale
+  // closure (trimmed !== session.name) and onRename fires twice with
+  // identical args. Reset on every begin/cancel so the next rename
+  // session starts clean.
+  const committedRef = useRef(false)
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -47,11 +56,16 @@ export const useRenameState = (
     if (!onRename) {
       return
     }
+    committedRef.current = false
     setEditValue(session.name)
     setIsEditing(true)
   }
 
   const commitRename = (): void => {
+    if (committedRef.current) {
+      return
+    }
+    committedRef.current = true
     setIsEditing(false)
     const trimmed = editValue.trim()
     if (trimmed.length > 0 && trimmed !== session.name) {
@@ -62,6 +76,7 @@ export const useRenameState = (
   }
 
   const cancelRename = (): void => {
+    committedRef.current = false
     setEditValue(session.name)
     setIsEditing(false)
   }

--- a/src/features/workspace/hooks/useRenameState.ts
+++ b/src/features/workspace/hooks/useRenameState.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef, useState, type RefObject } from 'react'
+import type { Session } from '../types'
+
+export interface UseRenameStateReturn {
+  /** Whether the row is currently in rename mode. */
+  isEditing: boolean
+  /** Current input value. */
+  editValue: string
+  /** Setter for the input value (wire to <input onChange>). */
+  setEditValue: (value: string) => void
+  /** Ref to attach to the rename <input> for focus + select on enter-edit. */
+  inputRef: RefObject<HTMLInputElement | null>
+  /** Enter rename mode. No-op if onRename is undefined. */
+  beginEdit: () => void
+  /** Exit rename mode and either fire onRename or revert. */
+  commitRename: () => void
+  /** Exit rename mode and discard the edit. */
+  cancelRename: () => void
+}
+
+/**
+ * Shared rename state machine used by both the Active SessionRow and
+ * the Recent RecentSessionRow. Pulled out so a fix to commit-on-blur,
+ * trim semantics, or focus selection lands in one place — earlier
+ * cycles already had bugs from divergent copies of this logic.
+ *
+ * The two row components keep their own JSX (Reorder.Item vs <li>,
+ * different size tokens, different aria-hidden treatment) — only the
+ * editing contract is shared.
+ */
+export const useRenameState = (
+  session: Session,
+  onRename: ((id: string, name: string) => void) | undefined
+): UseRenameStateReturn => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [editValue, setEditValue] = useState(session.name)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isEditing])
+
+  const beginEdit = (): void => {
+    if (!onRename) {
+      return
+    }
+    setEditValue(session.name)
+    setIsEditing(true)
+  }
+
+  const commitRename = (): void => {
+    setIsEditing(false)
+    const trimmed = editValue.trim()
+    if (trimmed.length > 0 && trimmed !== session.name) {
+      onRename?.(session.id, trimmed)
+    } else {
+      setEditValue(session.name)
+    }
+  }
+
+  const cancelRename = (): void => {
+    setEditValue(session.name)
+    setIsEditing(false)
+  }
+
+  return {
+    isEditing,
+    editValue,
+    setEditValue,
+    inputRef,
+    beginEdit,
+    commitRename,
+    cancelRename,
+  }
+}

--- a/src/features/workspace/hooks/useRenameState.ts
+++ b/src/features/workspace/hooks/useRenameState.ts
@@ -76,7 +76,15 @@ export const useRenameState = (
   }
 
   const cancelRename = (): void => {
-    committedRef.current = false
+    // Mark this session committed so the trailing onBlur (fired
+    // synchronously by the browser when React unmounts the input on
+    // the next render) cannot re-enter commitRename and call onRename
+    // with the user's typed text — which would silently rename the
+    // session despite the Escape intent. beginEdit unconditionally
+    // resets this back to false, so subsequent rename sessions stay
+    // unaffected. The previous `false` here disarmed the guard for the
+    // *current* session's lingering blur, which was the bug.
+    committedRef.current = true
     setEditValue(session.name)
     setIsEditing(false)
   }

--- a/src/features/workspace/utils/agentForSession.test.ts
+++ b/src/features/workspace/utils/agentForSession.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from 'vitest'
+import { agentForSession } from './agentForSession'
+import { AGENTS } from '../../../agents/registry'
+import type { Session } from '../types'
+
+const baseSession: Omit<Session, 'agentType'> = {
+  id: 's1',
+  projectId: 'p1',
+  name: 'demo',
+  status: 'running',
+  workingDirectory: '~',
+  createdAt: '2026-05-06T00:00:00Z',
+  lastActivityAt: '2026-05-06T00:00:00Z',
+  activity: {
+    fileChanges: [],
+    toolCalls: [],
+    testResults: [],
+    contextWindow: { used: 0, total: 200_000, percentage: 0, emoji: '😊' },
+    usage: {
+      sessionDuration: 0,
+      turnCount: 0,
+      messages: { sent: 0, limit: 200 },
+      tokens: { input: 0, output: 0, total: 0 },
+    },
+  },
+}
+
+describe('agentForSession', () => {
+  test('claude-code maps to AGENTS.claude', () => {
+    expect(agentForSession({ ...baseSession, agentType: 'claude-code' })).toBe(
+      AGENTS.claude
+    )
+  })
+
+  test('codex maps to AGENTS.codex', () => {
+    expect(agentForSession({ ...baseSession, agentType: 'codex' })).toBe(
+      AGENTS.codex
+    )
+  })
+
+  test('aider falls back to AGENTS.shell', () => {
+    expect(agentForSession({ ...baseSession, agentType: 'aider' })).toBe(
+      AGENTS.shell
+    )
+  })
+
+  test('generic falls back to AGENTS.shell', () => {
+    expect(agentForSession({ ...baseSession, agentType: 'generic' })).toBe(
+      AGENTS.shell
+    )
+  })
+})

--- a/src/features/workspace/utils/agentForSession.ts
+++ b/src/features/workspace/utils/agentForSession.ts
@@ -1,0 +1,12 @@
+import { AGENTS, type Agent, type AgentId } from '../../../agents/registry'
+import type { Session } from '../types'
+
+const AGENT_BY_SESSION_TYPE: Record<Session['agentType'], AgentId> = {
+  'claude-code': 'claude',
+  codex: 'codex',
+  aider: 'shell',
+  generic: 'shell',
+}
+
+export const agentForSession = (session: Session): Agent =>
+  AGENTS[AGENT_BY_SESSION_TYPE[session.agentType]]

--- a/src/features/workspace/utils/pickNextVisibleSessionId.test.ts
+++ b/src/features/workspace/utils/pickNextVisibleSessionId.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from 'vitest'
+import {
+  isOpenSessionStatus,
+  pickNextVisibleSessionId,
+} from './pickNextVisibleSessionId'
+import type { Session, SessionStatus } from '../types'
+
+const buildSession = (id: string, status: SessionStatus): Session => ({
+  id,
+  projectId: 'p1',
+  name: id,
+  status,
+  workingDirectory: '~',
+  agentType: 'claude-code',
+  createdAt: '2026-05-06T00:00:00Z',
+  lastActivityAt: '2026-05-06T00:00:00Z',
+  activity: {
+    fileChanges: [],
+    toolCalls: [],
+    testResults: [],
+    contextWindow: { used: 0, total: 200_000, percentage: 0, emoji: '😊' },
+    usage: {
+      sessionDuration: 0,
+      turnCount: 0,
+      messages: { sent: 0, limit: 200 },
+      tokens: { input: 0, output: 0, total: 0 },
+    },
+  },
+})
+
+describe('isOpenSessionStatus', () => {
+  test('running and paused are open; completed and errored are not', () => {
+    expect(isOpenSessionStatus('running')).toBe(true)
+    expect(isOpenSessionStatus('paused')).toBe(true)
+    expect(isOpenSessionStatus('completed')).toBe(false)
+    expect(isOpenSessionStatus('errored')).toBe(false)
+  })
+})
+
+describe('pickNextVisibleSessionId', () => {
+  test('picks the right neighbor in visible order', () => {
+    const sessions = [
+      buildSession('A', 'running'),
+      buildSession('B', 'running'),
+      buildSession('C', 'running'),
+    ]
+    expect(pickNextVisibleSessionId(sessions, 'B', 'B')).toBe('C')
+  })
+
+  test('wraps to the left neighbor when the removed session is last', () => {
+    const sessions = [
+      buildSession('A', 'running'),
+      buildSession('B', 'running'),
+      buildSession('C', 'running'),
+    ]
+    expect(pickNextVisibleSessionId(sessions, 'C', 'C')).toBe('B')
+  })
+
+  test('skips sessions that are neither open nor the active one', () => {
+    // Hidden Recent session B sits between two open ones in array order.
+    const sessions = [
+      buildSession('A', 'running'),
+      buildSession('B', 'completed'),
+      buildSession('C', 'running'),
+    ]
+    expect(pickNextVisibleSessionId(sessions, 'A', 'A')).toBe('C')
+  })
+
+  test('includes the active session even when its status is exited', () => {
+    // C is completed but currently active (TerminalZone shows Restart pane).
+    // Removing C from the sidebar should pick the visually adjacent tab in
+    // the strip — same semantics as SessionTabs.handleClose.
+    const sessions = [
+      buildSession('A', 'running'),
+      buildSession('B', 'running'),
+      buildSession('C', 'completed'),
+    ]
+    expect(pickNextVisibleSessionId(sessions, 'C', 'C')).toBe('B')
+  })
+
+  test('returns undefined when only one visible session exists', () => {
+    const sessions = [buildSession('A', 'running')]
+    expect(pickNextVisibleSessionId(sessions, 'A', 'A')).toBeUndefined()
+  })
+
+  test('returns undefined when the removed id is not visible', () => {
+    const sessions = [
+      buildSession('A', 'running'),
+      buildSession('B', 'completed'),
+    ]
+    // B is not active and not open → not visible → no fallback can be
+    // computed from this set. Caller decides what to do.
+    expect(pickNextVisibleSessionId(sessions, 'B', 'A')).toBeUndefined()
+  })
+})

--- a/src/features/workspace/utils/pickNextVisibleSessionId.ts
+++ b/src/features/workspace/utils/pickNextVisibleSessionId.ts
@@ -1,0 +1,36 @@
+import type { Session, SessionStatus } from '../types'
+
+const OPEN_STATUSES: ReadonlySet<SessionStatus> = new Set(['running', 'paused'])
+
+export const isOpenSessionStatus = (status: SessionStatus): boolean =>
+  OPEN_STATUSES.has(status)
+
+/**
+ * Pick the next visible session id when the user removes the currently
+ * active session. Mirrors the SessionTabs `open` semantics — the strip
+ * keeps the active session visible even after its PTY exits, so the
+ * candidate list is `running/paused ∪ {activeSessionId}`. The next id
+ * is the visually adjacent tab to the right (wrapping left when the
+ * removed session is last). Returns `undefined` when there is no other
+ * visible session — caller should fall back to whatever the session
+ * manager picks.
+ */
+export const pickNextVisibleSessionId = (
+  sessions: Session[],
+  removedId: string,
+  activeSessionId: string | null
+): string | undefined => {
+  const visible = sessions.filter(
+    (s) => isOpenSessionStatus(s.status) || s.id === activeSessionId
+  )
+  if (visible.length <= 1) {
+    return undefined
+  }
+  const ids = visible.map((s) => s.id)
+  const idx = ids.indexOf(removedId)
+  if (idx === -1) {
+    return undefined
+  }
+
+  return idx === ids.length - 1 ? ids[idx - 1] : ids[idx + 1]
+}

--- a/src/features/workspace/utils/pickNextVisibleSessionId.ts
+++ b/src/features/workspace/utils/pickNextVisibleSessionId.ts
@@ -6,23 +6,35 @@ export const isOpenSessionStatus = (status: SessionStatus): boolean =>
   OPEN_STATUSES.has(status)
 
 /**
+ * Returns the sessions visible in the SessionTabs strip — running or
+ * paused sessions plus the currently active one (so a just-exited
+ * active session keeps its tab even after status flips to
+ * completed/errored). This is the single source of truth for "open"
+ * semantics; both `SessionTabs` and `pickNextVisibleSessionId`
+ * consume it so the visible-set definition can never drift between
+ * the strip's render and the close-fallback navigation.
+ */
+export const getVisibleSessions = (
+  sessions: Session[],
+  activeSessionId: string | null
+): Session[] =>
+  sessions.filter(
+    (s) => isOpenSessionStatus(s.status) || s.id === activeSessionId
+  )
+
+/**
  * Pick the next visible session id when the user removes the currently
- * active session. Mirrors the SessionTabs `open` semantics — the strip
- * keeps the active session visible even after its PTY exits, so the
- * candidate list is `running/paused ∪ {activeSessionId}`. The next id
- * is the visually adjacent tab to the right (wrapping left when the
- * removed session is last). Returns `undefined` when there is no other
- * visible session — caller should fall back to whatever the session
- * manager picks.
+ * active session. The next id is the visually adjacent tab to the right
+ * (wrapping left when the removed session is last). Returns
+ * `undefined` when there is no other visible session — caller should
+ * fall back to whatever the session manager picks.
  */
 export const pickNextVisibleSessionId = (
   sessions: Session[],
   removedId: string,
   activeSessionId: string | null
 ): string | undefined => {
-  const visible = sessions.filter(
-    (s) => isOpenSessionStatus(s.status) || s.id === activeSessionId
-  )
+  const visible = getVisibleSessions(sessions, activeSessionId)
   if (visible.length <= 1) {
     return undefined
   }

--- a/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
+++ b/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
@@ -42,15 +42,15 @@ const getSessionLabel = async (sessionId: string): Promise<string | null> =>
     const pane = document.querySelector<HTMLElement>(
       `[data-testid="terminal-pane"][data-session-id="${id}"]`
     )
-    // Find the corresponding tab button by walking from the pane's session
-    // to the tabbar (workspace session name === tab aria-label minus emoji).
-    const buttons = Array.from(
-      document.querySelectorAll<HTMLButtonElement>('button[aria-label^="🤖 "]')
-    )
     if (!pane) return null
-    // We don't actually need the label to match the pane — tab order is
-    // deterministic, so return the last button's label as the newest tab.
-    return buttons[buttons.length - 1]?.getAttribute('aria-label') ?? null
+    // SessionTabs (step 3) exposes each tab as `<div role="tab" data-session-id>`;
+    // we identify the most recently spawned tab by document order.
+    const tabs = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '[data-testid="session-tab"][data-session-id]'
+      )
+    )
+    return tabs[tabs.length - 1]?.getAttribute('data-session-id') ?? null
   }, sessionId)
 
 describe('Multi-tab terminal isolation', () => {
@@ -82,8 +82,8 @@ describe('Multi-tab terminal isolation', () => {
       { timeout: 15_000, timeoutMsg: 'marker A never landed in session 1' }
     )
 
-    // Spawn session 2.
-    await clickBySelector('button[aria-label="New tab"]')
+    // Spawn session 2 via the SessionTabs "+" button.
+    await clickBySelector('button[aria-label="New session"]')
     await browser.waitUntil(async () => (await allSessionIds()).length === 2, {
       timeout: 10_000,
       timeoutMsg: 'second session did not mount',

--- a/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
+++ b/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
@@ -45,9 +45,14 @@ const getLatestSessionTabId = async (
   sessionId: string
 ): Promise<string | null> =>
   browser.execute((id: string) => {
-    const pane = document.querySelector<HTMLElement>(
-      `[data-testid="terminal-pane"][data-session-id="${id}"]`
-    )
+    // Mirror cycle-15's id-based lookup pattern in Sidebar.tsx (and
+    // SessionTabs.tsx originally): every TerminalZone panel is rendered
+    // with `id="session-panel-${session.id}"`, so getElementById keeps
+    // session ids out of the CSS-attribute parser entirely. Same
+    // correctness invariant as docs/reviews/patterns/accessibility.md
+    // finding #14 — applies here too even if the runtime symptom would
+    // surface inside `browser.execute` rather than at user-facing focus.
+    const pane = document.getElementById(`session-panel-${id}`)
     if (!pane) return null
     const tabs = Array.from(
       document.querySelectorAll<HTMLElement>(

--- a/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
+++ b/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
@@ -37,14 +37,18 @@ const allSessionIds = async (): Promise<string[]> =>
     return Array.from(seen)
   })
 
-const getSessionLabel = async (sessionId: string): Promise<string | null> =>
+// Returns the data-session-id of the latest spawned tab (document
+// order), or null if the supplied sessionId has no terminal-pane in
+// the DOM. Renamed from `getSessionLabel` to reflect what it actually
+// returns — an opaque session id, not a human-readable label.
+const getLatestSessionTabId = async (
+  sessionId: string
+): Promise<string | null> =>
   browser.execute((id: string) => {
     const pane = document.querySelector<HTMLElement>(
       `[data-testid="terminal-pane"][data-session-id="${id}"]`
     )
     if (!pane) return null
-    // SessionTabs (step 3) exposes each tab as `<div role="tab" data-session-id>`;
-    // we identify the most recently spawned tab by document order.
     const tabs = Array.from(
       document.querySelectorAll<HTMLElement>(
         '[data-testid="session-tab"][data-session-id]'
@@ -137,8 +141,9 @@ describe('Multi-tab terminal isolation', () => {
     expect(s2).toContain(markerB)
     expect(s2).not.toContain(markerA)
 
-    // `getSessionLabel` is exercised to confirm the helper doesn't throw,
-    // but we don't assert on its value — tab naming is ephemeral.
-    void (await getSessionLabel(session2Id))
+    // `getLatestSessionTabId` is exercised to confirm the helper
+    // doesn't throw, but we don't assert on its value — tab id is
+    // ephemeral.
+    void (await getLatestSessionTabId(session2Id))
   })
 })

--- a/tests/e2e/terminal/specs/pty-spawn.spec.ts
+++ b/tests/e2e/terminal/specs/pty-spawn.spec.ts
@@ -1,13 +1,23 @@
 describe('PTY spawn (default session)', () => {
   before(async () => {
-    const hasBridge = await browser.execute(
-      () => typeof window.__VIMEFLOW_E2E__ !== 'undefined'
-    )
-    if (!hasBridge) {
-      throw new Error(
-        'window.__VIMEFLOW_E2E__ missing — rebuild with VITE_E2E=1'
+    // Each spec spawns a fresh webdriver session → fresh app instance.
+    // The e2e bridge attaches in a React effect after mount, so a sync
+    // probe at hook-start time races against React boot. Poll until it
+    // appears OR the timeout elapses; only the timeout proves the build
+    // is actually missing VITE_E2E.
+    await browser
+      .waitUntil(
+        async () =>
+          await browser.execute(
+            () => typeof window.__VIMEFLOW_E2E__ !== 'undefined'
+          ),
+        { timeout: 20_000, interval: 250 }
       )
-    }
+      .catch(() => {
+        throw new Error(
+          'window.__VIMEFLOW_E2E__ missing — rebuild with VITE_E2E=1'
+        )
+      })
   })
 
   it('renders a terminal pane with non-empty buffer', async () => {

--- a/tests/e2e/terminal/specs/session-lifecycle.spec.ts
+++ b/tests/e2e/terminal/specs/session-lifecycle.spec.ts
@@ -28,8 +28,9 @@ describe('Terminal session lifecycle', () => {
     // Baseline: useSessionManager boots with one default session.
     await waitForCount(1, 'default session never became active')
 
-    // Click "New tab".
-    await clickBySelector('button[aria-label="New tab"]')
+    // Click the SessionTabs "+" button (aria-label="New session" since
+    // step 3 replaced TerminalZone's legacy tab-bar).
+    await clickBySelector('button[aria-label="New session"]')
     await waitForCount(2, 'new tab did not register a second PTY session')
 
     // Close the *second* session by its frontend name. useSessionManager


### PR DESCRIPTION
## Summary

Step 3 of the UI handoff migration (roadmap §9). Restyles the sidebar sessions list per handoff §4.2 and replaces the cycle-2 placeholder strip with a real browser-style SessionTabs component per §4.3.

### Sidebar (§4.2)
- **Active vs Recent groupings**: running/paused → Active (drag-orderable), completed/errored → Recent (read-only list).
- **Row layout**: StatusDot + bold title + relative time on row 1; subtitle (currentAction or cwd basename) on row 2; state pill + +added/-removed deltas on row 3.
- **Active row**: lavender-tinted `bg-primary/10` with a 2px lavender accent bar on the left edge.
- Active and Recent groups share a single `min-h-0 flex-1 overflow-y-auto` scroll region (so a long Recent list can't push FileExplorer below the fixed sidebar).

### SessionTabs (§4.3)
- 38px strip with 30px tabs that lift via `-mb-px` so the active tab visually merges into the canvas below.
- Per-tab agent identity chip drives accent color from the `AGENTS` registry.
- Roving keyboard focus (ArrowLeft/ArrowRight cycle, Enter/Space activate) per the WAI-ARIA tabs pattern. `tabIndex=0` only on the active tab.
- Status pip + close X + ghost `+` button. Filter keeps `running`/`paused` sessions plus the active session even after its PTY exits (so a Restart pane keeps its tab).
- Closing the active tab pre-selects the next visible tab using the `open` order (not the full `sessions` index), so the strip's selection doesn't jump to a hidden Recent session.
- Replaces TerminalZone's legacy `tab-bar` (removed; obsolete now that SessionTabs drives the same state).

### New shared helpers
- `src/features/workspace/utils/agentForSession.ts` — maps `Session.agentType` → `AGENTS` registry entry (claude-code → claude, aider/generic → shell fallback).
- `src/features/workspace/components/StatusDot.tsx` — 7px rounded span with running/paused/completed/errored tone classes; reused by Sidebar rows and SessionTabs pips.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run type-check` — clean
- [x] `npm run test` — 1674 passed, 3 skipped
- [x] `npm run format:check` — clean
- [x] Codex review (6 cycles): every behavioral concern addressed (duplicate UI, exited active tab, scroll constraint, roving focus, child key bubble, layoutScroll node, visible-order close fallback, close-then-select ordering)
- [ ] Manual smoke: drag-reorder Active sessions; close active tab and verify visible next selected; ArrowLeft/Right cycles tabs; close X is reachable by keyboard; long Recent group scrolls within the shared region.