### PR TITLE
fix(tooltip): preserve floating anchor refs

### DIFF
--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,8 +1,31 @@
 import { createRef } from 'react'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
 import { Tooltip } from './Tooltip'
+
+const rect = ({
+  x,
+  y,
+  width,
+  height,
+}: {
+  x: number
+  y: number
+  width: number
+  height: number
+}): DOMRect =>
+  ({
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    left: x,
+    right: x + width,
+    bottom: y + height,
+    toJSON: () => ({}),
+  }) as DOMRect
 
 describe('Tooltip', () => {
   test('returns children unchanged when disabled', () => {
@@ -163,6 +186,49 @@ describe('Tooltip', () => {
 
     expect(ref.current).toBeInstanceOf(HTMLButtonElement)
     expect(ref.current?.textContent).toBe('trigger')
+  })
+
+  test('anchors the floating element when the trigger has its own ref', async () => {
+    const user = userEvent.setup()
+    const ref = createRef<HTMLButtonElement>()
+
+    const getBoundingClientRect = vi.spyOn(
+      HTMLElement.prototype,
+      'getBoundingClientRect'
+    )
+
+    getBoundingClientRect.mockImplementation(function (
+      this: HTMLElement
+    ): DOMRect {
+      if (this === ref.current) {
+        return rect({ x: 300, y: 100, width: 80, height: 32 })
+      }
+
+      if (this.getAttribute('role') === 'tooltip') {
+        return rect({ x: 0, y: 0, width: 64, height: 28 })
+      }
+
+      return rect({ x: 0, y: 0, width: 0, height: 0 })
+    })
+
+    try {
+      render(
+        <Tooltip content="hello" delayMs={0} placement="right">
+          <button ref={ref} type="button">
+            trigger
+          </button>
+        </Tooltip>
+      )
+
+      await user.hover(screen.getByRole('button', { name: 'trigger' }))
+      const tip = await screen.findByRole('tooltip')
+
+      await waitFor(() => {
+        expect(tip.getAttribute('style')).toMatch(/translate\((?!0px, 0px)/)
+      })
+    } finally {
+      getBoundingClientRect.mockRestore()
+    }
   })
 
   test('appends className to the baseline classes', async () => {

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -164,8 +164,8 @@ export const Tooltip = ({
   return (
     <>
       {cloneElement(children as ReactElement<Record<string, unknown>>, {
-        ref: mergedRef,
         ...getReferenceProps(children.props as Record<string, unknown>),
+        ref: mergedRef,
       })}
       {open && (
         <FloatingPortal>


### PR DESCRIPTION
## Summary

Fixes the shared `Tooltip` primitive so triggers that already carry a `ref` still receive Floating UI's merged reference ref.

## Why

PR #240 added interactive activity detail tooltips to `ActivityEvent` rows. Those rows pass their own `rowRef`, and the previous clone order let Floating UI's reference props overwrite the merged ref. As a result, Activity Feed/tool-call detail tooltips could fall back to the page origin instead of anchoring beside the hovered or focused row.

## Changes

- Applies Floating UI reference props before `ref: mergedRef` so the merged reference ref wins.
- Adds regression coverage for tooltip triggers that provide their own ref and verifies the floating element does not stay at `translate(0px, 0px)`.

## Issue linkage

No matching GitHub issue exists to reopen or close. Related regression source: #240.

## Validation

- `npx eslint src/components/Tooltip.tsx src/components/Tooltip.test.tsx`
- `npx vitest run src/components/Tooltip.test.tsx src/features/agent-status/components/ActivityEvent.test.tsx src/features/agent-status/components/ActivityFeed.test.tsx`
- `npm run type-check`
- Browser measurement: focused Activity Feed row anchored the dialog beside the row (`transform: translate(8px, 69px)`) instead of at page origin.
- Pre-push `npm test --passWithNoTests`: 183 files passed, 2468 tests passed, 3 skipped.
