### PR TITLE
feat(agent-status): add activity detail tooltips

### DIFF
--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,7 +1,7 @@
 import { createRef } from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { Tooltip } from './Tooltip'
 
 describe('Tooltip', () => {
@@ -208,6 +208,76 @@ describe('Tooltip', () => {
     await user.hover(screen.getByRole('button', { name: 'trigger' }))
     await screen.findByRole('tooltip')
     expect(screen.queryByTestId('tooltip-shortcut')).not.toBeInTheDocument()
+  })
+
+  test('supports interactive floating content when requested', async () => {
+    const user = userEvent.setup()
+    const handleCopy = vi.fn()
+
+    render(
+      <Tooltip
+        content={
+          <button type="button" onClick={handleCopy}>
+            Copy
+          </button>
+        }
+        delayMs={0}
+        interactive
+        ariaLabel="Activity details"
+      >
+        <button type="button">trigger</button>
+      </Tooltip>
+    )
+
+    await user.hover(screen.getByRole('button', { name: 'trigger' }))
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Activity details',
+    })
+
+    expect(dialog).toHaveClass('pointer-events-auto')
+    await user.click(within(dialog).getByRole('button', { name: 'Copy' }))
+    expect(handleCopy).toHaveBeenCalledTimes(1)
+  })
+
+  test('tabs from trigger into interactive floating content', async () => {
+    const user = userEvent.setup()
+    const handleCopy = vi.fn()
+
+    render(
+      <>
+        <Tooltip
+          content={
+            <button type="button" onClick={handleCopy}>
+              Copy
+            </button>
+          }
+          delayMs={0}
+          interactive
+          ariaLabel="Activity details"
+        >
+          <button type="button">trigger</button>
+        </Tooltip>
+        <button type="button">next action</button>
+      </>
+    )
+
+    const trigger = screen.getByRole('button', { name: 'trigger' })
+
+    await user.tab()
+    expect(trigger).toHaveFocus()
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Activity details',
+    })
+
+    await user.tab()
+
+    const copyButton = within(dialog).getByRole('button', { name: 'Copy' })
+    expect(copyButton).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+    expect(handleCopy).toHaveBeenCalledTimes(1)
   })
 
   test('clears stale open state when tooltip becomes disabled mid-flight', async () => {

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -8,6 +8,7 @@ import {
   type Ref,
 } from 'react'
 import {
+  FloatingFocusManager,
   FloatingPortal,
   autoUpdate,
   flip,
@@ -25,7 +26,7 @@ import {
 } from '@floating-ui/react'
 import { formatShortcut, type ShortcutInput } from '../lib/formatShortcut'
 
-export interface TooltipProps {
+interface TooltipBaseProps {
   content: ReactNode
   /**
    * Optional keyboard shortcut shown as a single chip on the right side
@@ -42,8 +43,24 @@ export interface TooltipProps {
   className?: string
 }
 
-const TOOLTIP_CLASSES =
-  'pointer-events-none z-50 rounded-md shadow-lg px-3 py-1.5 ' +
+interface PassiveTooltipProps extends TooltipBaseProps {
+  interactive?: false
+  ariaLabel?: never
+}
+
+interface InteractiveTooltipProps extends TooltipBaseProps {
+  /**
+   * Allows pointer interaction inside the floating surface. Keep this off for
+   * passive labels so regular tooltips remain non-interactive descriptions.
+   */
+  interactive: true
+  ariaLabel: string
+}
+
+export type TooltipProps = PassiveTooltipProps | InteractiveTooltipProps
+
+const TOOLTIP_BASE_CLASSES =
+  'z-50 rounded-md shadow-lg px-3 py-1.5 ' +
   'bg-surface-container-high/90 backdrop-blur-md backdrop-saturate-150 ' +
   'border border-outline-variant/20 ' +
   'text-xs text-on-surface'
@@ -61,6 +78,8 @@ export const Tooltip = ({
   disabled = false,
   maxWidth = 320,
   className = '',
+  interactive = false,
+  ariaLabel = undefined,
 }: TooltipProps): ReactElement => {
   // `content != null` would admit falsy ReactNodes (`false`, `''`) and render
   // an empty floating box — these are common with the `cond && 'text'` idiom.
@@ -96,12 +115,12 @@ export const Tooltip = ({
   const { getReferenceProps, getFloatingProps } = useInteractions([
     useHover(context, {
       enabled,
-      delay: { open: delayMs, close: 0 },
+      delay: { open: delayMs, close: interactive ? 150 : 0 },
       handleClose: safePolygon(),
     }),
     useFocus(context, { enabled }),
     useDismiss(context, { enabled, escapeKey: true }),
-    useRole(context, { enabled, role: 'tooltip' }),
+    useRole(context, { enabled, role: interactive ? 'dialog' : 'tooltip' }),
   ])
 
   const childRef = isValidElement(children)
@@ -113,6 +132,35 @@ export const Tooltip = ({
     return children
   }
 
+  const interactionClass = interactive
+    ? 'pointer-events-auto'
+    : 'pointer-events-none'
+  const tooltipClasses = `${interactionClass} ${TOOLTIP_BASE_CLASSES}`
+  const classes = className ? `${tooltipClasses} ${className}` : tooltipClasses
+
+  const floatingSurface = (
+    <div
+      ref={refs.setFloating}
+      data-placement={resolvedPlacement}
+      style={{ ...floatingStyles, maxWidth }}
+      className={classes}
+      {...getFloatingProps(
+        ariaLabel === undefined ? undefined : { 'aria-label': ariaLabel }
+      )}
+    >
+      {shortcut !== undefined ? (
+        <div className="flex items-center gap-3">
+          <span className="min-w-0 flex-1">{content}</span>
+          <kbd data-testid="tooltip-shortcut" className={SHORTCUT_CHIP_CLASSES}>
+            {formatShortcut(shortcut)}
+          </kbd>
+        </div>
+      ) : (
+        content
+      )}
+    </div>
+  )
+
   return (
     <>
       {cloneElement(children as ReactElement<Record<string, unknown>>, {
@@ -121,29 +169,18 @@ export const Tooltip = ({
       })}
       {open && (
         <FloatingPortal>
-          <div
-            ref={refs.setFloating}
-            data-placement={resolvedPlacement}
-            style={{ ...floatingStyles, maxWidth }}
-            className={
-              className ? `${TOOLTIP_CLASSES} ${className}` : TOOLTIP_CLASSES
-            }
-            {...getFloatingProps()}
-          >
-            {shortcut !== undefined ? (
-              <div className="flex items-center gap-3">
-                <span className="min-w-0 flex-1">{content}</span>
-                <kbd
-                  data-testid="tooltip-shortcut"
-                  className={SHORTCUT_CHIP_CLASSES}
-                >
-                  {formatShortcut(shortcut)}
-                </kbd>
-              </div>
-            ) : (
-              content
-            )}
-          </div>
+          {interactive ? (
+            <FloatingFocusManager
+              context={context}
+              // eslint-disable-next-line react/jsx-boolean-value -- non-modal lets Tab leave the floating surface after reaching its controls.
+              modal={false}
+              initialFocus={-1}
+            >
+              {floatingSurface}
+            </FloatingFocusManager>
+          ) : (
+            floatingSurface
+          )}
         </FloatingPortal>
       )}
     </>

--- a/src/features/agent-status/components/ActivityEvent.test.tsx
+++ b/src/features/agent-status/components/ActivityEvent.test.tsx
@@ -1,10 +1,42 @@
-import { describe, test, expect, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, test, expect, vi } from 'vitest'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ActivityEvent } from './ActivityEvent'
 import type { ToolActivityEvent } from '../types/activityEvent'
 
 const now = new Date('2026-04-22T12:00:00Z')
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  'clipboard'
+)
+
+afterEach(() => {
+  if (originalClipboardDescriptor) {
+    Object.defineProperty(
+      window.navigator,
+      'clipboard',
+      originalClipboardDescriptor
+    )
+
+    return
+  }
+
+  Reflect.deleteProperty(window.navigator, 'clipboard')
+})
+
+const setClipboard = (
+  clipboard:
+    | {
+        writeText: (text: string) => Promise<void>
+      }
+    | undefined
+): void => {
+  Object.defineProperty(window.navigator, 'clipboard', {
+    configurable: true,
+    value: clipboard,
+  })
+}
 
 const toolEvent = (
   overrides: Partial<ToolActivityEvent> = {}
@@ -357,22 +389,7 @@ describe('ActivityEvent — running state', () => {
 })
 
 describe('ActivityEvent — tooltip integration', () => {
-  // Unique-to-this-consumer concern: the body span only becomes a keyboard
-  // focus stop and a tooltip trigger when the text actually overflows. The
-  // hover-reveals-tooltip behavior is covered by Tooltip.test.tsx.
-  // jsdom reports scrollWidth and clientWidth as 0 without real layout, so
-  // mock the getters for the truncated path and leave defaults for the
-  // fits-in-container path.
-
-  test('marks body span as focusable with tabIndex 0 when truncated', async () => {
-    const scrollWidthSpy = vi
-      .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
-      .mockReturnValue(500)
-
-    const clientWidthSpy = vi
-      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
-      .mockReturnValue(100)
-
+  test('marks every activity row as focusable with tabIndex 0', () => {
     render(
       <ActivityEvent
         event={{
@@ -389,20 +406,13 @@ describe('ActivityEvent — tooltip integration', () => {
       />
     )
 
-    await waitFor(() =>
-      expect(
-        screen.getByText(/Tooltip\.tsx/, { selector: 'span' })
-      ).toHaveAttribute('tabindex', '0')
+    expect(screen.getByRole('article', { name: 'EDIT' })).toHaveAttribute(
+      'tabindex',
+      '0'
     )
-
-    scrollWidthSpy.mockRestore()
-    clientWidthSpy.mockRestore()
   })
 
-  test('omits tabIndex and keeps tooltip disabled when body fits container', async () => {
-    // Default jsdom layout: scrollWidth = clientWidth = 0, so !isTruncated.
-    const user = userEvent.setup()
-
+  test('shows activity details even when the body fits in the row', async () => {
     render(
       <ActivityEvent
         event={{
@@ -418,12 +428,91 @@ describe('ActivityEvent — tooltip integration', () => {
       />
     )
 
-    const body = screen.getByText('short.tsx', { selector: 'span' })
-    expect(body).not.toHaveAttribute('tabindex')
+    const row = screen.getByRole('article', { name: 'READ' })
+    fireEvent.focus(row)
 
-    await user.hover(body)
-    // With Tooltip disabled, no floating element ever mounts.
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    const details = await screen.findByRole('dialog', {
+      name: 'READ activity details',
+    })
+
+    expect(details).toHaveTextContent('short.tsx')
+  })
+
+  test('shows full activity details on row hover and copies the body', async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+
+    const body =
+      "pwd && echo '---' && git rev-parse --show-toplevel && npm run test -- --run src/features/agent-status/components/ActivityEvent.test.tsx"
+
+    setClipboard({ writeText })
+
+    render(
+      <ActivityEvent
+        event={{
+          id: 'e3',
+          kind: 'bash',
+          tool: 'Bash',
+          body,
+          timestamp: '2026-04-23T03:00:00Z',
+          status: 'done',
+          durationMs: 42,
+        }}
+        now={new Date('2026-04-23T03:01:00Z')}
+      />
+    )
+
+    const row = screen.getByRole('article', { name: 'BASH' })
+    fireEvent.focus(row)
+
+    const details = await screen.findByRole('dialog', {
+      name: 'BASH activity details',
+    })
+
+    expect(details).toHaveTextContent(body)
+    await user.click(
+      within(details).getByRole('button', { name: 'Copy activity details' })
+    )
+
+    expect(writeText).toHaveBeenCalledWith(body)
+    expect(within(details).getByText('Copied')).toBeInTheDocument()
+  })
+
+  test('shows copy failure when the Clipboard API is unavailable', async () => {
+    const user = userEvent.setup()
+
+    setClipboard(undefined)
+
+    render(
+      <ActivityEvent
+        event={{
+          id: 'e4',
+          kind: 'bash',
+          tool: 'Bash',
+          body: 'pnpm test',
+          timestamp: '2026-04-23T03:00:00Z',
+          status: 'done',
+          durationMs: 42,
+        }}
+        now={new Date('2026-04-23T03:01:00Z')}
+      />
+    )
+
+    const row = screen.getByRole('article', { name: 'BASH' })
+    fireEvent.focus(row)
+
+    const details = await screen.findByRole('dialog', {
+      name: 'BASH activity details',
+    })
+
+    await user.click(
+      within(details).getByRole('button', { name: 'Copy activity details' })
+    )
+
+    expect(within(details).getByText('Failed')).toBeInTheDocument()
+    expect(
+      within(details).getByRole('button', { name: 'Copy failed, try again' })
+    ).toBeInTheDocument()
   })
 })
 

--- a/src/features/agent-status/components/ActivityEvent.tsx
+++ b/src/features/agent-status/components/ActivityEvent.tsx
@@ -1,4 +1,12 @@
-import { useLayoutEffect, useRef, useState, type ReactElement } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type FocusEventHandler,
+  type KeyboardEventHandler,
+  type ReactElement,
+  type Ref,
+} from 'react'
 import { Tooltip } from '../../../components/Tooltip'
 import { formatRelativeTime, formatDuration } from '../utils/relativeTime'
 import type {
@@ -7,8 +15,14 @@ import type {
 } from '../types/activityEvent'
 
 interface ActivityEventProps {
+  ariaPosInSet?: number
+  ariaSetSize?: number
   event: ActivityEventType
   now: Date
+  onFocus?: FocusEventHandler<HTMLElement>
+  onKeyDown?: KeyboardEventHandler<HTMLElement>
+  rowRef?: Ref<HTMLElement>
+  tabIndex?: 0 | -1
 }
 
 const KIND_ICON: Record<ActivityEventKind, string> = {
@@ -70,6 +84,103 @@ const getBodyClass = (kind: ActivityEventKind): string => {
   return 'text-xs text-on-surface font-mono'
 }
 
+const COPY_FEEDBACK_MS = 1500
+
+type CopyState = 'idle' | 'copied' | 'failed'
+
+const writeClipboardText = async (text: string): Promise<void> => {
+  const clipboard = (window.navigator as unknown as { clipboard?: Clipboard })
+    .clipboard
+
+  if (clipboard?.writeText === undefined) {
+    throw new Error('Clipboard API unavailable')
+  }
+
+  await clipboard.writeText(text)
+}
+
+interface ActivityTooltipContentProps {
+  body: string
+  label: string
+}
+
+const ActivityTooltipContent = ({
+  body,
+  label,
+}: ActivityTooltipContentProps): ReactElement => {
+  const [copyState, setCopyState] = useState<CopyState>('idle')
+
+  useEffect(() => {
+    setCopyState('idle')
+  }, [body])
+
+  useEffect(() => {
+    if (copyState === 'idle') {
+      return
+    }
+
+    const id = window.setTimeout(() => setCopyState('idle'), COPY_FEEDBACK_MS)
+
+    return (): void => window.clearTimeout(id)
+  }, [copyState])
+
+  const handleCopy = useCallback(async (): Promise<void> => {
+    try {
+      await writeClipboardText(body)
+      setCopyState('copied')
+    } catch {
+      setCopyState('failed')
+    }
+  }, [body])
+
+  const copyButtonLabel =
+    copyState === 'copied'
+      ? 'Copied activity details'
+      : copyState === 'failed'
+        ? 'Copy failed, try again'
+        : 'Copy activity details'
+
+  const copyFeedback =
+    copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Failed' : ''
+
+  return (
+    <div className="w-[min(30rem,calc(100vw-2rem))]">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <span className="min-w-0 text-[10px] font-bold uppercase tracking-[0.12em] text-on-surface-variant">
+          {label}
+        </span>
+        <div className="flex shrink-0 items-center gap-2">
+          <span
+            aria-live="polite"
+            className="min-w-10 text-right text-[10px] font-semibold uppercase tracking-[0.08em] text-on-surface-variant"
+          >
+            {copyFeedback}
+          </span>
+          <button
+            type="button"
+            aria-label={copyButtonLabel}
+            onClick={(): void => {
+              void handleCopy()
+            }}
+            className="inline-flex h-6 items-center gap-1 rounded-md bg-on-surface/10 px-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-on-surface-variant transition-colors hover:bg-on-surface/15 hover:text-on-surface focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container"
+          >
+            <span
+              className="material-symbols-outlined text-sm"
+              aria-hidden="true"
+            >
+              {copyState === 'copied' ? 'check' : 'content_copy'}
+            </span>
+            Copy
+          </button>
+        </div>
+      </div>
+      <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md bg-surface-container/60 px-2.5 py-2 font-mono text-[11px] leading-relaxed text-on-surface">
+        {body}
+      </pre>
+    </div>
+  )
+}
+
 interface StatusChipsProps {
   event: ActivityEventType
 }
@@ -122,40 +233,19 @@ const StatusChips = ({ event }: StatusChipsProps): ReactElement | null => {
 }
 
 export const ActivityEvent = ({
+  ariaPosInSet = undefined,
+  ariaSetSize = undefined,
   event,
   now,
+  onFocus = undefined,
+  onKeyDown = undefined,
+  rowRef = undefined,
+  tabIndex = 0,
 }: ActivityEventProps): ReactElement => {
   const symbol = KIND_ICON[event.kind]
   const colorClass = KIND_COLOR[event.kind]
   const label = getLabel(event)
   const isRunning = event.status === 'running'
-
-  // Only surface the tooltip (and its keyboard focus stop) when the body
-  // actually overflows its container. Without this, a feed with many
-  // already-fitting rows adds redundant Tab stops proportional to event
-  // count and causes AT to double-announce content that's fully visible.
-  const bodyRef = useRef<HTMLSpanElement>(null)
-  const [isTruncated, setIsTruncated] = useState(false)
-
-  useLayoutEffect(() => {
-    const el = bodyRef.current
-    if (!el) {
-      return
-    }
-
-    const measure = (): void => {
-      setIsTruncated(el.scrollWidth > el.clientWidth)
-    }
-
-    measure()
-
-    const observer = new ResizeObserver(measure)
-    observer.observe(el)
-
-    return (): void => {
-      observer.disconnect()
-    }
-  }, [event.body])
 
   const timestampText = isRunning
     ? // Clamp negative deltas to zero so a tool whose emitted timestamp
@@ -165,50 +255,57 @@ export const ActivityEvent = ({
     : formatRelativeTime(event.timestamp, now)
 
   return (
-    <article aria-label={label} className="flex items-start gap-2 py-1">
-      <div className="relative">
-        <span
-          className={`material-symbols-outlined text-sm ${colorClass} w-6 h-6 rounded-md bg-surface-container-high flex items-center justify-center`}
-          aria-hidden="true"
-        >
-          {symbol}
-        </span>
-        {isRunning && (
+    <Tooltip
+      content={<ActivityTooltipContent body={event.body} label={label} />}
+      placement="left"
+      maxWidth={520}
+      interactive
+      ariaLabel={`${label} activity details`}
+      className="p-3"
+    >
+      <article
+        ref={rowRef}
+        aria-label={label}
+        aria-posinset={ariaPosInSet}
+        aria-setsize={ariaSetSize}
+        tabIndex={tabIndex}
+        onFocus={onFocus}
+        onKeyDown={onKeyDown}
+        className="flex items-start gap-2 rounded-md py-1 outline-none focus-visible:ring-1 focus-visible:ring-primary-container"
+      >
+        <div className="relative">
           <span
-            role="status"
-            aria-label="running"
-            className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-success animate-pulse"
-          />
-        )}
-      </div>
-
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center justify-between gap-2">
-          <span
-            className={`text-[10px] font-bold uppercase tracking-[0.12em] ${colorClass}`}
+            className={`material-symbols-outlined text-sm ${colorClass} w-6 h-6 rounded-md bg-surface-container-high flex items-center justify-center`}
+            aria-hidden="true"
           >
-            {label}
+            {symbol}
           </span>
-          <span className="text-[9px] font-mono text-outline">
-            {timestampText}
-          </span>
+          {isRunning && (
+            <span
+              role="status"
+              aria-label="running"
+              className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-success animate-pulse"
+            />
+          )}
         </div>
-        <Tooltip
-          content={event.body}
-          placement="left"
-          maxWidth={320}
-          disabled={!isTruncated}
-        >
-          <span
-            ref={bodyRef}
-            tabIndex={isTruncated ? 0 : undefined}
-            className={`mt-0.5 block truncate outline-none focus-visible:ring-1 focus-visible:ring-primary-container ${getBodyClass(event.kind)}`}
-          >
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <span
+              className={`text-[10px] font-bold uppercase tracking-[0.12em] ${colorClass}`}
+            >
+              {label}
+            </span>
+            <span className="text-[9px] font-mono text-outline">
+              {timestampText}
+            </span>
+          </div>
+          <span className={`mt-0.5 block truncate ${getBodyClass(event.kind)}`}>
             {event.body}
           </span>
-        </Tooltip>
-        <StatusChips event={event} />
-      </div>
-    </article>
+          <StatusChips event={event} />
+        </div>
+      </article>
+    </Tooltip>
   )
 }

--- a/src/features/agent-status/components/ActivityFeed.test.tsx
+++ b/src/features/agent-status/components/ActivityFeed.test.tsx
@@ -1,5 +1,11 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, act } from '@testing-library/react'
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  createEvent,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ActivityFeed } from './ActivityFeed'
 import type { ActivityEvent as ActivityEventType } from '../types/activityEvent'
@@ -97,6 +103,93 @@ describe('ActivityFeed', () => {
     expect(articles[2]).toHaveTextContent('src/third.ts')
   })
 
+  test('uses roving tabindex for activity rows', () => {
+    render(
+      <ActivityFeed
+        events={[
+          doneEvent('a', 'src/first.ts'),
+          doneEvent('b', 'src/second.ts'),
+          doneEvent('c', 'src/third.ts'),
+        ]}
+      />
+    )
+    const articles = screen.getAllByRole('article')
+
+    expect(articles[0]).toHaveAttribute('tabindex', '0')
+    expect(articles[1]).toHaveAttribute('tabindex', '-1')
+    expect(articles[2]).toHaveAttribute('tabindex', '-1')
+
+    act(() => {
+      articles[0].focus()
+    })
+    fireEvent.keyDown(articles[0], { key: 'ArrowDown' })
+
+    expect(articles[0]).toHaveAttribute('tabindex', '-1')
+    expect(articles[1]).toHaveAttribute('tabindex', '0')
+    expect(articles[1]).toHaveFocus()
+
+    fireEvent.keyDown(articles[1], { key: 'End' })
+
+    expect(articles[1]).toHaveAttribute('tabindex', '-1')
+    expect(articles[2]).toHaveAttribute('tabindex', '0')
+    expect(articles[2]).toHaveFocus()
+  })
+
+  test('prevents handled navigation keys at feed boundaries', () => {
+    render(
+      <ActivityFeed
+        events={[
+          doneEvent('a', 'src/first.ts'),
+          doneEvent('b', 'src/second.ts'),
+          doneEvent('c', 'src/third.ts'),
+        ]}
+      />
+    )
+    const articles = screen.getAllByRole('article')
+
+    const homeEvent = createEvent.keyDown(articles[0], { key: 'Home' })
+    fireEvent(articles[0], homeEvent)
+
+    expect(homeEvent.defaultPrevented).toBe(true)
+    expect(articles[0]).toHaveAttribute('tabindex', '0')
+
+    const upEvent = createEvent.keyDown(articles[0], { key: 'ArrowUp' })
+    fireEvent(articles[0], upEvent)
+
+    expect(upEvent.defaultPrevented).toBe(true)
+    expect(articles[0]).toHaveAttribute('tabindex', '0')
+
+    fireEvent.keyDown(articles[0], { key: 'End' })
+    expect(articles[2]).toHaveAttribute('tabindex', '0')
+
+    const downEvent = createEvent.keyDown(articles[2], { key: 'ArrowDown' })
+    fireEvent(articles[2], downEvent)
+
+    expect(downEvent.defaultPrevented).toBe(true)
+    expect(articles[2]).toHaveAttribute('tabindex', '0')
+  })
+
+  test('exposes activity rows as an ARIA feed', () => {
+    render(
+      <ActivityFeed
+        events={[
+          doneEvent('a', 'src/first.ts'),
+          doneEvent('b', 'src/second.ts'),
+          doneEvent('c', 'src/third.ts'),
+        ]}
+      />
+    )
+    const feed = screen.getByRole('feed', { name: 'Activity events' })
+    const articles = screen.getAllByRole('article')
+
+    expect(feed).toContainElement(articles[0])
+    expect(articles[0]).toHaveAttribute('aria-posinset', '1')
+    expect(articles[1]).toHaveAttribute('aria-posinset', '2')
+    expect(articles[2]).toHaveAttribute('aria-posinset', '3')
+    expect(articles[0]).toHaveAttribute('aria-setsize', '3')
+    expect(articles[2]).toHaveAttribute('aria-setsize', '3')
+  })
+
   test('rail layout element is present (last-resort testid)', () => {
     render(<ActivityFeed events={[doneEvent('a', 'src/a.ts')]} />)
 
@@ -108,8 +201,11 @@ describe('ActivityFeed', () => {
       doneEvent(`e${i}`, `src/${i}.ts`)
     )
     render(<ActivityFeed events={events} />)
+    const articles = screen.getAllByRole('article')
 
-    expect(screen.getAllByRole('article')).toHaveLength(10)
+    expect(articles).toHaveLength(10)
+    expect(articles[0]).toHaveAttribute('aria-setsize', '15')
+    expect(articles[9]).toHaveAttribute('aria-setsize', '15')
     expect(
       screen.getByRole('button', { name: /5 earlier events/i })
     ).toBeInTheDocument()

--- a/src/features/agent-status/components/ActivityFeed.tsx
+++ b/src/features/agent-status/components/ActivityFeed.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useState, type ReactElement } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+} from 'react'
 import { ActivityEvent } from './ActivityEvent'
 import { CollapsibleSection } from './CollapsibleSection'
 import type { ActivityEvent as ActivityEventType } from '../types/activityEvent'
@@ -16,6 +24,8 @@ const VISIBLE_WHEN_COLLAPSED = 10
 export const ActivityFeed = ({ events }: ActivityFeedProps): ReactElement => {
   const [now, setNow] = useState<Date>(() => new Date())
   const [showAll, setShowAll] = useState<boolean>(false)
+  const [activeEventId, setActiveEventId] = useState<string | null>(null)
+  const eventRefs = useRef<Map<string, HTMLElement>>(new Map())
 
   // Two separate effects — combining them into one `[hasRunning, events]`
   // dep list resets the interval on every event arrival, which stalls the
@@ -54,7 +64,62 @@ export const ActivityFeed = ({ events }: ActivityFeedProps): ReactElement => {
   }, [hasRunning])
 
   const overflow = events.length - VISIBLE_WHEN_COLLAPSED
-  const visible = showAll ? events : events.slice(0, VISIBLE_WHEN_COLLAPSED)
+
+  const visible = useMemo(
+    () => (showAll ? events : events.slice(0, VISIBLE_WHEN_COLLAPSED)),
+    [events, showAll]
+  )
+
+  const activeVisibleEventId =
+    activeEventId !== null &&
+    visible.some((event) => event.id === activeEventId)
+      ? activeEventId
+      : (visible[0]?.id ?? null)
+
+  useEffect(() => {
+    setActiveEventId((current) => {
+      if (visible.length === 0) {
+        return null
+      }
+
+      return current !== null && visible.some((event) => event.id === current)
+        ? current
+        : visible[0].id
+    })
+  }, [visible])
+
+  const handleEventKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>, index: number): void => {
+      let nextIndex: number | null = null
+      const lastIndex = visible.length - 1
+
+      if (event.key === 'ArrowDown') {
+        nextIndex = Math.min(index + 1, lastIndex)
+      } else if (event.key === 'ArrowUp') {
+        nextIndex = Math.max(index - 1, 0)
+      } else if (event.key === 'Home') {
+        nextIndex = 0
+      } else if (event.key === 'End') {
+        nextIndex = lastIndex
+      }
+
+      if (nextIndex === null) {
+        return
+      }
+
+      event.preventDefault()
+
+      if (nextIndex === index) {
+        return
+      }
+
+      const nextEvent = visible[nextIndex]
+
+      setActiveEventId(nextEvent.id)
+      eventRefs.current.get(nextEvent.id)?.focus()
+    },
+    [visible]
+  )
 
   return (
     <CollapsibleSection title="Activity" count={events.length} defaultExpanded>
@@ -62,15 +127,35 @@ export const ActivityFeed = ({ events }: ActivityFeedProps): ReactElement => {
         <p className="text-xs text-on-surface-variant">No activity yet</p>
       ) : (
         <>
-          <div className="relative">
+          <div role="feed" aria-label="Activity events" className="relative">
             <div
               data-testid="activity-feed-rail"
               className="absolute left-3 top-0 bottom-0 w-px bg-outline-variant/40"
               aria-hidden="true"
             />
             <div className="relative flex flex-col">
-              {visible.map((event) => (
-                <ActivityEvent key={event.id} event={event} now={now} />
+              {visible.map((event, index) => (
+                <ActivityEvent
+                  key={event.id}
+                  event={event}
+                  now={now}
+                  rowRef={(element): void => {
+                    if (element) {
+                      eventRefs.current.set(event.id, element)
+
+                      return
+                    }
+
+                    eventRefs.current.delete(event.id)
+                  }}
+                  ariaPosInSet={index + 1}
+                  ariaSetSize={events.length}
+                  tabIndex={event.id === activeVisibleEventId ? 0 : -1}
+                  onFocus={(): void => setActiveEventId(event.id)}
+                  onKeyDown={(keyboardEvent): void =>
+                    handleEventKeyDown(keyboardEvent, index)
+                  }
+                />
               ))}
             </div>
           </div>


### PR DESCRIPTION
## Summary

Adds interactive activity detail tooltips to every activity feed item, so short and truncated tool calls both expose the full command/script/function call on hover or focus.

## Why

The activity feed truncates long tool calls in the narrow panel. Users need a way to inspect the full payload without leaving the feed, and they need to copy that payload directly from the tooltip without adding one Tab stop per feed item.

## Changes

- Adds an opt-in interactive mode to the shared `Tooltip` primitive while preserving passive tooltip behavior by default.
- Wraps each `ActivityEvent` row in the interactive tooltip, with full pre-wrapped activity body text and a copy button.
- Removes the prior overflow-only tooltip gate so every activity row gets the same inspect/copy affordance.
- Adds roving tabindex handling in `ActivityFeed` so keyboard users get one feed Tab stop and can move between rows with arrow/Home/End keys.
- Requires `ariaLabel` at the type level for interactive tooltip dialogs.
- Updates Tooltip, ActivityEvent, and ActivityFeed coverage for interactive content, always-available activity details, roving focus, and copy feedback.

## Validation

- `npm run lint`
- `npm test -- --run src/components/Tooltip.test.tsx src/features/agent-status/components/ActivityEvent.test.tsx src/features/agent-status/components/ActivityFeed.test.tsx`
- `npm run type-check`
- Pre-push `npm test --passWithNoTests`: 182 files passed, 2427 tests passed, 3 skipped
