### PR TITLE
feat(qa-runner): deployable webhook daemon with fixer-stall failure model

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -27,6 +27,7 @@ words:
   - healthz
   - dedup
   - checkpointed
+  - cmdline
 
   # General vocabulary flagged by cspell's defaults
   - unparseable

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -23,6 +23,11 @@ words:
   - dryrun
   - unreviewed
 
+  # QA daemon (webhook receiver + persistent state machine)
+  - healthz
+  - dedup
+  - checkpointed
+
   # General vocabulary flagged by cspell's defaults
   - unparseable
   - lossily

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -64,7 +64,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
-| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 37       | 7    | 2026-06-01   |
+| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 38       | 8    | 2026-06-01   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 7        | 2    | 2026-05-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -53,7 +53,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 75       | 23   | 2026-05-31   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
-| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 45       | 12   | 2026-05-31   |
+| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 46       | 12   | 2026-06-01   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                   | security           | 7        | 3    | 2026-05-02   |
 | [Credential Leakage](patterns/credential-leakage.md)                 | security           | 1        | 0    | 2026-05-31   |
@@ -64,7 +64,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
-| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 35       | 7    | 2026-06-01   |
+| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 37       | 7    | 2026-06-01   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 7        | 2    | 2026-05-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -64,7 +64,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
-| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 31       | 7    | 2026-05-31   |
+| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 35       | 7    | 2026-06-01   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 7        | 2    | 2026-05-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-20   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,7 +2,7 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-05-31
+last_updated: 2026-06-01
 ref_count: 12
 ---
 
@@ -448,3 +448,12 @@ prevent showing previous data.
 - **Finding:** `existsSync(lock)` followed by `writeFileSync(lock, ...)` is non-atomic; two concurrent processes can both pass the existence check before either writes, resulting in double-dispatch.
 - **Fix:** Replace with `fs.openSync(lock, 'wx')` wrapped in try/catch; `EEXIST` means another process holds the lock.
 - **Commit:** `7644ec4` + cycle-2 fix
+
+### 46. Timeout fires before live HEAD check, causing false fixer-stall classification
+
+- **Source:** github-claude | PR #324 round 2 | 2026-06-01
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/run.js`
+- **Finding:** `r.timedOut` triggered `die(msg, 6)` before the live HEAD check ran. A commit landing in the final ~15 s poll window was undetected; the worktree HEAD had advanced past `startHead`, yet `run.js` exited 6 claiming "no commit". `watch.js` classified this as a fixer stall, incrementing `noopCount`. The stranded local commit was never pushed, so the daemon's next remote-HEAD comparison still saw no progress and did not reset the counter, leading to false pausing after `maxNoops` consecutive misclassifications.
+- **Fix:** Before dying on `timedOut`, check `sh('git', ['-C', wt, 'rev-parse', 'HEAD']).trim() !== startHead`. If a commit is present, fall through to the push-verification block instead of exiting 6.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -3,7 +3,7 @@ id: error-surfacing
 category: error-handling
 created: 2026-04-10
 last_updated: 2026-06-01
-ref_count: 7
+ref_count: 8
 ---
 
 # Error Surfacing
@@ -367,4 +367,13 @@ failed" must mean the editor shows the original file, not the requested one.
 - **File:** `scripts/qa-runner/lib/worker.js`
 - **Finding:** When `gh pr view` failed transiently, `runOne` returned `'skip'` and `daemon.js` always called `queue.done()`, discarding the event. For open labeled PRs the fallback poll re-enqueues them, but one-shot webhooks (`pull_request:closed`, `unlabeled`, `converted_to_draft`) cannot be recreated by the poll. A transient API blip while processing such an event caused the daemon to preserve state but never clean up or announce the terminal transition.
 - **Fix:** Changed the pre-tick snapshot-unavailable return from `'skip'` to `'retry'`. Updated `daemon.js` to requeue non-poll jobs that return `'retry'` so one-shot events survive transient `gh` failures.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 38. `queue.take()` outside try-catch — persistent save failure terminates the daemon
+
+- **Source:** github-claude | PR #324 round 3 | 2026-06-01
+- **Severity:** HIGH
+- **File:** `scripts/qa-runner/daemon.js`
+- **Finding:** `queue.take()` at line 31 sat outside the `try-catch-finally` block that protected `runOne` and `queue.done()`. If `save()` inside `take()` threw (disk full, `ENOSPC` on the rename, permissions error), the exception propagated through the `while` loop, out of the `worker` async function, and became an unhandled promise rejection. Because `worker(i + 1)` at line 114 was called without `.catch()`, Node.js ≥ 15 converts unhandled promise rejections to process termination, killing the entire daemon rather than one worker. This is the symmetric counterpart to finding #32 (`queue.done()` in `finally`).
+- **Fix:** Wrapped `queue.take()` in its own `try-catch` inside the `while` loop so save failures are logged and the loop continues. Changed `const job = queue.take()` to `let job` plus a guarded `try { job = queue.take() } catch (e) { log(...); await sleep(1500); continue }`.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -314,3 +314,39 @@ failed" must mean the editor shows the original file, not the requested one.
 - **Finding:** `postLinear(…, 'In Progress')` was called before the `ctx.execute` guard, so every report-only tick falsely transitioned linked Linear issues to "In Progress" even when no fix cycle ran.
 - **Fix:** Moved `postLinear` inside the `ctx.execute` block so it only fires when a real fix cycle is dispatched.
 - **Commit:** same commit as this entry
+
+### 32. Worker crashes permanently if queue.done() throws in finally block
+
+- **Source:** github-claude | PR #324 round 1 | 2026-06-01
+- **Severity:** HIGH
+- **File:** `scripts/qa-runner/daemon.js`
+- **Finding:** `queue.done()` was called in a bare `finally` block. If `save()` inside it threw (disk-full, permissions, rename failure), the exception propagated out of the `try-catch-finally` block and rejected the worker's async function. Because `worker(i + 1)` was called without `.catch()` or `await`, this became an unhandled promise rejection that could crash the daemon or silently shrink the concurrency pool.
+- **Fix:** Wrapped `queue.done()` in an inner `try-catch` inside the `finally` block so failures are logged but never escape the worker loop.
+- **Commit:** same commit as this entry
+
+### 33. before=null initial probe causes spurious grace trigger, kills kimi in 2 min
+
+- **Source:** github-claude | PR #324 round 1 | 2026-06-01
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/lib/run-until-change.js`
+- **Finding:** `probe()` returning `null` on the initial call set `before = null`. The poll condition `now && now !== before` then fired on the first successful probe, immediately arming the 120-second grace timer and killing kimi before it could commit.
+- **Fix:** Made `before` mutable; when `before` is `null` and `now` is non-null, set `before = now` as the baseline before evaluating change detection.
+- **Commit:** same commit as this entry
+
+### 34. null exit code (signal-killed child) counted as fixer stall, inflates noopCount
+
+- **Source:** github-claude | PR #324 round 1 | 2026-06-01
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `dispatchFix` resolved `null` when `run.js` was killed by an external signal. `codes.some((c) => c !== 0)` evaluated `null !== 0` as `true`, counting the kill as a fixer stall and incrementing `noopCount` toward pausing the PR.
+- **Fix:** Excluded `null` from the `fixerStall` predicate and routed signal-killed children through the transient exit-code-2 path so host OOM/restarts don't count toward pausing.
+- **Commit:** same commit as this entry
+
+### 35. Stale lock reaping via process.kill(pid,0) vulnerable to PID recycling
+
+- **Source:** github-claude | PR #324 round 1 | 2026-06-01
+- **Severity:** LOW
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `isLocked` used `process.kill(pid, 0)` alone to check liveness. If the original `run.js` crashed and its PID was reused by an unrelated process, the PR was skipped every tick forever until that unrelated process died.
+- **Fix:** Added a `/proc/<pid>/cmdline` check for the substring `run.js`; if the live process is not a `run.js`, the lock is reaped as stale. Full ownership validation (start time + expected PR) was deferred per the PR author's original plan.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -2,7 +2,7 @@
 id: error-surfacing
 category: error-handling
 created: 2026-04-10
-last_updated: 2026-05-31
+last_updated: 2026-06-01
 ref_count: 7
 ---
 
@@ -350,3 +350,21 @@ failed" must mean the editor shows the original file, not the requested one.
 - **Finding:** `isLocked` used `process.kill(pid, 0)` alone to check liveness. If the original `run.js` crashed and its PID was reused by an unrelated process, the PR was skipped every tick forever until that unrelated process died.
 - **Fix:** Added a `/proc/<pid>/cmdline` check for the substring `run.js`; if the live process is not a `run.js`, the lock is reaped as stale. Full ownership validation (start time + expected PR) was deferred per the PR author's original plan.
 - **Commit:** same commit as this entry
