### PR TITLE
fix(qa-runner): harden VIM-14 daemon rollout

### DIFF
--- a/scripts/qa-runner/README.md
+++ b/scripts/qa-runner/README.md
@@ -110,6 +110,18 @@ node scripts/qa-runner/run.js 317 --push   # live: commit/push as the fixer bot,
 - **v2 — a self-hosted GitHub Actions runner** on a small always-on box, triggered by
   `pull_request_review`: event-driven for free, full toolchain, your secrets.
 
+## Daemon rollout
+
+The webhook daemon is safe-by-default for the staged rollout:
+
+```bash
+GITHUB_WEBHOOK_SECRET=... QA_TRUSTED_SENDERS=you node scripts/qa-runner/daemon.js
+```
+
+It runs `watch.js tick --execute` for queued PRs. It does **not** pass
+`--approve` unless explicitly armed with `QA_APPROVE=1`, which belongs to the
+orchestrator-bot rung.
+
 ## Identity (`lib/bot-identity.js`)
 
 Two optional, gitignored env files — each a **separate GitHub account** so machine

--- a/scripts/qa-runner/config.example.json
+++ b/scripts/qa-runner/config.example.json
@@ -7,6 +7,7 @@
   "port": 8787,
   "maxParallel": 2,
   "maxNoops": 15,
+  "approve": false,
   "triggerPhrase": "/upsource-review",
   "trustedSenders": [],
   "comment": "Copy to config.json (gitignored) to override. SECRETS are env-only: GITHUB_WEBHOOK_SECRET (webhook HMAC), bot tokens in bot.env/orchestrator.env, Linear in linear.env. trustedSenders = GitHub logins allowed to trigger a fix via a PR comment; env QA_TRUSTED_SENDERS (comma-separated) overrides it."

--- a/scripts/qa-runner/daemon.js
+++ b/scripts/qa-runner/daemon.js
@@ -51,14 +51,14 @@ const worker = async (id) => {
         log,
         events,
       })
-      if (outcome === 'retry' && job.reason !== 'poll' && running) {
+      if (outcome === 'retry' && job.reason !== 'poll') {
         log(
           `worker ${id}: #${job.pr} transient retry in ${RETRY_BACKOFF_MS / 1000}s`
         )
-        await sleep(RETRY_BACKOFF_MS)
         if (running) {
-          queue.enqueue(job.pr, job.reason)
+          await sleep(RETRY_BACKOFF_MS)
         }
+        queue.enqueue(job.pr, job.reason)
       }
     } catch (e) {
       log(`worker ${id}: #${job.pr} ERROR ${e.message}`)

--- a/scripts/qa-runner/daemon.js
+++ b/scripts/qa-runner/daemon.js
@@ -17,12 +17,16 @@ import { createEvents } from './lib/events.js'
 
 const log = (s) => process.stdout.write(`${new Date().toISOString()} ${s}\n`)
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const DRAIN_POLL_MS = 1000
+const DRAIN_TIMEOUT_MS = 60000
+const RETRY_BACKOFF_MS = 15000
 
 const config = loadConfig()
 const state = createState()
 const queue = createQueue()
 const events = createEvents(log)
 let running = true
+let shuttingDown = false
 
 // One worker: claim a PR, run a single cycle, release, repeat. Live concurrency
 // is capped by the worker count (config.maxParallel).
@@ -47,8 +51,14 @@ const worker = async (id) => {
         log,
         events,
       })
-      if (outcome === 'retry' && job.reason !== 'poll') {
-        queue.enqueue(job.pr, job.reason)
+      if (outcome === 'retry' && job.reason !== 'poll' && running) {
+        log(
+          `worker ${id}: #${job.pr} transient retry in ${RETRY_BACKOFF_MS / 1000}s`
+        )
+        await sleep(RETRY_BACKOFF_MS)
+        if (running) {
+          queue.enqueue(job.pr, job.reason)
+        }
       }
     } catch (e) {
       log(`worker ${id}: #${job.pr} ERROR ${e.message}`)
@@ -125,13 +135,31 @@ poll()
 // Graceful-ish shutdown: stop accepting + claiming; let in-flight cycles finish
 // (state is checkpointed each tick); force-exit after a grace window.
 const shutdown = (sig) => {
-  log(`${sig} — draining; in-flight: ${queue.inFlight().join(', ') || 'none'}`)
+  if (shuttingDown) {
+    return
+  }
+  shuttingDown = true
   running = false
-  server.close(() => log('http server closed'))
+
+  const exitWhenDrained = () => {
+    const inFlight = queue.inFlight()
+    if (!inFlight.length) {
+      log('drain complete — exiting')
+      process.exit(0)
+    }
+    setTimeout(exitWhenDrained, DRAIN_POLL_MS)
+  }
+
+  log(`${sig} — draining; in-flight: ${queue.inFlight().join(', ') || 'none'}`)
+  server.close(() => {
+    log('http server closed')
+    exitWhenDrained()
+  })
+
   setTimeout(() => {
     log('drain window elapsed — exiting')
     process.exit(0)
-  }, 60000).unref()
+  }, DRAIN_TIMEOUT_MS)
 }
 
 process.on('SIGTERM', () => shutdown('SIGTERM'))

