### PR TITLE
[codex] default main-agent feature work to worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ VISUAL_VERIFICATION.md
 # Git worktrees (local per-agent checkouts)
 .claude/worktrees/
 .worktrees/
-worktrees/
+/worktrees/
 
 # Vimeflow runtime data (statusline sessions, etc.)
 .vimeflow/

--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,6 @@ VISUAL_VERIFICATION.md
 .codex-reviews/
 
 # Git worktrees (local per-agent checkouts)
-.claude/worktrees/
-.worktrees/
 /worktrees/
 
 # Vimeflow runtime data (statusline sessions, etc.)

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ VISUAL_VERIFICATION.md
 # Git worktrees (local per-agent checkouts)
 .claude/worktrees/
 .worktrees/
+worktrees/
 
 # Vimeflow runtime data (statusline sessions, etc.)
 .vimeflow/

--- a/rules/common/git-workflow.md
+++ b/rules/common/git-workflow.md
@@ -39,7 +39,7 @@ When creating PRs:
 ## Branching
 
 - **Never commit to `main`** — always work on a feature branch (`feat/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`, `perf/`, `ci/`).
-- The **interactive main agent** defaults to a dedicated linked worktree under `worktrees/<slug>/` when starting feature work (`git worktree add worktrees/<slug> -b feat/<name>` or `EnterWorktree`). A dirty primary checkout should not block the work; isolate the feature in a worktree instead.
+- The **interactive main agent** defaults to a dedicated linked worktree under `worktrees/<slug>/` when starting feature work (`git worktree add worktrees/<slug> -b <branch-name>`). A dirty primary checkout should not block the work; isolate the feature in a worktree instead.
 - The **primary checkout** is used for writing feature work only when the user explicitly asks for it or the task must modify the exact checkout the user has open. Read-only tasks can happen there without a branch.
 - **Subagents and Lifeline autonomous runs** (`/lifeline:loop`, dispatched parallel agents) must each isolate themselves in their own dedicated worktree under `worktrees/<slug>/`. See [worktrees.md](./worktrees.md).
 

--- a/rules/common/git-workflow.md
+++ b/rules/common/git-workflow.md
@@ -52,7 +52,7 @@ After creating a PR, the agent remains on the feature branch until the PR is res
 3. **Push fixes**: commit and push from the same branch
 4. **Repeat**: wait for next review cycle, fix, push
 5. **Done**: only the user merges or closes the PR
-6. **Cleanup**: after merge, remove the linked worktree and delete the local branch; for primary-checkout overrides, return to `main` and delete the local branch. See [worktrees.md](./worktrees.md).
+6. **Cleanup**: after merge, remove the linked worktree and delete the local branch; for primary-checkout overrides, return to `main` and delete the local branch. In both cases, refresh the primary checkout's `main` from the remote default branch before starting the next branch or worktree. See [worktrees.md](./worktrees.md).
 
 > For the full development process (planning, TDD, code review) before git operations,
 > see [development-workflow.md](./development-workflow.md).

--- a/rules/common/git-workflow.md
+++ b/rules/common/git-workflow.md
@@ -39,23 +39,24 @@ When creating PRs:
 ## Branching
 
 - **Never commit to `main`** — always work on a feature branch (`feat/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`, `perf/`, `ci/`).
-- The **interactive main agent** checks out a feature branch in the **primary checkout** (`git checkout -b feat/<name>`). It does not create a worktree for itself — the user's diff viewer depends on seeing live edits in the primary checkout.
-- **Subagents and Lifeline autonomous runs** (`/lifeline:loop`, dispatched parallel agents) must isolate themselves in a dedicated worktree under `.claude/worktrees/<branch>/`. See [worktrees.md](./worktrees.md).
+- The **interactive main agent** defaults to a dedicated linked worktree under `.claude/worktrees/<slug>/` when starting feature work (`git worktree add .claude/worktrees/<slug> -b feat/<name>` or `EnterWorktree`). A dirty primary checkout should not block the work; isolate the feature in a worktree instead.
+- The **primary checkout** is used for writing feature work only when the user explicitly asks for it or the task must modify the exact checkout the user has open. Read-only tasks can happen there without a branch.
+- **Subagents and Lifeline autonomous runs** (`/lifeline:loop`, dispatched parallel agents) must each isolate themselves in their own dedicated worktree under `.claude/worktrees/<slug>/`. See [worktrees.md](./worktrees.md).
 
 ## Post-PR Protocol
 
 After creating a PR, the agent remains on the feature branch until the PR is resolved:
 
