### PR TITLE
fix(qa-runner): use Linear app credentials for role comments

### DIFF
--- a/docs/explorations/linear-setup-runbook.md
+++ b/docs/explorations/linear-setup-runbook.md
@@ -30,7 +30,18 @@ All Linear facts verified against live docs on 2026-05-30; cost target = **free 
 
 ## Phase 4 — direct API access (optional, non-agent only) 🧑
 
-10. 🧑 Only for git hooks / CI that aren't agents and aren't tied to a PR. Create a personal API key → `Settings → Security & access → Personal API keys`; copy `linear.env.example` → `linear.env` (repo root, gitignored), fill `LINEAR_API_KEY`, then `source linear.env`. The MCP server uses OAuth and does **not** use this key. Details: `rules/common/linear-workflow.md`.
+10. 🧑 For the QA runner role bots, create two Linear OAuth apps:
+    - **Kimi Review Runner** → copy `linear-agent.env.example` to `linear-agent.env`.
+    - **Vimeflow Orchestrator** → copy `linear-orchestrator.env.example` to `linear-orchestrator.env`.
+11. 🧑 In each app, enable **Client credentials**, grant access to the VIM team, and store `LINEAR_CLIENT_ID`, `LINEAR_CLIENT_SECRET`, and `LINEAR_SCOPES=read,write` in the matching gitignored env file.
+12. 🤖 Smoke test each role:
+
+```bash
+node scripts/qa-runner/lib/linear-status.js VIM-18 "fixer Linear app smoke" --as fixer
+node scripts/qa-runner/lib/linear-status.js VIM-18 "orchestrator Linear app smoke" --as orchestrator
+```
+
+13. 🧑 Only for git hooks / CI that are not role bots and are not tied to a PR. Create a personal API key → `Settings → Security & access → Personal API keys`; copy `linear.env.example` → `linear.env` (repo root, gitignored), fill `LINEAR_API_KEY`, then `source linear.env`. The MCP server uses OAuth and does **not** use this key. Details: `rules/common/linear-workflow.md`.
 
 ## Later — full delegation (Path C)
 

--- a/linear-agent.env.example
+++ b/linear-agent.env.example
@@ -1,0 +1,16 @@
+# Linear app credentials for the QA runner fixer role.
+# Copy to linear-agent.env at the repo root (gitignored). Do not commit secrets.
+#
+# Linear app setup:
+# 1. Use the Kimi Review Runner Linear OAuth app.
+# 2. Enable Client credentials.
+# 3. Give the app access to the VIM team.
+# 4. Keep scopes narrow; read/write is enough for issue comments + status moves.
+LINEAR_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+LINEAR_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+LINEAR_SCOPES=read,write
+
+# Optional compatibility fallback for an existing OAuth access token.
+# Client credentials are preferred because they are app-actor, daemon-friendly,
+# and can be re-minted by the helper.
+# LINEAR_ACCESS_TOKEN=lin_oauth_xxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/linear-orchestrator.env.example
+++ b/linear-orchestrator.env.example
@@ -1,0 +1,17 @@
+# Linear app credentials for the QA runner orchestrator role.
+# Copy to linear-orchestrator.env at the repo root (gitignored). Do not commit
+# secrets.
+#
+# Linear app setup:
+# 1. Use the Vimeflow Orchestrator Linear OAuth app.
+# 2. Enable Client credentials.
+# 3. Give the app access to the VIM team.
+# 4. Keep scopes narrow; read/write is enough for issue comments + status moves.
+LINEAR_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+LINEAR_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+LINEAR_SCOPES=read,write
+
+# Optional compatibility fallback for an existing OAuth access token.
+# Client credentials are preferred because they are app-actor, daemon-friendly,
+# and can be re-minted by the helper.
+# LINEAR_ACCESS_TOKEN=lin_oauth_xxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/rules/common/linear-workflow.md
+++ b/rules/common/linear-workflow.md
@@ -4,11 +4,12 @@ Issue tracking for this repo lives in **Linear** (team **Vimeflow**, key `VIM`).
 
 ## How status moves
 
