### PR TITLE
feat(frontend): PR-C — frontend backend bridge (renderer migration)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,7 +43,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 4        | 3    | 2026-05-07   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 5        | 0    | 2026-05-09   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 2        | 0    | 2026-05-04   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 49       | 22   | 2026-05-12   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 50       | 23   | 2026-05-14   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 55       | 19   | 2026-05-09   |
 | [Accessibility](patterns/accessibility.md)                           | a11y           | 25       | 6    | 2026-05-09   |

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-05-12
-ref_count: 22
+last_updated: 2026-05-14
+ref_count: 23
 ---
 
 # Testing Gaps
@@ -489,3 +489,12 @@ filesystem scope restrictions).
 - **Finding:** `readPaneBuffer` in `src/lib/e2e-bridge.ts` gained a new focused-wrapper-first lookup path in PR #199 cycle 2 (for multi-pane disambiguation), but the module had no co-located test file. Component-level tests verified that `data-focused="true"` is correctly set on the active pane's wrapper, but nothing tested that `readPaneBuffer` itself scopes its `.xterm-rows` query to the focused wrapper. If `data-focused` is transiently absent (between a `pane.active` flip and the next React commit), the fallback queries the whole subtree and returns the first `.xterm-rows` — potentially the wrong pane's buffer — and any E2E spec asserting agent output could pass on stale data. The module had been an exception to the project's co-located-test rule because it's gated by `if (import.meta.env.VITE_E2E)` at the bottom, but the read functions themselves are pure DOM helpers and trivially testable in jsdom.
 - **Fix:** Exported `readPaneBuffer` (small comment notes it's for unit-testing — production goes through `readVisibleTerminalBuffer` / `readTerminalBufferForSession`). Created `src/lib/e2e-bridge.test.ts` with a `buildSessionWrapper(paneTexts, activeIndex)` helper that builds the post-5b DOM shape via `document.createElement`, then 5 tests covering: multi-pane focused-buffer selection, single-pane fallback, defensive no-`data-focused` fallback to first-in-DOM, empty-string when no `.xterm-rows`, and the pty-id-lookup path (called with a `split-view-slot` directly). Code-review heuristic: VITE_E2E-gated entry-point doesn't excuse the unit-testable PURE-FUNCTION helpers below it — extract and test them.
 - **Commit:** _(see git log for the cycle-5 fix commit on PR #199)_
+
+### 49. Duplicate test name claimed runtime-signal coverage while the mock bypassed it
+
+- **Source:** github-claude | PR #208 round 1 | 2026-05-14
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/services/gitService.test.ts`
+- **Finding:** The factory test named `returns TauriGitService when isDesktop() is true (via vimeflow)` was byte-for-byte identical to the preceding `isDesktop() is true` test. Because the suite mocked `isDesktop`, the test never set `window.vimeflow` and never exercised the real OR-detection branch it claimed to cover.
+- **Fix:** Removed the duplicate factory test and kept the actual `window.vimeflow` signal coverage in `src/lib/environment.test.ts`. Code-review heuristic: when a test name includes a specific runtime signal ("via vimeflow", "via Tauri", "via env"), the body must manipulate that signal or call the real helper that observes it; otherwise the test is only duplicate branch coverage with a misleading title.
+- **Commit:** _(see git log for the PR #208 round-1 fix commit)_

--- a/docs/superpowers/plans/2026-05-14-pr-c-frontend-backend-bridge.md
+++ b/docs/superpowers/plans/2026-05-14-pr-c-frontend-backend-bridge.md
@@ -1,0 +1,1935 @@
+# PR-C — Frontend backend bridge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decouple the React renderer from `@tauri-apps/api` by adding `src/lib/backend.ts` (the runtime-neutral IPC seam) + `src/types/vimeflow.d.ts` (the `Window.vimeflow` global), then migrate the 7 renderer files that currently import `@tauri-apps/api` directly onto the bridge. Tauri remains the live host through end of PR-C; the bridge falls back to `@tauri-apps/api` when `window.vimeflow` isn't set, so the renderer behaves identically pre- and post-PR.
+
+**Architecture:** Layered bridge — `invoke` / `listen` check `window.vimeflow` at call-time and delegate to it if present (PR-D target); otherwise they fall back to `@tauri-apps/api/core` (`invoke`) + `@tauri-apps/api/event` (`listen`) and unwrap `Event<T>.payload` so consumers always see the bare-payload shape PR-D ships natively. The bridge wraps the transport's unlisten function in a `called` guard so `UnlistenFn` is idempotent across both paths (load-bearing for React 18 StrictMode dev-mode double-cleanup). PR-D's bridge edit is a 4-to-6-line delete of the `@tauri-apps` imports and the fallback branches.
+
+**Tech Stack:** TypeScript 5.9, React 19, Vitest 3, jsdom, `@tauri-apps/api` (transitional through PR-C; removed in PR-D).
+
+**Spec:** `docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md`
+
+**Migration roadmap:** `docs/superpowers/plans/2026-05-13-electron-rust-backend-migration.md` (the 4-PR index). This plan implements a strict subset of Tasks 2 + 8 + 9 of that roadmap (see spec §1 "Roadmap context" for the cut list).
+
+---
+
+## File Structure
+
+### New (3 files)
+
+- `src/lib/backend.ts` — defines `BackendApi`, `UnlistenFn`, and the module-level `invoke` + `listen` functions. Layered: prefers `window.vimeflow`, falls back to `@tauri-apps/api`.
+- `src/lib/backend.test.ts` — Vitest unit tests; 12 cases across two `describe` blocks (window.vimeflow path × 6, Tauri fallback path × 6).
+- `src/types/vimeflow.d.ts` — ambient declaration of `Window.vimeflow?: BackendApi`. Single owner.
+
+### Modified (16 files)
+
+- `src/lib/environment.ts` — `isTauri` → `isDesktop` (OR-detection: `__TAURI_INTERNALS__ != null || window.vimeflow != null`); `getEnvironment` returns `'desktop' | 'browser'`.
+- `src/lib/environment.test.ts` — rename existing cases + add 4 new cases for the Electron-signal semantics.
+- `src/lib/e2e-bridge.ts` — single `invoke` import flips.
+- `src/features/terminal/services/terminalService.ts` — factory line 388: `isTauri()` → `isDesktop()`.
+- `src/features/terminal/services/tauriTerminalService.ts` — imports flip; 3 `listen` callbacks refactor `event.payload` → bare payload.
+- `src/features/terminal/services/tauriTerminalService.test.ts` — mocks flip; payload-shape assertions simplify.
+- `src/features/files/services/fileSystemService.ts` — drop 3 dynamic imports; static top-level `import { invoke } from '../../../lib/backend'`; factory line 110: `isTauri()` → `isDesktop()`.
+- `src/features/files/services/fileSystemService.test.ts` — mock flip.
+- `src/features/diff/services/gitService.ts` — factory line 180: `'__TAURI_INTERNALS__' in window` → `isDesktop()`. `TauriGitService` imports flip.
+- `src/features/diff/services/gitService.test.ts` — `__TAURI_INTERNALS__` direct manipulation rewritten to `vi.mock(environment).mockReturnValue` with `MODE` override preserved.
+- `src/features/diff/hooks/useGitBranch.ts` — single `invoke` import flip.
+- `src/features/diff/hooks/useGitBranch.test.ts` — mock flip.
+- `src/features/diff/hooks/useGitStatus.ts` — `invoke` + `listen` + `UnlistenFn` imports flip; 1 listen callback refactor.
+- `src/features/diff/hooks/useGitStatus.test.ts` — mock flip; synthetic Event<T> assertions simplify to bare-payload.
+- `src/features/agent-status/hooks/useAgentStatus.ts` — `invoke` + `listen` imports flip; 4 listen callbacks refactor.
+- `src/features/agent-status/hooks/useAgentStatus.test.ts` — mock flip; 4 places' synthetic Event<T> assertions simplify.
+
+### Files NOT touched
+
+- `src-tauri/**` — Rust runtime locked by PR-A/B.
+- `electron/**` — does not exist; PR-D creates it.
+- `tests/e2e/**` — driver swap stays in PR-D.
+- `src/bindings/**` — no Rust IPC shape changes.
+- `package.json` — `@tauri-apps/api` stays through PR-C.
+- `vite.config.ts` — no plugin / alias / `base` changes.
+- `eslint.config.ts` — no-restricted-imports rule deferred to PR-D (spec §8.1).
+
+---
+
+## Task 0: Baseline Verification
+
+**Files:** none.
+
+- [ ] **Step 1: Confirm working tree is clean and on a PR-C branch**
+
+```bash
+cd /home/will/projects/vimeflow
+git status
+git branch --show-current
+```
+
+Expected: `nothing to commit, working tree clean`. Branch: `dev` (or `feat/pr-c-frontend-backend-bridge` if a feature branch is preferred — create it BEFORE Task 1 via `git checkout -b feat/pr-c-frontend-backend-bridge`).
+
+- [ ] **Step 2: Confirm TS tests + type-check + lint + format are green**
+
+```bash
+npm run test
+npm run type-check
+npm run lint
+npm run format:check
+```
+
+Expected: all green. Record the Vitest test count for comparison in Task 10 (the PR adds ~16 new bridge/environment tests; total should climb by that amount).
+
+- [ ] **Step 3: Confirm Rust tests are green (smoke; Rust unchanged in PR-C)**
+
+```bash
+(cd src-tauri && cargo test)
+```
+
+Expected: all green. PR-C does not touch `src-tauri/**`, so the count must match the post-PR-B baseline byte-for-byte.
+
+- [ ] **Step 4: Inventory current `@tauri-apps/api` coupling**
+
+```bash
+rg -nE "@tauri-apps/api|__TAURI_INTERNALS__" src tests > /tmp/pr-c-baseline.txt
+wc -l /tmp/pr-c-baseline.txt
+```
+
+Expected: hits in 12 files — `e2e-bridge.ts`, `environment.ts`, `environment.test.ts`, `fileSystemService.ts`, `useAgentStatus.ts` (+`.test.ts`), `gitService.ts` (+`.test.ts`), `useGitStatus.ts` (+`.test.ts`), `useGitBranch.ts` (+`.test.ts`), `tauriTerminalService.ts` (+`.test.ts`). Save for Task 10's diff comparison.
+
+- [ ] **Step 5: Smoke-check the Tauri host before any change**
+
+```bash
+npm run tauri:dev
+```
+
+Open the app, confirm: default terminal spawns, file explorer lists, git diff panel shows status, Cmd/Ctrl+Q closes cleanly. Kill the dev server. This is the "renderer cannot tell the difference" baseline.
+
+---
+
+## Task 1: Create `src/lib/backend.ts` + `vimeflow.d.ts` + tests
+
+**Files:**
+
+- Create: `src/lib/backend.ts`
+- Create: `src/lib/backend.test.ts`
+- Create: `src/types/vimeflow.d.ts`
+
+This task implements the bridge from spec §4.1-4.3. TDD: write the failing tests first, watch them fail, then implement.
+
+- [ ] **Step 1: Create the ambient `Window.vimeflow` declaration**
+
+Create `src/types/vimeflow.d.ts`:
+
+```ts
+import type { BackendApi } from '../lib/backend'
+
+declare global {
+  interface Window {
+    /**
+     * Electron preload's contextBridge exposes the backend API here
+     * starting in PR-D. Undefined during PR-C — the bridge in
+     * `src/lib/backend.ts` falls back to `@tauri-apps/api` in that
+     * case. Tests fabricate this object to exercise the
+     * production-target code path.
+     */
+    vimeflow?: BackendApi
+  }
+}
+
+export {}
+```
+
+The trailing `export {}` makes the file a module so `import type` is legal.
+
+- [ ] **Step 2: Verify `tsconfig.json` includes `src/types/**`\*\*
+
+```bash
+grep -nE '"include"|"src/types"' tsconfig.json tsconfig.app.json 2>/dev/null
+```
+
+Expected: `src` is included by `tsconfig.app.json` (or whichever app-level config Vite uses), which covers `src/types/**` transitively. If not, the new ambient declaration won't load — add `"src/types/**/*.d.ts"` to the `"include"` array of the app-level tsconfig.
+
+- [ ] **Step 3: Write the failing tests in `src/lib/backend.test.ts`**
+
+```ts
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { invoke, listen, type BackendApi } from './backend'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}))
+
+// Import the mocked symbols AFTER vi.mock so they're the spies.
+import { invoke as tauriInvoke } from '@tauri-apps/api/core'
+import { listen as tauriListen } from '@tauri-apps/api/event'
+
+const mockedTauriInvoke = vi.mocked(tauriInvoke)
+const mockedTauriListen = vi.mocked(tauriListen)
+
+describe('backend (window.vimeflow path)', () => {
+  let mockInvoke: ReturnType<typeof vi.fn>
+  let mockListen: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockedTauriInvoke.mockReset()
+    mockedTauriListen.mockReset()
+    mockInvoke = vi.fn()
+    mockListen = vi.fn()
+    ;(window as Window).vimeflow = {
+      invoke: mockInvoke,
+      listen: mockListen,
+    } as unknown as BackendApi
+  })
+
+  afterEach(() => {
+    delete (window as Window).vimeflow
+  })
+
+  test('invoke delegates to window.vimeflow.invoke with same args', async () => {
+    mockInvoke.mockResolvedValueOnce({ id: 'abc' })
+
+    const result = await invoke<{ id: string }>('spawn_pty', {
+      sessionId: 's1',
+    })
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    expect(mockInvoke).toHaveBeenCalledWith('spawn_pty', { sessionId: 's1' })
+    expect(result).toEqual({ id: 'abc' })
+    expect(mockedTauriInvoke).not.toHaveBeenCalled()
+  })
+
+  test('invoke rejection passes through unchanged', async () => {
+    mockInvoke.mockRejectedValueOnce('sidecar error')
+
+    await expect(invoke('git_status', { cwd: '/x' })).rejects.toBe(
+      'sidecar error'
+    )
+  })
+
+  test('listen delegates to window.vimeflow.listen', async () => {
+    const rawUnlisten = vi.fn()
+    mockListen.mockResolvedValueOnce(rawUnlisten)
+
+    const unlisten = await listen<{ a: number }>('agent-status', () => {})
+
+    expect(mockListen).toHaveBeenCalledTimes(1)
+    expect(mockListen).toHaveBeenCalledWith(
+      'agent-status',
+      expect.any(Function)
+    )
+    expect(typeof unlisten).toBe('function')
+    // Bridge wraps with a `called` guard, so identity check would fail —
+    // assert behavior instead in cases #5 and #6.
+  })
+
+  test('listen callback receives bare payload', async () => {
+    mockListen.mockImplementationOnce(async (_event, cb) => {
+      cb({ sessionId: 's1', data: 'hi' })
+      return vi.fn()
+    })
+    const cb = vi.fn()
+
+    await listen<{ sessionId: string; data: string }>('pty-data', cb)
+
+    expect(cb).toHaveBeenCalledWith({ sessionId: 's1', data: 'hi' })
+  })
+
+  test('listen resolves only after window.vimeflow.listen resolves', async () => {
+    let resolveTransport!: (unlisten: () => void) => void
+    mockListen.mockReturnValueOnce(
+      new Promise<() => void>((res) => {
+        resolveTransport = res
+      })
+    )
+
+    const bridgePromise = listen('x', () => {})
+    let resolved = false
+    void bridgePromise.then(() => {
+      resolved = true
+    })
+
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+    resolveTransport(vi.fn())
+    await bridgePromise
+    expect(resolved).toBe(true)
+  })
+
+  test('UnlistenFn from window.vimeflow path is idempotent', async () => {
+    const rawUnlisten = vi.fn()
+    mockListen.mockResolvedValueOnce(rawUnlisten)
+
+    const unlisten = await listen('x', () => {})
+    unlisten()
+    unlisten()
+
+    expect(rawUnlisten).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('backend (@tauri-apps fallback path)', () => {
+  beforeEach(() => {
+    mockedTauriInvoke.mockReset()
+    mockedTauriListen.mockReset()
+    delete (window as Window).vimeflow
+  })
+
+  test('invoke delegates to tauriInvoke when window.vimeflow is unset', async () => {
+    mockedTauriInvoke.mockResolvedValueOnce({ ok: true })
+
+    const result = await invoke<{ ok: boolean }>('list_sessions')
+
+    expect(mockedTauriInvoke).toHaveBeenCalledTimes(1)
+    expect(mockedTauriInvoke).toHaveBeenCalledWith('list_sessions', undefined)
+    expect(result).toEqual({ ok: true })
+  })
+
+  test('invoke rejection passes through tauri string error unchanged', async () => {
+    mockedTauriInvoke.mockRejectedValueOnce('PTY session not found')
+
+    await expect(invoke('write_pty', { id: 'x' })).rejects.toBe(
+      'PTY session not found'
+    )
+  })
+
+  test('listen unwraps Event<T>.payload on the Tauri callback', async () => {
+    mockedTauriListen.mockImplementationOnce(async (_name, cb) => {
+      cb({
+        event: 'pty-data',
+        id: 0,
+        payload: { sessionId: 's1', data: 'hi' },
+        windowLabel: '',
+      } as unknown as Parameters<typeof cb>[0])
+      return vi.fn()
+    })
+    const cb = vi.fn()
+
+    await listen<{ sessionId: string; data: string }>('pty-data', cb)
+
+    expect(cb).toHaveBeenCalledWith({ sessionId: 's1', data: 'hi' })
+  })
+
+  test('UnlistenFn calls through to tauriListen-resolved unlisten', async () => {
+    const rawUnlisten = vi.fn()
+    mockedTauriListen.mockResolvedValueOnce(rawUnlisten)
+
+    const unlisten = await listen('pty-exit', () => {})
+    unlisten()
+
+    expect(rawUnlisten).toHaveBeenCalledTimes(1)
+  })
+
+  test('UnlistenFn from fallback path is idempotent', async () => {
+    const rawUnlisten = vi.fn()
+    mockedTauriListen.mockResolvedValueOnce(rawUnlisten)
+
+    const unlisten = await listen('x', () => {})
+    unlisten()
+    unlisten()
+
+    expect(rawUnlisten).toHaveBeenCalledTimes(1)
+  })
+
+  test('listen resolves only after tauriListen resolves (attach-before-resolve)', async () => {
+    let resolveTransport!: (unlisten: () => void) => void
+    mockedTauriListen.mockReturnValueOnce(
+      new Promise<() => void>((res) => {
+        resolveTransport = res
+      })
+    )
+
+    const bridgePromise = listen('x', () => {})
+    let resolved = false
+    void bridgePromise.then(() => {
+      resolved = true
+    })
+
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+    resolveTransport(vi.fn())
+    await bridgePromise
+    expect(resolved).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 4: Run the failing tests**
+
+```bash
+npx vitest run src/lib/backend.test.ts
+```
+
+Expected: FAIL with `cannot find module './backend'` (or similar — `backend.ts` doesn't exist yet).
+
+- [ ] **Step 5: Implement `src/lib/backend.ts`**
+
+```ts
+import { invoke as tauriInvoke } from '@tauri-apps/api/core'
+import { listen as tauriListen } from '@tauri-apps/api/event'
+
+/**
+ * Detach a previously-registered listener. Idempotent — a second call is
+ * a no-op. PR-D removes the `@tauri-apps/event` import and the
+ * `tauriUnlisten` branch below; the bridge's `called` guard wrapper
+ * (in `listen()` below) stays so StrictMode double-cleanup remains
+ * safe regardless of which transport produced `rawUnlisten`.
+ */
+export type UnlistenFn = () => void
+
+export interface BackendApi {
+  invoke: <T>(method: string, args?: Record<string, unknown>) => Promise<T>
+
+  listen: <T>(
+    event: string,
+    callback: (payload: T) => void
+  ) => Promise<UnlistenFn>
+}
+
+/**
+ * Invoke a backend command. Prefers `window.vimeflow.invoke` (PR-D's
+ * Electron preload target) when set; otherwise falls back to
+ * `@tauri-apps/api/core` so the Tauri host keeps working through end
+ * of PR-C. Rejection value is the transport's reject value, passed
+ * through unchanged — Tauri rejects with a bare string, sidecar
+ * (PR-D) MUST reject with the same shape.
+ */
+export const invoke = async <T>(
+  method: string,
+  args?: Record<string, unknown>
+): Promise<T> => {
+  if (typeof window !== 'undefined' && window.vimeflow) {
+    return window.vimeflow.invoke<T>(method, args)
+  }
+  return tauriInvoke<T>(method, args)
+}
+
+/**
+ * Subscribe to a backend event. Callback receives the bare payload
+ * (NOT Tauri's `Event<T>` envelope). The returned promise resolves
+ * only after the underlying transport listener is attached, so
+ * callers can `await listen(...)` before triggering IPC that would
+ * otherwise race the attachment. The returned `UnlistenFn` detaches
+ * the listener AND is idempotent — the bridge wraps the transport's
+ * unlisten with a `called` guard so React StrictMode's
+ * mount→cleanup→remount double-fire is safe regardless of whether
+ * the transport itself is idempotent.
+ */
+export const listen = async <T>(
+  event: string,
+  callback: (payload: T) => void
+): Promise<UnlistenFn> => {
+  const rawUnlisten =
+    typeof window !== 'undefined' && window.vimeflow
+      ? await window.vimeflow.listen<T>(event, callback)
+      : await tauriListen<T>(event, (e) => callback(e.payload))
+
+  let called = false
+  return () => {
+    if (called) return
+    called = true
+    rawUnlisten()
+  }
+}
+```
+
+- [ ] **Step 6: Run the tests, expect pass**
+
+```bash
+npx vitest run src/lib/backend.test.ts
+```
+
+Expected: all 12 tests pass. If any fail, fix the implementation in Step 5 before continuing.
+
+- [ ] **Step 7: Type-check + lint**
+
+```bash
+npm run type-check
+npm run lint src/lib/backend.ts src/lib/backend.test.ts src/types/vimeflow.d.ts
+```
+
+Expected: clean. Common gotcha: `@typescript-eslint/explicit-function-return-type` requires `Promise<T>` annotations on the exported functions — already present in the sketch above.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/backend.ts src/lib/backend.test.ts src/types/vimeflow.d.ts
+git commit -m "$(cat <<'EOF'
+feat(frontend): add src/lib/backend.ts IPC bridge with Tauri fallback
+
+Adds the runtime-neutral renderer-side IPC seam. invoke/listen prefer
+window.vimeflow when set (PR-D target); fall back to @tauri-apps/api
+when not (current PR-C state). UnlistenFn wraps the transport's
+unlisten with a `called` guard so StrictMode double-cleanup is safe.
+
+Adds 12 unit tests (6 per code path) including attach-before-resolve
+and idempotency on both paths.
+
+Spec: docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md §4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Rename `isTauri` → `isDesktop` with OR-detection
+
+**Files:**
+
+- Modify: `src/lib/environment.ts`
+- Modify: `src/lib/environment.test.ts`
+
+- [ ] **Step 1: Rewrite `src/lib/environment.ts`**
+
+Replace the file contents with:
+
+```ts
+/**
+ * Environment detection utilities for VIBM
+ *
+ * Provides functions to detect the runtime environment (desktop app
+ * vs browser). "Desktop" covers both the current Tauri host AND the
+ * Electron host introduced in PR-D — see spec §2.4.
+ */
+
+interface TauriInternals {
+  metadata?: {
+    currentWindow?: {
+      label?: string
+    }
+  }
+}
+
+declare global {
+  interface Window {
+    __TAURI_INTERNALS__?: TauriInternals
+  }
+}
+
+/**
+ * True when the renderer is running inside a desktop host (Tauri today,
+ * Electron in PR-D). Uses `!= null` (not `in`) so an explicit
+ * `window.vimeflow = undefined` does NOT trip the check.
+ */
+export const isDesktop = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  return window.__TAURI_INTERNALS__ != null || window.vimeflow != null
+}
+
+/** True when the renderer is in a browser / Vitest context. */
+export const isBrowser = (): boolean => !isDesktop()
+
+/** 'desktop' covers both Tauri and Electron; 'browser' is everything else. */
+export const getEnvironment = (): 'desktop' | 'browser' =>
+  isDesktop() ? 'desktop' : 'browser'
+
+export const isTest = (): boolean => import.meta.env.MODE === 'test'
+```
+
+(The `Window.vimeflow` augmentation lives in `src/types/vimeflow.d.ts` — added in Task 1 — and is in-scope here without an explicit import. Do NOT redeclare it.)
+
+- [ ] **Step 2: Rewrite `src/lib/environment.test.ts`**
+
+Replace with:
+
+```ts
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+import { isDesktop, isBrowser, getEnvironment, isTest } from './environment'
+import type { BackendApi } from './backend'
+
+describe('environment', () => {
+  let originalTauriInternals: typeof window.__TAURI_INTERNALS__
+  let originalVimeflow: typeof window.vimeflow
+
+  beforeEach(() => {
+    originalTauriInternals = (window as Window).__TAURI_INTERNALS__
+    originalVimeflow = (window as Window).vimeflow
+  })
+
+  afterEach(() => {
+    if (originalTauriInternals === undefined) {
+      delete (window as Window).__TAURI_INTERNALS__
+    } else {
+      ;(window as Window).__TAURI_INTERNALS__ = originalTauriInternals
+    }
+    if (originalVimeflow === undefined) {
+      delete (window as Window).vimeflow
+    } else {
+      ;(window as Window).vimeflow = originalVimeflow
+    }
+  })
+
+  describe('isDesktop', () => {
+    test('returns true when __TAURI_INTERNALS__ is set (Tauri host)', () => {
+      ;(window as Window).__TAURI_INTERNALS__ = {}
+      delete (window as Window).vimeflow
+
+      expect(isDesktop()).toBe(true)
+    })
+
+    test('returns true when window.vimeflow is set (Electron host)', () => {
+      delete (window as Window).__TAURI_INTERNALS__
+      ;(window as Window).vimeflow = {
+        invoke: () => Promise.resolve(),
+        listen: () => Promise.resolve(() => {}),
+      } as unknown as BackendApi
+
+      expect(isDesktop()).toBe(true)
+    })
+
+    test('returns false when window.vimeflow is explicitly undefined', () => {
+      delete (window as Window).__TAURI_INTERNALS__
+      ;(window as Window).vimeflow = undefined
+
+      expect(isDesktop()).toBe(false)
+    })
+
+    test('returns false when neither signal is present (browser)', () => {
+      delete (window as Window).__TAURI_INTERNALS__
+      delete (window as Window).vimeflow
+
+      expect(isDesktop()).toBe(false)
+    })
+
+    test('returns true when __TAURI_INTERNALS__ has metadata', () => {
+      ;(window as Window).__TAURI_INTERNALS__ = {
+        metadata: { currentWindow: { label: 'main' } },
+      }
+
+      expect(isDesktop()).toBe(true)
+    })
+  })
+
+  describe('isBrowser', () => {
+    test('returns false when desktop signal is set', () => {
+      ;(window as Window).__TAURI_INTERNALS__ = {}
+
+      expect(isBrowser()).toBe(false)
+    })
+
+    test('returns true when no desktop signal is set', () => {
+      delete (window as Window).__TAURI_INTERNALS__
+      delete (window as Window).vimeflow
+
+      expect(isBrowser()).toBe(true)
+    })
+  })
+
+  describe('getEnvironment', () => {
+    test('returns desktop when Tauri signal is present', () => {
+      ;(window as Window).__TAURI_INTERNALS__ = {}
+
+      expect(getEnvironment()).toBe('desktop')
+    })
+
+    test('returns desktop when vimeflow signal is present', () => {
+      delete (window as Window).__TAURI_INTERNALS__
+      ;(window as Window).vimeflow = {
+        invoke: () => Promise.resolve(),
+        listen: () => Promise.resolve(() => {}),
+      } as unknown as BackendApi
+
+      expect(getEnvironment()).toBe('desktop')
+    })
+
+    test('returns browser when no signal is present', () => {
+      delete (window as Window).__TAURI_INTERNALS__
+      delete (window as Window).vimeflow
+
+      expect(getEnvironment()).toBe('browser')
+    })
+  })
+
+  describe('isTest', () => {
+    test('returns true when MODE is test', () => {
+      expect(isTest()).toBe(true)
+    })
+  })
+})
+```
+
+- [ ] **Step 3: Run environment tests**
+
+```bash
+npx vitest run src/lib/environment.test.ts
+```
+
+Expected: all tests pass. If a Vitest jsdom global is missing for `Window.vimeflow`, ensure Task 1 created `src/types/vimeflow.d.ts` and the file is in the tsconfig include path.
+
+- [ ] **Step 4: Verify nothing in the repo still imports the old `isTauri`**
+
+```bash
+rg -n "isTauri\b" src tests
+```
+
+Expected: the 3 production hits remain — they'll be migrated in Tasks 4-9. (`isTauri` still exists as a symbol; Tasks 4-9 swap each caller to `isDesktop`.)
+
+Wait — that's wrong. We've removed `isTauri` from `environment.ts` entirely in Step 1. After Step 1, the 3 callers will fail to compile. Fix: migrate the callers in this same task before committing, OR temporarily re-export `isTauri = isDesktop` as a deprecated alias for the rest of the PR.
+
+Per spec §2.4 ("There are exactly 3 production call sites ... so no compat alias is provided"), do the rename atomically. Update the 3 callers in this task:
+
+- [ ] **Step 5: Update `src/features/terminal/services/terminalService.ts:388`**
+
+```ts
+// Before:
+import { isTauri } from '../../../lib/environment'
+// ...
+if (isTauri()) {
+
+// After:
+import { isDesktop } from '../../../lib/environment'
+// ...
+if (isDesktop()) {
+```
+
+- [ ] **Step 6: Update `src/features/files/services/fileSystemService.ts:110`**
+
+```ts
+// Before:
+import { isTauri } from '../../../lib/environment'
+// ...
+if (isTauri()) {
+
+// After:
+import { isDesktop } from '../../../lib/environment'
+// ...
+if (isDesktop()) {
+```
+
+- [ ] **Step 7: Update `src/features/diff/services/gitService.ts:180`**
+
+```ts
+// Before:
+// Check if running under Tauri
+if ('__TAURI_INTERNALS__' in window) {
+  return new TauriGitService(cwd)
+}
+
+// After:
+// Check if running on the desktop host (Tauri today, Electron in PR-D)
+if (isDesktop()) {
+  return new TauriGitService(cwd)
+}
+```
+
+Add `import { isDesktop } from '../../../lib/environment'` at the top of the file (with the other imports).
+
+- [ ] **Step 8: Type-check + targeted test sweep**
+
+```bash
+npm run type-check
+npx vitest run src/lib/environment.test.ts src/features/terminal/services/terminalService.test.ts src/features/files/services/ src/features/diff/services/gitService.test.ts
+```
+
+Expected: type-check clean. The service tests may still fail because they mock `@tauri-apps/api` rather than the bridge — those failures are addressed in Tasks 4-9. For now, only confirm the type-check is clean and the environment tests pass.
+
+If gitService.test.ts has a test that sets `__TAURI_INTERNALS__` directly to drive the factory, it will probably still pass because `__TAURI_INTERNALS__` is in the OR. Don't refactor those tests in this task — Task 8 does it.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/environment.ts src/lib/environment.test.ts \
+  src/features/terminal/services/terminalService.ts \
+  src/features/files/services/fileSystemService.ts \
+  src/features/diff/services/gitService.ts
+git commit -m "$(cat <<'EOF'
+refactor(frontend): rename isTauri → isDesktop with OR-detection
+
+Renames the environment helper from isTauri to isDesktop and changes
+its semantics: it now returns true when EITHER __TAURI_INTERNALS__
+(today) OR window.vimeflow (PR-D / Electron) is set. The OR makes the
+factory pattern correct across both runtime eras — same `TauriXxx`
+service implementation, two different transports underneath.
+
+Updates 3 production call sites: terminalService.ts (factory),
+fileSystemService.ts (factory), gitService.ts (factory; previously
+checked `'__TAURI_INTERNALS__' in window` directly — now goes through
+the helper).
+
+Adds 4 new isDesktop test cases for the Electron-signal path and the
+`vimeflow = undefined` distinction. The `'tauri'` literal is retired
+from getEnvironment's return type.
+
+Spec: docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md §2.4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Migrate `src/lib/e2e-bridge.ts`
+
+**Files:**
+
+- Modify: `src/lib/e2e-bridge.ts`
+
+This is the smallest migration — a single `invoke` call. Use it as the warmup for the pattern that Tasks 4-9 repeat.
+
+- [ ] **Step 1: Edit `src/lib/e2e-bridge.ts`**
+
+Change the first import line:
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+
+// After:
+import { invoke } from './backend'
+```
+
+No other change. The single call site (`invoke<string[]>('list_active_pty_sessions')`) keeps its shape.
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: clean. The `invoke` signature is identical on both sides (`<T>(method, args?) => Promise<T>`), so no call-site change is needed.
+
+- [ ] **Step 3: Smoke-check the file isn't otherwise referenced**
+
+```bash
+rg -n "e2e-bridge" src tests
+```
+
+Expected: hits in `src/main.tsx` (or wherever the side-effect import happens). The file isn't imported for its API — only for side-effect (it conditionally installs `window.__VIMEFLOW_E2E__`). No call-site refactor needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/e2e-bridge.ts
+git commit -m "$(cat <<'EOF'
+refactor(e2e): route e2e-bridge invoke through src/lib/backend
+
+Replaces the direct @tauri-apps/api/core import in src/lib/e2e-bridge.ts
+with the runtime-neutral bridge from src/lib/backend.ts. No behavioral
+change — under Tauri the bridge falls back to the same tauri.invoke
+call that this file used directly before.
+
+Spec: docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md §5.1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Migrate `useGitBranch.ts`
+
+**Files:**
+
+- Modify: `src/features/diff/hooks/useGitBranch.ts`
+- Modify: `src/features/diff/hooks/useGitBranch.test.ts`
+
+This hook has a single `invoke` call, no `listen`. Mechanically identical to Task 3 with a test-mock flip.
+
+- [ ] **Step 1: Edit `useGitBranch.ts` import**
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+
+// After:
+import { invoke } from '../../../lib/backend'
+```
+
+No call-site change.
+
+- [ ] **Step 2: Edit `useGitBranch.test.ts` mock**
+
+Find the existing mock block (near the top of the file). Replace:
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+const mockedInvoke = vi.mocked(invoke)
+```
+
+with:
+
+```ts
+// After:
+import { invoke } from '../../../lib/backend'
+
+vi.mock('../../../lib/backend', () => ({
+  invoke: vi.fn(),
+}))
+
+const mockedInvoke = vi.mocked(invoke)
+```
+
+If the test file imports `listen` too, include it in the mock factory (but for `useGitBranch.ts` only `invoke` is used — confirm by reading the test file first).
+
+- [ ] **Step 3: Run the hook test**
+
+```bash
+npx vitest run src/features/diff/hooks/useGitBranch.test.ts
+```
+
+Expected: all tests pass. If a test fails because it asserts the underlying tauri invoke was called, update the assertion to spy on the bridge's `invoke` instead — same shape (`mockedInvoke.mock.calls[0]` etc.).
+
+- [ ] **Step 4: Type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/hooks/useGitBranch.ts \
+  src/features/diff/hooks/useGitBranch.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(diff): route useGitBranch through src/lib/backend
+
+Replaces the direct @tauri-apps/api/core import with the bridge.
+Test mock flips from @tauri-apps/api/core to src/lib/backend; same
+assertion shape.
+
+Spec: docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md §5.1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Migrate `useGitStatus.ts`
+
+**Files:**
+
+- Modify: `src/features/diff/hooks/useGitStatus.ts`
+- Modify: `src/features/diff/hooks/useGitStatus.test.ts`
+
+`useGitStatus` adds one `listen` callback (`git-status-changed`) on top of the invoke pattern. The callback currently destructures `event.payload.cwds`; after migration, it destructures the bare payload.
+
+- [ ] **Step 1: Edit `useGitStatus.ts` imports**
+
+```ts
+// Before:
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { invoke } from '@tauri-apps/api/core'
+
+// After:
+import { invoke, listen, type UnlistenFn } from '../../../lib/backend'
+```
+
+- [ ] **Step 2: Edit the listen callback (search for `listen<GitStatusChangedPayload>` or the git-status-changed listener)**
+
+Find the existing callback. The current shape (in the source file's git watcher section):
+
+```ts
+const unlisten = await listen<GitStatusChangedPayload>(
+  'git-status-changed',
+  (event) => {
+    const cwds = event.payload.cwds
+    // ... rest of logic ...
+  }
+)
+```
+
+Replace with bare-payload form:
+
+```ts
+const unlisten = await listen<GitStatusChangedPayload>(
+  'git-status-changed',
+  (payload) => {
+    const cwds = payload.cwds
+    // ... rest of logic UNCHANGED ...
+  }
+)
+```
+
+Be careful to update only the destructuring access (`event.payload.X` → `payload.X`); don't touch any other code in the callback body.
+
+- [ ] **Step 3: Edit `useGitStatus.test.ts` mock + listen-callback fixtures**
+
+Replace the mock block:
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}))
+
+// After:
+import { invoke, listen } from '../../../lib/backend'
+
+vi.mock('../../../lib/backend', () => ({
+  invoke: vi.fn(),
+  listen: vi.fn(),
+}))
+```
+
+Then find every place the test fires the listener manually via the captured callback. Today's pattern:
+
+```ts
+eventHandler!({ payload: { cwds: ['/home/test/project'] } })
+```
+
+Becomes:
+
+```ts
+eventHandler!({ cwds: ['/home/test/project'] })
+```
+
+(Drop the synthetic `payload:` wrapper. The bridge already unwraps; tests pass the bare payload directly.)
+
+Also update the `EventCallback` type alias used in the test (if any). Today:
+
+```ts
+type EventCallback = (event: { payload: { cwds: string[] } }) => void
+```
+
+Becomes:
+
+```ts
+type EventCallback = (payload: { cwds: string[] }) => void
+```
+
+- [ ] **Step 4: Run the hook test**
+
+```bash
+npx vitest run src/features/diff/hooks/useGitStatus.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/hooks/useGitStatus.ts \
+  src/features/diff/hooks/useGitStatus.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(diff): route useGitStatus through src/lib/backend
+
+Replaces direct @tauri-apps/api imports with the bridge. The
+git-status-changed listener callback refactors `event.payload.cwds`
+to `payload.cwds` (bridge unwraps Tauri's Event<T> envelope).
+
+Test fixtures drop the synthetic { payload: ... } wrapper around
+listener arguments; EventCallback type alias matches the bridge's
+bare-payload signature.
+
+Spec: docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md §5.1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Migrate `useAgentStatus.ts`
+
+**Files:**
+
+- Modify: `src/features/agent-status/hooks/useAgentStatus.ts`
+- Modify: `src/features/agent-status/hooks/useAgentStatus.test.ts`
+
+This is the heaviest single migration — 4 listen callbacks (`agent-status`, `agent-tool-call`, `agent-turn`, `test-run`) plus multiple invoke call sites. The mechanical change is uniform: each `event.payload.X` becomes `payload.X` (or simply `payload` where the whole thing is consumed). Move carefully — a typo in any of the 4 callbacks could silently break agent detection.
+
+- [ ] **Step 1: Edit `useAgentStatus.ts` imports**
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+
+// After:
+import { invoke, listen } from '../../../lib/backend'
+```
+
+- [ ] **Step 2: Refactor the 4 listen callbacks**
+
+For each callback in `useAgentStatus.ts`'s `subscribe()` function, replace `event` → `payload` in the argument name AND drop the `event.payload` access pattern.
+
+**Callback 1 — `agent-status`** (around line 355-425):
+
+```ts
+// Before:
+const unlistenStatus = await listen<AgentStatusEvent>(
+  'agent-status',
+  (event) => {
+    if (event.payload.sessionId !== resolvePtyId()) {
+      return
+    }
+
+    const p = event.payload
+    // ... rest unchanged ...
+  }
+)
+
+// After:
+const unlistenStatus = await listen<AgentStatusEvent>(
+  'agent-status',
+  (payload) => {
+    if (payload.sessionId !== resolvePtyId()) {
+      return
+    }
+
+    const p = payload
+    // ... rest unchanged ...
+  }
+)
+```
+
+**Callback 2 — `agent-tool-call`** (around line 429-490):
+
+```ts
+// Before:
+const unlistenToolCall = await listen<AgentToolCallEvent>(
+  'agent-tool-call',
+  (event) => {
+    const ptyId = getPtySessionId(sessionId)
+    if (event.payload.sessionId !== ptyId) {
+      return
+    }
+    const p = event.payload
+    // ... rest unchanged ...
+  }
+)
+
+// After:
+const unlistenToolCall = await listen<AgentToolCallEvent>(
+  'agent-tool-call',
+  (payload) => {
+    const ptyId = getPtySessionId(sessionId)
+    if (payload.sessionId !== ptyId) {
+      return
+    }
+    const p = payload
+    // ... rest unchanged ...
+  }
+)
+```
+
+**Callback 3 — `agent-turn`** (around line 494-518):
+
+```ts
+// Before:
+const unlistenTurn = await listen<AgentTurnEvent>('agent-turn', (event) => {
+  if (event.payload.sessionId !== resolvePtyId()) {
+    return
+  }
+  const nextTurns = event.payload.numTurns
+  // ... rest unchanged ...
+})
+
+// After:
+const unlistenTurn = await listen<AgentTurnEvent>('agent-turn', (payload) => {
+  if (payload.sessionId !== resolvePtyId()) {
+    return
+  }
+  const nextTurns = payload.numTurns
+  // ... rest unchanged ...
+})
+```
+
+**Callback 4 — `test-run`** (around line 525-537):
+
+```ts
+// Before:
+const unlistenTestRun = await listen<TestRunSnapshot>('test-run', (event) => {
+  if (event.payload.sessionId !== resolvePtyId()) {
+    return
+  }
+  setStatus((prev) => ({
+    ...prev,
+    testRun: event.payload,
+  }))
+})
+
+// After:
+const unlistenTestRun = await listen<TestRunSnapshot>('test-run', (payload) => {
+  if (payload.sessionId !== resolvePtyId()) {
+    return
+  }
+  setStatus((prev) => ({
+    ...prev,
+    testRun: payload,
+  }))
+})
+```
+
+- [ ] **Step 3: Sanity grep — no `event.payload` should remain in this file**
+
+```bash
+rg -n "event\.payload" src/features/agent-status/hooks/useAgentStatus.ts
+```
+
+Expected: zero hits. If any remain, fix before continuing.
+
+- [ ] **Step 4: Edit `useAgentStatus.test.ts` mock + listener fixtures**
+
+Replace the mock block at the top of the file:
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))
+
+// After:
+import { invoke, listen } from '../../../lib/backend'
+
+vi.mock('../../../lib/backend', () => ({
+  invoke: vi.fn(),
+  listen: vi.fn(),
+}))
+```
+
+Update the `EventCallback` type alias at top of file:
+
+```ts
+// Before:
+type EventCallback<T = unknown> = (event: { payload: T }) => void
+
+// After:
+type EventCallback<T = unknown> = (payload: T) => void
+```
+
+Update the `emit` helper (around line 52):
+
+```ts
+// Before:
+const emit = <T>(eventName: string, payload: T): void => {
+  // Find the listener callback that was registered for this event,
+  // fire it with a synthetic Event<T> envelope.
+  const call = mockedListen.mock.calls.find((c) => c[0] === eventName)
+  const cb = call?.[1] as EventCallback<T>
+  cb({ payload })
+}
+
+// After:
+const emit = <T>(eventName: string, payload: T): void => {
+  const call = mockedListen.mock.calls.find((c) => c[0] === eventName)
+  const cb = call?.[1] as EventCallback<T>
+  cb(payload)
+}
+```
+
+Find every test that constructs a `{ payload: ... }` shape to pass to the listener — they're the `testRunHandler` / `eventHandler!` calls around lines 1139-1202 and elsewhere. Each:
+
+```ts
+// Before:
+testRunHandler?.({ payload: snap })
+
+// After:
+testRunHandler?.(snap)
+```
+
+And every `handler:` type annotation:
+
+```ts
+// Before:
+handler: (e: { payload: TestRunSnapshot }) => void
+
+// After:
+handler: (payload: TestRunSnapshot) => void
+```
+
+This is a sweep — search the test file for every `payload:` literal that wraps a listener argument, and unwrap.
+
+- [ ] **Step 5: Sanity grep — no `event.payload` or `{ payload:` listener fixtures should remain**
+
+```bash
+rg -n "event\.payload|\{ payload:" src/features/agent-status/hooks/useAgentStatus.test.ts
+```
+
+Expected: zero matches (or, if any remain, they MUST be legitimately the agent-status `payload` shape — not a synthetic Event<T> wrapper).
+
+- [ ] **Step 6: Run the hook test in isolation**
+
+```bash
+npx vitest run src/features/agent-status/hooks/useAgentStatus.test.ts
+```
+
+Expected: all tests pass. If a test fails on a specific callback's payload assertion, the most likely cause is missing the `event.payload` → `payload` rewrite in either the .ts or the .test.ts file. Re-check Steps 2 and 4.
+
+- [ ] **Step 7: Run all tests to catch any cross-file regression**
+
+```bash
+npm run test
+```
+
+Expected: all green. The useAgentStatus migration is large; running the full suite catches any indirect breakage.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/features/agent-status/hooks/useAgentStatus.ts \
+  src/features/agent-status/hooks/useAgentStatus.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(agent-status): route useAgentStatus through src/lib/backend
+
+Heaviest single-file migration in PR-C. Replaces direct @tauri-apps
+imports with the bridge. Refactors 4 listener callbacks (agent-status,
+agent-tool-call, agent-turn, test-run) from `event.payload.X` to
+`payload.X` since the bridge unwraps Tauri's Event<T> envelope on the
+fallback path.
+
+Test fixtures: EventCallback type, emit() helper, and 4+ inline
+listener calls all drop the synthetic { payload: ... } wrapper.
+
+Spec: docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md §5.1 + §7.4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Migrate `fileSystemService.ts` (dynamic → static import)
+
+**Files:**
+
+- Modify: `src/features/files/services/fileSystemService.ts`
+- Modify: `src/features/files/services/fileSystemService.test.ts`
+
+`fileSystemService` uses dynamic `await import('@tauri-apps/api/core')` inside each method. The migration converts to a single top-level static import.
+
+- [ ] **Step 1: Edit `fileSystemService.ts`**
+
+Add a top-level import of the bridge (with the other top-level imports near line 1-5):
+
+```ts
+import type { FileNode } from '../types'
+import type { FileEntry } from '../../../bindings'
+import { isDesktop } from '../../../lib/environment' // (already updated in Task 2)
+import { invoke } from '../../../lib/backend' // ← NEW
+import { mockFileTree } from '../data/mockFileTree'
+```
+
+Then strip the dynamic `await import(...)` from all three methods inside `TauriFileSystemService` (lines 42-67). After the edit:
+
+```ts
+class TauriFileSystemService implements IFileSystemService {
+  async listDir(path: string): Promise<FileNode[]> {
+    const entries = await invoke<FileEntry[]>('list_dir', {
+      request: { path },
+    })
+
+    return entries.map((entry) => toFileNode(entry, path))
+  }
+
+  async readFile(path: string): Promise<string> {
+    return invoke<string>('read_file', {
+      request: { path },
+    })
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    await invoke<void>('write_file', {
+      request: { path, content },
+    })
+  }
+}
+```
+
+(Three `const { invoke } = await import('@tauri-apps/api/core')` lines disappear. The factory was already updated to `isDesktop()` in Task 2.)
+
+- [ ] **Step 2: Edit `fileSystemService.test.ts` mock**
+
+Replace:
+
+```ts
+// Before:
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+// After:
+vi.mock('../../../lib/backend', () => ({
+  invoke: vi.fn(),
+}))
+```
+
+Update the import too:
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+
+// After:
+import { invoke } from '../../../lib/backend'
+```
+
+- [ ] **Step 3: Run the test**
+
+```bash
+npx vitest run src/features/files/services/fileSystemService.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/files/services/fileSystemService.ts \
+  src/features/files/services/fileSystemService.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(files): route fileSystemService through src/lib/backend
+
+Replaces the 3-method dynamic-import workaround with a single
+top-level static import of the bridge. The dynamic import was no
+longer load-bearing — useAgentStatus, gitService, and
+tauriTerminalService already pull @tauri-apps/api eagerly into the
+production bundle, so making fileSystemService consistent does not
+regress the bundle. PR-D shrinks the bundle by removing @tauri-apps
+entirely.
+
+Spec: docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md §5.2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Migrate `gitService.ts` (factory branching + class imports)
+
+**Files:**
+
+- Modify: `src/features/diff/services/gitService.ts`
+- Modify: `src/features/diff/services/gitService.test.ts`
+
+`gitService` has both a factory branching pattern (Task 2 already updated the factory's `isDesktop()` check) AND a `TauriGitService` class that imports `invoke`. This task migrates the class's imports and rewrites the factory branching test.
+
+- [ ] **Step 1: Edit `gitService.ts` import**
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+
+// After:
+import { invoke } from '../../../lib/backend'
+```
+
+(The factory's `isDesktop()` check was already added in Task 2; no factory edit here.)
+
+- [ ] **Step 2: Edit `gitService.test.ts` — top-level mocks**
+
+Replace:
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+const mockedInvoke = vi.mocked(invoke)
+
+// After:
+import { invoke } from '../../../lib/backend'
+import { isDesktop } from '../../../lib/environment'
+
+vi.mock('../../../lib/backend', () => ({
+  invoke: vi.fn(),
+}))
+
+vi.mock('../../../lib/environment', () => ({
+  isDesktop: vi.fn(),
+  isBrowser: vi.fn(),
+  getEnvironment: vi.fn(),
+  isTest: vi.fn(),
+}))
+
+const mockedInvoke = vi.mocked(invoke)
+const mockedIsDesktop = vi.mocked(isDesktop)
+```
+
+- [ ] **Step 3: Rewrite the factory test at `gitService.test.ts:401-416`**
+
+Today's test (paraphrased):
+
+```ts
+test('returns TauriGitService when __TAURI_INTERNALS__ exists', () => {
+  type WindowWithTauri = Window & { __TAURI_INTERNALS__?: unknown }
+  const tauriWindow = window as WindowWithTauri
+  try {
+    tauriWindow.__TAURI_INTERNALS__ = {}
+    // ... assert createGitService returns TauriGitService ...
+  } finally {
+    delete tauriWindow.__TAURI_INTERNALS__
+  }
+})
+```
+
+After:
+
+```ts
+test('returns TauriGitService when isDesktop() is true', () => {
+  const prevMode = import.meta.env.MODE
+  vi.stubEnv('MODE', 'development')
+  mockedIsDesktop.mockReturnValue(true)
+  try {
+    const svc = createGitService('/some/cwd')
+    expect(svc).toBeInstanceOf(TauriGitService)
+  } finally {
+    vi.unstubAllEnvs()
+  }
+})
+```
+
+(The `MODE` override is critical — the factory's first branch returns `MockGitService` when `MODE === 'test'`, so the test must bypass that branch to reach the `isDesktop()` check. The previous `__TAURI_INTERNALS__` test must have had a similar override; preserve it.)
+
+Add a companion test for the Electron / vimeflow case:
+
+```ts
+test('returns TauriGitService when isDesktop() is true (via vimeflow)', () => {
+  vi.stubEnv('MODE', 'development')
+  mockedIsDesktop.mockReturnValue(true)
+  try {
+    const svc = createGitService('/some/cwd')
+    expect(svc).toBeInstanceOf(TauriGitService)
+  } finally {
+    vi.unstubAllEnvs()
+  }
+})
+```
+
+(Both Tauri and Electron drive the same `isDesktop = true` path; the factory doesn't distinguish them. The test for the Electron case mocks `isDesktop` true the same way and asserts the same outcome.)
+
+- [ ] **Step 4: Run the test**
+
+```bash
+npx vitest run src/features/diff/services/gitService.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/services/gitService.ts \
+  src/features/diff/services/gitService.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(diff): route gitService through src/lib/backend
+
+Replaces direct @tauri-apps/api/core import in TauriGitService with
+the bridge. Factory's __TAURI_INTERNALS__ check was already swapped
+to isDesktop() in the environment rename commit; this commit migrates
+the class's invoke import.
+
+Rewrites the factory branching test to mock isDesktop() instead of
+manipulating __TAURI_INTERNALS__ directly — the seam the test should
+poke. Preserves the MODE=development override (the factory's
+MODE='test' branch otherwise short-circuits to MockGitService).
+Adds a companion test for the Electron / vimeflow path.
+
+Spec: docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md §5.3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Migrate `tauriTerminalService.ts` (+ terminalService.ts factory verified)
+
+**Files:**
+
+- Modify: `src/features/terminal/services/tauriTerminalService.ts`
+- Modify: `src/features/terminal/services/tauriTerminalService.test.ts`
+
+`TauriTerminalService` has 3 listen callbacks (`pty-data`, `pty-exit`, `pty-error`) and a `UnlistenFn` type import. The terminalService.ts factory was already updated in Task 2.
+
+- [ ] **Step 1: Edit `tauriTerminalService.ts` imports**
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+
+// After:
+import { invoke, listen, type UnlistenFn } from '../../../lib/backend'
+```
+
+- [ ] **Step 2: Refactor the 3 listen callbacks in `ensureListeners()`**
+
+**Callback 1 — `pty-data`** (around line 59-69):
+
+```ts
+// Before:
+const unlistenData = await listen<PtyDataEvent>('pty-data', (event) => {
+  const { sessionId, data, offsetStart, byteLen } = event.payload
+  // ...
+})
+
+// After:
+const unlistenData = await listen<PtyDataEvent>('pty-data', (payload) => {
+  const { sessionId, data, offsetStart, byteLen } = payload
+  // ...
+})
+```
+
+**Callback 2 — `pty-exit`** (around line 71-74):
+
+```ts
+// Before:
+const unlistenExit = await listen<PtyExitEvent>('pty-exit', (event) => {
+  const { sessionId, code } = event.payload
+  this.exitCallbacks.forEach((cb) => cb(sessionId, code))
+})
+
+// After:
+const unlistenExit = await listen<PtyExitEvent>('pty-exit', (payload) => {
+  const { sessionId, code } = payload
+  this.exitCallbacks.forEach((cb) => cb(sessionId, code))
+})
+```
+
+**Callback 3 — `pty-error`** (around line 76-82):
+
+```ts
+// Before:
+const unlistenError = await listen<PtyErrorEvent>('pty-error', (event) => {
+  const { sessionId, message } = event.payload
+  this.errorCallbacks.forEach((cb) => cb(sessionId, message))
+})
+
+// After:
+const unlistenError = await listen<PtyErrorEvent>('pty-error', (payload) => {
+  const { sessionId, message } = payload
+  this.errorCallbacks.forEach((cb) => cb(sessionId, message))
+})
+```
+
+- [ ] **Step 3: Sanity grep — no `event.payload` should remain in this file**
+
+```bash
+rg -n "event\.payload" src/features/terminal/services/tauriTerminalService.ts
+```
+
+Expected: zero hits.
+
+- [ ] **Step 4: Edit `tauriTerminalService.test.ts` mock + fixtures**
+
+Replace the top-level mocks:
+
+```ts
+// Before:
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))
+
+// After:
+import { invoke, listen } from '../../../lib/backend'
+
+vi.mock('../../../lib/backend', () => ({
+  invoke: vi.fn(),
+  listen: vi.fn(),
+}))
+```
+
+Update the `EventCallback` type alias:
+
+```ts
+// Before:
+type EventCallback = (event: { payload: unknown }) => void
+
+// After:
+type EventCallback = (payload: unknown) => void
+```
+
+Update the `emitTauriEvent` helper (around line 34):
+
+```ts
+// Before:
+const emitTauriEvent = (eventName: string, payload: unknown): void => {
+  const call = mockedListen.mock.calls.find((c) => c[0] === eventName)
+  const cb = call?.[1] as EventCallback
+  cb({ payload })
+}
+
+// After:
+const emitTauriEvent = (eventName: string, payload: unknown): void => {
+  const call = mockedListen.mock.calls.find((c) => c[0] === eventName)
+  const cb = call?.[1] as EventCallback
+  cb(payload)
+}
+```
+
+(The helper name `emitTauriEvent` is now slightly stale — the emission isn't Tauri-specific anymore — but renaming it is a drive-by; leave it.)
+
+- [ ] **Step 5: Sanity grep**
+
+```bash
+rg -n "event\.payload|\{ payload:" src/features/terminal/services/tauriTerminalService.test.ts
+```
+
+Expected: zero matches (or, if any remain, legitimate non-listener `payload` literals).
+
+- [ ] **Step 6: Run the test**
+
+```bash
+npx vitest run src/features/terminal/services/tauriTerminalService.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Run all terminal tests to confirm `terminalService.ts` factory still works**
+
+```bash
+npx vitest run src/features/terminal/services/
+```
+
+Expected: all green. The factory was updated to `isDesktop()` in Task 2; this confirms nothing regressed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/features/terminal/services/tauriTerminalService.ts \
+  src/features/terminal/services/tauriTerminalService.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(terminal): route TauriTerminalService through src/lib/backend
+
+Replaces direct @tauri-apps imports with the bridge. The 3 listener
+callbacks (pty-data, pty-exit, pty-error) refactor `event.payload.X`
+to `payload.X` since the bridge unwraps Tauri's Event<T> envelope on
+the fallback path.
+
+Test fixtures: EventCallback type and emitTauriEvent helper drop the
+synthetic { payload: ... } wrapper. (The helper retains its name to
+avoid drive-by churn; it now wraps the bridge's listen, not Tauri's.)
+
+terminalService.ts factory line was already swapped to isDesktop()
+in the earlier environment rename commit.
+
+Spec: docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md §5.1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Final verification gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Format + lint sweep**
+
+```bash
+npm run format:check
+npm run lint
+```
+
+Expected: clean. If `format:check` fails on the modified files, run `npm run format` and commit the formatting fix separately as `style(frontend): prettier sweep` (do NOT bundle with feature commits — see `rules/common/pr-scope.md`).
+
+- [ ] **Step 2: Full TS test suite**
+
+```bash
+npm run test
+```
+
+Expected: all green. Test count should climb by ~16 vs Task 0 baseline (12 in `backend.test.ts` + 4 new cases in `environment.test.ts`).
+
+- [ ] **Step 3: Type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Rust smoke (PR-C did not touch Rust; the count must match PR-B baseline)**
+
+```bash
+(cd src-tauri && cargo test)
+```
+
+Expected: byte-identical test count to the post-PR-B baseline. A diff here means something accidentally tripped the Rust build (e.g., a stray edit elsewhere). Bisect.
+
+- [ ] **Step 5: Coupling-inventory diff vs Task 0 baseline**
+
+```bash
+rg -nE "@tauri-apps/api|__TAURI_INTERNALS__" src tests > /tmp/pr-c-final.txt
+diff /tmp/pr-c-baseline.txt /tmp/pr-c-final.txt
+```
+
+Expected: production hits remain in exactly these files (no others):
+
+- `src/lib/backend.ts` — the bridge's fallback imports (+ JSDoc).
+- `src/lib/backend.test.ts` — the Vitest mock targets (+ synthetic Event<T> fixtures in the fallback tests).
+- `src/lib/environment.ts` — the `__TAURI_INTERNALS__` probe inside `isDesktop()` + the `Window` ambient declaration.
+- `src/lib/environment.test.ts` — fixtures writing `__TAURI_INTERNALS__` to drive `isDesktop()` truthy.
+
+Any other file is a leak — open the file, find the import, route it through the bridge. Do NOT close PR-C with leaks.
+
+- [ ] **Step 6: Manual smoke — `npm run tauri:dev`**
+
+```bash
+npm run tauri:dev
+```
+
+Walk through:
+
+1. App window opens. Default workspace renders. ✓
+2. Default terminal session spawns; prompt is visible. ✓
+3. Type in the terminal; characters echo. ✓
+4. File Explorer lists the working directory. Click a file → editor shows its content. ✓
+5. Diff panel shows current branch + uncommitted status. ✓
+6. Spawn a second terminal pane via the existing flow; switch panes; close the second pane. ✓
+7. Cmd/Ctrl+Q → clean exit; relaunch → session cache behaves identically to pre-PR-C. ✓
+
+If any step regresses, bisect by reverting the most recent commits one at a time. Bridge-fallback bugs typically surface at step 2 (PTY event flow) or step 5 (git watcher) because those exercise the listener path most aggressively.
+
+- [ ] **Step 7: E2E smoke**
+
+```bash
+npm run test:e2e:build
+npm run test:e2e
+```
+
+Expected: all green. The `e2e-bridge.ts` migration is a one-line import swap; the runtime path through `tauri-driver` + Wry is unchanged. If a spec fails, it's a real regression — do not paper it over by adjusting the spec.
+
+- [ ] **Step 8: Frontend-only Tauri references — should be zero outside the bridge**
+
+```bash
+rg -n "from '@tauri-apps/api" src
+```
+
+Expected: 2 hits, both in `src/lib/backend.ts` (the fallback's runtime imports). Anything else means a renderer file still imports `@tauri-apps/api` directly — fix before opening the PR.
+
+```bash
+rg -n "from '@tauri-apps/api" src/lib/backend.test.ts
+```
+
+Expected: 2 hits (the test mocks the same two modules the bridge consumes). These ARE expected — the test exercises the fallback path explicitly.
+
+- [ ] **Step 9: No drive-by formatting in feature commits**
+
+```bash
+git log --oneline 6a0a3f2..HEAD
+```
+
+(Replace `6a0a3f2` with the pre-Task-1 SHA recorded in Task 0.) Walk the commit list; every commit should be one of the conventional types from spec §5.5's ordering (`feat(frontend)`, `refactor(frontend|terminal|diff|files|agent-status|e2e)`). Any `style(...)` commit must be its own atomic commit, not bundled with a refactor.
+
+If any commit bundles formatting drive-bys with feature work, `git reset --mixed <SHA>` to before it and re-split. (Use `git reflog` to recover if needed.)
+
+- [ ] **Step 10: Spec-claims sanity check**
+
+```bash
+grep -nE "^#\[tauri::command\]" src-tauri/src/ -r | wc -l
+```
+
+Expected: ~19 (unchanged from PR-B). PR-C does not touch Rust wrappers.
+
+```bash
+rg -n "isTauri\b" src tests
+```
+
+Expected: zero hits. The rename is complete; no leftover callers.
+
+```bash
+rg -n "TauriXxx|DesktopXxx" src 2>&1 | head -5
+```
+
+(Sanity check that we did NOT rename the class identifiers — those wait for PR-D.) Expected: `TauriTerminalService`, `TauriGitService`, `TauriFileSystemService` all still exist; `DesktopXxx` symbols do NOT yet exist.
+
+- [ ] **Step 11: Update `CHANGELOG.md` + `CHANGELOG.zh-CN.md`**
+
+Add a top-of-file entry (or extend the active section if one is in flight) describing PR-C's renderer-side IPC seam. Mirror the entry in `CHANGELOG.zh-CN.md`. Cross-link the entry to the relevant `docs/reviews/` patterns if any reviews surface during the PR (defer if none yet).
+
+---
+
+## Final Verification Checklist
+
+After Task 10 completes:
+
+- [ ] `npm run test` test count climbed by ~16 vs Task 0 baseline.
+- [ ] `cargo test` count byte-identical to PR-B baseline (PR-C touches no Rust).
+- [ ] `rg -n "from '@tauri-apps/api" src` returns exactly 2 hits (both in `src/lib/backend.ts`).
+- [ ] `rg -n "isTauri\b" src tests` returns zero hits.
+- [ ] `TauriTerminalService`, `TauriGitService`, `TauriFileSystemService` class names + filenames unchanged (PR-D renames).
+- [ ] Manual smoke (`npm run tauri:dev`) walks all 7 steps from Task 10 Step 6 without regression.
+- [ ] E2E (`npm run test:e2e`) green; harness unchanged.
+- [ ] No `style(...)` commits bundled with feature commits.
+
+When everything above is green, open the PR via `/lifeline:request-pr` (or manually):
+
+```bash
+git push -u origin <pr-c-branch>
+gh pr create \
+  --base dev \
+  --title "feat(frontend): PR-C — frontend backend bridge (Tauri host stays)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+PR-C of the 4-PR Tauri → Electron migration. Decouples the React
+renderer from `@tauri-apps/api` by introducing `src/lib/backend.ts`
+as the runtime-neutral IPC seam. Tauri host stays live through
+PR-C — the bridge falls back to `@tauri-apps/api` when
+`window.vimeflow` isn't set (PR-D ships the preload that sets it).
+
+## Spec + migration roadmap
+
+- Spec: `docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md`
+- Plan: `docs/superpowers/plans/2026-05-14-pr-c-frontend-backend-bridge.md`
+- Roadmap (4-PR index): `docs/superpowers/plans/2026-05-13-electron-rust-backend-migration.md`
+
+## Test plan
+
+- [x] `npm run test` — green (+16 unit tests across `backend.test.ts` and `environment.test.ts`)
+- [x] `npm run type-check` + `npm run lint` + `npm run format:check` — clean
+- [x] `cargo test` — green; count byte-identical to PR-B baseline
+- [x] Manual smoke: `npm run tauri:dev` — all 7 baseline flows work identically
+- [x] E2E: `npm run test:e2e` — green; harness unchanged
+- [x] Coupling inventory: `@tauri-apps/api` imports remain only in the bridge + bridge tests + environment's `__TAURI_INTERNALS__` probe
+
+## Cross-PR contract
+
+§2 of the spec locks three contracts PR-D consumes:
+
+- §2.1 — `BackendApi { invoke, listen }` surface (PR-D's `window.vimeflow` producer satisfies this)
+- §2.4 — `isDesktop()` OR-detection (correct under both Tauri-today and Electron-PR-D)
+- §2.5 — PR-D's bridge edit minimality: 4-to-6-line delete of the fallback imports + branches
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+(Adjust `--base dev` if the integration branch uses a different name.)
+
+After PR-C merges to `dev`:
+
+- The PR-D planner session can start. PR-D consumes §2.1, §2.4, and §2.5 of this PR's spec.
+- Local dev continues against Tauri (`npm run tauri:dev`) — PR-C didn't change the desktop shell.
+- `npm run test` test count climbed by ~16; `cargo test` count unchanged.

--- a/docs/superpowers/plans/2026-05-14-pr-c-frontend-backend-bridge.md
+++ b/docs/superpowers/plans/2026-05-14-pr-c-frontend-backend-bridge.md
@@ -143,10 +143,12 @@ The trailing `export {}` makes the file a module so `import type` is legal.
 - [ ] **Step 2: Verify `tsconfig.json` includes `src/types/**`\*\*
 
 ```bash
-grep -nE '"include"|"src/types"' tsconfig.json tsconfig.app.json 2>/dev/null
+grep -nE '"include"' tsconfig.json
 ```
 
-Expected: `src` is included by `tsconfig.app.json` (or whichever app-level config Vite uses), which covers `src/types/**` transitively. If not, the new ambient declaration won't load — add `"src/types/**/*.d.ts"` to the `"include"` array of the app-level tsconfig.
+Expected: a line like `"include": ["src"]`. This repo uses a single top-level `tsconfig.json` (no `tsconfig.app.json` split), and the `["src"]` include transitively covers `src/types/**`. The new ambient declaration loads automatically; no tsconfig edit is needed.
+
+If the `include` line is missing or doesn't contain `"src"`, investigate before continuing — the rest of the bridge won't be type-checked.
 
 - [ ] **Step 3: Write the failing tests in `src/lib/backend.test.ts`**
 
@@ -1469,6 +1471,18 @@ const mockedInvoke = vi.mocked(invoke)
 const mockedIsDesktop = vi.mocked(isDesktop)
 ```
 
+Critical: add a `beforeEach` that resets `mockedIsDesktop` to a safe default at the top of the test suite, so the per-test `mockReturnValue(true)` calls in Step 3 don't leak across the factory's three-way branch tests:
+
+```ts
+beforeEach(() => {
+  // Default: behave as non-desktop. Individual tests override.
+  mockedIsDesktop.mockReturnValue(false)
+  mockedInvoke.mockReset()
+})
+```
+
+Without this reset, a test setting `mockedIsDesktop.mockReturnValue(true)` would leak into the existing "returns HttpGitService when MODE=development and no desktop signal" test (or equivalent), which would then route to `TauriGitService` and fail in a confusing way. Vitest doesn't auto-reset `vi.mocked()` spies between tests unless `clearMocks: true` is set globally; this `beforeEach` makes the reset explicit.
+
 - [ ] **Step 3: Rewrite the factory test at `gitService.test.ts:401-416`**
 
 Today's test (paraphrased):
@@ -1635,56 +1649,109 @@ rg -n "event\.payload" src/features/terminal/services/tauriTerminalService.ts
 
 Expected: zero hits.
 
-- [ ] **Step 4: Edit `tauriTerminalService.test.ts` mock + fixtures**
+- [ ] **Step 4: Edit `tauriTerminalService.test.ts` — migrate the stateful mock**
 
-Replace the top-level mocks:
+The existing test file does NOT use a simple `vi.fn()` for `listen` —
+it uses a stateful mock impl that records callbacks in an
+`eventListeners` Map so `emitTauriEvent` can later fire them. Preserve
+that pattern; only the imported module changes (and the
+`Event<T>.payload` unwrap).
+
+Replace the top-level mock block + dynamic-invoke import:
 
 ```ts
-// Before:
-import { invoke } from '@tauri-apps/api/core'
-import { listen } from '@tauri-apps/api/event'
+// Before (top of file, lines ~1-40):
+import { describe, test, expect, beforeEach, vi, type Mock } from 'vitest'
+import { TauriTerminalService } from './tauriTerminalService'
 
-vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
-vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+type EventCallback = (event: { payload: unknown }) => void
+const eventListeners = new Map<string, EventCallback[]>()
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(
+    (eventName: string, callback: EventCallback): Promise<() => void> => {
+      const existing = eventListeners.get(eventName) ?? []
+      existing.push(callback)
+      eventListeners.set(eventName, existing)
+
+      return Promise.resolve(() => {
+        const cbs = eventListeners.get(eventName) ?? []
+        const index = cbs.indexOf(callback)
+        if (index > -1) {
+          cbs.splice(index, 1)
+        }
+      })
+    }
+  ),
+}))
+
+const emitTauriEvent = (eventName: string, payload: unknown): void => {
+  const callbacks = eventListeners.get(eventName) ?? []
+  callbacks.forEach((cb) => cb({ payload }))
+}
+
+const { invoke } = await import('@tauri-apps/api/core')
 
 // After:
-import { invoke, listen } from '../../../lib/backend'
+import { describe, test, expect, beforeEach, vi, type Mock } from 'vitest'
+import { TauriTerminalService } from './tauriTerminalService'
+import { invoke } from '../../../lib/backend'
+
+type EventCallback = (payload: unknown) => void
+const eventListeners = new Map<string, EventCallback[]>()
 
 vi.mock('../../../lib/backend', () => ({
   invoke: vi.fn(),
-  listen: vi.fn(),
+  listen: vi.fn(
+    (eventName: string, callback: EventCallback): Promise<() => void> => {
+      const existing = eventListeners.get(eventName) ?? []
+      existing.push(callback)
+      eventListeners.set(eventName, existing)
+
+      return Promise.resolve(() => {
+        const cbs = eventListeners.get(eventName) ?? []
+        const index = cbs.indexOf(callback)
+        if (index > -1) {
+          cbs.splice(index, 1)
+        }
+      })
+    }
+  ),
 }))
-```
 
-Update the `EventCallback` type alias:
-
-```ts
-// Before:
-type EventCallback = (event: { payload: unknown }) => void
-
-// After:
-type EventCallback = (payload: unknown) => void
-```
-
-Update the `emitTauriEvent` helper (around line 34):
-
-```ts
-// Before:
 const emitTauriEvent = (eventName: string, payload: unknown): void => {
-  const call = mockedListen.mock.calls.find((c) => c[0] === eventName)
-  const cb = call?.[1] as EventCallback
-  cb({ payload })
-}
-
-// After:
-const emitTauriEvent = (eventName: string, payload: unknown): void => {
-  const call = mockedListen.mock.calls.find((c) => c[0] === eventName)
-  const cb = call?.[1] as EventCallback
-  cb(payload)
+  const callbacks = eventListeners.get(eventName) ?? []
+  callbacks.forEach((cb) => cb(payload))
 }
 ```
 
-(The helper name `emitTauriEvent` is now slightly stale — the emission isn't Tauri-specific anymore — but renaming it is a drive-by; leave it.)
+Key changes:
+
+- `vi.mock('@tauri-apps/api/core', ...)` + `vi.mock('@tauri-apps/api/event', ...)` collapse into a single `vi.mock('../../../lib/backend', ...)` factory exposing both `invoke` and `listen`.
+- `EventCallback` type changes from `(event: { payload: unknown }) => void` to `(payload: unknown) => void` (bridge surface).
+- `emitTauriEvent` fires with bare `payload`, not `{ payload }`.
+- The top-level `const { invoke } = await import('@tauri-apps/api/core')` (line 40) becomes a regular top-level `import { invoke } from '../../../lib/backend'` — the bridge mock factory exposes the spy directly, so no dynamic-import workaround is needed.
+- The helper name `emitTauriEvent` stays (drive-by rename out of scope).
+
+- [ ] **Step 4b: Migrate the F1 regression test's dynamic import (line ~428)**
+
+The existing F1 regression test (`F1 regression: onData await blocks until underlying listen attaches`) does a dynamic `await import('@tauri-apps/api/event')` to retrieve the listen mock and stall it. After migration, it imports from the bridge module instead:
+
+```ts
+// Before (around line 428):
+const eventModule = await import('@tauri-apps/api/event')
+const listenMock = vi.mocked(eventModule.listen)
+
+// After:
+const backendModule = await import('../../../lib/backend')
+const listenMock = vi.mocked(backendModule.listen)
+```
+
+The rest of the test body — the `listenGate`, `stalledImpl`, callback recording into `eventListeners`, `releaseListen()` — works unchanged. Critical: the `stalledImpl` callback still records into `eventListeners` and `emitTauriEvent` reads from the same map, so the stall-then-release flow stays intact.
 
 - [ ] **Step 5: Sanity grep**
 
@@ -1780,8 +1847,10 @@ Expected: byte-identical test count to the post-PR-B baseline. A diff here means
 
 ```bash
 rg -nE "@tauri-apps/api|__TAURI_INTERNALS__" src tests > /tmp/pr-c-final.txt
-diff /tmp/pr-c-baseline.txt /tmp/pr-c-final.txt
+diff /tmp/pr-c-baseline.txt /tmp/pr-c-final.txt || true
 ```
+
+`diff` exits non-zero whenever the files differ — and after a successful migration they SHOULD differ (entries for `useGitBranch.ts`, `useGitStatus.ts`, etc. drop out of the final list). The `|| true` swallows that expected non-zero, so a shell with `set -e` doesn't abort. Read the actual diff output to confirm what changed.
 
 Expected: production hits remain in exactly these files (no others):
 
@@ -1819,19 +1888,23 @@ npm run test:e2e
 
 Expected: all green. The `e2e-bridge.ts` migration is a one-line import swap; the runtime path through `tauri-driver` + Wry is unchanged. If a spec fails, it's a real regression — do not paper it over by adjusting the spec.
 
-- [ ] **Step 8: Frontend-only Tauri references — should be zero outside the bridge**
+- [ ] **Step 8: Frontend-only Tauri references — should be confined to the bridge module**
+
+Production code (excluding tests):
 
 ```bash
-rg -n "from '@tauri-apps/api" src
+rg -n "from '@tauri-apps/api" src --glob '!*.test.ts' --glob '!*.test.tsx'
 ```
 
-Expected: 2 hits, both in `src/lib/backend.ts` (the fallback's runtime imports). Anything else means a renderer file still imports `@tauri-apps/api` directly — fix before opening the PR.
+Expected: exactly 2 hits, both in `src/lib/backend.ts` (the fallback's runtime imports for `core` + `event`). Anything else means a renderer file still imports `@tauri-apps/api` directly — fix before opening the PR.
+
+Test code (separate check):
 
 ```bash
-rg -n "from '@tauri-apps/api" src/lib/backend.test.ts
+rg -n "from '@tauri-apps/api" src tests
 ```
 
-Expected: 2 hits (the test mocks the same two modules the bridge consumes). These ARE expected — the test exercises the fallback path explicitly.
+Expected: 4 hits total. 2 in `src/lib/backend.ts` (the production fallback imports above) PLUS 2 in `src/lib/backend.test.ts` (the test imports the same two mocked modules so the spies are typed). Both pairs are intentional — the bridge module owns the only `@tauri-apps/api` surface area in PR-C, and its test exercises the fallback against the real module identifiers.
 
 - [ ] **Step 9: No drive-by formatting in feature commits**
 
@@ -1863,9 +1936,27 @@ rg -n "TauriXxx|DesktopXxx" src 2>&1 | head -5
 
 (Sanity check that we did NOT rename the class identifiers — those wait for PR-D.) Expected: `TauriTerminalService`, `TauriGitService`, `TauriFileSystemService` all still exist; `DesktopXxx` symbols do NOT yet exist.
 
-- [ ] **Step 11: Update `CHANGELOG.md` + `CHANGELOG.zh-CN.md`**
+- [ ] **Step 11: Update `CHANGELOG.md` + `CHANGELOG.zh-CN.md` (separate commit)**
 
 Add a top-of-file entry (or extend the active section if one is in flight) describing PR-C's renderer-side IPC seam. Mirror the entry in `CHANGELOG.zh-CN.md`. Cross-link the entry to the relevant `docs/reviews/` patterns if any reviews surface during the PR (defer if none yet).
+
+This step happens AFTER Steps 1-10 of the verification gate have all passed. It introduces file changes, so it MUST be its own commit (not bundled with feature work) and the formatting gate must re-run:
+
+```bash
+git add CHANGELOG.md CHANGELOG.zh-CN.md
+npm run format:check
+git commit -m "docs(changelog): pr-c frontend backend bridge entry"
+```
+
+If `format:check` fails (likely on the bilingual markdown line wrapping), run `npm run format` first, re-add, then commit. The other gate commands (`npm run lint`, `type-check`, `test`, `cargo test`, `test:e2e`) only check source code paths the CHANGELOG does not touch, so re-running them is optional. The `tauri:dev` manual smoke is similarly unaffected.
+
+- [ ] **Step 12: Final coupling re-check after CHANGELOG commit**
+
+```bash
+rg -nE "@tauri-apps/api|__TAURI_INTERNALS__" src tests
+```
+
+Same expected residual hits as Step 5. The CHANGELOG commit shouldn't touch any of these paths; this re-check confirms nothing accidentally leaked in via a paired CHANGELOG-flavored "I'm already here" edit (see `rules/common/pr-scope.md`).
 
 ---
 

--- a/docs/superpowers/plans/2026-05-14-pr-c-frontend-backend-bridge.md
+++ b/docs/superpowers/plans/2026-05-14-pr-c-frontend-backend-bridge.md
@@ -2024,3 +2024,5 @@ After PR-C merges to `dev`:
 - The PR-D planner session can start. PR-D consumes §2.1, §2.4, and §2.5 of this PR's spec.
 - Local dev continues against Tauri (`npm run tauri:dev`) — PR-C didn't change the desktop shell.
 - `npm run test` test count climbed by ~16; `cargo test` count unchanged.
+
+<!-- codex-reviewed: 2026-05-14T10:03:01Z -->

--- a/docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md
+++ b/docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md
@@ -72,7 +72,17 @@ Contract details:
 
 - `invoke<T>(method, args?)` returns `Promise<T>`. The `T` parameter is
   the deserialized `result` field of the response frame (PR-B §5.1.2).
-  Errors reject the promise with **the underlying transport's reject
+  The `args` parameter is optional at the renderer-facing surface
+  (`args?: Record<string, unknown>`) because many command call sites
+  pass no payload (`invoke('list_sessions')`). The bridge MUST pass
+  `args` through to the underlying transport unchanged — Tauri's
+  `tauriInvoke(method, undefined)` already handles undefined; PR-D's
+  `window.vimeflow.invoke` producer (Electron preload) MUST normalize
+  to `params: args ?? {}` when serializing the request frame, because
+  PR-B §5.1.1 requires the `params` field to be an object (the sidecar
+  router decodes empty objects per-method, but rejects missing keys).
+  This normalization lives in the preload, not the bridge.
+- Errors reject the promise with **the underlying transport's reject
   value, passed through unchanged**. The bridge MUST NOT wrap, transform,
   or normalize the rejection shape. Today that means Tauri's invoke
   rejects with a string (Rust's `Result<T, String>` Err arm reaches JS
@@ -323,8 +333,9 @@ import { listen as tauriListen } from '@tauri-apps/api/event'
 /**
  * Detach a previously-registered listener. Idempotent — a second call is
  * a no-op. PR-D removes the `@tauri-apps/event` import and the
- * `tauriUnlisten` branch below; the bridge then returns the
- * `window.vimeflow.listen` unsubscribe function directly.
+ * `tauriUnlisten` branch below; the bridge's `called` guard wrapper
+ * (in `listen()` below) stays so StrictMode double-cleanup remains
+ * safe regardless of which transport produced `rawUnlisten`.
  */
 export type UnlistenFn = () => void
 

--- a/docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md
+++ b/docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md
@@ -840,3 +840,5 @@ in `src/lib/`. After PR-D, the e2e-bridge will be the only file in
 `tests/e2e/shared/` or `src/test/` so renderer-runtime code and
 test-instrumentation code live in different directories. Defer to a
 follow-up PR; not blocking PR-C or PR-D.
+
+<!-- codex-reviewed: 2026-05-14T09:17:09Z -->

--- a/docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md
+++ b/docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md
@@ -1,0 +1,831 @@
+# PR-C — Frontend backend bridge (renderer migration)
+
+## 1. Overview
+
+**Goal.** Decouple the React renderer from `@tauri-apps/api` by introducing
+`src/lib/backend.ts` as the runtime-neutral IPC seam. Migrate 7 renderer
+files (3 services, 3 hooks, 1 e2e-bridge module — enumerated in §3) off
+direct Tauri imports onto the bridge. Tauri host stays the live runtime
+through the whole PR — the bridge falls back to `@tauri-apps/api` when
+`window.vimeflow` isn't set (the PR-C steady state). PR-D ships the
+Electron preload that sets `window.vimeflow` and drops the fallback.
+
+**Non-goals.**
+
+- No Electron shell. No sidecar spawning. No `window.vimeflow` producer.
+- No Rust changes (PR-A locked the runtime-neutral surface; PR-B locked
+  the sidecar + IPC wire shape).
+- No class / file renames (`TauriTerminalService`, `TauriGitService`,
+  `TauriFileSystemService` and the matching `tauriXxxService.ts`
+  filenames keep their identity through PR-C — they're renamed to
+  `DesktopXxx` in PR-D when `@tauri-apps/*` actually leaves the tree).
+  The `isTauri` → `isDesktop` environment-helper API rename IS in scope
+  because the helper's semantics genuinely change (see §2.4 and §3.2).
+- No E2E driver swap (`tests/e2e/shared/tauri-driver.ts` stays; PR-D
+  moves the harness to Electron).
+- No `package.json` dep removal — `@tauri-apps/api` stays through PR-C
+  because the bridge's fallback branch still imports it.
+- No `src-tauri/**`, no `tests/e2e/**`, no `src/bindings/**` touches.
+
+**Roadmap context.** Implements a strict subset of Task 2 + Task 8 + the
+`e2e-bridge` slice of Task 9 from
+`docs/superpowers/plans/2026-05-13-electron-rust-backend-migration.md`.
+
+The subset cuts:
+
+- Task 2 — only the renderer-side `BackendApi` surface lands; the
+  `window.vimeflow` producer is deferred to PR-D's Electron preload.
+- Task 8 — only the import-path migration lands. `TauriXxx` → `DesktopXxx`
+  class/file renames and `@tauri-apps/*` dep removal are deferred to PR-D.
+- Task 9 — only `src/lib/e2e-bridge.ts` migrates onto the bridge. The
+  `tauri-driver` → Electron launcher swap stays in PR-D.
+
+The bridge's renderer-side surface is designed to satisfy §5.1 (IPC wire
+envelope) of
+`docs/superpowers/specs/2026-05-13-pr-b-rust-sidecar-ipc-design.md` so
+that PR-D's `window.vimeflow` producer (Electron preload + `ipcMain`
+dispatch to the Rust sidecar) plugs in without further renderer churn.
+PR-C itself does NOT exercise §5.1 — the Tauri fallback path bypasses
+the wire envelope entirely.
+
+## 2. Cross-PR contract
+
+### 2.1 `BackendApi` shape (the seam)
+
+`src/lib/backend.ts` exports module-level `invoke` and `listen` functions
+and the `BackendApi` interface they implement:
+
+```ts
+export type UnlistenFn = () => void
+
+export interface BackendApi {
+  invoke: <T>(method: string, args?: Record<string, unknown>) => Promise<T>
+
+  listen: <T>(
+    event: string,
+    callback: (payload: T) => void
+  ) => Promise<UnlistenFn>
+}
+```
+
+Contract details:
+
+- `invoke<T>(method, args?)` returns `Promise<T>`. The `T` parameter is
+  the deserialized `result` field of the response frame (PR-B §5.1.2).
+  Errors reject the promise with **the underlying transport's reject
+  value, passed through unchanged**. The bridge MUST NOT wrap, transform,
+  or normalize the rejection shape. Today that means Tauri's invoke
+  rejects with a string (Rust's `Result<T, String>` Err arm reaches JS
+  as a bare string, not an `Error`). In PR-D, `window.vimeflow.invoke`
+  MUST reject with the sidecar response frame's `error` field as a bare
+  string, preserving the same shape. Call sites today read rejections as
+  `catch (err: unknown)` and coerce via `String(err)` / `err instanceof Error`
+  — that pattern stays valid.
+- `listen<T>(event, callback)` returns `Promise<UnlistenFn>`. The
+  function MUST resolve only after the underlying transport listener is
+  fully attached, so callers can `await listen(...)` before triggering
+  IPC that would otherwise race the attachment (currently load-bearing
+  in `TauriTerminalService.ensureListeners` and `useAgentStatus` —
+  preserving this is a hard requirement, not a nice-to-have).
+- The `callback(payload)` argument is the bare `payload` field of the
+  event frame, never Tauri's `Event<T>` wrapper. Existing call sites
+  that destructure `event.payload` must update — the bridge unwraps
+  on the Tauri fallback path so all consumers code against the same
+  shape PR-D will ship natively.
+- The returned `UnlistenFn` detaches the transport listener AND is
+  idempotent (calling it twice is a no-op). Consumers store it in
+  refs / arrays and invoke it during effect cleanup; double-fire is
+  observed today in StrictMode dev paths.
+
+### 2.2 Layered implementation
+
+`window.vimeflow?: BackendApi` is the production target. PR-C's bridge
+checks `window.vimeflow` at call-time and delegates if present;
+otherwise it falls back to `@tauri-apps/api/core` (`invoke`) and
+`@tauri-apps/api/event` (`listen`), unwrapping `Event<T>.payload` so
+the callback surface stays uniform.
+
+During PR-C, `window.vimeflow` is never set in production — Tauri is
+the host and there is no preload to install it. The branch exists for
+two reasons:
+
+1. **PR-D edit minimality.** PR-D removes the `@tauri-apps` imports and
+   both fallback `else` branches in a 4-to-6-line delete. No reshape
+   of the function signatures.
+2. **Test ergonomics.** Unit tests exercise both paths by fabricating
+   a `window.vimeflow` (the production target shape) and by leaving it
+   unset (the current Tauri fallback). Both paths must be tested or
+   PR-D's edit could regress the live path.
+
+### 2.4 `isDesktop()` semantics
+
+`src/lib/environment.ts` exports `isDesktop()` (renamed from
+`isTauri()`). The function returns `true` when EITHER signal is
+present on `window`:
+
+```ts
+export const isDesktop = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  return window.__TAURI_INTERNALS__ != null || window.vimeflow != null
+}
+```
+
+The signal check uses `!= null` (not `in window`) so that an explicit
+`window.vimeflow = undefined` — which tests set when exercising the
+fallback path — does NOT trip the detection. Tauri sets
+`__TAURI_INTERNALS__` to a real object; Electron preload (PR-D) will
+set `vimeflow` to the `BackendApi` instance. Anything else is browser
+/ Vitest.
+
+The OR makes the factory pattern correct in both PR-C and PR-D:
+
+- **PR-C (Tauri host).** `__TAURI_INTERNALS__` is set, `vimeflow` is
+  not. Factories return `TauriXxx` services. Bridge falls back to
+  `@tauri-apps/api`.
+- **PR-D (Electron host).** `vimeflow` is set, `__TAURI_INTERNALS__`
+  is not. Factories return the same `TauriXxx` services (renamed to
+  `DesktopXxx` in PR-D). Bridge uses `window.vimeflow` directly.
+- **Browser / Vitest jsdom.** Neither signal is set. Factories
+  return `MockXxx` / `HttpXxx`. Bridge functions are never called.
+
+`isBrowser()` stays as `!isDesktop()`. `getEnvironment()` returns
+`'desktop' | 'browser'` (the `'tauri'` literal is retired). The
+rename is API-visible: every consumer of `isTauri()` /
+`getEnvironment() === 'tauri'` must update. There are exactly 3
+production call sites (`terminalService.ts:388`,
+`fileSystemService.ts:110`, `gitService.ts:180` — the last reads
+`__TAURI_INTERNALS__` directly) plus the test file, so no compat
+alias is provided.
+
+### 2.5 What PR-D consumes
+
+- PR-D will provide `window.vimeflow: BackendApi` from Electron preload,
+  forwarding to `ipcMain.handle('backend:invoke', ...)`. `ipcMain` then
+  speaks PR-B §5.1's LSP-style IPC frames to the Rust sidecar's stdin /
+  stdout.
+- PR-D will register a `webContents.send('backend:event', ...)` fan-out
+  so sidecar event frames reach every renderer that called
+  `window.vimeflow.listen(...)`.
+- PR-D will delete the `@tauri-apps/api/core` + `@tauri-apps/api/event`
+  imports from `src/lib/backend.ts` and the fallback branches that
+  wrap them. PR-D MUST ALSO either:
+  - (a) tighten `Window.vimeflow?` to `Window.vimeflow` (required) in
+    `src/types/vimeflow.d.ts` — appropriate because Electron preload
+    guarantees the global is set before the renderer boots; OR
+  - (b) keep the `typeof window !== 'undefined' && window.vimeflow`
+    guard and throw a clear error when the global is missing,
+    preserving the optional `?` annotation.
+
+  (a) is preferred — it shrinks the bridge body to a one-liner per
+  function and matches the runtime invariant the preload installs.
+  (b) is the safe fallback if the typings should keep room for a
+  partially-bootstrapped renderer (e.g. early-load diagnostic paths).
+  Either way, the bridge body is no larger than three lines per
+  function and the idempotency guard from §4.1 stays put.
+
+## 3. File structure & touch list
+
+### 3.1 New (3 files)
+
+- `src/lib/backend.ts` — defines `BackendApi`, `UnlistenFn`, and the
+  module-level `invoke` + `listen` functions. Does NOT redeclare
+  `Window.vimeflow` — that ambient augmentation lives in
+  `src/types/vimeflow.d.ts` (single owner; see below). `backend.ts`
+  reads `window.vimeflow` at call-time; the augmentation makes the
+  access type-safe.
+- `src/lib/backend.test.ts` — Vitest unit tests covering both layered
+  paths (synthetic `window.vimeflow` + Tauri fallback), payload
+  unwrap on the fallback, `UnlistenFn` idempotency, listener
+  attach-before-resolve contract.
+- `src/types/vimeflow.d.ts` — the **single owner** of the
+  `Window.vimeflow?: BackendApi` ambient global augmentation. Kept in
+  `src/types/` (the project's existing global-types directory) so
+  every file in the renderer sees the augmentation without importing
+  the bridge module. The file does `import type { BackendApi } from '../lib/backend'`
+  to reference the type; it is the only file with a `declare global`
+  block for `Window.vimeflow`. Avoiding a duplicate declaration in
+  `backend.ts` keeps the global single-owner so a third reader
+  (e.g. a future debug helper) can't accidentally end up with two
+  conflicting augmentations.
+
+### 3.2 Modified (16 files)
+
+`src/lib/`
+
+- `environment.ts` — rename `isTauri` → `isDesktop`; `isBrowser` becomes
+  `!isDesktop`; `getEnvironment` returns `'desktop' | 'browser'`. No
+  compat alias (blast radius is 3 production call sites — full rename
+  is cheaper than a deprecation cycle).
+- `environment.test.ts` — rename existing `isTauri` test cases to
+  match the new export name AND add coverage for the new OR-detection
+  semantics (§2.4):
+  - `isDesktop()` is `true` when `window.__TAURI_INTERNALS__ = {}`
+    is set (existing Tauri-detection case, renamed).
+  - `isDesktop()` is `true` when `window.vimeflow = { invoke: ..., listen: ... }`
+    is set, `__TAURI_INTERNALS__` absent (the PR-D / Electron signal).
+  - `isDesktop()` is `false` when `window.vimeflow = undefined`,
+    `__TAURI_INTERNALS__` absent (loose-comparison case — locks the
+    distinction between "property unset" and "property set to undefined").
+  - `isDesktop()` is `false` when neither global is present (browser /
+    Vitest baseline).
+    Renaming the existing test cases without adding the new ones leaves
+    the Electron-signal path uncovered; the migration MUST add the new
+    cases.
+- `e2e-bridge.ts` — replace the `@tauri-apps/api/core` `invoke` import
+  with `import { invoke } from './backend'`.
+
+`src/features/terminal/services/`
+
+- `terminalService.ts` — factory at line 388 swaps `isTauri()` for
+  `isDesktop()`. Class names + factory return shape unchanged.
+- `tauriTerminalService.ts` — imports flip to `src/lib/backend`.
+  Three `listen` callbacks (`pty-data`, `pty-exit`, `pty-error`)
+  refactor `(event) => { ... event.payload ... }` to
+  `(payload) => { ... payload ... }`. Class identifier stays
+  `TauriTerminalService` (PR-D renames).
+- `tauriTerminalService.test.ts` — `vi.mock('@tauri-apps/api/core', ...)`
+  and `vi.mock('@tauri-apps/api/event', ...)` become
+  `vi.mock('../../../lib/backend', ...)`; assertion helpers update to
+  the bare-payload shape.
+
+`src/features/files/services/`
+
+- `fileSystemService.ts` — drop dynamic `await import('@tauri-apps/api/core')`
+  inside each method; replace with a top-level `import { invoke } from '../../../lib/backend'`.
+  Factory at line 110 swaps `isTauri()` for `isDesktop()`. Three
+  call sites (`list_dir`, `read_file`, `write_file`) lose their
+  dynamic import boilerplate.
+- `fileSystemService.test.ts` — mock `../../../lib/backend` instead
+  of `@tauri-apps/api/core`.
+
+`src/features/diff/services/`
+
+- `gitService.ts` — factory at line 174-185 swaps
+  `'__TAURI_INTERNALS__' in window` for `isDesktop()` (importing
+  from `src/lib/environment`). `TauriGitService` class imports flip
+  to `src/lib/backend`. `MockGitService` and `HttpGitService` stay
+  unchanged.
+- `gitService.test.ts` — the test at line 401-416 that toggles
+  `__TAURI_INTERNALS__` is rewritten to toggle `isDesktop()` via a
+  `vi.mock('../../../lib/environment', ...)` spy; bridge mocks
+  replace `@tauri-apps/api/core`.
+
+`src/features/diff/hooks/`
+
+- `useGitBranch.ts` — single `invoke` import flips to `src/lib/backend`.
+  No `listen` calls in this hook.
+- `useGitBranch.test.ts` — mock `../../../lib/backend`.
+- `useGitStatus.ts` — `invoke` + `listen` + `UnlistenFn` imports
+  flip to `src/lib/backend`. One `listen<GitStatusChangedPayload>`
+  callback refactors `event.payload` → bare payload.
+- `useGitStatus.test.ts` — mock `../../../lib/backend`.
+
+`src/features/agent-status/hooks/`
+
+- `useAgentStatus.ts` — `invoke` + `listen` imports flip to
+  `src/lib/backend`. Four `listen` callbacks
+  (`agent-status`, `agent-tool-call`, `agent-turn`, `test-run`)
+  refactor `(event) => { ... event.payload ... }` to
+  `(payload) => { ... payload ... }`. This is the highest-touch
+  file in the PR.
+- `useAgentStatus.test.ts` — mock `../../../lib/backend`.
+
+### 3.3 NOT touched
+
+- `src-tauri/**` — Rust runtime locked by PR-A/B; no IPC shape
+  changes mean no Rust diff.
+- `electron/**` — does not exist; PR-D creates it.
+- `tests/e2e/**` — driver swap stays in PR-D. The frontend bridge
+  migration of `src/lib/e2e-bridge.ts` is the only E2E-adjacent
+  touch (and it's a renderer-side file, not a harness file).
+- `src/bindings/**` — no Rust IPC shape changes; ts-rs output is
+  byte-identical.
+- `package.json` — `@tauri-apps/api` stays in `dependencies`
+  through PR-C because the bridge's fallback branch still imports
+  from it. `@tauri-apps/cli` and the `tauri:*` npm scripts also
+  stay — they're the local dev runtime.
+- `vite.config.ts` — no plugin / alias / `base` changes. The bridge
+  is a pure source-level abstraction.
+- `MockGitService`, `HttpGitService`, `MockTerminalService`,
+  `MockFileSystemService` — unchanged. Mock services don't import
+  `@tauri-apps/api` today; only the Tauri-flavored services do.
+
+## 4. Bridge implementation sketch
+
+### 4.1 `src/lib/backend.ts` (~60 lines)
+
+```ts
+import { invoke as tauriInvoke } from '@tauri-apps/api/core'
+import { listen as tauriListen } from '@tauri-apps/api/event'
+
+/**
+ * Detach a previously-registered listener. Idempotent — a second call is
+ * a no-op. PR-D removes the `@tauri-apps/event` import and the
+ * `tauriUnlisten` branch below; the bridge then returns the
+ * `window.vimeflow.listen` unsubscribe function directly.
+ */
+export type UnlistenFn = () => void
+
+export interface BackendApi {
+  invoke: <T>(method: string, args?: Record<string, unknown>) => Promise<T>
+
+  listen: <T>(
+    event: string,
+    callback: (payload: T) => void
+  ) => Promise<UnlistenFn>
+}
+
+/**
+ * Invoke a backend command. Prefers `window.vimeflow.invoke` (PR-D's
+ * Electron preload target) when set; otherwise falls back to
+ * `@tauri-apps/api/core` so the Tauri host keeps working through end
+ * of PR-C. Rejection value is the transport's reject value, passed
+ * through unchanged — Tauri rejects with a bare string, sidecar
+ * (PR-D) MUST reject with the same shape.
+ */
+export const invoke = async <T>(
+  method: string,
+  args?: Record<string, unknown>
+): Promise<T> => {
+  if (typeof window !== 'undefined' && window.vimeflow) {
+    return window.vimeflow.invoke<T>(method, args)
+  }
+  return tauriInvoke<T>(method, args)
+}
+
+/**
+ * Subscribe to a backend event. Callback receives the bare payload
+ * (NOT Tauri's `Event<T>` envelope). The returned promise resolves
+ * only after the underlying transport listener is attached, so
+ * callers can `await listen(...)` before triggering IPC that would
+ * otherwise race the attachment. The returned `UnlistenFn` detaches
+ * the listener AND is idempotent — the bridge wraps the transport's
+ * unlisten with a `called` guard so React StrictMode's
+ * mount→cleanup→remount double-fire is safe regardless of whether
+ * the transport itself is idempotent.
+ */
+export const listen = async <T>(
+  event: string,
+  callback: (payload: T) => void
+): Promise<UnlistenFn> => {
+  const rawUnlisten =
+    typeof window !== 'undefined' && window.vimeflow
+      ? await window.vimeflow.listen<T>(event, callback)
+      : // Tauri fallback: unwrap `Event<T>.payload` so the callback shape
+        // is uniform across both paths. `tauriListen` resolves after the
+        // listener has attached on the Rust side, so awaiting preserves
+        // the load-bearing attach-before-resolve contract.
+        await tauriListen<T>(event, (e) => callback(e.payload))
+
+  // Idempotency guard: a second invocation is a no-op. Defends against
+  // StrictMode double-cleanup AND against transports that throw on
+  // double-detach (no guarantee `tauriListen` / `window.vimeflow.listen`
+  // tolerate it).
+  let called = false
+  return () => {
+    if (called) return
+    called = true
+    rawUnlisten()
+  }
+}
+```
+
+Notes:
+
+- The bridge does NOT import `UnlistenFn` from `@tauri-apps/api/event`.
+  It defines its own `UnlistenFn = () => void` so PR-D's @tauri-apps
+  removal touches the bridge module only.
+- `typeof window !== 'undefined'` guards against SSR / Node-only
+  contexts. The bridge is renderer-only today, but the guard is cheap
+  and matches the existing `isTauri()` pattern.
+- No singleton state, no init promise — the bridge is fully stateless.
+  Per-listener attach state lives in the underlying transport
+  (`@tauri-apps/api/event` for now, `window.vimeflow` in PR-D).
+
+### 4.2 `src/types/vimeflow.d.ts` (~10 lines)
+
+```ts
+import type { BackendApi } from '../lib/backend'
+
+declare global {
+  interface Window {
+    /**
+     * Electron preload's contextBridge exposes the backend API here
+     * starting in PR-D. Undefined during PR-C — the bridge in
+     * `src/lib/backend.ts` falls back to `@tauri-apps/api` in that
+     * case. Tests fabricate this object to exercise the
+     * production-target code path.
+     */
+    vimeflow?: BackendApi
+  }
+}
+
+export {}
+```
+
+The trailing `export {}` makes the file a module so the `import type`
+above is legal; the `declare global` block extends `Window`
+program-wide.
+
+### 4.3 `src/lib/backend.test.ts` testbed (~10 cases)
+
+Two top-level `describe` blocks — one per code path:
+
+**`describe('backend (window.vimeflow path)')` — 6 cases:**
+
+1. `invoke` delegates to `window.vimeflow.invoke` with the same
+   `method` + `args` arguments. Assert called-with shape; assert
+   resolved value passes through.
+2. `invoke<T>` rejection passes through unchanged when
+   `window.vimeflow.invoke` rejects.
+3. `listen` delegates to `window.vimeflow.listen`. Assert
+   `window.vimeflow.listen` was called once with the bridge's event
+   name + a function arg. (No identity check on the returned
+   `UnlistenFn` — the bridge wraps with a `called` guard per §4.1, so
+   `listen`'s return value is a new function, not the transport's
+   raw unlisten.)
+4. `listen` callback is invoked with the bare payload object when
+   `window.vimeflow.listen`'s implementation fires it — no
+   `Event<T>` wrapping done by the bridge.
+5. `listen` resolves only after `window.vimeflow.listen` has
+   resolved. Same deferred-mock pattern as case #10 — locks the
+   attach-before-resolve contract on the production-target path too,
+   not only the Tauri fallback. This is the case that catches a
+   PR-D regression where the preload's `listen` resolves before
+   `ipcRenderer.on` has attached.
+6. `UnlistenFn` from the `window.vimeflow` path is idempotent. Same
+   spy-on-raw-unlisten assertion as case #9, against
+   `window.vimeflow.listen`'s returned unlisten. The bridge's
+   `called` guard wraps regardless of which path produced
+   `rawUnlisten`, so this test confirms the guard runs on both
+   paths.
+
+**`describe('backend (@tauri-apps fallback path)')` — 6 cases:**
+
+5. `invoke` delegates to `tauriInvoke` when `window.vimeflow` is
+   undefined; method + args preserved.
+6. `invoke` rejection passes through Tauri's bare-string rejection
+   shape unchanged.
+7. `listen` wraps `tauriListen` — the callback registered with
+   Tauri unwraps `Event<T>.payload` before calling the bridge's
+   callback. Fire a synthetic `Event<T>` through the Tauri mock
+   and assert the bridge callback received `event.payload`, not
+   the whole event.
+8. The `UnlistenFn` returned by `listen` calls through to the
+   `tauriListen`-resolved unlisten function on invocation. Mocking
+   spy on the raw unlisten verifies the call-through. (No identity
+   check — bridge's `called` guard from §4.1 makes the returned
+   function a wrapper, not the raw transport function.)
+9. `UnlistenFn` is idempotent. A second invocation is a no-op:
+   assert the spy on the raw transport unlisten was called exactly
+   once after two invocations of the bridge's `UnlistenFn`. The
+   idempotency lives in the bridge's `called` guard, NOT in the
+   transport — `tauriListen` / `window.vimeflow.listen` may or may
+   not be idempotent themselves; the bridge's wrapper makes the
+   guarantee unconditional.
+10. `listen` resolves only after `tauriListen` has resolved. Use
+    a deferred mock that resolves on demand; assert the bridge's
+    `listen` promise stays pending until the underlying resolve
+    fires. This locks the load-bearing attach-before-resolve
+    contract (currently relied on by `TauriTerminalService` and
+    `useAgentStatus`).
+
+`beforeEach` for the `window.vimeflow` block fabricates an object
+matching `BackendApi` and assigns it to `window.vimeflow`. `beforeEach`
+for the fallback block calls `delete (window as Window).vimeflow`.
+Both forms (`delete` and `= undefined`) actually satisfy §2.4's
+`!= null` check because `undefined != null` is `false` under loose
+comparison — the `delete` form is preferred only because it's more
+idiomatic for "this global isn't installed". Both blocks use
+`vi.mock('@tauri-apps/api/core', ...)` + `vi.mock('@tauri-apps/api/event', ...)`
+to inject deterministic fakes for the Tauri path; the
+`window.vimeflow` block additionally exercises a synthetic global so
+the fallback mocks are present but never called.
+
+## 5. Migration strategy
+
+### 5.1 Common pattern (5 of 7 files)
+
+Three-step migration:
+
+1. Replace `import { invoke } from '@tauri-apps/api/core'` and
+   `import { listen, type UnlistenFn } from '@tauri-apps/api/event'`
+   with a single `import { invoke, listen, type UnlistenFn } from '<path>/lib/backend'`
+   (using the correct relative path for the file).
+2. For each `listen<T>(name, (event) => { ... event.payload ... })`
+   callback, refactor to `(payload) => { ... payload ... }`. The
+   destructure-from-payload form is preferred over destructure-in-
+   params (`({ a, b }) => ...`) because it keeps `payload` available
+   when callbacks need to read additional fields conditionally
+   (see `useAgentStatus`).
+3. Update the sibling test:
+   - `vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))` and
+     `vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))`
+     become a single
+     `vi.mock('<path>/lib/backend', () => ({ invoke: vi.fn(), listen: vi.fn() }))`.
+   - Any test that constructed a synthetic `Event<T>` wrapper
+     (`{ event, id, payload, windowLabel }`) to pass into the listener
+     callback now passes the bare payload object.
+   - `mockedInvoke` / `mockedListen` references stay valid via
+     `vi.mocked(invoke)` / `vi.mocked(listen)` against the new module.
+
+Files fitting the pattern: `e2e-bridge.ts` (invoke only), `useGitBranch.ts`
+(invoke only), `useGitStatus.ts` (invoke + 1 listen), `useAgentStatus.ts`
+(invoke + 4 listens), `tauriTerminalService.ts` (invoke + 3 listens).
+
+### 5.2 Special case — `fileSystemService.ts` (dynamic → static import)
+
+Today each of the three methods (`listDir`, `readFile`, `writeFile`)
+has a top-level `const { invoke } = await import('@tauri-apps/api/core')`.
+The dynamic import was a workaround so the @tauri-apps bundle didn't
+ship to mock callers in browser builds.
+
+After migration: a single top-level
+`import { invoke } from '../../../lib/backend'`. The dynamic-import
+boilerplate disappears from all three methods.
+
+The dynamic import is NOT load-bearing today: `useAgentStatus.ts`,
+`useGitStatus.ts`, `useGitBranch.ts`, `gitService.ts`, and
+`tauriTerminalService.ts` all import `@tauri-apps/api` at module-top
+and are themselves imported eagerly by `WorkspaceView` /
+`createTerminalService` / `createGitService`. So `@tauri-apps/api`
+is already in every production bundle — `fileSystemService`'s
+dynamic-import workaround is an isolated outlier, not a bundle-wide
+discipline. Making it consistent with the other six files (all
+static via the bridge) does NOT introduce a regression. PR-D's
+removal of `@tauri-apps/api` from the bridge — and from
+`package.json` — is what actually shrinks the bundle.
+
+### 5.3 Special case — `gitService.ts` (factory branching)
+
+Today lines 174-185 read:
+
+```ts
+if (import.meta.env.MODE === 'test') return new MockGitService()
+if ('__TAURI_INTERNALS__' in window) return new TauriGitService(cwd)
+return new HttpGitService()
+```
+
+After:
+
+```ts
+if (import.meta.env.MODE === 'test') return new MockGitService()
+if (isDesktop()) return new TauriGitService(cwd)
+return new HttpGitService()
+```
+
+`TauriGitService` keeps its name through PR-C (PR-D renames). The
+factory's `isDesktop()` call detects BOTH Tauri (today, via
+`__TAURI_INTERNALS__`) AND Electron (PR-D, via `window.vimeflow`),
+so the factory branch stays correct across both runtimes.
+
+The sibling test at `gitService.test.ts:401-416` currently sets
+`__TAURI_INTERNALS__` directly to drive the factory. After migration,
+the test mocks `isDesktop()` via
+`vi.mock('../../../lib/environment', () => ({ isDesktop: vi.fn() }))`
+and uses `mockedIsDesktop.mockReturnValue(true|false)`. No more
+direct manipulation of the global object — the abstraction is the
+seam the test should poke.
+
+The factory's first branch (`if (import.meta.env.MODE === 'test') return new MockGitService()`)
+short-circuits before `isDesktop()` runs, so the test MUST also
+override `MODE` before mocking `isDesktop()` to true. The existing
+suite at `gitService.test.ts:380-420` already does this via
+`vi.stubEnv('MODE', 'development')` / a similar mechanism — the
+migration MUST preserve that override; mocking `isDesktop()` alone
+will still hit the `MockGitService` branch and the test will pass
+silently on the wrong implementation.
+
+### 5.4 Test mocking pattern (canonical form)
+
+Before:
+
+```ts
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))
+
+const mockedInvoke = vi.mocked(invoke)
+const mockedListen = vi.mocked(listen)
+```
+
+After:
+
+```ts
+import { invoke, listen } from '../../../lib/backend'
+
+vi.mock('../../../lib/backend', () => ({
+  invoke: vi.fn(),
+  listen: vi.fn(),
+}))
+
+const mockedInvoke = vi.mocked(invoke)
+const mockedListen = vi.mocked(listen)
+```
+
+When a test fires a listener callback through `mockedListen`, it now
+passes the bare payload:
+
+```ts
+// Before: synthesizes the Event<T> envelope.
+const callback = mockedListen.mock.calls[0][1]
+callback({ event: 'pty-data', id: 0, payload: { ... }, windowLabel: '' })
+
+// After: callback receives the bare payload.
+const callback = mockedListen.mock.calls[0][1]
+callback({ ... })   // ← the payload object directly
+```
+
+### 5.5 Ordering (10 tasks, bridge-first, per-file)
+
+1. `backend.ts` + `backend.test.ts` + `vimeflow.d.ts`.
+2. `environment.ts` `isTauri` → `isDesktop` (rename + OR-detection).
+3. `e2e-bridge.ts` — single-line invoke migration; warmup.
+4. `useGitBranch.ts` — single-invoke hook; no listen.
+5. `useGitStatus.ts` — invoke + 1 listen callback refactor.
+6. `useAgentStatus.ts` — invoke + 4 listen callback refactors;
+   heaviest single file in the PR.
+7. `fileSystemService.ts` — dynamic-import → static-import sweep.
+8. `gitService.ts` — factory branching + class import flips.
+9. `tauriTerminalService.ts` + `terminalService.ts` factory.
+10. Final sweep + verification gate (`rg -n '@tauri-apps/api' src tests`
+    should leave one production hit — the bridge fallback — and the
+    matching test-only imports inside `backend.test.ts`).
+
+Order is not load-bearing — tasks 3-9 each touch independent files
+once Task 1 (the bridge) exists. Subagent-driven-development can
+parallelize tasks 3-9; sequencing only matters for local-dev
+convenience and bisect granularity.
+
+## 6. Verification gate
+
+### 6.1 Local commands
+
+```bash
+npm run format:check
+npm run lint
+npm run type-check
+npm run test
+(cd src-tauri && cargo test)    # smoke — Rust unchanged; count must match PR-B baseline
+```
+
+All must be green. The Rust suite is a paranoia check — PR-C does not
+touch `src-tauri/**`, so the count should be byte-identical to the
+post-PR-B baseline. A diff there means the bridge migration
+accidentally tripped the Rust build (e.g., a stray edit; the gate
+catches that).
+
+### 6.2 Coupling inventory
+
+```bash
+rg -nE "@tauri-apps/api|__TAURI_INTERNALS__" src tests
+```
+
+Expected residual hits live ONLY in these four files (line counts
+not pinned — JSDoc comments may also reference `@tauri-apps/api`
+inside `backend.ts` to explain the fallback, and the rg pattern
+matches those too):
+
+- `src/lib/backend.ts` — `@tauri-apps/api/core` +
+  `@tauri-apps/api/event` import statements (the fallback's
+  runtime dependency) AND any JSDoc that names the modules for
+  context.
+- `src/lib/backend.test.ts` — `vi.mock('@tauri-apps/api/core', ...)`
+  and `/event` mock targets, plus any synthetic `Event<T>` fixtures
+  the fallback tests pass to the mocked listener.
+- `src/lib/environment.ts` — the `window.__TAURI_INTERNALS__ != null`
+  probe inside `isDesktop()`, plus the `Window` ambient augmentation
+  that declares `__TAURI_INTERNALS__`.
+- `src/lib/environment.test.ts` — fixtures writing
+  `__TAURI_INTERNALS__` to drive `isDesktop()` truthy / falsy.
+
+No other file under `src/**` should match. Anything else is a leak —
+i.e. a service or hook that bypassed the bridge migration. Fix it
+before continuing the verification gate. `src-tauri/**` hits are out
+of PR-C scope (PR-A/B locked the Rust side).
+
+### 6.3 Manual smoke (`npm run tauri:dev`)
+
+1. App window opens, default workspace renders.
+2. Default terminal session spawns and reaches a prompt.
+3. Type into the terminal — characters echo.
+4. File Explorer lists the working directory; click a file — editor
+   shows its content.
+5. Diff panel shows the current branch + uncommitted status.
+6. Spawn a second terminal pane via the existing flow; switch panes;
+   close the second pane.
+7. Cmd/Ctrl+Q — clean exit; relaunch and verify session-cache parity
+   with the pre-PR-C baseline.
+
+If any step regresses, bisect by reverting the most recent task's
+commits. Bridge bugs typically surface at step 2 (PTY event flow) or
+step 5 (git watcher) because those exercise the listener path most
+aggressively.
+
+### 6.4 E2E (`npm run test:e2e:build && npm run test:e2e`)
+
+E2E specs MUST pass without any change — the `e2e-bridge` migration
+replaces one `invoke` import with another semantically identical
+import; the runtime path through `tauri-driver` + Wry is unchanged.
+
+If a spec fails, that's a real regression in the bridge fallback
+path. Do not paper it over by adjusting the spec.
+
+## 7. Risks
+
+### 7.1 Listener attach-before-resolve race
+
+`TauriTerminalService.ensureListeners`,
+`useAgentStatus.subscribe`, and `useGitStatus`'s watcher path all
+`await listen(...)` before triggering IPC that would otherwise race
+the attachment. The bridge's `listen` preserves this by awaiting the
+underlying `tauriListen` before returning (§4.1). Test case #10
+(§4.3) locks the contract. **PR-D regression risk:** the Electron
+preload's `window.vimeflow.listen` MUST also resolve only after
+`ipcRenderer.on` has attached on the main process. PR-D's preload
+tests must mirror test case #10 against the new transport.
+
+### 7.2 StrictMode double-cleanup
+
+React 18 StrictMode mounts → cleans up → remounts in dev. The
+bridge's `UnlistenFn` idempotency guard (§4.1) ensures the second
+cleanup is a no-op even if the underlying transport throws on
+double-detach. Production behavior is unchanged (StrictMode is
+dev-only).
+
+### 7.3 Test mocking pattern churn
+
+All 7 sibling test files currently mock `@tauri-apps/api/core` and
+`@tauri-apps/api/event`. After PR-C they mock `src/lib/backend`. The
+diff in test files is large (mock factory rewrites + payload-shape
+simplification). Reviewers may flag this as scope creep — it is
+load-bearing and matches Task 8 of the migration roadmap. Call it
+out in the PR description.
+
+### 7.4 `useAgentStatus` is the highest-risk single file
+
+4 `listen` callbacks (`agent-status`, `agent-tool-call`, `agent-turn`,
+`test-run`), a complex state machine, multiple refs guarding async
+continuations. The migration is mechanical (each `event.payload.X`
+becomes `payload.X`) but a typo in any of the 4 callbacks could
+silently break agent detection. Test coverage on this hook is high
+(`useAgentStatus.test.ts` has 1200+ lines); per-callback assertions
+catch most regressions. Run the spec for this file alone after the
+migration: `npx vitest run src/features/agent-status/hooks/useAgentStatus.test.ts`.
+
+### 7.5 `UnlistenFn` type drift
+
+`tauriListen` returns `Promise<UnlistenFn>` where `UnlistenFn` is
+imported from `@tauri-apps/api/event`. The bridge defines its own
+`UnlistenFn = () => void` (§4.1) so PR-D's `@tauri-apps/api` removal
+is a clean delete. If a future file accidentally imports
+`UnlistenFn` from `@tauri-apps/api/event` instead of from
+`src/lib/backend`, PR-D will fail to compile. §8.1 captures the
+ESLint rule that prevents this.
+
+## 8. Open questions / follow-ups
+
+### 8.1 ESLint `no-restricted-imports` rule
+
+Add an `eslint-plugin-import` `no-restricted-imports` rule that bans
+`@tauri-apps/api*` imports outside `src/lib/backend.ts` and
+`src/lib/backend.test.ts`. Locks the abstraction so future code
+can't bypass the bridge. **Deferred to PR-D** because adding the rule
+in PR-C would also need to touch `eslint.config.ts` (which is
+otherwise out of scope), and the rule would be more obviously valuable
+once `@tauri-apps/api` removal is the actual goal.
+
+### 8.2 `Window.vimeflow` optionality in PR-D
+
+PR-D chooses between two contracts (§2.5):
+
+- **(a) `vimeflow: BackendApi` (non-optional).** Bridge body shrinks
+  to one line per function. Matches the runtime invariant the
+  Electron preload installs.
+- **(b) `vimeflow?: BackendApi` (optional + bridge guard).** Bridge
+  keeps a `typeof window !== 'undefined' && window.vimeflow` guard
+  and throws when missing. Preserves typing room for partially-
+  bootstrapped renderer states.
+
+Recommended default: (a). The preload is the source of truth for
+"this global exists"; the typing should match.
+
+### 8.3 `BackendApi` versioning
+
+PR-C's `BackendApi` is unversioned. If the IPC wire envelope changes
+in a future PR (e.g. adds frame kinds, changes the response/error
+shape), the bridge will need a version negotiation. Out of scope for
+PR-C; flagged here so a future planner pass can pick it up.
+
+### 8.4 `e2e-bridge.ts` co-location
+
+`src/lib/e2e-bridge.ts` currently lives alongside the bridge module
+in `src/lib/`. After PR-D, the e2e-bridge will be the only file in
+`src/lib/` that uses `backend.invoke`. Consider relocating it to
+`tests/e2e/shared/` or `src/test/` so renderer-runtime code and
+test-instrumentation code live in different directories. Defer to a
+follow-up PR; not blocking PR-C or PR-D.

--- a/src/features/agent-status/hooks/useAgentStatus.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.test.ts
@@ -1,12 +1,11 @@
 import { afterEach, describe, test, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { invoke } from '@tauri-apps/api/core'
-import { listen } from '@tauri-apps/api/event'
+import { invoke, listen } from '../../../lib/backend'
 import { getPtySessionId } from '../../terminal/ptySessionMap'
 import type { TestRunSnapshot } from '../types'
 import { useAgentStatus } from './useAgentStatus'
 
-type EventCallback<T = unknown> = (event: { payload: T }) => void
+type EventCallback<T = unknown> = (payload: T) => void
 
 const eventListeners = new Map<string, EventCallback[]>()
 
@@ -34,8 +33,9 @@ const defaultInvokeImpl = (): Promise<null> => Promise.resolve(null)
 
 const defaultGetPtySessionIdImpl = (id: string): string => `pty-${id}`
 
-vi.mock('@tauri-apps/api/core', () => ({
+vi.mock('../../../lib/backend', () => ({
   invoke: vi.fn(),
+  listen: vi.fn(),
 }))
 
 vi.mock('../../terminal/ptySessionMap', () => ({
@@ -45,14 +45,10 @@ vi.mock('../../terminal/ptySessionMap', () => ({
   ),
 }))
 
-vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn(),
-}))
-
 const emit = <T>(eventName: string, payload: T): void => {
   const listeners = eventListeners.get(eventName) ?? []
   for (const cb of listeners) {
-    cb({ payload })
+    cb(payload)
   }
 }
 
@@ -1136,11 +1132,11 @@ describe('useAgentStatus', () => {
     const PTY_ID = 'pty-tr'
     vi.mocked(getPtySessionId).mockReturnValue(PTY_ID)
 
-    let testRunHandler: ((e: { payload: TestRunSnapshot }) => void) | undefined
+    let testRunHandler: ((payload: TestRunSnapshot) => void) | undefined
 
     vi.mocked(listen).mockImplementation(((
       event: string,
-      handler: (e: { payload: TestRunSnapshot }) => void
+      handler: (payload: TestRunSnapshot) => void
     ) => {
       if (event === 'test-run') {
         testRunHandler = handler
@@ -1168,7 +1164,7 @@ describe('useAgentStatus', () => {
     }
 
     act(() => {
-      testRunHandler?.({ payload: snap })
+      testRunHandler?.(snap)
     })
 
     expect(result.current.testRun).toEqual(snap)
@@ -1178,11 +1174,11 @@ describe('useAgentStatus', () => {
     const PTY_ID = 'pty-real'
     vi.mocked(getPtySessionId).mockReturnValue(PTY_ID)
 
-    let testRunHandler: ((e: { payload: TestRunSnapshot }) => void) | undefined
+    let testRunHandler: ((payload: TestRunSnapshot) => void) | undefined
 
     vi.mocked(listen).mockImplementation(((
       event: string,
-      handler: (e: { payload: TestRunSnapshot }) => void
+      handler: (payload: TestRunSnapshot) => void
     ) => {
       if (event === 'test-run') {
         testRunHandler = handler
@@ -1199,17 +1195,15 @@ describe('useAgentStatus', () => {
 
     act(() => {
       testRunHandler?.({
-        payload: {
-          sessionId: 'wrong-pty-id',
-          runner: 'vitest',
-          commandPreview: 'vitest',
-          startedAt: '',
-          finishedAt: '',
-          durationMs: 0,
-          status: 'pass',
-          summary: { passed: 1, failed: 0, skipped: 0, total: 1, groups: [] },
-          outputExcerpt: null,
-        },
+        sessionId: 'wrong-pty-id',
+        runner: 'vitest',
+        commandPreview: 'vitest',
+        startedAt: '',
+        finishedAt: '',
+        durationMs: 0,
+        status: 'pass',
+        summary: { passed: 1, failed: 0, skipped: 0, total: 1, groups: [] },
+        outputExcerpt: null,
       })
     })
 

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { invoke } from '@tauri-apps/api/core'
-import { listen } from '@tauri-apps/api/event'
+import { invoke, listen } from '../../../lib/backend'
 import { getPtySessionId } from '../../terminal/ptySessionMap'
 import type {
   AgentDetectedEvent,
@@ -354,12 +353,12 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
 
       const unlistenStatus = await listen<AgentStatusEvent>(
         'agent-status',
-        (event) => {
-          if (event.payload.sessionId !== resolvePtyId()) {
+        (payload) => {
+          if (payload.sessionId !== resolvePtyId()) {
             return
           }
 
-          const p = event.payload
+          const p = payload
 
           setStatus((prev) => ({
             ...prev,
@@ -428,13 +427,13 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
 
       const unlistenToolCall = await listen<AgentToolCallEvent>(
         'agent-tool-call',
-        (event) => {
+        (payload) => {
           const ptyId = getPtySessionId(sessionId)
-          if (event.payload.sessionId !== ptyId) {
+          if (payload.sessionId !== ptyId) {
             return
           }
 
-          const p = event.payload
+          const p = payload
 
           if (p.status === 'running') {
             setStatus((prev) => ({
@@ -493,15 +492,15 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
 
       const unlistenTurn = await listen<AgentTurnEvent>(
         'agent-turn',
-        (event) => {
-          if (event.payload.sessionId !== resolvePtyId()) {
+        (payload) => {
+          if (payload.sessionId !== resolvePtyId()) {
             return
           }
 
           // numTurns is u32 in the Rust binding — fits safely in JS number,
           // no Number() coercion needed (those are reserved for u64/i64
           // fields where serde-json may emit values past Number.MAX_SAFE_INTEGER).
-          const nextTurns = event.payload.numTurns
+          const nextTurns = payload.numTurns
 
           setStatus((prev) => ({
             ...prev,
@@ -524,14 +523,14 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
       // batch from session start would lose the snapshot entirely.
       const unlistenTestRun = await listen<TestRunSnapshot>(
         'test-run',
-        (event) => {
-          if (event.payload.sessionId !== resolvePtyId()) {
+        (payload) => {
+          if (payload.sessionId !== resolvePtyId()) {
             return
           }
 
           setStatus((prev) => ({
             ...prev,
-            testRun: event.payload,
+            testRun: payload,
           }))
         }
       )

--- a/src/features/diff/hooks/useGitBranch.test.ts
+++ b/src/features/diff/hooks/useGitBranch.test.ts
@@ -1,9 +1,9 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { invoke } from '@tauri-apps/api/core'
+import { invoke } from '../../../lib/backend'
 import { useGitBranch } from './useGitBranch'
 
-vi.mock('@tauri-apps/api/core', () => ({
+vi.mock('../../../lib/backend', () => ({
   invoke: vi.fn(),
 }))
 

--- a/src/features/diff/hooks/useGitBranch.ts
+++ b/src/features/diff/hooks/useGitBranch.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { invoke } from '@tauri-apps/api/core'
+import { invoke } from '../../../lib/backend'
 
 export interface UseGitBranchOptions {
   /** When false, returns empty state and skips IPC. */

