### PR TITLE
refactor(agent-adapter): step A-status — typed DTOs for statusline + parser

### DIFF
--- a/crates/backend/src/agent/adapter/claude_code/statusline.rs
+++ b/crates/backend/src/agent/adapter/claude_code/statusline.rs
@@ -11,7 +11,7 @@
 
 use serde::Deserialize;
 
-use super::super::serde_helpers::{lenient_f64, lenient_string, lenient_u64};
+use super::super::serde_helpers::{lenient_f64, lenient_object, lenient_string, lenient_u64};
 use crate::agent::types::{
     AgentStatusEvent, ContextWindowStatus, CostMetrics, CurrentUsage, RateLimitInfo, RateLimits,
 };
@@ -53,13 +53,20 @@ struct ClaudeStatusDto {
     session_id: Option<String>,
     #[serde(default, deserialize_with = "lenient_string")]
     version: Option<String>,
-    #[serde(default)]
+    // Nested struct fields use `lenient_object` so a wrong-typed
+    // block (`"context_window": 42`, `"rate_limits": []`) degrades to
+    // `None` and produces the per-block defaults the conversion layer
+    // already encodes — instead of poisoning the whole `parse_statusline`
+    // with an Err. Matches the pre-A-status `has_<block>(value)` /
+    // `is_some_and(Value::is_object)` guards. Round-1 review fix
+    // (Claude MEDIUM + codex connector P1).
+    #[serde(default, deserialize_with = "lenient_object")]
     model: Option<ClaudeModelDto>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_object")]
     context_window: Option<ClaudeContextWindowDto>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_object")]
     cost: Option<ClaudeCostDto>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_object")]
     rate_limits: Option<ClaudeRateLimitsDto>,
 }
 
@@ -83,7 +90,7 @@ struct ClaudeContextWindowDto {
     total_input_tokens: Option<u64>,
     #[serde(default, deserialize_with = "lenient_u64")]
     total_output_tokens: Option<u64>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_object")]
     current_usage: Option<ClaudeCurrentUsageDto>,
 }
 
@@ -115,9 +122,9 @@ struct ClaudeCostDto {
 
 #[derive(Deserialize, Default)]
 struct ClaudeRateLimitsDto {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_object")]
     five_hour: Option<ClaudeRateLimitInfoDto>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_object")]
     seven_day: Option<ClaudeRateLimitInfoDto>,
 }
 
@@ -668,6 +675,72 @@ mod tests {
         let event = &result.unwrap().event;
         assert_eq!(event.model_id, "claude-opus-4-20250514");
         assert_eq!(event.model_display_name, "claude-opus-4-20250514");
+    }
+
+    /// Round-1 upsource fix: a wrong-typed nested block (e.g.
+    /// `"context_window": 42`) must degrade to the per-block defaults
+    /// instead of poisoning the whole `parse_statusline` call. This
+    /// pins the `lenient_object` round of the helpers: before that
+    /// helper landed, this input made the entire status update an
+    /// `Err` and the watcher dropped the event.
+    #[test]
+    fn wrong_typed_nested_blocks_degrade_to_defaults_per_block() {
+        let json = r#"{
+            "session_id": "abc",
+            "model": {"id": "claude-x", "display_name": "X"},
+            "context_window": 42,
+            "cost": {"total_cost_usd": 1.5}
+        }"#;
+        let event = &parse_statusline("pty-wrong-ctx", json)
+            .expect("wrong-typed nested block must NOT poison parse")
+            .event;
+        assert_eq!(event.agent_session_id, "abc");
+        assert_eq!(event.model_id, "claude-x");
+        // context_window block lost → all defaults.
+        assert_eq!(event.context_window.used_percentage, None);
+        assert_eq!(event.context_window.context_window_size, 0);
+        assert!((event.context_window.remaining_percentage - 100.0).abs() < f64::EPSILON);
+        // cost block survived independently.
+        assert_eq!(event.cost.total_cost_usd, Some(1.5));
+    }
+
+    /// Companion: wrong-typed `cost` block should degrade
+    /// `cost.total_cost_usd` to `None` (block-absent semantics —
+    /// distinct from `Some(0.0)` which only fires when the block IS
+    /// present but the inner field is missing).
+    #[test]
+    fn wrong_typed_cost_block_degrades_to_none() {
+        let json = r#"{"cost": ["not", "an", "object"]}"#;
+        let event = &parse_statusline("pty-wrong-cost", json)
+            .expect("wrong-typed cost block must NOT poison parse")
+            .event;
+        assert_eq!(event.cost.total_cost_usd, None);
+        assert_eq!(event.cost.total_duration_ms, 0);
+    }
+
+    /// Companion: wrong-typed `rate_limits` + nested `current_usage`.
+    /// Pins that `lenient_object` is applied at both the top-level
+    /// `ClaudeStatusDto.rate_limits` and the nested
+    /// `ClaudeContextWindowDto.current_usage` positions.
+    #[test]
+    fn wrong_typed_rate_limits_and_current_usage_degrade() {
+        let json = r#"{
+            "context_window": {
+                "used_percentage": 25.0,
+                "context_window_size": 100,
+                "total_input_tokens": 25,
+                "current_usage": "garbage"
+            },
+            "rate_limits": 99
+        }"#;
+        let event = &parse_statusline("pty-wrong-rl-cu", json)
+            .expect("wrong-typed nested blocks must NOT poison parse")
+            .event;
+        assert_eq!(event.context_window.used_percentage, Some(25.0));
+        assert!(event.context_window.current_usage.is_none());
+        assert_eq!(event.rate_limits.five_hour.used_percentage, 0.0);
+        assert_eq!(event.rate_limits.five_hour.resets_at, 0);
+        assert!(event.rate_limits.seven_day.is_none());
     }
 
     /// Step 0c (post-upsource cycle 2): replaces the deleted

--- a/crates/backend/src/agent/adapter/claude_code/statusline.rs
+++ b/crates/backend/src/agent/adapter/claude_code/statusline.rs
@@ -1,130 +1,234 @@
-//! Statusline JSON parser for Claude Code agent status
+//! Statusline JSON parser for Claude Code agent status.
 //!
-//! Parses the JSON that Claude Code writes via its statusline command
-//! into typed `AgentStatusEvent` structs. Uses `serde_json::Value` for
-//! flexible parsing — gracefully handles partial/evolving JSON.
+//! Step A-status of the v4-frozen refactor plan (#246) replaced the
+//! former `serde_json::Value` pull-style extraction with typed DTOs
+//! that flow through `#[derive(Deserialize)]`. Per-field
+//! `Option<T> + #[serde(default)]` keeps the old "missing → default"
+//! and "null → default" semantics; per-field
+//! `deserialize_with = "...lenient_*"` keeps the old single-field
+//! degradation on wrong-typed inputs (a JSON string where a `u64` was
+//! expected no longer poisons the whole parse).
 
+use serde::Deserialize;
+
+use super::super::serde_helpers::{lenient_f64, lenient_string, lenient_u64};
 use crate::agent::types::{
     AgentStatusEvent, ContextWindowStatus, CostMetrics, CurrentUsage, RateLimitInfo, RateLimits,
 };
-use serde_json::Value;
 
 /// Parsed statusline result wrapping the typed status event.
 ///
 /// Step 0c (post-upsource review) dropped the former
-/// `transcript_path: Option<String>` field — the watcher now resolves
-/// the transcript path independently via
-/// [`extract_transcript_path`] (which `TranscriptPathSource::dynamic_hint`
-/// calls). Keeping a parallel field here was dead code:
-/// `ClaudeCodeAdapter::parse_status` discards it and no test exercises
-/// the live extraction through this path.
+/// `transcript_path: Option<String>` field — the watcher resolves the
+/// transcript path independently via [`extract_transcript_path`]
+/// (which `TranscriptPathSource::dynamic_hint` calls).
 #[derive(Debug, Clone)]
 pub struct ParsedStatusline {
-    /// The typed agent status event
+    /// The typed agent status event.
     pub event: AgentStatusEvent,
 }
