### PR TITLE
feat(diff): inline review comments to active agent pane (PR4 of 4)

### DIFF
--- a/crates/backend/src/git/mod.rs
+++ b/crates/backend/src/git/mod.rs
@@ -660,6 +660,11 @@ pub struct GetGitDiffResponse {
     pub new_text: String,
     /// The raw unified-diff text. Reused by PR2's `extractHunkPatch()`.
     pub raw_diff: String,
+    /// Absolute path of the git repository toplevel (canonicalized). Empty
+    /// when `cwd` is not inside a git repo. The frontend joins this with the
+    /// repo-root-relative file path to build an absolute reference an agent
+    /// can resolve regardless of its own cwd (PR4 inline-feedback dispatch).
+    pub repo_root: String,
 }
 
 fn raw_diff_file_header_has(raw_diff: &str, marker: &str) -> bool {
@@ -1429,6 +1434,7 @@ pub(crate) async fn get_git_diff_inner(
             old_text: String::new(),
             new_text: String::new(),
             raw_diff: String::new(),
+            repo_root: String::new(),
         });
     }
 
@@ -1580,6 +1586,7 @@ pub(crate) async fn get_git_diff_inner(
         old_text,
         new_text,
         raw_diff,
+        repo_root: canonical_toplevel.to_string_lossy().into_owned(),
     })
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react'
 import { WorkerPoolContextProvider } from '@pierre/diffs/react'
 import { WorkspaceView } from './features/workspace/WorkspaceView'
+import { InlineCommentDemo } from './features/diff/demo/InlineCommentDemo'
 
 // Pierre's worker entry is exposed as a dedicated package export so Vite
 // bundles it via `new Worker(url, ...)` with the worker config in
@@ -23,12 +24,19 @@ const highlighterOptions = {
   theme: 'pierre-dark' as const,
 }
 
+// Dev-only gate for the PR4 inline-comment gutter demo (spec §7). Launch with
+// `npm run dev` then open `?demo=inline-comments`. Guarded by `import.meta.env.DEV`
+// so it can never render in a production build.
+const isInlineCommentDemo = (): boolean =>
+  import.meta.env.DEV &&
+  new URLSearchParams(window.location.search).get('demo') === 'inline-comments'
+
 const App = (): ReactElement => (
   <WorkerPoolContextProvider
     poolOptions={poolOptions}
     highlighterOptions={highlighterOptions}
   >
-    <WorkspaceView />
+    {isInlineCommentDemo() ? <InlineCommentDemo /> : <WorkspaceView />}
   </WorkerPoolContextProvider>
 )
 

--- a/src/bindings/GetGitDiffResponse.ts
+++ b/src/bindings/GetGitDiffResponse.ts
@@ -22,4 +22,11 @@ export type GetGitDiffResponse = {
    * The raw unified-diff text. Reused by PR2's `extractHunkPatch()`.
    */
   rawDiff: string
+  /**
+   * Absolute path of the git repository toplevel (canonicalized). Empty
+   * when `cwd` is not inside a git repo. The frontend joins this with the
+   * repo-root-relative file path to build an absolute reference an agent
+   * can resolve regardless of its own cwd (PR4 inline-feedback dispatch).
+   */
+  repoRoot: string
 }

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -1813,7 +1813,7 @@ describe('DiffPanelContent', () => {
       )
     })
 
