### PR TITLE
refactor(agent-adapter): step 0c — LocatedStatusSource + TranscriptPathSource

### DIFF
--- a/crates/backend/src/agent/adapter/base/mod.rs
+++ b/crates/backend/src/agent/adapter/base/mod.rs
@@ -29,14 +29,17 @@ pub(crate) fn start_for(
     cwd: PathBuf,
     state: AgentWatcherState,
 ) -> Result<(), String> {
-    let source = adapter.status_source(&cwd, &session_id)?;
-    path_security::ensure_status_source_under_trust_root(&source.path, &source.trust_root)?;
+    let located = adapter.located_status_source(&cwd, &session_id)?;
+    path_security::ensure_status_source_under_trust_root(
+        &located.status_path,
+        &located.trust_root,
+    )?;
 
     log::debug!(
         "Watcher startup detail: session={}, cwd={}, path={}",
         session_id,
         cwd.display(),
-        source.path.display()
+        located.status_path.display()
     );
 
     // Stop any existing watcher for this session before counting active
@@ -47,7 +50,7 @@ pub(crate) fn start_for(
     log::info!(
         "Starting agent watcher: session={}, path={}, active_watchers={}",
         session_id,
-        source.path.display(),
+        located.status_path.display(),
         state.active_count(),
     );
 
@@ -57,7 +60,7 @@ pub(crate) fn start_for(
         pty_state,
         transcript_state,
         session_id.clone(),
-        source.path,
+        located,
     )?;
     state.insert(session_id, handle);
 

--- a/crates/backend/src/agent/adapter/base/transcript_state.rs
+++ b/crates/backend/src/agent/adapter/base/transcript_state.rs
@@ -433,17 +433,19 @@ mod tests {
             stop_flags: Arc<Mutex<Vec<Arc<AtomicBool>>>>,
         }
 
+        impl crate::agent::adapter::types::TranscriptPathSource for OrderingAdapter {}
+
         impl AgentAdapter for OrderingAdapter {
             fn agent_type(&self) -> crate::agent::types::AgentType {
                 crate::agent::types::AgentType::ClaudeCode
             }
 
-            fn status_source(
+            fn located_status_source(
                 &self,
                 _cwd: &std::path::Path,
                 _session_id: &str,
-            ) -> Result<crate::agent::adapter::types::StatusSource, String> {
-                unreachable!("status_source not exercised in this test")
+            ) -> Result<crate::agent::adapter::types::LocatedStatusSource, String> {
+                unreachable!("located_status_source not exercised in this test")
             }
 
             fn parse_status(
@@ -460,6 +462,12 @@ mod tests {
             ) -> Result<PathBuf, crate::agent::adapter::types::ValidateTranscriptError>
             {
                 unreachable!("validate_transcript not exercised in this test")
+            }
+
+            fn transcript_path_source(
+                &self,
+            ) -> &dyn crate::agent::adapter::types::TranscriptPathSource {
+                self
             }
 
             fn tail_transcript(

--- a/crates/backend/src/agent/adapter/base/watcher_runtime.rs
+++ b/crates/backend/src/agent/adapter/base/watcher_runtime.rs
@@ -16,11 +16,30 @@ use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use super::diagnostics::short_sid;
 use super::diagnostics::{record_event_diag, EventTiming, PathHistory, TxOutcome};
 use super::transcript_state::{TranscriptStartStatus, TranscriptState};
-use crate::agent::adapter::types::ValidateTranscriptError;
+use crate::agent::adapter::types::{LocatedStatusSource, RawPath, ValidateTranscriptError};
 use crate::agent::adapter::AgentAdapter;
 use crate::agent::events::emit_agent_status;
 use crate::runtime::EventSink;
 use crate::terminal::PtyState;
+
+/// Step 0c: resolve the transcript path by asking the adapter's
+/// `TranscriptPathSource` for a dynamic hint (Claude, fresh per
+/// update) first, then falling back to the static hint (Codex, fixed
+/// at attach time and stored on the [`LocatedStatusSource`]).
+///
+/// Replaces the former `parsed.transcript_path` side channel on
+/// [`crate::agent::adapter::types::ParsedStatus`]. The shape is the
+/// same `Option<RawPath>` the previous field carried; the difference
+/// is that `TranscriptPathSource` is the single typed origin point
+/// the watcher now consults.
+fn resolve_transcript_path(
+    adapter: &Arc<dyn AgentAdapter>,
+    raw: &str,
+    located: &LocatedStatusSource,
+) -> Option<RawPath> {
+    let tps = adapter.transcript_path_source();
+    tps.dynamic_hint(raw).or_else(|| tps.static_hint(located))
+}
 
 /// Handle to a running watcher — dropping it stops the watcher and polling thread
 pub struct WatcherHandle {
@@ -228,14 +247,25 @@ fn maybe_start_transcript(
 /// CWD is intentionally NOT captured here. `maybe_start_transcript` queries
 /// PtyState fresh on every invocation so a `cd` mid-session updates the
 /// workspace seen by the test-runner parser.
+///
+/// Step 0c: the parameter shape changed from a bare
+/// `status_file_path: PathBuf` to the full
+/// [`LocatedStatusSource`] so the per-update transcript-path lookup
+/// (which now goes through
+/// [`TranscriptPathSource`](crate::agent::adapter::types::TranscriptPathSource))
+/// can consult `static_transcript_hint` for Codex. The file watched
+/// is still `located.status_path`; the rest of the struct is cloned
+/// into each callback so they can resolve transcript paths via the
+/// new trait without re-reading from the adapter.
 pub(super) fn start_watching(
     adapter: Arc<dyn AgentAdapter>,
     events: Arc<dyn EventSink>,
     pty_state: PtyState,
     transcript_state: TranscriptState,
     session_id: String,
-    status_file_path: PathBuf,
+    located: LocatedStatusSource,
 ) -> Result<WatcherHandle, String> {
+    let status_file_path = located.status_path.clone();
     let target_path = status_file_path.clone();
     let sid = session_id.clone();
     let last_processed = Arc::new(Mutex::new(Instant::now()));
@@ -261,6 +291,11 @@ pub(super) fn start_watching(
     let events_for_cb = events.clone();
     let pty_state_for_cb = pty_state.clone();
     let transcript_state_for_cb = transcript_state.clone();
+    // Step 0c: each watcher callback (notify / inline-init / poll)
+    // needs the full `LocatedStatusSource` so it can ask the adapter's
+    // `TranscriptPathSource::static_hint` for Codex's attach-time
+    // rollout path. Cheap — it's two `PathBuf`s + `Option<String>`.
+    let located_for_cb = located.clone();
 
     // Debounce interval — ignore events within 100ms of the last processed one
     let debounce_ms = 100;
@@ -323,18 +358,22 @@ pub(super) fn start_watching(
                     log::error!("Failed to emit agent-status event: {}", e);
                 }
 
-                if let Some(ref path) = parsed.transcript_path {
-                    let outcome = maybe_start_transcript(
-                        &adapter_for_cb,
-                        events_for_cb.clone(),
-                        &pty_state_for_cb,
-                        &transcript_state_for_cb,
-                        &sid,
-                        path,
-                    );
-                    (outcome, Some(path.clone()))
-                } else {
-                    (TxOutcome::NoPath, None)
+                // Step 0c: resolve the transcript path via
+                // `TranscriptPathSource` instead of the removed
+                // `parsed.transcript_path` side channel.
+                match resolve_transcript_path(&adapter_for_cb, &contents, &located_for_cb) {
+                    Some(path) => {
+                        let outcome = maybe_start_transcript(
+                            &adapter_for_cb,
+                            events_for_cb.clone(),
+                            &pty_state_for_cb,
+                            &transcript_state_for_cb,
+                            &sid,
+                            &path,
+                        );
+                        (outcome, Some(path))
+                    }
+                    None => (TxOutcome::NoPath, None),
                 }
             }
             Err(e) => {
@@ -384,6 +423,7 @@ pub(super) fn start_watching(
         let initial_events = events.clone();
         let initial_pty_state = pty_state.clone();
         let initial_transcript_state = transcript_state.clone();
+        let initial_located = located.clone();
         let started = Instant::now();
         let mut outcome = TxOutcome::NoPath;
         let mut inline_tx_path: Option<String> = None;
@@ -393,16 +433,20 @@ pub(super) fn start_watching(
                 match initial_adapter.parse_status(&initial_sid, &contents) {
                     Ok(parsed) => {
                         let _ = emit_agent_status(initial_events.as_ref(), &parsed.event);
-                        if let Some(ref path) = parsed.transcript_path {
+                        // Step 0c: resolve via `TranscriptPathSource`
+                        // (was `parsed.transcript_path`).
+                        if let Some(path) =
+                            resolve_transcript_path(&initial_adapter, &contents, &initial_located)
+                        {
                             outcome = maybe_start_transcript(
                                 &initial_adapter,
                                 initial_events.clone(),
                                 &initial_pty_state,
                                 &initial_transcript_state,
                                 &initial_sid,
-                                path,
+                                &path,
                             );
-                            inline_tx_path = Some(path.clone());
+                            inline_tx_path = Some(path);
                         }
                     }
                     Err(e) => {
@@ -441,6 +485,10 @@ pub(super) fn start_watching(
         let poll_timing_for_thread = poll_timing.clone();
         let path_history_for_poll = path_history.clone();
         let adapter_for_poll = adapter.clone();
+        // Step 0c: poll thread also routes transcript-path lookups
+        // through `TranscriptPathSource` and so needs its own clone of
+        // the `LocatedStatusSource`.
+        let poll_located = located.clone();
         Some(std::thread::spawn(move || {
             // `poll_last` is the per-thread dedup buffer. Originally
             // wrapped in `Arc<Mutex<String>>` by analogy with the other
@@ -485,18 +533,21 @@ pub(super) fn start_watching(
                 let (outcome, tx_path) = match adapter_for_poll.parse_status(&poll_sid, &contents) {
                     Ok(parsed) => {
                         let _ = emit_agent_status(poll_events.as_ref(), &parsed.event);
-                        if let Some(ref path) = parsed.transcript_path {
-                            let outcome = maybe_start_transcript(
-                                &adapter_for_poll,
-                                poll_events.clone(),
-                                &poll_pty_state,
-                                &poll_transcript_state,
-                                &poll_sid,
-                                path,
-                            );
-                            (outcome, Some(path.clone()))
-                        } else {
-                            (TxOutcome::NoPath, None)
+                        // Step 0c: same `TranscriptPathSource` flow as
+                        // the notify and inline callbacks.
+                        match resolve_transcript_path(&adapter_for_poll, &contents, &poll_located) {
+                            Some(path) => {
+                                let outcome = maybe_start_transcript(
+                                    &adapter_for_poll,
+                                    poll_events.clone(),
+                                    &poll_pty_state,
+                                    &poll_transcript_state,
+                                    &poll_sid,
+                                    &path,
+                                );
+                                (outcome, Some(path))
+                            }
+                            None => (TxOutcome::NoPath, None),
                         }
                     }
                     Err(e) => {

--- a/crates/backend/src/agent/adapter/claude_code/mod.rs
+++ b/crates/backend/src/agent/adapter/claude_code/mod.rs
@@ -25,12 +25,14 @@ impl TranscriptPathSource for ClaudeCodeAdapter {
     // inside every statusline JSON update.
 
     fn dynamic_hint(&self, raw: &str) -> Option<RawPath> {
-        // Light JSON pass extracts only `transcript_path`; the full
-        // statusline parse still runs once per update via
-        // `parse_status` for the event side of the contract. The
-        // sibling parse here keeps `TranscriptPathSource` honest as a
-        // standalone trait — when B' moves it off `AgentAdapter`
-        // entirely, this code path stays unchanged.
+        // Re-parses the JSON to surface just `transcript_path`. The
+        // win vs. calling `parse_statusline` here is skipping the
+        // event construction, NOT skipping the JSON parse itself —
+        // see `statusline::extract_transcript_path` docs for the
+        // detail and the deferred-optimization escape hatch. Keeps
+        // `TranscriptPathSource` honest as a standalone trait — when
+        // B' moves it off `AgentAdapter` entirely, this code path
+        // stays unchanged.
         statusline::extract_transcript_path(raw)
     }
 }

--- a/crates/backend/src/agent/adapter/claude_code/mod.rs
+++ b/crates/backend/src/agent/adapter/claude_code/mod.rs
@@ -3,7 +3,9 @@
 use std::path::{Path, PathBuf};
 
 use crate::agent::adapter::base::TranscriptHandle;
-use crate::agent::adapter::types::{ParsedStatus, StatusSource, ValidateTranscriptError};
+use crate::agent::adapter::types::{
+    LocatedStatusSource, ParsedStatus, RawPath, TranscriptPathSource, ValidateTranscriptError,
+};
 use crate::agent::adapter::AgentAdapter;
 use crate::agent::types::AgentType;
 use crate::runtime::EventSink;
@@ -17,27 +19,49 @@ mod transcript_fixture_tests;
 
 pub struct ClaudeCodeAdapter;
 
+impl TranscriptPathSource for ClaudeCodeAdapter {
+    // `static_hint` defaults to `None` — Claude's locator has no
+    // attach-time transcript knowledge; the path arrives dynamically
+    // inside every statusline JSON update.
+
+    fn dynamic_hint(&self, raw: &str) -> Option<RawPath> {
+        // Light JSON pass extracts only `transcript_path`; the full
+        // statusline parse still runs once per update via
+        // `parse_status` for the event side of the contract. The
+        // sibling parse here keeps `TranscriptPathSource` honest as a
+        // standalone trait — when B' moves it off `AgentAdapter`
+        // entirely, this code path stays unchanged.
+        statusline::extract_transcript_path(raw)
+    }
+}
+
 impl AgentAdapter for ClaudeCodeAdapter {
     fn agent_type(&self) -> AgentType {
         AgentType::ClaudeCode
     }
 
-    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String> {
-        Ok(StatusSource {
-            path: cwd
+    fn located_status_source(
+        &self,
+        cwd: &Path,
+        session_id: &str,
+    ) -> Result<LocatedStatusSource, String> {
+        Ok(LocatedStatusSource {
+            status_path: cwd
                 .join(".vimeflow")
                 .join("sessions")
                 .join(session_id)
                 .join("status.json"),
             trust_root: cwd.to_path_buf(),
+            static_transcript_hint: None,
         })
     }
 
     fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String> {
         let parsed = statusline::parse_statusline(session_id, raw)?;
+        // Step 0c: `transcript_path` was removed from `ParsedStatus`;
+        // the watcher reaches it via `TranscriptPathSource::dynamic_hint`.
         Ok(ParsedStatus {
             event: parsed.event,
-            transcript_path: parsed.transcript_path,
         })
     }
 
@@ -53,6 +77,10 @@ impl AgentAdapter for ClaudeCodeAdapter {
         transcript_path: PathBuf,
     ) -> Result<TranscriptHandle, String> {
         transcript::start_tailing(events, session_id, transcript_path, cwd)
+    }
+
+    fn transcript_path_source(&self) -> &dyn TranscriptPathSource {
+        self
     }
 }
 
@@ -70,19 +98,23 @@ mod tests {
     }
 
     #[test]
-    fn status_source_returns_claude_path_under_cwd() {
+    fn located_status_source_returns_claude_path_under_cwd() {
         let adapter = ClaudeCodeAdapter;
         let cwd = PathBuf::from("/tmp/ws");
-        let src = <ClaudeCodeAdapter as AgentAdapter>::status_source(&adapter, &cwd, "sess-1")
-            .expect("claude status source is infallible");
+        let src =
+            <ClaudeCodeAdapter as AgentAdapter>::located_status_source(&adapter, &cwd, "sess-1")
+                .expect("claude status source is infallible");
         assert_eq!(
-            src.path,
+            src.status_path,
             cwd.join(".vimeflow")
                 .join("sessions")
                 .join("sess-1")
                 .join("status.json")
         );
         assert_eq!(src.trust_root, cwd);
+        // Claude always reports `None` for the static hint — Step 0c
+        // contract: the transcript path is purely dynamic for Claude.
+        assert_eq!(src.static_transcript_hint, None);
     }
 
     #[test]
@@ -91,6 +123,41 @@ mod tests {
         let parsed = <ClaudeCodeAdapter as AgentAdapter>::parse_status(&adapter, "sess-1", r#"{}"#)
             .expect("minimal json should parse");
         assert_eq!(parsed.event.session_id, "sess-1");
-        assert!(parsed.transcript_path.is_none());
+    }
+
+    /// Step 0c: with `transcript_path` removed from `ParsedStatus`, the
+    /// Claude adapter resolves it via `dynamic_hint` instead. Pin both
+    /// branches of the lookup so a regression to "extracts None even
+    /// when present" or "extracts something even when absent" is loud.
+    #[test]
+    fn dynamic_hint_extracts_transcript_path_when_present() {
+        let adapter = ClaudeCodeAdapter;
+        let tps = adapter.transcript_path_source();
+
+        let with_path = r#"{"transcript_path":"/tmp/conv.jsonl","model":{"id":"x"}}"#;
+        assert_eq!(
+            tps.dynamic_hint(with_path),
+            Some("/tmp/conv.jsonl".to_string()),
+        );
+
+        let without_path = r#"{"model":{"id":"x"}}"#;
+        assert_eq!(tps.dynamic_hint(without_path), None);
+    }
+
+    /// Claude's `static_hint` must stay `None` no matter what the
+    /// supplied `LocatedStatusSource.static_transcript_hint` says —
+    /// Step 0c contract: Claude's hint is purely dynamic. Defensive
+    /// test: even if the watcher happens to carry a hint set by a
+    /// future bug, Claude does not surface it.
+    #[test]
+    fn static_hint_is_none_for_claude_regardless_of_located_value() {
+        let adapter = ClaudeCodeAdapter;
+        let tps = adapter.transcript_path_source();
+        let located = LocatedStatusSource {
+            status_path: PathBuf::from("/tmp/status.json"),
+            trust_root: PathBuf::from("/tmp"),
+            static_transcript_hint: Some("/tmp/should_be_ignored.jsonl".to_string()),
+        };
+        assert_eq!(tps.static_hint(&located), None);
     }
 }

--- a/crates/backend/src/agent/adapter/claude_code/statusline.rs
+++ b/crates/backend/src/agent/adapter/claude_code/statusline.rs
@@ -18,16 +18,23 @@ pub struct ParsedStatusline {
     pub transcript_path: Option<String>,
 }
 
-/// Lightweight `transcript_path` extractor — parses the JSON just
-/// enough to surface the field, no event construction.
+/// `transcript_path` extractor — used by
+/// `TranscriptPathSource::dynamic_hint` for the Claude adapter so the
+/// watcher can resolve a fresh transcript path on every statusline
+/// update.
 ///
-/// Used by `TranscriptPathSource::dynamic_hint` for the Claude adapter
-/// so the watcher can resolve a fresh transcript path on every update
-/// without redoing the full `parse_statusline` work (the full parser
-/// runs once per update for `parse_status`; `dynamic_hint` runs against
-/// the same raw bytes). Returns `None` for malformed JSON, missing
-/// field, or any non-string value at the `transcript_path` key — the
-/// same lenience the private `transcript_path(Value)` helper applies.
+/// **What this avoids vs `parse_statusline`:** the full
+/// `AgentStatusEvent` construction (model id, context-window math,
+/// cost/rate-limit field plumbing). The JSON itself IS re-parsed —
+/// `serde_json::from_str::<Value>(raw)` runs once here and once
+/// inside `parse_statusline` against the same bytes. For
+/// kilobyte-sized statusline files that's acceptable; if profiling
+/// ever shows it matters, the caller can switch to a streaming /
+/// narrow-`Deserialize` shape.
+///
+/// Returns `None` for malformed JSON, a missing field, or any
+/// non-string value at the `transcript_path` key — the same lenience
+/// the private `transcript_path(Value)` helper applies.
 pub fn extract_transcript_path(raw: &str) -> Option<String> {
     let value: Value = serde_json::from_str(raw).ok()?;
     transcript_path(&value)

--- a/crates/backend/src/agent/adapter/claude_code/statusline.rs
+++ b/crates/backend/src/agent/adapter/claude_code/statusline.rs
@@ -18,6 +18,21 @@ pub struct ParsedStatusline {
     pub transcript_path: Option<String>,
 }
 
+/// Lightweight `transcript_path` extractor — parses the JSON just
+/// enough to surface the field, no event construction.
+///
+/// Used by `TranscriptPathSource::dynamic_hint` for the Claude adapter
+/// so the watcher can resolve a fresh transcript path on every update
+/// without redoing the full `parse_statusline` work (the full parser
+/// runs once per update for `parse_status`; `dynamic_hint` runs against
+/// the same raw bytes). Returns `None` for malformed JSON, missing
+/// field, or any non-string value at the `transcript_path` key — the
+/// same lenience the private `transcript_path(Value)` helper applies.
+pub fn extract_transcript_path(raw: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(raw).ok()?;
+    transcript_path(&value)
+}
+
 /// Parse raw JSON string from the statusline file into an `AgentStatusEvent`.
 ///
 /// All fields are optional — gracefully handles partial/evolving JSON.

--- a/crates/backend/src/agent/adapter/claude_code/statusline.rs
+++ b/crates/backend/src/agent/adapter/claude_code/statusline.rs
@@ -9,13 +9,19 @@ use crate::agent::types::{
 };
 use serde_json::Value;
 
-/// Parsed statusline result with the event and optional transcript path
+/// Parsed statusline result wrapping the typed status event.
+///
+/// Step 0c (post-upsource review) dropped the former
+/// `transcript_path: Option<String>` field — the watcher now resolves
+/// the transcript path independently via
+/// [`extract_transcript_path`] (which `TranscriptPathSource::dynamic_hint`
+/// calls). Keeping a parallel field here was dead code:
+/// `ClaudeCodeAdapter::parse_status` discards it and no test exercises
+/// the live extraction through this path.
 #[derive(Debug, Clone)]
 pub struct ParsedStatusline {
     /// The typed agent status event
     pub event: AgentStatusEvent,
-    /// Transcript path extracted from statusline (used by watcher to start tailing)
-    pub transcript_path: Option<String>,
 }
 
 /// `transcript_path` extractor — used by
@@ -68,9 +74,6 @@ pub fn parse_statusline(session_id: &str, json: &str) -> Result<ParsedStatusline
     // Extract rate limits
     let rate_limits = parse_rate_limits(&value);
 
-    // Extract transcript path
-    let transcript_path = transcript_path(&value);
-
     let event = AgentStatusEvent {
         session_id: session_id.to_string(),
         agent_session_id,
@@ -82,10 +85,11 @@ pub fn parse_statusline(session_id: &str, json: &str) -> Result<ParsedStatusline
         rate_limits,
     };
 
-    Ok(ParsedStatusline {
-        event,
-        transcript_path,
-    })
+    // Note: transcript_path extraction happens via the standalone
+    // `extract_transcript_path` helper (called by
+    // `TranscriptPathSource::dynamic_hint`). Not surfaced here.
+
+    Ok(ParsedStatusline { event })
 }
 
 /// Parse context window fields from a JSON value
@@ -494,11 +498,9 @@ mod tests {
         let seven_day = event.rate_limits.seven_day.as_ref().unwrap();
         assert!((seven_day.used_percentage - 5.0).abs() < f64::EPSILON);
 
-        // Transcript path
-        assert_eq!(
-            parsed.transcript_path.as_deref(),
-            Some("/home/user/.claude/sessions/abc-123/transcript.jsonl")
-        );
+        // Transcript path: pinned separately via
+        // `extract_transcript_path` tests below — `parse_statusline`
+        // no longer surfaces it as of Step 0c.
     }
 
     #[test]
@@ -520,7 +522,6 @@ mod tests {
         assert_eq!(event.context_window.context_window_size, 0);
         assert!(event.context_window.current_usage.is_none());
         assert_eq!(event.cost.total_cost_usd, None);
-        assert!(parsed.transcript_path.is_none());
     }
 
     #[test]
@@ -743,5 +744,28 @@ mod tests {
         let event = &result.unwrap().event;
         assert_eq!(event.model_id, "claude-opus-4-20250514");
         assert_eq!(event.model_display_name, "claude-opus-4-20250514");
+    }
+
+    /// Step 0c (post-upsource cycle 2): replaces the deleted
+    /// `parsed.transcript_path` assertions in `parses_full_statusline_json`
+    /// + `parses_minimal_json`. The semantic coverage migrates from
+    /// `parse_statusline`'s dropped field to the standalone
+    /// `extract_transcript_path` helper. The full live-path contract
+    /// (Claude adapter → `TranscriptPathSource::dynamic_hint`) is
+    /// covered in `claude_code/mod.rs::dynamic_hint_extracts_transcript_path_when_present`.
+    #[test]
+    fn extract_transcript_path_returns_field_when_present_else_none() {
+        let with_path = r#"{"transcript_path": "/home/u/.claude/sessions/x.jsonl", "model": {"id": "x"}}"#;
+        assert_eq!(
+            extract_transcript_path(with_path).as_deref(),
+            Some("/home/u/.claude/sessions/x.jsonl"),
+        );
+
+        let without_path = r#"{"model": {"id": "x"}}"#;
+        assert_eq!(extract_transcript_path(without_path), None);
+
+        // Lenient on malformed JSON — returns None instead of panicking.
+        let malformed = r#"{not valid json"#;
+        assert_eq!(extract_transcript_path(malformed), None);
     }
 }

--- a/crates/backend/src/agent/adapter/codex/mod.rs
+++ b/crates/backend/src/agent/adapter/codex/mod.rs
@@ -473,6 +473,23 @@ mod status_source_tests {
             src.static_transcript_hint.as_deref(),
             Some(rollout_path.to_string_lossy().as_ref()),
         );
+        // Back-compat check: the production write path
+        // (`located_status_source` itself) still populates the
+        // deprecated mutex slot. Pinning this directly here (rather
+        // than only in the parse-side test) ensures a future edit
+        // that drops the `*slot = Some(...)` assignment is caught
+        // even though `parse_status` no longer surfaces the value.
+        assert_eq!(
+            adapter
+                .resolved_rollout_path
+                .lock()
+                .ok()
+                .and_then(|slot| slot.clone()),
+            Some(rollout_path.clone()),
+            "located_status_source must keep populating the deprecated \
+             resolved_rollout_path mutex for back-compat until a later \
+             step removes the field"
+        );
     }
 
     #[test]

--- a/crates/backend/src/agent/adapter/codex/mod.rs
+++ b/crates/backend/src/agent/adapter/codex/mod.rs
@@ -127,19 +127,22 @@ impl AgentAdapter for CodexAdapter {
     }
 
     fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String> {
-        // The deprecated `transcript_path` field is gone from
-        // `ParsedStatus` as of Step 0c. The mutex is still read so the
-        // pinned regression test
-        // (`parse_status_includes_resolved_rollout_path_when_available`)
-        // can assert the field stays populated — that's how a future
-        // removal step can prove no caller observes it.
-        let transcript_path = self
-            .resolved_rollout_path
-            .lock()
-            .ok()
-            .and_then(|slot| slot.as_ref().map(|path| path.to_string_lossy().to_string()));
-        let _ = transcript_path; // back-compat read; intentionally unused by parser
-
+        // Step 0c: `ParsedStatus.transcript_path` was removed; the
+        // rollout path now reaches the watcher via
+        // `TranscriptPathSource::static_hint(&LocatedStatusSource)`,
+        // reading the value off the `LocatedStatusSource` returned by
+        // `located_status_source` at attach time.
+        //
+        // The deprecated `resolved_rollout_path` mutex is NOT read
+        // here — `parse_status` is on the hot path (every statusline
+        // update), and a `Mutex::lock()` + `String` allocation per
+        // call adds up. The write side of the mutex (in
+        // `located_status_source`) is anchored by the
+        // `located_status_source_returns_resolved_rollout_on_happy_path`
+        // test; the "slot is not cleared by subsequent parse_status
+        // calls" property is anchored by
+        // `parse_status_includes_resolved_rollout_path_when_available`,
+        // which pre-populates the mutex and reads it directly.
         parser::parse_rollout(session_id, raw)
     }
 
@@ -217,10 +220,17 @@ mod adapter_tests {
 
     #[test]
     fn parse_status_includes_resolved_rollout_path_when_available() {
-        // Back-compat regression test: the deprecated mutex is still
-        // populated by `located_status_source` so a future step that
-        // proves no caller reads it can land cleanly. Keep this until
-        // the mutex is actually removed (tracked under Step B'/D').
+        // Back-compat regression test. Pins two properties of the
+        // deprecated `resolved_rollout_path` mutex side channel:
+        // (a) the slot holds the value the caller pre-populated, and
+        // (b) calling `parse_status` does NOT clear it.
+        //
+        // This test pre-seeds the mutex directly (not via the
+        // production write path) — the locator-side write is anchored
+        // separately by
+        // `located_status_source_returns_resolved_rollout_on_happy_path`.
+        // Together the two tests pin both sides of the back-compat
+        // contract so a future step can drop the mutex confidently.
         let adapter = CodexAdapter::new(12345, SystemTime::UNIX_EPOCH);
         {
             let mut slot = adapter
@@ -235,9 +245,9 @@ mod adapter_tests {
         let parsed = <CodexAdapter as AgentAdapter>::parse_status(&adapter, "pty-1", raw)
             .expect("minimal codex status parses");
 
-        // The transcript path field is gone; what we still pin is that
-        // the deprecated slot holds the expected value (proving the
-        // back-compat write path is intact).
+        // The transcript path field is gone from `ParsedStatus`; what
+        // we pin is (a) the parse succeeded and (b) the slot is
+        // unchanged after parse_status returned.
         assert_eq!(parsed.event.agent_session_id, "sess");
         assert_eq!(
             adapter

--- a/crates/backend/src/agent/adapter/codex/mod.rs
+++ b/crates/backend/src/agent/adapter/codex/mod.rs
@@ -10,7 +10,9 @@ use std::sync::{Mutex, OnceLock};
 use std::time::SystemTime;
 
 use crate::agent::adapter::base::TranscriptHandle;
-use crate::agent::adapter::types::{ParsedStatus, StatusSource, ValidateTranscriptError};
+use crate::agent::adapter::types::{
+    LocatedStatusSource, ParsedStatus, RawPath, TranscriptPathSource, ValidateTranscriptError,
+};
 use crate::agent::adapter::AgentAdapter;
 use crate::agent::types::AgentType;
 use crate::runtime::EventSink;
@@ -26,6 +28,14 @@ pub struct CodexAdapter {
     pty_start: SystemTime,
     codex_home: PathBuf,
     locator_cache: OnceLock<CompositeLocator>,
+    /// Deprecated as of Step 0c: the rollout path now flows through
+    /// `LocatedStatusSource.static_transcript_hint` →
+    /// `TranscriptPathSource::static_hint`. The field is kept (and
+    /// still populated) for back-compat — the
+    /// `parse_status_includes_resolved_rollout_path_when_available`
+    /// regression test pins the value so a later step can prove the
+    /// removal is a no-op. Slated for removal in a later step (B'/D')
+    /// once no caller reads it.
     resolved_rollout_path: Mutex<Option<PathBuf>>,
 }
 
@@ -68,12 +78,30 @@ fn default_codex_home() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(".codex"))
 }
 
+impl TranscriptPathSource for CodexAdapter {
+    /// Codex's transcript path is known at attach time and flows
+    /// through the locator into
+    /// `LocatedStatusSource.static_transcript_hint`. The runtime
+    /// supplies the same `LocatedStatusSource` on every update; we
+    /// just return what's already there.
+    fn static_hint(&self, located: &LocatedStatusSource) -> Option<RawPath> {
+        located.static_transcript_hint.clone()
+    }
+
+    // `dynamic_hint` defaults to `None` — Codex's rollout file path
+    // does not appear inside the statusline JSON stream.
+}
+
 impl AgentAdapter for CodexAdapter {
     fn agent_type(&self) -> AgentType {
         AgentType::Codex
     }
 
-    fn status_source(&self, cwd: &Path, _session_id: &str) -> Result<StatusSource, String> {
+    fn located_status_source(
+        &self,
+        cwd: &Path,
+        _session_id: &str,
+    ) -> Result<LocatedStatusSource, String> {
         let ctx = BindContext {
             cwd,
             pid: self.pid,
@@ -82,24 +110,37 @@ impl AgentAdapter for CodexAdapter {
 
         let location = retry_locator(|| self.locator().resolve_rollout(&ctx))?;
 
+        // Keep the deprecated mutex populated for back-compat (Step 0c
+        // user choice). The new static-hint path threads through
+        // `LocatedStatusSource.static_transcript_hint` below.
         if let Ok(mut slot) = self.resolved_rollout_path.lock() {
             *slot = Some(location.rollout_path.clone());
         }
 
-        Ok(StatusSource {
-            path: location.rollout_path,
+        let static_transcript_hint = Some(location.rollout_path.to_string_lossy().into_owned());
+
+        Ok(LocatedStatusSource {
+            status_path: location.rollout_path,
             trust_root: self.codex_home.clone(),
+            static_transcript_hint,
         })
     }
 
     fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String> {
+        // The deprecated `transcript_path` field is gone from
+        // `ParsedStatus` as of Step 0c. The mutex is still read so the
+        // pinned regression test
+        // (`parse_status_includes_resolved_rollout_path_when_available`)
+        // can assert the field stays populated — that's how a future
+        // removal step can prove no caller observes it.
         let transcript_path = self
             .resolved_rollout_path
             .lock()
             .ok()
             .and_then(|slot| slot.as_ref().map(|path| path.to_string_lossy().to_string()));
+        let _ = transcript_path; // back-compat read; intentionally unused by parser
 
-        parser::parse_rollout(session_id, raw, transcript_path)
+        parser::parse_rollout(session_id, raw)
     }
 
     fn validate_transcript(&self, raw: &str) -> Result<PathBuf, ValidateTranscriptError> {
@@ -114,6 +155,10 @@ impl AgentAdapter for CodexAdapter {
         transcript_path: PathBuf,
     ) -> Result<TranscriptHandle, String> {
         transcript::start_tailing(events, session_id, transcript_path, cwd)
+    }
+
+    fn transcript_path_source(&self) -> &dyn TranscriptPathSource {
+        self
     }
 }
 
@@ -156,7 +201,11 @@ mod adapter_tests {
     use std::time::SystemTime;
 
     #[test]
-    fn parse_status_delegates_to_parser_with_transcript_path_none() {
+    fn parse_status_returns_event_without_transcript_path_field() {
+        // Step 0c: `ParsedStatus.transcript_path` was removed; the
+        // adapter's `parse_status` should now return only the event.
+        // This test pins that change: a successful parse populates the
+        // event correctly and there's no transcript_path to inspect.
         let adapter = CodexAdapter::new(12345, SystemTime::UNIX_EPOCH);
         let raw = r#"{"timestamp":"...","type":"session_meta","payload":{"id":"sess","cli_version":"0.128.0"}}
 "#;
@@ -164,11 +213,14 @@ mod adapter_tests {
             .expect("minimal codex status parses");
 
         assert_eq!(parsed.event.agent_session_id, "sess");
-        assert!(parsed.transcript_path.is_none());
     }
 
     #[test]
     fn parse_status_includes_resolved_rollout_path_when_available() {
+        // Back-compat regression test: the deprecated mutex is still
+        // populated by `located_status_source` so a future step that
+        // proves no caller reads it can land cleanly. Keep this until
+        // the mutex is actually removed (tracked under Step B'/D').
         let adapter = CodexAdapter::new(12345, SystemTime::UNIX_EPOCH);
         {
             let mut slot = adapter
@@ -183,10 +235,58 @@ mod adapter_tests {
         let parsed = <CodexAdapter as AgentAdapter>::parse_status(&adapter, "pty-1", raw)
             .expect("minimal codex status parses");
 
+        // The transcript path field is gone; what we still pin is that
+        // the deprecated slot holds the expected value (proving the
+        // back-compat write path is intact).
+        assert_eq!(parsed.event.agent_session_id, "sess");
         assert_eq!(
-            parsed.transcript_path.as_deref(),
-            Some("/tmp/codex-rollout.jsonl")
+            adapter
+                .resolved_rollout_path
+                .lock()
+                .ok()
+                .and_then(|slot| slot.clone()),
+            Some(PathBuf::from("/tmp/codex-rollout.jsonl")),
         );
+    }
+
+    /// Step 0c: the new transcript-path-resolution path goes through
+    /// `TranscriptPathSource::static_hint(&LocatedStatusSource)`.
+    /// Pin both directions of the contract: when the located source
+    /// carries `Some(_)`, Codex's static_hint surfaces it verbatim;
+    /// when it carries `None`, static_hint returns `None`.
+    #[test]
+    fn static_hint_returns_static_transcript_hint_from_located() {
+        let adapter = CodexAdapter::new(12345, SystemTime::UNIX_EPOCH);
+        let tps = adapter.transcript_path_source();
+
+        let with_hint = LocatedStatusSource {
+            status_path: PathBuf::from("/home/u/.codex/sessions/r.jsonl"),
+            trust_root: PathBuf::from("/home/u/.codex"),
+            static_transcript_hint: Some("/home/u/.codex/sessions/r.jsonl".to_string()),
+        };
+        assert_eq!(
+            tps.static_hint(&with_hint),
+            Some("/home/u/.codex/sessions/r.jsonl".to_string()),
+        );
+
+        let without_hint = LocatedStatusSource {
+            status_path: PathBuf::from("/tmp/x"),
+            trust_root: PathBuf::from("/tmp"),
+            static_transcript_hint: None,
+        };
+        assert_eq!(tps.static_hint(&without_hint), None);
+    }
+
+    /// Codex's `dynamic_hint` MUST stay `None` regardless of input —
+    /// the rollout file path never appears inside the JSONL statusline
+    /// stream. Defensive test: even with a payload that looks
+    /// transcript-pathy, Codex does not surface a dynamic hint.
+    #[test]
+    fn dynamic_hint_is_none_for_codex_regardless_of_raw() {
+        let adapter = CodexAdapter::new(12345, SystemTime::UNIX_EPOCH);
+        let tps = adapter.transcript_path_source();
+        let raw = r#"{"transcript_path":"/should/be/ignored"}"#;
+        assert_eq!(tps.dynamic_hint(raw), None);
     }
 
     #[test]
@@ -352,7 +452,7 @@ mod status_source_tests {
     }
 
     #[test]
-    fn status_source_returns_resolved_rollout_on_happy_path() {
+    fn located_status_source_returns_resolved_rollout_on_happy_path() {
         let codex_home = tempfile::tempdir().expect("tempdir");
         let pty_start = SystemTime::now() - Duration::from_secs(5);
         let rollout_path = seed_codex_home_with_thread(codex_home.path(), 999, pty_start);
@@ -360,21 +460,29 @@ mod status_source_tests {
         let adapter = CodexAdapter::with_home(999, pty_start, codex_home.path().to_path_buf());
         let cwd = codex_home.path().to_path_buf();
 
-        let src = <CodexAdapter as AgentAdapter>::status_source(&adapter, &cwd, "sid")
-            .expect("status_source should resolve");
+        let src = <CodexAdapter as AgentAdapter>::located_status_source(&adapter, &cwd, "sid")
+            .expect("located_status_source should resolve");
 
-        assert_eq!(src.path, rollout_path);
+        assert_eq!(src.status_path, rollout_path);
         assert_eq!(src.trust_root, codex_home.path());
+        // Step 0c: the located source now also surfaces the rollout
+        // path as a `static_transcript_hint` so the watcher can reach
+        // it via `TranscriptPathSource::static_hint` without the
+        // deprecated mutex side channel.
+        assert_eq!(
+            src.static_transcript_hint.as_deref(),
+            Some(rollout_path.to_string_lossy().as_ref()),
+        );
     }
 
     #[test]
-    fn status_source_returns_err_on_retry_exhausted() {
+    fn located_status_source_returns_err_on_retry_exhausted() {
         let codex_home = tempfile::tempdir().expect("tempdir");
         let adapter =
             CodexAdapter::with_home(999, SystemTime::now(), codex_home.path().to_path_buf());
         let cwd = codex_home.path().to_path_buf();
 
-        let err = <CodexAdapter as AgentAdapter>::status_source(&adapter, &cwd, "sid")
+        let err = <CodexAdapter as AgentAdapter>::located_status_source(&adapter, &cwd, "sid")
             .expect_err("empty codex_home should exhaust retry");
         assert!(err.contains("retry exhausted"), "got: {}", err);
     }

--- a/crates/backend/src/agent/adapter/codex/parser.rs
+++ b/crates/backend/src/agent/adapter/codex/parser.rs
@@ -6,11 +6,7 @@ use crate::agent::types::{
 };
 use serde_json::Value;
 
-pub fn parse_rollout(
-    session_id: &str,
-    raw: &str,
-    transcript_path: Option<String>,
-) -> Result<ParsedStatus, String> {
+pub fn parse_rollout(session_id: &str, raw: &str) -> Result<ParsedStatus, String> {
     let mut state = CodexFoldState::default();
     let lines: Vec<&str> = raw.split('\n').collect();
     let trailing_complete = raw.ends_with('\n');
@@ -33,9 +29,13 @@ pub fn parse_rollout(
         }
     }
 
+    // Step 0c: `transcript_path` was removed from `ParsedStatus`. The
+    // rollout path now reaches the watcher via
+    // `TranscriptPathSource::static_hint`, reading the value off the
+    // `LocatedStatusSource` returned by `located_status_source` at
+    // attach time.
     Ok(ParsedStatus {
         event: state.into_event(session_id),
-        transcript_path,
     })
 }
 
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn parses_minimal_single_turn() {
         let raw = fixture("rollout-minimal.jsonl");
-        let parsed = parse_rollout("pty-test", &raw, None).expect("happy path");
+        let parsed = parse_rollout("pty-test", &raw).expect("happy path");
         let event = parsed.event;
 
         assert_eq!(event.session_id, "pty-test");
@@ -335,13 +335,15 @@ mod tests {
                 .abs()
                 < f64::EPSILON
         );
-        assert!(parsed.transcript_path.is_none());
+        // Step 0c: `transcript_path` was removed from `ParsedStatus`.
+        // The path is now reached via `TranscriptPathSource::static_hint`
+        // — exercised by the adapter-level tests in `codex/mod.rs`.
     }
 
     #[test]
     fn long_session_uses_last_token_usage_not_lifetime() {
         let raw = fixture("rollout-long-session.jsonl");
-        let parsed = parse_rollout("pty-long", &raw, None).expect("long session");
+        let parsed = parse_rollout("pty-long", &raw).expect("long session");
         let event = parsed.event;
         let used = event
             .context_window
@@ -361,7 +363,7 @@ mod tests {
     #[test]
     fn token_count_info_null_preserves_prior_context() {
         let raw = fixture("rollout-info-null.jsonl");
-        let parsed = parse_rollout("pty-info-null", &raw, None).expect("info-null");
+        let parsed = parse_rollout("pty-info-null", &raw).expect("info-null");
         let event = parsed.event;
 
         assert_eq!(event.context_window.total_input_tokens, 1000);
@@ -372,14 +374,14 @@ mod tests {
     #[test]
     fn multi_turn_sums_durations() {
         let raw = fixture("rollout-multi-turn.jsonl");
-        let parsed = parse_rollout("pty-multi", &raw, None).expect("multi-turn");
+        let parsed = parse_rollout("pty-multi", &raw).expect("multi-turn");
         assert_eq!(parsed.event.cost.total_duration_ms, 60000);
     }
 
     #[test]
     fn incomplete_trailing_line_dropped_silently() {
         let raw = fixture("rollout-incomplete-trail.jsonl");
-        let parsed = parse_rollout("pty-trail", &raw, None).expect("incomplete trail");
+        let parsed = parse_rollout("pty-trail", &raw).expect("incomplete trail");
 
         assert_eq!(parsed.event.cost.total_duration_ms, 0);
         assert_eq!(parsed.event.model_id, "gpt-5.4");
@@ -388,7 +390,7 @@ mod tests {
     #[test]
     fn malformed_mid_line_skipped_with_warn() {
         let raw = fixture("rollout-malformed-mid.jsonl");
-        let parsed = parse_rollout("pty-malformed", &raw, None).expect("malformed mid");
+        let parsed = parse_rollout("pty-malformed", &raw).expect("malformed mid");
 
         assert_eq!(parsed.event.agent_session_id, "sess-malformed");
         assert_eq!(parsed.event.model_id, "gpt-5.4");
@@ -398,13 +400,13 @@ mod tests {
     fn task_started_fallback_for_context_window_size() {
         let raw = r#"{"timestamp":"...","type":"event_msg","payload":{"type":"task_started","model_context_window":128000}}
 "#;
-        let parsed = parse_rollout("pty-fallback", raw, None).expect("task_started fallback");
+        let parsed = parse_rollout("pty-fallback", raw).expect("task_started fallback");
         assert_eq!(parsed.event.context_window.context_window_size, 128000);
     }
 
     #[test]
     fn empty_rollout_returns_defaults() {
-        let parsed = parse_rollout("pty-empty", "", None).expect("empty rollout");
+        let parsed = parse_rollout("pty-empty", "").expect("empty rollout");
         assert_eq!(parsed.event.model_id, "unknown");
         assert_eq!(parsed.event.context_window.context_window_size, 0);
         assert!(parsed.event.context_window.used_percentage.is_none());
@@ -415,23 +417,15 @@ mod tests {
     fn unknown_event_type_ignored_without_error() {
         let raw = r#"{"timestamp":"...","type":"future_event_kind","payload":{"hello":"world"}}
 "#;
-        let parsed = parse_rollout("pty-unknown", raw, None).expect("unknown event kind");
+        let parsed = parse_rollout("pty-unknown", raw).expect("unknown event kind");
         assert_eq!(parsed.event.model_id, "unknown");
     }
 
-    #[test]
-    fn includes_transcript_path_when_provided() {
-        let raw = fixture("rollout-minimal.jsonl");
-        let parsed = parse_rollout(
-            "pty-test",
-            &raw,
-            Some("/home/user/.codex/sessions/rollout.jsonl".to_string()),
-        )
-        .expect("happy path");
-
-        assert_eq!(
-            parsed.transcript_path.as_deref(),
-            Some("/home/user/.codex/sessions/rollout.jsonl")
-        );
-    }
+    // Step 0c: the former `includes_transcript_path_when_provided` test
+    // was removed — `parse_rollout` no longer takes (or surfaces) a
+    // transcript path. The adapter-level
+    // `static_hint_returns_static_transcript_hint_from_located` test in
+    // `codex/mod.rs::adapter_tests` pins the new contract: the rollout
+    // path reaches the watcher via
+    // `TranscriptPathSource::static_hint(&LocatedStatusSource)`.
 }

--- a/crates/backend/src/agent/adapter/mod.rs
+++ b/crates/backend/src/agent/adapter/mod.rs
@@ -30,13 +30,23 @@ use crate::terminal::PtyState;
 use base::{TranscriptHandle, TranscriptState};
 use claude_code::ClaudeCodeAdapter;
 use codex::CodexAdapter;
-use types::{ParsedStatus, StatusSource, ValidateTranscriptError};
+use types::{LocatedStatusSource, ParsedStatus, TranscriptPathSource, ValidateTranscriptError};
 
 /// Provider hooks for one CLI coding agent.
 pub trait AgentAdapter: Send + Sync + 'static {
     fn agent_type(&self) -> AgentType;
 
-    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String>;
+    /// Return the statusline location + attach-time transcript hint.
+    ///
+    /// Step 0c rename of the former `status_source`; the return type is
+    /// now [`LocatedStatusSource`] so attach-time transcript paths
+    /// (Codex's rollout path) reach the runtime through a typed field
+    /// instead of an adapter-private side channel.
+    fn located_status_source(
+        &self,
+        cwd: &Path,
+        session_id: &str,
+    ) -> Result<LocatedStatusSource, String>;
 
     fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String>;
 
@@ -49,6 +59,16 @@ pub trait AgentAdapter: Send + Sync + 'static {
         cwd: Option<PathBuf>,
         transcript_path: PathBuf,
     ) -> Result<TranscriptHandle, String>;
+
+    /// Return the [`TranscriptPathSource`] this adapter exposes.
+    ///
+    /// Step 0c addition: the watcher uses this accessor to resolve
+    /// transcript paths via the new trait instead of via the deprecated
+    /// `ParsedStatus.transcript_path` side channel. Step B' will pull
+    /// the trait out of `AgentAdapter` entirely; until then each
+    /// adapter implements `TranscriptPathSource` for itself and returns
+    /// `self`.
+    fn transcript_path_source(&self) -> &dyn TranscriptPathSource;
 }
 
 impl dyn AgentAdapter {
@@ -100,19 +120,26 @@ impl NoOpAdapter {
     }
 }
 
+impl TranscriptPathSource for NoOpAdapter {}
+
 impl AgentAdapter for NoOpAdapter {
     fn agent_type(&self) -> AgentType {
         self.agent_type
     }
 
-    fn status_source(&self, cwd: &Path, session_id: &str) -> Result<StatusSource, String> {
-        Ok(StatusSource {
-            path: cwd
+    fn located_status_source(
+        &self,
+        cwd: &Path,
+        session_id: &str,
+    ) -> Result<LocatedStatusSource, String> {
+        Ok(LocatedStatusSource {
+            status_path: cwd
                 .join(".vimeflow")
                 .join("sessions")
                 .join(session_id)
                 .join("status.json"),
             trust_root: cwd.to_path_buf(),
+            static_transcript_hint: None,
         })
     }
 
@@ -142,6 +169,10 @@ impl AgentAdapter for NoOpAdapter {
             self.agent_type
         ))
     }
+
+    fn transcript_path_source(&self) -> &dyn TranscriptPathSource {
+        self
+    }
 }
 
 /// Start watching an agent status source for a PTY session.
@@ -165,7 +196,7 @@ pub(crate) async fn start_agent_watcher_inner(
     )?;
     let cwd_path = attach.initial_cwd.clone();
     // `adapter.start(...)` walks into `base::start_for`, which calls
-    // `adapter.status_source(...)`. For codex sessions, that call runs a
+    // `adapter.located_status_source(...)`. For codex sessions, that call runs a
     // bounded retry (up to 5 attempts × 100 ms inter-attempt sleeps)
     // using `std::thread::sleep` because codex commits its `logs` row
     // ~300ms after the rollout file opens.
@@ -258,19 +289,40 @@ mod noop_tests {
     }
 
     #[test]
-    fn status_source_uses_claude_shaped_path() {
+    fn located_status_source_uses_claude_shaped_path() {
         let adapter = NoOpAdapter::new(AgentType::Aider);
         let cwd = PathBuf::from("/tmp/ws");
-        let src = <NoOpAdapter as AgentAdapter>::status_source(&adapter, &cwd, "sid")
+        let src = <NoOpAdapter as AgentAdapter>::located_status_source(&adapter, &cwd, "sid")
             .expect("noop adapter always resolves a status source");
         assert_eq!(
-            src.path,
+            src.status_path,
             cwd.join(".vimeflow")
                 .join("sessions")
                 .join("sid")
                 .join("status.json")
         );
         assert_eq!(src.trust_root, cwd);
+        // NoOp adapters never know a static transcript path — Step 0c
+        // contract: only Codex's locator returns Some.
+        assert_eq!(src.static_transcript_hint, None);
+    }
+
+    /// Step 0c: NoOpAdapter's `TranscriptPathSource` impl uses the
+    /// trait's default `None` for both methods. Pins the contract so a
+    /// future contributor doesn't accidentally override one of them
+    /// (which would change behavior for every "not yet implemented"
+    /// agent — Aider, Generic).
+    #[test]
+    fn noop_transcript_path_source_returns_none_for_both_hints() {
+        let adapter = NoOpAdapter::new(AgentType::Aider);
+        let tps = adapter.transcript_path_source();
+        let located = LocatedStatusSource {
+            status_path: PathBuf::from("/tmp/status.json"),
+            trust_root: PathBuf::from("/tmp"),
+            static_transcript_hint: Some("/tmp/ignored.jsonl".to_string()),
+        };
+        assert_eq!(tps.static_hint(&located), None);
+        assert_eq!(tps.dynamic_hint(r#"{"transcript_path":"/tmp/x"}"#), None);
     }
 
     #[test]

--- a/crates/backend/src/agent/adapter/types.rs
+++ b/crates/backend/src/agent/adapter/types.rs
@@ -2,7 +2,9 @@
 
 use std::path::PathBuf;
 
-use crate::agent::types::AgentStatusEvent;
+use crate::agent::types::{
+    AgentStatusEvent, ContextWindowStatus, CostMetrics, RateLimits,
+};
 
 /// Raw, untrusted, not-yet-validated transcript path emitted by either
 /// the locator at attach time (via
@@ -45,23 +47,43 @@ pub struct LocatedStatusSource {
     pub static_transcript_hint: Option<RawPath>,
 }
 
-/// Decoder output — provider-neutral status state.
+/// Decoder output — provider-neutral status state, **session-id-free**
+/// and **transcript-path-free**.
 ///
 /// Defined in step 0c per the v4-frozen plan; reserved for the
 /// state-decoder split (Step B') that moves status decoding off the
 /// `AgentAdapter` trait. For 0c the type exists but no caller consumes
-/// it directly — `parse_status` continues to return [`ParsedStatus`],
-/// which has lost its `transcript_path` field in this step.
+/// it directly — `parse_status` continues to return [`ParsedStatus`]
+/// (a session-id-stamped envelope built by runtime code), which has
+/// lost its `transcript_path` field in this step.
 ///
-/// Distinct from `ParsedStatus` in two ways: (a) `session_id` lives on
-/// the embedded event today and B' will lift it out so the decoder
-/// becomes session-id-free, and (b) `StatusSnapshot` never carries a
-/// transcript path — that lookup is fully owned by
-/// [`TranscriptPathSource`].
+/// Distinct from `ParsedStatus`/`AgentStatusEvent` in two structural
+/// ways:
+///
+/// 1. No `session_id` — the Vimeflow PTY session id is a runtime fact,
+///    not a decoder output. Future Step B' will have the decoder
+///    return this type, and the runtime composes
+///    `AgentStatusEvent { session_id, ..snapshot }` afterwards.
+/// 2. No transcript path — that lookup is fully owned by
+///    [`TranscriptPathSource`]; the decoder never surfaces it.
+///
+/// Field set mirrors the non-`session_id` fields of
+/// [`AgentStatusEvent`]. A future B' commit changes the conversion
+/// from "manual struct build" to a `From<StatusSnapshot> for
+/// AgentStatusEvent` plus the runtime-supplied id.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct StatusSnapshot {
-    pub event: AgentStatusEvent,
+    /// Agent's internal session id (distinct from the Vimeflow PTY
+    /// session id, which lives on `AgentStatusEvent.session_id` and is
+    /// stamped by runtime code, not by the decoder).
+    pub agent_session_id: String,
+    pub model_id: String,
+    pub model_display_name: String,
+    pub version: String,
+    pub context_window: ContextWindowStatus,
+    pub cost: CostMetrics,
+    pub rate_limits: RateLimits,
 }
 
 /// Statusline-parser output as consumed by `base/watcher_runtime`.

--- a/crates/backend/src/agent/adapter/types.rs
+++ b/crates/backend/src/agent/adapter/types.rs
@@ -4,16 +4,109 @@ use std::path::PathBuf;
 
 use crate::agent::types::AgentStatusEvent;
 
+/// Raw, untrusted, not-yet-validated transcript path emitted by either
+/// the locator at attach time (via
+/// [`TranscriptPathSource::static_hint`]) or the statusline decoder at
+/// each update (via [`TranscriptPathSource::dynamic_hint`]).
+/// Validation through `AgentAdapter::validate_transcript` converts a
+/// `RawPath` into a canonicalized `PathBuf` before any transcript
+/// tailing happens.
+///
+/// Type alias rather than newtype because every caller already works
+/// with `String`; a newtype would add ceremony without strengthening
+/// the safety boundary, which lives at `validate_transcript`.
+pub type RawPath = String;
+
+/// Located statusline source — what
+/// `AgentAdapter::located_status_source` returns at attach time.
+///
+/// Step 0c rename of the former `StatusSource`. The new
+/// `static_transcript_hint` field carries Codex's locator-known rollout
+/// path so the runtime can ask [`TranscriptPathSource::static_hint`]
+/// for it without depending on the adapter-private `Mutex` side channel
+/// (deprecated in 0c, kept in place for back-compat; targeted for
+/// removal in a later step).
 #[derive(Debug, Clone)]
-pub struct StatusSource {
-    pub path: PathBuf,
+pub struct LocatedStatusSource {
+    /// Filesystem path of the statusline file the watcher will observe.
+    pub status_path: PathBuf,
+    /// Directory used as the trust root by `path_security` checks when
+    /// validating any transcript path paired with this statusline.
     pub trust_root: PathBuf,
+    /// Transcript path known at attach time. `Some(_)` for Codex (the
+    /// locator resolves the rollout file before any statusline update);
+    /// `None` for Claude (the path is dynamic, arriving inside every
+    /// statusline JSON update — see
+    /// [`TranscriptPathSource::dynamic_hint`]).
+    ///
+    /// Held here so the runtime can pass a `&LocatedStatusSource` into
+    /// `static_hint` instead of threading the path through
+    /// `parse_status` as a side channel.
+    pub static_transcript_hint: Option<RawPath>,
 }
 
+/// Decoder output — provider-neutral status state.
+///
+/// Defined in step 0c per the v4-frozen plan; reserved for the
+/// state-decoder split (Step B') that moves status decoding off the
+/// `AgentAdapter` trait. For 0c the type exists but no caller consumes
+/// it directly — `parse_status` continues to return [`ParsedStatus`],
+/// which has lost its `transcript_path` field in this step.
+///
+/// Distinct from `ParsedStatus` in two ways: (a) `session_id` lives on
+/// the embedded event today and B' will lift it out so the decoder
+/// becomes session-id-free, and (b) `StatusSnapshot` never carries a
+/// transcript path — that lookup is fully owned by
+/// [`TranscriptPathSource`].
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct StatusSnapshot {
+    pub event: AgentStatusEvent,
+}
+
+/// Statusline-parser output as consumed by `base/watcher_runtime`.
+///
+/// Step 0c removed the `transcript_path: Option<String>` field — the
+/// runtime now resolves transcript paths via [`TranscriptPathSource`]
+/// instead of via this side channel.
 #[derive(Debug, Clone)]
 pub struct ParsedStatus {
     pub event: AgentStatusEvent,
-    pub transcript_path: Option<String>,
+}
+
+/// Where transcript paths come from. Broken out as a standalone trait
+/// per the v4-frozen plan so future Step B' can extract it cleanly
+/// from `AgentAdapter` without churning callers.
+///
+/// Per-provider contract:
+///
+/// - **Claude:** `static_hint` returns `None`; `dynamic_hint(raw)`
+///   extracts `transcript_path` from the statusline JSON on every
+///   update.
+/// - **Codex:** `static_hint(&located)` returns
+///   `located.static_transcript_hint.clone()` (the locator-known
+///   rollout path captured at attach time); `dynamic_hint` returns
+///   `None`.
+///
+/// The runtime asks `dynamic_hint` first (fresh-per-update Claude
+/// path) and falls back to `static_hint` (steady-state Codex path).
+/// If both return `None`, no transcript is tailed.
+pub trait TranscriptPathSource: Send + Sync {
+    /// Transcript path known at attach time. Default returns `None`;
+    /// Codex overrides to surface the rollout path stored in the
+    /// supplied [`LocatedStatusSource`].
+    fn static_hint(&self, located: &LocatedStatusSource) -> Option<RawPath> {
+        let _ = located;
+        None
+    }
+
+    /// Transcript path extracted from the raw statusline content on
+    /// every update. Default returns `None`; Claude overrides to parse
+    /// the JSON's `transcript_path` field.
+    fn dynamic_hint(&self, raw: &str) -> Option<RawPath> {
+        let _ = raw;
+        None
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -51,7 +51,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 2        | 0    | 2026-05-04   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 54       | 24   | 2026-05-23   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 3        | 1    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 73       | 21   | 2026-05-23   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 74       | 22   | 2026-05-23   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 42       | 10   | 2026-05-21   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -51,7 +51,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 2        | 0    | 2026-05-04   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 54       | 24   | 2026-05-23   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 3        | 1    | 2026-04-09   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 74       | 22   | 2026-05-23   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 75       | 23   | 2026-05-23   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 42       | 10   | 2026-05-21   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -3,7 +3,7 @@ id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
 last_updated: 2026-05-23
-ref_count: 21
+ref_count: 22
 ---
 
 # Documentation Accuracy
@@ -692,4 +692,13 @@ Stale documentation misleads future contributors and review agents.
 - **File:** `crates/backend/src/agent/config.rs`
 - **Finding:** `spec_for(agent_type: AgentType)` was documented as "Panics in debug builds if the registry has drifted..." but the implementation used `unwrap_or_else(|| panic!(...))` with no `#[cfg(debug_assertions)]` guard — it panics in every build. A future contributor reading the doc might believe release builds silently fall through, or might add a release-only fallback that would be worse than the crash. The unconditional panic is the right behavior here (a programming-error invariant should fail loudly); only the doc was wrong.
 - **Fix:** Dropped "in debug builds" from the doc-comment. New wording: "Panics if the registry has drifted away from `AgentType` — the registry must cover every enum variant. The panic fires in both debug and release builds; treat it as a programming-error guard, not a recoverable runtime error." Code-review heuristic: words like "in debug builds", "in tests", "may panic" in Rust doc-comments are contracts — they imply specific `cfg()` gates or fallback paths. Use them only when those gates exist; otherwise the implementation drifts from the documentation contract.
+- **Commit:** same commit as this entry
+
+### 74. parse_status comment claimed test exercised a read path that the test bypassed
+
+- **Source:** github-claude | PR #256 | 2026-05-23
+- **Severity:** LOW
+- **File:** `crates/backend/src/agent/adapter/codex/mod.rs`
+- **Finding:** `CodexAdapter::parse_status` (Step 0c v1) contained a `let transcript_path = self.resolved_rollout_path.lock()...; let _ = transcript_path;` block — a deliberately-unused mutex read + heap `String` allocation per status update. The justifying comment claimed the deprecated mutex was kept "read" so the pinned regression test (`parse_status_includes_resolved_rollout_path_when_available`) could anchor the back-compat contract. But the test seeded the mutex directly in a separate block BEFORE calling `parse_status` and then read the mutex DIRECTLY afterwards — it never relied on `parse_status` touching the mutex at all. The comment misled future readers into thinking the read-path was load-bearing; in reality it was dead code on the hot path (every Codex statusline update paid a `Mutex::lock()` + `to_string_lossy().to_string()`).
+- **Fix:** Removed lines 136-141 (the dead `let _ = transcript_path;` block). Rewrote both (a) the `parse_status` comment to describe what's actually pinned and where (write side: `located_status_source_returns_resolved_rollout_on_happy_path`; "slot not cleared on parse" side: `parse_status_includes_resolved_rollout_path_when_available`) and (b) the regression test's own comment to admit it pre-seeds directly. Code-review heuristic: a `let _ = expr;` pattern justified ONLY by "the test reads this" is a smell — verify the test actually reaches the code path through the production entry point; if it pre-seeds and reads directly, the in-function read is dead and the comment is lying.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -3,7 +3,7 @@ id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
 last_updated: 2026-05-23
-ref_count: 22
+ref_count: 23
 ---
 
 # Documentation Accuracy
@@ -701,4 +701,13 @@ Stale documentation misleads future contributors and review agents.
 - **File:** `crates/backend/src/agent/adapter/codex/mod.rs`
 - **Finding:** `CodexAdapter::parse_status` (Step 0c v1) contained a `let transcript_path = self.resolved_rollout_path.lock()...; let _ = transcript_path;` block — a deliberately-unused mutex read + heap `String` allocation per status update. The justifying comment claimed the deprecated mutex was kept "read" so the pinned regression test (`parse_status_includes_resolved_rollout_path_when_available`) could anchor the back-compat contract. But the test seeded the mutex directly in a separate block BEFORE calling `parse_status` and then read the mutex DIRECTLY afterwards — it never relied on `parse_status` touching the mutex at all. The comment misled future readers into thinking the read-path was load-bearing; in reality it was dead code on the hot path (every Codex statusline update paid a `Mutex::lock()` + `to_string_lossy().to_string()`).
 - **Fix:** Removed lines 136-141 (the dead `let _ = transcript_path;` block). Rewrote both (a) the `parse_status` comment to describe what's actually pinned and where (write side: `located_status_source_returns_resolved_rollout_on_happy_path`; "slot not cleared on parse" side: `parse_status_includes_resolved_rollout_path_when_available`) and (b) the regression test's own comment to admit it pre-seeds directly. Code-review heuristic: a `let _ = expr;` pattern justified ONLY by "the test reads this" is a smell — verify the test actually reaches the code path through the production entry point; if it pre-seeds and reads directly, the in-function read is dead and the comment is lying.
+- **Commit:** same commit as this entry
+
+### 75. ParsedStatusline.transcript_path field left alive after the consumer dropped it
+
+- **Source:** github-claude | PR #256 | 2026-05-23
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/agent/adapter/claude_code/statusline.rs`
+- **Finding:** Step 0c removed `transcript_path` from the public `ParsedStatus` struct (`adapter/types.rs`) and rewired the watcher to call `extract_transcript_path` via `TranscriptPathSource::dynamic_hint`. The intent was to kill the side channel entirely — but the analogous field on the **internal** `ParsedStatusline` struct (returned by `parse_statusline`) was left intact. The only production caller (`ClaudeCodeAdapter::parse_status`) silently dropped the field. Two harms: (1) every Claude statusline update wasted a `transcript_path(&value)` JSON lookup + heap `String` allocation for a value nobody read; (2) two tests in `statusline.rs` (`parses_full_statusline_json` line 501-505, `parses_minimal_json` line 527) still asserted on the field, falsely appearing to pin transcript-path extraction behavior when in fact they exercised dead code — a real regression in `extract_transcript_path` (the live path) would not have been caught.
+- **Fix:** Removed `transcript_path: Option<String>` from `ParsedStatusline`, deleted the `let transcript_path = transcript_path(&value);` line, dropped the field from the `Ok(ParsedStatusline { ... })` literal, and deleted both test assertions. Added a new test `extract_transcript_path_returns_field_when_present_else_none` (present / absent / malformed JSON) to keep the live helper covered at the `statusline.rs` level. The adapter-level live path stays covered by `dynamic_hint_extracts_transcript_path_when_present` in `claude_code/mod.rs`. Code-review heuristic: when a public struct loses a field, sweep ALL its construction sites for parallel internal structs whose corresponding field is now dead. Rust's `dead_code` lint does not catch this case because the field is technically read by `Debug` / `Clone` derives even when no code path consumes its value.
 - **Commit:** same commit as this entry


### PR DESCRIPTION
## Summary

**Step 0c** of the [v4-frozen refactor plan](https://github.com/winoooops/vimeflow/blob/refactor/agent-adapter/crates/backend/src/agent/adapter/REVIEW.md#final-plan-v4-frozen). First step on this branch that **changes production data flow** — 0a/0b were define-only seam prep; 0c removes the `ParsedStatus.transcript_path` side channel and threads transcript-path resolution through a new typed trait.

## What lands

### Types (`adapter/types.rs`)

| Type | Status | Notes |
| --- | --- | --- |
| `StatusSource` | **REMOVED** | Replaced by `LocatedStatusSource`. |
| `LocatedStatusSource { status_path, trust_root, static_transcript_hint }` | NEW | Adds `static_transcript_hint: Option<RawPath>` so Codex's locator-known rollout path flows through a typed field instead of an adapter-private side channel. |
| `pub type RawPath = String` | NEW | Names the raw, not-yet-validated transcript-path strings emitted by either hint flavor. |
| `StatusSnapshot` | NEW | Session-id-free **and** transcript-path-free per acceptance. Reserved for Step B' state-decoder split; `#[allow(dead_code)]` for the interim. |
| `ParsedStatus.transcript_path` | **REMOVED** | The whole point of this step — kills the side channel. |
| `pub trait TranscriptPathSource: Send + Sync` | NEW | Two default-`None` methods: `static_hint(&LocatedStatusSource) -> Option<RawPath>` (Codex's path) and `dynamic_hint(raw) -> Option<RawPath>` (Claude's path). |

### Trait + adapter wiring

- `AgentAdapter::status_source` → `located_status_source`, returning `LocatedStatusSource`.
- New `fn transcript_path_source(&self) -> &dyn TranscriptPathSource` accessor on `AgentAdapter` (kept as a separate trait reached via an accessor — NOT a supertrait — to preserve a clean B' extraction boundary).
- `ClaudeCodeAdapter` — `static_hint = None`, `dynamic_hint(raw)` calls the new `statusline::extract_transcript_path(raw)` helper. `located_status_source.static_transcript_hint = None` (Claude's path is purely dynamic).
- `CodexAdapter` — `static_hint(&located)` returns `located.static_transcript_hint.clone()`, `dynamic_hint = None`. `located_status_source` populates `static_transcript_hint` from the locator's resolved rollout path.
- `NoOpAdapter` — `impl TranscriptPathSource for NoOpAdapter {}` (both defaults).

### Watcher routing (`base/watcher_runtime.rs` + `base/mod.rs`)

The 3 watcher callbacks (notify, inline-init, polling fallback) now resolve transcript paths via a new free `resolve_transcript_path(adapter, raw, located)` helper that calls `transcript_path_source().dynamic_hint(raw)` then falls back to `.static_hint(located)`. `start_watching`'s signature widened from `status_file_path: PathBuf` to `located: LocatedStatusSource` so each closure can carry the full source for `static_hint`.

### Codex mutex side-channel — deprecated, not removed

Per pre-implementation design call: `resolved_rollout_path: Mutex<Option<PathBuf>>` stays on `CodexAdapter` and is still populated by `located_status_source` for back-compat. `parse_status` reads-and-discards it (`let _ = transcript_path;`) so the regression test pins the write path until a later step removes the field. Both branches of the back-compat are now under test:
- `parse_status_includes_resolved_rollout_path_when_available` — pins the parse side.
- `located_status_source_returns_resolved_rollout_on_happy_path` now also asserts the mutex is populated by the production locator path.

## Codex review log

| Round | Findings | Outcome |
|-------|----------|---------|
| 1 | 1 MEDIUM + 2 LOW | MEDIUM: `StatusSnapshot` originally wrapped `AgentStatusEvent` which carries `session_id` — contradicts the "no session_id" acceptance. Redefined as a dedicated session-id-free struct. LOW #1: mutex regression test overclaimed — added an explicit mutex assertion on the production write path. LOW #2: `extract_transcript_path` docs overstated the parse-cost win — clarified that the win is skipping event construction, not the JSON parse. |
| 2 | **0 / 0 / 0 / 0 — "Ship it."** | All round-1 findings closed; no net-new. |

Round-2 verdict (verbatim): _"Step 0c acceptance still checks out: StatusSource production usage is replaced, TranscriptPathSource exists with static/dynamic hints, ParsedStatus.transcript_path is structurally gone, and watcher routing uses dynamic first then static. I found no net-new issues."_

## Diff at a glance

Two commits, expected to squash on merge:

1. `b067c9f` — original step 0c commit (9 files, +496/-105).
2. `c8894cb` — codex round-1 fixes (4 files, +73/-25): `StatusSnapshot` redefine + mutex assertion + docs clarification.

Files touched (all under `crates/backend/src/agent/adapter/`):

- `types.rs` — new types + trait.
- `mod.rs` — `AgentAdapter` trait rename + accessor; `NoOpAdapter` impl.
- `claude_code/mod.rs` — Claude's `TranscriptPathSource` impl, `located_status_source`, tests.
- `claude_code/statusline.rs` — new `extract_transcript_path` helper.
- `codex/mod.rs` — Codex's `TranscriptPathSource` impl, `located_status_source` (still populates the deprecated mutex), tests.
- `codex/parser.rs` — `parse_rollout` no longer takes/returns transcript_path.
- `base/mod.rs::start_for` — calls `located_status_source`, passes full source down.
- `base/watcher_runtime.rs` — new `resolve_transcript_path` helper; 3 callbacks rewired.
- `base/transcript_state.rs` — `OrderingAdapter` test mock migrated to new trait shape.

## Test plan

- [x] `cargo build -p vimeflow --lib` → clean
- [x] `cargo test -p vimeflow --lib agent::adapter` → 260 passed, 0 failed (256 prior + 4 net new for step 0c)
- [x] `cargo test -p vimeflow --lib` → 539 passed, 0 failed (`terminal::commands::tests::read_loop_eof_marks_cache_exited` flake observed once, passes on rerun; pre-existing, unrelated to this diff)
- [x] `cargo clippy -p vimeflow --lib --no-deps` → same 6 pre-existing warnings as step 0b's baseline; no new warnings
- [x] `rustfmt --check` on touched files → clean (pre-existing drift at `attach.rs:165`, `mod.rs:189`, and `claude_code/test_runners/*.rs` left alone per `rules/common/pr-scope.md`)
- [x] 2 rounds of `codex exec` — final round 0/0/0/0 (`.codex-reviews/round-2.output.md`)
- [ ] Reviewer: confirm `ParsedStatus.transcript_path` is structurally gone (not just stubbed) and no production caller reads it
- [ ] Reviewer: confirm watcher routing in all 3 callbacks (notify / inline-init / poll) consistently uses `resolve_transcript_path`
- [ ] Reviewer: confirm `StatusSnapshot`'s field set genuinely matches the "no session_id, no transcript path" acceptance

## Merge target

Targets `refactor/agent-adapter` (the integration branch). One final PR from `refactor/agent-adapter` → `main` lands the full refactor as a single squash commit per the merge strategy in #246.

Part of #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)