+
+// -------------------------- DTO layer --------------------------
+//
+// The DTOs below are the typed shape of Claude Code's statusline
+// JSON. They are crate-private — production callers consume
+// `AgentStatusEvent` via `parse_statusline`'s conversion path; tests
+// reach behavior through the public entry points.
+//
+// Two invariants the DTO design preserves end-to-end:
+// 1. `null` and missing are indistinguishable from the caller's view —
+//    both produce `None` at the DTO level (`#[serde(default)]`), and
+//    the conversion layer maps `None` to the same domain-specific
+//    default the pull-style code used (`0` for counts, the computed
+//    fallback for `used_percentage`, etc.).
+// 2. A wrong-typed field (e.g. `"42"` for a `u64`) does NOT poison the
+//    whole parse — `lenient_*` deserializers degrade the offending
+//    field to `None` and let the rest of the document continue. This
+//    mirrors the pre-A-status behavior of
+//    `Value::as_u64().unwrap_or(0)` at every field.
+
+#[derive(Deserialize, Default)]
+struct ClaudeStatusDto {
+    #[serde(default, deserialize_with = "lenient_string")]
+    session_id: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    version: Option<String>,
+    #[serde(default)]
+    model: Option<ClaudeModelDto>,
+    #[serde(default)]
+    context_window: Option<ClaudeContextWindowDto>,
+    #[serde(default)]
+    cost: Option<ClaudeCostDto>,
+    #[serde(default)]
+    rate_limits: Option<ClaudeRateLimitsDto>,
+}
+
+#[derive(Deserialize, Default)]
+struct ClaudeModelDto {
+    #[serde(default, deserialize_with = "lenient_string")]
+    id: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    display_name: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct ClaudeContextWindowDto {
+    #[serde(default, deserialize_with = "lenient_f64")]
+    used_percentage: Option<f64>,
+    #[serde(default, deserialize_with = "lenient_f64")]
+    remaining_percentage: Option<f64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    context_window_size: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    total_input_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    total_output_tokens: Option<u64>,
+    #[serde(default)]
+    current_usage: Option<ClaudeCurrentUsageDto>,
+}
+
+#[derive(Deserialize, Default)]
+struct ClaudeCurrentUsageDto {
+    #[serde(default, deserialize_with = "lenient_u64")]
+    input_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    output_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    cache_creation_input_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    cache_read_input_tokens: Option<u64>,
+}
+
+#[derive(Deserialize, Default)]
+struct ClaudeCostDto {
+    #[serde(default, deserialize_with = "lenient_f64")]
+    total_cost_usd: Option<f64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    total_duration_ms: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    total_api_duration_ms: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    total_lines_added: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    total_lines_removed: Option<u64>,
+}
+
+#[derive(Deserialize, Default)]
+struct ClaudeRateLimitsDto {
+    #[serde(default)]
+    five_hour: Option<ClaudeRateLimitInfoDto>,
+    #[serde(default)]
+    seven_day: Option<ClaudeRateLimitInfoDto>,
+}
+
+#[derive(Deserialize, Default)]
+struct ClaudeRateLimitInfoDto {
+    #[serde(default, deserialize_with = "lenient_f64")]
+    used_percentage: Option<f64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    resets_at: Option<u64>,
+}
+
+/// Narrow DTO for the transcript-path extractor — keeps it independent
+/// of the full statusline shape so
+/// `TranscriptPathSource::dynamic_hint` can call it without paying for
+/// the full status decode. The JSON parse itself still runs (same
+/// `serde_json::from_str` cost as `parse_statusline`), but this DTO
+/// has a single field, so serde doesn't build the rest of the
+/// `AgentStatusEvent` graph.
+#[derive(Deserialize, Default)]
+struct ClaudeTranscriptPathDto {
+    #[serde(default, deserialize_with = "lenient_string")]
+    transcript_path: Option<String>,
+}
+
+// ----------------------- Entry points -------------------------
 
 /// `transcript_path` extractor — used by
 /// `TranscriptPathSource::dynamic_hint` for the Claude adapter so the
 /// watcher can resolve a fresh transcript path on every statusline
 /// update.
 ///
-/// **What this avoids vs `parse_statusline`:** the full
-/// `AgentStatusEvent` construction (model id, context-window math,
-/// cost/rate-limit field plumbing). The JSON itself IS re-parsed —
-/// `serde_json::from_str::<Value>(raw)` runs once here and once
-/// inside `parse_statusline` against the same bytes. For
-/// kilobyte-sized statusline files that's acceptable; if profiling
-/// ever shows it matters, the caller can switch to a streaming /
-/// narrow-`Deserialize` shape.
-///
 /// Returns `None` for malformed JSON, a missing field, or any
 /// non-string value at the `transcript_path` key — the same lenience
-/// the private `transcript_path(Value)` helper applies.
+/// the pre-A-status pull-style code applied.
 pub fn extract_transcript_path(raw: &str) -> Option<String> {
-    let value: Value = serde_json::from_str(raw).ok()?;
-    transcript_path(&value)
+    serde_json::from_str::<ClaudeTranscriptPathDto>(raw)
+        .ok()
+        .and_then(|dto| dto.transcript_path)
 }
 
-/// Parse raw JSON string from the statusline file into an `AgentStatusEvent`.
+/// Parse the raw statusline JSON into an [`AgentStatusEvent`].
 ///
-/// All fields are optional — gracefully handles partial/evolving JSON.
-/// Returns `Err` only if the input is not valid JSON at all.
+/// Returns `Err` when the input is not valid JSON or its top-level
+/// shape is not a JSON object (Step A-status: serde reports the latter
+/// as `"invalid JSON: invalid type: ..., expected struct ..."` —
+/// behavior preserved, error message text different from the previous
+/// hand-written `"statusline JSON is not an object"`).
 pub fn parse_statusline(session_id: &str, json: &str) -> Result<ParsedStatusline, String> {
-    let value: Value = serde_json::from_str(json).map_err(|e| format!("invalid JSON: {}", e))?;
+    let dto: ClaudeStatusDto =
+        serde_json::from_str(json).map_err(|e| format!("invalid JSON: {}", e))?;
+    Ok(ParsedStatusline {
+        event: dto_to_event(session_id, dto),
+    })
+}
 
-    if !value.is_object() {
-        return Err("statusline JSON is not an object".to_string());
-    }
+// ------------------ DTO → AgentStatusEvent --------------------
 
-    // Extract model info
-    let model_id = model_id(&value);
-    let model_display_name = model_display_name(&value, &model_id);
+fn dto_to_event(session_id: &str, dto: ClaudeStatusDto) -> AgentStatusEvent {
+    let model_id = dto
+        .model
+        .as_ref()
+        .and_then(|m| m.id.clone())
+        .unwrap_or_else(|| "unknown".to_string());
+    let model_display_name = dto
+        .model
+        .as_ref()
+        .and_then(|m| m.display_name.clone())
+        .unwrap_or_else(|| model_id.clone());
 
-    // Extract session ID and version
-    let agent_session_id = agent_session_id(&value);
-    let version = version(&value);
-
-    // Extract context window
-    let context_window = parse_context_window(&value);
-
-    // Extract cost metrics
-    let cost = parse_cost_metrics(&value);
-
-    // Extract rate limits
-    let rate_limits = parse_rate_limits(&value);
-
-    let event = AgentStatusEvent {
+    AgentStatusEvent {
         session_id: session_id.to_string(),
-        agent_session_id,
+        agent_session_id: dto.session_id.unwrap_or_default(),
         model_id,
         model_display_name,
-        version,
-        context_window,
-        cost,
-        rate_limits,
-    };
-
-    // Note: transcript_path extraction happens via the standalone
-    // `extract_transcript_path` helper (called by
-    // `TranscriptPathSource::dynamic_hint`). Not surfaced here.
-
-    Ok(ParsedStatusline { event })
+        version: dto.version.unwrap_or_default(),
+        context_window: context_window_from_dto(dto.context_window),
+        cost: cost_from_dto(dto.cost),
+        rate_limits: rate_limits_from_dto(dto.rate_limits),
+    }
 }
 
-/// Parse context window fields from a JSON value
-fn parse_context_window(value: &Value) -> ContextWindowStatus {
-    let defaults = ContextWindowStatus {
-        used_percentage: None,
-        remaining_percentage: 100.0,
-        context_window_size: 0,
-        total_input_tokens: 0,
-        total_output_tokens: 0,
-        current_usage: None,
+fn context_window_from_dto(cw: Option<ClaudeContextWindowDto>) -> ContextWindowStatus {
+    // Block-missing short-circuit preserves the pre-A-status default of
+    // `remaining_percentage = 100.0` even when no context_window block
+    // was emitted. Test pin:
+    // `handles_missing_context_window`.
+    let cw = match cw {
+        Some(c) => c,
+        None => {
+            return ContextWindowStatus {
+                used_percentage: None,
+                remaining_percentage: 100.0,
+                context_window_size: 0,
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                current_usage: None,
+            }
+        }
     };
 
-    if !has_context_window(value) {
-        return defaults;
-    }
+    let used_raw = cw.used_percentage;
+    let context_window_size = cw.context_window_size.unwrap_or(0);
+    let total_input_tokens = cw.total_input_tokens.unwrap_or(0);
+    let total_output_tokens = cw.total_output_tokens.unwrap_or(0);
 
-    let used_percentage = used_percentage(value);
-
-    let remaining_percentage = remaining_percentage(value)
-        .unwrap_or_else(|| used_percentage.map_or(100.0, |used| 100.0 - used));
-
-    let context_window_size = context_window_size(value);
-
-    let total_input_tokens = total_input_tokens(value);
-
-    let total_output_tokens = total_output_tokens(value);
-
-    let current_usage = current_usage(value);
-
-    // If used_percentage is null (before first API response), compute it
-    // from total_input_tokens / context_window_size. Claude Code doesn't
-    // emit used_percentage during the loading phase (skills, MCPs, CLAUDE.md)
-    // but it does report total_input_tokens which reflects system prompt size.
-    let computed_percentage = used_percentage
+    // If `used_percentage` is null (Claude Code's loading phase: skills,
+    // MCPs, CLAUDE.md), compute it from
+    // `total_input_tokens / context_window_size`. Test pins:
+    // `clamps_computed_context_window_percentage`,
+    // `handles_null_used_percentage`.
+    let computed_percentage = used_raw
         .or_else(|| {
             if context_window_size > 0 && total_input_tokens > 0 {
                 Some((total_input_tokens as f64 / context_window_size as f64) * 100.0)
@@ -134,9 +238,12 @@ fn parse_context_window(value: &Value) -> ContextWindowStatus {
         })
         .map(clamp_percentage);
 
+    // `remaining_percentage` priority: computed-from-used → raw input →
+    // 100.0 default. Test pins: `computes_remaining_from_used_when_missing`,
+    // `clamps_raw_remaining_percentage_when_no_computed_fallback`.
     let computed_remaining = computed_percentage
         .map(|used| clamp_percentage(100.0 - used))
-        .unwrap_or_else(|| clamp_percentage(remaining_percentage));
+        .unwrap_or_else(|| clamp_percentage(cw.remaining_percentage.unwrap_or(100.0)));
 
     ContextWindowStatus {
         used_percentage: computed_percentage,
@@ -144,271 +251,74 @@ fn parse_context_window(value: &Value) -> ContextWindowStatus {
         context_window_size,
         total_input_tokens,
         total_output_tokens,
-        current_usage,
+        current_usage: cw.current_usage.map(|cu| CurrentUsage {
+            input_tokens: cu.input_tokens.unwrap_or(0),
+            output_tokens: cu.output_tokens.unwrap_or(0),
+            cache_creation_input_tokens: cu.cache_creation_input_tokens.unwrap_or(0),
+            cache_read_input_tokens: cu.cache_read_input_tokens.unwrap_or(0),
+        }),
+    }
+}
+
+fn cost_from_dto(cost: Option<ClaudeCostDto>) -> CostMetrics {
+    // Block-missing → `total_cost_usd = None`. Block-present-but-field-
+    // missing → `Some(0.0)`. This is a Claude-protocol distinction the
+    // pull-style code encoded via `has_cost(...)`; preserved here with
+    // the explicit `match` on `Option<ClaudeCostDto>`. Test pins:
+    // `parse_cost_metrics_returns_none_when_cost_block_missing`,
+    // `parse_cost_metrics_returns_some_zero_when_field_missing`.
+    let cost = match cost {
+        Some(c) => c,
+        None => {
+            return CostMetrics {
+                total_cost_usd: None,
+                total_duration_ms: 0,
+                total_api_duration_ms: 0,
+                total_lines_added: 0,
+                total_lines_removed: 0,
+            }
+        }
+    };
+
+    CostMetrics {
+        total_cost_usd: Some(cost.total_cost_usd.unwrap_or(0.0)),
+        total_duration_ms: cost.total_duration_ms.unwrap_or(0),
+        total_api_duration_ms: cost.total_api_duration_ms.unwrap_or(0),
+        total_lines_added: cost.total_lines_added.unwrap_or(0),
+        total_lines_removed: cost.total_lines_removed.unwrap_or(0),
+    }
+}
+
+fn rate_limits_from_dto(rl: Option<ClaudeRateLimitsDto>) -> RateLimits {
+    let rl = rl.unwrap_or_default();
+
+    // Five-hour window defaults to (0.0, 0) when missing or null —
+    // matches `parses_minimal_json`'s expectation for an empty input.
+    let five_hour = rl
+        .five_hour
+        .map(rate_limit_info_from_dto)
+        .unwrap_or(RateLimitInfo {
+            used_percentage: 0.0,
+            resets_at: 0,
+        });
+
+    // Seven-day window: `Some(_)` when present and non-null, `None`
+    // otherwise. Test pin: `handles_null_seven_day_rate_limit`.
+    RateLimits {
+        five_hour,
+        seven_day: rl.seven_day.map(rate_limit_info_from_dto),
+    }
+}
+
+fn rate_limit_info_from_dto(dto: ClaudeRateLimitInfoDto) -> RateLimitInfo {
+    RateLimitInfo {
+        used_percentage: dto.used_percentage.unwrap_or(0.0),
+        resets_at: dto.resets_at.unwrap_or(0),
     }
 }
 
 fn clamp_percentage(value: f64) -> f64 {
     value.clamp(0.0, 100.0)
-}
-
-/// Parse cost metrics from a JSON value
-fn parse_cost_metrics(value: &Value) -> CostMetrics {
-    let defaults = CostMetrics {
-        total_cost_usd: None,
-        total_duration_ms: 0,
-        total_api_duration_ms: 0,
-        total_lines_added: 0,
-        total_lines_removed: 0,
-    };
-
-    if !has_cost(value) {
-        return defaults;
-    }
-
-    CostMetrics {
-        total_cost_usd: Some(total_cost_usd(value)),
-        total_duration_ms: total_duration_ms(value),
-        total_api_duration_ms: total_api_duration_ms(value),
-        total_lines_added: total_lines_added(value),
-        total_lines_removed: total_lines_removed(value),
-    }
-}
-
-/// Parse rate limits from a JSON value
-fn parse_rate_limits(value: &Value) -> RateLimits {
-    let default_info = RateLimitInfo {
-        used_percentage: 0.0,
-        resets_at: 0,
-    };
-
-    let defaults = RateLimits {
-        five_hour: default_info.clone(),
-        seven_day: None,
-    };
-
-    if !has_rate_limits(value) {
-        return defaults;
-    }
-
-    let five_hour = five_hour_rate_limit(value).unwrap_or(RateLimitInfo {
-        used_percentage: 0.0,
-        resets_at: 0,
-    });
-
-    let seven_day = seven_day_rate_limit(value);
-
-    RateLimits {
-        five_hour,
-        seven_day,
-    }
-}
-
-fn model_id(value: &Value) -> String {
-    value
-        .get("model")
-        .and_then(|model| model.get("id"))
-        .and_then(Value::as_str)
-        .unwrap_or("unknown")
-        .to_string()
-}
-
-fn model_display_name(value: &Value, model_id: &str) -> String {
-    value
-        .get("model")
-        .and_then(|model| model.get("display_name"))
-        .and_then(Value::as_str)
-        .unwrap_or(model_id)
-        .to_string()
-}
-
-fn agent_session_id(value: &Value) -> String {
-    value
-        .get("session_id")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string()
-}
-
-fn version(value: &Value) -> String {
-    value
-        .get("version")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string()
-}
-
-fn transcript_path(value: &Value) -> Option<String> {
-    value
-        .get("transcript_path")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-}
-
-fn has_context_window(value: &Value) -> bool {
-    value.get("context_window").is_some_and(Value::is_object)
-}
-
-fn used_percentage(value: &Value) -> Option<f64> {
-    value
-        .get("context_window")
-        .and_then(|context_window| context_window.get("used_percentage"))
-        .and_then(Value::as_f64)
-}
-
-fn remaining_percentage(value: &Value) -> Option<f64> {
-    value
-        .get("context_window")
-        .and_then(|context_window| context_window.get("remaining_percentage"))
-        .and_then(Value::as_f64)
-}
-
-fn context_window_size(value: &Value) -> u64 {
-    value
-        .get("context_window")
-        .and_then(|context_window| context_window.get("context_window_size"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
-}
-
-fn total_input_tokens(value: &Value) -> u64 {
-    value
-        .get("context_window")
-        .and_then(|context_window| context_window.get("total_input_tokens"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
-}
-
-fn total_output_tokens(value: &Value) -> u64 {
-    value
-        .get("context_window")
-        .and_then(|context_window| context_window.get("total_output_tokens"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
-}
-
-fn current_usage(value: &Value) -> Option<CurrentUsage> {
-    has_current_usage(value).then(|| CurrentUsage {
-        input_tokens: u64_or(
-            value,
-            &["context_window", "current_usage", "input_tokens"],
-            0,
-        ),
-        output_tokens: u64_or(
-            value,
-            &["context_window", "current_usage", "output_tokens"],
-            0,
-        ),
-        cache_creation_input_tokens: u64_or(
-            value,
-            &[
-                "context_window",
-                "current_usage",
-                "cache_creation_input_tokens",
-            ],
-            0,
-        ),
-        cache_read_input_tokens: u64_or(
-            value,
-            &["context_window", "current_usage", "cache_read_input_tokens"],
-            0,
-        ),
-    })
-}
-
-fn has_current_usage(value: &Value) -> bool {
-    value
-        .get("context_window")
-        .and_then(|context_window| context_window.get("current_usage"))
-        .is_some_and(Value::is_object)
-}
-
-fn has_cost(value: &Value) -> bool {
-    value.get("cost").is_some_and(Value::is_object)
-}
-
-fn total_cost_usd(value: &Value) -> f64 {
-    value
-        .get("cost")
-        .and_then(|cost| cost.get("total_cost_usd"))
-        .and_then(Value::as_f64)
-        .unwrap_or(0.0)
-}
-
-fn total_duration_ms(value: &Value) -> u64 {
-    value
-        .get("cost")
-        .and_then(|cost| cost.get("total_duration_ms"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
-}
-
-fn total_api_duration_ms(value: &Value) -> u64 {
-    value
-        .get("cost")
-        .and_then(|cost| cost.get("total_api_duration_ms"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
-}
-
-fn total_lines_added(value: &Value) -> u64 {
-    value
-        .get("cost")
-        .and_then(|cost| cost.get("total_lines_added"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
-}
-
-fn total_lines_removed(value: &Value) -> u64 {
-    value
-        .get("cost")
-        .and_then(|cost| cost.get("total_lines_removed"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
-}
-
-fn has_rate_limits(value: &Value) -> bool {
-    value.get("rate_limits").is_some_and(Value::is_object)
-}
-
-fn five_hour_rate_limit(value: &Value) -> Option<RateLimitInfo> {
-    has_rate_limit_window(value, "five_hour").then(|| RateLimitInfo {
-        used_percentage: f64_or(value, &["rate_limits", "five_hour", "used_percentage"], 0.0),
-        resets_at: u64_or(value, &["rate_limits", "five_hour", "resets_at"], 0),
-    })
-}
-
-fn seven_day_rate_limit(value: &Value) -> Option<RateLimitInfo> {
-    has_rate_limit_window(value, "seven_day").then(|| RateLimitInfo {
-        used_percentage: f64_or(value, &["rate_limits", "seven_day", "used_percentage"], 0.0),
-        resets_at: u64_or(value, &["rate_limits", "seven_day", "resets_at"], 0),
-    })
-}
-
-fn has_rate_limit_window(value: &Value, window: &str) -> bool {
-    value
-        .get("rate_limits")
-        .and_then(|rate_limits| rate_limits.get(window))
-        .is_some_and(Value::is_object)
-}
-
-fn value_at<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
-    path.iter()
-        .try_fold(value, |current, key| current.get(*key))
-}
-
-fn f64_at(value: &Value, path: &[&str]) -> Option<f64> {
-    value_at(value, path).and_then(Value::as_f64)
-}
-
-fn u64_or(value: &Value, path: &[&str], default: u64) -> u64 {
-    value_at(value, path)
-        .and_then(Value::as_u64)
-        .unwrap_or(default)
-}
-
-fn f64_or(value: &Value, path: &[&str], default: f64) -> f64 {
-    f64_at(value, path).unwrap_or(default)
 }
 
 #[cfg(test)]
@@ -606,9 +516,23 @@ mod tests {
 
     #[test]
     fn rejects_non_object_json() {
+        // Step A-status: typed-DTO migration dropped the hand-written
+        // `is_object` precheck. A non-object top-level value now fails
+        // at serde's `expected struct` step rather than at our former
+        // `"not an object"` Err. Behavior preserved (Err), error text
+        // changes from `"statusline JSON is not an object"` to
+        // `"invalid JSON: invalid type: integer ..., expected struct
+        // ClaudeStatusDto"`. No production caller string-matches on
+        // either form; the assertion below pins the `invalid JSON`
+        // prefix we still own.
         let result = parse_statusline("pty-7", "42");
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not an object"));
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("invalid JSON"),
+            "expected the `invalid JSON:` prefix, got: {}",
+            err
+        );
     }
 
     #[test]

--- a/crates/backend/src/agent/adapter/codex/parser.rs
+++ b/crates/backend/src/agent/adapter/codex/parser.rs
@@ -27,7 +27,7 @@
 
 use serde::Deserialize;
 
-use super::super::serde_helpers::{lenient_f64, lenient_string, lenient_u64};
+use super::super::serde_helpers::{lenient_f64, lenient_object, lenient_string, lenient_u64};
 use crate::agent::adapter::types::ParsedStatus;
 use crate::agent::types::{
     AgentStatusEvent, ContextWindowStatus, CostMetrics, CurrentUsage, RateLimitInfo, RateLimits,
@@ -129,14 +129,17 @@ enum EventMsgPayloadDto {
     },
     TokenCount {
         /// Critical for the v4-frozen plan's R2.4 invariant: when this
-        /// is `None` (either field missing OR JSON null), the fold
-        /// MUST NOT clear `state.last_token_count_info`. The
+        /// is `None` (either field missing OR JSON null OR wrong-typed),
+        /// the fold MUST NOT clear `state.last_token_count_info`. The
         /// regression test `token_count_info_null_preserves_prior_context`
         /// fails if a future contributor changes the fold to overwrite
-        /// on `None`.
-        #[serde(default)]
+        /// on `None`. `lenient_object` (round-1 fix) widens "None" to
+        /// also include the wrong-typed case (e.g. `"info": 1`) — a
+        /// single malformed sub-block no longer kills the whole
+        /// `event_msg` line. Connector P2 round-1 finding.
+        #[serde(default, deserialize_with = "lenient_object")]
         info: Option<TokenCountInfoDto>,
-        #[serde(default)]
+        #[serde(default, deserialize_with = "lenient_object")]
         rate_limits: Option<RateLimitsPayloadDto>,
     },
     #[serde(other)]
@@ -145,7 +148,7 @@ enum EventMsgPayloadDto {
 
 #[derive(Deserialize, Default)]
 struct TokenCountInfoDto {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_object")]
     last_token_usage: Option<LastTokenUsageDto>,
     #[serde(default, deserialize_with = "lenient_u64")]
     model_context_window: Option<u64>,
@@ -165,9 +168,9 @@ struct LastTokenUsageDto {
 
 #[derive(Deserialize, Default)]
 struct RateLimitsPayloadDto {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_object")]
     primary: Option<RateLimitWindowDto>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_object")]
     secondary: Option<RateLimitWindowDto>,
 }
 
@@ -584,6 +587,43 @@ mod tests {
                 std::mem::discriminant(&other),
             ),
         }
+    }
+
+    /// Round-1 upsource fix (codex connector P2): a `token_count`
+    /// event with a wrong-typed `info` or `rate_limits` sub-block
+    /// must NOT cause `parse_rollout` to drop the whole event_msg
+    /// line. Before `lenient_object` landed, a strict struct
+    /// deserialize on `"info": 1` would fail the line and
+    /// `parse_rollout` would `log::warn!` + skip it, losing whatever
+    /// token-state or rate-limit-state context the line still
+    /// carried.
+    ///
+    /// Setup: feed (1) a known-good `token_count` to seed state, then
+    /// (2) a `token_count` with wrong-typed `info` paired with a
+    /// VALID `rate_limits`. The valid `rate_limits` sub-block must
+    /// still be folded; the prior `last_token_count_info` must be
+    /// preserved (Some-only invariant).
+    #[test]
+    fn wrong_typed_token_count_info_preserves_prior_state_and_sibling_rate_limits() {
+        let raw = r#"{"timestamp":"...","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"output_tokens":200,"cached_input_tokens":0,"total_tokens":1200},"model_context_window":200000}}}
+{"timestamp":"...","type":"event_msg","payload":{"type":"token_count","info":1,"rate_limits":{"primary":{"used_percent":42.5,"resets_at":1776000000}}}}
+"#;
+        let parsed = parse_rollout("pty-wrong-info", raw)
+            .expect("wrong-typed sub-block must NOT drop the line");
+        // Prior token-state preserved (the wrong-typed `info` was
+        // treated as None by `lenient_object`, then ignored by the
+        // Some-only fold).
+        assert_eq!(parsed.event.context_window.total_input_tokens, 1000);
+        assert_eq!(parsed.event.context_window.total_output_tokens, 200);
+        // Sibling rate_limits sub-block on the SAME malformed line
+        // still folded — proving per-field degradation, not
+        // whole-line drop.
+        assert!(
+            (parsed.event.rate_limits.five_hour.used_percentage - 42.5).abs() < f64::EPSILON,
+            "rate_limits.primary.used_percent should have folded; got {}",
+            parsed.event.rate_limits.five_hour.used_percentage
+        );
+        assert_eq!(parsed.event.rate_limits.five_hour.resets_at, 1776000000);
     }
 
     // Step 0c: the former `includes_transcript_path_when_provided` test

--- a/crates/backend/src/agent/adapter/codex/parser.rs
+++ b/crates/backend/src/agent/adapter/codex/parser.rs
@@ -1,10 +1,37 @@
 //! Parser for Codex rollout JSONL files.
+//!
+//! Step A-status of the v4-frozen refactor plan (#246) replaced the
+//! former `serde_json::Value` pull-style fold with typed DTOs. Each
+//! rollout line deserializes through an internally-tagged enum
+//! (`CodexRolloutLine` on the outer `type` discriminator), then a
+//! second internally-tagged enum for `event_msg.payload` sub-types.
+//! Per-field `Option<T> + #[serde(default)]` + `lenient_*`
+//! deserializers preserve the pre-A-status leniency: a wrong-typed
+//! field or an unknown event tag does NOT poison the rest of the
+//! document.
+//!
+//! The two load-bearing invariants from the v4-frozen plan are
+//! structurally encoded by the DTOs:
+//!
+//! 1. **`token_count.info: Option<TokenCountInfoDto>`** — the fold
+//!    updates `state.last_token_count_info` ONLY when the deserialized
+//!    `info` is `Some(_)`. A `token_count` event with `info: null` or
+//!    `info: <missing>` preserves prior context (the
+//!    `token_count_info_null_preserves_prior_context` regression
+//!    test pins this).
+//!
+//! 2. **Unknown event tags fall through to `#[serde(other)]`** —
+//!    silently ignored, never an Err. The pre-A-status `Value`-based
+//!    matcher had the same behavior; the test
+//!    `unknown_event_type_ignored_without_error` pins it.
 
+use serde::Deserialize;
+
+use super::super::serde_helpers::{lenient_f64, lenient_string, lenient_u64};
 use crate::agent::adapter::types::ParsedStatus;
 use crate::agent::types::{
     AgentStatusEvent, ContextWindowStatus, CostMetrics, CurrentUsage, RateLimitInfo, RateLimits,
 };
-use serde_json::Value;
 
 pub fn parse_rollout(session_id: &str, raw: &str) -> Result<ParsedStatus, String> {
     let mut state = CodexFoldState::default();
@@ -20,8 +47,11 @@ pub fn parse_rollout(session_id: &str, raw: &str) -> Result<ParsedStatus, String
             continue;
         }
 
-        match serde_json::from_str::<Value>(line) {
-            Ok(value) => fold_event(&mut state, &value),
+        // Per-line deserialize: a single malformed line is logged and
+        // skipped; the rest of the document continues. Test pin:
+        // `malformed_mid_line_skipped_with_warn`.
+        match serde_json::from_str::<CodexRolloutLine>(line) {
+            Ok(parsed) => fold_event(&mut state, parsed),
             Err(_) => log::warn!(
                 "codex: skipping malformed rollout line for sid={}",
                 session_id
@@ -38,6 +68,118 @@ pub fn parse_rollout(session_id: &str, raw: &str) -> Result<ParsedStatus, String
         event: state.into_event(session_id),
     })
 }
+
+// -------------------------- DTO layer --------------------------
+
+/// One JSONL line from the rollout stream. The outer
+/// `#[serde(tag = "type")]` dispatches on the `"type"` discriminator;
+/// `#[serde(other)]` catches unknown / forward-compatible tags
+/// without erroring.
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum CodexRolloutLine {
+    SessionMeta {
+        #[serde(default)]
+        payload: Option<SessionMetaPayloadDto>,
+    },
+    TurnContext {
+        #[serde(default)]
+        payload: Option<TurnContextPayloadDto>,
+    },
+    EventMsg {
+        #[serde(default)]
+        payload: Option<EventMsgPayloadDto>,
+    },
+    /// Forward-compatible catch-all for unknown event kinds (and the
+    /// existing `response_item`, `user_message`, etc. shapes the
+    /// status decoder doesn't fold). `#[serde(other)]` requires a
+    /// unit variant — by design.
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize, Default)]
+struct SessionMetaPayloadDto {
+    #[serde(default, deserialize_with = "lenient_string")]
+    id: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    cli_version: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct TurnContextPayloadDto {
+    #[serde(default, deserialize_with = "lenient_string")]
+    model: Option<String>,
+}
+
+/// `event_msg.payload` is itself an internally-tagged variant. The
+/// status decoder cares about three of these (`task_started`,
+/// `task_complete`, `token_count`); everything else falls through to
+/// `Unknown`.
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum EventMsgPayloadDto {
+    TaskStarted {
+        #[serde(default, deserialize_with = "lenient_u64")]
+        model_context_window: Option<u64>,
+    },
+    TaskComplete {
+        #[serde(default, deserialize_with = "lenient_u64")]
+        duration_ms: Option<u64>,
+    },
+    TokenCount {
+        /// Critical for the v4-frozen plan's R2.4 invariant: when this
+        /// is `None` (either field missing OR JSON null), the fold
+        /// MUST NOT clear `state.last_token_count_info`. The
+        /// regression test `token_count_info_null_preserves_prior_context`
+        /// fails if a future contributor changes the fold to overwrite
+        /// on `None`.
+        #[serde(default)]
+        info: Option<TokenCountInfoDto>,
+        #[serde(default)]
+        rate_limits: Option<RateLimitsPayloadDto>,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize, Default)]
+struct TokenCountInfoDto {
+    #[serde(default)]
+    last_token_usage: Option<LastTokenUsageDto>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    model_context_window: Option<u64>,
+}
+
+#[derive(Deserialize, Default)]
+struct LastTokenUsageDto {
+    #[serde(default, deserialize_with = "lenient_u64")]
+    input_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    output_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    cached_input_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    total_tokens: Option<u64>,
+}
+
+#[derive(Deserialize, Default)]
+struct RateLimitsPayloadDto {
+    #[serde(default)]
+    primary: Option<RateLimitWindowDto>,
+    #[serde(default)]
+    secondary: Option<RateLimitWindowDto>,
+}
+
+#[derive(Deserialize, Default)]
+struct RateLimitWindowDto {
+    #[serde(default, deserialize_with = "lenient_f64")]
+    used_percent: Option<f64>,
+    #[serde(default, deserialize_with = "lenient_u64")]
+    resets_at: Option<u64>,
+}
+
+// -------------------------- Fold state --------------------------
 
 #[derive(Default)]
 struct CodexFoldState {
@@ -144,123 +286,83 @@ impl CodexFoldState {
     }
 }
 
-fn fold_event(state: &mut CodexFoldState, value: &Value) {
-    match value.get("type").and_then(Value::as_str) {
-        Some("session_meta") => {
-            absorb_session_meta(state, value.get("payload").unwrap_or(&Value::Null))
-        }
-        Some("turn_context") => {
-            absorb_turn_context(state, value.get("payload").unwrap_or(&Value::Null))
-        }
-        Some("event_msg") => {
-            let payload = value.get("payload").unwrap_or(&Value::Null);
-            match payload.get("type").and_then(Value::as_str) {
-                Some("task_started") => absorb_task_started(state, payload),
-                Some("task_complete") => absorb_task_complete(state, payload),
-                Some("token_count") => absorb_token_count(state, payload),
-                _ => {}
+fn fold_event(state: &mut CodexFoldState, line: CodexRolloutLine) {
+    match line {
+        CodexRolloutLine::SessionMeta { payload } => {
+            if let Some(p) = payload {
+                if let Some(id) = p.id {
+                    state.agent_session_id = id;
+                }
+                if let Some(version) = p.cli_version {
+                    state.cli_version = version;
+                }
             }
         }
-        _ => {}
-    }
-}
-
-fn absorb_session_meta(state: &mut CodexFoldState, payload: &Value) {
-    if let Some(id) = payload.get("id").and_then(Value::as_str) {
-        state.agent_session_id = id.to_string();
-    }
-    if let Some(version) = payload.get("cli_version").and_then(Value::as_str) {
-        state.cli_version = version.to_string();
-    }
-}
-
-fn absorb_turn_context(state: &mut CodexFoldState, payload: &Value) {
-    if let Some(model) = payload.get("model").and_then(Value::as_str) {
-        state.model = model.to_string();
-    }
-}
-
-fn absorb_task_started(state: &mut CodexFoldState, payload: &Value) {
-    if let Some(size) = payload.get("model_context_window").and_then(Value::as_u64) {
-        state.last_task_started_context_window = Some(size);
-    }
-}
-
-fn absorb_task_complete(state: &mut CodexFoldState, payload: &Value) {
-    if let Some(duration_ms) = payload.get("duration_ms").and_then(Value::as_u64) {
-        state.total_duration_ms = state.total_duration_ms.saturating_add(duration_ms);
-    }
-}
-
-fn absorb_token_count(state: &mut CodexFoldState, payload: &Value) {
-    if let Some(info) = payload.get("info") {
-        if !info.is_null() {
-            state.last_token_count_info = Some(parse_token_count_info(info));
+        CodexRolloutLine::TurnContext { payload } => {
+            if let Some(p) = payload {
+                if let Some(model) = p.model {
+                    state.model = model;
+                }
+            }
         }
-    }
-
-    if let Some(rate_limits) = payload.get("rate_limits") {
-        if !rate_limits.is_null() {
-            state.last_rate_limits = Some(parse_rate_limits(rate_limits));
-        }
+        CodexRolloutLine::EventMsg { payload } => match payload {
+            Some(EventMsgPayloadDto::TaskStarted {
+                model_context_window,
+            }) => {
+                if let Some(size) = model_context_window {
+                    state.last_task_started_context_window = Some(size);
+                }
+            }
+            Some(EventMsgPayloadDto::TaskComplete { duration_ms }) => {
+                if let Some(ms) = duration_ms {
+                    state.total_duration_ms = state.total_duration_ms.saturating_add(ms);
+                }
+            }
+            Some(EventMsgPayloadDto::TokenCount { info, rate_limits }) => {
+                // R2.4 invariant: Some-only update. A `token_count`
+                // event whose `info` is null / missing preserves prior
+                // state. Test pin:
+                // `token_count_info_null_preserves_prior_context`.
+                if let Some(info) = info {
+                    state.last_token_count_info = Some(token_count_info_from_dto(info));
+                }
+                if let Some(rl) = rate_limits {
+                    state.last_rate_limits = Some(rate_limits_from_dto(rl));
+                }
+            }
+            Some(EventMsgPayloadDto::Unknown) | None => {}
+        },
+        CodexRolloutLine::Unknown => {}
     }
 }
 
-fn parse_token_count_info(info: &Value) -> TokenCountInfo {
-    let last = info.get("last_token_usage").unwrap_or(&Value::Null);
-
+fn token_count_info_from_dto(dto: TokenCountInfoDto) -> TokenCountInfo {
+    let last = dto.last_token_usage.unwrap_or_default();
     TokenCountInfo {
-        last_input_tokens: last
-            .get("input_tokens")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-        last_output_tokens: last
-            .get("output_tokens")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-        last_cached_input_tokens: last
-            .get("cached_input_tokens")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-        last_total_tokens: last
-            .get("total_tokens")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-        model_context_window: info
-            .get("model_context_window")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
+        last_input_tokens: last.input_tokens.unwrap_or(0),
+        last_output_tokens: last.output_tokens.unwrap_or(0),
+        last_cached_input_tokens: last.cached_input_tokens.unwrap_or(0),
+        last_total_tokens: last.total_tokens.unwrap_or(0),
+        model_context_window: dto.model_context_window.unwrap_or(0),
     }
 }
 
-fn parse_rate_limits(value: &Value) -> RateLimits {
-    let primary = value.get("primary").unwrap_or(&Value::Null);
+fn rate_limits_from_dto(dto: RateLimitsPayloadDto) -> RateLimits {
+    // Pre-A-status default behavior: missing/null `primary` yields a
+    // (0.0, 0) `RateLimitInfo`. The DTO field is `Option<...>` so
+    // `unwrap_or_default()` gives us the same shape.
+    let primary = dto.primary.unwrap_or_default();
     let five_hour = RateLimitInfo {
-        used_percentage: primary
-            .get("used_percent")
-            .and_then(Value::as_f64)
-            .unwrap_or(0.0),
-        resets_at: primary
-            .get("resets_at")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
+        used_percentage: primary.used_percent.unwrap_or(0.0),
+        resets_at: primary.resets_at.unwrap_or(0),
     };
 
-    let seven_day = value.get("secondary").and_then(|secondary| {
-        if secondary.is_null() {
-            None
-        } else {
-            Some(RateLimitInfo {
-                used_percentage: secondary
-                    .get("used_percent")
-                    .and_then(Value::as_f64)
-                    .unwrap_or(0.0),
-                resets_at: secondary
-                    .get("resets_at")
-                    .and_then(Value::as_u64)
-                    .unwrap_or(0),
-            })
-        }
+    // `secondary` distinguishes null/missing → `None` from
+    // present-with-fields → `Some(_)`. The DTO's
+    // `secondary: Option<RateLimitWindowDto>` does that directly.
+    let seven_day = dto.secondary.map(|s| RateLimitInfo {
+        used_percentage: s.used_percent.unwrap_or(0.0),
+        resets_at: s.resets_at.unwrap_or(0),
     });
 
     RateLimits {

--- a/crates/backend/src/agent/adapter/codex/parser.rs
+++ b/crates/backend/src/agent/adapter/codex/parser.rs
@@ -523,6 +523,28 @@ mod tests {
         assert_eq!(parsed.event.model_id, "unknown");
     }
 
+    /// Step A-status: the inner `EventMsgPayloadDto::Unknown` branch
+    /// (`#[serde(other)]`) covers forward-compatible `event_msg`
+    /// sub-types (e.g. when Codex grows a new payload kind alongside
+    /// `task_started` / `task_complete` / `token_count`). The outer
+    /// `unknown_event_type_ignored_without_error` only exercises the
+    /// outer `#[serde(other)]`; this test pins the inner one
+    /// independently so a future contributor cannot break the inner
+    /// catch-all without a failing test (codex review round 1, LOW).
+    #[test]
+    fn unknown_event_msg_payload_type_ignored_without_error() {
+        // The `task_complete` line that follows must still be folded —
+        // proving the unknown-payload line did NOT poison the state
+        // fold (a regression would either error the whole document or
+        // mutate state in a way that breaks `total_duration_ms`).
+        let raw = r#"{"timestamp":"...","type":"event_msg","payload":{"type":"future_payload_kind","extra":42}}
+{"timestamp":"...","type":"event_msg","payload":{"type":"task_complete","duration_ms":5000}}
+"#;
+        let parsed = parse_rollout("pty-unknown-payload", raw)
+            .expect("unknown event_msg payload type folds as no-op");
+        assert_eq!(parsed.event.cost.total_duration_ms, 5000);
+    }
+
     // Step 0c: the former `includes_transcript_path_when_provided` test
     // was removed — `parse_rollout` no longer takes (or surfaces) a
     // transcript path. The adapter-level

--- a/crates/backend/src/agent/adapter/codex/parser.rs
+++ b/crates/backend/src/agent/adapter/codex/parser.rs
@@ -525,24 +525,65 @@ mod tests {
 
     /// Step A-status: the inner `EventMsgPayloadDto::Unknown` branch
     /// (`#[serde(other)]`) covers forward-compatible `event_msg`
-    /// sub-types (e.g. when Codex grows a new payload kind alongside
-    /// `task_started` / `task_complete` / `token_count`). The outer
-    /// `unknown_event_type_ignored_without_error` only exercises the
-    /// outer `#[serde(other)]`; this test pins the inner one
-    /// independently so a future contributor cannot break the inner
-    /// catch-all without a failing test (codex review round 1, LOW).
+    /// sub-types. This test pins the BEHAVIOR (an unknown-payload line
+    /// doesn't poison the rest of the document) — paired with the
+    /// DTO-level
+    /// `inner_event_msg_unknown_payload_deserializes_to_unknown_variant`
+    /// below which pins the MECHANISM (deserialization goes through
+    /// `EventMsgPayloadDto::Unknown`, not through the per-line
+    /// deserialize-skip catch).
+    ///
+    /// Codex review round 2 (LOW): this test alone is NOT enough —
+    /// removing `#[serde(other)]` would make the first line fail to
+    /// deserialize, `parse_rollout` would skip it, and the second
+    /// line's `task_complete` would still set `total_duration_ms ==
+    /// 5000`. The DTO-level test below closes that loophole.
     #[test]
     fn unknown_event_msg_payload_type_ignored_without_error() {
-        // The `task_complete` line that follows must still be folded —
-        // proving the unknown-payload line did NOT poison the state
-        // fold (a regression would either error the whole document or
-        // mutate state in a way that breaks `total_duration_ms`).
         let raw = r#"{"timestamp":"...","type":"event_msg","payload":{"type":"future_payload_kind","extra":42}}
 {"timestamp":"...","type":"event_msg","payload":{"type":"task_complete","duration_ms":5000}}
 "#;
         let parsed = parse_rollout("pty-unknown-payload", raw)
             .expect("unknown event_msg payload type folds as no-op");
         assert_eq!(parsed.event.cost.total_duration_ms, 5000);
+    }
+
+    /// Step A-status round 2: pin the OUTER `CodexRolloutLine::Unknown`
+    /// branch at the DTO level. If `#[serde(other)]` is removed from
+    /// the outer enum, `from_str::<CodexRolloutLine>` errors and the
+    /// `.expect(...)` below panics — making the regression loud rather
+    /// than letting it hide behind `parse_rollout`'s per-line skip.
+    #[test]
+    fn outer_unknown_type_deserializes_to_unknown_variant() {
+        let line = r#"{"timestamp":"...","type":"future_event_kind","payload":{"hello":"world"}}"#;
+        let parsed: CodexRolloutLine = serde_json::from_str(line)
+            .expect("outer #[serde(other)] catches unknown type");
+        assert!(
+            matches!(parsed, CodexRolloutLine::Unknown),
+            "expected CodexRolloutLine::Unknown for an unknown outer type"
+        );
+    }
+
+    /// Step A-status round 2: pin the INNER `EventMsgPayloadDto::Unknown`
+    /// branch at the DTO level. If `#[serde(other)]` is removed from
+    /// the inner enum, `from_str::<CodexRolloutLine>` errors when it
+    /// reaches the `payload`, and the `.expect(...)` below panics —
+    /// distinguishing the `#[serde(other)]` catch from the per-line
+    /// deserialize-skip catch in `parse_rollout`.
+    #[test]
+    fn inner_event_msg_unknown_payload_deserializes_to_unknown_variant() {
+        let line = r#"{"timestamp":"...","type":"event_msg","payload":{"type":"future_payload_kind","extra":42}}"#;
+        let parsed: CodexRolloutLine = serde_json::from_str(line)
+            .expect("inner #[serde(other)] catches unknown payload type");
+        match parsed {
+            CodexRolloutLine::EventMsg {
+                payload: Some(EventMsgPayloadDto::Unknown),
+            } => {}
+            other => panic!(
+                "expected EventMsg with EventMsgPayloadDto::Unknown payload, got: {:?}",
+                std::mem::discriminant(&other),
+            ),
+        }
     }
 
     // Step 0c: the former `includes_transcript_path_when_provided` test

--- a/crates/backend/src/agent/adapter/mod.rs
+++ b/crates/backend/src/agent/adapter/mod.rs
@@ -8,6 +8,7 @@ mod attach;
 pub mod base;
 pub mod claude_code;
 pub mod codex;
+mod serde_helpers;
 pub mod types;
 
 pub(crate) use attach::AttachContext;

--- a/crates/backend/src/agent/adapter/serde_helpers.rs
+++ b/crates/backend/src/agent/adapter/serde_helpers.rs
@@ -79,6 +79,37 @@ where
         .map(str::to_string))
 }
 
+/// Deserialize an `Option<T>` nested-struct field with wrong-type
+/// tolerance.
+///
+/// Returns `Ok(None)` when the value is missing, `null`, OR any
+/// non-object JSON type (an array, number, string, or bool sitting
+/// where the schema expects an object). Returns `Ok(Some(T))` when
+/// the value is a JSON object that successfully decodes into `T` —
+/// which itself happens via `serde_json::from_value::<T>(value)`,
+/// relying on `T`'s leaf fields to be `lenient_*`-decorated for
+/// inner wrong-type tolerance. If the inner `from_value` fails (e.g.
+/// a leaf that should be `lenient_*` was left strict), we still
+/// return `Ok(None)` — consistent with the scalar helpers' "wrong
+/// shape becomes a missing block" contract.
+///
+/// Mirrors the pre-A-status `has_<block>(value).then(|| ...)` /
+/// `is_some_and(Value::is_object)` guards that fell back to per-block
+/// defaults when an outer block was the wrong shape (rather than
+/// erroring the whole document). Closes the round-1 Claude review
+/// MEDIUM + codex connector P1/P2 on PR #257.
+pub(super) fn lenient_object<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: serde::de::DeserializeOwned,
+{
+    let value = Value::deserialize(deserializer)?;
+    if !value.is_object() {
+        return Ok(None);
+    }
+    Ok(serde_json::from_value::<T>(value).ok())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -156,5 +187,69 @@ mod tests {
         assert_eq!(p.count, None);
         assert_eq!(p.ratio, Some(0.5));
         assert_eq!(p.label.as_deref(), Some("ok"));
+    }
+
+    // ----- lenient_object tests -----
+
+    #[derive(Deserialize, Debug, PartialEq, Default)]
+    struct Inner {
+        #[serde(default, deserialize_with = "lenient_u64")]
+        n: Option<u64>,
+    }
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct ObjectProbe {
+        #[serde(default, deserialize_with = "lenient_object")]
+        block: Option<Inner>,
+    }
+
+    #[test]
+    fn lenient_object_accepts_objects_rejects_others() {
+        // Happy path: an object decodes to Some(_).
+        let p: ObjectProbe =
+            serde_json::from_str(r#"{"block": {"n": 7}}"#).expect("object ok");
+        assert_eq!(p.block, Some(Inner { n: Some(7) }));
+
+        // Empty object → Some(default) (the block IS present).
+        let p: ObjectProbe = serde_json::from_str(r#"{"block": {}}"#).expect("empty object ok");
+        assert_eq!(p.block, Some(Inner { n: None }));
+
+        // null → None (treated identical to missing — same as the
+        // scalar helpers).
+        let p: ObjectProbe = serde_json::from_str(r#"{"block": null}"#).expect("null ok→None");
+        assert_eq!(p.block, None);
+
+        // Wrong types → None (this is the round-1 fix point — without
+        // `lenient_object` these would have errored the whole parse).
+        let p: ObjectProbe = serde_json::from_str(r#"{"block": 42}"#).expect("integer ok→None");
+        assert_eq!(p.block, None);
+
+        let p: ObjectProbe = serde_json::from_str(r#"{"block": []}"#).expect("array ok→None");
+        assert_eq!(p.block, None);
+
+        let p: ObjectProbe =
+            serde_json::from_str(r#"{"block": "string"}"#).expect("string ok→None");
+        assert_eq!(p.block, None);
+
+        let p: ObjectProbe = serde_json::from_str(r#"{}"#).expect("missing ok→None");
+        assert_eq!(p.block, None);
+    }
+
+    /// Round-1 fix invariant: a wrong-typed nested block does NOT
+    /// poison sibling fields. Mirror of the scalar-tolerance test
+    /// above, but for the new `lenient_object` helper.
+    #[test]
+    fn lenient_object_wrong_typed_block_does_not_poison_siblings() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct MixedProbe {
+            #[serde(default, deserialize_with = "lenient_object")]
+            block: Option<Inner>,
+            #[serde(default, deserialize_with = "lenient_u64")]
+            sibling: Option<u64>,
+        }
+        let p: MixedProbe =
+            serde_json::from_str(r#"{"block": 42, "sibling": 99}"#).expect("partial degrade");
+        assert_eq!(p.block, None);
+        assert_eq!(p.sibling, Some(99));
     }
 }

--- a/crates/backend/src/agent/adapter/serde_helpers.rs
+++ b/crates/backend/src/agent/adapter/serde_helpers.rs
@@ -1,0 +1,160 @@
+//! Wrong-type-tolerant serde deserializers shared across adapter DTOs.
+//!
+//! Step A-status of the v4-frozen refactor plan (#246) migrates Claude
+//! and Codex parsers off `serde_json::Value` pull-style extraction and
+//! onto typed DTOs. The old pull-style code was unintentionally lenient:
+//! a wrong-typed field (e.g. `"42"` where an `u64` was expected) yielded
+//! `Value::as_u64() == None` → field-level fallback to `0`, while the
+//! rest of the document continued parsing.
+//!
+//! Strict `#[derive(Deserialize)]` does NOT have that property — a
+//! single wrong-typed field fails the whole document. The helpers in
+//! this module restore the per-field tolerance by deserializing to
+//! `Value` first, then asking the value to coerce. A wrong type
+//! produces `Ok(None)`, NOT `Err(_)`. The caller maps `None` to a
+//! domain-specific default (usually `0` for token counts /
+//! durations).
+//!
+//! Use via the `deserialize_with` attribute, paired with
+//! `#[serde(default)]` so missing / `null` reach the same `None`
+//! branch:
+//!
+//! ```ignore
+//! #[derive(Deserialize)]
+//! struct Foo {
+//!     #[serde(default, deserialize_with = "super::serde_helpers::lenient_u64")]
+//!     count: Option<u64>,
+//! }
+//! ```
+
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
+
+/// Deserialize an `Option<u64>` field with wrong-type tolerance.
+///
+/// Returns `Ok(None)` when the value is missing, `null`, a non-integer
+/// number, a string, an array, or any other JSON type that cannot
+/// represent a `u64`. Returns `Ok(Some(_))` when the value is a JSON
+/// integer that fits in `u64`.
+///
+/// Mirrors the pre-A-status behavior of
+/// `value.get(key).and_then(Value::as_u64)`.
+pub(super) fn lenient_u64<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Value::deserialize(deserializer)?.as_u64())
+}
+
+/// Deserialize an `Option<f64>` field with wrong-type tolerance.
+///
+/// Returns `Ok(None)` for missing / `null` / non-numeric / non-finite
+/// inputs. Returns `Ok(Some(_))` for any JSON number (including
+/// integers, which `serde_json` coerces to `f64` lossily for large
+/// magnitudes — same coercion `Value::as_f64` already applies).
+///
+/// Mirrors the pre-A-status behavior of
+/// `value.get(key).and_then(Value::as_f64)`.
+pub(super) fn lenient_f64<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Value::deserialize(deserializer)?.as_f64())
+}
+
+/// Deserialize an `Option<String>` field with wrong-type tolerance.
+///
+/// Returns `Ok(None)` when the value is missing, `null`, a number, an
+/// array, or any non-string JSON type. Returns `Ok(Some(_))` for
+/// strings.
+///
+/// Mirrors the pre-A-status behavior of
+/// `value.get(key).and_then(Value::as_str).map(str::to_string)`.
+pub(super) fn lenient_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Value::deserialize(deserializer)?
+        .as_str()
+        .map(str::to_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Probe {
+        #[serde(default, deserialize_with = "lenient_u64")]
+        count: Option<u64>,
+        #[serde(default, deserialize_with = "lenient_f64")]
+        ratio: Option<f64>,
+        #[serde(default, deserialize_with = "lenient_string")]
+        label: Option<String>,
+    }
+
+    #[test]
+    fn lenient_u64_accepts_integer_rejects_others() {
+        // Happy paths
+        let p: Probe = serde_json::from_str(r#"{"count": 42}"#).expect("integer ok");
+        assert_eq!(p.count, Some(42));
+
+        // Wrong types → None (NOT Err); whole document continues parsing
+        let p: Probe = serde_json::from_str(r#"{"count": "42"}"#).expect("string ok→None");
+        assert_eq!(p.count, None);
+
+        let p: Probe = serde_json::from_str(r#"{"count": 42.5}"#).expect("float ok→None");
+        assert_eq!(p.count, None);
+
+        let p: Probe = serde_json::from_str(r#"{"count": -5}"#).expect("negative ok→None");
+        assert_eq!(p.count, None);
+
+        let p: Probe = serde_json::from_str(r#"{"count": null}"#).expect("null ok→None");
+        assert_eq!(p.count, None);
+
+        let p: Probe = serde_json::from_str(r#"{}"#).expect("missing ok→None");
+        assert_eq!(p.count, None);
+    }
+
+    #[test]
+    fn lenient_f64_accepts_numbers_rejects_others() {
+        let p: Probe = serde_json::from_str(r#"{"ratio": 3.14}"#).expect("float ok");
+        assert_eq!(p.ratio, Some(3.14));
+
+        // Integer coerces to f64 — matches `Value::as_f64` behavior
+        let p: Probe = serde_json::from_str(r#"{"ratio": 42}"#).expect("integer ok→Some");
+        assert_eq!(p.ratio, Some(42.0));
+
+        // Wrong types → None
+        let p: Probe = serde_json::from_str(r#"{"ratio": "3.14"}"#).expect("string ok→None");
+        assert_eq!(p.ratio, None);
+
+        let p: Probe = serde_json::from_str(r#"{"ratio": null}"#).expect("null ok→None");
+        assert_eq!(p.ratio, None);
+    }
+
+    #[test]
+    fn lenient_string_accepts_strings_rejects_others() {
+        let p: Probe = serde_json::from_str(r#"{"label": "hello"}"#).expect("string ok");
+        assert_eq!(p.label.as_deref(), Some("hello"));
+
+        let p: Probe = serde_json::from_str(r#"{"label": 42}"#).expect("number ok→None");
+        assert_eq!(p.label, None);
+
+        let p: Probe = serde_json::from_str(r#"{"label": null}"#).expect("null ok→None");
+        assert_eq!(p.label, None);
+    }
+
+    /// Per-field tolerance — one wrong-typed field does NOT poison
+    /// the rest of the document. This is the defining property the
+    /// helpers exist to preserve.
+    #[test]
+    fn one_wrong_field_does_not_poison_the_rest() {
+        let p: Probe = serde_json::from_str(r#"{"count": "garbage", "ratio": 0.5, "label": "ok"}"#)
+            .expect("partial degradation");
+        assert_eq!(p.count, None);
+        assert_eq!(p.ratio, Some(0.5));
+        assert_eq!(p.label.as_deref(), Some("ok"));
+    }
+}

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -70,3 +70,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 16       | 0    | 2026-05-18   |
+| [Parser Resilience](patterns/parser-resilience.md)                   | code-quality       | 1        | 1    | 2026-05-24   |

--- a/docs/reviews/patterns/parser-resilience.md
+++ b/docs/reviews/patterns/parser-resilience.md
@@ -1,0 +1,76 @@
+---
+id: parser-resilience
+category: code-quality
+created: 2026-05-24
+last_updated: 2026-05-24
+ref_count: 1
+---
+
+# Parser Resilience
+
+## Summary
+
+When migrating a permissive parser (e.g. `serde_json::Value` pull-style
+extraction) to a typed-DTO shape, the strict-by-default behavior of
+`#[derive(Deserialize)]` quietly erases the "partial / wrong-typed
+input still parses something" property of the original. Catch this on
+every leaf field AND every nested-struct field separately — the two
+have different deserialization paths and different attribute fixes.
+
+For each leaf scalar field:
+
+- Use `#[serde(default)]` so `null` / missing maps to the type's
+  `Default` (typically `None` if wrapped in `Option<T>`).
+- Use `#[serde(deserialize_with = "lenient_T")]` so a wrong-typed
+  present value (e.g. a JSON string where `u64` was expected) yields
+  `None` instead of erroring the whole document.
+
+For each nested-struct field:
+
+- The above is **not enough**. `#[serde(default)]` still only handles
+  missing/null at the outer position; a present-but-wrong-type value
+  (`"context_window": 42`) makes the struct deserialize fail and
+  poisons the parent document.
+- Use `#[serde(deserialize_with = "lenient_object")]` (or equivalent)
+  to mirror the per-field tolerance at the nested-struct boundary:
+  materialize the value, check `is_object()`, then re-decode into the
+  target type.
+
+## Findings
+
+### 1. Strict nested-struct deserialization silently dropped status events on wrong-typed sub-blocks
+
+- **Source:** github-claude + github-codex-connector | PR #257 | 2026-05-24
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/agent/adapter/claude_code/statusline.rs`, `crates/backend/src/agent/adapter/codex/parser.rs`
+- **Finding:** Step A-status's initial DTO migration covered scalar
+  wrong-type tolerance via `lenient_u64` / `lenient_f64` /
+  `lenient_string` but missed nested struct fields. `ClaudeStatusDto`'s
+  nested fields (`model`, `context_window`, `cost`, `rate_limits`,
+  `current_usage`, `five_hour`, `seven_day`) and the equivalent Codex
+  positions (`info`, `rate_limits`, `last_token_usage`, `primary`,
+  `secondary`) were all `Option<NestedDto>` with only `#[serde(default)]`.
+  Behavioral regression vs. pre-A-status `is_some_and(Value::is_object)`
+  guards: a present-but-wrong-type sub-block (`"context_window": 42`,
+  `"rate_limits": []`) made the entire `parse_statusline` return
+  `Err`, and the watcher's `parse_status` match arm mapped that to
+  `TxOutcome::ParseError` — dropping the whole status event. For
+  Codex it was lower severity because `parse_rollout` already catches
+  per-line Err and skips, but the same `token_count` event still lost
+  its sibling rate-limit / token-usage data.
+- **Fix:** Added a third helper `lenient_object<T: DeserializeOwned>`
+  to `serde_helpers.rs` paralleling the scalar helpers:
+  materialize via `Value::deserialize`, check `is_object()`, then
+  `serde_json::from_value::<T>` (inner field-level helpers ensure
+  this succeeds for any object). Wrong-type / non-object → `Ok(None)`,
+  matching the scalar helpers' "wrong shape becomes a missing block"
+  contract. Applied at every nested-struct field listed by Claude +
+  codex connector. Three new parse-entry regression tests pin
+  per-block degradation; one for the Codex side proves wrong-typed
+  `info` preserves prior token state AND lets sibling `rate_limits`
+  on the same line still fold (per-field degradation, not whole-line
+  drop). **Heuristic:** when migrating a `serde_json::Value`-based
+  parser to typed DTOs, treat scalar leniency and nested-struct
+  leniency as TWO separate audits — they live in different parts of
+  the struct and have different attribute fixes.
+- **Commit:** same commit as this entry


### PR DESCRIPTION
## Summary

**Step A-status** of the [v4-frozen refactor plan](https://github.com/winoooops/vimeflow/blob/refactor/agent-adapter/crates/backend/src/agent/adapter/REVIEW.md#final-plan-v4-frozen). First step **after the side-channel kill (0c)** that touches parser internals — migrates `claude_code/statusline.rs` and `codex/parser.rs` from `serde_json::Value` pull-style extraction to typed DTOs flowing through `#[derive(Deserialize)]`. Status-only — transcript DTOs are explicitly deferred to **A-transcript** per the v4-frozen scope rules.

## What lands

### New shared helper module

`crates/backend/src/agent/adapter/serde_helpers.rs` (private) with three wrong-type-tolerant deserializers:

| Helper | Mirrors pre-A-status |
|---|---|
| `lenient_u64` | `Value::as_u64().unwrap_or(default)` |
| `lenient_f64` | `Value::as_f64().unwrap_or(default)` |
| `lenient_string` | `Value::as_str().map(str::to_string)` |

Each goes via `Value::deserialize` then asks the value to coerce; wrong types return `Ok(None)` instead of erroring. 4 unit tests pin the contract including the defining "one wrong field does not poison the rest" property.

### Claude (`claude_code/statusline.rs`)

Typed DTOs: `ClaudeStatusDto` (root) + nested `ClaudeModelDto` / `ClaudeContextWindowDto` / `ClaudeCurrentUsageDto` / `ClaudeCostDto` / `ClaudeRateLimitsDto` / `ClaudeRateLimitInfoDto` + a narrow `ClaudeTranscriptPathDto` for the `extract_transcript_path` helper. The conversion layer preserves every Claude-protocol nuance:
- **cost block-vs-field distinction:** `None` if cost block absent, `Some(0.0)` if block present but field missing.
- **`used_percentage` computed fallback:** when JSON has `null`, compute from `total_input_tokens / context_window_size` IFF both > 0, then clamp to [0, 100].
- **`remaining_percentage` priority chain:** computed-from-used → raw input → 100.0 default; clamped at each step.

### Codex (`codex/parser.rs`)

Internally-tagged `CodexRolloutLine` enum dispatches on the outer `type`; `EventMsgPayloadDto` is a second internally-tagged enum dispatching on `payload.type`. Both enums use `#[serde(other)]` unit variants for forward-compatibility (unknown event kinds and unknown payload sub-types silently fall through).

The **load-bearing R2.4 invariant** is structurally encoded: `TokenCount { info: Option<TokenCountInfoDto>, ... }` + the fold's `if let Some(info) = info { state.last_token_count_info = Some(...) }` makes "Some-only update" mechanical. A `token_count` event with `info: null` or `info: <missing>` preserves prior context — pinned by `token_count_info_null_preserves_prior_context`.

### Two design decisions

1. **Shared helpers** in a new private `serde_helpers.rs` module (rather than duplicating in each file) — DRY for a contract both parsers need identically.
2. **Dropped the `is_object` precheck** — serde reports non-object input as `"invalid type: ..., expected struct ..."` instead of the former hand-written `"statusline JSON is not an object"`. Behavior preserved (`Err`); error text changes. Saves one JSON parse per Claude statusline update. The `rejects_non_object_json` test was updated to assert the `invalid JSON:` prefix that's still owned by the wrapper.

## Codex review log

Three rounds of `codex exec`, all logged under `.codex-reviews/`:

| Round | Findings | Outcome |
|---|---|---|
| 1 | 1 LOW | `unknown_event_type_ignored_without_error` only exercised the OUTER `#[serde(other)]`, not the INNER `EventMsgPayloadDto::Unknown`. Added a behavior test for the inner branch. |
| 2 | 1 LOW (same finding stronger) | Codex correctly pointed out the round-1 behavior test could pass either via `#[serde(other)]` no-op fold OR via `parse_rollout`'s per-line deserialize-skip — couldn't distinguish. Added two DTO-level tests that bypass `parse_rollout` entirely. |
| 3 | **0 / 0 / 0 / 0 — "Ship it."** | Both `#[serde(other)]` branches now pin loudly; removing either attribute fails the corresponding test at the `.expect(...)` panic. |

## Acceptance compliance (per #246 Step A-status bullets)

- [x] Replace `serde_json::Value` pull-style parsing with typed DTOs in `claude_code/statusline.rs` and `codex/parser.rs` state-fold.
- [x] Per-field `Option<T> + #[serde(default)]`.
- [x] Codex token-state fold MUST preserve prior state on `info: None`.
- [x] Add `deserialize_with` for fields where current `Value::as_*` was lenient about wrong types.
- [x] Do NOT touch `claude_code/transcript.rs` or `codex/transcript.rs`.
- [x] All status fixture tests still pass.

## Diff at a glance

Three commits, expected to squash on merge:

1. `082d430` — original step A-status commit (4 files, +636/-449).
2. `f577436` — codex round 1 fix (parser.rs +22, new behavior test for inner Unknown).
3. `8883e6a` — codex round 2 fix (parser.rs +51/-10, two DTO-level tests; round-1 behavior test kept).

Files touched (all under `crates/backend/src/agent/adapter/`):

- `serde_helpers.rs` — **new** (160 lines): three lenient deserializers + 4 unit tests.
- `mod.rs` — `+1 line` (`mod serde_helpers;`).
- `claude_code/statusline.rs` — full rewrite of production code; tests preserved verbatim except `rejects_non_object_json`.
- `codex/parser.rs` — full rewrite of production code; existing fixture tests preserved verbatim; three new tests (one behavior, two DTO-level).

`claude_code/transcript.rs` and `codex/transcript.rs` are **intentionally untouched** (deferred to A-transcript per the v4-frozen plan).

## Test plan

- [x] `cargo build -p vimeflow --lib` → clean
- [x] `cargo test -p vimeflow --lib agent::adapter` → 268 passed, 0 failed (was 261 in step 0c; +7 net for A-status: 4 serde_helpers + 3 codex parser additions)
- [x] `cargo test -p vimeflow --lib` → 546 passed, 0 failed
- [x] `cargo clippy -p vimeflow --lib --no-deps` → same 6 pre-existing warnings as step 0c baseline; no new warnings
- [x] `rustfmt --check` on all touched files → clean (drift at `mod.rs:190` and `statusline.rs:679` is pre-existing from earlier steps; left alone per `rules/common/pr-scope.md`)
- [x] 3 rounds of `codex exec` — final round 0/0/0/0 (`.codex-reviews/round-3.output.md`)
- [ ] Reviewer: confirm `token_count.info: Option<TokenCountInfoDto>` Some-only fold is structurally enforced
- [ ] Reviewer: confirm both `#[serde(other)]` branches are pinned by DTO-level tests (not just behavior tests)
- [ ] Reviewer: confirm transcript files are genuinely untouched

## Merge target

Targets `refactor/agent-adapter` (the integration branch). One final PR from `refactor/agent-adapter` → `main` lands the full refactor as a single squash commit per the merge strategy in #246.

Part of #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)