### PR TITLE
test(adapter): step F phase 0 — base::start_for characterization tests (F.0)

### DIFF
--- a/crates/backend/src/agent/adapter/base/mod.rs
+++ b/crates/backend/src/agent/adapter/base/mod.rs
@@ -76,3 +76,202 @@ pub(crate) fn start_for(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::adapter::bindings::AgentBindings;
+    use crate::agent::adapter::traits::StatusSourceLocator;
+    use crate::agent::adapter::types::LocatedStatusSource;
+    use crate::agent::adapter::AttachContext;
+    use crate::agent::types::AgentType;
+    use crate::runtime::FakeEventSink;
+    use crate::terminal::PtyState;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::SystemTime;
+    use tempfile::TempDir;
+
+    fn make_attach_ctx(cwd: &std::path::Path) -> AttachContext {
+        AttachContext {
+            session_id: "test-sess".to_string(),
+            initial_cwd: cwd.to_path_buf(),
+            shell_pid: 1,
+            agent_pid: 2,
+            pty_start: SystemTime::UNIX_EPOCH,
+            agent_type: AgentType::ClaudeCode,
+            provider_home: Some(PathBuf::from("/home/u/.claude")),
+            proc_root: None,
+        }
+    }
+
+    fn write_claude_status(cwd: &std::path::Path, sid: &str) {
+        let dir = cwd.join(".vimeflow").join("sessions").join(sid);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("status.json"), r#"{"session_id":"sid","model":{}}"#).unwrap();
+    }
+
+    fn seeded_fixture(sid: &str) -> (TranscriptState, AgentWatcherState) {
+        let sink = Arc::new(FakeEventSink::new());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let transcript_path = tmp.path().join("t.jsonl");
+        std::fs::write(&transcript_path, "").expect("write");
+        let transcript_state = TranscriptState::new();
+        let adapter: Arc<dyn crate::agent::adapter::traits::TranscriptStreamer> =
+            Arc::new(crate::agent::adapter::claude_code::ClaudeCodeAdapter);
+        transcript_state
+            .start_or_replace(
+                adapter,
+                sink,
+                sid.to_string(),
+                transcript_path,
+                None,
+            )
+            .expect("seed transcript state");
+        let watcher_state = AgentWatcherState::new();
+        let seed = WatcherHandle::new_for_test(transcript_state.clone(), sid.to_string());
+        watcher_state.insert(sid.to_string(), seed);
+        (transcript_state, watcher_state)
+    }
+
+    #[test]
+    fn t_lifecycle_1_start_for_happy_path_registers_session() {
+        let tmp = TempDir::new().unwrap();
+        let sid = "test-sess".to_string();
+        write_claude_status(tmp.path(), &sid);
+
+        let ctx = make_attach_ctx(tmp.path());
+        let bindings = AgentBindings::for_attach(&ctx).unwrap();
+        let events: Arc<dyn EventSink> = Arc::new(FakeEventSink::new());
+        let pty_state = PtyState::new();
+        let transcript_state = TranscriptState::new();
+        let watcher_state = AgentWatcherState::new();
+
+        start_for(
+            bindings,
+            events,
+            pty_state,
+            transcript_state,
+            sid.clone(),
+            tmp.path().to_path_buf(),
+            watcher_state.clone(),
+        )
+        .expect("start_for happy path");
+        assert!(watcher_state.contains(&sid), "session registered");
+
+        watcher_state.remove(&sid);
+    }
+
+    #[cfg(test)]
+    struct ErrLocator;
+
+    impl StatusSourceLocator for ErrLocator {
+        fn locate(
+            &self,
+            _cwd: &std::path::Path,
+            _session_id: &str,
+        ) -> Result<LocatedStatusSource, String> {
+            Err("locate failed".to_string())
+        }
+    }
+
+    #[test]
+    fn t_lifecycle_2a_start_for_locate_err_preserves_existing_watcher() {
+        let sid = "test-sess".to_string();
+        let (transcript_state, watcher_state) = seeded_fixture(&sid);
+
+        let adapter: Arc<crate::agent::adapter::claude_code::ClaudeCodeAdapter> =
+            Arc::new(crate::agent::adapter::claude_code::ClaudeCodeAdapter);
+        let bindings = AgentBindings {
+            agent_type: AgentType::ClaudeCode,
+            locator: Arc::new(ErrLocator),
+            decoder: adapter.clone(),
+            transcript_paths: adapter.clone(),
+            validator: adapter.clone(),
+            streamer: adapter,
+        };
+        let events: Arc<dyn EventSink> = Arc::new(FakeEventSink::new());
+        let pty_state = PtyState::new();
+
+        let result = start_for(
+            bindings,
+            events,
+            pty_state,
+            transcript_state.clone(),
+            sid.clone(),
+            PathBuf::from("/tmp"),
+            watcher_state.clone(),
+        );
+
+        assert!(result.is_err(), "locate failure should return Err");
+        assert!(
+            watcher_state.contains(&sid),
+            "existing watcher should be preserved"
+        );
+        assert!(
+            transcript_state.contains(&sid),
+            "transcript state entry should be preserved"
+        );
+
+        watcher_state.remove(&sid);
+    }
+
+    #[cfg(test)]
+    struct OutsideTrustLocator;
+
+    impl StatusSourceLocator for OutsideTrustLocator {
+        fn locate(
+            &self,
+            cwd: &std::path::Path,
+            _session_id: &str,
+        ) -> Result<LocatedStatusSource, String> {
+            let parent = cwd.parent().unwrap_or(cwd);
+            Ok(LocatedStatusSource {
+                status_path: parent.join("sibling.json"),
+                trust_root: cwd.to_path_buf(),
+                static_transcript_hint: None,
+            })
+        }
+    }
+
+    #[test]
+    fn t_lifecycle_2b_start_for_trust_err_preserves_existing_watcher() {
+        let sid = "test-sess".to_string();
+        let (transcript_state, watcher_state) = seeded_fixture(&sid);
+
+        let adapter: Arc<crate::agent::adapter::claude_code::ClaudeCodeAdapter> =
+            Arc::new(crate::agent::adapter::claude_code::ClaudeCodeAdapter);
+        let bindings = AgentBindings {
+            agent_type: AgentType::ClaudeCode,
+            locator: Arc::new(OutsideTrustLocator),
+            decoder: adapter.clone(),
+            transcript_paths: adapter.clone(),
+            validator: adapter.clone(),
+            streamer: adapter,
+        };
+        let events: Arc<dyn EventSink> = Arc::new(FakeEventSink::new());
+        let pty_state = PtyState::new();
+
+        let result = start_for(
+            bindings,
+            events,
+            pty_state,
+            transcript_state.clone(),
+            sid.clone(),
+            PathBuf::from("/tmp"),
+            watcher_state.clone(),
+        );
+
+        assert!(result.is_err(), "trust failure should return Err");
+        assert!(
+            watcher_state.contains(&sid),
+            "existing watcher should be preserved"
+        );
+        assert!(
+            transcript_state.contains(&sid),
+            "transcript state entry should be preserved"
+        );
+
+        watcher_state.remove(&sid);
+    }
+}