-1. **Stay**: remain on the feature branch (primary checkout for main agent, linked worktree for subagents) — do not return to `main`
+1. **Stay**: remain on the feature branch in the same worktree or primary-checkout override — do not return to `main`
 2. **Review-fix loop**: run `/lifeline:upsource-review` to fetch and address code review findings
 3. **Push fixes**: commit and push from the same branch
 4. **Repeat**: wait for next review cycle, fix, push
 5. **Done**: only the user merges or closes the PR
-6. **Cleanup**: after merge, return to `main` and delete the local branch (and remove the worktree if one was used — see [worktrees.md](./worktrees.md))
+6. **Cleanup**: after merge, remove the linked worktree and delete the local branch; for primary-checkout overrides, return to `main` and delete the local branch. See [worktrees.md](./worktrees.md).
 
 > For the full development process (planning, TDD, code review) before git operations,
 > see [development-workflow.md](./development-workflow.md).
 
 ## Multi-Agent Workflows
 
-When multiple agents work simultaneously, each subagent must use a dedicated git worktree. The interactive main agent stays in the primary checkout. See [worktrees.md](./worktrees.md) for lifecycle, lock contention guardrails, and cleanup procedures.
+When multiple agents work simultaneously, every writing agent gets a dedicated git worktree by default, including the interactive main agent. Do not share a worktree across agents unless the user explicitly asks for handoff or integration work in that checkout. See [worktrees.md](./worktrees.md) for lifecycle, lock contention guardrails, and cleanup procedures.

--- a/rules/common/git-workflow.md
+++ b/rules/common/git-workflow.md
@@ -39,9 +39,9 @@ When creating PRs:
 ## Branching
 
 - **Never commit to `main`** — always work on a feature branch (`feat/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`, `perf/`, `ci/`).
-- The **interactive main agent** defaults to a dedicated linked worktree under `.claude/worktrees/<slug>/` when starting feature work (`git worktree add .claude/worktrees/<slug> -b feat/<name>` or `EnterWorktree`). A dirty primary checkout should not block the work; isolate the feature in a worktree instead.
+- The **interactive main agent** defaults to a dedicated linked worktree under `worktrees/<slug>/` when starting feature work (`git worktree add worktrees/<slug> -b feat/<name>` or `EnterWorktree`). A dirty primary checkout should not block the work; isolate the feature in a worktree instead.
 - The **primary checkout** is used for writing feature work only when the user explicitly asks for it or the task must modify the exact checkout the user has open. Read-only tasks can happen there without a branch.
-- **Subagents and Lifeline autonomous runs** (`/lifeline:loop`, dispatched parallel agents) must each isolate themselves in their own dedicated worktree under `.claude/worktrees/<slug>/`. See [worktrees.md](./worktrees.md).
+- **Subagents and Lifeline autonomous runs** (`/lifeline:loop`, dispatched parallel agents) must each isolate themselves in their own dedicated worktree under `worktrees/<slug>/`. See [worktrees.md](./worktrees.md).
 
 ## Post-PR Protocol
 

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -93,8 +93,8 @@ Cleanup mode is the exception to the stay-on-branch rule above. Once the PR is r
 **Linked worktree (default for main agent, Lifeline, and subagents):**
 
 ```bash
-# From inside the linked worktree, return to the primary checkout first
-cd "$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
+# From the linked worktree root (worktrees/<slug>), return to the primary checkout first
+cd ../..
 # Use the same <slug> and <branch-name> from the worktree add step above
 git worktree remove worktrees/<slug>
 git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -93,14 +93,13 @@ Cleanup mode is the exception to the stay-on-branch rule above. Once the PR is r
 **Linked worktree (default for main agent, Lifeline, and subagents):**
 
 ```bash
