### PR TITLE
refactor(transcript): shared TranscriptTailService engine (C, Phase 2 of A-transcript+C)

### DIFF
--- a/crates/backend/src/agent/adapter/base/mod.rs
+++ b/crates/backend/src/agent/adapter/base/mod.rs
@@ -20,6 +20,10 @@ use crate::terminal::PtyState;
 
 pub use transcript_state::{TranscriptHandle, TranscriptStartStatus, TranscriptState};
 pub(crate) use transcript_tail_service::{TranscriptDecoder, TranscriptTailService};
+// `RecordingDecoder` stays module-private to `transcript_tail_service` (only its
+// own tests use it); 2.3's Claude end-to-end test imports these two.
+#[cfg(test)]
+pub(crate) use transcript_tail_service::{ScriptedBufRead, Step};
 pub use watcher_runtime::{AgentWatcherState, WatcherHandle};
 
 /// Step B': `start_for` now takes the typed `AgentBindings` bundle

--- a/crates/backend/src/agent/adapter/base/mod.rs
+++ b/crates/backend/src/agent/adapter/base/mod.rs
@@ -8,6 +8,7 @@
 mod diagnostics;
 mod path_security;
 mod transcript_state;
+mod transcript_tail_service;
 mod watcher_runtime;
 
 use std::path::PathBuf;
@@ -18,6 +19,7 @@ use crate::runtime::EventSink;
 use crate::terminal::PtyState;
 
 pub use transcript_state::{TranscriptHandle, TranscriptStartStatus, TranscriptState};
+pub(crate) use transcript_tail_service::{TranscriptDecoder, TranscriptTailService};
 pub use watcher_runtime::{AgentWatcherState, WatcherHandle};
 
 /// Step B': `start_for` now takes the typed `AgentBindings` bundle

--- a/crates/backend/src/agent/adapter/base/transcript_tail_service.rs
+++ b/crates/backend/src/agent/adapter/base/transcript_tail_service.rs
@@ -99,3 +99,148 @@ impl TranscriptTailService {
         }
     }
 }
