### PR TITLE
fix(e2e): chunk typed keystrokes per char + verify shell echo

### DIFF
--- a/tests/e2e/agent/specs/agent-detect-fake.spec.ts
+++ b/tests/e2e/agent/specs/agent-detect-fake.spec.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
@@ -9,32 +8,17 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const FIXTURE_DIR = path.resolve(__dirname, '../../fixtures/agents')
 
-// Host has any claude processes? The current detector (crates/backend/src/agent/
-// detector.rs) scans /proc globally for argv[0]="claude" and attributes any
-// match to the fresh PTY. On a dev box running real Claude Code, the host
-// processes win the race and this spec sees non-deterministic failures
-// (sometimes "invalid session id" when the app crashes in a code path
-// triggered by the early false-detection). Skipping until PTY-ancestry
-// filtering lands — tracked by https://github.com/winoooops/vimeflow/issues/71.
-const hasPreexistingClaudeProcesses = (): boolean => {
-  const result = spawnSync('pgrep', ['-x', 'claude'], { encoding: 'utf8' })
-  // pgrep exits 0 if any matches, 1 if none. Any non-empty stdout = matches.
-  return result.status === 0 && result.stdout.trim().length > 0
-}
-
 describe('Agent detection (fake-claude)', function () {
   // Linux-only: detector reads /proc; fixture uses bash + exec -a.
+  //
+  // The detector is PTY-scoped — `detect_agent` (crates/backend/src/agent/
+  // detector.rs) walks the queried PTY's process tree via
+  // /proc/<pid>/task/<pid>/children rather than scanning /proc globally,
+  // so a host `claude` process outside the PTY tree no longer collides
+  // with the test. The pre-existing skip guard for issue #71 has been
+  // removed; the original race it described is fixed.
   before(function () {
     if (process.platform !== 'linux') {
-      this.skip()
-    }
-    if (hasPreexistingClaudeProcesses()) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        '[agent-detect-fake] skipping: pre-existing `claude` process(es) ' +
-          'on host will collide with the global-scoped detector. ' +
-          'See https://github.com/winoooops/vimeflow/issues/71'
-      )
       this.skip()
     }
   })

--- a/tests/e2e/shared/terminal.ts
+++ b/tests/e2e/shared/terminal.ts
@@ -2,8 +2,10 @@
  * Terminal interaction helpers for the WDIO suite.
  *
  * xterm.js listens for keystrokes on a hidden `.xterm-helper-textarea`.
- * Focus the textarea through the DOM, then let WebDriver send ordered
- * key input to the active element.
+ * Focus the textarea through the DOM, then drive input with a per-char
+ * down → up → pause action chain so xterm receives chars in the order
+ * they were authored (see `typeInActiveTerminal` for the reorder
+ * incident that motivated the per-char dispatch).
  */
 
 type FocusFailure = 'no_pane' | 'no_textarea' | 'focus_failed'
