### PR TITLE
feat(qa-runner): format Linear observability comments

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -53,7 +53,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 76       | 24   | 2026-06-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
-| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 46       | 12   | 2026-06-01   |
+| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 49       | 13   | 2026-06-02   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                   | security           | 7        | 3    | 2026-05-02   |
 | [Credential Leakage](patterns/credential-leakage.md)                 | security           | 1        | 0    | 2026-05-31   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -53,7 +53,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 76       | 24   | 2026-06-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
-| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 49       | 13   | 2026-06-02   |
+| [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 50       | 14   | 2026-06-02   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                   | security           | 7        | 3    | 2026-05-02   |
 | [Credential Leakage](patterns/credential-leakage.md)                 | security           | 1        | 0    | 2026-05-31   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -3,7 +3,7 @@ id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-02
-ref_count: 13
+ref_count: 14
 ---
 
 # Async Race Conditions
@@ -483,4 +483,13 @@ prevent showing previous data.
 - **File:** `scripts/qa-runner/watch.js`
 - **Finding:** When `--linear-decisions` is used without `--execute`, a `NEEDS_FIX` PR still passes `--state In Progress` to `linear-status.js` even though the tick is report-only and no fixer is dispatched. This makes Linear show active work for a PR the runner explicitly did not start.
 - **Fix:** Narrowed `stateName` assignment to only set `'In Progress'` when `s.state === 'NEEDS_FIX'` AND `action === 'dispatch fixer'`, preventing Linear state changes on report-only ticks.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 50. Default parameter on markDecisionPosted reverts per-PR store safety
+
+- **Source:** github-claude | PR #330 round 1 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/lib/decision-comment.js`
+- **Finding:** After round 1 switched decision storage to per-PR files (`decisionStorePath(pr.number)`), `markDecisionPosted` and `readDecisionStore` retained `file = DEFAULT_DECISION_STORE` as their default parameter. Every current call site passes an explicit path, so no regression exists today. A future caller that omits the argument — or a maintenance edit that drops the fourth parameter — silently reverts to the shared global store, reintroducing the concurrent-read-modify-write race the per-PR redesign eliminated.
+- **Fix:** Removed the `DEFAULT_DECISION_STORE` default from both functions, making the per-PR path a required argument. Call sites in `watch.js` and tests already pass explicit paths, so the change is non-breaking.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,8 +2,8 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-01
-ref_count: 12
+last_updated: 2026-06-02
+ref_count: 13
 ---
 
 # Async Race Conditions
@@ -456,4 +456,31 @@ prevent showing previous data.
 - **File:** `scripts/qa-runner/run.js`
 - **Finding:** `r.timedOut` triggered `die(msg, 6)` before the live HEAD check ran. A commit landing in the final ~15 s poll window was undetected; the worktree HEAD had advanced past `startHead`, yet `run.js` exited 6 claiming "no commit". `watch.js` classified this as a fixer stall, incrementing `noopCount`. The stranded local commit was never pushed, so the daemon's next remote-HEAD comparison still saw no progress and did not reset the counter, leading to false pausing after `maxNoops` consecutive misclassifications.
 - **Fix:** Before dying on `timedOut`, check `sh('git', ['-C', wt, 'rev-parse', 'HEAD']).trim() !== startHead`. If a commit is present, fall through to the push-verification block instead of exiting 6.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 47. Non-atomic store read-modify-write breaks dedup under parallel ticks
+
+- **Source:** github-claude | PR #330 round 1 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `maybePostDecisionLinear` reads the full store, checks its PR's entry, then writes the full store back. With `maxParallel > 1` the daemon spawns multiple concurrent `watch.js tick --pr N` processes. Two processes for different PRs can interleave: both read `{}`, A writes `{ '317': 'key-A' }`, B writes `{ '318': 'key-B' }` — A's entry is silently lost.
+- **Fix:** Changed `maybePostDecisionLinear` to use per-PR decision store files via `decisionStorePath(pr.number)`, so each concurrent tick only touches its own file, eliminating the race entirely.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 48. Merge store updates before writing decision state
+
+- **Source:** github-codex-connector | PR #330 round 1 | 2026-06-02
+- **Severity:** P2
+- **File:** `scripts/qa-runner/lib/decision-comment.js`
+- **Finding:** With the daemon's default `maxParallel=2`, separate `watch.js tick --pr ...` processes can read the decision store concurrently and then each write a full JSON object based on its stale snapshot. If two different PRs post decisions at the same time, the later write drops the earlier PR's key.
+- **Fix:** Added `decisionStorePath(pr)` to generate per-PR store paths. `watch.js` now passes the per-PR path to `readDecisionStore` and `markDecisionPosted`, so concurrent ticks for different PRs no longer contend on the same file.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 49. Move Linear only when execute is armed
+
+- **Source:** github-codex-connector | PR #330 round 1 | 2026-06-02
+- **Severity:** P2
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** When `--linear-decisions` is used without `--execute`, a `NEEDS_FIX` PR still passes `--state In Progress` to `linear-status.js` even though the tick is report-only and no fixer is dispatched. This makes Linear show active work for a PR the runner explicitly did not start.
+- **Fix:** Narrowed `stateName` assignment to only set `'In Progress'` when `s.state === 'NEEDS_FIX'` AND `action === 'dispatch fixer'`, preventing Linear state changes on report-only ticks.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/diagnostic-instrumentation.md
+++ b/docs/reviews/patterns/diagnostic-instrumentation.md
@@ -2,8 +2,8 @@
 id: diagnostic-instrumentation
 category: code-quality
 created: 2026-04-30
-last_updated: 2026-04-30
-ref_count: 2
+last_updated: 2026-06-02
+ref_count: 3
 ---
 
 # Diagnostic Instrumentation
@@ -98,3 +98,21 @@ The discipline:
 - **Finding:** `spawn_trailing_debounce_thread` calls `std::thread::spawn(...)` and discards the returned `JoinHandle`. In production the emit closure only calls `emit_for_all_subscribers`, which logs errors rather than panicking, so the swallowed-panic path is unreachable. In tests, however, the closure was `move || { emitted_tx.send(()).expect("failed to record debounce emit"); }` — and if the receiver dropped first (test cleanup ordering races), `.expect` would panic inside the detached thread. The panic was invisible: the next test assertion (`recv_timeout(...).expect("debounce should emit")`) would fire instead, attributing the failure to "no emit" when the real cause was "the emit closure panicked." Same finding-class as #5 (structurally-zero `dt` produces misleading log values) — both are diagnostics that point an investigator at the wrong cause.
 - **Fix:** Tests now use `let _ = emitted_tx.send(())` instead of `.expect(...)`, swallowing send errors so the detached thread can never panic. The positive `recv_timeout(...).expect("debounce should emit")` assertion remains the canonical failure signal, with no false-attribution interference from the worker thread. Returning the `JoinHandle` and exposing it for tests was considered but rejected: the fire-and-forget API is the right shape for production callers, and `catch_unwind` machinery would be heavy for the low-risk scenario.
 - **Commit:** _(see git log for the round-2 fix commit)_
+
+### 8. Missing sentinel for unqueried thread count produces false "zero unresolved" in Linear comments
+
+- **Source:** github-claude | PR #330 round 1 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `computeState` skips the `unresolvedThreads` GraphQL call when CI is failing or still pending (CI_RED / WAITING states). The early-return path hardcodes `threads: 0`, which `formatDecisionComment` renders as `- Unresolved threads: 0`. An operator reading the Linear comment could dismiss thread backlog as a root cause because the comment explicitly says threads are clear, when in fact they were never queried.
+- **Fix:** Changed the early-return sentinel from `threads: 0` to `threads: null`. `formatDecisionComment` already uses `${threads ?? 'unknown'}`, so the unqueried path now renders honestly as "unknown".
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 9. Markdown inline-code inconsistency in SHA helper degrades comment formatting
+
+- **Source:** github-claude | PR #330 round 1 | 2026-06-02
+- **Severity:** LOW
+- **File:** `scripts/qa-runner/lib/decision-comment.js`
+- **Finding:** `shortSha` returns `` `abc1234` `` for a truthy SHA but the plain string `'unknown'` for a falsy one. Both `formatDecisionComment` and `formatFixerCycleComment` use the helper for the Head table row, producing inconsistent Markdown formatting: `| Head | unknown |` (plain text) versus `| Head | \`1b5cb1a\` |` (inline code).
+- **Fix:** Changed the falsy branch to return `` `unknown` `` so both branches produce inline-code spans.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/scripts/qa-runner/README.md
+++ b/scripts/qa-runner/README.md
@@ -90,6 +90,8 @@ node scripts/qa-runner/watch.js tick --execute            # NEEDS_FIX  → run u
 node scripts/qa-runner/watch.js tick --execute --max 3    # …up to 3 at once
 node scripts/qa-runner/watch.js tick --approve            # GOOD_SHAPE → squash-merge
 node scripts/qa-runner/watch.js tick --execute --approve  # full autonomy
+node scripts/qa-runner/watch.js tick --pr 317 --linear-decisions --reason manual-debug
+                                                          # post one deduped Linear decision comment
 
 # loop forever (Ctrl-C to stop)
 node scripts/qa-runner/watch.js watch --execute --approve
@@ -122,6 +124,17 @@ GITHUB_WEBHOOK_SECRET=... QA_TRUSTED_SENDERS=you node scripts/qa-runner/daemon.j
 It runs `watch.js tick --execute` for queued PRs. It does **not** pass
 `--approve` unless explicitly armed with `QA_APPROVE=1`, which belongs to the
 orchestrator-bot rung.
+
+By default the daemon also passes `--linear-decisions --reason <event>` into each
+tick. The watcher posts one structured, deduped Linear decision comment per PR
+head/state/action combination, so operators can see why a signal became
+`WAITING`, `NEEDS_FIX`, `CI_RED`, or `GOOD_SHAPE` without reading local logs.
+Decision comments can be disabled with `QA_LINEAR_DECISION_COMMENTS=0` or
+`linearDecisionComments: false` in `config.json`.
+
+When the fixer completes a live `/lifeline:upsource-review` cycle, `run.js` posts
+a structured fixer comment with the PR, branch, pushed head, Kimi exit, stop mode,
+and worktree cleanliness.
 
 ## Identity
 

--- a/scripts/qa-runner/config.example.json
+++ b/scripts/qa-runner/config.example.json
@@ -8,7 +8,8 @@
   "maxParallel": 2,
   "maxNoops": 15,
   "approve": false,
+  "linearDecisionComments": true,
   "triggerPhrase": "/upsource-review",
   "trustedSenders": [],
-  "comment": "Copy to config.json (gitignored) to override. SECRETS are env-only: GITHUB_WEBHOOK_SECRET (webhook HMAC), bot tokens in bot.env/orchestrator.env, Linear in linear.env. trustedSenders = GitHub logins allowed to trigger a fix via a PR comment; env QA_TRUSTED_SENDERS (comma-separated) overrides it."
+  "comment": "Copy to config.json (gitignored) to override. SECRETS are env-only: GITHUB_WEBHOOK_SECRET (webhook HMAC), bot tokens in bot.env/orchestrator.env, Linear in linear*.env. trustedSenders = GitHub logins allowed to trigger a fix via a PR comment; env QA_TRUSTED_SENDERS (comma-separated) overrides it. linearDecisionComments posts deduped Linear comments explaining each state-machine decision."
 }

