### PR TITLE
refactor(adapter): rename watcher service to session lifecycle, widen base seams (F.1)

### DIFF
--- a/crates/backend/src/agent/adapter/base/path_security.rs
+++ b/crates/backend/src/agent/adapter/base/path_security.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 /// aborts before Vimeflow watches or reads from that path. Multi-user or
 /// shared-volume deployments should revisit this with fd-pinned traversal
 /// such as `cap-std`.
-pub(super) fn ensure_status_source_under_trust_root(
+pub(crate) fn ensure_status_source_under_trust_root(
     status_path: &Path,
     trust_root: &Path,
 ) -> Result<(), String> {

--- a/crates/backend/src/agent/adapter/base/watcher_runtime.rs
+++ b/crates/backend/src/agent/adapter/base/watcher_runtime.rs
@@ -157,7 +157,7 @@ impl AgentWatcherState {
     /// diagnostic "active_watchers=N" log line — surfaces leaked
     /// watchers from prior sessions that are still polling old
     /// status.json files in the background.
-    pub(super) fn active_count(&self) -> usize {
+    pub(crate) fn active_count(&self) -> usize {
         let watchers = self.watchers.lock().expect("failed to lock watchers");
         watchers.len()
     }
@@ -273,7 +273,7 @@ fn maybe_start_transcript(
 /// is still `located.status_path`; the rest of the struct is cloned
 /// into each callback so they can resolve transcript paths via the
 /// new trait without re-reading from the adapter.
-pub(super) fn start_watching(
+pub(crate) fn start_watching(
     bindings: AgentBindings,
     events: Arc<dyn EventSink>,
     pty_state: PtyState,

--- a/crates/backend/src/agent/adapter/mod.rs
+++ b/crates/backend/src/agent/adapter/mod.rs
@@ -11,7 +11,7 @@ pub mod claude_code;
 pub mod codex;
 mod error;
 mod serde_helpers;
-mod service;
+mod session_lifecycle;
 mod traits;
 pub mod types;
 
@@ -228,7 +228,7 @@ pub(crate) async fn start_agent_watcher_inner(
     // attach-resolution, the `AgentBindings::for_attach` +
     // `AttachError` → `String` mapping seam, and the spawn_blocking
     // hand-off to `base::start_for`.
-    service::AgentWatcherService::new(pty_state, watcher_state, transcript_state, events)
+    session_lifecycle::SessionLifecycle::new(pty_state, watcher_state, transcript_state, events)
         .start(session_id)
         .await
 }
@@ -287,17 +287,50 @@ pub(crate) async fn stop_agent_watcher_inner(
     events: Arc<dyn EventSink>,
     session_id: String,
 ) -> Result<(), String> {
-    service::AgentWatcherService::new(pty_state, watcher_state, transcript_state, events)
+    session_lifecycle::SessionLifecycle::new(pty_state, watcher_state, transcript_state, events)
         .stop(session_id)
         .await
 }
 
 #[cfg(test)]
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+#[cfg(test)]
+use std::sync::atomic::AtomicBool;
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(test)]
+pub(crate) fn make_test_session() -> crate::terminal::state::ManagedSession {
+    let pty_system = native_pty_system();
+    let pty_pair = pty_system
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("openpty");
+    let child = pty_pair
+        .slave
+        .spawn_command(CommandBuilder::new("/bin/true"))
+        .expect("spawn");
+    let writer = pty_pair.master.take_writer().expect("take_writer");
+
+    crate::terminal::state::ManagedSession {
+        master: pty_pair.master,
+        writer,
+        child,
+        cwd: "/tmp/workspace".into(),
+        generation: 0,
+        ring: Arc::new(Mutex::new(crate::terminal::state::RingBuffer::new(64))),
+        cancelled: Arc::new(AtomicBool::new(false)),
+        started_at: std::time::SystemTime::UNIX_EPOCH,
+    }
+}
+
+#[cfg(test)]
 mod noop_tests {
     use super::*;
-    use portable_pty::{native_pty_system, CommandBuilder, PtySize};
-    use std::sync::atomic::AtomicBool;
-    use std::sync::{Arc, Mutex};
 
     #[test]
     fn agent_type_round_trips() {
@@ -403,40 +436,12 @@ mod noop_tests {
         assert_eq!(snapshot.agent_session_id, "sess");
     }
 
-    fn make_test_session() -> crate::terminal::state::ManagedSession {
-        let pty_system = native_pty_system();
-        let pty_pair = pty_system
-            .openpty(PtySize {
-                rows: 24,
-                cols: 80,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .expect("openpty");
-        let child = pty_pair
-            .slave
-            .spawn_command(CommandBuilder::new("/bin/true"))
-            .expect("spawn");
-        let writer = pty_pair.master.take_writer().expect("take_writer");
-
-        crate::terminal::state::ManagedSession {
-            master: pty_pair.master,
-            writer,
-            child,
-            cwd: "/tmp/workspace".into(),
-            generation: 0,
-            ring: Arc::new(Mutex::new(crate::terminal::state::RingBuffer::new(64))),
-            cancelled: Arc::new(AtomicBool::new(false)),
-            started_at: std::time::SystemTime::UNIX_EPOCH,
-        }
-    }
-
     #[test]
     fn resolve_bind_inputs_uses_detected_agent_pid_not_shell_pid() {
         let state = PtyState::new();
         let session_id = "sid".to_string();
         state
-            .try_insert(session_id.clone(), make_test_session(), 64)
+            .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
         let attach = resolve_bind_inputs(&state, &session_id, |_| Some((AgentType::Codex, 4242)))
@@ -452,7 +457,7 @@ mod noop_tests {
         let state = PtyState::new();
         let session_id = "sid-populate".to_string();
         state
-            .try_insert(session_id.clone(), make_test_session(), 64)
+            .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
         let attach = resolve_bind_inputs(&state, &session_id, |_| Some((AgentType::Codex, 4242)))
@@ -486,7 +491,7 @@ mod noop_tests {
         let state = PtyState::new();
         let session_id = "sid-aider".to_string();
         state
-            .try_insert(session_id.clone(), make_test_session(), 64)
+            .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
         let attach = resolve_bind_inputs(&state, &session_id, |_| Some((AgentType::Aider, 9999)))
@@ -509,7 +514,7 @@ mod noop_tests {
         let state = PtyState::new();
         let session_id = "sid-runtime-live".to_string();
         state
-            .try_insert(session_id.clone(), make_test_session(), 64)
+            .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
         let runtime = SessionRuntimeContext::new(session_id.clone(), state);
@@ -550,7 +555,7 @@ mod noop_tests {
         assert_eq!(cloned_runtime.live_cwd(), None);
 
         state
-            .try_insert(session_id.clone(), make_test_session(), 64)
+            .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
         let expected = Some(PathBuf::from("/tmp/workspace"));

--- a/crates/backend/src/agent/adapter/session_lifecycle.rs
+++ b/crates/backend/src/agent/adapter/session_lifecycle.rs
@@ -1,4 +1,4 @@
-//! `AgentWatcherService` — the registry facade for agent-watcher
+//! `SessionLifecycle` — the registry facade for agent-watcher
 //! lifecycle.
 //!
 //! Step D' of the v4-frozen refactor plan (#246). Owns clones of the
@@ -37,7 +37,7 @@ use base::{AgentWatcherState, TranscriptState};
 /// facade shape is uniform and a future eager-prevalidation `stop`
 /// (or a `restart`) has the inputs it needs without a signature
 /// change.
-pub(crate) struct AgentWatcherService {
+pub(crate) struct SessionLifecycle {
     pty_state: PtyState,
     watcher_state: AgentWatcherState,
     transcript_state: TranscriptState,
@@ -56,7 +56,7 @@ mod tests {
     }
 }
 
-impl AgentWatcherService {
+impl SessionLifecycle {
     pub(crate) fn new(
         pty_state: PtyState,
         watcher_state: AgentWatcherState,


### PR DESCRIPTION
## Summary

**PR F.1 of 6** in the staged Step F migration (issue #246). Behavior-neutral **rename + visibility widening** — no logic changes; `new`/`start`/`stop` bodies are untouched.

- Rename `service.rs` → `session_lifecycle.rs`; `struct/impl AgentWatcherService` → `SessionLifecycle` (97% rename, doc comment updated).
- `mod.rs`: `mod service` → `mod session_lifecycle`; both call sites in `start_agent_watcher_inner` / `stop_agent_watcher_inner` updated.
- Widen three base seams `pub(super)` → `pub(crate)` so the sibling `session_lifecycle.rs` can reach them in later phases: `ensure_status_source_under_trust_root` (path_security.rs), `start_watching` + `AgentWatcherState::active_count` (watcher_runtime.rs). **No `base/mod.rs` re-exports** — deferred to F.3/F.4 (would trip `unused_imports` until a consumer exists). `runtime/state.rs` untouched (IPC seam keeps delegating).
- Promote `make_test_session` to `#[cfg(test)] pub(crate) fn` at file level (+ hoist its `#[cfg(test)]` imports), so F.2/F.4 verb tests in the sibling module can reach it.

Builds on F.0 (#294, merged). Spec § 9 row F.1 + plan Phase 1.

## Test plan

- [x] `cargo build -p vimeflow` — no new warnings (only the pre-existing ts-rs serde-attribute one)
- [x] `cargo test -p vimeflow agent::adapter` — 312 passed, incl. T-LIFECYCLE-1..4 (t_lifecycle_4 now in `session_lifecycle::tests`)
- [x] Full lib suite green (the PTY-EOF parallel flake is pre-existing, passes in isolation)
- [x] `AgentWatcherService` fully removed from production code (only prose/comment mentions remain)
- [x] Diff = exactly 4 files (rename + `mod.rs` + 2 one-line seam widenings); no `base/mod.rs`, no `runtime/state.rs`
- [x] `src/bindings/` unchanged
- [x] Local codex review (`--base origin/refactor/agent-adapter`): **0 HIGH/MEDIUM**

> Authored via the kimi (coder) + codex (reviewer) workflow; rename verified behavior-neutral before commit.