### PR TITLE
feat(workspace): local rename for browser panes via :rename-pane (#314)

### DIFF
--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -197,6 +197,20 @@ describe('BrowserPane', () => {
     expect(screen.getByLabelText('browser address')).toHaveFocus()
   })
 
+  test('shows a user-set pane label in the chrome title', () => {
+    // `:rename-pane` sets pane.userLabel; the browser chrome must surface it so
+    // the rename is visible (otherwise the command silently no-ops visually).
+    render(
+      <BrowserPane
+        session={session}
+        pane={{ ...browserPane, userLabel: 'docs-tab' }}
+        isActive
+      />
+    )
+
+    expect(screen.getByText('docs-tab')).toBeInTheDocument()
+  })
+
   test('close button fires before chrome click propagation is stopped', async () => {
     const user = userEvent.setup()
     const onClose = vi.fn()

--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -198,8 +198,7 @@ describe('BrowserPane', () => {
   })
 
   test('shows a user-set pane label in the chrome title', () => {
-    // `:rename-pane` sets pane.userLabel; the browser chrome must surface it so
-    // the rename is visible (otherwise the command silently no-ops visually).
+    // The browser chrome must surface a user-set pane label.
     render(
       <BrowserPane
         session={session}

--- a/src/features/browser/components/BrowserPane.tsx
+++ b/src/features/browser/components/BrowserPane.tsx
@@ -539,9 +539,7 @@ export const BrowserPane = ({
           </button>
         </form>
         <span className="hidden max-w-[160px] truncate font-mono text-[10px] text-on-surface-muted lg:inline">
-          {/* A user-set pane label (`:rename-pane`) wins over the live tab
-              title, mirroring the shell Header's `userLabel ?? agentTitle ??
-              session.name` precedence — so renaming a browser pane is visible. */}
+          {/* User label wins over the live tab title (shell-Header precedence). */}
           {pane.userLabel ??
             (activeTab ? (activeTab.title ?? activeTab.url) : null)}
         </span>

--- a/src/features/browser/components/BrowserPane.tsx
+++ b/src/features/browser/components/BrowserPane.tsx
@@ -539,7 +539,11 @@ export const BrowserPane = ({
           </button>
         </form>
         <span className="hidden max-w-[160px] truncate font-mono text-[10px] text-on-surface-muted lg:inline">
-          {activeTab ? (activeTab.title ?? activeTab.url) : null}
+          {/* A user-set pane label (`:rename-pane`) wins over the live tab
+              title, mirroring the shell Header's `userLabel ?? agentTitle ??
+              session.name` precedence — so renaming a browser pane is visible. */}
+          {pane.userLabel ??
+            (activeTab ? (activeTab.title ?? activeTab.url) : null)}
         </span>
         {onClose ? (
           <button

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -768,10 +768,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
   test(':rename-pane labels a browser pane locally', async () => {
     const user = userEvent.setup()
 
-    // Active pane is a browser pane. Previously the shell-only gate nulled its
-    // ptyId, so :rename-pane reported "No active pane to rename". It must now
-    // label the pane locally by its pseudo ptyId (the agent /rename sync is a
-    // tolerated NoLiveAgent no-op for non-agent panes).
+    // A browser pane must be labelable by its ptyId.
     const browserSession: Session = {
       ...createMockSession('session-browser', 'browser-tab'),
       panes: [

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -806,6 +806,12 @@ describe('WorkspaceView - Command Palette Integration', () => {
       'browser:session-browser',
       'web'
     )
+
+    // Label is set once and never rolled back (no second undefined call).
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mockSessionManager.setPaneUserLabel).toHaveBeenCalledTimes(1)
   })
 
   test(':next command switches to next session', async () => {

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -765,6 +765,52 @@ describe('WorkspaceView - Command Palette Integration', () => {
     expect(mockSessionManager.renameSession).not.toHaveBeenCalled()
   })
 
+  test(':rename-pane labels a browser pane locally', async () => {
+    const user = userEvent.setup()
+
+    // Active pane is a browser pane. Previously the shell-only gate nulled its
+    // ptyId, so :rename-pane reported "No active pane to rename". It must now
+    // label the pane locally by its pseudo ptyId (the agent /rename sync is a
+    // tolerated NoLiveAgent no-op for non-agent panes).
+    const browserSession: Session = {
+      ...createMockSession('session-browser', 'browser-tab'),
+      panes: [
+        {
+          id: 'b0',
+          kind: 'browser',
+          ptyId: 'browser:session-browser',
+          cwd: '/home/user',
+          agentType: 'generic',
+          status: 'running',
+          active: true,
+          browserUrl: 'https://example.com/',
+        },
+      ],
+    }
+    mockSessionManager.sessions = [browserSession]
+    mockSessionManager.activeSessionId = 'session-browser'
+
+    render(<WorkspaceView />)
+
+    openPalette()
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('combobox', {
+      name: 'Command palette search',
+    })
+    await user.clear(input)
+    await user.type(input, ':rename-pane web')
+    await user.keyboard('{Enter}')
+
+    expect(mockSessionManager.setPaneUserLabel).toHaveBeenCalledWith(
+      'browser:session-browser',
+      'web'
+    )
+  })
+
   test(':next command switches to next session', async () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -247,16 +247,15 @@ export const WorkspaceView = (): ReactElement => {
     ? (findActivePane(activeSessionForCommands) ?? null)
     : null
 
-  const activePaneForCommandsIsShell =
-    (activePaneForCommandInputs?.kind ?? 'shell') === 'shell'
+  // `:rename-pane` addresses any pane by its (pseudo) ptyId — browser panes
+  // included. The local label applies to every pane; the agent `/rename` sync
+  // is rejected as NoLiveAgent by the backend for non-agent panes (browser or
+  // generic shell), which the rename command + chord already tolerate via
+  // isExpectedLocalOnlyRenameFailure (so the local label sticks).
+  const activePanePtyIdForCommands = activePaneForCommandInputs?.ptyId ?? null
 
-  const activePanePtyIdForCommands = activePaneForCommandsIsShell
-    ? (activePaneForCommandInputs?.ptyId ?? null)
-    : null
-
-  const activePaneAgentTypeForCommands = activePaneForCommandsIsShell
-    ? (activePaneForCommandInputs?.agentType ?? null)
-    : null
+  const activePaneAgentTypeForCommands =
+    activePaneForCommandInputs?.agentType ?? null
 
   const activeSession = activeSessionId
     ? sessions.find((s) => s.id === activeSessionId)
@@ -611,6 +610,13 @@ export const WorkspaceView = (): ReactElement => {
     if (!activeSession || !activePane) {
       return null
     }
+
+    // The chord positions its input over the pane's header element
+    // (PaneRenameInput anchors via paneHeaderRefs by ptyId). Browser panes have
+    // no registered header anchor yet, so the input would fall back to the body
+    // centre — behind the native WebContentsView — and the chord would appear
+    // not to open. Keep it shell-only; the `:rename-pane` command still labels
+    // browser panes. Registering a browser rename anchor is Phase-2 chrome work.
     if ((activePane.kind ?? 'shell') !== 'shell') {
       return null
     }

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -247,11 +247,7 @@ export const WorkspaceView = (): ReactElement => {
     ? (findActivePane(activeSessionForCommands) ?? null)
     : null
 
-  // `:rename-pane` addresses any pane by its (pseudo) ptyId — browser panes
-  // included. The local label applies to every pane; the agent `/rename` sync
-  // is rejected as NoLiveAgent by the backend for non-agent panes (browser or
-  // generic shell), which the rename command + chord already tolerate via
-  // isExpectedLocalOnlyRenameFailure (so the local label sticks).
+  // Any pane is addressable by ptyId; the agent sync no-ops on non-agent panes.
   const activePanePtyIdForCommands = activePaneForCommandInputs?.ptyId ?? null
 
   const activePaneAgentTypeForCommands =
@@ -611,12 +607,7 @@ export const WorkspaceView = (): ReactElement => {
       return null
     }
 
-    // The chord positions its input over the pane's header element
-    // (PaneRenameInput anchors via paneHeaderRefs by ptyId). Browser panes have
-    // no registered header anchor yet, so the input would fall back to the body
-    // centre — behind the native WebContentsView — and the chord would appear
-    // not to open. Keep it shell-only; the `:rename-pane` command still labels
-    // browser panes. Registering a browser rename anchor is Phase-2 chrome work.
+    // Chord stays shell-only: it anchors over a pane-header element browser panes lack.
     if ((activePane.kind ?? 'shell') !== 'shell') {
       return null
     }

--- a/src/features/workspace/commands/buildWorkspaceCommands.test.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.test.ts
@@ -190,6 +190,37 @@ describe('buildWorkspaceCommands - happy paths', () => {
     expect(notifyInfo).not.toHaveBeenCalled()
   })
 
+  test(':rename-pane keeps a browser-pane label after the NoLiveAgent sync failure', async () => {
+    renameAgentSession.mockRejectedValueOnce(
+      new AgentRenameError('no live agent', 'no-live-agent')
+    )
+
+    const commands = buildWorkspaceCommands({
+      sessions: mockSessions,
+      activeSessionId: 'session-1',
+      createSession,
+      removeSession,
+      renameSession,
+      setPaneUserLabel,
+      renameAgentSession,
+      activePanePtyId: 'browser:p1',
+      activePaneAgentType: 'generic',
+      setActiveSessionId,
+      notifyInfo,
+    })
+
+    commands.find((c) => c.id === 'rename-pane')?.execute?.('web-tab')
+
+    expect(setPaneUserLabel).toHaveBeenCalledWith('browser:p1', 'web-tab')
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // NoLiveAgent is suppressed for non-agent panes: label kept, no rollback.
+    expect(setPaneUserLabel).toHaveBeenCalledTimes(1)
+    expect(notifyInfo).not.toHaveBeenCalled()
+  })
+
   test(':rename-pane surfaces unexpected backend rename failure after local label update', async () => {
     renameAgentSession.mockRejectedValueOnce(new Error('pty write failed'))
 


### PR DESCRIPTION
## Summary
Phase-2 roadmap #316, step 2f — closes #314. Second child PR against `feat/builtin-browser`.

Browser panes were locked out of `:rename-pane` (the shell-only gate nulled their ptyId → "No active pane to rename"). This enables the **command-palette rename** for browser panes and **surfaces the label** in the browser chrome.

- Relax the command-input gate (pass pane ptyId/agentType regardless of kind). The agent `/rename` sync is a tolerated NoLiveAgent no-op for non-agent panes (browser or generic shell).
- `BrowserPane` chrome title now shows `pane.userLabel ?? tab title/url` (mirrors the shell Header precedence) so the rename is visible.
- The leader-`r` **chord stays shell-only**: it anchors over a registered pane-header element, which browser panes lack (the input would render behind the native WebContentsView). Registering a browser rename anchor is Phase-2 chrome work — noted on #316.

## Test plan
- [x] command-palette `:rename-pane web` labels a browser pane (was "No active pane to rename")
- [x] `BrowserPane` surfaces a user-set label in its chrome title
- [x] full suite 3033 passed; tc/lint/format green; codex-verify clean