### PR TITLE
refactor(agent-adapter): Step D' — AgentWatcherService registry facade

### DIFF
--- a/crates/backend/src/agent/README.md
+++ b/crates/backend/src/agent/README.md
@@ -119,13 +119,13 @@ Starts the watcher pipeline for a PTY session. **Owns the full lifecycle:** remo
 
 `pid` is the detected agent PID (returned by `detector::detect_agent`), not the shell PID at the PTY root — Codex's `logs.process_uuid` indexes by the codex child PID. `pty_start` is captured at PTY spawn (`ManagedSession.started_at`) so the logs query can filter out PID-reuse and stale-loaded-thread matches. Both arguments are stored on `CodexAdapter` at construction (`CodexAdapter::new(pid, pty_start)` via the `for_attach(agent_type, pid, pty_start)` factory). The codex adapter wraps them in a private `BindContext` for its locator on each `status_source` call. `base::start_for` invokes `adapter.status_source(cwd, session_id)` once and codex's internal retry lives in `retry_locator` (5 attempts, 4 × 100ms inter-attempt sleeps, 400ms sleep budget on full exhaustion). Claude's impl ignores these fields — Claude's `status_source(cwd, sid)` is infallible.
 
-### `<dyn AgentAdapter>::stop`
+### `AgentWatcherService::stop`
 
 ```rust
-pub fn stop(state: &AgentWatcherState, session_id: &str) -> bool
+pub(crate) async fn stop(&self, session_id: String) -> Result<(), String>
 ```
 
-Stops the pipeline by dropping the `WatcherHandle` for `session_id`. Returns `true` if a handle was removed. The handle's `Drop` cascades — see [Lifecycle section](#lifecycle-watcherhandle-drop-cascade) below.
+Step D' moved stop onto the `AgentWatcherService` facade (`adapter/service.rs`); the former `<dyn AgentAdapter>::stop` inherent method was removed. `stop` calls `AgentWatcherState::remove(session_id)` directly — dropping the `WatcherHandle` whose `Drop` cascades the transcript-tail teardown (see [Lifecycle section](#lifecycle-watcherhandle-drop-cascade) below) — and returns `Err` when no handle was present.
 
 ### BackendState / IPC entry point
 

--- a/crates/backend/src/agent/adapter/mod.rs
+++ b/crates/backend/src/agent/adapter/mod.rs
@@ -11,6 +11,7 @@ pub mod claude_code;
 pub mod codex;
 mod error;
 mod serde_helpers;
+mod service;
 mod traits;
 pub mod types;
 
@@ -27,7 +28,6 @@ use std::time::SystemTime;
 
 pub use base::AgentWatcherState;
 
-use crate::agent::detector::detect_agent;
 use crate::agent::types::AgentType;
 use crate::runtime::EventSink;
 use crate::terminal::types::SessionId;
@@ -72,17 +72,13 @@ pub trait AgentAdapter: Send + Sync + 'static {
     // traits per frozen constraint #3.
 }
 
-impl dyn AgentAdapter {
-    // Step B': `for_attach` and `start` lifecycle methods were
-    // removed alongside the watcher migration to `AgentBindings`.
-    // `start_agent_watcher_inner` now calls
-    // `AgentBindings::for_attach(&attach)` and `base::start_for(bindings, ...)`
-    // directly. `stop` stays — it's a pure lookup on
-    // `AgentWatcherState` and has no adapter-shape dependency.
-    pub fn stop(state: &AgentWatcherState, session_id: &str) -> bool {
-        state.remove(session_id)
-    }
-}
+// Step D': the former `impl dyn AgentAdapter { fn stop }` inherent
+// method was removed — `AgentWatcherService::stop` now calls
+// `AgentWatcherState::remove` directly, so the last `dyn AgentAdapter`
+// lifecycle entry point is gone. (`for_attach` / `start` were already
+// removed in B'.) The `AgentAdapter` trait survives only as the
+// transitional decode/locate/validate/tail façade, unused in
+// production lifecycle paths.
 
 /// Stateless `StatusSourceLocator` for Claude Code.
 ///
