### PR TITLE
[codex] feat(workspace): accept agent OSC 7 cwd updates

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -135,8 +135,54 @@ type InvokeEnvelope =
 let sidecar: Sidecar | null = null
 let quitting = false
 
+const RENDERER_DIAGNOSTIC_PREFIXES = [
+  '[vimeflow:terminal-cwd]',
+  '[vimeflow:git-branch]',
+]
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const rendererConsoleLevelName = (level: number): string => {
+  switch (level) {
+    case 0:
+      return 'verbose'
+    case 1:
+      return 'info'
+    case 2:
+      return 'warning'
+    case 3:
+      return 'error'
+    default:
+      return 'unknown'
+  }
+}
+
+const installRendererDiagnosticLogging = (win: BrowserWindow): void => {
+  if (app.isPackaged) {
+    return
+  }
+
+  win.webContents.on(
+    'console-message',
+    (_event, level, message, line, sourceId) => {
+      if (
+        !RENDERER_DIAGNOSTIC_PREFIXES.some((prefix) =>
+          message.startsWith(prefix)
+        )
+      ) {
+        return
+      }
+
+      const source = sourceId.length > 0 ? ` (${sourceId}:${String(line)})` : ''
+
+      // eslint-disable-next-line no-console
+      console.info(
+        `[renderer:${rendererConsoleLevelName(level)}] ${message}${source}`
+      )
+    }
+  )
+}
 
 const isBackendInvokePayload = (
   payload: unknown
@@ -167,6 +213,8 @@ const createWindow = (): void => {
       preload: path.join(__dirname, 'preload.mjs'),
     },
   })
+
+  installRendererDiagnosticLogging(win)
 
   const devUrl = process.env.VITE_DEV_SERVER_URL
 

--- a/src/features/diff/hooks/useGitBranch.ts
+++ b/src/features/diff/hooks/useGitBranch.ts
@@ -19,6 +19,18 @@ interface GitHeadChangedPayload {
   cwds: string[]
 }
 