-# From the linked worktree root (worktrees/<slug>), return to the primary checkout first
-cd ../..
+# Replace <repo-root> with the absolute path to the primary checkout
 # Use the same <slug> and <branch-name> from the worktree add step above
-git worktree remove worktrees/<slug>
-git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
-git worktree prune                 # clean up stale worktree metadata
-git checkout main
-git pull --ff-only
+git -C <repo-root> worktree remove worktrees/<slug>
+git -C <repo-root> branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
+git -C <repo-root> worktree prune                 # clean up stale worktree metadata
+git -C <repo-root> checkout main
+git -C <repo-root> pull --ff-only
 ```
 
 **Primary-checkout override:**

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -180,14 +180,13 @@ A worktree is likely stale if:
 ### Cleanup all stale worktrees
 
 ```bash
-# Remove each stale worktree
-git worktree remove worktrees/<stale-branch>
+# Replace <repo-root> with the absolute path to the primary checkout
+# Remove each stale worktree and its matching local branch
+git -C <repo-root> worktree remove worktrees/<stale-slug>
+git -C <repo-root> branch -D <stale-branch-name>
 
 # After removing worktrees, prune metadata
-git worktree prune
-
-# Delete merged local branches
-git branch --merged main | grep -v '^\*\|main' | xargs -r git branch -d
+git -C <repo-root> worktree prune
 ```
 
 ## Hook Enforcement

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -93,7 +93,8 @@ Cleanup mode is the exception to the stay-on-branch rule above. Once the PR is r
 **Linked worktree (default for main agent, Lifeline, and subagents):**
 
 ```bash
-# From the primary checkout
+# From inside the linked worktree, return to the primary checkout first
+cd "$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
 git worktree remove worktrees/<slug>
 git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
 git worktree prune                 # clean up stale worktree metadata

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -16,8 +16,8 @@
 | ------------------------------ | ---------------------------- | ----------------------------- |
 | Interactive main agent         | `worktrees/<slug>/`          | Feature branch (never `main`) |
 | Explicit primary-checkout work | Primary checkout (repo root) | Feature branch (never `main`) |
-| `/lifeline:loop` (autonomous)  | `worktrees/<branch>/`        | Feature branch                |
-| Dispatched parallel subagents  | `worktrees/<branch>/`        | Feature branch                |
+| `/lifeline:loop` (autonomous)  | `worktrees/<slug>/`          | Feature branch                |
+| Dispatched parallel subagents  | `worktrees/<slug>/`          | Feature branch                |
 | Read-only research             | Primary checkout             | `main` is fine                |
 
 ## Worktree Location
@@ -44,13 +44,13 @@ Each worktree is a complete working directory with its own `src/`, `node_modules
 
 ```bash
 # From the primary checkout
-git worktree add worktrees/<slug> -b feat/<name>
+git worktree add worktrees/<slug> -b <branch-name>
 cd worktrees/<slug>
 npm install
 # edit, commit, push, create PR — all from the linked worktree
 ```
 
-Or use Claude Code's built-in `EnterWorktree` if available, pointed at `worktrees/<slug>/`. This is the normal path when a main agent starts a feature.
+Use a descriptive feature branch such as `feat/<name>`, `fix/<name>`, or `refactor/<name>`. Do not rely on worktree helper defaults that may create the checkout outside `worktrees/<slug>/`.
 
 If the user explicitly asks the main agent to work in the primary checkout, use a feature branch there instead:
 
@@ -68,7 +68,7 @@ cd worktrees/<slug>
 npm install
 ```
 
-Or use Claude Code's built-in `EnterWorktree`, pointed at `worktrees/<slug>/`. This path applies to `/lifeline:loop` and any parallel dispatched agents.
+Use the explicit `worktrees/<slug>/` path above for `/lifeline:loop` and any parallel dispatched agents.
 
 ### ACTIVE
 
