### PR TITLE
refactor(agent-adapter): step 0b — SessionRuntimeContext

### DIFF
--- a/crates/backend/src/agent/adapter/attach.rs
+++ b/crates/backend/src/agent/adapter/attach.rs
@@ -1,21 +1,31 @@
-//! Attach-time context for the agent adapter.
+//! Attach-time and runtime context for the agent adapter.
 //!
-//! `AttachContext` carries the immutable facts known at the moment an agent
-//! adapter is attached to a PTY session. It is constructed once in
-//! `start_agent_watcher_inner` and will be threaded through the
-//! adapter-binding / locator / decoder / streamer chain by later steps of
-//! the refactor.
+//! Two related types live here so the SNAPSHOT-vs-LIVE distinction is
+//! visible at a glance:
+//!
+//! - [`AttachContext`] — the immutable facts known at the moment an agent
+//!   adapter is attached to a PTY session. Built once in
+//!   `start_agent_watcher_inner`; threaded through the adapter-binding /
+//!   locator / decoder / streamer chain by later refactor steps.
+//! - [`SessionRuntimeContext`] — a live handle to `PtyState` scoped to one
+//!   session, exposing accessors (currently just `live_cwd()`) that
+//!   re-query `PtyState` on every call. Used by callers that need the
+//!   CURRENT workspace cwd (which can change mid-session via the user's
+//!   shell `cd`), not the attach-time snapshot.
 //!
 //! Tracking: [#246](https://github.com/winoooops/vimeflow/issues/246)
-//! (Step 0a of the `refactor/agent-adapter` v4-frozen plan).
+//! (Steps 0a + 0b of the `refactor/agent-adapter` v4-frozen plan).
 //!
-//! **Constraint (v4-frozen #5):** `initial_cwd` is a SNAPSHOT taken at
-//! attach time. Runtime callers that need the live workspace cwd
-//! (transcript replace, test-runner cwd resolution) MUST read it from
-//! `PtyState` via the future `SessionRuntimeContext` (Step 0b), NOT from
-//! `AttachContext`.
+//! **Constraint (v4-frozen #5):** `AttachContext.initial_cwd` is a
+//! SNAPSHOT taken at attach time. Runtime callers that need the live
+//! workspace cwd (transcript replace, test-runner cwd resolution) MUST
+//! read it from `PtyState` via [`SessionRuntimeContext`], NOT from
+//! `AttachContext`. Future refactor steps (B''/D') will migrate the
+//! call site at `base/watcher_runtime.rs::maybe_start_transcript` from
+//! `&PtyState` + `session_id` to a `&SessionRuntimeContext` so the
+//! invariant is structural rather than convention-only.
 //!
-//! **Provider-neutral schema:** the struct intentionally has no
+//! **Provider-neutral schema:** [`AttachContext`] intentionally has no
 //! per-agent field names (no `codex_home`, no `claude_home`). All
 //! per-agent metadata lives in [`crate::agent::config`], the central
 //! registry; `provider_home` is resolved at attach time via
@@ -26,6 +36,7 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 use crate::agent::types::AgentType;
+use crate::terminal::PtyState;
 
 /// Immutable attach-time facts. Built once per agent attach by
 /// `start_agent_watcher_inner` and consumed by adapter-binding code.
