### PR TITLE
fix(split-view): stop mid-drag snap-back on parent re-render

### DIFF
--- a/src/features/terminal/components/SplitView/SplitDividers.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.test.tsx
@@ -1,3 +1,4 @@
+// cspell:ignore subcomponents
 import { render, screen } from '@testing-library/react'
 import { test, expect, describe, vi, beforeEach, afterEach } from 'vitest'
 import { useRef } from 'react'
@@ -67,5 +68,66 @@ describe('SplitDividers', () => {
       'aria-orientation',
       'vertical'
     )
+  })
+
+  test('parent re-render does not overwrite an in-progress drag preview', () => {
+    // Regression: SplitDividers' per-layout subcomponents previously curried
+    // the shared `onRatioChange(axis, ratio)` prop through inline arrows
+    // (`(r) => onRatioChange('col', r)`). The inline ref changed on every
+    // render, which is in the dep array of useSplitDivider's commit-size
+    // effect; that effect mirrors `size / effectiveDimension` back into the
+    // CSS var. In `commit-on-end` mode `size` is the LAST committed value
+    // throughout the drag, so any parent re-render mid-drag (a session prop
+    // tick from terminal output, an agent status heartbeat) re-fired the
+    // effect and stomped the live `onDragPreview` write — visibly the
+    // divider snapped back toward the pre-drag position then caught up on
+    // the next mousemove RAF. Memoizing the curry with useCallback keeps
+    // the dep stable so the effect stays quiet mid-drag.
+    const onRatioChange = vi.fn()
+
+    const ReRenderHarness = ({
+      token,
+    }: {
+      token: number
+    }): React.ReactElement => {
+      const ref = useRef<HTMLDivElement>(document.createElement('div'))
+
+      return (
+        <div
+          ref={ref}
+          data-testid="container"
+          data-token={token}
+          style={{ width: CONTAINER_WIDTH, height: CONTAINER_HEIGHT }}
+        >
+          <SplitDividers
+            layout="vsplit"
+            containerRef={ref}
+            ratios={DEFAULT_RATIOS.vsplit}
+            onRatioChange={onRatioChange}
+          />
+        </div>
+      )
+    }
+    const { rerender } = render(<ReRenderHarness token={1} />)
+    const container = screen.getByTestId('container')
+
+    // Mount writes the default ratio (0.5fr / 0.5fr) via the commit-size effect.
+    expect(container.style.getPropertyValue('--split-col')).toBe('0.5fr')
+    expect(container.style.getPropertyValue('--split-col-end')).toBe('0.5fr')
+
+    // Simulate an in-progress drag: `onDragPreview` → `writeRatio(0.8)` has
+    // written the live ratio straight into the CSS var, bypassing React state.
+    container.style.setProperty('--split-col', '0.8fr')
+    container.style.setProperty('--split-col-end', '0.2fr')
+
+    // Parent re-renders (mirrors SplitView re-rendering from a session prop
+    // change while the user is still dragging). `onRatioChange` identity is
+    // stable across the rerender.
+    rerender(<ReRenderHarness token={2} />)
+
+    // Without the useCallback fix the inline arrow in VSplitDividers would
+    // have churned the effect dep and snapped these back to 0.5fr / 0.5fr.
+    expect(container.style.getPropertyValue('--split-col')).toBe('0.8fr')
+    expect(container.style.getPropertyValue('--split-col-end')).toBe('0.2fr')
   })
 })

--- a/src/features/terminal/components/SplitView/SplitDividers.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.tsx
@@ -1,5 +1,5 @@
-// cspell:ignore vsplit hsplit vdiv hdiv
-import { Fragment, type ReactElement, type RefObject } from 'react'
+// cspell:ignore vsplit hsplit vdiv hdiv subcomponent
+import { Fragment, useCallback, type ReactElement, type RefObject } from 'react'
 import { ResizeHandle } from '../../../../components/ResizeHandle'
 import type { LayoutId } from '../../../sessions/types'
 import { useSplitDivider } from './useSplitDivider'