@@ -228,41 +224,13 @@ pub(crate) async fn start_agent_watcher_inner(
     events: Arc<dyn EventSink>,
     session_id: String,
 ) -> Result<(), String> {
-    let attach = resolve_bind_inputs(&pty_state, &session_id, detect_agent)?;
-
-    // Step B': build the typed bindings (5 split-trait views) from
-    // the attach context. `AttachError` → `String` mapping happens
-    // at this seam — the watcher / `start_for` layer below speaks
-    // `String` errors, so we collapse the typed error here. The
-    // mapping point becomes the future D' `AgentWatcherService`
-    // boundary too.
-    let bindings = bindings::AgentBindings::for_attach(&attach)
-        .map_err(|e| format!("agent bindings: {}", e))?;
-    let cwd_path = attach.initial_cwd.clone();
-
-    // `base::start_for(bindings, ...)` calls `bindings.locator.locate(...)`.
-    // For codex sessions, the locator runs a bounded retry (5 × 100 ms
-    // inter-attempt sleeps) inside its `StatusSourceLocator::locate`
-    // impl — codex commits its `logs` row ~300 ms after the rollout
-    // file opens.
-    // `path_security::ensure_status_source_under_trust_root` does
-    // synchronous `canonicalize` filesystem I/O. Running either on a
-    // tokio worker thread starves other futures scheduled on the same
-    // worker; mirror the pattern at `src/git/watcher.rs:399` and hop
-    // onto the blocking pool so the async thread returns immediately.
-    tokio::task::spawn_blocking(move || {
-        base::start_for(
-            bindings,
-            events,
-            pty_state,
-            transcript_state,
-            session_id,
-            cwd_path,
-            watcher_state,
-        )
-    })
-    .await
-    .map_err(|e| format!("start_agent_watcher task panicked: {}", e))?
+    // Step D': delegate to `AgentWatcherService`. The service owns the
+    // attach-resolution, the `AgentBindings::for_attach` +
+    // `AttachError` → `String` mapping seam, and the spawn_blocking
+    // hand-off to `base::start_for`.
+    service::AgentWatcherService::new(pty_state, watcher_state, transcript_state, events)
+        .start(session_id)
+        .await
 }
 
 fn resolve_bind_inputs<F>(
@@ -306,16 +274,22 @@ where
 }
 
 /// Stop watching an agent status source.
+///
+/// Step D': delegates to `AgentWatcherService::stop`. `stop` only
+/// needs the `AgentWatcherState`, but the service is constructed with
+/// the full collaborator set so the facade shape is uniform with
+/// `start` (all four clones are cheap `Arc`-backed). The IPC seam
+/// (`runtime/state.rs`) passes the same four it passes to `start`.
 pub(crate) async fn stop_agent_watcher_inner(
-    state: &AgentWatcherState,
+    pty_state: PtyState,
+    watcher_state: AgentWatcherState,
+    transcript_state: TranscriptState,
+    events: Arc<dyn EventSink>,
     session_id: String,
 ) -> Result<(), String> {
-    if <dyn AgentAdapter>::stop(state, &session_id) {
-        log::info!("Stopped watching statusline for session {}", session_id);
-        Ok(())
-    } else {
-        Err(format!("No active watcher for session: {}", session_id))
-    }
+    service::AgentWatcherService::new(pty_state, watcher_state, transcript_state, events)
+        .stop(session_id)
+        .await
 }
 
 #[cfg(test)]