-| Context                                            | Mechanism                      | Notes                                                           |
-| -------------------------------------------------- | ------------------------------ | --------------------------------------------------------------- |
-| An agent (Claude Code / Codex) acting in a session | **Linear MCP server**          | Read/create/update issues, projects, comments. Auth via OAuth.  |
-| A pull request                                     | **GitHub ↔ Linear automation** | PR open → In Progress, merge → Done. PR is linked on the issue. |
-| A script / git hook / CI step (non-agent, non-PR)  | **GraphQL API + personal key** | `api.linear.app/graphql`; key in `linear.env`. MCP ignores it.  |
+| Context                                            | Mechanism                                       | Notes                                                                                                           |
+| -------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| An agent (Claude Code / Codex) acting in a session | **Linear MCP server**                           | Read/create/update issues, projects, comments. Auth via OAuth.                                                  |
+| A pull request                                     | **GitHub ↔ Linear automation**                  | PR open → In Progress, merge → Done. PR is linked on the issue.                                                 |
+| QA runner role bots (`fixer`, `orchestrator`)      | **GraphQL API + Linear app client credentials** | App credentials in `linear-agent.env` / `linear-orchestrator.env`; comments are attributed to the matching app. |
+| A script / git hook / CI step (non-agent, non-PR)  | **GraphQL API + personal key**                  | `api.linear.app/graphql`; key in `linear.env`. MCP ignores it.                                                  |
 
 ## Agent access (MCP) — the default
 
@@ -35,6 +36,12 @@ Reference the Linear issue in the PR so status flows automatically:
 
 The Linear MCP uses OAuth and does **not** use a personal key — this path is only for non-agent automation.
 
+- For the QA runner, prefer role-specific Linear OAuth apps:
+  - `linear-agent.env` for the fixer app.
+  - `linear-orchestrator.env` for the orchestrator app.
+  - Enable **Client credentials** in each Linear app.
+  - Store `LINEAR_CLIENT_ID`, `LINEAR_CLIENT_SECRET`, and `LINEAR_SCOPES=read,write`.
+  - `scripts/qa-runner/lib/linear-status.js --as fixer|orchestrator` mints an app-actor token at runtime and posts as that app.
 - Create a key: `Linear → Settings → Security & access → Personal API keys`.
 - Copy `linear.env.example` → `linear.env` (repo root, gitignored), fill `LINEAR_API_KEY`, then `source linear.env`. The `export` propagates the key to child processes.
 - Call `https://api.linear.app/graphql` with `Authorization: $LINEAR_API_KEY`. Use curl `--fail-with-body` (keep error bodies) **and** check the response `errors[]` array — GraphQL returns errors with HTTP 200.
@@ -43,6 +50,6 @@ The Linear MCP uses OAuth and does **not** use a personal key — this path is o
 
 - **Team / key:** Vimeflow / `VIM`; issues are `VIM-<n>`.
 - **Statuses:** Backlog → Todo → In Progress → In Review → Done; `Canceled` / `Duplicate` for dropped work (map GitHub `wontfix` → Canceled, `duplicate` → a Duplicate relation).
-- **Never commit a real key** — `linear.env` is gitignored; only `linear.env.example` (placeholder) is tracked.
+- **Never commit a real key** — `linear.env` and `linear-*.env` are gitignored; only `*.env.example` placeholders are tracked.
 
 Background, cost analysis, and migration steps live in `docs/explorations/linear-migration-analysis.html` + `docs/explorations/linear-setup-runbook.md`.

