### PR TITLE
fix(diff): apply thin-scrollbar to the Pierre diff scroll body

### DIFF
--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -300,6 +300,12 @@ describe('DiffPanelContent', () => {
     expect(layout).toHaveClass('min-h-0')
     expect(layout).toHaveClass('min-w-0')
 
+    // The Pierre diff scroll body carries the project thin-scrollbar treatment
+    // (Pierre spreads our style/className onto its scroll container and ships
+    // no scrollbar CSS of its own, so without this the diff pane shows the
+    // default chunky OS scrollbar instead of the Obsidian-Lens thin one).
+    expect(screen.getByTestId('diff-scroll-body')).toHaveClass('thin-scrollbar')
+
     // Initial pane width is the unmeasured sentinel, so MultiFileDiff mounts
     // immediately before a ResizeObserver trigger without forcing narrow mode.
     expect(screen.getByTestId('multi-file-diff')).toBeInTheDocument()

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -827,7 +827,7 @@ export const DiffPanelContent = ({
         </div>
         <div
           data-testid="diff-scroll-body"
-          className="min-h-0 flex-1 overflow-auto"
+          className="thin-scrollbar min-h-0 flex-1 overflow-auto"
         >
           {diffError ? (
             <ErrorCard message={diffError.message} />


### PR DESCRIPTION
The diff pane's vertical scrollbar rendered as the default chunky OS scrollbar instead of the app's thin Obsidian-Lens treatment (file list, terminal, and editor all use it).

**Cause:** the Pierre `<MultiFileDiff>` scroll container is our `diff-scroll-body` wrapper — Pierre spreads our `style`/`className` onto its root and ships no scrollbar CSS of its own — but that wrapper used a bare `overflow-auto` with no `thin-scrollbar`.

**Fix:** add the existing `thin-scrollbar` utility class to `diff-scroll-body` (one class) + a regression assertion.

## Test plan
- `npm run type-check`, `npm run lint` ✓
- `DiffPanelContent.test.tsx` → 44 passed (1 new assertion) ✓
- Manual: confirm the diff pane's vertical scrollbar is the thin dark style (deferred — no GUI in this env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)