@@ -63,6 +74,65 @@ pub(crate) struct AttachContext {
     /// through to the FS-scan strategy when `None`. Populated via
     /// [`crate::agent::config::default_proc_root`].
     pub(crate) proc_root: Option<PathBuf>,
+}
+
+/// Live runtime handle for one PTY session.
+///
+/// Pairs a session id with a `PtyState` handle so callers can read the
+/// CURRENT workspace cwd on demand. Distinct from [`AttachContext`],
+/// whose `initial_cwd` is frozen at attach time.
+///
+/// Cheap to clone — `PtyState` internally wraps `Arc<Mutex<...>>`, so
+/// cloning this struct only bumps refcounts.
+///
+/// The `PtyState` handle is intentionally private: future refactor
+/// callers (transcript replace, test-runner snapshot building) receive
+/// `&SessionRuntimeContext` instead of `&PtyState` + `session_id`, and
+/// the only cwd path they can take is [`Self::live_cwd`]. That keeps
+/// v4-frozen constraint #5 — "live cwd comes from `PtyState` via
+/// `SessionRuntimeContext`, never from `AttachContext`" — structural.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub(crate) struct SessionRuntimeContext {
+    /// Vimeflow PTY session id this runtime context is scoped to.
+    session_id: String,
+    /// Live PTY-state handle. Queried each call to [`Self::live_cwd`]
+    /// so a mid-session `cd` in the user's shell is observed
+    /// immediately.
+    pty_state: PtyState,
+}
+
+#[allow(dead_code)]
+impl SessionRuntimeContext {
+    /// Build a runtime context for `session_id` against the live
+    /// `PtyState`.
+    pub(crate) fn new(session_id: String, pty_state: PtyState) -> Self {
+        Self {
+            session_id,
+            pty_state,
+        }
+    }
+
+    /// The session id this context is scoped to. Provided so callers
+    /// that already need the id (logging, event composition) don't need
+    /// to thread it separately alongside the context.
+    pub(crate) fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Read the LIVE cwd for this session, re-querying `PtyState` on
+    /// every call. Returns `None` when the PTY session is gone (killed,
+    /// expired, or never existed).
+    ///
+    /// Mirrors the type returned by the current call site at
+    /// `base/watcher_runtime.rs::maybe_start_transcript`
+    /// (`Option<PathBuf>`), so that a future step can swap the
+    /// `pty_state.get_cwd(...).map(PathBuf::from)` expression for
+    /// `runtime.live_cwd()` without touching the caller's downstream
+    /// `TranscriptState::start_or_replace(... cwd ...)` signature.
+    pub(crate) fn live_cwd(&self) -> Option<PathBuf> {
+        self.pty_state.get_cwd(&self.session_id).map(PathBuf::from)
+    }
 }
 
 #[cfg(test)]
@@ -145,5 +215,41 @@ mod tests {
         let first = attach.agent_type;
         let second = attach.agent_type;
         assert_eq!(first, second);
+    }
+
+    /// `SessionRuntimeContext::session_id` round-trips through the
+    /// constructor. Data-shape only; the live-cwd semantic test lives in
+    /// `adapter::mod::noop_tests` where `make_test_session` builds a
+    /// real PTY-backed `ManagedSession`.
+    #[test]
+    fn session_runtime_context_remembers_session_id() {
+        let runtime =
+            SessionRuntimeContext::new("sid-runtime".to_string(), PtyState::new());
+        assert_eq!(runtime.session_id(), "sid-runtime");
+    }
+
+    /// On an empty `PtyState`, `live_cwd` returns `None` rather than
+    /// panicking or constructing an empty `PathBuf`. Pins the
+    /// "session-gone" branch — exercised in production when the PTY is
+    /// killed between the transcript-tail thread queuing a path
+    /// re-check and `PtyState` actually being read.
+    #[test]
+    fn session_runtime_context_live_cwd_is_none_for_missing_session() {
+        let runtime =
+            SessionRuntimeContext::new("sid-missing".to_string(), PtyState::new());
+        assert_eq!(runtime.live_cwd(), None);
+    }
+
+    /// Clone propagates the same view: cloned context sees the same
+    /// underlying `PtyState`, so a future insert into either handle is
+    /// visible from both. Cheap because `PtyState` is `Arc`-backed.
+    #[test]
+    fn session_runtime_context_is_clone() {
+        let original =
+            SessionRuntimeContext::new("sid-clone".to_string(), PtyState::new());
+        let cloned = original.clone();
+        assert_eq!(cloned.session_id(), original.session_id());
+        // Both views must agree on the absent-session result.
+        assert_eq!(cloned.live_cwd(), original.live_cwd());
     }
 }

