### PR TITLE
feat(git): live HEAD/branch detection with worktree support (#189)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Design specs: [`2026-04-12-agent-status-sidebar/`](docs/superpowers/specs/2026-0
 - Commit-msg hook: conventional commits via commitlint
 - Pre-push hook: full Vitest run
 
+### Linked worktrees inside the repo
+
+If you create linked worktrees inside the project, for example `git worktree add .claude/worktrees/feat-x ...`, add `.claude/worktrees/` to `.gitignore`. Otherwise the directory appears as untracked in `git status` from the main repo, and the watcher fires extra `git-status-changed` events for filesystem activity inside the worktree. Branch labels and the diff panel still stay correct; the watcher is just chattier than necessary.
+
 ## Changelog
 
 See [`CHANGELOG.md`](./CHANGELOG.md) (English) or [`CHANGELOG.zh-CN.md`](./CHANGELOG.zh-CN.md) (简体中文) for the linear timeline of notable changes. Each entry may cross-link review patterns from [`docs/reviews/`](./docs/reviews/CLAUDE.md) that it applied, updated, or created — so the CHANGELOG is the _when_ and `docs/reviews/` is the _why_.

--- a/crates/backend/src/git/mod.rs
+++ b/crates/backend/src/git/mod.rs
@@ -1033,12 +1033,30 @@ pub(crate) async fn git_branch_inner(cwd: String) -> Result<String, String> {
     }
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    if stderr.trim().is_empty() {
-        // Detached HEAD has no symbolic ref; the frontend treats empty as no branch.
-        return Ok(String::new());
+    if !stderr.trim().is_empty() {
+        return Err(format!("git_branch: {stderr}"));
     }
 
-    Err(format!("git_branch: {stderr}"))
+    let mut rev = Command::new("git");
+    rev.arg("-C")
+        .arg(&safe_cwd)
+        .arg("rev-parse")
+        .arg("--short=7")
+        .arg("--verify")
+        .arg("HEAD")
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    let rev_out = run_git_with_timeout(rev).await?;
+
+    if rev_out.status.success() {
+        let sha = String::from_utf8(rev_out.stdout)
+            .map_err(|e| format!("git_branch rev-parse utf8: {}", e))?
+            .trim()
+            .to_string();
+        return Ok(sha);
+    }
+
+    Ok(String::new())
 }
 
 #[cfg(test)]
@@ -1754,7 +1772,7 @@ copy to copy.txt
     }
 
     #[tokio::test]
-    async fn test_git_branch_returns_empty_for_detached_head() {
+    async fn test_git_branch_detached_head_returns_short_sha() {
         use std::process::Command;
 
         let tmp = home_tempdir();
@@ -1772,8 +1790,20 @@ copy to copy.txt
 
         configure_test_git(repo_path);
 
+        std::fs::write(repo_path.join("seed"), "seed").expect("failed to write seed");
+        let add_out = Command::new("git")
+            .args(["add", "."])
+            .current_dir(repo_path)
+            .output()
+            .expect("git add failed");
+        assert!(
+            add_out.status.success(),
+            "git add must succeed: {}",
+            String::from_utf8_lossy(&add_out.stderr)
+        );
+
         let commit_out = Command::new("git")
-            .args(["commit", "--allow-empty", "-m", "init"])
+            .args(["commit", "-m", "seed"])
             .current_dir(repo_path)
             .output()
             .expect("git commit failed");
@@ -1783,21 +1813,44 @@ copy to copy.txt
             String::from_utf8_lossy(&commit_out.stderr)
         );
 
-        let checkout_out = Command::new("git")
-            .args(["checkout", "--detach", "HEAD"])
+        let rev_out = Command::new("git")
+            .args(["rev-parse", "HEAD"])
             .current_dir(repo_path)
             .output()
-            .expect("git checkout failed");
+            .expect("git rev-parse failed");
         assert!(
-            checkout_out.status.success(),
-            "git checkout must succeed: {}",
-            String::from_utf8_lossy(&checkout_out.stderr)
+            rev_out.status.success(),
+            "git rev-parse must succeed: {}",
+            String::from_utf8_lossy(&rev_out.stderr)
+        );
+        let full_sha = String::from_utf8(rev_out.stdout)
+            .expect("sha should be utf8")
+            .trim()
+            .to_string();
+
+        let switch_out = Command::new("git")
+            .args(["switch", "--detach", &full_sha])
+            .current_dir(repo_path)
+            .output()
+            .expect("git switch failed");
+        assert!(
+            switch_out.status.success(),
+            "git switch must succeed: {}",
+            String::from_utf8_lossy(&switch_out.stderr)
         );
 
         let path = repo_path.to_string_lossy().to_string();
         let branch = git_branch(path).await.expect("git_branch");
 
-        assert_eq!(branch, "");
+        assert_eq!(
+            branch.len(),
+            7,
+            "short SHA should be exactly 7 chars: {branch:?}"
+        );
+        assert!(
+            full_sha.starts_with(&branch),
+            "short SHA must be a prefix of the full SHA: short={branch} full={full_sha}"
+        );
     }
 
     #[tokio::test]

--- a/crates/backend/src/git/test_helpers.rs
+++ b/crates/backend/src/git/test_helpers.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use tempfile::TempDir;
@@ -30,4 +30,75 @@ pub fn configure_test_git(repo_path: &Path) {
             .output()
             .expect("git config failed");
     }
+}
+
+/// Create a main repo plus linked worktrees in a tempdir under `$HOME`.
+/// Worktrees are siblings of the main repo so the main working tree does not
+/// see them as untracked nested directories.
+pub(crate) fn create_main_repo_with_worktrees(
+    branches: &[&str],
+) -> (TempDir, PathBuf, Vec<PathBuf>) {
+    let tmp = home_tempdir();
+    let main = tmp.path().join("main");
+    std::fs::create_dir(&main).expect("failed to create main repo dir");
+
+    let init = Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(&main)
+        .output()
+        .expect("git init failed");
+    assert!(
+        init.status.success(),
+        "git init must succeed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    configure_test_git(&main);
+    std::fs::write(main.join("seed"), "seed").expect("failed to write seed");
+
+    let add = Command::new("git")
+        .args(["add", "."])
+        .current_dir(&main)
+        .output()
+        .expect("git add failed");
+    assert!(
+        add.status.success(),
+        "git add must succeed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    let commit = Command::new("git")
+        .args(["commit", "-m", "seed"])
+        .current_dir(&main)
+        .output()
+        .expect("git commit failed");
+    assert!(
+        commit.status.success(),
+        "git commit must succeed: {}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+
+    let mut worktrees = Vec::with_capacity(branches.len());
+    for (index, branch) in branches.iter().enumerate() {
+        let worktree = tmp.path().join(format!("wt-{index}"));
+        let add_worktree = Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                worktree.to_str().expect("worktree path should be utf8"),
+            ])
+            .current_dir(&main)
+            .output()
+            .expect("git worktree add failed");
+        assert!(
+            add_worktree.status.success(),
+            "git worktree add must succeed: {}",
+            String::from_utf8_lossy(&add_worktree.stderr)
+        );
+        worktrees.push(worktree);
+    }
+
+    (tmp, main, worktrees)
 }

--- a/crates/backend/src/git/watcher.rs
+++ b/crates/backend/src/git/watcher.rs
@@ -445,6 +445,20 @@ fn path_is_inside_git_dir(path: &std::path::Path, git_dir: &std::path::Path) -> 
     path.parent() == Some(git_dir)
 }
 
+/// Returns true iff `reader` produces content different from the cached
+/// `last_content`. Always updates `last_content` on a successful read.
+///
+/// Seeding behaviour: when `last_content` is `None` and the read succeeds,
+/// the cache is seeded with the current content and the function returns
+/// `false`. This is intentional — the first observation establishes the
+/// baseline and must not be treated as a change, because every fresh
+/// subscription already emits an initial `git-head-changed` (see
+/// `start_git_watcher_inner`'s initial-emit path). Returning `true` here
+/// would double-fire on every subscribe.
+///
+/// Read errors return `false` and leave `last_content` untouched, so a
+/// transient `<git_dir>/HEAD` read failure (NFS stall, worktree removed,
+/// permissions) doesn't poison the cache.
 fn detect_head_change_with<R, E>(last_content: &mut Option<String>, reader: R) -> bool
 where
     R: FnOnce() -> Result<String, E>,
@@ -1136,6 +1150,7 @@ fn restore_pre_repo_subscribers(
         }
     }
 
+    emit_git_head_changed(&events, subscriber_cwds.clone());
     emit_git_status_changed(&events, subscriber_cwds);
 
     Ok(())

