### PR TITLE
fix(diff): make HIGHLIGHT dropdown work — sync lineDiffType to the worker pool

### DIFF
--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -1,5 +1,12 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactElement } from 'react'
 import { DiffPanelContent } from './DiffPanelContent'
@@ -1058,7 +1065,7 @@ describe('DiffPanelContent', () => {
   })
 
   describe('worker pool render-options sync', (): void => {
-    test('calls workerPool.setRenderOptions with the initial pool options on mount', (): void => {
+    test('calls workerPool.setRenderOptions with the initial pool options on mount', async (): Promise<void> => {
       vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
         files: [],
         filesCwd: null,
@@ -1078,11 +1085,15 @@ describe('DiffPanelContent', () => {
       // 'word'; the sync effect must push BOTH into the shared worker pool so
       // the renderer's workerManager-driven path picks them up. lineDiffType
       // matters because setRenderOptions defaults every omitted field —
-      // leaving it out would reset the pool to Pierre's 'word-alt'.
-      expect(workerPoolSetRenderOptionsMock).toHaveBeenCalledWith({
-        theme: 'pierre-dark',
-        lineDiffType: 'word',
-      })
+      // leaving it out would reset the pool to Pierre's 'word-alt'. Writes are
+      // serialized through a promise chain, so the call is scheduled a
+      // microtask later — await it.
+      await waitFor(() =>
+        expect(workerPoolSetRenderOptionsMock).toHaveBeenCalledWith({
+          theme: 'pierre-dark',
+          lineDiffType: 'word',
+        })
+      )
     })
 
     test('surfaces workerPool.setRenderOptions failures', async (): Promise<void> => {
@@ -1174,10 +1185,12 @@ describe('DiffPanelContent', () => {
         within(menu).getByRole('menuitem', { name: /pierre-light$/i })
       )
 
-      expect(workerPoolSetRenderOptionsMock).toHaveBeenLastCalledWith({
-        theme: 'pierre-light',
-        lineDiffType: 'word',
-      })
+      await waitFor(() =>
+        expect(workerPoolSetRenderOptionsMock).toHaveBeenLastCalledWith({
+          theme: 'pierre-light',
+          lineDiffType: 'word',
+        })
+      )
 
       expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
         'data-theme',
@@ -1248,10 +1261,12 @@ describe('DiffPanelContent', () => {
 
       // lineDiffType MUST ride along with theme — it is a pool-owned option,
       // so the HIGHLIGHT dropdown would be a no-op without this push.
-      expect(workerPoolSetRenderOptionsMock).toHaveBeenLastCalledWith({
-        theme: 'pierre-dark',
-        lineDiffType: 'char',
-      })
+      await waitFor(() =>
+        expect(workerPoolSetRenderOptionsMock).toHaveBeenLastCalledWith({
+          theme: 'pierre-dark',
+          lineDiffType: 'char',
+        })
+      )
 
       // Remount is gated on the synced value, so the diff keeps the prior
       // highlighting until the pool resolves.
@@ -1269,6 +1284,80 @@ describe('DiffPanelContent', () => {
         'data-line-diff-type',
         'char'
       )
+    })
+
+    test('serializes pool writes so a newer change waits for the prior write', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const firstWrite = deferredWorkerOptions()
+      const secondWrite = deferredWorkerOptions()
+      workerPoolSetRenderOptionsMock
+        .mockReturnValueOnce(firstWrite.promise) // mount sync — left pending
+        .mockReturnValueOnce(secondWrite.promise) // theme change
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: [
+          {
+            path: 'src/App.tsx',
+            status: 'modified',
+            staged: false,
+          },
+        ],
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      })
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: {
+            filePath: 'src/App.tsx',
+            oldPath: 'src/App.tsx',
+            newPath: 'src/App.tsx',
+            hunks: [],
+          },
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText: 'new',
+        })
+      )
+
+      render(<DiffPanelContent cwd="/repo" />)
+
+      // The mount write fires and is left pending (unresolved).
+      await waitFor(() =>
+        expect(workerPoolSetRenderOptionsMock).toHaveBeenCalledTimes(1)
+      )
+
+      // Change the theme while the mount write is still in flight.
+      await user.click(screen.getByRole('button', { name: /pierre-dark/i }))
+      const menu = await screen.findByRole('menu')
+      await user.click(
+        within(menu).getByRole('menuitem', { name: /pierre-light$/i })
+      )
+
+      // Serialization: the second write MUST NOT start until the first
+      // resolves. Overlapping `setRenderOptions` calls can land out of order
+      // and leave the shared pool on the stale value (WorkerPoolManager assigns
+      // `this.renderOptions` only after its awaits).
+      expect(workerPoolSetRenderOptionsMock).toHaveBeenCalledTimes(1)
+
+      // Resolve the first write; the chained second write then runs.
+      await act(async () => {
+        firstWrite.resolve()
+        await firstWrite.promise
+      })
+
+      await waitFor(() =>
+        expect(workerPoolSetRenderOptionsMock).toHaveBeenCalledTimes(2)
+      )
+
+      expect(workerPoolSetRenderOptionsMock).toHaveBeenLastCalledWith({
+        theme: 'pierre-light',
+        lineDiffType: 'word',
+      })
     })
   })
 })

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -62,7 +62,7 @@ vi.mock('@pierre/diffs/react', () => ({
   }: {
     oldFile: { name: string; contents: string }
     newFile: { name: string; contents: string }
-    options: { diffStyle?: string; theme?: string }
+    options: { diffStyle?: string; theme?: string; lineDiffType?: string }
   }): ReactElement => (
     <div
       data-testid="multi-file-diff"
@@ -72,6 +72,7 @@ vi.mock('@pierre/diffs/react', () => ({
       data-new-contents={newFile.contents}
       data-diff-style={options.diffStyle}
       data-theme={options.theme}
+      data-line-diff-type={options.lineDiffType}
     >
       MultiFileDiff stub
     </div>
@@ -1056,8 +1057,8 @@ describe('DiffPanelContent', () => {
     })
   })
 
-  describe('worker pool theme sync', (): void => {
-    test('calls workerPool.setRenderOptions with the initial theme on mount', (): void => {
+  describe('worker pool render-options sync', (): void => {
+    test('calls workerPool.setRenderOptions with the initial pool options on mount', (): void => {
       vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
         files: [],
         filesCwd: null,
@@ -1073,11 +1074,14 @@ describe('DiffPanelContent', () => {
 
       render(<DiffPanelContent />)
 
-      // DiffPanelContent's default theme state is 'pierre-dark'; the sync
-      // effect must push that into the shared worker pool so the renderer's
-      // workerManager-driven theme path picks it up.
+      // DiffPanelContent's defaults are theme 'pierre-dark' + lineDiffType
+      // 'word'; the sync effect must push BOTH into the shared worker pool so
+      // the renderer's workerManager-driven path picks them up. lineDiffType
+      // matters because setRenderOptions defaults every omitted field —
+      // leaving it out would reset the pool to Pierre's 'word-alt'.
       expect(workerPoolSetRenderOptionsMock).toHaveBeenCalledWith({
         theme: 'pierre-dark',
+        lineDiffType: 'word',
       })
     })
 
@@ -1116,7 +1120,7 @@ describe('DiffPanelContent', () => {
       render(<DiffPanelContent cwd="/repo" />)
 
       expect(await screen.findByRole('alert')).toHaveTextContent(
-        'Theme sync failed: worker failed'
+        'Diff render sync failed: worker failed'
       )
     })
 
@@ -1172,6 +1176,7 @@ describe('DiffPanelContent', () => {
 
       expect(workerPoolSetRenderOptionsMock).toHaveBeenLastCalledWith({
         theme: 'pierre-light',
+        lineDiffType: 'word',
       })
 
       expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
@@ -1187,6 +1192,82 @@ describe('DiffPanelContent', () => {
       expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
         'data-theme',
         'pierre-light'
+      )
+    })
+
+    test('remounts MultiFileDiff only after worker pool accepts a new lineDiffType', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const pendingSync = deferredWorkerOptions()
+      workerPoolSetRenderOptionsMock
+        .mockResolvedValueOnce(undefined)
+        .mockReturnValueOnce(pendingSync.promise)
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: [
+          {
+            path: 'src/App.tsx',
+            status: 'modified',
+            staged: false,
+          },
+        ],
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      })
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: {
+            filePath: 'src/App.tsx',
+            oldPath: 'src/App.tsx',
+            newPath: 'src/App.tsx',
+            hunks: [],
+          },
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText: 'new',
+        })
+      )
+
+      render(<DiffPanelContent cwd="/repo" />)
+
+      expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
+        'data-line-diff-type',
+        'word'
+      )
+
+      // HIGHLIGHT dropdown trigger shows the current value 'Word'.
+      await user.click(screen.getByRole('button', { name: 'Word' }))
+      const menu = await screen.findByRole('menu')
+      await user.click(
+        within(menu).getByRole('menuitem', { name: /character/i })
+      )
+
+      // lineDiffType MUST ride along with theme — it is a pool-owned option,
+      // so the HIGHLIGHT dropdown would be a no-op without this push.
+      expect(workerPoolSetRenderOptionsMock).toHaveBeenLastCalledWith({
+        theme: 'pierre-dark',
+        lineDiffType: 'char',
+      })
+
+      // Remount is gated on the synced value, so the diff keeps the prior
+      // highlighting until the pool resolves.
+      expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
+        'data-line-diff-type',
+        'word'
+      )
+
+      await act(async () => {
+        pendingSync.resolve()
+        await pendingSync.promise
+      })
+
+      expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
+        'data-line-diff-type',
+        'char'
       )
     })
   })

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -327,6 +327,15 @@ export const DiffPanelContent = ({
   // so theme and lineDiffType must be pushed together — passing only `theme`
   // silently reset lineDiffType back to Pierre's `word-alt` default.
   const workerPool = useWorkerPool()
+
+  // Serialize writes to the shared pool. `setRenderOptions` assigns the pool's
+  // internal `this.renderOptions` only AFTER awaiting theme resolution + the
+  // worker round-trip (node_modules/@pierre/diffs/dist/worker/WorkerPoolManager.js
+  // ~L124), so two overlapping calls can finish out of order and leave the pool
+  // on the OLDER value while the UI shows the newer one. Chaining each write
+  // after the previous guarantees the last-requested options win; the per-run
+  // `cancelled` flag then ensures only the latest run commits the synced value.
+  const poolWriteChainRef = useRef<Promise<unknown>>(Promise.resolve())
   useEffect(() => {
     const next: PoolRenderOptions = { theme, lineDiffType }
 
@@ -337,8 +346,17 @@ export const DiffPanelContent = ({
     }
 
     let cancelled = false
+    const previousWrite = poolWriteChainRef.current
 
-    const syncRenderOptions = async (): Promise<void> => {
+    const run = async (): Promise<void> => {
+      // Wait for the previous write so overlapping calls can't land out of
+      // order. A prior failure is irrelevant here — its own run reported it.
+      try {
+        await previousWrite
+      } catch {
+        // ignore the previous write's rejection; proceed with this one
+      }
+
       try {
         await workerPool.setRenderOptions(next)
         if (!cancelled) {
@@ -352,7 +370,9 @@ export const DiffPanelContent = ({
       }
     }
 
-    void syncRenderOptions()
+    const writePromise = run()
+    poolWriteChainRef.current = writePromise
+    void writePromise
 
     return (): void => {
       cancelled = true

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -335,6 +335,13 @@ export const DiffPanelContent = ({
   // on the OLDER value while the UI shows the newer one. Chaining each write
   // after the previous guarantees the last-requested options win; the per-run
   // `cancelled` flag then ensures only the latest run commits the synced value.
+  //
+  // LIMITATION (deferred to PR2): this chain is per component instance, but the
+  // worker pool is an app-wide singleton. Two DiffPanelContent instances (split
+  // layout) — or an unmount overlapping a remount — have independent chains and
+  // can still race on the shared pool. Pool-keyed (module-level) serialization,
+  // plus the deeper "one shared pool can only hold one theme/lineDiffType"
+  // question, are handled in PR2 (staging).
   const poolWriteChainRef = useRef<Promise<unknown>>(Promise.resolve())
   useEffect(() => {
     const next: PoolRenderOptions = { theme, lineDiffType }

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -30,6 +30,18 @@ type DiffIndicators = NonNullable<BaseDiffOptions['diffIndicators']>
 type Overflow = NonNullable<BaseDiffOptions['overflow']>
 type LineDiffType = NonNullable<BaseDiffOptions['lineDiffType']>
 
+// The subset of Pierre options the worker pool OWNS once a pool is active:
+// the Shiki `theme` and the intra-line word-diff algorithm (`lineDiffType`).
+// `DiffHunksRenderer.getRenderOptions()` returns
+// `workerManager.getDiffRenderOptions()` wholesale under a pool (see
+// node_modules/@pierre/diffs/dist/renderers/DiffHunksRenderer.js), so the
+// per-instance `<MultiFileDiff options>` props for these two are ignored —
+// they must be pushed into the pool via `setRenderOptions` instead.
+interface PoolRenderOptions {
+  theme: DiffsThemeNames
+  lineDiffType: LineDiffType
+}
+
 /**
  * Controlled/uncontrolled selection pair as a discriminated union. Forces
  * callers to pass BOTH `selectedFile` + `onSelectedFileChange` (controlled
@@ -224,42 +236,60 @@ export const DiffPanelContent = ({
 
   // Pierre option state — every option here is a controlled-component value
   // surfaced upward from DiffChipToolbar. Most values drive <MultiFileDiff>
-  // on the next render. Theme additionally flows through `syncedTheme` so the
-  // diff remount waits for the worker pool to accept the new theme first.
+  // on the next render. `theme` and `lineDiffType` are special: the worker
+  // pool owns them (see the render-options sync effect below), so they flow
+  // through `syncedRenderOptions` and the diff remount waits for the pool to
+  // accept the new value first.
   const [diffStyle, setDiffStyle] = useState<DiffStyle>('split')
   const [theme, setTheme] = useState<DiffsThemeNames>('pierre-dark')
-  const [syncedTheme, setSyncedTheme] = useState<DiffsThemeNames>(theme)
-  const syncedThemeRef = useRef<DiffsThemeNames>(theme)
+  const [lineDiffType, setLineDiffType] = useState<LineDiffType>('word')
 
   const [diffIndicators, setDiffIndicators] =
     useState<DiffIndicators>('classic')
 
-  const [lineDiffType, setLineDiffType] = useState<LineDiffType>('word')
   const [overflowOpt, setOverflowOpt] = useState<Overflow>('scroll')
   const [disableLineNumbers, setDisableLineNumbers] = useState(false)
   const [disableBackground, setDisableBackground] = useState(false)
   const [disableFileHeader, setDisableFileHeader] = useState(false)
   const [stickyHeader, setStickyHeader] = useState(true)
-  const [themeSyncError, setThemeSyncErrorState] = useState<string | null>(null)
-  const themeSyncErrorRef = useRef<string | null>(null)
 
-  const setThemeSyncError = useCallback((message: string | null): void => {
-    if (themeSyncErrorRef.current === message) {
+  // Pool-owned render options, gated behind the worker-pool sync below so the
+  // diff remount waits until the pool actually accepts the new value.
+  // `renderedTheme` / `renderedLineDiffType` read from HERE (not from `theme` /
+  // `lineDiffType` directly) whenever a pool is present.
+  const [syncedRenderOptions, setSyncedRenderOptions] =
+    useState<PoolRenderOptions>({ theme, lineDiffType })
+  const syncedRenderOptionsRef = useRef<PoolRenderOptions>(syncedRenderOptions)
+
+  const [renderSyncError, setRenderSyncErrorState] = useState<string | null>(
+    null
+  )
+  const renderSyncErrorRef = useRef<string | null>(null)
+
+  const setRenderSyncError = useCallback((message: string | null): void => {
+    if (renderSyncErrorRef.current === message) {
       return
     }
 
-    themeSyncErrorRef.current = message
-    setThemeSyncErrorState(message)
+    renderSyncErrorRef.current = message
+    setRenderSyncErrorState(message)
   }, [])
 
-  const commitSyncedTheme = useCallback((nextTheme: DiffsThemeNames): void => {
-    if (syncedThemeRef.current === nextTheme) {
-      return
-    }
+  const commitSyncedRenderOptions = useCallback(
+    (next: PoolRenderOptions): void => {
+      const prev = syncedRenderOptionsRef.current
+      if (
+        prev.theme === next.theme &&
+        prev.lineDiffType === next.lineDiffType
+      ) {
+        return
+      }
 
-    syncedThemeRef.current = nextTheme
-    setSyncedTheme(nextTheme)
-  }, [])
+      syncedRenderOptionsRef.current = next
+      setSyncedRenderOptions(next)
+    },
+    []
+  )
 
   // Responsive width tracking. The right pane drives the two width bands:
   //   width < SPLIT_MIN_WIDTH_PX → coerce diffStyle to 'unified' (saved
@@ -284,45 +314,61 @@ export const DiffPanelContent = ({
     return (): void => observer.disconnect()
   }, [paneNode])
 
-  // Push theme changes into the shared Pierre worker pool. The worker
-  // tokenizes off-main-thread and DiffHunksRenderer pulls its theme from
-  // `workerManager.getDiffRenderOptions().theme` (see
-  // node_modules/@pierre/diffs/dist/renderers/DiffHunksRenderer.js getOptionsWithDefaults),
-  // shadowing the per-instance `<MultiFileDiff options.theme>` prop. Without
-  // this sync, the chip-toolbar theme dropdown writes to local state but the
-  // diff keeps rendering with the pool's initial theme (the bug surfaced
-  // during PR1 QA).
+  // Push pool-owned render options (theme + lineDiffType) into the shared
+  // Pierre worker pool. The worker tokenizes off-main-thread AND computes
+  // word-level intra-line decorations there, and
+  // `DiffHunksRenderer.getRenderOptions()` returns
+  // `workerManager.getDiffRenderOptions()` wholesale when a pool is active (see
+  // node_modules/@pierre/diffs/dist/renderers/DiffHunksRenderer.js), shadowing
+  // the per-instance `<MultiFileDiff options>` props. Without this sync the
+  // toolbar's THEME and HIGHLIGHT dropdowns write local state but the diff
+  // keeps rendering with the pool's initial values (both surfaced during PR1
+  // QA). NOTE: `setRenderOptions` resets every omitted field to its default,
+  // so theme and lineDiffType must be pushed together — passing only `theme`
+  // silently reset lineDiffType back to Pierre's `word-alt` default.
   const workerPool = useWorkerPool()
   useEffect(() => {
+    const next: PoolRenderOptions = { theme, lineDiffType }
+
     if (!workerPool) {
-      commitSyncedTheme(theme)
+      commitSyncedRenderOptions(next)
 
       return
     }
 
     let cancelled = false
 
-    const syncTheme = async (): Promise<void> => {
+    const syncRenderOptions = async (): Promise<void> => {
       try {
-        await workerPool.setRenderOptions({ theme })
+        await workerPool.setRenderOptions(next)
         if (!cancelled) {
-          setThemeSyncError(null)
-          commitSyncedTheme(theme)
+          setRenderSyncError(null)
+          commitSyncedRenderOptions(next)
         }
       } catch (err) {
         if (!cancelled) {
-          setThemeSyncError(err instanceof Error ? err.message : String(err))
+          setRenderSyncError(err instanceof Error ? err.message : String(err))
         }
       }
     }
 
-    void syncTheme()
+    void syncRenderOptions()
 
     return (): void => {
       cancelled = true
     }
-  }, [commitSyncedTheme, setThemeSyncError, workerPool, theme])
-  const renderedTheme = workerPool ? syncedTheme : theme
+  }, [
+    commitSyncedRenderOptions,
+    setRenderSyncError,
+    workerPool,
+    theme,
+    lineDiffType,
+  ])
+  const renderedTheme = workerPool ? syncedRenderOptions.theme : theme
+
+  const renderedLineDiffType = workerPool
+    ? syncedRenderOptions.lineDiffType
+    : lineDiffType
 
   const hasMeasuredPane = paneWidth > 0
 
@@ -499,12 +545,12 @@ export const DiffPanelContent = ({
             currentFileIndex={currentFileIndex}
             totalFiles={effectiveFiles.length}
           />
-          {themeSyncError !== null ? (
+          {renderSyncError !== null ? (
             <div
               role="alert"
               className="px-3 pb-2 text-[11px] leading-4 text-[#f38ba8]"
             >
-              Theme sync failed: {themeSyncError}
+              Diff render sync failed: {renderSyncError}
             </div>
           ) : null}
         </div>
@@ -521,24 +567,27 @@ export const DiffPanelContent = ({
               <DiffNarrowPlaceholder min={DIFF_MIN_WIDTH_PX} />
             ) : (
               <MultiFileDiff
-                // `key={renderedTheme}` forces a clean remount after the worker
-                // pool has accepted the new theme.
-                // Pierre's WorkerPoolManager-driven theme path normally
-                // rerenders via subscribeToThemeChanges, but PR1 QA observed
-                // the second theme switch sticking. Forcing a remount is a
-                // belt-and-braces remedy: a brand-new FileDiff instance
-                // requests fresh tokenization from the pool only after
-                // `setRenderOptions` resolves.
-                // Cost: one extra tokenize per theme change. Acceptable for
-                // v1; revisit if perf is an issue with very large diffs.
-                key={renderedTheme}
+                // `key` forces a clean remount after the worker pool has
+                // accepted new pool-owned options (theme + lineDiffType).
+                // Pierre's WorkerPoolManager path normally rerenders via its
+                // theme subscribers, but PR1 QA observed the second theme
+                // switch sticking. Forcing a remount is a belt-and-braces
+                // remedy: a brand-new FileDiff instance requests fresh
+                // tokenization from the pool only after `setRenderOptions`
+                // resolves. The key is built from the SYNCED values so it only
+                // changes once the pool has the new option — no flash of the
+                // prior highlighting.
+                // Cost: one extra tokenize per theme/highlight change.
+                // Acceptable for v1; revisit if perf is an issue with very
+                // large diffs.
+                key={`${renderedTheme}:${renderedLineDiffType}`}
                 oldFile={pierreInputs.oldFile}
                 newFile={pierreInputs.newFile}
                 options={{
                   diffStyle: effectiveDiffStyle,
                   theme: renderedTheme,
                   diffIndicators,
-                  lineDiffType,
+                  lineDiffType: renderedLineDiffType,
                   overflow: overflowOpt,
                   disableLineNumbers,
                   disableBackground,


### PR DESCRIPTION
Follow-up hotfix to #263 (PR1). The toolbar's **HIGHLIGHT dropdown was a no-op** on `main`.

## Root cause
`lineDiffType` is a *pool-owned* render option, exactly like `theme`: when a worker pool is active, `DiffHunksRenderer.getRenderOptions()` returns `workerManager.getDiffRenderOptions()` wholesale, so the per-instance `<MultiFileDiff options.lineDiffType>` prop is **ignored**. PR1 only synced `theme` into the pool — and because `WorkerPoolManager.setRenderOptions` resets every *omitted* field to its default, each theme change was silently resetting `lineDiffType` back to Pierre's `word-alt`, mismatching the dropdown's `word` default from the first render.

## The fix
- Generalize the theme-only pool sync into a `{ theme, lineDiffType }` sync, pushing both pool-owned options together.
- Gate the diff remount on the *synced* values (committed only after `setRenderOptions` resolves) so there's no flash of stale highlighting; the remount key is built from both.
- **Serialize pool writes** (codex round-1 HIGH): `setRenderOptions` assigns its internal `this.renderOptions` only *after* its awaits, so overlapping rapid changes could land out of order and strand the pool on a stale value. Each write now awaits the previous one, so the last-requested options always win.

## Known limitation — deferred to PR2
Codex round-2 flagged that the serialization chain is *per component instance*, while the pool is app-wide shared — two diff panels (split layout) or an unmount overlapping a remount can still race. This is **pre-existing** (PR1 synced per-instance with no serialization at all) and edge-case. The pool-keyed (module-level) fix, plus the deeper "one shared pool holds only one theme/lineDiffType" question, are scoped to **PR2 (staging)** and documented inline in `DiffPanelContent.tsx`.

## Test plan
- `npm run type-check` ✓
- `npm run lint` ✓
- 31/31 tests in `DiffPanelContent.test.tsx` ✓ — adds a lineDiffType-remount test and a write-serialization test
- Manual: toggle HIGHLIGHT (Word / Word-Alt / Character / None) and confirm the intra-line highlighting actually changes; toggle theme and confirm highlight mode persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)