### PR TITLE
fix(terminal): stabilize prompt font fallback

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -107,6 +107,11 @@ words:
   - statusline
   - nvim
   - DECRQM
+  - JetBrainsMono
+  - MesloLGS
+  - FiraCode
+  - Cascadia
+  - Menlo
 
 ignorePaths:
   - node_modules

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -488,6 +488,71 @@ describe('Body', () => {
     }
   })
 
+  test('clears pending deferred terminal font refresh when switching sessions', async () => {
+    let resolveFonts: () => void = (): void => undefined
+
+    const fontsLoaded = new Promise<FontFace[]>((resolve) => {
+      resolveFonts = (): void => resolve([])
+    })
+
+    const load = vi.fn<FontFaceSet['load']>().mockReturnValue(fontsLoaded)
+    const originalFonts = document.fonts
+
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { load },
+    })
+
+    const offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockReturnValue(840)
+
+    const offsetHeightSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockReturnValue(600)
+
+    try {
+      const { rerender } = render(
+        <Body
+          sessionId="session-a"
+          cwd="/home/user"
+          service={defaultMockService}
+          deferFit
+        />
+      )
+
+      await waitFor(() => {
+        expect(load).toHaveBeenCalledTimes(2)
+      })
+
+      await act(async () => {
+        resolveFonts()
+        await fontsLoaded
+      })
+
+      mockFitAddon.fit.mockClear()
+      mockTerminal.refresh.mockClear()
+
+      rerender(
+        <Body
+          sessionId="session-b"
+          cwd="/home/user"
+          service={defaultMockService}
+        />
+      )
+
+      expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      expect(mockTerminal.refresh).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: originalFonts,
+      })
+      offsetWidthSpy.mockRestore()
+      offsetHeightSpy.mockRestore()
+    }
+  })
+
   test('loads fit addon', async () => {
     render(
       <Body

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -301,6 +301,193 @@ describe('Body', () => {
     }
   })
 
+  test('refreshes terminal after deferred terminal font refit flushes', async () => {
+    let resolveFonts: () => void = (): void => undefined
+
+    const fontsLoaded = new Promise<FontFace[]>((resolve) => {
+      resolveFonts = (): void => resolve([])
+    })
+
+    const load = vi.fn<FontFaceSet['load']>().mockReturnValue(fontsLoaded)
+    const originalFonts = document.fonts
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { load },
+    })
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    const offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockReturnValue(840)
+
+    const offsetHeightSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockReturnValue(600)
+
+    try {
+      const { rerender } = render(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+          deferFit
+        />
+      )
+
+      await waitFor(() => {
+        expect(load).toHaveBeenCalledTimes(2)
+      })
+
+      await act(async () => {
+        resolveFonts()
+        await fontsLoaded
+      })
+
+      expect(requestAnimationFrameSpy).not.toHaveBeenCalled()
+
+      mockFitAddon.fit.mockClear()
+      mockTerminal.refresh.mockClear()
+
+      rerender(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+        />
+      )
+
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        frameCallbacks[0](16)
+      })
+
+      expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      expect(mockTerminal.refresh).toHaveBeenCalledWith(0, 23)
+    } finally {
+      Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: originalFonts,
+      })
+      requestAnimationFrameSpy.mockRestore()
+      offsetWidthSpy.mockRestore()
+      offsetHeightSpy.mockRestore()
+    }
+  })
+
+  test('keeps deferred terminal font refresh pending when drag restarts before flush', async () => {
+    let resolveFonts: () => void = (): void => undefined
+
+    const fontsLoaded = new Promise<FontFace[]>((resolve) => {
+      resolveFonts = (): void => resolve([])
+    })
+
+    const load = vi.fn<FontFaceSet['load']>().mockReturnValue(fontsLoaded)
+    const originalFonts = document.fonts
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { load },
+    })
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    const offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockReturnValue(840)
+
+    const offsetHeightSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockReturnValue(600)
+
+    try {
+      const { rerender } = render(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+          deferFit
+        />
+      )
+
+      await waitFor(() => {
+        expect(load).toHaveBeenCalledTimes(2)
+      })
+
+      await act(async () => {
+        resolveFonts()
+        await fontsLoaded
+      })
+
+      rerender(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+        />
+      )
+
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+
+      rerender(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+          deferFit
+        />
+      )
+
+      act(() => {
+        frameCallbacks[0](16)
+      })
+
+      expect(mockFitAddon.fit).not.toHaveBeenCalled()
+      expect(mockTerminal.refresh).not.toHaveBeenCalled()
+
+      rerender(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+        />
+      )
+
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
+
+      act(() => {
+        frameCallbacks[1](32)
+      })
+
+      expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      expect(mockTerminal.refresh).toHaveBeenCalledWith(0, 23)
+    } finally {
+      Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: originalFonts,
+      })
+      requestAnimationFrameSpy.mockRestore()
+      offsetWidthSpy.mockRestore()
+      offsetHeightSpy.mockRestore()
+    }
+  })
+
   test('loads fit addon', async () => {
     render(
       <Body

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -301,6 +301,92 @@ describe('Body', () => {
     }
   })
 
+  test('retries terminal font-settle refit until the container is visible', async () => {
+    let resolveFonts: () => void = (): void => undefined
+    let fontContainerWidth = 0
+
+    const fontsLoaded = new Promise<FontFace[]>((resolve) => {
+      resolveFonts = (): void => resolve([])
+    })
+
+    const load = vi.fn<FontFaceSet['load']>().mockReturnValue(fontsLoaded)
+    const originalFonts = document.fonts
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { load },
+    })
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    const offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockImplementation(() => fontContainerWidth)
+
+    const offsetHeightSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockReturnValue(600)
+
+    try {
+      render(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+        />
+      )
+
+      await waitFor(() => {
+        expect(load).toHaveBeenCalledTimes(2)
+      })
+
+      await act(async () => {
+        resolveFonts()
+        await fontsLoaded
+      })
+
+      await waitFor(() => {
+        expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+      })
+
+      mockFitAddon.fit.mockClear()
+      mockTerminal.refresh.mockClear()
+
+      act(() => {
+        frameCallbacks[0](16)
+      })
+
+      // First flush attempt retries because width is still zero (hidden pane).
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
+      expect(mockFitAddon.fit).not.toHaveBeenCalled()
+      expect(mockTerminal.refresh).not.toHaveBeenCalled()
+
+      fontContainerWidth = 800
+
+      act(() => {
+        frameCallbacks[1](32)
+      })
+
+      expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      expect(mockTerminal.refresh).toHaveBeenCalledWith(0, 23)
+    } finally {
+      Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: originalFonts,
+      })
+      requestAnimationFrameSpy.mockRestore()
+      offsetWidthSpy.mockRestore()
+      offsetHeightSpy.mockRestore()
+    }
+  })
+
   test('refreshes terminal after deferred terminal font refit flushes', async () => {
     let resolveFonts: () => void = (): void => undefined
 
@@ -1546,6 +1632,68 @@ describe('Body', () => {
       } finally {
         offsetSpy.mockRestore()
         terminalCache.delete('cached-session')
+      }
+    })
+
+    test('caches terminals skip font settle refit when reused', async () => {
+      // Seed the module-level cache to force the reuse branch
+      const cachedFitAddon = { fit: vi.fn() }
+
+      const cachedTerminal = {
+        open: vi.fn(),
+        dispose: vi.fn(),
+        focus: vi.fn(),
+        cols: 80,
+        rows: 24,
+        onResize: vi.fn(() => ({ dispose: vi.fn() })),
+        parser: { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) },
+      }
+
+      const load = vi.fn<FontFaceSet['load']>().mockResolvedValue([])
+      const originalFonts = document.fonts
+
+      Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: { load },
+      })
+
+      terminalCache.set('cached-session', {
+        terminal: cachedTerminal as unknown as Terminal,
+        fitAddon: cachedFitAddon as unknown as FitAddon,
+      })
+
+      const offsetWidthSpy = vi
+        .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockReturnValue(800)
+
+      const offsetHeightSpy = vi
+        .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+        .mockReturnValue(600)
+
+      try {
+        render(
+          <Body
+            sessionId="cached-session"
+            cwd="/home/user"
+            service={defaultMockService}
+          />
+        )
+
+        await waitFor(() => {
+          expect(cachedTerminal.open).toHaveBeenCalled()
+        })
+
+        // Cached terminals already have terminals and fonts in-process, so we
+        // should not re-run the font-settle pipeline when restoring.
+        expect(load).not.toHaveBeenCalled()
+      } finally {
+        terminalCache.delete('cached-session')
+        offsetHeightSpy.mockRestore()
+        offsetWidthSpy.mockRestore()
+        Object.defineProperty(document, 'fonts', {
+          configurable: true,
+          value: originalFonts,
+        })
       }
     })
 

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -553,6 +553,104 @@ describe('Body', () => {
     }
   })
 