--- a/crates/backend/src/git/watcher.rs
+++ b/crates/backend/src/git/watcher.rs
@@ -250,6 +250,11 @@ struct RepoWatcher {
     /// happens at the watcher level, not at the subscriber level.
     subscribers: HashMap<String, u32>,
 
+    /// Canonical per-worktree gitdir. In the main worktree this is
+    /// `<toplevel>/.git`; in a linked worktree this is the corresponding
+    /// `<main>/.git/worktrees/<name>` directory.
+    _git_dir: PathBuf,
+
     /// The notify watcher instance. Wrapped in `Arc<Mutex<_>>` so the
     /// polling thread can dynamically register newly-created directories
     /// as `NonRecursive` watches (non-recursive inotify does NOT extend
@@ -274,6 +279,15 @@ struct RepoWatcher {
     /// HEAD only moves on commit/checkout. The active reader is the
     /// polling thread; this field roots the Arc.
     _last_status_hash: Arc<Mutex<Option<u64>>>,
+
+    /// Cached `<git_dir>/HEAD` content for the polling fallback. This is
+    /// independent from the status hash because a clean branch switch can
+    /// move HEAD without changing `git status --porcelain`.
+    _last_head_content: Arc<Mutex<Option<String>>>,
+
+    /// Set by the notify callback when it sees `<git_dir>/HEAD`; consumed by
+    /// the debounce trailing edge.
+    _head_dirty: Arc<AtomicBool>,
 }
 
 /// Handle to a pre-repo watcher (watching a directory that is not yet a git repo)
@@ -312,7 +326,8 @@ pub struct GitWatcherState {
     /// keyed by canonical input cwd
     pre_repo_watchers: Arc<Mutex<HashMap<PathBuf, PreRepoWatcher>>>,
 
-    /// Side-map: frontend's original cwd string → canonical repo toplevel.
+    /// Side-map: frontend's original cwd string → (canonical repo toplevel,
+    /// canonical per-worktree gitdir).
     /// Populated on every successful `start_git_watcher_inner` repo-path
     /// insertion; consumed by `stop_git_watcher_inner` to find the right
     /// `repo_watchers` bucket without re-running `rev-parse --show-toplevel`
@@ -324,10 +339,10 @@ pub struct GitWatcherState {
     /// `resolve_toplevel` would fail, the repo-bucket lookup would be
     /// skipped, and the polling thread (kept alive by the un-removed
     /// RepoWatcher) would keep firing `hash_git_status` forever.
-    cwd_to_toplevel: Arc<Mutex<HashMap<String, PathBuf>>>,
+    cwd_to_repo: Arc<Mutex<HashMap<String, (PathBuf, PathBuf)>>>,
 
     /// Side-map: frontend's original cwd string → canonicalized PathBuf
-    /// for **pre-repo** entries. Same role as `cwd_to_toplevel` but for
+    /// for **pre-repo** entries. Same role as `cwd_to_repo` but for
     /// the non-repo path: populated by `start_pre_repo_watcher_inner`,
     /// consumed by `stop_git_watcher_inner` to find the `pre_repo_watchers`
     /// bucket without re-running `validate_cwd`.
@@ -354,6 +369,14 @@ struct GitStatusChangedPayload {
     cwds: Vec<String>,
 }
 
+/// Payload emitted when git HEAD content may have changed.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GitHeadChangedPayload {
+    /// List of input cwds that should refresh their branch label.
+    cwds: Vec<String>,
+}
+
 /// Resolve the git toplevel for a given cwd. Uses `run_sync_with_timeout`
 /// so a hung `git rev-parse` (NFS stall, `.git/index.lock` held by a
 /// crashed process, etc.) can't park the polling thread forever.
@@ -375,6 +398,68 @@ fn resolve_toplevel(cwd: &std::path::Path) -> Result<PathBuf, String> {
     let toplevel = toplevel_str.trim();
 
     Ok(PathBuf::from(toplevel))
+}
+
+/// Resolve the per-worktree gitdir for a given cwd.
+///
+/// `--path-format=absolute` is required because plain `--git-dir` can return
+/// paths relative to the pane cwd. We canonicalize before scope validation so
+/// symlinks inside `.git/` resolve to the actual watched directory.
+fn resolve_git_dir(cwd: &std::path::Path) -> Result<PathBuf, String> {
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C")
+        .arg(cwd)
+        .arg("rev-parse")
+        .arg("--path-format=absolute")
+        .arg("--git-dir")
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    let output = run_sync_with_timeout(cmd, SYNC_GIT_TIMEOUT)?;
+
+    if !output.status.success() {
+        return Err("Not a git repository".to_string());
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let path = PathBuf::from(raw.trim());
+
+    path.canonicalize()
+        .map_err(|e| format!("canonicalize git_dir: {}", e))
+}
+
+/// `<git_dir>/HEAD` exactly. Full-path equality prevents working-tree files
+/// named `HEAD` from being misclassified as branch changes.
+fn path_is_git_head(path: &std::path::Path, git_dir: &std::path::Path) -> bool {
+    path == git_dir.join("HEAD")
+}
+
+/// `<git_dir>/index` exactly.
+fn path_is_git_index(path: &std::path::Path, git_dir: &std::path::Path) -> bool {
+    path == git_dir.join("index")
+}
+
+/// Any top-level path inside `git_dir`. The gitdir watch is non-recursive, but
+/// this still lets the shared notify callback drop gitdir-side noise such as
+/// `config`, `packed-refs`, and `COMMIT_EDITMSG`.
+fn path_is_inside_git_dir(path: &std::path::Path, git_dir: &std::path::Path) -> bool {
+    path.parent() == Some(git_dir)
+}
+
+fn detect_head_change_with<R, E>(last_content: &mut Option<String>, reader: R) -> bool
+where
+    R: FnOnce() -> Result<String, E>,
+{
+    let current = match reader() {
+        Ok(content) => content,
+        Err(_) => return false,
+    };
+
+    let changed = match last_content.as_deref() {
+        Some(previous) => previous != current,
+        None => false,
+    };
+    *last_content = Some(current);
+    changed
 }
 
 /// Hash the current `git status --porcelain=v1 -z --untracked-files=all`
@@ -423,10 +508,9 @@ fn hash_git_status(toplevel: &Path) -> Result<u64, String> {
 ///      inotify watch descriptors accumulate until `max_user_watches` is
 ///      exhausted.
 ///
-/// The explicit `.git/index` and `.git/HEAD` additions in
-/// `start_git_watcher_inner` (which DO need to be watched so staging /
-/// commits fire events) are the ONLY `.git/*` paths that should end up
-/// registered with notify.
+/// The explicit per-worktree gitdir watch in `start_git_watcher_inner`
+/// covers top-level git metadata files such as `HEAD` and `index` without
+/// recursing into `.git/objects`.
 fn enumerate_dirs(toplevel: &std::path::Path) -> Vec<PathBuf> {
     use std::ffi::OsStr;
 
@@ -483,7 +567,7 @@ fn start_git_watcher_inner(
     // `upgrade_to_repo_watcher`, or just a re-subscription after `git init`),
     // the old `cwd_to_safe_pre_repo` mapping is now obsolete. Leaving it
     // would just be a tiny memory leak — stop_git_watcher_inner consults
-    // `cwd_to_toplevel` first so the stale entry can't cause incorrect
+    // `cwd_to_repo` first so the stale entry can't cause incorrect
     // routing — but tidiness wins.
     // Capture the prior pre-repo mapping (if any) but do NOT clean up
     // `pre_repo_watchers` yet. The decision depends on which branch of
@@ -520,11 +604,14 @@ fn start_git_watcher_inner(
         }
     };
 
+    let git_dir =
+        resolve_git_dir(&safe_cwd).and_then(|path| validate_cwd(&path.to_string_lossy()))?;
+
     // Repo-transition path. Only NOW can we safely clean up the prior
     // `pre_repo_watchers` entry for this cwd: the subscriber is moving
     // from pre-repo to repo, so any leftover subscriber row under the
     // old safe_cwd would never be reached again (stop_git_watcher
-    // routes via `cwd_to_toplevel` once we register below). Doing this
+    // routes via `cwd_to_repo` once we register below). Doing this
     // BEFORE `resolve_toplevel` would have been wrong for the still-
     // pre-repo re-subscription case, where `start_pre_repo_watcher_inner`
     // needs the existing refcount to bump rather than recreate from 1
@@ -555,7 +642,7 @@ fn start_git_watcher_inner(
     // lock-free; phase 3 re-acquires A only for the final
     // check-then-insert.
     //
-    // While holding A here, ALSO insert into `cwd_to_toplevel` (lock B).
+    // While holding A here, ALSO insert into `cwd_to_repo` (lock B).
     // `stop_git_watcher_inner` always releases B before acquiring A, so
     // start holding A→B simultaneously is deadlock-free. Without the A+B
     // overlap, a concurrent stop could slip in between A's release and
@@ -569,11 +656,12 @@ fn start_git_watcher_inner(
         if let Some(watcher) = repo_watchers.get_mut(&toplevel) {
             *watcher.subscribers.entry(cwd.to_string()).or_insert(0) += 1;
             state
-                .cwd_to_toplevel
+                .cwd_to_repo
                 .lock()
-                .expect("failed to lock cwd_to_toplevel")
-                .insert(cwd.to_string(), toplevel.clone());
+                .expect("failed to lock cwd_to_repo")
+                .insert(cwd.to_string(), (toplevel.clone(), git_dir.clone()));
             drop(repo_watchers);
+            emit_git_head_changed(&events, vec![cwd.to_string()]);
             emit_git_status_changed(&events, vec![cwd.to_string()]);
             return Ok(());
         }
@@ -582,6 +670,10 @@ fn start_git_watcher_inner(
     // ── Phase 2: build watcher state OUTSIDE locks ────────────────────
     let state_clone = state.clone();
     let last_status_hash = Arc::new(Mutex::new(hash_git_status(&toplevel).ok()));
+    let last_head_content = Arc::new(Mutex::new(
+        std::fs::read_to_string(git_dir.join("HEAD")).ok(),
+    ));
+    let head_dirty = Arc::new(AtomicBool::new(false));
     let stop_flag = Arc::new(AtomicBool::new(false));
     let poll_stop_signal = WatcherStopSignal::new();
     let debounce_tx = {
@@ -589,6 +681,7 @@ fn start_git_watcher_inner(
         let state = state_clone.clone();
         let toplevel = toplevel.clone();
         let stop_flag = stop_flag.clone();
+        let head_dirty = head_dirty.clone();
 
         // Production callers ignore the completion flag — `stop_flag` plus
         // the Drop semantics of the captured Arcs are enough for shutdown.
@@ -597,7 +690,10 @@ fn start_git_watcher_inner(
         let (tx, _completed) = spawn_trailing_debounce_thread(
             stop_flag,
             Duration::from_millis(DEBOUNCE_MS),
-            move || emit_for_all_subscribers(&events, &state, &toplevel),
+            move || {
+                let head_was_dirty = head_dirty.swap(false, Ordering::AcqRel);
+                emit_for_all_subscribers(&events, &state, &toplevel, head_was_dirty);
+            },
         );
         tx
     };
@@ -606,6 +702,8 @@ fn start_git_watcher_inner(
     let notify_watcher = {
         let toplevel = toplevel.clone();
         let debounce_tx = debounce_tx.clone();
+        let git_dir = git_dir.clone();
+        let head_dirty = head_dirty.clone();
 
         notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
             let event = match res {
@@ -628,7 +726,23 @@ fn start_git_watcher_inner(
                 return;
             }
 
-            if debounce_tx.send(()).is_err() {
+            let mut should_forward = false;
+            for path in &event.paths {
+                if path_is_git_head(path, &git_dir) {
+                    head_dirty.store(true, Ordering::Release);
+                    should_forward = true;
+                } else if path_is_git_index(path, &git_dir) {
+                    should_forward = true;
+                } else if path_is_inside_git_dir(path, &git_dir) {
+                    // Drop gitdir-side noise. HEAD and index are handled
+                    // above; config, packed-refs, COMMIT_EDITMSG, etc. do
+                    // not require a branch or status refresh.
+                } else {
+                    should_forward = true;
+                }
+            }
+
+            if should_forward && debounce_tx.send(()).is_err() {
                 log::debug!(
                     "Git watcher debounce thread stopped for {}",
                     toplevel.display()
@@ -659,29 +773,23 @@ fn start_git_watcher_inner(
             dirs_guard.insert(dir);
         }
 
-        // Also watch .git/index and .git/HEAD (non-recursive — never recurse
-        // into .git/ because .git/objects/ would explode the watch count).
-        let git_index = toplevel.join(".git/index");
-        if git_index.exists() {
-            if let Err(e) = watcher_guard.watch(&git_index, RecursiveMode::NonRecursive) {
-                log::warn!("Failed to watch .git/index: {}", e);
-            }
-        }
-
-        let git_head = toplevel.join(".git/HEAD");
-        if git_head.exists() {
-            if let Err(e) = watcher_guard.watch(&git_head, RecursiveMode::NonRecursive) {
-                log::warn!("Failed to watch .git/HEAD: {}", e);
+        // Watch the per-worktree gitdir directory instead of individual files.
+        // Git updates HEAD and index by atomic rename-replace; directory
+        // watches survive those inode swaps, direct file watches do not.
+        if git_dir.exists() {
+            if let Err(e) = watcher_guard.watch(&git_dir, RecursiveMode::NonRecursive) {
+                log::warn!("Failed to watch {}: {}", git_dir.display(), e);
             }
         }
     }
 
-    // Start polling fallback thread with two jobs on the same 10s tick:
-    //   (1) Change detection — hashes `git status --porcelain=v1 -z`
+    // Start polling fallback thread with three jobs on the same 10s tick:
+    //   (1) HEAD detection — compares cached `<git_dir>/HEAD` contents.
+    //   (2) Status detection — hashes `git status --porcelain=v1 -z`
     //       output. Unlike HEAD-only comparison, this catches every
     //       panel-visible change: staging, unstaging, editing tracked
     //       files, creating/deleting untracked files.
-    //   (2) Dynamic dir registration — re-enumerates non-ignored dirs and
+    //   (3) Dynamic dir registration — re-enumerates non-ignored dirs and
     //       registers any not yet watched. Compensates for non-recursive
     //       inotify's inability to extend into post-startup directories.
     let poll_toplevel = toplevel.clone();
@@ -689,8 +797,10 @@ fn start_git_watcher_inner(
     let poll_state = state_clone.clone();
     let poll_thread_stop_signal = poll_stop_signal.clone();
     let poll_last_status_hash = last_status_hash.clone();
+    let poll_last_head_content = last_head_content.clone();
     let poll_watcher = watcher_arc.clone();
     let poll_watched_dirs = watched_dirs.clone();
+    let poll_git_dir = git_dir.clone();
 
     std::thread::spawn(move || {
         loop {
@@ -698,7 +808,25 @@ fn start_git_watcher_inner(
                 break;
             }
 
-            // (1) Change detection via status hash.
+            // (1) Change detection via HEAD contents. This is independent
+            // from status because a clean branch switch can leave porcelain
+            // output unchanged.
+            let head_changed = {
+                let mut last = poll_last_head_content
+                    .lock()
+                    .expect("failed to lock last_head_content");
+                detect_head_change_with(&mut last, || {
+                    std::fs::read_to_string(poll_git_dir.join("HEAD"))
+                })
+            };
+            if head_changed {
+                let cwds = collect_subscriber_cwds(&poll_state, &poll_toplevel);
+                if !cwds.is_empty() {
+                    emit_git_head_changed(&poll_events, cwds);
+                }
+            }
+
+            // (2) Change detection via status hash.
             if let Ok(current_hash) = hash_git_status(&poll_toplevel) {
                 let changed = {
                     let mut last = poll_last_status_hash
@@ -711,11 +839,11 @@ fn start_git_watcher_inner(
                     changed
                 };
                 if changed {
-                    emit_for_all_subscribers(&poll_events, &poll_state, &poll_toplevel);
+                    emit_for_all_subscribers(&poll_events, &poll_state, &poll_toplevel, false);
                 }
             }
 
-            // (2) Register any newly-created non-ignored directories.
+            // (3) Register any newly-created non-ignored directories.
             let new_dirs: Vec<PathBuf> = {
                 let current = enumerate_dirs(&poll_toplevel);
                 let watched = poll_watched_dirs
@@ -758,11 +886,14 @@ fn start_git_watcher_inner(
 
     let repo_watcher = RepoWatcher {
         subscribers,
+        _git_dir: git_dir.clone(),
         _watcher: watcher_arc,
         _watched_dirs: watched_dirs,
         stop_flag,
         poll_stop_signal,
         _last_status_hash: last_status_hash,
+        _last_head_content: last_head_content,
+        _head_dirty: head_dirty,
     };
 
     // ── Phase 3: re-check and insert under lock A ─────────────────────
@@ -777,7 +908,7 @@ fn start_git_watcher_inner(
     //       refcount as if we were a phase-1 hit.
     //   (b) Common case: no race; insert the new watcher.
     //
-    // `cwd_to_toplevel.insert` happens while lock A is still held, same
+    // `cwd_to_repo.insert` happens while lock A is still held, same
     // reasoning as phase 1 — closes the TOCTOU window where a concurrent
     // stop could read empty B, then read empty A, and silently leak the
     // watcher.
@@ -793,26 +924,28 @@ fn start_git_watcher_inner(
             // which stops its debounce and polling threads.
             *existing.subscribers.entry(cwd.to_string()).or_insert(0) += 1;
             state
-                .cwd_to_toplevel
+                .cwd_to_repo
                 .lock()
-                .expect("failed to lock cwd_to_toplevel")
-                .insert(cwd.to_string(), toplevel.clone());
+                .expect("failed to lock cwd_to_repo")
+                .insert(cwd.to_string(), (toplevel.clone(), git_dir.clone()));
             drop(repo_watchers);
             // `repo_watcher` (local) drops here.
+            emit_git_head_changed(&events, vec![cwd.to_string()]);
             emit_git_status_changed(&events, vec![cwd.to_string()]);
             return Ok(());
         }
 
         repo_watchers.insert(toplevel.clone(), repo_watcher);
         state
-            .cwd_to_toplevel
+            .cwd_to_repo
             .lock()
-            .expect("failed to lock cwd_to_toplevel")
-            .insert(cwd.to_string(), toplevel);
+            .expect("failed to lock cwd_to_repo")
+            .insert(cwd.to_string(), (toplevel, git_dir));
         drop(repo_watchers);
     }
 
     // Emit initial event using the frontend's original cwd string.
+    emit_git_head_changed(&events, vec![cwd.to_string()]);
     emit_git_status_changed(&events, vec![cwd.to_string()]);
 
     Ok(())
@@ -852,6 +985,7 @@ fn start_pre_repo_watcher_inner(
             .expect("failed to lock cwd_to_safe_pre_repo")
             .insert(cwd.to_string(), safe_cwd.clone());
 
+        emit_git_head_changed(&events, vec![cwd.to_string()]);
         emit_git_status_changed(&events, vec![cwd.to_string()]);
 
         return Ok(());
@@ -884,7 +1018,8 @@ fn start_pre_repo_watcher_inner(
         .expect("failed to lock cwd_to_safe_pre_repo")
         .insert(cwd.to_string(), safe_cwd);
 
-    // Emit initial event with the frontend's original cwd string
+    // Emit initial events with the frontend's original cwd string
+    emit_git_head_changed(&events, vec![cwd.to_string()]);
     emit_git_status_changed(&events, vec![cwd.to_string()]);
 
     Ok(())
@@ -1081,15 +1216,15 @@ fn upgrade_to_repo_watcher(
         // restore the remaining count directly under the repo watcher so
         // the frontend receives one initial event instead of N.
         if refcount > 1 {
-            let toplevel = state
-                .cwd_to_toplevel
+            let repo = state
+                .cwd_to_repo
                 .lock()
-                .map_err(|e| format!("Failed to lock cwd_to_toplevel: {}", e))?
+                .map_err(|e| format!("Failed to lock cwd_to_repo: {}", e))?
                 .get(&original_cwd)
                 .cloned();
 
-            match toplevel {
-                Some(toplevel) => {
+            match repo {
+                Some((toplevel, _git_dir)) => {
                     let mut repo_watchers = state
                         .repo_watchers
                         .lock()
@@ -1152,38 +1287,38 @@ pub(crate) async fn stop_git_watcher_backend(
 /// Synchronous core of `stop_git_watcher`. Owns its state clone so it can
 /// be called from the blocking pool.
 fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), String> {
-    // First: look up the repo-toplevel from the side-map populated by
+    // First: look up the repo metadata from the side-map populated by
     // `start_git_watcher_inner`. This is critical — re-running
     // `resolve_toplevel(&safe_cwd)` at stop time would fail if `.git`
     // was removed mid-session (agent ran `rm -rf .git`, force-reset,
     // `git filter-repo` etc.), silently skipping the repo-watcher
     // removal and leaking the polling thread. Using the recorded
     // mapping is correct even when the repo no longer resolves.
-    let recorded_toplevel: Option<PathBuf> = {
-        let mut map = state
-            .cwd_to_toplevel
+    let recorded_repo: Option<(PathBuf, PathBuf)> = {
+        let map = state
+            .cwd_to_repo
             .lock()
-            .map_err(|e| format!("Failed to lock cwd_to_toplevel: {}", e))?;
-        // `remove` here is optimistic: if the later repo-watcher lookup
-        // finds nothing, we've also cleaned up the side-map so a future
-        // idempotent stop is a pure no-op. If we stopped the watcher
-        // successfully, the map entry is no longer needed either.
-        map.remove(&cwd)
+            .map_err(|e| format!("Failed to lock cwd_to_repo: {}", e))?;
+        map.get(&cwd).cloned()
     };
 
-    if let Some(canonical) = recorded_toplevel {
+    if let Some((canonical, _git_dir)) = recorded_repo {
         let mut repo_watchers = state
             .repo_watchers
             .lock()
             .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
 
         if let Some(watcher) = repo_watchers.get_mut(&canonical) {
+            let mut remove_cwd_mapping = false;
             if let Some(count) = watcher.subscribers.get_mut(&cwd) {
                 *count = count.saturating_sub(1);
 
                 if *count == 0 {
                     watcher.subscribers.remove(&cwd);
+                    remove_cwd_mapping = true;
                 }
+            } else {
+                remove_cwd_mapping = true;
             }
 
             // If no more subscribers, remove the watcher (its Drop fires
@@ -1192,11 +1327,23 @@ fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), Str
                 repo_watchers.remove(&canonical);
             }
 
+            if remove_cwd_mapping {
+                state
+                    .cwd_to_repo
+                    .lock()
+                    .map_err(|e| format!("Failed to lock cwd_to_repo: {}", e))?
+                    .remove(&cwd);
+            }
+
             return Ok(());
         }
         // Recorded mapping but no watcher — fall through (possible if
-        // upgrade/teardown race removed the watcher but not the map
-        // entry; the map-removal above already cleaned up).
+        // upgrade/teardown race removed the watcher but not the map entry).
+        state
+            .cwd_to_repo
+            .lock()
+            .map_err(|e| format!("Failed to lock cwd_to_repo: {}", e))?
+            .remove(&cwd);
     }
 
     // No recorded toplevel → pre-repo watcher path. Look up the canonical
@@ -1205,19 +1352,16 @@ fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), Str
     // pre-existing watchers from before this side-map existed in long-
     // running sessions, though there shouldn't be any in practice).
     //
-    // The side-map removal here is symmetric with `cwd_to_toplevel.remove`
-    // above: it cleans up the map regardless of whether we successfully
-    // stop the watcher, so a future idempotent stop is a pure no-op.
     let recorded_pre_repo: Option<PathBuf> = {
-        let mut map = state
+        let map = state
             .cwd_to_safe_pre_repo
             .lock()
             .map_err(|e| format!("Failed to lock cwd_to_safe_pre_repo: {}", e))?;
-        map.remove(&cwd)
+        map.get(&cwd).cloned()
     };
 
-    let safe_cwd = match recorded_pre_repo {
-        Some(p) => p,
+    let safe_cwd = match &recorded_pre_repo {
+        Some(p) => p.clone(),
         None => {
             // No recorded mapping. Try live validation as a last resort;
             // if even that fails (cwd no longer exists), there's truly
@@ -1235,48 +1379,86 @@ fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), Str
         .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
 
     if let Some(watcher) = pre_repo_watchers.get_mut(&safe_cwd) {
+        let mut remove_cwd_mapping = false;
         if let Some(count) = watcher.subscribers.get_mut(&cwd) {
             *count = count.saturating_sub(1);
 
             if *count == 0 {
                 watcher.subscribers.remove(&cwd);
+                remove_cwd_mapping = true;
             }
+        } else {
+            remove_cwd_mapping = true;
         }
 
         if watcher.subscribers.is_empty() {
             pre_repo_watchers.remove(&safe_cwd);
         }
 
+        if remove_cwd_mapping {
+            state
+                .cwd_to_safe_pre_repo
+                .lock()
+                .map_err(|e| format!("Failed to lock cwd_to_safe_pre_repo: {}", e))?
+                .remove(&cwd);
+        }
+
         return Ok(());
+    }
+
+    if recorded_pre_repo.is_some() {
+        state
+            .cwd_to_safe_pre_repo
+            .lock()
+            .map_err(|e| format!("Failed to lock cwd_to_safe_pre_repo: {}", e))?
+            .remove(&cwd);
     }
 
     // Watcher not found — this is ok (idempotent stop)
     Ok(())
 }
 
-/// Emit git-status-changed event for all subscribers of a repo
+fn collect_subscriber_cwds(state: &GitWatcherState, toplevel: &std::path::Path) -> Vec<String> {
+    let repo_watchers = state
+        .repo_watchers
+        .lock()
+        .expect("failed to lock repo_watchers");
+
+    repo_watchers
+        .get(toplevel)
+        .map(|watcher| {
+            // Subscriber keys are the frontend's original cwd strings — emit
+            // them as-is so listener's `event.cwds.includes(myCwd)` matches.
+            watcher.subscribers.keys().cloned().collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Emit git status/head events for all subscribers of a repo.
 fn emit_for_all_subscribers(
     events: &Arc<dyn EventSink>,
     state: &GitWatcherState,
     toplevel: &std::path::Path,
+    head_was_dirty: bool,
 ) {
-    let cwds: Vec<String> = {
-        let repo_watchers = state
-            .repo_watchers
-            .lock()
-            .expect("failed to lock repo_watchers");
-
-        if let Some(watcher) = repo_watchers.get(toplevel) {
-            // Subscriber keys are the frontend's original cwd strings — emit
-            // them as-is so listener's `event.cwds.includes(myCwd)` matches.
-            watcher.subscribers.keys().cloned().collect()
-        } else {
-            vec![]
-        }
-    };
+    let cwds = collect_subscriber_cwds(state, toplevel);
 
     if !cwds.is_empty() {
+        if head_was_dirty {
+            emit_git_head_changed(events, cwds.clone());
+        }
         emit_git_status_changed(events, cwds);
+    }
+}
+
+/// Emit a git-head-changed event
+fn emit_git_head_changed(events: &Arc<dyn EventSink>, cwds: Vec<String>) {
+    let payload = GitHeadChangedPayload { cwds };
+    let result =
+        serialize_event(&payload).and_then(|payload| events.emit_json("git-head-changed", payload));
+
+    if let Err(e) = result {
+        log::error!("Failed to emit git-head-changed: {}", e);
     }
 }
 
@@ -1293,10 +1475,13 @@ fn emit_git_status_changed(events: &Arc<dyn EventSink>, cwds: Vec<String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_helpers::{configure_test_git, home_tempdir};
+    use super::super::test_helpers::{
+        configure_test_git, create_main_repo_with_worktrees, home_tempdir,
+    };
     use super::*;
     use crate::runtime::FakeEventSink;
     use std::fs;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
     use std::sync::{mpsc, Arc};
     use tempfile::TempDir;
@@ -1314,6 +1499,401 @@ mod tests {
         configure_test_git(temp.path());
 
         temp
+    }
+
+    fn test_setup() -> (GitWatcherState, Arc<FakeEventSink>, Arc<dyn EventSink>) {
+        let state = GitWatcherState::new();
+        let recording = Arc::new(FakeEventSink::new());
+        let sink: Arc<dyn EventSink> = recording.clone();
+
+        (state, recording, sink)
+    }
+
+    fn payload_includes_cwd(payload: &serde_json::Value, cwd: &str) -> bool {
+        payload["cwds"]
+            .as_array()
+            .map(|cwds| cwds.iter().any(|value| value.as_str() == Some(cwd)))
+            .unwrap_or(false)
+    }
+
+    fn wait_for_next_event(
+        sink: &FakeEventSink,
+        event_name: &str,
+        baseline: usize,
+        timeout_ms: u64,
+    ) -> Result<(), String> {
+        if sink.wait_for_count(event_name, baseline + 1, Duration::from_millis(timeout_ms)) {
+            Ok(())
+        } else {
+            Err(format!(
+                "did not see {event_name} #{} within {timeout_ms}ms",
+                baseline + 1
+            ))
+        }
+    }
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("git command failed");
+        assert!(
+            output.status.success(),
+            "git {:?} must succeed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn commit_seed(repo: &Path) {
+        fs::write(repo.join("seed"), "seed").expect("failed to write seed");
+        run_git(repo, &["add", "."]);
+        run_git(repo, &["commit", "-m", "seed"]);
+    }
+
+    #[tokio::test]
+    async fn test_stop_git_watcher_inner_handles_duplicate_starts() {
+        let repo = create_temp_repo();
+        let cwd = repo.path().to_string_lossy().to_string();
+        let (state, _recording, sink) = test_setup();
+
+        start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start 1");
+        start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start 2");
+
+        stop_git_watcher_inner(cwd.clone(), state.clone()).expect("stop 1");
+        {
+            let toplevel = resolve_toplevel(Path::new(&cwd)).expect("resolve");
+            let toplevel_key =
+                validate_cwd(&toplevel.to_string_lossy()).expect("toplevel should validate");
+            let watchers = state
+                .repo_watchers
+                .lock()
+                .expect("failed to lock repo_watchers");
+            assert!(
+                watchers.contains_key(&toplevel_key),
+                "bucket must survive first stop while refcount is still > 0"
+            );
+        }
+
+        stop_git_watcher_inner(cwd.clone(), state.clone()).expect("stop 2");
+        {
+            let toplevel = resolve_toplevel(Path::new(&cwd)).expect("resolve");
+            let toplevel_key =
+                validate_cwd(&toplevel.to_string_lossy()).expect("toplevel should validate");
+            let watchers = state
+                .repo_watchers
+                .lock()
+                .expect("failed to lock repo_watchers");
+            assert!(
+                !watchers.contains_key(&toplevel_key),
+                "bucket must be removed on the last stop"
+            );
+        }
+    }
+
+    #[test]
+    fn test_resolve_git_dir_returns_dotgit_in_main_repo() {
+        let repo = create_temp_repo();
+        let git_dir = resolve_git_dir(repo.path()).expect("resolve");
+        let expected = repo.path().join(".git").canonicalize().expect("canon");
+
+        assert_eq!(git_dir, expected);
+    }
+
+    #[test]
+    fn test_resolve_git_dir_returns_worktree_subdir_in_linked_worktree() {
+        let (_tmp, main, worktrees) = create_main_repo_with_worktrees(&["feat"]);
+        let git_dir = resolve_git_dir(&worktrees[0]).expect("resolve");
+        let expected = main
+            .join(".git/worktrees/wt-0")
+            .canonicalize()
+            .expect("canon");
+
+        assert_eq!(git_dir, expected);
+    }
+
+    #[test]
+    fn test_resolve_git_dir_errors_outside_a_repo() {
+        let temp = home_tempdir();
+        let result = resolve_git_dir(temp.path());
+
+        assert!(result.is_err(), "expected Err for non-repo, got {result:?}");
+    }
+
+    #[test]
+    fn test_path_is_git_head_matches_full_path_only() {
+        let git_dir = PathBuf::from("/tmp/foo/.git");
+        let user_head = PathBuf::from("/tmp/foo/some-dir/HEAD");
+        let real_head = git_dir.join("HEAD");
+
+        assert!(!path_is_git_head(&user_head, &git_dir));
+        assert!(path_is_git_head(&real_head, &git_dir));
+    }
+
+    #[test]
+    fn test_path_is_git_head_does_not_match_packed_refs() {
+        let git_dir = PathBuf::from("/tmp/foo/.git");
+        let packed_refs = git_dir.join("packed-refs");
+
+        assert!(!path_is_git_head(&packed_refs, &git_dir));
+    }
+
+    #[test]
+    fn test_path_is_inside_git_dir_filters_gitdir_noise() {
+        let git_dir = PathBuf::from("/tmp/foo/.git");
+
+        assert!(path_is_inside_git_dir(&git_dir.join("config"), &git_dir));
+        assert!(path_is_inside_git_dir(
+            &git_dir.join("packed-refs"),
+            &git_dir
+        ));
+        assert!(!path_is_inside_git_dir(
+            &PathBuf::from("/tmp/foo/src/lib.rs"),
+            &git_dir
+        ));
+        assert!(!path_is_inside_git_dir(
+            &git_dir.join("hooks").join("pre-commit"),
+            &git_dir
+        ));
+    }
+
+    #[test]
+    fn test_git_head_changed_payload_serializes_camel_case_cwds() {
+        let payload = GitHeadChangedPayload {
+            cwds: vec!["/home/u/repo".to_string()],
+        };
+        let json = serde_json::to_string(&payload).expect("serialize");
+
+        assert_eq!(json, r#"{"cwds":["/home/u/repo"]}"#);
+    }
+
+    #[test]
+    fn test_emit_git_head_changed_writes_to_sink() {
+        let (_state, recording, sink) = test_setup();
+
+        emit_git_head_changed(&sink, vec!["/home/u/repo".to_string()]);
+
+        let recorded = recording.recorded();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].0, "git-head-changed");
+        assert!(payload_includes_cwd(&recorded[0].1, "/home/u/repo"));
+    }
+
+    #[test]
+    fn test_detect_head_change_returns_false_on_first_read_but_seeds_cache() {
+        let mut last: Option<String> = None;
+        let changed = detect_head_change_with(&mut last, || {
+            Ok::<_, std::io::Error>("ref: refs/heads/main\n".to_string())
+        });
+
+        assert!(!changed, "first read seeds the cache without emitting");
+        assert_eq!(last.as_deref(), Some("ref: refs/heads/main\n"));
+    }
+
+    #[test]
+    fn test_detect_head_change_returns_false_when_content_identical() {
+        let mut last: Option<String> = Some("ref: refs/heads/main\n".to_string());
+        let changed = detect_head_change_with(&mut last, || {
+            Ok::<_, std::io::Error>("ref: refs/heads/main\n".to_string())
+        });
+
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_detect_head_change_returns_true_when_ref_differs() {
+        let mut last: Option<String> = Some("ref: refs/heads/main\n".to_string());
+        let changed = detect_head_change_with(&mut last, || {
+            Ok::<_, std::io::Error>("ref: refs/heads/feat\n".to_string())
+        });
+
+        assert!(changed);
+        assert_eq!(last.as_deref(), Some("ref: refs/heads/feat\n"));
+    }
+
+    #[test]
+    fn test_detect_head_change_returns_false_when_read_errs() {
+        let mut last: Option<String> = Some("ref: refs/heads/main\n".to_string());
+        let changed = detect_head_change_with::<_, std::io::Error>(&mut last, || {
+            Err(std::io::Error::new(std::io::ErrorKind::NotFound, "gone"))
+        });
+
+        assert!(!changed);
+        assert_eq!(last.as_deref(), Some("ref: refs/heads/main\n"));
+    }
+
+    #[tokio::test]
+    async fn test_start_git_watcher_emits_initial_git_head_changed() {
+        let repo = create_temp_repo();
+        commit_seed(repo.path());
+        let cwd = repo.path().to_string_lossy().to_string();
+        let (state, recording, sink) = test_setup();
+
+        start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
+
+        let recorded = recording.recorded();
+        assert!(
+            recorded
+                .iter()
+                .any(|(name, payload)| name == "git-head-changed"
+                    && payload_includes_cwd(payload, &cwd)),
+            "expected initial git-head-changed for the new subscriber"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_head_change_in_main_emits_git_head_changed() {
+        let repo = create_temp_repo();
+        commit_seed(repo.path());
+        let cwd = repo.path().to_string_lossy().to_string();
+        let (state, recording, sink) = test_setup();
+        start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
+
+        let baseline = recording.count("git-head-changed");
+        run_git(repo.path(), &["switch", "-c", "feat"]);
+
+        wait_for_next_event(&recording, "git-head-changed", baseline, 2_000).expect("head event");
+    }
+
+    #[tokio::test]
+    async fn test_head_watch_survives_atomic_rename_replace() {
+        let repo = create_temp_repo();
+        commit_seed(repo.path());
+        let cwd = repo.path().to_string_lossy().to_string();
+        let (state, recording, sink) = test_setup();
+        start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
+
+        let baseline1 = recording.count("git-head-changed");
+        run_git(repo.path(), &["switch", "-c", "feat-a"]);
+        wait_for_next_event(&recording, "git-head-changed", baseline1, 2_000).expect("first emit");
+
+        let baseline2 = recording.count("git-head-changed");
+        run_git(repo.path(), &["switch", "-c", "feat-b"]);
+        wait_for_next_event(&recording, "git-head-changed", baseline2, 2_000).expect("second emit");
+    }
+
+    #[tokio::test]
+    async fn test_head_change_in_worktree_emits_for_worktree_only() {
+        let (_tmp, main, worktrees) = create_main_repo_with_worktrees(&["feat"]);
+        let main_cwd = main.to_string_lossy().to_string();
+        let worktree_cwd = worktrees[0].to_string_lossy().to_string();
+        let (state, recording, sink) = test_setup();
+
+        start_git_watcher_inner(&main_cwd, sink.clone(), &state).expect("start main");
+        start_git_watcher_inner(&worktree_cwd, sink.clone(), &state).expect("start worktree");
+        let baseline = recording.count("git-head-changed");
+
+        run_git(&worktrees[0], &["switch", "-c", "feat2"]);
+
+        wait_for_next_event(&recording, "git-head-changed", baseline, 2_000)
+            .expect("head event for worktree");
+        let recorded = recording.recorded();
+        let new_head_events: Vec<_> = recorded
+            .iter()
+            .filter(|(name, _)| name == "git-head-changed")
+            .skip(baseline)
+            .collect();
+        assert!(
+            new_head_events.iter().any(|(_, payload)| {
+                payload_includes_cwd(payload, &worktree_cwd)
+                    && !payload_includes_cwd(payload, &main_cwd)
+            }),
+            "git-head-changed must list only the worktree cwd, got: {new_head_events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pre_repo_upgrades_to_linked_worktree_and_emits_initial_head_event() {
+        let (tmp, main, _worktrees) = create_main_repo_with_worktrees(&[]);
+        let worktree = tmp.path().join("wt-pending");
+        fs::create_dir(&worktree).expect("failed to create pending worktree dir");
+        let worktree_cwd = worktree.to_string_lossy().to_string();
+        let (state, recording, sink) = test_setup();
+
+        start_git_watcher_inner(&worktree_cwd, sink.clone(), &state).expect("subscribe pre-repo");
+        run_git(
+            &main,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feat",
+                worktree.to_str().expect("worktree path should be utf8"),
+            ],
+        );
+
+        let baseline = recording.count("git-head-changed");
+        let result = upgrade_to_repo_watcher(
+            validate_cwd(&worktree_cwd).expect("worktree cwd should validate"),
+            sink.clone(),
+            state.clone(),
+        );
+        assert!(result.is_ok(), "upgrade should succeed: {result:?}");
+
+        wait_for_next_event(&recording, "git-head-changed", baseline, 2_000)
+            .expect("initial git-head-changed on upgrade");
+    }
+
+    #[tokio::test]
+    async fn test_two_worktrees_independent_head_events() {
+        let (_tmp, main, worktrees) = create_main_repo_with_worktrees(&["feat-a", "feat-b"]);
+        let main_cwd = main.to_string_lossy().to_string();
+        let worktree_a_cwd = worktrees[0].to_string_lossy().to_string();
+        let worktree_b_cwd = worktrees[1].to_string_lossy().to_string();
+        let (state, recording, sink) = test_setup();
+
+        start_git_watcher_inner(&main_cwd, sink.clone(), &state).expect("start main");
+        start_git_watcher_inner(&worktree_a_cwd, sink.clone(), &state).expect("start wt a");
+        start_git_watcher_inner(&worktree_b_cwd, sink.clone(), &state).expect("start wt b");
+        let baseline = recording.count("git-head-changed");
+
+        run_git(&worktrees[0], &["switch", "-c", "feat-a-2"]);
+        wait_for_next_event(&recording, "git-head-changed", baseline, 2_000)
+            .expect("head event for wt a");
+
+        let recorded = recording.recorded();
+        let new_head_events: Vec<_> = recorded
+            .iter()
+            .filter(|(name, _)| name == "git-head-changed")
+            .skip(baseline)
+            .collect();
+        assert!(
+            new_head_events
+                .iter()
+                .any(|(_, payload)| payload_includes_cwd(payload, &worktree_a_cwd)),
+            "wt-a should receive its own git-head-changed event"
+        );
+        assert!(
+            new_head_events
+                .iter()
+                .all(|(_, payload)| !payload_includes_cwd(payload, &worktree_b_cwd)),
+            "wt-b must not receive git-head-changed for wt-a, got: {new_head_events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_worktree_removal_drops_branch() {
+        let (_tmp, main, worktrees) = create_main_repo_with_worktrees(&["feat"]);
+        let worktree_cwd = worktrees[0].to_string_lossy().to_string();
+        let (state, _recording, sink) = test_setup();
+
+        start_git_watcher_inner(&worktree_cwd, sink.clone(), &state).expect("start worktree");
+        run_git(
+            &main,
+            &[
+                "worktree",
+                "remove",
+                "--force",
+                worktrees[0].to_str().expect("worktree path should be utf8"),
+            ],
+        );
+
+        let result = crate::git::git_branch_inner(worktree_cwd).await;
+        assert!(
+            result.is_err(),
+            "git_branch must Err after worktree removal, got {result:?}"
+        );
     }
 
     #[test]
@@ -1386,12 +1966,18 @@ mod tests {
         drop(repo_watchers);
 
         let events = sink.recorded();
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].0, "git-status-changed");
-        assert_eq!(
-            events[0].1["cwds"].as_array().expect("cwds array")[0].as_str(),
-            Some(cwd.as_str())
-        );
+        let head_events: Vec<_> = events
+            .iter()
+            .filter(|(event, _)| event == "git-head-changed")
+            .collect();
+        let status_events: Vec<_> = events
+            .iter()
+            .filter(|(event, _)| event == "git-status-changed")
+            .collect();
+        assert_eq!(head_events.len(), 1);
+        assert_eq!(status_events.len(), 1);
+        assert!(payload_includes_cwd(&head_events[0].1, &cwd));
+        assert!(payload_includes_cwd(&status_events[0].1, &cwd));
     }
 
     #[test]

--- a/docs/superpowers/plans/2026-05-19-live-head-branch-worktree.md
+++ b/docs/superpowers/plans/2026-05-19-live-head-branch-worktree.md
@@ -1684,3 +1684,5 @@ git commit -m "docs(readme): recommend gitignore for nested linked worktrees"
 ## Plan Complete
 
 Plan committed. **STOP HERE** — control returns to `/lifeline:planner` for codex plan-complete review. Do NOT chain to `executing-plans` or `subagent-driven-development`. The implementation phase begins after codex review (Step 9.C of the planner skill) finishes and any findings are applied.
+
+<!-- codex-reviewed: 2026-05-19T09:12:26Z -->

--- a/docs/superpowers/plans/2026-05-19-live-head-branch-worktree.md
+++ b/docs/superpowers/plans/2026-05-19-live-head-branch-worktree.md
@@ -16,15 +16,16 @@
 
 Files modified or created in this plan:
 
-| File                                                                    | Responsibility                                                                                          | Action                                         |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| `crates/backend/src/git/watcher.rs`                                     | Watcher core: subscription, FS watch, debounce, polling, event emission. All of §2, §3, the bulk of §5. | Modify (additions + refactor)                  |
-| `crates/backend/src/git/mod.rs`                                         | `git_branch` IPC: branch-name fallback to short SHA. §4 contract change.                                | Modify (one function + tests)                  |
-| `crates/backend/src/git/test_helpers.rs`                                | Worktree fixture used by new unit tests.                                                                | Modify (add `create_main_repo_with_worktrees`) |
-| `src/features/diff/hooks/useGitBranch.ts`                               | Event subscription + watcher lifecycle in the hook. §4 in full.                                         | Modify (add second effect)                     |
-| `src/features/diff/hooks/useGitBranch.test.ts`                          | Vitest hook tests for the event subscription. §6.                                                       | Modify (add tests)                             |
-| `src/features/terminal/components/TerminalPane/HeaderMetadata.test.tsx` | Render tests for SHA-shaped branch values. §6.                                                          | Modify (add tests)                             |
-| `README.md`                                                             | One-line note recommending `.claude/worktrees/` in `.gitignore`. §7 risks.                              | Modify (small docs note)                       |
+| File                                           | Responsibility                                                                                          | Action                                         |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `crates/backend/src/git/watcher.rs`            | Watcher core: subscription, FS watch, debounce, polling, event emission. All of §2, §3, the bulk of §5. | Modify (additions + refactor)                  |
+| `crates/backend/src/git/mod.rs`                | `git_branch` IPC: branch-name fallback to short SHA. §4 contract change.                                | Modify (one function + tests)                  |
+| `crates/backend/src/git/test_helpers.rs`       | Worktree fixture used by new unit tests.                                                                | Modify (add `create_main_repo_with_worktrees`) |
+| `src/features/diff/hooks/useGitBranch.ts`      | Event subscription + watcher lifecycle in the hook. §4 in full.                                         | Modify (add second effect)                     |
+| `src/features/diff/hooks/useGitBranch.test.ts` | Vitest hook tests for the event subscription. §6.                                                       | Modify (add tests)                             |
+| `README.md`                                    | One-line note recommending `.claude/worktrees/` in `.gitignore`. §7 risks.                              | Modify (small docs note)                       |
+
+`HeaderMetadata.tsx` is intentionally NOT in this list: it renders any non-null branch string with `text-on-surface-muted` (verified at `HeaderMetadata.tsx:27-30`). Short-SHA strings render identically to branch names — no component change, no new test needed. Existing `HeaderMetadata.test.tsx` already covers the "branch is any string" case.
 
 The watcher.rs file is large (~1800 lines today) but its existing co-located test module is the right place for the new tests per `rules/rust/testing.md`. Do NOT split watcher.rs in this plan — the changes here are additive and the file's responsibility is unchanged.
 
@@ -67,7 +68,7 @@ Add to `mod tests` in `watcher.rs`:
 async fn test_stop_git_watcher_inner_handles_duplicate_starts() {
     let repo = create_temp_repo();
     let cwd = repo.path().to_string_lossy().to_string();
-    let (state, sink) = test_setup();
+    let (state, recording, sink) = test_setup();
 
     // Two starts for the same cwd.
     start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start 1");
@@ -103,20 +104,33 @@ async fn test_stop_git_watcher_inner_handles_duplicate_starts() {
 }
 ```
 
-`test_setup()` is a helper colocated with existing tests; if not present, add:
+`test_setup()` is a helper colocated with existing tests; if not present, add. **Important:** hold a concrete `Arc<RecordingEventSink>` clone alongside the `Arc<dyn EventSink>` — the trait has no `as_any` downcast, and `RecordingEventSink` (aliased as `FakeEventSink`) is the only sink with `recorded()` / `wait_for_count()` access.
 
 ```rust
-fn test_setup() -> (GitWatcherState, std::sync::Arc<dyn EventSink>) {
+use crate::runtime::test_event_sink::RecordingEventSink;
+
+fn test_setup() -> (GitWatcherState, std::sync::Arc<RecordingEventSink>, std::sync::Arc<dyn EventSink>) {
     let state = GitWatcherState::new();
-    let sink: std::sync::Arc<dyn EventSink> =
-        std::sync::Arc::new(FakeEventSink::new());
-    (state, sink)
+    let recording = std::sync::Arc::new(RecordingEventSink::new());
+    let sink: std::sync::Arc<dyn EventSink> = recording.clone();
+    (state, recording, sink)
+}
+
+/// Recorded payloads are `serde_json::Value`, not strings. Check membership
+/// through the JSON shape rather than substring-matching the Debug repr.
+fn payload_includes_cwd(payload: &serde_json::Value, cwd: &str) -> bool {
+    payload["cwds"]
+        .as_array()
+        .map(|arr| arr.iter().any(|v| v.as_str() == Some(cwd)))
+        .unwrap_or(false)
 }
 ```
 
+Use the `recording: Arc<RecordingEventSink>` handle for assertions and the `sink: Arc<dyn EventSink>` handle when passing into watcher code. `RecordingEventSink::wait_for_count(event, count, timeout)` is the right primitive when waiting for an event to arrive (no manual `clear()` — instead, snapshot the pre-action count and assert post-action count grew).
+
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cargo test -p vimeflow-backend test_stop_git_watcher_inner_handles_duplicate_starts -- --nocapture`
+Run: `cargo test -p vimeflow test_stop_git_watcher_inner_handles_duplicate_starts -- --nocapture`
 Expected: FAIL — second `stop_git_watcher_inner` is a silent no-op today (bucket remains).
 
 - [ ] **Step 3: Replace `remove` with peek-then-conditional-remove in `stop_git_watcher_inner`**
@@ -227,12 +241,12 @@ fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), Str
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `cargo test -p vimeflow-backend test_stop_git_watcher_inner_handles_duplicate_starts -- --nocapture`
+Run: `cargo test -p vimeflow test_stop_git_watcher_inner_handles_duplicate_starts -- --nocapture`
 Expected: PASS.
 
 Also run the full watcher test suite to confirm no regressions:
 
-Run: `cargo test -p vimeflow-backend --lib git::watcher::tests`
+Run: `cargo test -p vimeflow --lib git::watcher::tests`
 Expected: all tests PASS.
 
 - [ ] **Step 5: Commit**
@@ -297,7 +311,7 @@ fn test_resolve_git_dir_errors_outside_a_repo() {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cargo test -p vimeflow-backend resolve_git_dir -- --nocapture`
+Run: `cargo test -p vimeflow resolve_git_dir -- --nocapture`
 Expected: FAIL with "function not found" or compile error.
 
 - [ ] **Step 3: Add `resolve_git_dir` next to `resolve_toplevel` in `watcher.rs`**
@@ -341,7 +355,7 @@ fn resolve_git_dir(cwd: &std::path::Path) -> Result<PathBuf, String> {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p vimeflow-backend resolve_git_dir -- --nocapture`
+Run: `cargo test -p vimeflow resolve_git_dir -- --nocapture`
 Expected: PASS.
 
 - [ ] **Step 5: Widen `cwd_to_toplevel` to carry the `(toplevel, gitdir)` tuple**
@@ -408,7 +422,7 @@ Initialize it in the Phase-2 construction site (around `watcher.rs:830-870`).
 
 - [ ] **Step 7: Run all watcher tests + the new ones**
 
-Run: `cargo test -p vimeflow-backend --lib git::watcher::tests`
+Run: `cargo test -p vimeflow --lib git::watcher::tests`
 Expected: all PASS, including `test_resolve_git_dir_*`.
 
 If the test for `test_stop_git_watcher_inner_handles_duplicate_starts` (Task 1) fails because of the rename, update it to use `cwd_to_repo` and destructure `(toplevel, _gitdir)`.
@@ -442,47 +456,47 @@ async fn test_head_watch_survives_atomic_rename_replace() {
         .current_dir(repo.path()).status().unwrap();
 
     let cwd = repo.path().to_string_lossy().to_string();
-    let (state, sink) = test_setup();
-    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+    let (state, recording, sink) = test_setup();
     start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
 
     // First HEAD movement.
+    let baseline1 = recording.count("git-head-changed");
     Command::new("git").args(["switch", "-c", "feat-a"])
         .current_dir(repo.path()).status().unwrap();
-    wait_for_event(fake, "git-head-changed", 2_000).expect("first emit");
-    fake.clear();
+    wait_for_next_event(&recording, "git-head-changed", baseline1, 2_000).expect("first emit");
 
     // SECOND HEAD movement — would fail on direct-file-watch implementations
     // because git's rename-replace invalidates the file's inode watch.
+    let baseline2 = recording.count("git-head-changed");
     Command::new("git").args(["switch", "-c", "feat-b"])
         .current_dir(repo.path()).status().unwrap();
-    wait_for_event(fake, "git-head-changed", 2_000)
+    wait_for_next_event(&recording, "git-head-changed", baseline2, 2_000)
         .expect("second emit (rename-replace must not break the watch)");
 }
 ```
 
-`wait_for_event` is a polling helper around the FakeEventSink. If not present, add (next to other test helpers):
+`wait_for_next_event` wraps `RecordingEventSink::wait_for_count` to express the test pattern "I expect ONE MORE event after the current baseline." Add next to other test helpers:
 
 ```rust
-fn wait_for_event(
-    sink: &FakeEventSink,
+fn wait_for_next_event(
+    sink: &RecordingEventSink,
     event_name: &str,
+    baseline: usize,
     timeout_ms: u64,
 ) -> Result<(), String> {
-    let start = std::time::Instant::now();
-    while start.elapsed().as_millis() < timeout_ms as u128 {
-        if sink.recorded().iter().any(|(name, _)| name == event_name) {
-            return Ok(());
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+    if sink.wait_for_count(event_name, baseline + 1, std::time::Duration::from_millis(timeout_ms)) {
+        Ok(())
+    } else {
+        Err(format!("did not see {event_name} #{} within {timeout_ms}ms", baseline + 1))
     }
-    Err(format!("did not see {event_name} within {timeout_ms}ms"))
 }
 ```
 
+Test pattern: snapshot `recording.count(event)` BEFORE the action, then call `wait_for_next_event(&recording, event, baseline, timeout)`. Avoids a `clear()` method we don't have.
+
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cargo test -p vimeflow-backend test_head_watch_survives_atomic_rename_replace -- --nocapture`
+Run: `cargo test -p vimeflow test_head_watch_survives_atomic_rename_replace -- --nocapture`
 Expected: FAIL (today's per-file watch goes stale after the first rename; second `git switch` doesn't emit).
 
 - [ ] **Step 3: Change watch registration to watch the gitdir non-recursively**
@@ -512,7 +526,7 @@ Remove the previous `git_index = toplevel.join(".git/index")` and `git_head = to
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `cargo test -p vimeflow-backend test_head_watch_survives_atomic_rename_replace -- --nocapture`
+Run: `cargo test -p vimeflow test_head_watch_survives_atomic_rename_replace -- --nocapture`
 Expected: PASS.
 
 It will likely fail until Task 4 (classification + emit) and Task 6 (debounce wiring) are done. **In that case**, skip ahead — write the test, leave it as `#[ignore]` with a comment `TODO: enable after Task 6`, commit Task 3 with the watch change only, then un-ignore after Task 6.
@@ -538,7 +552,7 @@ Add to `mod tests`:
 
 ```rust
 #[test]
-fn test_head_classification_matches_full_path_only() {
+fn test_path_is_git_head_matches_full_path_only() {
     // A working-tree file whose name happens to be "HEAD" must NOT be
     // misclassified as a git HEAD change.
     let git_dir = PathBuf::from("/tmp/foo/.git");
@@ -552,17 +566,32 @@ fn test_head_classification_matches_full_path_only() {
 }
 
 #[test]
-fn test_head_classification_ignores_packed_refs() {
+fn test_path_is_git_head_does_not_match_packed_refs() {
     let git_dir = PathBuf::from("/tmp/foo/.git");
     let packed_refs = git_dir.join("packed-refs");
     assert!(!path_is_git_head(&packed_refs, &git_dir));
+}
+
+#[test]
+fn test_path_is_inside_git_dir_filters_gitdir_noise() {
+    let git_dir = PathBuf::from("/tmp/foo/.git");
+    assert!(path_is_inside_git_dir(&git_dir.join("config"), &git_dir));
+    assert!(path_is_inside_git_dir(&git_dir.join("packed-refs"), &git_dir));
+    // Working-tree paths are NOT inside git_dir.
+    assert!(!path_is_inside_git_dir(
+        &PathBuf::from("/tmp/foo/src/lib.rs"), &git_dir));
+    // Subdirs of git_dir (e.g. hooks/, refs/heads/) have `parent() == git_dir/<sub>`,
+    // not git_dir itself — they correctly DON'T match. NonRecursive watch on
+    // git_dir never surfaces those paths anyway.
+    assert!(!path_is_inside_git_dir(
+        &git_dir.join("hooks").join("pre-commit"), &git_dir));
 }
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cargo test -p vimeflow-backend path_is_git_head -- --nocapture`
-Expected: FAIL — `path_is_git_head` doesn't exist.
+Run: `cargo test -p vimeflow path_is_git -- --nocapture`
+Expected: FAIL — `path_is_git_head` and friends don't exist.
 
 - [ ] **Step 3: Add the classifier and the `head_dirty` flag**
 
@@ -578,33 +607,54 @@ struct RepoWatcher {
 }
 ```
 
-Add the helper near other private helpers:
+Add the classification helpers near other private helpers. There are THREE relevant categories of path the notify callback may receive (because the single `RecommendedWatcher` serves both the recursive working-tree watch on `<toplevel>` and the non-recursive gitdir watch on `<git_dir>`):
 
 ```rust
-/// True if `path` is exactly `<git_dir>/HEAD`. Compares by full-path
-/// equality rather than filename so a user file like
-/// `<toplevel>/some-dir/HEAD` (delivered by the working-tree recursive
-/// watch into the same notify callback) is not misclassified.
+/// `<git_dir>/HEAD` exactly.
 fn path_is_git_head(path: &std::path::Path, git_dir: &std::path::Path) -> bool {
     path == git_dir.join("HEAD")
 }
+
+/// `<git_dir>/index` exactly.
+fn path_is_git_index(path: &std::path::Path, git_dir: &std::path::Path) -> bool {
+    path == git_dir.join("index")
+}
+
+/// Any path inside `git_dir` (top level only — `NonRecursive` watch doesn't
+/// surface deeper paths, but we still gate). Used to recognize gitdir-side
+/// noise (config, packed-refs, COMMIT_EDITMSG, hooks/, …) that should be
+/// dropped instead of forwarded to the debounce thread.
+fn path_is_inside_git_dir(path: &std::path::Path, git_dir: &std::path::Path) -> bool {
+    path.parent() == Some(git_dir)
+}
 ```
 
-In the notify callback that already exists in `start_git_watcher_inner` (find it by searching for the closure that calls the debounce-channel `tx.send(())`), add classification BEFORE the existing forward:
+In the notify callback inside `start_git_watcher_inner` (find it by searching for the closure that calls `debounce_tx.send(())`), classify by full-path equality AND gate the forward so gitdir-side noise doesn't reach the debounce thread:
 
 ```rust
 let git_dir_for_callback = git_dir.clone();
 let head_dirty_for_callback = head_dirty.clone();
 
-// inside the closure:
+// inside the closure — replaces the existing unconditional forward:
 if let Ok(event) = result {
+    let mut should_forward = false;
     for p in &event.paths {
         if path_is_git_head(p, &git_dir_for_callback) {
             head_dirty_for_callback.store(true, Ordering::Release);
-            break;
+            should_forward = true;
+        } else if path_is_git_index(p, &git_dir_for_callback) {
+            should_forward = true;
+        } else if path_is_inside_git_dir(p, &git_dir_for_callback) {
+            // config / packed-refs / COMMIT_EDITMSG / hooks/ etc. — drop.
+            // Branch name unchanged, working-tree state unchanged: no event needed.
+        } else {
+            // Outside git_dir → working-tree event from the recursive watch.
+            should_forward = true;
         }
     }
-    let _ = debounce_tx.send(());
+    if should_forward {
+        let _ = debounce_tx.send(());
+    }
 }
 ```
 
@@ -618,8 +668,8 @@ and stored in `RepoWatcher`.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p vimeflow-backend path_is_git_head -- --nocapture`
-Expected: PASS.
+Run: `cargo test -p vimeflow path_is_git -- --nocapture`
+Expected: PASS (all three classifier tests).
 
 - [ ] **Step 5: Commit**
 
@@ -653,11 +703,10 @@ fn test_git_head_changed_payload_serializes_camel_case_cwds() {
 #[test]
 fn test_emit_git_head_changed_writes_to_sink() {
     let (_state, sink) = test_setup();
-    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
 
     emit_git_head_changed(&sink, vec!["/home/u/repo".to_string()]);
 
-    let recorded = fake.recorded();
+    let recorded = recording.recorded();
     assert_eq!(recorded.len(), 1);
     assert_eq!(recorded[0].0, "git-head-changed");
     assert!(recorded[0].1.contains("/home/u/repo"));
@@ -666,7 +715,7 @@ fn test_emit_git_head_changed_writes_to_sink() {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cargo test -p vimeflow-backend git_head_changed -- --nocapture`
+Run: `cargo test -p vimeflow git_head_changed -- --nocapture`
 Expected: FAIL — `GitHeadChangedPayload` / `emit_git_head_changed` don't exist.
 
 - [ ] **Step 3: Add the payload and helper next to their `git-status-changed` siblings**
@@ -699,7 +748,7 @@ fn emit_git_head_changed(events: &Arc<dyn EventSink>, cwds: Vec<String>) {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p vimeflow-backend git_head_changed -- --nocapture`
+Run: `cargo test -p vimeflow git_head_changed -- --nocapture`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -731,21 +780,20 @@ async fn test_head_change_in_main_emits_git_head_changed() {
         .current_dir(repo.path()).status().unwrap();
 
     let cwd = repo.path().to_string_lossy().to_string();
-    let (state, sink) = test_setup();
-    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+    let (state, recording, sink) = test_setup();
     start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
 
-    fake.clear();
+    let baseline = recording.count("git-head-changed");
     Command::new("git").args(["switch", "-c", "feat"])
         .current_dir(repo.path()).status().unwrap();
 
-    wait_for_event(fake, "git-head-changed", 2_000).expect("head event");
+    wait_for_next_event(&recording, "git-head-changed", baseline, 2_000).expect("head event");
 }
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cargo test -p vimeflow-backend test_head_change_in_main_emits_git_head_changed -- --nocapture`
+Run: `cargo test -p vimeflow test_head_change_in_main_emits_git_head_changed -- --nocapture`
 Expected: FAIL — no emit path yet.
 
 - [ ] **Step 3: Extend the fan-out helper and the debounce emit**
@@ -789,7 +837,7 @@ emit_for_all_subscribers(&events, &state, &toplevel, head_was_dirty);
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p vimeflow-backend git::watcher::tests --lib`
+Run: `cargo test -p vimeflow git::watcher::tests --lib`
 Expected: all PASS, including `test_head_change_in_main_emits_git_head_changed` and the un-ignored `test_head_watch_survives_atomic_rename_replace`.
 
 - [ ] **Step 5: Commit**
@@ -821,12 +869,11 @@ async fn test_start_git_watcher_emits_initial_git_head_changed() {
         .current_dir(repo.path()).status().unwrap();
 
     let cwd = repo.path().to_string_lossy().to_string();
-    let (state, sink) = test_setup();
-    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+    let (state, recording, sink) = test_setup();
 
     start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
 
-    let recorded = fake.recorded();
+    let recorded = recording.recorded();
     assert!(recorded.iter().any(|(n, p)| n == "git-head-changed" && p.contains(&cwd)),
         "expected initial git-head-changed for the new subscriber, got {:?}",
         recorded.iter().map(|(n, _)| n).collect::<Vec<_>>());
@@ -835,7 +882,7 @@ async fn test_start_git_watcher_emits_initial_git_head_changed() {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cargo test -p vimeflow-backend test_start_git_watcher_emits_initial_git_head_changed -- --nocapture`
+Run: `cargo test -p vimeflow test_start_git_watcher_emits_initial_git_head_changed -- --nocapture`
 Expected: FAIL — only `git-status-changed` is emitted today.
 
 - [ ] **Step 3: Pair every single-cwd `emit_git_status_changed` with `emit_git_head_changed`**
@@ -853,7 +900,7 @@ The `emit_for_all_subscribers` path (multi-cwd, triggered by FS events) is NOT t
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p vimeflow-backend test_start_git_watcher_emits_initial_git_head_changed -- --nocapture`
+Run: `cargo test -p vimeflow test_start_git_watcher_emits_initial_git_head_changed -- --nocapture`
 Expected: PASS.
 
 Also confirm: the existing `test_start_git_watcher_emits_initial_git_status_changed`-style test (if one exists) still passes.
@@ -873,111 +920,170 @@ git commit -m "feat(git-watcher): emit initial git-head-changed on subscribe"
 
 - Modify: `crates/backend/src/git/watcher.rs:684-745` (the polling thread block)
 
-- [ ] **Step 1: Write the failing test**
+**The hard part:** in a real watcher process, the notify thread AND the polling thread both call `emit_git_head_changed` on HEAD movement. An end-to-end test where you `git switch` and assert the event fires CAN'T distinguish "notify caught it" from "polling caught it." Codex flagged this in plan review: testing the polling fallback end-to-end requires either disabling notify (no clean way in `notify` crate) or testing the comparator directly.
+
+Extract the HEAD-content comparison into a free function and unit-test it directly. The polling thread then becomes a thin caller.
+
+- [ ] **Step 1: Write the failing tests for the comparator**
 
 Add to `mod tests`:
 
 ```rust
-#[tokio::test]
-async fn test_polling_emits_head_changed_on_clean_switch_with_unchanged_status() {
-    let repo = create_temp_repo();
-    fs::write(repo.path().join("seed"), "seed").unwrap();
-    Command::new("git").args(["add", "."]).current_dir(repo.path()).status().unwrap();
-    Command::new("git").args(["commit", "-m", "seed"])
-        .current_dir(repo.path()).status().unwrap();
-    // Create a second branch BEFORE we start the watcher so switching to it
-    // doesn't reorder commits in a way that changes status output.
-    Command::new("git").args(["branch", "other"])
-        .current_dir(repo.path()).status().unwrap();
+#[test]
+fn test_detect_head_change_returns_true_on_first_read() {
+    // Initial state: no cached content yet → first read is a "change".
+    let mut last: Option<String> = None;
+    let changed = detect_head_change_with(&mut last, || {
+        Ok::<_, std::io::Error>("ref: refs/heads/main\n".to_string())
+    });
+    assert!(changed);
+    assert_eq!(last.as_deref(), Some("ref: refs/heads/main\n"));
+}
 
-    let cwd = repo.path().to_string_lossy().to_string();
-    let (state, sink) = test_setup();
-    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
-    start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
-    fake.clear();
+#[test]
+fn test_detect_head_change_returns_false_when_content_identical() {
+    let mut last: Option<String> = Some("ref: refs/heads/main\n".to_string());
+    let changed = detect_head_change_with(&mut last, || {
+        Ok::<_, std::io::Error>("ref: refs/heads/main\n".to_string())
+    });
+    assert!(!changed);
+}
 
-    // Simulate inotify being unreliable: switch via plumbing so the file
-    // event might be missed (we can't easily disable notify in tests, but
-    // we CAN verify the polling thread emits independently — wait longer
-    // than POLL_INTERVAL_SECS=10 and assert the event fired without our
-    // having to rely on the notify path).
-    Command::new("git").args(["switch", "other"])
-        .current_dir(repo.path()).status().unwrap();
+#[test]
+fn test_detect_head_change_returns_true_when_ref_differs() {
+    let mut last: Option<String> = Some("ref: refs/heads/main\n".to_string());
+    let changed = detect_head_change_with(&mut last, || {
+        Ok::<_, std::io::Error>("ref: refs/heads/feat\n".to_string())
+    });
+    assert!(changed);
+    assert_eq!(last.as_deref(), Some("ref: refs/heads/feat\n"));
+}
 
-    // Wait up to one poll interval + slack.
-    wait_for_event(fake, "git-head-changed", 12_000).expect("head event");
+#[test]
+fn test_detect_head_change_returns_false_when_read_errs() {
+    // Worktree removed, permissions, etc. — last_content stays as-is.
+    let mut last: Option<String> = Some("ref: refs/heads/main\n".to_string());
+    let changed = detect_head_change_with::<_, std::io::Error>(&mut last, || {
+        Err(std::io::Error::new(std::io::ErrorKind::NotFound, "gone"))
+    });
+    assert!(!changed);
+    assert_eq!(last.as_deref(), Some("ref: refs/heads/main\n"));
 }
 ```
 
-(The test is slow — 10-12 s. Run it under `--release` or accept the wall-clock cost; alternatively make `POLL_INTERVAL_SECS` configurable via env in test builds. For the plan we accept the wall-clock cost on first run; CI can `--test-threads=1` if needed.)
+- [ ] **Step 2: Run tests to verify they fail**
 
-- [ ] **Step 2: Run test to verify it fails**
+Run: `cargo test -p vimeflow detect_head_change -- --nocapture`
+Expected: FAIL — `detect_head_change_with` doesn't exist.
 
-Run: `cargo test -p vimeflow-backend test_polling_emits_head_changed_on_clean_switch_with_unchanged_status -- --nocapture`
-Expected: FAIL if you can suppress notify; PASS today by coincidence because notify still catches it. Treat the assertion as "we don't depend on the notify path" — if the test passes today, that's because notify covered it; the polling path independence still needs the code change for NFS/FUSE reliability. Comment in the test:
+- [ ] **Step 3: Add the comparator and integrate into the polling thread**
 
-```rust
-// This test asserts emission within ~one poll interval. On platforms
-// where notify is reliable it can pass before the poll fires; we add
-// the polling-path code change for NFS/FUSE robustness regardless.
-```
-
-- [ ] **Step 3: Add HEAD-content caching to `RepoWatcher` and compare in the polling thread**
-
-Add field:
+Add near `hash_git_status` in `watcher.rs`:
 
 ```rust
-struct RepoWatcher {
-    // ...
-    last_head_content: Arc<Mutex<Option<String>>>,
-}
-```
-
-Initialize in Phase-2 builder:
-
-```rust
-let initial_head = std::fs::read_to_string(git_dir.join("HEAD")).ok();
-let last_head_content = Arc::new(Mutex::new(initial_head));
-```
-
-Inside the polling thread (around `watcher.rs:695`), add an independent comparison alongside the existing `hash_git_status` check:
-
-```rust
-// (Existing) status-hash comparison emits git-status-changed.
-let status_changed = /* existing block */;
-
-// (NEW) HEAD-content comparison emits git-head-changed independently.
-// hash_git_status does NOT cover HEAD moves on a clean tree, so a
-// `git switch <branch>` against an unmodified tree must be caught here.
-let head_changed = {
-    match std::fs::read_to_string(poll_git_dir.join("HEAD")) {
+/// True iff reading HEAD via `reader` produces content different from
+/// `last_content`. Always updates `last_content` on success. Returns false
+/// on first read with no cached content (the caller should treat the first
+/// successful read as the baseline, NOT as a change — flipping the polarity
+/// would emit a spurious `git-head-changed` immediately on subscribe; that
+/// initial emit is already covered by Task 7's start-of-subscription path).
+fn detect_head_change_with<R, E>(
+    last_content: &mut Option<String>,
+    reader: R,
+) -> bool
+where
+    R: FnOnce() -> Result<String, E>,
+{
+    match reader() {
         Ok(current) => {
-            let mut last = poll_last_head_content.lock().unwrap();
-            let differs = last.as_deref() != Some(current.as_str());
-            if differs {
-                *last = Some(current);
+            let differs = last_content.as_deref() != Some(current.as_str());
+            *last_content = Some(current);
+            // First-read case: differs is true because `None != Some(_)`. The
+            // initial emit on subscribe (Task 7) covers this separately; we
+            // return false here to avoid double-emit.
+            if last_content.is_some() && differs {
+                let was_first = matches!(last_content, Some(_)) && last_content.as_ref().map(|s| s.is_empty()).unwrap_or(false);
+                let _ = was_first;
+                differs
+            } else {
+                differs
             }
-            differs
         }
-        // Read errors (worktree removed, permissions) are not "head
-        // changed" — they'll be visible to git_branch IPC on next call.
         Err(_) => false,
     }
-};
+}
+```
 
+Wait — the "first read isn't a change" logic is fiddly. Cleaner: only return `true` when `last_content` was `Some(prev)` and `prev != current`:
+
+```rust
+fn detect_head_change_with<R, E>(
+    last_content: &mut Option<String>,
+    reader: R,
+) -> bool
+where
+    R: FnOnce() -> Result<String, E>,
+{
+    let current = match reader() {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let differs = match last_content.as_deref() {
+        Some(prev) => prev != current,
+        None => false, // First successful read seeds the cache without emitting.
+    };
+    *last_content = Some(current);
+    differs
+}
+```
+
+Update the first test accordingly: `test_detect_head_change_returns_true_on_first_read` becomes `test_detect_head_change_returns_false_on_first_read_but_seeds_cache`:
+
+```rust
+#[test]
+fn test_detect_head_change_returns_false_on_first_read_but_seeds_cache() {
+    let mut last: Option<String> = None;
+    let changed = detect_head_change_with(&mut last, || {
+        Ok::<_, std::io::Error>("ref: refs/heads/main\n".to_string())
+    });
+    assert!(!changed, "first read seeds the cache without emitting");
+    assert_eq!(last.as_deref(), Some("ref: refs/heads/main\n"));
+}
+```
+
+The polling thread then becomes a thin caller around this helper:
+
+```rust
+// Inside the polling-thread closure, alongside the existing status-hash compare:
+let head_changed = {
+    let mut last = poll_last_head_content.lock().unwrap();
+    detect_head_change_with(&mut last, || {
+        std::fs::read_to_string(poll_git_dir.join("HEAD"))
+    })
+};
 if head_changed {
     let cwds = collect_subscriber_cwds(&poll_state, &poll_toplevel);
     if !cwds.is_empty() {
         emit_git_head_changed(&poll_events, cwds);
     }
 }
-
-if status_changed {
-    emit_for_all_subscribers(/* head_was_dirty: */ false, ...);
-}
 ```
 
-(Clone `git_dir` and `last_head_content` into the polling thread's captures alongside the existing `poll_toplevel`, `poll_state`, etc.)
+Seed the cache at `RepoWatcher` construction (Phase 2 builder):
+
+```rust
+let initial_head = std::fs::read_to_string(git_dir.join("HEAD")).ok();
+let last_head_content = Arc::new(Mutex::new(initial_head));
+```
+
+Note: the initial seed bypasses `detect_head_change_with` (no comparator runs); first poll-cycle read will compare against the seeded content.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p vimeflow detect_head_change -- --nocapture`
+Expected: PASS (all four comparator tests).
+
+Optional end-to-end check (slow, depends on POLL_INTERVAL_SECS=10): add a separate `#[tokio::test] #[ignore] async fn` that performs the live `git switch` and waits ~12 s. Marked `#[ignore]` so it doesn't slow normal CI runs; run with `cargo test -- --ignored` for manual verification.
 
 Extract a small helper for the subscriber-list collection if the body repeats too much:
 
@@ -991,10 +1097,14 @@ fn collect_subscriber_cwds(state: &GitWatcherState, toplevel: &std::path::Path) 
 }
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+Add `last_head_content` to `RepoWatcher`:
 
-Run: `cargo test -p vimeflow-backend test_polling_emits_head_changed_on_clean_switch_with_unchanged_status -- --nocapture --test-threads=1`
-Expected: PASS within ~12 s.
+```rust
+struct RepoWatcher {
+    // ...
+    last_head_content: Arc<Mutex<Option<String>>>,
+}
+```
 
 - [ ] **Step 5: Commit**
 
@@ -1046,10 +1156,10 @@ Also confirm `test_git_branch_returns_error_for_non_repo_cwd` (around `mod.rs:18
 
 - [ ] **Step 2: Run tests to verify the detached test now fails**
 
-Run: `cargo test -p vimeflow-backend test_git_branch_detached_head_returns_short_sha -- --nocapture`
+Run: `cargo test -p vimeflow test_git_branch_detached_head_returns_short_sha -- --nocapture`
 Expected: FAIL — current impl returns `""`.
 
-Also run: `cargo test -p vimeflow-backend test_git_branch_returns_error_for_non_repo_cwd -- --nocapture`
+Also run: `cargo test -p vimeflow test_git_branch_returns_error_for_non_repo_cwd -- --nocapture`
 Expected: PASS (we want it to keep passing after the change).
 
 - [ ] **Step 3: Implement the short-SHA fallback in `git_branch_inner`**
@@ -1112,7 +1222,7 @@ pub(crate) async fn git_branch_inner(cwd: String) -> Result<String, String> {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p vimeflow-backend test_git_branch_ -- --nocapture`
+Run: `cargo test -p vimeflow test_git_branch_ -- --nocapture`
 Expected: all `test_git_branch_*` PASS, including:
 
 - `test_git_branch_returns_default_branch_for_unborn_repo`
@@ -1402,19 +1512,19 @@ async fn test_head_change_in_worktree_emits_for_worktree_only() {
         create_main_repo_with_worktrees(&["feat"]);
     let main_cwd = main.to_string_lossy().to_string();
     let wt_cwd = wts[0].to_string_lossy().to_string();
-    let (state, sink) = test_setup();
-    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+    let (state, recording, sink) = test_setup();
 
     start_git_watcher_inner(&main_cwd, sink.clone(), &state).expect("start main");
     start_git_watcher_inner(&wt_cwd, sink.clone(), &state).expect("start wt");
-    fake.clear();
+    let baseline = recording.count("git-head-changed");
 
     Command::new("git").args(["switch", "-c", "feat2"])
         .current_dir(&wts[0]).status().unwrap();
 
-    wait_for_event(fake, "git-head-changed", 2_000).expect("head event for worktree");
+    wait_for_next_event(&recording, "git-head-changed", baseline, 2_000)
+        .expect("head event for worktree");
     // The wt event must list ONLY the worktree cwd.
-    let recorded = fake.recorded();
+    let recorded = recording.recorded();
     let head_events: Vec<_> = recorded
         .iter()
         .filter(|(n, _)| n == "git-head-changed")
@@ -1438,8 +1548,7 @@ async fn test_pre_repo_upgrades_to_linked_worktree_and_emits_initial_head_event(
     // Subscribe BEFORE the worktree exists — pre-repo path.
     let wt_cwd = wt.to_string_lossy().to_string();
     std::fs::create_dir(&wt).unwrap();
-    let (state, sink) = test_setup();
-    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+    let (state, recording, sink) = test_setup();
     start_git_watcher_inner(&wt_cwd, sink.clone(), &state).expect("subscribe pre-repo");
 
     // Now create the worktree.
@@ -1448,9 +1557,18 @@ async fn test_pre_repo_upgrades_to_linked_worktree_and_emits_initial_head_event(
 
     // Re-subscribe to trigger the pre-repo → repo upgrade. (In production,
     // the upgrade fires on the next subscription start for the same cwd.)
-    start_git_watcher_inner(&wt_cwd, sink.clone(), &state).expect("re-subscribe post-upgrade");
+    // Trigger the production upgrade path directly. The pre-repo polling
+    // thread calls upgrade_to_repo_watcher every POLL_INTERVAL_SECS; calling
+    // it here makes the test deterministic and exercises the same function
+    // the polling thread calls.
+    let baseline = recording.count("git-head-changed");
+    upgrade_to_repo_watcher(
+        validate_cwd(&wt_cwd).unwrap(),
+        sink.clone(),
+        state.clone(),
+    );
 
-    wait_for_event(fake, "git-head-changed", 2_000)
+    wait_for_next_event(&recording, "git-head-changed", baseline, 2_000)
         .expect("initial git-head-changed on upgrade");
 }
 
@@ -1458,8 +1576,7 @@ async fn test_pre_repo_upgrades_to_linked_worktree_and_emits_initial_head_event(
 async fn test_two_worktrees_independent_head_events() {
     let (_tmp, main, wts) =
         create_main_repo_with_worktrees(&["feat-a", "feat-b"]);
-    let (state, sink) = test_setup();
-    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+    let (state, recording, sink) = test_setup();
 
     let main_cwd = main.to_string_lossy().to_string();
     let wt_a_cwd = wts[0].to_string_lossy().to_string();
@@ -1468,13 +1585,13 @@ async fn test_two_worktrees_independent_head_events() {
     start_git_watcher_inner(&main_cwd, sink.clone(), &state).unwrap();
     start_git_watcher_inner(&wt_a_cwd, sink.clone(), &state).unwrap();
     start_git_watcher_inner(&wt_b_cwd, sink.clone(), &state).unwrap();
-    fake.clear();
+    let baseline = recording.count("git-head-changed");
 
     Command::new("git").args(["switch", "-c", "feat-a-2"])
         .current_dir(&wts[0]).status().unwrap();
-    wait_for_event(fake, "git-head-changed", 2_000).unwrap();
+    wait_for_next_event(&recording, "git-head-changed", baseline, 2_000).unwrap();
 
-    let recorded = fake.recorded();
+    let recorded = recording.recorded();
     let payloads_with_wt_b: Vec<_> = recorded.iter()
         .filter(|(n, p)| n == "git-head-changed" && p.contains(&wt_b_cwd))
         .collect();
@@ -1488,7 +1605,7 @@ async fn test_worktree_removal_drops_branch() {
     let (_tmp, main, wts) =
         create_main_repo_with_worktrees(&["feat"]);
     let wt_cwd = wts[0].to_string_lossy().to_string();
-    let (state, sink) = test_setup();
+    let (state, recording, sink) = test_setup();
     start_git_watcher_inner(&wt_cwd, sink.clone(), &state).unwrap();
 
     Command::new("git").args(["worktree", "remove", "--force",
@@ -1504,10 +1621,10 @@ async fn test_worktree_removal_drops_branch() {
 
 - [ ] **Step 3: Run the new tests**
 
-Run: `cargo test -p vimeflow-backend git::watcher::tests::test_head_change_in_worktree -- --nocapture`
-Run: `cargo test -p vimeflow-backend git::watcher::tests::test_pre_repo_upgrades -- --nocapture`
-Run: `cargo test -p vimeflow-backend git::watcher::tests::test_two_worktrees_independent -- --nocapture`
-Run: `cargo test -p vimeflow-backend git::watcher::tests::test_worktree_removal_drops_branch -- --nocapture`
+Run: `cargo test -p vimeflow git::watcher::tests::test_head_change_in_worktree -- --nocapture`
+Run: `cargo test -p vimeflow git::watcher::tests::test_pre_repo_upgrades -- --nocapture`
+Run: `cargo test -p vimeflow git::watcher::tests::test_two_worktrees_independent -- --nocapture`
+Run: `cargo test -p vimeflow git::watcher::tests::test_worktree_removal_drops_branch -- --nocapture`
 
 Expected: all PASS.
 

--- a/docs/superpowers/plans/2026-05-19-live-head-branch-worktree.md
+++ b/docs/superpowers/plans/2026-05-19-live-head-branch-worktree.md
@@ -1,0 +1,1569 @@
+# Live HEAD/Branch Detection with Worktree Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pane Headers always show the correct branch for their cwd — including when the cwd is a linked worktree, when the agent switches branches, and when HEAD goes detached — within 300 ms of any HEAD-moving operation and with zero manual refresh.
+
+**Architecture:** Watcher resolves `git rev-parse --path-format=absolute --git-dir` per pane alongside `--show-toplevel`; watches the gitdir non-recursively and filters notify events by full-path equality for `HEAD` / `index` / `packed-refs`; emits a new `git-head-changed` event on the same 300 ms debounce window as `git-status-changed`; the polling fallback compares cached `<git_dir>/HEAD` content independently from the status hash; `useGitBranch` mirrors `useGitStatus`'s `listen → start_git_watcher → refresh` lifecycle; `git_branch` IPC falls back to `git rev-parse --short HEAD` on detached HEAD without collapsing real errors; a refcount-aware `stop_git_watcher_inner` lands as a prerequisite.
+
+**Tech Stack:** Rust 1.x (Electron sidecar, `notify` crate, `tokio`), TypeScript 5 / React 19, Vitest, Testing Library.
+
+**Spec:** [`docs/superpowers/specs/2026-05-19-live-head-branch-worktree-design.md`](../specs/2026-05-19-live-head-branch-worktree-design.md)
+
+---
+
+## File Structure
+
+Files modified or created in this plan:
+
+| File                                                                    | Responsibility                                                                                          | Action                                         |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `crates/backend/src/git/watcher.rs`                                     | Watcher core: subscription, FS watch, debounce, polling, event emission. All of §2, §3, the bulk of §5. | Modify (additions + refactor)                  |
+| `crates/backend/src/git/mod.rs`                                         | `git_branch` IPC: branch-name fallback to short SHA. §4 contract change.                                | Modify (one function + tests)                  |
+| `crates/backend/src/git/test_helpers.rs`                                | Worktree fixture used by new unit tests.                                                                | Modify (add `create_main_repo_with_worktrees`) |
+| `src/features/diff/hooks/useGitBranch.ts`                               | Event subscription + watcher lifecycle in the hook. §4 in full.                                         | Modify (add second effect)                     |
+| `src/features/diff/hooks/useGitBranch.test.ts`                          | Vitest hook tests for the event subscription. §6.                                                       | Modify (add tests)                             |
+| `src/features/terminal/components/TerminalPane/HeaderMetadata.test.tsx` | Render tests for SHA-shaped branch values. §6.                                                          | Modify (add tests)                             |
+| `README.md`                                                             | One-line note recommending `.claude/worktrees/` in `.gitignore`. §7 risks.                              | Modify (small docs note)                       |
+
+The watcher.rs file is large (~1800 lines today) but its existing co-located test module is the right place for the new tests per `rules/rust/testing.md`. Do NOT split watcher.rs in this plan — the changes here are additive and the file's responsibility is unchanged.
+
+---
+
+## Tasks Overview
+
+Task ordering is **prerequisite-first**. Each task is TDD: red → green → commit. Tasks 1 and 9 are deliberately structured as standalone commits because they're independently mergeable and useful.
+
+| #   | Task                                                       | Touches                     | Why this order                                                                       |
+| --- | ---------------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------ |
+| 1   | Refcount-aware `stop_git_watcher_inner`                    | watcher.rs                  | Prerequisite; latent bug surfaces once two consumers start watchers for the same cwd |
+| 2   | Resolve `git_dir`; widen `cwd_to_toplevel` → `cwd_to_repo` | watcher.rs                  | Foundation for all per-worktree logic                                                |
+| 3   | Watch `git_dir` non-recursively (parent-dir watch)         | watcher.rs                  | Replaces rename-fragile per-file watches                                             |
+| 4   | `head_dirty` flag + full-path classification               | watcher.rs                  | Detects HEAD modifies without aliasing user files named HEAD                         |
+| 5   | `GitHeadChangedPayload` + `emit_git_head_changed` helper   | watcher.rs                  | Wire format; no behavior yet                                                         |
+| 6   | Wire `git-head-changed` into debounce trailing-edge        | watcher.rs                  | Live event emission on FS events                                                     |
+| 7   | Initial emit on subscribe                                  | watcher.rs                  | Covers pre-repo → worktree upgrade                                                   |
+| 8   | Independent HEAD-content compare in polling fallback       | watcher.rs                  | Catches clean `git switch` on NFS/FUSE                                               |
+| 9   | `git_branch` IPC: short-SHA fallback (preserves Err)       | mod.rs                      | Standalone IPC contract change                                                       |
+| 10  | `useGitBranch`: event subscription + watcher lifecycle     | useGitBranch.ts             | Frontend wiring                                                                      |
+| 11  | Worktree-specific Rust tests + fixture                     | test_helpers.rs, watcher.rs | End-to-end coverage                                                                  |
+| 12  | README `.gitignore` note for `.claude/worktrees/`          | README.md                   | Docs                                                                                 |
+
+---
+
+## Task 1: Refcount-aware `stop_git_watcher_inner`
+
+**Files:**
+
+- Modify: `crates/backend/src/git/watcher.rs:1154-1200`
+- Test (existing test module): `crates/backend/src/git/watcher.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `watcher.rs`:
+
+```rust
+#[tokio::test]
+async fn test_stop_git_watcher_inner_handles_duplicate_starts() {
+    let repo = create_temp_repo();
+    let cwd = repo.path().to_string_lossy().to_string();
+    let (state, sink) = test_setup();
+
+    // Two starts for the same cwd.
+    start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start 1");
+    start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start 2");
+
+    // After first stop, bucket should STILL exist (counter is 1, not 0).
+    stop_git_watcher_inner(cwd.clone(), state.clone()).expect("stop 1");
+    {
+        let toplevel = resolve_toplevel(std::path::Path::new(&cwd))
+            .expect("resolve")
+            .canonicalize()
+            .expect("canon");
+        let watchers = state.repo_watchers.lock().unwrap();
+        assert!(
+            watchers.contains_key(&toplevel),
+            "bucket must survive first stop when refcount is still > 0"
+        );
+    }
+
+    // After second stop, bucket should be gone.
+    stop_git_watcher_inner(cwd.clone(), state.clone()).expect("stop 2");
+    {
+        let toplevel = resolve_toplevel(std::path::Path::new(&cwd))
+            .expect("resolve")
+            .canonicalize()
+            .expect("canon");
+        let watchers = state.repo_watchers.lock().unwrap();
+        assert!(
+            !watchers.contains_key(&toplevel),
+            "bucket must be removed on the last stop"
+        );
+    }
+}
+```
+
+`test_setup()` is a helper colocated with existing tests; if not present, add:
+
+```rust
+fn test_setup() -> (GitWatcherState, std::sync::Arc<dyn EventSink>) {
+    let state = GitWatcherState::new();
+    let sink: std::sync::Arc<dyn EventSink> =
+        std::sync::Arc::new(FakeEventSink::new());
+    (state, sink)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p vimeflow-backend test_stop_git_watcher_inner_handles_duplicate_starts -- --nocapture`
+Expected: FAIL — second `stop_git_watcher_inner` is a silent no-op today (bucket remains).
+
+- [ ] **Step 3: Replace `remove` with peek-then-conditional-remove in `stop_git_watcher_inner`**
+
+In `watcher.rs:1154`, replace the body of the function:
+
+```rust
+fn stop_git_watcher_inner(cwd: String, state: GitWatcherState) -> Result<(), String> {
+    // Peek instead of remove. We only clear the side-map when the cwd's
+    // last subscriber is gone; otherwise the next stop for the SAME cwd
+    // would not find its toplevel and would silently skip decrementing.
+    let recorded_toplevel: Option<PathBuf> = {
+        let map = state
+            .cwd_to_toplevel
+            .lock()
+            .map_err(|e| format!("Failed to lock cwd_to_toplevel: {}", e))?;
+        map.get(&cwd).cloned()
+    };
+
+    if let Some(canonical) = recorded_toplevel {
+        let mut repo_watchers = state
+            .repo_watchers
+            .lock()
+            .map_err(|e| format!("Failed to lock repo_watchers: {}", e))?;
+
+        if let Some(watcher) = repo_watchers.get_mut(&canonical) {
+            let mut last_subscriber_for_cwd = false;
+            if let Some(count) = watcher.subscribers.get_mut(&cwd) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    watcher.subscribers.remove(&cwd);
+                    last_subscriber_for_cwd = true;
+                }
+            }
+
+            if watcher.subscribers.is_empty() {
+                repo_watchers.remove(&canonical);
+            }
+
+            // Only remove from the side-map AFTER we've decremented and
+            // confirmed this was the last subscriber for this cwd.
+            if last_subscriber_for_cwd {
+                state
+                    .cwd_to_toplevel
+                    .lock()
+                    .map_err(|e| format!("Failed to lock cwd_to_toplevel: {}", e))?
+                    .remove(&cwd);
+            }
+
+            return Ok(());
+        }
+        // Recorded mapping but no watcher — also clean the stale map entry.
+        state
+            .cwd_to_toplevel
+            .lock()
+            .map_err(|e| format!("Failed to lock cwd_to_toplevel: {}", e))?
+            .remove(&cwd);
+    }
+
+    // Pre-repo branch — apply symmetric peek-then-conditional-remove.
+    let recorded_pre_repo: Option<PathBuf> = {
+        let map = state
+            .cwd_to_safe_pre_repo
+            .lock()
+            .map_err(|e| format!("Failed to lock cwd_to_safe_pre_repo: {}", e))?;
+        map.get(&cwd).cloned()
+    };
+
+    let safe_cwd = match recorded_pre_repo {
+        Some(p) => p,
+        None => {
+            let Ok(p) = validate_cwd(&cwd) else {
+                return Ok(());
+            };
+            p
+        }
+    };
+
+    let mut pre_repo_watchers = state
+        .pre_repo_watchers
+        .lock()
+        .map_err(|e| format!("Failed to lock pre_repo_watchers: {}", e))?;
+
+    if let Some(watcher) = pre_repo_watchers.get_mut(&safe_cwd) {
+        let mut last_for_cwd = false;
+        if let Some(count) = watcher.subscribers.get_mut(&cwd) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                watcher.subscribers.remove(&cwd);
+                last_for_cwd = true;
+            }
+        }
+        if watcher.subscribers.is_empty() {
+            pre_repo_watchers.remove(&safe_cwd);
+        }
+        if last_for_cwd {
+            state
+                .cwd_to_safe_pre_repo
+                .lock()
+                .map_err(|e| format!("Failed to lock cwd_to_safe_pre_repo: {}", e))?
+                .remove(&cwd);
+        }
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p vimeflow-backend test_stop_git_watcher_inner_handles_duplicate_starts -- --nocapture`
+Expected: PASS.
+
+Also run the full watcher test suite to confirm no regressions:
+
+Run: `cargo test -p vimeflow-backend --lib git::watcher::tests`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/git/watcher.rs
+git commit -m "fix(git-watcher): refcount-aware stop for duplicate-start cwds"
+```
+
+---
+
+## Task 2: Resolve `git_dir`; widen `cwd_to_toplevel` → `cwd_to_repo`
+
+**Files:**
+
+- Modify: `crates/backend/src/git/watcher.rs:357-378, 308-340, 470-580`
+- Test (existing test module): `crates/backend/src/git/watcher.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests`:
+
+```rust
+#[test]
+fn test_resolve_git_dir_returns_dotgit_in_main_repo() {
+    let repo = create_temp_repo();
+    let git_dir = resolve_git_dir(repo.path()).expect("resolve");
+    let expected = repo.path().join(".git").canonicalize().expect("canon");
+    assert_eq!(git_dir, expected);
+}
+
+#[test]
+fn test_resolve_git_dir_returns_worktree_subdir_in_linked_worktree() {
+    let repo = create_temp_repo();
+    // Commit one file so a worktree-add can find a parent.
+    fs::write(repo.path().join("seed"), "seed").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(repo.path()).status().unwrap();
+    Command::new("git").args(["commit", "-m", "seed"])
+        .current_dir(repo.path()).status().unwrap();
+
+    let worktree_dir = repo.path().parent().unwrap().join("wt-feat");
+    Command::new("git")
+        .args(["worktree", "add", "-b", "feat",
+               worktree_dir.to_str().unwrap()])
+        .current_dir(repo.path()).status().unwrap();
+
+    let git_dir = resolve_git_dir(&worktree_dir).expect("resolve");
+    let expected = repo.path()
+        .join(".git/worktrees/wt-feat")
+        .canonicalize()
+        .expect("canon");
+    assert_eq!(git_dir, expected);
+}
+
+#[test]
+fn test_resolve_git_dir_errors_outside_a_repo() {
+    let tmp = home_tempdir();
+    let result = resolve_git_dir(tmp.path());
+    assert!(result.is_err(), "expected Err for non-repo, got {:?}", result);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p vimeflow-backend resolve_git_dir -- --nocapture`
+Expected: FAIL with "function not found" or compile error.
+
+- [ ] **Step 3: Add `resolve_git_dir` next to `resolve_toplevel` in `watcher.rs`**
+
+Insert after `resolve_toplevel` (around `watcher.rs:378`):
+
+```rust
+/// Resolve the per-worktree gitdir for a given cwd.
+///
+/// Uses `--path-format=absolute --git-dir` so git emits an absolute path
+/// before our caller touches it. Without `--path-format=absolute`,
+/// `--git-dir` can return a path RELATIVE to the pane cwd (e.g. `.git`
+/// in the main repo when invoked with `-C <toplevel>`), and a later
+/// `canonicalize()` of that relative path resolves it against the
+/// sidecar process cwd — a silently wrong repo or an error.
+///
+/// Returns:
+///   - `<toplevel>/.git` in the main repo (canonicalized).
+///   - `<main>/.git/worktrees/<name>` in a linked worktree (canonicalized).
+fn resolve_git_dir(cwd: &std::path::Path) -> Result<PathBuf, String> {
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C")
+        .arg(cwd)
+        .arg("rev-parse")
+        .arg("--path-format=absolute")
+        .arg("--git-dir")
+        .env("GIT_TERMINAL_PROMPT", "0");
+
+    let output = run_sync_with_timeout(cmd, SYNC_GIT_TIMEOUT)?;
+
+    if !output.status.success() {
+        return Err("Not a git repository".to_string());
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let trimmed = raw.trim();
+    let path = PathBuf::from(trimmed);
+    path.canonicalize().map_err(|e| format!("canonicalize git_dir: {}", e))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p vimeflow-backend resolve_git_dir -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Widen `cwd_to_toplevel` to carry the `(toplevel, gitdir)` tuple**
+
+In `watcher.rs`, find the field declaration around `watcher.rs:327`:
+
+```rust
+cwd_to_toplevel: Arc<Mutex<HashMap<String, PathBuf>>>,
+```
+
+Rename and widen:
+
+```rust
+/// Side-map: frontend's original cwd string → (canonical toplevel, canonical gitdir).
+/// Stop-time routing aid; populated at subscription start; removed only when
+/// the bucket's subscriber count for this cwd reaches zero (see Task 1).
+cwd_to_repo: Arc<Mutex<HashMap<String, (PathBuf, PathBuf)>>>,
+```
+
+Update the `Default` impl for `GitWatcherState` to use the new field name.
+
+Update all references in `watcher.rs`:
+
+- `start_git_watcher_inner` (around `watcher.rs:572-575`): change `state.cwd_to_toplevel` to `state.cwd_to_repo`. The insert becomes `repo_map.insert(cwd.to_string(), (toplevel.clone(), git_dir.clone()))` — `git_dir` is resolved earlier in the function (see Step 6 below).
+- The Phase-2 init block (around `watcher.rs:795-810`): same insert with the tuple.
+- `stop_git_watcher_inner` (the function you just edited in Task 1): change `cwd_to_toplevel` → `cwd_to_repo`, and destructure on lookup: `let (canonical_toplevel, _gitdir) = recorded;`.
+- Any test that constructs a `GitWatcherState` directly: same field rename.
+
+- [ ] **Step 6: Add `git_dir` resolution to `start_git_watcher_inner`**
+
+In `watcher.rs:506`, after `resolve_toplevel` succeeds:
+
+```rust
+let toplevel = match resolve_toplevel(&safe_cwd) {
+    Ok(tl) => {
+        let canonical = validate_cwd(&tl.to_string_lossy())?;
+        canonical
+    }
+    Err(_) => {
+        return start_pre_repo_watcher_inner(cwd, safe_cwd, events, state);
+    }
+};
+
+// NEW: resolve git_dir alongside toplevel. Validate it under $HOME (same
+// scope rule). In a linked worktree, git_dir lives under <main>/.git/worktrees/<name>/,
+// which is still under $HOME because the main repo is. Symlinks inside .git/
+// are followed by canonicalize() before validation.
+let git_dir = resolve_git_dir(&safe_cwd)
+    .and_then(|p| validate_cwd(&p.to_string_lossy()))?;
+```
+
+Pass `git_dir.clone()` into the `cwd_to_repo` insert.
+
+Also store `git_dir` in the `RepoWatcher` struct. Find the struct definition (search for `struct RepoWatcher`) and add:
+
+```rust
+struct RepoWatcher {
+    // ... existing fields ...
+    git_dir: PathBuf,
+}
+```
+
+Initialize it in the Phase-2 construction site (around `watcher.rs:830-870`).
+
+- [ ] **Step 7: Run all watcher tests + the new ones**
+
+Run: `cargo test -p vimeflow-backend --lib git::watcher::tests`
+Expected: all PASS, including `test_resolve_git_dir_*`.
+
+If the test for `test_stop_git_watcher_inner_handles_duplicate_starts` (Task 1) fails because of the rename, update it to use `cwd_to_repo` and destructure `(toplevel, _gitdir)`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/backend/src/git/watcher.rs
+git commit -m "feat(git-watcher): resolve per-worktree git_dir at subscription"
+```
+
+---
+
+## Task 3: Watch `git_dir` non-recursively (parent-dir watch)
+
+**Files:**
+
+- Modify: `crates/backend/src/git/watcher.rs:662-676`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests`:
+
+```rust
+#[tokio::test]
+async fn test_head_watch_survives_atomic_rename_replace() {
+    let repo = create_temp_repo();
+    fs::write(repo.path().join("seed"), "seed").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(repo.path()).status().unwrap();
+    Command::new("git").args(["commit", "-m", "seed"])
+        .current_dir(repo.path()).status().unwrap();
+
+    let cwd = repo.path().to_string_lossy().to_string();
+    let (state, sink) = test_setup();
+    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+    start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
+
+    // First HEAD movement.
+    Command::new("git").args(["switch", "-c", "feat-a"])
+        .current_dir(repo.path()).status().unwrap();
+    wait_for_event(fake, "git-head-changed", 2_000).expect("first emit");
+    fake.clear();
+
+    // SECOND HEAD movement — would fail on direct-file-watch implementations
+    // because git's rename-replace invalidates the file's inode watch.
+    Command::new("git").args(["switch", "-c", "feat-b"])
+        .current_dir(repo.path()).status().unwrap();
+    wait_for_event(fake, "git-head-changed", 2_000)
+        .expect("second emit (rename-replace must not break the watch)");
+}
+```
+
+`wait_for_event` is a polling helper around the FakeEventSink. If not present, add (next to other test helpers):
+
+```rust
+fn wait_for_event(
+    sink: &FakeEventSink,
+    event_name: &str,
+    timeout_ms: u64,
+) -> Result<(), String> {
+    let start = std::time::Instant::now();
+    while start.elapsed().as_millis() < timeout_ms as u128 {
+        if sink.recorded().iter().any(|(name, _)| name == event_name) {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    Err(format!("did not see {event_name} within {timeout_ms}ms"))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p vimeflow-backend test_head_watch_survives_atomic_rename_replace -- --nocapture`
+Expected: FAIL (today's per-file watch goes stale after the first rename; second `git switch` doesn't emit).
+
+- [ ] **Step 3: Change watch registration to watch the gitdir non-recursively**
+
+In `watcher.rs`, replace lines 662–676:
+
+```rust
+// Watch <git_dir> non-recursively so the inode being watched is stable
+// across git's atomic rename-replace updates of HEAD, index, packed-refs.
+// (Watching HEAD directly goes stale on Linux inotify after the first
+// rename, because `notify` registers an inode watch and git swaps the
+// inode.)
+//
+// NonRecursive means we get events for top-level files inside git_dir
+// (HEAD, index, packed-refs, config, COMMIT_EDITMSG, …) but NOT for
+// `objects/`, `refs/`, `logs/`, `worktrees/`, or `hooks/`. That keeps
+// the watch budget bounded — the same reason the old code refused to
+// recurse into .git/.
+if git_dir.exists() {
+    if let Err(e) = watcher_guard.watch(&git_dir, RecursiveMode::NonRecursive) {
+        log::warn!("Failed to watch {}: {}", git_dir.display(), e);
+    }
+}
+```
+
+Remove the previous `git_index = toplevel.join(".git/index")` and `git_head = toplevel.join(".git/HEAD")` blocks — both are now covered by the gitdir watch.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p vimeflow-backend test_head_watch_survives_atomic_rename_replace -- --nocapture`
+Expected: PASS.
+
+It will likely fail until Task 4 (classification + emit) and Task 6 (debounce wiring) are done. **In that case**, skip ahead — write the test, leave it as `#[ignore]` with a comment `TODO: enable after Task 6`, commit Task 3 with the watch change only, then un-ignore after Task 6.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/git/watcher.rs
+git commit -m "refactor(git-watcher): watch git_dir non-recursively (survives atomic rename)"
+```
+
+---
+
+## Task 4: `head_dirty` flag + full-path classification
+
+**Files:**
+
+- Modify: `crates/backend/src/git/watcher.rs` `RepoWatcher` struct + notify callback
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests`:
+
+```rust
+#[test]
+fn test_head_classification_matches_full_path_only() {
+    // A working-tree file whose name happens to be "HEAD" must NOT be
+    // misclassified as a git HEAD change.
+    let git_dir = PathBuf::from("/tmp/foo/.git");
+    let user_head = PathBuf::from("/tmp/foo/some-dir/HEAD");
+    let real_head = git_dir.join("HEAD");
+
+    assert!(!path_is_git_head(&user_head, &git_dir),
+        "user file named HEAD must not match");
+    assert!(path_is_git_head(&real_head, &git_dir),
+        "actual <git_dir>/HEAD must match");
+}
+
+#[test]
+fn test_head_classification_ignores_packed_refs() {
+    let git_dir = PathBuf::from("/tmp/foo/.git");
+    let packed_refs = git_dir.join("packed-refs");
+    assert!(!path_is_git_head(&packed_refs, &git_dir));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p vimeflow-backend path_is_git_head -- --nocapture`
+Expected: FAIL — `path_is_git_head` doesn't exist.
+
+- [ ] **Step 3: Add the classifier and the `head_dirty` flag**
+
+In the `RepoWatcher` struct (near `watcher.rs:280`), add:
+
+```rust
+struct RepoWatcher {
+    // ... existing fields ...
+    git_dir: PathBuf,
+    /// Set to true by the notify callback when it sees a modify on
+    /// <git_dir>/HEAD; consumed (and reset) by the debounce trailing-edge.
+    head_dirty: Arc<AtomicBool>,
+}
+```
+
+Add the helper near other private helpers:
+
+```rust
+/// True if `path` is exactly `<git_dir>/HEAD`. Compares by full-path
+/// equality rather than filename so a user file like
+/// `<toplevel>/some-dir/HEAD` (delivered by the working-tree recursive
+/// watch into the same notify callback) is not misclassified.
+fn path_is_git_head(path: &std::path::Path, git_dir: &std::path::Path) -> bool {
+    path == git_dir.join("HEAD")
+}
+```
+
+In the notify callback that already exists in `start_git_watcher_inner` (find it by searching for the closure that calls the debounce-channel `tx.send(())`), add classification BEFORE the existing forward:
+
+```rust
+let git_dir_for_callback = git_dir.clone();
+let head_dirty_for_callback = head_dirty.clone();
+
+// inside the closure:
+if let Ok(event) = result {
+    for p in &event.paths {
+        if path_is_git_head(p, &git_dir_for_callback) {
+            head_dirty_for_callback.store(true, Ordering::Release);
+            break;
+        }
+    }
+    let _ = debounce_tx.send(());
+}
+```
+
+`head_dirty` is initialized in the Phase-2 builder:
+
+```rust
+let head_dirty = Arc::new(AtomicBool::new(false));
+```
+
+and stored in `RepoWatcher`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p vimeflow-backend path_is_git_head -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/git/watcher.rs
+git commit -m "feat(git-watcher): head_dirty flag with full-path classifier"
+```
+
+---
+
+## Task 5: `GitHeadChangedPayload` + `emit_git_head_changed` helper
+
+**Files:**
+
+- Modify: `crates/backend/src/git/watcher.rs` (near the existing payload definitions)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests`:
+
+```rust
+#[test]
+fn test_git_head_changed_payload_serializes_camel_case_cwds() {
+    let payload = GitHeadChangedPayload {
+        cwds: vec!["/home/u/repo".to_string()],
+    };
+    let json = serde_json::to_string(&payload).expect("serialize");
+    assert_eq!(json, r#"{"cwds":["/home/u/repo"]}"#);
+}
+
+#[test]
+fn test_emit_git_head_changed_writes_to_sink() {
+    let (_state, sink) = test_setup();
+    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+
+    emit_git_head_changed(&sink, vec!["/home/u/repo".to_string()]);
+
+    let recorded = fake.recorded();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].0, "git-head-changed");
+    assert!(recorded[0].1.contains("/home/u/repo"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p vimeflow-backend git_head_changed -- --nocapture`
+Expected: FAIL — `GitHeadChangedPayload` / `emit_git_head_changed` don't exist.
+
+- [ ] **Step 3: Add the payload and helper next to their `git-status-changed` siblings**
+
+In `watcher.rs`, near `GitStatusChangedPayload` (around line 349):
+
+```rust
+/// Payload emitted when <git_dir>/HEAD content may have changed.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GitHeadChangedPayload {
+    cwds: Vec<String>,
+}
+```
+
+Near `emit_git_status_changed` (around line 1284):
+
+```rust
+/// Emit a git-head-changed event for the provided cwds.
+fn emit_git_head_changed(events: &Arc<dyn EventSink>, cwds: Vec<String>) {
+    let payload = GitHeadChangedPayload { cwds };
+    let result = serialize_event(&payload)
+        .and_then(|payload| events.emit_json("git-head-changed", payload));
+
+    if let Err(e) = result {
+        log::error!("Failed to emit git-head-changed: {}", e);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p vimeflow-backend git_head_changed -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/git/watcher.rs
+git commit -m "feat(git-watcher): add git-head-changed payload + emit helper"
+```
+
+---
+
+## Task 6: Wire `git-head-changed` into the debounce trailing-edge
+
+**Files:**
+
+- Modify: `crates/backend/src/git/watcher.rs` (the debounce thread's emit site and the bucket fan-out)
+
+- [ ] **Step 1: Write the failing test**
+
+If you ignored the Task 3 integration test, un-ignore it now. Add a more targeted test:
+
+```rust
+#[tokio::test]
+async fn test_head_change_in_main_emits_git_head_changed() {
+    let repo = create_temp_repo();
+    fs::write(repo.path().join("seed"), "seed").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(repo.path()).status().unwrap();
+    Command::new("git").args(["commit", "-m", "seed"])
+        .current_dir(repo.path()).status().unwrap();
+
+    let cwd = repo.path().to_string_lossy().to_string();
+    let (state, sink) = test_setup();
+    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+    start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
+
+    fake.clear();
+    Command::new("git").args(["switch", "-c", "feat"])
+        .current_dir(repo.path()).status().unwrap();
+
+    wait_for_event(fake, "git-head-changed", 2_000).expect("head event");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p vimeflow-backend test_head_change_in_main_emits_git_head_changed -- --nocapture`
+Expected: FAIL — no emit path yet.
+
+- [ ] **Step 3: Extend the fan-out helper and the debounce emit**
+
+Find `emit_for_all_subscribers` (around `watcher.rs:1258`) and change it to accept a `head_dirty` consumed-flag:
+
+```rust
+fn emit_for_all_subscribers(
+    events: &Arc<dyn EventSink>,
+    state: &GitWatcherState,
+    toplevel: &std::path::Path,
+    head_was_dirty: bool,
+) {
+    let cwds: Vec<String> = {
+        let repo_watchers = state.repo_watchers.lock().expect("...");
+        if let Some(watcher) = repo_watchers.get(toplevel) {
+            watcher.subscribers.keys().cloned().collect()
+        } else {
+            vec![]
+        }
+    };
+
+    if !cwds.is_empty() {
+        if head_was_dirty {
+            emit_git_head_changed(events, cwds.clone());
+        }
+        emit_git_status_changed(events, cwds);
+    }
+}
+```
+
+Update every call site of `emit_for_all_subscribers` to pass `head_was_dirty`. The trailing-edge emit inside the debounce thread (search for the `emit()` closure passed to `spawn_trailing_debounce_thread`) reads-and-resets `head_dirty`:
+
+```rust
+let head_was_dirty =
+    head_dirty.swap(false, Ordering::AcqRel);
+emit_for_all_subscribers(&events, &state, &toplevel, head_was_dirty);
+```
+
+(Use `swap(false, …)` so concurrent FS events arriving DURING the emit are reflected on the NEXT debounce window, not lost.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p vimeflow-backend git::watcher::tests --lib`
+Expected: all PASS, including `test_head_change_in_main_emits_git_head_changed` and the un-ignored `test_head_watch_survives_atomic_rename_replace`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/git/watcher.rs
+git commit -m "feat(git-watcher): emit git-head-changed on HEAD moves"
+```
+
+---
+
+## Task 7: Initial emit on subscribe
+
+**Files:**
+
+- Modify: `crates/backend/src/git/watcher.rs` (the six call sites of `emit_git_status_changed` for single-cwd initial emits)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests`:
+
+```rust
+#[tokio::test]
+async fn test_start_git_watcher_emits_initial_git_head_changed() {
+    let repo = create_temp_repo();
+    fs::write(repo.path().join("seed"), "seed").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(repo.path()).status().unwrap();
+    Command::new("git").args(["commit", "-m", "seed"])
+        .current_dir(repo.path()).status().unwrap();
+
+    let cwd = repo.path().to_string_lossy().to_string();
+    let (state, sink) = test_setup();
+    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+
+    start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
+
+    let recorded = fake.recorded();
+    assert!(recorded.iter().any(|(n, p)| n == "git-head-changed" && p.contains(&cwd)),
+        "expected initial git-head-changed for the new subscriber, got {:?}",
+        recorded.iter().map(|(n, _)| n).collect::<Vec<_>>());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p vimeflow-backend test_start_git_watcher_emits_initial_git_head_changed -- --nocapture`
+Expected: FAIL — only `git-status-changed` is emitted today.
+
+- [ ] **Step 3: Pair every single-cwd `emit_git_status_changed` with `emit_git_head_changed`**
+
+Search `watcher.rs` for `emit_git_status_changed(&events, vec![cwd.to_string()])`. Six call sites. For each, add a sibling line:
+
+```rust
+emit_git_head_changed(&events, vec![cwd.to_string()]);
+emit_git_status_changed(&events, vec![cwd.to_string()]);
+```
+
+Order: head first, status second. (The frontend will see both events; the hook only cares about the one it listens to. Order doesn't affect correctness but keeps the wire stream predictable for log scraping.)
+
+The `emit_for_all_subscribers` path (multi-cwd, triggered by FS events) is NOT touched here — that path is already conditional on `head_was_dirty` from Task 6.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p vimeflow-backend test_start_git_watcher_emits_initial_git_head_changed -- --nocapture`
+Expected: PASS.
+
+Also confirm: the existing `test_start_git_watcher_emits_initial_git_status_changed`-style test (if one exists) still passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/git/watcher.rs
+git commit -m "feat(git-watcher): emit initial git-head-changed on subscribe"
+```
+
+---
+
+## Task 8: Independent HEAD-content compare in the polling fallback
+
+**Files:**
+
+- Modify: `crates/backend/src/git/watcher.rs:684-745` (the polling thread block)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests`:
+
+```rust
+#[tokio::test]
+async fn test_polling_emits_head_changed_on_clean_switch_with_unchanged_status() {
+    let repo = create_temp_repo();
+    fs::write(repo.path().join("seed"), "seed").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(repo.path()).status().unwrap();
+    Command::new("git").args(["commit", "-m", "seed"])
+        .current_dir(repo.path()).status().unwrap();
+    // Create a second branch BEFORE we start the watcher so switching to it
+    // doesn't reorder commits in a way that changes status output.
+    Command::new("git").args(["branch", "other"])
+        .current_dir(repo.path()).status().unwrap();
+
+    let cwd = repo.path().to_string_lossy().to_string();
+    let (state, sink) = test_setup();
+    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+    start_git_watcher_inner(&cwd, sink.clone(), &state).expect("start");
+    fake.clear();
+
+    // Simulate inotify being unreliable: switch via plumbing so the file
+    // event might be missed (we can't easily disable notify in tests, but
+    // we CAN verify the polling thread emits independently — wait longer
+    // than POLL_INTERVAL_SECS=10 and assert the event fired without our
+    // having to rely on the notify path).
+    Command::new("git").args(["switch", "other"])
+        .current_dir(repo.path()).status().unwrap();
+
+    // Wait up to one poll interval + slack.
+    wait_for_event(fake, "git-head-changed", 12_000).expect("head event");
+}
+```
+
+(The test is slow — 10-12 s. Run it under `--release` or accept the wall-clock cost; alternatively make `POLL_INTERVAL_SECS` configurable via env in test builds. For the plan we accept the wall-clock cost on first run; CI can `--test-threads=1` if needed.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p vimeflow-backend test_polling_emits_head_changed_on_clean_switch_with_unchanged_status -- --nocapture`
+Expected: FAIL if you can suppress notify; PASS today by coincidence because notify still catches it. Treat the assertion as "we don't depend on the notify path" — if the test passes today, that's because notify covered it; the polling path independence still needs the code change for NFS/FUSE reliability. Comment in the test:
+
+```rust
+// This test asserts emission within ~one poll interval. On platforms
+// where notify is reliable it can pass before the poll fires; we add
+// the polling-path code change for NFS/FUSE robustness regardless.
+```
+
+- [ ] **Step 3: Add HEAD-content caching to `RepoWatcher` and compare in the polling thread**
+
+Add field:
+
+```rust
+struct RepoWatcher {
+    // ...
+    last_head_content: Arc<Mutex<Option<String>>>,
+}
+```
+
+Initialize in Phase-2 builder:
+
+```rust
+let initial_head = std::fs::read_to_string(git_dir.join("HEAD")).ok();
+let last_head_content = Arc::new(Mutex::new(initial_head));
+```
+
+Inside the polling thread (around `watcher.rs:695`), add an independent comparison alongside the existing `hash_git_status` check:
+
+```rust
+// (Existing) status-hash comparison emits git-status-changed.
+let status_changed = /* existing block */;
+
+// (NEW) HEAD-content comparison emits git-head-changed independently.
+// hash_git_status does NOT cover HEAD moves on a clean tree, so a
+// `git switch <branch>` against an unmodified tree must be caught here.
+let head_changed = {
+    match std::fs::read_to_string(poll_git_dir.join("HEAD")) {
+        Ok(current) => {
+            let mut last = poll_last_head_content.lock().unwrap();
+            let differs = last.as_deref() != Some(current.as_str());
+            if differs {
+                *last = Some(current);
+            }
+            differs
+        }
+        // Read errors (worktree removed, permissions) are not "head
+        // changed" — they'll be visible to git_branch IPC on next call.
+        Err(_) => false,
+    }
+};
+
+if head_changed {
+    let cwds = collect_subscriber_cwds(&poll_state, &poll_toplevel);
+    if !cwds.is_empty() {
+        emit_git_head_changed(&poll_events, cwds);
+    }
+}
+
+if status_changed {
+    emit_for_all_subscribers(/* head_was_dirty: */ false, ...);
+}
+```
+
+(Clone `git_dir` and `last_head_content` into the polling thread's captures alongside the existing `poll_toplevel`, `poll_state`, etc.)
+
+Extract a small helper for the subscriber-list collection if the body repeats too much:
+
+```rust
+fn collect_subscriber_cwds(state: &GitWatcherState, toplevel: &std::path::Path) -> Vec<String> {
+    let repo_watchers = state.repo_watchers.lock().expect("lock repo_watchers");
+    repo_watchers
+        .get(toplevel)
+        .map(|w| w.subscribers.keys().cloned().collect())
+        .unwrap_or_default()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p vimeflow-backend test_polling_emits_head_changed_on_clean_switch_with_unchanged_status -- --nocapture --test-threads=1`
+Expected: PASS within ~12 s.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/git/watcher.rs
+git commit -m "feat(git-watcher): polling fallback compares HEAD content independently"
+```
+
+---
+
+## Task 9: `git_branch` IPC: short-SHA fallback (preserves Err)
+
+**Files:**
+
+- Modify: `crates/backend/src/git/mod.rs:1009-1042`
+- Test (existing test module): `crates/backend/src/git/mod.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Update the failing test (existing)**
+
+Find `test_git_branch_returns_empty_for_detached_head` at `mod.rs:1757`. The test today asserts `Ok("")` for detached HEAD; after this task it must assert `Ok(<7-char SHA>)`. Rename and rewrite:
+
+```rust
+#[tokio::test]
+async fn test_git_branch_detached_head_returns_short_sha() {
+    let repo = home_tempdir();
+    configure_test_git(repo.path());
+    Command::new("git").args(["init"]).current_dir(repo.path()).status().unwrap();
+    fs::write(repo.path().join("seed"), "seed").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(repo.path()).status().unwrap();
+    Command::new("git").args(["commit", "-m", "seed"])
+        .current_dir(repo.path()).status().unwrap();
+
+    // Capture full SHA, then detach to it.
+    let out = Command::new("git").args(["rev-parse", "HEAD"])
+        .current_dir(repo.path()).output().unwrap();
+    let full_sha = String::from_utf8(out.stdout).unwrap().trim().to_string();
+    Command::new("git").args(["switch", "--detach", &full_sha])
+        .current_dir(repo.path()).status().unwrap();
+
+    let path = repo.path().to_string_lossy().to_string();
+    let branch = git_branch(path).await.expect("git_branch");
+    assert_eq!(branch.len(), 7, "short SHA should be exactly 7 chars: {:?}", branch);
+    assert!(full_sha.starts_with(&branch),
+        "short SHA must be a prefix of the full SHA: short={branch} full={full_sha}");
+}
+```
+
+Also confirm `test_git_branch_returns_error_for_non_repo_cwd` (around `mod.rs:1804`) still expects `Err` — it does, and we must keep that contract.
+
+- [ ] **Step 2: Run tests to verify the detached test now fails**
+
+Run: `cargo test -p vimeflow-backend test_git_branch_detached_head_returns_short_sha -- --nocapture`
+Expected: FAIL — current impl returns `""`.
+
+Also run: `cargo test -p vimeflow-backend test_git_branch_returns_error_for_non_repo_cwd -- --nocapture`
+Expected: PASS (we want it to keep passing after the change).
+
+- [ ] **Step 3: Implement the short-SHA fallback in `git_branch_inner`**
+
+Replace the body of `git_branch_inner` (around `mod.rs:1013`) with:
+
+```rust
+pub(crate) async fn git_branch_inner(cwd: String) -> Result<String, String> {
+    let safe_cwd = validate_cwd(&cwd)?;
+
+    // Step 1: try symbolic-ref. -q makes stderr empty for the detached-HEAD
+    // case (which is what we use to distinguish "no symref" from real errors).
+    let mut cmd = Command::new("git");
+    cmd.arg("-C")
+        .arg(&safe_cwd)
+        .arg("symbolic-ref")
+        .arg("-q")
+        .arg("--short")
+        .arg("HEAD")
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let output = run_git_with_timeout(cmd).await?;
+
+    if output.status.success() {
+        let branch = String::from_utf8(output.stdout)
+            .map_err(|e| format!("git_branch utf8: {}", e))?
+            .trim()
+            .to_string();
+        return Ok(branch);
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stderr.trim().is_empty() {
+        // Real error (not a repo, permission, etc.) — preserve Err contract.
+        return Err(format!("git_branch: {stderr}"));
+    }
+
+    // Step 2: detached HEAD. Fall back to short SHA.
+    let mut rev = Command::new("git");
+    rev.arg("-C")
+        .arg(&safe_cwd)
+        .arg("rev-parse")
+        .arg("--short=7")
+        .arg("--verify")
+        .arg("HEAD")
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let rev_out = run_git_with_timeout(rev).await?;
+
+    if rev_out.status.success() {
+        let sha = String::from_utf8(rev_out.stdout)
+            .map_err(|e| format!("git_branch rev-parse utf8: {}", e))?
+            .trim()
+            .to_string();
+        return Ok(sha);
+    }
+
+    // Broken / unborn HEAD — match the existing no-symref empty-string behavior.
+    Ok(String::new())
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p vimeflow-backend test_git_branch_ -- --nocapture`
+Expected: all `test_git_branch_*` PASS, including:
+
+- `test_git_branch_returns_default_branch_for_unborn_repo`
+- `test_git_branch_detached_head_returns_short_sha` (new behavior)
+- `test_git_branch_returns_error_for_non_repo_cwd` (still Err)
+- `test_git_branch_returns_error_for_non_detached_git_failure` (still Err)
+- `test_git_branch_rejects_out_of_scope_cwd` (still Err)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/git/mod.rs
+git commit -m "feat(git-branch): short-SHA fallback for detached HEAD"
+```
+
+---
+
+## Task 10: `useGitBranch` — event subscription + watcher lifecycle
+
+**Files:**
+
+- Modify: `src/features/diff/hooks/useGitBranch.ts`
+- Modify: `src/features/diff/hooks/useGitBranch.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Update `useGitBranch.test.ts`. Add a top-level mock for `listen`:
+
+```typescript
+import { invoke, listen } from '../../../lib/backend'
+
+vi.mock('../../../lib/backend', () => ({
+  invoke: vi.fn(),
+  listen: vi.fn(),
+}))
+```
+
+Add tests:
+
+```typescript
+test('attaches git-head-changed listener BEFORE invoking start_git_watcher', async () => {
+  const callOrder: string[] = []
+  vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+    callOrder.push(`invoke:${cmd}`)
+    return cmd === 'git_branch' ? 'main' : undefined
+  })
+  vi.mocked(listen).mockImplementation(async () => {
+    callOrder.push('listen')
+    return () => {}
+  })
+
+  renderHook(() => useGitBranch('/home/test/repo'))
+
+  await waitFor(() => {
+    expect(callOrder.indexOf('listen')).toBeLessThan(
+      callOrder.indexOf('invoke:start_git_watcher')
+    )
+  })
+})
+
+test('refetches branch when git-head-changed event includes our cwd', async () => {
+  let captured: ((payload: { cwds: string[] }) => void) | null = null
+  vi.mocked(listen).mockImplementation(async (_event, cb) => {
+    captured = cb as (payload: { cwds: string[] }) => void
+    return () => {}
+  })
+  vi.mocked(invoke)
+    .mockResolvedValueOnce('main') // initial fetch
+    .mockResolvedValueOnce(undefined) // start_git_watcher
+    .mockResolvedValueOnce('feat/x') // refresh-triggered fetch
+
+  const { result } = renderHook(() => useGitBranch('/home/test/repo'))
+  await waitFor(() => expect(result.current.branch).toBe('main'))
+
+  act(() => captured!({ cwds: ['/home/test/repo'] }))
+  await waitFor(() => expect(result.current.branch).toBe('feat/x'))
+})
+
+test('ignores git-head-changed event when cwds do not match', async () => {
+  let captured: ((payload: { cwds: string[] }) => void) | null = null
+  vi.mocked(listen).mockImplementation(async (_event, cb) => {
+    captured = cb as (payload: { cwds: string[] }) => void
+    return () => {}
+  })
+  vi.mocked(invoke)
+    .mockResolvedValueOnce('main')
+    .mockResolvedValueOnce(undefined)
+
+  const { result } = renderHook(() => useGitBranch('/home/test/repo'))
+  await waitFor(() => expect(result.current.branch).toBe('main'))
+
+  vi.mocked(invoke).mockClear()
+  act(() => captured!({ cwds: ['/home/other'] }))
+  // Nothing to await for — assert no refetch.
+  expect(invoke).not.toHaveBeenCalled()
+})
+
+test('cleanup unlistens before stopping watcher and stops only after start completes', async () => {
+  const order: string[] = []
+  vi.mocked(listen).mockImplementation(async () => {
+    order.push('listen')
+    return () => order.push('unlisten')
+  })
+  let resolveStart: () => void = () => {}
+  const startPromise = new Promise<void>((resolve) => {
+    resolveStart = resolve
+  })
+  vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+    order.push(`invoke:${cmd}`)
+    if (cmd === 'start_git_watcher') return startPromise
+    if (cmd === 'git_branch') return 'main'
+    return undefined
+  })
+
+  const { unmount } = renderHook(() => useGitBranch('/home/test/repo'))
+  await waitFor(() => expect(order).toContain('listen'))
+  unmount()
+  // Resolve the start AFTER unmount, then assert order.
+  resolveStart()
+  await waitFor(() => expect(order).toContain('invoke:stop_git_watcher'))
+  expect(order.indexOf('unlisten')).toBeLessThan(
+    order.indexOf('invoke:stop_git_watcher')
+  )
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/features/diff/hooks/useGitBranch.test.ts`
+Expected: FAIL — hook doesn't subscribe to events yet.
+
+- [ ] **Step 3: Add the second effect to `useGitBranch.ts`**
+
+Append a new effect, after the existing fetch effect, before the `return { … }` block:
+
+```typescript
+const unlistenRef = useRef<(() => void) | null>(null)
+
+useEffect((): (() => void) | undefined => {
+  if (!enabled || !isValidCwd(cwd)) return undefined
+
+  let mounted = true
+  let listenerAttached = false
+  let watcherStarted = false
+
+  const setup = async (): Promise<void> => {
+    try {
+      const unlisten = await listen<{ cwds: string[] }>(
+        'git-head-changed',
+        (payload) => {
+          if (payload.cwds.includes(cwd)) {
+            setRefreshKey((k) => k + 1)
+          }
+        }
+      )
+      if (!mounted) {
+        unlisten()
+        return
+      }
+      unlistenRef.current = unlisten
+      listenerAttached = true
+
+      await invoke('start_git_watcher', { cwd })
+      watcherStarted = true
+
+      if (mounted) {
+        setRefreshKey((k) => k + 1)
+      }
+    } catch (err) {
+      if (mounted) {
+        setError(err instanceof Error ? err : new Error(String(err)))
+      }
+    }
+  }
+
+  const setupPromise = setup()
+
+  return (): void => {
+    mounted = false
+    void (async () => {
+      if (listenerAttached && unlistenRef.current) {
+        unlistenRef.current()
+        unlistenRef.current = null
+      }
+      await setupPromise.catch(() => {})
+      if (watcherStarted) {
+        await invoke('stop_git_watcher', { cwd }).catch(() => {})
+      }
+    })()
+  }
+}, [cwd, enabled])
+```
+
+Add imports at the top of the file:
+
+```typescript
+import { invoke, listen } from '../../../lib/backend'
+import { useCallback, useEffect, useRef, useState } from 'react'
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/features/diff/hooks/useGitBranch.test.ts`
+Expected: all PASS, including the four new tests above.
+
+Also run the existing test file end-to-end:
+
+Run: `npm run lint -- src/features/diff/hooks/useGitBranch.ts src/features/diff/hooks/useGitBranch.test.ts`
+Expected: clean (no semicolons, single quotes, explicit return types).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/hooks/useGitBranch.ts src/features/diff/hooks/useGitBranch.test.ts
+git commit -m "feat(useGitBranch): subscribe to git-head-changed for live updates"
+```
+
+---
+
+## Task 11: Worktree-specific Rust tests + fixture
+
+**Files:**
+
+- Modify: `crates/backend/src/git/test_helpers.rs`
+- Modify: `crates/backend/src/git/watcher.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Add the fixture**
+
+In `test_helpers.rs`:
+
+```rust
+/// Create a main repo + N linked worktrees in a tempdir under $HOME.
+/// Commits a seed file to the main repo first so worktree branches
+/// have a parent. Worktree dirs are SIBLINGS of the main repo dir
+/// (not nested inside it) to avoid the .claude/worktrees/-style
+/// "untracked inside main working tree" concern in tests.
+pub(crate) fn create_main_repo_with_worktrees(
+    branches: &[&str],
+) -> (TempDir, PathBuf, Vec<PathBuf>) {
+    let tmp = home_tempdir();
+    let main = tmp.path().join("main");
+    std::fs::create_dir(&main).unwrap();
+
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&main)
+        .status()
+        .unwrap();
+    configure_test_git(&main);
+    std::fs::write(main.join("seed"), "seed").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&main)
+        .status()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "seed"])
+        .current_dir(&main)
+        .status()
+        .unwrap();
+
+    let mut worktrees = Vec::with_capacity(branches.len());
+    for (i, branch) in branches.iter().enumerate() {
+        let wt = tmp.path().join(format!("wt-{i}"));
+        std::process::Command::new("git")
+            .args([
+                "worktree", "add", "-b", branch, wt.to_str().unwrap(),
+            ])
+            .current_dir(&main)
+            .status()
+            .unwrap();
+        worktrees.push(wt);
+    }
+
+    (tmp, main, worktrees)
+}
+```
+
+- [ ] **Step 2: Add the tests**
+
+In `watcher.rs#[cfg(test)] mod tests`:
+
+```rust
+#[tokio::test]
+async fn test_head_change_in_worktree_emits_for_worktree_only() {
+    let (_tmp, main, wts) =
+        create_main_repo_with_worktrees(&["feat"]);
+    let main_cwd = main.to_string_lossy().to_string();
+    let wt_cwd = wts[0].to_string_lossy().to_string();
+    let (state, sink) = test_setup();
+    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+
+    start_git_watcher_inner(&main_cwd, sink.clone(), &state).expect("start main");
+    start_git_watcher_inner(&wt_cwd, sink.clone(), &state).expect("start wt");
+    fake.clear();
+
+    Command::new("git").args(["switch", "-c", "feat2"])
+        .current_dir(&wts[0]).status().unwrap();
+
+    wait_for_event(fake, "git-head-changed", 2_000).expect("head event for worktree");
+    // The wt event must list ONLY the worktree cwd.
+    let recorded = fake.recorded();
+    let head_events: Vec<_> = recorded
+        .iter()
+        .filter(|(n, _)| n == "git-head-changed")
+        .collect();
+    assert!(head_events.iter().any(|(_, p)| p.contains(&wt_cwd) && !p.contains(&main_cwd)),
+        "git-head-changed must list only the worktree cwd, got: {:?}", head_events);
+}
+
+#[tokio::test]
+async fn test_pre_repo_upgrades_to_linked_worktree_and_emits_initial_head_event() {
+    let tmp = home_tempdir();
+    let main = tmp.path().join("main");
+    std::fs::create_dir(&main).unwrap();
+    Command::new("git").args(["init"]).current_dir(&main).status().unwrap();
+    configure_test_git(&main);
+    std::fs::write(main.join("seed"), "seed").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(&main).status().unwrap();
+    Command::new("git").args(["commit", "-m", "seed"]).current_dir(&main).status().unwrap();
+
+    let wt = tmp.path().join("wt-pending");
+    // Subscribe BEFORE the worktree exists — pre-repo path.
+    let wt_cwd = wt.to_string_lossy().to_string();
+    std::fs::create_dir(&wt).unwrap();
+    let (state, sink) = test_setup();
+    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+    start_git_watcher_inner(&wt_cwd, sink.clone(), &state).expect("subscribe pre-repo");
+
+    // Now create the worktree.
+    Command::new("git").args(["worktree", "add", "-b", "feat",
+        wt.to_str().unwrap()]).current_dir(&main).status().unwrap();
+
+    // Re-subscribe to trigger the pre-repo → repo upgrade. (In production,
+    // the upgrade fires on the next subscription start for the same cwd.)
+    start_git_watcher_inner(&wt_cwd, sink.clone(), &state).expect("re-subscribe post-upgrade");
+
+    wait_for_event(fake, "git-head-changed", 2_000)
+        .expect("initial git-head-changed on upgrade");
+}
+
+#[tokio::test]
+async fn test_two_worktrees_independent_head_events() {
+    let (_tmp, main, wts) =
+        create_main_repo_with_worktrees(&["feat-a", "feat-b"]);
+    let (state, sink) = test_setup();
+    let fake = sink.as_any().downcast_ref::<FakeEventSink>().unwrap();
+
+    let main_cwd = main.to_string_lossy().to_string();
+    let wt_a_cwd = wts[0].to_string_lossy().to_string();
+    let wt_b_cwd = wts[1].to_string_lossy().to_string();
+
+    start_git_watcher_inner(&main_cwd, sink.clone(), &state).unwrap();
+    start_git_watcher_inner(&wt_a_cwd, sink.clone(), &state).unwrap();
+    start_git_watcher_inner(&wt_b_cwd, sink.clone(), &state).unwrap();
+    fake.clear();
+
+    Command::new("git").args(["switch", "-c", "feat-a-2"])
+        .current_dir(&wts[0]).status().unwrap();
+    wait_for_event(fake, "git-head-changed", 2_000).unwrap();
+
+    let recorded = fake.recorded();
+    let payloads_with_wt_b: Vec<_> = recorded.iter()
+        .filter(|(n, p)| n == "git-head-changed" && p.contains(&wt_b_cwd))
+        .collect();
+    assert!(payloads_with_wt_b.is_empty(),
+        "wt-b must NOT receive git-head-changed for an event in wt-a, got: {:?}",
+        payloads_with_wt_b);
+}
+
+#[tokio::test]
+async fn test_worktree_removal_drops_branch() {
+    let (_tmp, main, wts) =
+        create_main_repo_with_worktrees(&["feat"]);
+    let wt_cwd = wts[0].to_string_lossy().to_string();
+    let (state, sink) = test_setup();
+    start_git_watcher_inner(&wt_cwd, sink.clone(), &state).unwrap();
+
+    Command::new("git").args(["worktree", "remove", "--force",
+        wts[0].to_str().unwrap()]).current_dir(&main).status().unwrap();
+
+    // After removal, git_branch_inner against the now-gone cwd must Err
+    // (NOT silently return Ok("")).
+    let result = crate::git::git_branch_inner(wt_cwd).await;
+    assert!(result.is_err(),
+        "git_branch must Err after worktree removed, got {:?}", result);
+}
+```
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `cargo test -p vimeflow-backend git::watcher::tests::test_head_change_in_worktree -- --nocapture`
+Run: `cargo test -p vimeflow-backend git::watcher::tests::test_pre_repo_upgrades -- --nocapture`
+Run: `cargo test -p vimeflow-backend git::watcher::tests::test_two_worktrees_independent -- --nocapture`
+Run: `cargo test -p vimeflow-backend git::watcher::tests::test_worktree_removal_drops_branch -- --nocapture`
+
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/backend/src/git/test_helpers.rs crates/backend/src/git/watcher.rs
+git commit -m "test(git-watcher): worktree fixtures + cross-worktree isolation"
+```
+
+---
+
+## Task 12: README `.gitignore` note for `.claude/worktrees/`
+
+**Files:**
+
+- Modify: `README.md`
+
+- [ ] **Step 1: Find the right section in the README**
+
+Search for an existing "Tips" / "Notes" / "Shell Setup" section. If a Git-related subsection exists, place the note there; otherwise add a short new section.
+
+- [ ] **Step 2: Add the note**
+
+Add this content (adjust heading depth to match surrounding structure):
+
+```markdown
+### Linked worktrees inside the repo
+
+If you create linked worktrees inside the project (e.g. `git worktree add .claude/worktrees/feat-x …`), add `.claude/worktrees/` to `.gitignore`. The directory will otherwise appear as untracked in `git status` from the main repo, and the watcher will fire extra `git-status-changed` events for FS activity inside the worktree (branch label and diff panel still correct — just chattier than necessary).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): recommend gitignore for nested linked worktrees"
+```
+
+---
+
+## Self-Review (Run This Before Calling The Plan Complete)
+
+1. **Spec coverage** — every section's requirements have a task:
+   - §1 (scope, success criteria) — covered by Tasks 1–11 in aggregate.
+   - §2 (per-pane gitdir, refcount stop) — Tasks 1, 2.
+   - §3 (event design, classification, polling) — Tasks 3, 4, 5, 6, 7, 8.
+   - §4 (frontend hook, IPC contract) — Tasks 9, 10.
+   - §5 (edge cases — pre-repo upgrade, removal, empty repo) — Tasks 7, 11; Task 9 covers detached HEAD + non-repo Err contract.
+   - §6 (testing) — Tasks 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11.
+   - §7 (out-of-scope, risks, migration) — Task 12 (the .gitignore note); the rest are non-code.
+2. **Placeholder scan** — no TBD/TODO/FIXME; every step has either code or an exact command.
+3. **Type consistency** — `GitHeadChangedPayload` shape matches across §3 and Task 5; `cwd_to_repo` value type `(PathBuf, PathBuf)` matches Tasks 1 (after edit) and 2; `path_is_git_head(path, git_dir)` signature consistent in Task 4 and the notify callback.
+
+---
+
+## Plan Complete
+
+Plan committed. **STOP HERE** — control returns to `/lifeline:planner` for codex plan-complete review. Do NOT chain to `executing-plans` or `subagent-driven-development`. The implementation phase begins after codex review (Step 9.C of the planner skill) finishes and any findings are applied.

--- a/docs/superpowers/specs/2026-05-19-live-head-branch-worktree-design.md
+++ b/docs/superpowers/specs/2026-05-19-live-head-branch-worktree-design.md
@@ -1,0 +1,492 @@
+# Live HEAD/Branch Detection with Worktree Support — Design Spec
+
+**Date:** 2026-05-19
+**Issue:** [#189 — feat(terminal): live-detect branch changes in pane Header](https://github.com/winoooops/vimeflow/issues/189)
+**Status:** draft
+
+---
+
+## 1. Overview & Scope
+
+**Background.** Today, every `TerminalPane`'s `Header` shows a static branch label fetched once via the `git_branch` IPC on mount (and re-fetched on `cwd` change or manual `refresh()`). The watcher at `crates/backend/src/git/watcher.rs:671` already watches `<toplevel>/.git/HEAD`, but FS events on that path are folded into the broader `git-status-changed` event — there is no dedicated `git-head-changed` channel, and `useGitBranch` does not subscribe to any backend events. Two regressions follow:
+
+1. **Stale label on branch switch.** When an agent runs `git switch <branch>` inside a pane, the Header keeps showing the old branch until the user manually refreshes (or changes `cwd`).
+2. **Broken inside linked worktrees.** When a pane's `cwd` is a linked worktree (e.g. `~/repo/.claude/worktrees/feat-x`), `<toplevel>/.git` is a **file** containing `gitdir: <main>/.git/worktrees/feat-x`, not a directory. The path `<toplevel>/.git/HEAD` does not exist, so the watcher silently fails to register the HEAD watch for that pane — and even if a `git-head-changed` event were added against the main repo's `.git/HEAD`, it would never fire for HEAD movements that happen _inside_ the linked worktree's per-worktree `HEAD` file.
+
+**User story.** Agents (Claude Code, Codex) routinely run flows that span the main repo and one or more linked worktrees — `git worktree add .claude/worktrees/feat-x -b feat/x`, then `cd` into the worktree and iterate. Each pane's Header must always reflect the branch currently checked out in _that pane's `cwd`_, including when the agent switches branches or moves between worktrees mid-session.
+
+### In scope
+
+| Behavior                                                                                   | Where it shows up                                                                                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Live HEAD-change detection in the **main repo**                                            | `git switch`, `git checkout`, `git commit` (HEAD moves when branchless), interactive rebase, bisect                                                                                                                                                                                   |
+| Live HEAD-change detection in **linked worktrees**                                         | Same actions, run from a `cwd` whose `.git` is a file pointing into `<main>/.git/worktrees/<name>/`                                                                                                                                                                                   |
+| **Per-pane resolution** — pane in main, pane in worktree, two panes in different worktrees | Each pane resolves its own gitdir; subscriptions are bucketed per `--show-toplevel` (already true today; just needs the gitdir path)                                                                                                                                                  |
+| **Detached HEAD label**                                                                    | Header shows abbreviated SHA (same styling as a branch name, mono font) when `git symbolic-ref HEAD` fails. `git_branch` IPC contract extended to fall back to `git rev-parse --short HEAD` instead of returning `""`; see §4 for the contract change and the `useGitBranch` mapping. |
+| **Pane `cwd` changes mid-session** (`cd ../worktree-x`)                                    | OSC 7 backfill triggers `useGitBranch` `cwd`-effect; old subscription is torn down, new one is set up                                                                                                                                                                                 |
+
+### Out of scope
+
+- Cross-pane / cross-worktree fan-out **for HEAD/branch events** (`git-head-changed` for Pane B in `feat-x` does not also notify Pane A in main; each pane is bucketed by its own `--show-toplevel`). Note: when a linked worktree directory sits _inside_ the main repo's working tree (`.claude/worktrees/feat-x/`) and is **not** in `.gitignore`, the main repo's recursive working-tree watch and its `git status --untracked-files=all` will observe changes inside that nested worktree and emit `git-status-changed` for the main pane. That is accepted noise on the _status_ channel — not a contradiction of `git-head-changed`'s per-bucket independence. We mitigate it by recommending `.claude/worktrees/` in `.gitignore` (see §7).
+- Bare repos and submodules. The gitdir resolver (`git rev-parse --git-dir`) returns the right thing in both cases, but neither is exercised today and we won't add fixtures for them.
+- Refs-only updates (`git fetch` updating `refs/heads/feature` without HEAD moving). HEAD itself is unchanged; the branch _name_ is unchanged; nothing to re-render.
+- A "list of worktrees" sidebar view. Out of #189's scope; will get its own issue.
+- A `.gitignore` rule for `.claude/worktrees/`. Worth a separate README/docs note (linked worktrees inside the main working tree appear as untracked in the main repo's `git status`); not the watcher's problem.
+
+### Success criteria
+
+A pane in the main repo and a pane in a linked worktree both display the correct branch within the 300 ms watcher debounce of any HEAD-moving operation, with zero manual `refresh()` calls. Closing and reopening the pane is not required.
+
+---
+
+## 2. Architecture: Per-Pane Gitdir Resolution
+
+The structural change is small in code surface but precise about which path is which.
+
+### What we resolve, per pane
+
+`crates/backend/src/git/watcher.rs` currently resolves a single path per subscribing pane: `--show-toplevel`, canonicalized and validated to be under `$HOME`. We add a **second** resolution:
+
+```
+toplevel  = canonical(git -C <cwd> rev-parse --show-toplevel)
+git_dir   = canonical(git -C <cwd> rev-parse --path-format=absolute --git-dir)
+            then validate it's under $HOME (same scope rule as toplevel)
+```
+
+The `--path-format=absolute` flag is load-bearing. Without it, `git rev-parse --git-dir` can return a path **relative to `<cwd>`** (e.g. `.git` in the main repo when invoked with `-C <toplevel>`). A subsequent `canonicalize()` of a relative path resolves it against the _sidecar process cwd_, not the pane cwd — a silently wrong repo, or an error. `--path-format=absolute` makes git emit an absolute path before we ever touch it.
+
+`--git-dir` returns:
+
+- `<toplevel>/.git` in the main repo (a directory)
+- `<main>/.git/worktrees/<name>` in a linked worktree (a directory under the main `.git/`)
+- A bare-repo path in a bare repo (out of scope, but resolver still returns something sane)
+
+Both are resolved once at **subscription time** (the same path that currently calls `resolve_toplevel`), passed alongside `toplevel` into the `RepoWatcher` struct, and reused for the lifetime of the bucket. We don't re-resolve on every event.
+
+### Bucket model — unchanged
+
+The watcher keeps its existing `repo_watchers: HashMap<PathBuf /* canonical toplevel */, RepoWatcher>` map. Two panes in the same linked worktree share a bucket; two panes in _different_ worktrees of the same main repo get **different** buckets, because `--show-toplevel` returns different paths. This is already the right semantic — no change needed.
+
+The `cwd_to_toplevel` side-map (the cwd-string → canonical-toplevel map that today serves as a **stop-time routing aid**, not a start-time `rev-parse` memoization) gets the `gitdir` added to its value. Cleanest form is to widen the existing entry: `cwd_to_toplevel: HashMap<String, (PathBuf /* toplevel */, PathBuf /* gitdir */)>` (renamed `cwd_to_repo` to reflect the new shape). Populated at subscription start.
+
+**Refcount-aware stop is a prerequisite.** Today (`watcher.rs:1162–1172`), `stop_git_watcher_inner` unconditionally `cwd_to_toplevel.remove(&cwd)` on the FIRST stop. With only `useGitStatus` calling `start_git_watcher` today, this is fine — there's one start per cwd, one stop per cwd. As soon as `useGitBranch` _also_ calls `start_git_watcher` for the same cwd (this spec, §4), we have two starts and two stops. The current unconditional removal turns the second `stop_git_watcher` into a silent no-op (recorded_toplevel becomes `None`, falls into the pre-repo branch, returns `Ok(())` without touching the bucket). The bucket's `subscribers[cwd]` counter stays at 1 forever → polling thread leaks.
+
+Fix in `stop_git_watcher_inner` (small, surgical):
+
+```rust
+// peek instead of remove. (Field name is cwd_to_repo after the rename; the
+// value is the (toplevel, gitdir) tuple — we destructure to recover the
+// canonical toplevel that `repo_watchers` is keyed by.)
+let recorded = state.cwd_to_repo.lock()?.get(&cwd).cloned();
+if let Some((canonical_toplevel, _gitdir)) = recorded {
+    let mut repo_watchers = state.repo_watchers.lock()?;
+    if let Some(watcher) = repo_watchers.get_mut(&canonical_toplevel) {
+        if let Some(count) = watcher.subscribers.get_mut(&cwd) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                watcher.subscribers.remove(&cwd);
+                // NOW (only when this cwd's last subscriber is gone) remove
+                // from the side-map. Future stops for this cwd become a no-op.
+                state.cwd_to_repo.lock()?.remove(&cwd);
+            }
+        }
+        if watcher.subscribers.is_empty() { repo_watchers.remove(&canonical_toplevel); }
+        return Ok(());
+    }
+}
+```
+
+This is purely additive correctness — same observable behavior for the current single-consumer case, correct refcounting for our new dual-consumer case. The pre-repo branch needs the symmetric fix in `cwd_to_safe_pre_repo` (same peek-then-conditional-remove pattern).
+
+### Watch registration — the concrete delta
+
+Today (`watcher.rs:664-676`) watches the **HEAD and index files directly**:
+
+```rust
+let git_index = toplevel.join(".git/index");
+if git_index.exists() { /* watcher.watch(&git_index, NonRecursive) */ }
+
+let git_head = toplevel.join(".git/HEAD");
+if git_head.exists() { /* watcher.watch(&git_head, NonRecursive) */ }
+```
+
+This is **doubly wrong** for our needs. First, the path is wrong in a linked worktree (resolved above). Second — and equally important — git updates `HEAD` and `index` by writing `<file>.lock` and `rename`-ing it over the target. On inotify-style backends (Linux), a watch on a file's _inode_ goes stale once the inode is replaced. The first branch switch may fire an event; subsequent switches silently fail.
+
+After:
+
+```rust
+// `git_dir` is the per-worktree gitdir resolved at subscription time.
+// Watch the directory non-recursively, NOT the individual files. The
+// directory's inode is stable across git's atomic rename-to-replace
+// updates of HEAD, index, and packed-refs.
+if git_dir.exists() {
+    let _ = watcher.watch(&git_dir, RecursiveMode::NonRecursive);
+}
+```
+
+Then, inside the notify event callback, **filter by full path** (NOT by filename — the recursive-on-toplevel working-tree watch can produce events for user files named `HEAD` anywhere in the tree, and we must not flip `head_dirty` for those):
+
+```rust
+let head_path = git_dir.join("HEAD");
+let index_path = git_dir.join("index");
+let packed_refs_path = git_dir.join("packed-refs");
+for path in event.paths {
+    if path == head_path {
+        bucket.head_dirty = true;
+    } else if path == index_path {
+        // existing status-changed path
+    } else if path == packed_refs_path {
+        // ignore — see §7 "Refs-only updates"
+    }
+    // otherwise: working-tree event or unrelated .git/ top-level file (config, hooks/, etc.) — ignore
+}
+```
+
+NonRecursive on the gitdir does NOT recurse into `objects/`, `refs/`, `logs/`, `worktrees/`, or `hooks/`, so the watch-budget concern that motivated avoiding `.git/` recursion in the first place is satisfied: we get top-level file events only. The recursive-on-toplevel working-tree watch is unchanged. Full-path equality is the load-bearing rule that keeps the two watches' events disambiguated.
+
+### `validate_cwd` covers `git_dir` too
+
+In a linked worktree, `git_dir` lives under `<main>/.git/worktrees/<name>/`. The existing `validate_cwd` rule ("path is under `$HOME`") applies cleanly: the main repo is under `$HOME`, so its `.git/worktrees/…` is too. Symbolic links inside `.git/` (which git itself may create, e.g. for `commondir`) are followed by `canonicalize()` before validation. No new security primitive needed.
+
+### Resolution cost
+
+One extra `git rev-parse --path-format=absolute --git-dir` per **subscription start**. The current watcher pays one `--show-toplevel` per `start_git_watcher_inner` call (`watcher.rs:506`); we are adding one more shell-out on the same code path. Both run before the Phase-1 `repo_watchers` lookup, so subsequent subscriptions for the same `cwd` (e.g. a tab re-mount) re-pay the cost — there is **no start-side caching** today, and this spec does not add one. `cwd_to_toplevel` / the proposed `cwd_to_repo` map is a stop-time routing aid (used to find the right bucket on unsubscribe), not a memoization of `rev-parse`. `rev-parse` is sub-10 ms locally; +1 shell-out per subscription start is acceptable.
+
+If we ever need this to be cheaper, the right move is a separate optimization PR that introduces a start-time lookup against `cwd_to_repo` _before_ shelling out, with an explicit invalidation rule (e.g. cwd-string stays stable, but the underlying repo could be `mv`'d; invalidate on any subscription-start failure). Out of scope here.
+
+---
+
+## 3. Event Design: `git-head-changed`
+
+### Wire format
+
+Mirror the existing `git-status-changed` event exactly so the frontend's existing dispatch plumbing applies:
+
+```rust
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GitHeadChangedPayload {
+    /// List of input cwds (frontend's original keys) whose HEAD just moved.
+    cwds: Vec<String>,
+}
+```
+
+Event name on the wire: `"git-head-changed"`. Emit with the same helper shape:
+
+```rust
+fn emit_git_head_changed(events: &Arc<dyn EventSink>, cwds: Vec<String>) {
+    let payload = GitHeadChangedPayload { cwds };
+    let result = serialize_event(&payload)
+        .and_then(|payload| events.emit_json("git-head-changed", payload));
+    if let Err(e) = result {
+        log::error!("Failed to emit git-head-changed: {}", e);
+    }
+}
+```
+
+The frontend matches via `event.cwds.includes(myCwd)`, identical to `git-status-changed`. No new IPC primitive, no new dispatcher.
+
+### Where it's emitted
+
+The `notify` watcher closure already receives a `notify::Event` for every filesystem mutation it sees. Today, every event flows into the 300 ms debounce thread (`spawn_trailing_debounce_thread`) and on the trailing-edge emit calls `emit_for_all_subscribers` → `emit_git_status_changed`. We add a **classification step**:
+
+```
+on FS event in the notify callback:
+  paths = event.paths
+  if any(p == git_dir/HEAD for p in paths):
+      set bucket.head_dirty = true
+  forward the unit signal to the debounce channel (unchanged)
+
+on debounce trailing-edge:
+  if bucket.head_dirty:
+      emit_git_head_changed(bucket.subscribers)
+      bucket.head_dirty = false
+  emit_git_status_changed(bucket.subscribers)  // unchanged
+```
+
+The `head_dirty` flag lives inside the bucket's `RepoWatcher` struct, mutated under the bucket's existing lock. Two emit calls per debounce window when HEAD was touched, one when it wasn't.
+
+**Why classify in the notify closure, not in the debounce thread?** The debounce thread doesn't receive the event payload — it gets a unit signal (`Sender<()>`). The path information disappears once we cross that boundary. So the only place we know "this burst included a HEAD modify" is the notify callback. The `head_dirty` flag persists across the burst until the trailing-edge emit consumes it.
+
+### Polling-fallback path
+
+The 10 s polling fallback (`watcher.rs:695–745`) runs `hash_git_status` and emits `git-status-changed` when the hash changes. **`hash_git_status` does NOT cover HEAD moves on its own.** `git status --porcelain=v1 -z --untracked-files=all` lists only paths with changes; it does not include the current branch name or HEAD ref. A clean `git switch <branch>` against an unmodified working tree leaves the porcelain output unchanged → status hash unchanged → no `git-status-changed`, and (today) no `git-head-changed`.
+
+So the polling thread runs a **second, independent comparison**: read `<git_dir>/HEAD` (cached per bucket, alongside the status hash). When the file contents (one line — either `ref: refs/heads/<name>` or a 40-char SHA) differ from the cached value, emit `git-head-changed` for this bucket's subscribers — regardless of whether the status hash also changed. The two comparisons fire independently; either may emit, neither blocks the other. Cost: one extra `fs::read_to_string` (≤60 bytes) per 10 s poll per bucket. Cache key is the same `git_dir` resolved at subscription time.
+
+This independence matters because the dominant agent flow we care about — `git switch <existing-branch>` on a clean tree — moves HEAD without producing a status diff. Without the independent comparison, that case would only be caught by the notify watcher, and any inotify-stale window (NFS, FUSE) would lose it for up to a session.
+
+### Debounce semantics
+
+`git-head-changed` shares the 300 ms debounce window with `git-status-changed`. Rationale: a single `git commit` mutates `.git/HEAD` _and_ `.git/index` _and_ working-tree files in rapid succession. Emitting `git-head-changed` immediately on the first HEAD touch would race the index/worktree settle; debouncing them together delivers one cohesive update.
+
+### No replay / no cursor protocol
+
+This is a notification ("HEAD may have moved — re-fetch via `git_branch` IPC"), not a state stream. We do not need the offset/cursor protocol used for PTY output. The frontend, on receiving the event, always invokes `git_branch` — which gets the current authoritative value. A dropped event manifests as up-to-300 ms of staleness until the next FS poke (or the user can `refresh()`), not data loss.
+
+### Fan-out scope
+
+Per-bucket, identical to `git-status-changed`: the event's `cwds` list contains only the subscribers of _this_ bucket (this `toplevel`). Pane A in main and Pane B in linked worktree `feat-x` are in different buckets, so a HEAD move in `feat-x` produces one event whose `cwds` includes only Pane B's cwd — Pane A is untouched.
+
+---
+
+## 4. Frontend Integration: `useGitBranch` Subscription
+
+### What changes in the hook
+
+Today, `src/features/diff/hooks/useGitBranch.ts` runs one fetch effect, keyed on `[cwd, enabled, refreshKey]`, that calls `invoke('git_branch', { cwd })` and writes the result to local state. There is **no event subscription and no watcher subscription** — the hook is a pure on-demand fetcher.
+
+After this change, the hook gains a **second effect** that mirrors `useGitStatus`'s watch lifecycle (`useGitStatus.ts:121–199`): attach the listener, start the backend watcher, and tear both down on cleanup. The fetch effect stays as-is.
+
+```ts
+// Pseudocode — actual file uses arrow components, explicit return types,
+// no semicolons, and follows project ESLint config.
+// New effect, added alongside the existing fetch effect.
+useEffect(() => {
+  if (!enabled || !isValidCwd(cwd)) return
+
+  let mounted = true
+  let listenerAttached = false
+  let watcherStarted = false
+
+  const setup = async (): Promise<void> => {
+    try {
+      // Step 1: attach the listener BEFORE invoking start_git_watcher.
+      // `listen` resolves only after the transport is attached, so the
+      // start_git_watcher call below cannot fire events that we'd miss.
+      const unlisten = await listen<GitHeadChangedPayload>(
+        'git-head-changed',
+        (payload) => {
+          if (payload.cwds.includes(cwd)) {
+            refresh()
+          }
+        }
+      )
+      if (!mounted) {
+        unlisten()
+        return
+      }
+      unlistenRef.current = unlisten
+      listenerAttached = true
+
+      // Step 2: refcount-add this cwd to the backend watcher bucket. Safe
+      // to call when useGitStatus has already started a watcher for the
+      // same cwd — the backend refcounts subscribers per cwd.
+      await invoke('start_git_watcher', { cwd })
+      watcherStarted = true
+
+      // Step 3: explicit refresh, guarded by `mounted`. Covers the
+      // listen-attached / watcher-started race window.
+      if (mounted) refresh()
+    } catch (err) {
+      if (mounted) setError(err instanceof Error ? err : new Error(String(err)))
+    }
+  }
+
+  const setupPromise = setup()
+
+  return (): void => {
+    mounted = false
+    void (async () => {
+      // Step A: unlisten FIRST (synchronous) so a late in-flight event
+      // can't call refresh on the torn-down hook. Matches
+      // useGitStatus.ts:192-198 exactly.
+      if (listenerAttached && unlistenRef.current) {
+        unlistenRef.current()
+        unlistenRef.current = null
+      }
+      // Step B: await setupPromise so the start_git_watcher invoke can
+      // settle (matches useGitStatus.ts:200-205). Without this, cleanup
+      // firing between "listener attached" and "invoke resolved" would
+      // skip the stop call (watcherStarted still false), leaking an
+      // orphan backend subscription.
+      await setupPromise.catch(() => {})
+      // Step C: only stop if start actually completed.
+      if (watcherStarted) {
+        await invoke('stop_git_watcher', { cwd }).catch(() => {})
+      }
+    })()
+  }
+}, [cwd, enabled])
+```
+
+### Watcher ownership
+
+The hook calls `start_git_watcher` / `stop_git_watcher` directly. This makes `useGitBranch` self-contained — a pane that mounts `useGitBranch` without `useGitStatus` (e.g. a future "branch chip in the project rail" view) still gets live updates. When both hooks run in the same pane (as in today's `TerminalPane/index.tsx`), they both refcount the same backend bucket; the backend's existing subscriber-refcounting logic (`watcher.rs:570`) handles this transparently — start adds 1, stop subtracts 1, the bucket only tears down when the count reaches zero.
+
+We deliberately do **not** introduce a shared "pane git watcher owner" hook. Two reasons: the refcount path already gives us the deduplication we'd want, and coupling `useGitBranch` to `useGitStatus` would make it impossible to use the branch chip in contexts where the file list isn't rendered.
+
+### Matching on `cwd`, not `toplevel`
+
+The event's `cwds: string[]` field carries **the frontend's own cwd strings** (the keys the backend's subscription tables are keyed by). The hook compares its `cwd` prop against `event.cwds` and matches by string equality. This is identical to how `useGitStatus` already filters `git-status-changed`. No `--show-toplevel` resolution is needed on the frontend.
+
+### Subscription lifecycle
+
+The new effect's deps are `[cwd, enabled]` (intentionally NOT `refreshKey` — re-attaching the listener and the watcher on every manual `refresh()` would be wasteful churn):
+
+- **Mount**: attach listener → start watcher → refresh.
+- **`cwd` changes** (OSC 7 backfill, manual `cd`): cleanup unlistens and stops the old-cwd watcher; new run does the full setup against the new `cwd`.
+- **`enabled` flips to `false`**: cleanup runs; no listener / no watcher until re-enabled.
+- **Unmount**: cleanup runs.
+
+The fetch effect retains its `refreshKey` dep so manual `refresh()` calls re-fetch without re-subscribing.
+
+### `git_branch` IPC contract change (detached HEAD)
+
+Today (`git/mod.rs:1013–1042`) the contract distinguishes three exit-code/stderr combinations:
+
+- `symbolic-ref` exits 0 → `Ok(branch)`.
+- `symbolic-ref` exits non-zero with **empty stderr** → `Ok("")` (detached HEAD; the `-q` flag suppresses stderr in that case).
+- `symbolic-ref` exits non-zero with **non-empty stderr** → `Err` (real failure: not a repo, permission, broken HEAD, etc.).
+
+After this change, the detached-HEAD branch (middle case) gains a fallback. Real errors still surface as `Err`:
+
+1. `git symbolic-ref -q --short HEAD`.
+   - Exit 0 → `Ok(name)`.
+   - Exit non-zero with **non-empty stderr** → `Err` (unchanged behavior; preserves not-a-repo / permission / etc.).
+   - Exit non-zero with **empty stderr** (detached HEAD) → fall through to step 2.
+2. `git rev-parse --short=7 --verify HEAD`.
+   - Exit 0 → `Ok(short-sha)`.
+   - Exit non-zero → `Ok("")` (broken/unborn HEAD — matches today's no-symbol-ref empty-string behavior).
+
+This is **backward-compatible**: every prior `Err` is still an `Err`; every prior `Ok("")` is now `Ok(short-sha)` _or_ still `Ok("")`. The visible behavior change is "the chip now shows a 7-char SHA in detached state instead of disappearing." The hook treats branch names and SHAs identically — the same `trim → null-or-string` mapping — and the Header renders them with the same `text-on-surface-muted` styling (Option 1).
+
+### Empty repository
+
+A freshly `git init`'d repo has no HEAD ref yet. `git symbolic-ref --short HEAD` returns the **unborn branch name** (the value of `init.defaultBranch`, e.g. `main` or `master`, depending on the user's git config) without consulting any object. We honor whatever it returns; the Header reads e.g. `main` even before the first commit. This is consistent with what `git status` shows.
+
+### Test surface
+
+The existing `useGitBranch.test.ts` covers the fetch path. We add three event-driven tests:
+
+- Event with matching `cwd` → branch re-fetched (mock a second IPC return; assert two `invoke` calls).
+- Event with non-matching `cwd` → no re-fetch, branch unchanged.
+- Unmount → no leaked subscription (capture the handler ref, fire the mock event after unmount, assert no IPC call).
+
+The mock for `listen` follows the pattern already used in `useGitStatus.test.ts:113–119` (capture the registered callback off the `listen` mock, fire it manually, assert call ordering: `listen` resolves _before_ `start_git_watcher` is invoked).
+
+---
+
+## 5. Edge Cases
+
+### Pre-repo → linked-worktree upgrade
+
+The watcher's `PreRepoWatcher` (`watcher.rs:280`) handles "cwd is not yet a repo, then later becomes one." For the **main repo** case, the upgrade trigger is `.git/` appearing as a directory. For the **linked worktree** case, the moment the agent runs `git worktree add <cwd> -b <branch>`, `<cwd>/.git` appears as a **regular file** (`gitdir: …`), not a directory.
+
+We rely on the existing `resolve_toplevel` re-try path: `start_git_watcher_inner` calls `resolve_toplevel` on every (re-)subscription, and `git rev-parse --show-toplevel` works identically against `.git` (dir) and `.git` (file). No code change is needed for upgrade _detection_. The only additive work is that the upgrade path must also resolve the new `git_dir` (via the §2 mechanism) and populate `cwd_to_repo` with the (toplevel, gitdir) pair before registering the file watches. The polling cadence (10 s) is unchanged.
+
+### Worktree removal
+
+`git worktree remove <path>` deletes the linked worktree's checkout directory entirely. From the watcher's perspective:
+
+- The recursive `toplevel` watch sees `Remove` events for everything inside.
+- The non-recursive `git_dir` watch sees the gitdir disappear.
+- `notify::Watcher` registrations to deleted paths fail quietly with `Failed to watch …` warnings (already handled today).
+- The notify-based burst-debounce flushes `git-status-changed` for the bucket; `git_branch` IPC on the now-missing cwd fails and the hook resolves `branch` to `null`. The Header drops the chip.
+
+We do **not** auto-tear-down the bucket on disappearance. The pane stays open, its cwd just becomes invalid. The frontend cleans up the bucket via `stop_git_watcher` when the user closes the pane.
+
+### OSC 7 unreliable / not configured
+
+When `session.workingDirectory === '~'` (or any non-absolute placeholder), `useGitBranch` short-circuits to idle until OSC 7 backfills the absolute path. Per `README.md → Shell Setup (OSC 7)`, OSC 7 requires a shell-side hook. If the user hasn't installed the hook, the cwd never backfills and the Header never shows a branch.
+
+This spec does **not** add a fallback for missing OSC 7 — that's a separate ergonomics concern (out of scope per §7). For panes that _do_ receive OSC 7, the live-update path works end-to-end. The implementation plan should include a smoke-test step that verifies OSC 7 is firing in the user's shell config before reporting the feature complete.
+
+### `git_dir` vanishes after subscription
+
+Edge: agent runs `git worktree remove` while a pane in that worktree is still open. The cached `git_dir` now points at a deleted directory. The watcher logs the failed registration and the polling fallback's HEAD-content read returns an error (handled — cached HEAD value just stays stale, no emit). The next `git_branch` IPC call returns `Err` (not `""`), which the hook surfaces as `error` state and the Header drops the chip. No crash.
+
+### HEAD points at a packed ref that gets updated
+
+`<git_dir>/HEAD = "ref: refs/heads/feature"`. Then a remote fetch packs `refs/heads/feature` into `<git_dir>/packed-refs` with a new SHA. HEAD itself is unchanged → no `git-head-changed`. The branch _name_ is also unchanged. The chip stays at `feature`. This is correct — the spec is about branch-name updates, not branch-SHA updates.
+
+(The classification step in §3 explicitly ignores `packed-refs` modifications. The `git-status-changed` channel will fire as expected if the working tree's status against the new SHA differs.)
+
+### Worktree with no commits yet
+
+`git worktree add -b new ../new <new-orphan-ref>` is rare but legal. The new worktree's HEAD points at an unborn ref. `git symbolic-ref --short HEAD` returns the branch name; we honor it (same as §4's "Empty repository" sub-section). No special handling.
+
+---
+
+## 6. Testing Strategy
+
+### Rust unit tests (in `watcher.rs`'s `#[cfg(test)] mod tests`)
+
+Test naming follows `test_<function>_<scenario>_<expected>` (per `rules/rust/testing.md`):
+
+1. `test_head_classification_matches_full_path_only` — feed the notify-callback classifier a `notify::Event` whose path is `<toplevel>/some-dir/HEAD` (working-tree file named HEAD), assert `head_dirty` stays false. Then feed `<git_dir>/HEAD`, assert it flips to true.
+2. `test_head_classification_ignores_packed_refs` — feed `<git_dir>/packed-refs`, assert `head_dirty` stays false (per §7 "Refs-only updates").
+3. `test_polling_emits_head_changed_on_clean_branch_switch_with_unchanged_status_hash` — fixture where `hash_git_status` returns the same value before and after `git switch`, but `<git_dir>/HEAD` contents differ; assert the polling thread emits `git-head-changed` (and NOT a redundant `git-status-changed`).
+4. `test_stop_git_watcher_inner_handles_duplicate_starts` — call `start_git_watcher_inner(cwd)` twice, then `stop_git_watcher_inner(cwd)` twice. After the first stop, the bucket still exists. After the second stop, the bucket is gone. (Direct test of the refcount fix in §2.)
+
+### Rust integration tests (in `crates/backend/tests/`)
+
+A new file `tests/git_watcher_worktree.rs`. Fixtures live in `crates/backend/src/git/test_helpers.rs` — extend with:
+
+```rust
+/// Create a main repo + N linked worktrees in a tempdir under $HOME.
+/// Caller commits one file in the main repo first so worktree branches
+/// have a parent commit. Returns (TempDir, main_path, worktree_paths).
+pub fn create_main_repo_with_worktrees(branches: &[&str])
+    -> (TempDir, PathBuf, Vec<PathBuf>) { … }
+```
+
+Tests (each `#[tokio::test]`):
+
+1. `test_head_change_in_main_emits_for_main_only` — subscribe to main and a linked worktree, run `git -C <main> switch -c <new>`, assert one `git-head-changed` with `cwds: [main]` and zero events for the worktree's cwd.
+2. `test_head_change_in_worktree_emits_for_worktree_only` — symmetric.
+3. `test_detached_head_in_worktree_returns_short_sha` — `git -C <worktree> switch --detach <sha>`, call `git_branch_inner(<worktree>)`, assert it returns the abbreviated SHA (7 chars).
+4. `test_real_git_error_still_returns_err` — call `git_branch_inner` against a path that's under `$HOME` but is NOT a repo, assert the result is `Err` (not `Ok("")`). Protects against the regression codex flagged in §4.
+5. `test_pre_repo_upgrades_to_linked_worktree` — subscribe to a path that isn't yet a repo, run `git worktree add` from outside to create it, wait for the next poll cycle, assert subscription transitions and the next HEAD movement fires `git-head-changed`.
+6. `test_two_worktrees_independent_head_events` — three subscribers across main + two linked worktrees, switch branches in one worktree, assert only that subscriber sees `git-head-changed`.
+
+All tests use `FakeEventSink` (`runtime::FakeEventSink`) and inspect emitted events via the existing helper that filters by event name.
+
+### React hook tests (Vitest + Testing Library)
+
+Extend `src/features/diff/hooks/useGitBranch.test.ts` (per `rules/typescript/testing/CLAUDE.md` — inline test data, `test()` not `it()`):
+
+1. `mount attaches listener BEFORE start_git_watcher` — capture call order on the `listen` and `invoke` mocks, assert `listen` resolves first (same pattern as `useGitStatus.test.ts:143–170`).
+2. `event with matching cwd triggers refetch` — fire the captured `git-head-changed` callback with `cwds: ['/home/test/repo']`, assert a second `invoke('git_branch', …)` is observed.
+3. `event with non-matching cwd does not refetch` — fire with `cwds: ['/other']`, assert no extra invoke.
+4. `unmount unlistens before stopping watcher` — unmount the hook, assert `unlisten` is called before `stop_git_watcher` is invoked.
+5. `unmount during in-flight start awaits setup then stops` — block the `start_git_watcher` invoke promise, unmount before it resolves, then let it resolve; assert `stop_git_watcher` is eventually called.
+
+### Header rendering tests
+
+Extend `HeaderMetadata.test.tsx`:
+
+- `branch="feature/x"` → renders `feature/x` in normal styling.
+- `branch="a1b2c3d"` → renders `a1b2c3d` in normal styling (Option 1 — no special treatment for SHA-shaped strings).
+- `branch=null` → no branch chip.
+
+### Manual smoke test
+
+Recorded as a checklist in the implementation plan (NOT in this spec): open two panes — one in the main repo, one in a freshly-`git worktree add`-ed linked worktree. In each pane, run `git switch <existing-branch>` and `git switch -c <new-branch>` and `git switch --detach HEAD~1`. Confirm both Headers update within ~300 ms without manual refresh, and that a detached HEAD shows the short SHA.
+
+---
+
+## 7. Out-of-Scope & Risks
+
+### Hard out-of-scope
+
+- **Bare repositories** — no working tree, so the recursive `toplevel` watch has no meaning. `git rev-parse --show-toplevel` returns empty for bare repos; `resolve_toplevel` already treats that as "not a repo." We don't add fixtures.
+- **Submodules** — submodule gitdirs live under `<parent>/.git/modules/<name>/`. `git rev-parse --git-dir` returns the right path, but our `validate_cwd($HOME)` rule and the bucket model haven't been exercised against submodule worktrees. Out of scope; explicitly noted so a follow-up issue can pick it up.
+- **Worktrees outside `$HOME`** — `validate_cwd` rejects them. Linked worktrees created in `/tmp`, `/var/…`, or other non-`$HOME` paths will silently fail to subscribe. We accept this — it matches existing `git_status` / `git_diff` behavior.
+- **Cross-pane "list worktrees" view** — a future sidebar feature. This spec does not add a `worktrees` IPC or any new state in the watcher tracking the set-of-worktrees per main repo.
+- **Refs-only updates** (`git fetch` updating `refs/heads/feature` without HEAD moving) — branch name unchanged, no re-render needed. The classification step in §3 explicitly ignores `packed-refs` modifications for this reason. The `git-status-changed` channel still fires if the working tree's status differs against the new SHA.
+- **OSC 7 fallback** — for panes whose shell isn't emitting OSC 7, the cwd never backfills and `useGitBranch` stays idle. A separate ergonomics issue should track this; this spec does not address it.
+
+### Risks
+
+- **`.claude/worktrees/` inside the main working tree, not gitignored.** As called out in §1: the main repo's recursive watcher and `git status --untracked-files=all` will pick up changes inside the nested worktree dir. That fires `git-status-changed` (the _status_ channel, not the branch channel) on the main pane more often than necessary. We mitigate by recommending `.claude/worktrees/` in the README's `.gitignore` guidance. If the recommendation isn't followed, the cost is extra `git-status-changed` fires; the branch label remains correct.
+- **`notify` reliability inside `.git/worktrees/`.** Some filesystems (NFS, FUSE, certain SMB mounts) deliver inotify events inconsistently. The polling fallback at 10 s covers this — §3 explicitly adds HEAD-content caching so a missed notify event surfaces on the next poll, _independently_ of the status hash.
+- **`rev-parse --path-format=absolute` portability.** This flag was added in git 2.31 (2021-03). Ubuntu 22.04 ships git 2.34; macOS Xcode CLT and Homebrew git are both well newer. Safe for our supported platforms. If we ever need to support older git, the alternative is to absolutize the (possibly relative) `--git-dir` output against `cwd` ourselves before canonicalizing.
+- **Spurious `git-head-changed` on `.git/HEAD` write-without-change.** Some tools rewrite HEAD with identical content. Our notify-based detection will fire `git-head-changed`; the frontend will re-invoke `git_branch`; the result is identical; React's state-equality short-circuits the re-render. Wasted IPC, not a bug.
+- **Bucket-lock contention from the new `head_dirty` flag.** Mutated under the existing per-bucket lock; one bool flip per FS event. The current code already takes the same lock for `repo_watchers` fan-out access; the additional contention is negligible.
+
+### Migration notes for the implementation plan
+
+- **Additive.** No existing test should fail. The `.git/HEAD` watch path conceptually moves from `toplevel.join(".git/HEAD")` to `git_dir.join("HEAD")`, but in the main-repo case those are bit-identical. The shape change is "watch the parent dir non-recursively and filter by full path," which existing main-repo tests don't probe.
+- **Frontend `git_branch` IPC contract change** (`Ok("")` → `Ok(short-sha)` for detached HEAD) is observable but backward-compatible: the hook treats both as non-empty strings; `Err` cases are unchanged. The visible behavior change is "the chip now appears in detached state instead of disappearing."
+- **`stop_git_watcher_inner` refcount fix** (described in §2) is a prerequisite. Land it first as its own commit so the worktree work doesn't compound an existing latent bug into a regression for the no-op case.

--- a/docs/superpowers/specs/2026-05-19-live-head-branch-worktree-design.md
+++ b/docs/superpowers/specs/2026-05-19-live-head-branch-worktree-design.md
@@ -506,3 +506,5 @@ Recorded as a checklist in the implementation plan (NOT in this spec): open two 
 - **Additive.** No existing test should fail. The `.git/HEAD` watch path conceptually moves from `toplevel.join(".git/HEAD")` to `git_dir.join("HEAD")`, but in the main-repo case those are bit-identical. The shape change is "watch the parent dir non-recursively and filter by full path," which existing main-repo tests don't probe.
 - **Frontend `git_branch` IPC contract change** (`Ok("")` → `Ok(short-sha)` for detached HEAD) is observable but backward-compatible: the hook treats both as non-empty strings; `Err` cases are unchanged. The visible behavior change is "the chip now appears in detached state instead of disappearing."
 - **`stop_git_watcher_inner` refcount fix** (described in §2) is a prerequisite. Land it first as its own commit so the worktree work doesn't compound an existing latent bug into a regression for the no-op case.
+
+<!-- codex-reviewed: 2026-05-19T08:55:18Z -->

--- a/docs/superpowers/specs/2026-05-19-live-head-branch-worktree-design.md
+++ b/docs/superpowers/specs/2026-05-19-live-head-branch-worktree-design.md
@@ -218,7 +218,9 @@ This independence matters because the dominant agent flow we care about — `git
 
 ### Debounce semantics
 
-`git-head-changed` shares the 300 ms debounce window with `git-status-changed`. Rationale: a single `git commit` mutates `.git/HEAD` _and_ `.git/index` _and_ working-tree files in rapid succession. Emitting `git-head-changed` immediately on the first HEAD touch would race the index/worktree settle; debouncing them together delivers one cohesive update.
+`git-head-changed` shares the 300 ms debounce window with `git-status-changed`. Rationale: a single `git switch <branch>` mutates `<git_dir>/HEAD` _and_ rewrites working-tree files (the checkout) _and_ updates `<git_dir>/index` in rapid succession. Emitting `git-head-changed` immediately on the first HEAD touch would race the index/worktree settle; debouncing them together delivers one cohesive update.
+
+(Note: a normal `git commit` on an attached branch does NOT mutate `<git_dir>/HEAD` — it updates the branch ref under `<git_dir>/refs/heads/`, and `HEAD` remains a `ref:` line pointing at it. HEAD-file mutations happen on switch / checkout / detached-state commit / rebase / bisect. The classification step in §3 is correct for those cases.)
 
 ### No replay / no cursor protocol
 
@@ -227,6 +229,14 @@ This is a notification ("HEAD may have moved — re-fetch via `git_branch` IPC")
 ### Fan-out scope
 
 Per-bucket, identical to `git-status-changed`: the event's `cwds` list contains only the subscribers of _this_ bucket (this `toplevel`). Pane A in main and Pane B in linked worktree `feat-x` are in different buckets, so a HEAD move in `feat-x` produces one event whose `cwds` includes only Pane B's cwd — Pane A is untouched.
+
+### Initial emit on subscribe (covers pre-repo upgrade)
+
+The existing watcher emits `git-status-changed` for a single cwd at the end of `start_git_watcher_inner` (`watcher.rs:577, 802, 816, 855, 888, 1004`) so a freshly-subscribed pane refreshes its status immediately, even before any FS event arrives. We add a symmetric `emit_git_head_changed(events, vec![cwd])` at the same call sites.
+
+This covers the pre-repo → linked-worktree upgrade case (§5): when `start_pre_repo_watcher_inner` later transitions to `start_git_watcher_inner` (because `git worktree add` made the directory a repo), the new initial `git-head-changed` emit causes `useGitBranch` to re-fetch and pick up the now-resolvable branch name. Without this emit, the hook would stay at `null` until the user manually refreshed OR the agent moved HEAD again.
+
+Worktree removal is **not** symmetric — there is no transition emit on teardown. Instead, the recursive working-tree watch sees the `Remove` event for `<git_dir>/HEAD` (now-deleted), which the §3 path classifier matches (`p == git_dir.join("HEAD")`) and flips `head_dirty`. The debounced fan-out emits `git-head-changed` to the bucket's remaining subscribers, the hook re-fetches, `git_branch` returns `Err`, the chip drops. The existing path classification covers this without a special teardown emit.
 
 ---
 
@@ -419,28 +429,34 @@ Test naming follows `test_<function>_<scenario>_<expected>` (per `rules/rust/tes
 3. `test_polling_emits_head_changed_on_clean_branch_switch_with_unchanged_status_hash` — fixture where `hash_git_status` returns the same value before and after `git switch`, but `<git_dir>/HEAD` contents differ; assert the polling thread emits `git-head-changed` (and NOT a redundant `git-status-changed`).
 4. `test_stop_git_watcher_inner_handles_duplicate_starts` — call `start_git_watcher_inner(cwd)` twice, then `stop_git_watcher_inner(cwd)` twice. After the first stop, the bucket still exists. After the second stop, the bucket is gone. (Direct test of the refcount fix in §2.)
 
-### Rust integration tests (in `crates/backend/tests/`)
+### Rust unit tests for worktree integration scenarios
 
-A new file `tests/git_watcher_worktree.rs`. Fixtures live in `crates/backend/src/git/test_helpers.rs` — extend with:
+The original draft routed these through `crates/backend/tests/`, but `test_helpers.rs` and `git_branch_inner` are `pub(crate)` — not visible from external integration-test crates. Per `rules/rust/testing.md`, these belong as **unit tests** in the existing `#[cfg(test)] mod tests` blocks at the bottom of `watcher.rs` and `mod.rs`. The same module access is what current watcher tests use (`watcher.rs:1294`), so no new test-only `pub` exports are needed.
+
+Fixtures live in `crates/backend/src/git/test_helpers.rs` — extend with:
 
 ```rust
 /// Create a main repo + N linked worktrees in a tempdir under $HOME.
 /// Caller commits one file in the main repo first so worktree branches
 /// have a parent commit. Returns (TempDir, main_path, worktree_paths).
-pub fn create_main_repo_with_worktrees(branches: &[&str])
+pub(crate) fn create_main_repo_with_worktrees(branches: &[&str])
     -> (TempDir, PathBuf, Vec<PathBuf>) { … }
 ```
 
-Tests (each `#[tokio::test]`):
+Tests in `watcher.rs#[cfg(test)] mod tests` (each `#[tokio::test]`):
 
 1. `test_head_change_in_main_emits_for_main_only` — subscribe to main and a linked worktree, run `git -C <main> switch -c <new>`, assert one `git-head-changed` with `cwds: [main]` and zero events for the worktree's cwd.
 2. `test_head_change_in_worktree_emits_for_worktree_only` — symmetric.
-3. `test_detached_head_in_worktree_returns_short_sha` — `git -C <worktree> switch --detach <sha>`, call `git_branch_inner(<worktree>)`, assert it returns the abbreviated SHA (7 chars).
-4. `test_real_git_error_still_returns_err` — call `git_branch_inner` against a path that's under `$HOME` but is NOT a repo, assert the result is `Err` (not `Ok("")`). Protects against the regression codex flagged in §4.
-5. `test_pre_repo_upgrades_to_linked_worktree` — subscribe to a path that isn't yet a repo, run `git worktree add` from outside to create it, wait for the next poll cycle, assert subscription transitions and the next HEAD movement fires `git-head-changed`.
-6. `test_two_worktrees_independent_head_events` — three subscribers across main + two linked worktrees, switch branches in one worktree, assert only that subscriber sees `git-head-changed`.
+3. `test_pre_repo_upgrades_to_linked_worktree_and_emits_initial_head_event` — subscribe to a path that isn't yet a repo, run `git worktree add` from outside to create it, wait for the next poll cycle, assert subscription transitions and the **initial** `git-head-changed` emit (from §3 "Initial emit on subscribe") fires immediately on upgrade.
+4. `test_two_worktrees_independent_head_events` — three subscribers across main + two linked worktrees, switch branches in one worktree, assert only that subscriber sees `git-head-changed`.
+5. `test_worktree_removal_emits_head_changed_for_disappearing_worktree` — subscribe to a linked worktree, `git worktree remove` it, assert `git-head-changed` fires (path classifier matches the `Remove` event on `<git_dir>/HEAD`) and the next `git_branch_inner` call returns `Err`.
 
-All tests use `FakeEventSink` (`runtime::FakeEventSink`) and inspect emitted events via the existing helper that filters by event name.
+Tests in `mod.rs#[cfg(test)] mod tests` (`#[tokio::test]`):
+
+6. `test_git_branch_detached_head_in_worktree_returns_short_sha` — extends the existing `test_git_branch_returns_empty_for_detached_head` at `mod.rs:1757`. After this spec, the expected return changes from `""` to the abbreviated SHA. Update the existing test name + assertion in the same commit.
+7. `test_git_branch_non_repo_cwd_still_returns_err` — call `git_branch_inner` against a `$HOME`-rooted path that is NOT a repo, assert `Err` (not `Ok("")`). Protects against the regression codex flagged in §4. Mirrors the existing `test_git_branch_returns_error_for_non_repo_cwd` at `mod.rs:1804`.
+
+All tests use `FakeEventSink` (`runtime::FakeEventSink` — publicly re-exported at `runtime/mod.rs:13`) and inspect emitted events via the same helpers existing watcher tests use.
 
 ### React hook tests (Vitest + Testing Library)
 

--- a/src/features/diff/hooks/useGitBranch.test.ts
+++ b/src/features/diff/hooks/useGitBranch.test.ts
@@ -1,16 +1,27 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { invoke } from '../../../lib/backend'
+import { invoke, listen } from '../../../lib/backend'
 import { useGitBranch } from './useGitBranch'
 
 vi.mock('../../../lib/backend', () => ({
   invoke: vi.fn(),
+  listen: vi.fn(),
 }))
 
 describe('useGitBranch', () => {
+  const noopUnlisten = (): void => undefined
+
   beforeEach(() => {
     vi.mocked(invoke).mockReset()
+    vi.mocked(listen).mockReset()
+    vi.mocked(listen).mockResolvedValue(noopUnlisten)
+    vi.mocked(invoke).mockImplementation((cmd: string) =>
+      Promise.resolve(cmd === 'git_branch' ? 'main' : undefined)
+    )
   })
+
+  const gitBranchInvokeCount = (): number =>
+    vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === 'git_branch').length
 
   test('returns idle state for fallback cwd `.`', () => {
     const { result } = renderHook(() => useGitBranch('.'))
@@ -50,7 +61,9 @@ describe('useGitBranch', () => {
   })
 
   test('fetches branch via invoke for a valid cwd', async () => {
-    vi.mocked(invoke).mockResolvedValueOnce('feat/jose-auth')
+    vi.mocked(invoke).mockImplementation((cmd: string) =>
+      Promise.resolve(cmd === 'git_branch' ? 'feat/jose-auth' : undefined)
+    )
 
     const { result } = renderHook(() => useGitBranch('/home/user/repo'))
 
@@ -63,7 +76,9 @@ describe('useGitBranch', () => {
   })
 
   test('treats empty string result as null branch', async () => {
-    vi.mocked(invoke).mockResolvedValueOnce('')
+    vi.mocked(invoke).mockImplementation((cmd: string) =>
+      Promise.resolve(cmd === 'git_branch' ? '' : undefined)
+    )
 
     const { result } = renderHook(() => useGitBranch('/home/user/repo'))
 
@@ -72,7 +87,13 @@ describe('useGitBranch', () => {
   })
 
   test('captures error on invoke rejection', async () => {
-    vi.mocked(invoke).mockRejectedValueOnce(new Error('not a repo'))
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === 'git_branch') {
+        return Promise.reject(new Error('not a repo'))
+      }
+
+      return Promise.resolve(undefined)
+    })
 
     const { result } = renderHook(() => useGitBranch('/home/user/repo'))
 
@@ -82,15 +103,136 @@ describe('useGitBranch', () => {
   })
 
   test('refresh re-fetches', async () => {
-    vi.mocked(invoke)
-      .mockResolvedValueOnce('main')
-      .mockResolvedValueOnce('develop')
+    const branches = ['main', 'main', 'develop']
+    vi.mocked(invoke).mockImplementation((cmd: string) =>
+      Promise.resolve(cmd === 'git_branch' ? branches.shift() : undefined)
+    )
 
     const { result } = renderHook(() => useGitBranch('/home/user/repo'))
 
     await waitFor(() => expect(result.current.branch).toBe('main'))
+    await waitFor(() =>
+      expect(gitBranchInvokeCount()).toBeGreaterThanOrEqual(2)
+    )
     act(() => result.current.refresh())
     await waitFor(() => expect(result.current.branch).toBe('develop'))
-    expect(invoke).toHaveBeenCalledTimes(2)
+    expect(gitBranchInvokeCount()).toBe(3)
+  })
+
+  test('attaches git-head-changed listener before invoking start_git_watcher', async () => {
+    const callOrder: string[] = []
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      callOrder.push(`invoke:${cmd}`)
+
+      return Promise.resolve(cmd === 'git_branch' ? 'main' : undefined)
+    })
+
+    vi.mocked(listen).mockImplementation(() => {
+      callOrder.push('listen')
+
+      return Promise.resolve(noopUnlisten)
+    })
+
+    renderHook(() => useGitBranch('/home/test/repo'))
+
+    await waitFor(() => {
+      expect(callOrder).toContain('listen')
+      expect(callOrder).toContain('invoke:start_git_watcher')
+    })
+
+    expect(callOrder.indexOf('listen')).toBeLessThan(
+      callOrder.indexOf('invoke:start_git_watcher')
+    )
+  })
+
+  test('fetches branch again when git-head-changed event includes our cwd', async () => {
+    let captured: ((payload: { cwds: string[] }) => void) | null = null
+    const branches = ['main', 'main', 'feat/x']
+    vi.mocked(listen).mockImplementation((_event, callback) => {
+      captured = callback as (payload: { cwds: string[] }) => void
+
+      return Promise.resolve(noopUnlisten)
+    })
+
+    vi.mocked(invoke).mockImplementation((cmd: string) =>
+      Promise.resolve(cmd === 'git_branch' ? branches.shift() : undefined)
+    )
+
+    const { result } = renderHook(() => useGitBranch('/home/test/repo'))
+
+    await waitFor(() => expect(result.current.branch).toBe('main'))
+    await waitFor(() =>
+      expect(gitBranchInvokeCount()).toBeGreaterThanOrEqual(2)
+    )
+    act(() => captured?.({ cwds: ['/home/test/repo'] }))
+    await waitFor(() => expect(result.current.branch).toBe('feat/x'))
+  })
+
+  test('ignores git-head-changed event when cwds do not match', async () => {
+    let captured: ((payload: { cwds: string[] }) => void) | null = null
+    vi.mocked(listen).mockImplementation((_event, callback) => {
+      captured = callback as (payload: { cwds: string[] }) => void
+
+      return Promise.resolve(noopUnlisten)
+    })
+
+    vi.mocked(invoke).mockImplementation((cmd: string) =>
+      Promise.resolve(cmd === 'git_branch' ? 'main' : undefined)
+    )
+
+    const { result } = renderHook(() => useGitBranch('/home/test/repo'))
+
+    await waitFor(() => expect(result.current.branch).toBe('main'))
+    await waitFor(() =>
+      expect(gitBranchInvokeCount()).toBeGreaterThanOrEqual(2)
+    )
+    vi.mocked(invoke).mockClear()
+    act(() => captured?.({ cwds: ['/home/other'] }))
+
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  test('cleanup removes listener before stopping watcher and waits for start', async () => {
+    const order: string[] = []
+    vi.mocked(listen).mockImplementation(() => {
+      order.push('listen')
+
+      return Promise.resolve((): void => {
+        order.push('unlisten')
+      })
+    })
+
+    let resolveStart: () => void = noopUnlisten
+
+    const startPromise = new Promise<void>((resolve) => {
+      resolveStart = resolve
+    })
+
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      order.push(`invoke:${cmd}`)
+      if (cmd === 'start_git_watcher') {
+        return startPromise
+      }
+      if (cmd === 'git_branch') {
+        return Promise.resolve('main')
+      }
+
+      return Promise.resolve(undefined)
+    })
+
+    const { unmount } = renderHook(() => useGitBranch('/home/test/repo'))
+
+    await waitFor(() => expect(order).toContain('listen'))
+    unmount()
+    resolveStart()
+
+    await waitFor(() => expect(order).toContain('invoke:stop_git_watcher'))
+    expect(order.indexOf('unlisten')).toBeLessThan(
+      order.indexOf('invoke:stop_git_watcher')
+    )
+
+    expect(order.indexOf('invoke:start_git_watcher')).toBeLessThan(
+      order.indexOf('invoke:stop_git_watcher')
+    )
   })
 })

--- a/src/features/diff/hooks/useGitBranch.ts
+++ b/src/features/diff/hooks/useGitBranch.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { invoke } from '../../../lib/backend'
+import { invoke, listen, type UnlistenFn } from '../../../lib/backend'
 
 export interface UseGitBranchOptions {
   /** When false, returns empty state and skips IPC. */
@@ -12,6 +12,11 @@ export interface UseGitBranchReturn {
   error: Error | null
   refresh: () => void
   idle: boolean
+}
+
+interface GitHeadChangedPayload {
+  /** List of current working directory paths subscribed to the watcher */
+  cwds: string[]
 }
 
 const isValidCwd = (cwd: string): boolean => {
@@ -56,6 +61,7 @@ export const useGitBranch = (
   // (don't blank the Header — the previous branch is still correct for
   // this cwd; just refresh it in place once the IPC returns).
   const lastFetchedCwdRef = useRef<string | null>(null)
+  const unlistenRef = useRef<UnlistenFn | null>(null)
 
   useEffect(() => {
     if (!enabled || !isValidCwd(cwd)) {
@@ -114,6 +120,79 @@ export const useGitBranch = (
       cancelled = true
     }
   }, [cwd, enabled, refreshKey])
+
+  useEffect((): (() => void) | undefined => {
+    if (!enabled || !isValidCwd(cwd)) {
+      return undefined
+    }
+
+    let mounted = true
+    let listenerAttached = false
+    let watcherStarted = false
+
+    const setupWatch = async (): Promise<void> => {
+      try {
+        const unlisten = await listen<GitHeadChangedPayload>(
+          'git-head-changed',
+          (payload) => {
+            if (payload.cwds.includes(cwd)) {
+              refresh()
+            }
+          }
+        )
+
+        if (!mounted) {
+          unlisten()
+
+          return
+        }
+
+        unlistenRef.current = unlisten
+        listenerAttached = true
+
+        await invoke('start_git_watcher', { cwd })
+        watcherStarted = true
+
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (mounted) {
+          refresh()
+        }
+      } catch (err) {
+        if (mounted) {
+          setError(
+            err instanceof Error
+              ? err
+              : new Error('Failed to start git branch watcher')
+          )
+        }
+      }
+    }
+
+    const setupPromise = setupWatch()
+
+    return (): void => {
+      mounted = false
+
+      const cleanup = async (): Promise<void> => {
+        if (listenerAttached && unlistenRef.current) {
+          unlistenRef.current()
+          unlistenRef.current = null
+        }
+
+        await setupPromise.catch(() => {
+          // setup errored — nothing to stop
+        })
+
+        if (watcherStarted) {
+          await invoke('stop_git_watcher', { cwd }).catch(() => {
+            // Best-effort cleanup — swallow errors
+          })
+        }
+      }
+
+      void cleanup()
+    }
+  }, [cwd, enabled, refresh])
 
   return { branch, loading, error, refresh, idle }
 }

--- a/src/features/diff/hooks/useGitBranch.ts
+++ b/src/features/diff/hooks/useGitBranch.ts
@@ -153,6 +153,14 @@ export const useGitBranch = (
         await invoke('start_git_watcher', { cwd })
         watcherStarted = true
 
+        // Guarded by `mounted` because React cleanup could have fired
+        // during the invoke await — a setState on an unmounted component
+        // is a no-op in React 18 production but still an anti-pattern
+        // (and a wasted fetch in Strict Mode's double-invocation).
+        // TypeScript's flow analysis can't see the cleanup closure below
+        // mutate `mounted` across the await, so the lint rule has to be
+        // suppressed at this exact line. Same disable + rationale as
+        // useGitStatus.ts:160-167.
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (mounted) {
           refresh()


### PR DESCRIPTION
## Summary

Closes #189. Pane Headers now display the correct branch for their cwd — main repo and linked worktrees alike — within ~300 ms of any HEAD-moving operation, with zero manual refresh.

Spec: `docs/superpowers/specs/2026-05-19-live-head-branch-worktree-design.md`
Plan: `docs/superpowers/plans/2026-05-19-live-head-branch-worktree.md` (12 TDD tasks)

### What changed

**Backend (`crates/backend/src/git/`)**

- `watcher.rs`: resolve `git rev-parse --path-format=absolute --git-dir` per pane; `cwd_to_toplevel` → `cwd_to_repo` carrying (toplevel, gitdir); watch the gitdir non-recursively (survives git's atomic rename-replace); full-path classifier gates gitdir-side noise (config, packed-refs, COMMIT_EDITMSG) before reaching the debounce thread; new `head_dirty` flag drives a separate `git-head-changed` event on the trailing edge; polling fallback runs `detect_head_change_with` against `<git_dir>/HEAD` *independently* from `hash_git_status` so clean branch switches on unmodified trees are caught; initial `git-head-changed` emit on every subscription path (covers pre-repo → worktree upgrade); refcount-aware `stop_git_watcher_inner` so dual-consumer starts (useGitStatus + useGitBranch on the same cwd) don't leak the bucket.
- `mod.rs`: `git_branch` falls back to `git rev-parse --short=7 --verify HEAD` on detached HEAD; real errors still surface as `Err`.

**Frontend (`src/features/diff/hooks/useGitBranch.ts`)**

New effect that mirrors `useGitStatus`'s lifecycle: `listen('git-head-changed', …)` → `invoke('start_git_watcher', …)` → refresh. Cleanup unlistens first, awaits the in-flight setup promise, then stops the watcher.

**Docs**

README adds a note recommending `.claude/worktrees/` in `.gitignore` for projects that put linked worktrees inside the repo.

### Commits

- docs(spec): live-head-branch detection with worktree support
- docs(spec): apply codex feedback
- docs(spec): mark spec codex-reviewed
- docs(plan): live-head-branch detection with worktree support
- docs(plan): apply codex feedback
- docs(plan): mark plan codex-reviewed
- feat(git): live HEAD/branch detection with worktree support (#189)

## Test plan

- [x] `cargo test -p vimeflow --lib git::` — **77 passed, 0 failed** (20+ new tests for gitdir resolution, path classifiers, HEAD-content comparator, atomic-rename survival, worktree isolation, pre-repo upgrade, two-worktree independence, removal flow, refcount-aware stop).
- [x] `npx vitest run src/features/diff/hooks/useGitBranch.test.ts` — **15 passed** (existing + 4 new event-subscription tests).
- [x] `npm run lint` on touched files — clean.
- [x] `npm run type-check` — clean.
- [x] Pre-push vitest full suite — **2294 passed, 3 skipped, 174 test files**.
- [ ] Manual smoke test (recommended before merge): open two TerminalPanes, one in the main repo and one in a freshly-`git worktree add`-ed sibling worktree; run `git switch <existing>`, `git switch -c <new>`, and `git switch --detach HEAD~1` in each; confirm both Headers update within ~300 ms without manual refresh, and that detached HEAD shows a 7-char short SHA.