### PR TITLE
fix(dock): raise resize-handle z-index above DockTab + restore Top position

### DIFF
--- a/src/features/workspace/components/DockPanel.test.tsx
+++ b/src/features/workspace/components/DockPanel.test.tsx
@@ -145,6 +145,21 @@ describe('DockPanel', () => {
     expect(screen.getByTestId('resize-handle')).toBeInTheDocument()
   })
 
+  test('resize handle has z-index so it paints above the DockTab header', () => {
+    // Regression for the bottom-dock "can't resize" bug: the handle is
+    // a `position:absolute` sibling of the `position:relative` DockTab.
+    // Both default to `z-index: auto`, and DOM order ties resolve to the
+    // later sibling, so without an explicit z-index the DockTab paints
+    // over the handle and swallows every mousedown at the boundary.
+    for (const position of ['bottom', 'top', 'left', 'right'] as const) {
+      const { unmount } = renderDockPanel({ position })
+
+      expect(screen.getByTestId('resize-handle').className).toMatch(/\bz-10\b/)
+
+      unmount()
+    }
+  })
+
   test('renders horizontal resize handle for left dock', () => {
     renderDockPanel({ position: 'left' })
 

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -278,7 +278,11 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
             tabIndex={0}
             onMouseDown={onVerticalResizeMouseDown}
             onKeyDown={handleVerticalKeyDown}
-            className={`absolute ${position === 'top' ? 'bottom-0' : 'top-0'} left-0 right-0 h-1 cursor-ns-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
+            // z-10 keeps the 4-px handle above the DockTab header
+            // (`relative` sibling) and the content area; without it,
+            // both later-in-source-order children paint on top and
+            // swallow mousedown events at the handle's coordinates.
+            className={`absolute ${position === 'top' ? 'bottom-0' : 'top-0'} left-0 right-0 z-10 h-1 cursor-ns-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
               isVerticalResizing ? 'bg-primary/30' : ''
             }`}
           />
@@ -294,7 +298,7 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
             tabIndex={0}
             onMouseDown={onHorizontalResizeMouseDown}
             onKeyDown={handleHorizontalKeyDown}
-            className={`absolute ${position === 'right' ? 'left-0' : 'right-0'} top-0 bottom-0 w-1 cursor-col-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
+            className={`absolute ${position === 'right' ? 'left-0' : 'right-0'} top-0 bottom-0 z-10 w-1 cursor-col-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
               isHorizontalResizing ? 'bg-primary/30' : ''
             }`}
           />

--- a/src/features/workspace/components/DockSwitcher.test.tsx
+++ b/src/features/workspace/components/DockSwitcher.test.tsx
@@ -4,8 +4,12 @@ import { describe, test, expect, vi } from 'vitest'
 import { DockSwitcher } from './DockSwitcher'
 
 describe('DockSwitcher', () => {
-  test('renders bottom / left / right buttons', () => {
+  test('renders top / bottom / left / right buttons', () => {
     render(<DockSwitcher position="bottom" onPick={vi.fn()} />)
+
+    expect(
+      screen.getByRole('button', { name: /dock: top/i })
+    ).toBeInTheDocument()
 
     expect(
       screen.getByRole('button', { name: /dock: bottom/i })
@@ -20,12 +24,14 @@ describe('DockSwitcher', () => {
     ).toBeInTheDocument()
   })
 
-  test('does not render a Top button (deferred to follow-up)', () => {
-    render(<DockSwitcher position="bottom" onPick={vi.fn()} />)
+  test('clicking Top calls onPick with "top"', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    render(<DockSwitcher position="bottom" onPick={onPick} />)
 
-    expect(
-      screen.queryByRole('button', { name: /dock: top/i })
-    ).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /dock: top/i }))
+
+    expect(onPick).toHaveBeenCalledWith('top')
   })
 
   test('does not render a Hidden button', () => {

--- a/src/features/workspace/components/DockSwitcher.tsx
+++ b/src/features/workspace/components/DockSwitcher.tsx
@@ -8,6 +8,7 @@ interface DockSwitcherProps {
 }
 
 const OPTIONS: { id: DockPosition; label: string }[] = [
+  { id: 'top', label: 'Top' },
   { id: 'bottom', label: 'Bottom' },
   { id: 'left', label: 'Left' },
   { id: 'right', label: 'Right' },


### PR DESCRIPTION
## Summary

Two related dock fixes flagged on PR #219:

**Bottom-dock can't resize.** The `position:absolute` 4-px resize handle (`top-0 h-1 left-0 right-0`) and the `position:relative` DockTab header (later in DOM order, both `z-index: auto`) painted in document order, so the header silently obscured the handle and swallowed every `mousedown` at the boundary. Verified in-browser — `elementFromPoint(x, handleY)` returned the DockTab strip, not the handle. Adds `z-10` to both vertical (`top`/`bottom`) and horizontal (`left`/`right`) resize handles so they paint above the header.

**`Top` dock position missing from the switcher.** All layout, glyph, and border infrastructure was already in place from PR #215 — only the OPTIONS array deferred it as a follow-up. Adds `{ id: 'top', label: 'Top' }` as the first entry.

### Files

- `src/features/workspace/components/DockPanel.tsx` — `z-10` on both resize handle variants, brief comment explaining the stacking bug
- `src/features/workspace/components/DockPanel.test.tsx` — regression test asserting `z-10` for all four positions
- `src/features/workspace/components/DockSwitcher.tsx` — add `Top` entry to OPTIONS
- `src/features/workspace/components/DockSwitcher.test.tsx` — swap the "no Top button (deferred)" assertion for a four-position render check + `onPick('top')` click test

## Test plan

- [x] `npx vitest run src/features/workspace src/hooks` → 448 tests pass
- [x] `npm run lint` → clean
- [x] `npm run type-check` → clean
- [x] Live verification: `elementFromPoint` at the handle's center returns the resize-handle, not the DockTab; dragging grows/shrinks the bottom dock
- [x] Live verification: DockSwitcher renders all four buttons (Top / Bottom / Left / Right)
- [ ] Manual: click `Top` button — dock moves to top edge with chevron-up collapse icon
- [ ] Manual: drag the resize handle from each of the four positions and confirm size changes