--- a/crates/backend/src/agent/adapter/attach.rs
+++ b/crates/backend/src/agent/adapter/attach.rs
@@ -218,13 +218,13 @@ mod tests {
     }
 
     /// `SessionRuntimeContext::session_id` round-trips through the
-    /// constructor. Data-shape only; the live-cwd semantic test lives in
+    /// constructor. Data-shape only; the live-cwd semantic test (plus
+    /// the cross-clone shared-state assertion) lives in
     /// `adapter::mod::noop_tests` where `make_test_session` builds a
     /// real PTY-backed `ManagedSession`.
     #[test]
     fn session_runtime_context_remembers_session_id() {
-        let runtime =
-            SessionRuntimeContext::new("sid-runtime".to_string(), PtyState::new());
+        let runtime = SessionRuntimeContext::new("sid-runtime".to_string(), PtyState::new());
         assert_eq!(runtime.session_id(), "sid-runtime");
     }
 
@@ -235,21 +235,24 @@ mod tests {
     /// re-check and `PtyState` actually being read.
     #[test]
     fn session_runtime_context_live_cwd_is_none_for_missing_session() {
-        let runtime =
-            SessionRuntimeContext::new("sid-missing".to_string(), PtyState::new());
+        let runtime = SessionRuntimeContext::new("sid-missing".to_string(), PtyState::new());
         assert_eq!(runtime.live_cwd(), None);
     }
 
-    /// Clone propagates the same view: cloned context sees the same
-    /// underlying `PtyState`, so a future insert into either handle is
-    /// visible from both. Cheap because `PtyState` is `Arc`-backed.
+    /// `Clone` impl exists and produces an identically-shaped handle:
+    /// same session id, same `None` cwd on an empty `PtyState`. Two
+    /// independent empty states would pass these assertions too, so
+    /// this is a smoke test, NOT a proof that clones share the
+    /// underlying `Arc`-backed `PtyState`. The shared-state invariant
+    /// is asserted by
+    /// `session_runtime_context_clone_shares_pty_state` in
+    /// `adapter::mod::noop_tests`, where the PTY-backed test helper
+    /// `make_test_session` lives.
     #[test]
     fn session_runtime_context_is_clone() {
-        let original =
-            SessionRuntimeContext::new("sid-clone".to_string(), PtyState::new());
+        let original = SessionRuntimeContext::new("sid-clone".to_string(), PtyState::new());
         let cloned = original.clone();
         assert_eq!(cloned.session_id(), original.session_id());
-        // Both views must agree on the absent-session result.
         assert_eq!(cloned.live_cwd(), original.live_cwd());
     }
 }

--- a/crates/backend/src/agent/adapter/mod.rs
+++ b/crates/backend/src/agent/adapter/mod.rs
@@ -408,4 +408,46 @@ mod noop_tests {
         assert_eq!(runtime.live_cwd(), Some(PathBuf::from("/tmp/workspace")));
         assert_eq!(runtime.session_id(), "sid-runtime-live");
     }
