### PR TITLE
fix: make command palette shortcut platform-aware

### DIFF
--- a/crates/backend/src/agent/adapter/mod.rs
+++ b/crates/backend/src/agent/adapter/mod.rs
@@ -277,7 +277,7 @@ mod noop_tests {
             .expect("openpty");
         let child = pty_pair
             .slave
-            .spawn_command(CommandBuilder::new("/bin/true"))
+            .spawn_command(CommandBuilder::new("/usr/bin/true"))
             .expect("spawn");
         let writer = pty_pair.master.take_writer().expect("take_writer");
 

--- a/crates/backend/src/agent/detector.rs
+++ b/crates/backend/src/agent/detector.rs
@@ -207,6 +207,7 @@ mod tests {
         assert!(detect_agent_with_source(10, &source).is_none());
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn reads_self_cmdline() {
         // /proc/self always exists and points to our own process

--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -1240,10 +1240,10 @@ mod tests {
                 pixel_height: 0,
             })
             .expect("openpty");
-        // Spawn /bin/true and reap immediately. We only need the pair to
+        // Spawn /usr/bin/true and reap immediately. We only need the pair to
         // source a real master + writer of the correct trait-object types;
         // the synthetic child below replaces the real one for the kill path.
-        let cmd = CommandBuilder::new("/bin/true");
+        let cmd = CommandBuilder::new("/usr/bin/true");
         let mut helper_child = pty_pair.slave.spawn_command(cmd).expect("spawn");
         let _ = helper_child.wait();
         let writer = pty_pair.master.take_writer().expect("take_writer");

--- a/crates/backend/src/terminal/state.rs
+++ b/crates/backend/src/terminal/state.rs
@@ -443,7 +443,7 @@ mod tests {
     }
 
     /// Build a real but ephemeral `ManagedSession` for tests that need
-    /// `PtyState::try_insert` exercising. The shell is `/bin/true` so the
+    /// `PtyState::try_insert` exercising. The shell is `/usr/bin/true` so the
     /// child exits immediately — we don't care about its output, only that
     /// `Box<dyn MasterPty + Send>` and `Box<dyn Child + Send + Sync>` are
     /// real values that satisfy `try_insert`'s signature. The `Drop` impl
@@ -460,10 +460,10 @@ mod tests {
                 pixel_height: 0,
             })
             .expect("openpty");
-        // /bin/true exits immediately with status 0 — keeps the test fast
+        // /usr/bin/true exits immediately with status 0 — keeps the test fast
         // and avoids leaving long-running shells around if cleanup is
         // skipped.
-        let cmd = CommandBuilder::new("/bin/true");
+        let cmd = CommandBuilder::new("/usr/bin/true");
         let child = pty_pair.slave.spawn_command(cmd).expect("spawn");
         let writer = pty_pair.master.take_writer().expect("take_writer");
         ManagedSession {
@@ -529,11 +529,11 @@ mod tests {
                 pixel_height: 0,
             })
             .expect("openpty");
-        // Spawn /bin/true and immediately drop the real child handle —
+        // Spawn /usr/bin/true and immediately drop the real child handle —
         // we only used the pair to obtain a master + writer of correct
         // trait-object types. The writer dangles when the helper exits,
         // which is fine because the test never writes to it.
-        let cmd = CommandBuilder::new("/bin/true");
+        let cmd = CommandBuilder::new("/usr/bin/true");
         let mut helper_child = pty_pair.slave.spawn_command(cmd).expect("spawn");
         // Reap the helper so it doesn't linger as a zombie in CI. Best-effort.
         let _ = helper_child.wait();

--- a/electron/command-palette-shortcut.test.ts
+++ b/electron/command-palette-shortcut.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest'
 import { COMMAND_PALETTE_TOGGLE } from './ipc-channels'
 import {
   COMMAND_PALETTE_GLOBAL_ACCELERATORS,
+  commandPaletteShortcutConfigForPlatform,
   type CommandPaletteShortcutOverrideOptions,
   installCommandPaletteShortcutOverride,
   isCommandPaletteShortcutInput,
@@ -93,47 +94,122 @@ const emitWindowEvent = (
 }
 
 describe('command palette shortcut override', () => {
-  test('matches Ctrl+: keydown without meta or alt modifiers', () => {
+  test('selects Command on macOS and Control elsewhere', () => {
+    expect(commandPaletteShortcutConfigForPlatform('darwin').modifier).toBe(
+      'command'
+    )
+
+    expect(commandPaletteShortcutConfigForPlatform('linux').modifier).toBe(
+      'control'
+    )
+
+    expect(commandPaletteShortcutConfigForPlatform('win32').modifier).toBe(
+      'control'
+    )
+  })
+
+  test('matches Ctrl+; keydown on Linux without meta or alt modifiers', () => {
     expect(
-      isCommandPaletteShortcutInput({
-        type: 'keyDown',
-        key: ':',
-        control: true,
-        meta: false,
-        alt: false,
-      })
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: ';',
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        commandPaletteShortcutConfigForPlatform('linux')
+      )
     ).toBe(true)
   })
 
+  test('ignores Ctrl+Shift+; keydown on Linux', () => {
+    expect(
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: ';',
+          control: true,
+          meta: false,
+          alt: false,
+          shift: true,
+        },
+        commandPaletteShortcutConfigForPlatform('linux')
+      )
+    ).toBe(false)
+  })
+
+  test('matches Cmd+; keydown on macOS without control or alt modifiers', () => {
+    expect(
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: ';',
+          control: false,
+          meta: true,
+          alt: false,
+        },
+        commandPaletteShortcutConfigForPlatform('darwin')
+      )
+    ).toBe(true)
+  })
+
+  test('ignores Cmd+Shift+; keydown on macOS', () => {
+    expect(
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: ';',
+          control: false,
+          meta: true,
+          alt: false,
+          shift: true,
+        },
+        commandPaletteShortcutConfigForPlatform('darwin')
+      )
+    ).toBe(false)
+  })
+
   test('ignores non-toggle inputs', () => {
+    const linuxConfig = commandPaletteShortcutConfigForPlatform('linux')
+
     expect(
-      isCommandPaletteShortcutInput({
-        type: 'keyUp',
-        key: ':',
-        control: true,
-        meta: false,
-        alt: false,
-      })
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyUp',
+          key: ';',
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        linuxConfig
+      )
     ).toBe(false)
 
     expect(
-      isCommandPaletteShortcutInput({
-        type: 'keyDown',
-        key: ':',
-        control: true,
-        meta: true,
-        alt: false,
-      })
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: ';',
+          control: true,
+          meta: true,
+          alt: false,
+        },
+        linuxConfig
+      )
     ).toBe(false)
 
     expect(
-      isCommandPaletteShortcutInput({
-        type: 'keyDown',
-        key: ';',
-        control: true,
-        meta: false,
-        alt: false,
-      })
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: ':',
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        linuxConfig
+      )
     ).toBe(false)
   })
 