+
+// --- Test support (module-level, `pub(crate)` so the per-provider decoder
+// tests in Tasks 2.3/2.4 can drive the same scripted reader). ---
+
+/// One scripted `read_line` outcome.
+#[cfg(test)]
+pub(crate) enum Step {
+    /// `read_line` returns this text verbatim (may or may not end in `\n`).
+    Chunk(&'static str),
+    /// Non-terminal EOF — `Ok(0)`; the loop fires `on_caught_up` and polls again.
+    Eof,
+    /// Like `Eof`, but also flips `stop` so the loop exits after this read.
+    EofStop,
+    /// One read failure — the loop warns, sleeps, and continues.
+    Err,
+}
+
+#[cfg(test)]
+pub(crate) struct ScriptedBufRead {
+    pub steps: std::vec::IntoIter<Step>,
+    pub stop: Arc<AtomicBool>,
+}
+
+#[cfg(test)]
+impl std::io::Read for ScriptedBufRead {
+    fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+        unreachable!("run only calls read_line")
+    }
+}
+
+#[cfg(test)]
+impl std::io::BufRead for ScriptedBufRead {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        unreachable!()
+    }
+    fn consume(&mut self, _: usize) {}
+    fn read_line(&mut self, buf: &mut String) -> std::io::Result<usize> {
+        match self.steps.next() {
+            Some(Step::Chunk(s)) => {
+                buf.push_str(s);
+                Ok(s.len())
+            }
+            Some(Step::Err) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "scripted read error",
+            )),
+            Some(Step::Eof) => Ok(0),
+            Some(Step::EofStop) | None => {
+                self.stop.store(true, Ordering::Release);
+                Ok(0)
+            }
+        }
+    }
+}
+
+/// `run` MOVES the decoder, so tests clone the inner `Arc`s up front to inspect
+/// what was decoded after the loop returns.
+#[cfg(test)]
+#[derive(Clone, Default)]
+struct RecordingDecoder {
+    lines: Arc<std::sync::Mutex<Vec<String>>>,
+    caught_up: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[cfg(test)]
+impl TranscriptDecoder for RecordingDecoder {
+    fn decode_line(&mut self, line: &str) {
+        self.lines.lock().unwrap().push(line.to_string());
+    }
+    fn on_caught_up(&mut self) {
+        self.caught_up.fetch_add(1, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive the service over a scripted read sequence and return what the
+    /// recording decoder saw: the decoded lines + the `on_caught_up` count.
+    fn drive(steps: Vec<Step>) -> (Vec<String>, usize) {
+        let stop = Arc::new(AtomicBool::new(false));
+        let dec = RecordingDecoder::default();
+        let lines = dec.lines.clone();
+        let caught = dec.caught_up.clone();
+        TranscriptTailService::new(Box::new(dec), "t")
+            .with_poll_interval(Duration::ZERO)
+            .run(
+                ScriptedBufRead {
+                    steps: steps.into_iter(),
+                    stop: stop.clone(),
+                },
+                stop,
+            );
+        let decoded = lines.lock().unwrap().clone();
+        (decoded, caught.load(Ordering::Acquire))
+    }
+
+    #[test]
+    fn engine_partial_survives_eof_then_completes() {
+        // A partial buffered before a non-terminal EOF survives and joins the
+        // rest of the line when the file grows.
+        let (lines, _) = drive(vec![
+            Step::Chunk("{\"a\":1"),
+            Step::Eof,
+            Step::Chunk("23}\n"),
+            Step::EofStop,
+        ]);
+        assert_eq!(lines, ["{\"a\":123}"]);
+    }
+
+    #[test]
+    fn engine_truncated_partial_never_emits() {
+        // A partial that never completes before stop is dropped — and the EOF
+        // arm still fired exactly once.
+        let (lines, caught) = drive(vec![Step::Chunk("{\"a\":1"), Step::EofStop]);
+        assert!(lines.is_empty());
+        assert_eq!(caught, 1);
+    }
+
+    #[test]
+    fn engine_strips_crlf() {
+        let (lines, _) = drive(vec![Step::Chunk("{\"a\":1}\r\n"), Step::EofStop]);
+        assert_eq!(lines, ["{\"a\":1}"]);
+    }
+
+    #[test]
+    fn engine_skips_blank_line() {
+        let (lines, _) = drive(vec![Step::Chunk("   \n"), Step::EofStop]);
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn engine_read_error_warns_and_continues() {
+        // A single read error warns + sleeps + continues; the next line still
+        // decodes (pins the frozen error→warn→sleep contract).
+        let (lines, _) = drive(vec![
+            Step::Chunk("{\"a\":1}\n"),
+            Step::Err,
+            Step::Chunk("{\"b\":2}\n"),
+            Step::EofStop,
+        ]);
+        assert_eq!(lines, ["{\"a\":1}", "{\"b\":2}"]);
+    }
+}

--- a/crates/backend/src/agent/adapter/base/transcript_tail_service.rs
+++ b/crates/backend/src/agent/adapter/base/transcript_tail_service.rs
@@ -1,0 +1,101 @@
+//! Provider-neutral transcript tail engine (step C).
+//!
+//! Both the Claude Code and Codex transcript watchers previously carried a
+//! near-identical `tail_loop`: read lines from a growing JSONL file, buffer a
+//! trailing partial across the EOF poll boundary, strip CRLF, skip blank
+//! lines, and hand each complete line to a provider-specific parser. This
+//! module collapses that duplication into one [`TranscriptTailService`] driven
+//! by an injected [`TranscriptDecoder`] — the decoder is the only
+//! provider-specific seam.
+//!
+//! The loop owns the frozen line-buffering contract (F-EVENTS replay→live
+//! boundary): a partial line survives a non-terminal EOF, [`on_caught_up`]
+//! fires on the first EOF of each catch-up, and a read error warns + sleeps +
+//! continues rather than tearing the watcher down.
+//!
+//! [`on_caught_up`]: TranscriptDecoder::on_caught_up
+
+use std::io::BufRead;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Poll cadence between EOF reads of the growing transcript file. Moved here
+/// from the per-provider modules so both tails share one value.
+pub(crate) const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// The provider-specific seam: turns one complete transcript line into events,
+/// and reacts to the replay→live boundary. Implementations own their
+/// per-session parse state (in-flight tool calls, turn counts, last cwd).
+pub(crate) trait TranscriptDecoder: Send {
+    /// Decode one complete (newline-stripped, non-blank) transcript line.
+    fn decode_line(&mut self, line: &str);
+    /// Called on the first EOF of each catch-up pass — the replay→live
+    /// boundary. Used to flush replay-only emitter state exactly once.
+    fn on_caught_up(&mut self);
+}
+
+/// Owns the read/buffer/normalize loop; delegates per-line semantics to the
+/// injected [`TranscriptDecoder`].
+pub(crate) struct TranscriptTailService {
+    decoder: Box<dyn TranscriptDecoder>,
+    provider_label: &'static str,
+    poll_interval: Duration,
+}
+
+impl TranscriptTailService {
+    pub(crate) fn new(decoder: Box<dyn TranscriptDecoder>, provider_label: &'static str) -> Self {
+        Self {
+            decoder,
+            provider_label,
+            poll_interval: POLL_INTERVAL,
+        }
+    }
+
+    /// Override the poll cadence (tests drive `Duration::ZERO` so the EOF
+    /// sleeps are no-ops).
+    #[cfg(test)]
+    pub(crate) fn with_poll_interval(mut self, d: Duration) -> Self {
+        self.poll_interval = d;
+        self
+    }
+
+    /// Tail `reader` line-by-line until `stop` is set, dispatching each
+    /// complete line to the decoder. Buffers a trailing partial across EOF,
+    /// strips CRLF, skips blank lines, fires `on_caught_up` on each EOF, and
+    /// treats a read error as warn + sleep + continue.
+    pub(crate) fn run<R: BufRead>(mut self, mut reader: R, stop: Arc<AtomicBool>) {
+        let mut line_buf = String::new();
+        let mut partial = String::new();
+        while !stop.load(Ordering::Acquire) {
+            line_buf.clear();
+            match reader.read_line(&mut line_buf) {
+                Ok(0) => {
+                    self.decoder.on_caught_up();
+                    std::thread::sleep(self.poll_interval);
+                }
+                Ok(_) => {
+                    if !line_buf.ends_with('\n') {
+                        partial.push_str(&line_buf);
+                        continue;
+                    }
+                    let full = if partial.is_empty() {
+                        line_buf.as_str()
+                    } else {
+                        partial.push_str(&line_buf);
+                        partial.as_str()
+                    };
+                    let trimmed = full.trim_end_matches(['\r', '\n']);
+                    if !trimmed.trim().is_empty() {
+                        self.decoder.decode_line(trimmed);
+                    }
+                    partial.clear();
+                }
+                Err(e) => {
+                    log::warn!("Error reading {} line: {}", self.provider_label, e);
+                    std::thread::sleep(self.poll_interval);
+                }
+            }
+        }
+    }
+}

--- a/crates/backend/src/agent/adapter/claude_code/transcript.rs
+++ b/crates/backend/src/agent/adapter/claude_code/transcript.rs
@@ -6,25 +6,22 @@
 
 use std::collections::HashMap;
 use std::fs::{self, File};
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use serde_json::Value;
 
 use super::test_runners::emitter::TestRunEmitter;
 use super::test_runners::matcher::{match_command, MatchedCommand};
 use super::transcript_dto::{ClaudeToolResultDto, ClaudeToolUseDto, ClaudeTranscriptLineDto};
-use crate::agent::adapter::base::TranscriptHandle;
+use crate::agent::adapter::base::{TranscriptDecoder, TranscriptHandle, TranscriptTailService};
 use crate::agent::adapter::types::ValidateTranscriptError;
 use crate::agent::events::{emit_agent_cwd, emit_agent_tool_call, emit_agent_turn};
 use crate::agent::types::{AgentCwdEvent, AgentToolCallEvent, AgentTurnEvent, ToolCallStatus};
 use crate::runtime::EventSink;
-
-/// Poll interval for checking new transcript lines
-const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Maximum length for the args summary string
 const MAX_ARGS_LEN: usize = 100;
@@ -175,78 +172,74 @@ pub fn start_tailing(
     let stop_flag = Arc::new(AtomicBool::new(false));
     let stop_clone = stop_flag.clone();
 
+    // Read from the beginning — each Claude Code session gets a unique JSONL
+    // file, so all lines belong to the current session. Replay catches any
+    // tool calls written before tailing started (the transcript file is often
+    // created seconds after the statusline first reports its path).
+    let decoder = ClaudeTranscriptDecoder::new(events, session_id, cwd);
+    let service = TranscriptTailService::new(Box::new(decoder), "transcript");
+
     let join_handle = std::thread::spawn(move || {
-        tail_loop(events, session_id, cwd, file, stop_clone);
+        service.run(BufReader::new(file), stop_clone);
     });
 
     Ok(TranscriptHandle::new(stop_flag, join_handle))
 }
 
-/// Background loop that tails the transcript file
-fn tail_loop(
+/// Per-session Claude Code decoder: owns the in-flight tool-call map, turn
+/// count, last-seen cwd, and the replay-aware emitter, and turns each complete
+/// transcript line into `agent-*` events. Driven by [`TranscriptTailService`],
+/// which owns the read/buffer/poll loop.
+struct ClaudeTranscriptDecoder {
     events: Arc<dyn EventSink>,
     session_id: String,
     cwd: Option<PathBuf>,
-    file: File,
-    stop_flag: Arc<AtomicBool>,
-) {
-    let mut reader = BufReader::new(file);
+    /// In-flight tool calls: tool_use_id -> call details.
+    in_flight: InFlightToolCalls,
+    num_turns: u32,
+    /// Last agent-reported cwd. Tracked so consecutive lines that share the
+    /// same `cwd` field don't re-emit. Initial `None` so the first observed
+    /// cwd always fires a transition event.
+    last_cwd: Option<String>,
+    /// Replay-aware emitter — buffers test-run snapshots during the initial
+    /// catch-up read and emits the latest one (only) on the first EOF. Once
+    /// we're tailing live, every snapshot emits immediately.
+    emitter: TestRunEmitter,
+}
 
-    // Read from the beginning — each Claude Code session gets a unique JSONL
-    // file, so all lines belong to the current session. Replay catches any
-    // tool calls written before tailing started (the transcript file is often
-    // created seconds after the statusline first reports its path).
-
-    // In-flight tool calls: tool_use_id -> call details
-    let mut in_flight: InFlightToolCalls = HashMap::new();
-    let mut num_turns = 0_u32;
-    // Last agent-reported cwd. Tracked so consecutive lines that share the
-    // same `cwd` field don't re-emit. Initial `None` so the first observed
-    // cwd always fires a transition event.
-    let mut last_cwd: Option<String> = None;
-
-    // Replay-aware emitter — buffers test-run snapshots during the initial
-    // catch-up read and emits the latest one (only) on the first EOF. Once
-    // we're tailing live, every snapshot emits immediately.
-    let mut emitter = TestRunEmitter::new(events.clone());
-
-    // Buffer for partial lines
-    let mut line_buf = String::new();
-
-    // Acquire pairs with the Release in `TranscriptHandle::stop` /
-    // `Drop` (Claude review on PR #152, F12) so the stop signal is
-    // observed promptly on weakly-ordered architectures. Same pattern
-    // applied to `WatcherHandle`'s stop_flag in F8.
-    while !stop_flag.load(Ordering::Acquire) {
-        line_buf.clear();
-        match reader.read_line(&mut line_buf) {
-            Ok(0) => {
-                // First EOF marks the end of replay; subsequent EOFs are
-                // idempotent. After this, every submit emits live.
-                emitter.finish_replay();
-                std::thread::sleep(POLL_INTERVAL);
-            }
-            Ok(_) => {
-                let line = line_buf.trim();
-                if line.is_empty() {
-                    continue;
-                }
-                process_line(
-                    line,
-                    &session_id,
-                    cwd.as_deref(),
-                    &events,
-                    &mut emitter,
-                    &mut in_flight,
-                    &mut num_turns,
-                    &mut last_cwd,
-                );
-            }
-            Err(e) => {
-                log::warn!("Error reading transcript line: {}", e);
-                std::thread::sleep(POLL_INTERVAL);
-            }
+impl ClaudeTranscriptDecoder {
+    fn new(events: Arc<dyn EventSink>, session_id: String, cwd: Option<PathBuf>) -> Self {
+        let emitter = TestRunEmitter::new(events.clone());
+        Self {
+            events,
+            session_id,
+            cwd,
+            in_flight: HashMap::new(),
+            num_turns: 0,
+            last_cwd: None,
+            emitter,
         }
+    }
+}
+
+impl TranscriptDecoder for ClaudeTranscriptDecoder {
+    fn decode_line(&mut self, line: &str) {
+        process_line(
+            line,
+            &self.session_id,
+            self.cwd.as_deref(),
+            &self.events,
+            &mut self.emitter,
+            &mut self.in_flight,
+            &mut self.num_turns,
+            &mut self.last_cwd,
+        );
+    }
+
+    /// First EOF marks the end of replay; subsequent EOFs are idempotent.
+    /// After this, every submit emits live.
+    fn on_caught_up(&mut self) {
+        self.emitter.finish_replay();
     }
 }
 
@@ -1435,5 +1428,51 @@ mod tests {
     fn summarize_input_preserves_absent_vs_null() {
         assert_eq!(summarize_input(None), "");
         assert_eq!(summarize_input(Some(&serde_json::Value::Null)), "null");
+    }
+
+    /// End-to-end G3 carve-out: a real `tool_use` line split across the
+    /// replay→live EOF boundary — where *neither half is valid JSON* — must
+    /// still emit `agent-tool-call`. The old per-provider `tail_loop` handed
+    /// each partial to the parser as if it were a complete line (both halves
+    /// failed `from_str`, so the event was silently dropped); the shared
+    /// `TranscriptTailService` buffers the partial across the non-terminal EOF
+    /// and rejoins it. This is the sanctioned Phase 2 behavior change
+    /// (F-EVENTS two-sided G3 carve-out), so the assertion is PASS, not the
+    /// pre-C drop.
+    #[test]
+    fn split_tool_use_line_across_eof_still_emits() {
+        use crate::agent::adapter::base::{ScriptedBufRead, Step};
+
+        let concrete = Arc::new(crate::runtime::FakeEventSink::new());
+        let events: Arc<dyn EventSink> = concrete.clone();
+        let decoder = ClaudeTranscriptDecoder::new(events, "sess-g3".to_string(), None);
+
+        // One valid tool_use assistant line, split mid-string-value so neither
+        // side parses on its own: `..."tool_us` | `e"...`.
+        let first = r#"{"type":"assistant","message":{"content":[{"type":"tool_us"#;
+        let second = "e\",\"id\":\"toolu_g3\",\"name\":\"Read\",\"input\":{\"file_path\":\"/a.ts\"}}]}}\n";
+
+        let stop = Arc::new(AtomicBool::new(false));
+        TranscriptTailService::new(Box::new(decoder), "transcript")
+            .with_poll_interval(std::time::Duration::ZERO)
+            .run(
+                ScriptedBufRead {
+                    steps: vec![
+                        Step::Chunk(first),
+                        Step::Eof,
+                        Step::Chunk(second),
+                        Step::EofStop,
+                    ]
+                    .into_iter(),
+                    stop: stop.clone(),
+                },
+                stop,
+            );
+
+        assert_eq!(
+            concrete.count("agent-tool-call"),
+            1,
+            "split tool_use line must rejoin across EOF and emit exactly one event"
+        );
     }
 }

--- a/crates/backend/src/agent/adapter/codex/transcript.rs
+++ b/crates/backend/src/agent/adapter/codex/transcript.rs
@@ -2,15 +2,15 @@
 
 use std::collections::HashMap;
 use std::fs::{self, File};
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
-use crate::agent::adapter::base::TranscriptHandle;
+use crate::agent::adapter::base::{TranscriptDecoder, TranscriptHandle, TranscriptTailService};
 use crate::agent::adapter::claude_code::test_runners::build::{maybe_build_snapshot, BuildArgs};
 use crate::agent::adapter::claude_code::test_runners::emitter::TestRunEmitter;
 use crate::agent::adapter::claude_code::test_runners::matcher::{match_command, MatchedCommand};
@@ -27,7 +27,6 @@ use super::transcript_dto::{
     CodexRecordType,
 };
 
-const POLL_INTERVAL: Duration = Duration::from_millis(500);
 const MAX_ARGS_LEN: usize = 100;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -58,13 +57,11 @@ type InFlightToolCalls = HashMap<String, InFlightToolCall>;
 /// would cause false reverts on reasoning-only turns after an
 /// `exec_command.workdir` transition has already moved us to a new
 /// directory. See spec section 1.
-fn extract_session_cwd(dto: &CodexLineDto) -> Option<String> {
-    if !matches!(dto.record_type(), CodexRecordType::SessionMeta) {
+fn extract_session_cwd(record_type: CodexRecordType, payload: &CodexPayloadDto) -> Option<String> {
+    if !matches!(record_type, CodexRecordType::SessionMeta) {
         return None;
     }
-    let payload =
-        serde_json::from_value::<CodexPayloadDto>(dto.payload.clone()).unwrap_or_default();
-    payload.cwd.filter(|s| !s.is_empty())
+    payload.cwd.clone().filter(|s| !s.is_empty())
 }
 
 /// Pull the mid-session workdir off a Codex `exec_command` function-call
@@ -75,20 +72,18 @@ fn extract_session_cwd(dto: &CodexLineDto) -> Option<String> {
 /// `arguments` is a JSON-encoded string per Codex's rollout schema —
 /// it must be parsed before reading `workdir`. Malformed JSON, missing
 /// fields, or empty strings all short-circuit to `None`.
-fn extract_exec_workdir(dto: &CodexLineDto) -> Option<String> {
-    if !matches!(dto.record_type(), CodexRecordType::ResponseItem) {
+fn extract_exec_workdir(record_type: CodexRecordType, payload: &CodexPayloadDto) -> Option<String> {
+    if !matches!(record_type, CodexRecordType::ResponseItem) {
         return None;
     }
-    let payload =
-        serde_json::from_value::<CodexPayloadDto>(dto.payload.clone()).unwrap_or_default();
     if payload.payload_type() != CodexPayloadType::FunctionCall {
         return None;
     }
     if payload.name.as_deref() != Some("exec_command") {
         return None;
     }
-    let raw = payload.arguments?;
-    let args: CodexExecArgsDto = serde_json::from_str(&raw).ok()?;
+    let raw = payload.arguments.as_deref()?;
+    let args: CodexExecArgsDto = serde_json::from_str(raw).ok()?;
     args.workdir.filter(|s| !s.is_empty())
 }
 
@@ -97,11 +92,11 @@ fn extract_exec_workdir(dto: &CodexLineDto) -> Option<String> {
 /// falls back to the exec_command workdir path. Returns
 /// `Option<String>` because the workdir path must return owned strings
 /// (parsed JSON allocates).
-fn extract_codex_cwd(dto: &CodexLineDto) -> Option<String> {
-    if let Some(cwd) = extract_session_cwd(dto) {
+fn extract_codex_cwd(record_type: CodexRecordType, payload: &CodexPayloadDto) -> Option<String> {
+    if let Some(cwd) = extract_session_cwd(record_type, payload) {
         return Some(cwd);
     }
-    extract_exec_workdir(dto)
+    extract_exec_workdir(record_type, payload)
 }
 
 pub(super) fn validate_transcript_path(
@@ -180,78 +175,64 @@ pub(super) fn start_tailing(
     let stop_flag = Arc::new(AtomicBool::new(false));
     let stop_clone = stop_flag.clone();
 
+    let decoder = CodexTranscriptDecoder::new(events, session_id, cwd);
+    let service = TranscriptTailService::new(Box::new(decoder), "Codex rollout transcript");
+
     let join_handle = std::thread::spawn(move || {
-        tail_loop(events, session_id, cwd, file, stop_clone);
+        service.run(BufReader::new(file), stop_clone);
     });
 
     Ok(TranscriptHandle::new(stop_flag, join_handle))
 }
 
-fn tail_loop(
+/// Per-session Codex decoder: owns the in-flight tool-call map (each entry
+/// carrying its `CompletionMode`), turn count, last-seen cwd, and the
+/// replay-aware emitter, and turns each complete rollout line into `agent-*`
+/// events. Driven by [`TranscriptTailService`], which owns the
+/// read/buffer/poll loop (including the partial-line buffering Codex's old
+/// `tail_loop` did inline).
+struct CodexTranscriptDecoder {
     events: Arc<dyn EventSink>,
     session_id: String,
     cwd: Option<PathBuf>,
-    file: File,
-    stop_flag: Arc<AtomicBool>,
-) {
-    let mut reader = BufReader::new(file);
-    let mut line_buf = String::new();
-    let mut partial_line = String::new();
-    let mut in_flight: InFlightToolCalls = HashMap::new();
-    let mut num_turns = 0_u32;
-    let mut last_cwd: Option<String> = None;
-    let mut emitter = TestRunEmitter::new(events.clone());
+    in_flight: InFlightToolCalls,
+    num_turns: u32,
+    last_cwd: Option<String>,
+    emitter: TestRunEmitter,
+}
 
-    while !stop_flag.load(Ordering::Acquire) {
-        line_buf.clear();
-        match reader.read_line(&mut line_buf) {
-            Ok(0) => {
-                emitter.finish_replay();
-                std::thread::sleep(POLL_INTERVAL);
-            }
-            Ok(_) => {
-                if !line_buf.ends_with('\n') {
-                    partial_line.push_str(&line_buf);
-                    continue;
-                }
-
-                if !partial_line.is_empty() {
-                    partial_line.push_str(&line_buf);
-                    process_line(
-                        partial_line.trim_end_matches('\n'),
-                        &session_id,
-                        cwd.as_deref(),
-                        &events,
-                        &mut emitter,
-                        &mut in_flight,
-                        &mut num_turns,
-                        &mut last_cwd,
-                    );
-                    partial_line.clear();
-                    continue;
-                }
-
-                let line = line_buf.trim_end_matches('\n');
-                if line.is_empty() {
-                    continue;
-                }
-
-                process_line(
-                    line,
-                    &session_id,
-                    cwd.as_deref(),
-                    &events,
-                    &mut emitter,
-                    &mut in_flight,
-                    &mut num_turns,
-                    &mut last_cwd,
-                );
-            }
-            Err(e) => {
-                log::warn!("Error reading Codex rollout transcript line: {}", e);
-                std::thread::sleep(POLL_INTERVAL);
-            }
+impl CodexTranscriptDecoder {
+    fn new(events: Arc<dyn EventSink>, session_id: String, cwd: Option<PathBuf>) -> Self {
+        let emitter = TestRunEmitter::new(events.clone());
+        Self {
+            events,
+            session_id,
+            cwd,
+            in_flight: HashMap::new(),
+            num_turns: 0,
+            last_cwd: None,
+            emitter,
         }
+    }
+}
+
+impl TranscriptDecoder for CodexTranscriptDecoder {
+    fn decode_line(&mut self, line: &str) {
+        process_line(
+            line,
+            &self.session_id,
+            self.cwd.as_deref(),
+            &self.events,
+            &mut self.emitter,
+            &mut self.in_flight,
+            &mut self.num_turns,
+            &mut self.last_cwd,
+        );
+    }
+
+    /// First EOF marks the end of replay; subsequent EOFs are idempotent.
+    fn on_caught_up(&mut self) {
+        self.emitter.finish_replay();
     }
 }
 
@@ -269,6 +250,19 @@ fn process_line(
         Ok(dto) => dto,
         Err(_) => return,
     };
+    let record_type = dto.record_type();
+
+    // Unknown record types carry nothing we consume — skip the payload parse
+    // entirely (pre-C never parsed the payload for them either).
+    if matches!(record_type, CodexRecordType::Other) {
+        return;
+    }
+
+    // Parse the payload ONCE per line; the cwd transition and the dispatch
+    // share it. Pre-C, response_item lines parsed this twice — extract_exec_
+    // workdir for the cwd, then process_response_item for the dispatch.
+    let payload =
+        serde_json::from_value::<CodexPayloadDto>(dto.payload.clone()).unwrap_or_default();
 
     // Emit agent-cwd on transitions only. Codex's two cwd sources are
     // session_meta.payload.cwd (session start) and
@@ -276,7 +270,7 @@ fn process_line(
     // calls (mid-session). turn_context.cwd is intentionally NOT a
     // source — see spec section 1 and the regression test
     // `process_line_turn_context_after_exec_command_does_not_revert`.
-    if let Some(observed) = extract_codex_cwd(&dto) {
+    if let Some(observed) = extract_codex_cwd(record_type, &payload) {
         if last_cwd
             .as_deref()
             .map_or(true, |seen| seen != observed.as_str())
@@ -292,13 +286,13 @@ fn process_line(
         }
     }
 
-    match dto.record_type() {
+    match record_type {
         CodexRecordType::ResponseItem => {
-            process_response_item(&dto, session_id, cwd, events, in_flight);
+            process_response_item(&dto, &payload, session_id, cwd, events, in_flight);
         }
         CodexRecordType::EventMsg => {
             process_event_msg(
-                &dto, session_id, cwd, events, emitter, in_flight, num_turns,
+                &dto, &payload, session_id, cwd, events, emitter, in_flight, num_turns,
             );
         }
         _ => {}
@@ -307,27 +301,26 @@ fn process_line(
 
 fn process_response_item(
     dto: &CodexLineDto,
+    payload: &CodexPayloadDto,
     session_id: &str,
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
     in_flight: &mut InFlightToolCalls,
 ) {
-    let payload =
-        serde_json::from_value::<CodexPayloadDto>(dto.payload.clone()).unwrap_or_default();
     let timestamp = dto.timestamp.clone().unwrap_or_else(now_iso8601);
 
     match payload.payload_type() {
         CodexPayloadType::FunctionCall => {
-            start_function_call(&payload, session_id, cwd, events, in_flight, &timestamp);
+            start_function_call(payload, session_id, cwd, events, in_flight, &timestamp);
         }
         CodexPayloadType::CustomToolCall => {
-            start_custom_tool_call(&payload, session_id, events, in_flight, &timestamp);
+            start_custom_tool_call(payload, session_id, events, in_flight, &timestamp);
         }
         CodexPayloadType::FunctionCallOutput => {
-            process_output_completion(&payload, session_id, events, in_flight, &timestamp, false);
+            process_output_completion(payload, session_id, events, in_flight, &timestamp, false);
         }
         CodexPayloadType::CustomToolCallOutput => {
-            process_output_completion(&payload, session_id, events, in_flight, &timestamp, true);
+            process_output_completion(payload, session_id, events, in_flight, &timestamp, true);
         }
         _ => {}
     }
@@ -335,6 +328,7 @@ fn process_response_item(
 
 fn process_event_msg(
     dto: &CodexLineDto,
+    payload: &CodexPayloadDto,
     session_id: &str,
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
@@ -342,21 +336,19 @@ fn process_event_msg(
     in_flight: &mut InFlightToolCalls,
     num_turns: &mut u32,
 ) {
-    let payload =
-        serde_json::from_value::<CodexPayloadDto>(dto.payload.clone()).unwrap_or_default();
     let timestamp = dto.timestamp.clone().unwrap_or_else(now_iso8601);
 
     match payload.payload_type() {
         CodexPayloadType::UserMessage => {
-            process_user_message(&payload, session_id, events, num_turns);
+            process_user_message(payload, session_id, events, num_turns);
         }
         CodexPayloadType::ExecCommandEnd => {
             process_exec_command_end(
-                &payload, session_id, cwd, events, emitter, in_flight, &timestamp,
+                payload, session_id, cwd, events, emitter, in_flight, &timestamp,
             );
         }
         CodexPayloadType::PatchApplyEnd => {
-            process_patch_apply_end(&payload, session_id, events, in_flight, &timestamp);
+            process_patch_apply_end(payload, session_id, events, in_flight, &timestamp);
         }
         _ => {}
     }
@@ -1085,10 +1077,19 @@ mod tests {
 
     // ---- extract_session_cwd unit tests (v2: session_meta ONLY) ----
 
+    /// Parse a rollout line into the payload the cwd extractors now take —
+    /// mirrors the single parse `process_line` does before calling them.
+    fn payload_of(dto: &CodexLineDto) -> CodexPayloadDto {
+        serde_json::from_value::<CodexPayloadDto>(dto.payload.clone()).unwrap_or_default()
+    }
+
     #[test]
     fn extract_session_cwd_session_meta_returns_cwd() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"session_meta","payload":{"cwd":"/workspace/A"}}"#).unwrap();
-        assert_eq!(extract_session_cwd(&dto), Some("/workspace/A".to_string()));
+        assert_eq!(
+            extract_session_cwd(dto.record_type(), &payload_of(&dto)),
+            Some("/workspace/A".to_string())
+        );
     }
 
     #[test]
@@ -1098,19 +1099,19 @@ mod tests {
         // it as live would cause false reverts after exec_command transitions.
         // This test is a defensive guard against re-introduction.
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"turn_context","payload":{"cwd":"/workspace/A"}}"#).unwrap();
-        assert_eq!(extract_session_cwd(&dto), None);
+        assert_eq!(extract_session_cwd(dto.record_type(), &payload_of(&dto)), None);
     }
 
     #[test]
     fn extract_session_cwd_other_type_returns_none() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"event_msg","payload":{"cwd":"/workspace/A"}}"#).unwrap();
-        assert_eq!(extract_session_cwd(&dto), None);
+        assert_eq!(extract_session_cwd(dto.record_type(), &payload_of(&dto)), None);
     }
 
     #[test]
     fn extract_session_cwd_empty_string_returns_none() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"session_meta","payload":{"cwd":""}}"#).unwrap();
-        assert_eq!(extract_session_cwd(&dto), None);
+        assert_eq!(extract_session_cwd(dto.record_type(), &payload_of(&dto)), None);
     }
 
     // ---- extract_exec_workdir unit tests (the mid-session signal) ----
@@ -1118,7 +1119,10 @@ mod tests {
     #[test]
     fn extract_exec_workdir_happy_path() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/workspace/B\"}"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(&dto).as_deref(), Some("/workspace/B"));
+        assert_eq!(
+            extract_exec_workdir(dto.record_type(), &payload_of(&dto)).as_deref(),
+            Some("/workspace/B")
+        );
     }
 
     #[test]
@@ -1126,31 +1130,31 @@ mod tests {
         // event_msg carrying a function_call-shaped payload should still
         // be rejected — the outer event type gate is response_item.
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"event_msg","payload":{"type":"function_call","name":"exec_command","arguments":"{\"workdir\":\"/x\"}"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(&dto), None);
+        assert_eq!(extract_exec_workdir(dto.record_type(), &payload_of(&dto)), None);
     }
 
     #[test]
     fn extract_exec_workdir_non_function_call_returns_none() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"custom_tool_call","name":"exec_command","input":"{\"workdir\":\"/x\"}"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(&dto), None);
+        assert_eq!(extract_exec_workdir(dto.record_type(), &payload_of(&dto)), None);
     }
 
     #[test]
     fn extract_exec_workdir_non_exec_command_returns_none() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"read_file","arguments":"{\"path\":\"/x\"}"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(&dto), None);
+        assert_eq!(extract_exec_workdir(dto.record_type(), &payload_of(&dto)), None);
     }
 
     #[test]
     fn extract_exec_workdir_malformed_arguments_json_returns_none() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{not json"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(&dto), None);
+        assert_eq!(extract_exec_workdir(dto.record_type(), &payload_of(&dto)), None);
     }
 
     #[test]
     fn extract_exec_workdir_missing_workdir_field_returns_none() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(&dto), None);
+        assert_eq!(extract_exec_workdir(dto.record_type(), &payload_of(&dto)), None);
     }
 
     // ---- process_line transition-semantics tests ----


### PR DESCRIPTION
## Phase 2 (C) — shared transcript tail engine

Third and final PR of the #246 A-transcript+C work (Phase 0 tests #279 → Phase 1 DTOs #286 → **this**). Collapses the two duplicated transcript `tail_loop`s (Claude Code + Codex) into one provider-neutral `TranscriptTailService` driven by an injected `TranscriptDecoder` — the decoder is the only provider-specific seam.

### Commits
| Task | What |
|------|------|
| 2.1 | `TranscriptTailService` + `TranscriptDecoder` trait + shared `POLL_INTERVAL` (read / buffer-partial-across-EOF / strip-CRLF / skip-blank / poll loop) |
| 2.2 | 5 deterministic buffering tests via a scripted `BufRead` (no real files/threads): partial-survives-EOF, truncated-never-emits, CRLF strip, blank skip, read-error→warn→sleep→continue |
| 2.3 | `ClaudeTranscriptDecoder` + thin `start_tailing`; `tail_loop` + per-provider `POLL_INTERVAL` deleted |
| 2.4 | `CodexTranscriptDecoder` + thin `start_tailing`; **double-parse delay fix** |

### Behavior
Behavior-neutral **except** the sanctioned two-sided **G3 carve-out**: the old Claude loop processed an EOF-split partial as a complete line (both halves failed `from_str` → the event was dropped); the shared service buffers + rejoins it. New end-to-end test `split_tool_use_line_across_eof_still_emits` proves a tool_use line split where neither half is valid JSON now emits `agent-tool-call`. (Codex already buffered partials inline, so it's unchanged there.)

### Delay fix (resolves the #286 deferred MEDIUM)
`process_line` (Codex) now parses each line's payload **once** and threads `&payload` to both the cwd transition and the dispatch. Pre-C, a `response_item` line parsed the payload **twice** (`extract_exec_workdir` for cwd, then `process_response_item` for dispatch) — doubled serde cost on the most numerous lines during replay. The cwd extractors now take `(record_type, &payload)`; `Other` record types early-return before the parse (pre-C never parsed them either), so the parse count is unchanged for every record type **except** `response_item` (2 → 1).

### Frozen constraints
`Ordering::Acquire` stop, `POLL_INTERVAL`, first-EOF `on_caught_up`, and `error→warn→sleep` are preserved (the last pinned by `engine_read_error_warns_and_continues`). Replay→live boundary semantics unchanged.

### Tests
5 engine + 173 Claude + 75 Codex + Phase 0 `T-replay`, all green; full `cargo test -p vimeflow` green (the lone `read_loop_eof_marks_cache_exited` failure is the pre-existing #278 flake — passes in isolation). Local `codex review --base refactor/agent-adapter`: no correctness findings.

Step F (the deferred capstone) remains tracked on #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)