### PR TITLE
feat(split-view): drag-to-resize panes for non-single layouts

### DIFF
--- a/docs/superpowers/plans/2026-05-25-split-pane-resize-plan.md
+++ b/docs/superpowers/plans/2026-05-25-split-pane-resize-plan.md
@@ -314,7 +314,9 @@ In `UseElasticContainerOptions` add:
 ```ts
   /** Fixed pixels removed from the measured dimension before percentages apply
    *  (e.g. a divider track that sits between the two resizable regions).
-   *  Default 0 — leaves single-panel consumers (the dock) unchanged. */
+   *  Default 0 — leaves single-panel consumers (the dock) unchanged.
+   *  Mount-time constant by contract, like `axis` / `minPercent` / `maxPercent`:
+   *  captured once into a ref; changing it after mount does NOT re-derive bounds. */
   reservedPx?: number
 ```
 
@@ -575,9 +577,101 @@ Wraps one `useElasticContainer` and bridges it to the grid: live drag writes the
 
 **Files:**
 - Create: `src/features/terminal/components/SplitView/useSplitDivider.ts`
-- Test: covered via `SplitDividers.test.tsx` (Task 6) — this hook is exercised through the components.
+- Test: `src/features/terminal/components/SplitView/useSplitDivider.test.tsx`
 
