### PR TITLE
[codex] docs: refresh 0.1.0 source readmes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 English | [简体中文](./CHANGELOG.zh-CN.md)
 
-This file records the supported user-facing state of Vimeflow. For the detailed implementation timeline, use [docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml), [docs/superpowers/](./docs/superpowers/), and the review knowledge base in [docs/reviews/](./docs/reviews/CLAUDE.md).
+This file records the supported user-facing state of Vimeflow. For the detailed implementation timeline, use [docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml), [docs/superpowers/](./docs/superpowers/), and the review knowledge base in [docs/reviews/CLAUDE.md](./docs/reviews/CLAUDE.md).
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,332 +1,50 @@
 # Changelog
 
-🇺🇸 English | [🇨🇳 简体中文](./CHANGELOG.zh-CN.md)
+English | [简体中文](./CHANGELOG.zh-CN.md)
 
-All notable changes to Vimeflow are recorded here. Format follows
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project is
-pre-1.0 so everything sits under `[Unreleased]` and is grouped by roadmap
-phase (see `docs/roadmap/progress.yaml`).
-
-**Pairing with reviews.** Each entry may cite patterns from
-[`docs/reviews/patterns/`](docs/reviews/CLAUDE.md) that were applied,
-updated, or created by the change — giving a linear timeline alongside
-the thematic retrospective index.
-
-**Updating.** On merge, append one bullet under the active phase in both
-this file and `CHANGELOG.zh-CN.md`. Entry shape:
-`- <change> ([#PR](url), <short-sha>) — patterns: [Name](docs/reviews/patterns/x.md)`.
-Supplementary notes (scope, deferred items, spec paths) use indented
-nested bullets (`    - …`). Security and Fixed entries should link a
-pattern when one exists; bump its `ref_count` per `docs/reviews/CLAUDE.md`.
-
----
+This file records the supported user-facing state of Vimeflow. For the detailed implementation timeline, use [docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml), [docs/superpowers/](./docs/superpowers/), and the review knowledge base in [docs/reviews/](./docs/reviews/CLAUDE.md).
 
 ## [Unreleased]
 
-### Electron Migration (Tauri → Electron + Rust Sidecar)
+### Changed
 