--- a/scripts/qa-runner/daemon.js
+++ b/scripts/qa-runner/daemon.js
@@ -115,7 +115,7 @@ server.listen(config.port, config.host, () => {
   )
 
   log(
-    `config: label=${config.label} maxParallel=${config.maxParallel} maxNoops=${config.maxNoops} pollSeconds=${config.pollSeconds} trusted=[${config.trustedSenders.join(',')}]`
+    `config: label=${config.label} maxParallel=${config.maxParallel} maxNoops=${config.maxNoops} pollSeconds=${config.pollSeconds} linearDecisionComments=${config.linearDecisionComments} trusted=[${config.trustedSenders.join(',')}]`
   )
   if (!config.webhookSecret) {
     log(

--- a/scripts/qa-runner/lib/config.js
+++ b/scripts/qa-runner/lib/config.js
@@ -57,6 +57,10 @@ export const loadConfig = () => {
     maxNoops: num(env.QA_MAX_NOOPS, num(file.maxNoops, 15)),
     pollSeconds: num(env.QA_POLL_SECONDS, num(file.pollSeconds, 60)),
     approve: bool(env.QA_APPROVE, bool(file.approve)),
+    linearDecisionComments: bool(
+      env.QA_LINEAR_DECISION_COMMENTS,
+      bool(file.linearDecisionComments, true)
+    ),
     triggerPhrase:
       env.QA_TRIGGER_PHRASE || file.triggerPhrase || '/upsource-review',
     trustedSenders: senders.length ? senders : file.trustedSenders || [],

--- a/scripts/qa-runner/lib/decision-comment.js
+++ b/scripts/qa-runner/lib/decision-comment.js
@@ -156,12 +156,7 @@ export const readDecisionStore = (file) => {
 
 export const shouldPostDecision = (store, pr, key) => store[String(pr)] !== key
 
-export const markDecisionPosted = (
-  store,
-  pr,
-  key,
-  file
-) => {
+export const markDecisionPosted = (store, pr, key, file) => {
   const next = { ...store, [String(pr)]: key }
   mkdirSync(dirname(file), { recursive: true })
   writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`)

--- a/scripts/qa-runner/lib/decision-comment.js
+++ b/scripts/qa-runner/lib/decision-comment.js
@@ -1,0 +1,167 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const QA_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
+const STATE_DIR = join(QA_DIR, '.state')
+
+export const DEFAULT_DECISION_STORE = join(STATE_DIR, 'decision-comments.json')
+
+const tableValue = (value) =>
+  String(value ?? 'unknown')
+    .replace(/\r?\n/g, ' ')
+    .replace(/\|/g, '\\|')
+
+const shortSha = (sha) => (sha ? `\`${sha.slice(0, 7)}\`` : 'unknown')
+
+export const actionForDecision = (state, { approve, execute } = {}) => {
+  if (state === 'NEEDS_FIX') {
+    return execute ? 'dispatch fixer' : 'none'
+  }
+  if (state === 'GOOD_SHAPE') {
+    return approve ? 'approve/merge' : 'none'
+  }
+
+  return 'none'
+}
+
+export const explainDecision = (state, action) => {
+  if (state === 'NEEDS_FIX') {
+    return action === 'dispatch fixer'
+      ? 'Review findings require a fixer cycle and execute is armed.'
+      : 'Review findings require a fixer cycle, but execute is not armed.'
+  }
+  if (state === 'GOOD_SHAPE') {
+    return action === 'approve/merge'
+      ? 'PR meets success criteria and approve is armed.'
+      : 'PR meets success criteria, but approve is not armed.'
+  }
+  if (state === 'CI_RED') {
+    return 'Non-review CI is failing or canceled, so the fixer is not dispatched.'
+  }
+  if (state === 'WAITING') {
+    return 'The runner is waiting for CI, review, mergeability, or a new event.'
+  }
+
+  return 'No action was selected for this state.'
+}
+
+export const decisionKey = ({
+  pr,
+  state,
+  detail,
+  headSha,
+  action,
+  approve,
+  execute,
+}) =>
+  [
+    pr,
+    headSha || 'unknown-head',
+    state,
+    detail,
+    action,
+    approve ? 'approve' : 'no-approve',
+    execute ? 'execute' : 'no-execute',
+  ].join('|')
+
+export const formatDecisionComment = ({
+  pr,
+  branch,
+  state,
+  detail,
+  sourceEvent,
+  action,
+  approve,
+  execute,
+  headSha,
+  ci,
+  claude,
+  threads,
+  mergeable,
+  mergeStateStatus,
+}) => {
+  const lines = [
+    `## QA runner decision: ${state}`,
+    '',
+    '| Field | Value |',
+    '| --- | --- |',
+    `| PR | #${tableValue(pr)} |`,
+    `| Branch | \`${tableValue(branch)}\` |`,
+    `| Source event | \`${tableValue(sourceEvent || 'manual')}\` |`,
+    `| Decision | \`${tableValue(state)}\` |`,
+    `| Detail | ${tableValue(detail)} |`,
+    `| Action | ${tableValue(action)} |`,
+    `| Execute armed | ${execute ? 'true' : 'false'} |`,
+    `| Approve armed | ${approve ? 'true' : 'false'} |`,
+    `| Head | ${shortSha(headSha)} |`,
+    '',
+    'Checks:',
+    `- CI: ${ci ?? 'unknown'}`,
+    `- Claude: ${claude ?? 'unknown'}`,
+    `- Unresolved threads: ${threads ?? 'unknown'}`,
+    `- Mergeable: ${mergeable ?? 'unknown'}${
+      mergeStateStatus ? ` (${mergeStateStatus})` : ''
+    }`,
+    '',
+    `Reason: ${explainDecision(state, action)}`,
+  ]
+
+  return lines.join('\n')
+}
+
+export const formatFixerCycleComment = ({
+  pr,
+  url,
+  branch,
+  headSha,
+  result = 'fix pushed',
+  kimiExit,
+  stopMode,
+  worktreeClean,
+}) => {
+  const lines = [
+    '## QA fixer cycle: complete',
+    '',
+    '| Field | Value |',
+    '| --- | --- |',
+    `| PR | #${tableValue(pr)} |`,
+    `| URL | ${tableValue(url)} |`,
+    `| Branch | \`${tableValue(branch)}\` |`,
+    `| Result | ${tableValue(result)} |`,
+    `| Head | ${shortSha(headSha)} |`,
+    `| Kimi exit | \`${tableValue(kimiExit)}\` |`,
+    `| Stop mode | ${tableValue(stopMode)} |`,
+    `| Worktree | ${worktreeClean ? 'clean' : 'dirty after run'} |`,
+    '',
+    'Action: pushed one `/lifeline:upsource-review` fixer cycle; re-review is pending.',
+  ]
+
+  return lines.join('\n')
+}
+
+export const readDecisionStore = (file = DEFAULT_DECISION_STORE) => {
+  if (!existsSync(file)) {
+    return {}
+  }
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+export const shouldPostDecision = (store, pr, key) => store[String(pr)] !== key
+
+export const markDecisionPosted = (
+  store,
+  pr,
+  key,
+  file = DEFAULT_DECISION_STORE
+) => {
+  const next = { ...store, [String(pr)]: key }
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`)
+
+  return next
+}

--- a/scripts/qa-runner/lib/decision-comment.js
+++ b/scripts/qa-runner/lib/decision-comment.js
@@ -15,7 +15,7 @@ const tableValue = (value) =>
     .replace(/\r?\n/g, ' ')
     .replace(/\|/g, '\\|')
 
-const shortSha = (sha) => (sha ? `\`${sha.slice(0, 7)}\`` : 'unknown')
+const shortSha = (sha) => (sha ? `\`${sha.slice(0, 7)}\`` : '`unknown`')
 
 export const actionForDecision = (state, { approve, execute } = {}) => {
   if (state === 'NEEDS_FIX') {
@@ -143,7 +143,7 @@ export const formatFixerCycleComment = ({
   return lines.join('\n')
 }
 
-export const readDecisionStore = (file = DEFAULT_DECISION_STORE) => {
+export const readDecisionStore = (file) => {
   if (!existsSync(file)) {
     return {}
   }
@@ -160,7 +160,7 @@ export const markDecisionPosted = (
   store,
   pr,
   key,
-  file = DEFAULT_DECISION_STORE
+  file
 ) => {
   const next = { ...store, [String(pr)]: key }
   mkdirSync(dirname(file), { recursive: true })

--- a/scripts/qa-runner/lib/decision-comment.js
+++ b/scripts/qa-runner/lib/decision-comment.js
@@ -7,6 +7,9 @@ const STATE_DIR = join(QA_DIR, '.state')
 
 export const DEFAULT_DECISION_STORE = join(STATE_DIR, 'decision-comments.json')
 
+export const decisionStorePath = (pr) =>
+  join(STATE_DIR, `decision-pr-${pr}.json`)
+
 const tableValue = (value) =>
   String(value ?? 'unknown')
     .replace(/\r?\n/g, ' ')

--- a/scripts/qa-runner/lib/decision-comment.test.js
+++ b/scripts/qa-runner/lib/decision-comment.test.js
@@ -1,0 +1,126 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  actionForDecision,
+  decisionKey,
+  formatDecisionComment,
+  formatFixerCycleComment,
+  markDecisionPosted,
+  readDecisionStore,
+  shouldPostDecision,
+} from './decision-comment.js'
+
+const tempRoots = []
+
+const makeStore = () => {
+  const root = mkdtempSync(join(tmpdir(), 'decision-comment-'))
+  tempRoots.push(root)
+
+  return join(root, 'decision-comments.json')
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+describe('actionForDecision', () => {
+  test('selects fixer dispatch only when NEEDS_FIX and execute is armed', () => {
+    expect(actionForDecision('NEEDS_FIX', { execute: true })).toBe(
+      'dispatch fixer'
+    )
+    expect(actionForDecision('NEEDS_FIX', { execute: false })).toBe('none')
+  })
+
+  test('selects merge only when GOOD_SHAPE and approve is armed', () => {
+    expect(actionForDecision('GOOD_SHAPE', { approve: true })).toBe(
+      'approve/merge'
+    )
+    expect(actionForDecision('GOOD_SHAPE', { approve: false })).toBe('none')
+  })
+})
+
+describe('formatDecisionComment', () => {
+  test('formats a structured GOOD_SHAPE decision', () => {
+    const body = formatDecisionComment({
+      pr: 329,
+      branch: 'codex/linear-bot-identity',
+      state: 'GOOD_SHAPE',
+      detail: '0 threads | Claude clean',
+      sourceEvent: 'pr:ready_for_review',
+      action: 'none',
+      approve: false,
+      execute: true,
+      headSha: 'd892dded2b3faefb70ff87b19238cc82e58877fb',
+      ci: 'green',
+      claude: 'clean',
+      threads: 0,
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'CLEAN',
+    })
+
+    expect(body).toContain('## QA runner decision: GOOD_SHAPE')
+    expect(body).toContain('| PR | #329 |')
+    expect(body).toContain('| Source event | `pr:ready_for_review` |')
+    expect(body).toContain('| Detail | 0 threads \\| Claude clean |')
+    expect(body).toContain('- CI: green')
+    expect(body).toContain(
+      'Reason: PR meets success criteria, but approve is not armed.'
+    )
+  })
+})
+
+describe('formatFixerCycleComment', () => {
+  test('formats a structured fixer completion comment', () => {
+    const body = formatFixerCycleComment({
+      pr: 328,
+      url: 'https://github.com/winoooops/vimeflow/pull/328',
+      branch: 'feature/vim-18',
+      headSha: '1b5cb1a2b3faefb70ff87b19238cc82e58877fb',
+      result: 'fix pushed | review pending',
+      kimiExit: 'signal SIGTERM',
+      stopMode: 'single-pass stop',
+      worktreeClean: true,
+    })
+
+    expect(body).toContain('## QA fixer cycle: complete')
+    expect(body).toContain('| PR | #328 |')
+    expect(body).toContain(
+      '| URL | https://github.com/winoooops/vimeflow/pull/328 |'
+    )
+    expect(body).toContain('| Branch | `feature/vim-18` |')
+    expect(body).toContain('| Result | fix pushed \\| review pending |')
+    expect(body).toContain('| Head | `1b5cb1a` |')
+    expect(body).toContain('| Kimi exit | `signal SIGTERM` |')
+    expect(body).toContain('| Stop mode | single-pass stop |')
+    expect(body).toContain('| Worktree | clean |')
+    expect(body).toContain('re-review is pending')
+  })
+})
+
+describe('decision store', () => {
+  test('dedupes repeated decisions for a PR', () => {
+    const file = makeStore()
+
+    const key = decisionKey({
+      pr: 329,
+      state: 'GOOD_SHAPE',
+      detail: 'clean',
+      headSha: 'abc',
+      action: 'none',
+      approve: false,
+      execute: true,
+    })
+    const empty = readDecisionStore(file)
+
+    expect(shouldPostDecision(empty, 329, key)).toBe(true)
+
+    const updated = markDecisionPosted(empty, 329, key, file)
+
+    expect(shouldPostDecision(updated, 329, key)).toBe(false)
+    expect(shouldPostDecision(readDecisionStore(file), 329, key)).toBe(false)
+  })
+})

--- a/scripts/qa-runner/lib/worker.js
+++ b/scripts/qa-runner/lib/worker.js
@@ -67,10 +67,19 @@ const snapshot = (pr, exec = execFileSync) => {
   }
 }
 
-export const watchArgs = (pr, { label, approve = false } = {}) => {
+export const watchArgs = (
+  pr,
+  { label, approve = false, linearDecisionComments = false, reason } = {}
+) => {
   const args = [WATCH, 'tick', '--pr', String(pr), '--execute']
   if (approve) {
     args.push('--approve')
+  }
+  if (linearDecisionComments) {
+    args.push('--linear-decisions')
+  }
+  if (reason) {
+    args.push('--reason', reason)
   }
   if (label) {
     args.push('--label', label)
@@ -79,9 +88,9 @@ export const watchArgs = (pr, { label, approve = false } = {}) => {
   return args
 }
 
-const tick = (pr, config) =>
+const tick = (pr, config, reason) =>
   new Promise((resolve) => {
-    const args = watchArgs(pr, config)
+    const args = watchArgs(pr, { ...config, reason })
     const child = spawn('node', args, { stdio: 'inherit' })
     child.on('exit', (code) => resolve(code ?? -1))
     child.on('error', () => resolve(-1))
@@ -165,7 +174,7 @@ export const runOne = async (pr, reason, deps) => {
   }
 
   events.emit({ type: 'cycle', pr, round: st.roundCount, detail: reason })
-  const code = await tick(pr, config)
+  const code = await tick(pr, config, reason)
   const after = snapshot(pr, snapshotExec)
 
   // Post-tick read failed (same rule as the pre-tick guard): never interpret null

--- a/scripts/qa-runner/lib/worker.test.js
+++ b/scripts/qa-runner/lib/worker.test.js
@@ -60,6 +60,27 @@ describe('watchArgs', () => {
       '--approve'
     )
   })
+
+  test('adds Linear decision observability flags when configured', () => {
+    expect(
+      watchArgs(123, {
+        label: 'auto-review',
+        linearDecisionComments: true,
+        reason: 'pr:ready_for_review',
+      })
+    ).toEqual([
+      expect.stringContaining('watch.js'),
+      'tick',
+      '--pr',
+      '123',
+      '--execute',
+      '--linear-decisions',
+      '--reason',
+      'pr:ready_for_review',
+      '--label',
+      'auto-review',
+    ])
+  })
 })
 
 describe('runOne', () => {

--- a/scripts/qa-runner/run.js
+++ b/scripts/qa-runner/run.js
@@ -30,6 +30,7 @@ import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { botEnv, botLabel, loadBot } from './lib/bot-identity.js'
+import { formatFixerCycleComment } from './lib/decision-comment.js'
 import { linkedVim } from './lib/pr-utils.js'
 import { runUntilChange } from './lib/run-until-change.js'
 
@@ -292,6 +293,7 @@ const run = async (pr, live) => {
     //   2. Committed but the push never landed (bad credentials, non-fast-forward,
     //      killed mid-push) — the probe is the LOCAL HEAD, so grace tripped on the
     //      commit; origin/<branch> stays behind, so the daemon sees an unchanged remote.
+    let pushedHead = null
     if (live) {
       const head = sh('git', ['-C', wt, 'rev-parse', 'HEAD']).trim()
       if (head === startHead) {
@@ -309,23 +311,48 @@ const run = async (pr, live) => {
           8
         )
       }
+      pushedHead = head
     }
     out('')
     out(
       `kimi exit: ${r.status ?? `signal ${r.signal}`}${r.killed ? ' (single-pass stop)' : ''}`
     )
     out('--- worktree changes ---')
-    out(sh('git', ['-C', wt, 'status', '--short']) || '(none)')
+    const worktreeStatus = sh('git', ['-C', wt, 'status', '--short']).trim()
+    out(worktreeStatus || '(none)')
     // r.killed (single-pass stop) is also success — every failure mode die()'d above.
     if (live && (r.status === 0 || r.killed)) {
       const vim = linkedVim(info.body)
       if (vim) {
+        const kimiExit =
+          r.status === null || r.status === undefined
+            ? r.signal
+              ? `signal ${r.signal}`
+              : 'unknown'
+            : String(r.status)
+
+        const stopMode = r.timedOut
+          ? 'timeout stop'
+          : r.killed
+            ? 'single-pass stop'
+            : 'process exit'
+
+        const body = formatFixerCycleComment({
+          pr,
+          url: info.url,
+          branch,
+          headSha: pushedHead,
+          kimiExit,
+          stopMode,
+          worktreeClean: !worktreeStatus,
+        })
+
         spawnSync(
           'node',
           [
             join(SCRIPT_DIR, 'lib', 'linear-status.js'),
             vim,
-            `QA runner: ran an upsource-review cycle on PR #${pr} (${info.url}).`,
+            body,
             '--as',
             'fixer',
           ],

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -298,7 +298,7 @@ const computeState = (pr, ctx) => {
     state,
     detail,
     vim,
-    threads: 0,
+    threads: null,
     headSha: view.headRefOid,
     ci,
     claude,

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -33,6 +33,7 @@ import { botLabel, botProcessEnv, loadBot } from './lib/bot-identity.js'
 import {
   actionForDecision,
   decisionKey,
+  decisionStorePath,
   formatDecisionComment,
   markDecisionPosted,
   readDecisionStore,
@@ -353,7 +354,8 @@ const maybePostDecisionLinear = (pr, s, ctx) => {
     approve: ctx.approve,
     execute: ctx.execute,
   })
-  const store = readDecisionStore()
+  const storeFile = decisionStorePath(pr.number)
+  const store = readDecisionStore(storeFile)
   if (!shouldPostDecision(store, pr.number, key)) {
     out(`           ↳ Linear ${s.vim}: decision unchanged`)
 
@@ -377,9 +379,12 @@ const maybePostDecisionLinear = (pr, s, ctx) => {
     mergeStateStatus: s.mergeStateStatus,
   })
 
-  const stateName = s.state === 'NEEDS_FIX' ? 'In Progress' : undefined
+  const stateName =
+    s.state === 'NEEDS_FIX' && action === 'dispatch fixer'
+      ? 'In Progress'
+      : undefined
   if (postLinear(s.vim, body, stateName)) {
-    markDecisionPosted(store, pr.number, key)
+    markDecisionPosted(store, pr.number, key, storeFile)
   }
 }
 

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -30,6 +30,14 @@ import {
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { botLabel, botProcessEnv, loadBot } from './lib/bot-identity.js'
+import {
+  actionForDecision,
+  decisionKey,
+  formatDecisionComment,
+  markDecisionPosted,
+  readDecisionStore,
+  shouldPostDecision,
+} from './lib/decision-comment.js'
 import { linkedVim } from './lib/pr-utils.js'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
@@ -229,6 +237,9 @@ const computeState = (pr, ctx) => {
       : 'green'
   const claudeCheck = checks.find((c) => c.name === 'Claude Code Review')
   const claudeReady = claudeCheck?.bucket === 'pass'
+  let claude = claudeReady
+    ? 'review check passed'
+    : (claudeCheck?.bucket ?? 'missing')
 
   const view = ghJson([
     'pr',
@@ -250,6 +261,8 @@ const computeState = (pr, ctx) => {
     } else {
       // verdict is irrelevant until threads are clear — defer the fetch to here
       const verdict = claudeVerdictClean(ctx.owner, ctx.name, pr.number) // null|true|false
+      claude =
+        verdict === true ? 'clean' : verdict === false ? 'issues' : 'no verdict'
       if (verdict === false) {
         ;[state, detail] = ['NEEDS_FIX', 'Claude verdict: patch has issues']
       } else if (verdict === null) {
@@ -267,15 +280,35 @@ const computeState = (pr, ctx) => {
       }
     }
 
-    return { state, detail, vim, threads, headSha: view.headRefOid }
+    return {
+      state,
+      detail,
+      vim,
+      threads,
+      headSha: view.headRefOid,
+      ci,
+      claude,
+      mergeable: view.mergeable,
+      mergeStateStatus: view.mergeStateStatus,
+    }
   }
 
-  return { state, detail, vim, threads: 0, headSha: view.headRefOid }
+  return {
+    state,
+    detail,
+    vim,
+    threads: 0,
+    headSha: view.headRefOid,
+    ci,
+    claude,
+    mergeable: view.mergeable,
+    mergeStateStatus: view.mergeStateStatus,
+  }
 }
 
 const postLinear = (vim, body, stateName) => {
   if (!vim) {
-    return
+    return false
   }
 
   const args = [
@@ -293,10 +326,60 @@ const postLinear = (vim, body, stateName) => {
     out(
       `           ↳ Linear ${vim}${stateName ? ` → ${stateName}` : ''}: commented`
     )
+
+    return true
   } else {
     out(
       `           ↳ Linear ${vim}: skipped (${(r.stderr || '').trim().split('\n')[0] || 'no LINEAR_API_KEY'})`
     )
+
+    return false
+  }
+}
+
+const maybePostDecisionLinear = (pr, s, ctx) => {
+  if (!ctx.linearDecisions || !s.vim) {
+    return
+  }
+
+  const action = actionForDecision(s.state, ctx)
+
+  const key = decisionKey({
+    pr: pr.number,
+    state: s.state,
+    detail: s.detail,
+    headSha: s.headSha,
+    action,
+    approve: ctx.approve,
+    execute: ctx.execute,
+  })
+  const store = readDecisionStore()
+  if (!shouldPostDecision(store, pr.number, key)) {
+    out(`           ↳ Linear ${s.vim}: decision unchanged`)
+
+    return
+  }
+
+  const body = formatDecisionComment({
+    pr: pr.number,
+    branch: pr.headRefName,
+    state: s.state,
+    detail: s.detail,
+    sourceEvent: ctx.reason,
+    action,
+    approve: ctx.approve,
+    execute: ctx.execute,
+    headSha: s.headSha,
+    ci: s.ci,
+    claude: s.claude,
+    threads: s.threads,
+    mergeable: s.mergeable,
+    mergeStateStatus: s.mergeStateStatus,
+  })
+
+  const stateName = s.state === 'NEEDS_FIX' ? 'In Progress' : undefined
+  if (postLinear(s.vim, body, stateName)) {
+    markDecisionPosted(store, pr.number, key)
   }
 }
 
@@ -483,13 +566,9 @@ const tick = async (ctx) => {
       `${s.state.padEnd(10)} #${pr.number}  ${pr.headRefName}${s.vim ? `  (${s.vim})` : ''}`
     )
     out(`           ${s.detail}`)
+    maybePostDecisionLinear(pr, s, ctx)
     if (s.state === 'NEEDS_FIX') {
       if (ctx.execute) {
-        postLinear(
-          s.vim,
-          `QA runner: review findings on PR #${pr.number} — ${s.detail}. Running an upsource cycle.`,
-          'In Progress'
-        )
         needsFix.push(pr.number)
       } else {
         out(`           (report-only — pass --execute to run the cycle)`)
@@ -600,6 +679,8 @@ const main = () => {
     label: val('label') || DEFAULT_LABEL,
     approve: has('approve'),
     execute: has('execute'),
+    linearDecisions: has('linear-decisions'),
+    reason: val('reason') || 'manual',
     all: has('all'),
     pr: val('pr') ? Number(val('pr')) : undefined,
     maxParallel: Number(val('max')) || MAX_PARALLEL,
@@ -616,7 +697,7 @@ const main = () => {
     return watch(ctx)
   }
   err(
-    `unknown command: ${cmd}. Use: scan | tick | watch  [--pr N] [--approve] [--execute] [--all] [--max N] [--label NAME]`
+    `unknown command: ${cmd}. Use: scan | tick | watch  [--pr N] [--approve] [--execute] [--linear-decisions] [--reason EVENT] [--all] [--max N] [--label NAME]`
   )
   process.exit(1)
 }


### PR DESCRIPTION
## Summary

- Add structured Linear decision comments for eligible QA runner state-machine ticks.
- Pass the daemon event reason into watcher ticks and dedupe decision comments by PR/head/state/action.
- Replace the fixer runner's terse Linear completion note with a formatted safe-metadata summary.

## Linear

VIM-18

## Validation

- `npx prettier --write scripts/qa-runner/lib/decision-comment.js scripts/qa-runner/lib/decision-comment.test.js scripts/qa-runner/run.js scripts/qa-runner/README.md`
- `npx eslint scripts/qa-runner/lib/decision-comment.js scripts/qa-runner/lib/decision-comment.test.js scripts/qa-runner/run.js scripts/qa-runner/lib/worker.js scripts/qa-runner/lib/worker.test.js scripts/qa-runner/watch.js scripts/qa-runner/daemon.js scripts/qa-runner/lib/config.js`
- `npx vitest run scripts/qa-runner/lib/decision-comment.test.js scripts/qa-runner/lib/worker.test.js scripts/qa-runner/lib/linear-status.test.js`
- `git diff --check`