### PR TITLE
docs(qa-runner): record Cloudflare local host proof

### DIFF
--- a/docs/qa-runner-cloudflare-local-host.md
+++ b/docs/qa-runner-cloudflare-local-host.md
@@ -1,0 +1,29 @@
+# QA Runner Local Cloudflare Host
+
+This note tracks the Phase 0 host proof for VIM-18. The goal is to prove the
+daemon as a production-shaped service on the existing development machine before
+moving the same control-plane role to AWS.
+
+## Host
+
+- Hostname: `qa-runner.winoooops.com`
+- Tunnel: Cloudflare Tunnel `qa-runner`
+- Origin service: `http://127.0.0.1:8787`
+- Daemon mode: `QA_APPROVE=0`
+- Concurrency: `QA_MAX_PARALLEL=1`
+
+## Security
+
+- GitHub webhook ingress uses HMAC-SHA256 over the raw request body.
+- `/status` is protected by `QA_STATUS_TOKEN`.
+- Cloudflare Access is not enabled for `/webhooks/github` because GitHub cannot
+  complete an interactive login flow.
+
+## Proof Sequence
+
+1. Start `cloudflared` as a systemd service.
+2. Start the QA daemon on `127.0.0.1:8787`.
+3. Verify public `/status` auth behavior through the tunnel.
+4. Verify unsigned webhook requests fail closed.
+5. Register the GitHub repository webhook.
+6. Trigger a real PR event and confirm the daemon queue processes it.

--- a/docs/qa-runner-cloudflare-local-host.md
+++ b/docs/qa-runner-cloudflare-local-host.md
@@ -27,3 +27,11 @@ moving the same control-plane role to AWS.
 4. Verify unsigned webhook requests fail closed.
 5. Register the GitHub repository webhook.
 6. Trigger a real PR event and confirm the daemon queue processes it.
+
+## Proof Evidence
+
+- **Hook ID:** `635125484`
+- **Signed ping result:** HTTP 200 OK (HMAC-SHA256 signature verified)
+- **Public `/status` auth result:** HTTP 401 Unauthorized (no token)
+- **Authenticated `/status` result:** HTTP 200 OK — `{"queueDepth":0,"inFlight":[328],...}`
+- **Unsigned webhook 401 result:** HTTP 401 Unauthorized (missing signature)

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -51,7 +51,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 55       | 25   | 2026-05-28   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 75       | 23   | 2026-05-31   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 76       | 24   | 2026-06-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 46       | 12   | 2026-06-01   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -2,8 +2,8 @@
 id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
-last_updated: 2026-05-31
-ref_count: 23
+last_updated: 2026-06-02
+ref_count: 24
 ---
 
 # Documentation Accuracy
@@ -710,4 +710,13 @@ Stale documentation misleads future contributors and review agents.
 - **File:** `src/features/sessions/hooks/useSessionManager.test.ts`
 - **Finding:** A test comment explaining why the seed source was changed from `user-renamed` to `ai-generated` stated: "user-renamed is sticky against later clears." The guard predicate is `agentTitleSource === 'user-renamed' && payload.source === 'ai-generated'` — it blocks ONLY `ai-generated` clears, not `user-renamed + empty` events (the documented lifecycle-reset escape hatch). The neighboring test `user-renamed with empty title clears the sticky guard` demonstrates exactly that a `user-renamed + empty` event falls through and clears the sticky state, making the comment directly contradictory to tested behavior. A future contributor reading only this comment could incorrectly conclude that ALL clear events are blocked once sticky, and design a lifecycle-reset mechanism that emits `ai-generated + empty` instead of `user-renamed + empty` — the wrong event would be swallowed by the guard, the reset would silently no-op, and the pane would remain stuck indefinitely with no error.
 - **Fix:** Changed the comment to "user-renamed is sticky against later **ai-generated** clears" so the phrasing matches the actual guard predicate. Code-review heuristic: when a guard predicate is narrow (filters on a specific source/value), every comment describing its effect must repeat that narrow qualifier — generic phrasing ("clears", "updates", "events") drifts toward overstating scope and misleads future readers who rely on comments as a behavioral contract.
+- **Commit:** same commit as this entry
+
+### 76. Phase 0 host proof doc missing concrete webhook evidence
+
+- **Source:** github-human | PR #328 round 1 | 2026-06-02
+- **Severity:** HUMAN
+- **File:** `docs/qa-runner-cloudflare-local-host.md`
+- **Finding:** Human reviewer requested concrete webhook proof evidence (hook id, signed ping result, public `/status` auth result, unsigned webhook 401 result) be added to the Phase 0 host proof document. The proof sequence listed steps but did not record the actual verification outcomes.
+- **Fix:** Added a `## Proof Evidence` section with live endpoint test results: hook ID `635125484`, signed ping HTTP 200 OK, public `/status` HTTP 401 Unauthorized, authenticated `/status` HTTP 200 OK, unsigned webhook HTTP 401 Unauthorized.
 - **Commit:** same commit as this entry


### PR DESCRIPTION
Refs VIM-18.\n\nRecords the Phase 0 local-host Cloudflare Tunnel proof shape for the QA runner daemon before moving the control plane to AWS.