### PR TITLE
fix(terminal): UTF-8 locale, GPU-occlusion, and focus-repaint rendering fixes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ playwright-report
 *.min.js
 *.d.ts
 docs/design/*/code.html
+docs/diagrams/*.html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ Follow the review process and checklist defined in `agents/code-reviewer.md`. Ke
 ## Review Guidelines
 
 - **Scope boundary (mandatory)**: Review ONLY the lines added or modified in the diff. Pre-existing bugs in unchanged code are out of scope — note them as follow-ups in a separate "Out-of-Scope Observations" section, never as findings with severity. Do not cascade into related files or chase increasingly niche edge cases in working code. Exception: actively exploitable CRITICAL security vulnerabilities.
+- **Illustrative docs are out of scope**: Static, hand-authored explainer/diagram files under `docs/**` (e.g. `docs/diagrams/*.html`, `docs/design/*/code.html`) carry no application logic, runtime code, or tests. They are documentation. Do not line-by-line review them, raise CSS/SVG/markup nits, or treat them as behavioral surface; at most confirm links resolve. These files are also Prettier-ignored.
 - Severity levels: CRITICAL (security/data loss), HIGH (bugs), MEDIUM (maintainability), LOW (style)
 - Flag any hardcoded secrets, `console.log` statements, or `any` types
 - Approval: no CRITICAL/HIGH = approve; HIGH only = warn; CRITICAL = block

--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -53,6 +53,35 @@ fn utf8_ctype_override(
     }
 }
 
+/// The locale env mutations to apply to a spawned shell, derived from the
+/// inherited locale env in POSIX precedence order.
+struct LocaleEnvPlan {
+    /// `LC_CTYPE` to inject, or `None` when an inherited UTF-8 locale is kept.
+    ctype: Option<&'static str>,
+    /// Whether to drop `LC_ALL` from the child env. A non-empty `LC_ALL`
+    /// overrides `LC_CTYPE` under POSIX precedence, so injecting `LC_CTYPE`
+    /// alone would be ignored and the shell would keep byte-counting glyphs.
+    clear_lc_all: bool,
+}
+
+/// Plan the locale env mutations for a spawned shell. When a UTF-8 override is
+/// needed but `LC_ALL` is set to a non-empty (non-UTF-8) locale — the very
+/// reason the override fired — `LC_ALL` is cleared so the injected `LC_CTYPE`
+/// governs character handling; individual `LC_*`/`LANG` still drive the user's
+/// message/collation language.
+fn locale_env_plan(
+    lc_all: Option<&str>,
+    lc_ctype: Option<&str>,
+    lang: Option<&str>,
+) -> LocaleEnvPlan {
+    let ctype = utf8_ctype_override(lc_all, lc_ctype, lang);
+    let clear_lc_all = ctype.is_some() && matches!(lc_all, Some(value) if !value.is_empty());
+    LocaleEnvPlan {
+        ctype,
+        clear_lc_all,
+    }
+}
+
 /// Spawn a new PTY session with a shell
 pub(crate) async fn spawn_pty_inner(
     state: PtyState,
@@ -188,11 +217,15 @@ pub(crate) async fn spawn_pty_inner(
     let inherited_lc_all = std::env::var("LC_ALL").ok();
     let inherited_lc_ctype = std::env::var("LC_CTYPE").ok();
     let inherited_lang = std::env::var("LANG").ok();
-    if let Some(ctype) = utf8_ctype_override(
+    let locale_plan = locale_env_plan(
         inherited_lc_all.as_deref(),
         inherited_lc_ctype.as_deref(),
         inherited_lang.as_deref(),
-    ) {
+    );
+    if locale_plan.clear_lc_all {
+        cmd.env_remove("LC_ALL");
+    }
+    if let Some(ctype) = locale_plan.ctype {
         cmd.env("LC_CTYPE", ctype);
     }
 
@@ -927,6 +960,42 @@ mod tests {
             utf8_ctype_override(None, Some("C"), Some("en_US.UTF-8")),
             Some(DEFAULT_UTF8_CTYPE)
         );
+    }
+
+    #[test]
+    fn locale_env_plan_clears_non_utf8_lc_all_when_injecting() {
+        // A non-UTF-8 LC_ALL is effective and would override an injected
+        // LC_CTYPE, so it must be cleared alongside the injection.
+        let plan = locale_env_plan(Some("C"), None, None);
+        assert_eq!(plan.ctype, Some(DEFAULT_UTF8_CTYPE));
+        assert!(plan.clear_lc_all);
+
+        // Even when a lower-precedence UTF-8 locale exists, the non-UTF-8
+        // LC_ALL still wins, so both the injection and the clear must happen.
+        let plan = locale_env_plan(Some("POSIX"), None, Some("de_DE.UTF-8"));
+        assert_eq!(plan.ctype, Some(DEFAULT_UTF8_CTYPE));
+        assert!(plan.clear_lc_all);
+    }
+
+    #[test]
+    fn locale_env_plan_keeps_lc_all_when_no_override() {
+        // A UTF-8 LC_ALL needs no override and must not be cleared.
+        let plan = locale_env_plan(Some("en_US.UTF-8"), None, Some("C"));
+        assert_eq!(plan.ctype, None);
+        assert!(!plan.clear_lc_all);
+    }
+
+    #[test]
+    fn locale_env_plan_does_not_clear_unset_or_empty_lc_all() {
+        // No LC_ALL: inject LC_CTYPE only, nothing to clear.
+        let plan = locale_env_plan(None, None, Some("C"));
+        assert_eq!(plan.ctype, Some(DEFAULT_UTF8_CTYPE));
+        assert!(!plan.clear_lc_all);
+
+        // Empty LC_ALL behaves as unset under POSIX, so it need not be cleared.
+        let plan = locale_env_plan(Some(""), None, Some("C"));
+        assert_eq!(plan.ctype, Some(DEFAULT_UTF8_CTYPE));
+        assert!(!plan.clear_lc_all);
     }
 
     #[tokio::test]

--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -18,6 +18,41 @@ fn cleanup_generated_bridge_dir(dir: Option<&std::path::Path>) {
     }
 }
 
+/// `LC_CTYPE` injected into a spawned shell when the inherited environment
+/// selects no UTF-8 locale. A non-UTF-8 (or empty) locale makes the shell
+/// byte-count multibyte glyphs, so this picks the most broadly available UTF-8
+/// character map per platform.
+#[cfg(target_os = "macos")]
+const DEFAULT_UTF8_CTYPE: &str = "en_US.UTF-8";
+#[cfg(not(target_os = "macos"))]
+const DEFAULT_UTF8_CTYPE: &str = "C.UTF-8";
+
+fn is_utf8_locale(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("utf-8") || lower.contains("utf8")
+}
+
+/// Decide which `LC_CTYPE` to inject into a spawned shell from the inherited
+/// locale env, evaluated in POSIX precedence order (`LC_ALL` > `LC_CTYPE` >
+/// `LANG`). Returns `Some` only when no UTF-8 locale is inherited — an explicit
+/// UTF-8 locale is left untouched. Targets `LC_CTYPE` (character handling)
+/// rather than `LANG` so the user's message/collation language is preserved.
+fn utf8_ctype_override(
+    lc_all: Option<&str>,
+    lc_ctype: Option<&str>,
+    lang: Option<&str>,
+) -> Option<&'static str> {
+    let effective = [lc_all, lc_ctype, lang]
+        .into_iter()
+        .flatten()
+        .find(|value| !value.is_empty());
+
+    match effective {
+        Some(value) if is_utf8_locale(value) => None,
+        _ => Some(DEFAULT_UTF8_CTYPE),
+    }
+}
+
 /// Spawn a new PTY session with a shell
 pub(crate) async fn spawn_pty_inner(
     state: PtyState,
@@ -142,6 +177,24 @@ pub(crate) async fn spawn_pty_inner(
     // contract to child TUIs without accepting arbitrary env from IPC.
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
+
+    // Ensure a UTF-8 locale for character handling. GUI launches frequently
+    // inherit no LANG/LC_* (Terminal.app/iTerm2 set them; a dock/Finder or
+    // `electron:dev` launch does not), so the shell falls back to the C locale
+    // and byte-counts multibyte Powerline/Nerd Font glyphs — miscomputing line
+    // width and desyncing the cursor during line editing (autocomplete,
+    // redisplay). Inject LC_CTYPE only when no UTF-8 locale is inherited, so an
+    // explicit user locale is preserved.
+    let inherited_lc_all = std::env::var("LC_ALL").ok();
+    let inherited_lc_ctype = std::env::var("LC_CTYPE").ok();
+    let inherited_lang = std::env::var("LANG").ok();
+    if let Some(ctype) = utf8_ctype_override(
+        inherited_lc_all.as_deref(),
+        inherited_lc_ctype.as_deref(),
+        inherited_lang.as_deref(),
+    ) {
+        cmd.env("LC_CTYPE", ctype);
+    }
 
     // Inject a `claude` wrapper function into the interactive shell.
     //
@@ -833,6 +886,47 @@ mod tests {
         let events = Arc::new(crate::runtime::FakeEventSink::new());
 
         (PtyState::new(), cache, events, temp_dir)
+    }
+
+    #[test]
+    fn utf8_ctype_override_injects_default_when_locale_unset() {
+        assert_eq!(
+            utf8_ctype_override(None, None, None),
+            Some(DEFAULT_UTF8_CTYPE)
+        );
+    }
+
+    #[test]
+    fn utf8_ctype_override_injects_for_non_utf8_or_empty_locale() {
+        assert_eq!(
+            utf8_ctype_override(None, None, Some("C")),
+            Some(DEFAULT_UTF8_CTYPE)
+        );
+        assert_eq!(
+            utf8_ctype_override(None, None, Some("")),
+            Some(DEFAULT_UTF8_CTYPE)
+        );
+    }
+
+    #[test]
+    fn utf8_ctype_override_preserves_inherited_utf8_locale() {
+        assert_eq!(utf8_ctype_override(None, None, Some("en_US.UTF-8")), None);
+        assert_eq!(utf8_ctype_override(None, Some("zh_CN.UTF-8"), None), None);
+        assert_eq!(utf8_ctype_override(Some("en_US.utf8"), None, None), None);
+    }
+
+    #[test]
+    fn utf8_ctype_override_follows_posix_precedence() {
+        // LC_ALL (UTF-8) wins even when LANG is non-UTF-8.
+        assert_eq!(
+            utf8_ctype_override(Some("en_US.UTF-8"), None, Some("C")),
+            None
+        );
+        // A non-UTF-8 LC_CTYPE overrides a UTF-8 LANG, so injection still wins.
+        assert_eq!(
+            utf8_ctype_override(None, Some("C"), Some("en_US.UTF-8")),
+            Some(DEFAULT_UTF8_CTYPE)
+        );
     }
 
     #[tokio::test]

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -112,6 +112,7 @@ words:
   - FiraCode
   - Cascadia
   - Menlo
+  - backgrounding
 
 ignorePaths:
   - node_modules

--- a/docs/decisions/2026-05-27-terminal-rendering-fixes.md
+++ b/docs/decisions/2026-05-27-terminal-rendering-fixes.md
@@ -1,0 +1,115 @@
+# Terminal rendering: keep WebGL, fix the four real causes around it
+
+**Date:** 2026-05-27
+**Status:** Accepted (font + locale + GPU-occlusion + focus-repaint shipped; backend UTF-8 chunk-split deferred)
+**Scope:** the xterm.js terminal pane (`src/features/terminal/components/TerminalPane/`), the Electron main process GPU flags (`electron/main.ts`), the renderer font stack (`src/index.css`, `terminalFont.ts`), and the Rust PTY spawn path (`crates/backend/src/terminal/commands.rs`). Lands across two branches: `fix/terminal-nerd-font-symbol-source` and `fix/terminal-pty-utf8-locale`.
+
+## Context
+
+Three user-visible symptoms surfaced over a week of macOS dogfooding, all in the xterm.js pane:
+
+1. **Prompt font misalignment** — typed text in the Powerline (p10k) prompt rendered with "unseeable white spaces" and was pushed far to the right on the next line.
+2. **Autocomplete cursor desync** — during line editing (zsh-autosuggestions / syntax highlight / completion redisplay), typed text was flung to the far right of the row.
+3. **"Ghosting"** — duplicate/overlapping rows, garbled "alien" glyphs, and stray `?` characters in the Claude Code TUI running inside Vimeflow, triggered by switching to another window while an agent streamed output.
+
+They looked like one bug ("the terminal renders wrong"). They were **four independent root causes** in three different layers — font sourcing, the PTY's locale, Chromium's GPU process, and xterm's render loop. The investigation's central risk was treating them as one and shipping a fix that masked one cause while leaving the others. A `/goal` hard gate (no fix until Claude **and** an independent Codex analysis agree on the root cause) was used to force per-cause isolation; the [retrospective](../superpowers/retros/2026-05-27-terminal-rendering-investigation.md) covers that process.
+
+The one decision that needed protecting throughout: **the WebGL renderer is a documented choice** (`docs/roadmap/tauri-migration-roadmap.md:125` — "xterm.js performance with large agent output — use WebGL renderer"). Several tempting fixes would have quietly reversed it.
+
+## Options considered (per cause)
+
+### Cause 1 — prompt font misalignment
+
+The installed `Hack Nerd Font` is a **non-Mono** variant (wider ink/advance than a single cell); the renderer's font stack also leaned on whatever Nerd Font happened to be installed on the machine, so glyph advances differed across machines.
+
+1. **Require users to install a specific "Mono" Nerd Font** and document it.
+2. **Switch the whole terminal to a single `... Mono` Nerd family** globally.
+3. **Bundle a dedicated symbol face and scope it with CSS `unicode-range`** — the web equivalent of kitty's `symbol_map` / Ghostty's font-fallback ranges. Powerline + Nerd Font codepoints render from the bundled `Vimeflow Nerd Symbols` face; everything else renders from the text font.
+
+### Cause 2 — autocomplete cursor desync
+
+GUI launches (dock/Finder, `electron:dev`) inherit **no `LANG`/`LC_*`** — unlike Terminal.app / iTerm2, which set them — so the spawned shell runs in the **C locale** and byte-counts multibyte glyphs. zsh then measures each Powerline/Nerd glyph as ~3 cells, miscomputes line width, and desyncs the cursor.
+
+1. **Set `LANG`** in the spawn environment.
+2. **Set `LC_ALL`** (overrides everything).
+3. **Set `LC_CTYPE` only**, and only when the inherited environment selects no UTF-8 locale.
+
+### Cause 3 — ghosting, "alien" glyph corruption (severe)
+
+Both the WebGL and Canvas renderers paint through Chromium's GPU process. When the window is occluded, Chromium backgrounds it and **reclaims its GPU resources**, scrambling xterm's cached glyph textures → garbage glyphs that persist until a repaint. Confirmed by `app.disableHardwareAcceleration()` making the corruption vanish (software rendering, no GPU process to reclaim).
+
+1. **Swap WebGL → Canvas2D** as the primary renderer.
+2. **Disable hardware acceleration globally** (`app.disableHardwareAcceleration()`).
+3. **Clear the texture atlas** (`clearTextureAtlas()`) on occlusion.
+4. **Keep hardware acceleration + WebGL, but stop the occlusion-driven reclaim** with `disable-backgrounding-occluded-windows` + `disable-renderer-backgrounding`.
+
+### Cause 4 — ghosting, duplicate/overlapping rows (milder residual)
+
+xterm renders on a debounced `requestAnimationFrame` loop (`RenderDebouncer` → `rAF` → `refreshRows`, verified in `@xterm/xterm@6.0.0` source) and listens only for `pagehide`, **not** `visibilitychange`. Chromium throttles rAF for occluded/backgrounded windows, so rows that streamed in while the user was away never flush — they stay stale until something forces a repaint (a text selection clears it, proving the buffer is correct and only the paint is stale). Renderer-agnostic: reproduces on WebGL, Canvas2D, and software rendering.
+
+1. **Set `webPreferences.backgroundThrottling: false`** on the BrowserWindow.
+2. **Disable Chromium's background timer throttling** globally.
+3. **Force a full `refresh(0, rows-1)`** on `window` `focus` and on `document` `visibilitychange → visible`.
+
+## Decision
+
+| Cause                                | Chosen fix                                                                                                        | Commit / branch                                     |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| 1 — font misalignment                | Bundle `Vimeflow Nerd Symbols`, scope it with `unicode-range` (Option 3); reorder the font stack to put it first  | `76d1524` on `fix/terminal-nerd-font-symbol-source` |
+| 2 — cursor desync                    | Inject `LC_CTYPE` only when no UTF-8 locale is inherited — `en_US.UTF-8` on macOS, `C.UTF-8` elsewhere (Option 3) | `717cc9a` on `fix/terminal-pty-utf8-locale`         |
+| 3 — GPU corruption                   | Keep WebGL + the two occlusion switches (Option 4)                                                                | `f99742c`                                           |
+| 4 — stale rows                       | Force `refresh(0, rows-1)` on focus + visibilitychange (Option 3)                                                 | `f8a8577`                                           |
+| (deferred) backend UTF-8 chunk-split | — not yet fixed —                                                                                                 | see Known risks                                     |
+
+## Justification
+
+1. **`unicode-range` is the same mechanism real terminals use.** kitty's `symbol_map`, Ghostty's font-fallback ranges, and Windows Terminal's font-fallback all map a codepoint range to a dedicated face. Bundling the face removes the cross-machine variance entirely — the glyph source no longer depends on what the user happened to `brew install`.
+2. **`LC_CTYPE` is the minimal correct knob.** It governs character classification / width (the thing zsh gets wrong), while leaving the user's message and collation language (`LC_MESSAGES`, `LC_COLLATE`) untouched — which `LANG` or `LC_ALL` would clobber. Injecting only when nothing UTF-8 is inherited means a user with an explicit locale is never second-guessed. This mirrors what Terminal.app / iTerm2 do.
+3. **The occlusion switches preserve the documented WebGL decision.** They keep hardware acceleration and the WebGL renderer (the choice made for large-agent-output throughput) while removing only the occlusion-driven GPU reclaim that corrupts the texture cache. The diagnostic that proved the cause — disabling hardware acceleration — is explicitly _not_ the fix, because it would reverse a documented decision and regress throughput.
+4. **The focus-repaint is complementary, not redundant.** Cause 3's switches keep the window painting while it is _covered_; Cause 4's repaint flushes rows that went stale during the window-switch and only re-render on _return_. Because Cause 4 is renderer-agnostic and survives software rendering, it is not subsumed by the GPU fix — both are needed.
+5. **Each cause was isolated before its fix was written.** The `/goal` gate (Claude + independent Codex consensus) refused any fix until the mechanism was confirmed with evidence. This is why the fixes are four atomic commits across two branches rather than one "terminal rendering" mega-commit — each is independently testable and revertable.
+
+## Alternatives rejected
+
+### Swap WebGL → Canvas2D (Cause 3, rejected)
+
+Reverses a documented decision (`tauri-migration-roadmap.md:125`) and regresses large-output throughput. It also **does not fix the bug**: Canvas2D paints through the same GPU process, so it corrupts on occlusion exactly like WebGL. It was tried unilaterally during the investigation and reverted after the user flagged the documented decision — the single biggest process miss of the week (see retro).
+
+### Disable hardware acceleration globally (Cause 3, rejected)
+
+Makes the corruption vanish, which is why it's the perfect _diagnostic_. As a _fix_ it throws out GPU rendering for the entire app to solve a bug scoped to occluded-window glyph caches — a sledgehammer that regresses every GPU-accelerated surface, not just the terminal.
+
+### `clearTextureAtlas()` on occlusion (Cause 3, rejected)
+
+Refuted by evidence: the residual artifact is renderer-agnostic and survives software rendering, where there is no texture atlas to clear. Clearing the atlas treats a symptom of one cause and does nothing for the other.
+
+### `webPreferences.backgroundThrottling: false` / global timer-throttle disable (Cause 4, rejected)
+
+Broader blast radius than needed — disables throttling for _all_ timers/rAF on the window or app, including idle background work we _want_ throttled for battery. A targeted repaint on the two recovery events (focus, visibility) flushes the stale rows without keeping the whole rAF loop hot while the window is hidden. The occlusion switches from Cause 3 already keep the loop alive while _covered_; the repaint handles the _return_ edge specifically.
+
+### Set `LANG` or `LC_ALL` (Cause 2, rejected)
+
+`LANG` is the lowest-precedence locale var and would be overridden by any inherited `LC_*`; `LC_ALL` is the highest and would clobber a user's deliberate message/collation language. `LC_CTYPE` is the precise variable for character width and the right precedence tier.
+
+## Known risks & mitigations
+
+| Risk                                                                                                                                                                                                                  | Likelihood | Mitigation                                                                                                                                                                                                                                                                      |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Backend `String::from_utf8_lossy(&buf[..n])` splits a multibyte glyph across PTY read boundaries → `U+FFFD` (`?`) injected into the stream (`commands.rs:772`)                                                        | Medium     | **Deferred, not fixed.** Identified during the investigation and corroborated by Codex as a third contributor to the stray-`?` artifact. Fix is a carry-over decoder that holds the trailing incomplete byte sequence until the next read. Tracked as the open follow-up below. |
+| The two occlusion switches keep an occluded window's GPU resources resident — small VRAM cost while backgrounded                                                                                                      | Low        | Scoped to this app's single main window; the throughput/correctness win outweighs the idle VRAM. Revisit only if multi-window lands.                                                                                                                                            |
+| `unicode-range` face must be bundled and loaded before first paint, or the first prompt flashes fallback glyphs                                                                                                       | Low        | Face is bundled with the app and declared in `src/index.css`; FOUT is cosmetic and one-frame.                                                                                                                                                                                   |
+| CDP could not reproduce real OS window-occlusion (`setVisibilityState` self-recovers; `disable-renderer-backgrounding` prevents the minimize-throttle), so Cause 3/4 before-after was verified by hand, not automated | Low        | xterm render loop confirmed by source reading + synthetic `focus`/`visibilitychange` dispatch (`refresh` fires); the OS-occlusion edge is the one path that needs a human in the loop.                                                                                          |
+
+## Open follow-up
+
+- **Backend UTF-8 chunk-boundary decode** (`crates/backend/src/terminal/commands.rs:772`). Replace the per-read `from_utf8_lossy` with a decoder that carries the trailing incomplete byte sequence into the next read, so a glyph split across two PTY reads is decoded whole instead of emitting `U+FFFD`. Unit-testable in isolation; no renderer interaction.
+
+## References
+
+- WebGL renderer decision: `docs/roadmap/tauri-migration-roadmap.md:125`
+- Investigation retrospective: [2026-05-27-terminal-rendering-investigation.md](../superpowers/retros/2026-05-27-terminal-rendering-investigation.md)
+- xterm render loop: `@xterm/xterm@6.0.0` `RenderDebouncer` / `refreshRows`
+- kitty `symbol_map`: <https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.symbol_map>
+- CSS `unicode-range`: <https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range>
+- Chromium occlusion switches: `disable-backgrounding-occluded-windows`, `disable-renderer-backgrounding`
+- Related upstream report context: Claude Code issue [#20627](https://github.com/anthropics/claude-code/issues/20627)

--- a/docs/decisions/CLAUDE.md
+++ b/docs/decisions/CLAUDE.md
@@ -10,14 +10,15 @@ This file is an index. Each linked record is self-contained. Read only what you 
 
 ## Records
 
-| Date       | Decision                                                                                       | Status                                          |
-| ---------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| 2026-05-23 | [Diff renderer: `@pierre/diffs`](./2026-05-23-pierre-diffs-renderer.md)                        | Accepted (spike validated, integration pending) |
-| 2026-05-16 | [In-repo skill symlinks for `/lifeline:*`](./2026-05-16-in-repo-skills-setup.md)               | Accepted                                        |
-| 2026-05-05 | [Codex adapter trait simplification](./2026-05-05-codex-adapter-trait-simplification.md)       | Accepted                                        |
-| 2026-05-04 | [Codex adapter Stage 2 scope expansion](./2026-05-04-codex-adapter-stage-2-scope-expansion.md) | Accepted                                        |
-| 2026-05-03 | [Claude parser JSON boundary](./2026-05-03-claude-parser-json-boundary.md)                     | Accepted                                        |
-| 2026-04-22 | [Tooltip library: `@floating-ui/react`](./2026-04-22-tooltip-library.md)                       | Accepted                                        |
+| Date       | Decision                                                                                             | Status                                                        |
+| ---------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| 2026-05-27 | [Terminal rendering: keep WebGL, fix the four real causes](./2026-05-27-terminal-rendering-fixes.md) | Accepted (3 of 4 shipped; backend UTF-8 chunk-split deferred) |
+| 2026-05-23 | [Diff renderer: `@pierre/diffs`](./2026-05-23-pierre-diffs-renderer.md)                              | Accepted (spike validated, integration pending)               |
+| 2026-05-16 | [In-repo skill symlinks for `/lifeline:*`](./2026-05-16-in-repo-skills-setup.md)                     | Accepted                                                      |
+| 2026-05-05 | [Codex adapter trait simplification](./2026-05-05-codex-adapter-trait-simplification.md)             | Accepted                                                      |
+| 2026-05-04 | [Codex adapter Stage 2 scope expansion](./2026-05-04-codex-adapter-stage-2-scope-expansion.md)       | Accepted                                                      |
+| 2026-05-03 | [Claude parser JSON boundary](./2026-05-03-claude-parser-json-boundary.md)                           | Accepted                                                      |
+| 2026-04-22 | [Tooltip library: `@floating-ui/react`](./2026-04-22-tooltip-library.md)                             | Accepted                                                      |
 
 ## Adding a record
 

--- a/docs/diagrams/terminal-ghosting-rca.html
+++ b/docs/diagrams/terminal-ghosting-rca.html
@@ -1,0 +1,896 @@
+<!doctype html>
+<!--
+  ========================================================================
+  REVIEW NOTE — for human and agent (Codex / Claude) reviewers
+  ========================================================================
+  This file is a STATIC, hand-authored explainer/diagram document. It holds
+  no application logic, no runtime code, no imports, and no tests — only
+  prose, inline CSS, and inline SVG, for illustration.
+
+  It is documentation, NOT code. Please do not line-by-line review it, chase
+  CSS/SVG nits, or treat it as part of the app's behavioral surface. To
+  verify it, open it in a browser and confirm it renders. It is excluded
+  from Prettier via .prettierignore for the same reason.
+
+  Reviewable companions (the real artifacts):
+    - docs/decisions/2026-05-27-terminal-rendering-fixes.md
+    - docs/superpowers/retros/2026-05-27-terminal-rendering-investigation.md
+  ========================================================================
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Anatomy of a Ghost — Debugging the Vimeflow Terminal</title>
+    <style>
+      :root {
+        --base: #1e1e2e;
+        --mantle: #181825;
+        --crust: #11111b;
+        --surface0: #313244;
+        --surface1: #45475a;
+        --surface2: #585b70;
+        --text: #cdd6f4;
+        --subtext1: #bac2de;
+        --subtext0: #a6adc8;
+        --overlay0: #6c7086;
+        --overlay1: #7f849c;
+        --blue: #89b4fa;
+        --lavender: #b4befe;
+        --sapphire: #74c7ec;
+        --teal: #94e2d5;
+        --green: #a6e3a1;
+        --yellow: #f9e2af;
+        --peach: #fab387;
+        --red: #f38ba8;
+        --maroon: #eba0ac;
+        --mauve: #cba6f7;
+        --pink: #f5c2e7;
+        --c-font: var(--peach);
+        --c-locale: var(--yellow);
+        --c-gpu: var(--red);
+        --c-raf: var(--mauve);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        margin: 0;
+        background:
+          radial-gradient(
+            1200px 800px at 80% -10%,
+            rgba(137, 180, 250, 0.08),
+            transparent 60%
+          ),
+          radial-gradient(
+            1000px 700px at -10% 20%,
+            rgba(203, 166, 247, 0.07),
+            transparent 55%
+          ),
+          var(--base);
+        color: var(--text);
+        font-family:
+          "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        line-height: 1.65;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .wrap {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 0 24px 120px;
+      }
+
+      code,
+      .mono {
+        font-family:
+          "JetBrains Mono", "SF Mono", ui-monospace, "Cascadia Code", monospace;
+        font-size: 0.88em;
+        background: rgba(17, 17, 27, 0.6);
+        padding: 0.12em 0.4em;
+        border-radius: 5px;
+        color: var(--sapphire);
+      }
+
+      h1,
+      h2,
+      h3 {
+        font-family:
+          "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.2;
+        letter-spacing: -0.02em;
+      }
+
+      /* ---------- Hero ---------- */
+      header.hero {
+        padding: 96px 24px 64px;
+        max-width: 980px;
+        margin: 0 auto;
+        text-align: center;
+      }
+
+      .kicker {
+        text-transform: uppercase;
+        letter-spacing: 0.32em;
+        font-size: 12px;
+        color: var(--overlay1);
+        font-weight: 600;
+      }
+
+      header.hero h1 {
+        font-size: clamp(38px, 7vw, 68px);
+        margin: 18px 0 10px;
+        background: linear-gradient(120deg, var(--lavender), var(--sapphire), var(--teal));
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+
+      header.hero p.sub {
+        font-size: clamp(16px, 2.2vw, 21px);
+        color: var(--subtext0);
+        max-width: 660px;
+        margin: 0 auto;
+      }
+
+      .pills {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        justify-content: center;
+        margin-top: 34px;
+      }
+
+      .pill {
+        font-size: 13px;
+        padding: 7px 14px;
+        border-radius: 999px;
+        background: rgba(49, 50, 68, 0.55);
+        border: 1px solid rgba(127, 132, 156, 0.25);
+        color: var(--subtext1);
+        backdrop-filter: blur(8px);
+      }
+
+      .pill b {
+        color: var(--text);
+      }
+
+      /* ---------- Sections ---------- */
+      section {
+        margin-top: 72px;
+      }
+
+      h2 {
+        font-size: clamp(24px, 4vw, 34px);
+        margin: 0 0 6px;
+      }
+
+      .lede {
+        color: var(--subtext0);
+        font-size: 17px;
+        margin: 0 0 28px;
+      }
+
+      .num {
+        color: var(--overlay0);
+        font-variant-numeric: tabular-nums;
+        margin-right: 10px;
+      }
+
+      p {
+        color: var(--subtext1);
+      }
+
+      a {
+        color: var(--blue);
+        text-decoration: none;
+        border-bottom: 1px solid rgba(137, 180, 250, 0.35);
+      }
+      a:hover {
+        color: var(--sapphire);
+      }
+
+      .card {
+        background: linear-gradient(
+          180deg,
+          rgba(49, 50, 68, 0.45),
+          rgba(24, 24, 37, 0.55)
+        );
+        border: 1px solid rgba(127, 132, 156, 0.18);
+        border-radius: 18px;
+        padding: 26px 28px;
+        backdrop-filter: blur(10px);
+      }
+
+      .figure {
+        background: rgba(17, 17, 27, 0.45);
+        border: 1px solid rgba(127, 132, 156, 0.15);
+        border-radius: 18px;
+        padding: 22px;
+        margin: 8px 0 6px;
+        overflow-x: auto;
+      }
+      .figcap {
+        color: var(--overlay1);
+        font-size: 13.5px;
+        text-align: center;
+        margin-top: 10px;
+      }
+      svg {
+        display: block;
+        margin: 0 auto;
+        max-width: 100%;
+        height: auto;
+      }
+
+      /* ---------- Cause cards ---------- */
+      .cause {
+        border-radius: 18px;
+        padding: 26px 28px;
+        margin-bottom: 22px;
+        border: 1px solid rgba(127, 132, 156, 0.18);
+        background: rgba(24, 24, 37, 0.5);
+        border-left: 4px solid var(--accent);
+      }
+      .cause .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--accent);
+      }
+      .cause h3 {
+        font-size: 22px;
+        margin: 10px 0 4px;
+      }
+      .cause .layer {
+        font-size: 13px;
+        color: var(--overlay1);
+        margin-bottom: 16px;
+      }
+      .cause .layer b {
+        color: var(--subtext0);
+      }
+      .grid2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 18px;
+      }
+      @media (max-width: 720px) {
+        .grid2 {
+          grid-template-columns: 1fr;
+        }
+      }
+      .block h4 {
+        margin: 0 0 6px;
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--overlay1);
+        font-family: "Manrope", sans-serif;
+      }
+      .block p {
+        margin: 0;
+        font-size: 15px;
+      }
+      .fixline {
+        margin-top: 16px;
+        padding-top: 14px;
+        border-top: 1px dashed rgba(127, 132, 156, 0.22);
+        font-size: 14.5px;
+        color: var(--subtext0);
+      }
+      .commit {
+        font-family: "JetBrains Mono", monospace;
+        font-size: 12px;
+        color: var(--green);
+        background: rgba(166, 227, 161, 0.1);
+        padding: 2px 8px;
+        border-radius: 6px;
+      }
+
+      /* ---------- Table ---------- */
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14.5px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 13px 14px;
+        border-bottom: 1px solid rgba(127, 132, 156, 0.14);
+        vertical-align: top;
+      }
+      th {
+        color: var(--subtext0);
+        font-weight: 600;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+      td:first-child {
+        color: var(--text);
+        font-weight: 500;
+      }
+      .verdict {
+        font-weight: 700;
+        white-space: nowrap;
+      }
+      .ok {
+        color: var(--green);
+      }
+      .no {
+        color: var(--red);
+      }
+      .diag {
+        color: var(--yellow);
+      }
+
+      .callout {
+        border-radius: 16px;
+        padding: 22px 26px;
+        background: linear-gradient(
+          135deg,
+          rgba(137, 180, 250, 0.12),
+          rgba(203, 166, 247, 0.1)
+        );
+        border: 1px solid rgba(180, 190, 254, 0.25);
+        margin: 26px 0;
+      }
+      .callout b {
+        color: var(--lavender);
+      }
+
+      footer {
+        margin-top: 90px;
+        padding-top: 28px;
+        border-top: 1px solid rgba(127, 132, 156, 0.18);
+        color: var(--overlay0);
+        font-size: 14px;
+      }
+      footer a {
+        margin-right: 18px;
+      }
+      .legend {
+        display: flex;
+        gap: 18px;
+        flex-wrap: wrap;
+        justify-content: center;
+        margin-top: 14px;
+        font-size: 13px;
+        color: var(--subtext0);
+      }
+      .dot {
+        display: inline-block;
+        width: 11px;
+        height: 11px;
+        border-radius: 3px;
+        margin-right: 6px;
+        vertical-align: middle;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="hero">
+      <div class="kicker">Vimeflow · Root-Cause Investigation</div>
+      <h1>Anatomy of a Ghost</h1>
+      <p class="sub">
+        Three terminal glitches that looked like one bug were really four,
+        living in four different layers of the stack. Here is how the theory was
+        built — and why the fix that <em>proved</em> the cause was deliberately
+        not the fix that shipped.
+      </p>
+      <div class="pills">
+        <span class="pill"><b>4</b> root causes</span>
+        <span class="pill"><b>6</b> hypotheses tested</span>
+        <span class="pill"><b>2</b> independent analyses (Claude + Codex)</span>
+        <span class="pill"><b>WebGL</b> preserved</span>
+      </div>
+    </header>
+
+    <div class="wrap">
+      <!-- ===================== THE SYMPTOMS ===================== -->
+      <section>
+        <h2><span class="num">01</span>One symptom name, four real bugs</h2>
+        <p class="lede">
+          Everything showed up as “the terminal renders wrong.” That framing is
+          a trap: it invites a single fix for what are actually independent
+          faults. The first job was to <strong>split the symptom</strong> into
+          distinct, separately-triggered behaviours.
+        </p>
+
+        <div class="figure">
+          <svg viewBox="0 0 900 470" role="img" aria-label="The terminal rendering stack with four bugs pinned to their layers">
+            <defs>
+              <marker id="arrow" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto">
+                <path d="M0,0 L7,3 L0,6 Z" fill="#7f849c" />
+              </marker>
+              <linearGradient id="layerg" x1="0" y1="0" x2="1" y2="1">
+                <stop offset="0" stop-color="#313244" stop-opacity="0.75" />
+                <stop offset="1" stop-color="#181825" stop-opacity="0.85" />
+              </linearGradient>
+            </defs>
+
+            <!-- layers -->
+            <g font-family="Manrope, sans-serif">
+              <!-- helper: each layer row -->
+              <!-- 1 zsh -->
+              <rect x="60" y="20" width="430" height="46" rx="10" fill="url(#layerg)" stroke="#45475a"/>
+              <text x="80" y="48" fill="#cdd6f4" font-size="15" font-weight="600">zsh + Powerline / p10k prompt</text>
+              <text x="80" y="62" fill="#6c7086" font-size="11" font-family="JetBrains Mono, monospace">emits bytes · measures glyph width</text>
+
+              <!-- 2 PTY -->
+              <rect x="60" y="78" width="430" height="46" rx="10" fill="url(#layerg)" stroke="#45475a"/>
+              <text x="80" y="106" fill="#cdd6f4" font-size="15" font-weight="600">Rust PTY backend</text>
+              <text x="80" y="120" fill="#6c7086" font-size="11" font-family="JetBrains Mono, monospace">commands.rs · spawn env · read loop</text>
+
+              <!-- 3 IPC -->
+              <rect x="60" y="136" width="430" height="40" rx="10" fill="url(#layerg)" stroke="#45475a"/>
+              <text x="80" y="161" fill="#bac2de" font-size="14">LSP-framed IPC over stdio → Electron main</text>
+
+              <!-- 4 renderer -->
+              <rect x="60" y="188" width="430" height="40" rx="10" fill="url(#layerg)" stroke="#45475a"/>
+              <text x="80" y="213" fill="#bac2de" font-size="14">Electron renderer (React)</text>
+
+              <!-- 5 xterm -->
+              <rect x="60" y="240" width="430" height="56" rx="10" fill="url(#layerg)" stroke="#45475a"/>
+              <text x="80" y="266" fill="#cdd6f4" font-size="15" font-weight="600">xterm.js</text>
+              <text x="80" y="282" fill="#6c7086" font-size="11" font-family="JetBrains Mono, monospace">parser → buffer → RenderDebouncer → rAF → refreshRows</text>
+
+              <!-- 6 webgl -->
+              <rect x="60" y="308" width="430" height="40" rx="10" fill="url(#layerg)" stroke="#45475a"/>
+              <text x="80" y="333" fill="#bac2de" font-size="14">@xterm/addon-webgl · glyph texture atlas</text>
+
+              <!-- 7 gpu -->
+              <rect x="60" y="360" width="430" height="46" rx="10" fill="url(#layerg)" stroke="#45475a"/>
+              <text x="80" y="388" fill="#cdd6f4" font-size="15" font-weight="600">Chromium GPU process</text>
+              <text x="80" y="402" fill="#6c7086" font-size="11" font-family="JetBrains Mono, monospace">textures · compositing · occlusion mgmt</text>
+
+              <!-- screen -->
+              <rect x="60" y="420" width="430" height="34" rx="10" fill="#11111b" stroke="#313244"/>
+              <text x="80" y="442" fill="#a6adc8" font-size="13">🖥  Screen</text>
+
+              <!-- flow arrows down the left -->
+              <line x1="48" y1="20" x2="48" y2="454" stroke="#45475a" stroke-width="2"/>
+              <polygon points="44,448 52,448 48,456" fill="#45475a"/>
+              <text x="20" y="240" fill="#6c7086" font-size="11" transform="rotate(-90 20 240)">data flow</text>
+            </g>
+
+            <!-- bug callouts on the right -->
+            <g font-family="Inter, sans-serif" font-size="12.5">
+              <!-- cause 2 locale -> zsh + PTY -->
+              <line x1="490" y1="100" x2="560" y2="60" stroke="#7f849c" stroke-dasharray="3 3" marker-end="url(#arrow)"/>
+              <rect x="560" y="38" width="320" height="46" rx="9" fill="rgba(249,226,175,0.10)" stroke="#f9e2af"/>
+              <text x="574" y="58" fill="#f9e2af" font-weight="700">② Cursor desync</text>
+              <text x="574" y="74" fill="#bac2de" font-size="11.5">C-locale → glyph width mis-measured</text>
+
+              <!-- cause 1 font -> xterm css -->
+              <line x1="490" y1="262" x2="560" y2="172" stroke="#7f849c" stroke-dasharray="3 3" marker-end="url(#arrow)"/>
+              <rect x="560" y="150" width="320" height="46" rx="9" fill="rgba(250,179,135,0.10)" stroke="#fab387"/>
+              <text x="574" y="170" fill="#fab387" font-weight="700">① Prompt misalignment</text>
+              <text x="574" y="186" fill="#bac2de" font-size="11.5">font stack sourced glyphs unevenly</text>
+
+              <!-- cause 4 raf -> xterm -->
+              <line x1="490" y1="270" x2="560" y2="262" stroke="#7f849c" stroke-dasharray="3 3" marker-end="url(#arrow)"/>
+              <rect x="560" y="240" width="320" height="46" rx="9" fill="rgba(203,166,247,0.10)" stroke="#cba6f7"/>
+              <text x="574" y="260" fill="#cba6f7" font-weight="700">④ Duplicate / overlapping rows</text>
+              <text x="574" y="276" fill="#bac2de" font-size="11.5">throttled rAF never repaints on return</text>
+
+              <!-- cause 3 gpu -->
+              <line x1="490" y1="383" x2="560" y2="360" stroke="#7f849c" stroke-dasharray="3 3" marker-end="url(#arrow)"/>
+              <rect x="560" y="338" width="320" height="46" rx="9" fill="rgba(243,139,168,0.10)" stroke="#f38ba8"/>
+              <text x="574" y="358" fill="#f38ba8" font-weight="700">③ “Alien” glyph corruption</text>
+              <text x="574" y="374" fill="#bac2de" font-size="11.5">occlusion reclaims GPU glyph textures</text>
+            </g>
+          </svg>
+          <div class="legend">
+            <span><span class="dot" style="background: var(--c-font)"></span>① Font</span>
+            <span><span class="dot" style="background: var(--c-locale)"></span>② Locale</span>
+            <span><span class="dot" style="background: var(--c-gpu)"></span>③ GPU</span>
+            <span><span class="dot" style="background: var(--c-raf)"></span>④ rAF</span>
+          </div>
+          <p class="figcap">
+            The same pixels, four different points of failure — from the shell
+            that emits the bytes down to the GPU process that paints them.
+          </p>
+        </div>
+      </section>
+
+      <!-- ===================== METHOD ===================== -->
+      <section>
+        <h2><span class="num">02</span>The method: theory before patch</h2>
+        <p class="lede">
+          The investigation opened with a deliberately humbling rule, because
+          the early days had been a guess-and-ship loop that fixed nothing.
+        </p>
+
+        <div class="callout">
+          <b>The hard gate.</b> Write no fix until two independent analyses —
+          Claude’s and an independent <code>codex exec</code> reading the same
+          evidence — agree on the mechanism. Every earlier “fix” (a Canvas2D
+          swap, <code>clearTextureAtlas()</code>, <code>backgroundThrottling</code>,
+          a premature focus-repaint) was demoted to an
+          <em>unverified guess</em> and had to be confirmed or refuted with
+          evidence, not asserted.
+        </div>
+
+        <div class="grid2">
+          <div class="card">
+            <h4 style="color: var(--sapphire); margin-top: 0">Triage by trigger, not by looks</h4>
+            <p>
+              The breakthrough wasn’t staring at screenshots — it was asking
+              <em>“what makes each artifact disappear?”</em> Two glitches shared
+              one trigger (a window switch) but had opposite survival
+              characteristics under software rendering. That split one apparent
+              bug into two causes.
+            </p>
+          </div>
+          <div class="card">
+            <h4 style="color: var(--teal); margin-top: 0">A diagnostic is not a fix</h4>
+            <p>
+              Disabling hardware acceleration made the corruption vanish — a
+              perfect <em>proof</em> of where the fault lived. Shipping it would
+              have thrown away GPU rendering app-wide and reversed a documented
+              decision. The proof and the cure are different objects.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== GHOSTING DEEP DIVE ===================== -->
+      <section>
+        <h2><span class="num">03</span>Splitting the ghost in two</h2>
+        <p class="lede">
+          “Ghosting” after switching windows mid-stream was the hardest report.
+          It turned out to be <strong>two causes wearing one costume</strong>.
+          The decisive experiment was running the exact same session under
+          software rendering.
+        </p>
+
+        <div class="figure">
+          <svg viewBox="0 0 880 360" role="img" aria-label="Bifurcation of the ghosting artifact by the software-render survival test">
+            <defs>
+              <marker id="arrow2" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto">
+                <path d="M0,0 L7,3 L0,6 Z" fill="#7f849c" />
+              </marker>
+            </defs>
+            <g font-family="Inter, sans-serif">
+              <!-- trigger -->
+              <rect x="40" y="150" width="190" height="64" rx="12" fill="rgba(137,180,250,0.10)" stroke="#89b4fa"/>
+              <text x="135" y="178" text-anchor="middle" fill="#cdd6f4" font-size="14" font-weight="700">“Ghosting”</text>
+              <text x="135" y="197" text-anchor="middle" fill="#a6adc8" font-size="11.5">switch window mid-stream</text>
+
+              <!-- test node -->
+              <line x1="230" y1="182" x2="300" y2="182" stroke="#7f849c" stroke-width="2" marker-end="url(#arrow2)"/>
+              <rect x="300" y="148" width="200" height="68" rx="12" fill="rgba(249,226,175,0.10)" stroke="#f9e2af"/>
+              <text x="400" y="174" text-anchor="middle" fill="#f9e2af" font-size="13" font-weight="700">EXPERIMENT</text>
+              <text x="400" y="193" text-anchor="middle" fill="#bac2de" font-size="11.5">disable HW acceleration</text>
+              <text x="400" y="208" text-anchor="middle" fill="#6c7086" font-size="10.5">(software rendering)</text>
+
+              <!-- branch up: vanishes -->
+              <path d="M500,168 C560,168 560,80 620,80" fill="none" stroke="#a6e3a1" stroke-width="2" marker-end="url(#arrow2)"/>
+              <rect x="620" y="46" width="220" height="74" rx="12" fill="rgba(243,139,168,0.10)" stroke="#f38ba8"/>
+              <text x="730" y="70" text-anchor="middle" fill="#f38ba8" font-size="13" font-weight="700">Alien glyphs VANISH</text>
+              <text x="730" y="89" text-anchor="middle" fill="#bac2de" font-size="11">⇒ lives in the GPU layer</text>
+              <text x="730" y="106" text-anchor="middle" fill="#6c7086" font-size="10.5">cause ③ · texture reclaim</text>
+
+              <!-- branch down: survives -->
+              <path d="M500,196 C560,196 560,290 620,290" fill="none" stroke="#f38ba8" stroke-width="2" marker-end="url(#arrow2)"/>
+              <rect x="620" y="256" width="220" height="74" rx="12" fill="rgba(203,166,247,0.10)" stroke="#cba6f7"/>
+              <text x="730" y="280" text-anchor="middle" fill="#cba6f7" font-size="13" font-weight="700">Duplicate rows SURVIVE</text>
+              <text x="730" y="299" text-anchor="middle" fill="#bac2de" font-size="11">⇒ not the GPU — it’s the paint loop</text>
+              <text x="730" y="316" text-anchor="middle" fill="#6c7086" font-size="10.5">cause ④ · rAF throttle</text>
+
+              <!-- labels on branches -->
+              <text x="560" y="120" fill="#a6e3a1" font-size="11" font-weight="600">no GPU →</text>
+              <text x="540" y="250" fill="#f38ba8" font-size="11" font-weight="600">no GPU, still broken →</text>
+            </g>
+          </svg>
+          <p class="figcap">
+            One experiment, a clean fork. What dies without a GPU was a GPU bug;
+            what lives without a GPU was never about the GPU at all.
+          </p>
+        </div>
+
+        <p>
+          A second tell corroborated cause ④: selecting text with the mouse made
+          the duplicate rows snap clean. A selection forces a repaint — so the
+          <em>buffer was always correct</em>; only the <em>paint</em> was stale.
+          That pointed straight at xterm’s render scheduler.
+        </p>
+      </section>
+
+      <!-- ===================== THE FOUR CAUSES ===================== -->
+      <section>
+        <h2><span class="num">04</span>The four causes, end to end</h2>
+        <p class="lede">
+          For each: the symptom, the layer it lived in, the path from
+          observation to theory, the evidence that nailed it, and the smallest
+          reversible fix that followed.
+        </p>
+
+        <!-- Cause 1 -->
+        <div class="cause" style="--accent: var(--c-font)">
+          <span class="tag">① Font · renderer CSS</span>
+          <h3>Prompt glyphs misaligned, text shoved right</h3>
+          <div class="layer">Layer: <b>renderer font stack</b> · <code>terminalFont.ts</code>, <code>index.css</code></div>
+          <div class="grid2">
+            <div class="block">
+              <h4>How the theory formed</h4>
+              <p>
+                Measured the actual glyph advances. The installed
+                <code>Hack Nerd Font</code> is a <em>non-Mono</em> variant — its
+                Powerline glyphs ink wider than one cell — and the font stack
+                leaned on whatever Nerd Font happened to be installed, so the
+                source varied machine to machine. Cross-referenced how kitty
+                (<code>symbol_map</code>), Ghostty and Windows Terminal solve it:
+                map a codepoint range to one dedicated face.
+              </p>
+            </div>
+            <div class="block">
+              <h4>Evidence</h4>
+              <p>
+                Glyphs only misaligned for the Powerline / Nerd codepoint range;
+                ordinary text was fine. The advance differed across machines with
+                different fonts installed — a sourcing problem, not a layout one.
+              </p>
+            </div>
+          </div>
+          <div class="fixline">
+            <strong>Fix →</strong> bundle a <code>Vimeflow Nerd Symbols</code>
+            face and scope it with CSS <code>unicode-range</code> (the web
+            equivalent of <code>symbol_map</code>); reorder the stack to put it
+            first. <span class="commit">76d1524</span>
+          </div>
+        </div>
+
+        <!-- Cause 2 -->
+        <div class="cause" style="--accent: var(--c-locale)">
+          <span class="tag">② Locale · Rust PTY spawn</span>
+          <h3>Cursor flung to the far right while editing</h3>
+          <div class="layer">Layer: <b>PTY spawn environment</b> · <code>commands.rs</code></div>
+          <div class="grid2">
+            <div class="block">
+              <h4>How the theory formed</h4>
+              <p>
+                Noticed it only happened in GUI launches (dock / Finder /
+                <code>electron:dev</code>), never in Terminal.app. Those GUI
+                launches inherit <em>no</em> <code>LANG</code> / <code>LC_*</code>,
+                so the shell runs in the <strong>C locale</strong> and
+                byte-counts multibyte glyphs. zsh then measures each Powerline /
+                Nerd glyph as ~3 cells, mis-computes the line width, and desyncs
+                the cursor.
+              </p>
+            </div>
+            <div class="block">
+              <h4>Evidence</h4>
+              <p>
+                <code>wcwidth</code> returns the wrong width for these codepoints
+                only in the C locale; Terminal.app and iTerm2 set a UTF-8 locale
+                and never exhibit it. The fault is environmental, upstream of any
+                rendering.
+              </p>
+            </div>
+          </div>
+          <div class="fixline">
+            <strong>Fix →</strong> inject <code>LC_CTYPE</code> (only the
+            character-width knob, leaving message/collation language alone) when
+            no UTF-8 locale is inherited — <code>en_US.UTF-8</code> on macOS,
+            <code>C.UTF-8</code> elsewhere. <span class="commit">717cc9a</span>
+          </div>
+        </div>
+
+        <!-- Cause 3 -->
+        <div class="cause" style="--accent: var(--c-gpu)">
+          <span class="tag">③ GPU · Chromium GPU process</span>
+          <h3>Garbled “alien” glyphs after a window switch</h3>
+          <div class="layer">Layer: <b>Chromium GPU process</b> · <code>electron/main.ts</code></div>
+          <div class="grid2">
+            <div class="block">
+              <h4>How the theory formed</h4>
+              <p>
+                Ran the hypothesis gauntlet. A Canvas2D swap didn’t help (same
+                GPU process). Clearing the texture atlas didn’t help. The
+                addon/version pairing was correct. Then disabling hardware
+                acceleration made the corruption <strong>vanish entirely</strong>
+                — isolating the fault to the GPU layer: Chromium reclaims an
+                occluded window’s GPU resources and scrambles xterm’s cached
+                glyph textures.
+              </p>
+            </div>
+            <div class="block">
+              <h4>Evidence</h4>
+              <p>
+                Corruption present under WebGL <em>and</em> Canvas (both paint
+                through the GPU process); gone under software rendering. The
+                trigger is occlusion — covering the window — which is exactly
+                when Chromium backgrounds it.
+              </p>
+            </div>
+          </div>
+          <div class="fixline">
+            <strong>Fix →</strong> keep WebGL + hardware acceleration, but stop
+            the reclaim with <code>disable-backgrounding-occluded-windows</code>
+            + <code>disable-renderer-backgrounding</code>.
+            <span class="commit">f99742c</span>
+          </div>
+        </div>
+
+        <!-- Cause 4 -->
+        <div class="cause" style="--accent: var(--c-raf)">
+          <span class="tag">④ rAF · xterm render scheduler</span>
+          <h3>Duplicate / overlapping rows + stray “?”</h3>
+          <div class="layer">Layer: <b>xterm render loop</b> · <code>Body.tsx</code></div>
+          <div class="grid2">
+            <div class="block">
+              <h4>How the theory formed</h4>
+              <p>
+                Read <code>@xterm/xterm@6.0.0</code> directly: rendering runs on
+                a debounced <code>requestAnimationFrame</code> loop
+                (<code>RenderDebouncer → rAF → refreshRows</code>), and xterm
+                listens only for <code>pagehide</code> — never
+                <code>visibilitychange</code>. Chromium throttles rAF for an
+                occluded window, so rows that streamed in while you were away
+                never flush, and nothing repaints them on return.
+              </p>
+            </div>
+            <div class="block">
+              <h4>Evidence</h4>
+              <p>
+                Renderer-agnostic and survives software rendering (so: not the
+                GPU). A text selection clears it instantly — proof the buffer is
+                right and only the paint is stale.
+              </p>
+            </div>
+          </div>
+          <div class="fixline">
+            <strong>Fix →</strong> force a full <code>refresh(0, rows-1)</code> on
+            <code>window</code> focus and on <code>document</code>
+            visibilitychange → visible — flush the stale rows on the exact event
+            xterm ignores. <span class="commit">f8a8577</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== HYPOTHESIS LEDGER ===================== -->
+      <section>
+        <h2><span class="num">05</span>The hypothesis ledger</h2>
+        <p class="lede">
+          Every candidate was marked <span class="ok">confirmed</span>,
+          <span class="no">refuted</span>, or <span class="diag">diagnostic-only</span>
+          with evidence — not opinion. Claude and an independent
+          <code>codex exec</code> reached the same conclusions before any fix
+          was written.
+        </p>
+        <div class="figure" style="padding: 6px 18px">
+          <table>
+            <thead>
+              <tr>
+                <th>Hypothesis</th>
+                <th>Verdict</th>
+                <th>Basis</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>GPU texture reclaim on occlusion</td>
+                <td class="verdict ok">Confirmed</td>
+                <td>Vanishes under software rendering; renderer-agnostic.</td>
+              </tr>
+              <tr>
+                <td>rAF render-throttle, no visibility repaint</td>
+                <td class="verdict ok">Confirmed</td>
+                <td>xterm source: rAF loop + no <code>visibilitychange</code>; survives software render; selection clears it.</td>
+              </tr>
+              <tr>
+                <td>C-locale glyph-width miscount</td>
+                <td class="verdict ok">Confirmed</td>
+                <td>GUI launch inherits no UTF-8 locale; <code>wcwidth</code> wrong in C locale.</td>
+              </tr>
+              <tr>
+                <td>Nerd Font glyph sourcing</td>
+                <td class="verdict ok">Confirmed</td>
+                <td>Misalign scoped to symbol codepoints; advance varies by machine.</td>
+              </tr>
+              <tr>
+                <td>Canvas2D-vs-WebGL renderer swap</td>
+                <td class="verdict no">Refuted</td>
+                <td>Canvas paints through the same GPU process — corrupts identically.</td>
+              </tr>
+              <tr>
+                <td>Texture-atlas corruption (<code>clearTextureAtlas</code>)</td>
+                <td class="verdict no">Refuted</td>
+                <td>Residual survives software rendering, where there is no atlas to clear.</td>
+              </tr>
+              <tr>
+                <td>Renderer addon / version mismatch</td>
+                <td class="verdict no">Refuted</td>
+                <td><code>webgl 0.19.0</code> is the stable pair for xterm 6.0.0.</td>
+              </tr>
+              <tr>
+                <td>PTY → xterm data-path double-write</td>
+                <td class="verdict no">Refuted</td>
+                <td>Drain is mount-time only; “selection fixes it” ⇒ buffer correct.</td>
+              </tr>
+              <tr>
+                <td>Disable hardware acceleration</td>
+                <td class="verdict diag">Diagnostic</td>
+                <td>Proves the GPU layer — but reverses the documented WebGL decision, so rejected as a fix.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ===================== LANDING THE FIX ===================== -->
+      <section>
+        <h2><span class="num">06</span>Intentionally landing the fix</h2>
+        <p class="lede">
+          With the mechanism agreed, the rule was: the
+          <strong>smallest reversible change that follows directly</strong> from
+          each cause — and not one that contradicts the architecture.
+        </p>
+        <div class="card">
+          <p style="margin-top: 0">
+            <b style="color: var(--lavender)">WebGL stays primary.</b> The
+            roadmap documents WebGL as the renderer of choice for
+            large-agent-output throughput. The diagnostic that proved cause ③
+            (disabling hardware acceleration) was therefore explicitly
+            <em>not</em> shipped; the two occlusion switches keep WebGL and
+            remove only the reclaim that corrupts the cache.
+          </p>
+          <p>
+            <b style="color: var(--lavender)">Four atomic commits, not one
+            mega-fix.</b> Each cause is independently testable and revertable —
+            a direct product of isolating each mechanism before touching code.
+          </p>
+          <p style="margin-bottom: 0">
+            <b style="color: var(--lavender)">One honest deferral.</b> The backend
+            decodes each PTY read with <code>String::from_utf8_lossy</code>,
+            which can split a multibyte glyph across read boundaries and emit a
+            stray <code>?</code> (<code>U+FFFD</code>). Codex flagged it as a
+            third contributor to the stray-<code>?</code> artifact. It is logged
+            as a follow-up — a carry-over decoder — rather than rushed.
+          </p>
+        </div>
+
+        <div class="callout">
+          <b>What only a human can close.</b> The fixes verify green across lint,
+          type-check, and the full unit + Rust suites. But the final
+          before/after under <em>real</em> OS-window occlusion can’t be staged by
+          automation — CDP can’t occlude one native window with another, and the
+          shipped switches suppress the very throttle that produces the artifact.
+          That last observation is, by its nature, a person at the machine
+          switching windows while output streams.
+        </div>
+      </section>
+
+      <footer>
+        <div style="margin-bottom: 14px">
+          <a href="../decisions/2026-05-27-terminal-rendering-fixes.md">Decision record</a>
+          <a href="../superpowers/retros/2026-05-27-terminal-rendering-investigation.md">Investigation retro</a>
+          <a href="https://github.com/winoooops/vimeflow/pull/288">PR #288</a>
+        </div>
+        Commits ·
+        <span class="mono" style="color: var(--green); background: none">76d1524</span> font ·
+        <span class="mono" style="color: var(--green); background: none">717cc9a</span> locale ·
+        <span class="mono" style="color: var(--green); background: none">f99742c</span> GPU ·
+        <span class="mono" style="color: var(--green); background: none">f8a8577</span> rAF
+        <div style="margin-top: 16px; color: var(--surface2)">
+          Vimeflow · root-cause investigation · the WebGL renderer is the
+          documented primary, preserved throughout.
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -49,7 +49,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 4        | 3    | 2026-05-07   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality       | 5        | 0    | 2026-05-09   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 54       | 25   | 2026-05-25   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 55       | 25   | 2026-05-28   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 73       | 22   | 2026-05-24   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
@@ -60,7 +60,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                   | security           | 3        | 1    | 2026-04-20   |
 | [Preflight Checks](patterns/preflight-checks.md)                     | error-handling     | 1        | 0    | 2026-04-20   |
 | [CSP Configuration](patterns/csp-configuration.md)                   | security           | 8        | 5    | 2026-05-16   |
-| [PTY Session Management](patterns/pty-session-management.md)         | backend            | 7        | 2    | 2026-05-20   |
+| [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 22       | 10   | 2026-05-25   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
 | [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 27       | 7    | 2026-05-16   |

--- a/docs/reviews/patterns/pty-session-management.md
+++ b/docs/reviews/patterns/pty-session-management.md
@@ -2,7 +2,7 @@
 id: pty-session-management
 category: backend
 created: 2026-04-09
-last_updated: 2026-05-20
+last_updated: 2026-05-28
 ref_count: 2
 ---
 
@@ -79,3 +79,12 @@ below preserve their original Tauri-era file paths for auditability.
 - **Finding:** Step 5c-2's `addPane` has two orphan-cleanup branches: (a) `!fresh` (session vanished during spawn), (b) `!appended` (reducer rejected at commit). Branch (b) correctly tombstones first (`dropAllForPty(result.sessionId)` then `await service.kill(...)`); branch (a) used the inverse order (kill then drop), so during the kill IPC round-trip any `pty-data` event the orphan emitted would be accepted into `usePtyBufferDrain`'s `bufferedRef` / `pendingPanesRef` and only discarded once `dropAllForPty` ran. The F6 invariant in `usePtyBufferDrain.ts` is explicit: "tombstone FIRST so any racing pty-data event arriving between here and Rust's actual kill is dropped on the floor instead of re-populating bufferedRef." Copy-paste drift between the two branches.
 - **Fix:** Swap the order in branch (a) so `dropAllForPty(result.sessionId)` runs BEFORE the `await service.kill(...)`. One-line move. Identical shape to branch (b); both branches now match the F6 contract. Code-review heuristic: any two cleanup branches in the same function that handle the same resource MUST share the same tombstone+kill ordering — any divergence is a copy-paste bug, not a deliberate design choice.
 - **Commit:** _(see git log for the cycle-2 fix commit on PR #204)_
+
+### 8. Injecting `LC_CTYPE` is ignored when a non-empty `LC_ALL` is inherited (POSIX precedence)
+
+- **Source:** github-codex-connector (P2) | PR #288 cycle 1 | 2026-05-28
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/terminal/commands.rs`
+- **Finding:** The UTF-8 locale fix injected `LC_CTYPE` into the spawned shell whenever no UTF-8 locale was inherited, but only set `LC_CTYPE` — it never touched `LC_ALL`. POSIX locale precedence is `LC_ALL` > `LC_CTYPE` > `LANG`: a non-empty `LC_ALL` overrides every category, so when the inherited env had `LC_ALL=C` (or `POSIX`), the spawned shell still ran in the non-UTF-8 locale and the original glyph-width / cursor-desync bug remained. The override decision (`utf8_ctype_override`) correctly treated a non-UTF-8 `LC_ALL` as needing an override, but the application step then set a category that `LC_ALL` shadows.
+- **Fix:** Introduced `locale_env_plan()` returning a struct with `ctype: Option<&'static str>` and `clear_lc_all: bool`. The `clear_lc_all` flag is set when an override fires AND the inherited `LC_ALL` is non-empty; the spawn path then calls `cmd.env_remove("LC_ALL")` — `portable-pty`'s `CommandBuilder` seeds the full parent env, so `env_remove` drops the inherited value — before `cmd.env("LC_CTYPE", ctype)`. Dropping `LC_ALL` rather than overwriting it lets the individual `LC_FOO` categories and `LANG` keep driving message/collation language. An empty `LC_ALL` is treated as unset (POSIX) and left alone. Code-review heuristic: when forcing a single locale category via an env var, account for the full POSIX precedence chain — a higher-precedence var (`LC_ALL`) set to a conflicting value silently nullifies the lower one. Pure-function the decision (`locale_env_plan`) so both the ctype choice and the clear-higher-var choice are unit-testable without spawning a process.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,7 +2,7 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-05-25
+last_updated: 2026-05-28
 ref_count: 25
 ---
 
