### PR TITLE
refactor(transcript): typed lenient DTOs for both parsers (A-transcript, Phase 1)

### DIFF
--- a/crates/backend/src/agent/adapter/claude_code/mod.rs
+++ b/crates/backend/src/agent/adapter/claude_code/mod.rs
@@ -18,6 +18,7 @@ use crate::runtime::EventSink;
 pub mod statusline;
 pub mod test_runners;
 pub mod transcript;
+mod transcript_dto;
 
 #[cfg(test)]
 mod transcript_fixture_tests;

--- a/crates/backend/src/agent/adapter/claude_code/transcript.rs
+++ b/crates/backend/src/agent/adapter/claude_code/transcript.rs
@@ -318,7 +318,6 @@ fn process_line(
     }
 }
 
-/// Extract tool_use entries from an assistant message
 /// Pull the top-level `timestamp` field off a transcript line, or fall back
 /// to the current clock. Claude Code JSONL lines carry the real event time —
 /// `now_iso8601()` would otherwise stamp every event parsed in a single tick
@@ -328,6 +327,7 @@ fn extract_timestamp(timestamp: Option<&str>) -> String {
     timestamp.map(str::to_string).unwrap_or_else(now_iso8601)
 }
 
+/// Extract tool_use entries from an assistant message.
 fn process_assistant_message(
     dto: &ClaudeTranscriptLineDto,
     session_id: &str,
@@ -684,11 +684,10 @@ fn extract_tool_result_content(content: &Value) -> String {
     // A-transcript migration can pass `&dto.content`. Absent `content` (passed
     // as `Value::Null` by callers) and `null` both miss the str/array arms and
     // fall through to `""` — behavior-neutral with the prior `.get("content")`.
-    let raw = content;
-    if let Some(s) = raw.as_str() {
+    if let Some(s) = content.as_str() {
         return cap_with_head_and_tail(s);
     }
-    if let Some(arr) = raw.as_array() {
+    if let Some(arr) = content.as_array() {
         let memory_cap = MAX_TOOL_RESULT_CONTENT_LEN + TOOL_RESULT_TAIL_LEN;
         let prune_threshold = memory_cap * 2;
         let mut buf = String::new();
@@ -1255,12 +1254,21 @@ mod tests {
 
     #[test]
     fn extract_timestamp_ignores_non_string_field() {
-        // If a malformed line has a non-string timestamp (e.g. a number
-        // or null), the DTO's lenient_string deserializer degrades it to
-        // None, and extract_timestamp falls back to now_iso8601.
-        let ts = extract_timestamp(None);
+        // Integration guard for the full JSONL → DTO → fallback path: a
+        // non-string `timestamp` degrades to None via the DTO's lenient_string
+        // deserializer, so extract_timestamp falls back to now_iso8601 (this is
+        // the round-trip the migration must not lose — distinct from the
+        // extract_timestamp(None) unit case above).
+        let dto: ClaudeTranscriptLineDto = serde_json::from_str(
+            r#"{"type":"assistant","timestamp":1234567890,"message":{"content":[]}}"#,
+        )
+        .expect("line with non-string timestamp still parses");
+        assert!(
+            dto.timestamp.is_none(),
+            "non-string timestamp degrades to None via lenient_string"
+        );
 
-        // Falls back to now_iso8601 format (not the numeric literal).
+        let ts = extract_timestamp(dto.timestamp.as_deref());
         assert!(ts.ends_with('Z'));
         assert_eq!(ts.len(), 20);
     }

--- a/crates/backend/src/agent/adapter/claude_code/transcript.rs
+++ b/crates/backend/src/agent/adapter/claude_code/transcript.rs
@@ -498,7 +498,7 @@ fn process_tool_result(
 
     if let Some(matched) = call.test_match {
         // Pull the captured Bash output content.
-        let content = extract_tool_result_content(value);
+        let content = extract_tool_result_content(value.get("content").unwrap_or(&Value::Null));
         let captured = super::test_runners::types::CapturedOutput { content, is_error };
         // Build the snapshot only when we have a workspace cwd. Falling
         // back to `Path::new(".")` would canonicalise to the backend
@@ -683,11 +683,12 @@ fn days_to_date(days: u64) -> (u64, u64, u64) {
 /// Pull the textual `content` out of a tool_result JSON value.
 /// Handles both the simple-string shape and the array-of-blocks shape
 /// (where each block may carry `{type:"text", text:"..."}` payloads).
-fn extract_tool_result_content(value: &Value) -> String {
-    let raw = match value.get("content") {
-        Some(c) => c,
-        None => return String::new(),
-    };
+fn extract_tool_result_content(content: &Value) -> String {
+    // Takes the `content` *value* directly (not the enclosing block) so the
+    // A-transcript migration can pass `&dto.content`. Absent `content` (passed
+    // as `Value::Null` by callers) and `null` both miss the str/array arms and
+    // fall through to `""` — behavior-neutral with the prior `.get("content")`.
+    let raw = content;
     if let Some(s) = raw.as_str() {
         return cap_with_head_and_tail(s);
     }
@@ -852,7 +853,7 @@ mod tests {
             "content": "a".repeat(MAX_TOOL_RESULT_CONTENT_LEN + 1024)
         });
 
-        let content = extract_tool_result_content(&value);
+        let content = extract_tool_result_content(&value["content"]);
 
         assert!(content.len() < MAX_TOOL_RESULT_CONTENT_LEN + 1024);
         assert!(content.contains(TOOL_RESULT_TRUNCATED_MARKER));
@@ -881,7 +882,7 @@ mod tests {
             ]
         });
 
-        let content = extract_tool_result_content(&value);
+        let content = extract_tool_result_content(&value["content"]);
 
         assert!(content.contains(TOOL_RESULT_TRUNCATED_MARKER));
         assert!(
@@ -915,7 +916,7 @@ mod tests {
             ]
         });
 
-        let content = extract_tool_result_content(&value);
+        let content = extract_tool_result_content(&value["content"]);
 
         assert_eq!(content.len(), MAX_TOOL_RESULT_CONTENT_LEN);
         assert!(
@@ -944,7 +945,7 @@ mod tests {
             "content": &combined
         });
 
-        let content = extract_tool_result_content(&value);
+        let content = extract_tool_result_content(&value["content"]);
 
         assert!(
             content.contains(summary_line),
@@ -984,7 +985,7 @@ mod tests {
             ]
         });
 
-        let content = extract_tool_result_content(&value);
+        let content = extract_tool_result_content(&value["content"]);
 
         assert_eq!(content.len(), MAX_TOOL_RESULT_CONTENT_LEN);
         assert!(

--- a/crates/backend/src/agent/adapter/claude_code/transcript.rs
+++ b/crates/backend/src/agent/adapter/claude_code/transcript.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 
 use super::test_runners::emitter::TestRunEmitter;
 use super::test_runners::matcher::{match_command, MatchedCommand};
+use super::transcript_dto::{ClaudeToolResultDto, ClaudeToolUseDto, ClaudeTranscriptLineDto};
 use crate::agent::adapter::base::TranscriptHandle;
 use crate::agent::adapter::types::ValidateTranscriptError;
 use crate::agent::events::{emit_agent_cwd, emit_agent_tool_call, emit_agent_turn};
@@ -123,41 +124,15 @@ fn tool_block_type(item: &Value) -> &str {
     line_type(item)
 }
 
-fn tool_use_id(item: &Value) -> Option<&str> {
-    item.get("id").and_then(Value::as_str)
-}
-
-fn tool_name(item: &Value) -> &str {
-    item.get("name")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown")
-}
-
-fn bash_command(item: &Value) -> Option<&str> {
-    if tool_name(item) != "Bash" {
+fn bash_command<'a>(name: &'a str, input: Option<&'a Value>) -> Option<&'a str> {
+    if name != "Bash" {
         return None;
     }
-
-    item.get("input")
-        .and_then(|input| input.get("command"))
-        .and_then(Value::as_str)
+    input?.get("command").and_then(Value::as_str)
 }
 
-fn tool_file_path(item: &Value) -> Option<&str> {
-    item.get("input")
-        .and_then(|input| input.get("file_path"))
-        .and_then(Value::as_str)
-}
-
-fn tool_result_id(value: &Value) -> Option<&str> {
-    value.get("tool_use_id").and_then(Value::as_str)
-}
-
-fn tool_result_is_error(value: &Value) -> bool {
-    value
-        .get("is_error")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
+fn tool_file_path<'a>(input: Option<&'a Value>) -> Option<&'a str> {
+    input?.get("file_path").and_then(Value::as_str)
 }
 
 fn text_block_type(block: &Value) -> Option<&str> {
@@ -286,7 +261,7 @@ fn process_line(
     num_turns: &mut u32,
     last_cwd: &mut Option<String>,
 ) {
-    let value: Value = match serde_json::from_str(line) {
+    let dto: ClaudeTranscriptLineDto = match serde_json::from_str(line) {
         Ok(v) => v,
         Err(_) => {
             // Malformed JSON — skip silently
@@ -298,7 +273,7 @@ fn process_line(
     // tracking. Surface transitions through `agent-cwd` so the frontend
     // can mirror them into pane.cwd without depending on the interactive
     // shell emitting OSC 7.
-    if let Some(observed) = value.get("cwd").and_then(Value::as_str) {
+    if let Some(observed) = dto.cwd.as_deref() {
         if !observed.is_empty()
             && last_cwd.as_deref().map_or(true, |seen| seen != observed)
         {
@@ -314,19 +289,27 @@ fn process_line(
         }
     }
 
-    match line_type(&value) {
+    match dto.line_type.as_deref().unwrap_or("") {
         "assistant" => {
-            process_assistant_message(&value, session_id, cwd, events, in_flight);
+            process_assistant_message(&dto, session_id, cwd, events, in_flight);
         }
         "user" => {
             process_user_message(
-                &value, session_id, cwd, events, emitter, in_flight, num_turns,
+                &dto, session_id, cwd, events, emitter, in_flight, num_turns,
             );
         }
         "tool_result" => {
-            let timestamp = extract_timestamp(&value);
+            let timestamp = extract_timestamp(dto.timestamp.as_deref());
             process_tool_result(
-                &value, session_id, cwd, events, emitter, in_flight, &timestamp,
+                dto.tool_use_id.as_deref(),
+                dto.is_error,
+                &dto.content,
+                session_id,
+                cwd,
+                events,
+                emitter,
+                in_flight,
+                &timestamp,
             );
         }
         _ => {
@@ -341,52 +324,54 @@ fn process_line(
 /// `now_iso8601()` would otherwise stamp every event parsed in a single tick
 /// (e.g. initial watch / batch catch-up) with the same "now", making the UI
 /// feed look as if everything happened at once.
-fn extract_timestamp(value: &Value) -> String {
-    value
-        .get("timestamp")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .unwrap_or_else(now_iso8601)
+fn extract_timestamp(timestamp: Option<&str>) -> String {
+    timestamp.map(str::to_string).unwrap_or_else(now_iso8601)
 }
 
 fn process_assistant_message(
-    value: &Value,
+    dto: &ClaudeTranscriptLineDto,
     session_id: &str,
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
     in_flight: &mut InFlightToolCalls,
 ) {
-    let content = match message_content_items(value) {
+    let content = match message_content_items(dto) {
         Some(arr) => arr,
         None => return,
     };
 
-    let timestamp = extract_timestamp(value);
+    let timestamp = extract_timestamp(dto.timestamp.as_deref());
 
     for item in content {
         if tool_block_type(item) != "tool_use" {
             continue;
         }
 
-        let id = match tool_use_id(item) {
+        let tool_use_dto: ClaudeToolUseDto = match serde_json::from_value(item.clone()) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+
+        let id = match tool_use_dto.id.as_deref() {
             Some(id) => id.to_string(),
             None => continue,
         };
 
-        let name = tool_name(item).to_string();
+        let name = tool_use_dto.name.as_deref().unwrap_or("unknown");
+        let input_value = tool_use_dto.rest.get("input");
 
         // Run the matcher BEFORE summarize_input truncates — the matcher
         // needs the full untruncated command to tokenize correctly.
-        let test_match = bash_command(item).and_then(|cmd| match_command(cmd, cwd));
+        let test_match = bash_command(name, input_value).and_then(|cmd| match_command(cmd, cwd));
 
-        let args = summarize_input(item.get("input"));
+        let args = summarize_input(input_value);
 
         // Tag Write/Edit on test files. Use the FULL untruncated
         // input.file_path — `args` is summarized to MAX_ARGS_LEN and
         // long workspace paths could otherwise drop the suffix that
         // makes a file recognizable as a test (e.g. `…ndle.test.ts`).
-        let is_test_file = if matches!(name.as_str(), "Write" | "Edit") {
-            tool_file_path(item)
+        let is_test_file = if matches!(name, "Write" | "Edit") {
+            tool_file_path(input_value)
                 .map(super::test_runners::test_file_patterns::is_test_file)
                 .unwrap_or(false)
         } else {
@@ -399,7 +384,7 @@ fn process_assistant_message(
             InFlightToolCall {
                 started_at: now,
                 started_at_iso: timestamp.clone(),
-                tool: name.clone(),
+                tool: name.to_string(),
                 args: args.clone(),
                 is_test_file,
                 test_match,
@@ -409,7 +394,7 @@ fn process_assistant_message(
         let event = AgentToolCallEvent {
             session_id: session_id.to_string(),
             tool_use_id: id,
-            tool: name,
+            tool: name.to_string(),
             args,
             status: ToolCallStatus::Running,
             timestamp: timestamp.clone(),
@@ -425,7 +410,7 @@ fn process_assistant_message(
 
 /// Extract tool_result entries from a user message.
 fn process_user_message(
-    value: &Value,
+    dto: &ClaudeTranscriptLineDto,
     session_id: &str,
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
@@ -433,18 +418,30 @@ fn process_user_message(
     in_flight: &mut InFlightToolCalls,
     num_turns: &mut u32,
 ) {
-    let content = match message_content(value) {
+    let content = match dto.message.as_ref().map(|m| &m.content) {
         Some(content) => content,
         None => return,
     };
 
-    let timestamp = extract_timestamp(value);
+    let timestamp = extract_timestamp(dto.timestamp.as_deref());
 
     if let Some(items) = content.as_array() {
         for item in items {
             if is_tool_result_block(item) {
+                let block_dto: ClaudeToolResultDto = match serde_json::from_value(item.clone()) {
+                    Ok(d) => d,
+                    Err(_) => continue,
+                };
                 process_tool_result(
-                    item, session_id, cwd, events, emitter, in_flight, &timestamp,
+                    block_dto.tool_use_id.as_deref(),
+                    block_dto.is_error,
+                    &block_dto.content,
+                    session_id,
+                    cwd,
+                    events,
+                    emitter,
+                    in_flight,
+                    &timestamp,
                 );
             }
         }
@@ -465,7 +462,9 @@ fn process_user_message(
 
 /// Process a tool_result line and emit Done/Failed event
 fn process_tool_result(
-    value: &Value,
+    tool_use_id: Option<&str>,
+    is_error: Option<bool>,
+    content: &Value,
     session_id: &str,
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
@@ -473,12 +472,12 @@ fn process_tool_result(
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
 ) {
-    let tool_use_id = match tool_result_id(value) {
+    let tool_use_id = match tool_use_id {
         Some(id) => id.to_string(),
         None => return,
     };
 
-    let is_error = tool_result_is_error(value);
+    let is_error = is_error.unwrap_or(false);
 
     // An orphaned tool_result — a tool_result whose parent tool_use was
     // never recorded in_flight — arrives most often when a Claude Code
@@ -498,8 +497,11 @@ fn process_tool_result(
 
     if let Some(matched) = call.test_match {
         // Pull the captured Bash output content.
-        let content = extract_tool_result_content(value.get("content").unwrap_or(&Value::Null));
-        let captured = super::test_runners::types::CapturedOutput { content, is_error };
+        let content_str = extract_tool_result_content(content);
+        let captured = super::test_runners::types::CapturedOutput {
+            content: content_str,
+            is_error,
+        };
         // Build the snapshot only when we have a workspace cwd. Falling
         // back to `Path::new(".")` would canonicalise to the backend
         // process's cwd — NOT the user's workspace — so test-file groups
@@ -555,14 +557,8 @@ fn process_tool_result(
     }
 }
 
-fn message_content_items(value: &Value) -> Option<&[Value]> {
-    message_content(value)
-        .and_then(|c| c.as_array())
-        .map(Vec::as_slice)
-}
-
-fn message_content(value: &Value) -> Option<&Value> {
-    value.get("message").and_then(|m| m.get("content"))
+fn message_content_items(dto: &ClaudeTranscriptLineDto) -> Option<&[Value]> {
+    dto.message.as_ref()?.content.as_array().map(Vec::as_slice)
 }
 
 fn is_tool_result_block(value: &Value) -> bool {
@@ -997,9 +993,9 @@ mod tests {
     #[test]
     fn parse_nested_tool_result_from_user_message() {
         let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_abc","content":"file contents...","is_error":false}]}}"#;
-        let value: Value = serde_json::from_str(line).unwrap();
+        let dto: ClaudeTranscriptLineDto = serde_json::from_str(line).unwrap();
 
-        let content = message_content_items(&value).unwrap();
+        let content = message_content_items(&dto).unwrap();
         let result = content
             .iter()
             .find(|item| is_tool_result_block(item))
@@ -1022,18 +1018,17 @@ mod tests {
             r#"{"type":"tool_result"}"#, // missing tool_use_id
         ];
 
-        // process_line requires app_handle — test the parsing path directly
+        // Every line shape must deserialize without error (DTO fields are
+        // all defaulted/lenient). Lines that are not valid JSON at all are
+        // skipped silently by process_line.
         for line in &bad_lines {
-            let result: Result<Value, _> = serde_json::from_str(line);
-            // Should either fail to parse or produce a Value we can handle
-            if let Ok(value) = result {
-                // These should not cause panics in extraction logic
-                let _ = line_type(&value);
-                let _ = value
-                    .get("message")
-                    .and_then(|m| m.get("content"))
-                    .and_then(|c| c.as_array());
-                let _ = tool_result_id(&value);
+            let result: Result<ClaudeTranscriptLineDto, _> = serde_json::from_str(line);
+            if let Ok(dto) = result {
+                let _ = dto.line_type.as_deref().unwrap_or("");
+                let _ = dto.message.as_ref().map(|m| m.content.as_array());
+                let _ = dto.tool_use_id.as_deref();
+                let _ = dto.is_error;
+                let _ = &dto.content;
             }
         }
     }
@@ -1243,19 +1238,12 @@ mod tests {
     // contract so future refactors can't silently regress it.
     #[test]
     fn extract_timestamp_uses_transcript_field_when_present() {
-        let line =
-            r#"{"type":"assistant","timestamp":"2026-04-22T10:30:00Z","message":{"content":[]}}"#;
-        let value: Value = serde_json::from_str(line).unwrap();
-
-        assert_eq!(extract_timestamp(&value), "2026-04-22T10:30:00Z");
+        assert_eq!(extract_timestamp(Some("2026-04-22T10:30:00Z")), "2026-04-22T10:30:00Z");
     }
 
     #[test]
     fn extract_timestamp_falls_back_to_now_when_absent() {
-        let line = r#"{"type":"assistant","message":{"content":[]}}"#;
-        let value: Value = serde_json::from_str(line).unwrap();
-
-        let ts = extract_timestamp(&value);
+        let ts = extract_timestamp(None);
 
         // Shape check against now_iso8601 — same ISO-8601 UTC format
         // (YYYY-MM-DDTHH:MM:SSZ). We can't compare exact values because
@@ -1268,11 +1256,9 @@ mod tests {
     #[test]
     fn extract_timestamp_ignores_non_string_field() {
         // If a malformed line has a non-string timestamp (e.g. a number
-        // or null), we should fall back rather than coerce.
-        let line = r#"{"type":"assistant","timestamp":1234567890,"message":{"content":[]}}"#;
-        let value: Value = serde_json::from_str(line).unwrap();
-
-        let ts = extract_timestamp(&value);
+        // or null), the DTO's lenient_string deserializer degrades it to
+        // None, and extract_timestamp falls back to now_iso8601.
+        let ts = extract_timestamp(None);
 
         // Falls back to now_iso8601 format (not the numeric literal).
         assert!(ts.ends_with('Z'));
@@ -1283,11 +1269,10 @@ mod tests {
     fn extract_timestamp_preserves_full_iso_string_exactly() {
         // Sub-second precision and timezone offsets should pass through
         // untouched — the frontend parses whatever we emit.
-        let line =
-            r#"{"type":"user","timestamp":"2026-04-22T10:30:45.123Z","message":{"content":[]}}"#;
-        let value: Value = serde_json::from_str(line).unwrap();
-
-        assert_eq!(extract_timestamp(&value), "2026-04-22T10:30:45.123Z");
+        assert_eq!(
+            extract_timestamp(Some("2026-04-22T10:30:45.123Z")),
+            "2026-04-22T10:30:45.123Z"
+        );
     }
 
     // is_user_prompt / is_non_empty_user_block — direct in-module coverage.
@@ -1391,5 +1376,56 @@ mod tests {
 
         let null_type: Value = serde_json::from_str(r#"{"type":null,"text":"hello"}"#).unwrap();
         assert!(is_non_empty_user_block(&null_type));
+    }
+
+    /// Regression: a tool_result line with a wrong-typed `is_error` must
+    /// still emit the `agent-tool-call` event (lenient degradation, not a
+    /// silent drop). The DTO's `lenient_bool` turns `"oops"` → `None`,
+    /// which `process_tool_result` maps to `false` → `Done` status.
+    #[test]
+    fn process_line_emits_with_wrong_typed_is_error() {
+        let concrete = Arc::new(crate::runtime::FakeEventSink::new());
+        let events: Arc<dyn EventSink> = concrete.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight: InFlightToolCalls = HashMap::new();
+        let mut num_turns = 0;
+        let mut last_cwd = None;
+
+        // Seed in_flight so the tool_result has a match
+        in_flight.insert(
+            "toolu_xyz".to_string(),
+            InFlightToolCall {
+                started_at: Instant::now(),
+                started_at_iso: "2026-04-28T12:00:00Z".to_string(),
+                tool: "Bash".to_string(),
+                args: "echo hi".to_string(),
+                is_test_file: false,
+                test_match: None,
+            },
+        );
+
+        let line = r#"{"type":"tool_result","tool_use_id":"toolu_xyz","content":"ok","is_error":"oops"}"#;
+        process_line(
+            line,
+            "sess-1",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+        );
+
+        assert_eq!(concrete.count("agent-tool-call"), 1);
+        assert!(in_flight.is_empty(), "matched tool_use should be removed");
+    }
+
+    /// Regression: `summarize_input` must preserve the absent vs present-null
+    /// distinction ("" vs "null") that the DTO's `#[serde(flatten)] rest`
+    /// map preserves for `tool_use.input`.
+    #[test]
+    fn summarize_input_preserves_absent_vs_null() {
+        assert_eq!(summarize_input(None), "");
+        assert_eq!(summarize_input(Some(&serde_json::Value::Null)), "null");
     }
 }

--- a/crates/backend/src/agent/adapter/claude_code/transcript_dto.rs
+++ b/crates/backend/src/agent/adapter/claude_code/transcript_dto.rs
@@ -1,0 +1,145 @@
+//! Typed, lenient DTOs for the Claude transcript JSONL parser (A-transcript,
+//! option B). Scalar leaves are typed via the shared `lenient_*` deserializers
+//! so wrong-typed/missing fields degrade to `None` (never erroring the parse);
+//! the genuinely union/arbitrary fields (`message.content`, `tool_*.content`,
+//! `tool_use.input`) stay raw `Value` and keep their ported predicates/helpers.
+//!
+//! Invariant: **every field is `#[serde(default)]`/lenient**, so a line of *any*
+//! shape deserializes without error — a non-`tool_result` line simply gets
+//! `content = Value::Null` and `tool_use_id`/`is_error = None`. This lets the
+//! parser apply `ClaudeTranscriptLineDto` to every line, not just `tool_result`.
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use crate::agent::adapter::serde_helpers::{lenient_bool, lenient_object, lenient_string};
+
+/// One transcript JSONL line. Carries the top-level fields `process_line`
+/// reads — including the top-level `cwd` (emits `agent-cwd` before the
+/// `line_type` dispatch) and the top-level `tool_result` shape
+/// (`tool_use_id` / `is_error` / `content`), since `tool_result` is one of the
+/// top-level line types alongside `assistant` / `user`.
+#[derive(Deserialize, Default)]
+pub(super) struct ClaudeTranscriptLineDto {
+    #[serde(rename = "type", default, deserialize_with = "lenient_string")]
+    pub line_type: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub cwd: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub timestamp: Option<String>,
+    #[serde(default, deserialize_with = "lenient_object")]
+    pub message: Option<ClaudeMessageDto>,
+    // Top-level tool_result fields:
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub tool_use_id: Option<String>,
+    #[serde(default, deserialize_with = "lenient_bool")]
+    pub is_error: Option<bool>,
+    /// Raw — consumed by the ported `extract_tool_result_content`.
+    #[serde(default)]
+    pub content: Value,
+}
+
+/// `message` envelope. `content` is string | array | other and stays raw —
+/// classified by the ported predicates (`is_user_prompt`, `line_type`, …),
+/// which a tagged enum can't express (missing/non-string block `type` must
+/// count as content).
+#[derive(Deserialize, Default)]
+pub(super) struct ClaudeMessageDto {
+    #[serde(default)]
+    pub content: Value,
+}
+
+/// A `tool_use` content block. Scalars are typed; `input` is presence-sensitive
+/// (`summarize_input` returns `""` for absent vs `"null"` for present-`null`),
+/// so it is read off the flattened raw map rather than a collapsing `Option`.
+#[derive(Deserialize, Default)]
+pub(super) struct ClaudeToolUseDto {
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub id: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub name: Option<String>,
+    /// Captures `input` (and any other non-scalar fields). `rest.get("input")`
+    /// gives the `Option<&Value>` the input consumers expect: `None` = absent,
+    /// `Some(Null)` = present-`null`.
+    #[serde(flatten)]
+    pub rest: Map<String, Value>,
+}
+
+/// A `tool_result` content block. Scalars typed; `content` raw (string |
+/// array-of-text-blocks) — `extract_tool_result_content` consumes the value.
+#[derive(Deserialize, Default)]
+pub(super) struct ClaudeToolResultDto {
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub tool_use_id: Option<String>,
+    #[serde(default, deserialize_with = "lenient_bool")]
+    pub is_error: Option<bool>,
+    #[serde(default)]
+    pub content: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_line_dto_parses_envelope_and_top_level_cwd() {
+        let dto: ClaudeTranscriptLineDto = serde_json::from_str(
+            r#"{"type":"assistant","cwd":"/ws","timestamp":"t","message":{"content":[]}}"#,
+        )
+        .expect("envelope parses");
+        assert_eq!(dto.line_type.as_deref(), Some("assistant"));
+        assert_eq!(dto.cwd.as_deref(), Some("/ws"));
+        assert_eq!(dto.timestamp.as_deref(), Some("t"));
+        assert!(dto.message.is_some());
+    }
+
+    #[test]
+    fn claude_line_dto_tolerates_any_shape_without_error() {
+        // Non-tool_result line: no top-level content / tool_use_id → defaults, no error.
+        let dto: ClaudeTranscriptLineDto =
+            serde_json::from_str(r#"{"type":"user","message":{"content":"hi"}}"#)
+                .expect("non-tool_result line parses");
+        assert_eq!(dto.line_type.as_deref(), Some("user"));
+        assert!(dto.tool_use_id.is_none());
+        assert!(dto.is_error.is_none());
+        assert_eq!(dto.content, Value::Null);
+
+        // Wrong-shaped `message` degrades to None via lenient_object (not an error).
+        let dto: ClaudeTranscriptLineDto =
+            serde_json::from_str(r#"{"type":"user","message":42}"#).expect("wrong message parses");
+        assert!(dto.message.is_none());
+
+        // Entirely unknown shape still parses (every field defaulted/lenient).
+        let dto: ClaudeTranscriptLineDto =
+            serde_json::from_str(r#"{"unexpected":true}"#).expect("unknown line parses");
+        assert!(dto.line_type.is_none());
+    }
+
+    #[test]
+    fn claude_tool_result_dto_is_error_is_lenient() {
+        // Wrong-typed is_error degrades to None instead of erroring the block.
+        let dto: ClaudeToolResultDto =
+            serde_json::from_str(r#"{"tool_use_id":"x","is_error":"oops","content":"c"}"#)
+                .expect("tool_result with bad is_error parses");
+        assert_eq!(dto.tool_use_id.as_deref(), Some("x"));
+        assert_eq!(dto.is_error, None);
+        assert_eq!(dto.content, Value::String("c".to_string()));
+    }
+
+    #[test]
+    fn claude_tool_use_dto_distinguishes_absent_vs_null_input() {
+        let absent: ClaudeToolUseDto =
+            serde_json::from_str(r#"{"id":"i","name":"Read"}"#).expect("tool_use absent input");
+        assert_eq!(absent.id.as_deref(), Some("i"));
+        assert_eq!(absent.name.as_deref(), Some("Read"));
+        assert!(absent.rest.get("input").is_none(), "absent input → None");
+
+        let nulled: ClaudeToolUseDto = serde_json::from_str(r#"{"id":"i","name":"Read","input":null}"#)
+            .expect("tool_use null input");
+        assert_eq!(
+            nulled.rest.get("input"),
+            Some(&Value::Null),
+            "present-null input preserved (≠ absent)"
+        );
+    }
+}

--- a/crates/backend/src/agent/adapter/codex/mod.rs
+++ b/crates/backend/src/agent/adapter/codex/mod.rs
@@ -3,6 +3,7 @@
 mod locator;
 mod parser;
 mod transcript;
+mod transcript_dto;
 mod types;
 
 use std::path::{Path, PathBuf};

--- a/crates/backend/src/agent/adapter/codex/transcript.rs
+++ b/crates/backend/src/agent/adapter/codex/transcript.rs
@@ -22,6 +22,11 @@ use crate::agent::events::{emit_agent_cwd, emit_agent_tool_call, emit_agent_turn
 use crate::agent::types::{AgentCwdEvent, AgentToolCallEvent, AgentTurnEvent, ToolCallStatus};
 use crate::runtime::EventSink;
 
+use super::transcript_dto::{
+    CodexCustomToolOutputDto, CodexExecArgsDto, CodexLineDto, CodexPayloadDto, CodexPayloadType,
+    CodexRecordType,
+};
+
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 const MAX_ARGS_LEN: usize = 100;
 
@@ -53,16 +58,13 @@ type InFlightToolCalls = HashMap<String, InFlightToolCall>;
 /// would cause false reverts on reasoning-only turns after an
 /// `exec_command.workdir` transition has already moved us to a new
 /// directory. See spec section 1.
-fn extract_session_cwd(value: &Value) -> Option<&str> {
-    let event_type = value.get("type").and_then(Value::as_str)?;
-    if event_type != "session_meta" {
+fn extract_session_cwd(dto: &CodexLineDto) -> Option<String> {
+    if !matches!(dto.record_type(), CodexRecordType::SessionMeta) {
         return None;
     }
-    value
-        .get("payload")?
-        .get("cwd")
-        .and_then(Value::as_str)
-        .filter(|s| !s.is_empty())
+    let payload =
+        serde_json::from_value::<CodexPayloadDto>(dto.payload.clone()).unwrap_or_default();
+    payload.cwd.filter(|s| !s.is_empty())
 }
 
 /// Pull the mid-session workdir off a Codex `exec_command` function-call
@@ -73,23 +75,21 @@ fn extract_session_cwd(value: &Value) -> Option<&str> {
 /// `arguments` is a JSON-encoded string per Codex's rollout schema —
 /// it must be parsed before reading `workdir`. Malformed JSON, missing
 /// fields, or empty strings all short-circuit to `None`.
-fn extract_exec_workdir(value: &Value) -> Option<String> {
-    if value.get("type").and_then(Value::as_str)? != "response_item" {
+fn extract_exec_workdir(dto: &CodexLineDto) -> Option<String> {
+    if !matches!(dto.record_type(), CodexRecordType::ResponseItem) {
         return None;
     }
-    let payload = value.get("payload")?;
-    if payload.get("type").and_then(Value::as_str)? != "function_call" {
+    let payload =
+        serde_json::from_value::<CodexPayloadDto>(dto.payload.clone()).unwrap_or_default();
+    if payload.payload_type() != CodexPayloadType::FunctionCall {
         return None;
     }
-    if payload.get("name").and_then(Value::as_str)? != "exec_command" {
+    if payload.name.as_deref() != Some("exec_command") {
         return None;
     }
-    let raw = payload.get("arguments").and_then(Value::as_str)?;
-    let args: Value = serde_json::from_str(raw).ok()?;
-    args.get("workdir")
-        .and_then(Value::as_str)
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
+    let raw = payload.arguments?;
+    let args: CodexExecArgsDto = serde_json::from_str(&raw).ok()?;
+    args.workdir.filter(|s| !s.is_empty())
 }
 
 /// Dispatcher returning the observed cwd from whichever source carries
@@ -97,11 +97,11 @@ fn extract_exec_workdir(value: &Value) -> Option<String> {
 /// falls back to the exec_command workdir path. Returns
 /// `Option<String>` because the workdir path must return owned strings
 /// (parsed JSON allocates).
-fn extract_codex_cwd(value: &Value) -> Option<String> {
-    if let Some(cwd) = extract_session_cwd(value) {
-        return Some(cwd.to_string());
+fn extract_codex_cwd(dto: &CodexLineDto) -> Option<String> {
+    if let Some(cwd) = extract_session_cwd(dto) {
+        return Some(cwd);
     }
-    extract_exec_workdir(value)
+    extract_exec_workdir(dto)
 }
 
 pub(super) fn validate_transcript_path(
@@ -265,8 +265,8 @@ fn process_line(
     num_turns: &mut u32,
     last_cwd: &mut Option<String>,
 ) {
-    let value: Value = match serde_json::from_str(line) {
-        Ok(value) => value,
+    let dto: CodexLineDto = match serde_json::from_str(line) {
+        Ok(dto) => dto,
         Err(_) => return,
     };
 
@@ -276,7 +276,7 @@ fn process_line(
     // calls (mid-session). turn_context.cwd is intentionally NOT a
     // source — see spec section 1 and the regression test
     // `process_line_turn_context_after_exec_command_does_not_revert`.
-    if let Some(observed) = extract_codex_cwd(&value) {
+    if let Some(observed) = extract_codex_cwd(&dto) {
         if last_cwd
             .as_deref()
             .map_or(true, |seen| seen != observed.as_str())
@@ -292,13 +292,13 @@ fn process_line(
         }
     }
 
-    match value.get("type").and_then(Value::as_str) {
-        Some("response_item") => {
-            process_response_item(&value, session_id, cwd, events, in_flight);
+    match dto.record_type() {
+        CodexRecordType::ResponseItem => {
+            process_response_item(&dto, session_id, cwd, events, in_flight);
         }
-        Some("event_msg") => {
+        CodexRecordType::EventMsg => {
             process_event_msg(
-                &value, session_id, cwd, events, emitter, in_flight, num_turns,
+                &dto, session_id, cwd, events, emitter, in_flight, num_turns,
             );
         }
         _ => {}
@@ -306,34 +306,35 @@ fn process_line(
 }
 
 fn process_response_item(
-    value: &Value,
+    dto: &CodexLineDto,
     session_id: &str,
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
     in_flight: &mut InFlightToolCalls,
 ) {
-    let payload = value.get("payload").unwrap_or(&Value::Null);
-    let timestamp = extract_timestamp(value);
+    let payload =
+        serde_json::from_value::<CodexPayloadDto>(dto.payload.clone()).unwrap_or_default();
+    let timestamp = dto.timestamp.clone().unwrap_or_else(now_iso8601);
 
-    match payload.get("type").and_then(Value::as_str) {
-        Some("function_call") => {
-            start_function_call(payload, session_id, cwd, events, in_flight, &timestamp);
+    match payload.payload_type() {
+        CodexPayloadType::FunctionCall => {
+            start_function_call(&payload, session_id, cwd, events, in_flight, &timestamp);
         }
-        Some("custom_tool_call") => {
-            start_custom_tool_call(payload, session_id, events, in_flight, &timestamp);
+        CodexPayloadType::CustomToolCall => {
+            start_custom_tool_call(&payload, session_id, events, in_flight, &timestamp);
         }
-        Some("function_call_output") => {
-            process_output_completion(payload, session_id, events, in_flight, &timestamp, false);
+        CodexPayloadType::FunctionCallOutput => {
+            process_output_completion(&payload, session_id, events, in_flight, &timestamp, false);
         }
-        Some("custom_tool_call_output") => {
-            process_output_completion(payload, session_id, events, in_flight, &timestamp, true);
+        CodexPayloadType::CustomToolCallOutput => {
+            process_output_completion(&payload, session_id, events, in_flight, &timestamp, true);
         }
         _ => {}
     }
 }
 
 fn process_event_msg(
-    value: &Value,
+    dto: &CodexLineDto,
     session_id: &str,
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
@@ -341,32 +342,33 @@ fn process_event_msg(
     in_flight: &mut InFlightToolCalls,
     num_turns: &mut u32,
 ) {
-    let payload = value.get("payload").unwrap_or(&Value::Null);
-    let timestamp = extract_timestamp(value);
+    let payload =
+        serde_json::from_value::<CodexPayloadDto>(dto.payload.clone()).unwrap_or_default();
+    let timestamp = dto.timestamp.clone().unwrap_or_else(now_iso8601);
 
-    match payload.get("type").and_then(Value::as_str) {
-        Some("user_message") => {
-            process_user_message(payload, session_id, events, num_turns);
+    match payload.payload_type() {
+        CodexPayloadType::UserMessage => {
+            process_user_message(&payload, session_id, events, num_turns);
         }
-        Some("exec_command_end") => {
+        CodexPayloadType::ExecCommandEnd => {
             process_exec_command_end(
-                payload, session_id, cwd, events, emitter, in_flight, &timestamp,
+                &payload, session_id, cwd, events, emitter, in_flight, &timestamp,
             );
         }
-        Some("patch_apply_end") => {
-            process_patch_apply_end(payload, session_id, events, in_flight, &timestamp);
+        CodexPayloadType::PatchApplyEnd => {
+            process_patch_apply_end(&payload, session_id, events, in_flight, &timestamp);
         }
         _ => {}
     }
 }
 
 fn process_user_message(
-    payload: &Value,
+    payload: &CodexPayloadDto,
     session_id: &str,
     events: &Arc<dyn EventSink>,
     num_turns: &mut u32,
 ) {
-    let Some(message) = payload.get("message").and_then(Value::as_str) else {
+    let Some(message) = payload.message.as_deref() else {
         return;
     };
     if message.trim().is_empty() {
@@ -385,23 +387,19 @@ fn process_user_message(
 }
 
 fn start_function_call(
-    payload: &Value,
+    payload: &CodexPayloadDto,
     session_id: &str,
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
 ) {
-    let Some(call_id) = payload.get("call_id").and_then(Value::as_str) else {
+    let Some(call_id) = payload.call_id.as_deref() else {
         return;
     };
-    let tool = payload
-        .get("name")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown")
-        .to_string();
-    let args = summarize_function_call_args(payload);
-    let cmd = function_call_cmd(payload);
+    let tool = payload.name.as_deref().unwrap_or("unknown").to_string();
+    let args = summarize_function_call_args(payload.arguments.as_deref());
+    let cmd = function_call_cmd(payload.arguments.as_deref());
     let test_match = cmd
         .as_deref()
         .filter(|_| tool == "exec_command")
@@ -440,22 +438,18 @@ fn start_function_call(
 }
 
 fn start_custom_tool_call(
-    payload: &Value,
+    payload: &CodexPayloadDto,
     session_id: &str,
     events: &Arc<dyn EventSink>,
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
 ) {
-    let Some(call_id) = payload.get("call_id").and_then(Value::as_str) else {
+    let Some(call_id) = payload.call_id.as_deref() else {
         return;
     };
-    let tool = payload
-        .get("name")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown")
-        .to_string();
-    let args = summarize_custom_tool_input(payload);
-    let is_test_file = custom_tool_is_test_file(payload);
+    let tool = payload.name.as_deref().unwrap_or("unknown").to_string();
+    let args = summarize_custom_tool_input(payload.input.as_deref());
+    let is_test_file = custom_tool_is_test_file(payload.input.as_deref());
 
     in_flight.insert(
         call_id.to_string(),
@@ -490,14 +484,14 @@ fn start_custom_tool_call(
 }
 
 fn process_output_completion(
-    payload: &Value,
+    payload: &CodexPayloadDto,
     session_id: &str,
     events: &Arc<dyn EventSink>,
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
     is_custom_tool_output: bool,
 ) {
-    let Some(call_id) = payload.get("call_id").and_then(Value::as_str) else {
+    let Some(call_id) = payload.call_id.as_deref() else {
         return;
     };
 
@@ -516,7 +510,7 @@ fn process_output_completion(
         None => return,
     };
 
-    let status = if is_custom_tool_output && custom_tool_output_failed(payload) {
+    let status = if is_custom_tool_output && custom_tool_output_failed(payload.output.as_deref()) {
         ToolCallStatus::Failed
     } else {
         ToolCallStatus::Done
@@ -542,7 +536,7 @@ fn process_output_completion(
 }
 
 fn process_exec_command_end(
-    payload: &Value,
+    payload: &CodexPayloadDto,
     session_id: &str,
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
@@ -550,7 +544,7 @@ fn process_exec_command_end(
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
 ) {
-    let Some(call_id) = payload.get("call_id").and_then(Value::as_str) else {
+    let Some(call_id) = payload.call_id.as_deref() else {
         return;
     };
 
@@ -561,15 +555,8 @@ fn process_exec_command_end(
     if let Some(matched) = call.test_match {
         if let Some(cwd_ref) = cwd {
             let captured = CapturedOutput {
-                content: payload
-                    .get("aggregated_output")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string(),
-                is_error: payload
-                    .get("exit_code")
-                    .and_then(Value::as_i64)
-                    .is_some_and(|code| code != 0),
+                content: payload.aggregated_output.as_deref().unwrap_or("").to_string(),
+                is_error: payload.exit_code.is_some_and(|code| code != 0),
             };
             if let Some(snapshot) = maybe_build_snapshot(BuildArgs {
                 session_id,
@@ -590,11 +577,7 @@ fn process_exec_command_end(
         }
     }
 
-    let status = if payload
-        .get("exit_code")
-        .and_then(Value::as_i64)
-        .is_some_and(|code| code != 0)
-    {
+    let status = if payload.exit_code.is_some_and(|code| code != 0) {
         ToolCallStatus::Failed
     } else {
         ToolCallStatus::Done
@@ -618,13 +601,13 @@ fn process_exec_command_end(
 }
 
 fn process_patch_apply_end(
-    payload: &Value,
+    payload: &CodexPayloadDto,
     session_id: &str,
     events: &Arc<dyn EventSink>,
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
 ) {
-    let Some(call_id) = payload.get("call_id").and_then(Value::as_str) else {
+    let Some(call_id) = payload.call_id.as_deref() else {
         return;
     };
 
@@ -632,11 +615,7 @@ fn process_patch_apply_end(
         return;
     };
 
-    let status = if payload
-        .get("success")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-    {
+    let status = if payload.success.unwrap_or(false) {
         ToolCallStatus::Done
     } else {
         ToolCallStatus::Failed
@@ -667,66 +646,38 @@ fn emit_tool_call(events: &Arc<dyn EventSink>, event: AgentToolCallEvent) {
     }
 }
 
-fn extract_timestamp(value: &Value) -> String {
-    value
-        .get("timestamp")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .unwrap_or_else(now_iso8601)
+fn function_call_cmd(arguments: Option<&str>) -> Option<String> {
+    let raw = arguments?;
+    let args: CodexExecArgsDto = serde_json::from_str(raw).ok()?;
+    args.cmd.or(args.command)
 }
 
-fn function_call_cmd(payload: &Value) -> Option<String> {
-    let raw = payload.get("arguments").and_then(Value::as_str)?;
-    let args: Value = serde_json::from_str(raw).ok()?;
-    args.get("cmd")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .or_else(|| {
-            args.get("command")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        })
-}
-
-fn summarize_function_call_args(payload: &Value) -> String {
-    if let Some(cmd) = function_call_cmd(payload) {
+fn summarize_function_call_args(arguments: Option<&str>) -> String {
+    if let Some(cmd) = function_call_cmd(arguments) {
         return truncate_string(&cmd, MAX_ARGS_LEN);
     }
 
-    let raw = payload
-        .get("arguments")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
+    let raw = arguments.unwrap_or_default();
 
-    if let Ok(args) = serde_json::from_str::<Value>(raw) {
-        if let Some(path) = args
-            .get("path")
-            .and_then(Value::as_str)
-            .or_else(|| args.get("file_path").and_then(Value::as_str))
-        {
-            return truncate_string(path, MAX_ARGS_LEN);
+    if let Ok(args) = serde_json::from_str::<CodexExecArgsDto>(raw) {
+        if let Some(path) = args.path.or(args.file_path) {
+            return truncate_string(&path, MAX_ARGS_LEN);
         }
     }
 
     truncate_string(raw, MAX_ARGS_LEN)
 }
 
-fn summarize_custom_tool_input(payload: &Value) -> String {
-    let input = payload
-        .get("input")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
+fn summarize_custom_tool_input(input: Option<&str>) -> String {
+    let input = input.unwrap_or_default();
     if let Some(first_path) = extract_patch_paths(input).into_iter().next() {
         return truncate_string(&first_path, MAX_ARGS_LEN);
     }
     truncate_string(input, MAX_ARGS_LEN)
 }
 
-fn custom_tool_is_test_file(payload: &Value) -> bool {
-    let input = payload
-        .get("input")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
+fn custom_tool_is_test_file(input: Option<&str>) -> bool {
+    let input = input.unwrap_or_default();
 
     extract_patch_paths(input)
         .into_iter()
@@ -745,25 +696,21 @@ fn extract_patch_paths(input: &str) -> Vec<String> {
         .collect()
 }
 
-fn custom_tool_output_failed(payload: &Value) -> bool {
-    let raw = payload
-        .get("output")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    let parsed: Value = match serde_json::from_str(raw) {
+fn custom_tool_output_failed(output: Option<&str>) -> bool {
+    let raw = output.unwrap_or_default();
+    let parsed: CodexCustomToolOutputDto = match serde_json::from_str(&raw) {
         Ok(parsed) => parsed,
         Err(_) => return false,
     };
 
-    parsed
-        .get("metadata")
-        .and_then(|meta| meta.get("exit_code"))
-        .and_then(Value::as_i64)
-        .is_some_and(|code| code != 0)
+    parsed.metadata.and_then(|m| m.exit_code).is_some_and(|code| code != 0)
 }
 
-fn exec_command_duration_ms(payload: &Value) -> Option<u64> {
-    let duration = payload.get("duration")?;
+fn exec_command_duration_ms(payload: &CodexPayloadDto) -> Option<u64> {
+    if !payload.rest.contains_key("duration") {
+        return None;
+    }
+    let duration = payload.rest.get("duration")?;
     let secs = duration.get("secs").and_then(Value::as_u64).unwrap_or(0);
     let nanos = duration.get("nanos").and_then(Value::as_u64).unwrap_or(0);
     Some(
@@ -1125,31 +1072,23 @@ mod tests {
 
     #[test]
     fn summarize_function_call_args_prefers_exec_command_cmd() {
-        let payload = json!({
-            "arguments": "{\"cmd\":\"cargo test --workspace --all-features\",\"workdir\":\"/tmp/ws\"}"
-        });
-
         assert_eq!(
-            summarize_function_call_args(&payload),
+            summarize_function_call_args(Some("{\"cmd\":\"cargo test --workspace --all-features\",\"workdir\":\"/tmp/ws\"}")),
             "cargo test --workspace --all-features"
         );
     }
 
     #[test]
     fn custom_tool_output_failed_reads_metadata_exit_code() {
-        let payload = json!({
-            "output": "{\"output\":\"nope\",\"metadata\":{\"exit_code\":1}}"
-        });
-
-        assert!(custom_tool_output_failed(&payload));
+        assert!(custom_tool_output_failed(Some("{\"output\":\"nope\",\"metadata\":{\"exit_code\":1}}")));
     }
 
     // ---- extract_session_cwd unit tests (v2: session_meta ONLY) ----
 
     #[test]
     fn extract_session_cwd_session_meta_returns_cwd() {
-        let v = json!({"type": "session_meta", "payload": {"cwd": "/workspace/A"}});
-        assert_eq!(extract_session_cwd(&v), Some("/workspace/A"));
+        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"session_meta","payload":{"cwd":"/workspace/A"}}"#).unwrap();
+        assert_eq!(extract_session_cwd(&dto), Some("/workspace/A".to_string()));
     }
 
     #[test]
@@ -1158,103 +1097,60 @@ mod tests {
         // Codex's turn_context.cwd is pinned to session-start and treating
         // it as live would cause false reverts after exec_command transitions.
         // This test is a defensive guard against re-introduction.
-        let v = json!({"type": "turn_context", "payload": {"cwd": "/workspace/A"}});
-        assert_eq!(extract_session_cwd(&v), None);
+        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"turn_context","payload":{"cwd":"/workspace/A"}}"#).unwrap();
+        assert_eq!(extract_session_cwd(&dto), None);
     }
 
     #[test]
     fn extract_session_cwd_other_type_returns_none() {
-        let v = json!({"type": "event_msg", "payload": {"cwd": "/workspace/A"}});
-        assert_eq!(extract_session_cwd(&v), None);
+        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"event_msg","payload":{"cwd":"/workspace/A"}}"#).unwrap();
+        assert_eq!(extract_session_cwd(&dto), None);
     }
 
     #[test]
     fn extract_session_cwd_empty_string_returns_none() {
-        let v = json!({"type": "session_meta", "payload": {"cwd": ""}});
-        assert_eq!(extract_session_cwd(&v), None);
+        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"session_meta","payload":{"cwd":""}}"#).unwrap();
+        assert_eq!(extract_session_cwd(&dto), None);
     }
 
     // ---- extract_exec_workdir unit tests (the mid-session signal) ----
 
     #[test]
     fn extract_exec_workdir_happy_path() {
-        let v = json!({
-            "type": "response_item",
-            "payload": {
-                "type": "function_call",
-                "name": "exec_command",
-                "call_id": "c1",
-                "arguments": "{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"
-            }
-        });
-        assert_eq!(extract_exec_workdir(&v).as_deref(), Some("/workspace/B"));
+        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"}}"#).unwrap();
+        assert_eq!(extract_exec_workdir(&dto).as_deref(), Some("/workspace/B"));
     }
 
     #[test]
     fn extract_exec_workdir_other_event_type_returns_none() {
         // event_msg carrying a function_call-shaped payload should still
         // be rejected — the outer event type gate is response_item.
-        let v = json!({
-            "type": "event_msg",
-            "payload": {
-                "type": "function_call",
-                "name": "exec_command",
-                "arguments": "{\"workdir\":\"/x\"}"
-            }
-        });
-        assert_eq!(extract_exec_workdir(&v), None);
+        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"event_msg","payload":{"type":"function_call","name":"exec_command","arguments":"{\"workdir\":\"/x\"}"}}"#).unwrap();
+        assert_eq!(extract_exec_workdir(&dto), None);
     }
 
     #[test]
     fn extract_exec_workdir_non_function_call_returns_none() {
-        let v = json!({
-            "type": "response_item",
-            "payload": {
-                "type": "custom_tool_call",
-                "name": "exec_command",
-                "input": "{\"workdir\":\"/x\"}"
-            }
-        });
-        assert_eq!(extract_exec_workdir(&v), None);
+        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"custom_tool_call","name":"exec_command","input":"{\"workdir\":\"/x\"}"}}"#).unwrap();
+        assert_eq!(extract_exec_workdir(&dto), None);
     }
 
     #[test]
     fn extract_exec_workdir_non_exec_command_returns_none() {
-        let v = json!({
-            "type": "response_item",
-            "payload": {
-                "type": "function_call",
-                "name": "read_file",
-                "arguments": "{\"path\":\"/x\"}"
-            }
-        });
-        assert_eq!(extract_exec_workdir(&v), None);
+        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"read_file","arguments":"{\"path\":\"/x\"}"}}"#).unwrap();
+        assert_eq!(extract_exec_workdir(&dto), None);
     }
 
     #[test]
     fn extract_exec_workdir_malformed_arguments_json_returns_none() {
-        let v = json!({
-            "type": "response_item",
-            "payload": {
-                "type": "function_call",
-                "name": "exec_command",
-                "arguments": "{not json"
-            }
-        });
-        assert_eq!(extract_exec_workdir(&v), None);
+        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{not json"}}"#).unwrap();
+        assert_eq!(extract_exec_workdir(&dto), None);
     }
 
     #[test]
     fn extract_exec_workdir_missing_workdir_field_returns_none() {
-        let v = json!({
-            "type": "response_item",
-            "payload": {
-                "type": "function_call",
-                "name": "exec_command",
-                "arguments": "{\"cmd\":\"ls\"}"
-            }
-        });
-        assert_eq!(extract_exec_workdir(&v), None);
+        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"}}"#).unwrap();
+        assert_eq!(extract_exec_workdir(&dto), None);
     }
 
     // ---- process_line transition-semantics tests ----
@@ -1417,6 +1313,84 @@ mod tests {
         assert_eq!(cwd_events[1].1["cwd"], "/workspace/B");
         // Crucially, last_cwd should still be B — the worktree we're in.
         assert_eq!(last_cwd.as_deref(), Some("/workspace/B"));
+    }
+
+    // ---- DTO-migration regression tests (Task 1.6) ----
+
+    #[test]
+    fn process_line_wrong_typed_exit_code_emits_done() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let start = r#"{"timestamp":"2026-05-22T10:00:00Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\"}"}}"#;
+        process_line(start, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd);
+
+        let end = r#"{"timestamp":"2026-05-22T10:00:01Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"c1","exit_code":"bad","aggregated_output":"ok"}}"#;
+        process_line(end, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd);
+
+        let tool_calls: Vec<_> = sink.recorded().into_iter().filter(|(n, _)| n == "agent-tool-call").collect();
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[1].1["status"], "done");
+    }
+
+    #[test]
+    fn process_line_wrong_typed_success_emits_failed() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let start = r#"{"timestamp":"2026-05-22T10:00:00Z","type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","call_id":"c1","input":"*** Begin Patch\n*** Update File: foo.ts\n*** End Patch"}}"#;
+        process_line(start, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd);
+
+        let end = r#"{"timestamp":"2026-05-22T10:00:01Z","type":"event_msg","payload":{"type":"patch_apply_end","call_id":"c1","success":"bad"}}"#;
+        process_line(end, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd);
+
+        let tool_calls: Vec<_> = sink.recorded().into_iter().filter(|(n, _)| n == "agent-tool-call").collect();
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[1].1["status"], "failed");
+    }
+
+    #[test]
+    fn process_line_duration_null_yields_zero_duration() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let start = r#"{"timestamp":"2026-05-22T10:00:00Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\"}"}}"#;
+        process_line(start, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd);
+
+        let end = r#"{"timestamp":"2026-05-22T10:00:01Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"c1","exit_code":0,"duration":null}}"#;
+        process_line(end, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd);
+
+        let tool_calls: Vec<_> = sink.recorded().into_iter().filter(|(n, _)| n == "agent-tool-call").collect();
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[1].1["durationMs"], 0);
+    }
+
+    #[test]
+    fn process_line_non_string_timestamp_emits_not_drops() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let line = r#"{"timestamp":42,"type":"event_msg","payload":{"type":"user_message","message":"hello"}}"#;
+        process_line(line, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd);
+
+        let turns: Vec<_> = sink.recorded().into_iter().filter(|(n, _)| n == "agent-turn").collect();
+        assert_eq!(turns.len(), 1);
     }
 
     // ---- end-to-end watcher test (with v2 regression guard inline) ----

--- a/crates/backend/src/agent/adapter/codex/transcript_dto.rs
+++ b/crates/backend/src/agent/adapter/codex/transcript_dto.rs
@@ -1,0 +1,210 @@
+//! Typed, lenient DTOs for the Codex transcript JSONL parser (A-transcript,
+//! option B). Scalar leaves are typed via the shared `lenient_*` deserializers
+//! so wrong-typed/missing fields degrade to `None` (never erroring the parse);
+//! the genuinely union/arbitrary fields (`arguments`, `output`, custom-tool
+//! `input`) stay raw `Option<String>` and keep their ported helpers.
+//!
+//! Invariant: **every field is `#[serde(default)]`/lenient**, so a line of *any*
+//! shape deserializes without error. The parser applies `CodexLineDto` to every
+//! line; wrong-shaped payloads degrade via the classifier `Other` path, not a
+//! hard parse error.
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use crate::agent::adapter::serde_helpers::{lenient_bool, lenient_i64, lenient_string};
+
+/// Top-level record type classifier — manual over `Option<String>` so a
+/// missing or non-string `type` falls through to `Other` instead of erroring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CodexRecordType {
+    SessionMeta,
+    ResponseItem,
+    EventMsg,
+    Other,
+}
+
+/// Inner payload-type classifier — same manual pattern for `payload.type`.
+/// Used for BOTH `response_item` and `event_msg` payloads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CodexPayloadType {
+    FunctionCall,
+    FunctionCallOutput,
+    ExecCommandEnd,
+    UserMessage,
+    PatchApplyEnd,
+    CustomToolCall,
+    CustomToolCallOutput,
+    Other,
+}
+
+/// One transcript JSONL line: `{timestamp, type, payload}`.
+#[derive(Deserialize, Default)]
+pub(super) struct CodexLineDto {
+    #[serde(rename = "type", default, deserialize_with = "lenient_string")]
+    pub type_tag: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub timestamp: Option<String>,
+    #[serde(default)]
+    pub payload: Value,
+}
+
+impl CodexLineDto {
+    pub fn record_type(&self) -> CodexRecordType {
+        match self.type_tag.as_deref() {
+            Some("session_meta") => CodexRecordType::SessionMeta,
+            Some("response_item") => CodexRecordType::ResponseItem,
+            Some("event_msg") => CodexRecordType::EventMsg,
+            _ => CodexRecordType::Other,
+        }
+    }
+}
+
+/// Per-payload DTO with all scalar leaves typed lenient. Different payload
+/// types use different subsets; every field is `Option`/`Default` so an
+/// unrecognized payload degrades gracefully.
+#[derive(Deserialize, Default)]
+pub(super) struct CodexPayloadDto {
+    #[serde(rename = "type", default, deserialize_with = "lenient_string")]
+    pub type_tag: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub call_id: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub name: Option<String>,
+    #[allow(dead_code)]
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub status: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub message: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub cwd: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub aggregated_output: Option<String>,
+    #[serde(default, deserialize_with = "lenient_bool")]
+    pub success: Option<bool>,
+    #[serde(default, deserialize_with = "lenient_i64")]
+    pub exit_code: Option<i64>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub arguments: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub output: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub input: Option<String>,
+    /// Captures `duration` (and any other non-scalar fields). Presence is
+    /// `rest.contains_key("duration")`; the value is `rest.get("duration")`.
+    /// Present (even `null` / non-object) → `Some(0)`; absent → `None`.
+    #[serde(flatten)]
+    pub rest: Map<String, Value>,
+}
+
+impl CodexPayloadDto {
+    pub fn payload_type(&self) -> CodexPayloadType {
+        match self.type_tag.as_deref() {
+            Some("function_call") => CodexPayloadType::FunctionCall,
+            Some("function_call_output") => CodexPayloadType::FunctionCallOutput,
+            Some("exec_command_end") => CodexPayloadType::ExecCommandEnd,
+            Some("user_message") => CodexPayloadType::UserMessage,
+            Some("patch_apply_end") => CodexPayloadType::PatchApplyEnd,
+            Some("custom_tool_call") => CodexPayloadType::CustomToolCall,
+            Some("custom_tool_call_output") => CodexPayloadType::CustomToolCallOutput,
+            _ => CodexPayloadType::Other,
+        }
+    }
+}
+
+/// Re-parsed from `function_call.arguments` (a JSON-encoded string). Fields use
+/// `lenient_string` so a wrong-typed field degrades to `None` *independently* —
+/// matching the original per-field `args.get(k).and_then(Value::as_str)` reads
+/// (a plain `Option<String>` would fail the whole struct parse on one bad
+/// field, losing the sibling `cmd`/`path` reads).
+#[derive(Deserialize, Default)]
+pub(super) struct CodexExecArgsDto {
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub workdir: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub cmd: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub command: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub path: Option<String>,
+    #[serde(default, deserialize_with = "lenient_string")]
+    pub file_path: Option<String>,
+}
+
+/// Re-parsed from custom-tool `output` (a JSON-encoded string).
+#[derive(Deserialize, Default)]
+pub(super) struct CodexCustomToolOutputDto {
+    #[serde(default)]
+    pub metadata: Option<CodexCustomToolMetadataDto>,
+}
+
+#[derive(Deserialize, Default)]
+pub(super) struct CodexCustomToolMetadataDto {
+    #[serde(default, deserialize_with = "lenient_i64")]
+    pub exit_code: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_record_type_falls_through_on_unknown_missing_or_non_string() {
+        let unknown: CodexLineDto =
+            serde_json::from_str(r#"{"type":"brand_new_kind","payload":{}}"#).unwrap();
+        assert!(matches!(unknown.record_type(), CodexRecordType::Other));
+        let missing: CodexLineDto = serde_json::from_str(r#"{"payload":{}}"#).unwrap();
+        assert!(matches!(missing.record_type(), CodexRecordType::Other));
+        let nonstring: CodexLineDto =
+            serde_json::from_str(r#"{"type":42,"payload":{}}"#).unwrap();
+        assert!(matches!(nonstring.record_type(), CodexRecordType::Other));
+    }
+
+    #[test]
+    fn codex_payload_type_falls_through_on_unknown_missing_or_non_string() {
+        let unknown: CodexPayloadDto =
+            serde_json::from_str(r#"{"type":"brand_new_kind"}"#).unwrap();
+        assert!(matches!(unknown.payload_type(), CodexPayloadType::Other));
+        let missing: CodexPayloadDto = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(matches!(missing.payload_type(), CodexPayloadType::Other));
+        let nonstring: CodexPayloadDto = serde_json::from_str(r#"{"type":42}"#).unwrap();
+        assert!(matches!(nonstring.payload_type(), CodexPayloadType::Other));
+    }
+
+    #[test]
+    fn codex_exec_end_exit_code_is_lenient_and_duration_presence_preserved() {
+        let p: CodexPayloadDto =
+            serde_json::from_str(r#"{"exit_code":"bad","aggregated_output":"o"}"#).unwrap();
+        assert_eq!(p.exit_code, None);
+        assert!(p.rest.get("duration").is_none());
+
+        let p2: CodexPayloadDto = serde_json::from_str(r#"{"duration":null}"#).unwrap();
+        assert_eq!(p2.rest.get("duration"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn codex_duration_present_non_object_yields_some_zero() {
+        let p: CodexPayloadDto = serde_json::from_str(r#"{"duration":123}"#).unwrap();
+        assert!(p.rest.contains_key("duration"));
+        assert_eq!(p.rest.get("duration"), Some(&Value::Number(123.into())));
+    }
+
+    #[test]
+    fn codex_line_dto_parses_non_object_payload_without_error() {
+        let dto: CodexLineDto =
+            serde_json::from_str(r#"{"type":"event_msg","payload":42}"#).unwrap();
+        assert_eq!(dto.record_type(), CodexRecordType::EventMsg);
+        assert_eq!(dto.payload, Value::Number(42.into()));
+    }
+
+    #[test]
+    fn codex_custom_tool_output_dto_reads_metadata_exit_code() {
+        let dto: CodexCustomToolOutputDto =
+            serde_json::from_str(r#"{"metadata":{"exit_code":1}}"#).unwrap();
+        assert_eq!(dto.metadata.unwrap().exit_code, Some(1));
+
+        let dto2: CodexCustomToolOutputDto =
+            serde_json::from_str(r#"{"metadata":{"exit_code":"oops"}}"#).unwrap();
+        assert_eq!(dto2.metadata.unwrap().exit_code, None);
+    }
+}

--- a/crates/backend/src/agent/adapter/codex/transcript_dto.rs
+++ b/crates/backend/src/agent/adapter/codex/transcript_dto.rs
@@ -71,9 +71,6 @@ pub(super) struct CodexPayloadDto {
     pub call_id: Option<String>,
     #[serde(default, deserialize_with = "lenient_string")]
     pub name: Option<String>,
-    #[allow(dead_code)]
-    #[serde(default, deserialize_with = "lenient_string")]
-    pub status: Option<String>,
     #[serde(default, deserialize_with = "lenient_string")]
     pub message: Option<String>,
     #[serde(default, deserialize_with = "lenient_string")]

--- a/crates/backend/src/agent/adapter/serde_helpers.rs
+++ b/crates/backend/src/agent/adapter/serde_helpers.rs
@@ -110,6 +110,36 @@ where
     Ok(serde_json::from_value::<T>(value).ok())
 }
 
+/// Deserialize an `Option<bool>` field with wrong-type tolerance.
+///
+/// Returns `Ok(None)` for missing / `null` / non-bool inputs (a `"true"`
+/// string or a number is NOT a bool). Returns `Ok(Some(_))` for JSON
+/// booleans.
+///
+/// Mirrors the pre-A-transcript behavior of
+/// `value.get(key).and_then(Value::as_bool)`.
+pub(super) fn lenient_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Value::deserialize(deserializer)?.as_bool())
+}
+
+/// Deserialize an `Option<i64>` field with wrong-type tolerance.
+///
+/// Returns `Ok(None)` for missing / `null` / non-integer inputs (a numeric
+/// string or a non-integer float is NOT an i64). Returns `Ok(Some(_))` for
+/// JSON integers in i64 range.
+///
+/// Mirrors the pre-A-transcript behavior of
+/// `value.get(key).and_then(Value::as_i64)`.
+pub(super) fn lenient_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Value::deserialize(deserializer)?.as_i64())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -123,6 +153,10 @@ mod tests {
         ratio: Option<f64>,
         #[serde(default, deserialize_with = "lenient_string")]
         label: Option<String>,
+        #[serde(default, deserialize_with = "lenient_bool")]
+        flag: Option<bool>,
+        #[serde(default, deserialize_with = "lenient_i64")]
+        code: Option<i64>,
     }
 
     #[test]
@@ -175,6 +209,47 @@ mod tests {
 
         let p: Probe = serde_json::from_str(r#"{"label": null}"#).expect("null ok→None");
         assert_eq!(p.label, None);
+    }
+
+    #[test]
+    fn lenient_bool_accepts_bools_rejects_others() {
+        let p: Probe = serde_json::from_str(r#"{"flag": true}"#).expect("bool ok");
+        assert_eq!(p.flag, Some(true));
+
+        // Wrong types → None (matches `Value::as_bool`): a "true" string or 1 is not a bool.
+        let p: Probe = serde_json::from_str(r#"{"flag": "true"}"#).expect("string ok→None");
+        assert_eq!(p.flag, None);
+
+        let p: Probe = serde_json::from_str(r#"{"flag": 1}"#).expect("number ok→None");
+        assert_eq!(p.flag, None);
+
+        let p: Probe = serde_json::from_str(r#"{"flag": null}"#).expect("null ok→None");
+        assert_eq!(p.flag, None);
+
+        let p: Probe = serde_json::from_str(r#"{}"#).expect("missing ok→None");
+        assert_eq!(p.flag, None);
+    }
+
+    #[test]
+    fn lenient_i64_accepts_ints_rejects_others() {
+        let p: Probe = serde_json::from_str(r#"{"code": -3}"#).expect("negative int ok");
+        assert_eq!(p.code, Some(-3));
+
+        let p: Probe = serde_json::from_str(r#"{"code": 0}"#).expect("zero ok");
+        assert_eq!(p.code, Some(0));
+
+        // Wrong types → None (matches `Value::as_i64`): strings and non-integer floats.
+        let p: Probe = serde_json::from_str(r#"{"code": "3"}"#).expect("string ok→None");
+        assert_eq!(p.code, None);
+
+        let p: Probe = serde_json::from_str(r#"{"code": 1.5}"#).expect("float ok→None");
+        assert_eq!(p.code, None);
+
+        let p: Probe = serde_json::from_str(r#"{"code": null}"#).expect("null ok→None");
+        assert_eq!(p.code, None);
+
+        let p: Probe = serde_json::from_str(r#"{}"#).expect("missing ok→None");
+        assert_eq!(p.code, None);
     }
 
     /// Per-field tolerance — one wrong-typed field does NOT poison

--- a/docs/superpowers/plans/2026-05-25-transcript-dtos-and-engine.md
+++ b/docs/superpowers/plans/2026-05-25-transcript-dtos-and-engine.md
@@ -9,9 +9,10 @@
 **Tech Stack:** Rust (`crates/backend`), `serde` / `serde_json`, `cargo test`. Frontend untouched (transcript DTOs are internal — no `#[derive(TS)]`).
 
 **Conventions for every task:**
+
 - Commit type `test:` for Phase 0, `feat:`/`refactor:` for Phase 1/2, per commitlint. End commit bodies with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
 - After any `cargo test`, if `git status` shows `src/bindings/` churn, `git restore src/bindings/` before committing (ts-rs regenerates raw files; F-BINDINGS).
-- The crate's **package name is `vimeflow`** (`crates/backend/Cargo.toml`); `vimeflow-backend` is only the *binary target*. So all Cargo commands use `-p vimeflow` (never `-p vimeflow-backend`).
+- The crate's **package name is `vimeflow`** (`crates/backend/Cargo.toml`); `vimeflow-backend` is only the _binary target_. So all Cargo commands use `-p vimeflow` (never `-p vimeflow-backend`).
 - Run a single Rust test with `cargo test -p vimeflow <test_name> -- --nocapture`. Cargo accepts only **one** filter before `--`; run multiple test names as separate commands.
 - For any task that **creates** a new file, `git add <path>` before committing — `git commit -am` stages only already-tracked files.
 
@@ -20,17 +21,20 @@
 ## File Structure
 
 **Phase 0 (tests only):**
+
 - Modify: `crates/backend/src/agent/adapter/claude_code/transcript_fixture_tests.rs` — add Claude `T-replay`.
 - Modify: `crates/backend/src/agent/adapter/codex/transcript.rs` (`#[cfg(test)] mod tests`) — add Codex `T-replay`.
 
 **Phase 1 (A-transcript):**
+
 - Modify: `crates/backend/src/agent/adapter/serde_helpers.rs` — add `lenient_bool`, `lenient_i64` (+ tests).
 - Create: `crates/backend/src/agent/adapter/claude_code/transcript_dto.rs` — Claude line/message/block DTOs.
 - Create: `crates/backend/src/agent/adapter/codex/transcript_dto.rs` — Codex envelope + per-`type` payload DTOs + inner arg/output DTOs.
 - Modify: `claude_code/transcript.rs`, `codex/transcript.rs` — migrate `process_line` bodies to DTOs; retarget helpers; `use super::transcript_dto::…`.
-- Modify: `claude_code/mod.rs`, `codex/mod.rs` — declare `mod transcript_dto;` here. **A sibling-module declaration must live in the parent `mod.rs`** (exactly like the existing `mod statusline;`); declaring `mod transcript_dto;` *inside* `transcript.rs` would resolve to `transcript/transcript_dto.rs` and fail to find the sibling file.
+- Modify: `claude_code/mod.rs`, `codex/mod.rs` — declare `mod transcript_dto;` here. **A sibling-module declaration must live in the parent `mod.rs`** (exactly like the existing `mod statusline;`); declaring `mod transcript_dto;` _inside_ `transcript.rs` would resolve to `transcript/transcript_dto.rs` and fail to find the sibling file.
 
 **Phase 2 (C engine):**
+
 - Create: `crates/backend/src/agent/adapter/base/transcript_tail_service.rs` — `TranscriptDecoder` trait + `TranscriptTailService` + `POLL_INTERVAL`.
 - Modify: `crates/backend/src/agent/adapter/base/mod.rs` — wire + re-export.
 - Create/Modify: `claude_code/transcript.rs`, `codex/transcript.rs` — `<Provider>TranscriptDecoder` (move `process_line` + per-session state); thin `start_tailing`; delete `tail_loop`; add the deterministic + end-to-end buffering tests.
@@ -39,11 +43,12 @@
 
 ## Phase 0 — Characterization tests (PR 1, no production change)
 
-> **Note — these are characterization tests, not classic TDD.** They pin *current* behavior, so they must **PASS against the current code**. "Expected: PASS" below means the existing behavior already satisfies the assertion; a FAIL means current behavior differs from the spec's assumption — stop and investigate, do not "fix" the test to be green. Harness: `FakeEventSink` (`runtime::FakeEventSink`) — `wait_for_count(event, count, timeout) -> bool`, `count(event) -> usize`, `recorded() -> Vec<(String, Value)>`. (Spec § 3.)
+> **Note — these are characterization tests, not classic TDD.** They pin _current_ behavior, so they must **PASS against the current code**. "Expected: PASS" below means the existing behavior already satisfies the assertion; a FAIL means current behavior differs from the spec's assumption — stop and investigate, do not "fix" the test to be green. Harness: `FakeEventSink` (`runtime::FakeEventSink`) — `wait_for_count(event, count, timeout) -> bool`, `count(event) -> usize`, `recorded() -> Vec<(String, Value)>`. (Spec § 3.)
 
 ### Task 0.1: Claude `T-replay` (replay→live boundary via `test-run`)
 
 **Files:**
+
 - Test: `crates/backend/src/agent/adapter/claude_code/transcript_fixture_tests.rs`
 
 - [ ] **Step 1: Read the existing harness + the replay fixture.**
@@ -107,6 +112,7 @@ git commit -m "test(transcript): pin Claude replay-collapse then live test-run"
 ### Task 0.2: Codex `T-replay`
 
 **Files:**
+
 - Test: `crates/backend/src/agent/adapter/codex/transcript.rs` (`#[cfg(test)] mod tests`)
 
 - [ ] **Step 1: Read the existing Codex loop test.**
@@ -168,6 +174,7 @@ git commit -m "test(transcript): pin Codex replay-collapse then live test-run"
 ### Task 1.1: Add `lenient_bool` + `lenient_i64` helpers
 
 **Files:**
+
 - Modify: `crates/backend/src/agent/adapter/serde_helpers.rs`
 
 - [ ] **Step 1: Write the failing helper tests** (mirror `lenient_string_accepts_strings_rejects_others`).
@@ -235,6 +242,7 @@ git commit -m "feat(transcript): add lenient_bool and lenient_i64 deserializers"
 ### Task 1.2: Claude transcript DTOs (`transcript_dto.rs`)
 
 **Files:**
+
 - Create: `crates/backend/src/agent/adapter/claude_code/transcript_dto.rs`
 - Modify: `claude_code/mod.rs` (add `mod transcript_dto;` — sibling decl lives in the parent `mod.rs`, like `mod statusline;`)
 - Modify: `claude_code/transcript.rs` (`use super::transcript_dto::…`)
@@ -340,18 +348,20 @@ git commit -m "feat(transcript): add Claude transcript DTOs"
 ### Task 1.3: Retarget `extract_tool_result_content` to take the content value (Claude)
 
 **Files:**
+
 - Modify: `claude_code/transcript.rs`
 
-This is a **pure refactor done *before* the DTO migration** — it still operates on raw `Value`, so it compiles and stays green standalone (Task 1.4 later feeds it `&dto.content`). `summarize_input` already takes the input *value* and the three `input` consumers (`bash_command`/`tool_file_path`/`summarize_input`, `claude:378`) keep their current args here — only `extract_tool_result_content` is retargeted.
+This is a **pure refactor done _before_ the DTO migration** — it still operates on raw `Value`, so it compiles and stays green standalone (Task 1.4 later feeds it `&dto.content`). `summarize_input` already takes the input _value_ and the three `input` consumers (`bash_command`/`tool_file_path`/`summarize_input`, `claude:378`) keep their current args here — only `extract_tool_result_content` is retargeted.
 
 - [ ] **Step 1: Change the signature** to `fn extract_tool_result_content(content: &Value) -> String`, deleting its internal `value.get("content")` lookup (the former `raw` becomes the `content` arg, `claude:686`).
-- [ ] **Step 2: Update *all* call sites** to pass the content value: (a) the production `process_tool_result` (still on the raw block) → `extract_tool_result_content(block.get("content").unwrap_or(&Value::Null))`; (b) the **existing `extract_tool_result_content_*` tests** (F15/F1), which currently build an enclosing `serde_json::json!({ "content": … })` and pass the whole object → change them to pass the content value directly (`&value["content"]`). Both are behavior-neutral (absent and `null` both yield `""`). Missing (b) is the trap: the helper would otherwise receive `{"content": …}` and see no `content` field.
+- [ ] **Step 2: Update _all_ call sites** to pass the content value: (a) the production `process_tool_result` (still on the raw block) → `extract_tool_result_content(block.get("content").unwrap_or(&Value::Null))`; (b) the **existing `extract_tool_result_content_*` tests** (F15/F1), which currently build an enclosing `serde_json::json!({ "content": … })` and pass the whole object → change them to pass the content value directly (`&value["content"]`). Both are behavior-neutral (absent and `null` both yield `""`). Missing (b) is the trap: the helper would otherwise receive `{"content": …}` and see no `content` field.
 - [ ] **Step 3: Run — expect PASS.** `cargo test -p vimeflow extract_tool_result_content` (matches the F15/F1 test fns by name) → PASS; **confirm the summary reports those tests ran (not `0 passed`)**.
 - [ ] **Step 4: Commit.** `git commit -am "refactor(transcript): extract_tool_result_content takes the content value"`
 
 ### Task 1.4: Migrate Claude `process_line` to DTOs + regression tests
 
 **Files:**
+
 - Modify: `claude_code/transcript.rs`
 
 - [ ] **Step 1: Write the DTO/event regression tests** (drive `process_line` / `tail` and assert events survive wrong-typed + presence-sensitive inputs).
@@ -369,19 +379,20 @@ fn summarize_input_preserves_absent_vs_null() {
 }
 ```
 
-- [ ] **Step 2: Run the baseline — expect PASS.** `cargo test -p vimeflow summarize_input_preserves_absent_vs_null` and `cargo test -p vimeflow process_line_emits_with_wrong_typed_is_error` (separately) → both PASS against the *current* code (the current `.and_then(as_bool).unwrap_or(false)` / `summarize_input` already degrade gracefully). They are the regression net: the Step 3 migration must keep them green. **Confirm each reports 1 test ran (not `0`).**
-- [ ] **Step 3: Migrate the `process_line` body**, shape-by-shape (spec § 4 enumerates every field + its consumer). Parse each line once via `serde_json::from_str::<ClaudeTranscriptLineDto>(line)`. **Invariant — no line ever deserialize-fails:** every `ClaudeTranscriptLineDto` field is `#[serde(default)]`/lenient, so a non-`tool_result` line simply gets `content = Value::Null`, `tool_use_id`/`is_error = None`, and a wrong-shaped `message` degrades to `None` via `lenient_object`; the DTO is therefore safe to apply to *all* line types, not just `tool_result`. Then read typed fields; classify `message.content` items with the existing ported predicates (`is_user_prompt`, `is_non_empty_user_block`, `line_type`); feed `summarize_input` / `bash_command` / `tool_file_path` the preserved raw `input`. Keep the emitted events byte-for-byte for deterministic fields.
+- [ ] **Step 2: Run the baseline — expect PASS.** `cargo test -p vimeflow summarize_input_preserves_absent_vs_null` and `cargo test -p vimeflow process_line_emits_with_wrong_typed_is_error` (separately) → both PASS against the _current_ code (the current `.and_then(as_bool).unwrap_or(false)` / `summarize_input` already degrade gracefully). They are the regression net: the Step 3 migration must keep them green. **Confirm each reports 1 test ran (not `0`).**
+- [ ] **Step 3: Migrate the `process_line` body**, shape-by-shape (spec § 4 enumerates every field + its consumer). Parse each line once via `serde_json::from_str::<ClaudeTranscriptLineDto>(line)`. **Invariant — no line ever deserialize-fails:** every `ClaudeTranscriptLineDto` field is `#[serde(default)]`/lenient, so a non-`tool_result` line simply gets `content = Value::Null`, `tool_use_id`/`is_error = None`, and a wrong-shaped `message` degrades to `None` via `lenient_object`; the DTO is therefore safe to apply to _all_ line types, not just `tool_result`. Then read typed fields; classify `message.content` items with the existing ported predicates (`is_user_prompt`, `is_non_empty_user_block`, `line_type`); feed `summarize_input` / `bash_command` / `tool_file_path` the preserved raw `input`. Keep the emitted events byte-for-byte for deterministic fields.
 - [ ] **Step 4: Run the full Claude transcript tests + Phase 0 `T-replay`** — `cargo test -p vimeflow claude_code` (the module-root filter covers `transcript`, `transcript_dto`, **and** the Phase 0 `transcript_fixture_tests`) → all green. Restore `src/bindings/` if perturbed.
 - [ ] **Step 5: Commit.** `git commit -am "refactor(transcript): migrate Claude process_line to typed DTOs"`
 
 ### Task 1.5: Codex transcript DTOs (`transcript_dto.rs`)
 
 **Files:**
+
 - Create: `crates/backend/src/agent/adapter/codex/transcript_dto.rs`
 - Modify: `codex/mod.rs` (declare `mod transcript_dto;` — sibling decl lives in the parent `mod.rs`, like `mod statusline;`/`mod parser;`)
 - Modify: `codex/transcript.rs` (`use super::transcript_dto::…`)
 
-**Reference:** spec § 4 "Codex shapes" — `{timestamp, type, payload}` envelope; **two-level dispatch** (top-level `type`: `session_meta`/`response_item`/`event_msg`; inner `payload.type` for BOTH `response_item` *and* `event_msg`, `codex:347`). Each dispatch is a **manual classifier over `Option<String>`** (read the tag with `lenient_string`, `match tag.as_deref()` with an `Other` default) — **not** a `#[serde(tag="type")]` + `#[serde(other)]` enum, which *errors* on a missing or non-string tag rather than falling through. Payload scalars typed lenient (`call_id`/`name`/`status`/`message`/`aggregated_output` via `lenient_string`; `success` via `lenient_bool`; `exit_code` via `lenient_i64`, `codex:571`/`:595`). Raw carve-outs: `arguments`/`output`/custom-tool `input` as `Option<String>` (`lenient_string`) re-parsed by ported helpers; `duration` via `#[serde(flatten)] rest` presence (`codex:765`). Two cwd sources preserved in order (`session_meta.cwd` then `exec_command.arguments.workdir`, `codex:100`); `turn_context.cwd` NOT a source.
+**Reference:** spec § 4 "Codex shapes" — `{timestamp, type, payload}` envelope; **two-level dispatch** (top-level `type`: `session_meta`/`response_item`/`event_msg`; inner `payload.type` for BOTH `response_item` _and_ `event_msg`, `codex:347`). Each dispatch is a **manual classifier over `Option<String>`** (read the tag with `lenient_string`, `match tag.as_deref()` with an `Other` default) — **not** a `#[serde(tag="type")]` + `#[serde(other)]` enum, which _errors_ on a missing or non-string tag rather than falling through. Payload scalars typed lenient (`call_id`/`name`/`status`/`message`/`aggregated_output` via `lenient_string`; `success` via `lenient_bool`; `exit_code` via `lenient_i64`, `codex:571`/`:595`). Raw carve-outs: `arguments`/`output`/custom-tool `input` as `Option<String>` (`lenient_string`) re-parsed by ported helpers; `duration` via `#[serde(flatten)] rest` presence (`codex:765`). Two cwd sources preserved in order (`session_meta.cwd` then `exec_command.arguments.workdir`, `codex:100`); `turn_context.cwd` NOT a source.
 
 - [ ] **Step 1: Create `transcript_dto.rs` with the failing tests AND wire the module** — write the tests below into the new file, declare `mod transcript_dto;` in `codex/mod.rs`, and `use super::transcript_dto::…` in `transcript.rs`. (Declare the module now — an undeclared sibling file is ignored, so the red run would find zero tests; with it declared, the tests reference not-yet-defined DTOs → compile FAIL = the real red.) Tests: top-level + inner dispatch fall-through (incl. missing/non-string `type`), `exit_code`/`success` lenient, `duration` presence (absent vs null vs object), inner `arguments` re-parse.
 
@@ -415,6 +426,7 @@ fn codex_exec_end_exit_code_is_lenient_and_duration_presence_preserved() {
 ### Task 1.6: Migrate Codex `process_line` / `process_event_msg` / `process_response_item` to DTOs
 
 **Files:**
+
 - Modify: `codex/transcript.rs`
 
 - [ ] **Step 1: Write a Codex regression test** — a record with wrong-typed `exit_code` / `success` still emits the correct completion event; a `duration:null` exec_command_end still yields the `Some(0)` duration (per `exec_command_duration_ms`); a **non-string `timestamp`** still emits (falls back to `now_iso8601`, not dropped); `session_meta` AND mid-session `exec_command.arguments.workdir` both emit `agent-cwd` in order.
@@ -435,6 +447,7 @@ fn codex_exec_end_exit_code_is_lenient_and_duration_presence_preserved() {
 ### Task 2.1: Define the engine + wire the module
 
 **Files:**
+
 - Create: `crates/backend/src/agent/adapter/base/transcript_tail_service.rs`
 - Modify: `crates/backend/src/agent/adapter/base/mod.rs`
 
@@ -499,6 +512,7 @@ impl TranscriptTailService {
 ### Task 2.2: Deterministic engine buffering tests (`ScriptedBufRead` + recording decoder)
 
 **Files:**
+
 - Modify: `base/transcript_tail_service.rs` (`#[cfg(test)] mod tests`)
 
 - [ ] **Step 1: Add cross-module test support** — define `ScriptedBufRead`, `Step`, and `RecordingDecoder` as **`#[cfg(test)] pub(crate)`** items at **module level** in `transcript_tail_service.rs` (NOT inside a private `mod tests`), **and add the re-export to `base/mod.rs`** in this same task: `#[cfg(test)] pub(crate) use transcript_tail_service::{ScriptedBufRead, Step, RecordingDecoder};`. (Both land here together so no intermediate commit references missing items.) Task 2.3's `claude_code` test then imports `crate::agent::adapter::base::{ScriptedBufRead, Step, RecordingDecoder}` through the re-export — the private module path is not reachable from a sibling.
@@ -555,6 +569,7 @@ impl TranscriptDecoder for RecordingDecoder {
 ### Task 2.3: `ClaudeTranscriptDecoder` + thin `start_tailing` (Claude)
 
 **Files:**
+
 - Modify: `claude_code/transcript.rs`
 
 - [ ] **Step 1: Define `ClaudeTranscriptDecoder`** owning `events: Arc<dyn EventSink>`, `session_id: String`, `cwd: Option<PathBuf>`, `in_flight`, `num_turns`, `last_cwd`, `emitter: TestRunEmitter`. `new(events, session_id, cwd)` constructs it. Move the (Phase-1-typed) `process_line` body into `decode_line(&mut self, line: &str)`; `on_caught_up(&mut self)` calls `self.emitter.finish_replay()`.
@@ -566,6 +581,7 @@ impl TranscriptDecoder for RecordingDecoder {
 ### Task 2.4: `CodexTranscriptDecoder` + thin `start_tailing` (Codex)
 
 **Files:**
+
 - Modify: `codex/transcript.rs`
 
 - [ ] **Step 1:** Define `CodexTranscriptDecoder` (same shape; `in_flight` carries `CompletionMode`); move the typed `process_line` body into `decode_line`; `on_caught_up` → `finish_replay`.
@@ -584,7 +600,7 @@ impl TranscriptDecoder for RecordingDecoder {
 ## Self-Review notes (for the author before execution)
 
 - **Spec coverage:** Phase 0 (§ 3) → Tasks 0.1–0.3; Phase 1 (§ 4) → 1.1–1.7 (lenient helpers, both DTO files, retargets, both migrations, presence-sensitive + wrong-typed regression tests); Phase 2 (§ 5) → 2.1–2.5 (engine, deterministic tests, both decoders, thin `start_tailing`, end-to-end G3, `tail_loop` deletion); Step F (§ 6) is deferred (no task — only the #246 note in 2.5). Frozen constraints (§ 2) are gate checks in 0.3 / 1.7 / 2.5.
-- **Known under-specification (intentional):** the per-site `process_line` migrations (Tasks 1.4 / 1.6) give the transformation *pattern* + the typed DTOs + the regression test net rather than enumerating all ~46/~55 sites verbatim — the spec § 4 is the exhaustive field reference, and the existing parse tests + new regression tests catch any missed site. The `ScriptedBufRead` script representation (Task 2.2) is sketched as a `Vec<Step>` enum; the author finalizes the exact enum.
+- **Known under-specification (intentional):** the per-site `process_line` migrations (Tasks 1.4 / 1.6) give the transformation _pattern_ + the typed DTOs + the regression test net rather than enumerating all ~46/~55 sites verbatim — the spec § 4 is the exhaustive field reference, and the existing parse tests + new regression tests catch any missed site. The `ScriptedBufRead` script representation (Task 2.2) is sketched as a `Vec<Step>` enum; the author finalizes the exact enum.
 - **Type consistency:** decoder API is `decode_line(&mut self, line: &str)` / `on_caught_up(&mut self)` everywhere; service is `TranscriptTailService::new(decoder, label)` + `run<R: BufRead>(mut self, reader, stop)`; provider labels `"transcript"` (Claude) / `"Codex rollout transcript"` (Codex) feed `"Error reading {label} line: {e}"`.
 
 <!-- codex-reviewed: 2026-05-26T07:33:56Z -->

--- a/docs/superpowers/specs/2026-05-25-transcript-dtos-and-engine-design.md
+++ b/docs/superpowers/specs/2026-05-25-transcript-dtos-and-engine-design.md
@@ -21,11 +21,11 @@ rollout-status parsers with typed `#[derive(Deserialize)]` DTOs +
 `lenient_*` deserializers (see
 [`docs/reviews/patterns/parser-resilience.md`](../../reviews/patterns/parser-resilience.md)).
 Separately, both tailers independently re-implement near-identical
-streaming *mechanics* — the `BufReader`/`read_line` loop, `stop_flag`,
+streaming _mechanics_ — the `BufReader`/`read_line` loop, `stop_flag`,
 `POLL_INTERVAL`, and the `TestRunEmitter` replay boundary. Each also
-declares the same *shape* of per-session state
+declares the same _shape_ of per-session state
 (`in_flight`/`num_turns`/`last_cwd`), threaded identically through the
-loop — but the state's *type* is provider-specific (Codex's
+loop — but the state's _type_ is provider-specific (Codex's
 `InFlightToolCall` carries `CompletionMode`, Claude's does not). That
 split is precisely why C keeps the loop mechanics in the shared service
 while the state itself lives in the provider decoder (§ 2 G2). The two
@@ -33,23 +33,23 @@ behavioral divergences are:
 
 - the per-line `process_line` body — the genuinely provider-specific
   part (Claude content-blocks vs Codex `response_item` / `function_call`
-  + `CompletionMode`); and
+  - `CompletionMode`); and
 - **partial-line buffering** — Codex buffers a JSONL line split across
   read boundaries until its trailing `\n`
   (`codex/transcript.rs`), while Claude processes each `read_line`
   result immediately (`claude_code/transcript.rs`) and therefore
-  *silently drops* events on a split line. This is a behavioral
+  _silently drops_ events on a split line. This is a behavioral
   divergence, not shared scaffolding — see the standardization
   decision below.
 
 **Why now / why paired.** A-transcript makes the implicit `Value`-pull
-tolerance explicit, centralized, and test-pinned. It does *not* by itself
+tolerance explicit, centralized, and test-pinned. It does _not_ by itself
 convert an upstream field rename into a failure — lenient parsing still
 deserializes a missing/renamed field to `None`, exactly as the `Value`
 walk did — but it collapses the ~100 scattered `.get("x") → None` no-ops
 into one declared per-message contract whose tolerance is reviewable in
 one place and exercised by fixtures, so field-shape drift becomes
-*detectable under test* instead of an invisible no-emit. C removes the
+_detectable under test_ instead of an invisible no-emit. C removes the
 duplication so future tailer changes happen once instead of twice. They
 are paired because:
 
@@ -59,7 +59,7 @@ are paired because:
   decoder's `decode_line` would still hold a `Value`-pull body — the seam
   lands while the ~100 fragile extraction sites stay untyped, and you'd
   rewrite those same bodies again when A-transcript follows. Pairing
-  rewrites each body *once*: typed as it moves into its decoder.
+  rewrites each body _once_: typed as it moves into its decoder.
 
 **Why gated behind a test-hardening Phase 0.** A coverage audit (2026-05-25)
 found the transcript test suites are strong on per-line parsing (which
@@ -67,11 +67,11 @@ de-risks A-transcript) but have two gaps on exactly the streaming-engine
 behaviors C extracts:
 
 1. **Partial-line buffering** — Codex has it, Claude doesn't, and
-   *neither* is tested at the tailer level (the integration tests
+   _neither_ is tested at the tailer level (the integration tests
    `fs::write` the whole file once, so the split-line path never runs).
    **Decision: C standardizes on Codex-style buffering for both.** For
-   Codex this is preservation; for Claude it is an *intentional behavior
-   change* that fixes the latent split-line event drop (buffering is
+   Codex this is preservation; for Claude it is an _intentional behavior
+   change_ that fixes the latent split-line event drop (buffering is
    ~free: two byte-compares per complete line, one reused buffer, no
    steady-state allocation — the per-line JSON parse dwarfs it). The
    exact buffering contract — EOF with a pending non-`\n`-terminated
@@ -82,21 +82,22 @@ behaviors C extracts:
 
    **Sequencing (important):** Phase 0 pins only the **replay→live
    boundary** (deterministically, via `test-run` counts — see § 3); it
-   does *not* add a split-line buffering test. A buffering test can be made
+   does _not_ add a split-line buffering test. A buffering test can be made
    deterministic only by feeding bytes to the extracted buffering
-   *synchronously*, which is impossible while buffering is inlined in
-   `tail_loop` (a poll-loop integration test cannot prove a *buffered*
+   _synchronously_, which is impossible while buffering is inlined in
+   `tail_loop` (a poll-loop integration test cannot prove a _buffered_
    partial was read before the line completed). So **both** buffering
-   tests — Codex's preserved behavior *and* Claude's newly-added behavior —
+   tests — Codex's preserved behavior _and_ Claude's newly-added behavior —
    land in C (§ 5) as one synchronous unit test on `TranscriptTailService`:
-   where the test can be deterministic *and* where buffering could actually
+   where the test can be deterministic _and_ where buffering could actually
    regress. Phase 0 = "pin (only) what can be deterministically pinned
    before extraction."
-2. **Replay → live boundary** — no test appends a line *after* the initial
+
+2. **Replay → live boundary** — no test appends a line _after_ the initial
    EOF / `finish_replay` to assert live emission. Pure preservation for
    both adapters → fully covered in Phase 0.
 
-Net: Phase 0 lands all-green against *current* behavior (both adapters'
+Net: Phase 0 lands all-green against _current_ behavior (both adapters'
 replay→live) before any refactor touches the code it protects. Buffering —
 Codex's preserved behavior and Claude's new behavior alike — is pinned
 deterministically in C (§ 5), the same PR that extracts and changes it.
@@ -119,33 +120,33 @@ design + go/no-go after A-transcript + C land.
   DTOs + `lenient_*` deserializers, mirroring A-status (#257) and
   [`parser-resilience.md`](../../reviews/patterns/parser-resilience.md).
   Outcome: the parse contract becomes explicit, centralized, and
-  test-pinned. This does *not* make an upstream field rename a compile
+  test-pinned. This does _not_ make an upstream field rename a compile
   failure — `Option<T>` / `#[serde(default)]` / `lenient_*` deserialize a
   missing or renamed field to `None`, exactly as the `Value` walk did.
   The win is that the ~100 scattered implicit `.get("x") → None` no-ops
   collapse into one declared per-message DTO whose tolerance is reviewable
   in one place and exercised by fixtures, so field-shape drift is
-  *detectable under test* (a fixture-covered event stops emitting) instead
+  _detectable under test_ (a fixture-covered event stops emitting) instead
   of an invisible silent drop.
 - **G2 (C).** Hoist the duplicated tail scaffolding — the near-identical
   `tail_loop` in both `claude_code/transcript.rs:211` and
   `codex/transcript.rs:190` — into one `TranscriptTailService` that owns
-  exactly the provider-*agnostic* loop mechanics: the
+  exactly the provider-_agnostic_ loop mechanics: the
   `BufReader`/`read_line` loop, `stop_flag`, `POLL_INTERVAL`, partial-line
-  buffering, the read-error branch, and the *trigger* for the replay→live
-  boundary: it calls `decoder.on_caught_up()` on *each* EOF — like the
+  buffering, the read-error branch, and the _trigger_ for the replay→live
+  boundary: it calls `decoder.on_caught_up()` on _each_ EOF — like the
   current `finish_replay()` this is idempotent, so only the first call
   (the replay→live transition) has an observable effect. Everything
   provider-shaped — the per-session `in_flight` (whose value type
   differs: Codex carries `CompletionMode`, Claude does not), `num_turns`,
   `last_cwd`, and the `TestRunEmitter` — lives **inside** the injected
-  `TranscriptDecoder`, which is *constructed* with the per-session context
+  `TranscriptDecoder`, which is _constructed_ with the per-session context
   it needs (the `EventSink`, `session_id`, and `cwd`) and then exposes
   only `decode_line(&mut self, line: &str)` and `on_caught_up(&mut self)`
   (the `finish_replay` flush). Because that context is owned by the
   decoder, no per-line context struct is passed. The service therefore holds no provider state
   and needs no generic parameter — it is constructed from a `Box<dyn
-  TranscriptDecoder>` plus a `&'static str` provider label (used only for
+TranscriptDecoder>` plus a `&'static str` provider label (used only for
   the unified read-error log line required by F-CONCURRENCY). The trait
   carries a `Send` supertrait bound (`trait TranscriptDecoder: Send`) so
   the `Box<dyn TranscriptDecoder>` — already `'static` by the
@@ -153,9 +154,9 @@ design + go/no-go after A-transcript + C land.
   that G4 describes. § C specifies this boundary in full.
 - **G3 (consequence of G2).** Because the shared service has exactly one
   buffering implementation, **Claude adopts Codex-style buffering**. That
-  single change has two observable effects: it *fixes* the latent
+  single change has two observable effects: it _fixes_ the latent
   split-line event drop (Claude now emits those records), and a
-  *permanently* newline-less **final** record is no longer emitted — it
+  _permanently_ newline-less **final** record is no longer emitted — it
   stays buffered, matching Codex, where Claude today processes the no-`\n`
   `read_line` result immediately. Both effects are bounded by Phase-2
   tests (§ 5) and reflected in the F-EVENTS carve-out below.
@@ -169,10 +170,10 @@ design + go/no-go after A-transcript + C land.
 
 - **The rollout-locator subsystem** (`CompositeLocator` / `SqliteFirst` /
   `FsScan` and its ~8 supporting types) is **untouched**. A-transcript + C
-  scope is the transcript *parse* + *tail* path only — the locator is a
+  scope is the transcript _parse_ + _tail_ path only — the locator is a
   separate step-9 concern.
 - **A-status is not re-done.** It already shipped (#257); this effort
-  *reuses* its `lenient_*` helpers rather than re-deriving them.
+  _reuses_ its `lenient_*` helpers rather than re-deriving them.
 - **Step F** (the single-class session-lifecycle capstone) is **deferred**
   — see § 6. It reshapes `watcher_runtime` / the D' `AgentWatcherService`
   and earns its own design + go/no-go after A-transcript + C land.
@@ -182,25 +183,25 @@ design + go/no-go after A-transcript + C land.
 
 ### Frozen constraints (v4-frozen — must hold across A-transcript + C)
 
-- **F-EVENTS** — the emitted `AgentEvent` *variants and their shapes* are
+- **F-EVENTS** — the emitted `AgentEvent` _variants and their shapes_ are
   frozen; DTOs are an internal parse layer producing the same
   variants/shapes from the same bytes. **G3 carve-out (two sides of one
   change — Claude adopting Codex-style buffering):** (a) Claude now
-  *emits* the event for a split-line input it currently drops; (b) Claude
-  no longer *emits* a permanently newline-less *final* record (it stays
+  _emits_ the event for a split-line input it currently drops; (b) Claude
+  no longer _emits_ a permanently newline-less _final_ record (it stays
   buffered, matching Codex, where Claude today processes the no-`\n`
   `read_line` result immediately). (a) is the fix; (b) is benign — a
   newline-less final line is malformed/incomplete and both writers
   newline-terminate records — and is pinned by § 5's truncated-final test.
   No other byte→event mapping changes.
 - **F-TRAIT** — `TranscriptStreamer::tail(&self, events, session_id,
-  cwd, transcript_path) -> Result<TranscriptHandle, String>`
+cwd, transcript_path) -> Result<TranscriptHandle, String>`
   (`traits.rs:123`) is frozen, and its one-line delegation to
   `transcript::start_tailing` is unchanged; the body that changes is
   `start_tailing`'s (to construct a decoder + service — § 5).
   `TranscriptState::start_or_replace` is likewise
   unchanged — the shorthand "`Arc<dyn TranscriptStreamer>`" means its
-  *streamer* parameter stays `Arc<dyn TranscriptStreamer>`; its full B''
+  _streamer_ parameter stays `Arc<dyn TranscriptStreamer>`; its full B''
   signature (`streamer`, `events`, `session_id`, `transcript_path`,
   `cwd`) is untouched.
 - **F-CONCURRENCY** — `stop_flag` as `AtomicBool` read with
@@ -208,7 +209,7 @@ design + go/no-go after A-transcript + C land.
   `TranscriptHandle::stop` / `Drop`, PR #152 F12), `POLL_INTERVAL`
   (500 ms), and the first-EOF `finish_replay()` boundary are preserved
   verbatim by the shared service. The read-error → `warn` → sleep
-  *behavior* is preserved too, but the warning *text* is not a frozen
+  _behavior_ is preserved too, but the warning _text_ is not a frozen
   contract: the providers log different literals today
   (`codex/transcript.rs:251` "Error reading Codex rollout transcript
   line" vs `claude_code/transcript.rs:272` "Error reading transcript
@@ -228,36 +229,36 @@ design + go/no-go after A-transcript + C land.
 ## 3. Phase 0 — test hardening (lands first, all-green, no production change)
 
 **Purpose.** Build the regression net for the loop-level behaviors C
-extracts, *before* C touches them. Phase 0 adds tests only — zero
+extracts, _before_ C touches them. Phase 0 adds tests only — zero
 production changes — and is all-green against the current branch tip.
 
 **Existing coverage (do not redo).** Two layers already exist:
 
-- *Per-line parsing* — `parse_tool_use_from_assistant_line`,
+- _Per-line parsing_ — `parse_tool_use_from_assistant_line`,
   `extract_tool_result_content_*`, and the Codex `response_item` /
   `CompletionMode` tests are pure functions over a single JSON line.
   A-transcript (Phase 1) leans on these.
-- *End-to-end replay* — both adapters already drive the full loop with
+- _End-to-end replay_ — both adapters already drive the full loop with
   `FakeEventSink`, in different homes (detailed under **Harness** below):
   Claude via `transcript_fixture_tests.rs` (`start_or_replace`), Codex via
   the in-module `mod tests` in `codex/transcript.rs` (`start_tailing`).
-  Both write a whole fixture up front, so the loop *is* exercised — but
-  only in the **replay** direction (whole file written *before* start) and
+  Both write a whole fixture up front, so the loop _is_ exercised — but
+  only in the **replay** direction (whole file written _before_ start) and
   only on `\n`-terminated lines.
 
 **The gap (confirmed).** Because those fixtures write the file once up
 front, two behaviors C must preserve are never exercised: (1) a JSONL
 line **split across reads** (no test writes partial bytes then completes
 them); and (2) a line **appended after catch-up** (no test writes to the
-file *after* `start_or_replace`, so the post-first-EOF live-tail path and
+file _after_ `start_or_replace`, so the post-first-EOF live-tail path and
 the `finish_replay` boundary go untested). **Phase 0 closes only gap (2),
 the replay→live boundary.** Gap (1), split-line buffering, is real but
 cannot be pinned deterministically before extraction, so it is closed in C
 (§ 5) — see "Split-line buffering is pinned in C" below. Phase 0 does
-*not* re-cover replay or per-line parsing.
+_not_ re-cover replay or per-line parsing.
 
 **Harness — reuse each adapter's existing pattern.** The two adapters
-already test the loop end-to-end in *different* homes, and Phase 0 extends
+already test the loop end-to-end in _different_ homes, and Phase 0 extends
 each in place rather than inventing a shared one:
 
 - **Claude** — `claude_code/transcript_fixture_tests.rs`, driving
@@ -266,7 +267,7 @@ each in place rather than inventing a shared one:
   `codex/transcript.rs` (mirroring `start_tailing_replays_…` at
   `transcript.rs:878`), driving `start_tailing(...)`.
 
-Both entry points' *signatures* are preserved across C — the rewrite
+Both entry points' _signatures_ are preserved across C — the rewrite
 changes their bodies to build a decoder + `TranscriptTailService`, not
 their call shape — so tests written against them exercise today's
 `tail_loop` and tomorrow's `TranscriptTailService::run` **unchanged**,
@@ -282,7 +283,7 @@ split-write is a § 5 / C concern, not Phase 0.
 **Tests to add — T-replay (replay→live boundary via `test-run`, both
 adapters).** Only `test-run` events flow through `TestRunEmitter` /
 `finish_replay`; `agent-tool-call` / `agent-turn` / `agent-cwd` emit
-*independently* of the boundary and so cannot pin it. A `test-run` is
+_independently_ of the boundary and so cannot pin it. A `test-run` is
 built only when a test-runner tool **start** (registered in `in_flight`)
 is matched by its **completion** — an orphan completion returns `None` and
 never `submit`s — so the fixture uses start+completion **pairs**; and the
@@ -292,30 +293,30 @@ existing turn fixtures pass. Recipe:
 
 1. Pre-write **≥3** test-run-producing pairs. (≥3, not ≥2: the final
    assertion is `test-run == 2` = 1 replay-collapsed + 1 live; with only
-   *2* replay pairs, a regression that fails to collapse *and* drops the
+   _2_ replay pairs, a regression that fails to collapse _and_ drops the
    live snapshot would also total 2 — `2 uncollapsed + 0 live`. With ≥3,
    no-collapse totals ≥3 and missing-live totals 1, so `== 2` uniquely
    means "collapsed + live".) Claude already has this —
-   `transcript_vitest_replay.jsonl` carries *three* vitest pairs and
+   `transcript_vitest_replay.jsonl` carries _three_ vitest pairs and
    `replay_emits_only_latest_snapshot` already asserts the 3→1 collapse —
    so Claude's T-replay reuses that fixture and adds only the live half.
-   Codex's `start_tailing_replays_…` has just *one* `exec_command`
+   Codex's `start_tailing_replays_…` has just _one_ `exec_command`
    "cargo test" pair (`codex:898`; the apply-patch pair is not a
    test-runner pair), so the Codex test **authors two more pairs** from
    the same shape. **Copy** the fixture lines into a tempdir transcript and
-   tail *that* path — never the checked-in fixture, since the live appends
+   tail _that_ path — never the checked-in fixture, since the live appends
    in steps 3–4 would otherwise mutate it and skew future replay counts.
    Start the tail with `Some(cwd)`.
 2. **Catch-up barrier:** `wait_for_count("test-run", 1, 5s)`. With
    buffering, replay holds all snapshots and emits exactly one at
    `finish_replay` (first EOF), so the `test-run` count is `0` until then —
-   this wait proves replay is done, and only *now* is an append genuinely
+   this wait proves replay is done, and only _now_ is an append genuinely
    "live". Appending earlier would fold the new pair into replay and
    collapse it, making the final count scheduling-dependent.
-3. Append a *new* full pair **live** (start line, then completion line).
+3. Append a _new_ full pair **live** (start line, then completion line).
 4. **Drain barrier:** append a **sentinel** line emitting a distinct
    non-`test-run` event (a user prompt → `agent-turn`). Capture
-   `n0 = sink.count("agent-turn")` *before* the append, then
+   `n0 = sink.count("agent-turn")` _before_ the append, then
    `wait_for_count("agent-turn", n0 + 1, 5s)` — baseline-relative because
    the replay fixture already emits an `agent-turn` (`codex:893`), so an
    absolute `wait_for_count(.., 1)` would return immediately. Being last,
@@ -333,23 +334,23 @@ One test per adapter — both share the same `TestRunEmitter` and call
 `finish_replay()` (`claude:251`, `codex:209`).
 
 **Split-line buffering is pinned in C, not Phase 0.** A deterministic
-split-line test must feed bytes to the buffering logic *synchronously* —
+split-line test must feed bytes to the buffering logic _synchronously_ —
 impossible while buffering is inlined in `tail_loop`: an integration test
-through the real poll loop cannot prove a *buffered* partial was read
+through the real poll loop cannot prove a _buffered_ partial was read
 before the line completed, because a buffered partial emits no signal (any
 timing-based attempt either races or can false-pass). The authoritative
 pin therefore lands in C (§ 5) as a synchronous unit test on the extracted
-`TranscriptTailService` — both where the test *can* be deterministic and
+`TranscriptTailService` — both where the test _can_ be deterministic and
 where buffering could actually regress. That one C test covers Codex's
 preserved buffering **and** Claude's newly-added buffering (§ 1 G3).
 
 **Acceptance (Phase 0 gate).** Both transcript suites green with T-replay
 added (one per adapter); `git diff` touches test code only (no production
-change); the new tests pass against the *pre-refactor* `tail_loop`.
+change); the new tests pass against the _pre-refactor_ `tail_loop`.
 A-transcript and C do not start until Phase 0 is green and committed.
 
 **Out of scope for Phase 0.** The EOF-with-pending-partial edge (file
-ends mid-line, `\n` never arrives) is *not* pinned here — current Codex
+ends mid-line, `\n` never arrives) is _not_ pinned here — current Codex
 holds such a partial buffered indefinitely. That behavior and the
 standardized policy are defined and tested in § C (the deferred
 engine-contract decision), where the Claude change is introduced.
@@ -358,14 +359,14 @@ engine-contract decision), where the Claude change is introduced.
 
 **Precedent (follow exactly).** A-status (#257) already ran this play for
 the statusline / rollout-status parsers. A-transcript applies the
-*identical* recipe to the transcript `process_line` paths — it is a
+_identical_ recipe to the transcript `process_line` paths — it is a
 representation swap, not a behavior change.
 
 - **Reuse the shared deserializers** in `agent/adapter/serde_helpers.rs`:
   `lenient_string`, `lenient_u64`, `lenient_f64`, `lenient_object` (each
   returns `Option<T>` and degrades a wrong-typed field to `None` rather
   than erroring the parse). They are `pub(super)` = `pub(in
-  agent::adapter)`, and `statusline.rs` — a sibling at the same module
+agent::adapter)`, and `statusline.rs` — a sibling at the same module
   depth as `transcript.rs` — already calls them, so the transcript
   parsers reach them with **no visibility change**.
 - **Add two new lenient helpers** alongside them: `lenient_bool` and
@@ -375,7 +376,7 @@ representation swap, not a behavior change.
   custom-tool-output metadata path, `Value::as_i64`) — bool/signed-int
   fields A-status never needed, so `serde_helpers` has no helper for them
   yet. Without lenient versions, a wrong-typed `is_error` / `exit_code`
-  would *error* the DTO parse instead of degrading to `None` (changing
+  would _error_ the DTO parse instead of degrading to `None` (changing
   the current `.unwrap_or(false)` / `.is_some_and(..)` semantics). The two
   are a one-for-one extension of the existing precedent (same `Option<T>`
   / wrong-type→`None` shape).
@@ -391,35 +392,35 @@ representation swap, not a behavior change.
   DTO types + their fields (or the conversion fns over them) must be
   `pub(super)` so `transcript.rs` reads them as typed field access — a
   private DTO in a sibling/child module is not visible to the parser. Raw
-  `Value` carve-out **subfields** (Claude `tool_result.content`; *not* the
+  `Value` carve-out **subfields** (Claude `tool_result.content`; _not_ the
   whole Codex `payload`, which is a typed per-`type` DTO — only specific
-  subfields stay raw) carry `#[serde(default)]` so a *missing* field
+  subfields stay raw) carry `#[serde(default)]` so a _missing_ field
   deserializes to `Value::Null` rather than erroring — the ported helpers
   already treat Null/absent as the empty/`None` case (a `tool_result`
   missing `content` → `extract_tool_result_content` returns `""`), exactly
   as the current `.get(..) → None`. (An `Option<Value>` field instead defaults to `None`
-  *and* maps JSON `null` → `None`, collapsing the two — which is why
+  _and_ maps JSON `null` → `None`, collapsing the two — which is why
   presence-sensitive `duration` can use neither; see its Codex bullet.)
 
-**Claude shapes (~46 sites).** Type the *envelope*
+**Claude shapes (~46 sites).** Type the _envelope_
 (`ClaudeTranscriptLineDto` / `ClaudeMessageDto`), which must carry **all**
 top-level fields `process_line` reads — not just `{type, message,
-timestamp}` but also the top-level **`cwd`** (emits `agent-cwd` *before*
+timestamp}` but also the top-level **`cwd`** (emits `agent-cwd` _before_
 the `line_type` dispatch, `claude:301`) and the top-level **`tool_result`**
 shape (`tool_use_id` / `is_error` / `content`), since `tool_result` is one
 of the top-level `line_type` arms alongside `assistant` / `user`
 (`claude:326`) — not only a nested block. The per-content layer stays
-deliberately loose, because the current tolerance is *wider than derive
-can express*:
+deliberately loose, because the current tolerance is _wider than derive
+can express_:
 
 - **Content + block classification are not a derivable tagged enum.**
   `message.content` is string | array | (object/number/null), and the
-  last case must read as *no prompt* — never a line parse failure
+  last case must read as _no prompt_ — never a line parse failure
   (`is_user_prompt`, `claude:589`; test `:1343`). Within an array, a block
   with a **missing or non-string `type`** counts as user content
   (explicit test `…falls_through_to_content`, `claude:1376`), which a
   `#[serde(tag = "type")]` + `#[serde(other)]` enum cannot express (it
-  catches only unknown *string* tags and would fail on a typeless / non-
+  catches only unknown _string_ tags and would fail on a typeless / non-
   object item). So keep `content` raw (`Value`, or `Vec<Value>` for the
   array case) and **port the existing predicates** (`is_user_prompt`,
   `is_non_empty_user_block`, `is_tool_result_block`, `line_type`)
@@ -430,7 +431,7 @@ can express*:
   it is `from_value`'d into a typed block DTO whose **scalars** are lenient
   fields — `tool_use` → `{ id, name: Option<String> via lenient_string }`;
   `tool_result` → `{ tool_use_id: Option<String> (lenient_string),
-  is_error: Option<bool> (lenient_bool) }`. (`is_error` is where
+is_error: Option<bool> (lenient_bool) }`. (`is_error` is where
   `lenient_bool` earns its place.) The union/arbitrary fields stay raw and
   keep their helpers:
   - `tool_result.content` → plain raw `Value (#[serde(default)])`;
@@ -439,8 +440,8 @@ can express*:
     `claude:686`) — a one-line, behavior-neutral change (absent and `null`
     both yield `""` today, so `#[serde(default)]` → `Value::Null` matches).
   - `tool_use.input` is **presence-sensitive** like Codex's `duration`:
-    `summarize_input` returns `""` for *absent* but `"null"` for
-    *present-`null`* (`claude:602`), which a plain `Value (#[serde(default)])`
+    `summarize_input` returns `""` for _absent_ but `"null"` for
+    _present-`null`_ (`claude:602`), which a plain `Value (#[serde(default)])`
     (absent → `Value::Null`) would conflate. Read it via the block DTO's
     `#[serde(flatten)] rest` map — `rest.get("input")` gives the
     `Option<&Value>` `summarize_input` already expects (`None` = absent →
@@ -464,12 +465,12 @@ predicates.
 contract points the DTO must honor:
 
 - **Two cwd sources, in order.** `agent-cwd` comes from `session_meta`'s
-  `payload.cwd` (`extract_session_cwd`, `codex:53`) *and*, mid-session,
+  `payload.cwd` (`extract_session_cwd`, `codex:53`) _and_, mid-session,
   from an `exec_command` `function_call`'s `arguments.workdir`
   (`extract_exec_workdir`, `codex:76`); the dispatcher tries `session_meta`
   first, then the workdir fallback (`extract_codex_cwd`, `codex:100`).
   Both must be preserved, in that order — dropping or reordering either is
-  an F-EVENTS / ordering regression. `turn_context.cwd` remains *not* a
+  an F-EVENTS / ordering regression. `turn_context.cwd` remains _not_ a
   source (it just repeats `session_meta.cwd`; matching it causes false
   reverts — `codex:48`).
 - **Typed payload scalars; raw carve-outs.** Each record's `payload` is a
@@ -486,7 +487,7 @@ contract points the DTO must honor:
     those helpers (or read from the flattened raw map if presence-
     sensitive), never narrowed to a fixed struct.
   - `function_call.arguments` and custom-tool `payload.output` are
-    *JSON-encoded strings* (`codex:87`, `:679`, `:752`) — typed as
+    _JSON-encoded strings_ (`codex:87`, `:679`, `:752`) — typed as
     `Option<String>` (`lenient_string`, so a non-string degrades to
     `None`), then **re-parsed** in conversion: `arguments` → `workdir`
     (cwd), `cmd` || `command` (match), `path` || `file_path` (arg
@@ -500,23 +501,23 @@ contract points the DTO must honor:
     `exec_command_duration_ms`, `codex:765`). No `Option` field captures
     this (`Option<DurationDto>` / `Option<Value>` both coerce JSON `null`
     → `None`). Realize it with `#[serde(flatten)] rest: serde_json::Map<
-    String, Value>` on that payload DTO — presence is
+String, Value>` on that payload DTO — presence is
     `rest.contains_key("duration")`, the value `rest.get("duration")`, fed
     to the ported `exec_command_duration_ms` exactly as today. This is the
     one field needing the flattened raw map; the scalars above are
     ordinary typed fields.
 - **Two-level dispatch, each with a fall-through.** Codex dispatches
-  *twice*: the top-level `type` (`session_meta` / `response_item` /
+  _twice_: the top-level `type` (`session_meta` / `response_item` /
   `event_msg`) selects the record, then an inner `payload.type` selects
   the payload variant — for `response_item` that is `function_call` /
   `function_call_output` / …, and for **`event_msg`** it is `user_message`
   / `exec_command_end` / `patch_apply_end` (`process_event_msg`,
   `codex:347`). All of these become typed enums (replacing the
   `value.get("type")` / `payload.get("type")` string compares), and
-  **each** dispatch — top-level *and* both inner ones — needs an explicit
+  **each** dispatch — top-level _and_ both inner ones — needs an explicit
   unknown/typeless fall-through (a `#[serde(other)]` tagged enum where
   `type` is always a present string; otherwise a small classifier), so an
-  unrecognized record *or* payload degrades rather than fails (dropping
+  unrecognized record _or_ payload degrades rather than fails (dropping
   the `event_msg` fall-through would lose turns / test-run completions /
   patch completions). The `CompletionMode`-bearing `function_call` /
   output records are retained.
@@ -534,9 +535,9 @@ enclosing block); `summarize_input` already takes the `input` value. The
 C later relocates the body into the decoder.
 
 **Risk + mitigation.** The one risk is a `lenient_*` deserializer being
-*stricter* than the old `.get()` walk and silently dropping an event.
-Mitigations: (1) the *reused* helpers are the same ones A-status
-validated against precisely this failure mode, and the two *new* ones
+_stricter_ than the old `.get()` walk and silently dropping an event.
+Mitigations: (1) the _reused_ helpers are the same ones A-status
+validated against precisely this failure mode, and the two _new_ ones
 (`lenient_bool` / `lenient_i64`) get their own unit tests (acceptance
 below); (2) the existing per-line parse tests (§ 3 "existing coverage")
 pin the shapes and run unchanged; (3) migrate shape-by-shape, each
@@ -626,30 +627,30 @@ while !stop.load(Ordering::Acquire) {            // unchanged stop semantics
    `trim_end_matches('\n')`. The shared `normalize(full)` strips the line
    terminator CRLF-safely — `trim_end_matches(['\r', '\n'])` (the same
    char-array pattern already used at `runtime/ipc.rs:275`) — and returns
-   `None` when the remainder is blank *after a full `.trim()`*. For Claude
+   `None` when the remainder is blank _after a full `.trim()`_. For Claude
    the **blank-line skip is exact** (both skip a line blank after `.trim()`),
    while a **non-blank line is event-equivalent**: the engine strips only
    the terminator and leaves any surrounding whitespace Claude's `.trim()`
    would have removed, which `serde_json::from_str` tolerates identically.
    For Codex it is likewise **event-equivalent, not verbatim**: Codex today
    skips only the
-   *exactly* empty line (after `trim_end_matches('\n')`) and lets a
+   _exactly_ empty line (after `trim_end_matches('\n')`) and lets a
    whitespace-only line fall through to `process_line`, where it is a no-op
    parse failure (`codex:234`) — so no event either way, but the engine now
-   skips it *before* `decode_line` instead of after a failed parse. The
+   skips it _before_ `decode_line` instead of after a failed parse. The
    engine does **not** strip leading/interior whitespace from a non-blank
    line: JSONL records start with `{` and `serde_json::from_str` tolerates
    incidental surrounding whitespace, so a record that parsed before still
    parses. (The content-level trims inside the decoder predicates — e.g.
    `is_user_prompt`'s `.trim()` on text — are unchanged; they run on parsed
    values, not the raw line.)
-2. **EOF with a pending partial → keep buffering, do *not* flush.** When
+2. **EOF with a pending partial → keep buffering, do _not_ flush.** When
    `read_line` returns `Ok(0)` while `partial` is non-empty (the file ends
    mid-line, no `\n`), the engine calls `on_caught_up` + sleeps and leaves
    `partial` buffered for when the line completes — matching Codex today
    (the partial sits until a `\n` arrives). Rationale: during live tailing
    a newline-less tail means the record is still being written; emitting it
-   would parse a truncated line. The only cost — a *permanently*
+   would parse a truncated line. The only cost — a _permanently_
    newline-less final record (finished session whose last line lacks `\n`)
    never emits — is a non-case in practice (both writers newline-terminate
    records) and is exactly today's Codex behavior, so no regression. For
@@ -664,7 +665,7 @@ other `Read` / `BufRead` methods are unreachable — `run` only calls
 signature `read_line(&mut self, buf: &mut String) -> io::Result<usize>`:
 the entry **appends** its bytes to `buf` and returns `Ok(len)`, or appends
 nothing and returns `Ok(0)` to signal EOF. The script must route the
-service *through its own `Ok(0)` arm while `partial` is non-empty* — the
+service _through its own `Ok(0)` arm while `partial` is non-empty_ — the
 contract under test. Cases (each "→" is one `read_line` call):
 
 - **Partial survives a service-level EOF, then completes.** appends
@@ -686,9 +687,9 @@ contract under test. Cases (each "→" is one `read_line` call):
   `stop` → `decode_line` is **not** called (blank-line skip). (Each case
   ends with the terminating `Ok(0)`/`stop` flip so `run` returns.) Pins
   the § 5 normalization contract.
-- **Claude split-line *fix*, end-to-end (the G3 proof).** The cases above
-  use a *recording* decoder, so they prove **engine** assembly + the EOF
-  policy provider-agnostically — not that any provider then *emits*. To
+- **Claude split-line _fix_, end-to-end (the G3 proof).** The cases above
+  use a _recording_ decoder, so they prove **engine** assembly + the EOF
+  policy provider-agnostically — not that any provider then _emits_. To
   prove the G3 fix (Claude now emits the previously-dropped split-line
   event), run the **real** `ClaudeTranscriptDecoder` + `FakeEventSink`
   through the service with a `ScriptedBufRead` that splits a real Claude
@@ -699,23 +700,23 @@ contract under test. Cases (each "→" is one `read_line` call):
   `ClaudeTranscriptDecoder::new` is in scope) and reaches the base
   service's override via its `pub(crate)` `with_poll_interval`. (A Codex
   end-to-end analogue is optional — the engine assembly case + the
-  existing Codex tests cover its *preserved* buffering.)
+  existing Codex tests cover its _preserved_ buffering.)
 
 This exercises the real service wiring — not a detached helper — keeping
 the inline reused-buffer assembly (no per-line owned-`String` allocation).
 The engine cases pin assembly + the EOF policy (Codex's buffering is thus
-*preserved*); the Claude split-line **fix** (§ 1 G3) is proven end-to-end
+_preserved_); the Claude split-line **fix** (§ 1 G3) is proven end-to-end
 by the real-decoder case. Together they replace the timing-based attempt
 Phase 0 could not make deterministic. (The test builds the service with
 `with_poll_interval(Duration::ZERO)` so the post-EOF sleep — which runs
-*before* the loop re-checks `stop` — is a no-op and the test is instant.)
+_before_ the loop re-checks `stop` — is a no-op and the test is instant.)
 
 **The spawn site collapses (G4).** Both adapters' `TranscriptStreamer::tail()`
 already delegate to `transcript::start_tailing(events, session_id,
 transcript_path, cwd)` (`claude_code/mod.rs:106`, `codex/mod.rs:149`), and
 the Codex Phase 0 tests call `start_tailing` directly — so `start_tailing`
 (in each `transcript.rs`) is the spawn site that changes; `tail()` stays a
-one-line delegator. Validation is *not* here: it is the separate
+one-line delegator. Validation is _not_ here: it is the separate
 `TranscriptPathValidator::validate` method, so `start_tailing` just opens
 the already-validated path (temp-path fixtures keep working). The body
 becomes, identically for both adapters bar the decoder type + label:
@@ -766,7 +767,7 @@ both provider decoders can implement the trait and build the service.
   newline-less final record); F-CONCURRENCY (`Acquire` stop,
   `POLL_INTERVAL`, first-EOF `on_caught_up`, error→warn→sleep) preserved;
   the two duplicated `tail_loop`s collapse to one shared loop (the
-  production scaffolding shrinks — the effort *adds* DTOs/service/tests
+  production scaffolding shrinks — the effort _adds_ DTOs/service/tests
   overall, so this is a dedup, not a net-LOC claim).
 
 ## 6. Step F — single-class session lifecycle (deferred capstone, NOT in this effort)
@@ -775,7 +776,7 @@ both provider decoders can implement the trait and build the service.
 and several state holders: `base::start_for`, `AgentWatcherState` /
 `WatcherHandle`, `TranscriptState` / the D' `AgentWatcherService`, the
 locator, and — after C — `TranscriptTailService`. These pieces are
-*temporally driven*: per session they fire in a fixed order (locate →
+_temporally driven_: per session they fire in a fixed order (locate →
 validate → start watcher → start tail → … → stop). Step F would hoist that
 sequence behind a **single class with a minimal surface** — the caller
 sees only the lifecycle verbs (`start(session)`, `stop(session)`, …) and
@@ -785,7 +786,7 @@ that C / D' / the locator already provide.
 
 **Why deferred (explicitly out of A-transcript + C).** It reshapes
 `watcher_runtime` / the D' `AgentWatcherService` — a wider blast radius
-than the transcript-only A + C — and only pays off *once C exists*
+than the transcript-only A + C — and only pays off _once C exists_
 (`TranscriptTailService` is one of the services it would delegate to). So
 it earns its own spec + go/no-go **after** A-transcript + C land, and is
 recorded on #246 as the deferred capstone. Nothing in A-transcript or C
@@ -807,11 +808,11 @@ forward unchanged into that effort.
 implement → local `codex exec` to zero findings → push → PR →
 `/lifeline:upsource-review` → `/approve-pr`):
 
-| PR                       | Scope                                                                                                                                          | Gate                                                                          |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| **Phase 0 — tests**      | `T-replay` (both adapters): ≥3 replay pairs, catch-up + drain barriers, `Some(cwd)`. **No production change.**                                  | both transcript suites green; `git diff` = test code only                     |
+| PR                         | Scope                                                                                                                                                                                              | Gate                                                                                                                         |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Phase 0 — tests**        | `T-replay` (both adapters): ≥3 replay pairs, catch-up + drain barriers, `Some(cwd)`. **No production change.**                                                                                     | both transcript suites green; `git diff` = test code only                                                                    |
 | **Phase 1 — A-transcript** | typed DTOs + `lenient_bool` / `lenient_i64` in both `process_line` paths (option B); behavior-neutral helper retargets; DTO/event regression tests (incl. presence-sensitive `input` / `duration`) | existing parse + Phase 0 tests green; events shape- and deterministic-field-equivalent (nondeterministic fields by contract) |
-| **Phase 2 — C**          | `TranscriptTailService` + `TranscriptDecoder` in `base`; both `start_tailing` delegate; the two `tail_loop`s deleted; deterministic `ScriptedBufRead` buffering test | Phase 0 tests green **unchanged**; buffering test green; G3 effects realized   |
+| **Phase 2 — C**            | `TranscriptTailService` + `TranscriptDecoder` in `base`; both `start_tailing` delegate; the two `tail_loop`s deleted; deterministic `ScriptedBufRead` buffering test                               | Phase 0 tests green **unchanged**; buffering test green; G3 effects realized                                                 |
 
 The order is forced: Phase 0 builds the regression net before Phase 1/2
 touch the code it guards; Phase 1 types the bodies before Phase 2 relocates
@@ -832,7 +833,7 @@ green and revertable.
   `output` / `duration`) — the § 4 boundary keeps them raw + ported
   helpers; present-vs-absent (`input`, `duration`) is handled by the
   `#[serde(flatten)]` raw map, not a collapsing `Option`.
-- **Two-level Codex dispatch** — top-level `type` *and* both inner
+- **Two-level Codex dispatch** — top-level `type` _and_ both inner
   `payload.type` dispatches (`response_item`, `event_msg`) need
   fall-throughs, or turns / test-run / patch completions drop (§ 4).
 - **ts-rs drift** — transcript DTOs are internal (no `#[derive(TS)]`); if
@@ -843,7 +844,7 @@ green and revertable.
 F-EVENTS (+ the two-sided G3 carve-out), F-CONCURRENCY, F-ATTACH, and
 F-BINDINGS hold; the two duplicated `tail_loop`s collapse to one shared
 loop (production-scaffolding dedup — the effort adds DTOs/service/tests
-overall, so it is *not* a net-LOC reduction); both transcript parsers are
+overall, so it is _not_ a net-LOC reduction); both transcript parsers are
 typed (option B). #246's **A-transcript** and **C** boxes tick.
 
 **#246 checklist update.** On completion, tick **A-transcript** and **C**,


### PR DESCRIPTION
## What

**Phase 1 (A-transcript, option B)** of #246's A-transcript + C effort — types both transcript JSONL parsers with lenient DTOs. Builds on the Phase 0 test net (#279).

- **`lenient_bool` / `lenient_i64`** added to `serde_helpers.rs` (mirror the existing `lenient_u64/f64/string/object`; wrong-typed → `None`).
- **Claude** (`claude_code/transcript_dto.rs` + `transcript.rs`): `process_line` parses via `ClaudeTranscriptLineDto`, dispatches on typed `line_type`; top-level `cwd` + `tool_result` fields read from the DTO; blocks `from_value` into `ClaudeToolUseDto`/`ClaudeToolResultDto`. `content`/`input` stay raw (classified by the existing predicates); `extract_tool_result_content` retargeted to take the content value.
- **Codex** (`codex/transcript_dto.rs` + `transcript.rs`): `CodexLineDto` + manual `record_type()`/`payload_type()` classifiers (`Other` fall-through for missing/non-string `type`), `CodexPayloadDto` with lenient scalars + `#[serde(flatten)]` rest map for presence-sensitive `duration`, inner `CodexExecArgsDto`/`CodexCustomToolOutputDto` for the JSON-in-string `arguments`/`output`. Preserves both cwd sources in order, `duration` present(→`Some(0)`)/absent(→`None`), the dual `response_item`+`event_msg` inner dispatch, and per-field lenient `arguments` reads.

## Verification

- Behavior-neutral: typed scalars where serde can express the tolerance; raw `Value`/`String` + ported helpers for the union/JSON-string/presence fields.
- `cargo test -p vimeflow` — all transcript/agent tests green (579 passed). The one failure, `read_loop_eof_marks_cache_exited`, is the **pre-existing** flaky real-PTY test tracked in #278 (unrelated; diff is transcript-only).
- New regression tests: lenient `is_error`/`success`/`exit_code`; `summarize_input` absent(`""`)-vs-null(`"null"`); `duration` presence; classifier fall-throughs.
- **Two codex review milestones** (Claude side, Codex side) — both clean, no regressions.

## How

Migrations implemented via **kimi** (verbatim port against spec §4), each **verified by Claude** (independent test run + diff review) and codex-reviewed. Per the codex-reviewed plan (`docs/superpowers/plans/2026-05-25-transcript-dtos-and-engine.md`).

## Next

Phase 2 (C — `TranscriptTailService` + injected `TranscriptDecoder`) follows as a separate PR against `refactor/agent-adapter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)