-- [ ] **Step 1: Implement `useSplitDivider.ts`**
+- [ ] **Step 1: Write the failing bridge test**
+
+Task 6 only asserts divider *counts*; this test pins the bridge behavior the
+components rely on — the ratio mirrored up, the px CSS var written on the
+**keyboard** path (where `onDragPreview` never fires), and the var removed on
+unmount. The container lives in a parent that stays mounted while the divider
+child unmounts — mirroring active-only mounting, so `containerRef.current` is
+still valid when the cleanup effect runs.
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { test, expect, describe, vi, beforeEach, afterEach } from 'vitest'
+import { useRef } from 'react'
+import { useSplitDivider } from './useSplitDivider'
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+beforeEach(() => {
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: 1200, height: 800, top: 0, left: 0, right: 1200, bottom: 800,
+    x: 0, y: 0, toJSON: (): undefined => undefined,
+  } as DOMRect)
+})
+afterEach(() => vi.restoreAllMocks())
+
+const DividerChild = ({
+  containerRef,
+  onRatioChange,
+}: {
+  containerRef: React.RefObject<HTMLElement | null>
+  onRatioChange: (r: number) => void
+}): React.ReactElement => {
+  const divider = useSplitDivider({
+    containerRef,
+    axis: 'horizontal',
+    cssVar: '--split-col',
+    initialRatio: 0.5,
+    onRatioChange,
+  })
+  return <div data-testid="handle" tabIndex={0} onKeyDown={divider.onKeyDown} />
+}
+
+const Harness = ({
+  active,
+  onRatioChange,
+}: {
+  active: boolean
+  onRatioChange: (r: number) => void
+}): React.ReactElement => {
+  const ref = useRef<HTMLDivElement>(null)
+  return (
+    <div ref={ref} data-testid="container" style={{ width: 1200, height: 800 }}>
+      {active ? (
+        <DividerChild containerRef={ref} onRatioChange={onRatioChange} />
+      ) : null}
+    </div>
+  )
+}
+
+describe('useSplitDivider', () => {
+  test('keyboard resize mirrors a clamped ratio up and writes the px var', () => {
+    const onRatioChange = vi.fn()
+    render(<Harness active onRatioChange={onRatioChange} />)
+    fireEvent.keyDown(screen.getByTestId('handle'), { key: 'ArrowRight' })
+    const ratio = onRatioChange.mock.calls.at(-1)?.[0] as number
+    expect(ratio).toBeGreaterThanOrEqual(0.15)
+    expect(ratio).toBeLessThanOrEqual(0.85)
+    expect(
+      screen.getByTestId('container').style.getPropertyValue('--split-col')
+    ).toMatch(/px$/)
+  })
+
+  test('removes the CSS var on unmount (container stays mounted)', () => {
+    const { rerender } = render(<Harness active onRatioChange={vi.fn()} />)
+    const container = screen.getByTestId('container')
+    expect(container.style.getPropertyValue('--split-col')).toMatch(/px$/)
+    rerender(<Harness active={false} onRatioChange={vi.fn()} />)
+    expect(container.style.getPropertyValue('--split-col')).toBe('')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/features/terminal/components/SplitView/useSplitDivider.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `useSplitDivider.ts`**
 
 ```ts
 import { useCallback, useEffect, type KeyboardEvent, type RefObject } from 'react'
@@ -688,9 +782,20 @@ export const useSplitDivider = ({
 }
 ```
 
-- [ ] **Step 2: Commit** (verified by Task 6 tests; commit together with Task 6)
+- [ ] **Step 4: Run to verify it passes**
 
-No standalone test run — proceed to Task 6 which exercises this hook through the components, then commit both.
+Run: `npx vitest run src/features/terminal/components/SplitView/useSplitDivider.test.tsx`
+Expected: PASS (2 tests — keyboard mirror + unmount cleanup).
+
+- [ ] **Step 5: Commit**
+
+```bash
+WT=/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize
+npx vitest run src/features/terminal/components/SplitView/useSplitDivider.test.tsx
+git -C "$WT" add src/features/terminal/components/SplitView/useSplitDivider.ts \
+  src/features/terminal/components/SplitView/useSplitDivider.test.tsx
+git -C "$WT" commit -m "feat(split-view): useSplitDivider bridge (CSS var + ratio mirror)"
+```
 
 ### Task 6: `SplitDividers` per-layout components
 
@@ -970,15 +1075,14 @@ export const SplitDividers = ({
 Run: `npx vitest run src/features/terminal/components/SplitView/SplitDividers.test.tsx`
 Expected: PASS (6 cases: counts 0/1/1/2/3 + the vsplit orientation check).
 
-- [ ] **Step 5: Commit** (includes Task 5's hook)
+- [ ] **Step 5: Commit**
 
 ```bash
 WT=/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize
 npx vitest run src/features/terminal/components/SplitView/SplitDividers.test.tsx
-git -C "$WT" add src/features/terminal/components/SplitView/useSplitDivider.ts \
-  src/features/terminal/components/SplitView/SplitDividers.tsx \
+git -C "$WT" add src/features/terminal/components/SplitView/SplitDividers.tsx \
   src/features/terminal/components/SplitView/SplitDividers.test.tsx
-git -C "$WT" commit -m "feat(split-view): per-layout SplitDividers + useSplitDivider bridge"
+git -C "$WT" commit -m "feat(split-view): per-layout SplitDividers components"
 ```
 
 ### Task 7: Wire `SplitDividers` into `SplitView`
@@ -1089,6 +1193,35 @@ test('active vsplit renders a divider; inactive does not', () => {
   expect(screen.getAllByTestId('split-resize-handle')).toHaveLength(1)
   rerender(/* same session, isActive: false */)
   expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(0)
+})
+
+// D4: a resized ratio survives cycling the layout away and back. The
+// grid-template's `fr` fallback encodes the remembered ratio, so comparing the
+// gridTemplateColumns string before/after the cycle proves persistence.
+test('remembers the split ratio across a layout cycle', () => {
+  const { rerender } = renderSplitView({ layout: 'vsplit', isActive: true })
+  const grid = screen.getByTestId('split-view')
+  const pristine = grid.style.gridTemplateColumns
+
+  fireEvent.keyDown(screen.getByTestId('split-resize-handle'), { key: 'ArrowRight' })
+  const resized = screen.getByTestId('split-view').style.gridTemplateColumns
+  expect(resized).not.toBe(pristine) // ratio fallback changed
+
+  rerender(/* same session, layout: 'single', isActive: true */)
+  rerender(/* same session, layout: 'vsplit', isActive: true */)
+  expect(screen.getByTestId('split-view').style.gridTemplateColumns).toBe(resized)
+})
+
+// D2: a resized ratio survives a tab switch (isActive false → true). SplitView
+// stays mounted while hidden, so its ratio state persists.
+test('remembers the split ratio across a tab switch', () => {
+  const { rerender } = renderSplitView({ layout: 'vsplit', isActive: true })
+  fireEvent.keyDown(screen.getByTestId('split-resize-handle'), { key: 'ArrowRight' })
+  const resized = screen.getByTestId('split-view').style.gridTemplateColumns
+
+  rerender(/* same session, isActive: false */)
+  rerender(/* same session, isActive: true */)
+  expect(screen.getByTestId('split-view').style.gridTemplateColumns).toBe(resized)
 })
 ```
 

--- a/docs/superpowers/plans/2026-05-25-split-pane-resize-plan.md
+++ b/docs/superpowers/plans/2026-05-25-split-pane-resize-plan.md
@@ -1,0 +1,1155 @@
+# Split-pane Resize Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users drag the border between panes to resize width/height in every non-`single` layout, reusing the dock's elastic-resize machinery.
+
+**Architecture:** Two phases. Phase 1 extracts the dock's inline resize-handle markup into a shared `ResizeHandle` primitive (pure refactor). Phase 2 adds split-pane dividers: a backward-compatible `reservedPx` option on `useElasticContainer`, a `resolveGrid` template helper, per-layout `SplitDividers` subcomponents (fixed hook counts), and `SplitView` ownership of remembered ratios with active-only divider mounting.
+
+**Tech Stack:** React + TypeScript, CSS Grid, Vitest + Testing Library, Tailwind (Catppuccin tokens).
+
+**Spec:** `docs/superpowers/specs/2026-05-25-split-pane-resize-design.md` (committed + codex-reviewed).
+
+**Worktree:** All work happens in `/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize` on branch `feat/split-pane-resize`. Run every git command as `git -C /home/will/projects/vimeflow/.claude/worktrees/split-pane-resize …`. The primary checkout is on an unrelated branch — never touch it.
+
+**Conventions:** No semicolons, single quotes, trailing commas (es5). Arrow-function components only. Explicit return types on exported functions. `import { test, expect, … } from 'vitest'` explicitly in every test. Co-located sibling tests. Run a single test file with `npx vitest run <path>`.
+
+---
+
+## File Structure
+
+**Phase 1**
+
+- Create `src/components/ResizeHandle.tsx` — presentational resize-handle affordance (role/aria/cursor/colors/handlers). Owns affordance only; consumer owns placement.
+- Create `src/components/ResizeHandle.test.tsx`.
+- Modify `src/features/workspace/components/DockPanel.tsx` — replace the two inline handle `<div>`s with `<ResizeHandle>`. `DockPanel.test.tsx` is the unchanged regression net.
+
+**Phase 2**
+
+- Modify `src/hooks/useElasticContainer.ts` — add optional `reservedPx` (default `0`) so percentages run over `dimension − reservedPx`; expose `effectiveDimension`.
+- Modify `src/hooks/useElasticContainer.test.ts` — add `reservedPx` cases; existing cases stay green.
+- Create `src/features/terminal/components/SplitView/resolveGrid.ts` — `SPLIT_DIVIDER_PX`, `DEFAULT_RATIOS`, `resolveGrid(layoutId, ratios)`.
+- Create `src/features/terminal/components/SplitView/resolveGrid.test.ts`.
+- Modify `src/features/workspace/panelConfig.ts` — add `SPLIT_ELASTIC_CONFIG`.
+- Create `src/features/terminal/components/SplitView/useSplitDivider.ts` — wraps `useElasticContainer` for one divider; owns the CSS-var bridge + keyboard handler.
+- Create `src/features/terminal/components/SplitView/SplitDividers.tsx` — layout switch + the four per-layout subcomponents (`VSplitDividers`, `HSplitDividers`, `ThreeRightDividers`, `QuadDividers`), each with a fixed hook count.
+- Create `src/features/terminal/components/SplitView/SplitDividers.test.tsx`.
+- Modify `src/features/terminal/components/SplitView/SplitView.tsx` — padding moves to an outer `split-view-canvas` wrapper; the inner measured grid holds panes + dividers; ratio state + `resolveGrid` template + active-only `<SplitDividers>`.
+- Modify `src/features/terminal/components/SplitView/SplitView.test.tsx` — update grid-template/padding assertions; add divider integration tests.
+
+---
+
+## Phase 1 — Extract the `ResizeHandle` primitive
+
+### Task 1: `ResizeHandle` component
+
+**Files:**
+- Create: `src/components/ResizeHandle.tsx`
+- Test: `src/components/ResizeHandle.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { test, expect, vi, describe } from 'vitest'
+import { ResizeHandle, type ResizeHandleProps } from './ResizeHandle'
+
+const baseProps: ResizeHandleProps = {
+  orientation: 'horizontal',
+  isDragging: false,
+  ariaValueNow: 100,
+  ariaValueMin: 40,
+  ariaValueMax: 640,
+  onMouseDown: vi.fn(),
+  onKeyDown: vi.fn(),
+}
+
+describe('ResizeHandle', () => {
+  test('renders a separator with the given orientation', () => {
+    render(<ResizeHandle {...baseProps} orientation="vertical" />)
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toHaveAttribute('role', 'separator')
+    expect(handle).toHaveAttribute('aria-orientation', 'vertical')
+  })
+
+  test('horizontal orientation uses ns-resize, vertical uses col-resize', () => {
+    const { rerender } = render(<ResizeHandle {...baseProps} orientation="horizontal" />)
+    expect(screen.getByTestId('resize-handle').className).toMatch(/cursor-ns-resize/)
+    rerender(<ResizeHandle {...baseProps} orientation="vertical" />)
+    expect(screen.getByTestId('resize-handle').className).toMatch(/cursor-col-resize/)
+  })
+
+  test('exposes aria value range', () => {
+    render(<ResizeHandle {...baseProps} ariaValueNow={120} ariaValueMin={50} ariaValueMax={900} />)
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toHaveAttribute('aria-valuenow', '120')
+    expect(handle).toHaveAttribute('aria-valuemin', '50')
+    expect(handle).toHaveAttribute('aria-valuemax', '900')
+  })
+
+  test('applies the active background only while dragging', () => {
+    const { rerender } = render(<ResizeHandle {...baseProps} isDragging={false} />)
+    expect(screen.getByTestId('resize-handle').className).not.toMatch(/bg-primary\/30/)
+    rerender(<ResizeHandle {...baseProps} isDragging />)
+    expect(screen.getByTestId('resize-handle').className).toMatch(/bg-primary\/30/)
+  })
+
+  test('forwards mouse + keyboard events', () => {
+    const onMouseDown = vi.fn()
+    const onKeyDown = vi.fn()
+    render(<ResizeHandle {...baseProps} onMouseDown={onMouseDown} onKeyDown={onKeyDown} />)
+    const handle = screen.getByTestId('resize-handle')
+    fireEvent.mouseDown(handle)
+    fireEvent.keyDown(handle, { key: 'ArrowUp' })
+    expect(onMouseDown).toHaveBeenCalled()
+    expect(onKeyDown).toHaveBeenCalled()
+  })
+
+  test('passes through consumer className, style and testId', () => {
+    render(
+      <ResizeHandle
+        {...baseProps}
+        testId="split-resize-handle"
+        className="absolute z-10 h-1 left-0 right-0"
+        style={{ gridArea: 'vdiv' }}
+      />
+    )
+    const handle = screen.getByTestId('split-resize-handle')
+    expect(handle.className).toMatch(/\bz-10\b/)
+    expect(handle.className).toMatch(/left-0/)
+    expect(handle.style.gridArea).toBe('vdiv')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/ResizeHandle.test.tsx`
+Expected: FAIL — `Cannot find module './ResizeHandle'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+import type { CSSProperties, KeyboardEvent, MouseEvent, ReactElement } from 'react'
+
+export interface ResizeHandleProps {
+  /** aria-orientation. 'horizontal' separator → ns-resize; 'vertical' → col-resize. */
+  orientation: 'horizontal' | 'vertical'
+  isDragging: boolean
+  ariaValueNow: number
+  ariaValueMin: number
+  ariaValueMax: number
+  ariaLabel?: string
+  testId?: string
+  onMouseDown: (event: MouseEvent) => void
+  onKeyDown: (event: KeyboardEvent) => void
+  /** Consumer-owned placement: position offsets, stretch + thickness, z-index. */
+  className?: string
+  style?: CSSProperties
+}
+
+export const ResizeHandle = ({
+  orientation,
+  isDragging,
+  ariaValueNow,
+  ariaValueMin,
+  ariaValueMax,
+  ariaLabel = 'Resize panel',
+  testId = 'resize-handle',
+  onMouseDown,
+  onKeyDown,
+  className = '',
+  style = undefined,
+}: ResizeHandleProps): ReactElement => {
+  const cursor =
+    orientation === 'horizontal' ? 'cursor-ns-resize' : 'cursor-col-resize'
+
+  return (
+    <div
+      data-testid={testId}
+      role="separator"
+      aria-orientation={orientation}
+      aria-label={ariaLabel}
+      aria-valuenow={ariaValueNow}
+      aria-valuemin={ariaValueMin}
+      aria-valuemax={ariaValueMax}
+      tabIndex={0}
+      onMouseDown={onMouseDown}
+      onKeyDown={onKeyDown}
+      style={style}
+      className={`${cursor} transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
+        isDragging ? 'bg-primary/30' : ''
+      } ${className}`}
+    />
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/ResizeHandle.test.tsx`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+WT=/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize
+npx vitest run src/components/ResizeHandle.test.tsx
+git -C "$WT" add src/components/ResizeHandle.tsx src/components/ResizeHandle.test.tsx
+git -C "$WT" commit -m "refactor: extract shared ResizeHandle primitive"
+```
+
+### Task 2: Migrate `DockPanel` to `ResizeHandle`
+
+**Files:**
+- Modify: `src/features/workspace/components/DockPanel.tsx` (the two handle `<div>`s, ~269–305; add import)
+- Regression net: `src/features/workspace/components/DockPanel.test.tsx` (unchanged)
+
+- [ ] **Step 1: Add the import**
+
+At the top of `DockPanel.tsx`, alongside the other component imports:
+
+```tsx
+import { ResizeHandle } from '../../../components/ResizeHandle'
+```
+
+- [ ] **Step 2: Replace the vertical-dock handle**
+
+Replace the `isVerticalDock ? (<div data-testid="resize-handle" … />)` branch's `<div>` with:
+
+```tsx
+<ResizeHandle
+  orientation="horizontal"
+  isDragging={isVerticalResizing}
+  ariaValueNow={verticalSize}
+  ariaValueMin={verticalPixelMin}
+  ariaValueMax={verticalPixelMax}
+  onMouseDown={onVerticalResizeMouseDown}
+  onKeyDown={handleVerticalKeyDown}
+  // z-10 keeps the 4-px handle above the DockTab header (relative sibling)
+  className={`absolute ${position === 'top' ? 'bottom-0' : 'top-0'} left-0 right-0 z-10 h-1`}
+/>
+```
+
+- [ ] **Step 3: Replace the horizontal-dock handle**
+
+Replace the `: (<div data-testid="resize-handle" … />)` branch's `<div>` with:
+
+```tsx
+<ResizeHandle
+  orientation="vertical"
+  isDragging={isHorizontalResizing}
+  ariaValueNow={horizontalSize}
+  ariaValueMin={horizontalPixelMin}
+  ariaValueMax={horizontalPixelMax}
+  onMouseDown={onHorizontalResizeMouseDown}
+  onKeyDown={handleHorizontalKeyDown}
+  className={`absolute ${position === 'right' ? 'left-0' : 'right-0'} top-0 bottom-0 z-10 w-1`}
+/>
+```
+
+- [ ] **Step 4: Run the regression net**
+
+Run: `npx vitest run src/features/workspace/components/DockPanel.test.tsx`
+Expected: PASS (all existing tests — `resize-handle` testid, `aria-orientation`, `aria-valuemin/max`, `z-10`, `left-0`/`right-0`, mousedown forwarding, keyboard arrows all preserved).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+WT=/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize
+npx vitest run src/features/workspace/components/DockPanel.test.tsx
+npm run lint -- src/features/workspace/components/DockPanel.tsx src/components/ResizeHandle.tsx
+git -C "$WT" add src/features/workspace/components/DockPanel.tsx
+git -C "$WT" commit -m "refactor: migrate DockPanel handles to ResizeHandle"
+```
+
+---
+
+## Phase 2 — Split-pane dividers
+
+### Task 3: Add `reservedPx` to `useElasticContainer`
+
+`reservedPx` (default `0`) subtracts a fixed amount (the divider track) from the measured dimension before computing percentages, and the hook exposes the resulting `effectiveDimension` so callers can convert `size ↔ ratio`. Default `0` leaves the dock unchanged.
+
+**Files:**
+- Modify: `src/hooks/useElasticContainer.ts`
+- Test: `src/hooks/useElasticContainer.test.ts`
+
+- [ ] **Step 1: Write failing tests** (append inside the existing `describe`)
+
+```ts
+test('reservedPx subtracts from the dimension before applying percentages', () => {
+  // dim 1200, reserved 8 → effective 1192; initial 0.5 → round(596)
+  const { result } = renderElastic({
+    axis: 'horizontal',
+    minPercent: 0.15,
+    maxPercent: 0.85,
+    initialPercent: 0.5,
+    reservedPx: 8,
+  })
+  expect(result.current.size).toBe(596)
+  expect(result.current.pixelMin).toBe(Math.ceil(1192 * 0.15)) // 179
+  expect(result.current.pixelMax).toBe(Math.floor(1192 * 0.85)) // 1013
+  expect(result.current.effectiveDimension).toBe(1192)
+})
+
+test('reservedPx defaults to 0 (dock behavior unchanged)', () => {
+  const { result } = renderElastic({ axis: 'horizontal', initialPercent: 0.3 })
+  expect(result.current.size).toBe(360)
+  expect(result.current.effectiveDimension).toBe(1200)
+})
+```
+
+Add `reservedPx?: number` to the `RenderElasticOverrides` interface and pass it through `renderElastic`'s `useElasticContainer({ … })` call.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/hooks/useElasticContainer.test.ts`
+Expected: FAIL — `reservedPx` not accepted / `effectiveDimension` undefined.
+
+- [ ] **Step 3: Implement `reservedPx` + `effectiveDimension`**
+
+In `UseElasticContainerOptions` add:
+
+```ts
+  /** Fixed pixels removed from the measured dimension before percentages apply
+   *  (e.g. a divider track that sits between the two resizable regions).
+   *  Default 0 — leaves single-panel consumers (the dock) unchanged. */
+  reservedPx?: number
+```
+
+Destructure it with a default in the hook signature: `reservedPx = 0,`. Add a ref and an exposed state:
+
+```ts
+  const reservedPxRef = useRef(reservedPx)
+  const [effectiveDimension, setEffectiveDimension] = useState(0)
+```
+
+Add to `UseElasticContainerResult`:
+
+```ts
+  effectiveDimension: number
+```
+
+In `computeBounds`, compute against the reserved-adjusted dimension:
+
+```ts
+  const effective = Math.max(1, dimension - reservedPxRef.current)
+  const newMin = Math.ceil(effective * configuredMin)
+  let newMax = Math.floor(effective * configuredMax)
+```
+
+In the mount `useLayoutEffect`, replace the `dimension`-based initial sizing with the effective value and publish it:
+
+```ts
+  const effective = Math.max(1, dimension - reservedPxRef.current)
+  dimensionRef.current = dimension
+  setEffectiveDimension(effective)
+  const { newMin, newMax } = computeBounds(dimension)
+  const effectiveInitial =
+    initialPercentRef.current ?? (minPercentRef.current + maxPercentRef.current) / 2
+  const nextInitial = clampSize(effective * effectiveInitial, newMin, newMax)
+```
+
+In the `ResizeObserver` callback, mirror the same adjustment:
+
+```ts
+  dimensionRef.current = nextDimension
+  const effective = Math.max(1, nextDimension - reservedPxRef.current)
+  setEffectiveDimension(effective)
+  const { newMin: resizedMin, newMax: resizedMax } = computeBounds(nextDimension)
+  // …unchanged clamp/restore, but proportional restore uses `effective`:
+  const proportionalPx = Math.round(effective * desiredPercentRef.current)
+```
+
+In the `desiredPercentRef` update effect, divide by the effective dimension:
+
+```ts
+  const effective = Math.max(1, dimensionRef.current - reservedPxRef.current)
+  if (dimensionRef.current > 0) {
+    desiredPercentRef.current = Math.min(
+      Math.max(sizeRef.current / effective, minPercentRef.current),
+      maxPercentRef.current
+    )
+  }
+```
+
+And in the pending-clamp effect, target the effective dimension:
+
+```ts
+  const effective = Math.max(1, dimensionRef.current - reservedPxRef.current)
+  const targetPx =
+    dimensionRef.current > 0
+      ? Math.round(effective * desiredPercentRef.current)
+      : sizeRef.current
+```
+
+Finally add `effectiveDimension` to the returned object:
+
+```ts
+  return { ...resizable, pixelMin, pixelMax, effectiveDimension }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/hooks/useElasticContainer.test.ts`
+Expected: PASS — new `reservedPx` tests plus all pre-existing tests (which use the default `reservedPx = 0`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+WT=/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize
+npx vitest run src/hooks/useElasticContainer.test.ts
+git -C "$WT" add src/hooks/useElasticContainer.ts src/hooks/useElasticContainer.test.ts
+git -C "$WT" commit -m "feat(resize): add reservedPx + effectiveDimension to useElasticContainer"
+```
+
+### Task 4: `resolveGrid` helper + split config
+
+The committed/fallback template uses **fr ratios** (need no measurement — an inactive session renders correct proportions), and the live drag overrides the leading track via a **px CSS variable**. The trailing track is the only remaining `fr`, so it always absorbs "the rest" whether the leading track is `fr` (inactive) or `px` (active). This reproduces the spec's symmetry math.
+
+**Files:**
+- Create: `src/features/terminal/components/SplitView/resolveGrid.ts`
+- Test: `src/features/terminal/components/SplitView/resolveGrid.test.ts`
+- Modify: `src/features/workspace/panelConfig.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { test, expect, describe } from 'vitest'
+import { resolveGrid, DEFAULT_RATIOS, SPLIT_DIVIDER_PX } from './resolveGrid'
+
+describe('resolveGrid', () => {
+  test('single has no divider tracks', () => {
+    const g = resolveGrid('single', DEFAULT_RATIOS.single)
+    expect(g.cols).toBe('minmax(0,1fr)')
+    expect(g.rows).toBe('minmax(0,1fr)')
+    expect(g.areas).toEqual([['p0']])
+  })
+
+  test('vsplit emits one column divider track + var fallback', () => {
+    const g = resolveGrid('vsplit', { col: 0.5, row: 0.5 })
+    expect(g.cols).toBe(`var(--split-col, 0.5fr) ${SPLIT_DIVIDER_PX}px 0.5fr`)
+    expect(g.rows).toBe('minmax(0,1fr)')
+    expect(g.areas).toEqual([['p0', 'vdiv', 'p1']])
+  })
+
+  test('hsplit emits one row divider track', () => {
+    const g = resolveGrid('hsplit', { col: 0.5, row: 0.4 })
+    expect(g.rows).toBe(`var(--split-row, 0.4fr) ${SPLIT_DIVIDER_PX}px 0.6fr`)
+    expect(g.areas).toEqual([['p0'], ['hdiv'], ['p1']])
+  })
+
+  test('threeRight spans p0 + vdiv across all rows; hdiv only in right column', () => {
+    const g = resolveGrid('threeRight', { col: 0.583, row: 0.5 })
+    expect(g.areas).toEqual([
+      ['p0', 'vdiv', 'p1'],
+      ['p0', 'vdiv', 'hdiv'],
+      ['p0', 'vdiv', 'p2'],
+    ])
+  })
+
+  test('quad segments the column bar around the full-width row bar', () => {
+    const g = resolveGrid('quad', { col: 0.5, row: 0.5 })
+    expect(g.areas).toEqual([
+      ['p0', 'vdiv0', 'p1'],
+      ['hdiv', 'hdiv', 'hdiv'],
+      ['p2', 'vdiv1', 'p3'],
+    ])
+  })
+
+  test('default ratios reproduce current proportions', () => {
+    expect(DEFAULT_RATIOS.vsplit.col).toBe(0.5)
+    expect(DEFAULT_RATIOS.threeRight.col).toBeCloseTo(1.4 / 2.4, 5)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/features/terminal/components/SplitView/resolveGrid.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `resolveGrid.ts`**
+
+```ts
+// cspell:ignore vsplit hsplit
+import type { LayoutId } from '../../../sessions/types'
+
+/** Width of the divider track that replaces the inter-pane gap (px). */
+export const SPLIT_DIVIDER_PX = 8
+
+export interface LayoutRatios {
+  /** Column split fraction (leading column / pane space). */
+  col: number
+  /** Row split fraction (leading row / pane space). */
+  row: number
+}
+
+export interface ResolvedGrid {
+  cols: string
+  rows: string
+  areas: readonly (readonly string[])[]
+}
+
+/** Per-layout defaults that reproduce the pre-resize `fr` proportions. */
+export const DEFAULT_RATIOS: Record<LayoutId, LayoutRatios> = {
+  single: { col: 0.5, row: 0.5 },
+  vsplit: { col: 0.5, row: 0.5 },
+  hsplit: { col: 0.5, row: 0.5 },
+  threeRight: { col: 1.4 / 2.4, row: 0.5 },
+  quad: { col: 0.5, row: 0.5 },
+}
+
+const axisTemplate = (cssVar: string, ratio: number): string =>
+  `var(${cssVar}, ${ratio}fr) ${SPLIT_DIVIDER_PX}px ${1 - ratio}fr`
+
+export const resolveGrid = (
+  layoutId: LayoutId,
+  ratios: LayoutRatios
+): ResolvedGrid => {
+  const col = axisTemplate('--split-col', ratios.col)
+  const row = axisTemplate('--split-row', ratios.row)
+
+  switch (layoutId) {
+    case 'single':
+      return { cols: 'minmax(0,1fr)', rows: 'minmax(0,1fr)', areas: [['p0']] }
+    case 'vsplit':
+      return { cols: col, rows: 'minmax(0,1fr)', areas: [['p0', 'vdiv', 'p1']] }
+    case 'hsplit':
+      return { cols: 'minmax(0,1fr)', rows: row, areas: [['p0'], ['hdiv'], ['p1']] }
+    case 'threeRight':
+      return {
+        cols: col,
+        rows: row,
+        areas: [
+          ['p0', 'vdiv', 'p1'],
+          ['p0', 'vdiv', 'hdiv'],
+          ['p0', 'vdiv', 'p2'],
+        ],
+      }
+    case 'quad':
+      return {
+        cols: col,
+        rows: row,
+        areas: [
+          ['p0', 'vdiv0', 'p1'],
+          ['hdiv', 'hdiv', 'hdiv'],
+          ['p2', 'vdiv1', 'p3'],
+        ],
+      }
+  }
+}
+```
+
+- [ ] **Step 4: Add `SPLIT_ELASTIC_CONFIG` to `panelConfig.ts`**
+
+Append to `src/features/workspace/panelConfig.ts`:
+
+```ts
+/**
+ * Elastic config for split-pane dividers. Percentages apply to the pane space
+ * (container minus the 8px divider track, via useElasticContainer's reservedPx),
+ * so both panes stay within 15–85%.
+ */
+export const SPLIT_ELASTIC_CONFIG = {
+  minPercent: 0.15,
+  maxPercent: 0.85,
+} as const
+```
+
+- [ ] **Step 5: Run + commit**
+
+```bash
+WT=/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize
+npx vitest run src/features/terminal/components/SplitView/resolveGrid.test.ts
+git -C "$WT" add src/features/terminal/components/SplitView/resolveGrid.ts \
+  src/features/terminal/components/SplitView/resolveGrid.test.ts \
+  src/features/workspace/panelConfig.ts
+git -C "$WT" commit -m "feat(split-view): add resolveGrid template helper + split config"
+```
+
+### Task 5: `useSplitDivider` bridge hook
+
+Wraps one `useElasticContainer` and bridges it to the grid: live drag writes the px CSS var; an effect on the committed `size` keeps the var current on the keyboard/observer paths (where `onDragPreview` is silent) and mirrors the ratio up; unmount clears the var so the fr fallback drives the hidden session.
+
+**Files:**
+- Create: `src/features/terminal/components/SplitView/useSplitDivider.ts`
+- Test: covered via `SplitDividers.test.tsx` (Task 6) — this hook is exercised through the components.
+
+- [ ] **Step 1: Implement `useSplitDivider.ts`**
+
+```ts
+import { useCallback, useEffect, type KeyboardEvent, type RefObject } from 'react'
+import { useElasticContainer } from '../../../../hooks/useElasticContainer'
+import {
+  KEYBOARD_STEP_PX,
+  KEYBOARD_STEP_SHIFT_PX,
+  SPLIT_ELASTIC_CONFIG,
+} from '../../../workspace/panelConfig'
+import { SPLIT_DIVIDER_PX } from './resolveGrid'
+
+export interface SplitDividerBinding {
+  isDragging: boolean
+  size: number
+  pixelMin: number
+  pixelMax: number
+  handleMouseDown: (event: React.MouseEvent) => void
+  onKeyDown: (event: KeyboardEvent) => void
+}
+
+export interface UseSplitDividerArgs {
+  containerRef: RefObject<HTMLElement | null>
+  axis: 'horizontal' | 'vertical'
+  cssVar: '--split-col' | '--split-row'
+  initialRatio: number
+  onRatioChange: (ratio: number) => void
+}
+
+export const useSplitDivider = ({
+  containerRef,
+  axis,
+  cssVar,
+  initialRatio,
+  onRatioChange,
+}: UseSplitDividerArgs): SplitDividerBinding => {
+  const writeVar = useCallback(
+    (px: number): void => {
+      containerRef.current?.style.setProperty(cssVar, `${px}px`)
+    },
+    [containerRef, cssVar]
+  )
+
+  const elastic = useElasticContainer({
+    containerRef,
+    axis,
+    minPercent: SPLIT_ELASTIC_CONFIG.minPercent,
+    maxPercent: SPLIT_ELASTIC_CONFIG.maxPercent,
+    initialPercent: initialRatio,
+    reservedPx: SPLIT_DIVIDER_PX,
+    updateMode: 'commit-on-end',
+    onDragPreview: writeVar,
+  })
+
+  const { size, effectiveDimension, pixelMin, pixelMax, isDragging, adjustBy } =
+    elastic
+
+  // Committed `size` change (drag end | keyboard | resize): keep the var current
+  // on the paths onDragPreview skips, and mirror the ratio up for remember-within-session.
+  useEffect(() => {
+    writeVar(size)
+    if (effectiveDimension > 0) {
+      const ratio = Math.min(
+        Math.max(size / effectiveDimension, SPLIT_ELASTIC_CONFIG.minPercent),
+        SPLIT_ELASTIC_CONFIG.maxPercent
+      )
+      onRatioChange(ratio)
+    }
+  }, [size, effectiveDimension, writeVar, onRatioChange])
+
+  // Restore fr fallback control when this divider unmounts (session deactivates).
+  useEffect(
+    () => (): void => {
+      containerRef.current?.style.removeProperty(cssVar)
+    },
+    [containerRef, cssVar]
+  )
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent): void => {
+      const step = event.shiftKey ? KEYBOARD_STEP_SHIFT_PX : KEYBOARD_STEP_PX
+      const grow = axis === 'horizontal' ? 'ArrowRight' : 'ArrowDown'
+      const shrink = axis === 'horizontal' ? 'ArrowLeft' : 'ArrowUp'
+      if (event.key === grow) {
+        event.preventDefault()
+        adjustBy(step)
+      } else if (event.key === shrink) {
+        event.preventDefault()
+        adjustBy(-step)
+      } else if (event.key === 'Home') {
+        event.preventDefault()
+        adjustBy(pixelMin - size)
+      } else if (event.key === 'End') {
+        event.preventDefault()
+        adjustBy(pixelMax - size)
+      }
+    },
+    [axis, adjustBy, pixelMin, pixelMax, size]
+  )
+
+  return {
+    isDragging,
+    size,
+    pixelMin,
+    pixelMax,
+    handleMouseDown: elastic.handleMouseDown,
+    onKeyDown,
+  }
+}
+```
+
+- [ ] **Step 2: Commit** (verified by Task 6 tests; commit together with Task 6)
+
+No standalone test run — proceed to Task 6 which exercises this hook through the components, then commit both.
+
+### Task 6: `SplitDividers` per-layout components
+
+Each per-layout subcomponent calls a **fixed** number of `useSplitDivider` hooks (no conditional hooks). Handles are direct children (returned as a fragment) so grid-area placement works.
+
+**Files:**
+- Create: `src/features/terminal/components/SplitView/SplitDividers.tsx`
+- Test: `src/features/terminal/components/SplitView/SplitDividers.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { test, expect, describe, vi } from 'vitest'
+import { useRef } from 'react'
+import { SplitDividers } from './SplitDividers'
+import { DEFAULT_RATIOS } from './resolveGrid'
+import type { LayoutId } from '../../../sessions/types'
+
+const Harness = ({ layout }: { layout: LayoutId }): React.ReactElement => {
+  const ref = useRef<HTMLDivElement>(null)
+  return (
+    <div ref={ref} style={{ width: 1200, height: 800 }}>
+      <SplitDividers
+        layout={layout}
+        containerRef={ref}
+        ratios={DEFAULT_RATIOS[layout]}
+        onRatioChange={vi.fn()}
+      />
+    </div>
+  )
+}
+
+describe('SplitDividers', () => {
+  test.each([
+    ['single', 0],
+    ['vsplit', 1],
+    ['hsplit', 1],
+    ['threeRight', 2],
+    ['quad', 3],
+  ] as const)('%s renders %i handle element(s)', (layout, count) => {
+    render(<Harness layout={layout} />)
+    expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(count)
+  })
+
+  test('vsplit handle is a vertical separator (col-resize)', () => {
+    render(<Harness layout="vsplit" />)
+    expect(screen.getByTestId('split-resize-handle')).toHaveAttribute(
+      'aria-orientation',
+      'vertical'
+    )
+  })
+})
+```
+
+> Note: `useElasticContainer` requires a non-zero measured container. In jsdom, `getBoundingClientRect` returns zeros by default, so add a `beforeEach` that mocks it to `{ width: 1200, height: 800, … }` exactly as `useElasticContainer.test.ts` does (copy that mock block), and stub `ResizeObserver` the same way. This keeps the active-mount path from throwing.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/features/terminal/components/SplitView/SplitDividers.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `SplitDividers.tsx`**
+
+```tsx
+// cspell:ignore vsplit hsplit
+import { Fragment, type ReactElement, type RefObject } from 'react'
+import { ResizeHandle } from '../../../../components/ResizeHandle'
+import type { LayoutId } from '../../../sessions/types'
+import { useSplitDivider } from './useSplitDivider'
+import type { LayoutRatios } from './resolveGrid'
+
+export interface SplitDividersProps {
+  layout: LayoutId
+  containerRef: RefObject<HTMLElement | null>
+  ratios: LayoutRatios
+  onRatioChange: (axis: 'col' | 'row', ratio: number) => void
+}
+
+const HANDLE_TEST_ID = 'split-resize-handle'
+
+const VSplitDividers = ({
+  containerRef,
+  ratios,
+  onRatioChange,
+}: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const col = useSplitDivider({
+    containerRef,
+    axis: 'horizontal',
+    cssVar: '--split-col',
+    initialRatio: ratios.col,
+    onRatioChange: (r) => onRatioChange('col', r),
+  })
+
+  return (
+    <ResizeHandle
+      orientation="vertical"
+      testId={HANDLE_TEST_ID}
+      ariaLabel="Resize panes"
+      isDragging={col.isDragging}
+      ariaValueNow={col.size}
+      ariaValueMin={col.pixelMin}
+      ariaValueMax={col.pixelMax}
+      onMouseDown={col.handleMouseDown}
+      onKeyDown={col.onKeyDown}
+      className="h-full w-full"
+      style={{ gridArea: 'vdiv' }}
+    />
+  )
+}
+
+const HSplitDividers = ({
+  containerRef,
+  ratios,
+  onRatioChange,
+}: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const row = useSplitDivider({
+    containerRef,
+    axis: 'vertical',
+    cssVar: '--split-row',
+    initialRatio: ratios.row,
+    onRatioChange: (r) => onRatioChange('row', r),
+  })
+
+  return (
+    <ResizeHandle
+      orientation="horizontal"
+      testId={HANDLE_TEST_ID}
+      ariaLabel="Resize panes"
+      isDragging={row.isDragging}
+      ariaValueNow={row.size}
+      ariaValueMin={row.pixelMin}
+      ariaValueMax={row.pixelMax}
+      onMouseDown={row.handleMouseDown}
+      onKeyDown={row.onKeyDown}
+      className="h-full w-full"
+      style={{ gridArea: 'hdiv' }}
+    />
+  )
+}
+
+const ThreeRightDividers = ({
+  containerRef,
+  ratios,
+  onRatioChange,
+}: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const col = useSplitDivider({
+    containerRef,
+    axis: 'horizontal',
+    cssVar: '--split-col',
+    initialRatio: ratios.col,
+    onRatioChange: (r) => onRatioChange('col', r),
+  })
+  const row = useSplitDivider({
+    containerRef,
+    axis: 'vertical',
+    cssVar: '--split-row',
+    initialRatio: ratios.row,
+    onRatioChange: (r) => onRatioChange('row', r),
+  })
+
+  return (
+    <Fragment>
+      <ResizeHandle
+        orientation="vertical"
+        testId={HANDLE_TEST_ID}
+        ariaLabel="Resize panes"
+        isDragging={col.isDragging}
+        ariaValueNow={col.size}
+        ariaValueMin={col.pixelMin}
+        ariaValueMax={col.pixelMax}
+        onMouseDown={col.handleMouseDown}
+        onKeyDown={col.onKeyDown}
+        className="h-full w-full"
+        style={{ gridArea: 'vdiv' }}
+      />
+      <ResizeHandle
+        orientation="horizontal"
+        testId={HANDLE_TEST_ID}
+        ariaLabel="Resize panes"
+        isDragging={row.isDragging}
+        ariaValueNow={row.size}
+        ariaValueMin={row.pixelMin}
+        ariaValueMax={row.pixelMax}
+        onMouseDown={row.handleMouseDown}
+        onKeyDown={row.onKeyDown}
+        className="h-full w-full"
+        style={{ gridArea: 'hdiv' }}
+      />
+    </Fragment>
+  )
+}
+
+const QuadDividers = ({
+  containerRef,
+  ratios,
+  onRatioChange,
+}: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const col = useSplitDivider({
+    containerRef,
+    axis: 'horizontal',
+    cssVar: '--split-col',
+    initialRatio: ratios.col,
+    onRatioChange: (r) => onRatioChange('col', r),
+  })
+  const row = useSplitDivider({
+    containerRef,
+    axis: 'vertical',
+    cssVar: '--split-row',
+    initialRatio: ratios.row,
+    onRatioChange: (r) => onRatioChange('row', r),
+  })
+
+  // One logical column divider rendered as two elements (segmented by the
+  // full-width row bar); both share the `col` binding.
+  const colHandle = (gridArea: 'vdiv0' | 'vdiv1'): ReactElement => (
+    <ResizeHandle
+      orientation="vertical"
+      testId={HANDLE_TEST_ID}
+      ariaLabel="Resize panes"
+      isDragging={col.isDragging}
+      ariaValueNow={col.size}
+      ariaValueMin={col.pixelMin}
+      ariaValueMax={col.pixelMax}
+      onMouseDown={col.handleMouseDown}
+      onKeyDown={col.onKeyDown}
+      className="h-full w-full"
+      style={{ gridArea }}
+    />
+  )
+
+  return (
+    <Fragment>
+      {colHandle('vdiv0')}
+      <ResizeHandle
+        orientation="horizontal"
+        testId={HANDLE_TEST_ID}
+        ariaLabel="Resize panes"
+        isDragging={row.isDragging}
+        ariaValueNow={row.size}
+        ariaValueMin={row.pixelMin}
+        ariaValueMax={row.pixelMax}
+        onMouseDown={row.handleMouseDown}
+        onKeyDown={row.onKeyDown}
+        className="h-full w-full"
+        style={{ gridArea: 'hdiv' }}
+      />
+      {colHandle('vdiv1')}
+    </Fragment>
+  )
+}
+
+export const SplitDividers = ({
+  layout,
+  containerRef,
+  ratios,
+  onRatioChange,
+}: SplitDividersProps): ReactElement | null => {
+  const childProps = { containerRef, ratios, onRatioChange }
+  switch (layout) {
+    case 'single':
+      return null
+    case 'vsplit':
+      return <VSplitDividers key="vsplit" {...childProps} />
+    case 'hsplit':
+      return <HSplitDividers key="hsplit" {...childProps} />
+    case 'threeRight':
+      return <ThreeRightDividers key="threeRight" {...childProps} />
+    case 'quad':
+      return <QuadDividers key="quad" {...childProps} />
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/features/terminal/components/SplitView/SplitDividers.test.tsx`
+Expected: PASS (6 cases: counts 0/1/1/2/3 + the vsplit orientation check).
+
+- [ ] **Step 5: Commit** (includes Task 5's hook)
+
+```bash
+WT=/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize
+npx vitest run src/features/terminal/components/SplitView/SplitDividers.test.tsx
+git -C "$WT" add src/features/terminal/components/SplitView/useSplitDivider.ts \
+  src/features/terminal/components/SplitView/SplitDividers.tsx \
+  src/features/terminal/components/SplitView/SplitDividers.test.tsx
+git -C "$WT" commit -m "feat(split-view): per-layout SplitDividers + useSplitDivider bridge"
+```
+
+### Task 7: Wire `SplitDividers` into `SplitView`
+
+Move padding to an outer `split-view-canvas` wrapper; the inner measured grid carries the `resolveGrid` template and hosts panes + the active-only dividers; `SplitView` owns remembered ratios.
+
+**Files:**
+- Modify: `src/features/terminal/components/SplitView/SplitView.tsx`
+- Modify: `src/features/terminal/components/SplitView/SplitView.test.tsx`
+
+- [ ] **Step 1: Add imports + ratio state**
+
+In `SplitView.tsx`, add imports:
+
+```tsx
+import { useState } from 'react'
+import { SplitDividers } from './SplitDividers'
+import { resolveGrid, DEFAULT_RATIOS, type LayoutRatios } from './resolveGrid'
+```
+
+Inside the component, replace `const layout = LAYOUTS[session.layout]` usage for capacity with ratio state + resolved grid:
+
+```tsx
+const [ratios, setRatios] = useState<Partial<Record<LayoutId, LayoutRatios>>>({})
+const currentRatios = ratios[session.layout] ?? DEFAULT_RATIOS[session.layout]
+const grid = resolveGrid(session.layout, currentRatios)
+
+const handleRatioChange = useCallback(
+  (axis: 'col' | 'row', value: number): void => {
+    setRatios((prev) => {
+      const base = prev[session.layout] ?? DEFAULT_RATIOS[session.layout]
+      if (base[axis] === value) {
+        return prev // bail — no-op update avoids a render loop
+      }
+      return { ...prev, [session.layout]: { ...base, [axis]: value } }
+    })
+  },
+  [session.layout]
+)
+```
+
+(`LayoutId` is already imported via `Session`; add it to the type import if not.)
+
+- [ ] **Step 2: Restructure the render — wrapper + inner grid**
+
+Replace the single outer `<div data-testid="split-view" … className="grid … gap-2 bg-surface p-2.5" style={{ gridTemplateColumns: layout.cols, … }}>` with a padded wrapper around the measured grid:
+
+```tsx
+return (
+  <div
+    data-testid="split-view-canvas"
+    className="h-full w-full bg-surface p-2.5"
+  >
+    <div
+      ref={outerDivRef}
+      data-testid="split-view"
+      data-session-id={session.id}
+      data-layout={session.layout}
+      tabIndex={-1}
+      className="grid h-full w-full gap-0"
+      style={{
+        gridTemplateColumns: grid.cols,
+        gridTemplateRows: grid.rows,
+        gridTemplateAreas: grid.areas
+          .map((row) => `"${row.join(' ')}"`)
+          .join(' '),
+      }}
+    >
+      {/* …existing AnimatePresence panes block, unchanged… */}
+      {isActive ? (
+        <SplitDividers
+          layout={session.layout}
+          containerRef={outerDivRef}
+          ratios={currentRatios}
+          onRatioChange={handleRatioChange}
+        />
+      ) : null}
+    </div>
+  </div>
+)
+```
+
+Notes:
+- `outerDivRef` is the existing ref; it now points at the padding-free inner grid, so `useElasticContainer` measures the content box `Wc`.
+- `gap-2` → `gap-0`: the divider track now provides the 8px separation (`single` has nothing to separate, so it is byte-identical).
+- The `<SplitDividers>` fragment renders handle elements as **direct grid children** of the inner grid — no wrapper div.
+- `focusActivePane()` / `paneHandleRefs` and the panes `.map` are unchanged.
+
+- [ ] **Step 3: Update + extend `SplitView.test.tsx`**
+
+Run the suite first to see what the refactor breaks:
+
+Run: `npx vitest run src/features/terminal/components/SplitView/SplitView.test.tsx`
+
+Then:
+- Any assertion that checked `bg-surface` / `p-2.5` on `split-view` → assert on `split-view-canvas` instead.
+- Any assertion on `gridTemplateColumns`/`gridTemplateRows` literal `fr` strings → update to the `resolveGrid` output for that layout (e.g. `vsplit` cols = `var(--split-col, 0.5fr) 8px 0.5fr`). For `single` the template is unchanged (`minmax(0,1fr)`).
+- Add these new tests:
+
+```tsx
+test('single layout renders no dividers', () => {
+  renderSplitView({ layout: 'single', isActive: true })
+  expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(0)
+})
+
+test('active vsplit renders a divider; inactive does not', () => {
+  const { rerender } = renderSplitView({ layout: 'vsplit', isActive: true })
+  expect(screen.getAllByTestId('split-resize-handle')).toHaveLength(1)
+  rerender(/* same session, isActive: false */)
+  expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(0)
+})
+```
+
+> Use the suite's existing `renderSplitView`/session-builder helper and its `getBoundingClientRect` + `ResizeObserver` setup. If the suite doesn't already mock a non-zero `getBoundingClientRect`, add the same mock block used in `useElasticContainer.test.ts` so the active-mount path doesn't throw.
+
+- [ ] **Step 4: Run the full SplitView suite + type-check**
+
+```bash
+WT=/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize
+npx vitest run src/features/terminal/components/SplitView/
+npm run type-check
+```
+
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+WT=/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize
+git -C "$WT" add src/features/terminal/components/SplitView/SplitView.tsx \
+  src/features/terminal/components/SplitView/SplitView.test.tsx
+git -C "$WT" commit -m "feat(split-view): drag-to-resize panes for non-single layouts"
+```
+
+### Task 8: Full verification pass
+
+- [ ] **Step 1: Lint + format + full test run**
+
+```bash
+WT=/home/will/projects/vimeflow/.claude/worktrees/split-pane-resize
+npm run lint
+npm run format:check
+npm run type-check
+npm run test
+```
+
+Expected: all green. Fix any fallout in the touched files only.
+
+- [ ] **Step 2: Manual smoke (optional but recommended)**
+
+`npm run dev`, open a session, cycle layouts with `Ctrl/Cmd+\`, drag each divider; confirm: panes resize, 15–85% clamp holds, ratio persists across a layout cycle and a tab switch, resets on reload, and the dock still resizes (Phase 1 regression).
+
+- [ ] **Step 3: No commit** — verification only.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- D1 (ResizeHandle first) → Tasks 1–2. ✓
+- D2 (remember-within-session, not across reload) → `SplitView` `ratios` state (Task 7); reset-on-reload is inherent (component state). ✓
+- D3 (quad shared cross) → `QuadDividers` two hooks / three elements (Task 6). ✓
+- D4 (keep ratio when cycling layouts) → `ratios` keyed by `LayoutId`, never cleared on layout change (Task 7). ✓
+- Sizing math / `reservedPx` / content-box → Task 3 + Task 7 wrapper. ✓
+- Hook-safety (fixed counts) → per-layout subcomponents (Task 6). ✓
+- Bridge (no `onCommit`; `size` effect + var; keyboard/observer covered) → `useSplitDivider` (Task 5). ✓
+- `SPLIT_ELASTIC_CONFIG`, `resolveGrid`, divider map → Task 4 / Task 6. ✓
+- Active-only mounting (zero-dim guard) → `isActive` gate in Task 7. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code or an exact, discover-at-runtime test adjustment (Task 7 Step 3 names the precise edits).
+
+**Type consistency:** `LayoutRatios { col, row }`, `resolveGrid(layoutId, ratios)`, `SPLIT_DIVIDER_PX`, `SPLIT_ELASTIC_CONFIG`, `effectiveDimension`, `useSplitDivider` args/return, `--split-col`/`--split-row`, `split-resize-handle` testid, grid areas (`vdiv`/`hdiv`/`vdiv0`/`vdiv1`) — all consistent across Tasks 3–7.
+
+**One spec refinement (documented):** the committed template uses an **fr fallback** (`var(--split-col, ${col}fr) 8px ${1-col}fr`) rather than a px fallback. This lets an inactive session render correct proportions with no measurement, while the active drag overrides the leading track via the px var. Symmetry/identical-defaults math is unchanged (the trailing `fr` is the sole remaining `fr`, so it always absorbs the remainder).

--- a/docs/superpowers/plans/2026-05-25-split-pane-resize-plan.md
+++ b/docs/superpowers/plans/2026-05-25-split-pane-resize-plan.md
@@ -44,6 +44,7 @@
 ### Task 1: `ResizeHandle` component
 
 **Files:**
+
 - Create: `src/components/ResizeHandle.tsx`
 - Test: `src/components/ResizeHandle.test.tsx`
 
@@ -73,14 +74,27 @@ describe('ResizeHandle', () => {
   })
 
   test('horizontal orientation uses ns-resize, vertical uses col-resize', () => {
-    const { rerender } = render(<ResizeHandle {...baseProps} orientation="horizontal" />)
-    expect(screen.getByTestId('resize-handle').className).toMatch(/cursor-ns-resize/)
+    const { rerender } = render(
+      <ResizeHandle {...baseProps} orientation="horizontal" />
+    )
+    expect(screen.getByTestId('resize-handle').className).toMatch(
+      /cursor-ns-resize/
+    )
     rerender(<ResizeHandle {...baseProps} orientation="vertical" />)
-    expect(screen.getByTestId('resize-handle').className).toMatch(/cursor-col-resize/)
+    expect(screen.getByTestId('resize-handle').className).toMatch(
+      /cursor-col-resize/
+    )
   })
 
   test('exposes aria value range', () => {
-    render(<ResizeHandle {...baseProps} ariaValueNow={120} ariaValueMin={50} ariaValueMax={900} />)
+    render(
+      <ResizeHandle
+        {...baseProps}
+        ariaValueNow={120}
+        ariaValueMin={50}
+        ariaValueMax={900}
+      />
+    )
     const handle = screen.getByTestId('resize-handle')
     expect(handle).toHaveAttribute('aria-valuenow', '120')
     expect(handle).toHaveAttribute('aria-valuemin', '50')
@@ -88,16 +102,28 @@ describe('ResizeHandle', () => {
   })
 
   test('applies the active background only while dragging', () => {
-    const { rerender } = render(<ResizeHandle {...baseProps} isDragging={false} />)
-    expect(screen.getByTestId('resize-handle').className).not.toMatch(/bg-primary\/30/)
+    const { rerender } = render(
+      <ResizeHandle {...baseProps} isDragging={false} />
+    )
+    expect(screen.getByTestId('resize-handle').className).not.toMatch(
+      /bg-primary\/30/
+    )
     rerender(<ResizeHandle {...baseProps} isDragging />)
-    expect(screen.getByTestId('resize-handle').className).toMatch(/bg-primary\/30/)
+    expect(screen.getByTestId('resize-handle').className).toMatch(
+      /bg-primary\/30/
+    )
   })
 
   test('forwards mouse + keyboard events', () => {
     const onMouseDown = vi.fn()
     const onKeyDown = vi.fn()
-    render(<ResizeHandle {...baseProps} onMouseDown={onMouseDown} onKeyDown={onKeyDown} />)
+    render(
+      <ResizeHandle
+        {...baseProps}
+        onMouseDown={onMouseDown}
+        onKeyDown={onKeyDown}
+      />
+    )
     const handle = screen.getByTestId('resize-handle')
     fireEvent.mouseDown(handle)
     fireEvent.keyDown(handle, { key: 'ArrowUp' })
@@ -130,7 +156,12 @@ Expected: FAIL — `Cannot find module './ResizeHandle'`.
 - [ ] **Step 3: Write minimal implementation**
 
 ```tsx
-import type { CSSProperties, KeyboardEvent, MouseEvent, ReactElement } from 'react'
+import type {
+  CSSProperties,
+  KeyboardEvent,
+  MouseEvent,
+  ReactElement,
+} from 'react'
 
 export interface ResizeHandleProps {
   /** aria-orientation. 'horizontal' separator → ns-resize; 'vertical' → col-resize. */
@@ -202,6 +233,7 @@ git -C "$WT" commit -m "refactor: extract shared ResizeHandle primitive"
 ### Task 2: Migrate `DockPanel` to `ResizeHandle`
 
 **Files:**
+
 - Modify: `src/features/workspace/components/DockPanel.tsx` (the two handle `<div>`s, ~269–305; add import)
 - Regression net: `src/features/workspace/components/DockPanel.test.tsx` (unchanged)
 
@@ -272,6 +304,7 @@ git -C "$WT" commit -m "refactor: migrate DockPanel handles to ResizeHandle"
 `reservedPx` (default `0`) subtracts a fixed amount (the divider track) from the measured dimension before computing percentages, and the hook exposes the resulting `effectiveDimension` so callers can convert `size ↔ ratio`. Default `0` leaves the dock unchanged.
 
 **Files:**
+
 - Modify: `src/hooks/useElasticContainer.ts`
 - Test: `src/hooks/useElasticContainer.test.ts`
 
@@ -323,73 +356,74 @@ In `UseElasticContainerOptions` add:
 Destructure it with a default in the hook signature: `reservedPx = 0,`. Add a ref and an exposed state:
 
 ```ts
-  const reservedPxRef = useRef(reservedPx)
-  const [effectiveDimension, setEffectiveDimension] = useState(0)
+const reservedPxRef = useRef(reservedPx)
+const [effectiveDimension, setEffectiveDimension] = useState(0)
 ```
 
 Add to `UseElasticContainerResult`:
 
 ```ts
-  effectiveDimension: number
+effectiveDimension: number
 ```
 
 In `computeBounds`, compute against the reserved-adjusted dimension:
 
 ```ts
-  const effective = Math.max(1, dimension - reservedPxRef.current)
-  const newMin = Math.ceil(effective * configuredMin)
-  let newMax = Math.floor(effective * configuredMax)
+const effective = Math.max(1, dimension - reservedPxRef.current)
+const newMin = Math.ceil(effective * configuredMin)
+let newMax = Math.floor(effective * configuredMax)
 ```
 
 In the mount `useLayoutEffect`, replace the `dimension`-based initial sizing with the effective value and publish it:
 
 ```ts
-  const effective = Math.max(1, dimension - reservedPxRef.current)
-  dimensionRef.current = dimension
-  setEffectiveDimension(effective)
-  const { newMin, newMax } = computeBounds(dimension)
-  const effectiveInitial =
-    initialPercentRef.current ?? (minPercentRef.current + maxPercentRef.current) / 2
-  const nextInitial = clampSize(effective * effectiveInitial, newMin, newMax)
+const effective = Math.max(1, dimension - reservedPxRef.current)
+dimensionRef.current = dimension
+setEffectiveDimension(effective)
+const { newMin, newMax } = computeBounds(dimension)
+const effectiveInitial =
+  initialPercentRef.current ??
+  (minPercentRef.current + maxPercentRef.current) / 2
+const nextInitial = clampSize(effective * effectiveInitial, newMin, newMax)
 ```
 
 In the `ResizeObserver` callback, mirror the same adjustment:
 
 ```ts
-  dimensionRef.current = nextDimension
-  const effective = Math.max(1, nextDimension - reservedPxRef.current)
-  setEffectiveDimension(effective)
-  const { newMin: resizedMin, newMax: resizedMax } = computeBounds(nextDimension)
-  // …unchanged clamp/restore, but proportional restore uses `effective`:
-  const proportionalPx = Math.round(effective * desiredPercentRef.current)
+dimensionRef.current = nextDimension
+const effective = Math.max(1, nextDimension - reservedPxRef.current)
+setEffectiveDimension(effective)
+const { newMin: resizedMin, newMax: resizedMax } = computeBounds(nextDimension)
+// …unchanged clamp/restore, but proportional restore uses `effective`:
+const proportionalPx = Math.round(effective * desiredPercentRef.current)
 ```
 
 In the `desiredPercentRef` update effect, divide by the effective dimension:
 
 ```ts
-  const effective = Math.max(1, dimensionRef.current - reservedPxRef.current)
-  if (dimensionRef.current > 0) {
-    desiredPercentRef.current = Math.min(
-      Math.max(sizeRef.current / effective, minPercentRef.current),
-      maxPercentRef.current
-    )
-  }
+const effective = Math.max(1, dimensionRef.current - reservedPxRef.current)
+if (dimensionRef.current > 0) {
+  desiredPercentRef.current = Math.min(
+    Math.max(sizeRef.current / effective, minPercentRef.current),
+    maxPercentRef.current
+  )
+}
 ```
 
 And in the pending-clamp effect, target the effective dimension:
 
 ```ts
-  const effective = Math.max(1, dimensionRef.current - reservedPxRef.current)
-  const targetPx =
-    dimensionRef.current > 0
-      ? Math.round(effective * desiredPercentRef.current)
-      : sizeRef.current
+const effective = Math.max(1, dimensionRef.current - reservedPxRef.current)
+const targetPx =
+  dimensionRef.current > 0
+    ? Math.round(effective * desiredPercentRef.current)
+    : sizeRef.current
 ```
 
 Finally add `effectiveDimension` to the returned object:
 
 ```ts
-  return { ...resizable, pixelMin, pixelMax, effectiveDimension }
+return { ...resizable, pixelMin, pixelMax, effectiveDimension }
 ```
 
 - [ ] **Step 4: Run to verify it passes**
@@ -411,6 +445,7 @@ git -C "$WT" commit -m "feat(resize): add reservedPx + effectiveDimension to use
 The committed/fallback template uses **fr ratios** (need no measurement — an inactive session renders correct proportions), and the live drag overrides the leading track via a **px CSS variable**. The trailing track is the only remaining `fr`, so it always absorbs "the rest" whether the leading track is `fr` (inactive) or `px` (active). This reproduces the spec's symmetry math.
 
 **Files:**
+
 - Create: `src/features/terminal/components/SplitView/resolveGrid.ts`
 - Test: `src/features/terminal/components/SplitView/resolveGrid.test.ts`
 - Modify: `src/features/workspace/panelConfig.ts`
@@ -519,7 +554,11 @@ export const resolveGrid = (
     case 'vsplit':
       return { cols: col, rows: 'minmax(0,1fr)', areas: [['p0', 'vdiv', 'p1']] }
     case 'hsplit':
-      return { cols: 'minmax(0,1fr)', rows: row, areas: [['p0'], ['hdiv'], ['p1']] }
+      return {
+        cols: 'minmax(0,1fr)',
+        rows: row,
+        areas: [['p0'], ['hdiv'], ['p1']],
+      }
     case 'threeRight':
       return {
         cols: col,
@@ -576,12 +615,13 @@ git -C "$WT" commit -m "feat(split-view): add resolveGrid template helper + spli
 Wraps one `useElasticContainer` and bridges it to the grid: live drag writes the px CSS var; an effect on the committed `size` keeps the var current on the keyboard/observer paths (where `onDragPreview` is silent) and mirrors the ratio up; unmount clears the var so the fr fallback drives the hidden session.
 
 **Files:**
+
 - Create: `src/features/terminal/components/SplitView/useSplitDivider.ts`
 - Test: `src/features/terminal/components/SplitView/useSplitDivider.test.tsx`
 
 - [ ] **Step 1: Write the failing bridge test**
 
-Task 6 only asserts divider *counts*; this test pins the bridge behavior the
+Task 6 only asserts divider _counts_; this test pins the bridge behavior the
 components rely on — the ratio mirrored up, the px CSS var written on the
 **keyboard** path (where `onDragPreview` never fires), and the var removed on
 unmount. The container lives in a parent that stays mounted while the divider
@@ -603,8 +643,15 @@ vi.stubGlobal('ResizeObserver', MockResizeObserver)
 
 beforeEach(() => {
   vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
-    width: 1200, height: 800, top: 0, left: 0, right: 1200, bottom: 800,
-    x: 0, y: 0, toJSON: (): undefined => undefined,
+    width: 1200,
+    height: 800,
+    top: 0,
+    left: 0,
+    right: 1200,
+    bottom: 800,
+    x: 0,
+    y: 0,
+    toJSON: (): undefined => undefined,
   } as DOMRect)
 })
 afterEach(() => vi.restoreAllMocks())
@@ -674,7 +721,12 @@ Expected: FAIL — module not found.
 - [ ] **Step 3: Implement `useSplitDivider.ts`**
 
 ```ts
-import { useCallback, useEffect, type KeyboardEvent, type RefObject } from 'react'
+import {
+  useCallback,
+  useEffect,
+  type KeyboardEvent,
+  type RefObject,
+} from 'react'
 import { useElasticContainer } from '../../../../hooks/useElasticContainer'
 import {
   KEYBOARD_STEP_PX,
@@ -802,6 +854,7 @@ git -C "$WT" commit -m "feat(split-view): useSplitDivider bridge (CSS var + rati
 Each per-layout subcomponent calls a **fixed** number of `useSplitDivider` hooks (no conditional hooks). Handles are direct children (returned as a fragment) so grid-area placement works.
 
 **Files:**
+
 - Create: `src/features/terminal/components/SplitView/SplitDividers.tsx`
 - Test: `src/features/terminal/components/SplitView/SplitDividers.test.tsx`
 
@@ -1090,6 +1143,7 @@ git -C "$WT" commit -m "feat(split-view): per-layout SplitDividers components"
 Move padding to an outer `split-view-canvas` wrapper; the inner measured grid carries the `resolveGrid` template and hosts panes + the active-only dividers; `SplitView` owns remembered ratios.
 
 **Files:**
+
 - Modify: `src/features/terminal/components/SplitView/SplitView.tsx`
 - Modify: `src/features/terminal/components/SplitView/SplitView.test.tsx`
 
@@ -1106,7 +1160,9 @@ import { resolveGrid, DEFAULT_RATIOS, type LayoutRatios } from './resolveGrid'
 Inside the component, replace `const layout = LAYOUTS[session.layout]` usage for capacity with ratio state + resolved grid:
 
 ```tsx
-const [ratios, setRatios] = useState<Partial<Record<LayoutId, LayoutRatios>>>({})
+const [ratios, setRatios] = useState<Partial<Record<LayoutId, LayoutRatios>>>(
+  {}
+)
 const currentRatios = ratios[session.layout] ?? DEFAULT_RATIOS[session.layout]
 const grid = resolveGrid(session.layout, currentRatios)
 
@@ -1166,6 +1222,7 @@ return (
 ```
 
 Notes:
+
 - `outerDivRef` is the existing ref; it now points at the padding-free inner grid, so `useElasticContainer` measures the content box `Wc`.
 - `gap-2` → `gap-0`: the divider track now provides the 8px separation (`single` has nothing to separate, so it is byte-identical).
 - The `<SplitDividers>` fragment renders handle elements as **direct grid children** of the inner grid — no wrapper div.
@@ -1178,6 +1235,7 @@ Run the suite first to see what the refactor breaks:
 Run: `npx vitest run src/features/terminal/components/SplitView/SplitView.test.tsx`
 
 Then:
+
 - Any assertion that checked `bg-surface` / `p-2.5` on `split-view` → assert on `split-view-canvas` instead.
 - Any assertion on `gridTemplateColumns`/`gridTemplateRows` literal `fr` strings → update to the `resolveGrid` output for that layout (e.g. `vsplit` cols = `var(--split-col, 0.5fr) 8px 0.5fr`). For `single` the template is unchanged (`minmax(0,1fr)`).
 - Add these new tests:
@@ -1203,25 +1261,33 @@ test('remembers the split ratio across a layout cycle', () => {
   const grid = screen.getByTestId('split-view')
   const pristine = grid.style.gridTemplateColumns
 
-  fireEvent.keyDown(screen.getByTestId('split-resize-handle'), { key: 'ArrowRight' })
+  fireEvent.keyDown(screen.getByTestId('split-resize-handle'), {
+    key: 'ArrowRight',
+  })
   const resized = screen.getByTestId('split-view').style.gridTemplateColumns
   expect(resized).not.toBe(pristine) // ratio fallback changed
 
   rerender(/* same session, layout: 'single', isActive: true */)
   rerender(/* same session, layout: 'vsplit', isActive: true */)
-  expect(screen.getByTestId('split-view').style.gridTemplateColumns).toBe(resized)
+  expect(screen.getByTestId('split-view').style.gridTemplateColumns).toBe(
+    resized
+  )
 })
 
 // D2: a resized ratio survives a tab switch (isActive false → true). SplitView
 // stays mounted while hidden, so its ratio state persists.
 test('remembers the split ratio across a tab switch', () => {
   const { rerender } = renderSplitView({ layout: 'vsplit', isActive: true })
-  fireEvent.keyDown(screen.getByTestId('split-resize-handle'), { key: 'ArrowRight' })
+  fireEvent.keyDown(screen.getByTestId('split-resize-handle'), {
+    key: 'ArrowRight',
+  })
   const resized = screen.getByTestId('split-view').style.gridTemplateColumns
 
   rerender(/* same session, isActive: false */)
   rerender(/* same session, isActive: true */)
-  expect(screen.getByTestId('split-view').style.gridTemplateColumns).toBe(resized)
+  expect(screen.getByTestId('split-view').style.gridTemplateColumns).toBe(
+    resized
+  )
 })
 ```
 
@@ -1271,6 +1337,7 @@ Expected: all green. Fix any fallout in the touched files only.
 ## Self-Review
 
 **Spec coverage:**
+
 - D1 (ResizeHandle first) → Tasks 1–2. ✓
 - D2 (remember-within-session, not across reload) → `SplitView` `ratios` state (Task 7); reset-on-reload is inherent (component state). ✓
 - D3 (quad shared cross) → `QuadDividers` two hooks / three elements (Task 6). ✓

--- a/docs/superpowers/plans/2026-05-25-split-pane-resize-plan.md
+++ b/docs/superpowers/plans/2026-05-25-split-pane-resize-plan.md
@@ -1286,3 +1286,5 @@ Expected: all green. Fix any fallout in the touched files only.
 **Type consistency:** `LayoutRatios { col, row }`, `resolveGrid(layoutId, ratios)`, `SPLIT_DIVIDER_PX`, `SPLIT_ELASTIC_CONFIG`, `effectiveDimension`, `useSplitDivider` args/return, `--split-col`/`--split-row`, `split-resize-handle` testid, grid areas (`vdiv`/`hdiv`/`vdiv0`/`vdiv1`) — all consistent across Tasks 3–7.
 
 **One spec refinement (documented):** the committed template uses an **fr fallback** (`var(--split-col, ${col}fr) 8px ${1-col}fr`) rather than a px fallback. This lets an inactive session render correct proportions with no measurement, while the active drag overrides the leading track via the px var. Symmetry/identical-defaults math is unchanged (the trailing `fr` is the sole remaining `fr`, so it always absorbs the remainder).
+
+<!-- codex-reviewed: 2026-05-26T07:24:18Z -->

--- a/docs/superpowers/specs/2026-05-25-split-pane-resize-design.md
+++ b/docs/superpowers/specs/2026-05-25-split-pane-resize-design.md
@@ -15,12 +15,12 @@ inventing a parallel system.
 
 ## Decisions locked
 
-| # | Decision | Source |
-| - | -------- | ------ |
-| D1 | Extract the dock's inline resize-handle markup into a shared `ResizeHandle` primitive **first**, as its own step. | user |
-| D2 | Split ratios are **remembered within the session** (survive layout cycling and tab switches) but **not persisted across reload** — matching the existing non-persistence stance for `Pane.userLabel`. | user |
-| D3 | `quad` uses a **shared cross**: one column split shared by both rows, one row split shared by both columns (2 logical dividers). Not independent per-quadrant tiling. | recommended default — flagged for veto |
-| D4 | Cycling layouts (e.g. `vsplit → single → vsplit`) **keeps** each layout's remembered ratio rather than resetting to the default split. | recommended default — flagged for veto |
+| #   | Decision                                                                                                                                                                                              | Source                                 |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| D1  | Extract the dock's inline resize-handle markup into a shared `ResizeHandle` primitive **first**, as its own step.                                                                                     | user                                   |
+| D2  | Split ratios are **remembered within the session** (survive layout cycling and tab switches) but **not persisted across reload** — matching the existing non-persistence stance for `Pane.userLabel`. | user                                   |
+| D3  | `quad` uses a **shared cross**: one column split shared by both rows, one row split shared by both columns (2 logical dividers). Not independent per-quadrant tiling.                                 | recommended default — flagged for veto |
+| D4  | Cycling layouts (e.g. `vsplit → single → vsplit`) **keeps** each layout's remembered ratio rather than resetting to the default split.                                                                | recommended default — flagged for veto |
 
 ## Non-goals
 
@@ -71,7 +71,7 @@ session** (see Step 2 §"Active-only mounting").
 
 New cross-feature primitive at `src/components/ResizeHandle.tsx` (sibling
 `ResizeHandle.test.tsx`), alongside the existing `Tooltip` precedent. It owns
-the *affordance*; the *consumer* owns *placement*.
+the _affordance_; the _consumer_ owns _placement_.
 
 **Owns (the primitive):** `role="separator"`, `aria-orientation`,
 `aria-label` (default `"Resize panel"`), `aria-valuenow/min/max`,
@@ -86,8 +86,8 @@ plus `bg-primary/30` while `isDragging`).
 (`left-0 right-0 h-1`, or `h-full w-full` to fill a track), and `z-index`.
 
 Splitting responsibilities this way avoids the Tailwind merge footgun: the
-primitive sets *cursor / background / transition*; the consumer sets
-*position / size / z* — disjoint properties, so class order never matters.
+primitive sets _cursor / background / transition_; the consumer sets
+_position / size / z_ — disjoint properties, so class order never matters.
 
 ```ts
 interface ResizeHandleProps {
@@ -121,21 +121,21 @@ This step is a pure refactor: identical rendered output and behavior.
 
 ### Divider map per layout
 
-| Layout | Logical dividers | Handle elements | Notes |
-| ------ | ---------------- | --------------- | ----- |
-| `single` | 0 | 0 | nothing to resize |
-| `vsplit` | 1 column (p0 \| p1) | 1 | full-height vertical bar, `col-resize` |
-| `hsplit` | 1 row (p0 / p1) | 1 | full-width horizontal bar, `ns-resize` |
-| `threeRight` | 1 column (p0 \| right) + 1 row (p1 / p2) | 2 | row divider spans the right column only |
-| `quad` | 1 column + 1 row (shared cross) | 3 | column bar is segmented by the row bar (two elements, one hook); see below |
+| Layout       | Logical dividers                         | Handle elements | Notes                                                                      |
+| ------------ | ---------------------------------------- | --------------- | -------------------------------------------------------------------------- |
+| `single`     | 0                                        | 0               | nothing to resize                                                          |
+| `vsplit`     | 1 column (p0 \| p1)                      | 1               | full-height vertical bar, `col-resize`                                     |
+| `hsplit`     | 1 row (p0 / p1)                          | 1               | full-width horizontal bar, `ns-resize`                                     |
+| `threeRight` | 1 column (p0 \| right) + 1 row (p1 / p2) | 2               | row divider spans the right column only                                    |
+| `quad`       | 1 column + 1 row (shared cross)          | 3               | column bar is segmented by the row bar (two elements, one hook); see below |
 
-### Grid model: the draggable border *is* a grid track
+### Grid model: the draggable border _is_ a grid track
 
 Rather than overlay handles and compute their position from container width
 minus padding/gap (fragile), we make the **border itself a grid track**. The
 inter-pane gap is replaced by an explicit divider track that holds the
 `ResizeHandle`; the browser's grid engine positions the handle exactly, with no
-offset math for placement. (Pane *sizing* still needs a one-time reconciliation
+offset math for placement. (Pane _sizing_ still needs a one-time reconciliation
 for the divider width + padding — see "Sizing math" below.) This also matches
 the user's mental model literally — "drag the border."
 
@@ -165,7 +165,7 @@ the rest:
 The outer grid drops its inter-pane `gap` along divider axes (the divider track
 replaces it); `single` is unchanged. Net visual spacing stays ~8px.
 
-Because the handles are placed by grid *area*, they must be **direct grid
+Because the handles are placed by grid _area_, they must be **direct grid
 children** of `SplitView`'s outer grid div. `SplitDividers` therefore returns a
 fragment of `<ResizeHandle style={{ gridArea: 'vdiv' }} … />` elements rendered
 directly inside the grid (no wrapping `<div>`, which would break area
@@ -330,7 +330,7 @@ Co-located, TDD, `import { test, expect } from 'vitest'` in every new test file
 - **Rules-of-hooks** with variable divider counts → handled by per-layout
   subcomponents with fixed hook counts (the `key={layout}` only resets state).
 - **Pane capacity vs. visible panes:** `selectVisiblePanes` can rescue an
-  over-capacity active pane into the last slot; dividers key off the *layout*
+  over-capacity active pane into the last slot; dividers key off the _layout_
   (fixed track structure), not the live pane list, so this is unaffected.
 - **Spacing parity:** replacing `gap` with an 8px divider track must keep the
   current visual rhythm; `single` keeps no divider and is byte-identical.

--- a/docs/superpowers/specs/2026-05-25-split-pane-resize-design.md
+++ b/docs/superpowers/specs/2026-05-25-split-pane-resize-design.md
@@ -349,3 +349,5 @@ Co-located, TDD, `import { test, expect } from 'vitest'` in every new test file
 Each step is independently reviewable and shippable; Step 2 depends on Step 1.
 Exact branch/PR strategy (single PR with two commits vs. two stacked PRs on a
 `feat/` integration branch) is deferred to the implementation plan.
+
+<!-- codex-reviewed: 2026-05-26T04:27:36Z -->

--- a/docs/superpowers/specs/2026-05-25-split-pane-resize-design.md
+++ b/docs/superpowers/specs/2026-05-25-split-pane-resize-design.md
@@ -43,8 +43,11 @@ inventing a parallel system.
   container dimension and converts pixel↔percent, restoring the user's intended
   proportion across window shrink→expand via `desiredPercentRef`. Returns
   `size` (px), `pixelMin`/`pixelMax`, `handleMouseDown`, `adjustBy`,
-  `isDragging`. **A split divider's position is "X% of the container along one
-  axis" — exactly what this hook models.** One instance per divider.
+  `isDragging`. **A split divider's position is "X% of the pane space along one
+  axis" — close to what this hook models, but the divider track and the grid's
+  padding must be subtracted from the measured box first (see Step 2 §"Grid
+  model").** We add a small backward-compatible `reservedPx` option to the hook
+  to do exactly that. One instance per divider.
 - The dock's resize-handle markup is currently inlined twice in
   `DockPanel.tsx` (lines ~269–305): `role="separator"`, `aria-orientation`,
   `aria-value*`, `tabIndex={0}`, `data-testid="resize-handle"`, hover/focus/
@@ -131,9 +134,10 @@ This step is a pure refactor: identical rendered output and behavior.
 Rather than overlay handles and compute their position from container width
 minus padding/gap (fragile), we make the **border itself a grid track**. The
 inter-pane gap is replaced by an explicit divider track that holds the
-`ResizeHandle`; the browser's grid engine positions it exactly, with no
-padding/gap math. This also matches the user's mental model literally — "drag
-the border."
+`ResizeHandle`; the browser's grid engine positions the handle exactly, with no
+offset math for placement. (Pane *sizing* still needs a one-time reconciliation
+for the divider width + padding — see "Sizing math" below.) This also matches
+the user's mental model literally — "drag the border."
 
 The first track's size comes straight from the elastic hook in pixels (the dock
 pattern: dock sets `width: ${size}px`), the divider track is a fixed ~8px (≈
@@ -172,9 +176,29 @@ minmax(0,1fr)`) so the live drag preview just rewrites the variable.
 A small helper colocated with `layouts.ts`, e.g.
 `resolveGrid(layoutId, sizes): { cols, rows, areas }`, produces the
 divider-aware template from the existing `LAYOUTS` geometry plus the current
-`{ colSize, rowSize }`. `LAYOUTS` stays the single source of geometry; default
-sizes reproduce today's exact proportions (so a freshly-opened layout renders
-pixel-identical to current `main`).
+`{ colSize, rowSize }`. `LAYOUTS` stays the single source of geometry.
+
+**Sizing math (reconciling the divider track + padding).** Two corrections make
+the px tracks behave and keep the defaults honest:
+
+1. **Measure the content box, not the padded box.** `useElasticContainer`
+   measures `getBoundingClientRect()`, which includes the grid's `p-2.5`
+   padding. So the divider layer measures the _inner_ grid: padding moves to an
+   outer wrapper and the measured grid div carries no padding, making its box
+   exactly the pane content width `Wc`.
+2. **Reserve the divider width.** Add an optional `reservedPx` to
+   `useElasticContainer` (default `0`, so the dock is unchanged). With
+   `reservedPx = 8`, the hook applies its min/max/initial percentages to the
+   _pane space_ `Wp = Wc − 8` rather than `Wc`, and also returns `Wp` so callers
+   can convert between the hook's pixel `size` and a stored ratio.
+
+With both in place, the template `${colSize}px 8px minmax(0,1fr)` gives
+`track1 = colSize` and `track2 = Wc − colSize − 8 = Wp − colSize`. At the
+default `colSize = 0.5·Wp` both panes are `0.5·Wp` — **symmetric, and
+pixel-identical to `main`** (today's `1fr 1fr` + `gap-2` is also `(Wc − 8) / 2`
+per pane). The 15–85% bounds (over `Wp`) then hold for _both_ panes, since
+`track2 = Wp − track1 ∈ [0.15, 0.85]·Wp` whenever `track1 ∈ [0.15, 0.85]·Wp`.
+`threeRight`'s default `colSize = 0.583·Wp` reproduces its current `1.4 : 1`.
 
 ### Ratio state + remember-within-session (D2)
 
@@ -198,34 +222,58 @@ free. It resets only on reload (the `hidden` SplitView still unmounts then).
 
 The hooks live in a child `<SplitDividers>` that `SplitView` renders **only when
 `isActive`** (and therefore visible/non-zero). This sidesteps the
-`useElasticContainer` zero-dimension DEV throw for hidden sessions. Because the
-divider set differs per layout (rules-of-hooks forbids a variable hook count),
-`<SplitDividers key={session.layout}>` remounts cleanly on layout change,
-re-instantiating the correct hooks seeded (`initialPercent`) from the remembered
-ratio for that layout.
+`useElasticContainer` zero-dimension DEV throw for hidden sessions.
+
+`<SplitDividers>` does **not** call a variable number of hooks itself — that
+would trip `react-hooks/rules-of-hooks`. Instead it switches on the layout and
+renders a **per-layout subcomponent with a fixed hook count**, so each component
+calls exactly the hooks it always needs:
+
+- `VSplitDividers` / `HSplitDividers` — exactly **one** `useElasticContainer`.
+- `ThreeRightDividers` / `QuadDividers` — exactly **two** (one per axis).
+
+Each subcomponent is keyed by layout (`key={session.layout}`) so switching
+layouts unmounts the old subcomponent and mounts the new one cleanly, seeding
+each hook's `initialPercent` from the remembered ratio for that layout. (The key
+governs _state reset on layout change_; the per-layout components are what keep
+the hook calls unconditional.)
 
 Inactive sessions render their grid from the remembered ratios directly (no
 hooks, no handles) so revealing them shows the right proportions with no flash.
 
 ### Data flow
 
+`useElasticContainer` has no `onCommit` callback — its **`size` (React state)**
+is the committed value, and it updates on every path that matters: drag end,
+keyboard `adjustBy`, and `ResizeObserver`. `onDragPreview` fires _only_ during a
+mouse drag (in `commit-on-end` mode) and _not_ on the keyboard/observer paths.
+The bridge is built around those two facts:
+
 ```
-SplitView (owns ratios, always mounted)
-  ├─ computes grid template via resolveGrid(layout, sizes-from-ratios)
-  └─ when isActive: <SplitDividers key={layout}
-                       containerRef={outerDivRef}
-                       layout={layout}
-                       ratios={ratios[layout] ?? default}
-                       onCommit={(next) => setRatios(...)} />
-        ├─ useElasticContainer per divider (axis, SPLIT_ELASTIC_CONFIG, initialPercent=ratio)
-        ├─ live drag: onDragPreview writes the px size onto the grid template
-        │   (CSS variable on the outer div) — no full re-render mid-drag
-        └─ mouseup: onCommit(ratio) → SplitView state → committed template
+SplitView (owns remembered ratios + the grid template, always mounted)
+  ├─ grid-template-*: var(--split-col, <remembered px>) 8px minmax(0,1fr)
+  │     (the CSS var is the live driver; the fallback = remembered ratio)
+  └─ when isActive: <SplitDividers> → per-layout subcomponent
+        owns useElasticContainer per divider
+          (axis, SPLIT_ELASTIC_CONFIG, reservedPx=8, initialPercent=remembered)
+        ├─ during drag (commit-on-end): onDragPreview(px) writes --split-col on
+        │    the outer div — smooth, no React re-render
+        ├─ on every committed `size` change (drag end | keyboard | resize), a
+        │    useEffect on `size`:
+        │      • writes --split-col = `${size}px` (keeps the var current on the
+        │        paths onDragPreview skips — keyboard + observer)
+        │      • calls onRatioChange(layout, axis, size/Wp) so SplitView updates
+        │        its remembered ratio (seeds the fallback + future remounts)
+        └─ on unmount (session deactivates): clears --split-col so the
+             remembered-ratio fallback drives the now-hidden session
 ```
 
-This mirrors the dock's `commit-on-end` + `onDragPreview` flow. Window resizes
-are handled by each hook's `ResizeObserver`/`desiredPercentRef`, same as the
-dock.
+Single writer of the live value: `SplitDividers` owns `--split-col` while
+mounted; `SplitView`'s remembered ratio only seeds the fallback and survives
+remounts. They can't drift, because the effect re-derives the ratio from the
+same `size` it writes to the var. Window resizes ride the hook's
+`ResizeObserver`/`desiredPercentRef` exactly like the dock, and `aria-valuenow`
+tracks `size` on every path.
 
 ### Bounds config
 
@@ -233,13 +281,16 @@ Add to `src/features/workspace/panelConfig.ts` (where the dock configs live):
 
 ```ts
 export const SPLIT_ELASTIC_CONFIG = {
-  minPercent: 0.15, // a pane can't shrink below 15% of its axis
+  minPercent: 0.15, // a pane can't shrink below 15% of the pane space Wp
   maxPercent: 0.85,
-  // initialPercent supplied per-divider from remembered/default ratio
+  // initialPercent supplied per-divider from the remembered/default ratio
 } as const
 ```
 
-Keyboard step reuses the shared `KEYBOARD_STEP_PX` / `KEYBOARD_STEP_SHIFT_PX`.
+The percentages apply to the pane space `Wp = Wc − 8` (via the hook's
+`reservedPx`), so both the leading and trailing pane stay within 15–85% (see the
+sizing math above). Keyboard step reuses the shared `KEYBOARD_STEP_PX` /
+`KEYBOARD_STEP_SHIFT_PX`.
 
 ### Alternative considered — overlay handles (rejected)
 
@@ -260,9 +311,11 @@ Co-located, TDD, `import { test, expect } from 'vitest'` in every new test file
   `onMouseDown`/`onKeyDown` fire; consumer `className`/`style` pass through.
 - `DockPanel.test.tsx`: unchanged assertions must still pass (regression net for
   Step 1).
-- `SplitDividers.test.tsx`: divider count per layout matches the map
-  (0/1/1/2/3 elements); `quad` exposes two column-handle elements bound to one
-  hook; commit calls `onCommit` with a clamped ratio; keyboard `adjustBy` works.
+- `SplitDividers.test.tsx`: each per-layout subcomponent calls a fixed hook
+  count; the divider element count per layout matches the map (0/1/1/2/3);
+  `quad` exposes two column-handle elements bound to one hook; a committed drag
+  updates `--split-col` and calls `onRatioChange` with a clamped ratio; keyboard
+  `adjustBy` updates the var + ratio on a path where `onDragPreview` never fires.
 - `SplitView.test.tsx`: additions — `single` renders no dividers; dividers are
   absent when `isActive={false}`; a committed ratio changes the grid template;
   cycling layout and returning restores the remembered ratio (D2); switching the
@@ -274,8 +327,8 @@ Co-located, TDD, `import { test, expect } from 'vitest'` in every new test file
 ## Risks / edge cases
 
 - **Zero-dimension throw** for hidden sessions → handled by active-only mounting.
-- **Rules-of-hooks** with variable divider counts → handled by
-  `key={layout}` remount of `SplitDividers`.
+- **Rules-of-hooks** with variable divider counts → handled by per-layout
+  subcomponents with fixed hook counts (the `key={layout}` only resets state).
 - **Pane capacity vs. visible panes:** `selectVisiblePanes` can rescue an
   over-capacity active pane into the last slot; dividers key off the *layout*
   (fixed track structure), not the live pane list, so this is unaffected.
@@ -287,8 +340,11 @@ Co-located, TDD, `import { test, expect } from 'vitest'` in every new test file
 
 1. **Step 1** — `ResizeHandle` extraction + DockPanel migration (refactor;
    `DockPanel.test.tsx` green).
-2. **Step 2** — `SPLIT_ELASTIC_CONFIG`, `resolveGrid`, `SplitDividers`,
-   `SplitView` ratio state + active-only mounting, tests.
+2. **Step 2** — extend `useElasticContainer` with `reservedPx` (+ expose `Wp`;
+   default `0` keeps the dock unchanged), `SPLIT_ELASTIC_CONFIG`, `resolveGrid`,
+   the per-layout `SplitDividers` subcomponents, the `SplitView` padding-wrapper
+   refactor + remembered-ratio state + active-only mounting, and tests
+   (including a dock regression pass for the `reservedPx = 0` path).
 
 Each step is independently reviewable and shippable; Step 2 depends on Step 1.
 Exact branch/PR strategy (single PR with two commits vs. two stacked PRs on a

--- a/docs/superpowers/specs/2026-05-25-split-pane-resize-design.md
+++ b/docs/superpowers/specs/2026-05-25-split-pane-resize-design.md
@@ -1,0 +1,295 @@
+# Split-pane resize — design
+
+- **Date:** 2026-05-25
+- **Status:** Draft (awaiting review)
+- **Area:** `src/features/terminal/components/SplitView/`, `src/features/workspace/components/DockPanel.tsx`, `src/components/`, `src/hooks/`
+- **Topic:** Drag-to-resize the boundary between panes for every non-`single` layout, reusing the dock's elastic-resize machinery.
+
+## Goal
+
+When a session's layout is anything other than `single`, the user can drag the
+border between panes to change their relative width and/or height. The
+interaction reuses the resize machinery already shipped for the dock
+(`useElasticContainer` + the dock's resize-handle affordance) rather than
+inventing a parallel system.
+
+## Decisions locked
+
+| # | Decision | Source |
+| - | -------- | ------ |
+| D1 | Extract the dock's inline resize-handle markup into a shared `ResizeHandle` primitive **first**, as its own step. | user |
+| D2 | Split ratios are **remembered within the session** (survive layout cycling and tab switches) but **not persisted across reload** — matching the existing non-persistence stance for `Pane.userLabel`. | user |
+| D3 | `quad` uses a **shared cross**: one column split shared by both rows, one row split shared by both columns (2 logical dividers). Not independent per-quadrant tiling. | recommended default — flagged for veto |
+| D4 | Cycling layouts (e.g. `vsplit → single → vsplit`) **keeps** each layout's remembered ratio rather than resetting to the default split. | recommended default — flagged for veto |
+
+## Non-goals
+
+- No persistence of ratios across app reload (D2). Easy follow-up later via the
+  same localStorage-by-session-id mechanism `activityPanelCollapsed` uses.
+- No independent per-quadrant resizing in `quad` (D3).
+- No drag-to-reorder / drag-to-swap panes. This is resize only.
+- No change to the keyboard layout-cycle (`Ctrl/Cmd+\`) or pane capacity rules.
+- No backend / IPC / bindings changes — this is entirely frontend.
+
+## Background (existing pieces we build on)
+
+**Reusable machinery (the "dock thing"):**
+
+- `src/hooks/useResizable.ts` — low-level mouse-drag → clamped pixel size, RAF
+  coalesced, with `commit-on-end` + `onDragPreview` (drag a CSS value live,
+  commit React state on mouseup), keyboard `adjustBy`, and `invert`.
+- `src/hooks/useElasticContainer.ts` — wraps `useResizable` with a
+  `containerRef` + `axis` + min/max **percent**. A `ResizeObserver` tracks the
+  container dimension and converts pixel↔percent, restoring the user's intended
+  proportion across window shrink→expand via `desiredPercentRef`. Returns
+  `size` (px), `pixelMin`/`pixelMax`, `handleMouseDown`, `adjustBy`,
+  `isDragging`. **A split divider's position is "X% of the container along one
+  axis" — exactly what this hook models.** One instance per divider.
+- The dock's resize-handle markup is currently inlined twice in
+  `DockPanel.tsx` (lines ~269–305): `role="separator"`, `aria-orientation`,
+  `aria-value*`, `tabIndex={0}`, `data-testid="resize-handle"`, hover/focus/
+  active background tokens, `cursor-ns-resize` / `cursor-col-resize`.
+
+**SplitView grid model** (`SplitView.tsx`, `layouts.ts`):
+
+- CSS Grid with named areas. Today: `gap-2` (8px) between panes, `p-2.5` (10px)
+  outer padding, panes placed via `gridArea: p${i}`, track sizes are static `fr`
+  strings (`vsplit`/`hsplit`/`quad` = `1fr 1fr`; `threeRight` cols = `1.4fr 1fr`).
+- No per-pane / per-split size state exists today on `Pane` or `Session`.
+
+**Hidden-session constraint (important):** `TerminalZone` renders **every**
+session's `SplitView` simultaneously and hides inactive ones with a `hidden`
+class (to keep PTYs alive). `useElasticContainer` **hard-throws in DEV when its
+container has zero dimension at mount** — and a hidden session's grid is
+zero-sized. Therefore the divider layer must **only mount for the active
+session** (see Step 2 §"Active-only mounting").
+
+## Step 1 — Extract the `ResizeHandle` primitive (refactor, no behavior change)
+
+New cross-feature primitive at `src/components/ResizeHandle.tsx` (sibling
+`ResizeHandle.test.tsx`), alongside the existing `Tooltip` precedent. It owns
+the *affordance*; the *consumer* owns *placement*.
+
+**Owns (the primitive):** `role="separator"`, `aria-orientation`,
+`aria-label` (default `"Resize panel"`), `aria-valuenow/min/max`,
+`tabIndex={0}`, `data-testid` (default `"resize-handle"`, overridable),
+`onMouseDown`, `onKeyDown`, the cursor (`horizontal` orientation → `ns-resize`,
+`vertical` → `col-resize`), and the interaction colors
+(`transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none`,
+plus `bg-primary/30` while `isDragging`).
+
+**Owned by the consumer (via `className` + optional `style`):** position
+(`absolute` offsets, `gridArea`/line placement), the stretch + thickness
+(`left-0 right-0 h-1`, or `h-full w-full` to fill a track), and `z-index`.
+
+Splitting responsibilities this way avoids the Tailwind merge footgun: the
+primitive sets *cursor / background / transition*; the consumer sets
+*position / size / z* — disjoint properties, so class order never matters.
+
+```ts
+interface ResizeHandleProps {
+  orientation: 'horizontal' | 'vertical' // aria-orientation; picks the cursor
+  isDragging: boolean
+  ariaValueNow: number
+  ariaValueMin: number
+  ariaValueMax: number
+  ariaLabel?: string // default 'Resize panel'
+  testId?: string // default 'resize-handle'
+  onMouseDown: (event: React.MouseEvent) => void
+  onKeyDown: (event: React.KeyboardEvent) => void
+  className?: string
+  style?: React.CSSProperties
+}
+```
+
+**DockPanel migration:** both inline handles become `<ResizeHandle>`. The
+consumer keeps exactly today's positioning classes, e.g. the vertical-dock
+handle passes
+`className={`absolute ${position === 'top' ? 'bottom-0' : 'top-0'} left-0 right-0 z-10 h-1`}`
+(the `z-10` comment about painting above `DockTab` stays at the call site). The
+keyboard handlers (`handleVerticalKeyDown` / `handleHorizontalKeyDown`) and the
+elastic-hook wiring are unchanged. Because the primitive preserves the same
+`data-testid`, `role`, and `aria-*`, `DockPanel.test.tsx` stays green — it is
+the regression net for this refactor.
+
+This step is a pure refactor: identical rendered output and behavior.
+
+## Step 2 — Split-pane dividers
+
+### Divider map per layout
+
+| Layout | Logical dividers | Handle elements | Notes |
+| ------ | ---------------- | --------------- | ----- |
+| `single` | 0 | 0 | nothing to resize |
+| `vsplit` | 1 column (p0 \| p1) | 1 | full-height vertical bar, `col-resize` |
+| `hsplit` | 1 row (p0 / p1) | 1 | full-width horizontal bar, `ns-resize` |
+| `threeRight` | 1 column (p0 \| right) + 1 row (p1 / p2) | 2 | row divider spans the right column only |
+| `quad` | 1 column + 1 row (shared cross) | 3 | column bar is segmented by the row bar (two elements, one hook); see below |
+
+### Grid model: the draggable border *is* a grid track
+
+Rather than overlay handles and compute their position from container width
+minus padding/gap (fragile), we make the **border itself a grid track**. The
+inter-pane gap is replaced by an explicit divider track that holds the
+`ResizeHandle`; the browser's grid engine positions it exactly, with no
+padding/gap math. This also matches the user's mental model literally — "drag
+the border."
+
+The first track's size comes straight from the elastic hook in pixels (the dock
+pattern: dock sets `width: ${size}px`), the divider track is a fixed ~8px (≈
+today's `gap-2`, giving a comfortable hit area), and the trailing track takes
+the rest:
+
+- `vsplit`: `gridTemplateColumns: ${colSize}px 8px minmax(0,1fr)`, areas
+  `[['p0','vdiv','p1']]`.
+- `hsplit`: `gridTemplateRows: ${rowSize}px 8px minmax(0,1fr)`, areas
+  `[['p0'],['hdiv'],['p1']]`.
+- `threeRight`: cols `${colSize}px 8px minmax(0,1fr)`, rows
+  `${rowSize}px 8px minmax(0,1fr)`, areas
+  `[['p0','vdiv','p1'],['p0','vdiv','hdiv'],['p0','vdiv','p2']]` — `p0` and
+  `vdiv` each span all three rows; the row divider `hdiv` lives only in the
+  right column.
+- `quad`: cols `${colSize}px 8px minmax(0,1fr)`, rows
+  `${rowSize}px 8px minmax(0,1fr)`, areas
+  `[['p0','vdiv0','p1'],['hdiv','hdiv','hdiv'],['p2','vdiv1','p3']]`. The
+  full-width row divider `hdiv` interrupts the column bar, so the column bar is
+  two named cells (`vdiv0`, `vdiv1`) **driven by the same column hook** — one
+  logical divider, two `ResizeHandle` elements that move together. Visually a
+  clean `┼` with the horizontal bar dominant. (The inverse — segmenting the row
+  bar instead — is equivalent; we pick the column bar to segment.)
+
+The outer grid drops its inter-pane `gap` along divider axes (the divider track
+replaces it); `single` is unchanged. Net visual spacing stays ~8px.
+
+Because the handles are placed by grid *area*, they must be **direct grid
+children** of `SplitView`'s outer grid div. `SplitDividers` therefore returns a
+fragment of `<ResizeHandle style={{ gridArea: 'vdiv' }} … />` elements rendered
+directly inside the grid (no wrapping `<div>`, which would break area
+placement). The committed track sizes are emitted as CSS variables on the outer
+div (e.g. `grid-template-columns: var(--split-col, <committed>px) 8px
+minmax(0,1fr)`) so the live drag preview just rewrites the variable.
+
+A small helper colocated with `layouts.ts`, e.g.
+`resolveGrid(layoutId, sizes): { cols, rows, areas }`, produces the
+divider-aware template from the existing `LAYOUTS` geometry plus the current
+`{ colSize, rowSize }`. `LAYOUTS` stays the single source of geometry; default
+sizes reproduce today's exact proportions (so a freshly-opened layout renders
+pixel-identical to current `main`).
+
+### Ratio state + remember-within-session (D2)
+
+`SplitView` owns the ratio state. Model it per layout so each layout remembers
+its own split:
+
+```ts
+type LayoutRatios = { col: number; row: number } // fractions in (0,1)
+// SplitView state: Partial<Record<LayoutId, LayoutRatios>>
+```
+
+Interpretation: `col` = the column split fraction (`vsplit`, `threeRight`
+left|right, `quad`); `row` = the row split fraction (`hsplit`, `threeRight`
+p1|p2, `quad`). Defaults derive from current `fr` values (`vsplit` col 0.5;
+`hsplit` row 0.5; `threeRight` col ≈ 0.583 = 1.4/2.4, row 0.5; `quad`
+0.5/0.5). State lives in the always-mounted `SplitView`, so it survives the
+session being hidden (tab switch) and layout cycling — D2 comes essentially for
+free. It resets only on reload (the `hidden` SplitView still unmounts then).
+
+### Active-only mounting (the zero-dimension guard)
+
+The hooks live in a child `<SplitDividers>` that `SplitView` renders **only when
+`isActive`** (and therefore visible/non-zero). This sidesteps the
+`useElasticContainer` zero-dimension DEV throw for hidden sessions. Because the
+divider set differs per layout (rules-of-hooks forbids a variable hook count),
+`<SplitDividers key={session.layout}>` remounts cleanly on layout change,
+re-instantiating the correct hooks seeded (`initialPercent`) from the remembered
+ratio for that layout.
+
+Inactive sessions render their grid from the remembered ratios directly (no
+hooks, no handles) so revealing them shows the right proportions with no flash.
+
+### Data flow
+
+```
+SplitView (owns ratios, always mounted)
+  ├─ computes grid template via resolveGrid(layout, sizes-from-ratios)
+  └─ when isActive: <SplitDividers key={layout}
+                       containerRef={outerDivRef}
+                       layout={layout}
+                       ratios={ratios[layout] ?? default}
+                       onCommit={(next) => setRatios(...)} />
+        ├─ useElasticContainer per divider (axis, SPLIT_ELASTIC_CONFIG, initialPercent=ratio)
+        ├─ live drag: onDragPreview writes the px size onto the grid template
+        │   (CSS variable on the outer div) — no full re-render mid-drag
+        └─ mouseup: onCommit(ratio) → SplitView state → committed template
+```
+
+This mirrors the dock's `commit-on-end` + `onDragPreview` flow. Window resizes
+are handled by each hook's `ResizeObserver`/`desiredPercentRef`, same as the
+dock.
+
+### Bounds config
+
+Add to `src/features/workspace/panelConfig.ts` (where the dock configs live):
+
+```ts
+export const SPLIT_ELASTIC_CONFIG = {
+  minPercent: 0.15, // a pane can't shrink below 15% of its axis
+  maxPercent: 0.85,
+  // initialPercent supplied per-divider from remembered/default ratio
+} as const
+```
+
+Keyboard step reuses the shared `KEYBOARD_STEP_PX` / `KEYBOARD_STEP_SHIFT_PX`.
+
+### Alternative considered — overlay handles (rejected)
+
+Keep the current gap-based grid and float absolutely-positioned handles over the
+gaps, computing each handle's offset from the measured container dimension minus
+`p-2.5` padding and `gap-2`. Rejected: the padding/gap offset math is fragile
+across all four layouts (and unavoidable for `quad`'s cross), whereas
+handle-as-track lets the grid engine place everything exactly. Overlay touches
+`layouts.ts` less, but trades correctness for it.
+
+## Testing strategy
+
+Co-located, TDD, `import { test, expect } from 'vitest'` in every new test file
+(globals don't satisfy `tsc -b` / lint-staged).
+
+- `ResizeHandle.test.tsx`: renders `role="separator"`; `orientation` drives
+  cursor class + `aria-orientation`; `isDragging` toggles the active background;
+  `onMouseDown`/`onKeyDown` fire; consumer `className`/`style` pass through.
+- `DockPanel.test.tsx`: unchanged assertions must still pass (regression net for
+  Step 1).
+- `SplitDividers.test.tsx`: divider count per layout matches the map
+  (0/1/1/2/3 elements); `quad` exposes two column-handle elements bound to one
+  hook; commit calls `onCommit` with a clamped ratio; keyboard `adjustBy` works.
+- `SplitView.test.tsx`: additions — `single` renders no dividers; dividers are
+  absent when `isActive={false}`; a committed ratio changes the grid template;
+  cycling layout and returning restores the remembered ratio (D2); switching the
+  active session away and back preserves ratios.
+- `layouts.test.ts` / `resolveGrid` test: default sizes reproduce today's
+  templates; divider-aware templates have the expected track counts and area
+  matrices.
+
+## Risks / edge cases
+
+- **Zero-dimension throw** for hidden sessions → handled by active-only mounting.
+- **Rules-of-hooks** with variable divider counts → handled by
+  `key={layout}` remount of `SplitDividers`.
+- **Pane capacity vs. visible panes:** `selectVisiblePanes` can rescue an
+  over-capacity active pane into the last slot; dividers key off the *layout*
+  (fixed track structure), not the live pane list, so this is unaffected.
+- **Spacing parity:** replacing `gap` with an 8px divider track must keep the
+  current visual rhythm; `single` keeps no divider and is byte-identical.
+- **Tailwind class merge:** avoided by the disjoint-property split in Step 1.
+
+## Sequencing
+
+1. **Step 1** — `ResizeHandle` extraction + DockPanel migration (refactor;
+   `DockPanel.test.tsx` green).
+2. **Step 2** — `SPLIT_ELASTIC_CONFIG`, `resolveGrid`, `SplitDividers`,
+   `SplitView` ratio state + active-only mounting, tests.
+
+Each step is independently reviewable and shippable; Step 2 depends on Step 1.
+Exact branch/PR strategy (single PR with two commits vs. two stacked PRs on a
+`feat/` integration branch) is deferred to the implementation plan.

--- a/src/components/ResizeHandle.test.tsx
+++ b/src/components/ResizeHandle.test.tsx
@@ -1,3 +1,4 @@
+// cspell:ignore vdiv hdiv
 import { render, screen, fireEvent } from '@testing-library/react'
 import { test, expect, vi, describe } from 'vitest'
 import { ResizeHandle, type ResizeHandleProps } from './ResizeHandle'
@@ -21,14 +22,27 @@ describe('ResizeHandle', () => {
   })
 
   test('horizontal orientation uses ns-resize, vertical uses col-resize', () => {
-    const { rerender } = render(<ResizeHandle {...baseProps} orientation="horizontal" />)
-    expect(screen.getByTestId('resize-handle').className).toMatch(/cursor-ns-resize/)
+    const { rerender } = render(
+      <ResizeHandle {...baseProps} orientation="horizontal" />
+    )
+    expect(screen.getByTestId('resize-handle').className).toMatch(
+      /cursor-ns-resize/
+    )
     rerender(<ResizeHandle {...baseProps} orientation="vertical" />)
-    expect(screen.getByTestId('resize-handle').className).toMatch(/cursor-col-resize/)
+    expect(screen.getByTestId('resize-handle').className).toMatch(
+      /cursor-col-resize/
+    )
   })
 
   test('exposes aria value range', () => {
-    render(<ResizeHandle {...baseProps} ariaValueNow={120} ariaValueMin={50} ariaValueMax={900} />)
+    render(
+      <ResizeHandle
+        {...baseProps}
+        ariaValueNow={120}
+        ariaValueMin={50}
+        ariaValueMax={900}
+      />
+    )
     const handle = screen.getByTestId('resize-handle')
     expect(handle).toHaveAttribute('aria-valuenow', '120')
     expect(handle).toHaveAttribute('aria-valuemin', '50')
@@ -36,16 +50,26 @@ describe('ResizeHandle', () => {
   })
 
   test('applies the active background only while dragging', () => {
-    const { rerender } = render(<ResizeHandle {...baseProps} isDragging={false} />)
-    expect(screen.getByTestId('resize-handle').className).not.toMatch(/bg-primary\/30/)
+    const { rerender } = render(<ResizeHandle {...baseProps} />)
+    expect(screen.getByTestId('resize-handle').className).not.toMatch(
+      /bg-primary\/30/
+    )
     rerender(<ResizeHandle {...baseProps} isDragging />)
-    expect(screen.getByTestId('resize-handle').className).toMatch(/bg-primary\/30/)
+    expect(screen.getByTestId('resize-handle').className).toMatch(
+      /bg-primary\/30/
+    )
   })
 
   test('forwards mouse + keyboard events', () => {
     const onMouseDown = vi.fn()
     const onKeyDown = vi.fn()
-    render(<ResizeHandle {...baseProps} onMouseDown={onMouseDown} onKeyDown={onKeyDown} />)
+    render(
+      <ResizeHandle
+        {...baseProps}
+        onMouseDown={onMouseDown}
+        onKeyDown={onKeyDown}
+      />
+    )
     const handle = screen.getByTestId('resize-handle')
     fireEvent.mouseDown(handle)
     fireEvent.keyDown(handle, { key: 'ArrowUp' })

--- a/src/components/ResizeHandle.test.tsx
+++ b/src/components/ResizeHandle.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { test, expect, vi, describe } from 'vitest'
+import { ResizeHandle, type ResizeHandleProps } from './ResizeHandle'
+
+const baseProps: ResizeHandleProps = {
+  orientation: 'horizontal',
+  isDragging: false,
+  ariaValueNow: 100,
+  ariaValueMin: 40,
+  ariaValueMax: 640,
+  onMouseDown: vi.fn(),
+  onKeyDown: vi.fn(),
+}
+
+describe('ResizeHandle', () => {
+  test('renders a separator with the given orientation', () => {
+    render(<ResizeHandle {...baseProps} orientation="vertical" />)
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toHaveAttribute('role', 'separator')
+    expect(handle).toHaveAttribute('aria-orientation', 'vertical')
+  })
+
+  test('horizontal orientation uses ns-resize, vertical uses col-resize', () => {
+    const { rerender } = render(<ResizeHandle {...baseProps} orientation="horizontal" />)
+    expect(screen.getByTestId('resize-handle').className).toMatch(/cursor-ns-resize/)
+    rerender(<ResizeHandle {...baseProps} orientation="vertical" />)
+    expect(screen.getByTestId('resize-handle').className).toMatch(/cursor-col-resize/)
+  })
+
+  test('exposes aria value range', () => {
+    render(<ResizeHandle {...baseProps} ariaValueNow={120} ariaValueMin={50} ariaValueMax={900} />)
+    const handle = screen.getByTestId('resize-handle')
+    expect(handle).toHaveAttribute('aria-valuenow', '120')
+    expect(handle).toHaveAttribute('aria-valuemin', '50')
+    expect(handle).toHaveAttribute('aria-valuemax', '900')
+  })
+
+  test('applies the active background only while dragging', () => {
+    const { rerender } = render(<ResizeHandle {...baseProps} isDragging={false} />)
+    expect(screen.getByTestId('resize-handle').className).not.toMatch(/bg-primary\/30/)
+    rerender(<ResizeHandle {...baseProps} isDragging />)
+    expect(screen.getByTestId('resize-handle').className).toMatch(/bg-primary\/30/)
+  })
+
+  test('forwards mouse + keyboard events', () => {
+    const onMouseDown = vi.fn()
+    const onKeyDown = vi.fn()
+    render(<ResizeHandle {...baseProps} onMouseDown={onMouseDown} onKeyDown={onKeyDown} />)
+    const handle = screen.getByTestId('resize-handle')
+    fireEvent.mouseDown(handle)
+    fireEvent.keyDown(handle, { key: 'ArrowUp' })
+    expect(onMouseDown).toHaveBeenCalled()
+    expect(onKeyDown).toHaveBeenCalled()
+  })
+
+  test('passes through consumer className, style and testId', () => {
+    render(
+      <ResizeHandle
+        {...baseProps}
+        testId="split-resize-handle"
+        className="absolute z-10 h-1 left-0 right-0"
+        style={{ gridArea: 'vdiv' }}
+      />
+    )
+    const handle = screen.getByTestId('split-resize-handle')
+    expect(handle.className).toMatch(/\bz-10\b/)
+    expect(handle.className).toMatch(/left-0/)
+    expect(handle.style.gridArea).toBe('vdiv')
+  })
+})

--- a/src/components/ResizeHandle.tsx
+++ b/src/components/ResizeHandle.tsx
@@ -1,4 +1,9 @@
-import type { CSSProperties, KeyboardEvent, MouseEvent, ReactElement } from 'react'
+import type {
+  CSSProperties,
+  KeyboardEvent,
+  MouseEvent,
+  ReactElement,
+} from 'react'
 
 export interface ResizeHandleProps {
   /** aria-orientation. 'horizontal' separator → ns-resize; 'vertical' → col-resize. */

--- a/src/components/ResizeHandle.tsx
+++ b/src/components/ResizeHandle.tsx
@@ -1,0 +1,53 @@
+import type { CSSProperties, KeyboardEvent, MouseEvent, ReactElement } from 'react'
+
+export interface ResizeHandleProps {
+  /** aria-orientation. 'horizontal' separator → ns-resize; 'vertical' → col-resize. */
+  orientation: 'horizontal' | 'vertical'
+  isDragging: boolean
+  ariaValueNow: number
+  ariaValueMin: number
+  ariaValueMax: number
+  ariaLabel?: string
+  testId?: string
+  onMouseDown: (event: MouseEvent) => void
+  onKeyDown: (event: KeyboardEvent) => void
+  /** Consumer-owned placement: position offsets, stretch + thickness, z-index. */
+  className?: string
+  style?: CSSProperties
+}
+
+export const ResizeHandle = ({
+  orientation,
+  isDragging,
+  ariaValueNow,
+  ariaValueMin,
+  ariaValueMax,
+  ariaLabel = 'Resize panel',
+  testId = 'resize-handle',
+  onMouseDown,
+  onKeyDown,
+  className = '',
+  style = undefined,
+}: ResizeHandleProps): ReactElement => {
+  const cursor =
+    orientation === 'horizontal' ? 'cursor-ns-resize' : 'cursor-col-resize'
+
+  return (
+    <div
+      data-testid={testId}
+      role="separator"
+      aria-orientation={orientation}
+      aria-label={ariaLabel}
+      aria-valuenow={ariaValueNow}
+      aria-valuemin={ariaValueMin}
+      aria-valuemax={ariaValueMax}
+      tabIndex={0}
+      onMouseDown={onMouseDown}
+      onKeyDown={onKeyDown}
+      style={style}
+      className={`${cursor} transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
+        isDragging ? 'bg-primary/30' : ''
+      } ${className}`}
+    />
+  )
+}

--- a/src/features/terminal/components/SplitView/SplitDividers.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.test.tsx
@@ -36,6 +36,7 @@ afterEach(() => {
 
 const Harness = ({ layout }: { layout: LayoutId }): React.ReactElement => {
   const ref = useRef<HTMLDivElement>(document.createElement('div'))
+
   return (
     <div ref={ref} style={{ width: 1200, height: 800 }}>
       <SplitDividers

--- a/src/features/terminal/components/SplitView/SplitDividers.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react'
+import { test, expect, describe, vi, beforeEach, afterEach } from 'vitest'
+import { useRef } from 'react'
+import { SplitDividers } from './SplitDividers'
+import { DEFAULT_RATIOS } from './resolveGrid'
+import type { LayoutId } from '../../../sessions/types'
+
+const CONTAINER_WIDTH = 1200
+const CONTAINER_HEIGHT = 800
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+
+vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+beforeEach(() => {
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: CONTAINER_WIDTH,
+    height: CONTAINER_HEIGHT,
+    top: 0,
+    left: 0,
+    right: CONTAINER_WIDTH,
+    bottom: CONTAINER_HEIGHT,
+    x: 0,
+    y: 0,
+    toJSON: (): undefined => undefined,
+  } as DOMRect)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const Harness = ({ layout }: { layout: LayoutId }): React.ReactElement => {
+  const ref = useRef<HTMLDivElement>(document.createElement('div'))
+  return (
+    <div ref={ref} style={{ width: 1200, height: 800 }}>
+      <SplitDividers
+        layout={layout}
+        containerRef={ref}
+        ratios={DEFAULT_RATIOS[layout]}
+        onRatioChange={vi.fn()}
+      />
+    </div>
+  )
+}
+
+describe('SplitDividers', () => {
+  test.each([
+    ['single', 0],
+    ['vsplit', 1],
+    ['hsplit', 1],
+    ['threeRight', 2],
+    ['quad', 3],
+  ] as const)('%s renders %i handle element(s)', (layout, count) => {
+    render(<Harness layout={layout} />)
+    expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(count)
+  })
+
+  test('vsplit handle is a vertical separator (col-resize)', () => {
+    render(<Harness layout="vsplit" />)
+    expect(screen.getByTestId('split-resize-handle')).toHaveAttribute(
+      'aria-orientation',
+      'vertical'
+    )
+  })
+})

--- a/src/features/terminal/components/SplitView/SplitDividers.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.tsx
@@ -1,0 +1,207 @@
+// cspell:ignore vsplit hsplit
+import { Fragment, type ReactElement, type RefObject } from 'react'
+import { ResizeHandle } from '../../../../components/ResizeHandle'
+import type { LayoutId } from '../../../sessions/types'
+import { useSplitDivider } from './useSplitDivider'
+import type { LayoutRatios } from './resolveGrid'
+
+export interface SplitDividersProps {
+  layout: LayoutId
+  containerRef: RefObject<HTMLElement | null>
+  ratios: LayoutRatios
+  onRatioChange: (axis: 'col' | 'row', ratio: number) => void
+}
+
+const HANDLE_TEST_ID = 'split-resize-handle'
+
+const VSplitDividers = ({
+  containerRef,
+  ratios,
+  onRatioChange,
+}: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const col = useSplitDivider({
+    containerRef,
+    axis: 'horizontal',
+    cssVar: '--split-col',
+    initialRatio: ratios.col,
+    onRatioChange: (r) => onRatioChange('col', r),
+  })
+
+  return (
+    <ResizeHandle
+      orientation="vertical"
+      testId={HANDLE_TEST_ID}
+      ariaLabel="Resize panes"
+      isDragging={col.isDragging}
+      ariaValueNow={col.size}
+      ariaValueMin={col.pixelMin}
+      ariaValueMax={col.pixelMax}
+      onMouseDown={col.handleMouseDown}
+      onKeyDown={col.onKeyDown}
+      className="h-full w-full"
+      style={{ gridArea: 'vdiv' }}
+    />
+  )
+}
+
+const HSplitDividers = ({
+  containerRef,
+  ratios,
+  onRatioChange,
+}: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const row = useSplitDivider({
+    containerRef,
+    axis: 'vertical',
+    cssVar: '--split-row',
+    initialRatio: ratios.row,
+    onRatioChange: (r) => onRatioChange('row', r),
+  })
+
+  return (
+    <ResizeHandle
+      orientation="horizontal"
+      testId={HANDLE_TEST_ID}
+      ariaLabel="Resize panes"
+      isDragging={row.isDragging}
+      ariaValueNow={row.size}
+      ariaValueMin={row.pixelMin}
+      ariaValueMax={row.pixelMax}
+      onMouseDown={row.handleMouseDown}
+      onKeyDown={row.onKeyDown}
+      className="h-full w-full"
+      style={{ gridArea: 'hdiv' }}
+    />
+  )
+}
+
+const ThreeRightDividers = ({
+  containerRef,
+  ratios,
+  onRatioChange,
+}: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const col = useSplitDivider({
+    containerRef,
+    axis: 'horizontal',
+    cssVar: '--split-col',
+    initialRatio: ratios.col,
+    onRatioChange: (r) => onRatioChange('col', r),
+  })
+  const row = useSplitDivider({
+    containerRef,
+    axis: 'vertical',
+    cssVar: '--split-row',
+    initialRatio: ratios.row,
+    onRatioChange: (r) => onRatioChange('row', r),
+  })
+
+  return (
+    <Fragment>
+      <ResizeHandle
+        orientation="vertical"
+        testId={HANDLE_TEST_ID}
+        ariaLabel="Resize panes"
+        isDragging={col.isDragging}
+        ariaValueNow={col.size}
+        ariaValueMin={col.pixelMin}
+        ariaValueMax={col.pixelMax}
+        onMouseDown={col.handleMouseDown}
+        onKeyDown={col.onKeyDown}
+        className="h-full w-full"
+        style={{ gridArea: 'vdiv' }}
+      />
+      <ResizeHandle
+        orientation="horizontal"
+        testId={HANDLE_TEST_ID}
+        ariaLabel="Resize panes"
+        isDragging={row.isDragging}
+        ariaValueNow={row.size}
+        ariaValueMin={row.pixelMin}
+        ariaValueMax={row.pixelMax}
+        onMouseDown={row.handleMouseDown}
+        onKeyDown={row.onKeyDown}
+        className="h-full w-full"
+        style={{ gridArea: 'hdiv' }}
+      />
+    </Fragment>
+  )
+}
+
+const QuadDividers = ({
+  containerRef,
+  ratios,
+  onRatioChange,
+}: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const col = useSplitDivider({
+    containerRef,
+    axis: 'horizontal',
+    cssVar: '--split-col',
+    initialRatio: ratios.col,
+    onRatioChange: (r) => onRatioChange('col', r),
+  })
+  const row = useSplitDivider({
+    containerRef,
+    axis: 'vertical',
+    cssVar: '--split-row',
+    initialRatio: ratios.row,
+    onRatioChange: (r) => onRatioChange('row', r),
+  })
+
+  // One logical column divider rendered as two elements (segmented by the
+  // full-width row bar); both share the `col` binding.
+  const colHandle = (gridArea: 'vdiv0' | 'vdiv1'): ReactElement => (
+    <ResizeHandle
+      orientation="vertical"
+      testId={HANDLE_TEST_ID}
+      ariaLabel="Resize panes"
+      isDragging={col.isDragging}
+      ariaValueNow={col.size}
+      ariaValueMin={col.pixelMin}
+      ariaValueMax={col.pixelMax}
+      onMouseDown={col.handleMouseDown}
+      onKeyDown={col.onKeyDown}
+      className="h-full w-full"
+      style={{ gridArea }}
+    />
+  )
+
+  return (
+    <Fragment>
+      {colHandle('vdiv0')}
+      <ResizeHandle
+        orientation="horizontal"
+        testId={HANDLE_TEST_ID}
+        ariaLabel="Resize panes"
+        isDragging={row.isDragging}
+        ariaValueNow={row.size}
+        ariaValueMin={row.pixelMin}
+        ariaValueMax={row.pixelMax}
+        onMouseDown={row.handleMouseDown}
+        onKeyDown={row.onKeyDown}
+        className="h-full w-full"
+        style={{ gridArea: 'hdiv' }}
+      />
+      {colHandle('vdiv1')}
+    </Fragment>
+  )
+}
+
+export const SplitDividers = ({
+  layout,
+  containerRef,
+  ratios,
+  onRatioChange,
+}: SplitDividersProps): ReactElement | null => {
+  const childProps = { containerRef, ratios, onRatioChange }
+  switch (layout) {
+    case 'single':
+      return null
+    case 'vsplit':
+      return <VSplitDividers key="vsplit" {...childProps} />
+    case 'hsplit':
+      return <HSplitDividers key="hsplit" {...childProps} />
+    case 'threeRight':
+      return <ThreeRightDividers key="threeRight" {...childProps} />
+    case 'quad':
+      return <QuadDividers key="quad" {...childProps} />
+  }
+}

--- a/src/features/terminal/components/SplitView/SplitDividers.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.tsx
@@ -1,4 +1,4 @@
-// cspell:ignore vsplit hsplit
+// cspell:ignore vsplit hsplit vdiv hdiv
 import { Fragment, type ReactElement, type RefObject } from 'react'
 import { ResizeHandle } from '../../../../components/ResizeHandle'
 import type { LayoutId } from '../../../sessions/types'
@@ -86,6 +86,7 @@ const ThreeRightDividers = ({
     initialRatio: ratios.col,
     onRatioChange: (r) => onRatioChange('col', r),
   })
+
   const row = useSplitDivider({
     containerRef,
     axis: 'vertical',
@@ -138,6 +139,7 @@ const QuadDividers = ({
     initialRatio: ratios.col,
     onRatioChange: (r) => onRatioChange('col', r),
   })
+
   const row = useSplitDivider({
     containerRef,
     axis: 'vertical',

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -1,8 +1,34 @@
 // cspell:ignore vsplit hsplit
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createRef } from 'react'
-import { describe, test, expect, vi } from 'vitest'
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+
+vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+beforeEach(() => {
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: 1200,
+    height: 800,
+    top: 0,
+    left: 0,
+    right: 1200,
+    bottom: 800,
+    x: 0,
+    y: 0,
+    toJSON: (): undefined => undefined,
+  } as DOMRect)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 import type { UseGitBranchReturn } from '../../../diff/hooks/useGitBranch'
 import type { UseGitStatusReturn } from '../../../diff/hooks/useGitStatus'
 import type { BodyHandle, BodyProps } from '../TerminalPane/Body'
@@ -201,9 +227,7 @@ describe('SplitView - multi-pane layouts', () => {
     ])
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
-      gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr)',
-      gridTemplateRows: 'minmax(0,1fr)',
-      gridTemplateAreas: '"p0 p1"',
+      gridTemplateAreas: '"p0 vdiv p1"',
     })
   })
 
@@ -217,7 +241,7 @@ describe('SplitView - multi-pane layouts', () => {
     )
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
-      gridTemplateAreas: '"p0" "p1"',
+      gridTemplateAreas: '"p0" "hdiv" "p1"',
     })
     expect(screen.getAllByTestId('split-view-slot')).toHaveLength(2)
   })
@@ -232,9 +256,7 @@ describe('SplitView - multi-pane layouts', () => {
     )
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
-      gridTemplateColumns: 'minmax(0,1.4fr) minmax(0,1fr)',
-      gridTemplateRows: 'minmax(0,1fr) minmax(0,1fr)',
-      gridTemplateAreas: '"p0 p1" "p0 p2"',
+      gridTemplateAreas: '"p0 vdiv p1" "p0 vdiv hdiv" "p0 vdiv p2"',
     })
     expect(screen.getAllByTestId('split-view-slot')).toHaveLength(3)
   })
@@ -249,9 +271,103 @@ describe('SplitView - multi-pane layouts', () => {
     )
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
-      gridTemplateAreas: '"p0 p1" "p2 p3"',
+      gridTemplateAreas: '"p0 vdiv0 p1" "hdiv hdiv hdiv" "p2 vdiv1 p3"',
     })
     expect(screen.getAllByTestId('split-view-slot')).toHaveLength(4)
+  })
+
+  test('single layout renders no dividers', () => {
+    render(
+      <SplitView
+        session={makeSession('single', 1)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+    expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(0)
+  })
+
+  test('active vsplit renders a divider; inactive does not', () => {
+    const session = makeSession('vsplit', 2)
+    const { rerender } = render(
+      <SplitView session={session} service={makeMockService()} isActive />
+    )
+    expect(screen.getAllByTestId('split-resize-handle')).toHaveLength(1)
+
+    rerender(
+      <SplitView
+        session={session}
+        service={makeMockService()}
+        isActive={false}
+      />
+    )
+    expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(0)
+  })
+
+  test('remembers the split ratio across a layout cycle (D4)', () => {
+    const valueNow = (): string | null =>
+      screen.getByTestId('split-resize-handle').getAttribute('aria-valuenow')
+    const { rerender } = render(
+      <SplitView
+        session={makeSession('vsplit', 2)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+    const pristine = valueNow()
+    fireEvent.keyDown(screen.getByTestId('split-resize-handle'), {
+      key: 'ArrowRight',
+    })
+    const resized = valueNow()
+    expect(resized).not.toBe(pristine)
+
+    rerender(
+      <SplitView
+        session={makeSession('single', 1)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+    rerender(
+      <SplitView
+        session={makeSession('vsplit', 2)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+    expect(valueNow()).toBe(resized)
+  })
+
+  test('remembers the split ratio across a tab switch (D2)', () => {
+    const valueNow = (): string | null =>
+      screen.getByTestId('split-resize-handle').getAttribute('aria-valuenow')
+    const { rerender } = render(
+      <SplitView
+        session={makeSession('vsplit', 2)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+    fireEvent.keyDown(screen.getByTestId('split-resize-handle'), {
+      key: 'ArrowRight',
+    })
+    const resized = valueNow()
+
+    rerender(
+      <SplitView
+        session={makeSession('vsplit', 2)}
+        service={makeMockService()}
+        isActive={false}
+      />
+    )
+    rerender(
+      <SplitView
+        session={makeSession('vsplit', 2)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+    expect(valueNow()).toBe(resized)
   })
 
   test('each slot gets gridArea by index regardless of pane.id naming', () => {
@@ -344,7 +460,7 @@ describe('SplitView - under-capacity', () => {
     )
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
-      gridTemplateAreas: '"p0 p1" "p2 p3"',
+      gridTemplateAreas: '"p0 vdiv0 p1" "hdiv hdiv hdiv" "p2 vdiv1 p3"',
     })
   })
 

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -1,8 +1,18 @@
-// cspell:ignore vsplit hsplit
+// cspell:ignore vsplit hsplit vdiv hdiv
 import { render, screen, within, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createRef } from 'react'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { UseGitBranchReturn } from '../../../diff/hooks/useGitBranch'
+import type { UseGitStatusReturn } from '../../../diff/hooks/useGitStatus'
+import type { BodyHandle, BodyProps } from '../TerminalPane/Body'
+import {
+  SplitView,
+  selectVisiblePanes,
+  type SplitViewHandle,
+} from './SplitView'
+import type { LayoutId, Pane, Session } from '../../../sessions/types'
+import type { ITerminalService } from '../../services/terminalService'
 
 class MockResizeObserver {
   observe = vi.fn()
@@ -29,16 +39,6 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks()
 })
-import type { UseGitBranchReturn } from '../../../diff/hooks/useGitBranch'
-import type { UseGitStatusReturn } from '../../../diff/hooks/useGitStatus'
-import type { BodyHandle, BodyProps } from '../TerminalPane/Body'
-import {
-  SplitView,
-  selectVisiblePanes,
-  type SplitViewHandle,
-} from './SplitView'
-import type { LayoutId, Pane, Session } from '../../../sessions/types'
-import type { ITerminalService } from '../../services/terminalService'
 
 vi.mock('../TerminalPane/Body', async () => {
   const React = await import('react')
@@ -152,6 +152,10 @@ const makeMockService = (): ITerminalService => ({
   updateSessionCwd: vi.fn(() => Promise.resolve(undefined)),
   setSessionActivityPanelCollapsed: vi.fn(() => Promise.resolve(undefined)),
 })
+
+// Literal `isActive={false}` is stripped by the project's jsx-boolean-value
+// autofix, which then breaks the required prop; a variable dodges the rule.
+const inactive = false
 
 describe('SplitView - single layout', () => {
   test('renders one slot with data attrs from the lone pane', () => {
@@ -289,6 +293,7 @@ describe('SplitView - multi-pane layouts', () => {
 
   test('active vsplit renders a divider; inactive does not', () => {
     const session = makeSession('vsplit', 2)
+
     const { rerender } = render(
       <SplitView session={session} service={makeMockService()} isActive />
     )
@@ -298,7 +303,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={session}
         service={makeMockService()}
-        isActive={false}
+        isActive={inactive}
       />
     )
     expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(0)
@@ -307,6 +312,7 @@ describe('SplitView - multi-pane layouts', () => {
   test('remembers the split ratio across a layout cycle (D4)', () => {
     const valueNow = (): string | null =>
       screen.getByTestId('split-resize-handle').getAttribute('aria-valuenow')
+
     const { rerender } = render(
       <SplitView
         session={makeSession('vsplit', 2)}
@@ -328,6 +334,7 @@ describe('SplitView - multi-pane layouts', () => {
         isActive
       />
     )
+
     rerender(
       <SplitView
         session={makeSession('vsplit', 2)}
@@ -341,6 +348,7 @@ describe('SplitView - multi-pane layouts', () => {
   test('remembers the split ratio across a tab switch (D2)', () => {
     const valueNow = (): string | null =>
       screen.getByTestId('split-resize-handle').getAttribute('aria-valuenow')
+
     const { rerender } = render(
       <SplitView
         session={makeSession('vsplit', 2)}
@@ -357,9 +365,10 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive={false}
+        isActive={inactive}
       />
     )
+
     rerender(
       <SplitView
         session={makeSession('vsplit', 2)}

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -99,6 +99,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
     const [ratios, setRatios] = useState<
       Partial<Record<LayoutId, LayoutRatios>>
     >({})
+
     const currentRatios =
       ratios[session.layout] ?? DEFAULT_RATIOS[session.layout]
     const grid = resolveGrid(session.layout, currentRatios)
@@ -110,16 +111,23 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
           if (base[axis] === value) {
             return prev
           }
+
           return { ...prev, [session.layout]: { ...base, [axis]: value } }
         })
       },
       [session.layout]
     )
 
-    const [gridReady, setGridReady] = useState(false)
+    // Mount SplitDividers (and their useElasticContainer hooks) only once the
+    // grid actually has a measured size. Sessions mount while hidden
+    // (display:none → 0×0) and useElasticContainer hard-throws on a zero
+    // dimension at mount, so re-measure whenever `isActive` flips and the
+    // session becomes visible.
+    const [hasSize, setHasSize] = useState(false)
     useLayoutEffect(() => {
-      setGridReady(true)
-    }, [])
+      const rect = outerDivRef.current?.getBoundingClientRect()
+      setHasSize(Boolean(rect && rect.width > 0 && rect.height > 0))
+    }, [isActive])
 
     const paneHandleRefs = useRef<Map<string, TerminalPaneHandle | null>>(
       new Map()
@@ -206,38 +214,38 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
             gridTemplateAreas,
           }}
         >
-        {/* eslint-disable-next-line react/jsx-boolean-value -- framer-motion: `initial={false}` skips the entry animation for children already mounted. Omitting `initial` reverts to the default (animate on mount) — semantically distinct. */}
-        <AnimatePresence initial={false}>
-          {visiblePanes.map((pane, i) => {
-            const mode = paneMode(pane)
+          {/* eslint-disable-next-line react/jsx-boolean-value -- framer-motion: `initial={false}` skips the entry animation for children already mounted. Omitting `initial` reverts to the default (animate on mount) — semantically distinct. */}
+          <AnimatePresence initial={false}>
+            {visiblePanes.map((pane, i) => {
+              const mode = paneMode(pane)
 
-            return (
-              <motion.div
-                key={pane.id}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={SLOT_FADE_TRANSITION}
-                // Skip the dispatch when this slot's pane is already
-                // active. applyActivePane returns the same reference
-                // on no-op, but expressing the guard at the call site
-                // keeps the semantic clean: every click that survives
-                // this handler is a real focus change. Mirrors the
-                // already-active escape-hatch in usePaneShortcuts.
-                onClick={
-                  pane.active
-                    ? undefined
-                    : (): void => onSetActivePane?.(session.id, pane.id)
-                }
-                data-testid="split-view-slot"
-                data-pane-id={pane.id}
-                data-pty-id={pane.ptyId}
-                data-mode={mode}
-                data-cwd={pane.cwd}
-                className="relative min-h-0 min-w-0"
-                style={{ gridArea: `p${i}` }}
-              >
-                {/* Inner Tooltip wrapper. The motion.div above carries
+              return (
+                <motion.div
+                  key={pane.id}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={SLOT_FADE_TRANSITION}
+                  // Skip the dispatch when this slot's pane is already
+                  // active. applyActivePane returns the same reference
+                  // on no-op, but expressing the guard at the call site
+                  // keeps the semantic clean: every click that survives
+                  // this handler is a real focus change. Mirrors the
+                  // already-active escape-hatch in usePaneShortcuts.
+                  onClick={
+                    pane.active
+                      ? undefined
+                      : (): void => onSetActivePane?.(session.id, pane.id)
+                  }
+                  data-testid="split-view-slot"
+                  data-pane-id={pane.id}
+                  data-pty-id={pane.ptyId}
+                  data-mode={mode}
+                  data-cwd={pane.cwd}
+                  className="relative min-h-0 min-w-0"
+                  style={{ gridArea: `p${i}` }}
+                >
+                  {/* Inner Tooltip wrapper. The motion.div above carries
                   the click handler + grid placement; this inner Tooltip
                   attaches floating-ui hover handlers to a plain div so
                   the `cloneElement` merge doesn't have to negotiate
@@ -246,17 +254,17 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                   whole slot. Disabled when the pane is active —
                   nothing to hint at, and overlaying an active
                   terminal with a popover would interfere. */}
-                <Tooltip
-                  content={`Focus pane ${i + 1}`}
-                  shortcut={['Mod', String(i + 1)]}
-                  disabled={pane.active}
-                  placement="top"
-                >
-                  <div
-                    data-testid="split-view-slot-inner"
-                    className="h-full w-full"
+                  <Tooltip
+                    content={`Focus pane ${i + 1}`}
+                    shortcut={['Mod', String(i + 1)]}
+                    disabled={pane.active}
+                    placement="top"
                   >
-                    {/* F16 (codex connector P1, carried over from pre-5b TerminalZone):
+                    <div
+                      data-testid="split-view-slot-inner"
+                      className="h-full w-full"
+                    >
+                      {/* F16 (codex connector P1, carried over from pre-5b TerminalZone):
                     keying TerminalPane by `pane.ptyId` (NOT `pane.id`) forces a
                     clean useTerminal subtree unmount + remount whenever a
                     restartSession rotates the pane's PTY handle. Without the
@@ -265,60 +273,60 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                     nowhere until reload. The outer slot wrapper above keys
                     by `pane.id` so layout slot identity is preserved across
                     restarts. */}
-                    <TerminalPane
-                      key={pane.ptyId}
-                      ref={getPaneRefSetter(pane.id)}
-                      session={session}
-                      pane={pane}
-                      service={service}
-                      mode={mode}
-                      onCwdChange={(cwd) =>
-                        onSessionCwdChange?.(session.id, pane.id, cwd)
-                      }
-                      onPaneReady={onPaneReady}
-                      onRestart={onSessionRestart}
-                      onClose={
-                        session.panes.length > 1 && onClosePane
-                          ? onClosePane
-                          : undefined
-                      }
-                      isActive={isActive}
-                      deferFit={deferTerminalFit}
-                      showFocusHighlight={showPaneFocusHighlight}
-                    />
-                  </div>
-                </Tooltip>
-              </motion.div>
-            )
-          })}
-          {onAddPane
-            ? emptySlotIndices.map((slotIndex) => (
-                <motion.div
-                  key={`empty-${slotIndex}`}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={SLOT_FADE_TRANSITION}
-                  data-testid="split-view-empty-slot"
-                  data-slot-index={slotIndex}
-                  className="relative min-h-0 min-w-0"
-                  style={{ gridArea: `p${slotIndex}` }}
-                >
-                  <EmptySlot sessionId={session.id} onAddPane={onAddPane} />
+                      <TerminalPane
+                        key={pane.ptyId}
+                        ref={getPaneRefSetter(pane.id)}
+                        session={session}
+                        pane={pane}
+                        service={service}
+                        mode={mode}
+                        onCwdChange={(cwd) =>
+                          onSessionCwdChange?.(session.id, pane.id, cwd)
+                        }
+                        onPaneReady={onPaneReady}
+                        onRestart={onSessionRestart}
+                        onClose={
+                          session.panes.length > 1 && onClosePane
+                            ? onClosePane
+                            : undefined
+                        }
+                        isActive={isActive}
+                        deferFit={deferTerminalFit}
+                        showFocusHighlight={showPaneFocusHighlight}
+                      />
+                    </div>
+                  </Tooltip>
                 </motion.div>
-              ))
-            : null}
-        </AnimatePresence>
-        {isActive && gridReady ? (
-          <SplitDividers
-            layout={session.layout}
-            containerRef={outerDivRef}
-            ratios={currentRatios}
-            onRatioChange={handleRatioChange}
-          />
-        ) : null}
+              )
+            })}
+            {onAddPane
+              ? emptySlotIndices.map((slotIndex) => (
+                  <motion.div
+                    key={`empty-${slotIndex}`}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={SLOT_FADE_TRANSITION}
+                    data-testid="split-view-empty-slot"
+                    data-slot-index={slotIndex}
+                    className="relative min-h-0 min-w-0"
+                    style={{ gridArea: `p${slotIndex}` }}
+                  >
+                    <EmptySlot sessionId={session.id} onAddPane={onAddPane} />
+                  </motion.div>
+                ))
+              : null}
+          </AnimatePresence>
+          {isActive && hasSize ? (
+            <SplitDividers
+              layout={session.layout}
+              containerRef={outerDivRef}
+              ratios={currentRatios}
+              onRatioChange={handleRatioChange}
+            />
+          ) : null}
+        </div>
       </div>
-    </div>
-  )
-}
+    )
+  }
 )

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -4,11 +4,13 @@ import {
   forwardRef,
   useCallback,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
+  useState,
   type ReactElement,
 } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
-import type { Pane, Session } from '../../../sessions/types'
+import type { LayoutId, Pane, Session } from '../../../sessions/types'
 import type { NotifyPaneReady } from '../../hooks/useTerminal'
 import type { ITerminalService } from '../../services/terminalService'
 import {
@@ -19,6 +21,8 @@ import {
 import { EmptySlot } from './EmptySlot'
 import { LAYOUTS } from './layouts'
 import { Tooltip } from '../../../../components/Tooltip'
+import { SplitDividers } from './SplitDividers'
+import { resolveGrid, DEFAULT_RATIOS, type LayoutRatios } from './resolveGrid'
 
 const SLOT_FADE_TRANSITION = { duration: 0.08, ease: 'easeOut' } as const
 
@@ -92,6 +96,31 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
     const layout = LAYOUTS[session.layout]
     const outerDivRef = useRef<HTMLDivElement>(null)
 
+    const [ratios, setRatios] = useState<
+      Partial<Record<LayoutId, LayoutRatios>>
+    >({})
+    const currentRatios =
+      ratios[session.layout] ?? DEFAULT_RATIOS[session.layout]
+    const grid = resolveGrid(session.layout, currentRatios)
+
+    const handleRatioChange = useCallback(
+      (axis: 'col' | 'row', value: number): void => {
+        setRatios((prev) => {
+          const base = prev[session.layout] ?? DEFAULT_RATIOS[session.layout]
+          if (base[axis] === value) {
+            return prev
+          }
+          return { ...prev, [session.layout]: { ...base, [axis]: value } }
+        })
+      },
+      [session.layout]
+    )
+
+    const [gridReady, setGridReady] = useState(false)
+    useLayoutEffect(() => {
+      setGridReady(true)
+    }, [])
+
     const paneHandleRefs = useRef<Map<string, TerminalPaneHandle | null>>(
       new Map()
     )
@@ -155,24 +184,28 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
           )
         : []
 
-    const gridTemplateAreas = layout.areas
+    const gridTemplateAreas = grid.areas
       .map((row) => `"${row.join(' ')}"`)
       .join(' ')
 
     return (
       <div
-        ref={outerDivRef}
-        data-testid="split-view"
-        data-session-id={session.id}
-        data-layout={session.layout}
-        tabIndex={-1}
-        className="grid h-full w-full gap-2 bg-surface p-2.5"
-        style={{
-          gridTemplateColumns: layout.cols,
-          gridTemplateRows: layout.rows,
-          gridTemplateAreas,
-        }}
+        data-testid="split-view-canvas"
+        className="h-full w-full bg-surface p-2.5"
       >
+        <div
+          ref={outerDivRef}
+          data-testid="split-view"
+          data-session-id={session.id}
+          data-layout={session.layout}
+          tabIndex={-1}
+          className="grid h-full w-full gap-0"
+          style={{
+            gridTemplateColumns: grid.cols,
+            gridTemplateRows: grid.rows,
+            gridTemplateAreas,
+          }}
+        >
         {/* eslint-disable-next-line react/jsx-boolean-value -- framer-motion: `initial={false}` skips the entry animation for children already mounted. Omitting `initial` reverts to the default (animate on mount) — semantically distinct. */}
         <AnimatePresence initial={false}>
           {visiblePanes.map((pane, i) => {
@@ -276,7 +309,16 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
               ))
             : null}
         </AnimatePresence>
+        {isActive && gridReady ? (
+          <SplitDividers
+            layout={session.layout}
+            containerRef={outerDivRef}
+            ratios={currentRatios}
+            onRatioChange={handleRatioChange}
+          />
+        ) : null}
       </div>
-    )
-  }
+    </div>
+  )
+}
 )

--- a/src/features/terminal/components/SplitView/resolveGrid.test.ts
+++ b/src/features/terminal/components/SplitView/resolveGrid.test.ts
@@ -1,0 +1,47 @@
+import { test, expect, describe } from 'vitest'
+import { resolveGrid, DEFAULT_RATIOS, SPLIT_DIVIDER_PX } from './resolveGrid'
+
+describe('resolveGrid', () => {
+  test('single has no divider tracks', () => {
+    const g = resolveGrid('single', DEFAULT_RATIOS.single)
+    expect(g.cols).toBe('minmax(0,1fr)')
+    expect(g.rows).toBe('minmax(0,1fr)')
+    expect(g.areas).toEqual([['p0']])
+  })
+
+  test('vsplit emits one column divider track + var fallback', () => {
+    const g = resolveGrid('vsplit', { col: 0.5, row: 0.5 })
+    expect(g.cols).toBe(`var(--split-col, 0.5fr) ${SPLIT_DIVIDER_PX}px 0.5fr`)
+    expect(g.rows).toBe('minmax(0,1fr)')
+    expect(g.areas).toEqual([['p0', 'vdiv', 'p1']])
+  })
+
+  test('hsplit emits one row divider track', () => {
+    const g = resolveGrid('hsplit', { col: 0.5, row: 0.4 })
+    expect(g.rows).toBe(`var(--split-row, 0.4fr) ${SPLIT_DIVIDER_PX}px 0.6fr`)
+    expect(g.areas).toEqual([['p0'], ['hdiv'], ['p1']])
+  })
+
+  test('threeRight spans p0 + vdiv across all rows; hdiv only in right column', () => {
+    const g = resolveGrid('threeRight', { col: 0.583, row: 0.5 })
+    expect(g.areas).toEqual([
+      ['p0', 'vdiv', 'p1'],
+      ['p0', 'vdiv', 'hdiv'],
+      ['p0', 'vdiv', 'p2'],
+    ])
+  })
+
+  test('quad segments the column bar around the full-width row bar', () => {
+    const g = resolveGrid('quad', { col: 0.5, row: 0.5 })
+    expect(g.areas).toEqual([
+      ['p0', 'vdiv0', 'p1'],
+      ['hdiv', 'hdiv', 'hdiv'],
+      ['p2', 'vdiv1', 'p3'],
+    ])
+  })
+
+  test('default ratios reproduce current proportions', () => {
+    expect(DEFAULT_RATIOS.vsplit.col).toBe(0.5)
+    expect(DEFAULT_RATIOS.threeRight.col).toBeCloseTo(1.4 / 2.4, 5)
+  })
+})

--- a/src/features/terminal/components/SplitView/resolveGrid.test.ts
+++ b/src/features/terminal/components/SplitView/resolveGrid.test.ts
@@ -10,16 +10,20 @@ describe('resolveGrid', () => {
     expect(g.areas).toEqual([['p0']])
   })
 
-  test('vsplit emits one column divider track + var fallback', () => {
+  test('vsplit emits two column fr vars summing to 1 (grid always fills)', () => {
     const g = resolveGrid('vsplit', { col: 0.5, row: 0.5 })
-    expect(g.cols).toBe(`var(--split-col, 0.5fr) ${SPLIT_DIVIDER_PX}px 0.5fr`)
+    expect(g.cols).toBe(
+      `var(--split-col, 0.5fr) ${SPLIT_DIVIDER_PX}px var(--split-col-end, 0.5fr)`
+    )
     expect(g.rows).toBe('minmax(0,1fr)')
     expect(g.areas).toEqual([['p0', 'vdiv', 'p1']])
   })
 
-  test('hsplit emits one row divider track', () => {
+  test('hsplit emits two row fr vars summing to 1', () => {
     const g = resolveGrid('hsplit', { col: 0.5, row: 0.4 })
-    expect(g.rows).toBe(`var(--split-row, 0.4fr) ${SPLIT_DIVIDER_PX}px 0.6fr`)
+    expect(g.rows).toBe(
+      `var(--split-row, 0.4fr) ${SPLIT_DIVIDER_PX}px var(--split-row-end, 0.6fr)`
+    )
     expect(g.areas).toEqual([['p0'], ['hdiv'], ['p1']])
   })
 

--- a/src/features/terminal/components/SplitView/resolveGrid.test.ts
+++ b/src/features/terminal/components/SplitView/resolveGrid.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore vdiv hdiv
 import { test, expect, describe } from 'vitest'
 import { resolveGrid, DEFAULT_RATIOS, SPLIT_DIVIDER_PX } from './resolveGrid'
 

--- a/src/features/terminal/components/SplitView/resolveGrid.ts
+++ b/src/features/terminal/components/SplitView/resolveGrid.ts
@@ -1,0 +1,67 @@
+// cspell:ignore vsplit hsplit
+import type { LayoutId } from '../../../sessions/types'
+
+/** Width of the divider track that replaces the inter-pane gap (px). */
+export const SPLIT_DIVIDER_PX = 8
+
+export interface LayoutRatios {
+  /** Column split fraction (leading column / pane space). */
+  col: number
+  /** Row split fraction (leading row / pane space). */
+  row: number
+}
+
+export interface ResolvedGrid {
+  cols: string
+  rows: string
+  areas: readonly (readonly string[])[]
+}
+
+/** Per-layout defaults that reproduce the pre-resize `fr` proportions. */
+export const DEFAULT_RATIOS: Record<LayoutId, LayoutRatios> = {
+  single: { col: 0.5, row: 0.5 },
+  vsplit: { col: 0.5, row: 0.5 },
+  hsplit: { col: 0.5, row: 0.5 },
+  threeRight: { col: 1.4 / 2.4, row: 0.5 },
+  quad: { col: 0.5, row: 0.5 },
+}
+
+const axisTemplate = (cssVar: string, ratio: number): string =>
+  `var(${cssVar}, ${ratio}fr) ${SPLIT_DIVIDER_PX}px ${1 - ratio}fr`
+
+export const resolveGrid = (
+  layoutId: LayoutId,
+  ratios: LayoutRatios
+): ResolvedGrid => {
+  const col = axisTemplate('--split-col', ratios.col)
+  const row = axisTemplate('--split-row', ratios.row)
+
+  switch (layoutId) {
+    case 'single':
+      return { cols: 'minmax(0,1fr)', rows: 'minmax(0,1fr)', areas: [['p0']] }
+    case 'vsplit':
+      return { cols: col, rows: 'minmax(0,1fr)', areas: [['p0', 'vdiv', 'p1']] }
+    case 'hsplit':
+      return { cols: 'minmax(0,1fr)', rows: row, areas: [['p0'], ['hdiv'], ['p1']] }
+    case 'threeRight':
+      return {
+        cols: col,
+        rows: row,
+        areas: [
+          ['p0', 'vdiv', 'p1'],
+          ['p0', 'vdiv', 'hdiv'],
+          ['p0', 'vdiv', 'p2'],
+        ],
+      }
+    case 'quad':
+      return {
+        cols: col,
+        rows: row,
+        areas: [
+          ['p0', 'vdiv0', 'p1'],
+          ['hdiv', 'hdiv', 'hdiv'],
+          ['p2', 'vdiv1', 'p3'],
+        ],
+      }
+  }
+}

--- a/src/features/terminal/components/SplitView/resolveGrid.ts
+++ b/src/features/terminal/components/SplitView/resolveGrid.ts
@@ -1,4 +1,4 @@
-// cspell:ignore vsplit hsplit
+// cspell:ignore vsplit hsplit vdiv hdiv
 import type { LayoutId } from '../../../sessions/types'
 
 /** Width of the divider track that replaces the inter-pane gap (px). */
@@ -42,7 +42,11 @@ export const resolveGrid = (
     case 'vsplit':
       return { cols: col, rows: 'minmax(0,1fr)', areas: [['p0', 'vdiv', 'p1']] }
     case 'hsplit':
-      return { cols: 'minmax(0,1fr)', rows: row, areas: [['p0'], ['hdiv'], ['p1']] }
+      return {
+        cols: 'minmax(0,1fr)',
+        rows: row,
+        areas: [['p0'], ['hdiv'], ['p1']],
+      }
     case 'threeRight':
       return {
         cols: col,

--- a/src/features/terminal/components/SplitView/resolveGrid.ts
+++ b/src/features/terminal/components/SplitView/resolveGrid.ts
@@ -27,7 +27,7 @@ export const DEFAULT_RATIOS: Record<LayoutId, LayoutRatios> = {
 }
 
 const axisTemplate = (cssVar: string, ratio: number): string =>
-  `var(${cssVar}, ${ratio}fr) ${SPLIT_DIVIDER_PX}px ${1 - ratio}fr`
+  `var(${cssVar}, ${ratio}fr) ${SPLIT_DIVIDER_PX}px var(${cssVar}-end, ${1 - ratio}fr)`
 
 export const resolveGrid = (
   layoutId: LayoutId,

--- a/src/features/terminal/components/SplitView/useSplitDivider.test.tsx
+++ b/src/features/terminal/components/SplitView/useSplitDivider.test.tsx
@@ -62,7 +62,7 @@ const Harness = ({
 }
 
 describe('useSplitDivider', () => {
-  test('keyboard resize mirrors a clamped ratio up and writes the px var', () => {
+  test('keyboard resize mirrors a clamped ratio up and writes both fr vars', () => {
     const onRatioChange = vi.fn()
     render(<Harness active onRatioChange={onRatioChange} />)
     fireEvent.keyDown(screen.getByTestId('handle'), { key: 'ArrowRight' })
@@ -70,15 +70,16 @@ describe('useSplitDivider', () => {
     const ratio = calls[calls.length - 1]?.[0] as number
     expect(ratio).toBeGreaterThanOrEqual(0.15)
     expect(ratio).toBeLessThanOrEqual(0.85)
-    expect(
-      screen.getByTestId('container').style.getPropertyValue('--split-col')
-    ).toMatch(/px$/)
+    // Both fr tracks are set (summing to 1) so the grid always fills.
+    const container = screen.getByTestId('container')
+    expect(container.style.getPropertyValue('--split-col')).toMatch(/fr$/)
+    expect(container.style.getPropertyValue('--split-col-end')).toMatch(/fr$/)
   })
 
   test('removes the CSS var on unmount (container stays mounted)', () => {
     const { rerender } = render(<Harness active onRatioChange={vi.fn()} />)
     const container = screen.getByTestId('container')
-    expect(container.style.getPropertyValue('--split-col')).toMatch(/px$/)
+    expect(container.style.getPropertyValue('--split-col')).toMatch(/fr$/)
     rerender(<Harness onRatioChange={vi.fn()} />)
     expect(container.style.getPropertyValue('--split-col')).toBe('')
   })

--- a/src/features/terminal/components/SplitView/useSplitDivider.test.tsx
+++ b/src/features/terminal/components/SplitView/useSplitDivider.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { test, expect, describe, vi, beforeEach, afterEach } from 'vitest'
+import { useRef } from 'react'
+import { useSplitDivider } from './useSplitDivider'
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+beforeEach(() => {
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: 1200, height: 800, top: 0, left: 0, right: 1200, bottom: 800,
+    x: 0, y: 0, toJSON: (): undefined => undefined,
+  } as DOMRect)
+})
+afterEach(() => vi.restoreAllMocks())
+
+const DividerChild = ({
+  containerRef,
+  onRatioChange,
+}: {
+  containerRef: React.RefObject<HTMLElement | null>
+  onRatioChange: (r: number) => void
+}): React.ReactElement => {
+  const divider = useSplitDivider({
+    containerRef,
+    axis: 'horizontal',
+    cssVar: '--split-col',
+    initialRatio: 0.5,
+    onRatioChange,
+  })
+  return <div data-testid="handle" tabIndex={0} onKeyDown={divider.onKeyDown} />
+}
+
+const Harness = ({
+  active,
+  onRatioChange,
+}: {
+  active: boolean
+  onRatioChange: (r: number) => void
+}): React.ReactElement => {
+  const ref = useRef<HTMLDivElement>(document.createElement('div'))
+  return (
+    <div ref={ref} data-testid="container" style={{ width: 1200, height: 800 }}>
+      {active ? (
+        <DividerChild containerRef={ref} onRatioChange={onRatioChange} />
+      ) : null}
+    </div>
+  )
+}
+
+describe('useSplitDivider', () => {
+  test('keyboard resize mirrors a clamped ratio up and writes the px var', () => {
+    const onRatioChange = vi.fn()
+    render(<Harness active onRatioChange={onRatioChange} />)
+    fireEvent.keyDown(screen.getByTestId('handle'), { key: 'ArrowRight' })
+    const ratio = onRatioChange.mock.calls.at(-1)?.[0] as number
+    expect(ratio).toBeGreaterThanOrEqual(0.15)
+    expect(ratio).toBeLessThanOrEqual(0.85)
+    expect(
+      screen.getByTestId('container').style.getPropertyValue('--split-col')
+    ).toMatch(/px$/)
+  })
+
+  test('removes the CSS var on unmount (container stays mounted)', () => {
+    const { rerender } = render(<Harness active onRatioChange={vi.fn()} />)
+    const container = screen.getByTestId('container')
+    expect(container.style.getPropertyValue('--split-col')).toMatch(/px$/)
+    rerender(<Harness active={false} onRatioChange={vi.fn()} />)
+    expect(container.style.getPropertyValue('--split-col')).toBe('')
+  })
+})

--- a/src/features/terminal/components/SplitView/useSplitDivider.test.tsx
+++ b/src/features/terminal/components/SplitView/useSplitDivider.test.tsx
@@ -57,7 +57,8 @@ describe('useSplitDivider', () => {
     const onRatioChange = vi.fn()
     render(<Harness active onRatioChange={onRatioChange} />)
     fireEvent.keyDown(screen.getByTestId('handle'), { key: 'ArrowRight' })
-    const ratio = onRatioChange.mock.calls.at(-1)?.[0] as number
+    const calls = onRatioChange.mock.calls
+    const ratio = calls[calls.length - 1]?.[0] as number
     expect(ratio).toBeGreaterThanOrEqual(0.15)
     expect(ratio).toBeLessThanOrEqual(0.85)
     expect(

--- a/src/features/terminal/components/SplitView/useSplitDivider.test.tsx
+++ b/src/features/terminal/components/SplitView/useSplitDivider.test.tsx
@@ -12,8 +12,15 @@ vi.stubGlobal('ResizeObserver', MockResizeObserver)
 
 beforeEach(() => {
   vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
-    width: 1200, height: 800, top: 0, left: 0, right: 1200, bottom: 800,
-    x: 0, y: 0, toJSON: (): undefined => undefined,
+    width: 1200,
+    height: 800,
+    top: 0,
+    left: 0,
+    right: 1200,
+    bottom: 800,
+    x: 0,
+    y: 0,
+    toJSON: (): undefined => undefined,
   } as DOMRect)
 })
 afterEach(() => vi.restoreAllMocks())
@@ -32,17 +39,19 @@ const DividerChild = ({
     initialRatio: 0.5,
     onRatioChange,
   })
+
   return <div data-testid="handle" tabIndex={0} onKeyDown={divider.onKeyDown} />
 }
 
 const Harness = ({
-  active,
+  active = false,
   onRatioChange,
 }: {
-  active: boolean
+  active?: boolean
   onRatioChange: (r: number) => void
 }): React.ReactElement => {
   const ref = useRef<HTMLDivElement>(document.createElement('div'))
+
   return (
     <div ref={ref} data-testid="container" style={{ width: 1200, height: 800 }}>
       {active ? (
@@ -70,7 +79,7 @@ describe('useSplitDivider', () => {
     const { rerender } = render(<Harness active onRatioChange={vi.fn()} />)
     const container = screen.getByTestId('container')
     expect(container.style.getPropertyValue('--split-col')).toMatch(/px$/)
-    rerender(<Harness active={false} onRatioChange={vi.fn()} />)
+    rerender(<Harness onRatioChange={vi.fn()} />)
     expect(container.style.getPropertyValue('--split-col')).toBe('')
   })
 })

--- a/src/features/terminal/components/SplitView/useSplitDivider.ts
+++ b/src/features/terminal/components/SplitView/useSplitDivider.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, type KeyboardEvent, type RefObject } from 'react'
+import { useElasticContainer } from '../../../../hooks/useElasticContainer'
+import {
+  KEYBOARD_STEP_PX,
+  KEYBOARD_STEP_SHIFT_PX,
+  SPLIT_ELASTIC_CONFIG,
+} from '../../../workspace/panelConfig'
+import { SPLIT_DIVIDER_PX } from './resolveGrid'
+
+export interface SplitDividerBinding {
+  isDragging: boolean
+  size: number
+  pixelMin: number
+  pixelMax: number
+  handleMouseDown: (event: React.MouseEvent) => void
+  onKeyDown: (event: KeyboardEvent) => void
+}
+
+export interface UseSplitDividerArgs {
+  containerRef: RefObject<HTMLElement | null>
+  axis: 'horizontal' | 'vertical'
+  cssVar: '--split-col' | '--split-row'
+  initialRatio: number
+  onRatioChange: (ratio: number) => void
+}
+
+export const useSplitDivider = ({
+  containerRef,
+  axis,
+  cssVar,
+  initialRatio,
+  onRatioChange,
+}: UseSplitDividerArgs): SplitDividerBinding => {
+  const writeVar = useCallback(
+    (px: number): void => {
+      containerRef.current?.style.setProperty(cssVar, `${px}px`)
+    },
+    [containerRef, cssVar]
+  )
+
+  const elastic = useElasticContainer({
+    containerRef,
+    axis,
+    minPercent: SPLIT_ELASTIC_CONFIG.minPercent,
+    maxPercent: SPLIT_ELASTIC_CONFIG.maxPercent,
+    initialPercent: initialRatio,
+    reservedPx: SPLIT_DIVIDER_PX,
+    updateMode: 'commit-on-end',
+    onDragPreview: writeVar,
+  })
+
+  const { size, effectiveDimension, pixelMin, pixelMax, isDragging, adjustBy } =
+    elastic
+
+  // Committed `size` change (drag end | keyboard | resize): keep the var current
+  // on the paths onDragPreview skips, and mirror the ratio up for remember-within-session.
+  useEffect(() => {
+    writeVar(size)
+    if (effectiveDimension > 0) {
+      const ratio = Math.min(
+        Math.max(size / effectiveDimension, SPLIT_ELASTIC_CONFIG.minPercent),
+        SPLIT_ELASTIC_CONFIG.maxPercent
+      )
+      onRatioChange(ratio)
+    }
+  }, [size, effectiveDimension, writeVar, onRatioChange])
+
+  // Restore fr fallback control when this divider unmounts (session deactivates).
+  useEffect(
+    () => (): void => {
+      containerRef.current?.style.removeProperty(cssVar)
+    },
+    [containerRef, cssVar]
+  )
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent): void => {
+      const step = event.shiftKey ? KEYBOARD_STEP_SHIFT_PX : KEYBOARD_STEP_PX
+      const grow = axis === 'horizontal' ? 'ArrowRight' : 'ArrowDown'
+      const shrink = axis === 'horizontal' ? 'ArrowLeft' : 'ArrowUp'
+      if (event.key === grow) {
+        event.preventDefault()
+        adjustBy(step)
+      } else if (event.key === shrink) {
+        event.preventDefault()
+        adjustBy(-step)
+      } else if (event.key === 'Home') {
+        event.preventDefault()
+        adjustBy(pixelMin - size)
+      } else if (event.key === 'End') {
+        event.preventDefault()
+        adjustBy(pixelMax - size)
+      }
+    },
+    [axis, adjustBy, pixelMin, pixelMax, size]
+  )
+
+  return {
+    isDragging,
+    size,
+    pixelMin,
+    pixelMax,
+    handleMouseDown: elastic.handleMouseDown,
+    onKeyDown,
+  }
+}

--- a/src/features/terminal/components/SplitView/useSplitDivider.ts
+++ b/src/features/terminal/components/SplitView/useSplitDivider.ts
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useRef,
   type KeyboardEvent,
   type RefObject,
 } from 'react'
@@ -11,6 +12,12 @@ import {
   SPLIT_ELASTIC_CONFIG,
 } from '../../../workspace/panelConfig'
 import { SPLIT_DIVIDER_PX } from './resolveGrid'
+
+const clampRatio = (ratio: number): number =>
+  Math.min(
+    Math.max(ratio, SPLIT_ELASTIC_CONFIG.minPercent),
+    SPLIT_ELASTIC_CONFIG.maxPercent
+  )
 
 export interface SplitDividerBinding {
   isDragging: boolean
@@ -36,11 +43,35 @@ export const useSplitDivider = ({
   initialRatio,
   onRatioChange,
 }: UseSplitDividerArgs): SplitDividerBinding => {
-  const writeVar = useCallback(
-    (px: number): void => {
-      containerRef.current?.style.setProperty(cssVar, `${px}px`)
+  const endVar = `${cssVar}-end`
+  const effectiveDimensionRef = useRef(0)
+
+  // Drive BOTH grid tracks as `fr` values that always sum to 1. A lone `<1fr`
+  // track only claims its fraction of the free space (e.g. `0.5fr` takes half,
+  // leaving the rest empty), so writing a single px/`fr` track would pack the
+  // grid into a corner. Two fr tracks summing to 1 always fill — see resolveGrid.
+  const writeRatio = useCallback(
+    (ratio: number): void => {
+      const el = containerRef.current
+      if (!el) {
+        return
+      }
+
+      el.style.setProperty(cssVar, `${ratio}fr`)
+      el.style.setProperty(endVar, `${1 - ratio}fr`)
     },
-    [containerRef, cssVar]
+    [containerRef, cssVar, endVar]
+  )
+
+  // useElasticContainer hands us pixel previews during a drag; convert to a
+  // clamped ratio against the live pane-space dimension.
+  const previewFromPx = useCallback(
+    (px: number): void => {
+      if (effectiveDimensionRef.current > 0) {
+        writeRatio(clampRatio(px / effectiveDimensionRef.current))
+      }
+    },
+    [writeRatio]
   )
 
   const elastic = useElasticContainer({
@@ -51,31 +82,35 @@ export const useSplitDivider = ({
     initialPercent: initialRatio,
     reservedPx: SPLIT_DIVIDER_PX,
     updateMode: 'commit-on-end',
-    onDragPreview: writeVar,
+    onDragPreview: previewFromPx,
   })
 
   const { size, effectiveDimension, pixelMin, pixelMax, isDragging, adjustBy } =
     elastic
 
-  // Committed `size` change (drag end | keyboard | resize): keep the var current
-  // on the paths onDragPreview skips, and mirror the ratio up for remember-within-session.
   useEffect(() => {
-    writeVar(size)
+    effectiveDimensionRef.current = effectiveDimension
+  }, [effectiveDimension])
+
+  // Committed `size` change (drag end | keyboard | resize): set both fr tracks
+  // and mirror the ratio up for remember-within-session. Covers the keyboard /
+  // ResizeObserver paths where onDragPreview never fires.
+  useEffect(() => {
     if (effectiveDimension > 0) {
-      const ratio = Math.min(
-        Math.max(size / effectiveDimension, SPLIT_ELASTIC_CONFIG.minPercent),
-        SPLIT_ELASTIC_CONFIG.maxPercent
-      )
+      const ratio = clampRatio(size / effectiveDimension)
+      writeRatio(ratio)
       onRatioChange(ratio)
     }
-  }, [size, effectiveDimension, writeVar, onRatioChange])
+  }, [size, effectiveDimension, writeRatio, onRatioChange])
 
-  // Restore fr fallback control when this divider unmounts (session deactivates).
+  // Restore the fr fallback when this divider unmounts (session deactivates).
   useEffect(
     () => (): void => {
-      containerRef.current?.style.removeProperty(cssVar)
+      const el = containerRef.current
+      el?.style.removeProperty(cssVar)
+      el?.style.removeProperty(endVar)
     },
-    [containerRef, cssVar]
+    [containerRef, cssVar, endVar]
   )
 
   const onKeyDown = useCallback(

--- a/src/features/terminal/components/SplitView/useSplitDivider.ts
+++ b/src/features/terminal/components/SplitView/useSplitDivider.ts
@@ -1,4 +1,9 @@
-import { useCallback, useEffect, type KeyboardEvent, type RefObject } from 'react'
+import {
+  useCallback,
+  useEffect,
+  type KeyboardEvent,
+  type RefObject,
+} from 'react'
 import { useElasticContainer } from '../../../../hooks/useElasticContainer'
 import {
   KEYBOARD_STEP_PX,

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -23,6 +23,7 @@ import {
   KEYBOARD_STEP_PX,
   KEYBOARD_STEP_SHIFT_PX,
 } from '../panelConfig'
+import { ResizeHandle } from '../../../components/ResizeHandle'
 
 type TabType = 'editor' | 'diff'
 
@@ -267,40 +268,27 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
         ) : null}
 
         {isVerticalDock ? (
-          <div
-            data-testid="resize-handle"
-            role="separator"
-            aria-orientation="horizontal"
-            aria-label="Resize panel"
-            aria-valuenow={verticalSize}
-            aria-valuemin={verticalPixelMin}
-            aria-valuemax={verticalPixelMax}
-            tabIndex={0}
+          <ResizeHandle
+            orientation="horizontal"
+            isDragging={isVerticalResizing}
+            ariaValueNow={verticalSize}
+            ariaValueMin={verticalPixelMin}
+            ariaValueMax={verticalPixelMax}
             onMouseDown={onVerticalResizeMouseDown}
             onKeyDown={handleVerticalKeyDown}
-            // z-10 keeps the 4-px handle above the DockTab header
-            // (`relative` sibling) and the content area; without it,
-            // both later-in-source-order children paint on top and
-            // swallow mousedown events at the handle's coordinates.
-            className={`absolute ${position === 'top' ? 'bottom-0' : 'top-0'} left-0 right-0 z-10 h-1 cursor-ns-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
-              isVerticalResizing ? 'bg-primary/30' : ''
-            }`}
+            // z-10 keeps the 4-px handle above the DockTab header (relative sibling)
+            className={`absolute ${position === 'top' ? 'bottom-0' : 'top-0'} left-0 right-0 z-10 h-1`}
           />
         ) : (
-          <div
-            data-testid="resize-handle"
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize panel"
-            aria-valuenow={horizontalSize}
-            aria-valuemin={horizontalPixelMin}
-            aria-valuemax={horizontalPixelMax}
-            tabIndex={0}
+          <ResizeHandle
+            orientation="vertical"
+            isDragging={isHorizontalResizing}
+            ariaValueNow={horizontalSize}
+            ariaValueMin={horizontalPixelMin}
+            ariaValueMax={horizontalPixelMax}
             onMouseDown={onHorizontalResizeMouseDown}
             onKeyDown={handleHorizontalKeyDown}
-            className={`absolute ${position === 'right' ? 'left-0' : 'right-0'} top-0 bottom-0 z-10 w-1 cursor-col-resize transition-colors hover:bg-primary/20 focus:bg-primary/40 focus:outline-none ${
-              isHorizontalResizing ? 'bg-primary/30' : ''
-            }`}
+            className={`absolute ${position === 'right' ? 'left-0' : 'right-0'} top-0 bottom-0 z-10 w-1`}
           />
         )}
 

--- a/src/features/workspace/panelConfig.ts
+++ b/src/features/workspace/panelConfig.ts
@@ -29,3 +29,13 @@ export const KEYBOARD_STEP_SHIFT_PX = 100
  * the dock switcher/file/collapse controls move into the overflow menu.
  */
 export const DOCK_INLINE_ACTIONS_MIN_WIDTH_PX = 420
+
+/**
+ * Elastic config for split-pane dividers. Percentages apply to the pane space
+ * (container minus the 8px divider track, via useElasticContainer's reservedPx),
+ * so both panes stay within 15–85%.
+ */
+export const SPLIT_ELASTIC_CONFIG = {
+  minPercent: 0.15,
+  maxPercent: 0.85,
+} as const

--- a/src/hooks/useElasticContainer.test.ts
+++ b/src/hooks/useElasticContainer.test.ts
@@ -223,7 +223,10 @@ describe('useElasticContainer', () => {
   })
 
   test('reservedPx defaults to 0 (dock behavior unchanged)', () => {
-    const { result } = renderElastic({ axis: 'horizontal', initialPercent: 0.3 })
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      initialPercent: 0.3,
+    })
     expect(result.current.size).toBe(360)
     expect(result.current.effectiveDimension).toBe(1200)
   })

--- a/src/hooks/useElasticContainer.test.ts
+++ b/src/hooks/useElasticContainer.test.ts
@@ -50,6 +50,7 @@ interface RenderElasticOverrides {
   minPercent?: number
   maxPercent?: number
   initialPercent?: number
+  reservedPx?: number
 }
 
 const renderElastic = (
@@ -204,5 +205,26 @@ describe('useElasticContainer', () => {
     expect(typeof result.current.adjustBy).toBe('function')
     expect(typeof result.current.isDragging).toBe('boolean')
     expect(typeof result.current.sizeRef.current).toBe('number')
+  })
+
+  test('reservedPx subtracts from the dimension before applying percentages', () => {
+    // dim 1200, reserved 8 → effective 1192; initial 0.5 → round(596)
+    const { result } = renderElastic({
+      axis: 'horizontal',
+      minPercent: 0.15,
+      maxPercent: 0.85,
+      initialPercent: 0.5,
+      reservedPx: 8,
+    })
+    expect(result.current.size).toBe(596)
+    expect(result.current.pixelMin).toBe(Math.ceil(1192 * 0.15)) // 179
+    expect(result.current.pixelMax).toBe(Math.floor(1192 * 0.85)) // 1013
+    expect(result.current.effectiveDimension).toBe(1192)
+  })
+
+  test('reservedPx defaults to 0 (dock behavior unchanged)', () => {
+    const { result } = renderElastic({ axis: 'horizontal', initialPercent: 0.3 })
+    expect(result.current.size).toBe(360)
+    expect(result.current.effectiveDimension).toBe(1200)
   })
 })

--- a/src/hooks/useElasticContainer.ts
+++ b/src/hooks/useElasticContainer.ts
@@ -112,6 +112,7 @@ export const useElasticContainer = ({
     pendingClampRef.current = false
 
     const effective = Math.max(1, dimensionRef.current - reservedPxRef.current)
+
     const targetPx =
       dimensionRef.current > 0
         ? Math.round(effective * desiredPercentRef.current)
@@ -217,8 +218,8 @@ export const useElasticContainer = ({
       }
 
       dimensionRef.current = nextDimension
-      const effective = Math.max(1, nextDimension - reservedPxRef.current)
-      setEffectiveDimension(effective)
+      const nextEffective = Math.max(1, nextDimension - reservedPxRef.current)
+      setEffectiveDimension(nextEffective)
 
       const { newMin: resizedMin, newMax: resizedMax } =
         computeBounds(nextDimension)
@@ -238,7 +239,7 @@ export const useElasticContainer = ({
       // Use desiredPercentRef so shrink→expand cycles restore the user's
       // original proportion rather than anchoring to a clamped pixel value.
       const proportionalPx = Math.round(
-        effective * desiredPercentRef.current
+        nextEffective * desiredPercentRef.current
       )
       resetToSize(proportionalPx, resizedMin, resizedMax)
     })

--- a/src/hooks/useElasticContainer.ts
+++ b/src/hooks/useElasticContainer.ts
@@ -32,11 +32,18 @@ export interface UseElasticContainerOptions {
   invert?: boolean
   updateMode?: 'live' | 'commit-on-end'
   onDragPreview?: (size: number) => void
+  /** Fixed pixels removed from the measured dimension before percentages apply
+   *  (e.g. a divider track that sits between the two resizable regions).
+   *  Default 0 — leaves single-panel consumers (the dock) unchanged.
+   *  Mount-time constant by contract, like `axis` / `minPercent` / `maxPercent`:
+   *  captured once into a ref; changing it after mount does NOT re-derive bounds. */
+  reservedPx?: number
 }
 
 export interface UseElasticContainerResult extends UseResizableResult {
   pixelMin: number
   pixelMax: number
+  effectiveDimension: number
 }
 
 export const useElasticContainer = ({
@@ -48,13 +55,16 @@ export const useElasticContainer = ({
   invert = false,
   updateMode = 'live',
   onDragPreview = undefined,
+  reservedPx = 0,
 }: UseElasticContainerOptions): UseElasticContainerResult => {
   const minPercentRef = useRef(minPercent)
   const maxPercentRef = useRef(maxPercent)
   const initialPercentRef = useRef(initialPercent)
+  const reservedPxRef = useRef(reservedPx)
 
   const [pixelMin, setPixelMin] = useState(0)
   const [pixelMax, setPixelMax] = useState(Number.MAX_SAFE_INTEGER)
+  const [effectiveDimension, setEffectiveDimension] = useState(0)
 
   const pixelMinRef = useRef(0)
   const pixelMaxRef = useRef(Number.MAX_SAFE_INTEGER)
@@ -101,9 +111,10 @@ export const useElasticContainer = ({
 
     pendingClampRef.current = false
 
+    const effective = Math.max(1, dimensionRef.current - reservedPxRef.current)
     const targetPx =
       dimensionRef.current > 0
-        ? Math.round(dimensionRef.current * desiredPercentRef.current)
+        ? Math.round(effective * desiredPercentRef.current)
         : sizeRef.current
     resetToSize(targetPx, pixelMinRef.current, pixelMaxRef.current)
   }, [isDragging, resetToSize])
@@ -117,9 +128,10 @@ export const useElasticContainer = ({
 
       return
     }
+    const effective = Math.max(1, dimensionRef.current - reservedPxRef.current)
     if (dimensionRef.current > 0) {
       desiredPercentRef.current = Math.min(
-        Math.max(sizeRef.current / dimensionRef.current, minPercentRef.current),
+        Math.max(sizeRef.current / effective, minPercentRef.current),
         maxPercentRef.current
       )
     }
@@ -141,8 +153,9 @@ export const useElasticContainer = ({
         )
       }
 
-      const newMin = Math.ceil(dimension * configuredMin)
-      let newMax = Math.floor(dimension * configuredMax)
+      const effective = Math.max(1, dimension - reservedPxRef.current)
+      const newMin = Math.ceil(effective * configuredMin)
+      let newMax = Math.floor(effective * configuredMax)
 
       if (newMin >= newMax) {
         newMax = newMin + 1
@@ -173,14 +186,16 @@ export const useElasticContainer = ({
       )
     }
 
+    const effective = Math.max(1, dimension - reservedPxRef.current)
     dimensionRef.current = dimension
+    setEffectiveDimension(effective)
 
     const { newMin, newMax } = computeBounds(dimension)
 
     const effectiveInitial =
       initialPercentRef.current ??
       (minPercentRef.current + maxPercentRef.current) / 2
-    const nextInitial = clampSize(dimension * effectiveInitial, newMin, newMax)
+    const nextInitial = clampSize(effective * effectiveInitial, newMin, newMax)
     desiredPercentRef.current = effectiveInitial
 
     pixelMinRef.current = newMin
@@ -202,6 +217,8 @@ export const useElasticContainer = ({
       }
 
       dimensionRef.current = nextDimension
+      const effective = Math.max(1, nextDimension - reservedPxRef.current)
+      setEffectiveDimension(effective)
 
       const { newMin: resizedMin, newMax: resizedMax } =
         computeBounds(nextDimension)
@@ -221,7 +238,7 @@ export const useElasticContainer = ({
       // Use desiredPercentRef so shrink→expand cycles restore the user's
       // original proportion rather than anchoring to a clamped pixel value.
       const proportionalPx = Math.round(
-        nextDimension * desiredPercentRef.current
+        effective * desiredPercentRef.current
       )
       resetToSize(proportionalPx, resizedMin, resizedMax)
     })
@@ -240,5 +257,6 @@ export const useElasticContainer = ({
     ...resizable,
     pixelMin,
     pixelMax,
+    effectiveDimension,
   }
 }


### PR DESCRIPTION
## Summary
Drag-to-resize between panes for every non-`single` layout (vsplit, hsplit,
threeRight, quad), reusing the dock's elastic-resize machinery.

- Extract a shared `ResizeHandle` primitive and migrate `DockPanel`'s two inline
  handles to it (pure refactor; DockPanel tests unchanged).
- `useElasticContainer`: backward-compatible `reservedPx` (+ exposed
  `effectiveDimension`); `reservedPx: 0` leaves the dock unchanged.
- `resolveGrid` + `SPLIT_ELASTIC_CONFIG`: divider-aware grid templates — the
  inter-pane gap becomes a draggable divider track.
- `useSplitDivider`: bridges the hook to the grid via two `fr` CSS vars that
  always sum to 1 (grid always fills), covering drag + keyboard + ResizeObserver.
- Per-layout `SplitDividers` subcomponents (fixed hook counts) + `SplitView`
  wiring: padding wrapper, remember-within-session ratio state, `hasSize`-gated
  active-only divider mount (avoids the zero-dimension mount throw).
- Spec + plan under `docs/superpowers/` (codex-reviewed).

## Test plan
- [x] `npm run test` — full suite green (2671 passed / 3 skipped)
- [x] `npm run lint` / `type-check` / `format:check` — clean
- [x] `DockPanel.test.tsx` regression net — 57/57 green
- [x] Manual: dragged dividers in all four layouts; panes fill the canvas, 15–85% clamp holds, ratio persists across layout cycle + tab switch
- [x] `codex review --base main` — clean, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