@@ -95,6 +95,7 @@ Cleanup mode is the exception to the stay-on-branch rule above. Once the PR is r
 ```bash
 # From inside the linked worktree, return to the primary checkout first
 cd "$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
+# Use the same <slug> and <branch-name> from the worktree add step above
 git worktree remove worktrees/<slug>
 git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
 git worktree prune                 # clean up stale worktree metadata

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -3,35 +3,35 @@
 ## Principles
 
 1. **`main` branch is sacred** — never commit directly to `main`. The primary checkout may stay on `main` while feature work happens in a linked worktree.
-2. **Main-agent feature work defaults to a worktree** — when the interactive main agent starts implementation work for a feature or fix, it creates/enters a dedicated linked worktree under `.claude/worktrees/<slug>/` on a feature branch (`feat/<name>`, `fix/<name>`, etc.) and commits there.
+2. **Main-agent feature work defaults to a worktree** — when the interactive main agent starts implementation work for a feature or fix, it creates/enters a dedicated linked worktree under `worktrees/<slug>/` on a feature branch (`feat/<name>`, `fix/<name>`, etc.) and commits there.
    - **Why:** defaulting to an isolated worktree keeps the primary checkout available for the user's app, ad hoc inspection, or unrelated local edits. A dirty primary checkout is not a reason to block feature work; create a worktree instead.
    - **Exception:** use the primary checkout only when the user explicitly asks for it, the task is read-only, or the work must modify the exact checkout the user has open.
-3. **Subagents and Lifeline runs use their own worktree** — any autonomous or parallel agent (`/lifeline:loop`, dispatched parallel agents) must be fully isolated under `.claude/worktrees/<slug>/` so it does not fight the user, the main agent, or another subagent for a working tree.
+3. **Subagents and Lifeline runs use their own worktree** — any autonomous or parallel agent (`/lifeline:loop`, dispatched parallel agents) must be fully isolated under `worktrees/<slug>/` so it does not fight the user, the main agent, or another subagent for a working tree.
 4. **Read-only tasks skip branching** — research, exploration, and answering questions can happen on `main` in the primary checkout. No branch needed.
 5. **Git commands start with `git`** — always invoke git as the first token in the command (e.g., `git push`, not `ENV=val git push` or `cd repo && git push`). This ensures the PreToolUse hook can reliably detect and guard git operations. This framework is designed for agents, not humans — compound shell expressions are unnecessary.
 
 ## Who Works Where
 
-| Actor                          | Location                      | Branch                        |
-| ------------------------------ | ----------------------------- | ----------------------------- |
-| Interactive main agent         | `.claude/worktrees/<slug>/`   | Feature branch (never `main`) |
-| Explicit primary-checkout work | Primary checkout (repo root)  | Feature branch (never `main`) |
-| `/lifeline:loop` (autonomous)  | `.claude/worktrees/<branch>/` | Feature branch                |
-| Dispatched parallel subagents  | `.claude/worktrees/<branch>/` | Feature branch                |
-| Read-only research             | Primary checkout              | `main` is fine                |
+| Actor                          | Location                     | Branch                        |
+| ------------------------------ | ---------------------------- | ----------------------------- |
+| Interactive main agent         | `worktrees/<slug>/`          | Feature branch (never `main`) |
+| Explicit primary-checkout work | Primary checkout (repo root) | Feature branch (never `main`) |
+| `/lifeline:loop` (autonomous)  | `worktrees/<branch>/`        | Feature branch                |
+| Dispatched parallel subagents  | `worktrees/<branch>/`        | Feature branch                |
+| Read-only research             | Primary checkout             | `main` is fine                |
 
 ## Worktree Location
 
-All agent worktrees live under `.claude/worktrees/` (gitignored, local-only):
+All agent worktrees live under `worktrees/` (gitignored, local-only):
 
 ```
 Vimeflow/                          ← primary checkout (user baseline / explicit override only)
+├── worktrees/                     ← gitignored (local-only)
+│   ├── feat-agent-sidebar/        ← main agent's feature checkout
+│   ├── feat-lifeline-retry/       ← Lifeline loop's full checkout
+│   └── refactor-parallel-a/       ← dispatched subagent's full checkout
 ├── .claude/
