### PR TITLE
fix(agent-status): reset run-scoped status when an agent exits in a live pane

### DIFF
--- a/src/features/agent-status/hooks/useAgentStatus.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.test.ts
@@ -1570,4 +1570,116 @@ describe('useAgentStatus', () => {
     expect(result.current.isActive).toBe(false)
     expect(result.current.agentExited).toBe(false)
   })
+
+  test('clears run-scoped status after the exit-hold expires when an agent exits in a live pane', async () => {
+    // Bug: exiting an agent inside a pane WITHOUT closing the pane left the
+    // activity panel painting the dead agent's frozen snapshot — context
+    // window, tool-call counts, and the activity feed — indefinitely. The
+    // exit-collapse only flipped isActive/agentExited and retained every
+    // run-scoped metric, and the panel renders those fields unconditionally.
+    // After EXIT_HOLD_MS the panel must return to a clean idle state, not a
+    // stale snapshot of the agent that just exited.
+    const PTY_ID = 'pty-session-1'
+    let detectCallCount = 0
+
+    vi.mocked(invoke).mockImplementation(((cmd: string) => {
+      if (cmd === 'detect_agent_in_session') {
+        detectCallCount += 1
+        // First poll: agent present. Subsequent polls: agent exited but the
+        // PTY/pane stays alive (user typed `exit`, dropped back to the shell).
+        if (detectCallCount === 1) {
+          return Promise.resolve({
+            sessionId: PTY_ID,
+            agentType: 'claudeCode',
+            pid: 4242,
+          })
+        }
+
+        return Promise.resolve(null)
+      }
+
+      return Promise.resolve(null)
+    }) as unknown as typeof invoke)
+
+    const { result } = renderHook(() => useAgentStatus('session-1'))
+
+    // Agent detected → active, all listeners attached.
+    await vi.waitFor(() => {
+      expect(result.current.isActive).toBe(true)
+      expect(eventListeners.get('agent-status')?.length).toBe(1)
+      expect(eventListeners.get('agent-tool-call')?.length).toBe(1)
+      expect(eventListeners.get('agent-turn')?.length).toBe(1)
+    })
+
+    // Populate the run-scoped metrics the panel renders.
+    act(() => {
+      emit('agent-status', {
+        sessionId: PTY_ID,
+        modelId: 'claude-opus-4-7',
+        modelDisplayName: 'Claude Opus 4.7',
+        version: '2.1.0',
+        agentSessionId: 'cc-session',
+        contextWindow: {
+          usedPercentage: 8,
+          remainingPercentage: 92,
+          contextWindowSize: 1000000,
+          totalInputTokens: 88964,
+          totalOutputTokens: 0,
+          currentUsage: {
+            inputTokens: 80000,
+            outputTokens: 0,
+            cacheCreationInputTokens: 140,
+            cacheReadInputTokens: 80000,
+          },
+        },
+        cost: null,
+        rateLimits: null,
+      })
+
+      emit('agent-tool-call', {
+        sessionId: PTY_ID,
+        toolUseId: 'toolu_1',
+        tool: 'Bash',
+        args: '{"cmd":"echo hi"}',
+        status: 'done',
+        timestamp: '2026-05-27T00:00:00Z',
+        durationMs: 12,
+      })
+
+      emit('agent-turn', {
+        sessionId: PTY_ID,
+        numTurns: 6,
+      })
+    })
+
+    expect(result.current.contextWindow?.usedPercentage).toBe(8)
+    expect(result.current.toolCalls.total).toBe(1)
+    expect(result.current.recentToolCalls).toHaveLength(1)
+    expect(result.current.numTurns).toBe(6)
+
+    // Agent exits: next poll returns null → exit-hold begins. The final
+    // snapshot is intentionally held for EXIT_HOLD_MS (5s).
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.agentExited).toBe(true)
+    expect(result.current.toolCalls.total).toBe(1) // still held during the hold window
+
+    // After the exit-hold expires, the panel resets to a clean idle state.
+    await act(async () => {
+      vi.advanceTimersByTime(6000)
+      await Promise.resolve()
+    })
+
+    expect(result.current.isActive).toBe(false)
+    expect(result.current.agentExited).toBe(false)
+    expect(result.current.contextWindow).toBeNull()
+    expect(result.current.toolCalls.total).toBe(0)
+    expect(result.current.toolCalls.byType).toEqual({})
+    expect(result.current.recentToolCalls).toEqual([])
+    expect(result.current.numTurns).toBe(0)
+  })
 })

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -331,15 +331,21 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
           prev.sessionId === sid ? { ...prev, agentExited: true } : prev
         )
 
-        // Hold final state for 5s, then collapse. Runs regardless of
-        // watcherStartedRef — that's the F1 fix: a transient
-        // start_agent_watcher failure no longer blocks collapse.
+        // Hold the final snapshot for 5s, then reset the panel to a clean
+        // idle state. Reset to the full default rather than only flipping
+        // isActive/agentExited: the panel renders run-scoped metrics
+        // (context window, tool calls, activity feed, tests, turns)
+        // unconditionally, so retaining them here leaves a dead agent's
+        // frozen snapshot painting the panel forever while the PTY/pane
+        // stays alive (agent exited without closing the pane). Mirrors the
+        // session-change and agent-process-change resets above.
+        //
+        // Runs regardless of watcherStartedRef — that's the F1 fix: a
+        // transient start_agent_watcher failure no longer blocks collapse.
         collapseTimeoutRef.current = setTimeout(() => {
           collapseTimeoutRef.current = null
           setStatus((prev) =>
-            prev.sessionId === sid
-              ? { ...prev, isActive: false, agentExited: false }
-              : prev
+            prev.sessionId === sid ? createDefaultStatus(sid) : prev
           )
         }, EXIT_HOLD_MS)
       }


### PR DESCRIPTION
## Summary

Exiting a coding agent inside a pane (e.g. typing `exit` to drop back to the shell) **without closing the pane** left the activity panel painting the dead agent's frozen snapshot — context window, token cache, tool-call counts, activity feed, tests — indefinitely.

**Root cause:** `AgentStatusPanel` renders run-scoped metrics unconditionally (no `isActive` gate) and the panel shell is a permanent workspace fixture, so the exit-collapse in `useAgentStatus` has to wipe the run state. It only flipped `isActive` / `agentExited`, retaining every metric field (`contextWindow`, `cost`, `toolCalls`, `recentToolCalls`, `testRun`, `numTurns`, …).

**Fix:** when the existing 5s exit-hold (`EXIT_HOLD_MS`) expires, reset to `createDefaultStatus(sid)` — the same wipe already used on session-change and agent-process-change. The panel returns to a clean idle state after an agent exits. The 5s hold and the F1 "collapse even if `start_agent_watcher` failed" behavior are both preserved. The cwd-mirror bridge in `WorkspaceView` is unaffected — it already bails when `!agentIsActive`.

## Test plan

- New regression test in `useAgentStatus.test.ts`: detect an agent → populate context window / tool calls / turns → agent exits (detection returns `null`) → assert metrics are still held during the 5s window → advance past `EXIT_HOLD_MS` → assert full reset (`contextWindow` null, `toolCalls` zeroed, `recentToolCalls` empty, `numTurns` 0, flags cleared).
- `npm run test` — **2734 passed / 3 skipped**, no regressions
- `npm run lint` clean · `npm run type-check` clean
- `codex review --base main` — **0 findings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