--- a/crates/backend/src/agent/adapter/service.rs
+++ b/crates/backend/src/agent/adapter/service.rs
@@ -1,0 +1,116 @@
+//! `AgentWatcherService` — the registry facade for agent-watcher
+//! lifecycle.
+//!
+//! Step D' of the v4-frozen refactor plan (#246). Owns clones of the
+//! four runtime collaborators (`PtyState`, `AgentWatcherState`,
+//! `TranscriptState`, `Arc<dyn EventSink>`) and exposes the two
+//! lifecycle verbs the IPC layer needs:
+//!
+//! - `start(session_id)` — resolve the [`AttachContext`] from live
+//!   `PtyState`, build the typed [`AgentBindings`], and hand off to
+//!   `base::start_for` on the blocking pool.
+//! - `stop(session_id)` — remove the session's watcher from
+//!   `AgentWatcherState` (its `Drop` cascades the transcript-tail
+//!   teardown).
+//!
+//! **`AttachError` → `String` boundary.** Per #246's D' acceptance and
+//! frozen constraint #4, the typed `AttachError` from
+//! `AgentBindings::for_attach` is collapsed to `String` *here* — the
+//! `base::start_for` layer and everything below it speaks `String`
+//! errors. This is the single mapping seam; `start_agent_watcher_inner`
+//! delegates to this method rather than mapping independently.
+
+use std::sync::Arc;
+
+use super::bindings::AgentBindings;
+use super::{base, resolve_bind_inputs};
+use crate::agent::detector::detect_agent;
+use crate::runtime::EventSink;
+use crate::terminal::PtyState;
+use base::{AgentWatcherState, TranscriptState};
+
+/// Registry facade owning clones of the four runtime collaborators.
+///
+/// Constructed per IPC call from `BackendState`'s long-lived
+/// originals (all four are cheap `Arc`-backed clones). `stop` only
+/// reads `watcher_state`, but the service carries all four so the
+/// facade shape is uniform and a future eager-prevalidation `stop`
+/// (or a `restart`) has the inputs it needs without a signature
+/// change.
+pub(crate) struct AgentWatcherService {
+    pty_state: PtyState,
+    watcher_state: AgentWatcherState,
+    transcript_state: TranscriptState,
+    events: Arc<dyn EventSink>,
+}
+
+impl AgentWatcherService {
+    pub(crate) fn new(
+        pty_state: PtyState,
+        watcher_state: AgentWatcherState,
+        transcript_state: TranscriptState,
+        events: Arc<dyn EventSink>,
+    ) -> Self {
+        Self {
+            pty_state,
+            watcher_state,
+            transcript_state,
+            events,
+        }
+    }
+
+    /// Start (or restart) the agent watcher for `session_id`.
+    ///
+    /// Resolves the attach inputs from live `PtyState`, builds the
+    /// `AgentBindings`, and runs `base::start_for` on the blocking
+    /// pool. `AttachError` is mapped to `String` at this boundary.
+    pub(crate) async fn start(&self, session_id: String) -> Result<(), String> {
+        let attach = resolve_bind_inputs(&self.pty_state, &session_id, detect_agent)?;
+
+        // `AttachError` → `String` mapping seam (frozen constraint #4 /
+        // #246 D'). Everything from `base::start_for` down speaks
+        // `String`; the typed error stops here.
+        let bindings =
+            AgentBindings::for_attach(&attach).map_err(|e| format!("agent bindings: {}", e))?;
+        let cwd_path = attach.initial_cwd.clone();
+
+        // Clone the owned collaborators into the blocking task.
+        // `base::start_for(bindings, ...)` calls
+        // `bindings.locator.locate(...)`; for codex sessions the
+        // locator runs a bounded retry (5 × 100 ms inter-attempt
+        // sleeps) inside its `StatusSourceLocator::locate` impl, and
+        // `path_security::ensure_status_source_under_trust_root` does
+        // synchronous `canonicalize` I/O. Running either on a tokio
+        // worker thread starves co-scheduled futures, so hop onto the
+        // blocking pool (mirrors `src/git/watcher.rs`).
+        let events = self.events.clone();
+        let pty_state = self.pty_state.clone();
+        let transcript_state = self.transcript_state.clone();
+        let watcher_state = self.watcher_state.clone();
+        tokio::task::spawn_blocking(move || {
+            base::start_for(
+                bindings,
+                events,
+                pty_state,
+                transcript_state,
+                session_id,
+                cwd_path,
+                watcher_state,
+            )
+        })
+        .await
+        .map_err(|e| format!("start_agent_watcher task panicked: {}", e))?
+    }
+
+    /// Stop the agent watcher for `session_id`. Removing the
+    /// `WatcherHandle` from `AgentWatcherState` runs its `Drop`, which
+    /// cascades the transcript-tail teardown.
+    pub(crate) async fn stop(&self, session_id: String) -> Result<(), String> {
+        if self.watcher_state.remove(&session_id) {
+            log::info!("Stopped watching statusline for session {}", session_id);
+            Ok(())
+        } else {
+            Err(format!("No active watcher for session: {}", session_id))
+        }
+    }
+}

--- a/crates/backend/src/runtime/state.rs
+++ b/crates/backend/src/runtime/state.rs
@@ -190,7 +190,14 @@ impl BackendState {
     }
 
     pub async fn stop_agent_watcher(&self, session_id: String) -> Result<(), String> {
-        crate::agent::adapter::stop_agent_watcher_inner(&self.agents, session_id).await
+        crate::agent::adapter::stop_agent_watcher_inner(
+            self.pty.clone(),
+            self.agents.clone(),
+            self.transcripts.clone(),
+            self.events.clone(),
+            session_id,
+        )
+        .await
     }
 
     #[cfg(feature = "e2e-test")]


