### PR TITLE
[codex] Fix terminal resize performance

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -69,7 +69,7 @@ jobs:
         run: npm run build
 
       - name: Build Tauri application
-        run: npx tauri build
+        run: npm run tauri:build -- --ci
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -70,9 +70,7 @@ jobs:
 
       - name: Build Tauri application (Ubuntu)
         if: matrix.platform == 'ubuntu'
-        env:
-          NO_STRIP: '1'
-        run: npx tauri build --ci
+        run: npm run tauri:build -- --ci
 
       - name: Build Tauri application
         if: matrix.platform != 'ubuntu'

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build Tauri application
         if: matrix.platform != 'ubuntu'
-        run: npx tauri build
+        run: npx tauri build --ci
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build Tauri application
         if: matrix.platform != 'ubuntu'
-        run: npx tauri build --ci
+        run: npx tauri build
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -68,8 +68,15 @@ jobs:
       - name: Build frontend
         run: npm run build
 
+      - name: Build Tauri application (Ubuntu)
+        if: matrix.platform == 'ubuntu'
+        env:
+          NO_STRIP: '1'
+        run: npx tauri build --ci
+
       - name: Build Tauri application
-        run: npm run tauri:build -- --ci
+        if: matrix.platform != 'ubuntu'
+        run: npx tauri build --ci
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -770,6 +770,78 @@ describe('Body', () => {
       }
     })
 
+    test('fits the new session instead of flushing the old session when drag ends during session switch', async () => {
+      const firstFitAddon = { fit: vi.fn() }
+      const secondFitAddon = { fit: vi.fn() }
+      const frameCallbacks: FrameRequestCallback[] = []
+
+      vi.mocked(FitAddon)
+        .mockImplementationOnce(() => firstFitAddon as never)
+        .mockImplementationOnce(() => secondFitAddon as never)
+
+      const offsetWidthSpy = vi
+        .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockReturnValue(840)
+
+      const offsetHeightSpy = vi
+        .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+        .mockReturnValue(600)
+
+      global.ResizeObserver = vi.fn().mockImplementation(() => ({
+        observe: vi.fn(),
+        unobserve: vi.fn(),
+        disconnect: vi.fn(),
+      }))
+
+      try {
+        const { rerender } = render(
+          <Body
+            sessionId="session-a"
+            cwd="/home/user"
+            service={defaultMockService}
+            deferFit
+          />
+        )
+
+        await waitFor(() => {
+          expect(FitAddon).toHaveBeenCalledTimes(1)
+        })
+
+        expect(firstFitAddon.fit).not.toHaveBeenCalled()
+
+        const requestAnimationFrameSpy = vi
+          .spyOn(window, 'requestAnimationFrame')
+          .mockImplementation((callback: FrameRequestCallback): number => {
+            frameCallbacks.push(callback)
+
+            return frameCallbacks.length
+          })
+
+        try {
+          rerender(
+            <Body
+              sessionId="session-b"
+              cwd="/home/user"
+              service={defaultMockService}
+            />
+          )
+
+          await waitFor(() => {
+            expect(FitAddon).toHaveBeenCalledTimes(2)
+          })
+
+          expect(requestAnimationFrameSpy).not.toHaveBeenCalled()
+          expect(firstFitAddon.fit).not.toHaveBeenCalled()
+          expect(secondFitAddon.fit).toHaveBeenCalledTimes(1)
+        } finally {
+          requestAnimationFrameSpy.mockRestore()
+        }
+      } finally {
+        offsetWidthSpy.mockRestore()
+        offsetHeightSpy.mockRestore()
+      }
+    })
+
     test('regression #81: ResizeObserver skips fit when container is hidden (width=0)', async () => {
       let resizeCallback: ResizeObserverCallback | undefined
       const mockObserve = vi.fn()

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -684,6 +684,81 @@ describe('Body', () => {
       }
     })
 
+    test('skips flushed fit when layout drag restarts before frame runs', async () => {
+      const mockObserve = vi.fn()
+      const frameCallbacks: FrameRequestCallback[] = []
+
+      const requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback: FrameRequestCallback): number => {
+          frameCallbacks.push(callback)
+
+          return frameCallbacks.length
+        })
+
+      global.ResizeObserver = vi.fn().mockImplementation(() => ({
+        observe: mockObserve,
+        unobserve: vi.fn(),
+        disconnect: vi.fn(),
+      }))
+
+      try {
+        const { rerender } = render(
+          <Body
+            sessionId="test-session"
+            cwd="/home/user"
+            service={defaultMockService}
+            deferFit
+          />
+        )
+
+        await waitFor(() => {
+          expect(global.ResizeObserver).toHaveBeenCalled()
+          expect(mockObserve).toHaveBeenCalled()
+        })
+
+        const container = screen.getByTestId('terminal-pane')
+        Object.defineProperty(container, 'offsetWidth', {
+          value: 840,
+          configurable: true,
+        })
+
+        Object.defineProperty(container, 'offsetHeight', {
+          value: 600,
+          configurable: true,
+        })
+
+        mockFitAddon.fit.mockClear()
+
+        rerender(
+          <Body
+            sessionId="test-session"
+            cwd="/home/user"
+            service={defaultMockService}
+          />
+        )
+
+        expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+
+        rerender(
+          <Body
+            sessionId="test-session"
+            cwd="/home/user"
+            service={defaultMockService}
+            deferFit
+          />
+        )
+
+        act(() => {
+          frameCallbacks[0](16)
+        })
+
+        expect(mockFitAddon.fit).not.toHaveBeenCalled()
+      } finally {
+        requestAnimationFrameSpy.mockRestore()
+      }
+    })
+
     test('regression #81: ResizeObserver skips fit when container is hidden (width=0)', async () => {
       let resizeCallback: ResizeObserverCallback | undefined
       const mockObserve = vi.fn()

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createRef } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
@@ -532,6 +532,158 @@ describe('Body', () => {
       })
     })
 
