### PR TITLE
fix(sessions): keep sessions with a live browser pane reachable (#313)

### DIFF
--- a/src/features/sessions/utils/pickNextVisibleSessionId.test.ts
+++ b/src/features/sessions/utils/pickNextVisibleSessionId.test.ts
@@ -1,9 +1,10 @@
 import { describe, test, expect } from 'vitest'
 import {
+  getVisibleSessions,
   isOpenSessionStatus,
   pickNextVisibleSessionId,
 } from './pickNextVisibleSessionId'
-import type { Session, SessionStatus } from '../types'
+import type { Pane, Session, SessionStatus } from '../types'
 
 const buildSession = (id: string, status: SessionStatus): Session => ({
   id,
@@ -38,6 +39,58 @@ const buildSession = (id: string, status: SessionStatus): Session => ({
       tokens: { input: 0, output: 0, total: 0 },
     },
   },
+})
+
+const withBrowserPane = (
+  session: Session,
+  browserStatus: Pane['status']
+): Session => ({
+  ...session,
+  panes: [
+    ...session.panes,
+    {
+      id: 'browser-0',
+      kind: 'browser',
+      ptyId: `browser:${session.id}`,
+      cwd: '~',
+      agentType: 'generic',
+      status: browserStatus,
+      active: false,
+      browserUrl: 'https://example.com/',
+    },
+  ],
+})
+
+describe('getVisibleSessions', () => {
+  test('hides a fully-completed, non-active session', () => {
+    const sessions = [
+      buildSession('A', 'running'),
+      buildSession('B', 'completed'),
+    ]
+    expect(getVisibleSessions(sessions, 'A').map((s) => s.id)).toEqual(['A'])
+  })
+
+  test('keeps a completed session that still has a running browser pane', () => {
+    // The shell exited (status flips to completed) but a browser pane is still
+    // live — the tab must stay reachable even when the session is not active,
+    // or the native browser view is orphaned with no way back to it.
+    const sessions = [
+      buildSession('A', 'running'),
+      withBrowserPane(buildSession('B', 'completed'), 'running'),
+    ]
+    expect(getVisibleSessions(sessions, 'A').map((s) => s.id)).toEqual([
+      'A',
+      'B',
+    ])
+  })
+
+  test('hides a completed session whose browser pane has also exited', () => {
+    const sessions = [
+      buildSession('A', 'running'),
+      withBrowserPane(buildSession('B', 'completed'), 'completed'),
+    ]
+    expect(getVisibleSessions(sessions, 'A').map((s) => s.id)).toEqual(['A'])
+  })
 })
 
 describe('isOpenSessionStatus', () => {
@@ -88,6 +141,17 @@ describe('pickNextVisibleSessionId', () => {
       buildSession('C', 'completed'),
     ]
     expect(pickNextVisibleSessionId(sessions, 'C', 'C')).toBe('B')
+  })
+
+  test('treats a completed session with a live browser pane as visible', () => {
+    // B is completed and not active, but its browser pane is running, so it is
+    // visible — removing A picks B (the right neighbor) rather than skipping to C.
+    const sessions = [
+      buildSession('A', 'running'),
+      withBrowserPane(buildSession('B', 'completed'), 'running'),
+      buildSession('C', 'running'),
+    ]
+    expect(pickNextVisibleSessionId(sessions, 'A', 'A')).toBe('B')
   })
 
   test('returns undefined when only one visible session exists', () => {

--- a/src/features/sessions/utils/pickNextVisibleSessionId.test.ts
+++ b/src/features/sessions/utils/pickNextVisibleSessionId.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'vitest'
 import {
   getVisibleSessions,
   isOpenSessionStatus,
+  isSessionVisible,
   pickNextVisibleSessionId,
 } from './pickNextVisibleSessionId'
 import type { Pane, Session, SessionStatus } from '../types'
@@ -59,6 +60,44 @@ const withBrowserPane = (
       browserUrl: 'https://example.com/',
     },
   ],
+})
+
+describe('isSessionVisible', () => {
+  // The shared predicate behind BOTH getVisibleSessions (tab strip) and
+  // TerminalZone (panel aria linkage) — they must agree on every case.
+  test('open status is visible', () => {
+    expect(isSessionVisible(buildSession('A', 'running'), null)).toBe(true)
+    expect(isSessionVisible(buildSession('A', 'paused'), null)).toBe(true)
+  })
+
+  test('completed/errored non-active session is not visible', () => {
+    expect(isSessionVisible(buildSession('A', 'completed'), 'other')).toBe(
+      false
+    )
+    expect(isSessionVisible(buildSession('A', 'errored'), 'other')).toBe(false)
+  })
+
+  test('the active session is always visible', () => {
+    expect(isSessionVisible(buildSession('A', 'completed'), 'A')).toBe(true)
+  })
+
+  test('a completed session with a running browser pane is visible', () => {
+    expect(
+      isSessionVisible(
+        withBrowserPane(buildSession('A', 'completed'), 'running'),
+        'other'
+      )
+    ).toBe(true)
+  })
+
+  test('a completed session whose browser pane also exited is not visible', () => {
+    expect(
+      isSessionVisible(
+        withBrowserPane(buildSession('A', 'completed'), 'completed'),
+        'other'
+      )
+    ).toBe(false)
+  })
 })
 
 describe('getVisibleSessions', () => {

--- a/src/features/sessions/utils/pickNextVisibleSessionId.ts
+++ b/src/features/sessions/utils/pickNextVisibleSessionId.ts
@@ -18,24 +18,34 @@ const hasLiveBrowserPane = (session: Session): boolean =>
   session.panes.some((pane) => isBrowserPane(pane) && pane.status === 'running')
 
 /**
- * Returns the sessions visible in the SessionTabs strip — running or
- * paused sessions, sessions with a live browser pane, plus the currently
- * active one (so a just-exited active session keeps its tab even after status
- * flips to completed/errored). This is the single source of truth for "open"
- * semantics; both `SessionTabs` and `pickNextVisibleSessionId` consume it so
- * the visible-set definition can never drift between the strip's render and the
- * close-fallback navigation.
+ * Whether a single session is visible in the SessionTabs strip — running or
+ * paused, has a live browser pane, or is the currently active one (so a
+ * just-exited active session keeps its tab even after status flips to
+ * completed/errored).
+ *
+ * This is the single source of truth for "is this session's tab visible".
+ * Every visibility surface MUST consume it — `getVisibleSessions` (the strip +
+ * close-fallback navigation) and `TerminalZone` (the tabpanel-to-tab aria
+ * linkage) — so the tab and its panel can never disagree about whether the tab
+ * exists.
+ */
+export const isSessionVisible = (
+  session: Session,
+  activeSessionId: string | null
+): boolean =>
+  isOpenSessionStatus(session.status) ||
+  hasLiveBrowserPane(session) ||
+  session.id === activeSessionId
+
+/**
+ * Returns the sessions visible in the SessionTabs strip. Thin wrapper over
+ * `isSessionVisible` so the strip and `pickNextVisibleSessionId` share one
+ * predicate.
  */
 export const getVisibleSessions = (
   sessions: Session[],
   activeSessionId: string | null
-): Session[] =>
-  sessions.filter(
-    (s) =>
-      isOpenSessionStatus(s.status) ||
-      hasLiveBrowserPane(s) ||
-      s.id === activeSessionId
-  )
+): Session[] => sessions.filter((s) => isSessionVisible(s, activeSessionId))
 
 /**
  * Pick the next visible session id when the user removes the currently

--- a/src/features/sessions/utils/pickNextVisibleSessionId.ts
+++ b/src/features/sessions/utils/pickNextVisibleSessionId.ts
@@ -1,4 +1,5 @@
 import type { Session, SessionStatus } from '../types'
+import { isBrowserPane } from './paneKind'
 
 const OPEN_STATUSES: ReadonlySet<SessionStatus> = new Set(['running', 'paused'])
 
@@ -6,20 +7,34 @@ export const isOpenSessionStatus = (status: SessionStatus): boolean =>
   OPEN_STATUSES.has(status)
 
 /**
+ * A session is reachable while any browser pane is still running, even if its
+ * shells have exited. Session `status` is deliberately shell-driven (so an
+ * always-on browser pane can't mask agent completion / the Restart affordance —
+ * see `deriveShellSessionStatus`), which means a session with a live browser
+ * pane but no live shell reads as `completed`. Visibility must not follow that:
+ * dropping its tab would orphan a live native view with no way back to it.
+ */
+const hasLiveBrowserPane = (session: Session): boolean =>
+  session.panes.some((pane) => isBrowserPane(pane) && pane.status === 'running')
+
+/**
  * Returns the sessions visible in the SessionTabs strip — running or
- * paused sessions plus the currently active one (so a just-exited
- * active session keeps its tab even after status flips to
- * completed/errored). This is the single source of truth for "open"
- * semantics; both `SessionTabs` and `pickNextVisibleSessionId`
- * consume it so the visible-set definition can never drift between
- * the strip's render and the close-fallback navigation.
+ * paused sessions, sessions with a live browser pane, plus the currently
+ * active one (so a just-exited active session keeps its tab even after status
+ * flips to completed/errored). This is the single source of truth for "open"
+ * semantics; both `SessionTabs` and `pickNextVisibleSessionId` consume it so
+ * the visible-set definition can never drift between the strip's render and the
+ * close-fallback navigation.
  */
 export const getVisibleSessions = (
   sessions: Session[],
   activeSessionId: string | null
 ): Session[] =>
   sessions.filter(
-    (s) => isOpenSessionStatus(s.status) || s.id === activeSessionId
+    (s) =>
+      isOpenSessionStatus(s.status) ||
+      hasLiveBrowserPane(s) ||
+      s.id === activeSessionId
   )
 
 /**

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -106,6 +106,15 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
   ),
 }))
 
+// Mock the browser barrel so SplitView can render a browser pane without the
+// real WebContentsView bridge — we only assert TerminalZone's panel wiring.
+vi.mock('../../browser', () => ({
+  BrowserPane: (): ReactElement => (
+    <div data-testid="browser-pane-mock">Mocked BrowserPane</div>
+  ),
+  focusBrowserPane: vi.fn().mockResolvedValue(undefined),
+}))
+
 describe('TerminalZone', () => {
   const defaultProps = {
     sessions: mockSessions.slice(0, 2), // First two sessions
@@ -116,6 +125,80 @@ describe('TerminalZone', () => {
     addPane: vi.fn(),
     removePane: vi.fn(),
   }
+
+  test('wires the tabpanel aria linkage for a completed session kept visible by a live browser pane', () => {
+    const sessions: Session[] = [
+      {
+        ...mockSessions[0],
+        id: 'alive',
+        status: 'running' as const,
+        panes: [
+          {
+            ...mockSessions[0].panes[0],
+            ptyId: 'alive',
+            status: 'running' as const,
+          },
+        ],
+      },
+      {
+        ...mockSessions[0],
+        id: 'browser-live',
+        status: 'completed' as const,
+        layout: 'single' as LayoutId,
+        panes: [
+          {
+            id: 'b0',
+            kind: 'browser',
+            ptyId: 'browser:browser-live',
+            cwd: '~',
+            agentType: 'generic',
+            status: 'running' as const,
+            active: true,
+            browserUrl: 'https://example.com/',
+          },
+        ],
+      },
+      {
+        ...mockSessions[0],
+        id: 'exited',
+        status: 'completed' as const,
+        panes: [
+          {
+            ...mockSessions[0].panes[0],
+            ptyId: 'exited',
+            status: 'completed' as const,
+          },
+        ],
+      },
+    ]
+
+    render(
+      <TerminalZone
+        {...defaultProps}
+        sessions={sessions}
+        activeSessionId="alive"
+      />
+    )
+
+    // Inactive panels carry the `hidden` class (display:none), so include
+    // hidden roles to reach them.
+    const panels = screen.getAllByRole('tabpanel', { hidden: true })
+
+    const browserPanel = panels.find(
+      (p) => p.id === 'session-panel-browser-live'
+    )
+    const exitedPanel = panels.find((p) => p.id === 'session-panel-exited')
+
+    // Completed but kept visible by its running browser pane → the tab exists,
+    // so the panel must carry the aria-labelledby relationship to it.
+    expect(browserPanel).toHaveAttribute(
+      'aria-labelledby',
+      'session-tab-browser-live'
+    )
+
+    // Completed, shell-only, non-active → no tab → panel stays aria-clean.
+    expect(exitedPanel).not.toHaveAttribute('aria-labelledby')
+  })
 
   test('renders terminal content area with TerminalPane', () => {
     render(<TerminalZone {...defaultProps} />)

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -13,7 +13,7 @@ import type {
   PaneEventHandler,
   NotifyPaneReadyResult,
 } from '../../sessions/hooks/useSessionManager'
-import { isOpenSessionStatus } from '../../sessions/utils/pickNextVisibleSessionId'
+import { isSessionVisible } from '../../sessions/utils/pickNextVisibleSessionId'
 import { LayoutSwitcher } from '../../terminal/components/LayoutSwitcher'
 import {
   SplitView,
@@ -220,19 +220,15 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
             sessions.map((session) => {
               const isActive = session.id === activeSessionId
 
-              // SessionTabs.open keeps a tab for running/paused sessions OR
-              // the active session — completed/errored non-active sessions
-              // exist as panels here but have no corresponding tab id, so
-              // aria-labelledby would point at a non-existent element. Only
-              // wire the linkage when the panel actually has a visible tab
-              // (= isActive OR open status). Hidden panels stay aria-clean.
-              // Use the canonical `isOpenSessionStatus` predicate from the
-              // utility (same source as Sidebar's Active/Recent grouping)
-              // so a future non-open status (e.g. `suspended`) auto-flows
-              // into both visibility surfaces without TerminalZone needing
-              // a separate update.
-              const hasVisibleTab =
-                isActive || isOpenSessionStatus(session.status)
+              // Completed/errored non-active sessions exist as panels here but
+              // may have no corresponding tab id, so aria-labelledby would point
+              // at a non-existent element. Wire the linkage only when the panel
+              // actually has a visible tab. Use the SAME `isSessionVisible`
+              // predicate `getVisibleSessions` uses — sharing it is what keeps
+              // the tab and its panel from disagreeing (e.g. a completed session
+              // kept visible by a running browser pane must still get the tab
+              // relationship). Hidden panels stay aria-clean.
+              const hasVisibleTab = isSessionVisible(session, activeSessionId)
 
               return (
                 <div


### PR DESCRIPTION
## Summary
Phase-2 roadmap #316, step 2e — closes #313. First child PR against the `feat/builtin-browser` integration branch.

When a session's last shell PTY exits, status flips to `completed` (shell-driven by design, so an always-on browser pane can't mask agent completion / the Restart affordance). `getVisibleSessions` then dropped the tab after switch-away, orphaning a still-live browser pane.

This decouples **reachability** from **agent-completion**: `getVisibleSessions` now also retains any session with a running browser pane (`hasLiveBrowserPane`). The shell-driven `status` and its tested invariant are unchanged — only tab visibility follows the live browser.

## Test plan
- [x] `getVisibleSessions` keeps `[completed shell + running browser]` when not active; hides it once the browser pane also exits
- [x] `pickNextVisibleSessionId` treats a live-browser session as a visible neighbor
- [x] full suite (3025 passed) + tc/lint/format green; codex-verify clean