### PR TITLE
feat(command-palette): accent bar + themed scrollbar (#167)

### DIFF
--- a/src/features/command-palette/components/CommandResultItem.test.tsx
+++ b/src/features/command-palette/components/CommandResultItem.test.tsx
@@ -83,7 +83,7 @@ describe('CommandResultItem', () => {
     expect(description).toHaveClass('text-sm')
   })
 
-  test('selected state applies correct background styles without border', () => {
+  test('selected state applies bg tint and 2px left-accent border', () => {
     const mockOnSelect = vi.fn()
 
     render(
@@ -97,7 +97,8 @@ describe('CommandResultItem', () => {
 
     const option = screen.getByRole('option')
     expect(option).toHaveClass('bg-primary-container/10')
-    expect(option).not.toHaveClass('border')
+    expect(option).toHaveClass('border-l-2')
+    expect(option).toHaveClass('border-primary-container')
   })
 
   test('selected state applies filled icon variation', () => {
@@ -117,7 +118,7 @@ describe('CommandResultItem', () => {
     expect(icon).toHaveClass('text-primary-container')
   })
 
-  test('unselected state applies hover background styles', () => {
+  test('unselected state applies hover background and transparent left border placeholder', () => {
     const mockOnSelect = vi.fn()
 
     render(
@@ -132,6 +133,8 @@ describe('CommandResultItem', () => {
     const option = screen.getByRole('option')
     expect(option).toHaveClass('hover:bg-surface-container-highest/50')
     expect(option).not.toHaveClass('bg-primary-container/10')
+    expect(option).toHaveClass('border-l-2')
+    expect(option).toHaveClass('border-transparent')
   })
 
   test('unselected state applies outlined icon variation', () => {

--- a/src/features/command-palette/components/CommandResultItem.tsx
+++ b/src/features/command-palette/components/CommandResultItem.tsx
@@ -20,8 +20,8 @@ export const CommandResultItem = ({
     aria-selected={isSelected}
     onClick={onSelect}
     className={`
-        group px-3 py-2.5 rounded-xl flex items-center justify-between cursor-pointer transition-all
-        ${isSelected ? 'bg-primary-container/10' : 'hover:bg-surface-container-highest/50'}
+        group px-3 py-2.5 rounded-xl flex items-center justify-between cursor-pointer transition-all border-l-2
+        ${isSelected ? 'bg-primary-container/10 border-primary-container' : 'border-transparent hover:bg-surface-container-highest/50'}
       `}
   >
     <div className="flex items-center gap-3">

--- a/src/features/command-palette/components/CommandResults.test.tsx
+++ b/src/features/command-palette/components/CommandResults.test.tsx
@@ -214,7 +214,12 @@ describe('CommandResults', () => {
 
     const listbox = screen.getByRole('listbox')
 
-    expect(listbox).toHaveClass('p-2', 'overflow-y-auto', 'max-h-96')
+    expect(listbox).toHaveClass(
+      'thin-scrollbar',
+      'p-2',
+      'overflow-y-auto',
+      'max-h-96'
+    )
   })
 
   test('renders descriptions when present', () => {

--- a/src/features/command-palette/components/CommandResults.tsx
+++ b/src/features/command-palette/components/CommandResults.tsx
@@ -17,7 +17,7 @@ export const CommandResults = ({
   <div
     id="command-palette-listbox"
     role="listbox"
-    className="p-2 overflow-y-auto max-h-96"
+    className="thin-scrollbar p-2 overflow-y-auto max-h-96"
   >
     {filteredResults.map((command, index) => (
       <motion.div


### PR DESCRIPTION
## Summary

Step 8 of the [UI Handoff Migration](docs/superpowers/specs/2026-05-05-ui-handoff-migration-design.md) — closes issue #167 in two commits:

1. **`22b2146` `feat(command-palette): 2px left-accent border on selected row`** — per handoff §4.10, adds a `border-l-2 border-primary-container` accent bar to the selected `CommandResultItem`. Unselected rows get `border-transparent` so the row content does not horizontally shift on selection change.
2. **`b2e6aa5` `fix(command-palette): use thin-scrollbar on results listbox`** — the results list previously used the default browser/system scrollbar, which on WebKitGTK/Linux paints a wide grey track that visually clashed with the dark UI. Apply the project-wide `thin-scrollbar` utility (matches sessions/List, AgentStatusPanel, ExplorerPane, ChangedFilesList, SplitDiffView, etc.).

## Test plan

- [x] `npm run test` — 2289 passed.
- [x] `npm run lint` — clean.
- [x] `npm run type-check` — clean.
- [ ] Manual: open ⌘K palette, scroll, confirm scrollbar is the thin lavender track that matches the sidebar/activity panel. Arrow through results and confirm the 2px lavender accent bar appears on the highlighted row without content jiggling.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)