+    test('coalesces repeated ResizeObserver notifications into one fit per frame', async () => {
+      let resizeCallback: ResizeObserverCallback | undefined
+      const mockObserve = vi.fn()
+      const frameCallbacks: FrameRequestCallback[] = []
+
+      const requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback: FrameRequestCallback): number => {
+          frameCallbacks.push(callback)
+
+          return frameCallbacks.length
+        })
+
+      global.ResizeObserver = vi
+        .fn()
+        .mockImplementation((callback: ResizeObserverCallback) => {
+          resizeCallback = callback
+
+          return {
+            observe: mockObserve,
+            unobserve: vi.fn(),
+            disconnect: vi.fn(),
+          }
+        })
+
+      try {
+        render(
+          <Body
+            sessionId="test-session"
+            cwd="/home/user"
+            service={defaultMockService}
+          />
+        )
+
+        await waitFor(() => {
+          expect(global.ResizeObserver).toHaveBeenCalled()
+          expect(mockObserve).toHaveBeenCalled()
+        })
+
+        mockFitAddon.fit.mockClear()
+
+        const container = screen.getByTestId('terminal-pane')
+        Object.defineProperty(container, 'offsetWidth', {
+          value: 820,
+          configurable: true,
+        })
+
+        Object.defineProperty(container, 'offsetHeight', {
+          value: 600,
+          configurable: true,
+        })
+
+        act(() => {
+          resizeCallback?.([], {} as ResizeObserver)
+          resizeCallback?.([], {} as ResizeObserver)
+          resizeCallback?.([], {} as ResizeObserver)
+        })
+
+        expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+        expect(mockFitAddon.fit).not.toHaveBeenCalled()
+
+        act(() => {
+          frameCallbacks[0](16)
+        })
+
+        expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      } finally {
+        requestAnimationFrameSpy.mockRestore()
+      }
+    })
+
+    test('defers ResizeObserver fit while layout drag is active', async () => {
+      let resizeCallback: ResizeObserverCallback | undefined
+      const mockObserve = vi.fn()
+      const frameCallbacks: FrameRequestCallback[] = []
+
+      const requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback: FrameRequestCallback): number => {
+          frameCallbacks.push(callback)
+
+          return frameCallbacks.length
+        })
+
+      global.ResizeObserver = vi
+        .fn()
+        .mockImplementation((callback: ResizeObserverCallback) => {
+          resizeCallback = callback
+
+          return {
+            observe: mockObserve,
+            unobserve: vi.fn(),
+            disconnect: vi.fn(),
+          }
+        })
+
+      try {
+        const { rerender } = render(
+          <Body
+            sessionId="test-session"
+            cwd="/home/user"
+            service={defaultMockService}
+            deferFit
+          />
+        )
+
+        await waitFor(() => {
+          expect(global.ResizeObserver).toHaveBeenCalled()
+          expect(mockObserve).toHaveBeenCalled()
+        })
+
+        mockFitAddon.fit.mockClear()
+
+        const container = screen.getByTestId('terminal-pane')
+        Object.defineProperty(container, 'offsetWidth', {
+          value: 840,
+          configurable: true,
+        })
+
+        Object.defineProperty(container, 'offsetHeight', {
+          value: 600,
+          configurable: true,
+        })
+
+        act(() => {
+          resizeCallback?.([], {} as ResizeObserver)
+          resizeCallback?.([], {} as ResizeObserver)
+        })
+
+        expect(requestAnimationFrameSpy).not.toHaveBeenCalled()
+        expect(mockFitAddon.fit).not.toHaveBeenCalled()
+
+        rerender(
+          <Body
+            sessionId="test-session"
+            cwd="/home/user"
+            service={defaultMockService}
+          />
+        )
+
+        expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+
+        act(() => {
+          frameCallbacks[0](16)
+        })
+
+        expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      } finally {
+        requestAnimationFrameSpy.mockRestore()
+      }
+    })
+
     test('regression #81: ResizeObserver skips fit when container is hidden (width=0)', async () => {
       let resizeCallback: ResizeObserverCallback | undefined
       const mockObserve = vi.fn()
@@ -591,7 +743,9 @@ describe('Body', () => {
       }
 
       // fitAddon SHOULD fire now that the container has real dimensions
-      expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      await waitFor(() => {
+        expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      })
     })
 
     test('regression #81: cached terminal reuse skips fit in zero-width container', async () => {
@@ -689,6 +843,41 @@ describe('Body', () => {
       // already-fitted dimensions to the PTY without re-measuring).
       expect(mockFitAddon.fit).not.toHaveBeenCalled()
       expect(mockUseTerminal.resize).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not forward duplicate xterm resize dimensions to PTY', async () => {
+      render(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+        />
+      )
+
+      await waitFor(() => {
+        expect(mockTerminal.onResize).toHaveBeenCalled()
+      })
+
+      vi.mocked(mockUseTerminal.resize).mockClear()
+
+      const container = screen.getByTestId('terminal-pane')
+      Object.defineProperty(container, 'offsetWidth', {
+        value: 800,
+        configurable: true,
+      })
+
+      const onResizeCallback = mockTerminal.onResize.mock
+        .calls[0][0] as (size: { cols: number; rows: number }) => void
+
+      act(() => {
+        onResizeCallback({ cols: 80, rows: 24 })
+        onResizeCallback({ cols: 80, rows: 24 })
+        onResizeCallback({ cols: 81, rows: 24 })
+      })
+
+      expect(mockUseTerminal.resize).toHaveBeenCalledTimes(2)
+      expect(mockUseTerminal.resize).toHaveBeenNthCalledWith(1, 80, 24)
+      expect(mockUseTerminal.resize).toHaveBeenNthCalledWith(2, 81, 24)
     })
 
     test('P2: disposes old session terminal when switching to different sessionId', async () => {

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -616,6 +616,14 @@ describe('Body', () => {
           return frameCallbacks.length
         })
 
+      const offsetWidthSpy = vi
+        .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockReturnValue(840)
+
+      const offsetHeightSpy = vi
+        .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+        .mockReturnValue(600)
+
       global.ResizeObserver = vi
         .fn()
         .mockImplementation((callback: ResizeObserverCallback) => {
@@ -643,6 +651,7 @@ describe('Body', () => {
           expect(mockObserve).toHaveBeenCalled()
         })
 
+        expect(mockFitAddon.fit).not.toHaveBeenCalled()
         mockFitAddon.fit.mockClear()
 
         const container = screen.getByTestId('terminal-pane')
@@ -681,6 +690,8 @@ describe('Body', () => {
         expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
       } finally {
         requestAnimationFrameSpy.mockRestore()
+        offsetWidthSpy.mockRestore()
+        offsetHeightSpy.mockRestore()
       }
     })
 

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -175,6 +175,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const previousDeferFitRef = useRef(deferFit)
   const cancelScheduledFitRef = useRef<(() => void) | null>(null)
   const flushFitRef = useRef<(() => void) | null>(null)
+  const flushFitSessionIdRef = useRef<string | null>(null)
+  const pendingDeferredFitFlushRef = useRef(false)
 
   // Use terminal hook for PTY lifecycle management
   const {
@@ -242,11 +244,17 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     if (!wasDeferred && deferFit) {
       cancelScheduledFitRef.current?.()
     } else if (wasDeferred && !deferFit) {
-      flushFitRef.current?.()
+      const flushFit = flushFitRef.current
+
+      if (flushFit && flushFitSessionIdRef.current === sessionId) {
+        flushFit()
+      } else {
+        pendingDeferredFitFlushRef.current = true
+      }
     }
 
     previousDeferFitRef.current = deferFit
-  }, [deferFit])
+  }, [deferFit, sessionId])
 
   useImperativeHandle(
     ref,
@@ -291,12 +299,12 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       }
     }
 
-    const fitIfNeeded = (targetFitAddon: FitAddon, force = false): void => {
+    const fitIfNeeded = (targetFitAddon: FitAddon, force = false): boolean => {
       const width = node.offsetWidth
       const height = node.offsetHeight
 
       if (width <= 0) {
-        return
+        return false
       }
 
       if (
@@ -305,11 +313,13 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         lastFitSize.width === width &&
         lastFitSize.height === height
       ) {
-        return
+        return false
       }
 
       lastFitSize = { width, height }
       targetFitAddon.fit()
+
+      return true
     }
 
     const scheduleFit = (targetFitAddon: FitAddon): void => {
@@ -342,13 +352,15 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       })
     }
 
-    const fitInitialWhenReady = (targetFitAddon: FitAddon): void => {
+    const fitInitialWhenReady = (targetFitAddon: FitAddon): boolean => {
       if (deferFitRef.current) {
-        return
+        return false
       }
 
-      fitIfNeeded(targetFitAddon, true)
+      return fitIfNeeded(targetFitAddon, true)
     }
+
+    let didInitialFit = false
 
     if (cached) {
       // Reuse existing terminal from cache
@@ -362,7 +374,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       // Re-fit to new container — guard against hidden (display:none) containers
       // where offsetWidth is 0. Fitting at zero width tells xterm cols≈1,
       // which causes the PTY to re-wrap scrollback into a narrow column.
-      fitInitialWhenReady(fitAddon)
+      didInitialFit = fitInitialWhenReady(fitAddon)
     } else {
       // Create new terminal instance
       newTerminal = new Terminal({
@@ -385,7 +397,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       newTerminal.open(node)
 
       // Fit terminal to container — guard against hidden (display:none) containers
-      fitInitialWhenReady(fitAddon)
+      didInitialFit = fitInitialWhenReady(fitAddon)
 
       // Register OSC 7 handler for cwd tracking
       // Shells emit: \e]7;file://hostname/path\a on every cd
@@ -418,6 +430,15 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     cancelScheduledFitRef.current = cancelScheduledFit
     flushFitRef.current = (): void => {
       flushFit(fitAddon)
+    }
+    flushFitSessionIdRef.current = sessionId
+
+    if (pendingDeferredFitFlushRef.current && !deferFitRef.current) {
+      pendingDeferredFitFlushRef.current = false
+
+      if (!didInitialFit) {
+        flushFit(fitAddon)
+      }
     }
 
     // Send initial terminal size to PTY (avoids default 80×24 when terminal is actually larger)
@@ -480,8 +501,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     // When Body unmounts, the session is closed — free resources
     return (): void => {
       cancelScheduledFit()
-      cancelScheduledFitRef.current = null
-      flushFitRef.current = null
+      if (flushFitSessionIdRef.current === sessionId) {
+        cancelScheduledFitRef.current = null
+        flushFitRef.current = null
+        flushFitSessionIdRef.current = null
+      }
       resizeObserver.disconnect()
       resizeDisposable.dispose()
       node.removeEventListener('focusin', handleFocusIn)

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -341,6 +341,14 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       })
     }
 
+    const fitInitialWhenReady = (targetFitAddon: FitAddon): void => {
+      if (deferFitRef.current) {
+        return
+      }
+
+      fitIfNeeded(targetFitAddon, true)
+    }
+
     if (cached) {
       // Reuse existing terminal from cache
       newTerminal = cached.terminal
@@ -353,7 +361,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       // Re-fit to new container — guard against hidden (display:none) containers
       // where offsetWidth is 0. Fitting at zero width tells xterm cols≈1,
       // which causes the PTY to re-wrap scrollback into a narrow column.
-      fitIfNeeded(fitAddon, true)
+      fitInitialWhenReady(fitAddon)
     } else {
       // Create new terminal instance
       newTerminal = new Terminal({
@@ -376,7 +384,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       newTerminal.open(node)
 
       // Fit terminal to container — guard against hidden (display:none) containers
-      fitIfNeeded(fitAddon, true)
+      fitInitialWhenReady(fitAddon)
 
       // Register OSC 7 handler for cwd tracking
       // Shells emit: \e]7;file://hostname/path\a on every cd

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -322,6 +322,9 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
       fitFrameId = window.requestAnimationFrame(() => {
         fitFrameId = null
+        if (deferFitRef.current) {
+          return
+        }
         fitIfNeeded(targetFitAddon)
       })
     }
@@ -331,6 +334,9 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
       fitFrameId = window.requestAnimationFrame(() => {
         fitFrameId = null
+        if (deferFitRef.current) {
+          return
+        }
         fitIfNeeded(targetFitAddon)
       })
     }

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -301,7 +301,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
       if (
         !force &&
-        lastFitSize?.width === width &&
+        lastFitSize !== null &&
+        lastFitSize.width === width &&
         lastFitSize.height === height
       ) {
         return

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react'
@@ -138,6 +139,12 @@ export interface BodyProps {
    * Called when xterm gains or loses focus.
    */
   onFocusChange?: (focused: boolean) => void
+
+  /**
+   * Defer expensive xterm fitting while surrounding layout is actively being
+   * dragged. The final size is fitted when this flips back to false.
+   */
+  deferFit?: boolean
 }
 
 export interface BodyHandle {
@@ -157,12 +164,17 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     mode = 'spawn',
     onPtyStatusChange = undefined,
     onFocusChange = undefined,
+    deferFit = false,
   },
   ref
 ): ReactElement {
   const containerRef = useRef<HTMLDivElement>(null)
   const [terminal, setTerminal] = useState<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
+  const deferFitRef = useRef(deferFit)
+  const previousDeferFitRef = useRef(deferFit)
+  const cancelScheduledFitRef = useRef<(() => void) | null>(null)
+  const flushFitRef = useRef<(() => void) | null>(null)
 
   // Use terminal hook for PTY lifecycle management
   const {
@@ -222,6 +234,20 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     onPtyStatusChangeRef.current?.(status)
   }, [status])
 
+  useLayoutEffect(() => {
+    const wasDeferred = previousDeferFitRef.current
+
+    deferFitRef.current = deferFit
+
+    if (!wasDeferred && deferFit) {
+      cancelScheduledFitRef.current?.()
+    } else if (wasDeferred && !deferFit) {
+      flushFitRef.current?.()
+    }
+
+    previousDeferFitRef.current = deferFit
+  }, [deferFit])
+
   useImperativeHandle(
     ref,
     () => ({
@@ -255,6 +281,59 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     const cached = terminalCache.get(sessionId)
     let newTerminal: Terminal
     let fitAddon: FitAddon
+    let fitFrameId: number | null = null
+    let lastFitSize: { width: number; height: number } | null = null
+
+    const cancelScheduledFit = (): void => {
+      if (fitFrameId !== null) {
+        window.cancelAnimationFrame(fitFrameId)
+        fitFrameId = null
+      }
+    }
+
+    const fitIfNeeded = (targetFitAddon: FitAddon, force = false): void => {
+      const width = node.offsetWidth
+      const height = node.offsetHeight
+
+      if (width <= 0) {
+        return
+      }
+
+      if (
+        !force &&
+        lastFitSize?.width === width &&
+        lastFitSize.height === height
+      ) {
+        return
+      }
+
+      lastFitSize = { width, height }
+      targetFitAddon.fit()
+    }
+
+    const scheduleFit = (targetFitAddon: FitAddon): void => {
+      if (deferFitRef.current) {
+        return
+      }
+
+      if (fitFrameId !== null) {
+        return
+      }
+
+      fitFrameId = window.requestAnimationFrame(() => {
+        fitFrameId = null
+        fitIfNeeded(targetFitAddon)
+      })
+    }
+
+    const flushFit = (targetFitAddon: FitAddon): void => {
+      cancelScheduledFit()
+
+      fitFrameId = window.requestAnimationFrame(() => {
+        fitFrameId = null
+        fitIfNeeded(targetFitAddon)
+      })
+    }
 
     if (cached) {
       // Reuse existing terminal from cache
@@ -268,10 +347,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       // Re-fit to new container — guard against hidden (display:none) containers
       // where offsetWidth is 0. Fitting at zero width tells xterm cols≈1,
       // which causes the PTY to re-wrap scrollback into a narrow column.
-      const width = node.offsetWidth
-      if (width > 0) {
-        fitAddon.fit()
-      }
+      fitIfNeeded(fitAddon, true)
     } else {
       // Create new terminal instance
       newTerminal = new Terminal({
@@ -294,10 +370,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       newTerminal.open(node)
 
       // Fit terminal to container — guard against hidden (display:none) containers
-      const width = node.offsetWidth
-      if (width > 0) {
-        fitAddon.fit()
-      }
+      fitIfNeeded(fitAddon, true)
 
       // Register OSC 7 handler for cwd tracking
       // Shells emit: \e]7;file://hostname/path\a on every cd
@@ -327,6 +400,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       terminalCache.set(sessionId, { terminal: newTerminal, fitAddon })
     }
 
+    cancelScheduledFitRef.current = cancelScheduledFit
+    flushFitRef.current = (): void => {
+      flushFit(fitAddon)
+    }
+
     // Send initial terminal size to PTY (avoids default 80×24 when terminal is actually larger)
     // This will be a no-op on first render but ensures PTY gets correct size on subsequent recreations
     resizeRef.current(newTerminal.cols, newTerminal.rows)
@@ -336,14 +414,27 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     // fitAddon.fit() (the trigger upstream) has already computed and applied
     // them. Calling fit() again here would re-measure the container — pure
     // overhead during rapid sidebar drag / window resize. Just forward to PTY.
+    let lastForwardedResize: { cols: number; rows: number } | null = null
+
     const resizeDisposable = newTerminal.onResize(({ cols, rows }) => {
       // Guard: don't forward resize when container is hidden (display:none).
       // Otherwise the PTY receives cols≈1 and re-wraps scrollback.
       const width = containerRef.current?.offsetWidth ?? 0
-      if (width > 0) {
-        // Notify PTY service of size change using ref (stable across renders)
-        resizeRef.current(cols, rows)
+      if (width <= 0) {
+        return
       }
+
+      if (
+        lastForwardedResize?.cols === cols &&
+        lastForwardedResize.rows === rows
+      ) {
+        return
+      }
+
+      lastForwardedResize = { cols, rows }
+
+      // Notify PTY service of size change using ref (stable across renders)
+      resizeRef.current(cols, rows)
     })
 
     const handleFocusIn = (): void => {
@@ -363,10 +454,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     // Guard: skip fit when container is hidden (display:none → width=0)
     // to avoid PTY scrollback re-wrapping at a narrow column count.
     const resizeObserver = new ResizeObserver(() => {
-      const width = containerRef.current?.offsetWidth ?? 0
-      if (width > 0) {
-        fitAddon.fit()
-      }
+      scheduleFit(fitAddon)
     })
     resizeObserver.observe(node)
 
@@ -376,6 +464,9 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     // Cleanup: disconnect observers and dispose terminal from cache
     // When Body unmounts, the session is closed — free resources
     return (): void => {
+      cancelScheduledFit()
+      cancelScheduledFitRef.current = null
+      flushFitRef.current = null
       resizeObserver.disconnect()
       resizeDisposable.dispose()
       node.removeEventListener('focusin', handleFocusIn)

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -8,15 +8,19 @@ import { TerminalPane } from './index'
 vi.mock('./Body', async () => {
   const React = await import('react')
 
-  const Body = React.forwardRef<{ focusTerminal: () => void }, unknown>(
-    function MockBody(_, ref): React.ReactElement {
-      React.useImperativeHandle(ref, () => ({
-        focusTerminal: vi.fn(),
-      }))
+  const Body = React.forwardRef<
+    { focusTerminal: () => void },
+    { deferFit: boolean }
+  >(function MockBody({ deferFit }, ref): React.ReactElement {
+    React.useImperativeHandle(ref, () => ({
+      focusTerminal: vi.fn(),
+    }))
 
-      return React.createElement('div', { 'data-testid': 'body-mock' })
-    }
-  )
+    return React.createElement('div', {
+      'data-testid': 'body-mock',
+      'data-defer-fit': deferFit ? 'true' : 'false',
+    })
+  })
 
   return {
     Body,
@@ -98,6 +102,15 @@ describe('TerminalPane index', () => {
     render(<TerminalPane {...baseProps} mode="attach" />)
 
     expect(screen.getByTestId('body-mock')).toBeInTheDocument()
+  })
+
+  test('forwards deferred fit state to Body', () => {
+    render(<TerminalPane {...baseProps} deferFit />)
+
+    expect(screen.getByTestId('body-mock')).toHaveAttribute(
+      'data-defer-fit',
+      'true'
+    )
   })
 
   test('renders RestartAffordance when mode is awaiting-restart', () => {

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -38,6 +38,7 @@ export interface TerminalPaneProps {
   session: Session
   isActive: boolean
   onClose?: (sessionId: string) => void
+  deferFit?: boolean
 }
 
 export {
@@ -60,6 +61,7 @@ export const TerminalPane = ({
   session,
   isActive,
   onClose = undefined,
+  deferFit = false,
 }: TerminalPaneProps): ReactElement => {
   const agent = agentForSession(session)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -188,6 +190,7 @@ export const TerminalPane = ({
             mode={mode}
             onPtyStatusChange={setPtyStatus}
             onFocusChange={onTerminalFocusChange}
+            deferFit={deferFit}
           />
         </div>
       )}

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable vitest/expect-expect */
 import type { ReactElement } from 'react'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { act, render, screen, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WorkspaceView } from './WorkspaceView'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
@@ -152,7 +152,13 @@ describe('WorkspaceView', () => {
     const container = screen.getByTestId('workspace-view')
 
     expect(container).toHaveClass('grid')
-    expect(container.style.gridTemplateColumns).toBe('48px 272px 1fr auto')
+    expect(container.style.gridTemplateColumns).toBe(
+      '48px var(--workspace-sidebar-width) 1fr auto'
+    )
+
+    expect(container.style.getPropertyValue('--workspace-sidebar-width')).toBe(
+      '272px'
+    )
   })
 
   test('fills viewport height', () => {
@@ -435,9 +441,63 @@ describe('WorkspaceView', () => {
     const container = screen.getByTestId('workspace-view')
 
     expect(container.style.gridTemplateColumns).toContain('48px')
-    expect(container.style.gridTemplateColumns).toContain('272px')
+    expect(container.style.gridTemplateColumns).toContain(
+      'var(--workspace-sidebar-width)'
+    )
+
+    expect(container.style.getPropertyValue('--workspace-sidebar-width')).toBe(
+      '272px'
+    )
     expect(container.style.gridTemplateColumns).toContain('1fr')
     expect(container.style.gridTemplateColumns).toContain('auto')
+  })
+
+  test('previews sidebar drag width through CSS variable before committing React state', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      render(<WorkspaceView />)
+
+      const workspace = screen.getByTestId('workspace-view')
+      const handle = screen.getByTestId('sidebar-resize-handle')
+
+      fireEvent.mouseDown(handle, { clientX: 200 })
+
+      fireEvent.mouseMove(document, { clientX: 300 })
+
+      expect(
+        workspace.style.getPropertyValue('--workspace-sidebar-width')
+      ).toBe('272px')
+      expect(handle).toHaveAttribute('aria-valuenow', '272')
+
+      const callback = frameCallbacks[0]
+      if (!callback) {
+        throw new Error('Expected sidebar resize animation frame')
+      }
+
+      act(() => {
+        callback(16)
+      })
+
+      expect(
+        workspace.style.getPropertyValue('--workspace-sidebar-width')
+      ).toBe('372px')
+      expect(handle).toHaveAttribute('aria-valuenow', '272')
+
+      fireEvent.mouseUp(document)
+
+      expect(handle).toHaveAttribute('aria-valuenow', '372')
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+    }
   })
 
   test('mounts SessionTabs above terminal zone', () => {

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -464,7 +464,7 @@ describe('WorkspaceView', () => {
       })
 
     try {
-      render(<WorkspaceView />)
+      const { rerender } = render(<WorkspaceView />)
 
       const workspace = screen.getByTestId('workspace-view')
       const handle = screen.getByTestId('sidebar-resize-handle')
@@ -486,6 +486,13 @@ describe('WorkspaceView', () => {
       act(() => {
         callback(16)
       })
+
+      expect(
+        workspace.style.getPropertyValue('--workspace-sidebar-width')
+      ).toBe('372px')
+      expect(handle).toHaveAttribute('aria-valuenow', '372')
+
+      rerender(<WorkspaceView />)
 
       expect(
         workspace.style.getPropertyValue('--workspace-sidebar-width')

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -490,7 +490,7 @@ describe('WorkspaceView', () => {
       expect(
         workspace.style.getPropertyValue('--workspace-sidebar-width')
       ).toBe('372px')
-      expect(handle).toHaveAttribute('aria-valuenow', '272')
+      expect(handle).toHaveAttribute('aria-valuenow', '372')
 
       fireEvent.mouseUp(document)
 

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -153,7 +153,7 @@ describe('WorkspaceView', () => {
 
     expect(container).toHaveClass('grid')
     expect(container.style.gridTemplateColumns).toBe(
-      '48px var(--workspace-sidebar-width) 1fr auto'
+      '48px var(--workspace-sidebar-width, 272px) 1fr auto'
     )
 
     expect(container.style.getPropertyValue('--workspace-sidebar-width')).toBe(
@@ -442,7 +442,7 @@ describe('WorkspaceView', () => {
 
     expect(container.style.gridTemplateColumns).toContain('48px')
     expect(container.style.gridTemplateColumns).toContain(
-      'var(--workspace-sidebar-width)'
+      'var(--workspace-sidebar-width, 272px)'
     )
 
     expect(container.style.getPropertyValue('--workspace-sidebar-width')).toBe(

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -507,6 +507,47 @@ describe('WorkspaceView', () => {
     }
   })
 
+  test('skips duplicate sidebar preview write after fast drag release', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    const setPropertySpy = vi.spyOn(
+      CSSStyleDeclaration.prototype,
+      'setProperty'
+    )
+
+    try {
+      render(<WorkspaceView />)
+
+      const handle = screen.getByTestId('sidebar-resize-handle')
+
+      fireEvent.mouseDown(handle, { clientX: 200 })
+      fireEvent.mouseMove(document, { clientX: 300 })
+      fireEvent.mouseUp(document)
+
+      const sidebarWidthWrites = setPropertySpy.mock.calls.filter(
+        ([propertyName]) => propertyName === '--workspace-sidebar-width'
+      )
+
+      expect(sidebarWidthWrites).toEqual([
+        ['--workspace-sidebar-width', '272px'],
+        ['--workspace-sidebar-width', '372px'],
+      ])
+      expect(frameCallbacks).toHaveLength(1)
+      expect(handle).toHaveAttribute('aria-valuenow', '372')
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+      setPropertySpy.mockRestore()
+    }
+  })
+
   test('mounts SessionTabs above terminal zone', () => {
     render(<WorkspaceView />)
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -54,6 +54,8 @@ const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
 export const WorkspaceView = (): ReactElement => {
   const workspaceRef = useRef<HTMLDivElement>(null)
   const sidebarResizeHandleRef = useRef<HTMLDivElement | null>(null)
+  // Imperative resize previews keep this ref, the CSS variable, and
+  // aria-valuenow in sync without per-frame React commits.
   const sidebarResizeValueRef = useRef(SIDEBAR_INITIAL)
 
   // Round 4, Finding 1 (codex P1): one terminal service per WorkspaceView

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1,5 +1,12 @@
 import type { CSSProperties, ReactElement } from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { IconRail } from './components/IconRail'
 import { Tabs } from '../sessions/components/Tabs'
 import { Sidebar } from '../../components/sidebar/Sidebar'
@@ -199,6 +206,10 @@ export const WorkspaceView = (): ReactElement => {
     updateMode: 'commit-on-end',
     onDragPreview: previewSidebarWidth,
   })
+
+  useLayoutEffect(() => {
+    previewSidebarWidth(sidebarWidth)
+  }, [previewSidebarWidth, sidebarWidth])
 
   const activeSession = activeSessionId
     ? sessions.find((s) => s.id === activeSessionId)
@@ -518,7 +529,6 @@ export const WorkspaceView = (): ReactElement => {
           data-testid="sidebar-resize-handle"
           role="separator"
           aria-orientation="vertical"
-          aria-valuenow={sidebarWidth}
           aria-valuemin={SIDEBAR_MIN}
           aria-valuemax={SIDEBAR_MAX}
           onMouseDown={handleMouseDown}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -57,6 +57,7 @@ export const WorkspaceView = (): ReactElement => {
   // Imperative resize previews keep this ref, the CSS variable, and
   // aria-valuenow in sync without per-frame React commits.
   const sidebarResizeValueRef = useRef(SIDEBAR_INITIAL)
+  const hasAppliedSidebarResizePreviewRef = useRef(false)
 
   // Round 4, Finding 1 (codex P1): one terminal service per WorkspaceView
   // instance. Both `useSessionManager` and every `TerminalPane` (via
@@ -200,6 +201,14 @@ export const WorkspaceView = (): ReactElement => {
   )
 
   const previewSidebarWidth = useCallback((nextWidth: number): void => {
+    if (
+      hasAppliedSidebarResizePreviewRef.current &&
+      sidebarResizeValueRef.current === nextWidth
+    ) {
+      return
+    }
+
+    hasAppliedSidebarResizePreviewRef.current = true
     sidebarResizeValueRef.current = nextWidth
     workspaceRef.current?.style.setProperty(
       '--workspace-sidebar-width',

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -214,6 +214,14 @@ export const WorkspaceView = (): ReactElement => {
     onDragPreview: previewSidebarWidth,
   })
 
+  const setSidebarResizeHandle = useCallback(
+    (element: HTMLDivElement | null): void => {
+      sidebarResizeHandleRef.current = element
+      element?.setAttribute('aria-valuenow', String(sidebarWidth))
+    },
+    [sidebarWidth]
+  )
+
   useLayoutEffect(() => {
     previewSidebarWidth(sidebarWidth)
   }, [previewSidebarWidth, sidebarWidth])
@@ -532,16 +540,14 @@ export const WorkspaceView = (): ReactElement => {
 
         {/* Resize handle */}
         <div
-          ref={sidebarResizeHandleRef}
+          ref={setSidebarResizeHandle}
           data-testid="sidebar-resize-handle"
           role="separator"
           aria-orientation="vertical"
           aria-valuemin={SIDEBAR_MIN}
           aria-valuemax={SIDEBAR_MAX}
-          aria-valuenow={sidebarWidth}
-          // aria-valuenow has a JSX fallback for a11y tooling; live drag
-          // preview remains owned by previewSidebarWidth while sidebarWidth
-          // is stable during commit-on-end drags.
+          // aria-valuenow is owned imperatively so drag previews can update
+          // the splitter value without per-frame React state commits.
           onMouseDown={handleMouseDown}
           className={`
             absolute right-0 top-0 z-10 h-full w-1 cursor-col-resize

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -495,8 +495,9 @@ export const WorkspaceView = (): ReactElement => {
       className="grid h-screen grid-rows-1 overflow-hidden"
       style={
         {
-          '--workspace-sidebar-width': `${sidebarWidth}px`,
-          gridTemplateColumns: '48px var(--workspace-sidebar-width) 1fr auto',
+          // `--workspace-sidebar-width` is owned by previewSidebarWidth so
+          // React rerenders cannot overwrite an in-progress drag preview.
+          gridTemplateColumns: `48px var(--workspace-sidebar-width, ${SIDEBAR_DEFAULT}px) 1fr auto`,
         } as CSSProperties
       }
     >

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -538,8 +538,10 @@ export const WorkspaceView = (): ReactElement => {
           aria-orientation="vertical"
           aria-valuemin={SIDEBAR_MIN}
           aria-valuemax={SIDEBAR_MAX}
-          // aria-valuenow is owned by previewSidebarWidth so unrelated
-          // React renders do not overwrite the frame-accurate drag preview.
+          aria-valuenow={sidebarWidth}
+          // aria-valuenow has a JSX fallback for a11y tooling; live drag
+          // preview remains owned by previewSidebarWidth while sidebarWidth
+          // is stable during commit-on-end drags.
           onMouseDown={handleMouseDown}
           className={`
             absolute right-0 top-0 z-10 h-full w-1 cursor-col-resize

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -26,7 +26,7 @@ import { InfoBanner } from './components/InfoBanner'
 import { CommandPalette } from '../command-palette/CommandPalette'
 import { mockNavigationItems, mockSettingsItem } from './data/mockNavigation'
 import { useSessionManager } from '../sessions/hooks/useSessionManager'
-import { useResizable } from '../../hooks/useResizable'
+import { clampSize, useResizable } from '../../hooks/useResizable'
 import { useSidebarTab, type SidebarTab } from '../../hooks/useSidebarTab'
 import { useNotifyInfo } from './hooks/useNotifyInfo'
 import { createFileSystemService } from '../files/services/fileSystemService'
@@ -44,9 +44,7 @@ const SIDEBAR_MIN = 240
 const SIDEBAR_MAX = 560
 const SIDEBAR_DEFAULT = 272
 
-const SIDEBAR_INITIAL = Math.round(
-  Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, SIDEBAR_DEFAULT))
-)
+const SIDEBAR_INITIAL = clampSize(SIDEBAR_DEFAULT, SIDEBAR_MIN, SIDEBAR_MAX)
 
 const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
   { id: 'sessions', label: 'SESSIONS' },

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -217,9 +217,8 @@ export const WorkspaceView = (): ReactElement => {
   const setSidebarResizeHandle = useCallback(
     (element: HTMLDivElement | null): void => {
       sidebarResizeHandleRef.current = element
-      element?.setAttribute('aria-valuenow', String(sidebarWidth))
     },
-    [sidebarWidth]
+    []
   )
 
   useLayoutEffect(() => {
@@ -546,8 +545,8 @@ export const WorkspaceView = (): ReactElement => {
           aria-orientation="vertical"
           aria-valuemin={SIDEBAR_MIN}
           aria-valuemax={SIDEBAR_MAX}
-          // aria-valuenow is owned imperatively so drag previews can update
-          // the splitter value without per-frame React state commits.
+          // aria-valuenow is set by the layout effect and drag preview path
+          // so previews do not need per-frame React state commits.
           onMouseDown={handleMouseDown}
           className={`
             absolute right-0 top-0 z-10 h-full w-1 cursor-col-resize

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -192,7 +192,8 @@ export const WorkspaceView = (): ReactElement => {
     const resizeHandle = sidebarResizeHandleRef.current
     if (!resizeHandle) {
       if (import.meta.env.DEV) {
-        throw new Error('Sidebar resize handle not mounted for aria-valuenow')
+        // eslint-disable-next-line no-console
+        console.error('Sidebar resize handle not mounted for aria-valuenow')
       }
 
       return

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -57,7 +57,6 @@ export const WorkspaceView = (): ReactElement => {
   // Imperative resize previews keep this ref, the CSS variable, and
   // aria-valuenow in sync without per-frame React commits.
   const sidebarResizeValueRef = useRef(SIDEBAR_INITIAL)
-  const hasAppliedSidebarResizePreviewRef = useRef(false)
 
   // Round 4, Finding 1 (codex P1): one terminal service per WorkspaceView
   // instance. Both `useSessionManager` and every `TerminalPane` (via
@@ -201,19 +200,26 @@ export const WorkspaceView = (): ReactElement => {
   )
 
   const previewSidebarWidth = useCallback((nextWidth: number): void => {
+    const workspaceElement = workspaceRef.current
+    if (!workspaceElement) {
+      return
+    }
+
+    const nextCssWidth = `${nextWidth}px`
     if (
-      hasAppliedSidebarResizePreviewRef.current &&
-      sidebarResizeValueRef.current === nextWidth
+      sidebarResizeValueRef.current === nextWidth &&
+      workspaceElement.style.getPropertyValue('--workspace-sidebar-width') ===
+        nextCssWidth
     ) {
       return
     }
 
-    hasAppliedSidebarResizePreviewRef.current = true
-    sidebarResizeValueRef.current = nextWidth
-    workspaceRef.current?.style.setProperty(
+    workspaceElement.style.setProperty(
       '--workspace-sidebar-width',
-      `${nextWidth}px`
+      nextCssWidth
     )
+    sidebarResizeValueRef.current = nextWidth
+
     const resizeHandle = sidebarResizeHandleRef.current
 
     if (!resizeHandle) {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -214,13 +214,6 @@ export const WorkspaceView = (): ReactElement => {
     onDragPreview: previewSidebarWidth,
   })
 
-  const setSidebarResizeHandle = useCallback(
-    (element: HTMLDivElement | null): void => {
-      sidebarResizeHandleRef.current = element
-    },
-    []
-  )
-
   useLayoutEffect(() => {
     previewSidebarWidth(sidebarWidth)
   }, [previewSidebarWidth, sidebarWidth])
@@ -540,7 +533,7 @@ export const WorkspaceView = (): ReactElement => {
 
         {/* Resize handle */}
         <div
-          ref={setSidebarResizeHandle}
+          ref={sidebarResizeHandleRef}
           data-testid="sidebar-resize-handle"
           role="separator"
           aria-orientation="vertical"

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import type { CSSProperties, ReactElement } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { IconRail } from './components/IconRail'
 import { Tabs } from '../sessions/components/Tabs'
@@ -43,6 +43,8 @@ const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
 ]
 
 export const WorkspaceView = (): ReactElement => {
+  const workspaceRef = useRef<HTMLDivElement>(null)
+
   // Round 4, Finding 1 (codex P1): one terminal service per WorkspaceView
   // instance. Both `useSessionManager` and every `TerminalPane` (via
   // `TerminalZone`) MUST receive the same instance. Under Tauri the factory
@@ -173,6 +175,13 @@ export const WorkspaceView = (): ReactElement => {
     }
   }, [sessions, updateSessionAgentType])
 
+  const previewSidebarWidth = useCallback((nextWidth: number): void => {
+    workspaceRef.current?.style.setProperty(
+      '--workspace-sidebar-width',
+      `${nextWidth}px`
+    )
+  }, [])
+
   const {
     size: sidebarWidth,
     isDragging,
@@ -181,6 +190,8 @@ export const WorkspaceView = (): ReactElement => {
     initial: SIDEBAR_DEFAULT,
     min: SIDEBAR_MIN,
     max: SIDEBAR_MAX,
+    updateMode: 'commit-on-end',
+    onDragPreview: previewSidebarWidth,
   })
 
   const activeSession = activeSessionId
@@ -445,14 +456,18 @@ export const WorkspaceView = (): ReactElement => {
 
   return (
     <div
+      ref={workspaceRef}
       data-testid="workspace-view"
       // `grid-rows-1` pins the implicit row to `1fr`; without it
       // `grid-auto-rows: auto` lets the row grow to content size and
       // `h-full` stops propagating the 100vh constraint downward.
       className="grid h-screen grid-rows-1 overflow-hidden"
-      style={{
-        gridTemplateColumns: `48px ${sidebarWidth}px 1fr auto`,
-      }}
+      style={
+        {
+          '--workspace-sidebar-width': `${sidebarWidth}px`,
+          gridTemplateColumns: '48px var(--workspace-sidebar-width) 1fr auto',
+        } as CSSProperties
+      }
     >
       <IconRail items={mockNavigationItems} settingsItem={mockSettingsItem} />
 
@@ -524,6 +539,7 @@ export const WorkspaceView = (): ReactElement => {
         <TerminalZone
           sessions={sessions}
           activeSessionId={activeSessionId}
+          deferTerminalFit={isDragging}
           onSessionCwdChange={updateSessionCwd}
           restoreData={restoreData}
           loading={loading}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -189,10 +189,16 @@ export const WorkspaceView = (): ReactElement => {
       `${nextWidth}px`
     )
 
-    sidebarResizeHandleRef.current?.setAttribute(
-      'aria-valuenow',
-      String(nextWidth)
-    )
+    const resizeHandle = sidebarResizeHandleRef.current
+    if (!resizeHandle) {
+      if (import.meta.env.DEV) {
+        throw new Error('Sidebar resize handle not mounted for aria-valuenow')
+      }
+
+      return
+    }
+
+    resizeHandle.setAttribute('aria-valuenow', String(nextWidth))
   }, [])
 
   const {
@@ -531,6 +537,8 @@ export const WorkspaceView = (): ReactElement => {
           aria-orientation="vertical"
           aria-valuemin={SIDEBAR_MIN}
           aria-valuemax={SIDEBAR_MAX}
+          // aria-valuenow is owned by previewSidebarWidth so unrelated
+          // React renders do not overwrite the frame-accurate drag preview.
           onMouseDown={handleMouseDown}
           className={`
             absolute right-0 top-0 z-10 h-full w-1 cursor-col-resize

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -56,7 +56,7 @@ export const WorkspaceView = (): ReactElement => {
   const sidebarResizeHandleRef = useRef<HTMLDivElement | null>(null)
   // Imperative resize previews keep this ref, the CSS variable, and
   // aria-valuenow in sync without per-frame React commits.
-  const sidebarResizeValueRef = useRef(SIDEBAR_INITIAL)
+  const sidebarResizeValueRef = useRef<number | null>(null)
 
   // Round 4, Finding 1 (codex P1): one terminal service per WorkspaceView
   // instance. Both `useSessionManager` and every `TerminalPane` (via
@@ -193,7 +193,7 @@ export const WorkspaceView = (): ReactElement => {
       sidebarResizeHandleRef.current = element
       element?.setAttribute(
         'aria-valuenow',
-        String(sidebarResizeValueRef.current)
+        String(sidebarResizeValueRef.current ?? SIDEBAR_INITIAL)
       )
     },
     []
@@ -206,11 +206,7 @@ export const WorkspaceView = (): ReactElement => {
     }
 
     const nextCssWidth = `${nextWidth}px`
-    if (
-      sidebarResizeValueRef.current === nextWidth &&
-      workspaceElement.style.getPropertyValue('--workspace-sidebar-width') ===
-        nextCssWidth
-    ) {
+    if (sidebarResizeValueRef.current === nextWidth) {
       return
     }
 
@@ -517,7 +513,7 @@ export const WorkspaceView = (): ReactElement => {
         {
           // `--workspace-sidebar-width` is owned by previewSidebarWidth so
           // React rerenders cannot overwrite an in-progress drag preview.
-          gridTemplateColumns: `48px var(--workspace-sidebar-width, ${SIDEBAR_DEFAULT}px) 1fr auto`,
+          gridTemplateColumns: `48px var(--workspace-sidebar-width, ${SIDEBAR_INITIAL}px) 1fr auto`,
         } as CSSProperties
       }
     >

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -44,6 +44,7 @@ const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
 
 export const WorkspaceView = (): ReactElement => {
   const workspaceRef = useRef<HTMLDivElement>(null)
+  const sidebarResizeHandleRef = useRef<HTMLDivElement>(null)
 
   // Round 4, Finding 1 (codex P1): one terminal service per WorkspaceView
   // instance. Both `useSessionManager` and every `TerminalPane` (via
@@ -179,6 +180,11 @@ export const WorkspaceView = (): ReactElement => {
     workspaceRef.current?.style.setProperty(
       '--workspace-sidebar-width',
       `${nextWidth}px`
+    )
+
+    sidebarResizeHandleRef.current?.setAttribute(
+      'aria-valuenow',
+      String(nextWidth)
     )
   }, [])
 
@@ -508,6 +514,7 @@ export const WorkspaceView = (): ReactElement => {
 
         {/* Resize handle */}
         <div
+          ref={sidebarResizeHandleRef}
           data-testid="sidebar-resize-handle"
           role="separator"
           aria-orientation="vertical"

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -44,6 +44,10 @@ const SIDEBAR_MIN = 240
 const SIDEBAR_MAX = 560
 const SIDEBAR_DEFAULT = 272
 
+const SIDEBAR_INITIAL = Math.round(
+  Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, SIDEBAR_DEFAULT))
+)
+
 const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
   { id: 'sessions', label: 'SESSIONS' },
   { id: 'files', label: 'FILES' },
@@ -52,7 +56,7 @@ const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
 export const WorkspaceView = (): ReactElement => {
   const workspaceRef = useRef<HTMLDivElement>(null)
   const sidebarResizeHandleRef = useRef<HTMLDivElement | null>(null)
-  const sidebarResizeValueRef = useRef(SIDEBAR_DEFAULT)
+  const sidebarResizeValueRef = useRef(SIDEBAR_INITIAL)
 
   // Round 4, Finding 1 (codex P1): one terminal service per WorkspaceView
   // instance. Both `useSessionManager` and every `TerminalPane` (via

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -51,7 +51,8 @@ const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
 
 export const WorkspaceView = (): ReactElement => {
   const workspaceRef = useRef<HTMLDivElement>(null)
-  const sidebarResizeHandleRef = useRef<HTMLDivElement>(null)
+  const sidebarResizeHandleRef = useRef<HTMLDivElement | null>(null)
+  const sidebarResizeValueRef = useRef(SIDEBAR_DEFAULT)
 
   // Round 4, Finding 1 (codex P1): one terminal service per WorkspaceView
   // instance. Both `useSessionManager` and every `TerminalPane` (via
@@ -183,19 +184,26 @@ export const WorkspaceView = (): ReactElement => {
     }
   }, [sessions, updateSessionAgentType])
 
+  const setSidebarResizeHandle = useCallback(
+    (element: HTMLDivElement | null): void => {
+      sidebarResizeHandleRef.current = element
+      element?.setAttribute(
+        'aria-valuenow',
+        String(sidebarResizeValueRef.current)
+      )
+    },
+    []
+  )
+
   const previewSidebarWidth = useCallback((nextWidth: number): void => {
+    sidebarResizeValueRef.current = nextWidth
     workspaceRef.current?.style.setProperty(
       '--workspace-sidebar-width',
       `${nextWidth}px`
     )
-
     const resizeHandle = sidebarResizeHandleRef.current
-    if (!resizeHandle) {
-      if (import.meta.env.DEV) {
-        // eslint-disable-next-line no-console
-        console.error('Sidebar resize handle not mounted for aria-valuenow')
-      }
 
+    if (!resizeHandle) {
       return
     }
 
@@ -533,7 +541,7 @@ export const WorkspaceView = (): ReactElement => {
 
         {/* Resize handle */}
         <div
-          ref={sidebarResizeHandleRef}
+          ref={setSidebarResizeHandle}
           data-testid="sidebar-resize-handle"
           role="separator"
           aria-orientation="vertical"

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -99,7 +99,13 @@ describe('WorkspaceView - Visual Verification (Feature #20)', () => {
       render(<WorkspaceView />)
       const workspace = screen.getByTestId('workspace-view')
 
-      expect(workspace.style.gridTemplateColumns).toBe('48px 272px 1fr auto')
+      expect(workspace.style.gridTemplateColumns).toBe(
+        '48px var(--workspace-sidebar-width) 1fr auto'
+      )
+
+      expect(
+        workspace.style.getPropertyValue('--workspace-sidebar-width')
+      ).toBe('272px')
     })
 
     test('workspace uses full screen height', () => {

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -100,7 +100,7 @@ describe('WorkspaceView - Visual Verification (Feature #20)', () => {
       const workspace = screen.getByTestId('workspace-view')
 
       expect(workspace.style.gridTemplateColumns).toBe(
-        '48px var(--workspace-sidebar-width) 1fr auto'
+        '48px var(--workspace-sidebar-width, 272px) 1fr auto'
       )
 
       expect(

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -42,6 +42,7 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
       cwd,
       restoredFrom,
       mode,
+      deferFit,
       onRestart,
       session,
       isActive,
@@ -52,6 +53,7 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
         data-cwd={cwd}
         data-restored={restoredFrom ? 'true' : 'false'}
         data-mode={mode}
+        data-defer-fit={deferFit ? 'true' : 'false'}
         data-session-name={session.name}
         data-is-active={isActive ? 'true' : 'false'}
         data-session-agent-type={session.agentType}
@@ -164,6 +166,16 @@ describe('TerminalZone', () => {
       (pane) => pane.getAttribute('data-session-id') === 'sess-1'
     )
     expect(activeMockPane).toHaveAttribute('data-cwd', '~')
+  })
+
+  test('forwards deferred terminal fit state to TerminalPane', () => {
+    render(<TerminalZone {...defaultProps} deferTerminalFit />)
+
+    const mockPanes = screen.getAllByTestId('terminal-pane-mock')
+
+    mockPanes.forEach((pane) => {
+      expect(pane).toHaveAttribute('data-defer-fit', 'true')
+    })
   })
 
   test('passes session.agentType through to each TerminalPane', () => {

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -33,6 +33,11 @@ export interface TerminalZoneProps {
    */
   onSessionRestart?: (sessionId: string) => void
   /**
+   * Temporarily hold xterm fitting while surrounding workspace chrome is being
+   * dragged. The active terminal gets one final fit when the drag ends.
+   */
+  deferTerminalFit?: boolean
+  /**
    * Terminal service forwarded to every `TerminalPane`. MUST be the same
    * instance the parent passes to `useSessionManager` — see Round 4
    * Finding 1 in `useSessionManager.ts` for the rationale.
@@ -48,6 +53,7 @@ export const TerminalZone = ({
   loading = false,
   onPaneReady = undefined,
   onSessionRestart = undefined,
+  deferTerminalFit = false,
   service,
 }: TerminalZoneProps): ReactElement => (
   <div data-testid="terminal-zone" className="flex min-h-0 flex-1 flex-col">
@@ -141,6 +147,7 @@ export const TerminalZone = ({
                 onRestart={onSessionRestart}
                 session={session}
                 isActive={isActive}
+                deferFit={deferTerminalFit}
               />
             </div>
           )

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -251,6 +251,69 @@ describe('useResizable', () => {
     expect(onDragPreview).not.toHaveBeenCalled()
   })
 
+  test('commit-on-end keyboard resize during drag survives mouseup', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const onDragPreview = vi.fn()
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      const { result } = renderHook(() =>
+        useResizable({
+          initial: 256,
+          min: 100,
+          max: 500,
+          updateMode: 'commit-on-end',
+          onDragPreview,
+        })
+      )
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 200,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 320 }))
+      })
+
+      const callback = frameCallbacks[0]
+      if (!callback) {
+        throw new Error('Expected resize animation frame to be scheduled')
+      }
+
+      act(() => {
+        callback(16)
+      })
+
+      expect(onDragPreview).toHaveBeenCalledWith(376)
+
+      act(() => {
+        result.current.adjustBy(50)
+      })
+
+      expect(result.current.size).toBe(306)
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mouseup'))
+      })
+
+      expect(result.current.size).toBe(306)
+      expect(onDragPreview).toHaveBeenCalledTimes(1)
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
   test('mouseup flushes pending size before ending drag', () => {
     const requestAnimationFrameSpy = vi
       .spyOn(window, 'requestAnimationFrame')

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -370,6 +370,60 @@ describe('useResizable', () => {
     }
   })
 
+  test('commit-on-end keyboard resize uses pending drag size before frame flush', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const onDragPreview = vi.fn()
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      const { result } = renderHook(() =>
+        useResizable({
+          initial: 256,
+          min: 100,
+          max: 500,
+          updateMode: 'commit-on-end',
+          onDragPreview,
+        })
+      )
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 200,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 320 }))
+      })
+
+      expect(onDragPreview).not.toHaveBeenCalled()
+
+      act(() => {
+        result.current.adjustBy(50)
+      })
+
+      expect(result.current.size).toBe(426)
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mouseup'))
+      })
+
+      expect(result.current.size).toBe(426)
+      expect(onDragPreview).not.toHaveBeenCalled()
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
   test('mouseup flushes pending size before ending drag', () => {
     const requestAnimationFrameSpy = vi
       .spyOn(window, 'requestAnimationFrame')

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -179,6 +179,57 @@ describe('useResizable', () => {
     }
   })
 
+  test('live mode does not call onDragPreview alongside state updates', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const onDragPreview = vi.fn()
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      const { result } = renderHook(() =>
+        useResizable({
+          initial: 256,
+          min: 100,
+          max: 500,
+          updateMode: 'live',
+          onDragPreview,
+        })
+      )
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 200,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 320 }))
+      })
+
+      const callback = frameCallbacks[0]
+      if (!callback) {
+        throw new Error('Expected resize animation frame to be scheduled')
+      }
+
+      act(() => {
+        callback(16)
+      })
+
+      expect(result.current.size).toBe(376)
+      expect(onDragPreview).not.toHaveBeenCalled()
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
   test('mouseup flushes pending size before ending drag', () => {
     const requestAnimationFrameSpy = vi
       .spyOn(window, 'requestAnimationFrame')

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -301,13 +301,13 @@ describe('useResizable', () => {
         result.current.adjustBy(50)
       })
 
-      expect(result.current.size).toBe(306)
+      expect(result.current.size).toBe(426)
 
       act(() => {
         document.dispatchEvent(new MouseEvent('mouseup'))
       })
 
-      expect(result.current.size).toBe(306)
+      expect(result.current.size).toBe(426)
       expect(onDragPreview).toHaveBeenCalledTimes(1)
     } finally {
       requestAnimationFrameSpy.mockRestore()

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -235,6 +235,72 @@ describe('useResizable', () => {
     }
   })
 
+  test('new drag cancels pending preview from previous drag', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const onDragPreview = vi.fn()
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => undefined)
+
+    try {
+      const { result } = renderHook(() =>
+        useResizable({
+          initial: 256,
+          min: 100,
+          max: 500,
+          updateMode: 'commit-on-end',
+          onDragPreview,
+        })
+      )
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 200,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 320 }))
+      })
+
+      const staleCallback = frameCallbacks[0]
+      if (!staleCallback) {
+        throw new Error('Expected resize animation frame to be scheduled')
+      }
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 400,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1)
+
+      act(() => {
+        staleCallback(16)
+      })
+
+      expect(onDragPreview).not.toHaveBeenCalled()
+      expect(result.current.size).toBe(256)
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+      cancelAnimationFrameSpy.mockRestore()
+    }
+  })
+
   test('live mode does not call onDragPreview alongside state updates', () => {
     const frameCallbacks: FrameRequestCallback[] = []
     const onDragPreview = vi.fn()

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
+import { describe, test, expect, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { useResizable } from './useResizable'
 
 describe('useResizable', () => {
@@ -50,7 +50,7 @@ describe('useResizable', () => {
     expect(result.current.isDragging).toBe(false)
   })
 
-  test('mousemove updates size within bounds', () => {
+  test('mousemove updates size within bounds', async () => {
     const { result } = renderHook(() =>
       useResizable({ initial: 256, min: 100, max: 500 })
     )
@@ -67,10 +67,160 @@ describe('useResizable', () => {
       document.dispatchEvent(new MouseEvent('mousemove', { clientX: 300 }))
     })
 
-    expect(result.current.size).toBe(356)
+    await waitFor(() => {
+      expect(result.current.size).toBe(356)
+    })
   })
 
-  test('size is clamped to min', () => {
+  test('coalesces rapid mousemove updates to one animation frame', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 200,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 300 }))
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 320 }))
+      })
+
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+      expect(result.current.size).toBe(256)
+
+      const callback = frameCallbacks[0]
+      if (!callback) {
+        throw new Error('Expected resize animation frame to be scheduled')
+      }
+
+      act(() => {
+        callback(16)
+      })
+
+      expect(result.current.size).toBe(376)
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
+  test('commit-on-end mode previews drag size before committing state', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const onDragPreview = vi.fn()
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      const { result } = renderHook(() =>
+        useResizable({
+          initial: 256,
+          min: 100,
+          max: 500,
+          updateMode: 'commit-on-end',
+          onDragPreview,
+        })
+      )
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 200,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 320 }))
+      })
+
+      expect(result.current.size).toBe(256)
+      expect(onDragPreview).not.toHaveBeenCalled()
+
+      const callback = frameCallbacks[0]
+      if (!callback) {
+        throw new Error('Expected resize animation frame to be scheduled')
+      }
+
+      act(() => {
+        callback(16)
+      })
+
+      expect(result.current.size).toBe(256)
+      expect(onDragPreview).toHaveBeenCalledWith(376)
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mouseup'))
+      })
+
+      expect(result.current.size).toBe(376)
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
+  test('mouseup flushes pending size before ending drag', () => {
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((): number => 1)
+
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => undefined)
+
+    try {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 200,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 320 }))
+      })
+
+      expect(result.current.size).toBe(256)
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mouseup'))
+      })
+
+      expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1)
+      expect(result.current.size).toBe(376)
+      expect(result.current.isDragging).toBe(false)
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+      cancelAnimationFrameSpy.mockRestore()
+    }
+  })
+
+  test('size is clamped to min', async () => {
     const { result } = renderHook(() =>
       useResizable({ initial: 150, min: 100, max: 500 })
     )
@@ -87,10 +237,12 @@ describe('useResizable', () => {
       document.dispatchEvent(new MouseEvent('mousemove', { clientX: 0 }))
     })
 
-    expect(result.current.size).toBe(100)
+    await waitFor(() => {
+      expect(result.current.size).toBe(100)
+    })
   })
 
-  test('vertical direction grows as clientY increases', () => {
+  test('vertical direction grows as clientY increases', async () => {
     const { result } = renderHook(() =>
       useResizable({
         initial: 200,
@@ -113,10 +265,12 @@ describe('useResizable', () => {
     })
 
     // Dragging down (clientY 100 → 150): +50 delta, size 200 → 250
-    expect(result.current.size).toBe(250)
+    await waitFor(() => {
+      expect(result.current.size).toBe(250)
+    })
   })
 
-  test('vertical + invert: dragging UP grows the panel (bottom-anchored drawer)', () => {
+  test('vertical + invert: dragging UP grows the panel (bottom-anchored drawer)', async () => {
     // Simulates a bottom-anchored drawer with a top-edge drag handle:
     // dragging UP (clientY decreases) must GROW the panel, not shrink it.
     const { result } = renderHook(() =>
@@ -142,10 +296,12 @@ describe('useResizable', () => {
       document.dispatchEvent(new MouseEvent('mousemove', { clientY: 150 }))
     })
 
-    expect(result.current.size).toBe(250)
+    await waitFor(() => {
+      expect(result.current.size).toBe(250)
+    })
   })
 
-  test('vertical + invert: dragging DOWN shrinks the panel', () => {
+  test('vertical + invert: dragging DOWN shrinks the panel', async () => {
     const { result } = renderHook(() =>
       useResizable({
         initial: 300,
@@ -169,10 +325,12 @@ describe('useResizable', () => {
       document.dispatchEvent(new MouseEvent('mousemove', { clientY: 200 }))
     })
 
-    expect(result.current.size).toBe(200)
+    await waitFor(() => {
+      expect(result.current.size).toBe(200)
+    })
   })
 
-  test('size is clamped to max', () => {
+  test('size is clamped to max', async () => {
     const { result } = renderHook(() =>
       useResizable({ initial: 400, min: 100, max: 500 })
     )
@@ -189,7 +347,9 @@ describe('useResizable', () => {
       document.dispatchEvent(new MouseEvent('mousemove', { clientX: 500 }))
     })
 
-    expect(result.current.size).toBe(500)
+    await waitFor(() => {
+      expect(result.current.size).toBe(500)
+    })
   })
 
   test('initial value above max is clamped on mount', () => {

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -424,6 +424,59 @@ describe('useResizable', () => {
     }
   })
 
+  test('commit-on-end keyboard resize resets the next mousemove origin', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const onDragPreview = vi.fn()
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      const { result } = renderHook(() =>
+        useResizable({
+          initial: 256,
+          min: 100,
+          max: 500,
+          updateMode: 'commit-on-end',
+          onDragPreview,
+        })
+      )
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 200,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 320 }))
+      })
+
+      act(() => {
+        result.current.adjustBy(50)
+      })
+
+      expect(result.current.size).toBe(426)
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 330 }))
+        document.dispatchEvent(new MouseEvent('mouseup'))
+      })
+
+      expect(result.current.size).toBe(436)
+      expect(onDragPreview).toHaveBeenCalledWith(436)
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
   test('mouseup flushes pending size before ending drag', () => {
     const requestAnimationFrameSpy = vi
       .spyOn(window, 'requestAnimationFrame')

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -179,6 +179,67 @@ describe('useResizable', () => {
     }
   })
 
+  test('commit-on-end mouseup restores preview when final size returns to committed size', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const onDragPreview = vi.fn()
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      const { result } = renderHook(() =>
+        useResizable({
+          initial: 256,
+          min: 100,
+          max: 500,
+          updateMode: 'commit-on-end',
+          onDragPreview,
+        })
+      )
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 200,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 320 }))
+      })
+
+      const callback = frameCallbacks[0]
+      if (!callback) {
+        throw new Error('Expected resize animation frame to be scheduled')
+      }
+
+      act(() => {
+        callback(16)
+      })
+
+      expect(onDragPreview).toHaveBeenLastCalledWith(376)
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200 }))
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mouseup'))
+      })
+
+      expect(result.current.size).toBe(256)
+      expect(onDragPreview).toHaveBeenLastCalledWith(256)
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
   test('commit-on-end preview uses latest preview callback before frame flush', () => {
     const frameCallbacks: FrameRequestCallback[] = []
     const firstOnDragPreview = vi.fn()

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -230,6 +230,27 @@ describe('useResizable', () => {
     }
   })
 
+  test('commit-on-end keyboard resize does not call onDragPreview', () => {
+    const onDragPreview = vi.fn()
+
+    const { result } = renderHook(() =>
+      useResizable({
+        initial: 256,
+        min: 100,
+        max: 500,
+        updateMode: 'commit-on-end',
+        onDragPreview,
+      })
+    )
+
+    act(() => {
+      result.current.adjustBy(50)
+    })
+
+    expect(result.current.size).toBe(306)
+    expect(onDragPreview).not.toHaveBeenCalled()
+  })
+
   test('mouseup flushes pending size before ending drag', () => {
     const requestAnimationFrameSpy = vi
       .spyOn(window, 'requestAnimationFrame')

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -179,6 +179,62 @@ describe('useResizable', () => {
     }
   })
 
+  test('commit-on-end preview uses latest preview callback before frame flush', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const firstOnDragPreview = vi.fn()
+    const secondOnDragPreview = vi.fn()
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      const { result, rerender } = renderHook(
+        ({ onDragPreview }) =>
+          useResizable({
+            initial: 256,
+            min: 100,
+            max: 500,
+            updateMode: 'commit-on-end',
+            onDragPreview,
+          }),
+        { initialProps: { onDragPreview: firstOnDragPreview } }
+      )
+
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: () => undefined,
+          clientX: 200,
+          clientY: 0,
+        } as React.MouseEvent)
+      })
+
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 320 }))
+      })
+
+      rerender({ onDragPreview: secondOnDragPreview })
+
+      const callback = frameCallbacks[0]
+      if (!callback) {
+        throw new Error('Expected resize animation frame to be scheduled')
+      }
+
+      act(() => {
+        callback(16)
+      })
+
+      expect(firstOnDragPreview).not.toHaveBeenCalled()
+      expect(secondOnDragPreview).toHaveBeenCalledWith(376)
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
   test('live mode does not call onDragPreview alongside state updates', () => {
     const frameCallbacks: FrameRequestCallback[] = []
     const onDragPreview = vi.fn()

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -90,10 +90,10 @@ export const useResizable = ({
   }, [])
 
   const commitSize = useCallback(
-    (nextSize: number): void => {
+    (nextSize: number, syncPreview = false): void => {
       sizeRef.current = nextSize
 
-      if (updateModeRef.current === 'commit-on-end') {
+      if (syncPreview && updateModeRef.current === 'commit-on-end') {
         preview(nextSize)
       }
 
@@ -196,7 +196,7 @@ export const useResizable = ({
       pendingSize.current = null
 
       if (finalSize !== null) {
-        commitSize(finalSize)
+        commitSize(finalSize, true)
       }
 
       setIsDragging(false)

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -177,6 +177,7 @@ export const useResizable = ({
   const handleMouseDown = useCallback(
     (e: React.MouseEvent): void => {
       e.preventDefault()
+      cancelPendingSize()
       const initialPos = direction === 'horizontal' ? e.clientX : e.clientY
       startPos.current = initialPos
       currentPos.current = initialPos
@@ -185,7 +186,7 @@ export const useResizable = ({
       isDraggingRef.current = true
       setIsDragging(true)
     },
-    [direction]
+    [cancelPendingSize, direction]
   )
 
   useEffect(() => {

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -72,8 +72,10 @@ export const useResizable = ({
   const previewSize = useRef(size)
   const updateModeRef = useRef(updateMode)
   const onDragPreviewRef = useRef(onDragPreview)
+  const isDraggingRef = useRef(false)
   const startPos = useRef(0)
   const startSize = useRef(0)
+  const currentPos = useRef(0)
   const pendingSize = useRef<number | null>(null)
   const animationFrameId = useRef<number | null>(null)
 
@@ -175,9 +177,12 @@ export const useResizable = ({
   const handleMouseDown = useCallback(
     (e: React.MouseEvent): void => {
       e.preventDefault()
-      startPos.current = direction === 'horizontal' ? e.clientX : e.clientY
+      const initialPos = direction === 'horizontal' ? e.clientX : e.clientY
+      startPos.current = initialPos
+      currentPos.current = initialPos
       startSize.current = sizeRef.current
       previewSize.current = sizeRef.current
+      isDraggingRef.current = true
       setIsDragging(true)
     },
     [direction]
@@ -189,8 +194,9 @@ export const useResizable = ({
     }
 
     const handleMouseMove = (e: MouseEvent): void => {
-      const currentPos = direction === 'horizontal' ? e.clientX : e.clientY
-      const rawDelta = currentPos - startPos.current
+      const nextCurrentPos = direction === 'horizontal' ? e.clientX : e.clientY
+      currentPos.current = nextCurrentPos
+      const rawDelta = nextCurrentPos - startPos.current
       const delta = invert ? -rawDelta : rawDelta
 
       scheduleSize(clampSize(startSize.current + delta, min, max))
@@ -211,6 +217,7 @@ export const useResizable = ({
         commitSize(finalSize, updateModeRef.current === 'commit-on-end')
       }
 
+      isDraggingRef.current = false
       setIsDragging(false)
     }
 
@@ -245,6 +252,11 @@ export const useResizable = ({
 
       if (updateModeRef.current === 'commit-on-end') {
         previewSize.current = nextSize
+      }
+
+      if (isDraggingRef.current) {
+        startPos.current = currentPos.current
+        startSize.current = nextSize
       }
     },
     [min, max, cancelPendingSize, commitSize]

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -33,6 +33,8 @@ export interface UseResizableOptions {
   /**
    * Receives coalesced preview sizes without requiring a React state update.
    * Useful for hot splitter drags that can update a CSS variable directly.
+   * Programmatic `adjustBy` calls intentionally skip this callback; callers
+   * should mirror committed keyboard resize through their normal render path.
    */
   onDragPreview?: (size: number) => void
 }

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -221,7 +221,13 @@ export const useResizable = ({
   const adjustBy = useCallback(
     (delta: number): void => {
       cancelPendingSize()
-      const nextSize = clampSize(sizeRef.current + delta, min, max)
+
+      const baseSize =
+        updateModeRef.current === 'commit-on-end'
+          ? previewSize.current
+          : sizeRef.current
+      const nextSize = clampSize(baseSize + delta, min, max)
+
       commitSize(nextSize)
 
       if (updateModeRef.current === 'commit-on-end') {

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -214,7 +214,10 @@ export const useResizable = ({
         (updateModeRef.current === 'commit-on-end' ? previewSize.current : null)
       pendingSize.current = null
 
-      if (finalSize !== null) {
+      if (
+        finalSize !== null &&
+        (finalSize !== sizeRef.current || finalSize !== previewSize.current)
+      ) {
         commitSize(finalSize, updateModeRef.current === 'commit-on-end')
       }
 

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -221,7 +221,12 @@ export const useResizable = ({
   const adjustBy = useCallback(
     (delta: number): void => {
       cancelPendingSize()
-      commitSize(clampSize(sizeRef.current + delta, min, max))
+      const nextSize = clampSize(sizeRef.current + delta, min, max)
+      commitSize(nextSize)
+
+      if (updateModeRef.current === 'commit-on-end') {
+        previewSize.current = nextSize
+      }
     },
     [min, max, cancelPendingSize, commitSize]
   )

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -6,7 +6,7 @@ import {
   useLayoutEffect,
 } from 'react'
 
-const clampSize = (value: number, min: number, max: number): number =>
+export const clampSize = (value: number, min: number, max: number): number =>
   Math.round(Math.min(max, Math.max(min, value)))
 
 export interface UseResizableOptions {
@@ -206,7 +206,7 @@ export const useResizable = ({
       pendingSize.current = null
 
       if (finalSize !== null) {
-        commitSize(finalSize, true)
+        commitSize(finalSize, updateModeRef.current === 'commit-on-end')
       }
 
       setIsDragging(false)

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -33,6 +33,8 @@ export interface UseResizableOptions {
   /**
    * Receives coalesced preview sizes without requiring a React state update.
    * Useful for hot splitter drags that can update a CSS variable directly.
+   * Only called in `commit-on-end` mode; `live` mode commits React state
+   * instead and intentionally ignores this callback.
    * Programmatic `adjustBy` calls intentionally skip this callback; callers
    * should mirror committed keyboard resize through their normal render path.
    */
@@ -230,12 +232,13 @@ export const useResizable = ({
 
   const adjustBy = useCallback(
     (delta: number): void => {
+      const baseSize =
+        pendingSize.current ??
+        (updateModeRef.current === 'commit-on-end'
+          ? previewSize.current
+          : sizeRef.current)
       cancelPendingSize()
 
-      const baseSize =
-        updateModeRef.current === 'commit-on-end'
-          ? previewSize.current
-          : sizeRef.current
       const nextSize = clampSize(baseSize + delta, min, max)
 
       commitSize(nextSize)

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -1,5 +1,8 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 
+const clampSize = (value: number, min: number, max: number): number =>
+  Math.round(Math.min(max, Math.max(min, value)))
+
 export interface UseResizableOptions {
   initial: number
   min: number
@@ -13,6 +16,19 @@ export interface UseResizableOptions {
    * the panel, not shrink it.
    */
   invert?: boolean
+  /**
+   * Controls when drag updates are committed to React state.
+   *
+   * - `live` keeps the previous behavior: one state update per animation frame.
+   * - `commit-on-end` sends frame-coalesced preview sizes to `onDragPreview`
+   *   during drag, then commits React state once on mouseup.
+   */
+  updateMode?: 'live' | 'commit-on-end'
+  /**
+   * Receives coalesced preview sizes without requiring a React state update.
+   * Useful for hot splitter drags that can update a CSS variable directly.
+   */
+  onDragPreview?: (size: number) => void
 }
 
 export interface UseResizableResult {
@@ -34,25 +50,122 @@ export const useResizable = ({
   max,
   direction = 'horizontal',
   invert = false,
+  updateMode = 'live',
+  onDragPreview = undefined,
 }: UseResizableOptions): UseResizableResult => {
   // Clamp `initial` on mount so an out-of-range default doesn't briefly
   // surface (in ARIA attributes, in the rendered size) before the first
   // drag triggers the mousemove handler's clamp.
-  const [size, setSize] = useState(() =>
-    Math.round(Math.min(max, Math.max(min, initial)))
-  )
+  const [size, setSize] = useState(() => clampSize(initial, min, max))
   const [isDragging, setIsDragging] = useState(false)
+  const sizeRef = useRef(size)
+  const previewSize = useRef(size)
+  const updateModeRef = useRef(updateMode)
+  const onDragPreviewRef = useRef(onDragPreview)
   const startPos = useRef(0)
   const startSize = useRef(0)
+  const pendingSize = useRef<number | null>(null)
+  const animationFrameId = useRef<number | null>(null)
+
+  useEffect(() => {
+    sizeRef.current = size
+    previewSize.current = size
+  }, [size])
+
+  useEffect(() => {
+    updateModeRef.current = updateMode
+  }, [updateMode])
+
+  useEffect(() => {
+    onDragPreviewRef.current = onDragPreview
+  }, [onDragPreview])
+
+  const preview = useCallback((nextSize: number): void => {
+    if (previewSize.current === nextSize) {
+      return
+    }
+
+    previewSize.current = nextSize
+    onDragPreviewRef.current?.(nextSize)
+  }, [])
+
+  const commitSize = useCallback(
+    (nextSize: number): void => {
+      sizeRef.current = nextSize
+      preview(nextSize)
+
+      setSize((currentSize) => {
+        if (currentSize === nextSize) {
+          return currentSize
+        }
+
+        return nextSize
+      })
+    },
+    [preview]
+  )
+
+  const flushPendingSize = useCallback((): void => {
+    const nextSize = pendingSize.current
+    pendingSize.current = null
+    animationFrameId.current = null
+
+    if (nextSize === null) {
+      return
+    }
+
+    if (updateModeRef.current === 'commit-on-end') {
+      preview(nextSize)
+
+      return
+    }
+
+    commitSize(nextSize)
+  }, [commitSize, preview])
+
+  const cancelPendingSize = useCallback((): void => {
+    if (animationFrameId.current !== null) {
+      window.cancelAnimationFrame(animationFrameId.current)
+      animationFrameId.current = null
+    }
+
+    pendingSize.current = null
+  }, [])
+
+  const scheduleSize = useCallback(
+    (nextSize: number): void => {
+      const currentSize =
+        updateModeRef.current === 'commit-on-end'
+          ? previewSize.current
+          : sizeRef.current
+
+      if (
+        nextSize === pendingSize.current ||
+        (pendingSize.current === null && nextSize === currentSize)
+      ) {
+        return
+      }
+
+      pendingSize.current = nextSize
+
+      if (animationFrameId.current !== null) {
+        return
+      }
+
+      animationFrameId.current = window.requestAnimationFrame(flushPendingSize)
+    },
+    [flushPendingSize]
+  )
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent): void => {
       e.preventDefault()
       startPos.current = direction === 'horizontal' ? e.clientX : e.clientY
-      startSize.current = size
+      startSize.current = sizeRef.current
+      previewSize.current = sizeRef.current
       setIsDragging(true)
     },
-    [size, direction]
+    [direction]
   )
 
   useEffect(() => {
@@ -65,13 +178,24 @@ export const useResizable = ({
       const rawDelta = currentPos - startPos.current
       const delta = invert ? -rawDelta : rawDelta
 
-      const newSize = Math.round(
-        Math.min(max, Math.max(min, startSize.current + delta))
-      )
-      setSize(newSize)
+      scheduleSize(clampSize(startSize.current + delta, min, max))
     }
 
     const handleMouseUp = (): void => {
+      if (animationFrameId.current !== null) {
+        window.cancelAnimationFrame(animationFrameId.current)
+        animationFrameId.current = null
+      }
+
+      const finalSize =
+        pendingSize.current ??
+        (updateModeRef.current === 'commit-on-end' ? previewSize.current : null)
+      pendingSize.current = null
+
+      if (finalSize !== null) {
+        commitSize(finalSize)
+      }
+
       setIsDragging(false)
     }
 
@@ -82,15 +206,30 @@ export const useResizable = ({
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
     }
-  }, [isDragging, min, max, direction, invert])
+  }, [
+    isDragging,
+    min,
+    max,
+    direction,
+    invert,
+    commitSize,
+    flushPendingSize,
+    scheduleSize,
+  ])
+
+  useEffect(
+    () => (): void => {
+      cancelPendingSize()
+    },
+    [cancelPendingSize]
+  )
 
   const adjustBy = useCallback(
     (delta: number): void => {
-      setSize((current) =>
-        Math.round(Math.min(max, Math.max(min, current + delta)))
-      )
+      cancelPendingSize()
+      commitSize(clampSize(sizeRef.current + delta, min, max))
     },
-    [min, max]
+    [min, max, cancelPendingSize, commitSize]
   )
 
   return { size, isDragging, handleMouseDown, adjustBy }

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -92,7 +92,10 @@ export const useResizable = ({
   const commitSize = useCallback(
     (nextSize: number): void => {
       sizeRef.current = nextSize
-      preview(nextSize)
+
+      if (updateModeRef.current === 'commit-on-end') {
+        preview(nextSize)
+      }
 
       setSize((currentSize) => {
         if (currentSize === nextSize) {

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -206,16 +206,7 @@ export const useResizable = ({
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
     }
-  }, [
-    isDragging,
-    min,
-    max,
-    direction,
-    invert,
-    commitSize,
-    flushPendingSize,
-    scheduleSize,
-  ])
+  }, [isDragging, min, max, direction, invert, commitSize, scheduleSize])
 
   useEffect(
     () => (): void => {

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -1,4 +1,10 @@
-import { useState, useCallback, useRef, useEffect } from 'react'
+import {
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+} from 'react'
 
 const clampSize = (value: number, min: number, max: number): number =>
   Math.round(Math.min(max, Math.max(min, value)))
@@ -67,16 +73,15 @@ export const useResizable = ({
   const pendingSize = useRef<number | null>(null)
   const animationFrameId = useRef<number | null>(null)
 
-  useEffect(() => {
-    sizeRef.current = size
+  useLayoutEffect(() => {
     previewSize.current = size
   }, [size])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     updateModeRef.current = updateMode
   }, [updateMode])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     onDragPreviewRef.current = onDragPreview
   }, [onDragPreview])
 
@@ -91,10 +96,13 @@ export const useResizable = ({
 
   const commitSize = useCallback(
     (nextSize: number, syncPreview = false): void => {
+      // RAF and keyboard paths read sizeRef before React effects run.
       sizeRef.current = nextSize
 
       if (syncPreview && updateModeRef.current === 'commit-on-end') {
         preview(nextSize)
+      } else if (updateModeRef.current !== 'commit-on-end') {
+        previewSize.current = nextSize
       }
 
       setSize((currentSize) => {

--- a/tests/e2e/core/specs/files-to-editor.spec.ts
+++ b/tests/e2e/core/specs/files-to-editor.spec.ts
@@ -31,14 +31,28 @@ describe('File explorer → editor flow', () => {
     const explorer = await $('[data-testid="file-explorer"]')
     await explorer.waitForDisplayed({ timeout: 15_000 })
 
+    const refreshButton = await $('[aria-label="Refresh file tree"]')
+    await refreshButton.waitForDisplayed({ timeout: 15_000 })
+    await refreshButton.click()
+
     await browser.waitUntil(
       async () => {
-        const count = await browser.execute(
-          () => document.querySelectorAll('[role="treeitem"]').length
-        )
-        return count > 0
+        return browser.execute((name: string) => {
+          const items = Array.from(
+            document.querySelectorAll<HTMLElement>('[role="treeitem"]')
+          )
+
+          return items.some(
+            (el) =>
+              !el.hasAttribute('aria-expanded') &&
+              (el.textContent ?? '').includes(name)
+          )
+        }, FIXTURE_NAME)
       },
-      { timeout: 15_000, timeoutMsg: 'file tree never populated' }
+      {
+        timeout: 15_000,
+        timeoutMsg: `fixture ${FIXTURE_NAME} never appeared in the refreshed file tree`,
+      }
     )
 
     // Click our fixture file specifically. Falls back to an error if the


### PR DESCRIPTION
Fixes #196

## Summary

- Add RAF coalescing to `useResizable` and a commit-on-end mode so sidebar drags can preview width without re-rendering the workspace on every mousemove.
- Drive the workspace sidebar width through a CSS custom property during drag, then commit React state once at drag end.
- Defer xterm fitting during sidebar drags, RAF-throttle ResizeObserver fitting, and skip duplicate PTY resize IPC when terminal dimensions do not change.
- Update the Tauri build workflow to call the repo package script, `npm run tauri:build -- --ci`, on Ubuntu so CI uses the same `NO_STRIP=1` AppImage path that passes locally; macOS and Windows keep the direct Tauri invocation but also pass `--ci` to suppress unattended prompts.

## Root Cause

Sidebar resizing was pushing every mousemove through React state, CSS grid layout, xterm `fitAddon.fit()`, canvas repaint, and PTY resize IPC. That hot path is especially visible in Linux production builds where the WebKitGTK/AppImage rendering path has less headroom than dev browser rendering.

## Test Plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run type-check`
- [x] `npm test`
- [x] `npm run build`
- [x] `cargo test` from `src-tauri/`
- [x] Regenerated bindings and verified `src/bindings/` has no diff or untracked files
- [x] `npm run tauri:build -- --ci`
- [x] Branch CI green: code quality, unit tests, Rust tests, and TypeScript bindings verification

## Notes

A raw local `npx tauri build --ci` still fails at AppImage bundling with `failed to run linuxdeploy`. The package script path succeeds because it sets the repo's Linux bundling environment before invoking Tauri.

The non-Ubuntu workflow step intentionally uses `npx tauri build --ci`: current macOS/Windows CI does not configure signing or notarization credentials, so the flag is used to prevent interactive prompts in unattended runners. If release signing is added later, revisit that step so signing behavior is explicit.
