### PR TITLE
[codex] Preserve agent status layout

### DIFF
--- a/src/features/agent-status/components/ActivityFeed.tsx
+++ b/src/features/agent-status/components/ActivityFeed.tsx
@@ -31,10 +31,13 @@ export const ActivityFeed = ({ events }: ActivityFeedProps): ReactElement => {
   // session's 10+ events would surface `Show less` on first render.
   const hasRunning = events.some((e) => e.status === 'running')
   useEffect(() => {
-    setNow(new Date())
     if (events.length === 0) {
       setShowAll(false)
+
+      return
     }
+
+    setNow(new Date())
   }, [events])
 
   // Effect 2: own the 1s tick's lifecycle — start it only while a

--- a/src/features/agent-status/components/AgentStatusPanel.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.test.tsx
@@ -90,12 +90,12 @@ const defaultProps = {
 }
 
 describe('AgentStatusPanel', () => {
-  test('renders at 0px width when agent is not active', () => {
+  test('renders at 280px width when agent is not active', () => {
     render(
       <AgentStatusPanel {...defaultProps} agentStatus={inactiveAgentStatus} />
     )
     const panel = screen.getByTestId('agent-status-panel')
-    expect(panel.style.width).toBe('0px')
+    expect(panel.style.width).toBe('280px')
   })
 
   test('renders at 280px width when agent is active', () => {
@@ -106,23 +106,18 @@ describe('AgentStatusPanel', () => {
     expect(panel.style.width).toBe('280px')
   })
 
-  test('applies ease-out transition when collapsing', () => {
+  test('keeps inactive context and cache placeholders mounted', () => {
     render(
       <AgentStatusPanel {...defaultProps} agentStatus={inactiveAgentStatus} />
     )
-    const panel = screen.getByTestId('agent-status-panel')
-    expect(panel.style.transition).toBe('width 200ms ease-out')
+
+    expect(screen.getByText(/CURRENT CONTEXT/)).toBeInTheDocument()
+    expect(screen.getByTestId('context-percentage')).toHaveTextContent('\u2014')
+    expect(screen.getByText(/no data yet/i)).toBeInTheDocument()
+    expect(screen.getByText(/No activity yet/i)).toBeInTheDocument()
   })
 
-  test('applies ease-in transition when expanding', () => {
-    render(
-      <AgentStatusPanel {...defaultProps} agentStatus={activeAgentStatus} />
-    )
-    const panel = screen.getByTestId('agent-status-panel')
-    expect(panel.style.transition).toBe('width 200ms ease-in')
-  })
-
-  test('has overflow-hidden to clip content during collapse', () => {
+  test('has overflow-hidden to clip content inside the fixed panel', () => {
     render(
       <AgentStatusPanel {...defaultProps} agentStatus={inactiveAgentStatus} />
     )

--- a/src/features/agent-status/components/AgentStatusPanel.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.tsx
@@ -23,6 +23,9 @@ interface AgentStatusPanelProps {
   gitStatus?: UseGitStatusReturn
 }
 
+const PANEL_WIDTH_PX = 280
+const DEFAULT_CONTEXT_WINDOW_SIZE = 200_000
+
 export const AgentStatusPanel = ({
   agentStatus,
   cwd,
@@ -60,52 +63,46 @@ export const AgentStatusPanel = ({
   return (
     <div
       data-testid="agent-status-panel"
-      className="flex h-full flex-col overflow-hidden bg-surface-container"
+      className="flex h-full shrink-0 flex-col overflow-hidden bg-surface-container"
       style={{
-        width: status.isActive ? '280px' : '0px',
-        transition: status.isActive
-          ? 'width 200ms ease-in'
-          : 'width 200ms ease-out',
+        width: `${PANEL_WIDTH_PX}px`,
       }}
     >
-      {status.isActive && status.agentType ? (
-        <>
-          <div className="flex flex-col gap-2 p-2">
-            <ContextBucket
-              usedPercentage={status.contextWindow?.usedPercentage ?? null}
-              contextWindowSize={
-                status.contextWindow?.contextWindowSize ?? 200_000
-              }
-              totalInputTokens={status.contextWindow?.totalInputTokens ?? 0}
-              totalOutputTokens={status.contextWindow?.totalOutputTokens ?? 0}
-            />
-            <TokenCache usage={status.contextWindow?.currentUsage ?? null} />
-          </div>
+      <div className="flex flex-col gap-2 p-2">
+        <ContextBucket
+          usedPercentage={status.contextWindow?.usedPercentage ?? null}
+          contextWindowSize={
+            status.contextWindow?.contextWindowSize ??
+            DEFAULT_CONTEXT_WINDOW_SIZE
+          }
+          totalInputTokens={status.contextWindow?.totalInputTokens ?? 0}
+          totalOutputTokens={status.contextWindow?.totalOutputTokens ?? 0}
+        />
+        <TokenCache usage={status.contextWindow?.currentUsage ?? null} />
+      </div>
 
-          <div className="thin-scrollbar min-h-0 flex-1 overflow-y-auto overflow-x-clip">
-            <ToolCallSummary
-              total={status.toolCalls.total}
-              byType={status.toolCalls.byType}
-              active={status.toolCalls.active}
-            />
-            <ActivityFeed events={events} />
-            <FilesChanged
-              files={effectiveFiles}
-              loading={effectiveLoading}
-              error={error}
-              onRetry={refresh}
-              onSelect={onOpenDiff}
-            />
-            <TestResults snapshot={status.testRun} onOpenFile={onOpenFile} />
-          </div>
-          <ActivityFooter
-            totalDurationMs={status.cost?.totalDurationMs ?? 0}
-            numTurns={status.numTurns}
-            linesAdded={lineTotals.added}
-            linesRemoved={lineTotals.removed}
-          />
-        </>
-      ) : null}
+      <div className="thin-scrollbar min-h-0 flex-1 overflow-y-auto overflow-x-clip">
+        <ToolCallSummary
+          total={status.toolCalls.total}
+          byType={status.toolCalls.byType}
+          active={status.toolCalls.active}
+        />
+        <ActivityFeed events={events} />
+        <FilesChanged
+          files={effectiveFiles}
+          loading={effectiveLoading}
+          error={error}
+          onRetry={refresh}
+          onSelect={onOpenDiff}
+        />
+        <TestResults snapshot={status.testRun} onOpenFile={onOpenFile} />
+      </div>
+      <ActivityFooter
+        totalDurationMs={status.cost?.totalDurationMs ?? 0}
+        numTurns={status.numTurns}
+        linesAdded={lineTotals.added}
+        linesRemoved={lineTotals.removed}
+      />
     </div>
   )
 }

--- a/src/features/workspace/components/SidebarStatusHeader.test.tsx
+++ b/src/features/workspace/components/SidebarStatusHeader.test.tsx
@@ -63,6 +63,19 @@ describe('SidebarStatusHeader', () => {
     expect(screen.getByText('Idle')).toBeInTheDocument()
   })
 
+  test('keeps the idle placeholder at the live card height', () => {
+    render(
+      <SidebarStatusHeader
+        status={inactiveStatus}
+        activeSessionName="my session"
+      />
+    )
+
+    expect(screen.getByTestId('sidebar-status-header-idle')).toHaveClass(
+      'min-h-44'
+    )
+  })
+
   test('falls back to "No session" when there is no active session', () => {
     render(
       <SidebarStatusHeader status={inactiveStatus} activeSessionName={null} />

--- a/src/features/workspace/components/SidebarStatusHeader.tsx
+++ b/src/features/workspace/components/SidebarStatusHeader.tsx
@@ -57,7 +57,7 @@ export const SidebarStatusHeader = ({
   return (
     <div
       data-testid="sidebar-status-header-idle"
-      className="flex flex-col gap-3 rounded-xl bg-surface-container-high p-3"
+      className="flex min-h-44 flex-col gap-3 rounded-xl bg-surface-container-high p-3"
     >
       <div className="flex items-center gap-2.5">
         <div className="h-8 w-8 shrink-0 rounded-lg bg-gradient-to-br from-primary-container to-secondary" />


### PR DESCRIPTION
## Summary

- Keep the right `AgentStatusPanel` reserved at 280px for both shell and agent terminals instead of collapsing when no agent is detected.
- Keep the context bucket, token cache, activity feed, files changed, tests, and footer mounted with inactive placeholder values so the context area can be filled later without layout shifts.
- Give the left sidebar idle status header the same `min-h-44` footprint as the live `StatusCard`.
- Avoid a redundant empty-feed timestamp update now that the activity feed can stay mounted during shell sessions.

## Root Cause

The right activity panel width and content tree were gated on `agentStatus.isActive && agentType`, so normal shell sessions collapsed the panel to 0px. The sidebar idle placeholder also lacked the live status card's minimum height, so switching between agent and shell terminals changed the left header size.

## Test Plan

- [x] `npm test -- --run src/features/agent-status/components/ActivityFeed.test.tsx src/features/agent-status/components/AgentStatusPanel.test.tsx src/features/workspace/components/SidebarStatusHeader.test.tsx` — 31 passed
- [x] `npm test -- --run src/features/workspace/WorkspaceView.test.tsx src/features/workspace/WorkspaceView.visual.test.tsx src/features/workspace/WorkspaceView.verification.test.tsx src/features/workspace/WorkspaceView.integration.test.tsx` — 101 passed
- [x] `npm run type-check` — clean
- [x] `npx eslint src/features/agent-status/components/ActivityFeed.tsx src/features/agent-status/components/AgentStatusPanel.tsx src/features/agent-status/components/AgentStatusPanel.test.tsx src/features/workspace/components/SidebarStatusHeader.tsx src/features/workspace/components/SidebarStatusHeader.test.tsx` — clean
- [x] `npx prettier --check src/features/agent-status/components/ActivityFeed.tsx src/features/agent-status/components/AgentStatusPanel.tsx src/features/agent-status/components/AgentStatusPanel.test.tsx src/features/workspace/components/SidebarStatusHeader.tsx src/features/workspace/components/SidebarStatusHeader.test.tsx` — clean
- [x] `git diff --check` — clean
- [x] Pre-push hook: `npm test` — 2088 passed / 3 skipped

## Notes

The broader workspace and pre-push test runs still print existing jsdom/React `act(...)` and CodeMirror measurement warnings, but all tests pass.