-    test('initial render: selectedLines derived from hunk 0 (additions)', (): void => {
+    test('initial render: no persistent hunk selection (gutter + follows hover)', (): void => {
       render(
         <DiffPanelContent
           cwd="/repo"
@@ -1822,10 +1822,13 @@ describe('DiffPanelContent', () => {
         />
       )
 
+      // PR4: the focused-hunk selection is only a transient flash on prev/next
+      // navigation. There is no persistent selection on load — otherwise Pierre
+      // would pin the comment-gutter "+" to the focused hunk instead of letting
+      // it follow the mouse.
       const diff = screen.getByTestId('multi-file-diff')
-      expect(diff.getAttribute('data-selected-lines-start')).toBe('1')
-      expect(diff.getAttribute('data-selected-lines-end')).toBe('3')
-      expect(diff.getAttribute('data-selected-lines-side')).toBe('additions')
+      expect(diff.getAttribute('data-selected-lines-start')).toBeNull()
+      expect(diff.getAttribute('data-selected-lines-side')).toBeNull()
     })
 
     test('counter shows 1/3 on initial render', (): void => {
@@ -2043,14 +2046,10 @@ describe('DiffPanelContent', () => {
       )
 
       // Index 2 clamps to 1: counter is the valid "2/2", never the invalid "3/2".
+      // (The focused hunk now drives staging via the counter/index, not a
+      // persistent Pierre selection — see the transient nav-flash design.)
       expect(screen.getByLabelText(/hunk 2\/2/i)).toBeInTheDocument()
       expect(screen.queryByLabelText(/hunk 3\/2/i)).not.toBeInTheDocument()
-
-      // focusedHunk resolves to the now-last hunk (index 1) — selectedLines is
-      // non-null, so per-hunk staging is not silently blocked.
-      const diff = screen.getByTestId('multi-file-diff')
-      expect(diff.getAttribute('data-selected-lines-start')).toBe('20')
-      expect(diff.getAttribute('data-selected-lines-side')).toBe('additions')
     })
   })
 

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -24,6 +24,7 @@ import type { GitService } from '../services/gitService'
 import * as gitServiceModule from '../services/gitService'
 import * as pierreAdapterModule from '../services/pierreAdapter'
 import type { MockInstance } from 'vitest'
+import type { PaneCandidate } from '../services/activePanePicker'
 
 // Mock the hooks
 vi.mock('../hooks/useGitStatus')
@@ -71,15 +72,46 @@ vi.mock('@pierre/diffs/react', () => ({
     newFile,
     options,
     selectedLines = undefined,
+    lineAnnotations = undefined,
+    renderGutterUtility = undefined,
+    renderAnnotation = undefined,
   }: {
     oldFile: { name: string; contents: string }
     newFile: { name: string; contents: string }
-    options: { diffStyle?: string; theme?: string; lineDiffType?: string }
+    options: {
+      diffStyle?: string
+      theme?: string
+      lineDiffType?: string
+      enableGutterUtility?: boolean
+    }
     selectedLines?: {
       start: number
       end: number
       side?: string
     } | null
+    lineAnnotations?: {
+      lineNumber: number
+      side: string
+      metadata: {
+        id: string
+        text: string
+        author: string
+        createdAt: number
+      }
+    }[]
+    renderGutterUtility?: (
+      getHovered: () => { lineNumber: number; side: string }
+    ) => ReactElement
+    renderAnnotation?: (a: {
+      lineNumber: number
+      side: string
+      metadata: {
+        id: string
+        text: string
+        author: string
+        createdAt: number
+      }
+    }) => ReactElement
   }): ReactElement => (
     <div
       data-testid="multi-file-diff"
@@ -98,6 +130,20 @@ vi.mock('@pierre/diffs/react', () => ({
       }
       data-selected-lines-side={selectedLines?.side ?? undefined}
     >
+      {renderGutterUtility != null ? (
+        <div data-testid="gutter-utility-slot">
+          {renderGutterUtility(() => ({ lineNumber: 1, side: 'additions' }))}
+        </div>
+      ) : null}
+      {lineAnnotations != null && renderAnnotation != null ? (
+        <div data-testid="annotation-slot">
+          {lineAnnotations.map((annotation, index) => (
+            <div key={annotation.metadata.id ?? index}>
+              {renderAnnotation(annotation)}
+            </div>
+          ))}
+        </div>
+      ) : null}
       MultiFileDiff stub
     </div>
   ),
@@ -1996,6 +2042,202 @@ describe('DiffPanelContent', () => {
       const diff = screen.getByTestId('multi-file-diff')
       expect(diff.getAttribute('data-selected-lines-start')).toBe('20')
       expect(diff.getAttribute('data-selected-lines-side')).toBe('additions')
+    })
+  })
+
+  describe('inline review comments', () => {
+    const inlineFileDiff: FileDiff = {
+      filePath: 'src/foo.ts',
+      oldPath: 'src/foo.ts',
+      newPath: 'src/foo.ts',
+      hunks: [
+        {
+          id: 'hunk-0',
+          header: '@@ -1,3 +1,3 @@',
+          oldStart: 1,
+          oldLines: 3,
+          newStart: 1,
+          newLines: 3,
+          lines: [
+            { type: 'context', content: 'alpha' },
+            { type: 'added', content: 'beta' },
+            { type: 'context', content: 'gamma' },
+          ],
+        },
+      ],
+    }
+
+    beforeEach(() => {
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: [{ path: 'src/foo.ts', status: 'modified', staged: false }],
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      })
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: inlineFileDiff,
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText: 'new',
+          rawDiff: '',
+        })
+      )
+    })
+
+    test('clicking the gutter + opens a composer and submitting adds an annotation rendered via renderAnnotation', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const gutterSlot = screen.getByTestId('gutter-utility-slot')
+
+      const addButton = within(gutterSlot).getByRole('button', {
+        name: 'Add comment on this line',
+      })
+
+      await user.click(addButton)
+
+      const dialog = screen.getByRole('dialog', { name: /Comment on line/ })
+      const textarea = within(dialog).getByPlaceholderText('Request change')
+
+      await user.type(textarea, 'Great change!')
+      await user.keyboard('{Enter}')
+
+      expect(
+        await screen.findByRole('button', { name: /finish feedback \(1\)/i })
+      ).toBeInTheDocument()
+
+      const annotationSlot = screen.getByTestId('annotation-slot')
+      expect(
+        within(annotationSlot).getByText('Great change!')
+      ).toBeInTheDocument()
+    })
+
+    test('onDiscardFeedback (Discard feedback chip) clears the batch', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const gutterSlot = screen.getByTestId('gutter-utility-slot')
+
+      const addButton = within(gutterSlot).getByRole('button', {
+        name: 'Add comment on this line',
+      })
+
+      await user.click(addButton)
+
+      const dialog = screen.getByRole('dialog', { name: /Comment on line/ })
+      const textarea = within(dialog).getByPlaceholderText('Request change')
+
+      await user.type(textarea, 'Great change!')
+      await user.keyboard('{Enter}')
+
+      expect(
+        await screen.findByRole('button', { name: /finish feedback \(1\)/i })
+      ).toBeInTheDocument()
+
+      await user.click(
+        screen.getByRole('button', { name: /discard feedback/i })
+      )
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('button', { name: /finish feedback/i })
+        ).not.toBeInTheDocument()
+      )
+
+      expect(screen.queryByText('Great change!')).not.toBeInTheDocument()
+    })
+
+    test('Finish with one running candidate dispatches via writePty and clears the batch', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const writePty = vi.fn().mockResolvedValue(undefined)
+
+      const candidate: PaneCandidate = {
+        paneId: 'pane-1',
+        ptyId: 'pty-1',
+        tabName: 'Tab 1',
+        agentLabel: 'Claude Code',
+        cwd: '/repo',
+        status: 'running',
+        isFocused: true,
+      }
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackDispatch={{
+            candidates: [candidate],
+            writePty,
+          }}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const gutterSlot = screen.getByTestId('gutter-utility-slot')
+
+      const addButton = within(gutterSlot).getByRole('button', {
+        name: 'Add comment on this line',
+      })
+
+      await user.click(addButton)
+
+      const dialog = screen.getByRole('dialog', { name: /Comment on line/ })
+      const textarea = within(dialog).getByPlaceholderText('Request change')
+
+      await user.type(textarea, 'Great change!')
+      await user.keyboard('{Enter}')
+
+      expect(
+        await screen.findByRole('button', { name: /finish feedback \(1\)/i })
+      ).toBeInTheDocument()
+
+      await user.click(
+        screen.getByRole('button', { name: /finish feedback \(1\)/i })
+      )
+
+      const popover = await screen.findByRole('dialog', {
+        name: 'Finish feedback',
+      })
+      expect(popover).toHaveTextContent(/Send 1 comment/)
+
+      await user.click(within(popover).getByRole('button', { name: 'Confirm' }))
+
+      await waitFor(() => expect(writePty).toHaveBeenCalledTimes(1))
+
+      const [, payload] = writePty.mock.calls[0]
+      expect(typeof payload).toBe('string')
+      expect(payload as string).toContain('\x1b[200~')
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('button', { name: /finish feedback/i })
+        ).not.toBeInTheDocument()
+      )
     })
   })
 })

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -23,6 +23,7 @@ import {
 import type { GitService } from '../services/gitService'
 import * as gitServiceModule from '../services/gitService'
 import * as pierreAdapterModule from '../services/pierreAdapter'
+import * as useFeedbackBatchModule from '../hooks/useFeedbackBatch'
 import type { MockInstance } from 'vitest'
 import type { PaneCandidate } from '../services/activePanePicker'
 
@@ -2238,6 +2239,58 @@ describe('DiffPanelContent', () => {
           screen.queryByRole('button', { name: /finish feedback/i })
         ).not.toBeInTheDocument()
       )
+    })
+
+    test('preserves the composer draft and shows a notification when the feedback cap is reached', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const addAnnotationSpy = vi.fn().mockReturnValue('cap-reached')
+
+      const spy = vi
+        .spyOn(useFeedbackBatchModule, 'useFeedbackBatch')
+        .mockReturnValue({
+          batch: new Map(),
+          annotationsForFile: () => [],
+          addAnnotation: addAnnotationSpy,
+          updateAnnotation: vi.fn(),
+          removeAnnotation: vi.fn(),
+          clearBatch: vi.fn(),
+          totalAnnotations: () => 50,
+        })
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const gutterSlot = screen.getByTestId('gutter-utility-slot')
+
+      const addButton = within(gutterSlot).getByRole('button', {
+        name: 'Add comment on this line',
+      })
+
+      await user.click(addButton)
+
+      const dialog = screen.getByRole('dialog', { name: /Comment on line/ })
+      const textarea = within(dialog).getByPlaceholderText('Request change')
+
+      await user.type(textarea, 'Draft comment')
+      await user.keyboard('{Enter}')
+
+      expect(addAnnotationSpy).toHaveBeenCalledTimes(1)
+      expect(
+        screen.getByRole('dialog', { name: /Comment on line/ })
+      ).toBeInTheDocument()
+
+      expect(await screen.findByRole('status')).toHaveTextContent(
+        'Feedback limit reached'
+      )
+
+      spy.mockRestore()
     })
   })
 })

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -163,6 +163,7 @@ const fileDiffMock = ({
   oldText = '',
   newText = '',
   rawDiff = '',
+  repoRoot = '/repo',
 }: {
   diff: FileDiff | null
   loading: boolean
@@ -170,6 +171,7 @@ const fileDiffMock = ({
   oldText?: string
   newText?: string
   rawDiff?: string
+  repoRoot?: string
 }): UseFileDiffReturn => ({
   response:
     diff === null
@@ -180,6 +182,7 @@ const fileDiffMock = ({
           oldText,
           newText,
           rawDiff,
+          repoRoot,
         },
   diff,
   loading,
@@ -1537,6 +1540,7 @@ describe('DiffPanelContent', () => {
           oldText: '',
           newText: '',
           rawDiff: hunkRawDiff,
+          repoRoot: '/repo',
         },
         diff: hunkFileDiff,
         loading: false,
@@ -1581,6 +1585,7 @@ describe('DiffPanelContent', () => {
           oldText: '',
           newText: '',
           rawDiff: hunkRawDiff,
+          repoRoot: '/repo',
         },
         diff: hunkFileDiff,
         loading: false,
@@ -1619,6 +1624,7 @@ describe('DiffPanelContent', () => {
           oldText: '',
           newText: '',
           rawDiff: '',
+          repoRoot: '/repo',
         },
         diff: hunkFileDiff,
         loading: false,
@@ -1656,6 +1662,7 @@ describe('DiffPanelContent', () => {
           oldText: '',
           newText: '',
           rawDiff: hunkRawDiff,
+          repoRoot: '/repo',
         },
         diff: hunkFileDiff,
         loading: false,
@@ -1708,6 +1715,7 @@ describe('DiffPanelContent', () => {
           oldText: '',
           newText: '',
           rawDiff: hunkRawDiff,
+          repoRoot: '/repo',
         },
         diff: hunkFileDiff,
         loading: false,
@@ -2233,6 +2241,9 @@ describe('DiffPanelContent', () => {
       const [, payload] = writePty.mock.calls[0]
       expect(typeof payload).toBe('string')
       expect(payload as string).toContain('\x1b[200~')
+      // P1 fix: the dispatched reference is an ABSOLUTE path (repoRoot joined
+      // with the repo-relative file path), so an agent in any cwd resolves it.
+      expect(payload as string).toContain('/repo/')
 
       await waitFor(() =>
         expect(

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -285,12 +285,27 @@ export const DiffPanelContent = ({
   // previous workspace do not leak into the new one.
   const previousCwdRef = useRef(cwd)
 
+  // Last non-empty git repo root seen for the current cwd. `response.repoRoot`
+  // goes transiently null whenever the user selects another file (useFileDiff
+  // clears `response` while the next diff loads or if it errors); without this,
+  // an in-flight feedback batch sent during that window would fall back to
+  // repo-relative paths and mis-resolve for agents in a repo subdirectory.
+  // Reset on cwd change below (a new repo invalidates the old root).
+  const lastRepoRootRef = useRef('')
+
   useEffect(() => {
     if (previousCwdRef.current !== cwd) {
       previousCwdRef.current = cwd
+      lastRepoRootRef.current = ''
       feedback.clearBatch()
     }
   }, [cwd, feedback, feedback.clearBatch])
+
+  useEffect(() => {
+    if (response?.repoRoot) {
+      lastRepoRootRef.current = response.repoRoot
+    }
+  }, [response])
 
   // Composer target state: which line currently has an open composer.
   // `editId` set => editing an existing comment in place; absent => a new
@@ -415,7 +430,12 @@ export const DiffPanelContent = ({
         // entries share one repo (the batch is cleared on cwd change), so the
         // current diff's repoRoot applies to every file. Falls back to the
         // repo-relative path if the root is unavailable (not in a git repo).
-        const repoRoot = response?.repoRoot ?? ''
+        // Prefer the current diff's root; fall back to the last-known root when
+        // `response` is transiently null (file-switch loading/error) so an
+        // in-flight batch keeps absolute paths. The empty-string (non-repo)
+        // case needs no fallback — the ref is empty there too — so `??` (null/
+        // undefined only) is exactly right.
+        const repoRoot = response?.repoRoot ?? lastRepoRootRef.current
         const entries: DispatchEntry[] = []
         for (const [key, annotations] of feedback.batch) {
           const firstSep = key.indexOf('::')

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -279,6 +279,14 @@ export const DiffPanelContent = ({
   const { message: notifyMessage, notifyInfo } = useNotifyInfo()
 
   // Inline review comment batch state.
+  //
+  // KNOWN LIMITATION (deferred — tracked in #307; part of the workspace-layer
+  // refactor #306): DockPanel conditionally mounts DiffPanelContent only while
+  // the diff tab is active and unmounts it on dock close, so leaving the diff
+  // tab before Finish/Discard tears this component down and silently drops an
+  // unsent batch. The fix is to hoist the batch (and its cwd-invalidation)
+  // above the dock lifecycle; deferred here to avoid a risky partial lift that
+  // could leak stale comments across cwd changes.
   const feedback = useFeedbackBatch()
 
   // Clear the feedback batch when cwd changes so stale comments from a
@@ -437,13 +445,18 @@ export const DiffPanelContent = ({
         // undefined only) is exactly right.
         const repoRoot = response?.repoRoot ?? lastRepoRootRef.current
         const entries: DispatchEntry[] = []
+        // batchKey is `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`.
+        // Slice off the cwd prefix, then the trailing staged token, leaving the
+        // file path in between. The staged flag rides into the payload so an
+        // `MM` file (staged + unstaged both commented) stays disambiguated.
         for (const [key, annotations] of feedback.batch) {
           const firstSep = key.indexOf('::')
           const remainder = key.slice(firstSep + 2)
           const lastSep = remainder.lastIndexOf('::')
           const relPath = remainder.slice(0, lastSep)
+          const staged = remainder.slice(lastSep + 2) === 'staged'
           const filePath = repoRoot ? `${repoRoot}/${relPath}` : relPath
-          entries.push({ filePath, annotations })
+          entries.push({ filePath, staged, annotations })
         }
 
         try {

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -33,6 +33,7 @@ import type { ChangedFile, SelectedDiffFile } from '../types'
 import {
   useFeedbackBatch,
   parseBatchKey,
+  DRAFT_ID,
   type ReviewComment,
 } from '../hooks/useFeedbackBatch'
 import { ReviewCommentComposer } from './ReviewCommentComposer'
@@ -45,6 +46,7 @@ import {
 import {
   resolveCandidatePanes,
   type PaneCandidate,
+  type FeedbackDispatchTarget,
 } from '../services/activePanePicker'
 
 // Pierre option subtypes — derived from `BaseDiffOptions` (rather than typed as
@@ -90,18 +92,11 @@ interface DiffPanelContentBaseProps {
   /** Optional shared git status from a parent-level watcher subscription */
   gitStatus?: UseGitStatusReturn
   /** Optional feedback dispatch target for inline review comments */
-  feedbackDispatch?: {
-    candidates: PaneCandidate[]
-    writePty: (ptyId: string, data: string) => Promise<void>
-  }
+  feedbackDispatch?: FeedbackDispatchTarget
 }
 
 export type DiffPanelContentProps = DiffPanelContentBaseProps &
   DiffPanelSelectionControl
-
-// Sentinel id marking the transient "draft" annotation that renders the
-// composer inline before a real comment exists.
-const DRAFT_ID = '__draft__'
 
 // Monotonic id source. A module counter keeps comment ids stable + unique
 // without reaching for Date.now()/Math.random() in render.
@@ -1134,15 +1129,9 @@ export const DiffPanelContent = ({
             />
           ) : null}
         </div>
-        {/*
-          STALE-BRANCH NOTE: main adds `thin-scrollbar` here via #293 (merged
-          after this branch diverged), so it was never present to "remove" — the
-          Claude review on #301 flagged it from the stale diff. Keep
-          `thin-scrollbar` on this className when reconciling with main.
-        */}
         <div
           data-testid="diff-scroll-body"
-          className="min-h-0 flex-1 overflow-auto"
+          className="thin-scrollbar min-h-0 flex-1 overflow-auto"
         >
           {diffError ? (
             <ErrorCard message={diffError.message} />

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -30,7 +30,11 @@ import { createGitService } from '../services/gitService'
 import { enqueuePoolWrite } from '../services/workerPoolWrites'
 import { useNotifyInfo } from '../../workspace/hooks/useNotifyInfo'
 import type { ChangedFile, SelectedDiffFile } from '../types'
-import { useFeedbackBatch, type ReviewComment } from '../hooks/useFeedbackBatch'
+import {
+  useFeedbackBatch,
+  parseBatchKey,
+  type ReviewComment,
+} from '../hooks/useFeedbackBatch'
 import { ReviewCommentComposer } from './ReviewCommentComposer'
 import { ReviewCommentRow } from './ReviewCommentRow'
 import { FinishFeedbackPopover } from './FinishFeedbackPopover'
@@ -288,6 +292,11 @@ export const DiffPanelContent = ({
   // above the dock lifecycle; deferred here to avoid a risky partial lift that
   // could leak stale comments across cwd changes.
   const feedback = useFeedbackBatch()
+  // Destructured so the cwd-clear effect can depend on the stable `clearBatch`
+  // identity (memoized, empty deps) rather than the whole `feedback` object —
+  // which is a fresh reference each render and would re-fire the effect every
+  // render (the if-guard makes it a no-op, but it is needless work).
+  const { clearBatch } = feedback
 
   // Clear the feedback batch when cwd changes so stale comments from a
   // previous workspace do not leak into the new one.
@@ -305,9 +314,9 @@ export const DiffPanelContent = ({
     if (previousCwdRef.current !== cwd) {
       previousCwdRef.current = cwd
       lastRepoRootRef.current = ''
-      feedback.clearBatch()
+      clearBatch()
     }
-  }, [cwd, feedback, feedback.clearBatch])
+  }, [cwd, clearBatch])
 
   useEffect(() => {
     if (response?.repoRoot) {
@@ -445,16 +454,12 @@ export const DiffPanelContent = ({
         // undefined only) is exactly right.
         const repoRoot = response?.repoRoot ?? lastRepoRootRef.current
         const entries: DispatchEntry[] = []
-        // batchKey is `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`.
-        // Slice off the cwd prefix, then the trailing staged token, leaving the
-        // file path in between. The staged flag rides into the payload so an
-        // `MM` file (staged + unstaged both commented) stays disambiguated.
+        // parseBatchKey is the single source of truth for the key format (it
+        // lives next to makeBatchKey in useFeedbackBatch). The staged flag rides
+        // into the payload so an `MM` file (staged + unstaged both commented)
+        // stays disambiguated.
         for (const [key, annotations] of feedback.batch) {
-          const firstSep = key.indexOf('::')
-          const remainder = key.slice(firstSep + 2)
-          const lastSep = remainder.lastIndexOf('::')
-          const relPath = remainder.slice(0, lastSep)
-          const staged = remainder.slice(lastSep + 2) === 'staged'
+          const { filePath: relPath, staged } = parseBatchKey(key)
           const filePath = repoRoot ? `${repoRoot}/${relPath}` : relPath
           entries.push({ filePath, staged, annotations })
         }
@@ -1129,6 +1134,12 @@ export const DiffPanelContent = ({
             />
           ) : null}
         </div>
+        {/*
+          STALE-BRANCH NOTE: main adds `thin-scrollbar` here via #293 (merged
+          after this branch diverged), so it was never present to "remove" — the
+          Claude review on #301 flagged it from the stale diff. Keep
+          `thin-scrollbar` on this className when reconciling with main.
+        */}
         <div
           data-testid="diff-scroll-body"
           className="min-h-0 flex-1 overflow-auto"

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -9,7 +9,9 @@ import {
 } from 'react'
 import { MultiFileDiff, useWorkerPool } from '@pierre/diffs/react'
 import type {
+  AnnotationSide,
   BaseDiffOptions,
+  DiffLineAnnotation,
   DiffsThemeNames,
   SelectedLineRange,
 } from '@pierre/diffs'
@@ -28,6 +30,18 @@ import { createGitService } from '../services/gitService'
 import { enqueuePoolWrite } from '../services/workerPoolWrites'
 import { useNotifyInfo } from '../../workspace/hooks/useNotifyInfo'
 import type { ChangedFile, SelectedDiffFile } from '../types'
+import { useFeedbackBatch, type ReviewComment } from '../hooks/useFeedbackBatch'
+import { ReviewCommentComposer } from './ReviewCommentComposer'
+import { ReviewCommentRow } from './ReviewCommentRow'
+import { FinishFeedbackPopover } from './FinishFeedbackPopover'
+import {
+  dispatchFeedbackBatch,
+  type DispatchEntry,
+} from '../services/feedbackDispatch'
+import {
+  resolveCandidatePanes,
+  type PaneCandidate,
+} from '../services/activePanePicker'
 
 // Pierre option subtypes — derived from `BaseDiffOptions` (rather than typed as
 // the raw enum literals) so a Pierre version bump that widens or renames any
@@ -71,10 +85,26 @@ interface DiffPanelContentBaseProps {
   cwd?: string
   /** Optional shared git status from a parent-level watcher subscription */
   gitStatus?: UseGitStatusReturn
+  /** Optional feedback dispatch target for inline review comments */
+  feedbackDispatch?: {
+    candidates: PaneCandidate[]
+    writePty: (ptyId: string, data: string) => Promise<void>
+  }
 }
 
 export type DiffPanelContentProps = DiffPanelContentBaseProps &
   DiffPanelSelectionControl
+
+// Sentinel id marking the transient "draft" annotation that renders the
+// composer inline before a real comment exists.
+const DRAFT_ID = '__draft__'
+
+// Monotonic id source. A module counter keeps comment ids stable + unique
+// without reaching for Date.now()/Math.random() in render.
+let feedbackCommentSeq = 0
+
+const nextFeedbackCommentId = (): string =>
+  `feedback-comment-${(feedbackCommentSeq += 1)}`
 
 // Small inline status cards. They previously lived as an inline JSX ladder in
 // the right-pane block; extracting them keeps the populated-state JSX readable
@@ -113,6 +143,7 @@ export const DiffPanelContent = ({
   gitStatus = undefined,
   selectedFile: controlledSelectedFile,
   onSelectedFileChange,
+  feedbackDispatch = undefined,
 }: DiffPanelContentProps): ReactElement => {
   const internalGitStatus = useGitStatus(cwd, {
     watch: true,
@@ -246,6 +277,125 @@ export const DiffPanelContent = ({
   // Notification hook — reused for the "Pierre split differently" and
   // "could not isolate hunk" informational messages.
   const { message: notifyMessage, notifyInfo } = useNotifyInfo()
+
+  // Inline review comment batch state.
+  const feedback = useFeedbackBatch()
+
+  // Clear the feedback batch when cwd changes so stale comments from a
+  // previous workspace do not leak into the new one.
+  const previousCwdRef = useRef(cwd)
+
+  useEffect(() => {
+    if (previousCwdRef.current !== cwd) {
+      previousCwdRef.current = cwd
+      feedback.clearBatch()
+    }
+  }, [cwd, feedback, feedback.clearBatch])
+
+  // Composer target state: which line currently has an open composer.
+  // `editId` set => editing an existing comment in place; absent => a new
+  // draft on that line.
+  const [composerTarget, setComposerTarget] = useState<{
+    lineNumber: number
+    side: AnnotationSide
+    editId?: string
+  } | null>(null)
+
+  // Finish feedback popover open state.
+  const [finishOpen, setFinishOpen] = useState(false)
+
+  // Real annotations for the currently selected file.
+  const realAnnotations = feedback.annotationsForFile(
+    cwd,
+    selectedFilePath ?? ''
+  )
+
+  // Merge a transient draft annotation in only while composing a NEW comment,
+  // so the composer renders inline below the target line. Editing reuses the
+  // existing annotation's slot, so no draft is added there. When idle we pass
+  // `realAnnotations` straight through to keep its identity stable (avoids
+  // Pierre re-tokenizing on every render).
+  const lineAnnotations = useMemo((): DiffLineAnnotation<ReviewComment>[] => {
+    if (composerTarget !== null && composerTarget.editId === undefined) {
+      const draft: DiffLineAnnotation<ReviewComment> = {
+        side: composerTarget.side,
+        lineNumber: composerTarget.lineNumber,
+        metadata: { id: DRAFT_ID, text: '', author: 'self', createdAt: 0 },
+      }
+
+      return [...realAnnotations, draft]
+    }
+
+    return realAnnotations
+  }, [realAnnotations, composerTarget])
+
+  const confirmComposer = useCallback(
+    (text: string): void => {
+      setComposerTarget((current) => {
+        if (current === null) {
+          return null
+        }
+
+        if (selectedFilePath === null) {
+          return null
+        }
+
+        if (current.editId !== undefined) {
+          feedback.updateAnnotation(cwd, selectedFilePath, current.editId, {
+            text,
+          })
+        } else {
+          feedback.addAnnotation(cwd, selectedFilePath, {
+            side: current.side,
+            lineNumber: current.lineNumber,
+            metadata: {
+              id: nextFeedbackCommentId(),
+              text,
+              author: 'self',
+              createdAt: Date.now(),
+            },
+          })
+        }
+
+        return null
+      })
+    },
+    [feedback, cwd, selectedFilePath]
+  )
+
+  const closeComposer = useCallback((): void => {
+    setComposerTarget(null)
+  }, [])
+
+  const handleSendFeedback = useCallback(
+    (pane: PaneCandidate): void => {
+      void (async (): Promise<void> => {
+        const entries: DispatchEntry[] = []
+        for (const [key, annotations] of feedback.batch) {
+          const sep = key.indexOf('::')
+          const entryCwd = key.slice(0, sep)
+          const filePath = key.slice(sep + 2)
+          entries.push({ cwd: entryCwd, filePath, annotations })
+        }
+
+        try {
+          if (feedbackDispatch) {
+            await dispatchFeedbackBatch(
+              pane.paneId,
+              pane.ptyId,
+              entries,
+              feedbackDispatch.writePty
+            )
+          }
+          feedback.clearBatch()
+          setFinishOpen(false)
+        } catch {
+          notifyInfo('Terminal session ended; feedback not sent.')
+        }
+      })()
+    },
+    [feedback, feedbackDispatch, notifyInfo]
+  )
 
   // Single-flight staging flag — drops clicks while an IPC is in flight.
   const [staging, setStaging] = useState(false)
@@ -694,6 +844,9 @@ export const DiffPanelContent = ({
     [effectiveFiles, currentFileIndex, commitSelection, cwd]
   )
 
+  // Toolbar shell ref for anchoring the FinishFeedbackPopover.
+  const toolbarShellRef = useRef<HTMLDivElement>(null)
+
   // Loading state
   if (effectiveStatusLoading) {
     return (
@@ -771,7 +924,11 @@ export const DiffPanelContent = ({
         data-testid="diff-right-pane"
         className="flex min-w-0 flex-1 flex-col overflow-hidden"
       >
-        <div data-testid="diff-toolbar-shell" className="shrink-0">
+        <div
+          ref={toolbarShellRef}
+          data-testid="diff-toolbar-shell"
+          className="shrink-0"
+        >
           <DiffChipToolbar
             diffMode={selectedFileStaged ? 'staged' : 'unstaged'}
             diffStyle={effectiveDiffStyle}
@@ -806,6 +963,9 @@ export const DiffPanelContent = ({
             onDiscardAll={handleDiscardAll}
             staging={staging}
             selectedFileName={selectedFilePath ?? undefined}
+            feedbackCount={feedback.totalAnnotations()}
+            onDiscardFeedback={feedback.clearBatch}
+            onFinishFeedback={(): void => setFinishOpen(true)}
           />
           {renderSyncError !== null ? (
             <div
@@ -823,6 +983,20 @@ export const DiffPanelContent = ({
             >
               {notifyMessage}
             </div>
+          ) : null}
+          {finishOpen && toolbarShellRef.current !== null ? (
+            <FinishFeedbackPopover
+              anchor={toolbarShellRef.current}
+              result={resolveCandidatePanes({
+                allPanes: feedbackDispatch?.candidates ?? [],
+                diffCwd: cwd,
+                focusedPaneId: null,
+              })}
+              commentCount={feedback.totalAnnotations()}
+              fileCount={feedback.batch.size}
+              onCancel={(): void => setFinishOpen(false)}
+              onSend={handleSendFeedback}
+            />
           ) : null}
         </div>
         <div
@@ -855,6 +1029,7 @@ export const DiffPanelContent = ({
                 oldFile={pierreInputs.oldFile}
                 newFile={pierreInputs.newFile}
                 selectedLines={selectedLines}
+                lineAnnotations={lineAnnotations}
                 options={{
                   diffStyle: effectiveDiffStyle,
                   theme: renderedTheme,
@@ -865,6 +1040,71 @@ export const DiffPanelContent = ({
                   disableBackground,
                   disableFileHeader,
                   stickyHeader,
+                  enableGutterUtility: true,
+                }}
+                renderGutterUtility={(getHoveredLine): ReactElement => (
+                  <button
+                    type="button"
+                    aria-label="Add comment on this line"
+                    className="flex h-5 w-5 items-center justify-center rounded bg-primary/80 text-on-primary hover:bg-primary"
+                    onClick={(): void => {
+                      const hovered = getHoveredLine()
+                      if (hovered) {
+                        setComposerTarget({
+                          lineNumber: hovered.lineNumber,
+                          side: hovered.side,
+                        })
+                      }
+                    }}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="material-symbols-outlined text-sm leading-none"
+                    >
+                      add
+                    </span>
+                  </button>
+                )}
+                renderAnnotation={(
+                  annotation: DiffLineAnnotation<ReviewComment>
+                ): ReactElement => {
+                  const isDraft = annotation.metadata.id === DRAFT_ID
+
+                  const isEditing =
+                    composerTarget?.editId !== undefined &&
+                    composerTarget.editId === annotation.metadata.id
+
+                  if (isDraft || isEditing) {
+                    return (
+                      <ReviewCommentComposer
+                        lineNumber={annotation.lineNumber}
+                        side={annotation.side}
+                        initialText={isEditing ? annotation.metadata.text : ''}
+                        onConfirm={confirmComposer}
+                        onCancel={closeComposer}
+                      />
+                    )
+                  }
+
+                  return (
+                    <ReviewCommentRow
+                      comment={annotation.metadata}
+                      onEdit={(): void =>
+                        setComposerTarget({
+                          lineNumber: annotation.lineNumber,
+                          side: annotation.side,
+                          editId: annotation.metadata.id,
+                        })
+                      }
+                      onDelete={(): void =>
+                        feedback.removeAnnotation(
+                          cwd,
+                          selectedFilePath ?? '',
+                          annotation.metadata.id
+                        )
+                      }
+                    />
+                  )
                 }}
                 style={{ display: 'block', width: '100%' }}
               />

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -399,17 +399,22 @@ export const DiffPanelContent = ({
     setComposerTarget(null)
   }, [])
 
+  const sendingFeedbackRef = useRef(false)
+
   const handleSendFeedback = useCallback(
     (pane: PaneCandidate): void => {
+      if (sendingFeedbackRef.current) {
+        return
+      }
+      sendingFeedbackRef.current = true
       void (async (): Promise<void> => {
         const entries: DispatchEntry[] = []
         for (const [key, annotations] of feedback.batch) {
           const firstSep = key.indexOf('::')
-          const entryCwd = key.slice(0, firstSep)
           const remainder = key.slice(firstSep + 2)
           const lastSep = remainder.lastIndexOf('::')
           const filePath = remainder.slice(0, lastSep)
-          entries.push({ cwd: entryCwd, filePath, annotations })
+          entries.push({ filePath, annotations })
         }
 
         try {
@@ -425,6 +430,8 @@ export const DiffPanelContent = ({
           setFinishOpen(false)
         } catch {
           notifyInfo('Terminal session ended; feedback not sent.')
+        } finally {
+          sendingFeedbackRef.current = false
         }
       })()
     },
@@ -1030,9 +1037,6 @@ export const DiffPanelContent = ({
               result={resolveCandidatePanes({
                 allPanes: feedbackDispatch?.candidates ?? [],
                 diffCwd: cwd,
-                focusedPaneId:
-                  feedbackDispatch?.candidates.find((c) => c.isFocused)
-                    ?.paneId ?? null,
               })}
               commentCount={feedback.totalAnnotations()}
               fileCount={feedback.batch.size}

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -408,12 +408,21 @@ export const DiffPanelContent = ({
       }
       sendingFeedbackRef.current = true
       void (async (): Promise<void> => {
+        // git reports file paths relative to the repo TOPLEVEL, but the target
+        // agent runs in the pane's cwd (possibly a repo subdirectory). Join the
+        // toplevel (`response.repoRoot`) so the dispatched reference is an
+        // absolute path the agent can resolve regardless of its cwd. All batch
+        // entries share one repo (the batch is cleared on cwd change), so the
+        // current diff's repoRoot applies to every file. Falls back to the
+        // repo-relative path if the root is unavailable (not in a git repo).
+        const repoRoot = response?.repoRoot ?? ''
         const entries: DispatchEntry[] = []
         for (const [key, annotations] of feedback.batch) {
           const firstSep = key.indexOf('::')
           const remainder = key.slice(firstSep + 2)
           const lastSep = remainder.lastIndexOf('::')
-          const filePath = remainder.slice(0, lastSep)
+          const relPath = remainder.slice(0, lastSep)
+          const filePath = repoRoot ? `${repoRoot}/${relPath}` : relPath
           entries.push({ filePath, annotations })
         }
 
@@ -435,7 +444,7 @@ export const DiffPanelContent = ({
         }
       })()
     },
-    [feedback, feedbackDispatch, notifyInfo]
+    [feedback, feedbackDispatch, notifyInfo, response]
   )
 
   // Single-flight staging flag — drops clicks while an IPC is in flight.

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -514,56 +514,98 @@ export const DiffPanelContent = ({
 
   const focusedHunk = response?.fileDiff.hunks[clampedHunkIndex] ?? null
 
+  // Map a hunk to its Pierre line range. Deletion-only hunks (newLines === 0)
+  // use old-side coordinates so the highlight lands on the deletions column.
+  const hunkToRange = useCallback(
+    (
+      hunk: NonNullable<typeof response>['fileDiff']['hunks'][number]
+    ): SelectedLineRange => {
+      const isDeletionOnly = hunk.newLines === 0
+      const lineStart = isDeletionOnly ? hunk.oldStart : hunk.newStart
+      const lineCount = isDeletionOnly ? hunk.oldLines : hunk.newLines
+
+      return {
+        start: lineStart,
+        end: lineStart + Math.max(lineCount - 1, 0),
+        side: isDeletionOnly ? 'deletions' : 'additions',
+      }
+    },
+    []
+  )
+
+  // Pierre anchors the gutter "+" comment affordance to the active SELECTION
+  // whenever one exists (placeUtilityFromSelection in InteractionManager), only
+  // falling back to the hovered line otherwise. A PERSISTENT focused-hunk
+  // selection would therefore pin the "+" to that hunk and stop it following the
+  // mouse. So the focused-hunk selection is surfaced only as a brief FLASH on
+  // prev/next navigation (to scroll/highlight the target hunk), then cleared so
+  // commenting works on any hovered line.
+  const [navSelection, setNavSelection] = useState<SelectedLineRange | null>(
+    null
+  )
+  const navClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearNavSelectionTimer = useCallback((): void => {
+    if (navClearTimerRef.current !== null) {
+      clearTimeout(navClearTimerRef.current)
+      navClearTimerRef.current = null
+    }
+  }, [])
+
+  const flashHunkSelection = useCallback(
+    (hunk: NonNullable<typeof response>['fileDiff']['hunks'][number]): void => {
+      setNavSelection(hunkToRange(hunk))
+      clearNavSelectionTimer()
+      navClearTimerRef.current = setTimeout(() => {
+        setNavSelection(null)
+        navClearTimerRef.current = null
+      }, 1200)
+    },
+    [hunkToRange, clearNavSelectionTimer]
+  )
+
+  useEffect(() => clearNavSelectionTimer, [clearNavSelectionTimer])
+
+  // Drop any pending nav flash when the selected file changes (the hunk ranges
+  // belong to the previous file).
+  useEffect(() => {
+    clearNavSelectionTimer()
+    setNavSelection(null)
+  }, [selectedFilePath, selectedFileStaged, clearNavSelectionTimer])
+
   const onPrevHunk = useCallback((): void => {
     if (!response) {
       return
     }
 
-    const len = response.fileDiff.hunks.length
-    if (len === 0) {
+    const hunks = response.fileDiff.hunks
+    if (hunks.length === 0) {
       return
     }
 
-    setFocusedHunkIndex((prev) => (prev + len - 1) % len)
-  }, [response])
+    const next = (clampedHunkIndex + hunks.length - 1) % hunks.length
+    setFocusedHunkIndex(next)
+    flashHunkSelection(hunks[next])
+  }, [response, clampedHunkIndex, flashHunkSelection])
 
   const onNextHunk = useCallback((): void => {
     if (!response) {
       return
     }
 
-    const len = response.fileDiff.hunks.length
-    if (len === 0) {
+    const hunks = response.fileDiff.hunks
+    if (hunks.length === 0) {
       return
     }
 
-    setFocusedHunkIndex((prev) => (prev + 1) % len)
-  }, [response])
+    const next = (clampedHunkIndex + 1) % hunks.length
+    setFocusedHunkIndex(next)
+    flashHunkSelection(hunks[next])
+  }, [response, clampedHunkIndex, flashHunkSelection])
 
-  // Derive the Pierre selectedLines from the focused hunk. Deletion-only hunks
-  // (newLines === 0) use the old-side coordinates so the highlight lands on the
-  // deletions column; all other hunks use the new-side (additions).
-  const selectedLines: SelectedLineRange | null =
-    useMemo((): SelectedLineRange | null => {
-      const hunk = response?.fileDiff.hunks[clampedHunkIndex]
-      if (!hunk) {
-        return null
-      }
-
-      const isDeletionOnly = hunk.newLines === 0
-      const lineStart = isDeletionOnly ? hunk.oldStart : hunk.newStart
-      const lineCount = isDeletionOnly ? hunk.oldLines : hunk.newLines
-
-      const side = isDeletionOnly
-        ? ('deletions' as const)
-        : ('additions' as const)
-
-      return {
-        start: lineStart,
-        end: lineStart + Math.max(lineCount - 1, 0),
-        side,
-      }
-    }, [response, clampedHunkIndex])
+  // Only the transient nav flash drives Pierre's selection — see the comment on
+  // `navSelection` above for why a persistent focused-hunk selection is avoided.
+  const selectedLines: SelectedLineRange | null = navSelection
 
   // Shared helper for all three hunk-based staging operations. Extracts the
   // focused hunk patch, calls the provided service operation, then refreshes
@@ -1118,10 +1160,15 @@ export const DiffPanelContent = ({
                   enableGutterUtility: true,
                 }}
                 renderGutterUtility={(getHoveredLine): ReactElement => (
+                  // Pierre wraps this button in a center-aligned slot pinned to
+                  // the gutter's right edge, so by default the "+" lands on top of
+                  // the line number. translate-x-3/4 nudges it into the gutter
+                  // gap next to the code (GitHub-style); the percentage is of the
+                  // button's own width, so it adapts to any line-number column.
                   <button
                     type="button"
                     aria-label="Add comment on this line"
-                    className="flex h-5 w-5 items-center justify-center rounded bg-primary/80 text-on-primary hover:bg-primary"
+                    className="flex h-5 w-5 translate-x-3/4 items-center justify-center rounded-full bg-primary text-on-primary shadow-md hover:bg-primary/90"
                     onClick={(): void => {
                       const hovered = getHoveredLine()
                       if (hovered && selectedFilePath !== null) {

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -1030,7 +1030,9 @@ export const DiffPanelContent = ({
               result={resolveCandidatePanes({
                 allPanes: feedbackDispatch?.candidates ?? [],
                 diffCwd: cwd,
-                focusedPaneId: null,
+                focusedPaneId:
+                  feedbackDispatch?.candidates.find((c) => c.isFocused)
+                    ?.paneId ?? null,
               })}
               commentCount={feedback.totalAnnotations()}
               fileCount={feedback.batch.size}

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -1154,6 +1154,14 @@ export const DiffPanelContent = ({
                   if (isDraft || isEditing) {
                     return (
                       <ReviewCommentComposer
+                        // Key by target identity so switching the gutter `+` to
+                        // another line (the draft stays at the same annotation
+                        // index, so React would otherwise reuse this instance
+                        // and carry the old textarea text to the new line)
+                        // forces a remount with fresh state.
+                        key={`${annotation.lineNumber}:${annotation.side}:${
+                          isEditing ? annotation.metadata.id : 'draft'
+                        }`}
                         lineNumber={annotation.lineNumber}
                         side={annotation.side}
                         initialText={isEditing ? annotation.metadata.text : ''}

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -298,6 +298,8 @@ export const DiffPanelContent = ({
   const [composerTarget, setComposerTarget] = useState<{
     lineNumber: number
     side: AnnotationSide
+    filePath: string
+    staged: boolean
     editId?: string
   } | null>(null)
 
@@ -307,7 +309,8 @@ export const DiffPanelContent = ({
   // Real annotations for the currently selected file.
   const realAnnotations = feedback.annotationsForFile(
     cwd,
-    selectedFilePath ?? ''
+    selectedFilePath ?? '',
+    selectedFileStaged
   )
 
   // Merge a transient draft annotation in only while composing a NEW comment,
@@ -331,43 +334,65 @@ export const DiffPanelContent = ({
 
   const confirmComposer = useCallback(
     (text: string): void => {
-      setComposerTarget((current) => {
-        if (current === null) {
-          return null
-        }
+      if (composerTarget === null) {
+        return
+      }
 
-        if (selectedFilePath === null) {
-          return null
-        }
+      if (selectedFilePath === null) {
+        return
+      }
 
-        if (current.editId !== undefined) {
-          feedback.updateAnnotation(cwd, selectedFilePath, current.editId, {
-            text,
-          })
-        } else {
-          const result = feedback.addAnnotation(cwd, selectedFilePath, {
-            side: current.side,
-            lineNumber: current.lineNumber,
+      if (
+        composerTarget.filePath !== selectedFilePath ||
+        composerTarget.staged !== selectedFileStaged
+      ) {
+        setComposerTarget(null)
+
+        return
+      }
+
+      if (composerTarget.editId !== undefined) {
+        feedback.updateAnnotation(
+          cwd,
+          selectedFilePath,
+          selectedFileStaged,
+          composerTarget.editId,
+          { text }
+        )
+        setComposerTarget(null)
+      } else {
+        const result = feedback.addAnnotation(
+          cwd,
+          selectedFilePath,
+          selectedFileStaged,
+          {
+            side: composerTarget.side,
+            lineNumber: composerTarget.lineNumber,
             metadata: {
               id: nextFeedbackCommentId(),
               text,
               author: 'self',
               createdAt: Date.now(),
             },
-          })
-          if (result === 'cap-reached') {
-            notifyInfo(
-              'Feedback limit reached (50 comments). Finish or discard before adding more.'
-            )
-
-            return current
           }
+        )
+        if (result === 'cap-reached') {
+          notifyInfo(
+            'Feedback limit reached (50 comments). Finish or discard before adding more.'
+          )
+        } else {
+          setComposerTarget(null)
         }
-
-        return null
-      })
+      }
     },
-    [feedback, cwd, selectedFilePath, notifyInfo]
+    [
+      composerTarget,
+      selectedFilePath,
+      selectedFileStaged,
+      feedback,
+      cwd,
+      notifyInfo,
+    ]
   )
 
   const closeComposer = useCallback((): void => {
@@ -379,9 +404,11 @@ export const DiffPanelContent = ({
       void (async (): Promise<void> => {
         const entries: DispatchEntry[] = []
         for (const [key, annotations] of feedback.batch) {
-          const sep = key.indexOf('::')
-          const entryCwd = key.slice(0, sep)
-          const filePath = key.slice(sep + 2)
+          const firstSep = key.indexOf('::')
+          const entryCwd = key.slice(0, firstSep)
+          const remainder = key.slice(firstSep + 2)
+          const lastSep = remainder.lastIndexOf('::')
+          const filePath = remainder.slice(0, lastSep)
           entries.push({ cwd: entryCwd, filePath, annotations })
         }
 
@@ -419,6 +446,12 @@ export const DiffPanelContent = ({
   // how useFileDiff and selectedFileEntry are driven.
   useEffect(() => {
     setFocusedHunkIndex(0)
+  }, [selectedFilePath, selectedFileStaged])
+
+  // Clear composer when the selected file changes so a draft opened on one
+  // file is not accidentally submitted against another.
+  useEffect(() => {
+    setComposerTarget(null)
   }, [selectedFilePath, selectedFileStaged])
 
   const hunkCount = response?.fileDiff.hunks.length ?? 0
@@ -1056,10 +1089,12 @@ export const DiffPanelContent = ({
                     className="flex h-5 w-5 items-center justify-center rounded bg-primary/80 text-on-primary hover:bg-primary"
                     onClick={(): void => {
                       const hovered = getHoveredLine()
-                      if (hovered) {
+                      if (hovered && selectedFilePath !== null) {
                         setComposerTarget({
                           lineNumber: hovered.lineNumber,
                           side: hovered.side,
+                          filePath: selectedFilePath,
+                          staged: selectedFileStaged,
                         })
                       }
                     }}
@@ -1100,6 +1135,8 @@ export const DiffPanelContent = ({
                         setComposerTarget({
                           lineNumber: annotation.lineNumber,
                           side: annotation.side,
+                          filePath: selectedFilePath ?? '',
+                          staged: selectedFileStaged,
                           editId: annotation.metadata.id,
                         })
                       }
@@ -1107,6 +1144,7 @@ export const DiffPanelContent = ({
                         feedback.removeAnnotation(
                           cwd,
                           selectedFilePath ?? '',
+                          selectedFileStaged,
                           annotation.metadata.id
                         )
                       }

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -345,7 +345,7 @@ export const DiffPanelContent = ({
             text,
           })
         } else {
-          feedback.addAnnotation(cwd, selectedFilePath, {
+          const result = feedback.addAnnotation(cwd, selectedFilePath, {
             side: current.side,
             lineNumber: current.lineNumber,
             metadata: {
@@ -355,12 +355,19 @@ export const DiffPanelContent = ({
               createdAt: Date.now(),
             },
           })
+          if (result === 'cap-reached') {
+            notifyInfo(
+              'Feedback limit reached (50 comments). Finish or discard before adding more.'
+            )
+
+            return current
+          }
         }
 
         return null
       })
     },
-    [feedback, cwd, selectedFilePath]
+    [feedback, cwd, selectedFilePath, notifyInfo]
   )
 
   const closeComposer = useCallback((): void => {

--- a/src/features/diff/components/FinishFeedbackPopover.test.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.test.tsx
@@ -1,0 +1,182 @@
+import { test, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FinishFeedbackPopover } from './FinishFeedbackPopover'
+import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
+
+const createAnchor = (): HTMLDivElement => {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+
+  return el
+}
+
+const makePane = (overrides: Partial<PaneCandidate> = {}): PaneCandidate => ({
+  paneId: 'pane-1',
+  ptyId: 'pty-1',
+  tabName: 'Tab 1',
+  agentLabel: 'Claude Code',
+  cwd: '/repo',
+  status: 'running',
+  isFocused: false,
+  ...overrides,
+})
+
+test('kind none shows no-agent message and Dismiss button calls onCancel', async () => {
+  const user = userEvent.setup()
+  const anchor = createAnchor()
+  const onCancel = vi.fn()
+  const onSend = vi.fn()
+
+  render(
+    <FinishFeedbackPopover
+      anchor={anchor}
+      result={{ kind: 'none' } as ResolveResult}
+      commentCount={0}
+      fileCount={0}
+      onSend={onSend}
+      onCancel={onCancel}
+    />
+  )
+
+  expect(
+    screen.getByRole('dialog', { name: 'Finish feedback' })
+  ).toBeInTheDocument()
+
+  expect(
+    screen.getByText(/No coding agent is active in this workspace/)
+  ).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument()
+
+  await user.click(screen.getByRole('button', { name: 'Dismiss' }))
+  expect(onCancel).toHaveBeenCalledTimes(1)
+  expect(onSend).not.toHaveBeenCalled()
+
+  anchor.remove()
+})
+
+test('kind one shows pane info, correct copy, and buttons work', async () => {
+  const user = userEvent.setup()
+  const anchor = createAnchor()
+  const onCancel = vi.fn()
+  const onSend = vi.fn()
+  const pane = makePane({ tabName: 'claude', agentLabel: 'Claude Code' })
+
+  render(
+    <FinishFeedbackPopover
+      anchor={anchor}
+      result={{ kind: 'one', pane } as ResolveResult}
+      commentCount={5}
+      fileCount={2}
+      onSend={onSend}
+      onCancel={onCancel}
+    />
+  )
+
+  expect(
+    screen.getByText(
+      /Send 5 comments across 2 files to claude \(Claude Code\)\?/
+    )
+  ).toBeInTheDocument()
+
+  await user.click(screen.getByRole('button', { name: 'Confirm' }))
+  expect(onSend).toHaveBeenCalledTimes(1)
+  expect(onSend).toHaveBeenCalledWith(pane)
+
+  onSend.mockClear()
+  await user.click(screen.getByRole('button', { name: 'Cancel' }))
+  expect(onCancel).toHaveBeenCalledTimes(1)
+  expect(onSend).not.toHaveBeenCalled()
+
+  anchor.remove()
+})
+
+test('kind many renders row per candidate and sends to correct pane', async () => {
+  const user = userEvent.setup()
+  const anchor = createAnchor()
+  const onCancel = vi.fn()
+  const onSend = vi.fn()
+
+  const paneA = makePane({
+    paneId: 'pane-a',
+    ptyId: 'pty-a',
+    tabName: 'claude-a',
+    agentLabel: 'Claude Code',
+  })
+
+  const paneB = makePane({
+    paneId: 'pane-b',
+    ptyId: 'pty-b',
+    tabName: 'codex-b',
+    agentLabel: 'Codex',
+  })
+
+  render(
+    <FinishFeedbackPopover
+      anchor={anchor}
+      result={{ kind: 'many', candidates: [paneA, paneB] } as ResolveResult}
+      commentCount={3}
+      fileCount={1}
+      onSend={onSend}
+      onCancel={onCancel}
+    />
+  )
+
+  expect(
+    screen.getByText(/Multiple agents in this workspace\. Pick one:/)
+  ).toBeInTheDocument()
+  expect(screen.getByText('claude-a (Claude Code)')).toBeInTheDocument()
+  expect(screen.getByText('codex-b (Codex)')).toBeInTheDocument()
+
+  const sendButtons = screen.getAllByRole('button', { name: 'Send' })
+  expect(sendButtons).toHaveLength(2)
+
+  await user.click(sendButtons[1])
+  expect(onSend).toHaveBeenCalledTimes(1)
+  expect(onSend).toHaveBeenCalledWith(paneB)
+
+  await user.click(screen.getByRole('button', { name: 'Cancel' }))
+  expect(onCancel).toHaveBeenCalledTimes(1)
+
+  anchor.remove()
+})
+
+test('pluralization uses singular for 1 comment and 1 file', () => {
+  const anchor = createAnchor()
+  const pane = makePane()
+
+  render(
+    <FinishFeedbackPopover
+      anchor={anchor}
+      result={{ kind: 'one', pane } as ResolveResult}
+      commentCount={1}
+      fileCount={1}
+      onSend={vi.fn()}
+      onCancel={vi.fn()}
+    />
+  )
+
+  expect(screen.getByText(/Send 1 comment across 1 file/)).toBeInTheDocument()
+
+  anchor.remove()
+})
+
+test('pluralization uses plural for multiple comments and files', () => {
+  const anchor = createAnchor()
+  const pane = makePane()
+
+  render(
+    <FinishFeedbackPopover
+      anchor={anchor}
+      result={{ kind: 'one', pane } as ResolveResult}
+      commentCount={3}
+      fileCount={2}
+      onSend={vi.fn()}
+      onCancel={vi.fn()}
+    />
+  )
+
+  expect(screen.getByText(/Send 3 comments across 2 files/)).toBeInTheDocument()
+
+  anchor.remove()
+})

--- a/src/features/diff/components/FinishFeedbackPopover.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement } from 'react'
 import {
+  FloatingFocusManager,
   FloatingPortal,
   autoUpdate,
   flip,
@@ -51,99 +52,101 @@ export const FinishFeedbackPopover = ({
 
   return (
     <FloatingPortal>
-      <div
-        ref={refs.setFloating}
-        style={floatingStyles}
-        className="z-50 flex w-[320px] flex-col gap-3 rounded-lg border border-outline-variant/20 bg-surface-container-high/95 p-4 shadow-xl backdrop-blur-md"
-        aria-label="Finish feedback"
-        {...getFloatingProps()}
-      >
-        {result.kind === 'none' && (
-          <div className="flex flex-col gap-3">
-            <p className="text-sm text-on-surface">
-              No coding agent is active in this workspace. Start{' '}
-              <code className="rounded bg-surface-container/50 px-1 py-0.5 text-xs font-mono text-on-surface-variant">
-                claude
-              </code>{' '}
-              or{' '}
-              <code className="rounded bg-surface-container/50 px-1 py-0.5 text-xs font-mono text-on-surface-variant">
-                codex
-              </code>{' '}
-              in a terminal pane.
-            </p>
-            <div className="flex justify-end">
-              <button
-                type="button"
-                onClick={(): void => onCancel()}
-                className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
-              >
-                Dismiss
-              </button>
-            </div>
-          </div>
-        )}
-
-        {result.kind === 'one' && (
-          <div className="flex flex-col gap-3">
-            <p className="text-sm text-on-surface">
-              Send {commentCount} {commentWord} across {fileCount} {fileWord} to{' '}
-              {result.pane.tabName} ({result.pane.agentLabel})?
-            </p>
-            <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={(): void => onCancel()}
-                className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={(): void => onSend(result.pane)}
-                className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80"
-              >
-                Confirm
-              </button>
-            </div>
-          </div>
-        )}
-
-        {result.kind === 'many' && (
-          <div className="flex flex-col gap-3">
-            <h2 className="text-sm font-medium text-on-surface">
-              Multiple agents in this workspace. Pick one:
-            </h2>
-            <div className="flex flex-col gap-2">
-              {result.candidates.map((pane) => (
-                <div
-                  key={pane.ptyId}
-                  className="flex items-center justify-between gap-2"
+      <FloatingFocusManager context={context} initialFocus={-1}>
+        <div
+          ref={refs.setFloating}
+          style={floatingStyles}
+          className="z-50 flex w-[320px] flex-col gap-3 rounded-lg border border-outline-variant/20 bg-surface-container-high/95 p-4 shadow-xl backdrop-blur-md"
+          aria-label="Finish feedback"
+          {...getFloatingProps()}
+        >
+          {result.kind === 'none' && (
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-on-surface">
+                No coding agent is active in this workspace. Start{' '}
+                <code className="rounded bg-surface-container/50 px-1 py-0.5 text-xs font-mono text-on-surface-variant">
+                  claude
+                </code>{' '}
+                or{' '}
+                <code className="rounded bg-surface-container/50 px-1 py-0.5 text-xs font-mono text-on-surface-variant">
+                  codex
+                </code>{' '}
+                in a terminal pane.
+              </p>
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={(): void => onCancel()}
+                  className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
                 >
-                  <span className="text-sm text-on-surface">
-                    {pane.tabName} ({pane.agentLabel})
-                  </span>
-                  <button
-                    type="button"
-                    onClick={(): void => onSend(pane)}
-                    className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80"
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          )}
+
+          {result.kind === 'one' && (
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-on-surface">
+                Send {commentCount} {commentWord} across {fileCount} {fileWord}{' '}
+                to {result.pane.tabName} ({result.pane.agentLabel})?
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={(): void => onCancel()}
+                  className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={(): void => onSend(result.pane)}
+                  className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80"
+                >
+                  Confirm
+                </button>
+              </div>
+            </div>
+          )}
+
+          {result.kind === 'many' && (
+            <div className="flex flex-col gap-3">
+              <h2 className="text-sm font-medium text-on-surface">
+                Multiple agents in this workspace. Pick one:
+              </h2>
+              <div className="flex flex-col gap-2">
+                {result.candidates.map((pane) => (
+                  <div
+                    key={pane.ptyId}
+                    className="flex items-center justify-between gap-2"
                   >
-                    Send
-                  </button>
-                </div>
-              ))}
+                    <span className="text-sm text-on-surface">
+                      {pane.tabName} ({pane.agentLabel})
+                    </span>
+                    <button
+                      type="button"
+                      onClick={(): void => onSend(pane)}
+                      className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80"
+                    >
+                      Send
+                    </button>
+                  </div>
+                ))}
+              </div>
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={(): void => onCancel()}
+                  className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+                >
+                  Cancel
+                </button>
+              </div>
             </div>
-            <div className="flex justify-end">
-              <button
-                type="button"
-                onClick={(): void => onCancel()}
-                className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      </FloatingFocusManager>
     </FloatingPortal>
   )
 }

--- a/src/features/diff/components/FinishFeedbackPopover.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.tsx
@@ -116,7 +116,7 @@ export const FinishFeedbackPopover = ({
             <div className="flex flex-col gap-2">
               {result.candidates.map((pane) => (
                 <div
-                  key={pane.paneId}
+                  key={pane.ptyId}
                   className="flex items-center justify-between gap-2"
                 >
                   <span className="text-sm text-on-surface">

--- a/src/features/diff/components/FinishFeedbackPopover.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.tsx
@@ -1,0 +1,149 @@
+import { type ReactElement } from 'react'
+import {
+  FloatingPortal,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react'
+import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
+
+interface FinishFeedbackPopoverProps {
+  anchor: HTMLElement
+  result: ResolveResult
+  commentCount: number
+  fileCount: number
+  onSend: (pane: PaneCandidate) => void
+  onCancel: () => void
+}
+
+export const FinishFeedbackPopover = ({
+  anchor,
+  result,
+  commentCount,
+  fileCount,
+  onSend,
+  onCancel,
+}: FinishFeedbackPopoverProps): ReactElement => {
+  const { refs, floatingStyles, context } = useFloating({
+    open: true,
+    onOpenChange: (open): void => {
+      if (!open) {
+        onCancel()
+      }
+    },
+    placement: 'bottom-start',
+    middleware: [offset(4), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+    elements: { reference: anchor },
+  })
+
+  const dismiss = useDismiss(context, { ancestorScroll: true })
+  const role = useRole(context, { role: 'dialog' })
+  const { getFloatingProps } = useInteractions([dismiss, role])
+
+  const commentWord = commentCount === 1 ? 'comment' : 'comments'
+  const fileWord = fileCount === 1 ? 'file' : 'files'
+
+  return (
+    <FloatingPortal>
+      <div
+        ref={refs.setFloating}
+        style={floatingStyles}
+        className="z-50 flex w-[320px] flex-col gap-3 rounded-lg border border-outline-variant/20 bg-surface-container-high/95 p-4 shadow-xl backdrop-blur-md"
+        aria-label="Finish feedback"
+        {...getFloatingProps()}
+      >
+        {result.kind === 'none' && (
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-on-surface">
+              No coding agent is active in this workspace. Start{' '}
+              <code className="rounded bg-surface-container/50 px-1 py-0.5 text-xs font-mono text-on-surface-variant">
+                claude
+              </code>{' '}
+              or{' '}
+              <code className="rounded bg-surface-container/50 px-1 py-0.5 text-xs font-mono text-on-surface-variant">
+                codex
+              </code>{' '}
+              in a terminal pane.
+            </p>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={(): void => onCancel()}
+                className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        )}
+
+        {result.kind === 'one' && (
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-on-surface">
+              Send {commentCount} {commentWord} across {fileCount} {fileWord} to{' '}
+              {result.pane.tabName} ({result.pane.agentLabel})?
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={(): void => onCancel()}
+                className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={(): void => onSend(result.pane)}
+                className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80"
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        )}
+
+        {result.kind === 'many' && (
+          <div className="flex flex-col gap-3">
+            <h2 className="text-sm font-medium text-on-surface">
+              Multiple agents in this workspace. Pick one:
+            </h2>
+            <div className="flex flex-col gap-2">
+              {result.candidates.map((pane) => (
+                <div
+                  key={pane.paneId}
+                  className="flex items-center justify-between gap-2"
+                >
+                  <span className="text-sm text-on-surface">
+                    {pane.tabName} ({pane.agentLabel})
+                  </span>
+                  <button
+                    type="button"
+                    onClick={(): void => onSend(pane)}
+                    className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80"
+                  >
+                    Send
+                  </button>
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={(): void => onCancel()}
+                className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </FloatingPortal>
+  )
+}

--- a/src/features/diff/components/ReviewCommentComposer.test.tsx
+++ b/src/features/diff/components/ReviewCommentComposer.test.tsx
@@ -1,0 +1,269 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { ReviewCommentComposer } from './ReviewCommentComposer'
+
+/**
+ * Create a real anchor element attached to document.body.
+ * floating-ui needs the anchor in the DOM to compute positioning.
+ */
+const createAnchor = (): HTMLDivElement => {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+
+  return el
+}
+
+describe('ReviewCommentComposer', () => {
+  let anchor: HTMLDivElement
+
+  beforeEach(() => {
+    anchor = createAnchor()
+  })
+
+  afterEach(() => {
+    anchor.remove()
+  })
+
+  test('renders the textarea pre-filled with initialText', () => {
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        initialText="pre-filled text"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('textbox')).toHaveValue('pre-filled text')
+  })
+
+  test('renders with an empty textarea when no initialText provided', () => {
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('textbox')).toHaveValue('')
+  })
+
+  test('typing updates the textarea value', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    const textarea = screen.getByRole('textbox')
+    await user.clear(textarea)
+    await user.type(textarea, 'hello world')
+
+    expect(textarea).toHaveValue('hello world')
+  })
+
+  test('Enter confirms with trimmed text', async () => {
+    const user = userEvent.setup()
+    const handleConfirm = vi.fn()
+
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        initialText="  my comment  "
+        onConfirm={handleConfirm}
+        onCancel={vi.fn()}
+      />
+    )
+
+    // Click the textarea to ensure it has focus before pressing Enter.
+    await user.click(screen.getByRole('textbox'))
+    await user.keyboard('{Enter}')
+
+    expect(handleConfirm).toHaveBeenCalledTimes(1)
+    expect(handleConfirm).toHaveBeenCalledWith('my comment')
+  })
+
+  test('Shift+Enter inserts a newline and does not confirm', async () => {
+    const user = userEvent.setup()
+    const handleConfirm = vi.fn()
+
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        initialText="line one"
+        onConfirm={handleConfirm}
+        onCancel={vi.fn()}
+      />
+    )
+
+    const textarea = screen.getByRole('textbox')
+    // Move cursor to end then Shift+Enter
+    await user.click(textarea)
+    await user.keyboard('{Shift>}{Enter}{/Shift}')
+
+    expect(handleConfirm).not.toHaveBeenCalled()
+    expect(textarea).toHaveValue('line one\n')
+  })
+
+  test('Escape calls onCancel', async () => {
+    const user = userEvent.setup()
+    const handleCancel = vi.fn()
+
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        initialText="some text"
+        onConfirm={vi.fn()}
+        onCancel={handleCancel}
+      />
+    )
+
+    await user.keyboard('{Escape}')
+
+    expect(handleCancel).toHaveBeenCalledTimes(1)
+  })
+
+  test('Cancel button calls onCancel', async () => {
+    const user = userEvent.setup()
+    const handleCancel = vi.fn()
+
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        onConfirm={vi.fn()}
+        onCancel={handleCancel}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(handleCancel).toHaveBeenCalledTimes(1)
+  })
+
+  test('Add comment button is disabled when text is empty', () => {
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        initialText=""
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Add comment' })).toBeDisabled()
+  })
+
+  test('Add comment button is disabled when text is whitespace only', () => {
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        initialText="   "
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Add comment' })).toBeDisabled()
+  })
+
+  test('Enter does not confirm when text is empty', async () => {
+    const user = userEvent.setup()
+    const handleConfirm = vi.fn()
+
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        initialText=""
+        onConfirm={handleConfirm}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.keyboard('{Enter}')
+
+    expect(handleConfirm).not.toHaveBeenCalled()
+  })
+
+  test('Enter does not confirm when text is whitespace only', async () => {
+    const user = userEvent.setup()
+    const handleConfirm = vi.fn()
+
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        initialText="   "
+        onConfirm={handleConfirm}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.keyboard('{Enter}')
+
+    expect(handleConfirm).not.toHaveBeenCalled()
+  })
+
+  test('Add comment button fires onConfirm with trimmed text when clicked', async () => {
+    const user = userEvent.setup()
+    const handleConfirm = vi.fn()
+
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        initialText="valid comment"
+        onConfirm={handleConfirm}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Add comment' }))
+
+    expect(handleConfirm).toHaveBeenCalledTimes(1)
+    expect(handleConfirm).toHaveBeenCalledWith('valid comment')
+  })
+
+  test('click outside the popover calls onCancel via useDismiss', async () => {
+    const user = userEvent.setup()
+    const handleCancel = vi.fn()
+
+    render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        initialText="some text"
+        onConfirm={vi.fn()}
+        onCancel={handleCancel}
+      />
+    )
+
+    // Click on a DOM element outside the floating popover.
+    // useDismiss fires onOpenChange(false) → onCancel on pointerdown outside.
+    await user.click(document.body)
+
+    await waitFor(() => {
+      expect(handleCancel).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  test('renders the popover via FloatingPortal (outside the render container)', () => {
+    const { container } = render(
+      <ReviewCommentComposer
+        anchor={anchor}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    // The textarea must be in the document but NOT inside the React render root.
+    // FloatingPortal mounts directly under document.body, escaping the render container.
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+    // The render root (container) must not contain a textbox.
+    // (It is an empty div when FloatingPortal is used correctly.)
+    const { queryByRole } = within(container)
+    expect(queryByRole('textbox')).not.toBeInTheDocument()
+  })
+})

--- a/src/features/diff/components/ReviewCommentComposer.test.tsx
+++ b/src/features/diff/components/ReviewCommentComposer.test.tsx
@@ -1,34 +1,41 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { ReviewCommentComposer } from './ReviewCommentComposer'
 
-/**
- * Create a real anchor element attached to document.body.
- * floating-ui needs the anchor in the DOM to compute positioning.
- */
-const createAnchor = (): HTMLDivElement => {
-  const el = document.createElement('div')
-  document.body.appendChild(el)
-
-  return el
-}
-
 describe('ReviewCommentComposer', () => {
-  let anchor: HTMLDivElement
+  test('renders the "Local comment" header and the R-side line reference', () => {
+    render(
+      <ReviewCommentComposer
+        lineNumber={190}
+        side="additions"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
 
-  beforeEach(() => {
-    anchor = createAnchor()
+    expect(screen.getByText('Local comment')).toBeInTheDocument()
+    expect(screen.getByText('Comment on line R190')).toBeInTheDocument()
   })
 
-  afterEach(() => {
-    anchor.remove()
+  test('renders the L-side line reference for a deletions-side comment', () => {
+    render(
+      <ReviewCommentComposer
+        lineNumber={42}
+        side="deletions"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Comment on line L42')).toBeInTheDocument()
   })
 
   test('renders the textarea pre-filled with initialText', () => {
     render(
       <ReviewCommentComposer
-        anchor={anchor}
+        lineNumber={1}
+        side="additions"
         initialText="pre-filled text"
         onConfirm={vi.fn()}
         onCancel={vi.fn()}
@@ -38,31 +45,19 @@ describe('ReviewCommentComposer', () => {
     expect(screen.getByRole('textbox')).toHaveValue('pre-filled text')
   })
 
-  test('renders with an empty textarea when no initialText provided', () => {
-    render(
-      <ReviewCommentComposer
-        anchor={anchor}
-        onConfirm={vi.fn()}
-        onCancel={vi.fn()}
-      />
-    )
-
-    expect(screen.getByRole('textbox')).toHaveValue('')
-  })
-
   test('typing updates the textarea value', async () => {
     const user = userEvent.setup()
 
     render(
       <ReviewCommentComposer
-        anchor={anchor}
+        lineNumber={1}
+        side="additions"
         onConfirm={vi.fn()}
         onCancel={vi.fn()}
       />
     )
 
     const textarea = screen.getByRole('textbox')
-    await user.clear(textarea)
     await user.type(textarea, 'hello world')
 
     expect(textarea).toHaveValue('hello world')
@@ -74,14 +69,14 @@ describe('ReviewCommentComposer', () => {
 
     render(
       <ReviewCommentComposer
-        anchor={anchor}
+        lineNumber={1}
+        side="additions"
         initialText="  my comment  "
         onConfirm={handleConfirm}
         onCancel={vi.fn()}
       />
     )
 
-    // Click the textarea to ensure it has focus before pressing Enter.
     await user.click(screen.getByRole('textbox'))
     await user.keyboard('{Enter}')
 
@@ -95,7 +90,8 @@ describe('ReviewCommentComposer', () => {
 
     render(
       <ReviewCommentComposer
-        anchor={anchor}
+        lineNumber={1}
+        side="additions"
         initialText="line one"
         onConfirm={handleConfirm}
         onCancel={vi.fn()}
@@ -103,7 +99,6 @@ describe('ReviewCommentComposer', () => {
     )
 
     const textarea = screen.getByRole('textbox')
-    // Move cursor to end then Shift+Enter
     await user.click(textarea)
     await user.keyboard('{Shift>}{Enter}{/Shift}')
 
@@ -117,13 +112,15 @@ describe('ReviewCommentComposer', () => {
 
     render(
       <ReviewCommentComposer
-        anchor={anchor}
+        lineNumber={1}
+        side="additions"
         initialText="some text"
         onConfirm={vi.fn()}
         onCancel={handleCancel}
       />
     )
 
+    await user.click(screen.getByRole('textbox'))
     await user.keyboard('{Escape}')
 
     expect(handleCancel).toHaveBeenCalledTimes(1)
@@ -135,7 +132,8 @@ describe('ReviewCommentComposer', () => {
 
     render(
       <ReviewCommentComposer
-        anchor={anchor}
+        lineNumber={1}
+        side="additions"
         onConfirm={vi.fn()}
         onCancel={handleCancel}
       />
@@ -146,48 +144,32 @@ describe('ReviewCommentComposer', () => {
     expect(handleCancel).toHaveBeenCalledTimes(1)
   })
 
-  test('Add comment button is disabled when text is empty', () => {
+  test('Comment button is disabled when text is empty', () => {
     render(
       <ReviewCommentComposer
-        anchor={anchor}
+        lineNumber={1}
+        side="additions"
         initialText=""
         onConfirm={vi.fn()}
         onCancel={vi.fn()}
       />
     )
 
-    expect(screen.getByRole('button', { name: 'Add comment' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Comment' })).toBeDisabled()
   })
 
-  test('Add comment button is disabled when text is whitespace only', () => {
+  test('Comment button is disabled when text is whitespace only', () => {
     render(
       <ReviewCommentComposer
-        anchor={anchor}
+        lineNumber={1}
+        side="additions"
         initialText="   "
         onConfirm={vi.fn()}
         onCancel={vi.fn()}
       />
     )
 
-    expect(screen.getByRole('button', { name: 'Add comment' })).toBeDisabled()
-  })
-
-  test('Enter does not confirm when text is empty', async () => {
-    const user = userEvent.setup()
-    const handleConfirm = vi.fn()
-
-    render(
-      <ReviewCommentComposer
-        anchor={anchor}
-        initialText=""
-        onConfirm={handleConfirm}
-        onCancel={vi.fn()}
-      />
-    )
-
-    await user.keyboard('{Enter}')
-
-    expect(handleConfirm).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Comment' })).toBeDisabled()
   })
 
   test('Enter does not confirm when text is whitespace only', async () => {
@@ -196,74 +178,37 @@ describe('ReviewCommentComposer', () => {
 
     render(
       <ReviewCommentComposer
-        anchor={anchor}
+        lineNumber={1}
+        side="additions"
         initialText="   "
         onConfirm={handleConfirm}
         onCancel={vi.fn()}
       />
     )
 
+    await user.click(screen.getByRole('textbox'))
     await user.keyboard('{Enter}')
 
     expect(handleConfirm).not.toHaveBeenCalled()
   })
 
-  test('Add comment button fires onConfirm with trimmed text when clicked', async () => {
+  test('Comment button fires onConfirm with trimmed text when clicked', async () => {
     const user = userEvent.setup()
     const handleConfirm = vi.fn()
 
     render(
       <ReviewCommentComposer
-        anchor={anchor}
+        lineNumber={1}
+        side="additions"
         initialText="valid comment"
         onConfirm={handleConfirm}
         onCancel={vi.fn()}
       />
     )
 
-    await user.click(screen.getByRole('button', { name: 'Add comment' }))
+    await user.click(screen.getByRole('button', { name: 'Comment' }))
 
     expect(handleConfirm).toHaveBeenCalledTimes(1)
     expect(handleConfirm).toHaveBeenCalledWith('valid comment')
-  })
-
-  test('click outside the popover calls onCancel via useDismiss', async () => {
-    const user = userEvent.setup()
-    const handleCancel = vi.fn()
-
-    render(
-      <ReviewCommentComposer
-        anchor={anchor}
-        initialText="some text"
-        onConfirm={vi.fn()}
-        onCancel={handleCancel}
-      />
-    )
-
-    // Click on a DOM element outside the floating popover.
-    // useDismiss fires onOpenChange(false) → onCancel on pointerdown outside.
-    await user.click(document.body)
-
-    await waitFor(() => {
-      expect(handleCancel).toHaveBeenCalledTimes(1)
-    })
-  })
-
-  test('renders the popover via FloatingPortal (outside the render container)', () => {
-    const { container } = render(
-      <ReviewCommentComposer
-        anchor={anchor}
-        onConfirm={vi.fn()}
-        onCancel={vi.fn()}
-      />
-    )
-
-    // The textarea must be in the document but NOT inside the React render root.
-    // FloatingPortal mounts directly under document.body, escaping the render container.
-    expect(screen.getByRole('textbox')).toBeInTheDocument()
-    // The render root (container) must not contain a textbox.
-    // (It is an empty div when FloatingPortal is used correctly.)
-    const { queryByRole } = within(container)
-    expect(queryByRole('textbox')).not.toBeInTheDocument()
   })
 })

--- a/src/features/diff/components/ReviewCommentComposer.tsx
+++ b/src/features/diff/components/ReviewCommentComposer.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState, type ReactElement } from 'react'
+import {
+  FloatingPortal,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react'
+
+interface ReviewCommentComposerProps {
+  anchor: HTMLElement
+  initialText?: string
+  onConfirm: (text: string) => void
+  onCancel: () => void
+}
+
+export const ReviewCommentComposer = ({
+  anchor,
+  initialText = '',
+  onConfirm,
+  onCancel,
+}: ReviewCommentComposerProps): ReactElement => {
+  const [text, setText] = useState(initialText)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: true,
+    onOpenChange: (open): void => {
+      if (!open) {
+        onCancel()
+      }
+    },
+    placement: 'bottom-start',
+    middleware: [offset(4), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+    elements: { reference: anchor },
+  })
+
+  const dismiss = useDismiss(context, { ancestorScroll: true })
+  const role = useRole(context, { role: 'dialog' })
+  const { getFloatingProps } = useInteractions([dismiss, role])
+
+  useEffect((): void => {
+    textareaRef.current?.focus()
+  }, [])
+
+  const submit = (): void => {
+    const trimmed = text.trim()
+
+    if (trimmed.length > 0) {
+      onConfirm(trimmed)
+    }
+  }
+
+  return (
+    <FloatingPortal>
+      <div
+        ref={refs.setFloating}
+        style={floatingStyles}
+        className="z-50 flex w-[320px] flex-col gap-2 rounded-lg border border-outline-variant/20 bg-surface-container-high/95 p-3 shadow-xl backdrop-blur-md"
+        {...getFloatingProps()}
+      >
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={(e): void => setText(e.target.value)}
+          onKeyDown={(e): void => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              submit()
+            } else if (e.key === 'Escape') {
+              e.preventDefault()
+              onCancel()
+            }
+          }}
+          rows={3}
+          className="resize-none rounded bg-surface-container/50 p-2 text-xs text-on-surface focus:outline-none focus:ring-1 focus:ring-primary"
+          placeholder="Add a comment…"
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={(): void => onCancel()}
+            className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={(): void => submit()}
+            disabled={text.trim().length === 0}
+            className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 disabled:opacity-50"
+          >
+            Add comment
+          </button>
+        </div>
+      </div>
+    </FloatingPortal>
+  )
+}

--- a/src/features/diff/components/ReviewCommentComposer.tsx
+++ b/src/features/diff/components/ReviewCommentComposer.tsx
@@ -1,25 +1,23 @@
 import { useEffect, useRef, useState, type ReactElement } from 'react'
-import {
-  FloatingPortal,
-  autoUpdate,
-  flip,
-  offset,
-  shift,
-  useDismiss,
-  useFloating,
-  useInteractions,
-  useRole,
-} from '@floating-ui/react'
+import type { AnnotationSide } from '@pierre/diffs'
 
 interface ReviewCommentComposerProps {
-  anchor: HTMLElement
+  /** 1-based line number the comment is anchored to. */
+  lineNumber: number
+  /** Which side of the diff the line lives on (additions => R, deletions => L). */
+  side: AnnotationSide
   initialText?: string
   onConfirm: (text: string) => void
   onCancel: () => void
 }
 
+// Codex-style inline comment composer. Rendered in Pierre's annotation slot
+// (full-width, below the target line) rather than as a floating popover, so it
+// sits in the diff flow and never chases the cursor. Enter submits, Shift+Enter
+// inserts a newline, Escape cancels.
 export const ReviewCommentComposer = ({
-  anchor,
+  lineNumber,
+  side,
   initialText = '',
   onConfirm,
   onCancel,
@@ -27,25 +25,13 @@ export const ReviewCommentComposer = ({
   const [text, setText] = useState(initialText)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-  const { refs, floatingStyles, context } = useFloating({
-    open: true,
-    onOpenChange: (open): void => {
-      if (!open) {
-        onCancel()
-      }
-    },
-    placement: 'bottom-start',
-    middleware: [offset(4), flip(), shift({ padding: 8 })],
-    whileElementsMounted: autoUpdate,
-    elements: { reference: anchor },
-  })
-
-  const dismiss = useDismiss(context, { ancestorScroll: true })
-  const role = useRole(context, { role: 'dialog' })
-  const { getFloatingProps } = useInteractions([dismiss, role])
-
   useEffect((): void => {
-    textareaRef.current?.focus()
+    const node = textareaRef.current
+    if (node) {
+      node.focus()
+      // Place the caret at the end when editing existing text.
+      node.setSelectionRange(node.value.length, node.value.length)
+    }
   }, [])
 
   const submit = (): void => {
@@ -56,49 +42,62 @@ export const ReviewCommentComposer = ({
     }
   }
 
+  const lineRef = `${side === 'deletions' ? 'L' : 'R'}${lineNumber}`
+
   return (
-    <FloatingPortal>
-      <div
-        ref={refs.setFloating}
-        style={floatingStyles}
-        className="z-50 flex w-[320px] flex-col gap-2 rounded-lg border border-outline-variant/20 bg-surface-container-high/95 p-3 shadow-xl backdrop-blur-md"
-        {...getFloatingProps()}
-      >
-        <textarea
-          ref={textareaRef}
-          value={text}
-          onChange={(e): void => setText(e.target.value)}
-          onKeyDown={(e): void => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault()
-              submit()
-            } else if (e.key === 'Escape') {
-              e.preventDefault()
-              onCancel()
-            }
-          }}
-          rows={3}
-          className="resize-none rounded bg-surface-container/50 p-2 text-xs text-on-surface focus:outline-none focus:ring-1 focus:ring-primary"
-          placeholder="Add a comment…"
-        />
-        <div className="flex justify-end gap-2">
-          <button
-            type="button"
-            onClick={(): void => onCancel()}
-            className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+    <div
+      role="dialog"
+      aria-label={`Comment on line ${lineRef}`}
+      className="mx-2 my-1 flex flex-col gap-2 rounded-lg bg-surface-container-high/80 p-3"
+    >
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-1.5 text-xs font-medium text-on-surface">
+          <span
+            aria-hidden="true"
+            className="material-symbols-outlined text-base leading-none"
           >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={(): void => submit()}
-            disabled={text.trim().length === 0}
-            className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 disabled:opacity-50"
-          >
-            Add comment
-          </button>
-        </div>
+            comment
+          </span>
+          Local comment
+        </span>
+        <span className="text-on-surface-variant text-[0.7rem]">
+          Comment on line {lineRef}
+        </span>
       </div>
-    </FloatingPortal>
+      <textarea
+        ref={textareaRef}
+        value={text}
+        onChange={(e): void => setText(e.target.value)}
+        onKeyDown={(e): void => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault()
+            submit()
+          } else if (e.key === 'Escape') {
+            e.preventDefault()
+            onCancel()
+          }
+        }}
+        rows={3}
+        className="resize-none rounded bg-surface-container/60 p-2 text-xs text-on-surface placeholder:text-on-surface-variant/60 focus:outline-none focus:ring-1 focus:ring-primary"
+        placeholder="Request change"
+      />
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={(): void => onCancel()}
+          className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={(): void => submit()}
+          disabled={text.trim().length === 0}
+          className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 disabled:opacity-50"
+        >
+          Comment
+        </button>
+      </div>
+    </div>
   )
 }

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -7,7 +7,12 @@ describe('ReviewCommentRow', () => {
   test('renders the comment text', () => {
     render(
       <ReviewCommentRow
-        comment={{ id: '1', text: 'Looks good to me', author: 'self', createdAt: 1000 }}
+        comment={{
+          id: '1',
+          text: 'Looks good to me',
+          author: 'self',
+          createdAt: 1000,
+        }}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />
@@ -39,7 +44,12 @@ describe('ReviewCommentRow', () => {
 
     render(
       <ReviewCommentRow
-        comment={{ id: '3', text: 'Remove this', author: 'self', createdAt: 3000 }}
+        comment={{
+          id: '3',
+          text: 'Remove this',
+          author: 'self',
+          createdAt: 3000,
+        }}
         onEdit={vi.fn()}
         onDelete={handleDelete}
       />
@@ -56,7 +66,12 @@ describe('ReviewCommentRow', () => {
 
     render(
       <ReviewCommentRow
-        comment={{ id: '4', text: 'Some comment', author: 'self', createdAt: 4000 }}
+        comment={{
+          id: '4',
+          text: 'Some comment',
+          author: 'self',
+          createdAt: 4000,
+        }}
         onEdit={vi.fn()}
         onDelete={handleDelete}
       />

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, test, vi } from 'vitest'
+import { ReviewCommentRow } from './ReviewCommentRow'
+
+describe('ReviewCommentRow', () => {
+  test('renders the comment text', () => {
+    render(
+      <ReviewCommentRow
+        comment={{ id: '1', text: 'Looks good to me', author: 'self', createdAt: 1000 }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Looks good to me')).toBeInTheDocument()
+  })
+
+  test('clicking Edit button fires onEdit once', async () => {
+    const user = userEvent.setup()
+    const handleEdit = vi.fn()
+
+    render(
+      <ReviewCommentRow
+        comment={{ id: '2', text: 'Fix this', author: 'self', createdAt: 2000 }}
+        onEdit={handleEdit}
+        onDelete={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Edit comment' }))
+
+    expect(handleEdit).toHaveBeenCalledTimes(1)
+  })
+
+  test('clicking Delete button fires onDelete once', async () => {
+    const user = userEvent.setup()
+    const handleDelete = vi.fn()
+
+    render(
+      <ReviewCommentRow
+        comment={{ id: '3', text: 'Remove this', author: 'self', createdAt: 3000 }}
+        onEdit={vi.fn()}
+        onDelete={handleDelete}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Delete comment' }))
+
+    expect(handleDelete).toHaveBeenCalledTimes(1)
+  })
+
+  test('clicking Edit does not fire onDelete', async () => {
+    const user = userEvent.setup()
+    const handleDelete = vi.fn()
+
+    render(
+      <ReviewCommentRow
+        comment={{ id: '4', text: 'Some comment', author: 'self', createdAt: 4000 }}
+        onEdit={vi.fn()}
+        onDelete={handleDelete}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Edit comment' }))
+
+    expect(handleDelete).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -23,7 +23,10 @@ export const ReviewCommentRow = ({
         className="rounded p-1 text-on-surface-variant hover:bg-surface-container-highest hover:text-on-surface"
         aria-label="Edit comment"
       >
-        <span aria-hidden="true" className="material-symbols-outlined text-base">
+        <span
+          aria-hidden="true"
+          className="material-symbols-outlined text-base"
+        >
           edit
         </span>
       </button>
@@ -33,7 +36,10 @@ export const ReviewCommentRow = ({
         className="rounded p-1 text-on-surface-variant hover:bg-error-container/30 hover:text-error"
         aria-label="Delete comment"
       >
-        <span aria-hidden="true" className="material-symbols-outlined text-base">
+        <span
+          aria-hidden="true"
+          className="material-symbols-outlined text-base"
+        >
           delete
         </span>
       </button>

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement } from 'react'
+import type { ReviewComment } from '../hooks/useFeedbackBatch'
+
+interface ReviewCommentRowProps {
+  comment: ReviewComment
+  onEdit: () => void
+  onDelete: () => void
+}
+
+export const ReviewCommentRow = ({
+  comment,
+  onEdit,
+  onDelete,
+}: ReviewCommentRowProps): ReactElement => (
+  <div className="mx-2 my-1 flex items-start gap-2 rounded-md bg-surface-container-high/60 px-3 py-2">
+    <p className="flex-1 break-words whitespace-pre-wrap text-xs text-on-surface">
+      {comment.text}
+    </p>
+    <div className="flex shrink-0 items-center gap-1">
+      <button
+        type="button"
+        onClick={(): void => onEdit()}
+        className="rounded p-1 text-on-surface-variant hover:bg-surface-container-highest hover:text-on-surface"
+        aria-label="Edit comment"
+      >
+        <span aria-hidden="true" className="material-symbols-outlined text-base">
+          edit
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={(): void => onDelete()}
+        className="rounded p-1 text-on-surface-variant hover:bg-error-container/30 hover:text-error"
+        aria-label="Delete comment"
+      >
+        <span aria-hidden="true" className="material-symbols-outlined text-base">
+          delete
+        </span>
+      </button>
+    </div>
+  </div>
+)

--- a/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
@@ -63,6 +63,9 @@ const renderToolbar = (
     onNextFile: vi.fn<() => void>(),
     currentFileIndex: 1,
     totalFiles: 9,
+    feedbackCount: 0,
+    onFinishFeedback: vi.fn<() => void>(),
+    onDiscardFeedback: vi.fn<() => void>(),
   }
 
   return render(<DiffChipToolbar {...baseProps} {...overrides} />)
@@ -604,6 +607,50 @@ describe('DiffChipToolbar', () => {
 
       expect(screen.getByLabelText(/hunk 2\/3/i)).toBeInTheDocument()
     })
+  })
+
+  test('does not render feedback chips when feedbackCount is 0', () => {
+    renderToolbar({ feedbackCount: 0 })
+
+    expect(
+      screen.queryByRole('button', { name: /finish feedback/i })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: /discard feedback/i })
+    ).not.toBeInTheDocument()
+  })
+
+  test('renders both feedback chips when feedbackCount > 0', () => {
+    renderToolbar({ feedbackCount: 3 })
+
+    expect(
+      screen.getByRole('button', { name: /finish feedback \(3\)/i })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: /discard feedback/i })
+    ).toBeInTheDocument()
+  })
+
+  test('clicking Finish feedback chip calls onFinishFeedback once', async () => {
+    const user = userEvent.setup()
+    const onFinishFeedback = vi.fn<() => void>()
+
+    renderToolbar({ feedbackCount: 3, onFinishFeedback })
+
+    await user.click(screen.getByRole('button', { name: /finish feedback/i }))
+    expect(onFinishFeedback).toHaveBeenCalledTimes(1)
+  })
+
+  test('clicking Discard feedback chip calls onDiscardFeedback once', async () => {
+    const user = userEvent.setup()
+    const onDiscardFeedback = vi.fn<() => void>()
+
+    renderToolbar({ feedbackCount: 3, onDiscardFeedback })
+
+    await user.click(screen.getByRole('button', { name: /discard feedback/i }))
+    expect(onDiscardFeedback).toHaveBeenCalledTimes(1)
   })
 
   test('PriorityPlus collapses the lower-priority chips into the overflow menu at a narrow width', () => {

--- a/src/features/diff/components/toolbar/DiffChipToolbar.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.tsx
@@ -136,6 +136,14 @@ export interface DiffChipToolbarProps {
   // Filename shown in the Discard All confirmation popover ("Discard all
   // changes to <selectedFileName>?"). Optional — omit for a generic prompt.
   selectedFileName?: string
+  // Feedback actions — inline review feedback chips. When `feedbackCount > 0`
+  // the toolbar renders a high-priority "Finish feedback (N)" chip plus a
+  // muted, lowest-priority "Discard feedback" chip; at 0 neither renders.
+  // Optional (default 0 / no-op) so pre-feedback callers are unaffected,
+  // mirroring the other optional-handler chips in this component.
+  feedbackCount?: number
+  onFinishFeedback?: () => void
+  onDiscardFeedback?: () => void
 }
 
 // Styling shared by every icon-button chip — the staging chips, the prev/next
@@ -162,6 +170,24 @@ const COUNTER_CHIP_CLASSES =
   'inline-flex items-center justify-center gap-1 min-w-[3.25rem] h-8 px-2 ' +
   'rounded-md bg-surface-container/40 text-on-surface-variant text-[0.7rem] ' +
   'font-mono tracking-tight'
+
+// Interactive text chip — used by the feedback actions. Mirrors the counter
+// chip sizing but adds hover affordance so it reads as clickable.
+const TEXT_CHIP_CLASSES =
+  'inline-flex items-center justify-center gap-1 h-8 px-2 ' +
+  'rounded-md bg-surface-container/40 text-on-surface-variant text-[0.7rem] ' +
+  'font-mono tracking-tight ' +
+  'hover:bg-surface-container/70 hover:text-on-surface ' +
+  'transition-colors'
+
+// Muted interactive text chip — used by the Discard feedback action. Lower
+// contrast surface so it overflows first, but still interactive on hover.
+const MUTED_TEXT_CHIP_CLASSES =
+  'inline-flex items-center justify-center gap-1 h-8 px-2 ' +
+  'rounded-md bg-surface-container/20 text-on-surface-variant/40 ' +
+  'text-[0.7rem] font-mono tracking-tight ' +
+  'hover:bg-surface-container/30 hover:text-on-surface-variant/60 ' +
+  'transition-colors'
 
 // Wrap an aria-disabled chip in an "Available in PRx" tooltip so users know
 // the placeholder will light up later. The button stays focusable because
@@ -350,6 +376,9 @@ export const DiffChipToolbar = ({
   onDiscardAll = undefined,
   staging = false,
   selectedFileName = undefined,
+  feedbackCount = 0,
+  onFinishFeedback = undefined,
+  onDiscardFeedback = undefined,
 }: DiffChipToolbarProps): ReactElement => {
   // Discard All confirmation popover state. The trigger is the discard-all
   // chip; the floating content is the DiscardAllConfirm component rendered
@@ -468,7 +497,21 @@ export const DiffChipToolbar = ({
       onClick={onNextHunk}
       disabled={!hunkNavEnabled}
     />,
-    // 8. stage — FUNCTIONAL in PR2 when onStage is provided.
+    // 8. finish feedback — shown when there is pending inline review feedback.
+    ...(feedbackCount > 0
+      ? [
+          <button
+            key="finish-feedback"
+            type="button"
+            aria-label={`finish feedback (${feedbackCount})`}
+            onClick={onFinishFeedback}
+            className={TEXT_CHIP_CLASSES}
+          >
+            Finish feedback ({feedbackCount})
+          </button>,
+        ]
+      : []),
+    // 9. stage — FUNCTIONAL in PR2 when onStage is provided.
     onStage !== undefined ? (
       <IconChip
         key="stage"
@@ -581,7 +624,7 @@ export const DiffChipToolbar = ({
         <DisabledIconChip icon="delete_sweep" label="discard all" />
       </ComingSoonTooltip>
     ),
-    // 12. highlight dropdown — `lineDiffType` Pierre option.
+    // 13. highlight dropdown — `lineDiffType` Pierre option.
     <Dropdown
       key="highlight"
       label="highlight"
@@ -590,7 +633,7 @@ export const DiffChipToolbar = ({
       onChange={onLineDiffTypeChange}
       width={260}
     />,
-    // 13. theme dropdown — `DiffsThemeNames` enumeration.
+    // 14. theme dropdown — `DiffsThemeNames` enumeration.
     <Dropdown
       key="theme"
       label="theme"
@@ -598,7 +641,7 @@ export const DiffChipToolbar = ({
       options={THEME_OPTIONS}
       onChange={onThemeChange}
     />,
-    // 14. View ▾ gear chip — consolidates the indicators / overflow
+    // 15. View ▾ gear chip — consolidates the indicators / overflow
     // dropdowns and the four boolean toggle chips into a single portal-
     // rendered popover with a Format section (nested sub-dropdowns) and
     // a View Options section (checkbox rows). Replaces six standalone
@@ -619,6 +662,21 @@ export const DiffChipToolbar = ({
       stickyHeader={stickyHeader}
       onStickyHeaderChange={onStickyHeaderChange}
     />,
+    // 16. discard feedback — muted text chip, lowest priority so Priority+
+    // overflows it first. Only renders when there is pending feedback.
+    ...(feedbackCount > 0
+      ? [
+          <button
+            key="discard-feedback"
+            type="button"
+            aria-label="discard feedback"
+            onClick={onDiscardFeedback}
+            className={MUTED_TEXT_CHIP_CLASSES}
+          >
+            Discard feedback
+          </button>,
+        ]
+      : []),
   ]
 
   return (

--- a/src/features/diff/demo/InlineCommentDemo.tsx
+++ b/src/features/diff/demo/InlineCommentDemo.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useMemo, useState, type ReactElement } from 'react'
 import { MultiFileDiff } from '@pierre/diffs/react'
 import type { AnnotationSide, DiffLineAnnotation } from '@pierre/diffs'
-import { useFeedbackBatch, type ReviewComment } from '../hooks/useFeedbackBatch'
+import {
+  useFeedbackBatch,
+  DRAFT_ID,
+  type ReviewComment,
+} from '../hooks/useFeedbackBatch'
 import { ReviewCommentComposer } from '../components/ReviewCommentComposer'
 import { ReviewCommentRow } from '../components/ReviewCommentRow'
 
@@ -16,10 +20,6 @@ import { ReviewCommentRow } from '../components/ReviewCommentRow'
 
 const DEMO_CWD = '/demo'
 const DEMO_FILE = 'greet.ts'
-
-// Sentinel id marking the transient "draft" annotation that renders the
-// composer inline before a real comment exists.
-const DRAFT_ID = '__draft__'
 
 const OLD_CONTENTS = `export function greet(name) {
   const msg = 'Hello, ' + name

--- a/src/features/diff/demo/InlineCommentDemo.tsx
+++ b/src/features/diff/demo/InlineCommentDemo.tsx
@@ -55,7 +55,11 @@ export const InlineCommentDemo = (): ReactElement => {
   const feedback = useFeedbackBatch()
   const [target, setTarget] = useState<ComposerTarget | null>(null)
 
-  const realAnnotations = feedback.annotationsForFile(DEMO_CWD, DEMO_FILE)
+  const realAnnotations = feedback.annotationsForFile(
+    DEMO_CWD,
+    DEMO_FILE,
+    false
+  )
 
   // Merge a transient draft annotation in only while composing a NEW comment,
   // so the composer renders inline below the target line. Editing reuses the
@@ -84,11 +88,17 @@ export const InlineCommentDemo = (): ReactElement => {
         }
 
         if (current.editId !== undefined) {
-          feedback.updateAnnotation(DEMO_CWD, DEMO_FILE, current.editId, {
-            text,
-          })
+          feedback.updateAnnotation(
+            DEMO_CWD,
+            DEMO_FILE,
+            false,
+            current.editId,
+            {
+              text,
+            }
+          )
         } else {
-          feedback.addAnnotation(DEMO_CWD, DEMO_FILE, {
+          feedback.addAnnotation(DEMO_CWD, DEMO_FILE, false, {
             side: current.side,
             lineNumber: current.lineNumber,
             metadata: {
@@ -194,6 +204,7 @@ export const InlineCommentDemo = (): ReactElement => {
                   feedback.removeAnnotation(
                     DEMO_CWD,
                     DEMO_FILE,
+                    false,
                     annotation.metadata.id
                   )
                 }

--- a/src/features/diff/demo/InlineCommentDemo.tsx
+++ b/src/features/diff/demo/InlineCommentDemo.tsx
@@ -147,10 +147,13 @@ export const InlineCommentDemo = (): ReactElement => {
           }}
           lineAnnotations={lineAnnotations}
           renderGutterUtility={(getHoveredLine): ReactElement => (
+            // translate-x-3/4 shifts the "+" out of the line-number cell into the
+            // gutter gap next to the code (GitHub-style) — Pierre otherwise
+            // center-anchors it on top of the number. Mirrors DiffPanelContent.
             <button
               type="button"
               aria-label="Add comment on this line"
-              className="flex h-5 w-5 items-center justify-center rounded bg-primary/80 text-on-primary hover:bg-primary"
+              className="flex h-5 w-5 translate-x-3/4 items-center justify-center rounded-full bg-primary text-on-primary shadow-md hover:bg-primary/90"
               onClick={(): void => {
                 const hovered = getHoveredLine()
                 if (hovered) {

--- a/src/features/diff/demo/InlineCommentDemo.tsx
+++ b/src/features/diff/demo/InlineCommentDemo.tsx
@@ -1,0 +1,223 @@
+import { useCallback, useRef, useState, type ReactElement } from 'react'
+import { MultiFileDiff } from '@pierre/diffs/react'
+import type { AnnotationSide, DiffLineAnnotation } from '@pierre/diffs'
+import { useFeedbackBatch, type ReviewComment } from '../hooks/useFeedbackBatch'
+import { ReviewCommentComposer } from '../components/ReviewCommentComposer'
+import { ReviewCommentRow } from '../components/ReviewCommentRow'
+
+// Dev-only interactive demo justifying the PR4 "gutter affordance" approach to
+// adding inline review comments (spec §7). It wires the REAL Pierre
+// `renderGutterUtility` + `getHoveredLine` API (the only per-line interaction
+// hook `<MultiFileDiff>` exposes — there is no `onDiffLineClick`) to the real
+// ReviewCommentComposer / ReviewCommentRow / useFeedbackBatch built in Tasks
+// 4.1–4.2, so hovering a line, clicking the gutter 💬, and seeing the comment
+// render inline can be validated by hand before the full DiffPanelContent
+// integration (Task 4.5). Launch via `npm run dev` → `?demo=inline-comments`.
+
+const DEMO_CWD = '/demo'
+const DEMO_FILE = 'greet.ts'
+
+const OLD_CONTENTS = `export function greet(name) {
+  const msg = 'Hello, ' + name
+  console.log(msg)
+  return msg
+}
+`
+
+const NEW_CONTENTS = `export function greet(name: string): string {
+  const msg = \`Hello, \${name}!\`
+  logger.info(msg)
+  return msg
+}
+`
+
+// Monotonic id source. A module counter keeps comment ids stable + unique
+// without reaching for Date.now()/Math.random() in render.
+let commentSeq = 0
+const nextCommentId = (): string => `demo-comment-${(commentSeq += 1)}`
+
+interface ComposerState {
+  anchor: HTMLElement
+  side: AnnotationSide
+  lineNumber: number
+  editId?: string
+  initialText: string
+}
+
+/**
+ * InlineCommentDemo - dev harness for the gutter-comment interaction.
+ */
+export const InlineCommentDemo = (): ReactElement => {
+  const feedback = useFeedbackBatch()
+  const [composer, setComposer] = useState<ComposerState | null>(null)
+
+  const annotations = feedback.annotationsForFile(DEMO_CWD, DEMO_FILE)
+
+  const openAddComposer = useCallback(
+    (anchor: HTMLElement, lineNumber: number, side: AnnotationSide): void => {
+      setComposer({ anchor, side, lineNumber, initialText: '' })
+    },
+    []
+  )
+
+  const openEditComposer = useCallback(
+    (
+      anchor: HTMLElement,
+      annotation: DiffLineAnnotation<ReviewComment>
+    ): void => {
+      setComposer({
+        anchor,
+        side: annotation.side,
+        lineNumber: annotation.lineNumber,
+        editId: annotation.metadata.id,
+        initialText: annotation.metadata.text,
+      })
+    },
+    []
+  )
+
+  const confirmComposer = useCallback(
+    (text: string): void => {
+      if (composer === null) {
+        return
+      }
+
+      if (composer.editId !== undefined) {
+        feedback.updateAnnotation(DEMO_CWD, DEMO_FILE, composer.editId, {
+          text,
+        })
+      } else {
+        const comment: ReviewComment = {
+          id: nextCommentId(),
+          text,
+          author: 'self',
+          createdAt: Date.now(),
+        }
+        feedback.addAnnotation(DEMO_CWD, DEMO_FILE, {
+          side: composer.side,
+          lineNumber: composer.lineNumber,
+          metadata: comment,
+        })
+      }
+
+      setComposer(null)
+    },
+    [composer, feedback]
+  )
+
+  const closeComposer = useCallback((): void => {
+    setComposer(null)
+  }, [])
+
+  return (
+    <div className="flex h-screen w-screen flex-col bg-surface text-on-surface">
+      <header className="shrink-0 px-4 py-3">
+        <h1 className="font-headline text-sm font-semibold">
+          Inline review comments — gutter affordance demo
+        </h1>
+        <p className="text-on-surface-variant text-xs">
+          Hover a diff line, click the 💬 in the gutter, type a comment, press
+          Enter. {feedback.totalAnnotations()} comment(s) in the batch.
+        </p>
+      </header>
+      <div className="thin-scrollbar min-h-0 flex-1 overflow-auto px-4 pb-8">
+        <MultiFileDiff
+          oldFile={{ name: DEMO_FILE, contents: OLD_CONTENTS }}
+          newFile={{ name: DEMO_FILE, contents: NEW_CONTENTS }}
+          // `enableGutterUtility` is REQUIRED to activate Pierre's per-line
+          // hover tracking + render the gutter slot — without it
+          // `handlePointerMove` ignores hover and the 💬 button never appears
+          // (the `renderGutterUtility` prop alone does nothing). See
+          // node_modules/@pierre/diffs/dist/managers/InteractionManager.js.
+          options={{
+            diffStyle: 'unified',
+            theme: 'pierre-dark',
+            enableGutterUtility: true,
+          }}
+          lineAnnotations={annotations}
+          renderGutterUtility={(getHoveredLine): ReactElement => (
+            <button
+              type="button"
+              aria-label="Add comment on this line"
+              className="flex h-5 w-5 items-center justify-center rounded bg-primary/80 text-on-primary hover:bg-primary"
+              onClick={(event): void => {
+                const hovered = getHoveredLine()
+                if (hovered) {
+                  openAddComposer(
+                    event.currentTarget,
+                    hovered.lineNumber,
+                    hovered.side
+                  )
+                }
+              }}
+            >
+              <span
+                aria-hidden="true"
+                className="material-symbols-outlined text-sm leading-none"
+              >
+                add_comment
+              </span>
+            </button>
+          )}
+          renderAnnotation={(
+            annotation: DiffLineAnnotation<ReviewComment>
+          ): ReactElement => (
+            <AnnotationRow
+              annotation={annotation}
+              onEdit={openEditComposer}
+              onDelete={(): void =>
+                feedback.removeAnnotation(
+                  DEMO_CWD,
+                  DEMO_FILE,
+                  annotation.metadata.id
+                )
+              }
+            />
+          )}
+          style={{ display: 'block', width: '100%' }}
+        />
+      </div>
+      {composer !== null ? (
+        <ReviewCommentComposer
+          anchor={composer.anchor}
+          initialText={composer.initialText}
+          onConfirm={confirmComposer}
+          onCancel={closeComposer}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+// Small wrapper so the edit affordance can capture its own DOM element as the
+// composer anchor (ReviewCommentRow is anchor-agnostic by design).
+interface AnnotationRowProps {
+  annotation: DiffLineAnnotation<ReviewComment>
+  onEdit: (
+    anchor: HTMLElement,
+    annotation: DiffLineAnnotation<ReviewComment>
+  ) => void
+  onDelete: () => void
+}
+
+const AnnotationRow = ({
+  annotation,
+  onEdit,
+  onDelete,
+}: AnnotationRowProps): ReactElement => {
+  const ref = useRef<HTMLDivElement>(null)
+
+  return (
+    <div ref={ref}>
+      <ReviewCommentRow
+        comment={annotation.metadata}
+        onEdit={(): void => {
+          if (ref.current) {
+            onEdit(ref.current, annotation)
+          }
+        }}
+        onDelete={onDelete}
+      />
+    </div>
+  )
+}

--- a/src/features/diff/demo/InlineCommentDemo.tsx
+++ b/src/features/diff/demo/InlineCommentDemo.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, type ReactElement } from 'react'
+import { useCallback, useMemo, useState, type ReactElement } from 'react'
 import { MultiFileDiff } from '@pierre/diffs/react'
 import type { AnnotationSide, DiffLineAnnotation } from '@pierre/diffs'
 import { useFeedbackBatch, type ReviewComment } from '../hooks/useFeedbackBatch'
@@ -6,16 +6,20 @@ import { ReviewCommentComposer } from '../components/ReviewCommentComposer'
 import { ReviewCommentRow } from '../components/ReviewCommentRow'
 
 // Dev-only interactive demo justifying the PR4 "gutter affordance" approach to
-// adding inline review comments (spec §7). It wires the REAL Pierre
-// `renderGutterUtility` + `getHoveredLine` API (the only per-line interaction
-// hook `<MultiFileDiff>` exposes — there is no `onDiffLineClick`) to the real
-// ReviewCommentComposer / ReviewCommentRow / useFeedbackBatch built in Tasks
-// 4.1–4.2, so hovering a line, clicking the gutter 💬, and seeing the comment
-// render inline can be validated by hand before the full DiffPanelContent
-// integration (Task 4.5). Launch via `npm run dev` → `?demo=inline-comments`.
+// adding inline review comments (spec §7), matching the Codex inline-composer
+// UX: a `+` in the gutter on hover opens a FULL-WIDTH composer panel BELOW the
+// line (via Pierre's `renderAnnotation` slot, driven by a transient draft
+// annotation) — not a floating popover. Wires the real Pierre
+// `renderGutterUtility` + `getHoveredLine` API to the real
+// ReviewCommentComposer / ReviewCommentRow / useFeedbackBatch (Tasks 4.1–4.2).
+// Launch: `npm run dev` → http://localhost:5173/?demo=inline-comments
 
 const DEMO_CWD = '/demo'
 const DEMO_FILE = 'greet.ts'
+
+// Sentinel id marking the transient "draft" annotation that renders the
+// composer inline before a real comment exists.
+const DRAFT_ID = '__draft__'
 
 const OLD_CONTENTS = `export function greet(name) {
   const msg = 'Hello, ' + name
@@ -36,77 +40,74 @@ const NEW_CONTENTS = `export function greet(name: string): string {
 let commentSeq = 0
 const nextCommentId = (): string => `demo-comment-${(commentSeq += 1)}`
 
-interface ComposerState {
-  anchor: HTMLElement
-  side: AnnotationSide
+// Which line currently has an open composer. `editId` set => editing an
+// existing comment in place; absent => a new draft on that line.
+interface ComposerTarget {
   lineNumber: number
+  side: AnnotationSide
   editId?: string
-  initialText: string
 }
 
 /**
- * InlineCommentDemo - dev harness for the gutter-comment interaction.
+ * InlineCommentDemo - dev harness for the Codex-style gutter-comment flow.
  */
 export const InlineCommentDemo = (): ReactElement => {
   const feedback = useFeedbackBatch()
-  const [composer, setComposer] = useState<ComposerState | null>(null)
+  const [target, setTarget] = useState<ComposerTarget | null>(null)
 
-  const annotations = feedback.annotationsForFile(DEMO_CWD, DEMO_FILE)
+  const realAnnotations = feedback.annotationsForFile(DEMO_CWD, DEMO_FILE)
 
-  const openAddComposer = useCallback(
-    (anchor: HTMLElement, lineNumber: number, side: AnnotationSide): void => {
-      setComposer({ anchor, side, lineNumber, initialText: '' })
-    },
-    []
-  )
+  // Merge a transient draft annotation in only while composing a NEW comment,
+  // so the composer renders inline below the target line. Editing reuses the
+  // existing annotation's slot, so no draft is added there. When idle we pass
+  // `realAnnotations` straight through to keep its identity stable (avoids
+  // Pierre re-tokenizing on every render).
+  const lineAnnotations = useMemo((): DiffLineAnnotation<ReviewComment>[] => {
+    if (target !== null && target.editId === undefined) {
+      const draft: DiffLineAnnotation<ReviewComment> = {
+        side: target.side,
+        lineNumber: target.lineNumber,
+        metadata: { id: DRAFT_ID, text: '', author: 'self', createdAt: 0 },
+      }
 
-  const openEditComposer = useCallback(
-    (
-      anchor: HTMLElement,
-      annotation: DiffLineAnnotation<ReviewComment>
-    ): void => {
-      setComposer({
-        anchor,
-        side: annotation.side,
-        lineNumber: annotation.lineNumber,
-        editId: annotation.metadata.id,
-        initialText: annotation.metadata.text,
-      })
-    },
-    []
-  )
+      return [...realAnnotations, draft]
+    }
+
+    return realAnnotations
+  }, [realAnnotations, target])
 
   const confirmComposer = useCallback(
     (text: string): void => {
-      if (composer === null) {
-        return
-      }
-
-      if (composer.editId !== undefined) {
-        feedback.updateAnnotation(DEMO_CWD, DEMO_FILE, composer.editId, {
-          text,
-        })
-      } else {
-        const comment: ReviewComment = {
-          id: nextCommentId(),
-          text,
-          author: 'self',
-          createdAt: Date.now(),
+      setTarget((current) => {
+        if (current === null) {
+          return null
         }
-        feedback.addAnnotation(DEMO_CWD, DEMO_FILE, {
-          side: composer.side,
-          lineNumber: composer.lineNumber,
-          metadata: comment,
-        })
-      }
 
-      setComposer(null)
+        if (current.editId !== undefined) {
+          feedback.updateAnnotation(DEMO_CWD, DEMO_FILE, current.editId, {
+            text,
+          })
+        } else {
+          feedback.addAnnotation(DEMO_CWD, DEMO_FILE, {
+            side: current.side,
+            lineNumber: current.lineNumber,
+            metadata: {
+              id: nextCommentId(),
+              text,
+              author: 'self',
+              createdAt: Date.now(),
+            },
+          })
+        }
+
+        return null
+      })
     },
-    [composer, feedback]
+    [feedback]
   )
 
   const closeComposer = useCallback((): void => {
-    setComposer(null)
+    setTarget(null)
   }, [])
 
   return (
@@ -116,7 +117,7 @@ export const InlineCommentDemo = (): ReactElement => {
           Inline review comments — gutter affordance demo
         </h1>
         <p className="text-on-surface-variant text-xs">
-          Hover a diff line, click the 💬 in the gutter, type a comment, press
+          Hover a diff line, click the + in the gutter, type a comment, press
           Enter. {feedback.totalAnnotations()} comment(s) in the batch.
         </p>
       </header>
@@ -126,7 +127,7 @@ export const InlineCommentDemo = (): ReactElement => {
           newFile={{ name: DEMO_FILE, contents: NEW_CONTENTS }}
           // `enableGutterUtility` is REQUIRED to activate Pierre's per-line
           // hover tracking + render the gutter slot — without it
-          // `handlePointerMove` ignores hover and the 💬 button never appears
+          // `handlePointerMove` ignores hover and the + button never appears
           // (the `renderGutterUtility` prop alone does nothing). See
           // node_modules/@pierre/diffs/dist/managers/InteractionManager.js.
           options={{
@@ -134,20 +135,19 @@ export const InlineCommentDemo = (): ReactElement => {
             theme: 'pierre-dark',
             enableGutterUtility: true,
           }}
-          lineAnnotations={annotations}
+          lineAnnotations={lineAnnotations}
           renderGutterUtility={(getHoveredLine): ReactElement => (
             <button
               type="button"
               aria-label="Add comment on this line"
               className="flex h-5 w-5 items-center justify-center rounded bg-primary/80 text-on-primary hover:bg-primary"
-              onClick={(event): void => {
+              onClick={(): void => {
                 const hovered = getHoveredLine()
                 if (hovered) {
-                  openAddComposer(
-                    event.currentTarget,
-                    hovered.lineNumber,
-                    hovered.side
-                  )
+                  setTarget({
+                    lineNumber: hovered.lineNumber,
+                    side: hovered.side,
+                  })
                 }
               }}
             >
@@ -155,69 +155,54 @@ export const InlineCommentDemo = (): ReactElement => {
                 aria-hidden="true"
                 className="material-symbols-outlined text-sm leading-none"
               >
-                add_comment
+                add
               </span>
             </button>
           )}
           renderAnnotation={(
             annotation: DiffLineAnnotation<ReviewComment>
-          ): ReactElement => (
-            <AnnotationRow
-              annotation={annotation}
-              onEdit={openEditComposer}
-              onDelete={(): void =>
-                feedback.removeAnnotation(
-                  DEMO_CWD,
-                  DEMO_FILE,
-                  annotation.metadata.id
-                )
-              }
-            />
-          )}
+          ): ReactElement => {
+            const isDraft = annotation.metadata.id === DRAFT_ID
+
+            const isEditing =
+              target?.editId !== undefined &&
+              target.editId === annotation.metadata.id
+
+            if (isDraft || isEditing) {
+              return (
+                <ReviewCommentComposer
+                  lineNumber={annotation.lineNumber}
+                  side={annotation.side}
+                  initialText={isEditing ? annotation.metadata.text : ''}
+                  onConfirm={confirmComposer}
+                  onCancel={closeComposer}
+                />
+              )
+            }
+
+            return (
+              <ReviewCommentRow
+                comment={annotation.metadata}
+                onEdit={(): void =>
+                  setTarget({
+                    lineNumber: annotation.lineNumber,
+                    side: annotation.side,
+                    editId: annotation.metadata.id,
+                  })
+                }
+                onDelete={(): void =>
+                  feedback.removeAnnotation(
+                    DEMO_CWD,
+                    DEMO_FILE,
+                    annotation.metadata.id
+                  )
+                }
+              />
+            )
+          }}
           style={{ display: 'block', width: '100%' }}
         />
       </div>
-      {composer !== null ? (
-        <ReviewCommentComposer
-          anchor={composer.anchor}
-          initialText={composer.initialText}
-          onConfirm={confirmComposer}
-          onCancel={closeComposer}
-        />
-      ) : null}
-    </div>
-  )
-}
-
-// Small wrapper so the edit affordance can capture its own DOM element as the
-// composer anchor (ReviewCommentRow is anchor-agnostic by design).
-interface AnnotationRowProps {
-  annotation: DiffLineAnnotation<ReviewComment>
-  onEdit: (
-    anchor: HTMLElement,
-    annotation: DiffLineAnnotation<ReviewComment>
-  ) => void
-  onDelete: () => void
-}
-
-const AnnotationRow = ({
-  annotation,
-  onEdit,
-  onDelete,
-}: AnnotationRowProps): ReactElement => {
-  const ref = useRef<HTMLDivElement>(null)
-
-  return (
-    <div ref={ref}>
-      <ReviewCommentRow
-        comment={annotation.metadata}
-        onEdit={(): void => {
-          if (ref.current) {
-            onEdit(ref.current, annotation)
-          }
-        }}
-        onDelete={onDelete}
-      />
     </div>
   )
 }

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useFeedbackBatch } from './useFeedbackBatch'
+import type { ReviewComment } from './useFeedbackBatch'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+
+const makeAnnotation = (
+  id: string,
+  text = 'comment',
+  lineNumber = 1,
+  side: 'additions' | 'deletions' = 'additions',
+): DiffLineAnnotation<ReviewComment> => ({
+  side,
+  lineNumber,
+  metadata: {
+    id,
+    text,
+    author: 'self',
+    createdAt: 1000,
+  },
+})
+
+describe('useFeedbackBatch', () => {
+  test('empty initial state: totalAnnotations === 0 and annotationsForFile returns []', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    expect(result.current.totalAnnotations()).toBe(0)
+    expect(result.current.annotationsForFile('/r', 'a.ts')).toEqual([])
+  })
+
+  test('add one annotation: annotationsForFile returns it; totalAnnotations === 1', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+    const annotation = makeAnnotation('ann-1')
+
+    act(() => {
+      result.current.addAnnotation('/repo', 'src/a.ts', annotation)
+    })
+
+    expect(result.current.totalAnnotations()).toBe(1)
+    const list = result.current.annotationsForFile('/repo', 'src/a.ts')
+    expect(list).toHaveLength(1)
+    expect(list[0]).toEqual(annotation)
+  })
+
+  test('annotationsForFile returns STABLE reference for absent file across two calls', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    const first = result.current.annotationsForFile('/repo', 'missing.ts')
+    const second = result.current.annotationsForFile('/repo', 'missing.ts')
+
+    // Both calls must return the exact same array object (module-level EMPTY)
+    expect(first).toBe(second)
+  })
+
+  test('add 50 then 51st addAnnotation returns cap-reached and totalAnnotations stays 50', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    // Add 50 annotations across multiple files to hit the cap
+    act(() => {
+      for (let i = 0; i < 50; i++) {
+        result.current.addAnnotation('/repo', `file-${i}.ts`, makeAnnotation(`id-${i}`, 'x', i + 1))
+      }
+    })
+
+    expect(result.current.totalAnnotations()).toBe(50)
+
+    let returnValue: 'ok' | 'cap-reached' = 'ok'
+    act(() => {
+      returnValue = result.current.addAnnotation('/repo', 'extra.ts', makeAnnotation('id-extra'))
+    })
+
+    expect(returnValue).toBe('cap-reached')
+    expect(result.current.totalAnnotations()).toBe(50)
+  })
+
+  test('updateAnnotation patches text; preserves createdAt, author, side, lineNumber', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    const original = makeAnnotation('upd-1', 'original text', 5, 'deletions')
+
+    act(() => {
+      result.current.addAnnotation('/repo', 'b.ts', original)
+    })
+
+    act(() => {
+      result.current.updateAnnotation('/repo', 'b.ts', 'upd-1', { text: 'updated text' })
+    })
+
+    const [updated] = result.current.annotationsForFile('/repo', 'b.ts')
+    expect(updated.metadata.text).toBe('updated text')
+    expect(updated.metadata.createdAt).toBe(1000)
+    expect(updated.metadata.author).toBe('self')
+    expect(updated.side).toBe('deletions')
+    expect(updated.lineNumber).toBe(5)
+  })
+
+  test('remove the only annotation for a file deletes the Map key entirely', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+    const cwd = '/repo'
+    const filePath = 'solo.ts'
+    const key = `${cwd}::${filePath}`
+
+    act(() => {
+      result.current.addAnnotation(cwd, filePath, makeAnnotation('solo-1'))
+    })
+
+    expect(result.current.batch.has(key)).toBe(true)
+
+    act(() => {
+      result.current.removeAnnotation(cwd, filePath, 'solo-1')
+    })
+
+    expect(result.current.batch.has(key)).toBe(false)
+  })
+
+  test('remove one of two annotations leaves key with list length 1', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+    const cwd = '/repo'
+    const filePath = 'duo.ts'
+
+    act(() => {
+      result.current.addAnnotation(cwd, filePath, makeAnnotation('duo-1', 'first', 1))
+      result.current.addAnnotation(cwd, filePath, makeAnnotation('duo-2', 'second', 2))
+    })
+
+    act(() => {
+      result.current.removeAnnotation(cwd, filePath, 'duo-1')
+    })
+
+    const list = result.current.annotationsForFile(cwd, filePath)
+    expect(list).toHaveLength(1)
+    expect(list[0].metadata.id).toBe('duo-2')
+    expect(result.current.batch.has(`${cwd}::${filePath}`)).toBe(true)
+  })
+
+  test('clearBatch empties the Map', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    act(() => {
+      result.current.addAnnotation('/repo', 'a.ts', makeAnnotation('c-1'))
+      result.current.addAnnotation('/repo', 'b.ts', makeAnnotation('c-2'))
+    })
+
+    expect(result.current.totalAnnotations()).toBe(2)
+
+    act(() => {
+      result.current.clearBatch()
+    })
+
+    expect(result.current.totalAnnotations()).toBe(0)
+    expect(result.current.batch.size).toBe(0)
+  })
+
+  test('clearBatch identity is stable across a re-render (add does not change clearBatch ref)', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    // Capture clearBatch before any state change
+    const clearBatchBefore = result.current.clearBatch
+
+    // Trigger a state change via add — batch updates, so many callbacks change
+    act(() => {
+      result.current.addAnnotation('/repo', 'a.ts', makeAnnotation('stab-1'))
+    })
+
+    // clearBatch must be the same function reference ([] dep array)
+    expect(result.current.clearBatch).toBe(clearBatchBefore)
+  })
+})

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -8,7 +8,7 @@ const makeAnnotation = (
   id: string,
   text = 'comment',
   lineNumber = 1,
-  side: 'additions' | 'deletions' = 'additions',
+  side: 'additions' | 'deletions' = 'additions'
 ): DiffLineAnnotation<ReviewComment> => ({
   side,
   lineNumber,
@@ -25,7 +25,7 @@ describe('useFeedbackBatch', () => {
     const { result } = renderHook(() => useFeedbackBatch())
 
     expect(result.current.totalAnnotations()).toBe(0)
-    expect(result.current.annotationsForFile('/r', 'a.ts')).toEqual([])
+    expect(result.current.annotationsForFile('/r', 'a.ts', false)).toEqual([])
   })
 
   test('add one annotation: annotationsForFile returns it; totalAnnotations === 1', () => {
@@ -33,11 +33,11 @@ describe('useFeedbackBatch', () => {
     const annotation = makeAnnotation('ann-1')
 
     act(() => {
-      result.current.addAnnotation('/repo', 'src/a.ts', annotation)
+      result.current.addAnnotation('/repo', 'src/a.ts', false, annotation)
     })
 
     expect(result.current.totalAnnotations()).toBe(1)
-    const list = result.current.annotationsForFile('/repo', 'src/a.ts')
+    const list = result.current.annotationsForFile('/repo', 'src/a.ts', false)
     expect(list).toHaveLength(1)
     expect(list[0]).toEqual(annotation)
   })
@@ -45,8 +45,17 @@ describe('useFeedbackBatch', () => {
   test('annotationsForFile returns STABLE reference for absent file across two calls', () => {
     const { result } = renderHook(() => useFeedbackBatch())
 
-    const first = result.current.annotationsForFile('/repo', 'missing.ts')
-    const second = result.current.annotationsForFile('/repo', 'missing.ts')
+    const first = result.current.annotationsForFile(
+      '/repo',
+      'missing.ts',
+      false
+    )
+
+    const second = result.current.annotationsForFile(
+      '/repo',
+      'missing.ts',
+      false
+    )
 
     // Both calls must return the exact same array object (module-level EMPTY)
     expect(first).toBe(second)
@@ -58,7 +67,12 @@ describe('useFeedbackBatch', () => {
     // Add 50 annotations across multiple files to hit the cap
     act(() => {
       for (let i = 0; i < 50; i++) {
-        result.current.addAnnotation('/repo', `file-${i}.ts`, makeAnnotation(`id-${i}`, 'x', i + 1))
+        result.current.addAnnotation(
+          '/repo',
+          `file-${i}.ts`,
+          false,
+          makeAnnotation(`id-${i}`, 'x', i + 1)
+        )
       }
     })
 
@@ -66,7 +80,12 @@ describe('useFeedbackBatch', () => {
 
     let returnValue: 'ok' | 'cap-reached' = 'ok'
     act(() => {
-      returnValue = result.current.addAnnotation('/repo', 'extra.ts', makeAnnotation('id-extra'))
+      returnValue = result.current.addAnnotation(
+        '/repo',
+        'extra.ts',
+        false,
+        makeAnnotation('id-extra')
+      )
     })
 
     expect(returnValue).toBe('cap-reached')
@@ -79,14 +98,16 @@ describe('useFeedbackBatch', () => {
     const original = makeAnnotation('upd-1', 'original text', 5, 'deletions')
 
     act(() => {
-      result.current.addAnnotation('/repo', 'b.ts', original)
+      result.current.addAnnotation('/repo', 'b.ts', false, original)
     })
 
     act(() => {
-      result.current.updateAnnotation('/repo', 'b.ts', 'upd-1', { text: 'updated text' })
+      result.current.updateAnnotation('/repo', 'b.ts', false, 'upd-1', {
+        text: 'updated text',
+      })
     })
 
-    const [updated] = result.current.annotationsForFile('/repo', 'b.ts')
+    const [updated] = result.current.annotationsForFile('/repo', 'b.ts', false)
     expect(updated.metadata.text).toBe('updated text')
     expect(updated.metadata.createdAt).toBe(1000)
     expect(updated.metadata.author).toBe('self')
@@ -98,16 +119,21 @@ describe('useFeedbackBatch', () => {
     const { result } = renderHook(() => useFeedbackBatch())
     const cwd = '/repo'
     const filePath = 'solo.ts'
-    const key = `${cwd}::${filePath}`
+    const key = `${cwd}::${filePath}::unstaged`
 
     act(() => {
-      result.current.addAnnotation(cwd, filePath, makeAnnotation('solo-1'))
+      result.current.addAnnotation(
+        cwd,
+        filePath,
+        false,
+        makeAnnotation('solo-1')
+      )
     })
 
     expect(result.current.batch.has(key)).toBe(true)
 
     act(() => {
-      result.current.removeAnnotation(cwd, filePath, 'solo-1')
+      result.current.removeAnnotation(cwd, filePath, false, 'solo-1')
     })
 
     expect(result.current.batch.has(key)).toBe(false)
@@ -119,26 +145,48 @@ describe('useFeedbackBatch', () => {
     const filePath = 'duo.ts'
 
     act(() => {
-      result.current.addAnnotation(cwd, filePath, makeAnnotation('duo-1', 'first', 1))
-      result.current.addAnnotation(cwd, filePath, makeAnnotation('duo-2', 'second', 2))
+      result.current.addAnnotation(
+        cwd,
+        filePath,
+        false,
+        makeAnnotation('duo-1', 'first', 1)
+      )
+
+      result.current.addAnnotation(
+        cwd,
+        filePath,
+        false,
+        makeAnnotation('duo-2', 'second', 2)
+      )
     })
 
     act(() => {
-      result.current.removeAnnotation(cwd, filePath, 'duo-1')
+      result.current.removeAnnotation(cwd, filePath, false, 'duo-1')
     })
 
-    const list = result.current.annotationsForFile(cwd, filePath)
+    const list = result.current.annotationsForFile(cwd, filePath, false)
     expect(list).toHaveLength(1)
     expect(list[0].metadata.id).toBe('duo-2')
-    expect(result.current.batch.has(`${cwd}::${filePath}`)).toBe(true)
+    expect(result.current.batch.has(`${cwd}::${filePath}::unstaged`)).toBe(true)
   })
 
   test('clearBatch empties the Map', () => {
     const { result } = renderHook(() => useFeedbackBatch())
 
     act(() => {
-      result.current.addAnnotation('/repo', 'a.ts', makeAnnotation('c-1'))
-      result.current.addAnnotation('/repo', 'b.ts', makeAnnotation('c-2'))
+      result.current.addAnnotation(
+        '/repo',
+        'a.ts',
+        false,
+        makeAnnotation('c-1')
+      )
+
+      result.current.addAnnotation(
+        '/repo',
+        'b.ts',
+        false,
+        makeAnnotation('c-2')
+      )
     })
 
     expect(result.current.totalAnnotations()).toBe(2)
@@ -159,10 +207,39 @@ describe('useFeedbackBatch', () => {
 
     // Trigger a state change via add — batch updates, so many callbacks change
     act(() => {
-      result.current.addAnnotation('/repo', 'a.ts', makeAnnotation('stab-1'))
+      result.current.addAnnotation(
+        '/repo',
+        'a.ts',
+        false,
+        makeAnnotation('stab-1')
+      )
     })
 
     // clearBatch must be the same function reference ([] dep array)
     expect(result.current.clearBatch).toBe(clearBatchBefore)
+  })
+
+  test('staged and unstaged annotations for the same path are stored separately', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+    const stagedAnnotation = makeAnnotation('staged-1', 'staged comment')
+    const unstagedAnnotation = makeAnnotation('unstaged-1', 'unstaged comment')
+
+    act(() => {
+      result.current.addAnnotation('/repo', 'x.ts', true, stagedAnnotation)
+      result.current.addAnnotation('/repo', 'x.ts', false, unstagedAnnotation)
+    })
+
+    const stagedList = result.current.annotationsForFile('/repo', 'x.ts', true)
+
+    const unstagedList = result.current.annotationsForFile(
+      '/repo',
+      'x.ts',
+      false
+    )
+
+    expect(stagedList).toHaveLength(1)
+    expect(stagedList[0].metadata.text).toBe('staged comment')
+    expect(unstagedList).toHaveLength(1)
+    expect(unstagedList[0].metadata.text).toBe('unstaged comment')
   })
 })

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -123,7 +123,7 @@ describe('useFeedbackBatch', () => {
     const { result } = renderHook(() => useFeedbackBatch())
     const cwd = '/repo'
     const filePath = 'solo.ts'
-    const key = `${cwd}::${filePath}::unstaged`
+    const key = makeBatchKey(cwd, filePath, false)
 
     act(() => {
       result.current.addAnnotation(
@@ -171,7 +171,9 @@ describe('useFeedbackBatch', () => {
     const list = result.current.annotationsForFile(cwd, filePath, false)
     expect(list).toHaveLength(1)
     expect(list[0].metadata.id).toBe('duo-2')
-    expect(result.current.batch.has(`${cwd}::${filePath}::unstaged`)).toBe(true)
+    expect(result.current.batch.has(makeBatchKey(cwd, filePath, false))).toBe(
+      true
+    )
   })
 
   test('clearBatch empties the Map', () => {
@@ -247,21 +249,18 @@ describe('useFeedbackBatch', () => {
     expect(unstagedList[0].metadata.text).toBe('unstaged comment')
   })
 
-  test('makeBatchKey / parseBatchKey round-trip for staged and unstaged', () => {
-    const staged = makeBatchKey('/repo/a', 'src/x.ts', true)
-    const unstaged = makeBatchKey('/repo/a', 'src/x.ts', false)
+  test('makeBatchKey / parseBatchKey round-trip — including a cwd containing "::"', () => {
+    const cases = [
+      { cwd: '/repo/a', filePath: 'src/x.ts', staged: true },
+      { cwd: '/repo/a', filePath: 'src/x.ts', staged: false },
+      // A cwd containing the old "::" separator must still round-trip; the NUL
+      // separator can't appear in a path, so it parses unambiguously.
+      { cwd: '/home/user::special/p', filePath: 'src/y.ts', staged: false },
+    ]
 
-    expect(staged).toBe('/repo/a::src/x.ts::staged')
-    expect(parseBatchKey(staged)).toEqual({
-      cwd: '/repo/a',
-      filePath: 'src/x.ts',
-      staged: true,
-    })
-
-    expect(parseBatchKey(unstaged)).toEqual({
-      cwd: '/repo/a',
-      filePath: 'src/x.ts',
-      staged: false,
-    })
+    for (const expected of cases) {
+      const key = makeBatchKey(expected.cwd, expected.filePath, expected.staged)
+      expect(parseBatchKey(key)).toEqual(expected)
+    }
   })
 })

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { useFeedbackBatch } from './useFeedbackBatch'
+import {
+  useFeedbackBatch,
+  makeBatchKey,
+  parseBatchKey,
+} from './useFeedbackBatch'
 import type { ReviewComment } from './useFeedbackBatch'
 import type { DiffLineAnnotation } from '@pierre/diffs'
 
@@ -241,5 +245,23 @@ describe('useFeedbackBatch', () => {
     expect(stagedList[0].metadata.text).toBe('staged comment')
     expect(unstagedList).toHaveLength(1)
     expect(unstagedList[0].metadata.text).toBe('unstaged comment')
+  })
+
+  test('makeBatchKey / parseBatchKey round-trip for staged and unstaged', () => {
+    const staged = makeBatchKey('/repo/a', 'src/x.ts', true)
+    const unstaged = makeBatchKey('/repo/a', 'src/x.ts', false)
+
+    expect(staged).toBe('/repo/a::src/x.ts::staged')
+    expect(parseBatchKey(staged)).toEqual({
+      cwd: '/repo/a',
+      filePath: 'src/x.ts',
+      staged: true,
+    })
+
+    expect(parseBatchKey(unstaged)).toEqual({
+      cwd: '/repo/a',
+      filePath: 'src/x.ts',
+      staged: false,
+    })
   })
 })

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -1,0 +1,157 @@
+import { useCallback, useState } from 'react'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+
+export interface ReviewComment {
+  id: string
+  text: string
+  author: 'self'
+  createdAt: number
+}
+
+export type FeedbackBatch = Map<
+  /** batchKey: `${cwd}::${filePath}` */
+  string,
+  DiffLineAnnotation<ReviewComment>[]
+>
+
+const SOFT_CAP = 50
+
+/**
+ * Stable empty array returned for absent file keys.
+ * Must be module-level and frozen so callers get referential equality
+ * across renders — prevents Pierre from re-tokenizing or effects from looping.
+ */
+const EMPTY: DiffLineAnnotation<ReviewComment>[] = []
+Object.freeze(EMPTY)
+
+export interface UseFeedbackBatchReturn {
+  batch: FeedbackBatch
+  annotationsForFile: (
+    cwd: string,
+    filePath: string,
+  ) => DiffLineAnnotation<ReviewComment>[]
+  addAnnotation: (
+    cwd: string,
+    filePath: string,
+    annotation: DiffLineAnnotation<ReviewComment>,
+  ) => 'ok' | 'cap-reached'
+  updateAnnotation: (
+    cwd: string,
+    filePath: string,
+    id: string,
+    patch: Partial<ReviewComment>,
+  ) => void
+  removeAnnotation: (cwd: string, filePath: string, id: string) => void
+  clearBatch: () => void
+  totalAnnotations: () => number
+}
+
+export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
+  const [batch, setBatch] = useState<FeedbackBatch>(() => new Map())
+
+  const totalAnnotations = useCallback((): number => {
+    let count = 0
+    for (const list of batch.values()) {
+      count += list.length
+    }
+
+    return count
+  }, [batch])
+
+  const annotationsForFile = useCallback(
+    (cwd: string, filePath: string): DiffLineAnnotation<ReviewComment>[] => {
+      const key = `${cwd}::${filePath}`
+
+      return batch.get(key) ?? EMPTY
+    },
+    [batch],
+  )
+
+  const addAnnotation = useCallback(
+    (
+      cwd: string,
+      filePath: string,
+      annotation: DiffLineAnnotation<ReviewComment>,
+    ): 'ok' | 'cap-reached' => {
+      if (totalAnnotations() >= SOFT_CAP) {
+        return 'cap-reached'
+      }
+      const key = `${cwd}::${filePath}`
+      setBatch((prev) => {
+        const next = new Map(prev)
+        const existing = next.get(key) ?? []
+        next.set(key, [...existing, annotation])
+
+        return next
+      })
+
+      return 'ok'
+    },
+    [totalAnnotations],
+  )
+
+  const updateAnnotation = useCallback(
+    (
+      cwd: string,
+      filePath: string,
+      id: string,
+      patch: Partial<ReviewComment>,
+    ): void => {
+      const key = `${cwd}::${filePath}`
+      setBatch((prev) => {
+        const list = prev.get(key)
+        if (!list) {return prev}
+        const idx = list.findIndex((a) => a.metadata.id === id)
+        if (idx === -1) {return prev}
+        const next = new Map(prev)
+
+        const updated = list.map((a, i) => {
+          if (i !== idx) {return a}
+
+          return {
+            ...a,
+            metadata: { ...a.metadata, ...patch },
+          }
+        })
+        next.set(key, updated)
+
+        return next
+      })
+    },
+    [],
+  )
+
+  const removeAnnotation = useCallback(
+    (cwd: string, filePath: string, id: string): void => {
+      const key = `${cwd}::${filePath}`
+      setBatch((prev) => {
+        const list = prev.get(key)
+        if (!list) {return prev}
+        const filtered = list.filter((a) => a.metadata.id !== id)
+        const next = new Map(prev)
+        if (filtered.length === 0) {
+          next.delete(key)
+        } else {
+          next.set(key, filtered)
+        }
+
+        return next
+      })
+    },
+    [],
+  )
+
+  const clearBatch = useCallback((): void => {
+    setBatch(() => new Map())
+  }, [])
+
+  return {
+    batch,
+    annotationsForFile,
+    addAnnotation,
+    updateAnnotation,
+    removeAnnotation,
+    clearBatch,
+    totalAnnotations,
+  }
+}

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -9,7 +9,7 @@ export interface ReviewComment {
 }
 
 export type FeedbackBatch = Map<
-  /** batchKey: `${cwd}::${filePath}` */
+  /** batchKey: `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}` */
   string,
   DiffLineAnnotation<ReviewComment>[]
 >
@@ -29,19 +29,27 @@ export interface UseFeedbackBatchReturn {
   annotationsForFile: (
     cwd: string,
     filePath: string,
+    staged: boolean
   ) => DiffLineAnnotation<ReviewComment>[]
   addAnnotation: (
     cwd: string,
     filePath: string,
-    annotation: DiffLineAnnotation<ReviewComment>,
+    staged: boolean,
+    annotation: DiffLineAnnotation<ReviewComment>
   ) => 'ok' | 'cap-reached'
   updateAnnotation: (
     cwd: string,
     filePath: string,
+    staged: boolean,
     id: string,
-    patch: Partial<ReviewComment>,
+    patch: Partial<ReviewComment>
   ) => void
-  removeAnnotation: (cwd: string, filePath: string, id: string) => void
+  removeAnnotation: (
+    cwd: string,
+    filePath: string,
+    staged: boolean,
+    id: string
+  ) => void
   clearBatch: () => void
   totalAnnotations: () => number
 }
@@ -59,24 +67,29 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
   }, [batch])
 
   const annotationsForFile = useCallback(
-    (cwd: string, filePath: string): DiffLineAnnotation<ReviewComment>[] => {
-      const key = `${cwd}::${filePath}`
+    (
+      cwd: string,
+      filePath: string,
+      staged: boolean
+    ): DiffLineAnnotation<ReviewComment>[] => {
+      const key = `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`
 
       return batch.get(key) ?? EMPTY
     },
-    [batch],
+    [batch]
   )
 
   const addAnnotation = useCallback(
     (
       cwd: string,
       filePath: string,
-      annotation: DiffLineAnnotation<ReviewComment>,
+      staged: boolean,
+      annotation: DiffLineAnnotation<ReviewComment>
     ): 'ok' | 'cap-reached' => {
       if (totalAnnotations() >= SOFT_CAP) {
         return 'cap-reached'
       }
-      const key = `${cwd}::${filePath}`
+      const key = `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`
       setBatch((prev) => {
         const next = new Map(prev)
         const existing = next.get(key) ?? []
@@ -87,26 +100,33 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
 
       return 'ok'
     },
-    [totalAnnotations],
+    [totalAnnotations]
   )
 
   const updateAnnotation = useCallback(
     (
       cwd: string,
       filePath: string,
+      staged: boolean,
       id: string,
-      patch: Partial<ReviewComment>,
+      patch: Partial<ReviewComment>
     ): void => {
-      const key = `${cwd}::${filePath}`
+      const key = `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`
       setBatch((prev) => {
         const list = prev.get(key)
-        if (!list) {return prev}
+        if (!list) {
+          return prev
+        }
         const idx = list.findIndex((a) => a.metadata.id === id)
-        if (idx === -1) {return prev}
+        if (idx === -1) {
+          return prev
+        }
         const next = new Map(prev)
 
         const updated = list.map((a, i) => {
-          if (i !== idx) {return a}
+          if (i !== idx) {
+            return a
+          }
 
           return {
             ...a,
@@ -118,15 +138,17 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
         return next
       })
     },
-    [],
+    []
   )
 
   const removeAnnotation = useCallback(
-    (cwd: string, filePath: string, id: string): void => {
-      const key = `${cwd}::${filePath}`
+    (cwd: string, filePath: string, staged: boolean, id: string): void => {
+      const key = `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`
       setBatch((prev) => {
         const list = prev.get(key)
-        if (!list) {return prev}
+        if (!list) {
+          return prev
+        }
         const filtered = list.filter((a) => a.metadata.id !== id)
         const next = new Map(prev)
         if (filtered.length === 0) {
@@ -138,7 +160,7 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
         return next
       })
     },
-    [],
+    []
   )
 
   const clearBatch = useCallback((): void => {

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -8,6 +8,14 @@ export interface ReviewComment {
   createdAt: number
 }
 
+/**
+ * Sentinel annotation id for the in-progress draft comment — the one the
+ * composer is editing before it is committed to the batch. Shared so
+ * DiffPanelContent and the dev demo both render the composer (not a row) for
+ * it from a single definition.
+ */
+export const DRAFT_ID = '__draft__'
+
 export type FeedbackBatch = Map<
   /** batchKey: `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}` */
   string,
@@ -20,27 +28,32 @@ export interface ParsedBatchKey {
   staged: boolean
 }
 
+// NUL separates the key segments. It cannot occur in a Unix cwd or file path,
+// so splitting is unambiguous even when a path itself contains the old `::`
+// separator. The key is internal to the batch Map — never displayed or sent to
+// a terminal.
+const KEY_SEP = '\0'
+
 /**
  * The batch Map is keyed by a single string encoding (cwd, filePath, staged).
- * Construction (`makeBatchKey`) and parsing (`parseBatchKey`) live together so
- * the format has ONE source of truth — consumers (e.g. the dispatch path in
- * DiffPanelContent) must use these instead of hand-slicing on `::`, so a format
- * change can't silently break parsing in callers.
+ * `makeBatchKey` and `parseBatchKey` are the ONE source of truth for that
+ * format — consumers (e.g. the dispatch path in DiffPanelContent) use these
+ * rather than splitting the key by hand.
  */
 export const makeBatchKey = (
   cwd: string,
   filePath: string,
   staged: boolean
-): string => `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`
+): string =>
+  `${cwd}${KEY_SEP}${filePath}${KEY_SEP}${staged ? 'staged' : 'unstaged'}`
 
 export const parseBatchKey = (key: string): ParsedBatchKey => {
-  const firstSep = key.indexOf('::')
-  const lastSep = key.lastIndexOf('::')
+  const parts = key.split(KEY_SEP)
 
   return {
-    cwd: key.slice(0, firstSep),
-    filePath: key.slice(firstSep + 2, lastSep),
-    staged: key.slice(lastSep + 2) === 'staged',
+    cwd: parts[0] ?? '',
+    filePath: parts[1] ?? '',
+    staged: parts[2] === 'staged',
   }
 }
 

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -14,6 +14,36 @@ export type FeedbackBatch = Map<
   DiffLineAnnotation<ReviewComment>[]
 >
 
+export interface ParsedBatchKey {
+  cwd: string
+  filePath: string
+  staged: boolean
+}
+
+/**
+ * The batch Map is keyed by a single string encoding (cwd, filePath, staged).
+ * Construction (`makeBatchKey`) and parsing (`parseBatchKey`) live together so
+ * the format has ONE source of truth — consumers (e.g. the dispatch path in
+ * DiffPanelContent) must use these instead of hand-slicing on `::`, so a format
+ * change can't silently break parsing in callers.
+ */
+export const makeBatchKey = (
+  cwd: string,
+  filePath: string,
+  staged: boolean
+): string => `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`
+
+export const parseBatchKey = (key: string): ParsedBatchKey => {
+  const firstSep = key.indexOf('::')
+  const lastSep = key.lastIndexOf('::')
+
+  return {
+    cwd: key.slice(0, firstSep),
+    filePath: key.slice(firstSep + 2, lastSep),
+    staged: key.slice(lastSep + 2) === 'staged',
+  }
+}
+
 const SOFT_CAP = 50
 
 /**
@@ -72,7 +102,7 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
       filePath: string,
       staged: boolean
     ): DiffLineAnnotation<ReviewComment>[] => {
-      const key = `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`
+      const key = makeBatchKey(cwd, filePath, staged)
 
       return batch.get(key) ?? EMPTY
     },
@@ -89,7 +119,7 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
       if (totalAnnotations() >= SOFT_CAP) {
         return 'cap-reached'
       }
-      const key = `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`
+      const key = makeBatchKey(cwd, filePath, staged)
       setBatch((prev) => {
         const next = new Map(prev)
         const existing = next.get(key) ?? []
@@ -111,7 +141,7 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
       id: string,
       patch: Partial<ReviewComment>
     ): void => {
-      const key = `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`
+      const key = makeBatchKey(cwd, filePath, staged)
       setBatch((prev) => {
         const list = prev.get(key)
         if (!list) {
@@ -143,7 +173,7 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
 
   const removeAnnotation = useCallback(
     (cwd: string, filePath: string, staged: boolean, id: string): void => {
-      const key = `${cwd}::${filePath}::${staged ? 'staged' : 'unstaged'}`
+      const key = makeBatchKey(cwd, filePath, staged)
       setBatch((prev) => {
         const list = prev.get(key)
         if (!list) {

--- a/src/features/diff/services/activePanePicker.test.ts
+++ b/src/features/diff/services/activePanePicker.test.ts
@@ -17,7 +17,6 @@ test('0 candidates -> { kind: none }', () => {
   const result = resolveCandidatePanes({
     allPanes: [],
     diffCwd: '/repo',
-    focusedPaneId: null,
   })
 
   expect(result).toEqual({ kind: 'none' })
@@ -29,33 +28,30 @@ test('exactly 1 matching -> { kind: one, pane }', () => {
   const result = resolveCandidatePanes({
     allPanes: [pane],
     diffCwd: '/repo',
-    focusedPaneId: null,
   })
 
   expect(result).toEqual({ kind: 'one', pane })
 })
 
-test('2+ matching with focusedPaneId matching one -> { kind: one, pane: the focused }', () => {
+test('2+ matching with isFocused true on one -> { kind: one, pane: the focused }', () => {
   const paneA = makePane({ paneId: 'p1' })
-  const paneB = makePane({ paneId: 'p2' })
+  const paneB = makePane({ paneId: 'p2', isFocused: true })
 
   const result = resolveCandidatePanes({
     allPanes: [paneA, paneB],
     diffCwd: '/repo',
-    focusedPaneId: 'p2',
   })
 
   expect(result).toEqual({ kind: 'one', pane: paneB })
 })
 
-test('2+ matching with focusedPaneId not in set -> { kind: many, candidates }', () => {
+test('2+ matching with no isFocused pane -> { kind: many, candidates }', () => {
   const paneA = makePane({ paneId: 'p1' })
   const paneB = makePane({ paneId: 'p2' })
 
   const result = resolveCandidatePanes({
     allPanes: [paneA, paneB],
     diffCwd: '/repo',
-    focusedPaneId: 'p3',
   })
 
   expect(result).toEqual({ kind: 'many', candidates: [paneA, paneB] })
@@ -67,7 +63,6 @@ test('a pane with cwd /repo/sub matches diffCwd /repo (descendant)', () => {
   const result = resolveCandidatePanes({
     allPanes: [pane],
     diffCwd: '/repo',
-    focusedPaneId: null,
   })
 
   expect(result).toEqual({ kind: 'one', pane })
@@ -81,7 +76,6 @@ test('panes filtered out when status !== running', () => {
   const result = resolveCandidatePanes({
     allPanes: [idle, exited, error],
     diffCwd: '/repo',
-    focusedPaneId: null,
   })
 
   expect(result).toEqual({ kind: 'none' })
@@ -93,8 +87,19 @@ test('panes filtered out when agentLabel not in { Claude Code, Codex }', () => {
   const result = resolveCandidatePanes({
     allPanes: [pane],
     diffCwd: '/repo',
-    focusedPaneId: null,
   })
 
   expect(result).toEqual({ kind: 'none' })
+})
+
+test('resolves focused pane correctly even when multiple panes share the same paneId', () => {
+  const paneA = makePane({ paneId: 'p0', ptyId: 'pty-a', isFocused: false })
+  const paneB = makePane({ paneId: 'p0', ptyId: 'pty-b', isFocused: true })
+
+  const result = resolveCandidatePanes({
+    allPanes: [paneA, paneB],
+    diffCwd: '/repo',
+  })
+
+  expect(result).toEqual({ kind: 'one', pane: paneB })
 })

--- a/src/features/diff/services/activePanePicker.test.ts
+++ b/src/features/diff/services/activePanePicker.test.ts
@@ -1,0 +1,100 @@
+import { test, expect } from 'vitest'
+import { type PaneCandidate, resolveCandidatePanes } from './activePanePicker'
+
+const makePane = (
+  overrides: Partial<PaneCandidate> & { paneId: string }
+): PaneCandidate => ({
+  ptyId: `pty-${overrides.paneId}`,
+  tabName: 'tab',
+  agentLabel: 'Claude Code',
+  cwd: '/repo',
+  status: 'running',
+  isFocused: false,
+  ...overrides,
+})
+
+test('0 candidates -> { kind: none }', () => {
+  const result = resolveCandidatePanes({
+    allPanes: [],
+    diffCwd: '/repo',
+    focusedPaneId: null,
+  })
+
+  expect(result).toEqual({ kind: 'none' })
+})
+
+test('exactly 1 matching -> { kind: one, pane }', () => {
+  const pane = makePane({ paneId: 'p1' })
+
+  const result = resolveCandidatePanes({
+    allPanes: [pane],
+    diffCwd: '/repo',
+    focusedPaneId: null,
+  })
+
+  expect(result).toEqual({ kind: 'one', pane })
+})
+
+test('2+ matching with focusedPaneId matching one -> { kind: one, pane: the focused }', () => {
+  const paneA = makePane({ paneId: 'p1' })
+  const paneB = makePane({ paneId: 'p2' })
+
+  const result = resolveCandidatePanes({
+    allPanes: [paneA, paneB],
+    diffCwd: '/repo',
+    focusedPaneId: 'p2',
+  })
+
+  expect(result).toEqual({ kind: 'one', pane: paneB })
+})
+
+test('2+ matching with focusedPaneId not in set -> { kind: many, candidates }', () => {
+  const paneA = makePane({ paneId: 'p1' })
+  const paneB = makePane({ paneId: 'p2' })
+
+  const result = resolveCandidatePanes({
+    allPanes: [paneA, paneB],
+    diffCwd: '/repo',
+    focusedPaneId: 'p3',
+  })
+
+  expect(result).toEqual({ kind: 'many', candidates: [paneA, paneB] })
+})
+
+test('a pane with cwd /repo/sub matches diffCwd /repo (descendant)', () => {
+  const pane = makePane({ paneId: 'p1', cwd: '/repo/sub' })
+
+  const result = resolveCandidatePanes({
+    allPanes: [pane],
+    diffCwd: '/repo',
+    focusedPaneId: null,
+  })
+
+  expect(result).toEqual({ kind: 'one', pane })
+})
+
+test('panes filtered out when status !== running', () => {
+  const idle = makePane({ paneId: 'p1', status: 'idle' })
+  const exited = makePane({ paneId: 'p2', status: 'exited' })
+  const error = makePane({ paneId: 'p3', status: 'error' })
+
+  const result = resolveCandidatePanes({
+    allPanes: [idle, exited, error],
+    diffCwd: '/repo',
+    focusedPaneId: null,
+  })
+
+  expect(result).toEqual({ kind: 'none' })
+})
+
+test('panes filtered out when agentLabel not in { Claude Code, Codex }', () => {
+  const pane = makePane({ paneId: 'p1', agentLabel: 'Other Agent' })
+
+  const result = resolveCandidatePanes({
+    allPanes: [pane],
+    diffCwd: '/repo',
+    focusedPaneId: null,
+  })
+
+  expect(result).toEqual({ kind: 'none' })
+})

--- a/src/features/diff/services/activePanePicker.ts
+++ b/src/features/diff/services/activePanePicker.ts
@@ -1,0 +1,61 @@
+export interface PaneCandidate {
+  paneId: string
+  ptyId: string
+  tabName: string
+  agentLabel: string
+  cwd: string
+  status: 'idle' | 'running' | 'exited' | 'error'
+  isFocused: boolean
+}
+
+export interface ResolveCandidatesArgs {
+  allPanes: PaneCandidate[]
+  diffCwd: string
+  focusedPaneId: string | null
+}
+
+export type ResolveResult =
+  | { kind: 'none' }
+  | { kind: 'one'; pane: PaneCandidate }
+  | { kind: 'many'; candidates: PaneCandidate[] }
+
+export type SupportedAgent = 'Claude Code' | 'Codex'
+
+const SUPPORTED_AGENTS: readonly SupportedAgent[] = ['Claude Code', 'Codex']
+
+const isSupportedAgent = (label: string): boolean =>
+  SUPPORTED_AGENTS.some((agent) => agent === label)
+
+const isMatchingCwd = (paneCwd: string, diffCwd: string): boolean =>
+  paneCwd === diffCwd || paneCwd.startsWith(diffCwd + '/')
+
+// Filter to panes whose cwd matches the diff cwd (exact or descendant), whose
+// agentLabel is a SUPPORTED_AGENT, and whose status === 'running'. Then route:
+// 0 candidates -> none; 1 -> one; many with a focused match -> that focused one;
+// many without -> many.
+export const resolveCandidatePanes = (
+  args: ResolveCandidatesArgs
+): ResolveResult => {
+  const candidates = args.allPanes.filter(
+    (p) =>
+      isMatchingCwd(p.cwd, args.diffCwd) &&
+      isSupportedAgent(p.agentLabel) &&
+      p.status === 'running'
+  )
+
+  if (candidates.length === 0) {
+    return { kind: 'none' }
+  }
+
+  if (candidates.length === 1) {
+    return { kind: 'one', pane: candidates[0] }
+  }
+
+  const focused = candidates.find((p) => p.paneId === args.focusedPaneId)
+
+  if (focused) {
+    return { kind: 'one', pane: focused }
+  }
+
+  return { kind: 'many', candidates }
+}

--- a/src/features/diff/services/activePanePicker.ts
+++ b/src/features/diff/services/activePanePicker.ts
@@ -11,7 +11,6 @@ export interface PaneCandidate {
 export interface ResolveCandidatesArgs {
   allPanes: PaneCandidate[]
   diffCwd: string
-  focusedPaneId: string | null
 }
 
 export type ResolveResult =
@@ -51,7 +50,7 @@ export const resolveCandidatePanes = (
     return { kind: 'one', pane: candidates[0] }
   }
 
-  const focused = candidates.find((p) => p.paneId === args.focusedPaneId)
+  const focused = candidates.find((p) => p.isFocused)
 
   if (focused) {
     return { kind: 'one', pane: focused }

--- a/src/features/diff/services/activePanePicker.ts
+++ b/src/features/diff/services/activePanePicker.ts
@@ -8,6 +8,17 @@ export interface PaneCandidate {
   isFocused: boolean
 }
 
+/**
+ * The capability threaded WorkspaceView → DockPanel → DiffPanelContent so the
+ * diff can dispatch inline feedback to a live agent pane. Named once here (next
+ * to PaneCandidate) so the three layers share one shape instead of repeating an
+ * inline type that can drift silently under structural typing.
+ */
+export interface FeedbackDispatchTarget {
+  candidates: PaneCandidate[]
+  writePty: (ptyId: string, data: string) => Promise<void>
+}
+
 export interface ResolveCandidatesArgs {
   allPanes: PaneCandidate[]
   diffCwd: string

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -1,0 +1,79 @@
+import { test, expect, vi } from 'vitest'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import type { ReviewComment } from '../hooks/useFeedbackBatch'
+import {
+  formatFeedbackPayload,
+  dispatchFeedbackBatch,
+  type DispatchEntry,
+} from './feedbackDispatch'
+
+const makeAnnotation = (
+  lineNumber: number,
+  side: 'additions' | 'deletions',
+  text: string
+): DiffLineAnnotation<ReviewComment> => ({
+  lineNumber,
+  side,
+  metadata: {
+    id: `c-${lineNumber}-${side}`,
+    text,
+    author: 'self',
+    createdAt: Date.now(),
+  },
+})
+
+test('1 comment across 1 file -> header contains singular wording', () => {
+  const entries: DispatchEntry[] = [
+    {
+      cwd: '/repo',
+      filePath: 'src/App.tsx',
+      annotations: [makeAnnotation(5, 'additions', 'Nice work')],
+    },
+  ]
+  const payload = formatFeedbackPayload(entries)
+
+  expect(payload).toContain('1 comment across 1 file')
+})
+
+test('3 comments across 2 files -> header says plural counts and body has 3 entry lines', () => {
+  const entries: DispatchEntry[] = [
+    {
+      cwd: '/repo',
+      filePath: 'src/App.tsx',
+      annotations: [
+        makeAnnotation(5, 'additions', 'Nice work'),
+        makeAnnotation(10, 'deletions', 'Remove this'),
+      ],
+    },
+    {
+      cwd: '/repo',
+      filePath: 'src/main.tsx',
+      annotations: [makeAnnotation(3, 'additions', 'Consider renaming')],
+    },
+  ]
+  const payload = formatFeedbackPayload(entries)
+
+  expect(payload).toContain('3 comments across 2 files')
+  expect(payload).toContain('> src/App.tsx:5 (additions)')
+  expect(payload).toContain('> src/App.tsx:10 (deletions)')
+  expect(payload).toContain('> src/main.tsx:3 (additions)')
+})
+
+test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', async () => {
+  const writePty = vi.fn().mockResolvedValue(undefined)
+
+  const entries: DispatchEntry[] = [
+    {
+      cwd: '/repo',
+      filePath: 'src/App.tsx',
+      annotations: [makeAnnotation(5, 'additions', 'Nice work')],
+    },
+  ]
+
+  await dispatchFeedbackBatch('pane-1', 'pty-1', entries, writePty)
+
+  expect(writePty).toHaveBeenCalledTimes(1)
+  const sent = writePty.mock.calls[0][1] as string
+  expect(sent.startsWith('\x1b[200~')).toBe(true)
+  expect(sent.endsWith('\x1b[201~\n')).toBe(true)
+})

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -102,3 +102,28 @@ test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', a
   expect(sent.startsWith('\x1b[200~')).toBe(true)
   expect(sent.endsWith('\x1b[201~\r')).toBe(true)
 })
+
+test('strips terminal control characters so a crafted path/comment cannot break out of the paste', () => {
+  const entries: DispatchEntry[] = [
+    {
+      // filename embedding the paste-END sentinel + CR
+      filePath: 'src/ev\x1b[201~il.tsx',
+      annotations: [
+        makeAnnotation(5, 'additions', 'breakout\x1b[201~\rinjected'),
+      ],
+    },
+  ]
+  const body = formatFeedbackPayload(entries)
+
+  // No ESC or CR survives the format step — the dangerous bytes that form the
+  // bracketed-paste sentinel / inject prompt lines are gone (the harmless
+  // printable remainder like "[201~" stays as plain text).
+  expect(body).not.toContain('\x1b')
+  expect(body).not.toContain('\r')
+  expect(body).toContain('breakout[201~injected')
+
+  // End to end: the only control sequences in the dispatched payload are the
+  // wrapper's own start/end sentinels — exactly two ESC bytes, one trailing CR.
+  const sent = `\x1b[200~${body}\x1b[201~\r`
+  expect((sent.match(/\x1b/g) ?? []).length).toBe(2)
+})

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -25,7 +25,6 @@ const makeAnnotation = (
 test('1 comment across 1 file -> header contains singular wording', () => {
   const entries: DispatchEntry[] = [
     {
-      cwd: '/repo',
       filePath: 'src/App.tsx',
       annotations: [makeAnnotation(5, 'additions', 'Nice work')],
     },
@@ -38,7 +37,6 @@ test('1 comment across 1 file -> header contains singular wording', () => {
 test('3 comments across 2 files -> header says plural counts and body has 3 entry lines', () => {
   const entries: DispatchEntry[] = [
     {
-      cwd: '/repo',
       filePath: 'src/App.tsx',
       annotations: [
         makeAnnotation(5, 'additions', 'Nice work'),
@@ -46,7 +44,6 @@ test('3 comments across 2 files -> header says plural counts and body has 3 entr
       ],
     },
     {
-      cwd: '/repo',
       filePath: 'src/main.tsx',
       annotations: [makeAnnotation(3, 'additions', 'Consider renaming')],
     },
@@ -54,15 +51,14 @@ test('3 comments across 2 files -> header says plural counts and body has 3 entr
   const payload = formatFeedbackPayload(entries)
 
   expect(payload).toContain('3 comments across 2 files')
-  expect(payload).toContain('> /repo/src/App.tsx:5 (additions)')
-  expect(payload).toContain('> /repo/src/App.tsx:10 (deletions)')
-  expect(payload).toContain('> /repo/src/main.tsx:3 (additions)')
+  expect(payload).toContain('> src/App.tsx:5 (additions)')
+  expect(payload).toContain('> src/App.tsx:10 (deletions)')
+  expect(payload).toContain('> src/main.tsx:3 (additions)')
 })
 
 test('multi-line comment prefixes every line', () => {
   const entries: DispatchEntry[] = [
     {
-      cwd: '/repo',
       filePath: 'src/App.tsx',
       annotations: [
         makeAnnotation(5, 'additions', 'Line one\nLine two\nLine three'),
@@ -71,24 +67,22 @@ test('multi-line comment prefixes every line', () => {
   ]
   const payload = formatFeedbackPayload(entries)
 
-  expect(payload).toContain('> /repo/src/App.tsx:5 (additions)')
+  expect(payload).toContain('> src/App.tsx:5 (additions)')
   expect(payload).toContain('> ─ Line one')
   expect(payload).toContain('> ─ Line two')
   expect(payload).toContain('> ─ Line three')
 })
 
-test('avoids double slash when cwd ends with /', () => {
+test('repo-relative file path is emitted directly without joining', () => {
   const entries: DispatchEntry[] = [
     {
-      cwd: '/repo/',
       filePath: 'src/App.tsx',
       annotations: [makeAnnotation(5, 'additions', 'Nice work')],
     },
   ]
   const payload = formatFeedbackPayload(entries)
 
-  expect(payload).toContain('> /repo/src/App.tsx:5 (additions)')
-  expect(payload).not.toContain('//')
+  expect(payload).toContain('> src/App.tsx:5 (additions)')
 })
 
 test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', async () => {
@@ -96,7 +90,6 @@ test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', a
 
   const entries: DispatchEntry[] = [
     {
-      cwd: '/repo',
       filePath: 'src/App.tsx',
       annotations: [makeAnnotation(5, 'additions', 'Nice work')],
     },

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -54,9 +54,9 @@ test('3 comments across 2 files -> header says plural counts and body has 3 entr
   const payload = formatFeedbackPayload(entries)
 
   expect(payload).toContain('3 comments across 2 files')
-  expect(payload).toContain('> src/App.tsx:5 (additions)')
-  expect(payload).toContain('> src/App.tsx:10 (deletions)')
-  expect(payload).toContain('> src/main.tsx:3 (additions)')
+  expect(payload).toContain('> /repo/src/App.tsx:5 (additions)')
+  expect(payload).toContain('> /repo/src/App.tsx:10 (deletions)')
+  expect(payload).toContain('> /repo/src/main.tsx:3 (additions)')
 })
 
 test('multi-line comment prefixes every line', () => {
@@ -71,10 +71,24 @@ test('multi-line comment prefixes every line', () => {
   ]
   const payload = formatFeedbackPayload(entries)
 
-  expect(payload).toContain('> src/App.tsx:5 (additions)')
+  expect(payload).toContain('> /repo/src/App.tsx:5 (additions)')
   expect(payload).toContain('> ─ Line one')
   expect(payload).toContain('> ─ Line two')
   expect(payload).toContain('> ─ Line three')
+})
+
+test('avoids double slash when cwd ends with /', () => {
+  const entries: DispatchEntry[] = [
+    {
+      cwd: '/repo/',
+      filePath: 'src/App.tsx',
+      annotations: [makeAnnotation(5, 'additions', 'Nice work')],
+    },
+  ]
+  const payload = formatFeedbackPayload(entries)
+
+  expect(payload).toContain('> /repo/src/App.tsx:5 (additions)')
+  expect(payload).not.toContain('//')
 })
 
 test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', async () => {

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -75,5 +75,5 @@ test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', a
   expect(writePty).toHaveBeenCalledTimes(1)
   const sent = writePty.mock.calls[0][1] as string
   expect(sent.startsWith('\x1b[200~')).toBe(true)
-  expect(sent.endsWith('\x1b[201~\n')).toBe(true)
+  expect(sent.endsWith('\x1b[201~\r')).toBe(true)
 })

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -26,6 +26,7 @@ test('1 comment across 1 file -> header contains singular wording', () => {
   const entries: DispatchEntry[] = [
     {
       filePath: 'src/App.tsx',
+      staged: false,
       annotations: [makeAnnotation(5, 'additions', 'Nice work')],
     },
   ]
@@ -38,6 +39,7 @@ test('3 comments across 2 files -> header says plural counts and body has 3 entr
   const entries: DispatchEntry[] = [
     {
       filePath: 'src/App.tsx',
+      staged: false,
       annotations: [
         makeAnnotation(5, 'additions', 'Nice work'),
         makeAnnotation(10, 'deletions', 'Remove this'),
@@ -45,6 +47,7 @@ test('3 comments across 2 files -> header says plural counts and body has 3 entr
     },
     {
       filePath: 'src/main.tsx',
+      staged: false,
       annotations: [makeAnnotation(3, 'additions', 'Consider renaming')],
     },
   ]
@@ -60,6 +63,7 @@ test('multi-line comment prefixes every line', () => {
   const entries: DispatchEntry[] = [
     {
       filePath: 'src/App.tsx',
+      staged: false,
       annotations: [
         makeAnnotation(5, 'additions', 'Line one\nLine two\nLine three'),
       ],
@@ -77,6 +81,7 @@ test('repo-relative file path is emitted directly without joining', () => {
   const entries: DispatchEntry[] = [
     {
       filePath: 'src/App.tsx',
+      staged: false,
       annotations: [makeAnnotation(5, 'additions', 'Nice work')],
     },
   ]
@@ -85,12 +90,34 @@ test('repo-relative file path is emitted directly without joining', () => {
   expect(payload).toContain('> src/App.tsx:5 (additions)')
 })
 
+test('each entry line is labelled with its staged/unstaged diff view', () => {
+  const entries: DispatchEntry[] = [
+    {
+      filePath: 'src/App.tsx',
+      staged: true,
+      annotations: [makeAnnotation(5, 'additions', 'staged side')],
+    },
+    {
+      filePath: 'src/App.tsx',
+      staged: false,
+      annotations: [makeAnnotation(8, 'additions', 'unstaged side')],
+    },
+  ]
+  const payload = formatFeedbackPayload(entries)
+
+  // An MM file produces two same-path entries whose line numbers refer to
+  // different comparisons — the [staged]/[unstaged] tag keeps them distinct.
+  expect(payload).toContain('> src/App.tsx:5 (additions) [staged]')
+  expect(payload).toContain('> src/App.tsx:8 (additions) [unstaged]')
+})
+
 test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', async () => {
   const writePty = vi.fn().mockResolvedValue(undefined)
 
   const entries: DispatchEntry[] = [
     {
       filePath: 'src/App.tsx',
+      staged: false,
       annotations: [makeAnnotation(5, 'additions', 'Nice work')],
     },
   ]
@@ -108,6 +135,7 @@ test('strips terminal control characters so a crafted path/comment cannot break 
     {
       // filename embedding the paste-END sentinel + CR
       filePath: 'src/ev\x1b[201~il.tsx',
+      staged: false,
       annotations: [
         makeAnnotation(5, 'additions', 'breakout\x1b[201~\rinjected'),
       ],

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -59,6 +59,24 @@ test('3 comments across 2 files -> header says plural counts and body has 3 entr
   expect(payload).toContain('> src/main.tsx:3 (additions)')
 })
 
+test('multi-line comment prefixes every line', () => {
+  const entries: DispatchEntry[] = [
+    {
+      cwd: '/repo',
+      filePath: 'src/App.tsx',
+      annotations: [
+        makeAnnotation(5, 'additions', 'Line one\nLine two\nLine three'),
+      ],
+    },
+  ]
+  const payload = formatFeedbackPayload(entries)
+
+  expect(payload).toContain('> src/App.tsx:5 (additions)')
+  expect(payload).toContain('> ─ Line one')
+  expect(payload).toContain('> ─ Line two')
+  expect(payload).toContain('> ─ Line three')
+})
+
 test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', async () => {
   const writePty = vi.fn().mockResolvedValue(undefined)
 

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -1,0 +1,46 @@
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import type { ReviewComment } from '../hooks/useFeedbackBatch'
+
+const PASTE_START = '\x1b[200~'
+const PASTE_END = '\x1b[201~'
+
+export interface DispatchEntry {
+  cwd: string
+  filePath: string
+  annotations: DiffLineAnnotation<ReviewComment>[]
+}
+
+export const formatFeedbackPayload = (entries: DispatchEntry[]): string => {
+  const totalCount = entries.reduce((s, e) => s + e.annotations.length, 0)
+  const fileCount = entries.length
+  const header = `> Inline review feedback (${totalCount} comment${totalCount === 1 ? '' : 's'} across ${fileCount} file${fileCount === 1 ? '' : 's'}):`
+
+  const body = entries
+    .flatMap((entry) =>
+      entry.annotations.map(
+        (a) =>
+          `> ${entry.filePath}:${a.lineNumber} (${a.side})\n> ─ ${a.metadata.text}\n>`
+      )
+    )
+    .join('\n')
+
+  return [
+    header,
+    '>',
+    body,
+    '> ―',
+    '> Please address these and reply when done.',
+  ].join('\n')
+}
+
+export const dispatchFeedbackBatch = async (
+  _paneId: string,
+  ptyId: string,
+  entries: DispatchEntry[],
+  writePty: (ptyId: string, data: string) => Promise<void>
+): Promise<void> => {
+  const formatted = formatFeedbackPayload(entries)
+  const payload = `${PASTE_START}${formatted}${PASTE_END}\n`
+
+  await writePty(ptyId, payload)
+}

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -5,15 +5,8 @@ const PASTE_START = '\x1b[200~'
 const PASTE_END = '\x1b[201~'
 
 export interface DispatchEntry {
-  cwd: string
   filePath: string
   annotations: DiffLineAnnotation<ReviewComment>[]
-}
-
-const joinPath = (cwd: string, filePath: string): string => {
-  const base = cwd.endsWith('/') ? cwd.slice(0, -1) : cwd
-
-  return `${base}/${filePath}`
 }
 
 export const formatFeedbackPayload = (entries: DispatchEntry[]): string => {
@@ -27,7 +20,7 @@ export const formatFeedbackPayload = (entries: DispatchEntry[]): string => {
         const lines = a.metadata.text.split('\n').map((line) => `> ─ ${line}`)
 
         return [
-          `> ${joinPath(entry.cwd, entry.filePath)}:${a.lineNumber} (${a.side})`,
+          `> ${entry.filePath}:${a.lineNumber} (${a.side})`,
           ...lines,
           '>',
         ].join('\n')

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -4,6 +4,22 @@ import type { ReviewComment } from '../hooks/useFeedbackBatch'
 const PASTE_START = '\x1b[200~'
 const PASTE_END = '\x1b[201~'
 
+// Strip terminal control characters (C0 controls 0x00-0x1F + DEL 0x7F, which
+// includes ESC and CR) from any user/repo-supplied text before it enters the
+// bracketed-paste payload. git permits filenames containing newlines/ESC and
+// comment text is free-form, so without this a crafted filename or comment
+// could embed the paste-end sentinel (ESC [ 201 ~) — terminating the paste
+// early — or a CR that injects extra prompt lines into the agent's terminal.
+// A char-code filter avoids a control-character regex literal.
+const stripControls = (value: string): string =>
+  Array.from(value)
+    .filter((ch) => {
+      const code = ch.charCodeAt(0)
+
+      return code > 0x1f && code !== 0x7f
+    })
+    .join('')
+
 export interface DispatchEntry {
   filePath: string
   annotations: DiffLineAnnotation<ReviewComment>[]
@@ -17,10 +33,12 @@ export const formatFeedbackPayload = (entries: DispatchEntry[]): string => {
   const body = entries
     .flatMap((entry) =>
       entry.annotations.map((a) => {
-        const lines = a.metadata.text.split('\n').map((line) => `> ─ ${line}`)
+        const lines = a.metadata.text
+          .split('\n')
+          .map((line) => `> ─ ${stripControls(line)}`)
 
         return [
-          `> ${entry.filePath}:${a.lineNumber} (${a.side})`,
+          `> ${stripControls(entry.filePath)}:${a.lineNumber} (${a.side})`,
           ...lines,
           '>',
         ].join('\n')

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -10,6 +10,12 @@ export interface DispatchEntry {
   annotations: DiffLineAnnotation<ReviewComment>[]
 }
 
+const joinPath = (cwd: string, filePath: string): string => {
+  const base = cwd.endsWith('/') ? cwd.slice(0, -1) : cwd
+
+  return `${base}/${filePath}`
+}
+
 export const formatFeedbackPayload = (entries: DispatchEntry[]): string => {
   const totalCount = entries.reduce((s, e) => s + e.annotations.length, 0)
   const fileCount = entries.length
@@ -21,7 +27,7 @@ export const formatFeedbackPayload = (entries: DispatchEntry[]): string => {
         const lines = a.metadata.text.split('\n').map((line) => `> ─ ${line}`)
 
         return [
-          `> ${entry.filePath}:${a.lineNumber} (${a.side})`,
+          `> ${joinPath(entry.cwd, entry.filePath)}:${a.lineNumber} (${a.side})`,
           ...lines,
           '>',
         ].join('\n')

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -17,10 +17,15 @@ export const formatFeedbackPayload = (entries: DispatchEntry[]): string => {
 
   const body = entries
     .flatMap((entry) =>
-      entry.annotations.map(
-        (a) =>
-          `> ${entry.filePath}:${a.lineNumber} (${a.side})\n> ─ ${a.metadata.text}\n>`
-      )
+      entry.annotations.map((a) => {
+        const lines = a.metadata.text.split('\n').map((line) => `> ─ ${line}`)
+
+        return [
+          `> ${entry.filePath}:${a.lineNumber} (${a.side})`,
+          ...lines,
+          '>',
+        ].join('\n')
+      })
     )
     .join('\n')
 

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -40,7 +40,7 @@ export const dispatchFeedbackBatch = async (
   writePty: (ptyId: string, data: string) => Promise<void>
 ): Promise<void> => {
   const formatted = formatFeedbackPayload(entries)
-  const payload = `${PASTE_START}${formatted}${PASTE_END}\n`
+  const payload = `${PASTE_START}${formatted}${PASTE_END}\r`
 
   await writePty(ptyId, payload)
 }

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -22,6 +22,13 @@ const stripControls = (value: string): string =>
 
 export interface DispatchEntry {
   filePath: string
+  /**
+   * Which diff view the comments were authored against. A file with both
+   * staged AND unstaged changes (git status `MM`) produces two batch entries
+   * for the same path whose line numbers refer to different comparisons —
+   * the payload labels each so the agent addresses the correct version.
+   */
+  staged: boolean
   annotations: DiffLineAnnotation<ReviewComment>[]
 }
 
@@ -38,7 +45,7 @@ export const formatFeedbackPayload = (entries: DispatchEntry[]): string => {
           .map((line) => `> ─ ${stripControls(line)}`)
 
         return [
-          `> ${stripControls(entry.filePath)}:${a.lineNumber} (${a.side})`,
+          `> ${stripControls(entry.filePath)}:${a.lineNumber} (${a.side}) [${entry.staged ? 'staged' : 'unstaged'}]`,
           ...lines,
           '>',
         ].join('\n')

--- a/src/features/diff/services/gitService.ts
+++ b/src/features/diff/services/gitService.ts
@@ -60,6 +60,8 @@ const synthesizeDiffResponse = (fileDiff: FileDiff): GetGitDiffResponse => {
     oldText: linesToText(oldLines),
     newText: linesToText(newLines),
     rawDiff: rawLinesToText(rawDiffLines),
+    // The mock service has no real repository; the toplevel is unknown.
+    repoRoot: '',
   }
 }
 

--- a/src/features/diff/services/pierreAdapter.test.ts
+++ b/src/features/diff/services/pierreAdapter.test.ts
@@ -17,6 +17,7 @@ const makeResponse = (
   oldText: '',
   newText: '',
   rawDiff: '',
+  repoRoot: '',
   ...overrides,
 })
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -961,41 +961,45 @@ export const WorkspaceView = (): ReactElement => {
     horizontalDockElastic.isDragging
 
   const feedbackDispatch = useMemo(() => {
-    const candidates: PaneCandidate[] = sessions.flatMap((session) =>
-      session.panes.map((pane) => {
-        const agent = AGENTS[agentTypeToRegistryKey(pane.agentType)]
+    // Inline-review feedback dispatches to the single CONNECTED (active) pane —
+    // the one whose diff is on screen. We gate the candidate on LIVE agent
+    // state from `useAgentStatus` (sessionId match + isActive + !agentExited),
+    // NOT the PTY-lifecycle `pane.status`: a pane whose agent exited can keep a
+    // stale 'codex'/'claude-code' label while its shell PTY is still running,
+    // and the live signal is the only way to avoid pasting feedback into a bare
+    // shell. `agentLabel` maps agentType directly to the picker's SupportedAgent
+    // literals (the registry display name diverges, e.g. AGENTS.codex.name ===
+    // 'Codex CLI', which would mis-filter Codex).
+    const agentLabel =
+      agentStatus.agentType === 'claude-code'
+        ? 'Claude Code'
+        : agentStatus.agentType === 'codex'
+          ? 'Codex'
+          : null
 
-        const statusMap: Record<typeof pane.status, PaneCandidate['status']> = {
-          running: 'running',
-          paused: 'idle',
-          completed: 'exited',
-          errored: 'error',
-        }
-
-        // `agentLabel` must match the picker's SupportedAgent literals
-        // ('Claude Code' | 'Codex'); the registry display name diverges
-        // (e.g. AGENTS.codex.name === 'Codex CLI'), which would silently
-        // filter Codex panes out of feedback dispatch. Map agentType
-        // directly; unsupported types fall back to the display name and
-        // are filtered by resolveCandidatePanes.
-        const agentLabel =
-          pane.agentType === 'claude-code'
-            ? 'Claude Code'
-            : pane.agentType === 'codex'
-              ? 'Codex'
-              : agent.name
-
-        return {
-          paneId: pane.id,
-          ptyId: pane.ptyId,
-          tabName: pane.userLabel ?? pane.agentTitle ?? session.name,
-          agentLabel,
-          cwd: pane.cwd,
-          status: statusMap[pane.status],
-          isFocused: pane.active && session.id === activeSessionId,
-        }
-      })
-    )
+    const candidates: PaneCandidate[] =
+      activePane &&
+      activePanePtyId &&
+      agentStatus.sessionId === activePanePtyId &&
+      agentStatus.isActive &&
+      !agentStatus.agentExited &&
+      agentLabel !== null
+        ? [
+            {
+              paneId: activePane.id,
+              ptyId: activePanePtyId,
+              tabName:
+                activePane.userLabel ??
+                activePane.agentTitle ??
+                activeSession?.name ??
+                'Terminal',
+              agentLabel,
+              cwd: activePane.cwd,
+              status: 'running',
+              isFocused: true,
+            },
+          ]
+        : []
 
     return {
       candidates,
@@ -1003,7 +1007,16 @@ export const WorkspaceView = (): ReactElement => {
         await terminalService.write({ sessionId: ptyId, data })
       },
     }
-  }, [sessions, activeSessionId, terminalService])
+  }, [
+    activePane,
+    activePanePtyId,
+    activeSession,
+    agentStatus.agentType,
+    agentStatus.isActive,
+    agentStatus.agentExited,
+    agentStatus.sessionId,
+    terminalService,
+  ])
 
   const dockOrPeek = isDockOpen ? (
     <DockPanel

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -64,6 +64,7 @@ import { useDockShortcuts } from './hooks/useDockShortcuts'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
 import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 import { useGitStatus } from '../diff/hooks/useGitStatus'
+import type { PaneCandidate } from '../diff/services/activePanePicker'
 import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
 import { lineDelta } from '../sessions/utils/lineDelta'
@@ -959,6 +960,51 @@ export const WorkspaceView = (): ReactElement => {
     verticalDockElastic.isDragging ||
     horizontalDockElastic.isDragging
 
+  const feedbackDispatch = useMemo(() => {
+    const candidates: PaneCandidate[] = sessions.flatMap((session) =>
+      session.panes.map((pane) => {
+        const agent = AGENTS[agentTypeToRegistryKey(pane.agentType)]
+
+        const statusMap: Record<typeof pane.status, PaneCandidate['status']> = {
+          running: 'running',
+          paused: 'idle',
+          completed: 'exited',
+          errored: 'error',
+        }
+
+        // `agentLabel` must match the picker's SupportedAgent literals
+        // ('Claude Code' | 'Codex'); the registry display name diverges
+        // (e.g. AGENTS.codex.name === 'Codex CLI'), which would silently
+        // filter Codex panes out of feedback dispatch. Map agentType
+        // directly; unsupported types fall back to the display name and
+        // are filtered by resolveCandidatePanes.
+        const agentLabel =
+          pane.agentType === 'claude-code'
+            ? 'Claude Code'
+            : pane.agentType === 'codex'
+              ? 'Codex'
+              : agent.name
+
+        return {
+          paneId: pane.id,
+          ptyId: pane.ptyId,
+          tabName: pane.userLabel ?? pane.agentTitle ?? session.name,
+          agentLabel,
+          cwd: pane.cwd,
+          status: statusMap[pane.status],
+          isFocused: pane.active && session.id === activeSessionId,
+        }
+      })
+    )
+
+    return {
+      candidates,
+      writePty: async (ptyId: string, data: string): Promise<void> => {
+        await terminalService.write({ sessionId: ptyId, data })
+      },
+    }
+  }, [sessions, activeSessionId, terminalService])
+
   const dockOrPeek = isDockOpen ? (
     <DockPanel
       ref={dockPanelRef}
@@ -995,6 +1041,7 @@ export const WorkspaceView = (): ReactElement => {
       onContainerFocus={() => {
         setActiveContainerId(DOCK_CONTAINER_ID)
       }}
+      feedbackDispatch={feedbackDispatch}
     />
   ) : (
     <DockPeekButton position={dockPosition} onOpen={() => openDock()} />

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -17,7 +17,7 @@ import { DockSwitcher, type DockPosition } from './DockSwitcher'
 import { DockTab } from './DockTab'
 import type { SelectedDiffFile } from '../../diff/types'
 import type { UseGitStatusReturn } from '../../diff/hooks/useGitStatus'
-import type { PaneCandidate } from '../../diff/services/activePanePicker'
+import type { FeedbackDispatchTarget } from '../../diff/services/activePanePicker'
 import { DOCK_CONTAINER_ID } from '../containerIds'
 import {
   DOCK_INLINE_ACTIONS_MIN_WIDTH_PX,
@@ -74,10 +74,7 @@ interface DockPanelBaseProps {
   /** Optional shared git status from WorkspaceView. */
   gitStatus?: UseGitStatusReturn
   /** Optional feedback dispatch target for inline review comments. */
-  feedbackDispatch?: {
-    candidates: PaneCandidate[]
-    writePty: (ptyId: string, data: string) => Promise<void>
-  }
+  feedbackDispatch?: FeedbackDispatchTarget
   isFocused?: boolean
   onContainerFocus?: () => void
 }

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -17,6 +17,7 @@ import { DockSwitcher, type DockPosition } from './DockSwitcher'
 import { DockTab } from './DockTab'
 import type { SelectedDiffFile } from '../../diff/types'
 import type { UseGitStatusReturn } from '../../diff/hooks/useGitStatus'
+import type { PaneCandidate } from '../../diff/services/activePanePicker'
 import { DOCK_CONTAINER_ID } from '../containerIds'
 import {
   DOCK_INLINE_ACTIONS_MIN_WIDTH_PX,
@@ -72,6 +73,11 @@ interface DockPanelBaseProps {
   cwd?: string
   /** Optional shared git status from WorkspaceView. */
   gitStatus?: UseGitStatusReturn
+  /** Optional feedback dispatch target for inline review comments. */
+  feedbackDispatch?: {
+    candidates: PaneCandidate[]
+    writePty: (ptyId: string, data: string) => Promise<void>
+  }
   isFocused?: boolean
   onContainerFocus?: () => void
 }
@@ -111,6 +117,7 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
       isLoading = false,
       cwd = '.',
       gitStatus = undefined,
+      feedbackDispatch = undefined,
       isFocused = false,
       onContainerFocus = undefined,
       selectedDiffFile,
@@ -340,9 +347,14 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
                     gitStatus={gitStatus}
                     selectedFile={selectedDiffFile}
                     onSelectedFileChange={onSelectedDiffFileChange}
+                    feedbackDispatch={feedbackDispatch}
                   />
                 ) : (
-                  <DiffPanelContent cwd={cwd} gitStatus={gitStatus} />
+                  <DiffPanelContent
+                    cwd={cwd}
+                    gitStatus={gitStatus}
+                    feedbackDispatch={feedbackDispatch}
+                  />
                 )}
               </div>
             </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -590,7 +590,16 @@ function gitApiPlugin(): Plugin {
 
             res.writeHead(200, { 'Content-Type': 'application/json' })
             res.end(
-              JSON.stringify({ fileDiff, oldText, newText, rawDiff: diff })
+              JSON.stringify({
+                fileDiff,
+                oldText,
+                newText,
+                rawDiff: diff,
+                // Dev parity with the Rust producer's `repo_root` (PR4): the
+                // dev server runs at the repo root, so process.cwd() is the
+                // toplevel the frontend joins with repo-relative paths.
+                repoRoot,
+              })
             )
 
             return


### PR DESCRIPTION
The final PR of the `@pierre/diffs` integration (#255), after PR1 (#263), PR2 (#280), PR3 (#284). Adds **inline review comments** on the diff that batch up and dispatch to the connected coding agent's terminal.

## What it does
- **Gutter-affordance capture (Codex-style):** hover a diff line → a `+` appears in Pierre's gutter (`renderGutterUtility` + `enableGutterUtility`), placed beside the line number (GitHub-style) and following the hovered line → click → a full-width inline composer opens below the line (Pierre annotation slot, driven by a transient draft annotation). Type → the comment renders inline (`ReviewCommentRow`); edit/delete in place. Validated interactively first via a dev-only demo (`?demo=inline-comments`).
- **Per-workspace feedback batch** (`useFeedbackBatch`): keyed by `(cwd, filePath, staged)` through a shared `makeBatchKey`/`parseBatchKey` codec (NUL-separated, path-safe), soft cap 50, cleared on cwd change.
- **Finish / Discard chips** appear on the toolbar when the batch is non-empty.
- **Dispatch to the active agent (Option A):** "Finish feedback" resolves the **connected (active) pane** gated on **live `useAgentStatus`** (Claude Code / Codex, running) and writes a bracketed-paste, **absolute-path** feedback message to its PTY via the existing `write_pty`. Each line is tagged `[staged]`/`[unstaged]` so an `MM` file stays disambiguated. No new agent-status store.

## Backend
- `GetGitDiffResponse` gains `repoRoot` (canonical git toplevel, already computed in `get_git_diff_inner`) so the frontend sends **absolute** file references an agent resolves from any cwd. Bindings regenerated; Vite dev middleware mirrors it.

## Hardening (resolved across codex + Claude review)
paths (absolute, subdir-safe) · dispatch targeting (active pane, live agent state, `ptyId` routing) · **terminal-injection** (strip C0/DEL controls from the PTY payload) · gutter `+` placement (beside the number, hover-follow) · staged/unstaged payload labels · **NUL-separated batch-key codec** (path-safe, single source of truth) · shared `FeedbackDispatchTarget` / `DRAFT_ID` (no duplicated shapes/sentinels) · stable cwd-clear effect deps · `thin-scrollbar` on the diff scroll body · composer state-reuse (remount on target change) · accessibility (focus-trap the popover) · single-flight send · repo-root preserved across transient null diffs · CI format gate.

## Known follow-ups (deferred — tracked)
- **Feedback batch lost when the dock unmounts the diff tab** (switch to Editor / close the dock before Finish/Discard) — batch lives in `DiffPanelContent`, which `DockPanel` only mounts while the diff tab is active. **#307** (a slice of the broader workspace-layer flattening **#306**).
- **`addAnnotation` soft-cap TOCTOU** — the cap guard reads stale render-closure state; concurrent programmatic adds in one React flush could exceed 50. Unreachable in the one-comment-per-submit UI. **#309**.
- **Toolbar optional-handler API gap** — Finish/Discard render with optionally-`undefined` onClick; no live caller hits it. **#310**.
- **Rename-side path context** — payload carries `path:line (side)` but not the side-specific old/new path for rename deletion-side comments (rare); common path is correct. Fast follow-up threads full diff context through `DispatchEntry`.

## Test plan
- `npm run type-check`, `npm run lint`, `npm run format:check` ✓
- `npm run test` → 2858 passed (3 skipped) ✓ · `npm run build` ✓ · `cargo test` (backend) ✓
- Local codex review (`--base origin/main`) and Claude Code Review: **patch is correct**.
- Gutter + composer verified interactively in the browser demo; full Electron E2E (→ agent receives the paste) at reviewer's GUI pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
