### PR TITLE
fix(workspace): wire settings tooltip to issue #252

### DIFF
--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -82,10 +82,10 @@ const cacheHitPercentage = (
   return rate === null ? null : Math.round(rate * 100)
 }
 
-// Filed before merge — see the PR description for the issue body.
-// `0` is intentionally a loud placeholder; the gear tooltip
-// renders "see issue #0" so a missed pre-merge bump is obvious.
-const SETTINGS_FOLLOWUP_ISSUE_NUMBER = 0
+// Follow-up tracked at https://github.com/winoooops/vimeflow/issues/252
+// (Settings dialog — Zed-style modal with 14 categories). Remove
+// this const and the gear's `aria-disabled` once the dialog lands.
+const SETTINGS_FOLLOWUP_ISSUE_NUMBER = 252
 
 const SIDEBAR_MIN = 240
 const SIDEBAR_MAX = 560


### PR DESCRIPTION
## Summary

- Bumps `SETTINGS_FOLLOWUP_ISSUE_NUMBER` from the `0` placeholder to **#252**, the Settings-dialog follow-up filed against this PR.
- The gear tooltip now renders `Settings panel coming — see issue #252` instead of `... issue #0`.

## Context

PR #236 (rail trim) intentionally shipped `SETTINGS_FOLLOWUP_ISSUE_NUMBER = 0` as a loud placeholder so a missed pre-merge bump would surface in the gear tooltip. Two pre-merge checklist steps got skipped:

1. File the follow-up issue using the paste-ready body in `docs/superpowers/specs/2026-05-20-icon-rail-trim-design.md` §10.
2. Bump the constant to the filed issue's number.

This PR completes both — issue #252 has already been filed, this PR wires the constant.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npx eslint src/features/workspace/WorkspaceView.tsx` — clean
- [x] `npx vitest run src/features/workspace/components/IconRail.test.tsx src/features/workspace/WorkspaceView.command-palette.test.tsx` — 22/22 pass (incl. the issue-number interpolation case)
- [ ] `npm run electron:dev` — hover the gear, confirm tooltip reads `Settings panel coming — see issue #252`