@@ -544,3 +544,12 @@ filesystem scope restrictions).
 - **Finding:** Workspace-level tests rendered `DiffPanelContent` through `DockPanel` / `WorkspaceView` but did not mock `@pierre/diffs/react`. The child now calls `useWorkerPool()` unconditionally, so a Pierre release that throws outside `WorkerPoolContextProvider` would break these suites even though the tests are not trying to exercise Pierre itself.
 - **Fix:** Add explicit `@pierre/diffs/react` mocks in each higher-level test that renders through the diff panel, matching the direct `DiffPanelContent.test.tsx` pattern. Code-review heuristic: when a child component gains a mandatory provider hook, update both direct tests and every integration-style test that renders the child transitively.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 55. Event-listener guard branches need a test for both the fire and the suppress path
+
+- **Source:** github-claude | PR #288 cycle 1 | 2026-05-28
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/Body.test.tsx`
+- **Finding:** The focus-repaint fix registered two listeners that share one guarded handler — `window 'focus'` and `document 'visibilitychange'` — where the handler early-returns unless `document.visibilityState === 'visible'`. The new regression test only dispatched `window.focus` (which in jsdom runs with the default `visibilityState === 'visible'`, so the guard always passes). The `visibilitychange` path was never exercised, leaving the non-trivial branch untested: a future edit that inverts or drops the `visibilityState !== 'visible'` guard would still pass every test while silently repainting a hidden terminal (or suppressing a needed repaint on minimized-window restore — the primary scenario the fix targets).
+- **Fix:** Added a test that shadows the read-only `document.visibilityState` getter via `Object.defineProperty(document, 'visibilityState', { configurable: true, get })`, dispatches `visibilitychange` once with `'hidden'` (asserts `refresh` NOT called) and once with `'visible'` (asserts `refresh` called), and restores the prototype getter in a `finally` by `delete`-ing the instance override. Code-review heuristic: when one handler guards on a runtime condition, the test must drive BOTH branches — the condition-true (fires) and condition-false (suppressed) paths. Asserting only the happy path lets a guard regression pass silently. When two events share a guarded handler, test the event whose default test-environment state actually exercises the guard (here `visibilitychange`), not just the one where the guard is incidentally always-true (`focus`).
+- **Commit:** same commit as this entry

--- a/docs/superpowers/retros/2026-05-27-terminal-rendering-investigation.md
+++ b/docs/superpowers/retros/2026-05-27-terminal-rendering-investigation.md
@@ -1,0 +1,78 @@
+# Terminal Rendering Investigation Retrospective
+
+> **Date:** 2026-05-27
+> **Scope:** Three macOS terminal symptoms (prompt font misalignment, autocomplete cursor desync, "ghosting") traced to four independent root causes across three layers. Spans `fix/terminal-nerd-font-symbol-source` (1 commit) and `fix/terminal-pty-utf8-locale` (3 commits).
+> **Outcome:** Font, locale, GPU-occlusion, and stale-row causes fixed and committed; backend UTF-8 chunk-split identified and deferred. The technical choices are recorded in [`docs/decisions/2026-05-27-terminal-rendering-fixes.md`](../../decisions/2026-05-27-terminal-rendering-fixes.md).
+
+## TL;DR
+
+Three terminal symptoms that _looked_ like one bug ("the terminal renders wrong") were four independent root causes:
+
+| Symptom                                    | Root cause                                                                                      | Layer                  | Fix                                                                                                      |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| Prompt glyphs misaligned / pushed right    | Nerd Font glyph source varied by machine; installed face was non-Mono (wide advance)            | renderer font stack    | bundled `Vimeflow Nerd Symbols` + `unicode-range` (`76d1524`)                                            |
+| Cursor flung right during line editing     | GUI-launched PTY inherits no `LANG`/`LC_*` → shell byte-counts multibyte glyphs in the C locale | Rust PTY spawn         | inject `LC_CTYPE` when no UTF-8 locale inherited (`717cc9a`)                                             |
+| Garbled "alien" glyphs after window switch | Chromium reclaims occluded window's GPU resources → xterm glyph-texture cache corrupts          | Chromium GPU process   | `disable-backgrounding-occluded-windows` + `disable-renderer-backgrounding`, WebGL preserved (`f99742c`) |
+| Duplicate / overlapping rows + stray `?`   | xterm's rAF render loop throttled while occluded; no repaint on focus/visibility return         | xterm render scheduler | force `refresh(0, rows-1)` on focus + visibilitychange (`f8a8577`)                                       |
+
+The investigation's value was less in any single fix than in the **discipline that kept them separate** — and in recovering from the early days when that discipline was absent and wrong fixes shipped.
+
+## What worked
+
+### The `/goal` hard gate stopped the guess-and-ship spiral
+
+The turning point was reframing the work as a `/goal` with one non-negotiable: **write no fix until Claude and an independent Codex analysis agree on the root cause.** Before the gate, fixes were shipped on hunches (texture-atlas clear, a Canvas2D swap, `backgroundThrottling`, a focus-repaint added _before_ the cause was understood) and each failed because it addressed a symptom, not a confirmed mechanism. After the gate, every fix was preceded by a confirmed-or-refuted hypothesis with evidence. The four-commit shape is a direct product of that gate: one commit per isolated, evidence-backed cause.
+
+### Independent Codex RCA produced genuine consensus, not an echo
+
+Running `codex exec -s read-only` on the symptom corpus _independently_ (no priming with Claude's hypotheses) converged on the same GPU-reclaim + rAF-throttle split and additionally surfaced the backend `from_utf8_lossy` chunk-split as a third contributor to the stray `?`. Two analyses reaching the same mechanism from different starting points is much stronger evidence than one analysis stated twice — and Codex caught a cause Claude had under-weighted.
+
+### A diagnostic that is deliberately not the fix
+
+`app.disableHardwareAcceleration()` made the alien-glyph corruption vanish, cleanly proving the GPU process was the cause. The discipline was recognizing this as a _diagnostic_, not a _fix_ — shipping it would have reversed the documented WebGL decision and regressed throughput app-wide. The real fix (two targeted occlusion switches) keeps WebGL and removes only the reclaim. Separating "what proves the cause" from "what we ship" was the cleanest move of the investigation.
+
+### Reading the renderer's source beat guessing at its behavior
+
+Cause 4 was confirmed by reading `@xterm/xterm@6.0.0`: the render path is `RenderDebouncer → requestAnimationFrame → refreshRows`, and xterm listens only for `pagehide`, never `visibilitychange`. That single source read explained every observation (renderer-agnostic, survives software rendering, "selection fixes it") and pointed straight at the fix surface (force a repaint on the events xterm ignores).
+
+### Symptom triage by trigger, not by appearance
+
+The breakthrough in untangling "ghosting" was noticing two artifacts with one trigger but different survival characteristics: the alien glyphs vanished under software rendering (GPU cause) while the duplicate rows survived it (rAF cause). Bucketing by "what makes it disappear" rather than "what it looks like" split one apparent bug into two causes.
+
+## Friction points
+
+### Shipping fixes before the root cause was understood
+
+The first several days were a guess-and-ship loop — atlas clear, Canvas2D swap, `backgroundThrottling`, premature focus-repaint. The user's blunt feedback ("this is not a fix, I still see double line and duplicate rows everywhere") was the correct signal that the loop was producing motion, not progress. The lesson is the one `systematic-debugging` already encodes: a fix written before the mechanism is confirmed is a guess wearing a fix's clothes.
+
+### Reversing a documented decision without checking the docs
+
+The Canvas2D swap was made unilaterally. The user pushed back: _"I think WebGL will have better performance and is decided as the primary rendering engine in the previous decision @docs."_ They were right — `tauri-migration-roadmap.md:125` documents WebGL. The miss: not searching the docs for a prior decision before reversing the renderer. **Before changing an architectural default, grep the decisions/roadmap for whether it was already chosen on purpose.** This is the single most important takeaway for future contributors.
+
+### CDP could not reproduce real OS window-occlusion
+
+The GPU and rAF causes are triggered by the _OS_ occluding/backgrounding the window. CDP's `Emulation.setVisibilityState` self-recovers and dispatches a clean repaint; `disable-renderer-backgrounding` (already shipped for Cause 3) prevents the minimize-throttle; and OS-level occlusion isn't CDP-settable. So while the render loop and the fix's listeners were verified programmatically (synthetic `focus`/`visibilitychange` → `refresh` fires; renderer confirmed WebGL live), the final before/after under the _real_ window-switch needed a human at the machine. Some verification edges genuinely can't be automated, and pretending otherwise wastes cycles.
+
+### Three branches for one investigation
+
+The font fix landed on its own branch (`fix/terminal-nerd-font-symbol-source`) before the ghosting investigation began on `fix/terminal-pty-utf8-locale`. Correct in isolation (different layers, different review surfaces), but it means the shared docs (this retro + the decision) live with only one of the two PRs. Future multi-cause investigations should decide the branch/PR topology up front so the cross-cutting docs have an obvious home.
+
+## What we'd do differently
+
+1. **Gate fixes on confirmed mechanism from the start.** The `/goal` discipline should have been the _opening_ move, not the recovery move. `systematic-debugging` exists for exactly this; invoke it on the first "the terminal renders wrong," not after the third failed guess.
+2. **Grep `docs/decisions/` + roadmap before reversing any default.** A 10-second search would have prevented the Canvas2D detour entirely.
+3. **Triage by trigger and survival characteristics, not appearance.** "What makes it disappear?" split one bug into two causes faster than any amount of staring at screenshots.
+4. **Decide branch/PR topology before splitting work across branches**, so cross-cutting docs (retro, decision record) have a single, obvious home.
+5. **Name the un-automatable verification edge early.** Once it was clear CDP couldn't reproduce OS occlusion, the right move was to say so and hand that one check to the user — not to keep building CDP harnesses against a wall.
+
+## Deferrals tracked
+
+- **Backend UTF-8 chunk-boundary decode** (`crates/backend/src/terminal/commands.rs:772`). `String::from_utf8_lossy(&buf[..n])` can split a multibyte glyph across PTY reads and emit `U+FFFD` (`?`). Codex flagged it as a third contributor to the stray-`?` artifact. Fix is a carry-over decoder that holds the trailing incomplete bytes for the next read — unit-testable, no renderer interaction. Logged in the decision record's open-follow-up section.
+
+## Pointers
+
+- Decision record: [`docs/decisions/2026-05-27-terminal-rendering-fixes.md`](../../decisions/2026-05-27-terminal-rendering-fixes.md)
+- Fix commits: `76d1524` (font), `717cc9a` (locale), `f99742c` (GPU occlusion), `f8a8577` (focus repaint)
+- WebGL decision: `docs/roadmap/tauri-migration-roadmap.md:125`
+- Upstream context: Claude Code issue [#20627](https://github.com/anthropics/claude-code/issues/20627)
+- Skill that should have opened the work: `superpowers:systematic-debugging`

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -10,6 +10,16 @@ import { installCommandPaletteShortcutOverride } from './command-palette-shortcu
 import { BACKEND_EVENT, BACKEND_INVOKE } from './ipc-channels'
 import { spawnSidecar, type Sidecar } from './sidecar'
 
+// Keep the GPU serving this window while it is occluded (covered by another
+// window) or unfocused. Chromium otherwise backgrounds the occluded window and
+// reclaims its GPU resources, which corrupts xterm's cached glyph textures so
+// they render as garbage on return. (Confirmed: disabling hardware
+// acceleration entirely made the corruption vanish — it is the GPU layer.)
+// These switches keep hardware acceleration and the WebGL renderer while
+// stopping the occlusion-driven reclaim.
+app.commandLine.appendSwitch('disable-backgrounding-occluded-windows')
+app.commandLine.appendSwitch('disable-renderer-backgrounding')
+
 // __dirname is not defined in ESM modules. Derive it from import.meta.url.
 // vite-plugin-electron bundles main.ts as ESM (main.js) under
 // package.json:type=module, so we need the ESM-compatible idiom.

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -252,6 +252,51 @@ describe('Body', () => {
     expect(mockTerminal.refresh).toHaveBeenCalledWith(0, 23)
   })
 
+  test('repaints on visibilitychange only when the document is visible', async () => {
+    render(
+      <Body
+        sessionId="test-session"
+        cwd="/home/user"
+        service={defaultMockService}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mockTerminal.open).toHaveBeenCalled()
+    })
+
+    // jsdom exposes a read-only visibilityState getter on Document.prototype;
+    // shadow it on the instance so we can exercise both branches of the guard.
+    const setVisibility = (state: DocumentVisibilityState): void => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => state,
+      })
+    }
+
+    try {
+      mockTerminal.refresh.mockClear()
+
+      // Hidden: the guard must suppress repainting an invisible terminal.
+      setVisibility('hidden')
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+      expect(mockTerminal.refresh).not.toHaveBeenCalled()
+
+      // Visible: the minimized-window restore path must flush stale rows.
+      setVisibility('visible')
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+      expect(mockTerminal.refresh).toHaveBeenCalledWith(0, 23)
+    } finally {
+      // Drop the instance override so jsdom's prototype getter is restored.
+      delete (document as { visibilityState?: DocumentVisibilityState })
+        .visibilityState
+    }
+  })
+
   test('refits terminal after bundled terminal fonts load', async () => {
     let resolveFonts: () => void = (): void => undefined
 

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -228,6 +228,30 @@ describe('Body', () => {
     })
   })
 
+  test('repaints the terminal when the window regains focus', async () => {
+    render(
+      <Body
+        sessionId="test-session"
+        cwd="/home/user"
+        service={defaultMockService}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mockTerminal.open).toHaveBeenCalled()
+    })
+
+    mockTerminal.refresh.mockClear()
+
+    // Root cause B: the render loop stalls while the window is covered;
+    // regaining focus must force a full repaint to flush stale rows.
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    expect(mockTerminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
   test('refits terminal after bundled terminal fonts load', async () => {
     let resolveFonts: () => void = (): void => undefined
 

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -847,6 +847,24 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     node.addEventListener('focusin', handleFocusIn)
     node.addEventListener('focusout', handleFocusOut)
 
+    // Root cause B (Claude + Codex consensus): xterm renders on a debounced
+    // animation-frame loop and never forces a repaint when the OS window
+    // regains focus or visibility. The browser throttles that loop while the
+    // window is covered or unfocused, so rows that streamed in while we were
+    // away stay stale until something forces a repaint (the buffer is correct
+    // — a text selection fixes only the pixels). Repaint on focus/visibility
+    // recovery to flush them.
+    const repaintOnWindowVisible = (): void => {
+      if (document.visibilityState !== 'visible') {
+        return
+      }
+
+      newTerminal.refresh(0, Math.max(newTerminal.rows - 1, 0))
+    }
+
+    window.addEventListener('focus', repaintOnWindowVisible)
+    document.addEventListener('visibilitychange', repaintOnWindowVisible)
+
     // P2 Fix: Add ResizeObserver to detect container size changes
     // When the container resizes (e.g., window resize, panel collapse),
     // fit the terminal which will trigger the onResize event above.
@@ -876,6 +894,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       resizeDisposable.dispose()
       node.removeEventListener('focusin', handleFocusIn)
       node.removeEventListener('focusout', handleFocusOut)
+      window.removeEventListener('focus', repaintOnWindowVisible)
+      document.removeEventListener('visibilitychange', repaintOnWindowVisible)
       // Dispose the renderer addon (and any WebGL context-loss subscription)
       // before the terminal itself — order matters: the addon holds
       // references to the terminal's renderer state and must clean up while


### PR DESCRIPTION
## Summary

Three independent terminal-rendering root causes surfaced during macOS dogfooding, plus the investigation docs that record them:

- **fix(terminal): set a UTF-8 locale when spawning the PTY** — GUI launches (dock/Finder, `electron:dev`) inherit no `LANG`/`LC_*`, so the shell runs in the C locale and byte-counts multibyte glyphs, miscomputing line width and desyncing the cursor during line editing. Inject `LC_CTYPE` (`en_US.UTF-8` on macOS, `C.UTF-8` elsewhere) only when no UTF-8 locale is inherited.
- **fix(terminal): keep GPU textures intact when the window is occluded** — Chromium reclaims an occluded window's GPU resources, scrambling xterm's cached glyph textures into garbage glyphs. Set `disable-backgrounding-occluded-windows` + `disable-renderer-backgrounding` to stop the reclaim while preserving hardware acceleration and the documented WebGL renderer.
- **fix(terminal): repaint the terminal when the window regains focus** — xterm's debounced rAF render loop is throttled while the window is occluded and never repaints on focus/visibility return, leaving stale duplicate/overlapping rows. Force `refresh(0, rows-1)` on `window` focus and `document` visibilitychange→visible.
- **docs(terminal): record rendering investigation retro + decision** — decision record (four root causes, options per cause, why WebGL was preserved over a Canvas2D swap / disabling HW accel) and the investigation retrospective.

A related font-sourcing fix (bundled `Vimeflow Nerd Symbols` + `unicode-range`) lives on `fix/terminal-nerd-font-symbol-source` and is referenced by these docs. The backend `from_utf8_lossy` chunk-boundary decode (stray `?`/`U+FFFD`) is logged as a deferred follow-up in the decision record.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run type-check` — clean
- [x] `npm test` — 2711 passed, 3 skipped (incl. the new `Body.test.tsx` focus-repaint test + the `commands.rs` LC_CTYPE unit tests)
- [x] `cargo test` — 573 passed; the 11 failures are macOS-local only (`/bin/true` lives at `/usr/bin/true`, `/proc` absent) and pass on the `ubuntu-latest` CI runner
- [x] Manual: switch away from the window while an agent streams output, switch back — confirm no garbled glyphs (GPU fix) and no stale duplicate rows (focus-repaint fix)
- [ ] Manual: type into the p10k prompt — confirm the cursor tracks correctly (locale fix)