### PR TITLE
[codex] fix agent pane border reset

### DIFF
--- a/src/features/agent-status/components/AgentStatusPanel.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel.test.tsx
@@ -6,6 +6,7 @@ import * as useGitStatusModule from '../../diff/hooks/useGitStatus'
 
 const inactiveAgentStatus: AgentStatus = {
   isActive: false,
+  agentExited: false,
   agentType: null,
   modelId: null,
   modelDisplayName: null,
@@ -24,6 +25,7 @@ const inactiveAgentStatus: AgentStatus = {
 const activeAgentStatus: AgentStatus = {
   ...inactiveAgentStatus,
   isActive: true,
+  agentExited: false,
   agentType: 'claude-code',
   modelId: 'claude-3-5-sonnet-20241022',
   modelDisplayName: 'Claude 3.5 Sonnet',

--- a/src/features/agent-status/hooks/useActivityEvents.test.tsx
+++ b/src/features/agent-status/hooks/useActivityEvents.test.tsx
@@ -5,6 +5,7 @@ import type { AgentStatus } from '../types'
 
 const baseStatus: AgentStatus = {
   isActive: true,
+  agentExited: false,
   agentType: 'claude-code',
   modelId: null,
   modelDisplayName: null,

--- a/src/features/agent-status/hooks/useAgentStatus.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.test.ts
@@ -721,11 +721,77 @@ describe('useAgentStatus', () => {
       })
     })
 
-    // Advance timer to trigger next poll
-    vi.advanceTimersByTime(2000)
+    // Advance timer to trigger the next poll.
+    vi.advanceTimersByTime(500)
 
     await vi.waitFor(() => {
       expect(invoke).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  test('does not poll detection before event listeners are ready', async () => {
+    const listenEvents: string[] = []
+    const pendingListenResolves: ((unlisten: () => void) => void)[] = []
+
+    vi.mocked(listen).mockImplementation(((event: string) => {
+      listenEvents.push(event)
+
+      return new Promise((resolve) => {
+        pendingListenResolves.push(resolve)
+      })
+    }) as unknown as typeof listen)
+
+    renderHook(() => useAgentStatus('session-1'))
+
+    expect(listenEvents).toEqual(['agent-status'])
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(invoke).not.toHaveBeenCalledWith('detect_agent_in_session', {
+      sessionId: 'pty-session-1',
+    })
+
+    await act(async () => {
+      pendingListenResolves.shift()?.((): void => undefined)
+      await Promise.resolve()
+    })
+
+    expect(listenEvents).toEqual(['agent-status', 'agent-tool-call'])
+
+    await act(async () => {
+      pendingListenResolves.shift()?.((): void => undefined)
+      await Promise.resolve()
+    })
+
+    expect(listenEvents).toEqual([
+      'agent-status',
+      'agent-tool-call',
+      'agent-turn',
+    ])
+
+    await act(async () => {
+      pendingListenResolves.shift()?.((): void => undefined)
+      await Promise.resolve()
+    })
+
+    expect(listenEvents).toEqual([
+      'agent-status',
+      'agent-tool-call',
+      'agent-turn',
+      'test-run',
+    ])
+
+    await act(async () => {
+      pendingListenResolves.shift()?.((): void => undefined)
+      await Promise.resolve()
+    })
+
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('detect_agent_in_session', {
+        sessionId: 'pty-session-1',
+      })
     })
   })
 
@@ -1226,7 +1292,7 @@ describe('useAgentStatus', () => {
     //      detect_agent in start_agent_watcher returned None even
     //      though the polled detect_agent_in_session succeeded).
     //   3. Frontend's catch swallows; watcherStartedRef stays false.
-    //   4. Next 2s poll: detect_agent_in_session returns null
+    //   4. Next poll: detect_agent_in_session returns null
     //      (agent really exited).
     //   5. Pre-fix: collapse path early-returned because
     //      `if (!watcherStartedRef.current) return` — panel stuck
@@ -1279,12 +1345,15 @@ describe('useAgentStatus', () => {
       expect(result.current.agentType).toBe('claude-code')
     })
 
-    // Step 4: advance 2s for the next polling tick. Detection now
+    // Step 4: advance to the next polling tick. Detection now
     // returns null.
     await act(async () => {
-      vi.advanceTimersByTime(2000)
+      vi.advanceTimersByTime(500)
       await Promise.resolve()
     })
+
+    expect(result.current.agentExited).toBe(true)
+    expect(result.current.isActive).toBe(true)
 
     // Step 5/6: panel should collapse after EXIT_HOLD_MS (5s). With
     // the pre-fix behavior the early-return at the gate would prevent
@@ -1296,5 +1365,6 @@ describe('useAgentStatus', () => {
     })
 
     expect(result.current.isActive).toBe(false)
+    expect(result.current.agentExited).toBe(false)
   })
 })

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -15,7 +15,7 @@ import type {
 // ActivityFeed paginates this with a 'show more' control so the whole
 // buffer is reachable without overloading the initial render.
 const RECENT_TOOL_CALLS_LIMIT = 50
-const DETECTION_POLL_MS = 2000
+const DETECTION_POLL_MS = 500
 const EXIT_HOLD_MS = 5000
 
 const AGENT_TYPE_MAP = {
@@ -32,6 +32,7 @@ const isKnownAgentType = (
 
 const createDefaultStatus = (sessionId: string | null): AgentStatus => ({
   isActive: false,
+  agentExited: false,
   agentType: null,
   modelId: null,
   modelDisplayName: null,
@@ -135,6 +136,9 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
   // Track the collapse timeout so it can be cancelled if the agent
   // reappears before the 5s hold expires (e.g., brief detection gap).
   const collapseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Detection can start the backend watcher, whose replay events must not
+  // fire before the event listeners below are attached.
+  const listenersReadyRef = useRef(false)
 
   // Reset state when sessionId changes
   useEffect(() => {
@@ -157,6 +161,7 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
       watcherStartInFlightRef.current = false
       watcherStartGenerationRef.current += 1
       knownPtyIdRef.current = undefined
+      listenersReadyRef.current = false
       if (collapseTimeoutRef.current) {
         clearTimeout(collapseTimeoutRef.current)
         collapseTimeoutRef.current = null
@@ -165,7 +170,8 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
     }
   }, [sessionId])
 
-  // Detection polling: poll detect_agent_in_session every 2s.
+  // Detection polling: poll detect_agent_in_session frequently enough that
+  // pane chrome returns to shell styling promptly after an agent exits.
   // On detection, update state. On agent exit, stop watchers and
   // hold final state for 5s before collapsing.
   const handleDetection = useCallback(async (sid: string): Promise<void> => {
@@ -206,6 +212,7 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
             ? {
                 ...prev,
                 isActive: true,
+                agentExited: false,
                 agentType: mapped,
               }
             : prev
@@ -290,13 +297,19 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
         // session-change cleanup must still have the captured PTY id to retry.
         void stopWatchers(sid, knownPtyIdRef.current)
 
+        setStatus((prev) =>
+          prev.sessionId === sid ? { ...prev, agentExited: true } : prev
+        )
+
         // Hold final state for 5s, then collapse. Runs regardless of
         // watcherStartedRef — that's the F1 fix: a transient
         // start_agent_watcher failure no longer blocks collapse.
         collapseTimeoutRef.current = setTimeout(() => {
           collapseTimeoutRef.current = null
           setStatus((prev) =>
-            prev.sessionId === sid ? { ...prev, isActive: false } : prev
+            prev.sessionId === sid
+              ? { ...prev, isActive: false, agentExited: false }
+              : prev
           )
         }, EXIT_HOLD_MS)
       }
@@ -311,6 +324,10 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
     }
 
     const interval = setInterval(() => {
+      if (!listenersReadyRef.current) {
+        return
+      }
+
       void handleDetection(sessionId)
     }, DETECTION_POLL_MS)
 
@@ -334,6 +351,7 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
 
     const unlistenFns: (() => void)[] = []
     let cancelled = false
+    listenersReadyRef.current = false
 
     const addUnlisten = (fn: () => void): void => {
       if (cancelled) {
@@ -546,12 +564,14 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
       // subscribe resolved. The linter can't see cross-await mutation.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!cancelled) {
+        listenersReadyRef.current = true
         void handleDetection(sessionId)
       }
     })()
 
     return (): void => {
       cancelled = true
+      listenersReadyRef.current = false
 
       for (const unlisten of unlistenFns) {
         unlisten()

--- a/src/features/agent-status/types/index.ts
+++ b/src/features/agent-status/types/index.ts
@@ -36,6 +36,13 @@ export interface CostMetrics {
 
 export interface AgentStatus {
   isActive: boolean
+  /**
+   * True after a previously detected agent disappears while the PTY remains
+   * alive. Consumers that render pane chrome use this to return to shell
+   * styling immediately, while the activity panel can still hold final
+   * metrics during its exit window.
+   */
+  agentExited: boolean
   agentType: 'claude-code' | 'codex' | 'aider' | 'generic' | null
   modelId: string | null
   modelDisplayName: string | null

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -188,6 +188,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
       await import('../agent-status/hooks/useAgentStatus')
     vi.mocked(useAgentStatus).mockReturnValue({
       isActive: false,
+      agentExited: false,
       agentType: null,
       modelId: null,
       modelDisplayName: null,
@@ -318,6 +319,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
       await import('../agent-status/hooks/useAgentStatus')
     vi.mocked(useAgentStatus).mockReturnValue({
       isActive: true,
+      agentExited: false,
       agentType: 'codex',
       modelId: null,
       modelDisplayName: null,
@@ -344,6 +346,54 @@ describe('WorkspaceView - Command Palette Integration', () => {
     )
   })
 
+  test('resets active pane chrome to shell after a detected agent exits', async () => {
+    const activeSession = mockSessions[0]
+    mockSessions[0] = {
+      ...activeSession,
+      agentType: 'codex',
+      panes: activeSession.panes.map((pane) => ({
+        ...pane,
+        agentType: 'codex',
+      })),
+    }
+
+    const { useAgentStatus } =
+      await import('../agent-status/hooks/useAgentStatus')
+    vi.mocked(useAgentStatus).mockReturnValue({
+      isActive: true,
+      agentExited: true,
+      agentType: 'codex',
+      modelId: null,
+      modelDisplayName: null,
+      version: null,
+      sessionId: 'pty-session-1',
+      agentSessionId: null,
+      contextWindow: null,
+      cost: null,
+      rateLimits: null,
+      numTurns: 0,
+      toolCalls: { total: 0, byType: {}, active: null },
+      recentToolCalls: [],
+      testRun: null,
+    })
+
+    render(<WorkspaceView />)
+
+    await waitFor(() =>
+      expect(mockSessionManager.updatePaneAgentType).toHaveBeenCalledWith(
+        'session-1',
+        'p0',
+        'generic'
+      )
+    )
+  })
+
+  test('does not reset pane chrome before detection reports an agent', () => {
+    render(<WorkspaceView />)
+
+    expect(mockSessionManager.updatePaneAgentType).not.toHaveBeenCalled()
+  })
+
   test('does not apply stale agent status from another session to the active shell tab', async () => {
     mockSessions[1] = {
       ...mockSessions[1],
@@ -355,6 +405,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
       await import('../agent-status/hooks/useAgentStatus')
     vi.mocked(useAgentStatus).mockReturnValue({
       isActive: true,
+      agentExited: false,
       agentType: 'claude-code',
       modelId: null,
       modelDisplayName: null,

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../terminal/components/TerminalPane', () => ({
 vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   useAgentStatus: vi.fn(() => ({
     isActive: true,
+    agentExited: false,
     agentType: 'claude-code',
     modelId: null,
     modelDisplayName: null,
@@ -934,6 +935,7 @@ describe('WorkspaceView Integration Tests', () => {
         await import('../agent-status/hooks/useAgentStatus')
       vi.mocked(useAgentStatus).mockReturnValue({
         isActive: true,
+        agentExited: false,
         agentType: 'claude-code',
         modelId: 'sonnet-4-5',
         modelDisplayName: 'Sonnet 4.5',
@@ -973,6 +975,7 @@ describe('WorkspaceView Integration Tests', () => {
         await import('../agent-status/hooks/useAgentStatus')
       vi.mocked(useAgentStatus).mockReturnValue({
         isActive: true,
+        agentExited: false,
         agentType: 'claude-code',
         modelId: null,
         modelDisplayName: null,

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -84,6 +84,7 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   useAgentStatus: vi.fn(
     (): AgentStatus => ({
       isActive: true,
+      agentExited: false,
       agentType: 'claude-code',
       modelId: null,
       modelDisplayName: null,
@@ -326,6 +327,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
     // codex caught in round-2 v1).
     const idleAgentStatus: AgentStatus = {
       isActive: false,
+      agentExited: false,
       agentType: null,
       modelId: null,
       modelDisplayName: null,
@@ -384,6 +386,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
   test('WorkspaceView passes enabled: false when idle diff dock is closed', async () => {
     const idleAgentStatus: AgentStatus = {
       isActive: false,
+      agentExited: false,
       agentType: null,
       modelId: null,
       modelDisplayName: null,

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -196,25 +196,17 @@ export const WorkspaceView = (): ReactElement => {
 
   const agentStatus = useAgentStatus(activePanePtyId ?? null)
 
-  // Bridge: when the detector resolves a live agent for the active
-  // session, write it into Session.agentType. This is the single source
-  // of truth — chrome consumers (Tab strip, Header chip, Footer
-  // prompt-marker, RestartAffordance) all read agentForSession(session)
-  // and follow naturally. AgentStatusPanel is NOT in this set; it reads
-  // useAgentStatus directly.
+  // Bridge: keep pane chrome in sync with agent detection for the active
+  // pane. Live detections stamp the agent identity; an explicit
+  // agentExited signal means useAgentStatus previously detected an agent
+  // and then confirmed it exited while the PTY stayed alive, so the pane
+  // should return to shell chrome even if the activity panel is still in
+  // its exit-hold window.
   //
-  // Only writes on isActive=true with non-null agentType. isActive=false
-  // is ambiguous (tab just activated / EXIT_HOLD window / agent gone but
-  // shell alive — detector returns None) so we leave Session.agentType
-  // untouched. Once detected, it sticks until PTY exit.
-  //
-  // Status guard: skip the write when the active session has already
-  // exited (status completed/errored). useAgentStatus keeps isActive
-  // true for EXIT_HOLD_MS (5s) after the agent process disappears; if
-  // the PTY also exits during that window, the reset effect below sets
-  // agentType='generic' on the completed session — without this guard
-  // a re-render that re-fires the bridge would write the stale agent
-  // back, ping-ponging against the reset.
+  // Status guard: skip writes when the active session has already exited
+  // (status completed/errored). The PTY-exit reset effect below owns that
+  // path; without this guard, a delayed status update could re-stamp stale
+  // agent chrome onto a completed session.
   const activeSessionStatus = activeSession?.status
   useEffect(() => {
     if (!activeSessionId) {
@@ -226,18 +218,33 @@ export const WorkspaceView = (): ReactElement => {
     if (agentStatus.sessionId !== activePanePtyId) {
       return
     }
-    if (!agentStatus.isActive || !agentStatus.agentType) {
-      return
-    }
     if (activeSessionStatus !== 'running' && activeSessionStatus !== 'paused') {
       return
     }
-    updatePaneAgentType(activeSessionId, activePaneId, agentStatus.agentType)
+
+    if (agentStatus.agentExited) {
+      updatePaneAgentType(activeSessionId, activePaneId, 'generic')
+
+      return
+    }
+
+    if (agentStatus.isActive) {
+      if (agentStatus.agentType) {
+        updatePaneAgentType(
+          activeSessionId,
+          activePaneId,
+          agentStatus.agentType
+        )
+      }
+
+      return
+    }
   }, [
     activeSessionId,
     activePaneId,
     activePanePtyId,
     activeSessionStatus,
+    agentStatus.agentExited,
     agentStatus.isActive,
     agentStatus.agentType,
     agentStatus.sessionId,

--- a/src/features/workspace/components/SidebarStatusHeader.test.tsx
+++ b/src/features/workspace/components/SidebarStatusHeader.test.tsx
@@ -5,6 +5,7 @@ import { SidebarStatusHeader } from './SidebarStatusHeader'
 
 const inactiveStatus: AgentStatus = {
   isActive: false,
+  agentExited: false,
   agentType: null,
   modelId: null,
   modelDisplayName: null,
@@ -23,6 +24,7 @@ const inactiveStatus: AgentStatus = {
 const activeStatus: AgentStatus = {
   ...inactiveStatus,
   isActive: true,
+  agentExited: false,
   agentType: 'claude-code',
   modelId: 'claude-3-5-sonnet-20241022',
   modelDisplayName: 'Claude 3.5 Sonnet',


### PR DESCRIPTION
## Summary

- Add an `agentExited` status signal so pane chrome can reset to shell styling immediately when a detected coding agent exits while the PTY remains alive.
- Reduce agent detection polling from 2000ms to 500ms so the border no longer waits multiple seconds before returning from Codex green to shell yellow.
- Update workspace bridge logic and regression coverage for both the exit reset and the initial no-detection state.

## Root Cause

The pane border color follows `pane.agentType`, but the workspace bridge only wrote active agent detections and relied on PTY exit or the activity panel collapse path to return to `generic`. When Codex exited but the shell stayed alive, the pane could keep the Codex agent type until a delayed status transition.

## Validation

- `npm test -- --run src/features/agent-status/hooks/useAgentStatus.test.ts`
- `npm test -- --run src/features/workspace/WorkspaceView.command-palette.test.tsx`
- `npm test -- --run src/features/workspace/WorkspaceView.subscription.test.tsx`
- `npm run lint`
- `npm run format:check`
- `npm run type-check`

Ready for review.