### PR TITLE
refactor(agent-adapter): Step B'' — TranscriptState on Arc<dyn TranscriptStreamer>

### DIFF
--- a/crates/backend/src/agent/README.md
+++ b/crates/backend/src/agent/README.md
@@ -287,7 +287,7 @@ The runtime details are split by responsibility:
 1. `base/path_security.rs` canonicalizes `trust_root`, walks to the deepest existing ancestor of `src.path`, asserts under `trust_root`, creates the parent, then re-canonicalizes and re-asserts.
 2. `base/watcher_runtime.rs` builds the `notify` watcher with a 100ms debounce, filters events on the target file, performs the inline-init read, and spawns the 3s polling fallback for WSL2/inotify gaps and atomic-write rename patterns.
 3. `base/diagnostics.rs` owns `watcher.event` / `watcher.slow_event` / `watcher.tx_path_change` support types: `EventTiming`, `PathHistory`, and `TxOutcome`.
-4. `base/transcript_state.rs` owns the transcript registry. When `parse_status` yields a transcript path, the watcher runtime routes through `TranscriptState::start_or_replace(adapter.clone(), …)`, which owns the `(transcript_path, cwd)` identity check, `Replaced` / `AlreadyRunning` short-circuit, and previous-handle cleanup.
+4. `base/transcript_state.rs` owns the transcript registry. When the watcher resolves a transcript path (via `TranscriptPathSource`), it routes through `TranscriptState::start_or_replace(streamer.clone(), …)` — `pub(crate)`, taking `Arc<dyn TranscriptStreamer>` as of step B'' (was `Arc<dyn AgentAdapter>`) — which owns the `(transcript_path, cwd)` identity check, `Replaced` / `AlreadyRunning` short-circuit, and previous-handle cleanup.
 5. `base/watcher_runtime.rs` constructs the `WatcherHandle` with `_watcher: Some(...)`, `transcript_state: state.clone()`, and `session_id: sid.clone()` so its `Drop` can cascade.
 
 ---
@@ -371,7 +371,7 @@ pub enum TranscriptStartStatus { Started, Replaced, AlreadyRunning }
 
 Constructed once inside `BackendState` and passed into watcher startup. **Visibility:** `pub #[doc(hidden)]` — production code goes through the trait surface (`AgentAdapter::start`), but `crates/backend/tests/transcript_*.rs` integration tests drive `TranscriptState::start_or_replace` directly to isolate transcript-parsing assertions from watcher-orchestration assertions. `#[doc(hidden)]` keeps it out of generated docs; a doc-comment on each pub item warns "Test-only public surface — production code MUST use AgentAdapter::start instead."
 
