### PR TITLE
feat(resize): full dock elastic resize — useElasticContainer + horizontal handle

### DIFF
--- a/docs/superpowers/plans/2026-05-17-dock-elastic-resize-plan.md
+++ b/docs/superpowers/plans/2026-05-17-dock-elastic-resize-plan.md
@@ -1,0 +1,1615 @@
+# Dock Elastic Resize Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add full drag-resize to all four DockPanel positions (vertical already partially done, horizontal missing) via a shared `useElasticContainer` hook with percent-based, live-updating bounds.
+
+**Architecture:** A new `useElasticContainer` hook wraps the existing `useResizable` primitive, adding `ResizeObserver`-driven percent→pixel bound conversion and post-drag re-clamping. Two instances live in `WorkspaceView` (one per axis); `DockPanel` gains horizontal resize props and a new inner-edge handle. All bounds constants move to `panelConfig.ts`.
+
+**Tech Stack:** React 19, TypeScript (ESM), Vitest + Testing Library, Tailwind CSS, `ResizeObserver` (browser API).
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| CREATE | `src/features/workspace/panelConfig.ts` | All size-tuning constants |
+| MODIFY | `src/hooks/useResizable.ts` | Add `resetToSize` + expose `sizeRef` |
+| MODIFY | `src/hooks/useResizable.test.ts` | Tests for new methods |
+| CREATE | `src/hooks/useElasticContainer.ts` | Percent-bound resize hook |
+| CREATE | `src/hooks/useElasticContainer.test.ts` | Hook unit tests |
+| MODIFY | `src/features/workspace/components/DockPanel.tsx` | New props + horizontal handle |
+| MODIFY | `src/features/workspace/components/DockPanel.test.tsx` | Tests for horizontal handle |
+| MODIFY | `src/features/workspace/WorkspaceView.tsx` | Wire elastic containers |
+| MODIFY | `src/features/workspace/WorkspaceView.test.tsx` | Add useElasticContainer mock |
+| MODIFY | `src/features/workspace/WorkspaceView.integration.test.tsx` | Add useElasticContainer mock |
+| MODIFY | `src/features/workspace/WorkspaceView.command-palette.test.tsx` | Add useElasticContainer mock |
+| MODIFY | `src/features/workspace/WorkspaceView.notifyInfo.test.tsx` | Add useElasticContainer mock |
+| MODIFY | `src/features/workspace/WorkspaceView.subscription.test.tsx` | Add useElasticContainer mock |
+| MODIFY | `src/features/workspace/WorkspaceView.verification.test.tsx` | Add useElasticContainer mock |
+| MODIFY | `src/features/workspace/WorkspaceView.visual.test.tsx` | Add useElasticContainer mock |
+| CREATE | `src/features/workspace/WorkspaceView.elastic.test.tsx` | Issue #217 persistence proof |
+
+---
+
+## Task 1: Create `panelConfig.ts`
+
+**Files:**
+- Create: `src/features/workspace/panelConfig.ts`
+
+- [ ] **Step 1: Write the file**
+
+```typescript
+/**
+ * Dock panel elastic config — used by WorkspaceView's two useElasticContainer
+ * instances (one for vertical dock size, one for horizontal dock size).
+ */
+export const DOCK_ELASTIC_CONFIG = {
+  minPercent: 0.05,
+  maxPercent: 0.8,
+  initialPercent: 0.3,
+} as const
+
+/**
+ * Terminal zone outer elastic config — reserved for future useElasticContainer
+ * wiring of the whole terminal zone.
+ */
+export const TERMINAL_ZONE_ELASTIC_CONFIG = {
+  minPercent: 0.1,
+  maxPercent: 0.9,
+  initialPercent: 0.5,
+} as const
+
+/**
+ * Per-pane elastic config descriptor for TerminalZone's 1–4 pane splits.
+ * Intentionally omits `containerRef` and `axis` — those are call-site concerns.
+ * NOT directly spreadable into UseElasticContainerOptions.
+ * Out of scope for this PR — defined here to avoid a future breaking change.
+ */
+export interface PaneElasticConfig {
+  minPercent: number
+  maxPercent: number
+  /** undefined = compute as 1/paneCount at runtime. */
+  initialPercent: number | undefined
+}
+
+export const TERMINAL_PANE_ELASTIC_CONFIGS: PaneElasticConfig[] = [
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+]
+
+/** Keyboard resize step sizes (pixels), shared by all panels. */
+export const KEYBOARD_STEP_PX = 20
+export const KEYBOARD_STEP_SHIFT_PX = 100
+```
+
+- [ ] **Step 2: Verify type-check passes**
+
+```bash
+npx tsc -b --noEmit 2>&1 | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/workspace/panelConfig.ts
+git commit -m "feat(resize): add panelConfig.ts — single tuning surface for all panel bounds"
+```
+
+---
+
+## Task 2: Extend `useResizable` with `resetToSize` and `sizeRef`
+
+**Files:**
+- Modify: `src/hooks/useResizable.ts`
+- Modify: `src/hooks/useResizable.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `src/hooks/useResizable.test.ts` (inside the `describe('useResizable', ...)` block, before its closing `}`):
+
+```typescript
+  describe('resetToSize', () => {
+    test('sets size to clamped value', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.resetToSize(300)
+      })
+
+      expect(result.current.size).toBe(300)
+    })
+
+    test('clamps to min when value is below min', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.resetToSize(50)
+      })
+
+      expect(result.current.size).toBe(100)
+    })
+
+    test('clamps to max when value is above max', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.resetToSize(600)
+      })
+
+      expect(result.current.size).toBe(500)
+    })
+
+    test('uses explicit bounds when provided, bypassing closure min/max', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.resetToSize(800, 50, 900)
+      })
+
+      expect(result.current.size).toBe(800)
+    })
+
+    test('updates previewSize so adjustBy baseline is fresh after reset', async () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500, updateMode: 'commit-on-end' })
+      )
+
+      act(() => {
+        result.current.resetToSize(400)
+      })
+
+      act(() => {
+        result.current.adjustBy(0)
+      })
+
+      await waitFor(() => {
+        expect(result.current.size).toBe(400)
+      })
+    })
+  })
+
+  describe('sizeRef', () => {
+    test('sizeRef.current matches size on initial render', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      expect(result.current.sizeRef.current).toBe(256)
+    })
+
+    test('sizeRef.current updates synchronously after resetToSize', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.resetToSize(350)
+      })
+
+      expect(result.current.sizeRef.current).toBe(350)
+    })
+  })
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npx vitest run src/hooks/useResizable.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL — `result.current.resetToSize is not a function`.
+
+- [ ] **Step 3: Implement `resetToSize` and expose `sizeRef` in `useResizable.ts`**
+
+In `src/hooks/useResizable.ts`, update `UseResizableResult`:
+
+```typescript
+export interface UseResizableResult {
+  size: number
+  isDragging: boolean
+  handleMouseDown: (e: React.MouseEvent) => void
+  adjustBy: (delta: number) => void
+  /**
+   * Set size to an absolute pixel value, clamped to [min, max].
+   * Pass explicitMin/explicitMax to bypass stale closure bounds
+   * (required when called from a ResizeObserver callback alongside
+   * a state update that hasn't re-rendered yet).
+   */
+  resetToSize: (px: number, explicitMin?: number, explicitMax?: number) => void
+  /** Synchronous read of the last committed size; safe to read in callbacks. */
+  sizeRef: React.MutableRefObject<number>
+}
+```
+
+Add `MutableRefObject` to the React import at top of file:
+
+```typescript
+import {
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  type MutableRefObject,
+} from 'react'
+```
+
+Add `resetToSize` callback inside `useResizable` (after the `adjustBy` definition):
+
+```typescript
+  const resetToSize = useCallback(
+    (px: number, explicitMin?: number, explicitMax?: number): void => {
+      const clampMin = explicitMin ?? min
+      const clampMax = explicitMax ?? max
+      cancelPendingSize()
+      const nextSize = clampSize(px, clampMin, clampMax)
+      commitSize(nextSize)
+      // Unconditionally sync previewSize so adjustBy baseline is fresh
+      // even in commit-on-end mode (where commitSize doesn't update previewSize).
+      previewSize.current = nextSize
+      if (isDraggingRef.current) {
+        startPos.current = currentPos.current
+        startSize.current = nextSize
+      }
+    },
+    [min, max, cancelPendingSize, commitSize]
+  )
+```
+
+Update the return statement:
+
+```typescript
+  return { size, isDragging, handleMouseDown, adjustBy, resetToSize, sizeRef }
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+npx vitest run src/hooks/useResizable.test.ts 2>&1 | tail -10
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useResizable.ts src/hooks/useResizable.test.ts
+git commit -m "feat(resize): add resetToSize + expose sizeRef on useResizable"
+```
+
+---
+
+## Task 3: Create `useElasticContainer`
+
+**Files:**
+- Create: `src/hooks/useElasticContainer.ts`
+- Create: `src/hooks/useElasticContainer.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `src/hooks/useElasticContainer.test.ts`:
+
+```typescript
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useRef } from 'react'
+import { useElasticContainer } from './useElasticContainer'
+
+// Stub ResizeObserver globally — jsdom doesn't implement it.
+let observerCallback: ResizeObserverCallback | null = null
+const mockObserve = vi.fn()
+const mockDisconnect = vi.fn()
+const mockUnobserve = vi.fn()
+
+class MockResizeObserver {
+  constructor(cb: ResizeObserverCallback) {
+    observerCallback = cb
+  }
+  observe = mockObserve
+  disconnect = mockDisconnect
+  unobserve = mockUnobserve
+}
+
+vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+// Return realistic dimensions so the hook does not throw on null ref.
+const CONTAINER_WIDTH = 1200
+const CONTAINER_HEIGHT = 800
+
+beforeEach(() => {
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: CONTAINER_WIDTH,
+    height: CONTAINER_HEIGHT,
+    top: 0,
+    left: 0,
+    right: CONTAINER_WIDTH,
+    bottom: CONTAINER_HEIGHT,
+    x: 0,
+    y: 0,
+    toJSON: () => undefined,
+  } as DOMRect)
+  observerCallback = null
+  mockObserve.mockClear()
+  mockDisconnect.mockClear()
+  mockUnobserve.mockClear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const renderElastic = (
+  overrides: Partial<{
+    axis: 'horizontal' | 'vertical'
+    minPercent: number
+    maxPercent: number
+    initialPercent: number
+  }> = {}
+) => {
+  const containerEl = document.createElement('div')
+  return renderHook(() => {
+    const containerRef = useRef<HTMLDivElement>(containerEl)
+    return useElasticContainer({
+      containerRef,
+      axis: 'horizontal',
+      minPercent: 0.05,
+      maxPercent: 0.8,
+      initialPercent: 0.3,
+      ...overrides,
+    })
+  })
+}
+
+describe('useElasticContainer', () => {
+  test('initializes size from initialPercent × container dimension', () => {
+    // 0.3 × 1200 = 360
+    const { result } = renderElastic({ axis: 'horizontal', initialPercent: 0.3 })
+    expect(result.current.size).toBe(360)
+  })
+
+  test('initializes pixelMin and pixelMax from percent config', () => {
+    // minPercent 0.05 × 1200 → ceil(60) = 60
+    // maxPercent 0.80 × 1200 → floor(960) = 960
+    const { result } = renderElastic({ axis: 'horizontal', minPercent: 0.05, maxPercent: 0.8 })
+    expect(result.current.pixelMin).toBe(60)
+    expect(result.current.pixelMax).toBe(960)
+  })
+
+  test('uses vertical dimension when axis is vertical', () => {
+    // 0.3 × 800 = 240
+    const { result } = renderElastic({ axis: 'vertical', initialPercent: 0.3 })
+    expect(result.current.size).toBe(240)
+  })
+
+  test('defaults initialPercent to midpoint when not provided', () => {
+    // midpoint = (0.05 + 0.80) / 2 = 0.425; 0.425 × 1200 = 510
+    const { result } = renderElastic({ axis: 'horizontal', minPercent: 0.05, maxPercent: 0.8, initialPercent: undefined as unknown as number })
+    expect(result.current.size).toBe(510)
+  })
+
+  test('throws when containerRef.current is null', () => {
+    expect(() => {
+      renderHook(() => {
+        const containerRef = useRef<HTMLDivElement>(null)
+        return useElasticContainer({
+          containerRef,
+          axis: 'horizontal',
+          minPercent: 0.05,
+          maxPercent: 0.8,
+        })
+      })
+    }).toThrow()
+  })
+
+  test('throws when minPercent >= maxPercent in dev', () => {
+    expect(() => {
+      renderElastic({ minPercent: 0.8, maxPercent: 0.05 })
+    }).toThrow()
+  })
+
+  test('ResizeObserver re-clamp updates pixelMin/pixelMax on container resize', () => {
+    const { result } = renderElastic({ axis: 'horizontal', minPercent: 0.05, maxPercent: 0.8 })
+
+    // Simulate container resize to 800px wide
+    act(() => {
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+        width: 800,
+        height: CONTAINER_HEIGHT,
+        top: 0, left: 0, right: 800, bottom: CONTAINER_HEIGHT,
+        x: 0, y: 0, toJSON: () => undefined,
+      } as DOMRect)
+      observerCallback?.(
+        [{ contentRect: { width: 800, height: CONTAINER_HEIGHT } } as ResizeObserverEntry],
+        {} as ResizeObserver
+      )
+    })
+
+    // ceil(800 * 0.05) = 40, floor(800 * 0.80) = 640
+    expect(result.current.pixelMin).toBe(40)
+    expect(result.current.pixelMax).toBe(640)
+  })
+
+  test('ResizeObserver clamps size when container shrinks below current size', () => {
+    const { result } = renderElastic({ axis: 'horizontal', minPercent: 0.05, maxPercent: 0.8, initialPercent: 0.7 })
+    // Initial: 0.7 × 1200 = 840px
+
+    act(() => {
+      observerCallback?.(
+        [{ contentRect: { width: 400, height: CONTAINER_HEIGHT } } as ResizeObserverEntry],
+        {} as ResizeObserver
+      )
+    })
+
+    // max = floor(400 * 0.8) = 320; size must be ≤ 320
+    expect(result.current.size).toBeLessThanOrEqual(320)
+  })
+
+  test('disconnects ResizeObserver on unmount', () => {
+    const { unmount } = renderElastic()
+    unmount()
+    expect(mockDisconnect).toHaveBeenCalled()
+  })
+
+  test('returns handleMouseDown, adjustBy, isDragging, sizeRef', () => {
+    const { result } = renderElastic()
+    expect(typeof result.current.handleMouseDown).toBe('function')
+    expect(typeof result.current.adjustBy).toBe('function')
+    expect(typeof result.current.isDragging).toBe('boolean')
+    expect(typeof result.current.sizeRef.current).toBe('number')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npx vitest run src/hooks/useElasticContainer.test.ts 2>&1 | tail -10
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `useElasticContainer.ts`**
+
+Create `src/hooks/useElasticContainer.ts`:
+
+```typescript
+import {
+  useState,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  type RefObject,
+  type MutableRefObject,
+} from 'react'
+import { useResizable, clampSize, type UseResizableResult } from './useResizable'
+
+export interface UseElasticContainerOptions {
+  /**
+   * Ref to the parent available-area element (NOT the resizable panel itself).
+   * Pre-condition: must be non-null when the first useLayoutEffect fires.
+   * Mount-time constant — the ResizeObserver is attached once and never reconnected.
+   */
+  containerRef: RefObject<Element | null>
+  /**
+   * Which dimension to observe. Maps to useResizable direction.
+   * Mount-time constant — changing after mount results in undefined behavior.
+   */
+  axis: 'horizontal' | 'vertical'
+  /** Fraction of available dimension for minimum size. 0 < min < max ≤ 1. Mount-time constant. */
+  minPercent: number
+  /** Fraction of available dimension for maximum size. Mount-time constant. */
+  maxPercent: number
+  /** Initial size as fraction of dimension. Defaults to (min+max)/2. Mount-time constant. */
+  initialPercent?: number
+  invert?: boolean
+  updateMode?: 'live' | 'commit-on-end'
+  onDragPreview?: (size: number) => void
+}
+
+export interface UseElasticContainerResult extends UseResizableResult {
+  pixelMin: number
+  pixelMax: number
+}
+
+export const useElasticContainer = ({
+  containerRef,
+  axis,
+  minPercent,
+  maxPercent,
+  initialPercent,
+  invert = false,
+  updateMode = 'live',
+  onDragPreview = undefined,
+}: UseElasticContainerOptions): UseElasticContainerResult => {
+  // Snapshot mount-time percent options into refs so the init effect
+  // always reads the original values even if props change.
+  const minPercentRef = useRef(minPercent)
+  const maxPercentRef = useRef(maxPercent)
+  const initialPercentRef = useRef(initialPercent)
+
+  const [pixelMin, setPixelMin] = useState(0)
+  const [pixelMax, setPixelMax] = useState(Number.MAX_SAFE_INTEGER)
+
+  // Internal refs for synchronous reads in callbacks.
+  const pixelMinRef = useRef(0)
+  const pixelMaxRef = useRef(Number.MAX_SAFE_INTEGER)
+  const pendingReclampRef = useRef(false)
+
+  const resizable = useResizable({
+    initial: 0,
+    min: pixelMin,
+    max: pixelMax,
+    direction: axis,
+    invert,
+    updateMode,
+    onDragPreview,
+  })
+
+  const { resetToSize, sizeRef, isDragging } = resizable
+
+  // Keep isDraggingRef in sync for synchronous reads in ResizeObserver callbacks.
+  const isDraggingRef = useRef(false)
+  useLayoutEffect(() => {
+    isDraggingRef.current = isDragging
+  }, [isDragging])
+
+  // Post-drag re-clamp: if a ResizeObserver fired during drag, apply the
+  // deferred clamp now that the drag has ended.
+  useEffect(() => {
+    if (isDragging || !pendingReclampRef.current) {
+      return
+    }
+    pendingReclampRef.current = false
+    resetToSize(sizeRef.current, pixelMinRef.current, pixelMaxRef.current)
+  }, [isDragging, resetToSize, sizeRef])
+
+  const computeBounds = useCallback(
+    (dimension: number): { newMin: number; newMax: number } => {
+      const mn = minPercentRef.current
+      const mx = maxPercentRef.current
+
+      if (mn <= 0 || mx > 1 || mn >= mx) {
+        if (import.meta.env.DEV) {
+          throw new Error(
+            `useElasticContainer: invalid percent bounds minPercent=${mn} maxPercent=${mx}`
+          )
+        }
+      }
+
+      let newMin = Math.ceil(dimension * mn)
+      let newMax = Math.floor(dimension * mx)
+
+      if (newMin >= newMax) {
+        if (import.meta.env.DEV) {
+          throw new Error(
+            `useElasticContainer: degenerate container — pixelMin(${newMin}) >= pixelMax(${newMax})`
+          )
+        }
+        newMax = newMin
+      }
+
+      return { newMin, newMax }
+    },
+    []
+  )
+
+  // Mount-only initialization.
+  useLayoutEffect(() => {
+    const el = containerRef.current
+    if (!el) {
+      throw new Error('useElasticContainer: containerRef.current is null at mount')
+    }
+
+    const rect = el.getBoundingClientRect()
+    const dimension = axis === 'horizontal' ? rect.width : rect.height
+    const { newMin, newMax } = computeBounds(dimension)
+
+    const effectiveInitial =
+      initialPercentRef.current ?? (minPercentRef.current + maxPercentRef.current) / 2
+    const newInitial = clampSize(dimension * effectiveInitial, newMin, newMax)
+
+    pixelMinRef.current = newMin
+    pixelMaxRef.current = newMax
+    setPixelMin(newMin)
+    setPixelMax(newMax)
+    resetToSize(newInitial, newMin, newMax)
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const dim =
+        axis === 'horizontal' ? entry.contentRect.width : entry.contentRect.height
+
+      const { newMin: rMin, newMax: rMax } = computeBounds(dim)
+
+      pixelMinRef.current = rMin
+      pixelMaxRef.current = rMax
+      setPixelMin(rMin)
+      setPixelMax(rMax)
+
+      if (isDraggingRef.current) {
+        pendingReclampRef.current = true
+        return
+      }
+      resetToSize(sizeRef.current, rMin, rMax)
+    })
+
+    observer.observe(el)
+
+    return (): void => {
+      observer.disconnect()
+    }
+    // Empty deps: axis, percent refs, and containerRef are all mount-time constants.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return {
+    ...resizable,
+    pixelMin,
+    pixelMax,
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+npx vitest run src/hooks/useElasticContainer.test.ts 2>&1 | tail -15
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Run full type-check**
+
+```bash
+npx tsc -b --noEmit 2>&1 | head -30
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hooks/useElasticContainer.ts src/hooks/useElasticContainer.test.ts
+git commit -m "feat(resize): add useElasticContainer — percent-bound ResizeObserver hook"
+```
+
+---
+
+## Task 4: Update `DockPanel` — new props + horizontal resize handle
+
+**Files:**
+- Modify: `src/features/workspace/components/DockPanel.tsx`
+- Modify: `src/features/workspace/components/DockPanel.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `src/features/workspace/components/DockPanel.test.tsx`.
+
+First update `renderDockPanel` to include new required props. Find the `props` object inside `renderDockPanel` and extend it:
+
+```typescript
+const renderDockPanel = (
+  overrides: Partial<DockPanelTestProps> = {}
+): ReturnType<typeof render> => {
+  const props: DockPanelTestProps = {
+    position: 'bottom',
+    tab: 'editor',
+    onTabChange: vi.fn(),
+    onPositionChange: vi.fn(),
+    onClose: vi.fn(),
+    verticalSize: 400,
+    onVerticalResizeMouseDown: vi.fn(),
+    isVerticalResizing: false,
+    onVerticalSizeAdjust: vi.fn(),
+    verticalPixelMin: 40,
+    verticalPixelMax: 640,
+    horizontalSize: 360,
+    onHorizontalResizeMouseDown: vi.fn(),
+    isHorizontalResizing: false,
+    onHorizontalSizeAdjust: vi.fn(),
+    horizontalPixelMin: 40,
+    horizontalPixelMax: 640,
+    selectedFilePath: null,
+    content: '',
+    ...overrides,
+  } as DockPanelTestProps
+
+  return render(<DockPanel {...props} />)
+}
+```
+
+Then add these new tests (append inside the `describe('DockPanel', ...)` block):
+
+```typescript
+  test('renders horizontal resize handle for left dock', () => {
+    renderDockPanel({ position: 'left' })
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toBeInTheDocument()
+    expect(handle).toHaveAttribute('aria-orientation', 'vertical')
+  })
+
+  test('renders horizontal resize handle for right dock', () => {
+    renderDockPanel({ position: 'right' })
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toBeInTheDocument()
+    expect(handle).toHaveAttribute('aria-orientation', 'vertical')
+  })
+
+  test('horizontal resize handle is on right edge for left dock', () => {
+    renderDockPanel({ position: 'left' })
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle.className).toMatch(/right-0/)
+  })
+
+  test('horizontal resize handle is on left edge for right dock', () => {
+    renderDockPanel({ position: 'right' })
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle.className).toMatch(/left-0/)
+  })
+
+  test('side dock uses controlled width from horizontalSize prop', () => {
+    renderDockPanel({ position: 'left', horizontalSize: 480 })
+    expect(screen.getByTestId('dock-panel')).toHaveStyle({ width: '480px' })
+  })
+
+  test('side dock does not use flex basis', () => {
+    renderDockPanel({ position: 'right', horizontalSize: 360 })
+    const panel = screen.getByTestId('dock-panel')
+    expect(panel).not.toHaveStyle({ flex: '0 0 40%' })
+  })
+
+  test('horizontal handle mousedown calls onHorizontalResizeMouseDown', () => {
+    const onHorizontalResizeMouseDown = vi.fn()
+    renderDockPanel({ position: 'left', onHorizontalResizeMouseDown })
+    fireEvent.mouseDown(screen.getByTestId('resize-handle'))
+    expect(onHorizontalResizeMouseDown).toHaveBeenCalled()
+  })
+
+  test('left dock ArrowRight grows horizontal size', async () => {
+    const user = userEvent.setup()
+    const onHorizontalSizeAdjust = vi.fn()
+    renderDockPanel({ position: 'left', onHorizontalSizeAdjust })
+    screen.getByTestId('resize-handle').focus()
+    await user.keyboard('{ArrowRight}')
+    expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(20)
+  })
+
+  test('left dock ArrowLeft shrinks horizontal size', async () => {
+    const user = userEvent.setup()
+    const onHorizontalSizeAdjust = vi.fn()
+    renderDockPanel({ position: 'left', onHorizontalSizeAdjust })
+    screen.getByTestId('resize-handle').focus()
+    await user.keyboard('{ArrowLeft}')
+    expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(-20)
+  })
+
+  test('right dock ArrowLeft grows horizontal size (invert)', async () => {
+    const user = userEvent.setup()
+    const onHorizontalSizeAdjust = vi.fn()
+    renderDockPanel({ position: 'right', onHorizontalSizeAdjust })
+    screen.getByTestId('resize-handle').focus()
+    await user.keyboard('{ArrowLeft}')
+    expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(20)
+  })
+
+  test('vertical handle aria-valuemin/max come from verticalPixelMin/Max props', () => {
+    renderDockPanel({ position: 'bottom', verticalPixelMin: 75, verticalPixelMax: 900 })
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toHaveAttribute('aria-valuemin', '75')
+    expect(handle).toHaveAttribute('aria-valuemax', '900')
+  })
+
+  test('horizontal handle aria-valuemin/max come from horizontalPixelMin/Max props', () => {
+    renderDockPanel({ position: 'left', horizontalPixelMin: 60, horizontalPixelMax: 960 })
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toHaveAttribute('aria-valuemin', '60')
+    expect(handle).toHaveAttribute('aria-valuemax', '960')
+  })
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npx vitest run src/features/workspace/components/DockPanel.test.tsx 2>&1 | tail -20
+```
+
+Expected: many FAIL — missing props and horizontal handle not implemented.
+
+- [ ] **Step 3: Rewrite `DockPanel.tsx`**
+
+Replace the entire file content:
+
+```typescript
+import type { KeyboardEvent, MouseEvent, ReactElement } from 'react'
+import { CodeEditor } from '../../editor/components/CodeEditor'
+import { DiffPanelContent } from '../../diff/components/DiffPanelContent'
+import { DockSwitcher, type DockPosition } from './DockSwitcher'
+import { DockTab } from './DockTab'
+import type { SelectedDiffFile } from '../../diff/types'
+import type { UseGitStatusReturn } from '../../diff/hooks/useGitStatus'
+import {
+  KEYBOARD_STEP_PX,
+  KEYBOARD_STEP_SHIFT_PX,
+} from '../panelConfig'
+
+type TabType = 'editor' | 'diff'
+
+type SelectedDiffControl =
+  | { selectedDiffFile?: undefined; onSelectedDiffFileChange?: undefined }
+  | {
+      selectedDiffFile: SelectedDiffFile | null
+      onSelectedDiffFileChange: (file: SelectedDiffFile | null) => void
+    }
+
+interface DockPanelBaseProps {
+  position: DockPosition
+  tab: TabType
+  onTabChange: (next: TabType) => void
+  onPositionChange: (next: DockPosition) => void
+  onClose: () => void
+  /** Controlled height for top/bottom docks. */
+  verticalSize: number
+  onVerticalResizeMouseDown: (event: MouseEvent) => void
+  isVerticalResizing: boolean
+  onVerticalSizeAdjust: (delta: number) => void
+  /** Live pixel bounds from useElasticContainer (for ARIA + keyboard Home/End). */
+  verticalPixelMin: number
+  verticalPixelMax: number
+  /** Controlled width for left/right docks. */
+  horizontalSize: number
+  onHorizontalResizeMouseDown: (event: MouseEvent) => void
+  isHorizontalResizing: boolean
+  onHorizontalSizeAdjust: (delta: number) => void
+  horizontalPixelMin: number
+  horizontalPixelMax: number
+
+  selectedFilePath: string | null
+  content: string
+  onContentChange?: (content: string) => void
+  onSave?: () => void
+  isDirty?: boolean
+  isLoading?: boolean
+  cwd?: string
+  gitStatus?: UseGitStatusReturn
+}
+
+type DockPanelProps = DockPanelBaseProps & SelectedDiffControl
+
+const DockPanel = ({
+  position,
+  tab,
+  onTabChange,
+  onPositionChange,
+  onClose,
+  verticalSize,
+  onVerticalResizeMouseDown,
+  isVerticalResizing,
+  onVerticalSizeAdjust,
+  verticalPixelMin,
+  verticalPixelMax,
+  horizontalSize,
+  onHorizontalResizeMouseDown,
+  isHorizontalResizing,
+  onHorizontalSizeAdjust,
+  horizontalPixelMin,
+  horizontalPixelMax,
+  selectedFilePath,
+  content,
+  onContentChange = undefined,
+  onSave = undefined,
+  isDirty = false,
+  isLoading = false,
+  cwd = '.',
+  gitStatus = undefined,
+  selectedDiffFile,
+  onSelectedDiffFileChange,
+}: DockPanelProps): ReactElement => {
+  const isVerticalDock = position === 'top' || position === 'bottom'
+
+  const containerStyle = isVerticalDock
+    ? { height: `${verticalSize}px` }
+    : { width: `${horizontalSize}px` }
+
+  const borderClass =
+    position === 'top'
+      ? 'border-b border-[rgba(74,68,79,0.3)]'
+      : position === 'bottom'
+        ? 'border-t border-[rgba(74,68,79,0.3)]'
+        : position === 'left'
+          ? 'border-r border-[rgba(74,68,79,0.3)]'
+          : 'border-l border-[rgba(74,68,79,0.3)]'
+
+  const collapseIconName =
+    position === 'top'
+      ? 'expand_less'
+      : position === 'bottom'
+        ? 'expand_more'
+        : position === 'left'
+          ? 'chevron_left'
+          : 'chevron_right'
+
+  const sectionAriaLabel = tab === 'editor' ? 'Code editor' : 'Diff viewer'
+
+  const handleVerticalKeyDown = (e: KeyboardEvent): void => {
+    const step = e.shiftKey ? KEYBOARD_STEP_SHIFT_PX : KEYBOARD_STEP_PX
+    const growKey = position === 'top' ? 'ArrowDown' : 'ArrowUp'
+    const shrinkKey = position === 'top' ? 'ArrowUp' : 'ArrowDown'
+
+    if (e.key === growKey) {
+      e.preventDefault()
+      onVerticalSizeAdjust(step)
+    } else if (e.key === shrinkKey) {
+      e.preventDefault()
+      onVerticalSizeAdjust(-step)
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      onVerticalSizeAdjust(verticalPixelMin - verticalSize)
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      onVerticalSizeAdjust(verticalPixelMax - verticalSize)
+    }
+  }
+
+  const handleHorizontalKeyDown = (e: KeyboardEvent): void => {
+    const step = e.shiftKey ? KEYBOARD_STEP_SHIFT_PX : KEYBOARD_STEP_PX
+    // Left dock grows rightward (ArrowRight = grow), right dock grows leftward (ArrowLeft = grow).
+    const growKey = position === 'left' ? 'ArrowRight' : 'ArrowLeft'
+    const shrinkKey = position === 'left' ? 'ArrowLeft' : 'ArrowRight'
+
+    if (e.key === growKey) {
+      e.preventDefault()
+      onHorizontalSizeAdjust(step)
+    } else if (e.key === shrinkKey) {
+      e.preventDefault()
+      onHorizontalSizeAdjust(-step)
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      onHorizontalSizeAdjust(horizontalPixelMin - horizontalSize)
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      onHorizontalSizeAdjust(horizontalPixelMax - horizontalSize)
+    }
+  }
+
+  return (
+    <section
+      data-testid="dock-panel"
+      data-position={position}
+      aria-label={sectionAriaLabel}
+      style={containerStyle}
+      className={`relative z-30 flex shrink-0 flex-col bg-[#121221] ${borderClass}`}
+    >
+      {isVerticalDock ? (
+        <div
+          data-testid="resize-handle"
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize panel"
+          aria-valuenow={verticalSize}
+          aria-valuemin={verticalPixelMin}
+          aria-valuemax={verticalPixelMax}
+          tabIndex={0}
+          onMouseDown={onVerticalResizeMouseDown}
+          onKeyDown={handleVerticalKeyDown}
+          className={`absolute ${position === 'top' ? 'bottom-0' : 'top-0'} left-0 right-0 h-1 cursor-ns-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
+            isVerticalResizing ? 'bg-primary/30' : ''
+          }`}
+        />
+      ) : (
+        <div
+          data-testid="resize-handle"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize panel"
+          aria-valuenow={horizontalSize}
+          aria-valuemin={horizontalPixelMin}
+          aria-valuemax={horizontalPixelMax}
+          tabIndex={0}
+          onMouseDown={onHorizontalResizeMouseDown}
+          onKeyDown={handleHorizontalKeyDown}
+          className={`absolute ${position === 'right' ? 'left-0' : 'right-0'} top-0 bottom-0 w-1 cursor-col-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
+            isHorizontalResizing ? 'bg-primary/30' : ''
+          }`}
+        />
+      )}
+
+      <DockTab
+        tab={tab}
+        onTabChange={onTabChange}
+        selectedFilePath={selectedFilePath}
+        collapseIconName={collapseIconName}
+        onClose={onClose}
+      >
+        <DockSwitcher position={position} onPick={onPositionChange} />
+      </DockTab>
+
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {tab === 'editor' && (
+          <div
+            data-testid="editor-panel"
+            className="flex min-h-0 flex-1 overflow-hidden"
+          >
+            <CodeEditor
+              filePath={selectedFilePath}
+              content={content}
+              onContentChange={onContentChange}
+              onSave={onSave}
+              isDirty={isDirty}
+              isLoading={isLoading}
+            />
+          </div>
+        )}
+
+        {tab === 'diff' && (
+          <div
+            data-testid="diff-panel"
+            className="flex min-h-0 flex-1 overflow-hidden"
+          >
+            {selectedDiffFile !== undefined ? (
+              <DiffPanelContent
+                cwd={cwd}
+                gitStatus={gitStatus}
+                selectedFile={selectedDiffFile}
+                onSelectedFileChange={onSelectedDiffFileChange}
+              />
+            ) : (
+              <DiffPanelContent cwd={cwd} gitStatus={gitStatus} />
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default DockPanel
+```
+
+- [ ] **Step 4: Run DockPanel tests**
+
+```bash
+npx vitest run src/features/workspace/components/DockPanel.test.tsx 2>&1 | tail -20
+```
+
+Expected: all PASS. Fix any failures before continuing.
+
+- [ ] **Step 5: Run type-check**
+
+```bash
+npx tsc -b --noEmit 2>&1 | head -30
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/workspace/components/DockPanel.tsx src/features/workspace/components/DockPanel.test.tsx
+git commit -m "feat(dock): add horizontal resize handle + percent-bound ARIA props"
+```
+
+---
+
+## Task 5: Wire `useElasticContainer` into `WorkspaceView`
+
+**Files:**
+- Modify: `src/features/workspace/WorkspaceView.tsx`
+- Modify: `src/features/workspace/WorkspaceView.test.tsx`
+- Modify: `src/features/workspace/WorkspaceView.integration.test.tsx`
+- Modify: `src/features/workspace/WorkspaceView.command-palette.test.tsx`
+- Modify: `src/features/workspace/WorkspaceView.notifyInfo.test.tsx`
+- Modify: `src/features/workspace/WorkspaceView.subscription.test.tsx`
+- Modify: `src/features/workspace/WorkspaceView.verification.test.tsx`
+- Modify: `src/features/workspace/WorkspaceView.visual.test.tsx`
+
+- [ ] **Step 1: Add `useElasticContainer` mock to all existing WorkspaceView test files**
+
+Add this module-level mock to the top of each of the 7 test files listed above (after existing `vi.mock(...)` calls, before any `describe`):
+
+```typescript
+vi.mock('../../hooks/useElasticContainer', () => ({
+  useElasticContainer: vi.fn(() => ({
+    size: 400,
+    isDragging: false,
+    handleMouseDown: vi.fn(),
+    adjustBy: vi.fn(),
+    resetToSize: vi.fn(),
+    sizeRef: { current: 400 },
+    pixelMin: 40,
+    pixelMax: 640,
+  })),
+}))
+```
+
+Note: `WorkspaceView.command-palette.test.tsx`, `WorkspaceView.notifyInfo.test.tsx`, etc. use paths relative to their location. If the test file is in `src/features/workspace/`, the mock path is `'../../hooks/useElasticContainer'`.
+
+- [ ] **Step 2: Confirm all existing WorkspaceView tests still pass**
+
+```bash
+npx vitest run src/features/workspace/WorkspaceView.test.tsx src/features/workspace/WorkspaceView.integration.test.tsx src/features/workspace/WorkspaceView.command-palette.test.tsx src/features/workspace/WorkspaceView.notifyInfo.test.tsx src/features/workspace/WorkspaceView.subscription.test.tsx src/features/workspace/WorkspaceView.verification.test.tsx src/features/workspace/WorkspaceView.visual.test.tsx 2>&1 | tail -20
+```
+
+Expected: all PASS (before the WorkspaceView changes — mocks prevent the jsdom zero-dimension throw).
+
+- [ ] **Step 3: Update `WorkspaceView.tsx`**
+
+**3a. Add import for `useElasticContainer` and `DOCK_ELASTIC_CONFIG`:**
+
+Find the imports section and add:
+```typescript
+import { useElasticContainer } from '../../hooks/useElasticContainer'
+import { DOCK_ELASTIC_CONFIG } from './panelConfig'
+```
+
+Remove the old import of `clampSize` if it was only used for vertical dock (check — it's also used for sidebar, so keep it).
+
+**3b. Add `dockCanvasRef` just before the `dockPosition` state:**
+
+```typescript
+  // Ref to the dock-canvas-wrapper div; used by useElasticContainer to measure
+  // the available area for percent-based bounds.
+  const dockCanvasRef = useRef<HTMLDivElement>(null)
+```
+
+**3c. Replace the `verticalDockResize = useResizable(...)` block (lines ~361-369 in the original) with two elastic instances:**
+
+Remove:
+```typescript
+  // Vertical dock height is lifted so the value survives DockPanel unmounts.
+  const verticalDockResize = useResizable({
+    initial: 400,
+    min: 150,
+    max: 640,
+    direction: 'vertical',
+    // Bottom dock grows when dragging up from its top edge; top dock grows
+    // when dragging down from its bottom edge.
+    invert: dockPosition === 'bottom',
+  })
+```
+
+Add:
+```typescript
+  // Two separate elastic instances — one per axis — so each size survives
+  // dock position switches and DockPanel unmounts independently.
+  const verticalDockElastic = useElasticContainer({
+    containerRef: dockCanvasRef,
+    axis: 'vertical',
+    ...DOCK_ELASTIC_CONFIG,
+    invert: dockPosition === 'bottom',
+  })
+
+  const horizontalDockElastic = useElasticContainer({
+    containerRef: dockCanvasRef,
+    axis: 'horizontal',
+    ...DOCK_ELASTIC_CONFIG,
+    invert: dockPosition === 'right',
+  })
+```
+
+**3d. Update `terminalFitDeferred` (line ~579 in original):**
+
+Change:
+```typescript
+  const terminalFitDeferred = isDragging || verticalDockResize.isDragging
+```
+
+To:
+```typescript
+  const terminalFitDeferred =
+    isDragging || verticalDockElastic.isDragging || horizontalDockElastic.isDragging
+```
+
+**3e. Update the `<DockPanel>` call site (lines ~582-604 in original):**
+
+Replace:
+```tsx
+      verticalSize={verticalDockResize.size}
+      onVerticalResizeMouseDown={verticalDockResize.handleMouseDown}
+      isVerticalResizing={verticalDockResize.isDragging}
+      onVerticalSizeAdjust={verticalDockResize.adjustBy}
+```
+
+With:
+```tsx
+      verticalSize={verticalDockElastic.size}
+      onVerticalResizeMouseDown={verticalDockElastic.handleMouseDown}
+      isVerticalResizing={verticalDockElastic.isDragging}
+      onVerticalSizeAdjust={verticalDockElastic.adjustBy}
+      verticalPixelMin={verticalDockElastic.pixelMin}
+      verticalPixelMax={verticalDockElastic.pixelMax}
+      horizontalSize={horizontalDockElastic.size}
+      onHorizontalResizeMouseDown={horizontalDockElastic.handleMouseDown}
+      isHorizontalResizing={horizontalDockElastic.isDragging}
+      onHorizontalSizeAdjust={horizontalDockElastic.adjustBy}
+      horizontalPixelMin={horizontalDockElastic.pixelMin}
+      horizontalPixelMax={horizontalDockElastic.pixelMax}
+```
+
+**3f. Add `ref={dockCanvasRef}` to the `dock-canvas-wrapper` div (line ~700 in original):**
+
+Change:
+```tsx
+        <div
+          data-testid="dock-canvas-wrapper"
+          className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
+          style={{ flexDirection: dockCanvasFlexDirection }}
+        >
+```
+
+To:
+```tsx
+        <div
+          ref={dockCanvasRef}
+          data-testid="dock-canvas-wrapper"
+          className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
+          style={{ flexDirection: dockCanvasFlexDirection }}
+        >
+```
+
+**3g. Remove the now-unused `useResizable` import if `verticalDockResize` was the only call-site for the dock. Keep it for the sidebar resize — check:**
+
+Grep the file: `useResizable` is also called for the sidebar (`const { size: sidebarWidth, ... } = useResizable(...)`). Keep the import.
+
+- [ ] **Step 4: Run type-check**
+
+```bash
+npx tsc -b --noEmit 2>&1 | head -30
+```
+
+Expected: no errors. Fix any prop-shape mismatches before continuing.
+
+- [ ] **Step 5: Run all WorkspaceView tests**
+
+```bash
+npx vitest run src/features/workspace/WorkspaceView.test.tsx src/features/workspace/WorkspaceView.integration.test.tsx src/features/workspace/WorkspaceView.command-palette.test.tsx src/features/workspace/WorkspaceView.notifyInfo.test.tsx src/features/workspace/WorkspaceView.subscription.test.tsx src/features/workspace/WorkspaceView.verification.test.tsx src/features/workspace/WorkspaceView.visual.test.tsx 2>&1 | tail -20
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/workspace/WorkspaceView.tsx \
+  src/features/workspace/WorkspaceView.test.tsx \
+  src/features/workspace/WorkspaceView.integration.test.tsx \
+  src/features/workspace/WorkspaceView.command-palette.test.tsx \
+  src/features/workspace/WorkspaceView.notifyInfo.test.tsx \
+  src/features/workspace/WorkspaceView.subscription.test.tsx \
+  src/features/workspace/WorkspaceView.verification.test.tsx \
+  src/features/workspace/WorkspaceView.visual.test.tsx
+git commit -m "feat(workspace): wire useElasticContainer — replace vertical useResizable, add horizontal"
+```
+
+---
+
+## Task 6: Issue #217 — Size persistence integration test
+
+**Files:**
+- Create: `src/features/workspace/WorkspaceView.elastic.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+Create `src/features/workspace/WorkspaceView.elastic.test.tsx`:
+
+```typescript
+/**
+ * WorkspaceView elastic resize integration tests.
+ * Uses REAL useElasticContainer (not mocked) to prove that resize state
+ * lives in WorkspaceView, not inside DockPanel.
+ * Stubs ResizeObserver and getBoundingClientRect so jsdom works.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { WorkspaceView } from './WorkspaceView'
+
+// --- Shared mocks (same as other WorkspaceView test files) ---
+
+vi.mock('../terminal/components/TerminalPane', () => ({
+  TerminalPane: vi.fn(() => (
+    <div data-testid="terminal-pane-mock">Mocked TerminalPane</div>
+  )),
+}))
+
+vi.mock('../agent-status/hooks/useAgentStatus', () => ({
+  useAgentStatus: vi.fn(() => ({
+    isActive: false,
+    agentType: null,
+    modelId: null,
+    modelDisplayName: null,
+    version: null,
+    sessionId: null,
+    agentSessionId: null,
+    contextWindow: null,
+    cost: null,
+    rateLimits: null,
+    numTurns: 0,
+    toolCalls: { total: 0, byType: {}, active: null },
+    recentToolCalls: [],
+    testRun: null,
+  })),
+}))
+
+vi.mock('../terminal/services/terminalService', () => ({
+  createTerminalService: vi.fn(() => ({
+    spawn: vi.fn().mockResolvedValue({ sessionId: 'sess-1', pid: 1, cwd: '~' }),
+    write: vi.fn().mockResolvedValue(undefined),
+    resize: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onData: vi.fn((): (() => void) => (): void => {}),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onExit: vi.fn((): (() => void) => (): void => {}),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onError: vi.fn((): (() => void) => (): void => {}),
+    listSessions: vi.fn().mockResolvedValue({
+      activeSessionId: 'sess-1',
+      sessions: [
+        {
+          id: 'sess-1',
+          cwd: '~',
+          status: {
+            kind: 'Alive',
+            pid: 1234,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    }),
+    setActiveSession: vi.fn().mockResolvedValue(undefined),
+    reorderSessions: vi.fn().mockResolvedValue(undefined),
+    updateSessionCwd: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+vi.mock('../editor/hooks/useCodeMirror', () => ({
+  useCodeMirror: vi.fn(() => ({
+    editorView: null,
+    updateContent: vi.fn(),
+  })),
+}))
+
+vi.mock('../editor/hooks/useVimMode', () => ({
+  useVimMode: vi.fn(() => 'NORMAL'),
+}))
+
+vi.mock('../editor/services/languageService', () => ({
+  getLanguageExtension: vi.fn(() => []),
+}))
+
+vi.mock('../diff/hooks/useGitStatus', () => ({
+  useGitStatus: vi.fn(() => ({
+    files: [],
+    filesCwd: '.',
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    idle: false,
+  })),
+}))
+
+vi.mock('../diff/hooks/useFileDiff', () => ({
+  useFileDiff: vi.fn(() => ({ diff: null, loading: false, error: null })),
+}))
+
+// --- DOM stubs for useElasticContainer ---
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe = vi.fn()
+      disconnect = vi.fn()
+      unobserve = vi.fn()
+    }
+  )
+
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: 1200,
+    height: 800,
+    top: 0,
+    left: 0,
+    right: 1200,
+    bottom: 800,
+    x: 0,
+    y: 0,
+    toJSON: (): undefined => undefined,
+  } as DOMRect)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('WorkspaceView elastic resize — size persistence (issue #217)', () => {
+  test('vertical size survives dock close and reopen', async () => {
+    const user = userEvent.setup()
+    render(<WorkspaceView />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+    })
+
+    // Simulate a resize: mousedown on handle, move 100px up (grows bottom dock),
+    // then mouseup.
+    const handle = screen.getByTestId('resize-handle')
+    const initialHeight = parseInt(
+      (screen.getByTestId('dock-panel') as HTMLElement).style.height,
+      10
+    )
+
+    fireEvent.mouseDown(handle, { clientY: 500 })
+    fireEvent.mouseMove(document, { clientY: 400 }) // +100px up = grow bottom dock
+    fireEvent.mouseUp(document)
+
+    await waitFor(() => {
+      const newHeight = parseInt(
+        (screen.getByTestId('dock-panel') as HTMLElement).style.height,
+        10
+      )
+      expect(newHeight).toBeGreaterThan(initialHeight)
+    })
+
+    const heightAfterResize = parseInt(
+      (screen.getByTestId('dock-panel') as HTMLElement).style.height,
+      10
+    )
+
+    // Close the dock (DockPanel unmounts).
+    await user.click(screen.getByRole('button', { name: /collapse panel/i }))
+    expect(screen.queryByTestId('dock-panel')).not.toBeInTheDocument()
+
+    // Reopen (DockPanel remounts from fresh).
+    await user.click(screen.getByRole('button', { name: /open panel/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+    })
+
+    // Height must match the resized value, not the default initial value.
+    const heightAfterReopen = parseInt(
+      (screen.getByTestId('dock-panel') as HTMLElement).style.height,
+      10
+    )
+    expect(heightAfterReopen).toBe(heightAfterResize)
+  })
+
+  test('vertical and horizontal sizes are independent across position switches', async () => {
+    const user = userEvent.setup()
+    render(<WorkspaceView />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+    })
+
+    const initialVerticalHeight = parseInt(
+      (screen.getByTestId('dock-panel') as HTMLElement).style.height,
+      10
+    )
+
+    // Switch to right dock.
+    await user.click(screen.getByRole('button', { name: /dock: right/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toHaveAttribute('data-position', 'right')
+    })
+
+    const initialHorizontalWidth = parseInt(
+      (screen.getByTestId('dock-panel') as HTMLElement).style.width,
+      10
+    )
+
+    // Switch back to bottom.
+    await user.click(screen.getByRole('button', { name: /dock: bottom/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toHaveAttribute('data-position', 'bottom')
+    })
+
+    // Vertical size must not have been reset by the position switch.
+    const heightAfterSwitch = parseInt(
+      (screen.getByTestId('dock-panel') as HTMLElement).style.height,
+      10
+    )
+    expect(heightAfterSwitch).toBe(initialVerticalHeight)
+
+    // Switch to left dock — horizontal size should match the right-dock size
+    // (same horizontal elastic instance).
+    await user.click(screen.getByRole('button', { name: /dock: left/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toHaveAttribute('data-position', 'left')
+    })
+
+    const widthOnLeft = parseInt(
+      (screen.getByTestId('dock-panel') as HTMLElement).style.width,
+      10
+    )
+    expect(widthOnLeft).toBe(initialHorizontalWidth)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+npx vitest run src/features/workspace/WorkspaceView.elastic.test.tsx 2>&1 | tail -20
+```
+
+Expected: all PASS. If the collapse/reopen button names differ, check the actual ARIA labels with `screen.debug()` and adjust.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+npm run test 2>&1 | tail -30
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Run lint**
+
+```bash
+npm run lint 2>&1 | head -30
+```
+
+Expected: no errors. Fix any ESLint issues before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/workspace/WorkspaceView.elastic.test.tsx
+git commit -m "test(workspace): prove vertical size persists across dock close/reopen (issue #217)"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| Spec requirement | Covered by |
+|---|---|
+| Horizontal resize handle on left/right docks | Task 4 (DockPanel), Task 5 (WorkspaceView) |
+| Drag handle on inner edge (right of left, left of right) | Task 4 — `position === 'right' ? 'left-0' : 'right-0'` |
+| Keyboard resize (ArrowLeft/Right) for horizontal | Task 4 — `handleHorizontalKeyDown` |
+| Percent-based bounds (5%–80%) | Task 1 (panelConfig), Task 3 (useElasticContainer) |
+| `panelConfig.ts` as single tuning surface | Task 1 |
+| `useElasticContainer` shared hook | Task 3 |
+| `resetToSize` + `sizeRef` on `useResizable` | Task 2 |
+| Size survives dock close/reopen (issue #217) | Task 6 |
+| Re-clamp on container resize (ResizeObserver) | Task 3 |
+| Post-drag re-clamp | Task 3 |
+| ARIA `aria-valuemin`/`aria-valuemax` from live pixel bounds | Task 4 |
+| Terminal fit deferral includes horizontal drag | Task 5, step 3d |
+| All existing WorkspaceView tests still pass | Task 5, step 5 |
+| `panelConfig.ts` — terminal configs defined (out of scope wiring) | Task 1 |
+
+### No placeholders found ✓
+
+All steps include actual code, exact commands, and expected output.
+
+### Type consistency check
+
+- `verticalPixelMin` / `verticalPixelMax` — defined in Task 4 props, used in Task 4 handle, passed from Task 5
+- `horizontalPixelMin` / `horizontalPixelMax` — same pattern
+- `useElasticContainer` returns `UseElasticContainerResult extends UseResizableResult` — all fields consumed in Task 5
+- `DOCK_ELASTIC_CONFIG` spread in Task 5 — matches `UseElasticContainerOptions` fields (minPercent, maxPercent, initialPercent)
+- `KEYBOARD_STEP_PX` / `KEYBOARD_STEP_SHIFT_PX` — defined Task 1, imported Task 4

--- a/docs/superpowers/plans/2026-05-17-dock-elastic-resize-plan.md
+++ b/docs/superpowers/plans/2026-05-17-dock-elastic-resize-plan.md
@@ -12,30 +12,31 @@
 
 ## File Map
 
-| Action | File | Purpose |
-|--------|------|---------|
-| CREATE | `src/features/workspace/panelConfig.ts` | All size-tuning constants |
-| MODIFY | `src/hooks/useResizable.ts` | Add `resetToSize` + expose `sizeRef` |
-| MODIFY | `src/hooks/useResizable.test.ts` | Tests for new methods |
-| CREATE | `src/hooks/useElasticContainer.ts` | Percent-bound resize hook |
-| CREATE | `src/hooks/useElasticContainer.test.ts` | Hook unit tests |
-| MODIFY | `src/features/workspace/components/DockPanel.tsx` | New props + horizontal handle |
-| MODIFY | `src/features/workspace/components/DockPanel.test.tsx` | Tests for horizontal handle |
-| MODIFY | `src/features/workspace/WorkspaceView.tsx` | Wire elastic containers |
-| MODIFY | `src/features/workspace/WorkspaceView.test.tsx` | Add useElasticContainer mock |
-| MODIFY | `src/features/workspace/WorkspaceView.integration.test.tsx` | Add useElasticContainer mock |
-| MODIFY | `src/features/workspace/WorkspaceView.command-palette.test.tsx` | Add useElasticContainer mock |
-| MODIFY | `src/features/workspace/WorkspaceView.notifyInfo.test.tsx` | Add useElasticContainer mock |
-| MODIFY | `src/features/workspace/WorkspaceView.subscription.test.tsx` | Add useElasticContainer mock |
-| MODIFY | `src/features/workspace/WorkspaceView.verification.test.tsx` | Add useElasticContainer mock |
-| MODIFY | `src/features/workspace/WorkspaceView.visual.test.tsx` | Add useElasticContainer mock |
-| CREATE | `src/features/workspace/WorkspaceView.elastic.test.tsx` | Issue #217 persistence proof |
+| Action | File                                                            | Purpose                              |
+| ------ | --------------------------------------------------------------- | ------------------------------------ |
+| CREATE | `src/features/workspace/panelConfig.ts`                         | All size-tuning constants            |
+| MODIFY | `src/hooks/useResizable.ts`                                     | Add `resetToSize` + expose `sizeRef` |
+| MODIFY | `src/hooks/useResizable.test.ts`                                | Tests for new methods                |
+| CREATE | `src/hooks/useElasticContainer.ts`                              | Percent-bound resize hook            |
+| CREATE | `src/hooks/useElasticContainer.test.ts`                         | Hook unit tests                      |
+| MODIFY | `src/features/workspace/components/DockPanel.tsx`               | New props + horizontal handle        |
+| MODIFY | `src/features/workspace/components/DockPanel.test.tsx`          | Tests for horizontal handle          |
+| MODIFY | `src/features/workspace/WorkspaceView.tsx`                      | Wire elastic containers              |
+| MODIFY | `src/features/workspace/WorkspaceView.test.tsx`                 | Add useElasticContainer mock         |
+| MODIFY | `src/features/workspace/WorkspaceView.integration.test.tsx`     | Add useElasticContainer mock         |
+| MODIFY | `src/features/workspace/WorkspaceView.command-palette.test.tsx` | Add useElasticContainer mock         |
+| MODIFY | `src/features/workspace/WorkspaceView.notifyInfo.test.tsx`      | Add useElasticContainer mock         |
+| MODIFY | `src/features/workspace/WorkspaceView.subscription.test.tsx`    | Add useElasticContainer mock         |
+| MODIFY | `src/features/workspace/WorkspaceView.verification.test.tsx`    | Add useElasticContainer mock         |
+| MODIFY | `src/features/workspace/WorkspaceView.visual.test.tsx`          | Add useElasticContainer mock         |
+| CREATE | `src/features/workspace/WorkspaceView.elastic.test.tsx`         | Issue #217 persistence proof         |
 
 ---
 
 ## Task 1: Create `panelConfig.ts`
 
 **Files:**
+
 - Create: `src/features/workspace/panelConfig.ts`
 
 - [ ] **Step 1: Write the file**
@@ -106,6 +107,7 @@ git commit -m "feat(resize): add panelConfig.ts — single tuning surface for al
 ## Task 2: Extend `useResizable` with `resetToSize` and `sizeRef`
 
 **Files:**
+
 - Modify: `src/hooks/useResizable.ts`
 - Modify: `src/hooks/useResizable.test.ts`
 
@@ -114,95 +116,100 @@ git commit -m "feat(resize): add panelConfig.ts — single tuning surface for al
 Append to `src/hooks/useResizable.test.ts` (inside the `describe('useResizable', ...)` block, before its closing `}`):
 
 ```typescript
-  describe('resetToSize', () => {
-    test('sets size to clamped value', () => {
-      const { result } = renderHook(() =>
-        useResizable({ initial: 256, min: 100, max: 500 })
-      )
+describe('resetToSize', () => {
+  test('sets size to clamped value', () => {
+    const { result } = renderHook(() =>
+      useResizable({ initial: 256, min: 100, max: 500 })
+    )
 
-      act(() => {
-        result.current.resetToSize(300)
-      })
-
-      expect(result.current.size).toBe(300)
+    act(() => {
+      result.current.resetToSize(300)
     })
 
-    test('clamps to min when value is below min', () => {
-      const { result } = renderHook(() =>
-        useResizable({ initial: 256, min: 100, max: 500 })
-      )
-
-      act(() => {
-        result.current.resetToSize(50)
-      })
-
-      expect(result.current.size).toBe(100)
-    })
-
-    test('clamps to max when value is above max', () => {
-      const { result } = renderHook(() =>
-        useResizable({ initial: 256, min: 100, max: 500 })
-      )
-
-      act(() => {
-        result.current.resetToSize(600)
-      })
-
-      expect(result.current.size).toBe(500)
-    })
-
-    test('uses explicit bounds when provided, bypassing closure min/max', () => {
-      const { result } = renderHook(() =>
-        useResizable({ initial: 256, min: 100, max: 500 })
-      )
-
-      act(() => {
-        result.current.resetToSize(800, 50, 900)
-      })
-
-      expect(result.current.size).toBe(800)
-    })
-
-    test('updates previewSize so adjustBy baseline is fresh after reset', async () => {
-      const { result } = renderHook(() =>
-        useResizable({ initial: 256, min: 100, max: 500, updateMode: 'commit-on-end' })
-      )
-
-      act(() => {
-        result.current.resetToSize(400)
-      })
-
-      act(() => {
-        result.current.adjustBy(0)
-      })
-
-      await waitFor(() => {
-        expect(result.current.size).toBe(400)
-      })
-    })
+    expect(result.current.size).toBe(300)
   })
 
-  describe('sizeRef', () => {
-    test('sizeRef.current matches size on initial render', () => {
-      const { result } = renderHook(() =>
-        useResizable({ initial: 256, min: 100, max: 500 })
-      )
+  test('clamps to min when value is below min', () => {
+    const { result } = renderHook(() =>
+      useResizable({ initial: 256, min: 100, max: 500 })
+    )
 
-      expect(result.current.sizeRef.current).toBe(256)
+    act(() => {
+      result.current.resetToSize(50)
     })
 
-    test('sizeRef.current updates synchronously after resetToSize', () => {
-      const { result } = renderHook(() =>
-        useResizable({ initial: 256, min: 100, max: 500 })
-      )
+    expect(result.current.size).toBe(100)
+  })
 
-      act(() => {
-        result.current.resetToSize(350)
+  test('clamps to max when value is above max', () => {
+    const { result } = renderHook(() =>
+      useResizable({ initial: 256, min: 100, max: 500 })
+    )
+
+    act(() => {
+      result.current.resetToSize(600)
+    })
+
+    expect(result.current.size).toBe(500)
+  })
+
+  test('uses explicit bounds when provided, bypassing closure min/max', () => {
+    const { result } = renderHook(() =>
+      useResizable({ initial: 256, min: 100, max: 500 })
+    )
+
+    act(() => {
+      result.current.resetToSize(800, 50, 900)
+    })
+
+    expect(result.current.size).toBe(800)
+  })
+
+  test('updates previewSize so adjustBy baseline is fresh after reset', async () => {
+    const { result } = renderHook(() =>
+      useResizable({
+        initial: 256,
+        min: 100,
+        max: 500,
+        updateMode: 'commit-on-end',
       })
+    )
 
-      expect(result.current.sizeRef.current).toBe(350)
+    act(() => {
+      result.current.resetToSize(400)
+    })
+
+    act(() => {
+      result.current.adjustBy(0)
+    })
+
+    await waitFor(() => {
+      expect(result.current.size).toBe(400)
     })
   })
+})
+
+describe('sizeRef', () => {
+  test('sizeRef.current matches size on initial render', () => {
+    const { result } = renderHook(() =>
+      useResizable({ initial: 256, min: 100, max: 500 })
+    )
+
+    expect(result.current.sizeRef.current).toBe(256)
+  })
+
+  test('sizeRef.current updates synchronously after resetToSize', () => {
+    const { result } = renderHook(() =>
+      useResizable({ initial: 256, min: 100, max: 500 })
+    )
+
+    act(() => {
+      result.current.resetToSize(350)
+    })
+
+    expect(result.current.sizeRef.current).toBe(350)
+  })
+})
 ```
 
 - [ ] **Step 2: Run tests to confirm they fail**
@@ -251,29 +258,29 @@ import {
 Add `resetToSize` callback inside `useResizable` (after the `adjustBy` definition):
 
 ```typescript
-  const resetToSize = useCallback(
-    (px: number, explicitMin?: number, explicitMax?: number): void => {
-      const clampMin = explicitMin ?? min
-      const clampMax = explicitMax ?? max
-      cancelPendingSize()
-      const nextSize = clampSize(px, clampMin, clampMax)
-      commitSize(nextSize)
-      // Unconditionally sync previewSize so adjustBy baseline is fresh
-      // even in commit-on-end mode (where commitSize doesn't update previewSize).
-      previewSize.current = nextSize
-      if (isDraggingRef.current) {
-        startPos.current = currentPos.current
-        startSize.current = nextSize
-      }
-    },
-    [min, max, cancelPendingSize, commitSize]
-  )
+const resetToSize = useCallback(
+  (px: number, explicitMin?: number, explicitMax?: number): void => {
+    const clampMin = explicitMin ?? min
+    const clampMax = explicitMax ?? max
+    cancelPendingSize()
+    const nextSize = clampSize(px, clampMin, clampMax)
+    commitSize(nextSize)
+    // Unconditionally sync previewSize so adjustBy baseline is fresh
+    // even in commit-on-end mode (where commitSize doesn't update previewSize).
+    previewSize.current = nextSize
+    if (isDraggingRef.current) {
+      startPos.current = currentPos.current
+      startSize.current = nextSize
+    }
+  },
+  [min, max, cancelPendingSize, commitSize]
+)
 ```
 
 Update the return statement:
 
 ```typescript
-  return { size, isDragging, handleMouseDown, adjustBy, resetToSize, sizeRef }
+return { size, isDragging, handleMouseDown, adjustBy, resetToSize, sizeRef }
 ```
 
 - [ ] **Step 4: Run tests to confirm they pass**
@@ -296,6 +303,7 @@ git commit -m "feat(resize): add resetToSize + expose sizeRef on useResizable"
 ## Task 3: Create `useElasticContainer`
 
 **Files:**
+
 - Create: `src/hooks/useElasticContainer.ts`
 - Create: `src/hooks/useElasticContainer.test.ts`
 
@@ -377,14 +385,21 @@ const renderElastic = (
 describe('useElasticContainer', () => {
   test('initializes size from initialPercent × container dimension', () => {
     // 0.3 × 1200 = 360
-    const { result } = renderElastic({ axis: 'horizontal', initialPercent: 0.3 })
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      initialPercent: 0.3,
+    })
     expect(result.current.size).toBe(360)
   })
 
   test('initializes pixelMin and pixelMax from percent config', () => {
     // minPercent 0.05 × 1200 → ceil(60) = 60
     // maxPercent 0.80 × 1200 → floor(960) = 960
-    const { result } = renderElastic({ axis: 'horizontal', minPercent: 0.05, maxPercent: 0.8 })
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      minPercent: 0.05,
+      maxPercent: 0.8,
+    })
     expect(result.current.pixelMin).toBe(60)
     expect(result.current.pixelMax).toBe(960)
   })
@@ -397,7 +412,12 @@ describe('useElasticContainer', () => {
 
   test('defaults initialPercent to midpoint when not provided', () => {
     // midpoint = (0.05 + 0.80) / 2 = 0.425; 0.425 × 1200 = 510
-    const { result } = renderElastic({ axis: 'horizontal', minPercent: 0.05, maxPercent: 0.8, initialPercent: undefined as unknown as number })
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      minPercent: 0.05,
+      maxPercent: 0.8,
+      initialPercent: undefined as unknown as number,
+    })
     expect(result.current.size).toBe(510)
   })
 
@@ -422,18 +442,31 @@ describe('useElasticContainer', () => {
   })
 
   test('ResizeObserver re-clamp updates pixelMin/pixelMax on container resize', () => {
-    const { result } = renderElastic({ axis: 'horizontal', minPercent: 0.05, maxPercent: 0.8 })
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      minPercent: 0.05,
+      maxPercent: 0.8,
+    })
 
     // Simulate container resize to 800px wide
     act(() => {
       vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
         width: 800,
         height: CONTAINER_HEIGHT,
-        top: 0, left: 0, right: 800, bottom: CONTAINER_HEIGHT,
-        x: 0, y: 0, toJSON: () => undefined,
+        top: 0,
+        left: 0,
+        right: 800,
+        bottom: CONTAINER_HEIGHT,
+        x: 0,
+        y: 0,
+        toJSON: () => undefined,
       } as DOMRect)
       observerCallback?.(
-        [{ contentRect: { width: 800, height: CONTAINER_HEIGHT } } as ResizeObserverEntry],
+        [
+          {
+            contentRect: { width: 800, height: CONTAINER_HEIGHT },
+          } as ResizeObserverEntry,
+        ],
         {} as ResizeObserver
       )
     })
@@ -444,12 +477,21 @@ describe('useElasticContainer', () => {
   })
 
   test('ResizeObserver clamps size when container shrinks below current size', () => {
-    const { result } = renderElastic({ axis: 'horizontal', minPercent: 0.05, maxPercent: 0.8, initialPercent: 0.7 })
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      minPercent: 0.05,
+      maxPercent: 0.8,
+      initialPercent: 0.7,
+    })
     // Initial: 0.7 × 1200 = 840px
 
     act(() => {
       observerCallback?.(
-        [{ contentRect: { width: 400, height: CONTAINER_HEIGHT } } as ResizeObserverEntry],
+        [
+          {
+            contentRect: { width: 400, height: CONTAINER_HEIGHT },
+          } as ResizeObserverEntry,
+        ],
         {} as ResizeObserver
       )
     })
@@ -496,7 +538,11 @@ import {
   type RefObject,
   type MutableRefObject,
 } from 'react'
-import { useResizable, clampSize, type UseResizableResult } from './useResizable'
+import {
+  useResizable,
+  clampSize,
+  type UseResizableResult,
+} from './useResizable'
 
 export interface UseElasticContainerOptions {
   /**
@@ -612,7 +658,9 @@ export const useElasticContainer = ({
   useLayoutEffect(() => {
     const el = containerRef.current
     if (!el) {
-      throw new Error('useElasticContainer: containerRef.current is null at mount')
+      throw new Error(
+        'useElasticContainer: containerRef.current is null at mount'
+      )
     }
 
     const rect = el.getBoundingClientRect()
@@ -620,7 +668,8 @@ export const useElasticContainer = ({
     const { newMin, newMax } = computeBounds(dimension)
 
     const effectiveInitial =
-      initialPercentRef.current ?? (minPercentRef.current + maxPercentRef.current) / 2
+      initialPercentRef.current ??
+      (minPercentRef.current + maxPercentRef.current) / 2
     const newInitial = clampSize(dimension * effectiveInitial, newMin, newMax)
 
     pixelMinRef.current = newMin
@@ -633,7 +682,9 @@ export const useElasticContainer = ({
       const entry = entries[0]
       if (!entry) return
       const dim =
-        axis === 'horizontal' ? entry.contentRect.width : entry.contentRect.height
+        axis === 'horizontal'
+          ? entry.contentRect.width
+          : entry.contentRect.height
 
       const { newMin: rMin, newMax: rMax } = computeBounds(dim)
 
@@ -694,6 +745,7 @@ git commit -m "feat(resize): add useElasticContainer — percent-bound ResizeObs
 ## Task 4: Update `DockPanel` — new props + horizontal resize handle
 
 **Files:**
+
 - Modify: `src/features/workspace/components/DockPanel.tsx`
 - Modify: `src/features/workspace/components/DockPanel.test.tsx`
 
@@ -737,90 +789,98 @@ const renderDockPanel = (
 Then add these new tests (append inside the `describe('DockPanel', ...)` block):
 
 ```typescript
-  test('renders horizontal resize handle for left dock', () => {
-    renderDockPanel({ position: 'left' })
-    const handle = screen.getByTestId('resize-handle')
-    expect(handle).toBeInTheDocument()
-    expect(handle).toHaveAttribute('aria-orientation', 'vertical')
-  })
+test('renders horizontal resize handle for left dock', () => {
+  renderDockPanel({ position: 'left' })
+  const handle = screen.getByTestId('resize-handle')
+  expect(handle).toBeInTheDocument()
+  expect(handle).toHaveAttribute('aria-orientation', 'vertical')
+})
 
-  test('renders horizontal resize handle for right dock', () => {
-    renderDockPanel({ position: 'right' })
-    const handle = screen.getByTestId('resize-handle')
-    expect(handle).toBeInTheDocument()
-    expect(handle).toHaveAttribute('aria-orientation', 'vertical')
-  })
+test('renders horizontal resize handle for right dock', () => {
+  renderDockPanel({ position: 'right' })
+  const handle = screen.getByTestId('resize-handle')
+  expect(handle).toBeInTheDocument()
+  expect(handle).toHaveAttribute('aria-orientation', 'vertical')
+})
 
-  test('horizontal resize handle is on right edge for left dock', () => {
-    renderDockPanel({ position: 'left' })
-    const handle = screen.getByTestId('resize-handle')
-    expect(handle.className).toMatch(/right-0/)
-  })
+test('horizontal resize handle is on right edge for left dock', () => {
+  renderDockPanel({ position: 'left' })
+  const handle = screen.getByTestId('resize-handle')
+  expect(handle.className).toMatch(/right-0/)
+})
 
-  test('horizontal resize handle is on left edge for right dock', () => {
-    renderDockPanel({ position: 'right' })
-    const handle = screen.getByTestId('resize-handle')
-    expect(handle.className).toMatch(/left-0/)
-  })
+test('horizontal resize handle is on left edge for right dock', () => {
+  renderDockPanel({ position: 'right' })
+  const handle = screen.getByTestId('resize-handle')
+  expect(handle.className).toMatch(/left-0/)
+})
 
-  test('side dock uses controlled width from horizontalSize prop', () => {
-    renderDockPanel({ position: 'left', horizontalSize: 480 })
-    expect(screen.getByTestId('dock-panel')).toHaveStyle({ width: '480px' })
-  })
+test('side dock uses controlled width from horizontalSize prop', () => {
+  renderDockPanel({ position: 'left', horizontalSize: 480 })
+  expect(screen.getByTestId('dock-panel')).toHaveStyle({ width: '480px' })
+})
 
-  test('side dock does not use flex basis', () => {
-    renderDockPanel({ position: 'right', horizontalSize: 360 })
-    const panel = screen.getByTestId('dock-panel')
-    expect(panel).not.toHaveStyle({ flex: '0 0 40%' })
-  })
+test('side dock does not use flex basis', () => {
+  renderDockPanel({ position: 'right', horizontalSize: 360 })
+  const panel = screen.getByTestId('dock-panel')
+  expect(panel).not.toHaveStyle({ flex: '0 0 40%' })
+})
 
-  test('horizontal handle mousedown calls onHorizontalResizeMouseDown', () => {
-    const onHorizontalResizeMouseDown = vi.fn()
-    renderDockPanel({ position: 'left', onHorizontalResizeMouseDown })
-    fireEvent.mouseDown(screen.getByTestId('resize-handle'))
-    expect(onHorizontalResizeMouseDown).toHaveBeenCalled()
-  })
+test('horizontal handle mousedown calls onHorizontalResizeMouseDown', () => {
+  const onHorizontalResizeMouseDown = vi.fn()
+  renderDockPanel({ position: 'left', onHorizontalResizeMouseDown })
+  fireEvent.mouseDown(screen.getByTestId('resize-handle'))
+  expect(onHorizontalResizeMouseDown).toHaveBeenCalled()
+})
 
-  test('left dock ArrowRight grows horizontal size', async () => {
-    const user = userEvent.setup()
-    const onHorizontalSizeAdjust = vi.fn()
-    renderDockPanel({ position: 'left', onHorizontalSizeAdjust })
-    screen.getByTestId('resize-handle').focus()
-    await user.keyboard('{ArrowRight}')
-    expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(20)
-  })
+test('left dock ArrowRight grows horizontal size', async () => {
+  const user = userEvent.setup()
+  const onHorizontalSizeAdjust = vi.fn()
+  renderDockPanel({ position: 'left', onHorizontalSizeAdjust })
+  screen.getByTestId('resize-handle').focus()
+  await user.keyboard('{ArrowRight}')
+  expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(20)
+})
 
-  test('left dock ArrowLeft shrinks horizontal size', async () => {
-    const user = userEvent.setup()
-    const onHorizontalSizeAdjust = vi.fn()
-    renderDockPanel({ position: 'left', onHorizontalSizeAdjust })
-    screen.getByTestId('resize-handle').focus()
-    await user.keyboard('{ArrowLeft}')
-    expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(-20)
-  })
+test('left dock ArrowLeft shrinks horizontal size', async () => {
+  const user = userEvent.setup()
+  const onHorizontalSizeAdjust = vi.fn()
+  renderDockPanel({ position: 'left', onHorizontalSizeAdjust })
+  screen.getByTestId('resize-handle').focus()
+  await user.keyboard('{ArrowLeft}')
+  expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(-20)
+})
 
-  test('right dock ArrowLeft grows horizontal size (invert)', async () => {
-    const user = userEvent.setup()
-    const onHorizontalSizeAdjust = vi.fn()
-    renderDockPanel({ position: 'right', onHorizontalSizeAdjust })
-    screen.getByTestId('resize-handle').focus()
-    await user.keyboard('{ArrowLeft}')
-    expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(20)
-  })
+test('right dock ArrowLeft grows horizontal size (invert)', async () => {
+  const user = userEvent.setup()
+  const onHorizontalSizeAdjust = vi.fn()
+  renderDockPanel({ position: 'right', onHorizontalSizeAdjust })
+  screen.getByTestId('resize-handle').focus()
+  await user.keyboard('{ArrowLeft}')
+  expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(20)
+})
 
-  test('vertical handle aria-valuemin/max come from verticalPixelMin/Max props', () => {
-    renderDockPanel({ position: 'bottom', verticalPixelMin: 75, verticalPixelMax: 900 })
-    const handle = screen.getByTestId('resize-handle')
-    expect(handle).toHaveAttribute('aria-valuemin', '75')
-    expect(handle).toHaveAttribute('aria-valuemax', '900')
+test('vertical handle aria-valuemin/max come from verticalPixelMin/Max props', () => {
+  renderDockPanel({
+    position: 'bottom',
+    verticalPixelMin: 75,
+    verticalPixelMax: 900,
   })
+  const handle = screen.getByTestId('resize-handle')
+  expect(handle).toHaveAttribute('aria-valuemin', '75')
+  expect(handle).toHaveAttribute('aria-valuemax', '900')
+})
 
-  test('horizontal handle aria-valuemin/max come from horizontalPixelMin/Max props', () => {
-    renderDockPanel({ position: 'left', horizontalPixelMin: 60, horizontalPixelMax: 960 })
-    const handle = screen.getByTestId('resize-handle')
-    expect(handle).toHaveAttribute('aria-valuemin', '60')
-    expect(handle).toHaveAttribute('aria-valuemax', '960')
+test('horizontal handle aria-valuemin/max come from horizontalPixelMin/Max props', () => {
+  renderDockPanel({
+    position: 'left',
+    horizontalPixelMin: 60,
+    horizontalPixelMax: 960,
   })
+  const handle = screen.getByTestId('resize-handle')
+  expect(handle).toHaveAttribute('aria-valuemin', '60')
+  expect(handle).toHaveAttribute('aria-valuemax', '960')
+})
 ```
 
 - [ ] **Step 2: Run tests to confirm they fail**
@@ -1109,6 +1169,7 @@ git commit -m "feat(dock): add horizontal resize handle + percent-bound ARIA pro
 ## Task 5: Wire `useElasticContainer` into `WorkspaceView`
 
 **Files:**
+
 - Modify: `src/features/workspace/WorkspaceView.tsx`
 - Modify: `src/features/workspace/WorkspaceView.test.tsx`
 - Modify: `src/features/workspace/WorkspaceView.integration.test.tsx`
@@ -1152,6 +1213,7 @@ Expected: all PASS (before the WorkspaceView changes — mocks prevent the jsdom
 **3a. Add import for `useElasticContainer` and `DOCK_ELASTIC_CONFIG`:**
 
 Find the imports section and add:
+
 ```typescript
 import { useElasticContainer } from '../../hooks/useElasticContainer'
 import { DOCK_ELASTIC_CONFIG } from './panelConfig'
@@ -1162,62 +1224,69 @@ Remove the old import of `clampSize` if it was only used for vertical dock (chec
 **3b. Add `dockCanvasRef` just before the `dockPosition` state:**
 
 ```typescript
-  // Ref to the dock-canvas-wrapper div; used by useElasticContainer to measure
-  // the available area for percent-based bounds.
-  const dockCanvasRef = useRef<HTMLDivElement>(null)
+// Ref to the dock-canvas-wrapper div; used by useElasticContainer to measure
+// the available area for percent-based bounds.
+const dockCanvasRef = useRef<HTMLDivElement>(null)
 ```
 
 **3c. Replace the `verticalDockResize = useResizable(...)` block (lines ~361-369 in the original) with two elastic instances:**
 
 Remove:
+
 ```typescript
-  // Vertical dock height is lifted so the value survives DockPanel unmounts.
-  const verticalDockResize = useResizable({
-    initial: 400,
-    min: 150,
-    max: 640,
-    direction: 'vertical',
-    // Bottom dock grows when dragging up from its top edge; top dock grows
-    // when dragging down from its bottom edge.
-    invert: dockPosition === 'bottom',
-  })
+// Vertical dock height is lifted so the value survives DockPanel unmounts.
+const verticalDockResize = useResizable({
+  initial: 400,
+  min: 150,
+  max: 640,
+  direction: 'vertical',
+  // Bottom dock grows when dragging up from its top edge; top dock grows
+  // when dragging down from its bottom edge.
+  invert: dockPosition === 'bottom',
+})
 ```
 
 Add:
-```typescript
-  // Two separate elastic instances — one per axis — so each size survives
-  // dock position switches and DockPanel unmounts independently.
-  const verticalDockElastic = useElasticContainer({
-    containerRef: dockCanvasRef,
-    axis: 'vertical',
-    ...DOCK_ELASTIC_CONFIG,
-    invert: dockPosition === 'bottom',
-  })
 
-  const horizontalDockElastic = useElasticContainer({
-    containerRef: dockCanvasRef,
-    axis: 'horizontal',
-    ...DOCK_ELASTIC_CONFIG,
-    invert: dockPosition === 'right',
-  })
+```typescript
+// Two separate elastic instances — one per axis — so each size survives
+// dock position switches and DockPanel unmounts independently.
+const verticalDockElastic = useElasticContainer({
+  containerRef: dockCanvasRef,
+  axis: 'vertical',
+  ...DOCK_ELASTIC_CONFIG,
+  invert: dockPosition === 'bottom',
+})
+
+const horizontalDockElastic = useElasticContainer({
+  containerRef: dockCanvasRef,
+  axis: 'horizontal',
+  ...DOCK_ELASTIC_CONFIG,
+  invert: dockPosition === 'right',
+})
 ```
 
 **3d. Update `terminalFitDeferred` (line ~579 in original):**
 
 Change:
+
 ```typescript
-  const terminalFitDeferred = isDragging || verticalDockResize.isDragging
+const terminalFitDeferred = isDragging || verticalDockResize.isDragging
 ```
 
 To:
+
 ```typescript
-  const terminalFitDeferred =
-    isDragging || verticalDockElastic.isDragging || horizontalDockElastic.isDragging
+const terminalFitDeferred =
+  isDragging ||
+  verticalDockElastic.isDragging ||
+  horizontalDockElastic.isDragging
 ```
 
 **3e. Update the `<DockPanel>` call site (lines ~582-604 in original):**
 
 Replace:
+
 ```tsx
       verticalSize={verticalDockResize.size}
       onVerticalResizeMouseDown={verticalDockResize.handleMouseDown}
@@ -1226,6 +1295,7 @@ Replace:
 ```
 
 With:
+
 ```tsx
       verticalSize={verticalDockElastic.size}
       onVerticalResizeMouseDown={verticalDockElastic.handleMouseDown}
@@ -1244,6 +1314,7 @@ With:
 **3f. Add `ref={dockCanvasRef}` to the `dock-canvas-wrapper` div (line ~700 in original):**
 
 Change:
+
 ```tsx
         <div
           data-testid="dock-canvas-wrapper"
@@ -1253,6 +1324,7 @@ Change:
 ```
 
 To:
+
 ```tsx
         <div
           ref={dockCanvasRef}
@@ -1301,6 +1373,7 @@ git commit -m "feat(workspace): wire useElasticContainer — replace vertical us
 ## Task 6: Issue #217 — Size persistence integration test
 
 **Files:**
+
 - Create: `src/features/workspace/WorkspaceView.elastic.test.tsx`
 
 - [ ] **Step 1: Write the test file**
@@ -1585,22 +1658,22 @@ git commit -m "test(workspace): prove vertical size persists across dock close/r
 
 ### Spec coverage check
 
-| Spec requirement | Covered by |
-|---|---|
-| Horizontal resize handle on left/right docks | Task 4 (DockPanel), Task 5 (WorkspaceView) |
-| Drag handle on inner edge (right of left, left of right) | Task 4 — `position === 'right' ? 'left-0' : 'right-0'` |
-| Keyboard resize (ArrowLeft/Right) for horizontal | Task 4 — `handleHorizontalKeyDown` |
-| Percent-based bounds (5%–80%) | Task 1 (panelConfig), Task 3 (useElasticContainer) |
-| `panelConfig.ts` as single tuning surface | Task 1 |
-| `useElasticContainer` shared hook | Task 3 |
-| `resetToSize` + `sizeRef` on `useResizable` | Task 2 |
-| Size survives dock close/reopen (issue #217) | Task 6 |
-| Re-clamp on container resize (ResizeObserver) | Task 3 |
-| Post-drag re-clamp | Task 3 |
-| ARIA `aria-valuemin`/`aria-valuemax` from live pixel bounds | Task 4 |
-| Terminal fit deferral includes horizontal drag | Task 5, step 3d |
-| All existing WorkspaceView tests still pass | Task 5, step 5 |
-| `panelConfig.ts` — terminal configs defined (out of scope wiring) | Task 1 |
+| Spec requirement                                                  | Covered by                                             |
+| ----------------------------------------------------------------- | ------------------------------------------------------ |
+| Horizontal resize handle on left/right docks                      | Task 4 (DockPanel), Task 5 (WorkspaceView)             |
+| Drag handle on inner edge (right of left, left of right)          | Task 4 — `position === 'right' ? 'left-0' : 'right-0'` |
+| Keyboard resize (ArrowLeft/Right) for horizontal                  | Task 4 — `handleHorizontalKeyDown`                     |
+| Percent-based bounds (5%–80%)                                     | Task 1 (panelConfig), Task 3 (useElasticContainer)     |
+| `panelConfig.ts` as single tuning surface                         | Task 1                                                 |
+| `useElasticContainer` shared hook                                 | Task 3                                                 |
+| `resetToSize` + `sizeRef` on `useResizable`                       | Task 2                                                 |
+| Size survives dock close/reopen (issue #217)                      | Task 6                                                 |
+| Re-clamp on container resize (ResizeObserver)                     | Task 3                                                 |
+| Post-drag re-clamp                                                | Task 3                                                 |
+| ARIA `aria-valuemin`/`aria-valuemax` from live pixel bounds       | Task 4                                                 |
+| Terminal fit deferral includes horizontal drag                    | Task 5, step 3d                                        |
+| All existing WorkspaceView tests still pass                       | Task 5, step 5                                         |
+| `panelConfig.ts` — terminal configs defined (out of scope wiring) | Task 1                                                 |
 
 ### No placeholders found ✓
 

--- a/docs/superpowers/specs/2026-05-17-dock-elastic-resize-design.md
+++ b/docs/superpowers/specs/2026-05-17-dock-elastic-resize-design.md
@@ -673,3 +673,5 @@ useElasticContainer              useResizable
   unmounted `DockPanel`).
 - Touch / pointer-events resize — mouse and keyboard only, matching the current
   sidebar.
+
+<!-- codex-reviewed: 2026-05-17T17:16:23Z -->

--- a/docs/superpowers/specs/2026-05-17-dock-elastic-resize-design.md
+++ b/docs/superpowers/specs/2026-05-17-dock-elastic-resize-design.md
@@ -243,20 +243,55 @@ lifecycle assertion.
 
 ### 6.4 `WorkspaceView.integration.test.tsx` additions (issue \#217)
 
-Required by issue \#217 — proves that vertical size survives `isDockOpen` flip:
+The test uses the **real** `useElasticContainer` hook (not mocked) to prove that
+resize state actually lives in `WorkspaceView` — a mock that always returns a
+fixed size cannot distinguish correct from incorrect architecture.
+
+jsdom stubs required (in `beforeEach`):
+
+```ts
+// ResizeObserver stub
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe = vi.fn()
+    disconnect = vi.fn()
+    unobserve = vi.fn()
+  }
+)
+
+// Return realistic dimensions so useElasticContainer does not throw
+vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+  width: 1200,
+  height: 800,
+  top: 0,
+  left: 0,
+  right: 1200,
+  bottom: 800,
+  x: 0,
+  y: 0,
+  toJSON: () => undefined,
+} as DOMRect)
+```
+
+Test sequence (proves issue \#217 invariant):
 
 1. Render `WorkspaceView`
-2. Mock `useElasticContainer` to expose a controlled `size` value (avoids DOM measurement in jsdom)
-3. Set `size = 500`; assert `dock-panel` has `height: 500px`
-4. Click the collapse button — assert `DockPanel` unmounts
+2. Fire `mousedown` + `mousemove` + `mouseup` on `getByTestId('resize-handle')`
+   to produce a non-default size (e.g. delta = +100 px)
+3. Assert `dock-panel` style reflects the new height
+4. Click collapse — assert `DockPanel` unmounts
 5. Click `DockPeekButton` — assert `DockPanel` remounts
-6. Assert `dock-panel` still has `height: 500px` (not the initial value)
+6. Assert `dock-panel` still has the height from step 3 (not the initial value)
 
-Additional integration tests:
+This fails if someone accidentally co-locates resize state inside `DockPanel`
+(remount would reset to `initialPercent`, not the user-set value).
 
-- Switching `dockPosition` from `bottom` to `right` preserves the horizontal
-  size independently (the two elastic instances are separate)
-- Switching `dockPosition` from `right` to `left` keeps horizontal size
+Additional integration tests (real hook, same stubs):
+
+- Position switch `bottom → right`: horizontal size retains its initial value;
+  vertical size is independent and retains its value
+- Position switch `right → left`: horizontal size persists across position flip
 
 ---
 
@@ -328,8 +363,12 @@ export const KEYBOARD_STEP_SHIFT_PX = 100
 from `panelConfig.ts` — pixel bounds for ARIA come from the
 `verticalPixelMin`/`verticalPixelMax`/`horizontalPixelMin`/`horizontalPixelMax`
 props (live values from `useElasticContainer`). `WorkspaceView.tsx` spreads
-`DOCK_ELASTIC_CONFIG` into each `useElasticContainer` call. The terminal pane
-configs are defined here but not wired in this PR.
+`DOCK_ELASTIC_CONFIG` into each `useElasticContainer` call. The terminal zone
+and pane configs (`TERMINAL_ZONE_ELASTIC_CONFIG`, `TERMINAL_PANE_ELASTIC_CONFIGS`,
+`PaneElasticConfig`) are forward-looking data definitions only — they are not
+wired to any hook in this PR and do not affect `UseElasticContainerOptions`'s
+required `containerRef`/`axis` fields. They establish the shape for future PRs
+without requiring spreading the full config object directly.
 
 ---
 
@@ -465,7 +504,7 @@ export interface UseElasticContainerResult extends UseResizableResult {
   pixelMax: number
   // Note: UseResizableResult now also includes:
   //   resetToSize(px, explicitMin?, explicitMax?): void
-  //   sizeRef: RefObject<number>
+  //   sizeRef: MutableRefObject<number>
 }
 ```
 
@@ -515,28 +554,38 @@ Then calls **`resetToSize(newInitial, newMin, newMax)`** with explicit bounds.
 
 #### `ResizeObserver` re-clamp
 
-On each observation, computes fresh `newMin`/`newMax` (integer-safe). Calls
-`setPixelMin`/`setPixelMax` (for ARIA + re-renders).
+`useElasticContainer` maintains:
 
-`useElasticContainer` maintains an `isDraggingRef: MutableRefObject<boolean>`,
-kept in sync with `useResizable.isDragging` via a `useLayoutEffect` (fires
-before paint, so the ref is current when any ResizeObserver callback fires in
-the same frame).
+- `isDraggingRef: MutableRefObject<boolean>` — kept in sync with
+  `useResizable.isDragging` via `useLayoutEffect` (fires before paint, so the
+  ref is current when any ResizeObserver callback fires in the same frame).
+- `pixelMinRef / pixelMaxRef: MutableRefObject<number>` — updated synchronously
+  with `setPixelMin`/`setPixelMax` to allow callbacks to read latest bounds.
+- `pendingReclampRef: MutableRefObject<boolean>` — set when a re-clamp is
+  deferred to post-drag.
 
-On each observation, the callback computes `newMin`/`newMax` (integer-safe,
-with tiny-container guard applied). Synchronously writes
-`pixelMinRef.current = newMin` and `pixelMaxRef.current = newMax`. Calls
-`setPixelMin(newMin)`, `setPixelMax(newMax)` for ARIA + re-renders.
+On each observation, the callback:
 
-**During active drag (`isDraggingRef.current === true`):** defers `resetToSize`
-but updates refs and enqueues state updates. Marks a pending-reclamp flag
-(`pendingReclampRef.current = true`). **After `mouseup`** (detected via a
-`useEffect` on `isDragging` that fires when it transitions `true → false`):
-calls `resetToSize(sizeRef.current, pixelMinRef.current, pixelMaxRef.current)`
-if `pendingReclampRef.current` is true, then clears the flag.
+1. Computes `newMin`/`newMax` (integer-safe, tiny-container guard applied).
+2. Synchronously writes `pixelMinRef.current = newMin`, `pixelMaxRef.current = newMax`.
+3. Calls `setPixelMin(newMin)`, `setPixelMax(newMax)`.
 
-**When not dragging:** reads the current committed size via `sizeRef.current`.
-Calls `resetToSize(sizeRef.current, newMin, newMax)`.
+**During active drag:** defers `resetToSize` (avoids disrupting the in-progress
+drag). Sets `pendingReclampRef.current = true`. The `setPixelMin`/`setPixelMax`
+state update causes a re-render → `useResizable` is called with fresh `min`/`max`
+→ its drag effect re-registers with new bounds on the next render. Subsequent
+`mousemove` events are clamped by the fresh bounds after that render. There is
+a one-frame window where in-progress RAF sizes may be clamped against previous
+bounds — this is the documented acceptable race.
+
+**After `mouseup`** (detected via `useEffect` watching `isDragging`, firing on
+`true → false` transition): calls
+`resetToSize(sizeRef.current, pixelMinRef.current, pixelMaxRef.current)` if
+`pendingReclampRef.current` is true, then clears the flag. This closes the
+case where no `mousemove` fired after the bounds update.
+
+**When not dragging:** calls `resetToSize(sizeRef.current, newMin, newMax)`
+immediately (no deferral needed).
 
 #### Tiny-container guard
 
@@ -544,8 +593,9 @@ If `pixelMin >= pixelMax` after integer rounding (exact threshold depends on
 fractional CSS pixels returned by `getBoundingClientRect()` and the configured
 percent values; not a fixed pixel dimension), the hook silently forces
 `pixelMax = pixelMin` in production and throws an invariant error in
-development. (No `console.warn` — the project lint rule blocks all `console.*`
-calls; an invariant throw is the correct dev-mode signal.)
+development. Use `import.meta.env.DEV` (Vite's dev-mode flag, available in
+this renderer) to guard the throw — do not use `process.env.NODE_ENV`.
+(No `console.warn` — the project lint rule blocks all `console.*` calls.)
 The result is equal bounds (`min === max`), which is valid input for
 `useResizable` — `clampSize(value, n, n)` always returns `n` correctly.
 The 5 %–80 % invariant is relaxed for this edge case ("size stays at

--- a/docs/superpowers/specs/2026-05-17-dock-elastic-resize-design.md
+++ b/docs/superpowers/specs/2026-05-17-dock-elastic-resize-design.md
@@ -187,9 +187,10 @@ dragging changes the available terminal width just as sidebar dragging does.
 
 ### jsdom test strategy
 
-Since `getBoundingClientRect()` returns zero in jsdom, all WorkspaceView test
-files that render `WorkspaceView` (`.test.tsx`, `.integration.test.tsx`, etc.)
-must mock `useElasticContainer` at the module level:
+Two categories of WorkspaceView tests, handled differently:
+
+**All existing WorkspaceView test files** (`.test.tsx`, `.integration.test.tsx`,
+etc.) add a module-level mock to avoid zero-dimension throws:
 
 ```ts
 vi.mock('../../hooks/useElasticContainer', () => ({
@@ -206,8 +207,35 @@ vi.mock('../../hooks/useElasticContainer', () => ({
 }))
 ```
 
-The issue \#217 integration test overrides `size` per test to drive the
-lifecycle assertion.
+**Issue \#217 persistence test** lives in a **new, separate file**
+(`WorkspaceView.elastic.test.tsx`) that does **not** mock `useElasticContainer`.
+It uses the real hook with DOM stubs:
+
+```ts
+// ResizeObserver stub
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe = vi.fn()
+    disconnect = vi.fn()
+    unobserve = vi.fn()
+  }
+)
+// Realistic container dimensions (avoids the zero-dim throw)
+vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+  width: 1200,
+  height: 800,
+  top: 0,
+  left: 0,
+  right: 1200,
+  bottom: 800,
+  x: 0,
+  y: 0,
+  toJSON: () => undefined,
+} as DOMRect)
+```
+
+This cleanly separates mocked tests from the real-hook persistence proof.
 
 ---
 
@@ -326,8 +354,11 @@ export const TERMINAL_ZONE_ELASTIC_CONFIG = {
 /**
  * Per-pane elastic config descriptor for TerminalZone's 1–4 pane splits.
  * The terminal zone can render 1, 2, 3, or 4 panes simultaneously; each pane
- * gets its own useElasticContainer instance. The config shape matches
- * UseElasticContainerOptions so future wiring can spread it directly.
+ * gets its own useElasticContainer instance.
+ *
+ * This interface intentionally omits `containerRef` and `axis` — those are
+ * call-site concerns (the caller supplies the ref to the pane's parent element
+ * and knows its axis). It is NOT directly spreadable into UseElasticContainerOptions.
  *
  * Out of scope for this PR — data structure is defined here to avoid a future
  * breaking change to panelConfig.ts when pane resize is implemented.

--- a/docs/superpowers/specs/2026-05-17-dock-elastic-resize-design.md
+++ b/docs/superpowers/specs/2026-05-17-dock-elastic-resize-design.md
@@ -1,0 +1,594 @@
+# Dock Elastic Resize — Design Spec
+
+## 1. Context and Problem Statement
+
+### Current state
+
+`DockPanel` supports four positions (top, bottom, left, right). Vertical docks
+(top/bottom) have a drag handle wired through `verticalDockResize` lifted to
+`WorkspaceView`, but:
+
+- The min/max bounds (150 px–640 px) are hardcoded in two places:
+  `DockPanel.tsx` constants and the `useResizable` call in `WorkspaceView.tsx`.
+- The 640 px max is too restrictive — it prevents the panel from growing
+  beyond ~40 % of a standard 1440 px screen.
+- Horizontal docks (left/right) have **no resize handle at all**. Their width
+  is a fixed `flex: 0 0 40%` string with no drag or keyboard adjustment.
+
+### Issue \#217
+
+PR \#215 introduced height-persistence (resized size survives close/reopen)
+but no automated test covers it. Issue \#217 is explicitly deferred to this
+follow-up PR.
+
+### Goals
+
+1. **Horizontal resize** — left and right dock positions gain a drag handle on
+   the inner edge (right edge of left-dock, left edge of right-dock), matching
+   the sidebar-handle visual style. Width is fully adjustable, keyboard-
+   navigable, and ARIA-annotated.
+2. **Configurable, percent-based bounds** — min/max expressed as a fraction of
+   the container's live dimension (default: 5 %–80 %). All constants live in a
+   single config file (`panelConfig.ts`); a reviewer changes one value to tune the range.
+3. **Shared resize logic via `useElasticContainer`** — a new hook that
+   encapsulates percent→pixel conversion and `ResizeObserver` tracking. Dock
+   (vertical + horizontal) and, in a future PR, TerminalZone all use the same
+   hook. The name intentionally avoids panel-specific terminology.
+4. **Tests** — unit tests for `useElasticContainer`; new DockPanel handle tests
+   for left/right; WorkspaceView integration test covering issue \#217.
+
+### Size-clamping invariant
+
+Whenever the container's observed dimension changes (via `ResizeObserver`),
+`useElasticContainer` re-clamps the stored pixel size against the updated pixel
+bounds derived from the new dimension. Size is always stored as pixels; bounds
+recomputation is the hook's responsibility, not the caller's.
+
+**Invariant scope:** the 5 %–80 % contract is guaranteed when
+`Math.ceil(dimension × minPercent) < Math.floor(dimension × maxPercent)`
+(a condition, not a fixed px threshold — exact dimension depends on fractional
+CSS pixels and config values). Degenerate containers and active-drag +
+concurrent container-resize scenarios are best-effort: the post-drag re-clamp
+closes the latter case after `mouseup`.
+
+---
+
+## 4. DockPanel Changes
+
+### New props
+
+```ts
+interface DockPanelBaseProps {
+  // existing vertical props (unchanged) ...
+  verticalSize: number
+  onVerticalResizeMouseDown: (event: MouseEvent) => void
+  isVerticalResizing: boolean
+  onVerticalSizeAdjust: (delta: number) => void
+  verticalPixelMin: number // NEW — from useElasticContainer.pixelMin
+  verticalPixelMax: number // NEW — from useElasticContainer.pixelMax
+
+  // NEW horizontal props (ignored when position === 'top' | 'bottom')
+  horizontalSize: number
+  onHorizontalResizeMouseDown: (event: MouseEvent) => void
+  isHorizontalResizing: boolean
+  onHorizontalSizeAdjust: (delta: number) => void
+  horizontalPixelMin: number
+  horizontalPixelMax: number
+}
+```
+
+### Container style
+
+```ts
+// vertical dock: controlled height
+containerStyle = { height: `${verticalSize}px` }
+
+// horizontal dock: controlled width (was: flex: 0 0 40%)
+containerStyle = { width: `${horizontalSize}px` }
+```
+
+`SIDE_DOCK_BASIS = '40%'` and the hardcoded `DRAWER_MIN`/`DRAWER_MAX` constants
+are **removed** from `DockPanel.tsx`. All bounds come from `panelConfig.ts`.
+
+### Horizontal resize handle
+
+Rendered when `position === 'left' | 'right'` at the inner edge:
+
+- `right-dock` handle: `left-0` edge (faces terminal zone, mirrors sidebar handle)
+- `left-dock` handle: `right-0` edge
+
+```tsx
+{
+  !isVerticalDock && (
+    <div
+      data-testid="resize-handle"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize panel"
+      aria-valuenow={horizontalSize}
+      aria-valuemin={horizontalPixelMin}
+      aria-valuemax={horizontalPixelMax}
+      tabIndex={0}
+      onMouseDown={onHorizontalResizeMouseDown}
+      onKeyDown={/* horizontal keyboard handler */}
+      className={`absolute ${horizontalHandleEdgeClass} top-0 bottom-0 w-1 cursor-col-resize ...`}
+    />
+  )
+}
+```
+
+Keyboard handler mirrors the vertical one (ArrowLeft/ArrowRight for left/right
+docks; direction mapping matches the drag `invert` logic).
+
+### ARIA updates
+
+Vertical handle `aria-valuemin`/`aria-valuemax` now come from `verticalPixelMin`
+/ `verticalPixelMax` (props) instead of the removed `DRAWER_MIN`/`DRAWER_MAX`
+constants. Home/End keyboard handlers use these prop values.
+
+---
+
+## 5. WorkspaceView Wiring
+
+### Definitive `useElasticContainer` declarations (consolidated)
+
+```ts
+// Ref to the dock-canvas-wrapper div (parent container, not the dock itself)
+const dockCanvasRef = useRef<HTMLDivElement>(null)
+
+// Bottom dock: drag UP grows panel → invert=true
+// Top dock: drag DOWN grows panel → invert=false
+// Right dock: drag LEFT grows panel → invert=true
+// Left dock: drag RIGHT grows panel → invert=false
+const verticalDockElastic = useElasticContainer({
+  containerRef: dockCanvasRef,
+  axis: 'vertical',
+  ...DOCK_ELASTIC_CONFIG,
+  invert: dockPosition === 'bottom',
+})
+
+const horizontalDockElastic = useElasticContainer({
+  containerRef: dockCanvasRef,
+  axis: 'horizontal',
+  ...DOCK_ELASTIC_CONFIG,
+  invert: dockPosition === 'right',
+})
+```
+
+`dockCanvasRef` is attached to `<div data-testid="dock-canvas-wrapper">`.
+The old `verticalDockResize = useResizable(...)` call is **removed**.
+
+### Terminal fit deferral
+
+The existing terminal fit deferral (`deferTerminalFit`) must include both drag
+states — add `horizontalDockElastic.isDragging` alongside the existing
+`verticalDockElastic.isDragging` and sidebar `isDragging`. Horizontal dock
+dragging changes the available terminal width just as sidebar dragging does.
+
+### DockPanel call site
+
+```tsx
+<DockPanel
+  // ... existing props ...
+  verticalSize={verticalDockElastic.size}
+  onVerticalResizeMouseDown={verticalDockElastic.handleMouseDown}
+  isVerticalResizing={verticalDockElastic.isDragging}
+  onVerticalSizeAdjust={verticalDockElastic.adjustBy}
+  verticalPixelMin={verticalDockElastic.pixelMin}
+  verticalPixelMax={verticalDockElastic.pixelMax}
+  horizontalSize={horizontalDockElastic.size}
+  onHorizontalResizeMouseDown={horizontalDockElastic.handleMouseDown}
+  isHorizontalResizing={horizontalDockElastic.isDragging}
+  onHorizontalSizeAdjust={horizontalDockElastic.adjustBy}
+  horizontalPixelMin={horizontalDockElastic.pixelMin}
+  horizontalPixelMax={horizontalDockElastic.pixelMax}
+/>
+```
+
+### jsdom test strategy
+
+Since `getBoundingClientRect()` returns zero in jsdom, all WorkspaceView test
+files that render `WorkspaceView` (`.test.tsx`, `.integration.test.tsx`, etc.)
+must mock `useElasticContainer` at the module level:
+
+```ts
+vi.mock('../../hooks/useElasticContainer', () => ({
+  useElasticContainer: vi.fn(() => ({
+    size: 400,
+    isDragging: false,
+    handleMouseDown: vi.fn(),
+    adjustBy: vi.fn(),
+    resetToSize: vi.fn(),
+    sizeRef: { current: 400 },
+    pixelMin: 40,
+    pixelMax: 640,
+  })),
+}))
+```
+
+The issue \#217 integration test overrides `size` per test to drive the
+lifecycle assertion.
+
+---
+
+## 6. Test Plan
+
+### 6.1 `useResizable.test.ts` additions
+
+- `resetToSize` clamps to `[min, max]`
+- `resetToSize` with explicit bounds clamps to the provided bounds
+- `resetToSize` during active drag re-anchors `startSize` so next `mousemove`
+  continues from the reset position
+- `sizeRef.current` updates synchronously after `resetToSize`
+
+### 6.2 `useElasticContainer.test.ts` (new file)
+
+- Initialization sets size from `initialPercent`
+- Initialization throws when `containerRef.current` is null
+- Initialization throws when percent bounds are invalid (`minPercent >= maxPercent`)
+- `ResizeObserver` re-clamp updates `pixelMin`/`pixelMax` and clamps size
+- `ResizeObserver` defers `resetToSize` during active drag and fires post-drag
+- Tiny-container guard: production forces `pixelMax = pixelMin`, dev throws
+- StrictMode idempotency: double-running the initialization effect produces the
+  same final state
+
+### 6.3 `DockPanel.test.tsx` additions
+
+- Renders horizontal resize handle for `position='left'` and `position='right'`
+- Does not render resize handle for `position='top'` and `position='bottom'` — wait, vertical IS rendered. Clarification: renders resize handle for ALL four positions (vertical for top/bottom, horizontal for left/right)
+- Horizontal handle mousedown calls `onHorizontalResizeMouseDown`
+- Horizontal handle keyboard ArrowLeft/ArrowRight calls `onHorizontalSizeAdjust`
+- Side dock uses `width: ${horizontalSize}px` (not the old `flex: 0 0 40%`)
+- `aria-valuemin`/`aria-valuemax` on vertical handle come from `verticalPixelMin`/`verticalPixelMax` props
+
+### 6.4 `WorkspaceView.integration.test.tsx` additions (issue \#217)
+
+Required by issue \#217 — proves that vertical size survives `isDockOpen` flip:
+
+1. Render `WorkspaceView`
+2. Mock `useElasticContainer` to expose a controlled `size` value (avoids DOM measurement in jsdom)
+3. Set `size = 500`; assert `dock-panel` has `height: 500px`
+4. Click the collapse button — assert `DockPanel` unmounts
+5. Click `DockPeekButton` — assert `DockPanel` remounts
+6. Assert `dock-panel` still has `height: 500px` (not the initial value)
+
+Additional integration tests:
+
+- Switching `dockPosition` from `bottom` to `right` preserves the horizontal
+  size independently (the two elastic instances are separate)
+- Switching `dockPosition` from `right` to `left` keeps horizontal size
+
+---
+
+## 3. Configuration — `src/features/workspace/panelConfig.ts`
+
+All numeric constants that were previously hardcoded in `DockPanel.tsx` and
+`WorkspaceView.tsx` move here. This is the **single tuning surface** for all
+panel size constraints in the workspace.
+
+```ts
+/**
+ * Dock panel elastic config — used by WorkspaceView's two useElasticContainer
+ * instances (one for vertical dock size, one for horizontal dock size).
+ */
+export const DOCK_ELASTIC_CONFIG = {
+  minPercent: 0.05,
+  maxPercent: 0.8,
+  initialPercent: 0.3,
+} as const
+
+/**
+ * Terminal zone outer elastic config — for future useElasticContainer wiring
+ * of the whole terminal zone. Reserved now so the config is the single tuning
+ * surface when that PR lands.
+ */
+export const TERMINAL_ZONE_ELASTIC_CONFIG = {
+  minPercent: 0.1,
+  maxPercent: 0.9,
+  initialPercent: 0.5,
+} as const
+
+/**
+ * Per-pane elastic config descriptor for TerminalZone's 1–4 pane splits.
+ * The terminal zone can render 1, 2, 3, or 4 panes simultaneously; each pane
+ * gets its own useElasticContainer instance. The config shape matches
+ * UseElasticContainerOptions so future wiring can spread it directly.
+ *
+ * Out of scope for this PR — data structure is defined here to avoid a future
+ * breaking change to panelConfig.ts when pane resize is implemented.
+ */
+export interface PaneElasticConfig {
+  minPercent: number
+  maxPercent: number
+  /**
+   * undefined = compute as 1/paneCount at runtime (equal share default).
+   * Set to a fixed fraction to pin the pane's initial size.
+   */
+  initialPercent: number | undefined
+}
+
+/**
+ * Elastic config for each pane slot (index 0–3 for pane 1–4).
+ * When fewer than 4 panes are shown, only the first `paneCount` entries
+ * are used.
+ */
+export const TERMINAL_PANE_ELASTIC_CONFIGS: PaneElasticConfig[] = [
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+]
+
+/** Keyboard resize step sizes (pixels), shared by all panels. */
+export const KEYBOARD_STEP_PX = 20
+export const KEYBOARD_STEP_SHIFT_PX = 100
+```
+
+`DockPanel.tsx` imports **only `KEYBOARD_STEP_PX` and `KEYBOARD_STEP_SHIFT_PX`**
+from `panelConfig.ts` — pixel bounds for ARIA come from the
+`verticalPixelMin`/`verticalPixelMax`/`horizontalPixelMin`/`horizontalPixelMax`
+props (live values from `useElasticContainer`). `WorkspaceView.tsx` spreads
+`DOCK_ELASTIC_CONFIG` into each `useElasticContainer` call. The terminal pane
+configs are defined here but not wired in this PR.
+
+---
+
+## 2. `useElasticContainer` Hook
+
+### Location
+
+`src/hooks/useElasticContainer.ts` (sibling of `src/hooks/useResizable.ts`)
+
+### Purpose
+
+A thin wrapper over `useResizable` that adds percent-bound tracking, a
+`ResizeObserver`, and correct percent-to-pixel conversion. The hook creates one
+instance per axis; `WorkspaceView` creates two (vertical and horizontal).
+
+- A `containerRef` the caller attaches to the **parent available-area element**
+  (not the dock panel itself — attaching to the panel creates self-referential
+  bounds).
+- A `ResizeObserver` that watches `containerRef` and recomputes pixel bounds
+  whenever the observed dimension changes, then re-clamps the current size.
+- Percent→pixel conversion: `pixelMin = Math.ceil(dimension × minPercent)`,
+  `pixelMax = Math.floor(dimension × maxPercent)`.
+
+`useResizable`'s existing logic is unchanged. The hook gains two new public API
+members (`resetToSize` and `sizeRef`) to support `useElasticContainer`.
+
+### Required `useResizable` API extension
+
+`useElasticContainer` needs to set an absolute size after measuring the
+container. `adjustBy(delta)` is not suitable because it clamps against stale
+closure bounds. The `useResizable` implementation gains two new public API members; all
+existing logic is unchanged.
+
+**Add two members to `UseResizableResult`:**
+
+```ts
+// New members on UseResizableResult
+resetToSize: (px: number, explicitMin?: number, explicitMax?: number) => void
+/** Synchronous read of the last committed size; safe to read in callbacks. */
+sizeRef: MutableRefObject<number>  // MutableRefObject (not readonly RefObject)
+```
+
+Implementation:
+
+1. `cancelPendingSize()` — stops any in-flight RAF.
+2. Compute `nextSize = clampSize(px, explicitMin ?? min, explicitMax ?? max)`.
+3. `commitSize(nextSize)`.
+4. Always update `previewSize.current = nextSize` (unconditionally, not only
+   during drag) so `adjustBy` in `commit-on-end` mode reads a fresh baseline.
+5. If `isDraggingRef.current`, also re-anchor drag baselines:
+   `startPos.current = currentPos.current`, `startSize.current = nextSize`.
+
+When explicit bounds are provided they bypass stale closure values.
+
+**Test-mock update required:** any test that mocks `useResizable`'s return value
+must add both new members:
+
+```ts
+resetToSize: vi.fn(),
+sizeRef: { current: 0 },
+```
+
+The existing `useResizable` unit tests do not mock themselves; only tests that
+mock the hook at a higher level are affected.
+
+### `containerRef` ownership
+
+`containerRef` **must be attached to the parent available-area element** — the
+element whose shrinking or growing changes how much space the dock can occupy
+(e.g. the `dock-canvas-wrapper` div in `WorkspaceView`). It must **not** be
+attached to the dock panel itself. Attaching it to the panel would create a
+self-referential loop where the bounds are derived from the panel's own current
+size.
+
+### API
+
+```ts
+export interface UseElasticContainerOptions {
+  /**
+   * Ref attached to the *parent* container that defines the available space
+   * (not the resizable element itself — see ownership note above).
+   *
+   * **Pre-condition (hard):** `containerRef.current` MUST be non-null when the
+   * first `useLayoutEffect` fires. Violation throws in both development and
+   * production — there is no silent fallback or recovery path.
+   *
+   * **Mount-time constant:** `containerRef` (the ref object itself) must not
+   * change after mount. The `ResizeObserver` is attached once to the element
+   * present at first layout effect and never reconnected. If the observed
+   * element is replaced, behavior is undefined.
+   */
+  containerRef: RefObject<Element | null>
+  /**
+   * Which dimension to observe and use for percent → pixel conversion.
+   * Maps directly to `useResizable.direction` (horizontal → clientX,
+   * vertical → clientY for drag tracking).
+   *
+   * **Mount-time constant.** Changing after mount results in undefined behavior.
+   * Callers must create separate hook instances per axis (one for vertical dock
+   * size, one for horizontal) so that each size survives position switches.
+   */
+  axis: 'horizontal' | 'vertical'
+  /**
+   * Fraction of available dimension for minimum size, e.g. 0.05.
+   * Pre-condition: 0 < minPercent < maxPercent ≤ 1. Throws if violated.
+   * **Mount-time constant** — changes after mount are ignored.
+   */
+  minPercent: number
+  /**
+   * Fraction of available dimension for maximum size, e.g. 0.80.
+   * **Mount-time constant** — changes after mount are ignored.
+   */
+  maxPercent: number
+  /**
+   * Initial size as a fraction of the available dimension at mount.
+   * Defaults to (minPercent + maxPercent) / 2 when omitted.
+   * Clamped to [minPercent, maxPercent].
+   * **Mount-time constant** — used only during initialization.
+   */
+  initialPercent?: number
+  /** Forwarded verbatim to useResizable. */
+  updateMode?: 'live' | 'commit-on-end'
+  /** Forwarded verbatim to useResizable. */
+  invert?: boolean
+  /** Forwarded verbatim to useResizable. */
+  onDragPreview?: (size: number) => void
+}
+
+export interface UseElasticContainerResult extends UseResizableResult {
+  /** Current lower pixel bound; use for aria-valuemin and keyboard Home. */
+  pixelMin: number
+  /** Current upper pixel bound; use for aria-valuemax and keyboard End. */
+  pixelMax: number
+  // Note: UseResizableResult now also includes:
+  //   resetToSize(px, explicitMin?, explicitMax?): void
+  //   sizeRef: RefObject<number>
+}
+```
+
+### Behaviour contract
+
+#### First-render bootstrap
+
+`useElasticContainer` calls `useResizable` with placeholder values
+`{ initial: 0, min: 0, max: Number.MAX_SAFE_INTEGER }` on the first render.
+These are never painted: the initialization `useLayoutEffect` fires before the
+browser paints and replaces them with correct values.
+
+#### Bound computation — integer-safe
+
+To prevent the `Math.round` in `clampSize` from producing a value below the
+minimum:
+
+```
+pixelMin = Math.ceil(dimension * minPercent)
+pixelMax = Math.floor(dimension * maxPercent)
+```
+
+Any clamped-then-rounded size is guaranteed ≥ `pixelMin` and ≤ `pixelMax`.
+
+#### Initialization (`useLayoutEffect`, deps `[]` — idempotent, mount only)
+
+`axis` is a mount-time constant so the initialization effect has empty deps.
+React StrictMode runs setup/cleanup/setup in development — the effect must be
+idempotent. Percent options are captured via `useRef(initialValue)` on first
+render; refs are never reassigned.
+
+Asserts `containerRef.current !== null` (throws in both dev and prod — no
+fallback). Validates `0 < minPercent < maxPercent ≤ 1` (throws). Reads
+`getBoundingClientRect()`. Computes, **in this order:**
+
+1. `newMin = Math.ceil(dim × minPercent)`
+2. `newMax = Math.floor(dim × maxPercent)`
+3. Apply tiny-container guard: in development, throw invariant error if
+   `newMin >= newMax`; in production, force `newMax = newMin` silently.
+4. `effective = initialPercent ?? (minPercent + maxPercent) / 2`
+5. `newInitial = clampSize(dim × effective, newMin, newMax)`
+
+Calls `setPixelMin(newMin)`, `setPixelMax(newMax)`, and synchronously
+writes `pixelMinRef.current = newMin`, `pixelMaxRef.current = newMax` (internal
+refs used by the post-drag re-clamp to read latest bounds without a re-render).
+Then calls **`resetToSize(newInitial, newMin, newMax)`** with explicit bounds.
+
+#### `ResizeObserver` re-clamp
+
+On each observation, computes fresh `newMin`/`newMax` (integer-safe). Calls
+`setPixelMin`/`setPixelMax` (for ARIA + re-renders).
+
+`useElasticContainer` maintains an `isDraggingRef: MutableRefObject<boolean>`,
+kept in sync with `useResizable.isDragging` via a `useLayoutEffect` (fires
+before paint, so the ref is current when any ResizeObserver callback fires in
+the same frame).
+
+On each observation, the callback computes `newMin`/`newMax` (integer-safe,
+with tiny-container guard applied). Synchronously writes
+`pixelMinRef.current = newMin` and `pixelMaxRef.current = newMax`. Calls
+`setPixelMin(newMin)`, `setPixelMax(newMax)` for ARIA + re-renders.
+
+**During active drag (`isDraggingRef.current === true`):** defers `resetToSize`
+but updates refs and enqueues state updates. Marks a pending-reclamp flag
+(`pendingReclampRef.current = true`). **After `mouseup`** (detected via a
+`useEffect` on `isDragging` that fires when it transitions `true → false`):
+calls `resetToSize(sizeRef.current, pixelMinRef.current, pixelMaxRef.current)`
+if `pendingReclampRef.current` is true, then clears the flag.
+
+**When not dragging:** reads the current committed size via `sizeRef.current`.
+Calls `resetToSize(sizeRef.current, newMin, newMax)`.
+
+#### Tiny-container guard
+
+If `pixelMin >= pixelMax` after integer rounding (exact threshold depends on
+fractional CSS pixels returned by `getBoundingClientRect()` and the configured
+percent values; not a fixed pixel dimension), the hook silently forces
+`pixelMax = pixelMin` in production and throws an invariant error in
+development. (No `console.warn` — the project lint rule blocks all `console.*`
+calls; an invariant throw is the correct dev-mode signal.)
+The result is equal bounds (`min === max`), which is valid input for
+`useResizable` — `clampSize(value, n, n)` always returns `n` correctly.
+The 5 %–80 % invariant is relaxed for this edge case ("size stays at
+`pixelMin`"). This is a degenerate case for effectively zero-dimension
+containers, not a normal operating condition.
+
+#### Other behaviours
+
+- **Drag** — delegates to `useResizable`. `min`/`max` passed per render reflect
+  current `pixelMin`/`pixelMax` state. The existing `useResizable` drag effect
+  already lists `[min, max]` in its deps (verified in `src/hooks/useResizable.ts`
+  line 235); when `pixelMin`/`pixelMax` state changes, React re-registers the
+  drag handler with fresh bounds on the next render.
+- **Keyboard** — delegates to `useResizable.adjustBy`.
+- **Cleanup** — `ResizeObserver` disconnected on unmount.
+
+### Relationship
+
+```
+useElasticContainer              useResizable
+┌──────────────────────┐         ┌─────────────────────────────┐
+│ containerRef         │         │ min, max  (pixels, from     │
+│ axis                 │ calls ─▶│   pixelMin/pixelMax state)  │
+│ minPercent           │         │ direction                   │
+│ maxPercent           │         │ invert                      │
+│ ResizeObserver       │         │ updateMode                  │
+│ re-clamp on resize   │         │ onDragPreview               │
+└──────────────────────┘         └─────────────────────────────┘
+          │                                 │
+          │   returns UseElasticContainerResult:
+          │     { ...UseResizableResult,    │
+          │       pixelMin, pixelMax }      │
+          └──────────────────────────────── ┘
+```
+
+---
+
+### Non-goals (this PR)
+
+- TerminalZone resize — `useElasticContainer` is wired there in a follow-up.
+- Persistence across page refreshes — size is in-memory (`WorkspaceView` React
+  state) only; the in-memory approach satisfies issue \#217 (size survives
+  the `isDockOpen` flip because state lives in `WorkspaceView`, not in the
+  unmounted `DockPanel`).
+- Touch / pointer-events resize — mouse and keyboard only, matching the current
+  sidebar.

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -13,6 +13,18 @@ const terminalZonePropsSpy = vi.hoisted(() => vi.fn())
 // Mock all WorkspaceView dependencies
 vi.mock('../sessions/hooks/useSessionManager')
 vi.mock('../../hooks/useResizable')
+vi.mock('../../hooks/useElasticContainer', () => ({
+  useElasticContainer: vi.fn(() => ({
+    size: 400,
+    isDragging: false,
+    handleMouseDown: vi.fn(),
+    adjustBy: vi.fn(),
+    resetToSize: vi.fn(),
+    sizeRef: { current: 400 },
+    pixelMin: 40,
+    pixelMax: 640,
+  })),
+}))
 vi.mock('./hooks/useNotifyInfo')
 vi.mock('../agent-status/hooks/useAgentStatus')
 vi.mock('../diff/hooks/useGitStatus')
@@ -142,6 +154,8 @@ describe('WorkspaceView - Command Palette Integration', () => {
       isDragging: false,
       handleMouseDown: vi.fn(),
       adjustBy: vi.fn(),
+      resetToSize: vi.fn(),
+      sizeRef: { current: 272 },
     })
 
     // Mock useNotifyInfo

--- a/src/features/workspace/WorkspaceView.elastic.test.tsx
+++ b/src/features/workspace/WorkspaceView.elastic.test.tsx
@@ -1,0 +1,218 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { WorkspaceView } from './WorkspaceView'
+
+vi.mock('../terminal/components/TerminalPane', () => ({
+  TerminalPane: vi.fn(() => (
+    <div data-testid="terminal-pane-mock">Mocked TerminalPane</div>
+  )),
+}))
+
+vi.mock('../agent-status/hooks/useAgentStatus', () => ({
+  useAgentStatus: vi.fn(() => ({
+    isActive: false,
+    agentType: null,
+    modelId: null,
+    modelDisplayName: null,
+    version: null,
+    sessionId: null,
+    agentSessionId: null,
+    contextWindow: null,
+    cost: null,
+    rateLimits: null,
+    numTurns: 0,
+    toolCalls: { total: 0, byType: {}, active: null },
+    recentToolCalls: [],
+    testRun: null,
+  })),
+}))
+
+vi.mock('../terminal/services/terminalService', () => ({
+  createTerminalService: vi.fn(() => ({
+    spawn: vi.fn().mockResolvedValue({ sessionId: 'sess-1', pid: 1, cwd: '~' }),
+    write: vi.fn().mockResolvedValue(undefined),
+    resize: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onData: vi.fn((): (() => void) => (): void => {}),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onExit: vi.fn((): (() => void) => (): void => {}),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onError: vi.fn((): (() => void) => (): void => {}),
+    listSessions: vi.fn().mockResolvedValue({
+      activeSessionId: 'sess-1',
+      sessions: [
+        {
+          id: 'sess-1',
+          cwd: '~',
+          status: {
+            kind: 'Alive',
+            pid: 1234,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    }),
+    setActiveSession: vi.fn().mockResolvedValue(undefined),
+    reorderSessions: vi.fn().mockResolvedValue(undefined),
+    updateSessionCwd: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+vi.mock('../editor/hooks/useCodeMirror', () => ({
+  useCodeMirror: vi.fn(() => ({
+    editorView: null,
+    updateContent: vi.fn(),
+    setContainer: vi.fn(),
+  })),
+}))
+
+vi.mock('../editor/hooks/useVimMode', () => ({
+  useVimMode: vi.fn(() => 'NORMAL'),
+}))
+
+vi.mock('../editor/services/languageService', () => ({
+  getLanguageExtension: vi.fn(() => []),
+}))
+
+vi.mock('../diff/hooks/useGitStatus', () => ({
+  useGitStatus: vi.fn(() => ({
+    files: [],
+    filesCwd: '.',
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    idle: false,
+  })),
+}))
+
+vi.mock('../diff/hooks/useFileDiff', () => ({
+  useFileDiff: vi.fn(() => ({ diff: null, loading: false, error: null })),
+}))
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe = vi.fn()
+      disconnect = vi.fn()
+      unobserve = vi.fn()
+    }
+  )
+
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: 1200,
+    height: 800,
+    top: 0,
+    left: 0,
+    right: 1200,
+    bottom: 800,
+    x: 0,
+    y: 0,
+    toJSON: (): undefined => undefined,
+  } as DOMRect)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+const readDockPanelHeight = (): number =>
+  parseInt(screen.getByTestId('dock-panel').style.height, 10)
+
+const readDockPanelWidth = (): number =>
+  parseInt(screen.getByTestId('dock-panel').style.width, 10)
+
+describe('WorkspaceView elastic resize size persistence', () => {
+  test('vertical size survives dock close and reopen', async () => {
+    const user = userEvent.setup()
+    render(<WorkspaceView />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+    })
+
+    const handle = screen.getByTestId('resize-handle')
+
+    const initialHeight = readDockPanelHeight()
+
+    fireEvent.mouseDown(handle, { clientY: 500 })
+    fireEvent.mouseMove(document, { clientY: 400 })
+    fireEvent.mouseUp(document)
+
+    await waitFor(() => {
+      const nextHeight = readDockPanelHeight()
+
+      expect(nextHeight).toBeGreaterThan(initialHeight)
+    })
+
+    const heightAfterResize = readDockPanelHeight()
+
+    await user.click(screen.getByRole('button', { name: /collapse panel/i }))
+    expect(screen.queryByTestId('dock-panel')).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: /show panel docked bottom/i })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+    })
+
+    const heightAfterReopen = readDockPanelHeight()
+
+    expect(heightAfterReopen).toBe(heightAfterResize)
+  })
+
+  test('vertical and horizontal sizes are independent across position switches', async () => {
+    const user = userEvent.setup()
+    render(<WorkspaceView />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+    })
+
+    const initialVerticalHeight = readDockPanelHeight()
+
+    await user.click(screen.getByRole('button', { name: /dock: right/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toHaveAttribute(
+        'data-position',
+        'right'
+      )
+    })
+
+    const initialHorizontalWidth = readDockPanelWidth()
+
+    await user.click(screen.getByRole('button', { name: /more dock actions/i }))
+    await user.click(screen.getByRole('button', { name: /dock: bottom/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toHaveAttribute(
+        'data-position',
+        'bottom'
+      )
+    })
+
+    const heightAfterSwitch = readDockPanelHeight()
+
+    expect(heightAfterSwitch).toBe(initialVerticalHeight)
+
+    await user.click(screen.getByRole('button', { name: /dock: left/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-panel')).toHaveAttribute(
+        'data-position',
+        'left'
+      )
+    })
+
+    const widthOnLeft = readDockPanelWidth()
+
+    expect(widthOnLeft).toBe(initialHorizontalWidth)
+  })
+})

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -69,6 +69,19 @@ vi.mock('../terminal/services/terminalService', () => ({
   })),
 }))
 
+vi.mock('../../hooks/useElasticContainer', () => ({
+  useElasticContainer: vi.fn(() => ({
+    size: 400,
+    isDragging: false,
+    handleMouseDown: vi.fn(),
+    adjustBy: vi.fn(),
+    resetToSize: vi.fn(),
+    sizeRef: { current: 400 },
+    pixelMin: 40,
+    pixelMax: 640,
+  })),
+}))
+
 // Mock CodeMirror hooks for unsaved changes tests
 let mockOnChange: ((content: string) => void) | undefined
 let mockOnSave: (() => void) | undefined

--- a/src/features/workspace/WorkspaceView.notifyInfo.test.tsx
+++ b/src/features/workspace/WorkspaceView.notifyInfo.test.tsx
@@ -22,6 +22,19 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   })),
 }))
 
+vi.mock('../../hooks/useElasticContainer', () => ({
+  useElasticContainer: vi.fn(() => ({
+    size: 400,
+    isDragging: false,
+    handleMouseDown: vi.fn(),
+    adjustBy: vi.fn(),
+    resetToSize: vi.fn(),
+    sizeRef: { current: 400 },
+    pixelMin: 40,
+    pixelMax: 640,
+  })),
+}))
+
 describe('WorkspaceView × notifyInfo banner', () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true })

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -121,6 +121,19 @@ vi.mock('../diff/hooks/useGitStatus', () => ({
   ),
 }))
 
+vi.mock('../../hooks/useElasticContainer', () => ({
+  useElasticContainer: vi.fn(() => ({
+    size: 400,
+    isDragging: false,
+    handleMouseDown: vi.fn(),
+    adjustBy: vi.fn(),
+    resetToSize: vi.fn(),
+    sizeRef: { current: 400 },
+    pixelMin: 40,
+    pixelMax: 640,
+  })),
+}))
+
 const capturedPanelProps: { agentStatus?: AgentStatus; gitStatus?: unknown } =
   {}
 const capturedDockPanelProps: { gitStatus?: unknown } = {}

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -49,6 +49,19 @@ vi.mock('../terminal/hooks/usePaneShortcuts', () => ({
   usePaneShortcuts: vi.fn(),
 }))
 
+vi.mock('../../hooks/useElasticContainer', () => ({
+  useElasticContainer: vi.fn(() => ({
+    size: 400,
+    isDragging: false,
+    handleMouseDown: vi.fn(),
+    adjustBy: vi.fn(),
+    resetToSize: vi.fn(),
+    sizeRef: { current: 400 },
+    pixelMin: 40,
+    pixelMax: 640,
+  })),
+}))
+
 // Capture AgentStatusPanel's props (specifically `onOpenFile`) so the
 // new handleOpenTestFile tests can invoke the handler directly without
 // rendering the full panel and synthesizing a test-row click.
@@ -464,6 +477,7 @@ describe('WorkspaceView', () => {
     render(<WorkspaceView />)
 
     await user.click(screen.getByRole('button', { name: /dock: left/i }))
+    await user.click(screen.getByRole('button', { name: /more dock actions/i }))
     await user.click(screen.getByRole('button', { name: /collapse panel/i }))
 
     const inner = screen.getByTestId('dock-canvas-wrapper')
@@ -499,6 +513,7 @@ describe('WorkspaceView', () => {
     render(<WorkspaceView />)
 
     await user.click(screen.getByRole('button', { name: /dock: right/i }))
+    await user.click(screen.getByRole('button', { name: /more dock actions/i }))
     await user.click(screen.getByRole('button', { name: /collapse panel/i }))
 
     const inner = screen.getByTestId('dock-canvas-wrapper')

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -32,6 +32,7 @@ import { CommandPalette } from '../command-palette/CommandPalette'
 import { mockNavigationItems, mockSettingsItem } from './data/mockNavigation'
 import { useSessionManager } from '../sessions/hooks/useSessionManager'
 import { clampSize, useResizable } from '../../hooks/useResizable'
+import { useElasticContainer } from '../../hooks/useElasticContainer'
 import { useSidebarTab, type SidebarTab } from '../../hooks/useSidebarTab'
 import { useNotifyInfo } from './hooks/useNotifyInfo'
 import { createFileSystemService } from '../files/services/fileSystemService'
@@ -55,6 +56,10 @@ import {
   TERMINAL_CONTAINER_ID,
   type FocusTarget,
 } from './containerIds'
+import {
+  DOCK_VERTICAL_ELASTIC_CONFIG,
+  DOCK_HORIZONTAL_ELASTIC_CONFIG,
+} from './panelConfig'
 
 const SIDEBAR_MIN = 240
 const SIDEBAR_MAX = 560
@@ -354,6 +359,7 @@ export const WorkspaceView = (): ReactElement => {
   const [fileError, setFileError] = useState<string | null>(null)
 
   // Dock panel controlled state.
+  const dockCanvasRef = useRef<HTMLDivElement>(null)
   const [dockPosition, setDockPosition] = useState<DockPosition>('bottom')
   const [isDockOpen, setIsDockOpen] = useState(true)
   const [dockTab, setDockTab] = useState<DockTab>('editor')
@@ -459,15 +465,19 @@ export const WorkspaceView = (): ReactElement => {
     modKey: preferModifier === 'meta' ? '⌘' : 'Ctrl',
   })
 
-  // Vertical dock height is lifted so the value survives DockPanel unmounts.
-  const verticalDockResize = useResizable({
-    initial: 400,
-    min: 150,
-    max: 640,
-    direction: 'vertical',
-    // Bottom dock grows when dragging up from its top edge; top dock grows
-    // when dragging down from its bottom edge.
+  // One elastic size per axis so values survive dock unmounts and position changes.
+  const verticalDockElastic = useElasticContainer({
+    containerRef: dockCanvasRef,
+    axis: 'vertical',
+    ...DOCK_VERTICAL_ELASTIC_CONFIG,
     invert: dockPosition === 'bottom',
+  })
+
+  const horizontalDockElastic = useElasticContainer({
+    containerRef: dockCanvasRef,
+    axis: 'horizontal',
+    ...DOCK_HORIZONTAL_ELASTIC_CONFIG,
+    invert: dockPosition === 'right',
   })
 
   const [selectedDiffFile, setSelectedDiffFile] =
@@ -677,7 +687,11 @@ export const WorkspaceView = (): ReactElement => {
     dockPosition === 'top' || dockPosition === 'bottom' ? 'column' : 'row'
 
   const dockBeforeTerminal = dockPosition === 'top' || dockPosition === 'left'
-  const terminalFitDeferred = isDragging || verticalDockResize.isDragging
+
+  const terminalFitDeferred =
+    isDragging ||
+    verticalDockElastic.isDragging ||
+    horizontalDockElastic.isDragging
 
   const dockOrPeek = isDockOpen ? (
     <DockPanel
@@ -697,10 +711,18 @@ export const WorkspaceView = (): ReactElement => {
       position={dockPosition}
       onPositionChange={setDockPosition}
       onClose={closeDock}
-      verticalSize={verticalDockResize.size}
-      onVerticalResizeMouseDown={verticalDockResize.handleMouseDown}
-      isVerticalResizing={verticalDockResize.isDragging}
-      onVerticalSizeAdjust={verticalDockResize.adjustBy}
+      verticalSize={verticalDockElastic.size}
+      onVerticalResizeMouseDown={verticalDockElastic.handleMouseDown}
+      isVerticalResizing={verticalDockElastic.isDragging}
+      onVerticalSizeAdjust={verticalDockElastic.adjustBy}
+      verticalPixelMin={verticalDockElastic.pixelMin}
+      verticalPixelMax={verticalDockElastic.pixelMax}
+      horizontalSize={horizontalDockElastic.size}
+      onHorizontalResizeMouseDown={horizontalDockElastic.handleMouseDown}
+      isHorizontalResizing={horizontalDockElastic.isDragging}
+      onHorizontalSizeAdjust={horizontalDockElastic.adjustBy}
+      horizontalPixelMin={horizontalDockElastic.pixelMin}
+      horizontalPixelMax={horizontalDockElastic.pixelMax}
       selectedDiffFile={selectedDiffFile}
       onSelectedDiffFileChange={setSelectedDiffFile}
       isFocused={activeContainerId === DOCK_CONTAINER_ID}
@@ -798,6 +820,7 @@ export const WorkspaceView = (): ReactElement => {
         />
 
         <div
+          ref={dockCanvasRef}
           data-testid="dock-canvas-wrapper"
           className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
           style={{ flexDirection: dockCanvasFlexDirection }}

--- a/src/features/workspace/WorkspaceView.verification.test.tsx
+++ b/src/features/workspace/WorkspaceView.verification.test.tsx
@@ -75,6 +75,19 @@ vi.mock('../terminal/services/terminalService', () => ({
   })),
 }))
 
+vi.mock('../../hooks/useElasticContainer', () => ({
+  useElasticContainer: vi.fn(() => ({
+    size: 400,
+    isDragging: false,
+    handleMouseDown: vi.fn(),
+    adjustBy: vi.fn(),
+    resetToSize: vi.fn(),
+    sizeRef: { current: 400 },
+    pixelMin: 40,
+    pixelMax: 640,
+  })),
+}))
+
 // eslint-disable-next-line import/first
 import { render, screen } from '@testing-library/react'
 // eslint-disable-next-line import/first

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -71,6 +71,19 @@ vi.mock('../terminal/services/terminalService', () => ({
   })),
 }))
 
+vi.mock('../../hooks/useElasticContainer', () => ({
+  useElasticContainer: vi.fn(() => ({
+    size: 400,
+    isDragging: false,
+    handleMouseDown: vi.fn(),
+    adjustBy: vi.fn(),
+    resetToSize: vi.fn(),
+    sizeRef: { current: 400 },
+    pixelMin: 40,
+    pixelMax: 640,
+  })),
+}))
+
 // eslint-disable-next-line import/first
 import { render, screen } from '@testing-library/react'
 // eslint-disable-next-line import/first

--- a/src/features/workspace/components/DockPanel.test.tsx
+++ b/src/features/workspace/components/DockPanel.test.tsx
@@ -31,6 +31,14 @@ const renderDockPanel = (
     onVerticalResizeMouseDown: vi.fn(),
     isVerticalResizing: false,
     onVerticalSizeAdjust: vi.fn(),
+    verticalPixelMin: 40,
+    verticalPixelMax: 640,
+    horizontalSize: 360,
+    onHorizontalResizeMouseDown: vi.fn(),
+    isHorizontalResizing: false,
+    onHorizontalSizeAdjust: vi.fn(),
+    horizontalPixelMin: 40,
+    horizontalPixelMax: 640,
     selectedFilePath: null,
     content: '',
     ...overrides,
@@ -137,10 +145,32 @@ describe('DockPanel', () => {
     expect(screen.getByTestId('resize-handle')).toBeInTheDocument()
   })
 
-  test('does not render resize handle for side docks', () => {
+  test('renders horizontal resize handle for left dock', () => {
     renderDockPanel({ position: 'left' })
 
-    expect(screen.queryByTestId('resize-handle')).not.toBeInTheDocument()
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toBeInTheDocument()
+    expect(handle).toHaveAttribute('aria-orientation', 'vertical')
+  })
+
+  test('renders horizontal resize handle for right dock', () => {
+    renderDockPanel({ position: 'right' })
+
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toBeInTheDocument()
+    expect(handle).toHaveAttribute('aria-orientation', 'vertical')
+  })
+
+  test('horizontal resize handle is on right edge for left dock', () => {
+    renderDockPanel({ position: 'left' })
+
+    expect(screen.getByTestId('resize-handle').className).toMatch(/right-0/)
+  })
+
+  test('horizontal resize handle is on left edge for right dock', () => {
+    renderDockPanel({ position: 'right' })
+
+    expect(screen.getByTestId('resize-handle').className).toMatch(/left-0/)
   })
 
   test('has controlled height from WorkspaceView for bottom dock', () => {
@@ -149,10 +179,18 @@ describe('DockPanel', () => {
     expect(screen.getByTestId('dock-panel')).toHaveStyle({ height: '420px' })
   })
 
-  test('uses fixed flex basis for side docks', () => {
-    renderDockPanel({ position: 'right' })
+  test('side dock uses controlled width from horizontalSize prop', () => {
+    renderDockPanel({ position: 'left', horizontalSize: 480 })
 
-    expect(screen.getByTestId('dock-panel')).toHaveStyle({ flex: '0 0 40%' })
+    expect(screen.getByTestId('dock-panel')).toHaveStyle({ width: '480px' })
+  })
+
+  test('side dock does not use flex basis', () => {
+    renderDockPanel({ position: 'right', horizontalSize: 360 })
+
+    expect(screen.getByTestId('dock-panel')).not.toHaveStyle({
+      flex: '0 0 40%',
+    })
   })
 
   test('resize handle forwards mouse down to lifted resize hook', () => {
@@ -162,6 +200,15 @@ describe('DockPanel', () => {
     fireEvent.mouseDown(screen.getByTestId('resize-handle'), { clientY: 100 })
 
     expect(onVerticalResizeMouseDown).toHaveBeenCalled()
+  })
+
+  test('horizontal handle mousedown calls onHorizontalResizeMouseDown', () => {
+    const onHorizontalResizeMouseDown = vi.fn()
+    renderDockPanel({ position: 'left', onHorizontalResizeMouseDown })
+
+    fireEvent.mouseDown(screen.getByTestId('resize-handle'))
+
+    expect(onHorizontalResizeMouseDown).toHaveBeenCalled()
   })
 
   test('bottom resize handle keyboard arrows call onVerticalSizeAdjust', async () => {
@@ -185,6 +232,102 @@ describe('DockPanel', () => {
     await user.keyboard('{ArrowDown}')
 
     expect(onVerticalSizeAdjust).toHaveBeenCalledWith(20)
+  })
+
+  test('left dock ArrowRight grows horizontal size', async () => {
+    const user = userEvent.setup()
+    const onHorizontalSizeAdjust = vi.fn()
+    renderDockPanel({ position: 'left', onHorizontalSizeAdjust })
+
+    screen.getByTestId('resize-handle').focus()
+    await user.keyboard('{ArrowRight}')
+
+    expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(20)
+  })
+
+  test('left dock ArrowLeft shrinks horizontal size', async () => {
+    const user = userEvent.setup()
+    const onHorizontalSizeAdjust = vi.fn()
+    renderDockPanel({ position: 'left', onHorizontalSizeAdjust })
+
+    screen.getByTestId('resize-handle').focus()
+    await user.keyboard('{ArrowLeft}')
+
+    expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(-20)
+  })
+
+  test('right dock ArrowLeft grows horizontal size', async () => {
+    const user = userEvent.setup()
+    const onHorizontalSizeAdjust = vi.fn()
+    renderDockPanel({ position: 'right', onHorizontalSizeAdjust })
+
+    screen.getByTestId('resize-handle').focus()
+    await user.keyboard('{ArrowLeft}')
+
+    expect(onHorizontalSizeAdjust).toHaveBeenCalledWith(20)
+  })
+
+  test('vertical handle aria-valuemin and aria-valuemax come from props', () => {
+    renderDockPanel({
+      position: 'bottom',
+      verticalPixelMin: 75,
+      verticalPixelMax: 900,
+    })
+
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toHaveAttribute('aria-valuemin', '75')
+    expect(handle).toHaveAttribute('aria-valuemax', '900')
+  })
+
+  test('horizontal handle aria-valuemin and aria-valuemax come from props', () => {
+    renderDockPanel({
+      position: 'left',
+      horizontalPixelMin: 60,
+      horizontalPixelMax: 960,
+    })
+
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toHaveAttribute('aria-valuemin', '60')
+    expect(handle).toHaveAttribute('aria-valuemax', '960')
+  })
+
+  test('narrow side dock keeps dock switcher in compact actions menu', async () => {
+    const user = userEvent.setup()
+    renderDockPanel({ position: 'left', horizontalSize: 360 })
+
+    expect(
+      screen.queryByRole('button', { name: /dock: left/i })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /more dock actions/i }))
+
+    expect(
+      screen.getByRole('button', { name: /dock: left/i })
+    ).toBeInTheDocument()
+  })
+
+  test('wide side dock keeps dock switcher inline', () => {
+    renderDockPanel({ position: 'left', horizontalSize: 480 })
+
+    expect(
+      screen.getByRole('button', { name: /dock: left/i })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: /more dock actions/i })
+    ).not.toBeInTheDocument()
+  })
+
+  test('bottom dock keeps dock switcher inline', () => {
+    renderDockPanel({ position: 'bottom' })
+
+    expect(
+      screen.getByRole('button', { name: /dock: bottom/i })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: /more dock actions/i })
+    ).not.toBeInTheDocument()
   })
 
   test('renders controlled active tab', () => {
@@ -299,8 +442,11 @@ describe('DockPanel', () => {
     }
   )
 
-  test('mounts DockSwitcher in header with current position', () => {
-    renderDockPanel({ position: 'left' })
+  test('mounts DockSwitcher with current position in compact menu for side docks', async () => {
+    const user = userEvent.setup()
+    renderDockPanel({ position: 'left', horizontalSize: 360 })
+
+    await user.click(screen.getByRole('button', { name: /more dock actions/i }))
 
     const leftSwitcherButton = screen.getByRole('button', {
       name: /dock: left/i,

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -3,6 +3,7 @@ import {
   forwardRef,
   useImperativeHandle,
   useRef,
+  type KeyboardEvent,
   type MouseEvent,
   type PointerEvent,
   type ReactElement,
@@ -17,6 +18,11 @@ import { DockTab } from './DockTab'
 import type { SelectedDiffFile } from '../../diff/types'
 import type { UseGitStatusReturn } from '../../diff/hooks/useGitStatus'
 import { DOCK_CONTAINER_ID } from '../containerIds'
+import {
+  DOCK_INLINE_ACTIONS_MIN_WIDTH_PX,
+  KEYBOARD_STEP_PX,
+  KEYBOARD_STEP_SHIFT_PX,
+} from '../panelConfig'
 
 type TabType = 'editor' | 'diff'
 
@@ -37,14 +43,21 @@ interface DockPanelBaseProps {
   onPositionChange: (next: DockPosition) => void
   /** Caller closes the dock; DockPanel unmounts on close. */
   onClose: () => void
-  /** Controlled top/bottom dock size from WorkspaceView's lifted useResizable. */
+  /** Controlled height for top/bottom docks. */
   verticalSize: number
-  /** Mouse handler from the lifted vertical resize hook. Ignored for side docks. */
   onVerticalResizeMouseDown: (event: MouseEvent) => void
-  /** Drag state from the lifted vertical resize hook. Ignored for side docks. */
   isVerticalResizing: boolean
-  /** Keyboard adjuster from WorkspaceView's lifted useResizable. */
   onVerticalSizeAdjust: (delta: number) => void
+  /** Live pixel bounds from useElasticContainer for ARIA and Home/End. */
+  verticalPixelMin: number
+  verticalPixelMax: number
+  /** Controlled width for left/right docks. */
+  horizontalSize: number
+  onHorizontalResizeMouseDown: (event: MouseEvent) => void
+  isHorizontalResizing: boolean
+  onHorizontalSizeAdjust: (delta: number) => void
+  horizontalPixelMin: number
+  horizontalPixelMax: number
 
   selectedFilePath: string | null
   /** Current buffer content, owned by the parent `useEditorBuffer`. */
@@ -69,10 +82,6 @@ export interface DockPanelHandle {
   focusDiff(): void
 }
 
-const DRAWER_MIN = 150
-const DRAWER_MAX = 640
-const SIDE_DOCK_BASIS = '40%'
-
 const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
   function DockPanel(
     {
@@ -85,6 +94,14 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
       onVerticalResizeMouseDown,
       isVerticalResizing,
       onVerticalSizeAdjust,
+      verticalPixelMin,
+      verticalPixelMax,
+      horizontalSize,
+      onHorizontalResizeMouseDown,
+      isHorizontalResizing,
+      onHorizontalSizeAdjust,
+      horizontalPixelMin,
+      horizontalPixelMax,
       selectedFilePath,
       content,
       onContentChange = undefined,
@@ -150,7 +167,7 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
 
     const containerStyle = isVerticalDock
       ? { height: `${verticalSize}px` }
-      : { flex: `0 0 ${SIDE_DOCK_BASIS}` as const }
+      : { width: `${horizontalSize}px` }
 
     // Border edge varies by position; color literals are kept static so
     // Tailwind JIT can scan and emit both border-[#cba6f7] and
@@ -177,8 +194,50 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
             ? 'chevron_left'
             : 'chevron_right'
 
-    const resizeHandleEdgeClass = position === 'top' ? 'bottom-0' : 'top-0'
     const sectionAriaLabel = tab === 'editor' ? 'Code editor' : 'Diff viewer'
+
+    const compactActions =
+      !isVerticalDock && horizontalSize < DOCK_INLINE_ACTIONS_MIN_WIDTH_PX
+
+    const handleVerticalKeyDown = (e: KeyboardEvent): void => {
+      const step = e.shiftKey ? KEYBOARD_STEP_SHIFT_PX : KEYBOARD_STEP_PX
+      const growKey = position === 'top' ? 'ArrowDown' : 'ArrowUp'
+      const shrinkKey = position === 'top' ? 'ArrowUp' : 'ArrowDown'
+
+      if (e.key === growKey) {
+        e.preventDefault()
+        onVerticalSizeAdjust(step)
+      } else if (e.key === shrinkKey) {
+        e.preventDefault()
+        onVerticalSizeAdjust(-step)
+      } else if (e.key === 'Home') {
+        e.preventDefault()
+        onVerticalSizeAdjust(verticalPixelMin - verticalSize)
+      } else if (e.key === 'End') {
+        e.preventDefault()
+        onVerticalSizeAdjust(verticalPixelMax - verticalSize)
+      }
+    }
+
+    const handleHorizontalKeyDown = (e: KeyboardEvent): void => {
+      const step = e.shiftKey ? KEYBOARD_STEP_SHIFT_PX : KEYBOARD_STEP_PX
+      const growKey = position === 'left' ? 'ArrowRight' : 'ArrowLeft'
+      const shrinkKey = position === 'left' ? 'ArrowLeft' : 'ArrowRight'
+
+      if (e.key === growKey) {
+        e.preventDefault()
+        onHorizontalSizeAdjust(step)
+      } else if (e.key === shrinkKey) {
+        e.preventDefault()
+        onHorizontalSizeAdjust(-step)
+      } else if (e.key === 'Home') {
+        e.preventDefault()
+        onHorizontalSizeAdjust(horizontalPixelMin - horizontalSize)
+      } else if (e.key === 'End') {
+        e.preventDefault()
+        onHorizontalSizeAdjust(horizontalPixelMax - horizontalSize)
+      }
+    }
 
     return (
       <section
@@ -207,38 +266,36 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
           />
         ) : null}
 
-        {isVerticalDock && (
+        {isVerticalDock ? (
           <div
             data-testid="resize-handle"
             role="separator"
             aria-orientation="horizontal"
             aria-label="Resize panel"
             aria-valuenow={verticalSize}
-            aria-valuemin={DRAWER_MIN}
-            aria-valuemax={DRAWER_MAX}
+            aria-valuemin={verticalPixelMin}
+            aria-valuemax={verticalPixelMax}
             tabIndex={0}
             onMouseDown={onVerticalResizeMouseDown}
-            onKeyDown={(e): void => {
-              const step = e.shiftKey ? 100 : 20
-              const growKey = position === 'top' ? 'ArrowDown' : 'ArrowUp'
-              const shrinkKey = position === 'top' ? 'ArrowUp' : 'ArrowDown'
-
-              if (e.key === growKey) {
-                e.preventDefault()
-                onVerticalSizeAdjust(step)
-              } else if (e.key === shrinkKey) {
-                e.preventDefault()
-                onVerticalSizeAdjust(-step)
-              } else if (e.key === 'Home') {
-                e.preventDefault()
-                onVerticalSizeAdjust(DRAWER_MIN - verticalSize)
-              } else if (e.key === 'End') {
-                e.preventDefault()
-                onVerticalSizeAdjust(DRAWER_MAX - verticalSize)
-              }
-            }}
-            className={`absolute ${resizeHandleEdgeClass} left-0 right-0 h-1 cursor-ns-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
+            onKeyDown={handleVerticalKeyDown}
+            className={`absolute ${position === 'top' ? 'bottom-0' : 'top-0'} left-0 right-0 h-1 cursor-ns-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
               isVerticalResizing ? 'bg-primary/30' : ''
+            }`}
+          />
+        ) : (
+          <div
+            data-testid="resize-handle"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize panel"
+            aria-valuenow={horizontalSize}
+            aria-valuemin={horizontalPixelMin}
+            aria-valuemax={horizontalPixelMax}
+            tabIndex={0}
+            onMouseDown={onHorizontalResizeMouseDown}
+            onKeyDown={handleHorizontalKeyDown}
+            className={`absolute ${position === 'right' ? 'left-0' : 'right-0'} top-0 bottom-0 w-1 cursor-col-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
+              isHorizontalResizing ? 'bg-primary/30' : ''
             }`}
           />
         )}
@@ -249,6 +306,7 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
           selectedFilePath={selectedFilePath}
           collapseIconName={collapseIconName}
           onClose={onClose}
+          compactActions={compactActions}
         >
           <DockSwitcher position={position} onPick={onPositionChange} />
         </DockTab>

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -307,6 +307,7 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
           collapseIconName={collapseIconName}
           onClose={onClose}
           compactActions={compactActions}
+          menuAlign={position === 'left' ? 'left' : 'right'}
         >
           <DockSwitcher position={position} onPick={onPositionChange} />
         </DockTab>

--- a/src/features/workspace/components/DockTab.test.tsx
+++ b/src/features/workspace/components/DockTab.test.tsx
@@ -84,6 +84,58 @@ describe('DockTab', () => {
     ).toBeTruthy()
   })
 
+  test('compactActions hides auxiliary controls behind a more button', async () => {
+    const user = userEvent.setup()
+    render(
+      <DockTab
+        tab="editor"
+        onTabChange={vi.fn()}
+        selectedFilePath="~/src/app.tsx"
+        collapseIconName="chevron_left"
+        onClose={vi.fn()}
+        compactActions
+      >
+        <div>Switcher slot</div>
+      </DockTab>
+    )
+
+    expect(screen.getByRole('button', { name: /editor/i })).toBeInTheDocument()
+    expect(screen.queryByText('Switcher slot')).not.toBeInTheDocument()
+    expect(screen.queryByText('src/app.tsx')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /more dock actions/i }))
+
+    expect(screen.getByTestId('dock-actions-menu')).toBeInTheDocument()
+    expect(screen.getByText('Switcher slot')).toBeInTheDocument()
+    expect(screen.getByText('src/app.tsx')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /collapse panel/i })
+    ).toBeInTheDocument()
+  })
+
+  test('compactActions closes the menu on Escape', async () => {
+    const user = userEvent.setup()
+    render(
+      <DockTab
+        tab="editor"
+        onTabChange={vi.fn()}
+        selectedFilePath={null}
+        collapseIconName="chevron_left"
+        onClose={vi.fn()}
+        compactActions
+      >
+        <div>Switcher slot</div>
+      </DockTab>
+    )
+
+    await user.click(screen.getByRole('button', { name: /more dock actions/i }))
+    expect(screen.getByTestId('dock-actions-menu')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByTestId('dock-actions-menu')).not.toBeInTheDocument()
+  })
+
   test('clicking the close button calls onClose', async () => {
     const user = userEvent.setup()
     const onClose = vi.fn()

--- a/src/features/workspace/components/DockTab.test.tsx
+++ b/src/features/workspace/components/DockTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { act, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, test, expect, vi } from 'vitest'
 import { DockTab } from './DockTab'
@@ -111,6 +111,35 @@ describe('DockTab', () => {
     expect(
       screen.getByRole('button', { name: /collapse panel/i })
     ).toBeInTheDocument()
+  })
+
+  test('compact menu closes when clicking outside', async () => {
+    const user = userEvent.setup()
+    render(
+      <DockTab
+        tab="editor"
+        onTabChange={vi.fn()}
+        selectedFilePath={null}
+        collapseIconName="chevron_left"
+        onClose={vi.fn()}
+        compactActions
+      >
+        <div>Switcher slot</div>
+      </DockTab>
+    )
+
+    await user.click(screen.getByRole('button', { name: /more dock actions/i }))
+    expect(screen.getByTestId('dock-actions-menu')).toBeInTheDocument()
+
+    // Fire mousedown on document.body — outside the menu; wrap in act so
+    // the React state update from the listener is flushed before asserting.
+    act(() => {
+      document.body.dispatchEvent(
+        new MouseEvent('mousedown', { bubbles: true })
+      )
+    })
+
+    expect(screen.queryByTestId('dock-actions-menu')).not.toBeInTheDocument()
   })
 
   test('compactActions closes the menu on Escape', async () => {

--- a/src/features/workspace/components/DockTab.test.tsx
+++ b/src/features/workspace/components/DockTab.test.tsx
@@ -212,4 +212,80 @@ describe('DockTab', () => {
     const closeButton = screen.getByRole('button', { name: /collapse panel/i })
     expect(within(closeButton).getByText('chevron_left')).toBeInTheDocument()
   })
+
+  // F1: actionsOpen is cleared when compactActions transitions to false
+  test('menu is hidden and actionsOpen resets when compactActions changes to false', async () => {
+    const user = userEvent.setup()
+
+    const { rerender } = render(
+      <DockTab
+        tab="editor"
+        onTabChange={vi.fn()}
+        selectedFilePath={null}
+        collapseIconName="chevron_left"
+        onClose={vi.fn()}
+        compactActions
+      />
+    )
+
+    // Open the menu
+    await user.click(screen.getByRole('button', { name: /more dock actions/i }))
+    expect(screen.getByTestId('dock-actions-menu')).toBeInTheDocument()
+
+    // Widen the dock → compactActions goes false
+    rerender(
+      <DockTab
+        tab="editor"
+        onTabChange={vi.fn()}
+        selectedFilePath={null}
+        collapseIconName="chevron_left"
+        onClose={vi.fn()}
+      />
+    )
+
+    // Menu element is gone (not rendered) and actionsOpen was cleared,
+    // so narrowing again should not auto-open the menu
+    expect(screen.queryByTestId('dock-actions-menu')).not.toBeInTheDocument()
+
+    // Narrow again → compactActions back to true; menu must NOT auto-open
+    rerender(
+      <DockTab
+        tab="editor"
+        onTabChange={vi.fn()}
+        selectedFilePath={null}
+        collapseIconName="chevron_left"
+        onClose={vi.fn()}
+        compactActions
+      />
+    )
+
+    expect(screen.queryByTestId('dock-actions-menu')).not.toBeInTheDocument()
+  })
+
+  // F4: clicking the trigger button a second time closes the menu
+  test('clicking the trigger button while menu is open closes it', async () => {
+    const user = userEvent.setup()
+    render(
+      <DockTab
+        tab="editor"
+        onTabChange={vi.fn()}
+        selectedFilePath={null}
+        collapseIconName="chevron_left"
+        onClose={vi.fn()}
+        compactActions
+      />
+    )
+
+    const triggerButton = screen.getByRole('button', {
+      name: /more dock actions/i,
+    })
+
+    // First click: open
+    await user.click(triggerButton)
+    expect(screen.getByTestId('dock-actions-menu')).toBeInTheDocument()
+
+    // Second click: close
+    await user.click(triggerButton)
+    expect(screen.queryByTestId('dock-actions-menu')).not.toBeInTheDocument()
+  })
 })

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -124,6 +124,15 @@ export const DockTab = ({
     <div
       className="relative flex h-[34px] min-w-0 items-center gap-1 border-b border-[rgba(74,68,79,0.25)] bg-[#0d0d1c] px-2"
       onKeyDown={compactActions ? handleCompactKeyDown : undefined}
+      onBlurCapture={
+        compactActions
+          ? (e): void => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+                setActionsOpen(false)
+              }
+            }
+          : undefined
+      }
     >
       <div className="flex min-w-0 shrink-0 gap-1">
         <button

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -1,5 +1,7 @@
 import {
+  useEffect,
   useId,
+  useRef,
   useState,
   type KeyboardEvent,
   type ReactElement,
@@ -48,6 +50,25 @@ export const DockTab = ({
 }: DockTabProps): ReactElement => {
   const actionsMenuId = useId()
   const [actionsOpen, setActionsOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!actionsOpen) {
+      return
+    }
+
+    const handleOutsideClick = (event: MouseEvent): void => {
+      if (!menuRef.current?.contains(event.target as Node)) {
+        setActionsOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleOutsideClick)
+
+    return (): void => {
+      document.removeEventListener('mousedown', handleOutsideClick)
+    }
+  }, [actionsOpen])
 
   const displayPath = selectedFilePath
     ? selectedFilePath.replace(/^~\//, '')
@@ -116,6 +137,7 @@ export const DockTab = ({
 
           {actionsOpen && (
             <div
+              ref={menuRef}
               id={actionsMenuId}
               data-testid="dock-actions-menu"
               className="absolute right-0 top-[28px] z-50 flex min-w-[190px] flex-col gap-2 rounded-lg border border-[rgba(74,68,79,0.35)] bg-[#0d0d1c] p-2 shadow-xl"

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -157,6 +157,8 @@ export const DockTab = ({
             <div
               ref={menuRef}
               id={actionsMenuId}
+              role="menu"
+              aria-label="Dock actions"
               data-testid="dock-actions-menu"
               className={`absolute ${menuAlignClass} top-[28px] z-50 flex min-w-[190px] flex-col gap-2 rounded-lg border border-[rgba(74,68,79,0.35)] bg-[#0d0d1c] p-2 shadow-xl`}
               onClick={() => setActionsOpen(false)}

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -70,6 +70,13 @@ export const DockTab = ({
     }
   }, [actionsOpen])
 
+  // F1: clear actionsOpen when compact menu is no longer rendered
+  useEffect((): void => {
+    if (!compactActions) {
+      setActionsOpen(false)
+    }
+  }, [compactActions])
+
   const displayPath = selectedFilePath
     ? selectedFilePath.replace(/^~\//, '')
     : 'No file'
@@ -81,6 +88,12 @@ export const DockTab = ({
 
     setActionsOpen(false)
   }
+
+  // F3: align dropdown toward the center of the screen so it stays on-screen.
+  // chevron_left = left dock → open rightward (left-0)
+  // chevron_right = right dock → open leftward (right-0)
+  const menuAlignClass =
+    collapseIconName === 'chevron_left' ? 'left-0' : 'right-0'
 
   return (
     <div
@@ -124,7 +137,12 @@ export const DockTab = ({
             aria-label="More dock actions"
             aria-controls={actionsMenuId}
             aria-expanded={actionsOpen}
-            onClick={() => setActionsOpen((isOpen) => !isOpen)}
+            onMouseDown={(e): void => {
+              // F4: stop the document mousedown listener from firing so that
+              // onClick is the sole toggle — prevents close→reopen on same click.
+              e.stopPropagation()
+            }}
+            onClick={(): void => setActionsOpen((prev) => !prev)}
             className="grid h-6 w-6 cursor-pointer place-items-center rounded-[5px] bg-transparent text-[#8a8299] transition-colors hover:bg-white/5 hover:text-[#e2c7ff] focus:bg-white/5 focus:text-[#e2c7ff] focus:outline-none"
           >
             <span
@@ -140,7 +158,7 @@ export const DockTab = ({
               ref={menuRef}
               id={actionsMenuId}
               data-testid="dock-actions-menu"
-              className="absolute right-0 top-[28px] z-50 flex min-w-[190px] flex-col gap-2 rounded-lg border border-[rgba(74,68,79,0.35)] bg-[#0d0d1c] p-2 shadow-xl"
+              className={`absolute ${menuAlignClass} top-[28px] z-50 flex min-w-[190px] flex-col gap-2 rounded-lg border border-[rgba(74,68,79,0.35)] bg-[#0d0d1c] p-2 shadow-xl`}
               onClick={() => setActionsOpen(false)}
             >
               <span

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -172,9 +172,12 @@ export const DockTab = ({
               className={`absolute ${menuAlignClass} top-[28px] z-50 flex min-w-[190px] flex-col gap-2 rounded-lg border border-[rgba(74,68,79,0.35)] bg-[#0d0d1c] p-2 shadow-xl`}
               onClick={() => setActionsOpen(false)}
             >
+              {/* stopPropagation so clicking the read-only path label does not
+                  bubble to the container's onClick and close the menu */}
               <span
                 className="max-w-[210px] truncate px-1 font-mono text-[10px] text-outline"
                 title={selectedFilePath ?? ''}
+                onClick={(e): void => e.stopPropagation()}
               >
                 {displayPath}
               </span>

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -1,4 +1,10 @@
-import type { ReactElement, ReactNode } from 'react'
+import {
+  useId,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
 
 export type DockTabType = 'editor' | 'diff'
 
@@ -12,12 +18,15 @@ interface DockTabProps {
     | 'chevron_left'
     | 'chevron_right'
   onClose: () => void
+  compactActions?: boolean
   /** Slot rendered between the tab strip spacer and the file-path/close cluster. */
   children?: ReactNode
 }
 
-const tabButtonClass = (active: boolean): string =>
-  `flex items-center gap-1.5 font-mono text-[10.5px] h-[26px] px-[11px] rounded-md border transition-colors ${
+const tabButtonClass = (active: boolean, compact: boolean): string =>
+  `flex items-center justify-center font-mono text-[10.5px] h-[26px] rounded-md border transition-colors ${
+    compact ? 'w-[30px] px-0' : 'gap-1.5 px-[11px]'
+  } ${
     active
       ? 'bg-[rgba(226,199,255,0.08)] border-[rgba(203,166,247,0.3)] text-[#e2c7ff]'
       : 'bg-transparent border-transparent text-[#8a8299] hover:text-[#e2c7ff]'
@@ -34,61 +43,137 @@ export const DockTab = ({
   selectedFilePath,
   collapseIconName,
   onClose,
+  compactActions = false,
   children = undefined,
-}: DockTabProps): ReactElement => (
-  <div className="flex h-[34px] items-center gap-1 border-b border-[rgba(74,68,79,0.25)] bg-[#0d0d1c] px-2">
-    <div className="flex gap-1">
-      <button
-        type="button"
-        aria-pressed={tab === 'editor'}
-        onClick={() => onTabChange('editor')}
-        className={tabButtonClass(tab === 'editor')}
-        aria-label="Editor"
-      >
-        <span className={tabIconClass(tab === 'editor')} aria-hidden="true">
-          code
-        </span>
-        <span>Editor</span>
-      </button>
+}: DockTabProps): ReactElement => {
+  const actionsMenuId = useId()
+  const [actionsOpen, setActionsOpen] = useState(false)
 
-      <button
-        type="button"
-        aria-pressed={tab === 'diff'}
-        onClick={() => onTabChange('diff')}
-        className={tabButtonClass(tab === 'diff')}
-        aria-label="Diff Viewer"
-      >
-        <span className={tabIconClass(tab === 'diff')} aria-hidden="true">
-          difference
-        </span>
-        <span>Diff Viewer</span>
-      </button>
-    </div>
+  const displayPath = selectedFilePath
+    ? selectedFilePath.replace(/^~\//, '')
+    : 'No file'
 
-    <div className="flex-1" />
+  const handleCompactKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== 'Escape') {
+      return
+    }
 
-    {children}
+    setActionsOpen(false)
+  }
 
-    <div className="ml-2 flex items-center gap-3">
-      <span
-        className="font-mono text-[10px] text-outline"
-        title={selectedFilePath ?? ''}
-      >
-        {selectedFilePath ? selectedFilePath.replace(/^~\//, '') : 'No file'}
-      </span>
-      <button
-        type="button"
-        aria-label="Collapse panel"
-        onClick={onClose}
-        className="grid h-6 w-6 cursor-pointer place-items-center rounded-[5px] bg-transparent text-[#8a8299] transition-colors hover:bg-white/5 hover:text-[#e2c7ff]"
-      >
-        <span
-          className="material-symbols-outlined text-[14px]"
-          aria-hidden="true"
+  return (
+    <div
+      className="relative flex h-[34px] min-w-0 items-center gap-1 border-b border-[rgba(74,68,79,0.25)] bg-[#0d0d1c] px-2"
+      onKeyDown={compactActions ? handleCompactKeyDown : undefined}
+    >
+      <div className="flex min-w-0 shrink-0 gap-1">
+        <button
+          type="button"
+          aria-pressed={tab === 'editor'}
+          onClick={() => onTabChange('editor')}
+          className={tabButtonClass(tab === 'editor', compactActions)}
+          aria-label="Editor"
         >
-          {collapseIconName}
-        </span>
-      </button>
+          <span className={tabIconClass(tab === 'editor')} aria-hidden="true">
+            code
+          </span>
+          {!compactActions && <span>Editor</span>}
+        </button>
+
+        <button
+          type="button"
+          aria-pressed={tab === 'diff'}
+          onClick={() => onTabChange('diff')}
+          className={tabButtonClass(tab === 'diff', compactActions)}
+          aria-label="Diff Viewer"
+        >
+          <span className={tabIconClass(tab === 'diff')} aria-hidden="true">
+            difference
+          </span>
+          {!compactActions && <span>Diff Viewer</span>}
+        </button>
+      </div>
+
+      <div className="min-w-0 flex-1" />
+
+      {compactActions ? (
+        <div className="relative shrink-0">
+          <button
+            type="button"
+            aria-label="More dock actions"
+            aria-controls={actionsMenuId}
+            aria-expanded={actionsOpen}
+            onClick={() => setActionsOpen((isOpen) => !isOpen)}
+            className="grid h-6 w-6 cursor-pointer place-items-center rounded-[5px] bg-transparent text-[#8a8299] transition-colors hover:bg-white/5 hover:text-[#e2c7ff] focus:bg-white/5 focus:text-[#e2c7ff] focus:outline-none"
+          >
+            <span
+              className="material-symbols-outlined text-[16px]"
+              aria-hidden="true"
+            >
+              more_horiz
+            </span>
+          </button>
+
+          {actionsOpen && (
+            <div
+              id={actionsMenuId}
+              data-testid="dock-actions-menu"
+              className="absolute right-0 top-[28px] z-50 flex min-w-[190px] flex-col gap-2 rounded-lg border border-[rgba(74,68,79,0.35)] bg-[#0d0d1c] p-2 shadow-xl"
+              onClick={() => setActionsOpen(false)}
+            >
+              <span
+                className="max-w-[210px] truncate px-1 font-mono text-[10px] text-outline"
+                title={selectedFilePath ?? ''}
+              >
+                {displayPath}
+              </span>
+
+              <div className="flex items-center justify-between gap-2">
+                {children}
+                <button
+                  type="button"
+                  aria-label="Collapse panel"
+                  onClick={onClose}
+                  className="grid h-6 w-6 shrink-0 cursor-pointer place-items-center rounded-[5px] bg-transparent text-[#8a8299] transition-colors hover:bg-white/5 hover:text-[#e2c7ff]"
+                >
+                  <span
+                    className="material-symbols-outlined text-[14px]"
+                    aria-hidden="true"
+                  >
+                    {collapseIconName}
+                  </span>
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <>
+          {children && <div className="shrink-0">{children}</div>}
+
+          <div className="ml-2 flex min-w-0 items-center gap-3">
+            <span
+              className="min-w-0 max-w-[180px] truncate font-mono text-[10px] text-outline"
+              title={selectedFilePath ?? ''}
+            >
+              {displayPath}
+            </span>
+            <button
+              type="button"
+              aria-label="Collapse panel"
+              onClick={onClose}
+              className="grid h-6 w-6 shrink-0 cursor-pointer place-items-center rounded-[5px] bg-transparent text-[#8a8299] transition-colors hover:bg-white/5 hover:text-[#e2c7ff]"
+            >
+              <span
+                className="material-symbols-outlined text-[14px]"
+                aria-hidden="true"
+              >
+                {collapseIconName}
+              </span>
+            </button>
+          </div>
+        </>
+      )}
     </div>
-  </div>
-)
+  )
+}

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -21,6 +21,12 @@ interface DockTabProps {
     | 'chevron_right'
   onClose: () => void
   compactActions?: boolean
+  /**
+   * Which side the compact actions dropdown opens toward.
+   * 'left' = left-docks (opens rightward). 'right' = right-docks (opens leftward).
+   * Defaults to 'right'. Prefer over inferring from collapseIconName.
+   */
+  menuAlign?: 'left' | 'right'
   /** Slot rendered between the tab strip spacer and the file-path/close cluster. */
   children?: ReactNode
 }
@@ -46,12 +52,17 @@ export const DockTab = ({
   collapseIconName,
   onClose,
   compactActions = false,
+  menuAlign = 'right',
   children = undefined,
 }: DockTabProps): ReactElement => {
   const actionsMenuId = useId()
   const [actionsOpen, setActionsOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
+  // Tracks whether the most recent close was layout-driven (compactActions→false)
+  // vs. an explicit user action. Only user-action closes return focus to the trigger
+  // (which may be unmounted in a layout-driven close).
+  const layoutDrivenCloseRef = useRef(false)
 
   useEffect(() => {
     if (!actionsOpen) {
@@ -71,18 +82,26 @@ export const DockTab = ({
     }
   }, [actionsOpen])
 
-  // Return focus to trigger when the menu closes so keyboard users are not stranded.
+  // Return focus to trigger when the menu closes via a user action.
+  // Layout-driven closes (compactActions→false) skip this because the trigger
+  // button is unmounted at the same time — triggerRef.current would be null.
   const prevActionsOpenRef = useRef(false)
   useEffect(() => {
-    if (prevActionsOpenRef.current && !actionsOpen) {
+    if (
+      prevActionsOpenRef.current &&
+      !actionsOpen &&
+      !layoutDrivenCloseRef.current
+    ) {
       triggerRef.current?.focus()
     }
+    layoutDrivenCloseRef.current = false
     prevActionsOpenRef.current = actionsOpen
   }, [actionsOpen])
 
   // Clear actionsOpen when compact menu is no longer rendered.
   useEffect((): void => {
     if (!compactActions) {
+      layoutDrivenCloseRef.current = true
       setActionsOpen(false)
     }
   }, [compactActions])
@@ -99,11 +118,7 @@ export const DockTab = ({
     setActionsOpen(false)
   }
 
-  // F3: align dropdown toward the center of the screen so it stays on-screen.
-  // chevron_left = left dock → open rightward (left-0)
-  // chevron_right = right dock → open leftward (right-0)
-  const menuAlignClass =
-    collapseIconName === 'chevron_left' ? 'left-0' : 'right-0'
+  const menuAlignClass = menuAlign === 'left' ? 'left-0' : 'right-0'
 
   return (
     <div

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -51,6 +51,7 @@ export const DockTab = ({
   const actionsMenuId = useId()
   const [actionsOpen, setActionsOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
     if (!actionsOpen) {
@@ -70,7 +71,16 @@ export const DockTab = ({
     }
   }, [actionsOpen])
 
-  // F1: clear actionsOpen when compact menu is no longer rendered
+  // Return focus to trigger when the menu closes so keyboard users are not stranded.
+  const prevActionsOpenRef = useRef(false)
+  useEffect(() => {
+    if (prevActionsOpenRef.current && !actionsOpen) {
+      triggerRef.current?.focus()
+    }
+    prevActionsOpenRef.current = actionsOpen
+  }, [actionsOpen])
+
+  // Clear actionsOpen when compact menu is no longer rendered.
   useEffect((): void => {
     if (!compactActions) {
       setActionsOpen(false)
@@ -133,12 +143,13 @@ export const DockTab = ({
       {compactActions ? (
         <div className="relative shrink-0">
           <button
+            ref={triggerRef}
             type="button"
             aria-label="More dock actions"
             aria-controls={actionsMenuId}
             aria-expanded={actionsOpen}
             onMouseDown={(e): void => {
-              // F4: stop the document mousedown listener from firing so that
+              // Stop the document mousedown listener from firing so that
               // onClick is the sole toggle — prevents close→reopen on same click.
               e.stopPropagation()
             }}
@@ -157,8 +168,6 @@ export const DockTab = ({
             <div
               ref={menuRef}
               id={actionsMenuId}
-              role="menu"
-              aria-label="Dock actions"
               data-testid="dock-actions-menu"
               className={`absolute ${menuAlignClass} top-[28px] z-50 flex min-w-[190px] flex-col gap-2 rounded-lg border border-[rgba(74,68,79,0.35)] bg-[#0d0d1c] p-2 shadow-xl`}
               onClick={() => setActionsOpen(false)}

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -103,6 +103,10 @@ export const DockTab = ({
     if (!compactActions) {
       layoutDrivenCloseRef.current = true
       setActionsOpen(false)
+      // If the menu was already closed, setActionsOpen is a no-op and the
+      // [actionsOpen] effect never fires, so the flag would stay true
+      // permanently. Reset it here to avoid blocking the next focus-return.
+      layoutDrivenCloseRef.current = false
     }
   }, [compactActions])
 
@@ -170,7 +174,6 @@ export const DockTab = ({
             ref={triggerRef}
             type="button"
             aria-label="More dock actions"
-            aria-controls={actionsMenuId}
             aria-expanded={actionsOpen}
             onMouseDown={(e): void => {
               // Stop the document mousedown listener from firing so that

--- a/src/features/workspace/panelConfig.ts
+++ b/src/features/workspace/panelConfig.ts
@@ -25,40 +25,6 @@ export const DOCK_HORIZONTAL_ELASTIC_CONFIG = {
   initialPercent: 0.3,
 } as const
 
-/**
- * @deprecated Use DOCK_VERTICAL_ELASTIC_CONFIG or DOCK_HORIZONTAL_ELASTIC_CONFIG
- */
-export const DOCK_ELASTIC_CONFIG = DOCK_VERTICAL_ELASTIC_CONFIG
-
-/**
- * Terminal zone outer elastic config, reserved for future useElasticContainer
- * wiring of the whole terminal zone.
- */
-export const TERMINAL_ZONE_ELASTIC_CONFIG = {
-  minPercent: 0.1,
-  maxPercent: 0.9,
-  initialPercent: 0.5,
-} as const
-
-/**
- * Per-pane elastic config descriptor for TerminalZone's 1-4 pane splits.
- * Intentionally omits `containerRef` and `axis`; those are call-site concerns.
- * Out of scope for this PR, but defined here to avoid a future breaking change.
- */
-export interface PaneElasticConfig {
-  minPercent: number
-  maxPercent: number
-  /** undefined = compute as 1/paneCount at runtime. */
-  initialPercent: number | undefined
-}
-
-export const TERMINAL_PANE_ELASTIC_CONFIGS: PaneElasticConfig[] = [
-  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
-  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
-  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
-  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
-]
-
 /** Keyboard resize step sizes (pixels), shared by all panels. */
 export const KEYBOARD_STEP_PX = 20
 

--- a/src/features/workspace/panelConfig.ts
+++ b/src/features/workspace/panelConfig.ts
@@ -8,12 +8,6 @@ export const DOCK_VERTICAL_ELASTIC_CONFIG = {
   initialPercent: 0.3,
 } as const
 
-/** Vertical-axis elastic config for the dock panel (top/bottom positions). */
-export const DOCK_VERTICAL_ELASTIC_CONFIG = DOCK_ELASTIC_CONFIG
-
-/** Horizontal-axis elastic config for the dock panel (left/right positions). */
-export const DOCK_HORIZONTAL_ELASTIC_CONFIG = DOCK_ELASTIC_CONFIG
-
 /**
  * Elastic config for the horizontal dock axis (left/right positions).
  * 15% of a 1200 px canvas = 180 px, wide enough to render the compact

--- a/src/features/workspace/panelConfig.ts
+++ b/src/features/workspace/panelConfig.ts
@@ -1,8 +1,8 @@
 /**
- * Dock panel elastic config, used by WorkspaceView's two useElasticContainer
- * instances: one for vertical dock size and one for horizontal dock size.
+ * Elastic config for the vertical dock axis (top/bottom positions).
+ * 5% of an 800 px canvas = 40 px, which fits the DockTab header comfortably.
  */
-export const DOCK_ELASTIC_CONFIG = {
+export const DOCK_VERTICAL_ELASTIC_CONFIG = {
   minPercent: 0.05,
   maxPercent: 0.8,
   initialPercent: 0.3,
@@ -13,6 +13,22 @@ export const DOCK_VERTICAL_ELASTIC_CONFIG = DOCK_ELASTIC_CONFIG
 
 /** Horizontal-axis elastic config for the dock panel (left/right positions). */
 export const DOCK_HORIZONTAL_ELASTIC_CONFIG = DOCK_ELASTIC_CONFIG
+
+/**
+ * Elastic config for the horizontal dock axis (left/right positions).
+ * 15% of a 1200 px canvas = 180 px, wide enough to render the compact
+ * DockTab header (two 30 px icon buttons + overflow) without overflow.
+ */
+export const DOCK_HORIZONTAL_ELASTIC_CONFIG = {
+  minPercent: 0.15,
+  maxPercent: 0.8,
+  initialPercent: 0.3,
+} as const
+
+/**
+ * @deprecated Use DOCK_VERTICAL_ELASTIC_CONFIG or DOCK_HORIZONTAL_ELASTIC_CONFIG
+ */
+export const DOCK_ELASTIC_CONFIG = DOCK_VERTICAL_ELASTIC_CONFIG
 
 /**
  * Terminal zone outer elastic config, reserved for future useElasticContainer

--- a/src/features/workspace/panelConfig.ts
+++ b/src/features/workspace/panelConfig.ts
@@ -1,0 +1,55 @@
+/**
+ * Dock panel elastic config, used by WorkspaceView's two useElasticContainer
+ * instances: one for vertical dock size and one for horizontal dock size.
+ */
+export const DOCK_ELASTIC_CONFIG = {
+  minPercent: 0.05,
+  maxPercent: 0.8,
+  initialPercent: 0.3,
+} as const
+
+/** Vertical-axis elastic config for the dock panel (top/bottom positions). */
+export const DOCK_VERTICAL_ELASTIC_CONFIG = DOCK_ELASTIC_CONFIG
+
+/** Horizontal-axis elastic config for the dock panel (left/right positions). */
+export const DOCK_HORIZONTAL_ELASTIC_CONFIG = DOCK_ELASTIC_CONFIG
+
+/**
+ * Terminal zone outer elastic config, reserved for future useElasticContainer
+ * wiring of the whole terminal zone.
+ */
+export const TERMINAL_ZONE_ELASTIC_CONFIG = {
+  minPercent: 0.1,
+  maxPercent: 0.9,
+  initialPercent: 0.5,
+} as const
+
+/**
+ * Per-pane elastic config descriptor for TerminalZone's 1-4 pane splits.
+ * Intentionally omits `containerRef` and `axis`; those are call-site concerns.
+ * Out of scope for this PR, but defined here to avoid a future breaking change.
+ */
+export interface PaneElasticConfig {
+  minPercent: number
+  maxPercent: number
+  /** undefined = compute as 1/paneCount at runtime. */
+  initialPercent: number | undefined
+}
+
+export const TERMINAL_PANE_ELASTIC_CONFIGS: PaneElasticConfig[] = [
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+  { minPercent: 0.1, maxPercent: 0.9, initialPercent: undefined },
+]
+
+/** Keyboard resize step sizes (pixels), shared by all panels. */
+export const KEYBOARD_STEP_PX = 20
+
+export const KEYBOARD_STEP_SHIFT_PX = 100
+
+/**
+ * Minimum side-dock width required to keep DockTab actions inline. Below this,
+ * the dock switcher/file/collapse controls move into the overflow menu.
+ */
+export const DOCK_INLINE_ACTIONS_MIN_WIDTH_PX = 420

--- a/src/hooks/useElasticContainer.test.ts
+++ b/src/hooks/useElasticContainer.test.ts
@@ -179,6 +179,16 @@ describe('useElasticContainer', () => {
     expect(result.current.size).toBeLessThanOrEqual(320)
   })
 
+  test('minPercent 0.15 computes pixelMin as ceil(1200 * 0.15) = 180', () => {
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      minPercent: 0.15,
+      maxPercent: 0.8,
+    })
+
+    expect(result.current.pixelMin).toBe(Math.ceil(CONTAINER_WIDTH * 0.15))
+  })
+
   test('disconnects ResizeObserver on unmount', () => {
     const { unmount } = renderElastic()
 

--- a/src/hooks/useElasticContainer.test.ts
+++ b/src/hooks/useElasticContainer.test.ts
@@ -1,0 +1,198 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useRef } from 'react'
+import { useElasticContainer } from './useElasticContainer'
+
+let observerCallback: ResizeObserverCallback | null = null
+const mockObserve = vi.fn()
+const mockDisconnect = vi.fn()
+const mockUnobserve = vi.fn()
+
+class MockResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    observerCallback = callback
+  }
+
+  observe = mockObserve
+  disconnect = mockDisconnect
+  unobserve = mockUnobserve
+}
+
+vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+const CONTAINER_WIDTH = 1200
+const CONTAINER_HEIGHT = 800
+
+beforeEach(() => {
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: CONTAINER_WIDTH,
+    height: CONTAINER_HEIGHT,
+    top: 0,
+    left: 0,
+    right: CONTAINER_WIDTH,
+    bottom: CONTAINER_HEIGHT,
+    x: 0,
+    y: 0,
+    toJSON: (): undefined => undefined,
+  } as DOMRect)
+  observerCallback = null
+  mockObserve.mockClear()
+  mockDisconnect.mockClear()
+  mockUnobserve.mockClear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+interface RenderElasticOverrides {
+  axis?: 'horizontal' | 'vertical'
+  minPercent?: number
+  maxPercent?: number
+  initialPercent?: number
+}
+
+const renderElastic = (
+  overrides: RenderElasticOverrides = {}
+): ReturnType<
+  typeof renderHook<ReturnType<typeof useElasticContainer>, unknown>
+> => {
+  const containerElement = document.createElement('div')
+
+  return renderHook(() => {
+    const containerRef = useRef<HTMLDivElement>(containerElement)
+
+    return useElasticContainer({
+      containerRef,
+      axis: 'horizontal',
+      minPercent: 0.05,
+      maxPercent: 0.8,
+      initialPercent: 0.3,
+      ...overrides,
+    })
+  })
+}
+
+describe('useElasticContainer', () => {
+  test('initializes size from initialPercent times container dimension', () => {
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      initialPercent: 0.3,
+    })
+
+    expect(result.current.size).toBe(360)
+  })
+
+  test('initializes pixelMin and pixelMax from percent config', () => {
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      minPercent: 0.05,
+      maxPercent: 0.8,
+    })
+
+    expect(result.current.pixelMin).toBe(60)
+    expect(result.current.pixelMax).toBe(960)
+  })
+
+  test('uses vertical dimension when axis is vertical', () => {
+    const { result } = renderElastic({
+      axis: 'vertical',
+      initialPercent: 0.3,
+    })
+
+    expect(result.current.size).toBe(240)
+  })
+
+  test('defaults initialPercent to midpoint when not provided', () => {
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      minPercent: 0.05,
+      maxPercent: 0.8,
+      initialPercent: undefined,
+    })
+
+    expect(result.current.size).toBe(510)
+  })
+
+  test('throws when containerRef.current is null', () => {
+    expect(() => {
+      renderHook(() => {
+        const containerRef = useRef<HTMLDivElement>(null)
+
+        return useElasticContainer({
+          containerRef,
+          axis: 'horizontal',
+          minPercent: 0.05,
+          maxPercent: 0.8,
+        })
+      })
+    }).toThrow()
+  })
+
+  test('throws when minPercent >= maxPercent in dev', () => {
+    expect(() => {
+      renderElastic({ minPercent: 0.8, maxPercent: 0.05 })
+    }).toThrow()
+  })
+
+  test('ResizeObserver re-clamp updates pixelMin and pixelMax on container resize', () => {
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      minPercent: 0.05,
+      maxPercent: 0.8,
+    })
+
+    act(() => {
+      observerCallback?.(
+        [
+          {
+            contentRect: { width: 800, height: CONTAINER_HEIGHT },
+          } as ResizeObserverEntry,
+        ],
+        {} as ResizeObserver
+      )
+    })
+
+    expect(result.current.pixelMin).toBe(40)
+    expect(result.current.pixelMax).toBe(640)
+  })
+
+  test('ResizeObserver clamps size when container shrinks below current size', () => {
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      minPercent: 0.05,
+      maxPercent: 0.8,
+      initialPercent: 0.7,
+    })
+
+    act(() => {
+      observerCallback?.(
+        [
+          {
+            contentRect: { width: 400, height: CONTAINER_HEIGHT },
+          } as ResizeObserverEntry,
+        ],
+        {} as ResizeObserver
+      )
+    })
+
+    expect(result.current.size).toBeLessThanOrEqual(320)
+  })
+
+  test('disconnects ResizeObserver on unmount', () => {
+    const { unmount } = renderElastic()
+
+    unmount()
+
+    expect(mockDisconnect).toHaveBeenCalled()
+  })
+
+  test('returns handleMouseDown, adjustBy, isDragging, sizeRef', () => {
+    const { result } = renderElastic()
+
+    expect(typeof result.current.handleMouseDown).toBe('function')
+    expect(typeof result.current.adjustBy).toBe('function')
+    expect(typeof result.current.isDragging).toBe('boolean')
+    expect(typeof result.current.sizeRef.current).toBe('number')
+  })
+})

--- a/src/hooks/useElasticContainer.ts
+++ b/src/hooks/useElasticContainer.ts
@@ -113,7 +113,7 @@ export const useElasticContainer = ({
           )
         }
 
-        newMax = newMin
+        newMax = newMin + 1
       }
 
       return { newMin, newMax }

--- a/src/hooks/useElasticContainer.ts
+++ b/src/hooks/useElasticContainer.ts
@@ -96,11 +96,9 @@ export const useElasticContainer = ({
         configuredMax > 1 ||
         configuredMin >= configuredMax
       ) {
-        if (import.meta.env.DEV) {
-          throw new Error(
-            `useElasticContainer: invalid percent bounds minPercent=${configuredMin} maxPercent=${configuredMax}`
-          )
-        }
+        throw new Error(
+          `useElasticContainer: invalid percent bounds minPercent=${configuredMin} maxPercent=${configuredMax}`
+        )
       }
 
       const newMin = Math.ceil(dimension * configuredMin)

--- a/src/hooks/useElasticContainer.ts
+++ b/src/hooks/useElasticContainer.ts
@@ -61,6 +61,20 @@ export const useElasticContainer = ({
   const isDraggingRef = useRef(false)
   const pendingClampRef = useRef(false)
 
+  // desiredPercentRef tracks the user's intended proportional size so that
+  // a window shrink→expand cycle restores the panel to the original proportion
+  // rather than staying at the clamped pixel value.
+  const desiredPercentRef = useRef(
+    initialPercentRef.current ??
+      (minPercentRef.current + maxPercentRef.current) / 2
+  )
+  // Current observed container dimension; used to convert pixel→percent on drag end.
+  const dimensionRef = useRef(0)
+  // Incremented each time the ResizeObserver drives a size change, so the
+  // useLayoutEffect below can distinguish observer-driven from user-driven updates.
+  const observerUpdateCountRef = useRef(0)
+  const prevObserverUpdateCountRef = useRef(0)
+
   const resizable = useResizable({
     initial: 0,
     min: pixelMin,
@@ -78,18 +92,38 @@ export const useElasticContainer = ({
   }, [isDragging])
 
   /* eslint-disable react-hooks/exhaustive-deps */
-  // sizeRef/pixelMinRef/pixelMaxRef are stable refs — their identity never
-  // changes and .current mutations are not reactive, so they are intentionally
-  // omitted from the dep array (exhaustive-deps would add them but refs are
-  // never the right reactive trigger).
+  // sizeRef/pixelMinRef/pixelMaxRef/dimensionRef/desiredPercentRef are stable refs —
+  // their identity never changes and .current mutations are not reactive.
   useEffect(() => {
     if (isDragging || !pendingClampRef.current) {
       return
     }
 
     pendingClampRef.current = false
-    resetToSize(sizeRef.current, pixelMinRef.current, pixelMaxRef.current)
+
+    const targetPx =
+      dimensionRef.current > 0
+        ? Math.round(dimensionRef.current * desiredPercentRef.current)
+        : sizeRef.current
+    resetToSize(targetPx, pixelMinRef.current, pixelMaxRef.current)
   }, [isDragging, resetToSize])
+
+  // Update desiredPercent when the user explicitly changes size (drag end or keyboard).
+  // Skip updates caused by the ResizeObserver (observerUpdateCount changed) so that
+  // container shrink→expand cycles restore the user's original proportion.
+  useLayoutEffect(() => {
+    if (prevObserverUpdateCountRef.current !== observerUpdateCountRef.current) {
+      prevObserverUpdateCountRef.current = observerUpdateCountRef.current
+
+      return
+    }
+    if (dimensionRef.current > 0) {
+      desiredPercentRef.current = Math.min(
+        Math.max(sizeRef.current / dimensionRef.current, minPercentRef.current),
+        maxPercentRef.current
+      )
+    }
+  }, [resizable.size])
   /* eslint-enable react-hooks/exhaustive-deps */
 
   const computeBounds = useCallback(
@@ -139,12 +173,15 @@ export const useElasticContainer = ({
       )
     }
 
+    dimensionRef.current = dimension
+
     const { newMin, newMax } = computeBounds(dimension)
 
     const effectiveInitial =
       initialPercentRef.current ??
       (minPercentRef.current + maxPercentRef.current) / 2
     const nextInitial = clampSize(dimension * effectiveInitial, newMin, newMax)
+    desiredPercentRef.current = effectiveInitial
 
     pixelMinRef.current = newMin
     pixelMaxRef.current = newMax
@@ -160,11 +197,14 @@ export const useElasticContainer = ({
           ? entry.contentRect.width
           : entry.contentRect.height
 
+      dimensionRef.current = nextDimension
+
       const { newMin: resizedMin, newMax: resizedMax } =
         computeBounds(nextDimension)
 
       pixelMinRef.current = resizedMin
       pixelMaxRef.current = resizedMax
+      observerUpdateCountRef.current += 1
       setPixelMin(resizedMin)
       setPixelMax(resizedMax)
 
@@ -174,7 +214,12 @@ export const useElasticContainer = ({
         return
       }
 
-      resetToSize(sizeRef.current, resizedMin, resizedMax)
+      // Use desiredPercentRef so shrink→expand cycles restore the user's
+      // original proportion rather than anchoring to a clamped pixel value.
+      const proportionalPx = Math.round(
+        nextDimension * desiredPercentRef.current
+      )
+      resetToSize(proportionalPx, resizedMin, resizedMax)
     })
 
     observer.observe(containerElement)

--- a/src/hooks/useElasticContainer.ts
+++ b/src/hooks/useElasticContainer.ts
@@ -197,6 +197,10 @@ export const useElasticContainer = ({
           ? entry.contentRect.width
           : entry.contentRect.height
 
+      if (nextDimension <= 0) {
+        return
+      }
+
       dimensionRef.current = nextDimension
 
       const { newMin: resizedMin, newMax: resizedMax } =

--- a/src/hooks/useElasticContainer.ts
+++ b/src/hooks/useElasticContainer.ts
@@ -129,16 +129,17 @@ export const useElasticContainer = ({
 
     const rect = containerElement.getBoundingClientRect()
     const dimension = axis === 'horizontal' ? rect.width : rect.height
-    const { newMin, newMax } = computeBounds(dimension)
 
-    // Mount-time degenerate guard: throw inside useLayoutEffect so React
-    // propagates it to an error boundary (unlike ResizeObserver callbacks,
-    // which run outside React's event loop and bypass error boundaries).
-    if (import.meta.env.DEV && newMin >= newMax) {
+    // Check dimension before computeBounds applies the 1-px floor — a zero
+    // dimension means the container is hidden or collapsed at mount, which
+    // is a configuration error the caller should fix.
+    if (import.meta.env.DEV && dimension <= 0) {
       throw new Error(
-        `useElasticContainer: degenerate container at mount — pixelMin(${newMin}) >= pixelMax(${newMax}). Container may be zero-width/height.`
+        `useElasticContainer: container has zero ${axis === 'horizontal' ? 'width' : 'height'} at mount. The element may be hidden or not yet laid out.`
       )
     }
+
+    const { newMin, newMax } = computeBounds(dimension)
 
     const effectiveInitial =
       initialPercentRef.current ??

--- a/src/hooks/useElasticContainer.ts
+++ b/src/hooks/useElasticContainer.ts
@@ -1,0 +1,187 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react'
+import {
+  clampSize,
+  useResizable,
+  type UseResizableResult,
+} from './useResizable'
+
+export interface UseElasticContainerOptions {
+  /**
+   * Ref to the parent available-area element, not the resizable panel itself.
+   * This is a mount-time constant and must be non-null when layout effects run.
+   */
+  containerRef: RefObject<Element | null>
+  /**
+   * Which dimension to observe. Maps directly to useResizable direction.
+   * This is a mount-time constant.
+   */
+  axis: 'horizontal' | 'vertical'
+  /** Fraction of available dimension for minimum size. */
+  minPercent: number
+  /** Fraction of available dimension for maximum size. */
+  maxPercent: number
+  /** Initial size as fraction of dimension. Defaults to midpoint. */
+  initialPercent?: number
+  invert?: boolean
+  updateMode?: 'live' | 'commit-on-end'
+  onDragPreview?: (size: number) => void
+}
+
+export interface UseElasticContainerResult extends UseResizableResult {
+  pixelMin: number
+  pixelMax: number
+}
+
+export const useElasticContainer = ({
+  containerRef,
+  axis,
+  minPercent,
+  maxPercent,
+  initialPercent,
+  invert = false,
+  updateMode = 'live',
+  onDragPreview = undefined,
+}: UseElasticContainerOptions): UseElasticContainerResult => {
+  const minPercentRef = useRef(minPercent)
+  const maxPercentRef = useRef(maxPercent)
+  const initialPercentRef = useRef(initialPercent)
+
+  const [pixelMin, setPixelMin] = useState(0)
+  const [pixelMax, setPixelMax] = useState(Number.MAX_SAFE_INTEGER)
+
+  const pixelMinRef = useRef(0)
+  const pixelMaxRef = useRef(Number.MAX_SAFE_INTEGER)
+  const isDraggingRef = useRef(false)
+  const pendingClampRef = useRef(false)
+
+  const resizable = useResizable({
+    initial: 0,
+    min: pixelMin,
+    max: pixelMax,
+    direction: axis,
+    invert,
+    updateMode,
+    onDragPreview,
+  })
+
+  const { isDragging, resetToSize, sizeRef } = resizable
+
+  useLayoutEffect(() => {
+    isDraggingRef.current = isDragging
+  }, [isDragging])
+
+  useEffect(() => {
+    if (isDragging || !pendingClampRef.current) {
+      return
+    }
+
+    pendingClampRef.current = false
+    resetToSize(sizeRef.current, pixelMinRef.current, pixelMaxRef.current)
+  }, [isDragging, resetToSize, sizeRef])
+
+  const computeBounds = useCallback(
+    (dimension: number): { newMin: number; newMax: number } => {
+      const configuredMin = minPercentRef.current
+      const configuredMax = maxPercentRef.current
+
+      if (
+        configuredMin <= 0 ||
+        configuredMax > 1 ||
+        configuredMin >= configuredMax
+      ) {
+        if (import.meta.env.DEV) {
+          throw new Error(
+            `useElasticContainer: invalid percent bounds minPercent=${configuredMin} maxPercent=${configuredMax}`
+          )
+        }
+      }
+
+      const newMin = Math.ceil(dimension * configuredMin)
+      let newMax = Math.floor(dimension * configuredMax)
+
+      if (newMin >= newMax) {
+        if (import.meta.env.DEV) {
+          throw new Error(
+            `useElasticContainer: degenerate container: pixelMin(${newMin}) >= pixelMax(${newMax})`
+          )
+        }
+
+        newMax = newMin
+      }
+
+      return { newMin, newMax }
+    },
+    []
+  )
+
+  useLayoutEffect(() => {
+    const containerElement = containerRef.current
+    if (!containerElement) {
+      throw new Error(
+        'useElasticContainer: containerRef.current is null at mount'
+      )
+    }
+
+    const rect = containerElement.getBoundingClientRect()
+    const dimension = axis === 'horizontal' ? rect.width : rect.height
+    const { newMin, newMax } = computeBounds(dimension)
+
+    const effectiveInitial =
+      initialPercentRef.current ??
+      (minPercentRef.current + maxPercentRef.current) / 2
+    const nextInitial = clampSize(dimension * effectiveInitial, newMin, newMax)
+
+    pixelMinRef.current = newMin
+    pixelMaxRef.current = newMax
+    setPixelMin(newMin)
+    setPixelMax(newMax)
+    resetToSize(nextInitial, newMin, newMax)
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+
+      const nextDimension =
+        axis === 'horizontal'
+          ? entry.contentRect.width
+          : entry.contentRect.height
+
+      const { newMin: resizedMin, newMax: resizedMax } =
+        computeBounds(nextDimension)
+
+      pixelMinRef.current = resizedMin
+      pixelMaxRef.current = resizedMax
+      setPixelMin(resizedMin)
+      setPixelMax(resizedMax)
+
+      if (isDraggingRef.current) {
+        pendingClampRef.current = true
+
+        return
+      }
+
+      resetToSize(sizeRef.current, resizedMin, resizedMax)
+    })
+
+    observer.observe(containerElement)
+
+    return (): void => {
+      observer.disconnect()
+    }
+    // axis, percent config, and containerRef are mount-time constants by contract.
+    // Re-running this effect after pixel-bound state updates would reset user size.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return {
+    ...resizable,
+    pixelMin,
+    pixelMax,
+  }
+}

--- a/src/hooks/useElasticContainer.ts
+++ b/src/hooks/useElasticContainer.ts
@@ -77,6 +77,11 @@ export const useElasticContainer = ({
     isDraggingRef.current = isDragging
   }, [isDragging])
 
+  /* eslint-disable react-hooks/exhaustive-deps */
+  // sizeRef/pixelMinRef/pixelMaxRef are stable refs — their identity never
+  // changes and .current mutations are not reactive, so they are intentionally
+  // omitted from the dep array (exhaustive-deps would add them but refs are
+  // never the right reactive trigger).
   useEffect(() => {
     if (isDragging || !pendingClampRef.current) {
       return
@@ -84,7 +89,8 @@ export const useElasticContainer = ({
 
     pendingClampRef.current = false
     resetToSize(sizeRef.current, pixelMinRef.current, pixelMaxRef.current)
-  }, [isDragging, resetToSize, sizeRef])
+  }, [isDragging, resetToSize])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   const computeBounds = useCallback(
     (dimension: number): { newMin: number; newMax: number } => {

--- a/src/hooks/useElasticContainer.ts
+++ b/src/hooks/useElasticContainer.ts
@@ -111,12 +111,6 @@ export const useElasticContainer = ({
       let newMax = Math.floor(dimension * configuredMax)
 
       if (newMin >= newMax) {
-        if (import.meta.env.DEV) {
-          throw new Error(
-            `useElasticContainer: degenerate container: pixelMin(${newMin}) >= pixelMax(${newMax})`
-          )
-        }
-
         newMax = newMin + 1
       }
 
@@ -136,6 +130,15 @@ export const useElasticContainer = ({
     const rect = containerElement.getBoundingClientRect()
     const dimension = axis === 'horizontal' ? rect.width : rect.height
     const { newMin, newMax } = computeBounds(dimension)
+
+    // Mount-time degenerate guard: throw inside useLayoutEffect so React
+    // propagates it to an error boundary (unlike ResizeObserver callbacks,
+    // which run outside React's event loop and bypass error boundaries).
+    if (import.meta.env.DEV && newMin >= newMax) {
+      throw new Error(
+        `useElasticContainer: degenerate container at mount — pixelMin(${newMin}) >= pixelMax(${newMax}). Container may be zero-width/height.`
+      )
+    }
 
     const effectiveInitial =
       initialPercentRef.current ??

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -792,4 +792,99 @@ describe('useResizable', () => {
 
     expect(result.current.size).toBe(100)
   })
+
+  describe('resetToSize', () => {
+    test('sets size to clamped value', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.resetToSize(300)
+      })
+
+      expect(result.current.size).toBe(300)
+    })
+
+    test('clamps to min when value is below min', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.resetToSize(50)
+      })
+
+      expect(result.current.size).toBe(100)
+    })
+
+    test('clamps to max when value is above max', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.resetToSize(600)
+      })
+
+      expect(result.current.size).toBe(500)
+    })
+
+    test('uses explicit bounds when provided, bypassing closure min/max', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.resetToSize(800, 50, 900)
+      })
+
+      expect(result.current.size).toBe(800)
+    })
+
+    test('updates previewSize so adjustBy baseline is fresh after reset', async () => {
+      const { result } = renderHook(() =>
+        useResizable({
+          initial: 256,
+          min: 100,
+          max: 500,
+          updateMode: 'commit-on-end',
+        })
+      )
+
+      act(() => {
+        result.current.resetToSize(400)
+      })
+
+      act(() => {
+        result.current.adjustBy(0)
+      })
+
+      await waitFor(() => {
+        expect(result.current.size).toBe(400)
+      })
+    })
+  })
+
+  describe('sizeRef', () => {
+    test('sizeRef.current matches size on initial render', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      expect(result.current.sizeRef.current).toBe(256)
+    })
+
+    test('sizeRef.current updates synchronously after resetToSize', () => {
+      const { result } = renderHook(() =>
+        useResizable({ initial: 256, min: 100, max: 500 })
+      )
+
+      act(() => {
+        result.current.resetToSize(350)
+      })
+
+      expect(result.current.sizeRef.current).toBe(350)
+    })
+  })
 })

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -4,6 +4,7 @@ import {
   useRef,
   useEffect,
   useLayoutEffect,
+  type MutableRefObject,
 } from 'react'
 
 export const clampSize = (value: number, min: number, max: number): number =>
@@ -52,6 +53,14 @@ export interface UseResizableResult {
    * mouse-driven adjustment.
    */
   adjustBy: (delta: number) => void
+  /**
+   * Set size to an absolute pixel value, clamped to [min, max].
+   * Pass explicitMin/explicitMax to bypass stale closure bounds when this is
+   * called alongside bound state updates from ResizeObserver callbacks.
+   */
+  resetToSize: (px: number, explicitMin?: number, explicitMax?: number) => void
+  /** Synchronous read of the last committed size; safe to read in callbacks. */
+  sizeRef: MutableRefObject<number>
 }
 
 export const useResizable = ({
@@ -266,5 +275,30 @@ export const useResizable = ({
     [min, max, cancelPendingSize, commitSize]
   )
 
-  return { size, isDragging, handleMouseDown, adjustBy }
+  const resetToSize = useCallback(
+    (px: number, explicitMin?: number, explicitMax?: number): void => {
+      const clampMin = explicitMin ?? min
+      const clampMax = explicitMax ?? max
+      cancelPendingSize()
+      const nextSize = clampSize(px, clampMin, clampMax)
+
+      commitSize(nextSize)
+      previewSize.current = nextSize
+
+      if (isDraggingRef.current) {
+        startPos.current = currentPos.current
+        startSize.current = nextSize
+      }
+    },
+    [min, max, cancelPendingSize, commitSize]
+  )
+
+  return {
+    size,
+    isDragging,
+    handleMouseDown,
+    adjustBy,
+    resetToSize,
+    sizeRef,
+  }
 }


### PR DESCRIPTION
## Summary

- Add `useElasticContainer` — percent-bound, `ResizeObserver`-driven hook wrapping `useResizable`; two instances in `WorkspaceView` (one per axis)
- Extend `useResizable` with `resetToSize(px, explicitMin?, explicitMax?)` and expose `sizeRef: MutableRefObject<number>`
- Add `panelConfig.ts` as single tuning surface for all panel size constants (5 %–80 % defaults, keyboard step sizes, forward-looking terminal configs)
- `DockPanel`: horizontal resize handle for left/right positions with ARIA, keyboard (ArrowLeft/Right, Home/End), and drag; controlled `width` replaces fixed `flex: 0 0 40%`; compact icon-only tab mode when width < 420 px
- `WorkspaceView`: replace `verticalDockResize` with two elastic instances, add `dockCanvasRef`, include horizontal drag in `terminalFitDeferred`
- Tests: `useElasticContainer` unit tests, DockPanel horizontal handle tests, `WorkspaceView.elastic.test.tsx` proves size persistence across close/reopen (closes #217)

## Test plan

- [ ] Run `npm run test` — 2235 tests pass, 0 failures
- [ ] Run `npm run type-check` — no errors
- [ ] Run `npm run lint` — no errors
- [ ] Manually open app, drag bottom dock handle — grows/shrinks past old 640 px cap
- [ ] Switch dock to left position — drag inner-edge handle to resize width
- [ ] Switch dock to right position — drag inner-edge handle to resize width
- [ ] Resize dock, close it, reopen — size persists (issue #217)
- [ ] Shrink window — dock bounds update via ResizeObserver, size clamps if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)