### PR TITLE
refactor(qa-runner): rename .mjs scripts to .js + bring them under eslint

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -18,6 +18,11 @@ words:
   # Anthropic id prefixes appearing in code and test fixtures
   - toolu
 
+  # QA-runner automation (kimi fixer CLI, dry-run worktrees, review state)
+  - kimi
+  - dryrun
+  - unreviewed
+
   # General vocabulary flagged by cspell's defaults
   - unparseable
   - lossily

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | -------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security           | 21       | 3    | 2026-05-20   |
 | [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 25       | 9    | 2026-05-31   |
-| [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 3        | 3    | 2026-05-24   |
+| [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 5        | 3    | 2026-05-31   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 4        | 3    | 2026-05-07   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality       | 5        | 0    | 2026-05-09   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
@@ -71,5 +71,6 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 18       | 0    | 2026-05-26   |
+| [Promise Patterns](patterns/promise-patterns.md)                     | code-quality       | 1        | 0    | 2026-05-31   |
 | [Verify Render Target](patterns/verify-render-target.md)             | code-quality       | 2        | 0    | 2026-05-24   |
 | [Status Indicator Display](patterns/status-indicator-display.md)     | code-quality       | 3        | 0    | 2026-05-26   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -444,7 +444,7 @@ prevent showing previous data.
 
 - **Source:** github-claude | PR #320 | 2026-05-31
 - **Severity:** MEDIUM
-- **File:** `scripts/qa-runner/run.mjs`
+- **File:** `scripts/qa-runner/run.js`
 - **Finding:** `existsSync(lock)` followed by `writeFileSync(lock, ...)` is non-atomic; two concurrent processes can both pass the existence check before either writes, resulting in double-dispatch.
 - **Fix:** Replace with `fs.openSync(lock, 'wx')` wrapped in try/catch; `EEXIST` means another process holds the lock.
 - **Commit:** `7644ec4` + cycle-2 fix

--- a/docs/reviews/patterns/credential-leakage.md
+++ b/docs/reviews/patterns/credential-leakage.md
@@ -18,7 +18,7 @@ Secret files (OAuth tokens, API keys, bearer tokens) referenced in code must be 
 
 - **Source:** github-codex-connector | PR #321 round 1 | 2026-05-31
 - **Severity:** P1 / HIGH
-- **File:** `scripts/qa-runner/lib/linear-status.mjs`
+- **File:** `scripts/qa-runner/lib/linear-status.js`
 - **Finding:** The new role token files (`linear-agent.env`, `linear-orchestrator.env`) are read as local OAuth secret stores, but only `linear.env` is covered in `.gitignore`. A normal `git add .` can commit the bearer token despite the comment saying the files are gitignored.
 - **Fix:** Added `linear-*.env` to `.gitignore` so all role-specific Linear agent token files are ignored.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -283,7 +283,7 @@ failed" must mean the editor shows the original file, not the requested one.
 
 - **Source:** github-claude | PR #320 | 2026-05-31
 - **Severity:** HIGH
-- **File:** `scripts/qa-runner/watch.mjs`
+- **File:** `scripts/qa-runner/watch.js`
 - **Finding:** `computeState` checks `threads > 0` before `claudePending`, so a pending Claude review is ignored when open threads exist. The watcher dispatches a fix cycle, advances HEAD, and later reads Claude's stale verdict for the pre-fix SHA as "patch is correct".
 - **Fix:** Swap the priority arms so `claudePending || ci === 'pending'` is evaluated before `threads > 0`.
 - **Commit:** `7644ec4` + cycle-2 fix
@@ -292,7 +292,7 @@ failed" must mean the editor shows the original file, not the requested one.
 
 - **Source:** github-claude | PR #320 | 2026-05-31
 - **Severity:** HIGH
-- **File:** `scripts/qa-runner/watch.mjs`
+- **File:** `scripts/qa-runner/watch.js`
 - **Finding:** REST API call uses `?per_page=100` with no pagination loop. On PRs with >100 issue comments, the latest Claude review is invisible and the PR is permanently stuck in `WAITING`.
 - **Fix:** Use `gh api --paginate` piped through `jq -s add` to concatenate all pages before filtering.
 - **Commit:** `7644ec4` + cycle-2 fix
@@ -301,7 +301,7 @@ failed" must mean the editor shows the original file, not the requested one.
 
 - **Source:** github-claude | PR #320 | 2026-05-31
 - **Severity:** MEDIUM
-- **File:** `scripts/qa-runner/watch.mjs`
+- **File:** `scripts/qa-runner/watch.js`
 - **Finding:** `approve()` calls `gh pr review --approve` then `gh pr merge --squash` sequentially. On merge failure, the PR stays approved; the next tick posts another approval before retrying merge, spamming the timeline.
 - **Fix:** Query existing PR reviews and skip `--approve` if the effective approver identity (bot or ambient `gh` user) already approved.
 - **Commit:** `7644ec4` + cycle-2 fix
@@ -310,7 +310,7 @@ failed" must mean the editor shows the original file, not the requested one.
 
 - **Source:** github-claude | PR #320 round 1 | 2026-05-31
 - **Severity:** MEDIUM
-- **File:** `scripts/qa-runner/watch.mjs`
+- **File:** `scripts/qa-runner/watch.js`
 - **Finding:** `postLinear(…, 'In Progress')` was called before the `ctx.execute` guard, so every report-only tick falsely transitioned linked Linear issues to "In Progress" even when no fix cycle ran.
 - **Fix:** Moved `postLinear` inside the `ctx.execute` block so it only fires when a real fix cycle is dispatched.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/git-operations.md
+++ b/docs/reviews/patterns/git-operations.md
@@ -217,7 +217,7 @@ between display and mutation operations.
 
 - **Source:** github-claude | PR #320 | 2026-05-31
 - **Severity:** MEDIUM
-- **File:** `scripts/qa-runner/run.mjs`
+- **File:** `scripts/qa-runner/run.js`
 - **Finding:** The guard `if (bot && live && !existing)` skips HTTPS remote + credential helper setup for reused worktrees. A worktree created without a bot identity retains its original remote; the bot's `GH_TOKEN` is injected into env but git pushes over the old remote, breaking the author≠approver invariant.
 - **Fix:** Remove the `!existing` guard so remote config runs unconditionally when `bot && live`.
 - **Commit:** `7644ec4` + cycle-2 fix
@@ -226,7 +226,7 @@ between display and mutation operations.
 
 - **Source:** github-claude | PR #320 round 1 | 2026-05-31
 - **Severity:** LOW
-- **File:** `scripts/qa-runner/watch.mjs`
+- **File:** `scripts/qa-runner/watch.js`
 - **Finding:** `ensureWorktree()` created `.claude/worktrees/qa-pr-N` per PR, but `approve()` never cleaned them up after squash-merge. Over many PRs the worktrees accumulated, holding git references that prevented GC.
 - **Fix:** Added `git worktree remove --force` in `approve()\'s` success path, right after remote branch deletion.
 - **Commit:** same commit as this entry
@@ -235,7 +235,7 @@ between display and mutation operations.
 
 - **Source:** github-codex-connector | PR #320 round 3 | 2026-05-31
 - **Severity:** P1 / HIGH
-- **File:** `scripts/qa-runner/watch.mjs`
+- **File:** `scripts/qa-runner/watch.js`
 - **Finding:** `approve()` unconditionally deleted the remote branch via base-repo API after merge. For fork PRs, `headRefName` is the contributor's branch name; the deletion would remove a same-named base-repo branch instead.
 - **Fix:** Fetched `isCrossRepository` from `gh pr view\' and gated the remote ref-delete on `!isCrossRepository`.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/preflight-checks.md
+++ b/docs/reviews/patterns/preflight-checks.md
@@ -35,7 +35,7 @@ When adding / removing / refactoring preflight checks:
 
 - **Source:** github-claude | PR #320 round 1 | 2026-05-31
 - **Severity:** MEDIUM
-- **File:** `scripts/qa-runner/watch.mjs`
+- **File:** `scripts/qa-runner/watch.js`
 - **Finding:** `computeState()\'s` two most expensive calls — `unresolvedThreads()` (paginated GraphQL) and `claudeVerdictClean()` (paginated REST) — ran before the CI fail / Claude pending early-exits, wasting API quota on PRs that would exit cheaply.
 - **Fix:** Deferred both expensive calls until inside the `else` branch after all cheap guard checks pass.
 - **Commit:** same commit as this entry
@@ -44,7 +44,7 @@ When adding / removing / refactoring preflight checks:
 
 - **Source:** github-codex-connector | PR #320 round 1 | 2026-05-31
 - **Severity:** P1 / HIGH
-- **File:** `scripts/qa-runner/watch.mjs`
+- **File:** `scripts/qa-runner/watch.js`
 - **Finding:** `computeState()` enumerated negative states (missing, pending, fail) to block on Claude check status, but `skipping` and `cancel` buckets bypassed the gate. An old clean Claude comment could still let the PR reach `GOOD_SHAPE` and auto-merge without a fresh review.
 - **Fix:** Replaced negative-state enumeration with a single positive gate `claudeReady = claudeCheck?.bucket === 'pass'`; block on `!claudeReady` so any non-pass state (including skipped/cancelled) waits.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/promise-patterns.md
+++ b/docs/reviews/patterns/promise-patterns.md
@@ -1,0 +1,34 @@
+---
+id: promise-patterns
+category: code-quality
+created: 2026-05-31
+last_updated: 2026-05-31
+ref_count: 0
+---
+
+# Promise Patterns
+
+## Summary
+
+When writing modern JavaScript/TypeScript, prefer top-level `await` with
+`try/catch` over `.then()`/`.catch()` chains. The ESLint
+`promise/prefer-await-to-then` rule (enabled in this repo) flags `.catch()`
+as well as `.then()` and `.finally()`. Besides lint compliance, the
+`await` form is usually easier to read, debug, and reason about — especially
+when multiple sequential async operations are involved.
+
+## Findings
+
+### 1. Replace final catch before enabling lint
+
+- **Source:** github-codex-connector | PR #322 round 1 | 2026-05-31
+- **Severity:** P2 / MEDIUM
+- **File:** `scripts/qa-runner/lib/linear-status.js`
+- **Finding:** `main().catch(...)` at the top level kept `npm run lint` failing
+  for the `scripts/qa-runner/**` files that the commit was bringing under
+  ESLint coverage. The `promise/prefer-await-to-then` rule flags `.catch()`
+  as well as `.then()`/`.finally()`.
+- **Fix:** Replaced `main().catch(...)` with top-level
+  `try { await main() } catch (...) { ... }`, matching the pattern already
+  used in `watch.js`.
+- **Commit:** same commit as this entry (see `git blame` / `git log`)

--- a/docs/reviews/patterns/resource-cleanup.md
+++ b/docs/reviews/patterns/resource-cleanup.md
@@ -2,7 +2,7 @@
 id: resource-cleanup
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-05-24
+last_updated: 2026-05-31
 ref_count: 3
 ---
 
@@ -44,4 +44,34 @@ causes listener accumulation and duplicate event handling.
 - **Finding:** The new UI-side store exported only `readActivityPanelCollapsed` and `writeActivityPanelCollapsed`. `removeSession` never deleted the key, so every closed session left a `vimeflow:sessions:activityPanelCollapsed:<id>` entry in localStorage forever — replacing the Rust PTY cache (auto-cleaned on PTY exit) without an equivalent cleanup hook.
 - **Fix:** Add `deleteActivityPanelCollapsed(sessionId)` to the store. Call it from `removeSession` only on the happy path (after both kill phases settle), so a partial-kill bail does not drop the preference for a session the user can still see and retry.
 - **Verification:** Targeted tests in `activityPanelCollapsedStore.test.ts` (delete removes entry, no-op when absent, isolates by id) + `useSessionManager.test.ts` (removeSession clears the key on success, preserves it when kill rejects).
+- **Commit:** same commit as this entry (see `git blame` / `git log`)
+
+### 4. Lock file fd leak and stale lock on writeSync failure
+
+- **Source:** github-claude | PR #322 round 1 | 2026-05-31
+- **Severity:** LOW
+- **File:** `scripts/qa-runner/run.js`
+- **Finding:** `openSync(lock, 'wx')` created the file, but if `writeSync` then
+  threw (e.g. disk-full), `closeSync(fd)` was never called (leaked fd) and
+  execution never reached the outer `try/finally` that unlinks the lock. The
+  lock file persisted, permanently blocking future automation for that PR.
+- **Fix:** Replaced the `openSync`/`writeSync`/`closeSync` trio with a single
+  atomic `writeFileSync(lock, ..., { flag: 'wx' })` and added `unlinkSync(lock)`
+  in the non-`EEXIST` catch path so write failures clean up the partially
+  created lock before re-throwing.
+- **Commit:** same commit as this entry (see `git blame` / `git log`)
+
+### 5. Stream pipe() drops trailing partial line from console
+
+- **Source:** github-claude | PR #322 round 1 | 2026-05-31
+- **Severity:** LOW
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** The `pipe()` helper buffered child stdout/stderr line-by-line
+  for console output, but only flushed when it found a `\n`. A final partial
+  line (e.g. the last line of kimi's summary without a trailing newline) was
+  silently dropped from the console, though it was still written to the log
+  file.
+- **Fix:** Added `stream.on('end', () => { if (buf) out(...) })` after the
+  `'data'` handler to flush any remaining buffered text when the child stream
+  closes.
 - **Commit:** same commit as this entry (see `git blame` / `git log`)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,10 +38,6 @@ export default defineConfig([
       // tests/e2e/tsconfig.json, WDIO globals, and domain terms
       // (tput, xterm, wdio, pty, …) rather than extending the main one.
       'tests/e2e/**',
-      // QA-runner ops scripts: standalone node tooling (run via `node`, not
-      // bundled) with their own idioms; the app's React/TS/cspell rules don't
-      // carry. Covered by `node --check` + Prettier. Same rationale as e2e above.
-      'scripts/qa-runner/**',
     ],
   },
   {

--- a/scripts/qa-runner/README.md
+++ b/scripts/qa-runner/README.md
@@ -44,7 +44,7 @@ from the CI gate, so a clean patch is never held `WAITING` by its own reviewers.
 
 | State          | When                                                                    | Action (armed)                      |
 | -------------- | ----------------------------------------------------------------------- | ----------------------------------- |
-| **NEEDS_FIX**  | unresolved review threads > 0, **or** Claude verdict "patch has issues" | `--execute` → `run.js <pr> --push` |
+| **NEEDS_FIX**  | unresolved review threads > 0, **or** Claude verdict "patch has issues" | `--execute` → `run.js <pr> --push`  |
 | **CI_RED**     | a non-review CI check is failing                                        | report only (humans fix the build)  |
 | **WAITING**    | CI/Claude still running · draft · not mergeable · no Claude review yet  | report only (poll again)            |
 | **GOOD_SHAPE** | 0 threads · Claude ✅ · non-review CI green · `MERGEABLE`               | `--approve` → squash-merge + delete |
@@ -64,13 +64,13 @@ authenticated comment author is on the whitelist.
 
 ## Status
 
-| Increment | What                                                                                               | State                    |
-| --------- | -------------------------------------------------------------------------------------------------- | ------------------------ |
+| Increment | What                                                                                              | State                    |
+| --------- | ------------------------------------------------------------------------------------------------- | ------------------------ |
 | **1**     | `watch.js scan` — read-only: list eligible PRs                                                    | ✅ done                  |
 | **2**     | `run.js` — lock → dispatch kimi (upsource-review skill) → codex gate → push, fixer bot identity   | ✅ done                  |
 | **3**     | `watch.js tick/watch` — outer state machine, `--execute` fixes, `--approve` merges, Linear wiring | ✅ done — proven on #317 |
-| **4**     | two-bot loop (fixer ≠ orchestrator) + parallel fixes (cap `--max`)                                 | ✅ done                  |
-| 5         | host: cron / `/loop`, then a self-hosted GitHub Actions runner on `pull_request_review`            | ⬜ next                  |
+| **4**     | two-bot loop (fixer ≠ orchestrator) + parallel fixes (cap `--max`)                                | ✅ done                  |
+| 5         | host: cron / `/loop`, then a self-hosted GitHub Actions runner on `pull_request_review`           | ⬜ next                  |
 
 ## Usage
 
@@ -117,8 +117,8 @@ actions are attributable and split by role. Either absent ⇒ that role acts as 
 own `gh` (backward-compatible). **Never paste a token into chat** — they're read
 from these files.
 
-| File               | Keys        | Role                                      | Used by                   |
-| ------------------ | ----------- | ----------------------------------------- | ------------------------- |
+| File               | Keys        | Role                                      | Used by                  |
+| ------------------ | ----------- | ----------------------------------------- | ------------------------ |
 | `bot.env`          | `GH_BOT_*`  | inner **fixer**                           | `run.js` (kimi)          |
 | `orchestrator.env` | `GH_ORCH_*` | outer **orchestrator** (reviews + merges) | `watch.js` (`--approve`) |
 

--- a/scripts/qa-runner/README.md
+++ b/scripts/qa-runner/README.md
@@ -7,7 +7,7 @@ Design + rationale: [`docs/explorations/linear-agent-cicd-pilot.html`](../../doc
 ## Shape
 
 ```
- ① watch.mjs (outer watcher + state machine, as the ORCHESTRATOR bot)  — poll open
+ ① watch.js (outer watcher + state machine, as the ORCHESTRATOR bot)  — poll open
     PRs, gate on opt-in (`auto-review` label) + a per-PR lock, compute each PR's
     review STATE, and act:
        NEEDS_FIX  → dispatch the inner runner (--execute), up to --max in parallel
@@ -15,7 +15,7 @@ Design + rationale: [`docs/explorations/linear-agent-cicd-pilot.html`](../../doc
        WAITING / CI_RED → report only
                  │
                  ▼  per NEEDS_FIX PR, concurrently, each in its own worktree:
- ② run.mjs → kimi --afk (as the FIXER bot) · upsource-review skill  — poll → fix →
+ ② run.js → kimi --afk (as the FIXER bot) · upsource-review skill  — poll → fix →
     CODEX GATE → commit → push → reply/resolve threads → repeat until clean.
                  │
                  ▼
@@ -44,7 +44,7 @@ from the CI gate, so a clean patch is never held `WAITING` by its own reviewers.
 
 | State          | When                                                                    | Action (armed)                      |
 | -------------- | ----------------------------------------------------------------------- | ----------------------------------- |
-| **NEEDS_FIX**  | unresolved review threads > 0, **or** Claude verdict "patch has issues" | `--execute` → `run.mjs <pr> --push` |
+| **NEEDS_FIX**  | unresolved review threads > 0, **or** Claude verdict "patch has issues" | `--execute` → `run.js <pr> --push` |
 | **CI_RED**     | a non-review CI check is failing                                        | report only (humans fix the build)  |
 | **WAITING**    | CI/Claude still running · draft · not mergeable · no Claude review yet  | report only (poll again)            |
 | **GOOD_SHAPE** | 0 threads · Claude ✅ · non-review CI green · `MERGEABLE`               | `--approve` → squash-merge + delete |
@@ -66,9 +66,9 @@ authenticated comment author is on the whitelist.
 
 | Increment | What                                                                                               | State                    |
 | --------- | -------------------------------------------------------------------------------------------------- | ------------------------ |
-| **1**     | `watch.mjs scan` — read-only: list eligible PRs                                                    | ✅ done                  |
-| **2**     | `run.mjs` — lock → dispatch kimi (upsource-review skill) → codex gate → push, fixer bot identity   | ✅ done                  |
-| **3**     | `watch.mjs tick/watch` — outer state machine, `--execute` fixes, `--approve` merges, Linear wiring | ✅ done — proven on #317 |
+| **1**     | `watch.js scan` — read-only: list eligible PRs                                                    | ✅ done                  |
+| **2**     | `run.js` — lock → dispatch kimi (upsource-review skill) → codex gate → push, fixer bot identity   | ✅ done                  |
+| **3**     | `watch.js tick/watch` — outer state machine, `--execute` fixes, `--approve` merges, Linear wiring | ✅ done — proven on #317 |
 | **4**     | two-bot loop (fixer ≠ orchestrator) + parallel fixes (cap `--max`)                                 | ✅ done                  |
 | 5         | host: cron / `/loop`, then a self-hosted GitHub Actions runner on `pull_request_review`            | ⬜ next                  |
 
@@ -76,41 +76,41 @@ authenticated comment author is on the whitelist.
 
 ```bash
 # read-only eligibility (no side effects, ever)
-node scripts/qa-runner/watch.mjs scan            # eligible PRs (need the `auto-review` label)
-node scripts/qa-runner/watch.mjs scan --all      # ignore the label gate (debug)
-node scripts/qa-runner/watch.mjs scan --pr 317   # a single PR
+node scripts/qa-runner/watch.js scan            # eligible PRs (need the `auto-review` label)
+node scripts/qa-runner/watch.js scan --all      # ignore the label gate (debug)
+node scripts/qa-runner/watch.js scan --pr 317   # a single PR
 
 # one pass of the state machine — REPORT-ONLY by default
-node scripts/qa-runner/watch.mjs tick            # classify every eligible PR, do nothing
-node scripts/qa-runner/watch.mjs tick --pr 317   # classify one PR
+node scripts/qa-runner/watch.js tick            # classify every eligible PR, do nothing
+node scripts/qa-runner/watch.js tick --pr 317   # classify one PR
 
 # arm the actions (each is independent and opt-in)
-node scripts/qa-runner/watch.mjs tick --execute            # NEEDS_FIX  → run upsource cycles (parallel, cap 2)
-node scripts/qa-runner/watch.mjs tick --execute --max 3    # …up to 3 at once
-node scripts/qa-runner/watch.mjs tick --approve            # GOOD_SHAPE → squash-merge
-node scripts/qa-runner/watch.mjs tick --execute --approve  # full autonomy
+node scripts/qa-runner/watch.js tick --execute            # NEEDS_FIX  → run upsource cycles (parallel, cap 2)
+node scripts/qa-runner/watch.js tick --execute --max 3    # …up to 3 at once
+node scripts/qa-runner/watch.js tick --approve            # GOOD_SHAPE → squash-merge
+node scripts/qa-runner/watch.js tick --execute --approve  # full autonomy
 
 # loop forever (Ctrl-C to stop)
-node scripts/qa-runner/watch.mjs watch --execute --approve
+node scripts/qa-runner/watch.js watch --execute --approve
 ```
 
-`run.mjs` (the inner runner) can also be driven directly; it is **dry-run by
+`run.js` (the inner runner) can also be driven directly; it is **dry-run by
 default**, `--push` arms the live path, and it adopts the fixer bot identity from
 `bot.env` if present:
 
 ```bash
-node scripts/qa-runner/run.mjs 317          # dry-run: kimi fixes + codex gate, nothing pushed
-node scripts/qa-runner/run.mjs 317 --push   # live: commit/push as the fixer bot, reply/resolve, Linear status
+node scripts/qa-runner/run.js 317          # dry-run: kimi fixes + codex gate, nothing pushed
+node scripts/qa-runner/run.js 317 --push   # live: commit/push as the fixer bot, reply/resolve, Linear status
 ```
 
 ## Host (v1 → v2)
 
-- **v1 — your machine:** a cron / `/loop` calling `watch.mjs tick --execute --approve`
+- **v1 — your machine:** a cron / `/loop` calling `watch.js tick --execute --approve`
   (or `watch`). Everything's already authed locally.
 - **v2 — a self-hosted GitHub Actions runner** on a small always-on box, triggered by
   `pull_request_review`: event-driven for free, full toolchain, your secrets.
 
-## Identity (`lib/bot-identity.mjs`)
+## Identity (`lib/bot-identity.js`)
 
 Two optional, gitignored env files — each a **separate GitHub account** so machine
 actions are attributable and split by role. Either absent ⇒ that role acts as your
@@ -119,8 +119,8 @@ from these files.
 
 | File               | Keys        | Role                                      | Used by                   |
 | ------------------ | ----------- | ----------------------------------------- | ------------------------- |
-| `bot.env`          | `GH_BOT_*`  | inner **fixer**                           | `run.mjs` (kimi)          |
-| `orchestrator.env` | `GH_ORCH_*` | outer **orchestrator** (reviews + merges) | `watch.mjs` (`--approve`) |
+| `bot.env`          | `GH_BOT_*`  | inner **fixer**                           | `run.js` (kimi)          |
+| `orchestrator.env` | `GH_ORCH_*` | outer **orchestrator** (reviews + merges) | `watch.js` (`--approve`) |
 
 Each = a classic PAT (`repo` scope) on a Write-collaborator account; see the
 `*.example` files. The identity flows through three points: API actor (`GH_TOKEN`),

--- a/scripts/qa-runner/lib/bot-identity.js
+++ b/scripts/qa-runner/lib/bot-identity.js
@@ -1,6 +1,6 @@
 // Shared bot-identity loader for the QA runner's two roles:
-//   inner / fixer        → bot.env          (GH_BOT_*)   — used by run.mjs (kimi)
-//   outer / orchestrator → orchestrator.env  (GH_ORCH_*)  — used by watch.mjs (merge)
+//   inner / fixer        → bot.env          (GH_BOT_*)   — used by run.js (kimi)
+//   outer / orchestrator → orchestrator.env  (GH_ORCH_*)  — used by watch.js (merge)
 //
 // Each file holds a separate GitHub account so the bot that WRITES the fix is a
 // distinct identity from the bot that MERGES it — author ≠ approver, which also
@@ -13,17 +13,24 @@ import { join } from 'node:path'
 // Read `<scriptDir>/<file>` and pull the `<prefix>_TOKEN|USER|EMAIL` keys.
 export const loadBot = (scriptDir, file, prefix) => {
   const f = join(scriptDir, file)
-  if (!existsSync(f)) return null
+  if (!existsSync(f)) {
+    return null
+  }
   const want = new Set([`${prefix}_TOKEN`, `${prefix}_USER`, `${prefix}_EMAIL`])
   const env = {}
   for (const line of readFileSync(f, 'utf8').split('\n')) {
     const m = line.match(/^\s*(?:export\s+)?([A-Z_]+)\s*=\s*(.+?)\s*$/)
-    if (m && want.has(m[1])) env[m[1]] = m[2].replace(/^["']|["']$/g, '')
+    if (m && want.has(m[1])) {
+      env[m[1]] = m[2].replace(/^["']|["']$/g, '')
+    }
   }
   const token = env[`${prefix}_TOKEN`]
   const user = env[`${prefix}_USER`]
   const email = env[`${prefix}_EMAIL`]
-  if (!token || !user || !email || token.includes('xxxx')) return null
+  if (!token || !user || !email || token.includes('xxxx')) {
+    return null
+  }
+
   return { token, user, email }
 }
 

--- a/scripts/qa-runner/lib/linear-status.js
+++ b/scripts/qa-runner/lib/linear-status.js
@@ -137,7 +137,9 @@ const main = async () => {
   }
 }
 
-main().catch((e) => {
+try {
+  await main()
+} catch (e) {
   process.stderr.write(`${e.message}\n`)
   process.exit(1)
-})
+}

--- a/scripts/qa-runner/lib/linear-status.js
+++ b/scripts/qa-runner/lib/linear-status.js
@@ -8,7 +8,7 @@
 // comments carry the agent's identity, not yours. Without a linked agent it falls
 // back to the personal LINEAR_API_KEY ($env or repo-root linear.env).
 //
-// Usage: node linear-status.mjs <VIM-N> "<comment>" [--state "<name>"] [--as <role>]
+// Usage: node linear-status.js <VIM-N> "<comment>" [--state "<name>"] [--as <role>]
 
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
@@ -29,10 +29,14 @@ const repoRoot = () =>
 
 // Pull a single KEY=value from a dotenv-style file, or undefined.
 const readEnvVar = (file, key) => {
-  if (!existsSync(file)) return undefined
+  if (!existsSync(file)) {
+    return undefined
+  }
+
   const m = readFileSync(file, 'utf8').match(
     new RegExp(`^\\s*(?:export\\s+)?${key}\\s*=\\s*(.+?)\\s*$`, 'm')
   )
+
   return m ? m[1].replace(/^["']|["']$/g, '') : undefined
 }
 
@@ -48,16 +52,21 @@ const loadAuth = (role) => {
   const root = repoRoot()
   if (role) {
     const file = ROLE_FILE[role]
-    if (!file)
+    if (!file) {
       throw new Error(`unknown --as role "${role}" (fixer|orchestrator)`)
+    }
     const tok = readEnvVar(join(root, file), 'LINEAR_AGENT_TOKEN')
-    if (tok && !/PASTE|xxxx/i.test(tok))
+    if (tok && !/PASTE|xxxx/i.test(tok)) {
       return { header: `Bearer ${tok}`, who: `${role} agent` }
+    }
   }
+
   const key =
     process.env.LINEAR_API_KEY ||
     readEnvVar(join(root, 'linear.env'), 'LINEAR_API_KEY')
-  if (key) return { header: key, who: 'you (personal key)' }
+  if (key) {
+    return { header: key, who: 'you (personal key)' }
+  }
   throw new Error(
     'no Linear auth — link the agent (LINEAR_AGENT_TOKEN) or set LINEAR_API_KEY (env or repo-root linear.env). See rules/common/linear-workflow.md'
   )
@@ -75,6 +84,7 @@ const gql = async (auth, query, variables) => {
       `Linear GraphQL: ${json.errors.map((e) => e.message).join('; ')}`
     )
   }
+
   return json.data
 }
 
@@ -82,7 +92,7 @@ const main = async () => {
   const [identifier, body, ...rest] = process.argv.slice(2)
   if (!identifier || !body) {
     throw new Error(
-      'usage: linear-status.mjs <VIM-N> "<comment>" [--state "<name>"] [--as <role>]'
+      'usage: linear-status.js <VIM-N> "<comment>" [--state "<name>"] [--as <role>]'
     )
   }
   const flag = (n) => (rest.includes(n) ? rest[rest.indexOf(n) + 1] : undefined)
@@ -94,7 +104,9 @@ const main = async () => {
     'query($id:String!){issue(id:$id){id identifier team{id}}}',
     { id: identifier }
   )
-  if (!d.issue) throw new Error(`issue ${identifier} not found`)
+  if (!d.issue) {
+    throw new Error(`issue ${identifier} not found`)
+  }
 
   await gql(
     auth.header,
@@ -109,10 +121,13 @@ const main = async () => {
       'query($t:ID!){workflowStates(filter:{team:{id:{eq:$t}}}){nodes{id name}}}',
       { t: d.issue.team.id }
     )
+
     const st = s.workflowStates.nodes.find(
       (n) => n.name.toLowerCase() === stateName.toLowerCase()
     )
-    if (!st) throw new Error(`state "${stateName}" not found for the team`)
+    if (!st) {
+      throw new Error(`state "${stateName}" not found for the team`)
+    }
     await gql(
       auth.header,
       'mutation($id:String!,$s:String!){issueUpdate(id:$id,input:{stateId:$s}){success}}',

--- a/scripts/qa-runner/lib/pr-utils.js
+++ b/scripts/qa-runner/lib/pr-utils.js
@@ -1,4 +1,4 @@
-// Shared PR-body helpers for the QA runner (used by watch.mjs + run.mjs).
+// Shared PR-body helpers for the QA runner (used by watch.js + run.js).
 
 // The Linear issue this PR closes — prefer the `Closes/Fixes/Resolves VIM-N` magic
 // word, fall back to the first VIM-N mention. Deterministic so status never posts
@@ -6,5 +6,6 @@
 export const linkedVim = (body) => {
   const b = body || ''
   const closing = b.match(/\b(?:closes|fixes|resolves)\s+(VIM-\d+)\b/i)
+
   return (closing?.[1] || b.match(/\bVIM-\d+\b/i)?.[0])?.toUpperCase()
 }

--- a/scripts/qa-runner/run.js
+++ b/scripts/qa-runner/run.js
@@ -18,15 +18,13 @@
 
 import { execFileSync, spawnSync } from 'node:child_process'
 import {
-  closeSync,
   existsSync,
   mkdirSync,
-  openSync,
   readdirSync,
   rmSync,
   symlinkSync,
   unlinkSync,
-  writeSync,
+  writeFileSync,
 } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -181,12 +179,15 @@ const run = (pr, live) => {
   mkdirSync(LOCK_DIR, { recursive: true })
   const lock = join(LOCK_DIR, `pr-${pr}.lock`)
   try {
-    const fd = openSync(lock, 'wx')
-    writeSync(fd, `pid ${process.pid}\n`)
-    closeSync(fd)
+    writeFileSync(lock, `pid ${process.pid}\n`, { flag: 'wx' })
   } catch (e) {
     if (e.code === 'EEXIST') {
       die(`PR #${pr} locked (run in flight). rm ${lock} to override.`, 3)
+    }
+    try {
+      unlinkSync(lock)
+    } catch {
+      /* lock may not exist */
     }
     throw e
   }

--- a/scripts/qa-runner/run.js
+++ b/scripts/qa-runner/run.js
@@ -31,19 +31,21 @@ import {
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { botEnv, botLabel, loadBot } from './lib/bot-identity.mjs'
-import { linkedVim } from './lib/pr-utils.mjs'
+import { botEnv, botLabel, loadBot } from './lib/bot-identity.js'
+import { linkedVim } from './lib/pr-utils.js'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const LOCK_DIR = join(SCRIPT_DIR, '.locks')
 const KIMI_TIMEOUT_MS = 45 * 60 * 1000
 
 const out = (s = '') => process.stdout.write(`${s}\n`)
+
 const die = (s, code = 1) => {
   const err = new Error(s)
   err.exitCode = code
   throw err
 }
+
 const sh = (cmd, args, opts = {}) =>
   execFileSync(cmd, args, {
     encoding: 'utf8',
@@ -61,11 +63,14 @@ const lifelineSkillsDir = () => {
     'lifeline',
     'lifeline'
   )
+
   const versions = readdirSync(root)
     .filter((v) => existsSync(join(root, v, 'skills', 'upsource-review')))
     .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-  if (!versions.length)
+  if (!versions.length) {
     die('lifeline upsource-review skill not found in the plugin cache.')
+  }
+
   return join(root, versions[versions.length - 1], 'skills')
 }
 
@@ -84,9 +89,13 @@ const worktreeForBranch = (branch) => {
   for (const line of sh('git', ['worktree', 'list', '--porcelain']).split(
     '\n'
   )) {
-    if (line.startsWith('worktree ')) path = line.slice('worktree '.length)
-    else if (line === `branch refs/heads/${branch}`) return path
+    if (line.startsWith('worktree ')) {
+      path = line.slice('worktree '.length)
+    } else if (line === `branch refs/heads/${branch}`) {
+      return path
+    }
   }
+
   return null
 }
 
@@ -95,11 +104,12 @@ const ensureWorktree = (pr, branch, live, skillsDir, bot, repo) => {
   // No self-review: refuse only when the branch is held by a DIFFERENT worktree (a
   // dev checkout). Our own qa-pr-N from a prior round is fine — reset + reuse it.
   const held = worktreeForBranch(branch)
-  if (held && held !== wt)
+  if (held && held !== wt) {
     die(
       `refusing to review PR #${pr}: branch '${branch}' is checked out at ${held} (no self-review)`,
       4
     )
+  }
   const ref = live ? branch : `qa/dryrun-${pr}`
   if (!existsSync(wt)) {
     sh('git', ['fetch', 'origin', branch, '-q'])
@@ -134,6 +144,7 @@ const ensureWorktree = (pr, branch, live, skillsDir, bot, repo) => {
       'origin',
       `https://github.com/${repo}.git`,
     ])
+
     sh('git', [
       '-C',
       wt,
@@ -142,6 +153,7 @@ const ensureWorktree = (pr, branch, live, skillsDir, bot, repo) => {
       '!gh auth git-credential',
     ])
   }
+
   return wt
 }
 
@@ -151,7 +163,10 @@ const invocation = (pr, live) => {
     `Run the lifeline upsource-review skill now on pull request #${pr} of this repository. ` +
     `"${pr}" is the PR number — not a line number or a count. Resolve PR #${pr}, fetch its ` +
     `review findings, and fix every one. Do not ask for clarification; the target is PR #${pr}.`
-  if (live) return base
+  if (live) {
+    return base
+  }
+
   return (
     `${base}\n\n` +
     'MODE: DRY RUN — run the cycle through the codex verify gate ONLY, then STOP. ' +
@@ -170,8 +185,9 @@ const run = (pr, live) => {
     writeSync(fd, `pid ${process.pid}\n`)
     closeSync(fd)
   } catch (e) {
-    if (e.code === 'EEXIST')
+    if (e.code === 'EEXIST') {
       die(`PR #${pr} locked (run in flight). rm ${lock} to override.`, 3)
+    }
     throw e
   }
   try {
@@ -184,14 +200,18 @@ const run = (pr, live) => {
         'number,headRefName,url,body,state,isCrossRepository',
       ])
     )
-    if (info.state !== 'OPEN') die(`PR #${pr} is ${info.state}, not OPEN.`)
-    if (info.isCrossRepository)
+    if (info.state !== 'OPEN') {
+      die(`PR #${pr} is ${info.state}, not OPEN.`)
+    }
+    if (info.isCrossRepository) {
       die(
         `PR #${pr} is from a fork — its head ref isn't a base-repo branch; refusing to avoid fetching/pushing the wrong branch.`,
         5
       )
+    }
     const branch = info.headRefName
     const bot = loadBot(SCRIPT_DIR, 'bot.env', 'GH_BOT')
+
     const repo = JSON.parse(
       sh('gh', ['repo', 'view', '--json', 'nameWithOwner'])
     ).nameWithOwner
@@ -201,6 +221,7 @@ const run = (pr, live) => {
       `${live ? 'LIVE' : 'DRY-RUN'}: kimi → /skill:upsource-review ${pr}  ` +
         `(branch ${branch}, as ${botLabel(bot)}, worktree ${wt})`
     )
+
     const r = spawnSync(
       'kimi',
       [
@@ -223,8 +244,11 @@ const run = (pr, live) => {
         },
       }
     )
-    if (r.error) die('kimi spawn failed: ' + r.error.message)
-    out(`\nkimi exit: ${r.status ?? `signal ${r.signal}`}`)
+    if (r.error) {
+      die('kimi spawn failed: ' + r.error.message)
+    }
+    out('')
+    out(`kimi exit: ${r.status ?? `signal ${r.signal}`}`)
     out('--- worktree changes ---')
     out(sh('git', ['-C', wt, 'status', '--short']) || '(none)')
     if (live && r.status === 0) {
@@ -233,7 +257,7 @@ const run = (pr, live) => {
         spawnSync(
           'node',
           [
-            join(SCRIPT_DIR, 'lib', 'linear-status.mjs'),
+            join(SCRIPT_DIR, 'lib', 'linear-status.js'),
             vim,
             `QA runner: ran an upsource-review cycle on PR #${pr} (${info.url}).`,
             '--as',
@@ -257,10 +281,11 @@ const run = (pr, live) => {
 const main = () => {
   const argv = process.argv.slice(2)
   const pr = Number(argv.find((a) => /^\d+$/.test(a)))
-  if (!pr)
+  if (!pr) {
     die(
-      'usage: run.mjs <PR#> [--push]   (default = dry-run; --push arms the live path)'
+      'usage: run.js <PR#> [--push]   (default = dry-run; --push arms the live path)'
     )
+  }
   try {
     run(pr, argv.includes('--push'))
   } catch (e) {

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -349,6 +349,12 @@ const dispatchFix = (pr) =>
           buf = buf.slice(nl + 1)
         }
       })
+
+      stream.on('end', () => {
+        if (buf) {
+          out(`${tag} ${buf}`)
+        }
+      })
     }
     pipe(child.stdout)
     pipe(child.stderr)

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -3,16 +3,16 @@
 //
 //   scan   — read-only: list eligible PRs (auto-review label) + why.
 //   tick   — one pass: per eligible PR, compute the review state and act:
-//              NEEDS_FIX  → (with --execute) run.mjs <pr> --push   (an upsource cycle)
+//              NEEDS_FIX  → (with --execute) run.js <pr> --push   (an upsource cycle)
 //                           dispatched CONCURRENTLY, capped at --max (default 2).
 //              GOOD_SHAPE → (with --approve) squash-merge AS THE ORCHESTRATOR BOT
 //                           (orchestrator.env) + delete branch.
 //              WAITING / CI_RED → report only.
 //            State is mirrored to the linked Linear issue (a VIM-N in the PR body)
-//            via lib/linear-status.mjs — Linear is the control plane / observability.
+//            via lib/linear-status.js — Linear is the control plane / observability.
 //   watch  — loop `tick` every pollSeconds (Ctrl-C to stop).
 //
-// Two identities: the INNER fixer runs as bot.env (handled inside run.mjs); the
+// Two identities: the INNER fixer runs as bot.env (handled inside run.js); the
 // OUTER merge runs as orchestrator.env so author ≠ approver. Either absent ⇒ that
 // action falls back to your own gh.
 //
@@ -23,8 +23,8 @@ import { execFileSync, spawn, spawnSync } from 'node:child_process'
 import { createWriteStream, existsSync, mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { botLabel, botProcessEnv, loadBot } from './lib/bot-identity.mjs'
-import { linkedVim } from './lib/pr-utils.mjs'
+import { botLabel, botProcessEnv, loadBot } from './lib/bot-identity.js'
+import { linkedVim } from './lib/pr-utils.js'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const LOCK_DIR = join(SCRIPT_DIR, '.locks')
@@ -32,6 +32,7 @@ const LOG_DIR = join(SCRIPT_DIR, 'logs')
 const DEFAULT_LABEL = 'auto-review'
 const POLL_SECONDS = 60
 const MAX_PARALLEL = 2
+
 // CI checks that are the *reviewers*, not the build/test gate — excluded from "CI green".
 const REVIEW_CHECKS = new Set([
   'Claude Code Review',
@@ -41,6 +42,7 @@ const REVIEW_CHECKS = new Set([
 
 const out = (s = '') => process.stdout.write(`${s}\n`)
 const err = (s = '') => process.stderr.write(`${s}\n`)
+
 // gh as the ambient identity, or — when `env` is passed — as a bot.
 const gh = (args, env) =>
   execFileSync('gh', args, {
@@ -52,6 +54,7 @@ const ghJson = (args) => JSON.parse(gh(args))
 
 const repoSlug = () => {
   const r = ghJson(['repo', 'view', '--json', 'owner,name'])
+
   return { owner: r.owner.login, name: r.name }
 }
 
@@ -85,6 +88,7 @@ const unresolvedThreads = (owner, name, pr) => {
     const q = cursor
       ? 'query($o:String!,$n:String!,$p:Int!,$c:String!){repository(owner:$o,name:$n){pullRequest(number:$p){reviewThreads(first:100,after:$c){pageInfo{hasNextPage endCursor}nodes{isResolved}}}}}'
       : 'query($o:String!,$n:String!,$p:Int!){repository(owner:$o,name:$n){pullRequest(number:$p){reviewThreads(first:100){pageInfo{hasNextPage endCursor}nodes{isResolved}}}}}'
+
     const args = [
       'api',
       'graphql',
@@ -97,13 +101,18 @@ const unresolvedThreads = (owner, name, pr) => {
       '-F',
       `p=${pr}`,
     ]
-    if (cursor) args.push('-F', `c=${cursor}`)
+    if (cursor) {
+      args.push('-F', `c=${cursor}`)
+    }
     const r = ghJson(args)
     const threads = r.data.repository.pullRequest.reviewThreads
     count += (threads.nodes || []).filter((t) => !t.isResolved).length
-    if (!threads.pageInfo.hasNextPage) break
+    if (!threads.pageInfo.hasNextPage) {
+      break
+    }
     cursor = threads.pageInfo.endCursor
   }
+
   return count
 }
 
@@ -123,6 +132,7 @@ const claudeVerdictClean = (owner, name, pr) => {
       '--slurp',
     ])
   ).flat()
+
   const last = comments
     .filter(
       (c) =>
@@ -133,7 +143,10 @@ const claudeVerdictClean = (owner, name, pr) => {
         c.body.startsWith('## Claude Code Review')
     )
     .pop()
-  if (!last) return null
+  if (!last) {
+    return null
+  }
+
   return /patch is correct|✅/i.test(
     last.body.match(/Overall:[^\n]*/)?.[0] || ''
   )
@@ -146,9 +159,12 @@ const hasLabel = (pr, label) => (pr.labels || []).some((l) => l.name === label)
 
 // The review state machine.
 const computeState = (pr, ctx) => {
-  if (pr.isDraft) return { state: 'WAITING', detail: 'draft' }
+  if (pr.isDraft) {
+    return { state: 'WAITING', detail: 'draft' }
+  }
   const checks = checksFor(pr.number)
   const nonReview = checks.filter((c) => !REVIEW_CHECKS.has(c.name))
+
   // 'cancel' (aborted) is not a pass — block it; only 'pass'/'skipping' count as green.
   const ci = nonReview.some((c) => c.bucket === 'fail' || c.bucket === 'cancel')
     ? 'fail'
@@ -157,6 +173,7 @@ const computeState = (pr, ctx) => {
       : 'green'
   const claudeCheck = checks.find((c) => c.name === 'Claude Code Review')
   const claudeReady = claudeCheck?.bucket === 'pass'
+
   const view = ghJson([
     'pr',
     'view',
@@ -166,56 +183,65 @@ const computeState = (pr, ctx) => {
   ])
   const vim = linkedVim(view.body)
   let state, detail
-  if (ci === 'fail')
-    [state, detail] = ['CI_RED', 'non-review CI failing or canceled']
-  else if (!claudeReady || ci === 'pending')
-    [state, detail] = ['WAITING', 'CI / Claude re-running']
-  else {
+  if (ci === 'fail') {
+    ;[state, detail] = ['CI_RED', 'non-review CI failing or canceled']
+  } else if (!claudeReady || ci === 'pending') {
+    ;[state, detail] = ['WAITING', 'CI / Claude re-running']
+  } else {
     const threads = unresolvedThreads(ctx.owner, ctx.name, pr.number)
-    if (threads > 0)
-      [state, detail] = ['NEEDS_FIX', `${threads} unresolved thread(s)`]
-    else {
+    if (threads > 0) {
+      ;[state, detail] = ['NEEDS_FIX', `${threads} unresolved thread(s)`]
+    } else {
       // verdict is irrelevant until threads are clear — defer the fetch to here
       const verdict = claudeVerdictClean(ctx.owner, ctx.name, pr.number) // null|true|false
-      if (verdict === false)
-        [state, detail] = ['NEEDS_FIX', 'Claude verdict: patch has issues']
-      else if (verdict === null)
-        [state, detail] = ['WAITING', 'no Claude review yet']
-      else if (view.mergeable !== 'MERGEABLE')
-        [state, detail] = [
+      if (verdict === false) {
+        ;[state, detail] = ['NEEDS_FIX', 'Claude verdict: patch has issues']
+      } else if (verdict === null) {
+        ;[state, detail] = ['WAITING', 'no Claude review yet']
+      } else if (view.mergeable !== 'MERGEABLE') {
+        ;[state, detail] = [
           'WAITING',
           `not mergeable (${view.mergeStateStatus})`,
         ]
-      else
-        [state, detail] = [
+      } else {
+        ;[state, detail] = [
           'GOOD_SHAPE',
           '0 threads · Claude clean · CI green · mergeable',
         ]
+      }
     }
+
     return { state, detail, vim, threads, headSha: view.headRefOid }
   }
+
   return { state, detail, vim, threads: 0, headSha: view.headRefOid }
 }
 
 const postLinear = (vim, body, stateName) => {
-  if (!vim) return
+  if (!vim) {
+    return
+  }
+
   const args = [
-    join(SCRIPT_DIR, 'lib', 'linear-status.mjs'),
+    join(SCRIPT_DIR, 'lib', 'linear-status.js'),
     vim,
     body,
     '--as',
     'orchestrator',
   ]
-  if (stateName) args.push('--state', stateName)
+  if (stateName) {
+    args.push('--state', stateName)
+  }
   const r = spawnSync('node', args, { encoding: 'utf8' })
-  if (r.status === 0)
+  if (r.status === 0) {
     out(
       `           ↳ Linear ${vim}${stateName ? ` → ${stateName}` : ''}: commented`
     )
-  else
+  } else {
     out(
       `           ↳ Linear ${vim}: skipped (${(r.stderr || '').trim().split('\n')[0] || 'no LINEAR_API_KEY'})`
     )
+  }
 }
 
 // Squash-merge + branch delete as the orchestrator bot (or you, if none).
@@ -225,6 +251,7 @@ const approve = (pr, vim, headSha, ctx) => {
   const env = botProcessEnv(ctx.orchBot)
   const merger = botLabel(ctx.orchBot)
   out(`           → APPROVING as ${merger}: squash-merge #${pr.number}`)
+
   const prInfo = ghJson([
     'pr',
     'view',
@@ -232,6 +259,7 @@ const approve = (pr, vim, headSha, ctx) => {
     '--json',
     'reviews,isCrossRepository',
   ])
+
   const alreadyApproved = (prInfo.reviews || []).some(
     (r) => r.state === 'APPROVED' && r.author?.login === ctx.approverLogin
   )
@@ -290,9 +318,9 @@ const approve = (pr, vim, headSha, ctx) => {
   )
 }
 
-// Run run.mjs for one PR as a child, teeing output to a per-PR log and prefixing
+// Run run.js for one PR as a child, teeing output to a per-PR log and prefixing
 // the console so concurrent runs stay legible. Resolves the exit code; never
-// rejects — a failed child must not abort the pool. run.mjs adopts the INNER
+// rejects — a failed child must not abort the pool. run.js adopts the INNER
 // (fixer) bot identity itself, so we just inherit the env here.
 const dispatchFix = (pr) =>
   new Promise((resolve) => {
@@ -300,14 +328,16 @@ const dispatchFix = (pr) =>
     const logPath = join(LOG_DIR, `pr-${pr}.log`)
     const logFd = createWriteStream(logPath, { flags: 'a' })
     const tag = `[#${pr}]`
-    out(`${tag} → run.mjs ${pr} --push   (log: ${logPath})`)
+    out(`${tag} → run.js ${pr} --push   (log: ${logPath})`)
+
     const child = spawn(
       'node',
-      [join(SCRIPT_DIR, 'run.mjs'), String(pr), '--push'],
+      [join(SCRIPT_DIR, 'run.js'), String(pr), '--push'],
       {
         env: process.env,
       }
     )
+
     const pipe = (stream) => {
       let buf = ''
       stream.on('data', (d) => {
@@ -324,9 +354,10 @@ const dispatchFix = (pr) =>
     pipe(child.stderr)
     child.on('close', (code) => {
       logFd.end()
-      out(`${tag} ✓ run.mjs exited ${code}`)
+      out(`${tag} ✓ run.js exited ${code}`)
       resolve(code)
     })
+
     child.on('error', (e) => {
       logFd.end()
       out(`${tag} ✗ spawn error: ${e.message}`)
@@ -337,8 +368,11 @@ const dispatchFix = (pr) =>
 // Bounded-concurrency pool — at most `limit` workers in flight.
 const pool = async (items, limit, worker) => {
   let i = 0
+
   const next = async () => {
-    while (i < items.length) await worker(items[i++])
+    while (i < items.length) {
+      await worker(items[i++])
+    }
   }
   await Promise.all(Array.from({ length: Math.min(limit, items.length) }, next))
 }
@@ -347,13 +381,16 @@ const tick = async (ctx) => {
   let prs = openPRs().filter(
     (p) => (ctx.all || hasLabel(p, ctx.label)) && !p.isDraft
   )
-  if (ctx.pr) prs = prs.filter((p) => p.number === ctx.pr)
+  if (ctx.pr) {
+    prs = prs.filter((p) => p.number === ctx.pr)
+  }
   if (!prs.length) {
     out(
       ctx.pr
         ? `PR #${ctx.pr} is not an eligible open PR.`
         : `No eligible PRs (label '${ctx.label}').`
     )
+
     return
   }
   out(
@@ -395,7 +432,9 @@ const tick = async (ctx) => {
         } catch (e) {
           out(`           ✗ approve failed: ${e.message.split('\n')[0]}`)
         }
-      } else out(`           (report-only — pass --approve to auto-merge)`)
+      } else {
+        out(`           (report-only — pass --approve to auto-merge)`)
+      }
     }
     out('')
   }
@@ -412,6 +451,7 @@ const watch = async (ctx) => {
     `QA watcher — looping every ${POLL_SECONDS}s ` +
       `(approve=${ctx.approve} execute=${ctx.execute} max=${ctx.maxParallel}). Ctrl-C to stop.\n`
   )
+
   const loop = async () => {
     try {
       await tick(ctx)
@@ -426,9 +466,12 @@ const watch = async (ctx) => {
 // Read-only eligibility lister (lightweight).
 const scan = (ctx) => {
   let prs = openPRs()
-  if (ctx.pr) prs = prs.filter((p) => p.number === ctx.pr)
+  if (ctx.pr) {
+    prs = prs.filter((p) => p.number === ctx.pr)
+  }
   if (!prs.length) {
     out('No open PRs.')
+
     return
   }
   out(
@@ -440,7 +483,9 @@ const scan = (ctx) => {
       !pr.isDraft &&
       (ctx.all || hasLabel(pr, ctx.label)) &&
       !isLocked(pr.number)
-    if (eligible) n++
+    if (eligible) {
+      n++
+    }
     out(
       `${eligible ? 'ELIGIBLE →' : 'skip      '} #${pr.number}  ${pr.headRefName}  —  ${pr.title}`
     )
@@ -452,12 +497,15 @@ const main = () => {
   const argv = process.argv.slice(2)
   const cmd = argv[0] && !argv[0].startsWith('--') ? argv[0] : 'scan'
   const has = (n) => argv.includes(`--${n}`)
+
   const val = (n) => {
     const i = argv.indexOf(`--${n}`)
+
     return i >= 0 ? argv[i + 1] : undefined
   }
   const { owner, name } = repoSlug()
   const orchBot = loadBot(SCRIPT_DIR, 'orchestrator.env', 'GH_ORCH')
+
   const ctx = {
     owner,
     name,
@@ -470,18 +518,24 @@ const main = () => {
     orchBot,
     approverLogin: orchBot?.user ?? ghJson(['api', 'user']).login,
   }
-  if (cmd === 'scan') return scan(ctx)
-  if (cmd === 'tick') return tick(ctx)
-  if (cmd === 'watch') return watch(ctx)
+  if (cmd === 'scan') {
+    return scan(ctx)
+  }
+  if (cmd === 'tick') {
+    return tick(ctx)
+  }
+  if (cmd === 'watch') {
+    return watch(ctx)
+  }
   err(
     `unknown command: ${cmd}. Use: scan | tick | watch  [--pr N] [--approve] [--execute] [--all] [--max N] [--label NAME]`
   )
   process.exit(1)
 }
 
-const result = main()
-if (result && typeof result.then === 'function')
-  result.catch((e) => {
-    err(e.message)
-    process.exit(1)
-  })
+try {
+  await main()
+} catch (e) {
+  err(e.message)
+  process.exit(1)
+}


### PR DESCRIPTION
Second stacked PR on `wip/linear-wiring` — brings the qa-runner automation under the linter (your call to harden it before the daemon).

## Why

The 5 qa-runner scripts were `.mjs` and **eslint-ignored**, so neither CI lint nor the lint-staged pre-commit hook (eslint glob = `{js,jsx,ts,tsx}`, not `.mjs`) ever checked them. Renaming to `.js` + dropping the ignore gives them the same guard as the rest of the repo, and `.js` is in *both* lint globs.

## What
- **Renames** (history preserved, 85–90% similarity): `run` · `watch` · `lib/{bot-identity,linear-status,pr-utils}` `.mjs → .js`; imports, spawn paths, usage strings updated.
- **eslint.config.js**: removed the `scripts/qa-runner/**` ignore (the `.js` override already `disableTypeChecked` for these node scripts).
- **Most of the diff** is the now-active linter auto-applying `curly: all` braces + `padding-line-between-statements` blank lines (84 auto-fixes via `--fix`).
- **2 manual fixes**: `watch.js` `.then/.catch` → `try { await main() }`; `run.js` split a `\n`+word log string that tripped cspell tokenisation.
- **cspell**: whitelisted `kimi`, `dryrun`, `unreviewed`.
- **Docs**: README + review-pattern KB `.mjs → .js` pointers.

## Verified
eslint clean · prettier clean · `node --check` all 5 · smoke (run/watch/linear-status load + run). **No behaviour change** — the `run.js` no-args stack trace is pre-existing (the usage `die()` sits outside the try/catch, untouched here).

Refs VIM-10. Next stack item: the daemon.