-│   ├── skills/                    ← tracked in git (pushed to repo)
-│   └── worktrees/                 ← gitignored (local-only)
-│       ├── feat-agent-sidebar/    ← main agent's feature checkout
-│       ├── feat-lifeline-retry/   ← Lifeline loop's full checkout
-│       └── refactor-parallel-a/   ← dispatched subagent's full checkout
+│   └── skills/                    ← tracked in git (pushed to repo)
 ├── src/
 └── ...
 ```
@@ -44,13 +44,13 @@ Each worktree is a complete working directory with its own `src/`, `node_modules
 
 ```bash
 # From the primary checkout
-git worktree add .claude/worktrees/<slug> -b feat/<name>
-cd .claude/worktrees/<slug>
+git worktree add worktrees/<slug> -b feat/<name>
+cd worktrees/<slug>
 npm install
 # edit, commit, push, create PR — all from the linked worktree
 ```
 
-Or use Claude Code's built-in `EnterWorktree` if available; it creates under `.claude/worktrees/` by default. This is the normal path when a main agent starts a feature.
+Or use Claude Code's built-in `EnterWorktree` if available, pointed at `worktrees/<slug>/`. This is the normal path when a main agent starts a feature.
 
 If the user explicitly asks the main agent to work in the primary checkout, use a feature branch there instead:
 
@@ -63,12 +63,12 @@ git checkout -b feat/<name>
 
 ```bash
 # From the primary checkout
-git worktree add .claude/worktrees/<slug> -b <branch-name>
-cd .claude/worktrees/<slug>
+git worktree add worktrees/<slug> -b <branch-name>
+cd worktrees/<slug>
 npm install
 ```
 
-Or use Claude Code's built-in `EnterWorktree` (creates under `.claude/worktrees/` by default). This path applies to `/lifeline:loop` and any parallel dispatched agents.
+Or use Claude Code's built-in `EnterWorktree`, pointed at `worktrees/<slug>/`. This path applies to `/lifeline:loop` and any parallel dispatched agents.
 
 ### ACTIVE
 
@@ -92,7 +92,7 @@ After the user merges or closes the PR:
 
 ```bash
 # From the primary checkout
-git worktree remove .claude/worktrees/<slug>
+git worktree remove worktrees/<slug>
 git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
 git worktree prune                 # clean up stale worktree metadata
 ```
