### PR TITLE
feat(diff): functional hunk navigation (PR3 of 4)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                              | Category           | Findings | Refs | Last Updated |
 | -------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security           | 21       | 3    | 2026-05-20   |
-| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 22       | 8    | 2026-05-25   |
+| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 23       | 8    | 2026-05-27   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 3        | 3    | 2026-05-24   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 4        | 3    | 2026-05-07   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality       | 5        | 0    | 2026-05-09   |

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,7 +2,7 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-05-25
+last_updated: 2026-05-27
 ref_count: 8
 ---
 
@@ -212,4 +212,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/diff/components/toolbar/PriorityPlus.tsx`
 - **Finding:** PriorityPlus used `container.clientWidth` with `lastVisible.offsetLeft + offsetWidth` to reserve space for the overflow chip. In the docked diff panel, the wrapper's `offsetParent` is a positioned ancestor outside the toolbar, so the item coordinate included the file-list offset while the container width did not. The toolbar hid one extra chip whenever overflow started.
 - **Fix:** Measure both the container and last visible item with `getBoundingClientRect()` and subtract viewport-relative `right` values. Added a regression test that simulates a toolbar offset by the file list and proves the last fitting chip stays visible.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 23. Index-into-data reset effect missed the same-collection shrink case
+
+- **Source:** github-claude + github-codex-connector | PR #284 | 2026-05-27
+- **Severity:** HIGH
+- **File:** `src/features/diff/components/DiffPanelContent.tsx`
+- **Finding:** `focusedHunkIndex` was reset to 0 only on `[selectedFilePath, selectedFileStaged]` change. Staging/discarding a hunk reloads the SAME file with fewer hunks (path + staged unchanged), so the reset never fired — the stale index pointed out of range, the hunk counter rendered an invalid value (e.g. "3/2", with no `Math.min` clamp unlike the sibling file counter), and per-hunk stage/unstage/discard silently no-op'd via the `focusedHunk === null` guard until the user manually navigated. The reset effect's dependency set covered file-identity changes but not the equivalent "the indexed collection shrank under a held index" case.
+- **Fix:** Added a clamp effect keyed on `hunkCount` (`setFocusedHunkIndex((prev) => Math.min(prev, hunkCount - 1))`) plus a derived `clampedHunkIndex` (`hunkCount > 0 ? Math.min(focusedHunkIndex, hunkCount - 1) : 0`) used for the focused hunk, `selectedLines`, and the toolbar counter — so the single render between the shrink and the effect firing also stays in range. Lesson: when state holds an index/cursor into a refetchable collection, the clamp must key on the collection length, not only on the identity that selected it. Regression test: focus the last of 3 hunks, reload the same file with 2 hunks, assert the counter clamps to "2/2" (never "3/2") and `selectedLines` stays non-null.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -70,10 +70,16 @@ vi.mock('@pierre/diffs/react', () => ({
     oldFile,
     newFile,
     options,
+    selectedLines = undefined,
   }: {
     oldFile: { name: string; contents: string }
     newFile: { name: string; contents: string }
     options: { diffStyle?: string; theme?: string; lineDiffType?: string }
+    selectedLines?: {
+      start: number
+      end: number
+      side?: string
+    } | null
   }): ReactElement => (
     <div
       data-testid="multi-file-diff"
@@ -84,6 +90,13 @@ vi.mock('@pierre/diffs/react', () => ({
       data-diff-style={options.diffStyle}
       data-theme={options.theme}
       data-line-diff-type={options.lineDiffType}
+      data-selected-lines-start={
+        selectedLines != null ? String(selectedLines.start) : undefined
+      }
+      data-selected-lines-end={
+        selectedLines != null ? String(selectedLines.end) : undefined
+      }
+      data-selected-lines-side={selectedLines?.side ?? undefined}
     >
       MultiFileDiff stub
     </div>
@@ -1679,6 +1692,256 @@ describe('DiffPanelContent', () => {
       expect(
         await screen.findByText(/Failed to discard hunk: discard err/)
       ).toBeInTheDocument()
+    })
+  })
+
+  describe('Hunk navigation (PR3)', () => {
+    // Three-hunk fixture:
+    //   hunk 0: additions, newStart=1, newLines=3   → selectedLines: start=1,end=3,side=additions
+    //   hunk 1: additions, newStart=20, newLines=4  → selectedLines: start=20,end=23,side=additions
+    //   hunk 2: deletion-only, oldStart=50, oldLines=2, newLines=0
+    //                                               → selectedLines: start=50,end=51,side=deletions
+    const threeHunkDiff: FileDiff = {
+      filePath: 'src/multi.ts',
+      oldPath: 'src/multi.ts',
+      newPath: 'src/multi.ts',
+      hunks: [
+        {
+          id: 'hunk-0',
+          header: '@@ -1,3 +1,3 @@',
+          oldStart: 1,
+          oldLines: 3,
+          newStart: 1,
+          newLines: 3,
+          lines: [],
+        },
+        {
+          id: 'hunk-1',
+          header: '@@ -20,4 +20,4 @@',
+          oldStart: 20,
+          oldLines: 4,
+          newStart: 20,
+          newLines: 4,
+          lines: [],
+        },
+        {
+          id: 'hunk-2',
+          header: '@@ -50,2 +50,0 @@',
+          oldStart: 50,
+          oldLines: 2,
+          newStart: 50,
+          newLines: 0,
+          lines: [],
+        },
+      ],
+    }
+
+    beforeEach(() => {
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: [{ path: 'src/multi.ts', status: 'modified', staged: false }],
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      })
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: threeHunkDiff,
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText: 'new',
+          rawDiff: '',
+        })
+      )
+    })
+
+    test('initial render: selectedLines derived from hunk 0 (additions)', (): void => {
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      const diff = screen.getByTestId('multi-file-diff')
+      expect(diff.getAttribute('data-selected-lines-start')).toBe('1')
+      expect(diff.getAttribute('data-selected-lines-end')).toBe('3')
+      expect(diff.getAttribute('data-selected-lines-side')).toBe('additions')
+    })
+
+    test('counter shows 1/3 on initial render', (): void => {
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      expect(screen.getByLabelText(/hunk 1\/3/i)).toBeInTheDocument()
+    })
+
+    test('clicking next-hunk advances focus: counter 2/3 and selectedLines from hunk 1', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /next hunk/i }))
+
+      expect(screen.getByLabelText(/hunk 2\/3/i)).toBeInTheDocument()
+
+      const diff = screen.getByTestId('multi-file-diff')
+      expect(diff.getAttribute('data-selected-lines-start')).toBe('20')
+      expect(diff.getAttribute('data-selected-lines-end')).toBe('23')
+      expect(diff.getAttribute('data-selected-lines-side')).toBe('additions')
+    })
+
+    test('clicking next-hunk three times wraps from last hunk back to first', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      // Advance to hunk 2 (index 2)
+      await user.click(screen.getByRole('button', { name: /next hunk/i }))
+      await user.click(screen.getByRole('button', { name: /next hunk/i }))
+      // Wrap around to hunk 0 (index 0)
+      await user.click(screen.getByRole('button', { name: /next hunk/i }))
+
+      expect(screen.getByLabelText(/hunk 1\/3/i)).toBeInTheDocument()
+
+      const diff = screen.getByTestId('multi-file-diff')
+      expect(diff.getAttribute('data-selected-lines-start')).toBe('1')
+      expect(diff.getAttribute('data-selected-lines-side')).toBe('additions')
+    })
+
+    test('clicking prev-hunk from first hunk wraps to last hunk', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /prev hunk/i }))
+
+      expect(screen.getByLabelText(/hunk 3\/3/i)).toBeInTheDocument()
+
+      const diff = screen.getByTestId('multi-file-diff')
+      // Hunk 2 is deletion-only: oldStart=50, oldLines=2 → side=deletions, start=50, end=51
+      expect(diff.getAttribute('data-selected-lines-start')).toBe('50')
+      expect(diff.getAttribute('data-selected-lines-end')).toBe('51')
+      expect(diff.getAttribute('data-selected-lines-side')).toBe('deletions')
+    })
+
+    test('deletion-only hunk yields side=deletions using old-side coordinates', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      // Advance to hunk 2 (the deletion-only one)
+      await user.click(screen.getByRole('button', { name: /next hunk/i }))
+      await user.click(screen.getByRole('button', { name: /next hunk/i }))
+
+      expect(screen.getByLabelText(/hunk 3\/3/i)).toBeInTheDocument()
+
+      const diff = screen.getByTestId('multi-file-diff')
+      expect(diff.getAttribute('data-selected-lines-start')).toBe('50')
+      expect(diff.getAttribute('data-selected-lines-end')).toBe('51')
+      expect(diff.getAttribute('data-selected-lines-side')).toBe('deletions')
+    })
+
+    test('reset-on-file-change: focus resets to hunk 0 when selected file changes', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const onSelectedFileChange = vi.fn()
+
+      // Two files: multi.ts (3 hunks) and other.ts (1 hunk)
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: [
+          { path: 'src/multi.ts', status: 'modified', staged: false },
+          { path: 'src/other.ts', status: 'modified', staged: false },
+        ],
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      })
+
+      const { rerender } = render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={onSelectedFileChange}
+        />
+      )
+
+      // Advance to hunk 2 on multi.ts
+      await user.click(screen.getByRole('button', { name: /next hunk/i }))
+      await user.click(screen.getByRole('button', { name: /next hunk/i }))
+      expect(screen.getByLabelText(/hunk 3\/3/i)).toBeInTheDocument()
+
+      // Switch to a different file (1 hunk only)
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: {
+            filePath: 'src/other.ts',
+            oldPath: 'src/other.ts',
+            newPath: 'src/other.ts',
+            hunks: [
+              {
+                id: 'hunk-0',
+                header: '@@ -5,2 +5,2 @@',
+                oldStart: 5,
+                oldLines: 2,
+                newStart: 5,
+                newLines: 2,
+                lines: [],
+              },
+            ],
+          },
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText: 'new',
+          rawDiff: '',
+        })
+      )
+
+      rerender(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/other.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={onSelectedFileChange}
+        />
+      )
+
+      // Focus must reset to 0: counter shows 1/1 (not 3/3 or out-of-range)
+      expect(screen.getByLabelText(/hunk 1\/1/i)).toBeInTheDocument()
     })
   })
 })

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -1943,5 +1943,59 @@ describe('DiffPanelContent', () => {
       // Focus must reset to 0: counter shows 1/1 (not 3/3 or out-of-range)
       expect(screen.getByLabelText(/hunk 1\/1/i)).toBeInTheDocument()
     })
+
+    test('clamp-on-shrink: same-file refetch with fewer hunks clamps focus (valid counter, staging not blocked)', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      const { rerender } = render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      // Focus the last hunk of the 3-hunk file (prev from hunk 0 wraps to 3/3).
+      await user.click(screen.getByRole('button', { name: /prev hunk/i }))
+      expect(screen.getByLabelText(/hunk 3\/3/i)).toBeInTheDocument()
+
+      // Simulate a stage/discard refetch: SAME file (path + staged unchanged)
+      // but the hunk array shrank 3 → 2 (the focused last hunk was discarded).
+      // The file-change reset must NOT fire here; only the hunk-count clamp.
+      const twoHunkDiff: FileDiff = {
+        filePath: 'src/multi.ts',
+        oldPath: 'src/multi.ts',
+        newPath: 'src/multi.ts',
+        hunks: [threeHunkDiff.hunks[0], threeHunkDiff.hunks[1]],
+      }
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: twoHunkDiff,
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText: 'new',
+          rawDiff: '',
+        })
+      )
+
+      rerender(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      // Index 2 clamps to 1: counter is the valid "2/2", never the invalid "3/2".
+      expect(screen.getByLabelText(/hunk 2\/2/i)).toBeInTheDocument()
+      expect(screen.queryByLabelText(/hunk 3\/2/i)).not.toBeInTheDocument()
+
+      // focusedHunk resolves to the now-last hunk (index 1) — selectedLines is
+      // non-null, so per-hunk staging is not silently blocked.
+      const diff = screen.getByTestId('multi-file-diff')
+      expect(diff.getAttribute('data-selected-lines-start')).toBe('20')
+      expect(diff.getAttribute('data-selected-lines-side')).toBe('additions')
+    })
   })
 })

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -264,7 +264,29 @@ export const DiffPanelContent = ({
     setFocusedHunkIndex(0)
   }, [selectedFilePath, selectedFileStaged])
 
-  const focusedHunk = response?.fileDiff.hunks[focusedHunkIndex] ?? null
+  const hunkCount = response?.fileDiff.hunks.length ?? 0
+
+  // Clamp focusedHunkIndex when the hunk array shrinks WITHOUT a file change.
+  // Staging/discarding a hunk reloads the SAME file with fewer hunks, so the
+  // file-change reset above does not fire (path + staged are unchanged). A
+  // stale index would then point out of range: focusedHunk goes null, the
+  // counter renders an invalid value (e.g. "3/2"), and stage/unstage/discard
+  // silently no-op until the user manually navigates. Clamp to the last valid
+  // index — preserves position for middle-hunk staging, only adjusting at the
+  // boundary. (PR3 review: Claude HIGH + codex P2.)
+  useEffect(() => {
+    if (hunkCount > 0) {
+      setFocusedHunkIndex((prev) => Math.min(prev, hunkCount - 1))
+    }
+  }, [hunkCount])
+
+  // Read the index through a clamp so the single render between a hunk-count
+  // shrink and the effect above can't surface a stale/out-of-range value — the
+  // counter, focused hunk, and selection all stay valid even on that frame.
+  const clampedHunkIndex =
+    hunkCount > 0 ? Math.min(focusedHunkIndex, hunkCount - 1) : 0
+
+  const focusedHunk = response?.fileDiff.hunks[clampedHunkIndex] ?? null
 
   const onPrevHunk = useCallback((): void => {
     if (!response) {
@@ -297,7 +319,7 @@ export const DiffPanelContent = ({
   // deletions column; all other hunks use the new-side (additions).
   const selectedLines: SelectedLineRange | null =
     useMemo((): SelectedLineRange | null => {
-      const hunk = response?.fileDiff.hunks[focusedHunkIndex]
+      const hunk = response?.fileDiff.hunks[clampedHunkIndex]
       if (!hunk) {
         return null
       }
@@ -315,7 +337,7 @@ export const DiffPanelContent = ({
         end: lineStart + Math.max(lineCount - 1, 0),
         side,
       }
-    }, [response, focusedHunkIndex])
+    }, [response, clampedHunkIndex])
 
   // Shared helper for all three hunk-based staging operations. Extracts the
   // focused hunk patch, calls the provided service operation, then refreshes
@@ -770,8 +792,8 @@ export const DiffPanelContent = ({
             onDisableFileHeaderChange={setDisableFileHeader}
             stickyHeader={stickyHeader}
             onStickyHeaderChange={setStickyHeader}
-            totalHunks={response?.fileDiff.hunks.length ?? 0}
-            focusedHunkIndex={focusedHunkIndex}
+            totalHunks={hunkCount}
+            focusedHunkIndex={clampedHunkIndex}
             onPrevHunk={onPrevHunk}
             onNextHunk={onNextHunk}
             onPrevFile={(): void => goToFile(-1)}

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -8,7 +8,11 @@ import {
   useRef,
 } from 'react'
 import { MultiFileDiff, useWorkerPool } from '@pierre/diffs/react'
-import type { BaseDiffOptions, DiffsThemeNames } from '@pierre/diffs'
+import type {
+  BaseDiffOptions,
+  DiffsThemeNames,
+  SelectedLineRange,
+} from '@pierre/diffs'
 import { useGitStatus, type UseGitStatusReturn } from '../hooks/useGitStatus'
 import { useFileDiff } from '../hooks/useFileDiff'
 import { ChangedFilesList } from './ChangedFilesList'
@@ -246,9 +250,72 @@ export const DiffPanelContent = ({
   // Single-flight staging flag — drops clicks while an IPC is in flight.
   const [staging, setStaging] = useState(false)
 
-  // PR2: focusedHunk defaults to the first hunk until PR3 wires prev/next
-  // navigation. Null when there are no hunks (whole-file operations only).
-  const focusedHunk = response?.fileDiff.hunks[0] ?? null
+  // PR3: focusedHunkIndex is the 0-based index into response.fileDiff.hunks.
+  // Replaced the PR2 hardcoded `[0]` so prev/next navigation can step through
+  // hunks. Null when there are no hunks (whole-file operations only).
+  const [focusedHunkIndex, setFocusedHunkIndex] = useState(0)
+
+  // Reset focusedHunkIndex to 0 when the selected file changes. Without this,
+  // a stale index (e.g. 2) would point out of range when switching to a file
+  // with fewer hunks — focusedHunk would be undefined and staging would no-op.
+  // Key off the (path, staged) pair that uniquely identifies the file, matching
+  // how useFileDiff and selectedFileEntry are driven.
+  useEffect(() => {
+    setFocusedHunkIndex(0)
+  }, [selectedFilePath, selectedFileStaged])
+
+  const focusedHunk = response?.fileDiff.hunks[focusedHunkIndex] ?? null
+
+  const onPrevHunk = useCallback((): void => {
+    if (!response) {
+      return
+    }
+
+    const len = response.fileDiff.hunks.length
+    if (len === 0) {
+      return
+    }
+
+    setFocusedHunkIndex((prev) => (prev + len - 1) % len)
+  }, [response])
+
+  const onNextHunk = useCallback((): void => {
+    if (!response) {
+      return
+    }
+
+    const len = response.fileDiff.hunks.length
+    if (len === 0) {
+      return
+    }
+
+    setFocusedHunkIndex((prev) => (prev + 1) % len)
+  }, [response])
+
+  // Derive the Pierre selectedLines from the focused hunk. Deletion-only hunks
+  // (newLines === 0) use the old-side coordinates so the highlight lands on the
+  // deletions column; all other hunks use the new-side (additions).
+  const selectedLines: SelectedLineRange | null =
+    useMemo((): SelectedLineRange | null => {
+      const hunk = response?.fileDiff.hunks[focusedHunkIndex]
+      if (!hunk) {
+        return null
+      }
+
+      const isDeletionOnly = hunk.newLines === 0
+      const lineStart = isDeletionOnly ? hunk.oldStart : hunk.newStart
+      const lineCount = isDeletionOnly ? hunk.oldLines : hunk.newLines
+
+      const side = isDeletionOnly
+        ? ('deletions' as const)
+        : ('additions' as const)
+
+      return {
+        start: lineStart,
+        end: lineStart + Math.max(lineCount - 1, 0),
+        side,
+      }
+    }, [response, focusedHunkIndex])
 
   // Shared helper for all three hunk-based staging operations. Extracts the
   // focused hunk patch, calls the provided service operation, then refreshes
@@ -704,7 +771,9 @@ export const DiffPanelContent = ({
             stickyHeader={stickyHeader}
             onStickyHeaderChange={setStickyHeader}
             totalHunks={response?.fileDiff.hunks.length ?? 0}
-            focusedHunkIndex={0}
+            focusedHunkIndex={focusedHunkIndex}
+            onPrevHunk={onPrevHunk}
+            onNextHunk={onNextHunk}
             onPrevFile={(): void => goToFile(-1)}
             onNextFile={(): void => goToFile(1)}
             currentFileIndex={currentFileIndex}
@@ -763,6 +832,7 @@ export const DiffPanelContent = ({
                 key={`${renderedTheme}:${renderedLineDiffType}`}
                 oldFile={pierreInputs.oldFile}
                 newFile={pierreInputs.newFile}
+                selectedLines={selectedLines}
                 options={{
                   diffStyle: effectiveDiffStyle,
                   theme: renderedTheme,

--- a/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
@@ -538,6 +538,74 @@ describe('DiffChipToolbar', () => {
     })
   })
 
+  describe('Hunk navigation chips — PR3 functional mode', () => {
+    test('clicking next-hunk chip calls onNextHunk', async () => {
+      const user = userEvent.setup()
+      const onNextHunk = vi.fn<() => void>()
+
+      renderToolbar({ onNextHunk, onPrevHunk: vi.fn(), totalHunks: 3 })
+
+      await user.click(screen.getByRole('button', { name: /next hunk/i }))
+      expect(onNextHunk).toHaveBeenCalledTimes(1)
+    })
+
+    test('clicking prev-hunk chip calls onPrevHunk', async () => {
+      const user = userEvent.setup()
+      const onPrevHunk = vi.fn<() => void>()
+
+      renderToolbar({ onPrevHunk, onNextHunk: vi.fn(), totalHunks: 3 })
+
+      await user.click(screen.getByRole('button', { name: /prev hunk/i }))
+      expect(onPrevHunk).toHaveBeenCalledTimes(1)
+    })
+
+    test('hunk chips are enabled when totalHunks > 1 and handlers provided', () => {
+      renderToolbar({
+        onPrevHunk: vi.fn(),
+        onNextHunk: vi.fn(),
+        totalHunks: 3,
+        focusedHunkIndex: 1,
+      })
+
+      expect(
+        screen.getByRole('button', { name: /prev hunk/i })
+      ).not.toBeDisabled()
+
+      expect(
+        screen.getByRole('button', { name: /next hunk/i })
+      ).not.toBeDisabled()
+    })
+
+    test('hunk chips are disabled when totalHunks <= 1', async () => {
+      const user = userEvent.setup()
+      const onPrevHunk = vi.fn<() => void>()
+      const onNextHunk = vi.fn<() => void>()
+
+      renderToolbar({
+        onPrevHunk,
+        onNextHunk,
+        totalHunks: 1,
+        focusedHunkIndex: 0,
+      })
+
+      const prev = screen.getByRole('button', { name: /prev hunk/i })
+      const next = screen.getByRole('button', { name: /next hunk/i })
+      expect(prev).toBeDisabled()
+      expect(next).toBeDisabled()
+
+      await user.click(prev)
+      await user.click(next)
+      expect(onPrevHunk).not.toHaveBeenCalled()
+      expect(onNextHunk).not.toHaveBeenCalled()
+    })
+
+    test('counter shows focusedHunkIndex + 1 / totalHunks', () => {
+      renderToolbar({ totalHunks: 3, focusedHunkIndex: 1 })
+
+      expect(screen.getByLabelText(/hunk 2\/3/i)).toBeInTheDocument()
+    })
+  })
+
   test('PriorityPlus collapses the lower-priority chips into the overflow menu at a narrow width', () => {
     renderToolbar({ diffMode: 'unstaged' })
 

--- a/src/features/diff/components/toolbar/DiffChipToolbar.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.tsx
@@ -117,6 +117,12 @@ export interface DiffChipToolbarProps {
   // counter always renders the position as `currentFileIndex + 1 / totalFiles`.
   currentFileIndex: number
   totalFiles: number
+  // Hunk navigation handlers — FUNCTIONAL in PR3. When provided the prev/next
+  // hunk chips become interactive; omitting them leaves them disabled. Both
+  // must be provided together for the chips to enable (mirrors the file-nav
+  // pattern).
+  onPrevHunk?: () => void
+  onNextHunk?: () => void
   // Staging actions — FUNCTIONAL in PR2. When provided the staging chips
   // become interactive; omitting them (or passing `staging === true`) leaves
   // the chips disabled so pre-PR2 callers remain unaffected.
@@ -308,7 +314,8 @@ const DiscardAllConfirm = ({
 // it only changes which file is selected, so no Rust backend is needed.
 // Staging chips (stage / unstage / discard / discard all) are FUNCTIONAL
 // in PR2 when the on* handlers are provided. Hunk prev/next/counter chips
-// remain disabled placeholders until PR3.
+// are FUNCTIONAL in PR3 when onPrevHunk/onNextHunk are provided and there
+// is more than one hunk.
 export const DiffChipToolbar = ({
   diffMode,
   diffStyle,
@@ -331,6 +338,8 @@ export const DiffChipToolbar = ({
   onStickyHeaderChange,
   totalHunks = 0,
   focusedHunkIndex = 0,
+  onPrevHunk = undefined,
+  onNextHunk = undefined,
   onPrevFile = undefined,
   onNextFile = undefined,
   currentFileIndex,
@@ -387,6 +396,11 @@ export const DiffChipToolbar = ({
   const fileNavEnabled =
     onPrevFile !== undefined && onNextFile !== undefined && totalFiles > 1
 
+  // Hunk arrows are functional when both handlers are present AND there is
+  // more than one hunk to navigate. With <= 1 hunk they render disabled.
+  const hunkNavEnabled =
+    onPrevHunk !== undefined && onNextHunk !== undefined && totalHunks > 1
+
   // Build the chip list in priority order. Highest priority first → last to
   // overflow into the `…` menu when the toolbar is narrow.
   //
@@ -428,23 +442,32 @@ export const DiffChipToolbar = ({
       onClick={onNextFile}
       disabled={!fileNavEnabled}
     />,
-    // 5. prev hunk — disabled placeholder in PR1; PR3 wires the click.
-    <ComingSoonTooltip key="prev-hunk" label="Available in PR3">
-      <DisabledIconChip icon="chevron_left" label="prev hunk" />
-    </ComingSoonTooltip>,
+    // 5. prev hunk — FUNCTIONAL in PR3 when onPrevHunk is provided and
+    // totalHunks > 1. Disabled (inert, no tooltip) when only one hunk.
+    <IconChip
+      key="prev-hunk"
+      icon="chevron_left"
+      label="prev hunk"
+      onClick={onPrevHunk}
+      disabled={!hunkNavEnabled}
+    />,
     // 6. hunk N/M counter — text chip with the `data_object` icon (code/hunks)
-    // so it reads distinctly from the file counter. Reads `1/totalHunks` until
-    // PR3 starts mutating the focus index.
+    // so it reads distinctly from the file counter. Now shows the real
+    // focusedHunkIndex once PR3 wires the navigation state.
     <CounterChip
       key="hunk-counter"
       icon="data_object"
       label={`hunk ${hunkCounterText}`}
       text={hunkCounterText}
     />,
-    // 7. next hunk — disabled placeholder in PR1; PR3 wires the click.
-    <ComingSoonTooltip key="next-hunk" label="Available in PR3">
-      <DisabledIconChip icon="chevron_right" label="next hunk" />
-    </ComingSoonTooltip>,
+    // 7. next hunk — FUNCTIONAL in PR3 counterpart to prev hunk.
+    <IconChip
+      key="next-hunk"
+      icon="chevron_right"
+      label="next hunk"
+      onClick={onNextHunk}
+      disabled={!hunkNavEnabled}
+    />,
     // 8. stage — FUNCTIONAL in PR2 when onStage is provided.
     onStage !== undefined ? (
       <IconChip


### PR DESCRIPTION
PR3 of the @pierre/diffs integration (#255). Follows PR2 (#280). Makes the prev/next-hunk toolbar chips — disabled "Available in PR3" placeholders since PR1 — functional. Frontend-only: no IPC, no renderer swap.

## What it does
- Adds `focusedHunkIndex` toolbar state in `DiffPanelContent` (replacing PR2's hardcoded first-hunk), with wrap-around `onPrevHunk`/`onNextHunk` handlers.
- Derives Pierre's `selectedLines` controlled prop from the focused hunk and passes it to `<MultiFileDiff>` (deletion-only hunks use the old-side coords + `side: 'deletions'`; otherwise new-side + `'additions'`). Navigating updates `selectedLines` as a controlled prop — no remount/re-tokenize.
- Resets the focused index to the first hunk when the selected file changes (avoids a stale index pointing out of range).
- Lifts the disabled prev/next-hunk chips + the `N/M` counter in `DiffChipToolbar` (disabled only when ≤1 hunk).
- The focused hunk now also drives **PR2's per-hunk staging** (shared `focusedHunk`) — navigate, then stage/unstage/discard acts on the focused hunk.

## Known limitation (documented follow-up)
Pierre's `selectedLines` sets the selection highlight; whether it auto-scrolls an off-screen hunk into view is internal to Pierre and unverified here (no GUI in the build env). If it doesn't, a follow-up will `scrollIntoView` the selected element. The selection is the source-of-truth focused-hunk state regardless.

## Test plan
- `npm run type-check`, `npm run lint` ✓
- `npm run test` → 2772 passed (12 new: nav, wrap-around both directions, `selectedLines` derivation, deletion-only side, reset-on-file-change, chip enable/disable) ✓
- `npm run build` ✓
- Independent codex pass: no findings.
- Manual Electron E2E (highlight moves on nav; staging acts on the navigated hunk) deferred — no GUI in the implementation env.

(CI Actions are currently disabled on the repo, so this PR has no green checks; verified locally instead.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)