### PR TITLE
fix(workspace): scope agent activity bar collapse to session, not pane

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | -------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security           | 21       | 3    | 2026-05-20   |
 | [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 19       | 5    | 2026-05-20   |
-| [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 2        | 3    | 2026-05-20   |
+| [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 3        | 3    | 2026-05-24   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 4        | 3    | 2026-05-07   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality       | 5        | 0    | 2026-05-09   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 2        | 0    | 2026-05-04   |

--- a/docs/reviews/patterns/resource-cleanup.md
+++ b/docs/reviews/patterns/resource-cleanup.md
@@ -2,7 +2,7 @@
 id: resource-cleanup
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-05-20
+last_updated: 2026-05-24
 ref_count: 3
 ---
 
@@ -35,3 +35,13 @@ causes listener accumulation and duplicate event handling.
 - **Fix:** Add `Drop` for `TranscriptHandle` to set the stop flag. Keep explicit `stop(self)` for paths that must also join the thread.
 - **Verification:** Added `transcript_handle_drop_sets_stop_flag`; `cargo test --lib agent::transcript -j1`.
 - **Commit:** (pending — agent-status-sidebar PR)
+
+### 3. localStorage activityPanelCollapsed key leaks on session close
+
+- **Source:** github-claude | PR #259 round 1 | 2026-05-24
+- **Severity:** MEDIUM
+- **File:** `src/features/sessions/utils/activityPanelCollapsedStore.ts`
+- **Finding:** The new UI-side store exported only `readActivityPanelCollapsed` and `writeActivityPanelCollapsed`. `removeSession` never deleted the key, so every closed session left a `vimeflow:sessions:activityPanelCollapsed:<id>` entry in localStorage forever — replacing the Rust PTY cache (auto-cleaned on PTY exit) without an equivalent cleanup hook.
+- **Fix:** Add `deleteActivityPanelCollapsed(sessionId)` to the store. Call it from `removeSession` only on the happy path (after both kill phases settle), so a partial-kill bail does not drop the preference for a session the user can still see and retry.
+- **Verification:** Targeted tests in `activityPanelCollapsedStore.test.ts` (delete removes entry, no-op when absent, isolates by id) + `useSessionManager.test.ts` (removeSession clears the key on success, preserves it when kill rejects).
+- **Commit:** same commit as this entry (see `git blame` / `git log`)

--- a/src/features/sessions/components/List.test.tsx
+++ b/src/features/sessions/components/List.test.tsx
@@ -14,6 +14,7 @@ const mockSessions: Session[] = [
     workingDirectory: '/home/user/projects/Vimeflow',
     agentType: 'claude-code',
     layout: 'single',
+    activityPanelCollapsed: false,
     panes: [
       {
         id: 'p0',
@@ -22,7 +23,6 @@ const mockSessions: Session[] = [
         agentType: 'claude-code',
         status: 'running',
         active: true,
-        activityPanelCollapsed: null,
         pid: 12345,
       },
     ],
@@ -54,6 +54,7 @@ const mockSessions: Session[] = [
     workingDirectory: '/home/user/projects/Vimeflow',
     agentType: 'claude-code',
     layout: 'single',
+    activityPanelCollapsed: false,
     panes: [
       {
         id: 'p0',
@@ -62,7 +63,6 @@ const mockSessions: Session[] = [
         agentType: 'claude-code',
         status: 'paused',
         active: true,
-        activityPanelCollapsed: null,
         pid: 12346,
       },
     ],
@@ -89,6 +89,7 @@ const mockSessions: Session[] = [
     workingDirectory: '/home/user/projects/Vimeflow',
     agentType: 'claude-code',
     layout: 'single',
+    activityPanelCollapsed: false,
     panes: [
       {
         id: 'p0',
@@ -97,7 +98,6 @@ const mockSessions: Session[] = [
         agentType: 'claude-code',
         status: 'completed',
         active: true,
-        activityPanelCollapsed: null,
       },
     ],
     createdAt: '2026-04-07T02:00:00Z',

--- a/src/features/sessions/components/Tabs.test.tsx
+++ b/src/features/sessions/components/Tabs.test.tsx
@@ -13,6 +13,7 @@ const buildSession = (overrides: Partial<Session> = {}): Session => ({
   workingDirectory: '~',
   agentType: 'claude-code',
   layout: 'single',
+  activityPanelCollapsed: false,
   panes: [
     {
       id: 'p0',
@@ -21,7 +22,6 @@ const buildSession = (overrides: Partial<Session> = {}): Session => ({
       agentType: 'claude-code',
       status: 'running',
       active: true,
-      activityPanelCollapsed: null,
     },
   ],
   createdAt: '2026-05-06T00:00:00Z',

--- a/src/features/sessions/hooks/useRenameState.test.ts
+++ b/src/features/sessions/hooks/useRenameState.test.ts
@@ -11,6 +11,7 @@ const buildSession = (name = 'auth'): Session => ({
   workingDirectory: '~',
   agentType: 'claude-code',
   layout: 'single',
+  activityPanelCollapsed: false,
   panes: [
     {
       id: 'p0',
@@ -19,7 +20,6 @@ const buildSession = (name = 'auth'): Session => ({
       agentType: 'claude-code',
       status: 'running',
       active: true,
-      activityPanelCollapsed: null,
     },
   ],
   createdAt: '2026-05-06T00:00:00Z',

--- a/src/features/sessions/hooks/useSessionManager.test.ts
+++ b/src/features/sessions/hooks/useSessionManager.test.ts
@@ -9,16 +9,7 @@ import {
   getAllPtySessionIds,
   registerPtySession,
 } from '../../terminal/ptySessionMap'
-
-const absorbExpectedRejection = async (
-  promise: Promise<void>
-): Promise<void> => {
-  try {
-    await promise
-  } catch {
-    return
-  }
-}
+import { readActivityPanelCollapsed } from '../utils/activityPanelCollapsedStore'
 
 const createMockService = (): ITerminalService => ({
   spawn: vi
@@ -56,6 +47,7 @@ describe('useSessionManager', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     clearPtySessionMap()
+    window.localStorage.clear()
   })
 
   test('on mount, registers global pty-data listener BEFORE calling listSessions', async () => {
@@ -2877,7 +2869,7 @@ describe('useSessionManager', () => {
     expect(service.updateSessionCwd).toHaveBeenCalledWith('pty-1', '/new/cwd')
   })
 
-  test('setPaneActivityPanelCollapsed optimistically updates and persists', async () => {
+  test('setSessionActivityPanelCollapsed updates session state and persists to localStorage', async () => {
     const service = createMockService()
     service.spawn = vi.fn().mockResolvedValue({
       sessionId: 'pty-1',
@@ -2893,51 +2885,26 @@ describe('useSessionManager', () => {
     act(() => result.current.createSession())
     await waitFor(() => expect(result.current.sessions).toHaveLength(1))
 
-    const session = result.current.sessions[0]
-    const pane = session.panes[0]
+    const sessionId = result.current.sessions[0].id
+    expect(result.current.sessions[0].activityPanelCollapsed).toBe(false)
 
-    await act(async () => {
-      await result.current.setPaneActivityPanelCollapsed(
-        session.id,
-        pane.id,
-        true
-      )
+    act(() => {
+      result.current.setSessionActivityPanelCollapsed(sessionId, true)
     })
 
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      true
-    )
-
-    expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledWith({
-      id: pane.ptyId,
-      collapsed: true,
-    })
+    expect(result.current.sessions[0].activityPanelCollapsed).toBe(true)
+    expect(readActivityPanelCollapsed(sessionId)).toBe(true)
+    // UI-only state — must NOT flow through the agent/PTY backend.
+    expect(service.setSessionActivityPanelCollapsed).not.toHaveBeenCalled()
   })
 
-  test('setPaneActivityPanelCollapsed keeps latest optimistic value when an older IPC rejects', async () => {
+  test('setSessionActivityPanelCollapsed is a no-op when value is unchanged', async () => {
     const service = createMockService()
     service.spawn = vi.fn().mockResolvedValue({
       sessionId: 'pty-1',
       pid: 123,
       cwd: '/home/user',
     })
-
-    let rejectFirst: ((err: Error) => void) | null = null
-    let resolveSecond: (() => void) | null = null
-    service.setSessionActivityPanelCollapsed = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((_resolve, reject) => {
-            rejectFirst = reject
-          })
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveSecond = resolve
-          })
-      )
 
     const { result } = renderHook(() =>
       useSessionManager(service, { autoCreateOnEmpty: false })
@@ -2947,51 +2914,18 @@ describe('useSessionManager', () => {
     act(() => result.current.createSession())
     await waitFor(() => expect(result.current.sessions).toHaveLength(1))
 
-    const session = result.current.sessions[0]
-    const pane = session.panes[0]
+    const sessionId = result.current.sessions[0].id
+    const snapshot = result.current.sessions[0]
 
-    let first: Promise<void> = Promise.resolve()
-    let second: Promise<void> = Promise.resolve()
     act(() => {
-      first = absorbExpectedRejection(
-        result.current.setPaneActivityPanelCollapsed(session.id, pane.id, true)
-      )
-
-      second = result.current.setPaneActivityPanelCollapsed(
-        session.id,
-        pane.id,
-        false
-      )
+      result.current.setSessionActivityPanelCollapsed(sessionId, false)
     })
 
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      false
-    )
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(1)
-    )
-
-    await act(async () => {
-      rejectFirst?.(new Error('first IPC failed'))
-      await first
-    })
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(2)
-    )
-
-    await act(async () => {
-      resolveSecond?.()
-      await second
-    })
-
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      false
-    )
+    // Same boolean → object identity preserved; no re-render churn.
+    expect(result.current.sessions[0]).toBe(snapshot)
   })
 
-  test('setPaneActivityPanelCollapsed rolls back to pre-chain value when two IPC calls fail in sequence', async () => {
+  test('setSessionActivityPanelCollapsed silently ignores unknown session ids', async () => {
     const service = createMockService()
     service.spawn = vi.fn().mockResolvedValue({
       sessionId: 'pty-1',
@@ -2999,428 +2933,15 @@ describe('useSessionManager', () => {
       cwd: '/home/user',
     })
 
-    let rejectFirst: ((err: Error) => void) | null = null
-    let rejectSecond: ((err: Error) => void) | null = null
-    service.setSessionActivityPanelCollapsed = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((_resolve, reject) => {
-            rejectFirst = reject
-          })
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((_resolve, reject) => {
-            rejectSecond = reject
-          })
-      )
-
     const { result } = renderHook(() =>
       useSessionManager(service, { autoCreateOnEmpty: false })
     )
     await waitFor(() => expect(result.current.loading).toBe(false))
 
-    act(() => result.current.createSession())
-    await waitFor(() => expect(result.current.sessions).toHaveLength(1))
-
-    const session = result.current.sessions[0]
-    const pane = session.panes[0]
-    // Pre-chain ground truth: pane starts un-collapsed (null in our model).
-    expect(pane.activityPanelCollapsed).toBeNull()
-
-    let first: Promise<void> = Promise.resolve()
-    let second: Promise<void> = Promise.resolve()
-
     act(() => {
-      first = absorbExpectedRejection(
-        result.current.setPaneActivityPanelCollapsed(session.id, pane.id, true)
-      )
-
-      second = absorbExpectedRejection(
-        result.current.setPaneActivityPanelCollapsed(session.id, pane.id, false)
-      )
+      result.current.setSessionActivityPanelCollapsed('does-not-exist', true)
     })
-
-    // Both optimistic updates applied; latest wins on screen.
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      false
-    )
-
-    // Wait for the first IPC call to be issued before triggering its rejection;
-    // the second call is chained behind the first and can't start its own IPC
-    // until first's persistActivityPanelCollapsed resolves (or rejects).
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(1)
-    )
-
-    await act(async () => {
-      rejectFirst?.(new Error('first IPC failed'))
-      await first
-    })
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(2)
-    )
-
-    await act(async () => {
-      rejectSecond?.(new Error('second IPC failed'))
-      await second
-    })
-
-    // Both calls failed; UI must reconcile to the backend's untouched value
-    // (null), NOT to the first call's optimistic `true`.
-    expect(
-      result.current.sessions[0].panes[0].activityPanelCollapsed
-    ).toBeNull()
-  })
-
-  test('setPaneActivityPanelCollapsed preserves a null baseline across queued calls even after the optimistic render has committed', async () => {
-    // Codex review cycle 2 caught this: if A optimistically sets `true`
-    // and React commits before B is issued, `sessionsRef.current` shows A's
-    // optimistic value. The fix must NOT collapse a legitimate `null`
-    // baseline into A's stale optimistic value via nullish-coalescing.
-    const service = createMockService()
-    service.spawn = vi.fn().mockResolvedValue({
-      sessionId: 'pty-1',
-      pid: 123,
-      cwd: '/home/user',
-    })
-
-    let rejectFirst: ((err: Error) => void) | null = null
-    let rejectSecond: ((err: Error) => void) | null = null
-    service.setSessionActivityPanelCollapsed = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((_resolve, reject) => {
-            rejectFirst = reject
-          })
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((_resolve, reject) => {
-            rejectSecond = reject
-          })
-      )
-
-    const { result } = renderHook(() =>
-      useSessionManager(service, { autoCreateOnEmpty: false })
-    )
-    await waitFor(() => expect(result.current.loading).toBe(false))
-
-    act(() => result.current.createSession())
-    await waitFor(() => expect(result.current.sessions).toHaveLength(1))
-
-    const session = result.current.sessions[0]
-    const pane = session.panes[0]
-    expect(pane.activityPanelCollapsed).toBeNull()
-
-    // Fire A in its own act — React commits A's optimistic `true` before B
-    // is issued. This is the scenario the cycle-1 fix missed.
-    let first: Promise<void> = Promise.resolve()
-
-    act(() => {
-      first = absorbExpectedRejection(
-        result.current.setPaneActivityPanelCollapsed(session.id, pane.id, true)
-      )
-    })
-
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      true
-    )
-
-    let second: Promise<void> = Promise.resolve()
-
-    act(() => {
-      second = absorbExpectedRejection(
-        result.current.setPaneActivityPanelCollapsed(session.id, pane.id, false)
-      )
-    })
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(1)
-    )
-
-    await act(async () => {
-      rejectFirst?.(new Error('first IPC failed'))
-      await first
-    })
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(2)
-    )
-
-    await act(async () => {
-      rejectSecond?.(new Error('second IPC failed'))
-      await second
-    })
-
-    // Both calls failed. Backend never persisted anything, so UI must
-    // reconcile to the original null — NOT to A's optimistic true that was
-    // briefly observable through sessionsRef.current.
-    expect(
-      result.current.sessions[0].panes[0].activityPanelCollapsed
-    ).toBeNull()
-  })
-
-  test('setPaneActivityPanelCollapsed does NOT clobber a newer queued same-direction optimistic value when an earlier same-direction call fails', async () => {
-    // Claude review cycle 4 caught this: when A(true) and C(true) race and
-    // A fails, a value-equality guard sees `pane=true !== A.collapsed=true`
-    // as false and rolls C's optimistic true back to null — even though C
-    // owns the latest optimistic state. The fix switches to chain-head
-    // identity ownership so A's failure can never displace C.
-    const service = createMockService()
-    service.spawn = vi.fn().mockResolvedValue({
-      sessionId: 'pty-1',
-      pid: 123,
-      cwd: '/home/user',
-    })
-
-    let rejectFirst: ((err: Error) => void) | null = null
-    let resolveSecond: (() => void) | null = null
-    service.setSessionActivityPanelCollapsed = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((_resolve, reject) => {
-            rejectFirst = reject
-          })
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveSecond = resolve
-          })
-      )
-
-    const { result } = renderHook(() =>
-      useSessionManager(service, { autoCreateOnEmpty: false })
-    )
-    await waitFor(() => expect(result.current.loading).toBe(false))
-
-    act(() => result.current.createSession())
-    await waitFor(() => expect(result.current.sessions).toHaveLength(1))
-
-    const session = result.current.sessions[0]
-    const pane = session.panes[0]
-
-    let first: Promise<void> = Promise.resolve()
-    let second: Promise<void> = Promise.resolve()
-
-    act(() => {
-      first = absorbExpectedRejection(
-        result.current.setPaneActivityPanelCollapsed(session.id, pane.id, true)
-      )
-
-      // Same direction — both true. The value-equality guard CANNOT
-      // distinguish A from C here.
-      second = result.current.setPaneActivityPanelCollapsed(
-        session.id,
-        pane.id,
-        true
-      )
-    })
-
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      true
-    )
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(1)
-    )
-
-    await act(async () => {
-      rejectFirst?.(new Error('first IPC failed'))
-      await first
-    })
-
-    // A failed but C is still the head of the chain — pane must stay true.
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      true
-    )
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(2)
-    )
-
-    await act(async () => {
-      resolveSecond?.()
-      await second
-    })
-
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      true
-    )
-  })
-
-  test('setPaneActivityPanelCollapsed superseded calls resolve silently — no throw to bubble into UI notifications', async () => {
-    // Claude review cycle 3 caught this: the catch block re-threw `err`
-    // unconditionally, so a rapid toggle (collapse then expand, where the
-    // collapse IPC fails) would surface an error toast from the WorkspaceView
-    // notifyInfo bridge — even though the user's most recent action (expand)
-    // already succeeded and the UI shows the correct state. The fix moves the
-    // throw inside the `if (isHead)` guard so only the call that still owns
-    // the chain head propagates failure to callers.
-    const service = createMockService()
-    service.spawn = vi.fn().mockResolvedValue({
-      sessionId: 'pty-1',
-      pid: 123,
-      cwd: '/home/user',
-    })
-
-    let rejectFirst: ((err: Error) => void) | null = null
-    let resolveSecond: (() => void) | null = null
-    service.setSessionActivityPanelCollapsed = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((_resolve, reject) => {
-            rejectFirst = reject
-          })
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveSecond = resolve
-          })
-      )
-
-    const { result } = renderHook(() =>
-      useSessionManager(service, { autoCreateOnEmpty: false })
-    )
-    await waitFor(() => expect(result.current.loading).toBe(false))
-
-    act(() => result.current.createSession())
-    await waitFor(() => expect(result.current.sessions).toHaveLength(1))
-
-    const session = result.current.sessions[0]
-    const pane = session.panes[0]
-
-    let first: Promise<void> = Promise.resolve()
-    let second: Promise<void> = Promise.resolve()
-
-    act(() => {
-      // Note: NOT wrapped in absorbExpectedRejection — the post-cycle-6
-      // contract is that a superseded call resolves cleanly. If `first`
-      // rejects, the `await first` below will throw and fail the test,
-      // catching any regression that re-introduces unconditional re-throw.
-      first = result.current.setPaneActivityPanelCollapsed(
-        session.id,
-        pane.id,
-        true
-      )
-
-      second = result.current.setPaneActivityPanelCollapsed(
-        session.id,
-        pane.id,
-        false
-      )
-    })
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(1)
-    )
-
-    await act(async () => {
-      rejectFirst?.(new Error('first IPC failed'))
-      // If the catch re-throws, `await first` rejects and the test fails.
-      await first
-    })
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(2)
-    )
-
-    await act(async () => {
-      resolveSecond?.()
-      await second
-    })
-
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      false
-    )
-  })
-
-  test('setPaneActivityPanelCollapsed rolls back to a previously-successful sibling value when a later queued IPC fails', async () => {
-    const service = createMockService()
-    service.spawn = vi.fn().mockResolvedValue({
-      sessionId: 'pty-1',
-      pid: 123,
-      cwd: '/home/user',
-    })
-
-    let resolveFirst: (() => void) | null = null
-    let rejectSecond: ((err: Error) => void) | null = null
-    service.setSessionActivityPanelCollapsed = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveFirst = resolve
-          })
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((_resolve, reject) => {
-            rejectSecond = reject
-          })
-      )
-
-    const { result } = renderHook(() =>
-      useSessionManager(service, { autoCreateOnEmpty: false })
-    )
-    await waitFor(() => expect(result.current.loading).toBe(false))
-
-    act(() => result.current.createSession())
-    await waitFor(() => expect(result.current.sessions).toHaveLength(1))
-
-    const session = result.current.sessions[0]
-    const pane = session.panes[0]
-
-    let first: Promise<void> = Promise.resolve()
-    let second: Promise<void> = Promise.resolve()
-
-    act(() => {
-      first = result.current.setPaneActivityPanelCollapsed(
-        session.id,
-        pane.id,
-        true
-      )
-
-      second = absorbExpectedRejection(
-        result.current.setPaneActivityPanelCollapsed(session.id, pane.id, false)
-      )
-    })
-
-    // Both optimistic updates applied; latest wins on screen.
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      false
-    )
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(1)
-    )
-
-    await act(async () => {
-      resolveFirst?.()
-      await first
-    })
-
-    await waitFor(() =>
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledTimes(2)
-    )
-
-    await act(async () => {
-      rejectSecond?.(new Error('second IPC failed'))
-      await second
-    })
-
-    // The second call failed; rollback must restore to the first call's
-    // SUCCESSFUL persisted value (true), NOT to the pre-chain value (null).
-    expect(result.current.sessions[0].panes[0].activityPanelCollapsed).toBe(
-      true
-    )
+    expect(result.current.sessions).toHaveLength(0)
   })
 
   describe('setSessionLayout', () => {

--- a/src/features/sessions/hooks/useSessionManager.test.ts
+++ b/src/features/sessions/hooks/useSessionManager.test.ts
@@ -715,6 +715,87 @@ describe('useSessionManager', () => {
     await waitFor(() => expect(result.current.sessions).toHaveLength(0))
   })
 
+  // Replaces the implicit cleanup the Rust PTY cache used to do on session
+  // exit. Without this hook, every closed session leaked a localStorage
+  // entry forever — see PR #259 review (M1).
+  test('removeSession clears the session activityPanelCollapsed localStorage key', async () => {
+    const service = createMockService()
+    service.listSessions = vi.fn().mockResolvedValue({
+      activeSessionId: 's1',
+      sessions: [
+        {
+          id: 's1',
+          cwd: '/tmp',
+          status: {
+            kind: 'Alive',
+            pid: 1,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    })
+
+    const { result } = renderHook(() =>
+      useSessionManager(service, { autoCreateOnEmpty: false })
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => {
+      result.current.setSessionActivityPanelCollapsed('s1', true)
+    })
+    expect(readActivityPanelCollapsed('s1')).toBe(true)
+
+    act(() => result.current.removeSession('s1'))
+
+    await waitFor(() => expect(result.current.sessions).toHaveLength(0))
+    expect(readActivityPanelCollapsed('s1')).toBe(false)
+    expect(
+      window.localStorage.getItem('vimeflow:sessions:activityPanelCollapsed:s1')
+    ).toBeNull()
+  })
+
+  // Partial-kill bail: when ANY pane's kill IPC rejects, removeSession bails
+  // BEFORE dropping bookkeeping (and now BEFORE clearing the localStorage
+  // key). The session is still visible to the user; their preference must
+  // survive so a retry doesn't reset the bar to expanded.
+  test('removeSession preserves localStorage key when kill rejects', async () => {
+    const service = createMockService()
+    service.listSessions = vi.fn().mockResolvedValue({
+      activeSessionId: 's1',
+      sessions: [
+        {
+          id: 's1',
+          cwd: '/tmp',
+          status: {
+            kind: 'Alive',
+            pid: 1,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    })
+    service.kill = vi.fn().mockRejectedValue(new Error('kill failed'))
+
+    const { result } = renderHook(() =>
+      useSessionManager(service, { autoCreateOnEmpty: false })
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => {
+      result.current.setSessionActivityPanelCollapsed('s1', true)
+    })
+    expect(readActivityPanelCollapsed('s1')).toBe(true)
+
+    act(() => result.current.removeSession('s1'))
+
+    await waitFor(() => expect(service.kill).toHaveBeenCalled())
+    // Session stays; preference must NOT have been swept by the partial-kill bail.
+    expect(result.current.sessions).toHaveLength(1)
+    expect(readActivityPanelCollapsed('s1')).toBe(true)
+  })
+
   // Round 9, Finding 6 (claude MEDIUM): React requires functional updaters to
   // be PURE. The previous code fired `service.setActiveSession` and
   // `service.reorderSessions` from INSIDE the setSessions updater in

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -25,7 +25,10 @@ import {
   nextFreePaneId,
 } from '../utils/paneLifecycle'
 import { deriveSessionStatus } from '../utils/sessionStatus'
-import { writeActivityPanelCollapsed } from '../utils/activityPanelCollapsedStore'
+import {
+  deleteActivityPanelCollapsed,
+  writeActivityPanelCollapsed,
+} from '../utils/activityPanelCollapsedStore'
 import { usePtyExitListener } from '../../terminal/hooks/usePtyExitListener'
 import { useAutoCreateOnEmpty } from './useAutoCreateOnEmpty'
 import { useActiveSessionController } from './useActiveSessionController'
@@ -529,6 +532,14 @@ export const useSessionManager = (
           unregisterPtySession(ptyId)
         }
         restoreDataRef.current.delete(target.id)
+
+        // Replaces the implicit cleanup the Rust PTY cache used to do on
+        // session exit. Without it, every closed session leaves a stale
+        // `vimeflow:sessions:activityPanelCollapsed:<id>` key in
+        // localStorage forever. Runs only on the happy path (after both
+        // kill phases settle) so a partial-kill bail-out doesn't drop
+        // the preference for a session the user can still see.
+        deleteActivityPanelCollapsed(target.id)
 
         const currentActiveId = activeSessionIdRef.current
         let computedFallback = null as string | null

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -25,37 +25,13 @@ import {
   nextFreePaneId,
 } from '../utils/paneLifecycle'
 import { deriveSessionStatus } from '../utils/sessionStatus'
+import { writeActivityPanelCollapsed } from '../utils/activityPanelCollapsedStore'
 import { usePtyExitListener } from '../../terminal/hooks/usePtyExitListener'
 import { useAutoCreateOnEmpty } from './useAutoCreateOnEmpty'
 import { useActiveSessionController } from './useActiveSessionController'
 import { useSessionRestore } from './useSessionRestore'
 
 export type { RestoreData, PaneEventHandler, NotifyPaneReadyResult }
-
-const absorbCollapseQueueFailure = async (
-  promise: Promise<void>
-): Promise<void> => {
-  try {
-    await promise
-  } catch {
-    return
-  }
-}
-
-const persistActivityPanelCollapsed = async (
-  service: ITerminalService,
-  prior: Promise<void>,
-  id: string,
-  collapsed: boolean
-): Promise<void> => {
-  await absorbCollapseQueueFailure(prior)
-  await service.setSessionActivityPanelCollapsed({ id, collapsed })
-}
-
-interface CollapseChainEntry {
-  tail: Promise<void>
-  originalValue: boolean | null
-}
 
 export interface SessionManager {
   sessions: Session[]
@@ -87,11 +63,14 @@ export interface SessionManager {
     paneId: string,
     agentType: Session['agentType']
   ) => void
-  setPaneActivityPanelCollapsed: (
+  /** Toggle the agent activity panel collapse state for ALL panes in the
+   *  session at once. UI-only state — persisted via localStorage so the
+   *  preference survives restart without flowing through the agent/PTY
+   *  lifecycle. */
+  setSessionActivityPanelCollapsed: (
     sessionId: string,
-    paneId: string,
     collapsed: boolean
-  ) => Promise<void>
+  ) => void
   /**
    * Update the stable session baseline cwd in React state only.
    *
@@ -320,13 +299,6 @@ export const useSessionManager = (
   // and fires the auto-create that the round-10 comment promised.
   const [pendingSpawns, setPendingSpawns] = useState(0)
   const pendingPaneOps = useRef<Set<string>>(new Set())
-  // Chain entry carries the persisted-pre-call value alongside the in-flight
-  // tail. originalValue is captured once per chain run — when the first call
-  // for a (sessionId, paneId) starts — and reused by every subsequent call
-  // that piggybacks on the chain. The tail acquired during back-to-back
-  // failures rolls UI back to originalValue, not to whichever optimistic
-  // value happened to be on screen when the call was issued.
-  const collapseChainRef = useRef<Map<string, CollapseChainEntry>>(new Map())
 
   const createSession = useCallback((): void => {
     setPendingSpawns((c) => c + 1)
@@ -371,6 +343,7 @@ export const useSessionManager = (
               workingDirectory: result.cwd,
               agentType: 'generic',
               layout: 'single',
+              activityPanelCollapsed: false,
               panes: [
                 {
                   id: 'p0',
@@ -379,7 +352,6 @@ export const useSessionManager = (
                   agentType: 'generic',
                   status: 'running',
                   active: true,
-                  activityPanelCollapsed: null,
                   pid: result.pid,
                   restoreData,
                 },
@@ -785,7 +757,6 @@ export const useSessionManager = (
             agentType: 'generic',
             status: 'running',
             active: true,
-            activityPanelCollapsed: null,
             pid: result.pid,
             restoreData,
           }
@@ -1245,137 +1216,21 @@ export const useSessionManager = (
     []
   )
 
-  const setPaneActivityPanelCollapsed = useCallback(
-    async (
-      sessionId: string,
-      paneId: string,
-      collapsed: boolean
-    ): Promise<void> => {
+  const setSessionActivityPanelCollapsed = useCallback(
+    (sessionId: string, collapsed: boolean): void => {
       const session = sessionsRef.current.find((s) => s.id === sessionId)
-      const pane = session?.panes.find((p) => p.id === paneId)
-      if (!session || !pane) {
+      if (!session || session.activityPanelCollapsed === collapsed) {
         return
       }
 
-      // Capture ptyId at call entry. Pane ids (`p0`, `p1`, ...) are reused
-      // by `nextFreePaneId` when a pane is removed and a new one is created
-      // in the same session, but ptyId is a per-spawn backend identifier
-      // that never recycles. We use it for BOTH the chain key AND the
-      // state-update predicate so a late persist/failure for a removed pane
-      // cannot contaminate a freshly-spawned replacement that happens to
-      // reuse the same React pane id.
-      const panePtyId = pane.ptyId
-      const chainKey = panePtyId
-      const existing = collapseChainRef.current.get(chainKey)
-
-      // Read pane.activityPanelCollapsed only on the FIRST call per chain run;
-      // every reentrant call (B issued while A is in flight) reads stale
-      // optimistic state and would set originalValue to whatever the previous
-      // call optimistically wrote. existing.originalValue carries the
-      // pre-A persisted truth forward so a B-rollback after A also failed
-      // restores UI to backend ground truth — not to A's speculative value.
-      // The explicit `existing !== undefined` check is required because
-      // `null` is a valid persisted value (un-collapsed default); `??` here
-      // would collapse a legitimate null baseline into the stale-fallback
-      // path and capture A's optimistic value as B's rollback target.
-      const originalValue =
-        existing !== undefined
-          ? existing.originalValue
-          : (pane.activityPanelCollapsed ?? null)
+      writeActivityPanelCollapsed(sessionId, collapsed)
       setSessions((prev) =>
         prev.map((s) =>
-          s.id !== sessionId
-            ? s
-            : {
-                ...s,
-                panes: s.panes.map((p) =>
-                  p.ptyId !== panePtyId
-                    ? p
-                    : { ...p, activityPanelCollapsed: collapsed }
-                ),
-              }
+          s.id === sessionId ? { ...s, activityPanelCollapsed: collapsed } : s
         )
       )
-
-      const prior = existing?.tail ?? Promise.resolve()
-
-      const next = persistActivityPanelCollapsed(
-        service,
-        prior,
-        pane.ptyId,
-        collapsed
-      )
-      const tail = absorbCollapseQueueFailure(next)
-
-      collapseChainRef.current.set(chainKey, { tail, originalValue })
-
-      try {
-        await next
-        // Persist succeeded — advance the chain's known-good baseline so a
-        // later queued failure (mixed success/fail case) rolls back to THIS
-        // call's value rather than the pre-chain value. Mutating the entry in
-        // place is safe and necessary: any queued caller after this point
-        // reads `existing?.originalValue` to seed its own rollback baseline
-        // and must see the just-persisted value, not the original.
-        const current = collapseChainRef.current.get(chainKey)
-        if (current !== undefined) {
-          current.originalValue = collapsed
-        }
-      } catch (err) {
-        // Capture liveBaseline NOW — `finally` will delete the chain entry
-        // before React processes the setSessions updater, so reading inside
-        // the updater would always see `undefined`. Same `null`-is-data
-        // caveat as the originalValue read above: use an explicit existence
-        // check so a legitimate `null` baseline isn't collapsed into the
-        // closure-snapshot fallback path.
-        const liveEntry = collapseChainRef.current.get(chainKey)
-
-        const liveBaseline =
-          liveEntry !== undefined ? liveEntry.originalValue : originalValue
-        // Ownership-by-identity: we roll back AND propagate the error ONLY
-        // when our tail is still the latest in the chain. Comparing
-        // `p.activityPanelCollapsed` against this call's `collapsed` would
-        // mis-fire when two same-direction calls (A=true, C=true) race —
-        // A's failure would value-match C's optimistic state and clobber
-        // it. The identity check sidesteps that: any newer queued call has
-        // already displaced our tail in the Map, so we silently defer to
-        // it — both the UI rollback AND the re-throw must stay inside the
-        // guard, otherwise the user sees an error notification for a
-        // superseded call whose newer sibling owns the visible outcome.
-        const isHead = liveEntry?.tail === tail
-
-        if (isHead) {
-          setSessions((prev) =>
-            prev.map((s) => {
-              if (s.id !== sessionId) {
-                return s
-              }
-
-              return {
-                ...s,
-                panes: s.panes.map((p) => {
-                  // Match by ptyId so a stale rollback for a removed pane
-                  // can never clobber a freshly-spawned pane that reused
-                  // the same React pane id. If the original pane is gone,
-                  // the find returns no match and setSessions is a no-op.
-                  if (p.ptyId !== panePtyId) {
-                    return p
-                  }
-
-                  return { ...p, activityPanelCollapsed: liveBaseline }
-                }),
-              }
-            })
-          )
-          throw err
-        }
-      } finally {
-        if (collapseChainRef.current.get(chainKey)?.tail === tail) {
-          collapseChainRef.current.delete(chainKey)
-        }
-      }
     },
-    [service]
+    []
   )
 
   const updateSessionCwd = useCallback((id: string, cwd: string): void => {
@@ -1427,7 +1282,7 @@ export const useSessionManager = (
     reorderSessions,
     updatePaneCwd,
     updatePaneAgentType,
-    setPaneActivityPanelCollapsed,
+    setSessionActivityPanelCollapsed,
     updateSessionCwd,
     updateSessionAgentType,
     // Round 12 F2: expose the ref-backed Map. Identity is stable across

--- a/src/features/sessions/types/index.test.ts
+++ b/src/features/sessions/types/index.test.ts
@@ -51,7 +51,6 @@ describe('Session Types', () => {
         agentType: 'claude-code',
         status: 'running',
         active: true,
-        activityPanelCollapsed: null,
         pid: 12345,
         restoreData: undefined,
       }
@@ -78,6 +77,7 @@ describe('Session Types', () => {
         workingDirectory: '/home/user/my-project',
         agentType: 'claude-code',
         layout: 'single',
+        activityPanelCollapsed: false,
         panes: [
           {
             id: 'p0',
@@ -86,7 +86,6 @@ describe('Session Types', () => {
             agentType: 'claude-code',
             status: 'running',
             active: true,
-            activityPanelCollapsed: null,
           },
         ],
         createdAt: '2026-04-07T00:00:00Z',

--- a/src/features/sessions/types/index.ts
+++ b/src/features/sessions/types/index.ts
@@ -31,15 +31,6 @@ export interface Pane {
 
   /** Exactly one pane per session has `active === true`. */
   active: boolean
-
-  /** Per-pane collapse preference for the right activity panel.
-   *  `null` = not yet persisted (pre-feature default). `true` / `false` =
-   *  persisted state. `undefined` is NOT a valid runtime value — every
-   *  init path (`createSession`, `sessionFromInfo`) sets the field
-   *  explicitly to `null`, and the Rust IPC contract is non-optional.
-   *  See `setPaneActivityPanelCollapsed` for the existence-vs-nullish
-   *  reasoning that depends on this invariant. */
-  activityPanelCollapsed: boolean | null
 }
 
 export interface Session {
@@ -53,6 +44,11 @@ export interface Session {
   agentType: 'claude-code' | 'codex' | 'aider' | 'generic'
   /** Per-session canvas layout. Default 'single' in step 5a. */
   layout: LayoutId
+  /** Session-scoped collapse state for the right agent activity panel.
+   *  Shared by every pane so switching pane within a session never
+   *  jumps the bar. UI-only: hydrated from localStorage by session id
+   *  and persisted there on toggle. Default `false` (expanded). */
+  activityPanelCollapsed: boolean
   /** At least one pane per session. Step 5a creates single-pane sessions. */
   panes: Pane[]
   currentAction?: string // current action description (e.g., "Creating auth middleware...")

--- a/src/features/sessions/utils/activeSessionPane.test.ts
+++ b/src/features/sessions/utils/activeSessionPane.test.ts
@@ -82,7 +82,6 @@ const makePane = (id: string, overrides: Partial<Pane> = {}): Pane => ({
   agentType: 'generic',
   status: 'running',
   active: false,
-  activityPanelCollapsed: null,
   ...overrides,
 })
 
@@ -98,6 +97,7 @@ const makeSession = (
   workingDirectory: panes.find((pane) => pane.active)?.cwd ?? panes[0].cwd,
   agentType: panes.find((pane) => pane.active)?.agentType ?? panes[0].agentType,
   layout,
+  activityPanelCollapsed: false,
   panes,
   createdAt: '2026-05-12T00:00:00Z',
   lastActivityAt: '2026-05-12T00:00:00Z',

--- a/src/features/sessions/utils/activityPanelCollapsedStore.test.ts
+++ b/src/features/sessions/utils/activityPanelCollapsedStore.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import {
+  deleteActivityPanelCollapsed,
   readActivityPanelCollapsed,
   writeActivityPanelCollapsed,
 } from './activityPanelCollapsedStore'
@@ -42,5 +43,39 @@ describe('activityPanelCollapsedStore', () => {
       'garbage'
     )
     expect(readActivityPanelCollapsed('sess-1')).toBe(false)
+  })
+
+  test('deleteActivityPanelCollapsed removes a persisted entry', () => {
+    writeActivityPanelCollapsed('sess-1', true)
+    expect(
+      window.localStorage.getItem(
+        'vimeflow:sessions:activityPanelCollapsed:sess-1'
+      )
+    ).toBe('true')
+
+    deleteActivityPanelCollapsed('sess-1')
+
+    expect(
+      window.localStorage.getItem(
+        'vimeflow:sessions:activityPanelCollapsed:sess-1'
+      )
+    ).toBeNull()
+    expect(readActivityPanelCollapsed('sess-1')).toBe(false)
+  })
+
+  test('deleteActivityPanelCollapsed is a no-op when no entry exists', () => {
+    expect(() => {
+      deleteActivityPanelCollapsed('never-written')
+    }).not.toThrow()
+  })
+
+  test('deleteActivityPanelCollapsed only touches the requested session', () => {
+    writeActivityPanelCollapsed('sess-1', true)
+    writeActivityPanelCollapsed('sess-2', true)
+
+    deleteActivityPanelCollapsed('sess-1')
+
+    expect(readActivityPanelCollapsed('sess-1')).toBe(false)
+    expect(readActivityPanelCollapsed('sess-2')).toBe(true)
   })
 })

--- a/src/features/sessions/utils/activityPanelCollapsedStore.test.ts
+++ b/src/features/sessions/utils/activityPanelCollapsedStore.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import {
+  readActivityPanelCollapsed,
+  writeActivityPanelCollapsed,
+} from './activityPanelCollapsedStore'
+
+describe('activityPanelCollapsedStore', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  test('defaults to false when nothing is persisted', () => {
+    expect(readActivityPanelCollapsed('sess-1')).toBe(false)
+  })
+
+  test('round-trips true', () => {
+    writeActivityPanelCollapsed('sess-1', true)
+    expect(readActivityPanelCollapsed('sess-1')).toBe(true)
+  })
+
+  test('round-trips false', () => {
+    writeActivityPanelCollapsed('sess-1', true)
+    writeActivityPanelCollapsed('sess-1', false)
+    expect(readActivityPanelCollapsed('sess-1')).toBe(false)
+  })
+
+  test('isolates by session id', () => {
+    writeActivityPanelCollapsed('sess-1', true)
+    writeActivityPanelCollapsed('sess-2', false)
+    expect(readActivityPanelCollapsed('sess-1')).toBe(true)
+    expect(readActivityPanelCollapsed('sess-2')).toBe(false)
+    expect(readActivityPanelCollapsed('sess-3')).toBe(false)
+  })
+
+  test('treats unparseable values as false', () => {
+    window.localStorage.setItem(
+      'vimeflow:sessions:activityPanelCollapsed:sess-1',
+      'garbage'
+    )
+    expect(readActivityPanelCollapsed('sess-1')).toBe(false)
+  })
+})

--- a/src/features/sessions/utils/activityPanelCollapsedStore.ts
+++ b/src/features/sessions/utils/activityPanelCollapsedStore.ts
@@ -1,0 +1,51 @@
+// UI-only persistence for the per-session agent-activity-panel collapse
+// preference. Lives at the frontend layer (localStorage) so the state is
+// decoupled from the PTY/agent lifecycle — toggling the bar should not
+// flow through the backend session cache, and surviving a restart is a
+// pure UI concern.
+//
+// Default `false` (expanded) when nothing has been persisted or when
+// localStorage is unavailable (SSR, sandboxed contexts, quota errors).
+
+const STORAGE_KEY_PREFIX = 'vimeflow:sessions:activityPanelCollapsed:'
+
+const storageKey = (sessionId: string): string =>
+  `${STORAGE_KEY_PREFIX}${sessionId}`
+
+const getStorage = (): Storage | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export const readActivityPanelCollapsed = (sessionId: string): boolean => {
+  const storage = getStorage()
+  if (!storage) {
+    return false
+  }
+  try {
+    return storage.getItem(storageKey(sessionId)) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export const writeActivityPanelCollapsed = (
+  sessionId: string,
+  collapsed: boolean
+): void => {
+  const storage = getStorage()
+  if (!storage) {
+    return
+  }
+  try {
+    storage.setItem(storageKey(sessionId), collapsed ? 'true' : 'false')
+  } catch {
+    // Quota exceeded / private mode — UI state stays consistent in memory.
+  }
+}

--- a/src/features/sessions/utils/activityPanelCollapsedStore.ts
+++ b/src/features/sessions/utils/activityPanelCollapsedStore.ts
@@ -49,3 +49,19 @@ export const writeActivityPanelCollapsed = (
     // Quota exceeded / private mode — UI state stays consistent in memory.
   }
 }
+
+// Replaces the implicit cleanup the Rust PTY cache used to do on
+// session exit. Call from the `removeSession` happy path so closed
+// sessions don't leak `vimeflow:sessions:activityPanelCollapsed:<id>`
+// keys into localStorage indefinitely.
+export const deleteActivityPanelCollapsed = (sessionId: string): void => {
+  const storage = getStorage()
+  if (!storage) {
+    return
+  }
+  try {
+    storage.removeItem(storageKey(sessionId))
+  } catch {
+    // Match the writer's silent-on-failure policy.
+  }
+}

--- a/src/features/sessions/utils/agentForSession.test.ts
+++ b/src/features/sessions/utils/agentForSession.test.ts
@@ -10,6 +10,7 @@ const baseSession: Omit<Session, 'agentType'> = {
   status: 'running',
   workingDirectory: '~',
   layout: 'single',
+  activityPanelCollapsed: false,
   panes: [
     {
       id: 'p0',
@@ -18,7 +19,6 @@ const baseSession: Omit<Session, 'agentType'> = {
       agentType: 'generic',
       status: 'running',
       active: true,
-      activityPanelCollapsed: null,
     },
   ],
   createdAt: '2026-05-06T00:00:00Z',
@@ -69,7 +69,6 @@ const basePane: Omit<Pane, 'agentType'> = {
   cwd: '~',
   status: 'running',
   active: true,
-  activityPanelCollapsed: null,
 }
 
 describe('agentForPane', () => {

--- a/src/features/sessions/utils/paneLifecycle.test.ts
+++ b/src/features/sessions/utils/paneLifecycle.test.ts
@@ -17,7 +17,6 @@ const mockPane = (overrides: Partial<Pane> = {}): Pane => ({
   agentType: 'generic',
   status: 'running',
   active: true,
-  activityPanelCollapsed: null,
   ...overrides,
 })
 
@@ -29,6 +28,7 @@ const mockSession = (overrides: Partial<Session> = {}): Session => ({
   workingDirectory: '/home/test',
   agentType: 'generic',
   layout: 'vsplit',
+  activityPanelCollapsed: false,
   panes: [mockPane({ id: 'p0', active: true })],
   createdAt: '2026-05-12T00:00:00Z',
   lastActivityAt: '2026-05-12T00:00:00Z',
@@ -135,7 +135,6 @@ describe('applyAddPane', () => {
     agentType: 'generic',
     status: 'running',
     active: true,
-    activityPanelCollapsed: null,
   }
 
   test('appends pane and flips existing pane to inactive', () => {
@@ -275,6 +274,7 @@ describe('applyRemovePane', () => {
       [
         mockSession({
           layout: 'quad',
+          activityPanelCollapsed: false,
           panes: [
             mockPane({ id: 'p0', ptyId: 'pty-0', active: true }),
             mockPane({ id: 'p1', ptyId: 'pty-1', active: false }),
@@ -309,6 +309,7 @@ describe('applyRemovePane', () => {
         mockSession({
           status: 'running',
           layout: 'vsplit',
+          activityPanelCollapsed: false,
           panes: [
             mockPane({ id: 'p0', status: 'completed', active: false }),
             mockPane({ id: 'p1', status: 'running', active: true }),

--- a/src/features/sessions/utils/pickNextVisibleSessionId.test.ts
+++ b/src/features/sessions/utils/pickNextVisibleSessionId.test.ts
@@ -13,6 +13,7 @@ const buildSession = (id: string, status: SessionStatus): Session => ({
   workingDirectory: '~',
   agentType: 'claude-code',
   layout: 'single',
+  activityPanelCollapsed: false,
   panes: [
     {
       id: 'p0',
@@ -21,7 +22,6 @@ const buildSession = (id: string, status: SessionStatus): Session => ({
       agentType: 'claude-code',
       status,
       active: true,
-      activityPanelCollapsed: null,
     },
   ],
   createdAt: '2026-05-06T00:00:00Z',

--- a/src/features/sessions/utils/sessionFromInfo.test.ts
+++ b/src/features/sessions/utils/sessionFromInfo.test.ts
@@ -1,15 +1,23 @@
-import { describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import type { SessionInfo } from '../../../bindings'
 import { sessionFromInfo } from './sessionFromInfo'
+import { writeActivityPanelCollapsed } from './activityPanelCollapsedStore'
 
 const aliveInfo = (id: string, cwd: string): SessionInfo => ({
   id,
   cwd,
   status: { kind: 'Alive', pid: 1234, replay_data: '', replay_end_offset: 0n },
-  activityPanelCollapsed: null,
 })
 
 describe('sessionFromInfo (pre-pane shape)', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
   test('produces a Session with id from info.id, status running for Alive', () => {
     const session = sessionFromInfo(aliveInfo('pty-1', '/home/will/repo'), 0)
     expect(session.id).toBe('pty-1')
@@ -24,7 +32,6 @@ describe('sessionFromInfo (pre-pane shape)', () => {
       id: 'pty-2',
       cwd: '/x',
       status: { kind: 'Exited', last_exit_code: null },
-      activityPanelCollapsed: null,
     }
     const session = sessionFromInfo(info, 0)
     expect(session.status).toBe('completed')
@@ -47,7 +54,6 @@ describe('sessionFromInfo (pre-pane shape)', () => {
       id: 'pty-2',
       cwd: '/x',
       status: { kind: 'Exited', last_exit_code: null },
-      activityPanelCollapsed: null,
     }
     const session = sessionFromInfo(info, 0)
     expect(session.panes).toHaveLength(1)
@@ -55,39 +61,14 @@ describe('sessionFromInfo (pre-pane shape)', () => {
     expect(session.panes[0].restoreData).toBeUndefined()
   })
 
-  test('reads activityPanelCollapsed from SessionInfo onto the first pane', () => {
-    const session = sessionFromInfo(
-      {
-        id: 'pty-1',
-        cwd: '/home/x',
-        status: {
-          kind: 'Alive',
-          pid: 1234,
-          replay_data: '',
-          replay_end_offset: 0n,
-        },
-        activityPanelCollapsed: true,
-      },
-      0
-    )
-    expect(session.panes[0].activityPanelCollapsed).toBe(true)
+  test('hydrates session.activityPanelCollapsed from localStorage', () => {
+    writeActivityPanelCollapsed('pty-1', true)
+    const session = sessionFromInfo(aliveInfo('pty-1', '/home/x'), 0)
+    expect(session.activityPanelCollapsed).toBe(true)
   })
 
-  test('defaults activityPanelCollapsed to null when SessionInfo carries null', () => {
-    const session = sessionFromInfo(
-      {
-        id: 'pty-2',
-        cwd: '/home/y',
-        status: {
-          kind: 'Alive',
-          pid: 5678,
-          replay_data: '',
-          replay_end_offset: 0n,
-        },
-        activityPanelCollapsed: null,
-      },
-      0
-    )
-    expect(session.panes[0].activityPanelCollapsed).toBeNull()
+  test('defaults session.activityPanelCollapsed to false when nothing persisted', () => {
+    const session = sessionFromInfo(aliveInfo('pty-2', '/home/y'), 0)
+    expect(session.activityPanelCollapsed).toBe(false)
   })
 })

--- a/src/features/sessions/utils/sessionFromInfo.ts
+++ b/src/features/sessions/utils/sessionFromInfo.ts
@@ -2,6 +2,7 @@ import type { SessionInfo } from '../../../bindings'
 import type { Pane, Session } from '../types'
 import { emptyActivity } from '../constants'
 import { tabName } from './tabName'
+import { readActivityPanelCollapsed } from './activityPanelCollapsedStore'
 
 /** Build a `Session` from a Rust `SessionInfo`. */
 export const sessionFromInfo = (info: SessionInfo, index: number): Session => {
@@ -14,7 +15,6 @@ export const sessionFromInfo = (info: SessionInfo, index: number): Session => {
     agentType: 'generic',
     status,
     active: true,
-    activityPanelCollapsed: info.activityPanelCollapsed ?? null,
   } satisfies Pane
 
   const pane: Pane =
@@ -39,6 +39,7 @@ export const sessionFromInfo = (info: SessionInfo, index: number): Session => {
     name: tabName(info.cwd, index),
     status,
     layout: 'single',
+    activityPanelCollapsed: readActivityPanelCollapsed(info.id),
     panes: [pane],
     workingDirectory: info.cwd,
     agentType: 'generic',

--- a/src/features/sessions/utils/sessionStatus.test.ts
+++ b/src/features/sessions/utils/sessionStatus.test.ts
@@ -9,7 +9,6 @@ const pane = (status: Pane['status']): Pane => ({
   agentType: 'generic',
   status,
   active: true,
-  activityPanelCollapsed: null,
 })
 
 describe('deriveSessionStatus', () => {

--- a/src/features/terminal/Terminal.integration.test.tsx
+++ b/src/features/terminal/Terminal.integration.test.tsx
@@ -34,6 +34,7 @@ const createTestSession = (sessionId: string, cwd: string): Session => ({
   workingDirectory: cwd,
   agentType: 'generic',
   layout: 'single',
+  activityPanelCollapsed: false,
   panes: [
     {
       id: 'p0',
@@ -42,7 +43,6 @@ const createTestSession = (sessionId: string, cwd: string): Session => ({
       agentType: 'generic',
       status: 'running',
       active: true,
-      activityPanelCollapsed: null,
     },
   ],
   createdAt: '2026-05-08T00:00:00Z',

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -71,6 +71,7 @@ const makeSession = (
   workingDirectory: '/tmp/fixture',
   agentType: 'generic',
   layout,
+  activityPanelCollapsed: false,
   panes: Array.from(
     { length: paneCount },
     (_, i): Pane => ({
@@ -80,7 +81,6 @@ const makeSession = (
       agentType: 'generic',
       status: 'running',
       active: i === activeIndex,
-      activityPanelCollapsed: null,
       pid: 1000 + i,
       restoreData: {
         sessionId: `pty-${i}`,
@@ -640,7 +640,6 @@ describe('selectVisiblePanes', () => {
     agentType: 'generic',
     status: 'running',
     active,
-    activityPanelCollapsed: null,
     pid: 1,
   })
 

--- a/src/features/terminal/components/TerminalPane/Header.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Header.test.tsx
@@ -13,6 +13,7 @@ const session: Session = {
   workingDirectory: '/home/user/repo',
   agentType: 'claude-code',
   layout: 'single',
+  activityPanelCollapsed: false,
   panes: [
     {
       id: 'p0',
@@ -21,7 +22,6 @@ const session: Session = {
       agentType: 'claude-code',
       status: 'running',
       active: true,
-      activityPanelCollapsed: null,
     },
   ],
   createdAt: '2026-05-08T10:00:00Z',

--- a/src/features/terminal/components/TerminalPane/HeaderMetadata.test.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderMetadata.test.tsx
@@ -14,6 +14,7 @@ const session: Session = {
   workingDirectory: '/home/user/repo',
   agentType: 'claude-code',
   layout: 'single',
+  activityPanelCollapsed: false,
   panes: [
     {
       id: 'p0',
@@ -22,7 +23,6 @@ const session: Session = {
       agentType: 'claude-code',
       status: 'running',
       active: true,
-      activityPanelCollapsed: null,
     },
   ],
   createdAt: '2026-05-08T10:00:00Z',

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -73,6 +73,7 @@ const session: Session = {
   workingDirectory: '/home/user/repo',
   agentType: 'claude-code',
   layout: 'single',
+  activityPanelCollapsed: false,
   panes: [
     {
       id: 'p0',
@@ -81,7 +82,6 @@ const session: Session = {
       agentType: 'claude-code',
       status: 'running',
       active: true,
-      activityPanelCollapsed: null,
     },
   ],
   createdAt: '2026-05-08T10:00:00Z',

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -18,6 +18,7 @@ const makeSession = (
   workingDirectory: '/tmp',
   agentType: 'generic',
   layout,
+  activityPanelCollapsed: false,
   panes: paneIds.map((paneId, index) => ({
     id: paneId,
     ptyId: `pty-${paneId}`,
@@ -25,7 +26,6 @@ const makeSession = (
     agentType: 'generic',
     status: 'running',
     active: index === activeIndex,
-    activityPanelCollapsed: null,
   })),
   createdAt: '2026-05-12T00:00:00Z',
   lastActivityAt: '2026-05-12T00:00:00Z',

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -90,6 +90,7 @@ const createMockSession = (id: string, name: string): Session => ({
   workingDirectory: '/home/user',
   agentType: 'claude-code',
   layout: 'single',
+  activityPanelCollapsed: false,
   panes: [
     {
       id: 'p0',
@@ -98,7 +99,6 @@ const createMockSession = (id: string, name: string): Session => ({
       agentType: 'claude-code',
       status: 'running',
       active: true,
-      activityPanelCollapsed: null,
     },
   ],
   createdAt: '2024-01-01T00:00:00Z',
@@ -154,7 +154,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
       reorderSessions: vi.fn(),
       updatePaneCwd: vi.fn(),
       updatePaneAgentType: vi.fn(),
-      setPaneActivityPanelCollapsed: vi.fn(),
+      setSessionActivityPanelCollapsed: vi.fn(),
       updateSessionCwd: vi.fn(),
       updateSessionAgentType: vi.fn(),
       restoreData: new Map(),

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -339,16 +339,14 @@ describe('WorkspaceView Integration Tests', () => {
 
       expect(await screen.findByTestId('agent-status-rail')).toBeInTheDocument()
 
+      // Session-scoped UI state — must NOT call the agent/PTY backend.
       const serviceResults = vi.mocked(createTerminalService).mock.results
       const serviceResult = serviceResults[serviceResults.length - 1]
 
       const service = serviceResult?.value as {
         setSessionActivityPanelCollapsed: ReturnType<typeof vi.fn>
       }
-      expect(service.setSessionActivityPanelCollapsed).toHaveBeenCalledWith({
-        id: 'sess-1',
-        collapsed: true,
-      })
+      expect(service.setSessionActivityPanelCollapsed).not.toHaveBeenCalled()
 
       await user.click(
         screen.getByRole('button', { name: /expand activity panel/i })

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -128,7 +128,7 @@ export const WorkspaceView = (): ReactElement => {
     reorderSessions,
     updatePaneCwd,
     updatePaneAgentType,
-    setPaneActivityPanelCollapsed,
+    setSessionActivityPanelCollapsed,
     setSessionActivePane,
     setSessionLayout,
     addPane,
@@ -216,7 +216,7 @@ export const WorkspaceView = (): ReactElement => {
   const activePanePtyId = activePane?.ptyId
 
   const agentStatus = useAgentStatus(activePanePtyId ?? null)
-  const activityPanelCollapsed = activePane?.activityPanelCollapsed ?? false
+  const activityPanelCollapsed = activeSession?.activityPanelCollapsed ?? false
 
   const activityPanelAgent = useMemo(
     () => AGENTS[agentTypeToRegistryKey(agentStatus.agentType)],
@@ -233,28 +233,13 @@ export const WorkspaceView = (): ReactElement => {
   const activityPanelStatus: SessionStatus = activePane?.status ?? 'paused'
 
   const handleActivityPanelCollapsed = useCallback(
-    async (collapsed: boolean): Promise<void> => {
-      if (!activeSessionId || !activePane) {
+    (collapsed: boolean): void => {
+      if (!activeSessionId) {
         return
       }
-
-      try {
-        await setPaneActivityPanelCollapsed(
-          activeSessionId,
-          activePane.id,
-          collapsed
-        )
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error)
-        // 'Error: ' prefix is a minimal severity signal until the
-        // notification API gains a typed level. Without it, a banner styled
-        // identically to routine `notifyInfo` messages can be mistaken for a
-        // status update when it actually means the persist failed and the
-        // optimistic UI just snapped back.
-        notifyInfo(`Error: Couldn't update activity panel: ${message}`)
-      }
+      setSessionActivityPanelCollapsed(activeSessionId, collapsed)
     },
-    [activePane, activeSessionId, notifyInfo, setPaneActivityPanelCollapsed]
+    [activeSessionId, setSessionActivityPanelCollapsed]
   )
 
   // Bridge: keep pane chrome in sync with agent detection for the active
@@ -1043,7 +1028,7 @@ export const WorkspaceView = (): ReactElement => {
             )}
             isRunning={agentStatus.isActive}
             onExpand={() => {
-              void handleActivityPanelCollapsed(false)
+              handleActivityPanelCollapsed(false)
             }}
           />
         ) : (
@@ -1056,7 +1041,7 @@ export const WorkspaceView = (): ReactElement => {
             agent={activityPanelAgent}
             status={activityPanelStatus}
             onCollapse={() => {
-              void handleActivityPanelCollapsed(true)
+              handleActivityPanelCollapsed(true)
             }}
           />
         )}

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -443,6 +443,7 @@ describe('TerminalZone', () => {
       workingDirectory: '/tmp/a',
       agentType: 'generic',
       layout: 'vsplit',
+      activityPanelCollapsed: false,
       panes: [
         {
           id: 'p0',
@@ -451,7 +452,6 @@ describe('TerminalZone', () => {
           agentType: 'generic',
           status: 'running',
           active: true,
-          activityPanelCollapsed: null,
           pid: 1001,
           restoreData: {
             sessionId: 'pty-a',
@@ -469,7 +469,6 @@ describe('TerminalZone', () => {
           agentType: 'generic',
           status: 'running',
           active: false,
-          activityPanelCollapsed: null,
           pid: 1002,
           restoreData: {
             sessionId: 'pty-b',

--- a/src/features/workspace/data/mockSessions.ts
+++ b/src/features/workspace/data/mockSessions.ts
@@ -10,6 +10,7 @@ export const mockSessions: Session[] = [
     workingDirectory: '~',
     agentType: 'claude-code',
     layout: 'single',
+    activityPanelCollapsed: false,
     panes: [
       {
         id: 'p0',
@@ -18,7 +19,6 @@ export const mockSessions: Session[] = [
         agentType: 'claude-code',
         status: 'running',
         active: true,
-        activityPanelCollapsed: null,
         pid: 12345,
       },
     ],
@@ -35,6 +35,7 @@ export const mockSessions: Session[] = [
     workingDirectory: '~',
     agentType: 'claude-code',
     layout: 'single',
+    activityPanelCollapsed: false,
     panes: [
       {
         id: 'p0',
@@ -43,7 +44,6 @@ export const mockSessions: Session[] = [
         agentType: 'claude-code',
         status: 'paused',
         active: true,
-        activityPanelCollapsed: null,
         pid: 12346,
       },
     ],
@@ -60,6 +60,7 @@ export const mockSessions: Session[] = [
     workingDirectory: '~',
     agentType: 'claude-code',
     layout: 'single',
+    activityPanelCollapsed: false,
     panes: [
       {
         id: 'p0',
@@ -68,7 +69,6 @@ export const mockSessions: Session[] = [
         agentType: 'claude-code',
         status: 'completed',
         active: true,
-        activityPanelCollapsed: null,
       },
     ],
     createdAt: '2026-04-07T02:00:00Z',
@@ -83,6 +83,7 @@ export const mockSessions: Session[] = [
     workingDirectory: '~',
     agentType: 'claude-code',
     layout: 'single',
+    activityPanelCollapsed: false,
     panes: [
       {
         id: 'p0',
@@ -91,7 +92,6 @@ export const mockSessions: Session[] = [
         agentType: 'claude-code',
         status: 'running',
         active: true,
-        activityPanelCollapsed: null,
         pid: 12347,
       },
     ],
@@ -108,6 +108,7 @@ export const mockSessions: Session[] = [
     workingDirectory: '~',
     agentType: 'claude-code',
     layout: 'single',
+    activityPanelCollapsed: false,
     panes: [
       {
         id: 'p0',
@@ -116,7 +117,6 @@ export const mockSessions: Session[] = [
         agentType: 'claude-code',
         status: 'completed',
         active: true,
-        activityPanelCollapsed: null,
       },
     ],
     createdAt: '2026-04-05T12:10:00Z',


### PR DESCRIPTION
## Summary
- Lift `activityPanelCollapsed` from `Pane` to `Session` so switching panes within a session no longer jumps the right-hand agent activity bar.
- Persist via a UI-side `localStorage` helper keyed by session id (`vimeflow:sessions:activityPanelCollapsed:<id>`); the per-PTY backend cache + IPC are no longer called from the frontend (Rust handler left in place; cleanup is a follow-up).
- Drop ~150 lines of IPC-chain rollback machinery the old per-pane async setter required.

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test` — 2547 passed / 3 skipped
- [ ] Manually toggle the bar on a multi-pane session; switching panes preserves state across panes and survives an app restart.