### PR TITLE
fix(build): use terser minifier to avoid xterm requestMode crash

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -101,6 +101,8 @@ words:
   - pty
   - termios
   - statusline
+  - nvim
+  - DECRQM
 
 ignorePaths:
   - node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "postcss": "^8",
         "prettier": "^3",
         "simple-git": "^3.33.0",
+        "terser": "^5.48.0",
         "tsx": "^4.21.0",
         "typescript": "^5",
         "typescript-eslint": "^8",
@@ -3447,6 +3448,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -19564,6 +19576,32 @@
         "async-exit-hook": "^2.0.1",
         "fs-extra": "^10.0.0"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "postcss": "^8",
     "prettier": "^3",
     "simple-git": "^3.33.0",
+    "terser": "^5.48.0",
     "tsx": "^4.21.0",
     "typescript": "^5",
     "typescript-eslint": "^8",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -674,6 +674,13 @@ export default defineConfig(({ mode }) => ({
   define: {
     __APP_VERSION__: JSON.stringify(packageJson.version),
   },
+  build: {
+    // esbuild's minifier mangles @xterm/xterm 6.0.0's const-enum IIFE in
+    // requestMode (drops `let r`, rewrites `r ||= {}` as assignment to
+    // an undeclared `i`), throwing ReferenceError when a TUI sends DECRQM
+    // queries (nvim, less, htop). Terser preserves the pattern correctly.
+    minify: 'terser',
+  },
   server: {
     port: 5173,
     strictPort: true,


### PR DESCRIPTION
## Summary

- esbuild (Vite's default minifier) mangles `@xterm/xterm` 6.0.0's const-enum IIFE in `InputHandler.requestMode`, dropping the surrounding `let r` and rewriting `r ||= {}` as an assignment to an undeclared `i` — `ReferenceError: i is not defined` the moment anything sends a DECRQM query (`CSI ? Pm $ p`).
- `nvim`, `less`, `htop`, and other TUIs probe the terminal with DECRQM during startup (synchronized output 2026, mouse, focus reporting), so the in-app terminal freezes the moment a full-screen TUI launches. Shell prompts and `ls` / `cat` never hit `requestMode`, which is why every other command kept working. Dev mode doesn't minify, so the bug only surfaces in the production bundle.
- Switch Vite to `minify: 'terser'`. The rebuilt bundle has `let i; var r;` both declared and the const-enum IIFE intact. Trades a few seconds of build time for a correct bundle. Added `nvim` and `DECRQM` to the cspell dictionary so the explanatory comment in `vite.config.ts` lints clean.

## Test plan

- [ ] `npm run build` succeeds with terser.
- [ ] In the built binary, open the terminal and run `nvim` — splash screen renders, `:q!` exits cleanly back to the shell.
- [ ] In DevTools console, no `ReferenceError: i is not defined` when nvim launches.
- [ ] `htop` / `less` (other DECRQM users) render fully.
- [ ] Plain shell commands (`ls`, `pwd`, `cat`) still work — terser change should be invisible to non-TUI output.