+const logGitBranchDebug = (
+  event: string,
+  details: Record<string, boolean | string | null>
+): void => {
+  if (!import.meta.env.DEV || import.meta.env.MODE === 'test') {
+    return
+  }
+
+  // eslint-disable-next-line no-console
+  console.info(`[vimeflow:git-branch] ${event} ${JSON.stringify(details)}`)
+}
+
 const isValidCwd = (cwd: string): boolean => {
   if (cwd.length === 0) {
     return false
@@ -85,6 +97,8 @@ export const useGitBranch = (
 
     const fetchBranch = async (): Promise<void> => {
       try {
+        logGitBranchDebug('fetch-start', { cwd, isNewCwd })
+
         if (isNewCwd) {
           // Clear here so a cwd change blanks stale data BEFORE the new
           // fetch resolves. Same-cwd re-fetches (refresh, enabled-toggle)
@@ -100,10 +114,19 @@ export const useGitBranch = (
 
         if (!cancelled) {
           const trimmed = result.trim()
+          logGitBranchDebug('fetch-success', {
+            cwd,
+            branch: trimmed === '' ? null : trimmed,
+            empty: trimmed === '',
+          })
           setBranch(trimmed === '' ? null : trimmed)
         }
       } catch (err) {
         if (!cancelled) {
+          logGitBranchDebug('fetch-error', {
+            cwd,
+            error: err instanceof Error ? err.message : String(err),
+          })
           setBranch(null)
           setError(err instanceof Error ? err : new Error(String(err)))
         }
@@ -167,6 +190,11 @@ export const useGitBranch = (
         }
       } catch (err) {
         if (mounted) {
+          logGitBranchDebug('watcher-error', {
+            cwd,
+            error: err instanceof Error ? err.message : String(err),
+          })
+
           setError(
             err instanceof Error
               ? err

--- a/src/features/sessions/hooks/useSessionManager.test.ts
+++ b/src/features/sessions/hooks/useSessionManager.test.ts
@@ -1882,7 +1882,7 @@ describe('useSessionManager', () => {
     )
   })
 
-  test('updateSessionCwd updates local state and calls IPC', async () => {
+  test('updateSessionCwd updates session cwd without touching pane cwd', async () => {
     const service = createMockService()
     service.listSessions = vi.fn().mockResolvedValue({
       activeSessionId: 's1',
@@ -1908,10 +1908,8 @@ describe('useSessionManager', () => {
     act(() => result.current.updateSessionCwd('s1', '/home/user'))
 
     expect(result.current.sessions[0].workingDirectory).toBe('/home/user')
-    expect(result.current.sessions[0].panes[0].cwd).toBe('/home/user')
-    await waitFor(() =>
-      expect(service.updateSessionCwd).toHaveBeenCalledWith('s1', '/home/user')
-    )
+    expect(result.current.sessions[0].panes[0].cwd).toBe('/tmp')
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
   test('updateSessionAgentType persists detected agent identity in local session state', async () => {

--- a/src/features/sessions/hooks/useSessionManager.test.ts
+++ b/src/features/sessions/hooks/useSessionManager.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore worktrees
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { useSessionManager } from './useSessionManager'
@@ -1907,6 +1908,7 @@ describe('useSessionManager', () => {
     act(() => result.current.updateSessionCwd('s1', '/home/user'))
 
     expect(result.current.sessions[0].workingDirectory).toBe('/home/user')
+    expect(result.current.sessions[0].panes[0].cwd).toBe('/home/user')
     await waitFor(() =>
       expect(service.updateSessionCwd).toHaveBeenCalledWith('s1', '/home/user')
     )
@@ -2832,7 +2834,7 @@ describe('useSessionManager', () => {
     warnSpy.mockRestore()
   })
 
-  test('updatePaneCwd updates pane cwd and mirrors to Rust via pane ptyId', async () => {
+  test('updatePaneCwd updates pane cwd without changing session cwd', async () => {
     const service = createMockService()
     service.listSessions = vi.fn().mockResolvedValue({
       activeSessionId: 'pty-1',
@@ -2862,7 +2864,7 @@ describe('useSessionManager', () => {
 
     const updated = result.current.sessions[0]
     expect(updated.panes[0].cwd).toBe('/new/cwd')
-    expect(updated.workingDirectory).toBe('/new/cwd')
+    expect(updated.workingDirectory).toBe('/old')
     expect(service.updateSessionCwd).toHaveBeenCalledWith('pty-1', '/new/cwd')
   })
 
@@ -3072,7 +3074,7 @@ describe('useSessionManager', () => {
       })
     }
 
-    test('addPane spawns in the active pane cwd and appends an active pane', async () => {
+    test('addPane spawns in the session cwd and appends an active pane', async () => {
       const service = createSequentialSpawnService()
 
       const { result } = renderHook(() =>
@@ -3084,6 +3086,14 @@ describe('useSessionManager', () => {
 
       ;(service.setActiveSession as ReturnType<typeof vi.fn>).mockClear()
 
+      act(() => {
+        result.current.updatePaneCwd(
+          sessionId,
+          'p0',
+          '/workspace/.claude/worktrees/test-branch'
+        )
+      })
+
       await addSecondPane(result, sessionId)
 
       const session = result.current.sessions[0]
@@ -3093,7 +3103,12 @@ describe('useSessionManager', () => {
         enableAgentBridge: true,
       })
       expect(session.panes).toHaveLength(2)
-      expect(session.panes[0]).toMatchObject({ id: 'p0', active: false })
+      expect(session.panes[0]).toMatchObject({
+        id: 'p0',
+        cwd: '/workspace/.claude/worktrees/test-branch',
+        active: false,
+      })
+
       expect(session.panes[1]).toMatchObject({
         id: 'p1',
         ptyId: 'pty-1',

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -67,6 +67,9 @@ export interface SessionManager {
    *
    * This intentionally does not call `service.updateSessionCwd`; callers that
    * need to sync a live PTY cwd to the backend must use `updatePaneCwd`.
+   *
+   * @deprecated Use `updatePaneCwd` for live pane cwd changes that must sync to
+   * the backend. This wrapper only updates the stable session baseline cwd.
    */
   updateSessionCwd: (id: string, cwd: string) => void
   /** Compatibility wrapper until workspace consumers migrate to pane ids. */

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -1212,6 +1212,13 @@ export const useSessionManager = (
       return
     }
 
+    if (import.meta.env.DEV && import.meta.env.MODE !== 'test') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'updateSessionCwd is deprecated; use updatePaneCwd for live PTY cwd sync'
+      )
+    }
+
     // State-only baseline update. `updatePaneCwd` is the live PTY cwd path and
     // is responsible for calling `service.updateSessionCwd`.
     setSessions((prev) =>

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -693,7 +693,7 @@ export const useSessionManager = (
       void (async (): Promise<void> => {
         try {
           const result = await service.spawn({
-            cwd: activePane.cwd,
+            cwd: session.workingDirectory,
             env: {},
             enableAgentBridge: true,
           })
@@ -1135,12 +1135,10 @@ export const useSessionManager = (
           const panes = session.panes.map((pane) =>
             pane.id === paneId ? { ...pane, cwd } : pane
           )
-          const activePane = panes.find((pane) => pane.active)
 
           return {
             ...session,
             panes,
-            workingDirectory: activePane?.cwd ?? session.workingDirectory,
           }
         })
       )
@@ -1200,6 +1198,12 @@ export const useSessionManager = (
       if (!target) {
         return
       }
+
+      setSessions((prev) =>
+        prev.map((session) =>
+          session.id === id ? { ...session, workingDirectory: cwd } : session
+        )
+      )
 
       updatePaneCwd(id, getActivePane(target).id, cwd)
     },

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -62,7 +62,12 @@ export interface SessionManager {
     paneId: string,
     agentType: Session['agentType']
   ) => void
-  /** Update the stable session baseline cwd; terminal output uses pane cwd. */
+  /**
+   * Update the stable session baseline cwd in React state only.
+   *
+   * This intentionally does not call `service.updateSessionCwd`; callers that
+   * need to sync a live PTY cwd to the backend must use `updatePaneCwd`.
+   */
   updateSessionCwd: (id: string, cwd: string) => void
   /** Compatibility wrapper until workspace consumers migrate to pane ids. */
   updateSessionAgentType: (id: string, agentType: Session['agentType']) => void
@@ -693,8 +698,13 @@ export const useSessionManager = (
 
       void (async (): Promise<void> => {
         try {
+          // New panes start from the stable session baseline. The active pane
+          // cwd is live per-pane state and may point at an agent task path; do
+          // not leak that pane-local agent context into fresh shells.
+          const spawnCwd = session.workingDirectory
+
           const result = await service.spawn({
-            cwd: session.workingDirectory,
+            cwd: spawnCwd,
             env: {},
             enableAgentBridge: true,
           })
@@ -1199,6 +1209,8 @@ export const useSessionManager = (
       return
     }
 
+    // State-only baseline update. `updatePaneCwd` is the live PTY cwd path and
+    // is responsible for calling `service.updateSessionCwd`.
     setSessions((prev) =>
       prev.map((session) =>
         session.id === id ? { ...session, workingDirectory: cwd } : session

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -55,13 +55,14 @@ export interface SessionManager {
   restartSession: (id: string) => void
   renameSession: (id: string, name: string) => void
   reorderSessions: (reordered: Session[]) => void
+  /** Update a pane's live cwd and the backend PTY cwd cache. */
   updatePaneCwd: (sessionId: string, paneId: string, cwd: string) => void
   updatePaneAgentType: (
     sessionId: string,
     paneId: string,
     agentType: Session['agentType']
   ) => void
-  /** Compatibility wrapper until workspace consumers migrate to pane ids. */
+  /** Update the stable session baseline cwd; terminal output uses pane cwd. */
   updateSessionCwd: (id: string, cwd: string) => void
   /** Compatibility wrapper until workspace consumers migrate to pane ids. */
   updateSessionAgentType: (id: string, agentType: Session['agentType']) => void
@@ -1192,23 +1193,18 @@ export const useSessionManager = (
     []
   )
 
-  const updateSessionCwd = useCallback(
-    (id: string, cwd: string): void => {
-      const target = sessionsRef.current.find((s) => s.id === id)
-      if (!target) {
-        return
-      }
+  const updateSessionCwd = useCallback((id: string, cwd: string): void => {
+    const target = sessionsRef.current.find((s) => s.id === id)
+    if (!target) {
+      return
+    }
 
-      setSessions((prev) =>
-        prev.map((session) =>
-          session.id === id ? { ...session, workingDirectory: cwd } : session
-        )
+    setSessions((prev) =>
+      prev.map((session) =>
+        session.id === id ? { ...session, workingDirectory: cwd } : session
       )
-
-      updatePaneCwd(id, getActivePane(target).id, cwd)
-    },
-    [updatePaneCwd]
-  )
+    )
+  }, [])
 
   const updateSessionAgentType = useCallback(
     (id: string, agentType: Session['agentType']): void => {

--- a/src/features/sessions/types/index.ts
+++ b/src/features/sessions/types/index.ts
@@ -38,7 +38,7 @@ export interface Session {
   projectId: string
   name: string // user-assigned or derived from prompt
   status: SessionStatus
-  /** Derived from `getActivePane(session).cwd`; retained for existing chrome. */
+  /** Stable session/project cwd used as the baseline for new panes. */
   workingDirectory: string
   /** Derived from `getActivePane(session).agentType`; retained for existing chrome. */
   agentType: 'claude-code' | 'codex' | 'aider' | 'generic'

--- a/src/features/sessions/utils/activeSessionPane.test.ts
+++ b/src/features/sessions/utils/activeSessionPane.test.ts
@@ -104,7 +104,7 @@ const makeSession = (
 })
 
 describe('applyActivePane', () => {
-  test('flips active flag and re-derives workingDirectory and agentType', () => {
+  test('flips active flag and preserves session workingDirectory', () => {
     const sessions: Session[] = [
       makeSession('s1', [
         makePane('p0', {
@@ -122,7 +122,7 @@ describe('applyActivePane', () => {
     expect(updated.panes.filter((pane) => pane.active)).toHaveLength(1)
     expect(updated.panes.find((pane) => pane.id === 'p1')?.active).toBe(true)
     expect(updated.panes.find((pane) => pane.id === 'p0')?.active).toBe(false)
-    expect(updated.workingDirectory).toBe('/tmp/p1')
+    expect(updated.workingDirectory).toBe('/tmp/p0')
     expect(updated.agentType).toBe('codex')
   })
 

--- a/src/features/sessions/utils/activeSessionPane.ts
+++ b/src/features/sessions/utils/activeSessionPane.ts
@@ -36,8 +36,8 @@ export const getActivePane = (session: Session): Pane => {
   return actives[0]
 }
 
-/** Flip the active pane inside one session and re-derive materialized
- * session fields from the new active pane.
+/** Flip the active pane inside one session and re-derive active-pane
+ * materialized fields from the new active pane.
  *
  * Pure helper — no side effects. No-op branches (missing session,
  * missing pane, already-active target) return the same `sessions`
@@ -82,7 +82,6 @@ export const applyActivePane = (
   const updatedSession: Session = {
     ...session,
     panes,
-    workingDirectory: target.cwd,
     agentType: target.agentType,
   }
 

--- a/src/features/sessions/utils/paneLifecycle.test.ts
+++ b/src/features/sessions/utils/paneLifecycle.test.ts
@@ -148,7 +148,7 @@ describe('applyAddPane', () => {
     })
   })
 
-  test('re-derives workingDirectory and agentType from new active pane', () => {
+  test('preserves workingDirectory and re-derives agentType from new active pane', () => {
     const result = applyAddPane(
       [mockSession()],
       's0',
@@ -156,7 +156,7 @@ describe('applyAddPane', () => {
       2
     )
 
-    expect(result.sessions[0].workingDirectory).toBe('/tmp/scratch')
+    expect(result.sessions[0].workingDirectory).toBe('/home/test')
     expect(result.sessions[0].agentType).toBe('codex')
   })
 
@@ -257,7 +257,7 @@ describe('applyRemovePane', () => {
       active: true,
     })
     expect(result.newActivePtyId).toBe('pty-0')
-    expect(result.sessions[0].workingDirectory).toBe('/dir-0')
+    expect(result.sessions[0].workingDirectory).toBe('/home/test')
     expect(result.sessions[0].agentType).toBe('claude-code')
   })
 

--- a/src/features/sessions/utils/paneLifecycle.ts
+++ b/src/features/sessions/utils/paneLifecycle.ts
@@ -88,7 +88,6 @@ export const applyAddPane = (
     ...session,
     panes,
     status: deriveSessionStatus(panes),
-    workingDirectory: newPane.cwd,
     agentType: newPane.agentType,
   }
 
@@ -144,7 +143,6 @@ export const applyRemovePane = (
     panes,
     layout: autoShrinkLayoutFor(panes.length, currentLayoutId),
     status: deriveSessionStatus(panes),
-    workingDirectory: activePane?.cwd ?? session.workingDirectory,
     agentType: activePane?.agentType ?? session.agentType,
   }
 

--- a/src/features/sessions/utils/subtitle.test.ts
+++ b/src/features/sessions/utils/subtitle.test.ts
@@ -2,13 +2,26 @@ import { describe, test, expect } from 'vitest'
 import { subtitle } from './subtitle'
 import type { Session } from '../types'
 
+// cspell:ignore worktrees
+
 const sessionWith = (
   workingDirectory: string,
-  currentAction?: string
+  currentAction?: string,
+  activePaneCwd = workingDirectory
 ): Session =>
   ({
     workingDirectory,
     currentAction,
+    panes: [
+      {
+        id: 'p0',
+        ptyId: 'pty-0',
+        cwd: activePaneCwd,
+        agentType: 'generic',
+        status: 'running',
+        active: true,
+      },
+    ],
   }) as unknown as Session
 
 describe('subtitle', () => {
@@ -24,6 +37,14 @@ describe('subtitle', () => {
 
   test('POSIX shallow path returns parent/basename', () => {
     expect(subtitle(sessionWith('/home/will'))).toBe('home/will')
+  })
+
+  test('uses active pane cwd instead of the session baseline cwd', () => {
+    expect(
+      subtitle(
+        sessionWith('/repo', undefined, '/repo/.claude/worktrees/agent-feature')
+      )
+    ).toBe('worktrees/agent-feature')
   })
 
   test('empty workingDirectory falls back to "~" (race-window safety)', () => {

--- a/src/features/sessions/utils/subtitle.ts
+++ b/src/features/sessions/utils/subtitle.ts
@@ -6,6 +6,8 @@ export const subtitle = (session: Session): string => {
     return session.currentAction
   }
 
+  // Legacy persisted/test sessions can predate pane arrays; keep their
+  // baseline working directory usable until storage migration is complete.
   const activePaneCwd = Array.isArray(session.panes)
     ? findActivePane(session)?.cwd
     : undefined

--- a/src/features/sessions/utils/subtitle.ts
+++ b/src/features/sessions/utils/subtitle.ts
@@ -1,17 +1,24 @@
 import type { Session } from '../types'
+import { findActivePane } from './activeSessionPane'
 
 export const subtitle = (session: Session): string => {
   if (session.currentAction !== undefined && session.currentAction !== '') {
     return session.currentAction
   }
+
+  const activePaneCwd = Array.isArray(session.panes)
+    ? findActivePane(session)?.cwd
+    : undefined
+  const cwd = activePaneCwd ?? session.workingDirectory
+
   // Normalize Windows `\` to `/` first — Tauri can hand back native
   // separators (e.g. `C:\Users\alice\repo`); a `/`-only split would
   // collapse to one segment and render the full path instead of the
   // basename.
-  const normalized = session.workingDirectory.replace(/\\/g, '/')
+  const normalized = cwd.replace(/\\/g, '/')
   const parts = normalized.split('/').filter(Boolean)
   if (parts.length === 0) {
-    return session.workingDirectory || '~'
+    return cwd || '~'
   }
   if (parts.length === 1) {
     return parts[0]

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -1,6 +1,7 @@
 // cspell:ignore worktree worktrees
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { act, render, waitFor } from '@testing-library/react'
+import { type ReactElement, useState } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
@@ -132,6 +133,32 @@ const restoreData = (sessionId: string, cwd: string): RestoreData => ({
   replayEndOffset: 0,
   bufferedEvents: [],
 })
+
+const StatefulBody = ({
+  initialCwd,
+  service,
+  onCwdChange,
+}: {
+  initialCwd: string
+  service: ITerminalService
+  onCwdChange: (cwd: string) => void
+}): ReactElement => {
+  const [cwd, setCwd] = useState(initialCwd)
+
+  return (
+    <Body
+      sessionId="pty-agent"
+      cwd={cwd}
+      service={service}
+      restoredFrom={restoreData('pty-agent', initialCwd)}
+      mode="attach"
+      onCwdChange={(nextCwd): void => {
+        setCwd(nextCwd)
+        onCwdChange(nextCwd)
+      }}
+    />
+  )
+}
 
 describe('Body agent-emitted OSC 7', () => {
   beforeEach(() => {
@@ -339,6 +366,71 @@ describe('Body agent-emitted OSC 7', () => {
     })
 
     expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree')
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('ignores OSC 7 updates for the current cwd', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/tmp/worktree"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/tmp/worktree')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData('pty-agent', '\x1b]7;file://host/tmp/worktree\x07')
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('preserves a split agent cd hint across an OSC cwd prop update', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <StatefulBody
+        initialCwd="/old"
+        service={service}
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/tmp/worktree\x07! cd child'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree')
+    })
+
+    act(() => {
+      service.emitData('pty-agent', '\r\n')
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree/child')
+    })
+
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -634,6 +634,139 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
+  test('does not roll back an agent-advanced cwd when shell OSC 7 reports a sibling worktree', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/repo/.claude/worktrees/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/repo/.claude/worktrees/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        'Entering worktree(/repo/.claude/worktrees/feat)\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/.claude/worktrees/feat')
+    })
+
+    onCwdChange.mockClear()
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/repo/.claude/worktrees/old\x07'
+      )
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('treats a no-op text hint as agent-owned before stale shell OSC 7 arrives', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/repo/.claude/worktrees/feat"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/repo/.claude/worktrees/feat')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        'Entering worktree(/repo/.claude/worktrees/feat)\r\n'
+      )
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/repo/.claude/worktrees/old\x07'
+      )
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('accepts sibling worktree OSC 7 after the shell confirms the current cwd', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/repo/.claude/worktrees/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/repo/.claude/worktrees/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        'Entering worktree(/repo/.claude/worktrees/feat)\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/.claude/worktrees/feat')
+    })
+
+    onCwdChange.mockClear()
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/repo/.claude/worktrees/feat\x07'
+      )
+
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/repo/.claude/worktrees/old\x07'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/.claude/worktrees/old')
+    })
+
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
   test('ignores OSC 7 updates for the current cwd', async () => {
     const service = createService()
     const onCwdChange = vi.fn()

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -80,6 +80,7 @@ class FakeTerminal {
 
 const createService = (): ControlledTerminalService => {
   const dataCallbacks = new Set<DataCallback>()
+  const nextOffsets = new Map<string, number>()
 
   return {
     spawn: vi.fn().mockResolvedValue({
@@ -110,11 +111,13 @@ const createService = (): ControlledTerminalService => {
     setActiveSession: vi.fn().mockResolvedValue(undefined),
     reorderSessions: vi.fn().mockResolvedValue(undefined),
     updateSessionCwd: vi.fn().mockResolvedValue(undefined),
-    emitData(sessionId: string, data: string, offsetStart = 0): void {
+    emitData(sessionId: string, data: string, offsetStart?: number): void {
+      const offset = offsetStart ?? nextOffsets.get(sessionId) ?? 0
       const byteLen = new TextEncoder().encode(data).length
+      nextOffsets.set(sessionId, offset + byteLen)
 
       dataCallbacks.forEach((callback) => {
-        callback(sessionId, data, offsetStart, byteLen)
+        callback(sessionId, data, offset, byteLen)
       })
     },
   }
@@ -244,19 +247,61 @@ describe('Body agent-emitted OSC 7', () => {
       expect(service.onData).toHaveBeenCalled()
     })
 
-    const firstChunk = '● Entering worktree(/tmp/'
-
     act(() => {
-      service.emitData('pty-agent', firstChunk)
-      service.emitData(
-        'pty-agent',
-        'dummy)\r\n',
-        new TextEncoder().encode(firstChunk).length
-      )
+      service.emitData('pty-agent', '● Entering worktree(/tmp/')
+      service.emitData('pty-agent', 'dummy)\r\n')
     })
 
     await waitFor(() => {
       expect(onCwdChange).toHaveBeenCalledWith('/tmp/dummy')
+    })
+
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('tracks Claude Bash cd commands across worktree-relative paths', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/home/will/projects/vimeflow"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/home/will/projects/vimeflow')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '! cd .claude/worktrees/\r\n' + '(Bash completed with no output)\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith(
+        '/home/will/projects/vimeflow/.claude/worktrees'
+      )
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '! cd codex-agent-osc7-cwd\r\n' + '(Bash completed with no output)\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith(
+        '/home/will/projects/vimeflow/.claude/worktrees/codex-agent-osc7-cwd'
+      )
     })
 
     expect(service.updateSessionCwd).not.toHaveBeenCalled()

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -59,10 +59,12 @@ class FakeTerminal {
   }))
   readonly onData = vi.fn(
     (handler: (data: string) => void): { dispose: () => void } => {
-      void handler
+      this.inputHandlers.add(handler)
 
       return {
-        dispose: vi.fn(),
+        dispose: vi.fn(() => {
+          this.inputHandlers.delete(handler)
+        }),
       }
     }
   )
@@ -77,6 +79,7 @@ class FakeTerminal {
   }
 
   private readonly oscHandlers = new Map<number, OscHandler>()
+  private readonly inputHandlers = new Set<(data: string) => void>()
 
   readonly write = vi.fn((data: string, callback?: () => void): void => {
     this.parseOsc(data)
@@ -88,6 +91,12 @@ class FakeTerminal {
 
     callback?.()
   })
+
+  emitInput(data: string): void {
+    this.inputHandlers.forEach((handler) => {
+      handler(data)
+    })
+  }
 
   private parseOsc(data: string): void {
     const oscPattern = /\x1b\](\d+);([\s\S]*?)(?:\x07|\x1b\\)/g
@@ -162,6 +171,17 @@ const restoreData = (sessionId: string, cwd: string): RestoreData => ({
   replayEndOffset: 0,
   bufferedEvents: [],
 })
+
+const getLatestTerminal = (): FakeTerminal => {
+  const results = vi.mocked(Terminal).mock.results
+  const terminal = results[results.length - 1]?.value
+
+  if (!terminal) {
+    throw new Error('Expected terminal to be created')
+  }
+
+  return terminal as FakeTerminal
+}
 
 const StatefulBody = ({
   initialCwd,
@@ -674,6 +694,54 @@ describe('Body agent-emitted OSC 7', () => {
     })
 
     expect(onCwdChange).not.toHaveBeenCalled()
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('accepts sibling worktree OSC 7 after user shell input', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/repo/.claude/worktrees/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/repo/.claude/worktrees/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+      expect(getLatestTerminal().onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        'Entering worktree(/repo/.claude/worktrees/feat)\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/.claude/worktrees/feat')
+    })
+
+    onCwdChange.mockClear()
+
+    act(() => {
+      getLatestTerminal().emitInput('cd /repo/.claude/worktrees/old\r')
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/repo/.claude/worktrees/old\x07'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/.claude/worktrees/old')
+    })
+
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -1,4 +1,4 @@
-// cspell:ignore worktree
+// cspell:ignore worktree worktrees
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { act, render, waitFor } from '@testing-library/react'
 import { Terminal } from '@xterm/xterm'
@@ -184,6 +184,79 @@ describe('Body agent-emitted OSC 7', () => {
 
     await waitFor(() => {
       expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree')
+    })
+
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('updates cwd when Claude EnterWorktree output arrives through PTY output', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '● Entering worktree(/home/will/projects/vimeflow/.claude/worktrees/dummy)\r\n' +
+          '  ⎿  Switched to worktree on branch dummy\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith(
+        '/home/will/projects/vimeflow/.claude/worktrees/dummy'
+      )
+    })
+
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('reassembles split Claude EnterWorktree output before updating cwd', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    const firstChunk = '● Entering worktree(/tmp/'
+
+    act(() => {
+      service.emitData('pty-agent', firstChunk)
+      service.emitData(
+        'pty-agent',
+        'dummy)\r\n',
+        new TextEncoder().encode(firstChunk).length
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/dummy')
     })
 
     expect(service.updateSessionCwd).not.toHaveBeenCalled()

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -1030,7 +1030,7 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
-  test('resets pending restored OSC 7 suppressions when session id changes', async () => {
+  test('clears restore OSC 7 suppression after restore writes finish without parser events', async () => {
     skipOscParsing = true
 
     const service = createService()
@@ -1038,7 +1038,7 @@ describe('Body agent-emitted OSC 7', () => {
     const replayData = '\x1b]7;file://host/repo/restored\x07'
     const replayEndOffset = new TextEncoder().encode(replayData).length
 
-    const { rerender } = render(
+    render(
       <Body
         sessionId="pty-old"
         cwd="/repo/old"
@@ -1058,31 +1058,13 @@ describe('Body agent-emitted OSC 7', () => {
     })
 
     skipOscParsing = false
-    const terminalCreateCount = vi.mocked(Terminal).mock.calls.length
-
-    rerender(
-      <Body
-        sessionId="pty-new"
-        cwd="/repo/new"
-        service={service}
-        restoredFrom={restoreData('pty-new', '/repo/new')}
-        mode="attach"
-        onCwdChange={onCwdChange}
-      />
-    )
-
-    await waitFor(() => {
-      expect(vi.mocked(Terminal).mock.calls.length).toBeGreaterThan(
-        terminalCreateCount
-      )
-    })
 
     act(() => {
-      getLatestTerminal().write('\x1b]7;file://host/repo/new/live\x07')
+      getLatestTerminal().write('\x1b]7;file://host/repo/live\x07')
     })
 
     await waitFor(() => {
-      expect(onCwdChange).toHaveBeenCalledWith('/repo/new/live')
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/live')
     })
 
     expect(service.updateSessionCwd).not.toHaveBeenCalled()

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -381,6 +381,59 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
+  test('does not roll back an agent-advanced cwd when the parent commits an earlier cwd', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    const { rerender } = render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/tmp/worktree\x07! cd child\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree/child')
+    })
+
+    rerender(
+      <Body
+        sessionId="pty-agent"
+        cwd="/tmp/worktree"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    act(() => {
+      service.emitData('pty-agent', '! cd grandchild\r\n')
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree/child/grandchild')
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalledWith('/tmp/worktree/grandchild')
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
   test('ignores OSC 7 updates for the current cwd', async () => {
     const service = createService()
     const onCwdChange = vi.fn()

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -64,8 +64,9 @@ class FakeTerminal {
 
   private readonly oscHandlers = new Map<number, OscHandler>()
 
-  readonly write = vi.fn((data: string): void => {
+  readonly write = vi.fn((data: string, callback?: () => void): void => {
     this.parseOsc(data)
+    callback?.()
   })
 
   private parseOsc(data: string): void {

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -80,6 +80,7 @@ class FakeTerminal {
 
   private readonly oscHandlers = new Map<number, OscHandler>()
   private readonly inputHandlers = new Set<(data: string) => void>()
+  private oscBuffer = ''
 
   readonly write = vi.fn((data: string, callback?: () => void): void => {
     this.parseOsc(data)
@@ -99,12 +100,20 @@ class FakeTerminal {
   }
 
   private parseOsc(data: string): void {
+    this.oscBuffer += data
     const oscPattern = /\x1b\](\d+);([\s\S]*?)(?:\x07|\x1b\\)/g
+    let lastMatchEnd = 0
 
-    for (const match of data.matchAll(oscPattern)) {
+    for (const match of this.oscBuffer.matchAll(oscPattern)) {
       const handler = this.oscHandlers.get(Number(match[1]))
       handler?.(match[2] ?? '')
+      lastMatchEnd = (match.index ?? 0) + match[0].length
     }
+
+    const remaining = this.oscBuffer.slice(lastMatchEnd)
+    const partialOscStart = remaining.lastIndexOf('\x1b]')
+    this.oscBuffer =
+      partialOscStart === -1 ? '' : remaining.slice(partialOscStart)
   }
 }
 
@@ -170,6 +179,15 @@ const restoreData = (sessionId: string, cwd: string): RestoreData => ({
   replayData: '',
   replayEndOffset: 0,
   bufferedEvents: [],
+})
+
+const bufferedEvent = (
+  data: string,
+  offsetStart = 0
+): RestoreData['bufferedEvents'][number] => ({
+  data,
+  offsetStart,
+  byteLen: new TextEncoder().encode(data).length,
 })
 
 const getLatestTerminal = (): FakeTerminal => {
@@ -697,6 +715,52 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
+  test('accepts sibling OSC 7 outside the Claude worktree directory', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/app"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/app')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        'Entering worktree(/app/worktrees/service-a)\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/app/worktrees/service-a')
+    })
+
+    onCwdChange.mockClear()
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/app/worktrees/service-b\x07'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/app/worktrees/service-b')
+    })
+
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
   test('accepts sibling worktree OSC 7 after user shell input', async () => {
     const service = createService()
     const onCwdChange = vi.fn()
@@ -862,6 +926,100 @@ describe('Body agent-emitted OSC 7', () => {
     })
 
     expect(onCwdChange).not.toHaveBeenCalled()
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('ignores OSC 7 updates replayed from restored terminal history', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    const replayData =
+      '\x1b]7;file://host/repo/old\x07' +
+      'historical output\r\n' +
+      '\x1b]7;file://host/repo/intermediate\x07'
+    const replayEndOffset = new TextEncoder().encode(replayData).length
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/repo/current"
+        service={service}
+        restoredFrom={{
+          ...restoreData('pty-agent', '/repo/current'),
+          replayData,
+          replayEndOffset,
+        }}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/repo/live\x07',
+        replayEndOffset
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/live')
+    })
+
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('ignores OSC 7 updates split across restored buffered events', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    const replayData = '\x1b]7;file://host/repo/buffered'
+    const bufferedData = '\x07'
+    const replayEndOffset = new TextEncoder().encode(replayData).length
+
+    const bufferedEndOffset =
+      replayEndOffset + new TextEncoder().encode(bufferedData).length
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/repo/current"
+        service={service}
+        restoredFrom={{
+          ...restoreData('pty-agent', '/repo/current'),
+          replayData,
+          replayEndOffset,
+          bufferedEvents: [bufferedEvent(bufferedData, replayEndOffset)],
+        }}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/repo/live\x07',
+        bufferedEndOffset
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/live')
+    })
+
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -1,0 +1,232 @@
+// cspell:ignore worktree
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, render, waitFor } from '@testing-library/react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { WebglAddon } from '@xterm/addon-webgl'
+import { CanvasAddon } from '@xterm/addon-canvas'
+import { Body, clearTerminalCache } from './Body'
+import type { RestoreData } from '../../hooks/useTerminal'
+import type { ITerminalService } from '../../services/terminalService'
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(),
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(),
+}))
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: vi.fn(),
+}))
+
+vi.mock('@xterm/addon-canvas', () => ({
+  CanvasAddon: vi.fn(),
+}))
+
+type DataCallback = Parameters<ITerminalService['onData']>[0]
+type OscHandler = (data: string) => boolean
+
+interface ControlledTerminalService extends ITerminalService {
+  emitData(sessionId: string, data: string, offsetStart?: number): void
+}
+
+class FakeTerminal {
+  readonly cols = 80
+  readonly rows = 24
+  readonly open = vi.fn()
+  readonly loadAddon = vi.fn()
+  readonly dispose = vi.fn()
+  readonly focus = vi.fn()
+  readonly clear = vi.fn()
+  readonly onResize = vi.fn((): { dispose: () => void } => ({
+    dispose: vi.fn(),
+  }))
+  readonly onData = vi.fn(
+    (handler: (data: string) => void): { dispose: () => void } => {
+      void handler
+
+      return {
+        dispose: vi.fn(),
+      }
+    }
+  )
+  readonly parser = {
+    registerOscHandler: vi.fn(
+      (identifier: number, handler: OscHandler): { dispose: () => void } => {
+        this.oscHandlers.set(identifier, handler)
+
+        return { dispose: vi.fn() }
+      }
+    ),
+  }
+
+  private readonly oscHandlers = new Map<number, OscHandler>()
+
+  readonly write = vi.fn((data: string): void => {
+    this.parseOsc(data)
+  })
+
+  private parseOsc(data: string): void {
+    const oscPattern = /\x1b\](\d+);([\s\S]*?)(?:\x07|\x1b\\)/g
+
+    for (const match of data.matchAll(oscPattern)) {
+      const handler = this.oscHandlers.get(Number(match[1]))
+      handler?.(match[2] ?? '')
+    }
+  }
+}
+
+const createService = (): ControlledTerminalService => {
+  const dataCallbacks = new Set<DataCallback>()
+
+  return {
+    spawn: vi.fn().mockResolvedValue({
+      sessionId: 'spawned-pty',
+      pid: 999,
+      cwd: '/old',
+    }),
+    write: vi.fn().mockResolvedValue(undefined),
+    resize: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn((callback: DataCallback): Promise<() => void> => {
+      dataCallbacks.add(callback)
+
+      return Promise.resolve((): void => {
+        dataCallbacks.delete(callback)
+      })
+    }),
+    onExit: vi.fn(
+      (): Promise<() => void> => Promise.resolve((): void => undefined)
+    ),
+    onError: vi.fn(
+      (): Promise<() => void> => Promise.resolve((): void => undefined)
+    ),
+    listSessions: vi.fn().mockResolvedValue({
+      activeSessionId: null,
+      sessions: [],
+    }),
+    setActiveSession: vi.fn().mockResolvedValue(undefined),
+    reorderSessions: vi.fn().mockResolvedValue(undefined),
+    updateSessionCwd: vi.fn().mockResolvedValue(undefined),
+    emitData(sessionId: string, data: string, offsetStart = 0): void {
+      const byteLen = new TextEncoder().encode(data).length
+
+      dataCallbacks.forEach((callback) => {
+        callback(sessionId, data, offsetStart, byteLen)
+      })
+    },
+  }
+}
+
+const restoreData = (sessionId: string, cwd: string): RestoreData => ({
+  sessionId,
+  cwd,
+  pid: 123,
+  replayData: '',
+  replayEndOffset: 0,
+  bufferedEvents: [],
+})
+
+describe('Body agent-emitted OSC 7', () => {
+  beforeEach(() => {
+    vi.mocked(Terminal).mockImplementation(() => new FakeTerminal() as never)
+    vi.mocked(FitAddon).mockImplementation(
+      () =>
+        ({
+          fit: vi.fn(),
+        }) as never
+    )
+
+    vi.mocked(WebglAddon).mockImplementation(() => {
+      throw new Error('WebGL unavailable in this test')
+    })
+
+    vi.mocked(CanvasAddon).mockImplementation(
+      () =>
+        ({
+          dispose: vi.fn(),
+        }) as never
+    )
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    clearTerminalCache()
+  })
+
+  test('updates cwd when OSC 7 arrives through PTY output', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        'agent switched worktree\r\n\x1b]7;file://host/tmp/worktree\x07'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree')
+    })
+
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('keeps agent OSC 7 updates isolated to the receiving pane', async () => {
+    const service = createService()
+    const onFirstCwdChange = vi.fn()
+    const onSecondCwdChange = vi.fn()
+
+    render(
+      <>
+        <Body
+          sessionId="pty-a"
+          cwd="/old/a"
+          service={service}
+          restoredFrom={restoreData('pty-a', '/old/a')}
+          mode="attach"
+          onCwdChange={onFirstCwdChange}
+        />
+        <Body
+          sessionId="pty-b"
+          cwd="/old/b"
+          service={service}
+          restoredFrom={restoreData('pty-b', '/old/b')}
+          mode="attach"
+          onCwdChange={onSecondCwdChange}
+        />
+      </>
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalledTimes(2)
+    })
+
+    act(() => {
+      service.emitData('pty-b', '\x1b]7;file://host/tmp/second-worktree\x07')
+    })
+
+    await waitFor(() => {
+      expect(onSecondCwdChange).toHaveBeenCalledWith('/tmp/second-worktree')
+    })
+
+    expect(onFirstCwdChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -745,7 +745,7 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
-  test('treats a no-op text hint as agent-owned before stale shell OSC 7 arrives', async () => {
+  test('does not treat a no-op text hint as agent-owned before shell OSC 7 arrives', async () => {
     const service = createService()
     const onCwdChange = vi.fn()
 
@@ -780,7 +780,10 @@ describe('Body agent-emitted OSC 7', () => {
       )
     })
 
-    expect(onCwdChange).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/.claude/worktrees/old')
+    })
+
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -320,6 +320,36 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
+  test('ignores cwd hints overwritten by carriage-return progress output', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        'Entering worktree(/tmp/fake)\rprogress 50%\n'
+      )
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
   test('tracks Claude Bash cd commands across worktree-relative paths', async () => {
     const service = createService()
     const onCwdChange = vi.fn()

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -424,6 +424,59 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
+  test('preserves Claude startup context across PTY chunk boundaries', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/home/will"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/home/will')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData('pty-agent', 'Claude Code v2.1.145\r\n')
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        'Opus 4.7 with max effort\r\n' + '~/projects/vimeflow\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/home/will/projects/vimeflow')
+    })
+
+    act(() => {
+      service.emitData('pty-agent', '! cd .claude/worktrees/\r\n')
+      service.emitData('pty-agent', '! cd codex-agent-osc7-cwd\r\n')
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith(
+        '/home/will/projects/vimeflow/.claude/worktrees/codex-agent-osc7-cwd'
+      )
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalledWith(
+      '/home/will/projects/vimeflow/.claude/worktrees/.claude/worktrees/codex-agent-osc7-cwd'
+    )
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
   test('resolves agent cd hints against a preceding OSC 7 cwd update', async () => {
     const service = createService()
     const onCwdChange = vi.fn()

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -27,10 +27,12 @@ vi.mock('@xterm/addon-canvas', () => ({
 }))
 
 type DataCallback = Parameters<ITerminalService['onData']>[0]
+type ExitCallback = Parameters<ITerminalService['onExit']>[0]
 type OscHandler = (data: string) => boolean
 
 interface ControlledTerminalService extends ITerminalService {
   emitData(sessionId: string, data: string, offsetStart?: number): void
+  emitExit(sessionId: string, code?: number | null): void
 }
 
 class FakeTerminal {
@@ -82,6 +84,7 @@ class FakeTerminal {
 
 const createService = (): ControlledTerminalService => {
   const dataCallbacks = new Set<DataCallback>()
+  const exitCallbacks = new Set<ExitCallback>()
   const nextOffsets = new Map<string, number>()
 
   return {
@@ -100,9 +103,13 @@ const createService = (): ControlledTerminalService => {
         dataCallbacks.delete(callback)
       })
     }),
-    onExit: vi.fn(
-      (): Promise<() => void> => Promise.resolve((): void => undefined)
-    ),
+    onExit: vi.fn((callback: ExitCallback): Promise<() => void> => {
+      exitCallbacks.add(callback)
+
+      return Promise.resolve((): void => {
+        exitCallbacks.delete(callback)
+      })
+    }),
     onError: vi.fn(
       (): Promise<() => void> => Promise.resolve((): void => undefined)
     ),
@@ -120,6 +127,11 @@ const createService = (): ControlledTerminalService => {
 
       dataCallbacks.forEach((callback) => {
         callback(sessionId, data, offset, byteLen)
+      })
+    },
+    emitExit(sessionId: string, code: number | null = 0): void {
+      exitCallbacks.forEach((callback) => {
+        callback(sessionId, code)
       })
     },
   }
@@ -425,6 +437,43 @@ describe('Body agent-emitted OSC 7', () => {
 
     act(() => {
       service.emitData('pty-agent', '\r\n')
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree/child')
+    })
+
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('flushes a buffered cwd hint when the PTY exits without a newline', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/tmp/worktree"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/tmp/worktree')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+      expect(service.onExit).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData('pty-agent', '! cd child')
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+
+    act(() => {
+      service.emitExit('pty-agent')
     })
 
     await waitFor(() => {

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -30,9 +30,20 @@ type DataCallback = Parameters<ITerminalService['onData']>[0]
 type ExitCallback = Parameters<ITerminalService['onExit']>[0]
 type OscHandler = (data: string) => boolean
 
+let deferWriteCallbacks = false
+const pendingWriteCallbacks: (() => void)[] = []
+
 interface ControlledTerminalService extends ITerminalService {
   emitData(sessionId: string, data: string, offsetStart?: number): void
   emitExit(sessionId: string, code?: number | null): void
+}
+
+const flushPendingWriteCallbacks = (): void => {
+  const callbacks = pendingWriteCallbacks.splice(0)
+
+  callbacks.forEach((callback) => {
+    callback()
+  })
 }
 
 class FakeTerminal {
@@ -69,6 +80,12 @@ class FakeTerminal {
 
   readonly write = vi.fn((data: string, callback?: () => void): void => {
     this.parseOsc(data)
+    if (deferWriteCallbacks && callback) {
+      pendingWriteCallbacks.push(callback)
+
+      return
+    }
+
     callback?.()
   })
 
@@ -174,6 +191,8 @@ const StatefulBody = ({
 
 describe('Body agent-emitted OSC 7', () => {
   beforeEach(() => {
+    deferWriteCallbacks = false
+    pendingWriteCallbacks.length = 0
     vi.mocked(Terminal).mockImplementation(() => new FakeTerminal() as never)
     vi.mocked(FitAddon).mockImplementation(
       () =>
@@ -195,6 +214,8 @@ describe('Body agent-emitted OSC 7', () => {
   })
 
   afterEach(() => {
+    deferWriteCallbacks = false
+    pendingWriteCallbacks.length = 0
     vi.clearAllMocks()
     clearTerminalCache()
   })
@@ -527,6 +548,48 @@ describe('Body agent-emitted OSC 7', () => {
 
     act(() => {
       service.emitExit('pty-agent')
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree/child')
+    })
+
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('flushes a late write callback cwd hint after PTY exit', async () => {
+    deferWriteCallbacks = true
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/tmp/worktree"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/tmp/worktree')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+      expect(service.onExit).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData('pty-agent', '! cd child')
+    })
+
+    act(() => {
+      service.emitExit('pty-agent')
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+
+    act(() => {
+      flushPendingWriteCallbacks()
     })
 
     await waitFor(() => {

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -794,6 +794,81 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
+  test('normalizes OSC 7 cwd paths before comparing repeated updates', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/tmp/foo/../worktree\x07'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree')
+    })
+
+    onCwdChange.mockClear()
+
+    act(() => {
+      service.emitData('pty-agent', '\x1b]7;file://host/tmp/worktree\x07')
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('clears partial text-hint buffers when OSC 7 moves to another cwd', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData('pty-agent', '! cd stale')
+    })
+
+    act(() => {
+      service.emitData('pty-agent', '\x1b]7;file://host/tmp/worktree\x07\r\n')
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree')
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalledWith('/tmp/worktree/stale')
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
   test('clears a partial agent cd hint when cwd prop changes to an unrelated path', async () => {
     const service = createService()
     const onCwdChange = vi.fn()

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -31,6 +31,7 @@ type ExitCallback = Parameters<ITerminalService['onExit']>[0]
 type OscHandler = (data: string) => boolean
 
 let deferWriteCallbacks = false
+let skipOscParsing = false
 const pendingWriteCallbacks: (() => void)[] = []
 
 interface ControlledTerminalService extends ITerminalService {
@@ -100,6 +101,10 @@ class FakeTerminal {
   }
 
   private parseOsc(data: string): void {
+    if (skipOscParsing) {
+      return
+    }
+
     this.oscBuffer += data
     const oscPattern = /\x1b\](\d+);([\s\S]*?)(?:\x07|\x1b\\)/g
     let lastMatchEnd = 0
@@ -230,6 +235,7 @@ const StatefulBody = ({
 describe('Body agent-emitted OSC 7', () => {
   beforeEach(() => {
     deferWriteCallbacks = false
+    skipOscParsing = false
     pendingWriteCallbacks.length = 0
     vi.mocked(Terminal).mockImplementation(() => new FakeTerminal() as never)
     vi.mocked(FitAddon).mockImplementation(
@@ -253,6 +259,7 @@ describe('Body agent-emitted OSC 7', () => {
 
   afterEach(() => {
     deferWriteCallbacks = false
+    skipOscParsing = false
     pendingWriteCallbacks.length = 0
     vi.clearAllMocks()
     clearTerminalCache()
@@ -1023,6 +1030,64 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
+  test('resets pending restored OSC 7 suppressions when session id changes', async () => {
+    skipOscParsing = true
+
+    const service = createService()
+    const onCwdChange = vi.fn()
+    const replayData = '\x1b]7;file://host/repo/restored\x07'
+    const replayEndOffset = new TextEncoder().encode(replayData).length
+
+    const { rerender } = render(
+      <Body
+        sessionId="pty-old"
+        cwd="/repo/old"
+        service={service}
+        restoredFrom={{
+          ...restoreData('pty-old', '/repo/old'),
+          replayData,
+          replayEndOffset,
+        }}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    skipOscParsing = false
+    const terminalCreateCount = vi.mocked(Terminal).mock.calls.length
+
+    rerender(
+      <Body
+        sessionId="pty-new"
+        cwd="/repo/new"
+        service={service}
+        restoredFrom={restoreData('pty-new', '/repo/new')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(Terminal).mock.calls.length).toBeGreaterThan(
+        terminalCreateCount
+      )
+    })
+
+    act(() => {
+      getLatestTerminal().write('\x1b]7;file://host/repo/new/live\x07')
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/new/live')
+    })
+
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
   test('normalizes OSC 7 cwd paths before comparing repeated updates', async () => {
     const service = createService()
     const onCwdChange = vi.fn()
@@ -1137,6 +1202,48 @@ describe('Body agent-emitted OSC 7', () => {
     })
 
     expect(onCwdChange).not.toHaveBeenCalledWith('/unrelated/child')
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('clears a partial agent cd hint when cwd prop becomes empty', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    const { rerender } = render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/tmp/worktree"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/tmp/worktree')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData('pty-agent', '! cd child')
+    })
+
+    rerender(
+      <Body
+        sessionId="pty-agent"
+        cwd=""
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/tmp/worktree')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    act(() => {
+      service.emitData('pty-agent', '\r\n')
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalledWith('/tmp/worktree/child')
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -307,6 +307,40 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
+  test('resolves agent cd hints against a preceding OSC 7 cwd update', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/old"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/old')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '\x1b]7;file://host/tmp/worktree\x07! cd child\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree/child')
+    })
+
+    expect(onCwdChange).toHaveBeenCalledWith('/tmp/worktree')
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
   test('keeps agent OSC 7 updates isolated to the receiving pane', async () => {
     const service = createService()
     const onFirstCwdChange = vi.fn()

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -564,6 +564,46 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
+  test('does not roll back an agent-advanced cwd when shell OSC 7 reports an ancestor cwd', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/repo"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/repo')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        'Entering worktree(/repo/.claude/worktrees/feat)\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/repo/.claude/worktrees/feat')
+    })
+
+    onCwdChange.mockClear()
+
+    act(() => {
+      service.emitData('pty-agent', '\x1b]7;file://host/repo\x07')
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalled()
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
   test('ignores OSC 7 updates for the current cwd', async () => {
     const service = createService()
     const onCwdChange = vi.fn()
@@ -588,6 +628,48 @@ describe('Body agent-emitted OSC 7', () => {
     })
 
     expect(onCwdChange).not.toHaveBeenCalled()
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
+  test('clears a partial agent cd hint when cwd prop changes to an unrelated path', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    const { rerender } = render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/tmp/worktree"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/tmp/worktree')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData('pty-agent', '! cd child')
+    })
+
+    rerender(
+      <Body
+        sessionId="pty-agent"
+        cwd="/unrelated"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/tmp/worktree')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    act(() => {
+      service.emitData('pty-agent', '\r\n')
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalledWith('/unrelated/child')
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -368,6 +368,62 @@ describe('Body agent-emitted OSC 7', () => {
     expect(service.updateSessionCwd).not.toHaveBeenCalled()
   })
 
+  test('uses Claude startup cwd before tracking worktree-relative cd commands', async () => {
+    const service = createService()
+    const onCwdChange = vi.fn()
+
+    render(
+      <Body
+        sessionId="pty-agent"
+        cwd="/home/will"
+        service={service}
+        restoredFrom={restoreData('pty-agent', '/home/will')}
+        mode="attach"
+        onCwdChange={onCwdChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(service.onData).toHaveBeenCalled()
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        'Claude Code v2.1.145\r\n' +
+          'Opus 4.7 with max effort\r\n' +
+          '~/projects/vimeflow\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith('/home/will/projects/vimeflow')
+    })
+
+    act(() => {
+      service.emitData(
+        'pty-agent',
+        '! cd .claude/worktrees/\r\n' + '(Bash completed with no output)\r\n'
+      )
+
+      service.emitData(
+        'pty-agent',
+        '! cd codex-agent-osc7-cwd\r\n' + '(Bash completed with no output)\r\n'
+      )
+    })
+
+    await waitFor(() => {
+      expect(onCwdChange).toHaveBeenCalledWith(
+        '/home/will/projects/vimeflow/.claude/worktrees/codex-agent-osc7-cwd'
+      )
+    })
+
+    expect(onCwdChange).not.toHaveBeenCalledWith(
+      '/home/will/.claude/worktrees/codex-agent-osc7-cwd'
+    )
+    expect(service.updateSessionCwd).not.toHaveBeenCalled()
+  })
+
   test('resolves agent cd hints against a preceding OSC 7 cwd update', async () => {
     const service = createService()
     const onCwdChange = vi.fn()

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -1472,6 +1472,65 @@ describe('Body', () => {
       expect(mockService.updateSessionCwd).not.toHaveBeenCalled()
     })
 
+    test('preserves file:// URL host for Windows UNC cwd updates', async () => {
+      const mockService = {
+        spawn: vi.fn().mockResolvedValue({ sessionId: 'pty-1', pid: 123 }),
+        write: vi.fn().mockResolvedValue(undefined),
+        resize: vi.fn().mockResolvedValue(undefined),
+        kill: vi.fn().mockResolvedValue(undefined),
+        updateSessionCwd: vi.fn().mockResolvedValue(undefined),
+        onData: vi.fn(() =>
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          Promise.resolve((): void => {})
+        ),
+        onExit: vi.fn(() =>
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          Promise.resolve((): void => {})
+        ),
+        onError: vi.fn(() =>
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          Promise.resolve((): void => {})
+        ),
+        listSessions: vi.fn().mockResolvedValue({
+          activeSessionId: null,
+          sessions: [],
+        }),
+        setActiveSession: vi.fn().mockResolvedValue(undefined),
+        reorderSessions: vi.fn().mockResolvedValue(undefined),
+      }
+
+      const onCwdChange = vi.fn()
+
+      render(
+        <Body
+          sessionId="test-session"
+          cwd="C:/Users/will"
+          service={mockService}
+          onCwdChange={onCwdChange}
+        />
+      )
+
+      await waitFor(() => {
+        expect(mockTerminal.parser.registerOscHandler).toHaveBeenCalledWith(
+          7,
+          expect.any(Function)
+        )
+      })
+
+      const oscHandler = vi.mocked(mockTerminal.parser.registerOscHandler).mock
+        .calls[0]?.[1]
+
+      ;(oscHandler as ((data: string) => void) | undefined)?.(
+        'file://server/share/project'
+      )
+
+      await waitFor(() => {
+        expect(onCwdChange).toHaveBeenCalledWith('//server/share/project')
+      })
+
+      expect(mockService.updateSessionCwd).not.toHaveBeenCalled()
+    })
+
     test('forwards plain absolute path to onCwdChange', async () => {
       const mockService = {
         spawn: vi.fn().mockResolvedValue({ sessionId: 'pty-1', pid: 123 }),

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -185,6 +185,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const flushFitSessionIdRef = useRef<string | null>(null)
   const pendingDeferredFitFlushRef = useRef(false)
   const agentCwdOutputBufferRef = useRef('')
+  const cwdPropRef = useRef(cwd)
   const agentCwdRef = useRef(cwd)
   const lastAgentCwdHintRef = useRef<string | null>(null)
 
@@ -195,10 +196,16 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   }, [onCwdChange])
 
   useEffect(() => {
-    agentCwdOutputBufferRef.current = ''
+    cwdPropRef.current = cwd
     agentCwdRef.current = cwd
     lastAgentCwdHintRef.current = null
-  }, [cwd, sessionId])
+  }, [cwd])
+
+  useEffect(() => {
+    agentCwdOutputBufferRef.current = ''
+    agentCwdRef.current = cwdPropRef.current
+    lastAgentCwdHintRef.current = null
+  }, [sessionId])
 
   const handleTerminalOutput = useCallback((data: string): void => {
     const output = `${agentCwdOutputBufferRef.current}${data}`
@@ -487,7 +494,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       // output both arrive through xterm's parser, so this stays pane-local.
       newTerminal.parser.registerOscHandler(7, (data) => {
         const path = parseOsc7Cwd(data)
-        if (path) {
+        if (path && path !== agentCwdRef.current) {
           agentCwdRef.current = path
           lastAgentCwdHintRef.current = null
           onCwdChangeRef.current?.(path)

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -204,6 +204,10 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const cwdPropRef = useRef(cwd)
   const agentCwdRef = useRef(cwd)
 
+  const terminalStatusRef = useRef<'idle' | 'running' | 'exited' | 'error'>(
+    'idle'
+  )
+
   // Store callbacks in refs to avoid terminal recreation when they change
   const onCwdChangeRef = useRef(onCwdChange)
   useEffect(() => {
@@ -231,6 +235,16 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     }
   }, [])
 
+  const flushAgentCwdOutputBuffer = useCallback((): void => {
+    const pendingOutput = agentCwdOutputBufferRef.current
+    if (!pendingOutput) {
+      return
+    }
+
+    agentCwdOutputBufferRef.current = ''
+    applyAgentCwdHint(`${pendingOutput}\r\n`)
+  }, [applyAgentCwdHint])
+
   const handleTerminalOutput = useCallback(
     (data: string): void => {
       const output = `${agentCwdOutputBufferRef.current}${data}`
@@ -245,6 +259,13 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
           -AGENT_CWD_HINT_BUFFER_SIZE
         )
 
+        if (
+          terminalStatusRef.current === 'exited' ||
+          terminalStatusRef.current === 'error'
+        ) {
+          flushAgentCwdOutputBuffer()
+        }
+
         return
       }
 
@@ -253,8 +274,15 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         .slice(lastLineBreakIndex + 1)
         .slice(-AGENT_CWD_HINT_BUFFER_SIZE)
       applyAgentCwdHint(completeOutput)
+
+      if (
+        terminalStatusRef.current === 'exited' ||
+        terminalStatusRef.current === 'error'
+      ) {
+        flushAgentCwdOutputBuffer()
+      }
     },
-    [applyAgentCwdHint]
+    [applyAgentCwdHint, flushAgentCwdOutputBuffer]
   )
 
   // Use terminal hook for PTY lifecycle management
@@ -273,6 +301,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     onOutput: handleTerminalOutput,
     mode,
   })
+  terminalStatusRef.current = status
 
   // Bridge workspace sessionId ↔ PTY sessionId for agent detection.
   // Use the PTY session's resolved cwd (absolute path from Rust),
@@ -315,14 +344,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       return
     }
 
-    const pendingOutput = agentCwdOutputBufferRef.current
-    if (!pendingOutput) {
-      return
-    }
-
-    agentCwdOutputBufferRef.current = ''
-    applyAgentCwdHint(`${pendingOutput}\r\n`)
-  }, [applyAgentCwdHint, status])
+    flushAgentCwdOutputBuffer()
+  }, [flushAgentCwdOutputBuffer, status])
 
   useLayoutEffect(() => {
     const wasDeferred = previousDeferFitRef.current

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -31,10 +31,18 @@ import {
   toComparablePath,
 } from './agentCwdGuard'
 import { getAgentCwdHintContext, parseAgentCwdHint } from './agentCwdHint'
-import { parseOsc7Cwd } from './osc7'
+import { parseOsc7Cwd, WINDOWS_DRIVE_PATH } from './osc7'
 import '@xterm/xterm/css/xterm.css'
 
 const AGENT_CWD_HINT_BUFFER_SIZE = 4096
+
+const shouldPreserveOsc7FileUrlHost = (currentCwd?: string): boolean =>
+  Boolean(
+    currentCwd &&
+    (WINDOWS_DRIVE_PATH.test(currentCwd) ||
+      currentCwd.startsWith('\\\\') ||
+      (currentCwd.startsWith('//') && !currentCwd.startsWith('///')))
+  )
 
 const logAgentCwdDebug = (
   event: string,
@@ -619,8 +627,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       // Register OSC 7 handler for cwd tracking. Shell prompts and agent/tool
       // output both arrive through xterm's parser, so this stays pane-local.
       newTerminal.parser.registerOscHandler(7, (data) => {
-        const path = parseOsc7Cwd(data)
         const previousCwd = agentCwdRef.current
+
+        const path = parseOsc7Cwd(data, {
+          preserveFileUrlHost: shouldPreserveOsc7FileUrlHost(previousCwd),
+        })
 
         const shouldSuppressRestoreOsc7 = isRestoringOutputRef.current
 

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -2,6 +2,7 @@
 import type { ReactElement } from 'react'
 import {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
@@ -24,6 +25,8 @@ import { registerPtySession, unregisterPtySession } from '../../ptySessionMap'
 import { parseAgentCwdHint } from './agentCwdHint'
 import { parseOsc7Cwd } from './osc7'
 import '@xterm/xterm/css/xterm.css'
+
+const AGENT_CWD_HINT_BUFFER_SIZE = 4096
 
 // Module-level cache of terminal instances per sessionId.
 //
@@ -197,7 +200,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     lastAgentCwdHintRef.current = null
   }, [cwd, sessionId])
 
-  const handleTerminalOutput = (data: string): void => {
+  const handleTerminalOutput = useCallback((data: string): void => {
     const output = `${agentCwdOutputBufferRef.current}${data}`
 
     const lastLineBreakIndex = Math.max(
@@ -206,7 +209,9 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     )
 
     if (lastLineBreakIndex === -1) {
-      agentCwdOutputBufferRef.current = output.slice(-4096)
+      agentCwdOutputBufferRef.current = output.slice(
+        -AGENT_CWD_HINT_BUFFER_SIZE
+      )
 
       return
     }
@@ -214,7 +219,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     const completeOutput = output.slice(0, lastLineBreakIndex + 1)
     agentCwdOutputBufferRef.current = output
       .slice(lastLineBreakIndex + 1)
-      .slice(-4096)
+      .slice(-AGENT_CWD_HINT_BUFFER_SIZE)
     const cwdHint = parseAgentCwdHint(completeOutput, agentCwdRef.current)
 
     if (
@@ -226,7 +231,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       lastAgentCwdHintRef.current = cwdHint
       onCwdChangeRef.current?.(cwdHint)
     }
-  }
+  }, [])
 
   // Use terminal hook for PTY lifecycle management
   const {
@@ -483,6 +488,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       newTerminal.parser.registerOscHandler(7, (data) => {
         const path = parseOsc7Cwd(data)
         if (path) {
+          agentCwdRef.current = path
+          lastAgentCwdHintRef.current = null
           onCwdChangeRef.current?.(path)
         }
 

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -28,6 +28,22 @@ import '@xterm/xterm/css/xterm.css'
 
 const AGENT_CWD_HINT_BUFFER_SIZE = 4096
 
+const toComparablePath = (path: string): string => path.replace(/\\/g, '/')
+
+const trimTrailingSlashes = (path: string): string =>
+  path === '/' ? path : path.replace(/\/+$/g, '')
+
+const isDescendantPath = (path: string, possibleParent: string): boolean => {
+  const normalizedPath = trimTrailingSlashes(toComparablePath(path))
+  const normalizedParent = trimTrailingSlashes(toComparablePath(possibleParent))
+
+  if (normalizedParent === '/') {
+    return normalizedPath !== '/' && normalizedPath.startsWith('/')
+  }
+
+  return normalizedPath.startsWith(`${normalizedParent}/`)
+}
+
 // Module-level cache of terminal instances per sessionId.
 //
 // HISTORICAL NOTE (corrected 2026-05-09): the original comment claimed
@@ -196,7 +212,9 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
   useEffect(() => {
     cwdPropRef.current = cwd
-    agentCwdRef.current = cwd
+    if (!isDescendantPath(agentCwdRef.current, cwd)) {
+      agentCwdRef.current = cwd
+    }
   }, [cwd])
 
   useEffect(() => {

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../hooks/useTerminal'
 import { type ITerminalService } from '../../services/terminalService'
 import { registerPtySession, unregisterPtySession } from '../../ptySessionMap'
-import { parseAgentCwdHint } from './agentCwdHint'
+import { getAgentCwdHintContext, parseAgentCwdHint } from './agentCwdHint'
 import { parseOsc7Cwd } from './osc7'
 import '@xterm/xterm/css/xterm.css'
 
@@ -213,6 +213,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const flushFitSessionIdRef = useRef<string | null>(null)
   const pendingDeferredFitFlushRef = useRef(false)
   const agentCwdOutputBufferRef = useRef('')
+  const agentCwdHintContextRef = useRef('')
   const cwdPropRef = useRef(cwd)
   const agentCwdRef = useRef(cwd)
 
@@ -245,13 +246,21 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
   useEffect(() => {
     agentCwdOutputBufferRef.current = ''
+    agentCwdHintContextRef.current = ''
     agentCwdRef.current = cwdPropRef.current
   }, [sessionId])
 
   const applyAgentCwdHint = useCallback(
     (output: string): void => {
       const previousCwd = agentCwdRef.current
-      const cwdHint = parseAgentCwdHint(output, previousCwd)
+      const outputWithContext = `${agentCwdHintContextRef.current}${output}`
+      const cwdHint = parseAgentCwdHint(outputWithContext, previousCwd)
+
+      agentCwdHintContextRef.current = cwdHint
+        ? ''
+        : getAgentCwdHintContext(outputWithContext).slice(
+            -AGENT_CWD_HINT_BUFFER_SIZE
+          )
 
       if (cwdHint) {
         logAgentCwdDebug('text-hint', {

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -350,11 +350,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         })
       }
 
-      if (cwdHint) {
-        agentCwdSourceRef.current = 'text-hint'
-      }
-
       if (shouldApplyCwdHint) {
+        agentCwdSourceRef.current = 'text-hint'
         agentCwdRef.current = cwdHint
         onCwdChangeRef.current?.(cwdHint)
       }

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../hooks/useTerminal'
 import { type ITerminalService } from '../../services/terminalService'
 import { registerPtySession, unregisterPtySession } from '../../ptySessionMap'
+import { parseAgentCwdHint } from './agentCwdHint'
 import { parseOsc7Cwd } from './osc7'
 import '@xterm/xterm/css/xterm.css'
 
@@ -180,6 +181,31 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const flushFitRef = useRef<(() => void) | null>(null)
   const flushFitSessionIdRef = useRef<string | null>(null)
   const pendingDeferredFitFlushRef = useRef(false)
+  const agentCwdOutputBufferRef = useRef('')
+  const lastAgentCwdHintRef = useRef<string | null>(null)
+
+  // Store callbacks in refs to avoid terminal recreation when they change
+  const onCwdChangeRef = useRef(onCwdChange)
+  useEffect(() => {
+    onCwdChangeRef.current = onCwdChange
+  }, [onCwdChange])
+
+  useEffect(() => {
+    agentCwdOutputBufferRef.current = ''
+    lastAgentCwdHintRef.current = null
+  }, [sessionId])
+
+  const handleTerminalOutput = (data: string): void => {
+    const output = `${agentCwdOutputBufferRef.current}${data}`
+    const cwdHint = parseAgentCwdHint(output)
+
+    agentCwdOutputBufferRef.current = output.slice(-4096)
+
+    if (cwdHint && cwdHint !== lastAgentCwdHintRef.current) {
+      lastAgentCwdHintRef.current = cwdHint
+      onCwdChangeRef.current?.(cwdHint)
+    }
+  }
 
   // Use terminal hook for PTY lifecycle management
   const {
@@ -194,6 +220,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     env,
     restoredFrom,
     onPaneReady,
+    onOutput: handleTerminalOutput,
     mode,
   })
 
@@ -209,12 +236,6 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       unregisterPtySession(sessionId)
     }
   }, [sessionId, ptySession?.id, ptySession?.cwd])
-
-  // Store callbacks in refs to avoid terminal recreation when they change
-  const onCwdChangeRef = useRef(onCwdChange)
-  useEffect(() => {
-    onCwdChangeRef.current = onCwdChange
-  }, [onCwdChange])
 
   // P1 Fix: Store resize callback in ref to avoid terminal recreation when it changes
   const resizeRef = useRef(resize)

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -56,6 +56,29 @@ const isDescendantPath = (path: string, possibleParent: string): boolean => {
   return normalizedPath.startsWith(`${normalizedParent}/`)
 }
 
+const stripCarriageReturnOverwrites = (output: string): string =>
+  output
+    .split('\n')
+    .map((line, index, lines) => {
+      if (index === lines.length - 1) {
+        return line
+      }
+
+      const lineWithoutTerminator = line.endsWith('\r')
+        ? line.slice(0, -1)
+        : line
+
+      const overwriteIndex = lineWithoutTerminator.lastIndexOf('\r')
+
+      const visibleLine =
+        overwriteIndex === -1
+          ? lineWithoutTerminator
+          : lineWithoutTerminator.slice(overwriteIndex + 1)
+
+      return `${visibleLine}\n`
+    })
+    .join('')
+
 // Module-level cache of terminal instances per sessionId.
 //
 // HISTORICAL NOTE (corrected 2026-05-09): the original comment claimed
@@ -258,7 +281,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const applyAgentCwdHint = useCallback(
     (output: string): void => {
       const previousCwd = agentCwdRef.current
-      const outputWithContext = `${agentCwdHintContextRef.current}${output}`
+      const visibleOutput = stripCarriageReturnOverwrites(output)
+      const outputWithContext = `${agentCwdHintContextRef.current}${visibleOutput}`
       const cwdHint = parseAgentCwdHint(outputWithContext, previousCwd)
 
       agentCwdHintContextRef.current = cwdHint
@@ -298,10 +322,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     (data: string): void => {
       const output = `${agentCwdOutputBufferRef.current}${data}`
 
-      const lastLineBreakIndex = Math.max(
-        output.lastIndexOf('\n'),
-        output.lastIndexOf('\r')
-      )
+      const lastLineBreakIndex = output.lastIndexOf('\n')
 
       if (lastLineBreakIndex === -1) {
         agentCwdOutputBufferRef.current = output.slice(

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -30,6 +30,18 @@ const AGENT_CWD_HINT_BUFFER_SIZE = 4096
 
 const toComparablePath = (path: string): string => path.replace(/\\/g, '/')
 
+const logAgentCwdDebug = (
+  event: string,
+  details: Record<string, boolean | string | null>
+): void => {
+  if (!import.meta.env.DEV || import.meta.env.MODE === 'test') {
+    return
+  }
+
+  // eslint-disable-next-line no-console
+  console.info(`[vimeflow:terminal-cwd] ${event} ${JSON.stringify(details)}`)
+}
+
 const trimTrailingSlashes = (path: string): string =>
   path === '/' ? path : path.replace(/\/+$/g, '')
 
@@ -215,25 +227,48 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   }, [onCwdChange])
 
   useEffect(() => {
+    const previousCwd = agentCwdRef.current
+
     cwdPropRef.current = cwd
     if (!isDescendantPath(agentCwdRef.current, cwd)) {
       agentCwdRef.current = cwd
     }
-  }, [cwd])
+
+    logAgentCwdDebug('prop-cwd', {
+      sessionId,
+      previousCwd,
+      propCwd: cwd,
+      agentCwd: agentCwdRef.current,
+      changed: previousCwd !== agentCwdRef.current,
+    })
+  }, [cwd, sessionId])
 
   useEffect(() => {
     agentCwdOutputBufferRef.current = ''
     agentCwdRef.current = cwdPropRef.current
   }, [sessionId])
 
-  const applyAgentCwdHint = useCallback((output: string): void => {
-    const cwdHint = parseAgentCwdHint(output, agentCwdRef.current)
+  const applyAgentCwdHint = useCallback(
+    (output: string): void => {
+      const previousCwd = agentCwdRef.current
+      const cwdHint = parseAgentCwdHint(output, previousCwd)
 
-    if (cwdHint && cwdHint !== agentCwdRef.current) {
-      agentCwdRef.current = cwdHint
-      onCwdChangeRef.current?.(cwdHint)
-    }
-  }, [])
+      if (cwdHint) {
+        logAgentCwdDebug('text-hint', {
+          sessionId,
+          previousCwd,
+          nextCwd: cwdHint,
+          changed: cwdHint !== previousCwd,
+        })
+      }
+
+      if (cwdHint && cwdHint !== agentCwdRef.current) {
+        agentCwdRef.current = cwdHint
+        onCwdChangeRef.current?.(cwdHint)
+      }
+    },
+    [sessionId]
+  )
 
   const flushAgentCwdOutputBuffer = useCallback((): void => {
     const pendingOutput = agentCwdOutputBufferRef.current
@@ -548,6 +583,16 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       // output both arrive through xterm's parser, so this stays pane-local.
       newTerminal.parser.registerOscHandler(7, (data) => {
         const path = parseOsc7Cwd(data)
+        const previousCwd = agentCwdRef.current
+
+        logAgentCwdDebug('osc7', {
+          sessionId,
+          raw: data,
+          previousCwd,
+          nextCwd: path,
+          changed: path !== null && path !== previousCwd,
+        })
+
         if (path && path !== agentCwdRef.current) {
           agentCwdRef.current = path
           onCwdChangeRef.current?.(path)

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/require-default-props */
+// cspell:ignore worktree worktrees
 import type { ReactElement } from 'react'
 import {
   forwardRef,
@@ -28,6 +29,8 @@ import '@xterm/xterm/css/xterm.css'
 
 const AGENT_CWD_HINT_BUFFER_SIZE = 4096
 
+type AgentCwdSource = 'osc7' | 'prop' | 'text-hint'
+
 const toComparablePath = (path: string): string => path.replace(/\\/g, '/')
 
 const logAgentCwdDebug = (
@@ -55,6 +58,47 @@ const isDescendantPath = (path: string, possibleParent: string): boolean => {
 
   return normalizedPath.startsWith(`${normalizedParent}/`)
 }
+
+const getWorktreeParentPath = (path: string): string | null => {
+  const normalizedPath = trimTrailingSlashes(toComparablePath(path))
+  const lastSeparatorIndex = normalizedPath.lastIndexOf('/')
+  if (lastSeparatorIndex === -1) {
+    return null
+  }
+
+  const parentPath = normalizedPath.slice(0, lastSeparatorIndex)
+  const parentName = parentPath.slice(parentPath.lastIndexOf('/') + 1)
+
+  return parentName === 'worktrees' ? parentPath : null
+}
+
+const isWorktreeSiblingPath = (
+  path: string,
+  possibleSibling: string
+): boolean => {
+  const normalizedPath = trimTrailingSlashes(toComparablePath(path))
+
+  const normalizedSibling = trimTrailingSlashes(
+    toComparablePath(possibleSibling)
+  )
+
+  const parentPath = getWorktreeParentPath(normalizedPath)
+
+  return (
+    normalizedPath !== normalizedSibling &&
+    parentPath !== null &&
+    parentPath === getWorktreeParentPath(normalizedSibling)
+  )
+}
+
+const shouldIgnoreStaleOsc7Cwd = (
+  currentCwd: string,
+  nextCwd: string,
+  currentSource: AgentCwdSource
+): boolean =>
+  currentSource === 'text-hint' &&
+  (isDescendantPath(currentCwd, nextCwd) ||
+    isWorktreeSiblingPath(currentCwd, nextCwd))
 
 const stripCarriageReturnOverwrites = (output: string): string =>
   output
@@ -239,6 +283,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const agentCwdHintContextRef = useRef('')
   const cwdPropRef = useRef(cwd)
   const agentCwdRef = useRef(cwd)
+  const agentCwdSourceRef = useRef<AgentCwdSource>('prop')
 
   const terminalStatusRef = useRef<'idle' | 'running' | 'exited' | 'error'>(
     'idle'
@@ -261,6 +306,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       agentCwdOutputBufferRef.current = ''
       agentCwdHintContextRef.current = ''
       agentCwdRef.current = cwd
+      agentCwdSourceRef.current = 'prop'
     }
 
     logAgentCwdDebug('prop-cwd', {
@@ -276,6 +322,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     agentCwdOutputBufferRef.current = ''
     agentCwdHintContextRef.current = ''
     agentCwdRef.current = cwdPropRef.current
+    agentCwdSourceRef.current = 'prop'
   }, [sessionId])
 
   const applyAgentCwdHint = useCallback(
@@ -285,7 +332,10 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       const outputWithContext = `${agentCwdHintContextRef.current}${visibleOutput}`
       const cwdHint = parseAgentCwdHint(outputWithContext, previousCwd)
 
-      agentCwdHintContextRef.current = cwdHint
+      const shouldApplyCwdHint =
+        cwdHint !== null && cwdHint !== agentCwdRef.current
+
+      agentCwdHintContextRef.current = shouldApplyCwdHint
         ? ''
         : getAgentCwdHintContext(outputWithContext).slice(
             -AGENT_CWD_HINT_BUFFER_SIZE
@@ -300,7 +350,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         })
       }
 
-      if (cwdHint && cwdHint !== agentCwdRef.current) {
+      if (cwdHint) {
+        agentCwdSourceRef.current = 'text-hint'
+      }
+
+      if (shouldApplyCwdHint) {
         agentCwdRef.current = cwdHint
         onCwdChangeRef.current?.(cwdHint)
       }
@@ -620,20 +674,28 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         const path = parseOsc7Cwd(data)
         const previousCwd = agentCwdRef.current
 
+        const shouldIgnore =
+          path !== null &&
+          shouldIgnoreStaleOsc7Cwd(
+            agentCwdRef.current,
+            path,
+            agentCwdSourceRef.current
+          )
+
         logAgentCwdDebug('osc7', {
           sessionId,
           raw: data,
           previousCwd,
           nextCwd: path,
           changed: path !== null && path !== previousCwd,
+          ignored: shouldIgnore,
         })
 
-        if (
-          path &&
-          path !== agentCwdRef.current &&
-          !isDescendantPath(agentCwdRef.current, path)
-        ) {
+        if (path && path === agentCwdRef.current) {
+          agentCwdSourceRef.current = 'osc7'
+        } else if (path && !shouldIgnore) {
           agentCwdRef.current = path
+          agentCwdSourceRef.current = 'osc7'
           onCwdChangeRef.current?.(path)
         }
 

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -694,6 +694,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         if (path && path === agentCwdRef.current) {
           agentCwdSourceRef.current = 'osc7'
         } else if (path && !shouldIgnore) {
+          agentCwdOutputBufferRef.current = ''
+          agentCwdHintContextRef.current = ''
           agentCwdRef.current = path
           agentCwdSourceRef.current = 'osc7'
           onCwdChangeRef.current?.(path)

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -204,33 +204,40 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     agentCwdRef.current = cwdPropRef.current
   }, [sessionId])
 
-  const handleTerminalOutput = useCallback((data: string): void => {
-    const output = `${agentCwdOutputBufferRef.current}${data}`
-
-    const lastLineBreakIndex = Math.max(
-      output.lastIndexOf('\n'),
-      output.lastIndexOf('\r')
-    )
-
-    if (lastLineBreakIndex === -1) {
-      agentCwdOutputBufferRef.current = output.slice(
-        -AGENT_CWD_HINT_BUFFER_SIZE
-      )
-
-      return
-    }
-
-    const completeOutput = output.slice(0, lastLineBreakIndex + 1)
-    agentCwdOutputBufferRef.current = output
-      .slice(lastLineBreakIndex + 1)
-      .slice(-AGENT_CWD_HINT_BUFFER_SIZE)
-    const cwdHint = parseAgentCwdHint(completeOutput, agentCwdRef.current)
+  const applyAgentCwdHint = useCallback((output: string): void => {
+    const cwdHint = parseAgentCwdHint(output, agentCwdRef.current)
 
     if (cwdHint && cwdHint !== agentCwdRef.current) {
       agentCwdRef.current = cwdHint
       onCwdChangeRef.current?.(cwdHint)
     }
   }, [])
+
+  const handleTerminalOutput = useCallback(
+    (data: string): void => {
+      const output = `${agentCwdOutputBufferRef.current}${data}`
+
+      const lastLineBreakIndex = Math.max(
+        output.lastIndexOf('\n'),
+        output.lastIndexOf('\r')
+      )
+
+      if (lastLineBreakIndex === -1) {
+        agentCwdOutputBufferRef.current = output.slice(
+          -AGENT_CWD_HINT_BUFFER_SIZE
+        )
+
+        return
+      }
+
+      const completeOutput = output.slice(0, lastLineBreakIndex + 1)
+      agentCwdOutputBufferRef.current = output
+        .slice(lastLineBreakIndex + 1)
+        .slice(-AGENT_CWD_HINT_BUFFER_SIZE)
+      applyAgentCwdHint(completeOutput)
+    },
+    [applyAgentCwdHint]
+  )
 
   // Use terminal hook for PTY lifecycle management
   const {
@@ -284,6 +291,20 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   useEffect(() => {
     onPtyStatusChangeRef.current?.(status)
   }, [status])
+
+  useEffect(() => {
+    if (status !== 'exited' && status !== 'error') {
+      return
+    }
+
+    const pendingOutput = agentCwdOutputBufferRef.current
+    if (!pendingOutput) {
+      return
+    }
+
+    agentCwdOutputBufferRef.current = ''
+    applyAgentCwdHint(`${pendingOutput}\r\n`)
+  }, [applyAgentCwdHint, status])
 
   useLayoutEffect(() => {
     const wasDeferred = previousDeferFitRef.current

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../hooks/useTerminal'
 import { type ITerminalService } from '../../services/terminalService'
 import { registerPtySession, unregisterPtySession } from '../../ptySessionMap'
+import { parseOsc7Cwd } from './osc7'
 import '@xterm/xterm/css/xterm.css'
 
 // Module-level cache of terminal instances per sessionId.
@@ -435,25 +436,12 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       // Fit terminal to container — guard against hidden (display:none) containers
       didInitialFit = fitInitialWhenReady(fitAddon)
 
-      // Register OSC 7 handler for cwd tracking
-      // Shells emit: \e]7;file://hostname/path\a on every cd
+      // Register OSC 7 handler for cwd tracking. Shell prompts and agent/tool
+      // output both arrive through xterm's parser, so this stays pane-local.
       newTerminal.parser.registerOscHandler(7, (data) => {
-        try {
-          const url = new URL(data)
-          let path = decodeURIComponent(url.pathname)
-          // Windows: new URL("file://host/C:/Users/...").pathname → "/C:/Users/..."
-          // Strip the leading slash before a drive letter so Rust canonicalize works
-          if (/^\/[A-Za-z]:/.test(path)) {
-            path = path.slice(1)
-          }
-          if (path) {
-            onCwdChangeRef.current?.(path)
-          }
-        } catch {
-          // Not a valid URL — some shells emit plain paths
-          if (data.startsWith('/')) {
-            onCwdChangeRef.current?.(data)
-          }
+        const path = parseOsc7Cwd(data)
+        if (path) {
+          onCwdChangeRef.current?.(path)
         }
 
         return true

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -231,7 +231,12 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     const previousCwd = agentCwdRef.current
 
     cwdPropRef.current = cwd
-    if (!isDescendantPath(agentCwdRef.current, cwd)) {
+    if (
+      toComparablePath(agentCwdRef.current) !== toComparablePath(cwd) &&
+      !isDescendantPath(agentCwdRef.current, cwd)
+    ) {
+      agentCwdOutputBufferRef.current = ''
+      agentCwdHintContextRef.current = ''
       agentCwdRef.current = cwd
     }
 
@@ -602,7 +607,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
           changed: path !== null && path !== previousCwd,
         })
 
-        if (path && path !== agentCwdRef.current) {
+        if (
+          path &&
+          path !== agentCwdRef.current &&
+          !isDescendantPath(agentCwdRef.current, path)
+        ) {
           agentCwdRef.current = path
           onCwdChangeRef.current?.(path)
         }

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -182,6 +182,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const flushFitSessionIdRef = useRef<string | null>(null)
   const pendingDeferredFitFlushRef = useRef(false)
   const agentCwdOutputBufferRef = useRef('')
+  const agentCwdRef = useRef(cwd)
   const lastAgentCwdHintRef = useRef<string | null>(null)
 
   // Store callbacks in refs to avoid terminal recreation when they change
@@ -192,16 +193,36 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
   useEffect(() => {
     agentCwdOutputBufferRef.current = ''
+    agentCwdRef.current = cwd
     lastAgentCwdHintRef.current = null
-  }, [sessionId])
+  }, [cwd, sessionId])
 
   const handleTerminalOutput = (data: string): void => {
     const output = `${agentCwdOutputBufferRef.current}${data}`
-    const cwdHint = parseAgentCwdHint(output)
 
-    agentCwdOutputBufferRef.current = output.slice(-4096)
+    const lastLineBreakIndex = Math.max(
+      output.lastIndexOf('\n'),
+      output.lastIndexOf('\r')
+    )
 
-    if (cwdHint && cwdHint !== lastAgentCwdHintRef.current) {
+    if (lastLineBreakIndex === -1) {
+      agentCwdOutputBufferRef.current = output.slice(-4096)
+
+      return
+    }
+
+    const completeOutput = output.slice(0, lastLineBreakIndex + 1)
+    agentCwdOutputBufferRef.current = output
+      .slice(lastLineBreakIndex + 1)
+      .slice(-4096)
+    const cwdHint = parseAgentCwdHint(completeOutput, agentCwdRef.current)
+
+    if (
+      cwdHint &&
+      cwdHint !== agentCwdRef.current &&
+      cwdHint !== lastAgentCwdHintRef.current
+    ) {
+      agentCwdRef.current = cwdHint
       lastAgentCwdHintRef.current = cwdHint
       onCwdChangeRef.current?.(cwdHint)
     }

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -341,19 +341,19 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
             -AGENT_CWD_HINT_BUFFER_SIZE
           )
 
-      if (cwdHint) {
+      if (cwdHint !== null) {
         logAgentCwdDebug('text-hint', {
           sessionId,
           previousCwd,
           nextCwd: cwdHint,
           changed: cwdHint !== previousCwd,
         })
-      }
 
-      if (shouldApplyCwdHint) {
-        agentCwdSourceRef.current = 'text-hint'
-        agentCwdRef.current = cwdHint
-        onCwdChangeRef.current?.(cwdHint)
+        if (shouldApplyCwdHint) {
+          agentCwdSourceRef.current = 'text-hint'
+          agentCwdRef.current = cwdHint
+          onCwdChangeRef.current?.(cwdHint)
+        }
       }
     },
     [sessionId]

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -409,6 +409,19 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     [applyAgentCwdHint, flushAgentCwdOutputBuffer]
   )
 
+  const handleTerminalInput = useCallback((): void => {
+    if (agentCwdSourceRef.current !== 'text-hint') {
+      return
+    }
+
+    agentCwdSourceRef.current = 'osc7'
+    logAgentCwdDebug('user-input', {
+      sessionId,
+      agentCwd: agentCwdRef.current,
+      unlocked: true,
+    })
+  }, [sessionId])
+
   // Use terminal hook for PTY lifecycle management
   const {
     session: ptySession,
@@ -423,6 +436,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     restoredFrom,
     onPaneReady,
     onOutput: handleTerminalOutput,
+    onInput: handleTerminalInput,
     mode,
   })
   terminalStatusRef.current = status

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -218,6 +218,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const cwdPropRef = useRef(cwd)
   const agentCwdRef = useRef(cwd)
   const agentCwdSourceRef = useRef<AgentCwdSource>('prop')
+  const sessionIdRef = useRef(sessionId)
+  sessionIdRef.current = sessionId
 
   const terminalStatusRef = useRef<'idle' | 'running' | 'exited' | 'error'>(
     'idle'
@@ -260,39 +262,36 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     agentCwdSourceRef.current = 'prop'
   }, [sessionId])
 
-  const applyAgentCwdHint = useCallback(
-    (output: string): void => {
-      const previousCwd = agentCwdRef.current
-      const visibleOutput = stripCarriageReturnOverwrites(output)
-      const outputWithContext = `${agentCwdHintContextRef.current}${visibleOutput}`
-      const cwdHint = parseAgentCwdHint(outputWithContext, previousCwd)
+  const applyAgentCwdHint = useCallback((output: string): void => {
+    const previousCwd = agentCwdRef.current
+    const visibleOutput = stripCarriageReturnOverwrites(output)
+    const outputWithContext = `${agentCwdHintContextRef.current}${visibleOutput}`
+    const cwdHint = parseAgentCwdHint(outputWithContext, previousCwd)
 
-      const shouldApplyCwdHint =
-        cwdHint !== null && cwdHint !== agentCwdRef.current
+    const shouldApplyCwdHint =
+      cwdHint !== null && cwdHint !== agentCwdRef.current
 
-      agentCwdHintContextRef.current = shouldApplyCwdHint
-        ? ''
-        : getAgentCwdHintContext(outputWithContext).slice(
-            -AGENT_CWD_HINT_BUFFER_SIZE
-          )
+    agentCwdHintContextRef.current = shouldApplyCwdHint
+      ? ''
+      : getAgentCwdHintContext(outputWithContext).slice(
+          -AGENT_CWD_HINT_BUFFER_SIZE
+        )
 
-      if (cwdHint !== null) {
-        logAgentCwdDebug('text-hint', {
-          sessionId,
-          previousCwd,
-          nextCwd: cwdHint,
-          changed: cwdHint !== previousCwd,
-        })
+    if (cwdHint !== null) {
+      logAgentCwdDebug('text-hint', {
+        sessionId: sessionIdRef.current,
+        previousCwd,
+        nextCwd: cwdHint,
+        changed: cwdHint !== previousCwd,
+      })
 
-        if (shouldApplyCwdHint) {
-          agentCwdSourceRef.current = 'text-hint'
-          agentCwdRef.current = cwdHint
-          onCwdChangeRef.current?.(cwdHint)
-        }
+      if (shouldApplyCwdHint) {
+        agentCwdSourceRef.current = 'text-hint'
+        agentCwdRef.current = cwdHint
+        onCwdChangeRef.current?.(cwdHint)
       }
-    },
-    [sessionId]
-  )
+    }
+  }, [])
 
   const flushAgentCwdOutputBuffer = useCallback((): void => {
     const pendingOutput = agentCwdOutputBufferRef.current

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -23,16 +23,18 @@ import {
 } from '../../hooks/useTerminal'
 import { type ITerminalService } from '../../services/terminalService'
 import { registerPtySession, unregisterPtySession } from '../../ptySessionMap'
+import {
+  type AgentCwdSource,
+  isDescendantPath,
+  shouldIgnoreStaleOsc7Cwd,
+  stripCarriageReturnOverwrites,
+  toComparablePath,
+} from './agentCwdGuard'
 import { getAgentCwdHintContext, parseAgentCwdHint } from './agentCwdHint'
 import { parseOsc7Cwd } from './osc7'
 import '@xterm/xterm/css/xterm.css'
 
 const AGENT_CWD_HINT_BUFFER_SIZE = 4096
-const OSC7_SEQUENCE_PATTERN = /\x1b\]7;[\s\S]*?(?:\x07|\x1b\\)/g
-
-type AgentCwdSource = 'osc7' | 'prop' | 'text-hint'
-
-const toComparablePath = (path: string): string => path.replace(/\\/g, '/')
 
 const logAgentCwdDebug = (
   event: string,
@@ -45,99 +47,6 @@ const logAgentCwdDebug = (
   // eslint-disable-next-line no-console
   console.info(`[vimeflow:terminal-cwd] ${event} ${JSON.stringify(details)}`)
 }
-
-const trimTrailingSlashes = (path: string): string =>
-  path === '/' ? path : path.replace(/\/+$/g, '')
-
-const isDescendantPath = (path: string, possibleParent: string): boolean => {
-  const normalizedPath = trimTrailingSlashes(toComparablePath(path))
-  const normalizedParent = trimTrailingSlashes(toComparablePath(possibleParent))
-
-  if (!normalizedParent) {
-    return false
-  }
-
-  if (normalizedParent === '/') {
-    return normalizedPath !== '/' && normalizedPath.startsWith('/')
-  }
-
-  return normalizedPath.startsWith(`${normalizedParent}/`)
-}
-
-const getWorktreeParentPath = (path: string): string | null => {
-  const normalizedPath = trimTrailingSlashes(toComparablePath(path))
-  const lastSeparatorIndex = normalizedPath.lastIndexOf('/')
-  if (lastSeparatorIndex === -1) {
-    return null
-  }
-
-  const parentPath = normalizedPath.slice(0, lastSeparatorIndex)
-  const parentName = parentPath.slice(parentPath.lastIndexOf('/') + 1)
-
-  const grandparentPath = parentPath.slice(0, parentPath.lastIndexOf('/'))
-
-  const grandparentName = grandparentPath.slice(
-    grandparentPath.lastIndexOf('/') + 1
-  )
-
-  return parentName === 'worktrees' && grandparentName === '.claude'
-    ? parentPath
-    : null
-}
-
-const isWorktreeSiblingPath = (
-  path: string,
-  possibleSibling: string
-): boolean => {
-  const normalizedPath = trimTrailingSlashes(toComparablePath(path))
-
-  const normalizedSibling = trimTrailingSlashes(
-    toComparablePath(possibleSibling)
-  )
-
-  const parentPath = getWorktreeParentPath(normalizedPath)
-
-  return (
-    normalizedPath !== normalizedSibling &&
-    parentPath !== null &&
-    parentPath === getWorktreeParentPath(normalizedSibling)
-  )
-}
-
-const shouldIgnoreStaleOsc7Cwd = (
-  currentCwd: string,
-  nextCwd: string,
-  currentSource: AgentCwdSource
-): boolean =>
-  currentSource === 'text-hint' &&
-  (isDescendantPath(currentCwd, nextCwd) ||
-    isWorktreeSiblingPath(currentCwd, nextCwd))
-
-const stripCarriageReturnOverwrites = (output: string): string =>
-  output
-    .split('\n')
-    .map((line, index, lines) => {
-      if (index === lines.length - 1) {
-        return line
-      }
-
-      const lineWithoutTerminator = line.endsWith('\r')
-        ? line.slice(0, -1)
-        : line
-
-      const overwriteIndex = lineWithoutTerminator.lastIndexOf('\r')
-
-      const visibleLine =
-        overwriteIndex === -1
-          ? lineWithoutTerminator
-          : lineWithoutTerminator.slice(overwriteIndex + 1)
-
-      return `${visibleLine}\n`
-    })
-    .join('')
-
-const countOsc7Sequences = (output: string): number =>
-  output.match(OSC7_SEQUENCE_PATTERN)?.length ?? 0
 
 // Module-level cache of terminal instances per sessionId.
 //
@@ -297,7 +206,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const pendingDeferredFitFlushRef = useRef(false)
   const agentCwdOutputBufferRef = useRef('')
   const agentCwdHintContextRef = useRef('')
-  const restoreOsc7SuppressionsRef = useRef(0)
+  const isRestoringOutputRef = useRef(false)
   const cwdPropRef = useRef(cwd)
   const agentCwdRef = useRef(cwd)
   const agentCwdSourceRef = useRef<AgentCwdSource>('prop')
@@ -338,7 +247,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   useEffect(() => {
     agentCwdOutputBufferRef.current = ''
     agentCwdHintContextRef.current = ''
-    restoreOsc7SuppressionsRef.current = 0
+    isRestoringOutputRef.current = false
     agentCwdRef.current = cwdPropRef.current
     agentCwdSourceRef.current = 'prop'
   }, [sessionId])
@@ -429,7 +338,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       return
     }
 
-    agentCwdSourceRef.current = 'osc7'
+    agentCwdSourceRef.current = 'user-input'
     logAgentCwdDebug('user-input', {
       sessionId,
       agentCwd: agentCwdRef.current,
@@ -437,8 +346,12 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     })
   }, [sessionId])
 
-  const handleRestoreOutput = useCallback((output: string): void => {
-    restoreOsc7SuppressionsRef.current += countOsc7Sequences(output)
+  const handleRestoreStart = useCallback((): void => {
+    isRestoringOutputRef.current = true
+  }, [])
+
+  const handleRestoreEnd = useCallback((): void => {
+    isRestoringOutputRef.current = false
   }, [])
 
   // Use terminal hook for PTY lifecycle management
@@ -455,7 +368,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     restoredFrom,
     onPaneReady,
     onOutput: handleTerminalOutput,
-    onRestoreOutput: handleRestoreOutput,
+    onRestoreStart: handleRestoreStart,
+    onRestoreEnd: handleRestoreEnd,
     onInput: handleTerminalInput,
     mode,
   })
@@ -708,11 +622,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         const path = parseOsc7Cwd(data)
         const previousCwd = agentCwdRef.current
 
-        const shouldSuppressRestoreOsc7 = restoreOsc7SuppressionsRef.current > 0
-
-        if (shouldSuppressRestoreOsc7) {
-          restoreOsc7SuppressionsRef.current -= 1
-        }
+        const shouldSuppressRestoreOsc7 = isRestoringOutputRef.current
 
         const shouldIgnore =
           path !== null &&

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -187,7 +187,6 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const agentCwdOutputBufferRef = useRef('')
   const cwdPropRef = useRef(cwd)
   const agentCwdRef = useRef(cwd)
-  const lastAgentCwdHintRef = useRef<string | null>(null)
 
   // Store callbacks in refs to avoid terminal recreation when they change
   const onCwdChangeRef = useRef(onCwdChange)
@@ -198,13 +197,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   useEffect(() => {
     cwdPropRef.current = cwd
     agentCwdRef.current = cwd
-    lastAgentCwdHintRef.current = null
   }, [cwd])
 
   useEffect(() => {
     agentCwdOutputBufferRef.current = ''
     agentCwdRef.current = cwdPropRef.current
-    lastAgentCwdHintRef.current = null
   }, [sessionId])
 
   const handleTerminalOutput = useCallback((data: string): void => {
@@ -229,13 +226,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       .slice(-AGENT_CWD_HINT_BUFFER_SIZE)
     const cwdHint = parseAgentCwdHint(completeOutput, agentCwdRef.current)
 
-    if (
-      cwdHint &&
-      cwdHint !== agentCwdRef.current &&
-      cwdHint !== lastAgentCwdHintRef.current
-    ) {
+    if (cwdHint && cwdHint !== agentCwdRef.current) {
       agentCwdRef.current = cwdHint
-      lastAgentCwdHintRef.current = cwdHint
       onCwdChangeRef.current?.(cwdHint)
     }
   }, [])
@@ -496,7 +488,6 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         const path = parseOsc7Cwd(data)
         if (path && path !== agentCwdRef.current) {
           agentCwdRef.current = path
-          lastAgentCwdHintRef.current = null
           onCwdChangeRef.current?.(path)
         }
 

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -28,6 +28,7 @@ import { parseOsc7Cwd } from './osc7'
 import '@xterm/xterm/css/xterm.css'
 
 const AGENT_CWD_HINT_BUFFER_SIZE = 4096
+const OSC7_SEQUENCE_PATTERN = /\x1b\]7;[\s\S]*?(?:\x07|\x1b\\)/g
 
 type AgentCwdSource = 'osc7' | 'prop' | 'text-hint'
 
@@ -69,7 +70,15 @@ const getWorktreeParentPath = (path: string): string | null => {
   const parentPath = normalizedPath.slice(0, lastSeparatorIndex)
   const parentName = parentPath.slice(parentPath.lastIndexOf('/') + 1)
 
-  return parentName === 'worktrees' ? parentPath : null
+  const grandparentPath = parentPath.slice(0, parentPath.lastIndexOf('/'))
+
+  const grandparentName = grandparentPath.slice(
+    grandparentPath.lastIndexOf('/') + 1
+  )
+
+  return parentName === 'worktrees' && grandparentName === '.claude'
+    ? parentPath
+    : null
 }
 
 const isWorktreeSiblingPath = (
@@ -122,6 +131,9 @@ const stripCarriageReturnOverwrites = (output: string): string =>
       return `${visibleLine}\n`
     })
     .join('')
+
+const countOsc7Sequences = (output: string): number =>
+  output.match(OSC7_SEQUENCE_PATTERN)?.length ?? 0
 
 // Module-level cache of terminal instances per sessionId.
 //
@@ -281,6 +293,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const pendingDeferredFitFlushRef = useRef(false)
   const agentCwdOutputBufferRef = useRef('')
   const agentCwdHintContextRef = useRef('')
+  const restoreOsc7SuppressionsRef = useRef(0)
   const cwdPropRef = useRef(cwd)
   const agentCwdRef = useRef(cwd)
   const agentCwdSourceRef = useRef<AgentCwdSource>('prop')
@@ -419,6 +432,10 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     })
   }, [sessionId])
 
+  const handleRestoreOutput = useCallback((output: string): void => {
+    restoreOsc7SuppressionsRef.current += countOsc7Sequences(output)
+  }, [])
+
   // Use terminal hook for PTY lifecycle management
   const {
     session: ptySession,
@@ -433,6 +450,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     restoredFrom,
     onPaneReady,
     onOutput: handleTerminalOutput,
+    onRestoreOutput: handleRestoreOutput,
     onInput: handleTerminalInput,
     mode,
   })
@@ -685,8 +703,15 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         const path = parseOsc7Cwd(data)
         const previousCwd = agentCwdRef.current
 
+        const shouldSuppressRestoreOsc7 = restoreOsc7SuppressionsRef.current > 0
+
+        if (shouldSuppressRestoreOsc7) {
+          restoreOsc7SuppressionsRef.current -= 1
+        }
+
         const shouldIgnore =
           path !== null &&
+          !shouldSuppressRestoreOsc7 &&
           shouldIgnoreStaleOsc7Cwd(
             agentCwdRef.current,
             path,
@@ -699,8 +724,12 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
           previousCwd,
           nextCwd: path,
           changed: path !== null && path !== previousCwd,
-          ignored: shouldIgnore,
+          ignored: shouldIgnore || shouldSuppressRestoreOsc7,
         })
+
+        if (shouldSuppressRestoreOsc7) {
+          return true
+        }
 
         if (path && path === agentCwdRef.current) {
           agentCwdSourceRef.current = 'osc7'

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -53,6 +53,10 @@ const isDescendantPath = (path: string, possibleParent: string): boolean => {
   const normalizedPath = trimTrailingSlashes(toComparablePath(path))
   const normalizedParent = trimTrailingSlashes(toComparablePath(possibleParent))
 
+  if (!normalizedParent) {
+    return false
+  }
+
   if (normalizedParent === '/') {
     return normalizedPath !== '/' && normalizedPath.startsWith('/')
   }
@@ -334,6 +338,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   useEffect(() => {
     agentCwdOutputBufferRef.current = ''
     agentCwdHintContextRef.current = ''
+    restoreOsc7SuppressionsRef.current = 0
     agentCwdRef.current = cwdPropRef.current
     agentCwdSourceRef.current = 'prop'
   }, [sessionId])

--- a/src/features/terminal/components/TerminalPane/agentCwdGuard.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdGuard.test.ts
@@ -1,0 +1,57 @@
+// cspell:ignore worktree worktrees
+import { describe, expect, test } from 'vitest'
+import {
+  isDescendantPath,
+  shouldIgnoreStaleOsc7Cwd,
+  stripCarriageReturnOverwrites,
+  toComparablePath,
+} from './agentCwdGuard'
+
+describe('agent cwd guard helpers', () => {
+  test('normalizes Windows separators for path comparisons', () => {
+    expect(toComparablePath('C:\\Users\\will\\repo')).toBe('C:/Users/will/repo')
+  })
+
+  test('detects descendant paths without treating equal paths as descendants', () => {
+    expect(isDescendantPath('/repo/worktree/child', '/repo/worktree')).toBe(
+      true
+    )
+    expect(isDescendantPath('/repo/worktree', '/repo/worktree')).toBe(false)
+  })
+
+  test('ignores stale OSC 7 ancestors after an agent text hint moves deeper', () => {
+    expect(
+      shouldIgnoreStaleOsc7Cwd(
+        '/repo/.claude/worktrees/test-branch/child',
+        '/repo/.claude/worktrees/test-branch',
+        'text-hint'
+      )
+    ).toBe(true)
+  })
+
+  test('ignores stale OSC 7 sibling worktrees after an agent text hint', () => {
+    expect(
+      shouldIgnoreStaleOsc7Cwd(
+        '/repo/.claude/worktrees/test-branch',
+        '/repo/.claude/worktrees/dummy',
+        'text-hint'
+      )
+    ).toBe(true)
+  })
+
+  test('allows shell-owned OSC 7 sibling worktrees after user input', () => {
+    expect(
+      shouldIgnoreStaleOsc7Cwd(
+        '/repo/.claude/worktrees/test-branch',
+        '/repo/.claude/worktrees/dummy',
+        'user-input'
+      )
+    ).toBe(false)
+  })
+
+  test('strips carriage-return progress output before hint parsing', () => {
+    expect(
+      stripCarriageReturnOverwrites('progress 10%\rprogress 20%\n! cd child')
+    ).toBe('progress 20%\n! cd child')
+  })
+})

--- a/src/features/terminal/components/TerminalPane/agentCwdGuard.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdGuard.ts
@@ -1,0 +1,98 @@
+// cspell:ignore worktree worktrees
+export type AgentCwdSource = 'osc7' | 'prop' | 'text-hint' | 'user-input'
+
+export const toComparablePath = (path: string): string =>
+  path.replace(/\\/g, '/')
+
+const trimTrailingSlashes = (path: string): string =>
+  path === '/' ? path : path.replace(/\/+$/g, '')
+
+export const isDescendantPath = (
+  path: string,
+  possibleParent: string
+): boolean => {
+  const normalizedPath = trimTrailingSlashes(toComparablePath(path))
+  const normalizedParent = trimTrailingSlashes(toComparablePath(possibleParent))
+
+  if (!normalizedParent) {
+    return false
+  }
+
+  if (normalizedParent === '/') {
+    return normalizedPath !== '/' && normalizedPath.startsWith('/')
+  }
+
+  return normalizedPath.startsWith(`${normalizedParent}/`)
+}
+
+const getWorktreeParentPath = (path: string): string | null => {
+  const normalizedPath = trimTrailingSlashes(toComparablePath(path))
+  const lastSeparatorIndex = normalizedPath.lastIndexOf('/')
+  if (lastSeparatorIndex === -1) {
+    return null
+  }
+
+  const parentPath = normalizedPath.slice(0, lastSeparatorIndex)
+  const parentName = parentPath.slice(parentPath.lastIndexOf('/') + 1)
+
+  const grandparentPath = parentPath.slice(0, parentPath.lastIndexOf('/'))
+
+  const grandparentName = grandparentPath.slice(
+    grandparentPath.lastIndexOf('/') + 1
+  )
+
+  return parentName === 'worktrees' && grandparentName === '.claude'
+    ? parentPath
+    : null
+}
+
+const isWorktreeSiblingPath = (
+  path: string,
+  possibleSibling: string
+): boolean => {
+  const normalizedPath = trimTrailingSlashes(toComparablePath(path))
+
+  const normalizedSibling = trimTrailingSlashes(
+    toComparablePath(possibleSibling)
+  )
+
+  const parentPath = getWorktreeParentPath(normalizedPath)
+
+  return (
+    normalizedPath !== normalizedSibling &&
+    parentPath !== null &&
+    parentPath === getWorktreeParentPath(normalizedSibling)
+  )
+}
+
+export const shouldIgnoreStaleOsc7Cwd = (
+  currentCwd: string,
+  nextCwd: string,
+  currentSource: AgentCwdSource
+): boolean =>
+  currentSource === 'text-hint' &&
+  (isDescendantPath(currentCwd, nextCwd) ||
+    isWorktreeSiblingPath(currentCwd, nextCwd))
+
+export const stripCarriageReturnOverwrites = (output: string): string =>
+  output
+    .split('\n')
+    .map((line, index, lines) => {
+      if (index === lines.length - 1) {
+        return line
+      }
+
+      const lineWithoutTerminator = line.endsWith('\r')
+        ? line.slice(0, -1)
+        : line
+
+      const overwriteIndex = lineWithoutTerminator.lastIndexOf('\r')
+
+      const visibleLine =
+        overwriteIndex === -1
+          ? lineWithoutTerminator
+          : lineWithoutTerminator.slice(overwriteIndex + 1)
+
+      return `${visibleLine}\n`
+    })
+    .join('')

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -1,6 +1,6 @@
 // cspell:ignore codex worktree worktrees
 import { describe, expect, test } from 'vitest'
-import { parseAgentCwdHint } from './agentCwdHint'
+import { getAgentCwdHintContext, parseAgentCwdHint } from './agentCwdHint'
 
 describe('parseAgentCwdHint', () => {
   test('extracts Claude EnterWorktree absolute path hints', () => {
@@ -69,6 +69,14 @@ describe('parseAgentCwdHint', () => {
     ).toBe(
       '/home/will/projects/vimeflow/.claude/worktrees/codex-agent-osc7-cwd'
     )
+  })
+
+  test('starts Claude startup context after a windows line ending', () => {
+    expect(
+      getAgentCwdHintContext(
+        'previous output\r\nClaude Code v2.1.145\r\n~/projects/vimeflow'
+      )
+    ).toBe('Claude Code v2.1.145\r\n~/projects/vimeflow')
   })
 
   test('ignores bare home paths outside the Claude startup banner', () => {

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -71,6 +71,19 @@ describe('parseAgentCwdHint', () => {
     )
   })
 
+  test('ignores bare home paths outside the Claude startup banner', () => {
+    expect(
+      parseAgentCwdHint('~/projects/vimeflow\r\n', '/home/will')
+    ).toBeNull()
+
+    expect(
+      parseAgentCwdHint(
+        'Here is a path example:\r\n~/projects/vimeflow\r\n',
+        '/home/will'
+      )
+    ).toBeNull()
+  })
+
   test('resolves home-relative Claude Bash cd commands', () => {
     expect(
       parseAgentCwdHint('! cd ~/projects/vimeflow\r\n', '/home/will')

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -68,6 +68,46 @@ describe('parseAgentCwdHint', () => {
     )
   })
 
+  test('resolves relative cd commands from a Windows forward-slash cwd', () => {
+    expect(
+      parseAgentCwdHint(
+        '! cd .claude/worktrees\r\n' + '! cd codex-agent-osc7-cwd\r\n',
+        'C:/Users/will/projects/vimeflow'
+      )
+    ).toBe(
+      'C:/Users/will/projects/vimeflow/.claude/worktrees/codex-agent-osc7-cwd'
+    )
+  })
+
+  test('resolves relative cd commands from a Windows backslash cwd', () => {
+    expect(
+      parseAgentCwdHint(
+        '! cd .claude\\worktrees\r\n' + '! cd codex-agent-osc7-cwd\r\n',
+        'C:\\Users\\will\\projects\\vimeflow'
+      )
+    ).toBe(
+      'C:\\Users\\will\\projects\\vimeflow\\.claude\\worktrees\\codex-agent-osc7-cwd'
+    )
+  })
+
+  test('accepts bare absolute Windows cd targets', () => {
+    expect(
+      parseAgentCwdHint(
+        '! cd C:\\Users\\will\\projects\\vimeflow\\.claude\\worktrees\\dummy\r\n',
+        'C:\\Users\\will\\projects\\vimeflow'
+      )
+    ).toBe('C:\\Users\\will\\projects\\vimeflow\\.claude\\worktrees\\dummy')
+  })
+
+  test('accepts quoted absolute Windows cd targets', () => {
+    expect(
+      parseAgentCwdHint(
+        '! cd "C:\\Users\\will\\projects\\vimeflow\\.claude\\worktrees\\dummy"\r\n',
+        'C:\\Users\\will\\projects\\vimeflow'
+      )
+    ).toBe('C:\\Users\\will\\projects\\vimeflow\\.claude\\worktrees\\dummy')
+  })
+
   test('uses reset narration as the final cwd when Claude rejects a cd', () => {
     expect(
       parseAgentCwdHint(

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -41,6 +41,18 @@ describe('parseAgentCwdHint', () => {
     ).toBe('/tmp/two')
   })
 
+  test('preserves POSIX UNC paths from agent cwd hints', () => {
+    expect(
+      parseAgentCwdHint('Entering worktree(//server/share/repo)\r\n')
+    ).toBe('//server/share/repo')
+
+    expect(parseAgentCwdHint('! cd //server/share/repo\r\n')).toBe(
+      '//server/share/repo'
+    )
+
+    expect(parseAgentCwdHint('! cd ///tmp/worktree\r\n')).toBe('/tmp/worktree')
+  })
+
   test('resolves Claude Bash cd commands from the current cwd', () => {
     expect(
       parseAgentCwdHint(

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -71,6 +71,23 @@ describe('parseAgentCwdHint', () => {
     )
   })
 
+  test('uses Claude startup home cwd with additional safe banner lines', () => {
+    expect(
+      parseAgentCwdHint(
+        'Claude Code v2.1.145\r\n' +
+          'Opus 4.7 with max effort\r\n' +
+          'Plan mode off\r\n' +
+          'Trusted workspace\r\n' +
+          'Session restored\r\n' +
+          '~/projects/vimeflow\r\n' +
+          '! cd .claude/worktrees/codex-agent-osc7-cwd\r\n',
+        '/home/will'
+      )
+    ).toBe(
+      '/home/will/projects/vimeflow/.claude/worktrees/codex-agent-osc7-cwd'
+    )
+  })
+
   test('starts Claude startup context after a windows line ending', () => {
     expect(
       getAgentCwdHintContext(

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -1,4 +1,4 @@
-// cspell:ignore worktree worktrees
+// cspell:ignore codex worktree worktrees
 import { describe, expect, test } from 'vitest'
 import { parseAgentCwdHint } from './agentCwdHint'
 
@@ -25,10 +25,54 @@ describe('parseAgentCwdHint', () => {
     ).toBe('/tmp/two')
   })
 
-  test('rejects shell cwd reset narration and relative paths', () => {
+  test('resolves Claude Bash cd commands from the current cwd', () => {
     expect(
-      parseAgentCwdHint('Shell cwd was reset to /home/will/projects/vimeflow')
-    ).toBeNull()
+      parseAgentCwdHint(
+        '! cd .claude/worktrees/\r\n' +
+          '(Bash completed with no output)\r\n' +
+          '! cd codex-agent-osc7-cwd\r\n' +
+          '(Bash completed with no output)\r\n',
+        '/home/will/projects/vimeflow'
+      )
+    ).toBe(
+      '/home/will/projects/vimeflow/.claude/worktrees/codex-agent-osc7-cwd'
+    )
+  })
+
+  test('resolves Codex CLI cd transcript lines from the current cwd', () => {
+    expect(
+      parseAgentCwdHint(
+        '• Ran cd .claude/worktrees && ls\r\n' +
+          '  └ codex-agent-osc7-cwd\r\n' +
+          '• Ran cd codex-agent-osc7-cwd\r\n',
+        '/home/will/projects/vimeflow'
+      )
+    ).toBe(
+      '/home/will/projects/vimeflow/.claude/worktrees/codex-agent-osc7-cwd'
+    )
+  })
+
+  test('uses reset narration as the final cwd when Claude rejects a cd', () => {
+    expect(
+      parseAgentCwdHint(
+        '! cd ../simple-tui\r\n' +
+          '(Bash completed with no output)\r\n' +
+          'Shell cwd was reset to /home/will/projects/vimeflow',
+        '/home/will/projects/vimeflow'
+      )
+    ).toBe('/home/will/projects/vimeflow')
+  })
+
+  test('rejects unsupported cwd hints', () => {
     expect(parseAgentCwdHint('Entering worktree(relative/path)')).toBeNull()
+    expect(parseAgentCwdHint('cd .claude/worktrees')).toBeNull()
+    expect(parseAgentCwdHint('! cd .claude/worktrees')).toBeNull()
+    expect(
+      parseAgentCwdHint('Ran cd .claude/worktrees', '/home/will/project')
+    ).toBeNull()
+
+    expect(
+      parseAgentCwdHint('$ cd .claude/worktrees', '/home/will/project')
+    ).toBeNull()
   })
 })

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -108,6 +108,15 @@ describe('parseAgentCwdHint', () => {
     ).toBe('C:\\Users\\will\\projects\\vimeflow\\.claude\\worktrees\\dummy')
   })
 
+  test('unescapes double backslashes in quoted Windows cd targets', () => {
+    expect(
+      parseAgentCwdHint(
+        '! cd "C:\\\\Users\\\\will\\\\projects\\\\vimeflow"\r\n',
+        'C:\\Users\\will'
+      )
+    ).toBe('C:\\Users\\will\\projects\\vimeflow')
+  })
+
   test('uses reset narration as the final cwd when Claude rejects a cd', () => {
     expect(
       parseAgentCwdHint(

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -67,6 +67,12 @@ describe('parseAgentCwdHint', () => {
     )
   })
 
+  test('resolves relative cd commands from POSIX UNC current cwd', () => {
+    expect(parseAgentCwdHint('! cd child\r\n', '//server/share/repo')).toBe(
+      '//server/share/repo/child'
+    )
+  })
+
   test('uses Claude startup home cwd before resolving relative worktree cd commands', () => {
     expect(
       parseAgentCwdHint(
@@ -91,6 +97,29 @@ describe('parseAgentCwdHint', () => {
           'Plan mode off\r\n' +
           'Trusted workspace\r\n' +
           'Session restored\r\n' +
+          '~/projects/vimeflow\r\n' +
+          '! cd .claude/worktrees/codex-agent-osc7-cwd\r\n',
+        '/home/will'
+      )
+    ).toBe(
+      '/home/will/projects/vimeflow/.claude/worktrees/codex-agent-osc7-cwd'
+    )
+  })
+
+  test('keeps additional safe Claude startup lines across chunks', () => {
+    const context = getAgentCwdHintContext(
+      'Claude Code v2.1.145\r\n' +
+        'Opus 4.7 with max effort\r\n' +
+        'Plan mode off\r\n' +
+        'Trusted workspace\r\n' +
+        'Session restored\r\n' +
+        'Loaded tools\r\n' +
+        'Ready\r\n'
+    )
+
+    expect(
+      parseAgentCwdHint(
+        context +
           '~/projects/vimeflow\r\n' +
           '! cd .claude/worktrees/codex-agent-osc7-cwd\r\n',
         '/home/will'

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -1,0 +1,34 @@
+// cspell:ignore worktree worktrees
+import { describe, expect, test } from 'vitest'
+import { parseAgentCwdHint } from './agentCwdHint'
+
+describe('parseAgentCwdHint', () => {
+  test('extracts Claude EnterWorktree absolute path hints', () => {
+    expect(
+      parseAgentCwdHint(
+        '● Entering worktree(/home/will/projects/vimeflow/.claude/worktrees/dummy)\r\n'
+      )
+    ).toBe('/home/will/projects/vimeflow/.claude/worktrees/dummy')
+  })
+
+  test('handles ANSI styled Claude output', () => {
+    expect(
+      parseAgentCwdHint('\x1b[34m●\x1b[0m Entering worktree(/tmp/dummy)\r\n')
+    ).toBe('/tmp/dummy')
+  })
+
+  test('returns the latest valid worktree path in a chunk', () => {
+    expect(
+      parseAgentCwdHint(
+        'Entering worktree(/tmp/one)\r\nSwitched\r\nEntering worktree(/tmp/two)'
+      )
+    ).toBe('/tmp/two')
+  })
+
+  test('rejects shell cwd reset narration and relative paths', () => {
+    expect(
+      parseAgentCwdHint('Shell cwd was reset to /home/will/projects/vimeflow')
+    ).toBeNull()
+    expect(parseAgentCwdHint('Entering worktree(relative/path)')).toBeNull()
+  })
+})

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -17,6 +17,22 @@ describe('parseAgentCwdHint', () => {
     ).toBe('/tmp/dummy')
   })
 
+  test('strips OSC sequences before parsing Claude output', () => {
+    expect(
+      parseAgentCwdHint(
+        '\x1b]7;file://host/ignored\x07● Entering worktree(/tmp/dummy)\r\n'
+      )
+    ).toBe('/tmp/dummy')
+  })
+
+  test('preserves closing parens inside Claude worktree paths', () => {
+    expect(
+      parseAgentCwdHint(
+        'Entering worktree(/home/user/.claude/worktrees/feature/(org)-fix)\r\n'
+      )
+    ).toBe('/home/user/.claude/worktrees/feature/(org)-fix')
+  })
+
   test('returns the latest valid worktree path in a chunk', () => {
     expect(
       parseAgentCwdHint(

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -163,6 +163,15 @@ describe('parseAgentCwdHint', () => {
     ).toBe('/home/will/projects/vimeflow')
   })
 
+  test('ignores reset narration trailing context after the cwd path', () => {
+    expect(
+      parseAgentCwdHint(
+        'Shell cwd was reset to /home/will/projects/vimeflow (previous: /tmp)',
+        '/tmp'
+      )
+    ).toBe('/home/will/projects/vimeflow')
+  })
+
   test('rejects unsupported cwd hints', () => {
     expect(parseAgentCwdHint('Entering worktree(relative/path)')).toBeNull()
     expect(parseAgentCwdHint('cd .claude/worktrees')).toBeNull()

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.test.ts
@@ -55,6 +55,28 @@ describe('parseAgentCwdHint', () => {
     )
   })
 
+  test('uses Claude startup home cwd before resolving relative worktree cd commands', () => {
+    expect(
+      parseAgentCwdHint(
+        'Claude Code v2.1.145\r\n' +
+          'Opus 4.7 with max effort\r\n' +
+          '~/projects/vimeflow\r\n' +
+          '! cd .claude/worktrees/\r\n' +
+          '(Bash completed with no output)\r\n' +
+          '! cd codex-agent-osc7-cwd\r\n',
+        '/home/will'
+      )
+    ).toBe(
+      '/home/will/projects/vimeflow/.claude/worktrees/codex-agent-osc7-cwd'
+    )
+  })
+
+  test('resolves home-relative Claude Bash cd commands', () => {
+    expect(
+      parseAgentCwdHint('! cd ~/projects/vimeflow\r\n', '/home/will')
+    ).toBe('/home/will/projects/vimeflow')
+  })
+
   test('resolves Codex CLI cd transcript lines from the current cwd', () => {
     expect(
       parseAgentCwdHint(

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -108,11 +108,13 @@ const parseCdTarget = (rawCommand: string | undefined): string | null => {
 }
 
 const normalizePath = (path: string): string =>
-  path.startsWith('/')
-    ? normalizePosixPath(path)
-    : WINDOWS_DRIVE_PATH.test(path)
-      ? normalizeWindowsDrivePath(path)
-      : path
+  path.startsWith('//') && !path.startsWith('///')
+    ? path
+    : path.startsWith('/')
+      ? normalizePosixPath(path)
+      : WINDOWS_DRIVE_PATH.test(path)
+        ? normalizeWindowsDrivePath(path)
+        : path
 
 const posixHomeFromCwd = (currentCwd: string): string | null => {
   const match = /^\/(?:home|Users)\/[^/]+/.exec(currentCwd)

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -1,0 +1,27 @@
+// cspell:ignore WORKTREE
+import { parseOsc7Cwd } from './osc7'
+
+const ANSI_ESCAPE_PATTERN =
+  /\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][\s\S]*?(?:\x07|\x1b\\))/g
+
+const CLAUDE_WORKTREE_PATTERN =
+  /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Entering worktree\(([^)\r\n]+)\)/g
+
+export const parseAgentCwdHint = (data: string): string | null => {
+  const normalizedData = data.replace(ANSI_ESCAPE_PATTERN, '')
+  let latestPath: string | null = null
+
+  for (const match of normalizedData.matchAll(CLAUDE_WORKTREE_PATTERN)) {
+    const rawPath = match[1].trim()
+    if (!rawPath) {
+      continue
+    }
+
+    const path = parseOsc7Cwd(rawPath)
+    if (path) {
+      latestPath = path
+    }
+  }
+
+  return latestPath
+}

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -11,7 +11,7 @@ const AGENT_CD_PATTERN =
   /(?:^|[\r\n])(?:[^\S\r\n]*(?:!\s*|[^\w\s(/\\:!$]+[^\S\r\n]*Ran\s+))cd(?:[ \t]+([^\r\n]+?))?[ \t]*(?=$|[\r\n])/g
 
 const CLAUDE_CWD_RESET_PATTERN =
-  /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Shell cwd was reset to ([^\r\n]+)/g
+  /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Shell cwd was reset to (\S+)/g
 
 const CLAUDE_STARTUP_HOME_CWD_PATTERN =
   /(?:^|[\r\n])[^\S\r\n]*(~[\\/][^\r\n]+?)[ \t]*(?=$|[\r\n])/g

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -13,8 +13,11 @@ const AGENT_CD_PATTERN =
 const CLAUDE_CWD_RESET_PATTERN =
   /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Shell cwd was reset to ([^\r\n]+)/g
 
+const AGENT_HOME_CWD_PATTERN =
+  /(?:^|[\r\n])[^\S\r\n]*(~[\\/][^\r\n]+?)[ \t]*(?=$|[\r\n])/g
+
 type CwdEvent =
-  | { index: number; kind: 'absolute'; path: string }
+  | { index: number; kind: 'path'; path: string }
   | { index: number; kind: 'cd'; target: string }
 
 const readQuotedTarget = (
@@ -69,7 +72,7 @@ const readBareTarget = (
 
 const parseCdTarget = (rawCommand: string | undefined): string | null => {
   const source = rawCommand?.trim()
-  if (!source || source === '-' || source.startsWith('~')) {
+  if (!source || source === '-' || source === '~' || /^~[^\\/]/.test(source)) {
     return null
   }
 
@@ -146,10 +149,62 @@ const normalizePath = (path: string): string =>
       ? normalizeWindowsDrivePath(path)
       : path
 
+const posixHomeFromCwd = (currentCwd: string): string | null => {
+  const match = /^\/(?:home|Users)\/[^/]+/.exec(currentCwd)
+
+  return match?.[0] ?? null
+}
+
+const windowsHomeFromCwd = (currentCwd: string): string | null => {
+  const match = /^[A-Za-z]:[\\/]Users[\\/][^\\/]+/.exec(currentCwd)
+
+  return match?.[0] ?? null
+}
+
+const resolveHomePath = (path: string, currentCwd?: string): string | null => {
+  if (!currentCwd || (!path.startsWith('~/') && !path.startsWith('~\\'))) {
+    return null
+  }
+
+  const currentHome = currentCwd.startsWith('/')
+    ? posixHomeFromCwd(currentCwd)
+    : WINDOWS_DRIVE_PATH.test(currentCwd)
+      ? windowsHomeFromCwd(currentCwd)
+      : null
+
+  if (!currentHome) {
+    return null
+  }
+
+  const suffix = path.slice(2)
+  if (currentHome.startsWith('/')) {
+    return `${currentHome}/${suffix.replace(/\\/g, '/')}`
+  }
+
+  const separator =
+    currentHome.includes('\\') && !currentHome.includes('/') ? '\\' : '/'
+
+  return `${currentHome}${separator}${suffix}`
+}
+
+const resolvePathHint = (path: string, currentCwd?: string): string | null => {
+  const absolutePath = parseOsc7Cwd(path)
+  if (absolutePath) {
+    return normalizePath(absolutePath)
+  }
+
+  const homePath = resolveHomePath(path, currentCwd)
+  if (homePath) {
+    return normalizePath(homePath)
+  }
+
+  return null
+}
+
 const resolveCdPath = (target: string, currentCwd?: string): string | null => {
-  const absoluteTarget = parseOsc7Cwd(target)
-  if (absoluteTarget) {
-    return normalizePath(absoluteTarget)
+  const pathHint = resolvePathHint(target, currentCwd)
+  if (pathHint) {
+    return pathHint
   }
 
   if (currentCwd?.startsWith('/')) {
@@ -179,17 +234,15 @@ export const parseAgentCwdHint = (
       continue
     }
 
-    const path = parseOsc7Cwd(rawPath)
-    if (path) {
-      events.push({ index: match.index, kind: 'absolute', path })
-    }
+    events.push({ index: match.index, kind: 'path', path: rawPath })
   }
 
   for (const match of normalizedData.matchAll(CLAUDE_CWD_RESET_PATTERN)) {
-    const path = parseOsc7Cwd(match[1].trim())
-    if (path) {
-      events.push({ index: match.index, kind: 'absolute', path })
-    }
+    events.push({ index: match.index, kind: 'path', path: match[1].trim() })
+  }
+
+  for (const match of normalizedData.matchAll(AGENT_HOME_CWD_PATTERN)) {
+    events.push({ index: match.index, kind: 'path', path: match[1].trim() })
   }
 
   for (const match of normalizedData.matchAll(AGENT_CD_PATTERN)) {
@@ -206,8 +259,8 @@ export const parseAgentCwdHint = (
 
   for (const event of events) {
     const path =
-      event.kind === 'absolute'
-        ? normalizePath(event.path)
+      event.kind === 'path'
+        ? resolvePathHint(event.path, nextCwd)
         : resolveCdPath(event.target, nextCwd)
 
     if (path) {

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -4,6 +4,8 @@ import { parseOsc7Cwd } from './osc7'
 const ANSI_ESCAPE_PATTERN =
   /\x1b(?:\][\s\S]*?(?:\x07|\x1b\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])/g
 
+const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
+
 const CLAUDE_WORKTREE_PATTERN =
   /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Entering worktree\(([^\r\n]+)\)[ \t]*(?=$|[\r\n])/g
 
@@ -32,7 +34,7 @@ const readQuotedTarget = (
 
     if (quote === '"' && char === '\\') {
       const next = source[index + 1]
-      if (next) {
+      if (next && !/[\\A-Za-z0-9._-]/.test(next)) {
         target = `${target}${next}`
         index += 1
 
@@ -55,7 +57,7 @@ const readBareTarget = (
   }
 
   return {
-    target: match[1].replace(/\\(.)/g, '$1'),
+    target: match[1].replace(/\\([^\\A-Za-z0-9._-])/g, '$1'),
     rest: match[2],
   }
 }
@@ -103,8 +105,37 @@ const normalizePosixPath = (path: string): string => {
   return `/${parts.join('/')}`
 }
 
+const normalizeWindowsDrivePath = (path: string): string => {
+  const separator = path.includes('\\') && !path.includes('/') ? '\\' : '/'
+  const slashPath = path.replace(/\\/g, '/')
+  const drive = slashPath.slice(0, 2)
+  const parts: string[] = []
+
+  for (const part of slashPath.slice(2).split('/')) {
+    if (!part || part === '.') {
+      continue
+    }
+
+    if (part === '..') {
+      parts.pop()
+
+      continue
+    }
+
+    parts.push(part)
+  }
+
+  const normalized = `${drive}/${parts.join('/')}`
+
+  return separator === '\\' ? normalized.replace(/\//g, '\\') : normalized
+}
+
 const normalizePath = (path: string): string =>
-  path.startsWith('/') ? normalizePosixPath(path) : path
+  path.startsWith('/')
+    ? normalizePosixPath(path)
+    : WINDOWS_DRIVE_PATH.test(path)
+      ? normalizeWindowsDrivePath(path)
+      : path
 
 const resolveCdPath = (target: string, currentCwd?: string): string | null => {
   const absoluteTarget = parseOsc7Cwd(target)
@@ -112,11 +143,18 @@ const resolveCdPath = (target: string, currentCwd?: string): string | null => {
     return normalizePath(absoluteTarget)
   }
 
-  if (!currentCwd?.startsWith('/')) {
-    return null
+  if (currentCwd?.startsWith('/')) {
+    return normalizePosixPath(`${currentCwd}/${target}`)
   }
 
-  return normalizePosixPath(`${currentCwd}/${target}`)
+  if (currentCwd && WINDOWS_DRIVE_PATH.test(currentCwd)) {
+    const separator =
+      currentCwd.includes('\\') && !currentCwd.includes('/') ? '\\' : '/'
+
+    return normalizeWindowsDrivePath(`${currentCwd}${separator}${target}`)
+  }
+
+  return null
 }
 
 export const parseAgentCwdHint = (

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -26,6 +26,8 @@ const CLAUDE_STARTUP_HEADER_PATTERN = /^Claude Code v\d/
 const CLAUDE_STARTUP_CONTEXT_HEADER_PATTERN =
   /(?:^|[\r\n])Claude Code v\d[^\r\n]*/g
 
+const CLAUDE_STARTUP_MAX_CONTEXT_LINES = 6
+
 type CwdEvent =
   | { index: number; kind: 'path'; path: string }
   | { index: number; kind: 'cd'; target: string }
@@ -175,7 +177,7 @@ const resolveCdPath = (target: string, currentCwd?: string): string | null => {
   }
 
   if (currentCwd?.startsWith('/')) {
-    return normalizePosixPath(`${currentCwd}/${target}`)
+    return normalizePath(`${currentCwd}/${target}`)
   }
 
   if (currentCwd && WINDOWS_DRIVE_PATH.test(currentCwd)) {
@@ -221,7 +223,7 @@ const isClaudeStartupHomeCwd = (data: string, index: number): boolean => {
   const startupLines = lines.slice(headerIndex + 1)
 
   return (
-    startupLines.length <= 6 &&
+    startupLines.length <= CLAUDE_STARTUP_MAX_CONTEXT_LINES &&
     startupLines.every((line) => isSafeClaudeStartupLine(line))
   )
 }
@@ -249,7 +251,7 @@ export const getAgentCwdHintContext = (data: string): string => {
     .filter(Boolean)
 
   if (
-    startupLines.length > 3 ||
+    startupLines.length > CLAUDE_STARTUP_MAX_CONTEXT_LINES ||
     startupLines.some((line) => !isSafeClaudeStartupLine(line))
   ) {
     return ''

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -1,10 +1,8 @@
 // cspell:ignore WORKTREE
-import { parseOsc7Cwd } from './osc7'
+import { parseOsc7Cwd, WINDOWS_DRIVE_PATH } from './osc7'
 
 const ANSI_ESCAPE_PATTERN =
   /\x1b(?:\][\s\S]*?(?:\x07|\x1b\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])/g
-
-const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
 
 const CLAUDE_WORKTREE_PATTERN =
   /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Entering worktree\(([^\r\n]+)\)[ \t]*(?=$|[\r\n])/g
@@ -34,6 +32,13 @@ const readQuotedTarget = (
 
     if (quote === '"' && char === '\\') {
       const next = source[index + 1]
+      if (next === '\\') {
+        target = `${target}\\`
+        index += 1
+
+        continue
+      }
+
       if (next && !/[\\A-Za-z0-9._-]/.test(next)) {
         target = `${target}${next}`
         index += 1

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -13,7 +13,7 @@ const AGENT_CD_PATTERN =
 const CLAUDE_CWD_RESET_PATTERN =
   /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Shell cwd was reset to ([^\r\n]+)/g
 
-const AGENT_HOME_CWD_PATTERN =
+const CLAUDE_STARTUP_HOME_CWD_PATTERN =
   /(?:^|[\r\n])[^\S\r\n]*(~[\\/][^\r\n]+?)[ \t]*(?=$|[\r\n])/g
 
 const CLAUDE_STARTUP_HEADER_PATTERN = /^Claude Code v\d/
@@ -281,7 +281,9 @@ export const parseAgentCwdHint = (
     events.push({ index: match.index, kind: 'path', path: match[1].trim() })
   }
 
-  for (const match of normalizedData.matchAll(AGENT_HOME_CWD_PATTERN)) {
+  for (const match of normalizedData.matchAll(
+    CLAUDE_STARTUP_HOME_CWD_PATTERN
+  )) {
     if (!isClaudeStartupHomeCwd(normalizedData, match.index)) {
       continue
     }

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -7,9 +7,124 @@ const ANSI_ESCAPE_PATTERN =
 const CLAUDE_WORKTREE_PATTERN =
   /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Entering worktree\(([^)\r\n]+)\)/g
 
-export const parseAgentCwdHint = (data: string): string | null => {
+const AGENT_CD_PATTERN =
+  /(?:^|[\r\n])(?:[^\S\r\n]*(?:!\s*|[^\w\s(/\\:!$]+[^\S\r\n]*Ran\s+))cd(?:[ \t]+([^\r\n]+?))?[ \t]*(?=$|[\r\n])/g
+
+const CLAUDE_CWD_RESET_PATTERN =
+  /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Shell cwd was reset to ([^\r\n]+)/g
+
+type CwdEvent =
+  | { index: number; kind: 'absolute'; path: string }
+  | { index: number; kind: 'cd'; target: string }
+
+const readQuotedTarget = (
+  source: string,
+  quote: '"' | "'"
+): { target: string; rest: string } | null => {
+  let target = ''
+
+  for (let index = 1; index < source.length; index += 1) {
+    const char = source[index]
+
+    if (char === quote) {
+      return { target, rest: source.slice(index + 1) }
+    }
+
+    if (quote === '"' && char === '\\') {
+      const next = source[index + 1]
+      if (next) {
+        target = `${target}${next}`
+        index += 1
+
+        continue
+      }
+    }
+
+    target = `${target}${char}`
+  }
+
+  return null
+}
+
+const readBareTarget = (
+  source: string
+): { target: string; rest: string } | null => {
+  const match = /^((?:\\.|[^\s])+)(.*)$/.exec(source)
+  if (!match) {
+    return null
+  }
+
+  return {
+    target: match[1].replace(/\\(.)/g, '$1'),
+    rest: match[2],
+  }
+}
+
+const parseCdTarget = (rawCommand: string | undefined): string | null => {
+  const source = rawCommand?.trim()
+  if (!source || source === '-' || source.startsWith('~')) {
+    return null
+  }
+
+  const parsed =
+    source.startsWith("'") || source.startsWith('"')
+      ? readQuotedTarget(source, source[0] as '"' | "'")
+      : readBareTarget(source)
+
+  if (!parsed || parsed.rest.trim()) {
+    const rest = parsed?.rest.trim()
+    if (!rest || rest.startsWith('&&') || rest.startsWith(';')) {
+      return parsed?.target ?? null
+    }
+
+    return null
+  }
+
+  return parsed.target
+}
+
+const normalizePosixPath = (path: string): string => {
+  const parts: string[] = []
+
+  for (const part of path.split('/')) {
+    if (!part || part === '.') {
+      continue
+    }
+
+    if (part === '..') {
+      parts.pop()
+
+      continue
+    }
+
+    parts.push(part)
+  }
+
+  return `/${parts.join('/')}`
+}
+
+const normalizePath = (path: string): string =>
+  path.startsWith('/') ? normalizePosixPath(path) : path
+
+const resolveCdPath = (target: string, currentCwd?: string): string | null => {
+  const absoluteTarget = parseOsc7Cwd(target)
+  if (absoluteTarget) {
+    return normalizePath(absoluteTarget)
+  }
+
+  if (!currentCwd?.startsWith('/')) {
+    return null
+  }
+
+  return normalizePosixPath(`${currentCwd}/${target}`)
+}
+
+export const parseAgentCwdHint = (
+  data: string,
+  currentCwd?: string
+): string | null => {
   const normalizedData = data.replace(ANSI_ESCAPE_PATTERN, '')
-  let latestPath: string | null = null
+  const events: CwdEvent[] = []
 
   for (const match of normalizedData.matchAll(CLAUDE_WORKTREE_PATTERN)) {
     const rawPath = match[1].trim()
@@ -19,6 +134,37 @@ export const parseAgentCwdHint = (data: string): string | null => {
 
     const path = parseOsc7Cwd(rawPath)
     if (path) {
+      events.push({ index: match.index, kind: 'absolute', path })
+    }
+  }
+
+  for (const match of normalizedData.matchAll(CLAUDE_CWD_RESET_PATTERN)) {
+    const path = parseOsc7Cwd(match[1].trim())
+    if (path) {
+      events.push({ index: match.index, kind: 'absolute', path })
+    }
+  }
+
+  for (const match of normalizedData.matchAll(AGENT_CD_PATTERN)) {
+    const target = parseCdTarget(match[1])
+    if (target) {
+      events.push({ index: match.index, kind: 'cd', target })
+    }
+  }
+
+  events.sort((first, second) => first.index - second.index)
+
+  let nextCwd = currentCwd
+  let latestPath: string | null = null
+
+  for (const event of events) {
+    const path =
+      event.kind === 'absolute'
+        ? normalizePath(event.path)
+        : resolveCdPath(event.target, nextCwd)
+
+    if (path) {
+      nextCwd = path
       latestPath = path
     }
   }

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -16,6 +16,8 @@ const CLAUDE_CWD_RESET_PATTERN =
 const AGENT_HOME_CWD_PATTERN =
   /(?:^|[\r\n])[^\S\r\n]*(~[\\/][^\r\n]+?)[ \t]*(?=$|[\r\n])/g
 
+const CLAUDE_STARTUP_HEADER_PATTERN = /^Claude Code v\d/
+
 type CwdEvent =
   | { index: number; kind: 'path'; path: string }
   | { index: number; kind: 'cd'; target: string }
@@ -221,6 +223,44 @@ const resolveCdPath = (target: string, currentCwd?: string): string | null => {
   return null
 }
 
+const nonEmptyLinesBefore = (data: string, index: number): string[] =>
+  data
+    .slice(0, index)
+    .split(/\r\n|\r|\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+const isClaudeStartupHomeCwd = (data: string, index: number): boolean => {
+  const lines = nonEmptyLinesBefore(data, index)
+  let headerIndex = -1
+
+  for (let lineIndex = lines.length - 1; lineIndex >= 0; lineIndex -= 1) {
+    if (CLAUDE_STARTUP_HEADER_PATTERN.test(lines[lineIndex])) {
+      headerIndex = lineIndex
+
+      break
+    }
+  }
+
+  if (headerIndex === -1) {
+    return false
+  }
+
+  const startupLines = lines.slice(headerIndex + 1)
+
+  return (
+    startupLines.length <= 3 &&
+    startupLines.every(
+      (line) =>
+        !line.startsWith('!') &&
+        !line.startsWith('$') &&
+        !line.includes('Entering worktree') &&
+        !line.includes('Shell cwd was reset to') &&
+        !line.includes('Ran cd ')
+    )
+  )
+}
+
 export const parseAgentCwdHint = (
   data: string,
   currentCwd?: string
@@ -242,6 +282,10 @@ export const parseAgentCwdHint = (
   }
 
   for (const match of normalizedData.matchAll(AGENT_HOME_CWD_PATTERN)) {
+    if (!isClaudeStartupHomeCwd(normalizedData, match.index)) {
+      continue
+    }
+
     events.push({ index: match.index, kind: 'path', path: match[1].trim() })
   }
 

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -73,10 +73,14 @@ const parseCdTarget = (rawCommand: string | undefined): string | null => {
       ? readQuotedTarget(source, source[0] as '"' | "'")
       : readBareTarget(source)
 
-  if (!parsed || parsed.rest.trim()) {
-    const rest = parsed?.rest.trim()
-    if (!rest || rest.startsWith('&&') || rest.startsWith(';')) {
-      return parsed?.target ?? null
+  if (!parsed) {
+    return null
+  }
+
+  if (parsed.rest.trim()) {
+    const rest = parsed.rest.trim()
+    if (rest.startsWith('&&') || rest.startsWith(';')) {
+      return parsed.target
     }
 
     return null

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -1,5 +1,10 @@
 // cspell:ignore WORKTREE
-import { parseOsc7Cwd, WINDOWS_DRIVE_PATH } from './osc7'
+import {
+  normalizePosixPath,
+  normalizeWindowsDrivePath,
+  parseOsc7Cwd,
+  WINDOWS_DRIVE_PATH,
+} from './osc7'
 
 const ANSI_ESCAPE_PATTERN =
   /\x1b(?:\][\s\S]*?(?:\x07|\x1b\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])/g
@@ -100,51 +105,6 @@ const parseCdTarget = (rawCommand: string | undefined): string | null => {
   }
 
   return parsed.target
-}
-
-const normalizePosixPath = (path: string): string => {
-  const parts: string[] = []
-
-  for (const part of path.split('/')) {
-    if (!part || part === '.') {
-      continue
-    }
-
-    if (part === '..') {
-      parts.pop()
-
-      continue
-    }
-
-    parts.push(part)
-  }
-
-  return `/${parts.join('/')}`
-}
-
-const normalizeWindowsDrivePath = (path: string): string => {
-  const separator = path.includes('\\') && !path.includes('/') ? '\\' : '/'
-  const slashPath = path.replace(/\\/g, '/')
-  const drive = slashPath.slice(0, 2)
-  const parts: string[] = []
-
-  for (const part of slashPath.slice(2).split('/')) {
-    if (!part || part === '.') {
-      continue
-    }
-
-    if (part === '..') {
-      parts.pop()
-
-      continue
-    }
-
-    parts.push(part)
-  }
-
-  const normalized = `${drive}/${parts.join('/')}`
-
-  return separator === '\\' ? normalized.replace(/\//g, '\\') : normalized
 }
 
 const normalizePath = (path: string): string =>
@@ -271,7 +231,7 @@ export const getAgentCwdHintContext = (data: string): string => {
   for (const match of normalizedData.matchAll(
     CLAUDE_STARTUP_CONTEXT_HEADER_PATTERN
   )) {
-    headerStart = match.index + (match[0].startsWith('Claude Code') ? 0 : 1)
+    headerStart = match.index + match[0].indexOf('Claude Code')
   }
 
   if (headerStart === -1) {

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -18,6 +18,9 @@ const CLAUDE_STARTUP_HOME_CWD_PATTERN =
 
 const CLAUDE_STARTUP_HEADER_PATTERN = /^Claude Code v\d/
 
+const CLAUDE_STARTUP_CONTEXT_HEADER_PATTERN =
+  /(?:^|[\r\n])Claude Code v\d[^\r\n]*/g
+
 type CwdEvent =
   | { index: number; kind: 'path'; path: string }
   | { index: number; kind: 'cd'; target: string }
@@ -230,6 +233,13 @@ const nonEmptyLinesBefore = (data: string, index: number): string[] =>
     .map((line) => line.trim())
     .filter(Boolean)
 
+const isSafeClaudeStartupLine = (line: string): boolean =>
+  !line.startsWith('!') &&
+  !line.startsWith('$') &&
+  !line.includes('Entering worktree') &&
+  !line.includes('Shell cwd was reset to') &&
+  !line.includes('Ran cd ')
+
 const isClaudeStartupHomeCwd = (data: string, index: number): boolean => {
   const lines = nonEmptyLinesBefore(data, index)
   let headerIndex = -1
@@ -250,15 +260,40 @@ const isClaudeStartupHomeCwd = (data: string, index: number): boolean => {
 
   return (
     startupLines.length <= 3 &&
-    startupLines.every(
-      (line) =>
-        !line.startsWith('!') &&
-        !line.startsWith('$') &&
-        !line.includes('Entering worktree') &&
-        !line.includes('Shell cwd was reset to') &&
-        !line.includes('Ran cd ')
-    )
+    startupLines.every((line) => isSafeClaudeStartupLine(line))
   )
+}
+
+export const getAgentCwdHintContext = (data: string): string => {
+  const normalizedData = data.replace(ANSI_ESCAPE_PATTERN, '')
+  let headerStart = -1
+
+  for (const match of normalizedData.matchAll(
+    CLAUDE_STARTUP_CONTEXT_HEADER_PATTERN
+  )) {
+    headerStart = match.index + (match[0].startsWith('Claude Code') ? 0 : 1)
+  }
+
+  if (headerStart === -1) {
+    return ''
+  }
+
+  const context = normalizedData.slice(headerStart)
+
+  const startupLines = context
+    .split(/\r\n|\r|\n/)
+    .slice(1)
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+  if (
+    startupLines.length > 3 ||
+    startupLines.some((line) => !isSafeClaudeStartupLine(line))
+  ) {
+    return ''
+  }
+
+  return context
 }
 
 export const parseAgentCwdHint = (

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -2,10 +2,10 @@
 import { parseOsc7Cwd } from './osc7'
 
 const ANSI_ESCAPE_PATTERN =
-  /\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][\s\S]*?(?:\x07|\x1b\\))/g
+  /\x1b(?:\][\s\S]*?(?:\x07|\x1b\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])/g
 
 const CLAUDE_WORKTREE_PATTERN =
-  /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Entering worktree\(([^)\r\n]+)\)/g
+  /(?:^|[\r\n])(?:[^\S\r\n]*(?:[^\w\s(/\\:]+[^\S\r\n]*)?)Entering worktree\(([^\r\n]+)\)[ \t]*(?=$|[\r\n])/g
 
 const AGENT_CD_PATTERN =
   /(?:^|[\r\n])(?:[^\S\r\n]*(?:!\s*|[^\w\s(/\\:!$]+[^\S\r\n]*Ran\s+))cd(?:[ \t]+([^\r\n]+?))?[ \t]*(?=$|[\r\n])/g

--- a/src/features/terminal/components/TerminalPane/agentCwdHint.ts
+++ b/src/features/terminal/components/TerminalPane/agentCwdHint.ts
@@ -219,7 +219,7 @@ const isClaudeStartupHomeCwd = (data: string, index: number): boolean => {
   const startupLines = lines.slice(headerIndex + 1)
 
   return (
-    startupLines.length <= 3 &&
+    startupLines.length <= 6 &&
     startupLines.every((line) => isSafeClaudeStartupLine(line))
   )
 }

--- a/src/features/terminal/components/TerminalPane/osc7.test.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.test.ts
@@ -14,13 +14,15 @@ describe('parseOsc7Cwd', () => {
   })
 
   test('decodes URL-encoded path characters', () => {
-    expect(parseOsc7Cwd('file://host/home/user/my%20project')).toBe(
+    expect(parseOsc7Cwd('file://localhost/home/user/my%20project')).toBe(
       '/home/user/my project'
     )
   })
 
   test('keeps malformed percent escapes instead of dropping the cwd update', () => {
-    expect(parseOsc7Cwd('file://host/home/user/100%')).toBe('/home/user/100%')
+    expect(parseOsc7Cwd('file://localhost/home/user/100%')).toBe(
+      '/home/user/100%'
+    )
   })
 
   test('normalizes Windows drive paths from file URLs', () => {
@@ -30,7 +32,7 @@ describe('parseOsc7Cwd', () => {
   })
 
   test('keeps POSIX paths with a colon in the first segment absolute', () => {
-    expect(parseOsc7Cwd('file://host/a:repo')).toBe('/a:repo')
+    expect(parseOsc7Cwd('file://localhost/a:repo')).toBe('/a:repo')
   })
 
   test('accepts plain absolute fallback paths', () => {
@@ -51,6 +53,20 @@ describe('parseOsc7Cwd', () => {
     expect(parseOsc7Cwd('file://host//server/share')).toBe('//server/share')
     expect(parseOsc7Cwd('//server/share')).toBe('//server/share')
     expect(parseOsc7Cwd('///tmp/worktree')).toBe('/tmp/worktree')
+  })
+
+  test('preserves non-local file URL hostnames as UNC paths', () => {
+    expect(parseOsc7Cwd('file://server/share/project')).toBe(
+      '//server/share/project'
+    )
+  })
+
+  test('can ignore non-local file URL hostnames for POSIX OSC 7 emitters', () => {
+    expect(
+      parseOsc7Cwd('file://workstation/home/user/my%20project', {
+        preserveFileUrlHost: false,
+      })
+    ).toBe('/home/user/my project')
   })
 
   test('rejects non-file URLs and relative paths', () => {

--- a/src/features/terminal/components/TerminalPane/osc7.test.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.test.ts
@@ -47,6 +47,12 @@ describe('parseOsc7Cwd', () => {
     )
   })
 
+  test('preserves POSIX UNC double-slash prefixes', () => {
+    expect(parseOsc7Cwd('file://host//server/share')).toBe('//server/share')
+    expect(parseOsc7Cwd('//server/share')).toBe('//server/share')
+    expect(parseOsc7Cwd('///tmp/worktree')).toBe('/tmp/worktree')
+  })
+
   test('rejects non-file URLs and relative paths', () => {
     expect(parseOsc7Cwd('https://example.com/home/user')).toBeNull()
     expect(parseOsc7Cwd('relative/path')).toBeNull()

--- a/src/features/terminal/components/TerminalPane/osc7.test.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.test.ts
@@ -1,0 +1,43 @@
+// cspell:ignore hostless worktree
+import { describe, expect, test } from 'vitest'
+import { parseOsc7Cwd } from './osc7'
+
+describe('parseOsc7Cwd', () => {
+  test('parses a POSIX file URL emitted by OSC 7', () => {
+    expect(parseOsc7Cwd('file://localhost/home/user/project')).toBe(
+      '/home/user/project'
+    )
+  })
+
+  test('parses a hostless POSIX file URL', () => {
+    expect(parseOsc7Cwd('file:///home/user/project')).toBe('/home/user/project')
+  })
+
+  test('decodes URL-encoded path characters', () => {
+    expect(parseOsc7Cwd('file://host/home/user/my%20project')).toBe(
+      '/home/user/my project'
+    )
+  })
+
+  test('keeps malformed percent escapes instead of dropping the cwd update', () => {
+    expect(parseOsc7Cwd('file://host/home/user/100%')).toBe('/home/user/100%')
+  })
+
+  test('normalizes Windows drive paths from file URLs', () => {
+    expect(parseOsc7Cwd('file://host/C:/Users/will/project')).toBe(
+      'C:/Users/will/project'
+    )
+  })
+
+  test('accepts plain absolute fallback paths', () => {
+    expect(parseOsc7Cwd('/tmp/worktree')).toBe('/tmp/worktree')
+    expect(parseOsc7Cwd('C:\\Users\\will\\project')).toBe(
+      'C:\\Users\\will\\project'
+    )
+  })
+
+  test('rejects non-file URLs and relative paths', () => {
+    expect(parseOsc7Cwd('https://example.com/home/user')).toBeNull()
+    expect(parseOsc7Cwd('relative/path')).toBeNull()
+  })
+})

--- a/src/features/terminal/components/TerminalPane/osc7.test.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.test.ts
@@ -40,6 +40,13 @@ describe('parseOsc7Cwd', () => {
     )
   })
 
+  test('normalizes dot segments in absolute fallback paths', () => {
+    expect(parseOsc7Cwd('/tmp/foo/../worktree')).toBe('/tmp/worktree')
+    expect(parseOsc7Cwd('C:\\Users\\will\\..\\project')).toBe(
+      'C:\\Users\\project'
+    )
+  })
+
   test('rejects non-file URLs and relative paths', () => {
     expect(parseOsc7Cwd('https://example.com/home/user')).toBeNull()
     expect(parseOsc7Cwd('relative/path')).toBeNull()

--- a/src/features/terminal/components/TerminalPane/osc7.test.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.test.ts
@@ -29,6 +29,10 @@ describe('parseOsc7Cwd', () => {
     )
   })
 
+  test('keeps POSIX paths with a colon in the first segment absolute', () => {
+    expect(parseOsc7Cwd('file://host/a:repo')).toBe('/a:repo')
+  })
+
   test('accepts plain absolute fallback paths', () => {
     expect(parseOsc7Cwd('/tmp/worktree')).toBe('/tmp/worktree')
     expect(parseOsc7Cwd('C:\\Users\\will\\project')).toBe(

--- a/src/features/terminal/components/TerminalPane/osc7.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.ts
@@ -1,6 +1,10 @@
 export const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
 const WINDOWS_FILE_URL_DRIVE_PATH = /^\/[A-Za-z]:[\\/]/
 
+export interface ParseOsc7CwdOptions {
+  preserveFileUrlHost?: boolean
+}
+
 export const normalizePosixPath = (path: string): string => {
   const parts: string[] = []
 
@@ -78,7 +82,27 @@ const normalizeAbsolutePath = (pathname: string): string | null => {
   return null
 }
 
-export const parseOsc7Cwd = (data: string): string | null => {
+const fileUrlPathname = (url: URL, options: ParseOsc7CwdOptions): string => {
+  const pathname = decodePathname(url.pathname)
+  const shouldPreserveHost = options.preserveFileUrlHost ?? true
+
+  if (
+    !shouldPreserveHost ||
+    !url.hostname ||
+    url.hostname === 'localhost' ||
+    WINDOWS_FILE_URL_DRIVE_PATH.test(pathname) ||
+    (pathname.startsWith('//') && !pathname.startsWith('///'))
+  ) {
+    return pathname
+  }
+
+  return `//${url.hostname}${pathname.startsWith('/') ? pathname : `/${pathname}`}`
+}
+
+export const parseOsc7Cwd = (
+  data: string,
+  options: ParseOsc7CwdOptions = {}
+): string | null => {
   const plainPath = normalizeAbsolutePath(data)
   if (plainPath) {
     return plainPath
@@ -95,5 +119,5 @@ export const parseOsc7Cwd = (data: string): string | null => {
     return null
   }
 
-  return normalizeAbsolutePath(decodePathname(url.pathname))
+  return normalizeAbsolutePath(fileUrlPathname(url, options))
 }

--- a/src/features/terminal/components/TerminalPane/osc7.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.ts
@@ -59,6 +59,10 @@ const normalizeAbsolutePath = (pathname: string): string | null => {
     ? pathname.slice(1)
     : pathname
 
+  if (path.startsWith('//') && !path.startsWith('///')) {
+    return path
+  }
+
   if (path.startsWith('/')) {
     return normalizePosixPath(path)
   }

--- a/src/features/terminal/components/TerminalPane/osc7.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.ts
@@ -1,0 +1,44 @@
+const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
+const WINDOWS_FILE_URL_DRIVE_PATH = /^\/[A-Za-z]:/
+
+const decodePathname = (pathname: string): string => {
+  try {
+    return decodeURIComponent(pathname)
+  } catch {
+    return pathname
+  }
+}
+
+const normalizeAbsolutePath = (pathname: string): string | null => {
+  const path = WINDOWS_FILE_URL_DRIVE_PATH.test(pathname)
+    ? pathname.slice(1)
+    : pathname
+
+  if (
+    path.startsWith('/') ||
+    path.startsWith('\\\\') ||
+    WINDOWS_DRIVE_PATH.test(path)
+  ) {
+    return path
+  }
+
+  return null
+}
+
+export const parseOsc7Cwd = (data: string): string | null => {
+  const plainPath = normalizeAbsolutePath(data)
+  if (plainPath) {
+    return plainPath
+  }
+
+  try {
+    const url = new URL(data)
+    if (url.protocol !== 'file:') {
+      return null
+    }
+
+    return normalizeAbsolutePath(decodePathname(url.pathname))
+  } catch {
+    return normalizeAbsolutePath(data)
+  }
+}

--- a/src/features/terminal/components/TerminalPane/osc7.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.ts
@@ -1,6 +1,51 @@
 export const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
 const WINDOWS_FILE_URL_DRIVE_PATH = /^\/[A-Za-z]:[\\/]/
 
+const normalizePosixPath = (path: string): string => {
+  const parts: string[] = []
+
+  for (const part of path.split('/')) {
+    if (!part || part === '.') {
+      continue
+    }
+
+    if (part === '..') {
+      parts.pop()
+
+      continue
+    }
+
+    parts.push(part)
+  }
+
+  return `/${parts.join('/')}`
+}
+
+const normalizeWindowsDrivePath = (path: string): string => {
+  const separator = path.includes('\\') && !path.includes('/') ? '\\' : '/'
+  const slashPath = path.replace(/\\/g, '/')
+  const drive = slashPath.slice(0, 2)
+  const parts: string[] = []
+
+  for (const part of slashPath.slice(2).split('/')) {
+    if (!part || part === '.') {
+      continue
+    }
+
+    if (part === '..') {
+      parts.pop()
+
+      continue
+    }
+
+    parts.push(part)
+  }
+
+  const normalized = `${drive}/${parts.join('/')}`
+
+  return separator === '\\' ? normalized.replace(/\//g, '\\') : normalized
+}
+
 const decodePathname = (pathname: string): string => {
   try {
     return decodeURIComponent(pathname)
@@ -14,11 +59,15 @@ const normalizeAbsolutePath = (pathname: string): string | null => {
     ? pathname.slice(1)
     : pathname
 
-  if (
-    path.startsWith('/') ||
-    path.startsWith('\\\\') ||
-    WINDOWS_DRIVE_PATH.test(path)
-  ) {
+  if (path.startsWith('/')) {
+    return normalizePosixPath(path)
+  }
+
+  if (WINDOWS_DRIVE_PATH.test(path)) {
+    return normalizeWindowsDrivePath(path)
+  }
+
+  if (path.startsWith('\\\\')) {
     return path
   }
 

--- a/src/features/terminal/components/TerminalPane/osc7.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.ts
@@ -1,4 +1,4 @@
-const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
+export const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
 const WINDOWS_FILE_URL_DRIVE_PATH = /^\/[A-Za-z]:[\\/]/
 
 const decodePathname = (pathname: string): string => {

--- a/src/features/terminal/components/TerminalPane/osc7.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.ts
@@ -1,7 +1,7 @@
 export const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
 const WINDOWS_FILE_URL_DRIVE_PATH = /^\/[A-Za-z]:[\\/]/
 
-const normalizePosixPath = (path: string): string => {
+export const normalizePosixPath = (path: string): string => {
   const parts: string[] = []
 
   for (const part of path.split('/')) {
@@ -21,7 +21,7 @@ const normalizePosixPath = (path: string): string => {
   return `/${parts.join('/')}`
 }
 
-const normalizeWindowsDrivePath = (path: string): string => {
+export const normalizeWindowsDrivePath = (path: string): string => {
   const separator = path.includes('\\') && !path.includes('/') ? '\\' : '/'
   const slashPath = path.replace(/\\/g, '/')
   const drive = slashPath.slice(0, 2)

--- a/src/features/terminal/components/TerminalPane/osc7.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.ts
@@ -1,5 +1,5 @@
 const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
-const WINDOWS_FILE_URL_DRIVE_PATH = /^\/[A-Za-z]:/
+const WINDOWS_FILE_URL_DRIVE_PATH = /^\/[A-Za-z]:[\\/]/
 
 const decodePathname = (pathname: string): string => {
   try {
@@ -31,14 +31,16 @@ export const parseOsc7Cwd = (data: string): string | null => {
     return plainPath
   }
 
+  let url: URL
   try {
-    const url = new URL(data)
-    if (url.protocol !== 'file:') {
-      return null
-    }
-
-    return normalizeAbsolutePath(decodePathname(url.pathname))
+    url = new URL(data)
   } catch {
-    return normalizeAbsolutePath(data)
+    return null
   }
+
+  if (url.protocol !== 'file:') {
+    return null
+  }
+
+  return normalizeAbsolutePath(decodePathname(url.pathname))
 }

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -7,10 +7,12 @@ import { MockTerminalService } from '../services/terminalService'
 // Mock xterm Terminal with test helpers
 interface MockTerminal extends Terminal {
   _mockTriggerData: (data: string) => void
+  _mockFlushWrites: () => void
 }
 
 const createMockTerminal = (): MockTerminal => {
   const listeners = new Map<string, ((data: string) => void)[]>()
+  const pendingWriteCallbacks: (() => void)[] = []
 
   return {
     onData: vi.fn((callback: (data: string) => void) => {
@@ -27,12 +29,22 @@ const createMockTerminal = (): MockTerminal => {
         }),
       }
     }),
-    write: vi.fn(),
+    write: vi.fn((_data: string | Uint8Array, callback?: () => void) => {
+      if (callback) {
+        pendingWriteCallbacks.push(callback)
+      }
+    }),
     clear: vi.fn(),
     dispose: vi.fn(),
     _mockTriggerData: (data: string) => {
       const callbacks = listeners.get('data') ?? []
       callbacks.forEach((cb) => cb(data))
+    },
+    _mockFlushWrites: () => {
+      const callbacks = pendingWriteCallbacks.splice(0)
+      callbacks.forEach((callback) => {
+        callback()
+      })
     },
   } as unknown as MockTerminal
 }
@@ -144,6 +156,9 @@ describe('useTerminal', () => {
       sessionId,
       data: 'Hello from PTY\r\n',
     })
+
+    expect(onOutput).not.toHaveBeenCalled()
+    mockTerminal._mockFlushWrites()
 
     expect(onOutput).toHaveBeenCalledWith('Hello from PTY\r\n')
   })
@@ -580,12 +595,17 @@ describe('useTerminal', () => {
 
     test('writes replay data before draining buffered events', async () => {
       const writes: string[] = []
+      const writeCallbacks: (() => void)[] = []
       const onOutput = vi.fn()
       vi.mocked(mockTerminal.write).mockImplementation(
-        (data: string | Uint8Array) => {
+        (data: string | Uint8Array, callback?: () => void) => {
           writes.push(
             typeof data === 'string' ? data : new TextDecoder().decode(data)
           )
+
+          if (callback) {
+            writeCallbacks.push(callback)
+          }
         }
       )
 
@@ -613,6 +633,12 @@ describe('useTerminal', () => {
       expect(writes[0]).toBe('REPLAY')
       // Then buffered events
       expect(writes[1]).toBe('BUFFERED')
+      expect(onOutput).not.toHaveBeenCalled()
+
+      writeCallbacks.forEach((callback) => {
+        callback()
+      })
+
       expect(onOutput).toHaveBeenCalledOnce()
       expect(onOutput).toHaveBeenCalledWith('BUFFERED')
     })

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -593,7 +593,7 @@ describe('useTerminal', () => {
       expect(mockTerminal.write).toHaveBeenCalledWith('Restored output\r\n')
     })
 
-    test('writes replay data before draining buffered events', async () => {
+    test('writes replay data before draining buffered events without reporting restored output', async () => {
       const writes: string[] = []
       const writeCallbacks: (() => void)[] = []
       const onOutput = vi.fn()
@@ -634,13 +634,7 @@ describe('useTerminal', () => {
       // Then buffered events
       expect(writes[1]).toBe('BUFFERED')
       expect(onOutput).not.toHaveBeenCalled()
-
-      writeCallbacks.forEach((callback) => {
-        callback()
-      })
-
-      expect(onOutput).toHaveBeenCalledOnce()
-      expect(onOutput).toHaveBeenCalledWith('BUFFERED')
+      expect(writeCallbacks).toHaveLength(0)
     })
 
     test('flushes buffered events with cursor filter (offsetStart >= replayEndOffset)', async () => {

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -706,10 +706,11 @@ describe('useTerminal', () => {
       expect(lifecycleEvents).toEqual(['start', 'output', 'end'])
     })
 
-    test('does not fire restore start without a matching restore end callback', async () => {
+    test('warns and skips restore start without a matching restore end callback', async () => {
       const writes: string[] = []
       const writeCallbacks: (() => void)[] = []
       const onRestoreStart = vi.fn()
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 
       vi.mocked(mockTerminal.write).mockImplementation(
         (data: string | Uint8Array, callback?: () => void) => {
@@ -736,15 +737,20 @@ describe('useTerminal', () => {
             bufferedEvents: [{ data: 'BUFFERED', offsetStart: 50, byteLen: 8 }],
           },
           onRestoreStart,
-        })
+        } as unknown as Parameters<typeof useTerminal>[0])
       )
 
       await waitFor(() => {
         expect(writes).toEqual(['REPLAY', 'BUFFERED'])
       })
 
+      expect(warn).toHaveBeenCalledWith(
+        'useTerminal restore lifecycle callbacks must be provided together'
+      )
       expect(onRestoreStart).not.toHaveBeenCalled()
       expect(writeCallbacks).toHaveLength(0)
+
+      warn.mockRestore()
     })
 
     test('flushes buffered events with cursor filter (offsetStart >= replayEndOffset)', async () => {

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -643,6 +643,63 @@ describe('useTerminal', () => {
       expect(writeCallbacks).toHaveLength(0)
     })
 
+    test('marks the restore phase until the final restored write callback fires', async () => {
+      const writes: string[] = []
+      const writeCallbacks: (() => void)[] = []
+      const lifecycleEvents: string[] = []
+
+      const onRestoreStart = vi.fn(() => {
+        lifecycleEvents.push('start')
+      })
+
+      const onRestoreEnd = vi.fn(() => {
+        lifecycleEvents.push('end')
+      })
+
+      vi.mocked(mockTerminal.write).mockImplementation(
+        (data: string | Uint8Array, callback?: () => void) => {
+          writes.push(
+            typeof data === 'string' ? data : new TextDecoder().decode(data)
+          )
+
+          if (callback) {
+            writeCallbacks.push(callback)
+          }
+        }
+      )
+
+      renderHook(() =>
+        useTerminal({
+          terminal: mockTerminal,
+          service: mockService,
+          restoredFrom: {
+            sessionId: 'session-1',
+            cwd: '/tmp',
+            pid: 1234,
+            replayData: 'REPLAY',
+            replayEndOffset: 50,
+            bufferedEvents: [{ data: 'BUFFERED', offsetStart: 50, byteLen: 8 }],
+          },
+          onRestoreStart,
+          onRestoreEnd,
+        })
+      )
+
+      await waitFor(() => {
+        expect(writes).toEqual(['REPLAY', 'BUFFERED'])
+      })
+
+      expect(onRestoreStart).toHaveBeenCalledOnce()
+      expect(onRestoreEnd).not.toHaveBeenCalled()
+      expect(lifecycleEvents).toEqual(['start'])
+      expect(writeCallbacks).toHaveLength(1)
+
+      writeCallbacks[0]()
+
+      expect(onRestoreEnd).toHaveBeenCalledOnce()
+      expect(lifecycleEvents).toEqual(['start', 'end'])
+    })
+
     test('flushes buffered events with cursor filter (offsetStart >= replayEndOffset)', async () => {
       const writes: string[] = []
       vi.mocked(mockTerminal.write).mockImplementation(

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -593,7 +593,7 @@ describe('useTerminal', () => {
       expect(mockTerminal.write).toHaveBeenCalledWith('Restored output\r\n')
     })
 
-    test('writes replay data before draining buffered events without reporting restored output', async () => {
+    test('reports restored output after the final restore write callback', async () => {
       const writes: string[] = []
       const writeCallbacks: (() => void)[] = []
       const onOutput = vi.fn()
@@ -636,11 +636,16 @@ describe('useTerminal', () => {
       // Then buffered events
       expect(writes[1]).toBe('BUFFERED')
       expect(onOutput).not.toHaveBeenCalled()
+
+      expect(onRestoreOutput).not.toHaveBeenCalled()
+      expect(writeCallbacks).toHaveLength(1)
+
+      writeCallbacks[0]()
+
       expect(onRestoreOutput).toHaveBeenCalledOnce()
       expect(onRestoreOutput).toHaveBeenCalledWith(
         ['REPLAY', 'BUFFERED'].join('')
       )
-      expect(writeCallbacks).toHaveLength(0)
     })
 
     test('marks the restore phase until the final restored write callback fires', async () => {
@@ -695,62 +700,16 @@ describe('useTerminal', () => {
       })
 
       expect(onRestoreStart).toHaveBeenCalledOnce()
-      expect(onRestoreOutput).toHaveBeenCalledOnce()
+      expect(onRestoreOutput).not.toHaveBeenCalled()
       expect(onRestoreEnd).not.toHaveBeenCalled()
-      expect(lifecycleEvents).toEqual(['start', 'output'])
+      expect(lifecycleEvents).toEqual(['start'])
       expect(writeCallbacks).toHaveLength(1)
 
       writeCallbacks[0]()
 
+      expect(onRestoreOutput).toHaveBeenCalledOnce()
       expect(onRestoreEnd).toHaveBeenCalledOnce()
       expect(lifecycleEvents).toEqual(['start', 'output', 'end'])
-    })
-
-    test('warns and skips restore start without a matching restore end callback', async () => {
-      const writes: string[] = []
-      const writeCallbacks: (() => void)[] = []
-      const onRestoreStart = vi.fn()
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-
-      vi.mocked(mockTerminal.write).mockImplementation(
-        (data: string | Uint8Array, callback?: () => void) => {
-          writes.push(
-            typeof data === 'string' ? data : new TextDecoder().decode(data)
-          )
-
-          if (callback) {
-            writeCallbacks.push(callback)
-          }
-        }
-      )
-
-      renderHook(() =>
-        useTerminal({
-          terminal: mockTerminal,
-          service: mockService,
-          restoredFrom: {
-            sessionId: 'session-1',
-            cwd: '/tmp',
-            pid: 1234,
-            replayData: 'REPLAY',
-            replayEndOffset: 50,
-            bufferedEvents: [{ data: 'BUFFERED', offsetStart: 50, byteLen: 8 }],
-          },
-          onRestoreStart,
-        } as unknown as Parameters<typeof useTerminal>[0])
-      )
-
-      await waitFor(() => {
-        expect(writes).toEqual(['REPLAY', 'BUFFERED'])
-      })
-
-      expect(warn).toHaveBeenCalledWith(
-        'useTerminal restore lifecycle callbacks must be provided together'
-      )
-      expect(onRestoreStart).not.toHaveBeenCalled()
-      expect(writeCallbacks).toHaveLength(0)
-
-      warn.mockRestore()
     })
 
     test('flushes buffered events with cursor filter (offsetStart >= replayEndOffset)', async () => {

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -652,6 +652,10 @@ describe('useTerminal', () => {
         lifecycleEvents.push('start')
       })
 
+      const onRestoreOutput = vi.fn(() => {
+        lifecycleEvents.push('output')
+      })
+
       const onRestoreEnd = vi.fn(() => {
         lifecycleEvents.push('end')
       })
@@ -681,6 +685,7 @@ describe('useTerminal', () => {
             bufferedEvents: [{ data: 'BUFFERED', offsetStart: 50, byteLen: 8 }],
           },
           onRestoreStart,
+          onRestoreOutput,
           onRestoreEnd,
         })
       )
@@ -690,14 +695,56 @@ describe('useTerminal', () => {
       })
 
       expect(onRestoreStart).toHaveBeenCalledOnce()
+      expect(onRestoreOutput).toHaveBeenCalledOnce()
       expect(onRestoreEnd).not.toHaveBeenCalled()
-      expect(lifecycleEvents).toEqual(['start'])
+      expect(lifecycleEvents).toEqual(['start', 'output'])
       expect(writeCallbacks).toHaveLength(1)
 
       writeCallbacks[0]()
 
       expect(onRestoreEnd).toHaveBeenCalledOnce()
-      expect(lifecycleEvents).toEqual(['start', 'end'])
+      expect(lifecycleEvents).toEqual(['start', 'output', 'end'])
+    })
+
+    test('does not fire restore start without a matching restore end callback', async () => {
+      const writes: string[] = []
+      const writeCallbacks: (() => void)[] = []
+      const onRestoreStart = vi.fn()
+
+      vi.mocked(mockTerminal.write).mockImplementation(
+        (data: string | Uint8Array, callback?: () => void) => {
+          writes.push(
+            typeof data === 'string' ? data : new TextDecoder().decode(data)
+          )
+
+          if (callback) {
+            writeCallbacks.push(callback)
+          }
+        }
+      )
+
+      renderHook(() =>
+        useTerminal({
+          terminal: mockTerminal,
+          service: mockService,
+          restoredFrom: {
+            sessionId: 'session-1',
+            cwd: '/tmp',
+            pid: 1234,
+            replayData: 'REPLAY',
+            replayEndOffset: 50,
+            bufferedEvents: [{ data: 'BUFFERED', offsetStart: 50, byteLen: 8 }],
+          },
+          onRestoreStart,
+        })
+      )
+
+      await waitFor(() => {
+        expect(writes).toEqual(['REPLAY', 'BUFFERED'])
+      })
+
+      expect(onRestoreStart).not.toHaveBeenCalled()
+      expect(writeCallbacks).toHaveLength(0)
     })
 
     test('flushes buffered events with cursor filter (offsetStart >= replayEndOffset)', async () => {

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -597,6 +597,7 @@ describe('useTerminal', () => {
       const writes: string[] = []
       const writeCallbacks: (() => void)[] = []
       const onOutput = vi.fn()
+      const onRestoreOutput = vi.fn()
       vi.mocked(mockTerminal.write).mockImplementation(
         (data: string | Uint8Array, callback?: () => void) => {
           writes.push(
@@ -622,6 +623,7 @@ describe('useTerminal', () => {
             bufferedEvents: [{ data: 'BUFFERED', offsetStart: 50, byteLen: 8 }],
           },
           onOutput,
+          onRestoreOutput,
         })
       )
 
@@ -634,6 +636,10 @@ describe('useTerminal', () => {
       // Then buffered events
       expect(writes[1]).toBe('BUFFERED')
       expect(onOutput).not.toHaveBeenCalled()
+      expect(onRestoreOutput).toHaveBeenCalledOnce()
+      expect(onRestoreOutput).toHaveBeenCalledWith(
+        ['REPLAY', 'BUFFERED'].join('')
+      )
       expect(writeCallbacks).toHaveLength(0)
     })
 

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -122,6 +122,32 @@ describe('useTerminal', () => {
     expect(mockTerminal.write).toHaveBeenCalledWith('Hello from PTY\r\n')
   })
 
+  test('reports accepted PTY output chunks', async () => {
+    const onOutput = vi.fn()
+
+    const { result } = renderHook(() =>
+      useTerminal({
+        terminal: mockTerminal,
+        service: mockService,
+        cwd: '/home/user',
+        onOutput,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('running')
+    })
+
+    const sessionId = result.current.session!.id
+
+    mockService.emit('data', {
+      sessionId,
+      data: 'Hello from PTY\r\n',
+    })
+
+    expect(onOutput).toHaveBeenCalledWith('Hello from PTY\r\n')
+  })
+
   test('handles keyboard input from xterm', async () => {
     const { result } = renderHook(() =>
       useTerminal({
@@ -554,6 +580,7 @@ describe('useTerminal', () => {
 
     test('writes replay data before draining buffered events', async () => {
       const writes: string[] = []
+      const onOutput = vi.fn()
       vi.mocked(mockTerminal.write).mockImplementation(
         (data: string | Uint8Array) => {
           writes.push(
@@ -574,6 +601,7 @@ describe('useTerminal', () => {
             replayEndOffset: 50,
             bufferedEvents: [{ data: 'BUFFERED', offsetStart: 50, byteLen: 8 }],
           },
+          onOutput,
         })
       )
 
@@ -585,6 +613,8 @@ describe('useTerminal', () => {
       expect(writes[0]).toBe('REPLAY')
       // Then buffered events
       expect(writes[1]).toBe('BUFFERED')
+      expect(onOutput).toHaveBeenCalledOnce()
+      expect(onOutput).toHaveBeenCalledWith('BUFFERED')
     })
 
     test('flushes buffered events with cursor filter (offsetStart >= replayEndOffset)', async () => {

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -95,6 +95,11 @@ export interface UseTerminalOptions {
   onOutput?: (data: string) => void
 
   /**
+   * Optional callback for user keyboard input before it is forwarded to the PTY.
+   */
+  onInput?: (data: string) => void
+
+  /**
    * Explicit lifecycle mode. When omitted, falls back to legacy inference
    * (`attach` if `restoredFrom` is set, else `spawn`) so existing call
    * sites that haven't migrated to the explicit prop continue to work.
@@ -150,6 +155,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     restoredFrom,
     onPaneReady,
     onOutput,
+    onInput,
     mode,
   } = options
 
@@ -193,6 +199,11 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
   useEffect(() => {
     onOutputRef.current = onOutput
   }, [onOutput])
+
+  const onInputRef = useRef(onInput)
+  useEffect(() => {
+    onInputRef.current = onInput
+  }, [onInput])
 
   const writeTerminalOutput = useCallback(
     (targetTerminal: Terminal, data: string): void => {
@@ -543,6 +554,8 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     }
 
     const handleInput = (data: string): void => {
+      onInputRef.current?.(data)
+
       // Guard writes after PTY exit to avoid rejected writes
       if (isMountedRef.current && status === 'running') {
         const writeAsync = async (): Promise<void> => {

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -294,7 +294,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
         // NOT by `encoder.encode(event.data).length` — see RestoreData jsdoc.
         for (const event of restore.bufferedEvents) {
           if (event.offsetStart >= cursorRef.current) {
-            writeTerminalOutput(terminal, event.data)
+            terminal.write(event.data)
 
             const writtenEnd = event.offsetStart + event.byteLen
             if (writtenEnd > cursorRef.current) {

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -88,6 +88,13 @@ export interface UseTerminalOptions {
   onPaneReady?: NotifyPaneReady
 
   /**
+   * Optional callback for PTY output chunks that passed the session and
+   * cursor-dedupe filters. Consumers can inspect agent-emitted terminal text
+   * without subscribing to the shared terminal service separately.
+   */
+  onOutput?: (data: string) => void
+
+  /**
    * Explicit lifecycle mode. When omitted, falls back to legacy inference
    * (`attach` if `restoredFrom` is set, else `spawn`) so existing call
    * sites that haven't migrated to the explicit prop continue to work.
@@ -142,6 +149,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     env,
     restoredFrom,
     onPaneReady,
+    onOutput,
     mode,
   } = options
 
@@ -180,6 +188,11 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
   useEffect(() => {
     onPaneReadyRef.current = onPaneReady
   }, [onPaneReady])
+
+  const onOutputRef = useRef(onOutput)
+  useEffect(() => {
+    onOutputRef.current = onOutput
+  }, [onOutput])
 
   // Store restoredFrom in a ref to prevent effect dependency cycles
   const restoredFromRef = useRef(restoredFrom)
@@ -256,6 +269,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
         for (const event of restore.bufferedEvents) {
           if (event.offsetStart >= cursorRef.current) {
             terminal.write(event.data)
+            onOutputRef.current?.(event.data)
 
             const writtenEnd = event.offsetStart + event.byteLen
             if (writtenEnd > cursorRef.current) {
@@ -386,6 +400,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
         // already written (replay or earlier live/buffered event).
         if (offsetStart >= cursorRef.current) {
           terminal.write(data)
+          onOutputRef.current?.(data)
           // Advance the cursor by the producer's raw byte count, not by the
           // length of `data`. Lossy UTF-8 in the producer (invalid bytes →
           // U+FFFD = 3 bytes when re-encoded) would otherwise drift the

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -213,7 +213,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
   const restoredFromRef = useRef(restoredFrom)
 
   // Store cwd in a ref — used only at spawn time, not as an effect dependency.
-  // OSC 7 updates session.workingDirectory which flows here as `cwd`, but we
+  // OSC 7 updates the pane cwd which flows here as `cwd`, but we
   // must NOT respawn the PTY when the shell changes directory.
   const cwdRef = useRef(cwd)
   cwdRef.current = cwd

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -95,6 +95,13 @@ export interface UseTerminalOptions {
   onOutput?: (data: string) => void
 
   /**
+   * Optional callback for historical replay/buffered output written while
+   * attaching to an existing PTY. This is intentionally separate from
+   * `onOutput` because restore writes must not be treated as live output.
+   */
+  onRestoreOutput?: (data: string) => void
+
+  /**
    * Optional callback for user keyboard input before it is forwarded to the PTY.
    */
   onInput?: (data: string) => void
@@ -155,6 +162,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     restoredFrom,
     onPaneReady,
     onOutput,
+    onRestoreOutput,
     onInput,
     mode,
   } = options
@@ -199,6 +207,11 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
   useEffect(() => {
     onOutputRef.current = onOutput
   }, [onOutput])
+
+  const onRestoreOutputRef = useRef(onRestoreOutput)
+  useEffect(() => {
+    onRestoreOutputRef.current = onRestoreOutput
+  }, [onRestoreOutput])
 
   const onInputRef = useRef(onInput)
   useEffect(() => {
@@ -282,25 +295,37 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
 
         didSpawnSessionRef.current = false // We did NOT spawn this session
 
-        // Write replay data first; the cursor is already initialized to
-        // restore.replayEndOffset (set when the ref was created).
-        terminal.write(restore.replayData)
-
         // Drain buffered events captured at restore-time, advancing the
-        // cursor with each write. The orchestrator's notifyPaneReady drain
+        // cursor with each accepted event. The orchestrator's notifyPaneReady drain
         // (in the data-subscribe effect) may re-deliver the same events
         // along with any that arrived later — cursor dedupe filters them.
         // Cursor advances by `event.byteLen` (the producer's raw byte count),
         // NOT by `encoder.encode(event.data).length` — see RestoreData jsdoc.
+        const restoredBufferedEvents: typeof restore.bufferedEvents = []
         for (const event of restore.bufferedEvents) {
           if (event.offsetStart >= cursorRef.current) {
-            terminal.write(event.data)
+            restoredBufferedEvents.push(event)
 
             const writtenEnd = event.offsetStart + event.byteLen
             if (writtenEnd > cursorRef.current) {
               cursorRef.current = writtenEnd
             }
           }
+        }
+
+        onRestoreOutputRef.current?.(
+          [
+            restore.replayData,
+            ...restoredBufferedEvents.map((event) => event.data),
+          ].join('')
+        )
+
+        // Write replay data first; the cursor is already initialized to
+        // restore.replayEndOffset (set when the ref was created).
+        terminal.write(restore.replayData)
+
+        for (const event of restoredBufferedEvents) {
+          terminal.write(event.data)
         }
 
         // Create session object from restore data

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -334,15 +334,16 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
           }
         }
 
-        const restoredOutput = [
+        const restoredOutputParts = [
           restore.replayData,
           ...restoredBufferedEvents.map((event) => event.data),
-        ].join('')
+        ]
 
-        const restoredOutputChunks = [
-          restore.replayData,
-          ...restoredBufferedEvents.map((event) => event.data),
-        ].filter((data) => data.length > 0)
+        const restoredOutput = restoredOutputParts.join('')
+
+        const restoredOutputChunks = restoredOutputParts.filter(
+          (data) => data.length > 0
+        )
 
         const restoreStart = onRestoreStartRef.current
         const restoreEnd = onRestoreEndRef.current

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -243,17 +243,6 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     onRestoreEndRef.current = onRestoreEnd
   }, [onRestoreEnd])
 
-  useEffect(() => {
-    if (Boolean(onRestoreStart) === Boolean(onRestoreEnd)) {
-      return
-    }
-
-    // eslint-disable-next-line no-console
-    console.warn(
-      'useTerminal restore lifecycle callbacks must be provided together'
-    )
-  }, [onRestoreStart, onRestoreEnd])
-
   const onInputRef = useRef(onInput)
   useEffect(() => {
     onInputRef.current = onInput
@@ -367,29 +356,35 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
 
         const restoreStart = onRestoreStartRef.current
         const restoreEnd = onRestoreEndRef.current
+        const hasRestoreOutput = Boolean(onRestoreOutputRef.current)
 
         const restoreEndCallback =
           restoredOutputChunks.length > 0 && restoreStart && restoreEnd
             ? restoreEnd
             : undefined
 
+        const finishRestore = (): void => {
+          onRestoreOutputRef.current?.(restoredOutput)
+          restoreEndCallback?.()
+        }
+
         if (restoreStart && restoreEndCallback) {
           restoreStart()
         }
 
-        onRestoreOutputRef.current?.(restoredOutput)
-
         if (restoredOutputChunks.length > 0) {
           restoredOutputChunks.forEach((data, index) => {
             const isLastChunk = index === restoredOutputChunks.length - 1
-            if (isLastChunk && restoreEndCallback) {
-              terminal.write(data, restoreEndCallback)
+            if (isLastChunk && (hasRestoreOutput || restoreEndCallback)) {
+              terminal.write(data, finishRestore)
 
               return
             }
 
             terminal.write(data)
           })
+        } else {
+          finishRestore()
         }
 
         // Create session object from restore data

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -48,7 +48,7 @@ export type NotifyPaneReady = (
  */
 export type UseTerminalMode = 'attach' | 'spawn' | 'awaiting-restart'
 
-export interface UseTerminalOptions {
+interface UseTerminalBaseOptions {
   /**
    * xterm.js Terminal instance
    */
@@ -102,15 +102,6 @@ export interface UseTerminalOptions {
   onRestoreOutput?: (data: string) => void
 
   /**
-   * Optional paired restore lifecycle callbacks. When both are provided,
-   * `onRestoreStart` fires immediately before historical replay/buffered output
-   * is written to xterm and `onRestoreEnd` fires after the final restore write
-   * callback.
-   */
-  onRestoreStart?: () => void
-  onRestoreEnd?: () => void
-
-  /**
    * Optional callback for user keyboard input before it is forwarded to the PTY.
    */
   onInput?: (data: string) => void
@@ -127,6 +118,24 @@ export interface UseTerminalOptions {
    */
   mode?: UseTerminalMode
 }
+
+type RestoreLifecycleOptions =
+  | {
+      /**
+       * Restore lifecycle callbacks must be provided as a pair. `onRestoreStart`
+       * fires immediately before historical replay/buffered output is written to
+       * xterm; `onRestoreEnd` fires after the final restore write callback.
+       */
+      onRestoreStart: () => void
+      onRestoreEnd: () => void
+    }
+  | {
+      onRestoreStart?: undefined
+      onRestoreEnd?: undefined
+    }
+
+export type UseTerminalOptions = UseTerminalBaseOptions &
+  RestoreLifecycleOptions
 
 export interface UseTerminalReturn {
   /**
@@ -233,6 +242,17 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
   useEffect(() => {
     onRestoreEndRef.current = onRestoreEnd
   }, [onRestoreEnd])
+
+  useEffect(() => {
+    if (Boolean(onRestoreStart) === Boolean(onRestoreEnd)) {
+      return
+    }
+
+    // eslint-disable-next-line no-console
+    console.warn(
+      'useTerminal restore lifecycle callbacks must be provided together'
+    )
+  }, [onRestoreStart, onRestoreEnd])
 
   const onInputRef = useRef(onInput)
   useEffect(() => {

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -102,9 +102,10 @@ export interface UseTerminalOptions {
   onRestoreOutput?: (data: string) => void
 
   /**
-   * Optional restore lifecycle callbacks. `onRestoreStart` fires immediately
-   * before historical replay/buffered output is written to xterm; `onRestoreEnd`
-   * fires after the final restore write callback.
+   * Optional paired restore lifecycle callbacks. When both are provided,
+   * `onRestoreStart` fires immediately before historical replay/buffered output
+   * is written to xterm and `onRestoreEnd` fires after the final restore write
+   * callback.
    */
   onRestoreStart?: () => void
   onRestoreEnd?: () => void
@@ -333,25 +334,35 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
           }
         }
 
-        onRestoreOutputRef.current?.(
-          [
-            restore.replayData,
-            ...restoredBufferedEvents.map((event) => event.data),
-          ].join('')
-        )
+        const restoredOutput = [
+          restore.replayData,
+          ...restoredBufferedEvents.map((event) => event.data),
+        ].join('')
 
         const restoredOutputChunks = [
           restore.replayData,
           ...restoredBufferedEvents.map((event) => event.data),
         ].filter((data) => data.length > 0)
 
-        if (restoredOutputChunks.length > 0) {
-          onRestoreStartRef.current?.()
+        const restoreStart = onRestoreStartRef.current
+        const restoreEnd = onRestoreEndRef.current
 
+        const restoreEndCallback =
+          restoredOutputChunks.length > 0 && restoreStart && restoreEnd
+            ? restoreEnd
+            : undefined
+
+        if (restoreStart && restoreEndCallback) {
+          restoreStart()
+        }
+
+        onRestoreOutputRef.current?.(restoredOutput)
+
+        if (restoredOutputChunks.length > 0) {
           restoredOutputChunks.forEach((data, index) => {
             const isLastChunk = index === restoredOutputChunks.length - 1
-            if (isLastChunk && onRestoreEndRef.current) {
-              terminal.write(data, onRestoreEndRef.current)
+            if (isLastChunk && restoreEndCallback) {
+              terminal.write(data, restoreEndCallback)
 
               return
             }

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -102,6 +102,14 @@ export interface UseTerminalOptions {
   onRestoreOutput?: (data: string) => void
 
   /**
+   * Optional restore lifecycle callbacks. `onRestoreStart` fires immediately
+   * before historical replay/buffered output is written to xterm; `onRestoreEnd`
+   * fires after the final restore write callback.
+   */
+  onRestoreStart?: () => void
+  onRestoreEnd?: () => void
+
+  /**
    * Optional callback for user keyboard input before it is forwarded to the PTY.
    */
   onInput?: (data: string) => void
@@ -163,6 +171,8 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     onPaneReady,
     onOutput,
     onRestoreOutput,
+    onRestoreStart,
+    onRestoreEnd,
     onInput,
     mode,
   } = options
@@ -212,6 +222,16 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
   useEffect(() => {
     onRestoreOutputRef.current = onRestoreOutput
   }, [onRestoreOutput])
+
+  const onRestoreStartRef = useRef(onRestoreStart)
+  useEffect(() => {
+    onRestoreStartRef.current = onRestoreStart
+  }, [onRestoreStart])
+
+  const onRestoreEndRef = useRef(onRestoreEnd)
+  useEffect(() => {
+    onRestoreEndRef.current = onRestoreEnd
+  }, [onRestoreEnd])
 
   const onInputRef = useRef(onInput)
   useEffect(() => {
@@ -320,12 +340,24 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
           ].join('')
         )
 
-        // Write replay data first; the cursor is already initialized to
-        // restore.replayEndOffset (set when the ref was created).
-        terminal.write(restore.replayData)
+        const restoredOutputChunks = [
+          restore.replayData,
+          ...restoredBufferedEvents.map((event) => event.data),
+        ].filter((data) => data.length > 0)
 
-        for (const event of restoredBufferedEvents) {
-          terminal.write(event.data)
+        if (restoredOutputChunks.length > 0) {
+          onRestoreStartRef.current?.()
+
+          restoredOutputChunks.forEach((data, index) => {
+            const isLastChunk = index === restoredOutputChunks.length - 1
+            if (isLastChunk && onRestoreEndRef.current) {
+              terminal.write(data, onRestoreEndRef.current)
+
+              return
+            }
+
+            terminal.write(data)
+          })
         }
 
         // Create session object from restore data

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -194,6 +194,21 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     onOutputRef.current = onOutput
   }, [onOutput])
 
+  const writeTerminalOutput = useCallback(
+    (targetTerminal: Terminal, data: string): void => {
+      if (!onOutputRef.current) {
+        targetTerminal.write(data)
+
+        return
+      }
+
+      targetTerminal.write(data, () => {
+        onOutputRef.current?.(data)
+      })
+    },
+    []
+  )
+
   // Store restoredFrom in a ref to prevent effect dependency cycles
   const restoredFromRef = useRef(restoredFrom)
 
@@ -268,8 +283,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
         // NOT by `encoder.encode(event.data).length` — see RestoreData jsdoc.
         for (const event of restore.bufferedEvents) {
           if (event.offsetStart >= cursorRef.current) {
-            terminal.write(event.data)
-            onOutputRef.current?.(event.data)
+            writeTerminalOutput(terminal, event.data)
 
             const writtenEnd = event.offsetStart + event.byteLen
             if (writtenEnd > cursorRef.current) {
@@ -381,7 +395,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     // OSC 7 updates cwd continuously; including it here would kill the PTY on every cd.
     // restoredFrom intentionally excluded — it's read from restoredFromRef at init time.
     // Including it would cause infinite loops as object identity changes.
-  }, [terminal, service, shell, env])
+  }, [terminal, service, shell, env, writeTerminalOutput])
 
   // Listen to PTY data events
   useEffect(() => {
@@ -399,8 +413,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
         // Cursor dedupe: drop events whose offset predates what we've
         // already written (replay or earlier live/buffered event).
         if (offsetStart >= cursorRef.current) {
-          terminal.write(data)
-          onOutputRef.current?.(data)
+          writeTerminalOutput(terminal, data)
           // Advance the cursor by the producer's raw byte count, not by the
           // length of `data`. Lossy UTF-8 in the producer (invalid bytes →
           // U+FFFD = 3 bytes when re-encoded) would otherwise drift the
@@ -521,7 +534,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
       unsubscribeExit?.()
       unsubscribeError?.()
     }
-  }, [terminal, session, service])
+  }, [terminal, session, service, writeTerminalOutput])
 
   // Handle keyboard input from xterm
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Extract OSC 7 cwd parsing into a focused helper that accepts valid file URLs, absolute fallback paths, and Windows drive paths.
- Keep TerminalPane cwd changes on the existing pane-local `onCwdChange -> updatePaneCwd -> update_session_cwd` lifecycle.
- Add PTY-output coverage proving agent/tool-emitted OSC 7 updates the receiving pane only.

## Why

Agent/tool output can intentionally switch the user-facing task context to another repo or worktree without mutating the interactive shell `$PWD`. The pane chrome, git branch/status, file explorer root, and diff root should follow that pane-local OSC 7 signal through the existing cwd persistence path.

## Root Cause

The runtime path already used xterm's OSC parser, but the behavior was only covered by directly invoking the registered handler. There was no regression coverage proving OSC 7 embedded in PTY output from an agent/tool drives the same pane-local cwd update path.

## Validation

- `npm test -- --run src/features/terminal/components/TerminalPane/agentCwdHint.test.ts src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx src/features/terminal/hooks/useTerminal.test.ts`
- `npm test -- --run src/features/terminal/components/TerminalPane/Body.test.tsx src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx src/features/terminal/components/TerminalPane/agentCwdHint.test.ts src/features/terminal/components/TerminalPane/osc7.test.ts src/features/terminal/hooks/useTerminal.test.ts`
- `npx eslint src/features/terminal/components/TerminalPane/agentCwdHint.ts src/features/terminal/components/TerminalPane/agentCwdHint.test.ts src/features/terminal/components/TerminalPane/Body.tsx src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx src/features/terminal/hooks/useTerminal.ts src/features/terminal/hooks/useTerminal.test.ts`
- `npx prettier --check src/features/terminal/components/TerminalPane/agentCwdHint.ts src/features/terminal/components/TerminalPane/agentCwdHint.test.ts src/features/terminal/components/TerminalPane/Body.tsx src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx src/features/terminal/hooks/useTerminal.ts src/features/terminal/hooks/useTerminal.test.ts`
- `npm run type-check`
- Pre-push hook full suite: `npm test` passed 178 files / 2344 tests / 3 skipped.

Closes #233