--- a/crates/backend/src/agent/adapter/base/mod.rs
+++ b/crates/backend/src/agent/adapter/base/mod.rs
@@ -162,7 +162,6 @@ mod tests {
         watcher_state.remove(&sid);
     }
 
-    #[cfg(test)]
     struct ErrLocator;
 
     impl StatusSourceLocator for ErrLocator {
@@ -216,7 +215,6 @@ mod tests {
         watcher_state.remove(&sid);
     }
 
-    #[cfg(test)]
     struct OutsideTrustLocator;
 
     impl StatusSourceLocator for OutsideTrustLocator {

--- a/crates/backend/src/agent/adapter/base/watcher_runtime.rs
+++ b/crates/backend/src/agent/adapter/base/watcher_runtime.rs
@@ -666,6 +666,22 @@ pub(super) fn start_watching(
 }
 
 #[cfg(test)]
+impl WatcherHandle {
+    pub(crate) fn new_for_test(
+        transcript_state: TranscriptState,
+        session_id: String,
+    ) -> Self {
+        WatcherHandle {
+            _watcher: None,
+            poll_stop: Arc::new((Mutex::new(false), Condvar::new())),
+            join_handle: None,
+            transcript_state,
+            session_id,
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/crates/backend/src/agent/adapter/base/watcher_runtime.rs
+++ b/crates/backend/src/agent/adapter/base/watcher_runtime.rs
@@ -684,6 +684,7 @@ impl WatcherHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::FakeEventSink;
 
     #[test]
     fn creates_empty_watcher_state() {
@@ -695,5 +696,39 @@ mod tests {
     fn remove_returns_false_for_missing_session() {
         let state = AgentWatcherState::new();
         assert!(!state.remove("nonexistent"));
+    }
+
+    #[test]
+    fn t_lifecycle_3_watcher_handle_drop_cascades_transcript_stop() {
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let transcript_path = tmp.path().join("t.jsonl");
+        std::fs::write(&transcript_path, "").expect("failed to write transcript");
+
+        let transcript_state = TranscriptState::new();
+        let sid = "test-sid".to_string();
+        let adapter: Arc<dyn TranscriptStreamer> =
+            Arc::new(crate::agent::adapter::claude_code::ClaudeCodeAdapter);
+        let sink = Arc::new(FakeEventSink::new());
+
+        let status = transcript_state
+            .start_or_replace(adapter, sink, sid.clone(), transcript_path, None)
+            .expect("failed to start transcript watcher");
+        assert_eq!(status, TranscriptStartStatus::Started);
+
+        let handle = WatcherHandle::new_for_test(transcript_state.clone(), sid.clone());
+        let watcher_state = AgentWatcherState::new();
+        watcher_state.insert(sid.clone(), handle);
+
+        assert!(
+            transcript_state.contains(&sid),
+            "transcript should be tracked before remove"
+        );
+
+        watcher_state.remove(&sid);
+
+        assert!(
+            !transcript_state.contains(&sid),
+            "transcript should be stopped after handle drop"
+        );
     }
 }

--- a/crates/backend/src/agent/adapter/service.rs
+++ b/crates/backend/src/agent/adapter/service.rs
@@ -44,6 +44,18 @@ pub(crate) struct AgentWatcherService {
     events: Arc<dyn EventSink>,
 }
 
+#[cfg(test)]
+mod tests {
+    use crate::agent::adapter::bindings::AgentBindings;
+
+    fn _assert_send_sync_static<T: Send + Sync + 'static>() {}
+
+    #[test]
+    fn t_lifecycle_4_agent_bindings_is_send_sync_static() {
+        _assert_send_sync_static::<AgentBindings>();
+    }
+}
+
 impl AgentWatcherService {
     pub(crate) fn new(
         pty_state: PtyState,


### PR DESCRIPTION
## Summary

**PR F.0 of 6** in the staged Step F migration (single-class `SessionLifecycle` capstone, issue #246). This phase adds **characterization tests only** — it pins `base::start_for`'s current behavior so the later phases (F.1–F.5) can rewire it with a safety net. **No production change**: every added line is `#[cfg(test)]`-gated.

- **T-LIFECYCLE-1** — happy path: `start_for` registers the session in `AgentWatcherState`.
- **T-LIFECYCLE-2a** — locate-`Err` short-circuits; a pre-existing watcher under the same sid is preserved. Identity-checked: asserts both `state.contains(sid)` **and** `transcript_state.contains(sid)` (the seed's `Drop` did not fire → not silently evicted+replaced).
- **T-LIFECYCLE-2b** — trust-root-`Err` short-circuits; same identity guarantee.
- **T-LIFECYCLE-3** — `WatcherHandle::Drop` cascades `transcript_state.stop(sid)`.
- **T-LIFECYCLE-4** — `AgentBindings` is `Send + Sync + 'static` (compile-time assertion).
- Adds the `#[cfg(test)] pub(crate) WatcherHandle::new_for_test` test seam (reused by 2a/2b/3, and by F.4/F.5 later).

Spec + plan (on `refactor/step-f-design`, not yet merged): `docs/superpowers/specs/2026-05-28-step-f-session-lifecycle-design.md` §3.3 and `docs/superpowers/plans/2026-05-28-step-f-session-lifecycle.md` Phase 0.

## Test plan

- [x] `cargo test -p vimeflow agent::adapter::base::tests::t_lifecycle` → 3 passed
- [x] `cargo test -p vimeflow agent::adapter::base::watcher_runtime::tests::t_lifecycle_3` → passed
- [x] `cargo test -p vimeflow agent::adapter::service::tests::t_lifecycle_4` → passed
- [x] Hunk-level `#[cfg(test)]` gate: every changed line is test-only; zero production lines (+262 across 3 files)
- [x] `src/bindings/` unchanged (regenerated artifacts restored, never committed)
- [x] Full lib suite green single-threaded (591/591); one pre-existing PTY-EOF parallel-execution flake (`terminal::commands::tests::read_loop_eof_marks_cache_exited`) is unrelated to this diff and passes 3/3 in isolation
- [x] Local codex review (`--base refactor/agent-adapter`): **0 HIGH/MEDIUM**

> Authored via kimi (coder) + codex (reviewer) workflow orchestration; each commit verified locally before commit.