### PR DESCRIPTION
## Summary

Step D' of the v4-frozen agent-adapter refactor ([#246](https://github.com/winoooops/vimeflow/issues/246)) — the **final core step**. Introduces `adapter/service.rs::AgentWatcherService`, the registry facade that owns clones of the four runtime collaborators (`PtyState`, `AgentWatcherState`, `TranscriptState`, `Arc<dyn EventSink>`) and exposes the two lifecycle verbs. The free `start_agent_watcher_inner` / `stop_agent_watcher_inner` functions become thin delegators.

## Acceptance (#246 D')

- ✅ New `adapter/service.rs` with `AgentWatcherService` owning/cloning the four collaborators.
- ✅ `start(session_id) -> Result<(), String>` — resolve `AttachContext` from live `PtyState`, build `AgentBindings`, spawn_blocking → `base::start_for`.
- ✅ `stop(session_id) -> Result<(), String>` — `AgentWatcherState::remove` + `WatcherHandle::Drop` cascade.
- ✅ Internally builds `AttachContext` + `AgentBindings`; maps `AttachError` → `String` at this boundary (frozen constraint #4 — single seam, no independent mapping in the inner fn).
- ✅ `adapter/mod.rs::start_agent_watcher_inner` delegates to the service.
- ✅ IPC integration test (`crates/backend/tests/ipc_subprocess.rs`) passes (9/9, incl. `start_agent_watcher` / `stop_agent_watcher`).

## Changes

- **`adapter/service.rs`** (new, 116 lines) — `AgentWatcherService` struct + `new` + `start` + `stop`. `start`'s body is the verbatim move of the old `start_agent_watcher_inner` (resolve_bind_inputs → for_attach map_err → spawn_blocking, same blocking-pool rationale). `stop` calls `AgentWatcherState::remove` directly.
- **`adapter/mod.rs`** — both `_inner` functions are now 3-line delegators. Removed the `impl dyn AgentAdapter { fn stop }` inherent method — the **last `dyn AgentAdapter` lifecycle entry point is gone**; the trait now survives only as the transitional decode/locate/validate/tail façade. Dropped the now-unused `detect_agent` import.
- **`runtime/state.rs`** — `stop_agent_watcher` passes the full 4-collaborator set (matching `start_agent_watcher`) so `stop_agent_watcher_inner` can build the service.
- **`agent/README.md`** — §stop refreshed (`<dyn AgentAdapter>::stop` → `AgentWatcherService::stop`).

## Design notes

- `resolve_bind_inputs` + its 3 tests **stay in `mod.rs`** — the service calls the private helper via Rust descendant-module visibility (no `pub(super)`, no test-fixture churn). Codex confirmed this is correct.
- `stop` reads only `watcher_state` but the service holds all four — uniform facade shape, cheap `Arc`-backed clones. Codex confirmed acceptable.

## What's left in #246

D' is the last **core** step. Remaining are the two **optional** (separate-decision) steps: A-transcript (transcript JSONL DTOs) and C (common tailer engine).

## Local verification

```
cargo build -p vimeflow --lib --tests              # OK (no warnings)
cargo test -p vimeflow --lib agent::adapter        # 281/0
cargo test -p vimeflow --test ipc_subprocess       # 9/0
cargo test -p vimeflow --lib resolve_bind_inputs   # 3/0
rustfmt --check --edition 2021 .../service.rs       # clean
RUSTDOCFLAGS='-D rustdoc::private-intra-doc-links' \
  cargo doc -p vimeflow --no-deps --document-private-items   # 0 errors
```

## Codex local review

| Round | Commit | Findings | Verdict |
| --- | --- | --- | --- |
| 1 | base | 0 CRIT/HIGH/MED, 1 LOW (service.rs rustfmt wrap) | ship it |
| 2 | amended | 0/0/0/0 | ship it |

The LOW (rustfmt) was fixed by reflowing `service.rs` only; repo-wide pre-existing fmt drift was deliberately left out of scope.

## Test plan

- [x] adapter unit tests 281/0
- [x] IPC integration test 9/0 (start/stop_agent_watcher exercised)
- [x] `AttachError → String` mapping confined to the service boundary
- [x] codex local review — ship it (×2)
- [ ] CI green on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)