@@ -176,7 +176,7 @@ A worktree is likely stale if:
 
 ```bash
 # Remove each stale worktree
-git worktree remove .claude/worktrees/<stale-branch>
+git worktree remove worktrees/<stale-branch>
 
 # After removing worktrees, prune metadata
 git worktree prune

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -2,31 +2,34 @@
 
 ## Principles
 
-1. **`main` branch is sacred** — never commit directly to `main`. The primary checkout is allowed (and expected) to be on a feature branch during active work.
-2. **Main agent works on a feature branch in the primary checkout** — the interactive Claude Code agent checks out `feat/<name>` (or `fix/`, `refactor/`, etc.) in the primary checkout and commits there. It does **not** create a worktree for itself.
-   - **Why:** the user runs the Vimeflow app from the primary checkout and watches the diff viewer live. Edits inside `.claude/worktrees/` are invisible to that view because the diff viewer only reflects its own cwd's working tree.
-3. **Subagents and Lifeline runs use a worktree** — any autonomous or parallel agent (`/lifeline:loop`, dispatched parallel agents) must be fully isolated under `.claude/worktrees/<branch>/` so it does not fight the user or the main agent for the working tree.
+1. **`main` branch is sacred** — never commit directly to `main`. The primary checkout may stay on `main` while feature work happens in a linked worktree.
+2. **Main-agent feature work defaults to a worktree** — when the interactive main agent starts implementation work for a feature or fix, it creates/enters a dedicated linked worktree under `.claude/worktrees/<slug>/` on a feature branch (`feat/<name>`, `fix/<name>`, etc.) and commits there.
+   - **Why:** defaulting to an isolated worktree keeps the primary checkout available for the user's app, ad hoc inspection, or unrelated local edits. A dirty primary checkout is not a reason to block feature work; create a worktree instead.
+   - **Exception:** use the primary checkout only when the user explicitly asks for it, the task is read-only, or the work must modify the exact checkout the user has open.
+3. **Subagents and Lifeline runs use their own worktree** — any autonomous or parallel agent (`/lifeline:loop`, dispatched parallel agents) must be fully isolated under `.claude/worktrees/<slug>/` so it does not fight the user, the main agent, or another subagent for a working tree.
 4. **Read-only tasks skip branching** — research, exploration, and answering questions can happen on `main` in the primary checkout. No branch needed.
 5. **Git commands start with `git`** — always invoke git as the first token in the command (e.g., `git push`, not `ENV=val git push` or `cd repo && git push`). This ensures the PreToolUse hook can reliably detect and guard git operations. This framework is designed for agents, not humans — compound shell expressions are unnecessary.
 
 ## Who Works Where
 
-| Actor                         | Location                      | Branch                        |
-| ----------------------------- | ----------------------------- | ----------------------------- |
-| Interactive main agent        | Primary checkout (repo root)  | Feature branch (never `main`) |
-| `/lifeline:loop` (autonomous) | `.claude/worktrees/<branch>/` | Feature branch                |
-| Dispatched parallel subagents | `.claude/worktrees/<branch>/` | Feature branch                |
-| Read-only research            | Primary checkout              | `main` is fine                |
+| Actor                          | Location                      | Branch                        |
+| ------------------------------ | ----------------------------- | ----------------------------- |
+| Interactive main agent         | `.claude/worktrees/<slug>/`   | Feature branch (never `main`) |
+| Explicit primary-checkout work | Primary checkout (repo root)  | Feature branch (never `main`) |
+| `/lifeline:loop` (autonomous)  | `.claude/worktrees/<branch>/` | Feature branch                |
+| Dispatched parallel subagents  | `.claude/worktrees/<branch>/` | Feature branch                |
+| Read-only research             | Primary checkout              | `main` is fine                |
 
 ## Worktree Location
 
-All subagent and Lifeline worktrees live under `.claude/worktrees/` (gitignored, local-only):
+All agent worktrees live under `.claude/worktrees/` (gitignored, local-only):
 
 ```