+  test('retries terminal font refresh when drag starts before scheduled refit runs', async () => {
+    let resolveFonts: () => void = (): void => undefined
+
+    const fontsLoaded = new Promise<FontFace[]>((resolve) => {
+      resolveFonts = (): void => resolve([])
+    })
+
+    const load = vi.fn<FontFaceSet['load']>().mockReturnValue(fontsLoaded)
+    const originalFonts = document.fonts
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { load },
+    })
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    const offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockReturnValue(840)
+
+    const offsetHeightSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockReturnValue(600)
+
+    try {
+      const { rerender } = render(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+        />
+      )
+
+      await waitFor(() => {
+        expect(load).toHaveBeenCalledTimes(2)
+      })
+
+      mockFitAddon.fit.mockClear()
+      mockTerminal.refresh.mockClear()
+
+      await act(async () => {
+        resolveFonts()
+        await fontsLoaded
+      })
+
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+
+      rerender(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+          deferFit
+        />
+      )
+
+      act(() => {
+        frameCallbacks[0](16)
+      })
+
+      expect(mockFitAddon.fit).not.toHaveBeenCalled()
+      expect(mockTerminal.refresh).not.toHaveBeenCalled()
+
+      rerender(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+        />
+      )
+
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
+
+      act(() => {
+        frameCallbacks[1](32)
+      })
+
+      expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      expect(mockTerminal.refresh).toHaveBeenCalledWith(0, 23)
+    } finally {
+      Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: originalFonts,
+      })
+      requestAnimationFrameSpy.mockRestore()
+      offsetWidthSpy.mockRestore()
+      offsetHeightSpy.mockRestore()
+    }
+  })
+
   test('loads fit addon', async () => {
     render(
       <Body

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -11,6 +11,7 @@ import {
   terminalCache,
   type BodyHandle,
 } from './Body'
+import { TERMINAL_FONT_FAMILY } from './terminalFont'
 import { useTerminal, type UseTerminalReturn } from '../../hooks/useTerminal'
 import type { ITerminalService } from '../../services/terminalService'
 
@@ -83,6 +84,9 @@ describe('Body', () => {
     focus: ReturnType<typeof vi.fn>
     onResize: ReturnType<typeof vi.fn>
     parser: { registerOscHandler: ReturnType<typeof vi.fn> }
+    refresh: ReturnType<typeof vi.fn>
+    cols: number
+    rows: number
     options: Record<string, unknown>
   }
   let mockFitAddon: { fit: ReturnType<typeof vi.fn> }
@@ -109,6 +113,9 @@ describe('Body', () => {
       parser: {
         registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
       },
+      refresh: vi.fn(),
+      cols: 80,
+      rows: 24,
       options: {},
     }
 
@@ -193,7 +200,7 @@ describe('Body', () => {
         expect.objectContaining({
           cursorBlink: true,
           fontSize: 14,
-          fontFamily: expect.stringContaining('JetBrains Mono'),
+          fontFamily: TERMINAL_FONT_FAMILY,
         })
       )
     })
@@ -219,6 +226,79 @@ describe('Body', () => {
         })
       )
     })
+  })
+
+  test('refits terminal after bundled terminal fonts load', async () => {
+    let resolveFonts: () => void = (): void => undefined
+
+    const fontsLoaded = new Promise<FontFace[]>((resolve) => {
+      resolveFonts = (): void => resolve([])
+    })
+
+    const load = vi.fn<FontFaceSet['load']>().mockReturnValue(fontsLoaded)
+    const originalFonts = document.fonts
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { load },
+    })
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    const offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockReturnValue(840)
+
+    const offsetHeightSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockReturnValue(600)
+
+    try {
+      render(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+        />
+      )
+
+      await waitFor(() => {
+        expect(load).toHaveBeenCalledTimes(2)
+      })
+
+      mockFitAddon.fit.mockClear()
+
+      await act(async () => {
+        resolveFonts()
+        await fontsLoaded
+      })
+
+      await waitFor(() => {
+        expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+      })
+
+      act(() => {
+        frameCallbacks[0](16)
+      })
+
+      expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+      expect(mockTerminal.refresh).toHaveBeenCalledWith(0, 23)
+    } finally {
+      Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: originalFonts,
+      })
+      requestAnimationFrameSpy.mockRestore()
+      offsetWidthSpy.mockRestore()
+      offsetHeightSpy.mockRestore()
+    }
   })
 
   test('loads fit addon', async () => {

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -700,6 +700,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       newTerminal.refresh(0, Math.max(newTerminal.rows - 1, 0))
     }
 
+    const clearPendingDeferredFit = (): void => {
+      pendingDeferredFitFlushRef.current = false
+      pendingDeferredRefreshAfterFitRef.current = false
+    }
+
     const refitAfterTerminalFontsSettle = (): void => {
       if (disposed) {
         return
@@ -714,7 +719,14 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         return
       }
 
-      flushFit(fitAddon, { force: true, afterFit: refreshAfterFontFit })
+      pendingDeferredRefreshAfterFitRef.current = true
+      flushFit(fitAddon, {
+        force: true,
+        afterFit: (): void => {
+          clearPendingDeferredFit()
+          refreshAfterFontFit()
+        },
+      })
     }
 
     const refitWhenTerminalFontsSettle = async (): Promise<void> => {
@@ -734,11 +746,6 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     }
 
     void refitWhenTerminalFontsSettle()
-
-    const clearPendingDeferredFit = (): void => {
-      pendingDeferredFitFlushRef.current = false
-      pendingDeferredRefreshAfterFitRef.current = false
-    }
 
     const flushDeferredFit = (): void => {
       if (pendingDeferredRefreshAfterFitRef.current) {

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -558,16 +558,26 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     ): void => {
       cancelScheduledFit()
 
-      fitFrameId = window.requestAnimationFrame(() => {
-        fitFrameId = null
-        if (deferFitRef.current) {
-          return
-        }
-        const didFit = fitIfNeeded(targetFitAddon, options.force ?? false)
-        if (didFit) {
-          options.afterFit?.()
-        }
-      })
+      const flushWithRetry = (): void => {
+        fitFrameId = window.requestAnimationFrame(() => {
+          fitFrameId = null
+          if (deferFitRef.current) {
+            return
+          }
+          const width = node.offsetWidth
+          const didFit = fitIfNeeded(targetFitAddon, options.force ?? false)
+          if (!didFit && width <= 0 && options.afterFit) {
+            flushWithRetry()
+
+            return
+          }
+          if (didFit) {
+            options.afterFit?.()
+          }
+        })
+      }
+
+      flushWithRetry()
     }
 
     const fitInitialWhenReady = (targetFitAddon: FitAddon): boolean => {
@@ -745,7 +755,9 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       refitAfterTerminalFontsSettle()
     }
 
-    void refitWhenTerminalFontsSettle()
+    if (!cached) {
+      void refitWhenTerminalFontsSettle()
+    }
 
     const flushDeferredFit = (): void => {
       if (pendingDeferredRefreshAfterFitRef.current) {

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -219,6 +219,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const flushFitRef = useRef<(() => void) | null>(null)
   const flushFitSessionIdRef = useRef<string | null>(null)
   const pendingDeferredFitFlushRef = useRef(false)
+  const pendingDeferredRefreshAfterFitRef = useRef(false)
   const agentCwdOutputBufferRef = useRef('')
   const agentCwdHintContextRef = useRef('')
   const isRestoringOutputRef = useRef(false)
@@ -708,6 +709,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
       if (deferFitRef.current) {
         pendingDeferredFitFlushRef.current = true
+        pendingDeferredRefreshAfterFitRef.current = true
 
         return
       }
@@ -733,17 +735,53 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
     void refitWhenTerminalFontsSettle()
 
-    cancelScheduledFitRef.current = cancelScheduledFit
-    flushFitRef.current = (): void => {
+    const clearPendingDeferredFit = (): void => {
+      pendingDeferredFitFlushRef.current = false
+      pendingDeferredRefreshAfterFitRef.current = false
+    }
+
+    const flushDeferredFit = (): void => {
+      if (pendingDeferredRefreshAfterFitRef.current) {
+        pendingDeferredFitFlushRef.current = false
+        flushFit(fitAddon, {
+          force: true,
+          afterFit: (): void => {
+            clearPendingDeferredFit()
+            refreshAfterFontFit()
+          },
+        })
+
+        return
+      }
+
+      pendingDeferredFitFlushRef.current = false
       flushFit(fitAddon)
     }
+
+    const refreshAfterPendingInitialFit = (): void => {
+      if (!pendingDeferredRefreshAfterFitRef.current) {
+        pendingDeferredFitFlushRef.current = false
+
+        return
+      }
+
+      clearPendingDeferredFit()
+      refreshAfterFontFit()
+    }
+
+    cancelScheduledFitRef.current = cancelScheduledFit
+    flushFitRef.current = flushDeferredFit
     flushFitSessionIdRef.current = sessionId
 
-    if (pendingDeferredFitFlushRef.current && !deferFitRef.current) {
-      pendingDeferredFitFlushRef.current = false
-
+    if (
+      (pendingDeferredFitFlushRef.current ||
+        pendingDeferredRefreshAfterFitRef.current) &&
+      !deferFitRef.current
+    ) {
       if (!didInitialFit) {
-        flushFit(fitAddon)
+        flushDeferredFit()
+      } else {
+        refreshAfterPendingInitialFit()
       }
     }
 

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -845,6 +845,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     // When Body unmounts, the session is closed — free resources
     return (): void => {
       disposed = true
+      pendingDeferredFitFlushRef.current = false
+      pendingDeferredRefreshAfterFitRef.current = false
       cancelScheduledFit()
       if (flushFitSessionIdRef.current === sessionId) {
         cancelScheduledFitRef.current = null

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -34,6 +34,11 @@ import {
 } from './agentCwdGuard'
 import { parseAgentCwdHint } from './agentCwdHint'
 import { parseOsc7Cwd, WINDOWS_DRIVE_PATH } from './osc7'
+import {
+  TERMINAL_FONT_FAMILY,
+  TERMINAL_FONT_SIZE,
+  loadTerminalFonts,
+} from './terminalFont'
 import '@xterm/xterm/css/xterm.css'
 
 const AGENT_CWD_HINT_BUFFER_SIZE = 4096
@@ -496,6 +501,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     let canvasAddon: CanvasAddon | null = null
     let fitFrameId: number | null = null
     let lastFitSize: { width: number; height: number } | null = null
+    let disposed = false
 
     const cancelScheduledFit = (): void => {
       if (fitFrameId !== null) {
@@ -545,7 +551,10 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       })
     }
 
-    const flushFit = (targetFitAddon: FitAddon): void => {
+    const flushFit = (
+      targetFitAddon: FitAddon,
+      options: { force?: boolean; afterFit?: () => void } = {}
+    ): void => {
       cancelScheduledFit()
 
       fitFrameId = window.requestAnimationFrame(() => {
@@ -553,7 +562,10 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         if (deferFitRef.current) {
           return
         }
-        fitIfNeeded(targetFitAddon)
+        const didFit = fitIfNeeded(targetFitAddon, options.force ?? false)
+        if (didFit) {
+          options.afterFit?.()
+        }
       })
     }
 
@@ -584,9 +596,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       // Create new terminal instance
       newTerminal = new Terminal({
         cursorBlink: true,
-        fontSize: 14,
-        fontFamily:
-          '"JetBrains Mono", "JetBrainsMono Nerd Font", "Pure Nerd Font", "Courier New", Courier, monospace',
+        fontSize: TERMINAL_FONT_SIZE,
+        fontFamily: TERMINAL_FONT_FAMILY,
         theme: toXtermTheme(catppuccinMocha),
         scrollback: 10000,
         allowProposedApi: true,
@@ -684,6 +695,44 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       terminalCache.set(sessionId, { terminal: newTerminal, fitAddon })
     }
 
+    const refreshAfterFontFit = (): void => {
+      newTerminal.refresh(0, Math.max(newTerminal.rows - 1, 0))
+    }
+
+    const refitAfterTerminalFontsSettle = (): void => {
+      if (disposed) {
+        return
+      }
+
+      lastFitSize = null
+
+      if (deferFitRef.current) {
+        pendingDeferredFitFlushRef.current = true
+
+        return
+      }
+
+      flushFit(fitAddon, { force: true, afterFit: refreshAfterFontFit })
+    }
+
+    const refitWhenTerminalFontsSettle = async (): Promise<void> => {
+      const terminalFontsLoaded = loadTerminalFonts()
+
+      if (!terminalFontsLoaded) {
+        return
+      }
+
+      try {
+        await terminalFontsLoaded
+      } catch {
+        // Fall back to the available system stack, then remeasure whatever loaded.
+      }
+
+      refitAfterTerminalFontsSettle()
+    }
+
+    void refitWhenTerminalFontsSettle()
+
     cancelScheduledFitRef.current = cancelScheduledFit
     flushFitRef.current = (): void => {
       flushFit(fitAddon)
@@ -757,6 +806,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     // Cleanup: disconnect observers and dispose terminal from cache
     // When Body unmounts, the session is closed — free resources
     return (): void => {
+      disposed = true
       cancelScheduledFit()
       if (flushFitSessionIdRef.current === sessionId) {
         cancelScheduledFitRef.current = null

--- a/src/features/terminal/components/TerminalPane/terminalFont.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalFont.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  TERMINAL_FONT_FAMILY,
+  TERMINAL_FONT_SIZE,
+  loadTerminalFonts,
+  type TerminalFontLoader,
+} from './terminalFont'
+
+describe('terminalFont', () => {
+  test('prefers full patched Nerd Font families before the symbol fallback', () => {
+    const bundledSymbols = TERMINAL_FONT_FAMILY.indexOf(
+      '"Vimeflow Nerd Symbols"'
+    )
+
+    const userNerdFont = TERMINAL_FONT_FAMILY.indexOf(
+      '"JetBrainsMono Nerd Font"'
+    )
+
+    expect(TERMINAL_FONT_FAMILY).toContain('"JetBrains Mono"')
+    expect(bundledSymbols).toBeGreaterThan(-1)
+    expect(userNerdFont).toBeGreaterThan(-1)
+    expect(userNerdFont).toBeLessThan(bundledSymbols)
+  })
+
+  test('falls back through platform monospace families', () => {
+    expect(TERMINAL_FONT_FAMILY).toContain('Menlo')
+    expect(TERMINAL_FONT_FAMILY).toContain('Monaco')
+    expect(TERMINAL_FONT_FAMILY).toContain('monospace')
+  })
+
+  test('loads the text and symbol faces when the Font Loading API is available', async () => {
+    const load = vi.fn<FontFaceSet['load']>().mockResolvedValue([])
+    const fontLoader: TerminalFontLoader = { load }
+
+    await loadTerminalFonts(fontLoader)
+
+    expect(load).toHaveBeenCalledWith(
+      `${TERMINAL_FONT_SIZE}px "JetBrains Mono"`
+    )
+
+    expect(load).toHaveBeenCalledWith(
+      `${TERMINAL_FONT_SIZE}px "Vimeflow Nerd Symbols"`,
+      expect.stringContaining('\ue0b0')
+    )
+  })
+
+  test('skips loading when the Font Loading API is unavailable', () => {
+    expect(loadTerminalFonts(null)).toBeNull()
+  })
+})

--- a/src/features/terminal/components/TerminalPane/terminalFont.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalFont.test.ts
@@ -42,6 +42,11 @@ describe('terminalFont', () => {
       `${TERMINAL_FONT_SIZE}px "Vimeflow Nerd Symbols"`,
       expect.stringContaining('\ue0b0')
     )
+
+    expect(load).toHaveBeenCalledWith(
+      `${TERMINAL_FONT_SIZE}px "Vimeflow Nerd Symbols"`,
+      expect.stringContaining(String.fromCodePoint(0xf011b))
+    )
   })
 
   test('skips loading when the Font Loading API is unavailable', () => {

--- a/src/features/terminal/components/TerminalPane/terminalFont.ts
+++ b/src/features/terminal/components/TerminalPane/terminalFont.ts
@@ -1,0 +1,53 @@
+export const TERMINAL_FONT_SIZE = 14
+
+export const TERMINAL_FONT_FAMILY = [
+  '"JetBrainsMono Nerd Font"',
+  '"MesloLGS NF"',
+  '"Hack Nerd Font"',
+  '"FiraCode Nerd Font"',
+  '"JetBrains Mono"',
+  '"Symbols Nerd Font Mono"',
+  '"Symbols Nerd Font"',
+  '"Vimeflow Nerd Symbols"',
+  '"Cascadia Mono"',
+  'Menlo',
+  'Monaco',
+  '"Courier New"',
+  'Courier',
+  'monospace',
+].join(', ')
+
+export type TerminalFontLoader = Pick<FontFaceSet, 'load'>
+
+const TERMINAL_TEXT_FONT_SPEC = `${TERMINAL_FONT_SIZE}px "JetBrains Mono"`
+const TERMINAL_SYMBOL_FONT_SPEC = `${TERMINAL_FONT_SIZE}px "Vimeflow Nerd Symbols"`
+const TERMINAL_SYMBOL_SAMPLE = '\ue0b0\ue0b1\ue0b2\ue0b3\uf011b\uf303'
+
+const currentFontLoader = (): TerminalFontLoader | null => {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const fonts = (document as Partial<Pick<Document, 'fonts'>>).fonts
+
+  return fonts ?? null
+}
+
+const waitForTerminalFonts = async (
+  fontLoader: TerminalFontLoader
+): Promise<void> => {
+  await Promise.all([
+    fontLoader.load(TERMINAL_TEXT_FONT_SPEC),
+    fontLoader.load(TERMINAL_SYMBOL_FONT_SPEC, TERMINAL_SYMBOL_SAMPLE),
+  ])
+}
+
+export const loadTerminalFonts = (
+  fontLoader: TerminalFontLoader | null = currentFontLoader()
+): Promise<void> | null => {
+  if (!fontLoader) {
+    return null
+  }
+
+  return waitForTerminalFonts(fontLoader)
+}

--- a/src/features/terminal/components/TerminalPane/terminalFont.ts
+++ b/src/features/terminal/components/TerminalPane/terminalFont.ts
@@ -21,7 +21,7 @@ export type TerminalFontLoader = Pick<FontFaceSet, 'load'>
 
 const TERMINAL_TEXT_FONT_SPEC = `${TERMINAL_FONT_SIZE}px "JetBrains Mono"`
 const TERMINAL_SYMBOL_FONT_SPEC = `${TERMINAL_FONT_SIZE}px "Vimeflow Nerd Symbols"`
-const TERMINAL_SYMBOL_SAMPLE = '\ue0b0\ue0b1\ue0b2\ue0b3\uf011b\uf303'
+const TERMINAL_SYMBOL_SAMPLE = '\ue0b0\ue0b1\ue0b2\ue0b3\u{f011b}\uf303'
 
 const currentFontLoader = (): TerminalFontLoader | null => {
   if (typeof document === 'undefined') {

--- a/src/features/terminal/components/TerminalPane/terminalFont.ts
+++ b/src/features/terminal/components/TerminalPane/terminalFont.ts
@@ -1,14 +1,18 @@
 export const TERMINAL_FONT_SIZE = 14
 
+// cspell:ignore CaskaydiaCove
 export const TERMINAL_FONT_FAMILY = [
   '"JetBrainsMono Nerd Font"',
   '"MesloLGS NF"',
   '"Hack Nerd Font"',
   '"FiraCode Nerd Font"',
+  '"CaskaydiaCove NF"',
+  '"Cascadia Code NF"',
   '"JetBrains Mono"',
   '"Symbols Nerd Font Mono"',
   '"Symbols Nerd Font"',
   '"Vimeflow Nerd Symbols"',
+  '"Cascadia Code"',
   '"Cascadia Mono"',
   'Menlo',
   'Monaco',

--- a/src/index.css
+++ b/src/index.css
@@ -38,21 +38,17 @@
 }
 
 @font-face {
-  font-family: 'Pure Nerd Font';
+  font-family: 'Vimeflow Nerd Symbols';
   font-style: normal;
   font-display: block;
   font-weight: 400;
   src: url('@azurity/pure-nerd-font/PureNerdFont.woff2') format('woff2');
-  /* Match JetBrains Mono's em metrics so Nerd Font icons (e.g. md-cat
-     U+F011B used in shell prompts) render at full cell size instead of
-     as tiny specks. PNF's natural ascent/descent (711/-45 in a 1000-unit
-     em = 75.6% content) is much smaller than JBM's (1020/-300 = 132%);
-     when the browser substitutes a PNF glyph into an xterm cell sized by
-     JBM, the glyph renders at ~57% scale and looks invisible. size-adjust
-     scales the glyph outlines, and the *-override descriptors align the
-     baseline so substituted icons share the same vertical centerline as
-     JBM characters in the same line. */
-  size-adjust: 174%;
+  /* Isolated alias for the bundled Nerd Font symbol face. Keep this after full
+     patched Nerd Font families in the xterm stack: the symbol-only face is a
+     missing-glyph safety net, not a replacement for one monospaced patched
+     terminal font. Avoid size-adjust here because scaling the fallback face
+     also scales glyph advances, which makes Powerline prompt icons overrun
+     xterm cells on macOS. */
   ascent-override: 102%;
   descent-override: 30%;
 }


### PR DESCRIPTION
## Summary

- Move terminal font constants and font-loading helpers into a dedicated `terminalFont` module.
- Prefer full patched Nerd Font families before the bundled symbol-only fallback so Powerline/prompt glyphs share one monospaced cell metric when available.
- Keep the bundled `Vimeflow Nerd Symbols` face as a last-resort missing-glyph fallback without `size-adjust`, avoiding oversized prompt separators on macOS.
- Refit and refresh xterm after bundled terminal fonts settle so panes do not keep stale fallback-font cell measurements.

## Test Plan

- [x] `npm test -- --run src/features/terminal/components/TerminalPane/terminalFont.test.ts src/features/terminal/components/TerminalPane/Body.test.tsx`
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`

## Notes

Related follow-up for user-configurable terminal font settings: #274.