### PR TITLE
fix(terminal): focus xterm on initial mount when pane is born active

### DIFF
--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -311,9 +311,24 @@ describe('TerminalPane index', () => {
     })
   })
 
-  test('does not focus on initial mount with pane.active=true', () => {
+  test('focuses on initial mount when pane.active=true', () => {
+    // A freshly-created pane (createSession, addPane, restored active pane on
+    // app launch) mounts already active and never transitions false→true. The
+    // rising-edge effect must therefore treat the first run as a focus event,
+    // otherwise the active terminal stays unfocused until the user clicks it.
     render(
       <TerminalPane {...baseProps} pane={{ ...baseProps.pane, active: true }} />
+    )
+
+    expect(focusTerminalSpy).toHaveBeenCalledOnce()
+  })
+
+  test('does not focus on initial mount when pane.active=false', () => {
+    render(
+      <TerminalPane
+        {...baseProps}
+        pane={{ ...baseProps.pane, active: false }}
+      />
     )
 
     expect(focusTerminalSpy).not.toHaveBeenCalled()
@@ -383,7 +398,15 @@ describe('TerminalPane index', () => {
   test('ref handle focuses terminal body when ready', () => {
     const ref = createRef<TerminalPaneHandle>()
 
-    render(<TerminalPane ref={ref} {...baseProps} />)
+    // Render inactive so the mount-time auto-focus path does not fire — this
+    // test isolates the imperative ref handle from the rising-edge effect.
+    render(
+      <TerminalPane
+        ref={ref}
+        {...baseProps}
+        pane={{ ...baseProps.pane, active: false }}
+      />
+    )
 
     expect(ref.current).not.toBeNull()
     expect(ref.current!.focusTerminal()).toBe(true)

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -71,7 +71,12 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
   ): ReactElement {
     const agent = agentForPane(pane)
     const bodyRef = useRef<BodyHandle>(null)
-    const wasActiveRef = useRef(pane.active)
+    // Seeded `undefined` (NOT `pane.active`) so the first effect run can detect
+    // initial mount distinctly from a stable `true → true` re-render. A pane
+    // born active (createSession, addPane, restored on app launch) must focus
+    // on first paint — otherwise its xterm stays unfocused with no transition
+    // for the rising-edge branch below to catch.
+    const wasActiveRef = useRef<boolean | undefined>(undefined)
     const [ptyStatus, setPtyStatus] = useState<PtyStatus>('idle')
     const [isCollapsed, setIsCollapsed] = useState(false)
 
@@ -91,7 +96,9 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     const isFocusHighlightVisible = isPaneActive && showFocusHighlight
 
     useEffect(() => {
-      if (pane.active && !wasActiveRef.current) {
+      // Fire on `undefined → true` (initial mount active) AND `false → true`
+      // (existing rising edge). Stable `true → true` re-renders are skipped.
+      if (pane.active && wasActiveRef.current !== true) {
         bodyRef.current?.focusTerminal()
       }
       wasActiveRef.current = pane.active


### PR DESCRIPTION
## Summary

A pane that is born active — a brand-new session, a new split-view pane, or the only pane on a clean launch — was never receiving keyboard focus. The user had to click into the terminal before typing.

## Root cause

`TerminalPane`'s focus effect was a rising-edge detector:

```ts
const wasActiveRef = useRef(pane.active)   // seeded TRUE
useEffect(() => {
  if (pane.active && !wasActiveRef.current) {
    bodyRef.current?.focusTerminal()
  }
  wasActiveRef.current = pane.active
}, [pane.active])
```

On the first run for an active pane, `wasActiveRef.current` already equals `true`, so the condition is `true && !true = false` and the focus call never fires. The design assumed the imperative `claimTerminal()` chain in `WorkspaceView` would handle initial mounts, but that chain has gaps:

- **App launch** — nothing calls `claimTerminal()` after `useSessionRestore` resolves or after `useAutoCreateOnEmpty` seeds the default session.
- **Create session (`+` tab)** — `handleCreateSession` calls `claimTerminal()` synchronously, but `createSession()` is async and the new session is not yet in state when the layout effect fires. The focus request targets pre-spawn state and is cleared before the new pane mounts.
- **Add pane (`+` in split view)** — `useSessionManager.addPane` has no `claimTerminal()` wrapper at all.

In all three paths the new pane mounts already active, the rising-edge effect skips, and focus is stranded on `document.body`.

## Fix

Seed `wasActiveRef` as `undefined` and broaden the guard to also fire on the `undefined → true` transition:

```ts
const wasActiveRef = useRef<boolean | undefined>(undefined)
useEffect(() => {
  if (pane.active && wasActiveRef.current !== true) {
    bodyRef.current?.focusTerminal()
  }
  wasActiveRef.current = pane.active
}, [pane.active])
```

Stable `true → true` re-renders still skip (a re-render with no `pane.active` change won't even re-run the effect). Inactive panes inside hidden (`display: none`) session panels on multi-session restore are no-ops — `terminal.focus()` on a hidden container has no effect in Chromium.

## Test plan

- [x] New positive unit test: `focuses on initial mount when pane.active=true`
- [x] New negative unit test: `does not focus on initial mount when pane.active=false`
- [x] Existing rising-edge tests (`false → true`, stable `true → true`, second rising edge) still pass
- [x] Existing imperative-handle test rendered inactive so it isolates the ref path from the new auto-focus path
- [x] Full vitest run — 175 files, 2323 tests pass
- [x] `npm run lint`, `npm run type-check` clean
- [ ] Smoke test in the running Electron app: launch cold, create new session, split a pane — verify cursor lands in xterm in each case (recommend before merge)