### PR TITLE
[codex] fix e2e chromedriver fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "diff2html": "^3.4.56",
         "electron": "^42.1.0",
         "electron-builder": "^26.8.1",
+        "electron-to-chromium": "^1.5.357",
         "eslint": "^9",
         "eslint-config-prettier": "^10",
         "eslint-plugin-import": "^2",
@@ -10252,9 +10253,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.329",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
-      "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
+      "version": "1.5.357",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+      "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "diff2html": "^3.4.56",
     "electron": "^42.1.0",
     "electron-builder": "^26.8.1",
+    "electron-to-chromium": "^1.5.357",
     "eslint": "^9",
     "eslint-config-prettier": "^10",
     "eslint-plugin-import": "^2",


### PR DESCRIPTION
## Summary

Adds an explicit `electron-to-chromium` dev dependency so WebdriverIO's Electron service has a current offline Electron-to-Chromium version map. This keeps E2E startup deterministic for Electron `42.1.0` even when the service cannot fetch `https://electronjs.org/headers/index.json`.

## Root Cause

After the Electron migration, E2E runs depend on `@wdio/electron-service` resolving the Chromium/Chromedriver version for the locally installed Electron. The lockfile resolved `electron-to-chromium@1.5.329`, whose fallback map only covered Electron 42 alpha releases, so the service could report `Chromedriver vundefined` and fail before launching tests when the live release-map request failed.

## Validation

- `npm run lint`
- `npm run test:e2e:build`
- forced Electron release-map fetch failure plus `npm run test:e2e:core:run`
- `npm run test:e2e:terminal:run`
- `npm run test:e2e:agent:run` (suite started successfully; the fake-Claude spec used its existing host-process skip guard)
- pre-push `npm test` hook passed: 174 files, 2289 passed, 3 skipped
- `git diff --check`