### PR TITLE
feat(agent): emit agent-cwd from codex transcript watcher

### DIFF
--- a/crates/backend/src/agent/adapter/codex/transcript.rs
+++ b/crates/backend/src/agent/adapter/codex/transcript.rs
@@ -18,8 +18,8 @@ use crate::agent::adapter::claude_code::test_runners::test_file_patterns::is_tes
 use crate::agent::adapter::claude_code::test_runners::timestamps::compute_duration_ms;
 use crate::agent::adapter::claude_code::test_runners::types::CapturedOutput;
 use crate::agent::adapter::types::ValidateTranscriptError;
-use crate::agent::events::{emit_agent_tool_call, emit_agent_turn};
-use crate::agent::types::{AgentToolCallEvent, AgentTurnEvent, ToolCallStatus};
+use crate::agent::events::{emit_agent_cwd, emit_agent_tool_call, emit_agent_turn};
+use crate::agent::types::{AgentCwdEvent, AgentToolCallEvent, AgentTurnEvent, ToolCallStatus};
 use crate::runtime::EventSink;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -43,6 +43,66 @@ struct InFlightToolCall {
 }
 
 type InFlightToolCalls = HashMap<String, InFlightToolCall>;
+
+/// Pull session-start cwd off a Codex rollout JSONL line.
+///
+/// Returns `Some(cwd)` ONLY for `session_meta` entries — the
+/// session-start anchor. `turn_context.cwd` is intentionally NOT
+/// matched here: empirically it just repeats `session_meta.cwd`
+/// every turn (no information value), and treating it as a live cwd
+/// would cause false reverts on reasoning-only turns after an
+/// `exec_command.workdir` transition has already moved us to a new
+/// directory. See spec section 1.
+fn extract_session_cwd(value: &Value) -> Option<&str> {
+    let event_type = value.get("type").and_then(Value::as_str)?;
+    if event_type != "session_meta" {
+        return None;
+    }
+    value
+        .get("payload")?
+        .get("cwd")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+
+/// Pull the mid-session workdir off a Codex `exec_command` function-call
+/// rollout entry. This is codex's de facto session cwd after the start
+/// (verified empirically — `turn_context.cwd` does not update on
+/// codex-driven cwd changes; `exec_command.arguments.workdir` does).
+///
+/// `arguments` is a JSON-encoded string per Codex's rollout schema —
+/// it must be parsed before reading `workdir`. Malformed JSON, missing
+/// fields, or empty strings all short-circuit to `None`.
+fn extract_exec_workdir(value: &Value) -> Option<String> {
+    if value.get("type").and_then(Value::as_str)? != "response_item" {
+        return None;
+    }
+    let payload = value.get("payload")?;
+    if payload.get("type").and_then(Value::as_str)? != "function_call" {
+        return None;
+    }
+    if payload.get("name").and_then(Value::as_str)? != "exec_command" {
+        return None;
+    }
+    let raw = payload.get("arguments").and_then(Value::as_str)?;
+    let args: Value = serde_json::from_str(raw).ok()?;
+    args.get("workdir")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Dispatcher returning the observed cwd from whichever source carries
+/// it. Tries the session_meta path first (cheap, no JSON re-parse),
+/// falls back to the exec_command workdir path. Returns
+/// `Option<String>` because the workdir path must return owned strings
+/// (parsed JSON allocates).
+fn extract_codex_cwd(value: &Value) -> Option<String> {
+    if let Some(cwd) = extract_session_cwd(value) {
+        return Some(cwd.to_string());
+    }
+    extract_exec_workdir(value)
+}
 
 pub(super) fn validate_transcript_path(
     transcript_path: &str,
@@ -139,6 +199,7 @@ fn tail_loop(
     let mut partial_line = String::new();
     let mut in_flight: InFlightToolCalls = HashMap::new();
     let mut num_turns = 0_u32;
+    let mut last_cwd: Option<String> = None;
     let mut emitter = TestRunEmitter::new(events.clone());
 
     while !stop_flag.load(Ordering::Acquire) {
@@ -164,6 +225,7 @@ fn tail_loop(
                         &mut emitter,
                         &mut in_flight,
                         &mut num_turns,
+                        &mut last_cwd,
                     );
                     partial_line.clear();
                     continue;
@@ -182,6 +244,7 @@ fn tail_loop(
                     &mut emitter,
                     &mut in_flight,
                     &mut num_turns,
+                    &mut last_cwd,
                 );
             }
             Err(e) => {
@@ -200,11 +263,34 @@ fn process_line(
     emitter: &mut TestRunEmitter,
     in_flight: &mut InFlightToolCalls,
     num_turns: &mut u32,
+    last_cwd: &mut Option<String>,
 ) {
     let value: Value = match serde_json::from_str(line) {
         Ok(value) => value,
         Err(_) => return,
     };
+
+    // Emit agent-cwd on transitions only. Codex's two cwd sources are
+    // session_meta.payload.cwd (session start) and
+    // response_item.payload.arguments.workdir for exec_command function
+    // calls (mid-session). turn_context.cwd is intentionally NOT a
+    // source — see spec section 1 and the regression test
+    // `process_line_turn_context_after_exec_command_does_not_revert`.
+    if let Some(observed) = extract_codex_cwd(&value) {
+        if last_cwd
+            .as_deref()
+            .map_or(true, |seen| seen != observed.as_str())
+        {
+            let event = AgentCwdEvent {
+                session_id: session_id.to_string(),
+                cwd: observed.clone(),
+            };
+            if let Err(e) = emit_agent_cwd(events.as_ref(), &event) {
+                log::warn!("Failed to emit agent-cwd event: {}", e);
+            }
+            *last_cwd = Some(observed);
+        }
+    }
 
     match value.get("type").and_then(Value::as_str) {
         Some("response_item") => {
@@ -949,5 +1035,333 @@ mod tests {
         });
 
         assert!(custom_tool_output_failed(&payload));
+    }
+
+    // ---- extract_session_cwd unit tests (v2: session_meta ONLY) ----
+
+    #[test]
+    fn extract_session_cwd_session_meta_returns_cwd() {
+        let v = json!({"type": "session_meta", "payload": {"cwd": "/workspace/A"}});
+        assert_eq!(extract_session_cwd(&v), Some("/workspace/A"));
+    }
+
+    #[test]
+    fn extract_session_cwd_turn_context_returns_none() {
+        // v2 spec section 1: turn_context is INTENTIONALLY NOT a cwd source.
+        // Codex's turn_context.cwd is pinned to session-start and treating
+        // it as live would cause false reverts after exec_command transitions.
+        // This test is a defensive guard against re-introduction.
+        let v = json!({"type": "turn_context", "payload": {"cwd": "/workspace/A"}});
+        assert_eq!(extract_session_cwd(&v), None);
+    }
+
+    #[test]
+    fn extract_session_cwd_other_type_returns_none() {
+        let v = json!({"type": "event_msg", "payload": {"cwd": "/workspace/A"}});
+        assert_eq!(extract_session_cwd(&v), None);
+    }
+
+    #[test]
+    fn extract_session_cwd_empty_string_returns_none() {
+        let v = json!({"type": "session_meta", "payload": {"cwd": ""}});
+        assert_eq!(extract_session_cwd(&v), None);
+    }
+
+    // ---- extract_exec_workdir unit tests (the mid-session signal) ----
+
+    #[test]
+    fn extract_exec_workdir_happy_path() {
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "c1",
+                "arguments": "{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v).as_deref(), Some("/workspace/B"));
+    }
+
+    #[test]
+    fn extract_exec_workdir_other_event_type_returns_none() {
+        // event_msg carrying a function_call-shaped payload should still
+        // be rejected — the outer event type gate is response_item.
+        let v = json!({
+            "type": "event_msg",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": "{\"workdir\":\"/x\"}"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v), None);
+    }
+
+    #[test]
+    fn extract_exec_workdir_non_function_call_returns_none() {
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "exec_command",
+                "input": "{\"workdir\":\"/x\"}"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v), None);
+    }
+
+    #[test]
+    fn extract_exec_workdir_non_exec_command_returns_none() {
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "read_file",
+                "arguments": "{\"path\":\"/x\"}"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v), None);
+    }
+
+    #[test]
+    fn extract_exec_workdir_malformed_arguments_json_returns_none() {
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": "{not json"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v), None);
+    }
+
+    #[test]
+    fn extract_exec_workdir_missing_workdir_field_returns_none() {
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": "{\"cmd\":\"ls\"}"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v), None);
+    }
+
+    // ---- process_line transition-semantics tests ----
+
+    fn empty_in_flight() -> InFlightToolCalls {
+        HashMap::new()
+    }
+
+    #[test]
+    fn process_line_first_cwd_always_emits() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let line = r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}"#;
+        process_line(
+            line,
+            "sid-1",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+        );
+
+        let cwd_events: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-cwd")
+            .collect();
+        assert_eq!(cwd_events.len(), 1);
+        assert_eq!(cwd_events[0].1["cwd"], "/workspace/A");
+        assert_eq!(last_cwd.as_deref(), Some("/workspace/A"));
+    }
+
+    #[test]
+    fn process_line_repeated_cwd_across_sources_suppresses() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let lines = [
+            r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/A\"}"}}"#,
+        ];
+        for line in lines {
+            process_line(
+                line,
+                "sid-1",
+                None,
+                &events,
+                &mut emitter,
+                &mut in_flight,
+                &mut num_turns,
+                &mut last_cwd,
+            );
+        }
+
+        let cwd_events: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-cwd")
+            .collect();
+        assert_eq!(cwd_events.len(), 1);
+        assert_eq!(cwd_events[0].1["cwd"], "/workspace/A");
+    }
+
+    #[test]
+    fn process_line_cwd_transition_across_sources_emits() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let lines = [
+            r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c2","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/A\"}"}}"#,
+        ];
+        for line in lines {
+            process_line(
+                line,
+                "sid-1",
+                None,
+                &events,
+                &mut emitter,
+                &mut in_flight,
+                &mut num_turns,
+                &mut last_cwd,
+            );
+        }
+
+        let cwd_events: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-cwd")
+            .collect();
+        assert_eq!(cwd_events.len(), 3);
+        assert_eq!(cwd_events[0].1["cwd"], "/workspace/A");
+        assert_eq!(cwd_events[1].1["cwd"], "/workspace/B");
+        assert_eq!(cwd_events[2].1["cwd"], "/workspace/A");
+    }
+
+    /// v2-critical regression guard. Codex review on the v2 spec (HIGH)
+    /// flagged that including turn_context.cwd as a cwd source would
+    /// cause a false revert: after session_meta(A) → exec_command(B),
+    /// the next turn's turn_context(A) (pinned to session-start) would
+    /// emit agent-cwd=A and bounce the pane chip back. This test locks
+    /// in the v2 design decision to skip turn_context entirely.
+    /// If anyone re-adds turn_context to extract_session_cwd, this
+    /// test fires.
+    #[test]
+    fn process_line_turn_context_after_exec_command_does_not_revert() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let lines = [
+            r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:02Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/workspace/A"}}"#,
+        ];
+        for line in lines {
+            process_line(
+                line,
+                "sid-1",
+                None,
+                &events,
+                &mut emitter,
+                &mut in_flight,
+                &mut num_turns,
+                &mut last_cwd,
+            );
+        }
+
+        let cwd_events: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-cwd")
+            .collect();
+        assert_eq!(
+            cwd_events.len(),
+            2,
+            "turn_context.cwd MUST NOT emit a cwd event \
+             (would cause false revert to session-start after exec_command transition)"
+        );
+        assert_eq!(cwd_events[0].1["cwd"], "/workspace/A");
+        assert_eq!(cwd_events[1].1["cwd"], "/workspace/B");
+        // Crucially, last_cwd should still be B — the worktree we're in.
+        assert_eq!(last_cwd.as_deref(), Some("/workspace/B"));
+    }
+
+    // ---- end-to-end watcher test (with v2 regression guard inline) ----
+
+    #[test]
+    fn start_tailing_emits_cwd_transitions_in_order() {
+        let sink = Arc::new(FakeEventSink::new());
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let transcript_path = tmp.path().join("rollout.jsonl");
+
+        // 7 lines, 3 expected emissions:
+        //   1. session_meta cwd=/workspace/A             (emit)
+        //   2. turn_context cwd=/workspace/A             (no emit — extractor rejects turn_context)
+        //   3. exec_command workdir=/workspace/B         (emit — transition)
+        //   4. event_msg task_started                    (no emit)
+        //   5. exec_command workdir=/workspace/B         (suppressed — same as last_cwd)
+        //   6. turn_context cwd=/workspace/A             (no emit — REGRESSION GUARD: must not revert)
+        //   7. exec_command workdir=/workspace/A         (emit — transition back)
+        write_rollout(
+            &transcript_path,
+            &[
+                json!({"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}),
+                json!({"timestamp":"2026-05-22T10:00:01Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/workspace/A"}}),
+                json!({"timestamp":"2026-05-22T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"}}),
+                json!({"timestamp":"2026-05-22T10:00:03Z","type":"event_msg","payload":{"type":"task_started"}}),
+                json!({"timestamp":"2026-05-22T10:00:04Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c2","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"}}),
+                json!({"timestamp":"2026-05-22T10:00:04.5Z","type":"turn_context","payload":{"turn_id":"t2","cwd":"/workspace/A"}}),
+                json!({"timestamp":"2026-05-22T10:00:05Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c3","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/A\"}"}}),
+            ],
+        );
+
+        let handle = start_tailing(sink.clone(), "sid-cwd".to_string(), transcript_path, None)
+            .expect("start tailing");
+
+        std::thread::sleep(Duration::from_millis(750));
+        handle.stop();
+        std::thread::sleep(Duration::from_millis(100));
+
+        let cwd_events: Vec<Value> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(event, _)| event == "agent-cwd")
+            .map(|(_, payload)| payload)
+            .collect();
+
+        assert_eq!(cwd_events.len(), 3, "expected exactly 3 cwd transitions");
+        assert_eq!(cwd_events[0]["cwd"], "/workspace/A");
+        assert_eq!(cwd_events[1]["cwd"], "/workspace/B");
+        assert_eq!(cwd_events[2]["cwd"], "/workspace/A");
+        for ev in &cwd_events {
+            assert_eq!(ev["sessionId"], "sid-cwd");
+        }
     }
 }