--- a/scripts/qa-runner/README.md
+++ b/scripts/qa-runner/README.md
@@ -21,9 +21,10 @@ Design + rationale: [`docs/explorations/linear-agent-cicd-pilot.html`](../../doc
                  ▼
  ③ Linear  — control plane / observability. Each state transition mirrors to the
     linked issue (a `VIM-N` in the PR body). The native GitHub↔Linear sync moves
-    the issue → Done on merge; the watcher's own posts use the `linear.env` API key
-    (headless ⇒ scoped API key, not interactive MCP — see
-    rules/common/linear-workflow.md) and no-op gracefully when no key is set.
+    the issue → Done on merge; the watcher's own posts use role-specific Linear
+    app credentials (`linear-agent.env` / `linear-orchestrator.env`) so comments
+    are attributed to the fixer or orchestrator app. Personal `linear.env` remains
+    a fallback for non-role scripts only.
 ```
 
 **Two bot identities** so the bot that writes a fix is never the bot that approves
@@ -122,7 +123,9 @@ It runs `watch.js tick --execute` for queued PRs. It does **not** pass
 `--approve` unless explicitly armed with `QA_APPROVE=1`, which belongs to the
 orchestrator-bot rung.
 
-## Identity (`lib/bot-identity.js`)
+## Identity
+
+### GitHub (`lib/bot-identity.js`)
 
 Two optional, gitignored env files — each a **separate GitHub account** so machine
 actions are attributable and split by role. Either absent ⇒ that role acts as your
@@ -138,6 +141,22 @@ Each = a classic PAT (`repo` scope) on a Write-collaborator account; see the
 `*.example` files. The identity flows through three points: API actor (`GH_TOKEN`),
 commit author (`GIT_AUTHOR_*`), and HTTPS push (the `gh` credential helper).
 
+### Linear (`lib/linear-status.js`)
+
+Two optional, gitignored env files — each a **separate Linear OAuth app** with
+Client credentials enabled. `linear-status.js --as fixer|orchestrator` mints an
+app-actor token on demand, so issue comments show the bot app identity in Linear.
+
+| File                      | Keys                                       | Role                   | Used by                       |
+| ------------------------- | ------------------------------------------ | ---------------------- | ----------------------------- |
+| `linear-agent.env`        | `LINEAR_CLIENT_ID`, `LINEAR_CLIENT_SECRET` | inner **fixer**        | `run.js` status posts         |
+| `linear-orchestrator.env` | `LINEAR_CLIENT_ID`, `LINEAR_CLIENT_SECRET` | outer **orchestrator** | `watch.js` status/merge posts |
+
+Use `LINEAR_SCOPES=read,write`. `LINEAR_ACCESS_TOKEN` / `LINEAR_AGENT_TOKEN` are
+kept only as compatibility fallbacks for existing OAuth tokens; client credentials
+are preferred for the daemon because the helper can re-mint app tokens without an
+interactive login.
+
 ## Guardrails
 
 - **Opt-in only** (`auto-review` label) — narrow blast radius for the pilot.
@@ -148,4 +167,5 @@ commit author (`GIT_AUTHOR_*`), and HTTPS push (the `gh` credential helper).
 - **author ≠ approver** — the fixer bot never merges its own work; the orchestrator does.
 - Branch deletion on merge is a **remote API ref-delete**, not `gh --delete-branch`
   (whose local delete fails when a worktree holds the branch).
-- Linear status via the **scoped API key**; never echo untrusted review text into a shell.
+- Linear status via role-specific **app credentials**; never echo untrusted review
+  text into a shell.

--- a/scripts/qa-runner/lib/linear-status.js
+++ b/scripts/qa-runner/lib/linear-status.js
@@ -3,18 +3,21 @@
 // issue via the GraphQL API. Headless ⇒ no interactive MCP (see
 // rules/common/linear-workflow.md).
 //
-// Auth is role-aware: `--as fixer|orchestrator` posts as that role's Linear AGENT
-// (OAuth token from linear-agent.env / linear-orchestrator.env → "Bearer …"), so
-// comments carry the agent's identity, not yours. Without a linked agent it falls
-// back to the personal LINEAR_API_KEY ($env or repo-root linear.env).
+// Auth is role-aware: `--as fixer|orchestrator` posts as that role's Linear app
+// (client credentials from linear-agent.env / linear-orchestrator.env -> app
+// actor token), so comments carry the bot identity, not yours. A stored OAuth
+// access token is kept as a compatibility fallback; without either, it falls back
+// to the personal LINEAR_API_KEY ($env or repo-root linear.env).
 //
 // Usage: node linear-status.js <VIM-N> "<comment>" [--state "<name>"] [--as <role>]
 
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 const API = 'https://api.linear.app/graphql'
+const TOKEN_API = 'https://api.linear.app/oauth/token'
 
 // Repo root (shared across linked worktrees via --git-common-dir) — where the
 // gitignored Linear env files live.
@@ -27,37 +30,102 @@ const repoRoot = () =>
     ).trim()
   )
 
-// Pull a single KEY=value from a dotenv-style file, or undefined.
-const readEnvVar = (file, key) => {
+const isRealSecret = (value) => value && !/PASTE|xxxx/i.test(value)
+
+export const readEnvFile = (file) => {
+  const env = {}
   if (!existsSync(file)) {
-    return undefined
+    return env
   }
 
-  const m = readFileSync(file, 'utf8').match(
-    new RegExp(`^\\s*(?:export\\s+)?${key}\\s*=\\s*(.+?)\\s*$`, 'm')
-  )
+  for (const line of readFileSync(file, 'utf8').split(/\r?\n/)) {
+    const m = line.match(
+      /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/
+    )
+    if (!m) {
+      continue
+    }
 
-  return m ? m[1].replace(/^["']|["']$/g, '') : undefined
+    const [, key, rawValue] = m
+    env[key] = rawValue.replace(/^["']|["']$/g, '')
+  }
+
+  return env
 }
 
-// Each role's Linear AGENT (OAuth) token lives in its own gitignored env file.
+// Each role's Linear app credentials live in a separate gitignored env file.
 const ROLE_FILE = {
   fixer: 'linear-agent.env',
   orchestrator: 'linear-orchestrator.env',
 }
 
-// Authorization for a role: prefer that role's AGENT token (Bearer, posts as the
-// agent), else the personal key (raw header, posts as you). Returns { header, who }.
-const loadAuth = (role) => {
-  const root = repoRoot()
+const readEnvVar = (file, key) => readEnvFile(file)[key]
+
+const roleFile = (root, role) => {
+  const file = ROLE_FILE[role]
+  if (!file) {
+    throw new Error(`unknown --as role "${role}" (fixer|orchestrator)`)
+  }
+
+  return join(root, file)
+}
+
+const mintClientCredentialsAuth = async (role, env, fetchImpl) => {
+  if (
+    !isRealSecret(env.LINEAR_CLIENT_ID) ||
+    !isRealSecret(env.LINEAR_CLIENT_SECRET)
+  ) {
+    return null
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    scope: env.LINEAR_SCOPES || 'read,write',
+    client_id: env.LINEAR_CLIENT_ID,
+    client_secret: env.LINEAR_CLIENT_SECRET,
+  })
+
+  const res = await fetchImpl(TOKEN_API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  const json = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    const reason = json.error_description || json.error || `HTTP ${res.status}`
+    throw new Error(`Linear ${role} client_credentials failed: ${reason}`)
+  }
+  if (!json.access_token) {
+    throw new Error(
+      `Linear ${role} client_credentials returned no access_token`
+    )
+  }
+
+  return { header: `Bearer ${json.access_token}`, who: `${role} app` }
+}
+
+// Authorization for a role: prefer role app client credentials (Bearer, posts as
+// the app), then a stored role access token, else the personal key (raw header,
+// posts as you). Returns { header, who }.
+export const loadAuthFromRoot = async (role, root, fetchImpl = fetch) => {
   if (role) {
-    const file = ROLE_FILE[role]
-    if (!file) {
-      throw new Error(`unknown --as role "${role}" (fixer|orchestrator)`)
+    const env = readEnvFile(roleFile(root, role))
+    let clientCredentialsError
+    try {
+      const auth = await mintClientCredentialsAuth(role, env, fetchImpl)
+      if (auth) {
+        return auth
+      }
+    } catch (e) {
+      clientCredentialsError = e
     }
-    const tok = readEnvVar(join(root, file), 'LINEAR_AGENT_TOKEN')
-    if (tok && !/PASTE|xxxx/i.test(tok)) {
-      return { header: `Bearer ${tok}`, who: `${role} agent` }
+
+    const tok = env.LINEAR_ACCESS_TOKEN || env.LINEAR_AGENT_TOKEN
+    if (isRealSecret(tok)) {
+      return { header: `Bearer ${tok}`, who: `${role} access token` }
+    }
+    if (clientCredentialsError) {
+      throw clientCredentialsError
     }
   }
 
@@ -68,9 +136,11 @@ const loadAuth = (role) => {
     return { header: key, who: 'you (personal key)' }
   }
   throw new Error(
-    'no Linear auth — link the agent (LINEAR_AGENT_TOKEN) or set LINEAR_API_KEY (env or repo-root linear.env). See rules/common/linear-workflow.md'
+    'no Linear auth — configure role client credentials, set LINEAR_ACCESS_TOKEN / LINEAR_AGENT_TOKEN, or set LINEAR_API_KEY (env or repo-root linear.env). See rules/common/linear-workflow.md'
   )
 }
+
+const loadAuth = (role) => loadAuthFromRoot(role, repoRoot())
 
 const gql = async (auth, query, variables) => {
   const res = await fetch(API, {
@@ -88,7 +158,7 @@ const gql = async (auth, query, variables) => {
   return json.data
 }
 
-const main = async () => {
+export const main = async () => {
   const [identifier, body, ...rest] = process.argv.slice(2)
   if (!identifier || !body) {
     throw new Error(
@@ -97,7 +167,7 @@ const main = async () => {
   }
   const flag = (n) => (rest.includes(n) ? rest[rest.indexOf(n) + 1] : undefined)
   const stateName = flag('--state')
-  const auth = loadAuth(flag('--as'))
+  const auth = await loadAuth(flag('--as'))
 
   const d = await gql(
     auth.header,
@@ -137,9 +207,14 @@ const main = async () => {
   }
 }
 
-try {
-  await main()
-} catch (e) {
-  process.stderr.write(`${e.message}\n`)
-  process.exit(1)
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    await main()
+  } catch (e) {
+    process.stderr.write(`${e.message}\n`)
+    process.exit(1)
+  }
 }

--- a/scripts/qa-runner/lib/linear-status.test.js
+++ b/scripts/qa-runner/lib/linear-status.test.js
@@ -1,0 +1,122 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { loadAuthFromRoot } from './linear-status.js'
+
+const tempRoots = []
+const originalLinearApiKey = process.env.LINEAR_API_KEY
+
+const makeRoot = () => {
+  const root = mkdtempSync(join(tmpdir(), 'linear-status-'))
+  tempRoots.push(root)
+
+  return root
+}
+
+const writeEnv = (root, file, body) => {
+  writeFileSync(join(root, file), body)
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+  if (originalLinearApiKey == null) {
+    delete process.env.LINEAR_API_KEY
+  } else {
+    process.env.LINEAR_API_KEY = originalLinearApiKey
+  }
+})
+
+describe('loadAuthFromRoot', () => {
+  test('mints a role app token from client credentials', async () => {
+    const root = makeRoot()
+    writeEnv(
+      root,
+      'linear-agent.env',
+      [
+        'LINEAR_CLIENT_ID=client-id',
+        'LINEAR_CLIENT_SECRET=client-secret',
+        'LINEAR_SCOPES=read,write',
+      ].join('\n')
+    )
+
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ access_token: 'app-token' }),
+    }))
+
+    const auth = await loadAuthFromRoot('fixer', root, fetchImpl)
+
+    expect(auth).toEqual({
+      header: 'Bearer app-token',
+      who: 'fixer app',
+    })
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.linear.app/oauth/token',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      })
+    )
+
+    expect(String(fetchImpl.mock.calls[0][1].body)).toContain(
+      'grant_type=client_credentials'
+    )
+  })
+
+  test('keeps the stored role access token fallback', async () => {
+    const root = makeRoot()
+    writeEnv(root, 'linear-orchestrator.env', 'LINEAR_ACCESS_TOKEN=oauth-token')
+    const fetchImpl = vi.fn()
+
+    await expect(
+      loadAuthFromRoot('orchestrator', root, fetchImpl)
+    ).resolves.toEqual({
+      header: 'Bearer oauth-token',
+      who: 'orchestrator access token',
+    })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  test('falls back to stored role access token when client credentials fail', async () => {
+    const root = makeRoot()
+    writeEnv(
+      root,
+      'linear-orchestrator.env',
+      [
+        'LINEAR_CLIENT_ID=client-id',
+        'LINEAR_CLIENT_SECRET=client-secret',
+        'LINEAR_ACCESS_TOKEN=oauth-token',
+      ].join('\n')
+    )
+
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        error_description:
+          'Client does not support the client_credentials grant type',
+      }),
+    }))
+
+    await expect(
+      loadAuthFromRoot('orchestrator', root, fetchImpl)
+    ).resolves.toEqual({
+      header: 'Bearer oauth-token',
+      who: 'orchestrator access token',
+    })
+  })
+
+  test('falls back to a personal api key outside role app auth', async () => {
+    const root = makeRoot()
+    process.env.LINEAR_API_KEY = 'lin_api_test'
+
+    await expect(loadAuthFromRoot(undefined, root, vi.fn())).resolves.toEqual({
+      header: 'lin_api_test',
+      who: 'you (personal key)',
+    })
+  })
+})


### PR DESCRIPTION
Refs VIM-18.

## Summary

- Prefer Linear app client-credentials auth for QA runner role comments.
- Keep stored role access tokens and personal Linear API keys as compatibility fallbacks.
- Add role env examples for `linear-agent.env` and `linear-orchestrator.env`.
- Document the two identity layers: GitHub bot accounts for commits/reviews, Linear apps for issue comments/status.

## Validation

- `npx eslint scripts/qa-runner/lib/linear-status.js scripts/qa-runner/lib/linear-status.test.js`
- `npx vitest run scripts/qa-runner/lib/linear-status.test.js scripts/qa-runner/lib/worker.test.js`
- `git diff --check`

## Notes

Live smoke during VIM-18 proved both app identities can post to Linear via client credentials: fixer as Kimi Review Runner and orchestrator as Vimeflow Orchestrator.