### PR TITLE
fix(sidebar): stabilize agent StatusCard height and replace new-sessio

### DIFF
--- a/src/features/agent-status/components/StatusCard.test.tsx
+++ b/src/features/agent-status/components/StatusCard.test.tsx
@@ -121,7 +121,7 @@ describe('StatusCard', () => {
       />
     )
 
-    expect(screen.getByTestId('agent-status-card')).toHaveClass('h-44')
+    expect(screen.getByTestId('agent-status-card')).toHaveClass('min-h-44')
     expect(screen.getByText('Claude Code')).toHaveClass(
       'shrink-0',
       'whitespace-nowrap'
@@ -139,7 +139,7 @@ describe('StatusCard', () => {
       />
     )
 
-    expect(screen.getByTestId('agent-status-card')).toHaveClass('h-44')
+    expect(screen.getByTestId('agent-status-card')).toHaveClass('min-h-44')
     expect(screen.getByText('Codex')).toHaveClass(
       'shrink-0',
       'whitespace-nowrap'

--- a/src/features/agent-status/components/StatusCard.test.tsx
+++ b/src/features/agent-status/components/StatusCard.test.tsx
@@ -112,6 +112,40 @@ describe('StatusCard', () => {
     expect(screen.getByTestId('agent-status-card')).toBeInTheDocument()
   })
 
+  test('keeps card height and agent names stable across claude and codex', () => {
+    const { rerender } = render(
+      <StatusCard
+        {...defaultProps}
+        agentType="claude-code"
+        modelDisplayName="Opus 4.7 (1M context)"
+      />
+    )
+
+    expect(screen.getByTestId('agent-status-card')).toHaveClass('h-44')
+    expect(screen.getByText('Claude Code')).toHaveClass(
+      'shrink-0',
+      'whitespace-nowrap'
+    )
+
+    expect(
+      screen.getByText('Opus 4.7 (1M context)', { selector: 'span' })
+    ).toHaveClass('min-w-0', 'flex-1', 'truncate')
+
+    rerender(
+      <StatusCard
+        {...defaultProps}
+        agentType="codex"
+        modelDisplayName="gpt-5.4"
+      />
+    )
+
+    expect(screen.getByTestId('agent-status-card')).toHaveClass('h-44')
+    expect(screen.getByText('Codex')).toHaveClass(
+      'shrink-0',
+      'whitespace-nowrap'
+    )
+  })
+
   test('renders BudgetMetrics section', () => {
     render(
       <StatusCard

--- a/src/features/agent-status/components/StatusCard.tsx
+++ b/src/features/agent-status/components/StatusCard.tsx
@@ -72,7 +72,7 @@ export const StatusCard = ({
   return (
     <div
       data-testid="agent-status-card"
-      className="flex flex-col gap-3 rounded-xl bg-surface-container-high p-3"
+      className="flex h-44 flex-col gap-3 overflow-hidden rounded-xl bg-surface-container-high p-3"
     >
       {/* Agent identity row */}
       <div className="flex items-center gap-2.5">
@@ -80,15 +80,15 @@ export const StatusCard = ({
         <div className="h-8 w-8 shrink-0 rounded-lg bg-gradient-to-br from-primary-container to-secondary" />
 
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <div className="flex items-center gap-2">
-            <span className="font-headline text-sm font-[800] text-on-surface">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="shrink-0 whitespace-nowrap font-headline text-sm font-[800] text-on-surface">
               {agentNames[agentType]}
             </span>
             {displayModel ? (
               <Tooltip content={displayModel} placement="bottom">
                 <span
                   tabIndex={0}
-                  className="truncate font-mono text-[10px] text-outline outline-none focus-visible:ring-1 focus-visible:ring-primary-container"
+                  className="min-w-0 flex-1 truncate font-mono text-[10px] text-outline outline-none focus-visible:ring-1 focus-visible:ring-primary-container"
                 >
                   {displayModel}
                 </span>

--- a/src/features/agent-status/components/StatusCard.tsx
+++ b/src/features/agent-status/components/StatusCard.tsx
@@ -72,7 +72,7 @@ export const StatusCard = ({
   return (
     <div
       data-testid="agent-status-card"
-      className="flex h-44 flex-col gap-3 overflow-hidden rounded-xl bg-surface-container-high p-3"
+      className="flex min-h-44 flex-col gap-3 rounded-xl bg-surface-container-high p-3"
     >
       {/* Agent identity row */}
       <div className="flex items-center gap-2.5">

--- a/src/features/sessions/components/List.test.tsx
+++ b/src/features/sessions/components/List.test.tsx
@@ -88,20 +88,20 @@ const mockSessions: Session[] = [
 
 describe('List', () => {
   const mockOnSessionClick = vi.fn()
-  const mockOnNewInstance = vi.fn()
+  const mockOnCreateSession = vi.fn()
 
   beforeEach(() => {
     mockOnSessionClick.mockClear()
-    mockOnNewInstance.mockClear()
+    mockOnCreateSession.mockClear()
   })
 
-  test('renders Active header with add button outside scroll container', () => {
+  test('renders new session ghost button inside scroll container', () => {
     render(
       <List
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
-        onNewInstance={mockOnNewInstance}
+        onCreateSession={mockOnCreateSession}
       />
     )
 
@@ -109,9 +109,21 @@ describe('List', () => {
       'Active'
     )
 
+    const scroll = screen.getByTestId('session-scroll')
+
+    const newSessionButton = screen.getByRole('button', {
+      name: 'new session',
+    })
+
+    expect(newSessionButton).toHaveAttribute(
+      'data-testid',
+      'sessions-list-new-session'
+    )
+    expect(newSessionButton).toHaveClass('w-full')
+    expect(scroll).toContainElement(newSessionButton)
     expect(
-      screen.getByRole('button', { name: 'Add session' })
-    ).toBeInTheDocument()
+      screen.queryByRole('button', { name: 'Add session' })
+    ).not.toBeInTheDocument()
   })
 
   test('renders Recent header inside scroll container when completed sessions exist', () => {
@@ -182,7 +194,7 @@ describe('List', () => {
     expect(mockOnSessionClick).toHaveBeenCalledWith('sess-2')
   })
 
-  test('calls onNewInstance when add button is clicked', async () => {
+  test('calls onCreateSession when new session button is clicked', async () => {
     const user = userEvent.setup()
 
     render(
@@ -190,32 +202,30 @@ describe('List', () => {
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
-        onNewInstance={mockOnNewInstance}
+        onCreateSession={mockOnCreateSession}
       />
     )
 
-    const addButton = screen.getByRole('button', { name: 'Add session' })
+    const addButton = screen.getByRole('button', { name: 'new session' })
     await user.click(addButton)
 
-    expect(mockOnNewInstance).toHaveBeenCalledOnce()
+    expect(mockOnCreateSession).toHaveBeenCalledOnce()
   })
 
-  test('add session button is NOT rendered when onNewInstance is undefined', () => {
-    // Regression guard: the Group.Header headerAction must be suppressed
-    // when no callback is supplied — otherwise the button renders, accepts
-    // focus, and silently no-ops on click. See PR #182 Claude review,
-    // cycle 2 [MEDIUM] finding.
+  test('new session button is NOT rendered when onCreateSession is undefined', () => {
+    // Regression guard: omit the creation affordance when no callback is
+    // supplied so the button cannot render, accept focus, and silently no-op.
     render(
       <List
         sessions={mockSessions}
         activeSessionId="sess-1"
         onSessionClick={mockOnSessionClick}
-        // intentionally NOT passing onNewInstance
+        // intentionally NOT passing onCreateSession
       />
     )
 
     expect(
-      screen.queryByRole('button', { name: 'Add session' })
+      screen.queryByRole('button', { name: 'new session' })
     ).not.toBeInTheDocument()
   })
 

--- a/src/features/sessions/components/List.test.tsx
+++ b/src/features/sessions/components/List.test.tsx
@@ -95,7 +95,7 @@ describe('List', () => {
     mockOnCreateSession.mockClear()
   })
 
-  test('renders new session ghost button inside scroll container', () => {
+  test('renders new session ghost button below the scroll area so it stays visible when sessions overflow', () => {
     render(
       <List
         sessions={mockSessions}
@@ -120,7 +120,7 @@ describe('List', () => {
       'sessions-list-new-session'
     )
     expect(newSessionButton).toHaveClass('w-full')
-    expect(scroll).toContainElement(newSessionButton)
+    expect(scroll).not.toContainElement(newSessionButton)
     expect(
       screen.queryByRole('button', { name: 'Add session' })
     ).not.toBeInTheDocument()

--- a/src/features/sessions/components/List.tsx
+++ b/src/features/sessions/components/List.tsx
@@ -157,27 +157,27 @@ export const List = ({
             </Group>
           </>
         )}
-
-        {onCreateSession ? (
-          <div className="mt-auto px-2 pb-2 pt-2">
-            <button
-              type="button"
-              onClick={onCreateSession}
-              className="flex w-full items-center justify-center gap-1.5 rounded-[8px] border border-outline-variant/40 bg-transparent px-3 py-2 font-label text-xs font-semibold text-on-surface-variant transition-colors hover:bg-on-surface/[0.04] hover:text-on-surface focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container"
-              aria-label="new session"
-              data-testid="sessions-list-new-session"
-            >
-              <span
-                className="material-symbols-outlined text-base"
-                aria-hidden="true"
-              >
-                add
-              </span>
-              <span>new session</span>
-            </button>
-          </div>
-        ) : null}
       </motion.div>
+
+      {onCreateSession ? (
+        <div className="shrink-0 px-2 pb-2 pt-2">
+          <button
+            type="button"
+            onClick={onCreateSession}
+            className="flex w-full items-center justify-center gap-1.5 rounded-[8px] border border-outline-variant/40 bg-transparent px-3 py-2 font-label text-xs font-semibold text-on-surface-variant transition-colors hover:bg-on-surface/[0.04] hover:text-on-surface focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container"
+            aria-label="new session"
+            data-testid="sessions-list-new-session"
+          >
+            <span
+              className="material-symbols-outlined text-base"
+              aria-hidden="true"
+            >
+              add
+            </span>
+            <span>new session</span>
+          </button>
+        </div>
+      ) : null}
     </>
   )
 }

--- a/src/features/sessions/components/List.tsx
+++ b/src/features/sessions/components/List.tsx
@@ -13,7 +13,7 @@ export interface ListProps {
   sessions: Session[]
   activeSessionId: string | null
   onSessionClick: (sessionId: string) => void
-  onNewInstance?: () => void
+  onCreateSession?: () => void
   onRemoveSession?: (sessionId: string) => void
   onRenameSession?: (sessionId: string, name: string) => void
   onReorderSessions?: (sessions: Session[]) => void
@@ -23,7 +23,7 @@ export const List = ({
   sessions,
   activeSessionId,
   onSessionClick,
-  onNewInstance = undefined,
+  onCreateSession = undefined,
   onRemoveSession = undefined,
   onRenameSession = undefined,
   onReorderSessions = undefined,
@@ -94,22 +94,7 @@ export const List = ({
 
   return (
     <>
-      <Group.Header
-        label="Active"
-        headerAction={
-          onNewInstance ? (
-            <button
-              type="button"
-              onClick={onNewInstance}
-              className="material-symbols-outlined text-base text-on-surface-variant/60 transition-colors hover:text-primary"
-              aria-label="Add session"
-              title="Add session"
-            >
-              add
-            </button>
-          ) : undefined
-        }
-      />
+      <Group.Header label="Active" />
 
       <motion.div
         data-testid="session-scroll"
@@ -172,6 +157,26 @@ export const List = ({
             </Group>
           </>
         )}
+
+        {onCreateSession ? (
+          <div className="mt-auto px-2 pb-2 pt-2">
+            <button
+              type="button"
+              onClick={onCreateSession}
+              className="flex w-full items-center justify-center gap-1.5 rounded-[8px] border border-outline-variant/40 bg-transparent px-3 py-2 font-label text-xs font-semibold text-on-surface-variant transition-colors hover:bg-on-surface/[0.04] hover:text-on-surface focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container"
+              aria-label="new session"
+              data-testid="sessions-list-new-session"
+            >
+              <span
+                className="material-symbols-outlined text-base"
+                aria-hidden="true"
+              >
+                add
+              </span>
+              <span>new session</span>
+            </button>
+          </div>
+        ) : null}
       </motion.div>
     </>
   )

--- a/src/features/sessions/components/List.tsx
+++ b/src/features/sessions/components/List.tsx
@@ -165,7 +165,6 @@ export const List = ({
             type="button"
             onClick={onCreateSession}
             className="flex w-full items-center justify-center gap-1.5 rounded-[8px] border border-outline-variant/40 bg-transparent px-3 py-2 font-label text-xs font-semibold text-on-surface-variant transition-colors hover:bg-on-surface/[0.04] hover:text-on-surface focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container"
-            aria-label="new session"
             data-testid="sessions-list-new-session"
           >
             <span

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -124,10 +124,10 @@ describe('WorkspaceView Integration Tests', () => {
       const terminalZone = screen.getByTestId('terminal-zone')
 
       // Create a second session so we can test switching
-      const newInstanceButton = screen.getByRole('button', {
-        name: 'New Instance',
+      const newSessionButton = screen.getByRole('button', {
+        name: 'new session',
       })
-      await user.click(newInstanceButton)
+      await user.click(newSessionButton)
 
       // Wait for second session to appear
       await screen.findByRole('button', { name: 'session 2' })
@@ -170,10 +170,10 @@ describe('WorkspaceView Integration Tests', () => {
       const sidebar = screen.getByTestId('sidebar')
 
       // Create a second session so we can test switching
-      const newInstanceButton = screen.getByRole('button', {
-        name: 'New Instance',
+      const newSessionButton = screen.getByRole('button', {
+        name: 'new session',
       })
-      await user.click(newInstanceButton)
+      await user.click(newSessionButton)
 
       // Wait for second session to appear
       await screen.findByRole('button', { name: 'session 2' })

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -316,7 +316,7 @@ describe('WorkspaceView', () => {
     expect(filesViewAfter).not.toHaveClass('hidden')
   })
 
-  test('clicking the New Instance gradient button creates a new session', async () => {
+  test('clicking the new session ghost button creates a new session', async () => {
     const user = userEvent.setup()
 
     render(<WorkspaceView />)
@@ -327,8 +327,10 @@ describe('WorkspaceView', () => {
     // 'session ${index + 1}').
     await screen.findByRole('button', { name: 'session 1' })
 
-    const newInstanceBtn = screen.getByRole('button', { name: 'New Instance' })
-    await user.click(newInstanceBtn)
+    const newSessionButton = screen.getByRole('button', {
+      name: 'new session',
+    })
+    await user.click(newSessionButton)
 
     // After clicking, the spawn() mock resolves with a new sessionId
     // and useSessionManager appends a new Session at index 1, with
@@ -403,10 +405,10 @@ describe('WorkspaceView', () => {
     })
     expect(firstSession.closest('li')!.className).toContain('bg-primary/10')
 
-    const newInstanceButton = screen.getByRole('button', {
-      name: 'New Instance',
+    const newSessionButton = screen.getByRole('button', {
+      name: 'new session',
     })
-    await user.click(newInstanceButton)
+    await user.click(newSessionButton)
 
     const secondSession = await screen.findByRole('button', {
       name: 'session 2',

--- a/src/features/workspace/components/SessionsView.test.tsx
+++ b/src/features/workspace/components/SessionsView.test.tsx
@@ -24,12 +24,21 @@ describe('SessionsView', () => {
     expect(screen.getByTestId('session-list')).toBeInTheDocument()
   })
 
-  test('New Instance button fires onCreateSession on click', async () => {
+  test('new session button fires onCreateSession on click', async () => {
     const onCreateSession = vi.fn()
     const user = userEvent.setup()
 
     render(<SessionsView {...baseProps} onCreateSession={onCreateSession} />)
-    await user.click(screen.getByRole('button', { name: 'New Instance' }))
+
+    const newSessionButton = screen.getByRole('button', {
+      name: 'new session',
+    })
+    expect(newSessionButton).toHaveAttribute(
+      'data-testid',
+      'sessions-list-new-session'
+    )
+
+    await user.click(newSessionButton)
 
     expect(onCreateSession).toHaveBeenCalledTimes(1)
   })

--- a/src/features/workspace/components/SessionsView.tsx
+++ b/src/features/workspace/components/SessionsView.tsx
@@ -39,23 +39,10 @@ export const SessionsView = ({
       sessions={sessions}
       activeSessionId={activeSessionId}
       onSessionClick={onSessionClick}
-      onNewInstance={onCreateSession}
+      onCreateSession={onCreateSession}
       onRemoveSession={onRemoveSession}
       onRenameSession={onRenameSession}
       onReorderSessions={onReorderSessions}
     />
-
-    <button
-      type="button"
-      onClick={onCreateSession}
-      className="m-3 flex shrink-0 items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-primary to-secondary py-2.5 font-label text-sm font-bold text-on-primary shadow-lg shadow-primary/10 transition-all hover:shadow-xl hover:shadow-primary/20"
-      aria-label="New Instance"
-      data-testid="sessions-view-new-instance"
-    >
-      <span className="material-symbols-outlined text-lg" aria-hidden="true">
-        bolt
-      </span>
-      <span>New Instance</span>
-    </button>
   </div>
 )


### PR DESCRIPTION
## Summary
- fix(sidebar): stabilize agent StatusCard height and replace new-session pill

Closes #186, #187.

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test` (146 files, 1864 passed)
- [ ] Manual: switch between Claude Code and Codex sessions; confirm StatusCard height is stable and elements below do not shift
- [ ] Manual: open the SESSIONS sidebar tab; confirm `+ new session` ghost button appears at the bottom of the list and clicking it creates a new session