@@ -43,8 +45,9 @@ const focusActiveTerminalTextarea = async (): Promise<void> => {
       // return type is `any` at runtime, so a future ChromeDriver version
       // or transport change could yield something outside FocusFailure.
       // Without this default, the unexpected value would slip past the
-      // switch and silently leave focus unestablished, causing
-      // browser.keys() to type into the wrong element.
+      // switch and silently leave focus unestablished, causing the key
+      // action chain in `typeInActiveTerminal` to type into the wrong
+      // element.
       const _exhaustive: never = status
       throw new Error(
         `focusActiveTerminalTextarea: unexpected status: ${String(_exhaustive)}`
@@ -53,12 +56,56 @@ const focusActiveTerminalTextarea = async (): Promise<void> => {
   }
 }
 
+const KEY_PAUSE_MS = 8
+const ECHO_VERIFY_TIMEOUT_MS = 5_000
+
+// Check whether the visible terminal buffer contains `text` (bash echo).
+// Collapses whitespace before comparison so xterm line-wrapping (prompt +
+// long path can exceed the col width and split the echoed string across
+// rows) doesn't mask a clean type.
+const bufferEchoes = (buffer: string, text: string): boolean => {
+  const collapse = (s: string): string => s.replace(/\s+/g, '')
+  return collapse(buffer).includes(collapse(text))
+}
+
 export const typeInActiveTerminal = async (text: string): Promise<void> => {
   await focusActiveTerminalTextarea()
-  await browser.keys(text)
+
+  // Send each char as a discrete keyDown then keyUp then short pause. The
+  // WebdriverIO default `browser.keys(text)` packs every keyDown before
+  // every keyUp into a single action; that batched-down delivery has been
+  // observed to reorder chars under CI load (run 26017368985, 2026-05-18:
+  // the test typed `echo` and bash echoed `ehco`), which silently corrupts
+  // paths and commands and surfaces as opaque downstream timeouts. Per-char
+  // dispatch with a short pause forces ordered delivery to xterm's keydown
+  // handler.
+  let chain = browser.action('key')
+  for (const char of text) {
+    chain = chain.down(char).up(char).pause(KEY_PAUSE_MS)
+  }
+  await chain.perform()
+
+  // Verify bash echoed the chars back before the caller advances. Catches
+  // any remaining reorder/drop with a precise diagnostic instead of letting
+  // a misspelled command surface 30s later as a generic waitForDisplayed
+  // timeout.
+  await browser.waitUntil(
+    async () => {
+      const buf = await browser.execute(
+        () => window.__VIMEFLOW_E2E__?.getTerminalBuffer() ?? ''
+      )
+      return bufferEchoes(buf, text)
+    },
+    {
+      timeout: ECHO_VERIFY_TIMEOUT_MS,
+      timeoutMsg: `typeInActiveTerminal: shell did not echo ${JSON.stringify(text)} within ${ECHO_VERIFY_TIMEOUT_MS}ms`,
+    }
+  )
 }
 
 export const pressEnterInActiveTerminal = async (): Promise<void> => {
   await focusActiveTerminalTextarea()
-  await browser.keys('\uE007')
+  // Enter is a single keystroke, no batching hazard. `\uE007` is the W3C
+  // WebDriver code point for Enter; ChromeDriver maps it to VK_RETURN.
+  await browser.action('key').down('\uE007').up('\uE007').perform()
 }


### PR DESCRIPTION
## Root cause

WebdriverIO's `browser.keys(text)` translates a string into a single W3C `actions` sequence that packs every `keyDown` before every `keyUp`:

```json
[ keyDown:e, keyDown:c, keyDown:h, keyDown:o, …, pause:10ms, keyUp:e, keyUp:c, keyUp:h, keyUp:o, … ]
```

Under CI load this batched-down delivery has been observed to reorder chars at xterm's helper textarea.

**Direct evidence (run [26017368985](https://github.com/winoooops/vimeflow/actions/runs/26017368985), 2026-05-18):** the `terminal-io` test typed `echo POST${COLUMNS}END` and bash's buffer tail read `ehco POST${COLUMNS}END` — `c` and `h` arrived in the wrong order at xterm.

The same helper (`tests/e2e/shared/terminal.ts::typeInActiveTerminal`) feeds the `agent-detect-fake` test, which has been flaking ~40% on `main` for the last 3 days. When the fixture path is misspelled, bash returns an error, no `claude`-named process spawns, the PTY-scoped detector polls 15× across 30s and finds nothing, and the test dies with the generic `element ("[data-testid="agent-status-card"]") still not displayed after 30000ms`. The post-type buffer was never inspected, so the keystroke corruption was invisible.

## Changes

**`tests/e2e/shared/terminal.ts`**
- Replaced `browser.keys(text)` with a per-char `browser.action('key').down(c).up(c).pause(8)` chain. Each keypress is now its own ordered `down → up` unit with an 8 ms gap. Total typing cost for a ~70-char path: ~600 ms (vs 30 s opaque timeout on a flake).
- Added a post-type `waitUntil` that checks the visible terminal buffer for the typed string (whitespace-collapsed to tolerate line wrapping). 5 s timeout with a precise diagnostic: `typeInActiveTerminal: shell did not echo "/home/runner/..."` — pinpoints the keystroke bug at the source instead of letting it surface 30 s later as a downstream `waitForDisplayed` timeout.
- `pressEnterInActiveTerminal` switched from `browser.keys('\\uE007')` to `browser.action('key').down('\\uE007').up('\\uE007').perform()` for API consistency (Enter is a single keystroke; no batching hazard, just keeping the helper coherent).

**`tests/e2e/agent/specs/agent-detect-fake.spec.ts`**
- Removed the `hasPreexistingClaudeProcesses` skip guard and the obsolete comment block referencing issue [#71](https://github.com/winoooops/vimeflow/issues/71). The race those described — global `/proc` scan attributing host-side `claude` processes to the test PTY — was fixed when `detect_agent` moved to walking `/proc/<pid>/task/<pid>/children` from the PTY root (`crates/backend/src/agent/detector.rs`; unit tests `detects_only_agent_inside_pty_process_tree`, `ignores_agent_outside_pty_process_tree` lock the behavior). The guard was lying about current detector semantics and would only skip tests for a problem that no longer exists.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run type-check` clean
- [x] `npx vitest run` — 175 files / 2323 tests pass
- [x] E2E TypeScript project compiles (`tsc --project tests/e2e/tsconfig.json --noEmit`)
- [ ] **Real proof requires CI:** the flake is non-deterministic. Watch the next 5-10 main runs after merge for a clean streak on the agent + terminal suites. If a flake recurs, the new echo-verify diagnostic will tell us exactly what was received — much easier to chase than an opaque `waitForDisplayed` timeout.

## Not in scope

- The per-char pause value (8 ms) is a guess. If CI still flakes after this lands and the new diagnostic shows echo-timeout rather than reorder, we'll know to raise the pause.
- The `terminal-io` spec retains its existing assertion-based verification; it didn't need echo-verify because it already checks bash output downstream. Only the shared helper changed.