+
+### 36. req.destroy() on payload-too-large tears down shared HTTP/1.x socket before 413 flushes
+
+- **Source:** github-claude | PR #324 round 2 | 2026-06-01
+- **Severity:** LOW
+- **File:** `scripts/qa-runner/lib/host.js`
+- **Finding:** In `readRawBody`, when the payload exceeded the 2 MB limit, `req.destroy()` was called before the promise rejected. The caller `handleWebhook` then called `sendJson(res, 413, ...)`. In Node.js HTTP/1.x, `req` and `res` share the same underlying `net.Socket`; `req.destroy()` propagated to `socket.destroy()`, closing the socket before the 413 headers could be flushed. GitHub received a TCP reset rather than a 413, logged the delivery as failed, and retried with exponential backoff for up to 72 hours.
+- **Fix:** Replaced `req.destroy()` with `req.pause()` in `readRawBody`; added `res.on('finish', () => req.destroy())` in `handleWebhook` so the 413 response completes before the socket closes.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 37. One-shot webhook events lost when pre-tick snapshot fails transiently
+
+- **Source:** github-codex-connector | PR #324 round 2 | 2026-06-01
+- **Severity:** P2 / MEDIUM
+- **File:** `scripts/qa-runner/lib/worker.js`
+- **Finding:** When `gh pr view` failed transiently, `runOne` returned `'skip'` and `daemon.js` always called `queue.done()`, discarding the event. For open labeled PRs the fallback poll re-enqueues them, but one-shot webhooks (`pull_request:closed`, `unlabeled`, `converted_to_draft`) cannot be recreated by the poll. A transient API blip while processing such an event caused the daemon to preserve state but never clean up or announce the terminal transition.
+- **Fix:** Changed the pre-tick snapshot-unavailable return from `'skip'` to `'retry'`. Updated `daemon.js` to requeue non-poll jobs that return `'retry'` so one-shot events survive transient `gh` failures.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/scripts/qa-runner/.gitignore
+++ b/scripts/qa-runner/.gitignore
@@ -1,6 +1,7 @@
 # local QA-runner state — never commit
 .locks/
 logs/
+.state/
 config.json
 bot.env
 orchestrator.env

--- a/scripts/qa-runner/config.example.json
+++ b/scripts/qa-runner/config.example.json
@@ -3,5 +3,11 @@
   "linearTeamKey": "VIM",
   "maxRounds": 8,
   "pollSeconds": 60,
-  "comment": "Copy to config.json (gitignored) to override defaults. The Linear API key for status posting lives in linear.env at the repo root (LINEAR_API_KEY) — see rules/common/linear-workflow.md."
+  "host": "0.0.0.0",
+  "port": 8787,
+  "maxParallel": 2,
+  "maxNoops": 15,
+  "triggerPhrase": "/upsource-review",
+  "trustedSenders": [],
+  "comment": "Copy to config.json (gitignored) to override. SECRETS are env-only: GITHUB_WEBHOOK_SECRET (webhook HMAC), bot tokens in bot.env/orchestrator.env, Linear in linear.env. trustedSenders = GitHub logins allowed to trigger a fix via a PR comment; env QA_TRUSTED_SENDERS (comma-separated) overrides it."
 }

--- a/scripts/qa-runner/daemon.js
+++ b/scripts/qa-runner/daemon.js
@@ -34,7 +34,15 @@ const worker = async (id) => {
       continue
     }
     try {
-      await runOne(job.pr, job.reason, { config, state, log, events })
+      const outcome = await runOne(job.pr, job.reason, {
+        config,
+        state,
+        log,
+        events,
+      })
+      if (outcome === 'retry' && job.reason !== 'poll') {
+        queue.enqueue(job.pr, job.reason)
+      }
     } catch (e) {
       log(`worker ${id}: #${job.pr} ERROR ${e.message}`)
     } finally {

--- a/scripts/qa-runner/daemon.js
+++ b/scripts/qa-runner/daemon.js
@@ -38,7 +38,11 @@ const worker = async (id) => {
     } catch (e) {
       log(`worker ${id}: #${job.pr} ERROR ${e.message}`)
     } finally {
-      queue.done(job.pr)
+      try {
+        queue.done(job.pr)
+      } catch (e) {
+        log(`worker ${id}: queue.done failed — ${e.message}`)
+      }
     }
   }
 }

