### PR TITLE
feat(workspace): shared focus highlight + container focus shortcuts

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,4 +63,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-16   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 9        | 0    | 2026-05-18   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 10       | 0    | 2026-05-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -35,31 +35,32 @@ When appending findings to a pattern file, label the source so future readers ca
 - `local-codex` — local `codex exec` runs (e.g. `/lifeline:review` or post-fix verify in
   `/lifeline:upsource-review`).
 
-| Pattern                                                              | Category       | Findings | Refs | Last Updated |
-| -------------------------------------------------------------------- | -------------- | -------- | ---- | ------------ |
-| [Filesystem Scope](patterns/filesystem-scope.md)                     | security       | 21       | 3    | 2026-05-03   |
-| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns | 18       | 5    | 2026-05-12   |
-| [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns | 2        | 3    | 2026-04-14   |
-| [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform | 4        | 3    | 2026-05-07   |
-| [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality   | 5        | 0    | 2026-05-09   |
-| [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality   | 2        | 0    | 2026-05-04   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing        | 50       | 23   | 2026-05-14   |
-| [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal       | 3        | 1    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality   | 67       | 20   | 2026-05-16   |
-| [Accessibility](patterns/accessibility.md)                           | a11y           | 25       | 6    | 2026-05-09   |
-| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns | 38       | 10   | 2026-05-16   |
-| [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend        | 2        | 1    | 2026-05-17   |
-| [Command Injection](patterns/command-injection.md)                   | security       | 7        | 3    | 2026-05-02   |
-| [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)             | security       | 15       | 2    | 2026-04-20   |
-| [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                   | security       | 3        | 1    | 2026-04-20   |
-| [Preflight Checks](patterns/preflight-checks.md)                     | error-handling | 1        | 0    | 2026-04-20   |
-| [CSP Configuration](patterns/csp-configuration.md)                   | security       | 8        | 5    | 2026-05-16   |
-| [PTY Session Management](patterns/pty-session-management.md)         | backend        | 7        | 2    | 2026-05-13   |
-| [Git Operations](patterns/git-operations.md)                         | correctness    | 18       | 8    | 2026-05-17   |
-| [CodeMirror Integration](patterns/codemirror-integration.md)         | editor         | 12       | 0    | 2026-04-11   |
-| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling | 27       | 7    | 2026-05-16   |
-| [File Tree Paths](patterns/file-tree-paths.md)                       | files          | 4        | 0    | 2026-04-10   |
-| [Scope Boundary](patterns/scope-boundary.md)                         | review-process | 7        | 2    | 2026-05-12   |
-| [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing    | 18       | 6    | 2026-05-16   |
-| [Module Boundaries](patterns/module-boundaries.md)                   | code-quality   | 3        | 1    | 2026-05-07   |
-| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality   | 7        | 2    | 2026-05-02   |
+| Pattern                                                              | Category           | Findings | Refs | Last Updated |
+| -------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
+| [Filesystem Scope](patterns/filesystem-scope.md)                     | security           | 21       | 3    | 2026-05-03   |
+| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 18       | 5    | 2026-05-12   |
+| [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 2        | 3    | 2026-04-14   |
+| [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 4        | 3    | 2026-05-07   |
+| [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality       | 5        | 0    | 2026-05-09   |
+| [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 2        | 0    | 2026-05-04   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 50       | 23   | 2026-05-14   |
+| [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 3        | 1    | 2026-04-09   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 67       | 20   | 2026-05-16   |
+| [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
+| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 38       | 10   | 2026-05-16   |
+| [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-17   |
+| [Command Injection](patterns/command-injection.md)                   | security           | 7        | 3    | 2026-05-02   |
+| [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)             | security           | 15       | 2    | 2026-04-20   |
+| [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                   | security           | 3        | 1    | 2026-04-20   |
+| [Preflight Checks](patterns/preflight-checks.md)                     | error-handling     | 1        | 0    | 2026-04-20   |
+| [CSP Configuration](patterns/csp-configuration.md)                   | security           | 8        | 5    | 2026-05-16   |
+| [PTY Session Management](patterns/pty-session-management.md)         | backend            | 7        | 2    | 2026-05-13   |
+| [Git Operations](patterns/git-operations.md)                         | correctness        | 18       | 8    | 2026-05-17   |
+| [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
+| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 27       | 7    | 2026-05-16   |
+| [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
+| [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 7        | 2    | 2026-05-12   |
+| [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-16   |
+| [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
+| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 3        | 0    | 2026-05-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,4 +63,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-16   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 10       | 0    | 2026-05-18   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 11       | 0    | 2026-05-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,4 +63,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-16   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 13       | 0    | 2026-05-18   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 16       | 0    | 2026-05-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,4 +63,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-16   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 3        | 0    | 2026-05-18   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 6        | 0    | 2026-05-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,4 +63,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-16   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 11       | 0    | 2026-05-18   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 13       | 0    | 2026-05-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,4 +63,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-16   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 6        | 0    | 2026-05-18   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 9        | 0    | 2026-05-18   |

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -105,3 +105,42 @@ against three classes of false-fire:
 - **Fix:** Exported `DIALOG_SELECTOR` from `src/features/workspace/containerIds.ts` and
   imported it in both hooks, removing the local definitions.
 - **Commit:** `fix(workspace): address round-2 Claude review findings on focus highlight PR`
+
+### 7. Tailwind JIT cannot detect border color in dynamic template literal
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** HIGH
+- **File:** `src/features/workspace/components/DockPanel.tsx`
+- **Finding:** Refactoring `borderClass` to use `border-[${borderColor}]` with a variable
+  meant Tailwind JIT's static scanner could not emit `border-[rgba(74,68,79,0.3)]` in the
+  production CSS bundle, causing the unfocused junction border to disappear. Color values
+  in Tailwind arbitrary-value classes must appear as complete literal strings.
+- **Fix:** Extracted `borderEdge` (position-dependent, variable) and kept color literals
+  static: `` `${borderEdge} border-[#cba6f7]` `` and `` `${borderEdge} border-[rgba(74,68,79,0.3)]` ``.
+  Both color strings are literal substrings visible to the Tailwind JIT scanner.
+- **Commit:** `fix(workspace): address round-4 Claude review findings on focus highlight PR`
+
+### 8. paneRefSetters map accumulates stale closures on pane unmount
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/SplitView/SplitView.tsx`
+- **Finding:** `getPaneRefSetter` cleaned up `paneHandleRefs` on `null` (unmount) but never
+  deleted the corresponding setter from `paneRefSetters`, causing the factory map to grow
+  without bound across pane create/destroy cycles.
+- **Fix:** Added `paneRefSetters.current.delete(id)` alongside `paneHandleRefs.current.delete(id)`
+  in the null branch of each setter.
+- **Commit:** `fix(workspace): address round-4 Claude review findings on focus highlight PR`
+
+### 9. forwardRef components require file-level eslint-disable for require-default-props
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** LOW
+- **File:** `DockPanel.tsx`, `TerminalZone.tsx`, `SplitView.tsx`, `TerminalPane/index.tsx`
+- **Finding:** `react/require-default-props { functions: 'defaultArguments' }` does not
+  recognize inline destructuring defaults inside `forwardRef` wrappers — it sees the
+  interface declaration but cannot trace through the `forwardRef()` call to find the
+  inner function's defaults. File-level disables are necessary for `forwardRef` components.
+- **Fix:** Restored file-level eslint-disable comments with an explanatory rationale
+  (`-- forwardRef components: ESLint cannot see through forwardRef to find destructuring defaults`).
+- **Commit:** `fix(workspace): address round-4 Claude review findings on focus highlight PR`

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -1,0 +1,69 @@
+---
+id: keyboard-shortcut-guards
+category: keyboard-shortcuts
+created: 2026-05-18
+last_updated: 2026-05-18
+ref_count: 0
+---
+
+# Keyboard Shortcut Guards
+
+## Summary
+
+Capture-phase keyboard listeners that implement global shortcuts must guard
+against three classes of false-fire:
+
+1. **Terminal-zone passthrough** — `Ctrl+e/g` (readline) and `Ctrl+b` (tmux)
+   must not be stolen when xterm has focus. Guard with `if (inTerminalZone) return`
+   before the relevant key branches.
+2. **Hardcoded attribute selectors** — `closest('[data-container-id="dock"]')` should
+   use the exported constant via a template literal to avoid silent breakage if the
+   value is renamed.
+3. **Duplicated guard constants** — `DIALOG_SELECTOR` and other shared predicates
+   should be exported from a single source-of-truth module (e.g. `containerIds.ts`)
+   and imported by each hook; duplication causes divergence when the guard needs
+   updating.
+
+## Findings
+
+### 1. Ctrl+e/g intercept inside terminal zone steals readline shortcuts
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/hooks/useDockShortcuts.ts`
+- **Finding:** `Ctrl+e` (readline "end-of-line") and `Ctrl+g` (bash abort) were
+  consumed by the capture-phase listener even when xterm's `<textarea>` had focus,
+  because the existing `isTextEntry && !inTerminalZone` guard was written to _allow_
+  terminal-zone shortcuts through, inadvertently also including the xterm hidden
+  textarea. The same guard pattern is already used correctly in `usePaneShortcuts`'s
+  reclaim path.
+- **Fix:** Added `if ((key === 'e' || key === 'g') && inTerminalZone) return` before
+  the dock-shortcut branches, matching the existing `.xterm-helper-textarea` guard
+  pattern in `usePaneShortcuts`.
+- **Commit:** `fix(workspace): address round-2 Claude review findings on focus highlight PR`
+
+### 2. Hardcoded `'[data-container-id="dock"]'` selector instead of constant
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** LOW
+- **File:** `src/features/terminal/hooks/usePaneShortcuts.ts`
+- **Finding:** The dock-reclaim branch used the raw string `'[data-container-id="dock"]'`
+  instead of the `DOCK_CONTAINER_ID` constant from `containerIds.ts`. If `DOCK_CONTAINER_ID`
+  is renamed the selector silently stops matching with no type error and no failing test.
+- **Fix:** Imported `DOCK_CONTAINER_ID` from `../../workspace/containerIds` and used a
+  template literal: `` `[data-container-id="${DOCK_CONTAINER_ID}"]` ``.
+- **Commit:** `fix(workspace): address round-2 Claude review findings on focus highlight PR`
+
+### 3. DIALOG_SELECTOR duplicated verbatim across both shortcut hooks
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** LOW
+- **File:** `src/features/workspace/hooks/useDockShortcuts.ts`,
+  `src/features/terminal/hooks/usePaneShortcuts.ts`
+- **Finding:** Both hooks defined an identical `const DIALOG_SELECTOR = '...'` locally.
+  If dialog-guard logic changes (e.g. adding `[aria-modal="true"]`), both constants
+  must be updated independently; divergence means one hook could fire inside a dialog
+  while the other does not.
+- **Fix:** Exported `DIALOG_SELECTOR` from `src/features/workspace/containerIds.ts` and
+  imported it in both hooks, removing the local definitions.
+- **Commit:** `fix(workspace): address round-2 Claude review findings on focus highlight PR`

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -196,3 +196,41 @@ against three classes of false-fire:
 - **Fix:** Hoisted the dialog guard to the top of the `digitMatch` block so it covers both
   reclaim and pane-switch paths symmetrically.
 - **Commit:** `fix(workspace): address round-7 Claude review findings on focus highlight PR`
+
+### 14. useCodeMirror RAF focus fires after useLayoutEffect with no hasFocus guard
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** MEDIUM
+- **File:** `src/features/editor/hooks/useCodeMirror.ts`
+- **Finding:** When `shouldAutoFocus` is true and both the RAF path (on mount) and the
+  synchronous `useLayoutEffect` path (via `focusRequestSeq`) target the same editor,
+  the RAF fires ~16ms later and can steal focus back from any panel that gained focus
+  between React's commit phase and the animation frame.
+- **Fix:** Added `!view.hasFocus` guard: `if (shouldAutoFocusRef.current && !view.hasFocus) { view.focus() }`.
+  The RAF becomes a fallback rather than an unconditional override.
+- **Commit:** `fix(workspace): address round-8 Claude review findings on focus highlight PR`
+
+### 15. useCodeMirror defaults shouldAutoFocus ?? true, opposite of CodeEditor false default
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** LOW
+- **File:** `src/features/editor/hooks/useCodeMirror.ts`
+- **Finding:** `shouldAutoFocus ?? true` defaults to opt-in auto-focus when the prop is
+  absent, but `CodeEditor` defaults `shouldAutoFocus = false`. Any future caller omitting
+  the prop would silently steal keyboard focus.
+- **Fix:** Changed both `?? true` to `?? false` so the hook's standalone behavior matches
+  typical embedded usage.
+- **Commit:** `fix(workspace): address round-8 Claude review findings on focus highlight PR`
+
+### 16. WorkspaceView focus orchestration lacked integration test coverage
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.integration.test.tsx`
+- **Finding:** The `activeContainerId` state machine, `focusRequestSeq` queue,
+  `openDock`/`claimTerminal`/`closeDock` helpers, and session-intent wrappers had no
+  assertions at the `WorkspaceView` level.
+- **Fix:** Added three integration tests: (1) initial state — terminal focused, no dock
+  focus outline; (2) clicking dock claims dock focus (terminal dims); (3) closing dock
+  returns container focus to terminal.
+- **Commit:** `fix(workspace): address round-8 Claude review findings on focus highlight PR`

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -144,3 +144,17 @@ against three classes of false-fire:
 - **Fix:** Restored file-level eslint-disable comments with an explanatory rationale
   (`-- forwardRef components: ESLint cannot see through forwardRef to find destructuring defaults`).
 - **Commit:** `fix(workspace): address round-4 Claude review findings on focus highlight PR`
+
+### 10. Ctrl+b from CodeMirror incorrectly fires claimTerminal
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/hooks/useDockShortcuts.ts`
+- **Finding:** The `Ctrl+b` handler's guard checked `activeContainerId === DOCK_CONTAINER_ID`
+  and `closest('[data-container-id="dock"]')`, but not `!inCodeMirror`. Because CodeMirror
+  lives inside the dock `<section>`, both checks pass when the editor has focus — causing
+  `claimTerminal` to fire and yank focus to the terminal during vim/Emacs editing (vim: page-back,
+  Emacs: backward-char).
+- **Fix:** Added `!inCodeMirror &&` to the `key === 'b'` condition, mirroring the guard already
+  applied to `e`/`g`. Added companion test verifying Ctrl+b does not fire from CodeMirror.
+- **Commit:** `fix(workspace): address round-5 Claude review finding on focus highlight PR`

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -158,3 +158,17 @@ against three classes of false-fire:
 - **Fix:** Added `!inCodeMirror &&` to the `key === 'b'` condition, mirroring the guard already
   applied to `e`/`g`. Added companion test verifying Ctrl+b does not fire from CodeMirror.
 - **Commit:** `fix(workspace): address round-5 Claude review finding on focus highlight PR`
+
+### 11. onContainerFocus double-invocation on pointer clicks
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/components/DockPanel.tsx`,
+  `src/features/workspace/components/TerminalZone.tsx`
+- **Finding:** `handlePointerDown` called `onContainerFocus?.()` directly, then a child
+  element got focus and the `onFocus` (bubbling) handler fired the same callback again.
+  Today harmless (idempotent `setActiveContainerId`), but any future consumer with
+  observable side-effects would see 2-3× invocations per click.
+- **Fix:** Removed the direct `onContainerFocus?.()` call from `handlePointerDown` in both
+  components; `onFocus` alone covers pointer and keyboard Tab paths.
+- **Commit:** `fix(workspace): address round-6 Claude review findings on focus highlight PR`

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -54,6 +54,44 @@ against three classes of false-fire:
   template literal: `` `[data-container-id="${DOCK_CONTAINER_ID}"]` ``.
 - **Commit:** `fix(workspace): address round-2 Claude review findings on focus highlight PR`
 
+### 4. Ctrl+e/g also stolen from CodeMirror vim mode
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** HIGH
+- **File:** `src/features/workspace/hooks/useDockShortcuts.ts`
+- **Finding:** After adding the `inTerminalZone` guard, `Ctrl+e` (vim scroll-viewport-down) and
+  `Ctrl+g` (vim print file location) were still consumed by the capture-phase listener when
+  CodeMirror had focus. `inCodeMirror` was explicitly exempted from the `isTextEntry` pass-through
+  so that dock shortcuts could fire from other panels, but this also meant dock shortcuts fired
+  _over_ CodeMirror vim bindings. The fix requires a symmetric guard for both surfaces.
+- **Fix:** Extended the guard to `if ((key === 'e' || key === 'g') && (inTerminalZone || inCodeMirror)) { return }`.
+  Added two unit tests covering the vim-mode collision path.
+- **Commit:** `fix(workspace): address round-3 Claude review findings on focus highlight PR`
+
+### 5. focusEditor() silently drops DOM focus when editorView returns false
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/components/DockPanel.tsx`
+- **Finding:** `DockPanel.focusEditor()` did not check the boolean return of
+  `editorHandleRef.current.focus()`. When no file is loaded (`filePath=null`), the `CodeEditorHandle`
+  returns `false` and focuses nothing, but the fallback `sectionRef.current?.focus()` branch
+  was only reached when the handle itself was null — not when the handle existed but `focus()` failed.
+  Result: visual focus ring appears (dock marked active) with no keyboard target.
+- **Fix:** `const ok = editorHandleRef.current.focus(); if (!ok) { sectionRef.current?.focus(); } return ok`
+- **Commit:** `fix(workspace): address round-3 Claude review findings on focus highlight PR`
+
+### 6. borderClass contained redundant Tailwind side-specific color utilities
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/DockPanel.tsx`
+- **Finding:** Each branch of the `borderClass` ternary applied both `border-[color]` (all sides)
+  and `border-{side}-[color]` (side-specific override), producing dead redundant classes since only
+  one border edge has non-zero width.
+- **Fix:** Extracted `borderColor` constant and simplified each branch to `border-{edge} border-[${borderColor}]`.
+- **Commit:** `fix(workspace): address round-3 Claude review findings on focus highlight PR`
+
 ### 3. DIALOG_SELECTOR duplicated verbatim across both shortcut hooks
 
 - **Source:** github-claude | PR #218 | 2026-05-18

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -172,3 +172,27 @@ against three classes of false-fire:
 - **Fix:** Removed the direct `onContainerFocus?.()` call from `handlePointerDown` in both
   components; `onFocus` alone covers pointer and keyboard Tab paths.
 - **Commit:** `fix(workspace): address round-6 Claude review findings on focus highlight PR`
+
+### 12. onTerminalZoneFocus duplicated claimTerminal — divergence risk
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** `onTerminalZoneFocus` was byte-for-byte identical to `claimTerminal`. If
+  `claimTerminal` later gains extra logic (telemetry, dock-state persistence), the
+  keyboard-reclaim path would silently diverge with no type error or failing test.
+- **Fix:** Removed the redundant `onTerminalZoneFocus` callback and passed `claimTerminal`
+  directly: `onTerminalZoneFocus: claimTerminal`.
+- **Commit:** `fix(workspace): address round-7 Claude review findings on focus highlight PR`
+
+### 13. Dialog guard in usePaneShortcuts only covered reclaim path, not pane-switch fallthrough
+
+- **Source:** github-claude | PR #218 | 2026-05-18
+- **Severity:** LOW
+- **File:** `src/features/terminal/hooks/usePaneShortcuts.ts`
+- **Finding:** `document.querySelector(DIALOG_SELECTOR)` was only checked inside the reclaim
+  `if` block. Ctrl+2 with a dialog open and terminal active (pane 2 not active) would still
+  call `setSessionActivePane` via the pre-existing pane-switch path.
+- **Fix:** Hoisted the dialog guard to the top of the `digitMatch` block so it covers both
+  reclaim and pane-switch paths symmetrically.
+- **Commit:** `fix(workspace): address round-7 Claude review findings on focus highlight PR`

--- a/docs/superpowers/plans/2026-05-17-shared-focus-highlight.md
+++ b/docs/superpowers/plans/2026-05-17-shared-focus-highlight.md
@@ -1,0 +1,1795 @@
+# Shared Focus Highlight Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add workspace-level `activeContainerId` state so the DockPanel (editor + diff) and TerminalZone share the same border-highlight logic, enabling keyboard shortcuts (`Ctrl+e/g/b` + `Ctrl+1-4` reclaim) to focus either zone.
+
+**Architecture:** A new `containerIds.ts` module exports shared constants and `FocusTarget` type. `WorkspaceView` owns `activeContainerId` state plus a `focusRequestSeq` counter that drives a `useLayoutEffect` for DOM focus movement. Both `TerminalZone` and `DockPanel` gain `forwardRef` imperative handles for programmatic focus. `useDockShortcuts` is a new capture-phase hook; `usePaneShortcuts` gains two optional params for terminal-reclaim logic.
+
+**Tech Stack:** React 18 (`forwardRef`, `useImperativeHandle`, `useLayoutEffect`, `useRef`), Vitest + `@testing-library/react`, TypeScript, Tailwind CSS.
+
+---
+
+## File Map
+
+| Status | Path                                                            | Change                                                            |
+| ------ | --------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Create | `src/features/workspace/containerIds.ts`                        | Shared constants + `FocusTarget` type                             |
+| Create | `src/features/workspace/hooks/useDockShortcuts.ts`              | Ctrl+e/g/b capture-phase hook                                     |
+| Create | `src/features/workspace/hooks/useDockShortcuts.test.ts`         | Hook unit tests                                                   |
+| Modify | `src/features/terminal/components/TerminalPane/index.tsx`       | `forwardRef` exposing `focusTerminal(): boolean`                  |
+| Modify | `src/features/terminal/components/TerminalPane/index.test.tsx`  | (if exists)                                                       |
+| Modify | `src/features/terminal/components/SplitView/SplitView.tsx`      | `forwardRef` exposing `focusActivePane(): boolean`                |
+| Modify | `src/features/terminal/components/SplitView/SplitView.test.tsx` | Handle test                                                       |
+| Modify | `src/features/workspace/components/TerminalZone.tsx`            | `isZoneFocused`, pointer/focus handlers, `forwardRef`             |
+| Modify | `src/features/workspace/components/TerminalZone.test.tsx`       | Opacity + ref tests                                               |
+| Modify | `src/features/workspace/components/DockPanel.tsx`               | `isFocused`, visual highlight, internal focus logic, `forwardRef` |
+| Modify | `src/features/workspace/components/DockPanel.test.tsx`          | Highlight + ref tests                                             |
+| Modify | `src/features/editor/hooks/useCodeMirror.ts`                    | `shouldAutoFocus` ref guard on RAF + `updateContent`              |
+| Modify | `src/features/editor/components/CodeEditor.tsx`                 | `shouldAutoFocus` prop + `forwardRef` exposing `focus(): boolean` |
+| Modify | `src/features/terminal/hooks/usePaneShortcuts.ts`               | `onTerminalZoneFocus` + `isTerminalContainerActive`               |
+| Modify | `src/features/terminal/hooks/usePaneShortcuts.test.ts`          | Container-reclaim truth table tests                               |
+| Modify | `src/features/workspace/WorkspaceView.tsx`                      | All wiring: state, refs, helpers, session wrappers                |
+
+---
+
+## Task 1: Shared constants module
+
+**Files:**
+
+- Create: `src/features/workspace/containerIds.ts`
+
+- [ ] **Step 1: Write the file**
+
+```ts
+// src/features/workspace/containerIds.ts
+export const TERMINAL_CONTAINER_ID = 'terminal' as const
+export const DOCK_CONTAINER_ID = 'dock' as const
+
+export type FocusTarget = 'terminal' | 'editor' | 'diff'
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors related to this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/workspace/containerIds.ts
+git commit -m "feat(workspace): add containerIds shared constants module"
+```
+
+---
+
+## Task 2: TerminalPane imperative handle
+
+`TerminalPane` currently keeps `bodyRef` private. We expose it upward so `SplitView` can call `focusTerminal()` without reaching into internals.
+
+**Files:**
+
+- Modify: `src/features/terminal/components/TerminalPane/index.tsx`
+
+- [ ] **Step 1: Write the test first**
+
+Open `src/features/terminal/components/TerminalPane/index.tsx`. In its sibling test file (check `src/features/terminal/components/TerminalPane/index.test.tsx` — if it doesn't exist, create it; check what exists in the directory first with `ls src/features/terminal/components/TerminalPane/`):
+
+```bash
+ls src/features/terminal/components/TerminalPane/
+```
+
+Add a test:
+
+```ts
+// Near bottom of index.test.tsx (add to existing describe block or create one)
+import { createRef } from 'react'
+import type { TerminalPaneHandle } from './index'
+
+test('TerminalPane: ref handle exposes focusTerminal returning false when body not ready', () => {
+  const ref = createRef<TerminalPaneHandle>()
+  // Use the existing mock infrastructure — Body is mocked, so bodyRef.current?.focusTerminal is undefined
+  render(
+    <TerminalPane
+      ref={ref}
+      session={makeSession()}
+      pane={makePane()}
+      service={mockService}
+      isActive={false}
+    />
+  )
+  // bodyRef.current is null in test env because Body is mocked without a real BodyHandle
+  expect(ref.current).not.toBeNull()
+  const result = ref.current!.focusTerminal()
+  expect(result).toBe(false)
+})
+```
+
+- [ ] **Step 2: Run — should FAIL with "TerminalPane: unknown handle / no forwardRef"**
+
+```bash
+npx vitest run src/features/terminal/components/TerminalPane/index.test.tsx
+```
+
+Expected: FAIL (property `ref` not accepted, or `ref.current` is null).
+
+- [ ] **Step 3: Add `TerminalPaneHandle` and `forwardRef` to `index.tsx`**
+
+At the top of `src/features/terminal/components/TerminalPane/index.tsx`, add to imports:
+
+```ts
+import { forwardRef, useImperativeHandle, ... } from 'react'
+// (add forwardRef, useImperativeHandle to existing react import)
+```
+
+After the `TerminalPaneProps` interface, add:
+
+```ts
+export interface TerminalPaneHandle {
+  /** Returns true if xterm body focused successfully, false if not ready. */
+  focusTerminal(): boolean
+}
+```
+
+Wrap the existing function with `forwardRef`:
+
+```ts
+export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
+  function TerminalPane(
+    {
+      session,
+      pane,
+      isActive,
+      service,
+      onPaneReady = undefined,
+      mode = 'spawn',
+      onClose = undefined,
+      onCwdChange = undefined,
+      onRestart = undefined,
+      deferFit = false,
+    }: TerminalPaneProps,
+    ref
+  ): ReactElement {
+    const agent = agentForPane(pane)
+    const bodyRef = useRef<BodyHandle>(null)
+    // ... rest of existing code unchanged ...
+
+    useImperativeHandle(ref, () => ({
+      focusTerminal(): boolean {
+        if (!bodyRef.current) return false
+        bodyRef.current.focusTerminal()
+        return true
+      },
+    }))
+
+    // ... rest of component (return JSX) unchanged ...
+  }
+)
+```
+
+The `useImperativeHandle` call goes just after the `wasActiveRef` / `bodyRef` declarations, before `ptyStatus`.
+
+- [ ] **Step 4: Run — should PASS**
+
+```bash
+npx vitest run src/features/terminal/components/TerminalPane/index.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify type-check passes**
+
+```bash
+npm run type-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/terminal/components/TerminalPane/index.tsx src/features/terminal/components/TerminalPane/index.test.tsx
+git commit -m "feat(terminal): expose focusTerminal() imperative handle on TerminalPane"
+```
+
+---
+
+## Task 3: SplitView imperative handle
+
+`SplitView` holds refs to its `TerminalPane` slots and exposes `focusActivePane()` which delegates to the active pane's `focusTerminal()`.
+
+**Files:**
+
+- Modify: `src/features/terminal/components/SplitView/SplitView.tsx`
+- Modify: `src/features/terminal/components/SplitView/SplitView.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+In `SplitView.test.tsx`, add at the bottom of the describe block:
+
+```ts
+import { createRef } from 'react'
+import type { SplitViewHandle } from './SplitView'
+
+test('SplitView: focusActivePane() returns false when no active pane ref is available (mocked TerminalPane)', () => {
+  const ref = createRef<SplitViewHandle>()
+  // TerminalPane is mocked — it won't expose an imperative handle
+  render(
+    <SplitView
+      ref={ref}
+      session={makeSession('s1', ['p0'])}  // use existing test helper
+      service={mockService}
+      isActive={true}
+    />
+  )
+  expect(ref.current).not.toBeNull()
+  const result = ref.current!.focusActivePane()
+  expect(result).toBe(false)
+})
+```
+
+Note: `SplitView.test.tsx` already has a `makeSession` helper — check it first and reuse it.
+
+- [ ] **Step 2: Run — should FAIL**
+
+```bash
+npx vitest run src/features/terminal/components/SplitView/SplitView.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add `SplitViewHandle` and `forwardRef`**
+
+In `SplitView.tsx`, add to imports: `forwardRef`, `useImperativeHandle`, `useRef` (from react).
+
+Add the export interface after `SplitViewProps`:
+
+```ts
+export interface SplitViewHandle {
+  /** Focuses the active TerminalPane. Returns true on success, false if no active pane is ready. */
+  focusActivePane(): boolean
+}
+```
+
+Change the component to use `forwardRef`. Inside the component body, add:
+
+1. A `Map`-based ref for pane handles: `const paneHandleRefs = useRef<Map<string, TerminalPaneHandle | null>>(new Map())`
+2. `useImperativeHandle`:
+
+```ts
+useImperativeHandle(ref, () => ({
+  focusActivePane(): boolean {
+    const activePane = session.panes.find((p) => p.active)
+    if (!activePane) {
+      outerDivRef.current?.focus()
+      return false
+    }
+    const handle = paneHandleRefs.current.get(activePane.id)
+    if (!handle) {
+      outerDivRef.current?.focus()
+      return false
+    }
+    const focused = handle.focusTerminal()
+    if (!focused) outerDivRef.current?.focus()
+    return focused
+  },
+}))
+```
+
+3. Add `outerDivRef = useRef<HTMLDivElement>(null)` and attach it to the outer `<div>` with `ref={outerDivRef} tabIndex={-1}`.
+
+4. Attach pane refs: in the `visiblePanes.map(...)`, change the `<TerminalPane>` to:
+
+```ts
+<TerminalPane
+  key={pane.ptyId}
+  ref={(handle): void => {
+    paneHandleRefs.current.set(pane.id, handle)
+  }}
+  // ... existing props unchanged
+/>
+```
+
+Also import `TerminalPaneHandle` from `'../TerminalPane'`.
+
+- [ ] **Step 4: Ensure existing tests still pass**
+
+```bash
+npx vitest run src/features/terminal/components/SplitView/SplitView.test.tsx
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Type-check**
+
+```bash
+npm run type-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/terminal/components/SplitView/SplitView.tsx src/features/terminal/components/SplitView/SplitView.test.tsx
+git commit -m "feat(terminal): expose focusActivePane() imperative handle on SplitView"
+```
+
+---
+
+## Task 4: TerminalZone visual + focus changes
+
+**Files:**
+
+- Modify: `src/features/workspace/components/TerminalZone.tsx`
+- Modify: `src/features/workspace/components/TerminalZone.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+In `TerminalZone.test.tsx`, add:
+
+```ts
+test('isZoneFocused=false applies opacity dim class to outer div', () => {
+  render(
+    <TerminalZone
+      sessions={[]}
+      activeSessionId={null}
+      service={mockService}
+      setSessionActivePane={vi.fn()}
+      setSessionLayout={vi.fn()}
+      addPane={vi.fn()}
+      removePane={vi.fn()}
+      isZoneFocused={false}
+    />
+  )
+  const outer = screen.getByTestId('terminal-zone')
+  expect(outer.className).toContain('opacity-[0.65]')
+})
+
+test('isZoneFocused=true (default) does not apply dim class', () => {
+  render(
+    <TerminalZone
+      sessions={[]}
+      activeSessionId={null}
+      service={mockService}
+      setSessionActivePane={vi.fn()}
+      setSessionLayout={vi.fn()}
+      addPane={vi.fn()}
+      removePane={vi.fn()}
+    />
+  )
+  const outer = screen.getByTestId('terminal-zone')
+  expect(outer.className).not.toContain('opacity-[0.65]')
+})
+
+test('TerminalZone: ref exposes focusActivePane returning false when no sessions', () => {
+  const ref = createRef<TerminalZoneHandle>()
+  render(
+    <TerminalZone
+      ref={ref}
+      sessions={[]}
+      activeSessionId={null}
+      service={mockService}
+      setSessionActivePane={vi.fn()}
+      setSessionLayout={vi.fn()}
+      addPane={vi.fn()}
+      removePane={vi.fn()}
+    />
+  )
+  expect(ref.current).not.toBeNull()
+  const result = ref.current!.focusActivePane()
+  expect(result).toBe(false)
+})
+```
+
+- [ ] **Step 2: Run — should FAIL**
+
+```bash
+npx vitest run src/features/workspace/components/TerminalZone.test.tsx
+```
+
+- [ ] **Step 3: Modify TerminalZone**
+
+In `TerminalZone.tsx`, add these changes:
+
+**Imports:** Add `forwardRef`, `useImperativeHandle`, `useRef` from react. Import `SplitViewHandle` from `'../../terminal/components/SplitView/SplitView'`.
+
+**New export interface** (after `TerminalZoneProps`):
+
+```ts
+export interface TerminalZoneHandle {
+  focusActivePane(): boolean
+}
+```
+
+**New prop** in `TerminalZoneProps`:
+
+```ts
+isZoneFocused?: boolean  // default: true
+onContainerPointerDown?: () => void
+```
+
+**Component body changes:**
+
+```ts
+export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
+  function TerminalZone({
+    // ... existing props ...,
+    isZoneFocused = true,
+    onContainerPointerDown = undefined,
+  }: TerminalZoneProps, ref): ReactElement {
+
+    const outerDivRef = useRef<HTMLDivElement>(null)
+    const activeSplitViewRef = useRef<SplitViewHandle | null>(null)
+
+    useImperativeHandle(ref, () => ({
+      focusActivePane(): boolean {
+        if (!activeSplitViewRef.current) {
+          outerDivRef.current?.focus()
+          return false
+        }
+        const focused = activeSplitViewRef.current.focusActivePane()
+        if (!focused) outerDivRef.current?.focus()
+        return focused
+      },
+    }))
+
+    const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>): void => {
+      onContainerPointerDown?.()
+      const target = e.target as Element
+      if (
+        !target.closest(
+          'button,input,textarea,a,select,[tabindex]:not([tabindex="-1"])'
+        )
+      ) {
+        ;(e.currentTarget as HTMLElement).focus()
+      }
+    }
+
+    // ... existing activeSession, showToolbar logic ...
+```
+
+**Outer div** (`data-testid="terminal-zone"`): change the `className` and add `ref`, `tabIndex`, handlers:
+
+```tsx
+<div
+  ref={outerDivRef}
+  data-testid="terminal-zone"
+  data-container-id="terminal"
+  tabIndex={-1}
+  className={`flex min-h-0 flex-1 flex-col ${
+    !isZoneFocused ? 'opacity-[0.65]' : 'opacity-100'
+  } transition-opacity duration-[220ms]`}
+  onPointerDown={handlePointerDown}
+  onFocus={onContainerPointerDown}
+>
+```
+
+**SplitView ref wiring:** in the sessions render loop, find the `<SplitView>` element. Attach a callback ref:
+
+```tsx
+<SplitView
+  ref={
+    isActive
+      ? (handle): void => {
+          activeSplitViewRef.current = handle
+        }
+      : null
+  }
+  // ... existing props ...
+/>
+```
+
+- [ ] **Step 4: Run — all tests should pass**
+
+```bash
+npx vitest run src/features/workspace/components/TerminalZone.test.tsx
+```
+
+- [ ] **Step 5: Type-check**
+
+```bash
+npm run type-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/workspace/components/TerminalZone.tsx src/features/workspace/components/TerminalZone.test.tsx
+git commit -m "feat(workspace): TerminalZone opacity dim, container focus, and imperative handle"
+```
+
+---
+
+## Task 5: DockPanel visual highlight + imperative handle
+
+**Files:**
+
+- Modify: `src/features/workspace/components/DockPanel.tsx`
+- Modify: `src/features/workspace/components/DockPanel.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+In `DockPanel.test.tsx`, add a test group:
+
+```ts
+describe('DockPanel focus highlight', () => {
+  test('isFocused=true applies mauve border to junction edge', () => {
+    renderDockPanel({ isFocused: true, position: 'bottom' })
+    const section = screen.getByTestId('dock-panel')
+    // bottom dock: junction border is border-top
+    expect(section.className).toContain('border-t-[#cba6f7]')
+  })
+
+  test('isFocused=false uses neutral border', () => {
+    renderDockPanel({ isFocused: false, position: 'bottom' })
+    const section = screen.getByTestId('dock-panel')
+    expect(section.className).toContain('border-t-[rgba(74,68,79,0.3)]')
+    expect(section.className).not.toContain('border-t-[#cba6f7]')
+  })
+
+  test('isFocused=true applies box-shadow via style prop', () => {
+    renderDockPanel({ isFocused: true })
+    const section = screen.getByTestId('dock-panel')
+    expect(section.style.boxShadow).toBeTruthy()
+  })
+
+  test('isFocused=false has no box-shadow', () => {
+    renderDockPanel({ isFocused: false })
+    const section = screen.getByTestId('dock-panel')
+    expect(section.style.boxShadow).toBeFalsy()
+  })
+})
+
+test('DockPanel: ref exposes focusEditor returning false when no editorView', () => {
+  // useCodeMirror mock returns editorView: null (override for this test)
+  vi.spyOn(useCodeMirrorModule, 'useCodeMirror').mockReturnValueOnce({
+    editorView: null,
+    updateContent: vi.fn(),
+    setContainer: vi.fn(),
+  })
+  const ref = createRef<DockPanelHandle>()
+  renderDockPanel({ ref, tab: 'editor' } as any)
+  expect(ref.current).not.toBeNull()
+  // focusEditor() should fall back and return false (no editorView)
+  const result = ref.current!.focusEditor()
+  expect(result).toBe(false)
+})
+```
+
+- [ ] **Step 2: Run — should FAIL**
+
+```bash
+npx vitest run src/features/workspace/components/DockPanel.test.tsx
+```
+
+- [ ] **Step 3: Modify DockPanel**
+
+**New imports** in `DockPanel.tsx`: `forwardRef`, `useImperativeHandle`, `useRef`, `type PointerEvent` (from react). Import `CodeEditorHandle` from `'../../editor/components/CodeEditor'` (this will be added in Task 6 — for now add as a future import with `// TODO: add after Task 6`).
+
+**New interface** (export):
+
+```ts
+export interface DockPanelHandle {
+  focusEditor(): boolean
+  focusDiff(): void
+}
+```
+
+**New props** in `DockPanelBaseProps`:
+
+```ts
+isFocused?: boolean
+onContainerFocus?: () => void
+```
+
+**Component changes** — add inside the function:
+
+```ts
+const sectionRef = useRef<HTMLDivElement>(null)
+const diffWrapperRef = useRef<HTMLDivElement>(null)
+const editorHandleRef = useRef<CodeEditorHandle | null>(null)
+
+useImperativeHandle(ref, () => ({
+  focusEditor(): boolean {
+    if (editorHandleRef.current) {
+      return editorHandleRef.current.focus()
+    }
+    sectionRef.current?.focus()
+    return false
+  },
+  focusDiff(): void {
+    diffWrapperRef.current?.focus() ?? sectionRef.current?.focus()
+  },
+}))
+
+const handlePointerDown = (e: React.PointerEvent<HTMLElement>): void => {
+  onContainerFocus?.()
+  const target = e.target as Element
+  if (
+    !target.closest(
+      'button,input,textarea,a,select,[tabindex]:not([tabindex="-1"])'
+    )
+  ) {
+    sectionRef.current?.focus()
+  }
+}
+```
+
+**Update `borderClass` logic** — focused replaces neutral with mauve color (same width):
+
+```ts
+const focusBorderColor = isFocused ? '#cba6f7' : 'rgba(74,68,79,0.3)'
+const borderClass =
+  position === 'top'
+    ? `border-b border-b-[${focusBorderColor}]`
+    : position === 'bottom'
+      ? `border-t border-t-[${focusBorderColor}]`
+      : position === 'left'
+        ? `border-r border-r-[${focusBorderColor}]`
+        : `border-l border-l-[${focusBorderColor}]`
+```
+
+**Update `<section>` element**:
+
+```tsx
+<section
+  ref={sectionRef}
+  data-testid="dock-panel"
+  data-position={position}
+  data-container-id="dock"
+  aria-label={sectionAriaLabel}
+  tabIndex={-1}
+  style={{
+    ...containerStyle,
+    boxShadow: isFocused
+      ? '0 0 0 1px #cba6f7 inset, 0 0 0 6px rgba(203,166,247,0.12)'
+      : undefined,
+    transition: 'box-shadow 220ms ease',
+  }}
+  onPointerDown={handlePointerDown}
+  onFocus={onContainerFocus}
+  className={`relative z-30 flex shrink-0 flex-col bg-[#121221] ${borderClass}`}
+>
+```
+
+**Wrap diff panel** with the stable focusable div:
+
+```tsx
+{
+  tab === 'diff' && (
+    <div
+      data-testid="diff-panel"
+      className="flex min-h-0 flex-1 overflow-hidden"
+    >
+      <div ref={diffWrapperRef} tabIndex={-1} className="flex min-h-0 flex-1">
+        {/* existing DiffPanelContent */}
+      </div>
+    </div>
+  )
+}
+```
+
+**Wrap component** with `forwardRef`:
+
+```ts
+const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
+  function DockPanel({ ...props }: DockPanelProps, ref): ReactElement {
+    // ... body ...
+  }
+)
+export default DockPanel
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npx vitest run src/features/workspace/components/DockPanel.test.tsx
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Type-check**
+
+```bash
+npm run type-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/workspace/components/DockPanel.tsx src/features/workspace/components/DockPanel.test.tsx
+git commit -m "feat(workspace): DockPanel focus highlight, container focus, and imperative handle"
+```
+
+---
+
+## Task 6: CodeEditor `shouldAutoFocus` + imperative handle
+
+**Files:**
+
+- Modify: `src/features/editor/hooks/useCodeMirror.ts`
+- Modify: `src/features/editor/components/CodeEditor.tsx`
+- Modify: `src/features/editor/components/CodeEditor.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+In `CodeEditor.test.tsx`, add:
+
+```ts
+import { createRef } from 'react'
+import type { CodeEditorHandle } from './CodeEditor'
+
+describe('CodeEditor imperative handle', () => {
+  test('ref.focus() returns true when editorView is ready', () => {
+    // existing mock returns a real editorView-like object
+    const ref = createRef<CodeEditorHandle>()
+    render(
+      <CodeEditor
+        ref={ref}
+        filePath="/test.ts"
+        content="hello"
+        shouldAutoFocus={false}
+      />
+    )
+    expect(ref.current).not.toBeNull()
+    // mockEditorView.focus exists via mock — focus() returns true
+    const result = ref.current!.focus()
+    expect(result).toBe(true)
+  })
+
+  test('ref.focus() returns false when no filePath (no editorView)', () => {
+    const ref = createRef<CodeEditorHandle>()
+    render(
+      <CodeEditor
+        ref={ref}
+        filePath={null}
+        content=""
+        shouldAutoFocus={false}
+      />
+    )
+    expect(ref.current).not.toBeNull()
+    const result = ref.current!.focus()
+    expect(result).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run — should FAIL**
+
+```bash
+npx vitest run src/features/editor/components/CodeEditor.test.tsx
+```
+
+- [ ] **Step 3: Update `useCodeMirror` to accept and respect `shouldAutoFocus`**
+
+In `useCodeMirror.ts`, add `shouldAutoFocus?: boolean` to `UseCodeMirrorOptions` interface (check the existing options shape first). Add a ref that's written during render:
+
+At the top of the hook body, after existing refs:
+
+```ts
+const shouldAutoFocusRef = useRef(shouldAutoFocus ?? true)
+shouldAutoFocusRef.current = shouldAutoFocus ?? true
+```
+
+Find the RAF focus call (`requestAnimationFrame(() => { ... view.focus() })`). Add the guard:
+
+```ts
+requestAnimationFrame(() => {
+  if (viewRef.current !== view) return
+  view.requestMeasure()
+  if (shouldAutoFocusRef.current) view.focus() // guard added
+})
+```
+
+Find `updateContent`'s `view.focus()` call and add the same guard:
+
+```ts
+// Focus editor after content load
+if (shouldAutoFocusRef.current) view.focus() // guard added
+```
+
+Return `viewRef` from the hook (already returned as `editorView` state) — no change needed.
+
+- [ ] **Step 4: Add `CodeEditorHandle` and `forwardRef` to `CodeEditor.tsx`**
+
+```ts
+// New imports
+import { forwardRef, useImperativeHandle } from 'react'
+
+// Add to props interface:
+interface CodeEditorProps {
+  // ...existing...
+  shouldAutoFocus?: boolean
+}
+
+// New handle type:
+export interface CodeEditorHandle {
+  /** Returns true if editorView focused, false if no file loaded. */
+  focus(): boolean
+}
+
+// Wrap component:
+export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
+  function CodeEditor({ ..., shouldAutoFocus = false }, ref): ReactElement {
+    const { editorView, updateContent, setContainer } = useCodeMirror({
+      // ...existing options...,
+      shouldAutoFocus,
+    })
+
+    useImperativeHandle(ref, () => ({
+      focus(): boolean {
+        if (!editorView) return false
+        editorView.focus()
+        return true
+      },
+    }))
+
+    // ...rest of component unchanged...
+  }
+)
+```
+
+- [ ] **Step 5: Run — all CodeEditor tests should pass**
+
+```bash
+npx vitest run src/features/editor/components/CodeEditor.test.tsx
+```
+
+- [ ] **Step 6: Type-check**
+
+```bash
+npm run type-check
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/editor/hooks/useCodeMirror.ts src/features/editor/components/CodeEditor.tsx src/features/editor/components/CodeEditor.test.tsx
+git commit -m "feat(editor): shouldAutoFocus guard and imperative focus() handle on CodeEditor"
+```
+
+---
+
+## Task 7: `usePaneShortcuts` container-reclaim additions
+
+Add `onTerminalZoneFocus` and `isTerminalContainerActive` optional params. The truth table from the spec (§6.4) drives the new logic.
+
+**Files:**
+
+- Modify: `src/features/terminal/hooks/usePaneShortcuts.ts`
+- Modify: `src/features/terminal/hooks/usePaneShortcuts.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `usePaneShortcuts.test.ts`:
+
+```ts
+describe('usePaneShortcuts — container-reclaim extensions', () => {
+  // Helper to attach a fake dock element to document.body
+  const attachFakeDock = (): HTMLElement => {
+    const el = document.createElement('div')
+    el.setAttribute('data-container-id', 'dock')
+    el.setAttribute('tabindex', '-1')
+    document.body.appendChild(el)
+    return el
+  }
+
+  const removeFakeDock = (el: HTMLElement): void => {
+    document.body.removeChild(el)
+  }
+
+  test('Ctrl+1 from dock (activeElement in dock): consumes key and calls onTerminalZoneFocus', () => {
+    const onTerminalZoneFocus = vi.fn()
+    const dockEl = attachFakeDock()
+    dockEl.focus()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'single', ['p0'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: false,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(onTerminalZoneFocus).toHaveBeenCalledOnce()
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    removeFakeDock(dockEl)
+  })
+
+  test('Ctrl+1 from dock (activeElement NOT in dock): passes through, no callback', () => {
+    const onTerminalZoneFocus = vi.fn()
+    // activeElement is body — not in dock
+    ;(document.activeElement as HTMLElement | null)?.blur?.()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'single', ['p0'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: false,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(onTerminalZoneFocus).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('Ctrl+1 in dialog: passes through regardless of container state', () => {
+    const onTerminalZoneFocus = vi.fn()
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    const inner = document.createElement('button')
+    dialog.appendChild(inner)
+    document.body.appendChild(dialog)
+    inner.focus()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'single', ['p0'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: false,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(onTerminalZoneFocus).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(dialog)
+  })
+
+  test('Ctrl+1 terminal-active + pane active + activeElement in xterm textarea: pass through', () => {
+    const onTerminalZoneFocus = vi.fn()
+    const textarea = document.createElement('textarea')
+    textarea.className = 'xterm-helper-textarea'
+    document.body.appendChild(textarea)
+    textarea.focus()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'single', ['p0'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: true,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(onTerminalZoneFocus).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(textarea)
+  })
+
+  test('Ctrl+1 terminal-active + pane active + activeElement NOT in xterm: consumes + calls callback', () => {
+    const onTerminalZoneFocus = vi.fn()
+    // activeElement is body
+    ;(document.activeElement as HTMLElement | null)?.blur?.()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'single', ['p0'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: true,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(onTerminalZoneFocus).toHaveBeenCalledOnce()
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+  })
+
+  test('existing tests unaffected when new params are omitted', () => {
+    // Same as existing "Ctrl+1 with already-active p0 lets the event propagate"
+    const setSessionActivePane = vi.fn()
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'vsplit', ['p0', 'p1'])],
+        activeSessionId: 's1',
+        setSessionActivePane,
+        setSessionLayout: vi.fn(),
+        // no isTerminalContainerActive, no onTerminalZoneFocus
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(setSessionActivePane).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run — should FAIL**
+
+```bash
+npx vitest run src/features/terminal/hooks/usePaneShortcuts.test.ts
+```
+
+- [ ] **Step 3: Implement the changes**
+
+Add to `UsePaneShortcutsOptions`:
+
+```ts
+onTerminalZoneFocus?: () => void
+isTerminalContainerActive?: boolean
+```
+
+Add refs in the hook body:
+
+```ts
+const onTerminalZoneFocusRef = useRef(onTerminalZoneFocus)
+const isTerminalContainerActiveRef = useRef(isTerminalContainerActive)
+onTerminalZoneFocusRef.current = onTerminalZoneFocus
+isTerminalContainerActiveRef.current = isTerminalContainerActive
+```
+
+In `handleKeyDown`, add this block immediately before the `activeId === null` guard (i.e., at the top of the digit-key logic, inside the `if (digitMatch)` block):
+
+```ts
+if (digitMatch) {
+  const paneIndex = Number.parseInt(digitMatch[1], 10) - 1
+
+  // Container-reclaim logic (only when new params are wired)
+  const isTCA = isTerminalContainerActiveRef.current
+  const onTZF = onTerminalZoneFocusRef.current
+
+  if (isTCA !== undefined && onTZF !== undefined) {
+    const ae = document.activeElement as Element | null
+
+    // Rule 0: Never fire inside a dialog
+    if (
+      document.querySelector(
+        '[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])'
+      )
+    ) {
+      return
+    }
+
+    if (!isTCA) {
+      // Dock is active — reclaim only if activeElement is inside dock
+      if (ae?.closest('[data-container-id="dock"]')) {
+        onTZF()
+        event.preventDefault()
+        event.stopPropagation()
+        // fall through to pane-focus logic below
+      } else {
+        return // stale state — pass through
+      }
+    } else {
+      // Terminal container is active
+      if (paneIndex < activeSession.panes.length) {
+        const target = activeSession.panes[paneIndex]
+        if (target.active) {
+          // Already-active pane
+          if (ae?.closest('.xterm-helper-textarea')) {
+            return // xterm has focus — pass through
+          }
+          // Focus is on chrome/sidebar — reclaim xterm
+          onTZF()
+          event.preventDefault()
+          event.stopPropagation()
+          return
+        }
+      }
+      // Different pane OR out-of-range: fall through to existing logic
+    }
+  }
+
+  // --- Existing logic below (unchanged) ---
+  if (paneIndex >= activeSession.panes.length) {
+    return
+  }
+  const target = activeSession.panes[paneIndex]
+  if (target.active) {
+    return
+  }
+  event.preventDefault()
+  event.stopPropagation()
+  setSessionActivePane(activeSession.id, target.id)
+  return
+}
+```
+
+**Important:** The new block goes before the existing `if (paneIndex >= activeSession.panes.length)` check. When the new block runs, it handles its paths and either returns early or falls through to the existing logic.
+
+- [ ] **Step 4: Run all pane shortcut tests**
+
+```bash
+npx vitest run src/features/terminal/hooks/usePaneShortcuts.test.ts
+```
+
+Expected: all PASS (new + existing).
+
+- [ ] **Step 5: Type-check**
+
+```bash
+npm run type-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/terminal/hooks/usePaneShortcuts.ts src/features/terminal/hooks/usePaneShortcuts.test.ts
+git commit -m "feat(terminal): usePaneShortcuts container-reclaim extensions (Ctrl+1-4 from dock)"
+```
+
+---
+
+## Task 8: `useDockShortcuts` new hook
+
+**Files:**
+
+- Create: `src/features/workspace/hooks/useDockShortcuts.ts`
+- Create: `src/features/workspace/hooks/useDockShortcuts.test.ts`
+
+- [ ] **Step 1: Write the test file first**
+
+Create `src/features/workspace/hooks/useDockShortcuts.test.ts`:
+
+```ts
+import { renderHook } from '@testing-library/react'
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
+import { useDockShortcuts } from './useDockShortcuts'
+import { DOCK_CONTAINER_ID, TERMINAL_CONTAINER_ID } from '../containerIds'
+
+// Helper: fire a keyboard event from document
+const fire = (
+  key: string,
+  modifiers: Partial<KeyboardEventInit> = {}
+): KeyboardEvent & { preventDefaultSpy: ReturnType<typeof vi.spyOn> } => {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    code: `Key${key.toUpperCase()}`,
+    bubbles: true,
+    cancelable: true,
+    ...modifiers,
+  })
+  const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+  document.dispatchEvent(event)
+  return Object.assign(event, { preventDefaultSpy })
+}
+
+// Attach a dock element and focus it so Ctrl+b guard passes
+const attachDockAndFocus = (): HTMLElement => {
+  const el = document.createElement('section')
+  el.setAttribute('data-container-id', 'dock')
+  el.setAttribute('tabindex', '-1')
+  document.body.appendChild(el)
+  el.focus()
+  return el
+}
+
+const removeEl = (el: HTMLElement): void => {
+  document.body.removeChild(el)
+}
+
+describe('useDockShortcuts', () => {
+  const makeProps = (overrides = {}) => ({
+    activeContainerId: DOCK_CONTAINER_ID,
+    openDock: vi.fn(),
+    claimTerminal: vi.fn(),
+    modKey: 'Ctrl' as const,
+    ...overrides,
+  })
+
+  beforeEach(() => vi.clearAllMocks())
+
+  test('Ctrl+e calls openDock("editor") and prevents default', () => {
+    const props = makeProps()
+    const dockEl = attachDockAndFocus()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('e', { ctrlKey: true })
+
+    expect(props.openDock).toHaveBeenCalledWith('editor')
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    removeEl(dockEl)
+  })
+
+  test('Ctrl+g calls openDock("diff") and prevents default', () => {
+    const props = makeProps()
+    const dockEl = attachDockAndFocus()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('g', { ctrlKey: true })
+
+    expect(props.openDock).toHaveBeenCalledWith('diff')
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    removeEl(dockEl)
+  })
+
+  test('Ctrl+b when dock active and activeElement in dock: calls claimTerminal', () => {
+    const props = makeProps({ activeContainerId: DOCK_CONTAINER_ID })
+    const dockEl = attachDockAndFocus()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('b', { ctrlKey: true })
+
+    expect(props.claimTerminal).toHaveBeenCalledOnce()
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    removeEl(dockEl)
+  })
+
+  test('Ctrl+b when dock active but activeElement NOT in dock: no-op', () => {
+    const props = makeProps({ activeContainerId: DOCK_CONTAINER_ID })
+    // activeElement is body (not in dock)
+    ;(document.activeElement as HTMLElement | null)?.blur?.()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('b', { ctrlKey: true })
+
+    expect(props.claimTerminal).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('Ctrl+b when terminal active: no-op (passes through to xterm)', () => {
+    const props = makeProps({ activeContainerId: TERMINAL_CONTAINER_ID })
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('b', { ctrlKey: true })
+
+    expect(props.claimTerminal).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('No modifier: no-op', () => {
+    const props = makeProps()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('e')
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('Shift+Ctrl+e: no-op (shift excluded)', () => {
+    const props = makeProps()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('e', { ctrlKey: true, shiftKey: true })
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('Ctrl+e from within a dialog: no-op', () => {
+    const props = makeProps()
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    const inner = document.createElement('button')
+    dialog.appendChild(inner)
+    document.body.appendChild(dialog)
+    inner.focus()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('e', { ctrlKey: true })
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(dialog)
+  })
+
+  test('macOS (modKey=⌘): Cmd+e fires, Ctrl+e does not', () => {
+    const props = makeProps({ modKey: '⌘' })
+    renderHook(() => useDockShortcuts(props))
+
+    // Ctrl+e should not fire
+    fire('e', { ctrlKey: true })
+    expect(props.openDock).not.toHaveBeenCalled()
+
+    // Cmd+e should fire
+    fire('e', { metaKey: true })
+    expect(props.openDock).toHaveBeenCalledWith('editor')
+  })
+
+  test('unmount removes listener', () => {
+    const props = makeProps()
+    const { unmount } = renderHook(() => useDockShortcuts(props))
+    unmount()
+    fire('e', { ctrlKey: true })
+    expect(props.openDock).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run — should FAIL (hook doesn't exist)**
+
+```bash
+npx vitest run src/features/workspace/hooks/useDockShortcuts.test.ts
+```
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/features/workspace/hooks/useDockShortcuts.ts`:
+
+```ts
+import { useEffect, useRef } from 'react'
+import {
+  DOCK_CONTAINER_ID,
+  TERMINAL_CONTAINER_ID,
+  type FocusTarget,
+} from '../containerIds'
+
+export interface UseDockShortcutsParams {
+  activeContainerId: string
+  /** Sets isDockOpen + activeContainerId + calls requestFocus internally */
+  openDock: (tab: 'editor' | 'diff') => void
+  /** Sets activeContainerId to terminal + calls requestFocus internally */
+  claimTerminal: () => void
+  modKey: '⌘' | 'Ctrl'
+}
+
+const DIALOG_SELECTOR =
+  '[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])'
+
+export const useDockShortcuts = ({
+  activeContainerId,
+  openDock,
+  claimTerminal,
+  modKey,
+}: UseDockShortcutsParams): void => {
+  // Latest-value refs so the capture listener never reads stale closure state
+  const activeContainerIdRef = useRef(activeContainerId)
+  const openDockRef = useRef(openDock)
+  const claimTerminalRef = useRef(claimTerminal)
+  const modKeyRef = useRef(modKey)
+
+  activeContainerIdRef.current = activeContainerId
+  openDockRef.current = openDock
+  claimTerminalRef.current = claimTerminal
+  modKeyRef.current = modKey
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      // Modifier check — must be exact platform modifier, no shift/alt
+      const mk = modKeyRef.current
+      const modPressed =
+        mk === '⌘' ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
+      if (!modPressed || e.shiftKey || e.altKey) return
+
+      // Never pierce dialogs
+      if (document.querySelector(DIALOG_SELECTOR)) return
+
+      const target: Element =
+        e.target instanceof Element
+          ? e.target
+          : (document.activeElement ?? document.body)
+
+      // Input guard — suppress from text-entry surfaces outside terminal zone
+      const inTerminalZone = !!target.closest('[data-container-id="terminal"]')
+      const inCodeMirror = !!target.closest('.cm-editor')
+      const isTextEntry =
+        !!target.closest('input, textarea') ||
+        (!inCodeMirror &&
+          !!(
+            target.closest('[contenteditable]') ||
+            target.closest('[role="textbox"]')
+          ))
+      if (isTextEntry && !inTerminalZone) return
+
+      const key = e.key.toLowerCase()
+
+      if (key === 'e') {
+        e.preventDefault()
+        e.stopPropagation()
+        openDockRef.current('editor')
+        return
+      }
+
+      if (key === 'g') {
+        e.preventDefault()
+        e.stopPropagation()
+        openDockRef.current('diff')
+        return
+      }
+
+      if (key === 'b') {
+        // Ctrl+b only fires when dock is the active container AND activeElement is inside dock
+        const ae = document.activeElement as Element | null
+        if (
+          activeContainerIdRef.current === DOCK_CONTAINER_ID &&
+          ae?.closest('[data-container-id="dock"]')
+        ) {
+          e.preventDefault()
+          e.stopPropagation()
+          claimTerminalRef.current()
+        }
+        // Otherwise: pass through (terminal zone, sidebar, etc.)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, { capture: true })
+    return (): void => {
+      document.removeEventListener('keydown', handleKeyDown, { capture: true })
+    }
+  }, []) // stable — all values read from refs
+}
+```
+
+- [ ] **Step 4: Run — all tests should pass**
+
+```bash
+npx vitest run src/features/workspace/hooks/useDockShortcuts.test.ts
+```
+
+- [ ] **Step 5: Type-check**
+
+```bash
+npm run type-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/workspace/hooks/useDockShortcuts.ts src/features/workspace/hooks/useDockShortcuts.test.ts
+git commit -m "feat(workspace): useDockShortcuts hook (Ctrl+e/g/b capture-phase)"
+```
+
+---
+
+## Task 9: WorkspaceView orchestration
+
+Wire all new state, refs, helpers, and shortcut hooks together.
+
+**Files:**
+
+- Modify: `src/features/workspace/WorkspaceView.tsx`
+
+- [ ] **Step 1: Add new imports**
+
+```ts
+import { useRef, useLayoutEffect, useState, useCallback, type ReactElement, ... } from 'react'
+import {
+  TERMINAL_CONTAINER_ID,
+  DOCK_CONTAINER_ID,
+  type FocusTarget,
+} from './containerIds'
+import { useDockShortcuts } from './hooks/useDockShortcuts'
+import type { TerminalZoneHandle } from './components/TerminalZone'
+import type { DockPanelHandle } from './components/DockPanel'
+import type { CodeEditorHandle } from '../editor/components/CodeEditor'
+// DockPanel already imported; ensure it's the default import
+```
+
+- [ ] **Step 2: Add new state + refs inside WorkspaceView**
+
+After the existing `usePaneShortcuts(...)` call, add:
+
+```ts
+// Container focus state
+const [activeContainerId, setActiveContainerId] = useState<string>(
+  TERMINAL_CONTAINER_ID
+)
+const [focusRequestSeq, setFocusRequestSeq] = useState(0)
+const pendingFocusTarget = useRef<FocusTarget | null>(null)
+
+// Imperative refs for programmatic focus
+const terminalZoneRef = useRef<TerminalZoneHandle>(null)
+const dockPanelRef = useRef<DockPanelHandle>(null)
+
+const requestFocus = useCallback((target: FocusTarget): void => {
+  pendingFocusTarget.current = target
+  setFocusRequestSeq((n) => n + 1)
+}, [])
+
+// Process pending focus requests after render
+useLayoutEffect(() => {
+  const target = pendingFocusTarget.current
+  if (!target) return
+  pendingFocusTarget.current = null
+  if (target === 'terminal') terminalZoneRef.current?.focusActivePane()
+  if (target === 'editor') dockPanelRef.current?.focusEditor()
+  if (target === 'diff') dockPanelRef.current?.focusDiff()
+}, [focusRequestSeq])
+
+// openDock: centralises all dock-opening paths
+const openDock = useCallback(
+  (tab?: 'editor' | 'diff'): void => {
+    const nextTab = tab ?? dockTab
+    if (tab) setDockTab(tab)
+    setIsDockOpen(true)
+    setActiveContainerId(DOCK_CONTAINER_ID)
+    requestFocus(nextTab === 'editor' ? 'editor' : 'diff')
+  },
+  [dockTab, requestFocus]
+)
+
+// claimTerminal: centralises all terminal-claiming paths
+const claimTerminal = useCallback((): void => {
+  setActiveContainerId(TERMINAL_CONTAINER_ID)
+  requestFocus('terminal')
+}, [requestFocus])
+
+// closeDock: used by dock close button
+const closeDock = useCallback((): void => {
+  setIsDockOpen(false)
+  claimTerminal()
+}, [claimTerminal])
+
+// onTerminalZoneFocus: passed to usePaneShortcuts
+const activeContainerIdRef = useRef(activeContainerId)
+activeContainerIdRef.current = activeContainerId
+const onTerminalZoneFocus = useCallback((): void => {
+  setActiveContainerId(TERMINAL_CONTAINER_ID)
+  requestFocus('terminal')
+}, [requestFocus])
+```
+
+- [ ] **Step 3: Update `usePaneShortcuts` call**
+
+Change the existing `usePaneShortcuts(...)` call to pass the new params:
+
+```ts
+usePaneShortcuts({
+  sessions,
+  activeSessionId,
+  setSessionActivePane,
+  setSessionLayout,
+  preferModifier,
+  onTerminalZoneFocus,
+  isTerminalContainerActive: activeContainerId === TERMINAL_CONTAINER_ID,
+})
+```
+
+- [ ] **Step 4: Add `useDockShortcuts` call**
+
+After the `usePaneShortcuts` call:
+
+```ts
+useDockShortcuts({
+  activeContainerId,
+  openDock: (tab) => openDock(tab),
+  claimTerminal,
+  modKey: preferModifier === 'meta' ? '⌘' : 'Ctrl',
+})
+```
+
+- [ ] **Step 5: Session-intent wrappers**
+
+Wrap `setActiveSessionId`, `createSession`, and `removeSession` so they claim terminal focus. Replace the raw functions with wrappers at the point of use:
+
+```ts
+// Near the usePaneShortcuts / useDockShortcuts calls:
+const handleSetActiveSessionId = useCallback(
+  (id: string): void => {
+    setActiveSessionId(id)
+    claimTerminal()
+  },
+  [setActiveSessionId, claimTerminal]
+)
+
+const handleCreateSession = useCallback((): void => {
+  createSession()
+  claimTerminal()
+}, [createSession, claimTerminal])
+
+const handleRemoveSession = useCallback(
+  (sessionId: string): void => {
+    const wasActive = sessionId === activeSessionId
+    removeSession(sessionId)
+    if (wasActive) claimTerminal()
+  },
+  [activeSessionId, removeSession, claimTerminal]
+)
+```
+
+Then replace all usages of `setActiveSessionId` / `createSession` / `removeSession` in the JSX:
+
+- `onSessionClick={setActiveSessionId}` → `onSessionClick={handleSetActiveSessionId}`
+- `onCreateSession={createSession}` → `onCreateSession={handleCreateSession}`
+- `onSelect={setActiveSessionId}` → `onSelect={handleSetActiveSessionId}`
+- `onClose={removeSession}` → `onClose={handleRemoveSession}`
+- `onNew={createSession}` → `onNew={handleCreateSession}`
+- `onRemoveSession={removeSession}` → `onRemoveSession={handleRemoveSession}`
+
+Also update `handleOpenDiff` to use `openDock`:
+
+```ts
+const handleOpenDiff = useCallback(
+  (file: ChangedFile): void => {
+    setSelectedDiffFile({
+      path: file.path,
+      staged: file.staged,
+      cwd: activeCwd,
+    })
+    openDock('diff')
+  },
+  [activeCwd, openDock]
+)
+```
+
+- [ ] **Step 6: Wire refs and new props into JSX**
+
+Find the `<TerminalZone ... />` element and add:
+
+```tsx
+<TerminalZone
+  ref={terminalZoneRef}
+  isZoneFocused={activeContainerId === TERMINAL_CONTAINER_ID}
+  onContainerPointerDown={() => setActiveContainerId(TERMINAL_CONTAINER_ID)}
+  // ... all existing props unchanged ...
+/>
+```
+
+Find the `<DockPanel ... />` element and add:
+
+```tsx
+<DockPanel
+  ref={dockPanelRef}
+  isFocused={activeContainerId === DOCK_CONTAINER_ID}
+  onContainerFocus={() => setActiveContainerId(DOCK_CONTAINER_ID)}
+  onClose={closeDock}
+  // ... all other props unchanged (replace onClose={() => setIsDockOpen(false)} with closeDock) ...
+/>
+```
+
+Find the `<DockPeekButton ... />` and update `onOpen`:
+
+```tsx
+<DockPeekButton position={dockPosition} onOpen={() => openDock()} />
+```
+
+Also update `<CodeEditor>` (inside DockPanel — already handled via DockPanel's `isFocused` prop threading `shouldAutoFocus`). **DockPanel** needs to pass `shouldAutoFocus={isFocused}` to its internal `<CodeEditor>`. Add this when writing the DockPanel internal change:
+
+In `DockPanel.tsx`, find the `<CodeEditor ... />` element and add:
+
+```tsx
+<CodeEditor
+  ref={editorHandleRef}
+  shouldAutoFocus={isFocused}
+  // ... existing props ...
+/>
+```
+
+- [ ] **Step 7: Update toolbar hint**
+
+In `TerminalZone.tsx`, find the keyboard hint `<span>` that currently shows `Ctrl+\ cycle`. Update it to show the new shortcuts using the `modKey` prop:
+
+```tsx
+<span className="ml-auto hidden items-center gap-1 font-mono text-xs text-on-surface-muted sm:inline-flex">
+  <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
+  <span>+1-4 pane</span>
+  <span>·</span>
+  <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
+  <span>+\ layout</span>
+  <span>·</span>
+  <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
+  <span>+e editor</span>
+  <span>·</span>
+  <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
+  <span>+g diff</span>
+  <span>·</span>
+  <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
+  <span>+b back</span>
+</span>
+```
+
+- [ ] **Step 8: Run the full test suite**
+
+```bash
+npm run test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Type-check**
+
+```bash
+npm run type-check
+```
+
+- [ ] **Step 10: Lint**
+
+```bash
+npm run lint
+```
+
+Fix any lint errors before proceeding.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/features/workspace/WorkspaceView.tsx src/features/workspace/components/TerminalZone.tsx src/features/workspace/components/DockPanel.tsx
+git commit -m "feat(workspace): wire activeContainerId, focus helpers, and dock shortcuts in WorkspaceView"
+```
+
+---
+
+## Task 10: Manual smoke test + final cleanup
+
+- [ ] **Step 1: Start dev server**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Smoke test the following flows**
+
+1. Start with terminal zone lit, dock neutral — click dock → dock border turns mauve (`#cba6f7`), terminal dims to 65% opacity
+2. Click terminal zone → terminal zone lit again, dock border neutral
+3. Press `Ctrl+e` → dock opens (if closed), editor tab active, dock lit
+4. Press `Ctrl+g` → diff tab active, dock lit
+5. Press `Ctrl+b` from dock → terminal zone regains focus
+6. Press `Ctrl+b` from terminal → NO zone change (passes through to xterm)
+7. Press `Ctrl+1` (single-pane) from dock → terminal zone regains focus
+8. Close dock (× button) → terminal zone regains focus automatically
+9. Open a file from the sidebar → file loads in editor WITHOUT stealing focus from terminal (if terminal is active)
+10. Click a session tab → terminal zone becomes active
+
+- [ ] **Step 3: Run the complete test suite one final time**
+
+```bash
+npm run test
+npm run type-check
+npm run lint
+```
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: shared-focus-highlight smoke test verified"
+```
+
+---
+
+## Self-Review
+
+### Spec Coverage
+
+| Spec Section                                            | Covered by Task        |
+| ------------------------------------------------------- | ---------------------- |
+| §3 State model: `activeContainerId`, constants          | Task 1, Task 9         |
+| §4 Visual: DockPanel mauve border + shadow              | Task 5                 |
+| §4 Visual: TerminalZone opacity dim                     | Task 4                 |
+| §5.1 Click focus transfer (pointer + focus events)      | Task 4, Task 5, Task 9 |
+| §5.1 Session-intent wrappers                            | Task 9                 |
+| §5.2 `requestFocus` + `useLayoutEffect` mechanism       | Task 9                 |
+| §5.2 Ref chain: TerminalZone → SplitView → TerminalPane | Task 2, Task 3, Task 4 |
+| §5.2 DockPanel ref: focusEditor + focusDiff             | Task 5                 |
+| §5.2 CodeEditor auto-focus gate + imperative handle     | Task 6                 |
+| §5.2 `Ctrl+e/g/b` shortcuts                             | Task 8                 |
+| §5.3 Toolbar hint update                                | Task 9 (step 7)        |
+| §6.3 `useDockShortcuts` with all guards                 | Task 8                 |
+| §6.4 `usePaneShortcuts` container-reclaim truth table   | Task 7                 |
+| §6.5 `openDock`, `claimTerminal`, `closeDock` helpers   | Task 9                 |
+| §6.5 `onTerminalZoneFocus` callback                     | Task 9                 |
+| §7 Tests                                                | Tasks 2-9              |
+
+### Potential Issues Flagged for Implementor
+
+1. **`TerminalPane/index.test.tsx`** — the test file may not exist. Check `ls src/features/terminal/components/TerminalPane/` before writing the test file. The mock infrastructure in that directory should be inspected to understand how `Body` is mocked.
+
+2. **`SplitView.test.tsx`** — inspect the existing `makeSession` helper and mock setup before adding the new test to ensure the helper signature matches.
+
+3. **`DockPanel` ref threading in Task 5** — `editorHandleRef` needs to be forwarded as a `ref` to `CodeEditor`. This requires importing `CodeEditorHandle` and `CodeEditor` ref after Task 6 is complete. Do Task 6 before Task 5's final wiring if the types cause compile errors. (Tasks 5 and 6 can be swapped if needed.)
+
+4. **`openDock` stale dockTab** — When `openDock()` is called without an explicit tab from `DockPeekButton`, it reads `dockTab` from the closure. Add `dockTab` to the `useCallback` deps (`[dockTab, requestFocus]`) to ensure the latest value is always used.
+
+5. **New-session focus** — `handleCreateSession` calls `claimTerminal()` synchronously, but the new pane may not be mounted yet (async IPC). The `useLayoutEffect` will attempt `focusActivePane()` which may return `false` and fall back to the zone div. This is acceptable for the initial PR (best-effort) per spec §5.1 note.

--- a/docs/superpowers/specs/2026-05-17-shared-focus-highlight-design.md
+++ b/docs/superpowers/specs/2026-05-17-shared-focus-highlight-design.md
@@ -20,7 +20,7 @@ This PR:
 - Adds visual focus treatment to `DockPanel` (mauve highlight)
 - Adds visual dim treatment to `TerminalZone` when dock is active
 - Wires focus transfer via click (pointer down) and keyboard shortcuts
-- Adds new shortcuts: `Ctrl+e` (editor), `Ctrl+g` (git diff), `Ctrl+b` (toggle dock)
+- Adds new shortcuts: `Ctrl+e` (jump to editor), `Ctrl+g` (jump to diff), `Ctrl+b` (return to terminal — dock only)
 - Side-effects `Ctrl+1-4` to claim terminal container focus
 - Adds `useDockShortcuts` hook
 
@@ -36,14 +36,18 @@ Out of scope:
 
 ### 3.1 Container IDs
 
-Two named constants defined alongside `WorkspaceView`:
+Constants live in a dedicated module so both `WorkspaceView` and `useDockShortcuts` can import them without a dependency cycle:
+
+**`src/features/workspace/containerIds.ts`**
 
 ```ts
-const TERMINAL_CONTAINER_ID = 'terminal' as const
-const DOCK_CONTAINER_ID = 'dock' as const
+export const TERMINAL_CONTAINER_ID = 'terminal' as const
+export const DOCK_CONTAINER_ID = 'dock' as const
+
+export type FocusTarget = 'terminal' | 'editor' | 'diff'
 ```
 
-The type is `string` — extensible without a union update when more containers are added.
+`FocusTarget` is exported from this module so `WorkspaceView`, `useDockShortcuts`, and their tests can import it without coupling to each other. The container ID type is `string` — extensible without a union update when more containers are added.
 
 ### 3.2 WorkspaceView state
 
@@ -77,11 +81,11 @@ Children receive a `boolean`; they do not know their own container ID.
 
 Accent color: `#cba6f7` (Catppuccin Mocha mauve / design-system primary). Fixed — not tied to any agent.
 
-| Layer             | Unfocused (current)            | Focused                            |
-| ----------------- | ------------------------------ | ---------------------------------- |
-| Junction border   | `1px solid rgba(74,68,79,0.3)` | `2px solid #cba6f7`                |
-| Container shadow  | none                           | `0 0 0 6px rgba(203,166,247,0.12)` |
-| DockTab header bg | transparent                    | `rgba(203,166,247,0.05)`           |
+| Layer             | Unfocused (current)                 | Focused                                                                                                                                 |
+| ----------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Junction border   | `1px solid rgba(74,68,79,0.3)`      | `1px solid #cba6f7` (width unchanged — avoids layout jitter)                                                                            |
+| Container shadow  | none                                | `0 0 0 1px #cba6f7 inset, 0 0 0 6px rgba(203,166,247,0.12)` — inset ring reinforces the border visually without changing box dimensions |
+| DockTab header bg | `bg-[#0d0d1c]` (current, unchanged) | `bg-[#0d0d1c]` + `rgba(203,166,247,0.05)` overlay                                                                                       |
 
 Transitions: `180ms ease` on border, `220ms ease` on shadow — same timing as `TerminalPane`.
 
@@ -114,24 +118,121 @@ The per-pane `Pane.active` highlight (colored border + glow) is **not changed** 
 
 ### 5.1 Click
 
-`onPointerDown` on the outer wrapper of each zone calls `setActiveContainerId` with its container ID. This mirrors how `SplitView` slot `onClick` claims pane-level focus today.
+`onPointerDown` on the outer wrapper of each zone calls the parent callback (no-arg) to update `activeContainerId`. **Each component** (`TerminalZone`, `DockPanel`) also handles the focus-wrapper logic internally: when the click target is non-interactive, the component calls `.focus()` on its own wrapper element. This keeps the parent callback no-arg and the focus logic co-located with the element that needs it.
 
-- Clicking inside `<TerminalZone>` wrapper → `setActiveContainerId(TERMINAL_CONTAINER_ID)`
-- Clicking inside `<DockPanel>` wrapper → `setActiveContainerId(DOCK_CONTAINER_ID)`
+```ts
+// Inside TerminalZone/DockPanel onPointerDown:
+onContainerPointerDown?.() // notify parent — no-arg
+const target = e.target as Element
+if (
+  !target.closest(
+    'button,input,textarea,a,select,[tabindex]:not([tabindex="-1"])'
+  )
+) {
+  ;(e.currentTarget as HTMLElement).focus()
+}
+```
+
+The selector excludes `tabindex="-1"` elements (programmatic-only fallback containers) so that clicking a `<div tabIndex={-1}>` inside the dock (e.g., the diff wrapper) still triggers the section focus.
+
+**Keyboard / programmatic focus:** a `focusin` listener (bubbles) on each zone wrapper calls `setActiveContainerId` whenever real DOM focus enters the zone from any path — Tab key, programmatic `.focus()`, or assistive technology. This keeps `activeContainerId` in sync even when the pointer is not involved. The `focusin` handler is the same as the `onPointerDown` callback (`onContainerPointerDown`) — `WorkspaceView` supplies a single closure for both events.
+
+- `onPointerDown` inside `<TerminalZone>` wrapper → `setActiveContainerId(TERMINAL_CONTAINER_ID)`
+- `onPointerDown` inside `<DockPanel>` wrapper → parent callback `onContainerFocus()` (no-arg) + component-internal conditional focus (see §5.1 pattern). `DockPanel` handles its own `.focus()` logic.
+- **Dock tab button click** → `WorkspaceView`'s `onTabChange(next)` handler calls `setDockTab(next)` + `setActiveContainerId(DOCK_CONTAINER_ID)`. No `requestFocus` — the tab button's own `onClick` naturally receives focus, and the new panel content renders after the state update.
+- `DockPeekButton` open → calls `openDock()`. `openDock()` calls `requestFocus(...)` internally because the dock was not visible and no element received natural click focus.
+
+`Ctrl+b`'s zone check remains reliable because any click inside the dock sets `activeContainerId` to `DOCK_CONTAINER_ID` via `onPointerDown` before the key handler fires.
+
+**Session tab / sidebar session clicks / new session creation / command-palette session commands:** all of these express terminal intent. Every path that changes the active session (session tab click, sidebar list selection, new session creation, command-palette `:new`/`:next`/`:previous`/`:goto` session commands) flows through `WorkspaceView` state setters. The `setActiveSessionId` handler calls `setActiveContainerId(TERMINAL_CONTAINER_ID)` and `requestFocus('terminal')`. For **new session creation** (`addSession`): session spawn is async (goes through the session manager and IPC); the new pane may not be mounted by the time the focus request fires. Implementation should treat this as best-effort: if `focusActivePane()` fails (returns `false`), no retry is scheduled — the user may need to click the terminal. A future improvement could watch for `activeSessionId` changes in `TerminalZone` and re-attempt focus when the new session's `SplitView` mounts, but that is out of scope for this PR. This covers: clicking a tab after dock focus, selecting from sidebar after dock focus, and creating a new session while dock is active.
 
 ### 5.2 Keyboard shortcuts
 
 New hook: `useDockShortcuts` (see §6.3).
 
-| Shortcut             | Action                                                                                                                                              |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Ctrl+1-4` / `⌘+1-4` | Focus terminal pane N (existing) **+ side-effect:** `setActiveContainerId(TERMINAL_CONTAINER_ID)`                                                   |
-| `Ctrl+\` / `⌘+\`     | Rotate terminal pane layout (existing, **unchanged**)                                                                                               |
-| `Ctrl+e` / `⌘+e`     | Jump to editor tab: `setDockTab('editor')` + `setActiveContainerId(DOCK_CONTAINER_ID)` + open dock if closed                                        |
-| `Ctrl+g` / `⌘+g`     | Jump to diff tab: `setDockTab('diff')` + `setActiveContainerId(DOCK_CONTAINER_ID)` + open dock if closed                                            |
-| `Ctrl+b` / `⌘+b`     | Toggle: if active=dock → `setActiveContainerId(TERMINAL_CONTAINER_ID)`; otherwise → `setActiveContainerId(DOCK_CONTAINER_ID)` + open dock if closed |
+| Shortcut             | Action                                                                                                                                                                                                                                                                                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Ctrl+1-4` / `⌘+1-4` | See §6.4 for the authoritative truth table. Summary: consumed when (a) dock-reclaim (double-guarded) or (b) terminal pane switch to a different pane (works from sidebar too — intentional). Pass-through when pane already active. Never from dialogs.                                                                                          |
+| `Ctrl+\` / `⌘+\`     | Rotate terminal pane layout (existing, **unchanged**)                                                                                                                                                                                                                                                                                            |
+| `Ctrl+e` / `⌘+e`     | Jump to editor tab: `setDockTab('editor')` + `setActiveContainerId(DOCK_CONTAINER_ID)` + open dock if closed                                                                                                                                                                                                                                     |
+| `Ctrl+g` / `⌘+g`     | Jump to diff tab: `setDockTab('diff')` + `setActiveContainerId(DOCK_CONTAINER_ID)` + open dock if closed                                                                                                                                                                                                                                         |
+| `Ctrl+b` / `⌘+b`     | Return to terminal: claims `TERMINAL_CONTAINER_ID`. **Only fires when `activeContainerId === DOCK_CONTAINER_ID` AND `document.activeElement` is inside `[data-container-id="dock"]`** — double-guarded to prevent stale state (e.g. sidebar focus after dock was last active) from stealing the key. From the terminal, passes through to xterm. |
 
-`Ctrl+e`, `Ctrl+g`, `Ctrl+b` work regardless of which zone is currently active.
+**Terminal steal policy (authoritative):**
+
+- `Ctrl+1-4` — dock-reclaim is double-guarded (dock active AND `activeElement` in dock). Terminal pane switching from any context (including sidebar) is intentional and consumes the key. Never fires from dialogs. Full truth table in §6.4.
+- `Ctrl+e`, `Ctrl+g` — capture-phase; globally stolen including from xterm. Users who need readline end-of-line / abort must use the mouse.
+- `Ctrl+b` — NOT stolen from terminal zone. Only fires when `activeContainerId === DOCK_CONTAINER_ID` AND `document.activeElement` inside dock panel (double-guarded).
+
+`Ctrl+b` does **not** close the dock. It only moves container focus from dock → terminal.
+
+#### DOM focus transfer — version-counter state + `useLayoutEffect`
+
+React state updates are batched; calling a focus helper immediately after `setState` reads stale state and may target unmounted DOM (e.g., a just-opened dock). Ref writes alone do not schedule re-renders, so `pendingFocusTarget` alone can't guarantee a `useLayoutEffect` fires. The correct pattern:
+
+1. A **`requestFocus(target: FocusTarget)`** helper in `WorkspaceView` increments a `focusRequestSeq` state counter AND writes to `pendingFocusTarget` ref. Incrementing the counter guarantees a re-render even when no other state changes (e.g., repeat `Ctrl+e` while dock is already on editor tab).
+
+2. `useLayoutEffect(..., [focusRequestSeq])` fires after every render caused by a focus request, reads the ref, calls the appropriate focus helper, and clears the ref.
+
+```ts
+// FocusTarget imported from src/features/workspace/containerIds.ts
+const pendingFocusTarget = useRef<FocusTarget | null>(null)
+const [focusRequestSeq, setFocusRequestSeq] = useState(0)
+
+const requestFocus = useCallback((target: FocusTarget): void => {
+  pendingFocusTarget.current = target
+  setFocusRequestSeq((n) => n + 1)
+}, [])
+
+useLayoutEffect(() => {
+  const target = pendingFocusTarget.current
+  if (!target) return
+  pendingFocusTarget.current = null
+  if (target === 'terminal') terminalZoneRef.current?.focusActivePane()
+  if (target === 'editor') dockPanelRef.current?.focusEditor()
+  if (target === 'diff') dockPanelRef.current?.focusDiff()
+}, [focusRequestSeq])
+```
+
+This handles both "already mounted" (re-focus on repeat press) and "just opened" (dock mounts before `useLayoutEffect` fires) cases.
+
+#### Ref chain
+
+| Ref               | What it holds                    | How exposed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ----------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `terminalZoneRef` | `TerminalZone` imperative handle | `forwardRef` + `useImperativeHandle` on `TerminalZone` exposing `{ focusActivePane(): boolean }`. `TerminalZone` maintains an `activeSplitViewRef` typed as `React.RefObject<SplitViewHandle>` and attaches it directly to `<SplitView ref={isActive ? activeSplitViewRef : null}>` (the `SplitView` component, not the session wrapper div) — this exposes `SplitView`'s imperative handle, not a DOM node. `SplitView` must have `forwardRef`. `TerminalZone.focusActivePane()`: (a) if `activeSplitViewRef.current` is null → focus `TerminalZone` outer div, return `false`; (b) call `activeSplitViewRef.current.focusActivePane()`; if it returns `false` → also focus `TerminalZone` outer div. `SplitView.focusActivePane()`: call active `TerminalPane`'s `focusTerminal(): boolean`; if `false` → focus `SplitView` outer `<div tabIndex={-1}>`, return `false`. `TerminalPane.focusTerminal()`: returns `true` if xterm body focused, `false` if not ready. |
+| `dockPanelRef`    | `DockPanel` imperative handle    | `forwardRef` + `useImperativeHandle` on `DockPanel`; exposes `focusEditor()` (CodeMirror `EditorView.focus()`) and `focusDiff()` (diff root `tabIndex={-1}` div `.focus()`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+
+`CodeEditor` exposes `focus(): boolean` via `useImperativeHandle` — returns `true` if `editorView` exists and was focused, `false` if `editorView` is null (no file). `DockPanel.focusEditor()` checks the return: if `false`, falls back to focusing the dock container `<section>` (`tabIndex={-1}`).
+
+**Auto-focus gate:** `CodeEditor` receives a new `shouldAutoFocus?: boolean` prop (default `false`; `DockPanel` passes `isFocused`). This intentionally prevents CodeMirror from stealing focus when a file is opened/selected from the sidebar while `activeContainerId` is `'terminal'` — the file loads into the editor buffer silently; the user uses `Ctrl+e` to switch. `useCodeMirror` already calls `view.focus()` on mount/file-path changes — some paths use `requestAnimationFrame`. The gate must use a **ref** (not the prop value directly captured in a closure) so the check is evaluated at execution time, not at scheduling time:
+
+```ts
+// Write synchronously during render — always current when any callback fires
+const shouldAutoFocusRef = useRef(shouldAutoFocus)
+shouldAutoFocusRef.current = shouldAutoFocus
+
+// Inside useCodeMirror's automatic focus paths ONLY (on-mount, file-path change):
+if (!shouldAutoFocusRef.current) return
+view.focus()
+```
+
+This guard applies **only to the automatic/scheduled `view.focus()` paths** inside `useCodeMirror`: (a) on mount, (b) on file-path change, (c) inside `updateContent()` which is called by `CodeEditor` on content/prop sync and may also call `view.focus()`. All three paths must check `shouldAutoFocusRef.current`. It does NOT apply to the imperative `CodeEditor.focus()` method — which is called by `DockPanel.focusEditor()` in response to explicit user actions (`Ctrl+e`, `Ctrl+g`) where focus is intentionally moved to the editor from any zone.
+
+The render-time ref write is sufficient: when `isFocused` becomes `false` (user leaves dock), `shouldAutoFocusRef.current` is updated before the next RAF fires, preventing stale auto-focus.
+
+For diff: `DockPanel` wraps `<DiffPanelContent>` in a stable `<div ref={diffWrapperRef} tabIndex={-1}>`. `DockPanel.focusDiff()` calls `diffWrapperRef.current?.focus()`. This guarantees focusability regardless of which render branch `DiffPanelContent` is in (loading / empty / populated).
+
+| Shortcut / action    | State mutation                                                    | `requestFocus()` called with                             |
+| -------------------- | ----------------------------------------------------------------- | -------------------------------------------------------- |
+| `Ctrl+1-4`           | via `onTerminalZoneFocus()` when appropriate per §6.4 truth table | `'terminal'` — `onTerminalZoneFocus` always calls it     |
+| `Ctrl+e`             | `openDock('editor')`                                              | `'editor'`                                               |
+| `Ctrl+g`             | `openDock('diff')`                                                | `'diff'`                                                 |
+| `Ctrl+b` (dock only) | `claimTerminal()`                                                 | `'terminal'`                                             |
+| Click terminal zone  | `setActiveContainerId(TERMINAL_CONTAINER_ID)`                     | — (natural click focus)                                  |
+| Click dock           | `setActiveContainerId(DOCK_CONTAINER_ID)`                         | — (natural click focus)                                  |
+| Peek button open     | `openDock()`                                                      | `'editor'` or `'diff'` per `dockTab` (inside `openDock`) |
+| Dock close button    | `closeDock()`                                                     | `'terminal'` (inside `closeDock`)                        |
 
 ### 5.3 Toolbar hint update
 
@@ -144,8 +245,10 @@ Ctrl+\ cycle
 to:
 
 ```
-Ctrl+1-4 pane · Ctrl+e editor · Ctrl+g diff · Ctrl+b dock
+{modKey}+1-4 pane · {modKey}+\ layout · {modKey}+e editor · {modKey}+g diff · {modKey}+b back
 ```
+
+(rendered with the platform `modKey` — `⌘` on macOS, `Ctrl` elsewhere, matching the existing hint pattern; `{modKey}+\` is restored to keep the existing layout-rotation shortcut discoverable)
 
 ---
 
@@ -153,17 +256,19 @@ Ctrl+1-4 pane · Ctrl+e editor · Ctrl+g diff · Ctrl+b dock
 
 ### 6.1 `TerminalZone`
 
-New optional prop (default preserves current behaviour):
+New optional props (defaults preserve current behaviour):
 
 ```ts
-isZoneFocused?: boolean  // default: true
+isZoneFocused?: boolean          // default: true — drives opacity dim
+onContainerPointerDown?: () => void  // called from onPointerDown on outer div
 ```
 
-The outer `<div data-testid="terminal-zone">` gains a conditional class:
+The outer `<div data-testid="terminal-zone" data-container-id="terminal">` gains:
 
-```ts
-className={`flex min-h-0 flex-1 flex-col ${!isZoneFocused ? 'opacity-[0.65] transition-opacity duration-[220ms]' : ''}`}
-```
+- `tabIndex={-1}` — makes the wrapper programmatically focusable (fallback target)
+- Opacity + transition applied unconditionally for smooth fade both ways: `${!isZoneFocused ? 'opacity-[0.65]' : 'opacity-100'} transition-opacity duration-[220ms]`
+- `onPointerDown` internally: calls `onContainerPointerDown?.()` (no-arg, notifies WorkspaceView) + component-internal conditional `.focus()` (same pattern as shown in §5.1)
+- `onFocus` (bubbling) → also calls `onContainerPointerDown` so Tab/programmatic DOM focus into any terminal-zone child claims terminal container focus
 
 ### 6.2 `DockPanel`
 
@@ -173,11 +278,26 @@ New optional prop (default preserves current behaviour):
 isFocused?: boolean  // default: false
 ```
 
-- `borderClass` logic extended: focused → replace `border-[rgba(74,68,79,0.3)]` with `border-[#cba6f7]` and upgrade from `border` to `border-2`
-- Container `<section>` gains `boxShadow` via inline style when focused
+- `borderClass` logic extended: focused → only the color changes, width stays at `1px`. For example, bottom dock: unfocused = `border-t border-t-[rgba(74,68,79,0.3)]` → focused = `border-t border-t-[#cba6f7]`. Only the junction edge's color changes — no width change, no layout jitter.
+- Container `<section>` gains `boxShadow` via inline style when focused: `0 0 0 1px #cba6f7 inset, 0 0 0 6px rgba(203,166,247,0.12)` — the inset ring adds visual depth without affecting box dimensions.
 - `DockTab` header `<div>` gains `rgba(203,166,247,0.05)` background when focused
 
-Outer `<section>` gets `onPointerDown` → `onContainerFocus?.()` (caller-provided callback, avoids threading `setActiveContainerId` into the component).
+Outer `<section data-testid="dock-panel" data-container-id="dock">` (gets `tabIndex={-1}`) gains:
+
+- `onFocus` (bubbling) → `onContainerFocus?.()` — keeps `activeContainerId` in sync when Tab or programmatic focus enters the dock
+- `onPointerDown` (internal, not exposed as prop) — calls `onContainerFocus?.()` then conditionally focuses its own wrapper:
+  ```ts
+  onContainerFocus?.()
+  if (
+    !e.target.closest(
+      'button,input,textarea,a,select,[tabindex]:not([tabindex="-1"])'
+    )
+  ) {
+    sectionRef.current?.focus()
+  }
+  ```
+
+`onContainerFocus?: () => void` is the caller-provided callback; `WorkspaceView` supplies `() => setActiveContainerId(DOCK_CONTAINER_ID)`.
 
 ### 6.3 New: `useDockShortcuts`
 
@@ -185,35 +305,174 @@ Location: `src/features/workspace/hooks/useDockShortcuts.ts`
 
 ```ts
 interface UseDockShortcutsParams {
-  isDockOpen: boolean
-  setIsDockOpen: (open: boolean) => void
-  setDockTab: (tab: 'editor' | 'diff') => void
   activeContainerId: string
-  setActiveContainerId: (id: string) => void
+  openDock: (tab: 'editor' | 'diff') => void // sets state + activeContainerId + calls requestFocus internally
+  claimTerminal: () => void // sets activeContainerId to terminal + calls requestFocus internally
   modKey: '⌘' | 'Ctrl'
 }
 ```
 
-Attaches a `keydown` listener (same pattern as `usePaneShortcuts`) for `e`, `g`, `b` with the platform modifier. Guards: skip if focus is inside a `contenteditable` or `<input>` (to avoid hijacking editor keystrokes).
+The hook stores `activeContainerId` in a latest-value ref (written during render, same pattern as `shouldAutoFocusRef`) so the capture-phase keydown handler always reads the current value, avoiding stale-closure bugs:
+
+```ts
+const activeContainerIdRef = useRef(activeContainerId)
+activeContainerIdRef.current = activeContainerId
+// handler reads activeContainerIdRef.current, not the closed-over prop
+```
+
+Attaches a `keydown` listener in **capture phase** (`addEventListener('keydown', handler, true)`) for `e`, `g`, `b` with the platform modifier. Capture phase is required so the handler runs before target-level handlers in xterm and CodeMirror; a bubble-phase listener would fire after those handlers and `preventDefault` / `stopPropagation` would have no effect on them.
+
+**Modifier check:** `modKey === '⌘'` → check `e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey`; `modKey === 'Ctrl'` → check `e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey`. Requiring the absence of Shift and Alt prevents accidentally handling `Ctrl+Shift+E`, `Ctrl+Alt+G`, etc. This is the specified policy for dock shortcuts; it may differ from `usePaneShortcuts` (which may allow Shift/Alt for non-US layout compatibility) — implementors should not assume identity between the two hooks.
+
+**Input guard — exact rule:**
+
+```ts
+// Fall back to document.activeElement for document-dispatched events (e.g. test suites)
+const target: Element =
+  e.target instanceof Element
+    ? e.target
+    : (document.activeElement ?? document.body)
+// Never fire when any open modal is visible (regardless of where focus is)
+if (
+  document.querySelector(
+    '[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])'
+  )
+)
+  return
+const inTerminalZone = !!target.closest('[data-container-id="terminal"]')
+const inCodeMirror = !!target.closest('.cm-editor')
+// Use closest() for ancestor checks so nested contenteditable/textbox widgets are caught
+const isTextEntry =
+  !!target.closest('input, textarea') ||
+  (!inCodeMirror &&
+    !!(
+      target.closest('[contenteditable]') || target.closest('[role="textbox"]')
+    ))
+if (isTextEntry && !inTerminalZone) return
+```
+
+Fires from: xterm's internal `<textarea>` (inside terminal zone), CodeMirror content (inside `.cm-editor`), non-text-entry areas of the dock.
+Suppressed from: `<input>` / `<textarea>` outside the terminal zone; `contenteditable` / `role=textbox` ancestors that are not CodeMirror; any open visible dialog (detected via `document.querySelector('[role="dialog"]:not([hidden]):not([aria-hidden="true"]),...')`).
+**Modal detection limitation:** React portals and CSS-toggled modals may not use `hidden` or `aria-hidden`. Implementors should verify the dialog guard against the command palette implementation. If the palette or other modals use a different open-state mechanism, add their selectors or use a broader focus-trap check.
+**Dock-local text inputs** (e.g., a future search field inside the dock): also suppressed — the `closest('input,textarea')` guard already covers them since they are outside the terminal zone.
+
+**Event cancellation:** every handled shortcut must call both `e.preventDefault()` and `e.stopPropagation()` to prevent bubble-through to CodeMirror key bindings, xterm, or Electron/browser accelerators — matching the existing `usePaneShortcuts` pattern.
 
 ### 6.4 `usePaneShortcuts`
 
-Add optional callback:
+Add optional no-arg callback (no-arg avoids importing workspace-layer constants into the terminal feature):
 
 ```ts
-onZoneFocus?: (containerId: string) => void
+onTerminalZoneFocus?: () => void
 ```
 
-Call it with `TERMINAL_CONTAINER_ID` inside the existing `Ctrl+1-4` handler. Backward-compatible (existing callers pass nothing).
+The second optional param mirrors to a latest-value ref (same pattern as `useDockShortcuts`):
+
+```ts
+isTerminalContainerActive?: boolean  // WorkspaceView passes activeContainerId === TERMINAL_CONTAINER_ID
+
+const isTerminalContainerActiveRef = useRef(isTerminalContainerActive)
+isTerminalContainerActiveRef.current = isTerminalContainerActive
+```
+
+When `onTerminalZoneFocus` or `isTerminalContainerActive` is not provided (existing callers), existing pane-switch behavior is unchanged. When both are provided by `WorkspaceView`, the following **authoritative truth table** applies (evaluated top-to-bottom, first match wins). Only `Digit1`–`Digit4` codes are affected; `Ctrl+\` is not.
+
+| Condition                                                                                                                                                    | Consumes key? | Action                                                                                           |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
+| `document.querySelector('[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])')` is non-null | No            | Pass through — exact same selector as `useDockShortcuts` guard                                   |
+| `isTerminalContainerActive === false` AND `document.activeElement` inside `[data-container-id="dock"]`                                                       | Yes           | `onTerminalZoneFocus()` + focus pane N if it exists (else fallback)                              |
+| `isTerminalContainerActive === false` (stale state, not in dock)                                                                                             | No            | Pass through                                                                                     |
+| `isTerminalContainerActive === true` AND pane N already active AND `document.activeElement` inside `.xterm-helper-textarea`                                  | No            | Pass through — xterm has focus, key reaches terminal app directly                                |
+| `isTerminalContainerActive === true` AND pane N already active AND `document.activeElement` NOT inside `.xterm-helper-textarea`                              | Yes           | `onTerminalZoneFocus()` + consume — restores xterm focus whether from terminal chrome or sidebar |
+| `isTerminalContainerActive === true` AND pane N differs                                                                                                      | Yes           | Focus pane N (existing behavior — works from sidebar, intentional)                               |
 
 ### 6.5 `WorkspaceView`
 
+**New `openDock()` helper** — replaces all direct `setIsDockOpen(true)` call sites so every dock-open path consistently claims dock focus:
+
+```ts
+const openDock = useCallback(
+  (tab?: TabType): void => {
+    const nextTab = tab ?? dockTab
+    if (tab) setDockTab(tab)
+    setIsDockOpen(true)
+    setActiveContainerId(DOCK_CONTAINER_ID)
+    requestFocus(nextTab === 'editor' ? 'editor' : 'diff')
+  },
+  [dockTab, requestFocus]
+)
+```
+
+Existing call sites that call `setIsDockOpen(true)` directly (e.g., `handleOpenDiff`, peek button, `Ctrl+e`, `Ctrl+g`) all migrate to `openDock()`. `Ctrl+b` does **not** call `openDock()` — it calls `claimTerminal()` only.
+
+**Dock close** — a `closeDock()` helper mirrors it:
+
+```ts
+const claimTerminal = useCallback((): void => {
+  setActiveContainerId(TERMINAL_CONTAINER_ID)
+  requestFocus('terminal')
+}, [requestFocus])
+
+const closeDock = useCallback((): void => {
+  setIsDockOpen(false)
+  claimTerminal()
+}, [claimTerminal])
+```
+
+**Session-intent wrappers** — every path that expresses terminal intent must call `claimTerminal()`. `WorkspaceView` wraps:
+
+```ts
+const handleSetActiveSessionId = useCallback(
+  (id: string): void => {
+    setActiveSessionId(id)
+    claimTerminal()
+  },
+  [claimTerminal]
+)
+
+const handleAddSession = useCallback(
+  (...args): void => {
+    addSession(...args)
+    claimTerminal()
+  },
+  [claimTerminal]
+)
+```
+
+Additionally, the **remove/close** path also wraps:
+
+```ts
+const handleRemoveSession = useCallback(
+  (sessionId: string): void => {
+    const wasActive = sessionId === activeSessionId
+    removeSession(sessionId)
+    if (wasActive) claimTerminal() // active session closed — return focus to terminal
+  },
+  [activeSessionId, claimTerminal]
+)
+```
+
+These wrappers replace direct calls in session tab clicks, sidebar selection, new-session button, tab-close button, and command-palette session commands (`:new`, `:next`, `:previous`, `:goto`, `:close`).
+
+Other changes:
+
 - Adds `activeContainerId` / `setActiveContainerId` state
+- Adds `pendingFocusTarget` ref + `useLayoutEffect` (see §5.2 DOM focus section)
+- Attaches `terminalZoneRef` and `dockPanelRef` to the respective components
 - Passes `isZoneFocused` to `<TerminalZone>`
-- Passes `isFocused` + `onContainerFocus` to `<DockPanel>` (and `<DockPeekButton>` need not handle this — peek button click implies opening, which is already handled by `setIsDockOpen`)
-- Calls `useDockShortcuts`
-- Passes `onZoneFocus={setActiveContainerId}` to `usePaneShortcuts`
-- Resets `activeContainerId` on dock close
+- Passes `isFocused` + `onContainerFocus` to `<DockPanel>`
+- Calls `useDockShortcuts`, passing `activeContainerId` so `Ctrl+b` can check current zone
+- Passes `onTerminalZoneFocus` to `usePaneShortcuts`:
+
+  ```ts
+  const activeContainerIdRef = useRef(activeContainerId)
+  activeContainerIdRef.current = activeContainerId // sync during render
+
+  const onTerminalZoneFocus = useCallback((): void => {
+    setActiveContainerId(TERMINAL_CONTAINER_ID)
+    requestFocus('terminal') // always — harmless when already active, correct for sidebar restore
+  }, [requestFocus])
+  ```
 
 ---
 
@@ -233,16 +492,21 @@ Call it with `TERMINAL_CONTAINER_ID` inside the existing `Ctrl+1-4` handler. Bac
 
 **New: `useDockShortcuts.test.ts`**:
 
-- `Ctrl+e` → `setDockTab('editor')`, `setActiveContainerId(DOCK_CONTAINER_ID)`, `setIsDockOpen(true)` called
-- `Ctrl+g` → `setDockTab('diff')`, `setActiveContainerId(DOCK_CONTAINER_ID)`, `setIsDockOpen(true)` called
-- `Ctrl+b` when `activeContainerId === DOCK_CONTAINER_ID` → `setActiveContainerId(TERMINAL_CONTAINER_ID)`
-- `Ctrl+b` when `activeContainerId === TERMINAL_CONTAINER_ID` → `setActiveContainerId(DOCK_CONTAINER_ID)`, `setIsDockOpen(true)`
+- `Ctrl+e` → `openDock('editor')` called
+- `Ctrl+g` → `openDock('diff')` called
+- `Ctrl+b` when `activeContainerId === DOCK_CONTAINER_ID` AND `document.activeElement` inside `[data-container-id="dock"]` → `claimTerminal()` called
+- `Ctrl+b` when `activeContainerId === DOCK_CONTAINER_ID` BUT `document.activeElement` NOT inside `[data-container-id="dock"]` (stale state, e.g. sidebar focus) → no-op
+- `Ctrl+b` when `activeContainerId === TERMINAL_CONTAINER_ID` → neither `claimTerminal()` nor `openDock()` called
 - No-op when modifier not held
 
 **`usePaneShortcuts.test.ts`** (existing file):
 
-- `Ctrl+1-4` calls `onZoneFocus(TERMINAL_CONTAINER_ID)` when callback provided
-- Existing tests unaffected when callback omitted
+- `Ctrl+1-4` from dock (mock `isTerminalContainerActive: false`, `activeElement` in dock): `onTerminalZoneFocus()` called, key consumed
+- `Ctrl+1-4` from dock (mock `isTerminalContainerActive: false`, `activeElement` NOT in dock): `onTerminalZoneFocus()` NOT called, key passes through
+- `Ctrl+1-4` in dialog (any container): `onTerminalZoneFocus()` NOT called, key passes through
+- `Ctrl+1-4` terminal-active + already-active pane + `activeElement` in terminal zone: `onTerminalZoneFocus()` NOT called, key passes through
+- `Ctrl+1-4` terminal-active + already-active pane + `activeElement` NOT in terminal zone (sidebar): `onTerminalZoneFocus()` called, key consumed
+- Existing tests (no callback/`isTerminalContainerActive`) unaffected
 
 ### Manual smoke test
 
@@ -252,6 +516,6 @@ Call it with `TERMINAL_CONTAINER_ID` inside the existing `Ctrl+1-4` handler. Bac
 2. Clicking dock → dock border turns mauve, terminal dims
 3. `Ctrl+e` → dock opens (if closed), editor tab active, dock lit
 4. `Ctrl+g` → diff tab active, dock lit
-5. `Ctrl+b` toggles container focus back and forth
-6. `Ctrl+1-4` → terminal zone regains focus
+5. `Ctrl+b` from dock → terminal zone regains focus; `Ctrl+b` from terminal → passes through (no zone change)
+6. `Ctrl+1-4` from dock → terminal zone regains focus
 7. Closing dock → terminal zone regains focus automatically

--- a/docs/superpowers/specs/2026-05-17-shared-focus-highlight-design.md
+++ b/docs/superpowers/specs/2026-05-17-shared-focus-highlight-design.md
@@ -1,0 +1,257 @@
+# Shared Focus Highlight — Design Spec
+
+**Date:** 2026-05-17  
+**Branch:** `feat/shared-focus-highlight`  
+**Status:** Approved
+
+---
+
+## 1. Problem
+
+Border highlights (colored ring + glow + opacity dim) currently exist only between terminal panes inside a single session. The Dock panel (editor + diff viewer) has no focus concept. Before keyboard shortcuts for expand/shrink can target the correct panel, the workspace needs a concept of an _active container_ — which major resizable section of the layout currently has user intent.
+
+---
+
+## 2. Scope
+
+This PR:
+
+- Introduces `activeContainerId` state to `WorkspaceView`
+- Adds visual focus treatment to `DockPanel` (mauve highlight)
+- Adds visual dim treatment to `TerminalZone` when dock is active
+- Wires focus transfer via click (pointer down) and keyboard shortcuts
+- Adds new shortcuts: `Ctrl+e` (editor), `Ctrl+g` (git diff), `Ctrl+b` (toggle dock)
+- Side-effects `Ctrl+1-4` to claim terminal container focus
+- Adds `useDockShortcuts` hook
+
+Out of scope:
+
+- Expand/shrink keyboard shortcuts (follow-on PR)
+- Sidebar / activity panel as focusable containers
+- Any change to per-pane `Pane.active` terminal focus logic
+
+---
+
+## 3. State model
+
+### 3.1 Container IDs
+
+Two named constants defined alongside `WorkspaceView`:
+
+```ts
+const TERMINAL_CONTAINER_ID = 'terminal' as const
+const DOCK_CONTAINER_ID = 'dock' as const
+```
+
+The type is `string` — extensible without a union update when more containers are added.
+
+### 3.2 WorkspaceView state
+
+```ts
+const [activeContainerId, setActiveContainerId] = useState<string>(
+  TERMINAL_CONTAINER_ID
+)
+```
+
+Default: `TERMINAL_CONTAINER_ID` — terminal is the primary view.
+
+**Reset rule:** when dock closes (`setIsDockOpen(false)`), also call `setActiveContainerId(TERMINAL_CONTAINER_ID)`.
+
+### 3.3 Derived props passed to children
+
+```ts
+// TerminalZone
+isZoneFocused={activeContainerId === TERMINAL_CONTAINER_ID}
+
+// DockPanel
+isFocused={activeContainerId === DOCK_CONTAINER_ID}
+```
+
+Children receive a `boolean`; they do not know their own container ID.
+
+---
+
+## 4. Visual treatment
+
+### 4.1 DockPanel — focused (`isFocused=true`)
+
+Accent color: `#cba6f7` (Catppuccin Mocha mauve / design-system primary). Fixed — not tied to any agent.
+
+| Layer             | Unfocused (current)            | Focused                            |
+| ----------------- | ------------------------------ | ---------------------------------- |
+| Junction border   | `1px solid rgba(74,68,79,0.3)` | `2px solid #cba6f7`                |
+| Container shadow  | none                           | `0 0 0 6px rgba(203,166,247,0.12)` |
+| DockTab header bg | transparent                    | `rgba(203,166,247,0.05)`           |
+
+Transitions: `180ms ease` on border, `220ms ease` on shadow — same timing as `TerminalPane`.
+
+The junction border is the edge that faces the terminal zone:
+
+- bottom dock → `border-top`
+- top dock → `border-bottom`
+- left dock → `border-right`
+- right dock → `border-left`
+
+### 4.2 TerminalZone — unfocused (`isZoneFocused=false`)
+
+The outer `<div>` of `TerminalZone` gets:
+
+```
+opacity: 0.65
+transition: opacity 220ms ease
+```
+
+The per-pane `Pane.active` highlight (colored border + glow) is **not changed** — it lives inside the dimmed wrapper and restores visually the moment `isZoneFocused` returns to `true`.
+
+### 4.3 Unchanged states
+
+- `TerminalZone` focused: current appearance, no change
+- `DockPanel` unfocused: current neutral border, no change
+
+---
+
+## 5. Focus transfer
+
+### 5.1 Click
+
+`onPointerDown` on the outer wrapper of each zone calls `setActiveContainerId` with its container ID. This mirrors how `SplitView` slot `onClick` claims pane-level focus today.
+
+- Clicking inside `<TerminalZone>` wrapper → `setActiveContainerId(TERMINAL_CONTAINER_ID)`
+- Clicking inside `<DockPanel>` wrapper → `setActiveContainerId(DOCK_CONTAINER_ID)`
+
+### 5.2 Keyboard shortcuts
+
+New hook: `useDockShortcuts` (see §6.3).
+
+| Shortcut             | Action                                                                                                                                              |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Ctrl+1-4` / `⌘+1-4` | Focus terminal pane N (existing) **+ side-effect:** `setActiveContainerId(TERMINAL_CONTAINER_ID)`                                                   |
+| `Ctrl+\` / `⌘+\`     | Rotate terminal pane layout (existing, **unchanged**)                                                                                               |
+| `Ctrl+e` / `⌘+e`     | Jump to editor tab: `setDockTab('editor')` + `setActiveContainerId(DOCK_CONTAINER_ID)` + open dock if closed                                        |
+| `Ctrl+g` / `⌘+g`     | Jump to diff tab: `setDockTab('diff')` + `setActiveContainerId(DOCK_CONTAINER_ID)` + open dock if closed                                            |
+| `Ctrl+b` / `⌘+b`     | Toggle: if active=dock → `setActiveContainerId(TERMINAL_CONTAINER_ID)`; otherwise → `setActiveContainerId(DOCK_CONTAINER_ID)` + open dock if closed |
+
+`Ctrl+e`, `Ctrl+g`, `Ctrl+b` work regardless of which zone is currently active.
+
+### 5.3 Toolbar hint update
+
+The keyboard hint strip inside `TerminalZone`'s layout toolbar updates from:
+
+```
+Ctrl+\ cycle
+```
+
+to:
+
+```
+Ctrl+1-4 pane · Ctrl+e editor · Ctrl+g diff · Ctrl+b dock
+```
+
+---
+
+## 6. Component / hook changes
+
+### 6.1 `TerminalZone`
+
+New optional prop (default preserves current behaviour):
+
+```ts
+isZoneFocused?: boolean  // default: true
+```
+
+The outer `<div data-testid="terminal-zone">` gains a conditional class:
+
+```ts
+className={`flex min-h-0 flex-1 flex-col ${!isZoneFocused ? 'opacity-[0.65] transition-opacity duration-[220ms]' : ''}`}
+```
+
+### 6.2 `DockPanel`
+
+New optional prop (default preserves current behaviour):
+
+```ts
+isFocused?: boolean  // default: false
+```
+
+- `borderClass` logic extended: focused → replace `border-[rgba(74,68,79,0.3)]` with `border-[#cba6f7]` and upgrade from `border` to `border-2`
+- Container `<section>` gains `boxShadow` via inline style when focused
+- `DockTab` header `<div>` gains `rgba(203,166,247,0.05)` background when focused
+
+Outer `<section>` gets `onPointerDown` → `onContainerFocus?.()` (caller-provided callback, avoids threading `setActiveContainerId` into the component).
+
+### 6.3 New: `useDockShortcuts`
+
+Location: `src/features/workspace/hooks/useDockShortcuts.ts`
+
+```ts
+interface UseDockShortcutsParams {
+  isDockOpen: boolean
+  setIsDockOpen: (open: boolean) => void
+  setDockTab: (tab: 'editor' | 'diff') => void
+  activeContainerId: string
+  setActiveContainerId: (id: string) => void
+  modKey: '⌘' | 'Ctrl'
+}
+```
+
+Attaches a `keydown` listener (same pattern as `usePaneShortcuts`) for `e`, `g`, `b` with the platform modifier. Guards: skip if focus is inside a `contenteditable` or `<input>` (to avoid hijacking editor keystrokes).
+
+### 6.4 `usePaneShortcuts`
+
+Add optional callback:
+
+```ts
+onZoneFocus?: (containerId: string) => void
+```
+
+Call it with `TERMINAL_CONTAINER_ID` inside the existing `Ctrl+1-4` handler. Backward-compatible (existing callers pass nothing).
+
+### 6.5 `WorkspaceView`
+
+- Adds `activeContainerId` / `setActiveContainerId` state
+- Passes `isZoneFocused` to `<TerminalZone>`
+- Passes `isFocused` + `onContainerFocus` to `<DockPanel>` (and `<DockPeekButton>` need not handle this — peek button click implies opening, which is already handled by `setIsDockOpen`)
+- Calls `useDockShortcuts`
+- Passes `onZoneFocus={setActiveContainerId}` to `usePaneShortcuts`
+- Resets `activeContainerId` on dock close
+
+---
+
+## 7. Testing plan
+
+### Unit tests
+
+**`DockPanel.test.tsx`** (existing file):
+
+- `isFocused=true` → container has mauve border class and box-shadow style
+- `isFocused=false` → container has neutral border class, no shadow
+
+**`TerminalZone.test.tsx`** (existing file):
+
+- `isZoneFocused=false` → outer div has opacity dim class
+- `isZoneFocused=true` (default) → outer div does not have dim class
+
+**New: `useDockShortcuts.test.ts`**:
+
+- `Ctrl+e` → `setDockTab('editor')`, `setActiveContainerId(DOCK_CONTAINER_ID)`, `setIsDockOpen(true)` called
+- `Ctrl+g` → `setDockTab('diff')`, `setActiveContainerId(DOCK_CONTAINER_ID)`, `setIsDockOpen(true)` called
+- `Ctrl+b` when `activeContainerId === DOCK_CONTAINER_ID` → `setActiveContainerId(TERMINAL_CONTAINER_ID)`
+- `Ctrl+b` when `activeContainerId === TERMINAL_CONTAINER_ID` → `setActiveContainerId(DOCK_CONTAINER_ID)`, `setIsDockOpen(true)`
+- No-op when modifier not held
+
+**`usePaneShortcuts.test.ts`** (existing file):
+
+- `Ctrl+1-4` calls `onZoneFocus(TERMINAL_CONTAINER_ID)` when callback provided
+- Existing tests unaffected when callback omitted
+
+### Manual smoke test
+
+`npm run dev` — verify:
+
+1. Clicking terminal → terminal zone lit, dock neutral
+2. Clicking dock → dock border turns mauve, terminal dims
+3. `Ctrl+e` → dock opens (if closed), editor tab active, dock lit
+4. `Ctrl+g` → diff tab active, dock lit
+5. `Ctrl+b` toggles container focus back and forth
+6. `Ctrl+1-4` → terminal zone regains focus
+7. Closing dock → terminal zone regains focus automatically

--- a/src/features/editor/components/CodeEditor.test.tsx
+++ b/src/features/editor/components/CodeEditor.test.tsx
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { CodeEditor } from './CodeEditor'
+import { createRef } from 'react'
+import { CodeEditor, type CodeEditorHandle } from './CodeEditor'
 import * as useCodeMirrorModule from '../hooks/useCodeMirror'
 import * as useVimModeModule from '../hooks/useVimMode'
 import * as languageServiceModule from '../services/languageService'
@@ -14,6 +15,7 @@ vi.mock('../services/languageService')
 describe('CodeEditor', () => {
   const mockEditorView = {
     destroy: vi.fn(),
+    focus: vi.fn(),
     state: { doc: { toString: (): string => 'test content' } },
   }
 
@@ -215,5 +217,36 @@ describe('CodeEditor', () => {
         onChange: onContentChange,
       })
     )
+  })
+
+  test('passes shouldAutoFocus to useCodeMirror', () => {
+    render(
+      <CodeEditor filePath="/home/user/test.ts" content="" shouldAutoFocus />
+    )
+
+    expect(mockUseCodeMirror).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldAutoFocus: true,
+      })
+    )
+  })
+
+  test('ref focus returns true when editorView is ready', () => {
+    const ref = createRef<CodeEditorHandle>()
+
+    render(<CodeEditor ref={ref} filePath="/test.ts" content="hello" />)
+
+    expect(ref.current).not.toBeNull()
+    expect(ref.current!.focus()).toBe(true)
+    expect(mockEditorView.focus).toHaveBeenCalledOnce()
+  })
+
+  test('ref focus returns false when no file is loaded', () => {
+    const ref = createRef<CodeEditorHandle>()
+
+    render(<CodeEditor ref={ref} filePath={null} content="" />)
+
+    expect(ref.current).not.toBeNull()
+    expect(ref.current!.focus()).toBe(false)
   })
 })

--- a/src/features/editor/components/CodeEditor.tsx
+++ b/src/features/editor/components/CodeEditor.tsx
@@ -1,5 +1,11 @@
-import type { ReactElement } from 'react'
-import { useEffect, useMemo } from 'react'
+/* eslint-disable react/require-default-props */
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  type ReactElement,
+} from 'react'
 import { useCodeMirror } from '../hooks/useCodeMirror'
 import { useVimMode } from '../hooks/useVimMode'
 import { VimStatusBar } from './VimStatusBar'
@@ -21,105 +27,130 @@ interface CodeEditorProps {
   isDirty?: boolean
   /** Render a loading overlay while an async file read is in flight. */
   isLoading?: boolean
+  shouldAutoFocus?: boolean
 }
 
-export const CodeEditor = ({
-  filePath,
-  content,
-  onContentChange = undefined,
-  onSave = undefined,
-  isDirty = false,
-  isLoading = false,
-}: CodeEditorProps): ReactElement => {
-  // Language extension is driven off the filename only. Memoize on
-  // `fileName` so typing (which re-renders via onContentChange) does
-  // NOT rebuild the language extension every keystroke — an non-memoized
-  // call would hand a fresh Extension object to useCodeMirror's
-  // language-update effect on every render, triggering a full
-  // Compartment.reconfigure() per keypress and visibly flickering
-  // syntax highlighting as the parser restarted from scratch.
-  const fileName = filePath ? (filePath.split('/').pop() ?? '') : ''
+export interface CodeEditorHandle {
+  /** Returns true if editorView focused, false if no file is loaded. */
+  focus(): boolean
+}
 
-  const language = useMemo(
-    () => (fileName ? getLanguageExtension(fileName) : null),
-    [fileName]
-  )
+export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
+  function CodeEditor(
+    {
+      filePath,
+      content,
+      onContentChange = undefined,
+      onSave = undefined,
+      isDirty = false,
+      isLoading = false,
+      shouldAutoFocus = false,
+    }: CodeEditorProps,
+    ref
+  ): ReactElement {
+    // Language extension is driven off the filename only. Memoize on
+    // `fileName` so typing (which re-renders via onContentChange) does
+    // NOT rebuild the language extension every keystroke — an non-memoized
+    // call would hand a fresh Extension object to useCodeMirror's
+    // language-update effect on every render, triggering a full
+    // Compartment.reconfigure() per keypress and visibly flickering
+    // syntax highlighting as the parser restarted from scratch.
+    const fileName = filePath ? (filePath.split('/').pop() ?? '') : ''
 
-  // `onSave` is required for vim :w to work. CodeEditor used to fall back
-  // to writing via a stashed fileSystemService if the caller forgot to
-  // pass onSave, but that path silently swallowed write errors and
-  // bypassed the error-surfacing improvements in WorkspaceView. We now
-  // require the caller to own the save lifecycle.
-  const handleSave = (): void => {
-    onSave?.()
-  }
+    const language = useMemo(
+      () => (fileName ? getLanguageExtension(fileName) : null),
+      [fileName]
+    )
 
-  const { editorView, updateContent, setContainer } = useCodeMirror({
-    initialContent: content,
-    language,
-    onSave: handleSave,
-    onChange: onContentChange,
-  })
-
-  const vimMode = useVimMode(editorView)
-
-  // Push prop content into CodeMirror whenever the caller updates it
-  // (e.g. a new file is opened and `useEditorBuffer` swaps the buffer
-  // content). `updateContent` no-ops when the CodeMirror doc already
-  // matches, so echo-back from user edits (typing → onContentChange →
-  // buffer state → content prop → updateContent) does not loop.
-  useEffect(() => {
-    if (filePath === null) {
-      return
+    // `onSave` is required for vim :w to work. CodeEditor used to fall back
+    // to writing via a stashed fileSystemService if the caller forgot to
+    // pass onSave, but that path silently swallowed write errors and
+    // bypassed the error-surfacing improvements in WorkspaceView. We now
+    // require the caller to own the save lifecycle.
+    const handleSave = (): void => {
+      onSave?.()
     }
 
-    updateContent(content)
-  }, [content, filePath, updateContent])
+    const { editorView, updateContent, setContainer } = useCodeMirror({
+      initialContent: content,
+      language,
+      onSave: handleSave,
+      onChange: onContentChange,
+      shouldAutoFocus,
+    })
 
-  if (!filePath) {
-    // `min-h-0` matches the invariant the main return path establishes:
-    // every flex child in CodeEditor must be prevented from growing
-    // past its bounded parent. No visible bug today because the
-    // placeholder is trivially short, but keeping the invariant
-    // consistent across both branches means a future richer placeholder
-    // (file picker, tips widget, animated illustration) won't silently
-    // reintroduce the flex `min-height: auto` scroll bug.
+    const vimMode = useVimMode(editorView)
+
+    useImperativeHandle(ref, () => ({
+      focus(): boolean {
+        if (!filePath || !editorView) {
+          return false
+        }
+
+        editorView.focus()
+
+        return true
+      },
+    }))
+
+    // Push prop content into CodeMirror whenever the caller updates it
+    // (e.g. a new file is opened and `useEditorBuffer` swaps the buffer
+    // content). `updateContent` no-ops when the CodeMirror doc already
+    // matches, so echo-back from user edits (typing → onContentChange →
+    // buffer state → content prop → updateContent) does not loop.
+    useEffect(() => {
+      if (filePath === null) {
+        return
+      }
+
+      updateContent(content)
+    }, [content, filePath, updateContent])
+
+    if (!filePath) {
+      // `min-h-0` matches the invariant the main return path establishes:
+      // every flex child in CodeEditor must be prevented from growing
+      // past its bounded parent. No visible bug today because the
+      // placeholder is trivially short, but keeping the invariant
+      // consistent across both branches means a future richer placeholder
+      // (file picker, tips widget, animated illustration) won't silently
+      // reintroduce the flex `min-height: auto` scroll bug.
+      return (
+        <div
+          className="flex min-h-0 flex-1 items-center justify-center text-on-surface-variant"
+          data-testid="no-file-selected"
+        >
+          No file selected
+        </div>
+      )
+    }
+
     return (
-      <div
-        className="flex min-h-0 flex-1 items-center justify-center text-on-surface-variant"
-        data-testid="no-file-selected"
-      >
-        No file selected
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          <div
+            ref={setContainer}
+            data-testid="codemirror-container"
+            className="h-full w-full"
+          />
+          {isLoading && (
+            <div
+              role="status"
+              aria-live="polite"
+              aria-label="Loading file"
+              data-testid="code-editor-loading"
+              className="absolute inset-0 flex items-center justify-center bg-surface/70 backdrop-blur-sm z-10"
+            >
+              <div className="flex items-center gap-2 text-sm text-on-surface-variant font-inter">
+                <span className="material-symbols-outlined animate-spin text-base">
+                  progress_activity
+                </span>
+                <span>Loading…</span>
+              </div>
+            </div>
+          )}
+        </div>
+        <VimStatusBar vimMode={vimMode} isDirty={isDirty} />
       </div>
     )
   }
-
-  return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <div className="relative min-h-0 flex-1 overflow-hidden">
-        <div
-          ref={setContainer}
-          data-testid="codemirror-container"
-          className="h-full w-full"
-        />
-        {isLoading && (
-          <div
-            role="status"
-            aria-live="polite"
-            aria-label="Loading file"
-            data-testid="code-editor-loading"
-            className="absolute inset-0 flex items-center justify-center bg-surface/70 backdrop-blur-sm z-10"
-          >
-            <div className="flex items-center gap-2 text-sm text-on-surface-variant font-inter">
-              <span className="material-symbols-outlined animate-spin text-base">
-                progress_activity
-              </span>
-              <span>Loading…</span>
-            </div>
-          </div>
-        )}
-      </div>
-      <VimStatusBar vimMode={vimMode} isDirty={isDirty} />
-    </div>
-  )
-}
+)

--- a/src/features/editor/hooks/useCodeMirror.ts
+++ b/src/features/editor/hooks/useCodeMirror.ts
@@ -120,7 +120,7 @@ export function useCodeMirror(
   const onSaveRef = useRef(onSave)
   const onChangeRef = useRef(onChange)
   const initialContentRef = useRef(initialContent)
-  const shouldAutoFocusRef = useRef(shouldAutoFocus ?? true)
+  const shouldAutoFocusRef = useRef(shouldAutoFocus ?? false)
 
   // Update `initialContentRef` synchronously during render (not via
   // useEffect). `setContainer` runs during the commit phase when React
@@ -132,7 +132,7 @@ export function useCodeMirror(
   // "latest value" pattern — unlike setState, they don't trigger a
   // re-render.
   initialContentRef.current = initialContent
-  shouldAutoFocusRef.current = shouldAutoFocus ?? true
+  shouldAutoFocusRef.current = shouldAutoFocus ?? false
 
   // onSave / onChange aren't read synchronously during render, so they
   // can use the normal effect-based ref update pattern.
@@ -219,7 +219,11 @@ export function useCodeMirror(
         return
       }
       view.requestMeasure()
-      if (shouldAutoFocusRef.current) {
+      // Guard with hasFocus: the synchronous useLayoutEffect path in
+      // WorkspaceView may have already focused the editor in the same
+      // commit cycle. Without this guard, the RAF fires ~16ms later and
+      // steals focus back from any panel that gained it in between.
+      if (shouldAutoFocusRef.current && !view.hasFocus) {
         view.focus()
       }
     })

--- a/src/features/editor/hooks/useCodeMirror.ts
+++ b/src/features/editor/hooks/useCodeMirror.ts
@@ -96,6 +96,7 @@ export interface UseCodeMirrorOptions {
   language: Extension | null
   onSave: () => void
   onChange?: (content: string) => void
+  shouldAutoFocus?: boolean
 }
 
 export interface UseCodeMirrorReturn {
@@ -113,11 +114,13 @@ export interface UseCodeMirrorReturn {
 export function useCodeMirror(
   options: UseCodeMirrorOptions
 ): UseCodeMirrorReturn {
-  const { initialContent, language, onSave, onChange } = options
+  const { initialContent, language, onSave, onChange, shouldAutoFocus } =
+    options
   const [editorView, setEditorView] = useState<EditorView | null>(null)
   const onSaveRef = useRef(onSave)
   const onChangeRef = useRef(onChange)
   const initialContentRef = useRef(initialContent)
+  const shouldAutoFocusRef = useRef(shouldAutoFocus ?? true)
 
   // Update `initialContentRef` synchronously during render (not via
   // useEffect). `setContainer` runs during the commit phase when React
@@ -129,6 +132,7 @@ export function useCodeMirror(
   // "latest value" pattern — unlike setState, they don't trigger a
   // re-render.
   initialContentRef.current = initialContent
+  shouldAutoFocusRef.current = shouldAutoFocus ?? true
 
   // onSave / onChange aren't read synchronously during render, so they
   // can use the normal effect-based ref update pattern.
@@ -215,7 +219,9 @@ export function useCodeMirror(
         return
       }
       view.requestMeasure()
-      view.focus()
+      if (shouldAutoFocusRef.current) {
+        view.focus()
+      }
     })
   }, [])
 
@@ -267,7 +273,9 @@ export function useCodeMirror(
     })
 
     // Focus editor after content load
-    view.focus()
+    if (shouldAutoFocusRef.current) {
+      view.focus()
+    }
   }, [])
 
   return {

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -1,11 +1,16 @@
 // cspell:ignore vsplit hsplit
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { createRef } from 'react'
 import { describe, test, expect, vi } from 'vitest'
 import type { UseGitBranchReturn } from '../../../diff/hooks/useGitBranch'
 import type { UseGitStatusReturn } from '../../../diff/hooks/useGitStatus'
 import type { BodyHandle, BodyProps } from '../TerminalPane/Body'
-import { SplitView, selectVisiblePanes } from './SplitView'
+import {
+  SplitView,
+  selectVisiblePanes,
+  type SplitViewHandle,
+} from './SplitView'
 import type { LayoutId, Pane, Session } from '../../../sessions/types'
 import type { ITerminalService } from '../../services/terminalService'
 
@@ -291,6 +296,26 @@ describe('SplitView - multi-pane layouts', () => {
     expect(activeWrapper).toHaveAttribute('data-focused', 'true')
     expect(activeWrapper).toHaveStyle({ opacity: '1' })
   })
+
+  test('showPaneFocusHighlight=false suppresses active pane marker without dimming active pane', () => {
+    const showPaneFocusHighlight = false
+
+    render(
+      <SplitView
+        session={makeSession('vsplit', 2, 1)}
+        service={makeMockService()}
+        isActive
+        showPaneFocusHighlight={showPaneFocusHighlight}
+      />
+    )
+
+    const activeWrapper = within(
+      screen.getAllByTestId('split-view-slot')[1]
+    ).getByTestId('terminal-pane-wrapper')
+
+    expect(activeWrapper).not.toHaveAttribute('data-focused')
+    expect(activeWrapper).toHaveStyle({ opacity: '1' })
+  })
 })
 
 describe('SplitView - under-capacity', () => {
@@ -444,6 +469,44 @@ describe('SplitView - no PTY lifecycle IPC', () => {
     )
 
     expect(service.spawn).not.toHaveBeenCalled()
+  })
+})
+
+describe('SplitView - imperative focus handle', () => {
+  test('focusActivePane returns true when active pane body is ready', () => {
+    const ref = createRef<SplitViewHandle>()
+
+    render(
+      <SplitView
+        ref={ref}
+        session={makeSession('single', 1)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+
+    expect(ref.current).not.toBeNull()
+    expect(ref.current!.focusActivePane()).toBe(true)
+  })
+
+  test('focusActivePane returns false when no active pane exists', () => {
+    const ref = createRef<SplitViewHandle>()
+    const session = makeSession('single', 1)
+
+    render(
+      <SplitView
+        ref={ref}
+        session={{
+          ...session,
+          panes: session.panes.map((pane) => ({ ...pane, active: false })),
+        }}
+        service={makeMockService()}
+        isActive
+      />
+    )
+
+    expect(ref.current).not.toBeNull()
+    expect(ref.current!.focusActivePane()).toBe(false)
   })
 })
 

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -1,5 +1,5 @@
+/* eslint-disable react/require-default-props -- forwardRef components: ESLint cannot see through forwardRef to find destructuring defaults */
 // cspell:ignore vsplit hsplit
-/* eslint-disable react/require-default-props */
 import {
   forwardRef,
   useCallback,
@@ -105,6 +105,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
           paneRefSetters.current.set(id, (h) => {
             if (h === null) {
               paneHandleRefs.current.delete(id)
+              paneRefSetters.current.delete(id)
             } else {
               paneHandleRefs.current.set(id, h)
             }

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable react/require-default-props */
 import {
   forwardRef,
+  useCallback,
   useImperativeHandle,
   useRef,
   type ReactElement,
@@ -92,6 +93,27 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
 
     const paneHandleRefs = useRef<Map<string, TerminalPaneHandle | null>>(
       new Map()
+    )
+
+    const paneRefSetters = useRef<
+      Map<string, (h: TerminalPaneHandle | null) => void>
+    >(new Map())
+
+    const getPaneRefSetter = useCallback(
+      (id: string): ((h: TerminalPaneHandle | null) => void) => {
+        if (!paneRefSetters.current.has(id)) {
+          paneRefSetters.current.set(id, (h) => {
+            if (h === null) {
+              paneHandleRefs.current.delete(id)
+            } else {
+              paneHandleRefs.current.set(id, h)
+            }
+          })
+        }
+
+        return paneRefSetters.current.get(id)!
+      },
+      []
     )
 
     useImperativeHandle(ref, () => ({
@@ -189,9 +211,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                   restarts. */}
                 <TerminalPane
                   key={pane.ptyId}
-                  ref={(handle): void => {
-                    paneHandleRefs.current.set(pane.id, handle)
-                  }}
+                  ref={getPaneRefSetter(pane.id)}
                   session={session}
                   pane={pane}
                   service={service}

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -105,7 +105,9 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
           paneRefSetters.current.set(id, (h) => {
             if (h === null) {
               paneHandleRefs.current.delete(id)
-              paneRefSetters.current.delete(id)
+              // paneRefSetters entry kept intentionally: stable closure over
+              // `id`, safe to reuse on remount (avoids extra ref cycle after
+              // ptyId key change on terminal restart).
             } else {
               paneHandleRefs.current.set(id, h)
             }

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -1,10 +1,20 @@
 // cspell:ignore vsplit hsplit
-import type { ReactElement } from 'react'
+/* eslint-disable react/require-default-props */
+import {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  type ReactElement,
+} from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import type { Pane, Session } from '../../../sessions/types'
 import type { NotifyPaneReady } from '../../hooks/useTerminal'
 import type { ITerminalService } from '../../services/terminalService'
-import { TerminalPane, type TerminalPaneMode } from '../TerminalPane'
+import {
+  TerminalPane,
+  type TerminalPaneHandle,
+  type TerminalPaneMode,
+} from '../TerminalPane'
 import { EmptySlot } from './EmptySlot'
 import { LAYOUTS } from './layouts'
 
@@ -21,6 +31,12 @@ export interface SplitViewProps {
   onAddPane?: (sessionId: string) => void
   onClosePane?: (sessionId: string, paneId: string) => void
   deferTerminalFit?: boolean
+  showPaneFocusHighlight?: boolean
+}
+
+export interface SplitViewHandle {
+  /** Focuses the active TerminalPane. Returns true if the pane was ready. */
+  focusActivePane(): boolean
 }
 
 const paneMode = (pane: Pane): TerminalPaneMode => {
@@ -54,78 +70,115 @@ export const selectVisiblePanes = (
   return sliced
 }
 
-export const SplitView = ({
-  session,
-  service,
-  isActive,
-  onSessionCwdChange = undefined,
-  onPaneReady = undefined,
-  onSessionRestart = undefined,
-  onSetActivePane = undefined,
-  onAddPane = undefined,
-  onClosePane = undefined,
-  deferTerminalFit = false,
-}: SplitViewProps): ReactElement => {
-  const layout = LAYOUTS[session.layout]
+export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
+  function SplitView(
+    {
+      session,
+      service,
+      isActive,
+      onSessionCwdChange = undefined,
+      onPaneReady = undefined,
+      onSessionRestart = undefined,
+      onSetActivePane = undefined,
+      onAddPane = undefined,
+      onClosePane = undefined,
+      deferTerminalFit = false,
+      showPaneFocusHighlight = true,
+    }: SplitViewProps,
+    ref
+  ): ReactElement {
+    const layout = LAYOUTS[session.layout]
+    const outerDivRef = useRef<HTMLDivElement>(null)
 
-  const visiblePanes = selectVisiblePanes(session.panes, layout.capacity)
+    const paneHandleRefs = useRef<Map<string, TerminalPaneHandle | null>>(
+      new Map()
+    )
 
-  const emptySlotIndices =
-    session.panes.length < layout.capacity
-      ? Array.from(
-          { length: layout.capacity - session.panes.length },
-          (_, index) => session.panes.length + index
-        )
-      : []
+    useImperativeHandle(ref, () => ({
+      focusActivePane(): boolean {
+        const activePane = session.panes.find((pane) => pane.active)
+        if (!activePane) {
+          outerDivRef.current?.focus()
 
-  const gridTemplateAreas = layout.areas
-    .map((row) => `"${row.join(' ')}"`)
-    .join(' ')
+          return false
+        }
 
-  return (
-    <div
-      data-testid="split-view"
-      data-session-id={session.id}
-      data-layout={session.layout}
-      className="grid h-full w-full gap-2 bg-surface p-2.5"
-      style={{
-        gridTemplateColumns: layout.cols,
-        gridTemplateRows: layout.rows,
-        gridTemplateAreas,
-      }}
-    >
-      {/* eslint-disable-next-line react/jsx-boolean-value -- framer-motion: `initial={false}` skips the entry animation for children already mounted. Omitting `initial` reverts to the default (animate on mount) — semantically distinct. */}
-      <AnimatePresence initial={false}>
-        {visiblePanes.map((pane, i) => {
-          const mode = paneMode(pane)
+        const handle = paneHandleRefs.current.get(activePane.id)
+        if (!handle) {
+          outerDivRef.current?.focus()
 
-          return (
-            <motion.div
-              key={pane.id}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={SLOT_FADE_TRANSITION}
-              // Skip the dispatch when this slot's pane is already
-              // active. applyActivePane returns the same reference
-              // on no-op, but expressing the guard at the call site
-              // keeps the semantic clean: every click that survives
-              // this handler is a real focus change. Mirrors the
-              // already-active escape-hatch in usePaneShortcuts.
-              onClick={
-                pane.active
-                  ? undefined
-                  : (): void => onSetActivePane?.(session.id, pane.id)
-              }
-              data-testid="split-view-slot"
-              data-pane-id={pane.id}
-              data-pty-id={pane.ptyId}
-              data-mode={mode}
-              data-cwd={pane.cwd}
-              className="relative min-h-0 min-w-0"
-              style={{ gridArea: `p${i}` }}
-            >
-              {/* F16 (codex connector P1, carried over from pre-5b TerminalZone):
+          return false
+        }
+
+        const focused = handle.focusTerminal()
+        if (!focused) {
+          outerDivRef.current?.focus()
+        }
+
+        return focused
+      },
+    }))
+
+    const visiblePanes = selectVisiblePanes(session.panes, layout.capacity)
+
+    const emptySlotIndices =
+      session.panes.length < layout.capacity
+        ? Array.from(
+            { length: layout.capacity - session.panes.length },
+            (_, index) => session.panes.length + index
+          )
+        : []
+
+    const gridTemplateAreas = layout.areas
+      .map((row) => `"${row.join(' ')}"`)
+      .join(' ')
+
+    return (
+      <div
+        ref={outerDivRef}
+        data-testid="split-view"
+        data-session-id={session.id}
+        data-layout={session.layout}
+        tabIndex={-1}
+        className="grid h-full w-full gap-2 bg-surface p-2.5"
+        style={{
+          gridTemplateColumns: layout.cols,
+          gridTemplateRows: layout.rows,
+          gridTemplateAreas,
+        }}
+      >
+        {/* eslint-disable-next-line react/jsx-boolean-value -- framer-motion: `initial={false}` skips the entry animation for children already mounted. Omitting `initial` reverts to the default (animate on mount) — semantically distinct. */}
+        <AnimatePresence initial={false}>
+          {visiblePanes.map((pane, i) => {
+            const mode = paneMode(pane)
+
+            return (
+              <motion.div
+                key={pane.id}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={SLOT_FADE_TRANSITION}
+                // Skip the dispatch when this slot's pane is already
+                // active. applyActivePane returns the same reference
+                // on no-op, but expressing the guard at the call site
+                // keeps the semantic clean: every click that survives
+                // this handler is a real focus change. Mirrors the
+                // already-active escape-hatch in usePaneShortcuts.
+                onClick={
+                  pane.active
+                    ? undefined
+                    : (): void => onSetActivePane?.(session.id, pane.id)
+                }
+                data-testid="split-view-slot"
+                data-pane-id={pane.id}
+                data-pty-id={pane.ptyId}
+                data-mode={mode}
+                data-cwd={pane.cwd}
+                className="relative min-h-0 min-w-0"
+                style={{ gridArea: `p${i}` }}
+              >
+                {/* F16 (codex connector P1, carried over from pre-5b TerminalZone):
                   keying TerminalPane by `pane.ptyId` (NOT `pane.id`) forces a
                   clean useTerminal subtree unmount + remount whenever a
                   restartSession rotates the pane's PTY handle. Without the
@@ -134,46 +187,51 @@ export const SplitView = ({
                   nowhere until reload. The outer slot wrapper above keys
                   by `pane.id` so layout slot identity is preserved across
                   restarts. */}
-              <TerminalPane
-                key={pane.ptyId}
-                session={session}
-                pane={pane}
-                service={service}
-                mode={mode}
-                onCwdChange={(cwd) =>
-                  onSessionCwdChange?.(session.id, pane.id, cwd)
-                }
-                onPaneReady={onPaneReady}
-                onRestart={onSessionRestart}
-                onClose={
-                  session.panes.length > 1 && onClosePane
-                    ? onClosePane
-                    : undefined
-                }
-                isActive={isActive}
-                deferFit={deferTerminalFit}
-              />
-            </motion.div>
-          )
-        })}
-        {onAddPane
-          ? emptySlotIndices.map((slotIndex) => (
-              <motion.div
-                key={`empty-${slotIndex}`}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={SLOT_FADE_TRANSITION}
-                data-testid="split-view-empty-slot"
-                data-slot-index={slotIndex}
-                className="relative min-h-0 min-w-0"
-                style={{ gridArea: `p${slotIndex}` }}
-              >
-                <EmptySlot sessionId={session.id} onAddPane={onAddPane} />
+                <TerminalPane
+                  key={pane.ptyId}
+                  ref={(handle): void => {
+                    paneHandleRefs.current.set(pane.id, handle)
+                  }}
+                  session={session}
+                  pane={pane}
+                  service={service}
+                  mode={mode}
+                  onCwdChange={(cwd) =>
+                    onSessionCwdChange?.(session.id, pane.id, cwd)
+                  }
+                  onPaneReady={onPaneReady}
+                  onRestart={onSessionRestart}
+                  onClose={
+                    session.panes.length > 1 && onClosePane
+                      ? onClosePane
+                      : undefined
+                  }
+                  isActive={isActive}
+                  deferFit={deferTerminalFit}
+                  showFocusHighlight={showPaneFocusHighlight}
+                />
               </motion.div>
-            ))
-          : null}
-      </AnimatePresence>
-    </div>
-  )
-}
+            )
+          })}
+          {onAddPane
+            ? emptySlotIndices.map((slotIndex) => (
+                <motion.div
+                  key={`empty-${slotIndex}`}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={SLOT_FADE_TRANSITION}
+                  data-testid="split-view-empty-slot"
+                  data-slot-index={slotIndex}
+                  className="relative min-h-0 min-w-0"
+                  style={{ gridArea: `p${slotIndex}` }}
+                >
+                  <EmptySlot sessionId={session.id} onAddPane={onAddPane} />
+                </motion.div>
+              ))
+            : null}
+        </AnimatePresence>
+      </div>
+    )
+  }
+)

--- a/src/features/terminal/components/SplitView/index.ts
+++ b/src/features/terminal/components/SplitView/index.ts
@@ -1,3 +1,7 @@
-export { SplitView, type SplitViewProps } from './SplitView'
+export {
+  SplitView,
+  type SplitViewHandle,
+  type SplitViewProps,
+} from './SplitView'
 
 export { LAYOUTS, type LayoutShape } from './layouts'

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { createRef } from 'react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { UseGitBranchReturn } from '../../../diff/hooks/useGitBranch'
 import type { UseGitStatusReturn } from '../../../diff/hooks/useGitStatus'
 import type { Session } from '../../../sessions/types'
 import type { BodyHandle, BodyProps } from './Body'
-import { TerminalPane } from './index'
+import { TerminalPane, type TerminalPaneHandle } from './index'
 
 const bodyPropsSpy = vi.hoisted(() => vi.fn())
 const focusTerminalSpy = vi.hoisted(() => vi.fn())
@@ -290,6 +291,26 @@ describe('TerminalPane index', () => {
     })
   })
 
+  test('active pane can suppress focus highlight while staying full opacity', () => {
+    const showFocusHighlight = false
+
+    render(
+      <TerminalPane {...baseProps} showFocusHighlight={showFocusHighlight} />
+    )
+
+    expect(screen.getByTestId('terminal-pane-wrapper')).not.toHaveAttribute(
+      'data-focused'
+    )
+
+    expect(screen.getByTestId('terminal-pane-wrapper')).toHaveStyle({
+      opacity: '1',
+    })
+
+    expect(screen.getByTestId('terminal-pane-focus-ring')).toHaveStyle({
+      border: '1px solid rgba(74,68,79,0.22)',
+    })
+  })
+
   test('does not focus on initial mount with pane.active=true', () => {
     render(
       <TerminalPane {...baseProps} pane={{ ...baseProps.pane, active: true }} />
@@ -357,5 +378,38 @@ describe('TerminalPane index', () => {
     )
 
     expect(focusTerminalSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('ref handle focuses terminal body when ready', () => {
+    const ref = createRef<TerminalPaneHandle>()
+
+    render(<TerminalPane ref={ref} {...baseProps} />)
+
+    expect(ref.current).not.toBeNull()
+    expect(ref.current!.focusTerminal()).toBe(true)
+    expect(focusTerminalSpy).toHaveBeenCalledOnce()
+  })
+
+  test('ref handle returns false when terminal body is not mounted', () => {
+    const ref = createRef<TerminalPaneHandle>()
+
+    const completedSession: Session = {
+      ...session,
+      status: 'completed',
+      panes: [{ ...session.panes[0], status: 'completed' }],
+    }
+
+    render(
+      <TerminalPane
+        ref={ref}
+        {...baseProps}
+        mode="awaiting-restart"
+        session={completedSession}
+        pane={completedSession.panes[0]}
+      />
+    )
+
+    expect(ref.current).not.toBeNull()
+    expect(ref.current!.focusTerminal()).toBe(false)
   })
 })

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/require-default-props */
+/* eslint-disable react/require-default-props -- forwardRef components: ESLint cannot see through forwardRef to find destructuring defaults */
 import {
   forwardRef,
   useCallback,

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -1,6 +1,9 @@
+/* eslint-disable react/require-default-props */
 import {
+  forwardRef,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -35,6 +38,12 @@ export interface TerminalPaneProps {
   onCwdChange?: (cwd: string) => void
   onRestart?: (sessionId: string) => void
   deferFit?: boolean
+  showFocusHighlight?: boolean
+}
+
+export interface TerminalPaneHandle {
+  /** Returns true if xterm body focused successfully, false if not ready. */
+  focusTerminal(): boolean
 }
 
 export {
@@ -43,187 +52,206 @@ export {
   terminalCache,
 } from './Body'
 
-export const TerminalPane = ({
-  session,
-  pane,
-  isActive,
-  service,
-  onPaneReady = undefined,
-  mode = 'spawn',
-  onClose = undefined,
-  onCwdChange = undefined,
-  onRestart = undefined,
-  deferFit = false,
-}: TerminalPaneProps): ReactElement => {
-  const agent = agentForPane(pane)
-  const bodyRef = useRef<BodyHandle>(null)
-  const wasActiveRef = useRef(pane.active)
-  const [ptyStatus, setPtyStatus] = useState<PtyStatus>('idle')
-  const [isCollapsed, setIsCollapsed] = useState(false)
+export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
+  function TerminalPane(
+    {
+      session,
+      pane,
+      isActive,
+      service,
+      onPaneReady = undefined,
+      mode = 'spawn',
+      onClose = undefined,
+      onCwdChange = undefined,
+      onRestart = undefined,
+      deferFit = false,
+      showFocusHighlight = true,
+    }: TerminalPaneProps,
+    ref
+  ): ReactElement {
+    const agent = agentForPane(pane)
+    const bodyRef = useRef<BodyHandle>(null)
+    const wasActiveRef = useRef(pane.active)
+    const [ptyStatus, setPtyStatus] = useState<PtyStatus>('idle')
+    const [isCollapsed, setIsCollapsed] = useState(false)
 
-  const isFocused = pane.active
+    useImperativeHandle(ref, () => ({
+      focusTerminal(): boolean {
+        if (!bodyRef.current) {
+          return false
+        }
 
-  useEffect(() => {
-    if (pane.active && !wasActiveRef.current) {
-      bodyRef.current?.focusTerminal()
-    }
-    wasActiveRef.current = pane.active
-  }, [pane.active])
+        bodyRef.current.focusTerminal()
 
-  const pipStatus: SessionStatus =
-    mode === 'awaiting-restart'
-      ? pane.status
-      : ptyStatusToSessionStatus(ptyStatus)
+        return true
+      },
+    }))
 
-  const isPaused = pipStatus === 'paused'
+    const isPaneActive = pane.active
+    const isFocusHighlightVisible = isPaneActive && showFocusHighlight
 
-  const { branch } = useGitBranch(pane.cwd, {
-    enabled: isActive,
-  })
+    useEffect(() => {
+      if (pane.active && !wasActiveRef.current) {
+        bodyRef.current?.focusTerminal()
+      }
+      wasActiveRef.current = pane.active
+    }, [pane.active])
 
-  const { files, filesCwd } = useGitStatus(pane.cwd, {
-    enabled: isActive,
-  })
+    const pipStatus: SessionStatus =
+      mode === 'awaiting-restart'
+        ? pane.status
+        : ptyStatusToSessionStatus(ptyStatus)
 
-  const isFresh = filesCwd === pane.cwd
+    const isPaused = pipStatus === 'paused'
 
-  const { added, removed } = useMemo(
-    () => (isFresh ? aggregateLineDelta(files) : { added: 0, removed: 0 }),
-    [files, isFresh]
-  )
+    const { branch } = useGitBranch(pane.cwd, {
+      enabled: isActive,
+    })
 
-  const handleContainerClick = useCallback((): void => {
-    // SplitView owns click-to-focus state changes. If this pane is inactive,
-    // the slot click flips pane.active first; the rising-edge effect above
-    // moves DOM focus into xterm after React commits the active state.
-    if (!pane.active) {
-      return
-    }
-    bodyRef.current?.focusTerminal()
-  }, [pane.active])
+    const { files, filesCwd } = useGitStatus(pane.cwd, {
+      enabled: isActive,
+    })
 
-  const handleToggleCollapse = useCallback((): void => {
-    setIsCollapsed((collapsed) => !collapsed)
-  }, [])
+    const isFresh = filesCwd === pane.cwd
 
-  const handleClose = useCallback((): void => {
-    onClose?.(session.id, pane.id)
-  }, [onClose, pane.id, session.id])
+    const { added, removed } = useMemo(
+      () => (isFresh ? aggregateLineDelta(files) : { added: 0, removed: 0 }),
+      [files, isFresh]
+    )
 
-  const handleRestart = useCallback(
-    (restartSessionId: string): void => {
-      // TODO(#202): for multi-pane sessions, this needs to thread `pane.id`
-      // through so `useSessionManager.restartSession` targets the clicked
-      // pane instead of `getActivePane(session)`. Deferred to 5c (production
-      // multi-pane).
-      //
-      // Until 5c lands the paneId-aware restart, gate the callback on
-      // `pane.active`. Without the guard, clicking Restart on a non-active
-      // exited pane silently restarts the active PTY (because
-      // `useSessionManager.restartSession` resolves via `getActivePane`).
-      // The guard makes non-active restarts INERT — a visible "click has
-      // no effect" is strictly safer than a wrong-pane restart with no
-      // recovery path until reload. Single-pane production has
-      // `pane.active` always true, so the guard is a no-op there.
+    const handleContainerClick = useCallback((): void => {
+      // SplitView owns click-to-focus state changes. If this pane is inactive,
+      // the slot click flips pane.active first; the rising-edge effect above
+      // moves DOM focus into xterm after React commits the active state.
       if (!pane.active) {
         return
       }
-      onRestart?.(restartSessionId)
-    },
-    [onRestart, pane.active]
-  )
+      bodyRef.current?.focusTerminal()
+    }, [pane.active])
 
-  const isAwaitingRestart = mode === 'awaiting-restart'
+    const handleToggleCollapse = useCallback((): void => {
+      setIsCollapsed((collapsed) => !collapsed)
+    }, [])
 
-  const footerPlaceholder = isAwaitingRestart
-    ? `session ended — restart to resume ${agent.short.toLowerCase()}`
-    : undefined
+    const handleClose = useCallback((): void => {
+      onClose?.(session.id, pane.id)
+    }, [onClose, pane.id, session.id])
 
-  const containerStyle = isFocused
-    ? {
-        boxShadow: `0 0 0 6px ${agent.accentDim}, 0 8px 32px rgba(0,0,0,0.35)`,
-        cursor: 'default' as const,
-      }
-    : {
-        boxShadow: 'none',
-        cursor: 'pointer' as const,
-      }
+    const handleRestart = useCallback(
+      (restartSessionId: string): void => {
+        // TODO(#202): for multi-pane sessions, this needs to thread `pane.id`
+        // through so `useSessionManager.restartSession` targets the clicked
+        // pane instead of `getActivePane(session)`. Deferred to 5c (production
+        // multi-pane).
+        //
+        // Until 5c lands the paneId-aware restart, gate the callback on
+        // `pane.active`. Without the guard, clicking Restart on a non-active
+        // exited pane silently restarts the active PTY (because
+        // `useSessionManager.restartSession` resolves via `getActivePane`).
+        // The guard makes non-active restarts INERT — a visible "click has
+        // no effect" is strictly safer than a wrong-pane restart with no
+        // recovery path until reload. Single-pane production has
+        // `pane.active` always true, so the guard is a no-op there.
+        if (!pane.active) {
+          return
+        }
+        onRestart?.(restartSessionId)
+      },
+      [onRestart, pane.active]
+    )
 
-  const focusRingStyle = {
-    border: isFocused
-      ? `2px solid ${agent.accent}`
-      : '1px solid rgba(74,68,79,0.22)',
-    transition:
-      'border-color 180ms ease, box-shadow 220ms ease, opacity 220ms ease',
-  }
+    const isAwaitingRestart = mode === 'awaiting-restart'
 
-  return (
-    <div
-      data-testid="terminal-pane-wrapper"
-      data-session-id={session.id}
-      data-mode={mode}
-      data-focused={isFocused || undefined}
-      onClick={handleContainerClick}
-      style={{
-        ...containerStyle,
-        background: '#121221',
-        borderRadius: 10,
-        transition: 'box-shadow 220ms ease, opacity 220ms ease',
-        opacity: isFocused ? 1 : 0.78,
-      }}
-      className="relative flex h-full w-full flex-col overflow-hidden"
-    >
-      <Header
-        agent={agent}
-        session={session}
-        pipStatus={pipStatus}
-        branch={branch}
-        added={added}
-        removed={removed}
-        isFocused={isFocused}
-        isCollapsed={isCollapsed}
-        onToggleCollapse={handleToggleCollapse}
-        onClose={onClose ? handleClose : undefined}
-      />
+    const footerPlaceholder = isAwaitingRestart
+      ? `session ended — restart to resume ${agent.short.toLowerCase()}`
+      : undefined
 
-      {isAwaitingRestart ? (
-        <RestartAffordance
+    const containerStyle = isFocusHighlightVisible
+      ? {
+          boxShadow: `0 0 0 6px ${agent.accentDim}, 0 8px 32px rgba(0,0,0,0.35)`,
+          cursor: 'default' as const,
+        }
+      : {
+          boxShadow: 'none',
+          cursor: isPaneActive ? ('default' as const) : ('pointer' as const),
+        }
+
+    const focusRingStyle = {
+      border: isFocusHighlightVisible
+        ? `2px solid ${agent.accent}`
+        : '1px solid rgba(74,68,79,0.22)',
+      transition:
+        'border-color 180ms ease, box-shadow 220ms ease, opacity 220ms ease',
+    }
+
+    return (
+      <div
+        data-testid="terminal-pane-wrapper"
+        data-session-id={session.id}
+        data-mode={mode}
+        data-focused={isFocusHighlightVisible || undefined}
+        onClick={handleContainerClick}
+        style={{
+          ...containerStyle,
+          background: '#121221',
+          borderRadius: 10,
+          transition: 'box-shadow 220ms ease, opacity 220ms ease',
+          opacity: isPaneActive ? 1 : 0.78,
+        }}
+        className="relative flex h-full w-full flex-col overflow-hidden"
+      >
+        <Header
           agent={agent}
-          sessionId={session.id}
-          exitedAt={session.lastActivityAt}
-          onRestart={handleRestart}
+          session={session}
+          pipStatus={pipStatus}
+          branch={branch}
+          added={added}
+          removed={removed}
+          isFocused={isFocusHighlightVisible}
+          isCollapsed={isCollapsed}
+          onToggleCollapse={handleToggleCollapse}
+          onClose={onClose ? handleClose : undefined}
         />
-      ) : (
-        <div className="relative min-h-0 flex-1">
-          <Body
-            ref={bodyRef}
-            sessionId={pane.ptyId}
-            cwd={pane.cwd}
-            service={service}
-            restoredFrom={pane.restoreData}
-            onCwdChange={onCwdChange}
-            onPaneReady={onPaneReady}
-            mode={mode}
-            onPtyStatusChange={setPtyStatus}
-            deferFit={deferFit}
-          />
-        </div>
-      )}
 
-      <Footer
-        agent={agent}
-        pipStatus={pipStatus}
-        isFocused={isFocused}
-        isPaused={isPaused}
-        onClickFocus={handleContainerClick}
-        placeholder={footerPlaceholder}
-      />
-      <span
-        data-testid="terminal-pane-focus-ring"
-        aria-hidden="true"
-        style={focusRingStyle}
-        className="pointer-events-none absolute inset-0 z-30 rounded-[10px]"
-      />
-    </div>
-  )
-}
+        {isAwaitingRestart ? (
+          <RestartAffordance
+            agent={agent}
+            sessionId={session.id}
+            exitedAt={session.lastActivityAt}
+            onRestart={handleRestart}
+          />
+        ) : (
+          <div className="relative min-h-0 flex-1">
+            <Body
+              ref={bodyRef}
+              sessionId={pane.ptyId}
+              cwd={pane.cwd}
+              service={service}
+              restoredFrom={pane.restoreData}
+              onCwdChange={onCwdChange}
+              onPaneReady={onPaneReady}
+              mode={mode}
+              onPtyStatusChange={setPtyStatus}
+              deferFit={deferFit}
+            />
+          </div>
+        )}
+
+        <Footer
+          agent={agent}
+          pipStatus={pipStatus}
+          isFocused={isFocusHighlightVisible}
+          isPaused={isPaused}
+          onClickFocus={handleContainerClick}
+          placeholder={footerPlaceholder}
+        />
+        <span
+          data-testid="terminal-pane-focus-ring"
+          aria-hidden="true"
+          style={focusRingStyle}
+          className="pointer-events-none absolute inset-0 z-30 rounded-[10px]"
+        />
+      </div>
+    )
+  }
+)

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -338,3 +338,161 @@ describe('usePaneShortcuts', () => {
     expect(event.preventDefaultSpy).not.toHaveBeenCalled()
   })
 })
+
+describe('usePaneShortcuts container reclaim extensions', () => {
+  const attachFakeDock = (): HTMLElement => {
+    const element = document.createElement('div')
+    element.setAttribute('data-container-id', 'dock')
+    element.setAttribute('tabindex', '-1')
+    document.body.appendChild(element)
+    element.focus()
+
+    return element
+  }
+
+  const removeFakeDock = (element: HTMLElement): void => {
+    document.body.removeChild(element)
+  }
+
+  const blurActiveElement = (): void => {
+    const activeElement = document.activeElement as HTMLElement | null
+    activeElement?.blur?.()
+  }
+
+  test('Ctrl+1 from focused dock consumes key and calls onTerminalZoneFocus', () => {
+    const onTerminalZoneFocus = vi.fn()
+    const dockElement = attachFakeDock()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'single', ['p0'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: false,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(onTerminalZoneFocus).toHaveBeenCalledOnce()
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    removeFakeDock(dockElement)
+  })
+
+  test('Ctrl+1 from stale dock state outside dock passes through', () => {
+    const onTerminalZoneFocus = vi.fn()
+    blurActiveElement()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'single', ['p0'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: false,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(onTerminalZoneFocus).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('Ctrl+1 in a dialog passes through regardless of container state', () => {
+    const onTerminalZoneFocus = vi.fn()
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    const inner = document.createElement('button')
+    dialog.appendChild(inner)
+    document.body.appendChild(dialog)
+    inner.focus()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'single', ['p0'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: false,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(onTerminalZoneFocus).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(dialog)
+  })
+
+  test('Ctrl+1 on active pane inside xterm helper textarea passes through', () => {
+    const onTerminalZoneFocus = vi.fn()
+    const textarea = document.createElement('textarea')
+    textarea.className = 'xterm-helper-textarea'
+    document.body.appendChild(textarea)
+    textarea.focus()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'single', ['p0'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: true,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(onTerminalZoneFocus).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(textarea)
+  })
+
+  test('Ctrl+1 on active pane outside xterm reclaims terminal focus', () => {
+    const onTerminalZoneFocus = vi.fn()
+    blurActiveElement()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'single', ['p0'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: true,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(onTerminalZoneFocus).toHaveBeenCalledOnce()
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+  })
+
+  test('omitted reclaim params preserve already-active pass-through behavior', () => {
+    const setSessionActivePane = vi.fn()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'vsplit', ['p0', 'p1'])],
+        activeSessionId: 's1',
+        setSessionActivePane,
+        setSessionLayout: vi.fn(),
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    expect(setSessionActivePane).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -478,6 +478,35 @@ describe('usePaneShortcuts container reclaim extensions', () => {
     expect(event.preventDefaultSpy).toHaveBeenCalled()
   })
 
+  test('Ctrl+1 from dock with vsplit (pane 1 active): calls onTerminalZoneFocus but does NOT switch pane', () => {
+    const onTerminalZoneFocus = vi.fn()
+    const setSessionActivePane = vi.fn()
+    const dockEl = attachFakeDock()
+    dockEl.focus()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'vsplit', ['p0', 'p1'], 1)], // p1 is active
+        activeSessionId: 's1',
+        setSessionActivePane,
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: false,
+        onTerminalZoneFocus,
+      })
+    )
+
+    const event = fire('1', { ctrlKey: true })
+
+    // Focus is reclaimed — container callback fired
+    expect(onTerminalZoneFocus).toHaveBeenCalledOnce()
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    // But pane should NOT be switched — the return prevents fallthrough
+    expect(setSessionActivePane).not.toHaveBeenCalled()
+
+    removeFakeDock(dockEl)
+  })
+
   test('omitted reclaim params preserve already-active pass-through behavior', () => {
     const setSessionActivePane = vi.fn()
 

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -121,6 +121,8 @@ export const usePaneShortcuts = ({
               onTerminalZoneFocusValue()
               event.preventDefault()
               event.stopPropagation()
+
+              return
             } else {
               return
             }

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -103,6 +103,12 @@ export const usePaneShortcuts = ({
       if (digitMatch) {
         const paneIndex = Number.parseInt(digitMatch[1], 10) - 1
 
+        // Dialog guard covers the full digit-key path — both reclaim and
+        // pane-switch — so Ctrl+1-4 is fully suppressed while any modal is open.
+        if (document.querySelector(DIALOG_SELECTOR)) {
+          return
+        }
+
         const isTerminalContainerActiveValue =
           isTerminalContainerActiveRef.current
         const onTerminalZoneFocusValue = onTerminalZoneFocusRef.current
@@ -112,10 +118,6 @@ export const usePaneShortcuts = ({
           onTerminalZoneFocusValue !== undefined
         ) {
           const activeElement = document.activeElement
-
-          if (document.querySelector(DIALOG_SELECTOR)) {
-            return
-          }
 
           if (!isTerminalContainerActiveValue) {
             if (

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -18,6 +18,9 @@ const LAYOUT_CYCLE: readonly LayoutId[] = Object.values(LAYOUTS).map(
   (layout) => layout.id
 )
 
+const DIALOG_SELECTOR =
+  '[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])'
+
 /** Which modifier the toolbar hint advertises — and therefore the only
  *  one we intercept on this platform. Restricting to a single modifier
  *  per platform prevents a hidden shortcut steal: on macOS, the
@@ -35,6 +38,8 @@ export interface UsePaneShortcutsOptions {
   /** Defaults to `'ctrl'` — the safer behavior for non-Mac shells
    *  where the toolbar already shows `Ctrl`. */
   preferModifier?: PaneShortcutModifier
+  onTerminalZoneFocus?: () => void
+  isTerminalContainerActive?: boolean
 }
 
 export const usePaneShortcuts = ({
@@ -43,13 +48,19 @@ export const usePaneShortcuts = ({
   setSessionActivePane,
   setSessionLayout,
   preferModifier = 'ctrl',
+  onTerminalZoneFocus = undefined,
+  isTerminalContainerActive = undefined,
 }: UsePaneShortcutsOptions): void => {
   const sessionsRef = useRef(sessions)
   const activeSessionIdRef = useRef(activeSessionId)
   const preferModifierRef = useRef(preferModifier)
+  const onTerminalZoneFocusRef = useRef(onTerminalZoneFocus)
+  const isTerminalContainerActiveRef = useRef(isTerminalContainerActive)
   sessionsRef.current = sessions
   activeSessionIdRef.current = activeSessionId
   preferModifierRef.current = preferModifier
+  onTerminalZoneFocusRef.current = onTerminalZoneFocus
+  isTerminalContainerActiveRef.current = isTerminalContainerActive
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -90,6 +101,45 @@ export const usePaneShortcuts = ({
       const digitMatch = /^Digit([1-4])$/.exec(event.code)
       if (digitMatch) {
         const paneIndex = Number.parseInt(digitMatch[1], 10) - 1
+
+        const isTerminalContainerActiveValue =
+          isTerminalContainerActiveRef.current
+        const onTerminalZoneFocusValue = onTerminalZoneFocusRef.current
+
+        if (
+          isTerminalContainerActiveValue !== undefined &&
+          onTerminalZoneFocusValue !== undefined
+        ) {
+          const activeElement = document.activeElement
+
+          if (document.querySelector(DIALOG_SELECTOR)) {
+            return
+          }
+
+          if (!isTerminalContainerActiveValue) {
+            if (activeElement?.closest('[data-container-id="dock"]')) {
+              onTerminalZoneFocusValue()
+              event.preventDefault()
+              event.stopPropagation()
+            } else {
+              return
+            }
+          } else if (paneIndex < activeSession.panes.length) {
+            const target = activeSession.panes[paneIndex]
+            if (target.active) {
+              if (activeElement?.closest('.xterm-helper-textarea')) {
+                return
+              }
+
+              onTerminalZoneFocusValue()
+              event.preventDefault()
+              event.stopPropagation()
+
+              return
+            }
+          }
+        }
+
         // Out-of-range: let the key propagate so terminal apps (vim,
         // tmux, etc.) can use ⌘N for their own purposes. The toolbar
         // advertises "⌘+1-4 focus pane" — reserving the slot when

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -4,6 +4,10 @@ import type { LayoutId, Session } from '../../sessions/types'
 // SplitView barrel — keeps usePaneShortcuts decoupled from a
 // sibling component's re-export surface.
 import { LAYOUTS } from '../components/SplitView/layouts'
+import {
+  DIALOG_SELECTOR,
+  DOCK_CONTAINER_ID,
+} from '../../workspace/containerIds'
 
 // Derive the cycle order from the canonical LAYOUTS record so a future
 // LayoutId added in `layouts.ts` automatically participates in ⌘\
@@ -17,9 +21,6 @@ import { LAYOUTS } from '../components/SplitView/layouts'
 const LAYOUT_CYCLE: readonly LayoutId[] = Object.values(LAYOUTS).map(
   (layout) => layout.id
 )
-
-const DIALOG_SELECTOR =
-  '[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])'
 
 /** Which modifier the toolbar hint advertises — and therefore the only
  *  one we intercept on this platform. Restricting to a single modifier
@@ -117,7 +118,11 @@ export const usePaneShortcuts = ({
           }
 
           if (!isTerminalContainerActiveValue) {
-            if (activeElement?.closest('[data-container-id="dock"]')) {
+            if (
+              activeElement?.closest(
+                `[data-container-id="${DOCK_CONTAINER_ID}"]`
+              )
+            ) {
               onTerminalZoneFocusValue()
               event.preventDefault()
               event.stopPropagation()

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -983,3 +983,85 @@ describe('WorkspaceView Integration Tests', () => {
     })
   })
 })
+
+describe('WorkspaceView focus orchestration', () => {
+  beforeEach(() => {
+    vi.spyOn(useCodeMirrorModule, 'useCodeMirror').mockImplementation(
+      createMockUseCodeMirror()
+    )
+
+    vi.spyOn(useVimModeModule, 'useVimMode').mockImplementation(
+      createMockUseVimMode()
+    )
+  })
+
+  test('initial state: terminal zone is focused, dock does not have focus outline', async () => {
+    render(<WorkspaceView />)
+
+    // Dock starts open but terminal is the active container
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+    })
+
+    const terminalZone = screen.getByTestId('terminal-zone')
+    const dockPanel = screen.getByTestId('dock-panel')
+
+    // Terminal zone should be at full opacity (active)
+    expect(terminalZone.className).not.toContain('opacity-[0.65]')
+    // Dock should NOT have the focus outline span
+    expect(
+      dockPanel.querySelector('[data-testid="dock-focus-outline"]')
+    ).toBeNull()
+  })
+
+  test('clicking dock claims dock focus: terminal dims, dock shows focus outline', async () => {
+    render(<WorkspaceView />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+    })
+
+    // Click a non-interactive part of the dock panel
+    const dockPanel = screen.getByTestId('dock-panel')
+    dockPanel.focus() // simulate focus entering dock via onFocus
+
+    await waitFor(() => {
+      // Terminal zone should dim when dock is active
+      const terminalZone = screen.getByTestId('terminal-zone')
+      expect(terminalZone.className).toContain('opacity-[0.65]')
+    })
+
+    // Dock should show focus outline
+    expect(
+      dockPanel.querySelector('[data-testid="dock-focus-outline"]')
+    ).not.toBeNull()
+  })
+
+  test('closing the dock returns container focus to terminal', async () => {
+    render(<WorkspaceView />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+    })
+
+    // Give focus to dock first
+    const dockPanel = screen.getByTestId('dock-panel')
+    dockPanel.focus()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-zone').className).toContain(
+        'opacity-[0.65]'
+      )
+    })
+
+    // Close the dock by clicking its close button
+    const closeButton = screen.getByRole('button', { name: /collapse/i })
+    await userEvent.click(closeButton)
+
+    await waitFor(() => {
+      // Terminal zone should be back at full opacity
+      const terminalZone = screen.getByTestId('terminal-zone')
+      expect(terminalZone.className).not.toContain('opacity-[0.65]')
+    })
+  })
+})

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -418,11 +418,6 @@ export const WorkspaceView = (): ReactElement => {
     claimTerminal()
   }, [claimTerminal])
 
-  const onTerminalZoneFocus = useCallback((): void => {
-    setActiveContainerId(TERMINAL_CONTAINER_ID)
-    requestFocus('terminal')
-  }, [requestFocus])
-
   const handleSetActiveSessionId = useCallback(
     (id: string): void => {
       setActiveSessionId(id)
@@ -453,7 +448,7 @@ export const WorkspaceView = (): ReactElement => {
     setSessionActivePane,
     setSessionLayout,
     preferModifier,
-    onTerminalZoneFocus,
+    onTerminalZoneFocus: claimTerminal,
     isTerminalContainerActive: activeContainerId === TERMINAL_CONTAINER_ID,
   })
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -828,7 +828,7 @@ export const WorkspaceView = (): ReactElement => {
               removePane={removePane}
               modKey={preferModifier === 'meta' ? '⌘' : 'Ctrl'}
               isZoneFocused={activeContainerId === TERMINAL_CONTAINER_ID}
-              onContainerPointerDown={() => {
+              onContainerFocus={() => {
                 setActiveContainerId(TERMINAL_CONTAINER_ID)
               }}
             />

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -18,9 +18,12 @@ import { SidebarStatusHeader } from './components/SidebarStatusHeader'
 import { FilesView } from './components/FilesView'
 import { SessionsView } from './components/SessionsView'
 import { StatusBar } from './components/StatusBar'
-import { TerminalZone } from './components/TerminalZone'
+import {
+  TerminalZone,
+  type TerminalZoneHandle,
+} from './components/TerminalZone'
 import { DockPeekButton } from './components/DockPeekButton'
-import DockPanel from './components/DockPanel'
+import DockPanel, { type DockPanelHandle } from './components/DockPanel'
 import type { DockPosition } from './components/DockSwitcher'
 import { AgentStatusPanel } from '../agent-status/components/AgentStatusPanel'
 import { UnsavedChangesDialog } from '../editor/components/UnsavedChangesDialog'
@@ -37,6 +40,7 @@ import {
   usePaneShortcuts,
   type PaneShortcutModifier,
 } from '../terminal/hooks/usePaneShortcuts'
+import { useDockShortcuts } from './hooks/useDockShortcuts'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
 import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 import { useGitStatus } from '../diff/hooks/useGitStatus'
@@ -46,6 +50,11 @@ import {
   WORKSPACE_TAB_KEYS,
 } from './commands/buildWorkspaceCommands'
 import type { ChangedFile, SelectedDiffFile } from '../diff/types'
+import {
+  DOCK_CONTAINER_ID,
+  TERMINAL_CONTAINER_ID,
+  type FocusTarget,
+} from './containerIds'
 
 const SIDEBAR_MIN = 240
 const SIDEBAR_MAX = 560
@@ -124,14 +133,6 @@ export const WorkspaceView = (): ReactElement => {
 
     return detected.startsWith('mac') ? 'meta' : 'ctrl'
   }, [])
-
-  usePaneShortcuts({
-    sessions,
-    activeSessionId,
-    setSessionActivePane,
-    setSessionLayout,
-    preferModifier,
-  })
 
   const { message: infoMessage, notifyInfo, dismiss } = useNotifyInfo()
   const { activeTab, setActiveTab } = useSidebarTab()
@@ -357,6 +358,112 @@ export const WorkspaceView = (): ReactElement => {
   const [isDockOpen, setIsDockOpen] = useState(true)
   const [dockTab, setDockTab] = useState<DockTab>('editor')
 
+  const [activeContainerId, setActiveContainerId] = useState<string>(
+    TERMINAL_CONTAINER_ID
+  )
+  const [focusRequestSeq, setFocusRequestSeq] = useState(0)
+  const pendingFocusTarget = useRef<FocusTarget | null>(null)
+  const terminalZoneRef = useRef<TerminalZoneHandle>(null)
+  const dockPanelRef = useRef<DockPanelHandle>(null)
+
+  const requestFocus = useCallback((target: FocusTarget): void => {
+    pendingFocusTarget.current = target
+    setFocusRequestSeq((value) => value + 1)
+  }, [])
+
+  useLayoutEffect(() => {
+    const target = pendingFocusTarget.current
+    if (!target) {
+      return
+    }
+
+    pendingFocusTarget.current = null
+
+    if (target === 'terminal') {
+      terminalZoneRef.current?.focusActivePane()
+
+      return
+    }
+
+    if (target === 'editor') {
+      dockPanelRef.current?.focusEditor()
+
+      return
+    }
+
+    dockPanelRef.current?.focusDiff()
+  }, [focusRequestSeq])
+
+  const openDock = useCallback(
+    (tab?: DockTab): void => {
+      const nextTab = tab ?? dockTab
+      if (tab) {
+        setDockTab(tab)
+      }
+
+      setIsDockOpen(true)
+      setActiveContainerId(DOCK_CONTAINER_ID)
+      requestFocus(nextTab)
+    },
+    [dockTab, requestFocus]
+  )
+
+  const claimTerminal = useCallback((): void => {
+    setActiveContainerId(TERMINAL_CONTAINER_ID)
+    requestFocus('terminal')
+  }, [requestFocus])
+
+  const closeDock = useCallback((): void => {
+    setIsDockOpen(false)
+    claimTerminal()
+  }, [claimTerminal])
+
+  const onTerminalZoneFocus = useCallback((): void => {
+    setActiveContainerId(TERMINAL_CONTAINER_ID)
+    requestFocus('terminal')
+  }, [requestFocus])
+
+  const handleSetActiveSessionId = useCallback(
+    (id: string): void => {
+      setActiveSessionId(id)
+      claimTerminal()
+    },
+    [claimTerminal, setActiveSessionId]
+  )
+
+  const handleCreateSession = useCallback((): void => {
+    createSession()
+    claimTerminal()
+  }, [claimTerminal, createSession])
+
+  const handleRemoveSession = useCallback(
+    (sessionId: string): void => {
+      const wasActive = sessionId === activeSessionId
+      removeSession(sessionId)
+      if (wasActive) {
+        claimTerminal()
+      }
+    },
+    [activeSessionId, claimTerminal, removeSession]
+  )
+
+  usePaneShortcuts({
+    sessions,
+    activeSessionId,
+    setSessionActivePane,
+    setSessionLayout,
+    preferModifier,
+    onTerminalZoneFocus,
+    isTerminalContainerActive: activeContainerId === TERMINAL_CONTAINER_ID,
+  })
+
+  useDockShortcuts({
+    activeContainerId,
+    openDock,
+    claimTerminal,
+    modKey: preferModifier === 'meta' ? '⌘' : 'Ctrl',
+  })
+
   // Vertical dock height is lifted so the value survives DockPanel unmounts.
   const verticalDockResize = useResizable({
     initial: 400,
@@ -556,15 +663,14 @@ export const WorkspaceView = (): ReactElement => {
   // Handle opening a diff file from AgentStatusPanel
   const handleOpenDiff = useCallback(
     (file: ChangedFile): void => {
-      setDockTab('diff')
       setSelectedDiffFile({
         path: file.path,
         staged: file.staged,
         cwd: activeCwd,
       })
-      setIsDockOpen(true)
+      openDock('diff')
     },
-    [activeCwd]
+    [activeCwd, openDock]
   )
 
   // Belt-and-suspenders: clear selection on cwd change
@@ -580,6 +686,7 @@ export const WorkspaceView = (): ReactElement => {
 
   const dockOrPeek = isDockOpen ? (
     <DockPanel
+      ref={dockPanelRef}
       selectedFilePath={editorBuffer.filePath}
       content={editorBuffer.currentContent}
       onContentChange={editorBuffer.updateContent}
@@ -594,21 +701,20 @@ export const WorkspaceView = (): ReactElement => {
       onTabChange={setDockTab}
       position={dockPosition}
       onPositionChange={setDockPosition}
-      onClose={() => setIsDockOpen(false)}
+      onClose={closeDock}
       verticalSize={verticalDockResize.size}
       onVerticalResizeMouseDown={verticalDockResize.handleMouseDown}
       isVerticalResizing={verticalDockResize.isDragging}
       onVerticalSizeAdjust={verticalDockResize.adjustBy}
       selectedDiffFile={selectedDiffFile}
       onSelectedDiffFileChange={setSelectedDiffFile}
-    />
-  ) : (
-    <DockPeekButton
-      position={dockPosition}
-      onOpen={() => {
-        setIsDockOpen(true)
+      isFocused={activeContainerId === DOCK_CONTAINER_ID}
+      onContainerFocus={() => {
+        setActiveContainerId(DOCK_CONTAINER_ID)
       }}
     />
+  ) : (
+    <DockPeekButton position={dockPosition} onOpen={() => openDock()} />
   )
 
   return (
@@ -649,9 +755,9 @@ export const WorkspaceView = (): ReactElement => {
                 hidden={activeTab !== 'sessions'}
                 sessions={sessions}
                 activeSessionId={activeSessionId}
-                onSessionClick={setActiveSessionId}
-                onCreateSession={createSession}
-                onRemoveSession={removeSession}
+                onSessionClick={handleSetActiveSessionId}
+                onCreateSession={handleCreateSession}
+                onRemoveSession={handleRemoveSession}
                 onRenameSession={renameSession}
                 onReorderSessions={reorderSessions}
               />
@@ -691,9 +797,9 @@ export const WorkspaceView = (): ReactElement => {
         <Tabs
           sessions={sessions}
           activeSessionId={activeSessionId}
-          onSelect={setActiveSessionId}
-          onClose={removeSession}
-          onNew={createSession}
+          onSelect={handleSetActiveSessionId}
+          onClose={handleRemoveSession}
+          onNew={handleCreateSession}
         />
 
         <div
@@ -707,6 +813,7 @@ export const WorkspaceView = (): ReactElement => {
             className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
           >
             <TerminalZone
+              ref={terminalZoneRef}
               sessions={sessions}
               activeSessionId={activeSessionId}
               onSessionCwdChange={updatePaneCwd}
@@ -720,6 +827,10 @@ export const WorkspaceView = (): ReactElement => {
               addPane={addPane}
               removePane={removePane}
               modKey={preferModifier === 'meta' ? '⌘' : 'Ctrl'}
+              isZoneFocused={activeContainerId === TERMINAL_CONTAINER_ID}
+              onContainerPointerDown={() => {
+                setActiveContainerId(TERMINAL_CONTAINER_ID)
+              }}
             />
           </div>
           {!dockBeforeTerminal ? dockOrPeek : null}

--- a/src/features/workspace/components/DockPanel.test.tsx
+++ b/src/features/workspace/components/DockPanel.test.tsx
@@ -388,15 +388,19 @@ describe('DockPanel', () => {
     test('isFocused=true applies mauve border to bottom junction edge', () => {
       renderDockPanel({ isFocused: true, position: 'bottom' })
 
-      expect(screen.getByTestId('dock-panel')).toHaveClass('border-t-[#cba6f7]')
+      // border-t is the edge class; border-[color] is the shared shorthand
+      const section = screen.getByTestId('dock-panel')
+      expect(section).toHaveClass('border-t')
+      expect(section).toHaveClass('border-[#cba6f7]')
     })
 
     test('isFocused=false uses neutral bottom junction edge', () => {
       renderDockPanel({ isFocused: false, position: 'bottom' })
       const section = screen.getByTestId('dock-panel')
 
-      expect(section).toHaveClass('border-t-[rgba(74,68,79,0.3)]')
-      expect(section).not.toHaveClass('border-t-[#cba6f7]')
+      expect(section).toHaveClass('border-t')
+      expect(section).toHaveClass('border-[rgba(74,68,79,0.3)]')
+      expect(section).not.toHaveClass('border-[#cba6f7]')
     })
 
     test('isFocused=true applies box shadow', () => {
@@ -465,6 +469,30 @@ describe('DockPanel', () => {
 
     expect(ref.current).not.toBeNull()
     expect(ref.current!.focusEditor()).toBe(false)
+  })
+
+  test('ref focusEditor falls back to section focus when editorView returns false', () => {
+    // Simulates Ctrl+e with dock open but no file loaded (filePath=null → editorView missing).
+    // focusEditor() should call sectionRef.focus() so the container captures keyboard input.
+    vi.spyOn(useCodeMirrorModule, 'useCodeMirror').mockReturnValueOnce({
+      editorView: null,
+      updateContent: vi.fn(),
+      setContainer: vi.fn(),
+    })
+    const ref = createRef<DockPanelHandle>()
+    renderDockPanel({ ref, tab: 'editor', selectedFilePath: null })
+
+    expect(ref.current).not.toBeNull()
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+
+    const result = ref.current!.focusEditor()
+
+    // Returns false because editorView is unavailable
+    expect(result).toBe(false)
+    // And the section element gets focused as fallback
+    expect(focusSpy).toHaveBeenCalled()
+
+    focusSpy.mockRestore()
   })
 
   test('ref focusDiff focuses the diff wrapper', () => {

--- a/src/features/workspace/components/DockPanel.test.tsx
+++ b/src/features/workspace/components/DockPanel.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, within, fireEvent } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
-import DockPanel from './DockPanel'
+import { createRef } from 'react'
+import DockPanel, { type DockPanelHandle } from './DockPanel'
 import * as useCodeMirrorModule from '../../editor/hooks/useCodeMirror'
 import * as useVimModeModule from '../../editor/hooks/useVimMode'
 import * as languageServiceModule from '../../editor/services/languageService'
@@ -41,6 +42,7 @@ const renderDockPanel = (
 describe('DockPanel', () => {
   const mockEditorView = {
     destroy: vi.fn(),
+    focus: vi.fn(),
     state: { doc: { toString: (): string => 'test content' } },
   }
 
@@ -380,5 +382,98 @@ describe('DockPanel', () => {
       expect.anything(),
       expect.objectContaining({ enabled: false })
     )
+  })
+
+  describe('focus highlight', () => {
+    test('isFocused=true applies mauve border to bottom junction edge', () => {
+      renderDockPanel({ isFocused: true, position: 'bottom' })
+
+      expect(screen.getByTestId('dock-panel')).toHaveClass('border-t-[#cba6f7]')
+    })
+
+    test('isFocused=false uses neutral bottom junction edge', () => {
+      renderDockPanel({ isFocused: false, position: 'bottom' })
+      const section = screen.getByTestId('dock-panel')
+
+      expect(section).toHaveClass('border-t-[rgba(74,68,79,0.3)]')
+      expect(section).not.toHaveClass('border-t-[#cba6f7]')
+    })
+
+    test('isFocused=true applies box shadow', () => {
+      renderDockPanel({ isFocused: true })
+
+      expect(screen.getByTestId('dock-panel').style.boxShadow).toBeTruthy()
+    })
+
+    test('isFocused=true renders a complete focus outline overlay', () => {
+      renderDockPanel({ isFocused: true })
+
+      expect(screen.getByTestId('dock-focus-outline')).toHaveClass(
+        'border-[#cba6f7]'
+      )
+    })
+
+    test('dock container suppresses native browser focus outline', () => {
+      renderDockPanel({ isFocused: true })
+
+      expect(screen.getByTestId('dock-panel')).toHaveClass('focus:outline-none')
+    })
+
+    test('diff focus target suppresses native browser focus outline', () => {
+      renderDockPanel({ isFocused: true, tab: 'diff' })
+
+      expect(screen.getByTestId('diff-focus-target')).toHaveClass(
+        'focus:outline-none'
+      )
+    })
+
+    test('isFocused=false has no box shadow', () => {
+      renderDockPanel({ isFocused: false })
+
+      expect(screen.getByTestId('dock-panel').style.boxShadow).toBe('')
+      expect(screen.queryByTestId('dock-focus-outline')).not.toBeInTheDocument()
+    })
+  })
+
+  test('ref focusEditor delegates to CodeEditor when editor is ready', () => {
+    const ref = createRef<DockPanelHandle>()
+
+    renderDockPanel({
+      ref,
+      tab: 'editor',
+      selectedFilePath: '/home/user/test.ts',
+    })
+
+    expect(ref.current).not.toBeNull()
+    expect(ref.current!.focusEditor()).toBe(true)
+    expect(mockEditorView.focus).toHaveBeenCalledOnce()
+  })
+
+  test('ref focusEditor returns false when no editorView is ready', () => {
+    vi.spyOn(useCodeMirrorModule, 'useCodeMirror').mockReturnValueOnce({
+      editorView: null,
+      updateContent: vi.fn(),
+      setContainer: vi.fn(),
+    })
+    const ref = createRef<DockPanelHandle>()
+
+    renderDockPanel({
+      ref,
+      tab: 'editor',
+      selectedFilePath: '/home/user/test.ts',
+    })
+
+    expect(ref.current).not.toBeNull()
+    expect(ref.current!.focusEditor()).toBe(false)
+  })
+
+  test('ref focusDiff focuses the diff wrapper', () => {
+    const ref = createRef<DockPanelHandle>()
+
+    renderDockPanel({ ref, tab: 'diff' })
+
+    expect(ref.current).not.toBeNull()
+    ref.current!.focusDiff()
+    expect(screen.getByTestId('diff-focus-target')).toHaveFocus()
   })
 })

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -1,10 +1,22 @@
-import type { MouseEvent, ReactElement } from 'react'
-import { CodeEditor } from '../../editor/components/CodeEditor'
+/* eslint-disable react/require-default-props */
+import {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  type MouseEvent,
+  type PointerEvent,
+  type ReactElement,
+} from 'react'
+import {
+  CodeEditor,
+  type CodeEditorHandle,
+} from '../../editor/components/CodeEditor'
 import { DiffPanelContent } from '../../diff/components/DiffPanelContent'
 import { DockSwitcher, type DockPosition } from './DockSwitcher'
 import { DockTab } from './DockTab'
 import type { SelectedDiffFile } from '../../diff/types'
 import type { UseGitStatusReturn } from '../../diff/hooks/useGitStatus'
+import { DOCK_CONTAINER_ID } from '../containerIds'
 
 type TabType = 'editor' | 'diff'
 
@@ -46,153 +58,242 @@ interface DockPanelBaseProps {
   cwd?: string
   /** Optional shared git status from WorkspaceView. */
   gitStatus?: UseGitStatusReturn
+  isFocused?: boolean
+  onContainerFocus?: () => void
 }
 
 type DockPanelProps = DockPanelBaseProps & SelectedDiffControl
+
+export interface DockPanelHandle {
+  focusEditor(): boolean
+  focusDiff(): void
+}
 
 const DRAWER_MIN = 150
 const DRAWER_MAX = 640
 const SIDE_DOCK_BASIS = '40%'
 
-const DockPanel = ({
-  position,
-  tab,
-  onTabChange,
-  onPositionChange,
-  onClose,
-  verticalSize,
-  onVerticalResizeMouseDown,
-  isVerticalResizing,
-  onVerticalSizeAdjust,
-  selectedFilePath,
-  content,
-  onContentChange = undefined,
-  onSave = undefined,
-  isDirty = false,
-  isLoading = false,
-  cwd = '.',
-  gitStatus = undefined,
-  selectedDiffFile,
-  onSelectedDiffFileChange,
-}: DockPanelProps): ReactElement => {
-  const isVerticalDock = position === 'top' || position === 'bottom'
+const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
+  function DockPanel(
+    {
+      position,
+      tab,
+      onTabChange,
+      onPositionChange,
+      onClose,
+      verticalSize,
+      onVerticalResizeMouseDown,
+      isVerticalResizing,
+      onVerticalSizeAdjust,
+      selectedFilePath,
+      content,
+      onContentChange = undefined,
+      onSave = undefined,
+      isDirty = false,
+      isLoading = false,
+      cwd = '.',
+      gitStatus = undefined,
+      isFocused = false,
+      onContainerFocus = undefined,
+      selectedDiffFile,
+      onSelectedDiffFileChange,
+    }: DockPanelProps,
+    ref
+  ): ReactElement {
+    const isVerticalDock = position === 'top' || position === 'bottom'
+    const sectionRef = useRef<HTMLElement>(null)
+    const diffWrapperRef = useRef<HTMLDivElement>(null)
+    const editorHandleRef = useRef<CodeEditorHandle | null>(null)
 
-  const containerStyle = isVerticalDock
-    ? { height: `${verticalSize}px` }
-    : { flex: `0 0 ${SIDE_DOCK_BASIS}` as const }
+    useImperativeHandle(ref, () => ({
+      focusEditor(): boolean {
+        if (editorHandleRef.current) {
+          return editorHandleRef.current.focus()
+        }
 
-  const borderClass =
-    position === 'top'
-      ? 'border-b border-[rgba(74,68,79,0.3)]'
-      : position === 'bottom'
-        ? 'border-t border-[rgba(74,68,79,0.3)]'
-        : position === 'left'
-          ? 'border-r border-[rgba(74,68,79,0.3)]'
-          : 'border-l border-[rgba(74,68,79,0.3)]'
+        sectionRef.current?.focus()
 
-  const collapseIconName =
-    position === 'top'
-      ? 'expand_less'
-      : position === 'bottom'
-        ? 'expand_more'
-        : position === 'left'
-          ? 'chevron_left'
-          : 'chevron_right'
+        return false
+      },
+      focusDiff(): void {
+        if (diffWrapperRef.current) {
+          diffWrapperRef.current.focus()
 
-  const resizeHandleEdgeClass = position === 'top' ? 'bottom-0' : 'top-0'
-  const sectionAriaLabel = tab === 'editor' ? 'Code editor' : 'Diff viewer'
+          return
+        }
 
-  return (
-    <section
-      data-testid="dock-panel"
-      data-position={position}
-      aria-label={sectionAriaLabel}
-      style={containerStyle}
-      className={`relative z-30 flex shrink-0 flex-col bg-[#121221] ${borderClass}`}
-    >
-      {isVerticalDock && (
-        <div
-          data-testid="resize-handle"
-          role="separator"
-          aria-orientation="horizontal"
-          aria-label="Resize panel"
-          aria-valuenow={verticalSize}
-          aria-valuemin={DRAWER_MIN}
-          aria-valuemax={DRAWER_MAX}
-          tabIndex={0}
-          onMouseDown={onVerticalResizeMouseDown}
-          onKeyDown={(e): void => {
-            const step = e.shiftKey ? 100 : 20
-            const growKey = position === 'top' ? 'ArrowDown' : 'ArrowUp'
-            const shrinkKey = position === 'top' ? 'ArrowUp' : 'ArrowDown'
+        sectionRef.current?.focus()
+      },
+    }))
 
-            if (e.key === growKey) {
-              e.preventDefault()
-              onVerticalSizeAdjust(step)
-            } else if (e.key === shrinkKey) {
-              e.preventDefault()
-              onVerticalSizeAdjust(-step)
-            } else if (e.key === 'Home') {
-              e.preventDefault()
-              onVerticalSizeAdjust(DRAWER_MIN - verticalSize)
-            } else if (e.key === 'End') {
-              e.preventDefault()
-              onVerticalSizeAdjust(DRAWER_MAX - verticalSize)
-            }
-          }}
-          className={`absolute ${resizeHandleEdgeClass} left-0 right-0 h-1 cursor-ns-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
-            isVerticalResizing ? 'bg-primary/30' : ''
-          }`}
-        />
-      )}
+    const handlePointerDown = (event: PointerEvent<HTMLElement>): void => {
+      onContainerFocus?.()
 
-      <DockTab
-        tab={tab}
-        onTabChange={onTabChange}
-        selectedFilePath={selectedFilePath}
-        collapseIconName={collapseIconName}
-        onClose={onClose}
+      const target =
+        event.target instanceof Element ? event.target : event.currentTarget
+
+      if (
+        !target.closest(
+          'button,input,textarea,a,select,[tabindex]:not([tabindex="-1"])'
+        )
+      ) {
+        sectionRef.current?.focus()
+      }
+    }
+
+    const containerStyle = isVerticalDock
+      ? { height: `${verticalSize}px` }
+      : { flex: `0 0 ${SIDE_DOCK_BASIS}` as const }
+
+    const borderClass =
+      position === 'top'
+        ? isFocused
+          ? 'border-b border-[#cba6f7] border-b-[#cba6f7]'
+          : 'border-b border-[rgba(74,68,79,0.3)] border-b-[rgba(74,68,79,0.3)]'
+        : position === 'bottom'
+          ? isFocused
+            ? 'border-t border-[#cba6f7] border-t-[#cba6f7]'
+            : 'border-t border-[rgba(74,68,79,0.3)] border-t-[rgba(74,68,79,0.3)]'
+          : position === 'left'
+            ? isFocused
+              ? 'border-r border-[#cba6f7] border-r-[#cba6f7]'
+              : 'border-r border-[rgba(74,68,79,0.3)] border-r-[rgba(74,68,79,0.3)]'
+            : isFocused
+              ? 'border-l border-[#cba6f7] border-l-[#cba6f7]'
+              : 'border-l border-[rgba(74,68,79,0.3)] border-l-[rgba(74,68,79,0.3)]'
+
+    const collapseIconName =
+      position === 'top'
+        ? 'expand_less'
+        : position === 'bottom'
+          ? 'expand_more'
+          : position === 'left'
+            ? 'chevron_left'
+            : 'chevron_right'
+
+    const resizeHandleEdgeClass = position === 'top' ? 'bottom-0' : 'top-0'
+    const sectionAriaLabel = tab === 'editor' ? 'Code editor' : 'Diff viewer'
+
+    return (
+      <section
+        ref={sectionRef}
+        data-testid="dock-panel"
+        data-position={position}
+        data-container-id={DOCK_CONTAINER_ID}
+        aria-label={sectionAriaLabel}
+        tabIndex={-1}
+        style={{
+          ...containerStyle,
+          boxShadow: isFocused
+            ? '0 0 0 1px #cba6f7 inset, 0 0 0 6px rgba(203,166,247,0.12)'
+            : undefined,
+          transition: 'box-shadow 220ms ease',
+        }}
+        onPointerDown={handlePointerDown}
+        onFocus={onContainerFocus}
+        className={`relative z-30 flex shrink-0 flex-col bg-[#121221] focus:outline-none ${borderClass}`}
       >
-        <DockSwitcher position={position} onPick={onPositionChange} />
-      </DockTab>
+        {isFocused ? (
+          <span
+            data-testid="dock-focus-outline"
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 z-40 border border-[#cba6f7]"
+          />
+        ) : null}
 
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        {tab === 'editor' && (
+        {isVerticalDock && (
           <div
-            data-testid="editor-panel"
-            className="flex min-h-0 flex-1 overflow-hidden"
-          >
-            <CodeEditor
-              filePath={selectedFilePath}
-              content={content}
-              onContentChange={onContentChange}
-              onSave={onSave}
-              isDirty={isDirty}
-              isLoading={isLoading}
-            />
-          </div>
+            data-testid="resize-handle"
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label="Resize panel"
+            aria-valuenow={verticalSize}
+            aria-valuemin={DRAWER_MIN}
+            aria-valuemax={DRAWER_MAX}
+            tabIndex={0}
+            onMouseDown={onVerticalResizeMouseDown}
+            onKeyDown={(e): void => {
+              const step = e.shiftKey ? 100 : 20
+              const growKey = position === 'top' ? 'ArrowDown' : 'ArrowUp'
+              const shrinkKey = position === 'top' ? 'ArrowUp' : 'ArrowDown'
+
+              if (e.key === growKey) {
+                e.preventDefault()
+                onVerticalSizeAdjust(step)
+              } else if (e.key === shrinkKey) {
+                e.preventDefault()
+                onVerticalSizeAdjust(-step)
+              } else if (e.key === 'Home') {
+                e.preventDefault()
+                onVerticalSizeAdjust(DRAWER_MIN - verticalSize)
+              } else if (e.key === 'End') {
+                e.preventDefault()
+                onVerticalSizeAdjust(DRAWER_MAX - verticalSize)
+              }
+            }}
+            className={`absolute ${resizeHandleEdgeClass} left-0 right-0 h-1 cursor-ns-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
+              isVerticalResizing ? 'bg-primary/30' : ''
+            }`}
+          />
         )}
 
-        {tab === 'diff' && (
-          <div
-            data-testid="diff-panel"
-            className="flex min-h-0 flex-1 overflow-hidden"
-          >
-            {selectedDiffFile !== undefined ? (
-              <DiffPanelContent
-                cwd={cwd}
-                gitStatus={gitStatus}
-                selectedFile={selectedDiffFile}
-                onSelectedFileChange={onSelectedDiffFileChange}
+        <DockTab
+          tab={tab}
+          onTabChange={onTabChange}
+          selectedFilePath={selectedFilePath}
+          collapseIconName={collapseIconName}
+          onClose={onClose}
+        >
+          <DockSwitcher position={position} onPick={onPositionChange} />
+        </DockTab>
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          {tab === 'editor' && (
+            <div
+              data-testid="editor-panel"
+              className="flex min-h-0 flex-1 overflow-hidden"
+            >
+              <CodeEditor
+                ref={editorHandleRef}
+                filePath={selectedFilePath}
+                content={content}
+                onContentChange={onContentChange}
+                onSave={onSave}
+                isDirty={isDirty}
+                isLoading={isLoading}
+                shouldAutoFocus={isFocused}
               />
-            ) : (
-              <DiffPanelContent cwd={cwd} gitStatus={gitStatus} />
-            )}
-          </div>
-        )}
-      </div>
-    </section>
-  )
-}
+            </div>
+          )}
+
+          {tab === 'diff' && (
+            <div
+              data-testid="diff-panel"
+              className="flex min-h-0 flex-1 overflow-hidden"
+            >
+              <div
+                data-testid="diff-focus-target"
+                ref={diffWrapperRef}
+                tabIndex={-1}
+                className="flex min-h-0 flex-1 focus:outline-none"
+              >
+                {selectedDiffFile !== undefined ? (
+                  <DiffPanelContent
+                    cwd={cwd}
+                    gitStatus={gitStatus}
+                    selectedFile={selectedDiffFile}
+                    onSelectedFileChange={onSelectedDiffFileChange}
+                  />
+                ) : (
+                  <DiffPanelContent cwd={cwd} gitStatus={gitStatus} />
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+    )
+  }
+)
 
 export default DockPanel

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -108,7 +108,13 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
     useImperativeHandle(ref, () => ({
       focusEditor(): boolean {
         if (editorHandleRef.current) {
-          return editorHandleRef.current.focus()
+          const ok = editorHandleRef.current.focus()
+
+          if (!ok) {
+            sectionRef.current?.focus()
+          }
+
+          return ok
         }
 
         sectionRef.current?.focus()
@@ -145,22 +151,16 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
       ? { height: `${verticalSize}px` }
       : { flex: `0 0 ${SIDE_DOCK_BASIS}` as const }
 
+    const borderColor = isFocused ? '#cba6f7' : 'rgba(74,68,79,0.3)'
+
     const borderClass =
       position === 'top'
-        ? isFocused
-          ? 'border-b border-[#cba6f7] border-b-[#cba6f7]'
-          : 'border-b border-[rgba(74,68,79,0.3)] border-b-[rgba(74,68,79,0.3)]'
+        ? `border-b border-[${borderColor}]`
         : position === 'bottom'
-          ? isFocused
-            ? 'border-t border-[#cba6f7] border-t-[#cba6f7]'
-            : 'border-t border-[rgba(74,68,79,0.3)] border-t-[rgba(74,68,79,0.3)]'
+          ? `border-t border-[${borderColor}]`
           : position === 'left'
-            ? isFocused
-              ? 'border-r border-[#cba6f7] border-r-[#cba6f7]'
-              : 'border-r border-[rgba(74,68,79,0.3)] border-r-[rgba(74,68,79,0.3)]'
-            : isFocused
-              ? 'border-l border-[#cba6f7] border-l-[#cba6f7]'
-              : 'border-l border-[rgba(74,68,79,0.3)] border-l-[rgba(74,68,79,0.3)]'
+            ? `border-r border-[${borderColor}]`
+            : `border-l border-[${borderColor}]`
 
     const collapseIconName =
       position === 'top'

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -133,8 +133,9 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
     }))
 
     const handlePointerDown = (event: PointerEvent<HTMLElement>): void => {
-      onContainerFocus?.()
-
+      // onContainerFocus is NOT called here — onFocus (bubbling) covers
+      // both pointer and keyboard Tab paths, avoiding a double invocation
+      // on every click (pointer → child-focus bubbles → onFocus fires too).
       const target =
         event.target instanceof Element ? event.target : event.currentTarget
 

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/require-default-props */
+/* eslint-disable react/require-default-props -- forwardRef components: ESLint cannot see through forwardRef to find destructuring defaults */
 import {
   forwardRef,
   useImperativeHandle,
@@ -151,16 +151,21 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
       ? { height: `${verticalSize}px` }
       : { flex: `0 0 ${SIDE_DOCK_BASIS}` as const }
 
-    const borderColor = isFocused ? '#cba6f7' : 'rgba(74,68,79,0.3)'
-
-    const borderClass =
+    // Border edge varies by position; color literals are kept static so
+    // Tailwind JIT can scan and emit both border-[#cba6f7] and
+    // border-[rgba(74,68,79,0.3)] in the production CSS bundle.
+    const borderEdge =
       position === 'top'
-        ? `border-b border-[${borderColor}]`
+        ? 'border-b'
         : position === 'bottom'
-          ? `border-t border-[${borderColor}]`
+          ? 'border-t'
           : position === 'left'
-            ? `border-r border-[${borderColor}]`
-            : `border-l border-[${borderColor}]`
+            ? 'border-r'
+            : 'border-l'
+
+    const borderClass = isFocused
+      ? `${borderEdge} border-[#cba6f7]`
+      : `${borderEdge} border-[rgba(74,68,79,0.3)]`
 
     const collapseIconName =
       position === 'top'

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -198,18 +198,15 @@ describe('TerminalZone', () => {
 
   test('pointer down marks terminal container active', async () => {
     const user = userEvent.setup()
-    const onContainerPointerDown = vi.fn()
+    const onContainerFocus = vi.fn()
 
     render(
-      <TerminalZone
-        {...defaultProps}
-        onContainerPointerDown={onContainerPointerDown}
-      />
+      <TerminalZone {...defaultProps} onContainerFocus={onContainerFocus} />
     )
 
     await user.click(screen.getByTestId('terminal-zone'))
 
-    expect(onContainerPointerDown).toHaveBeenCalled()
+    expect(onContainerFocus).toHaveBeenCalled()
   })
 
   // TerminalPane integration tests (Feature #30)

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -2,8 +2,8 @@
 import { describe, test, expect, vi } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ReactElement } from 'react'
-import { TerminalZone } from './TerminalZone'
+import { createRef, type ReactElement } from 'react'
+import { TerminalZone, type TerminalZoneHandle } from './TerminalZone'
 import { mockSessions } from '../data/mockSessions'
 import type { LayoutId, Session } from '../../sessions/types'
 import type { TerminalPaneProps } from '../../terminal/components/TerminalPane'
@@ -50,6 +50,7 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
       mode,
       onCwdChange,
       deferFit,
+      showFocusHighlight,
       onRestart,
       onClose,
       session,
@@ -64,6 +65,7 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
         data-restored={pane.restoreData ? 'true' : 'false'}
         data-mode={mode}
         data-defer-fit={deferFit ? 'true' : 'false'}
+        data-show-focus-highlight={showFocusHighlight ? 'true' : 'false'}
         data-session-name={session.name}
         data-is-active={isActive ? 'true' : 'false'}
         data-session-agent-type={session.agentType}
@@ -144,6 +146,70 @@ describe('TerminalZone', () => {
     expect(rootElement).toHaveClass('flex-col')
     expect(rootElement).toHaveClass('flex-1')
     expect(rootElement).toHaveClass('min-h-0')
+  })
+
+  test('isZoneFocused=false applies opacity dim class', () => {
+    const isZoneFocused = false
+
+    render(<TerminalZone {...defaultProps} isZoneFocused={isZoneFocused} />)
+
+    expect(screen.getByTestId('terminal-zone')).toHaveClass('opacity-[0.65]')
+  })
+
+  test('isZoneFocused=false suppresses active terminal pane highlight', () => {
+    const isZoneFocused = false
+
+    render(<TerminalZone {...defaultProps} isZoneFocused={isZoneFocused} />)
+
+    expect(screen.getAllByTestId('terminal-pane-mock')[0]).toHaveAttribute(
+      'data-show-focus-highlight',
+      'false'
+    )
+  })
+
+  test('isZoneFocused=true by default does not apply dim class', () => {
+    render(<TerminalZone {...defaultProps} />)
+
+    expect(screen.getByTestId('terminal-zone')).not.toHaveClass(
+      'opacity-[0.65]'
+    )
+
+    expect(screen.getAllByTestId('terminal-pane-mock')[0]).toHaveAttribute(
+      'data-show-focus-highlight',
+      'true'
+    )
+  })
+
+  test('ref exposes focusActivePane returning false when no sessions exist', () => {
+    const ref = createRef<TerminalZoneHandle>()
+
+    render(
+      <TerminalZone
+        ref={ref}
+        {...defaultProps}
+        sessions={[]}
+        activeSessionId={null}
+      />
+    )
+
+    expect(ref.current).not.toBeNull()
+    expect(ref.current!.focusActivePane()).toBe(false)
+  })
+
+  test('pointer down marks terminal container active', async () => {
+    const user = userEvent.setup()
+    const onContainerPointerDown = vi.fn()
+
+    render(
+      <TerminalZone
+        {...defaultProps}
+        onContainerPointerDown={onContainerPointerDown}
+      />
+    )
+
+    await user.click(screen.getByTestId('terminal-zone'))
+
+    expect(onContainerPointerDown).toHaveBeenCalled()
   })
 
   // TerminalPane integration tests (Feature #30)

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/require-default-props */
+/* eslint-disable react/require-default-props -- forwardRef components: ESLint cannot see through forwardRef to find destructuring defaults */
 import {
   forwardRef,
   useCallback,

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -64,7 +64,7 @@ export interface TerminalZoneProps {
    */
   modKey?: '⌘' | 'Ctrl'
   isZoneFocused?: boolean
-  onContainerPointerDown?: () => void
+  onContainerFocus?: () => void
 }
 
 export interface TerminalZoneHandle {
@@ -88,12 +88,18 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
       removePane,
       modKey = 'Ctrl',
       isZoneFocused = true,
-      onContainerPointerDown = undefined,
+      onContainerFocus = undefined,
     }: TerminalZoneProps,
     ref
   ): ReactElement {
     const outerDivRef = useRef<HTMLDivElement>(null)
     const activeSplitViewRef = useRef<SplitViewHandle | null>(null)
+
+    const setActiveSplitViewRefFn = useRef(
+      (handle: SplitViewHandle | null): void => {
+        activeSplitViewRef.current = handle
+      }
+    )
 
     useImperativeHandle(ref, () => ({
       focusActivePane(): boolean {
@@ -113,7 +119,7 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
     }))
 
     const handlePointerDown = (event: PointerEvent<HTMLDivElement>): void => {
-      onContainerPointerDown?.()
+      onContainerFocus?.()
 
       const target =
         event.target instanceof Element ? event.target : event.currentTarget
@@ -166,7 +172,7 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
         } transition-opacity duration-[220ms]`}
         onPointerDown={handlePointerDown}
         onFocus={(): void => {
-          onContainerPointerDown?.()
+          onContainerFocus?.()
         }}
       >
         {showToolbar ? (
@@ -245,13 +251,7 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
                   className={`absolute inset-0 ${isActive ? '' : 'hidden'}`}
                 >
                   <SplitView
-                    ref={
-                      isActive
-                        ? (handle): void => {
-                            activeSplitViewRef.current = handle
-                          }
-                        : null
-                    }
+                    ref={isActive ? setActiveSplitViewRefFn.current : null}
                     session={session}
                     service={service}
                     isActive={isActive}

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -1,4 +1,12 @@
-import { useCallback, type ReactElement } from 'react'
+/* eslint-disable react/require-default-props */
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  type PointerEvent,
+  type ReactElement,
+} from 'react'
 import type { LayoutId, Session } from '../../sessions/types'
 import type { ITerminalService } from '../../terminal/services/terminalService'
 import type {
@@ -7,7 +15,11 @@ import type {
 } from '../../sessions/hooks/useSessionManager'
 import { isOpenSessionStatus } from '../../sessions/utils/pickNextVisibleSessionId'
 import { LayoutSwitcher } from '../../terminal/components/LayoutSwitcher'
-import { SplitView } from '../../terminal/components/SplitView'
+import {
+  SplitView,
+  type SplitViewHandle,
+} from '../../terminal/components/SplitView'
+import { TERMINAL_CONTAINER_ID } from '../containerIds'
 
 export interface TerminalZoneProps {
   sessions: Session[]
@@ -51,136 +63,213 @@ export interface TerminalZoneProps {
    * that don't pass it explicitly.
    */
   modKey?: '⌘' | 'Ctrl'
+  isZoneFocused?: boolean
+  onContainerPointerDown?: () => void
 }
 
-export const TerminalZone = ({
-  sessions,
-  activeSessionId,
-  onSessionCwdChange = undefined,
-  loading = false,
-  onPaneReady = undefined,
-  onSessionRestart = undefined,
-  deferTerminalFit = false,
-  service,
-  setSessionActivePane,
-  setSessionLayout,
-  addPane,
-  removePane,
-  modKey = 'Ctrl',
-}: TerminalZoneProps): ReactElement => {
-  const activeSession = sessions.find(
-    (session) => session.id === activeSessionId
-  )
+export interface TerminalZoneHandle {
+  focusActivePane(): boolean
+}
 
-  const showToolbar =
-    !loading && sessions.length > 0 && activeSession !== undefined
+export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
+  function TerminalZone(
+    {
+      sessions,
+      activeSessionId,
+      onSessionCwdChange = undefined,
+      loading = false,
+      onPaneReady = undefined,
+      onSessionRestart = undefined,
+      deferTerminalFit = false,
+      service,
+      setSessionActivePane,
+      setSessionLayout,
+      addPane,
+      removePane,
+      modKey = 'Ctrl',
+      isZoneFocused = true,
+      onContainerPointerDown = undefined,
+    }: TerminalZoneProps,
+    ref
+  ): ReactElement {
+    const outerDivRef = useRef<HTMLDivElement>(null)
+    const activeSplitViewRef = useRef<SplitViewHandle | null>(null)
 
-  // Memoised onPick so a future `React.memo(LayoutSwitcher)` would
-  // see a stable reference until the active session id changes.
-  // `setSessionLayout` is itself a stable `useCallback([])`, so the
-  // dep list collapses to `pickSessionId`. The callback is only
-  // mounted via `showToolbar === true`, which itself requires
-  // `activeSession !== undefined`, so the undefined branch is
-  // unreachable from the LayoutSwitcher mount site. The optional
-  // chain stays in for the TS-level narrowing; the `if (!pickSessionId)`
-  // bail satisfies the compiler without adding a non-null assertion.
-  const pickSessionId = activeSession?.id
+    useImperativeHandle(ref, () => ({
+      focusActivePane(): boolean {
+        if (!activeSplitViewRef.current) {
+          outerDivRef.current?.focus()
 
-  const onPickLayout = useCallback(
-    (layoutId: LayoutId): void => {
-      if (!pickSessionId) {
-        return
+          return false
+        }
+
+        const focused = activeSplitViewRef.current.focusActivePane()
+        if (!focused) {
+          outerDivRef.current?.focus()
+        }
+
+        return focused
+      },
+    }))
+
+    const handlePointerDown = (event: PointerEvent<HTMLDivElement>): void => {
+      onContainerPointerDown?.()
+
+      const target =
+        event.target instanceof Element ? event.target : event.currentTarget
+
+      if (
+        !target.closest(
+          'button,input,textarea,a,select,[tabindex]:not([tabindex="-1"])'
+        )
+      ) {
+        event.currentTarget.focus()
       }
-      setSessionLayout(pickSessionId, layoutId)
-    },
-    [pickSessionId, setSessionLayout]
-  )
+    }
 
-  return (
-    <div data-testid="terminal-zone" className="flex min-h-0 flex-1 flex-col">
-      {showToolbar ? (
-        <div
-          data-testid="layout-toolbar"
-          className="flex shrink-0 items-center gap-2 bg-surface-container px-3 py-2"
-        >
-          <LayoutSwitcher
-            activeLayoutId={activeSession.layout}
-            onPick={onPickLayout}
-          />
-          <span className="ml-auto hidden items-center gap-1 font-mono text-xs text-on-surface-muted sm:inline-flex">
-            <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
-            <span>+1-4 focus</span>
-            <span>·</span>
-            <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
-            <span>+{'\\'} cycle</span>
-          </span>
-        </div>
-      ) : null}
+    const activeSession = sessions.find(
+      (session) => session.id === activeSessionId
+    )
 
-      {/* Terminal content area — relative + absolute inner to give xterm explicit dimensions */}
+    const showToolbar =
+      !loading && sessions.length > 0 && activeSession !== undefined
+
+    // Memoised onPick so a future `React.memo(LayoutSwitcher)` would
+    // see a stable reference until the active session id changes.
+    // `setSessionLayout` is itself a stable `useCallback([])`, so the
+    // dep list collapses to `pickSessionId`. The callback is only
+    // mounted via `showToolbar === true`, which itself requires
+    // `activeSession !== undefined`, so the undefined branch is
+    // unreachable from the LayoutSwitcher mount site. The optional
+    // chain stays in for the TS-level narrowing; the `if (!pickSessionId)`
+    // bail satisfies the compiler without adding a non-null assertion.
+    const pickSessionId = activeSession?.id
+
+    const onPickLayout = useCallback(
+      (layoutId: LayoutId): void => {
+        if (!pickSessionId) {
+          return
+        }
+        setSessionLayout(pickSessionId, layoutId)
+      },
+      [pickSessionId, setSessionLayout]
+    )
+
+    return (
       <div
-        data-testid="terminal-content"
-        className="relative min-h-0 flex-1 bg-surface"
+        ref={outerDivRef}
+        data-testid="terminal-zone"
+        data-container-id={TERMINAL_CONTAINER_ID}
+        tabIndex={-1}
+        className={`flex min-h-0 flex-1 flex-col ${
+          isZoneFocused ? 'opacity-100' : 'opacity-[0.65]'
+        } transition-opacity duration-[220ms]`}
+        onPointerDown={handlePointerDown}
+        onFocus={(): void => {
+          onContainerPointerDown?.()
+        }}
       >
-        {loading ? (
-          <div className="flex h-full items-center justify-center font-mono text-on-surface/60">
-            <p>Restoring sessions...</p>
+        {showToolbar ? (
+          <div
+            data-testid="layout-toolbar"
+            className="flex shrink-0 items-center gap-2 bg-surface-container px-3 py-2"
+          >
+            <LayoutSwitcher
+              activeLayoutId={activeSession.layout}
+              onPick={onPickLayout}
+            />
+            <span className="ml-auto hidden items-center gap-1 font-mono text-xs text-on-surface-muted sm:inline-flex">
+              <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
+              <span>+1-4 pane</span>
+              <span>·</span>
+              <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
+              <span>+{'\\'} layout</span>
+              <span>·</span>
+              <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
+              <span>+e editor</span>
+              <span>·</span>
+              <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
+              <span>+g diff</span>
+              <span>·</span>
+              <kbd className="rounded bg-on-surface/10 px-1">{modKey}</kbd>
+              <span>+b back</span>
+            </span>
           </div>
-        ) : sessions.length === 0 ? (
-          <div className="flex h-full items-center justify-center font-mono text-on-surface/60">
-            <p>
-              No active session. Click + in the session tab bar above to create
-              one.
-            </p>
-          </div>
-        ) : (
-          // Render all sessions but hide inactive ones to keep PTY sessions alive.
-          sessions.map((session) => {
-            const isActive = session.id === activeSessionId
+        ) : null}
 
-            // SessionTabs.open keeps a tab for running/paused sessions OR
-            // the active session — completed/errored non-active sessions
-            // exist as panels here but have no corresponding tab id, so
-            // aria-labelledby would point at a non-existent element. Only
-            // wire the linkage when the panel actually has a visible tab
-            // (= isActive OR open status). Hidden panels stay aria-clean.
-            // Use the canonical `isOpenSessionStatus` predicate from the
-            // utility (same source as Sidebar's Active/Recent grouping)
-            // so a future non-open status (e.g. `suspended`) auto-flows
-            // into both visibility surfaces without TerminalZone needing
-            // a separate update.
-            const hasVisibleTab =
-              isActive || isOpenSessionStatus(session.status)
+        {/* Terminal content area — relative + absolute inner to give xterm explicit dimensions */}
+        <div
+          data-testid="terminal-content"
+          className="relative min-h-0 flex-1 bg-surface"
+        >
+          {loading ? (
+            <div className="flex h-full items-center justify-center font-mono text-on-surface/60">
+              <p>Restoring sessions...</p>
+            </div>
+          ) : sessions.length === 0 ? (
+            <div className="flex h-full items-center justify-center font-mono text-on-surface/60">
+              <p>
+                No active session. Click + in the session tab bar above to
+                create one.
+              </p>
+            </div>
+          ) : (
+            // Render all sessions but hide inactive ones to keep PTY sessions alive.
+            sessions.map((session) => {
+              const isActive = session.id === activeSessionId
 
-            return (
-              <div
-                key={session.id}
-                id={`session-panel-${session.id}`}
-                role="tabpanel"
-                aria-labelledby={
-                  hasVisibleTab ? `session-tab-${session.id}` : undefined
-                }
-                data-testid="terminal-pane"
-                data-session-id={session.id}
-                className={`absolute inset-0 ${isActive ? '' : 'hidden'}`}
-              >
-                <SplitView
-                  session={session}
-                  service={service}
-                  isActive={isActive}
-                  onSessionCwdChange={onSessionCwdChange}
-                  onPaneReady={onPaneReady}
-                  onSessionRestart={onSessionRestart}
-                  onSetActivePane={setSessionActivePane}
-                  onAddPane={addPane}
-                  onClosePane={removePane}
-                  deferTerminalFit={deferTerminalFit}
-                />
-              </div>
-            )
-          })
-        )}
+              // SessionTabs.open keeps a tab for running/paused sessions OR
+              // the active session — completed/errored non-active sessions
+              // exist as panels here but have no corresponding tab id, so
+              // aria-labelledby would point at a non-existent element. Only
+              // wire the linkage when the panel actually has a visible tab
+              // (= isActive OR open status). Hidden panels stay aria-clean.
+              // Use the canonical `isOpenSessionStatus` predicate from the
+              // utility (same source as Sidebar's Active/Recent grouping)
+              // so a future non-open status (e.g. `suspended`) auto-flows
+              // into both visibility surfaces without TerminalZone needing
+              // a separate update.
+              const hasVisibleTab =
+                isActive || isOpenSessionStatus(session.status)
+
+              return (
+                <div
+                  key={session.id}
+                  id={`session-panel-${session.id}`}
+                  role="tabpanel"
+                  aria-labelledby={
+                    hasVisibleTab ? `session-tab-${session.id}` : undefined
+                  }
+                  data-testid="terminal-pane"
+                  data-session-id={session.id}
+                  className={`absolute inset-0 ${isActive ? '' : 'hidden'}`}
+                >
+                  <SplitView
+                    ref={
+                      isActive
+                        ? (handle): void => {
+                            activeSplitViewRef.current = handle
+                          }
+                        : null
+                    }
+                    session={session}
+                    service={service}
+                    isActive={isActive}
+                    onSessionCwdChange={onSessionCwdChange}
+                    onPaneReady={onPaneReady}
+                    onSessionRestart={onSessionRestart}
+                    onSetActivePane={setSessionActivePane}
+                    onAddPane={addPane}
+                    onClosePane={removePane}
+                    deferTerminalFit={deferTerminalFit}
+                    showPaneFocusHighlight={isZoneFocused}
+                  />
+                </div>
+              )
+            })
+          )}
+        </div>
       </div>
-    </div>
-  )
-}
+    )
+  }
+)

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -119,8 +119,8 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
     }))
 
     const handlePointerDown = (event: PointerEvent<HTMLDivElement>): void => {
-      onContainerFocus?.()
-
+      // onContainerFocus is NOT called here — onFocus (bubbling) covers
+      // both pointer and keyboard Tab paths, avoiding a double invocation.
       const target =
         event.target instanceof Element ? event.target : event.currentTarget
 

--- a/src/features/workspace/containerIds.ts
+++ b/src/features/workspace/containerIds.ts
@@ -1,0 +1,5 @@
+export const TERMINAL_CONTAINER_ID = 'terminal' as const
+
+export const DOCK_CONTAINER_ID = 'dock' as const
+
+export type FocusTarget = 'terminal' | 'editor' | 'diff'

--- a/src/features/workspace/containerIds.ts
+++ b/src/features/workspace/containerIds.ts
@@ -3,3 +3,6 @@ export const TERMINAL_CONTAINER_ID = 'terminal' as const
 export const DOCK_CONTAINER_ID = 'dock' as const
 
 export type FocusTarget = 'terminal' | 'editor' | 'diff'
+
+export const DIALOG_SELECTOR =
+  '[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])'

--- a/src/features/workspace/hooks/useDockShortcuts.test.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.test.ts
@@ -237,6 +237,30 @@ describe('useDockShortcuts', () => {
     document.body.removeChild(cmEditor)
   })
 
+  test('Ctrl+b does not fire claimTerminal when CodeMirror has focus (vim scroll-back guard)', () => {
+    // vim normal mode: Ctrl+b scrolls one page backward — must not trigger claimTerminal.
+    // CodeMirror lives inside the dock section, so both activeContainerId and closest() checks
+    // would pass without the !inCodeMirror guard.
+    const props = makeProps({ activeContainerId: DOCK_CONTAINER_ID })
+
+    const cmEditor = document.createElement('div')
+    cmEditor.className = 'cm-editor'
+    const cmContent = document.createElement('div')
+    cmContent.setAttribute('contenteditable', 'true')
+    cmContent.className = 'cm-content'
+    cmEditor.appendChild(cmContent)
+    document.body.appendChild(cmEditor)
+    cmContent.focus()
+
+    renderHook(() => useDockShortcuts(props))
+    const event = fire('b', { ctrlKey: true })
+
+    expect(props.claimTerminal).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(cmEditor)
+  })
+
   test('Ctrl+g does not fire when CodeMirror has focus (vim print location guard)', () => {
     // CodeMirror vim: Ctrl+g prints file/line info — must not switch to diff.
     const props = makeProps()

--- a/src/features/workspace/hooks/useDockShortcuts.test.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.test.ts
@@ -1,0 +1,175 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { DOCK_CONTAINER_ID, TERMINAL_CONTAINER_ID } from '../containerIds'
+import { useDockShortcuts } from './useDockShortcuts'
+
+const fire = (
+  key: string,
+  modifiers: Partial<KeyboardEventInit> = {}
+): KeyboardEvent & { preventDefaultSpy: ReturnType<typeof vi.spyOn> } => {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    code: `Key${key.toUpperCase()}`,
+    bubbles: true,
+    cancelable: true,
+    ...modifiers,
+  })
+  const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+  document.dispatchEvent(event)
+
+  return Object.assign(event, { preventDefaultSpy })
+}
+
+const attachDockAndFocus = (): HTMLElement => {
+  const element = document.createElement('section')
+  element.setAttribute('data-container-id', DOCK_CONTAINER_ID)
+  element.setAttribute('tabindex', '-1')
+  document.body.appendChild(element)
+  element.focus()
+
+  return element
+}
+
+const removeElement = (element: HTMLElement): void => {
+  document.body.removeChild(element)
+}
+
+const blurActiveElement = (): void => {
+  const activeElement = document.activeElement as HTMLElement | null
+  activeElement?.blur?.()
+}
+
+describe('useDockShortcuts', () => {
+  const makeProps = (
+    overrides: Partial<Parameters<typeof useDockShortcuts>[0]> = {}
+  ): Parameters<typeof useDockShortcuts>[0] => ({
+    activeContainerId: DOCK_CONTAINER_ID,
+    openDock: vi.fn(),
+    claimTerminal: vi.fn(),
+    modKey: 'Ctrl',
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('Ctrl+e calls openDock("editor") and prevents default', () => {
+    const props = makeProps()
+    const dockElement = attachDockAndFocus()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('e', { ctrlKey: true })
+
+    expect(props.openDock).toHaveBeenCalledWith('editor')
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    removeElement(dockElement)
+  })
+
+  test('Ctrl+g calls openDock("diff") and prevents default', () => {
+    const props = makeProps()
+    const dockElement = attachDockAndFocus()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('g', { ctrlKey: true })
+
+    expect(props.openDock).toHaveBeenCalledWith('diff')
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    removeElement(dockElement)
+  })
+
+  test('Ctrl+b when dock active and activeElement in dock calls claimTerminal', () => {
+    const props = makeProps({ activeContainerId: DOCK_CONTAINER_ID })
+    const dockElement = attachDockAndFocus()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('b', { ctrlKey: true })
+
+    expect(props.claimTerminal).toHaveBeenCalledOnce()
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    removeElement(dockElement)
+  })
+
+  test('Ctrl+b when dock active but activeElement outside dock is a no-op', () => {
+    const props = makeProps({ activeContainerId: DOCK_CONTAINER_ID })
+    blurActiveElement()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('b', { ctrlKey: true })
+
+    expect(props.claimTerminal).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('Ctrl+b when terminal active passes through', () => {
+    const props = makeProps({ activeContainerId: TERMINAL_CONTAINER_ID })
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('b', { ctrlKey: true })
+
+    expect(props.claimTerminal).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('no modifier is a no-op', () => {
+    const props = makeProps()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('e')
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('Shift+Ctrl+e is a no-op', () => {
+    const props = makeProps()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('e', { ctrlKey: true, shiftKey: true })
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('Ctrl+e from within a dialog is a no-op', () => {
+    const props = makeProps()
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    const inner = document.createElement('button')
+    dialog.appendChild(inner)
+    document.body.appendChild(dialog)
+    inner.focus()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('e', { ctrlKey: true })
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(dialog)
+  })
+
+  test('macOS modifier mode accepts Cmd+e and ignores Ctrl+e', () => {
+    const props = makeProps({ modKey: '⌘' })
+    renderHook(() => useDockShortcuts(props))
+
+    fire('e', { ctrlKey: true })
+    expect(props.openDock).not.toHaveBeenCalled()
+
+    fire('e', { metaKey: true })
+    expect(props.openDock).toHaveBeenCalledWith('editor')
+  })
+
+  test('unmount removes listener', () => {
+    const props = makeProps()
+    const { unmount } = renderHook(() => useDockShortcuts(props))
+
+    unmount()
+    fire('e', { ctrlKey: true })
+
+    expect(props.openDock).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/workspace/hooks/useDockShortcuts.test.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.test.ts
@@ -214,4 +214,48 @@ describe('useDockShortcuts', () => {
 
     document.body.removeChild(terminalZone)
   })
+
+  test('Ctrl+e does not fire when CodeMirror has focus (vim scroll guard)', () => {
+    // CodeMirror vim: Ctrl+e scrolls viewport down — must not be stolen.
+    const props = makeProps()
+
+    const cmEditor = document.createElement('div')
+    cmEditor.className = 'cm-editor'
+    const cmContent = document.createElement('div')
+    cmContent.setAttribute('contenteditable', 'true')
+    cmContent.className = 'cm-content'
+    cmEditor.appendChild(cmContent)
+    document.body.appendChild(cmEditor)
+    cmContent.focus()
+
+    renderHook(() => useDockShortcuts(props))
+    const event = fire('e', { ctrlKey: true })
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(cmEditor)
+  })
+
+  test('Ctrl+g does not fire when CodeMirror has focus (vim print location guard)', () => {
+    // CodeMirror vim: Ctrl+g prints file/line info — must not switch to diff.
+    const props = makeProps()
+
+    const cmEditor = document.createElement('div')
+    cmEditor.className = 'cm-editor'
+    const cmContent = document.createElement('div')
+    cmContent.setAttribute('contenteditable', 'true')
+    cmContent.className = 'cm-content'
+    cmEditor.appendChild(cmContent)
+    document.body.appendChild(cmEditor)
+    cmContent.focus()
+
+    renderHook(() => useDockShortcuts(props))
+    const event = fire('g', { ctrlKey: true })
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(cmEditor)
+  })
 })

--- a/src/features/workspace/hooks/useDockShortcuts.test.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.test.ts
@@ -172,4 +172,46 @@ describe('useDockShortcuts', () => {
 
     expect(props.openDock).not.toHaveBeenCalled()
   })
+
+  test('Ctrl+e does not fire when focus is inside terminal zone (xterm readline guard)', () => {
+    // xterm uses a hidden textarea for PTY input; Ctrl+e is readline "end-of-line".
+    // The hook must pass through when the event originates from the terminal zone.
+    const props = makeProps()
+
+    const terminalZone = document.createElement('div')
+    terminalZone.setAttribute('data-container-id', TERMINAL_CONTAINER_ID)
+    const xtermTextarea = document.createElement('textarea')
+    xtermTextarea.className = 'xterm-helper-textarea'
+    terminalZone.appendChild(xtermTextarea)
+    document.body.appendChild(terminalZone)
+    xtermTextarea.focus()
+
+    renderHook(() => useDockShortcuts(props))
+    const event = fire('e', { ctrlKey: true })
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(terminalZone)
+  })
+
+  test('Ctrl+g does not fire when focus is inside terminal zone (xterm abort guard)', () => {
+    const props = makeProps()
+
+    const terminalZone = document.createElement('div')
+    terminalZone.setAttribute('data-container-id', TERMINAL_CONTAINER_ID)
+    const xtermTextarea = document.createElement('textarea')
+    xtermTextarea.className = 'xterm-helper-textarea'
+    terminalZone.appendChild(xtermTextarea)
+    document.body.appendChild(terminalZone)
+    xtermTextarea.focus()
+
+    renderHook(() => useDockShortcuts(props))
+    const event = fire('g', { ctrlKey: true })
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(terminalZone)
+  })
 })

--- a/src/features/workspace/hooks/useDockShortcuts.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.ts
@@ -72,10 +72,10 @@ export const useDockShortcuts = ({
 
       const key = event.key.toLowerCase()
 
-      // Ctrl+e / Ctrl+g: do not steal readline shortcuts when xterm has focus.
-      // Ctrl+b is exempt — it only fires when dock is active (checked below),
-      // so it can never originate from xterm.
-      if ((key === 'e' || key === 'g') && inTerminalZone) {
+      // Ctrl+e / Ctrl+g: do not steal vim/readline shortcuts when xterm or
+      // CodeMirror has focus. Ctrl+b is exempt — it only fires when dock is
+      // active (checked below), so it can never originate from either surface.
+      if ((key === 'e' || key === 'g') && (inTerminalZone || inCodeMirror)) {
         return
       }
 

--- a/src/features/workspace/hooks/useDockShortcuts.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.ts
@@ -1,0 +1,114 @@
+import { useEffect, useRef } from 'react'
+import {
+  DOCK_CONTAINER_ID,
+  TERMINAL_CONTAINER_ID,
+  type FocusTarget,
+} from '../containerIds'
+
+type DockFocusTarget = Extract<FocusTarget, 'editor' | 'diff'>
+
+export interface UseDockShortcutsParams {
+  activeContainerId: string
+  openDock: (tab: DockFocusTarget) => void
+  claimTerminal: () => void
+  modKey: '⌘' | 'Ctrl'
+}
+
+const DIALOG_SELECTOR =
+  '[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])'
+
+export const useDockShortcuts = ({
+  activeContainerId,
+  openDock,
+  claimTerminal,
+  modKey,
+}: UseDockShortcutsParams): void => {
+  const activeContainerIdRef = useRef(activeContainerId)
+  const openDockRef = useRef(openDock)
+  const claimTerminalRef = useRef(claimTerminal)
+  const modKeyRef = useRef(modKey)
+
+  activeContainerIdRef.current = activeContainerId
+  openDockRef.current = openDock
+  claimTerminalRef.current = claimTerminal
+  modKeyRef.current = modKey
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      const expectedModifier =
+        modKeyRef.current === '⌘'
+          ? event.metaKey && !event.ctrlKey
+          : event.ctrlKey && !event.metaKey
+
+      if (!expectedModifier || event.shiftKey || event.altKey) {
+        return
+      }
+
+      if (document.querySelector(DIALOG_SELECTOR)) {
+        return
+      }
+
+      const target =
+        event.target instanceof Element
+          ? event.target
+          : document.activeElement instanceof Element
+            ? document.activeElement
+            : document.body
+
+      const inTerminalZone = !!target.closest(
+        `[data-container-id="${TERMINAL_CONTAINER_ID}"]`
+      )
+      const inCodeMirror = !!target.closest('.cm-editor')
+
+      const isTextEntry =
+        !!target.closest('input, textarea') ||
+        (!inCodeMirror &&
+          !!(
+            target.closest('[contenteditable]') ??
+            target.closest('[role="textbox"]')
+          ))
+
+      if (isTextEntry && !inTerminalZone) {
+        return
+      }
+
+      const key = event.key.toLowerCase()
+
+      if (key === 'e') {
+        event.preventDefault()
+        event.stopPropagation()
+        openDockRef.current('editor')
+
+        return
+      }
+
+      if (key === 'g') {
+        event.preventDefault()
+        event.stopPropagation()
+        openDockRef.current('diff')
+
+        return
+      }
+
+      if (key === 'b') {
+        const activeElement = document.activeElement
+        if (
+          activeContainerIdRef.current === DOCK_CONTAINER_ID &&
+          activeElement?.closest(`[data-container-id="${DOCK_CONTAINER_ID}"]`)
+        ) {
+          event.preventDefault()
+          event.stopPropagation()
+          claimTerminalRef.current()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, { capture: true })
+
+    return (): void => {
+      document.removeEventListener('keydown', handleKeyDown, {
+        capture: true,
+      })
+    }
+  }, [])
+}

--- a/src/features/workspace/hooks/useDockShortcuts.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.ts
@@ -98,6 +98,7 @@ export const useDockShortcuts = ({
       if (key === 'b') {
         const activeElement = document.activeElement
         if (
+          !inCodeMirror &&
           activeContainerIdRef.current === DOCK_CONTAINER_ID &&
           activeElement?.closest(`[data-container-id="${DOCK_CONTAINER_ID}"]`)
         ) {

--- a/src/features/workspace/hooks/useDockShortcuts.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import {
+  DIALOG_SELECTOR,
   DOCK_CONTAINER_ID,
   TERMINAL_CONTAINER_ID,
   type FocusTarget,
@@ -13,9 +14,6 @@ export interface UseDockShortcutsParams {
   claimTerminal: () => void
   modKey: '⌘' | 'Ctrl'
 }
-
-const DIALOG_SELECTOR =
-  '[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])'
 
 export const useDockShortcuts = ({
   activeContainerId,
@@ -73,6 +71,13 @@ export const useDockShortcuts = ({
       }
 
       const key = event.key.toLowerCase()
+
+      // Ctrl+e / Ctrl+g: do not steal readline shortcuts when xterm has focus.
+      // Ctrl+b is exempt — it only fires when dock is active (checked below),
+      // so it can never originate from xterm.
+      if ((key === 'e' || key === 'g') && inTerminalZone) {
+        return
+      }
 
       if (key === 'e') {
         event.preventDefault()


### PR DESCRIPTION
## Summary

- Add workspace-level `activeContainerId` state to `WorkspaceView` so `DockPanel` (editor + diff) and `TerminalZone` share the same border-highlight and keyboard-focus routing logic
- `DockPanel`: `isFocused` prop drives mauve border (`#cba6f7`) + inset box-shadow; `forwardRef` with `focusEditor()`/`focusDiff()` imperative handles
- `TerminalZone`: `isZoneFocused` prop drives `opacity-65` dim; `forwardRef` with `focusActivePane()` delegating `SplitView → TerminalPane → Body`
- `SplitView` / `TerminalPane`: `forwardRef` imperative handles for programmatic focus
- `CodeEditor`: `shouldAutoFocus` prop gates CodeMirror auto-focus; `forwardRef` with `focus(): boolean`
- `useDockShortcuts`: new capture-phase hook for `Ctrl+e` (editor), `Ctrl+g` (diff), `Ctrl+b` (return to terminal) with dialog + input guards
- `usePaneShortcuts`: new `onTerminalZoneFocus` + `isTerminalContainerActive` params; `Ctrl+1-4` reclaims terminal when dock is active (double-guarded)
- `WorkspaceView`: `requestFocus()`/`focusRequestSeq`/`useLayoutEffect` focus queue; `openDock()`/`claimTerminal()`/`closeDock()` helpers; session-intent wrappers so all session changes (create, switch, close) claim terminal focus

## Test plan

- [ ] Terminal zone lit by default; click dock → dock border turns mauve, terminal dims to 65% opacity
- [ ] Click terminal zone → terminal highlighted again, dock border neutral
- [ ] `Ctrl+e` → dock opens (if closed), editor tab active, dock lit
- [ ] `Ctrl+g` → diff tab active, dock lit
- [ ] `Ctrl+b` from dock → terminal regains focus; `Ctrl+b` from terminal → passes through to xterm (no zone change)
- [ ] `Ctrl+1` from dock (single-pane) → terminal zone regains focus
- [ ] Close dock (`×` button) → terminal zone regains focus automatically
- [ ] Open file from sidebar while terminal active → file loads in editor without stealing terminal focus
- [ ] Click a session tab / create session / close session → terminal zone becomes active