### PR TITLE
feat(agent-status): liquid bucket cursor response

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -62,6 +62,9 @@ words:
   - catppuccin
   - Catppuccin
 
+  # Custom DOM events
+  - vfliquidwake
+
   # Workspace domain abbreviations
   - sess # session
   - proj # project

--- a/docs/superpowers/plans/2026-05-22-liquid-bucket-cursor-response.md
+++ b/docs/superpowers/plans/2026-05-22-liquid-bucket-cursor-response.md
@@ -1,0 +1,2043 @@
+# Liquid Bucket Cursor Response Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a cursor-responsive water effect on the agent-status feature's bucket fills (rail CTX/CACHE and expanded-panel CURRENT CONTEXT) via a shared `LiquidFill` SVG primitive + `useWaterCursor` hook, with structural reset, locked tuning defaults, and no global listeners.
+
+**Architecture:** New `useWaterCursor` hook in `src/features/agent-status/hooks/` drives a critically-damped spring on 8 scalar signals and writes inline `transform` attributes directly to SVG refs on rAF. New `LiquidFill` component in `src/features/agent-status/components/` renders the SVG (glass cell, base rect below the wave trough, two phase-offset wave paths, sheen ellipse), nests pct-driven `translateY` groups around cursor-driven `scaleY/translateX/skewX` groups so the two concerns don't fight, and supports `mode="bar"` (fixed 22×110, used by `Bucket`) + `mode="fill"` (ResizeObserver-measured, used by `ContextBucket`). The existing `Bucket.tsx` SVG body is replaced by `<LiquidFill mode="bar" />`; `ContextBucket.tsx`'s flat-gradient fill div is replaced by `<LiquidFill mode="fill" className="h-full w-full" />` with a local `hexForColorClass` helper returning Tailwind hex literals. CSS keyframes rename `vf-bucket-*` → `vf-liquid-*`.
+
+**Tech Stack:** React 18 + TypeScript + Vite + Tailwind v3 (frontend), Vitest + Testing Library + jsdom (tests). No backend changes.
+
+**Spec:** [docs/superpowers/specs/2026-05-22-liquid-bucket-cursor-response-design.md](../specs/2026-05-22-liquid-bucket-cursor-response-design.md)
+
+---
+
+## Task 1: Rename `vf-bucket-*` CSS → `vf-liquid-*` (no behavior change)
+
+The keyframes and class names move out of bucket-specific territory because `LiquidFill` will be used by `ContextBucket` too. Behavior is unchanged at this step — only names rotate, plus the new `[data-interactive="on"]` selector that the hook needs.
+
+**Files:**
+
+- Modify: `src/index.css:187-215`
+- Modify: `src/features/agent-status/components/Bucket.tsx:176` (`className="vf-bucket-slosh"`)
+- Modify: `src/features/agent-status/components/Bucket.tsx:188` (`className="vf-bucket-wave-a"`)
+- Modify: `src/features/agent-status/components/Bucket.tsx:193` (`className="vf-bucket-wave-b"`)
+
+- [ ] **Step 1: Rename keyframes + classes in `src/index.css`**
+
+Replace lines 187-215 of `src/index.css` with:
+
+```css
+@keyframes vfLiquidSlosh {
+  0%,
+  100% {
+    transform: translateX(0) rotate(0deg);
+  }
+  50% {
+    transform: translateX(0.4px) rotate(0.6deg);
+  }
+}
+
+@keyframes vfLiquidWaveA {
+  from {
+    transform: translateX(-50%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes vfLiquidWaveB {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.vf-liquid-wave-a {
+  animation: vfLiquidWaveA var(--vf-liquid-wave-a-dur, 3.4s) linear infinite;
+}
+
+.vf-liquid-wave-b {
+  animation: vfLiquidWaveB var(--vf-liquid-wave-b-dur, 4.8s) linear infinite;
+}
+
+.vf-liquid-slosh {
+  animation: vfLiquidSlosh 2.6s ease-in-out infinite;
+}
+
+.vf-liquid-slosh[data-interactive='on'] {
+  animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vf-liquid-wave-a,
+  .vf-liquid-wave-b,
+  .vf-liquid-slosh {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 2: Rename the three class refs in `Bucket.tsx`**
+
+In `src/features/agent-status/components/Bucket.tsx`, change:
+
+- `className="vf-bucket-slosh"` → `className="vf-liquid-slosh"` (line 176)
+- `<g className="vf-bucket-wave-a">` → `<g className="vf-liquid-wave-a">` (line 188)
+- `<g className="vf-bucket-wave-b">` → `<g className="vf-liquid-wave-b">` (line 193)
+
+- [ ] **Step 3: Run existing Bucket tests to verify no regression**
+
+Run: `npx vitest run src/features/agent-status/components/Bucket.test.tsx`
+Expected: PASS — the test file does not assert on class names, only on `data-testid` attributes, so the rename is invisible to it.
+
+- [ ] **Step 4: Run lint + type-check**
+
+Run: `npm run lint && npm run type-check`
+Expected: PASS, no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.css src/features/agent-status/components/Bucket.tsx
+git commit -m "refactor(agent-status): rename vf-bucket-* CSS to vf-liquid-*"
+```
+
+---
+
+## Task 2: Create `useWaterCursor` hook skeleton + reduced-motion gate
+
+Failing test first. The skeleton attaches `pointermove` / `pointerleave` to `wrapRef.current` on mount, removes them on unmount, and is a no-op when `prefers-reduced-motion: reduce` matches.
+
+**Files:**
+
+- Create: `src/features/agent-status/hooks/useWaterCursor.ts`
+- Create: `src/features/agent-status/hooks/useWaterCursor.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/features/agent-status/hooks/useWaterCursor.test.tsx`:
+
+```tsx
+import { render } from '@testing-library/react'
+import { useEffect, useRef, type ReactElement } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { useWaterCursor, type LiquidRefs } from './useWaterCursor'
+
+interface MqlMock {
+  matches: boolean
+  addEventListener: ReturnType<typeof vi.fn>
+  removeEventListener: ReturnType<typeof vi.fn>
+}
+
+const makeMql = (matches: boolean): MqlMock => ({
+  matches,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+})
+
+const mockMatchMedia = (mql: MqlMock): void => {
+  vi.spyOn(window, 'matchMedia').mockImplementation(
+    () => mql as unknown as MediaQueryList
+  )
+}
+
+interface HarnessProps {
+  refs: LiquidRefs
+  addSpy: ReturnType<typeof vi.fn>
+  removeSpy: ReturnType<typeof vi.fn>
+}
+
+const Harness = ({ refs, addSpy, removeSpy }: HarnessProps): ReactElement => {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const refsRef = useRef<LiquidRefs | null>(refs)
+  useEffect(() => {
+    if (wrapRef.current === null) return
+    const el = wrapRef.current
+    const origAdd = el.addEventListener.bind(el)
+    const origRemove = el.removeEventListener.bind(el)
+    el.addEventListener = ((...args: Parameters<typeof origAdd>) => {
+      addSpy(args[0])
+      return origAdd(...args)
+    }) as typeof el.addEventListener
+    el.removeEventListener = ((...args: Parameters<typeof origRemove>) => {
+      removeSpy(args[0])
+      return origRemove(...args)
+    }) as typeof el.removeEventListener
+  }, [addSpy, removeSpy])
+  useWaterCursor(wrapRef, refsRef)
+  return <div ref={wrapRef} data-testid="wrap" />
+}
+
+const makeRefs = (): LiquidRefs => ({
+  slosh: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  waveAShift: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  waveBShift: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  waveAAnim: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  waveBAnim: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  sheen: document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'ellipse'
+  ) as SVGEllipseElement,
+  waterTop: 10,
+  ambientAmp: 1.8,
+  dims: { w: 22, h: 110 },
+})
+
+describe('useWaterCursor — skeleton + reduced-motion gate', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('attaches pointermove and pointerleave on mount when motion allowed', () => {
+    mockMatchMedia(makeMql(false))
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+    render(<Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />)
+    const kinds = addSpy.mock.calls.map((c) => c[0])
+    expect(kinds).toContain('pointermove')
+    expect(kinds).toContain('pointerleave')
+  })
+
+  test('skips listener registration under prefers-reduced-motion', () => {
+    mockMatchMedia(makeMql(true))
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+    render(<Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />)
+    const kinds = addSpy.mock.calls.map((c) => c[0])
+    expect(kinds).not.toContain('pointermove')
+    expect(kinds).not.toContain('pointerleave')
+  })
+
+  test('removes listeners on unmount', () => {
+    mockMatchMedia(makeMql(false))
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+    const { unmount } = render(
+      <Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />
+    )
+    unmount()
+    const kinds = removeSpy.mock.calls.map((c) => c[0])
+    expect(kinds).toContain('pointermove')
+    expect(kinds).toContain('pointerleave')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail (module not found)**
+
+Run: `npx vitest run src/features/agent-status/hooks/useWaterCursor.test.tsx`
+Expected: FAIL with "Failed to resolve import './useWaterCursor'".
+
+- [ ] **Step 3: Implement the hook skeleton**
+
+Create `src/features/agent-status/hooks/useWaterCursor.ts`:
+
+```ts
+import { useEffect, type RefObject } from 'react'
+
+export interface LiquidRefs {
+  slosh: SVGGElement
+  waveAShift: SVGGElement
+  waveBShift: SVGGElement
+  waveAAnim: SVGGElement
+  waveBAnim: SVGGElement
+  sheen: SVGEllipseElement
+  waterTop: number
+  ambientAmp: number
+  dims: { w: number; h: number }
+}
+
+export const LIQUID_DEFAULTS = {
+  halo: 70,
+  omega: 6.5,
+  maxTilt: 1.6,
+  ampMax: 1.5,
+  maxShift: 1.0,
+  maxLift: 1.0,
+  meniscus: 2.3,
+  speedup: 1.02,
+} as const
+
+export type LiquidTune = typeof LIQUID_DEFAULTS
+
+export const useWaterCursor = (
+  wrapRef: RefObject<HTMLElement | null>,
+  refsRef: RefObject<LiquidRefs | null>,
+  tune: Partial<LiquidTune> = {}
+): void => {
+  useEffect(() => {
+    const wrap = wrapRef.current
+    if (wrap === null) return
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    if (mql.matches) return
+
+    const onMove = (_e: PointerEvent): void => {
+      void _e
+      void tune
+      void refsRef
+    }
+    const onLeave = (): void => {}
+
+    wrap.addEventListener('pointermove', onMove)
+    wrap.addEventListener('pointerleave', onLeave)
+
+    return (): void => {
+      wrap.removeEventListener('pointermove', onMove)
+      wrap.removeEventListener('pointerleave', onLeave)
+    }
+  }, [wrapRef, refsRef, tune])
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/features/agent-status/hooks/useWaterCursor.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run lint + type-check**
+
+Run: `npm run lint && npm run type-check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/agent-status/hooks/useWaterCursor.ts src/features/agent-status/hooks/useWaterCursor.test.tsx
+git commit -m "feat(agent-status): scaffold useWaterCursor hook with reduced-motion gate"
+```
+
+---
+
+## Task 3: `useWaterCursor` — pointer-driven spring loop + clearInline
+
+This task makes the hook actually drive the SVG. TDD: assert that a `pointermove` over the wrap leads to `data-interactive="on"` on `refs.slosh` and a non-zero inline `transform`, and that a `pointerleave` eventually clears those after the spring settles.
+
+**Files:**
+
+- Modify: `src/features/agent-status/hooks/useWaterCursor.ts`
+- Modify: `src/features/agent-status/hooks/useWaterCursor.test.tsx`
+
+- [ ] **Step 1: Append failing tests for the loop**
+
+Add to the bottom of `src/features/agent-status/hooks/useWaterCursor.test.tsx`:
+
+```tsx
+import { act } from '@testing-library/react'
+
+const flushRaf = async (frames: number): Promise<void> => {
+  for (let i = 0; i < frames; i++) {
+    await act(async () => {
+      // Each tick advances rAF callbacks scheduled within React effects/timers.
+      await new Promise((r) => setTimeout(r, 16))
+    })
+  }
+}
+
+describe('useWaterCursor — spring loop', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('pointermove writes data-interactive=on and non-zero rotate', async () => {
+    mockMatchMedia(makeMql(false))
+    const refs = makeRefs()
+    const { getByTestId } = render(
+      <Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />
+    )
+    const wrap = getByTestId('wrap')
+    Object.defineProperty(wrap, 'getBoundingClientRect', {
+      value: () => ({
+        left: 0,
+        top: 0,
+        right: 100,
+        bottom: 100,
+        width: 100,
+        height: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    })
+    await act(async () => {
+      wrap.dispatchEvent(
+        new PointerEvent('pointermove', {
+          clientX: 80,
+          clientY: 50,
+          bubbles: true,
+        })
+      )
+    })
+    await flushRaf(2)
+    expect(refs.slosh.getAttribute('data-interactive')).toBe('on')
+    expect(refs.slosh.style.transform).toMatch(/rotate\(/)
+    expect(refs.slosh.style.transform).not.toMatch(/rotate\(0(\.0+)?deg\)/)
+  })
+
+  test('pointerleave settles back and clears inline', async () => {
+    mockMatchMedia(makeMql(false))
+    const refs = makeRefs()
+    const { getByTestId } = render(
+      <Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />
+    )
+    const wrap = getByTestId('wrap')
+    Object.defineProperty(wrap, 'getBoundingClientRect', {
+      value: () => ({
+        left: 0,
+        top: 0,
+        right: 100,
+        bottom: 100,
+        width: 100,
+        height: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    })
+    await act(async () => {
+      wrap.dispatchEvent(
+        new PointerEvent('pointermove', { clientX: 80, clientY: 50 })
+      )
+    })
+    await flushRaf(2)
+    await act(async () => {
+      wrap.dispatchEvent(new PointerEvent('pointerleave'))
+    })
+    await flushRaf(80) // > 1s — well past spring settle at omega=6.5
+    expect(refs.slosh.getAttribute('data-interactive')).toBeNull()
+    expect(refs.slosh.style.transform).toBe('')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/features/agent-status/hooks/useWaterCursor.test.tsx -t "spring loop"`
+Expected: FAIL — `data-interactive` is never set; `slosh.style.transform` stays empty.
+
+- [ ] **Step 3: Replace the hook body with the full spring loop**
+
+Replace the entire contents of `src/features/agent-status/hooks/useWaterCursor.ts` with:
+
+```ts
+import { useEffect, type RefObject } from 'react'
+
+export interface LiquidRefs {
+  slosh: SVGGElement
+  waveAShift: SVGGElement
+  waveBShift: SVGGElement
+  waveAAnim: SVGGElement
+  waveBAnim: SVGGElement
+  sheen: SVGEllipseElement
+  waterTop: number
+  ambientAmp: number
+  dims: { w: number; h: number }
+}
+
+export const LIQUID_DEFAULTS = {
+  halo: 70,
+  omega: 6.5,
+  maxTilt: 1.6,
+  ampMax: 1.5,
+  maxShift: 1.0,
+  maxLift: 1.0,
+  meniscus: 2.3,
+  speedup: 1.02,
+} as const
+
+export type LiquidTune = typeof LIQUID_DEFAULTS
+
+type Signal =
+  | 'tilt'
+  | 'amp'
+  | 'shiftX'
+  | 'lift'
+  | 'skew'
+  | 'speedT'
+  | 'sheenX'
+  | 'sheenA'
+
+type SignalState = Record<Signal, number>
+
+const initialTarget = (): SignalState => ({
+  tilt: 0,
+  amp: 1,
+  shiftX: 0,
+  lift: 0,
+  skew: 0,
+  speedT: 0,
+  sheenX: 0,
+  sheenA: 0,
+})
+
+const initialVel = (): SignalState => ({
+  tilt: 0,
+  amp: 0,
+  shiftX: 0,
+  lift: 0,
+  skew: 0,
+  speedT: 0,
+  sheenX: 0,
+  sheenA: 0,
+})
+
+export const useWaterCursor = (
+  wrapRef: RefObject<HTMLElement | null>,
+  refsRef: RefObject<LiquidRefs | null>,
+  tune: Partial<LiquidTune> = {}
+): void => {
+  useEffect(() => {
+    const wrap = wrapRef.current
+    if (wrap === null) return
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    if (mql.matches) return
+
+    const T: LiquidTune = { ...LIQUID_DEFAULTS, ...tune }
+
+    const target = initialTarget()
+    let cur = initialTarget()
+    let vel = initialVel()
+    let rafId: number | null = null
+    let lastT = performance.now()
+    let active = false
+
+    const onMove = (e: PointerEvent): void => {
+      const refs = refsRef.current
+      if (refs === null) return
+      const r = wrap.getBoundingClientRect()
+      const cx = r.left + r.width / 2
+      const cy = r.top + r.height / 2
+      const dx = e.clientX - cx
+      const dy = e.clientY - cy
+      const dist = Math.hypot(dx, dy)
+      const linear = Math.max(0, 1 - dist / (T.halo + r.width / 2))
+      const proximity = linear * linear * (3 - 2 * linear)
+      const norm = Math.max(-1, Math.min(1, dx / (r.width / 2 + T.halo)))
+      const aboveBelow = Math.max(-1, Math.min(1, dy / (r.height / 2 + T.halo)))
+      target.tilt = norm * proximity * T.maxTilt
+      target.amp = 1 + proximity * (T.ampMax - 1)
+      target.shiftX = norm * proximity * T.maxShift
+      target.lift = -aboveBelow * proximity * T.maxLift
+      target.skew = norm * proximity * T.meniscus
+      target.speedT = proximity
+      target.sheenX = norm
+      target.sheenA = proximity
+      ensureLoop()
+    }
+
+    const onLeave = (): void => {
+      target.tilt = 0
+      target.amp = 1
+      target.shiftX = 0
+      target.lift = 0
+      target.skew = 0
+      target.speedT = 0
+      target.sheenA = 0
+      ensureLoop()
+    }
+
+    const apply = (): void => {
+      const refs = refsRef.current
+      if (refs === null) return
+      if (!active) {
+        refs.slosh.setAttribute('data-interactive', 'on')
+        active = true
+      }
+      refs.slosh.style.transform = `rotate(${cur.tilt.toFixed(3)}deg)`
+      refs.slosh.style.transformOrigin = `${refs.dims.w / 2}px ${refs.dims.h}px`
+
+      const tx = `translateY(${cur.lift.toFixed(3)}px) scaleY(${cur.amp.toFixed(
+        4
+      )}) translateX(${cur.shiftX.toFixed(
+        3
+      )}px) skewX(${(-cur.skew).toFixed(3)}deg)`
+      const txA = `translateY(${cur.lift.toFixed(
+        3
+      )}px) scaleY(${cur.amp.toFixed(4)}) translateX(${(
+        cur.shiftX * 0.6
+      ).toFixed(3)}px) skewX(${(-cur.skew).toFixed(3)}deg)`
+      refs.waveAShift.style.transform = txA
+      refs.waveBShift.style.transform = tx
+
+      const speedFactor = 1 + cur.speedT * (T.speedup - 1)
+      refs.waveAAnim.style.animationDuration =
+        (3.4 / speedFactor).toFixed(3) + 's'
+      refs.waveBAnim.style.animationDuration =
+        (4.8 / speedFactor).toFixed(3) + 's'
+
+      const w = refs.dims.w
+      const sheenX = w / 2 + cur.sheenX * (w / 2 - 1)
+      refs.sheen.setAttribute('cx', sheenX.toFixed(2))
+      refs.sheen.setAttribute('cy', (refs.waterTop + cur.lift - 0.3).toFixed(2))
+      refs.sheen.setAttribute('fill-opacity', (cur.sheenA * 0.55).toFixed(3))
+    }
+
+    const clearInline = (): void => {
+      const refs = refsRef.current
+      if (refs === null) return
+      refs.slosh.removeAttribute('data-interactive')
+      refs.slosh.style.transform = ''
+      refs.slosh.style.transformOrigin = ''
+      refs.waveAShift.style.transform = ''
+      refs.waveBShift.style.transform = ''
+      refs.waveAAnim.style.animationDuration = ''
+      refs.waveBAnim.style.animationDuration = ''
+      refs.sheen.setAttribute('fill-opacity', '0')
+      active = false
+    }
+
+    function ensureLoop(): void {
+      if (rafId !== null) return
+      lastT = performance.now()
+      const step = (t: number): void => {
+        const dt = Math.min(0.05, (t - lastT) / 1000)
+        lastT = t
+        const w = T.omega
+        const keys: Signal[] = [
+          'tilt',
+          'amp',
+          'shiftX',
+          'lift',
+          'skew',
+          'speedT',
+          'sheenX',
+          'sheenA',
+        ]
+        for (const k of keys) {
+          const a = -2 * w * vel[k] - w * w * (cur[k] - target[k])
+          vel[k] += a * dt
+          cur[k] += vel[k] * dt
+        }
+        apply()
+
+        const settled =
+          Math.abs(cur.tilt - target.tilt) < 0.01 &&
+          Math.abs(cur.amp - target.amp) < 0.005 &&
+          Math.abs(cur.shiftX - target.shiftX) < 0.02 &&
+          Math.abs(cur.lift - target.lift) < 0.02 &&
+          Math.abs(cur.skew - target.skew) < 0.02 &&
+          Math.abs(cur.speedT - target.speedT) < 0.01 &&
+          Math.abs(cur.sheenA - target.sheenA) < 0.01 &&
+          Math.abs(cur.sheenX - target.sheenX) < 0.01
+        const atRest =
+          target.tilt === 0 &&
+          target.amp === 1 &&
+          target.shiftX === 0 &&
+          target.lift === 0 &&
+          target.skew === 0 &&
+          target.speedT === 0 &&
+          target.sheenA === 0
+        if (settled && atRest) {
+          cur = initialTarget()
+          vel = initialVel()
+          clearInline()
+          rafId = null
+          return
+        }
+        rafId = requestAnimationFrame(step)
+      }
+      rafId = requestAnimationFrame(step)
+    }
+
+    wrap.addEventListener('pointermove', onMove)
+    wrap.addEventListener('pointerleave', onLeave)
+
+    return (): void => {
+      if (rafId !== null) cancelAnimationFrame(rafId)
+      rafId = null
+      wrap.removeEventListener('pointermove', onMove)
+      wrap.removeEventListener('pointerleave', onLeave)
+      clearInline()
+    }
+  }, [wrapRef, refsRef, tune])
+}
+```
+
+- [ ] **Step 4: Run all `useWaterCursor` tests to verify they pass**
+
+Run: `npx vitest run src/features/agent-status/hooks/useWaterCursor.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run lint + type-check**
+
+Run: `npm run lint && npm run type-check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/agent-status/hooks/useWaterCursor.ts src/features/agent-status/hooks/useWaterCursor.test.tsx
+git commit -m "feat(agent-status): drive useWaterCursor with critically-damped spring"
+```
+
+---
+
+## Task 4: `useWaterCursor` — live-toggle reduced-motion
+
+`prefers-reduced-motion` flips while the app is running need to detach listeners on the spot. TDD: simulate a `change` event with `matches: true` and assert `pointermove` is no longer wired up; flip back to `false` and assert it is re-wired.
+
+**Files:**
+
+- Modify: `src/features/agent-status/hooks/useWaterCursor.ts`
+- Modify: `src/features/agent-status/hooks/useWaterCursor.test.tsx`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `src/features/agent-status/hooks/useWaterCursor.test.tsx`:
+
+```tsx
+describe('useWaterCursor — runtime reduced-motion toggle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('change → matches:true detaches pointer listeners', () => {
+    const mql = makeMql(false)
+    mockMatchMedia(mql)
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+    render(<Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />)
+    expect(addSpy.mock.calls.map((c) => c[0])).toContain('pointermove')
+
+    // Simulate OS-level Reduce Motion toggling ON.
+    const changeListener = mql.addEventListener.mock.calls.find(
+      (c) => c[0] === 'change'
+    )?.[1] as ((e: { matches: boolean }) => void) | undefined
+    expect(changeListener).toBeDefined()
+    changeListener?.({ matches: true })
+
+    expect(removeSpy.mock.calls.map((c) => c[0])).toContain('pointermove')
+    expect(removeSpy.mock.calls.map((c) => c[0])).toContain('pointerleave')
+  })
+
+  test('change → matches:false reattaches pointer listeners', () => {
+    const mql = makeMql(true)
+    mockMatchMedia(mql)
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+    render(<Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />)
+    expect(addSpy.mock.calls.map((c) => c[0])).not.toContain('pointermove')
+
+    const changeListener = mql.addEventListener.mock.calls.find(
+      (c) => c[0] === 'change'
+    )?.[1] as ((e: { matches: boolean }) => void) | undefined
+    changeListener?.({ matches: false })
+
+    expect(addSpy.mock.calls.map((c) => c[0])).toContain('pointermove')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/features/agent-status/hooks/useWaterCursor.test.tsx -t "runtime reduced-motion"`
+Expected: FAIL — `mql.addEventListener` is never called.
+
+- [ ] **Step 3: Refactor the hook to subscribe to `mql.change`**
+
+Replace the body of the `useEffect` callback in `src/features/agent-status/hooks/useWaterCursor.ts` with a structure that can attach/detach pointer listeners dynamically. Replace the `useEffect` block with:
+
+```ts
+useEffect(() => {
+  const wrap = wrapRef.current
+  if (wrap === null) return
+  const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+
+  const T: LiquidTune = { ...LIQUID_DEFAULTS, ...tune }
+
+  const target = initialTarget()
+  let cur = initialTarget()
+  let vel = initialVel()
+  let rafId: number | null = null
+  let lastT = performance.now()
+  let active = false
+  let attached = false
+
+  const onMove = (e: PointerEvent): void => {
+    const refs = refsRef.current
+    if (refs === null) return
+    const r = wrap.getBoundingClientRect()
+    const cx = r.left + r.width / 2
+    const cy = r.top + r.height / 2
+    const dx = e.clientX - cx
+    const dy = e.clientY - cy
+    const dist = Math.hypot(dx, dy)
+    const linear = Math.max(0, 1 - dist / (T.halo + r.width / 2))
+    const proximity = linear * linear * (3 - 2 * linear)
+    const norm = Math.max(-1, Math.min(1, dx / (r.width / 2 + T.halo)))
+    const aboveBelow = Math.max(-1, Math.min(1, dy / (r.height / 2 + T.halo)))
+    target.tilt = norm * proximity * T.maxTilt
+    target.amp = 1 + proximity * (T.ampMax - 1)
+    target.shiftX = norm * proximity * T.maxShift
+    target.lift = -aboveBelow * proximity * T.maxLift
+    target.skew = norm * proximity * T.meniscus
+    target.speedT = proximity
+    target.sheenX = norm
+    target.sheenA = proximity
+    ensureLoop()
+  }
+
+  const onLeave = (): void => {
+    target.tilt = 0
+    target.amp = 1
+    target.shiftX = 0
+    target.lift = 0
+    target.skew = 0
+    target.speedT = 0
+    target.sheenA = 0
+    ensureLoop()
+  }
+
+  const apply = (): void => {
+    const refs = refsRef.current
+    if (refs === null) return
+    if (!active) {
+      refs.slosh.setAttribute('data-interactive', 'on')
+      active = true
+    }
+    refs.slosh.style.transform = `rotate(${cur.tilt.toFixed(3)}deg)`
+    refs.slosh.style.transformOrigin = `${refs.dims.w / 2}px ${refs.dims.h}px`
+    const tx = `translateY(${cur.lift.toFixed(3)}px) scaleY(${cur.amp.toFixed(
+      4
+    )}) translateX(${cur.shiftX.toFixed(
+      3
+    )}px) skewX(${(-cur.skew).toFixed(3)}deg)`
+    const txA = `translateY(${cur.lift.toFixed(
+      3
+    )}px) scaleY(${cur.amp.toFixed(4)}) translateX(${(cur.shiftX * 0.6).toFixed(
+      3
+    )}px) skewX(${(-cur.skew).toFixed(3)}deg)`
+    refs.waveAShift.style.transform = txA
+    refs.waveBShift.style.transform = tx
+    const speedFactor = 1 + cur.speedT * (T.speedup - 1)
+    refs.waveAAnim.style.animationDuration =
+      (3.4 / speedFactor).toFixed(3) + 's'
+    refs.waveBAnim.style.animationDuration =
+      (4.8 / speedFactor).toFixed(3) + 's'
+    const w = refs.dims.w
+    const sheenX = w / 2 + cur.sheenX * (w / 2 - 1)
+    refs.sheen.setAttribute('cx', sheenX.toFixed(2))
+    refs.sheen.setAttribute('cy', (refs.waterTop + cur.lift - 0.3).toFixed(2))
+    refs.sheen.setAttribute('fill-opacity', (cur.sheenA * 0.55).toFixed(3))
+  }
+
+  const clearInline = (): void => {
+    const refs = refsRef.current
+    if (refs === null) return
+    refs.slosh.removeAttribute('data-interactive')
+    refs.slosh.style.transform = ''
+    refs.slosh.style.transformOrigin = ''
+    refs.waveAShift.style.transform = ''
+    refs.waveBShift.style.transform = ''
+    refs.waveAAnim.style.animationDuration = ''
+    refs.waveBAnim.style.animationDuration = ''
+    refs.sheen.setAttribute('fill-opacity', '0')
+    active = false
+  }
+
+  function ensureLoop(): void {
+    if (rafId !== null) return
+    lastT = performance.now()
+    const step = (t: number): void => {
+      const dt = Math.min(0.05, (t - lastT) / 1000)
+      lastT = t
+      const w = T.omega
+      const keys: Signal[] = [
+        'tilt',
+        'amp',
+        'shiftX',
+        'lift',
+        'skew',
+        'speedT',
+        'sheenX',
+        'sheenA',
+      ]
+      for (const k of keys) {
+        const a = -2 * w * vel[k] - w * w * (cur[k] - target[k])
+        vel[k] += a * dt
+        cur[k] += vel[k] * dt
+      }
+      apply()
+      const settled =
+        Math.abs(cur.tilt - target.tilt) < 0.01 &&
+        Math.abs(cur.amp - target.amp) < 0.005 &&
+        Math.abs(cur.shiftX - target.shiftX) < 0.02 &&
+        Math.abs(cur.lift - target.lift) < 0.02 &&
+        Math.abs(cur.skew - target.skew) < 0.02 &&
+        Math.abs(cur.speedT - target.speedT) < 0.01 &&
+        Math.abs(cur.sheenA - target.sheenA) < 0.01 &&
+        Math.abs(cur.sheenX - target.sheenX) < 0.01
+      const atRest =
+        target.tilt === 0 &&
+        target.amp === 1 &&
+        target.shiftX === 0 &&
+        target.lift === 0 &&
+        target.skew === 0 &&
+        target.speedT === 0 &&
+        target.sheenA === 0
+      if (settled && atRest) {
+        cur = initialTarget()
+        vel = initialVel()
+        clearInline()
+        rafId = null
+        return
+      }
+      rafId = requestAnimationFrame(step)
+    }
+    rafId = requestAnimationFrame(step)
+  }
+
+  const attach = (): void => {
+    if (attached) return
+    wrap.addEventListener('pointermove', onMove)
+    wrap.addEventListener('pointerleave', onLeave)
+    attached = true
+  }
+
+  const detach = (): void => {
+    if (!attached) return
+    wrap.removeEventListener('pointermove', onMove)
+    wrap.removeEventListener('pointerleave', onLeave)
+    attached = false
+    if (rafId !== null) cancelAnimationFrame(rafId)
+    rafId = null
+    clearInline()
+  }
+
+  const onMqlChange = (e: MediaQueryListEvent | { matches: boolean }): void => {
+    if (e.matches) detach()
+    else attach()
+  }
+  mql.addEventListener('change', onMqlChange as EventListener)
+
+  if (!mql.matches) attach()
+
+  return (): void => {
+    mql.removeEventListener('change', onMqlChange as EventListener)
+    detach()
+  }
+}, [wrapRef, refsRef, tune])
+```
+
+- [ ] **Step 4: Run all `useWaterCursor` tests to verify they pass**
+
+Run: `npx vitest run src/features/agent-status/hooks/useWaterCursor.test.tsx`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Run lint + type-check**
+
+Run: `npm run lint && npm run type-check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/agent-status/hooks/useWaterCursor.ts src/features/agent-status/hooks/useWaterCursor.test.tsx
+git commit -m "feat(agent-status): live-toggle pointer listeners on reduced-motion change"
+```
+
+---
+
+## Task 5: `LiquidFill` primitive — `mode="bar"` geometry (no hook attached yet)
+
+Write the SVG renderer for the rail-bucket geometry (22×110, two phase-offset waves, base rect below the trough, nested transform groups, tick marks). The hook will be wired up in Task 6.
+
+**Files:**
+
+- Create: `src/features/agent-status/components/LiquidFill.tsx`
+- Create: `src/features/agent-status/components/LiquidFill.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/features/agent-status/components/LiquidFill.test.tsx`:
+
+```tsx
+import { render } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import { LiquidFill } from './LiquidFill'
+
+describe('LiquidFill — bar mode geometry', () => {
+  test('renders SVG with viewBox "0 0 22 110"', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 22 110')
+    expect(svg?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  test('base rect y equals top + ambientAmp + 0.5', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
+    // pct=50 → liquidH=(110-4)*0.5=53 → top=57. ambientAmp = min(1.8, 22*0.09) = 1.8.
+    // base.y expected = 57 + 1.8 + 0.5 = 59.3
+    const baseRect = container.querySelector('rect[data-testid="liquid-base"]')
+    expect(baseRect).not.toBeNull()
+    expect(parseFloat(baseRect!.getAttribute('y') ?? '0')).toBeCloseTo(59.3, 1)
+  })
+
+  test('renders tick marks at 25/50/75', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
+    expect(
+      container.querySelector('[data-testid="liquid-tick-25"]')
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="liquid-tick-50"]')
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="liquid-tick-75"]')
+    ).not.toBeNull()
+  })
+
+  test('renders two phase-offset wave paths in nested transform groups', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
+    expect(
+      container.querySelector(
+        '[data-testid="liquid-water-y-a"] [data-testid="liquid-wave-shift-a"] path'
+      )
+    ).not.toBeNull()
+    expect(
+      container.querySelector(
+        '[data-testid="liquid-water-y-b"] [data-testid="liquid-wave-shift-b"] path'
+      )
+    ).not.toBeNull()
+  })
+
+  test('outer div carries the caller testId and className', () => {
+    const { container } = render(
+      <LiquidFill
+        mode="bar"
+        pct={50}
+        color="#cba6f7"
+        testId="lf"
+        className="some-class"
+      />
+    )
+    const wrap = container.querySelector('[data-testid="lf"]')
+    expect(wrap).not.toBeNull()
+    expect(wrap?.className).toContain('some-class')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail (module not found)**
+
+Run: `npx vitest run src/features/agent-status/components/LiquidFill.test.tsx`
+Expected: FAIL with "Failed to resolve import './LiquidFill'".
+
+- [ ] **Step 3: Implement `LiquidFill.tsx` for bar mode**
+
+Create `src/features/agent-status/components/LiquidFill.tsx`:
+
+```tsx
+import { useId, useMemo, type ReactElement } from 'react'
+
+import { LIQUID_DEFAULTS, type LiquidTune } from '../hooks/useWaterCursor'
+
+export interface LiquidFillProps {
+  pct: number
+  color: string
+  mode: 'bar' | 'fill'
+  ariaHidden?: boolean
+  className?: string
+  testId?: string
+  tune?: Partial<LiquidTune>
+}
+
+const BAR_DIMS = { w: 22, h: 110 } as const
+const TICK_LEVELS = [25, 50, 75] as const
+
+const buildWavePath = (
+  width: number,
+  amp: number,
+  totalH: number,
+  phase: number
+): string => {
+  const wavelength = width / 2
+  const segments = Math.ceil((width / wavelength) * 4)
+  const step = width / segments
+  const phaseOffset = ((phase % 1) + 1) % 1
+  const startY =
+    phaseOffset < 0.5 ? amp * (phaseOffset * 2) : amp * (2 - phaseOffset * 2)
+  let d = `M 0,${startY}`
+  for (let i = 1; i <= segments; i++) {
+    const x = step * i
+    const cp1x = step * (i - 1) + step / 2
+    const cp2x = step * i - step / 2
+    const flipped = (i + Math.floor(phaseOffset * 2)) % 2 === 0
+    const targetY = flipped ? amp : 0
+    const sY = (i - 1 + Math.floor(phaseOffset * 2)) % 2 === 0 ? amp : 0
+    d += ` C ${cp1x},${sY} ${cp2x},${targetY} ${x},${targetY}`
+  }
+  d += ` L ${width},${totalH} L 0,${totalH} Z`
+  return d
+}
+
+interface Geom {
+  w: number
+  h: number
+  top: number
+  ambientAmp: number
+  baseFloor: number
+  wavePathA: string
+  wavePathB: string
+}
+
+const computeGeom = (w: number, h: number, pct: number): Geom => {
+  const clamped = Math.max(0, Math.min(100, pct))
+  const liquidH = (h - 4) * (clamped / 100)
+  const top = h - liquidH
+  const ambientAmp = Math.min(1.8, w * 0.09)
+  const baseFloor = top + ambientAmp + 0.5
+  const wavePathA = buildWavePath(w * 2, ambientAmp, h, 0)
+  const wavePathB = buildWavePath(w * 2, ambientAmp, h, 0.25)
+  return { w, h, top, ambientAmp, baseFloor, wavePathA, wavePathB }
+}
+
+export const LiquidFill = ({
+  pct,
+  color,
+  mode,
+  ariaHidden = true,
+  className,
+  testId,
+  tune: _tune,
+}: LiquidFillProps): ReactElement => {
+  void _tune // hook wiring comes in Task 6
+
+  const reactId = useId().replace(/:/g, '')
+  const fillId = `liquid-fill-${reactId}`
+  const glassId = `liquid-glass-${reactId}`
+  const sheenId = `liquid-sheen-${reactId}`
+  const clipId = `liquid-clip-${reactId}`
+
+  const { w, h } = mode === 'bar' ? BAR_DIMS : BAR_DIMS // fill measured later
+  const geom = useMemo(() => computeGeom(w, h, pct), [w, h, pct])
+
+  return (
+    <div
+      data-testid={testId}
+      className={className}
+      style={{ display: mode === 'bar' ? 'inline-block' : undefined }}
+    >
+      <svg
+        width={mode === 'bar' ? w : '100%'}
+        height={mode === 'bar' ? h : '100%'}
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio={mode === 'bar' ? 'xMidYMid meet' : 'none'}
+        aria-hidden={ariaHidden ? 'true' : undefined}
+        style={{ overflow: 'visible', display: 'block' }}
+      >
+        <defs>
+          <linearGradient id={fillId} x1="0" y1="1" x2="0" y2="0">
+            <stop offset="0%" stopColor={color} stopOpacity="0.92" />
+            <stop offset="100%" stopColor={color} stopOpacity="0.55" />
+          </linearGradient>
+          <linearGradient id={glassId} x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.06)" />
+            <stop offset="40%" stopColor="rgba(255,255,255,0.02)" />
+            <stop offset="100%" stopColor="rgba(0,0,0,0.15)" />
+          </linearGradient>
+          <linearGradient id={sheenId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.55)" />
+            <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+          </linearGradient>
+          <clipPath id={clipId}>
+            <rect x="1" y="2" width={w - 2} height={h - 3} rx="3" ry="3" />
+          </clipPath>
+        </defs>
+
+        <rect
+          x="1"
+          y="2"
+          width={w - 2}
+          height={h - 3}
+          rx="3"
+          ry="3"
+          fill={`url(#${glassId})`}
+        />
+
+        <g clipPath={`url(#${clipId})`}>
+          <g
+            className="vf-liquid-slosh"
+            data-testid="liquid-slosh"
+            style={{
+              transformOrigin: `${w / 2}px ${h}px`,
+            }}
+          >
+            <rect
+              data-testid="liquid-base"
+              x={0}
+              y={geom.baseFloor}
+              width={w}
+              height={Math.max(0, h - geom.baseFloor)}
+              fill={`url(#${fillId})`}
+            />
+
+            <g
+              data-testid="liquid-water-y-a"
+              style={{
+                transform: `translateY(${geom.top - geom.ambientAmp / 2}px)`,
+                transition: 'transform 500ms ease',
+              }}
+            >
+              <g data-testid="liquid-wave-shift-a">
+                <g
+                  className="vf-liquid-wave-a"
+                  data-testid="liquid-wave-a-anim"
+                >
+                  <path d={geom.wavePathA} fill={color} fillOpacity="0.55" />
+                </g>
+              </g>
+            </g>
+
+            <g
+              data-testid="liquid-water-y-b"
+              style={{
+                transform: `translateY(${geom.top}px)`,
+                transition: 'transform 500ms ease',
+              }}
+            >
+              <g data-testid="liquid-wave-shift-b">
+                <g
+                  className="vf-liquid-wave-b"
+                  data-testid="liquid-wave-b-anim"
+                >
+                  <path
+                    d={geom.wavePathB}
+                    fill={`url(#${fillId})`}
+                    fillOpacity="0.95"
+                  />
+                </g>
+              </g>
+            </g>
+
+            <ellipse
+              data-testid="liquid-sheen"
+              cx={w / 2}
+              cy={geom.top}
+              rx={Math.max(3, w * 0.27)}
+              ry="0.8"
+              fill={`url(#${sheenId})`}
+              fillOpacity="0"
+            />
+          </g>
+
+          {TICK_LEVELS.map((t) => {
+            const y = h - (h - 4) * (t / 100)
+            return (
+              <g key={t} data-testid={`liquid-tick-${t}`}>
+                <line
+                  x1="1"
+                  x2="4"
+                  y1={y}
+                  y2={y}
+                  stroke="rgba(255,255,255,0.18)"
+                  strokeWidth="0.8"
+                />
+                <line
+                  x1={w - 4}
+                  x2={w - 1}
+                  y1={y}
+                  y2={y}
+                  stroke="rgba(255,255,255,0.18)"
+                  strokeWidth="0.8"
+                />
+              </g>
+            )
+          })}
+        </g>
+
+        <rect
+          x="1"
+          y="2"
+          width={w - 2}
+          height={h - 3}
+          rx="3"
+          ry="3"
+          fill="transparent"
+          stroke="rgba(255,255,255,0.18)"
+          strokeWidth="1"
+        />
+      </svg>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/features/agent-status/components/LiquidFill.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run lint + type-check**
+
+Run: `npm run lint && npm run type-check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/agent-status/components/LiquidFill.tsx src/features/agent-status/components/LiquidFill.test.tsx
+git commit -m "feat(agent-status): LiquidFill bar-mode SVG geometry"
+```
+
+---
+
+## Task 6: `LiquidFill` — attach `useWaterCursor` to the rendered SVG
+
+Wire the hook into `LiquidFill` so cursor movement on the outer wrap drives the SVG refs. TDD: render LiquidFill, fire pointermove on the outer div, assert `data-interactive="on"` lands on the `liquid-slosh` group.
+
+**Files:**
+
+- Modify: `src/features/agent-status/components/LiquidFill.tsx`
+- Modify: `src/features/agent-status/components/LiquidFill.test.tsx`
+
+- [ ] **Step 1: Append failing test**
+
+Append to `src/features/agent-status/components/LiquidFill.test.tsx`:
+
+```tsx
+import { act } from '@testing-library/react'
+
+describe('LiquidFill — cursor hook integration', () => {
+  test('pointermove on outer wrap sets data-interactive on slosh', async () => {
+    const { container, getByTestId } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
+    const wrap = getByTestId('lf') as HTMLDivElement
+    Object.defineProperty(wrap, 'getBoundingClientRect', {
+      value: () => ({
+        left: 0,
+        top: 0,
+        right: 22,
+        bottom: 110,
+        width: 22,
+        height: 110,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    })
+    await act(async () => {
+      wrap.dispatchEvent(
+        new PointerEvent('pointermove', {
+          clientX: 11,
+          clientY: 55,
+          bubbles: true,
+        })
+      )
+      await new Promise((r) => setTimeout(r, 32))
+    })
+    const slosh = container.querySelector('[data-testid="liquid-slosh"]')
+    expect(slosh?.getAttribute('data-interactive')).toBe('on')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/features/agent-status/components/LiquidFill.test.tsx -t "cursor hook integration"`
+Expected: FAIL — `data-interactive` is null.
+
+- [ ] **Step 3: Wire the hook**
+
+In `src/features/agent-status/components/LiquidFill.tsx`, replace the `import` block at the top and the function body to:
+
+1. Import `useEffect`, `useRef` from React.
+2. Import `useWaterCursor` (already imported `LIQUID_DEFAULTS`/`LiquidTune`).
+3. Create refs for wrap, slosh, waveAShift, waveBShift, waveAAnim, waveBAnim, sheen.
+4. Pack them into a `LiquidRefs` value via `useEffect` (so geometry updates with `pct`).
+5. Call `useWaterCursor(wrapRef, refsRef, tune)`.
+
+Patch `LiquidFill.tsx` — at the top of the file:
+
+```tsx
+import { useEffect, useId, useMemo, useRef, type ReactElement } from 'react'
+
+import {
+  LIQUID_DEFAULTS,
+  useWaterCursor,
+  type LiquidRefs,
+  type LiquidTune,
+} from '../hooks/useWaterCursor'
+```
+
+And replace the `LiquidFill` component body (from `export const LiquidFill = ...` to the closing `)` of the JSX) with:
+
+```tsx
+export const LiquidFill = ({
+  pct,
+  color,
+  mode,
+  ariaHidden = true,
+  className,
+  testId,
+  tune,
+}: LiquidFillProps): ReactElement => {
+  const reactId = useId().replace(/:/g, '')
+  const fillId = `liquid-fill-${reactId}`
+  const glassId = `liquid-glass-${reactId}`
+  const sheenId = `liquid-sheen-${reactId}`
+  const clipId = `liquid-clip-${reactId}`
+
+  const { w, h } = mode === 'bar' ? BAR_DIMS : BAR_DIMS
+  const geom = useMemo(() => computeGeom(w, h, pct), [w, h, pct])
+
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+  const sloshRef = useRef<SVGGElement | null>(null)
+  const waveAShiftRef = useRef<SVGGElement | null>(null)
+  const waveBShiftRef = useRef<SVGGElement | null>(null)
+  const waveAAnimRef = useRef<SVGGElement | null>(null)
+  const waveBAnimRef = useRef<SVGGElement | null>(null)
+  const sheenRef = useRef<SVGEllipseElement | null>(null)
+
+  const refsRef = useRef<LiquidRefs | null>(null)
+  useEffect(() => {
+    if (
+      sloshRef.current === null ||
+      waveAShiftRef.current === null ||
+      waveBShiftRef.current === null ||
+      waveAAnimRef.current === null ||
+      waveBAnimRef.current === null ||
+      sheenRef.current === null
+    ) {
+      refsRef.current = null
+      return
+    }
+    refsRef.current = {
+      slosh: sloshRef.current,
+      waveAShift: waveAShiftRef.current,
+      waveBShift: waveBShiftRef.current,
+      waveAAnim: waveAAnimRef.current,
+      waveBAnim: waveBAnimRef.current,
+      sheen: sheenRef.current,
+      waterTop: geom.top,
+      ambientAmp: geom.ambientAmp,
+      dims: { w, h },
+    }
+  }, [geom.top, geom.ambientAmp, w, h])
+
+  useWaterCursor(wrapRef, refsRef, tune)
+
+  return (
+    <div
+      ref={wrapRef}
+      data-testid={testId}
+      className={className}
+      style={{ display: mode === 'bar' ? 'inline-block' : undefined }}
+    >
+      <svg
+        width={mode === 'bar' ? w : '100%'}
+        height={mode === 'bar' ? h : '100%'}
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio={mode === 'bar' ? 'xMidYMid meet' : 'none'}
+        aria-hidden={ariaHidden ? 'true' : undefined}
+        style={{ overflow: 'visible', display: 'block' }}
+      >
+        <defs>
+          <linearGradient id={fillId} x1="0" y1="1" x2="0" y2="0">
+            <stop offset="0%" stopColor={color} stopOpacity="0.92" />
+            <stop offset="100%" stopColor={color} stopOpacity="0.55" />
+          </linearGradient>
+          <linearGradient id={glassId} x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.06)" />
+            <stop offset="40%" stopColor="rgba(255,255,255,0.02)" />
+            <stop offset="100%" stopColor="rgba(0,0,0,0.15)" />
+          </linearGradient>
+          <linearGradient id={sheenId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.55)" />
+            <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+          </linearGradient>
+          <clipPath id={clipId}>
+            <rect x="1" y="2" width={w - 2} height={h - 3} rx="3" ry="3" />
+          </clipPath>
+        </defs>
+
+        <rect
+          x="1"
+          y="2"
+          width={w - 2}
+          height={h - 3}
+          rx="3"
+          ry="3"
+          fill={`url(#${glassId})`}
+        />
+
+        <g clipPath={`url(#${clipId})`}>
+          <g
+            ref={sloshRef}
+            className="vf-liquid-slosh"
+            data-testid="liquid-slosh"
+            style={{ transformOrigin: `${w / 2}px ${h}px` }}
+          >
+            <rect
+              data-testid="liquid-base"
+              x={0}
+              y={geom.baseFloor}
+              width={w}
+              height={Math.max(0, h - geom.baseFloor)}
+              fill={`url(#${fillId})`}
+            />
+
+            <g
+              data-testid="liquid-water-y-a"
+              style={{
+                transform: `translateY(${geom.top - geom.ambientAmp / 2}px)`,
+                transition: 'transform 500ms ease',
+              }}
+            >
+              <g ref={waveAShiftRef} data-testid="liquid-wave-shift-a">
+                <g
+                  ref={waveAAnimRef}
+                  className="vf-liquid-wave-a"
+                  data-testid="liquid-wave-a-anim"
+                >
+                  <path d={geom.wavePathA} fill={color} fillOpacity="0.55" />
+                </g>
+              </g>
+            </g>
+
+            <g
+              data-testid="liquid-water-y-b"
+              style={{
+                transform: `translateY(${geom.top}px)`,
+                transition: 'transform 500ms ease',
+              }}
+            >
+              <g ref={waveBShiftRef} data-testid="liquid-wave-shift-b">
+                <g
+                  ref={waveBAnimRef}
+                  className="vf-liquid-wave-b"
+                  data-testid="liquid-wave-b-anim"
+                >
+                  <path
+                    d={geom.wavePathB}
+                    fill={`url(#${fillId})`}
+                    fillOpacity="0.95"
+                  />
+                </g>
+              </g>
+            </g>
+
+            <ellipse
+              ref={sheenRef}
+              data-testid="liquid-sheen"
+              cx={w / 2}
+              cy={geom.top}
+              rx={Math.max(3, w * 0.27)}
+              ry="0.8"
+              fill={`url(#${sheenId})`}
+              fillOpacity="0"
+            />
+          </g>
+
+          {TICK_LEVELS.map((t) => {
+            const y = h - (h - 4) * (t / 100)
+            return (
+              <g key={t} data-testid={`liquid-tick-${t}`}>
+                <line
+                  x1="1"
+                  x2="4"
+                  y1={y}
+                  y2={y}
+                  stroke="rgba(255,255,255,0.18)"
+                  strokeWidth="0.8"
+                />
+                <line
+                  x1={w - 4}
+                  x2={w - 1}
+                  y1={y}
+                  y2={y}
+                  stroke="rgba(255,255,255,0.18)"
+                  strokeWidth="0.8"
+                />
+              </g>
+            )
+          })}
+        </g>
+
+        <rect
+          x="1"
+          y="2"
+          width={w - 2}
+          height={h - 3}
+          rx="3"
+          ry="3"
+          fill="transparent"
+          stroke="rgba(255,255,255,0.18)"
+          strokeWidth="1"
+        />
+      </svg>
+    </div>
+  )
+}
+```
+
+Also remove the now-unused `LiquidTune` re-import — it's already used in the `LiquidFillProps` type.
+
+- [ ] **Step 4: Run all `LiquidFill` tests to verify they pass**
+
+Run: `npx vitest run src/features/agent-status/components/LiquidFill.test.tsx`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Run lint + type-check**
+
+Run: `npm run lint && npm run type-check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/agent-status/components/LiquidFill.tsx src/features/agent-status/components/LiquidFill.test.tsx
+git commit -m "feat(agent-status): drive LiquidFill SVG with useWaterCursor"
+```
+
+---
+
+## Task 7: `LiquidFill` — `mode="fill"` ResizeObserver sizing
+
+Make `mode="fill"` measure its outer `<div>` and render the SVG at the measured size with `preserveAspectRatio="none"`. The wave path's `width` argument scales with measured CSS width × 2 so the wavelength looks proportionate in any container.
+
+**Files:**
+
+- Modify: `src/features/agent-status/components/LiquidFill.tsx`
+- Modify: `src/features/agent-status/components/LiquidFill.test.tsx`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/features/agent-status/components/LiquidFill.test.tsx`:
+
+```tsx
+type ROCallback = (entries: { contentRect: DOMRectReadOnly }[]) => void
+class MockResizeObserver {
+  static instances: MockResizeObserver[] = []
+  cb: ROCallback
+  constructor(cb: ROCallback) {
+    this.cb = cb
+    MockResizeObserver.instances.push(this)
+  }
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+  trigger(rect: { width: number; height: number }): void {
+    this.cb([
+      {
+        contentRect: {
+          ...rect,
+          top: 0,
+          left: 0,
+          right: rect.width,
+          bottom: rect.height,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        } as DOMRectReadOnly,
+      },
+    ])
+  }
+}
+
+describe('LiquidFill — fill mode', () => {
+  beforeEach(() => {
+    MockResizeObserver.instances = []
+    ;(
+      globalThis as unknown as { ResizeObserver: typeof ResizeObserver }
+    ).ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  test('renders SVG with measured width/height after ResizeObserver fires', async () => {
+    const { container } = render(
+      <LiquidFill
+        mode="fill"
+        pct={50}
+        color="#cba6f7"
+        testId="lf-fill"
+        className="h-full w-full"
+      />
+    )
+    await act(async () => {
+      MockResizeObserver.instances[0]?.trigger({ width: 200, height: 72 })
+    })
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 200 72')
+    expect(svg?.getAttribute('preserveAspectRatio')).toBe('none')
+  })
+
+  test('outer div carries the caller className', () => {
+    const { getByTestId } = render(
+      <LiquidFill
+        mode="fill"
+        pct={50}
+        color="#cba6f7"
+        testId="lf-fill"
+        className="h-full w-full"
+      />
+    )
+    expect((getByTestId('lf-fill') as HTMLElement).className).toContain(
+      'h-full'
+    )
+    expect((getByTestId('lf-fill') as HTMLElement).className).toContain(
+      'w-full'
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/features/agent-status/components/LiquidFill.test.tsx -t "fill mode"`
+Expected: FAIL — viewBox stays at `0 0 22 110` because the component currently ignores mode for sizing.
+
+- [ ] **Step 3: Add ResizeObserver-driven dims**
+
+In `src/features/agent-status/components/LiquidFill.tsx`, add `useState` to the React import and a `useEffect` that creates a `ResizeObserver` when `mode === 'fill'`. Replace the `const { w, h } = mode === 'bar' ? BAR_DIMS : BAR_DIMS` line with:
+
+```tsx
+const [measured, setMeasured] = useState<{ w: number; h: number } | null>(null)
+
+useEffect(() => {
+  if (mode !== 'fill' || wrapRef.current === null) return
+  const el = wrapRef.current
+  const ro = new ResizeObserver((entries) => {
+    const rect = entries[0]?.contentRect
+    if (rect === undefined) return
+    setMeasured({ w: Math.max(1, rect.width), h: Math.max(1, rect.height) })
+  })
+  ro.observe(el)
+  return (): void => {
+    ro.disconnect()
+  }
+}, [mode])
+
+const { w, h } =
+  mode === 'bar' ? BAR_DIMS : (measured ?? { w: BAR_DIMS.w, h: BAR_DIMS.h })
+```
+
+Make sure to update the import:
+
+```tsx
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react'
+```
+
+Also update `computeGeom`'s wave-path call to scale wavelength with width — it already uses `w * 2`, so a wider gauge produces longer waves automatically. No further changes needed there.
+
+- [ ] **Step 4: Run all `LiquidFill` tests to verify they pass**
+
+Run: `npx vitest run src/features/agent-status/components/LiquidFill.test.tsx`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Run lint + type-check**
+
+Run: `npm run lint && npm run type-check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/agent-status/components/LiquidFill.tsx src/features/agent-status/components/LiquidFill.test.tsx
+git commit -m "feat(agent-status): LiquidFill fill-mode via ResizeObserver"
+```
+
+---
+
+## Task 8: Refactor `Bucket.tsx` to delegate SVG to `LiquidFill`
+
+Replace the inline SVG block with a `<LiquidFill mode="bar" />` while preserving the public API (`pct`, `color`, `label`, `title`) and the label + percentage chrome around it.
+
+**Files:**
+
+- Modify: `src/features/agent-status/components/Bucket.tsx`
+
+- [ ] **Step 1: Confirm the existing tests cover the public contract**
+
+Run: `npx vitest run src/features/agent-status/components/Bucket.test.tsx`
+Expected: PASS — these are the regression net for the refactor.
+
+- [ ] **Step 2: Replace the file**
+
+Overwrite `src/features/agent-status/components/Bucket.tsx` with:
+
+```tsx
+import { type ReactElement } from 'react'
+
+import { LiquidFill } from './LiquidFill'
+
+export interface BucketProps {
+  pct: number
+  color: string
+  label: string
+  title?: string
+}
+
+export const Bucket = ({
+  pct,
+  color,
+  label,
+  title = '',
+}: BucketProps): ReactElement => {
+  const clamped = Math.max(0, Math.min(100, pct))
+  const labelKey = label.toLowerCase()
+
+  return (
+    <div
+      data-testid={`bucket-${labelKey}`}
+      title={title}
+      className="flex flex-col items-center gap-1"
+    >
+      <div
+        data-testid={`bucket-${labelKey}-pct`}
+        className="font-display text-[14px] font-semibold leading-none tabular-nums tracking-tight text-on-surface"
+      >
+        {Math.round(clamped)}
+        <span
+          data-testid={`bucket-${labelKey}-pct-glyph`}
+          className="ml-px text-[12px]"
+          style={{ color }}
+        >
+          %
+        </span>
+      </div>
+
+      <LiquidFill
+        mode="bar"
+        pct={clamped}
+        color={color}
+        testId={`bucket-${labelKey}-svg`}
+      />
+
+      <span
+        data-testid={`bucket-${labelKey}-label`}
+        className="mt-0.5 font-mono text-[8px] uppercase tracking-[0.18em] text-on-surface-muted"
+      >
+        {label}
+      </span>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Update existing test assertions that target old SVG-internal test ids**
+
+Open `src/features/agent-status/components/Bucket.test.tsx` and rename any reference:
+
+- `bucket-tick-25` / `bucket-tick-50` / `bucket-tick-75` → `liquid-tick-25` / `liquid-tick-50` / `liquid-tick-75`
+- `bucket-liquid` → `liquid-slosh` (or remove the assertion if the test is just checking liquid presence — `getByTestId('liquid-base')` is the cleaner replacement)
+
+If a test asserts on an old test id with no direct equivalent, replace it with an equivalent assertion that hits the new test id, or delete the test if it duplicates a `LiquidFill.test.tsx` regression.
+
+- [ ] **Step 4: Run `Bucket.test.tsx`, `LiquidFill.test.tsx`, and `useWaterCursor.test.tsx`**
+
+Run: `npx vitest run src/features/agent-status/components/Bucket.test.tsx src/features/agent-status/components/LiquidFill.test.tsx src/features/agent-status/hooks/useWaterCursor.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Run `AgentStatusRail.test.tsx` to confirm no regression**
+
+Run: `npx vitest run src/features/agent-status/components/AgentStatusRail.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Run lint + type-check**
+
+Run: `npm run lint && npm run type-check`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/agent-status/components/Bucket.tsx src/features/agent-status/components/Bucket.test.tsx
+git commit -m "refactor(agent-status): Bucket delegates SVG to LiquidFill"
+```
+
+---
+
+## Task 9: Refactor `ContextBucket.tsx` to use `LiquidFill` + `hexForColorClass`
+
+Replace the flat-gradient fill `<div>` with `<LiquidFill mode="fill" />`. Add a local `hexForColorClass` helper that returns the matching hex literal from `tailwind.config.js`. Card chrome, scale, progress bar, percentage display, and color thresholds are untouched.
+
+**Files:**
+
+- Modify: `src/features/agent-status/components/ContextBucket.tsx`
+- Modify: `src/features/agent-status/components/ContextBucket.test.tsx`
+
+- [ ] **Step 1: Confirm baseline tests**
+
+Run: `npx vitest run src/features/agent-status/components/ContextBucket.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 2: Apply the refactor**
+
+In `src/features/agent-status/components/ContextBucket.tsx`:
+
+a) Add the `LiquidFill` import at the top of the file, alongside the existing imports:
+
+```tsx
+import { LiquidFill } from './LiquidFill'
+```
+
+b) Below the existing `getColorClass` definition (after line 68), add:
+
+```tsx
+const hexForColorClass = (pct: number | null): string => {
+  if (pct !== null && pct >= 90) return '#ffb4ab' // tailwind.config.js:25 — error
+  if (pct !== null && pct >= 80) return '#ff94a5' // tailwind.config.js:21 — tertiary
+  return '#cba6f7' // tailwind.config.js:10 — primary-container
+}
+```
+
+c) Replace lines 117-130 (the `<div data-testid="bucket-fill" ...>` block) with:
+
+```tsx
+<LiquidFill
+  mode="fill"
+  pct={effectivePct}
+  color={hexForColorClass(pct)}
+  className="h-full w-full"
+  testId="bucket-fill"
+/>
+```
+
+- [ ] **Step 3: Update `ContextBucket.test.tsx`**
+
+Open `src/features/agent-status/components/ContextBucket.test.tsx` and confirm the existing `bucket-fill` testid query continues to work — it now points to the LiquidFill outer `<div>` rather than the old gradient div, but the assertion target is the same.
+
+If any existing test reads `.style.height` or `.style.background` to assert on the gradient, replace it with an assertion against the rendered `LiquidFill`'s `data-testid="liquid-base"` element's `y` attribute (which scales with `pct`).
+
+Add a new test for the hex helper inside the same file:
+
+```tsx
+test('LiquidFill receives the correct hex for each threshold', () => {
+  const { rerender, container } = render(
+    <ContextBucket
+      usedPercentage={50}
+      contextWindowSize={200000}
+      totalInputTokens={50000}
+      totalOutputTokens={5000}
+    />
+  )
+  // primary-container at <80
+  let stops = container.querySelectorAll('linearGradient stop')
+  expect(stops[0]?.getAttribute('stop-color')).toBe('#cba6f7')
+
+  rerender(
+    <ContextBucket
+      usedPercentage={85}
+      contextWindowSize={200000}
+      totalInputTokens={170000}
+      totalOutputTokens={5000}
+    />
+  )
+  stops = container.querySelectorAll('linearGradient stop')
+  expect(stops[0]?.getAttribute('stop-color')).toBe('#ff94a5')
+
+  rerender(
+    <ContextBucket
+      usedPercentage={95}
+      contextWindowSize={200000}
+      totalInputTokens={185000}
+      totalOutputTokens={5000}
+    />
+  )
+  stops = container.querySelectorAll('linearGradient stop')
+  expect(stops[0]?.getAttribute('stop-color')).toBe('#ffb4ab')
+})
+```
+
+- [ ] **Step 4: Run `ContextBucket.test.tsx`**
+
+Run: `npx vitest run src/features/agent-status/components/ContextBucket.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full agent-status suite**
+
+Run: `npx vitest run src/features/agent-status`
+Expected: PASS.
+
+- [ ] **Step 6: Run lint + type-check**
+
+Run: `npm run lint && npm run type-check`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/agent-status/components/ContextBucket.tsx src/features/agent-status/components/ContextBucket.test.tsx
+git commit -m "refactor(agent-status): ContextBucket uses LiquidFill with hex color tokens"
+```
+
+---
+
+## Task 10: Whole-suite verification + manual smoke
+
+Run every check the pre-push hook will run, then walk the manual smoke list from spec §9.
+
+**Files:** none modified
+
+- [ ] **Step 1: Full test suite**
+
+Run: `npm run test`
+Expected: PASS, no failing tests across the repo.
+
+- [ ] **Step 2: Lint and type-check**
+
+Run: `npm run lint && npm run type-check && npm run format:check`
+Expected: PASS.
+
+- [ ] **Step 3: Boot the app and inspect each scenario**
+
+Run: `npm run dev` (in a separate terminal).
+
+For each of the following, observe the actual visual behavior and confirm:
+
+- **Rail collapsed, CTX bucket:** cursor approaches → water tilts, lifts, skews, waves quicken. Cursor leaves → spring relaxes ~600 ms back to ambient slosh.
+- **Rail collapsed, CACHE bucket:** same, independently of CTX.
+- **Expanded panel, CURRENT CONTEXT gauge:** cursor approaches → same behavior in a wide rectangular tank. Wave wavelength scales proportionally.
+- **Collapse ↔ expand toggling:** open Chrome DevTools, inspect both `Bucket` (rail) and `ContextBucket` (panel) trees. After each toggle, no `[data-interactive="on"]` should appear on detached nodes; no inline `transform` should linger on freshly mounted ones.
+- **Panel closed:** the `ContextBucket` unmounts. Devtools Memory tab shows no pending rAF handles owned by removed nodes.
+- **OS Reduce Motion toggled ON mid-session (no reload):** within one frame, waves and slosh stop; cursor stops driving the water; the fill is static.
+- **OS Reduce Motion toggled OFF mid-session:** ambient slosh resumes; pointer movement again drives the water.
+
+- [ ] **Step 4: If all smoke checks pass, no commit is needed.**
+
+If a smoke check fails, open a new sub-task to address it, fix, retest, and commit before opening the PR.
+
+---
+
+## Self-review checklist
+
+This list is for the writer of the plan to walk after committing. The plan executor does not need to re-run it.
+
+1. **Spec coverage**
+   - §1 Summary — Tasks 1-10 collectively cover every claim in the summary.
+   - §2 Scope — every "in scope" item maps to at least one task; nothing "out of scope" appears.
+   - §3 Tuning constants — frozen in `LIQUID_DEFAULTS` (Task 2, Step 3).
+   - §4 Hook (trigger zone, lifecycle, reduced-motion live-toggle) — Tasks 2, 3, 4.
+   - §5 LiquidFill (geometry, nested transform groups, sizing, sheen) — Tasks 5, 6, 7.
+   - §6.1 Bucket consumer — Task 8.
+   - §6.2 ContextBucket consumer + hexForColorClass — Task 9.
+   - §7 CSS rename — Task 1.
+   - §8 Testing — every consumer/hook test bullet has a task that lands the test.
+   - §9 Manual verification — Task 10.
+   - §10 Risks — addressed in §10 of the spec; the plan does not introduce new ones.
+   - §11 File-level diff plan — Tasks 1, 2, 3, 4, 5, 6, 7, 8, 9 produce the exact files in the diff plan.
+
+2. **Placeholder scan** — none. Every code step shows the actual code.
+
+3. **Type consistency** — `LiquidRefs`, `LiquidFillProps`, `BucketProps` are defined once and reused. `Signal` union appears only inside the hook implementation. `LIQUID_DEFAULTS` is the single source of truth for tuning.

--- a/docs/superpowers/plans/2026-05-22-liquid-bucket-cursor-response.md
+++ b/docs/superpowers/plans/2026-05-22-liquid-bucket-cursor-response.md
@@ -25,9 +25,34 @@ The keyframes and class names move out of bucket-specific territory because `Liq
 
 - [ ] **Step 1: Rename keyframes + classes in `src/index.css`**
 
-Replace lines 187-215 of `src/index.css` with:
+Replace lines 166-215 of `src/index.css` with the block below. **Wave
+directions are preserved exactly** from the current rules
+(`vfWaveA` = `0 → -50%`, `vfWaveB` = `-50% → 0`) — only the names
+change.
 
 ```css
+/* Liquid bucket animations (used by both Bucket and ContextBucket via
+   LiquidFill). Two opposing sine-wave translations create the ripple;
+   vfLiquidSlosh tilts the whole liquid mass < 1deg. Honors
+   prefers-reduced-motion. */
+@keyframes vfLiquidWaveA {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes vfLiquidWaveB {
+  from {
+    transform: translateX(-50%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
 @keyframes vfLiquidSlosh {
   0%,
   100% {
@@ -38,30 +63,12 @@ Replace lines 187-215 of `src/index.css` with:
   }
 }
 
-@keyframes vfLiquidWaveA {
-  from {
-    transform: translateX(-50%);
-  }
-  to {
-    transform: translateX(0);
-  }
-}
-
-@keyframes vfLiquidWaveB {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-50%);
-  }
-}
-
 .vf-liquid-wave-a {
-  animation: vfLiquidWaveA var(--vf-liquid-wave-a-dur, 3.4s) linear infinite;
+  animation: vfLiquidWaveA 3.4s linear infinite;
 }
 
 .vf-liquid-wave-b {
-  animation: vfLiquidWaveB var(--vf-liquid-wave-b-dur, 4.8s) linear infinite;
+  animation: vfLiquidWaveB 4.8s linear infinite;
 }
 
 .vf-liquid-slosh {
@@ -122,11 +129,25 @@ Failing test first. The skeleton attaches `pointermove` / `pointerleave` to `wra
 Create `src/features/agent-status/hooks/useWaterCursor.test.tsx`:
 
 ```tsx
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { useEffect, useRef, type ReactElement } from 'react'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import { useWaterCursor, type LiquidRefs } from './useWaterCursor'
+
+// jsdom does not provide PointerEvent. Use a MouseEvent dispatched with
+// the 'pointermove' / 'pointerleave' type — the listener key is the
+// event type string, and MouseEvent carries clientX / clientY which is
+// all the hook reads. This avoids touching src/test/setup.ts.
+const firePointer = (
+  el: Element,
+  type: 'pointermove' | 'pointerleave',
+  init: Partial<MouseEventInit> = {}
+): void => {
+  el.dispatchEvent(
+    new MouseEvent(type, { bubbles: true, cancelable: true, ...init })
+  )
+}
 
 interface MqlMock {
   matches: boolean
@@ -324,11 +345,11 @@ This task makes the hook actually drive the SVG. TDD: assert that a `pointermove
 
 - [ ] **Step 1: Append failing tests for the loop**
 
-Add to the bottom of `src/features/agent-status/hooks/useWaterCursor.test.tsx`:
+Add to the bottom of `src/features/agent-status/hooks/useWaterCursor.test.tsx`
+(the file already imports `act` and the `firePointer` helper at the top
+from Task 2; do not add new imports):
 
 ```tsx
-import { act } from '@testing-library/react'
-
 const flushRaf = async (frames: number): Promise<void> => {
   for (let i = 0; i < frames; i++) {
     await act(async () => {
@@ -336,6 +357,22 @@ const flushRaf = async (frames: number): Promise<void> => {
       await new Promise((r) => setTimeout(r, 16))
     })
   }
+}
+
+const stubRect = (el: Element, width: number, height: number): void => {
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    value: () => ({
+      left: 0,
+      top: 0,
+      right: width,
+      bottom: height,
+      width,
+      height,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }),
+  })
 }
 
 describe('useWaterCursor — spring loop', () => {
@@ -350,27 +387,9 @@ describe('useWaterCursor — spring loop', () => {
       <Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />
     )
     const wrap = getByTestId('wrap')
-    Object.defineProperty(wrap, 'getBoundingClientRect', {
-      value: () => ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 100,
-        width: 100,
-        height: 100,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      }),
-    })
+    stubRect(wrap, 100, 100)
     await act(async () => {
-      wrap.dispatchEvent(
-        new PointerEvent('pointermove', {
-          clientX: 80,
-          clientY: 50,
-          bubbles: true,
-        })
-      )
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
     })
     await flushRaf(2)
     expect(refs.slosh.getAttribute('data-interactive')).toBe('on')
@@ -385,27 +404,13 @@ describe('useWaterCursor — spring loop', () => {
       <Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />
     )
     const wrap = getByTestId('wrap')
-    Object.defineProperty(wrap, 'getBoundingClientRect', {
-      value: () => ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 100,
-        width: 100,
-        height: 100,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      }),
-    })
+    stubRect(wrap, 100, 100)
     await act(async () => {
-      wrap.dispatchEvent(
-        new PointerEvent('pointermove', { clientX: 80, clientY: 50 })
-      )
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
     })
     await flushRaf(2)
     await act(async () => {
-      wrap.dispatchEvent(new PointerEvent('pointerleave'))
+      firePointer(wrap, 'pointerleave')
     })
     await flushRaf(80) // > 1s — well past spring settle at omega=6.5
     expect(refs.slosh.getAttribute('data-interactive')).toBeNull()
@@ -1043,7 +1048,7 @@ Create `src/features/agent-status/components/LiquidFill.tsx`:
 ```tsx
 import { useId, useMemo, type ReactElement } from 'react'
 
-import { LIQUID_DEFAULTS, type LiquidTune } from '../hooks/useWaterCursor'
+import { type LiquidTune } from '../hooks/useWaterCursor'
 
 export interface LiquidFillProps {
   pct: number
@@ -1306,11 +1311,35 @@ Wire the hook into `LiquidFill` so cursor movement on the outer wrap drives the 
 
 - [ ] **Step 1: Append failing test**
 
-Append to `src/features/agent-status/components/LiquidFill.test.tsx`:
+Update the top-level imports of `src/features/agent-status/components/LiquidFill.test.tsx`:
 
 ```tsx
-import { act } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
+import { LiquidFill } from './LiquidFill'
+
+// jsdom does not provide PointerEvent — see useWaterCursor.test.tsx
+// for the same shim.
+const firePointer = (
+  el: Element,
+  type: 'pointermove' | 'pointerleave',
+  init: Partial<MouseEventInit> = {}
+): void => {
+  el.dispatchEvent(
+    new MouseEvent(type, { bubbles: true, cancelable: true, ...init })
+  )
+}
+```
+
+(The Task 5 file already had `render, describe, expect, test` — replace
+that import block with the one above. `beforeEach`, `vi`, and `act` are
+added now because the new test cases below use them. `firePointer` is
+defined once at the file top.)
+
+Then append the new test:
+
+```tsx
 describe('LiquidFill — cursor hook integration', () => {
   test('pointermove on outer wrap sets data-interactive on slosh', async () => {
     const { container, getByTestId } = render(
@@ -1331,13 +1360,7 @@ describe('LiquidFill — cursor hook integration', () => {
       }),
     })
     await act(async () => {
-      wrap.dispatchEvent(
-        new PointerEvent('pointermove', {
-          clientX: 11,
-          clientY: 55,
-          bubbles: true,
-        })
-      )
+      firePointer(wrap, 'pointermove', { clientX: 11, clientY: 55 })
       await new Promise((r) => setTimeout(r, 32))
     })
     const slosh = container.querySelector('[data-testid="liquid-slosh"]')
@@ -1356,7 +1379,7 @@ Expected: FAIL — `data-interactive` is null.
 In `src/features/agent-status/components/LiquidFill.tsx`, replace the `import` block at the top and the function body to:
 
 1. Import `useEffect`, `useRef` from React.
-2. Import `useWaterCursor` (already imported `LIQUID_DEFAULTS`/`LiquidTune`).
+2. Import `useWaterCursor` and the `LiquidRefs` type from the hook (`LiquidTune` was already imported in Task 5).
 3. Create refs for wrap, slosh, waveAShift, waveBShift, waveAAnim, waveBAnim, sheen.
 4. Pack them into a `LiquidRefs` value via `useEffect` (so geometry updates with `pct`).
 5. Call `useWaterCursor(wrapRef, refsRef, tune)`.
@@ -1367,7 +1390,6 @@ Patch `LiquidFill.tsx` — at the top of the file:
 import { useEffect, useId, useMemo, useRef, type ReactElement } from 'react'
 
 import {
-  LIQUID_DEFAULTS,
   useWaterCursor,
   type LiquidRefs,
   type LiquidTune,
@@ -1657,7 +1679,7 @@ describe('LiquidFill — fill mode', () => {
     ).ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
   })
 
-  test('renders SVG with measured width/height after ResizeObserver fires', async () => {
+  test('renders SVG with measured width/height attributes after ResizeObserver fires', async () => {
     const { container } = render(
       <LiquidFill
         mode="fill"
@@ -1673,6 +1695,10 @@ describe('LiquidFill — fill mode', () => {
     const svg = container.querySelector('svg')
     expect(svg?.getAttribute('viewBox')).toBe('0 0 200 72')
     expect(svg?.getAttribute('preserveAspectRatio')).toBe('none')
+    // Spec §5: mode="fill" sets the SVG width/height attributes from the
+    // ResizeObserver measurement (not a percentage placeholder).
+    expect(svg?.getAttribute('width')).toBe('200')
+    expect(svg?.getAttribute('height')).toBe('72')
   })
 
   test('outer div carries the caller className', () => {
@@ -1738,7 +1764,24 @@ import {
 } from 'react'
 ```
 
-Also update `computeGeom`'s wave-path call to scale wavelength with width — it already uses `w * 2`, so a wider gauge produces longer waves automatically. No further changes needed there.
+Then update the `<svg>` element's `width` and `height` attributes so
+they take the measured pixel values once `mode === 'fill'` has measured
+its container (falling back to `'100%'` only on the very first render,
+before the `ResizeObserver` has fired):
+
+```tsx
+<svg
+  width={mode === 'bar' ? w : (measured?.w ?? '100%')}
+  height={mode === 'bar' ? h : (measured?.h ?? '100%')}
+  viewBox={`0 0 ${w} ${h}`}
+  preserveAspectRatio={mode === 'bar' ? 'xMidYMid meet' : 'none'}
+  ...
+>
+```
+
+`computeGeom`'s wave-path call already scales wavelength with width
+(`w * 2`), so a wider gauge produces longer waves automatically — no
+further changes needed there.
 
 - [ ] **Step 4: Run all `LiquidFill` tests to verify they pass**
 
@@ -1837,12 +1880,57 @@ export const Bucket = ({
 
 - [ ] **Step 3: Update existing test assertions that target old SVG-internal test ids**
 
-Open `src/features/agent-status/components/Bucket.test.tsx` and rename any reference:
+**Spec contract note:** spec §6.1 says existing test ids "continue to
+pass because those test ids live on the SVG internals." This was a
+slight oversimplification — the SVG internals now live inside
+`LiquidFill`, which uses its own `liquid-*` test-id namespace. The test
+_semantics_ are preserved (same regressions, same structure) but the
+selector strings change. This is intentional and matches the §7 CSS
+rename. Apply the following selector renames in
+`src/features/agent-status/components/Bucket.test.tsx`:
 
-- `bucket-tick-25` / `bucket-tick-50` / `bucket-tick-75` → `liquid-tick-25` / `liquid-tick-50` / `liquid-tick-75`
-- `bucket-liquid` → `liquid-slosh` (or remove the assertion if the test is just checking liquid presence — `getByTestId('liquid-base')` is the cleaner replacement)
+| Old selector                                                                 | New selector                                                               |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `screen.getByTestId('bucket-tick-25')`                                       | `screen.getByTestId('liquid-tick-25')`                                     |
+| `screen.getByTestId('bucket-tick-50')`                                       | `screen.getByTestId('liquid-tick-50')`                                     |
+| `screen.getByTestId('bucket-tick-75')`                                       | `screen.getByTestId('liquid-tick-75')`                                     |
+| `screen.queryByTestId('bucket-liquid')` at pct=0 → `not.toBeInTheDocument()` | `screen.queryByTestId('liquid-base')` at pct=0 → `not.toBeInTheDocument()` |
+| `screen.getByTestId('bucket-liquid')` at pct>0 → `toBeInTheDocument()`       | `screen.getByTestId('liquid-base')` at pct>0 → `toBeInTheDocument()`       |
 
-If a test asserts on an old test id with no direct equivalent, replace it with an equivalent assertion that hits the new test id, or delete the test if it duplicates a `LiquidFill.test.tsx` regression.
+This requires `LiquidFill` to skip rendering the `<rect data-testid="liquid-base">`,
+the wave-y groups, the wave-shift groups, and the sheen ellipse when
+`pct <= 0`. Update Task 5's `LiquidFill.tsx` JSX accordingly during this
+task (or as a follow-up edit in this step):
+
+```tsx
+{geom.top < geom.h && (
+  <>
+    <rect
+      data-testid="liquid-base"
+      x={0}
+      y={geom.baseFloor}
+      width={w}
+      height={Math.max(0, h - geom.baseFloor)}
+      fill={`url(#${fillId})`}
+    />
+    <g data-testid="liquid-water-y-a" ...>...</g>
+    <g data-testid="liquid-water-y-b" ...>...</g>
+    <ellipse ref={sheenRef} data-testid="liquid-sheen" ... />
+  </>
+)}
+```
+
+The `geom.top < geom.h` predicate is true exactly when `pct > 0`
+(since `liquidH > 0` ⇔ `top < h`). When `pct === 0`, none of these
+elements render — matching the original `BucketLiquid` early-return
+behaviour at `Bucket.tsx:165-167`. The slosh wrapper and tick marks
+continue to render unconditionally so `liquid-slosh` and `liquid-tick-*`
+test ids are always available.
+
+Other `Bucket.test.tsx` selectors (`bucket-${labelKey}`,
+`bucket-${labelKey}-pct`, `bucket-${labelKey}-label`,
+`bucket-${labelKey}-pct-glyph`) are preserved by this task — `Bucket.tsx`
+still emits them on its own chrome.
 
 - [ ] **Step 4: Run `Bucket.test.tsx`, `LiquidFill.test.tsx`, and `useWaterCursor.test.tsx`**
 
@@ -1916,11 +2004,73 @@ c) Replace lines 117-130 (the `<div data-testid="bucket-fill" ...>` block) with:
 
 - [ ] **Step 3: Update `ContextBucket.test.tsx`**
 
-Open `src/features/agent-status/components/ContextBucket.test.tsx` and confirm the existing `bucket-fill` testid query continues to work — it now points to the LiquidFill outer `<div>` rather than the old gradient div, but the assertion target is the same.
+The existing file at `src/features/agent-status/components/ContextBucket.test.tsx`
+asserts on three categories of behaviour that no longer apply to the
+new `LiquidFill`-based fill:
 
-If any existing test reads `.style.height` or `.style.background` to assert on the gradient, replace it with an assertion against the rendered `LiquidFill`'s `data-testid="liquid-base"` element's `y` attribute (which scales with `pct`).
+1. **`fill.style.height === 'X%'`** — used by the `null state` block
+   (line 41) and the `fill height at various percentages` block
+   (lines 60-79). `LiquidFill`'s outer `<div>` does not set a `height`
+   style; instead, the wave-y groups carry inline `transform:
+translateY(...)` that moves with `pct`. Replace each
+   `fill.style.height` assertion with an assertion on the
+   `data-testid="liquid-base"` rect's `y` attribute, which equals
+   `top + ambientAmp + 0.5` = `(110 - (110 - 4) * pct / 100) + 1.8 + 0.5`.
+   At `pct=0` the `liquid-base` element is absent (see Task 8 Step 3
+   conditional render), so use `queryByTestId('liquid-base')` →
+   `not.toBeInTheDocument()` instead of a `y`-attribute assertion.
 
-Add a new test for the hex helper inside the same file:
+2. **`fill.className.toContain('from-primary-container/50')`** and the
+   matching `from-tertiary/50` and `from-error/50` assertions in the
+   `color shifts` block (lines 116-152). The new outer `<div>` only
+   carries the caller's `h-full w-full` className — Tailwind gradient
+   classes are no longer present. Replace each color-class assertion
+   with an assertion that the rendered `<linearGradient>` stops carry
+   the hex value `hexForColorClass(pct)` returns:
+
+   ```tsx
+   const stops = container.querySelectorAll('linearGradient stop')
+   // Two stops are emitted by the wave-fill gradient (defs > linearGradient with id `liquid-fill-*`).
+   // Both share the same stop-color (the gradient varies stop-opacity, not stop-color).
+   expect(stops[0]?.getAttribute('stop-color')).toBe('#cba6f7') // primary-container at <80
+   ```
+
+   The progress-bar (`bar.className.toContain('bg-primary-container')`),
+   percentage-text (`pct.className.toContain('text-primary-container')`),
+   and emoji-threshold assertions are **unchanged** — they don't touch
+   the gauge fill.
+
+3. The new `bucket-fill` selector at lines 40 / 63 / 70 / 77 / 116 / 130 /
+   144 / 160 continues to resolve. It now points to the `LiquidFill`
+   wrapper `<div>` instead of the old gradient `<div>`, but
+   `getByTestId('bucket-fill')` still returns a non-null element.
+
+Concrete edit list:
+
+- **`null state` block (lines 36-57)** — line 41:
+  `expect(fill.style.height).toBe('0%')` →
+  `expect(screen.queryByTestId('liquid-base')).not.toBeInTheDocument()`
+- **`fill height at various percentages` block (lines 59-80)** — for
+  each of the three tests at 50% / 74% / 90%, replace
+  `expect(fill.style.height).toBe('<N>%')` with:
+  ```tsx
+  const base = screen.getByTestId('liquid-base')
+  const expectedY = 110 - (110 - 4) * (N / 100) + 1.8 + 0.5
+  expect(parseFloat(base.getAttribute('y') ?? '0')).toBeCloseTo(expectedY, 1)
+  ```
+- **`color shifts` block (lines 112-152)** — for each of the three
+  threshold tests (primary at 50%, tertiary at 85%, error at 95%),
+  delete the two `fill.className.toContain('from-*')` /
+  `fill.className.toContain('to-*')` lines and replace with one assertion:
+  ```tsx
+  const stops = container.querySelectorAll('linearGradient stop')
+  expect(stops[0]?.getAttribute('stop-color')).toBe('<hex>') // '#cba6f7' / '#ff94a5' / '#ffb4ab'
+  ```
+  Keep the existing `bar.className.toContain('bg-*')` and
+  `pct.className.toContain('text-*')` assertions — they still apply.
+
+Add a new dedicated test for the hex helper (separate from the
+threshold tests above so the regression is named explicitly):
 
 ```tsx
 test('LiquidFill receives the correct hex for each threshold', () => {

--- a/docs/superpowers/plans/2026-05-22-liquid-bucket-cursor-response.md
+++ b/docs/superpowers/plans/2026-05-22-liquid-bucket-cursor-response.md
@@ -2191,3 +2191,5 @@ This list is for the writer of the plan to walk after committing. The plan execu
 2. **Placeholder scan** — none. Every code step shows the actual code.
 
 3. **Type consistency** — `LiquidRefs`, `LiquidFillProps`, `BucketProps` are defined once and reused. `Signal` union appears only inside the hook implementation. `LIQUID_DEFAULTS` is the single source of truth for tuning.
+
+<!-- codex-reviewed: 2026-05-22T11:15:32Z -->

--- a/docs/superpowers/specs/2026-05-22-liquid-bucket-cursor-response-design.md
+++ b/docs/superpowers/specs/2026-05-22-liquid-bucket-cursor-response-design.md
@@ -1,0 +1,423 @@
+# 2026-05-22 — Liquid bucket cursor response design
+
+## 1. Summary
+
+The agent-status feature renders two distinct "bucket fill" surfaces today:
+
+- `src/features/agent-status/components/Bucket.tsx` — a 22×110 SVG bucket
+  with two scrolling wave paths and an ambient slosh keyframe. Used twice
+  in `AgentStatusRail.tsx:97-114` (CTX and CACHE) for the collapsed rail.
+- `src/features/agent-status/components/ContextBucket.tsx` — a flat CSS
+  gauge: a `<div>` inside `[data-testid="bucket-gauge"]` whose height grows
+  to `effectivePct%` via a 500ms `transition: height` on a linear-gradient
+  fill (`ContextBucket.tsx:117-130`). Used in the expanded agent-status
+  panel as the CURRENT CONTEXT card.
+
+Both visually represent "how full is this resource," and the user has
+asked for the same cursor-responsive water effect on both. This spec
+introduces a single shared liquid renderer that both consume, so the
+behaviour is **global to bucket-style fills in agent-status** rather than
+opt-in per component.
+
+Two new modules under `src/features/agent-status/`:
+
+- `hooks/useWaterCursor.ts` — a rAF-driven spring that takes a wrapper
+  element and a set of SVG refs, attaches `pointermove` /
+  `pointerleave`, and writes seven inline transforms per frame (tilt,
+  scaleY, drift, lift, skew, wave-scroll speed, and a sheen position +
+  opacity). Targets relax to ambient when the cursor leaves; the loop
+  shuts down and clears every inline style once the spring settles, so
+  the at-rest visual is once again pure CSS keyframes.
+- `components/LiquidFill.tsx` — the SVG primitive. Renders the glass
+  cell, a solid base rect, two phase-offset wave paths, and a sheen
+  ellipse. Mounts `useWaterCursor` on its outer `<div>`. Supports two
+  modes: `mode="bar"` (fixed 22×110, used by `Bucket`) and `mode="fill"`
+  (measures its container via `ResizeObserver` and renders the SVG at
+  the measured size with `preserveAspectRatio="none"`, used by
+  `ContextBucket`).
+
+Two existing components are modified:
+
+- `Bucket.tsx` keeps its public API (`pct`, `color`, `label`, `title`)
+  and its label + percentage chrome, but delegates all SVG rendering to
+  `<LiquidFill mode="bar" pct={...} color={...} />`. The existing
+  `vf-bucket-*` ambient CSS classes move with the SVG into `LiquidFill`.
+- `ContextBucket.tsx` keeps its card chrome, scale labels, progress bar,
+  token counts, and the existing color thresholds (primary-container /
+  tertiary / error from `getColorClass`). The flat gradient `<div>` at
+  `ContextBucket.tsx:117-130` is replaced by
+  `<LiquidFill mode="fill" pct={effectivePct} color={...} />`. The
+  height transition that used to animate the gradient's `height` is
+  absorbed by the wave's `waterTop` y-coordinate transition inside
+  `LiquidFill`, so percentage changes still rise smoothly.
+
+The hook lives on each `LiquidFill` instance — there are no global
+listeners, no module-level state, and no shutdown hooks. When the rail
+collapses → expands, when the agent panel closes, or when the React
+tree unmounts the component for any reason, the hook's cleanup cancels
+its rAF and removes its listeners. **Reset is structural, not
+imperative.**
+
+No backend, no IPC, no preload changes.
+
+## 2. Scope
+
+In scope:
+
+- New shared hook + primitive (`useWaterCursor`, `LiquidFill`).
+- Modifying `Bucket.tsx` to delegate to `LiquidFill`.
+- Modifying `ContextBucket.tsx`'s gauge fill to use `LiquidFill`.
+- Moving the `vf-bucket-wave-a/b` and `vf-bucket-slosh` CSS from
+  `src/index.css` into a renamed `vf-liquid-*` block that both consumers
+  share (the rename is mandatory because the rules now apply outside the
+  rail-only `Bucket`).
+- Spec-defaults tuning constants live in `LiquidFill.tsx` as a single
+  `LIQUID_DEFAULTS` object.
+
+Out of scope:
+
+- Touching `TokenCache.tsx`, `BudgetMetrics.tsx`, `FilesChanged.tsx`,
+  `TestResults.tsx`, or any other agent-status component that does not
+  render a "fill level." A follow-up may extend the primitive there.
+- Touching `AgentStatusRail.tsx`, `AgentStatusPanel/`, or `Header.tsx` —
+  the agent-status panel collapse / expand / close lifecycle is the
+  feature's natural unmount path and is unchanged.
+- Touching `src/features/terminal/`, `src/features/files/`,
+  `src/features/diff/`, or any other feature.
+- Backend changes — there are none.
+- Storybook / visual-regression scaffolding — this repo has no Storybook
+  setup and adding one is not part of this change.
+
+## 3. Tuning constants (locked)
+
+These are the values the user selected by hand in
+`~/projects/water-bucket-prototype/index.html`, frozen here as the
+production defaults:
+
+```ts
+export const LIQUID_DEFAULTS = {
+  // Field
+  halo: 70, // px — radius around the bucket where the cursor
+  //      starts to influence the surface
+  omega: 6.5, // rad/s — spring stiffness (critically damped,
+  //         zeta = 1.0). ~600 ms settling time.
+
+  // Response
+  maxTilt: 1.6, // deg — whole-body rotation toward the cursor
+  ampMax: 1.5, // × ambient — wave amplitude gain at full proximity
+  maxShift: 1.0, // px — horizontal drift of the wave near the cursor
+  maxLift: 1.0, // px — vertical pull of the surface toward the cursor
+  meniscus: 2.3, // deg — surface-skew (skewX on the wave layers)
+  speedup: 1.02, // × — wave-scroll animation-duration multiplier
+  //     when the cursor is at the bucket
+} as const
+```
+
+A `prefers-reduced-motion: reduce` media query short-circuits the hook
+to a no-op (matching the existing behavior at `src/index.css:209-215`).
+The ambient CSS keyframes are also disabled by the same media query, so
+the at-rest visual under reduced motion is a static gradient fill — the
+same fallback we ship today.
+
+## 4. `useWaterCursor` hook
+
+Location: `src/features/agent-status/hooks/useWaterCursor.ts`.
+
+Signature:
+
+```ts
+export interface LiquidRefs {
+  slosh: SVGGElement // wrapper for the tilt rotation
+  waveAShift: SVGGElement // wave-A translate / scale / skew target
+  waveBShift: SVGGElement // wave-B translate / scale / skew target
+  waveAAnim: SVGGElement // wave-A animation-duration target
+  waveBAnim: SVGGElement // wave-B animation-duration target
+  sheen: SVGEllipseElement // sheen position + opacity target
+  waterTop: number // y of the waterline at rest (px)
+  ambientAmp: number // wave amplitude at rest (px)
+  dims: { w: number; h: number } // SVG viewport size, used for the
+  //   rotate transform-origin
+}
+
+export const useWaterCursor: (
+  wrapRef: RefObject<HTMLElement>,
+  refsRef: RefObject<LiquidRefs | null>,
+  tune?: Partial<typeof LIQUID_DEFAULTS>
+) => void
+```
+
+The hook only reads from the refs — never writes through React state.
+Each animation frame it integrates a critically-damped spring for eight
+scalar signals (`tilt`, `amp`, `shiftX`, `lift`, `skew`, `speedT`,
+`sheenX`, `sheenA`) and writes the result directly to the DOM via the
+ref handles. React renders are not involved in the loop.
+
+Lifecycle:
+
+- On mount: register `pointermove` and `pointerleave` on `wrapRef.current`.
+- On `pointermove`: compute proximity (smoothstep, not linear — kills
+  the "jittery at distance" feel where a cursor twitch 200px away makes
+  the water visibly move) and update spring targets.
+- On `pointerleave`: targets snap to ambient (`tilt=0`, `amp=1`, …).
+- The rAF loop runs only while any signal is away from its target. Once
+  all eight signals settle and all eight targets are at ambient, the
+  loop calls `clearInline()` (removes every inline style it added,
+  removes the `data-interactive="on"` attribute) and cancels itself.
+  This is what hands control back to the CSS keyframes.
+- On unmount: cancel rAF, remove listeners, run `clearInline()`. Idempotent.
+
+Reduced-motion: if
+`window.matchMedia('(prefers-reduced-motion: reduce)').matches` is true,
+the hook installs no listeners and the inline transforms never appear.
+The ambient CSS classes themselves are disabled by the same media query
+inside `src/index.css`, so the visual is a static fill.
+
+## 5. `LiquidFill` primitive
+
+Location: `src/features/agent-status/components/LiquidFill.tsx`.
+
+```ts
+export interface LiquidFillProps {
+  pct: number // 0..100
+  color: string // CSS color for the wave fill
+  mode: 'bar' | 'fill'
+  ariaHidden?: boolean // default true
+  className?: string // applied to the outer <div>
+  testId?: string
+  tune?: Partial<typeof LIQUID_DEFAULTS>
+}
+```
+
+Internals:
+
+- `mode="bar"`: SVG is rendered at `22×110` with `viewBox="0 0 22 110"`
+  and `preserveAspectRatio="xMidYMid meet"`. This is the exact geometry
+  the current `Bucket` ships, so the rail mockup does not shift by a
+  pixel.
+- `mode="fill"`: a `ResizeObserver` measures the outer `<div>` and the
+  SVG renders at the measured width × height with
+  `preserveAspectRatio="none"`. The wave path's `width` argument is set
+  to the measured CSS width × 2 (matching the `DIMS.w * 2` scaling the
+  prototype uses) so the wavelength looks the same whether the gauge is
+  60px wide or 240px wide.
+
+Geometry — these are constants and behaviors that come straight from the
+prototype:
+
+- `liquidH = (h - 4) * (pct / 100)` — usable interior height is reduced
+  by 2px at top and 2px at bottom for the glass frame.
+- `top = h - liquidH` — y of the waterline at rest.
+- `ambientAmp = min(1.8, w * 0.09)` for `mode="bar"`. For `mode="fill"`,
+  the same formula is used, so on a 200-px-wide gauge the ambient amp
+  reaches its 1.8 cap immediately — wide tanks don't get unreasonably
+  large waves.
+- Two wave paths are built via `buildWavePath(w * 2, ambientAmp, h,
+phase)` at `phase=0` and `phase=0.25`. Phase-offsetting prevents the
+  two waves from cancelling into a horizontal line at any moment.
+- The solid base rect's y is `top + ambientAmp + 0.5` — **below the
+  wave's deepest trough**. This is the key fix that hides what used to
+  read as a static seam at the water surface: the rect's flat top edge
+  sits inside the wave's filled body and is never visible.
+
+Pct transitions: `mode="fill"`'s `waterTop` is animated by a CSS
+`transition: y 500ms ease` on the wave-shift `<g>` elements (matching
+the 500ms transition the current ContextBucket gradient uses at
+`ContextBucket.tsx:123`), so percentage changes still rise smoothly.
+
+ARIA: when `ariaHidden !== false`, the SVG carries `aria-hidden="true"`
+and the cursor effect carries no role. The percentage text and label
+that consumers render around `LiquidFill` (in `Bucket.tsx`) and the
+percentage text in `ContextBucket.tsx:92-97` remain the accessible
+representation of state. No additional `aria-live` is added.
+
+## 6. Consumer changes
+
+### 6.1 `Bucket.tsx`
+
+The public API (`BucketProps = { pct, color, label, title? }`) is
+unchanged. The label and percentage `<div>`s at `Bucket.tsx:38-55` and
+`Bucket.tsx:142-147` are unchanged. The SVG block at `Bucket.tsx:57-140`
+is replaced by:
+
+```tsx
+<LiquidFill
+  mode="bar"
+  pct={clamped}
+  color={color}
+  testId={`bucket-${labelKey}-svg`}
+/>
+```
+
+The `BucketLiquid` inner component, `buildWavePath` helper, `DIMS`
+constant, `TICK_LEVELS` constant, and `useId`-based gradient-id sanitizer
+move into `LiquidFill.tsx`. The 25/50/75% tick marks at
+`Bucket.tsx:103-126` move with them. Existing tests
+(`Bucket.test.tsx`) that assert on `data-testid="bucket-tick-25"`,
+`data-testid="bucket-liquid"`, and on the rendered percentage continue
+to pass because those test ids live on the SVG internals, which are now
+rendered by `LiquidFill` but unchanged in structure.
+
+### 6.2 `ContextBucket.tsx`
+
+Lines 117-130 — the `<div data-testid="bucket-fill" ...>` block that
+renders the flat gradient — are replaced by:
+
+```tsx
+<LiquidFill
+  mode="fill"
+  pct={effectivePct}
+  color={cssVarForColorClass(pct)} // see below
+  testId="bucket-fill"
+/>
+```
+
+`getColorClass` at `ContextBucket.tsx:45-68` currently returns Tailwind
+class fragments (`from-error/50 to-error`, etc.). `LiquidFill` needs a
+single CSS color, so a sibling helper resolves the Tailwind token to the
+CSS variable it expands to (`var(--md-sys-color-error)`, etc.).
+`tailwind.config.js` defines these tokens; the helper does not introduce
+new colors and does not change the threshold logic. The progress bar
+(`ContextBucket.tsx:143-155`), token counts, header, scale, and dot
+overlay are untouched.
+
+The `data-testid="bucket-fill"` attribute is preserved on the new
+`<LiquidFill>` outer `<div>` so existing snapshot or query tests keep
+finding it.
+
+## 7. CSS changes
+
+In `src/index.css:187-215`:
+
+- Rename `@keyframes vfSlosh`, `@keyframes vfWaveA`, `@keyframes vfWaveB`
+  and the `.vf-bucket-*` selectors to `vfLiquidSlosh`, `vfLiquidWaveA`,
+  `vfLiquidWaveB`, `.vf-liquid-*`. The rename signals the wider scope —
+  these are no longer rail-bucket-specific.
+- Add `.vf-liquid-slosh[data-interactive="on"] { animation: none; }` so
+  the inline rotate from the hook wins over the CSS slosh while the
+  cursor is active. The hook removes the attribute on its way back to
+  rest, so the keyframe takes back over once the spring settles.
+- Keep the `@media (prefers-reduced-motion: reduce)` block — adjust
+  selectors to the new names.
+
+No other CSS files change. Tailwind classes referenced by consumers
+(`text-error`, `bg-primary-container`, etc.) are untouched.
+
+## 8. Testing
+
+Co-located tests follow the project pattern (sibling `.test.tsx`).
+
+`hooks/useWaterCursor.test.tsx`:
+
+- After mount, no inline transform is written until a `pointermove`
+  fires (the loop only starts on demand).
+- `pointermove` with the cursor over the wrap: within the next
+  `requestAnimationFrame`, the slosh element gains
+  `data-interactive="on"` and a non-zero `transform: rotate(...)`.
+- `pointerleave`: the loop continues to run until the spring settles,
+  then clears inline styles and removes `data-interactive`.
+- Unmount: rAF cancelled, listeners removed, inline styles cleared.
+  Tested by spying on `cancelAnimationFrame` and by asserting the
+  removed-from-DOM element has no leftover inline style values on a
+  ref we keep around.
+- `prefers-reduced-motion: reduce` → no listeners registered (verified
+  by spying on `addEventListener` on the wrap).
+
+`components/LiquidFill.test.tsx`:
+
+- `mode="bar"` renders an SVG at the fixed `22×110` viewport.
+- `mode="fill"` renders an SVG that updates its `width` / `height`
+  attributes in response to a `ResizeObserver` callback (mocked).
+- Tick marks at 25/50/75 are present in `mode="bar"` (regression for
+  the current Bucket visual).
+- The base rect's `y` attribute equals `top + ambientAmp + 0.5`
+  (regression for the surface-line fix).
+- Two wave paths are built with `phase=0` and `phase=0.25` (regression
+  against accidental same-phase rendering returning).
+
+`components/Bucket.test.tsx`:
+
+- Existing tests pass with no changes — the public API and test ids
+  carried by the SVG internals are preserved.
+
+`components/ContextBucket.test.tsx`:
+
+- The `data-testid="bucket-fill"` element is present.
+- The percentage text and color-threshold logic
+  (`{ pct >= 90 → error, pct >= 80 → tertiary, else → primary-container }`)
+  are unchanged.
+- The 500ms transition behavior is unchanged when `pct` updates (test
+  asserts the `waterTop` value, not the `height` style).
+
+`AgentStatusRail.test.tsx`: existing tests pass.
+
+`AgentStatusPanel/index.test.tsx`: existing tests pass.
+
+Run `npm run test`, `npm run lint`, and `npm run type-check` before
+opening the PR. The pre-push hook (`.husky/pre-push`) runs the full
+vitest suite — that gate stays green.
+
+## 9. Manual verification
+
+The full design lives in working form at
+`~/projects/water-bucket-prototype/index.html` with the locked tuning
+defaults already applied. The implementation is a port of that
+prototype's SVG + hook into React, so the production look-and-feel
+should match it byte-for-byte once the defaults from §3 are in code.
+
+Manual smoke checks before merge:
+
+1. Open the app. Collapse the agent panel to the rail. Move the cursor
+   slowly toward and away from the CTX bucket — water should tilt, lift,
+   skew, and quicken. Repeat for CACHE.
+2. Expand the agent panel. Move the cursor over the CURRENT CONTEXT
+   gauge — same response in the wider rectangular tank.
+3. Toggle rail collapsed ↔ expanded several times. Open Chrome devtools
+   and inspect the `Bucket` and `ContextBucket` subtrees. After each
+   toggle, no `[data-interactive="on"]` attributes should remain on
+   detached nodes; no inline `transform` styles should linger on
+   freshly mounted components.
+4. Close the agent panel entirely. The `ContextBucket` is unmounted —
+   browser memory inspection should not show pending rAF handles.
+5. Enable "Reduce motion" at the OS level. Waves and slosh stop; the
+   cursor effect stops; the fill is static. No JS errors in the console.
+
+## 10. Risks and non-issues
+
+- **Visual change to ContextBucket.** The flat gradient becomes a wavy
+  fill. This is an aesthetic decision the user confirmed in
+  brainstorming; the percentage display, scale, progress bar, and color
+  thresholds are unchanged, so the _information_ the card conveys is
+  identical. If review pushes back, reverting is a one-line consumer
+  change (`<LiquidFill mode="fill" ...>` → the old gradient div).
+- **`ResizeObserver` availability.** Already used elsewhere in the
+  Electron renderer; no polyfill needed for Chrome 100+.
+- **Spring stability.** Critically damped (zeta=1.0), so no overshoot.
+  The fixed-omega integration runs at ≤60Hz and uses `dt` clamped to
+  50ms, so frame drops do not blow up the simulation.
+- **Performance.** One rAF loop per visible `LiquidFill`. With the
+  current panel that's at most three (rail CTX, rail CACHE, expanded
+  context bucket — and the rail bucket is unmounted when the panel
+  expands, so the steady state is one or two). Each loop writes ~8
+  inline style attributes per frame. Negligible on any machine that can
+  run Electron.
+- **Tailwind-token → CSS-var helper.** The new helper in
+  `ContextBucket.tsx` (§6.2) is a small lookup table mapping the
+  threshold buckets (error / tertiary / primary-container) to their
+  CSS-variable names. It is co-located with `ContextBucket` (not
+  exported) and not introduced as a general-purpose primitive.
+
+## 11. File-level diff plan
+
+```
+A  src/features/agent-status/hooks/useWaterCursor.ts
+A  src/features/agent-status/hooks/useWaterCursor.test.tsx
+A  src/features/agent-status/components/LiquidFill.tsx
+A  src/features/agent-status/components/LiquidFill.test.tsx
+M  src/features/agent-status/components/Bucket.tsx
+M  src/features/agent-status/components/ContextBucket.tsx
+M  src/index.css                          # vf-bucket-* → vf-liquid-*
+A  docs/superpowers/specs/2026-05-22-liquid-bucket-cursor-response-design.md
+```
+
+No backend (`crates/backend/`) files change. No electron preload changes.
+No `package.json` changes.

--- a/docs/superpowers/specs/2026-05-22-liquid-bucket-cursor-response-design.md
+++ b/docs/superpowers/specs/2026-05-22-liquid-bucket-cursor-response-design.md
@@ -532,3 +532,5 @@ A  docs/superpowers/specs/2026-05-22-liquid-bucket-cursor-response-design.md
 
 No backend (`crates/backend/`) files change. No electron preload changes.
 No `package.json` changes.
+
+<!-- codex-reviewed: 2026-05-22T10:57:34Z -->

--- a/docs/superpowers/specs/2026-05-22-liquid-bucket-cursor-response-design.md
+++ b/docs/superpowers/specs/2026-05-22-liquid-bucket-cursor-response-design.md
@@ -128,12 +128,18 @@ Signature:
 ```ts
 export interface LiquidRefs {
   slosh: SVGGElement // wrapper for the tilt rotation
-  waveAShift: SVGGElement // wave-A translate / scale / skew target
-  waveBShift: SVGGElement // wave-B translate / scale / skew target
+  waveAShift: SVGGElement // wave-A cursor target — child of the
+  //   pct-driven <g data-water-y-a>. Owns only
+  //   scaleY / translateY(<lift>) / translateX / skewX.
+  waveBShift: SVGGElement // wave-B cursor target — child of the
+  //   pct-driven <g data-water-y-b>. Same set of transforms.
   waveAAnim: SVGGElement // wave-A animation-duration target
   waveBAnim: SVGGElement // wave-B animation-duration target
   sheen: SVGEllipseElement // sheen position + opacity target
-  waterTop: number // y of the waterline at rest (px)
+  waterTop: number // y of the waterline at rest (px) — used to
+  //   position the sheen ellipse, not by the wave transforms
+  //   (those are positioned by the React-managed outer
+  //   <g data-water-y-*> groups).
   ambientAmp: number // wave amplitude at rest (px)
   dims: { w: number; h: number } // SVG viewport size, used for the
   //   rotate transform-origin
@@ -150,14 +156,39 @@ The hook only reads from the refs — never writes through React state.
 Each animation frame it integrates a critically-damped spring for eight
 scalar signals (`tilt`, `amp`, `shiftX`, `lift`, `skew`, `speedT`,
 `sheenX`, `sheenA`) and writes the result directly to the DOM via the
-ref handles. React renders are not involved in the loop.
+ref handles. React renders are not involved in the loop. Because the
+pct-driven `translateY` lives on the outer `<g data-water-y-*>` groups
+(which the hook never touches), pct changes can animate via a
+CSS `transition: transform 500ms ease` on those groups without
+conflicting with the per-frame cursor transforms on the inner
+`<g data-wave-shift-*>` groups.
+
+Trigger zone and halo semantics:
+
+- The hook listens **only** on `wrapRef.current` — there are no
+  global / document / window pointer listeners. The cursor must enter
+  the wrapper element to start a response. The wrapper is the SVG
+  itself plus the CSS padding around it (the `bucket-wrap` `padding`
+  in `Bucket.tsx`, and the equivalent padded outer `<div>` rendered by
+  `LiquidFill` for `mode="fill"`).
+- The `halo` tuning value (70 px) is a **proximity falloff scaler**,
+  not a trigger radius. Inside the wrapper, proximity is computed via
+  smoothstep on `dist / (halo + width/2)`, peaking at the wrapper's
+  center and falling to zero at its edge. To extend the apparent reach
+  beyond the SVG, the wrapper's CSS padding is widened — implementers
+  who want a 70 px trigger reach pad the wrapper accordingly (the
+  default `padding: 14px` in the prototype assumes the user moves the
+  cursor onto the bucket before the response begins, which matches the
+  spec's intent of "the water reacts when the cursor is over it").
+  This is documented next to `LiquidFill`'s wrapper rendering so the
+  intent is not lost.
 
 Lifecycle:
 
 - On mount: register `pointermove` and `pointerleave` on `wrapRef.current`.
 - On `pointermove`: compute proximity (smoothstep, not linear — kills
-  the "jittery at distance" feel where a cursor twitch 200px away makes
-  the water visibly move) and update spring targets.
+  the "jittery near the wrapper edge" feel where a cursor twitch
+  translates into visible water movement) and update spring targets.
 - On `pointerleave`: targets snap to ambient (`tilt=0`, `amp=1`, …).
 - The rAF loop runs only while any signal is away from its target. Once
   all eight signals settle and all eight targets are at ambient, the
@@ -166,11 +197,17 @@ Lifecycle:
   This is what hands control back to the CSS keyframes.
 - On unmount: cancel rAF, remove listeners, run `clearInline()`. Idempotent.
 
-Reduced-motion: if
-`window.matchMedia('(prefers-reduced-motion: reduce)').matches` is true,
-the hook installs no listeners and the inline transforms never appear.
-The ambient CSS classes themselves are disabled by the same media query
-inside `src/index.css`, so the visual is a static fill.
+Reduced-motion: the hook subscribes to the
+`(prefers-reduced-motion: reduce)` media query on mount via
+`mql.addEventListener('change', ...)`, not just `mql.matches` at mount
+time. When the preference flips ON at runtime (the user toggles OS
+"Reduce motion" while the app is open), the hook detaches its pointer
+listeners and runs `clearInline()` immediately, so already-mounted
+fills lose their cursor response without a reload. When the preference
+flips OFF, listeners are reattached. The change listener is removed on
+unmount alongside the pointer listeners. The ambient CSS classes are
+also disabled by the same media query inside `src/index.css`, so the
+at-rest visual under reduced motion is a static fill.
 
 ## 5. `LiquidFill` primitive
 
@@ -219,10 +256,35 @@ phase)` at `phase=0` and `phase=0.25`. Phase-offsetting prevents the
   read as a static seam at the water surface: the rect's flat top edge
   sits inside the wave's filled body and is never visible.
 
-Pct transitions: `mode="fill"`'s `waterTop` is animated by a CSS
-`transition: y 500ms ease` on the wave-shift `<g>` elements (matching
-the 500ms transition the current ContextBucket gradient uses at
-`ContextBucket.tsx:123`), so percentage changes still rise smoothly.
+Pct transitions — nested transform groups: SVG `<g>` does not support a
+`y` attribute, and the cursor hook's spring writes to the wave groups'
+`transform` each frame, so a CSS transition on a combined transform
+would animate the cursor signals too. The renderer nests the
+percentage-driven and cursor-driven transforms onto two separate
+`<g>` elements:
+
+- **Outer `<g data-water-y-a>` / `<g data-water-y-b>`** — owns only
+  `transform: translateY(<waterTop>)` (waveB) or
+  `translateY(<waterTop - ambientAmp/2>)` (waveA). The renderer applies
+  CSS `transition: transform 500ms ease` to these groups. When `pct`
+  changes, only the `translateY` value updates and the transition
+  animates the waterline smoothly — matching the existing 500ms ease at
+  `ContextBucket.tsx:123`.
+- **Inner `<g data-wave-shift-a>` / `<g data-wave-shift-b>`** —
+  child of the outer group; owns only the cursor hook's
+  `scaleY` / `translateX` / `skewX`. No CSS transition (the spring is
+  the smoothing). These are the elements named `waveAShift` /
+  `waveBShift` in `LiquidRefs`; the hook writes here, not on the
+  outer group.
+
+Same separation for the slosh wrapper: outer `<g class="vf-liquid-slosh">`
+owns the ambient CSS slosh animation; the hook's `tilt` rotation is
+written to its inline `transform` only while interactive (the
+`[data-interactive="on"]` selector suppresses the keyframe so the
+inline transform wins). Because the rotation lives on the same
+element as the keyframe, no nesting is needed there — the keyframe
+and the inline transform are mutually exclusive by selector
+specificity.
 
 ARIA: when `ariaHidden !== false`, the SVG carries `aria-hidden="true"`
 and the cursor effect carries no role. The percentage text and label
@@ -266,19 +328,46 @@ renders the flat gradient — are replaced by:
 <LiquidFill
   mode="fill"
   pct={effectivePct}
-  color={cssVarForColorClass(pct)} // see below
+  color={hexForColorClass(pct)}
+  className="h-full w-full"
   testId="bucket-fill"
 />
 ```
 
+Sizing contract for `mode="fill"`: `LiquidFill`'s outer `<div>` must
+fill its parent so `ResizeObserver` measures the real gauge box and
+not a 0×0 intrinsic-content rect. Passing `className="h-full w-full"`
+ensures this inside the existing
+`<div data-testid="bucket-gauge" class="relative flex flex-1 flex-col
+justify-end overflow-hidden ...">` parent (the parent has a fixed
+72 px height from its `flex h-[72px]` ancestor, so `h-full` resolves
+to 72 px). The `flex flex-col justify-end` on the parent gauge no
+longer has anything to push to the bottom — `LiquidFill` draws its
+own waterline at `top = h - (h - 4) * (pct / 100)` — but the flex
+classes are left in place rather than removed, so the diff is
+minimal and the gauge container's own role (border-radius, dot
+overlay, background color) is preserved exactly.
+
 `getColorClass` at `ContextBucket.tsx:45-68` currently returns Tailwind
 class fragments (`from-error/50 to-error`, etc.). `LiquidFill` needs a
-single CSS color, so a sibling helper resolves the Tailwind token to the
-CSS variable it expands to (`var(--md-sys-color-error)`, etc.).
-`tailwind.config.js` defines these tokens; the helper does not introduce
-new colors and does not change the threshold logic. The progress bar
-(`ContextBucket.tsx:143-155`), token counts, header, scale, and dot
-overlay are untouched.
+single CSS color string, so a sibling helper `hexForColorClass(pct)`
+returns the matching hex value from `tailwind.config.js`:
+
+```ts
+const hexForColorClass = (pct: number | null): string => {
+  if (pct !== null && pct >= 90) return '#ffb4ab' // tailwind.config.js:25 (error)
+  if (pct !== null && pct >= 80) return '#ff94a5' // tailwind.config.js:21 (tertiary)
+  return '#cba6f7' // tailwind.config.js:10 (primary-container)
+}
+```
+
+The thresholds match `getColorClass` exactly; the helper is co-located
+in `ContextBucket.tsx` and not exported. The Tailwind token names
+(`error`, `tertiary`, `primary-container`) are not CSS variables in
+this project — `tailwind.config.js` defines them as hex literals — so
+the helper returns hex directly rather than `var(--md-sys-color-*)`,
+which do not exist. The progress bar (`ContextBucket.tsx:143-155`),
+token counts, header, scale, and dot overlay are untouched.
 
 The `data-testid="bucket-fill"` attribute is preserved on the new
 `<LiquidFill>` outer `<div>` so existing snapshot or query tests keep
@@ -319,14 +408,28 @@ Co-located tests follow the project pattern (sibling `.test.tsx`).
   Tested by spying on `cancelAnimationFrame` and by asserting the
   removed-from-DOM element has no leftover inline style values on a
   ref we keep around.
-- `prefers-reduced-motion: reduce` → no listeners registered (verified
-  by spying on `addEventListener` on the wrap).
+- `prefers-reduced-motion: reduce` matches at mount → no pointer
+  listeners registered (verified by spying on `addEventListener` on
+  the wrap).
+- `prefers-reduced-motion` flipped ON mid-mount (simulated by firing
+  the `change` event on the mocked `MediaQueryList`): pointer
+  listeners are removed and `clearInline()` runs. Conversely,
+  flipping it OFF at runtime reattaches the pointer listeners.
 
 `components/LiquidFill.test.tsx`:
 
 - `mode="bar"` renders an SVG at the fixed `22×110` viewport.
 - `mode="fill"` renders an SVG that updates its `width` / `height`
   attributes in response to a `ResizeObserver` callback (mocked).
+  Regression test: the outer `<div>` always carries the caller's
+  `className` (so a consumer can pass `h-full w-full` and trust the
+  observer to measure the real parent box).
+- Nested transform groups: the rendered tree contains
+  `<g data-water-y-a><g data-wave-shift-a>...</g></g>` (and the
+  matching `-b` pair). When the `pct` prop changes, only the outer
+  `data-water-y-*` group's inline `transform` updates; the inner
+  `data-wave-shift-*` group's `transform` is untouched. Regression
+  against a future refactor collapsing the two groups.
 - Tick marks at 25/50/75 are present in `mode="bar"` (regression for
   the current Bucket visual).
 - The base rect's `y` attribute equals `top + ambientAmp + 0.5`
@@ -378,8 +481,12 @@ Manual smoke checks before merge:
    freshly mounted components.
 4. Close the agent panel entirely. The `ContextBucket` is unmounted —
    browser memory inspection should not show pending rAF handles.
-5. Enable "Reduce motion" at the OS level. Waves and slosh stop; the
-   cursor effect stops; the fill is static. No JS errors in the console.
+5. Enable "Reduce motion" at the OS level **while the app is already
+   open** (do not reload). Within one frame, waves and slosh stop, the
+   cursor stops driving the water, and the fill becomes static. Toggle
+   Reduce Motion off again — the ambient slosh resumes and pointer
+   movement starts driving the water again. No JS errors in the
+   console at any point.
 
 ## 10. Risks and non-issues
 
@@ -400,11 +507,15 @@ Manual smoke checks before merge:
   expands, so the steady state is one or two). Each loop writes ~8
   inline style attributes per frame. Negligible on any machine that can
   run Electron.
-- **Tailwind-token → CSS-var helper.** The new helper in
-  `ContextBucket.tsx` (§6.2) is a small lookup table mapping the
-  threshold buckets (error / tertiary / primary-container) to their
-  CSS-variable names. It is co-located with `ContextBucket` (not
-  exported) and not introduced as a general-purpose primitive.
+- **Tailwind-token → hex helper.** The new `hexForColorClass` in
+  `ContextBucket.tsx` (§6.2) is a small lookup mapping the threshold
+  buckets (error / tertiary / primary-container) to their hex
+  literals from `tailwind.config.js`. It is co-located with
+  `ContextBucket` (not exported) and not introduced as a
+  general-purpose primitive. If `tailwind.config.js` ever migrates
+  to CSS variables for these tokens, the helper switches to
+  returning `var(--token-name)` strings — both forms are valid SVG
+  `fill` values.
 
 ## 11. File-level diff plan
 

--- a/src/features/agent-status/components/Bucket.test.tsx
+++ b/src/features/agent-status/components/Bucket.test.tsx
@@ -7,9 +7,9 @@ test('renders rounded percent, label, and tick marks at 25/50/75', () => {
 
   expect(screen.getByTestId('bucket-ctx-pct')).toHaveTextContent('74%')
   expect(screen.getByTestId('bucket-ctx-label')).toHaveTextContent('CTX')
-  expect(screen.getByTestId('bucket-tick-25')).toBeInTheDocument()
-  expect(screen.getByTestId('bucket-tick-50')).toBeInTheDocument()
-  expect(screen.getByTestId('bucket-tick-75')).toBeInTheDocument()
+  expect(screen.getByTestId('liquid-tick-25')).toBeInTheDocument()
+  expect(screen.getByTestId('liquid-tick-50')).toBeInTheDocument()
+  expect(screen.getByTestId('liquid-tick-75')).toBeInTheDocument()
 })
 
 test('clamps percent into [0, 100] without throwing', () => {
@@ -23,12 +23,12 @@ test('clamps percent into [0, 100] without throwing', () => {
 
 test('omits liquid when percent is 0', () => {
   render(<Bucket pct={0} color="#cba6f7" label="CTX" />)
-  expect(screen.queryByTestId('bucket-liquid')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('liquid-base')).not.toBeInTheDocument()
 })
 
 test('renders liquid layer when percent is positive', () => {
   render(<Bucket pct={42} color="#cba6f7" label="CTX" />)
-  expect(screen.getByTestId('bucket-liquid')).toBeInTheDocument()
+  expect(screen.getByTestId('liquid-base')).toBeInTheDocument()
 })
 
 test('label is rendered with mono tracking class for horizontal readability', () => {

--- a/src/features/agent-status/components/Bucket.tsx
+++ b/src/features/agent-status/components/Bucket.tsx
@@ -173,7 +173,7 @@ const BucketLiquid = ({
 
   return (
     <g
-      className="vf-bucket-slosh"
+      className="vf-liquid-slosh"
       data-testid="bucket-liquid"
       style={{ transformOrigin: `${dims.w / 2}px ${dims.h}px` }}
     >
@@ -185,12 +185,12 @@ const BucketLiquid = ({
         fill={fillUrl}
       />
       <g style={{ transform: `translateY(${top - amp / 2}px)` }}>
-        <g className="vf-bucket-wave-a">
+        <g className="vf-liquid-wave-a">
           <path d={wavePath} fill={color} fillOpacity="0.55" />
         </g>
       </g>
       <g style={{ transform: `translateY(${top}px)` }}>
-        <g className="vf-bucket-wave-b">
+        <g className="vf-liquid-wave-b">
           <path d={wavePath} fill={fillUrl} fillOpacity="0.95" />
         </g>
       </g>

--- a/src/features/agent-status/components/Bucket.tsx
+++ b/src/features/agent-status/components/Bucket.tsx
@@ -1,4 +1,5 @@
-import { useId, type ReactElement } from 'react'
+import { type ReactElement } from 'react'
+import { LiquidFill } from './LiquidFill'
 
 export interface BucketProps {
   pct: number
@@ -7,31 +8,13 @@ export interface BucketProps {
   title?: string
 }
 
-interface Dims {
-  w: number
-  h: number
-}
-
-const DIMS: Dims = { w: 22, h: 110 }
-const TICK_LEVELS = [25, 50, 75] as const
-
 export const Bucket = ({
   pct,
   color,
   label,
   title = '',
 }: BucketProps): ReactElement => {
-  // useId yields a per-instance unique string (e.g. ":r3:") that React
-  // guarantees won't collide between renders or component instances. SVG
-  // <defs> ids live in the document's global namespace for inline SVG, so
-  // using a caller-supplied prop here would silently corrupt rendering if
-  // two buckets ever shared the same value. Sanitize the colons so they
-  // can be embedded in url(#...) references without escaping.
-  const reactId = useId().replace(/:/g, '')
   const clamped = Math.max(0, Math.min(100, pct))
-  const fillId = `bucket-fill-${reactId}`
-  const glassId = `bucket-glass-${reactId}`
-  const clipId = `bucket-clip-${reactId}`
   const labelKey = label.toLowerCase()
 
   return (
@@ -54,90 +37,12 @@ export const Bucket = ({
         </span>
       </div>
 
-      <svg
-        width={DIMS.w}
-        height={DIMS.h}
-        viewBox={`0 0 ${DIMS.w} ${DIMS.h}`}
-        className="block"
-        aria-hidden="true"
-      >
-        <defs>
-          <linearGradient id={fillId} x1="0" y1="1" x2="0" y2="0">
-            <stop offset="0%" stopColor={color} stopOpacity="0.85" />
-            <stop offset="100%" stopColor={color} stopOpacity="0.55" />
-          </linearGradient>
-          <linearGradient id={glassId} x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0%" stopColor="rgba(255,255,255,0.06)" />
-            <stop offset="40%" stopColor="rgba(255,255,255,0.02)" />
-            <stop offset="100%" stopColor="rgba(0,0,0,0.15)" />
-          </linearGradient>
-          <clipPath id={clipId}>
-            <rect
-              x="1"
-              y="2"
-              width={DIMS.w - 2}
-              height={DIMS.h - 3}
-              rx="3"
-              ry="3"
-            />
-          </clipPath>
-        </defs>
-
-        <rect
-          x="1"
-          y="2"
-          width={DIMS.w - 2}
-          height={DIMS.h - 3}
-          rx="3"
-          ry="3"
-          fill={`url(#${glassId})`}
-        />
-
-        <g clipPath={`url(#${clipId})`}>
-          <BucketLiquid
-            dims={DIMS}
-            pct={clamped}
-            color={color}
-            fillUrl={`url(#${fillId})`}
-          />
-          {TICK_LEVELS.map((t) => {
-            const y = DIMS.h - (DIMS.h - 4) * (t / 100)
-
-            return (
-              <g key={t} data-testid={`bucket-tick-${t}`}>
-                <line
-                  x1="1"
-                  x2="4"
-                  y1={y}
-                  y2={y}
-                  stroke="rgba(255,255,255,0.18)"
-                  strokeWidth="0.8"
-                />
-                <line
-                  x1={DIMS.w - 4}
-                  x2={DIMS.w - 1}
-                  y1={y}
-                  y2={y}
-                  stroke="rgba(255,255,255,0.18)"
-                  strokeWidth="0.8"
-                />
-              </g>
-            )
-          })}
-        </g>
-
-        <rect
-          x="1"
-          y="2"
-          width={DIMS.w - 2}
-          height={DIMS.h - 3}
-          rx="3"
-          ry="3"
-          fill="transparent"
-          stroke="rgba(255,255,255,0.18)"
-          strokeWidth="1"
-        />
-      </svg>
+      <LiquidFill
+        mode="bar"
+        pct={clamped}
+        color={color}
+        testId={`bucket-${labelKey}-svg`}
+      />
 
       <span
         data-testid={`bucket-${labelKey}-label`}
@@ -147,82 +52,4 @@ export const Bucket = ({
       </span>
     </div>
   )
-}
-
-interface BucketLiquidProps {
-  dims: Dims
-  pct: number
-  color: string
-  fillUrl: string
-}
-
-const BucketLiquid = ({
-  dims,
-  pct,
-  color,
-  fillUrl,
-}: BucketLiquidProps): ReactElement | null => {
-  if (pct <= 0) {
-    return null
-  }
-
-  const liquidH = (dims.h - 4) * (pct / 100)
-  const top = dims.h - liquidH
-  const amp = Math.min(1.8, dims.w * 0.09)
-  const wavePath = buildWavePath(dims.w * 2, amp, dims.h)
-
-  return (
-    <g
-      className="vf-liquid-slosh"
-      data-testid="bucket-liquid"
-      style={{ transformOrigin: `${dims.w / 2}px ${dims.h}px` }}
-    >
-      <rect
-        x={0}
-        y={top + amp}
-        width={dims.w}
-        height={Math.max(0, dims.h - (top + amp))}
-        fill={fillUrl}
-      />
-      <g style={{ transform: `translateY(${top - amp / 2}px)` }}>
-        <g className="vf-liquid-wave-a">
-          <path d={wavePath} fill={color} fillOpacity="0.55" />
-        </g>
-      </g>
-      <g style={{ transform: `translateY(${top}px)` }}>
-        <g className="vf-liquid-wave-b">
-          <path d={wavePath} fill={fillUrl} fillOpacity="0.95" />
-        </g>
-      </g>
-      <line
-        x1="2"
-        x2={dims.w - 2}
-        y1={top + 0.5}
-        y2={top + 0.5}
-        stroke={color}
-        strokeWidth="1.1"
-        strokeOpacity="0.85"
-      />
-    </g>
-  )
-}
-
-const buildWavePath = (width: number, amp: number, totalH: number): string => {
-  const wavelength = width / 2
-  const segments = Math.ceil((width / wavelength) * 4)
-  const step = width / segments
-  let d = `M 0,${amp}`
-
-  for (let i = 1; i <= segments; i++) {
-    const x = step * i
-    const cp1x = step * (i - 1) + step / 2
-    const cp2x = step * i - step / 2
-    const targetY = i % 2 === 0 ? amp : 0
-    const startY = (i - 1) % 2 === 0 ? amp : 0
-
-    d += ` C ${cp1x},${startY} ${cp2x},${targetY} ${x},${targetY}`
-  }
-  d += ` L ${width},${totalH} L 0,${totalH} Z`
-
-  return d
 }

--- a/src/features/agent-status/components/ContextBucket.test.tsx
+++ b/src/features/agent-status/components/ContextBucket.test.tsx
@@ -37,8 +37,7 @@ describe('ContextBucket', () => {
     test('renders 0% fill when usedPercentage is null', () => {
       render(<ContextBucket {...defaultProps} usedPercentage={null} />)
 
-      const fill = screen.getByTestId('bucket-fill')
-      expect(fill.style.height).toBe('0%')
+      expect(screen.queryByTestId('liquid-base')).not.toBeInTheDocument()
     })
 
     test('renders dash for percentage when usedPercentage is null', () => {
@@ -60,22 +59,34 @@ describe('ContextBucket', () => {
     test('renders 50% fill height', () => {
       render(<ContextBucket {...defaultProps} usedPercentage={50} />)
 
-      const fill = screen.getByTestId('bucket-fill')
-      expect(fill.style.height).toBe('50%')
+      const base = screen.getByTestId('liquid-base')
+      const expectedY = 110 - (110 - 4) * (50 / 100) + 1.8 + 0.5
+      expect(parseFloat(base.getAttribute('y') ?? '0')).toBeCloseTo(
+        expectedY,
+        1
+      )
     })
 
     test('renders 74% fill height', () => {
       render(<ContextBucket {...defaultProps} usedPercentage={74} />)
 
-      const fill = screen.getByTestId('bucket-fill')
-      expect(fill.style.height).toBe('74%')
+      const base = screen.getByTestId('liquid-base')
+      const expectedY = 110 - (110 - 4) * (74 / 100) + 1.8 + 0.5
+      expect(parseFloat(base.getAttribute('y') ?? '0')).toBeCloseTo(
+        expectedY,
+        1
+      )
     })
 
     test('renders 90% fill height', () => {
       render(<ContextBucket {...defaultProps} usedPercentage={90} />)
 
-      const fill = screen.getByTestId('bucket-fill')
-      expect(fill.style.height).toBe('90%')
+      const base = screen.getByTestId('liquid-base')
+      const expectedY = 110 - (110 - 4) * (90 / 100) + 1.8 + 0.5
+      expect(parseFloat(base.getAttribute('y') ?? '0')).toBeCloseTo(
+        expectedY,
+        1
+      )
     })
   })
 
@@ -111,11 +122,15 @@ describe('ContextBucket', () => {
 
   describe('color shifts', () => {
     test('uses primary colors below 80%', () => {
-      render(<ContextBucket {...defaultProps} usedPercentage={50} />)
+      const { container } = render(
+        <ContextBucket {...defaultProps} usedPercentage={50} />
+      )
 
-      const fill = screen.getByTestId('bucket-fill')
-      expect(fill.className).toContain('from-primary-container/50')
-      expect(fill.className).toContain('to-primary-container')
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+      const stops = container.querySelectorAll(
+        'linearGradient[id^="liquid-fill-"] stop'
+      )
+      expect(stops[0]?.getAttribute('stop-color')).toBe('#cba6f7')
 
       const bar = screen.getByTestId('progress-bar-fill')
       expect(bar.className).toContain('bg-primary-container')
@@ -125,11 +140,15 @@ describe('ContextBucket', () => {
     })
 
     test('shifts to warning (tertiary) at 80%', () => {
-      render(<ContextBucket {...defaultProps} usedPercentage={80} />)
+      const { container } = render(
+        <ContextBucket {...defaultProps} usedPercentage={80} />
+      )
 
-      const fill = screen.getByTestId('bucket-fill')
-      expect(fill.className).toContain('from-tertiary/50')
-      expect(fill.className).toContain('to-tertiary')
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+      const stops = container.querySelectorAll(
+        'linearGradient[id^="liquid-fill-"] stop'
+      )
+      expect(stops[0]?.getAttribute('stop-color')).toBe('#ff94a5')
 
       const bar = screen.getByTestId('progress-bar-fill')
       expect(bar.className).toContain('bg-tertiary')
@@ -139,11 +158,15 @@ describe('ContextBucket', () => {
     })
 
     test('shifts to error at 90%', () => {
-      render(<ContextBucket {...defaultProps} usedPercentage={90} />)
+      const { container } = render(
+        <ContextBucket {...defaultProps} usedPercentage={90} />
+      )
 
-      const fill = screen.getByTestId('bucket-fill')
-      expect(fill.className).toContain('from-error/50')
-      expect(fill.className).toContain('to-error')
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+      const stops = container.querySelectorAll(
+        'linearGradient[id^="liquid-fill-"] stop'
+      )
+      expect(stops[0]?.getAttribute('stop-color')).toBe('#ffb4ab')
 
       const bar = screen.getByTestId('progress-bar-fill')
       expect(bar.className).toContain('bg-error')
@@ -154,11 +177,11 @@ describe('ContextBucket', () => {
   })
 
   describe('CSS transition', () => {
-    test('has height transition on bucket fill', () => {
+    test('has transform transition on liquid wave', () => {
       render(<ContextBucket {...defaultProps} usedPercentage={50} />)
 
-      const fill = screen.getByTestId('bucket-fill')
-      expect(fill.style.transition).toBe('height 500ms ease')
+      const waveY = screen.getByTestId('liquid-water-y-b')
+      expect(waveY.style.transition).toBe('transform 500ms ease')
     })
   })
 

--- a/src/features/agent-status/components/ContextBucket.test.tsx
+++ b/src/features/agent-status/components/ContextBucket.test.tsx
@@ -56,37 +56,42 @@ describe('ContextBucket', () => {
   })
 
   describe('fill height at various percentages', () => {
-    test('renders 50% fill height', () => {
-      render(<ContextBucket {...defaultProps} usedPercentage={50} />)
+    const getWrapperTy = (container: HTMLElement): number => {
+      // eslint-disable-next-line testing-library/no-node-access -- SVG transform style is not reachable via a11y queries
+      const wrapperEl = container.querySelector('[data-testid="liquid-water-y-base"]')
+      expect(wrapperEl).not.toBeNull()
+      const wrapper = wrapperEl as HTMLElement
+      const match = /translateY\((.+?)px\)/.exec(wrapper.style.transform)
 
-      const base = screen.getByTestId('liquid-base')
-      const expectedY = 110 - (110 - 4) * (50 / 100) + 1.8 + 0.5
-      expect(parseFloat(base.getAttribute('y') ?? '0')).toBeCloseTo(
-        expectedY,
-        1
+      return parseFloat(match?.[1] ?? '0')
+    }
+
+    test('renders 50% fill height', () => {
+      const { container } = render(
+        <ContextBucket {...defaultProps} usedPercentage={50} />
       )
+
+      // baseFloor = top + ambientAmp + 0.5  (BAR_DIMS w=22, h=110)
+      const expectedY = 110 - (110 - 4) * (50 / 100) + 1.8 + 0.5
+      expect(getWrapperTy(container)).toBeCloseTo(expectedY, 1)
     })
 
     test('renders 74% fill height', () => {
-      render(<ContextBucket {...defaultProps} usedPercentage={74} />)
-
-      const base = screen.getByTestId('liquid-base')
-      const expectedY = 110 - (110 - 4) * (74 / 100) + 1.8 + 0.5
-      expect(parseFloat(base.getAttribute('y') ?? '0')).toBeCloseTo(
-        expectedY,
-        1
+      const { container } = render(
+        <ContextBucket {...defaultProps} usedPercentage={74} />
       )
+
+      const expectedY = 110 - (110 - 4) * (74 / 100) + 1.8 + 0.5
+      expect(getWrapperTy(container)).toBeCloseTo(expectedY, 1)
     })
 
     test('renders 90% fill height', () => {
-      render(<ContextBucket {...defaultProps} usedPercentage={90} />)
-
-      const base = screen.getByTestId('liquid-base')
-      const expectedY = 110 - (110 - 4) * (90 / 100) + 1.8 + 0.5
-      expect(parseFloat(base.getAttribute('y') ?? '0')).toBeCloseTo(
-        expectedY,
-        1
+      const { container } = render(
+        <ContextBucket {...defaultProps} usedPercentage={90} />
       )
+
+      const expectedY = 110 - (110 - 4) * (90 / 100) + 1.8 + 0.5
+      expect(getWrapperTy(container)).toBeCloseTo(expectedY, 1)
     })
   })
 

--- a/src/features/agent-status/components/ContextBucket.test.tsx
+++ b/src/features/agent-status/components/ContextBucket.test.tsx
@@ -58,7 +58,9 @@ describe('ContextBucket', () => {
   describe('fill height at various percentages', () => {
     const getWrapperTy = (container: HTMLElement): number => {
       // eslint-disable-next-line testing-library/no-node-access -- SVG transform style is not reachable via a11y queries
-      const wrapperEl = container.querySelector('[data-testid="liquid-water-y-base"]')
+      const wrapperEl = container.querySelector(
+        '[data-testid="liquid-water-y-base"]'
+      )
       expect(wrapperEl).not.toBeNull()
       const wrapper = wrapperEl as HTMLElement
       const match = /translateY\((.+?)px\)/.exec(wrapper.style.transform)

--- a/src/features/agent-status/components/ContextBucket.test.tsx
+++ b/src/features/agent-status/components/ContextBucket.test.tsx
@@ -2,6 +2,12 @@ import { describe, test, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { ContextBucket, formatTokens, formatContextSize } from './ContextBucket'
 import type { ContextBucketProps } from './ContextBucket'
+import { BAR_DIMS, computeBaseFloor } from './LiquidFill'
+import {
+  LIQUID_COLOR_PRIMARY_CONTAINER,
+  LIQUID_COLOR_TERTIARY,
+  LIQUID_COLOR_ERROR,
+} from './liquidColors'
 
 const defaultProps: ContextBucketProps = {
   usedPercentage: 50,
@@ -73,8 +79,7 @@ describe('ContextBucket', () => {
         <ContextBucket {...defaultProps} usedPercentage={50} />
       )
 
-      // baseFloor = top + ambientAmp + 0.5  (BAR_DIMS w=22, h=110)
-      const expectedY = 110 - (110 - 4) * (50 / 100) + 1.8 + 0.5
+      const expectedY = computeBaseFloor(BAR_DIMS.w, BAR_DIMS.h, 50)
       expect(getWrapperTy(container)).toBeCloseTo(expectedY, 1)
     })
 
@@ -83,7 +88,7 @@ describe('ContextBucket', () => {
         <ContextBucket {...defaultProps} usedPercentage={74} />
       )
 
-      const expectedY = 110 - (110 - 4) * (74 / 100) + 1.8 + 0.5
+      const expectedY = computeBaseFloor(BAR_DIMS.w, BAR_DIMS.h, 74)
       expect(getWrapperTy(container)).toBeCloseTo(expectedY, 1)
     })
 
@@ -92,7 +97,7 @@ describe('ContextBucket', () => {
         <ContextBucket {...defaultProps} usedPercentage={90} />
       )
 
-      const expectedY = 110 - (110 - 4) * (90 / 100) + 1.8 + 0.5
+      const expectedY = computeBaseFloor(BAR_DIMS.w, BAR_DIMS.h, 90)
       expect(getWrapperTy(container)).toBeCloseTo(expectedY, 1)
     })
   })
@@ -137,7 +142,9 @@ describe('ContextBucket', () => {
       const stops = container.querySelectorAll(
         'linearGradient[id^="liquid-fill-"] stop'
       )
-      expect(stops[0]?.getAttribute('stop-color')).toBe('#cba6f7')
+      expect(stops[0]?.getAttribute('stop-color')).toBe(
+        LIQUID_COLOR_PRIMARY_CONTAINER
+      )
 
       const bar = screen.getByTestId('progress-bar-fill')
       expect(bar.className).toContain('bg-primary-container')
@@ -155,7 +162,7 @@ describe('ContextBucket', () => {
       const stops = container.querySelectorAll(
         'linearGradient[id^="liquid-fill-"] stop'
       )
-      expect(stops[0]?.getAttribute('stop-color')).toBe('#ff94a5')
+      expect(stops[0]?.getAttribute('stop-color')).toBe(LIQUID_COLOR_TERTIARY)
 
       const bar = screen.getByTestId('progress-bar-fill')
       expect(bar.className).toContain('bg-tertiary')
@@ -173,7 +180,7 @@ describe('ContextBucket', () => {
       const stops = container.querySelectorAll(
         'linearGradient[id^="liquid-fill-"] stop'
       )
-      expect(stops[0]?.getAttribute('stop-color')).toBe('#ffb4ab')
+      expect(stops[0]?.getAttribute('stop-color')).toBe(LIQUID_COLOR_ERROR)
 
       const bar = screen.getByTestId('progress-bar-fill')
       expect(bar.className).toContain('bg-error')

--- a/src/features/agent-status/components/ContextBucket.test.tsx
+++ b/src/features/agent-status/components/ContextBucket.test.tsx
@@ -1,8 +1,8 @@
-import { describe, test, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { ContextBucket, formatTokens, formatContextSize } from './ContextBucket'
 import type { ContextBucketProps } from './ContextBucket'
-import { BAR_DIMS, computeBaseFloor } from './LiquidFill'
+import { computeBaseFloor } from './LiquidFill'
 import {
   LIQUID_COLOR_PRIMARY_CONTAINER,
   LIQUID_COLOR_TERTIARY,
@@ -62,6 +62,47 @@ describe('ContextBucket', () => {
   })
 
   describe('fill height at various percentages', () => {
+    type ROCallback = (entries: { contentRect: DOMRectReadOnly }[]) => void
+    class MockResizeObserver {
+      static instances: MockResizeObserver[] = []
+      cb: ROCallback
+      constructor(cb: ROCallback) {
+        this.cb = cb
+        MockResizeObserver.instances.push(this)
+      }
+      observe = vi.fn()
+      unobserve = vi.fn()
+      disconnect = vi.fn()
+      trigger(rect: { width: number; height: number }): void {
+        this.cb([
+          {
+            contentRect: {
+              ...rect,
+              top: 0,
+              left: 0,
+              right: rect.width,
+              bottom: rect.height,
+              x: 0,
+              y: 0,
+              toJSON: () => ({}),
+            } as DOMRectReadOnly,
+          },
+        ])
+      }
+    }
+
+    const REAL_FILL_W = 300
+    const REAL_FILL_H = 72
+
+    beforeEach(() => {
+      MockResizeObserver.instances = []
+
+      const g = globalThis as unknown as {
+        ResizeObserver: typeof ResizeObserver
+      }
+      g.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+    })
+
     const getWrapperTy = (container: HTMLElement): number => {
       // eslint-disable-next-line testing-library/no-node-access -- SVG transform style is not reachable via a11y queries
       const wrapperEl = container.querySelector(
@@ -78,8 +119,13 @@ describe('ContextBucket', () => {
       const { container } = render(
         <ContextBucket {...defaultProps} usedPercentage={50} />
       )
-
-      const expectedY = computeBaseFloor(BAR_DIMS.w, BAR_DIMS.h, 50)
+      act(() => {
+        MockResizeObserver.instances[0]?.trigger({
+          width: REAL_FILL_W,
+          height: REAL_FILL_H,
+        })
+      })
+      const expectedY = computeBaseFloor(REAL_FILL_W, REAL_FILL_H, 50)
       expect(getWrapperTy(container)).toBeCloseTo(expectedY, 1)
     })
 
@@ -87,8 +133,13 @@ describe('ContextBucket', () => {
       const { container } = render(
         <ContextBucket {...defaultProps} usedPercentage={74} />
       )
-
-      const expectedY = computeBaseFloor(BAR_DIMS.w, BAR_DIMS.h, 74)
+      act(() => {
+        MockResizeObserver.instances[0]?.trigger({
+          width: REAL_FILL_W,
+          height: REAL_FILL_H,
+        })
+      })
+      const expectedY = computeBaseFloor(REAL_FILL_W, REAL_FILL_H, 74)
       expect(getWrapperTy(container)).toBeCloseTo(expectedY, 1)
     })
 
@@ -96,8 +147,13 @@ describe('ContextBucket', () => {
       const { container } = render(
         <ContextBucket {...defaultProps} usedPercentage={90} />
       )
-
-      const expectedY = computeBaseFloor(BAR_DIMS.w, BAR_DIMS.h, 90)
+      act(() => {
+        MockResizeObserver.instances[0]?.trigger({
+          width: REAL_FILL_W,
+          height: REAL_FILL_H,
+        })
+      })
+      const expectedY = computeBaseFloor(REAL_FILL_W, REAL_FILL_H, 90)
       expect(getWrapperTy(container)).toBeCloseTo(expectedY, 1)
     })
   })

--- a/src/features/agent-status/components/ContextBucket.test.tsx
+++ b/src/features/agent-status/components/ContextBucket.test.tsx
@@ -1,5 +1,9 @@
 import { act, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test } from 'vitest'
+import {
+  MockResizeObserver,
+  installMockResizeObserver,
+} from '../../../test/mockResizeObserver'
 import { ContextBucket, formatTokens, formatContextSize } from './ContextBucket'
 import type { ContextBucketProps } from './ContextBucket'
 import { computeBaseFloor } from './LiquidFill'
@@ -62,45 +66,11 @@ describe('ContextBucket', () => {
   })
 
   describe('fill height at various percentages', () => {
-    type ROCallback = (entries: { contentRect: DOMRectReadOnly }[]) => void
-    class MockResizeObserver {
-      static instances: MockResizeObserver[] = []
-      cb: ROCallback
-      constructor(cb: ROCallback) {
-        this.cb = cb
-        MockResizeObserver.instances.push(this)
-      }
-      observe = vi.fn()
-      unobserve = vi.fn()
-      disconnect = vi.fn()
-      trigger(rect: { width: number; height: number }): void {
-        this.cb([
-          {
-            contentRect: {
-              ...rect,
-              top: 0,
-              left: 0,
-              right: rect.width,
-              bottom: rect.height,
-              x: 0,
-              y: 0,
-              toJSON: () => ({}),
-            } as DOMRectReadOnly,
-          },
-        ])
-      }
-    }
-
     const REAL_FILL_W = 300
     const REAL_FILL_H = 72
 
     beforeEach(() => {
-      MockResizeObserver.instances = []
-
-      const g = globalThis as unknown as {
-        ResizeObserver: typeof ResizeObserver
-      }
-      g.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+      installMockResizeObserver()
     })
 
     const getWrapperTy = (container: HTMLElement): number => {

--- a/src/features/agent-status/components/ContextBucket.tsx
+++ b/src/features/agent-status/components/ContextBucket.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react'
+import { LiquidFill } from './LiquidFill'
 
 export interface ContextBucketProps {
   usedPercentage: number | null
@@ -67,6 +68,18 @@ const getColorClass = (
   }
 }
 
+const hexForColorClass = (pct: number | null): string => {
+  if (pct !== null && pct >= 90) {
+    return '#ffb4ab' // tailwind.config.js:25 — error
+  }
+
+  if (pct !== null && pct >= 80) {
+    return '#ff94a5' // tailwind.config.js:21 — tertiary
+  }
+
+  return '#cba6f7' // tailwind.config.js:10 — primary-container
+}
+
 export const ContextBucket = ({
   usedPercentage,
   contextWindowSize,
@@ -115,17 +128,12 @@ export const ContextBucket = ({
             }}
           />
           {/* Fill */}
-          <div
-            className={`relative w-full bg-gradient-to-t ${colors.fill}`}
-            data-testid="bucket-fill"
-            style={{
-              height: `${effectivePct}%`,
-              transition: 'height 500ms ease',
-              boxShadow:
-                pct !== null && effectivePct > 0
-                  ? '0 -4px 12px var(--tw-shadow-color, rgba(203, 166, 247, 0.25))'
-                  : 'none',
-            }}
+          <LiquidFill
+            mode="fill"
+            pct={effectivePct}
+            color={hexForColorClass(pct)}
+            className="h-full w-full"
+            testId="bucket-fill"
           />
         </div>
 

--- a/src/features/agent-status/components/ContextBucket.tsx
+++ b/src/features/agent-status/components/ContextBucket.tsx
@@ -136,6 +136,7 @@ export const ContextBucket = ({
             mode="fill"
             pct={effectivePct}
             color={hexForColorClass(pct)}
+            glow
             className="h-full w-full"
             testId="bucket-fill"
           />

--- a/src/features/agent-status/components/ContextBucket.tsx
+++ b/src/features/agent-status/components/ContextBucket.tsx
@@ -1,5 +1,10 @@
 import type { ReactElement } from 'react'
 import { LiquidFill } from './LiquidFill'
+import {
+  LIQUID_COLOR_ERROR,
+  LIQUID_COLOR_PRIMARY_CONTAINER,
+  LIQUID_COLOR_TERTIARY,
+} from './liquidColors'
 
 export interface ContextBucketProps {
   usedPercentage: number | null
@@ -70,14 +75,13 @@ const getColorClass = (
 
 const hexForColorClass = (pct: number | null): string => {
   if (pct !== null && pct >= 90) {
-    return '#ffb4ab' // tailwind.config.js:25 — error
+    return LIQUID_COLOR_ERROR
   }
-
   if (pct !== null && pct >= 80) {
-    return '#ff94a5' // tailwind.config.js:21 — tertiary
+    return LIQUID_COLOR_TERTIARY
   }
 
-  return '#cba6f7' // tailwind.config.js:10 — primary-container
+  return LIQUID_COLOR_PRIMARY_CONTAINER
 }
 
 export const ContextBucket = ({

--- a/src/features/agent-status/components/ContextBucket.tsx
+++ b/src/features/agent-status/components/ContextBucket.tsx
@@ -48,40 +48,55 @@ const getEmoji = (pct: number | null): string => {
   return '\u{1F975}'
 }
 
+type ColorTier = 'primary' | 'tertiary' | 'error'
+
+const getColorTier = (pct: number | null): ColorTier => {
+  if (pct !== null && pct >= 90) {
+    return 'error'
+  }
+  if (pct !== null && pct >= 80) {
+    return 'tertiary'
+  }
+
+  return 'primary'
+}
+
 const getColorClass = (
   pct: number | null
 ): { fill: string; bar: string; text: string } => {
-  if (pct !== null && pct >= 90) {
-    return {
-      fill: 'from-error/50 to-error',
-      bar: 'bg-error',
-      text: 'text-error',
-    }
-  }
-  if (pct !== null && pct >= 80) {
-    return {
-      fill: 'from-tertiary/50 to-tertiary',
-      bar: 'bg-tertiary',
-      text: 'text-tertiary',
-    }
-  }
-
-  return {
-    fill: 'from-primary-container/50 to-primary-container',
-    bar: 'bg-primary-container',
-    text: 'text-primary-container',
+  switch (getColorTier(pct)) {
+    case 'error':
+      return {
+        fill: 'from-error/50 to-error',
+        bar: 'bg-error',
+        text: 'text-error',
+      }
+    case 'tertiary':
+      return {
+        fill: 'from-tertiary/50 to-tertiary',
+        bar: 'bg-tertiary',
+        text: 'text-tertiary',
+      }
+    case 'primary':
+    default:
+      return {
+        fill: 'from-primary-container/50 to-primary-container',
+        bar: 'bg-primary-container',
+        text: 'text-primary-container',
+      }
   }
 }
 
 const hexForColorClass = (pct: number | null): string => {
-  if (pct !== null && pct >= 90) {
-    return LIQUID_COLOR_ERROR
+  switch (getColorTier(pct)) {
+    case 'error':
+      return LIQUID_COLOR_ERROR
+    case 'tertiary':
+      return LIQUID_COLOR_TERTIARY
+    case 'primary':
+    default:
+      return LIQUID_COLOR_PRIMARY_CONTAINER
   }
-  if (pct !== null && pct >= 80) {
-    return LIQUID_COLOR_TERTIARY
-  }
-
-  return LIQUID_COLOR_PRIMARY_CONTAINER
 }
 
 export const ContextBucket = ({

--- a/src/features/agent-status/components/ContextBucket.tsx
+++ b/src/features/agent-status/components/ContextBucket.tsx
@@ -61,29 +61,15 @@ const getColorTier = (pct: number | null): ColorTier => {
   return 'primary'
 }
 
-const getColorClass = (
-  pct: number | null
-): { fill: string; bar: string; text: string } => {
+const getColorClass = (pct: number | null): { bar: string; text: string } => {
   switch (getColorTier(pct)) {
     case 'error':
-      return {
-        fill: 'from-error/50 to-error',
-        bar: 'bg-error',
-        text: 'text-error',
-      }
+      return { bar: 'bg-error', text: 'text-error' }
     case 'tertiary':
-      return {
-        fill: 'from-tertiary/50 to-tertiary',
-        bar: 'bg-tertiary',
-        text: 'text-tertiary',
-      }
+      return { bar: 'bg-tertiary', text: 'text-tertiary' }
     case 'primary':
     default:
-      return {
-        fill: 'from-primary-container/50 to-primary-container',
-        bar: 'bg-primary-container',
-        text: 'text-primary-container',
-      }
+      return { bar: 'bg-primary-container', text: 'text-primary-container' }
   }
 }
 

--- a/src/features/agent-status/components/ContextBucket.tsx
+++ b/src/features/agent-status/components/ContextBucket.tsx
@@ -61,27 +61,29 @@ const getColorTier = (pct: number | null): ColorTier => {
   return 'primary'
 }
 
-const getColorClass = (pct: number | null): { bar: string; text: string } => {
+const getTierColors = (
+  pct: number | null
+): { bar: string; text: string; hex: string } => {
   switch (getColorTier(pct)) {
     case 'error':
-      return { bar: 'bg-error', text: 'text-error' }
+      return {
+        bar: 'bg-error',
+        text: 'text-error',
+        hex: LIQUID_COLOR_ERROR,
+      }
     case 'tertiary':
-      return { bar: 'bg-tertiary', text: 'text-tertiary' }
+      return {
+        bar: 'bg-tertiary',
+        text: 'text-tertiary',
+        hex: LIQUID_COLOR_TERTIARY,
+      }
     case 'primary':
     default:
-      return { bar: 'bg-primary-container', text: 'text-primary-container' }
-  }
-}
-
-const hexForColorClass = (pct: number | null): string => {
-  switch (getColorTier(pct)) {
-    case 'error':
-      return LIQUID_COLOR_ERROR
-    case 'tertiary':
-      return LIQUID_COLOR_TERTIARY
-    case 'primary':
-    default:
-      return LIQUID_COLOR_PRIMARY_CONTAINER
+      return {
+        bar: 'bg-primary-container',
+        text: 'text-primary-container',
+        hex: LIQUID_COLOR_PRIMARY_CONTAINER,
+      }
   }
 }
 
@@ -93,7 +95,7 @@ export const ContextBucket = ({
 }: ContextBucketProps): ReactElement => {
   const pct = usedPercentage
   const effectivePct = pct ?? 0
-  const colors = getColorClass(pct)
+  const tierColors = getTierColors(pct)
   const emoji = getEmoji(pct)
   const totalTokens = totalInputTokens + totalOutputTokens
 
@@ -108,7 +110,7 @@ export const ContextBucket = ({
           CURRENT CONTEXT
         </span>
         <span
-          className={`font-mono text-xs font-semibold ${pct !== null ? colors.text : 'text-outline'}`}
+          className={`font-mono text-xs font-semibold ${pct !== null ? tierColors.text : 'text-outline'}`}
           data-testid="context-percentage"
         >
           {pct !== null ? `${Math.round(pct)}%` : '\u2014'}
@@ -136,7 +138,7 @@ export const ContextBucket = ({
           <LiquidFill
             mode="fill"
             pct={effectivePct}
-            color={hexForColorClass(pct)}
+            color={tierColors.hex}
             glow
             className="h-full w-full"
             testId="bucket-fill"
@@ -146,7 +148,7 @@ export const ContextBucket = ({
         {/* Scale */}
         <div className="flex flex-col justify-between py-0.5 font-mono text-[8px] text-outline">
           <span>{formatContextSize(contextWindowSize)}</span>
-          <span className={pct !== null ? colors.text : 'text-outline'}>
+          <span className={pct !== null ? tierColors.text : 'text-outline'}>
             {pct !== null ? `${formatTokens(totalTokens)}` : '\u2014'}
           </span>
           <span>0k</span>
@@ -156,7 +158,7 @@ export const ContextBucket = ({
       {/* Progress bar */}
       <div className="mb-2 h-[5px] overflow-hidden rounded-full bg-surface">
         <div
-          className={`h-full rounded-full ${colors.bar}`}
+          className={`h-full rounded-full ${tierColors.bar}`}
           data-testid="progress-bar-fill"
           style={{
             width: `${effectivePct}%`,

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -1,5 +1,9 @@
 import { act, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test } from 'vitest'
+import {
+  MockResizeObserver,
+  installMockResizeObserver,
+} from '../../../test/mockResizeObserver'
 import { LiquidFill } from './LiquidFill'
 
 // jsdom does not provide PointerEvent — see useWaterCursor.test.tsx
@@ -190,35 +194,6 @@ describe('LiquidFill — cursor hook integration', () => {
   })
 })
 
-type ROCallback = (entries: { contentRect: DOMRectReadOnly }[]) => void
-class MockResizeObserver {
-  static instances: MockResizeObserver[] = []
-  cb: ROCallback
-  constructor(cb: ROCallback) {
-    this.cb = cb
-    MockResizeObserver.instances.push(this)
-  }
-  observe = vi.fn()
-  unobserve = vi.fn()
-  disconnect = vi.fn()
-  trigger(rect: { width: number; height: number }): void {
-    this.cb([
-      {
-        contentRect: {
-          ...rect,
-          top: 0,
-          left: 0,
-          right: rect.width,
-          bottom: rect.height,
-          x: 0,
-          y: 0,
-          toJSON: () => ({}),
-        } as DOMRectReadOnly,
-      },
-    ])
-  }
-}
-
 describe('LiquidFill — sheen cy stability', () => {
   test('cy attribute is not re-committed by React when pct changes', () => {
     const { container, rerender } = render(
@@ -278,10 +253,7 @@ describe('LiquidFill — baseFloor clamp at near-full pct (Round-3 F3)', () => {
 
 describe('LiquidFill — fill mode', () => {
   beforeEach(() => {
-    MockResizeObserver.instances = []
-    const g = globalThis as unknown as { ResizeObserver: typeof ResizeObserver }
-
-    g.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+    installMockResizeObserver()
   })
 
   test('renders SVG with measured width/height attributes after ResizeObserver fires', () => {

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -206,6 +206,33 @@ class MockResizeObserver {
   }
 }
 
+describe('LiquidFill — sheen cy stability', () => {
+  test('cy attribute is not re-committed by React when pct changes', () => {
+    const { container, rerender } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+    const sheen = container.querySelector('[data-testid="liquid-sheen"]')
+    expect(sheen).not.toBeNull()
+    const initialCy = sheen?.getAttribute('cy')
+
+    // Simulate the hook taking over: write a different cy via setAttribute.
+    sheen?.setAttribute('cy', '99.99')
+
+    // Re-render with a different pct (water rose).
+    rerender(<LiquidFill mode="bar" pct={80} color="#cba6f7" testId="lf" />)
+
+    // The cy we wrote via setAttribute must NOT be overwritten by React's
+    // commit. If React re-committed cy=geom.top, this would be a snapped
+    // value matching the new pct's top — not 99.99.
+    const cyAfterRerender = sheen?.getAttribute('cy')
+    expect(cyAfterRerender).toBe('99.99')
+    // The initial cy at mount must reflect the initial pct geometry.
+    expect(initialCy).not.toBeNull()
+    expect(parseFloat(initialCy ?? '0')).toBeGreaterThan(0)
+  })
+})
+
 describe('LiquidFill — fill mode', () => {
   beforeEach(() => {
     MockResizeObserver.instances = []

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -100,6 +100,23 @@ describe('LiquidFill — bar mode geometry', () => {
     expect(ad).toMatch(/L \d/)
     expect(bd).toMatch(/L \d/)
   })
+
+  test('wave path segment density scales with width so wide containers stay smooth', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG path attributes are not reachable via a11y queries
+    const aPath = container.querySelector(
+      '[data-testid="liquid-water-y-a"] path'
+    )
+    const d = aPath?.getAttribute('d') ?? ''
+    // Count the L commands in the polyline — should be at least 48 plus
+    // the closing path (2 more L). At width = 22 * 2 = 44, max(48, 30) = 48.
+    const lineCount = (d.match(/ L /g) ?? []).length
+
+    expect(lineCount).toBeGreaterThanOrEqual(48)
+  })
 })
 
 describe('LiquidFill — cursor hook integration', () => {

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -117,6 +117,36 @@ describe('LiquidFill — bar mode geometry', () => {
 
     expect(lineCount).toBeGreaterThanOrEqual(48)
   })
+
+  test('wave path is spatially periodic at width/2 so the CSS keyframe loops seamlessly', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG path attributes are not reachable via a11y queries
+    const a = container.querySelector('[data-testid="liquid-water-y-a"] path')
+    const d = a?.getAttribute('d') ?? ''
+
+    // Extract numeric L commands as [x, y] pairs.
+    const points = Array.from(d.matchAll(/L (-?\d+\.\d+),(-?\d+\.\d+)/g)).map(
+      (m) => [parseFloat(m[1]), parseFloat(m[2])] as [number, number]
+    )
+    // Path width = 22 * 2 = 44. Half-period offset = width/4 = 11.
+    // Sample a few points at +width/2 separation and compare y values.
+    // y(x) should equal y(x + width/2) within rounding tolerance because
+    // the wave has period = width/4 = 11 units, so width/2 = 22 = 2 full
+    // periods of separation.
+    const width = 44
+    const halfPath = width / 2
+    const tol = 0.01
+    const samples = points.filter(([x]) => x > 0 && x < halfPath - 2)
+    expect(samples.length).toBeGreaterThan(0)
+    for (const [x, y] of samples) {
+      const partner = points.find(([px]) => Math.abs(px - (x + halfPath)) < 0.5)
+      if (partner !== undefined) {
+        expect(Math.abs(partner[1] - y)).toBeLessThan(tol)
+      }
+    }
+  })
 })
 
 describe('LiquidFill — cursor hook integration', () => {

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -66,4 +66,26 @@ describe('LiquidFill — bar mode geometry', () => {
     expect(wrap).toBeInTheDocument()
     expect(wrap.className).toContain('some-class')
   })
+
+  test('wave-A and wave-B paths are actually phase-offset (different d strings)', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG path attributes are not reachable via a11y queries
+    const a = container.querySelector('[data-testid="liquid-water-y-a"] path')
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG path attributes are not reachable via a11y queries
+    const b = container.querySelector('[data-testid="liquid-water-y-b"] path')
+    expect(a).not.toBeNull()
+    expect(b).not.toBeNull()
+    // Different phase => different path data. Strip leading "M 0,..." since
+    // both share x=0; compare the bulk of the path.
+    const ad = (a?.getAttribute('d') ?? '').slice(20)
+    const bd = (b?.getAttribute('d') ?? '').slice(20)
+    expect(ad).not.toBe(bd)
+    // Both paths must reach the bottom and close — defensive sanity.
+    expect(ad).toMatch(/L \d/)
+    expect(bd).toMatch(/L \d/)
+  })
 })

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -27,14 +27,25 @@ describe('LiquidFill — bar mode geometry', () => {
     expect(svg?.getAttribute('aria-hidden')).toBe('true')
   })
 
-  test('base rect y equals top + ambientAmp + 0.5', () => {
-    render(<LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />)
+  test('liquid-water-y-base wrapper translateY equals top + ambientAmp + 0.5', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
 
     // pct=50 → liquidH=(110-4)*0.5=53 → top=57. ambientAmp = min(1.8, 22*0.09) = 1.8.
-    // base.y expected = 57 + 1.8 + 0.5 = 59.3
-    const baseRect = screen.getByTestId('liquid-base')
+    // baseFloor expected = 57 + 1.8 + 0.5 = 59.3
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+    const wrapperEl = container.querySelector('[data-testid="liquid-water-y-base"]')
+    expect(wrapperEl).not.toBeNull()
+    const wrapper = wrapperEl as HTMLElement
+    expect(wrapper.style.transition).toBe('transform 500ms ease')
+    const match = /translateY\((.+?)px\)/.exec(wrapper.style.transform)
+    const ty = parseFloat(match?.[1] ?? '0')
+    expect(ty).toBeCloseTo(59.3, 1)
 
-    expect(parseFloat(baseRect.getAttribute('y') ?? '0')).toBeCloseTo(59.3, 1)
+    // base rect itself must have y=0 (positioning is on the wrapper)
+    const baseRect = screen.getByTestId('liquid-base')
+    expect(baseRect.getAttribute('y')).toBe('0')
   })
 
   test('renders tick marks at 25/50/75', () => {
@@ -235,16 +246,23 @@ describe('LiquidFill — sheen cy stability', () => {
 
 // Round-3 Finding 3: baseFloor is clamped to h at near-zero pct values.
 describe('LiquidFill — baseFloor clamp at near-full pct (Round-3 F3)', () => {
-  test('liquid-base y attribute does not exceed h=110 at pct=1', () => {
-    render(<LiquidFill mode="bar" pct={1} color="#cba6f7" testId="lf-f3" />)
+  test('liquid-water-y-base wrapper translateY does not exceed h=110 at pct=1', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={1} color="#cba6f7" testId="lf-f3" />
+    )
+
     // At pct=1 (w=22, h=110):
     // liquidH = (110-4)*(1/100) = 1.06; top = 108.94
     // ambientAmp = min(1.8, 22*0.09) = 1.8
     // baseFloor (unclamped) = 108.94 + 1.8 + 0.5 = 111.24 — exceeds h=110
     // After clamp: baseFloor = min(111.24, 110) = 110
-    const baseRect = screen.getByTestId('liquid-base')
-    const y = parseFloat(baseRect.getAttribute('y') ?? '999')
-    expect(y).toBeLessThanOrEqual(110)
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+    const wrapperEl = container.querySelector('[data-testid="liquid-water-y-base"]')
+    expect(wrapperEl).not.toBeNull()
+    const wrapper = wrapperEl as HTMLElement
+    const match = /translateY\((.+?)px\)/.exec(wrapper.style.transform)
+    const ty = parseFloat(match?.[1] ?? '0')
+    expect(ty).toBeLessThanOrEqual(110)
   })
 })
 
@@ -297,5 +315,47 @@ describe('LiquidFill — fill mode', () => {
     )
     expect(screen.getByTestId('lf-fill').className).toContain('h-full')
     expect(screen.getByTestId('lf-fill').className).toContain('w-full')
+  })
+
+  // Round-4 F3: hide SVG before first ResizeObserver callback
+  test('SVG is visibility:hidden before ResizeObserver fires and clears after', () => {
+    const { container } = render(
+      <LiquidFill
+        mode="fill"
+        pct={50}
+        color="#cba6f7"
+        testId="lf-fill-vis"
+        className="h-full w-full"
+      />
+    )
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+    const svg = container.querySelector('svg') as SVGElement
+    expect(svg.style.visibility).toBe('hidden')
+
+    act(() => {
+      MockResizeObserver.instances[0]?.trigger({ width: 200, height: 72 })
+    })
+    expect(svg.style.visibility).toBe('')
+  })
+})
+
+// Round-4 F2: glow prop applies drop-shadow filter to SVG
+describe('LiquidFill — glow prop', () => {
+  test('SVG has drop-shadow filter when glow=true', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" glow testId="lf-glow" />
+    )
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+    const svg = container.querySelector('svg') as SVGElement
+    expect(svg.style.filter).toMatch(/drop-shadow\(.*#cba6f7/)
+  })
+
+  test('SVG has no filter when glow is omitted', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf-no-glow" />
+    )
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+    const svg = container.querySelector('svg') as SVGElement
+    expect(svg.style.filter).toBe('')
   })
 })

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -1,6 +1,18 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 import { LiquidFill } from './LiquidFill'
+
+// jsdom does not provide PointerEvent — see useWaterCursor.test.tsx
+// for the same shim.
+const firePointer = (
+  el: Element,
+  type: 'pointermove' | 'pointerleave',
+  init: Partial<MouseEventInit> = {}
+): void => {
+  el.dispatchEvent(
+    new MouseEvent(type, { bubbles: true, cancelable: true, ...init })
+  )
+}
 
 describe('LiquidFill — bar mode geometry', () => {
   test('renders SVG with viewBox "0 0 22 110"', () => {
@@ -87,5 +99,32 @@ describe('LiquidFill — bar mode geometry', () => {
     // Both paths must reach the bottom and close — defensive sanity.
     expect(ad).toMatch(/L \d/)
     expect(bd).toMatch(/L \d/)
+  })
+})
+
+describe('LiquidFill — cursor hook integration', () => {
+  test('pointermove on outer wrap sets data-interactive on slosh', async () => {
+    render(<LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />)
+    const wrap = screen.getByTestId('lf')
+    Object.defineProperty(wrap, 'getBoundingClientRect', {
+      value: () => ({
+        left: 0,
+        top: 0,
+        right: 22,
+        bottom: 110,
+        width: 22,
+        height: 110,
+        x: 0,
+        y: 0,
+        toJSON: (): Record<string, never> => ({}),
+      }),
+    })
+
+    await act(async () => {
+      firePointer(wrap, 'pointermove', { clientX: 11, clientY: 55 })
+      await new Promise((resolve) => setTimeout(resolve, 32))
+    })
+    const slosh = screen.getByTestId('liquid-slosh')
+    expect(slosh.getAttribute('data-interactive')).toBe('on')
   })
 })

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from '@testing-library/react'
-import { describe, expect, test } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { LiquidFill } from './LiquidFill'
 
 // jsdom does not provide PointerEvent — see useWaterCursor.test.tsx
@@ -126,5 +126,80 @@ describe('LiquidFill — cursor hook integration', () => {
     })
     const slosh = screen.getByTestId('liquid-slosh')
     expect(slosh.getAttribute('data-interactive')).toBe('on')
+  })
+})
+
+type ROCallback = (entries: { contentRect: DOMRectReadOnly }[]) => void
+class MockResizeObserver {
+  static instances: MockResizeObserver[] = []
+  cb: ROCallback
+  constructor(cb: ROCallback) {
+    this.cb = cb
+    MockResizeObserver.instances.push(this)
+  }
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+  trigger(rect: { width: number; height: number }): void {
+    this.cb([
+      {
+        contentRect: {
+          ...rect,
+          top: 0,
+          left: 0,
+          right: rect.width,
+          bottom: rect.height,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        } as DOMRectReadOnly,
+      },
+    ])
+  }
+}
+
+describe('LiquidFill — fill mode', () => {
+  beforeEach(() => {
+    MockResizeObserver.instances = []
+    const g = globalThis as unknown as { ResizeObserver: typeof ResizeObserver }
+
+    g.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  test('renders SVG with measured width/height attributes after ResizeObserver fires', () => {
+    const { container } = render(
+      <LiquidFill
+        mode="fill"
+        pct={50}
+        color="#cba6f7"
+        testId="lf-fill"
+        className="h-full w-full"
+      />
+    )
+    act(() => {
+      MockResizeObserver.instances[0]?.trigger({ width: 200, height: 72 })
+    })
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 200 72')
+    expect(svg?.getAttribute('preserveAspectRatio')).toBe('none')
+    // Spec §5: mode="fill" sets the SVG width/height attributes from the
+    // ResizeObserver measurement (not a percentage placeholder).
+    expect(svg?.getAttribute('width')).toBe('200')
+    expect(svg?.getAttribute('height')).toBe('72')
+  })
+
+  test('outer div carries the caller className', () => {
+    render(
+      <LiquidFill
+        mode="fill"
+        pct={50}
+        color="#cba6f7"
+        testId="lf-fill"
+        className="h-full w-full"
+      />
+    )
+    expect(screen.getByTestId('lf-fill').className).toContain('h-full')
+    expect(screen.getByTestId('lf-fill').className).toContain('w-full')
   })
 })

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import { LiquidFill } from './LiquidFill'
+
+describe('LiquidFill — bar mode geometry', () => {
+  test('renders SVG with viewBox "0 0 22 110"', () => {
+    const { container } = render(
+      <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
+    )
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+    const svg = container.querySelector('svg')
+
+    expect(svg).not.toBeNull()
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 22 110')
+    expect(svg?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  test('base rect y equals top + ambientAmp + 0.5', () => {
+    render(<LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />)
+
+    // pct=50 → liquidH=(110-4)*0.5=53 → top=57. ambientAmp = min(1.8, 22*0.09) = 1.8.
+    // base.y expected = 57 + 1.8 + 0.5 = 59.3
+    const baseRect = screen.getByTestId('liquid-base')
+
+    expect(parseFloat(baseRect.getAttribute('y') ?? '0')).toBeCloseTo(59.3, 1)
+  })
+
+  test('renders tick marks at 25/50/75', () => {
+    render(<LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />)
+
+    expect(screen.getByTestId('liquid-tick-25')).toBeInTheDocument()
+    expect(screen.getByTestId('liquid-tick-50')).toBeInTheDocument()
+    expect(screen.getByTestId('liquid-tick-75')).toBeInTheDocument()
+  })
+
+  test('renders two phase-offset wave paths in nested transform groups', () => {
+    render(<LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />)
+
+    const selA = '[data-testid="liquid-wave-shift-a"] path'
+    const selB = '[data-testid="liquid-wave-shift-b"] path'
+
+    const waveYA = screen.getByTestId('liquid-water-y-a')
+    // eslint-disable-next-line testing-library/no-node-access -- verifying nested SVG structure
+    const shiftA = waveYA.querySelector(selA)
+
+    const waveYB = screen.getByTestId('liquid-water-y-b')
+    // eslint-disable-next-line testing-library/no-node-access -- verifying nested SVG structure
+    const shiftB = waveYB.querySelector(selB)
+
+    expect(shiftA).not.toBeNull()
+    expect(shiftB).not.toBeNull()
+  })
+
+  test('outer div carries the caller testId and className', () => {
+    render(
+      <LiquidFill
+        mode="bar"
+        pct={50}
+        color="#cba6f7"
+        testId="lf"
+        className="some-class"
+      />
+    )
+    const wrap = screen.getByTestId('lf')
+
+    expect(wrap).toBeInTheDocument()
+    expect(wrap.className).toContain('some-class')
+  })
+})

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -118,7 +118,7 @@ describe('LiquidFill — bar mode geometry', () => {
     expect(lineCount).toBeGreaterThanOrEqual(48)
   })
 
-  test('wave path is spatially periodic at width/2 so the CSS keyframe loops seamlessly', () => {
+  test('wave path period equals width/4 (locks cycles=4 for seamless keyframe loop)', () => {
     const { container } = render(
       <LiquidFill mode="bar" pct={50} color="#cba6f7" testId="lf" />
     )
@@ -126,26 +126,27 @@ describe('LiquidFill — bar mode geometry', () => {
     const a = container.querySelector('[data-testid="liquid-water-y-a"] path')
     const d = a?.getAttribute('d') ?? ''
 
-    // Extract numeric L commands as [x, y] pairs.
     const points = Array.from(d.matchAll(/L (-?\d+\.\d+),(-?\d+\.\d+)/g)).map(
       (m) => [parseFloat(m[1]), parseFloat(m[2])] as [number, number]
     )
-    // Path width = 22 * 2 = 44. Half-period offset = width/4 = 11.
-    // Sample a few points at +width/2 separation and compare y values.
-    // y(x) should equal y(x + width/2) within rounding tolerance because
-    // the wave has period = width/4 = 11 units, so width/2 = 22 = 2 full
-    // periods of separation.
+    // Path width = 22 * 2 = 44. With cycles=4 the spatial period is
+    // width/4 = 11. The seamless-loop invariant is y(x) ≡ y(x + period).
+    // Comparing at +width/4 = 11 fails if cycles ever regresses to 2
+    // (period 22 → 11 is half a period).
     const width = 44
-    const halfPath = width / 2
+    const period = width / 4
     const tol = 0.01
-    const samples = points.filter(([x]) => x > 0 && x < halfPath - 2)
+    const samples = points.filter(([x]) => x > 0 && x < width - period - 2)
     expect(samples.length).toBeGreaterThan(0)
+    let comparedAny = false
     for (const [x, y] of samples) {
-      const partner = points.find(([px]) => Math.abs(px - (x + halfPath)) < 0.5)
+      const partner = points.find(([px]) => Math.abs(px - (x + period)) < 0.5)
       if (partner !== undefined) {
+        comparedAny = true
         expect(Math.abs(partner[1] - y)).toBeLessThan(tol)
       }
     }
+    expect(comparedAny).toBe(true)
   })
 })
 

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -35,7 +35,9 @@ describe('LiquidFill — bar mode geometry', () => {
     // pct=50 → liquidH=(110-4)*0.5=53 → top=57. ambientAmp = min(1.8, 22*0.09) = 1.8.
     // baseFloor expected = 57 + 1.8 + 0.5 = 59.3
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
-    const wrapperEl = container.querySelector('[data-testid="liquid-water-y-base"]')
+    const wrapperEl = container.querySelector(
+      '[data-testid="liquid-water-y-base"]'
+    )
     expect(wrapperEl).not.toBeNull()
     const wrapper = wrapperEl as HTMLElement
     expect(wrapper.style.transition).toBe('transform 500ms ease')
@@ -257,7 +259,9 @@ describe('LiquidFill — baseFloor clamp at near-full pct (Round-3 F3)', () => {
     // baseFloor (unclamped) = 108.94 + 1.8 + 0.5 = 111.24 — exceeds h=110
     // After clamp: baseFloor = min(111.24, 110) = 110
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
-    const wrapperEl = container.querySelector('[data-testid="liquid-water-y-base"]')
+    const wrapperEl = container.querySelector(
+      '[data-testid="liquid-water-y-base"]'
+    )
     expect(wrapperEl).not.toBeNull()
     const wrapper = wrapperEl as HTMLElement
     const match = /translateY\((.+?)px\)/.exec(wrapper.style.transform)

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -344,6 +344,7 @@ describe('LiquidFill — fill mode', () => {
 })
 
 // Round-4 F2: glow prop applies drop-shadow filter to SVG
+// Round-6 F1: glow filter uses color-mix() so non-hex color strings are valid
 describe('LiquidFill — glow prop', () => {
   test('SVG has drop-shadow filter when glow=true', () => {
     const { container } = render(
@@ -361,5 +362,24 @@ describe('LiquidFill — glow prop', () => {
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
     const svg = container.querySelector('svg') as SVGElement
     expect(svg.style.filter).toBe('')
+  })
+
+  test('glow filter uses color-mix() not hex-alpha suffix (round-6 F1)', () => {
+    const { container } = render(
+      <LiquidFill
+        mode="bar"
+        pct={50}
+        color="#cba6f7"
+        glow
+        testId="lf-glow-mix"
+      />
+    )
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG attributes are not reachable via a11y queries
+    const svg = container.querySelector('svg') as SVGElement
+    expect(svg.style.filter).toContain(
+      'color-mix(in srgb, #cba6f7 25%, transparent)'
+    )
+    // Ensure the old hex-alpha form is NOT present
+    expect(svg.style.filter).not.toContain('#cba6f740')
   })
 })

--- a/src/features/agent-status/components/LiquidFill.test.tsx
+++ b/src/features/agent-status/components/LiquidFill.test.tsx
@@ -233,6 +233,27 @@ describe('LiquidFill — sheen cy stability', () => {
   })
 })
 
+// Round-3 Finding 3: baseFloor is clamped to h at near-zero pct values.
+describe('LiquidFill — baseFloor clamp at near-full pct (Round-3 F3)', () => {
+  test('liquid-base y attribute does not exceed h=110 at pct=1', () => {
+    render(<LiquidFill mode="bar" pct={1} color="#cba6f7" testId="lf-f3" />)
+    // At pct=1 (w=22, h=110):
+    // liquidH = (110-4)*(1/100) = 1.06; top = 108.94
+    // ambientAmp = min(1.8, 22*0.09) = 1.8
+    // baseFloor (unclamped) = 108.94 + 1.8 + 0.5 = 111.24 — exceeds h=110
+    // After clamp: baseFloor = min(111.24, 110) = 110
+    const baseRect = screen.getByTestId('liquid-base')
+    const y = parseFloat(baseRect.getAttribute('y') ?? '999')
+    expect(y).toBeLessThanOrEqual(110)
+  })
+})
+
+// Round-3 Finding 4: settled check includes velWaterTop velocity threshold.
+// The fix is a one-liner with low direct test-surface value in jsdom (rAF
+// timing is not faithful enough to reliably observe mid-flight velocity).
+// TODO: add a browser-environment (Playwright/Cypress) integration test that
+// fires rapid pct changes and asserts the sheen cy doesn't snap mid-transition.
+
 describe('LiquidFill — fill mode', () => {
   beforeEach(() => {
     MockResizeObserver.instances = []

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -32,8 +32,13 @@ const buildWavePath = (
   totalH: number,
   phase: number
 ): string => {
-  // 2 full cycles across the path's width — matches the prior segment count.
-  const cycles = 2
+  // 4 full cycles across the path width gives a spatial period of
+  // width/4 = w/2 in user units (path width = w*2). This matches the
+  // `translateX(-50%)` keyframe in src/index.css, which moves the wave
+  // by w user units = exactly two periods, producing a seamless loop.
+  // Changing cycles without changing the keyframe creates a visible
+  // seam at every iteration.
+  const cycles = 4
   // Scale segment count with width so each segment stays around 1.5 px wide.
   // Rail Bucket (width=44) → 48 segments (~0.9 px each); ContextBucket
   // (width=400 at a 200 px gauge) → ~267 segments (~1.5 px each). The cap
@@ -75,8 +80,12 @@ const computeGeom = (w: number, h: number, pct: number): Geom => {
   const top = h - liquidH
   const ambientAmp = Math.min(1.8, w * 0.09)
   const baseFloor = top + ambientAmp + 0.5
+  // waveA at phase 0, waveB at phase 0.125. With cycles=4, the second
+  // wave is shifted by 0.5 cycles (180°) relative to the first — the
+  // maximum visible contrast that still preserves the seamless-loop
+  // invariant (both paths have the same period).
   const wavePathA = buildWavePath(w * 2, ambientAmp, h, 0)
-  const wavePathB = buildWavePath(w * 2, ambientAmp, h, 0.25)
+  const wavePathB = buildWavePath(w * 2, ambientAmp, h, 0.125)
 
   return { w, h, top, ambientAmp, baseFloor, wavePathA, wavePathB }
 }

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -21,29 +21,25 @@ const buildWavePath = (
   totalH: number,
   phase: number
 ): string => {
-  const wavelength = width / 2
-  const segments = Math.ceil((width / wavelength) * 4)
+  // 2 full cycles across the path's width — matches the prior segment count.
+  const cycles = 2
+  // 32 line segments give smooth waves at our render sizes (22–~240 px wide).
+  const segments = 32
   const step = width / segments
   const phaseOffset = ((phase % 1) + 1) % 1
 
-  const startY =
-    phaseOffset < 0.5 ? amp * (phaseOffset * 2) : amp * (2 - phaseOffset * 2)
+  const yAt = (x: number): number => {
+    const t = (x / width + phaseOffset) * cycles
 
-  let d = `M 0,${startY}`
-
-  for (let i = 1; i <= segments; i++) {
-    const x = step * i
-    const cp1x = step * (i - 1) + step / 2
-    const cp2x = step * i - step / 2
-    const flipped = (i + Math.floor(phaseOffset * 2)) % 2 === 0
-    const targetY = flipped ? amp : 0
-
-    const sY = (i - 1 + Math.floor(phaseOffset * 2)) % 2 === 0 ? amp : 0
-
-    d += ` C ${cp1x},${sY} ${cp2x},${targetY} ${x},${targetY}`
+    return (amp * (1 - Math.cos(t * 2 * Math.PI))) / 2
   }
 
-  d += ` L ${width},${totalH} L 0,${totalH} Z`
+  let d = `M 0,${yAt(0).toFixed(4)}`
+  for (let i = 1; i <= segments; i++) {
+    const x = step * i
+    d += ` L ${x.toFixed(4)},${yAt(x).toFixed(4)}`
+  }
+  d += ` L ${width.toFixed(4)},${totalH} L 0,${totalH} Z`
 
   return d
 }

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -120,6 +120,11 @@ export const LiquidFill = ({
   const waveAAnimRef = useRef<SVGGElement | null>(null)
   const waveBAnimRef = useRef<SVGGElement | null>(null)
   const sheenRef = useRef<SVGEllipseElement | null>(null)
+  // Capture the initial sheen y. After mount, useWaterCursor owns the
+  // cy attribute via setAttribute — React must NOT re-commit cy on
+  // pct changes, or the sheen snaps to the new water level before
+  // the spring can chase it.
+  const initialSheenCyRef = useRef(geom.top)
 
   useEffect(() => {
     if (mode !== 'fill' || wrapRef.current === null) {
@@ -290,7 +295,7 @@ export const LiquidFill = ({
                   ref={sheenRef}
                   data-testid="liquid-sheen"
                   cx={w / 2}
-                  cy={geom.top}
+                  cy={initialSheenCyRef.current}
                   rx={Math.max(3, w * 0.27)}
                   ry="0.8"
                   fill={`url(#${sheenId})`}

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -171,6 +171,11 @@ export const LiquidFill = ({
       ambientAmp: geom.ambientAmp,
       dims: { w, h },
     }
+
+    // Wake the cursor hook's rAF loop so currentWaterTop catches up to the
+    // new waterTop — without this, a pct change after the hover spring has
+    // settled would let the sheen snap to the new water level.
+    wrapRef.current?.dispatchEvent(new Event('vfliquidwake'))
   }, [geom.top, geom.ambientAmp, w, h])
 
   useWaterCursor(wrapRef, refsRef, tune)

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useId, useMemo, useRef, type ReactElement } from 'react'
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react'
 import {
   useWaterCursor,
   type LiquidRefs,
@@ -85,7 +92,12 @@ export const LiquidFill = ({
   const sheenId = `liquid-sheen-${reactId}`
   const clipId = `liquid-clip-${reactId}`
 
-  const { w, h } = mode === 'bar' ? BAR_DIMS : BAR_DIMS
+  const [measured, setMeasured] = useState<{ w: number; h: number } | null>(
+    null
+  )
+
+  const { w, h } =
+    mode === 'bar' ? BAR_DIMS : (measured ?? { w: BAR_DIMS.w, h: BAR_DIMS.h })
   const geom = useMemo(() => computeGeom(w, h, pct), [w, h, pct])
 
   const wrapRef = useRef<HTMLDivElement | null>(null)
@@ -95,6 +107,30 @@ export const LiquidFill = ({
   const waveAAnimRef = useRef<SVGGElement | null>(null)
   const waveBAnimRef = useRef<SVGGElement | null>(null)
   const sheenRef = useRef<SVGEllipseElement | null>(null)
+
+  useEffect(() => {
+    if (mode !== 'fill' || wrapRef.current === null) {
+      return
+    }
+
+    const el = wrapRef.current
+
+    const ro = new ResizeObserver((entries) => {
+      if (entries.length === 0) {
+        return
+      }
+
+      const { width, height } = entries[0].contentRect
+
+      setMeasured({ w: Math.max(1, width), h: Math.max(1, height) })
+    })
+
+    ro.observe(el)
+
+    return (): void => {
+      ro.disconnect()
+    }
+  }, [mode])
 
   const refsRef = useRef<LiquidRefs | null>(null)
   useEffect(() => {
@@ -134,8 +170,8 @@ export const LiquidFill = ({
       style={{ display: mode === 'bar' ? 'inline-block' : undefined }}
     >
       <svg
-        width={mode === 'bar' ? w : '100%'}
-        height={mode === 'bar' ? h : '100%'}
+        width={mode === 'bar' ? w : (measured?.w ?? '100%')}
+        height={mode === 'bar' ? h : (measured?.h ?? '100%')}
         viewBox={`0 0 ${w} ${h}`}
         preserveAspectRatio={mode === 'bar' ? 'xMidYMid meet' : 'none'}
         aria-hidden={ariaHidden ? 'true' : undefined}

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -1,0 +1,240 @@
+import { useId, useMemo, type ReactElement } from 'react'
+import { type LiquidTune } from '../hooks/useWaterCursor'
+
+export interface LiquidFillProps {
+  pct: number
+  color: string
+  mode: 'bar' | 'fill'
+  ariaHidden?: boolean
+  className?: string
+  testId?: string
+  tune?: Partial<LiquidTune>
+}
+
+const BAR_DIMS = { w: 22, h: 110 } as const
+
+const TICK_LEVELS = [25, 50, 75] as const
+
+const buildWavePath = (
+  width: number,
+  amp: number,
+  totalH: number,
+  phase: number
+): string => {
+  const wavelength = width / 2
+  const segments = Math.ceil((width / wavelength) * 4)
+  const step = width / segments
+  const phaseOffset = ((phase % 1) + 1) % 1
+
+  const startY =
+    phaseOffset < 0.5 ? amp * (phaseOffset * 2) : amp * (2 - phaseOffset * 2)
+
+  let d = `M 0,${startY}`
+
+  for (let i = 1; i <= segments; i++) {
+    const x = step * i
+    const cp1x = step * (i - 1) + step / 2
+    const cp2x = step * i - step / 2
+    const flipped = (i + Math.floor(phaseOffset * 2)) % 2 === 0
+    const targetY = flipped ? amp : 0
+
+    const sY = (i - 1 + Math.floor(phaseOffset * 2)) % 2 === 0 ? amp : 0
+
+    d += ` C ${cp1x},${sY} ${cp2x},${targetY} ${x},${targetY}`
+  }
+
+  d += ` L ${width},${totalH} L 0,${totalH} Z`
+
+  return d
+}
+
+interface Geom {
+  w: number
+  h: number
+  top: number
+  ambientAmp: number
+  baseFloor: number
+  wavePathA: string
+  wavePathB: string
+}
+
+const computeGeom = (w: number, h: number, pct: number): Geom => {
+  const clamped = Math.max(0, Math.min(100, pct))
+  const liquidH = (h - 4) * (clamped / 100)
+  const top = h - liquidH
+  const ambientAmp = Math.min(1.8, w * 0.09)
+  const baseFloor = top + ambientAmp + 0.5
+  const wavePathA = buildWavePath(w * 2, ambientAmp, h, 0)
+  const wavePathB = buildWavePath(w * 2, ambientAmp, h, 0.25)
+
+  return { w, h, top, ambientAmp, baseFloor, wavePathA, wavePathB }
+}
+
+export const LiquidFill = ({
+  pct,
+  color,
+  mode,
+  ariaHidden = true,
+  className = undefined,
+  testId = undefined,
+  tune: _tune = undefined,
+}: LiquidFillProps): ReactElement => {
+  void _tune // hook wiring comes in Task 6
+
+  const reactId = useId().replace(/:/g, '')
+  const fillId = `liquid-fill-${reactId}`
+  const glassId = `liquid-glass-${reactId}`
+  const sheenId = `liquid-sheen-${reactId}`
+  const clipId = `liquid-clip-${reactId}`
+
+  const { w, h } = mode === 'bar' ? BAR_DIMS : BAR_DIMS // fill measured in Task 7
+  const geom = useMemo(() => computeGeom(w, h, pct), [w, h, pct])
+
+  return (
+    <div
+      data-testid={testId}
+      className={className}
+      style={{ display: mode === 'bar' ? 'inline-block' : undefined }}
+    >
+      <svg
+        width={mode === 'bar' ? w : '100%'}
+        height={mode === 'bar' ? h : '100%'}
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio={mode === 'bar' ? 'xMidYMid meet' : 'none'}
+        aria-hidden={ariaHidden ? 'true' : undefined}
+        style={{ overflow: 'visible', display: 'block' }}
+      >
+        <defs>
+          <linearGradient id={fillId} x1="0" y1="1" x2="0" y2="0">
+            <stop offset="0%" stopColor={color} stopOpacity="0.92" />
+            <stop offset="100%" stopColor={color} stopOpacity="0.55" />
+          </linearGradient>
+          <linearGradient id={glassId} x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.06)" />
+            <stop offset="40%" stopColor="rgba(255,255,255,0.02)" />
+            <stop offset="100%" stopColor="rgba(0,0,0,0.15)" />
+          </linearGradient>
+          <linearGradient id={sheenId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.55)" />
+            <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+          </linearGradient>
+          <clipPath id={clipId}>
+            <rect x="1" y="2" width={w - 2} height={h - 3} rx="3" ry="3" />
+          </clipPath>
+        </defs>
+
+        <rect
+          x="1"
+          y="2"
+          width={w - 2}
+          height={h - 3}
+          rx="3"
+          ry="3"
+          fill={`url(#${glassId})`}
+        />
+
+        <g clipPath={`url(#${clipId})`}>
+          <g
+            className="vf-liquid-slosh"
+            data-testid="liquid-slosh"
+            style={{ transformOrigin: `${w / 2}px ${h}px` }}
+          >
+            <rect
+              data-testid="liquid-base"
+              x={0}
+              y={geom.baseFloor}
+              width={w}
+              height={Math.max(0, h - geom.baseFloor)}
+              fill={`url(#${fillId})`}
+            />
+
+            <g
+              data-testid="liquid-water-y-a"
+              style={{
+                transform: `translateY(${geom.top - geom.ambientAmp / 2}px)`,
+                transition: 'transform 500ms ease',
+              }}
+            >
+              <g data-testid="liquid-wave-shift-a">
+                <g
+                  className="vf-liquid-wave-a"
+                  data-testid="liquid-wave-a-anim"
+                >
+                  <path d={geom.wavePathA} fill={color} fillOpacity="0.55" />
+                </g>
+              </g>
+            </g>
+
+            <g
+              data-testid="liquid-water-y-b"
+              style={{
+                transform: `translateY(${geom.top}px)`,
+                transition: 'transform 500ms ease',
+              }}
+            >
+              <g data-testid="liquid-wave-shift-b">
+                <g
+                  className="vf-liquid-wave-b"
+                  data-testid="liquid-wave-b-anim"
+                >
+                  <path
+                    d={geom.wavePathB}
+                    fill={`url(#${fillId})`}
+                    fillOpacity="0.95"
+                  />
+                </g>
+              </g>
+            </g>
+
+            <ellipse
+              data-testid="liquid-sheen"
+              cx={w / 2}
+              cy={geom.top}
+              rx={Math.max(3, w * 0.27)}
+              ry="0.8"
+              fill={`url(#${sheenId})`}
+              fillOpacity="0"
+            />
+          </g>
+
+          {TICK_LEVELS.map((t) => {
+            const y = h - (h - 4) * (t / 100)
+
+            return (
+              <g key={t} data-testid={`liquid-tick-${t}`}>
+                <line
+                  x1="1"
+                  x2="4"
+                  y1={y}
+                  y2={y}
+                  stroke="rgba(255,255,255,0.18)"
+                  strokeWidth="0.8"
+                />
+                <line
+                  x1={w - 4}
+                  x2={w - 1}
+                  y1={y}
+                  y2={y}
+                  stroke="rgba(255,255,255,0.18)"
+                  strokeWidth="0.8"
+                />
+              </g>
+            )
+          })}
+        </g>
+
+        <rect
+          x="1"
+          y="2"
+          width={w - 2}
+          height={h - 3}
+          rx="3"
+          ry="3"
+          fill="transparent"
+          stroke="rgba(255,255,255,0.18)"
+          strokeWidth="1"
+        />
+      </svg>
+    </div>
+  )
+}

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -213,65 +213,73 @@ export const LiquidFill = ({
             data-testid="liquid-slosh"
             style={{ transformOrigin: `${w / 2}px ${h}px` }}
           >
-            <rect
-              data-testid="liquid-base"
-              x={0}
-              y={geom.baseFloor}
-              width={w}
-              height={Math.max(0, h - geom.baseFloor)}
-              fill={`url(#${fillId})`}
-            />
+            {geom.top < geom.h && (
+              <>
+                <rect
+                  data-testid="liquid-base"
+                  x={0}
+                  y={geom.baseFloor}
+                  width={w}
+                  height={Math.max(0, h - geom.baseFloor)}
+                  fill={`url(#${fillId})`}
+                />
 
-            <g
-              data-testid="liquid-water-y-a"
-              style={{
-                transform: `translateY(${geom.top - geom.ambientAmp / 2}px)`,
-                transition: 'transform 500ms ease',
-              }}
-            >
-              <g ref={waveAShiftRef} data-testid="liquid-wave-shift-a">
                 <g
-                  ref={waveAAnimRef}
-                  className="vf-liquid-wave-a"
-                  data-testid="liquid-wave-a-anim"
+                  data-testid="liquid-water-y-a"
+                  style={{
+                    transform: `translateY(${geom.top - geom.ambientAmp / 2}px)`,
+                    transition: 'transform 500ms ease',
+                  }}
                 >
-                  <path d={geom.wavePathA} fill={color} fillOpacity="0.55" />
+                  <g ref={waveAShiftRef} data-testid="liquid-wave-shift-a">
+                    <g
+                      ref={waveAAnimRef}
+                      className="vf-liquid-wave-a"
+                      data-testid="liquid-wave-a-anim"
+                    >
+                      <path
+                        d={geom.wavePathA}
+                        fill={color}
+                        fillOpacity="0.55"
+                      />
+                    </g>
+                  </g>
                 </g>
-              </g>
-            </g>
 
-            <g
-              data-testid="liquid-water-y-b"
-              style={{
-                transform: `translateY(${geom.top}px)`,
-                transition: 'transform 500ms ease',
-              }}
-            >
-              <g ref={waveBShiftRef} data-testid="liquid-wave-shift-b">
                 <g
-                  ref={waveBAnimRef}
-                  className="vf-liquid-wave-b"
-                  data-testid="liquid-wave-b-anim"
+                  data-testid="liquid-water-y-b"
+                  style={{
+                    transform: `translateY(${geom.top}px)`,
+                    transition: 'transform 500ms ease',
+                  }}
                 >
-                  <path
-                    d={geom.wavePathB}
-                    fill={`url(#${fillId})`}
-                    fillOpacity="0.95"
-                  />
+                  <g ref={waveBShiftRef} data-testid="liquid-wave-shift-b">
+                    <g
+                      ref={waveBAnimRef}
+                      className="vf-liquid-wave-b"
+                      data-testid="liquid-wave-b-anim"
+                    >
+                      <path
+                        d={geom.wavePathB}
+                        fill={`url(#${fillId})`}
+                        fillOpacity="0.95"
+                      />
+                    </g>
+                  </g>
                 </g>
-              </g>
-            </g>
 
-            <ellipse
-              ref={sheenRef}
-              data-testid="liquid-sheen"
-              cx={w / 2}
-              cy={geom.top}
-              rx={Math.max(3, w * 0.27)}
-              ry="0.8"
-              fill={`url(#${sheenId})`}
-              fillOpacity="0"
-            />
+                <ellipse
+                  ref={sheenRef}
+                  data-testid="liquid-sheen"
+                  cx={w / 2}
+                  cy={geom.top}
+                  rx={Math.max(3, w * 0.27)}
+                  ry="0.8"
+                  fill={`url(#${sheenId})`}
+                  fillOpacity="0"
+                />
+              </>
+            )}
           </g>
 
           {TICK_LEVELS.map((t) => {

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -1,5 +1,9 @@
-import { useId, useMemo, type ReactElement } from 'react'
-import { type LiquidTune } from '../hooks/useWaterCursor'
+import { useEffect, useId, useMemo, useRef, type ReactElement } from 'react'
+import {
+  useWaterCursor,
+  type LiquidRefs,
+  type LiquidTune,
+} from '../hooks/useWaterCursor'
 
 export interface LiquidFillProps {
   pct: number
@@ -73,21 +77,58 @@ export const LiquidFill = ({
   ariaHidden = true,
   className = undefined,
   testId = undefined,
-  tune: _tune = undefined,
+  tune = undefined,
 }: LiquidFillProps): ReactElement => {
-  void _tune // hook wiring comes in Task 6
-
   const reactId = useId().replace(/:/g, '')
   const fillId = `liquid-fill-${reactId}`
   const glassId = `liquid-glass-${reactId}`
   const sheenId = `liquid-sheen-${reactId}`
   const clipId = `liquid-clip-${reactId}`
 
-  const { w, h } = mode === 'bar' ? BAR_DIMS : BAR_DIMS // fill measured in Task 7
+  const { w, h } = mode === 'bar' ? BAR_DIMS : BAR_DIMS
   const geom = useMemo(() => computeGeom(w, h, pct), [w, h, pct])
+
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+  const sloshRef = useRef<SVGGElement | null>(null)
+  const waveAShiftRef = useRef<SVGGElement | null>(null)
+  const waveBShiftRef = useRef<SVGGElement | null>(null)
+  const waveAAnimRef = useRef<SVGGElement | null>(null)
+  const waveBAnimRef = useRef<SVGGElement | null>(null)
+  const sheenRef = useRef<SVGEllipseElement | null>(null)
+
+  const refsRef = useRef<LiquidRefs | null>(null)
+  useEffect(() => {
+    if (
+      sloshRef.current === null ||
+      waveAShiftRef.current === null ||
+      waveBShiftRef.current === null ||
+      waveAAnimRef.current === null ||
+      waveBAnimRef.current === null ||
+      sheenRef.current === null
+    ) {
+      refsRef.current = null
+
+      return
+    }
+
+    refsRef.current = {
+      slosh: sloshRef.current,
+      waveAShift: waveAShiftRef.current,
+      waveBShift: waveBShiftRef.current,
+      waveAAnim: waveAAnimRef.current,
+      waveBAnim: waveBAnimRef.current,
+      sheen: sheenRef.current,
+      waterTop: geom.top,
+      ambientAmp: geom.ambientAmp,
+      dims: { w, h },
+    }
+  }, [geom.top, geom.ambientAmp, w, h])
+
+  useWaterCursor(wrapRef, refsRef, tune)
 
   return (
     <div
+      ref={wrapRef}
       data-testid={testId}
       className={className}
       style={{ display: mode === 'bar' ? 'inline-block' : undefined }}
@@ -131,6 +172,7 @@ export const LiquidFill = ({
 
         <g clipPath={`url(#${clipId})`}>
           <g
+            ref={sloshRef}
             className="vf-liquid-slosh"
             data-testid="liquid-slosh"
             style={{ transformOrigin: `${w / 2}px ${h}px` }}
@@ -151,8 +193,9 @@ export const LiquidFill = ({
                 transition: 'transform 500ms ease',
               }}
             >
-              <g data-testid="liquid-wave-shift-a">
+              <g ref={waveAShiftRef} data-testid="liquid-wave-shift-a">
                 <g
+                  ref={waveAAnimRef}
                   className="vf-liquid-wave-a"
                   data-testid="liquid-wave-a-anim"
                 >
@@ -168,8 +211,9 @@ export const LiquidFill = ({
                 transition: 'transform 500ms ease',
               }}
             >
-              <g data-testid="liquid-wave-shift-b">
+              <g ref={waveBShiftRef} data-testid="liquid-wave-shift-b">
                 <g
+                  ref={waveBAnimRef}
                   className="vf-liquid-wave-b"
                   data-testid="liquid-wave-b-anim"
                 >
@@ -183,6 +227,7 @@ export const LiquidFill = ({
             </g>
 
             <ellipse
+              ref={sheenRef}
               data-testid="liquid-sheen"
               cx={w / 2}
               cy={geom.top}

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -20,6 +20,7 @@ export interface LiquidFillProps {
   className?: string
   testId?: string
   tune?: Partial<LiquidTune>
+  glow?: boolean
 }
 
 const BAR_DIMS = { w: 22, h: 110 } as const
@@ -98,6 +99,7 @@ export const LiquidFill = ({
   className = undefined,
   testId = undefined,
   tune = undefined,
+  glow = false,
 }: LiquidFillProps): ReactElement => {
   const reactId = useId().replace(/:/g, '')
   const fillId = `liquid-fill-${reactId}`
@@ -198,7 +200,13 @@ export const LiquidFill = ({
         viewBox={`0 0 ${w} ${h}`}
         preserveAspectRatio={mode === 'bar' ? 'xMidYMid meet' : 'none'}
         aria-hidden={ariaHidden ? 'true' : undefined}
-        style={{ overflow: 'visible', display: 'block' }}
+        style={{
+          overflow: 'visible',
+          display: 'block',
+          visibility:
+            mode === 'fill' && measured === null ? 'hidden' : undefined,
+          ...(glow ? { filter: `drop-shadow(0 -4px 8px ${color}40)` } : {}),
+        }}
       >
         <defs>
           <linearGradient id={fillId} x1="0" y1="1" x2="0" y2="0">
@@ -238,14 +246,22 @@ export const LiquidFill = ({
           >
             {geom.top < geom.h && (
               <>
-                <rect
-                  data-testid="liquid-base"
-                  x={0}
-                  y={geom.baseFloor}
-                  width={w}
-                  height={Math.max(0, h - geom.baseFloor)}
-                  fill={`url(#${fillId})`}
-                />
+                <g
+                  data-testid="liquid-water-y-base"
+                  style={{
+                    transform: `translateY(${geom.baseFloor}px)`,
+                    transition: 'transform 500ms ease',
+                  }}
+                >
+                  <rect
+                    data-testid="liquid-base"
+                    x={0}
+                    y={0}
+                    width={w}
+                    height={Math.max(0, h - geom.baseFloor)}
+                    fill={`url(#${fillId})`}
+                  />
+                </g>
 
                 <g
                   data-testid="liquid-water-y-a"

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -79,7 +79,7 @@ const computeGeom = (w: number, h: number, pct: number): Geom => {
   const liquidH = (h - 4) * (clamped / 100)
   const top = h - liquidH
   const ambientAmp = Math.min(1.8, w * 0.09)
-  const baseFloor = top + ambientAmp + 0.5
+  const baseFloor = Math.min(top + ambientAmp + 0.5, h)
   // waveA at phase 0, waveB at phase 0.125. With cycles=4, the second
   // wave is shifted by 0.5 cycles (180°) relative to the first — the
   // maximum visible contrast that still preserves the seamless-loop

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -23,7 +23,7 @@ export interface LiquidFillProps {
   glow?: boolean
 }
 
-const BAR_DIMS = { w: 22, h: 110 } as const
+export const BAR_DIMS = { w: 22, h: 110 } as const
 
 const TICK_LEVELS = [25, 50, 75] as const
 
@@ -75,12 +75,26 @@ interface Geom {
   wavePathB: string
 }
 
+/**
+ * Returns the y coordinate (in SVG user units) of the solid-fill body's
+ * top edge for a given container size and percentage. Exported for
+ * geometry assertions in consumer tests (e.g. ContextBucket.test.tsx).
+ */
+export const computeBaseFloor = (w: number, h: number, pct: number): number => {
+  const clamped = Math.max(0, Math.min(100, pct))
+  const liquidH = (h - 4) * (clamped / 100)
+  const top = h - liquidH
+  const ambientAmp = Math.min(1.8, w * 0.09)
+
+  return Math.min(top + ambientAmp + 0.5, h)
+}
+
 const computeGeom = (w: number, h: number, pct: number): Geom => {
   const clamped = Math.max(0, Math.min(100, pct))
   const liquidH = (h - 4) * (clamped / 100)
   const top = h - liquidH
   const ambientAmp = Math.min(1.8, w * 0.09)
-  const baseFloor = Math.min(top + ambientAmp + 0.5, h)
+  const baseFloor = computeBaseFloor(w, h, pct)
   // waveA at phase 0, waveB at phase 0.125. With cycles=4, the second
   // wave is shifted by 0.5 cycles (180°) relative to the first — the
   // maximum visible contrast that still preserves the seamless-loop
@@ -205,7 +219,11 @@ export const LiquidFill = ({
           display: 'block',
           visibility:
             mode === 'fill' && measured === null ? 'hidden' : undefined,
-          ...(glow ? { filter: `drop-shadow(0 -4px 8px ${color}40)` } : {}),
+          ...(glow
+            ? {
+                filter: `drop-shadow(0 -4px 8px color-mix(in srgb, ${color} 25%, transparent))`,
+              }
+            : {}),
         }}
       >
         <defs>

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -34,8 +34,12 @@ const buildWavePath = (
 ): string => {
   // 2 full cycles across the path's width — matches the prior segment count.
   const cycles = 2
-  // 32 line segments give smooth waves at our render sizes (22–~240 px wide).
-  const segments = 32
+  // Scale segment count with width so each segment stays around 1.5 px wide.
+  // Rail Bucket (width=44) → 48 segments (~0.9 px each); ContextBucket
+  // (width=400 at a 200 px gauge) → ~267 segments (~1.5 px each). The cap
+  // at 48 keeps small buckets smooth; the linear scaling keeps wide
+  // gauges from looking polygonal.
+  const segments = Math.max(48, Math.ceil(width / 1.5))
   const step = width / segments
   const phaseOffset = ((phase % 1) + 1) % 1
 

--- a/src/features/agent-status/components/LiquidFill.tsx
+++ b/src/features/agent-status/components/LiquidFill.tsx
@@ -75,6 +75,12 @@ interface Geom {
   wavePathB: string
 }
 
+const applyBaseFloorClamp = (
+  top: number,
+  ambientAmp: number,
+  h: number
+): number => Math.min(top + ambientAmp + 0.5, h)
+
 /**
  * Returns the y coordinate (in SVG user units) of the solid-fill body's
  * top edge for a given container size and percentage. Exported for
@@ -86,7 +92,7 @@ export const computeBaseFloor = (w: number, h: number, pct: number): number => {
   const top = h - liquidH
   const ambientAmp = Math.min(1.8, w * 0.09)
 
-  return Math.min(top + ambientAmp + 0.5, h)
+  return applyBaseFloorClamp(top, ambientAmp, h)
 }
 
 const computeGeom = (w: number, h: number, pct: number): Geom => {
@@ -94,7 +100,7 @@ const computeGeom = (w: number, h: number, pct: number): Geom => {
   const liquidH = (h - 4) * (clamped / 100)
   const top = h - liquidH
   const ambientAmp = Math.min(1.8, w * 0.09)
-  const baseFloor = computeBaseFloor(w, h, pct)
+  const baseFloor = applyBaseFloorClamp(top, ambientAmp, h)
   // waveA at phase 0, waveB at phase 0.125. With cycles=4, the second
   // wave is shifted by 0.5 cycles (180°) relative to the first — the
   // maximum visible contrast that still preserves the seamless-loop

--- a/src/features/agent-status/components/liquidColors.test.ts
+++ b/src/features/agent-status/components/liquidColors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest'
+// @ts-expect-error -- tailwind.config.js has no .d.ts
+import tailwindConfig from '../../../../tailwind.config.js'
+import {
+  LIQUID_COLOR_ERROR,
+  LIQUID_COLOR_PRIMARY_CONTAINER,
+  LIQUID_COLOR_TERTIARY,
+} from './liquidColors'
+
+interface TailwindThemeColors {
+  'primary-container'?: string
+  tertiary?: string
+  error?: string
+}
+
+const cfg = tailwindConfig as unknown as {
+  theme?: { extend?: { colors?: TailwindThemeColors } }
+}
+const colors = cfg.theme?.extend?.colors ?? {}
+
+describe('liquid colors stay in sync with tailwind.config.js', () => {
+  test('LIQUID_COLOR_PRIMARY_CONTAINER matches tailwind primary-container', () => {
+    expect(LIQUID_COLOR_PRIMARY_CONTAINER).toBe(colors['primary-container'])
+  })
+
+  test('LIQUID_COLOR_TERTIARY matches tailwind tertiary', () => {
+    expect(LIQUID_COLOR_TERTIARY).toBe(colors.tertiary)
+  })
+
+  test('LIQUID_COLOR_ERROR matches tailwind error', () => {
+    expect(LIQUID_COLOR_ERROR).toBe(colors.error)
+  })
+})

--- a/src/features/agent-status/components/liquidColors.ts
+++ b/src/features/agent-status/components/liquidColors.ts
@@ -1,0 +1,10 @@
+// Single source of truth for liquid-fill colors used by SVG `fill` attributes.
+// Each constant mirrors a Tailwind token in tailwind.config.js — the
+// cross-check test in liquidColors.test.ts forces the two to stay in sync.
+// SVG fill cannot take a Tailwind class name, hence the hex duplication.
+
+export const LIQUID_COLOR_PRIMARY_CONTAINER = '#cba6f7'
+
+export const LIQUID_COLOR_TERTIARY = '#ff94a5'
+
+export const LIQUID_COLOR_ERROR = '#ffb4ab'

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -223,3 +223,54 @@ describe('useWaterCursor — spring loop', () => {
     expect(spy.mock.calls.length).toBe(callsAfterSettle)
   })
 })
+
+describe('useWaterCursor — runtime reduced-motion toggle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('change → matches:true detaches pointer listeners', () => {
+    const mql = makeMql(false)
+    mockMatchMedia(mql)
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+    render(<Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />)
+    expect(addSpy.mock.calls.map((c: string[]) => c[0])).toContain(
+      'pointermove'
+    )
+
+    const changeListener = mql.addEventListener.mock.calls.find(
+      (c: unknown[]) => c[0] === 'change'
+    )?.[1] as ((e: { matches: boolean }) => void) | undefined
+    expect(changeListener).toBeDefined()
+    changeListener?.({ matches: true })
+
+    expect(removeSpy.mock.calls.map((c: string[]) => c[0])).toContain(
+      'pointermove'
+    )
+
+    expect(removeSpy.mock.calls.map((c: string[]) => c[0])).toContain(
+      'pointerleave'
+    )
+  })
+
+  test('change → matches:false reattaches pointer listeners', () => {
+    const mql = makeMql(true)
+    mockMatchMedia(mql)
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+    render(<Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />)
+    expect(addSpy.mock.calls.map((c: string[]) => c[0])).not.toContain(
+      'pointermove'
+    )
+
+    const changeListener = mql.addEventListener.mock.calls.find(
+      (c: unknown[]) => c[0] === 'change'
+    )?.[1] as ((e: { matches: boolean }) => void) | undefined
+    changeListener?.({ matches: false })
+
+    expect(addSpy.mock.calls.map((c: string[]) => c[0])).toContain(
+      'pointermove'
+    )
+  })
+})

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -1,6 +1,4 @@
-// @ts-expect-error — act is unused here; Task 3 appends tests that call it
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { act, render } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { useEffect, useRef, type ReactElement } from 'react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { useWaterCursor, type LiquidRefs } from './useWaterCursor'
@@ -9,8 +7,6 @@ import { useWaterCursor, type LiquidRefs } from './useWaterCursor'
 // the 'pointermove' / 'pointerleave' type — the listener key is the
 // event type string, and MouseEvent carries clientX / clientY which is
 // all the hook reads. This avoids touching src/test/setup.ts.
-// @ts-expect-error — firePointer is unused here; Task 3 appends tests that call it
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const firePointer = (
   el: Element,
   type: 'pointermove' | 'pointerleave',
@@ -88,6 +84,30 @@ const makeRefs = (): LiquidRefs => ({
   dims: { w: 22, h: 110 },
 })
 
+const flushRaf = async (frames: number): Promise<void> => {
+  for (let i = 0; i < frames; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 16))
+    })
+  }
+}
+
+const stubRect = (el: Element, width: number, height: number): void => {
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    value: () => ({
+      left: 0,
+      top: 0,
+      right: width,
+      bottom: height,
+      width,
+      height,
+      x: 0,
+      y: 0,
+      toJSON: (): Record<string, unknown> => ({}),
+    }),
+  })
+}
+
 describe('useWaterCursor — skeleton + reduced-motion gate', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -131,5 +151,44 @@ describe('useWaterCursor — skeleton + reduced-motion gate', () => {
     const kinds = removeSpy.mock.calls.map((c: string[]) => c[0])
     expect(kinds).toContain('pointermove')
     expect(kinds).toContain('pointerleave')
+  })
+})
+
+describe('useWaterCursor — spring loop', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('pointermove writes data-interactive=on and non-zero rotate', async () => {
+    mockMatchMedia(makeMql(false))
+    const refs = makeRefs()
+    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
+    const wrap = screen.getByTestId('wrap')
+    stubRect(wrap, 100, 100)
+    act(() => {
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
+    })
+    await flushRaf(2)
+    expect(refs.slosh.getAttribute('data-interactive')).toBe('on')
+    expect(refs.slosh.style.transform).toMatch(/rotate\(/)
+    expect(refs.slosh.style.transform).not.toMatch(/rotate\(0(\.0+)?deg\)/)
+  })
+
+  test('pointerleave settles back and clears inline', async () => {
+    mockMatchMedia(makeMql(false))
+    const refs = makeRefs()
+    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
+    const wrap = screen.getByTestId('wrap')
+    stubRect(wrap, 100, 100)
+    act(() => {
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
+    })
+    await flushRaf(2)
+    act(() => {
+      firePointer(wrap, 'pointerleave')
+    })
+    await flushRaf(80) // > 1s — well past spring settle at omega=6.5
+    expect(refs.slosh.getAttribute('data-interactive')).toBeNull()
+    expect(refs.slosh.style.transform).toBe('')
   })
 })

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -192,6 +192,31 @@ describe('useWaterCursor — spring loop', () => {
     expect(refs.slosh.style.transform).toBe('')
   })
 
+  test('omitted tune is referentially stable across renders', () => {
+    mockMatchMedia(makeMql(false))
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+
+    const { rerender } = render(
+      <Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />
+    )
+
+    // Initial mount registered the listeners.
+    expect(addSpy.mock.calls.map((c: string[]) => c[0])).toContain(
+      'pointermove'
+    )
+
+    // Re-render with a new refs object (simulates a parent state change).
+    rerender(
+      <Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />
+    )
+
+    // Listeners should NOT have been removed and re-added.
+    expect(removeSpy.mock.calls.map((c: string[]) => c[0])).not.toContain(
+      'pointermove'
+    )
+  })
+
   test('rAF stops after spring settles on a still hover', async () => {
     mockMatchMedia(makeMql(false))
     const refs = makeRefs()

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -363,6 +363,48 @@ describe('useWaterCursor — tune prop identity stability (Finding 1)', () => {
 // jsdom does not faithfully simulate. Skipping dedicated test — the fix is
 // covered by code-review inspection and manual verification.
 
+// Finding 4: vfliquidwake restarts rAF loop when waterTop changes post-settle
+describe('useWaterCursor — vfliquidwake wake event (Finding 4)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('vfliquidwake event restarts the spring loop so currentWaterTop catches up', async () => {
+    mockMatchMedia(makeMql(false))
+    const refs = makeRefs()
+
+    refs.waterTop = 50 // initial water level
+    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
+    const wrap = screen.getByTestId('wrap')
+
+    stubRect(wrap, 100, 100)
+    // Hover (do NOT leave) and let the spring fully settle so the rAF loop
+    // stops while currentWaterTop is still non-null (settled-hover scenario).
+    // This is the real bug path: atRest=false, so clearInline is not called
+    // and currentWaterTop stays at 50, but the rAF stops.
+    act(() => {
+      firePointer(wrap, 'pointermove', { clientX: 50, clientY: 50 })
+    })
+    await flushRaf(80) // well past settle for omega=6.5, rAF stopped
+    // At this point rAF is stopped but currentWaterTop ≈ 50. Simulate a pct change.
+    refs.waterTop = 30 // new water level (e.g., pct went up)
+    // Dispatch the wake event — this should restart the rAF loop so
+    // currentWaterTop can spring from 50 toward 30.
+    act(() => {
+      wrap.dispatchEvent(new Event('vfliquidwake'))
+    })
+    // After a few frames the sheen cy should be in-transit between old (~49.7)
+    // and new (~29.7) — not yet snapped to 29.7.
+    await flushRaf(5)
+    const cyAttr = refs.sheen.getAttribute('cy')
+    const cy = parseFloat(cyAttr ?? '0')
+
+    // Expected: cy is between the old (49.7) and new (29.7) waterTop, exclusive of both.
+    expect(cy).toBeGreaterThan(29.7)
+    expect(cy).toBeLessThan(49.7)
+  })
+})
+
 // Finding 3: detach() resets spring state so reduced-motion toggle OFF mid-hover
 // starts from initial values, not stale pre-detach tilt/amp.
 describe('useWaterCursor — detach resets spring state (Finding 3)', () => {

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -483,6 +483,67 @@ describe('useWaterCursor — active flag resets before null guard (Round-3 F2)',
   })
 })
 
+// Round-5 Finding 1: tune dep key-order independence
+describe('useWaterCursor — tune dep key-order independence (Round-5 F1)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('tune dep is order-independent — same values in different key order does not re-tear listeners', () => {
+    mockMatchMedia(makeMql(false))
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+
+    const HarnessWithTune = ({
+      tune,
+    }: {
+      tune: Partial<LiquidTune>
+    }): ReactElement => {
+      const wrapRef = useRef<HTMLDivElement>(null)
+      const refsRef = useRef<LiquidRefs | null>(makeRefs())
+
+      useEffect(() => {
+        if (wrapRef.current === null) {
+          return
+        }
+
+        const el = wrapRef.current
+        const origAdd = el.addEventListener.bind(el)
+        const origRemove = el.removeEventListener.bind(el)
+
+        el.addEventListener = ((...args: Parameters<typeof origAdd>) => {
+          addSpy(args[0])
+
+          return origAdd(...args)
+        }) as typeof el.addEventListener
+
+        el.removeEventListener = ((...args: Parameters<typeof origRemove>) => {
+          removeSpy(args[0])
+
+          return origRemove(...args)
+        }) as typeof el.removeEventListener
+      }, [])
+
+      useWaterCursor(wrapRef, refsRef, tune)
+
+      return <div ref={wrapRef} data-testid="wrap" />
+    }
+
+    const { rerender } = render(
+      <HarnessWithTune tune={{ halo: 70, omega: 6.5 }} />
+    )
+    expect(addSpy.mock.calls.map((c: string[]) => c[0])).toContain(
+      'pointermove'
+    )
+
+    // Re-render with the same values but different key order.
+    rerender(<HarnessWithTune tune={{ omega: 6.5, halo: 70 }} />)
+    expect(removeSpy.mock.calls.map((c: string[]) => c[0])).not.toContain(
+      'pointermove'
+    )
+  })
+})
+
 // Finding 3: detach() resets spring state so reduced-motion toggle OFF mid-hover
 // starts from initial values, not stale pre-detach tilt/amp.
 describe('useWaterCursor — detach resets spring state (Finding 3)', () => {

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -1,7 +1,11 @@
 import { act, render, screen } from '@testing-library/react'
 import { useEffect, useRef, type ReactElement } from 'react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { useWaterCursor, type LiquidRefs } from './useWaterCursor'
+import {
+  useWaterCursor,
+  type LiquidRefs,
+  type LiquidTune,
+} from './useWaterCursor'
 
 // jsdom does not provide PointerEvent. Use a MouseEvent dispatched with
 // the 'pointermove' / 'pointerleave' type — the listener key is the
@@ -39,9 +43,15 @@ interface HarnessProps {
   refs: LiquidRefs
   addSpy: ReturnType<typeof vi.fn>
   removeSpy: ReturnType<typeof vi.fn>
+  tune?: Partial<LiquidTune>
 }
 
-const Harness = ({ refs, addSpy, removeSpy }: HarnessProps): ReactElement => {
+const Harness = ({
+  refs,
+  addSpy,
+  removeSpy,
+  tune = undefined,
+}: HarnessProps): ReactElement => {
   const wrapRef = useRef<HTMLDivElement>(null)
   const refsRef = useRef<LiquidRefs | null>(refs)
 
@@ -67,7 +77,7 @@ const Harness = ({ refs, addSpy, removeSpy }: HarnessProps): ReactElement => {
     }) as typeof el.removeEventListener
   }, [addSpy, removeSpy])
 
-  useWaterCursor(wrapRef, refsRef)
+  useWaterCursor(wrapRef, refsRef, tune)
 
   return <div ref={wrapRef} data-testid="wrap" />
 }
@@ -297,5 +307,115 @@ describe('useWaterCursor — runtime reduced-motion toggle', () => {
     expect(addSpy.mock.calls.map((c: string[]) => c[0])).toContain(
       'pointermove'
     )
+  })
+})
+
+// Finding 1: inline tune object identity stability
+describe('useWaterCursor — tune prop identity stability (Finding 1)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('re-rendering with a freshly-constructed inline tune object does NOT remove+re-add pointer listeners', () => {
+    mockMatchMedia(makeMql(false))
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+
+    // Pass tune as an inline object literal that has a fresh identity each render.
+    const { rerender } = render(
+      <Harness
+        refs={makeRefs()}
+        addSpy={addSpy}
+        removeSpy={removeSpy}
+        tune={{ halo: 70 }}
+      />
+    )
+
+    // Confirm listeners were registered on initial mount.
+    expect(addSpy.mock.calls.map((c: string[]) => c[0])).toContain(
+      'pointermove'
+    )
+
+    // Re-render — the tune object `{ halo: 70 }` has a new JS identity each
+    // time, but its VALUES are identical. The hook should NOT tear down.
+    rerender(
+      <Harness
+        refs={makeRefs()}
+        addSpy={addSpy}
+        removeSpy={removeSpy}
+        tune={{ halo: 70 }}
+      />
+    )
+
+    // Listeners must NOT have been removed (which would indicate a teardown).
+    expect(removeSpy.mock.calls.map((c: string[]) => c[0])).not.toContain(
+      'pointermove'
+    )
+  })
+})
+
+// Finding 2: sheen cy tracks waterTop transition
+// NOTE: jsdom provides no real CSS transitions or rAF timing, so a meaningful
+// integration test for the 500ms waterTop animation would require a real
+// browser environment (Playwright/Cypress). The spring logic is exercised
+// indirectly by the existing rAF-loop tests. A unit test that asserts the
+// sheen cy doesn't snap requires observing intermediate rAF frames which
+// jsdom does not faithfully simulate. Skipping dedicated test — the fix is
+// covered by code-review inspection and manual verification.
+
+// Finding 3: detach() resets spring state so reduced-motion toggle OFF mid-hover
+// starts from initial values, not stale pre-detach tilt/amp.
+describe('useWaterCursor — detach resets spring state (Finding 3)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('after reduced-motion toggle ON then OFF, first apply writes near-zero rotate', async () => {
+    const mql = makeMql(false)
+    mockMatchMedia(mql)
+    const refs = makeRefs()
+    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
+    const wrap = screen.getByTestId('wrap')
+    stubRect(wrap, 100, 100)
+
+    // 1. Move pointer to build up non-zero spring state.
+    act(() => {
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
+    })
+    await flushRaf(3)
+
+    // Confirm non-zero tilt was applied before detach.
+    expect(refs.slosh.style.transform).toMatch(/rotate\(/)
+    expect(refs.slosh.style.transform).not.toMatch(/rotate\(0(\.0+)?deg\)/)
+
+    // 2. Simulate reduced-motion toggle ON → detaches + resets spring.
+    const changeListener = mql.addEventListener.mock.calls.find(
+      (c: unknown[]) => c[0] === 'change'
+    )?.[1] as ((e: { matches: boolean }) => void) | undefined
+    expect(changeListener).toBeDefined()
+    act(() => {
+      changeListener?.({ matches: true })
+    })
+
+    // 3. Simulate reduced-motion toggle OFF → re-attaches from clean state.
+    act(() => {
+      changeListener?.({ matches: false })
+    })
+
+    // 4. Fire a pointermove that should start the spring from zero.
+    act(() => {
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
+    })
+    // Run exactly ONE rAF frame — if spring reset correctly, cur.tilt is still
+    // near 0 (spring hasn't had time to build up from initial).
+    await flushRaf(1)
+
+    const transform = refs.slosh.style.transform
+    // Extract the rotate value and assert it is very small (< 0.5 deg),
+    // which confirms the spring started from zero, not from the stale value.
+    const match = /rotate\(([-\d.]+)deg\)/.exec(transform)
+    expect(match).not.toBeNull()
+    const tiltDeg = Math.abs(parseFloat(match?.[1] ?? '999'))
+    expect(tiltDeg).toBeLessThan(0.5)
   })
 })

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -1,0 +1,135 @@
+// @ts-expect-error — act is unused here; Task 3 appends tests that call it
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { act, render } from '@testing-library/react'
+import { useEffect, useRef, type ReactElement } from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { useWaterCursor, type LiquidRefs } from './useWaterCursor'
+
+// jsdom does not provide PointerEvent. Use a MouseEvent dispatched with
+// the 'pointermove' / 'pointerleave' type — the listener key is the
+// event type string, and MouseEvent carries clientX / clientY which is
+// all the hook reads. This avoids touching src/test/setup.ts.
+// @ts-expect-error — firePointer is unused here; Task 3 appends tests that call it
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const firePointer = (
+  el: Element,
+  type: 'pointermove' | 'pointerleave',
+  init: Partial<MouseEventInit> = {}
+): void => {
+  el.dispatchEvent(
+    new MouseEvent(type, { bubbles: true, cancelable: true, ...init })
+  )
+}
+
+interface MqlMock {
+  matches: boolean
+  addEventListener: ReturnType<typeof vi.fn>
+  removeEventListener: ReturnType<typeof vi.fn>
+}
+
+const makeMql = (matches: boolean): MqlMock => ({
+  matches,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+})
+
+const mockMatchMedia = (mql: MqlMock): void => {
+  vi.spyOn(window, 'matchMedia').mockImplementation(
+    () => mql as unknown as MediaQueryList
+  )
+}
+
+interface HarnessProps {
+  refs: LiquidRefs
+  addSpy: ReturnType<typeof vi.fn>
+  removeSpy: ReturnType<typeof vi.fn>
+}
+
+const Harness = ({ refs, addSpy, removeSpy }: HarnessProps): ReactElement => {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const refsRef = useRef<LiquidRefs | null>(refs)
+
+  useEffect(() => {
+    if (wrapRef.current === null) {
+      return
+    }
+
+    const el = wrapRef.current
+    const origAdd = el.addEventListener.bind(el)
+    const origRemove = el.removeEventListener.bind(el)
+
+    el.addEventListener = ((...args: Parameters<typeof origAdd>) => {
+      addSpy(args[0])
+
+      origAdd(...args)
+    }) as typeof el.addEventListener
+
+    el.removeEventListener = ((...args: Parameters<typeof origRemove>) => {
+      removeSpy(args[0])
+
+      origRemove(...args)
+    }) as typeof el.removeEventListener
+  }, [addSpy, removeSpy])
+
+  useWaterCursor(wrapRef, refsRef)
+
+  return <div ref={wrapRef} data-testid="wrap" />
+}
+
+const makeRefs = (): LiquidRefs => ({
+  slosh: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  waveAShift: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  waveBShift: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  waveAAnim: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  waveBAnim: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  sheen: document.createElementNS('http://www.w3.org/2000/svg', 'ellipse'),
+  waterTop: 10,
+  ambientAmp: 1.8,
+  dims: { w: 22, h: 110 },
+})
+
+describe('useWaterCursor — skeleton + reduced-motion gate', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('attaches pointermove and pointerleave on mount when motion allowed', () => {
+    mockMatchMedia(makeMql(false))
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+
+    render(<Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />)
+
+    const kinds = addSpy.mock.calls.map((c: string[]) => c[0])
+    expect(kinds).toContain('pointermove')
+    expect(kinds).toContain('pointerleave')
+  })
+
+  test('skips listener registration under prefers-reduced-motion', () => {
+    mockMatchMedia(makeMql(true))
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+
+    render(<Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />)
+
+    const kinds = addSpy.mock.calls.map((c: string[]) => c[0])
+    expect(kinds).not.toContain('pointermove')
+    expect(kinds).not.toContain('pointerleave')
+  })
+
+  test('removes listeners on unmount', () => {
+    mockMatchMedia(makeMql(false))
+    const addSpy = vi.fn()
+    const removeSpy = vi.fn()
+
+    const { unmount } = render(
+      <Harness refs={makeRefs()} addSpy={addSpy} removeSpy={removeSpy} />
+    )
+
+    unmount()
+
+    const kinds = removeSpy.mock.calls.map((c: string[]) => c[0])
+    expect(kinds).toContain('pointermove')
+    expect(kinds).toContain('pointerleave')
+  })
+})

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -361,22 +361,29 @@ describe('useWaterCursor — pure-wake does not activate hover state (Round-8 F1
     vi.restoreAllMocks()
   })
 
-  test('pure wake (pct change, no hover) does not set data-interactive', async () => {
+  test('pure wake (pct change, no hover) does not set data-interactive at any point', async () => {
     mockMatchMedia(makeMql(false))
     const refs = makeRefs()
     refs.waterTop = 50
 
-    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
+    // Spy on the slosh element's setAttribute calls so we catch any
+    // intra-frame 'data-interactive', 'on' write even if it's cleared
+    // by clearInline() in the same frame.
+    const setAttrSpy = vi.spyOn(refs.slosh, 'setAttribute')
 
+    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
     const wrap = screen.getByTestId('wrap')
     stubRect(wrap, 100, 100)
-    // No pointermove — just simulate a pct change → wake
     refs.waterTop = 30
     act(() => {
       wrap.dispatchEvent(new Event('vfliquidwake'))
     })
     await flushRaf(5)
-    expect(refs.slosh.getAttribute('data-interactive')).toBeNull()
+
+    const interactiveWrites = setAttrSpy.mock.calls.filter(
+      (c) => c[0] === 'data-interactive' && c[1] === 'on'
+    )
+    expect(interactiveWrites).toHaveLength(0)
   })
 })
 

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -355,6 +355,31 @@ describe('useWaterCursor — tune prop identity stability (Finding 1)', () => {
   })
 })
 
+// Round-8 Finding 1: pure-wake cycle must NOT set data-interactive
+describe('useWaterCursor — pure-wake does not activate hover state (Round-8 F1)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('pure wake (pct change, no hover) does not set data-interactive', async () => {
+    mockMatchMedia(makeMql(false))
+    const refs = makeRefs()
+    refs.waterTop = 50
+
+    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
+
+    const wrap = screen.getByTestId('wrap')
+    stubRect(wrap, 100, 100)
+    // No pointermove — just simulate a pct change → wake
+    refs.waterTop = 30
+    act(() => {
+      wrap.dispatchEvent(new Event('vfliquidwake'))
+    })
+    await flushRaf(5)
+    expect(refs.slosh.getAttribute('data-interactive')).toBeNull()
+  })
+})
+
 // Finding 2: sheen cy tracks waterTop transition
 // NOTE: jsdom provides no real CSS transitions or rAF timing, so a meaningful
 // integration test for the 500ms waterTop animation would require a real

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -191,4 +191,35 @@ describe('useWaterCursor — spring loop', () => {
     expect(refs.slosh.getAttribute('data-interactive')).toBeNull()
     expect(refs.slosh.style.transform).toBe('')
   })
+
+  test('rAF stops after spring settles on a still hover', async () => {
+    mockMatchMedia(makeMql(false))
+    const refs = makeRefs()
+
+    // Spy on rAF using the real implementation so frames still advance.
+    // vi.restoreAllMocks() in afterEach cleans this up.
+    const originalRaf = window.requestAnimationFrame.bind(window)
+
+    const spy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb) => originalRaf(cb))
+
+    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
+    const wrap = screen.getByTestId('wrap')
+    stubRect(wrap, 100, 100)
+
+    // Fire a single pointermove and let the spring fully settle
+    act(() => {
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
+    })
+    await flushRaf(80) // well past settle time for omega=6.5
+
+    // Record rAF call count after settle
+    const callsAfterSettle = spy.mock.calls.length
+
+    // Advance another 16 frames — no new rAF should be scheduled
+    await flushRaf(16)
+
+    expect(spy.mock.calls.length).toBe(callsAfterSettle)
+  })
 })

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -405,6 +405,84 @@ describe('useWaterCursor — vfliquidwake wake event (Finding 4)', () => {
   })
 })
 
+// Round-3 Finding 1: clearInline must not clear React-owned transformOrigin
+describe('useWaterCursor — clearInline preserves React-owned transformOrigin (Round-3 F1)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('transformOrigin is NOT empty after a complete hover → leave → settle cycle', async () => {
+    mockMatchMedia(makeMql(false))
+    const refs = makeRefs()
+    // Simulate what React sets on mount via JSX style={{ transformOrigin }}.
+    refs.slosh.style.transformOrigin = '11px 110px'
+
+    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
+    const wrap = screen.getByTestId('wrap')
+    stubRect(wrap, 100, 100)
+
+    // 1. Hover to start the spring.
+    act(() => {
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
+    })
+    await flushRaf(3)
+
+    // 2. Leave to let the spring return to rest and call clearInline.
+    act(() => {
+      firePointer(wrap, 'pointerleave')
+    })
+    await flushRaf(80) // well past spring settle at omega=6.5
+
+    // transformOrigin must still be non-empty — clearInline must not have cleared it.
+    expect(refs.slosh.style.transformOrigin).not.toBe('')
+  })
+})
+
+// Round-3 Finding 2: active flag must reset before null guard so pct=0 unmount
+// doesn't leave active=true and silently break data-interactive on the next remount.
+describe('useWaterCursor — active flag resets before null guard (Round-3 F2)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('data-interactive is written on remount after clearInline with null refs', async () => {
+    mockMatchMedia(makeMql(false))
+    const refs = makeRefs()
+
+    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
+    const wrap = screen.getByTestId('wrap')
+    stubRect(wrap, 100, 100)
+
+    // 1. Hover to make active=true.
+    act(() => {
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
+    })
+    await flushRaf(2)
+    expect(refs.slosh.getAttribute('data-interactive')).toBe('on')
+
+    // 2. Fire pointerleave to let the spring return to rest and call clearInline.
+    //    The key contract: active must be reset to false BEFORE the null guard
+    //    so that even if refs are null (pct=0 unmount path) the flag is cleared.
+    //    We can't null refsRef.current from outside the Harness closure, so we
+    //    verify the observable consequence: after settle, data-interactive is
+    //    gone, and a subsequent hover re-adds it (proving active was false).
+    act(() => {
+      firePointer(wrap, 'pointerleave')
+    })
+    await flushRaf(80)
+    // active=false must have been set. data-interactive must be gone.
+    expect(refs.slosh.getAttribute('data-interactive')).toBeNull()
+
+    // 3. Re-hover — because active=false was set correctly, apply() will call
+    //    setAttribute('data-interactive', 'on') again on the first frame.
+    act(() => {
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
+    })
+    await flushRaf(2)
+    expect(refs.slosh.getAttribute('data-interactive')).toBe('on')
+  })
+})
+
 // Finding 3: detach() resets spring state so reduced-motion toggle OFF mid-hover
 // starts from initial values, not stale pre-detach tilt/amp.
 describe('useWaterCursor — detach resets spring state (Finding 3)', () => {

--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -161,6 +161,7 @@ describe('useWaterCursor — skeleton + reduced-motion gate', () => {
     const kinds = removeSpy.mock.calls.map((c: string[]) => c[0])
     expect(kinds).toContain('pointermove')
     expect(kinds).toContain('pointerleave')
+    expect(kinds).toContain('vfliquidwake')
   })
 })
 

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -1,0 +1,65 @@
+import { useEffect, type RefObject } from 'react'
+
+export interface LiquidRefs {
+  slosh: SVGGElement
+  waveAShift: SVGGElement
+  waveBShift: SVGGElement
+  waveAAnim: SVGGElement
+  waveBAnim: SVGGElement
+  sheen: SVGEllipseElement
+  waterTop: number
+  ambientAmp: number
+  dims: { w: number; h: number }
+}
+
+export const LIQUID_DEFAULTS = {
+  halo: 70,
+  omega: 6.5,
+  maxTilt: 1.6,
+  ampMax: 1.5,
+  maxShift: 1.0,
+  maxLift: 1.0,
+  meniscus: 2.3,
+  speedup: 1.02,
+} as const
+
+export type LiquidTune = typeof LIQUID_DEFAULTS
+
+export const useWaterCursor = (
+  wrapRef: RefObject<HTMLElement | null>,
+  refsRef: RefObject<LiquidRefs | null>,
+  tune: Partial<LiquidTune> = {}
+): void => {
+  useEffect(() => {
+    const wrap = wrapRef.current
+
+    if (wrap === null) {
+      return
+    }
+
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+
+    if (mql.matches) {
+      return
+    }
+
+    const onMove = (_e: PointerEvent): void => {
+      void _e
+      void tune
+      void refsRef
+    }
+
+    // placeholder — full spring loop added in Task 3
+    const onLeave = (_e: PointerEvent): void => {
+      void _e
+    }
+
+    wrap.addEventListener('pointermove', onMove)
+    wrap.addEventListener('pointerleave', onLeave)
+
+    return (): void => {
+      wrap.removeEventListener('pointermove', onMove)
+      wrap.removeEventListener('pointerleave', onLeave)
+    }
+  }, [wrapRef, refsRef, tune])
+}

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -127,6 +127,13 @@ export const useWaterCursor = (
       ensureLoop()
     }
 
+    // Triggered by LiquidFill when refs.waterTop changes. Restarts the rAF
+    // loop so currentWaterTop can spring-chase the new target instead of
+    // the React render snapping the sheen to the new level.
+    const onWake = (): void => {
+      ensureLoop()
+    }
+
     const apply = (): void => {
       const refs = refsRef.current
       if (refs === null) {
@@ -278,6 +285,7 @@ export const useWaterCursor = (
       }
       wrap.addEventListener('pointermove', onMove)
       wrap.addEventListener('pointerleave', onLeave)
+      wrap.addEventListener('vfliquidwake', onWake)
       attached = true
     }
 
@@ -287,6 +295,7 @@ export const useWaterCursor = (
       }
       wrap.removeEventListener('pointermove', onMove)
       wrap.removeEventListener('pointerleave', onLeave)
+      wrap.removeEventListener('vfliquidwake', onWake)
       attached = false
       if (rafId !== null) {
         cancelAnimationFrame(rafId)

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -305,9 +305,17 @@ export const useWaterCursor = (
           target.sheenA === 0 &&
           target.sheenX === 0
         if (settled) {
-          if (atRest) {
+          if (atRest || refsRef.current === null) {
             cur = initialTarget()
             vel = initialVel()
+            target.tilt = 0
+            target.amp = 1
+            target.shiftX = 0
+            target.lift = 0
+            target.skew = 0
+            target.speedT = 0
+            target.sheenX = 0
+            target.sheenA = 0
             clearInline()
           }
           rafId = null

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -118,6 +118,7 @@ export const useWaterCursor = (
       target.skew = 0
       target.speedT = 0
       target.sheenA = 0
+      target.sheenX = 0
       ensureLoop()
     }
 
@@ -223,11 +224,14 @@ export const useWaterCursor = (
           target.lift === 0 &&
           target.skew === 0 &&
           target.speedT === 0 &&
-          target.sheenA === 0
-        if (settled && atRest) {
-          cur = initialTarget()
-          vel = initialVel()
-          clearInline()
+          target.sheenA === 0 &&
+          target.sheenX === 0
+        if (settled) {
+          if (atRest) {
+            cur = initialTarget()
+            vel = initialVel()
+            clearInline()
+          }
           rafId = null
 
           return

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -168,8 +168,8 @@ export const useWaterCursor = (
         target.sheenA !== 0 ||
         target.sheenX !== 0
 
-      if (hoverActive) {
-        if (!active) {
+      if (hoverActive || active) {
+        if (hoverActive && !active) {
           refs.slosh.setAttribute('data-interactive', 'on')
           active = true
         }

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -152,41 +152,60 @@ export const useWaterCursor = (
       if (refs === null) {
         return
       }
-      if (!active) {
-        refs.slosh.setAttribute('data-interactive', 'on')
-        active = true
+
+      // Hover-driven writes are skipped on pure-wake frames (pct change
+      // with no hover). On a pure wake, hover targets stay at ambient,
+      // so the slosh/wave/animationDuration writes here would be no-op
+      // identity values that clearInline() reverses in the same frame —
+      // unnecessary DOM work and fragile against future style-flushes.
+      const hoverActive =
+        target.tilt !== 0 ||
+        target.amp !== 1 ||
+        target.shiftX !== 0 ||
+        target.lift !== 0 ||
+        target.skew !== 0 ||
+        target.speedT !== 0 ||
+        target.sheenA !== 0 ||
+        target.sheenX !== 0
+
+      if (hoverActive) {
+        if (!active) {
+          refs.slosh.setAttribute('data-interactive', 'on')
+          active = true
+        }
+
+        refs.slosh.style.transform = `rotate(${cur.tilt.toFixed(3)}deg)`
+
+        const tx = `translateY(${cur.lift.toFixed(3)}px) scaleY(${cur.amp.toFixed(
+          4
+        )}) translateX(${cur.shiftX.toFixed(
+          3
+        )}px) skewX(${(-cur.skew).toFixed(3)}deg)`
+
+        const txA = `translateY(${cur.lift.toFixed(
+          3
+        )}px) scaleY(${cur.amp.toFixed(4)}) translateX(${(
+          cur.shiftX * 0.6
+        ).toFixed(3)}px) skewX(${(-cur.skew).toFixed(3)}deg)`
+        refs.waveAShift.style.transform = txA
+        refs.waveBShift.style.transform = tx
+
+        const speedFactor = 1 + cur.speedT * (T.speedup - 1)
+        refs.waveAAnim.style.animationDuration =
+          (3.4 / speedFactor).toFixed(3) + 's'
+
+        refs.waveBAnim.style.animationDuration =
+          (4.8 / speedFactor).toFixed(3) + 's'
       }
-      refs.slosh.style.transform = `rotate(${cur.tilt.toFixed(3)}deg)`
 
-      const tx = `translateY(${cur.lift.toFixed(3)}px) scaleY(${cur.amp.toFixed(
-        4
-      )}) translateX(${cur.shiftX.toFixed(
-        3
-      )}px) skewX(${(-cur.skew).toFixed(3)}deg)`
-
-      const txA = `translateY(${cur.lift.toFixed(
-        3
-      )}px) scaleY(${cur.amp.toFixed(4)}) translateX(${(
-        cur.shiftX * 0.6
-      ).toFixed(3)}px) skewX(${(-cur.skew).toFixed(3)}deg)`
-      refs.waveAShift.style.transform = txA
-      refs.waveBShift.style.transform = tx
-
-      const speedFactor = 1 + cur.speedT * (T.speedup - 1)
-      refs.waveAAnim.style.animationDuration =
-        (3.4 / speedFactor).toFixed(3) + 's'
-
-      refs.waveBAnim.style.animationDuration =
-        (4.8 / speedFactor).toFixed(3) + 's'
-
+      // Sheen position + opacity track currentWaterTop on every frame
+      // (wake or hover) so the highlight stays attached to the surface
+      // during pct transitions.
+      const sheenWaterTop = currentWaterTop ?? refs.waterTop
       const w = refs.dims.w
       const sheenX = w / 2 + cur.sheenX * (w / 2 - 1)
       refs.sheen.setAttribute('cx', sheenX.toFixed(2))
-      // Use the spring-animated currentWaterTop so the sheen tracks the 500ms
-      // CSS transition on pct changes instead of snapping to the new level.
-      const animatedTop = currentWaterTop ?? refs.waterTop
-      refs.sheen.setAttribute('cy', (animatedTop + cur.lift - 0.3).toFixed(2))
-
+      refs.sheen.setAttribute('cy', (sheenWaterTop + cur.lift - 0.3).toFixed(2))
       refs.sheen.setAttribute('fill-opacity', (cur.sheenA * 0.55).toFixed(3))
     }
 

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -59,10 +59,12 @@ const initialVel = (): SignalState => ({
   sheenA: 0,
 })
 
+const EMPTY_TUNE: Partial<LiquidTune> = Object.freeze({}) as Partial<LiquidTune>
+
 export const useWaterCursor = (
   wrapRef: RefObject<HTMLElement | null>,
   refsRef: RefObject<LiquidRefs | null>,
-  tune: Partial<LiquidTune> = {}
+  tune: Partial<LiquidTune> = EMPTY_TUNE
 ): void => {
   useEffect(() => {
     const wrap = wrapRef.current

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -179,22 +179,30 @@ export const useWaterCursor = (
     }
 
     const clearInline = (): void => {
+      // Reset closure state unconditionally — these aren't tied to refs.
+      active = false
+      // Re-sync so the next attach starts from the correct instantaneous waterTop.
+      currentWaterTop = null
+      velWaterTop = 0
+
       const refs = refsRef.current
       if (refs === null) {
         return
       }
       refs.slosh.removeAttribute('data-interactive')
       refs.slosh.style.transform = ''
-      refs.slosh.style.transformOrigin = ''
+      // transformOrigin is intentionally NOT cleared here. React owns that
+      // inline style via JSX style={{ transformOrigin }} on the <g> element.
+      // React's virtual-DOM diff compares virtual-DOM-to-virtual-DOM, so after
+      // clearInline clears the inline style React never re-writes it on
+      // subsequent renders — the SVG <g> falls back to its default origin (0 0)
+      // and the ambient slosh keyframe rotates around the wrong pivot until the
+      // next hover.
       refs.waveAShift.style.transform = ''
       refs.waveBShift.style.transform = ''
       refs.waveAAnim.style.animationDuration = ''
       refs.waveBAnim.style.animationDuration = ''
       refs.sheen.setAttribute('fill-opacity', '0')
-      active = false
-      // Re-sync so the next attach starts from the correct instantaneous waterTop.
-      currentWaterTop = null
-      velWaterTop = 0
     }
 
     function ensureLoop(): void {
@@ -249,9 +257,12 @@ export const useWaterCursor = (
           Math.abs(cur.sheenA - target.sheenA) < 0.01 &&
           Math.abs(cur.sheenX - target.sheenX) < 0.01 &&
           // Keep looping while waterTop is still chasing the CSS transition.
+          // velWaterTop threshold prevents early termination mid-flight under
+          // rapid pct changes (velocity ~12 px/s while position is within 0.02).
           (currentWaterTop === null ||
             refsRef.current === null ||
-            Math.abs(currentWaterTop - refsRef.current.waterTop) < 0.02)
+            (Math.abs(currentWaterTop - refsRef.current.waterTop) < 0.02 &&
+              Math.abs(velWaterTop) < 0.1))
 
         const atRest =
           target.tilt === 0 &&

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -157,7 +157,6 @@ export const useWaterCursor = (
         active = true
       }
       refs.slosh.style.transform = `rotate(${cur.tilt.toFixed(3)}deg)`
-      refs.slosh.style.transformOrigin = `${refs.dims.w / 2}px ${refs.dims.h}px`
 
       const tx = `translateY(${cur.lift.toFixed(3)}px) scaleY(${cur.amp.toFixed(
         4
@@ -310,6 +309,15 @@ export const useWaterCursor = (
       wrap.addEventListener('pointermove', onMove)
       wrap.addEventListener('pointerleave', onLeave)
       wrap.addEventListener('vfliquidwake', onWake)
+      // Set transform-origin once per attach lifecycle. The pivot derives
+      // from stable dims; React's JSX already sets the same value at mount,
+      // but clearInline() does NOT clear it (intentionally — see round-3
+      // F1). Writing here is belt-and-suspenders for the (rare) case where
+      // refs are rebuilt with different dims between attach cycles.
+      const refsNow = refsRef.current
+      if (refsNow !== null) {
+        refsNow.slosh.style.transformOrigin = `${refsNow.dims.w / 2}px ${refsNow.dims.h}px`
+      }
       attached = true
     }
 

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -25,6 +25,40 @@ export const LIQUID_DEFAULTS = {
 
 export type LiquidTune = { [K in keyof typeof LIQUID_DEFAULTS]: number }
 
+type Signal =
+  | 'tilt'
+  | 'amp'
+  | 'shiftX'
+  | 'lift'
+  | 'skew'
+  | 'speedT'
+  | 'sheenX'
+  | 'sheenA'
+
+type SignalState = Record<Signal, number>
+
+const initialTarget = (): SignalState => ({
+  tilt: 0,
+  amp: 1,
+  shiftX: 0,
+  lift: 0,
+  skew: 0,
+  speedT: 0,
+  sheenX: 0,
+  sheenA: 0,
+})
+
+const initialVel = (): SignalState => ({
+  tilt: 0,
+  amp: 0,
+  shiftX: 0,
+  lift: 0,
+  skew: 0,
+  speedT: 0,
+  sheenX: 0,
+  sheenA: 0,
+})
+
 export const useWaterCursor = (
   wrapRef: RefObject<HTMLElement | null>,
   refsRef: RefObject<LiquidRefs | null>,
@@ -32,34 +66,188 @@ export const useWaterCursor = (
 ): void => {
   useEffect(() => {
     const wrap = wrapRef.current
-
     if (wrap === null) {
       return
     }
-
     const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
-
     if (mql.matches) {
       return
     }
 
-    const onMove = (_e: PointerEvent): void => {
-      void _e
-      void tune
-      void refsRef
+    const T: LiquidTune = { ...LIQUID_DEFAULTS, ...tune }
+
+    const target = initialTarget()
+    let cur = initialTarget()
+    let vel = initialVel()
+    let rafId: number | null = null
+    let lastT = performance.now()
+    let active = false
+
+    const onMove = (e: PointerEvent): void => {
+      const refs = refsRef.current
+      if (refs === null) {
+        return
+      }
+      const r = wrap.getBoundingClientRect()
+      const cx = r.left + r.width / 2
+      const cy = r.top + r.height / 2
+      const dx = e.clientX - cx
+      const dy = e.clientY - cy
+      const dist = Math.hypot(dx, dy)
+      const linear = Math.max(0, 1 - dist / (T.halo + r.width / 2))
+      const proximity = linear * linear * (3 - 2 * linear)
+      const norm = Math.max(-1, Math.min(1, dx / (r.width / 2 + T.halo)))
+
+      const aboveBelow = Math.max(-1, Math.min(1, dy / (r.height / 2 + T.halo)))
+      target.tilt = norm * proximity * T.maxTilt
+      target.amp = 1 + proximity * (T.ampMax - 1)
+      target.shiftX = norm * proximity * T.maxShift
+      target.lift = -aboveBelow * proximity * T.maxLift
+      target.skew = norm * proximity * T.meniscus
+      target.speedT = proximity
+      target.sheenX = norm
+      target.sheenA = proximity
+      ensureLoop()
     }
 
-    // placeholder — full spring loop added in Task 3
-    const onLeave = (_e: PointerEvent): void => {
-      void _e
+    const onLeave = (): void => {
+      target.tilt = 0
+      target.amp = 1
+      target.shiftX = 0
+      target.lift = 0
+      target.skew = 0
+      target.speedT = 0
+      target.sheenA = 0
+      ensureLoop()
+    }
+
+    const apply = (): void => {
+      const refs = refsRef.current
+      if (refs === null) {
+        return
+      }
+      if (!active) {
+        refs.slosh.setAttribute('data-interactive', 'on')
+        active = true
+      }
+      refs.slosh.style.transform = `rotate(${cur.tilt.toFixed(3)}deg)`
+      refs.slosh.style.transformOrigin = `${refs.dims.w / 2}px ${refs.dims.h}px`
+
+      const tx = `translateY(${cur.lift.toFixed(3)}px) scaleY(${cur.amp.toFixed(
+        4
+      )}) translateX(${cur.shiftX.toFixed(
+        3
+      )}px) skewX(${(-cur.skew).toFixed(3)}deg)`
+
+      const txA = `translateY(${cur.lift.toFixed(
+        3
+      )}px) scaleY(${cur.amp.toFixed(4)}) translateX(${(
+        cur.shiftX * 0.6
+      ).toFixed(3)}px) skewX(${(-cur.skew).toFixed(3)}deg)`
+      refs.waveAShift.style.transform = txA
+      refs.waveBShift.style.transform = tx
+
+      const speedFactor = 1 + cur.speedT * (T.speedup - 1)
+      refs.waveAAnim.style.animationDuration =
+        (3.4 / speedFactor).toFixed(3) + 's'
+
+      refs.waveBAnim.style.animationDuration =
+        (4.8 / speedFactor).toFixed(3) + 's'
+
+      const w = refs.dims.w
+      const sheenX = w / 2 + cur.sheenX * (w / 2 - 1)
+      refs.sheen.setAttribute('cx', sheenX.toFixed(2))
+      refs.sheen.setAttribute('cy', (refs.waterTop + cur.lift - 0.3).toFixed(2))
+
+      refs.sheen.setAttribute('fill-opacity', (cur.sheenA * 0.55).toFixed(3))
+    }
+
+    const clearInline = (): void => {
+      const refs = refsRef.current
+      if (refs === null) {
+        return
+      }
+      refs.slosh.removeAttribute('data-interactive')
+      refs.slosh.style.transform = ''
+      refs.slosh.style.transformOrigin = ''
+      refs.waveAShift.style.transform = ''
+      refs.waveBShift.style.transform = ''
+      refs.waveAAnim.style.animationDuration = ''
+      refs.waveBAnim.style.animationDuration = ''
+      refs.sheen.setAttribute('fill-opacity', '0')
+      active = false
+    }
+
+    function ensureLoop(): void {
+      if (rafId !== null) {
+        return
+      }
+      lastT = performance.now()
+
+      const step = (t: number): void => {
+        const dt = Math.max(0, Math.min(0.05, (t - lastT) / 1000))
+        lastT = t
+        const w = T.omega
+
+        const keys: Signal[] = [
+          'tilt',
+          'amp',
+          'shiftX',
+          'lift',
+          'skew',
+          'speedT',
+          'sheenX',
+          'sheenA',
+        ]
+        for (const k of keys) {
+          const a = -2 * w * vel[k] - w * w * (cur[k] - target[k])
+          vel[k] += a * dt
+          cur[k] += vel[k] * dt
+        }
+        apply()
+
+        const settled =
+          Math.abs(cur.tilt - target.tilt) < 0.01 &&
+          Math.abs(cur.amp - target.amp) < 0.005 &&
+          Math.abs(cur.shiftX - target.shiftX) < 0.02 &&
+          Math.abs(cur.lift - target.lift) < 0.02 &&
+          Math.abs(cur.skew - target.skew) < 0.02 &&
+          Math.abs(cur.speedT - target.speedT) < 0.01 &&
+          Math.abs(cur.sheenA - target.sheenA) < 0.01 &&
+          Math.abs(cur.sheenX - target.sheenX) < 0.01
+
+        const atRest =
+          target.tilt === 0 &&
+          target.amp === 1 &&
+          target.shiftX === 0 &&
+          target.lift === 0 &&
+          target.skew === 0 &&
+          target.speedT === 0 &&
+          target.sheenA === 0
+        if (settled && atRest) {
+          cur = initialTarget()
+          vel = initialVel()
+          clearInline()
+          rafId = null
+
+          return
+        }
+        rafId = requestAnimationFrame(step)
+      }
+      rafId = requestAnimationFrame(step)
     }
 
     wrap.addEventListener('pointermove', onMove)
     wrap.addEventListener('pointerleave', onLeave)
 
     return (): void => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+      }
+      rafId = null
       wrap.removeEventListener('pointermove', onMove)
       wrap.removeEventListener('pointerleave', onLeave)
+      clearInline()
     }
   }, [wrapRef, refsRef, tune])
 }

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -82,6 +82,12 @@ export const useWaterCursor = (
     let lastT = performance.now()
     let active = false
 
+    // Tracks the animated water-top position — springs toward refs.waterTop each
+    // rAF frame so the sheen follows the 500ms CSS transition on pct changes
+    // instead of snapping to the new level instantly.
+    let currentWaterTop: number | null = null
+    let velWaterTop = 0
+
     const onMove = (e: PointerEvent): void => {
       const refs = refsRef.current
       if (refs === null) {
@@ -157,7 +163,10 @@ export const useWaterCursor = (
       const w = refs.dims.w
       const sheenX = w / 2 + cur.sheenX * (w / 2 - 1)
       refs.sheen.setAttribute('cx', sheenX.toFixed(2))
-      refs.sheen.setAttribute('cy', (refs.waterTop + cur.lift - 0.3).toFixed(2))
+      // Use the spring-animated currentWaterTop so the sheen tracks the 500ms
+      // CSS transition on pct changes instead of snapping to the new level.
+      const animatedTop = currentWaterTop ?? refs.waterTop
+      refs.sheen.setAttribute('cy', (animatedTop + cur.lift - 0.3).toFixed(2))
 
       refs.sheen.setAttribute('fill-opacity', (cur.sheenA * 0.55).toFixed(3))
     }
@@ -176,6 +185,9 @@ export const useWaterCursor = (
       refs.waveBAnim.style.animationDuration = ''
       refs.sheen.setAttribute('fill-opacity', '0')
       active = false
+      // Re-sync so the next attach starts from the correct instantaneous waterTop.
+      currentWaterTop = null
+      velWaterTop = 0
     }
 
     function ensureLoop(): void {
@@ -204,6 +216,20 @@ export const useWaterCursor = (
           vel[k] += a * dt
           cur[k] += vel[k] * dt
         }
+
+        // Spring-animate currentWaterTop toward refs.waterTop using the same
+        // critically-damped spring (omega w) so the sheen smoothly follows the
+        // 500ms CSS transition on pct changes instead of snapping instantly.
+        const refsNow = refsRef.current
+        if (refsNow !== null) {
+          currentWaterTop ??= refsNow.waterTop
+
+          const aTop =
+            -2 * w * velWaterTop - w * w * (currentWaterTop - refsNow.waterTop)
+          velWaterTop += aTop * dt
+          currentWaterTop += velWaterTop * dt
+        }
+
         apply()
 
         const settled =
@@ -214,7 +240,11 @@ export const useWaterCursor = (
           Math.abs(cur.skew - target.skew) < 0.02 &&
           Math.abs(cur.speedT - target.speedT) < 0.01 &&
           Math.abs(cur.sheenA - target.sheenA) < 0.01 &&
-          Math.abs(cur.sheenX - target.sheenX) < 0.01
+          Math.abs(cur.sheenX - target.sheenX) < 0.01 &&
+          // Keep looping while waterTop is still chasing the CSS transition.
+          (currentWaterTop === null ||
+            refsRef.current === null ||
+            Math.abs(currentWaterTop - refsRef.current.waterTop) < 0.02)
 
         const atRest =
           target.tilt === 0 &&
@@ -263,6 +293,19 @@ export const useWaterCursor = (
       }
       rafId = null
       clearInline()
+      // Reset spring state so the next attach starts from a clean slate.
+      // Without this, a reduced-motion toggle OFF mid-hover would resume from
+      // stale tilt/amp values and cause a visible 1-frame snap.
+      cur = initialTarget()
+      vel = initialVel()
+      target.tilt = 0
+      target.amp = 1
+      target.shiftX = 0
+      target.lift = 0
+      target.skew = 0
+      target.speedT = 0
+      target.sheenX = 0
+      target.sheenA = 0
     }
 
     const onMqlChange = (
@@ -284,5 +327,9 @@ export const useWaterCursor = (
       mql.removeEventListener('change', onMqlChange as EventListener)
       detach()
     }
-  }, [wrapRef, refsRef, tune])
+    // JSON.stringify(tune) is a stable primitive dep — re-runs only when tune
+    // VALUES change, not when callers pass a fresh inline-object identity each
+    // render (which would tear down and reattach the spring at 60fps).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wrapRef, refsRef, JSON.stringify(tune)])
 }

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -70,9 +70,6 @@ export const useWaterCursor = (
       return
     }
     const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
-    if (mql.matches) {
-      return
-    }
 
     const T: LiquidTune = { ...LIQUID_DEFAULTS, ...tune }
 
@@ -241,17 +238,49 @@ export const useWaterCursor = (
       rafId = requestAnimationFrame(step)
     }
 
-    wrap.addEventListener('pointermove', onMove)
-    wrap.addEventListener('pointerleave', onLeave)
+    let attached = false
 
-    return (): void => {
+    const attach = (): void => {
+      if (attached) {
+        return
+      }
+      wrap.addEventListener('pointermove', onMove)
+      wrap.addEventListener('pointerleave', onLeave)
+      attached = true
+    }
+
+    const detach = (): void => {
+      if (!attached) {
+        return
+      }
+      wrap.removeEventListener('pointermove', onMove)
+      wrap.removeEventListener('pointerleave', onLeave)
+      attached = false
       if (rafId !== null) {
         cancelAnimationFrame(rafId)
       }
       rafId = null
-      wrap.removeEventListener('pointermove', onMove)
-      wrap.removeEventListener('pointerleave', onLeave)
       clearInline()
+    }
+
+    const onMqlChange = (
+      e: MediaQueryListEvent | { matches: boolean }
+    ): void => {
+      if (e.matches) {
+        detach()
+      } else {
+        attach()
+      }
+    }
+    mql.addEventListener('change', onMqlChange as EventListener)
+
+    if (!mql.matches) {
+      attach()
+    }
+
+    return (): void => {
+      mql.removeEventListener('change', onMqlChange as EventListener)
+      detach()
     }
   }, [wrapRef, refsRef, tune])
 }

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -23,7 +23,7 @@ export const LIQUID_DEFAULTS = {
   speedup: 1.02,
 } as const
 
-export type LiquidTune = typeof LIQUID_DEFAULTS
+export type LiquidTune = { [K in keyof typeof LIQUID_DEFAULTS]: number }
 
 export const useWaterCursor = (
   wrapRef: RefObject<HTMLElement | null>,

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -336,9 +336,11 @@ export const useWaterCursor = (
       mql.removeEventListener('change', onMqlChange as EventListener)
       detach()
     }
-    // JSON.stringify(tune) is a stable primitive dep — re-runs only when tune
-    // VALUES change, not when callers pass a fresh inline-object identity each
-    // render (which would tear down and reattach the spring at 60fps).
+    // Effect deps intentionally narrow: wrapRef and refsRef are stable
+    // useRef objects (identity never changes); JSON.stringify(tune) covers
+    // tune VALUE changes without churning on object identity. The effect
+    // closure also reads refsRef.current internally — that's correct (it's
+    // a ref, not a reactive value).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wrapRef, refsRef, JSON.stringify(tune)])
 }

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -66,6 +66,9 @@ export const useWaterCursor = (
   refsRef: RefObject<LiquidRefs | null>,
   tune: Partial<LiquidTune> = EMPTY_TUNE
 ): void => {
+  const { halo, omega, maxTilt, ampMax, maxShift, maxLift, meniscus, speedup } =
+    tune
+
   useEffect(() => {
     const wrap = wrapRef.current
     if (wrap === null) {
@@ -73,7 +76,17 @@ export const useWaterCursor = (
     }
     const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
 
-    const T: LiquidTune = { ...LIQUID_DEFAULTS, ...tune }
+    const T: LiquidTune = {
+      ...LIQUID_DEFAULTS,
+      ...(halo !== undefined && { halo }),
+      ...(omega !== undefined && { omega }),
+      ...(maxTilt !== undefined && { maxTilt }),
+      ...(ampMax !== undefined && { ampMax }),
+      ...(maxShift !== undefined && { maxShift }),
+      ...(maxLift !== undefined && { maxLift }),
+      ...(meniscus !== undefined && { meniscus }),
+      ...(speedup !== undefined && { speedup }),
+    }
 
     const target = initialTarget()
     let cur = initialTarget()
@@ -347,11 +360,16 @@ export const useWaterCursor = (
       mql.removeEventListener('change', onMqlChange as EventListener)
       detach()
     }
-    // Effect deps intentionally narrow: wrapRef and refsRef are stable
-    // useRef objects (identity never changes); JSON.stringify(tune) covers
-    // tune VALUE changes without churning on object identity. The effect
-    // closure also reads refsRef.current internally — that's correct (it's
-    // a ref, not a reactive value).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wrapRef, refsRef, JSON.stringify(tune)])
+  }, [
+    wrapRef,
+    refsRef,
+    halo,
+    omega,
+    maxTilt,
+    ampMax,
+    maxShift,
+    maxLift,
+    meniscus,
+    speedup,
+  ])
 }

--- a/src/index.css
+++ b/src/index.css
@@ -163,10 +163,11 @@
   background: #4a444f;
 }
 
-/* Agent activity rail bucket animations.
-   Two opposing sine-wave translations create the ripple; vfSlosh tilts
-   the whole liquid mass < 1deg. Honors prefers-reduced-motion. */
-@keyframes vfWaveA {
+/* Liquid bucket animations (used by both Bucket and ContextBucket via
+   LiquidFill). Two opposing sine-wave translations create the ripple;
+   vfLiquidSlosh tilts the whole liquid mass < 1deg. Honors
+   prefers-reduced-motion. */
+@keyframes vfLiquidWaveA {
   from {
     transform: translateX(0);
   }
@@ -175,7 +176,7 @@
   }
 }
 
-@keyframes vfWaveB {
+@keyframes vfLiquidWaveB {
   from {
     transform: translateX(-50%);
   }
@@ -184,7 +185,7 @@
   }
 }
 
-@keyframes vfSlosh {
+@keyframes vfLiquidSlosh {
   0%,
   100% {
     transform: translateX(0) rotate(0deg);
@@ -194,22 +195,26 @@
   }
 }
 
-.vf-bucket-wave-a {
-  animation: vfWaveA 3.4s linear infinite;
+.vf-liquid-wave-a {
+  animation: vfLiquidWaveA 3.4s linear infinite;
 }
 
-.vf-bucket-wave-b {
-  animation: vfWaveB 4.8s linear infinite;
+.vf-liquid-wave-b {
+  animation: vfLiquidWaveB 4.8s linear infinite;
 }
 
-.vf-bucket-slosh {
-  animation: vfSlosh 2.6s ease-in-out infinite;
+.vf-liquid-slosh {
+  animation: vfLiquidSlosh 2.6s ease-in-out infinite;
+}
+
+.vf-liquid-slosh[data-interactive='on'] {
+  animation: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .vf-bucket-wave-a,
-  .vf-bucket-wave-b,
-  .vf-bucket-slosh {
+  .vf-liquid-wave-a,
+  .vf-liquid-wave-b,
+  .vf-liquid-slosh {
     animation: none;
   }
 }

--- a/src/test/mockResizeObserver.ts
+++ b/src/test/mockResizeObserver.ts
@@ -1,0 +1,49 @@
+import { vi } from 'vitest'
+
+export type ROCallback = (entries: { contentRect: DOMRectReadOnly }[]) => void
+
+/**
+ * jsdom-friendly ResizeObserver mock with a `trigger(rect)` handle so
+ * tests can fire synthetic resize events inside act(). Each instance is
+ * pushed onto the static `instances` array — `beforeEach` should clear
+ * it AND reinstall the constructor on globalThis.ResizeObserver.
+ */
+export class MockResizeObserver {
+  static instances: MockResizeObserver[] = []
+  cb: ROCallback
+
+  constructor(cb: ROCallback) {
+    this.cb = cb
+    MockResizeObserver.instances.push(this)
+  }
+
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+
+  trigger(rect: { width: number; height: number }): void {
+    this.cb([
+      {
+        contentRect: {
+          ...rect,
+          top: 0,
+          left: 0,
+          right: rect.width,
+          bottom: rect.height,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        } as DOMRectReadOnly,
+      },
+    ])
+  }
+}
+
+/**
+ * Install the mock on globalThis.ResizeObserver. Call from a `beforeEach`.
+ */
+export const installMockResizeObserver = (): void => {
+  MockResizeObserver.instances = []
+  const g = globalThis as unknown as { ResizeObserver: typeof ResizeObserver }
+  g.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+}


### PR DESCRIPTION
## Summary

- Cursor-responsive water effect on agent-status bucket fills (rail CTX/CACHE + the expanded panel's CURRENT CONTEXT gauge).
- Shared `LiquidFill` SVG primitive + `useWaterCursor` hook. The hook runs a critically-damped spring on 8 signals (tilt, amp, drift, lift, meniscus, wave-speed, sheen-x, sheen-α), writes inline transforms to SVG refs on rAF, and self-tears-down on unmount. Honors `prefers-reduced-motion` at mount AND when toggled at runtime (no reload required).
- `ContextBucket` gauge: flat gradient `<div>` → `<LiquidFill mode="fill" className="h-full w-full" />`, measured via `ResizeObserver`. Rail `Bucket` SVG body → `<LiquidFill mode="bar" />`. Both consumers preserve their existing test ids on owned chrome (`bucket-${labelKey}-pct`, `bucket-fill`, etc.); SVG-internal test ids renamed from `bucket-*` to the new `liquid-*` namespace.
- All changes are spec- and plan-driven. Spec at `docs/superpowers/specs/2026-05-22-liquid-bucket-cursor-response-design.md`, plan at `docs/superpowers/plans/2026-05-22-liquid-bucket-cursor-response.md`. Both were iteratively codex-reviewed (5 spec findings + 6 plan findings applied, footers added).
- 5 in-flight codex findings caught during execution (Tasks 2/3/5/6 + 2 visual seam/polygon issues post-merge) were fixed inline.

## Test plan

- [ ] Manual smoke per spec §9:
  - Rail CTX/CACHE: cursor approach → tilt/lift/skew/wave-speedup; leave → ~600ms spring back to ambient.
  - Expanded panel CURRENT CONTEXT: same behavior in the wider rectangular tank.
  - Collapse ↔ expand toggling: DevTools shows no `[data-interactive="on"]` on detached nodes; no inline `transform` on freshly mounted nodes.
  - Close panel entirely: no pending rAF handles in Memory tab.
  - OS Reduce Motion toggled ON mid-session (no reload): water stops within one frame; toggle OFF → ambient slosh resumes.
- [ ] Visual: water reads as continuous flow — no GIF-style loop seam at the keyframe iteration boundary, no visible polygonal segments at wide-container scale.
- [ ] `npm run test` — 2486 tests pass repo-wide.
- [ ] `npm run lint && npm run type-check` — clean.