--- a/scripts/qa-runner/daemon.js
+++ b/scripts/qa-runner/daemon.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// QA daemon — the state-owning orchestrator. Webhook receiver + worker pool +
+// fallback poll, draining on SIGTERM/SIGINT. Long-running; deploy on a host with
+// node + gh + git + kimi + the bot/Linear env files. Run from the repo root:
+//
+//   GITHUB_WEBHOOK_SECRET=… QA_TRUSTED_SENDERS=you node scripts/qa-runner/daemon.js
+//
+// GitHub POSTs to /webhooks/github (behind a TLS proxy — GitHub requires HTTPS).
+// The receiver verifies + enqueues fast; the worker pool does the heavy review.
+import { execFileSync } from 'node:child_process'
+import { loadConfig } from './lib/config.js'
+import { createState } from './lib/daemon-state.js'
+import { createQueue } from './lib/queue.js'
+import { createHost } from './lib/host.js'
+import { runOne } from './lib/worker.js'
+import { createEvents } from './lib/events.js'
+
+const log = (s) => process.stdout.write(`${new Date().toISOString()} ${s}\n`)
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const config = loadConfig()
+const state = createState()
+const queue = createQueue()
+const events = createEvents(log)
+let running = true
+
+// One worker: claim a PR, run a single cycle, release, repeat. Live concurrency
+// is capped by the worker count (config.maxParallel).
+const worker = async (id) => {
+  while (running) {
+    const job = queue.take()
+    if (!job) {
+      await sleep(1500)
+      continue
+    }
+    try {
+      await runOne(job.pr, job.reason, { config, state, log, events })
+    } catch (e) {
+      log(`worker ${id}: #${job.pr} ERROR ${e.message}`)
+    } finally {
+      queue.done(job.pr)
+    }
+  }
+}
+
+// Fallback poll — enqueue every eligible auto-review PR so a missed webhook can't
+// stall a PR. Deduped by the queue.
+const poll = async () => {
+  while (running) {
+    try {
+      const prs = JSON.parse(
+        execFileSync(
+          'gh',
+          [
+            'pr',
+            'list',
+            '--state',
+            'open',
+            '--label',
+            config.label,
+            // gh defaults to 30 — cap high so a missed webhook on PR #31+ still enqueues.
+            '--limit',
+            '200',
+            '--json',
+            'number,isDraft',
+          ],
+          { encoding: 'utf8' }
+        )
+      )
+      for (const pr of prs) {
+        if (!pr.isDraft) {
+          queue.enqueue(pr.number, 'poll')
+        }
+      }
+    } catch (e) {
+      log(`poll ERROR ${e.message}`)
+    }
+    await sleep(config.pollSeconds * 1000)
+  }
+}
+
+const server = createHost({ config, queue, state, log })
+server.listen(config.port, config.host, () => {
+  log(
+    `QA daemon → http://${config.host}:${config.port}  POST /webhooks/github · GET /healthz · GET /status`
+  )
+
+  log(
+    `config: label=${config.label} maxParallel=${config.maxParallel} maxNoops=${config.maxNoops} pollSeconds=${config.pollSeconds} trusted=[${config.trustedSenders.join(',')}]`
+  )
+  if (!config.webhookSecret) {
+    log(
+      'WARNING: GITHUB_WEBHOOK_SECRET unset — webhook endpoint FAILS CLOSED (rejects all).'
+    )
+  }
+  if (!config.trustedSenders.length) {
+    log('WARNING: QA_TRUSTED_SENDERS empty — comment triggers are disabled.')
+  }
+})
+
+for (let i = 0; i < config.maxParallel; i++) {
+  worker(i + 1)
+}
+poll()
+
+// Graceful-ish shutdown: stop accepting + claiming; let in-flight cycles finish
+// (state is checkpointed each tick); force-exit after a grace window.
+const shutdown = (sig) => {
+  log(`${sig} — draining; in-flight: ${queue.inFlight().join(', ') || 'none'}`)
+  running = false
+  server.close(() => log('http server closed'))
+  setTimeout(() => {
+    log('drain window elapsed — exiting')
+    process.exit(0)
+  }, 60000).unref()
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'))
+process.on('SIGINT', () => shutdown('SIGINT'))

--- a/scripts/qa-runner/daemon.js
+++ b/scripts/qa-runner/daemon.js
@@ -28,7 +28,14 @@ let running = true
 // is capped by the worker count (config.maxParallel).
 const worker = async (id) => {
   while (running) {
-    const job = queue.take()
+    let job
+    try {
+      job = queue.take()
+    } catch (e) {
+      log(`worker ${id}: queue.take failed — ${e.message}`)
+      await sleep(1500)
+      continue
+    }
     if (!job) {
       await sleep(1500)
       continue

--- a/scripts/qa-runner/lib/config.js
+++ b/scripts/qa-runner/lib/config.js
@@ -1,0 +1,61 @@
+// Config for the QA daemon. Precedence: env > config.json (gitignored) >
+// config.example.json. SECRETS (GITHUB_WEBHOOK_SECRET, bot/Linear tokens) come
+// ONLY from env / gitignored *.env files — never from a JSON config.
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const QA_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
+
+const readJson = (file) => {
+  if (!existsSync(file)) {
+    return {}
+  }
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+const num = (v, d) => {
+  const n = Number(v)
+
+  return Number.isFinite(n) ? n : d
+}
+
+const list = (v) =>
+  v
+    ? String(v)
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : []
+
+// Merge the layers and coerce types. Called once at daemon start.
+export const loadConfig = () => {
+  const file = {
+    ...readJson(join(QA_DIR, 'config.example.json')),
+    ...readJson(join(QA_DIR, 'config.json')),
+  }
+  const env = process.env
+  const senders = list(env.QA_TRUSTED_SENDERS)
+
+  return {
+    host: env.QA_HOST || file.host || '0.0.0.0',
+    port: num(env.QA_PORT, num(file.port, 8787)),
+    label: env.QA_LABEL || file.label || 'auto-review',
+    maxParallel: num(env.QA_MAX_PARALLEL, num(file.maxParallel, 2)),
+    maxNoops: num(env.QA_MAX_NOOPS, num(file.maxNoops, 15)),
+    pollSeconds: num(env.QA_POLL_SECONDS, num(file.pollSeconds, 60)),
+    triggerPhrase:
+      env.QA_TRIGGER_PHRASE || file.triggerPhrase || '/upsource-review',
+    trustedSenders: senders.length ? senders : file.trustedSenders || [],
+    // Secret: env only. Empty ⇒ the webhook endpoint rejects everything (fail closed).
+    webhookSecret: env.GITHUB_WEBHOOK_SECRET || '',
+    // Bearer token for GET /status (env only). Empty ⇒ /status is DISABLED, so the
+    // public webhook bind never leaks queue/PR state. Set to expose it to operators.
+    statusToken: env.QA_STATUS_TOKEN || '',
+    linearTeamKey: file.linearTeamKey || 'VIM',
+  }
+}

--- a/scripts/qa-runner/lib/daemon-state.js
+++ b/scripts/qa-runner/lib/daemon-state.js
@@ -1,0 +1,68 @@
+// Persistent per-PR daemon state — the runner's memory across cycles + restarts.
+// .state/daemon.json, atomic writes (tmp + rename) so a crash mid-write can't
+// corrupt it. This is what makes the daemon the STATE OWNER (vs watch.js's
+// ephemeral loop): noop/round counts and the last reviewed head SHA survive.
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const STATE_DIR = join(
+  dirname(dirname(fileURLToPath(import.meta.url))),
+  '.state'
+)
+const FILE = join(STATE_DIR, 'daemon.json')
+
+const EMPTY = {
+  lastHeadSha: null,
+  roundCount: 0,
+  noopCount: 0,
+  lastState: null,
+  pausedAt: null,
+}
+
+const read = () => {
+  if (!existsSync(FILE)) {
+    return {}
+  }
+  try {
+    return JSON.parse(readFileSync(FILE, 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+export const createState = (now = () => new Date().toISOString()) => {
+  let data = read()
+
+  const save = () => {
+    mkdirSync(STATE_DIR, { recursive: true })
+    const tmp = `${FILE}.tmp`
+    writeFileSync(tmp, JSON.stringify(data, null, 2))
+    renameSync(tmp, FILE)
+  }
+
+  return {
+    get: (pr) => ({ ...EMPTY, ...data[String(pr)] }),
+    // Is this PR currently tracked? Lets a terminal-state cleanup tell a PR the
+    // daemon was working from a repo-wide `closed` webhook it never touched.
+    has: (pr) => Object.prototype.hasOwnProperty.call(data, String(pr)),
+    update: (pr, patch) => {
+      const k = String(pr)
+      data[k] = { ...EMPTY, ...data[k], ...patch, updatedAt: now() }
+      save()
+
+      return data[k]
+    },
+    forget: (pr) => {
+      delete data[String(pr)]
+      save()
+    },
+    all: () => ({ ...data }),
+  }
+}

--- a/scripts/qa-runner/lib/events.js
+++ b/scripts/qa-runner/lib/events.js
@@ -1,0 +1,71 @@
+// Observable lifecycle events for the daemon. Every event is appended to
+// .state/events.jsonl — a structured, append-only POOL for later metrics
+// (success rate, rounds-to-merge, durations; the aggregator is a follow-up).
+// MILESTONE events also post a one-line comment to the linked VIM issue AS THE
+// ORCHESTRATOR AGENT (Bearer), so the whole lifecycle is observable in Linear,
+// not just the logs. Best-effort throughout: neither the file write nor the
+// Linear post may ever break or block the loop.
+import { spawn } from 'node:child_process'
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const LIB_DIR = dirname(fileURLToPath(import.meta.url))
+const STATE_DIR = join(dirname(LIB_DIR), '.state')
+const EVENTS_FILE = join(STATE_DIR, 'events.jsonl')
+const LINEAR_STATUS = join(LIB_DIR, 'linear-status.js')
+
+// type → a one-line Linear comment. Types absent here are pool/log only (no spam).
+const LINEAR_COMMENT = {
+  progress: (e) =>
+    `✅ Fix pushed for #${e.pr} (round ${e.round}). Re-review pending.`,
+  paused: (e) =>
+    `⏸️ Paused #${e.pr} after ${e.noopCount} failed fix attempts — needs a look.`,
+  merged: (e) => `🎉 #${e.pr} merged — review loop complete.`,
+  closed: (e) => `🚫 #${e.pr} closed without merge — review loop stopped.`,
+}
+
+export const createEvents = (log) => {
+  // Append to the pool + log every event; returns the stamped record.
+  const record = (event) => {
+    const e = { ts: new Date().toISOString(), ...event }
+    try {
+      mkdirSync(STATE_DIR, { recursive: true })
+      appendFileSync(EVENTS_FILE, `${JSON.stringify(e)}\n`)
+    } catch {
+      // best-effort: the metrics pool must never break the loop
+    }
+    log(
+      `event ${e.type} #${e.pr ?? '-'}${e.round != null ? ` r${e.round}` : ''}${e.detail ? ` — ${e.detail}` : ''}`
+    )
+
+    return e
+  }
+
+  // Milestone events post to the VIM issue as the orchestrator agent. Async +
+  // fire-and-forget so a slow/down Linear never blocks the daemon.
+  const toLinear = (vim, e) => {
+    const fmt = LINEAR_COMMENT[e.type]
+    if (!vim || !fmt) {
+      return
+    }
+
+    const child = spawn(
+      'node',
+      [LINEAR_STATUS, vim, fmt(e), '--as', 'orchestrator'],
+      { stdio: 'ignore' }
+    )
+    child.on('error', () => {
+      // best-effort: Linear observability must never break the loop
+    })
+  }
+
+  return {
+    emit: (event, vim) => {
+      const e = record(event)
+      toLinear(vim, e)
+
+      return e
+    },
+  }
+}

--- a/scripts/qa-runner/lib/host.js
+++ b/scripts/qa-runner/lib/host.js
@@ -27,7 +27,7 @@ const readRawBody = (req, limit = 2 * 1024 * 1024) =>
     req.on('data', (c) => {
       size += c.length
       if (size > limit) {
-        req.destroy()
+        req.pause()
         reject(new Error('payload too large'))
 
         return
@@ -50,6 +50,7 @@ const handleWebhook = async (req, res, deps) => {
     raw = await readRawBody(req)
   } catch (e) {
     sendJson(res, 413, { error: e.message })
+    res.on('finish', () => req.destroy())
 
     return
   }

--- a/scripts/qa-runner/lib/host.js
+++ b/scripts/qa-runner/lib/host.js
@@ -1,0 +1,146 @@
+// HTTP receiver — the daemon's deployable REST surface. Verifies, parses, and
+// enqueues fast (the heavy review work happens in the worker pool), so GitHub
+// always gets a quick 2xx.
+//   POST /webhooks/github   verify sig → parse → enqueue → 202 · 401 bad sig · 200 ignored
+//   GET  /healthz           liveness (no state — always open)
+//   GET  /status            queue depth + in-flight + per-PR state — Bearer-gated
+import { createServer } from 'node:http'
+import { timingSafeEqual } from 'node:crypto'
+import { parseEvent, verifySignature } from './webhook.js'
+
+// Constant-time Bearer check for /status. No token configured ⇒ always false, so
+// the caller disables the endpoint (the 0.0.0.0 webhook bind never leaks state).
+const bearerOk = (header, token) => {
+  if (!token) {
+    return false
+  }
+  const expected = Buffer.from(`Bearer ${token}`)
+  const got = Buffer.from(header || '')
+
+  return got.length === expected.length && timingSafeEqual(got, expected)
+}
+
+const readRawBody = (req, limit = 2 * 1024 * 1024) =>
+  new Promise((resolve, reject) => {
+    const chunks = []
+    let size = 0
+    req.on('data', (c) => {
+      size += c.length
+      if (size > limit) {
+        req.destroy()
+        reject(new Error('payload too large'))
+
+        return
+      }
+      chunks.push(c)
+    })
+    req.on('end', () => resolve(Buffer.concat(chunks)))
+    req.on('error', reject)
+  })
+
+const sendJson = (res, code, obj) => {
+  res.writeHead(code, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(obj))
+}
+
+const handleWebhook = async (req, res, deps) => {
+  const { config, queue, log } = deps
+  let raw
+  try {
+    raw = await readRawBody(req)
+  } catch (e) {
+    sendJson(res, 413, { error: e.message })
+
+    return
+  }
+  if (
+    !verifySignature(
+      raw,
+      req.headers['x-hub-signature-256'],
+      config.webhookSecret
+    )
+  ) {
+    log(`webhook: REJECTED bad signature from ${req.socket.remoteAddress}`)
+    sendJson(res, 401, { error: 'bad signature' })
+
+    return
+  }
+  const eventType = req.headers['x-github-event']
+  if (eventType === 'ping') {
+    sendJson(res, 200, { ok: true, pong: true })
+
+    return
+  }
+  let payload
+  try {
+    payload = JSON.parse(raw.toString('utf8'))
+  } catch {
+    sendJson(res, 400, { error: 'invalid json' })
+
+    return
+  }
+
+  const work = parseEvent(eventType, payload, {
+    trustedSenders: config.trustedSenders,
+    triggerPhrase: config.triggerPhrase,
+  })
+  if (!work) {
+    sendJson(res, 200, { ignored: true, event: eventType })
+
+    return
+  }
+  const fresh = queue.enqueue(work.pr, work.reason)
+  log(
+    `webhook: ${eventType} → PR #${work.pr} (${work.reason}) ${fresh ? 'ENQUEUED' : 'deduped'}`
+  )
+  sendJson(res, 202, { pr: work.pr, reason: work.reason, enqueued: fresh })
+}
+
+// Build (not start) the HTTP server. deps: { config, queue, state, log }.
+export const createHost = (deps) => {
+  const { config, queue, state } = deps
+  const startedAt = Date.now()
+
+  return createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://localhost')
+    try {
+      if (req.method === 'GET' && url.pathname === '/healthz') {
+        sendJson(res, 200, {
+          ok: true,
+          uptimeSec: Math.round((Date.now() - startedAt) / 1000),
+        })
+
+        return
+      }
+      if (req.method === 'GET' && url.pathname === '/status') {
+        if (!config.statusToken) {
+          sendJson(res, 404, { error: 'status disabled (set QA_STATUS_TOKEN)' })
+
+          return
+        }
+        if (!bearerOk(req.headers.authorization, config.statusToken)) {
+          sendJson(res, 401, { error: 'unauthorized' })
+
+          return
+        }
+        sendJson(res, 200, {
+          queueDepth: queue.depth(),
+          inFlight: queue.inFlight(),
+          prs: state.all(),
+        })
+
+        return
+      }
+      if (req.method === 'POST' && url.pathname === '/webhooks/github') {
+        await handleWebhook(req, res, deps)
+
+        return
+      }
+      sendJson(res, 404, { error: 'not found' })
+    } catch (e) {
+      if (!res.headersSent) {
+        sendJson(res, 500, { error: e.message })
+      }
+    }
+  })
+}

--- a/scripts/qa-runner/lib/host.js
+++ b/scripts/qa-runner/lib/host.js
@@ -114,7 +114,10 @@ export const createHost = (deps) => {
       }
       if (req.method === 'GET' && url.pathname === '/status') {
         if (!config.statusToken) {
-          sendJson(res, 404, { error: 'status disabled (set QA_STATUS_TOKEN)' })
+          // Generic 404 (not a descriptive one): a disabled /status must be
+          // indistinguishable from a nonexistent path so the public bind reveals
+          // neither the endpoint nor the env-var that enables it.
+          sendJson(res, 404, { error: 'not found' })
 
           return
         }

--- a/scripts/qa-runner/lib/queue.js
+++ b/scripts/qa-runner/lib/queue.js
@@ -1,0 +1,116 @@
+// Persistent, deduped work queue for the daemon (.state/queue.json, survives
+// restart). Dedup: a PR already pending or in-flight is not re-added. Both the
+// pending list AND the in-flight leases are persisted, and any lease left over
+// from a crash is requeued on startup — so one-shot events (closed-PR cleanup, a
+// comment waking a paused PR) that the fallback poll can't recreate aren't lost.
+// The maxParallel cap is enforced by the worker pool calling take() concurrently.
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const STATE_DIR = join(
+  dirname(dirname(fileURLToPath(import.meta.url))),
+  '.state'
+)
+const FILE = join(STATE_DIR, 'queue.json')
+
+const read = () => {
+  if (!existsSync(FILE)) {
+    return { pending: [], inFlight: [] }
+  }
+  try {
+    const j = JSON.parse(readFileSync(FILE, 'utf8'))
+
+    return { pending: j.pending || [], inFlight: j.inFlight || [] }
+  } catch {
+    return { pending: [], inFlight: [] }
+  }
+}
+
+export const createQueue = (now = () => new Date().toISOString()) => {
+  const persisted = read()
+  // Requeue leases that were claimed but never done() before a crash/restart, ahead
+  // of nothing in particular — runOne re-snapshots, so re-processing is idempotent.
+  const seen = new Set()
+  let pending = []
+  for (const e of [...persisted.pending, ...persisted.inFlight]) {
+    if (e && Number.isFinite(e.pr) && !seen.has(e.pr)) {
+      seen.add(e.pr)
+      pending.push(e)
+    }
+  }
+  const inFlight = new Map() // pr → the claimed job (reason preserved across restart)
+
+  const save = () => {
+    mkdirSync(STATE_DIR, { recursive: true })
+    const tmp = `${FILE}.tmp`
+    writeFileSync(
+      tmp,
+      JSON.stringify({ pending, inFlight: [...inFlight.values()] }, null, 2)
+    )
+    renameSync(tmp, FILE)
+  }
+
+  return {
+    // Returns true if newly enqueued, false if deduped (already pending/in-flight).
+    enqueue: (pr, reason) => {
+      const n = Number(pr)
+      const existing = pending.find((e) => e.pr === n)
+      if (existing) {
+        // The fallback poll is the lowest priority: never let it overwrite a real
+        // event's reason, since runOne skips paused PRs only for reason 'poll' — a
+        // downgrade would drop the very event meant to re-evaluate a paused PR.
+        if (!(reason === 'poll' && existing.reason !== 'poll')) {
+          existing.reason = reason
+        }
+        save()
+
+        return false
+      }
+      if (inFlight.has(n)) {
+        // A real event landing mid-cycle must become a FOLLOW-UP: the in-flight cycle
+        // may return without acting on it (e.g. a poll that returns 'paused'), and
+        // take() won't claim this entry until done() releases the lease — so it runs
+        // next, with the event reason that bypasses the pause-skip. A routine poll is
+        // still dropped here (the next poll re-enqueues it anyway).
+        if (reason !== 'poll') {
+          pending.push({ pr: n, reason, at: now() })
+          save()
+
+          return true
+        }
+
+        return false
+      }
+      pending.push({ pr: n, reason, at: now() })
+      save()
+
+      return true
+    },
+    // Claim the next pending PR not already in-flight, marking it in-flight.
+    take: () => {
+      const e = pending.find((x) => !inFlight.has(x.pr))
+      if (!e) {
+        return null
+      }
+      pending = pending.filter((x) => x.pr !== e.pr)
+      inFlight.set(e.pr, e)
+      save()
+
+      return e
+    },
+    // Release a claimed lease — persisted so a completed job isn't requeued on restart.
+    done: (pr) => {
+      inFlight.delete(Number(pr))
+      save()
+    },
+    depth: () => pending.length,
+    inFlight: () => [...inFlight.keys()],
+  }
+}

--- a/scripts/qa-runner/lib/run-until-change.js
+++ b/scripts/qa-runner/lib/run-until-change.js
@@ -1,0 +1,98 @@
+// Run a child process until a probe value changes, then wind it down. Polls
+// `probe()`; once it returns a value different from the start (the child's
+// observable effect has landed), waits `graceMs` for any follow-up, then
+// terminates the child (SIGTERM → SIGKILL). `timeoutMs` is a hard backstop.
+// Resolves with { status, signal, killed }.
+//
+// Generic on purpose — reusable for any "run a process until its work shows up,
+// then stop it from over-running" case. The QA runner uses it to enforce a
+// single review round: probe = the worktree HEAD, so once kimi commits the fix,
+// it is stopped before the upsource-review skill can POLL_NEXT into another round.
+//
+// Deps are injected so it is unit-testable without a real child or git:
+//   spawnChild() → a ChildProcess-like { kill(sig), on('exit'|'error', cb) }
+//   probe()      → any comparable value; a CHANGE triggers the wind-down
+export const runUntilChange = (spawnChild, probe, opts = {}) => {
+  // Options — all optional; the default is noted in each comment below.
+  const {
+    // grace after the probe changes — the window to let the child finish its
+    // follow-up (e.g. push + reply/resolve) before we terminate it. Too short
+    // truncates that work; too long lets a misbehaving child start another round (2 min).
+    graceMs = 120000,
+    // hard cap on total runtime — terminate even if the probe never changes (45 min).
+    timeoutMs = 45 * 60000,
+    // how often to sample probe() for a change (15 s).
+    pollMs = 15000,
+    log = () => {
+      // silent by default
+    },
+    timers = { setTimeout, clearTimeout, setInterval, clearInterval },
+  } = opts
+
+  return new Promise((resolve) => {
+    const before = probe()
+    const child = spawnChild()
+    let stopped = false
+    let stopReason = null
+    let graceTimer = null
+    let killTimer = null
+
+    const stop = (reason, why) => {
+      if (stopped) {
+        return
+      }
+      stopped = true
+      stopReason = reason
+      log(`run-until-change: ${why} — terminating`)
+      child.kill('SIGTERM')
+      // SIGKILL backstop if SIGTERM is ignored — captured so cleanup() can cancel it
+      // once the child exits, instead of holding the process (and the pool slot) 10s.
+      killTimer = timers.setTimeout(() => child.kill('SIGKILL'), 10000)
+    }
+
+    const poll = timers.setInterval(() => {
+      const now = probe()
+      if (now && now !== before && graceTimer === null) {
+        log(
+          `run-until-change: probe changed (${String(now).slice(0, 7)}) — grace ${graceMs / 1000}s then stop`
+        )
+
+        graceTimer = timers.setTimeout(
+          () => stop('grace', 'grace elapsed'),
+          graceMs
+        )
+      }
+    }, pollMs)
+
+    const overall = timers.setTimeout(
+      () => stop('timeout', `${Math.round(timeoutMs / 60000)}m timeout`),
+      timeoutMs
+    )
+
+    const cleanup = () => {
+      timers.clearInterval(poll)
+      if (graceTimer !== null) {
+        timers.clearTimeout(graceTimer)
+      }
+      if (killTimer !== null) {
+        timers.clearTimeout(killTimer)
+      }
+      timers.clearTimeout(overall)
+    }
+
+    child.on('exit', (code, signal) => {
+      cleanup()
+      resolve({
+        status: code ?? null,
+        signal: signal ?? null,
+        killed: stopped,
+        timedOut: stopReason === 'timeout',
+      })
+    })
+
+    child.on('error', (error) => {
+      cleanup()
+      resolve({ status: null, signal: null, error })
+    })
+  })
+}

--- a/scripts/qa-runner/lib/run-until-change.js
+++ b/scripts/qa-runner/lib/run-until-change.js
@@ -30,7 +30,7 @@ export const runUntilChange = (spawnChild, probe, opts = {}) => {
   } = opts
 
   return new Promise((resolve) => {
-    const before = probe()
+    let before = probe()
     const child = spawnChild()
     let stopped = false
     let stopReason = null
@@ -52,7 +52,12 @@ export const runUntilChange = (spawnChild, probe, opts = {}) => {
 
     const poll = timers.setInterval(() => {
       const now = probe()
-      if (now && now !== before && graceTimer === null) {
+      if (before === null && now) {
+        before = now
+
+        return
+      }
+      if (now && before !== null && now !== before && graceTimer === null) {
         log(
           `run-until-change: probe changed (${String(now).slice(0, 7)}) — grace ${graceMs / 1000}s then stop`
         )

--- a/scripts/qa-runner/lib/webhook.js
+++ b/scripts/qa-runner/lib/webhook.js
@@ -1,0 +1,92 @@
+// GitHub webhook security + event parsing — the daemon's trust boundary.
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+// Constant-time HMAC-SHA256 check of the RAW body against X-Hub-Signature-256.
+// Fail CLOSED: empty secret, missing/malformed header, or length mismatch ⇒ false.
+export const verifySignature = (rawBody, signatureHeader, secret) => {
+  if (!secret || !signatureHeader) {
+    return false
+  }
+  const digest = createHmac('sha256', secret).update(rawBody).digest('hex')
+  const a = Buffer.from(`sha256=${digest}`)
+  const b = Buffer.from(String(signatureHeader))
+  if (a.length !== b.length) {
+    return false
+  }
+
+  return timingSafeEqual(a, b)
+}
+
+const prWork = (pr, reason) => (Number.isInteger(pr) ? { pr, reason } : null)
+
+// Map a GitHub webhook event to the PR work it implies, or null to ignore. The
+// comment command is the only user-injectable trigger, so it is gated on a
+// configured trusted sender (the signature alone proves GitHub, not WHO).
+export const parseEvent = (eventType, payload, opts = {}) => {
+  const { trustedSenders = [], triggerPhrase = '/upsource-review' } = opts
+  const p = payload || {}
+
+  if (eventType === 'issue_comment') {
+    const isCreateEdit = p.action === 'created' || p.action === 'edited'
+    const onPr = Boolean(p.issue?.pull_request)
+    const hasCmd = (p.comment?.body || '').includes(triggerPhrase)
+    // Trust the ACTOR (sender), not the comment author: on an `edited` event the
+    // editor differs from the author, so author-gating lets an untrusted editor inject the command.
+    const trusted = trustedSenders.includes(p.sender?.login)
+    if (isCreateEdit && onPr && hasCmd && trusted) {
+      return prWork(p.issue?.number, `comment:${triggerPhrase}`)
+    }
+
+    return null
+  }
+
+  if (eventType === 'pull_request') {
+    // `closed` (merge OR close) reaches runOne's terminal cleanup; `unlabeled` /
+    // `converted_to_draft` reach its eligibility gate to FORGET an opted-out PR.
+    // Both matter because the fallback poll only lists OPEN, labeled, non-draft PRs,
+    // so without these a tracked PR's daemon-state would go stale after the change.
+    const wanted = [
+      'opened',
+      'reopened',
+      'synchronize',
+      'ready_for_review',
+      'labeled',
+      'unlabeled',
+      'converted_to_draft',
+      'closed',
+    ]
+
+    return wanted.includes(p.action)
+      ? prWork(p.pull_request?.number, `pr:${p.action}`)
+      : null
+  }
+
+  if (eventType === 'pull_request_review') {
+    return p.action === 'submitted'
+      ? prWork(p.pull_request?.number, 'review')
+      : null
+  }
+
+  if (eventType === 'pull_request_review_comment') {
+    return p.action === 'created'
+      ? prWork(p.pull_request?.number, 'review-comment')
+      : null
+  }
+
+  if (eventType === 'pull_request_review_thread') {
+    return ['resolved', 'unresolved'].includes(p.action)
+      ? prWork(p.pull_request?.number, `thread:${p.action}`)
+      : null
+  }
+
+  if (eventType === 'check_run' || eventType === 'workflow_run') {
+    if (p.action !== 'completed') {
+      return null
+    }
+    const node = p.check_run || p.workflow_run || {}
+
+    return prWork((node.pull_requests || [])[0]?.number, `ci:${eventType}`)
+  }
+
+  return null
+}

--- a/scripts/qa-runner/lib/worker.js
+++ b/scripts/qa-runner/lib/worker.js
@@ -1,0 +1,234 @@
+// The daemon's WORKER — the unit of work for one queued PR. `runOne(pr, reason)`
+// runs a SINGLE review cycle and records what happened; the worker pool in
+// daemon.js calls it concurrently (capped at maxParallel), and the poll + webhooks
+// re-enqueue the PR for the next cycle.
+//
+// One cycle = shell `watch.js tick --pr N --execute --approve` (which computes the
+// review state and either dispatches the kimi fixer or approves+merges), then
+// update the persistent state (round/noop counts, last-reviewed HEAD) and emit
+// lifecycle events (the .state/events.jsonl pool + Linear milestones). The long
+// kimi step runs via async spawn so it never blocks the daemon's event loop.
+//
+// Single-pass: one cycle then return, never looping internally — that in-dispatch
+// looping was the root cause of kimi's multi-round timeouts.
+import { execFileSync, spawn } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { linkedVim } from './pr-utils.js'
+
+const WATCH = join(dirname(dirname(fileURLToPath(import.meta.url))), 'watch.js')
+
+const snapshot = (pr) => {
+  try {
+    const j = JSON.parse(
+      execFileSync(
+        'gh',
+        [
+          'pr',
+          'view',
+          String(pr),
+          '--json',
+          'headRefOid,state,body,isDraft,labels',
+        ],
+        { encoding: 'utf8' }
+      )
+    )
+
+    return {
+      ok: true,
+      headSha: j.headRefOid,
+      state: j.state,
+      vim: linkedVim(j.body),
+      isDraft: Boolean(j.isDraft),
+      labels: (j.labels || []).map((l) => l.name),
+    }
+  } catch {
+    // ok:false marks an UNKNOWN read (network / auth / rate-limit), distinct from a
+    // real unlabeled/draft PR — the caller must not mutate state on an unknown.
+    return {
+      ok: false,
+      headSha: null,
+      state: null,
+      vim: undefined,
+      isDraft: false,
+      labels: [],
+    }
+  }
+}
+
+const tick = (pr, label) =>
+  new Promise((resolve) => {
+    const args = [WATCH, 'tick', '--pr', String(pr), '--execute', '--approve']
+    if (label) {
+      args.push('--label', label)
+    }
+    const child = spawn('node', args, { stdio: 'inherit' })
+    child.on('exit', (code) => resolve(code ?? -1))
+    child.on('error', () => resolve(-1))
+  })
+
+// Run one cycle for `pr`. deps: { config, state, log, events, now? }. Async — the
+// heavy watch.js/kimi run is awaited, keeping the daemon responsive. Returns an
+// outcome tag: 'done' | 'progress' | 'error' | 'waiting' | 'paused' | 'skip'.
+export const runOne = async (pr, reason, deps) => {
+  const {
+    config,
+    state,
+    log,
+    events,
+    now = () => new Date().toISOString(),
+  } = deps
+  const st = state.get(pr)
+  const tracked = state.has(pr)
+  const before = snapshot(pr)
+
+  // Unknown read (gh failed transiently): do NOT touch state — forgetting here would
+  // drop a tracked PR's round/noop counts and its later merged/closed milestone over a
+  // blip. Skip; the next poll/event re-snapshots.
+  if (!before.ok) {
+    log(`#${pr}: snapshot unavailable (transient) — skip, state preserved`)
+
+    return 'skip'
+  }
+
+  // Already terminal before we tick — a human merged/closed it, or a `pull_request
+  // closed` webhook arrived. Clean up now (no wasted cycle), even if paused. Only
+  // announce for PRs we were tracking: `closed` fires repo-wide, so an untracked PR
+  // is forgotten silently rather than posting a milestone we never earned.
+  if (before.state === 'MERGED' || before.state === 'CLOSED') {
+    state.forget(pr)
+    if (tracked) {
+      const type = before.state === 'MERGED' ? 'merged' : 'closed'
+      events.emit({ type, pr, detail: before.state }, before.vim)
+    }
+
+    return 'done'
+  }
+
+  // Eligibility gate. Webhooks (comment / review / CI) enqueue a PR regardless of
+  // label, but only labeled, non-draft PRs opt into the runner. Skip the rest BEFORE
+  // any state write — else watch.js would no-op AND we'd start tracking a PR that
+  // never opted in, letting a later close/merge webhook post a milestone for it.
+  const eligible = !before.isDraft && before.labels.includes(config.label)
+  if (!eligible) {
+    if (tracked) {
+      state.forget(pr) // label pulled / converted to draft mid-flight — stop tracking
+    }
+    log(
+      `#${pr}: not eligible (needs label '${config.label}', non-draft) — skip`
+    )
+
+    return 'skip'
+  }
+
+  const headMoved = Boolean(before.headSha) && before.headSha !== st.lastHeadSha
+
+  // A paused PR is skipped only by the routine POLL. Any real webhook event
+  // (review, CI, comment) or a head change re-evaluates it — the thing that
+  // unsticks it (CI finishing, a human re-triggering) arrives as an event, and
+  // refusing those is how a paused PR gets permanently stuck.
+  if (st.pausedAt && reason === 'poll' && !headMoved) {
+    log(
+      `#${pr}: paused (${st.noopCount}/${config.maxNoops} failed) — poll skip`
+    )
+
+    return 'paused'
+  }
+
+  events.emit({ type: 'cycle', pr, round: st.roundCount, detail: reason })
+  const code = await tick(pr, config.label)
+  const after = snapshot(pr)
+
+  // Post-tick read failed (same rule as the pre-tick guard): never interpret null
+  // state/head — that would log a real push/merge as a null-head 'waiting' or miss a
+  // terminal event. Leave state intact; the next poll/event reconciles.
+  if (!after.ok) {
+    log(
+      `#${pr}: post-tick snapshot unavailable (transient) — skip, state preserved`
+    )
+
+    return 'skip'
+  }
+
+  // Terminal states both drop the PR from tracking, but MERGED is a win and CLOSED
+  // (closed without merge) is an abandon — distinct events so we never post a 🎉
+  // "merged" milestone for a PR a human just closed.
+  if (after.state === 'MERGED') {
+    state.forget(pr)
+    events.emit({ type: 'merged', pr, detail: after.state }, after.vim)
+
+    return 'done'
+  }
+  if (after.state === 'CLOSED') {
+    state.forget(pr)
+    events.emit({ type: 'closed', pr, detail: after.state }, after.vim)
+
+    return 'done'
+  }
+
+  // Progress = a fix landed DURING this cycle (head advanced from the pre-tick SHA,
+  // not merely differs from the last recorded one — that would count a brand-new
+  // PR's first WAITING/CI_RED cycle as progress).
+  const fixed =
+    Boolean(after.headSha) &&
+    Boolean(before.headSha) &&
+    after.headSha !== before.headSha
+  if (fixed) {
+    const round = st.roundCount + 1
+    state.update(pr, {
+      lastHeadSha: after.headSha,
+      roundCount: round,
+      noopCount: 0,
+      pausedAt: null,
+    })
+    events.emit({ type: 'progress', pr, round }, after.vim)
+
+    return 'progress'
+  }
+
+  // watch.js exit codes: 1 = a dispatched fixer stalled (run.js non-zero — crash,
+  // timeout, no commit, or commit-without-push); 2 = a transient infra failure
+  // (classification / approve); -1 = the spawn itself failed.
+  if (code !== 0) {
+    if (code !== 1) {
+      // Transient (2) or a failed spawn (-1) — NOT a fixer stall. Retry next cycle
+      // without touching the failure streak, so a gh/GraphQL blip can't pause a
+      // healthy PR (which the poll guard would then keep skipping).
+      events.emit(
+        { type: 'error', pr, detail: `watch.js transient (exit ${code})` },
+        after.vim
+      )
+
+      return 'error'
+    }
+    // exit 1 = the fixer ran and couldn't advance the head. THE stall signal: count
+    // consecutive failures and pause at the cap so a broken PR stops burning cycles.
+    const noopCount = st.noopCount + 1
+    const paused = noopCount >= config.maxNoops
+    state.update(pr, {
+      lastHeadSha: after.headSha,
+      noopCount,
+      pausedAt: paused ? now() : st.pausedAt,
+    })
+
+    events.emit(
+      {
+        type: paused ? 'paused' : 'error',
+        pr,
+        noopCount,
+        detail: `fixer stall (watch.js exit ${code})`,
+      },
+      after.vim
+    )
+
+    return paused ? 'paused' : 'error'
+  }
+
+  // Clean exit, no head change. Because a dispatched fixer that no-ops now exits
+  // non-zero (above), this means NO fixer ran — the PR is genuinely WAITING on CI or
+  // review. NOT a stall: reset the failure streak AND clear any pause, since a clean
+  // recheck means it is no longer stuck and routine polling should resume.
+  state.update(pr, { lastHeadSha: after.headSha, noopCount: 0, pausedAt: null })
+
+  return 'waiting'
+}

--- a/scripts/qa-runner/lib/worker.js
+++ b/scripts/qa-runner/lib/worker.js
@@ -69,7 +69,7 @@ const tick = (pr, label) =>
 
 // Run one cycle for `pr`. deps: { config, state, log, events, now? }. Async — the
 // heavy watch.js/kimi run is awaited, keeping the daemon responsive. Returns an
-// outcome tag: 'done' | 'progress' | 'error' | 'waiting' | 'paused' | 'skip'.
+// outcome tag: 'done' | 'progress' | 'error' | 'waiting' | 'paused' | 'skip' | 'retry'.
 export const runOne = async (pr, reason, deps) => {
   const {
     config,
@@ -86,9 +86,9 @@ export const runOne = async (pr, reason, deps) => {
   // drop a tracked PR's round/noop counts and its later merged/closed milestone over a
   // blip. Skip; the next poll/event re-snapshots.
   if (!before.ok) {
-    log(`#${pr}: snapshot unavailable (transient) — skip, state preserved`)
+    log(`#${pr}: snapshot unavailable (transient) — retry, state preserved`)
 
-    return 'skip'
+    return 'retry'
   }
 
   // Already terminal before we tick — a human merged/closed it, or a `pull_request

--- a/scripts/qa-runner/run.js
+++ b/scripts/qa-runner/run.js
@@ -272,7 +272,11 @@ const run = async (pr, live) => {
       die('kimi spawn failed: ' + r.error.message)
     }
     if (r.timedOut) {
-      die(`kimi timed out with no commit (${KIMI_TIMEOUT_MS / 60000}m)`, 6)
+      const head = sh('git', ['-C', wt, 'rev-parse', 'HEAD']).trim()
+      if (head === startHead) {
+        die(`kimi timed out with no commit (${KIMI_TIMEOUT_MS / 60000}m)`, 6)
+      }
+      // commit landed in the final poll window — fall through to push verification
     }
     // A non-zero exit or unexpected signal (anything but our intentional single-pass
     // stop) is a real fixer failure — exit non-zero so the daemon's failure

--- a/scripts/qa-runner/run.js
+++ b/scripts/qa-runner/run.js
@@ -16,7 +16,7 @@
 // via a `skills/upsource-review` symlink we create in the worktree. codex is the
 // verify gate (inside the skill).
 
-import { execFileSync, spawnSync } from 'node:child_process'
+import { execFileSync, spawn, spawnSync } from 'node:child_process'
 import {
   existsSync,
   mkdirSync,
@@ -31,6 +31,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { botEnv, botLabel, loadBot } from './lib/bot-identity.js'
 import { linkedVim } from './lib/pr-utils.js'
+import { runUntilChange } from './lib/run-until-change.js'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const LOCK_DIR = join(SCRIPT_DIR, '.locks')
@@ -162,7 +163,15 @@ const invocation = (pr, live) => {
     `"${pr}" is the PR number — not a line number or a count. Resolve PR #${pr}, fetch its ` +
     `review findings, and fix every one. Do not ask for clarification; the target is PR #${pr}.`
   if (live) {
-    return base
+    // SINGLE PASS: the orchestrator owns re-dispatch — fix one round and exit, never poll.
+    return (
+      `${base}\n\n` +
+      'SINGLE PASS — fix only the CURRENT round of review findings: apply the fixes, ' +
+      'run the codex verify gate, commit, push, then reply to and resolve the threads ' +
+      'you addressed, and STOP. Do NOT poll or wait for a re-review, and do NOT begin ' +
+      'another fix round — exit cleanly as soon as this round is pushed. The orchestrator ' +
+      're-dispatches you when fresh review feedback arrives.'
+    )
   }
 
   return (
@@ -175,7 +184,7 @@ const invocation = (pr, live) => {
   )
 }
 
-const run = (pr, live) => {
+const run = async (pr, live) => {
   mkdirSync(LOCK_DIR, { recursive: true })
   const lock = join(LOCK_DIR, `pr-${pr}.lock`)
   try {
@@ -218,41 +227,93 @@ const run = (pr, live) => {
     ).nameWithOwner
     const skillsDir = lifelineSkillsDir()
     const wt = ensureWorktree(pr, branch, live, skillsDir, bot, repo)
+    // HEAD before the run (== origin/<branch>) — the baseline the post-run live
+    // checks compare against to tell "advanced the remote" from "did nothing".
+    const startHead = sh('git', ['-C', wt, 'rev-parse', 'HEAD']).trim()
     out(
       `${live ? 'LIVE' : 'DRY-RUN'}: kimi → /skill:upsource-review ${pr}  ` +
         `(branch ${branch}, as ${botLabel(bot)}, worktree ${wt})`
     )
 
-    const r = spawnSync(
-      'kimi',
-      [
-        '--afk',
-        '--print',
-        '-w',
-        wt,
-        '--skills-dir',
-        skillsDir,
-        '-p',
-        invocation(pr, live),
-      ],
-      {
-        stdio: 'inherit',
-        timeout: KIMI_TIMEOUT_MS,
-        env: {
-          ...process.env,
-          ...botEnv(bot),
-          USER_SUPPLIED_PR_NUMBER: String(pr),
-        },
-      }
+    // Single-pass guard: stop kimi once it commits (probe = worktree HEAD) so the skill can't POLL_NEXT.
+    const r = await runUntilChange(
+      () =>
+        spawn(
+          'kimi',
+          [
+            '--afk',
+            '--print',
+            '-w',
+            wt,
+            '--skills-dir',
+            skillsDir,
+            '-p',
+            invocation(pr, live),
+          ],
+          {
+            stdio: 'inherit',
+            env: {
+              ...process.env,
+              ...botEnv(bot),
+              USER_SUPPLIED_PR_NUMBER: String(pr),
+            },
+          }
+        ),
+      () => {
+        try {
+          return sh('git', ['-C', wt, 'rev-parse', 'HEAD']).trim()
+        } catch {
+          return null
+        }
+      },
+      { timeoutMs: KIMI_TIMEOUT_MS, log: out }
     )
     if (r.error) {
       die('kimi spawn failed: ' + r.error.message)
     }
+    if (r.timedOut) {
+      die(`kimi timed out with no commit (${KIMI_TIMEOUT_MS / 60000}m)`, 6)
+    }
+    // A non-zero exit or unexpected signal (anything but our intentional single-pass
+    // stop) is a real fixer failure — exit non-zero so the daemon's failure
+    // accounting sees it instead of recording a clean waiting cycle.
+    if (!r.killed && r.status !== 0) {
+      die(`kimi failed (${r.status ?? `signal ${r.signal}`})`, 7)
+    }
+    // Live invariant: exit 0 ONLY when the run advanced origin/<branch>, so the daemon
+    // can read a clean exit as real progress. Two ways it can fail to:
+    //   1. No commit at all — the fixer was dispatched for findings but addressed
+    //      none (HEAD never left startHead). Looks identical to a WAITING tick to the
+    //      daemon, so without this it would reset the failure streak and poll forever.
+    //   2. Committed but the push never landed (bad credentials, non-fast-forward,
+    //      killed mid-push) — the probe is the LOCAL HEAD, so grace tripped on the
+    //      commit; origin/<branch> stays behind, so the daemon sees an unchanged remote.
+    if (live) {
+      const head = sh('git', ['-C', wt, 'rev-parse', 'HEAD']).trim()
+      if (head === startHead) {
+        die(`kimi produced no commit — findings left unaddressed`, 9)
+      }
+      let remote = null
+      try {
+        remote = sh('git', ['-C', wt, 'rev-parse', `origin/${branch}`]).trim()
+      } catch {
+        /* remote-tracking ref missing — treated as not-pushed below */
+      }
+      if (remote !== head) {
+        die(
+          `kimi committed but the push did not land (local ${head.slice(0, 7)} ≠ origin/${branch} ${remote ? remote.slice(0, 7) : 'unknown'})`,
+          8
+        )
+      }
+    }
     out('')
-    out(`kimi exit: ${r.status ?? `signal ${r.signal}`}`)
+    out(
+      `kimi exit: ${r.status ?? `signal ${r.signal}`}${r.killed ? ' (single-pass stop)' : ''}`
+    )
     out('--- worktree changes ---')
     out(sh('git', ['-C', wt, 'status', '--short']) || '(none)')
-    if (live && r.status === 0) {
+    // r.killed (single-pass stop) is also success — every failure mode die()'d above.
+    if (live && (r.status === 0 || r.killed)) {
       const vim = linkedVim(info.body)
       if (vim) {
         spawnSync(
@@ -279,20 +340,20 @@ const run = (pr, live) => {
   }
 }
 
-const main = () => {
-  const argv = process.argv.slice(2)
-  const pr = Number(argv.find((a) => /^\d+$/.test(a)))
-  if (!pr) {
-    die(
-      'usage: run.js <PR#> [--push]   (default = dry-run; --push arms the live path)'
-    )
-  }
+const main = async () => {
   try {
-    run(pr, argv.includes('--push'))
+    const argv = process.argv.slice(2)
+    const pr = Number(argv.find((a) => /^\d+$/.test(a)))
+    if (!pr) {
+      die(
+        'usage: run.js <PR#> [--push]   (default = dry-run; --push arms the live path)'
+      )
+    }
+    await run(pr, argv.includes('--push'))
   } catch (e) {
     process.stderr.write(`${e.message}\n`)
     process.exit(e.exitCode || 1)
   }
 }
 
-main()
+await main()

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -187,6 +187,17 @@ const isLocked = (pr) => {
     const pid = Number((readFileSync(lock, 'utf8').match(/pid (\d+)/) || [])[1])
     if (pid > 0) {
       process.kill(pid, 0) // throws ESRCH if the owner process is gone
+      try {
+        const cmdLine = readFileSync(`/proc/${pid}/cmdline`, 'utf8')
+        if (!cmdLine.includes('run.js')) {
+          // PID recycled to a non-run.js process — stale lock
+          rmSync(lock, { force: true })
+
+          return false
+        }
+      } catch {
+        // /proc unreadable — treat as locked to be safe
+      }
 
       return true
     }
@@ -501,22 +512,24 @@ const tick = async (ctx) => {
     out('')
   }
   let fixerStall = false
+  let signalKilled = false
   if (needsFix.length) {
     out(
       `Dispatching ${needsFix.length} fix run(s), up to ${ctx.maxParallel} in parallel…\n`
     )
     const codes = await pool(needsFix, ctx.maxParallel, dispatchFix)
-    fixerStall = codes.some((c) => c !== 0)
+    fixerStall = codes.some((c) => c !== null && c !== 0)
+    signalKilled = codes.some((c) => c === null)
   }
   // Exit-code contract for the supervising daemon:
   //   1 = a dispatched FIXER stalled (run.js non-zero) — the actionable signal it
   //       counts toward pausing the PR (kimi can't drive these findings to zero).
-  //   2 = a TRANSIENT infra failure (classification / approve, no fixer stall) — the
-  //       daemon retries WITHOUT pausing, so a gh/GraphQL blip can't stick a PR.
+  //   2 = a TRANSIENT infra failure (classification / approve / signal-killed) — the
+  //       daemon retries WITHOUT pausing, so a gh/GraphQL blip or host OOM can't stick a PR.
   // Fixer stall wins when both happen in one tick.
   if (fixerStall) {
     process.exitCode = 1
-  } else if (classifyError || approveError) {
+  } else if (classifyError || approveError || signalKilled) {
     process.exitCode = 2
   }
 }

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -512,24 +512,27 @@ const tick = async (ctx) => {
     out('')
   }
   let fixerStall = false
-  let signalKilled = false
+  let transientChild = false
   if (needsFix.length) {
     out(
       `Dispatching ${needsFix.length} fix run(s), up to ${ctx.maxParallel} in parallel…\n`
     )
     const codes = await pool(needsFix, ctx.maxParallel, dispatchFix)
-    fixerStall = codes.some((c) => c !== null && c !== 0)
-    signalKilled = codes.some((c) => c === null)
+    // dispatchFix resolves a real run.js exit code, null (signal-killed), or -1
+    // (spawn failed: node/run.js missing, OOM before fork). Only a real non-zero
+    // exit is a fixer stall; null and -1 are transient infra, not kimi's fault.
+    fixerStall = codes.some((c) => c !== null && c !== -1 && c !== 0)
+    transientChild = codes.some((c) => c === null || c === -1)
   }
   // Exit-code contract for the supervising daemon:
   //   1 = a dispatched FIXER stalled (run.js non-zero) — the actionable signal it
   //       counts toward pausing the PR (kimi can't drive these findings to zero).
-  //   2 = a TRANSIENT infra failure (classification / approve / signal-killed) — the
-  //       daemon retries WITHOUT pausing, so a gh/GraphQL blip or host OOM can't stick a PR.
+  //   2 = a TRANSIENT infra failure (classify / approve / signal-kill / spawn-fail) —
+  //       the daemon retries WITHOUT pausing, so a blip or host OOM can't stick a PR.
   // Fixer stall wins when both happen in one tick.
   if (fixerStall) {
     process.exitCode = 1
-  } else if (classifyError || approveError || signalKilled) {
+  } else if (classifyError || approveError || transientChild) {
     process.exitCode = 2
   }
 }

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -20,7 +20,13 @@
 // `--pr N` targets one PR; `--max N` caps parallel fixes. See README.md.
 
 import { execFileSync, spawn, spawnSync } from 'node:child_process'
-import { createWriteStream, existsSync, mkdirSync } from 'node:fs'
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { botLabel, botProcessEnv, loadBot } from './lib/bot-identity.js'
@@ -69,6 +75,8 @@ const mainRoot = () =>
     ).trim()
   )
 
+const PR_FIELDS = 'number,title,headRefName,isDraft,labels'
+
 const openPRs = () =>
   ghJson([
     'pr',
@@ -78,8 +86,20 @@ const openPRs = () =>
     '--limit',
     '50',
     '--json',
-    'number,title,headRefName,isDraft,labels',
+    PR_FIELDS,
   ])
+
+// Candidate PRs for a tick/scan. A targeted --pr is fetched directly so a PR past
+// openPRs()'s first page still resolves (the daemon enqueues by number); without
+// one, the capped open list drives the human scan.
+const candidatePRs = (pr) => {
+  if (!pr) {
+    return openPRs()
+  }
+  const p = ghJson(['pr', 'view', String(pr), '--json', `${PR_FIELDS},state`])
+
+  return p.state === 'OPEN' ? [p] : []
+}
 
 const unresolvedThreads = (owner, name, pr) => {
   let cursor = ''
@@ -154,7 +174,32 @@ const claudeVerdictClean = (owner, name, pr) => {
 
 const checksFor = (pr) =>
   ghJson(['pr', 'checks', String(pr), '--json', 'name,bucket'])
-const isLocked = (pr) => existsSync(join(LOCK_DIR, `pr-${pr}.lock`))
+
+// Is a runner holding this PR's lock? Lazily reaps a STALE lock — one whose owner
+// PID is gone (host crash / SIGKILL before run.js released it) — so a requeued PR
+// isn't reported LOCKED and skipped forever after a restart.
+const isLocked = (pr) => {
+  const lock = join(LOCK_DIR, `pr-${pr}.lock`)
+  if (!existsSync(lock)) {
+    return false
+  }
+  try {
+    const pid = Number((readFileSync(lock, 'utf8').match(/pid (\d+)/) || [])[1])
+    if (pid > 0) {
+      process.kill(pid, 0) // throws ESRCH if the owner process is gone
+
+      return true
+    }
+  } catch (e) {
+    if (e.code === 'EPERM') {
+      return true // owner alive but not ours — still a live holder
+    }
+    // ESRCH / unreadable PID → stale; fall through to reap
+  }
+  rmSync(lock, { force: true })
+
+  return false
+}
 const hasLabel = (pr, label) => (pr.labels || []).some((l) => l.name === label)
 
 // The review state machine.
@@ -373,23 +418,24 @@ const dispatchFix = (pr) =>
 
 // Bounded-concurrency pool — at most `limit` workers in flight.
 const pool = async (items, limit, worker) => {
+  const results = []
   let i = 0
 
   const next = async () => {
     while (i < items.length) {
-      await worker(items[i++])
+      const idx = i++
+      results[idx] = await worker(items[idx])
     }
   }
   await Promise.all(Array.from({ length: Math.min(limit, items.length) }, next))
+
+  return results
 }
 
 const tick = async (ctx) => {
-  let prs = openPRs().filter(
+  const prs = candidatePRs(ctx.pr).filter(
     (p) => (ctx.all || hasLabel(p, ctx.label)) && !p.isDraft
   )
-  if (ctx.pr) {
-    prs = prs.filter((p) => p.number === ctx.pr)
-  }
   if (!prs.length) {
     out(
       ctx.pr
@@ -404,6 +450,8 @@ const tick = async (ctx) => {
       `approve=${ctx.approve} execute=${ctx.execute} max=${ctx.maxParallel}\n`
   )
   const needsFix = []
+  let classifyError = false
+  let approveError = false
   for (const pr of prs) {
     if (isLocked(pr.number)) {
       out(`LOCKED     #${pr.number} ${pr.headRefName} — run in flight, skip\n`)
@@ -413,7 +461,11 @@ const tick = async (ctx) => {
     try {
       s = computeState(pr, ctx)
     } catch (e) {
+      // A transient classification failure (gh checks / GraphQL) is NOT a clean tick —
+      // flag it so the exit is non-zero and a supervising daemon counts it, rather
+      // than reading exit 0 as "WAITING" and resetting the PR's failure streak.
       out(`ERROR      #${pr.number} — ${e.message.split('\n')[0]}\n`)
+      classifyError = true
       continue
     }
     out(
@@ -436,7 +488,11 @@ const tick = async (ctx) => {
         try {
           approve(pr, s.vim, s.headSha, ctx)
         } catch (e) {
+          // A failed merge (branch protection, perms, a moved head, a transient gh
+          // outage) is infra, not a fixer stall — flag it for the exit-2 path so the
+          // daemon retries without counting it toward pausing the PR.
           out(`           ✗ approve failed: ${e.message.split('\n')[0]}`)
+          approveError = true
         }
       } else {
         out(`           (report-only — pass --approve to auto-merge)`)
@@ -444,11 +500,24 @@ const tick = async (ctx) => {
     }
     out('')
   }
+  let fixerStall = false
   if (needsFix.length) {
     out(
       `Dispatching ${needsFix.length} fix run(s), up to ${ctx.maxParallel} in parallel…\n`
     )
-    await pool(needsFix, ctx.maxParallel, dispatchFix)
+    const codes = await pool(needsFix, ctx.maxParallel, dispatchFix)
+    fixerStall = codes.some((c) => c !== 0)
+  }
+  // Exit-code contract for the supervising daemon:
+  //   1 = a dispatched FIXER stalled (run.js non-zero) — the actionable signal it
+  //       counts toward pausing the PR (kimi can't drive these findings to zero).
+  //   2 = a TRANSIENT infra failure (classification / approve, no fixer stall) — the
+  //       daemon retries WITHOUT pausing, so a gh/GraphQL blip can't stick a PR.
+  // Fixer stall wins when both happen in one tick.
+  if (fixerStall) {
+    process.exitCode = 1
+  } else if (classifyError || approveError) {
+    process.exitCode = 2
   }
 }
 
@@ -471,10 +540,7 @@ const watch = async (ctx) => {
 
 // Read-only eligibility lister (lightweight).
 const scan = (ctx) => {
-  let prs = openPRs()
-  if (ctx.pr) {
-    prs = prs.filter((p) => p.number === ctx.pr)
-  }
+  const prs = candidatePRs(ctx.pr)
   if (!prs.length) {
     out('No open PRs.')
 
@@ -542,6 +608,10 @@ const main = () => {
 try {
   await main()
 } catch (e) {
+  // A throw reaching here is a top-level infra failure (repoSlug / targeted PR
+  // lookup / `gh api user`), NOT a dispatched-fixer stall — a fixer stall sets
+  // exitCode 1 inside tick and returns without throwing. Exit 2 (transient) so the
+  // daemon retries instead of counting it toward pausing a healthy PR.
   err(e.message)
-  process.exit(1)
+  process.exit(2)
 }


### PR DESCRIPTION
## QA Runner — deployable webhook daemon

The autonomous outer orchestrator for VIM-10: a long-running daemon (the **state owner**) that auto-reviews, fixes, and merges `auto-review` PRs. Deployable on any host with a public HTTPS endpoint.

### Architecture

```
GitHub → host.js (HMAC-verified receiver) → queue.js (persistent deduped queue)
       → daemon.js worker pool → worker.js runOne (ONE cycle/PR)
       → watch.js tick (review state machine) + run.js (single-pass kimi fixer)
       → daemon-state.js (persistent state) · events.js (pool + Linear milestones)
```

A fallback poll catches any missed webhook.

### Core correctness property

Every sub-path failure propagates, so the daemon never records a broken cycle as a clean "waiting" and loops forever:

- `watch.js` exit **1** = a dispatched fixer stalled → counts toward the `maxNoops` pause
- `watch.js` exit **2** = transient infra (classification / approve / `gh` outage) → retry, never pause
- `run.js` exits non-zero on kimi crash, no commit, or commit-without-push

### Security boundaries

- Webhook: HMAC-SHA256 over the **raw body**, `timingSafeEqual`, **fail-closed** (no secret ⇒ reject all)
- Comment triggers gated on the trusted **sender** (the actor), not the comment author
- `GET /status` Bearer-gated (no token ⇒ 404, so the public bind never leaks queue/PR state)
- Secrets env-only (`GITHUB_WEBHOOK_SECRET`, `QA_STATUS_TOKEN`) — never from JSON config

### Review

Scope-bounded `code-reviewer` pass (closing out the codex hardening loop): **0 critical · 1 high (fixed) · 0 medium/low**. All four security surfaces sound; the failure model verified end-to-end. Niche items (macOS PID-recycling, disk-full queue, a queue priority lane) parked as follow-ups.

### Deferred (code-only PR, by request)

- README deployment docs (env vars, webhook + TLS setup, REST API) — fast-follow once the wiring is in good shape
- No tests in this PR

Refs VIM-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