-Vimeflow/                          ← primary checkout (main agent works here on feat/* branch)
+Vimeflow/                          ← primary checkout (user baseline / explicit override only)
 ├── .claude/
 │   ├── skills/                    ← tracked in git (pushed to repo)
 │   └── worktrees/                 ← gitignored (local-only)
+│       ├── feat-agent-sidebar/    ← main agent's feature checkout
 │       ├── feat-lifeline-retry/   ← Lifeline loop's full checkout
 │       └── refactor-parallel-a/   ← dispatched subagent's full checkout
 ├── src/
@@ -37,34 +40,43 @@ Each worktree is a complete working directory with its own `src/`, `node_modules
 
 ## Lifecycle
 
-### Main agent (interactive) — feature branch in primary checkout
+### Main agent (interactive) — dedicated worktree by default
+
+```bash
+# From the primary checkout
+git worktree add .claude/worktrees/<slug> -b feat/<name>
+cd .claude/worktrees/<slug>
+npm install
+# edit, commit, push, create PR — all from the linked worktree
+```
+
+Or use Claude Code's built-in `EnterWorktree` if available; it creates under `.claude/worktrees/` by default. This is the normal path when a main agent starts a feature.
+
+If the user explicitly asks the main agent to work in the primary checkout, use a feature branch there instead:
 
 ```bash
 # From the primary checkout, starting on main
 git checkout -b feat/<name>
-# edit, commit, push, create PR — all from the primary checkout
 ```
-
-Do **not** run `EnterWorktree` reflexively at the start of an interactive task. Check out a feature branch instead so the user's diff viewer reflects your live edits.
 
 ### Subagent / Lifeline — dedicated worktree
 
 ```bash
 # From the primary checkout
-git worktree add .claude/worktrees/<branch-name> -b <branch-name>
-cd .claude/worktrees/<branch-name>
+git worktree add .claude/worktrees/<slug> -b <branch-name>
+cd .claude/worktrees/<slug>
 npm install
 ```
 
-Or use Claude Code's built-in: `EnterWorktree` (creates under `.claude/worktrees/` by default). This path applies to `/lifeline:loop` and any parallel dispatched agents.
+Or use Claude Code's built-in `EnterWorktree` (creates under `.claude/worktrees/` by default). This path applies to `/lifeline:loop` and any parallel dispatched agents.
 
 ### ACTIVE
 
-Agent works normally — edit, commit, push, create PR. Whether this happens in the primary checkout (main agent) or a linked worktree (subagent), the PR lifecycle is the same.
+Agent works normally — edit, commit, push, create PR. Whether this happens in a linked worktree (default) or a primary-checkout override, the PR lifecycle is the same.
 
 **Once a PR is created, the agent stays on that branch (or in that worktree) until the PR is resolved.** Do not switch back to `main` between creating the PR and the PR being merged or closed. This ensures review-fix cycles (`/lifeline:upsource-review`) happen in the correct working directory without branch switching.
 
-The PR lifecycle (primary checkout or linked worktree):
+The PR lifecycle:
 
 ```
 create PR → wait for review → fix findings → push → wait for review → ... → merged/closed
@@ -76,21 +88,21 @@ Only the **user** decides when a PR is merged. Agents do not merge PRs unless ex
 
 After the user merges or closes the PR:
 
-**Main agent (feature branch in primary checkout):**
+**Linked worktree (default for main agent, Lifeline, and subagents):**
+
+```bash
+# From the primary checkout
+git worktree remove .claude/worktrees/<slug>
+git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
+git worktree prune                 # clean up stale worktree metadata
+```
+
+**Primary-checkout override:**
 
 ```bash
 git checkout main
 git pull
 git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
-```
-
-**Subagent / Lifeline (linked worktree):**
-
-```bash
-# From the primary checkout
-git worktree remove .claude/worktrees/<branch-name>
-git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
-git worktree prune                 # clean up stale worktree metadata
 ```
 
 > **Why `-D` not `-d`:** Because this repo mandates squash-and-merge, the feature branch's individual commits never become ancestors of `main` — only the single squash commit does. `git branch -d` refuses to delete a branch it considers "not fully merged" and will fail on every normal cleanup. Use `-D` unconditionally.

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -88,6 +88,8 @@ Only the **user** decides when a PR is merged. Agents do not merge PRs unless ex
 
 After the user merges or closes the PR:
 
+Cleanup mode is the exception to the stay-on-branch rule above. Once the PR is resolved, the agent must refresh the primary checkout's `main` from the remote default branch before starting another branch or worktree. This baseline-refresh action is required after linked-worktree cleanup and after primary-checkout override cleanup so the next feature never branches from stale `main`.
+
 **Linked worktree (default for main agent, Lifeline, and subagents):**
 
 ```bash
@@ -101,7 +103,6 @@ git worktree prune                 # clean up stale worktree metadata
 
 ```bash
 git checkout main
-git pull
 git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
 ```
 

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -97,12 +97,15 @@ Cleanup mode is the exception to the stay-on-branch rule above. Once the PR is r
 git worktree remove worktrees/<slug>
 git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
 git worktree prune                 # clean up stale worktree metadata
+git checkout main
+git pull --ff-only
 ```
 
 **Primary-checkout override:**
 
 ```bash
 git checkout main
+git pull --ff-only
 git branch -D <branch-name>       # squash-merge: -D is always required; -d would fail
 ```
 

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -122,7 +122,7 @@ fi
 #
 # If -C or --work-tree was used, run the check against that directory instead
 # of the current working directory — this prevents false positives when
-# agents use git -C worktrees/<branch> commit from the primary checkout.
+# agents use git -C worktrees/<slug> commit from the primary checkout.
 if [ -n "$git_target_dir" ]; then
   current_branch=$(git -C "$git_target_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 else

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -7,8 +7,9 @@
 # Returns exit 0 (allow) otherwise — feature branches are fine anywhere.
 #
 # Policy (see rules/common/worktrees.md):
-#   - Main agent works on a feature branch in the primary checkout.
-#   - Subagents / Lifeline runs work on a feature branch in a linked worktree.
+#   - Main-agent feature work defaults to a feature branch in a linked worktree.
+#   - Subagents / Lifeline runs each use their own feature-branch worktree.
+#   - Primary-checkout feature work is an explicit user-directed override.
 #   - Nobody commits to `main`, ever.
 #
 # Hook input (JSON on stdin) contains the tool parameters.
@@ -134,8 +135,8 @@ if [ -z "$current_branch" ]; then
 fi
 
 if [ "$current_branch" = "main" ]; then
-  echo "BLOCKED: Cannot commit/push while on 'main'. Check out a feature branch first: git checkout -b feat/<name>" >&2
-  echo "        (Subagents / Lifeline runs should create a worktree: git worktree add .claude/worktrees/<branch> -b <branch>)" >&2
+  echo "BLOCKED: Cannot commit/push while on 'main'. Create a feature worktree first: git worktree add .claude/worktrees/<slug> -b feat/<name>" >&2
+  echo "        (Use the primary checkout only when the user explicitly asks for that override.)" >&2
   exit 2
 fi
 

--- a/scripts/hooks/block-main-commit.sh
+++ b/scripts/hooks/block-main-commit.sh
@@ -122,7 +122,7 @@ fi
 #
 # If -C or --work-tree was used, run the check against that directory instead
 # of the current working directory — this prevents false positives when
-# agents use git -C .claude/worktrees/<branch> commit from the primary checkout.
+# agents use git -C worktrees/<branch> commit from the primary checkout.
 if [ -n "$git_target_dir" ]; then
   current_branch=$(git -C "$git_target_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 else
@@ -135,7 +135,7 @@ if [ -z "$current_branch" ]; then
 fi
 
 if [ "$current_branch" = "main" ]; then
-  echo "BLOCKED: Cannot commit/push while on 'main'. Create a feature worktree first: git worktree add .claude/worktrees/<slug> -b feat/<name>" >&2
+  echo "BLOCKED: Cannot commit/push while on 'main'. Create a feature worktree first: git worktree add worktrees/<slug> -b feat/<name>" >&2
   echo "        (Use the primary checkout only when the user explicitly asks for that override.)" >&2
   exit 2
 fi


### PR DESCRIPTION
## Summary

- Make linked worktrees the default location for interactive main-agent feature and fix work.
- Use top-level `worktrees/<slug>/` as the default worktree path and keep only anchored `/worktrees/` in `.gitignore` for the canonical local checkout root.
- Keep primary-checkout feature work as an explicit override for user-directed cases.
- Require cleanup mode to refresh the primary checkout `main` from the remote default branch before any next branch or worktree, and show `git pull --ff-only` in both cleanup examples so agents execute the refresh.
- Make linked-worktree cleanup and stale-worktree cleanup independent of shell working-directory state by pinning commands to the primary checkout with `git -C <repo-root>`.
- Remove ambiguous `EnterWorktree` helper guidance and align lifecycle placeholders so `worktrees/<slug>/` and `<branch-name>` are carried consistently from creation through cleanup.
- Update the git workflow summary and the main-branch commit/push hook guidance to point agents at `git worktree add worktrees/<slug>`.

## Validation

- `bash -n scripts/hooks/block-main-commit.sh`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `rg -n '\\.claude/worktrees|\\.worktrees|EnterWorktree|worktrees/<branch>|git worktree remove worktrees/' .gitignore rules/common/worktrees.md rules/common/git-workflow.md scripts/hooks/block-main-commit.sh` returns no matches.
- `npm test` via pre-push hook: 183 test files passed, 2468 tests passed, 3 skipped. Existing React `act(...)` and CodeMirror/jsdom warnings were printed during the run.