@@ -14,17 +14,32 @@ export interface SplitDividersProps {
 
 const HANDLE_TEST_ID = 'split-resize-handle'
 
+// Each per-layout subcomponent curries the shared `onRatioChange(axis, ratio)`
+// prop into a single-arg `(ratio) => …` to satisfy `useSplitDivider`'s
+// `onRatioChange: (ratio: number) => void` contract. The currying MUST be
+// `useCallback`-stable, not an inline arrow: `useSplitDivider` keeps
+// `onRatioChange` in the dep array of an effect that mirrors the committed
+// `size` back into the CSS var. With an inline arrow, every parent re-render
+// (e.g. a session prop ticking from terminal output) recreates the ref and
+// re-fires that effect mid-drag, overwriting the live `onDragPreview` write
+// with the stale committed ratio — the divider visibly snaps back toward the
+// pre-drag position then catches back up on the next mousemove RAF.
 const VSplitDividers = ({
   containerRef,
   ratios,
   onRatioChange,
 }: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const onColChange = useCallback(
+    (r: number): void => onRatioChange('col', r),
+    [onRatioChange]
+  )
+
   const col = useSplitDivider({
     containerRef,
     axis: 'horizontal',
     cssVar: '--split-col',
     initialRatio: ratios.col,
-    onRatioChange: (r) => onRatioChange('col', r),
+    onRatioChange: onColChange,
   })
 
   return (
@@ -49,12 +64,17 @@ const HSplitDividers = ({
   ratios,
   onRatioChange,
 }: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const onRowChange = useCallback(
+    (r: number): void => onRatioChange('row', r),
+    [onRatioChange]
+  )
+
   const row = useSplitDivider({
     containerRef,
     axis: 'vertical',
     cssVar: '--split-row',
     initialRatio: ratios.row,
-    onRatioChange: (r) => onRatioChange('row', r),
+    onRatioChange: onRowChange,
   })
 
   return (
@@ -79,12 +99,22 @@ const ThreeRightDividers = ({
   ratios,
   onRatioChange,
 }: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const onColChange = useCallback(
+    (r: number): void => onRatioChange('col', r),
+    [onRatioChange]
+  )
+
+  const onRowChange = useCallback(
+    (r: number): void => onRatioChange('row', r),
+    [onRatioChange]
+  )
+
   const col = useSplitDivider({
     containerRef,
     axis: 'horizontal',
     cssVar: '--split-col',
     initialRatio: ratios.col,
-    onRatioChange: (r) => onRatioChange('col', r),
+    onRatioChange: onColChange,
   })
 
   const row = useSplitDivider({
@@ -92,7 +122,7 @@ const ThreeRightDividers = ({
     axis: 'vertical',
     cssVar: '--split-row',
     initialRatio: ratios.row,
-    onRatioChange: (r) => onRatioChange('row', r),
+    onRatioChange: onRowChange,
   })
 
   return (
@@ -132,12 +162,22 @@ const QuadDividers = ({
   ratios,
   onRatioChange,
 }: Omit<SplitDividersProps, 'layout'>): ReactElement => {
+  const onColChange = useCallback(
+    (r: number): void => onRatioChange('col', r),
+    [onRatioChange]
+  )
+
+  const onRowChange = useCallback(
+    (r: number): void => onRatioChange('row', r),
+    [onRatioChange]
+  )
+
   const col = useSplitDivider({
     containerRef,
     axis: 'horizontal',
     cssVar: '--split-col',
     initialRatio: ratios.col,
-    onRatioChange: (r) => onRatioChange('col', r),
+    onRatioChange: onColChange,
   })
 
   const row = useSplitDivider({
@@ -145,7 +185,7 @@ const QuadDividers = ({
     axis: 'vertical',
     cssVar: '--split-row',
     initialRatio: ratios.row,
-    onRatioChange: (r) => onRatioChange('row', r),
+    onRatioChange: onRowChange,
   })
 
   // One logical column divider rendered as two elements (segmented by the


### PR DESCRIPTION
## Summary

- `useCallback` the per-axis `onRatioChange` curry in each `SplitDividers` per-layout subcomponent so the prop fed to `useSplitDivider` is referentially stable across parent re-renders.
- Without this, any SplitView re-render mid-drag (a session prop ticking from terminal output, an agent status heartbeat, focused-pane state) churned `useSplitDivider`'s commit-size effect dep array and re-ran the effect. In `commit-on-end` mode (which split-pane uses) the React `size` state is the LAST committed value throughout the drag, so the re-fired effect's `writeRatio(size / effectiveDimension)` overwrote the live `onDragPreview` write — the divider visibly snapped back toward the pre-drag position then caught up on the next mousemove RAF. Faster drags made the rebound more visible because the gap between the stale committed ratio and the live cursor grew.
- Picks up the [LOW] inline-lambda finding from the Claude review on #283. That review identified the unnecessary effect re-runs but assessed the impact as benign — the `setRatios` equality guard does suppress the React-state churn — missing that in `commit-on-end` mode the `writeRatio` call itself stomps the live CSS var.

## Test plan

- [x] `npx vitest run` — 2803 passed / 3 skipped / 0 failed
- [x] `tsc -b` clean, `eslint` + `prettier --check` clean on changed files
- [x] Regression test in `SplitDividers.test.tsx` proven to catch the bug: temporarily reverted just `VSplitDividers` to the inline arrow and the new test failed with `expected '0.5fr' to be '0.8fr'`, then re-applied the fix and it passed
- [ ] Manual: grab the divider in `vsplit` / `hsplit` / `threeRight` / `quad` with an active Claude / Codex agent in one of the panes (so the session prop is ticking) and drag fast — divider should track the cursor smoothly without ever jumping back