### PR TITLE
fix(vitest): exclude nested worktree dirs from test discovery

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -116,6 +116,8 @@ words:
 
   # Git apply flag — `--whitespace=nowarn` suppresses whitespace warnings
   - nowarn
+  - worktree
+  - worktrees
 
 ignorePaths:
   - node_modules

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
       '**/{karma,rollup,webpack,vite,vitest,jest,ava,nyc,cypress,tsup,build,eslint,prettier}.config.*',
       '.claude/**',
       'tests/e2e/**',
+      // Nested git worktrees carry their own src/ and node_modules/. Vitest
+      // would otherwise discover their test files and load a second React
+      // instance, breaking every hooks-using test with a null dispatcher.
+      'worktrees/**',
+      '.worktrees/**',
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- Exclude `worktrees/**` and `.worktrees/**` from Vitest discovery so nested git worktrees don't pollute local `npm run test` runs.

## Why
Vitest's default include glob descends into `worktrees/<name>/src/**` when nested worktrees exist. The discovered tests resolve `react` from the *worktree's* own `node_modules/react` (nearest), while Vitest itself runs from main's `node_modules`. Two React instances load simultaneously, the hooks dispatcher belongs to one but the render path uses the other, so `useRef` returns null and every hooks-using component test fails with:

    TypeError: Cannot read properties of null (reading 'useRef')

CI is unaffected because CI checkouts have no nested worktrees. This is purely a local-developer-experience fix.

## Test plan
- [x] In a checkout with 3 populated nested worktrees: before fix → 848 files, 1514 failures; after fix → 207 files, 2821 passing.
- [x] `npx vitest run --exclude 'worktrees/**'` (smoking-gun reproduction).
- [x] Pre-push hook (`vitest run`) green on this branch.
- [ ] CI Unit Tests green on this PR.

## Notes
- The cspell vocabulary gets `worktree` / `worktrees` so the inline comment lints cleanly.