--- a/scripts/qa-runner/daemon.js
+++ b/scripts/qa-runner/daemon.js
@@ -151,9 +151,9 @@ const shutdown = (sig) => {
   }
 
   log(`${sig} — draining; in-flight: ${queue.inFlight().join(', ') || 'none'}`)
+  exitWhenDrained()
   server.close(() => {
     log('http server closed')
-    exitWhenDrained()
   })
 
   setTimeout(() => {

--- a/scripts/qa-runner/lib/config.js
+++ b/scripts/qa-runner/lib/config.js
@@ -32,6 +32,14 @@ const list = (v) =>
         .filter(Boolean)
     : []
 
+const bool = (v, d = false) => {
+  if (v == null || v === '') {
+    return d
+  }
+
+  return ['1', 'true', 'yes', 'on'].includes(String(v).toLowerCase())
+}
+
 // Merge the layers and coerce types. Called once at daemon start.
 export const loadConfig = () => {
   const file = {
@@ -48,6 +56,7 @@ export const loadConfig = () => {
     maxParallel: num(env.QA_MAX_PARALLEL, num(file.maxParallel, 2)),
     maxNoops: num(env.QA_MAX_NOOPS, num(file.maxNoops, 15)),
     pollSeconds: num(env.QA_POLL_SECONDS, num(file.pollSeconds, 60)),
+    approve: bool(env.QA_APPROVE, bool(file.approve)),
     triggerPhrase:
       env.QA_TRIGGER_PHRASE || file.triggerPhrase || '/upsource-review',
     trustedSenders: senders.length ? senders : file.trustedSenders || [],

--- a/scripts/qa-runner/lib/worker.js
+++ b/scripts/qa-runner/lib/worker.js
@@ -18,6 +18,14 @@ import { linkedVim } from './pr-utils.js'
 
 const WATCH = join(dirname(dirname(fileURLToPath(import.meta.url))), 'watch.js')
 
+const snapshotFailureText = (e) =>
+  [e?.stderr?.toString?.(), e?.stdout?.toString?.(), e?.message]
+    .filter(Boolean)
+    .join('\n')
+
+export const isMissingPullRequestSnapshot = (e) =>
+  /Could not resolve to a PullRequest/i.test(snapshotFailureText(e))
+
 const snapshot = (pr) => {
   try {
     const j = JSON.parse(
@@ -42,11 +50,14 @@ const snapshot = (pr) => {
       isDraft: Boolean(j.isDraft),
       labels: (j.labels || []).map((l) => l.name),
     }
-  } catch {
+  } catch (e) {
     // ok:false marks an UNKNOWN read (network / auth / rate-limit), distinct from a
     // real unlabeled/draft PR — the caller must not mutate state on an unknown.
+    // A GitHub "PullRequest not found" response for an untracked synthetic PR is
+    // permanent, so the smoke path can skip instead of hot-retrying forever.
     return {
       ok: false,
+      missing: isMissingPullRequestSnapshot(e),
       headSha: null,
       state: null,
       vim: undefined,
@@ -56,12 +67,21 @@ const snapshot = (pr) => {
   }
 }
 
-const tick = (pr, label) =>
+export const watchArgs = (pr, { label, approve = false } = {}) => {
+  const args = [WATCH, 'tick', '--pr', String(pr), '--execute']
+  if (approve) {
+    args.push('--approve')
+  }
+  if (label) {
+    args.push('--label', label)
+  }
+
+  return args
+}
+
+const tick = (pr, config) =>
   new Promise((resolve) => {
-    const args = [WATCH, 'tick', '--pr', String(pr), '--execute', '--approve']
-    if (label) {
-      args.push('--label', label)
-    }
+    const args = watchArgs(pr, config)
     const child = spawn('node', args, { stdio: 'inherit' })
     child.on('exit', (code) => resolve(code ?? -1))
     child.on('error', () => resolve(-1))
@@ -82,10 +102,17 @@ export const runOne = async (pr, reason, deps) => {
   const tracked = state.has(pr)
   const before = snapshot(pr)
 
-  // Unknown read (gh failed transiently): do NOT touch state — forgetting here would
-  // drop a tracked PR's round/noop counts and its later merged/closed milestone over a
-  // blip. Skip; the next poll/event re-snapshots.
+  // Missing untracked PR: a synthetic / stale webhook, not a transient. Do not
+  // requeue it; this is the local smoke's expected safe skip path.
   if (!before.ok) {
+    if (before.missing && !tracked) {
+      log(`#${pr}: PR not found — skip`)
+
+      return 'skip'
+    }
+    // Unknown read (gh failed transiently): do NOT touch state — forgetting here would
+    // drop a tracked PR's round/noop counts and its later merged/closed milestone over a
+    // blip. Skip; the next poll/event re-snapshots.
     log(`#${pr}: snapshot unavailable (transient) — retry, state preserved`)
 
     return 'retry'
@@ -136,7 +163,7 @@ export const runOne = async (pr, reason, deps) => {
   }
 
   events.emit({ type: 'cycle', pr, round: st.roundCount, detail: reason })
-  const code = await tick(pr, config.label)
+  const code = await tick(pr, config)
   const after = snapshot(pr)
 
   // Post-tick read failed (same rule as the pre-tick guard): never interpret null

--- a/scripts/qa-runner/lib/worker.js
+++ b/scripts/qa-runner/lib/worker.js
@@ -26,10 +26,10 @@ const snapshotFailureText = (e) =>
 export const isMissingPullRequestSnapshot = (e) =>
   /Could not resolve to a PullRequest/i.test(snapshotFailureText(e))
 
-const snapshot = (pr) => {
+const snapshot = (pr, exec = execFileSync) => {
   try {
     const j = JSON.parse(
-      execFileSync(
+      exec(
         'gh',
         [
           'pr',
@@ -87,9 +87,10 @@ const tick = (pr, config) =>
     child.on('error', () => resolve(-1))
   })
 
-// Run one cycle for `pr`. deps: { config, state, log, events, now? }. Async — the
-// heavy watch.js/kimi run is awaited, keeping the daemon responsive. Returns an
-// outcome tag: 'done' | 'progress' | 'error' | 'waiting' | 'paused' | 'skip' | 'retry'.
+// Run one cycle for `pr`. deps: { config, state, log, events, now?,
+// snapshotExec? }. Async — the heavy watch.js/kimi run is awaited, keeping the
+// daemon responsive. Returns an outcome tag:
+// 'done' | 'progress' | 'error' | 'waiting' | 'paused' | 'skip' | 'retry'.
 export const runOne = async (pr, reason, deps) => {
   const {
     config,
@@ -97,10 +98,11 @@ export const runOne = async (pr, reason, deps) => {
     log,
     events,
     now = () => new Date().toISOString(),
+    snapshotExec = execFileSync,
   } = deps
   const st = state.get(pr)
   const tracked = state.has(pr)
-  const before = snapshot(pr)
+  const before = snapshot(pr, snapshotExec)
 
   // Missing untracked PR: a synthetic / stale webhook, not a transient. Do not
   // requeue it; this is the local smoke's expected safe skip path.
@@ -164,7 +166,7 @@ export const runOne = async (pr, reason, deps) => {
 
   events.emit({ type: 'cycle', pr, round: st.roundCount, detail: reason })
   const code = await tick(pr, config)
-  const after = snapshot(pr)
+  const after = snapshot(pr, snapshotExec)
 
   // Post-tick read failed (same rule as the pre-tick guard): never interpret null
   // state/head — that would log a real push/merge as a null-head 'waiting' or miss a

--- a/scripts/qa-runner/lib/worker.test.js
+++ b/scripts/qa-runner/lib/worker.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest'
+import { isMissingPullRequestSnapshot, watchArgs } from './worker.js'
+
+describe('isMissingPullRequestSnapshot', () => {
+  test('identifies GitHub PR-not-found snapshot failures', () => {
+    expect(
+      isMissingPullRequestSnapshot({
+        stderr: Buffer.from(
+          'GraphQL: Could not resolve to a PullRequest with the number of 999999.'
+        ),
+      })
+    ).toBe(true)
+  })
+
+  test('does not classify generic command failures as missing PRs', () => {
+    expect(
+      isMissingPullRequestSnapshot({
+        stderr: Buffer.from('gh: network unavailable'),
+        message: 'Command failed: gh pr view 123',
+      })
+    ).toBe(false)
+  })
+})
+
+describe('watchArgs', () => {
+  test('runs fix cycles without approve by default', () => {
+    expect(watchArgs(123, { label: 'auto-review' })).toContain('--execute')
+    expect(watchArgs(123, { label: 'auto-review' })).not.toContain('--approve')
+  })
+
+  test('adds approve only when armed', () => {
+    expect(watchArgs(123, { label: 'auto-review', approve: true })).toContain(
+      '--approve'
+    )
+  })
+})

--- a/scripts/qa-runner/lib/worker.test.js
+++ b/scripts/qa-runner/lib/worker.test.js
@@ -1,5 +1,32 @@
-import { describe, expect, test } from 'vitest'
-import { isMissingPullRequestSnapshot, watchArgs } from './worker.js'
+import { describe, expect, test, vi } from 'vitest'
+import { isMissingPullRequestSnapshot, runOne, watchArgs } from './worker.js'
+
+const makeDeps = (overrides = {}) => ({
+  config: { label: 'auto-review', maxNoops: 3 },
+  state: {
+    get: vi.fn(() => ({
+      roundCount: 0,
+      noopCount: 0,
+      lastHeadSha: null,
+      pausedAt: null,
+    })),
+    has: vi.fn(() => false),
+    forget: vi.fn(),
+    update: vi.fn(),
+  },
+  log: vi.fn(),
+  events: { emit: vi.fn() },
+  now: () => '2024-01-01T00:00:00.000Z',
+  ...overrides,
+})
+
+const missingPrSnapshotExec = (pr) => () => {
+  const err = new Error(`Command failed: gh pr view ${pr}`)
+  err.stderr = Buffer.from(
+    `GraphQL: Could not resolve to a PullRequest with the number of ${pr}.`
+  )
+  throw err
+}
 
 describe('isMissingPullRequestSnapshot', () => {
   test('identifies GitHub PR-not-found snapshot failures', () => {
@@ -31,6 +58,47 @@ describe('watchArgs', () => {
   test('adds approve only when armed', () => {
     expect(watchArgs(123, { label: 'auto-review', approve: true })).toContain(
       '--approve'
+    )
+  })
+})
+
+describe('runOne', () => {
+  test('skips untracked PR when snapshot reports missing', async () => {
+    const deps = makeDeps({
+      snapshotExec: missingPrSnapshotExec(999),
+      state: {
+        has: vi.fn(() => false),
+        get: vi.fn(() => ({})),
+        forget: vi.fn(),
+        update: vi.fn(),
+      },
+    })
+    const outcome = await runOne(999, 'comment', deps)
+
+    expect(outcome).toBe('skip')
+    expect(deps.log).toHaveBeenCalledWith('#999: PR not found — skip')
+  })
+
+  test('retries tracked PR when snapshot reports missing', async () => {
+    const deps = makeDeps({
+      snapshotExec: missingPrSnapshotExec(42),
+      state: {
+        has: vi.fn(() => true),
+        get: vi.fn(() => ({
+          roundCount: 1,
+          noopCount: 0,
+          lastHeadSha: 'abc',
+          pausedAt: null,
+        })),
+        forget: vi.fn(),
+        update: vi.fn(),
+      },
+    })
+    const outcome = await runOne(42, 'comment', deps)
+
+    expect(outcome).toBe('retry')
+    expect(deps.log).toHaveBeenCalledWith(
+      '#42: snapshot unavailable (transient) — retry, state preserved'
     )
   })
 })


### PR DESCRIPTION
## Summary
- keep the daemon no-approve by default for Rung 2
- classify untracked PR-not-found snapshots as safe skips
- back off transient retries and exit cleanly on idle shutdown

Linear: VIM-14

## Verification
- npx vitest run scripts/qa-runner/lib/worker.test.js
- npx eslint scripts/qa-runner/daemon.js scripts/qa-runner/lib/config.js scripts/qa-runner/lib/worker.js scripts/qa-runner/lib/worker.test.js
- npx prettier --check scripts/qa-runner/daemon.js scripts/qa-runner/lib/config.js scripts/qa-runner/lib/worker.js scripts/qa-runner/lib/worker.test.js scripts/qa-runner/config.example.json scripts/qa-runner/README.md
- npm test (pre-push hook; 231 files, 3050 tests passed, 3 skipped)
- local fake-gh daemon smoke for Rung 1