-The desktop shell migrated from Tauri 2 to Electron 42 over three merged PRs (with parallel spec/plan tracks for PR-A/B/C bundled into #209). After the sequence, the only desktop runtime is Electron and the only shipping Rust binary is the `vimeflow-backend` sidecar that Electron spawns and talks to over LSP-framed JSON stdio. Architecture overview lives in `docs/superpowers/plans/2026-05-13-electron-rust-backend-migration.md`; the per-phase specs are dated `2026-05-13` through `2026-05-15`; the retrospective is `docs/superpowers/retros/2026-05-16-electron-migration.md`.
+- Shortened the English and Chinese README files into source-build guides for the current `0.1.0` line, with deeper implementation details moved behind references.
+- Documented the Lifeline Claude Code extension and the repository's harness-engineering practice framing in both READMEs.
 
-#### Added
+## [0.1.0] - Current Source-Supported Line
 
-- Electron shell + Rust sidecar wiring landed alongside the existing Tauri host so the two runtimes coexisted during the cutover. New files: `electron/main.ts` (BrowserWindow + `ipcMain.handle('backend:invoke')` + sidecar process orchestration), `electron/preload.ts` (`contextBridge.exposeInMainWorld('vimeflow', { invoke, listen })`), `electron/sidecar.ts` (LSP `Content-Length` framing + pending-request map + listener registry + clean-EOF → SIGTERM → SIGKILL shutdown escalation), `electron/ipc-channels.ts`, `electron/backend-methods.ts` (production method allowlist, with `e2e-test`-gated extras). Bundled the runtime-neutral Rust backend changes (`BackendState` + `_inner` helpers — the "PR-A" intent) and the sidecar IPC plumbing (`src-tauri/src/runtime/ipc.rs` + `src-tauri/src/bin/vimeflow-backend.rs` — the "PR-B" intent) plus the frontend bridge (`src/lib/backend.ts` — the "PR-C" intent) that made the Electron shell possible. Tauri stayed alive — `npm run tauri:dev` and `npm run electron:dev` both worked side-by-side until PR-D3.
-  ([#209](https://github.com/winoooops/vimeflow/pull/209), `105f0ec`)
-  - Specs: `docs/superpowers/specs/2026-05-13-pr-a-runtime-neutral-rust-backend-design.md`, `2026-05-13-pr-b-rust-sidecar-ipc-design.md`, `2026-05-14-pr-c-frontend-backend-bridge-design.md`, `2026-05-14-pr-d1-electron-shell-sidecar-wiring-design.md`.
-- AppImage packaging via `electron-builder` (Linux-only for now; macOS / Windows / signing / auto-update are deferred). New `electron-builder.yml` at repo root: Linux AppImage target, `directories.output: release`, `extraResources` places the sidecar at `<resources>/bin/vimeflow-backend` to match `electron/main.ts`'s `process.resourcesPath/bin/<BINARY>` resolution. New `build/icon.png` (512×512, sourced from the now-deleted `src-tauri/icons/icon.png`). New `electron:build` npm script chains type-check → `vite build --mode electron` → `cargo build --release --bin vimeflow-backend` → `electron-builder --linux AppImage`. The produced `release/vimeflow-<version>-x64.AppImage` (~146 MB) launches with `--no-sandbox` on dev hosts without a SUID `chrome-sandbox`; `--appimage-extract-and-run` is the fallback on hosts without `libfuse2`.
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`) —
-  spec: [`2026-05-15-pr-d3-tauri-removal-design.md`](docs/superpowers/specs/2026-05-15-pr-d3-tauri-removal-design.md);
-  plan: [`2026-05-15-pr-d3-tauri-removal.md`](docs/superpowers/plans/2026-05-15-pr-d3-tauri-removal.md).
+### Supported
 
-#### Changed
+- Vimeflow is currently supported only as a source-built `0.1.0` app.
+- Linux AppImage is the only supported packaged target, built locally with `npm run electron:build`.
+- Hosted binary releases, signed installers, auto-update, and macOS / Windows packaging are not supported yet.
 
-- E2E pipeline swapped from `tauri-driver` + `browserName: 'wry'` to `@wdio/electron-service` + `browserName: 'electron'` across all three WDIO suites (`tests/e2e/{core,terminal,agent}/wdio.conf.ts`). New `tests/e2e/shared/electron-app.ts` exposes `appEntryPoint` (the bundled `dist-electron/main.js`) and `appArgs` (`--no-sandbox` + `--user-data-dir=<mkdtempSync>` for per-worker app-data isolation). `test:e2e:build` rewrites to build the renderer + Electron bundles + sidecar (`--features e2e-test`) instead of the Tauri app binary. CI's `e2e.yml` drops the `tauri-driver` install + `webkit2gtk-driver` apt dep + the `WEBKIT_DISABLE_DMABUF_RENDERER` env. All 11 existing E2E specs land unchanged.
-  ([#210](https://github.com/winoooops/vimeflow/pull/210), `96aed26`) —
-  spec: [`2026-05-15-pr-d2-e2e-electron-driver-swap-design.md`](docs/superpowers/specs/2026-05-15-pr-d2-e2e-electron-driver-swap-design.md).
-- TypeScript service classes renamed from `Tauri*Service` to `Desktop*Service` (PR-C had explicitly deferred this rename). `TauriTerminalService` → `DesktopTerminalService` (with file rename `tauriTerminalService.ts` → `desktopTerminalService.ts`); `TauriGitService` → `DesktopGitService`; `TauriFileSystemService` → `DesktopFileSystemService`. Factory call sites + sibling test files + stale doc-comments in `useSessionManager.test.ts`, `useTerminal.ts`, and `terminal/types/index.ts` all updated.
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- `src/lib/backend.ts` collapsed to a thin `window.vimeflow.{invoke,listen}` delegate. The `@tauri-apps/api/core` + `/event` fallback branches were removed in the same line-count as PR-C's `§2.5` cross-PR contract had predicted. A new `requireBridge()` helper throws a descriptive Error when the preload didn't expose the bridge (mitigation for spec `§4.1 R3` — the bridge `!` non-null assertion racing a slow preload). The `called`-guard idempotency wrapper for `UnlistenFn` stays for React StrictMode safety.
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- CI: dropped `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libappindicator3-dev`, `librsvg2-dev`, `patchelf` from `.github/workflows/e2e.yml`'s apt install step. After the Tauri Cargo dep was removed, the sidecar binary no longer link-pulls `webkit2gtk-rs`. Kept `xvfb` for headless Electron runs.
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- Renamed the Rust crate directory `src-tauri/` to `crates/backend/` and introduced the root Cargo workspace manifest (`./Cargo.toml`). `.cargo/config.toml` now lives at repo root so `TS_RS_EXPORT_DIR` consistently targets `src/bindings/`; the previously untracked crate-local lockfile is replaced by a tracked root `Cargo.lock`. CI, npm scripts, Electron dev/packaging paths, lint/spell ignores, and current docs now point at the workspace layout.
-  (this branch)
+### Added
 
-#### Removed
+- Electron 42 desktop shell with the Rust `vimeflow-backend` sidecar over LSP-framed JSON IPC. This replaced the historical Tauri runtime. See the Electron migration retrospective in [docs/superpowers/retros/2026-05-16-electron-migration.md](./docs/superpowers/retros/2026-05-16-electron-migration.md).
+- Terminal-first workspace: session tabs, multi-pane `SplitView` layouts, docked editor and diff panels, file explorer, git diff surfaces, command palette, and status bar.
+- Agent observability for Claude Code and Codex through the shared backend adapter model and frontend agent-status panel.
+- Codex cwd tracking from transcript events and terminal OSC 7 updates, plus linked-worktree names in pane headers.
+- Agent-status UI polish including the collapsed rail bucket meters and activity-detail tooltips.
 
-- The entire Tauri runtime surface: `src-tauri/src/main.rs` (Tauri host entry), `src-tauri/src/lib.rs::run()` (collapsed from 170 lines to 6 lines of `pub mod` declarations), `src-tauri/src/runtime/tauri_bridge.rs` (`TauriEventSink` adapter), 20 `#[tauri::command]` wrapper functions across `terminal/`, `filesystem/`, `git/`, `agent/` (the IPC router calls `BackendState` methods directly; the wrappers were pure dead code post-PR-A/B), and the `mod.rs` re-exports of those names. The `pub(crate) fn xxx_inner` helpers and `#[cfg(test)] pub fn xxx` test aliases were all preserved (tests call the cfg(test) aliases directly without a `tauri::State`; `cargo test` count matches the PR-D2 baseline byte-for-byte).
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- Tauri-only files: `src-tauri/{build.rs, tauri.conf.json, capabilities/, icons/}` (15 icon files; `icon.png` was copied to `build/icon.png` first). Cargo deps `tauri`, `tauri-plugin-log`, `tauri-build`, and the dev-dep `tauri = features = ["test"]`. The `[lib] crate-type` narrowed from `["staticlib", "cdylib", "rlib"]` to `["rlib"]` (the first two existed only for the Tauri mobile binding path). `default-run = "vimeflow"` → `default-run = "vimeflow-backend"`.
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- `@tauri-apps/api` (production dep) and `@tauri-apps/cli` (dev dep) from `package.json`; `tauri:dev` and `tauri:build` npm scripts; the `"tauri"` keyword (replaced with `"electron"`). `package-lock.json` regenerated.
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- `.github/workflows/tauri-build.yml` deleted. The cross-platform `npx tauri build --ci` matrix workflow broke the moment the `tauri:build` script and `@tauri-apps/cli` were removed; a replacement multi-platform `electron:build` matrix is a deferred follow-up.
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
+### Changed
 
-### UI Handoff Migration
+- Rust backend moved to `crates/backend/` under a root Cargo workspace. The only shipping Rust binary is `vimeflow-backend`.
+- E2E coverage now runs through WebdriverIO with `@wdio/electron-service`; the old Tauri driver path is gone.
+- UI handoff work is still in progress. Completed and remaining items are tracked in [docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml).
 
-#### Added
+### Fixed
 
-- Handoff design tokens and `src/agents/registry.ts` landed as the first
-  additive UI migration step.
-  ([#171](https://github.com/winoooops/vimeflow/pull/171), `38af7ab`)
-- Handoff app shell proportions, status bar, and session-tab strip landed
-  while preserving the existing Tauri terminal integrations.
-  ([#173](https://github.com/winoooops/vimeflow/pull/173), `266b3a0`)
-- Sidebar session rows and browser-style session tabs were restyled and wired
-  to `useSessionManager`; the roadmap now tracks step 4, Single TerminalPane,
-  as the next handoff step.
-  ([#174](https://github.com/winoooops/vimeflow/pull/174), `ab1b888`) —
-  patterns: [Documentation Accuracy](docs/reviews/patterns/documentation-accuracy.md)
+- Tooltip floating-anchor references now survive anchor updates.
+- Terminal pane focus and border-reset issues from recent workspace polish were corrected.
 
-### Phase 4 — Agent Status Sidebar
+### Removed
 
-#### Added
+- Tauri runtime files, Tauri npm scripts, Tauri dependencies, and the old Tauri build workflow.
 
-- Codex Adapter Stage 2 — `CodexAdapter` lands behind the existing
-  `AgentAdapter` trait so a PTY running `codex` populates the same status
-  panel as a Claude session: model, context window (driven by
-  `last_token_usage`, not lifetime totals), 5h/7d rate limits, and
-  durations. SQLite-primary session locator (schema-driven `logs` /
-  `threads` discovery, named-placeholder tuple comparison on
-  `(ts, ts_nanos) >= pty_start`) with FS-scan fallback. New rusqlite
-  bundled dep. `cost.total_cost_usd` becomes `Option<f64>` (Rust → null on
-  the wire → frontend override `number | null` → `BudgetMetrics` renders
-  `'—'` for null in `ApiKeyVariant`). `ManagedSession.started_at` +
-  `PtyState::get_started_at` added so the locator can gate on PTY start
-  time. `BindContext { session_id, cwd, pid, pty_start }` and `BindError
-{ Pending, Fatal }` added to `agent/adapter/types.rs`;
-  `AgentAdapter::status_source` becomes fallible; `base::start_for` runs a
-  bounded retry on `Pending` (5 × 100ms = 500ms total, well under
-  `DETECTION_POLL_MS=2000`). Spec:
-  [`docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`](docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md);
-  plan:
-  [`docs/superpowers/plans/2026-05-04-codex-adapter-stage-2.md`](docs/superpowers/plans/2026-05-04-codex-adapter-stage-2.md).
-  - **Scope expansion documented in
-    [`docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md`](docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md):**
-    the spec's three locked rules (no transcript tailer in v1; `/proc`
-    verifier-only; `BindContext.pid` = shell PID) were all relaxed
-    during implementation. The transcript tailer landed in v1 and
-    reuses `claude_code/test_runners/*` to emit
-    `AgentToolCallEvent` / `AgentTurnEvent` / test-run signals;
-    `/proc/<pid>/fd/*` and `/proc/<pid>/cmdline` contribute Linux
-    fast-paths when the SQLite logs query returns no rows (every fd
-    candidate is round-tripped through `threads.rollout_path` for
-    multi-fd disambiguation); `BindContext.pid` is now the detected
-    agent PID via `detect_agent`, not the shell PID, because Codex's
-    `logs.process_uuid` indexes by the codex child PID.
-  - Six rollout JSONL fixtures under
-    `src-tauri/tests/fixtures/codex/` pin the spec's locked parser
-    rules (last_token_usage source, info-null partial update,
-    incomplete-trailing-line silent drop, malformed-mid warn).
-- README hero gif (`docs/media/hero-init.gif`) plus four static screenshots
-  in `docs/media/`: workspace overview, agent status sidebar close-up, git
-  diff viewer, and editor with vim mode. The hero recording (spawn `claude` →
-  `/init` → tool calls stream live) doubles as the manual verification
-  evidence that closed `p4-d6` (real Claude Code session, end-to-end).
-  Capture pipeline (Kooha WebM → ffmpeg 1.5× / 15 fps / 1280px / 80-color
-  palette) documented in `docs/media/CLAUDE.md`.
-  - Bilingual mirror in `README.zh-CN.md`.
-  - Roadmap (`docs/roadmap/progress.yaml`) bumped to v7: Phase 4 status →
-    `done`, with a top-level note listing cross-phase items shipped during
-    Phase 4 (#80, #83, #86, #107, #109, #115, #120).
-- WebdriverIO + tauri-driver E2E infrastructure with native Linux CI: 10 spec
-  files (11 tests green locally on Fedora/Nobara) covering app launch, IPC
-  round-trip, navigation, PTY spawn, terminal I/O, session lifecycle, multi-tab
-  isolation, terminal resize, file→editor flow, and fake-claude agent
-  detection. Frontend E2E bridge (`window.__VIMEFLOW_E2E__`) and Cargo
-  `e2e-test` feature added.
-  ([#70](https://github.com/winoooops/vimeflow/pull/70), `e97c1e8`) —
-  patterns: [E2E Testing](docs/reviews/patterns/e2e-testing.md),
-  [Cross-Platform Paths](docs/reviews/patterns/cross-platform-paths.md)
-  - WSL2 scope (#65) deferred — "local env unsupported; use native Linux or CI".
-  - Deferred follow-ups: REPL, structured logging (#61), transcript parsing
-    in E2E, HMR orphan-PTY harness (#55), Phase 3 CI.
-  - Spec: `docs/superpowers/specs/2026-04-14-e2e-testing-design.md`.
-- UNIFIED design spec and canonical tokens (`docs/design/UNIFIED.md`,
-  `tokens.css`, `tokens.ts`) — 5-zone layout contract, agent-state
-  machine, component APIs.
-  ([#68](https://github.com/winoooops/vimeflow/pull/68), `3d6bc9a`)
-- Per-session statusline shell bridge + CWD storage in `PtyState` for
-  watcher path derivation.
-  ([#57](https://github.com/winoooops/vimeflow/pull/57),
-  [#60](https://github.com/winoooops/vimeflow/pull/60),
-  `de43dfc`, `e8d243c`) —
-  patterns: [PTY Session Management](docs/reviews/patterns/pty-session-management.md)
-- Transcript JSONL parser emitting `agent-tool-call` events.
-  ([#63](https://github.com/winoooops/vimeflow/pull/63), `ca50df6`)
-- `ts-rs` type codegen → `src/bindings/` for type-safe Rust ↔ TS boundary.
-  ([#49](https://github.com/winoooops/vimeflow/pull/49), `53789f5`)
+### References
 
-#### Changed
-
-- Adopted the dedicated Lifeline Claude Code plugin workflow for autonomous
-  agent loops and review cycles, and removed the in-repo harness, local
-  `harness-plugin` marketplace, and old review helper scripts. Root docs now
-  keep project-local Lifeline setup notes in `README.md`, `README.zh-CN.md`,
-  and `CLAUDE.md`; no separate Lifeline docs under `docs/` are shipped.
-  ([#188](https://github.com/winoooops/vimeflow/pull/188), `68a5501`) —
-  patterns: [Documentation Accuracy](docs/reviews/patterns/documentation-accuracy.md).
-- `/harness-plugin:github-review` rewritten to consume `chatgpt-codex-connector`
-  inline reviews + Claude Code Review aggregated comments + human reviewer
-  comments as a third source. State persistence via git commit-message
-  trailers (no JSON state file) with lazy reconciliation against live GraphQL
-  state. Codex-verified react+resolve chain: reply + `resolveReviewThread`
-  fire only after local `codex exec` agrees the staged fix addressed the
-  upstream finding.
-  ([#112](https://github.com/winoooops/vimeflow/pull/112),
-  [`e9b6bdc`](https://github.com/winoooops/vimeflow/commit/e9b6bdc),
-  closes [#111](https://github.com/winoooops/vimeflow/issues/111)) —
-  patterns: [Error Surfacing](docs/reviews/patterns/error-surfacing.md),
-  [Documentation Accuracy](docs/reviews/patterns/documentation-accuracy.md),
-  [Git Operations](docs/reviews/patterns/git-operations.md).
-  - Disabled `.github/workflows/codex-review.yml` (renamed to `.disabled`).
-    The aggregated Codex Action hit OpenAI quota every push for two PRs
-    running ([PR #109 retrospective](docs/reviews/retrospectives/2026-04-29-tests-panel-bridge-session.md));
-    single-commit revert if quota is restored later.
-  - 7 self-dogfood cycles processed ~30 findings end-to-end; 16 of those
-    were self-discovered regressions caught by the dogfood loop itself.
-    0 follow-up issues filed.
-  - Skill structure: thin orchestrator (`SKILL.md`, ~700 lines) +
-    7 references (`parsing.md`, `empty-state-classification.md`,
-    `verify-prompt.md`, `pattern-kb.md`, `commit-trailers.md`,
-    `cleanup-recovery.md`, `input-resolution.md`) + 2 scripts
-    (`scripts/helpers.sh`, `scripts/verify.sh`).
-  - Retrospective: [`docs/reviews/retrospectives/2026-04-30-harness-github-review-rewrite-session.md`](docs/reviews/retrospectives/2026-04-30-harness-github-review-rewrite-session.md)
-  - Spec: `docs/superpowers/specs/2026-04-29-harness-github-review-connector-design.md`
-  - Plan: `docs/superpowers/plans/2026-04-29-harness-github-review-connector.md`
-- Harness default backend swapped from `claude_code_sdk` to `claude -p`
-  subprocess per role. Inherits the user's `~/.claude` CLI auth; the
-  default path no longer requires `ANTHROPIC_API_KEY` or
-  `ANTHROPIC_BASE_URL`. SDK is preserved as an opt-in fallback via
-  `--client sdk` (still requires the API key when used).
-  ([#73](https://github.com/winoooops/vimeflow/pull/73), `93a5338`) —
-  patterns: [Policy Judge Hygiene](docs/reviews/patterns/policy-judge-hygiene.md),
-  [Fail-Closed Hooks](docs/reviews/patterns/fail-closed-hooks.md),
-  [Async Race Conditions](docs/reviews/patterns/async-race-conditions.md),
-  [Command Injection](docs/reviews/patterns/command-injection.md),
-  [Preflight Checks](docs/reviews/patterns/preflight-checks.md)
-  - New modules: `cli_client.py` (stream-JSON parser + `ClaudeCliSession`
-    with session resume / stderr drain / monotonic-budget timeout),
-    `hook_runner.py` (CLI → Python hook bridge, fail-closed on both
-    import-time and runtime errors), `policy_judge.py` (deny-by-default
-    with `HARNESS_POLICY_JUDGE=ask` / `=explain` opt-in and a
-    gitignored `.policy_allow.local` escape hatch), `sdk_client.py`
-    (lazy-imported fallback — only module that touches `claude_code_sdk`).
-  - Shared helpers in `client.py`: `build_base_settings`,
-    `write_settings_file`, `create_client` (CLI factory mirrored by
-    `sdk_client.create_client`).
-  - Removed the `CLAUDE_CONFIG_DIR` override that was silently hiding
-    the user's CLI auth. Swapped `--allowed-tools` (permissive) for
-    `--tools` (exclusive) so the CLI tool surface matches the SDK's.
-  - 12 rounds of cloud-review hardening: shell-quoted hook command
-    paths (`shlex.quote`), concurrent stderr drain against pipe-buffer
-    deadlock, atomic cache writes with `fcntl.flock`, user-private
-    cache at `~/.claude/harness_policy_cache.json`, async
-    `_query_claude` so SDK-path hooks don't stall the event loop,
-    Python 3.9+ compatible `asyncio.wait_for` timeouts,
-    `ResultEvent(is_error=True)` escalation to `"error"` status,
-    first-writer-wins cache semantics.
-  - Spec: `docs/superpowers/plans/2026-04-20-harness-claude-cli-subprocess.md`.
-- README (English + zh-CN) refreshed with Phase 3/4 scope; progress
-  tracker rebaselined.
-  ([#67](https://github.com/winoooops/vimeflow/pull/67), `f590c18`) —
-  patterns: [Documentation Accuracy](docs/reviews/patterns/documentation-accuracy.md)
-
-#### Security
-
-- Harness policy judge is now deny-by-default rather than LLM
-  rubber-stamp. Unknown bash commands are blocked unless listed in
-  `harness/.policy_allow.local` (gitignored, user-managed) or the
-  operator sets `HARNESS_POLICY_JUDGE=ask` (LLM decides) /
-  `=explain` (LLM advises but still denies). `hook_runner.py` fails
-  CLOSED on every error path — import-time failures, hook exceptions,
-  and a 45 s outer deadline so Claude CLI's own hook timeout can't
-  SIGKILL us into a silent allow. Policy judge subprocess runs with
-  `--tools ""` so it can't invoke tools or trigger user-level hooks.
-  ([#73](https://github.com/winoooops/vimeflow/pull/73), `93a5338`) —
-  patterns: [Policy Judge Hygiene](docs/reviews/patterns/policy-judge-hygiene.md),
-  [Fail-Closed Hooks](docs/reviews/patterns/fail-closed-hooks.md)
-
-#### Fixed
-
-- PTY sessions destroyed by Vite HMR full-reload (e.g. `vim :w` inside the
-  workspace, manual refresh, error-boundary reset). Moved session state to a
-  Rust filesystem cache (single source of truth) and added a cursor-based
-  replay protocol (`offset_start` + `byte_len` + per-pane `cursorRef`) with
-  listen-before-snapshot ordering, so any remount transparently reattaches
-  to the live PTY without losing or doubling bytes.
-  ([#99](https://github.com/winoooops/vimeflow/pull/99), `cb0ffa6`) —
-  patterns: [Async Race Conditions](docs/reviews/patterns/async-race-conditions.md),
-  [PTY Session Management](docs/reviews/patterns/pty-session-management.md),
-  [React Lifecycle](docs/reviews/patterns/react-lifecycle.md),
-  [Resource Cleanup](docs/reviews/patterns/resource-cleanup.md)
-  - 15-round Codex/Claude review cycle; final verdict ✅ APPROVE.
-  - Retrospective: [`docs/reviews/retrospectives/2026-04-27-pty-reattach-review-cycle.md`](docs/reviews/retrospectives/2026-04-27-pty-reattach-review-cycle.md)
-  - Design: [`docs/superpowers/specs/2026-04-25-pty-reattach-on-reload-design.md`](docs/superpowers/specs/2026-04-25-pty-reattach-on-reload-design.md)
-  - Follow-ups deferred as separate issues: #100 (read-loop global mutex perf),
-    #101 (kill_pty active rotation alignment), #102 (bridge-dir cleanup on
-    CapReached), #103 (RingBuffer drain), #104 (dead `ManagedSession.cwd`),
-    #105 (TerminalPane unused dep), #106 (`inner_sessions` visibility).
-- `agent-status` `ContextBucket` test compared against hard-coded English
-  instead of runtime locale.
-  ([#69](https://github.com/winoooops/vimeflow/pull/69), `a656daf`) —
-  patterns: [Testing Gaps](docs/reviews/patterns/testing-gaps.md)
-- `tauri:dev` on Linux/Wayland failed to launch the WebKitGTK renderer
-  under DMA-BUF; disabled DMA-BUF renderer in the dev script.
-  ([#66](https://github.com/winoooops/vimeflow/pull/66), `07b5c6f`) —
-  patterns: [Cross-Platform Paths](docs/reviews/patterns/cross-platform-paths.md)
-
-### Phase 3 — Terminal Core
-
-#### Added
-
-- `portable-pty` + xterm.js terminal pane with Catppuccin Mocha theme,
-  session caching, FitAddon, WebglAddon, and multi-tab support.
-  ([#31](https://github.com/winoooops/vimeflow/pull/31), `ba395c7`) —
-  patterns: [PTY Session Management](docs/reviews/patterns/pty-session-management.md),
-  [Terminal Input Handling](docs/reviews/patterns/terminal-input-handling.md)
-- `TauriTerminalService` IPC bridge: PTY stdout → Tauri events → xterm.js,
-  xterm `onData` → `invoke(write_pty)` → PTY stdin. Resize wired via
-  `ResizeObserver` + `FitAddon` + `resize_pty`. Cleanup kills session on
-  unmount.
-  ([#34](https://github.com/winoooops/vimeflow/pull/34), `2fc3fa2`,
-  `1ecee29`) —
-  patterns: [Resource Cleanup](docs/reviews/patterns/resource-cleanup.md),
-  [Async Race Conditions](docs/reviews/patterns/async-race-conditions.md)
-
-### Phase 2 — Workspace Layout Shell
-
-#### Added
-
-- 4-zone workspace grid: Icon Rail, Sidebar, Terminal Zone, Agent Activity
-  panel. Context switcher tabs (Files / Editor / Diff) wired into the
-  sidebar. All components use Obsidian Lens semantic tokens.
-  ([#31](https://github.com/winoooops/vimeflow/pull/31), `ba395c7`) —
-  patterns: [React Lifecycle](docs/reviews/patterns/react-lifecycle.md),
-  [Accessibility](docs/reviews/patterns/accessibility.md)
-
-#### Removed
-
-- Chat-first UI: `ChatView`, `features/chat/`, chat domain types, mock
-  messages. Project pivoted from chat manager to CLI agent workspace.
-  ([#31](https://github.com/winoooops/vimeflow/pull/31), `ba395c7`)
-
-### Phase 1 — Tauri Scaffold + CI Green
-
-#### Added
-
-- Tauri v2 scaffold (`src-tauri/`), `tauri:dev` / `tauri:build` npm
-  scripts, `src/lib/environment.ts` (`isTauri()` detection), CI pipeline
-  across macOS/Windows/Linux with Rust caching.
-  ([#27](https://github.com/winoooops/vimeflow/pull/27), `9ce4d61`) —
-  patterns: [CSP Configuration](docs/reviews/patterns/csp-configuration.md)
-
----
-
-## Legend
-
-- **Added** — new capability, file, command, or dependency.
-- **Changed** — behavioral/API update that is not a bug fix.
-- **Fixed** — bug fix (link a review pattern if one informed it).
-- **Removed** — deleted capability, file, or dependency.
-- **Security** — security-relevant fix (pattern link **required**).
+- Build and setup: [SETUP.md](./SETUP.md)
+- Developer commands: [DEVELOPMENT.md](./DEVELOPMENT.md)
+- Architecture: [ARCHITECT.md](./ARCHITECT.md)
+- Current roadmap state: [docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](./CHANGELOG.md) | 简体中文
 
-本文件记录 Vimeflow 当前受支持的用户可见状态。更详细的实现时间线请查看 [docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml)、[docs/superpowers/](./docs/superpowers/) 以及 [docs/reviews/](./docs/reviews/CLAUDE.md) 中的 review 知识库。
+本文件记录 Vimeflow 当前受支持的用户可见状态。更详细的实现时间线请查看 [docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml)、[docs/superpowers/](./docs/superpowers/) 以及 [docs/reviews/CLAUDE.md](./docs/reviews/CLAUDE.md) 中的 review 知识库。
 
 ## [Unreleased]
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,289 +1,50 @@
 # 更新日志
 
-[🇺🇸 English](./CHANGELOG.md) | 🇨🇳 简体中文
+[English](./CHANGELOG.md) | 简体中文
 
-Vimeflow 的所有重要变更记录在此。格式遵循
-[Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)；项目尚处于 1.0
-之前，因此所有条目都归入 `[Unreleased]`，并按路线图阶段分组
-（参见 `docs/roadmap/progress.yaml`）。
-
-**与 reviews 的配对。** 每条记录都可以引用
-[`docs/reviews/patterns/`](docs/reviews/CLAUDE.md) 中在此次变更里被应用、
-更新或新增的模式 — 从而让线性时间线与按主题归档的复盘索引相互印证。
-
-**如何更新。** 合并后，在 `[Unreleased]` 对应阶段下为本文件和
-`CHANGELOG.md` 各追加一条。条目结构：
-`- <变更描述> ([#PR](url), <short-sha>) — patterns: [Name](docs/reviews/patterns/x.md)`。
-附加说明（范围、遗留项、规格路径）使用缩进的嵌套列表（`    - …`）。
-Security 和 Fixed 条目若存在对应模式应加以链接；按 `docs/reviews/CLAUDE.md`
-约定递增 `ref_count`。
-
----
+本文件记录 Vimeflow 当前受支持的用户可见状态。更详细的实现时间线请查看 [docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml)、[docs/superpowers/](./docs/superpowers/) 以及 [docs/reviews/](./docs/reviews/CLAUDE.md) 中的 review 知识库。
 
 ## [Unreleased]
 
-### Electron 迁移（Tauri → Electron + Rust 旁路）
+### Changed
 
-桌面外壳在三次合入的 PR 中（含与之并行的 PR-A/B/C 设计/计划轨道，最终在 #209 中一并落地）从 Tauri 2 迁移到 Electron 42。这一序列之后，唯一的桌面运行时是 Electron，唯一发布的 Rust 二进制是 `vimeflow-backend` 旁路进程——它由 Electron 通过 stdio 的 LSP 帧 JSON IPC 启动并通信。整体架构见 `docs/superpowers/plans/2026-05-13-electron-rust-backend-migration.md`；各阶段设计文档落在 `2026-05-13` 至 `2026-05-15`；复盘见 `docs/superpowers/retros/2026-05-16-electron-migration.md`。
+- 将英文和中文 README 缩短为当前 `0.1.0` 版本线的源码构建指南，并把更深入的实现细节改为通过引用文档进入。
+- 在中英文 README 中补充 Lifeline Claude Code 扩展，以及本仓库作为 harness engineering 实践项目的定位。
 
-#### Added
+## [0.1.0] - 当前源码支持版本线
 
-- Electron 外壳与 Rust 旁路接线和原有的 Tauri 主机并存，使过渡期两种运行时可以同时工作。新增文件：`electron/main.ts`（BrowserWindow + `ipcMain.handle('backend:invoke')` + 旁路进程编排）、`electron/preload.ts`（`contextBridge.exposeInMainWorld('vimeflow', { invoke, listen })`）、`electron/sidecar.ts`（LSP `Content-Length` 帧解析 + 挂起请求映射 + 监听器注册表 + 干净 EOF → SIGTERM → SIGKILL 关停升级）、`electron/ipc-channels.ts`、`electron/backend-methods.ts`（生产方法白名单，含 `e2e-test` 门控的额外项）。一并打包了运行时中立的 Rust 后端改动（`BackendState` + `_inner` 助手——"PR-A" 意图）、旁路 IPC 管道（`src-tauri/src/runtime/ipc.rs` + `src-tauri/src/bin/vimeflow-backend.rs`——"PR-B" 意图）以及前端桥（`src/lib/backend.ts`——"PR-C" 意图），使 Electron 外壳成为可能。Tauri 在期间继续可用——`npm run tauri:dev` 与 `npm run electron:dev` 并行工作，直到 PR-D3。
-  ([#209](https://github.com/winoooops/vimeflow/pull/209), `105f0ec`)
-  - 设计文档：`docs/superpowers/specs/2026-05-13-pr-a-runtime-neutral-rust-backend-design.md`、`2026-05-13-pr-b-rust-sidecar-ipc-design.md`、`2026-05-14-pr-c-frontend-backend-bridge-design.md`、`2026-05-14-pr-d1-electron-shell-sidecar-wiring-design.md`。
-- 通过 `electron-builder` 实现 AppImage 打包（暂时只支持 Linux；macOS / Windows / 签名 / 自动更新都列为后续跟进项）。仓库根目录新增 `electron-builder.yml`：Linux AppImage 目标、`directories.output: release`、`extraResources` 将旁路二进制放到 `<resources>/bin/vimeflow-backend`，以匹配 `electron/main.ts` 通过 `process.resourcesPath/bin/<BINARY>` 的解析路径。新增 `build/icon.png`（512×512，来源于现在已删除的 `src-tauri/icons/icon.png`）。新增 `electron:build` npm 脚本：依次执行 type-check → `vite build --mode electron` → `cargo build --release --bin vimeflow-backend` → `electron-builder --linux AppImage`。产生的 `release/vimeflow-<version>-x64.AppImage`（约 146 MB）在没有 SUID `chrome-sandbox` 的开发主机上需用 `--no-sandbox` 启动；缺少 `libfuse2` 的主机可改用 `--appimage-extract-and-run` 回退。
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`) —
-  设计文档：[`2026-05-15-pr-d3-tauri-removal-design.md`](docs/superpowers/specs/2026-05-15-pr-d3-tauri-removal-design.md)；
-  实施计划：[`2026-05-15-pr-d3-tauri-removal.md`](docs/superpowers/plans/2026-05-15-pr-d3-tauri-removal.md)。
+### Supported
 
-#### Changed
+- Vimeflow 目前仅支持从源码构建和使用 `0.1.0`。
+- Linux AppImage 是当前唯一受支持的打包目标，需要在本地通过 `npm run electron:build` 构建。
+- 暂不支持托管二进制发布、签名安装包、自动更新、macOS / Windows 打包。
 
-- E2E 流水线从 `tauri-driver` + `browserName: 'wry'` 切换到 `@wdio/electron-service` + `browserName: 'electron'`，覆盖三个 WDIO 套件（`tests/e2e/{core,terminal,agent}/wdio.conf.ts`）。新增 `tests/e2e/shared/electron-app.ts` 暴露 `appEntryPoint`（打包后的 `dist-electron/main.js`）与 `appArgs`（`--no-sandbox` + `--user-data-dir=<mkdtempSync>`，用于跨 worker 的 app-data 隔离）。`test:e2e:build` 重写为构建渲染进程 + Electron 打包 + 旁路（`--features e2e-test`），不再构建 Tauri 应用二进制。CI 的 `e2e.yml` 移除 `tauri-driver` 安装步骤、`webkit2gtk-driver` apt 依赖以及 `WEBKIT_DISABLE_DMABUF_RENDERER` 环境变量。原有的 11 个 E2E spec 文件无需改动。
-  ([#210](https://github.com/winoooops/vimeflow/pull/210), `96aed26`) —
-  设计文档：[`2026-05-15-pr-d2-e2e-electron-driver-swap-design.md`](docs/superpowers/specs/2026-05-15-pr-d2-e2e-electron-driver-swap-design.md)。
-- TypeScript 服务类从 `Tauri*Service` 重命名为 `Desktop*Service`（PR-C 明确将这一重命名延后到 PR-D）。`TauriTerminalService` → `DesktopTerminalService`（文件同步改名 `tauriTerminalService.ts` → `desktopTerminalService.ts`）；`TauriGitService` → `DesktopGitService`；`TauriFileSystemService` → `DesktopFileSystemService`。工厂调用点、姊妹测试文件，以及 `useSessionManager.test.ts`、`useTerminal.ts`、`terminal/types/index.ts` 中的过期注释一并更新。
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- `src/lib/backend.ts` 收敛为对 `window.vimeflow.{invoke,listen}` 的薄包装委托。`@tauri-apps/api/core` + `/event` 的回退分支按 PR-C `§2.5` 跨 PR 合约预言的行数被一次性删除。新增 `requireBridge()` 助手：当 preload 未能暴露桥时抛出带有上下文的 `Error`（缓解 spec `§4.1 R3` 中描述的"`!` 非空断言遇到慢速 preload" 风险）。`UnlistenFn` 上的 `called`-guard 幂等包装保留，用于 React StrictMode 的双重清理保护。
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- CI：从 `.github/workflows/e2e.yml` 的 apt 安装步骤中移除 `libwebkit2gtk-4.1-dev`、`libgtk-3-dev`、`libappindicator3-dev`、`librsvg2-dev`、`patchelf`。在 Tauri Cargo 依赖被移除之后，旁路二进制不再链接 `webkit2gtk-rs`，这些系统依赖完全失去意义。保留 `xvfb`（无头 Electron 运行仍需）。
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- 将 Rust crate 目录从 `src-tauri/` 重命名为 `crates/backend/`，并在仓库根目录引入 Cargo workspace manifest（`./Cargo.toml`）。`.cargo/config.toml` 现在位于仓库根目录，确保 `TS_RS_EXPORT_DIR` 稳定指向 `src/bindings/`；此前未跟踪的 crate 本地 lockfile 被仓库根目录跟踪的 `Cargo.lock` 取代。CI、npm 脚本、Electron 开发/打包路径、lint/spell 忽略规则，以及当前文档都已指向 workspace 布局。
-  （当前分支）
+### Added
 
-#### Removed
+- Electron 42 桌面外壳与 Rust `vimeflow-backend` 旁路进程，通过 LSP 帧 JSON IPC 通信，并取代历史 Tauri runtime。参见 Electron 迁移复盘：[docs/superpowers/retros/2026-05-16-electron-migration.md](./docs/superpowers/retros/2026-05-16-electron-migration.md)。
+- 终端优先工作空间：会话标签、多 pane `SplitView` 布局、可停靠编辑器和 Diff 面板、文件浏览器、Git Diff、命令面板和状态栏。
+- 通过共享后端 adapter 模型和前端 agent-status 面板支持 Claude Code 与 Codex 可观测性。
+- 支持来自 Codex transcript 事件和终端 OSC 7 的 cwd 跟踪，并在 pane header 中显示 linked-worktree 名称。
+- 代理状态 UI 打磨，包括折叠 rail 的 bucket meters 和 activity 详情 tooltip。
 
-- 整个 Tauri 运行时面：`src-tauri/src/main.rs`（Tauri 主机入口）、`src-tauri/src/lib.rs::run()`（从 170 行收敛到 6 行的 `pub mod` 声明）、`src-tauri/src/runtime/tauri_bridge.rs`（`TauriEventSink` 适配器）、`terminal/`、`filesystem/`、`git/`、`agent/` 中共 20 个 `#[tauri::command]` 包装函数（IPC 路由器直接调用 `BackendState` 方法；这些包装在 PR-A/B 之后就是纯死代码），以及对这些名字的 `mod.rs` 再导出。所有 `pub(crate) fn xxx_inner` 助手与 `#[cfg(test)] pub fn xxx` 测试别名都被保留（测试直接调用 cfg(test) 别名，不需要 `tauri::State`；`cargo test` 数量与 PR-D2 基线逐字节一致）。
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- Tauri 专属文件：`src-tauri/{build.rs, tauri.conf.json, capabilities/, icons/}`（共 15 个图标；`icon.png` 在删除前已先复制到 `build/icon.png`）。Cargo 依赖 `tauri`、`tauri-plugin-log`、`tauri-build`，以及 `dev-dependencies` 中的 `tauri = features = ["test"]`。`[lib] crate-type` 从 `["staticlib", "cdylib", "rlib"]` 收敛到 `["rlib"]`（前两个仅为 Tauri 移动绑定路径存在）。`default-run = "vimeflow"` → `default-run = "vimeflow-backend"`。
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- `package.json` 中的 `@tauri-apps/api`（生产依赖）和 `@tauri-apps/cli`（开发依赖）；`tauri:dev` 与 `tauri:build` npm 脚本；`keywords` 中的 `"tauri"` 已替换为 `"electron"`。`package-lock.json` 已重新生成。
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
-- 删除 `.github/workflows/tauri-build.yml`。该工作流原本跨 Ubuntu / macOS / Windows 运行 `npx tauri build --ci`，在 `tauri:build` 脚本与 `@tauri-apps/cli` 移除后立刻失效；替代的跨平台 `electron:build` 矩阵列为后续跟进项。
-  ([#211](https://github.com/winoooops/vimeflow/pull/211), `c5433da`)
+### Changed
 
-### UI Handoff 迁移
+- Rust 后端移动到 `crates/backend/`，并纳入仓库根目录 Cargo workspace。当前唯一发布的 Rust 二进制是 `vimeflow-backend`。
+- E2E 覆盖切换到 WebdriverIO 与 `@wdio/electron-service`；旧 Tauri driver 路径已经移除。
+- UI handoff 仍在进行中。已完成和剩余项目记录在 [docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml)。
 
-#### Added
+### Fixed
 
-- Handoff 设计 tokens 与 `src/agents/registry.ts` 作为第一步增量 UI 迁移
-  落地。
-  ([#171](https://github.com/winoooops/vimeflow/pull/171), `38af7ab`)
-- Handoff 应用外壳比例、状态栏、会话标签条已落地，同时保留现有 Tauri
-  终端集成。
-  ([#173](https://github.com/winoooops/vimeflow/pull/173), `266b3a0`)
-- 侧边栏会话行与浏览器风格会话标签已完成视觉迁移，并接入
-  `useSessionManager`；路线图现在将第 4 步 Single TerminalPane 标记为下一
-  个 handoff 步骤。
-  ([#174](https://github.com/winoooops/vimeflow/pull/174), `ab1b888`) —
-  patterns: [Documentation Accuracy](docs/reviews/patterns/documentation-accuracy.md)
+- Tooltip floating anchor 引用在 anchor 更新后仍能保持正确。
+- 修复近期 workspace 打磨中出现的终端 pane 焦点和边框重置问题。
 
-### 第 4 阶段 — 代理状态侧边栏
+### Removed
 
-#### Added
+- Tauri runtime 文件、Tauri npm 脚本、Tauri 依赖，以及旧 Tauri build workflow。
 
-- Codex 适配器 Stage 2 —— `CodexAdapter` 接入现有 `AgentAdapter` trait，使运行 `codex` 的 PTY 与 Claude 会话共用同一状态面板：模型、上下文窗口（以 `last_token_usage` 为来源，而非累计 token）、5 小时 / 7 天速率限额、累计耗时。SQLite 优先的会话定位器（基于 schema 探测 `logs` / `threads` 表，使用命名占位符 + `(ts, ts_nanos) >= pty_start` 的元组比较），并辅以 FS 扫描回退。新增 `rusqlite`（bundled）依赖。`cost.total_cost_usd` 改为 `Option<f64>`（Rust 端 → 线上 `null` → 前端 override 为 `number | null` → `BudgetMetrics` 的 `ApiKeyVariant` 在 null 时渲染 `'—'`）。新增 `ManagedSession.started_at` 与 `PtyState::get_started_at`，使定位器能按 PTY 启动时间过滤查询。`agent/adapter/types.rs` 新增 `BindContext { session_id, cwd, pid, pty_start }` 与 `BindError { Pending, Fatal }`；`AgentAdapter::status_source` 变为可失败；`base::start_for` 对 `Pending` 进行有界重试（5 × 100ms = 500ms，低于 `DETECTION_POLL_MS=2000`）。设计文档：[`docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md`](docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md)；实施计划：[`docs/superpowers/plans/2026-05-04-codex-adapter-stage-2.md`](docs/superpowers/plans/2026-05-04-codex-adapter-stage-2.md)。
-  - **作用域扩展记录在 [`docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md`](docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md) 中：** 设计文档原本锁定的三条规则（v1 不实现 codex transcript tailer；`/proc` 仅作 verifier；`BindContext.pid` = shell PID）在实施中全部被放宽。Transcript tailer 在 v1 已落地，复用 `claude_code/test_runners/*` 发出 `AgentToolCallEvent` / `AgentTurnEvent` / 测试运行信号；当 SQLite logs 查询返回零行时，`/proc/<pid>/fd/*` 与 `/proc/<pid>/cmdline` 提供 Linux 快速路径（所有 fd 候选都会与 `threads.rollout_path` 交叉校验，避免多 fd 误绑定）；`BindContext.pid` 现在是 `detect_agent` 检测出的代理 PID，而非 shell PID，因为 Codex 的 `logs.process_uuid` 索引的是 codex 子进程 PID。
-  - `src-tauri/tests/fixtures/codex/` 下的 6 个 rollout JSONL 夹具固定了 spec 中锁定的解析规则（last_token_usage 来源、info-null 部分更新、不完整末行静默丢弃、中间畸形行 warn）。
-- README 首屏 GIF（`docs/media/hero-init.gif`）以及 `docs/media/` 中的 4
-  张静态截图：工作空间总览、代理状态侧边栏特写、Git Diff 查看器、Vim 模式
-  编辑器。首屏录屏（启动 `claude` → 运行 `/init` → 工具调用实时流入）同
-  时作为 `p4-d6`（真实 Claude Code 会话，端到端）的人工验证证据。抓取流
-  程（Kooha WebM → ffmpeg 1.5×/15 fps/1280px 宽/80 色调色板）记录于
-  `docs/media/CLAUDE.md`。
-  - 中文 README（`README.zh-CN.md`）同步更新。
-  - 路线图（`docs/roadmap/progress.yaml`）升级到 v7：第 4 阶段状态 →
-    `done`，并在顶部 `notes` 中列出第 4 阶段期间跨阶段交付的项目
-    （#80、#83、#86、#107、#109、#115、#120）。
-- 基于 WebdriverIO + tauri-driver 的端到端测试基础设施，并在原生 Linux CI
-  中运行：10 个 spec 文件（Fedora/Nobara 本地 11 个测试全部通过），
-  覆盖应用启动、IPC 往返、导航、PTY 启动、终端读写、会话生命周期、多标签
-  页隔离、终端尺寸变化、文件→编辑器流程，以及 fake-claude 代理检测。新增
-  前端 E2E 桥（`window.__VIMEFLOW_E2E__`）和 Cargo `e2e-test` 特性。
-  ([#70](https://github.com/winoooops/vimeflow/pull/70), `e97c1e8`) —
-  patterns: [E2E Testing](docs/reviews/patterns/e2e-testing.md),
-  [Cross-Platform Paths](docs/reviews/patterns/cross-platform-paths.md)
-  - WSL2 范围（#65）延后 — "本地环境不支持；请使用原生 Linux 或 CI"。
-  - 延后跟进项：REPL、结构化日志（#61）、E2E 中的 transcript 解析、
-    HMR 孤儿 PTY 测试夹具（#55）、第 3 阶段 CI。
-  - 规格：`docs/superpowers/specs/2026-04-14-e2e-testing-design.md`。
-- UNIFIED 设计规格与规范 tokens（`docs/design/UNIFIED.md`、`tokens.css`、
-  `tokens.ts`）— 5 区布局契约、代理状态机、组件 API。
-  ([#68](https://github.com/winoooops/vimeflow/pull/68), `3d6bc9a`)
-- 每会话 statusline shell 桥，以及在 `PtyState` 中存储 CWD 供监听器派生路径。
-  ([#57](https://github.com/winoooops/vimeflow/pull/57),
-  [#60](https://github.com/winoooops/vimeflow/pull/60),
-  `de43dfc`, `e8d243c`) —
-  patterns: [PTY Session Management](docs/reviews/patterns/pty-session-management.md)
-- Transcript JSONL 解析器，对外发出 `agent-tool-call` 事件。
-  ([#63](https://github.com/winoooops/vimeflow/pull/63), `ca50df6`)
-- `ts-rs` 类型代码生成 → `src/bindings/`，实现类型安全的 Rust ↔ TS 边界。
-  ([#49](https://github.com/winoooops/vimeflow/pull/49), `53789f5`)
+### References
 
-#### Changed
-
-- 采用专用的 Lifeline Claude Code 插件工作流来承载自主代理循环与 review
-  流程，并移除仓库内 harness、本地 `harness-plugin` marketplace 与旧 review
-  辅助脚本。根文档现在在 `README.md`、`README.zh-CN.md` 与 `CLAUDE.md`
-  保留项目本地 Lifeline 安装说明；不再在 `docs/` 下随仓库提供单独 Lifeline 文档。
-  ([#188](https://github.com/winoooops/vimeflow/pull/188), `68a5501`) —
-  patterns: [Documentation Accuracy](docs/reviews/patterns/documentation-accuracy.md)。
-- 重写 `/harness-plugin:github-review`，同时消费 `chatgpt-codex-connector`
-  行内评审、Claude Code Review 聚合评论与人类评审者评论（第三类输入）。
-  状态持久化改为 git commit-message trailers（不再使用 JSON 状态文件），
-  Step 1 通过实时 GraphQL 比对做惰性回收。React+resolve 链由 codex 验证
-  把关：本地 `codex exec` 确认补丁确实修复了上游 finding 之后，才会触发
-  reply + `resolveReviewThread`。
-  ([#112](https://github.com/winoooops/vimeflow/pull/112),
-  [`e9b6bdc`](https://github.com/winoooops/vimeflow/commit/e9b6bdc),
-  closes [#111](https://github.com/winoooops/vimeflow/issues/111)) —
-  patterns: [Error Surfacing](docs/reviews/patterns/error-surfacing.md),
-  [Documentation Accuracy](docs/reviews/patterns/documentation-accuracy.md),
-  [Git Operations](docs/reviews/patterns/git-operations.md)。
-  - 禁用 `.github/workflows/codex-review.yml`（重命名为 `.disabled`）。
-    连续两个 PR 中，聚合式 Codex Action 每次推送都触达 OpenAI 配额上限
-    （[PR #109 复盘](docs/reviews/retrospectives/2026-04-29-tests-panel-bridge-session.md)）；
-    日后若配额恢复，可一行 commit 还原。
-  - 7 轮自身 dogfood 循环端到端处理约 30 个 findings；其中 16 个是
-    spec/plan 未预见、由 dogfood 循环本身发现的回归。0 个遗留 issue。
-  - Skill 结构：thin orchestrator（`SKILL.md`，约 700 行）+
-    7 个 references（`parsing.md`、`empty-state-classification.md`、
-    `verify-prompt.md`、`pattern-kb.md`、`commit-trailers.md`、
-    `cleanup-recovery.md`、`input-resolution.md`）+ 2 个脚本
-    （`scripts/helpers.sh`、`scripts/verify.sh`）。
-  - 复盘：[`docs/reviews/retrospectives/2026-04-30-harness-github-review-rewrite-session.md`](docs/reviews/retrospectives/2026-04-30-harness-github-review-rewrite-session.md)
-  - 规格：`docs/superpowers/specs/2026-04-29-harness-github-review-connector-design.md`
-  - 计划：`docs/superpowers/plans/2026-04-29-harness-github-review-connector.md`
-- Harness 默认后端从 `claude_code_sdk` 改为按角色启动 `claude -p` 子进程。
-  直接继承用户本地 `~/.claude` 的 CLI 登录凭证；默认路径不再需要
-  `ANTHROPIC_API_KEY` 或 `ANTHROPIC_BASE_URL`。SDK 被保留为通过
-  `--client sdk` 显式开启的备用后端（使用时仍需 API key）。
-  ([#73](https://github.com/winoooops/vimeflow/pull/73), `93a5338`) —
-  patterns: [Policy Judge Hygiene](docs/reviews/patterns/policy-judge-hygiene.md),
-  [Fail-Closed Hooks](docs/reviews/patterns/fail-closed-hooks.md),
-  [Async Race Conditions](docs/reviews/patterns/async-race-conditions.md),
-  [Command Injection](docs/reviews/patterns/command-injection.md),
-  [Preflight Checks](docs/reviews/patterns/preflight-checks.md)
-  - 新增模块：`cli_client.py`（stream-JSON 解析器 + `ClaudeCliSession`
-    会话续传 / stderr 并发排空 / 基于单调时钟的超时预算），
-    `hook_runner.py`（CLI → Python 钩子桥，在导入期和运行期都
-    fail-closed），`policy_judge.py`（默认拒绝，可通过
-    `HARNESS_POLICY_JUDGE=ask` / `=explain` 显式启用 LLM 判定，
-    或在 gitignore 的 `.policy_allow.local` 中列出基础命令作为
-    确定性放行），`sdk_client.py`（懒加载的备用后端 —— 唯一引入
-    `claude_code_sdk` 的模块）。
-  - `client.py` 提供共享帮助器：`build_base_settings`、
-    `write_settings_file`、`create_client`（CLI 工厂，
-    `sdk_client.create_client` 使用同形签名）。
-  - 删除了会隐藏 CLI 登录态的 `CLAUDE_CONFIG_DIR` 覆盖。CLI 调用
-    使用 `--tools`（排他）替代 `--allowed-tools`（仅允许），与 SDK
-    的工具面保持一致。
-  - 12 轮云端评审硬化：`shlex.quote` 对钩子命令路径做 shell 转义、
-    stderr 并发排空避免管道缓冲区死锁、`fcntl.flock` + 原子写
-    保护缓存、用户私有缓存路径 `~/.claude/harness_policy_cache.json`、
-    异步化 `_query_claude` 让 SDK 路径的钩子不阻塞事件循环、
-    Python 3.9+ 兼容的 `asyncio.wait_for` 超时、
-    `ResultEvent(is_error=True)` 升级为 `"error"` 状态、
-    并发 ask 模式下的先到先得缓存语义。
-  - 规格：`docs/superpowers/plans/2026-04-20-harness-claude-cli-subprocess.md`。
-- 刷新 README（英文 + 中文），对齐第 3/4 阶段范围；重设进度跟踪器基线。
-  ([#67](https://github.com/winoooops/vimeflow/pull/67), `f590c18`) —
-  patterns: [Documentation Accuracy](docs/reviews/patterns/documentation-accuracy.md)
-
-#### Security
-
-- Harness policy judge 改为默认拒绝，不再是 LLM 盖章放行。未在白名单
-  中的 bash 命令默认被拒；操作者必须通过 `harness/.policy_allow.local`
-  （gitignored，本地手动维护）列出基础命令，或显式设置
-  `HARNESS_POLICY_JUDGE=ask`（让 LLM 判定）/ `=explain`（让 LLM 说明
-  理由但始终拒绝）。`hook_runner.py` 在全部错误路径都 fail-closed：
-  导入期异常、运行期异常，以及一个 45 秒的外层截止期 — 以防 Claude
-  CLI 自身的钩子超时先于我们 SIGKILL 进程，导致静默放行。Policy judge
-  子进程以 `--tools ""` 启动，无法调用任何工具，也不会触发用户级钩子。
-  ([#73](https://github.com/winoooops/vimeflow/pull/73), `93a5338`) —
-  patterns: [Policy Judge Hygiene](docs/reviews/patterns/policy-judge-hygiene.md),
-  [Fail-Closed Hooks](docs/reviews/patterns/fail-closed-hooks.md)
-
-#### Fixed
-
-- Vite HMR 全量刷新（如在工作区里 `vim :w`、手动刷新、错误边界重置）会摧
-  毁 PTY 会话。把会话状态搬进 Rust 文件系统缓存（单一事实源），并引入基于
-  游标的回放协议（`offset_start` + `byte_len` + 每个面板的 `cursorRef`）配
-  合「先订阅后快照」次序，使任意 remount 都能透明重连到存活 PTY，既不丢字
-  节也不重复回放。
-  ([#99](https://github.com/winoooops/vimeflow/pull/99), `cb0ffa6`) —
-  patterns: [Async Race Conditions](docs/reviews/patterns/async-race-conditions.md),
-  [PTY Session Management](docs/reviews/patterns/pty-session-management.md),
-  [React Lifecycle](docs/reviews/patterns/react-lifecycle.md),
-  [Resource Cleanup](docs/reviews/patterns/resource-cleanup.md)
-  - 15 轮 Codex / Claude 评审循环；最终判定 ✅ APPROVE。
-  - 复盘：[`docs/reviews/retrospectives/2026-04-27-pty-reattach-review-cycle.md`](docs/reviews/retrospectives/2026-04-27-pty-reattach-review-cycle.md)
-  - 设计：[`docs/superpowers/specs/2026-04-25-pty-reattach-on-reload-design.md`](docs/superpowers/specs/2026-04-25-pty-reattach-on-reload-design.md)
-  - 未在本 PR 解决、已分别建 issue 的后续：#100（read 循环全局锁性能）、
-    #101（`kill_pty` 与 `removeSession` 的活动 tab 旋转策略不一致）、
-    #102（`spawn_pty` 在达到上限时遗留 bridge 目录）、
-    #103（`RingBuffer` 改用 drain）、#104（清理 `ManagedSession.cwd` 死字
-    段）、#105（`TerminalPane` 多余依赖）、#106（收紧 `inner_sessions` 可
-    见性）。
-- `agent-status` 的 `ContextBucket` 测试对照的是硬编码英文字串，而非运行
-  时 locale。
-  ([#69](https://github.com/winoooops/vimeflow/pull/69), `a656daf`) —
-  patterns: [Testing Gaps](docs/reviews/patterns/testing-gaps.md)
-- Linux/Wayland 下 `tauri:dev` 无法在 DMA-BUF 渲染器中启动 WebKitGTK；
-  在开发脚本中关闭 DMA-BUF 渲染器。
-  ([#66](https://github.com/winoooops/vimeflow/pull/66), `07b5c6f`) —
-  patterns: [Cross-Platform Paths](docs/reviews/patterns/cross-platform-paths.md)
-
-### 第 3 阶段 — 终端核心
-
-#### Added
-
-- 基于 `portable-pty` + xterm.js 的终端面板，采用 Catppuccin Mocha 主题，
-  按标签页缓存会话，集成 FitAddon、WebglAddon，支持多标签终端。
-  ([#31](https://github.com/winoooops/vimeflow/pull/31), `ba395c7`) —
-  patterns: [PTY Session Management](docs/reviews/patterns/pty-session-management.md),
-  [Terminal Input Handling](docs/reviews/patterns/terminal-input-handling.md)
-- `TauriTerminalService` IPC 桥：PTY stdout → Tauri 事件 → xterm.js，
-  xterm `onData` → `invoke(write_pty)` → PTY stdin。通过
-  `ResizeObserver` + `FitAddon` + `resize_pty` 实现尺寸同步；卸载时清理
-  并终止会话。
-  ([#34](https://github.com/winoooops/vimeflow/pull/34), `2fc3fa2`,
-  `1ecee29`) —
-  patterns: [Resource Cleanup](docs/reviews/patterns/resource-cleanup.md),
-  [Async Race Conditions](docs/reviews/patterns/async-race-conditions.md)
-
-### 第 2 阶段 — 工作区布局外壳
-
-#### Added
-
-- 4 区工作区网格：图标栏、侧边栏、终端区、代理活动面板。上下文切换标签
-  （文件 / 编辑器 / Diff）接入侧边栏。所有组件采用 Obsidian Lens 语义
-  tokens。
-  ([#31](https://github.com/winoooops/vimeflow/pull/31), `ba395c7`) —
-  patterns: [React Lifecycle](docs/reviews/patterns/react-lifecycle.md),
-  [Accessibility](docs/reviews/patterns/accessibility.md)
-
-#### Removed
-
-- 基于聊天的 UI：`ChatView`、`features/chat/`、聊天领域类型、mock 消息。
-  项目从聊天管理器转型为 CLI 代理工作区。
-  ([#31](https://github.com/winoooops/vimeflow/pull/31), `ba395c7`)
-
-### 第 1 阶段 — Tauri 脚手架 + CI 通过
-
-#### Added
-
-- Tauri v2 脚手架（`src-tauri/`）、`tauri:dev` / `tauri:build` npm 脚本、
-  `src/lib/environment.ts`（`isTauri()` 检测）、跨 macOS/Windows/Linux
-  的 CI 流水线及 Rust 缓存。
-  ([#27](https://github.com/winoooops/vimeflow/pull/27), `9ce4d61`) —
-  patterns: [CSP Configuration](docs/reviews/patterns/csp-configuration.md)
-
----
-
-## 图例
-
-- **Added** — 新增能力、文件、命令或依赖。
-- **Changed** — 行为/API 更新，非 bug 修复。
-- **Fixed** — bug 修复（若有相应复盘模式，请加链接）。
-- **Removed** — 删除的能力、文件或依赖。
-- **Security** — 安全相关修复（**必须**链接模式）。
+- 构建与安装：[SETUP.md](./SETUP.md)
+- 开发命令：[DEVELOPMENT.md](./DEVELOPMENT.md)
+- 架构：[ARCHITECT.md](./ARCHITECT.md)
+- 当前路线图状态：[docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,6 +10,7 @@ npm run format        # Prettier write
 npm run type-check    # tsc -b
 npm run test          # Vitest
 npm run test:coverage # Vitest coverage
+npm run dev           # Vite dev server, no Rust sidecar required
 npm run electron:dev  # Electron shell + vimeflow-backend sidecar
 npm run electron:build # Linux AppImage packaging
 npm run test:e2e:all  # WebdriverIO + @wdio/electron-service E2E suites

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ Build the supported `0.1.0` AppImage:
 
 ```bash
 npm run electron:build
-chmod +x release/vimeflow-0.1.0-x64.AppImage
-./release/vimeflow-0.1.0-x64.AppImage --no-sandbox
+chmod +x release/vimeflow-*.AppImage
+./release/vimeflow-*.AppImage --no-sandbox
 ```
 
 If the host does not provide `libfuse2`, use AppImage's fallback:
 
 ```bash
-./release/vimeflow-0.1.0-x64.AppImage --appimage-extract-and-run --no-sandbox
+./release/vimeflow-*.AppImage --appimage-extract-and-run --no-sandbox
 ```
 
 ## Use Vimeflow

--- a/README.md
+++ b/README.md
@@ -2,292 +2,114 @@
 
 <div align="center">
 
-**A CLI Agent Control Plane for the Terminal-First Era**
+**A terminal-first workspace for AI coding agents**
 
-🇺🇸 English | [🇨🇳 简体中文](./README.zh-CN.md)
+English | [简体中文](./README.zh-CN.md)
 
-</div>
-
-<div align="center">
-
-<img src="docs/media/hero-init.gif" alt="Spawning a Claude Code session in Vimeflow and running /init — the agent panel auto-detects and streams tool calls live" width="900" />
-
-<sub>Spawn <code>claude</code>, run <code>/init</code>, watch the agent panel auto-detect and stream tool calls live.</sub>
+<img src="docs/media/hero-init.gif" alt="Starting a Claude Code session in Vimeflow and watching the agent panel stream tool calls" width="900" />
 
 </div>
 
-> An Electron desktop app that unifies terminal sessions, file explorer, code editor, and git diff into a single workspace — purpose-built for AI coding agents like Claude Code and Codex.
+Vimeflow is an Electron desktop app with a Rust `vimeflow-backend` sidecar. It brings terminal sessions, multi-pane layouts, file browsing, code editing, git diff review, command palette actions, and live Claude Code / Codex observability into one workspace.
 
-Vimeflow is a **CLI coding agent control plane** built with Electron 42 (renderer: React + TypeScript) on top of a long-lived `vimeflow-backend` Rust sidecar (PTY, filesystem, git, agent observability) over LSP-framed JSON IPC. It gives you one window to manage terminal sessions where AI agents work, browse files, review diffs, and edit code — all with vim-style keybindings and a dark atmospheric UI.
+## Current Support
 
-> Historical note: Vimeflow was originally a Tauri 2 desktop app. The Electron migration ([retrospective](docs/superpowers/retros/2026-05-16-electron-migration.md), PRs [#209](https://github.com/winoooops/vimeflow/pull/209) / [#210](https://github.com/winoooops/vimeflow/pull/210) / [#211](https://github.com/winoooops/vimeflow/pull/211)) replaced the Tauri shell with Electron + a runtime-neutral Rust sidecar in May 2026.
+Vimeflow currently supports **version 0.1.0 from source code only**.
 
-But the product is only half the story. This repository is also a testbed for **Lifeline-driven, AI-native development**: an autonomous agent loop builds features from specification, governed by layered rules and specialized agents.
+- Supported release line: `0.1.0`
+- Supported packaged target: Linux AppImage built locally from source
+- Desktop runtime: Electron 42 + Rust sidecar over LSP-framed JSON IPC
+- Agent observability: Claude Code and Codex
+- Not yet supported: hosted binary releases, macOS / Windows packaging, signing, or auto-update
 
-## What's Built
+Development on non-Linux systems may work, but the current supported build path is source checkout plus the Linux AppImage target.
 
-![Vimeflow workspace — Icon Rail, Sidebar, Terminal Zone with an active Claude Code session, and the Agent Status panel](docs/media/workspace-overview.png)
+## Build And Run From Source
 
-### Terminal Core (Phase 3)
+Prerequisites:
 
-Full xterm.js terminal integrated with the `vimeflow-backend` Rust sidecar via Electron IPC:
-
-- **DesktopTerminalService** — singleton renderer-side bridge between xterm.js and `portable-pty` (renamed from `TauriTerminalService` in PR-D3)
-- Rust PTY commands: spawn, write, resize, kill — dispatched through `BackendState` methods; stdout streamed via `StdoutEventSink` events
-- Session caching per tab plus per-session multi-pane terminal layouts
-- ResizeObserver + FitAddon for responsive terminal sizing
-- WebGL renderer with Catppuccin Mocha theme
-
-### Workspace Shell (Phase 2 + UI Handoff)
-
-A terminal-first workspace inspired by IDE + terminal multiplexer patterns:
-
-- **Icon Rail** — project avatars and navigation
-- **Sidebar** — Sessions / Files tabs, handoff-styled session rows, status indicators, subtitles, state pills, and line deltas
-- **Session Tabs** — browser-style tabs wired to `useSessionManager`
-- **Terminal Zone** — primary workspace area with `SplitView` layouts (`single`, `vsplit`, `hsplit`, `threeRight`, `quad`) and 1-4 real xterm.js panes per session
-- **Layout Switcher** — toolbar for passive layout changes plus `Mod+1-4` pane focus and `Mod+\` layout cycling
-- **DockPanel** — editor and diff panels docked bottom / top / left / right with elastic resizing and keyboard-adjustable handles
-- **Agent Activity Panel** — status, metrics, collapsible sections, scoped to the active pane's PTY
-- **Context Switcher** — Sessions / Files tabs in the left sidebar; Editor / Diff live in the dock
-- **Status Bar** — compact workspace status row
-
-Current UI handoff progress is tracked in [`docs/roadmap/progress.yaml`](docs/roadmap/progress.yaml). Steps 1-5c2 are done (`#171`, `#173`, `#174`, `#190`, `#198`, `#199`, `#203`, `#204`), and follow-up chrome work has landed for DockPanel positioning / elastic resize / shared focus / shortcut tooltips (`#215`, `#218`, `#219`, `#224`). Remaining visual work includes auto-grow on layout pick, activity-panel polish, and the open shortcut-discovery issue for `Mod+\` / `Mod+B` ([#225](https://github.com/winoooops/vimeflow/issues/225)).
-
-### Agent Status Sidebar (Phase 4)
-
-Real-time agent observability panel that auto-detects running AI coding agents in terminal sessions. Supports **Claude Code** and **Codex** (since [#154](https://github.com/winoooops/vimeflow/pull/154)) with one shared frontend:
-
-- **`AgentAdapter` trait** — `crates/backend/src/agent/adapter/` defines a single trait (`status_source` / `parse_status` / `validate_transcript` / `tail_transcript`) that each agent's adapter implements; the watcher pipeline, frontend events, and panel UI are agent-agnostic
-- **Claude Code adapter** (`adapter/claude_code/`) — per-session shell script pipes Claude's statusline JSON to a watched file; the adapter parses it and emits sidecar events (`agent-detected`, `agent-status`, `agent-tool-call`, `agent-disconnected`)
-- **Codex adapter** (`adapter/codex/`) — schema-driven SQLite locator over `~/.codex/*.sqlite` (logs DB → thread_id, threads DB → rollout JSONL path) with `/proc`-driven Linux fast-paths and FS-scan fallback; fold `event_msg.token_count` into the same `AgentStatusEvent` shape Claude emits
-- **Rust backend orchestration** — `crates/backend/src/agent/` adds the agent detector (process tree polling), the `base::start_for` watcher driver (file-change notify + polling fallback), and per-adapter transcript JSONL tailers for tool-call / turn / test-run signals
-- **Frontend panel** — `src/features/agent-status/` with `useAgentStatus` hook subscribing to the sidecar event bus, plus components: StatusCard (identity + model badge), BudgetMetrics (adaptive ApiKey/Subscriber/Fallback layout — Codex sessions render Subscriber with rate-limit bars; Claude API-key sessions render the Cost cell), ContextBucket (fill gauge + progress bar driven by `last_token_usage` for Codex, `total_input_tokens` for Claude), ToolCallSummary (aggregated chips), RecentToolCalls, FilesChanged, TestResults, and ActivityFooter
-- **Auto-collapse** — panel is 0px when no agent detected, animates to 280px on detection, holds final state for 5s after disconnect
-- **ts-rs type codegen** — Rust types exported to `src/bindings/` for type-safe frontend consumption (`CostMetrics.totalCostUsd: number | null` distinguishes Codex's no-cost surface from Claude's reported cost)
-
-Design specs: [`2026-04-12-agent-status-sidebar/`](docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md) (panel) · [`2026-05-02-claude-adapter-refactor-design.md`](docs/superpowers/specs/2026-05-02-claude-adapter-refactor-design.md) (trait abstraction, Stage 1) · [`2026-05-03-codex-adapter-stage-2-design.md`](docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md) (Codex adapter, Stage 2) · [`2026-05-04-codex-adapter-stage-2-scope-expansion.md`](docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md) (ratified deviations)
-
-<p align="center">
-  <img src="docs/media/agent-status-sidebar.png" alt="Agent Status Sidebar — Current Context gauge, Token Cache block, Activity feed, Files Changed, Tests panel" width="280" />
-</p>
-
-<p align="center"><sub>Right panel close-up — Context gauge, Token Cache, Activity feed, Files Changed, and Tests panel. Driven by either a Claude Code or Codex session via the shared <code>AgentAdapter</code> trait.</sub></p>
-
-### Feature Modules
-
-| Module              | Description                                                                                                                   |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **terminal**        | xterm.js + sidecar PTY IPC bridge, session management                                                                         |
-| **editor**          | IDE-style tabbed editor — CodeMirror 6, vim mode (@replit/codemirror-vim), vim status bar                                     |
-| **diff**            | Lazygit-style git diff viewer (side-by-side + unified, hunk navigation, stage/discard)                                        |
-| **files**           | File explorer tree with breadcrumbs, git status badges (M/A/D/U), drag-and-drop                                               |
-| **command-palette** | Vim-style `:` palette (global shortcut, fuzzy match, namespace drill-in) — built-in command registry shipping incrementally   |
-| **agent-status**    | Real-time agent observability panel — multi-agent (Claude Code + Codex) via the `AgentAdapter` trait                          |
-| **workspace**       | Layout shell composing the rail, sidebar, session tabs, SplitView terminal canvas, dock panel, status bar, and activity panel |
-
-![Editor with vim mode — `:w` typed, status bar shows -- NORMAL --](docs/media/editor-vim.png)
-
-![Diff Viewer — changed files list and a hunk with green added lines](docs/media/git-diff.png)
-
-### Quality
-
-- Vitest + Testing Library coverage across frontend/domain modules, plus Rust tests for backend modules
-- Accessibility-first test queries (`getByRole` over `getByText`)
-- Pre-commit hooks: ESLint + Prettier on staged files
-- Commit-msg hook: conventional commits via commitlint
-- Pre-push hook: full Vitest run
-
-### Linked worktrees inside the repo
-
-If you create linked worktrees inside the project, for example `git worktree add .claude/worktrees/feat-x ...`, add `.claude/worktrees/` to `.gitignore`. Otherwise the directory appears as untracked in `git status` from the main repo, and the watcher fires extra `git-status-changed` events for filesystem activity inside the worktree. Branch labels and the diff panel still stay correct; the watcher is just chattier than necessary.
-
-## Changelog
-
-See [`CHANGELOG.md`](./CHANGELOG.md) (English) or [`CHANGELOG.zh-CN.md`](./CHANGELOG.zh-CN.md) (简体中文) for the linear timeline of notable changes. Each entry may cross-link review patterns from [`docs/reviews/`](./docs/reviews/CLAUDE.md) that it applied, updated, or created — so the CHANGELOG is the _when_ and `docs/reviews/` is the _why_.
-
-## Tech Stack
-
-| Layer         | Technologies                                          |
-| ------------- | ----------------------------------------------------- |
-| **Desktop**   | Electron 42, Rust sidecar, portable-pty, tokio        |
-| **Frontend**  | React 19, TypeScript 5 (strict), Vite                 |
-| **Styling**   | Tailwind CSS v4, Catppuccin Mocha semantic tokens     |
-| **Terminal**  | xterm.js 6, WebGL addon, FitAddon                     |
-| **Editor**    | CodeMirror 6, @replit/codemirror-vim (vim mode)       |
-| **Animation** | Framer Motion 12                                      |
-| **Testing**   | Vitest 3, Testing Library                             |
-| **Quality**   | ESLint 9 (flat config), Prettier 3, Husky, commitlint |
-| **Git**       | simple-git 3, diff2html 3                             |
-
-## Design System: "The Obsidian Lens"
-
-Dark atmospheric UI built on the Catppuccin Mocha palette — treats UI as illuminated, translucent layers within a deep void.
-
-- **No visible borders** — use tonal depth and surface hierarchy (8 levels)
-- **Glassmorphism** for floating elements (60-80% opacity, 12-20px blur)
-- **Typography**: Manrope (headlines), Inter (body/labels), JetBrains Mono (code)
-- **Semantic tokens**: `bg-surface-container`, `text-on-surface`, `text-primary`, etc.
-
-Full spec: [`docs/design/DESIGN.md`](docs/design/DESIGN.md)
-
-## Quick Start
+- Node.js >= 22; Node 24 from `.nvmrc` is preferred for CI parity
+- Rust stable toolchain
+- Git
+- Linux for the supported AppImage packaging path
 
 ```bash
-# Prerequisites: Node >= 22 (Node 24 via .nvmrc for CI parity), Rust toolchain
-nvm use                          # Uses .nvmrc
-
-# Frontend only (no Rust backend; useful for renderer-only iteration)
-npm install
-npm run dev                      # Vite dev server at localhost:5173
-
-# Full desktop app (requires Rust)
-npm run electron:dev             # Electron + Rust sidecar (vimeflow-backend)
-
-# Linux dev hosts without a working Chromium sandbox
-VIMEFLOW_NO_SANDBOX=1 npm run electron:dev
-
-# Packaged Linux AppImage
-npm run electron:build           # Produces release/vimeflow-<version>-x64.AppImage
-
-# Tests
-npm test                         # Vitest suite
-npx vitest run src/path/file.test.tsx  # Single file
-
-# Quality
-npm run lint                     # ESLint (type-checked)
-npm run format:check             # Prettier check
-npm run type-check               # tsc -b
+git clone https://github.com/winoooops/vimeflow.git
+cd vimeflow
+nvm use
+npm ci
 ```
 
-### Shell Setup (OSC 7)
-
-The sidebar file explorer auto-syncs with the terminal's working directory. This relies on your shell emitting [OSC 7](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands) escape sequences when `cd` is used.
-
-| Shell    | Status                                            |
-| -------- | ------------------------------------------------- |
-| **zsh**  | Works out of the box                              |
-| **fish** | Works out of the box                              |
-| **bash** | Requires a one-time setup (adds `PROMPT_COMMAND`) |
+Run the desktop app from source:
 
 ```bash
-# Automatic setup (idempotent — safe to run multiple times)
+npm run electron:dev
+```
+
+On Linux hosts without a working Chromium sandbox:
+
+```bash
+VIMEFLOW_NO_SANDBOX=1 npm run electron:dev
+```
+
+Build the supported `0.1.0` AppImage:
+
+```bash
+npm run electron:build
+chmod +x release/vimeflow-0.1.0-x64.AppImage
+./release/vimeflow-0.1.0-x64.AppImage --no-sandbox
+```
+
+If the host does not provide `libfuse2`, use AppImage's fallback:
+
+```bash
+./release/vimeflow-0.1.0-x64.AppImage --appimage-extract-and-run --no-sandbox
+```
+
+## Use Vimeflow
+
+1. Start Vimeflow with `npm run electron:dev` or the locally built AppImage.
+2. Open a terminal pane and run `claude` or `codex`.
+3. Use the workspace to split panes, browse files, edit code, and review git diffs.
+4. The agent status panel appears when a supported agent is detected.
+
+For terminal working-directory sync, `zsh` and `fish` usually emit OSC 7 automatically. For `bash`, run:
+
+```bash
 ./scripts/setup-shell-osc7.sh
 ```
 
-Or add manually to `~/.bashrc`:
+## Lifeline And Harness Engineering
+
+This repository is also a practical harness-engineering project. Vimeflow's development workflow uses the [Lifeline Claude Code extension](https://github.com/winoooops/lifeline) for planning, autonomous implementation loops, reviews, PR requests, upstream review handling, and PR approval.
+
+Project-local setup notes live in [CLAUDE.md](./CLAUDE.md#lifeline-plugin-setup).
+
+## Verify A Checkout
 
 ```bash
-PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}"'printf "\e]7;file://%s%s\a" "$HOSTNAME" "$PWD"'
+npm run lint
+npm run format:check
+npm run type-check
+npm test
+cargo test --manifest-path crates/backend/Cargo.toml
 ```
 
-### Linux: AppImage smoke
-
-`npm run electron:build` produces `release/vimeflow-<version>-x64.AppImage`. On dev hosts without a SUID `chrome-sandbox`, launch with `--no-sandbox`:
+Regenerate TypeScript bindings after Rust type changes:
 
 ```bash
-chmod +x release/vimeflow-*.AppImage
-./release/vimeflow-*.AppImage --no-sandbox &
+npm run generate:bindings
 ```
 
-On hosts without `libfuse2`, fall back to `--appimage-extract-and-run --no-sandbox` (extracts to tmp and runs the unpacked tree). Post-PR-D3, the GTK/WebKitGTK renderer flags from the old Tauri setup (`WEBKIT_DISABLE_DMABUF_RENDERER=1`) are no longer needed — Electron ships its own Chromium.
+## Project References
 
-### Lifeline Plugin Setup
-
-The autonomous development workflow is provided by the dedicated [Lifeline Claude Code plugin](https://github.com/winoooops/lifeline). Lifeline provides `/lifeline:planner`, `/lifeline:loop`, `/lifeline:review`, `/lifeline:request-pr`, `/lifeline:upsource-review`, and `/lifeline:approve-pr`.
-
-```bash
-# 1. Register the Lifeline marketplace (one-time)
-/plugin marketplace add winoooops/lifeline
-
-# 2. Install the plugin
-/plugin install lifeline@lifeline
-
-# 3. Reload to activate
-/reload-plugins
-```
-
-After installation, Lifeline is cached under Claude Code's plugin cache and persists across sessions. Project-local usage notes live in [`CLAUDE.md`](CLAUDE.md#lifeline-plugin-setup).
-
-> Plugin skills don't appear in `/` autocomplete due to a [known Claude Code bug](https://github.com/anthropics/claude-code/issues/18949). See [`CLAUDE.md`](CLAUDE.md#lifeline-plugin-setup) for the optional autocomplete workaround.
-
-## Repository Structure
-
-```
-CLAUDE.md                   # AI navigation hub (agents start here)
-ARCHITECT.md                # Architecture decisions, Electron sidecar IPC patterns
-docs/design/DESIGN.md       # UI design system (single source of truth)
-
-src/
-├── features/
-│   ├── workspace/          # Workspace shell, session tabs/sidebar, DockPanel
-│   ├── terminal/           # xterm.js + DesktopTerminalService IPC bridge
-│   ├── editor/             # Tabbed code editor with CodeMirror 6 + vim mode
-│   ├── diff/               # Lazygit-style diff viewer
-│   ├── files/              # File explorer tree
-│   ├── command-palette/    # Vim-style command palette
-│   └── agent-status/       # Real-time agent observability panel
-├── components/             # Shared primitives (Tooltip)
-├── hooks/                  # Shared React hooks
-├── agents/                 # Agent metadata registry
-├── bindings/               # Generated Rust -> TypeScript types
-└── test/                   # Vitest setup
-
-Cargo.toml                  # Workspace root manifest (members = ["crates/backend"])
-Cargo.lock                  # Workspace lockfile (tracked at repo root)
-target/                     # Cargo workspace build dir (gitignored)
-.cargo/config.toml          # Cargo env: TS_RS_EXPORT_DIR = src/bindings/
-crates/                     # Rust workspace members
-└── backend/                # Renamed from src-tauri/
-    ├── src/
-    │   ├── bin/
-    │   │   └── vimeflow-backend.rs  # Sidecar binary entry — stdin/stdout LSP-framed JSON IPC
-    │   ├── lib.rs                   # Module declarations only (post-PR-D3 collapse)
-    │   ├── runtime/                 # BackendState, IPC router, EventSink trait
-    │   ├── terminal/                # PTY commands (_inner helpers + BackendState methods)
-    │   ├── filesystem/              # List/read/write commands with scope validation
-    │   ├── git/                     # Git status, diff, stage/unstage
-    │   └── agent/                   # Agent detector, statusline watcher, transcript parser
-    ├── Cargo.toml                   # Crate manifest (Tauri deps removed in PR-D3)
-    └── README.md                    # Crate-level orientation
-
-electron/                   # Electron desktop shell (PR-D1+)
-├── main.ts                 # App lifecycle + ipcMain + sidecar process orchestration
-├── preload.ts              # contextBridge.exposeInMainWorld('vimeflow', { invoke, listen })
-├── sidecar.ts              # LSP frame codec + pending-request map + shutdown escalation
-├── ipc-channels.ts         # Channel-name constants
-└── backend-methods.ts      # Production method allowlist
-
-electron-builder.yml        # Linux AppImage packaging config
-
-agents/                     # 10 specialized AI agent definitions
-rules/                      # Hierarchical dev standards (common + TS + Rust)
-```
-
-## The AI-Native Development Process
-
-Traditional projects have humans write code and AI assist. Vimeflow inverts this:
-
-1. **Humans write specs** — product requirements, design system, development rules
-2. **Lifeline builds features** — the dedicated plugin decomposes specs into a feature list and implements them incrementally
-3. **Specialized agents review the work** — 10 AI agents handle planning, TDD, code review, security, and documentation
-4. **Rules govern everything** — a hierarchical rule system (common + language-specific) ensures consistency without human intervention per commit
-
-Lifeline is the dedicated workflow plugin for Vimeflow's AI-native development loop. See [`CLAUDE.md`](CLAUDE.md#lifeline-plugin-setup) for Vimeflow-specific usage notes and <https://github.com/winoooops/lifeline> for the plugin runbook.
-
-## Roadmap
-
-| Phase      | Status      | Description                                                                 |
-| ---------- | ----------- | --------------------------------------------------------------------------- |
-| Phase 1    | Done        | Historical Tauri scaffold; superseded by the Electron sidecar runtime       |
-| Phase 2    | Done        | Workspace layout shell                                                      |
-| Phase 3    | Done        | Terminal core (xterm.js + Electron-sidecar PTY IPC)                         |
-| Phase 4    | Done        | Agent status sidebar (Claude Code / Codex detection, telemetry, UI)         |
-| UI Handoff | In progress | Multi-pane terminal canvas and DockPanel landed; remaining polish continues |
-| Phase 5    | Planned     | Durable session persistence/state                                           |
-| Phase 6+   | Planned     | Remaining context, usage, and desktop polish work                           |
-
-Progress tracked in [`docs/roadmap/progress.yaml`](docs/roadmap/progress.yaml).
+- Setup details: [SETUP.md](./SETUP.md)
+- Development commands and style: [DEVELOPMENT.md](./DEVELOPMENT.md)
+- Architecture and Electron sidecar IPC: [ARCHITECT.md](./ARCHITECT.md)
+- Design system: [DESIGN.md](./DESIGN.md) and [docs/design/UNIFIED.md](./docs/design/UNIFIED.md)
+- Current roadmap status: [docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml)
+- Changelog: [CHANGELOG.md](./CHANGELOG.md) / [CHANGELOG.zh-CN.md](./CHANGELOG.zh-CN.md)
+- Backend crate notes: [crates/backend/README.md](./crates/backend/README.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Development on non-Linux systems may work, but the current supported build path 
 Prerequisites:
 
 - Node.js >= 22; Node 24 from `.nvmrc` is preferred for CI parity
+- `nvm` is optional but recommended for using `.nvmrc`; skip `nvm use` if Node 24 is already active through another manager
 - Rust stable toolchain
 - Git
 - Linux for the supported AppImage packaging path
@@ -36,7 +37,7 @@ Prerequisites:
 ```bash
 git clone https://github.com/winoooops/vimeflow.git
 cd vimeflow
-nvm use
+nvm use # Optional: switches to Node 24 from .nvmrc
 npm ci
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,6 +29,7 @@ Vimeflow 目前**仅支持从源码构建和使用 0.1.0 版本**。
 前置条件：
 
 - Node.js >= 22；推荐使用 `.nvmrc` 中的 Node 24 以对齐 CI
+- `nvm` 是可选但推荐的 `.nvmrc` 读取工具；如果已通过其他工具启用 Node 24，可跳过 `nvm use`
 - Rust stable 工具链
 - Git
 - Linux（用于当前受支持的 AppImage 打包路径）
@@ -36,7 +37,7 @@ Vimeflow 目前**仅支持从源码构建和使用 0.1.0 版本**。
 ```bash
 git clone https://github.com/winoooops/vimeflow.git
 cd vimeflow
-nvm use
+nvm use # 可选：切换到 .nvmrc 中的 Node 24
 npm ci
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,247 +2,114 @@
 
 <div align="center">
 
-**终端优先时代的 CLI Agent 控制面板**
+**面向 AI 编码代理的终端优先工作空间**
 
 [English](./README.md) | 简体中文
 
-</div>
-
-<div align="center">
-
-<img src="docs/media/hero-init.gif" alt="在 Vimeflow 中启动 Claude Code 会话并运行 /init — 代理面板自动识别并实时显示工具调用" width="900" />
-
-<sub>启动 <code>claude</code>，运行 <code>/init</code>，观察代理面板自动识别并实时显示工具调用。</sub>
+<img src="docs/media/hero-init.gif" alt="在 Vimeflow 中启动 Claude Code 会话并观察代理面板实时显示工具调用" width="900" />
 
 </div>
 
-> 一个 Electron 桌面应用，将终端会话、文件浏览器、代码编辑器和 Git Diff 统一到一个工作空间 — 专为 Claude Code、Codex 等 AI 编码代理打造。
+Vimeflow 是一个 Electron 桌面应用，使用 Rust `vimeflow-backend` 旁路进程。它把终端会话、多 pane 布局、文件浏览、代码编辑、Git Diff 审查、命令面板，以及 Claude Code / Codex 的实时可观测性集中在一个工作空间中。
 
-Vimeflow 是一个 **CLI 编码代理控制面板**，基于 Electron 42（渲染进程：React + TypeScript）与长期驻留的 `vimeflow-backend` Rust 旁路（PTY、文件系统、Git、代理可观测性）通过 LSP 帧 JSON IPC 协作构建。它在一个窗口内管理 AI 代理工作的终端会话、浏览文件、审查 Diff 和编辑代码 — 全部配备 Vim 风格快捷键和暗色氛围 UI。
+## 当前支持范围
 
-> 历史说明：Vimeflow 起初是 Tauri 2 桌面应用。Electron 迁移（[复盘](docs/superpowers/retros/2026-05-16-electron-migration.md)，PR [#209](https://github.com/winoooops/vimeflow/pull/209) / [#210](https://github.com/winoooops/vimeflow/pull/210) / [#211](https://github.com/winoooops/vimeflow/pull/211)）于 2026 年 5 月用 Electron + 运行时中立的 Rust 旁路替换了 Tauri 外壳。
+Vimeflow 目前**仅支持从源码构建和使用 0.1.0 版本**。
 
-但产品只是故事的一半。这个仓库也是**工程化 AI 原生开发**的试验场：自主代理循环从规格说明构建功能，由分层规则和专业代理管控。
+- 支持的版本线：`0.1.0`
+- 支持的打包目标：在本地从源码构建 Linux AppImage
+- 桌面运行时：Electron 42 + Rust 旁路，通过 LSP 帧 JSON IPC 通信
+- 代理可观测性：Claude Code 和 Codex
+- 暂不支持：托管二进制发布、macOS / Windows 打包、签名、自动更新
 
-## 已实现功能
+非 Linux 系统上的开发流程可能可用，但当前受支持的构建路径是源码检出加 Linux AppImage 目标。
 
-![Vimeflow 工作空间 — 图标栏、侧边栏、运行中的 Claude Code 会话和代理状态面板](docs/media/workspace-overview.png)
+## 从源码构建和运行
 
-### 终端核心（第 3 阶段）
+前置条件：
 
-完整的 xterm.js 终端，通过 Electron IPC 集成 `vimeflow-backend` Rust 旁路：
-
-- **DesktopTerminalService** — 渲染进程侧 xterm.js 与 `portable-pty` 之间的单例桥接（PR-D3 重命名自 `TauriTerminalService`）
-- Rust PTY 命令：spawn、write、resize、kill — 通过 `BackendState` 方法分发；stdout 经 `StdoutEventSink` 事件流式传输
-- 按标签页缓存会话，并支持每个会话的多 pane 终端布局
-- ResizeObserver + FitAddon 实现响应式终端尺寸
-- WebGL 渲染器 + Catppuccin Mocha 主题
-
-### 工作空间外壳（第 2 阶段 + UI Handoff）
-
-借鉴 IDE + 终端复用器模式的终端优先工作空间：
-
-- **图标栏** — 项目头像和导航
-- **侧边栏** — Sessions / Files 标签页，符合 handoff 设计的会话行、状态指示器、副标题、状态胶囊、行数变化
-- **会话标签页** — 通过 `useSessionManager` 驱动的浏览器风格标签
-- **终端区** — 主工作区域，使用 `SplitView` 布局（`single`、`vsplit`、`hsplit`、`threeRight`、`quad`），每个会话支持 1-4 个真实 xterm.js pane
-- **布局切换器** — 被动切换布局，并支持 `Mod+1-4` 聚焦 pane、`Mod+\` 循环布局
-- **DockPanel** — 编辑器和 Diff 面板，可停靠 bottom / top / left / right，支持弹性缩放和键盘调节
-- **代理活动面板** — 状态、指标、可折叠区域，并跟随当前活动 pane 的 PTY
-- **上下文切换器** — 左侧栏提供 Sessions / Files；Editor / Diff 位于 dock 中
-- **状态栏** — 紧凑的工作空间状态行
-
-当前 UI handoff 进度见 [`docs/roadmap/progress.yaml`](docs/roadmap/progress.yaml)。第 1-5c2 步已完成（`#171`、`#173`、`#174`、`#190`、`#198`、`#199`、`#203`、`#204`），DockPanel 停靠 / 弹性缩放 / 共享焦点 / 快捷键 tooltip 后续工作也已落地（`#215`、`#218`、`#219`、`#224`）。剩余视觉工作包括布局切换自动扩容、活动面板打磨，以及 `Mod+\` / `Mod+B` 的快捷键发现入口（[#225](https://github.com/winoooops/vimeflow/issues/225)）。
-
-### 代理状态侧边栏（第 4 阶段）
-
-实时代理可观察性面板，自动检测终端会话中运行的 AI 编码代理。自 [#154](https://github.com/winoooops/vimeflow/pull/154) 起同时支持 **Claude Code** 与 **Codex**，共用一套前端：
-
-- **`AgentAdapter` trait** — `crates/backend/src/agent/adapter/` 定义统一接口（`status_source` / `parse_status` / `validate_transcript` / `tail_transcript`），每种代理各自实现；监听管道、前端事件与面板 UI 与具体代理无关
-- **Claude Code 适配器**（`adapter/claude_code/`）— 每会话 shell 脚本把 Claude 的 statusline JSON 写入被监听文件；适配器解析后通过旁路事件发送（`agent-detected`、`agent-status`、`agent-tool-call`、`agent-disconnected`）
-- **Codex 适配器**（`adapter/codex/`）— 基于 schema 探测的 SQLite 定位器扫描 `~/.codex/*.sqlite`（logs DB → thread_id，threads DB → rollout JSONL 路径），辅以 Linux `/proc` 快速路径与 FS 扫描回退；将 `event_msg.token_count` 折叠为与 Claude 一致的 `AgentStatusEvent` 形状
-- **Rust 后端编排** — `crates/backend/src/agent/` 提供代理检测器（进程树轮询）、`base::start_for` 监听驱动（notify 文件变更 + 轮询回退），以及各适配器的 transcript JSONL tailer（用于工具调用 / 轮次 / 测试运行信号）
-- **前端面板** — `src/features/agent-status/` 包含订阅旁路事件总线的 `useAgentStatus` hook，以及组件：StatusCard（身份 + 模型徽章）、BudgetMetrics（自适应 ApiKey / Subscriber / Fallback 布局 — Codex 会话渲染 Subscriber 显示速率限额条；Claude API-key 会话渲染 Cost 单元）、ContextBucket（填充仪表 + 进度条；Codex 由 `last_token_usage` 驱动，Claude 由 `total_input_tokens` 驱动）、ToolCallSummary（聚合芯片）、RecentToolCalls、FilesChanged、TestResults 和 ActivityFooter
-- **自动折叠** — 未检测到代理时面板为 0px，检测到时动画展开到 280px，断开后保留最终状态 5 秒
-- **ts-rs 类型代码生成** — Rust 类型自动导出到 `src/bindings/`，前端可类型安全消费（`CostMetrics.totalCostUsd: number | null` 用以区分 Codex 不暴露 cost 的语义与 Claude 上报的实际花费）
-
-设计规格：[`2026-04-12-agent-status-sidebar/`](docs/superpowers/specs/2026-04-12-agent-status-sidebar/CLAUDE.md)（面板）· [`2026-05-02-claude-adapter-refactor-design.md`](docs/superpowers/specs/2026-05-02-claude-adapter-refactor-design.md)（trait 抽象，Stage 1）· [`2026-05-03-codex-adapter-stage-2-design.md`](docs/superpowers/specs/2026-05-03-codex-adapter-stage-2-design.md)（Codex 适配器，Stage 2）· [`2026-05-04-codex-adapter-stage-2-scope-expansion.md`](docs/decisions/2026-05-04-codex-adapter-stage-2-scope-expansion.md)（已记录的偏离）
-
-<p align="center">
-  <img src="docs/media/agent-status-sidebar.png" alt="代理状态侧边栏 — 上下文计量器、Token 缓存、活动事件流、变更文件、测试面板" width="280" />
-</p>
-
-<p align="center"><sub>右侧面板特写 — 上下文计量器、Token 缓存、活动事件流、变更文件和测试面板。可由 Claude Code 或 Codex 会话经共享 <code>AgentAdapter</code> trait 驱动。</sub></p>
-
-### 功能模块
-
-| 模块                | 描述                                                                                    |
-| ------------------- | --------------------------------------------------------------------------------------- |
-| **terminal**        | xterm.js + 旁路 PTY IPC 桥接，会话管理                                                  |
-| **editor**          | IDE 风格标签编辑器 — CodeMirror 6、Vim 模式、语言扩展、Vim 状态栏                       |
-| **diff**            | Lazygit 风格 Git Diff 查看器（并排 + 统一视图，hunk 导航，暂存/丢弃）                   |
-| **files**           | 文件浏览树，面包屑导航，Git 状态徽章（M/A/D/U），拖放支持                               |
-| **command-palette** | Vim 风格 `:` 命令面板（全局快捷键、模糊匹配、命名空间下钻）— 内置命令注册表陆续交付中   |
-| **agent-status**    | 实时代理可观察性面板 — 通过 `AgentAdapter` trait 同时支持 Claude Code 与 Codex          |
-| **workspace**       | 组合图标栏、侧边栏、会话标签、SplitView 终端画布、DockPanel、状态栏和活动面板的布局外壳 |
-
-![编辑器与 Vim 模式 — 输入 `:w`，状态栏显示 -- NORMAL --](docs/media/editor-vim.png)
-
-![Diff 查看器 — 变更文件列表和带绿色新增行的差异块](docs/media/git-diff.png)
-
-### 质量保障
-
-- Vitest + Testing Library 覆盖前端/领域模块，Rust 测试覆盖后端模块
-- 无障碍优先的测试查询（`getByRole` 优于 `getByText`）
-- Pre-commit 钩子：对暂存文件运行 ESLint + Prettier
-- Commit-msg 钩子：commitlint 约定式提交
-- Pre-push 钩子：完整 Vitest 运行
-
-## 更新日志
-
-参见 [`CHANGELOG.zh-CN.md`](./CHANGELOG.zh-CN.md)（中文）或 [`CHANGELOG.md`](./CHANGELOG.md)（English）— 记录所有重要变更的线性时间线。每条记录可交叉链接 [`docs/reviews/`](./docs/reviews/CLAUDE.md) 中该变更应用、更新或新增的复盘模式 — CHANGELOG 记录"何时"，`docs/reviews/` 记录"为何"。
-
-## 技术栈
-
-| 层级       | 技术                                                   |
-| ---------- | ------------------------------------------------------ |
-| **桌面**   | Electron 42、Rust 旁路、portable-pty、tokio            |
-| **前端**   | React 19、TypeScript 5（严格模式）、Vite               |
-| **样式**   | Tailwind CSS v4、Catppuccin Mocha 语义化 Token         |
-| **终端**   | xterm.js 6、WebGL addon、FitAddon                      |
-| **编辑器** | CodeMirror 6、@replit/codemirror-vim（Vim 模式）       |
-| **动画**   | Framer Motion 12                                       |
-| **测试**   | Vitest 3、Testing Library                              |
-| **质量**   | ESLint 9（flat config）、Prettier 3、Husky、commitlint |
-| **Git**    | simple-git 3、diff2html 3                              |
-
-## 设计系统："黑曜石之眼"
-
-基于 Catppuccin Mocha 调色板的暗色氛围 UI — 将 UI 视为深邃虚空中的发光半透明层。
-
-- **无可见边框** — 使用色调深度和表面层级（8 级）
-- **玻璃态射** 用于浮动元素（60-80% 透明度，12-20px 模糊）
-- **字体**：Manrope（标题）、Inter（正文/标签）、JetBrains Mono（代码）
-- **语义化 Token**：`bg-surface-container`、`text-on-surface`、`text-primary` 等
-
-完整规格：[`docs/design/DESIGN.md`](docs/design/DESIGN.md)
-
-## 快速开始
+- Node.js >= 22；推荐使用 `.nvmrc` 中的 Node 24 以对齐 CI
+- Rust stable 工具链
+- Git
+- Linux（用于当前受支持的 AppImage 打包路径）
 
 ```bash
-# 前置条件：Node >= 22（推荐通过 .nvmrc 使用 Node 24 以对齐 CI），Rust 工具链
-nvm use                          # 使用 .nvmrc
+git clone https://github.com/winoooops/vimeflow.git
+cd vimeflow
+nvm use
+npm ci
+```
 
-# 仅前端（无 Rust 后端）
-npm install
-npm run dev                      # Vite 开发服务器，localhost:5173
+从源码运行桌面应用：
 
-# 完整桌面应用（需要 Rust）
-npm run electron:dev             # Electron + Rust 旁路（vimeflow-backend）
+```bash
+npm run electron:dev
+```
 
-# Linux 开发主机没有可用 Chromium sandbox 时
+如果 Linux 主机没有可用的 Chromium sandbox：
+
+```bash
 VIMEFLOW_NO_SANDBOX=1 npm run electron:dev
-
-# 打包 Linux AppImage
-npm run electron:build           # 生成 release/vimeflow-<version>-x64.AppImage
-
-# 测试
-npm test                         # Vitest 测试套件
-npx vitest run src/path/file.test.tsx  # 单文件测试
-
-# 质量检查
-npm run lint                     # ESLint（类型检查）
-npm run format:check             # Prettier 检查
-npm run type-check               # tsc -b
 ```
 
-### Lifeline 插件安装
-
-自主开发工作流由专用的 [Lifeline Claude Code 插件](https://github.com/winoooops/lifeline)提供。Lifeline 是完整独立的工作流插件，提供 `/lifeline:planner`、`/lifeline:loop`、`/lifeline:review`、`/lifeline:request-pr`、`/lifeline:upsource-review` 和 `/lifeline:approve-pr`。
+构建受支持的 `0.1.0` AppImage：
 
 ```bash
-# 1. 注册 Lifeline marketplace（一次性）
-/plugin marketplace add winoooops/lifeline
-
-# 2. 安装插件
-/plugin install lifeline@lifeline
-
-# 3. 重载激活
-/reload-plugins
+npm run electron:build
+chmod +x release/vimeflow-0.1.0-x64.AppImage
+./release/vimeflow-0.1.0-x64.AppImage --no-sandbox
 ```
 
-安装后，Lifeline 会缓存在 Claude Code 的插件缓存中，并跨会话保留。项目本地说明见 [`CLAUDE.md`](CLAUDE.md#lifeline-plugin-setup)。
+如果主机缺少 `libfuse2`，使用 AppImage 回退方式：
 
-> 由于[已知的 Claude Code 问题](https://github.com/anthropics/claude-code/issues/18949)，插件技能不会出现在 `/` 自动补全中。可选的自动补全变通方法见 [`CLAUDE.md`](CLAUDE.md#lifeline-plugin-setup)。
-
-## 仓库结构
-
-```
-CLAUDE.md                   # AI 导航中心（代理从这里开始）
-ARCHITECT.md                # 架构决策、Electron 旁路 IPC 模式
-docs/design/DESIGN.md       # UI 设计系统（唯一真实来源）
-
-src/
-├── features/
-│   ├── workspace/          # 工作空间外壳、会话标签/侧边栏、DockPanel
-│   ├── terminal/           # xterm.js + DesktopTerminalService IPC 桥接
-│   ├── editor/             # CodeMirror 标签式代码编辑器
-│   ├── diff/               # Lazygit 风格 Diff 查看器
-│   ├── files/              # 文件浏览树
-│   ├── command-palette/    # Vim 风格命令面板
-│   └── agent-status/       # 实时代理可观察性面板
-├── components/             # 共享基础组件（Tooltip）
-├── hooks/                  # 共享 React hooks
-├── agents/                 # Agent 元数据 registry
-├── bindings/               # Rust -> TypeScript 生成类型
-└── test/                   # Vitest 配置
-
-Cargo.toml                  # Workspace 根 manifest（members = ["crates/backend"]）
-Cargo.lock                  # Workspace lockfile（仓库根目录跟踪）
-target/                     # Cargo workspace 构建目录（gitignored）
-.cargo/config.toml          # Cargo 环境：TS_RS_EXPORT_DIR = src/bindings/
-crates/                     # Rust workspace 成员
-└── backend/                # 从 src-tauri/ 重命名
-    ├── src/
-    │   ├── bin/
-    │   │   └── vimeflow-backend.rs  # 旁路二进制入口 — stdin/stdout LSP 帧 JSON IPC
-    │   ├── lib.rs                   # 仅模块声明（PR-D3 后折叠）
-    │   ├── runtime/                 # BackendState、IPC router、EventSink trait
-    │   ├── terminal/                # PTY 命令（_inner helper + BackendState 方法）
-    │   ├── filesystem/              # 列表/读/写命令，含 scope 验证
-    │   ├── git/                     # Git 状态、Diff、暂存/取消暂存
-    │   └── agent/                   # 代理检测器、statusline 监听器、transcript 解析器
-    ├── Cargo.toml                   # Crate manifest
-    └── README.md                    # Crate 级说明
-
-agents/                     # 10 个专业 AI 代理定义
-rules/                      # 分层开发标准（通用 + TS + Rust）
+```bash
+./release/vimeflow-0.1.0-x64.AppImage --appimage-extract-and-run --no-sandbox
 ```
 
-## AI 原生开发流程
+## 使用 Vimeflow
 
-传统项目由人类编写代码，AI 辅助。Vimeflow 反转了这一模式：
+1. 使用 `npm run electron:dev` 或本地构建的 AppImage 启动 Vimeflow。
+2. 打开终端 pane，并运行 `claude` 或 `codex`。
+3. 在工作空间中拆分 pane、浏览文件、编辑代码并审查 Git Diff。
+4. 检测到受支持代理后，代理状态面板会自动显示。
 
-1. **人类编写规格说明** — 产品需求、设计系统、开发规则
-2. **Lifeline 构建功能** — 专用插件将规格分解为功能列表并逐步实现
-3. **专业代理审查工作** — 10 个 AI 代理分别负责规划、TDD、代码审查、安全和文档
-4. **规则管控一切** — 分层规则系统（通用层 + 语言特定层）确保一致性，无需人工逐次提交干预
+终端工作目录同步依赖 OSC 7。`zsh` 和 `fish` 通常会自动发送；`bash` 可运行：
 
-Lifeline 是 Vimeflow AI 原生开发循环的专用工作流插件。Vimeflow 本地使用说明见 [`CLAUDE.md`](CLAUDE.md#lifeline-plugin-setup)，插件运行手册见 <https://github.com/winoooops/lifeline>。
+```bash
+./scripts/setup-shell-osc7.sh
+```
 
-## 路线图
+## Lifeline 与 Harness Engineering
 
-| 阶段       | 状态   | 描述                                                      |
-| ---------- | ------ | --------------------------------------------------------- |
-| 第 1 阶段  | 已完成 | 历史 Tauri 脚手架；已被 Electron sidecar runtime 取代     |
-| 第 2 阶段  | 已完成 | 工作空间布局外壳                                          |
-| 第 3 阶段  | 已完成 | 终端核心（xterm.js + Electron sidecar PTY IPC）           |
-| 第 4 阶段  | 已完成 | 代理状态侧边栏（Claude Code / Codex 检测、telemetry、UI） |
-| UI Handoff | 进行中 | 多 pane 终端画布和 DockPanel 已落地；剩余视觉打磨继续推进 |
-| 第 5 阶段  | 计划中 | 持久化会话状态                                            |
-| 第 6+ 阶段 | 计划中 | 剩余上下文、使用量和桌面打磨                              |
+这个仓库也是一个实践型 harness engineering 项目。Vimeflow 的开发流程使用 [Lifeline Claude Code 扩展](https://github.com/winoooops/lifeline) 来做规划、自主实现循环、代码审查、PR 请求、上游 review 处理和 PR 批准。
 
-进度跟踪：[`docs/roadmap/progress.yaml`](docs/roadmap/progress.yaml)
+项目本地安装说明见 [CLAUDE.md](./CLAUDE.md#lifeline-plugin-setup)。
+
+## 验证源码检出
+
+```bash
+npm run lint
+npm run format:check
+npm run type-check
+npm test
+cargo test --manifest-path crates/backend/Cargo.toml
+```
+
+Rust 类型变更后重新生成 TypeScript 绑定：
+
+```bash
+npm run generate:bindings
+```
+
+## 项目参考
+
+- 安装与环境细节：[SETUP.md](./SETUP.md)
+- 开发命令与代码风格：[DEVELOPMENT.md](./DEVELOPMENT.md)
+- 架构与 Electron 旁路 IPC：[ARCHITECT.md](./ARCHITECT.md)
+- 设计系统：[DESIGN.md](./DESIGN.md) 和 [docs/design/UNIFIED.md](./docs/design/UNIFIED.md)
+- 当前路线图状态：[docs/roadmap/progress.yaml](./docs/roadmap/progress.yaml)
+- 更新日志：[CHANGELOG.zh-CN.md](./CHANGELOG.zh-CN.md) / [CHANGELOG.md](./CHANGELOG.md)
+- 后端 crate 说明：[crates/backend/README.md](./crates/backend/README.md)
 
 ## 许可证
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,14 +56,14 @@ VIMEFLOW_NO_SANDBOX=1 npm run electron:dev
 
 ```bash
 npm run electron:build
-chmod +x release/vimeflow-0.1.0-x64.AppImage
-./release/vimeflow-0.1.0-x64.AppImage --no-sandbox
+chmod +x release/vimeflow-*.AppImage
+./release/vimeflow-*.AppImage --no-sandbox
 ```
 
 如果主机缺少 `libfuse2`，使用 AppImage 回退方式：
 
 ```bash
-./release/vimeflow-0.1.0-x64.AppImage --appimage-extract-and-run --no-sandbox
+./release/vimeflow-*.AppImage --appimage-extract-and-run --no-sandbox
 ```
 
 ## 使用 Vimeflow


### PR DESCRIPTION
## Summary

- Shorten the English and Chinese READMEs into focused source-build guides for the current 0.1.0 line.
- Make the current support boundary explicit: source-built 0.1.0, Linux AppImage only, no hosted binaries or macOS/Windows packaging yet.
- Keep deeper implementation details behind references instead of duplicating long architecture and roadmap sections.
- Refresh both changelogs to describe the current source-supported state, Electron sidecar runtime, recent workspace/agent polish, and the README/Lifeline documentation updates.
- Add the Lifeline Claude Code extension and harness-engineering project framing in both READMEs.

## Why

The root README had grown into a detailed project history and implementation overview. For 0.1.0 users, the higher-signal path is a shorter document that explains what is currently supported, how to build and run it from source, and where to find deeper project references.

## Impact

This is documentation-only. It does not change runtime behavior, package metadata, or build scripts.

## Validation

- `npx prettier --check README.md README.zh-CN.md CHANGELOG.md CHANGELOG.zh-CN.md`
- Local markdown link and anchor check across the edited docs
- Verified linked local docs/assets are non-empty
- Verified external GitHub URLs for `winoooops/lifeline` and `winoooops/vimeflow`
- `git diff --check`