--- a/src/features/diff/hooks/useGitStatus.test.ts
+++ b/src/features/diff/hooks/useGitStatus.test.ts
@@ -3,17 +3,14 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { useGitStatus } from './useGitStatus'
 import { mockChangedFiles } from '../data/mockDiff'
 
-// Mock Tauri APIs
+// Mock backend bridge
 const mockInvoke = vi.fn()
 const mockListen = vi.fn()
 const mockUnlisten = vi.fn()
 
-vi.mock('@tauri-apps/api/core', () => ({
+vi.mock('../../../lib/backend', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   invoke: (...args: unknown[]): any => mockInvoke(...args),
-}))
-
-vi.mock('@tauri-apps/api/event', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   listen: (...args: unknown[]): any => mockListen(...args),
 }))
@@ -212,16 +209,12 @@ describe('useGitStatus', () => {
     // cspell:disable-next-line
     test('refreshes when event cwds includes current cwd', async (): Promise<void> => {
       // cspell:disable-next-line
-      let eventHandler:
-        | ((event: { payload: { cwds: string[] } }) => void)
-        | null = null
+      let eventHandler: ((payload: { cwds: string[] }) => void) | null = null
 
       mockListen.mockImplementation(
         (_event: string, handler: unknown): Promise<typeof mockUnlisten> => {
           // cspell:disable-next-line
-          eventHandler = handler as (event: {
-            payload: { cwds: string[] }
-          }) => void
+          eventHandler = handler as (payload: { cwds: string[] }) => void
 
           return Promise.resolve(mockUnlisten)
         }
@@ -240,7 +233,7 @@ describe('useGitStatus', () => {
 
       // Fire event with matching cwd
       // cspell:disable-next-line
-      eventHandler!({ payload: { cwds: ['/home/test/project'] } })
+      eventHandler!({ cwds: ['/home/test/project'] })
 
       await waitFor(() => {
         // refresh() was called, files re-fetched
@@ -251,16 +244,12 @@ describe('useGitStatus', () => {
     // cspell:disable-next-line
     test('does not refresh when event cwds does not include current cwd', async (): Promise<void> => {
       // cspell:disable-next-line
-      let eventHandler:
-        | ((event: { payload: { cwds: string[] } }) => void)
-        | null = null
+      let eventHandler: ((payload: { cwds: string[] }) => void) | null = null
 
       mockListen.mockImplementation(
         (_event: string, handler: unknown): Promise<typeof mockUnlisten> => {
           // cspell:disable-next-line
-          eventHandler = handler as (event: {
-            payload: { cwds: string[] }
-          }) => void
+          eventHandler = handler as (payload: { cwds: string[] }) => void
 
           return Promise.resolve(mockUnlisten)
         }
@@ -279,7 +268,7 @@ describe('useGitStatus', () => {
 
       // Fire event with different cwd
       // cspell:disable-next-line
-      eventHandler!({ payload: { cwds: ['/other/project'] } })
+      eventHandler!({ cwds: ['/other/project'] })
 
       // Should not trigger refresh (loading stays false)
       expect(result.current.loading).toBe(initialLoading)
@@ -288,16 +277,12 @@ describe('useGitStatus', () => {
     // cspell:disable-next-line
     test('shared-watcher fan-out (multiple cwds in one event)', async (): Promise<void> => {
       // cspell:disable-next-line
-      let eventHandler:
-        | ((event: { payload: { cwds: string[] } }) => void)
-        | null = null
+      let eventHandler: ((payload: { cwds: string[] }) => void) | null = null
 
       mockListen.mockImplementation(
         (_event: string, handler: unknown): Promise<typeof mockUnlisten> => {
           // cspell:disable-next-line
-          eventHandler = handler as (event: {
-            payload: { cwds: string[] }
-          }) => void
+          eventHandler = handler as (payload: { cwds: string[] }) => void
 
           return Promise.resolve(mockUnlisten)
         }
@@ -316,7 +301,7 @@ describe('useGitStatus', () => {
       // cspell:disable-next-line
       eventHandler!({
         // cspell:disable-next-line
-        payload: { cwds: ['/home/test/repo/src/a', '/home/test/repo/src/b'] },
+        cwds: ['/home/test/repo/src/a', '/home/test/repo/src/b'],
       })
 
       await waitFor(() => {

--- a/src/features/diff/hooks/useGitStatus.ts
+++ b/src/features/diff/hooks/useGitStatus.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { listen, type UnlistenFn } from '@tauri-apps/api/event'
-import { invoke } from '@tauri-apps/api/core'
+import { invoke, listen, type UnlistenFn } from '../../../lib/backend'
 import { createGitService } from '../services/gitService'
 import type { ChangedFile } from '../types'
 
@@ -133,10 +132,10 @@ export const useGitStatus = (
         // Step 1: Attach event listener BEFORE starting watcher (race-free)
         const unlisten = await listen<GitStatusChangedPayload>(
           'git-status-changed',
-          (event) => {
+          (payload) => {
             // Only refresh if this cwd is in the fan-out list
             // cspell:disable-next-line
-            if (event.payload.cwds.includes(cwd)) {
+            if (payload.cwds.includes(cwd)) {
               refresh()
             }
           }

--- a/src/features/diff/services/gitService.test.ts
+++ b/src/features/diff/services/gitService.test.ts
@@ -7,11 +7,27 @@ import {
   type GitService,
 } from './gitService'
 import { mockChangedFiles, mockFileDiffs } from '../data/mockDiff'
+import { invoke } from '../../../lib/backend'
+import { isDesktop } from '../../../lib/environment'
 
-// Mock @tauri-apps/api/core
-vi.mock('@tauri-apps/api/core', () => ({
+vi.mock('../../../lib/backend', () => ({
   invoke: vi.fn(),
 }))
+
+vi.mock('../../../lib/environment', () => ({
+  isDesktop: vi.fn(),
+  isBrowser: vi.fn(),
+  getEnvironment: vi.fn(),
+  isTest: vi.fn(),
+}))
+
+const mockedInvoke = vi.mocked(invoke)
+const mockedIsDesktop = vi.mocked(isDesktop)
+
+beforeEach(() => {
+  mockedInvoke.mockReset()
+  mockedIsDesktop.mockReturnValue(false)
+})
 
 describe('MockGitService', () => {
   let service: GitService
@@ -282,10 +298,8 @@ describe('TauriGitService', () => {
   let service: GitService
   let invokeMock: ReturnType<typeof vi.fn>
 
-  beforeEach(async () => {
-    const { invoke } = await import('@tauri-apps/api/core')
-    invokeMock = vi.mocked(invoke)
-    invokeMock.mockClear()
+  beforeEach(() => {
+    invokeMock = mockedInvoke
     service = new TauriGitService('/home/user/project')
   })
 
@@ -398,33 +412,39 @@ describe('createGitService', () => {
     expect(service).toBeInstanceOf(MockGitService)
   })
 
-  test('returns TauriGitService when __TAURI_INTERNALS__ exists', () => {
-    const originalMode = import.meta.env.MODE
-
-    const tauriWindow = window as typeof window & {
-      __TAURI_INTERNALS__?: unknown
-    }
-
+  test('returns TauriGitService when isDesktop() is true', () => {
+    vi.stubEnv('MODE', 'development')
+    mockedIsDesktop.mockReturnValue(true)
     try {
-      import.meta.env.MODE = 'development'
-      tauriWindow.__TAURI_INTERNALS__ = {}
-
       const service = createGitService('/test/path')
 
       expect(service).toBeInstanceOf(TauriGitService)
     } finally {
-      delete tauriWindow.__TAURI_INTERNALS__
-      import.meta.env.MODE = originalMode
+      vi.unstubAllEnvs()
     }
   })
 
-  test('returns HttpGitService in development mode without Tauri', () => {
-    const originalMode = import.meta.env.MODE
-    import.meta.env.MODE = 'development'
+  test('returns TauriGitService when isDesktop() is true (via vimeflow)', () => {
+    vi.stubEnv('MODE', 'development')
+    mockedIsDesktop.mockReturnValue(true)
+    try {
+      const service = createGitService('/test/path')
 
-    const service = createGitService()
-    expect(service).toBeInstanceOf(HttpGitService)
+      expect(service).toBeInstanceOf(TauriGitService)
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
 
-    import.meta.env.MODE = originalMode
+  test('returns HttpGitService in development mode without desktop host', () => {
+    vi.stubEnv('MODE', 'development')
+    mockedIsDesktop.mockReturnValue(false)
+    try {
+      const service = createGitService()
+
+      expect(service).toBeInstanceOf(HttpGitService)
+    } finally {
+      vi.unstubAllEnvs()
+    }
   })
 })

--- a/src/features/diff/services/gitService.test.ts
+++ b/src/features/diff/services/gitService.test.ts
@@ -424,18 +424,6 @@ describe('createGitService', () => {
     }
   })
 
-  test('returns TauriGitService when isDesktop() is true (via vimeflow)', () => {
-    vi.stubEnv('MODE', 'development')
-    mockedIsDesktop.mockReturnValue(true)
-    try {
-      const service = createGitService('/test/path')
-
-      expect(service).toBeInstanceOf(TauriGitService)
-    } finally {
-      vi.unstubAllEnvs()
-    }
-  })
-
   test('returns HttpGitService in development mode without desktop host', () => {
     vi.stubEnv('MODE', 'development')
     mockedIsDesktop.mockReturnValue(false)

--- a/src/features/diff/services/gitService.ts
+++ b/src/features/diff/services/gitService.ts
@@ -1,6 +1,7 @@
-import { invoke } from '@tauri-apps/api/core'
 import type { ChangedFile, FileDiff } from '../types'
 import { mockChangedFiles, mockFileDiffs } from '../data/mockDiff'
+import { invoke } from '../../../lib/backend'
+import { isDesktop } from '../../../lib/environment'
 
 /** Git service interface for diff operations */
 export interface GitService {
@@ -176,8 +177,8 @@ export const createGitService = (cwd = '.'): GitService => {
     return new MockGitService()
   }
 
-  // Check if running under Tauri
-  if ('__TAURI_INTERNALS__' in window) {
+  // Check if running on the desktop host (Tauri today, Electron in PR-D)
+  if (isDesktop()) {
     return new TauriGitService(cwd)
   }
 

--- a/src/features/files/services/fileSystemService.ts
+++ b/src/features/files/services/fileSystemService.ts
@@ -1,6 +1,7 @@
 import type { FileNode } from '../types'
 import type { FileEntry } from '../../../bindings'
-import { isTauri } from '../../../lib/environment'
+import { isDesktop } from '../../../lib/environment'
+import { invoke } from '../../../lib/backend'
 import { mockFileTree } from '../data/mockFileTree'
 
 export interface IFileSystemService {
@@ -41,8 +42,6 @@ const toFileNode = (entry: FileEntry, parentPath: string): FileNode => {
 
 class TauriFileSystemService implements IFileSystemService {
   async listDir(path: string): Promise<FileNode[]> {
-    const { invoke } = await import('@tauri-apps/api/core')
-
     const entries = await invoke<FileEntry[]>('list_dir', {
       request: { path },
     })
@@ -51,16 +50,12 @@ class TauriFileSystemService implements IFileSystemService {
   }
 
   async readFile(path: string): Promise<string> {
-    const { invoke } = await import('@tauri-apps/api/core')
-
-    return await invoke<string>('read_file', {
+    return invoke<string>('read_file', {
       request: { path },
     })
   }
 
   async writeFile(path: string, content: string): Promise<void> {
-    const { invoke } = await import('@tauri-apps/api/core')
-
     await invoke<void>('write_file', {
       request: { path, content },
     })
@@ -107,7 +102,7 @@ class MockFileSystemService implements IFileSystemService {
 }
 
 export const createFileSystemService = (): IFileSystemService => {
-  if (isTauri()) {
+  if (isDesktop()) {
     return new TauriFileSystemService()
   }
 

--- a/src/features/terminal/services/tauriTerminalService.test.ts
+++ b/src/features/terminal/services/tauriTerminalService.test.ts
@@ -1,16 +1,13 @@
 import { describe, test, expect, beforeEach, vi, type Mock } from 'vitest'
 import { TauriTerminalService } from './tauriTerminalService'
+import { invoke } from '../../../lib/backend'
 
-// Mock @tauri-apps/api/core
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(),
-}))
-
-// Mock @tauri-apps/api/event — capture listener callbacks for testing
-type EventCallback = (event: { payload: unknown }) => void
+// Mock backend bridge — capture listener callbacks for testing.
+type EventCallback = (payload: unknown) => void
 const eventListeners = new Map<string, EventCallback[]>()
 
-vi.mock('@tauri-apps/api/event', () => ({
+vi.mock('../../../lib/backend', () => ({
+  invoke: vi.fn(),
   listen: vi.fn(
     (eventName: string, callback: EventCallback): Promise<() => void> => {
       const existing = eventListeners.get(eventName) ?? []
@@ -33,11 +30,8 @@ vi.mock('@tauri-apps/api/event', () => ({
  */
 const emitTauriEvent = (eventName: string, payload: unknown): void => {
   const callbacks = eventListeners.get(eventName) ?? []
-  callbacks.forEach((cb) => cb({ payload }))
+  callbacks.forEach((cb) => cb(payload))
 }
-
-// Import after mocks are set up
-const { invoke } = await import('@tauri-apps/api/core')
 
 /** Mock invoke to return a spawn response, then spawn a session */
 const mockSpawnAndInit = async (
@@ -425,8 +419,8 @@ describe('TauriTerminalService', () => {
     // step lets PTY events fire into the void during the listen() roundtrip.
     test('F1 regression: onData await blocks until underlying listen attaches', async () => {
       // Re-import the listen mock so we can stall it
-      const eventModule = await import('@tauri-apps/api/event')
-      const listenMock = vi.mocked(eventModule.listen)
+      const backendModule = await import('../../../lib/backend')
+      const listenMock = vi.mocked(backendModule.listen)
 
       // Stall the first three listen() calls (one per event: pty-data, pty-exit, pty-error)
       // by deferring their resolution until we explicitly release them.
@@ -461,7 +455,7 @@ describe('TauriTerminalService', () => {
         }
       }
       listenMock.mockImplementation(
-        stalledImpl as unknown as typeof eventModule.listen
+        stalledImpl as unknown as typeof backendModule.listen
       )
 
       try {

--- a/src/features/terminal/services/tauriTerminalService.ts
+++ b/src/features/terminal/services/tauriTerminalService.ts
@@ -1,5 +1,4 @@
-import { invoke } from '@tauri-apps/api/core'
-import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { invoke, listen, type UnlistenFn } from '../../../lib/backend'
 import type {
   PTYSpawnParams,
   PTYSpawnResult,
@@ -56,8 +55,8 @@ export class TauriTerminalService implements ITerminalService {
     }
 
     this.initPromise = (async (): Promise<void> => {
-      const unlistenData = await listen<PtyDataEvent>('pty-data', (event) => {
-        const { sessionId, data, offsetStart, byteLen } = event.payload
+      const unlistenData = await listen<PtyDataEvent>('pty-data', (payload) => {
+        const { sessionId, data, offsetStart, byteLen } = payload
 
         // PtyDataEvent.offset_start and .byte_len are u64 — bindings may emit
         // as bigint or number. Coerce to number; safe up to 2^53 = ~9 PB per
@@ -68,15 +67,15 @@ export class TauriTerminalService implements ITerminalService {
         this.dataCallbacks.forEach((cb) => cb(sessionId, data, offset, len))
       })
 
-      const unlistenExit = await listen<PtyExitEvent>('pty-exit', (event) => {
-        const { sessionId, code } = event.payload
+      const unlistenExit = await listen<PtyExitEvent>('pty-exit', (payload) => {
+        const { sessionId, code } = payload
         this.exitCallbacks.forEach((cb) => cb(sessionId, code))
       })
 
       const unlistenError = await listen<PtyErrorEvent>(
         'pty-error',
-        (event) => {
-          const { sessionId, message } = event.payload
+        (payload) => {
+          const { sessionId, message } = payload
           this.errorCallbacks.forEach((cb) => cb(sessionId, message))
         }
       )

--- a/src/features/terminal/services/terminalService.ts
+++ b/src/features/terminal/services/terminalService.ts
@@ -6,7 +6,7 @@ import type {
   PTYKillParams,
 } from '../types'
 import type { SessionList } from '../../../bindings'
-import { isTauri } from '../../../lib/environment'
+import { isDesktop } from '../../../lib/environment'
 import { TauriTerminalService } from './tauriTerminalService'
 
 /**
@@ -385,7 +385,7 @@ let tauriServiceInstance: TauriTerminalService | null = null
  * so each test/pane gets isolated mock state.
  */
 export function createTerminalService(): ITerminalService {
-  if (isTauri()) {
+  if (isDesktop()) {
     tauriServiceInstance ??= new TauriTerminalService()
 
     return tauriServiceInstance

--- a/src/lib/backend.test.ts
+++ b/src/lib/backend.test.ts
@@ -1,0 +1,219 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { invoke as tauriInvoke } from '@tauri-apps/api/core'
+import { listen as tauriListen } from '@tauri-apps/api/event'
+import { invoke, listen, type BackendApi } from './backend'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}))
+
+const mockedTauriInvoke = vi.mocked(tauriInvoke)
+const mockedTauriListen = vi.mocked(tauriListen)
+const noop = (): void => undefined
+
+const observeResolution = async (
+  promise: Promise<unknown>,
+  onResolve: () => void
+): Promise<void> => {
+  await promise
+  onResolve()
+}
+
+describe('backend (window.vimeflow path)', () => {
+  let mockInvoke: ReturnType<typeof vi.fn>
+  let mockListen: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockedTauriInvoke.mockReset()
+    mockedTauriListen.mockReset()
+    mockInvoke = vi.fn()
+    mockListen = vi.fn()
+    window.vimeflow = {
+      invoke: mockInvoke,
+      listen: mockListen,
+    } as unknown as BackendApi
+  })
+
+  afterEach(() => {
+    delete window.vimeflow
+  })
+
+  test('invoke delegates to window.vimeflow.invoke with same args', async () => {
+    mockInvoke.mockResolvedValueOnce({ id: 'abc' })
+
+    const result = await invoke<{ id: string }>('spawn_pty', {
+      sessionId: 's1',
+    })
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    expect(mockInvoke).toHaveBeenCalledWith('spawn_pty', { sessionId: 's1' })
+    expect(result).toEqual({ id: 'abc' })
+    expect(mockedTauriInvoke).not.toHaveBeenCalled()
+  })
+
+  test('invoke rejection passes through unchanged', async () => {
+    mockInvoke.mockRejectedValueOnce('sidecar error')
+
+    await expect(invoke('git_status', { cwd: '/x' })).rejects.toBe(
+      'sidecar error'
+    )
+  })
+
+  test('listen delegates to window.vimeflow.listen', async () => {
+    const rawUnlisten = vi.fn()
+    mockListen.mockResolvedValueOnce(rawUnlisten)
+
+    const unlisten = await listen<{ a: number }>('agent-status', noop)
+
+    expect(mockListen).toHaveBeenCalledTimes(1)
+    expect(mockListen).toHaveBeenCalledWith(
+      'agent-status',
+      expect.any(Function)
+    )
+    expect(typeof unlisten).toBe('function')
+  })
+
+  test('listen callback receives bare payload', async () => {
+    mockListen.mockImplementationOnce(
+      (
+        _event: string,
+        cb: (payload: { sessionId: string; data: string }) => void
+      ): Promise<() => void> => {
+        cb({ sessionId: 's1', data: 'hi' })
+
+        return Promise.resolve(vi.fn())
+      }
+    )
+    const cb = vi.fn()
+
+    await listen<{ sessionId: string; data: string }>('pty-data', cb)
+
+    expect(cb).toHaveBeenCalledWith({ sessionId: 's1', data: 'hi' })
+  })
+
+  test('listen resolves only after window.vimeflow.listen resolves', async () => {
+    let resolveTransport!: (unlisten: () => void) => void
+    mockListen.mockReturnValueOnce(
+      new Promise<() => void>((resolve) => {
+        resolveTransport = resolve
+      })
+    )
+
+    const bridgePromise = listen('x', noop)
+    let resolved = false
+
+    const resolutionPromise = observeResolution(bridgePromise, () => {
+      resolved = true
+    })
+
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+    resolveTransport(vi.fn())
+    await bridgePromise
+    await resolutionPromise
+    expect(resolved).toBe(true)
+  })
+
+  test('UnlistenFn from window.vimeflow path is idempotent', async () => {
+    const rawUnlisten = vi.fn()
+    mockListen.mockResolvedValueOnce(rawUnlisten)
+
+    const unlisten = await listen('x', noop)
+    unlisten()
+    unlisten()
+
+    expect(rawUnlisten).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('backend (@tauri-apps fallback path)', () => {
+  beforeEach(() => {
+    mockedTauriInvoke.mockReset()
+    mockedTauriListen.mockReset()
+    delete window.vimeflow
+  })
+
+  test('invoke delegates to tauriInvoke when window.vimeflow is unset', async () => {
+    mockedTauriInvoke.mockResolvedValueOnce({ ok: true })
+
+    const result = await invoke<{ ok: boolean }>('list_sessions')
+
+    expect(mockedTauriInvoke).toHaveBeenCalledTimes(1)
+    expect(mockedTauriInvoke).toHaveBeenCalledWith('list_sessions', undefined)
+    expect(result).toEqual({ ok: true })
+  })
+
+  test('invoke rejection passes through tauri string error unchanged', async () => {
+    mockedTauriInvoke.mockRejectedValueOnce('PTY session not found')
+
+    await expect(invoke('write_pty', { id: 'x' })).rejects.toBe(
+      'PTY session not found'
+    )
+  })
+
+  test('listen unwraps Event<T>.payload on the Tauri callback', async () => {
+    mockedTauriListen.mockImplementationOnce((_name, cb) => {
+      cb({
+        event: 'pty-data',
+        id: 0,
+        payload: { sessionId: 's1', data: 'hi' },
+        windowLabel: '',
+      } as unknown as Parameters<typeof cb>[0])
+
+      return Promise.resolve(vi.fn())
+    })
+    const cb = vi.fn()
+
+    await listen<{ sessionId: string; data: string }>('pty-data', cb)
+
+    expect(cb).toHaveBeenCalledWith({ sessionId: 's1', data: 'hi' })
+  })
+
+  test('UnlistenFn calls through to tauriListen-resolved unlisten', async () => {
+    const rawUnlisten = vi.fn()
+    mockedTauriListen.mockResolvedValueOnce(rawUnlisten)
+
+    const unlisten = await listen('pty-exit', noop)
+    unlisten()
+
+    expect(rawUnlisten).toHaveBeenCalledTimes(1)
+  })
+
+  test('UnlistenFn from fallback path is idempotent', async () => {
+    const rawUnlisten = vi.fn()
+    mockedTauriListen.mockResolvedValueOnce(rawUnlisten)
+
+    const unlisten = await listen('x', noop)
+    unlisten()
+    unlisten()
+
+    expect(rawUnlisten).toHaveBeenCalledTimes(1)
+  })
+
+  test('listen resolves only after tauriListen resolves (attach-before-resolve)', async () => {
+    let resolveTransport!: (unlisten: () => void) => void
+    mockedTauriListen.mockReturnValueOnce(
+      new Promise<() => void>((resolve) => {
+        resolveTransport = resolve
+      })
+    )
+
+    const bridgePromise = listen('x', noop)
+    let resolved = false
+
+    const resolutionPromise = observeResolution(bridgePromise, () => {
+      resolved = true
+    })
+
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+    resolveTransport(vi.fn())
+    await bridgePromise
+    await resolutionPromise
+    expect(resolved).toBe(true)
+  })
+})

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -1,0 +1,71 @@
+import { invoke as tauriInvoke } from '@tauri-apps/api/core'
+import { listen as tauriListen } from '@tauri-apps/api/event'
+
+/**
+ * Detach a previously-registered listener. Idempotent — a second call is
+ * a no-op. PR-D removes the `@tauri-apps/event` import and the
+ * `tauriUnlisten` branch below; the bridge's `called` guard wrapper
+ * (in `listen()` below) stays so StrictMode double-cleanup remains
+ * safe regardless of which transport produced `rawUnlisten`.
+ */
+export type UnlistenFn = () => void
+
+export interface BackendApi {
+  invoke: <T>(method: string, args?: Record<string, unknown>) => Promise<T>
+
+  listen: <T>(
+    event: string,
+    callback: (payload: T) => void
+  ) => Promise<UnlistenFn>
+}
+
+/**
+ * Invoke a backend command. Prefers `window.vimeflow.invoke` (PR-D's
+ * Electron preload target) when set; otherwise falls back to
+ * `@tauri-apps/api/core` so the Tauri host keeps working through end
+ * of PR-C. Rejection value is the transport's reject value, passed
+ * through unchanged — Tauri rejects with a bare string, sidecar
+ * (PR-D) MUST reject with the same shape.
+ */
+export const invoke = async <T>(
+  method: string,
+  args?: Record<string, unknown>
+): Promise<T> => {
+  if (typeof window !== 'undefined' && window.vimeflow) {
+    return window.vimeflow.invoke<T>(method, args)
+  }
+
+  return tauriInvoke<T>(method, args)
+}
+
+/**
+ * Subscribe to a backend event. Callback receives the bare payload
+ * (NOT Tauri's `Event<T>` envelope). The returned promise resolves
+ * only after the underlying transport listener is attached, so
+ * callers can `await listen(...)` before triggering IPC that would
+ * otherwise race the attachment. The returned `UnlistenFn` detaches
+ * the listener AND is idempotent — the bridge wraps the transport's
+ * unlisten with a `called` guard so React StrictMode's
+ * mount→cleanup→remount double-fire is safe regardless of whether
+ * the transport itself is idempotent.
+ */
+export const listen = async <T>(
+  event: string,
+  callback: (payload: T) => void
+): Promise<UnlistenFn> => {
+  const rawUnlisten =
+    typeof window !== 'undefined' && window.vimeflow
+      ? await window.vimeflow.listen<T>(event, callback)
+      : await tauriListen<T>(event, (e) => callback(e.payload))
+
+  let called = false
+
+  return () => {
+    if (called) {
+      return
+    }
+
+    called = true
+    rawUnlisten()
+  }
+}

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core'
+import { invoke } from './backend'
 import { getAllPtySessionIds } from '../features/terminal/ptySessionMap'
 
 const isVisible = (el: HTMLElement): boolean => {

--- a/src/lib/environment.test.ts
+++ b/src/lib/environment.test.ts
@@ -1,80 +1,115 @@
 import { describe, test, expect, beforeEach, afterEach } from 'vitest'
-import { isTauri, isBrowser, getEnvironment, isTest } from './environment'
+import { isDesktop, isBrowser, getEnvironment, isTest } from './environment'
+import type { BackendApi } from './backend'
 
-describe('environment detection', () => {
+const noop = (): void => undefined
+
+describe('environment', () => {
   let originalTauriInternals: typeof window.__TAURI_INTERNALS__
+  let originalVimeflow: typeof window.vimeflow
 
   beforeEach(() => {
-    // Save the original value
-    originalTauriInternals = (window as Window).__TAURI_INTERNALS__
+    originalTauriInternals = window.__TAURI_INTERNALS__
+    originalVimeflow = window.vimeflow
   })
 
   afterEach(() => {
-    // Restore the original value
     if (originalTauriInternals === undefined) {
-      delete (window as Window).__TAURI_INTERNALS__
+      delete window.__TAURI_INTERNALS__
     } else {
-      ;(window as Window).__TAURI_INTERNALS__ = originalTauriInternals
+      window.__TAURI_INTERNALS__ = originalTauriInternals
+    }
+
+    if (originalVimeflow === undefined) {
+      delete window.vimeflow
+    } else {
+      window.vimeflow = originalVimeflow
     }
   })
 
-  describe('isTauri', () => {
-    test('returns true when __TAURI_INTERNALS__ is defined', () => {
-      ;(window as Window).__TAURI_INTERNALS__ = {}
+  describe('isDesktop', () => {
+    test('returns true when __TAURI_INTERNALS__ is set (Tauri host)', () => {
+      window.__TAURI_INTERNALS__ = {}
+      delete window.vimeflow
 
-      expect(isTauri()).toBe(true)
+      expect(isDesktop()).toBe(true)
     })
 
-    test('returns false when __TAURI_INTERNALS__ is not defined', () => {
-      delete (window as Window).__TAURI_INTERNALS__
+    test('returns true when window.vimeflow is set (Electron host)', () => {
+      delete window.__TAURI_INTERNALS__
+      window.vimeflow = {
+        invoke: () => Promise.resolve(),
+        listen: () => Promise.resolve(noop),
+      } as unknown as BackendApi
 
-      expect(isTauri()).toBe(false)
+      expect(isDesktop()).toBe(true)
+    })
+
+    test('returns false when window.vimeflow is explicitly undefined', () => {
+      delete window.__TAURI_INTERNALS__
+      window.vimeflow = undefined
+
+      expect(isDesktop()).toBe(false)
+    })
+
+    test('returns false when neither signal is present (browser)', () => {
+      delete window.__TAURI_INTERNALS__
+      delete window.vimeflow
+
+      expect(isDesktop()).toBe(false)
     })
 
     test('returns true when __TAURI_INTERNALS__ has metadata', () => {
-      ;(window as Window).__TAURI_INTERNALS__ = {
-        metadata: {
-          currentWindow: {
-            label: 'main',
-          },
-        },
+      window.__TAURI_INTERNALS__ = {
+        metadata: { currentWindow: { label: 'main' } },
       }
 
-      expect(isTauri()).toBe(true)
+      expect(isDesktop()).toBe(true)
     })
   })
 
   describe('isBrowser', () => {
-    test('returns false when __TAURI_INTERNALS__ is defined', () => {
-      ;(window as Window).__TAURI_INTERNALS__ = {}
+    test('returns false when desktop signal is set', () => {
+      window.__TAURI_INTERNALS__ = {}
 
       expect(isBrowser()).toBe(false)
     })
 
-    test('returns true when __TAURI_INTERNALS__ is not defined', () => {
-      delete (window as Window).__TAURI_INTERNALS__
+    test('returns true when no desktop signal is set', () => {
+      delete window.__TAURI_INTERNALS__
+      delete window.vimeflow
 
       expect(isBrowser()).toBe(true)
     })
   })
 
   describe('getEnvironment', () => {
-    test('returns "tauri" when running in Tauri', () => {
-      ;(window as Window).__TAURI_INTERNALS__ = {}
+    test('returns desktop when Tauri signal is present', () => {
+      window.__TAURI_INTERNALS__ = {}
 
-      expect(getEnvironment()).toBe('tauri')
+      expect(getEnvironment()).toBe('desktop')
     })
 
-    test('returns "browser" when running in browser', () => {
-      delete (window as Window).__TAURI_INTERNALS__
+    test('returns desktop when vimeflow signal is present', () => {
+      delete window.__TAURI_INTERNALS__
+      window.vimeflow = {
+        invoke: () => Promise.resolve(),
+        listen: () => Promise.resolve(noop),
+      } as unknown as BackendApi
+
+      expect(getEnvironment()).toBe('desktop')
+    })
+
+    test('returns browser when no signal is present', () => {
+      delete window.__TAURI_INTERNALS__
+      delete window.vimeflow
 
       expect(getEnvironment()).toBe('browser')
     })
   })
 
   describe('isTest', () => {
-    test('returns true when running in test mode', () => {
-      // In vitest, import.meta.env.MODE is 'test' by default
+    test('returns true when MODE is test', () => {
       expect(isTest()).toBe(true)
     })
   })

--- a/src/lib/environment.ts
+++ b/src/lib/environment.ts
@@ -1,19 +1,17 @@
 /**
  * Environment detection utilities for VIBM
  *
- * Provides functions to detect the runtime environment (Tauri desktop app vs browser)
+ * Provides functions to detect the runtime environment (desktop app
+ * vs browser). "Desktop" covers both the current Tauri host AND the
+ * Electron host introduced in PR-D — see spec §2.4.
  */
 
-/**
- * Tauri internals interface for environment detection
- */
 interface TauriInternals {
   metadata?: {
     currentWindow?: {
       label?: string
     }
   }
-  // Add other properties as needed
 }
 
 declare global {
@@ -23,31 +21,23 @@ declare global {
 }
 
 /**
- * Check if the application is running in a Tauri desktop environment
- *
- * @returns true if running in Tauri, false if running in browser
+ * True when the renderer is running inside a desktop host (Tauri today,
+ * Electron in PR-D). Uses `!= null` (not `in`) so an explicit
+ * `window.vimeflow = undefined` does NOT trip the check.
  */
-export const isTauri = (): boolean =>
-  typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+export const isDesktop = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false
+  }
 
-/**
- * Check if the application is running in a browser environment
- *
- * @returns true if running in browser, false if running in Tauri
- */
-export const isBrowser = (): boolean => !isTauri()
+  return window.__TAURI_INTERNALS__ != null || window.vimeflow != null
+}
 
-/**
- * Get the current environment name
- *
- * @returns 'tauri' if running in Tauri, 'browser' if running in browser
- */
-export const getEnvironment = (): 'tauri' | 'browser' =>
-  isTauri() ? 'tauri' : 'browser'
+/** True when the renderer is in a browser / Vitest context. */
+export const isBrowser = (): boolean => !isDesktop()
 
-/**
- * Check if the application is running in test mode
- *
- * @returns true if running in test mode, false otherwise
- */
+/** 'desktop' covers both Tauri and Electron; 'browser' is everything else. */
+export const getEnvironment = (): 'desktop' | 'browser' =>
+  isDesktop() ? 'desktop' : 'browser'
+
 export const isTest = (): boolean => import.meta.env.MODE === 'test'

--- a/src/types/vimeflow.d.ts
+++ b/src/types/vimeflow.d.ts
@@ -1,0 +1,16 @@
+import type { BackendApi } from '../lib/backend'
+
+declare global {
+  interface Window {
+    /**
+     * Electron preload's contextBridge exposes the backend API here
+     * starting in PR-D. Undefined during PR-C — the bridge in
+     * `src/lib/backend.ts` falls back to the current Tauri transport in
+     * that case. Tests fabricate this object to exercise the
+     * production-target code path.
+     */
+    vimeflow?: BackendApi
+  }
+}
+
+export {}


### PR DESCRIPTION
## Summary

PR-C of the 4-PR Tauri → Electron migration. Decouples the React renderer from `@tauri-apps/api` by introducing `src/lib/backend.ts` as the runtime-neutral IPC seam. Migrates 7 renderer files off direct Tauri imports onto the bridge. Tauri host stays live through PR-C — the bridge falls back to `@tauri-apps/api` when `window.vimeflow` isn't set (PR-D ships the Electron preload that sets it).

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-14-pr-c-frontend-backend-bridge-design.md`
- Plan: `docs/superpowers/plans/2026-05-14-pr-c-frontend-backend-bridge.md`
- Roadmap (4-PR index): `docs/superpowers/plans/2026-05-13-electron-rust-backend-migration.md`

## Cross-PR contract

§2 of the spec locks three contracts PR-D consumes:

- §2.1 — `BackendApi { invoke, listen }` surface (PR-D's `window.vimeflow` producer satisfies this)
- §2.4 — `isDesktop()` OR-detection (correct under both Tauri-today and Electron-PR-D)
- §2.5 — PR-D's bridge edit minimality: 4-to-6-line delete of the fallback imports + branches

## Test plan

- [x] `npm run type-check` — exit 0, clean
- [x] `npm run lint` — exit 0, clean
- [x] `npm run format:check` — exit 0, clean
- [x] `npm run test` — 2104 passed, 3 skipped, 0 failed (164 files)
- [x] `(cd src-tauri && cargo test)` — 7 passed (Rust untouched)
- [x] Production `@tauri-apps/api` imports confined to `src/lib/backend.ts` (2 hits, expected)
- [x] `rg -n "isTauri\b" src tests` — zero hits (rename complete)
- [x] `TauriXxx` class names retained (rename deferred to PR-D)
- [x] Bridge tests: 12 cases across both code paths (`window.vimeflow` + Tauri fallback)
- [x] Environment tests: 11 cases (incl. 4 new for OR-detection)
- [ ] **Manual smoke (`npm run tauri:dev`)** — reviewer to run before merge
- [⚠] `npm run test:e2e` — 2 specs failing with `WebDriverError: unsupported operation` clicks; **confirmed pre-existing** (same failures reproduce on pre-PR-C `4971887`). Tracked under `docs/reviews/patterns/e2e-testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)