### PR TITLE
[codex] fix editor buffers to active session

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -51,9 +51,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Repair Electron binary install
-        run: npm rebuild electron
-
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Repair Electron binary install
+        run: npm rebuild electron
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Repair Electron binary install
+        run: npm rebuild electron
+
       - name: Build E2E artifacts (renderer + Electron bundles + sidecar)
         run: npm run test:e2e:build
 

--- a/electron/command-palette-shortcut.test.ts
+++ b/electron/command-palette-shortcut.test.ts
@@ -8,6 +8,13 @@ import {
   isCommandPaletteShortcutInput,
 } from './command-palette-shortcut'
 
+vi.mock('electron', () => ({
+  globalShortcut: {
+    register: vi.fn(() => true),
+    unregister: vi.fn(),
+  },
+}))
+
 type ShortcutInput = Parameters<typeof isCommandPaletteShortcutInput>[0]
 
 type BeforeInputHandler = (

--- a/src/features/command-palette/hooks/useCommandPalette.test.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.test.ts
@@ -74,6 +74,32 @@ describe('useCommandPalette', () => {
       // filteredResults is derived from query ':' so it shows all default commands
       expect(result.current.filteredResults.length).toBeGreaterThan(0)
     })
+
+    test('disabled palette rejects opens and closes current state', async () => {
+      const { result, rerender } = renderHook(
+        ({ enabled }: { enabled: boolean }) =>
+          useCommandPalette(undefined, { enabled }),
+        { initialProps: { enabled: true } }
+      )
+
+      act(() => {
+        result.current.open()
+      })
+
+      expect(result.current.state.isOpen).toBe(true)
+
+      rerender({ enabled: false })
+
+      await waitFor(() => {
+        expect(result.current.state.isOpen).toBe(false)
+      })
+
+      act(() => {
+        result.current.open()
+      })
+
+      expect(result.current.state.isOpen).toBe(false)
+    })
   })
 
   describe('keyboard trigger', () => {

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -9,6 +9,7 @@ import {
 import type {
   Command,
   CommandPaletteState,
+  UseCommandPaletteOptions,
   UseCommandPaletteReturn,
 } from '../registry/types'
 import { fuzzyMatch } from '../registry/fuzzyMatch'
@@ -51,8 +52,11 @@ const fullyConsumeEvent = (event: KeyboardEvent): void => {
 export { COMMAND_PALETTE_SHORTCUT_KEYS }
 
 export const useCommandPalette = (
-  commands: Command[] = defaultCommands
+  commands: Command[] = defaultCommands,
+  options: UseCommandPaletteOptions = {}
 ): UseCommandPaletteReturn => {
+  const isEnabled = options.enabled ?? true
+
   const [state, setState] = useState<CommandPaletteState>({
     isOpen: false,
     query: ':',
@@ -61,6 +65,9 @@ export const useCommandPalette = (
   })
   const leaderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const leaderActiveRef = useRef(false)
+  const isEnabledRef = useRef(isEnabled)
+
+  isEnabledRef.current = isEnabled
 
   const clearLeaderWindow = useCallback((): void => {
     if (leaderTimerRef.current) {
@@ -155,15 +162,24 @@ export const useCommandPalette = (
     return Math.min(state.selectedIndex, filteredResults.length - 1)
   }, [state.selectedIndex, filteredResults.length])
 
-  const openWithQuery = useCallback((query: string): void => {
-    setState((prev) => ({
-      ...prev,
-      isOpen: true,
-      query,
-      selectedIndex: 0,
-      currentNamespace: null,
-    }))
-  }, [])
+  const openWithQuery = useCallback(
+    (query: string): void => {
+      if (!isEnabledRef.current) {
+        clearLeaderWindow()
+
+        return
+      }
+
+      setState((prev) => ({
+        ...prev,
+        isOpen: true,
+        query,
+        selectedIndex: 0,
+        currentNamespace: null,
+      }))
+    },
+    [clearLeaderWindow]
+  )
 
   const open = useCallback((): void => {
     openWithQuery(':')
@@ -179,6 +195,14 @@ export const useCommandPalette = (
       currentNamespace: null,
     }))
   }, [clearLeaderWindow])
+
+  useEffect(() => {
+    if (isEnabled) {
+      return
+    }
+
+    close()
+  }, [close, isEnabled])
 
   const setQuery = useCallback((query: string): void => {
     setState((prev) => ({
@@ -318,6 +342,13 @@ export const useCommandPalette = (
     // the follow-up chord key (NOT intercepted) still reaches handleKeyDown
     // below and routes through chordRegistry / usePaneRenameChord.
     const handlePaletteShortcut = (): void => {
+      if (!isEnabledRef.current) {
+        clearLeaderWindow()
+        handlersRef.current.close()
+
+        return
+      }
+
       if (leaderActiveRef.current) {
         clearLeaderWindow()
         handlersRef.current.open()

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -343,7 +343,6 @@ export const useCommandPalette = (
     // below and routes through chordRegistry / usePaneRenameChord.
     const handlePaletteShortcut = (): void => {
       if (!isEnabledRef.current) {
-        clearLeaderWindow()
         handlersRef.current.close()
 
         return

--- a/src/features/command-palette/registry/types.ts
+++ b/src/features/command-palette/registry/types.ts
@@ -27,3 +27,7 @@ export interface UseCommandPaletteReturn {
   navigateUp: () => void
   navigateDown: () => void
 }
+
+export interface UseCommandPaletteOptions {
+  enabled?: boolean
+}

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -300,6 +300,12 @@ describe('DiffPanelContent', () => {
     expect(layout).toHaveClass('min-h-0')
     expect(layout).toHaveClass('min-w-0')
 
+    // The Pierre diff scroll body carries the project thin-scrollbar treatment
+    // (Pierre spreads our style/className onto its scroll container and ships
+    // no scrollbar CSS of its own, so without this the diff pane shows the
+    // default chunky OS scrollbar instead of the Obsidian-Lens thin one).
+    expect(screen.getByTestId('diff-scroll-body')).toHaveClass('thin-scrollbar')
+
     // Initial pane width is the unmeasured sentinel, so MultiFileDiff mounts
     // immediately before a ResizeObserver trigger without forcing narrow mode.
     expect(screen.getByTestId('multi-file-diff')).toBeInTheDocument()

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -827,7 +827,7 @@ export const DiffPanelContent = ({
         </div>
         <div
           data-testid="diff-scroll-body"
-          className="min-h-0 flex-1 overflow-auto"
+          className="thin-scrollbar min-h-0 flex-1 overflow-auto"
         >
           {diffError ? (
             <ErrorCard message={diffError.message} />

--- a/src/features/editor/components/UnsavedChangesDialog.test.tsx
+++ b/src/features/editor/components/UnsavedChangesDialog.test.tsx
@@ -52,6 +52,21 @@ describe('UnsavedChangesDialog', () => {
     expect(screen.getByText(/my-file\.rs/i)).toBeInTheDocument()
   })
 
+  test('uses custom action description in dialog content', () => {
+    render(
+      <UnsavedChangesDialog
+        isOpen
+        fileName="my-file.rs"
+        actionDescription="closing this session"
+        onSave={vi.fn()}
+        onDiscard={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/before closing this session/i)).toBeInTheDocument()
+  })
+
   test('calls onSave when Save button is clicked', () => {
     const onSave = vi.fn()
 

--- a/src/features/editor/components/UnsavedChangesDialog.test.tsx
+++ b/src/features/editor/components/UnsavedChangesDialog.test.tsx
@@ -142,6 +142,29 @@ describe('UnsavedChangesDialog', () => {
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
+  test('disables actions and ignores cancel shortcuts while saving', () => {
+    const onCancel = vi.fn()
+
+    render(
+      <UnsavedChangesDialog
+        isOpen
+        isSaving
+        fileName="example.ts"
+        onSave={vi.fn()}
+        onDiscard={vi.fn()}
+        onCancel={onCancel}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /discard/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
   test('renders dialog with aria attributes', () => {
     render(
       <UnsavedChangesDialog

--- a/src/features/editor/components/UnsavedChangesDialog.tsx
+++ b/src/features/editor/components/UnsavedChangesDialog.tsx
@@ -7,6 +7,7 @@ export interface UnsavedChangesDialogProps {
   fileName: string
   /** Optional error surfaced from a failed save/discard attempt. */
   errorMessage?: string | null
+  actionDescription?: string
   onSave: () => void
   onDiscard: () => void
   onCancel: () => void
@@ -16,6 +17,7 @@ export const UnsavedChangesDialog = ({
   isOpen,
   fileName,
   errorMessage = null,
+  actionDescription = 'switching files',
   onSave,
   onDiscard,
   onCancel,
@@ -153,8 +155,8 @@ export const UnsavedChangesDialog = ({
                 className="text-sm text-on-surface/80 font-inter leading-relaxed"
               >
                 <span className="font-medium text-on-surface">{fileName}</span>{' '}
-                has unsaved changes. Do you want to save them before switching
-                files?
+                has unsaved changes. Do you want to save them before{' '}
+                {actionDescription}?
               </p>
               {errorMessage && (
                 <div

--- a/src/features/editor/components/UnsavedChangesDialog.tsx
+++ b/src/features/editor/components/UnsavedChangesDialog.tsx
@@ -11,6 +11,7 @@ export interface UnsavedChangesDialogProps {
   onSave: () => void
   onDiscard: () => void
   onCancel: () => void
+  isSaving?: boolean
 }
 
 export const UnsavedChangesDialog = ({
@@ -21,6 +22,7 @@ export const UnsavedChangesDialog = ({
   onSave,
   onDiscard,
   onCancel,
+  isSaving = false,
 }: UnsavedChangesDialogProps): ReactElement | null => {
   const labelId = useId()
   const descriptionId = useId()
@@ -34,6 +36,14 @@ export const UnsavedChangesDialog = ({
   // focus on document.body — vim shortcuts then silently no-op until
   // the user clicks back into the editor, which looks like a freeze.
   const previousFocusRef = useRef<HTMLElement | null>(null)
+
+  const handleCancelRequest = (): void => {
+    if (isSaving) {
+      return
+    }
+
+    onCancel()
+  }
 
   useEffect(() => {
     if (isOpen) {
@@ -60,6 +70,10 @@ export const UnsavedChangesDialog = ({
 
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') {
+        if (isSaving) {
+          return
+        }
+
         onCancel()
 
         return
@@ -73,9 +87,13 @@ export const UnsavedChangesDialog = ({
         saveButtonRef.current,
         discardButtonRef.current,
         cancelButtonRef.current,
-      ].filter((b): b is HTMLButtonElement => b !== null)
+      ].filter((b): b is HTMLButtonElement => b !== null && !b.disabled)
 
       if (buttons.length === 0) {
+        if (isSaving) {
+          event.preventDefault()
+        }
+
         return
       }
 
@@ -104,7 +122,7 @@ export const UnsavedChangesDialog = ({
     return (): void => {
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [isOpen, onCancel])
+  }, [isOpen, isSaving, onCancel])
 
   return (
     <AnimatePresence>
@@ -123,7 +141,7 @@ export const UnsavedChangesDialog = ({
             exit={{ opacity: 0 }}
             transition={{ duration: 0.15 }}
             className="absolute inset-0 backdrop-blur-sm bg-black/40"
-            onClick={onCancel}
+            onClick={handleCancelRequest}
           />
 
           {/* Panel */}
@@ -175,9 +193,11 @@ export const UnsavedChangesDialog = ({
                 ref={saveButtonRef}
                 type="button"
                 onClick={onSave}
-                className="px-4 py-2 rounded-lg bg-primary hover:bg-primary/90 text-on-primary font-inter font-medium text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-[#1e1e2e]"
+                disabled={isSaving}
+                aria-busy={isSaving}
+                className="px-4 py-2 rounded-lg bg-primary hover:bg-primary/90 text-on-primary font-inter font-medium text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-[#1e1e2e] disabled:cursor-not-allowed disabled:opacity-60"
               >
-                Save
+                {isSaving ? 'Saving...' : 'Save'}
               </button>
 
               {/* Discard button (error) */}
@@ -185,7 +205,8 @@ export const UnsavedChangesDialog = ({
                 ref={discardButtonRef}
                 type="button"
                 onClick={onDiscard}
-                className="px-4 py-2 rounded-lg bg-error hover:bg-error/90 text-on-error font-inter font-medium text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-error focus:ring-offset-2 focus:ring-offset-[#1e1e2e]"
+                disabled={isSaving}
+                className="px-4 py-2 rounded-lg bg-error hover:bg-error/90 text-on-error font-inter font-medium text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-error focus:ring-offset-2 focus:ring-offset-[#1e1e2e] disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Discard
               </button>
@@ -194,8 +215,9 @@ export const UnsavedChangesDialog = ({
               <button
                 ref={cancelButtonRef}
                 type="button"
-                onClick={onCancel}
-                className="px-4 py-2 rounded-lg bg-surface-container hover:bg-surface-container-high text-on-surface font-inter font-medium text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-[#1e1e2e]"
+                onClick={handleCancelRequest}
+                disabled={isSaving}
+                className="px-4 py-2 rounded-lg bg-surface-container hover:bg-surface-container-high text-on-surface font-inter font-medium text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-[#1e1e2e] disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Cancel
               </button>

--- a/src/features/editor/hooks/useEditorBuffer.test.ts
+++ b/src/features/editor/hooks/useEditorBuffer.test.ts
@@ -300,6 +300,8 @@ describe('useEditorBuffer', () => {
     )
     expect(result.current.filePath).toBe('~/b.ts')
     expect(result.current.isDirty).toBe(true)
+    expect(result.current.getFilePathForScope('session-a')).toBe('~/a.ts')
+    expect(result.current.getFilePathForScope('missing')).toBeNull()
 
     rerender({ sessionId: 'session-a' })
 

--- a/src/features/editor/hooks/useEditorBuffer.test.ts
+++ b/src/features/editor/hooks/useEditorBuffer.test.ts
@@ -177,4 +177,42 @@ describe('useEditorBuffer', () => {
 
     expect(result.current.isDirty).toBe(true)
   })
+
+  test('keeps open files scoped to the active session', async () => {
+    vi.mocked(mockFileSystemService.readFile).mockImplementation((path) =>
+      Promise.resolve(`content for ${path}`)
+    )
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) =>
+        useEditorBuffer(mockFileSystemService, sessionId),
+      {
+        initialProps: { sessionId: 'session-a' },
+      }
+    )
+
+    await act(async () => {
+      await result.current.openFile('~/a.ts')
+    })
+
+    expect(result.current.filePath).toBe('~/a.ts')
+    expect(result.current.currentContent).toBe('content for ~/a.ts')
+
+    rerender({ sessionId: 'session-b' })
+
+    expect(result.current.filePath).toBeNull()
+    expect(result.current.currentContent).toBe('')
+
+    await act(async () => {
+      await result.current.openFile('~/b.ts')
+    })
+
+    expect(result.current.filePath).toBe('~/b.ts')
+    expect(result.current.currentContent).toBe('content for ~/b.ts')
+
+    rerender({ sessionId: 'session-a' })
+
+    expect(result.current.filePath).toBe('~/a.ts')
+    expect(result.current.currentContent).toBe('content for ~/a.ts')
+  })
 })

--- a/src/features/editor/hooks/useEditorBuffer.test.ts
+++ b/src/features/editor/hooks/useEditorBuffer.test.ts
@@ -257,4 +257,40 @@ describe('useEditorBuffer', () => {
       'session b edits'
     )
   })
+
+  test('reports and releases scoped unsaved buffers', async () => {
+    vi.mocked(mockFileSystemService.readFile).mockImplementation((path) =>
+      Promise.resolve(`content for ${path}`)
+    )
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) =>
+        useEditorBuffer(mockFileSystemService, sessionId),
+      {
+        initialProps: { sessionId: 'session-a' },
+      }
+    )
+
+    await act(async () => {
+      await result.current.openFile('~/a.ts')
+    })
+
+    act(() => {
+      result.current.updateContent('session a edits')
+    })
+
+    expect(result.current.hasUnsavedChanges('session-a')).toBe(true)
+    expect(result.current.hasUnsavedChanges('session-b')).toBe(false)
+
+    act(() => {
+      result.current.releaseScope('session-a')
+    })
+
+    expect(result.current.hasUnsavedChanges('session-a')).toBe(false)
+
+    rerender({ sessionId: 'session-a' })
+
+    expect(result.current.filePath).toBeNull()
+    expect(result.current.currentContent).toBe('')
+  })
 })

--- a/src/features/editor/hooks/useEditorBuffer.test.ts
+++ b/src/features/editor/hooks/useEditorBuffer.test.ts
@@ -215,4 +215,46 @@ describe('useEditorBuffer', () => {
     expect(result.current.filePath).toBe('~/a.ts')
     expect(result.current.currentContent).toBe('content for ~/a.ts')
   })
+
+  test('keeps action callbacks stable across active session changes', async () => {
+    vi.mocked(mockFileSystemService.readFile).mockImplementation((path) =>
+      Promise.resolve(`content for ${path}`)
+    )
+    vi.mocked(mockFileSystemService.writeFile).mockResolvedValue()
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) =>
+        useEditorBuffer(mockFileSystemService, sessionId),
+      {
+        initialProps: { sessionId: 'session-a' },
+      }
+    )
+
+    const initialOpenFile = result.current.openFile
+    const initialSaveFile = result.current.saveFile
+    const initialUpdateContent = result.current.updateContent
+
+    rerender({ sessionId: 'session-b' })
+
+    expect(result.current.openFile).toBe(initialOpenFile)
+    expect(result.current.saveFile).toBe(initialSaveFile)
+    expect(result.current.updateContent).toBe(initialUpdateContent)
+
+    await act(async () => {
+      await result.current.openFile('~/b.ts')
+    })
+
+    act(() => {
+      result.current.updateContent('session b edits')
+    })
+
+    await act(async () => {
+      await result.current.saveFile()
+    })
+
+    expect(mockFileSystemService.writeFile).toHaveBeenCalledWith(
+      '~/b.ts',
+      'session b edits'
+    )
+  })
 })

--- a/src/features/editor/hooks/useEditorBuffer.test.ts
+++ b/src/features/editor/hooks/useEditorBuffer.test.ts
@@ -258,6 +258,56 @@ describe('useEditorBuffer', () => {
     )
   })
 
+  test('saves an explicit inactive scope without switching active scope', async () => {
+    vi.mocked(mockFileSystemService.readFile).mockImplementation((path) =>
+      Promise.resolve(`content for ${path}`)
+    )
+    vi.mocked(mockFileSystemService.writeFile).mockResolvedValue()
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) =>
+        useEditorBuffer(mockFileSystemService, sessionId),
+      {
+        initialProps: { sessionId: 'session-a' },
+      }
+    )
+
+    await act(async () => {
+      await result.current.openFile('~/a.ts')
+    })
+
+    act(() => {
+      result.current.updateContent('session a edits')
+    })
+
+    rerender({ sessionId: 'session-b' })
+
+    await act(async () => {
+      await result.current.openFile('~/b.ts')
+    })
+
+    act(() => {
+      result.current.updateContent('session b edits')
+    })
+
+    await act(async () => {
+      await result.current.saveFile('session-a')
+    })
+
+    expect(mockFileSystemService.writeFile).toHaveBeenCalledWith(
+      '~/a.ts',
+      'session a edits'
+    )
+    expect(result.current.filePath).toBe('~/b.ts')
+    expect(result.current.isDirty).toBe(true)
+
+    rerender({ sessionId: 'session-a' })
+
+    expect(result.current.filePath).toBe('~/a.ts')
+    expect(result.current.originalContent).toBe('session a edits')
+    expect(result.current.isDirty).toBe(false)
+  })
+
   test('reports and releases scoped unsaved buffers', async () => {
     vi.mocked(mockFileSystemService.readFile).mockImplementation((path) =>
       Promise.resolve(`content for ${path}`)

--- a/src/features/editor/hooks/useEditorBuffer.ts
+++ b/src/features/editor/hooks/useEditorBuffer.ts
@@ -10,8 +10,8 @@ interface EditorBufferState {
   isLoading: boolean
 }
 
-type EditorBuffersByScope = Record<string, EditorBufferState>
-type OpenRequestIdsByScope = Record<string, number>
+type EditorBuffersByScope = Partial<Record<string, EditorBufferState>>
+type OpenRequestIdsByScope = Partial<Record<string, number>>
 
 const EMPTY_EDITOR_BUFFER: EditorBufferState = {
   filePath: null,
@@ -39,6 +39,8 @@ export interface EditorBuffer {
   openFile: (path: string) => Promise<void>
   saveFile: () => Promise<void>
   updateContent: (content: string) => void
+  hasUnsavedChanges: (scopeId: string) => boolean
+  releaseScope: (scopeId: string) => void
 }
 
 export const useEditorBuffer = (
@@ -175,6 +177,35 @@ export const useEditorBuffer = (
     [setBufferForScope]
   )
 
+  const hasUnsavedChanges = useCallback((scopeIdToCheck: string): boolean => {
+    const targetScopeId = resolveEditorBufferScopeId(scopeIdToCheck)
+    const buffer = buffersByScopeRef.current[targetScopeId]
+
+    if (!buffer) {
+      return false
+    }
+
+    return buffer.currentContent !== buffer.originalContent
+  }, [])
+
+  const releaseScope = useCallback((scopeIdToRelease: string): void => {
+    const targetScopeId = resolveEditorBufferScopeId(scopeIdToRelease)
+    const previousBuffers = buffersByScopeRef.current
+
+    if (previousBuffers[targetScopeId]) {
+      const nextBuffers = { ...previousBuffers }
+      delete nextBuffers[targetScopeId]
+      buffersByScopeRef.current = nextBuffers
+      setBuffersByScope(nextBuffers)
+    }
+
+    if (openRequestIdsRef.current[targetScopeId] !== undefined) {
+      const nextOpenRequestIds = { ...openRequestIdsRef.current }
+      delete nextOpenRequestIds[targetScopeId]
+      openRequestIdsRef.current = nextOpenRequestIds
+    }
+  }, [])
+
   return {
     filePath: activeBuffer.filePath,
     originalContent: activeBuffer.originalContent,
@@ -184,5 +215,7 @@ export const useEditorBuffer = (
     openFile,
     saveFile,
     updateContent,
+    hasUnsavedChanges,
+    releaseScope,
   }
 }

--- a/src/features/editor/hooks/useEditorBuffer.ts
+++ b/src/features/editor/hooks/useEditorBuffer.ts
@@ -47,9 +47,11 @@ export const useEditorBuffer = (
 ): EditorBuffer => {
   const activeScopeId = resolveEditorBufferScopeId(scopeId)
   const [buffersByScope, setBuffersByScope] = useState<EditorBuffersByScope>({})
+  const activeScopeIdRef = useRef(activeScopeId)
   const buffersByScopeRef = useRef<EditorBuffersByScope>({})
   const openRequestIdsRef = useRef<OpenRequestIdsByScope>({})
 
+  activeScopeIdRef.current = activeScopeId
   buffersByScopeRef.current = buffersByScope
 
   const activeBuffer = buffersByScope[activeScopeId] ?? EMPTY_EDITOR_BUFFER
@@ -95,7 +97,7 @@ export const useEditorBuffer = (
   // on-disk contents with A's buffer (silent data corruption).
   const openFile = useCallback(
     async (path: string): Promise<void> => {
-      const targetScopeId = activeScopeId
+      const targetScopeId = activeScopeIdRef.current
       const requestId = (openRequestIdsRef.current[targetScopeId] ?? 0) + 1
       openRequestIdsRef.current = {
         ...openRequestIdsRef.current,
@@ -132,11 +134,11 @@ export const useEditorBuffer = (
         throw error
       }
     },
-    [activeScopeId, fileSystemService, setBufferForScope]
+    [fileSystemService, setBufferForScope]
   )
 
   const saveFile = useCallback(async (): Promise<void> => {
-    const targetScopeId = activeScopeId
+    const targetScopeId = activeScopeIdRef.current
 
     const buffer =
       buffersByScopeRef.current[targetScopeId] ?? EMPTY_EDITOR_BUFFER
@@ -159,18 +161,18 @@ export const useEditorBuffer = (
         originalContent: content,
       }
     })
-  }, [activeScopeId, fileSystemService, setBufferForScope])
+  }, [fileSystemService, setBufferForScope])
 
   const updateContent = useCallback(
     (content: string): void => {
-      const targetScopeId = activeScopeId
+      const targetScopeId = activeScopeIdRef.current
 
       setBufferForScope(targetScopeId, (buffer) => ({
         ...buffer,
         currentContent: content,
       }))
     },
-    [activeScopeId, setBufferForScope]
+    [setBufferForScope]
   )
 
   return {

--- a/src/features/editor/hooks/useEditorBuffer.ts
+++ b/src/features/editor/hooks/useEditorBuffer.ts
@@ -40,6 +40,7 @@ export interface EditorBuffer {
   saveFile: (scopeId?: string) => Promise<void>
   updateContent: (content: string) => void
   hasUnsavedChanges: (scopeId: string) => boolean
+  getFilePathForScope: (scopeId: string) => string | null
   releaseScope: (scopeId: string) => void
 }
 
@@ -191,6 +192,12 @@ export const useEditorBuffer = (
     return buffer.currentContent !== buffer.originalContent
   }, [])
 
+  const getFilePathForScope = useCallback(
+    (scopeIdToRead: string): string | null =>
+      buffersByScopeRef.current[scopeIdToRead]?.filePath ?? null,
+    []
+  )
+
   const releaseScope = useCallback((scopeIdToRelease: string): void => {
     const previousBuffers = buffersByScopeRef.current
 
@@ -218,6 +225,7 @@ export const useEditorBuffer = (
     saveFile,
     updateContent,
     hasUnsavedChanges,
+    getFilePathForScope,
     releaseScope,
   }
 }

--- a/src/features/editor/hooks/useEditorBuffer.ts
+++ b/src/features/editor/hooks/useEditorBuffer.ts
@@ -37,7 +37,7 @@ export interface EditorBuffer {
    */
   isLoading: boolean
   openFile: (path: string) => Promise<void>
-  saveFile: () => Promise<void>
+  saveFile: (scopeId?: string) => Promise<void>
   updateContent: (content: string) => void
   hasUnsavedChanges: (scopeId: string) => boolean
   releaseScope: (scopeId: string) => void
@@ -139,31 +139,34 @@ export const useEditorBuffer = (
     [fileSystemService, setBufferForScope]
   )
 
-  const saveFile = useCallback(async (): Promise<void> => {
-    const targetScopeId = activeScopeIdRef.current
+  const saveFile = useCallback(
+    async (scopeIdToSave?: string): Promise<void> => {
+      const targetScopeId = scopeIdToSave ?? activeScopeIdRef.current
 
-    const buffer =
-      buffersByScopeRef.current[targetScopeId] ?? EMPTY_EDITOR_BUFFER
+      const buffer =
+        buffersByScopeRef.current[targetScopeId] ?? EMPTY_EDITOR_BUFFER
 
-    if (!buffer.filePath) {
-      throw new Error('No file loaded')
-    }
-
-    const filePath = buffer.filePath
-    const content = buffer.currentContent
-
-    await fileSystemService.writeFile(filePath, content)
-    setBufferForScope(targetScopeId, (currentBuffer) => {
-      if (currentBuffer.filePath !== filePath) {
-        return currentBuffer
+      if (!buffer.filePath) {
+        throw new Error('No file loaded')
       }
 
-      return {
-        ...currentBuffer,
-        originalContent: content,
-      }
-    })
-  }, [fileSystemService, setBufferForScope])
+      const filePath = buffer.filePath
+      const content = buffer.currentContent
+
+      await fileSystemService.writeFile(filePath, content)
+      setBufferForScope(targetScopeId, (currentBuffer) => {
+        if (currentBuffer.filePath !== filePath) {
+          return currentBuffer
+        }
+
+        return {
+          ...currentBuffer,
+          originalContent: content,
+        }
+      })
+    },
+    [fileSystemService, setBufferForScope]
+  )
 
   const updateContent = useCallback(
     (content: string): void => {

--- a/src/features/editor/hooks/useEditorBuffer.ts
+++ b/src/features/editor/hooks/useEditorBuffer.ts
@@ -1,6 +1,28 @@
 import { useState, useCallback, useRef } from 'react'
 import type { IFileSystemService } from '../../files/services/fileSystemService'
 
+const DEFAULT_EDITOR_BUFFER_SCOPE_ID = '__workspace_editor_buffer__'
+
+interface EditorBufferState {
+  filePath: string | null
+  originalContent: string
+  currentContent: string
+  isLoading: boolean
+}
+
+type EditorBuffersByScope = Record<string, EditorBufferState>
+type OpenRequestIdsByScope = Record<string, number>
+
+const EMPTY_EDITOR_BUFFER: EditorBufferState = {
+  filePath: null,
+  originalContent: '',
+  currentContent: '',
+  isLoading: false,
+}
+
+const resolveEditorBufferScopeId = (scopeId: string | null): string =>
+  scopeId ?? DEFAULT_EDITOR_BUFFER_SCOPE_ID
+
 export interface EditorBuffer {
   filePath: string | null
   originalContent: string
@@ -20,14 +42,45 @@ export interface EditorBuffer {
 }
 
 export const useEditorBuffer = (
-  fileSystemService: IFileSystemService
+  fileSystemService: IFileSystemService,
+  scopeId: string | null = null
 ): EditorBuffer => {
-  const [filePath, setFilePath] = useState<string | null>(null)
-  const [originalContent, setOriginalContent] = useState<string>('')
-  const [currentContent, setCurrentContent] = useState<string>('')
-  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const activeScopeId = resolveEditorBufferScopeId(scopeId)
+  const [buffersByScope, setBuffersByScope] = useState<EditorBuffersByScope>({})
+  const buffersByScopeRef = useRef<EditorBuffersByScope>({})
+  const openRequestIdsRef = useRef<OpenRequestIdsByScope>({})
 
-  const isDirty = currentContent !== originalContent
+  buffersByScopeRef.current = buffersByScope
+
+  const activeBuffer = buffersByScope[activeScopeId] ?? EMPTY_EDITOR_BUFFER
+
+  const isDirty = activeBuffer.currentContent !== activeBuffer.originalContent
+
+  const setBufferForScope = useCallback(
+    (
+      targetScopeId: string,
+      updateBuffer: (buffer: EditorBufferState) => EditorBufferState
+    ): void => {
+      const previousBuffers = buffersByScopeRef.current
+
+      const previousBuffer =
+        previousBuffers[targetScopeId] ?? EMPTY_EDITOR_BUFFER
+      const nextBuffer = updateBuffer(previousBuffer)
+
+      if (nextBuffer === previousBuffer) {
+        return
+      }
+
+      const nextBuffers = {
+        ...previousBuffers,
+        [targetScopeId]: nextBuffer,
+      }
+
+      buffersByScopeRef.current = nextBuffers
+      setBuffersByScope(nextBuffers)
+    },
+    []
+  )
 
   // Monotonically-increasing counter for last-write-wins semantics on
   // concurrent openFile calls. Each invocation captures its own id at
@@ -40,56 +93,92 @@ export const useEditorBuffer = (
   // window could leave the editor showing file A's content while
   // filePath is file B — a subsequent :w would then overwrite B's
   // on-disk contents with A's buffer (silent data corruption).
-  const openRequestIdRef = useRef(0)
-
   const openFile = useCallback(
     async (path: string): Promise<void> => {
-      const requestId = openRequestIdRef.current + 1
-      openRequestIdRef.current = requestId
+      const targetScopeId = activeScopeId
+      const requestId = (openRequestIdsRef.current[targetScopeId] ?? 0) + 1
+      openRequestIdsRef.current = {
+        ...openRequestIdsRef.current,
+        [targetScopeId]: requestId,
+      }
 
-      setIsLoading(true)
+      setBufferForScope(targetScopeId, (buffer) => ({
+        ...buffer,
+        isLoading: true,
+      }))
       try {
         const content = await fileSystemService.readFile(path)
 
         // Last-write-wins: ignore stale responses.
-        if (requestId !== openRequestIdRef.current) {
+        if (requestId !== openRequestIdsRef.current[targetScopeId]) {
           return
         }
 
-        setFilePath(path)
-        setOriginalContent(content)
-        setCurrentContent(content)
-      } finally {
-        // Only the latest request clears the loading flag — stale
-        // responses from earlier calls must NOT flip it back to
-        // false while a newer read is still in flight.
-        if (requestId === openRequestIdRef.current) {
-          setIsLoading(false)
+        setBufferForScope(targetScopeId, () => ({
+          filePath: path,
+          originalContent: content,
+          currentContent: content,
+          isLoading: false,
+        }))
+      } catch (error: unknown) {
+        if (requestId !== openRequestIdsRef.current[targetScopeId]) {
+          return
         }
+
+        setBufferForScope(targetScopeId, (buffer) => ({
+          ...buffer,
+          isLoading: false,
+        }))
+        throw error
       }
     },
-    [fileSystemService]
+    [activeScopeId, fileSystemService, setBufferForScope]
   )
 
   const saveFile = useCallback(async (): Promise<void> => {
-    if (!filePath) {
+    const targetScopeId = activeScopeId
+
+    const buffer =
+      buffersByScopeRef.current[targetScopeId] ?? EMPTY_EDITOR_BUFFER
+
+    if (!buffer.filePath) {
       throw new Error('No file loaded')
     }
 
-    await fileSystemService.writeFile(filePath, currentContent)
-    setOriginalContent(currentContent)
-  }, [fileSystemService, filePath, currentContent])
+    const filePath = buffer.filePath
+    const content = buffer.currentContent
 
-  const updateContent = useCallback((content: string): void => {
-    setCurrentContent(content)
-  }, [])
+    await fileSystemService.writeFile(filePath, content)
+    setBufferForScope(targetScopeId, (currentBuffer) => {
+      if (currentBuffer.filePath !== filePath) {
+        return currentBuffer
+      }
+
+      return {
+        ...currentBuffer,
+        originalContent: content,
+      }
+    })
+  }, [activeScopeId, fileSystemService, setBufferForScope])
+
+  const updateContent = useCallback(
+    (content: string): void => {
+      const targetScopeId = activeScopeId
+
+      setBufferForScope(targetScopeId, (buffer) => ({
+        ...buffer,
+        currentContent: content,
+      }))
+    },
+    [activeScopeId, setBufferForScope]
+  )
 
   return {
-    filePath,
-    originalContent,
-    currentContent,
+    filePath: activeBuffer.filePath,
+    originalContent: activeBuffer.originalContent,
+    currentContent: activeBuffer.currentContent,
     isDirty,
-    isLoading,
+    isLoading: activeBuffer.isLoading,
     openFile,
     saveFile,
     updateContent,

--- a/src/features/editor/hooks/useEditorBuffer.ts
+++ b/src/features/editor/hooks/useEditorBuffer.ts
@@ -115,6 +115,7 @@ export const useEditorBuffer = (
 
         // Last-write-wins: ignore stale responses.
         if (requestId !== openRequestIdsRef.current[targetScopeId]) {
+          // Newer requests own loading cleanup for this scope.
           return
         }
 

--- a/src/features/editor/hooks/useEditorBuffer.ts
+++ b/src/features/editor/hooks/useEditorBuffer.ts
@@ -178,8 +178,7 @@ export const useEditorBuffer = (
   )
 
   const hasUnsavedChanges = useCallback((scopeIdToCheck: string): boolean => {
-    const targetScopeId = resolveEditorBufferScopeId(scopeIdToCheck)
-    const buffer = buffersByScopeRef.current[targetScopeId]
+    const buffer = buffersByScopeRef.current[scopeIdToCheck]
 
     if (!buffer) {
       return false
@@ -189,19 +188,18 @@ export const useEditorBuffer = (
   }, [])
 
   const releaseScope = useCallback((scopeIdToRelease: string): void => {
-    const targetScopeId = resolveEditorBufferScopeId(scopeIdToRelease)
     const previousBuffers = buffersByScopeRef.current
 
-    if (previousBuffers[targetScopeId]) {
+    if (previousBuffers[scopeIdToRelease]) {
       const nextBuffers = { ...previousBuffers }
-      delete nextBuffers[targetScopeId]
+      delete nextBuffers[scopeIdToRelease]
       buffersByScopeRef.current = nextBuffers
       setBuffersByScope(nextBuffers)
     }
 
-    if (openRequestIdsRef.current[targetScopeId] !== undefined) {
+    if (openRequestIdsRef.current[scopeIdToRelease] !== undefined) {
       const nextOpenRequestIds = { ...openRequestIdsRef.current }
-      delete nextOpenRequestIds[targetScopeId]
+      delete nextOpenRequestIds[scopeIdToRelease]
       openRequestIdsRef.current = nextOpenRequestIds
     }
   }, [])

--- a/src/features/sessions/components/List.tsx
+++ b/src/features/sessions/components/List.tsx
@@ -1,6 +1,6 @@
 import { useRef, type ReactElement } from 'react'
 import { motion } from 'framer-motion'
-import type { Session } from '../types'
+import type { Session, SessionCloseResult } from '../types'
 import { Card } from './Card'
 import { Group } from './Group'
 import {
@@ -14,7 +14,7 @@ export interface ListProps {
   activeSessionId: string | null
   onSessionClick: (sessionId: string) => void
   onCreateSession?: () => void
-  onRemoveSession?: (sessionId: string) => boolean | void
+  onRemoveSession?: (sessionId: string) => SessionCloseResult
   onRenameSession?: (sessionId: string, name: string) => void
   onReorderSessions?: (sessions: Session[]) => void
 }
@@ -62,6 +62,8 @@ export const List = ({
   // stays a true no-op. Otherwise the trailing onSessionClick(nextId)
   // would silently switch the active session without removing the
   // intended one — a latent bug for callers that omit the prop.
+  // Returning false is the only cancellation sentinel; void means
+  // close/navigation may proceed.
   //
   // Focus restoration: removing the focused remove button drops DOM
   // focus to <body>; queueMicrotask defers until React commits the

--- a/src/features/sessions/components/List.tsx
+++ b/src/features/sessions/components/List.tsx
@@ -14,7 +14,7 @@ export interface ListProps {
   activeSessionId: string | null
   onSessionClick: (sessionId: string) => void
   onCreateSession?: () => void
-  onRemoveSession?: (sessionId: string) => void
+  onRemoveSession?: (sessionId: string) => boolean | void
   onRenameSession?: (sessionId: string, name: string) => void
   onReorderSessions?: (sessions: Session[]) => void
 }
@@ -74,7 +74,11 @@ export const List = ({
           id === activeSessionId
             ? pickNextVisibleSessionId(sessions, id, activeSessionId)
             : undefined
-        onRemoveSession(id)
+        const didRemove = onRemoveSession(id)
+        if (didRemove === false) {
+          return
+        }
+
         if (nextId !== undefined) {
           onSessionClick(nextId)
           queueMicrotask(() => {

--- a/src/features/sessions/components/Tabs.tsx
+++ b/src/features/sessions/components/Tabs.tsx
@@ -11,7 +11,7 @@ export interface TabsProps {
   sessions: Session[]
   activeSessionId: string | null
   onSelect: (sessionId: string) => void
-  onClose: (sessionId: string) => void
+  onClose: (sessionId: string) => boolean | void
   onNew: () => void
 }
 
@@ -61,7 +61,11 @@ export const Tabs = ({
       sessionId === activeSessionId
         ? pickNextVisibleSessionId(sessions, sessionId, activeSessionId)
         : undefined
-    onClose(sessionId)
+    const didClose = onClose(sessionId)
+    if (didClose === false) {
+      return
+    }
+
     if (nextId !== undefined) {
       onSelect(nextId)
       // WAI-ARIA Tabs Pattern §4.4.3: after a close, focus must move

--- a/src/features/sessions/components/Tabs.tsx
+++ b/src/features/sessions/components/Tabs.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement } from 'react'
-import type { Session } from '../types'
+import type { Session, SessionCloseResult } from '../types'
 import { agentForSession } from '../utils/agentForSession'
 import {
   getVisibleSessions,
@@ -11,7 +11,7 @@ export interface TabsProps {
   sessions: Session[]
   activeSessionId: string | null
   onSelect: (sessionId: string) => void
-  onClose: (sessionId: string) => boolean | void
+  onClose: (sessionId: string) => SessionCloseResult
   onNew: () => void
 }
 
@@ -55,8 +55,8 @@ export const Tabs = ({
     // the visible next-tab id. Order matters: onClose runs first so
     // removeSession can do its work (kill IPC, drop from list, pick its
     // own fallback); the trailing onSelect then overrides the selection
-    // to a tab the user can actually see. This way an onClose failure
-    // cannot strand the selection on a removed id.
+    // to a tab the user can actually see. Returning false is the only
+    // cancellation sentinel; void means close/navigation may proceed.
     const nextId =
       sessionId === activeSessionId
         ? pickNextVisibleSessionId(sessions, sessionId, activeSessionId)

--- a/src/features/sessions/types/index.ts
+++ b/src/features/sessions/types/index.ts
@@ -3,6 +3,8 @@
 
 export type SessionStatus = 'running' | 'paused' | 'completed' | 'errored'
 
+export type SessionCloseResult = false | void
+
 export type LayoutId = 'single' | 'vsplit' | 'hsplit' | 'threeRight' | 'quad'
 
 export interface Pane {

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -98,7 +98,12 @@ vi.mock('../agent-status/components/AgentStatusPanel', () => ({
 }))
 
 vi.mock('../editor/components/UnsavedChangesDialog', () => ({
-  UnsavedChangesDialog: (): ReactElement => <div />,
+  UnsavedChangesDialog: ({
+    isOpen,
+  }: {
+    isOpen: boolean
+  }): ReactElement | null =>
+    isOpen ? <div data-testid="unsaved-changes-dialog" /> : null,
 }))
 
 const createMockSession = (id: string, name: string): Session => ({
@@ -650,6 +655,63 @@ describe('WorkspaceView - Command Palette Integration', () => {
 
     expect(hasUnsavedChanges).toHaveBeenCalledWith('session-1')
     expect(mockSessionManager.removeSession).not.toHaveBeenCalled()
+  })
+
+  test('does not open the palette while the unsaved dialog is active', async () => {
+    const user = userEvent.setup()
+    const hasUnsavedChanges = vi.fn(() => true)
+    const { useEditorBuffer } = await import('../editor/hooks/useEditorBuffer')
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: 'src/current.ts',
+      originalContent: 'original',
+      currentContent: 'edits',
+      isDirty: true,
+      isLoading: false,
+      openFile: vi.fn(),
+      saveFile: vi.fn(),
+      updateContent: vi.fn(),
+      hasUnsavedChanges,
+      releaseScope: vi.fn(),
+    })
+
+    render(<WorkspaceView />)
+
+    openPalette()
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('dialog', { name: 'Command palette' })
+      ).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('combobox', {
+      name: 'Command palette search',
+    })
+    await user.clear(input)
+    await user.type(input, ':close')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('unsaved-changes-dialog')).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: 'Command palette' })
+      ).not.toBeInTheDocument()
+    })
+
+    openPalette()
+    expect(
+      screen.queryByRole('dialog', { name: 'Command palette' })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Command Palette' }))
+    expect(
+      screen.queryByRole('dialog', { name: 'Command palette' })
+    ).not.toBeInTheDocument()
+    expect(mockSessionManager.setActiveSessionId).not.toHaveBeenCalled()
   })
 
   test(':rename-session foo command renames active session', async () => {

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -261,6 +261,8 @@ describe('WorkspaceView - Command Palette Integration', () => {
       openFile: vi.fn(),
       saveFile: vi.fn(),
       updateContent: vi.fn(),
+      hasUnsavedChanges: vi.fn(() => false),
+      releaseScope: vi.fn(),
     })
 
     // Mock fileSystemService

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -615,6 +615,43 @@ describe('WorkspaceView - Command Palette Integration', () => {
     })
   })
 
+  test(':close command respects dirty-session guard', async () => {
+    const user = userEvent.setup()
+    const hasUnsavedChanges = vi.fn(() => true)
+    const { useEditorBuffer } = await import('../editor/hooks/useEditorBuffer')
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: 'src/current.ts',
+      originalContent: 'original',
+      currentContent: 'edits',
+      isDirty: true,
+      isLoading: false,
+      openFile: vi.fn(),
+      saveFile: vi.fn(),
+      updateContent: vi.fn(),
+      hasUnsavedChanges,
+      releaseScope: vi.fn(),
+    })
+
+    render(<WorkspaceView />)
+
+    openPalette()
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('combobox', {
+      name: 'Command palette search',
+    })
+    await user.clear(input)
+    await user.type(input, ':close')
+    await user.keyboard('{Enter}')
+
+    expect(hasUnsavedChanges).toHaveBeenCalledWith('session-1')
+    expect(mockSessionManager.removeSession).not.toHaveBeenCalled()
+  })
+
   test(':rename-session foo command renames active session', async () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -267,6 +267,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
       saveFile: vi.fn(),
       updateContent: vi.fn(),
       hasUnsavedChanges: vi.fn(() => false),
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
 
@@ -635,6 +636,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
       saveFile: vi.fn(),
       updateContent: vi.fn(),
       hasUnsavedChanges,
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
 
@@ -672,6 +674,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
       saveFile: vi.fn(),
       updateContent: vi.fn(),
       hasUnsavedChanges,
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
 

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -21,6 +21,7 @@ interface MockEditorBuffer {
   saveFile: ReturnType<typeof vi.fn>
   updateContent: ReturnType<typeof vi.fn>
   hasUnsavedChanges: ReturnType<typeof vi.fn>
+  getFilePathForScope: ReturnType<typeof vi.fn>
   releaseScope: ReturnType<typeof vi.fn>
 }
 
@@ -35,6 +36,7 @@ vi.mock('../editor/hooks/useEditorBuffer', () => ({
     saveFile: vi.fn().mockResolvedValue(undefined),
     updateContent: vi.fn(),
     hasUnsavedChanges: vi.fn(() => false),
+    getFilePathForScope: vi.fn(() => null),
     releaseScope: vi.fn(),
   }),
 }))

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -20,6 +20,8 @@ interface MockEditorBuffer {
   openFile: ReturnType<typeof vi.fn>
   saveFile: ReturnType<typeof vi.fn>
   updateContent: ReturnType<typeof vi.fn>
+  hasUnsavedChanges: ReturnType<typeof vi.fn>
+  releaseScope: ReturnType<typeof vi.fn>
 }
 
 vi.mock('../editor/hooks/useEditorBuffer', () => ({
@@ -32,6 +34,8 @@ vi.mock('../editor/hooks/useEditorBuffer', () => ({
     openFile: vi.fn().mockResolvedValue(undefined),
     saveFile: vi.fn().mockResolvedValue(undefined),
     updateContent: vi.fn(),
+    hasUnsavedChanges: vi.fn(() => false),
+    releaseScope: vi.fn(),
   }),
 }))
 

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -203,6 +203,7 @@ describe('WorkspaceView', () => {
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
       hasUnsavedChanges: vi.fn(() => false),
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
   })
@@ -286,6 +287,7 @@ describe('WorkspaceView', () => {
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
       hasUnsavedChanges,
+      getFilePathForScope: vi.fn(() => null),
       releaseScope,
     })
 
@@ -357,6 +359,7 @@ describe('WorkspaceView', () => {
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
       hasUnsavedChanges,
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
 
@@ -428,6 +431,7 @@ describe('WorkspaceView', () => {
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
       hasUnsavedChanges,
+      getFilePathForScope: vi.fn(() => null),
       releaseScope,
     })
 
@@ -515,6 +519,9 @@ describe('WorkspaceView', () => {
       saveFile,
       updateContent: vi.fn(),
       hasUnsavedChanges,
+      getFilePathForScope: vi.fn((scopeId: string) =>
+        scopeId === 'second' ? 'src/second.ts' : null
+      ),
       releaseScope,
     })
 
@@ -524,7 +531,12 @@ describe('WorkspaceView', () => {
       await screen.findByRole('tab', { name: 'first' })
 
       await user.click(screen.getByRole('button', { name: 'Close second' }))
-      await screen.findByRole('dialog', { name: /unsaved changes/i })
+
+      const dialog = await screen.findByRole('dialog', {
+        name: /unsaved changes/i,
+      })
+
+      expect(within(dialog).getByText('src/second.ts')).toBeInTheDocument()
       await user.click(screen.getByRole('button', { name: 'Save' }))
 
       await waitFor(() => {
@@ -598,6 +610,7 @@ describe('WorkspaceView', () => {
       saveFile,
       updateContent: vi.fn(),
       hasUnsavedChanges,
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
 
@@ -675,6 +688,7 @@ describe('WorkspaceView', () => {
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
       hasUnsavedChanges,
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
 
@@ -740,6 +754,7 @@ describe('WorkspaceView', () => {
       saveFile,
       updateContent: vi.fn(),
       hasUnsavedChanges,
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
 
@@ -778,6 +793,7 @@ describe('WorkspaceView', () => {
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
       hasUnsavedChanges,
+      getFilePathForScope: vi.fn(() => null),
       releaseScope,
     })
 
@@ -1437,6 +1453,7 @@ describe('WorkspaceView', () => {
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
       hasUnsavedChanges: vi.fn(() => false),
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
 
@@ -1469,6 +1486,7 @@ describe('WorkspaceView', () => {
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
       hasUnsavedChanges: vi.fn(() => true),
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
 
@@ -1504,6 +1522,7 @@ describe('WorkspaceView', () => {
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
       hasUnsavedChanges: vi.fn(() => false),
+      getFilePathForScope: vi.fn(() => null),
       releaseScope: vi.fn(),
     })
 

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -453,6 +453,87 @@ describe('WorkspaceView', () => {
     )
   })
 
+  test('removes a dirty background session after saving and restores the original active session', async () => {
+    const user = userEvent.setup()
+    const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'second')
+    const saveFile = vi.fn().mockResolvedValue(undefined)
+
+    workspaceTerminalMock.service.listSessions.mockResolvedValue({
+      activeSessionId: 'first',
+      sessions: [
+        {
+          id: 'first',
+          cwd: '/repo/first',
+          status: {
+            kind: 'Alive',
+            pid: 1,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+        {
+          id: 'second',
+          cwd: '/repo/second',
+          status: {
+            kind: 'Alive',
+            pid: 2,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+        {
+          id: 'third',
+          cwd: '/repo/third',
+          status: {
+            kind: 'Alive',
+            pid: 3,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    })
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: 'src/current.ts',
+      originalContent: 'original',
+      currentContent: 'edits',
+      isDirty: true,
+      isLoading: false,
+      openFile: vi.fn().mockResolvedValue(undefined),
+      saveFile,
+      updateContent: vi.fn(),
+      hasUnsavedChanges,
+      releaseScope: vi.fn(),
+    })
+
+    render(<WorkspaceView />)
+
+    await screen.findByRole('tab', { name: 'first' })
+
+    await user.click(screen.getByRole('button', { name: 'Close second' }))
+    await screen.findByRole('dialog', { name: /unsaved changes/i })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(saveFile).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tab', { name: 'second' })).toBeNull()
+    })
+
+    expect(screen.getByRole('tab', { name: 'first' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+
+    expect(screen.getByRole('tab', { name: 'third' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    )
+  })
+
   test('selects the next visible session after confirming a dirty active-session close', async () => {
     const user = userEvent.setup()
     const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'first')
@@ -507,6 +588,75 @@ describe('WorkspaceView', () => {
 
     await user.click(screen.getByRole('button', { name: 'Close first' }))
     await user.click(screen.getByRole('button', { name: 'Discard' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'third' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    })
+    expect(screen.queryByRole('tab', { name: 'hidden-ended' })).toBeNull()
+  })
+
+  test('selects the next visible session after saving a dirty active-session close', async () => {
+    const user = userEvent.setup()
+    const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'first')
+    const saveFile = vi.fn().mockResolvedValue(undefined)
+
+    workspaceTerminalMock.service.listSessions.mockResolvedValue({
+      activeSessionId: 'first',
+      sessions: [
+        {
+          id: 'first',
+          cwd: '/repo/first',
+          status: {
+            kind: 'Alive',
+            pid: 1,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+        {
+          id: 'hidden-ended',
+          cwd: '/repo/hidden-ended',
+          status: { kind: 'Exited', last_exit_code: 0 },
+        },
+        {
+          id: 'third',
+          cwd: '/repo/third',
+          status: {
+            kind: 'Alive',
+            pid: 3,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    })
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: 'src/current.ts',
+      originalContent: 'original',
+      currentContent: 'edits',
+      isDirty: true,
+      isLoading: false,
+      openFile: vi.fn().mockResolvedValue(undefined),
+      saveFile,
+      updateContent: vi.fn(),
+      hasUnsavedChanges,
+      releaseScope: vi.fn(),
+    })
+
+    render(<WorkspaceView />)
+
+    await screen.findByRole('tab', { name: 'first' })
+
+    await user.click(screen.getByRole('button', { name: 'Close first' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(saveFile).toHaveBeenCalled()
+    })
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'third' })).toHaveAttribute(

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -172,6 +172,8 @@ describe('WorkspaceView', () => {
       openFile: vi.fn().mockResolvedValue(undefined),
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
+      hasUnsavedChanges: vi.fn(() => false),
+      releaseScope: vi.fn(),
     })
   })
 
@@ -237,6 +239,72 @@ describe('WorkspaceView', () => {
     } finally {
       randomUUID.mockRestore()
     }
+  })
+
+  test('prompts before removing a dirty active session', async () => {
+    const user = userEvent.setup()
+    const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'sess-1')
+    const releaseScope = vi.fn()
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: 'src/current.ts',
+      originalContent: 'original',
+      currentContent: 'edits',
+      isDirty: true,
+      isLoading: false,
+      openFile: vi.fn().mockResolvedValue(undefined),
+      saveFile: vi.fn().mockResolvedValue(undefined),
+      updateContent: vi.fn(),
+      hasUnsavedChanges,
+      releaseScope,
+    })
+
+    render(<WorkspaceView />)
+
+    const activeTab = await screen.findByRole('tab', { name: 'session 1' })
+
+    await user.click(screen.getByRole('button', { name: 'Close session 1' }))
+
+    expect(hasUnsavedChanges).toHaveBeenCalledWith('sess-1')
+
+    const dialog = await screen.findByRole('dialog', {
+      name: /unsaved changes/i,
+    })
+
+    expect(dialog).toHaveTextContent(/before closing this session/i)
+    expect(within(dialog).getByText('src/current.ts')).toBeInTheDocument()
+    expect(activeTab).toHaveAttribute('aria-selected', 'true')
+    expect(releaseScope).not.toHaveBeenCalled()
+  })
+
+  test('releases an editor scope after a clean session is removed', async () => {
+    const user = userEvent.setup()
+    const hasUnsavedChanges = vi.fn(() => false)
+    const releaseScope = vi.fn()
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: null,
+      originalContent: '',
+      currentContent: '',
+      isDirty: false,
+      isLoading: false,
+      openFile: vi.fn().mockResolvedValue(undefined),
+      saveFile: vi.fn().mockResolvedValue(undefined),
+      updateContent: vi.fn(),
+      hasUnsavedChanges,
+      releaseScope,
+    })
+
+    render(<WorkspaceView />)
+
+    await screen.findByRole('tab', { name: 'session 1' })
+
+    await user.click(screen.getByRole('button', { name: 'Close session 1' }))
+
+    expect(hasUnsavedChanges).toHaveBeenCalledWith('sess-1')
+    await waitFor(() => {
+      expect(releaseScope).toHaveBeenCalledWith('sess-1')
+    })
   })
 
   test('applies correct grid layout with 4 columns (dynamic sidebar width)', () => {
@@ -882,6 +950,8 @@ describe('WorkspaceView', () => {
       openFile: openFileMock,
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
+      hasUnsavedChanges: vi.fn(() => false),
+      releaseScope: vi.fn(),
     })
 
     render(<WorkspaceView />)
@@ -912,6 +982,8 @@ describe('WorkspaceView', () => {
       openFile: openFileMock,
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
+      hasUnsavedChanges: vi.fn(() => true),
+      releaseScope: vi.fn(),
     })
 
     render(<WorkspaceView />)
@@ -945,6 +1017,8 @@ describe('WorkspaceView', () => {
       openFile: openFileMock,
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
+      hasUnsavedChanges: vi.fn(() => false),
+      releaseScope: vi.fn(),
     })
 
     render(<WorkspaceView />)

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -307,6 +307,152 @@ describe('WorkspaceView', () => {
     expect(releaseScope).not.toHaveBeenCalled()
   })
 
+  test('restores the original active session when cancelling a dirty background close', async () => {
+    const user = userEvent.setup()
+    const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'second')
+
+    workspaceTerminalMock.service.listSessions.mockResolvedValue({
+      activeSessionId: 'first',
+      sessions: [
+        {
+          id: 'first',
+          cwd: '/repo/first',
+          status: {
+            kind: 'Alive',
+            pid: 1,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+        {
+          id: 'second',
+          cwd: '/repo/second',
+          status: {
+            kind: 'Alive',
+            pid: 2,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+        {
+          id: 'third',
+          cwd: '/repo/third',
+          status: {
+            kind: 'Alive',
+            pid: 3,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    })
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: 'src/current.ts',
+      originalContent: 'original',
+      currentContent: 'edits',
+      isDirty: true,
+      isLoading: false,
+      openFile: vi.fn().mockResolvedValue(undefined),
+      saveFile: vi.fn().mockResolvedValue(undefined),
+      updateContent: vi.fn(),
+      hasUnsavedChanges,
+      releaseScope: vi.fn(),
+    })
+
+    render(<WorkspaceView />)
+
+    await screen.findByRole('tab', { name: 'first' })
+
+    await user.click(screen.getByRole('button', { name: 'Close second' }))
+    await screen.findByRole('dialog', { name: /unsaved changes/i })
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'first' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    })
+    expect(screen.getByRole('tab', { name: 'second' })).toBeInTheDocument()
+  })
+
+  test('restores the original active session after discarding a dirty background close', async () => {
+    const user = userEvent.setup()
+    const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'second')
+
+    workspaceTerminalMock.service.listSessions.mockResolvedValue({
+      activeSessionId: 'first',
+      sessions: [
+        {
+          id: 'first',
+          cwd: '/repo/first',
+          status: {
+            kind: 'Alive',
+            pid: 1,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+        {
+          id: 'second',
+          cwd: '/repo/second',
+          status: {
+            kind: 'Alive',
+            pid: 2,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+        {
+          id: 'third',
+          cwd: '/repo/third',
+          status: {
+            kind: 'Alive',
+            pid: 3,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    })
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: 'src/current.ts',
+      originalContent: 'original',
+      currentContent: 'edits',
+      isDirty: true,
+      isLoading: false,
+      openFile: vi.fn().mockResolvedValue(undefined),
+      saveFile: vi.fn().mockResolvedValue(undefined),
+      updateContent: vi.fn(),
+      hasUnsavedChanges,
+      releaseScope: vi.fn(),
+    })
+
+    render(<WorkspaceView />)
+
+    await screen.findByRole('tab', { name: 'first' })
+
+    await user.click(screen.getByRole('button', { name: 'Close second' }))
+    await screen.findByRole('dialog', { name: /unsaved changes/i })
+    await user.click(screen.getByRole('button', { name: 'Discard' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tab', { name: 'second' })).toBeNull()
+    })
+
+    expect(screen.getByRole('tab', { name: 'first' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+
+    expect(screen.getByRole('tab', { name: 'third' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    )
+  })
+
   test('selects the next visible session after confirming a dirty active-session close', async () => {
     const user = userEvent.setup()
     const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'first')

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -17,6 +17,56 @@ import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
 import type { AgentStatus } from '../agent-status/types'
 import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 import { usePaneShortcuts } from '../terminal/hooks/usePaneShortcuts'
+import type { SessionList } from '../../bindings'
+
+const workspaceTerminalMock = vi.hoisted(() => {
+  const defaultSessionList = (): SessionList => ({
+    activeSessionId: 'sess-1',
+    sessions: [
+      {
+        id: 'sess-1',
+        cwd: '~',
+        status: {
+          kind: 'Alive' as const,
+          pid: 1234,
+          replay_data: '',
+          replay_end_offset: BigInt(0),
+        },
+      },
+    ],
+  })
+
+  const service = {
+    spawn: vi
+      .fn()
+      .mockResolvedValue({ sessionId: 'new-id', pid: 999, cwd: '~' }),
+    write: vi.fn().mockResolvedValue(undefined),
+    resize: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(
+      (): Promise<() => void> =>
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        Promise.resolve((): void => {})
+    ),
+    onExit: vi.fn(
+      (): Promise<() => void> =>
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        Promise.resolve((): void => {})
+    ),
+    onError: vi.fn(
+      (): Promise<() => void> =>
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        Promise.resolve((): void => {})
+    ),
+    listSessions: vi.fn().mockResolvedValue(defaultSessionList()),
+    setActiveSession: vi.fn().mockResolvedValue(undefined),
+    reorderSessions: vi.fn().mockResolvedValue(undefined),
+    updateSessionCwd: vi.fn().mockResolvedValue(undefined),
+    setSessionActivityPanelCollapsed: vi.fn().mockResolvedValue(undefined),
+  }
+
+  return { defaultSessionList, service }
+})
 
 // Mock TerminalPane to avoid xterm.js issues in tests. Surface `pane.cwd`
 // as a data attribute so tests can observe the agent-cwd → pane.cwd bridge
@@ -111,46 +161,12 @@ vi.mock('../agent-status/components/AgentStatusPanel', () => ({
 
 // Mock terminal service to return initial session data synchronously
 vi.mock('../terminal/services/terminalService', () => ({
-  createTerminalService: vi.fn(() => ({
-    spawn: vi
-      .fn()
-      .mockResolvedValue({ sessionId: 'new-id', pid: 999, cwd: '~' }),
-    write: vi.fn().mockResolvedValue(undefined),
-    resize: vi.fn().mockResolvedValue(undefined),
-    kill: vi.fn().mockResolvedValue(undefined),
-    onData: vi.fn(
-      (): Promise<() => void> =>
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        Promise.resolve((): void => {})
-    ),
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    onExit: vi.fn((): (() => void) => (): void => {}),
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    onError: vi.fn((): (() => void) => (): void => {}),
-    listSessions: vi.fn().mockResolvedValue({
-      activeSessionId: 'sess-1',
-      sessions: [
-        {
-          id: 'sess-1',
-          cwd: '~',
-          status: {
-            kind: 'Alive',
-            pid: 1234,
-            replay_data: '',
-            replay_end_offset: BigInt(0),
-          },
-        },
-      ],
-    }),
-    setActiveSession: vi.fn().mockResolvedValue(undefined),
-    reorderSessions: vi.fn().mockResolvedValue(undefined),
-    updateSessionCwd: vi.fn().mockResolvedValue(undefined),
-    setSessionActivityPanelCollapsed: vi.fn().mockResolvedValue(undefined),
-  })),
+  createTerminalService: vi.fn(() => workspaceTerminalMock.service),
 }))
 
 describe('WorkspaceView', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     Object.defineProperty(navigator, 'platform', {
       value: 'Linux x86_64',
       configurable: true,
@@ -158,7 +174,21 @@ describe('WorkspaceView', () => {
     capturedAgentStatusPanelProps.onOpenFile = undefined
     capturedAgentStatusPanelProps.onOpenDiff = undefined
     capturedAgentStatusPanelProps.agentStatus = undefined
-    vi.mocked(usePaneShortcuts).mockClear()
+    workspaceTerminalMock.service.spawn.mockResolvedValue({
+      sessionId: 'new-id',
+      pid: 999,
+      cwd: '~',
+    })
+    workspaceTerminalMock.service.kill.mockResolvedValue(undefined)
+    workspaceTerminalMock.service.listSessions.mockResolvedValue(
+      workspaceTerminalMock.defaultSessionList()
+    )
+    workspaceTerminalMock.service.setActiveSession.mockResolvedValue(undefined)
+    workspaceTerminalMock.service.reorderSessions.mockResolvedValue(undefined)
+    workspaceTerminalMock.service.updateSessionCwd.mockResolvedValue(undefined)
+    workspaceTerminalMock.service.setSessionActivityPanelCollapsed.mockResolvedValue(
+      undefined
+    )
 
     // Default: clean buffer with no file open. Mirrors the real hook's
     // initial state so existing tests don't see a dirty buffer or get
@@ -275,6 +305,70 @@ describe('WorkspaceView', () => {
     expect(within(dialog).getByText('src/current.ts')).toBeInTheDocument()
     expect(activeTab).toHaveAttribute('aria-selected', 'true')
     expect(releaseScope).not.toHaveBeenCalled()
+  })
+
+  test('selects the next visible session after confirming a dirty active-session close', async () => {
+    const user = userEvent.setup()
+    const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'first')
+
+    workspaceTerminalMock.service.listSessions.mockResolvedValue({
+      activeSessionId: 'first',
+      sessions: [
+        {
+          id: 'first',
+          cwd: '/repo/first',
+          status: {
+            kind: 'Alive',
+            pid: 1,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+        {
+          id: 'hidden-ended',
+          cwd: '/repo/hidden-ended',
+          status: { kind: 'Exited', last_exit_code: 0 },
+        },
+        {
+          id: 'third',
+          cwd: '/repo/third',
+          status: {
+            kind: 'Alive',
+            pid: 3,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    })
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: 'src/current.ts',
+      originalContent: 'original',
+      currentContent: 'edits',
+      isDirty: true,
+      isLoading: false,
+      openFile: vi.fn().mockResolvedValue(undefined),
+      saveFile: vi.fn().mockResolvedValue(undefined),
+      updateContent: vi.fn(),
+      hasUnsavedChanges,
+      releaseScope: vi.fn(),
+    })
+
+    render(<WorkspaceView />)
+
+    await screen.findByRole('tab', { name: 'first' })
+
+    await user.click(screen.getByRole('button', { name: 'Close first' }))
+    await user.click(screen.getByRole('button', { name: 'Discard' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'third' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    })
+    expect(screen.queryByRole('tab', { name: 'hidden-ended' })).toBeNull()
   })
 
   test('releases an editor scope after a clean session is removed', async () => {

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -380,6 +380,7 @@ describe('WorkspaceView', () => {
   test('restores the original active session after discarding a dirty background close', async () => {
     const user = userEvent.setup()
     const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'second')
+    const releaseScope = vi.fn()
 
     workspaceTerminalMock.service.listSessions.mockResolvedValue({
       activeSessionId: 'first',
@@ -427,7 +428,7 @@ describe('WorkspaceView', () => {
       saveFile: vi.fn().mockResolvedValue(undefined),
       updateContent: vi.fn(),
       hasUnsavedChanges,
-      releaseScope: vi.fn(),
+      releaseScope,
     })
 
     render(<WorkspaceView />)
@@ -451,12 +452,14 @@ describe('WorkspaceView', () => {
       'aria-selected',
       'false'
     )
+    expect(releaseScope).toHaveBeenCalledWith('second')
   })
 
   test('removes a dirty background session after saving and restores the original active session', async () => {
     const user = userEvent.setup()
     const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'second')
     const saveFile = vi.fn().mockResolvedValue(undefined)
+    const releaseScope = vi.fn()
 
     const consoleWarn = vi
       .spyOn(console, 'warn')
@@ -512,7 +515,7 @@ describe('WorkspaceView', () => {
       saveFile,
       updateContent: vi.fn(),
       hasUnsavedChanges,
-      releaseScope: vi.fn(),
+      releaseScope,
     })
 
     try {
@@ -541,6 +544,7 @@ describe('WorkspaceView', () => {
         'aria-selected',
         'false'
       )
+      expect(releaseScope).toHaveBeenCalledWith('second')
     } finally {
       consoleWarn.mockRestore()
     }

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -550,6 +550,86 @@ describe('WorkspaceView', () => {
     }
   })
 
+  test('keeps dirty session close pending while save is in flight', async () => {
+    const user = userEvent.setup()
+    const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'second')
+    let resolveSave: (() => void) | null = null
+
+    const saveFile = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve
+        })
+    )
+
+    workspaceTerminalMock.service.listSessions.mockResolvedValue({
+      activeSessionId: 'first',
+      sessions: [
+        {
+          id: 'first',
+          cwd: '/repo/first',
+          status: {
+            kind: 'Alive',
+            pid: 1,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+        {
+          id: 'second',
+          cwd: '/repo/second',
+          status: {
+            kind: 'Alive',
+            pid: 2,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    })
+
+    vi.mocked(useEditorBuffer).mockReturnValue({
+      filePath: 'src/current.ts',
+      originalContent: 'original',
+      currentContent: 'edits',
+      isDirty: true,
+      isLoading: false,
+      openFile: vi.fn().mockResolvedValue(undefined),
+      saveFile,
+      updateContent: vi.fn(),
+      hasUnsavedChanges,
+      releaseScope: vi.fn(),
+    })
+
+    render(<WorkspaceView />)
+
+    await screen.findByRole('tab', { name: 'first' })
+
+    await user.click(screen.getByRole('button', { name: 'Close second' }))
+    await screen.findByRole('dialog', { name: /unsaved changes/i })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(saveFile).toHaveBeenCalledWith('second')
+    })
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(
+      screen.getByRole('dialog', { name: /unsaved changes/i })
+    ).toBeInTheDocument()
+
+    act(() => {
+      resolveSave?.()
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tab', { name: 'second' })).toBeNull()
+    })
+  })
+
   test('selects the next visible session after confirming a dirty active-session close', async () => {
     const user = userEvent.setup()
     const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'first')

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -3,7 +3,14 @@
 // cspell:ignore worktree worktrees
 import type { ReactElement } from 'react'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WorkspaceView } from './WorkspaceView'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
@@ -194,6 +201,42 @@ describe('WorkspaceView', () => {
     ).toBe(true)
     expect(typeof args.setSessionActivePane).toBe('function')
     expect(typeof args.setSessionLayout).toBe('function')
+  })
+
+  test('scopes the editor buffer to the active session', async () => {
+    const user = userEvent.setup()
+    const nextSessionId = '00000000-0000-4000-8000-000000000002'
+
+    const randomUUID = vi
+      .spyOn(crypto, 'randomUUID')
+      .mockReturnValue(nextSessionId)
+
+    try {
+      render(<WorkspaceView />)
+
+      await screen.findByRole('button', { name: 'session 1' })
+
+      await waitFor(() => {
+        expect(
+          vi
+            .mocked(useEditorBuffer)
+            .mock.calls.some(([, sessionId]) => sessionId === 'sess-1')
+        ).toBe(true)
+      })
+
+      await user.click(screen.getByRole('button', { name: 'new session' }))
+      await screen.findByRole('button', { name: 'session 2' })
+
+      await waitFor(() => {
+        expect(
+          vi
+            .mocked(useEditorBuffer)
+            .mock.calls.some(([, sessionId]) => sessionId === nextSessionId)
+        ).toBe(true)
+      })
+    } finally {
+      randomUUID.mockRestore()
+    }
   })
 
   test('applies correct grid layout with 4 columns (dynamic sidebar width)', () => {

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -458,6 +458,10 @@ describe('WorkspaceView', () => {
     const hasUnsavedChanges = vi.fn((scopeId: string) => scopeId === 'second')
     const saveFile = vi.fn().mockResolvedValue(undefined)
 
+    const consoleWarn = vi
+      .spyOn(console, 'warn')
+      .mockImplementation((): void => undefined)
+
     workspaceTerminalMock.service.listSessions.mockResolvedValue({
       activeSessionId: 'first',
       sessions: [
@@ -494,6 +498,10 @@ describe('WorkspaceView', () => {
       ],
     })
 
+    workspaceTerminalMock.service.setActiveSession.mockRejectedValueOnce(
+      new Error('IPC failed')
+    )
+
     vi.mocked(useEditorBuffer).mockReturnValue({
       filePath: 'src/current.ts',
       originalContent: 'original',
@@ -507,31 +515,35 @@ describe('WorkspaceView', () => {
       releaseScope: vi.fn(),
     })
 
-    render(<WorkspaceView />)
+    try {
+      render(<WorkspaceView />)
 
-    await screen.findByRole('tab', { name: 'first' })
+      await screen.findByRole('tab', { name: 'first' })
 
-    await user.click(screen.getByRole('button', { name: 'Close second' }))
-    await screen.findByRole('dialog', { name: /unsaved changes/i })
-    await user.click(screen.getByRole('button', { name: 'Save' }))
+      await user.click(screen.getByRole('button', { name: 'Close second' }))
+      await screen.findByRole('dialog', { name: /unsaved changes/i })
+      await user.click(screen.getByRole('button', { name: 'Save' }))
 
-    await waitFor(() => {
-      expect(saveFile).toHaveBeenCalled()
-    })
+      await waitFor(() => {
+        expect(saveFile).toHaveBeenCalledWith('second')
+      })
 
-    await waitFor(() => {
-      expect(screen.queryByRole('tab', { name: 'second' })).toBeNull()
-    })
+      await waitFor(() => {
+        expect(screen.queryByRole('tab', { name: 'second' })).toBeNull()
+      })
 
-    expect(screen.getByRole('tab', { name: 'first' })).toHaveAttribute(
-      'aria-selected',
-      'true'
-    )
+      expect(screen.getByRole('tab', { name: 'first' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
 
-    expect(screen.getByRole('tab', { name: 'third' })).toHaveAttribute(
-      'aria-selected',
-      'false'
-    )
+      expect(screen.getByRole('tab', { name: 'third' })).toHaveAttribute(
+        'aria-selected',
+        'false'
+      )
+    } finally {
+      consoleWarn.mockRestore()
+    }
   })
 
   test('selects the next visible session after confirming a dirty active-session close', async () => {
@@ -655,7 +667,7 @@ describe('WorkspaceView', () => {
     await user.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
-      expect(saveFile).toHaveBeenCalled()
+      expect(saveFile).toHaveBeenCalledWith('first')
     })
 
     await waitFor(() => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -247,44 +247,6 @@ export const WorkspaceView = (): ReactElement => {
   const activePaneAgentTypeForCommands =
     activePaneForCommandInputs?.agentType ?? null
 
-  const workspaceCommands = useMemo(
-    () =>
-      buildWorkspaceCommands({
-        sessions,
-        activeSessionId,
-        activePanePtyId: activePanePtyIdForCommands,
-        activePaneAgentType: activePaneAgentTypeForCommands,
-        createSession,
-        removeSession,
-        renameSession,
-        setPaneUserLabel,
-        renameAgentSession,
-        nextPaneRenameRequestId,
-        isCurrentPaneRenameRequest,
-        setActiveSessionId,
-        notifyInfo,
-      }),
-    // sessionsSignature captures every field the closures read; activity-only
-    // changes keep the signature stable so the memo (and downstream
-    // filteredResults / handler refs) do not churn during agent I/O.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      sessionsSignature,
-      activeSessionId,
-      activePanePtyIdForCommands,
-      activePaneAgentTypeForCommands,
-      createSession,
-      removeSession,
-      renameSession,
-      setPaneUserLabel,
-      nextPaneRenameRequestId,
-      isCurrentPaneRenameRequest,
-      setActiveSessionId,
-      notifyInfo,
-    ]
-  )
-  const commandPalette = useCommandPalette(workspaceCommands)
-
   const activeSession = activeSessionId
     ? sessions.find((s) => s.id === activeSessionId)
     : undefined
@@ -725,6 +687,44 @@ export const WorkspaceView = (): ReactElement => {
 
     previousSessionIdsRef.current = currentSessionIds
   }, [releaseScope, sessions])
+
+  const workspaceCommands = useMemo(
+    () =>
+      buildWorkspaceCommands({
+        sessions,
+        activeSessionId,
+        activePanePtyId: activePanePtyIdForCommands,
+        activePaneAgentType: activePaneAgentTypeForCommands,
+        createSession,
+        removeSession: handleRemoveSession,
+        renameSession,
+        setPaneUserLabel,
+        renameAgentSession,
+        nextPaneRenameRequestId,
+        isCurrentPaneRenameRequest,
+        setActiveSessionId,
+        notifyInfo,
+      }),
+    // sessionsSignature captures every field the closures read; activity-only
+    // changes keep the signature stable so the memo (and downstream
+    // filteredResults / handler refs) do not churn during agent I/O.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      sessionsSignature,
+      activeSessionId,
+      activePanePtyIdForCommands,
+      activePaneAgentTypeForCommands,
+      createSession,
+      handleRemoveSession,
+      renameSession,
+      setPaneUserLabel,
+      nextPaneRenameRequestId,
+      isCurrentPaneRenameRequest,
+      setActiveSessionId,
+      notifyInfo,
+    ]
+  )
+  const commandPalette = useCommandPalette(workspaceCommands)
 
   usePaneShortcuts({
     sessions,

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -671,6 +671,7 @@ export const WorkspaceView = (): ReactElement => {
 
       const wasActive = sessionId === activeSessionId
       removeSession(sessionId)
+      releaseScope(sessionId)
       if (wasActive) {
         claimTerminal()
       }
@@ -681,6 +682,7 @@ export const WorkspaceView = (): ReactElement => {
       activeSessionId,
       claimTerminal,
       hasUnsavedChanges,
+      releaseScope,
       removeSession,
       setActiveSessionId,
       setPendingFilePathSynced,
@@ -722,6 +724,7 @@ export const WorkspaceView = (): ReactElement => {
       }
 
       removeSession(sessionId)
+      releaseScope(sessionId)
 
       if (sessionId === activeSessionId || nextId !== undefined) {
         claimTerminal()
@@ -730,6 +733,7 @@ export const WorkspaceView = (): ReactElement => {
     [
       activeSessionId,
       claimTerminal,
+      releaseScope,
       removeSession,
       sessions,
       setActiveSessionId,
@@ -766,6 +770,7 @@ export const WorkspaceView = (): ReactElement => {
       handleRemoveSession,
       renameSession,
       setPaneUserLabel,
+      renameAgentSession,
       nextPaneRenameRequestId,
       isCurrentPaneRenameRequest,
       setActiveSessionId,

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -67,6 +67,7 @@ import { useGitStatus } from '../diff/hooks/useGitStatus'
 import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
 import { lineDelta } from '../sessions/utils/lineDelta'
+import { pickNextVisibleSessionId } from '../sessions/utils/pickNextVisibleSessionId'
 import { AGENTS, agentTypeToRegistryKey } from '../../agents/registry'
 import type { SessionStatus } from '../sessions/types'
 import {
@@ -688,6 +689,32 @@ export const WorkspaceView = (): ReactElement => {
     previousSessionIdsRef.current = currentSessionIds
   }, [releaseScope, sessions])
 
+  const removePendingSession = useCallback(
+    (sessionId: string): void => {
+      const nextId =
+        sessionId === activeSessionId
+          ? pickNextVisibleSessionId(sessions, sessionId, activeSessionId)
+          : undefined
+
+      removeSession(sessionId)
+
+      if (nextId !== undefined) {
+        setActiveSessionId(nextId)
+      }
+
+      if (sessionId === activeSessionId || nextId !== undefined) {
+        claimTerminal()
+      }
+    },
+    [
+      activeSessionId,
+      claimTerminal,
+      removeSession,
+      sessions,
+      setActiveSessionId,
+    ]
+  )
+
   const workspaceCommands = useMemo(
     () =>
       buildWorkspaceCommands({
@@ -933,10 +960,7 @@ export const WorkspaceView = (): ReactElement => {
     setSaveError(null)
 
     if (currentPendingSessionRemovalId) {
-      removeSession(currentPendingSessionRemovalId)
-      if (currentPendingSessionRemovalId === activeSessionId) {
-        claimTerminal()
-      }
+      removePendingSession(currentPendingSessionRemovalId)
       setFileError(null)
 
       return
@@ -954,10 +978,8 @@ export const WorkspaceView = (): ReactElement => {
       }
     }
   }, [
-    activeSessionId,
-    claimTerminal,
     editorBuffer,
-    removeSession,
+    removePendingSession,
     setPendingFilePathSynced,
     setPendingSessionRemovalIdSynced,
   ])
@@ -981,10 +1003,7 @@ export const WorkspaceView = (): ReactElement => {
     setSaveError(null)
 
     if (targetSessionRemovalId) {
-      removeSession(targetSessionRemovalId)
-      if (targetSessionRemovalId === activeSessionId) {
-        claimTerminal()
-      }
+      removePendingSession(targetSessionRemovalId)
       setFileError(null)
 
       return
@@ -1002,10 +1021,8 @@ export const WorkspaceView = (): ReactElement => {
       setFileError(`Failed to open file: ${message}`)
     }
   }, [
-    activeSessionId,
-    claimTerminal,
     editorBuffer,
-    removeSession,
+    removePendingSession,
     setPendingFilePathSynced,
     setPendingSessionRemovalIdSynced,
   ])

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -541,7 +541,7 @@ export const WorkspaceView = (): ReactElement => {
     []
   )
 
-  const setPendingSessionRestoreIdSynced = useCallback(
+  const setPendingSessionRestoreIdRef = useCallback(
     (value: string | null): void => {
       pendingSessionRestoreIdRef.current = value
     },
@@ -662,7 +662,7 @@ export const WorkspaceView = (): ReactElement => {
 
         setPendingFilePathSynced(null)
         setPendingSessionRemovalIdSynced(sessionId)
-        setPendingSessionRestoreIdSynced(restoreSessionId)
+        setPendingSessionRestoreIdRef(restoreSessionId)
         setSaveError(null)
         setShowUnsavedDialog(true)
 
@@ -685,7 +685,7 @@ export const WorkspaceView = (): ReactElement => {
       setActiveSessionId,
       setPendingFilePathSynced,
       setPendingSessionRemovalIdSynced,
-      setPendingSessionRestoreIdSynced,
+      setPendingSessionRestoreIdRef,
     ]
   )
 
@@ -903,7 +903,7 @@ export const WorkspaceView = (): ReactElement => {
       // If current file has unsaved changes, show dialog
       if (editorBuffer.isDirty) {
         setPendingFilePathSynced(filePath)
-        setPendingSessionRestoreIdSynced(null)
+        setPendingSessionRestoreIdRef(null)
         setShowUnsavedDialog(true)
 
         return
@@ -915,7 +915,7 @@ export const WorkspaceView = (): ReactElement => {
       editorBuffer.isDirty,
       openFileSafely,
       setPendingFilePathSynced,
-      setPendingSessionRestoreIdSynced,
+      setPendingSessionRestoreIdRef,
     ]
   )
 
@@ -928,7 +928,7 @@ export const WorkspaceView = (): ReactElement => {
     (filePath: string): void => {
       if (editorBuffer.isDirty) {
         setPendingFilePathSynced(filePath)
-        setPendingSessionRestoreIdSynced(null)
+        setPendingSessionRestoreIdRef(null)
         setShowUnsavedDialog(true)
 
         return
@@ -940,7 +940,7 @@ export const WorkspaceView = (): ReactElement => {
       editorBuffer.isDirty,
       openFileSafely,
       setPendingFilePathSynced,
-      setPendingSessionRestoreIdSynced,
+      setPendingSessionRestoreIdRef,
     ]
   )
 
@@ -991,7 +991,7 @@ export const WorkspaceView = (): ReactElement => {
     setShowUnsavedDialog(false)
     setPendingFilePathSynced(null)
     setPendingSessionRemovalIdSynced(null)
-    setPendingSessionRestoreIdSynced(null)
+    setPendingSessionRestoreIdRef(null)
     setSaveError(null)
 
     if (currentPendingSessionRemovalId) {
@@ -1020,7 +1020,7 @@ export const WorkspaceView = (): ReactElement => {
     removePendingSession,
     setPendingFilePathSynced,
     setPendingSessionRemovalIdSynced,
-    setPendingSessionRestoreIdSynced,
+    setPendingSessionRestoreIdRef,
   ])
 
   // Discard changes and open pending file.
@@ -1040,7 +1040,7 @@ export const WorkspaceView = (): ReactElement => {
     setShowUnsavedDialog(false)
     setPendingFilePathSynced(null)
     setPendingSessionRemovalIdSynced(null)
-    setPendingSessionRestoreIdSynced(null)
+    setPendingSessionRestoreIdRef(null)
     setSaveError(null)
 
     if (targetSessionRemovalId) {
@@ -1066,7 +1066,7 @@ export const WorkspaceView = (): ReactElement => {
     removePendingSession,
     setPendingFilePathSynced,
     setPendingSessionRemovalIdSynced,
-    setPendingSessionRestoreIdSynced,
+    setPendingSessionRestoreIdRef,
   ])
 
   // Cancel and stay on current file.
@@ -1083,7 +1083,7 @@ export const WorkspaceView = (): ReactElement => {
     setShowUnsavedDialog(false)
     setPendingFilePathSynced(null)
     setPendingSessionRemovalIdSynced(null)
-    setPendingSessionRestoreIdSynced(null)
+    setPendingSessionRestoreIdRef(null)
     setSaveError(null)
 
     if (
@@ -1099,7 +1099,7 @@ export const WorkspaceView = (): ReactElement => {
     setActiveSessionId,
     setPendingFilePathSynced,
     setPendingSessionRemovalIdSynced,
-    setPendingSessionRestoreIdSynced,
+    setPendingSessionRestoreIdRef,
   ])
 
   // Handle opening a diff file from AgentStatusPanel

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -671,7 +671,6 @@ export const WorkspaceView = (): ReactElement => {
 
       const wasActive = sessionId === activeSessionId
       removeSession(sessionId)
-      releaseScope(sessionId)
       if (wasActive) {
         claimTerminal()
       }
@@ -682,7 +681,6 @@ export const WorkspaceView = (): ReactElement => {
       activeSessionId,
       claimTerminal,
       hasUnsavedChanges,
-      releaseScope,
       removeSession,
       setActiveSessionId,
       setPendingFilePathSynced,
@@ -692,7 +690,9 @@ export const WorkspaceView = (): ReactElement => {
   )
 
   const previousSessionIdsRef = useRef<Set<string>>(new Set())
-  useEffect(() => {
+  // Tie editor-scope cleanup to committed session removals. Layout timing
+  // avoids a paint/input gap where a removed session can still look dirty.
+  useLayoutEffect(() => {
     const currentSessionIds = new Set(sessions.map((session) => session.id))
 
     for (const previousSessionId of previousSessionIdsRef.current) {
@@ -724,7 +724,6 @@ export const WorkspaceView = (): ReactElement => {
       }
 
       removeSession(sessionId)
-      releaseScope(sessionId)
 
       if (sessionId === activeSessionId || nextId !== undefined) {
         claimTerminal()
@@ -733,7 +732,6 @@ export const WorkspaceView = (): ReactElement => {
     [
       activeSessionId,
       claimTerminal,
-      releaseScope,
       removeSession,
       sessions,
       setActiveSessionId,

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -503,6 +503,7 @@ export const WorkspaceView = (): ReactElement => {
     string | null
   >(null)
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [isUnsavedDialogSaving, setIsUnsavedDialogSaving] = useState(false)
 
   // Live mirror of `pendingFilePath`. `handleSave` reads this AFTER its
   // saveFile() await so a Cancel/backdrop click during the in-flight
@@ -519,6 +520,7 @@ export const WorkspaceView = (): ReactElement => {
   const pendingFilePathRef = useRef<string | null>(null)
   const pendingSessionRemovalIdRef = useRef<string | null>(null)
   const pendingSessionRestoreIdRef = useRef<string | null>(null)
+  const isUnsavedDialogSavingRef = useRef(false)
 
   useEffect(() => {
     pendingFilePathRef.current = pendingFilePath
@@ -547,6 +549,12 @@ export const WorkspaceView = (): ReactElement => {
     },
     []
   )
+
+  const setUnsavedDialogSavingSynced = useCallback((value: boolean): void => {
+    isUnsavedDialogSavingRef.current = value
+    setIsUnsavedDialogSaving(value)
+  }, [])
+
   // General-purpose error banner for non-dialog file ops (direct file open,
   // async load failure inside CodeEditor, vim :w save failure).
   const [fileError, setFileError] = useState<string | null>(null)
@@ -971,7 +979,12 @@ export const WorkspaceView = (): ReactElement => {
   // on the return object), destructure { saveFile, openFile } into the
   // deps here to lock the handler identity.
   const handleSave = useCallback(async (): Promise<void> => {
+    if (isUnsavedDialogSavingRef.current) {
+      return
+    }
+
     const pendingSessionRemovalIdAtSave = pendingSessionRemovalIdRef.current
+    setUnsavedDialogSavingSynced(true)
 
     try {
       if (pendingSessionRemovalIdAtSave) {
@@ -982,18 +995,19 @@ export const WorkspaceView = (): ReactElement => {
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)
       setSaveError(`Failed to save: ${message}`)
+      setUnsavedDialogSavingSynced(false)
 
       // Keep the dialog open so the user can retry or cancel — the file
       // is still dirty and we haven't switched away.
       return
     }
 
-    // Read the pending-file path FROM THE REF after the save completes.
-    // If the user clicked the backdrop or pressed Escape during the
-    // save IPC, `handleCancel` cleared `pendingFilePath` to null and
-    // the ref reflects that. Reading the closure variable (or a
-    // capture-before-await constant) would see the stale snapshot and
-    // open the cancelled pending file anyway.
+    setUnsavedDialogSavingSynced(false)
+
+    // Read pending targets FROM THE REFS after the save completes.
+    // Cancellation is disabled while saving, but ref reads still keep
+    // this continuation aligned with any synchronous pending-action
+    // reset that happened before the save began.
     const currentPendingPath = pendingFilePathRef.current
     const currentPendingSessionRemovalId = pendingSessionRemovalIdRef.current
     const currentPendingSessionRestoreId = pendingSessionRestoreIdRef.current
@@ -1035,6 +1049,7 @@ export const WorkspaceView = (): ReactElement => {
     setPendingFilePathSynced,
     setPendingSessionRemovalIdSynced,
     setPendingSessionRestoreIdRef,
+    setUnsavedDialogSavingSynced,
   ])
 
   // Discard changes and open pending file.
@@ -1048,6 +1063,10 @@ export const WorkspaceView = (): ReactElement => {
   // wrong and could trick the user into a confirmation action on
   // the wrong file. Closing the dialog up front removes the window.
   const handleDiscard = useCallback(async (): Promise<void> => {
+    if (isUnsavedDialogSavingRef.current) {
+      return
+    }
+
     const target = pendingFilePathRef.current
     const targetSessionRemovalId = pendingSessionRemovalIdRef.current
     const targetSessionRestoreId = pendingSessionRestoreIdRef.current
@@ -1088,10 +1107,14 @@ export const WorkspaceView = (): ReactElement => {
   // CRITICAL: writes `pendingFilePathRef.current = null` synchronously
   // via `setPendingFilePathSynced` so a concurrently-running `handleSave`
   // awaiting saveFile() sees the cleared ref as soon as its microtask
-  // resumes. Without this, the useEffect-based ref mirror would only
-  // update on the next paint — after handleSave had already read the
-  // stale non-null value and opened the cancelled pending file.
+  // resumes. While a save is actively in flight the dialog disables
+  // cancellation so users cannot accidentally write the file but cancel
+  // the guarded session close/open action with no feedback.
   const handleCancel = useCallback((): void => {
+    if (isUnsavedDialogSavingRef.current) {
+      return
+    }
+
     const restoreSessionId = pendingSessionRestoreIdRef.current
 
     setShowUnsavedDialog(false)
@@ -1393,6 +1416,7 @@ export const WorkspaceView = (): ReactElement => {
         isOpen={showUnsavedDialog}
         fileName={editorBuffer.filePath ?? ''}
         errorMessage={saveError}
+        isSaving={isUnsavedDialogSaving}
         actionDescription={
           pendingSessionRemovalId ? 'closing this session' : 'switching files'
         }

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -531,7 +531,7 @@ export const WorkspaceView = (): ReactElement => {
   // WorkspaceView re-render — including each keystroke in the editor — and
   // reloads the file from disk, overwriting in-progress edits.
   const fileSystemService = useMemo(() => createFileSystemService(), [])
-  const editorBuffer = useEditorBuffer(fileSystemService)
+  const editorBuffer = useEditorBuffer(fileSystemService, activeSessionId)
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false)
   const [pendingFilePath, setPendingFilePath] = useState<string | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1208,6 +1208,17 @@ export const WorkspaceView = (): ReactElement => {
     <DockPeekButton position={dockPosition} onOpen={() => openDock()} />
   )
 
+  const pendingSessionFilePath = pendingSessionRemovalId
+    ? editorBuffer.getFilePathForScope(pendingSessionRemovalId)
+    : null
+
+  const unsavedDialogFileName = pendingSessionRemovalId
+    ? (pendingSessionFilePath ??
+      (pendingSessionRemovalId === activeSessionId
+        ? (editorBuffer.filePath ?? '')
+        : ''))
+    : (editorBuffer.filePath ?? '')
+
   return (
     <div
       ref={workspaceRef}
@@ -1414,7 +1425,7 @@ export const WorkspaceView = (): ReactElement => {
           destination the user is switching to. */}
       <UnsavedChangesDialog
         isOpen={showUnsavedDialog}
-        fileName={editorBuffer.filePath ?? ''}
+        fileName={unsavedDialogFileName}
         errorMessage={saveError}
         isSaving={isUnsavedDialogSaving}
         actionDescription={

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -772,7 +772,10 @@ export const WorkspaceView = (): ReactElement => {
       notifyInfo,
     ]
   )
-  const commandPalette = useCommandPalette(workspaceCommands)
+
+  const commandPalette = useCommandPalette(workspaceCommands, {
+    enabled: !showUnsavedDialog,
+  })
 
   usePaneShortcuts({
     sessions,

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -69,7 +69,7 @@ import { findActivePane } from '../sessions/utils/activeSessionPane'
 import { lineDelta } from '../sessions/utils/lineDelta'
 import { pickNextVisibleSessionId } from '../sessions/utils/pickNextVisibleSessionId'
 import { AGENTS, agentTypeToRegistryKey } from '../../agents/registry'
-import type { SessionStatus } from '../sessions/types'
+import type { SessionCloseResult, SessionStatus } from '../sessions/types'
 import {
   buildWorkspaceCommands,
   WORKSPACE_TAB_KEYS,
@@ -651,7 +651,7 @@ export const WorkspaceView = (): ReactElement => {
   }, [claimTerminal, createSession])
 
   const handleRemoveSession = useCallback(
-    (sessionId: string): boolean => {
+    (sessionId: string): SessionCloseResult => {
       if (hasUnsavedChanges(sessionId)) {
         const restoreSessionId =
           sessionId !== activeSessionId ? activeSessionId : null
@@ -675,7 +675,7 @@ export const WorkspaceView = (): ReactElement => {
         claimTerminal()
       }
 
-      return true
+      return undefined
     },
     [
       activeSessionId,

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -518,6 +518,7 @@ export const WorkspaceView = (): ReactElement => {
   // read and the handler would open the cancelled pending file.
   const pendingFilePathRef = useRef<string | null>(null)
   const pendingSessionRemovalIdRef = useRef<string | null>(null)
+  const pendingSessionRestoreIdRef = useRef<string | null>(null)
 
   useEffect(() => {
     pendingFilePathRef.current = pendingFilePath
@@ -536,6 +537,13 @@ export const WorkspaceView = (): ReactElement => {
     (value: string | null): void => {
       pendingSessionRemovalIdRef.current = value
       setPendingSessionRemovalId(value)
+    },
+    []
+  )
+
+  const setPendingSessionRestoreIdSynced = useCallback(
+    (value: string | null): void => {
+      pendingSessionRestoreIdRef.current = value
     },
     []
   )
@@ -645,12 +653,16 @@ export const WorkspaceView = (): ReactElement => {
   const handleRemoveSession = useCallback(
     (sessionId: string): boolean => {
       if (hasUnsavedChanges(sessionId)) {
+        const restoreSessionId =
+          sessionId !== activeSessionId ? activeSessionId : null
+
         if (sessionId !== activeSessionId) {
           setActiveSessionId(sessionId)
         }
 
         setPendingFilePathSynced(null)
         setPendingSessionRemovalIdSynced(sessionId)
+        setPendingSessionRestoreIdSynced(restoreSessionId)
         setSaveError(null)
         setShowUnsavedDialog(true)
 
@@ -673,6 +685,7 @@ export const WorkspaceView = (): ReactElement => {
       setActiveSessionId,
       setPendingFilePathSynced,
       setPendingSessionRemovalIdSynced,
+      setPendingSessionRestoreIdSynced,
     ]
   )
 
@@ -690,17 +703,25 @@ export const WorkspaceView = (): ReactElement => {
   }, [releaseScope, sessions])
 
   const removePendingSession = useCallback(
-    (sessionId: string): void => {
-      const nextId =
-        sessionId === activeSessionId
-          ? pickNextVisibleSessionId(sessions, sessionId, activeSessionId)
+    (sessionId: string, restoreSessionId: string | null): void => {
+      const restorableSessionId =
+        restoreSessionId &&
+        restoreSessionId !== sessionId &&
+        sessions.some((session) => session.id === restoreSessionId)
+          ? restoreSessionId
           : undefined
 
-      removeSession(sessionId)
+      const nextId =
+        restorableSessionId ??
+        (sessionId === activeSessionId
+          ? pickNextVisibleSessionId(sessions, sessionId, activeSessionId)
+          : undefined)
 
       if (nextId !== undefined) {
         setActiveSessionId(nextId)
       }
+
+      removeSession(sessionId)
 
       if (sessionId === activeSessionId || nextId !== undefined) {
         claimTerminal()
@@ -882,6 +903,7 @@ export const WorkspaceView = (): ReactElement => {
       // If current file has unsaved changes, show dialog
       if (editorBuffer.isDirty) {
         setPendingFilePathSynced(filePath)
+        setPendingSessionRestoreIdSynced(null)
         setShowUnsavedDialog(true)
 
         return
@@ -889,7 +911,12 @@ export const WorkspaceView = (): ReactElement => {
 
       void openFileSafely(filePath)
     },
-    [editorBuffer.isDirty, openFileSafely, setPendingFilePathSynced]
+    [
+      editorBuffer.isDirty,
+      openFileSafely,
+      setPendingFilePathSynced,
+      setPendingSessionRestoreIdSynced,
+    ]
   )
 
   // Open a test file from the activity panel. Mirrors handleFileSelect's
@@ -901,6 +928,7 @@ export const WorkspaceView = (): ReactElement => {
     (filePath: string): void => {
       if (editorBuffer.isDirty) {
         setPendingFilePathSynced(filePath)
+        setPendingSessionRestoreIdSynced(null)
         setShowUnsavedDialog(true)
 
         return
@@ -908,7 +936,12 @@ export const WorkspaceView = (): ReactElement => {
 
       void openFileSafely(filePath)
     },
-    [editorBuffer.isDirty, openFileSafely, setPendingFilePathSynced]
+    [
+      editorBuffer.isDirty,
+      openFileSafely,
+      setPendingFilePathSynced,
+      setPendingSessionRestoreIdSynced,
+    ]
   )
 
   // Save current file and open pending file.
@@ -949,6 +982,7 @@ export const WorkspaceView = (): ReactElement => {
     // open the cancelled pending file anyway.
     const currentPendingPath = pendingFilePathRef.current
     const currentPendingSessionRemovalId = pendingSessionRemovalIdRef.current
+    const currentPendingSessionRestoreId = pendingSessionRestoreIdRef.current
 
     // Current buffer is clean on disk. The dialog's job of guarding
     // the pending action is done — surface any pending-open failure via
@@ -957,10 +991,14 @@ export const WorkspaceView = (): ReactElement => {
     setShowUnsavedDialog(false)
     setPendingFilePathSynced(null)
     setPendingSessionRemovalIdSynced(null)
+    setPendingSessionRestoreIdSynced(null)
     setSaveError(null)
 
     if (currentPendingSessionRemovalId) {
-      removePendingSession(currentPendingSessionRemovalId)
+      removePendingSession(
+        currentPendingSessionRemovalId,
+        currentPendingSessionRestoreId
+      )
       setFileError(null)
 
       return
@@ -982,6 +1020,7 @@ export const WorkspaceView = (): ReactElement => {
     removePendingSession,
     setPendingFilePathSynced,
     setPendingSessionRemovalIdSynced,
+    setPendingSessionRestoreIdSynced,
   ])
 
   // Discard changes and open pending file.
@@ -997,13 +1036,15 @@ export const WorkspaceView = (): ReactElement => {
   const handleDiscard = useCallback(async (): Promise<void> => {
     const target = pendingFilePathRef.current
     const targetSessionRemovalId = pendingSessionRemovalIdRef.current
+    const targetSessionRestoreId = pendingSessionRestoreIdRef.current
     setShowUnsavedDialog(false)
     setPendingFilePathSynced(null)
     setPendingSessionRemovalIdSynced(null)
+    setPendingSessionRestoreIdSynced(null)
     setSaveError(null)
 
     if (targetSessionRemovalId) {
-      removePendingSession(targetSessionRemovalId)
+      removePendingSession(targetSessionRemovalId, targetSessionRestoreId)
       setFileError(null)
 
       return
@@ -1025,6 +1066,7 @@ export const WorkspaceView = (): ReactElement => {
     removePendingSession,
     setPendingFilePathSynced,
     setPendingSessionRemovalIdSynced,
+    setPendingSessionRestoreIdSynced,
   ])
 
   // Cancel and stay on current file.
@@ -1036,11 +1078,29 @@ export const WorkspaceView = (): ReactElement => {
   // update on the next paint — after handleSave had already read the
   // stale non-null value and opened the cancelled pending file.
   const handleCancel = useCallback((): void => {
+    const restoreSessionId = pendingSessionRestoreIdRef.current
+
     setShowUnsavedDialog(false)
     setPendingFilePathSynced(null)
     setPendingSessionRemovalIdSynced(null)
+    setPendingSessionRestoreIdSynced(null)
     setSaveError(null)
-  }, [setPendingFilePathSynced, setPendingSessionRemovalIdSynced])
+
+    if (
+      restoreSessionId &&
+      sessions.some((session) => session.id === restoreSessionId)
+    ) {
+      setActiveSessionId(restoreSessionId)
+      claimTerminal()
+    }
+  }, [
+    claimTerminal,
+    sessions,
+    setActiveSessionId,
+    setPendingFilePathSynced,
+    setPendingSessionRemovalIdSynced,
+    setPendingSessionRestoreIdSynced,
+  ])
 
   // Handle opening a diff file from AgentStatusPanel
   const handleOpenDiff = useCallback(

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -532,8 +532,13 @@ export const WorkspaceView = (): ReactElement => {
   // reloads the file from disk, overwriting in-progress edits.
   const fileSystemService = useMemo(() => createFileSystemService(), [])
   const editorBuffer = useEditorBuffer(fileSystemService, activeSessionId)
+  const { hasUnsavedChanges, releaseScope } = editorBuffer
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false)
   const [pendingFilePath, setPendingFilePath] = useState<string | null>(null)
+
+  const [pendingSessionRemovalId, setPendingSessionRemovalId] = useState<
+    string | null
+  >(null)
   const [saveError, setSaveError] = useState<string | null>(null)
 
   // Live mirror of `pendingFilePath`. `handleSave` reads this AFTER its
@@ -549,14 +554,28 @@ export const WorkspaceView = (): ReactElement => {
   // and resumes, the effect hasn't run yet, so a stale ref would be
   // read and the handler would open the cancelled pending file.
   const pendingFilePathRef = useRef<string | null>(null)
+  const pendingSessionRemovalIdRef = useRef<string | null>(null)
+
   useEffect(() => {
     pendingFilePathRef.current = pendingFilePath
   }, [pendingFilePath])
+
+  useEffect(() => {
+    pendingSessionRemovalIdRef.current = pendingSessionRemovalId
+  }, [pendingSessionRemovalId])
 
   const setPendingFilePathSynced = useCallback((value: string | null): void => {
     pendingFilePathRef.current = value
     setPendingFilePath(value)
   }, [])
+
+  const setPendingSessionRemovalIdSynced = useCallback(
+    (value: string | null): void => {
+      pendingSessionRemovalIdRef.current = value
+      setPendingSessionRemovalId(value)
+    },
+    []
+  )
   // General-purpose error banner for non-dialog file ops (direct file open,
   // async load failure inside CodeEditor, vim :w save failure).
   const [fileError, setFileError] = useState<string | null>(null)
@@ -661,15 +680,51 @@ export const WorkspaceView = (): ReactElement => {
   }, [claimTerminal, createSession])
 
   const handleRemoveSession = useCallback(
-    (sessionId: string): void => {
+    (sessionId: string): boolean => {
+      if (hasUnsavedChanges(sessionId)) {
+        if (sessionId !== activeSessionId) {
+          setActiveSessionId(sessionId)
+        }
+
+        setPendingFilePathSynced(null)
+        setPendingSessionRemovalIdSynced(sessionId)
+        setSaveError(null)
+        setShowUnsavedDialog(true)
+
+        return false
+      }
+
       const wasActive = sessionId === activeSessionId
       removeSession(sessionId)
       if (wasActive) {
         claimTerminal()
       }
+
+      return true
     },
-    [activeSessionId, claimTerminal, removeSession]
+    [
+      activeSessionId,
+      claimTerminal,
+      hasUnsavedChanges,
+      removeSession,
+      setActiveSessionId,
+      setPendingFilePathSynced,
+      setPendingSessionRemovalIdSynced,
+    ]
   )
+
+  const previousSessionIdsRef = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    const currentSessionIds = new Set(sessions.map((session) => session.id))
+
+    for (const previousSessionId of previousSessionIdsRef.current) {
+      if (!currentSessionIds.has(previousSessionId)) {
+        releaseScope(previousSessionId)
+      }
+    }
+
+    previousSessionIdsRef.current = currentSessionIds
+  }, [releaseScope, sessions])
 
   usePaneShortcuts({
     sessions,
@@ -866,14 +921,26 @@ export const WorkspaceView = (): ReactElement => {
     // capture-before-await constant) would see the stale snapshot and
     // open the cancelled pending file anyway.
     const currentPendingPath = pendingFilePathRef.current
+    const currentPendingSessionRemovalId = pendingSessionRemovalIdRef.current
 
     // Current buffer is clean on disk. The dialog's job of guarding
-    // the switch is done — surface any pending-open failure via the
-    // workspace-level banner instead of leaving the dialog stuck
-    // with a misleading "Failed to save" message.
+    // the pending action is done — surface any pending-open failure via
+    // the workspace-level banner instead of leaving the dialog stuck with
+    // a misleading "Failed to save" message.
     setShowUnsavedDialog(false)
     setPendingFilePathSynced(null)
+    setPendingSessionRemovalIdSynced(null)
     setSaveError(null)
+
+    if (currentPendingSessionRemovalId) {
+      removeSession(currentPendingSessionRemovalId)
+      if (currentPendingSessionRemovalId === activeSessionId) {
+        claimTerminal()
+      }
+      setFileError(null)
+
+      return
+    }
 
     if (currentPendingPath) {
       try {
@@ -886,7 +953,14 @@ export const WorkspaceView = (): ReactElement => {
         )
       }
     }
-  }, [editorBuffer, setPendingFilePathSynced])
+  }, [
+    activeSessionId,
+    claimTerminal,
+    editorBuffer,
+    removeSession,
+    setPendingFilePathSynced,
+    setPendingSessionRemovalIdSynced,
+  ])
 
   // Discard changes and open pending file.
   //
@@ -900,9 +974,21 @@ export const WorkspaceView = (): ReactElement => {
   // the wrong file. Closing the dialog up front removes the window.
   const handleDiscard = useCallback(async (): Promise<void> => {
     const target = pendingFilePathRef.current
+    const targetSessionRemovalId = pendingSessionRemovalIdRef.current
     setShowUnsavedDialog(false)
     setPendingFilePathSynced(null)
+    setPendingSessionRemovalIdSynced(null)
     setSaveError(null)
+
+    if (targetSessionRemovalId) {
+      removeSession(targetSessionRemovalId)
+      if (targetSessionRemovalId === activeSessionId) {
+        claimTerminal()
+      }
+      setFileError(null)
+
+      return
+    }
 
     if (!target) {
       return
@@ -915,7 +1001,14 @@ export const WorkspaceView = (): ReactElement => {
       const message = error instanceof Error ? error.message : String(error)
       setFileError(`Failed to open file: ${message}`)
     }
-  }, [editorBuffer, setPendingFilePathSynced])
+  }, [
+    activeSessionId,
+    claimTerminal,
+    editorBuffer,
+    removeSession,
+    setPendingFilePathSynced,
+    setPendingSessionRemovalIdSynced,
+  ])
 
   // Cancel and stay on current file.
   //
@@ -928,8 +1021,9 @@ export const WorkspaceView = (): ReactElement => {
   const handleCancel = useCallback((): void => {
     setShowUnsavedDialog(false)
     setPendingFilePathSynced(null)
+    setPendingSessionRemovalIdSynced(null)
     setSaveError(null)
-  }, [setPendingFilePathSynced])
+  }, [setPendingFilePathSynced, setPendingSessionRemovalIdSynced])
 
   // Handle opening a diff file from AgentStatusPanel
   const handleOpenDiff = useCallback(
@@ -1208,6 +1302,9 @@ export const WorkspaceView = (): ReactElement => {
         isOpen={showUnsavedDialog}
         fileName={editorBuffer.filePath ?? ''}
         errorMessage={saveError}
+        actionDescription={
+          pendingSessionRemovalId ? 'closing this session' : 'switching files'
+        }
         onSave={() => {
           void handleSave()
         }}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -947,7 +947,9 @@ export const WorkspaceView = (): ReactElement => {
     ]
   )
 
-  // Save current file and open pending file.
+  // Save the guarded buffer, then continue the pending file switch or
+  // session close. Session closes pass an explicit scope so a failed
+  // active-session IPC switch cannot make Save write the wrong tab.
   //
   // Use TWO separate try/catch blocks so save-failure and open-failure
   // emit accurate messages. Previously a single try/catch reported a
@@ -966,8 +968,14 @@ export const WorkspaceView = (): ReactElement => {
   // on the return object), destructure { saveFile, openFile } into the
   // deps here to lock the handler identity.
   const handleSave = useCallback(async (): Promise<void> => {
+    const pendingSessionRemovalIdAtSave = pendingSessionRemovalIdRef.current
+
     try {
-      await editorBuffer.saveFile()
+      if (pendingSessionRemovalIdAtSave) {
+        await editorBuffer.saveFile(pendingSessionRemovalIdAtSave)
+      } else {
+        await editorBuffer.saveFile()
+      }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)
       setSaveError(`Failed to save: ${message}`)

--- a/src/features/workspace/commands/buildWorkspaceCommands.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.ts
@@ -1,4 +1,4 @@
-import type { Session } from '../../sessions/types'
+import type { Session, SessionCloseResult } from '../../sessions/types'
 import { validateTitle } from '../../sessions/utils/sanitizeTitle'
 import { isExpectedLocalOnlyRenameFailure } from '../../sessions/utils/agentRenameErrors'
 import type { Command } from '../../command-palette/registry/types'
@@ -28,7 +28,7 @@ export interface WorkspaceCommandDeps {
   activePanePtyId: string | null
   activePaneAgentType?: Session['agentType'] | null
   createSession: () => void
-  removeSession: (id: string) => boolean | void
+  removeSession: (id: string) => SessionCloseResult
   renameSession: (id: string, name: string) => void
   /**
    * Set a per-pane user label, written by `:rename-pane`. In-memory only;

--- a/src/features/workspace/commands/buildWorkspaceCommands.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.ts
@@ -28,7 +28,7 @@ export interface WorkspaceCommandDeps {
   activePanePtyId: string | null
   activePaneAgentType?: Session['agentType'] | null
   createSession: () => void
-  removeSession: (id: string) => void
+  removeSession: (id: string) => boolean | void
   renameSession: (id: string, name: string) => void
   /**
    * Set a per-pane user label, written by `:rename-pane`. In-memory only;

--- a/src/features/workspace/components/SessionsView.tsx
+++ b/src/features/workspace/components/SessionsView.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 import { List } from '../../sessions/components/List'
-import type { Session } from '../../sessions/types'
+import type { Session, SessionCloseResult } from '../../sessions/types'
 
 export interface SessionsViewProps {
   hidden?: boolean
@@ -8,7 +8,7 @@ export interface SessionsViewProps {
   activeSessionId: string | null
   onSessionClick: (id: string) => void
   onCreateSession: () => void
-  onRemoveSession: (id: string) => void
+  onRemoveSession: (id: string) => SessionCloseResult
   onRenameSession: (id: string, name: string) => void
   onReorderSessions: (reordered: Session[]) => void
 }

--- a/tests/e2e/agent/wdio.conf.ts
+++ b/tests/e2e/agent/wdio.conf.ts
@@ -8,11 +8,16 @@ import {
 } from '../shared/electron-app.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const cacheDir = path.resolve(
+  process.env.RUNNER_TEMP ?? path.resolve(__dirname, '..', '.wdio-cache'),
+  'agent'
+)
 
 export const config: WebdriverIO.Config = {
   runner: 'local',
   framework: 'mocha',
   reporters: ['spec'],
+  cacheDir,
 
   specs: [path.resolve(__dirname, 'specs/**/*.spec.ts')],
   maxInstances: 1,

--- a/tests/e2e/core/wdio.conf.ts
+++ b/tests/e2e/core/wdio.conf.ts
@@ -8,11 +8,16 @@ import {
 } from '../shared/electron-app.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const cacheDir = path.resolve(
+  process.env.RUNNER_TEMP ?? path.resolve(__dirname, '..', '.wdio-cache'),
+  'core'
+)
 
 export const config: WebdriverIO.Config = {
   runner: 'local',
   framework: 'mocha',
   reporters: ['spec'],
+  cacheDir,
 
   specs: [path.resolve(__dirname, 'specs/**/*.spec.ts')],
   maxInstances: 1,

--- a/tests/e2e/terminal/wdio.conf.ts
+++ b/tests/e2e/terminal/wdio.conf.ts
@@ -8,11 +8,16 @@ import {
 } from '../shared/electron-app.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const cacheDir = path.resolve(
+  process.env.RUNNER_TEMP ?? path.resolve(__dirname, '..', '.wdio-cache'),
+  'terminal'
+)
 
 export const config: WebdriverIO.Config = {
   runner: 'local',
   framework: 'mocha',
   reporters: ['spec'],
+  cacheDir,
 
   specs: [path.resolve(__dirname, 'specs/**/*.spec.ts')],
   maxInstances: 1,


### PR DESCRIPTION
## Summary

- Scope `useEditorBuffer` state by active workspace session so opened files do not bleed across session switches.
- Preserve the existing unscoped default for non-session callers while keeping per-scope open-file race guards.
- Add regression coverage for hook-level scoped buffers and WorkspaceView active-session wiring.

## Root cause

`WorkspaceView` owned a single editor buffer instance and reused it for every session. When a user opened a file in one session and switched to another, the dock received the same selected file/content state, so the editor looked like files stayed open globally.

## Impact

Each session now sees its own editor buffer. Switching to a session with no opened file shows the empty editor state, and switching back restores that session's opened file/content.

## Test plan

- [x] `npm run type-check`
- [x] `npx eslint src/features/editor/hooks/useEditorBuffer.ts src/features/editor/hooks/useEditorBuffer.test.ts src/features/workspace/WorkspaceView.tsx src/features/workspace/WorkspaceView.test.tsx`
- [x] `npm test -- --run src/features/editor/hooks/useEditorBuffer.test.ts src/features/workspace/WorkspaceView.test.tsx`
- [x] `npm test -- --run src/features/workspace/WorkspaceView.integration.test.tsx`