+
+    /// Step 0b: cloning a `SessionRuntimeContext` MUST keep both
+    /// handles attached to the SAME `Arc`-backed `PtyState`. A
+    /// future contributor swapping the implicit `Clone` derive for
+    /// a manual impl that clones into independent state would break
+    /// the "live cwd through `SessionRuntimeContext`" guarantee and
+    /// this test would catch it.
+    ///
+    /// Proof strategy: insert a session via a `PtyState` handle that
+    /// is shared with the original runtime context, clone the
+    /// runtime, then assert the clone reports the same cwd. Inserting
+    /// AFTER the clone closes the loophole where two independent
+    /// empty `PtyState`s could pass the smoke test in
+    /// `attach::tests::session_runtime_context_is_clone`.
+    #[test]
+    fn session_runtime_context_clone_shares_pty_state() {
+        use super::attach::SessionRuntimeContext;
+
+        let state = PtyState::new();
+        let session_id = "sid-runtime-shared".to_string();
+        // `PtyState` is `Arc<Mutex<...>>`-backed; cloning before the
+        // runtime takes ownership of one clone keeps the other handle
+        // usable for the post-clone insert.
+        let runtime = SessionRuntimeContext::new(session_id.clone(), state.clone());
+        let cloned_runtime = runtime.clone();
+
+        // Both handles look empty before any insert — the live
+        // cross-clone visibility check is the one that follows.
+        assert_eq!(runtime.live_cwd(), None);
+        assert_eq!(cloned_runtime.live_cwd(), None);
+
+        state
+            .try_insert(session_id.clone(), make_test_session(), 64)
+            .unwrap_or_else(|_| panic!("insert session"));
+
+        let expected = Some(PathBuf::from("/tmp/workspace"));
+        assert_eq!(runtime.live_cwd(), expected);
+        // The decisive assertion: a `Clone` impl that broke the
+        // shared-`Arc` invariant would leave `cloned_runtime` reading
+        // its own empty `PtyState` and this would return `None`.
+        assert_eq!(cloned_runtime.live_cwd(), expected);
+    }
 }

--- a/crates/backend/src/agent/adapter/mod.rs
+++ b/crates/backend/src/agent/adapter/mod.rs
@@ -11,6 +11,10 @@ pub mod codex;
 pub mod types;
 
 pub(crate) use attach::AttachContext;
+// `SessionRuntimeContext` (also in `attach`) is not re-exported yet —
+// step 0b only defines the type; the first production caller lands in
+// step B'' when `TranscriptState::start_or_replace` rewires onto it.
+// Tests reach it directly as `attach::SessionRuntimeContext`.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -381,5 +385,27 @@ mod noop_tests {
         assert_eq!(attach.agent_type, AgentType::Aider);
         // Aider has no `home_subdir` in the registry → provider_home is None.
         assert_eq!(attach.provider_home, None);
+    }
+
+    /// Step 0b: `SessionRuntimeContext::live_cwd` returns the cwd the
+    /// session was inserted with, surfaced as the `PathBuf` that the
+    /// transcript-replace caller already consumes. Confirms the
+    /// "session present → Some(cwd)" branch end-to-end with a real
+    /// PTY-backed `ManagedSession` from `make_test_session`.
+    #[test]
+    fn session_runtime_context_live_cwd_reads_pty_state() {
+        use super::attach::SessionRuntimeContext;
+
+        let state = PtyState::new();
+        let session_id = "sid-runtime-live".to_string();
+        state
+            .try_insert(session_id.clone(), make_test_session(), 64)
+            .unwrap_or_else(|_| panic!("insert session"));
+
+        let runtime = SessionRuntimeContext::new(session_id.clone(), state);
+
+        // `make_test_session` inserts cwd = "/tmp/workspace".
+        assert_eq!(runtime.live_cwd(), Some(PathBuf::from("/tmp/workspace")));
+        assert_eq!(runtime.session_id(), "sid-runtime-live");
     }
 }


### PR DESCRIPTION
## Summary