@@ -143,24 +219,27 @@ describe('command palette shortcut override', () => {
     // the packaged app (event.preventDefault suppresses the renderer keydown),
     // so the main-process matcher must reject auto-repeat itself — otherwise
     // the 100 ms deduplication dispatcher still leaks one toggle every
-    // ~100 ms, flickering the palette open/closed while Ctrl+: is held.
+    // ~100 ms, flickering the palette open/closed while Ctrl+; is held.
     expect(
-      isCommandPaletteShortcutInput({
-        type: 'keyDown',
-        key: ':',
-        control: true,
-        meta: false,
-        alt: false,
-        isAutoRepeat: true,
-      })
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: ';',
+          control: true,
+          meta: false,
+          alt: false,
+          isAutoRepeat: true,
+        },
+        commandPaletteShortcutConfigForPlatform('linux')
+      )
     ).toBe(false)
   })
 
-  test('prevents renderer keydown and sends palette toggle IPC', () => {
+  test('prevents renderer Ctrl+; keydown and sends palette toggle IPC on Linux', () => {
     const { beforeInputHandlers, send, win } = createFakeWindow()
     const preventDefault = vi.fn()
 
-    installCommandPaletteShortcutOverride(win, { platform: 'darwin' })
+    installCommandPaletteShortcutOverride(win, { platform: 'linux' })
 
     const handler = beforeInputHandlers[0]
 
@@ -172,7 +251,7 @@ describe('command palette shortcut override', () => {
       { preventDefault },
       {
         type: 'keyDown',
-        key: ':',
+        key: ';',
         control: true,
         meta: false,
         alt: false,
@@ -183,7 +262,7 @@ describe('command palette shortcut override', () => {
     expect(send).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE)
   })
 
-  test('does not toggle on auto-repeat before-input-event keydown', () => {
+  test('prevents renderer Cmd+; keydown and sends palette toggle IPC on macOS', () => {
     const { beforeInputHandlers, send, win } = createFakeWindow()
     const preventDefault = vi.fn()
 
@@ -199,7 +278,62 @@ describe('command palette shortcut override', () => {
       { preventDefault },
       {
         type: 'keyDown',
-        key: ':',
+        key: ';',
+        control: false,
+        meta: true,
+        alt: false,
+      }
+    )
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(send).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE)
+  })
+
+  test('does not prevent renderer Cmd+Shift+; keydown on macOS', () => {
+    const { beforeInputHandlers, send, win } = createFakeWindow()
+    const preventDefault = vi.fn()
+
+    installCommandPaletteShortcutOverride(win, { platform: 'darwin' })
+
+    const handler = beforeInputHandlers[0]
+
+    if (handler === undefined) {
+      throw new Error('before-input-event handler was not registered')
+    }
+
+    handler(
+      { preventDefault },
+      {
+        type: 'keyDown',
+        key: ';',
+        control: false,
+        meta: true,
+        alt: false,
+        shift: true,
+      }
+    )
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  test('does not toggle on auto-repeat before-input-event keydown', () => {
+    const { beforeInputHandlers, send, win } = createFakeWindow()
+    const preventDefault = vi.fn()
+
+    installCommandPaletteShortcutOverride(win, { platform: 'linux' })
+
+    const handler = beforeInputHandlers[0]
+
+    if (handler === undefined) {
+      throw new Error('before-input-event handler was not registered')
+    }
+
+    handler(
+      { preventDefault },
+      {
+        type: 'keyDown',
+        key: ';',
         control: true,
         meta: false,
         alt: false,
@@ -262,7 +396,7 @@ describe('command palette shortcut override', () => {
         { preventDefault },
         {
           type: 'keyDown',
-          key: ':',
+          key: ';',
           control: true,
           meta: false,
           alt: false,
@@ -278,7 +412,7 @@ describe('command palette shortcut override', () => {
         { preventDefault },
         {
           type: 'keyDown',
-          key: ':',
+          key: ';',
           control: true,
           meta: false,
           alt: false,

--- a/electron/command-palette-shortcut.ts
+++ b/electron/command-palette-shortcut.ts
@@ -7,6 +7,7 @@ interface ShortcutInput {
   control: boolean
   meta: boolean
   alt: boolean
+  shift?: boolean
   isAutoRepeat?: boolean
 }
 
@@ -20,21 +21,43 @@ export interface CommandPaletteShortcutOverrideOptions {
   shortcutRegistry?: ShortcutRegistry
 }
 
-export const COMMAND_PALETTE_GLOBAL_ACCELERATORS = [
-  'Control+:',
-  'Control+Shift+;',
-  'Control+;',
-] as const
+type CommandPaletteShortcutModifier = 'control' | 'command'
+
+export interface CommandPaletteShortcutConfig {
+  modifier: CommandPaletteShortcutModifier
+  globalAccelerators: readonly string[]
+}
+
+const CONTROL_ACCELERATORS = ['Control+;'] as const
+
+const COMMAND_ACCELERATORS = ['Command+;'] as const
+
+export const commandPaletteShortcutConfigForPlatform = (
+  platform: NodeJS.Platform
+): CommandPaletteShortcutConfig =>
+  platform === 'darwin'
+    ? { modifier: 'command', globalAccelerators: COMMAND_ACCELERATORS }
+    : { modifier: 'control', globalAccelerators: CONTROL_ACCELERATORS }
+
+export const COMMAND_PALETTE_GLOBAL_ACCELERATORS =
+  commandPaletteShortcutConfigForPlatform('linux').globalAccelerators
 
 const SHORTCUT_TOGGLE_DEDUPLICATION_MS = 100
 
-export const isCommandPaletteShortcutInput = (input: ShortcutInput): boolean =>
+export const isCommandPaletteShortcutInput = (
+  input: ShortcutInput,
+  config: CommandPaletteShortcutConfig = commandPaletteShortcutConfigForPlatform(
+    process.platform
+  )
+): boolean =>
   input.type === 'keyDown' &&
-  input.control &&
-  !input.meta &&
+  (config.modifier === 'command'
+    ? input.meta && !input.control
+    : input.control && !input.meta) &&
   !input.alt &&
+  input.shift !== true &&
   !input.isAutoRepeat &&
-  input.key === ':'
+  input.key === ';'
 
 const sendCommandPaletteToggle = (win: BrowserWindow): void => {
   if (win.isDestroyed()) {
@@ -67,6 +90,7 @@ export const installCommandPaletteShortcutOverride = (
 ): void => {
   const platform = options.platform ?? process.platform
   const shortcutRegistry = options.shortcutRegistry ?? globalShortcut
+  const shortcutConfig = commandPaletteShortcutConfigForPlatform(platform)
   const dispatchCommandPaletteToggle = createCommandPaletteToggleDispatcher(win)
   let registeredAccelerators: string[] = []
 
@@ -75,7 +99,7 @@ export const installCommandPaletteShortcutOverride = (
       return
     }
 
-    registeredAccelerators = COMMAND_PALETTE_GLOBAL_ACCELERATORS.filter(
+    registeredAccelerators = shortcutConfig.globalAccelerators.filter(
       (accelerator) =>
         shortcutRegistry.register(accelerator, dispatchCommandPaletteToggle)
     )
@@ -93,7 +117,7 @@ export const installCommandPaletteShortcutOverride = (
   }
 
   win.webContents.on('before-input-event', (event, input) => {
-    if (!isCommandPaletteShortcutInput(input)) {
+    if (!isCommandPaletteShortcutInput(input, shortcutConfig)) {
       return
     }
 

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { StatusBar, type StatusBarProps } from './StatusBar'
 
 const defaultProps = {
@@ -11,7 +11,7 @@ const defaultProps = {
     changes: { added: 212, removed: 188 },
   },
   contextPct: 74,
-  paletteShortcut: ['Ctrl', ':'],
+  paletteShortcut: ['Mod', ';'],
   onOpenPalette: vi.fn(),
 } satisfies StatusBarProps
 
@@ -21,6 +21,13 @@ const renderStatusBar = (
   render(<StatusBar {...defaultProps} {...overrides} />)
 
 describe('StatusBar', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'Linux x86_64',
+      configurable: true,
+    })
+  })
+
   test('renders the running session state with every segment', () => {
     renderStatusBar()
 
@@ -42,7 +49,19 @@ describe('StatusBar', () => {
       screen.getByRole('button', { name: /open command palette/i })
     ).toBeInTheDocument()
     expect(screen.getByText('Ctrl')).toBeInTheDocument()
-    expect(screen.getByText(':')).toBeInTheDocument()
+    expect(screen.getByText(';')).toBeInTheDocument()
+  })
+
+  test('renders the platform command key on macOS', () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    })
+
+    renderStatusBar()
+
+    expect(screen.getByText('⌘')).toBeInTheDocument()
+    expect(screen.getByText(';')).toBeInTheDocument()
   })
 
   test('omits duration cache and diff segments without orphan separators', () => {

--- a/src/features/command-palette/hooks/useCommandPalette.test.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.test.ts
@@ -10,6 +10,10 @@ import type { BackendApi } from '../../../lib/backend'
 
 describe('useCommandPalette', () => {
   beforeEach(() => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'Linux x86_64',
+      configurable: true,
+    })
     chordRegistry._resetForTest()
     // Clear any focused elements before each test
     document.body.innerHTML = ''
@@ -72,12 +76,12 @@ describe('useCommandPalette', () => {
     })
   })
 
-  describe('keyboard trigger - Ctrl+:', () => {
+  describe('keyboard trigger', () => {
     test('exports the displayed command-palette shortcut', () => {
-      expect(COMMAND_PALETTE_SHORTCUT_KEYS).toEqual(['Ctrl', ':'])
+      expect(COMMAND_PALETTE_SHORTCUT_KEYS).toEqual(['Mod', ';'])
     })
 
-    test('Ctrl+: opens palette after the leader window expires', () => {
+    test('Ctrl+; opens palette after the leader window expires', () => {
       vi.useFakeTimers()
       const { result } = renderHook(() => useCommandPalette())
 
@@ -85,7 +89,7 @@ describe('useCommandPalette', () => {
 
       act(() => {
         const event = new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
           ctrlKey: true,
           bubbles: true,
         })
@@ -101,13 +105,39 @@ describe('useCommandPalette', () => {
       expect(result.current.state.isOpen).toBe(true)
     })
 
-    test('Ctrl+: with palette closed keeps palette closed during leader window', () => {
+    test('Cmd+; opens palette on macOS after the leader window expires', () => {
+      Object.defineProperty(navigator, 'platform', {
+        value: 'MacIntel',
+        configurable: true,
+      })
       vi.useFakeTimers()
       const { result } = renderHook(() => useCommandPalette())
 
       act(() => {
         const event = new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
+          metaKey: true,
+          bubbles: true,
+        })
+        document.dispatchEvent(event)
+      })
+
+      expect(result.current.state.isOpen).toBe(false)
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+
+      expect(result.current.state.isOpen).toBe(true)
+    })
+
+    test('Ctrl+; with palette closed keeps palette closed during leader window', () => {
+      vi.useFakeTimers()
+      const { result } = renderHook(() => useCommandPalette())
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', {
+          key: ';',
           ctrlKey: true,
           bubbles: true,
         })
@@ -123,13 +153,13 @@ describe('useCommandPalette', () => {
       expect(result.current.state.isOpen).toBe(false)
     })
 
-    test('does not open palette when bare : is pressed', async () => {
+    test('does not open palette when bare semicolon is pressed', async () => {
       const { result } = renderHook(() => useCommandPalette())
 
       expect(result.current.state.isOpen).toBe(false)
 
       act(() => {
-        const event = new KeyboardEvent('keydown', { key: ':' })
+        const event = new KeyboardEvent('keydown', { key: ';' })
         document.dispatchEvent(event)
       })
 
@@ -138,7 +168,7 @@ describe('useCommandPalette', () => {
       })
     })
 
-    test('toggles palette closed when Ctrl+: pressed while open', () => {
+    test('toggles palette closed when Ctrl+; pressed while open', () => {
       vi.useFakeTimers()
       const { result } = renderHook(() => useCommandPalette())
 
@@ -150,7 +180,7 @@ describe('useCommandPalette', () => {
 
       act(() => {
         const event = new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
           ctrlKey: true,
           bubbles: true,
         })
@@ -166,12 +196,12 @@ describe('useCommandPalette', () => {
       expect(result.current.state.isOpen).toBe(false)
     })
 
-    test('Ctrl+: trigger consumes the event when starting the leader window', () => {
+    test('Ctrl+; trigger consumes the event when starting the leader window', () => {
       vi.useFakeTimers()
       const { result } = renderHook(() => useCommandPalette())
 
       const event = new KeyboardEvent('keydown', {
-        key: ':',
+        key: ';',
         ctrlKey: true,
         bubbles: true,
         cancelable: true,
@@ -194,7 +224,7 @@ describe('useCommandPalette', () => {
       expect(stopImmediatePropagationSpy).toHaveBeenCalled()
     })
 
-    test('Ctrl+: while palette is open closes it immediately without leader delay', () => {
+    test('Ctrl+; while palette is open closes it immediately without leader delay', () => {
       vi.useFakeTimers()
       const { result } = renderHook(() => useCommandPalette())
 
@@ -204,7 +234,7 @@ describe('useCommandPalette', () => {
 
       act(() => {
         const event = new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
           ctrlKey: true,
           bubbles: true,
           cancelable: true,
@@ -221,7 +251,7 @@ describe('useCommandPalette', () => {
       expect(result.current.state.isOpen).toBe(false)
     })
 
-    test('Ctrl+: then r within 500ms triggers chord without opening palette', () => {
+    test('Ctrl+; then r within 500ms triggers chord without opening palette', () => {
       vi.useFakeTimers()
       const handler = vi.fn(() => true)
       chordRegistry.registerChord('r', handler)
@@ -229,7 +259,7 @@ describe('useCommandPalette', () => {
 
       act(() => {
         const leaderEvent = new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
           ctrlKey: true,
           bubbles: true,
           cancelable: true,
@@ -263,13 +293,13 @@ describe('useCommandPalette', () => {
       expect(result.current.state.isOpen).toBe(false)
     })
 
-    test('Ctrl+: then non-chord follow-up opens palette with follow-up query', () => {
+    test('Ctrl+; then non-chord follow-up opens palette with follow-up query', () => {
       vi.useFakeTimers()
       const { result } = renderHook(() => useCommandPalette())
 
       act(() => {
         const leaderEvent = new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
           ctrlKey: true,
           bubbles: true,
           cancelable: true,
@@ -297,13 +327,13 @@ describe('useCommandPalette', () => {
       expect(result.current.state.query).toBe(':q')
     })
 
-    test('Ctrl+: then Ctrl+: opens palette immediately', () => {
+    test('Ctrl+; then Ctrl+; opens palette immediately', () => {
       vi.useFakeTimers()
       const { result } = renderHook(() => useCommandPalette())
 
       act(() => {
         const leaderEvent = new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
           ctrlKey: true,
           bubbles: true,
           cancelable: true,
@@ -312,7 +342,7 @@ describe('useCommandPalette', () => {
       })
 
       const secondLeaderEvent = new KeyboardEvent('keydown', {
-        key: ':',
+        key: ';',
         ctrlKey: true,
         bubbles: true,
         cancelable: true,
@@ -343,7 +373,7 @@ describe('useCommandPalette', () => {
 
       act(() => {
         const leaderEvent = new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
           ctrlKey: true,
           bubbles: true,
           cancelable: true,
@@ -375,7 +405,7 @@ describe('useCommandPalette', () => {
       expect(result.current.state.isOpen).toBe(false)
     })
 
-    test('Ctrl+: trigger calls preventDefault and stops propagation when closing', async () => {
+    test('Ctrl+; trigger calls preventDefault and stops propagation when closing', async () => {
       const { result } = renderHook(() => useCommandPalette())
 
       act(() => {
@@ -385,7 +415,7 @@ describe('useCommandPalette', () => {
       expect(result.current.state.isOpen).toBe(true)
 
       const event = new KeyboardEvent('keydown', {
-        key: ':',
+        key: ';',
         ctrlKey: true,
         bubbles: true,
         cancelable: true,
@@ -411,7 +441,7 @@ describe('useCommandPalette', () => {
       expect(stopImmediatePropagationSpy).toHaveBeenCalled()
     })
 
-    test('Ctrl+: trigger overrides later document-level global shortcuts', async () => {
+    test('Ctrl+; trigger overrides later document-level global shortcuts', async () => {
       const { result } = renderHook(() => useCommandPalette())
       const globalShortcut = vi.fn()
       document.addEventListener('keydown', globalShortcut, { capture: true })
@@ -419,7 +449,7 @@ describe('useCommandPalette', () => {
       try {
         act(() => {
           const event = new KeyboardEvent('keydown', {
-            key: ':',
+            key: ';',
             ctrlKey: true,
             bubbles: true,
             cancelable: true,
@@ -481,7 +511,7 @@ describe('useCommandPalette', () => {
       }
     })
 
-    test('Ctrl+: trigger suppresses repeat events (key-hold flickering guard)', () => {
+    test('Ctrl+; trigger suppresses repeat events (key-hold flickering guard)', () => {
       vi.useFakeTimers()
       // Real-world hardware sends repeat=true events while a key is held.
       // The hook must short-circuit these via the `event.repeat` guard so
@@ -495,7 +525,7 @@ describe('useCommandPalette', () => {
 
       act(() => {
         const initialEvent = new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
           ctrlKey: true,
           bubbles: true,
           cancelable: true,
@@ -510,7 +540,7 @@ describe('useCommandPalette', () => {
       expect(result.current.state.isOpen).toBe(true)
 
       const repeatEvent = new KeyboardEvent('keydown', {
-        key: ':',
+        key: ';',
         ctrlKey: true,
         bubbles: true,
         cancelable: true,
@@ -540,7 +570,7 @@ describe('useCommandPalette', () => {
     test('capture-phase listener wins over child stopPropagation', () => {
       vi.useFakeTimers()
       // A child element calling event.stopPropagation() during the bubbling
-      // phase must NOT prevent the global Ctrl+: toggle. The hook attaches
+      // phase must NOT prevent the global Ctrl+; toggle. The hook attaches
       // with { capture: true } so it runs during the capture phase, before
       // any descendant bubble-phase listener can interfere.
       const { result } = renderHook(() => useCommandPalette())
@@ -555,7 +585,7 @@ describe('useCommandPalette', () => {
 
       act(() => {
         const event = new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
           ctrlKey: true,
           bubbles: true,
           cancelable: true,

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -17,11 +17,12 @@ import { getAllLeaves, traverseNamespace } from '../registry/commandTree'
 import { parseQuery } from '../registry/parseQuery'
 import * as chordRegistry from '../chordRegistry'
 import { listenCommandPaletteToggle } from '../../../lib/backend'
+import {
+  COMMAND_PALETTE_SHORTCUT_KEYS,
+  isCommandPaletteToggle,
+} from '../shortcutConfig'
 
 const LEADER_WINDOW_MS = 500
-
-const isPaletteToggle = (event: KeyboardEvent): boolean =>
-  event.ctrlKey && !event.metaKey && !event.altKey && event.key === ':'
 
 const queryForLeaderFollowUp = (event: KeyboardEvent): string | null => {
   if (
@@ -47,7 +48,7 @@ const fullyConsumeEvent = (event: KeyboardEvent): void => {
   event.stopImmediatePropagation()
 }
 
-export const COMMAND_PALETTE_SHORTCUT_KEYS = ['Ctrl', ':'] as const
+export { COMMAND_PALETTE_SHORTCUT_KEYS }
 
 export const useCommandPalette = (
   commands: Command[] = defaultCommands
@@ -310,9 +311,9 @@ export const useCommandPalette = (
 
   // Global keyboard listener — registered once for the hook's lifetime.
   useEffect(() => {
-    // Ctrl+: handling shared by the renderer keydown path and the Electron
+    // Platform command-palette toggle handling shared by the renderer keydown path and the Electron
     // before-input-event override. In the packaged app Electron owns the
-    // Ctrl+: binding and consumes it before the renderer sees it, dispatching
+    // toggle binding and consumes it before the renderer sees it, dispatching
     // an IPC toggle instead; this callback drives the same leader window so
     // the follow-up chord key (NOT intercepted) still reaches handleKeyDown
     // below and routes through chordRegistry / usePaneRenameChord.
@@ -334,14 +335,14 @@ export const useCommandPalette = (
     }
 
     const handleKeyDown = (event: KeyboardEvent): void => {
-      if (isPaletteToggle(event) && event.repeat) {
+      if (isCommandPaletteToggle(event) && event.repeat) {
         fullyConsumeEvent(event)
 
         return
       }
 
       if (leaderActiveRef.current) {
-        if (isPaletteToggle(event)) {
+        if (isCommandPaletteToggle(event)) {
           fullyConsumeEvent(event)
           clearLeaderWindow()
           handlersRef.current.open()
@@ -371,10 +372,10 @@ export const useCommandPalette = (
         return
       }
 
-      // Ctrl+: starts a short leader window. If no chord consumes the
+      // The palette toggle starts a short leader window. If no chord consumes the
       // follow-up key, the palette opens after the window or immediately on
       // the non-chord key.
-      if (isPaletteToggle(event)) {
+      if (isCommandPaletteToggle(event)) {
         fullyConsumeEvent(event)
         handlePaletteShortcut()
 

--- a/src/features/command-palette/hooks/usePaneRenameChord.test.tsx
+++ b/src/features/command-palette/hooks/usePaneRenameChord.test.tsx
@@ -100,7 +100,7 @@ describe('usePaneRenameChord', () => {
     mockSetPaneUserLabel.mockReset()
   })
 
-  test('Ctrl+: then r with focused pane opens rename input', () => {
+  test('palette toggle then r with focused pane opens rename input', () => {
     const focused = makeFocusedRef({ agentTitle: 'old title' })
 
     render(<Harness resolveFocusedPane={() => focused} />)

--- a/src/features/command-palette/shortcutConfig.test.ts
+++ b/src/features/command-palette/shortcutConfig.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+import {
+  COMMAND_PALETTE_SHORTCUT_KEYS,
+  commandPaletteShortcutModifierForPlatform,
+  isCommandPaletteToggle,
+} from './shortcutConfig'
+
+describe('command palette shortcut config', () => {
+  test('uses platform-conditional display keys', () => {
+    expect(COMMAND_PALETTE_SHORTCUT_KEYS).toEqual(['Mod', ';'])
+  })
+
+  test('selects meta on macOS and ctrl elsewhere', () => {
+    expect(commandPaletteShortcutModifierForPlatform('MacIntel')).toBe('meta')
+    expect(commandPaletteShortcutModifierForPlatform('Linux x86_64')).toBe(
+      'ctrl'
+    )
+    expect(commandPaletteShortcutModifierForPlatform('Win32')).toBe('ctrl')
+  })
+
+  test('matches the configured ctrl shortcut', () => {
+    expect(
+      isCommandPaletteToggle(
+        new KeyboardEvent('keydown', {
+          key: ';',
+          ctrlKey: true,
+        }),
+        'ctrl'
+      )
+    ).toBe(true)
+
+    expect(
+      isCommandPaletteToggle(
+        new KeyboardEvent('keydown', {
+          key: ';',
+          ctrlKey: true,
+          shiftKey: true,
+        }),
+        'ctrl'
+      )
+    ).toBe(false)
+
+    expect(
+      isCommandPaletteToggle(
+        new KeyboardEvent('keydown', {
+          key: ';',
+          metaKey: true,
+        }),
+        'ctrl'
+      )
+    ).toBe(false)
+  })
+
+  test('matches the configured meta shortcut', () => {
+    expect(
+      isCommandPaletteToggle(
+        new KeyboardEvent('keydown', {
+          key: ';',
+          metaKey: true,
+        }),
+        'meta'
+      )
+    ).toBe(true)
+
+    expect(
+      isCommandPaletteToggle(
+        new KeyboardEvent('keydown', {
+          key: ';',
+          metaKey: true,
+          shiftKey: true,
+        }),
+        'meta'
+      )
+    ).toBe(false)
+
+    expect(
+      isCommandPaletteToggle(
+        new KeyboardEvent('keydown', {
+          key: ';',
+          ctrlKey: true,
+        }),
+        'meta'
+      )
+    ).toBe(false)
+  })
+})

--- a/src/features/command-palette/shortcutConfig.ts
+++ b/src/features/command-palette/shortcutConfig.ts
@@ -1,0 +1,30 @@
+import { isMacPlatform, type ShortcutKey } from '../../lib/formatShortcut'
+
+export type CommandPaletteShortcutModifier = 'ctrl' | 'meta'
+
+export const COMMAND_PALETTE_SHORTCUT_KEYS = [
+  'Mod',
+  ';',
+] as const satisfies readonly ShortcutKey[]
+
+export const commandPaletteShortcutModifierForPlatform = (
+  platform: string
+): CommandPaletteShortcutModifier =>
+  platform.toLowerCase().startsWith('mac') ? 'meta' : 'ctrl'
+
+export const getCommandPaletteShortcutModifier =
+  (): CommandPaletteShortcutModifier => (isMacPlatform() ? 'meta' : 'ctrl')
+
+export const isCommandPaletteToggle = (
+  event: KeyboardEvent,
+  modifier: CommandPaletteShortcutModifier = getCommandPaletteShortcutModifier()
+): boolean => {
+  const expectedModifier =
+    modifier === 'meta'
+      ? event.metaKey && !event.ctrlKey
+      : event.ctrlKey && !event.metaKey
+
+  return (
+    expectedModifier && !event.altKey && !event.shiftKey && event.key === ';'
+  )
+}

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -24,7 +24,7 @@ vi.mock('../../lib/backend', () => ({
     })
   ),
   invoke: vi.fn().mockResolvedValue(null),
-  // useCommandPalette subscribes to the Electron main-process Ctrl+:
+  // useCommandPalette subscribes to the Electron main-process palette toggle
   // override on mount; return a synchronous no-op unlisten so the
   // WorkspaceView tree mounts without reaching a real bridge.
   listenCommandPaletteToggle: vi.fn(() => (): void => {
@@ -168,6 +168,10 @@ describe('WorkspaceView - Command Palette Integration', () => {
   let mockSessions: Session[]
 
   beforeEach(async () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'Linux x86_64',
+      configurable: true,
+    })
     // Reset all mocks
     vi.clearAllMocks()
     terminalZonePropsSpy.mockClear()
@@ -297,7 +301,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
   const openPalette = (): void => {
     act(() => {
       const event = new KeyboardEvent('keydown', {
-        key: ':',
+        key: ';',
         ctrlKey: true,
         bubbles: true,
       })

--- a/src/features/workspace/WorkspaceView.notifyInfo.test.tsx
+++ b/src/features/workspace/WorkspaceView.notifyInfo.test.tsx
@@ -37,6 +37,10 @@ vi.mock('../../hooks/useElasticContainer', () => ({
 
 describe('WorkspaceView × notifyInfo banner', () => {
   beforeEach(() => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'Linux x86_64',
+      configurable: true,
+    })
     vi.useFakeTimers({ shouldAdvanceTime: true })
   })
 
@@ -48,7 +52,7 @@ describe('WorkspaceView × notifyInfo banner', () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     act(() => {
       document.dispatchEvent(
-        new KeyboardEvent('keydown', { key: ':', ctrlKey: true })
+        new KeyboardEvent('keydown', { key: ';', ctrlKey: true })
       )
     })
     await screen.findByRole('dialog')

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -144,6 +144,10 @@ vi.mock('../terminal/services/terminalService', () => ({
 
 describe('WorkspaceView', () => {
   beforeEach(() => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'Linux x86_64',
+      configurable: true,
+    })
     capturedAgentStatusPanelProps.onOpenFile = undefined
     capturedAgentStatusPanelProps.onOpenDiff = undefined
     capturedAgentStatusPanelProps.agentStatus = undefined
@@ -916,7 +920,7 @@ describe('WorkspaceView', () => {
     act(() => {
       document.dispatchEvent(
         new KeyboardEvent('keydown', {
-          key: ':',
+          key: ';',
           ctrlKey: true,
           bubbles: true,
         })

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -576,7 +576,7 @@ export const WorkspaceView = (): ReactElement => {
   const dockPanelRef = useRef<DockPanelHandle>(null)
 
   const resolveFocusedPane = useCallback((): FocusedPaneRef | null => {
-    // The chord is a deliberate user gesture (`Ctrl+:` then `r`); fire
+    // The chord is a deliberate user gesture (palette toggle then `r`); fire
     // it whenever the workspace has an active session + active pane.
     // Don't gate on `activeContainerId === TERMINAL_CONTAINER_ID` —
     // that workspace-container focus state only flips on Ctrl+B or

--- a/src/features/workspace/components/IconRail.tsx
+++ b/src/features/workspace/components/IconRail.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from 'react'
 import { Tooltip } from '../../../components/Tooltip'
+import { formatShortcut } from '../../../lib/formatShortcut'
+import { COMMAND_PALETTE_SHORTCUT_KEYS } from '../../command-palette/shortcutConfig'
 import type { NavigationItem } from '../types'
 
 export interface IconRailIdentity {
@@ -97,6 +99,10 @@ export const IconRail = ({
 
   const settingsTooltip = `Settings panel coming — see issue #${settingsIssueNumber}`
 
+  const commandPaletteTooltip = `Command Palette (${formatShortcut(
+    COMMAND_PALETTE_SHORTCUT_KEYS
+  )})`
+
   return (
     <nav
       data-testid="icon-rail"
@@ -128,7 +134,7 @@ export const IconRail = ({
         <RailBtn
           icon="search"
           accessibleName="Command Palette"
-          tooltipContent="Command Palette (Ctrl+:)"
+          tooltipContent={commandPaletteTooltip}
           onClick={onCommand}
         />
         <RailBtn

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,6 +8,42 @@ afterEach(() => {
   paneHeaderRefs._resetForTest()
 })
 
+const createMemoryStorage = (): Storage => {
+  const store = new Map<string, string>()
+
+  return {
+    get length(): number {
+      return store.size
+    },
+    clear: (): void => {
+      store.clear()
+    },
+    getItem: (key: string): string | null => store.get(key) ?? null,
+    key: (index: number): string | null =>
+      Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string): void => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string): void => {
+      store.set(key, value)
+    },
+  }
+}
+
+if (typeof window.localStorage.clear !== 'function') {
+  const storage = createMemoryStorage()
+
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage,
+  })
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  })
+}
+
 // Mock xterm.js WebGL addon to prevent WebGL errors in jsdom
 vi.mock('@xterm/addon-webgl', () => ({
   WebglAddon: vi.fn(() => ({


### PR DESCRIPTION
## Summary
- centralize the command palette shortcut config around unshifted semicolon input
- use Cmd+; on macOS and Ctrl+; on Linux/Windows for Electron interception, React handling, and UI hints
- cover shifted punctuation rejection and platform-specific modifier behavior in unit tests
- make backend PTY test helpers portable across macOS and Linux so local Rust CI checks pass too

## Test Plan
- npm run lint
- npm run format:check
- npm run type-check
- npm test
- cargo test
- find src/bindings -name '*.ts' ! -name 'index.ts' -delete && npm run generate:bindings && git diff --exit-code src/bindings/ && test -z "$(git ls-files --others --exclude-standard src/bindings/)"\n- npm run test:e2e:build\n- npm run test:e2e:core:run\n- npm run test:e2e:terminal:run\n- npm run test:e2e:agent:run\n\n## Notes\n- The push hook reran `npm test` successfully after the final push: 202 test files passed, 2722 tests passed, 3 skipped.\n- GitHub currently reports no check runs for this PR/branch despite active workflows and a synchronize push; local equivalents of the configured CI commands are green.