### PR TITLE
[codex] add IDEA impact and cost gate

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@ playwright-report
 .lifeline-planner
 *.min.js
 *.d.ts
+docs/design/*.html
 docs/design/*/code.html
 docs/diagrams/*.html
 docs/explorations/*.html

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -26,6 +26,8 @@ When invoked:
 - **Skip** issues in unchanged code unless they are CRITICAL security issues
 - **Consolidate** similar issues (e.g., "5 functions missing error handling" not 5 separate findings)
 - **Prioritize** issues that could cause bugs, security vulnerabilities, or data loss
+- **Reality-check** each finding: would this produce a real bug, security issue, data loss, user-visible regression, or meaningful operating cost while a user uses the app or the system runs?
+- **Cost-check** each fix: is the cost/risk of fixing proportional to the impact, or is this better left as a follow-up instead of a blocking review finding?
 
 ## Scope Boundary (MANDATORY)
 
@@ -40,6 +42,8 @@ Do NOT report it as a finding with severity. Instead, add it to an **Out-of-Scop
 **Exception:** Actively exploitable CRITICAL security vulnerabilities may be flagged regardless of diff scope.
 
 **Anti-pattern to avoid:** Review rabbit-holes — where round N finds an issue, the fix in round N+1 triggers a new niche finding in the same area, spiraling into 5+ rounds on code that was already working. If the original PR goal is achieved and tests pass, stop.
+
+**Perfection trap to avoid:** Do not raise findings whose only impact is that the code could be more elegant, more "complete", or closer to an ideal abstraction. A finding must identify a concrete failure mode or meaningful future-change cost, and the proposed fix must be worth its implementation cost.
 
 ## Review Checklist
 
@@ -273,6 +277,13 @@ The four-field definition and formatting live in `rules/common/idea-framework.md
 - Scope each IDEA to **this specific finding**, not the whole PR.
 - Do **not** produce a PR-level IDEA block at the end of the review.
 - Use the per-finding format shown in the "Review Output Format" example above.
+- Add an implication layer to the IDEA reasoning before reporting the finding:
+  - **Reality**: Will this finding plausibly produce a bug in reality while the user is using the app or the system is running?
+  - **Fix cost**: What is the implementation, regression, review, and complexity cost of fixing it now?
+- Reflect the implication layer in the IDEA fields without adding new fields:
+  - Put the real runtime/user/system failure mode in **D — Danger**.
+  - Put the proportional fix and its cost/trade-off in **A — Alternatives**.
+- If the real-world danger is weak and the fix cost is non-trivial, skip the finding or put it in Out-of-Scope Observations as a follow-up. Do not block a PR for code that is merely less-than-perfect.
 
 ## Approval Criteria
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -278,7 +278,7 @@ The four-field definition and formatting live in `rules/common/idea-framework.md
 - Do **not** produce a PR-level IDEA block at the end of the review.
 - Use the per-finding format shown in the "Review Output Format" example above.
 - Add an implication layer to the IDEA reasoning before reporting the finding:
-  - **Reality**: Will this finding plausibly produce a real bug, security issue, data loss, user-visible regression, or meaningful operating cost while the user is using the app or the system is running?
+  - **Reality**: Will this finding plausibly produce a real bug, security issue, data loss, user-visible regression, or meaningful operating cost while the user is using the app or the system is running, or create meaningful future-change cost?
   - **Fix cost**: What is the implementation, regression, review, and complexity cost of fixing it now?
 - Reflect the implication layer in the IDEA fields without adding new fields:
   - Put the real runtime/user/system failure mode in **D — Danger**.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -278,12 +278,12 @@ The four-field definition and formatting live in `rules/common/idea-framework.md
 - Do **not** produce a PR-level IDEA block at the end of the review.
 - Use the per-finding format shown in the "Review Output Format" example above.
 - Add an implication layer to the IDEA reasoning before reporting the finding:
-  - **Reality**: Will this finding plausibly produce a bug in reality while the user is using the app or the system is running?
+  - **Reality**: Will this finding plausibly produce a real bug, security issue, data loss, user-visible regression, or meaningful operating cost while the user is using the app or the system is running?
   - **Fix cost**: What is the implementation, regression, review, and complexity cost of fixing it now?
 - Reflect the implication layer in the IDEA fields without adding new fields:
   - Put the real runtime/user/system failure mode in **D — Danger**.
   - Put the proportional fix and its cost/trade-off in **A — Alternatives**.
-- If the real-world danger is weak and the fix cost is non-trivial, skip the finding or put it in Out-of-Scope Observations as a follow-up. Do not block a PR for code that is merely less-than-perfect.
+- If the real-world danger is weak and the fix cost is non-trivial, skip the finding entirely. Do not block a PR for code that is merely less-than-perfect.
 
 ## Approval Criteria
 

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -51,7 +51,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 55       | 25   | 2026-05-28   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 78       | 24   | 2026-06-01   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 79       | 24   | 2026-06-01   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 45       | 12   | 2026-05-31   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -51,7 +51,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 55       | 25   | 2026-05-28   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 76       | 24   | 2026-06-01   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 78       | 24   | 2026-06-01   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 45       | 12   | 2026-05-31   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -51,7 +51,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 55       | 25   | 2026-05-28   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 75       | 23   | 2026-05-31   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 76       | 24   | 2026-06-01   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 45       | 12   | 2026-05-31   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |
@@ -65,7 +65,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
 | [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 31       | 7    | 2026-05-31   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
-| [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 7        | 2    | 2026-05-12   |
+| [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 8        | 3    | 2026-06-01   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-20   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -3,7 +3,7 @@ id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
 last_updated: 2026-05-31
-ref_count: 23
+ref_count: 24
 ---
 
 # Documentation Accuracy
@@ -710,4 +710,13 @@ Stale documentation misleads future contributors and review agents.
 - **File:** `src/features/sessions/hooks/useSessionManager.test.ts`
 - **Finding:** A test comment explaining why the seed source was changed from `user-renamed` to `ai-generated` stated: "user-renamed is sticky against later clears." The guard predicate is `agentTitleSource === 'user-renamed' && payload.source === 'ai-generated'` — it blocks ONLY `ai-generated` clears, not `user-renamed + empty` events (the documented lifecycle-reset escape hatch). The neighboring test `user-renamed with empty title clears the sticky guard` demonstrates exactly that a `user-renamed + empty` event falls through and clears the sticky state, making the comment directly contradictory to tested behavior. A future contributor reading only this comment could incorrectly conclude that ALL clear events are blocked once sticky, and design a lifecycle-reset mechanism that emits `ai-generated + empty` instead of `user-renamed + empty` — the wrong event would be swallowed by the guard, the reset would silently no-op, and the pane would remain stuck indefinitely with no error.
 - **Fix:** Changed the comment to "user-renamed is sticky against later **ai-generated** clears" so the phrasing matches the actual guard predicate. Code-review heuristic: when a guard predicate is narrow (filters on a specific source/value), every comment describing its effect must repeat that narrow qualifier — generic phrasing ("clears", "updates", "events") drifts toward overstating scope and misleads future readers who rely on comments as a behavioral contract.
+- **Commit:** same commit as this entry
+
+### 76. Reality check in IDEA Analysis section is narrower than canonical definition
+
+- **Source:** github-claude | PR #323 round 1 | 2026-06-01
+- **Severity:** MEDIUM
+- **File:** `agents/code-reviewer.md`
+- **Finding:** IDEA Analysis reality check (line 281) paraphrased the canonical impact criterion more narrowly than line 29, omitting security issue, data loss, user-visible regression, and operating cost
+- **Fix:** Aligned line 281 with the full formulation from line 29
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -2,7 +2,7 @@
 id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
-last_updated: 2026-05-31
+last_updated: 2026-06-01
 ref_count: 24
 ---
 
@@ -719,4 +719,22 @@ Stale documentation misleads future contributors and review agents.
 - **File:** `agents/code-reviewer.md`
 - **Finding:** IDEA Analysis reality check (line 281) paraphrased the canonical impact criterion more narrowly than line 29, omitting security issue, data loss, user-visible regression, and operating cost
 - **Fix:** Aligned line 281 with the full formulation from line 29
+- **Commit:** same commit as this entry
+
+### 77. idea-framework.md retains 'frame as follow-up' after parallel fix in code-reviewer.md
+
+- **Source:** github-claude | PR #323 round 2 | 2026-06-01
+- **Severity:** LOW
+- **File:** `rules/common/idea-framework.md`
+- **Finding:** Line 32 kept the two-option form "skip the finding or frame it as a follow-up" while the parallel sentence in `agents/code-reviewer.md` line 286 was tightened to "skip the finding entirely" in round 1, creating a divergence between canonical doc and agent spec
+- **Fix:** Aligned `idea-framework.md` line 32 to "skip the finding entirely" to match the round 1 fix
+- **Commit:** same commit as this entry
+
+### 78. Stale `last_updated` frontmatter in pattern files after new entries committed
+
+- **Source:** github-claude | PR #323 round 2 | 2026-06-01
+- **Severity:** LOW
+- **File:** `docs/reviews/patterns/documentation-accuracy.md` and `docs/reviews/patterns/scope-boundary.md`
+- **Finding:** Both pattern files received new entries (#76 and #8) in round 1 but their frontmatter `last_updated` remained at 2026-05-31 and 2026-05-12 respectively, diverging from the index table
+- **Fix:** Updated `last_updated` to 2026-06-01 in both frontmatter blocks
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -738,3 +738,12 @@ Stale documentation misleads future contributors and review agents.
 - **Finding:** Both pattern files received new entries (#76 and #8) in round 1 but their frontmatter `last_updated` remained at 2026-05-31 and 2026-05-12 respectively, diverging from the index table
 - **Fix:** Updated `last_updated` to 2026-06-01 in both frontmatter blocks
 - **Commit:** same commit as this entry
+
+### 79. Reality check runtime scope contradicts Perfection trap's future-change cost
+
+- **Source:** github-claude | PR #323 round 3 | 2026-06-01
+- **Severity:** MEDIUM
+- **File:** `agents/code-reviewer.md` and `rules/common/idea-framework.md`
+- **Finding:** The Reality check's "while the user is using the app or the system is running" qualifier scoped the gate to runtime impacts only, silently contradicting the Perfection trap (line 46) that explicitly permits findings justified by "meaningful future-change cost". Design Complexity findings with future maintenance cost but no immediate runtime failure would pass the Perfection trap but fail the Reality check and be dropped.
+- **Fix:** Restructured both Reality checks so "meaningful future-change cost" sits outside the runtime qualifier — e.g. "...while the user is using the app or the system is running, or create meaningful future-change cost?"
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/scope-boundary.md
+++ b/docs/reviews/patterns/scope-boundary.md
@@ -3,7 +3,7 @@ id: scope-boundary
 category: review-process
 created: 2026-04-12
 last_updated: 2026-05-12
-ref_count: 2
+ref_count: 3
 ---
 
 # Scope Boundary
@@ -76,3 +76,12 @@ separate follow-up section, not as findings with severity.
 - **Finding:** Cycle 4's SKIP for "Pass pane identity when wiring per-pane restart action" (issue #202) closed thread `PRRT_kwDOR06LW86BSzCk` via the rationale-in-thread + TODO-in-code disposition. The underlying code state did not change in cycle 5 (test additions only) or cycle 6 (doc comments only). On cycle 7's review of commit `6f08a03`, the connector posted essentially the same finding again — different inline comment id (`3223788780`) and new thread (`PRRT_kwDOR06LW86BS6GW`), retitled "Pass pane identity when forwarding restart callbacks", same root cause. The connector's heuristic re-flags any code state matching its lint on every push; it has no memory of prior threads. Class of lesson: previously-skipped findings that depend on code state will recur until either the code changes or the reviewer is told (via a `wontfix`-style label or repo-side configuration) to suppress them.
 - **Fix:** Replied on the new thread with the cross-cycle link: "Same finding as the cycle-4 disposition — SKIPPED + tracked in #202; see thread `PRRT_kwDOR06LW86BSzCk` and the TODO in `TerminalPane/index.tsx handleRestart`." Resolved the new thread (`PRRT_kwDOR06LW86BS6GW`). Recorded processed-inline id 3223788780 + processed-review id 4269233620 in the cycle 7 commit's watermark trailers so Step 1 of any future cycle doesn't re-poll this finding. Code-review heuristic: when a reviewer re-flags a previously-skipped finding on the next review cycle, reply with the cross-cycle pointer (resolved thread id + tracking issue) and resolve; do not re-fix. The discipline is to make the SKIP audit trail navigable from any single thread.
 - **Commit:** _(see git log for the cycle-7 fix commit on PR #199)_
+
+### 8. In-diff low-value findings misdirected to Out-of-Scope Observations
+
+- **Source:** github-claude | PR #323 round 1 | 2026-06-01
+- **Severity:** LOW
+- **File:** `agents/code-reviewer.md`
+- **Finding:** Line 286 routed low-value in-diff findings to Out-of-Scope Observations, conflating pre-existing out-of-diff issues with intentionally deprioritised new findings
+- **Fix:** Changed guidance to "skip the finding entirely" for weak-danger/non-trivial-cost cases
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/scope-boundary.md
+++ b/docs/reviews/patterns/scope-boundary.md
@@ -2,7 +2,7 @@
 id: scope-boundary
 category: review-process
 created: 2026-04-12
-last_updated: 2026-05-12
+last_updated: 2026-06-01
 ref_count: 3
 ---
 

--- a/rules/common/idea-framework.md
+++ b/rules/common/idea-framework.md
@@ -26,7 +26,7 @@ Keep each line to one or two sentences. If a field has no real content, write "n
 
 For code-review findings, IDEA must also make the practical implication legible:
 
-- **Reality**: Would this issue plausibly produce a real bug, security issue, data loss, user-visible regression, or meaningful operating cost while a user uses the app or the system runs?
+- **Reality**: Would this issue plausibly produce a real bug, security issue, data loss, user-visible regression, or meaningful operating cost while a user uses the app or the system runs, or create meaningful future-change cost?
 - **Fix cost**: What is the implementation, regression, review, and complexity cost of fixing it now?
 
 Do not add new IDEA fields for these questions. Fold the real-world consequence into **D — Danger** and the proportional fix/cost trade-off into **A — Alternatives**. If the danger is weak and the fix cost is non-trivial, skip the finding entirely — do not turn the review into a search for perfect code.

--- a/rules/common/idea-framework.md
+++ b/rules/common/idea-framework.md
@@ -29,7 +29,7 @@ For code-review findings, IDEA must also make the practical implication legible:
 - **Reality**: Would this issue plausibly produce a real bug, security issue, data loss, user-visible regression, or meaningful operating cost while a user uses the app or the system runs?
 - **Fix cost**: What is the implementation, regression, review, and complexity cost of fixing it now?
 
-Do not add new IDEA fields for these questions. Fold the real-world consequence into **D — Danger** and the proportional fix/cost trade-off into **A — Alternatives**. If the danger is weak and the fix cost is non-trivial, skip the finding or frame it as a follow-up instead of turning the review into a search for perfect code.
+Do not add new IDEA fields for these questions. Fold the real-world consequence into **D — Danger** and the proportional fix/cost trade-off into **A — Alternatives**. If the danger is weak and the fix cost is non-trivial, skip the finding entirely — do not turn the review into a search for perfect code.
 
 ## When to Use IDEA
 

--- a/rules/common/idea-framework.md
+++ b/rules/common/idea-framework.md
@@ -22,6 +22,15 @@ This makes reviews and option-comparisons scannable: a reader can read just the 
 
 Keep each line to one or two sentences. If a field has no real content, write "n/a" — don't pad.
 
+## Implication Layer
+
+For code-review findings, IDEA must also make the practical implication legible:
+
+- **Reality**: Would this issue plausibly produce a real bug, security issue, data loss, user-visible regression, or meaningful operating cost while a user uses the app or the system runs?
+- **Fix cost**: What is the implementation, regression, review, and complexity cost of fixing it now?
+
+Do not add new IDEA fields for these questions. Fold the real-world consequence into **D — Danger** and the proportional fix/cost trade-off into **A — Alternatives**. If the danger is weak and the fix cost is non-trivial, skip the finding or frame it as a follow-up instead of turning the review into a search for perfect code.
+
 ## When to Use IDEA
 
 Two contexts, same shape:


### PR DESCRIPTION
## Summary

- Add reality and fix-cost checks to the code-reviewer prompt.
- Extend per-finding IDEA guidance so `D — Danger` captures real user/system impact and `A — Alternatives` captures proportional fix cost/trade-off.
- Add a perfection-trap guard to avoid blocking PRs for idealized code concerns that lack practical impact.

## Why

The reviewer prompt already warns against noisy findings and review rabbit holes, but it did not explicitly force reviewers to ask whether a finding would produce a real bug in practice or whether the fix cost is proportional. This adds that decision layer without changing the four-field IDEA shape.

## Validation

- `git diff --check -- agents/code-reviewer.md rules/common/idea-framework.md`
- Pre-push `npm test`: 230 test files passed, 3046 tests passed, 3 skipped. Existing React `act(...)` and CodeMirror jsdom warnings appeared during the run, but the suite completed successfully.
