### PR TITLE
[codex] add codex coauthor trailer guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ crates/backend/
 
 Quick reference: no semicolons, single quotes, trailing commas (es5), arrow-function components only, explicit return types on exports, no `console.log`, `test()` not `it()`, CSpell spell-checking, ESM-only.
 
+Commit messages for Codex-assisted changes must include the trailer `Co-Authored-By: codex <codex@openai.com>` exactly once at the end. See `rules/common/git-workflow.md` for the full commit format.
+
 **For complete standards**, read these files in `rules/`:
 
 - `rules/common/coding-style.md` — immutability, file organization, error handling, input validation

--- a/rules/common/git-workflow.md
+++ b/rules/common/git-workflow.md
@@ -6,11 +6,15 @@
 <type>: <description>
 
 <optional body>
+
+Co-Authored-By: codex <codex@openai.com>
 ```
 
 Types: feat, fix, refactor, docs, test, chore, perf, ci
 
-Note: Attribution disabled globally via ~/.claude/settings.json.
+For any commit that Codex participated in, include the `Co-Authored-By: codex <codex@openai.com>` trailer exactly once at the end of the commit message so GitHub attributes Codex as a contributor.
+
+Note: Claude attribution disabled globally via ~/.claude/settings.json.
 
 ## Merge Strategy: Squash and Merge Only
 

--- a/rules/common/git-workflow.md
+++ b/rules/common/git-workflow.md
@@ -2,6 +2,18 @@
 
 ## Commit Message Format
 
+Types: feat, fix, refactor, docs, test, chore, perf, ci
+
+Standard commits:
+
+```
+<type>: <description>
+
+<optional body>
+```
+
+Codex-assisted commits:
+
 ```
 <type>: <description>
 
@@ -10,9 +22,10 @@
 Co-Authored-By: codex <codex@openai.com>
 ```
 
-Types: feat, fix, refactor, docs, test, chore, perf, ci
-
-For any commit that Codex participated in, include the `Co-Authored-By: codex <codex@openai.com>` trailer exactly once at the end of the commit message so GitHub attributes Codex as a contributor.
+For any commit that Codex participated in, include the
+`Co-Authored-By: codex <codex@openai.com>` trailer exactly once at the end of
+the commit message so GitHub attributes Codex as a contributor. Do not add the
+Codex trailer to commits where Codex did not participate.
 
 Note: Claude attribution disabled globally via ~/.claude/settings.json.
 


### PR DESCRIPTION
## Summary

Document the required Codex co-author trailer for Codex-assisted commits.

This updates the canonical git workflow commit-message template and adds a short reminder to `AGENTS.md`, so future Codex sessions see the requirement before committing.

## Validation

- `npx prettier --check AGENTS.md rules/common/git-workflow.md`
- `npm test` via pre-push hook

## Notes

Unrelated untracked local directories were not staged or pushed:

- `.claude/worktrees/`
- `docs/design/git-chip/`