### PR TITLE
fix: ignore .claude/worktrees/ in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ VISUAL_VERIFICATION.md
 
 # Git worktrees (local per-agent checkouts)
 /worktrees/
+/.claude/worktrees/
 
 # Vimeflow runtime data (statusline sessions, etc.)
 .vimeflow/


### PR DESCRIPTION
## Summary
- fix: ignore .claude/worktrees/ in git

## Test plan
- [x] `git check-ignore -v .claude/worktrees/<any>` resolves to the new `.gitignore` line
- [x] `git status` in the primary checkout no longer lists `.claude/worktrees/*` as untracked
- [x] Workspace Changed Files panel shows only real modified files, not worktree directory names