--- a/crates/backend/src/agent/types.rs
+++ b/crates/backend/src/agent/types.rs
@@ -156,12 +156,25 @@ pub struct AgentStatusEvent {
 
 /// Event emitted when the agent's tracked working directory changes.
 ///
-/// Sourced from the structured `cwd` field that Claude Code (and Codex,
-/// pending follow-up) writes on every transcript JSONL entry. This is the
-/// authoritative signal for "where the agent currently is" — it picks up
-/// tool-call-driven moves like `EnterWorktree` that intentionally do NOT
-/// mutate the interactive shell's `$PWD`, so neither OSC 7 nor PTY text
-/// patterns can catch them.
+/// Sourced from each adapter's structured cwd channel in its transcript
+/// JSONL:
+/// - **Claude Code** writes a top-level `cwd` field on every transcript
+///   entry; transitions fire as soon as the next line is parsed.
+/// - **Codex** writes cwd in two places the watcher reads:
+///   `session_meta.payload.cwd` (once, at session start) and
+///   `response_item.payload.arguments.workdir` for `exec_command`
+///   function calls (the mid-session signal — fires whenever codex
+///   runs a tool command in a new directory). Codex also writes
+///   `turn_context.payload.cwd` on every turn, but the watcher
+///   intentionally ignores that field because it's pinned to the
+///   session-start value and would cause false reverts after a
+///   mid-session `exec_command.workdir` transition.
+///
+/// In both cases this is the authoritative signal for "where the agent
+/// currently is" — it picks up tool-call-driven moves like Claude's
+/// `EnterWorktree` and codex's "switch to worktree" navigation that
+/// intentionally do NOT mutate the interactive shell's `$PWD`, so
+/// neither OSC 7 nor PTY text patterns can catch them.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]

--- a/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
+++ b/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
@@ -972,9 +972,14 @@ EOF
 
 **Files:** none modified.
 
-- [ ] **Step 1: Run the full backend test suite**
+- [ ] **Step 1: Run the full backend test suite (matches CI)**
 
-Run: `cargo test -p vimeflow --lib`
+Run: `cargo test -p vimeflow`
+
+This runs BOTH the lib tests (where the new tests in Tasks 1–3 live)
+AND the `crates/backend/tests/*` integration tests. Using `--lib`
+here would skip integration tests and could let an implementation
+pass the plan while failing CI's full backend gate.
 
 Expected: all tests pass. New tests added in Tasks 1–3 = 15.
 

--- a/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
+++ b/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
@@ -95,7 +95,17 @@ No new files. No new fixture files — tests use inline `json!()` values per the
 
 - [ ] **Step 2: Run the tests to verify they fail with a compile error**
 
-Run: `cargo test -p vimeflow --lib extract_session_cwd 2>&1 | tail -20`
+Run: `cargo test -p vimeflow --lib extract_session_cwd`
+
+> **Important — exit-code handling for all `Run:` commands in this plan:**
+> Do NOT pipe these commands through `| tail` or `| head`. In bash a piped
+> command's exit code is the exit code of the LAST stage; `tail`'s exit
+> code masks a failing `cargo test` / `npm test` / `npm run type-check`
+> and the executing agent will read the run as a pass. If output volume
+> is a concern, use `2>&1 | tee /tmp/<name>.log` or check
+> `${PIPESTATUS[0]}` explicitly. The expected-output blocks below show
+> what the relevant summary line looks like — verify it actually appears
+> in the unfiltered output before continuing.
 
 Expected: `error[E0425]: cannot find function 'extract_session_cwd'` (red — the helper doesn't exist yet).
 
@@ -130,7 +140,7 @@ fn extract_session_cwd(value: &Value) -> Option<&str> {
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
-Run: `cargo test -p vimeflow --lib extract_session_cwd 2>&1 | tail -15`
+Run: `cargo test -p vimeflow --lib extract_session_cwd`
 
 Expected: `test result: ok. 7 passed; 0 failed`.
 
@@ -373,7 +383,7 @@ EOF
 
 - [ ] **Step 2: Run the new tests to verify they fail with a compile error**
 
-Run: `cargo test -p vimeflow --lib process_line_first_cwd_always_emits 2>&1 | tail -20`
+Run: `cargo test -p vimeflow --lib process_line_first_cwd_always_emits`
 
 Expected: compile error — `process_line` only takes 7 args (no `last_cwd`), `extract_session_cwd` is dead-code, no emission code in `process_line`. **Red.**
 
@@ -565,7 +575,7 @@ fn process_line(
 
 - [ ] **Step 8: Run all four new tests to verify they pass**
 
-Run: `cargo test -p vimeflow --lib codex::transcript 2>&1 | tail -25`
+Run: `cargo test -p vimeflow --lib codex::transcript`
 
 Expected: all 11 new tests in `codex::transcript::tests` pass (7 helper + 3 transition + 1 e2e), plus the existing tests in the module still pass. **Green.**
 
@@ -573,7 +583,7 @@ If `start_tailing_emits_cwd_transitions_in_order` is flaky (occasional `assert_e
 
 - [ ] **Step 9: Run the full codex transcript test module to catch regressions**
 
-Run: `cargo test -p vimeflow --lib codex::transcript::tests 2>&1 | tail -8`
+Run: `cargo test -p vimeflow --lib codex::transcript::tests`
 
 Expected: `test result: ok. <N> passed; 0 failed`, where N is the pre-PR count plus 11.
 
@@ -666,7 +676,7 @@ If `git diff` shows extra changes outside the JSDoc, something else regenerated 
 
 - [ ] **Step 4: Confirm formatters pass**
 
-Run: `npm run format:check && npm run type-check 2>&1 | tail -8`
+Run: `npm run format:check && npm run type-check`
 
 Expected: both clean.
 
@@ -771,7 +781,7 @@ Replace with:
 
 - [ ] **Step 3: Confirm lints + types + tests pass**
 
-Run: `npm run lint && npm run format:check && npm run type-check && npm test 2>&1 | tail -10`
+Run: `npm run lint && npm run format:check && npm run type-check && npm test`
 
 Expected: all four clean.
 
@@ -802,19 +812,19 @@ EOF
 
 - [ ] **Step 1: Run the full backend test suite**
 
-Run: `cargo test -p vimeflow --lib 2>&1 | tail -10`
+Run: `cargo test -p vimeflow --lib`
 
 Expected: all tests pass. Note the test count — should be the pre-PR count plus 11 (the new tests added in Tasks 1 + 2).
 
 - [ ] **Step 2: Run the full frontend test suite**
 
-Run: `npm test 2>&1 | tail -10`
+Run: `npm test`
 
 Expected: all tests pass.
 
 - [ ] **Step 3: Run lint + format + type-check**
 
-Run: `npm run lint && npm run format:check && npm run type-check 2>&1 | tail -6`
+Run: `npm run lint && npm run format:check && npm run type-check`
 
 Expected: all three clean.
 
@@ -822,22 +832,43 @@ Expected: all three clean.
 
 Run: `git log --oneline main..HEAD`
 
-Expected: four behavior/doc commits beyond the spec commits — Tasks 1 through 4:
+Expected: four behavior/doc commits from Tasks 1–4 layered on top of
+the four `docs/` commits already produced by the `/lifeline:planner`
+phase (1 plan + 3 spec). Reverse-chronological order:
 
 ```
-<sha> docs(workspace): clarify agent-cwd source per adapter
-<sha> docs(agent): update AgentCwdEvent doc comment for codex shape
-<sha> feat(agent): emit agent-cwd from codex transcript watcher
-<sha> test(agent): add extract_session_cwd helper for codex rollouts
+<sha> docs(workspace): clarify agent-cwd source per adapter            ← Task 4
+<sha> docs(agent): update AgentCwdEvent doc comment for codex shape    ← Task 3
+<sha> feat(agent): emit agent-cwd from codex transcript watcher        ← Task 2
+<sha> test(agent): add extract_session_cwd helper for codex rollouts   ← Task 1
+<sha> docs(plan): codex-transcript-cwd-parser                          ← planner
+<sha> docs(spec): mark spec codex-reviewed                             ← planner
+<sha> docs(spec): apply codex feedback                                 ← planner
+<sha> docs(spec): codex-transcript-cwd-parser                          ← planner
 ```
 
-(Plus the three pre-existing `docs(spec):` commits from the planner phase.)
+Eight commits total. If you see fewer than eight, a task commit was
+skipped or squashed — investigate before pushing.
 
-- [ ] **Step 5: Check the new file size in `codex/transcript.rs`**
+- [ ] **Step 5: Note the new file size in `codex/transcript.rs`** (informational only — does NOT block)
 
 Run: `wc -l crates/backend/src/agent/adapter/codex/transcript.rs`
 
-Expected: 978–990 lines (was 953; added ~25 lines of behavior + ~150 lines of tests = ~25–35 line growth at the body level, ~150 line growth at the test-module level). The file is now further over the rules' 800-line ceiling. This is acknowledged debt per spec section 2 "Out of scope" — a separate refactor PR splits it. Do NOT split in this PR.
+The file was 953 lines pre-PR and grows by roughly:
+
+- ~33 lines of behavior code (helper + signature + emission + state).
+- ~225 lines of tests (7 helper + 3 transition + 1 e2e + a tiny
+  `empty_in_flight` helper).
+
+Expected post-PR size: roughly **1180–1230 lines**. The exact number
+is brittle (formatter passes, comment density, etc.) — this step is
+informational. If the count is wildly outside that range (e.g.
+< 1100 or > 1300), check whether tests were dropped or duplicated
+before pushing. Otherwise, accept the size and move on.
+
+The file is now further over the rules' 800-line ceiling. This is
+acknowledged debt per spec section 2 "Out of scope" — a separate
+refactor PR splits it. **Do NOT split in this PR.**
 
 - [ ] **Step 6: (No commit — verification only.)**
 

--- a/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
+++ b/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
@@ -1,0 +1,880 @@
+# Codex Transcript Cwd Parser Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port PR #239's `agent-cwd` extraction to the Codex transcript watcher so Codex panes get the same structured cwd channel Claude Code panes have, with the per-turn temporal contract documented in the spec.
+
+**Architecture:** Add a private `extract_session_cwd` helper to `codex/transcript.rs`. Thread `last_cwd: Option<String>` through the `tail_loop` and `process_line`. Pre-match cwd extraction emits `AgentCwdEvent` on transitions only. Update doc-comments + regenerate ts-rs binding. Update two frontend JSDoc blocks.
+
+**Tech Stack:** Rust (backend, `crates/backend`), `serde_json::Value`, `ts-rs` (binding regen), TypeScript (frontend doc-comments only).
+
+**Reference spec:** [`docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md`](../specs/2026-05-22-codex-transcript-cwd-parser-design.md) (codex-reviewed, 4 review passes).
+
+---
+
+## File Structure
+
+- **Modify** `crates/backend/src/agent/adapter/codex/transcript.rs` — add `extract_session_cwd` helper, `last_cwd` state in `tail_loop`, `last_cwd` parameter on `process_line`, pre-match emission, two new imports, 11 new tests (7 helper + 3 transition + 1 e2e).
+- **Modify** `crates/backend/src/agent/types.rs` — update `AgentCwdEvent` doc comment (lines 157–164) to describe both adapters' real shapes; drop "pending follow-up" / "every transcript JSONL entry".
+- **Regenerate** `src/bindings/AgentCwdEvent.ts` — via `npm run generate:bindings` (runs `cargo test ... export_bindings && prettier --write src/bindings/`). Not hand-edited.
+- **Modify** `src/features/agent-status/types/index.ts` — JSDoc block above `cwd: string | null` field (lines 54–62) to drop "every transcript JSONL entry (Claude Code today; Codex follow-up)" and describe both adapters.
+- **Modify** `src/features/workspace/WorkspaceView.tsx` — comment block above `agentStatus.cwd → updatePaneCwd` bridge (lines 315–321), same correction.
+
+No new files. No new fixture files — tests use inline `json!()` values per the codebase convention in `codex/transcript.rs::start_tailing_replays_tool_calls_turns_and_test_runs` (around line 791).
+
+---
+
+## Task 1: Add `extract_session_cwd` helper with unit tests
+
+**Files:**
+
+- Modify: `crates/backend/src/agent/adapter/codex/transcript.rs` — add helper near top (above `validate_transcript_path`, around line 47), add 7 unit tests inside existing `#[cfg(test)] mod tests` block (at end of file, around line 736+).
+
+### Step 1: Write the failing tests
+
+- [ ] **Step 1: Add 7 unit tests at the bottom of the existing `#[cfg(test)] mod tests` block in `crates/backend/src/agent/adapter/codex/transcript.rs`** (just before the closing `}` of the module).
+
+```rust
+    // ---- extract_session_cwd unit tests (added by codex-transcript-cwd PR) ----
+
+    #[test]
+    fn extract_session_cwd_session_meta_returns_cwd() {
+        let v = json!({"type": "session_meta", "payload": {"cwd": "/workspace/A"}});
+        assert_eq!(extract_session_cwd(&v), Some("/workspace/A"));
+    }
+
+    #[test]
+    fn extract_session_cwd_turn_context_returns_cwd() {
+        let v = json!({"type": "turn_context", "payload": {"cwd": "/workspace/A"}});
+        assert_eq!(extract_session_cwd(&v), Some("/workspace/A"));
+    }
+
+    #[test]
+    fn extract_session_cwd_event_msg_returns_none() {
+        // Defensive: even if a future schema put `cwd` in event_msg.payload,
+        // the type gate rejects it. Session cwd only lives on session_meta
+        // + turn_context as of cli_version 0.132.0.
+        let v = json!({"type": "event_msg", "payload": {"cwd": "/workspace/A"}});
+        assert_eq!(extract_session_cwd(&v), None);
+    }
+
+    #[test]
+    fn extract_session_cwd_response_item_returns_none() {
+        // function_call arguments.workdir is per-command scratch, NOT
+        // session cwd. The type gate rejects response_item entirely.
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "arguments": "{\"workdir\":\"/workspace/A\"}"
+            }
+        });
+        assert_eq!(extract_session_cwd(&v), None);
+    }
+
+    #[test]
+    fn extract_session_cwd_missing_payload_returns_none() {
+        let v = json!({"type": "turn_context"});
+        assert_eq!(extract_session_cwd(&v), None);
+    }
+
+    #[test]
+    fn extract_session_cwd_missing_cwd_returns_none() {
+        let v = json!({"type": "turn_context", "payload": {}});
+        assert_eq!(extract_session_cwd(&v), None);
+    }
+
+    #[test]
+    fn extract_session_cwd_empty_string_returns_none() {
+        let v = json!({"type": "turn_context", "payload": {"cwd": ""}});
+        assert_eq!(extract_session_cwd(&v), None);
+    }
+```
+
+> **Note:** `serde_json::json` is already imported in the test module's `use serde_json::json;` line (around line 740 in the file).
+
+- [ ] **Step 2: Run the tests to verify they fail with a compile error**
+
+Run: `cargo test -p vimeflow --lib extract_session_cwd 2>&1 | tail -20`
+
+Expected: `error[E0425]: cannot find function 'extract_session_cwd'` (red — the helper doesn't exist yet).
+
+- [ ] **Step 3: Add the `extract_session_cwd` helper near the top of `crates/backend/src/agent/adapter/codex/transcript.rs`**
+
+Insert this function immediately above the existing `pub(super) fn validate_transcript_path` (around line 47). Place it after the `type InFlightToolCalls = HashMap<…>;` declaration (around line 45).
+
+```rust
+/// Pull session-level cwd off a Codex rollout JSONL line.
+///
+/// Returns `Some(cwd)` only for the two event types that actually carry
+/// session cwd in the rollout schema as of `cli_version 0.132.0`:
+///   - `session_meta.payload.cwd` — fires once at session start.
+///   - `turn_context.payload.cwd` — fires per turn.
+///
+/// Empty strings are filtered out at the extraction site, matching the
+/// Claude Code transcript watcher's guard. Function-call
+/// `arguments.workdir` is per-command scratch and deliberately not
+/// considered session cwd.
+fn extract_session_cwd(value: &Value) -> Option<&str> {
+    let event_type = value.get("type").and_then(Value::as_str)?;
+    if event_type != "session_meta" && event_type != "turn_context" {
+        return None;
+    }
+    value
+        .get("payload")?
+        .get("cwd")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p vimeflow --lib extract_session_cwd 2>&1 | tail -15`
+
+Expected: `test result: ok. 7 passed; 0 failed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/agent/adapter/codex/transcript.rs
+git commit -m "$(cat <<'EOF'
+test(agent): add extract_session_cwd helper for codex rollouts
+
+Pure extraction helper scoped to session_meta + turn_context — the only
+two event types in the Codex rollout JSONL schema (cli_version 0.132.0)
+that carry session-level cwd. Seven unit tests cover the happy paths,
+the type-gate rejections, and the missing-field / empty-string guards.
+
+The helper is dead-code until Task 2 wires it into process_line; the
+function is not marked #[allow(dead_code)] because the unit tests count
+as uses for the dead-code lint.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Wire emission into `tail_loop` + `process_line`, with transition tests + e2e
+
+**Files:**
+
+- Modify: `crates/backend/src/agent/adapter/codex/transcript.rs`
+  - Add 2 new `use` lines at the top (around line 21–23).
+  - Add `let mut last_cwd: Option<String> = None;` in `tail_loop` (around line 141).
+  - Extend `process_line` signature with `last_cwd: &mut Option<String>` (around line 195).
+  - Add cwd extraction + emission in `process_line` body (after the `match serde_json::from_str` early-return, before the existing `match value.get("type")...`).
+  - Update both `process_line(...)` call sites in `tail_loop` (around lines 159 and 177) to pass `&mut last_cwd`.
+  - Add 3 transition-semantics unit tests + 1 e2e test in the existing `mod tests` block.
+
+### Step 1: Write the failing tests
+
+- [ ] **Step 1: Add 3 transition tests + 1 e2e test at the bottom of `mod tests` in the same file, just after the 7 helper tests from Task 1.**
+
+```rust
+    // ---- process_line transition-semantics tests ----
+
+    fn empty_in_flight() -> InFlightToolCalls {
+        HashMap::new()
+    }
+
+    #[test]
+    fn process_line_first_cwd_always_emits() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let line = r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}"#;
+        process_line(
+            line,
+            "sid-1",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+        );
+
+        let cwd_events: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-cwd")
+            .collect();
+        assert_eq!(cwd_events.len(), 1);
+        assert_eq!(cwd_events[0].1["cwd"], "/workspace/A");
+        assert_eq!(last_cwd.as_deref(), Some("/workspace/A"));
+    }
+
+    #[test]
+    fn process_line_repeated_cwd_suppresses() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let lines = [
+            r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/workspace/A"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:02Z","type":"turn_context","payload":{"turn_id":"t2","cwd":"/workspace/A"}}"#,
+        ];
+        for line in lines {
+            process_line(
+                line,
+                "sid-1",
+                None,
+                &events,
+                &mut emitter,
+                &mut in_flight,
+                &mut num_turns,
+                &mut last_cwd,
+            );
+        }
+
+        let cwd_events: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-cwd")
+            .collect();
+        assert_eq!(cwd_events.len(), 1);
+        assert_eq!(cwd_events[0].1["cwd"], "/workspace/A");
+    }
+
+    #[test]
+    fn process_line_cwd_transition_emits() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let lines = [
+            r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/workspace/B"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:02Z","type":"turn_context","payload":{"turn_id":"t2","cwd":"/workspace/A"}}"#,
+        ];
+        for line in lines {
+            process_line(
+                line,
+                "sid-1",
+                None,
+                &events,
+                &mut emitter,
+                &mut in_flight,
+                &mut num_turns,
+                &mut last_cwd,
+            );
+        }
+
+        let cwd_events: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-cwd")
+            .collect();
+        assert_eq!(cwd_events.len(), 3);
+        assert_eq!(cwd_events[0].1["cwd"], "/workspace/A");
+        assert_eq!(cwd_events[1].1["cwd"], "/workspace/B");
+        assert_eq!(cwd_events[2].1["cwd"], "/workspace/A");
+        for (_name, payload) in &cwd_events {
+            assert_eq!(payload["sessionId"], "sid-1");
+        }
+    }
+
+    // ---- end-to-end watcher test ----
+
+    #[test]
+    fn start_tailing_emits_cwd_transitions_in_order() {
+        let sink = Arc::new(FakeEventSink::new());
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let transcript_path = tmp.path().join("rollout.jsonl");
+
+        // 6 lines, 3 expected emissions:
+        //   1. session_meta cwd=/workspace/A   (emit)
+        //   2. turn_context cwd=/workspace/A   (suppressed)
+        //   3. turn_context cwd=/workspace/B   (emit)
+        //   4. event_msg noise                 (no cwd emit)
+        //   5. response_item noise             (no cwd emit)
+        //   6. turn_context cwd=/workspace/A   (emit)
+        write_rollout(
+            &transcript_path,
+            &[
+                json!({
+                    "timestamp": "2026-05-22T10:00:00Z",
+                    "type": "session_meta",
+                    "payload": { "id": "sid-cwd", "cwd": "/workspace/A" }
+                }),
+                json!({
+                    "timestamp": "2026-05-22T10:00:01Z",
+                    "type": "turn_context",
+                    "payload": { "turn_id": "t1", "cwd": "/workspace/A" }
+                }),
+                json!({
+                    "timestamp": "2026-05-22T10:00:02Z",
+                    "type": "turn_context",
+                    "payload": { "turn_id": "t2", "cwd": "/workspace/B" }
+                }),
+                json!({
+                    "timestamp": "2026-05-22T10:00:03Z",
+                    "type": "event_msg",
+                    "payload": { "type": "task_started" }
+                }),
+                json!({
+                    "timestamp": "2026-05-22T10:00:04Z",
+                    "type": "response_item",
+                    "payload": { "type": "function_call", "call_id": "c1", "name": "noop", "arguments": "{}" }
+                }),
+                json!({
+                    "timestamp": "2026-05-22T10:00:05Z",
+                    "type": "turn_context",
+                    "payload": { "turn_id": "t3", "cwd": "/workspace/A" }
+                }),
+            ],
+        );
+
+        let handle = start_tailing(
+            sink.clone(),
+            "sid-cwd".to_string(),
+            transcript_path,
+            None,
+        )
+        .expect("start tailing");
+
+        std::thread::sleep(Duration::from_millis(750));
+        handle.stop();
+        std::thread::sleep(Duration::from_millis(100));
+
+        let cwd_events: Vec<Value> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(event, _)| event == "agent-cwd")
+            .map(|(_, payload)| payload)
+            .collect();
+
+        assert_eq!(cwd_events.len(), 3, "expected exactly 3 cwd transitions");
+        assert_eq!(cwd_events[0]["cwd"], "/workspace/A");
+        assert_eq!(cwd_events[1]["cwd"], "/workspace/B");
+        assert_eq!(cwd_events[2]["cwd"], "/workspace/A");
+        for ev in &cwd_events {
+            assert_eq!(ev["sessionId"], "sid-cwd");
+        }
+    }
+```
+
+> **Note:** `write_rollout`, `FakeEventSink`, `Arc`, `Duration`, `json!`, `Value`, and `tempfile` are all already imported / in-scope in this `mod tests` block — verify the `use` lines around line 738–740 include `use crate::runtime::FakeEventSink;` and `use serde_json::json;`. If any are missing, add them.
+
+- [ ] **Step 2: Run the new tests to verify they fail with a compile error**
+
+Run: `cargo test -p vimeflow --lib process_line_first_cwd_always_emits 2>&1 | tail -20`
+
+Expected: compile error — `process_line` only takes 7 args (no `last_cwd`), `extract_session_cwd` is dead-code, no emission code in `process_line`. **Red.**
+
+### Step 2: Wire the implementation
+
+- [ ] **Step 3: Add two new imports at the top of `crates/backend/src/agent/adapter/codex/transcript.rs`**
+
+Find the existing import block (around lines 19–23):
+
+```rust
+use crate::agent::adapter::base::TranscriptHandle;
+use crate::agent::adapter::claude_code::test_runners::build::{maybe_build_snapshot, BuildArgs};
+use crate::agent::adapter::claude_code::test_runners::emitter::TestRunEmitter;
+use crate::agent::adapter::claude_code::test_runners::matcher::{match_command, MatchedCommand};
+use crate::agent::adapter::claude_code::test_runners::test_file_patterns::is_test_file;
+use crate::agent::adapter::claude_code::test_runners::timestamps::compute_duration_ms;
+use crate::agent::adapter::claude_code::test_runners::types::CapturedOutput;
+use crate::agent::adapter::types::ValidateTranscriptError;
+use crate::agent::events::{emit_agent_tool_call, emit_agent_turn};
+use crate::agent::types::{AgentToolCallEvent, AgentTurnEvent, ToolCallStatus};
+use crate::runtime::EventSink;
+```
+
+Modify the last two `use crate::agent::*` lines to add `emit_agent_cwd` and `AgentCwdEvent`:
+
+```rust
+use crate::agent::events::{emit_agent_cwd, emit_agent_tool_call, emit_agent_turn};
+use crate::agent::types::{AgentCwdEvent, AgentToolCallEvent, AgentTurnEvent, ToolCallStatus};
+```
+
+- [ ] **Step 4: Add `last_cwd` state in `tail_loop`**
+
+Find `fn tail_loop(…)` (around line 130). At the top of the function body, locate this block (around lines 138–141):
+
+```rust
+    let mut reader = BufReader::new(file);
+    let mut line_buf = String::new();
+    let mut partial_line = String::new();
+    let mut in_flight: InFlightToolCalls = HashMap::new();
+    let mut num_turns = 0_u32;
+    let mut emitter = TestRunEmitter::new(events.clone());
+```
+
+Add `let mut last_cwd: Option<String> = None;` immediately after `let mut num_turns = 0_u32;`:
+
+```rust
+    let mut reader = BufReader::new(file);
+    let mut line_buf = String::new();
+    let mut partial_line = String::new();
+    let mut in_flight: InFlightToolCalls = HashMap::new();
+    let mut num_turns = 0_u32;
+    let mut last_cwd: Option<String> = None;
+    let mut emitter = TestRunEmitter::new(events.clone());
+```
+
+- [ ] **Step 5: Update the partial-line branch's `process_line` call (around lines 158–168)**
+
+Find:
+
+```rust
+                if !partial_line.is_empty() {
+                    partial_line.push_str(&line_buf);
+                    process_line(
+                        partial_line.trim_end_matches('\n'),
+                        &session_id,
+                        cwd.as_deref(),
+                        &events,
+                        &mut emitter,
+                        &mut in_flight,
+                        &mut num_turns,
+                    );
+                    partial_line.clear();
+                    continue;
+                }
+```
+
+Add `&mut last_cwd,` as the final argument:
+
+```rust
+                if !partial_line.is_empty() {
+                    partial_line.push_str(&line_buf);
+                    process_line(
+                        partial_line.trim_end_matches('\n'),
+                        &session_id,
+                        cwd.as_deref(),
+                        &events,
+                        &mut emitter,
+                        &mut in_flight,
+                        &mut num_turns,
+                        &mut last_cwd,
+                    );
+                    partial_line.clear();
+                    continue;
+                }
+```
+
+- [ ] **Step 6: Update the single-line branch's `process_line` call (around lines 176–185)**
+
+Find:
+
+```rust
+                process_line(
+                    line,
+                    &session_id,
+                    cwd.as_deref(),
+                    &events,
+                    &mut emitter,
+                    &mut in_flight,
+                    &mut num_turns,
+                );
+```
+
+Add `&mut last_cwd,`:
+
+```rust
+                process_line(
+                    line,
+                    &session_id,
+                    cwd.as_deref(),
+                    &events,
+                    &mut emitter,
+                    &mut in_flight,
+                    &mut num_turns,
+                    &mut last_cwd,
+                );
+```
+
+- [ ] **Step 7: Extend `process_line` signature (around line 195) and add emission body**
+
+Find:
+
+```rust
+fn process_line(
+    line: &str,
+    session_id: &str,
+    cwd: Option<&Path>,
+    events: &Arc<dyn EventSink>,
+    emitter: &mut TestRunEmitter,
+    in_flight: &mut InFlightToolCalls,
+    num_turns: &mut u32,
+) {
+    let value: Value = match serde_json::from_str(line) {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+
+    match value.get("type").and_then(Value::as_str) {
+        Some("response_item") => {
+```
+
+Replace with:
+
+```rust
+fn process_line(
+    line: &str,
+    session_id: &str,
+    cwd: Option<&Path>,
+    events: &Arc<dyn EventSink>,
+    emitter: &mut TestRunEmitter,
+    in_flight: &mut InFlightToolCalls,
+    num_turns: &mut u32,
+    last_cwd: &mut Option<String>,
+) {
+    let value: Value = match serde_json::from_str(line) {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+
+    // Emit agent-cwd on transitions only. Codex's rollout schema carries
+    // session cwd on `session_meta` (once) + `turn_context` (per turn);
+    // mid-turn cwd changes are not visible until the next turn boundary
+    // (see spec section 3.5).
+    if let Some(observed) = extract_session_cwd(&value) {
+        if last_cwd.as_deref().map_or(true, |seen| seen != observed) {
+            let event = AgentCwdEvent {
+                session_id: session_id.to_string(),
+                cwd: observed.to_string(),
+            };
+            if let Err(e) = emit_agent_cwd(events.as_ref(), &event) {
+                log::warn!("Failed to emit agent-cwd event: {}", e);
+            }
+            *last_cwd = Some(observed.to_string());
+        }
+    }
+
+    match value.get("type").and_then(Value::as_str) {
+        Some("response_item") => {
+```
+
+- [ ] **Step 8: Run all four new tests to verify they pass**
+
+Run: `cargo test -p vimeflow --lib codex::transcript 2>&1 | tail -25`
+
+Expected: all 11 new tests in `codex::transcript::tests` pass (7 helper + 3 transition + 1 e2e), plus the existing tests in the module still pass. **Green.**
+
+If `start_tailing_emits_cwd_transitions_in_order` is flaky (occasional `assert_eq!(cwd_events.len(), 3)` fails because the tailer hasn't flushed yet), bump the first `std::thread::sleep(Duration::from_millis(750))` to `1000`. The existing `start_tailing_replays_tool_calls_turns_and_test_runs` uses 750ms successfully, so 750 should suffice.
+
+- [ ] **Step 9: Run the full codex transcript test module to catch regressions**
+
+Run: `cargo test -p vimeflow --lib codex::transcript::tests 2>&1 | tail -8`
+
+Expected: `test result: ok. <N> passed; 0 failed`, where N is the pre-PR count plus 11.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/backend/src/agent/adapter/codex/transcript.rs
+git commit -m "$(cat <<'EOF'
+feat(agent): emit agent-cwd from codex transcript watcher
+
+Wire extract_session_cwd into process_line and tail_loop. Track
+last_cwd across the read loop; emit AgentCwdEvent on transitions
+only, matching the Claude Code transcript watcher's contract (PR #239).
+
+Per spec, the temporal granularity is per-turn (session_meta + turn_context)
+rather than per-line — Codex does not stamp every JSONL entry with cwd.
+Mid-turn worktree switches will lag by up to one turn until the next
+turn_context line is written. The frontend `agent-cwd` listener is
+agent-type-agnostic, so Codex panes pick up cwd tracking automatically.
+
+Tests:
+- 3 process_line transition-semantics tests (first-emit, dedup,
+  back-and-forth).
+- 1 end-to-end start_tailing test driving 6 lines through a
+  FakeEventSink and asserting exactly 3 cwd events in order.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Update `AgentCwdEvent` doc comment + regenerate ts-rs binding
+
+**Files:**
+
+- Modify: `crates/backend/src/agent/types.rs` — doc comment block at lines 157–164.
+- Regenerate: `src/bindings/AgentCwdEvent.ts` — via `npm run generate:bindings`.
+
+- [ ] **Step 1: Replace the doc comment above `pub struct AgentCwdEvent` in `crates/backend/src/agent/types.rs`**
+
+Find this block (lines 157–164):
+
+```rust
+/// Event emitted when the agent's tracked working directory changes.
+///
+/// Sourced from the structured `cwd` field that Claude Code (and Codex,
+/// pending follow-up) writes on every transcript JSONL entry. This is the
+/// authoritative signal for "where the agent currently is" — it picks up
+/// tool-call-driven moves like `EnterWorktree` that intentionally do NOT
+/// mutate the interactive shell's `$PWD`, so neither OSC 7 nor PTY text
+/// patterns can catch them.
+```
+
+Replace with:
+
+```rust
+/// Event emitted when the agent's tracked working directory changes.
+///
+/// Sourced from each adapter's structured cwd channel in its transcript
+/// JSONL:
+/// - **Claude Code** writes a top-level `cwd` field on every transcript
+///   entry; transitions fire as soon as the next line is parsed.
+/// - **Codex** writes `payload.cwd` only on `session_meta` (once, at
+///   session start) and `turn_context` (per turn) entries; transitions
+///   therefore fire at session start and at each turn boundary, not
+///   mid-turn.
+///
+/// In both cases this is the authoritative signal for "where the agent
+/// currently is" — it picks up tool-call-driven moves like Claude's
+/// `EnterWorktree` that intentionally do NOT mutate the interactive
+/// shell's `$PWD`, so neither OSC 7 nor PTY text patterns can catch
+/// them.
+```
+
+- [ ] **Step 2: Regenerate the ts-rs binding**
+
+Run: `npm run generate:bindings`
+
+Expected output ends with prettier formatting summary (e.g. `src/bindings/AgentCwdEvent.ts ...ms`). No errors.
+
+- [ ] **Step 3: Verify the regenerated binding picked up the new doc comment**
+
+Run: `git diff src/bindings/AgentCwdEvent.ts`
+
+Expected: the `/**…*/` JSDoc block at the top of the file changed from the "every transcript JSONL entry / Codex follow-up" wording to the new per-adapter shape description. The TypeScript type body (`export type AgentCwdEvent = { sessionId: string; cwd: string }`) is unchanged.
+
+If `git diff` shows extra changes outside the JSDoc, something else regenerated — investigate before continuing.
+
+- [ ] **Step 4: Confirm formatters pass**
+
+Run: `npm run format:check && npm run type-check 2>&1 | tail -8`
+
+Expected: both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/agent/types.rs src/bindings/AgentCwdEvent.ts
+git commit -m "$(cat <<'EOF'
+docs(agent): update AgentCwdEvent doc comment for codex shape
+
+The doc previously claimed both adapters write cwd on "every transcript
+JSONL entry (Codex follow-up)". This PR is that follow-up, and the
+"every entry" claim is wrong for Codex — its rollout schema carries
+session cwd only on session_meta + turn_context entries. Updated doc
+describes both adapters' real field shapes (Claude per-line, Codex
+per-turn).
+
+The ts-rs binding at src/bindings/AgentCwdEvent.ts is regenerated to
+mirror the new doc comment.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Update frontend JSDoc comments
+
+**Files:**
+
+- Modify: `src/features/agent-status/types/index.ts` — JSDoc block at lines 54–62.
+- Modify: `src/features/workspace/WorkspaceView.tsx` — comment block at lines 315–321.
+
+No behavior change. Strictly comment-only.
+
+- [ ] **Step 1: Update `src/features/agent-status/types/index.ts`**
+
+Find this block (lines 54–62):
+
+```ts
+/**
+ * Agent-reported working directory, populated from the structured `cwd`
+ * field on every transcript JSONL entry (Claude Code today; Codex
+ * follow-up). `null` before the first transition or for agents that
+ * don't expose a transcript. The workspace bridge mirrors this into
+ * `pane.cwd` so the Header chip + git branch follow tool-call-driven
+ * cwd changes (e.g. Claude's built-in `EnterWorktree`).
+ */
+cwd: string | null
+```
+
+Replace the comment (keep the `cwd: string | null` line unchanged):
+
+```ts
+/**
+ * Agent-reported working directory, populated from each adapter's
+ * structured cwd channel in its transcript JSONL:
+ * - **Claude Code** writes a top-level `cwd` on every entry; transitions
+ *   fire as soon as the next line is parsed.
+ * - **Codex** writes `payload.cwd` only on `session_meta` (once) and
+ *   `turn_context` (per turn) entries; transitions fire at session start
+ *   and at each turn boundary, not mid-turn.
+ *
+ * `null` before the first transition or for agents that don't expose a
+ * transcript. The workspace bridge mirrors this into `pane.cwd` so the
+ * Header chip + git branch follow tool-call-driven cwd changes (e.g.
+ * Claude's built-in `EnterWorktree`).
+ */
+cwd: string | null
+```
+
+- [ ] **Step 2: Update `src/features/workspace/WorkspaceView.tsx`**
+
+Find this block (lines 315–321):
+
+```tsx
+// Mirror the agent's structured cwd into pane.cwd. The transcript JSONL
+// (Claude Code today; Codex follow-up) stamps every entry with the
+// agent's current cwd; the `agent-cwd` event surfaces transitions.
+// Tool-call-driven moves like Claude's built-in `EnterWorktree` do NOT
+// change the interactive shell's $PWD, so neither OSC 7 nor PTY text
+// patterns catch them — this bridge is what makes the worktree chip +
+// git branch follow agent-driven worktree switches.
+```
+
+Replace with:
+
+```tsx
+// Mirror the agent's structured cwd into pane.cwd. Both adapters expose
+// an `agent-cwd` event on transitions; the sources differ:
+//  - Claude Code stamps `cwd` on every transcript JSONL entry, so
+//    transitions surface as soon as the next line is parsed.
+//  - Codex carries `payload.cwd` only on `session_meta` + `turn_context`
+//    entries, so transitions surface at turn boundaries (per-turn,
+//    not mid-turn).
+// Tool-call-driven moves like Claude's built-in `EnterWorktree` do NOT
+// change the interactive shell's $PWD, so neither OSC 7 nor PTY text
+// patterns catch them — this bridge is what makes the worktree chip +
+// git branch follow agent-driven worktree switches.
+```
+
+- [ ] **Step 3: Confirm lints + types + tests pass**
+
+Run: `npm run lint && npm run format:check && npm run type-check && npm test 2>&1 | tail -10`
+
+Expected: all four clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/agent-status/types/index.ts src/features/workspace/WorkspaceView.tsx
+git commit -m "$(cat <<'EOF'
+docs(workspace): clarify agent-cwd source per adapter
+
+Mirrors the AgentCwdEvent doc comment update on the Rust side: drop
+the "Codex follow-up" / "every transcript JSONL entry" wording and
+describe each adapter's real cwd source (Claude per-line, Codex
+per-turn via session_meta + turn_context).
+
+No behavior change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Final verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full backend test suite**
+
+Run: `cargo test -p vimeflow --lib 2>&1 | tail -10`
+
+Expected: all tests pass. Note the test count — should be the pre-PR count plus 11 (the new tests added in Tasks 1 + 2).
+
+- [ ] **Step 2: Run the full frontend test suite**
+
+Run: `npm test 2>&1 | tail -10`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run lint + format + type-check**
+
+Run: `npm run lint && npm run format:check && npm run type-check 2>&1 | tail -6`
+
+Expected: all three clean.
+
+- [ ] **Step 4: Verify commit history shape**
+
+Run: `git log --oneline main..HEAD`
+
+Expected: four behavior/doc commits beyond the spec commits — Tasks 1 through 4:
+
+```
+<sha> docs(workspace): clarify agent-cwd source per adapter
+<sha> docs(agent): update AgentCwdEvent doc comment for codex shape
+<sha> feat(agent): emit agent-cwd from codex transcript watcher
+<sha> test(agent): add extract_session_cwd helper for codex rollouts
+```
+
+(Plus the three pre-existing `docs(spec):` commits from the planner phase.)
+
+- [ ] **Step 5: Check the new file size in `codex/transcript.rs`**
+
+Run: `wc -l crates/backend/src/agent/adapter/codex/transcript.rs`
+
+Expected: 978–990 lines (was 953; added ~25 lines of behavior + ~150 lines of tests = ~25–35 line growth at the body level, ~150 line growth at the test-module level). The file is now further over the rules' 800-line ceiling. This is acknowledged debt per spec section 2 "Out of scope" — a separate refactor PR splits it. Do NOT split in this PR.
+
+- [ ] **Step 6: (No commit — verification only.)**
+
+If any step above failed, fix the underlying issue and re-run. Do not push until every step is clean.
+
+---
+
+## Self-Review Checklist
+
+Run this after the plan is written (already done during plan authoring — recorded here for the implementer):
+
+**Spec coverage:**
+
+- ✅ Section 2 "In scope: codex/transcript.rs extraction + emission" → Tasks 1 + 2
+- ✅ Section 2 "In scope: AgentCwdEvent doc comment" → Task 3
+- ✅ Section 2 "In scope: ts-rs binding regenerated" → Task 3 Step 2
+- ✅ Section 2 "In scope: frontend JSDoc comments" → Task 4
+- ✅ Section 5.2 "7 extract_session_cwd unit tests" → Task 1 Step 1
+- ✅ Section 5.3 "3 transition tests" → Task 2 Step 1
+- ✅ Section 5.4 "1 e2e watcher test" → Task 2 Step 1 (final test block)
+- ✅ Section 5.5 "ts-rs regeneration verification via npm run generate:bindings" → Task 3 Step 2
+- ✅ Section 5.6 commands match what tasks invoke
+
+**Placeholder scan:** none — every code block is literal Rust / TS to paste; every command is exact.
+
+**Type consistency:** `extract_session_cwd` signature `(&Value) -> Option<&str>` matches between Task 1 (helper) and Task 2 (call site). `last_cwd: &mut Option<String>` matches between Task 2 Step 5/6/7 (signature) and tests (Task 2 Step 1).
+
+**Out-of-scope deferrals honored:**
+
+- Issue #234 — not touched. ✅
+- Shell-pwd-from-pane-1 bug — not touched. ✅
+- agentCwdHint pruning — not touched. ✅
+- codex/transcript.rs split — explicitly NOT split (Task 5 Step 5 calls it out). ✅
+- codex/parser.rs — not touched. ✅
+
+---
+
+## Stop Condition
+
+This plan stops after Task 5. The next action — execution — is the user's choice, **not** a chained skill call from this plan. Control returns to `/lifeline:planner` so codex can review the plan before any implementation begins.

--- a/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
+++ b/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
@@ -909,3 +909,5 @@ Run this after the plan is written (already done during plan authoring — recor
 ## Stop Condition
 
 This plan stops after Task 5. The next action — execution — is the user's choice, **not** a chained skill call from this plan. Control returns to `/lifeline:planner` so codex can review the plan before any implementation begins.
+
+<!-- codex-reviewed: 2026-05-22T12:42:45Z -->

--- a/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
+++ b/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
@@ -1,41 +1,47 @@
-# Codex Transcript Cwd Parser Implementation Plan
+# Codex Transcript Cwd Parser Implementation Plan (v2)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Port PR #239's `agent-cwd` extraction to the Codex transcript watcher so Codex panes get the same structured cwd channel Claude Code panes have, with the per-turn temporal contract documented in the spec.
+> **Revision history.** v1 of this plan was based on a v1 spec that assumed `turn_context.cwd` updates mid-session. Codex implemented v1 faithfully but the feature did not work end-to-end. v1's implementation commits (`cab6b73` → `dd95857`) and v1's plan/spec codex-reviewed footers were reverted. v2 (this plan) is rooted in the v2 spec at `docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md` and implements extraction from `session_meta.cwd` + `exec_command.workdir` only; `turn_context.cwd` is intentionally NOT a source.
 
-**Architecture:** Add a private `extract_session_cwd` helper to `codex/transcript.rs`. Thread `last_cwd: Option<String>` through the `tail_loop` and `process_line`. Pre-match cwd extraction emits `AgentCwdEvent` on transitions only. Update doc-comments + regenerate ts-rs binding. Update two frontend JSDoc blocks.
+**Goal:** Port PR #239's `agent-cwd` extraction to the Codex transcript watcher with the v2-corrected source model. Codex panes should emit `agent-cwd` transitions whenever codex switches its command working directory (via `exec_command.arguments.workdir`), without false reverts from `turn_context.cwd` (pinned to session start).
+
+**Architecture:** Three private helpers in `codex/transcript.rs`. `extract_session_cwd` matches `session_meta` ONLY. `extract_exec_workdir` matches `response_item.payload.type == "function_call"` AND `payload.name == "exec_command"`, parses the JSON-encoded `arguments` string, returns the `workdir` field. `extract_codex_cwd` dispatches between them. Pre-match cwd extraction in `process_line` emits `AgentCwdEvent` on transitions only. Update doc-comments + regenerate ts-rs binding. Update two frontend JSDoc blocks.
 
 **Tech Stack:** Rust (backend, `crates/backend`), `serde_json::Value`, `ts-rs` (binding regen), TypeScript (frontend doc-comments only).
 
-**Reference spec:** [`docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md`](../specs/2026-05-22-codex-transcript-cwd-parser-design.md) (codex-reviewed, 4 review passes).
+**Reference spec:** [`docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md`](../specs/2026-05-22-codex-transcript-cwd-parser-design.md) (v2, codex-reviewed).
+
+---
+
+## Important — exit-code handling for all `Run:` commands
+
+Do NOT pipe `Run:` commands through `| tail` or `| head`. In bash a piped command's exit code is the exit code of the LAST stage; `tail`'s exit code masks a failing `cargo test` / `npm test` / `npm run type-check` and the executing agent will read the run as a pass. Run commands unfiltered. The expected-output blocks below show what the relevant summary line looks like — verify it actually appears in the unfiltered output before continuing.
 
 ---
 
 ## File Structure
 
-- **Modify** `crates/backend/src/agent/adapter/codex/transcript.rs` — add `extract_session_cwd` helper, `last_cwd` state in `tail_loop`, `last_cwd` parameter on `process_line`, pre-match emission, two new imports, 11 new tests (7 helper + 3 transition + 1 e2e).
-- **Modify** `crates/backend/src/agent/types.rs` — update `AgentCwdEvent` doc comment (lines 157–164) to describe both adapters' real shapes; drop "pending follow-up" / "every transcript JSONL entry".
-- **Regenerate** `src/bindings/AgentCwdEvent.ts` — via `npm run generate:bindings` (runs `cargo test ... export_bindings && prettier --write src/bindings/`). Not hand-edited.
-- **Modify** `src/features/agent-status/types/index.ts` — JSDoc block above `cwd: string | null` field (lines 54–62) to drop "every transcript JSONL entry (Claude Code today; Codex follow-up)" and describe both adapters.
-- **Modify** `src/features/workspace/WorkspaceView.tsx` — comment block above `agentStatus.cwd → updatePaneCwd` bridge (lines 315–321), same correction.
+- **Modify** `crates/backend/src/agent/adapter/codex/transcript.rs` — add 3 helpers (`extract_session_cwd`, `extract_exec_workdir`, `extract_codex_cwd`), `last_cwd` state in `tail_loop`, `last_cwd` parameter on `process_line`, pre-match emission, two new imports, 15 new tests (4 session_cwd + 6 exec_workdir + 4 transition + 1 e2e).
+- **Modify** `crates/backend/src/agent/types.rs` — update `AgentCwdEvent` doc comment (lines 157–164) to describe the two-source Codex model (session_meta + exec_command.workdir) and the intentional `turn_context` skip.
+- **Regenerate** `src/bindings/AgentCwdEvent.ts` — via `npm run generate:bindings`. Not hand-edited.
+- **Modify** `src/features/agent-status/types/index.ts` — JSDoc block above `cwd: string | null` field (lines 54–62).
+- **Modify** `src/features/workspace/WorkspaceView.tsx` — comment block above `agentStatus.cwd → updatePaneCwd` bridge (lines 315–321).
 
-No new files. No new fixture files — tests use inline `json!()` values per the codebase convention in `codex/transcript.rs::start_tailing_replays_tool_calls_turns_and_test_runs` (around line 791).
+No new files. No fixture files — tests use inline `json!()` values per the codebase convention.
 
 ---
 
-## Task 1: Add `extract_session_cwd` helper with unit tests
+## Task 1: Add `extract_session_cwd` helper (session_meta only) with unit tests
 
 **Files:**
 
-- Modify: `crates/backend/src/agent/adapter/codex/transcript.rs` — add helper near top (above `validate_transcript_path`, around line 47), add 7 unit tests inside existing `#[cfg(test)] mod tests` block (at end of file, around line 736+).
+- Modify: `crates/backend/src/agent/adapter/codex/transcript.rs` — add helper near top (above `validate_transcript_path`, around line 47), add 4 unit tests inside existing `#[cfg(test)] mod tests` block.
 
-### Step 1: Write the failing tests
-
-- [ ] **Step 1: Add 7 unit tests at the bottom of the existing `#[cfg(test)] mod tests` block in `crates/backend/src/agent/adapter/codex/transcript.rs`** (just before the closing `}` of the module).
+- [ ] **Step 1: Add 4 unit tests at the bottom of the existing `#[cfg(test)] mod tests` block.**
 
 ```rust
-    // ---- extract_session_cwd unit tests (added by codex-transcript-cwd PR) ----
+    // ---- extract_session_cwd unit tests (v2: session_meta ONLY) ----
 
     #[test]
     fn extract_session_cwd_session_meta_returns_cwd() {
@@ -44,90 +50,53 @@ No new files. No new fixture files — tests use inline `json!()` values per the
     }
 
     #[test]
-    fn extract_session_cwd_turn_context_returns_cwd() {
+    fn extract_session_cwd_turn_context_returns_none() {
+        // v2 spec section 1: turn_context is INTENTIONALLY NOT a cwd source.
+        // Codex's turn_context.cwd is pinned to session-start and treating
+        // it as live would cause false reverts after exec_command transitions.
+        // This test is a defensive guard against re-introduction.
         let v = json!({"type": "turn_context", "payload": {"cwd": "/workspace/A"}});
-        assert_eq!(extract_session_cwd(&v), Some("/workspace/A"));
+        assert_eq!(extract_session_cwd(&v), None);
     }
 
     #[test]
-    fn extract_session_cwd_event_msg_returns_none() {
-        // Defensive: even if a future schema put `cwd` in event_msg.payload,
-        // the type gate rejects it. Session cwd only lives on session_meta
-        // + turn_context as of cli_version 0.132.0.
+    fn extract_session_cwd_other_type_returns_none() {
         let v = json!({"type": "event_msg", "payload": {"cwd": "/workspace/A"}});
         assert_eq!(extract_session_cwd(&v), None);
     }
 
     #[test]
-    fn extract_session_cwd_response_item_returns_none() {
-        // function_call arguments.workdir is per-command scratch, NOT
-        // session cwd. The type gate rejects response_item entirely.
-        let v = json!({
-            "type": "response_item",
-            "payload": {
-                "type": "function_call",
-                "arguments": "{\"workdir\":\"/workspace/A\"}"
-            }
-        });
-        assert_eq!(extract_session_cwd(&v), None);
-    }
-
-    #[test]
-    fn extract_session_cwd_missing_payload_returns_none() {
-        let v = json!({"type": "turn_context"});
-        assert_eq!(extract_session_cwd(&v), None);
-    }
-
-    #[test]
-    fn extract_session_cwd_missing_cwd_returns_none() {
-        let v = json!({"type": "turn_context", "payload": {}});
-        assert_eq!(extract_session_cwd(&v), None);
-    }
-
-    #[test]
     fn extract_session_cwd_empty_string_returns_none() {
-        let v = json!({"type": "turn_context", "payload": {"cwd": ""}});
+        let v = json!({"type": "session_meta", "payload": {"cwd": ""}});
         assert_eq!(extract_session_cwd(&v), None);
     }
 ```
 
-> **Note:** `serde_json::json` is already imported in the test module's `use serde_json::json;` line (around line 740 in the file).
+> `serde_json::json` is already imported via `use serde_json::json;` in the test module.
 
 - [ ] **Step 2: Run the tests to verify they fail with a compile error**
 
 Run: `cargo test -p vimeflow --lib extract_session_cwd`
 
-> **Important — exit-code handling for all `Run:` commands in this plan:**
-> Do NOT pipe these commands through `| tail` or `| head`. In bash a piped
-> command's exit code is the exit code of the LAST stage; `tail`'s exit
-> code masks a failing `cargo test` / `npm test` / `npm run type-check`
-> and the executing agent will read the run as a pass. If output volume
-> is a concern, use `2>&1 | tee /tmp/<name>.log` or check
-> `${PIPESTATUS[0]}` explicitly. The expected-output blocks below show
-> what the relevant summary line looks like — verify it actually appears
-> in the unfiltered output before continuing.
-
 Expected: `error[E0425]: cannot find function 'extract_session_cwd'` (red — the helper doesn't exist yet).
 
 - [ ] **Step 3: Add the `extract_session_cwd` helper near the top of `crates/backend/src/agent/adapter/codex/transcript.rs`**
 
-Insert this function immediately above the existing `pub(super) fn validate_transcript_path` (around line 47). Place it after the `type InFlightToolCalls = HashMap<…>;` declaration (around line 45).
+Insert immediately above `pub(super) fn validate_transcript_path` (around line 47), after the `type InFlightToolCalls = HashMap<…>;` declaration:
 
 ```rust
-/// Pull session-level cwd off a Codex rollout JSONL line.
+/// Pull session-start cwd off a Codex rollout JSONL line.
 ///
-/// Returns `Some(cwd)` only for the two event types that actually carry
-/// session cwd in the rollout schema as of `cli_version 0.132.0`:
-///   - `session_meta.payload.cwd` — fires once at session start.
-///   - `turn_context.payload.cwd` — fires per turn.
-///
-/// Empty strings are filtered out at the extraction site, matching the
-/// Claude Code transcript watcher's guard. Function-call
-/// `arguments.workdir` is per-command scratch and deliberately not
-/// considered session cwd.
+/// Returns `Some(cwd)` ONLY for `session_meta` entries — the
+/// session-start anchor. `turn_context.cwd` is intentionally NOT
+/// matched here: empirically it just repeats `session_meta.cwd`
+/// every turn (no information value), and treating it as a live cwd
+/// would cause false reverts on reasoning-only turns after an
+/// `exec_command.workdir` transition has already moved us to a new
+/// directory. See spec section 1.
 fn extract_session_cwd(value: &Value) -> Option<&str> {
     let event_type = value.get("type").and_then(Value::as_str)?;
-    if event_type != "session_meta" && event_type != "turn_context" {
+    if event_type != "session_meta" {
         return None;
     }
     value
@@ -142,23 +111,21 @@ fn extract_session_cwd(value: &Value) -> Option<&str> {
 
 Run: `cargo test -p vimeflow --lib extract_session_cwd`
 
-Expected: `test result: ok. 7 passed; 0 failed`.
+Expected: `test result: ok. 4 passed; 0 failed`.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add crates/backend/src/agent/adapter/codex/transcript.rs
 git commit -m "$(cat <<'EOF'
-test(agent): add extract_session_cwd helper for codex rollouts
+test(agent): add extract_session_cwd for codex session_meta cwd
 
-Pure extraction helper scoped to session_meta + turn_context — the only
-two event types in the Codex rollout JSONL schema (cli_version 0.132.0)
-that carry session-level cwd. Seven unit tests cover the happy paths,
-the type-gate rejections, and the missing-field / empty-string guards.
-
-The helper is dead-code until Task 2 wires it into process_line; the
-function is not marked #[allow(dead_code)] because the unit tests count
-as uses for the dead-code lint.
+v2 spec implementation, Task 1. Pure extraction helper scoped to
+session_meta — the session-start anchor in Codex's rollout JSONL
+schema (cli_version 0.132.0). Four unit tests cover the happy path,
+the defensive turn_context-rejection (turn_context.cwd is pinned to
+session-start and intentionally NOT a cwd source per v2 spec
+section 1), other-event-type rejection, and empty-string guard.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
@@ -167,21 +134,183 @@ EOF
 
 ---
 
-## Task 2: Wire emission into `tail_loop` + `process_line`, with transition tests + e2e
+## Task 2: Add `extract_exec_workdir` helper (the mid-session signal)
+
+**Files:**
+
+- Modify: `crates/backend/src/agent/adapter/codex/transcript.rs` — add helper immediately below `extract_session_cwd`, add 6 unit tests in the test module.
+
+- [ ] **Step 1: Add 6 unit tests at the bottom of the test module, after the Task 1 tests.**
+
+```rust
+    // ---- extract_exec_workdir unit tests (the mid-session signal) ----
+
+    #[test]
+    fn extract_exec_workdir_happy_path() {
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "c1",
+                "arguments": "{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v).as_deref(), Some("/workspace/B"));
+    }
+
+    #[test]
+    fn extract_exec_workdir_other_event_type_returns_none() {
+        // event_msg carrying a function_call-shaped payload should still
+        // be rejected — the outer event type gate is response_item.
+        let v = json!({
+            "type": "event_msg",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": "{\"workdir\":\"/x\"}"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v), None);
+    }
+
+    #[test]
+    fn extract_exec_workdir_non_function_call_returns_none() {
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "exec_command",
+                "input": "{\"workdir\":\"/x\"}"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v), None);
+    }
+
+    #[test]
+    fn extract_exec_workdir_non_exec_command_returns_none() {
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "read_file",
+                "arguments": "{\"path\":\"/x\"}"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v), None);
+    }
+
+    #[test]
+    fn extract_exec_workdir_malformed_arguments_json_returns_none() {
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": "{not json"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v), None);
+    }
+
+    #[test]
+    fn extract_exec_workdir_missing_workdir_field_returns_none() {
+        let v = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": "{\"cmd\":\"ls\"}"
+            }
+        });
+        assert_eq!(extract_exec_workdir(&v), None);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail with a compile error**
+
+Run: `cargo test -p vimeflow --lib extract_exec_workdir`
+
+Expected: `error[E0425]: cannot find function 'extract_exec_workdir'`.
+
+- [ ] **Step 3: Add the `extract_exec_workdir` helper immediately below `extract_session_cwd`**
+
+```rust
+/// Pull the mid-session workdir off a Codex `exec_command` function-call
+/// rollout entry. This is codex's de facto session cwd after the start
+/// (verified empirically — `turn_context.cwd` does not update on
+/// codex-driven cwd changes; `exec_command.arguments.workdir` does).
+///
+/// `arguments` is a JSON-encoded string per Codex's rollout schema —
+/// it must be parsed before reading `workdir`. Malformed JSON, missing
+/// fields, or empty strings all short-circuit to `None`.
+fn extract_exec_workdir(value: &Value) -> Option<String> {
+    if value.get("type").and_then(Value::as_str)? != "response_item" {
+        return None;
+    }
+    let payload = value.get("payload")?;
+    if payload.get("type").and_then(Value::as_str)? != "function_call" {
+        return None;
+    }
+    if payload.get("name").and_then(Value::as_str)? != "exec_command" {
+        return None;
+    }
+    let raw = payload.get("arguments").and_then(Value::as_str)?;
+    let args: Value = serde_json::from_str(raw).ok()?;
+    args.get("workdir")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p vimeflow --lib extract_exec_workdir`
+
+Expected: `test result: ok. 6 passed; 0 failed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/backend/src/agent/adapter/codex/transcript.rs
+git commit -m "$(cat <<'EOF'
+test(agent): add extract_exec_workdir for codex mid-session cwd
+
+v2 spec implementation, Task 2. Pulls the mid-session workdir off
+exec_command function-call rollout entries. The arguments field is a
+JSON-encoded string per Codex's schema; the helper parses it and
+extracts the workdir field, returning None on malformed JSON, missing
+fields, wrong tool names, or wrong event types.
+
+Six unit tests cover happy path, wrong-event-type rejection, wrong-
+function-call-type rejection, wrong-tool-name rejection, malformed-
+JSON rejection, and missing-workdir guard.
+
+Helper is dead-code until Task 3 wires it into process_line via the
+dispatcher.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire `extract_codex_cwd` dispatcher + emission, with transition tests + e2e
 
 **Files:**
 
 - Modify: `crates/backend/src/agent/adapter/codex/transcript.rs`
   - Add 2 new `use` lines at the top (around line 21–23).
+  - Add `extract_codex_cwd` dispatcher immediately below `extract_exec_workdir`.
   - Add `let mut last_cwd: Option<String> = None;` in `tail_loop` (around line 141).
   - Extend `process_line` signature with `last_cwd: &mut Option<String>` (around line 195).
-  - Add cwd extraction + emission in `process_line` body (after the `match serde_json::from_str` early-return, before the existing `match value.get("type")...`).
-  - Update both `process_line(...)` call sites in `tail_loop` (around lines 159 and 177) to pass `&mut last_cwd`.
-  - Add 3 transition-semantics unit tests + 1 e2e test in the existing `mod tests` block.
+  - Add cwd extraction + emission in `process_line` body (after the `match serde_json::from_str` early-return, before the existing `match value.get("type")…`).
+  - Update both `process_line(...)` call sites in `tail_loop` (around lines 159 and 177).
+  - Add 4 transition-semantics tests + 1 e2e test in the test module.
 
-### Step 1: Write the failing tests
-
-- [ ] **Step 1: Add 3 transition tests + 1 e2e test at the bottom of `mod tests` in the same file, just after the 7 helper tests from Task 1.**
+- [ ] **Step 1: Add 4 transition tests + 1 e2e test at the bottom of the test module, after the Task 2 tests.**
 
 ```rust
     // ---- process_line transition-semantics tests ----
@@ -222,7 +351,7 @@ EOF
     }
 
     #[test]
-    fn process_line_repeated_cwd_suppresses() {
+    fn process_line_repeated_cwd_across_sources_suppresses() {
         let sink = Arc::new(FakeEventSink::new());
         let events: Arc<dyn EventSink> = sink.clone();
         let mut emitter = TestRunEmitter::new(events.clone());
@@ -232,8 +361,7 @@ EOF
 
         let lines = [
             r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}"#,
-            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/workspace/A"}}"#,
-            r#"{"timestamp":"2026-05-22T10:00:02Z","type":"turn_context","payload":{"turn_id":"t2","cwd":"/workspace/A"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/A\"}"}}"#,
         ];
         for line in lines {
             process_line(
@@ -258,7 +386,7 @@ EOF
     }
 
     #[test]
-    fn process_line_cwd_transition_emits() {
+    fn process_line_cwd_transition_across_sources_emits() {
         let sink = Arc::new(FakeEventSink::new());
         let events: Arc<dyn EventSink> = sink.clone();
         let mut emitter = TestRunEmitter::new(events.clone());
@@ -268,8 +396,8 @@ EOF
 
         let lines = [
             r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}"#,
-            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/workspace/B"}}"#,
-            r#"{"timestamp":"2026-05-22T10:00:02Z","type":"turn_context","payload":{"turn_id":"t2","cwd":"/workspace/A"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c2","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/A\"}"}}"#,
         ];
         for line in lines {
             process_line(
@@ -293,12 +421,61 @@ EOF
         assert_eq!(cwd_events[0].1["cwd"], "/workspace/A");
         assert_eq!(cwd_events[1].1["cwd"], "/workspace/B");
         assert_eq!(cwd_events[2].1["cwd"], "/workspace/A");
-        for (_name, payload) in &cwd_events {
-            assert_eq!(payload["sessionId"], "sid-1");
-        }
     }
 
-    // ---- end-to-end watcher test ----
+    /// v2-critical regression guard. Codex review on the v2 spec (HIGH)
+    /// flagged that including turn_context.cwd as a cwd source would
+    /// cause a false revert: after session_meta(A) → exec_command(B),
+    /// the next turn's turn_context(A) (pinned to session-start) would
+    /// emit agent-cwd=A and bounce the pane chip back. This test locks
+    /// in the v2 design decision to skip turn_context entirely.
+    /// If anyone re-adds turn_context to extract_session_cwd, this
+    /// test fires.
+    #[test]
+    fn process_line_turn_context_after_exec_command_does_not_revert() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let lines = [
+            r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:02Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/workspace/A"}}"#,
+        ];
+        for line in lines {
+            process_line(
+                line,
+                "sid-1",
+                None,
+                &events,
+                &mut emitter,
+                &mut in_flight,
+                &mut num_turns,
+                &mut last_cwd,
+            );
+        }
+
+        let cwd_events: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-cwd")
+            .collect();
+        assert_eq!(
+            cwd_events.len(),
+            2,
+            "turn_context.cwd MUST NOT emit a cwd event \
+             (would cause false revert to session-start after exec_command transition)"
+        );
+        assert_eq!(cwd_events[0].1["cwd"], "/workspace/A");
+        assert_eq!(cwd_events[1].1["cwd"], "/workspace/B");
+        // Crucially, last_cwd should still be B — the worktree we're in.
+        assert_eq!(last_cwd.as_deref(), Some("/workspace/B"));
+    }
+
+    // ---- end-to-end watcher test (with v2 regression guard inline) ----
 
     #[test]
     fn start_tailing_emits_cwd_transitions_in_order() {
@@ -307,46 +484,24 @@ EOF
         let tmp = tempfile::tempdir().expect("tempdir");
         let transcript_path = tmp.path().join("rollout.jsonl");
 
-        // 6 lines, 3 expected emissions:
-        //   1. session_meta cwd=/workspace/A   (emit)
-        //   2. turn_context cwd=/workspace/A   (suppressed)
-        //   3. turn_context cwd=/workspace/B   (emit)
-        //   4. event_msg noise                 (no cwd emit)
-        //   5. response_item noise             (no cwd emit)
-        //   6. turn_context cwd=/workspace/A   (emit)
+        // 7 lines, 3 expected emissions:
+        //   1. session_meta cwd=/workspace/A             (emit)
+        //   2. turn_context cwd=/workspace/A             (no emit — extractor rejects turn_context)
+        //   3. exec_command workdir=/workspace/B         (emit — transition)
+        //   4. event_msg task_started                    (no emit)
+        //   5. exec_command workdir=/workspace/B         (suppressed — same as last_cwd)
+        //   6. turn_context cwd=/workspace/A             (no emit — REGRESSION GUARD: must not revert)
+        //   7. exec_command workdir=/workspace/A         (emit — transition back)
         write_rollout(
             &transcript_path,
             &[
-                json!({
-                    "timestamp": "2026-05-22T10:00:00Z",
-                    "type": "session_meta",
-                    "payload": { "id": "sid-cwd", "cwd": "/workspace/A" }
-                }),
-                json!({
-                    "timestamp": "2026-05-22T10:00:01Z",
-                    "type": "turn_context",
-                    "payload": { "turn_id": "t1", "cwd": "/workspace/A" }
-                }),
-                json!({
-                    "timestamp": "2026-05-22T10:00:02Z",
-                    "type": "turn_context",
-                    "payload": { "turn_id": "t2", "cwd": "/workspace/B" }
-                }),
-                json!({
-                    "timestamp": "2026-05-22T10:00:03Z",
-                    "type": "event_msg",
-                    "payload": { "type": "task_started" }
-                }),
-                json!({
-                    "timestamp": "2026-05-22T10:00:04Z",
-                    "type": "response_item",
-                    "payload": { "type": "function_call", "call_id": "c1", "name": "noop", "arguments": "{}" }
-                }),
-                json!({
-                    "timestamp": "2026-05-22T10:00:05Z",
-                    "type": "turn_context",
-                    "payload": { "turn_id": "t3", "cwd": "/workspace/A" }
-                }),
+                json!({"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}),
+                json!({"timestamp":"2026-05-22T10:00:01Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/workspace/A"}}),
+                json!({"timestamp":"2026-05-22T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"}}),
+                json!({"timestamp":"2026-05-22T10:00:03Z","type":"event_msg","payload":{"type":"task_started"}}),
+                json!({"timestamp":"2026-05-22T10:00:04Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c2","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"}}),
+                json!({"timestamp":"2026-05-22T10:00:04.5Z","type":"turn_context","payload":{"turn_id":"t2","cwd":"/workspace/A"}}),
+                json!({"timestamp":"2026-05-22T10:00:05Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c3","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/A\"}"}}),
             ],
         );
 
@@ -379,13 +534,11 @@ EOF
     }
 ```
 
-> **Note:** `write_rollout`, `FakeEventSink`, `Arc`, `Duration`, `json!`, `Value`, and `tempfile` are all already imported / in-scope in this `mod tests` block — verify the `use` lines around line 738–740 include `use crate::runtime::FakeEventSink;` and `use serde_json::json;`. If any are missing, add them.
-
 - [ ] **Step 2: Run the new tests to verify they fail with a compile error**
 
 Run: `cargo test -p vimeflow --lib process_line_first_cwd_always_emits`
 
-Expected: compile error — `process_line` only takes 7 args (no `last_cwd`), `extract_session_cwd` is dead-code, no emission code in `process_line`. **Red.**
+Expected: compile error — `process_line` only takes 7 args, `extract_codex_cwd` doesn't exist, no emission code. **Red.**
 
 ### Step 2: Wire the implementation
 
@@ -394,54 +547,55 @@ Expected: compile error — `process_line` only takes 7 args (no `last_cwd`), `e
 Find the existing import block (around lines 19–23):
 
 ```rust
-use crate::agent::adapter::base::TranscriptHandle;
-use crate::agent::adapter::claude_code::test_runners::build::{maybe_build_snapshot, BuildArgs};
-use crate::agent::adapter::claude_code::test_runners::emitter::TestRunEmitter;
-use crate::agent::adapter::claude_code::test_runners::matcher::{match_command, MatchedCommand};
-use crate::agent::adapter::claude_code::test_runners::test_file_patterns::is_test_file;
-use crate::agent::adapter::claude_code::test_runners::timestamps::compute_duration_ms;
-use crate::agent::adapter::claude_code::test_runners::types::CapturedOutput;
-use crate::agent::adapter::types::ValidateTranscriptError;
 use crate::agent::events::{emit_agent_tool_call, emit_agent_turn};
 use crate::agent::types::{AgentToolCallEvent, AgentTurnEvent, ToolCallStatus};
-use crate::runtime::EventSink;
 ```
 
-Modify the last two `use crate::agent::*` lines to add `emit_agent_cwd` and `AgentCwdEvent`:
+Modify to add `emit_agent_cwd` and `AgentCwdEvent`:
 
 ```rust
 use crate::agent::events::{emit_agent_cwd, emit_agent_tool_call, emit_agent_turn};
 use crate::agent::types::{AgentCwdEvent, AgentToolCallEvent, AgentTurnEvent, ToolCallStatus};
 ```
 
-- [ ] **Step 4: Add `last_cwd` state in `tail_loop`**
-
-Find `fn tail_loop(…)` (around line 130). At the top of the function body, locate this block (around lines 138–141):
+- [ ] **Step 4: Add the `extract_codex_cwd` dispatcher immediately below `extract_exec_workdir`**
 
 ```rust
-    let mut reader = BufReader::new(file);
-    let mut line_buf = String::new();
-    let mut partial_line = String::new();
+/// Dispatcher returning the observed cwd from whichever source carries
+/// it. Tries the session_meta path first (cheap, no JSON re-parse),
+/// falls back to the exec_command workdir path. Returns
+/// `Option<String>` because the workdir path must return owned strings
+/// (parsed JSON allocates).
+fn extract_codex_cwd(value: &Value) -> Option<String> {
+    if let Some(cwd) = extract_session_cwd(value) {
+        return Some(cwd.to_string());
+    }
+    extract_exec_workdir(value)
+}
+```
+
+- [ ] **Step 5: Add `last_cwd` state in `tail_loop`**
+
+Find `fn tail_loop(…)` (around line 130). Locate this block:
+
+```rust
     let mut in_flight: InFlightToolCalls = HashMap::new();
     let mut num_turns = 0_u32;
     let mut emitter = TestRunEmitter::new(events.clone());
 ```
 
-Add `let mut last_cwd: Option<String> = None;` immediately after `let mut num_turns = 0_u32;`:
+Add `let mut last_cwd: Option<String> = None;` after `num_turns`:
 
 ```rust
-    let mut reader = BufReader::new(file);
-    let mut line_buf = String::new();
-    let mut partial_line = String::new();
     let mut in_flight: InFlightToolCalls = HashMap::new();
     let mut num_turns = 0_u32;
     let mut last_cwd: Option<String> = None;
     let mut emitter = TestRunEmitter::new(events.clone());
 ```
 
-- [ ] **Step 5: Update the partial-line branch's `process_line` call (around lines 158–168)**
+- [ ] **Step 6: Update the partial-line branch's `process_line` call**
 
-Find:
+Find (around lines 158–168):
 
 ```rust
                 if !partial_line.is_empty() {
@@ -460,7 +614,7 @@ Find:
                 }
 ```
 
-Add `&mut last_cwd,` as the final argument:
+Add `&mut last_cwd,`:
 
 ```rust
                 if !partial_line.is_empty() {
@@ -480,9 +634,9 @@ Add `&mut last_cwd,` as the final argument:
                 }
 ```
 
-- [ ] **Step 6: Update the single-line branch's `process_line` call (around lines 176–185)**
+- [ ] **Step 7: Update the single-line branch's `process_line` call**
 
-Find:
+Find (around lines 176–185):
 
 ```rust
                 process_line(
@@ -511,7 +665,7 @@ Add `&mut last_cwd,`:
                 );
 ```
 
-- [ ] **Step 7: Extend `process_line` signature (around line 195) and add emission body**
+- [ ] **Step 8: Extend `process_line` signature (around line 195) and add emission body**
 
 Find:
 
@@ -552,20 +706,22 @@ fn process_line(
         Err(_) => return,
     };
 
-    // Emit agent-cwd on transitions only. Codex's rollout schema carries
-    // session cwd on `session_meta` (once) + `turn_context` (per turn);
-    // mid-turn cwd changes are not visible until the next turn boundary
-    // (see spec section 3.5).
-    if let Some(observed) = extract_session_cwd(&value) {
-        if last_cwd.as_deref().map_or(true, |seen| seen != observed) {
+    // Emit agent-cwd on transitions only. Codex's two cwd sources are
+    // session_meta.payload.cwd (session start) and
+    // response_item.payload.arguments.workdir for exec_command function
+    // calls (mid-session). turn_context.cwd is intentionally NOT a
+    // source — see spec section 1 and the regression test
+    // `process_line_turn_context_after_exec_command_does_not_revert`.
+    if let Some(observed) = extract_codex_cwd(&value) {
+        if last_cwd.as_deref().map_or(true, |seen| seen != observed.as_str()) {
             let event = AgentCwdEvent {
                 session_id: session_id.to_string(),
-                cwd: observed.to_string(),
+                cwd: observed.clone(),
             };
             if let Err(e) = emit_agent_cwd(events.as_ref(), &event) {
                 log::warn!("Failed to emit agent-cwd event: {}", e);
             }
-            *last_cwd = Some(observed.to_string());
+            *last_cwd = Some(observed);
         }
     }
 
@@ -573,19 +729,11 @@ fn process_line(
         Some("response_item") => {
 ```
 
-- [ ] **Step 8: Run all four new tests to verify they pass**
+- [ ] **Step 9: Run the new tests to verify they pass**
 
 Run: `cargo test -p vimeflow --lib codex::transcript`
 
-Expected: all 11 new tests in `codex::transcript::tests` pass (7 helper + 3 transition + 1 e2e), plus the existing tests in the module still pass. **Green.**
-
-If `start_tailing_emits_cwd_transitions_in_order` is flaky (occasional `assert_eq!(cwd_events.len(), 3)` fails because the tailer hasn't flushed yet), bump the first `std::thread::sleep(Duration::from_millis(750))` to `1000`. The existing `start_tailing_replays_tool_calls_turns_and_test_runs` uses 750ms successfully, so 750 should suffice.
-
-- [ ] **Step 9: Run the full codex transcript test module to catch regressions**
-
-Run: `cargo test -p vimeflow --lib codex::transcript::tests`
-
-Expected: `test result: ok. <N> passed; 0 failed`, where N is the pre-PR count plus 11.
+Expected: all 15 new tests (4 session_cwd + 6 exec_workdir + 4 transition + 1 e2e) pass, plus the existing tests in the module still pass.
 
 - [ ] **Step 10: Commit**
 
@@ -594,21 +742,25 @@ git add crates/backend/src/agent/adapter/codex/transcript.rs
 git commit -m "$(cat <<'EOF'
 feat(agent): emit agent-cwd from codex transcript watcher
 
-Wire extract_session_cwd into process_line and tail_loop. Track
-last_cwd across the read loop; emit AgentCwdEvent on transitions
-only, matching the Claude Code transcript watcher's contract (PR #239).
+v2 spec implementation, Task 3. Add extract_codex_cwd dispatcher that
+tries session_meta first, falls back to exec_command workdir. Thread
+last_cwd through tail_loop + process_line; emit AgentCwdEvent on
+transitions only, matching the Claude Code transcript watcher contract
+(PR #239).
 
-Per spec, the temporal granularity is per-turn (session_meta + turn_context)
-rather than per-line — Codex does not stamp every JSONL entry with cwd.
-Mid-turn worktree switches will lag by up to one turn until the next
-turn_context line is written. The frontend `agent-cwd` listener is
-agent-type-agnostic, so Codex panes pick up cwd tracking automatically.
+Critical v2 design point: turn_context.cwd is intentionally NOT a
+cwd source. It's pinned to session start in practice, and treating
+it as live would cause false reverts after exec_command.workdir
+transitions (codex review on the v2 spec caught this). Regression
+tests in process_line_turn_context_after_exec_command_does_not_revert
+and the e2e fixture lock in the v2 behavior.
 
-Tests:
-- 3 process_line transition-semantics tests (first-emit, dedup,
-  back-and-forth).
-- 1 end-to-end start_tailing test driving 6 lines through a
-  FakeEventSink and asserting exactly 3 cwd events in order.
+Tests added:
+- 4 process_line transition tests (first-emit, dedup across sources,
+  back-and-forth, turn_context-no-revert regression guard).
+- 1 end-to-end start_tailing test driving 7 lines through a
+  FakeEventSink and asserting exactly 3 cwd events in correct order
+  with no false revert.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
@@ -617,14 +769,14 @@ EOF
 
 ---
 
-## Task 3: Update `AgentCwdEvent` doc comment + regenerate ts-rs binding
+## Task 4: Update `AgentCwdEvent` doc comment + regenerate ts-rs binding
 
 **Files:**
 
 - Modify: `crates/backend/src/agent/types.rs` — doc comment block at lines 157–164.
 - Regenerate: `src/bindings/AgentCwdEvent.ts` — via `npm run generate:bindings`.
 
-- [ ] **Step 1: Replace the doc comment above `pub struct AgentCwdEvent` in `crates/backend/src/agent/types.rs`**
+- [ ] **Step 1: Replace the doc comment above `pub struct AgentCwdEvent`**
 
 Find this block (lines 157–164):
 
@@ -648,31 +800,34 @@ Replace with:
 /// JSONL:
 /// - **Claude Code** writes a top-level `cwd` field on every transcript
 ///   entry; transitions fire as soon as the next line is parsed.
-/// - **Codex** writes `payload.cwd` only on `session_meta` (once, at
-///   session start) and `turn_context` (per turn) entries; transitions
-///   therefore fire at session start and at each turn boundary, not
-///   mid-turn.
+/// - **Codex** writes cwd in two places the watcher reads:
+///   `session_meta.payload.cwd` (once, at session start) and
+///   `response_item.payload.arguments.workdir` for `exec_command`
+///   function calls (the mid-session signal — fires whenever codex
+///   runs a tool command in a new directory). Codex also writes
+///   `turn_context.payload.cwd` on every turn, but the watcher
+///   intentionally ignores that field because it's pinned to the
+///   session-start value and would cause false reverts after a
+///   mid-session `exec_command.workdir` transition.
 ///
 /// In both cases this is the authoritative signal for "where the agent
 /// currently is" — it picks up tool-call-driven moves like Claude's
-/// `EnterWorktree` that intentionally do NOT mutate the interactive
-/// shell's `$PWD`, so neither OSC 7 nor PTY text patterns can catch
-/// them.
+/// `EnterWorktree` and codex's "switch to worktree" navigation that
+/// intentionally do NOT mutate the interactive shell's `$PWD`, so
+/// neither OSC 7 nor PTY text patterns can catch them.
 ```
 
 - [ ] **Step 2: Regenerate the ts-rs binding**
 
 Run: `npm run generate:bindings`
 
-Expected output ends with prettier formatting summary (e.g. `src/bindings/AgentCwdEvent.ts ...ms`). No errors.
+Expected: prettier formatting summary; no errors.
 
 - [ ] **Step 3: Verify the regenerated binding picked up the new doc comment**
 
 Run: `git diff src/bindings/AgentCwdEvent.ts`
 
-Expected: the `/**…*/` JSDoc block at the top of the file changed from the "every transcript JSONL entry / Codex follow-up" wording to the new per-adapter shape description. The TypeScript type body (`export type AgentCwdEvent = { sessionId: string; cwd: string }`) is unchanged.
-
-If `git diff` shows extra changes outside the JSDoc, something else regenerated — investigate before continuing.
+Expected: the `/**…*/` JSDoc block at the top of the file changed from the "every transcript JSONL entry / Codex follow-up" wording to the new per-adapter shape description. The type body unchanged.
 
 - [ ] **Step 4: Confirm formatters pass**
 
@@ -685,17 +840,20 @@ Expected: both clean.
 ```bash
 git add crates/backend/src/agent/types.rs src/bindings/AgentCwdEvent.ts
 git commit -m "$(cat <<'EOF'
-docs(agent): update AgentCwdEvent doc comment for codex shape
+docs(agent): update AgentCwdEvent doc comment for v2 codex shape
 
-The doc previously claimed both adapters write cwd on "every transcript
-JSONL entry (Codex follow-up)". This PR is that follow-up, and the
-"every entry" claim is wrong for Codex — its rollout schema carries
-session cwd only on session_meta + turn_context entries. Updated doc
-describes both adapters' real field shapes (Claude per-line, Codex
-per-turn).
+v2 spec implementation, Task 4. Update the AgentCwdEvent doc comment
+to describe the two-source Codex cwd model accurately:
 
-The ts-rs binding at src/bindings/AgentCwdEvent.ts is regenerated to
-mirror the new doc comment.
+  - session_meta.payload.cwd (session start)
+  - exec_command.arguments.workdir (mid-session)
+
+Explicitly call out that turn_context.payload.cwd is intentionally
+NOT a source — it's pinned to session-start in practice and including
+it would cause false reverts.
+
+The ts-rs binding at src/bindings/AgentCwdEvent.ts is regenerated
+via npm run generate:bindings to mirror the new doc comment.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
@@ -704,7 +862,7 @@ EOF
 
 ---
 
-## Task 4: Update frontend JSDoc comments
+## Task 5: Update frontend JSDoc comments
 
 **Files:**
 
@@ -737,14 +895,15 @@ Replace the comment (keep the `cwd: string | null` line unchanged):
  * structured cwd channel in its transcript JSONL:
  * - **Claude Code** writes a top-level `cwd` on every entry; transitions
  *   fire as soon as the next line is parsed.
- * - **Codex** writes `payload.cwd` only on `session_meta` (once) and
- *   `turn_context` (per turn) entries; transitions fire at session start
- *   and at each turn boundary, not mid-turn.
+ * - **Codex** writes cwd in two read paths: `session_meta.payload.cwd`
+ *   (session start) and `response_item.payload.arguments.workdir` for
+ *   `exec_command` function calls (mid-session). `turn_context.cwd`
+ *   is intentionally NOT a source — pinned to session-start and would
+ *   cause false reverts.
  *
  * `null` before the first transition or for agents that don't expose a
  * transcript. The workspace bridge mirrors this into `pane.cwd` so the
- * Header chip + git branch follow tool-call-driven cwd changes (e.g.
- * Claude's built-in `EnterWorktree`).
+ * Header chip + git branch follow tool-call-driven cwd changes.
  */
 cwd: string | null
 ```
@@ -770,13 +929,16 @@ Replace with:
 // an `agent-cwd` event on transitions; the sources differ:
 //  - Claude Code stamps `cwd` on every transcript JSONL entry, so
 //    transitions surface as soon as the next line is parsed.
-//  - Codex carries `payload.cwd` only on `session_meta` + `turn_context`
-//    entries, so transitions surface at turn boundaries (per-turn,
-//    not mid-turn).
-// Tool-call-driven moves like Claude's built-in `EnterWorktree` do NOT
-// change the interactive shell's $PWD, so neither OSC 7 nor PTY text
-// patterns catch them — this bridge is what makes the worktree chip +
-// git branch follow agent-driven worktree switches.
+//  - Codex stamps cwd in session_meta.payload.cwd (session start) and
+//    response_item.payload.arguments.workdir for exec_command function
+//    calls (mid-session). turn_context.cwd is intentionally ignored
+//    by the backend — pinned to session-start and would cause false
+//    reverts.
+// Tool-call-driven moves like Claude's built-in `EnterWorktree` and
+// codex's "switch to worktree" navigation do NOT change the interactive
+// shell's $PWD, so neither OSC 7 nor PTY text patterns catch them —
+// this bridge is what makes the worktree chip + git branch follow
+// agent-driven worktree switches.
 ```
 
 - [ ] **Step 3: Confirm lints + types + tests pass**
@@ -790,12 +952,12 @@ Expected: all four clean.
 ```bash
 git add src/features/agent-status/types/index.ts src/features/workspace/WorkspaceView.tsx
 git commit -m "$(cat <<'EOF'
-docs(workspace): clarify agent-cwd source per adapter
+docs(workspace): clarify v2 agent-cwd source per adapter
 
-Mirrors the AgentCwdEvent doc comment update on the Rust side: drop
-the "Codex follow-up" / "every transcript JSONL entry" wording and
-describe each adapter's real cwd source (Claude per-line, Codex
-per-turn via session_meta + turn_context).
+v2 spec implementation, Task 5. Mirror the AgentCwdEvent doc comment
+update on the frontend side: drop the "Codex follow-up" / "every
+transcript JSONL entry" wording and describe Codex's two-source model
+explicitly (session_meta + exec_command.workdir, NOT turn_context).
 
 No behavior change.
 
@@ -806,7 +968,7 @@ EOF
 
 ---
 
-## Task 5: Final verification
+## Task 6: Final verification
 
 **Files:** none modified.
 
@@ -814,7 +976,7 @@ EOF
 
 Run: `cargo test -p vimeflow --lib`
 
-Expected: all tests pass. Note the test count — should be the pre-PR count plus 11 (the new tests added in Tasks 1 + 2).
+Expected: all tests pass. New tests added in Tasks 1–3 = 15.
 
 - [ ] **Step 2: Run the full frontend test suite**
 
@@ -832,43 +994,36 @@ Expected: all three clean.
 
 Run: `git log --oneline main..HEAD`
 
-Expected: four behavior/doc commits from Tasks 1–4 layered on top of
-the four `docs/` commits already produced by the `/lifeline:planner`
-phase (1 plan + 3 spec). Reverse-chronological order:
+Expected: five behavior/doc commits from Tasks 1–5 layered on top of
+the v2 planner artifacts:
 
 ```
-<sha> docs(workspace): clarify agent-cwd source per adapter            ← Task 4
-<sha> docs(agent): update AgentCwdEvent doc comment for codex shape    ← Task 3
-<sha> feat(agent): emit agent-cwd from codex transcript watcher        ← Task 2
-<sha> test(agent): add extract_session_cwd helper for codex rollouts   ← Task 1
-<sha> docs(plan): codex-transcript-cwd-parser                          ← planner
-<sha> docs(spec): mark spec codex-reviewed                             ← planner
-<sha> docs(spec): apply codex feedback                                 ← planner
-<sha> docs(spec): codex-transcript-cwd-parser                          ← planner
+<sha> docs(workspace): clarify v2 agent-cwd source per adapter            ← Task 5
+<sha> docs(agent): update AgentCwdEvent doc comment for v2 codex shape   ← Task 4
+<sha> feat(agent): emit agent-cwd from codex transcript watcher           ← Task 3
+<sha> test(agent): add extract_exec_workdir for codex mid-session cwd     ← Task 2
+<sha> test(agent): add extract_session_cwd for codex session_meta cwd     ← Task 1
+<sha> docs(plan): mark v2 plan codex-reviewed                             ← planner
+<sha> docs(plan): apply codex feedback (v2)                               ← planner (if any)
+<sha> docs(plan): redesign for v2 spec                                    ← planner
+<sha> docs(spec): mark v2 spec codex-reviewed
+<sha> docs(spec): apply codex feedback (drop turn_context as cwd source)
+<sha> docs(spec): redesign for correct codex schema (v2)
+<sha> docs(plan): mark plan codex-reviewed                                ← v1 (still in history)
+<sha> docs(plan): apply codex feedback                                    ← v1
+<sha> docs(plan): codex-transcript-cwd-parser                             ← v1
+<sha> docs(spec): mark spec codex-reviewed                                ← v1
+<sha> docs(spec): apply codex feedback                                    ← v1
+<sha> docs(spec): codex-transcript-cwd-parser                             ← v1
 ```
 
-Eight commits total. If you see fewer than eight, a task commit was
-skipped or squashed — investigate before pushing.
+(The v1 planner commits stay in history; codex's v1 implementation commits were `git reset`-ed away.)
 
 - [ ] **Step 5: Note the new file size in `codex/transcript.rs`** (informational only — does NOT block)
 
 Run: `wc -l crates/backend/src/agent/adapter/codex/transcript.rs`
 
-The file was 953 lines pre-PR and grows by roughly:
-
-- ~33 lines of behavior code (helper + signature + emission + state).
-- ~225 lines of tests (7 helper + 3 transition + 1 e2e + a tiny
-  `empty_in_flight` helper).
-
-Expected post-PR size: roughly **1180–1230 lines**. The exact number
-is brittle (formatter passes, comment density, etc.) — this step is
-informational. If the count is wildly outside that range (e.g.
-< 1100 or > 1300), check whether tests were dropped or duplicated
-before pushing. Otherwise, accept the size and move on.
-
-The file is now further over the rules' 800-line ceiling. This is
-acknowledged debt per spec section 2 "Out of scope" — a separate
-refactor PR splits it. **Do NOT split in this PR.**
+The file was 953 lines pre-PR and grows by roughly 50 behavior + 280 test lines = ~1280–1330 lines. The file is now further over the rules' 800-line ceiling. This is acknowledged debt per spec section 2 — a separate refactor PR splits it.
 
 - [ ] **Step 6: (No commit — verification only.)**
 
@@ -878,36 +1033,37 @@ If any step above failed, fix the underlying issue and re-run. Do not push until
 
 ## Self-Review Checklist
 
-Run this after the plan is written (already done during plan authoring — recorded here for the implementer):
+After writing the plan, the implementer should verify:
 
 **Spec coverage:**
 
-- ✅ Section 2 "In scope: codex/transcript.rs extraction + emission" → Tasks 1 + 2
-- ✅ Section 2 "In scope: AgentCwdEvent doc comment" → Task 3
-- ✅ Section 2 "In scope: ts-rs binding regenerated" → Task 3 Step 2
-- ✅ Section 2 "In scope: frontend JSDoc comments" → Task 4
-- ✅ Section 5.2 "7 extract_session_cwd unit tests" → Task 1 Step 1
-- ✅ Section 5.3 "3 transition tests" → Task 2 Step 1
-- ✅ Section 5.4 "1 e2e watcher test" → Task 2 Step 1 (final test block)
-- ✅ Section 5.5 "ts-rs regeneration verification via npm run generate:bindings" → Task 3 Step 2
-- ✅ Section 5.6 commands match what tasks invoke
+- ✅ Section 2 "In scope: codex/transcript.rs extraction + emission" → Tasks 1, 2, 3
+- ✅ Section 2 "In scope: AgentCwdEvent doc comment" → Task 4
+- ✅ Section 2 "In scope: ts-rs binding regenerated" → Task 4 Step 2
+- ✅ Section 2 "In scope: frontend JSDoc comments" → Task 5
+- ✅ Section 5.2 "4 extract_session_cwd unit tests (incl. turn_context-returns-None)" → Task 1
+- ✅ Section 5.3 "6 extract_exec_workdir unit tests" → Task 2
+- ✅ Section 5.4 "4 transition tests (incl. v2 regression guard)" → Task 3
+- ✅ Section 5.5 "1 e2e watcher test (with regression guard inline)" → Task 3
+- ✅ Section 5.6 "ts-rs regeneration via npm run generate:bindings" → Task 4 Step 2
 
-**Placeholder scan:** none — every code block is literal Rust / TS to paste; every command is exact.
+**v2 design decisions honored:**
 
-**Type consistency:** `extract_session_cwd` signature `(&Value) -> Option<&str>` matches between Task 1 (helper) and Task 2 (call site). `last_cwd: &mut Option<String>` matches between Task 2 Step 5/6/7 (signature) and tests (Task 2 Step 1).
+- ✅ `extract_session_cwd` matches `session_meta` ONLY (Task 1 Step 3).
+- ✅ `turn_context.cwd` extraction is rejected by a defensive test (Task 1 Step 1, second test).
+- ✅ The regression guard `process_line_turn_context_after_exec_command_does_not_revert` is present (Task 3 Step 1).
+- ✅ The e2e fixture includes a `turn_context(A)` after an `exec_command(B)` to lock in v2 at the integration layer (Task 3 Step 1).
 
 **Out-of-scope deferrals honored:**
 
 - Issue #234 — not touched. ✅
 - Shell-pwd-from-pane-1 bug — not touched. ✅
 - agentCwdHint pruning — not touched. ✅
-- codex/transcript.rs split — explicitly NOT split (Task 5 Step 5 calls it out). ✅
+- codex/transcript.rs split — explicitly NOT split (Task 6 Step 5 calls it out). ✅
 - codex/parser.rs — not touched. ✅
 
 ---
 
 ## Stop Condition
 
-This plan stops after Task 5. The next action — execution — is the user's choice, **not** a chained skill call from this plan. Control returns to `/lifeline:planner` so codex can review the plan before any implementation begins.
-
-<!-- codex-reviewed: 2026-05-22T12:42:45Z -->
+This plan stops after Task 6. The next action — execution — is the user's choice, **not** a chained skill call from this plan.

--- a/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
+++ b/docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md
@@ -1072,3 +1072,5 @@ After writing the plan, the implementer should verify:
 ## Stop Condition
 
 This plan stops after Task 6. The next action — execution — is the user's choice, **not** a chained skill call from this plan.
+
+<!-- codex-reviewed: 2026-05-22T18:06:06Z -->

--- a/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
+++ b/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
@@ -711,3 +711,5 @@ benefit:
   the helper did what the spec described, but the spec described
   the wrong thing. End-to-end verification in a running app caught
   this; unit tests alone wouldn't have.
+
+<!-- codex-reviewed: 2026-05-22T17:50:46Z -->

--- a/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
+++ b/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
@@ -35,20 +35,33 @@ that reading wrong:
   pinned. ✓ correct for "where did the session start".
 - **`turn_context.payload.cwd`** is repeated on every turn but always
   equals the session-start cwd. It does NOT update when codex moves.
-  The v1 spec assumed it does; in practice it does not.
+  v1 spec assumed it does; in practice it does not. **v2 intentionally
+  IGNORES this field** — see "Why we skip `turn_context.cwd`" below.
 - **`response_item.payload.arguments.workdir`** (for `exec_command`
   function calls) DOES update — every time codex runs a command in a
   different directory, the `workdir` field on that function-call
   reflects the new directory. This is codex's de facto mid-session
   cwd signal.
 
-v2 therefore extracts cwd from **three sources** in priority order:
+v2 therefore extracts cwd from **two sources**:
 
 1. `session_meta.payload.cwd` — first transition at session start.
-2. `turn_context.payload.cwd` — kept as a defensive anchor (if a
-   future Codex schema does update it, we already capture).
-3. `response_item.payload.arguments.workdir` (parsed JSON, scoped to
+2. `response_item.payload.arguments.workdir` (parsed JSON, scoped to
    `payload.name == "exec_command"`) — the mid-session signal.
+
+**Why we skip `turn_context.cwd`.** It carries no information beyond
+`session_meta.cwd` (always equal). Worse: treating it as a live cwd
+source creates a regression. Sequence: `session_meta(A)` →
+`exec_command.workdir(B)` would correctly emit `agent-cwd=A` then
+`agent-cwd=B`. But the NEXT turn's `turn_context(A)` (still pinned to
+session start) would then emit `agent-cwd=A` again, falsely reverting
+the pane chip to the starting checkout on every reasoning-only turn.
+The codex review on this spec (HIGH finding 2026-05-22) caught this
+hazardous ordering. Dropping `turn_context` from the source list
+removes the bug at the design level. If future Codex versions
+actually start updating `turn_context.cwd` mid-session, we'd add it
+back behind a schema-version gate — but that's not a current
+problem.
 
 Transition semantics carry over from PR #239: track `last_cwd:
 Option<String>` across calls; emit `AgentCwdEvent` only on changes;
@@ -75,15 +88,16 @@ emitted nothing (no `turn_context` update).
 
 ### 1.2 What v2 changes from v1
 
-- Extraction logic is split into three helper functions (or one
-  unified dispatcher), one per source.
-- `extract_session_cwd` is renamed / supplemented by
-  `extract_codex_cwd` (or kept and joined by `extract_exec_workdir`)
-  to reflect that `workdir` extraction is now in scope.
+- Extraction logic is split into three helper functions (one per
+  source plus a dispatcher).
+- `extract_session_cwd` matches `session_meta` ONLY (not
+  `turn_context` — see "Why we skip `turn_context.cwd`" above).
+- New `extract_exec_workdir` helper for the mid-session signal.
+- New `extract_codex_cwd` dispatcher.
 - The doc comments and spec now correctly describe Codex's per-source
-  semantics — "session-start in `session_meta`/`turn_context`,
-  mid-session in `exec_command.workdir`" — rather than v1's
-  "session_meta + turn_context per-turn".
+  semantics — "session start from `session_meta`, mid-session from
+  `exec_command.workdir`" — rather than v1's "session_meta +
+  turn_context per-turn".
 
 ## 2. Scope
 
@@ -93,10 +107,12 @@ Behavior change in one implementation file; doc-comment and JSDoc
 edits in three further files complete the work cleanly:
 
 - **Behavior:** `crates/backend/src/agent/adapter/codex/transcript.rs`
-  — the actual extraction + emission logic. Three sources:
-  `session_meta.payload.cwd`, `turn_context.payload.cwd`, and
-  `response_item.payload.arguments.workdir` (parsed JSON; scoped to
-  function calls named `exec_command`).
+  — the actual extraction + emission logic. Two sources:
+  `session_meta.payload.cwd` (session-start anchor) and
+  `response_item.payload.arguments.workdir` (mid-session signal, parsed
+  JSON; scoped to function calls named `exec_command`).
+  **`turn_context.cwd` is intentionally NOT a source** — it would
+  cause false reverts. See 1.1.
 - **Doc-comment fix** on `AgentCwdEvent` in
   `crates/backend/src/agent/types.rs` (currently says cwd is sourced
   from "the structured `cwd` field that Claude Code (and Codex,
@@ -112,8 +128,8 @@ edits in three further files complete the work cleanly:
     the comment above the `agentStatus.cwd → updatePaneCwd` bridge).
 - Add private helpers in `codex/transcript.rs`:
   - `extract_session_cwd(&Value) -> Option<&str>` — pulls
-    `payload.cwd` when `type` is `session_meta` or `turn_context`,
-    empty-string filtered out.
+    `payload.cwd` when `type == "session_meta"` ONLY (not
+    `turn_context`). Empty-string filtered out.
   - `extract_exec_workdir(&Value) -> Option<String>` — pulls
     `payload.arguments.workdir` when `type == "response_item"` AND
     `payload.type == "function_call"` AND `payload.name ==
@@ -131,14 +147,21 @@ edits in three further files complete the work cleanly:
 - Imports: `crate::agent::events::emit_agent_cwd` and
   `crate::agent::types::AgentCwdEvent`.
 - Unit-test coverage:
-  - 4 tests for `extract_session_cwd` (session_meta + turn_context
-    positive; missing payload, missing cwd, empty string negatives).
+  - 4 tests for `extract_session_cwd` (session_meta positive;
+    `turn_context` REJECTED — defensive against re-introduction;
+    missing payload; empty string).
   - 6 tests for `extract_exec_workdir` (happy path; wrong event
     type; wrong function-call type; wrong tool name; malformed
     arguments JSON; missing workdir).
-  - 3 transition-semantics tests covering first-emit, dedup, and
-    multi-source transitions (session_meta → exec_command workdir).
-  - 1 end-to-end fixture-driven test in `start_tailing`.
+  - 4 transition-semantics tests covering first-emit, dedup across
+    sources, multi-source transitions (session_meta → exec_command
+    workdir), AND the regression case
+    (`session_meta(A) → exec_command(B) → turn_context(A)` MUST NOT
+    emit a third `agent-cwd=A` revert).
+  - 1 end-to-end fixture-driven test in `start_tailing` that
+    includes a `turn_context(A)` line after an `exec_command(B)` to
+    guard against re-introduction of the bug at the integration
+    layer.
 
 ### Out of scope (deferred, not lost)
 
@@ -196,11 +219,14 @@ The cwd-carrying shapes are:
 
 Empirical findings from rollouts on disk:
 
-- `session_meta.cwd` and `turn_context.cwd` carry the **session's
-  starting cwd** and are pinned for the life of the session. No
-  rollout in `~/.codex/sessions/` showed a `turn_context.cwd` value
-  different from its `session_meta.cwd`, even across long sessions
-  where codex was instructed to switch worktrees.
+- `session_meta.cwd` carries the **session's starting cwd** and is
+  pinned for the life of the session.
+- `turn_context.cwd` is repeated on every turn and equals
+  `session_meta.cwd` in every rollout checked, even across long
+  sessions where codex was instructed to switch worktrees.
+  **v2 ignores this field** — it is information-free at best and a
+  source of false-revert bugs at worst. See "Why we skip
+  `turn_context.cwd`" in section 1.
 - `exec_command.arguments` is a JSON-encoded **string**, not a
   nested object. Parsing it yields `{cmd, workdir, …}`. The
   `workdir` is codex's actual mid-session working directory and
@@ -222,13 +248,16 @@ keeps each individual helper small and unit-testable.
 ```rust
 /// Pull session-start cwd off a Codex rollout JSONL line.
 ///
-/// Returns `Some(cwd)` only for `session_meta` / `turn_context` entries.
-/// In practice both carry the SAME value (the session's starting cwd);
-/// `turn_context` is kept here as a defensive anchor in case a future
-/// Codex schema starts updating it. Empty strings filtered out.
+/// Returns `Some(cwd)` ONLY for `session_meta` entries — the
+/// session-start anchor. `turn_context.cwd` is intentionally NOT
+/// matched here: empirically it just repeats `session_meta.cwd`
+/// every turn (no information value), and treating it as a live cwd
+/// would cause false reverts on reasoning-only turns after an
+/// `exec_command.workdir` transition has already moved us to a new
+/// directory. See spec section 1.
 fn extract_session_cwd(value: &Value) -> Option<&str> {
     let event_type = value.get("type").and_then(Value::as_str)?;
-    if event_type != "session_meta" && event_type != "turn_context" {
+    if event_type != "session_meta" {
         return None;
     }
     value
@@ -344,19 +373,21 @@ call sites in the read loop (single-line + partial-line branches).
 - **Missing payload / missing field / wrong type → silently `None`.**
   All `?` and `.and_then(…)` short-circuits.
 - **Temporal granularity is per-exec_command, not per-line and not
-  per-turn.** This is the v2-corrected understanding. Codex emits
-  cwd transitions whenever it runs a tool command in a new
-  directory — typically the first exec_command after a "switch to
-  worktree X" instruction. Bare turn boundaries do NOT carry cwd
-  changes (the `turn_context.cwd` field is static across a session).
-  In practice this means the pane chip catches up to the new cwd
-  on the FIRST exec_command after a worktree switch, which is
-  usually within ~1s of codex's "switching to" message.
+  per-turn.** Codex emits cwd transitions whenever it runs a tool
+  command in a new directory — typically the first exec_command
+  after a "switch to worktree X" instruction. The pane chip catches
+  up to the new cwd on that first exec_command, usually within ~1s
+  of codex's "switching to" message.
 - **Reasoning-only turns don't emit.** A turn that produces only
   text + thinking (no tool calls) won't emit a transition. This is
   correct — codex hasn't "moved" yet, it's just thinking. The next
-  exec_command (or session start, or new session_meta on reattach)
-  fires.
+  exec_command (or new session_meta on reattach) fires.
+- **`turn_context` lines never emit.** Even though they carry a
+  `payload.cwd` field, the extractor dispatcher does not look at
+  them. This is the v2-codex-review fix: treating `turn_context.cwd`
+  as a live cwd would cause a false revert after every
+  reasoning-only turn that follows an `exec_command.workdir`
+  transition.
 
 ## 4. Components & files
 
@@ -364,7 +395,7 @@ call sites in the read loop (single-line + partial-line branches).
 
 | File                                                   | Change                                                                                                                                                                                                                                                                                      |
 | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `crates/backend/src/agent/adapter/codex/transcript.rs` | Add 3 helpers (`extract_session_cwd`, `extract_exec_workdir`, `extract_codex_cwd`), thread `last_cwd: Option<String>` through `tail_loop` + `process_line`, add cwd extraction + transition emission, expand imports, 14 new tests (4 session_cwd + 6 exec_workdir + 3 transition + 1 e2e). |
+| `crates/backend/src/agent/adapter/codex/transcript.rs` | Add 3 helpers (`extract_session_cwd`, `extract_exec_workdir`, `extract_codex_cwd`), thread `last_cwd: Option<String>` through `tail_loop` + `process_line`, add cwd extraction + transition emission, expand imports, 15 new tests (4 session_cwd + 6 exec_workdir + 4 transition + 1 e2e). |
 | `crates/backend/src/agent/types.rs`                    | Edit the doc comment above `AgentCwdEvent` (line ~157–164) to describe both adapters' real shapes (Claude per-line, Codex per-exec_command).                                                                                                                                                |
 | `src/bindings/AgentCwdEvent.ts`                        | Regenerated by `npm run generate:bindings`. Not hand-edited.                                                                                                                                                                                                                                |
 | `src/features/agent-status/types/index.ts`             | Doc-only — update the JSDoc block above `cwd: string \| null` (around lines 54–62) to match the corrected source description. No type change.                                                                                                                                               |
@@ -436,13 +467,15 @@ with:
 /// JSONL:
 /// - **Claude Code** writes a top-level `cwd` field on every transcript
 ///   entry; transitions fire as soon as the next line is parsed.
-/// - **Codex** writes cwd in three places: `session_meta.payload.cwd`
-///   (once, at session start), `turn_context.payload.cwd` (per turn,
-///   pinned to the session-start value in practice), and
+/// - **Codex** writes cwd in two places the watcher reads:
+///   `session_meta.payload.cwd` (once, at session start) and
 ///   `response_item.payload.arguments.workdir` for `exec_command`
 ///   function calls (the mid-session signal — fires whenever codex
-///   runs a tool command in a new directory). The watcher reads all
-///   three.
+///   runs a tool command in a new directory). Codex also writes
+///   `turn_context.payload.cwd` on every turn, but the watcher
+///   intentionally ignores that field because it's pinned to the
+///   session-start value and would cause false reverts after a
+///   mid-session `exec_command.workdir` transition.
 ///
 /// In both cases this is the authoritative signal for "where the agent
 /// currently is" — it picks up tool-call-driven moves like Claude's
@@ -471,12 +504,12 @@ in the file.
 
 ### 5.2 `extract_session_cwd` unit tests (4)
 
-| Test                                            | Input shape                                      | Expected     |
-| ----------------------------------------------- | ------------------------------------------------ | ------------ |
-| `extract_session_cwd_session_meta_returns_cwd`  | `{"type":"session_meta","payload":{"cwd":"/x"}}` | `Some("/x")` |
-| `extract_session_cwd_turn_context_returns_cwd`  | `{"type":"turn_context","payload":{"cwd":"/x"}}` | `Some("/x")` |
-| `extract_session_cwd_other_type_returns_none`   | `{"type":"event_msg","payload":{"cwd":"/x"}}`    | `None`       |
-| `extract_session_cwd_empty_string_returns_none` | `{"type":"turn_context","payload":{"cwd":""}}`   | `None`       |
+| Test                                            | Input shape                                      | Expected                                                                  |
+| ----------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------- |
+| `extract_session_cwd_session_meta_returns_cwd`  | `{"type":"session_meta","payload":{"cwd":"/x"}}` | `Some("/x")`                                                              |
+| `extract_session_cwd_turn_context_returns_none` | `{"type":"turn_context","payload":{"cwd":"/x"}}` | `None` _(turn_context is intentionally NOT a cwd source — see section 1)_ |
+| `extract_session_cwd_other_type_returns_none`   | `{"type":"event_msg","payload":{"cwd":"/x"}}`    | `None`                                                                    |
+| `extract_session_cwd_empty_string_returns_none` | `{"type":"session_meta","payload":{"cwd":""}}`   | `None`                                                                    |
 
 ### 5.3 `extract_exec_workdir` unit tests (6)
 
@@ -489,21 +522,23 @@ in the file.
 | `extract_exec_workdir_malformed_arguments_json_returns_none` | `arguments` is `"{not json"`                                                                    | `None`       |
 | `extract_exec_workdir_missing_workdir_field_returns_none`    | `arguments={"cmd":"ls"}`                                                                        | `None`       |
 
-### 5.4 Transition semantics tests (3)
+### 5.4 Transition semantics tests (4)
 
 Drive `process_line` through a sequence of lines on a
 `FakeEventSink`. Each test sets up empty `last_cwd: None` + empty
 `in_flight`, calls `process_line` N times, then asserts.
 
-| Test                                                  | Sequence                                                                      | Expected `agent-cwd` |
-| ----------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------- |
-| `process_line_first_cwd_always_emits`                 | `session_meta(cwd=A)`                                                         | 1 (A)                |
-| `process_line_repeated_cwd_across_sources_suppresses` | `session_meta(cwd=A)` → `turn_context(cwd=A)` → `exec_command(workdir=A)`     | 1 (A)                |
-| `process_line_cwd_transition_across_sources_emits`    | `session_meta(cwd=A)` → `exec_command(workdir=B)` → `exec_command(workdir=A)` | 3 (A, B, A)          |
+| Test                                                           | Sequence                                                                      | Expected `agent-cwd`                                   |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `process_line_first_cwd_always_emits`                          | `session_meta(cwd=A)`                                                         | 1 (A)                                                  |
+| `process_line_repeated_cwd_across_sources_suppresses`          | `session_meta(cwd=A)` → `exec_command(workdir=A)`                             | 1 (A)                                                  |
+| `process_line_cwd_transition_across_sources_emits`             | `session_meta(cwd=A)` → `exec_command(workdir=B)` → `exec_command(workdir=A)` | 3 (A, B, A)                                            |
+| `process_line_turn_context_after_exec_command_does_not_revert` | `session_meta(cwd=A)` → `exec_command(workdir=B)` → `turn_context(cwd=A)`     | 2 (A, B) _(turn_context MUST NOT cause a revert to A)_ |
 
-The third test specifically covers the v2-critical case: a
-session_meta → exec_command transition (the real codex mid-session
-switch pattern).
+The third test covers the v2 mid-session switch pattern. The fourth
+test is the v2-critical regression guard: it locks in the codex
+review (HIGH finding 2026-05-22) — if anyone re-adds `turn_context`
+to the cwd source list, this test fires.
 
 ### 5.5 End-to-end watcher test (1)
 
@@ -518,13 +553,14 @@ fn start_tailing_emits_cwd_transitions_in_order() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let transcript_path = tmp.path().join("rollout.jsonl");
 
-    // 6 lines, 3 expected emissions:
+    // 7 lines, 3 expected emissions:
     //   1. session_meta cwd=/workspace/A             (emit)
-    //   2. turn_context cwd=/workspace/A             (suppressed — same)
+    //   2. turn_context cwd=/workspace/A             (no emit — extractor rejects turn_context)
     //   3. exec_command workdir=/workspace/B         (emit — transition)
     //   4. event_msg task_started                    (no emit)
     //   5. exec_command workdir=/workspace/B         (suppressed — same)
-    //   6. exec_command workdir=/workspace/A         (emit — transition back)
+    //   6. turn_context cwd=/workspace/A             (no emit — REGRESSION GUARD: must not revert to A)
+    //   7. exec_command workdir=/workspace/A         (emit — transition back)
     write_rollout(
         &transcript_path,
         &[
@@ -551,6 +587,9 @@ fn start_tailing_emits_cwd_transitions_in_order() {
                     "arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"
                 }
             }),
+            // Regression guard: turn_context pinned to A AFTER we moved
+            // to B via exec_command must NOT cause a revert to A.
+            json!({"timestamp":"2026-05-22T10:00:04.5Z","type":"turn_context","payload":{"turn_id":"t2","cwd":"/workspace/A"}}),
             json!({
                 "timestamp":"2026-05-22T10:00:05Z",
                 "type":"response_item",

--- a/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
+++ b/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
@@ -376,13 +376,19 @@ Proposed text:
 ```
 
 The `#[cfg_attr(test, derive(ts_rs::TS))]` + `ts(export)` attributes on
-`AgentCwdEvent` mean `cargo test` (under the existing project test
-config) regenerates `src/bindings/AgentCwdEvent.ts` with the new comment
-text. **The ts-rs binding itself is not hand-edited** — it's
-regenerated and committed alongside the Rust change. The two frontend
-JSDoc comments listed in 4.1 (`agent-status/types/index.ts` and
-`workspace/WorkspaceView.tsx`) ARE hand-edited; they live outside ts-rs
-and have to be updated manually.
+`AgentCwdEvent` regenerate `src/bindings/AgentCwdEvent.ts` with the
+new comment text. The canonical regeneration path in this repo is the
+`npm run generate:bindings` script — it runs
+`cargo test --manifest-path crates/backend/Cargo.toml export_bindings`
+to produce the ts-rs output, then `prettier --write src/bindings/` to
+format it. Skipping the prettier step (e.g. running just `cargo test`
+on its own) can leave raw generated formatting in the file and fail
+the `npm run format:check` gate. **The ts-rs binding itself is not
+hand-edited** — it's regenerated via `npm run generate:bindings` and
+committed alongside the Rust change. The two frontend JSDoc comments
+listed in 4.1 (`agent-status/types/index.ts` and
+`workspace/WorkspaceView.tsx`) ARE hand-edited; they live outside
+ts-rs and have to be updated manually.
 
 ## 5. Testing strategy
 
@@ -527,15 +533,25 @@ fn start_tailing_emits_cwd_transitions_in_order() {
 ### 5.5 ts-rs regeneration verification
 
 `AgentCwdEvent` already carries `#[cfg_attr(test, derive(ts_rs::TS))]` +
-`ts(export)`. Running `cargo test --lib` regenerates
-`src/bindings/AgentCwdEvent.ts` with the updated doc comment.
+`ts(export)`. Regeneration path:
+
+```bash
+npm run generate:bindings
+```
+
+which expands to
+`cargo test --manifest-path crates/backend/Cargo.toml export_bindings && prettier --write src/bindings/`.
+Running plain `cargo test --lib` will technically regenerate the file
+but leaves it un-formatted, which fails `npm run format:check`.
+
 Verification:
 
-- After running tests once locally, `git diff src/bindings/AgentCwdEvent.ts`
+- After `npm run generate:bindings`, `git diff src/bindings/AgentCwdEvent.ts`
   should show the doc-comment block changing to mention both adapters'
-  shapes (Claude per-line, Codex per-turn).
-- This is committed alongside the Rust change so reviewers see the
-  regenerated binding match the spec.
+  shapes (Claude per-line, Codex per-turn) and the file should already
+  be prettier-formatted (no further format step needed).
+- The regenerated binding is committed alongside the Rust change so
+  reviewers see the binding match the spec.
 
 ### 5.6 Commands
 
@@ -559,9 +575,17 @@ npm run type-check
 
 ### 5.7 Coverage expectation
 
-- New code: 100% covered (every branch in `extract_session_cwd` has a
-  dedicated unit test; transitions exercise both first-cwd and dedup
-  paths; the e2e test covers the read-loop integration).
+- **Extraction + transition behavior: 100% covered.** Every branch in
+  `extract_session_cwd` has a dedicated unit test; transitions exercise
+  first-cwd, dedup, and back-and-forth paths; the e2e test covers the
+  read-loop integration.
+- **Not covered:** the `emit_agent_cwd` error branch (the `log::warn`
+  on emission failure inside `process_line`). The branch is a defensive
+  logging path identical to the existing `emit_agent_tool_call` /
+  `emit_agent_turn` error branches in this file, which are also
+  untested; covering it would require a `FailingEventSink` test double
+  that doesn't exist today. Out of scope for this PR — flagged here
+  so the coverage claim isn't read as stronger than it is.
 - File-level coverage stays ≥80% per rules/common/testing.md.
 
 ### 5.8 Deviation log

--- a/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
+++ b/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
@@ -1,0 +1,575 @@
+# 2026-05-22 — Codex transcript cwd parser design
+
+## 1. Summary
+
+PR #239 added a structured `agent-cwd` event channel for the Claude Code
+transcript watcher (`crates/backend/src/agent/adapter/claude_code/transcript.rs`).
+That channel is the load-bearing path for keeping `pane.cwd` in sync when an
+agent moves between worktrees via in-process tool calls that intentionally
+don't mutate the interactive shell's `$PWD` (Claude's built-in
+`EnterWorktree`, Superpowers' worktree skill, etc.). Without it, OSC 7 and
+the text-pattern `agentCwdHint` paths are structurally blind to those moves
+and the per-pane chip pins to the starting checkout.
+
+PR #239's "Follow-ups" list named the matching work for the Codex adapter
+as the next small piece on top of that foundation:
+
+> Codex transcript cwd: same extraction in
+> `crates/backend/src/agent/adapter/codex/parser.rs` for the Codex rollout
+> JSONL. Field is in the same place; should be a small commit on top of
+> this PR's foundation.
+
+This spec covers that follow-up — port the `agent-cwd` extraction to the
+Codex rollout JSONL watcher so Codex panes get a cwd channel sourced from
+Codex's transcript JSONL. The temporal contract differs from Claude Code's
+per-line `cwd` channel and the implementation has to make that explicit:
+Codex's `cwd` field lives only on `session_meta` (once, at session start)
+and `turn_context` (once per turn) entries, so cwd transitions fire at
+session start and at each turn boundary — **not mid-turn**. A Codex-side
+worktree switch invoked mid-turn (e.g. an `apply_patch` that does its own
+`cd`, or an out-of-band `cd` inside an `exec_command` block) does not
+surface a new `agent-cwd` event until the next `turn_context` line is
+written, which typically happens when the agent next responds to the
+user. This is a known semantic limitation of the Codex rollout schema as
+of `cli_version 0.132.0` — not a shortcoming of the extraction logic.
+
+Two caveats from PR #239's wording have to be corrected in the
+implementation:
+
+1. **Wrong file.** The live event channel lives in `transcript.rs`, not
+   `parser.rs`. `codex/parser.rs` produces `AgentStatusEvent` snapshots
+   (tokens, cost, rate limits) — that event type has no `cwd` field, and
+   the frontend's `pane.cwd` is driven exclusively by `agent-cwd` events
+   emitted by the transcript tailer. The change lands in
+   `crates/backend/src/agent/adapter/codex/transcript.rs`.
+2. **"Same place" is misleading.** Claude Code stamps a top-level `cwd`
+   field on every JSONL line. Codex does not. In the Codex rollout JSONL
+   (verified against real `cli_version 0.132.0` rollouts on disk), `cwd`
+   appears only nested under two event types:
+   - `session_meta.payload.cwd` — once at session start.
+   - `turn_context.payload.cwd` — once per turn.
+
+   `event_msg` and `response_item` lines do **not** carry session cwd. The
+   per-`function_call` `arguments.workdir` is a per-command scratch path,
+   not the session cwd, and is deliberately ignored.
+
+   The extraction logic therefore can't be a structural copy-paste of
+   Claude's "every line has cwd at top-level" shape. It needs a small
+   helper scoped to the two event types that actually carry session cwd.
+
+The frontend side is already wired generically: `useAgentStatus` listens
+for `agent-cwd` regardless of agent type, and `WorkspaceView` bridges the
+hook output to `updatePaneCwd` (both shipped in PR #239 commit 5). Codex
+panes pick up cwd tracking the moment the backend starts emitting — no
+frontend change needed.
+
+## 2. Scope
+
+### In scope
+
+Behavior change in one implementation file; the rest are comment-only
+or fixture additions that complete the work cleanly:
+
+- **Behavior:** `crates/backend/src/agent/adapter/codex/transcript.rs` —
+  the actual extraction + emission logic.
+- **Doc-comment fix** on `AgentCwdEvent` in
+  `crates/backend/src/agent/types.rs` (currently says cwd is sourced from
+  "the structured `cwd` field that Claude Code (and Codex, **pending
+  follow-up**) writes on **every** transcript JSONL entry" — this PR
+  _is_ that follow-up, and the "every entry" claim is wrong for Codex).
+  The ts-rs binding at `src/bindings/AgentCwdEvent.ts` is regenerated
+  from the Rust doc-comment on test runs, so it updates automatically;
+  the spec calls out both files for clarity, but the binding is not
+  hand-edited.
+- **Frontend comment fixes** (no behavior change) — two JSDoc-style
+  block comments that repeat the same stale "every transcript JSONL
+  entry" claim and explicitly say "Codex follow-up", which this PR
+  resolves:
+  - `src/features/agent-status/types/index.ts` (around line 54–62, the
+    `cwd: string | null` field on the agent-status state).
+  - `src/features/workspace/WorkspaceView.tsx` (around line 315–321,
+    the comment above the `agentStatus.cwd → updatePaneCwd` bridge).
+- Add `extract_session_cwd(&Value) -> Option<&str>` private helper that
+  returns `payload.cwd` when `type` is `session_meta` or `turn_context`,
+  empty-string filtered out.
+- Add `last_cwd: Option<String>` state to the `tail_loop` and thread it
+  through `process_line`.
+- Emit `AgentCwdEvent` via the existing `emit_agent_cwd` helper on
+  transitions only (first observed cwd always fires; repeated identical
+  cwd values do not re-emit).
+- Imports: `crate::agent::events::emit_agent_cwd` and
+  `crate::agent::types::AgentCwdEvent`.
+- Unit-test coverage for the extraction helper and the transition
+  semantics (rules/rust/testing.md: `#[cfg(test)] mod tests` co-located).
+- End-to-end fixture coverage in `start_tailing` mirroring the existing
+  `start_tailing_replays_tool_calls_turns_and_test_runs` test — drive a
+  rollout through the tailer and assert `agent-cwd` events arrive in the
+  expected order on a `FakeEventSink`.
+
+### Out of scope (deferred, not lost)
+
+- **Issue #234** — persisted-session-cache refactor that reshapes the
+  flat PTY cache into a session→pane graph with per-pane cwd. The
+  agent-cwd channel this spec lands is a prerequisite for #234's
+  per-pane cwd persistence to work for Codex panes, but the schema
+  change itself is a separate spec/PR.
+- **Shell-pwd-doesn't-inherit-from-pane-1** — newly opened shell panes
+  don't start in the active pane's cwd. Separate root-cause investigation
+  needed in the terminal/PTY spawn path; not in this PR.
+- **Pruning the now-redundant `agentCwdHint` text patterns in
+  `Body.tsx`** — PR #239's other "Follow-ups" item; deferred until both
+  Claude and Codex adapters' structured channels have been validated in
+  production. OSC 7 and the Claude-startup-banner home-cwd resolution
+  stay either way — they cover interactive-shell `cd` cases the JSONL
+  channel doesn't see.
+- **`codex/transcript.rs` is already 953 lines** (rules say ≤400
+  typical, ≤800 max). This PR adds ~25 lines, pushing it further over.
+  Splitting is a separate refactor PR; calling it out here so the debt
+  is visible and not silently accumulating.
+- **`codex/parser.rs` changes** — none needed. The status-snapshot path
+  consumes `AgentStatusEvent`, which has no `cwd` field; adding one
+  would require a frontend change with no current consumer. If a future
+  consumer needs the cwd in the status snapshot, that's its own spec.
+
+### PR scope discipline
+
+One PR, one question: _Does the Codex transcript emit `agent-cwd` events
+with the same transition-only semantics as the Claude Code transcript?_
+No drive-by refactors, no incidental file moves, no unrelated test
+cleanup.
+
+## 3. Data flow & extraction shape
+
+### 3.1 Codex rollout JSONL shape (verified against `cli_version 0.132.0`)
+
+```jsonl
+{"timestamp":"…","type":"session_meta","payload":{"id":"…","cwd":"/abs/path","cli_version":"0.132.0", …}}
+{"timestamp":"…","type":"turn_context","payload":{"turn_id":"…","cwd":"/abs/path","model":"gpt-5.4", …}}
+{"timestamp":"…","type":"event_msg","payload":{"type":"task_started", …}}
+{"timestamp":"…","type":"event_msg","payload":{"type":"token_count", …}}
+{"timestamp":"…","type":"response_item","payload":{"type":"function_call","call_id":"…","arguments":"…"}}
+```
+
+Only `session_meta` and `turn_context` carry `payload.cwd`. Function-call
+`arguments.workdir` is per-command scratch and intentionally not
+considered session cwd.
+
+### 3.2 Extraction helper
+
+Private to `transcript.rs`:
+
+```rust
+fn extract_session_cwd(value: &Value) -> Option<&str> {
+    let event_type = value.get("type").and_then(Value::as_str)?;
+    if event_type != "session_meta" && event_type != "turn_context" {
+        return None;
+    }
+    value
+        .get("payload")?
+        .get("cwd")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+```
+
+Named `extract_session_cwd` (not `extract_cwd`) to make scope explicit —
+we are not pulling the per-command `workdir`.
+
+### 3.3 Integration into `process_line`
+
+```rust
+fn process_line(
+    line: &str,
+    session_id: &str,
+    cwd: Option<&Path>,
+    events: &Arc<dyn EventSink>,
+    emitter: &mut TestRunEmitter,
+    in_flight: &mut InFlightToolCalls,
+    num_turns: &mut u32,
+    last_cwd: &mut Option<String>,
+) {
+    let value: Value = match serde_json::from_str(line) {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+
+    if let Some(observed) = extract_session_cwd(&value) {
+        if last_cwd.as_deref().map_or(true, |seen| seen != observed) {
+            let event = AgentCwdEvent {
+                session_id: session_id.to_string(),
+                cwd: observed.to_string(),
+            };
+            if let Err(e) = emit_agent_cwd(events.as_ref(), &event) {
+                log::warn!("Failed to emit agent-cwd event: {}", e);
+            }
+            *last_cwd = Some(observed.to_string());
+        }
+    }
+
+    match value.get("type").and_then(Value::as_str) {
+        Some("response_item") => { /* unchanged */ }
+        Some("event_msg")     => { /* unchanged */ }
+        _ => {}
+    }
+}
+```
+
+Pre-match placement mirrors the Claude Code structure so a side-by-side
+diff between `claude_code/transcript.rs::process_line` and
+`codex/transcript.rs::process_line` makes the parity obvious.
+
+### 3.4 `tail_loop` state
+
+Add `let mut last_cwd: Option<String> = None;` next to the existing
+`num_turns` declaration. Thread it through to `process_line` (one new
+parameter at the end of the signature, matching Claude's call shape).
+
+### 3.5 Transition semantics
+
+- **First observed cwd always emits.** `last_cwd: None` →
+  `map_or(true, …)` short-circuits true on the first hit. Matches Claude.
+- **Repeated identical cwd suppresses.** `turn_context` lines fire once
+  per turn and frequently repeat the same cwd; only transitions emit.
+- **Empty string filtered at the extraction site.** `filter(|s|
+!s.is_empty())` inside `extract_session_cwd`. Matches Claude's
+  `!observed.is_empty()` guard.
+- **Malformed JSON skipped silently.** The existing `serde_json::from_str`
+  arm returns early; extraction never runs on malformed input.
+- **Missing `payload` or missing `cwd` field skipped silently.** Both
+  `?` operators in `extract_session_cwd` short-circuit to `None`.
+- **Temporal granularity is per-turn, not per-line.** This is the key
+  divergence from Claude. Codex's rollout schema only carries `cwd` on
+  `session_meta` (once) and `turn_context` (per turn). Mid-turn worktree
+  switches won't surface a new `agent-cwd` event until the next
+  `turn_context` line. In practice this means the pane chip may lag by
+  up to one turn after a tool-driven `cd`; the next user prompt or
+  agent turn closes the gap. This is a schema-imposed limit, not a
+  bug — the only ways to close the gap further would be (a) ask the
+  Codex team to add a mid-turn cwd event (out of scope), or (b) wire a
+  parallel text-pattern heuristic similar to Claude's `agentCwdHint`
+  for Codex output (deferred; the structured channel is the canonical
+  source, mirroring PR #239's design decision).
+
+## 4. Components & files
+
+### 4.1 Files changed
+
+| File                                                   | Change                                                                                                                                                                                                                        |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `crates/backend/src/agent/adapter/codex/transcript.rs` | Add `extract_session_cwd` helper, thread `last_cwd: Option<String>` through `tail_loop` + `process_line`, add cwd extraction + transition emission, expand imports.                                                           |
+| `crates/backend/src/agent/types.rs`                    | Edit the doc comment above `AgentCwdEvent` (line ~157–164) to drop "pending follow-up" / "every transcript JSONL entry" and describe both adapters' real field shapes.                                                        |
+| `src/bindings/AgentCwdEvent.ts`                        | Regenerated by `ts-rs` on `cargo test` runs (the `#[cfg_attr(test, derive(ts_rs::TS))]` + `ts(export)` attributes on `AgentCwdEvent`). Not hand-edited. The new doc-comment text appears in the generated `/**…*/` block.     |
+| `src/features/agent-status/types/index.ts`             | Doc-only — update the JSDoc block above `cwd: string \| null` (around lines 54–62) to drop "every transcript JSONL entry (Claude Code today; Codex follow-up)" and describe both adapters' real field shapes. No type change. |
+| `src/features/workspace/WorkspaceView.tsx`             | Doc-only — update the comment block above the `agentStatus.cwd → updatePaneCwd` bridge (around lines 315–321) for the same reason. No behavior change.                                                                        |
+
+### 4.2 Files NOT changed
+
+- `crates/backend/src/agent/adapter/codex/parser.rs` — status snapshot path, no cwd.
+- `crates/backend/src/agent/adapter/codex/mod.rs` — adapter trait impl; unchanged.
+- `crates/backend/src/agent/adapter/codex/locator.rs`, `types.rs` — unrelated.
+- `crates/backend/src/agent/events.rs` — `emit_agent_cwd` already exists (PR #239 commit 5).
+- `crates/backend/src/agent/types.rs` `AgentCwdEvent` _struct_ — fields stay
+  `(session_id, cwd)`. Only the doc comment changes.
+- Frontend behavior: `useAgentStatus`, `WorkspaceView`, pane state — all
+  already listen to `agent-cwd` regardless of agent type. The hook,
+  bridge, and pane-state code are untouched. Only two JSDoc-style
+  comment blocks change (see 4.1), and those changes are non-functional.
+
+### 4.3 New helper
+
+Added near the top of `codex/transcript.rs`, just above `validate_transcript_path`:
+
+```rust
+/// Pull session-level cwd off a Codex rollout JSONL line.
+///
+/// Returns `Some(cwd)` only for the two event types that actually carry
+/// session cwd in the rollout schema as of `cli_version 0.132.0`:
+///   - `session_meta.payload.cwd` — fires once at session start.
+///   - `turn_context.payload.cwd` — fires per turn.
+///
+/// Empty strings are filtered out at the extraction site, matching the
+/// Claude Code transcript watcher's guard. Function-call
+/// `arguments.workdir` is per-command scratch and deliberately not
+/// considered session cwd.
+fn extract_session_cwd(value: &Value) -> Option<&str> {
+    let event_type = value.get("type").and_then(Value::as_str)?;
+    if event_type != "session_meta" && event_type != "turn_context" {
+        return None;
+    }
+    value
+        .get("payload")?
+        .get("cwd")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+```
+
+### 4.4 `process_line` signature extension
+
+Adds one parameter at the end (matching Claude's call shape so the two
+adapters' `process_line` signatures stay structurally aligned):
+
+```rust
+// Before (current):
+fn process_line(
+    line: &str,
+    session_id: &str,
+    cwd: Option<&Path>,
+    events: &Arc<dyn EventSink>,
+    emitter: &mut TestRunEmitter,
+    in_flight: &mut InFlightToolCalls,
+    num_turns: &mut u32,
+) { … }
+
+// After:
+fn process_line(
+    line: &str,
+    session_id: &str,
+    cwd: Option<&Path>,
+    events: &Arc<dyn EventSink>,
+    emitter: &mut TestRunEmitter,
+    in_flight: &mut InFlightToolCalls,
+    num_turns: &mut u32,
+    last_cwd: &mut Option<String>,  // new
+) { … }
+```
+
+### 4.5 `tail_loop` state addition
+
+In `fn tail_loop`, alongside `let mut num_turns = 0_u32;`:
+
+```rust
+let mut last_cwd: Option<String> = None;
+```
+
+Threaded into both `process_line(…)` call sites in the read loop (the
+single-line branch and the partial-line branch — `codex/transcript.rs`
+has two because of its chunk-spanning partial-line handler at lines
+~152–185).
+
+### 4.6 Updated `AgentCwdEvent` doc comment
+
+Current text (`crates/backend/src/agent/types.rs:157–164`):
+
+> Sourced from the structured `cwd` field that Claude Code (and Codex,
+> pending follow-up) writes on every transcript JSONL entry. …
+
+Proposed text:
+
+```rust
+/// Event emitted when the agent's tracked working directory changes.
+///
+/// Sourced from each adapter's structured cwd channel in its transcript
+/// JSONL:
+/// - **Claude Code** writes a top-level `cwd` field on every transcript
+///   entry; transitions fire as soon as the next line is parsed.
+/// - **Codex** writes `payload.cwd` only on `session_meta` (once, at
+///   session start) and `turn_context` (per turn) entries; transitions
+///   therefore fire at session start and at each turn boundary, not
+///   mid-turn.
+///
+/// In both cases this is the authoritative signal for "where the agent
+/// currently is" — it picks up tool-call-driven moves like Claude's
+/// `EnterWorktree` that intentionally do NOT mutate the interactive
+/// shell's `$PWD`, so neither OSC 7 nor PTY text patterns can catch
+/// them.
+```
+
+The `#[cfg_attr(test, derive(ts_rs::TS))]` + `ts(export)` attributes on
+`AgentCwdEvent` mean `cargo test` (under the existing project test
+config) regenerates `src/bindings/AgentCwdEvent.ts` with the new comment
+text. **The ts-rs binding itself is not hand-edited** — it's
+regenerated and committed alongside the Rust change. The two frontend
+JSDoc comments listed in 4.1 (`agent-status/types/index.ts` and
+`workspace/WorkspaceView.tsx`) ARE hand-edited; they live outside ts-rs
+and have to be updated manually.
+
+## 5. Testing strategy
+
+### 5.1 Test inventory
+
+Three layers, all co-located in `codex/transcript.rs` (per
+rules/rust/testing.md: `#[cfg(test)] mod tests` at file bottom). Test
+function names match the codebase convention used throughout
+`codex/transcript.rs` and `claude_code/transcript.rs` — descriptive
+`<function>_<scenario>_<expected>` without a `test_` prefix.
+rules/rust/testing.md mentions a `test_` prefix as the rule; we follow
+the codebase here because all ~25 existing tests in
+`codex/transcript.rs` already omit it and matching them keeps the file
+internally consistent (see "deviation log" at the bottom of section 5).
+
+| Layer                        | Target                          | Count |
+| ---------------------------- | ------------------------------- | ----- |
+| Unit — `extract_session_cwd` | Pure extraction logic           | 7     |
+| Unit — transition state      | `process_line`'s last_cwd dedup | 3     |
+| End-to-end — `start_tailing` | Watcher → `FakeEventSink`       | 1     |
+
+### 5.2 `extract_session_cwd` unit tests (7)
+
+Drives the helper directly with hand-built `serde_json::Value`s. No
+filesystem, no threads.
+
+| Test                                               | Input shape                                                               | Expected                                                                     |
+| -------------------------------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `extract_session_cwd_session_meta_returns_cwd`     | `{"type":"session_meta","payload":{"cwd":"/x"}}`                          | `Some("/x")`                                                                 |
+| `extract_session_cwd_turn_context_returns_cwd`     | `{"type":"turn_context","payload":{"cwd":"/x"}}`                          | `Some("/x")`                                                                 |
+| `extract_session_cwd_event_msg_returns_none`       | `{"type":"event_msg","payload":{"cwd":"/x"}}`                             | `None` _(defensive — even if payload carried cwd, the type gate rejects it)_ |
+| `extract_session_cwd_response_item_returns_none`   | `{"type":"response_item","payload":{"arguments":"{\"workdir\":\"/x\"}"}}` | `None` _(workdir is per-command, not session cwd)_                           |
+| `extract_session_cwd_missing_payload_returns_none` | `{"type":"turn_context"}`                                                 | `None`                                                                       |
+| `extract_session_cwd_missing_cwd_returns_none`     | `{"type":"turn_context","payload":{}}`                                    | `None`                                                                       |
+| `extract_session_cwd_empty_string_returns_none`    | `{"type":"turn_context","payload":{"cwd":""}}`                            | `None`                                                                       |
+
+### 5.3 Transition semantics tests (3)
+
+Drive `process_line` through a sequence of lines on a `FakeEventSink`
+from `crate::runtime`. Each test sets up an empty `last_cwd: None`,
+calls `process_line` N times, then asserts the recorded events.
+
+| Test                                   | Sequence                                                              | Expected `agent-cwd` count |
+| -------------------------------------- | --------------------------------------------------------------------- | -------------------------- |
+| `process_line_first_cwd_always_emits`  | `session_meta(cwd=A)`                                                 | 1 (cwd=A)                  |
+| `process_line_repeated_cwd_suppresses` | `session_meta(cwd=A)` → `turn_context(cwd=A)` → `turn_context(cwd=A)` | 1 (cwd=A)                  |
+| `process_line_cwd_transition_emits`    | `session_meta(cwd=A)` → `turn_context(cwd=B)` → `turn_context(cwd=A)` | 3 (A, B, A)                |
+
+These intentionally bypass `start_tailing`'s thread/IO/poll machinery —
+the same approach Claude's `claude_code/transcript.rs` tests use for
+its parsing-shape unit tests.
+
+### 5.4 End-to-end watcher test (1)
+
+`start_tailing_emits_cwd_transitions_in_order` — inline-JSON, mirrors
+the existing `start_tailing_replays_tool_calls_turns_and_test_runs`
+test in the same file (around line 791), which uses the existing
+`write_rollout(&Path, &[Value])` helper. No external fixture file —
+matches the convention used by both `codex/transcript.rs`'s e2e test
+and `claude_code/transcript_fixture_tests.rs`'s `std::fs::write` style
+test setup.
+
+```rust
+#[test]
+fn start_tailing_emits_cwd_transitions_in_order() {
+    let sink = Arc::new(FakeEventSink::new());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let transcript_path = tmp.path().join("rollout.jsonl");
+
+    // 6 lines, 3 expected emissions:
+    //   1. session_meta cwd=/workspace/A   (emit)
+    //   2. turn_context cwd=/workspace/A   (suppressed — same as last)
+    //   3. turn_context cwd=/workspace/B   (emit)
+    //   4. event_msg noise                 (no cwd emit; not a cwd carrier)
+    //   5. response_item noise             (no cwd emit; not a cwd carrier)
+    //   6. turn_context cwd=/workspace/A   (emit)
+    write_rollout(
+        &transcript_path,
+        &[
+            json!({
+                "timestamp": "2026-05-22T10:00:00Z",
+                "type": "session_meta",
+                "payload": { "id": "sid-cwd", "cwd": "/workspace/A" }
+            }),
+            json!({
+                "timestamp": "2026-05-22T10:00:01Z",
+                "type": "turn_context",
+                "payload": { "turn_id": "t1", "cwd": "/workspace/A" }
+            }),
+            json!({
+                "timestamp": "2026-05-22T10:00:02Z",
+                "type": "turn_context",
+                "payload": { "turn_id": "t2", "cwd": "/workspace/B" }
+            }),
+            json!({
+                "timestamp": "2026-05-22T10:00:03Z",
+                "type": "event_msg",
+                "payload": { "type": "task_started" }
+            }),
+            json!({
+                "timestamp": "2026-05-22T10:00:04Z",
+                "type": "response_item",
+                "payload": { "type": "function_call", "call_id": "c1", "name": "noop", "arguments": "{}" }
+            }),
+            json!({
+                "timestamp": "2026-05-22T10:00:05Z",
+                "type": "turn_context",
+                "payload": { "turn_id": "t3", "cwd": "/workspace/A" }
+            }),
+        ],
+    );
+
+    let handle = start_tailing(
+        sink.clone(),
+        "sid-cwd".to_string(),
+        transcript_path,
+        None,  // cwd not needed for this test
+    )
+    .expect("start tailing");
+
+    std::thread::sleep(Duration::from_millis(750));
+    handle.stop();
+    std::thread::sleep(Duration::from_millis(100));
+
+    let cwd_events: Vec<Value> = sink
+        .recorded()
+        .into_iter()
+        .filter(|(event, _)| event == "agent-cwd")
+        .map(|(_, payload)| payload)
+        .collect();
+
+    assert_eq!(cwd_events.len(), 3);
+    assert_eq!(cwd_events[0]["cwd"], "/workspace/A");
+    assert_eq!(cwd_events[1]["cwd"], "/workspace/B");
+    assert_eq!(cwd_events[2]["cwd"], "/workspace/A");
+    for ev in &cwd_events {
+        assert_eq!(ev["sessionId"], "sid-cwd");
+    }
+}
+```
+
+### 5.5 ts-rs regeneration verification
+
+`AgentCwdEvent` already carries `#[cfg_attr(test, derive(ts_rs::TS))]` +
+`ts(export)`. Running `cargo test --lib` regenerates
+`src/bindings/AgentCwdEvent.ts` with the updated doc comment.
+Verification:
+
+- After running tests once locally, `git diff src/bindings/AgentCwdEvent.ts`
+  should show the doc-comment block changing to mention both adapters'
+  shapes (Claude per-line, Codex per-turn).
+- This is committed alongside the Rust change so reviewers see the
+  regenerated binding match the spec.
+
+### 5.6 Commands
+
+```bash
+# Unit + integration tests for the backend crate
+cargo test -p vimeflow --lib
+
+# Specifically the new tests
+cargo test -p vimeflow --lib codex::transcript::tests::extract_session_cwd
+cargo test -p vimeflow --lib codex::transcript::tests::process_line
+cargo test -p vimeflow --lib start_tailing_emits_cwd_transitions
+
+# Husky pre-push (vitest only) — the actual gate before push
+npm test
+
+# Local recommended gates (run before requesting review)
+npm run lint
+npm run format:check
+npm run type-check
+```
+
+### 5.7 Coverage expectation
+
+- New code: 100% covered (every branch in `extract_session_cwd` has a
+  dedicated unit test; transitions exercise both first-cwd and dedup
+  paths; the e2e test covers the read-loop integration).
+- File-level coverage stays ≥80% per rules/common/testing.md.
+
+### 5.8 Deviation log
+
+- **Test naming.** `rules/rust/testing.md` recommends a
+  `test_<function>_<scenario>_<expected>` convention. The codebase
+  uniformly omits the `test_` prefix (e.g., `validate_transcript_path_accepts_file_under_codex_root`,
+  `parse_tool_use_from_assistant_line`). New tests in this PR follow
+  the codebase convention for local consistency; updating the rule
+  doc is out of scope here but is a one-line follow-up if the team
+  wants the rule to match practice.

--- a/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
+++ b/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
@@ -1,110 +1,144 @@
-# 2026-05-22 — Codex transcript cwd parser design
+# 2026-05-22 — Codex transcript cwd parser design (v2)
+
+> **Revision history.** v1 of this spec (commits `36c7bae` → `45da21c`)
+> assumed Codex updates `turn_context.payload.cwd` per turn. Codex
+> implemented v1 faithfully (commits `cab6b73` → `dd95857`) but the
+> feature did not work end-to-end: in a real codex session the user
+> verified, `turn_context.cwd` only ever carried the session's
+> **starting** cwd, never the post-cd value. v1's implementation +
+> codex-reviewed footers were reverted; v2 (this spec) replaces v1's
+> extraction model with one rooted in the actual `cli_version 0.132.0`
+> rollout schema.
 
 ## 1. Summary
 
-PR #239 added a structured `agent-cwd` event channel for the Claude Code
-transcript watcher (`crates/backend/src/agent/adapter/claude_code/transcript.rs`).
-That channel is the load-bearing path for keeping `pane.cwd` in sync when an
-agent moves between worktrees via in-process tool calls that intentionally
-don't mutate the interactive shell's `$PWD` (Claude's built-in
-`EnterWorktree`, Superpowers' worktree skill, etc.). Without it, OSC 7 and
-the text-pattern `agentCwdHint` paths are structurally blind to those moves
-and the per-pane chip pins to the starting checkout.
+PR #239 added a structured `agent-cwd` event channel for the Claude
+Code transcript watcher
+(`crates/backend/src/agent/adapter/claude_code/transcript.rs`). That
+channel is the load-bearing path for keeping `pane.cwd` in sync when
+an agent moves between worktrees via in-process tool calls that
+intentionally don't mutate the interactive shell's `$PWD` (Claude's
+built-in `EnterWorktree`, Superpowers' worktree skill, etc.). Without
+it, OSC 7 and the text-pattern `agentCwdHint` paths are structurally
+blind to those moves and the per-pane chip pins to the starting
+checkout.
 
-PR #239's "Follow-ups" list named the matching work for the Codex adapter
-as the next small piece on top of that foundation:
+PR #239's "Follow-ups" list named the matching work for the Codex
+adapter as the next small piece on top of that foundation. v1 of this
+spec read that note as "look at `payload.cwd` on `session_meta` and
+`turn_context`". Empirical verification against real `cli_version
+0.132.0` rollouts on disk — including the session where the user told
+codex to switch to `.claude/worktrees/codex-dummy-worktree` — proved
+that reading wrong:
 
-> Codex transcript cwd: same extraction in
-> `crates/backend/src/agent/adapter/codex/parser.rs` for the Codex rollout
-> JSONL. Field is in the same place; should be a small commit on top of
-> this PR's foundation.
+- **`session_meta.payload.cwd`** is set ONCE at session start and
+  pinned. ✓ correct for "where did the session start".
+- **`turn_context.payload.cwd`** is repeated on every turn but always
+  equals the session-start cwd. It does NOT update when codex moves.
+  The v1 spec assumed it does; in practice it does not.
+- **`response_item.payload.arguments.workdir`** (for `exec_command`
+  function calls) DOES update — every time codex runs a command in a
+  different directory, the `workdir` field on that function-call
+  reflects the new directory. This is codex's de facto mid-session
+  cwd signal.
 
-This spec covers that follow-up — port the `agent-cwd` extraction to the
-Codex rollout JSONL watcher so Codex panes get a cwd channel sourced from
-Codex's transcript JSONL. The temporal contract differs from Claude Code's
-per-line `cwd` channel and the implementation has to make that explicit:
-Codex's `cwd` field lives only on `session_meta` (once, at session start)
-and `turn_context` (once per turn) entries, so cwd transitions fire at
-session start and at each turn boundary — **not mid-turn**. A Codex-side
-worktree switch invoked mid-turn (e.g. an `apply_patch` that does its own
-`cd`, or an out-of-band `cd` inside an `exec_command` block) does not
-surface a new `agent-cwd` event until the next `turn_context` line is
-written, which typically happens when the agent next responds to the
-user. This is a known semantic limitation of the Codex rollout schema as
-of `cli_version 0.132.0` — not a shortcoming of the extraction logic.
+v2 therefore extracts cwd from **three sources** in priority order:
 
-Two caveats from PR #239's wording have to be corrected in the
-implementation:
+1. `session_meta.payload.cwd` — first transition at session start.
+2. `turn_context.payload.cwd` — kept as a defensive anchor (if a
+   future Codex schema does update it, we already capture).
+3. `response_item.payload.arguments.workdir` (parsed JSON, scoped to
+   `payload.name == "exec_command"`) — the mid-session signal.
 
-1. **Wrong file.** The live event channel lives in `transcript.rs`, not
-   `parser.rs`. `codex/parser.rs` produces `AgentStatusEvent` snapshots
-   (tokens, cost, rate limits) — that event type has no `cwd` field, and
-   the frontend's `pane.cwd` is driven exclusively by `agent-cwd` events
-   emitted by the transcript tailer. The change lands in
-   `crates/backend/src/agent/adapter/codex/transcript.rs`.
-2. **"Same place" is misleading.** Claude Code stamps a top-level `cwd`
-   field on every JSONL line. Codex does not. In the Codex rollout JSONL
-   (verified against real `cli_version 0.132.0` rollouts on disk), `cwd`
-   appears only nested under two event types:
-   - `session_meta.payload.cwd` — once at session start.
-   - `turn_context.payload.cwd` — once per turn.
+Transition semantics carry over from PR #239: track `last_cwd:
+Option<String>` across calls; emit `AgentCwdEvent` only on changes;
+empty strings filtered at the extraction site. Frontend wiring is
+already agent-type-agnostic and picks up Codex transitions
+automatically.
 
-   `event_msg` and `response_item` lines do **not** carry session cwd. The
-   per-`function_call` `arguments.workdir` is a per-command scratch path,
-   not the session cwd, and is deliberately ignored.
+**Practical effect** of v2 vs v1: when codex tells the user "I'll use
+this worktree for subsequent commands", every subsequent `exec_command`
+carries the new workdir. The first such command emits an `agent-cwd`
+transition, and the pane chip + git branch follow. v1 would have
+emitted nothing (no `turn_context` update).
 
-   The extraction logic therefore can't be a structural copy-paste of
-   Claude's "every line has cwd at top-level" shape. It needs a small
-   helper scoped to the two event types that actually carry session cwd.
+### 1.1 What v2 keeps from v1
 
-The frontend side is already wired generically: `useAgentStatus` listens
-for `agent-cwd` regardless of agent type, and `WorkspaceView` bridges the
-hook output to `updatePaneCwd` (both shipped in PR #239 commit 5). Codex
-panes pick up cwd tracking the moment the backend starts emitting — no
-frontend change needed.
+- The frontend side stays untouched (`useAgentStatus`,
+  `WorkspaceView`, pane state are already wired generically via PR
+  #239 commit 5).
+- The doc-comment correction on `AgentCwdEvent` in
+  `crates/backend/src/agent/types.rs` (still needs to drop the
+  "pending follow-up" / "every transcript JSONL entry" language).
+- Two frontend JSDoc-comment corrections (same stale language).
+- The transition-only emission contract and `last_cwd` dedup.
+
+### 1.2 What v2 changes from v1
+
+- Extraction logic is split into three helper functions (or one
+  unified dispatcher), one per source.
+- `extract_session_cwd` is renamed / supplemented by
+  `extract_codex_cwd` (or kept and joined by `extract_exec_workdir`)
+  to reflect that `workdir` extraction is now in scope.
+- The doc comments and spec now correctly describe Codex's per-source
+  semantics — "session-start in `session_meta`/`turn_context`,
+  mid-session in `exec_command.workdir`" — rather than v1's
+  "session_meta + turn_context per-turn".
 
 ## 2. Scope
 
 ### In scope
 
-Behavior change in one implementation file; the rest are comment-only
-or fixture additions that complete the work cleanly:
+Behavior change in one implementation file; doc-comment and JSDoc
+edits in three further files complete the work cleanly:
 
-- **Behavior:** `crates/backend/src/agent/adapter/codex/transcript.rs` —
-  the actual extraction + emission logic.
+- **Behavior:** `crates/backend/src/agent/adapter/codex/transcript.rs`
+  — the actual extraction + emission logic. Three sources:
+  `session_meta.payload.cwd`, `turn_context.payload.cwd`, and
+  `response_item.payload.arguments.workdir` (parsed JSON; scoped to
+  function calls named `exec_command`).
 - **Doc-comment fix** on `AgentCwdEvent` in
-  `crates/backend/src/agent/types.rs` (currently says cwd is sourced from
-  "the structured `cwd` field that Claude Code (and Codex, **pending
-  follow-up**) writes on **every** transcript JSONL entry" — this PR
-  _is_ that follow-up, and the "every entry" claim is wrong for Codex).
-  The ts-rs binding at `src/bindings/AgentCwdEvent.ts` is regenerated
-  from the Rust doc-comment on test runs, so it updates automatically;
-  the spec calls out both files for clarity, but the binding is not
-  hand-edited.
-- **Frontend comment fixes** (no behavior change) — two JSDoc-style
-  block comments that repeat the same stale "every transcript JSONL
-  entry" claim and explicitly say "Codex follow-up", which this PR
-  resolves:
-  - `src/features/agent-status/types/index.ts` (around line 54–62, the
-    `cwd: string | null` field on the agent-status state).
+  `crates/backend/src/agent/types.rs` (currently says cwd is sourced
+  from "the structured `cwd` field that Claude Code (and Codex,
+  **pending follow-up**) writes on **every** transcript JSONL entry"
+  — this PR _is_ that follow-up, and the "every entry" claim is
+  wrong for both adapters now). The ts-rs binding at
+  `src/bindings/AgentCwdEvent.ts` is regenerated from the Rust
+  doc-comment via `npm run generate:bindings`.
+- **Frontend comment fixes** (no behavior change):
+  - `src/features/agent-status/types/index.ts` (around line 54–62,
+    the `cwd: string | null` field on the agent-status state).
   - `src/features/workspace/WorkspaceView.tsx` (around line 315–321,
     the comment above the `agentStatus.cwd → updatePaneCwd` bridge).
-- Add `extract_session_cwd(&Value) -> Option<&str>` private helper that
-  returns `payload.cwd` when `type` is `session_meta` or `turn_context`,
-  empty-string filtered out.
-- Add `last_cwd: Option<String>` state to the `tail_loop` and thread it
-  through `process_line`.
+- Add private helpers in `codex/transcript.rs`:
+  - `extract_session_cwd(&Value) -> Option<&str>` — pulls
+    `payload.cwd` when `type` is `session_meta` or `turn_context`,
+    empty-string filtered out.
+  - `extract_exec_workdir(&Value) -> Option<String>` — pulls
+    `payload.arguments.workdir` when `type == "response_item"` AND
+    `payload.type == "function_call"` AND `payload.name ==
+"exec_command"`. Requires parsing the `arguments` string as
+    JSON (it is a JSON-encoded string per Codex's schema).
+  - `extract_codex_cwd(&Value) -> Option<String>` — dispatcher that
+    tries `extract_session_cwd` first, falls back to
+    `extract_exec_workdir`. Returns `Option<String>` because the
+    workdir path requires owned strings (parsed JSON allocates).
+- Add `last_cwd: Option<String>` state to the `tail_loop` and thread
+  it through `process_line`.
 - Emit `AgentCwdEvent` via the existing `emit_agent_cwd` helper on
-  transitions only (first observed cwd always fires; repeated identical
-  cwd values do not re-emit).
+  transitions only (first observed cwd always fires; repeated
+  identical cwd values do not re-emit). Same contract as Claude.
 - Imports: `crate::agent::events::emit_agent_cwd` and
   `crate::agent::types::AgentCwdEvent`.
-- Unit-test coverage for the extraction helper and the transition
-  semantics (rules/rust/testing.md: `#[cfg(test)] mod tests` co-located).
-- End-to-end fixture coverage in `start_tailing` mirroring the existing
-  `start_tailing_replays_tool_calls_turns_and_test_runs` test — drive a
-  rollout through the tailer and assert `agent-cwd` events arrive in the
-  expected order on a `FakeEventSink`.
+- Unit-test coverage:
+  - 4 tests for `extract_session_cwd` (session_meta + turn_context
+    positive; missing payload, missing cwd, empty string negatives).
+  - 6 tests for `extract_exec_workdir` (happy path; wrong event
+    type; wrong function-call type; wrong tool name; malformed
+    arguments JSON; missing workdir).
+  - 3 transition-semantics tests covering first-emit, dedup, and
+    multi-source transitions (session_meta → exec_command workdir).
+  - 1 end-to-end fixture-driven test in `start_tailing`.
 
 ### Out of scope (deferred, not lost)
 
@@ -113,52 +147,85 @@ or fixture additions that complete the work cleanly:
   agent-cwd channel this spec lands is a prerequisite for #234's
   per-pane cwd persistence to work for Codex panes, but the schema
   change itself is a separate spec/PR.
-- **Shell-pwd-doesn't-inherit-from-pane-1** — newly opened shell panes
-  don't start in the active pane's cwd. Separate root-cause investigation
-  needed in the terminal/PTY spawn path; not in this PR.
+- **Shell-pwd-doesn't-inherit-from-pane-1** — newly opened shell
+  panes don't start in the active pane's cwd. Separate root-cause
+  investigation needed in the terminal/PTY spawn path; not in this
+  PR.
 - **Pruning the now-redundant `agentCwdHint` text patterns in
-  `Body.tsx`** — PR #239's other "Follow-ups" item; deferred until both
-  Claude and Codex adapters' structured channels have been validated in
-  production. OSC 7 and the Claude-startup-banner home-cwd resolution
-  stay either way — they cover interactive-shell `cd` cases the JSONL
-  channel doesn't see.
+  `Body.tsx`** — PR #239's other "Follow-ups" item; deferred until
+  both Claude and Codex adapters' structured channels have been
+  validated in production. OSC 7 and the Claude-startup-banner
+  home-cwd resolution stay either way — they cover
+  interactive-shell `cd` cases the JSONL channel doesn't see.
 - **`codex/transcript.rs` is already 953 lines** (rules say ≤400
-  typical, ≤800 max). This PR adds ~25 lines, pushing it further over.
-  Splitting is a separate refactor PR; calling it out here so the debt
-  is visible and not silently accumulating.
-- **`codex/parser.rs` changes** — none needed. The status-snapshot path
-  consumes `AgentStatusEvent`, which has no `cwd` field; adding one
-  would require a frontend change with no current consumer. If a future
-  consumer needs the cwd in the status snapshot, that's its own spec.
+  typical, ≤800 max). This PR adds ~50 lines of behavior + ~250
+  lines of tests, pushing it further over. Splitting is a separate
+  refactor PR; calling it out so the debt is visible and not
+  silently accumulating.
+- **`codex/parser.rs` changes** — none needed. The status-snapshot
+  path consumes `AgentStatusEvent`, which has no `cwd` field; adding
+  one would require a frontend change with no current consumer.
+- **`apply_patch` workdir** — `custom_tool_call` with
+  `name == "apply_patch"` doesn't carry a `workdir` field (the
+  `input` is the patch payload itself). Patches are applied relative
+  to codex's current command context, which we track via
+  `exec_command.workdir`, so no new source needed.
+- **`local_shell_call` / future tool variants** — only
+  `exec_command` is in scope. If Codex adds more cwd-bearing tool
+  types, that's a follow-up. Conservative-by-design.
 
 ### PR scope discipline
 
-One PR, one question: _Does the Codex transcript emit `agent-cwd` events
-with the same transition-only semantics as the Claude Code transcript?_
-No drive-by refactors, no incidental file moves, no unrelated test
-cleanup.
+One PR, one question: _Does the Codex transcript emit `agent-cwd`
+events on real cwd transitions, including mid-session worktree
+switches via codex's command-context navigation?_ No drive-by
+refactors, no incidental file moves, no unrelated test cleanup.
 
 ## 3. Data flow & extraction shape
 
 ### 3.1 Codex rollout JSONL shape (verified against `cli_version 0.132.0`)
 
+Each rollout JSONL line carries `timestamp`, `type`, and `payload`.
+The cwd-carrying shapes are:
+
 ```jsonl
 {"timestamp":"…","type":"session_meta","payload":{"id":"…","cwd":"/abs/path","cli_version":"0.132.0", …}}
 {"timestamp":"…","type":"turn_context","payload":{"turn_id":"…","cwd":"/abs/path","model":"gpt-5.4", …}}
-{"timestamp":"…","type":"event_msg","payload":{"type":"task_started", …}}
-{"timestamp":"…","type":"event_msg","payload":{"type":"token_count", …}}
-{"timestamp":"…","type":"response_item","payload":{"type":"function_call","call_id":"…","arguments":"…"}}
+{"timestamp":"…","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/abs/path\"}","call_id":"…"}}
 ```
 
-Only `session_meta` and `turn_context` carry `payload.cwd`. Function-call
-`arguments.workdir` is per-command scratch and intentionally not
-considered session cwd.
+Empirical findings from rollouts on disk:
 
-### 3.2 Extraction helper
+- `session_meta.cwd` and `turn_context.cwd` carry the **session's
+  starting cwd** and are pinned for the life of the session. No
+  rollout in `~/.codex/sessions/` showed a `turn_context.cwd` value
+  different from its `session_meta.cwd`, even across long sessions
+  where codex was instructed to switch worktrees.
+- `exec_command.arguments` is a JSON-encoded **string**, not a
+  nested object. Parsing it yields `{cmd, workdir, …}`. The
+  `workdir` is codex's actual mid-session working directory and
+  changes when codex switches its "command context".
+- `event_msg` types (`task_started`, `task_complete`, `token_count`,
+  `exec_command_end`, `patch_apply_end`, etc.) do NOT carry cwd
+  signals.
+- `response_item` with `function_call` and other tool names (e.g.
+  `read_file`, `write_file` if Codex adds them) MAY carry their own
+  per-call paths but those are tool inputs, not session cwd.
+  v2 deliberately scopes `extract_exec_workdir` to
+  `name == "exec_command"` only.
 
-Private to `transcript.rs`:
+### 3.2 Extraction helpers
+
+Three private helpers in `transcript.rs`. The dispatcher pattern
+keeps each individual helper small and unit-testable.
 
 ```rust
+/// Pull session-start cwd off a Codex rollout JSONL line.
+///
+/// Returns `Some(cwd)` only for `session_meta` / `turn_context` entries.
+/// In practice both carry the SAME value (the session's starting cwd);
+/// `turn_context` is kept here as a defensive anchor in case a future
+/// Codex schema starts updating it. Empty strings filtered out.
 fn extract_session_cwd(value: &Value) -> Option<&str> {
     let event_type = value.get("type").and_then(Value::as_str)?;
     if event_type != "session_meta" && event_type != "turn_context" {
@@ -170,10 +237,45 @@ fn extract_session_cwd(value: &Value) -> Option<&str> {
         .and_then(Value::as_str)
         .filter(|s| !s.is_empty())
 }
-```
 
-Named `extract_session_cwd` (not `extract_cwd`) to make scope explicit —
-we are not pulling the per-command `workdir`.
+/// Pull the mid-session workdir off a Codex `exec_command` function-call
+/// rollout entry. This is codex's de facto session cwd after the start
+/// (verified empirically — `turn_context.cwd` does not update on
+/// codex-driven cwd changes; `exec_command.arguments.workdir` does).
+///
+/// `arguments` is a JSON-encoded string per Codex's rollout schema —
+/// it must be parsed before reading `workdir`. Malformed JSON, missing
+/// fields, or empty strings all short-circuit to `None`.
+fn extract_exec_workdir(value: &Value) -> Option<String> {
+    let payload = value.get("payload")?;
+    if value.get("type").and_then(Value::as_str)? != "response_item" {
+        return None;
+    }
+    if payload.get("type").and_then(Value::as_str)? != "function_call" {
+        return None;
+    }
+    if payload.get("name").and_then(Value::as_str)? != "exec_command" {
+        return None;
+    }
+    let raw = payload.get("arguments").and_then(Value::as_str)?;
+    let args: Value = serde_json::from_str(raw).ok()?;
+    args.get("workdir")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Dispatcher returning the observed cwd from whichever source carries
+/// it. Tries the session_meta/turn_context path first (cheap, no JSON
+/// re-parse), falls back to the exec_command workdir path. Returns
+/// `Option<String>` because the workdir path must return owned strings.
+fn extract_codex_cwd(value: &Value) -> Option<String> {
+    if let Some(cwd) = extract_session_cwd(value) {
+        return Some(cwd.to_string());
+    }
+    extract_exec_workdir(value)
+}
+```
 
 ### 3.3 Integration into `process_line`
 
@@ -193,16 +295,16 @@ fn process_line(
         Err(_) => return,
     };
 
-    if let Some(observed) = extract_session_cwd(&value) {
-        if last_cwd.as_deref().map_or(true, |seen| seen != observed) {
+    if let Some(observed) = extract_codex_cwd(&value) {
+        if last_cwd.as_deref().map_or(true, |seen| seen != observed.as_str()) {
             let event = AgentCwdEvent {
                 session_id: session_id.to_string(),
-                cwd: observed.to_string(),
+                cwd: observed.clone(),
             };
             if let Err(e) = emit_agent_cwd(events.as_ref(), &event) {
                 log::warn!("Failed to emit agent-cwd event: {}", e);
             }
-            *last_cwd = Some(observed.to_string());
+            *last_cwd = Some(observed);
         }
     }
 
@@ -214,53 +316,59 @@ fn process_line(
 }
 ```
 
-Pre-match placement mirrors the Claude Code structure so a side-by-side
-diff between `claude_code/transcript.rs::process_line` and
-`codex/transcript.rs::process_line` makes the parity obvious.
+Note: the cwd extraction runs BEFORE the existing match, so an
+`exec_command` line emits its `agent-cwd` (when transitioning) AND
+then flows into the normal `response_item` arm that records the tool
+call. No double-processing — these are orthogonal concerns.
 
 ### 3.4 `tail_loop` state
 
 Add `let mut last_cwd: Option<String> = None;` next to the existing
-`num_turns` declaration. Thread it through to `process_line` (one new
-parameter at the end of the signature, matching Claude's call shape).
+`num_turns` declaration. Thread it through to both `process_line`
+call sites in the read loop (single-line + partial-line branches).
 
 ### 3.5 Transition semantics
 
 - **First observed cwd always emits.** `last_cwd: None` →
-  `map_or(true, …)` short-circuits true on the first hit. Matches Claude.
-- **Repeated identical cwd suppresses.** `turn_context` lines fire once
-  per turn and frequently repeat the same cwd; only transitions emit.
-- **Empty string filtered at the extraction site.** `filter(|s|
-!s.is_empty())` inside `extract_session_cwd`. Matches Claude's
-  `!observed.is_empty()` guard.
-- **Malformed JSON skipped silently.** The existing `serde_json::from_str`
-  arm returns early; extraction never runs on malformed input.
-- **Missing `payload` or missing `cwd` field skipped silently.** Both
-  `?` operators in `extract_session_cwd` short-circuit to `None`.
-- **Temporal granularity is per-turn, not per-line.** This is the key
-  divergence from Claude. Codex's rollout schema only carries `cwd` on
-  `session_meta` (once) and `turn_context` (per turn). Mid-turn worktree
-  switches won't surface a new `agent-cwd` event until the next
-  `turn_context` line. In practice this means the pane chip may lag by
-  up to one turn after a tool-driven `cd`; the next user prompt or
-  agent turn closes the gap. This is a schema-imposed limit, not a
-  bug — the only ways to close the gap further would be (a) ask the
-  Codex team to add a mid-turn cwd event (out of scope), or (b) wire a
-  parallel text-pattern heuristic similar to Claude's `agentCwdHint`
-  for Codex output (deferred; the structured channel is the canonical
-  source, mirroring PR #239's design decision).
+  `map_or(true, …)` short-circuits true on the first hit. Matches
+  Claude.
+- **Repeated identical cwd suppresses.** Multiple `exec_command`s
+  with the same workdir, or session_meta+turn_context both at
+  session-start, emit only the first.
+- **Empty strings filtered at extraction sites.** Both helpers
+  `filter(|s| !s.is_empty())`.
+- **Malformed JSON skipped silently.** `serde_json::from_str` early
+  return at top of `process_line`; the nested
+  `serde_json::from_str(arguments)` inside `extract_exec_workdir`
+  returns `None` on parse error.
+- **Missing payload / missing field / wrong type → silently `None`.**
+  All `?` and `.and_then(…)` short-circuits.
+- **Temporal granularity is per-exec_command, not per-line and not
+  per-turn.** This is the v2-corrected understanding. Codex emits
+  cwd transitions whenever it runs a tool command in a new
+  directory — typically the first exec_command after a "switch to
+  worktree X" instruction. Bare turn boundaries do NOT carry cwd
+  changes (the `turn_context.cwd` field is static across a session).
+  In practice this means the pane chip catches up to the new cwd
+  on the FIRST exec_command after a worktree switch, which is
+  usually within ~1s of codex's "switching to" message.
+- **Reasoning-only turns don't emit.** A turn that produces only
+  text + thinking (no tool calls) won't emit a transition. This is
+  correct — codex hasn't "moved" yet, it's just thinking. The next
+  exec_command (or session start, or new session_meta on reattach)
+  fires.
 
 ## 4. Components & files
 
 ### 4.1 Files changed
 
-| File                                                   | Change                                                                                                                                                                                                                        |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `crates/backend/src/agent/adapter/codex/transcript.rs` | Add `extract_session_cwd` helper, thread `last_cwd: Option<String>` through `tail_loop` + `process_line`, add cwd extraction + transition emission, expand imports.                                                           |
-| `crates/backend/src/agent/types.rs`                    | Edit the doc comment above `AgentCwdEvent` (line ~157–164) to drop "pending follow-up" / "every transcript JSONL entry" and describe both adapters' real field shapes.                                                        |
-| `src/bindings/AgentCwdEvent.ts`                        | Regenerated by `ts-rs` on `cargo test` runs (the `#[cfg_attr(test, derive(ts_rs::TS))]` + `ts(export)` attributes on `AgentCwdEvent`). Not hand-edited. The new doc-comment text appears in the generated `/**…*/` block.     |
-| `src/features/agent-status/types/index.ts`             | Doc-only — update the JSDoc block above `cwd: string \| null` (around lines 54–62) to drop "every transcript JSONL entry (Claude Code today; Codex follow-up)" and describe both adapters' real field shapes. No type change. |
-| `src/features/workspace/WorkspaceView.tsx`             | Doc-only — update the comment block above the `agentStatus.cwd → updatePaneCwd` bridge (around lines 315–321) for the same reason. No behavior change.                                                                        |
+| File                                                   | Change                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `crates/backend/src/agent/adapter/codex/transcript.rs` | Add 3 helpers (`extract_session_cwd`, `extract_exec_workdir`, `extract_codex_cwd`), thread `last_cwd: Option<String>` through `tail_loop` + `process_line`, add cwd extraction + transition emission, expand imports, 14 new tests (4 session_cwd + 6 exec_workdir + 3 transition + 1 e2e). |
+| `crates/backend/src/agent/types.rs`                    | Edit the doc comment above `AgentCwdEvent` (line ~157–164) to describe both adapters' real shapes (Claude per-line, Codex per-exec_command).                                                                                                                                                |
+| `src/bindings/AgentCwdEvent.ts`                        | Regenerated by `npm run generate:bindings`. Not hand-edited.                                                                                                                                                                                                                                |
+| `src/features/agent-status/types/index.ts`             | Doc-only — update the JSDoc block above `cwd: string \| null` (around lines 54–62) to match the corrected source description. No type change.                                                                                                                                               |
+| `src/features/workspace/WorkspaceView.tsx`             | Doc-only — update the comment block above the `agentStatus.cwd → updatePaneCwd` bridge (around lines 315–321). No behavior change.                                                                                                                                                          |
 
 ### 4.2 Files NOT changed
 
@@ -273,55 +381,26 @@ parameter at the end of the signature, matching Claude's call shape).
 - Frontend behavior: `useAgentStatus`, `WorkspaceView`, pane state — all
   already listen to `agent-cwd` regardless of agent type. The hook,
   bridge, and pane-state code are untouched. Only two JSDoc-style
-  comment blocks change (see 4.1), and those changes are non-functional.
+  comment blocks change (see 4.1), and those changes are
+  non-functional.
 
-### 4.3 New helper
+### 4.3 Helper signatures (full code in 3.2)
 
-Added near the top of `codex/transcript.rs`, just above `validate_transcript_path`:
+Three private functions added near the top of `codex/transcript.rs`,
+above `validate_transcript_path`:
 
 ```rust
-/// Pull session-level cwd off a Codex rollout JSONL line.
-///
-/// Returns `Some(cwd)` only for the two event types that actually carry
-/// session cwd in the rollout schema as of `cli_version 0.132.0`:
-///   - `session_meta.payload.cwd` — fires once at session start.
-///   - `turn_context.payload.cwd` — fires per turn.
-///
-/// Empty strings are filtered out at the extraction site, matching the
-/// Claude Code transcript watcher's guard. Function-call
-/// `arguments.workdir` is per-command scratch and deliberately not
-/// considered session cwd.
-fn extract_session_cwd(value: &Value) -> Option<&str> {
-    let event_type = value.get("type").and_then(Value::as_str)?;
-    if event_type != "session_meta" && event_type != "turn_context" {
-        return None;
-    }
-    value
-        .get("payload")?
-        .get("cwd")
-        .and_then(Value::as_str)
-        .filter(|s| !s.is_empty())
-}
+fn extract_session_cwd(value: &Value) -> Option<&str>          // session_meta + turn_context
+fn extract_exec_workdir(value: &Value) -> Option<String>       // response_item function_call exec_command
+fn extract_codex_cwd(value: &Value) -> Option<String>          // dispatcher
 ```
 
 ### 4.4 `process_line` signature extension
 
-Adds one parameter at the end (matching Claude's call shape so the two
-adapters' `process_line` signatures stay structurally aligned):
+Adds one parameter at the end (matching Claude's call shape so the
+two adapters' `process_line` signatures stay structurally aligned):
 
 ```rust
-// Before (current):
-fn process_line(
-    line: &str,
-    session_id: &str,
-    cwd: Option<&Path>,
-    events: &Arc<dyn EventSink>,
-    emitter: &mut TestRunEmitter,
-    in_flight: &mut InFlightToolCalls,
-    num_turns: &mut u32,
-) { … }
-
-// After:
 fn process_line(
     line: &str,
     session_id: &str,
@@ -342,19 +421,13 @@ In `fn tail_loop`, alongside `let mut num_turns = 0_u32;`:
 let mut last_cwd: Option<String> = None;
 ```
 
-Threaded into both `process_line(…)` call sites in the read loop (the
-single-line branch and the partial-line branch — `codex/transcript.rs`
-has two because of its chunk-spanning partial-line handler at lines
-~152–185).
+Threaded into both `process_line(…)` call sites in the read loop
+(the single-line branch and the partial-line branch).
 
 ### 4.6 Updated `AgentCwdEvent` doc comment
 
-Current text (`crates/backend/src/agent/types.rs:157–164`):
-
-> Sourced from the structured `cwd` field that Claude Code (and Codex,
-> pending follow-up) writes on every transcript JSONL entry. …
-
-Proposed text:
+Replace the current text (`crates/backend/src/agent/types.rs:157–164`)
+with:
 
 ```rust
 /// Event emitted when the agent's tracked working directory changes.
@@ -363,93 +436,80 @@ Proposed text:
 /// JSONL:
 /// - **Claude Code** writes a top-level `cwd` field on every transcript
 ///   entry; transitions fire as soon as the next line is parsed.
-/// - **Codex** writes `payload.cwd` only on `session_meta` (once, at
-///   session start) and `turn_context` (per turn) entries; transitions
-///   therefore fire at session start and at each turn boundary, not
-///   mid-turn.
+/// - **Codex** writes cwd in three places: `session_meta.payload.cwd`
+///   (once, at session start), `turn_context.payload.cwd` (per turn,
+///   pinned to the session-start value in practice), and
+///   `response_item.payload.arguments.workdir` for `exec_command`
+///   function calls (the mid-session signal — fires whenever codex
+///   runs a tool command in a new directory). The watcher reads all
+///   three.
 ///
 /// In both cases this is the authoritative signal for "where the agent
 /// currently is" — it picks up tool-call-driven moves like Claude's
-/// `EnterWorktree` that intentionally do NOT mutate the interactive
-/// shell's `$PWD`, so neither OSC 7 nor PTY text patterns can catch
-/// them.
+/// `EnterWorktree` and codex's "switch to worktree" navigation that
+/// intentionally do NOT mutate the interactive shell's `$PWD`, so
+/// neither OSC 7 nor PTY text patterns can catch them.
 ```
 
-The `#[cfg_attr(test, derive(ts_rs::TS))]` + `ts(export)` attributes on
-`AgentCwdEvent` regenerate `src/bindings/AgentCwdEvent.ts` with the
-new comment text. The canonical regeneration path in this repo is the
-`npm run generate:bindings` script — it runs
-`cargo test --manifest-path crates/backend/Cargo.toml export_bindings`
-to produce the ts-rs output, then `prettier --write src/bindings/` to
-format it. Skipping the prettier step (e.g. running just `cargo test`
-on its own) can leave raw generated formatting in the file and fail
-the `npm run format:check` gate. **The ts-rs binding itself is not
-hand-edited** — it's regenerated via `npm run generate:bindings` and
-committed alongside the Rust change. The two frontend JSDoc comments
-listed in 4.1 (`agent-status/types/index.ts` and
-`workspace/WorkspaceView.tsx`) ARE hand-edited; they live outside
-ts-rs and have to be updated manually.
+The ts-rs regeneration is via `npm run generate:bindings` (see 5.5).
 
 ## 5. Testing strategy
 
 ### 5.1 Test inventory
 
 Three layers, all co-located in `codex/transcript.rs` (per
-rules/rust/testing.md: `#[cfg(test)] mod tests` at file bottom). Test
-function names match the codebase convention used throughout
-`codex/transcript.rs` and `claude_code/transcript.rs` — descriptive
-`<function>_<scenario>_<expected>` without a `test_` prefix.
-rules/rust/testing.md mentions a `test_` prefix as the rule; we follow
-the codebase here because all ~25 existing tests in
-`codex/transcript.rs` already omit it and matching them keeps the file
-internally consistent (see "deviation log" at the bottom of section 5).
+rules/rust/testing.md: `#[cfg(test)] mod tests` at file bottom).
+Test names omit the `test_` prefix to match the existing convention
+in the file.
 
-| Layer                        | Target                          | Count |
-| ---------------------------- | ------------------------------- | ----- |
-| Unit — `extract_session_cwd` | Pure extraction logic           | 7     |
-| Unit — transition state      | `process_line`'s last_cwd dedup | 3     |
-| End-to-end — `start_tailing` | Watcher → `FakeEventSink`       | 1     |
+| Layer                         | Target                                         | Count |
+| ----------------------------- | ---------------------------------------------- | ----- |
+| Unit — `extract_session_cwd`  | session_meta + turn_context paths              | 4     |
+| Unit — `extract_exec_workdir` | response_item function_call paths              | 6     |
+| Unit — transition state       | `process_line`'s last_cwd dedup across sources | 3     |
+| End-to-end — `start_tailing`  | Watcher → `FakeEventSink`                      | 1     |
 
-### 5.2 `extract_session_cwd` unit tests (7)
+### 5.2 `extract_session_cwd` unit tests (4)
 
-Drives the helper directly with hand-built `serde_json::Value`s. No
-filesystem, no threads.
+| Test                                            | Input shape                                      | Expected     |
+| ----------------------------------------------- | ------------------------------------------------ | ------------ |
+| `extract_session_cwd_session_meta_returns_cwd`  | `{"type":"session_meta","payload":{"cwd":"/x"}}` | `Some("/x")` |
+| `extract_session_cwd_turn_context_returns_cwd`  | `{"type":"turn_context","payload":{"cwd":"/x"}}` | `Some("/x")` |
+| `extract_session_cwd_other_type_returns_none`   | `{"type":"event_msg","payload":{"cwd":"/x"}}`    | `None`       |
+| `extract_session_cwd_empty_string_returns_none` | `{"type":"turn_context","payload":{"cwd":""}}`   | `None`       |
 
-| Test                                               | Input shape                                                               | Expected                                                                     |
-| -------------------------------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `extract_session_cwd_session_meta_returns_cwd`     | `{"type":"session_meta","payload":{"cwd":"/x"}}`                          | `Some("/x")`                                                                 |
-| `extract_session_cwd_turn_context_returns_cwd`     | `{"type":"turn_context","payload":{"cwd":"/x"}}`                          | `Some("/x")`                                                                 |
-| `extract_session_cwd_event_msg_returns_none`       | `{"type":"event_msg","payload":{"cwd":"/x"}}`                             | `None` _(defensive — even if payload carried cwd, the type gate rejects it)_ |
-| `extract_session_cwd_response_item_returns_none`   | `{"type":"response_item","payload":{"arguments":"{\"workdir\":\"/x\"}"}}` | `None` _(workdir is per-command, not session cwd)_                           |
-| `extract_session_cwd_missing_payload_returns_none` | `{"type":"turn_context"}`                                                 | `None`                                                                       |
-| `extract_session_cwd_missing_cwd_returns_none`     | `{"type":"turn_context","payload":{}}`                                    | `None`                                                                       |
-| `extract_session_cwd_empty_string_returns_none`    | `{"type":"turn_context","payload":{"cwd":""}}`                            | `None`                                                                       |
+### 5.3 `extract_exec_workdir` unit tests (6)
 
-### 5.3 Transition semantics tests (3)
+| Test                                                         | Input shape                                                                                     | Expected     |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ------------ |
+| `extract_exec_workdir_happy_path`                            | `response_item` / `function_call` / `exec_command` with `arguments={"cmd":"ls","workdir":"/x"}` | `Some("/x")` |
+| `extract_exec_workdir_other_event_type_returns_none`         | `event_msg` carrying the same payload                                                           | `None`       |
+| `extract_exec_workdir_non_function_call_returns_none`        | `response_item` with `payload.type == "custom_tool_call"`                                       | `None`       |
+| `extract_exec_workdir_non_exec_command_returns_none`         | `response_item` `function_call` with `name == "read_file"`                                      | `None`       |
+| `extract_exec_workdir_malformed_arguments_json_returns_none` | `arguments` is `"{not json"`                                                                    | `None`       |
+| `extract_exec_workdir_missing_workdir_field_returns_none`    | `arguments={"cmd":"ls"}`                                                                        | `None`       |
 
-Drive `process_line` through a sequence of lines on a `FakeEventSink`
-from `crate::runtime`. Each test sets up an empty `last_cwd: None`,
-calls `process_line` N times, then asserts the recorded events.
+### 5.4 Transition semantics tests (3)
 
-| Test                                   | Sequence                                                              | Expected `agent-cwd` count |
-| -------------------------------------- | --------------------------------------------------------------------- | -------------------------- |
-| `process_line_first_cwd_always_emits`  | `session_meta(cwd=A)`                                                 | 1 (cwd=A)                  |
-| `process_line_repeated_cwd_suppresses` | `session_meta(cwd=A)` → `turn_context(cwd=A)` → `turn_context(cwd=A)` | 1 (cwd=A)                  |
-| `process_line_cwd_transition_emits`    | `session_meta(cwd=A)` → `turn_context(cwd=B)` → `turn_context(cwd=A)` | 3 (A, B, A)                |
+Drive `process_line` through a sequence of lines on a
+`FakeEventSink`. Each test sets up empty `last_cwd: None` + empty
+`in_flight`, calls `process_line` N times, then asserts.
 
-These intentionally bypass `start_tailing`'s thread/IO/poll machinery —
-the same approach Claude's `claude_code/transcript.rs` tests use for
-its parsing-shape unit tests.
+| Test                                                  | Sequence                                                                      | Expected `agent-cwd` |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------- |
+| `process_line_first_cwd_always_emits`                 | `session_meta(cwd=A)`                                                         | 1 (A)                |
+| `process_line_repeated_cwd_across_sources_suppresses` | `session_meta(cwd=A)` → `turn_context(cwd=A)` → `exec_command(workdir=A)`     | 1 (A)                |
+| `process_line_cwd_transition_across_sources_emits`    | `session_meta(cwd=A)` → `exec_command(workdir=B)` → `exec_command(workdir=A)` | 3 (A, B, A)          |
 
-### 5.4 End-to-end watcher test (1)
+The third test specifically covers the v2-critical case: a
+session_meta → exec_command transition (the real codex mid-session
+switch pattern).
+
+### 5.5 End-to-end watcher test (1)
 
 `start_tailing_emits_cwd_transitions_in_order` — inline-JSON, mirrors
 the existing `start_tailing_replays_tool_calls_turns_and_test_runs`
-test in the same file (around line 791), which uses the existing
-`write_rollout(&Path, &[Value])` helper. No external fixture file —
-matches the convention used by both `codex/transcript.rs`'s e2e test
-and `claude_code/transcript_fixture_tests.rs`'s `std::fs::write` style
-test setup.
+test (around line 791 in the file).
 
 ```rust
 #[test]
@@ -459,56 +519,53 @@ fn start_tailing_emits_cwd_transitions_in_order() {
     let transcript_path = tmp.path().join("rollout.jsonl");
 
     // 6 lines, 3 expected emissions:
-    //   1. session_meta cwd=/workspace/A   (emit)
-    //   2. turn_context cwd=/workspace/A   (suppressed — same as last)
-    //   3. turn_context cwd=/workspace/B   (emit)
-    //   4. event_msg noise                 (no cwd emit; not a cwd carrier)
-    //   5. response_item noise             (no cwd emit; not a cwd carrier)
-    //   6. turn_context cwd=/workspace/A   (emit)
+    //   1. session_meta cwd=/workspace/A             (emit)
+    //   2. turn_context cwd=/workspace/A             (suppressed — same)
+    //   3. exec_command workdir=/workspace/B         (emit — transition)
+    //   4. event_msg task_started                    (no emit)
+    //   5. exec_command workdir=/workspace/B         (suppressed — same)
+    //   6. exec_command workdir=/workspace/A         (emit — transition back)
     write_rollout(
         &transcript_path,
         &[
+            json!({"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"sid","cwd":"/workspace/A"}}),
+            json!({"timestamp":"2026-05-22T10:00:01Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/workspace/A"}}),
             json!({
-                "timestamp": "2026-05-22T10:00:00Z",
-                "type": "session_meta",
-                "payload": { "id": "sid-cwd", "cwd": "/workspace/A" }
+                "timestamp":"2026-05-22T10:00:02Z",
+                "type":"response_item",
+                "payload":{
+                    "type":"function_call",
+                    "name":"exec_command",
+                    "call_id":"c1",
+                    "arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"
+                }
+            }),
+            json!({"timestamp":"2026-05-22T10:00:03Z","type":"event_msg","payload":{"type":"task_started"}}),
+            json!({
+                "timestamp":"2026-05-22T10:00:04Z",
+                "type":"response_item",
+                "payload":{
+                    "type":"function_call",
+                    "name":"exec_command",
+                    "call_id":"c2",
+                    "arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"
+                }
             }),
             json!({
-                "timestamp": "2026-05-22T10:00:01Z",
-                "type": "turn_context",
-                "payload": { "turn_id": "t1", "cwd": "/workspace/A" }
-            }),
-            json!({
-                "timestamp": "2026-05-22T10:00:02Z",
-                "type": "turn_context",
-                "payload": { "turn_id": "t2", "cwd": "/workspace/B" }
-            }),
-            json!({
-                "timestamp": "2026-05-22T10:00:03Z",
-                "type": "event_msg",
-                "payload": { "type": "task_started" }
-            }),
-            json!({
-                "timestamp": "2026-05-22T10:00:04Z",
-                "type": "response_item",
-                "payload": { "type": "function_call", "call_id": "c1", "name": "noop", "arguments": "{}" }
-            }),
-            json!({
-                "timestamp": "2026-05-22T10:00:05Z",
-                "type": "turn_context",
-                "payload": { "turn_id": "t3", "cwd": "/workspace/A" }
+                "timestamp":"2026-05-22T10:00:05Z",
+                "type":"response_item",
+                "payload":{
+                    "type":"function_call",
+                    "name":"exec_command",
+                    "call_id":"c3",
+                    "arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/A\"}"
+                }
             }),
         ],
     );
 
-    let handle = start_tailing(
-        sink.clone(),
-        "sid-cwd".to_string(),
-        transcript_path,
-        None,  // cwd not needed for this test
-    )
-    .expect("start tailing");
-
+    let handle = start_tailing(sink.clone(), "sid-cwd".to_string(), transcript_path, None)
+        .expect("start tailing");
     std::thread::sleep(Duration::from_millis(750));
     handle.stop();
     std::thread::sleep(Duration::from_millis(100));
@@ -530,30 +587,15 @@ fn start_tailing_emits_cwd_transitions_in_order() {
 }
 ```
 
-### 5.5 ts-rs regeneration verification
+### 5.6 ts-rs regeneration
 
-`AgentCwdEvent` already carries `#[cfg_attr(test, derive(ts_rs::TS))]` +
-`ts(export)`. Regeneration path:
+Canonical path: `npm run generate:bindings` (expands to
+`cargo test --manifest-path crates/backend/Cargo.toml export_bindings
+&& prettier --write src/bindings/`). Skipping the prettier step can
+leave un-formatted output that fails `npm run format:check`. The
+binding regeneration is committed alongside the Rust change.
 
-```bash
-npm run generate:bindings
-```
-
-which expands to
-`cargo test --manifest-path crates/backend/Cargo.toml export_bindings && prettier --write src/bindings/`.
-Running plain `cargo test --lib` will technically regenerate the file
-but leaves it un-formatted, which fails `npm run format:check`.
-
-Verification:
-
-- After `npm run generate:bindings`, `git diff src/bindings/AgentCwdEvent.ts`
-  should show the doc-comment block changing to mention both adapters'
-  shapes (Claude per-line, Codex per-turn) and the file should already
-  be prettier-formatted (no further format step needed).
-- The regenerated binding is committed alongside the Rust change so
-  reviewers see the binding match the spec.
-
-### 5.6 Commands
+### 5.7 Commands
 
 ```bash
 # Unit + integration tests for the backend crate
@@ -561,8 +603,12 @@ cargo test -p vimeflow --lib
 
 # Specifically the new tests
 cargo test -p vimeflow --lib codex::transcript::tests::extract_session_cwd
+cargo test -p vimeflow --lib codex::transcript::tests::extract_exec_workdir
 cargo test -p vimeflow --lib codex::transcript::tests::process_line
 cargo test -p vimeflow --lib start_tailing_emits_cwd_transitions
+
+# Regenerate the ts-rs binding (commit the result)
+npm run generate:bindings
 
 # Husky pre-push (vitest only) — the actual gate before push
 npm test
@@ -573,29 +619,56 @@ npm run format:check
 npm run type-check
 ```
 
-### 5.7 Coverage expectation
+### 5.8 Coverage expectation
 
-- **Extraction + transition behavior: 100% covered.** Every branch in
-  `extract_session_cwd` has a dedicated unit test; transitions exercise
-  first-cwd, dedup, and back-and-forth paths; the e2e test covers the
-  read-loop integration.
-- **Not covered:** the `emit_agent_cwd` error branch (the `log::warn`
-  on emission failure inside `process_line`). The branch is a defensive
-  logging path identical to the existing `emit_agent_tool_call` /
-  `emit_agent_turn` error branches in this file, which are also
-  untested; covering it would require a `FailingEventSink` test double
-  that doesn't exist today. Out of scope for this PR — flagged here
-  so the coverage claim isn't read as stronger than it is.
+- **Extraction + transition behavior: 100% covered.** Every branch
+  in `extract_session_cwd` and `extract_exec_workdir` has a
+  dedicated unit test; transitions exercise first-cwd, dedup
+  (including cross-source dedup), and back-and-forth paths; the
+  e2e test covers the read-loop integration with all three sources
+  (session_meta, turn_context, exec_command).
+- **Not covered:** the `emit_agent_cwd` error branch (the
+  `log::warn` on emission failure inside `process_line`). The
+  branch is a defensive logging path identical to the existing
+  `emit_agent_tool_call` / `emit_agent_turn` error branches in
+  this file, which are also untested; covering it would require a
+  `FailingEventSink` test double that doesn't exist today. Out of
+  scope.
 - File-level coverage stays ≥80% per rules/common/testing.md.
 
-### 5.8 Deviation log
+### 5.9 Deviation log
 
 - **Test naming.** `rules/rust/testing.md` recommends a
   `test_<function>_<scenario>_<expected>` convention. The codebase
-  uniformly omits the `test_` prefix (e.g., `validate_transcript_path_accepts_file_under_codex_root`,
-  `parse_tool_use_from_assistant_line`). New tests in this PR follow
-  the codebase convention for local consistency; updating the rule
-  doc is out of scope here but is a one-line follow-up if the team
-  wants the rule to match practice.
+  uniformly omits the `test_` prefix (e.g.,
+  `validate_transcript_path_accepts_file_under_codex_root`,
+  `parse_tool_use_from_assistant_line`). New tests in this PR
+  follow the codebase convention for local consistency.
 
-<!-- codex-reviewed: 2026-05-22T10:58:30Z -->
+## 6. Lessons learned from v1
+
+This is the second iteration of the spec; the first was reverted
+after codex's faithful implementation didn't actually work
+end-to-end. The lesson is recorded here so future planner sessions
+benefit:
+
+- **Verify schema claims against real artifacts before specifying.**
+  v1 of the spec said "Codex's `cwd` field lives only on
+  `session_meta` and `turn_context`" based on a partial reading
+  (those events DO carry cwd). A 30-second `grep` across
+  `~/.codex/sessions/` would have shown that the value never
+  changes mid-session — the actual signal lives in
+  `function_call.arguments.workdir`. Codex review didn't catch
+  this because the review prompt only reads the spec, not the
+  domain.
+- **"Field is in the same place" hints are not authoritative.** PR
+  #239's follow-up text said the codex follow-up should look at
+  the same field as Claude. In hindsight, that note was the right
+  general direction but the WRONG specific field. Treat
+  hand-written follow-up hints as starting points, not final
+  schemas.
+- **Test coverage at the function-helper layer doesn't catch
+  schema mismatches.** All 11 v1 tests passed. The tests verified
+  the helper did what the spec described, but the spec described
+  the wrong thing. End-to-end verification in a running app caught
+  this; unit tests alone wouldn't have.

--- a/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
+++ b/docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md
@@ -597,3 +597,5 @@ npm run type-check
   the codebase convention for local consistency; updating the rule
   doc is out of scope here but is a one-line follow-up if the team
   wants the rule to match practice.
+
+<!-- codex-reviewed: 2026-05-22T10:58:30Z -->

--- a/src/bindings/AgentCwdEvent.ts
+++ b/src/bindings/AgentCwdEvent.ts
@@ -3,12 +3,25 @@
 /**
  * Event emitted when the agent's tracked working directory changes.
  *
- * Sourced from the structured `cwd` field that Claude Code (and Codex,
- * pending follow-up) writes on every transcript JSONL entry. This is the
- * authoritative signal for "where the agent currently is" — it picks up
- * tool-call-driven moves like `EnterWorktree` that intentionally do NOT
- * mutate the interactive shell's `$PWD`, so neither OSC 7 nor PTY text
- * patterns can catch them.
+ * Sourced from each adapter's structured cwd channel in its transcript
+ * JSONL:
+ * - **Claude Code** writes a top-level `cwd` field on every transcript
+ *   entry; transitions fire as soon as the next line is parsed.
+ * - **Codex** writes cwd in two places the watcher reads:
+ *   `session_meta.payload.cwd` (once, at session start) and
+ *   `response_item.payload.arguments.workdir` for `exec_command`
+ *   function calls (the mid-session signal — fires whenever codex
+ *   runs a tool command in a new directory). Codex also writes
+ *   `turn_context.payload.cwd` on every turn, but the watcher
+ *   intentionally ignores that field because it's pinned to the
+ *   session-start value and would cause false reverts after a
+ *   mid-session `exec_command.workdir` transition.
+ *
+ * In both cases this is the authoritative signal for "where the agent
+ * currently is" — it picks up tool-call-driven moves like Claude's
+ * `EnterWorktree` and codex's "switch to worktree" navigation that
+ * intentionally do NOT mutate the interactive shell's `$PWD`, so
+ * neither OSC 7 nor PTY text patterns can catch them.
  */
 export type AgentCwdEvent = {
   /**

--- a/src/features/agent-status/types/index.ts
+++ b/src/features/agent-status/types/index.ts
@@ -52,12 +52,19 @@ export interface AgentStatus {
   sessionId: string | null
   agentSessionId: string | null
   /**
-   * Agent-reported working directory, populated from the structured `cwd`
-   * field on every transcript JSONL entry (Claude Code today; Codex
-   * follow-up). `null` before the first transition or for agents that
-   * don't expose a transcript. The workspace bridge mirrors this into
-   * `pane.cwd` so the Header chip + git branch follow tool-call-driven
-   * cwd changes (e.g. Claude's built-in `EnterWorktree`).
+   * Agent-reported working directory, populated from each adapter's
+   * structured cwd channel in its transcript JSONL:
+   * - **Claude Code** writes a top-level `cwd` on every entry; transitions
+   *   fire as soon as the next line is parsed.
+   * - **Codex** writes cwd in two read paths: `session_meta.payload.cwd`
+   *   (session start) and `response_item.payload.arguments.workdir` for
+   *   `exec_command` function calls (mid-session). `turn_context.cwd`
+   *   is intentionally NOT a source — pinned to session-start and would
+   *   cause false reverts.
+   *
+   * `null` before the first transition or for agents that don't expose a
+   * transcript. The workspace bridge mirrors this into `pane.cwd` so the
+   * Header chip + git branch follow tool-call-driven cwd changes.
    */
   cwd: string | null
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -312,13 +312,20 @@ export const WorkspaceView = (): ReactElement => {
     updatePaneAgentType,
   ])
 
-  // Mirror the agent's structured cwd into pane.cwd. The transcript JSONL
-  // (Claude Code today; Codex follow-up) stamps every entry with the
-  // agent's current cwd; the `agent-cwd` event surfaces transitions.
-  // Tool-call-driven moves like Claude's built-in `EnterWorktree` do NOT
-  // change the interactive shell's $PWD, so neither OSC 7 nor PTY text
-  // patterns catch them — this bridge is what makes the worktree chip +
-  // git branch follow agent-driven worktree switches.
+  // Mirror the agent's structured cwd into pane.cwd. Both adapters expose
+  // an `agent-cwd` event on transitions; the sources differ:
+  //  - Claude Code stamps `cwd` on every transcript JSONL entry, so
+  //    transitions surface as soon as the next line is parsed.
+  //  - Codex stamps cwd in session_meta.payload.cwd (session start) and
+  //    response_item.payload.arguments.workdir for exec_command function
+  //    calls (mid-session). turn_context.cwd is intentionally ignored
+  //    by the backend — pinned to session-start and would cause false
+  //    reverts.
+  // Tool-call-driven moves like Claude's built-in `EnterWorktree` and
+  // codex's "switch to worktree" navigation do NOT change the interactive
+  // shell's $PWD, so neither OSC 7 nor PTY text patterns catch them —
+  // this bridge is what makes the worktree chip + git branch follow
+  // agent-driven worktree switches.
   //
   // Guards (Codex review on PR #239): scope to the active pane's session;
   // skip exited sessions; require the agent to be currently active so a


### PR DESCRIPTION
## Summary

PR #239's "Follow-ups" — port the structured `agent-cwd` event channel
to the Codex transcript watcher so Codex panes get the same pane-cwd
tracking Claude Code panes have via PR #239.

**Source model (v2-corrected):** Codex emits cwd transitions from two
sources:

- `session_meta.payload.cwd` — session-start anchor.
- `response_item.payload.arguments.workdir` for `exec_command` function
  calls — the mid-session signal.

`turn_context.payload.cwd` is intentionally **not** a source —
empirically it's pinned to session-start, and including it would cause
false reverts after an `exec_command.workdir` transition.

### Why this PR includes a v1 → v2 redesign

v1 of the spec (commits 36c7bae → 45da21c) assumed `turn_context.cwd`
updates mid-session. Codex implemented v1 faithfully (since-reverted
commits cab6b73 → dd95857) but the feature didn't work end-to-end.
Empirical verification against real `~/.codex/sessions/` rollouts
showed `turn_context.cwd` is static. v1 implementation was `git
reset`-ed; v2 spec + plan + implementation all land in this PR. The
v1 planner commits stay in history as breadcrumbs.

### Commits in this PR

Planner (spec + plan, both codex-reviewed twice, v1 + v2):

- `docs(spec): codex-transcript-cwd-parser` (v1)
- `docs(spec): apply codex feedback` (v1)
- `docs(spec): mark spec codex-reviewed` (v1)
- `docs(plan): codex-transcript-cwd-parser` (v1)
- `docs(plan): apply codex feedback` (v1)
- `docs(plan): mark plan codex-reviewed` (v1)
- `docs(spec): redesign for correct codex schema (v2)`
- `docs(spec): apply codex feedback (drop turn_context as cwd source)`
- `docs(spec): mark v2 spec codex-reviewed`
- `docs(plan): redesign for v2 spec`
- `docs(plan): apply codex feedback (v2 plan)`
- `docs(plan): mark v2 plan codex-reviewed`

Implementation (codex executed v2 plan):

- `feat(agent): emit codex cwd from exec command workdir`
- `docs(agent): update AgentCwdEvent docs for v2 codex shape`
- `docs(workspace): clarify v2 agent-cwd sources`

### Tests added

- 4 `extract_session_cwd` unit tests, incl.
  `extract_session_cwd_turn_context_returns_none` defensive guard.
- 6 `extract_exec_workdir` unit tests.
- 4 transition tests, incl. the v2 regression guard
  `process_line_turn_context_after_exec_command_does_not_revert`.
- 1 end-to-end `start_tailing` watcher test with the regression
  case (`turn_context(A)` after `exec_command(B)`) inline.

## Test plan

- [x] `cargo test -p vimeflow` — 517 / 518 passed; 1 pre-existing
  flake (`terminal::commands::tests::read_loop_eof_marks_cache_exited`,
  passes on rerun — same flake documented in PR #239's test plan).
- [x] `cargo test -p vimeflow --lib codex::transcript` — 20 / 20.
- [x] `npm test` — 2467 passed, 3 skipped.
- [x] `npm run lint` — clean.
- [x] `npm run format:check` — clean.
- [x] `npm run type-check` — clean.
- [ ] Manual smoke (open before merge): launch a Codex pane in
  vimeflow, ask codex to "use the worktree at
  `.claude/worktrees/<name>` for subsequent commands", run any command
  (`pwd`, `ls`). Verify the Header chip + git branch flip to the new
  worktree within ~1s of the first `exec_command` after the switch.

## Refs

- Follows PR #239 (Claude Code transcript cwd channel) — "Codex
  transcript cwd" follow-up item.
- Spec: `docs/superpowers/specs/2026-05-22-codex-transcript-cwd-parser-design.md` (v2, codex-reviewed).
- Plan: `docs/superpowers/plans/2026-05-22-codex-transcript-cwd-parser-plan.md` (v2, codex-reviewed).