-`start_or_replace` takes `Arc<dyn AgentAdapter>` so the registry can route the spawn through `adapter.tail_transcript(…)` without re-coupling `base` to any specific adapter. The replace-vs-keep identity check on `(transcript_path, cwd)` is unchanged — only the spawn site changes.
+As of step B'', `start_or_replace` is `pub(crate)` and takes `Arc<dyn TranscriptStreamer>` (B' had it on the transitional `Arc<dyn AgentAdapter>` façade), so the registry routes the spawn through `streamer.tail(…)` without re-coupling `base` to any specific adapter or to the broader `AgentAdapter` surface. The replace-vs-keep identity check on `(transcript_path, cwd)` is unchanged — only the spawn site changes. (Surrounding `Arc<dyn AgentAdapter>` snippets in this section pre-date the split and describe the legacy monolithic shape; the live signature is the B'' one.)
 
 ---
 

--- a/crates/backend/src/agent/adapter/base/transcript_state.rs
+++ b/crates/backend/src/agent/adapter/base/transcript_state.rs
@@ -5,16 +5,17 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use crate::agent::adapter::AgentAdapter;
+use crate::agent::adapter::traits::TranscriptStreamer;
 use crate::runtime::EventSink;
 
-/// Internal lifecycle type — created by adapter `tail_transcript`
+/// Internal lifecycle type — created by `TranscriptStreamer::tail`
 /// implementations (e.g., `claude_code::transcript::start_tailing` via
 /// `TranscriptHandle::new`, which is `pub(crate)`) and owned by
 /// `TranscriptState`'s internal `TranscriptWatcher` map. The type
 /// itself must remain `pub` because it appears in the
-/// `AgentAdapter::tail_transcript` trait signature, which is publicly
-/// visible from `agent::adapter::mod`. Construction is gated to the
+/// `TranscriptStreamer::tail` trait signature (and, until D' removes
+/// it, the transitional `AgentAdapter::tail_transcript` façade), which
+/// is visible from `agent::adapter`. Construction is gated to the
 /// crate via `pub(crate) fn new`; do not bypass that path.
 #[doc(hidden)]
 pub struct TranscriptHandle {
@@ -70,7 +71,7 @@ struct TranscriptWatcher {
 
 /// Runtime-managed registry of in-flight transcript tailers, one per
 /// session. Constructed once as part of `BackendState` and passed to the
-/// watcher runtime and adapter `tail_transcript` impls. `pub` supports
+/// watcher runtime and `TranscriptStreamer::tail` impls. `pub` supports
 /// direct instantiation in `#[cfg(test)]` integration tests under
 /// `crates/backend/tests/transcript_*.rs`; do not construct ad hoc instances
 /// in production code paths.
@@ -78,7 +79,7 @@ struct TranscriptWatcher {
 #[derive(Default, Clone)]
 pub struct TranscriptState {
     watchers: Arc<Mutex<HashMap<String, TranscriptWatcher>>>,
-    /// Per-session "start gate" — held across `tail_transcript` so the
+    /// Per-session "start gate" — held across `tail` so the
     /// notify callback and the 3s poll thread can't both pass the
     /// AlreadyRunning check, both spawn, and both emit duplicate
     /// `agent-tool-call` / `agent-turn` events from byte 0 of the
@@ -98,9 +99,18 @@ impl TranscriptState {
 
     /// Start tailing when none is active, or switch to a newer transcript
     /// path or workspace cwd.
-    pub fn start_or_replace(
+    ///
+    /// Step B'' narrowed the parameter from `Arc<dyn AgentAdapter>` to
+    /// `Arc<dyn TranscriptStreamer>` — `base` only ever needed the
+    /// `tail` spawn method, never the full adapter façade — and
+    /// narrowed visibility to `pub(crate)` (the only callers are the
+    /// watcher runtime + same-crate tests). The shared
+    /// `Arc<CompositeLocator>` plumbing from B' cycle 11 means
+    /// `bindings.streamer` already references the same allocation the
+    /// watcher's locator does.
+    pub(crate) fn start_or_replace(
         &self,
-        adapter: Arc<dyn AgentAdapter>,
+        streamer: Arc<dyn TranscriptStreamer>,
         events: Arc<dyn EventSink>,
         session_id: String,
         transcript_path: PathBuf,
@@ -110,7 +120,7 @@ impl TranscriptState {
         // one start_or_replace call per session can be inside the
         // check + spawn + insert critical section at a time. Without
         // this, the notify callback and 3s poll thread can both pass
-        // the AlreadyRunning check, both call adapter.tail_transcript,
+        // the AlreadyRunning check, both call streamer.tail,
         // and both emit events from byte 0 of the JSONL during the
         // tens-of-ms thread-spawn window before the loser's handle is
         // stopped (Claude review on PR #152, F2).
@@ -142,10 +152,10 @@ impl TranscriptState {
         // `start_or_replace` or `stop()` for this session can observe that
         // gap (both acquire the gate first, F4).
         //
-        // Trade-off: if `adapter.tail_transcript` fails AFTER the old
+        // Trade-off: if `streamer.tail` fails AFTER the old
         // watcher is stopped, the caller gets the error AND the session is
         // left with no active watcher. Previously (spawn-first order) a
-        // tail_transcript failure preserved the old watcher. The new
+        // tail failure preserved the old watcher. The new
         // behaviour is intentional for the Replaced path: a cwd change
         // means the old cwd is no longer the correct routing context, so a
         // failed swap should fail loudly rather than silently keep a
@@ -165,7 +175,7 @@ impl TranscriptState {
             handle.stop();
         }
 
-        let new_handle = adapter.tail_transcript(
+        let new_handle = streamer.tail(
             events,
             session_id.clone(),
             cwd.clone(),
@@ -211,7 +221,7 @@ impl TranscriptState {
         // Acquire the per-session start gate before touching `watchers`
         // (Claude review on PR #152, F4). Without this, an in-flight
         // `start_or_replace` could be between its drop-watchers-lock /
-        // tail_transcript-spawn / re-acquire-watchers steps when stop()
+        // tail-spawn / re-acquire-watchers steps when stop()
         // ran concurrently and removed the entry. `start_or_replace`
         // would then insert the freshly-spawned T1 as `Started` even
         // though `stop()` already ran — leaving T1 as a zombie tail
@@ -226,7 +236,7 @@ impl TranscriptState {
         // Intentionally do NOT remove this session's entry from
         // `start_gates`. If we deleted the gate after releasing it, a
         // subsequent `start_or_replace` would lookup the empty map
-        // slot, create a NEW gate, and enter `tail_transcript`
+        // slot, create a NEW gate, and enter `tail`
         // concurrently with another already-in-flight start that still
         // holds a clone of the OLD gate. Gates are ~56 bytes each
         // (`String` key + `Arc<Mutex<()>>` value); leaving them for
@@ -277,7 +287,7 @@ mod tests {
 
         let state = TranscriptState::new();
         let session_id = "session-1".to_string();
-        let adapter: Arc<dyn AgentAdapter> =
+        let adapter: Arc<dyn TranscriptStreamer> =
             Arc::new(crate::agent::adapter::claude_code::ClaudeCodeAdapter);
 
         let first_status = state
@@ -319,7 +329,7 @@ mod tests {
         let cwd = tmp.path().to_path_buf();
 
         let state = TranscriptState::new();
-        let adapter: Arc<dyn AgentAdapter> =
+        let adapter: Arc<dyn TranscriptStreamer> =
             Arc::new(crate::agent::adapter::claude_code::ClaudeCodeAdapter);
 
         let status = state
@@ -347,7 +357,7 @@ mod tests {
 
         let state = TranscriptState::new();
         let session_id = "session-cwd-change".to_string();
-        let adapter: Arc<dyn AgentAdapter> =
+        let adapter: Arc<dyn TranscriptStreamer> =
             Arc::new(crate::agent::adapter::claude_code::ClaudeCodeAdapter);
 
         let first = state
@@ -416,55 +426,28 @@ mod tests {
     /// produced duplicate `agent-tool-call` / `agent-turn` events on the
     /// frontend.
     ///
-    /// The invariant is observed via a custom adapter that records the
-    /// order of `tail_transcript` calls AND the order of stop-flag flips
+    /// The invariant is observed via a custom streamer that records the
+    /// order of `tail` calls AND the order of stop-flag flips
     /// on the handles it returns. After two `start_or_replace` calls (cwd
     /// A then cwd B on the same transcript_path), the recorded sequence
     /// must be: `spawn(A)`, `stop(A)`, `spawn(B)` — NOT `spawn(A)`,
     /// `spawn(B)`, `stop(A)`.
     ///
-    /// Claude review on PR #152, F19.
+    /// Claude review on PR #152, F19. Step B'' retyped the mock from a
+    /// full `AgentAdapter` (4 `unreachable!()` stubs + the real
+    /// `tail_transcript`) to a lean `TranscriptStreamer` — the only
+    /// trait `start_or_replace` now needs.
     #[test]
     fn replace_on_cwd_change_stops_old_before_spawning_new() {
         use std::sync::Mutex;
 
-        struct OrderingAdapter {
+        struct OrderingStreamer {
             events: Arc<Mutex<Vec<String>>>,
             stop_flags: Arc<Mutex<Vec<Arc<AtomicBool>>>>,
         }
 
-        impl crate::agent::adapter::types::TranscriptPathSource for OrderingAdapter {}
-
-        impl AgentAdapter for OrderingAdapter {
-            fn agent_type(&self) -> crate::agent::types::AgentType {
-                crate::agent::types::AgentType::ClaudeCode
-            }
-
-            fn located_status_source(
-                &self,
-                _cwd: &std::path::Path,
-                _session_id: &str,
-            ) -> Result<crate::agent::adapter::types::LocatedStatusSource, String> {
-                unreachable!("located_status_source not exercised in this test")
-            }
-
-            fn parse_status(
-                &self,
-                _session_id: &str,
-                _raw: &str,
-            ) -> Result<crate::agent::adapter::types::ParsedStatus, String> {
-                unreachable!("parse_status not exercised in this test")
-            }
-
-            fn validate_transcript(
-                &self,
-                _raw: &str,
-            ) -> Result<PathBuf, crate::agent::adapter::types::ValidateTranscriptError>
-            {
-                unreachable!("validate_transcript not exercised in this test")
-            }
-
-            fn tail_transcript(
+        impl TranscriptStreamer for OrderingStreamer {
+            fn tail(
                 &self,
                 _events: Arc<dyn crate::runtime::EventSink>,
                 _session_id: String,
@@ -516,7 +499,7 @@ mod tests {
 
         let events = Arc::new(Mutex::new(Vec::<String>::new()));
         let stop_flags = Arc::new(Mutex::new(Vec::<Arc<AtomicBool>>::new()));
-        let adapter: Arc<dyn AgentAdapter> = Arc::new(OrderingAdapter {
+        let adapter: Arc<dyn TranscriptStreamer> = Arc::new(OrderingStreamer {
             events: Arc::clone(&events),
             stop_flags: Arc::clone(&stop_flags),
         });

--- a/crates/backend/src/agent/adapter/base/watcher_runtime.rs
+++ b/crates/backend/src/agent/adapter/base/watcher_runtime.rs
@@ -17,17 +17,16 @@ use super::super::bindings::AgentBindings;
 use super::diagnostics::short_sid;
 use super::diagnostics::{record_event_diag, EventTiming, PathHistory, TxOutcome};
 use super::transcript_state::{TranscriptStartStatus, TranscriptState};
-// `TranscriptPathValidator` is referenced as `Arc<dyn TranscriptPathValidator>`
-// in `maybe_start_transcript`'s signature, so it must be in scope. `StateDecoder`
-// is consumed only via method dispatch on `Arc<dyn StateDecoder>` (vtable), so
-// it does not need to appear here. PR #261 cycle 2 review F9 — clarified
-// that the previous blanket `#[allow(unused_imports)]` on both traits was
-// only load-bearing for one (validator).
-use super::super::traits::TranscriptPathValidator;
+// `TranscriptPathValidator` and `TranscriptStreamer` are referenced as
+// `Arc<dyn ...>` in `maybe_start_transcript`'s signature, so both must be
+// in scope. `StateDecoder` is consumed only via method dispatch on
+// `Arc<dyn StateDecoder>` (vtable), so it does not need to appear here
+// (PR #261 cycle 2 review F9). Step B'' added `TranscriptStreamer` here
+// when `start_or_replace` migrated off `Arc<dyn AgentAdapter>`.
+use super::super::traits::{TranscriptPathValidator, TranscriptStreamer};
 use crate::agent::adapter::types::{
     stamp_snapshot, LocatedStatusSource, RawPath, TranscriptPathSource, ValidateTranscriptError,
 };
-use crate::agent::adapter::AgentAdapter;
 use crate::agent::events::emit_agent_status;
 use crate::runtime::EventSink;
 use crate::terminal::PtyState;
@@ -174,7 +173,7 @@ impl AgentWatcherState {
 /// check, a cwd change triggers a Replace of the tail thread.
 fn maybe_start_transcript(
     validator: &Arc<dyn TranscriptPathValidator>,
-    adapter_for_transcript_state: &Arc<dyn AgentAdapter>,
+    streamer: &Arc<dyn TranscriptStreamer>,
     events: Arc<dyn EventSink>,
     pty_state: &PtyState,
     transcript_state: &TranscriptState,
@@ -216,14 +215,14 @@ fn maybe_start_transcript(
         .get_cwd(&session_id.to_string())
         .map(PathBuf::from);
 
-    // Step B': `TranscriptState::start_or_replace` still takes an
-    // `Arc<dyn AgentAdapter>` until B'' migrates it onto
-    // `Arc<dyn TranscriptStreamer>`. We hand over the same façade
-    // adapter the bindings carry — the two paths agree by
-    // construction (`AgentBindings::for_attach` builds both views
-    // from the same underlying struct).
+    // Step B'': `TranscriptState::start_or_replace` now takes
+    // `Arc<dyn TranscriptStreamer>` directly (was `Arc<dyn AgentAdapter>`
+    // through B'). `bindings.streamer` is the concrete adapter's
+    // streamer view — for Codex it shares the same `Arc<CompositeLocator>`
+    // the watcher's locator uses (B' cycle 11), so there's no second
+    // locator allocation.
     match transcript_state.start_or_replace(
-        adapter_for_transcript_state.clone(),
+        streamer.clone(),
         events,
         session_id.to_string(),
         canonical.clone(),
@@ -304,50 +303,39 @@ pub(super) fn start_watching(
     // Step B': pull the trait views out of bindings up front. Each
     // is `Arc<dyn ...>` — cheap to clone into closures and threads.
     //
-    // Three `AgentBindings` fields are intentionally NOT destructured
-    // here and drop with the function-local move (PR #261 cycle 8
-    // review F24 — `#[allow(dead_code)]` silences these, so the
-    // omission is intentional and listed explicitly so the B''
-    // reviewer can audit the migration without re-deriving why):
+    // Two `AgentBindings` fields are intentionally NOT destructured
+    // here and drop with the function-local move:
     //
     // - `bindings.locator` — already used by `start_for` before this
     //   function runs (it borrowed `&bindings.locator` to call
     //   `locate(...)` and produce the `LocatedStatusSource` passed in
     //   as `located`). The `Arc` itself wasn't consumed there — it
     //   stayed alive on `bindings` and drops with this function-local
-    //   move now (PR #261 cycle 11 review F32 — earlier comment
-    //   said "consumed" but the locator was only borrowed). The
-    //   watcher itself doesn't need the locator again.
-    // - `bindings.streamer` — reserved for B'' which migrates
-    //   `TranscriptState::start_or_replace` onto
-    //   `Arc<dyn TranscriptStreamer>`. B'' MUST consume
-    //   `bindings.streamer` directly (not construct a fresh
-    //   `Arc<dyn TranscriptStreamer>` at the call site), because for
-    //   the Codex arm `bindings.streamer` and
-    //   `bindings.adapter_for_transcript_state` are clones of the
-    //   SAME `Arc<CodexAdapter>` — which holds the shared
-    //   `Arc<CompositeLocator>` from cycle 11 F31. Constructing a
-    //   fresh adapter at the B'' call site would re-introduce the
-    //   double-locator hazard cycle 11 closed. B'' will extract this
-    //   field AND remove `adapter_for_transcript_state` in the same
-    //   step. The compiler currently can't catch a B'' that forgets
-    //   to extract `streamer` because the field is silenced;
-    //   compensate by keeping this comment as the human-readable
-    //   migration checkpoint (PR #261 cycle 13 review F36).
+    //   move now (PR #261 cycle 11 review F32). The watcher itself
+    //   doesn't need the locator again.
     // - `bindings.agent_type` — diagnostics-only; the watcher
     //   doesn't branch on it (each adapter's split-trait impls
     //   carry their own behavior).
+    //
+    // Step B'' (this PR): `bindings.streamer` is now CONSUMED here and
+    // threaded into `TranscriptState::start_or_replace` (which migrated
+    // off `Arc<dyn AgentAdapter>` onto `Arc<dyn TranscriptStreamer>`).
+    // The former transitional `bindings.adapter_for_transcript_state`
+    // field was removed in this step — the cycle-11 shared-`Arc`
+    // guarantee now lives entirely in `bindings.streamer` (for Codex it
+    // is the `Arc<CodexAdapter>` that shares the same
+    // `Arc<CompositeLocator>` the locator uses).
     let decoder = bindings.decoder;
     let validator = bindings.validator;
     let transcript_paths = bindings.transcript_paths;
-    let adapter_for_transcript_state = bindings.adapter_for_transcript_state;
+    let streamer = bindings.streamer;
 
     let notify_timing_for_cb = notify_timing.clone();
     let path_history_for_cb = path_history.clone();
     let decoder_for_cb = decoder.clone();
     let validator_for_cb = validator.clone();
     let transcript_paths_for_cb = transcript_paths.clone();
-    let adapter_for_transcript_state_cb = adapter_for_transcript_state.clone();
+    let streamer_for_cb = streamer.clone();
     let last_processed_for_cb = last_processed.clone();
     let events_for_cb = events.clone();
     let pty_state_for_cb = pty_state.clone();
@@ -435,7 +423,7 @@ pub(super) fn start_watching(
                     Some(path) => {
                         let outcome = maybe_start_transcript(
                             &validator_for_cb,
-                            &adapter_for_transcript_state_cb,
+                            &streamer_for_cb,
                             events_for_cb.clone(),
                             &pty_state_for_cb,
                             &transcript_state_for_cb,
@@ -497,7 +485,7 @@ pub(super) fn start_watching(
         let initial_decoder = decoder.clone();
         let initial_validator = validator.clone();
         let initial_transcript_paths = transcript_paths.clone();
-        let initial_adapter_for_transcript_state = adapter_for_transcript_state.clone();
+        let initial_streamer = streamer.clone();
         let initial_events = events.clone();
         let initial_pty_state = pty_state.clone();
         let initial_transcript_state = transcript_state.clone();
@@ -519,7 +507,7 @@ pub(super) fn start_watching(
                         ) {
                             outcome = maybe_start_transcript(
                                 &initial_validator,
-                                &initial_adapter_for_transcript_state,
+                                &initial_streamer,
                                 initial_events.clone(),
                                 &initial_pty_state,
                                 &initial_transcript_state,
@@ -567,7 +555,7 @@ pub(super) fn start_watching(
         let poll_decoder = decoder.clone();
         let poll_validator = validator.clone();
         let poll_transcript_paths = transcript_paths.clone();
-        let poll_adapter_for_transcript_state = adapter_for_transcript_state.clone();
+        let poll_streamer = streamer.clone();
         // Step 0c: poll thread also routes transcript-path lookups
         // through `TranscriptPathSource` and so needs its own clone of
         // the `LocatedStatusSource`.
@@ -627,7 +615,7 @@ pub(super) fn start_watching(
                             Some(path) => {
                                 let outcome = maybe_start_transcript(
                                     &poll_validator,
-                                    &poll_adapter_for_transcript_state,
+                                    &poll_streamer,
                                     poll_events.clone(),
                                     &poll_pty_state,
                                     &poll_transcript_state,

--- a/crates/backend/src/agent/adapter/bindings.rs
+++ b/crates/backend/src/agent/adapter/bindings.rs
@@ -13,15 +13,11 @@
 //! - `bindings.transcript_paths` — dynamic / static transcript hints.
 //! - `bindings.validator` — raw path → canonical path (security
 //!   check).
-//! - `bindings.streamer` — spawn the tail thread.
-//!
-//! Plus one transitional field:
-//!
-//! - `bindings.adapter_for_transcript_state` — the `Arc<dyn AgentAdapter>`
-//!   that `TranscriptState::start_or_replace` STILL takes in B'.
-//!   B'' migrates that signature onto `Arc<dyn TranscriptStreamer>`
-//!   directly; until then bindings carry both views of the same
-//!   underlying adapter struct so the two paths agree.
+//! - `bindings.streamer` — spawn the tail thread. Step B'' wired this
+//!   directly into `TranscriptState::start_or_replace`
+//!   (`Arc<dyn TranscriptStreamer>`), removing the former transitional
+//!   `adapter_for_transcript_state: Arc<dyn AgentAdapter>` field that
+//!   B' carried only because `start_or_replace` still took the façade.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -33,25 +29,21 @@ use super::traits::{
     StateDecoder, StatusSourceLocator, TranscriptPathValidator, TranscriptStreamer,
 };
 use super::types::TranscriptPathSource;
-use super::{AgentAdapter, AttachContext, ClaudeStatusFileLocator, NoOpAdapter};
+use super::{AttachContext, ClaudeStatusFileLocator, NoOpAdapter};
 use crate::agent::types::AgentType;
 
 /// One session's typed adapter views, assembled from the
 /// [`AttachContext`] by [`AgentBindings::for_attach`].
 ///
-/// `agent_type` and `streamer` carry `#[allow(dead_code)]` for the
-/// duration of B': `agent_type` is for diagnostics / future
-/// telemetry, and `streamer` is the next-step migration target
-/// (B'' rewires `TranscriptState::start_or_replace` from
-/// `Arc<dyn AgentAdapter>` onto `Arc<dyn TranscriptStreamer>`).
-/// The bindings tests in this module read both fields via the
-/// `#[cfg(test)]` accessors below, so the `#[allow]` only suppresses
-/// the production-build warning — the compiler still tracks the
-/// fields as "live" in test builds, giving B'' a compile-time
-/// prompt if it forgets to consume `bindings.streamer` (PR #261
-/// cycle 14 review F39 — the `#[allow]` would otherwise silence
-/// the one compiler diagnostic that protects the B'' migration
-/// contract; the accessor compensates).
+/// `agent_type` carries `#[allow(dead_code)]` — it's for diagnostics
+/// / future telemetry and the watcher doesn't branch on it. Every
+/// other field has a production consumer: `locator` (in `start_for`),
+/// `decoder` / `transcript_paths` / `validator` (in the watcher
+/// callbacks), and `streamer` (in `TranscriptState::start_or_replace`,
+/// wired in step B''). The transitional `adapter_for_transcript_state:
+/// Arc<dyn AgentAdapter>` field was removed in B'' — `start_or_replace`
+/// now takes `Arc<dyn TranscriptStreamer>`, so the façade `Arc` is no
+/// longer needed.
 pub(crate) struct AgentBindings {
     #[allow(dead_code)]
     pub(crate) agent_type: AgentType,
@@ -59,27 +51,7 @@ pub(crate) struct AgentBindings {
     pub(crate) decoder: Arc<dyn StateDecoder>,
     pub(crate) transcript_paths: Arc<dyn TranscriptPathSource>,
     pub(crate) validator: Arc<dyn TranscriptPathValidator>,
-    #[allow(dead_code)]
     pub(crate) streamer: Arc<dyn TranscriptStreamer>,
-    /// Transitional: B'' migrates `TranscriptState::start_or_replace`
-    /// to take `Arc<dyn TranscriptStreamer>` directly; until then
-    /// the runtime hands it `Arc<dyn AgentAdapter>` carried here.
-    /// Removable post-B''.
-    pub(crate) adapter_for_transcript_state: Arc<dyn AgentAdapter>,
-}
-
-#[cfg(test)]
-impl AgentBindings {
-    /// Test-only accessor that reads `self.streamer`. Keeps the
-    /// compiler tracking the field as "live" in test builds so a
-    /// future B'' contributor who forgets to extract
-    /// `bindings.streamer` in `start_watching` gets a compile error
-    /// rather than the field silently disappearing (PR #261 cycle 14
-    /// review F39). Returns a typed handle so the accessor itself
-    /// can't be inlined or eliminated by the optimizer in test runs.
-    pub(crate) fn streamer_for_test(&self) -> &Arc<dyn TranscriptStreamer> {
-        &self.streamer
-    }
 }
 
 impl AgentBindings {
@@ -104,8 +76,7 @@ impl AgentBindings {
                     decoder: adapter.clone(),
                     transcript_paths: adapter.clone(),
                     validator: adapter.clone(),
-                    streamer: adapter.clone(),
-                    adapter_for_transcript_state: adapter,
+                    streamer: adapter,
                 })
             }
             AgentType::Codex => {
@@ -120,18 +91,17 @@ impl AgentBindings {
                 //
                 // The locator is built ONCE here and shared via `Arc`
                 // between `bindings.locator` (the outer
-                // `Arc<dyn StatusSourceLocator>`) and
-                // `adapter_for_transcript_state` (which holds an
-                // `Arc<CodexAdapter>` whose internal locator field is
-                // now `Arc<CompositeLocator>`, NOT an owned one).
+                // `Arc<dyn StatusSourceLocator>`) and `bindings.streamer`
+                // (the `Arc<CodexAdapter>` whose internal locator field
+                // is `Arc<CompositeLocator>`, NOT an owned one).
                 // Pre-cycle-11 the two paths each built an independent
                 // `CompositeLocator` from the same parameters — a
                 // latent double-retry hazard if `<CodexAdapter as
                 // AgentAdapter>::located_status_source` (the
                 // transitional façade) was ever called downstream. The
-                // structural fix (PR #261 cycle 11 F31) eliminates
-                // that hazard immediately rather than waiting for B''
-                // to remove `adapter_for_transcript_state`.
+                // structural fix (PR #261 cycle 11 F31) shares one
+                // `CompositeLocator`; B'' (this step) then consumes the
+                // streamer view directly in `start_or_replace`.
                 let codex_home = ctx
                     .provider_home
                     .clone()
@@ -171,8 +141,7 @@ impl AgentBindings {
                     decoder: adapter.clone(),
                     transcript_paths: adapter.clone(),
                     validator: adapter.clone(),
-                    streamer: adapter.clone(),
-                    adapter_for_transcript_state: adapter,
+                    streamer: adapter,
                 })
             }
             other => {
@@ -189,8 +158,7 @@ impl AgentBindings {
                     decoder: adapter.clone(),
                     transcript_paths: adapter.clone(),
                     validator: adapter.clone(),
-                    streamer: adapter.clone(),
-                    adapter_for_transcript_state: adapter,
+                    streamer: adapter,
                 })
             }
         }
@@ -259,39 +227,17 @@ mod tests {
         assert_eq!(noop.agent_type, AgentType::Aider);
     }
 
-    /// Read `bindings.streamer` via the `#[cfg(test)]` accessor so
-    /// the compiler keeps the field "live" in test builds. PR #261
-    /// cycle 14 review F39 — the field's `#[allow(dead_code)]`
-    /// would otherwise silence the one compile-time prompt that
-    /// surfaces the cycle-11 shared-Arc invariant when B'' lands
-    /// (see the watcher destructure-comment block in
-    /// `watcher_runtime.rs` for the human-readable B'' checkpoint).
-    /// `Arc::ptr_eq` against `adapter_for_transcript_state` proves
-    /// the shared-Arc relationship cycle 11 established for the
-    /// Codex arm.
-    #[test]
-    fn for_attach_codex_shares_arc_between_streamer_and_facade() {
-        let bindings = AgentBindings::for_attach(&codex_ctx(Some(PathBuf::from(
-            "/home/u/.codex",
-        ))))
-        .expect("codex binds");
-        let streamer = bindings.streamer_for_test();
-        let facade = &bindings.adapter_for_transcript_state;
-        // Both Arcs were minted from the same `Arc<CodexAdapter>` in
-        // `for_attach`, so the underlying allocations are identical
-        // even though the trait-object types differ
-        // (`dyn TranscriptStreamer` vs `dyn AgentAdapter`).
-        // `Arc::as_ptr` on a fat pointer cast to `*const ()` yields
-        // the thin data pointer — equal iff the two Arcs share an
-        // allocation.
-        let streamer_data = Arc::as_ptr(streamer) as *const ();
-        let facade_data = Arc::as_ptr(facade) as *const ();
-        assert_eq!(
-            streamer_data, facade_data,
-            "cycle 11 F31 invariant: bindings.streamer and bindings.adapter_for_transcript_state \
-             must be Arc::clones of the same underlying CodexAdapter allocation",
-        );
-    }
+    // NOTE: the B' shared-`Arc` regression test
+    // (`for_attach_codex_shares_arc_between_streamer_and_facade`, cycle 14
+    // F39) was removed in B''. It pinned that `bindings.streamer` and the
+    // now-deleted `bindings.adapter_for_transcript_state` were clones of
+    // the same `Arc<CodexAdapter>`. With the façade field gone, the
+    // cycle-11 F31 invariant ("one `CompositeLocator` per Codex attach,
+    // shared between the outer locator and the adapter's internal locator")
+    // is pinned at its source instead — see
+    // `codex::mod::tests::with_locator_shares_passed_locator_allocation`,
+    // which asserts `CodexAdapter::with_locator` stores the exact `Arc`
+    // it was handed rather than rebuilding one.
 
     /// Claude's locator is the stateless `ClaudeStatusFileLocator` —
     /// `locate(cwd, sid)` should return the same path shape the
@@ -335,18 +281,12 @@ mod tests {
     ///   fail this assertion).
     ///
     /// **NOT pinned here**: that `bindings.locator` and
-    /// `adapter_for_transcript_state.locator()` reference the SAME
-    /// `Arc<CompositeLocator>` instance (cycle 11 F31 made that
-    /// structural — see the `Arc::clone` line in the `for_attach`
-    /// Codex arm). Verifying via the public
-    /// `Arc<dyn StatusSourceLocator>` surface would require either
-    /// (a) downcasting, (b) adding a `#[cfg(test)]` `codex_home()`
-    /// accessor on `CompositeLocator`, or (c) a locator fixture with
-    /// a seeded SQLite DB so `locate(...)` returns `Ok` with an
-    /// observable `trust_root`. None of those are worth the test-only
-    /// API surface; the cycle-1 F1 fix that introduced the shared
-    /// binding lives in the `for_attach` body at lines 138-153 and
-    /// is self-evident at code-review time.
+    /// `bindings.streamer`'s internal locator reference the SAME
+    /// `Arc<CompositeLocator>` instance (cycle 11 F31). That
+    /// single-allocation invariant is pinned at its source in
+    /// `codex::adapter_tests::with_locator_shares_passed_locator_allocation`,
+    /// which doesn't need the test-only downcast / SQLite-fixture
+    /// machinery this bindings-level test would.
     #[test]
     fn for_attach_codex_without_provider_home_falls_back_to_default_home() {
         let bindings =

--- a/crates/backend/src/agent/adapter/claude_code/transcript_fixture_tests.rs
+++ b/crates/backend/src/agent/adapter/claude_code/transcript_fixture_tests.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use crate::agent::adapter::base::TranscriptState;
 use crate::agent::adapter::claude_code::ClaudeCodeAdapter;
-use crate::agent::adapter::AgentAdapter;
+use crate::agent::adapter::traits::TranscriptStreamer;
 use crate::runtime::FakeEventSink;
 
 #[test]
@@ -39,7 +39,7 @@ fn transcript_emits_turn_events_for_real_user_prompts_only() {
     .expect("write transcript fixture");
 
     let state = TranscriptState::new();
-    let adapter: Arc<dyn AgentAdapter> = Arc::new(ClaudeCodeAdapter);
+    let adapter: Arc<dyn TranscriptStreamer> = Arc::new(ClaudeCodeAdapter);
     state
         .start_or_replace(
             adapter,
@@ -74,7 +74,7 @@ fn vitest_pass_fixture_emits_one_test_run() {
     let sink = Arc::new(FakeEventSink::new());
 
     let state = TranscriptState::new();
-    let adapter: Arc<dyn AgentAdapter> = Arc::new(ClaudeCodeAdapter);
+    let adapter: Arc<dyn TranscriptStreamer> = Arc::new(ClaudeCodeAdapter);
     let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/transcript_vitest_pass.jsonl");
 
@@ -117,7 +117,7 @@ fn cargo_mixed_fixture_emits_test_run_with_groups() {
     let sink = Arc::new(FakeEventSink::new());
 
     let state = TranscriptState::new();
-    let adapter: Arc<dyn AgentAdapter> = Arc::new(ClaudeCodeAdapter);
+    let adapter: Arc<dyn TranscriptStreamer> = Arc::new(ClaudeCodeAdapter);
     let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/transcript_cargo_mixed.jsonl");
 
@@ -196,7 +196,7 @@ fn transcript_emits_agent_cwd_event_on_each_cwd_transition() {
     .expect("write transcript fixture");
 
     let state = TranscriptState::new();
-    let adapter: Arc<dyn AgentAdapter> = Arc::new(ClaudeCodeAdapter);
+    let adapter: Arc<dyn TranscriptStreamer> = Arc::new(ClaudeCodeAdapter);
     state
         .start_or_replace(
             adapter,
@@ -236,7 +236,7 @@ fn replay_emits_only_latest_snapshot() {
     let sink = Arc::new(FakeEventSink::new());
 
     let state = TranscriptState::new();
-    let adapter: Arc<dyn AgentAdapter> = Arc::new(ClaudeCodeAdapter);
+    let adapter: Arc<dyn TranscriptStreamer> = Arc::new(ClaudeCodeAdapter);
     let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/transcript_vitest_replay.jsonl");
 

--- a/crates/backend/src/agent/adapter/codex/mod.rs
+++ b/crates/backend/src/agent/adapter/codex/mod.rs
@@ -64,16 +64,27 @@ impl CodexAdapter {
     /// Construct a `CodexAdapter` that shares the supplied
     /// `Arc<CompositeLocator>` with the caller. Used by
     /// `AgentBindings::for_attach` so `bindings.locator` and
-    /// `adapter_for_transcript_state` reference the same locator
-    /// instance — eliminating the prior double-construction +
-    /// inner-locator latent retry-double risk (PR #261 cycle 11
-    /// F31).
+    /// `bindings.streamer`'s internal locator reference the same
+    /// `Arc<CompositeLocator>` instance — eliminating the prior
+    /// double-construction + inner-locator latent retry-double risk
+    /// (PR #261 cycle 11 F31).
     pub(crate) fn with_locator(locator: Arc<CompositeLocator>) -> Self {
         Self { locator }
     }
 
     fn locator(&self) -> &CompositeLocator {
         &self.locator
+    }
+
+    /// Test-only: thin data pointer of the internal
+    /// `Arc<CompositeLocator>`. Lets `with_locator_shares_passed_locator_allocation`
+    /// assert that `with_locator` stores the exact `Arc` it was handed
+    /// (the cycle-11 F31 single-allocation invariant), now that the
+    /// B'-era bindings-level shared-`Arc` test was retired in B''
+    /// alongside `adapter_for_transcript_state`.
+    #[cfg(test)]
+    pub(crate) fn locator_data_ptr(&self) -> *const () {
+        Arc::as_ptr(&self.locator) as *const ()
     }
 }
 
@@ -182,6 +193,31 @@ impl AgentAdapter for CodexAdapter {
 mod adapter_tests {
     use super::*;
     use std::time::SystemTime;
+
+    /// Cycle-11 F31 single-allocation invariant, pinned at its source.
+    /// `with_locator` must STORE the `Arc<CompositeLocator>` it is
+    /// handed — not rebuild one — so `AgentBindings::for_attach` can
+    /// share a single locator between `bindings.locator` and
+    /// `bindings.streamer`. B'' relocated this guard here from the
+    /// bindings-level shared-`Arc` test that was retired alongside
+    /// `adapter_for_transcript_state`.
+    #[test]
+    fn with_locator_shares_passed_locator_allocation() {
+        let locator = Arc::new(CompositeLocator::new(
+            default_codex_home(),
+            12345,
+            SystemTime::UNIX_EPOCH,
+            PathBuf::from("/proc"),
+        ));
+        let expected_ptr = Arc::as_ptr(&locator) as *const ();
+        let adapter = CodexAdapter::with_locator(locator);
+        assert_eq!(
+            adapter.locator_data_ptr(),
+            expected_ptr,
+            "with_locator must store the passed Arc<CompositeLocator>, not rebuild one \
+             (cycle 11 F31 single-allocation invariant)",
+        );
+    }
 
     #[test]
     fn parse_status_returns_event_without_transcript_path_field() {

--- a/crates/backend/src/agent/adapter/mod.rs
+++ b/crates/backend/src/agent/adapter/mod.rs
@@ -381,34 +381,27 @@ mod noop_tests {
         assert!(<NoOpAdapter as AgentAdapter>::parse_status(&adapter, "sid", "{}").is_err());
     }
 
-    /// Step B': pins the end-to-end codex façade roundtrip THROUGH
-    /// `AgentBindings::for_attach` rather than constructing the
-    /// adapter directly. Cycle 7 review F20 caught that the previous
-    /// body bypassed the dispatch path entirely; this version calls
-    /// `for_attach` and reaches `parse_status` via the bundled
-    /// `adapter_for_transcript_state`.
+    /// Pins the end-to-end codex decode roundtrip THROUGH
+    /// `AgentBindings::for_attach`. Cycle 7 review F20 caught that the
+    /// pre-cycle-7 body bypassed the dispatch path; B'' then removed
+    /// the `adapter_for_transcript_state` façade field, so this test
+    /// now reaches the decoder via the production `bindings.decoder`
+    /// (`Arc<dyn StateDecoder>`) surface instead of the
+    /// soon-to-be-retired `AgentAdapter::parse_status` façade.
     ///
     /// Coverage scope:
     /// - **Dispatch arm**: `AgentType::Codex` → Codex bindings (not
     ///   NoOp). A regression that hit the `_` / NoOp arm would fail
-    ///   the `bindings.agent_type` assertion.
-    /// - **Façade parser**: the bound `Arc<dyn AgentAdapter>` decodes
-    ///   real Codex rollout JSONL. A regression in `parse_status` /
-    ///   `parse_rollout_snapshot` would fail the `agent_session_id`
-    ///   assertion.
+    ///   the `bindings.agent_type` assertion (NoOp's decoder returns
+    ///   `Err`, which would also fail the decode below).
+    /// - **Decoder roundtrip**: `bindings.decoder.decode(...)` parses
+    ///   real Codex rollout JSONL into a session-id-free
+    ///   `StatusSnapshot`. A regression in `parse_rollout_snapshot`
+    ///   would fail the `agent_session_id` assertion.
     ///
-    /// **NOT pinned here**: the `provider_home → codex_home`
-    /// plumbing through the shared `Arc<CompositeLocator>`. Because
-    /// `parse_status` only exercises the rollout decoder (it never
-    /// touches the locator), a hypothetical regression to
-    /// `CodexAdapter::new` would still pass this test. That wiring
-    /// is structurally guaranteed by cycle-11 F31's `Arc::clone` in
-    /// the `for_attach` Codex arm (one `CompositeLocator` per attach,
-    /// shared between `bindings.locator` and
-    /// `adapter_for_transcript_state` via `with_locator`). The
-    /// locator-end of that wiring is not unit-testable cleanly
-    /// because `CompositeLocator` reaches for SQLite/FS state that
-    /// doesn't exist in the test env.
+    /// **NOT pinned here**: the single-`CompositeLocator` sharing
+    /// invariant — that lives in
+    /// `codex::adapter_tests::with_locator_shares_passed_locator_allocation`.
     /// Paired with `bindings::tests::for_attach_dispatches_by_agent_type`
     /// for dispatch shape on all three variants.
     #[test]
@@ -429,13 +422,11 @@ mod noop_tests {
 
         let raw = r#"{"timestamp":"...","type":"session_meta","payload":{"id":"sess","cli_version":"0.128.0"}}
 "#;
-        let parsed = <dyn AgentAdapter>::parse_status(
-            bindings.adapter_for_transcript_state.as_ref(),
-            "pty-codex",
-            raw,
-        )
-        .expect("codex façade through bindings should parse rollout JSONL");
-        assert_eq!(parsed.event.agent_session_id, "sess");
+        let snapshot = bindings
+            .decoder
+            .decode(Some("pty-codex"), raw)
+            .expect("codex decoder through bindings should parse rollout JSONL");
+        assert_eq!(snapshot.agent_session_id, "sess");
     }
 
     fn make_test_session() -> crate::terminal::state::ManagedSession {

--- a/crates/backend/src/agent/adapter/traits.rs
+++ b/crates/backend/src/agent/adapter/traits.rs
@@ -17,13 +17,14 @@
 //! - [`TranscriptStreamer`] — "spawn a thread that emits events from
 //!   this JSONL" (former `AgentAdapter::tail_transcript`).
 //!
-//! All four are `pub(crate)` per frozen constraint #3. The existing
-//! `AgentAdapter` trait stays alive in B' as a transitional façade —
-//! `TranscriptState::start_or_replace` still takes `Arc<dyn AgentAdapter>`
-//! and B'' (the next step) is where it migrates onto
-//! `Arc<dyn TranscriptStreamer>`. Until then, each adapter struct
-//! implements both `AgentAdapter` and the four split traits side by
-//! side.
+//! All four are `pub(crate)` per frozen constraint #3. As of step
+//! B'', `TranscriptState::start_or_replace` takes
+//! `Arc<dyn TranscriptStreamer>` directly (B' had it on the
+//! transitional `Arc<dyn AgentAdapter>` façade). The `AgentAdapter`
+//! trait stays alive only as the not-yet-removed façade — D' deletes
+//! it with the `AgentWatcherService` boundary. Until then, each
+//! adapter struct implements both `AgentAdapter` and the split traits
+//! side by side.
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/backend/src/agent/adapter/traits.rs
+++ b/crates/backend/src/agent/adapter/traits.rs
@@ -116,10 +116,10 @@ pub(crate) trait TranscriptPathValidator: Send + Sync {
 /// `AgentAdapter::tail_transcript` in the post-B' world.
 ///
 /// `TranscriptHandle` (defined in `base::transcript_state`) is the
-/// per-stream stop / generation handle the watcher already owns;
-/// B'' will migrate `TranscriptState::start_or_replace` to take
-/// `Arc<dyn TranscriptStreamer>` directly instead of going through
-/// `Arc<dyn AgentAdapter>`.
+/// per-stream stop / generation handle the watcher already owns.
+/// As of step B'', `TranscriptState::start_or_replace` takes
+/// `Arc<dyn TranscriptStreamer>` directly (it previously went through
+/// the transitional `Arc<dyn AgentAdapter>` façade).
 pub(crate) trait TranscriptStreamer: Send + Sync {
     fn tail(
         &self,


### PR DESCRIPTION
## Summary

Step B'' of the v4-frozen agent-adapter refactor ([#246](https://github.com/winoooops/vimeflow/issues/246)). Migrates `TranscriptState::start_or_replace` off the transitional `Arc<dyn AgentAdapter>` façade onto the concern-specific `Arc<dyn TranscriptStreamer>`, narrows it to `pub(crate)`, and removes the now-dead `AgentBindings.adapter_for_transcript_state` field that B' carried only to feed the old signature.

## Acceptance (#246 B'')

- ✅ `start_or_replace` accepts `Arc<dyn TranscriptStreamer>` (not `Arc<dyn AgentAdapter>`). `adapter.tail_transcript(...)` → `streamer.tail(...)` — identical 4-arg signature; `base` only ever needed the spawn method.
- ✅ Visibility narrowed `pub` → `pub(crate)` (callers are the watcher runtime + same-crate tests only).
- ✅ Per-session `start_gate` Mutex, old-before-new stop order, and the F19 regression test (`replace_on_cwd_change_stops_old_before_spawning_new`) all preserved — the migration is signature-only, no concurrency logic changed (codex confirmed byte-for-byte).

## Changes

- **`base/transcript_state.rs`** — core signature + body swap; doc comments updated; `OrderingAdapter` F19 mock → lean `OrderingStreamer` impl'ing just `TranscriptStreamer::tail` (dropped 4 `unreachable!()` AgentAdapter stubs); 3 `ClaudeCodeAdapter` test bindings retyped.
- **`base/watcher_runtime.rs`** — `maybe_start_transcript` takes `streamer: &Arc<dyn TranscriptStreamer>`; destructures `bindings.streamer`; 3 callback clones renamed; B'' checkpoint comment simplified.
- **`bindings.rs`** — removed `adapter_for_transcript_state` field + `streamer_for_test()` accessor + the B' shared-Arc test; `streamer` dropped `#[allow(dead_code)]` (now production-consumed); 3 `for_attach` arms drop the field assignment.
- **`codex/mod.rs`** — relocated the cycle-11 F31 single-allocation guard here: `with_locator_shares_passed_locator_allocation` (+ `#[cfg(test)] locator_data_ptr()` accessor) pins that `with_locator` stores the passed `Arc`, doesn't rebuild.
- **`claude_code/transcript_fixture_tests.rs`** — 5 test bindings retyped.
- **`mod.rs`** — `for_attach_returns_real_codex_adapter` reaches the decoder via the production `bindings.decoder` surface instead of the removed façade field.

## What this PR does NOT do

- Does **not** remove the `AgentAdapter` trait or its façade impls — that's D' (`AgentWatcherService` boundary). `AgentAdapter` is a `pub` trait, so no dead-code fallout from no longer constructing `Arc<dyn AgentAdapter>` in production.

## Local verification

```
cargo build -p vimeflow --lib --tests              # OK (no warnings)
cargo test -p vimeflow --lib agent::adapter        # 281/0
cargo test -p vimeflow                             # 560 lib + bin + 9 integration pass
                                                   # (one known pre-existing PTY flake, green on rerun)
RUSTDOCFLAGS='-D rustdoc::private-intra-doc-links' \
  cargo doc -p vimeflow --no-deps --document-private-items   # 0 errors
```

## Codex local review

| Round | Commit | Findings | Verdict |
| --- | --- | --- | --- |
| 1 | `f618738` (base) | 0/0/0/0 + 2 out-of-scope stale-doc notes | ship it |
| 2 | `61dc031` (doc refresh) | 0/0/0/0 | ship it |

Doc staleness from rounds 1-2 fixed in `61dc031` + `2d22d75` (traits.rs module doc, `TranscriptStreamer` trait doc, `agent/README.md`).

## Test plan

- [x] `cargo test -p vimeflow --lib agent::adapter` — 281/0
- [x] F19 old-before-new stop-order regression preserved
- [x] cycle-11 F31 single-CompositeLocator invariant pinned at `with_locator`
- [x] codex local review — 0 findings, ship it (×2)
- [ ] CI green on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)