**Step 0b** of the [v4-frozen refactor plan](https://github.com/winoooops/vimeflow/blob/refactor/agent-adapter/crates/backend/src/agent/adapter/REVIEW.md#final-plan-v4-frozen). Adds `SessionRuntimeContext` as the live counterpart to `AttachContext` — a per-session handle that carries a private `PtyState` reference and exposes a narrow `live_cwd() -> Option<PathBuf>` accessor that re-queries `PtyState` on every call so a mid-session `cd` in the user's shell is observed immediately.

Lives next to `AttachContext` in `crates/backend/src/agent/adapter/attach.rs` so the SNAPSHOT-vs-LIVE distinction is visible at a glance.

## Scope — define only

Per [#246's updated 0b acceptance section](https://github.com/winoooops/vimeflow/issues/246) (the "Scope: define only" blockquote that was added in tandem with this PR), Step 0b **does not rewire any production caller**. The transcript-replace call site at `crates/backend/src/agent/adapter/base/watcher_runtime.rs::maybe_start_transcript` and the test-runner cwd-resolution path reached through it migrate in Step B''/D' when `TranscriptState::start_or_replace` switches to the streamer-trait shape.

This matches:
- **Step 0a / PR #247** — same "seam prep" pattern (define the type, leave wiring to later steps).
- **v4-frozen plan body** — the 0.25d estimate explicitly fits define-only.

`SessionRuntimeContext` is `pub(crate)` inside the `attach` module, struct-level `#[allow(dead_code)]`, and intentionally **not** re-exported from `adapter::mod` (no speculative API surface).

## v4-frozen constraint #5 protection

The `PtyState` field is private. Callers receive `&SessionRuntimeContext` and the only cwd path they can take is `live_cwd()`. Future B''/D' will make the constraint **structural** by stopping production callers from carrying raw `&PtyState + session_id` pairs — at which point this PR's private-field invariant is what stops a regression.

## Codex review log

Three rounds of `codex exec` against this branch, all logged under `.codex-reviews/`:

| Round | Findings | Outcome |
|-------|----------|---------|
| 1 | 1 MEDIUM + 2 LOW | MEDIUM was acceptance-wording ambiguity → resolved documentarily in #246 body + this PR. LOW #1 (clone test rigor): replaced misleading prose + added `session_runtime_context_clone_shares_pty_state` semantic test. LOW #2 (rustfmt): collapsed three `let` blocks in `attach::tests`. |
| 2 | 0 MEDIUM, 1 new LOW | Round-1 fixes all closed. New LOW was `src/bindings/*.ts` ts-rs regeneration noise in the worktree (NOT in any commit); restored via `git restore src/bindings/`. |
| 3 | **0 / 0 / 0 / 0 — "Ship it."** | Final clean pass. |

Codex verdict (round 3): _"the shape is exactly Step 0b define-only: SessionRuntimeContext, private PtyState, `live_cwd() -> Option<PathBuf>`, 5 tests, and no production caller rewire. Issue #246 wording is now unambiguous enough."_

## Diff at a glance

- `crates/backend/src/agent/adapter/attach.rs` — module docs widened to cover both `AttachContext` (snapshot) and `SessionRuntimeContext` (live); new struct + impl + 3 data-shape tests.
- `crates/backend/src/agent/adapter/mod.rs` — `+26 lines`: comment explaining why `SessionRuntimeContext` is not yet re-exported, plus 2 new `noop_tests` semantic tests (`live_cwd_reads_pty_state` + `clone_shares_pty_state`).

Two commits on the branch, expected to squash on merge:
1. `7936dce` — original step 0b commit.
2. `90ec905` — codex round 1 review fixes.

## Test plan

- [x] `cargo build -p vimeflow --lib` → clean
- [x] `cargo test -p vimeflow --lib agent::adapter` → 256 passed, 0 failed (251 prior + 5 new for step 0b)
- [x] `cargo test -p vimeflow --lib` → 534 passed, 0 failed (the `terminal::commands::tests::read_loop_eof_marks_cache_exited` flake observed in one run passed on rerun and is unrelated to this diff)
- [x] `cargo clippy -p vimeflow --lib --no-deps` → same 6 pre-existing warnings as step 0a's baseline; no new warnings
- [x] `cargo fmt --check` on my added lines — clean (pre-existing rustfmt drift at `attach.rs:165` and `claude_code/test_runners/build.rs` is intentionally left alone per `rules/common/pr-scope.md`)
- [x] 3 rounds of `codex exec` — final round clean (`.codex-reviews/round-3.output.md`)
- [ ] Reviewer: confirm `SessionRuntimeContext` API shape protects frozen-constraint #5
- [ ] Reviewer: confirm scope is genuinely "define only" and matches step 0a's discipline

## Merge target

Targets `refactor/agent-adapter` (the integration branch). One final PR from `refactor/agent-adapter` → `main` lands the full refactor as a single squash commit per the merge strategy in #246.

Part of #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)