### PR TITLE
feat(qa-runner): expand CI failure orchestration

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,6 +63,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CSP Configuration](patterns/csp-configuration.md)                   | security           | 8        | 5    | 2026-05-16   |
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
+| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 2        | 0    | 2026-06-02   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
 | [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 40       | 9    | 2026-06-02   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Credential Leakage](patterns/credential-leakage.md)                 | security           | 1        | 0    | 2026-05-31   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)             | security           | 15       | 2    | 2026-04-20   |
 | [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                   | security           | 3        | 1    | 2026-04-20   |
-| [Preflight Checks](patterns/preflight-checks.md)                     | error-handling     | 3        | 0    | 2026-05-31   |
+| [Preflight Checks](patterns/preflight-checks.md)                     | error-handling     | 4        | 0    | 2026-06-02   |
 | [CSP Configuration](patterns/csp-configuration.md)                   | security           | 8        | 5    | 2026-05-16   |
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,9 +63,9 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CSP Configuration](patterns/csp-configuration.md)                   | security           | 8        | 5    | 2026-05-16   |
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
-| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 7        | 1    | 2026-06-02   |
+| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 9        | 2    | 2026-06-02   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
-| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 40       | 9    | 2026-06-02   |
+| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 41       | 10   | 2026-06-02   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 7        | 2    | 2026-05-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,7 +63,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CSP Configuration](patterns/csp-configuration.md)                   | security           | 8        | 5    | 2026-05-16   |
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
-| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 5        | 0    | 2026-06-02   |
+| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 7        | 1    | 2026-06-02   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
 | [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 40       | 9    | 2026-06-02   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -49,7 +49,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 4        | 3    | 2026-05-07   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality       | 5        | 0    | 2026-05-09   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 55       | 25   | 2026-05-28   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 56       | 26   | 2026-06-02   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 76       | 24   | 2026-06-02   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |
@@ -64,7 +64,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
-| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 38       | 8    | 2026-06-01   |
+| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 40       | 9    | 2026-06-02   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 7        | 2    | 2026-05-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,7 +63,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CSP Configuration](patterns/csp-configuration.md)                   | security           | 8        | 5    | 2026-05-16   |
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
-| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 2        | 0    | 2026-06-02   |
+| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 5        | 0    | 2026-06-02   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
 | [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 40       | 9    | 2026-06-02   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -3,7 +3,7 @@ id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-02
-ref_count: 14
+ref_count: 15
 ---
 
 # Async Race Conditions

--- a/docs/reviews/patterns/ci-orchestration-state.md
+++ b/docs/reviews/patterns/ci-orchestration-state.md
@@ -3,7 +3,7 @@ id: ci-orchestration-state
 category: correctness
 created: 2026-06-02
 last_updated: 2026-06-02
-ref_count: 1
+ref_count: 2
 ---
 
 # CI Orchestration State
@@ -57,6 +57,24 @@ Findings in the CI orchestration / QA runner pipeline where state is either lost
 - **File:** `scripts/qa-runner/lib/ci-policy.js`
 - **Finding:** `classifyChecks` produced `deterministicFailures` for non-review checks and `reviewRerunFailures` for failed review checks in `reviewRerunChecks`. A failed review check not in `reviewRerunChecks` fell through both lists, so `computeState` never saw it and the PR could reach `GOOD_SHAPE` despite the failure.
 - **Fix:** Added a `reviewNonRerunFailures` list to `classifyChecks` and mapped it to `CI_RED` in `computeState` before the `reviewRerunFailures` branch.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 8. Thread check before !claudeReady guard — premature NEEDS_FIX dispatch
+
+- **Source:** github-claude | PR #331 round 6 | 2026-06-02
+- **Severity:** HIGH
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** The pre-PR `computeState` evaluated `!claudeReady || ci === 'pending'` before fetching unresolved threads, so a pending Claude check always short-circuited to WAITING. The refactoring inverted the order: `openThreads() > 0` was checked before `!claudeReady || ciResult.ci === 'pending'`. If a PR carried leftover threads while Claude's review was still running, `computeState` returned `NEEDS_FIX` and dispatched a fixer — whereas the old code returned WAITING and let Claude finish first.
+- **Fix:** Swapped the `openThreads() > 0` branch with the `!claudeReady || ciResult.ci === 'pending'` branch so CI/Claude pending is checked first, restoring the original priority.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 9. REVIEW_RERUN_CHECKS aliases REVIEW_CHECKS — reviewNonRerunFailures always empty
+
+- **Source:** github-claude | PR #331 round 6 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/lib/ci-policy.js`
+- **Finding:** `REVIEW_RERUN_CHECKS = REVIEW_CHECKS` was a reference alias — both names pointed to the same `Set`. Since every item in `review` satisfied `reviewRerunChecks.has(check.name)`, the `!reviewRerunChecks.has(...)` filter was always false: `reviewNonRerunFailures` was structurally always empty and the `else if (ciResult.reviewNonRerunFailures.length)` CI_RED branch in `computeState` was permanently dead code.
+- **Fix:** Changed `REVIEW_RERUN_CHECKS` from a reference alias to a new `Set(['Claude Code Review', 'Codex Code Review'])`, activating the non-rerun failure path.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
 
 ### 6. markRerunAttempt before gh run rerun silently exhausts budget

--- a/docs/reviews/patterns/ci-orchestration-state.md
+++ b/docs/reviews/patterns/ci-orchestration-state.md
@@ -1,0 +1,33 @@
+---
+id: ci-orchestration-state
+category: correctness
+created: 2026-06-02
+last_updated: 2026-06-02
+ref_count: 0
+---
+
+# CI Orchestration State
+
+## Summary
+
+Findings in the CI orchestration / QA runner pipeline where state is either lost during refactoring or keyed incorrectly for deduplication and capping. The runner maintains mutable state (thread counts, rerun counters) across asynchronous polls and conditional branches; refactorings that flatten control flow or reuse identity helpers without considering their stability guarantees silently break observability and safety invariants.
+
+## Findings
+
+### 1. Rerun cap ineffective: check identity includes run ID which resets each cycle
+
+- **Source:** github-claude | PR #331 round 1 | 2026-06-02
+- **Severity:** HIGH
+- **File:** `scripts/qa-runner/lib/rerun-state.js`
+- **Finding:** `rerunKey` delegated to `checkIdentity`, which includes the GitHub Actions run ID extracted from `check.link`. Every rerun gets a new run ID, so the cap key changes on every attempt and the counter never accumulates past zero. The advertised safety guarantee (capped at 3 reruns) never trips.
+- **Fix:** Added `stableCheckIdentity` to `ci-policy.js` that keys by check name and workflow only (no run ID). Updated `rerun-state.js` to use the stable identity for cap keys while preserving `checkIdentity` for deduplication use cases.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 2. threads: null in outer return is a regression — NEEDS_FIX thread count lost
+
+- **Source:** github-claude | PR #331 round 1 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** A refactor extracted the `openThreads() > 0` branch into a peer `else-if`, causing it to fall through to the outer return that hardcoded `threads: null`. The lazy-set `threads` variable held the actual count, but the returned state object discarded it, so `formatDecisionComment` rendered "Unresolved threads: unknown".
+- **Fix:** Changed the outer return from `threads: null` to `threads` so all early-exit paths share the cached value (still null for paths that never call `openThreads()`).
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/ci-orchestration-state.md
+++ b/docs/reviews/patterns/ci-orchestration-state.md
@@ -3,7 +3,7 @@ id: ci-orchestration-state
 category: correctness
 created: 2026-06-02
 last_updated: 2026-06-02
-ref_count: 0
+ref_count: 1
 ---
 
 # CI Orchestration State
@@ -51,6 +51,31 @@ Findings in the CI orchestration / QA runner pipeline where state is either lost
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
 
 ### 5. Failed review check invisible when absent from reviewRerunChecks
+
+- **Source:** github-claude | PR #331 round 4 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/lib/ci-policy.js`
+- **Finding:** `classifyChecks` produced `deterministicFailures` for non-review checks and `reviewRerunFailures` for failed review checks in `reviewRerunChecks`. A failed review check not in `reviewRerunChecks` fell through both lists, so `computeState` never saw it and the PR could reach `GOOD_SHAPE` despite the failure.
+- **Fix:** Added a `reviewNonRerunFailures` list to `classifyChecks` and mapped it to `CI_RED` in `computeState` before the `reviewRerunFailures` branch.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 6. markRerunAttempt before gh run rerun silently exhausts budget
+
+- **Source:** github-claude | PR #331 round 5 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `rerunReviewCheck` called `markRerunAttempt` before `gh(['run', 'rerun', runId, '--failed'])`. Because `gh()` uses `execFileSync` and throws on non-zero exit, a transient API failure (rate limit, deleted run) incremented the counter without a real rerun. Three consecutive failures exhausted the `maxCiReruns=3` budget and locked the PR in `CI_RED` permanently.
+- **Fix:** Swapped the order so `gh(['run', 'rerun', ...])` runs first and `markRerunAttempt` is only called on success. A failed `gh` call propagates as a transient error (exit 2) without consuming budget. This reverses the round-4 fix for finding #3, which had moved `markRerunAttempt` before `gh` to prevent infinite loops — the round-5 analysis concluded that pessimistic accounting is worse than transient retries because it permanently disables rerun for a run ID that might succeed later.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 7. ciClassification 'rerun exhausted' even when check has no run ID
+
+- **Source:** github-claude | PR #331 round 5 | 2026-06-02
+- **Severity:** LOW
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `computeState` derived `ciClassification` from `state === 'CI_RED' ? 'rerun exhausted' : 'transient review failure'`. But `rerunReviewCheck` returns `CI_RED` for two reasons: (a) the rerun budget is exhausted, and (b) the selected check has no Actions run ID (`!runId`). Case (b) was falsely labeled "rerun exhausted", confusing operators who saw "0/3" attempts alongside that label.
+- **Fix:** Added `ciClassification` fields to each `rerunReviewCheck` return object (`'no run id'` vs `'rerun exhausted'`), and changed `computeState` to use `rerun.ciClassification` with a fallback to `'transient review failure'`.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
 
 - **Source:** github-claude | PR #331 round 4 | 2026-06-02
 - **Severity:** MEDIUM

--- a/docs/reviews/patterns/ci-orchestration-state.md
+++ b/docs/reviews/patterns/ci-orchestration-state.md
@@ -31,3 +31,30 @@ Findings in the CI orchestration / QA runner pipeline where state is either lost
 - **Finding:** A refactor extracted the `openThreads() > 0` branch into a peer `else-if`, causing it to fall through to the outer return that hardcoded `threads: null`. The lazy-set `threads` variable held the actual count, but the returned state object discarded it, so `formatDecisionComment` rendered "Unresolved threads: unknown".
 - **Fix:** Changed the outer return from `threads: null` to `threads` so all early-exit paths share the cached value (still null for paths that never call `openThreads()`).
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 3. gh run rerun throw skips markRerunAttempt → infinite retry loop
+
+- **Source:** github-claude | PR #331 round 4 | 2026-06-02
+- **Severity:** HIGH
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `gh()` calls `execFileSync` which throws on non-zero exit. If GitHub rejects the rerun request, the exception escapes `rerunReviewCheck` before `markRerunAttempt` is reached. The rerun counter is never incremented, so the same runId is re-attempted on every tick and `maxCiReruns` is never reached.
+- **Fix:** Swapped the order so `markRerunAttempt` is called before `gh(['run', 'rerun', ...])`. Pessimistic accounting ensures the cap is enforced even when the API call fails.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 4. Rerun attempt count in detail defeats Linear comment deduplication
+
+- **Source:** github-claude | PR #331 round 4 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `rerunReviewCheck` returned a `detail` string containing the attempt counter (`attempt ${status.nextAttempt}/${ctx.maxCiReruns}`). `decisionKey` includes `detail`, so each rerun tick produced a unique key and posted a new Linear comment. A single review check failure generated up to 3 comments instead of 1.
+- **Fix:** Removed the attempt counter from `detail` (now stable: `reran ${checkLabel(check)}`). The `rerunAttempt` and `rerunLimit` fields already carry per-attempt metadata to `formatDecisionComment`, which renders them in a separate table row.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 5. Failed review check invisible when absent from reviewRerunChecks
+
+- **Source:** github-claude | PR #331 round 4 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/lib/ci-policy.js`
+- **Finding:** `classifyChecks` produced `deterministicFailures` for non-review checks and `reviewRerunFailures` for failed review checks in `reviewRerunChecks`. A failed review check not in `reviewRerunChecks` fell through both lists, so `computeState` never saw it and the PR could reach `GOOD_SHAPE` despite the failure.
+- **Fix:** Added a `reviewNonRerunFailures` list to `classifyChecks` and mapped it to `CI_RED` in `computeState` before the `reviewRerunFailures` branch.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -2,8 +2,8 @@
 id: error-surfacing
 category: error-handling
 created: 2026-04-10
-last_updated: 2026-06-01
-ref_count: 8
+last_updated: 2026-06-02
+ref_count: 9
 ---
 
 # Error Surfacing
@@ -96,6 +96,24 @@ failed" must mean the editor shows the original file, not the requested one.
 - **File:** `plugins/harness/skills/github-review/SKILL.md`
 - **Finding:** `paginated_review_threads_query` ends with `echo "$result"` — bash propagates the exit code of the last command, so the function always returns 0 regardless of inner `gh api graphql` failures. A failed `page_json=$(gh api graphql ...)` produces empty output; downstream `jq` errors silently to stderr; the loop hits `break` because `has_next` is not `"true"` for empty input — and the function returns `0` with a corrupted thread map. The Step 1 caller's `2>/dev/null || echo "[]"` fallback never fires; Step 2B and 7.1 callers had no fallback at all. Same shape as the `void promise` footgun: silent error swallowing where the caller is expected to detect failures via exit code.
 - **Fix:** Add `|| return 1` after each `page_json=$(gh api graphql ...)` assignment so transient GraphQL failures actually propagate. Then loud-fail at every call site: Step 1 keeps its `|| echo "[]"` (best-effort reconciliation); Step 2B and 7.1 promote to `|| { echo "ERROR..."; exit 1; }` because a corrupted thread map there silently misses unresolved threads (Step 7.1 would declare clean exit prematurely) or breaks inline-comment lookup with no diagnostic.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 39. markRerunAttempt before gh run rerun drains budget on API failure
+
+- **Source:** github-claude | PR #331 round 2 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** In `rerunReviewCheck`, `markRerunAttempt` persists the incremented count to disk before `gh run rerun`. If the `gh` call exits non-zero (transient API error, rate limit, or the run has already completed), `execFileSync` throws, the exception surfaces as a classify error (exit 2), and the budget is consumed. With `maxCiReruns=3`, three consecutive transient `gh` failures exhaust the budget and flip the check to `CI_RED` permanently, with no actual rerun ever having run.
+- **Fix:** Swapped the order so `gh run rerun` executes first and `markRerunAttempt` is only called on success. This makes the budget consumption conditional on a successful dispatch.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 40. openThreads() before reviewRerunFailures adds GraphQL dep to rerun path
+
+- **Source:** github-claude | PR #331 round 2 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** In `computeState`, `openThreads()` — a `gh api` GraphQL call — was evaluated before the `reviewRerunFailures` check. Prior to the PR, threads were fetched only in the fully-clean path. After the PR they were fetched whenever `deterministicFailures.length === 0`, including every case where a reviewer check had failed and a rerun was warranted. If the GraphQL thread-count API was down, the exception propagated out of `computeState` and the tick exited 2 — the rerun logic was never reached.
+- **Fix:** Moved the `reviewRerunFailures` check above `openThreads()` so reruns are attempted before the GraphQL thread query. Unresolved threads are still checked before `GOOD_SHAPE` approval, preserving the original priority semantics without adding a fragile API dependency to the rerun hot path.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
 
 ### 9. `grep -vxFf` exits 1 on full-match input, aborting under `set -euo pipefail`
@@ -376,4 +394,22 @@ failed" must mean the editor shows the original file, not the requested one.
 - **File:** `scripts/qa-runner/daemon.js`
 - **Finding:** `queue.take()` at line 31 sat outside the `try-catch-finally` block that protected `runOne` and `queue.done()`. If `save()` inside `take()` threw (disk full, `ENOSPC` on the rename, permissions error), the exception propagated through the `while` loop, out of the `worker` async function, and became an unhandled promise rejection. Because `worker(i + 1)` at line 114 was called without `.catch()`, Node.js ≥ 15 converts unhandled promise rejections to process termination, killing the entire daemon rather than one worker. This is the symmetric counterpart to finding #32 (`queue.done()` in `finally`).
 - **Fix:** Wrapped `queue.take()` in its own `try-catch` inside the `while` loop so save failures are logged and the loop continues. Changed `const job = queue.take()` to `let job` plus a guarded `try { job = queue.take() } catch (e) { log(...); await sleep(1500); continue }`.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 39. markRerunAttempt before gh run rerun drains budget on API failure
+
+- **Source:** github-claude | PR #331 round 2 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** In `rerunReviewCheck`, `markRerunAttempt` persists the incremented count to disk before `gh run rerun`. If the `gh` call exits non-zero (transient API error, rate limit, or the run has already completed), `execFileSync` throws, the exception surfaces as a classify error (exit 2), and the budget is consumed. With `maxCiReruns=3`, three consecutive transient `gh` failures exhaust the budget and flip the check to `CI_RED` permanently, with no actual rerun ever having run.
+- **Fix:** Swapped the order so `gh run rerun` executes first and `markRerunAttempt` is only called on success. This makes the budget consumption conditional on a successful dispatch.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 40. openThreads() before reviewRerunFailures adds GraphQL dep to rerun path
+
+- **Source:** github-claude | PR #331 round 2 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** In `computeState`, `openThreads()` — a `gh api` GraphQL call — was evaluated before the `reviewRerunFailures` check. Prior to the PR, threads were fetched only in the fully-clean path. After the PR they were fetched whenever `deterministicFailures.length === 0`, including every case where a reviewer check had failed and a rerun was warranted. If the GraphQL thread-count API was down, the exception propagated out of `computeState` and the tick exited 2 — the rerun logic was never reached.
+- **Fix:** Moved the `reviewRerunFailures` check above `openThreads()` so reruns are attempted before the GraphQL thread query. Unresolved threads are still checked before `GOOD_SHAPE` approval, preserving the original priority semantics without adding a fragile API dependency to the rerun hot path.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -3,7 +3,7 @@ id: error-surfacing
 category: error-handling
 created: 2026-04-10
 last_updated: 2026-06-02
-ref_count: 9
+ref_count: 10
 ---
 
 # Error Surfacing
@@ -114,6 +114,15 @@ failed" must mean the editor shows the original file, not the requested one.
 - **File:** `scripts/qa-runner/watch.js`
 - **Finding:** In `computeState`, `openThreads()` — a `gh api` GraphQL call — was evaluated before the `reviewRerunFailures` check. Prior to the PR, threads were fetched only in the fully-clean path. After the PR they were fetched whenever `deterministicFailures.length === 0`, including every case where a reviewer check had failed and a rerun was warranted. If the GraphQL thread-count API was down, the exception propagated out of `computeState` and the tick exited 2 — the rerun logic was never reached.
 - **Fix:** Moved the `reviewRerunFailures` check above `openThreads()` so reruns are attempted before the GraphQL thread query. Unresolved threads are still checked before `GOOD_SHAPE` approval, preserving the original priority semantics without adding a fragile API dependency to the rerun hot path.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 41. Unsafe property traversal on GraphQL error response in linear-issue.js
+
+- **Source:** github-claude | PR #331 round 6 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/lib/linear-issue.js`
+- **Finding:** `teamData.teams.nodes[0]` threw `TypeError: Cannot read properties of undefined (reading 'nodes')` when the Linear API returned an error envelope (e.g. `{ errors: [{message: 'Unauthorized'}] }`) without a `teams` key. The `resolveLinkedIssue` catch in `watch.js` swallowed the exception but logged only the raw TypeError text, making auth failures and network errors operationally invisible.
+- **Fix:** Replaced direct property access with optional chaining, checking `nodes?.length` before indexing, and surfacing `teamData.errors?.[0]?.message` in the thrown error when available.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
 
 ### 9. `grep -vxFf` exits 1 on full-match input, aborting under `set -euo pipefail`

--- a/docs/reviews/patterns/preflight-checks.md
+++ b/docs/reviews/patterns/preflight-checks.md
@@ -2,7 +2,7 @@
 id: preflight-checks
 category: error-handling
 created: 2026-04-20
-last_updated: 2026-05-31
+last_updated: 2026-06-02
 ref_count: 0
 ---
 
@@ -48,3 +48,12 @@ When adding / removing / refactoring preflight checks:
 - **Finding:** `computeState()` enumerated negative states (missing, pending, fail) to block on Claude check status, but `skipping` and `cancel` buckets bypassed the gate. An old clean Claude comment could still let the PR reach `GOOD_SHAPE` and auto-merge without a fresh review.
 - **Fix:** Replaced negative-state enumeration with a single positive gate `claudeReady = claudeCheck?.bucket === 'pass'`; block on `!claudeReady` so any non-pass state (including skipped/cancelled) waits.
 - **Commit:** same commit as this entry
+
+### 4. Zero concurrency limit disables fixer dispatch without warning
+
+- **Source:** github-codex-connector | PR #331 round 1 | 2026-06-02
+- **Severity:** P2 / MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `numericOption(val('max'), MAX_PARALLEL)` correctly preserves `0` as a parsed number (unlike the previous `Number(...) || fallback` which fell back for `0`). However, the bounded-concurrency `pool()` uses `Math.min(limit, items.length)` workers; with `limit = 0` it starts none. A user passing `--max 0` intending to throttle or test would silently block all `NEEDS_FIX` dispatches, and the tick would exit cleanly with no work done and no error surfaced.
+- **Fix:** Clamped `maxParallel` to at least 1 via `Math.max(1, numericOption(val('max'), MAX_PARALLEL))`. This restores the prior behavior where `0` falls back to `MAX_PARALLEL`, while still allowing `--max-ci-reruns 0` where zero is semantically intentional.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-05-28
-ref_count: 25
+last_updated: 2026-06-02
+ref_count: 26
 ---
 
 # Testing Gaps
@@ -553,3 +553,12 @@ filesystem scope restrictions).
 - **Finding:** The focus-repaint fix registered two listeners that share one guarded handler — `window 'focus'` and `document 'visibilitychange'` — where the handler early-returns unless `document.visibilityState === 'visible'`. The new regression test only dispatched `window.focus` (which in jsdom runs with the default `visibilityState === 'visible'`, so the guard always passes). The `visibilitychange` path was never exercised, leaving the non-trivial branch untested: a future edit that inverts or drops the `visibilityState !== 'visible'` guard would still pass every test while silently repainting a hidden terminal (or suppressing a needed repaint on minimized-window restore — the primary scenario the fix targets).
 - **Fix:** Added a test that shadows the read-only `document.visibilityState` getter via `Object.defineProperty(document, 'visibilityState', { configurable: true, get })`, dispatches `visibilitychange` once with `'hidden'` (asserts `refresh` NOT called) and once with `'visible'` (asserts `refresh` called), and restores the prototype getter in a `finally` by `delete`-ing the instance override. Code-review heuristic: when one handler guards on a runtime condition, the test must drive BOTH branches — the condition-true (fires) and condition-false (suppressed) paths. Asserting only the happy path lets a guard regression pass silently. When two events share a guarded handler, test the event whose default test-environment state actually exercises the guard (here `visibilitychange`), not just the one where the guard is incidentally always-true (`focus`).
 - **Commit:** same commit as this entry
+
+### 56. REVIEW_CHECKS equals REVIEW_RERUN_CHECKS — reviewRerunChecks filter is no-op
+
+- **Source:** github-claude | PR #331 round 2 | 2026-06-02
+- **Severity:** LOW
+- **File:** `scripts/qa-runner/lib/ci-policy.js`
+- **Finding:** Both exported sets contained identical three entries. In `classifyChecks`, `review` was first filtered by `reviewChecks`, so every element was already in `reviewChecks`. Since `REVIEW_RERUN_CHECKS === REVIEW_CHECKS`, `reviewRerunChecks.has(check.name)` was always true for elements of `review` — the filter was a no-op. Adding a name to one set without updating the other would silently diverge behavior, and no test covered the divergent case.
+- **Fix:** Made `REVIEW_RERUN_CHECKS` an explicit alias of `REVIEW_CHECKS` so the sameness is intentional rather than coincidental. Added a test asserting that checks absent from `reviewRerunChecks` are excluded from `reviewRerunFailures`, pinning the contract against future drift.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/scripts/qa-runner/README.md
+++ b/scripts/qa-runner/README.md
@@ -138,6 +138,19 @@ The webhook daemon is safe-by-default for the staged rollout:
 GITHUB_WEBHOOK_SECRET=... QA_TRUSTED_SENDERS=you node scripts/qa-runner/daemon.js
 ```
 
+Run the daemon from a neutral checkout of the repository, normally `main` or the
+integration branch that contains the runner code. It does not need PR branches
+preloaded. For each `NEEDS_FIX` PR, `run.js` resolves the PR head branch, fetches
+`origin/<branch>`, and creates or resets `.claude/worktrees/qa-pr-N` from that
+remote branch before running the fixer. This is the expected shape for a fresh
+dedicated host: the root clone stays neutral, while each PR gets its own isolated
+worktree and lock file.
+
+If the PR branch is already checked out in another local worktree, the runner
+refuses to self-review and records a dispatch-blocked event instead of counting
+failed fixer attempts. On a dedicated daemon host this should normally only happen
+when an operator manually checks out the PR branch in the daemon clone.
+
 It runs `watch.js tick --execute` for queued PRs. It does **not** pass
 `--approve` unless explicitly armed with `QA_APPROVE=1`, which belongs to the
 orchestrator-bot rung.

--- a/scripts/qa-runner/README.md
+++ b/scripts/qa-runner/README.md
@@ -12,7 +12,8 @@ Design + rationale: [`docs/explorations/linear-agent-cicd-pilot.html`](../../doc
     review STATE, and act:
        NEEDS_FIX  → dispatch the inner runner (--execute), up to --max in parallel
        GOOD_SHAPE → squash-merge as the orchestrator bot + delete branch (--approve)
-       WAITING / CI_RED → report only
+       WAITING    → report only, or rerun transient reviewer checks when armed
+       CI_RED     → report only once automatic reruns are exhausted/unavailable
                  │
                  ▼  per NEEDS_FIX PR, concurrently, each in its own worktree:
  ② run.js → kimi --afk (as the FIXER bot) · upsource-review skill  — poll → fix →
@@ -43,12 +44,24 @@ branch protection): the **fixer** runs as `bot.env`, the **orchestrator** merges
 (`Claude Code Review`, `Codex Code Review`, `Post Review Comment`) are excluded
 from the CI gate, so a clean patch is never held `WAITING` by its own reviewers.
 
-| State          | When                                                                    | Action (armed)                      |
-| -------------- | ----------------------------------------------------------------------- | ----------------------------------- |
-| **NEEDS_FIX**  | unresolved review threads > 0, **or** Claude verdict "patch has issues" | `--execute` → `run.js <pr> --push`  |
-| **CI_RED**     | a non-review CI check is failing                                        | report only (humans fix the build)  |
-| **WAITING**    | CI/Claude still running · draft · not mergeable · no Claude review yet  | report only (poll again)            |
-| **GOOD_SHAPE** | 0 threads · Claude ✅ · non-review CI green · `MERGEABLE`               | `--approve` → squash-merge + delete |
+| State          | When                                                                                                     | Action (armed)                                 |
+| -------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| **NEEDS_FIX**  | unresolved review threads > 0, Claude verdict "patch has issues", or deterministic non-review CI failure | `--execute` → `run.js <pr> --push`             |
+| **CI_RED**     | transient reviewer reruns are exhausted/unavailable                                                      | report only                                    |
+| **WAITING**    | CI/Claude still running · draft · not mergeable · no Claude review yet · transient reviewer check rerun  | report only or rerun transient reviewer checks |
+| **GOOD_SHAPE** | 0 threads · Claude clean · non-review CI green · `MERGEABLE`                                             | `--approve` → squash-merge + delete            |
+
+Deterministic non-review CI failures include unit tests, Rust tests, type/check
+binding verification, code quality/lint, and build failures. The watcher passes
+the failed check names and GitHub Actions URLs into the fixer as
+`QA_FIX_CONTEXT`, so the fixer can inspect logs and repair code even when there
+are no unresolved review threads.
+
+Transient reviewer checks (`Claude Code Review`, `Codex Code Review`, and
+`Post Review Comment`) can be rerun automatically with `gh run rerun --failed`
+when `--execute` is armed. Reruns are capped by PR + head SHA + check identity
+(default **3**, configurable with `--max-ci-reruns` / `QA_MAX_CI_RERUNS`), so the
+daemon cannot spin forever.
 
 `NEEDS_FIX` PRs are dispatched **concurrently**, capped at `--max` (default **2**) —
 each kimi runs in its own `qa-pr-N` worktree behind its own `.locks/pr-N.lock`, so
@@ -90,8 +103,12 @@ node scripts/qa-runner/watch.js tick --execute            # NEEDS_FIX  → run u
 node scripts/qa-runner/watch.js tick --execute --max 3    # …up to 3 at once
 node scripts/qa-runner/watch.js tick --approve            # GOOD_SHAPE → squash-merge
 node scripts/qa-runner/watch.js tick --execute --approve  # full autonomy
+node scripts/qa-runner/watch.js tick --execute --max-ci-reruns 3
+                                                          # rerun transient reviewer failures up to 3 times
 node scripts/qa-runner/watch.js tick --pr 317 --linear-decisions --reason manual-debug
                                                           # post one deduped Linear decision comment
+node scripts/qa-runner/watch.js tick --pr 317 --linear-create-issues --linear-team VIM
+                                                          # create a missing Linear issue for an unlinked PR
 
 # loop forever (Ctrl-C to stop)
 node scripts/qa-runner/watch.js watch --execute --approve
@@ -131,6 +148,12 @@ head/state/action combination, so operators can see why a signal became
 `WAITING`, `NEEDS_FIX`, `CI_RED`, or `GOOD_SHAPE` without reading local logs.
 Decision comments can be disabled with `QA_LINEAR_DECISION_COMMENTS=0` or
 `linearDecisionComments: false` in `config.json`.
+
+If `QA_LINEAR_CREATE_ISSUES=1` / `linearCreateIssues: true` is enabled, an
+eligible PR with no `VIM-N` in the body or branch name gets a new Linear issue
+created through the orchestrator tool `create_linear_issue_for_pr`. The issue
+description links back to the GitHub PR, and the runner caches the PR→issue
+mapping for future comments.
 
 When the fixer completes a live `/lifeline:upsource-review` cycle, `run.js` posts
 a structured fixer comment with the PR, branch, pushed head, Kimi exit, stop mode,

--- a/scripts/qa-runner/config.example.json
+++ b/scripts/qa-runner/config.example.json
@@ -7,9 +7,11 @@
   "port": 8787,
   "maxParallel": 2,
   "maxNoops": 15,
+  "maxCiReruns": 3,
   "approve": false,
   "linearDecisionComments": true,
+  "linearCreateIssues": false,
   "triggerPhrase": "/upsource-review",
   "trustedSenders": [],
-  "comment": "Copy to config.json (gitignored) to override. SECRETS are env-only: GITHUB_WEBHOOK_SECRET (webhook HMAC), bot tokens in bot.env/orchestrator.env, Linear in linear*.env. trustedSenders = GitHub logins allowed to trigger a fix via a PR comment; env QA_TRUSTED_SENDERS (comma-separated) overrides it. linearDecisionComments posts deduped Linear comments explaining each state-machine decision."
+  "comment": "Copy to config.json (gitignored) to override. SECRETS are env-only: GITHUB_WEBHOOK_SECRET (webhook HMAC), bot tokens in bot.env/orchestrator.env, Linear in linear*.env. trustedSenders = GitHub logins allowed to trigger a fix via a PR comment; env QA_TRUSTED_SENDERS (comma-separated) overrides it. linearDecisionComments posts deduped Linear comments explaining each state-machine decision. linearCreateIssues is opt-in because it creates Linear issues for PRs without VIM links."
 }

--- a/scripts/qa-runner/daemon.js
+++ b/scripts/qa-runner/daemon.js
@@ -115,7 +115,7 @@ server.listen(config.port, config.host, () => {
   )
 
   log(
-    `config: label=${config.label} maxParallel=${config.maxParallel} maxNoops=${config.maxNoops} pollSeconds=${config.pollSeconds} linearDecisionComments=${config.linearDecisionComments} trusted=[${config.trustedSenders.join(',')}]`
+    `config: label=${config.label} maxParallel=${config.maxParallel} maxNoops=${config.maxNoops} maxCiReruns=${config.maxCiReruns} pollSeconds=${config.pollSeconds} linearDecisionComments=${config.linearDecisionComments} linearCreateIssues=${config.linearCreateIssues} trusted=[${config.trustedSenders.join(',')}]`
   )
   if (!config.webhookSecret) {
     log(

--- a/scripts/qa-runner/lib/ci-policy.js
+++ b/scripts/qa-runner/lib/ci-policy.js
@@ -1,0 +1,66 @@
+export const REVIEW_CHECKS = new Set([
+  'Claude Code Review',
+  'Codex Code Review',
+  'Post Review Comment',
+])
+
+export const REVIEW_RERUN_CHECKS = new Set([
+  'Claude Code Review',
+  'Codex Code Review',
+  'Post Review Comment',
+])
+
+const FAILED_BUCKETS = new Set(['fail', 'cancel'])
+
+export const runIdFromCheck = (check) =>
+  String(check?.link || '').match(/\/actions\/runs\/(\d+)/)?.[1] || null
+
+export const isFailedCheck = (check) => FAILED_BUCKETS.has(check.bucket)
+
+export const checkIdentity = (check) =>
+  [
+    check.name || 'unknown-check',
+    check.workflow || 'unknown-workflow',
+    runIdFromCheck(check) || check.link || 'unknown-run',
+  ].join('|')
+
+export const checkLabel = (check) =>
+  [check.name || 'unknown check', check.workflow && `(${check.workflow})`]
+    .filter(Boolean)
+    .join(' ')
+
+export const summarizeChecks = (checks) =>
+  checks.map((check) => ({
+    name: check.name || 'unknown check',
+    workflow: check.workflow || null,
+    bucket: check.bucket || 'unknown',
+    link: check.link || null,
+    runId: runIdFromCheck(check),
+  }))
+
+export const classifyChecks = (
+  checks,
+  { reviewChecks = REVIEW_CHECKS, reviewRerunChecks = REVIEW_RERUN_CHECKS } = {}
+) => {
+  const review = checks.filter((check) => reviewChecks.has(check.name))
+  const nonReview = checks.filter((check) => !reviewChecks.has(check.name))
+  const deterministicFailures = nonReview.filter(isFailedCheck)
+
+  const reviewRerunFailures = review.filter(
+    (check) => isFailedCheck(check) && reviewRerunChecks.has(check.name)
+  )
+
+  const ci = deterministicFailures.length
+    ? 'fail'
+    : nonReview.some((check) => check.bucket === 'pending')
+      ? 'pending'
+      : 'green'
+
+  return {
+    ci,
+    review,
+    nonReview,
+    deterministicFailures,
+    reviewRerunFailures,
+  }
+}

--- a/scripts/qa-runner/lib/ci-policy.js
+++ b/scripts/qa-runner/lib/ci-policy.js
@@ -4,7 +4,10 @@ export const REVIEW_CHECKS = new Set([
   'Post Review Comment',
 ])
 
-export const REVIEW_RERUN_CHECKS = REVIEW_CHECKS
+export const REVIEW_RERUN_CHECKS = new Set([
+  'Claude Code Review',
+  'Codex Code Review',
+])
 
 const FAILED_BUCKETS = new Set(['fail', 'cancel'])
 

--- a/scripts/qa-runner/lib/ci-policy.js
+++ b/scripts/qa-runner/lib/ci-policy.js
@@ -51,6 +51,10 @@ export const classifyChecks = (
     (check) => isFailedCheck(check) && reviewRerunChecks.has(check.name)
   )
 
+  const reviewNonRerunFailures = review.filter(
+    (check) => isFailedCheck(check) && !reviewRerunChecks.has(check.name)
+  )
+
   const ci = deterministicFailures.length
     ? 'fail'
     : nonReview.some((check) => check.bucket === 'pending')
@@ -63,5 +67,6 @@ export const classifyChecks = (
     nonReview,
     deterministicFailures,
     reviewRerunFailures,
+    reviewNonRerunFailures,
   }
 }

--- a/scripts/qa-runner/lib/ci-policy.js
+++ b/scripts/qa-runner/lib/ci-policy.js
@@ -20,6 +20,11 @@ export const checkIdentity = (check) =>
     runIdFromCheck(check) || check.link || 'unknown-run',
   ].join('|')
 
+export const stableCheckIdentity = (check) =>
+  [check.name || 'unknown-check', check.workflow || 'unknown-workflow'].join(
+    '|'
+  )
+
 export const checkLabel = (check) =>
   [check.name || 'unknown check', check.workflow && `(${check.workflow})`]
     .filter(Boolean)

--- a/scripts/qa-runner/lib/ci-policy.js
+++ b/scripts/qa-runner/lib/ci-policy.js
@@ -4,11 +4,7 @@ export const REVIEW_CHECKS = new Set([
   'Post Review Comment',
 ])
 
-export const REVIEW_RERUN_CHECKS = new Set([
-  'Claude Code Review',
-  'Codex Code Review',
-  'Post Review Comment',
-])
+export const REVIEW_RERUN_CHECKS = REVIEW_CHECKS
 
 const FAILED_BUCKETS = new Set(['fail', 'cancel'])
 

--- a/scripts/qa-runner/lib/ci-policy.test.js
+++ b/scripts/qa-runner/lib/ci-policy.test.js
@@ -49,6 +49,25 @@ describe('classifyChecks', () => {
     expect(result.reviewRerunFailures).toHaveLength(1)
     expect(result.reviewRerunFailures[0].name).toBe('Claude Code Review')
   })
+
+  test('classifies failed review checks not in reviewRerunChecks as non-rerun failures', () => {
+    const result = classifyChecks(
+      [
+        { name: 'Unit Tests', bucket: 'pass' },
+        { name: 'Claude Code Review', bucket: 'fail' },
+        { name: 'Post Review Comment', bucket: 'fail' },
+      ],
+      {
+        reviewRerunChecks: new Set(['Claude Code Review']),
+      }
+    )
+
+    expect(result.reviewRerunFailures).toHaveLength(1)
+    expect(result.reviewRerunFailures[0].name).toBe('Claude Code Review')
+    expect(result.reviewNonRerunFailures).toHaveLength(1)
+    expect(result.reviewNonRerunFailures[0].name).toBe('Post Review Comment')
+    expect(result.ci).toBe('green')
+  })
 })
 
 describe('check metadata helpers', () => {

--- a/scripts/qa-runner/lib/ci-policy.test.js
+++ b/scripts/qa-runner/lib/ci-policy.test.js
@@ -32,6 +32,22 @@ describe('classifyChecks', () => {
     expect(result.deterministicFailures).toHaveLength(0)
     expect(result.reviewRerunFailures).toHaveLength(1)
   })
+
+  test('excludes checks absent from reviewRerunChecks from rerun set', () => {
+    const result = classifyChecks(
+      [
+        { name: 'Unit Tests', bucket: 'pass' },
+        { name: 'Claude Code Review', bucket: 'fail' },
+        { name: 'Post Review Comment', bucket: 'fail' },
+      ],
+      {
+        reviewRerunChecks: new Set(['Claude Code Review', 'Codex Code Review']),
+      }
+    )
+
+    expect(result.reviewRerunFailures).toHaveLength(1)
+    expect(result.reviewRerunFailures[0].name).toBe('Claude Code Review')
+  })
 })
 
 describe('check metadata helpers', () => {

--- a/scripts/qa-runner/lib/ci-policy.test.js
+++ b/scripts/qa-runner/lib/ci-policy.test.js
@@ -3,6 +3,7 @@ import {
   checkIdentity,
   classifyChecks,
   runIdFromCheck,
+  stableCheckIdentity,
   summarizeChecks,
 } from './ci-policy.js'
 
@@ -68,6 +69,11 @@ describe('check metadata helpers', () => {
     }
 
     expect(checkIdentity(check)).toBe('Claude Code Review|Claude PR Review|123')
+
+    expect(stableCheckIdentity(check)).toBe(
+      'Claude Code Review|Claude PR Review'
+    )
+
     expect(summarizeChecks([check])).toEqual([
       {
         name: 'Claude Code Review',

--- a/scripts/qa-runner/lib/ci-policy.test.js
+++ b/scripts/qa-runner/lib/ci-policy.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest'
+import {
+  checkIdentity,
+  classifyChecks,
+  runIdFromCheck,
+  summarizeChecks,
+} from './ci-policy.js'
+
+describe('classifyChecks', () => {
+  test('classifies non-review failures as deterministic CI failures', () => {
+    const result = classifyChecks([
+      { name: 'Code Quality Check', bucket: 'fail', workflow: 'CI Checks' },
+      { name: 'Claude Code Review', bucket: 'pass' },
+    ])
+
+    expect(result.ci).toBe('fail')
+    expect(result.deterministicFailures).toHaveLength(1)
+    expect(result.reviewRerunFailures).toHaveLength(0)
+  })
+
+  test('classifies failed reviewer jobs as transient review failures', () => {
+    const result = classifyChecks([
+      { name: 'Unit Tests', bucket: 'pass' },
+      {
+        name: 'Claude Code Review',
+        bucket: 'fail',
+        workflow: 'Claude PR Review',
+      },
+    ])
+
+    expect(result.ci).toBe('green')
+    expect(result.deterministicFailures).toHaveLength(0)
+    expect(result.reviewRerunFailures).toHaveLength(1)
+  })
+})
+
+describe('check metadata helpers', () => {
+  test('extracts a GitHub Actions run id from a check URL', () => {
+    expect(
+      runIdFromCheck({
+        link: 'https://github.com/winoooops/vimeflow/actions/runs/123/jobs/456',
+      })
+    ).toBe('123')
+  })
+
+  test('builds stable check identities and safe summaries', () => {
+    const check = {
+      name: 'Claude Code Review',
+      bucket: 'cancel',
+      workflow: 'Claude PR Review',
+      link: 'https://github.com/winoooops/vimeflow/actions/runs/123',
+    }
+
+    expect(checkIdentity(check)).toBe('Claude Code Review|Claude PR Review|123')
+    expect(summarizeChecks([check])).toEqual([
+      {
+        name: 'Claude Code Review',
+        workflow: 'Claude PR Review',
+        bucket: 'cancel',
+        link: 'https://github.com/winoooops/vimeflow/actions/runs/123',
+        runId: '123',
+      },
+    ])
+  })
+})

--- a/scripts/qa-runner/lib/config.js
+++ b/scripts/qa-runner/lib/config.js
@@ -55,11 +55,16 @@ export const loadConfig = () => {
     label: env.QA_LABEL || file.label || 'auto-review',
     maxParallel: num(env.QA_MAX_PARALLEL, num(file.maxParallel, 2)),
     maxNoops: num(env.QA_MAX_NOOPS, num(file.maxNoops, 15)),
+    maxCiReruns: num(env.QA_MAX_CI_RERUNS, num(file.maxCiReruns, 3)),
     pollSeconds: num(env.QA_POLL_SECONDS, num(file.pollSeconds, 60)),
     approve: bool(env.QA_APPROVE, bool(file.approve)),
     linearDecisionComments: bool(
       env.QA_LINEAR_DECISION_COMMENTS,
       bool(file.linearDecisionComments, true)
+    ),
+    linearCreateIssues: bool(
+      env.QA_LINEAR_CREATE_ISSUES,
+      bool(file.linearCreateIssues, false)
     ),
     triggerPhrase:
       env.QA_TRIGGER_PHRASE || file.triggerPhrase || '/upsource-review',
@@ -69,6 +74,6 @@ export const loadConfig = () => {
     // Bearer token for GET /status (env only). Empty ⇒ /status is DISABLED, so the
     // public webhook bind never leaks queue/PR state. Set to expose it to operators.
     statusToken: env.QA_STATUS_TOKEN || '',
-    linearTeamKey: file.linearTeamKey || 'VIM',
+    linearTeamKey: env.QA_LINEAR_TEAM_KEY || file.linearTeamKey || 'VIM',
   }
 }

--- a/scripts/qa-runner/lib/daemon-state.js
+++ b/scripts/qa-runner/lib/daemon-state.js
@@ -24,6 +24,7 @@ const EMPTY = {
   noopCount: 0,
   lastState: null,
   pausedAt: null,
+  pauseReason: null,
 }
 
 const read = () => {

--- a/scripts/qa-runner/lib/decision-comment.js
+++ b/scripts/qa-runner/lib/decision-comment.js
@@ -31,8 +31,8 @@ export const actionForDecision = (state, { approve, execute } = {}) => {
 export const explainDecision = (state, action) => {
   if (state === 'NEEDS_FIX') {
     return action === 'dispatch fixer'
-      ? 'Review findings require a fixer cycle and execute is armed.'
-      : 'Review findings require a fixer cycle, but execute is not armed.'
+      ? 'Review or deterministic CI findings require a fixer cycle and execute is armed.'
+      : 'Review or deterministic CI findings require a fixer cycle, but execute is not armed.'
   }
   if (state === 'GOOD_SHAPE') {
     return action === 'approve/merge'
@@ -40,9 +40,13 @@ export const explainDecision = (state, action) => {
       : 'PR meets success criteria, but approve is not armed.'
   }
   if (state === 'CI_RED') {
-    return 'Non-review CI is failing or canceled, so the fixer is not dispatched.'
+    return 'CI is red and no automatic action is available for this state.'
   }
   if (state === 'WAITING') {
+    if (action === 'rerun check') {
+      return 'A transient check was rerun and the runner is waiting for the new result.'
+    }
+
     return 'The runner is waiting for CI, review, mergeability, or a new event.'
   }
 
@@ -83,6 +87,10 @@ export const formatDecisionComment = ({
   threads,
   mergeable,
   mergeStateStatus,
+  ciClassification,
+  checkSummaries = [],
+  rerunAttempt,
+  rerunLimit,
 }) => {
   const lines = [
     `## QA runner decision: ${state}`,
@@ -98,6 +106,18 @@ export const formatDecisionComment = ({
     `| Execute armed | ${execute ? 'true' : 'false'} |`,
     `| Approve armed | ${approve ? 'true' : 'false'} |`,
     `| Head | ${shortSha(headSha)} |`,
+  ]
+
+  if (ciClassification) {
+    lines.push(`| CI classification | ${tableValue(ciClassification)} |`)
+  }
+  if (rerunAttempt != null) {
+    lines.push(
+      `| Rerun attempt | ${tableValue(rerunAttempt)} / ${tableValue(rerunLimit)} |`
+    )
+  }
+
+  lines.push(
     '',
     'Checks:',
     `- CI: ${ci ?? 'unknown'}`,
@@ -105,10 +125,19 @@ export const formatDecisionComment = ({
     `- Unresolved threads: ${threads ?? 'unknown'}`,
     `- Mergeable: ${mergeable ?? 'unknown'}${
       mergeStateStatus ? ` (${mergeStateStatus})` : ''
-    }`,
-    '',
-    `Reason: ${explainDecision(state, action)}`,
-  ]
+    }`
+  )
+
+  if (checkSummaries.length) {
+    lines.push('', 'Affected checks:')
+    for (const check of checkSummaries) {
+      lines.push(
+        `- ${tableValue(check.name)}${check.workflow ? ` (${tableValue(check.workflow)})` : ''}: ${tableValue(check.bucket)}${check.link ? ` — ${tableValue(check.link)}` : ''}`
+      )
+    }
+  }
+
+  lines.push('', `Reason: ${explainDecision(state, action)}`)
 
   return lines.join('\n')
 }

--- a/scripts/qa-runner/lib/decision-comment.test.js
+++ b/scripts/qa-runner/lib/decision-comment.test.js
@@ -115,7 +115,7 @@ describe('formatDecisionComment', () => {
       pr: 330,
       branch: 'feature/vim-20',
       state: 'WAITING',
-      detail: 'reran Claude Code Review (attempt 1/3)',
+      detail: 'reran Claude Code Review',
       sourceEvent: 'ci:check_run',
       action: 'rerun check',
       approve: false,

--- a/scripts/qa-runner/lib/decision-comment.test.js
+++ b/scripts/qa-runner/lib/decision-comment.test.js
@@ -71,6 +71,72 @@ describe('formatDecisionComment', () => {
       'Reason: PR meets success criteria, but approve is not armed.'
     )
   })
+
+  test('formats deterministic CI check context without raw logs', () => {
+    const body = formatDecisionComment({
+      pr: 330,
+      branch: 'feature/vim-20',
+      state: 'NEEDS_FIX',
+      detail: 'deterministic CI failure: Code Quality Check',
+      sourceEvent: 'ci:check_run',
+      action: 'dispatch fixer',
+      approve: true,
+      execute: true,
+      headSha: '3c0454fa261b50f7448730be95759845ece1f8bb',
+      ci: 'fail',
+      claude: 'clean',
+      threads: null,
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'UNSTABLE',
+      ciClassification: 'deterministic failure',
+      checkSummaries: [
+        {
+          name: 'Code Quality Check',
+          workflow: 'CI Checks',
+          bucket: 'fail',
+          link: 'https://github.com/winoooops/vimeflow/actions/runs/123',
+        },
+      ],
+    })
+
+    expect(body).toContain('| CI classification | deterministic failure |')
+    expect(body).toContain('Affected checks:')
+    expect(body).toContain(
+      '- Code Quality Check (CI Checks): fail — https://github.com/winoooops/vimeflow/actions/runs/123'
+    )
+
+    expect(body).toContain(
+      'Reason: Review or deterministic CI findings require a fixer cycle and execute is armed.'
+    )
+  })
+
+  test('formats rerun attempt metadata', () => {
+    const body = formatDecisionComment({
+      pr: 330,
+      branch: 'feature/vim-20',
+      state: 'WAITING',
+      detail: 'reran Claude Code Review (attempt 1/3)',
+      sourceEvent: 'ci:check_run',
+      action: 'rerun check',
+      approve: false,
+      execute: true,
+      headSha: '3c0454fa261b50f7448730be95759845ece1f8bb',
+      ci: 'green',
+      claude: 'fail',
+      threads: null,
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'UNSTABLE',
+      ciClassification: 'transient review failure',
+      rerunAttempt: 1,
+      rerunLimit: 3,
+    })
+
+    expect(body).toContain('| CI classification | transient review failure |')
+    expect(body).toContain('| Rerun attempt | 1 / 3 |')
+    expect(body).toContain(
+      'Reason: A transient check was rerun and the runner is waiting for the new result.'
+    )
+  })
 })
 
 describe('formatFixerCycleComment', () => {

--- a/scripts/qa-runner/lib/dispatch-blocker.js
+++ b/scripts/qa-runner/lib/dispatch-blocker.js
@@ -1,0 +1,62 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const LIB_DIR = dirname(fileURLToPath(import.meta.url))
+const STATE_DIR = join(dirname(LIB_DIR), '.state')
+
+export const DISPATCH_BLOCKED_EXIT = 3
+
+export const RUN_SELF_REVIEW_EXIT = 4
+
+export const dispatchBlockerPath = (pr) =>
+  join(STATE_DIR, `dispatch-blocked-pr-${pr}.json`)
+
+export const writeDispatchBlocker = (pr, blocker) => {
+  mkdirSync(STATE_DIR, { recursive: true })
+  writeFileSync(
+    dispatchBlockerPath(pr),
+    JSON.stringify(
+      {
+        pr,
+        ts: new Date().toISOString(),
+        ...blocker,
+      },
+      null,
+      2
+    )
+  )
+}
+
+export const readDispatchBlocker = (pr) => {
+  const file = dispatchBlockerPath(pr)
+  if (!existsSync(file)) {
+    return null
+  }
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+export const clearDispatchBlocker = (pr) => {
+  rmSync(dispatchBlockerPath(pr), { force: true })
+}
+
+export const dispatchBlockerDetail = (blocker) => {
+  if (!blocker) {
+    return 'run.js reported a dispatch blocker'
+  }
+
+  const reason = blocker.reason || `run.js exited ${blocker.code ?? 'blocked'}`
+  const logPath = blocker.logPath ? ` Log: ${blocker.logPath}` : ''
+
+  return `${reason}${logPath}`
+}

--- a/scripts/qa-runner/lib/events.js
+++ b/scripts/qa-runner/lib/events.js
@@ -19,8 +19,19 @@ const LINEAR_STATUS = join(LIB_DIR, 'linear-status.js')
 const LINEAR_COMMENT = {
   progress: (e) =>
     `✅ Fix pushed for #${e.pr} (round ${e.round}). Re-review pending.`,
+  dispatch_blocked: (e) =>
+    [
+      '## QA runner dispatch blocked',
+      '',
+      '| Field | Value |',
+      '| --- | --- |',
+      `| PR | #${e.pr} |`,
+      `| Reason | ${String(e.detail || 'unknown').replace(/\s+/g, ' ')} |`,
+      '',
+      'The fixer did not run and this was not counted as a failed fix attempt. Run the daemon from a neutral checkout, free the PR branch worktree, or push a new head event to resume.',
+    ].join('\n'),
   paused: (e) =>
-    `⏸️ Paused #${e.pr} after ${e.noopCount} failed fix attempts — needs a look.`,
+    `⏸️ Paused #${e.pr} after ${e.noopCount} failed fix attempts — ${e.detail || 'needs a look'}.`,
   merged: (e) => `🎉 #${e.pr} merged — review loop complete.`,
   closed: (e) => `🚫 #${e.pr} closed without merge — review loop stopped.`,
 }

--- a/scripts/qa-runner/lib/fixer-worktree.js
+++ b/scripts/qa-runner/lib/fixer-worktree.js
@@ -1,0 +1,37 @@
+import { join } from 'node:path'
+
+export const fixerWorktreePath = (repoRoot, pr) =>
+  join(repoRoot, '.claude', 'worktrees', `qa-pr-${pr}`)
+
+export const worktreeRef = ({ pr, branch, live }) =>
+  live ? branch : `qa/dryrun-${pr}`
+
+export const isSelfReviewConflict = ({ heldPath, fixerPath }) =>
+  Boolean(heldPath) && heldPath !== fixerPath
+
+export const worktreePlan = ({ repoRoot, pr, branch, live, heldPath }) => {
+  const fixerPath = fixerWorktreePath(repoRoot, pr)
+
+  return {
+    path: fixerPath,
+    ref: worktreeRef({ pr, branch, live }),
+    fetchArgs: ['fetch', 'origin', branch, '-q'],
+    addArgs: [
+      'worktree',
+      'add',
+      '-B',
+      worktreeRef({ pr, branch, live }),
+      fixerPath,
+      `origin/${branch}`,
+    ],
+    checkoutArgs: [
+      '-C',
+      fixerPath,
+      'checkout',
+      '-B',
+      worktreeRef({ pr, branch, live }),
+      `origin/${branch}`,
+    ],
+    blockedBy: isSelfReviewConflict({ heldPath, fixerPath }) ? heldPath : null,
+  }
+}

--- a/scripts/qa-runner/lib/fixer-worktree.test.js
+++ b/scripts/qa-runner/lib/fixer-worktree.test.js
@@ -1,0 +1,89 @@
+import { join } from 'node:path'
+import { describe, expect, test } from 'vitest'
+import {
+  fixerWorktreePath,
+  isSelfReviewConflict,
+  worktreePlan,
+} from './fixer-worktree.js'
+
+describe('worktreePlan', () => {
+  test('fetches a remote PR branch into an isolated live fixer worktree', () => {
+    const plan = worktreePlan({
+      repoRoot: '/srv/vimeflow',
+      pr: 331,
+      branch: 'feature/vim-20',
+      live: true,
+      heldPath: null,
+    })
+
+    expect(plan).toMatchObject({
+      path: join('/srv/vimeflow', '.claude', 'worktrees', 'qa-pr-331'),
+      ref: 'feature/vim-20',
+      fetchArgs: ['fetch', 'origin', 'feature/vim-20', '-q'],
+      addArgs: [
+        'worktree',
+        'add',
+        '-B',
+        'feature/vim-20',
+        join('/srv/vimeflow', '.claude', 'worktrees', 'qa-pr-331'),
+        'origin/feature/vim-20',
+      ],
+      checkoutArgs: [
+        '-C',
+        join('/srv/vimeflow', '.claude', 'worktrees', 'qa-pr-331'),
+        'checkout',
+        '-B',
+        'feature/vim-20',
+        'origin/feature/vim-20',
+      ],
+      blockedBy: null,
+    })
+  })
+
+  test('keeps simultaneous PRs isolated by PR-numbered worktree paths', () => {
+    const first = worktreePlan({
+      repoRoot: '/srv/vimeflow',
+      pr: 331,
+      branch: 'feature/vim-20',
+      live: true,
+      heldPath: null,
+    })
+
+    const second = worktreePlan({
+      repoRoot: '/srv/vimeflow',
+      pr: 332,
+      branch: 'feature/vim-21',
+      live: true,
+      heldPath: null,
+    })
+
+    expect(first.path).toBe(
+      join('/srv/vimeflow', '.claude', 'worktrees', 'qa-pr-331')
+    )
+
+    expect(second.path).toBe(
+      join('/srv/vimeflow', '.claude', 'worktrees', 'qa-pr-332')
+    )
+    expect(first.path).not.toBe(second.path)
+    expect(first.ref).toBe('feature/vim-20')
+    expect(second.ref).toBe('feature/vim-21')
+  })
+
+  test('blocks only when another worktree already holds the PR branch', () => {
+    const fixerPath = fixerWorktreePath('/srv/vimeflow', 331)
+
+    expect(
+      isSelfReviewConflict({
+        heldPath: '/srv/vimeflow/.claude/worktrees/vim-20-dev',
+        fixerPath,
+      })
+    ).toBe(true)
+
+    expect(
+      isSelfReviewConflict({
+        heldPath: fixerPath,
+        fixerPath,
+      })
+    ).toBe(false)
+  })
+})

--- a/scripts/qa-runner/lib/linear-issue.js
+++ b/scripts/qa-runner/lib/linear-issue.js
@@ -28,10 +28,13 @@ export const createLinearIssueForPr = async (
     { key: teamKey },
     fetchImpl
   )
-  const team = teamData.teams.nodes[0]
-  if (!team) {
-    throw new Error(`Linear team ${teamKey} not found`)
+  const nodes = teamData?.teams?.nodes
+  if (!nodes?.length) {
+    throw new Error(
+      teamData?.errors?.[0]?.message ?? `Linear team ${teamKey} not found`
+    )
   }
+  const team = nodes[0]
 
   const issueData = await gql(
     auth.header,

--- a/scripts/qa-runner/lib/linear-issue.js
+++ b/scripts/qa-runner/lib/linear-issue.js
@@ -1,0 +1,56 @@
+import { loadAuthFromRoot, linearGql, repoRoot } from './linear-status.js'
+
+export const buildPrIssueInput = ({ teamId, pr, title, url, branch }) => ({
+  teamId,
+  title: `Review PR #${pr}: ${title || 'untitled pull request'}`,
+  description: [
+    'Created by the QA orchestrator because this pull request had no linked Linear issue.',
+    '',
+    `GitHub PR: ${url}`,
+    `Branch: \`${branch || 'unknown'}\``,
+  ].join('\n'),
+})
+
+export const createLinearIssueForPr = async (
+  { teamKey, pr, title, url, branch },
+  {
+    role = 'orchestrator',
+    root = repoRoot(),
+    fetchImpl = fetch,
+    gql = linearGql,
+  } = {}
+) => {
+  const auth = await loadAuthFromRoot(role, root, fetchImpl)
+
+  const teamData = await gql(
+    auth.header,
+    'query($key:String!){teams(filter:{key:{eq:$key}},first:1){nodes{id key name}}}',
+    { key: teamKey },
+    fetchImpl
+  )
+  const team = teamData.teams.nodes[0]
+  if (!team) {
+    throw new Error(`Linear team ${teamKey} not found`)
+  }
+
+  const issueData = await gql(
+    auth.header,
+    'mutation($input:IssueCreateInput!){issueCreate(input:$input){success issue{id identifier url}}}',
+    {
+      input: buildPrIssueInput({
+        teamId: team.id,
+        pr,
+        title,
+        url,
+        branch,
+      }),
+    },
+    fetchImpl
+  )
+  const issue = issueData.issueCreate?.issue
+  if (!issueData.issueCreate?.success || !issue?.identifier) {
+    throw new Error('Linear issueCreate failed')
+  }
+
+  return issue
+}

--- a/scripts/qa-runner/lib/linear-issue.test.js
+++ b/scripts/qa-runner/lib/linear-issue.test.js
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { buildPrIssueInput, createLinearIssueForPr } from './linear-issue.js'
+
+const tempRoots = []
+
+const makeRoot = () => {
+  const root = mkdtempSync(join(tmpdir(), 'linear-issue-'))
+  tempRoots.push(root)
+
+  return root
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+describe('buildPrIssueInput', () => {
+  test('creates a clear PR-linked issue payload', () => {
+    expect(
+      buildPrIssueInput({
+        teamId: 'team-id',
+        pr: 330,
+        title: 'QA runner comments',
+        url: 'https://github.com/winoooops/vimeflow/pull/330',
+        branch: 'feature/vim-20',
+      })
+    ).toEqual({
+      teamId: 'team-id',
+      title: 'Review PR #330: QA runner comments',
+      description: [
+        'Created by the QA orchestrator because this pull request had no linked Linear issue.',
+        '',
+        'GitHub PR: https://github.com/winoooops/vimeflow/pull/330',
+        'Branch: `feature/vim-20`',
+      ].join('\n'),
+    })
+  })
+})
+
+describe('createLinearIssueForPr', () => {
+  test('uses the orchestrator app auth and creates an issue in the configured team', async () => {
+    const root = makeRoot()
+    writeFileSync(
+      join(root, 'linear-orchestrator.env'),
+      ['LINEAR_CLIENT_ID=client-id', 'LINEAR_CLIENT_SECRET=client-secret'].join(
+        '\n'
+      )
+    )
+
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ access_token: 'app-token' }),
+    }))
+
+    const gql = vi
+      .fn()
+      .mockResolvedValueOnce({
+        teams: { nodes: [{ id: 'team-id', key: 'VIM', name: 'Vimeflow' }] },
+      })
+      .mockResolvedValueOnce({
+        issueCreate: {
+          success: true,
+          issue: {
+            id: 'issue-id',
+            identifier: 'VIM-42',
+            url: 'https://linear.app/vimeflow/issue/VIM-42/test',
+          },
+        },
+      })
+
+    const issue = await createLinearIssueForPr(
+      {
+        teamKey: 'VIM',
+        pr: 330,
+        title: 'QA runner comments',
+        url: 'https://github.com/winoooops/vimeflow/pull/330',
+        branch: 'feature/vim-20',
+      },
+      { root, fetchImpl, gql }
+    )
+
+    expect(issue.identifier).toBe('VIM-42')
+    expect(gql).toHaveBeenCalledWith(
+      'Bearer app-token',
+      expect.stringContaining('teams'),
+      { key: 'VIM' },
+      fetchImpl
+    )
+
+    expect(gql.mock.calls[1][2].input).toEqual(
+      expect.objectContaining({
+        teamId: 'team-id',
+        title: 'Review PR #330: QA runner comments',
+      })
+    )
+  })
+})

--- a/scripts/qa-runner/lib/linear-status.js
+++ b/scripts/qa-runner/lib/linear-status.js
@@ -21,7 +21,7 @@ const TOKEN_API = 'https://api.linear.app/oauth/token'
 
 // Repo root (shared across linked worktrees via --git-common-dir) — where the
 // gitignored Linear env files live.
-const repoRoot = () =>
+export const repoRoot = () =>
   dirname(
     execFileSync(
       'git',
@@ -142,8 +142,8 @@ export const loadAuthFromRoot = async (role, root, fetchImpl = fetch) => {
 
 const loadAuth = (role) => loadAuthFromRoot(role, repoRoot())
 
-const gql = async (auth, query, variables) => {
-  const res = await fetch(API, {
+export const linearGql = async (auth, query, variables, fetchImpl = fetch) => {
+  const res = await fetchImpl(API, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: auth },
     body: JSON.stringify({ query, variables }),
@@ -169,7 +169,7 @@ export const main = async () => {
   const stateName = flag('--state')
   const auth = await loadAuth(flag('--as'))
 
-  const d = await gql(
+  const d = await linearGql(
     auth.header,
     'query($id:String!){issue(id:$id){id identifier team{id}}}',
     { id: identifier }
@@ -178,7 +178,7 @@ export const main = async () => {
     throw new Error(`issue ${identifier} not found`)
   }
 
-  await gql(
+  await linearGql(
     auth.header,
     'mutation($id:String!,$body:String!){commentCreate(input:{issueId:$id,body:$body}){success}}',
     { id: d.issue.id, body }
@@ -186,7 +186,7 @@ export const main = async () => {
   process.stdout.write(`commented on ${identifier} (as ${auth.who})\n`)
 
   if (stateName) {
-    const s = await gql(
+    const s = await linearGql(
       auth.header,
       'query($t:ID!){workflowStates(filter:{team:{id:{eq:$t}}}){nodes{id name}}}',
       { t: d.issue.team.id }
@@ -198,7 +198,7 @@ export const main = async () => {
     if (!st) {
       throw new Error(`state "${stateName}" not found for the team`)
     }
-    await gql(
+    await linearGql(
       auth.header,
       'mutation($id:String!,$s:String!){issueUpdate(id:$id,input:{stateId:$s}){success}}',
       { id: d.issue.id, s: st.id }

--- a/scripts/qa-runner/lib/orchestrator-tools.js
+++ b/scripts/qa-runner/lib/orchestrator-tools.js
@@ -1,0 +1,13 @@
+import { createLinearIssueForPr } from './linear-issue.js'
+
+export const ORCHESTRATOR_TOOLS = [
+  {
+    name: 'create_linear_issue_for_pr',
+    description:
+      'Create a Linear issue for a GitHub PR that has no linked VIM issue, then use that issue for future QA comments.',
+    execute: createLinearIssueForPr,
+  },
+]
+
+export const orchestratorTool = (name) =>
+  ORCHESTRATOR_TOOLS.find((tool) => tool.name === name)

--- a/scripts/qa-runner/lib/pr-utils.js
+++ b/scripts/qa-runner/lib/pr-utils.js
@@ -1,11 +1,64 @@
-// Shared PR-body helpers for the QA runner (used by watch.js + run.js).
+// Shared PR helpers for the QA runner (used by watch.js + run.js).
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const QA_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
+const STATE_DIR = join(QA_DIR, '.state')
 
 // The Linear issue this PR closes — prefer the `Closes/Fixes/Resolves VIM-N` magic
 // word, fall back to the first VIM-N mention. Deterministic so status never posts
 // to a related/historical ticket mentioned earlier in the body.
-export const linkedVim = (body) => {
-  const b = body || ''
+export const linkedVim = (...texts) => {
+  const b = texts.filter(Boolean).join('\n')
   const closing = b.match(/\b(?:closes|fixes|resolves)\s+(VIM-\d+)\b/i)
 
   return (closing?.[1] || b.match(/\bVIM-\d+\b/i)?.[0])?.toUpperCase()
 }
+
+export const linkedIssueStorePath = (pr) =>
+  join(STATE_DIR, `linear-pr-${pr}.json`)
+
+export const readLinkedIssueCache = (pr, file = linkedIssueStorePath(pr)) => {
+  if (!existsSync(file)) {
+    return null
+  }
+  try {
+    const data = JSON.parse(readFileSync(file, 'utf8'))
+
+    return data.identifier || null
+  } catch {
+    return null
+  }
+}
+
+export const writeLinkedIssueCache = (
+  pr,
+  issue,
+  file = linkedIssueStorePath(pr)
+) => {
+  const identifier = issue?.identifier || issue
+  if (!identifier) {
+    return null
+  }
+
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(
+    file,
+    `${JSON.stringify(
+      {
+        identifier,
+        url: issue?.url || null,
+        updatedAt: new Date().toISOString(),
+      },
+      null,
+      2
+    )}\n`
+  )
+
+  return identifier
+}
+
+export const linkedVimForPr = ({ body, branch, pr, cacheFile }) =>
+  linkedVim(body, branch) ||
+  (pr ? readLinkedIssueCache(pr, cacheFile || linkedIssueStorePath(pr)) : null)

--- a/scripts/qa-runner/lib/pr-utils.test.js
+++ b/scripts/qa-runner/lib/pr-utils.test.js
@@ -1,0 +1,50 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+import { linkedVim, linkedVimForPr, writeLinkedIssueCache } from './pr-utils.js'
+
+const tempRoots = []
+
+const makeStore = () => {
+  const root = mkdtempSync(join(tmpdir(), 'pr-utils-'))
+  tempRoots.push(root)
+
+  return join(root, 'linear-pr-330.json')
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+describe('linkedVim', () => {
+  test('prefers closing magic words and also scans branch text', () => {
+    expect(linkedVim('Related VIM-1\nCloses VIM-20')).toBe('VIM-20')
+    expect(linkedVim('', 'feature/vim-21-ci-fixes')).toBe('VIM-21')
+  })
+})
+
+describe('linked issue cache', () => {
+  test('falls back to a cached orchestrator-created issue', () => {
+    const file = makeStore()
+    writeLinkedIssueCache(
+      330,
+      {
+        identifier: 'VIM-42',
+        url: 'https://linear.app/vimeflow/issue/VIM-42/test',
+      },
+      file
+    )
+
+    expect(
+      linkedVimForPr({
+        body: '',
+        branch: 'feature/no-ticket',
+        pr: 330,
+        cacheFile: file,
+      })
+    ).toBe('VIM-42')
+  })
+})

--- a/scripts/qa-runner/lib/rerun-state.js
+++ b/scripts/qa-runner/lib/rerun-state.js
@@ -1,0 +1,54 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { checkIdentity } from './ci-policy.js'
+
+const QA_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
+const STATE_DIR = join(QA_DIR, '.state')
+
+export const rerunStorePath = (pr) => join(STATE_DIR, `ci-reruns-pr-${pr}.json`)
+
+export const rerunKey = ({ pr, headSha, check }) =>
+  [pr, headSha || 'unknown-head', checkIdentity(check)].join('|')
+
+export const readRerunStore = (file) => {
+  if (!existsSync(file)) {
+    return {}
+  }
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+export const rerunCount = (store, key) => Number(store[key]?.count || 0)
+
+export const markRerunAttempt = (
+  store,
+  key,
+  file,
+  now = () => new Date().toISOString()
+) => {
+  const next = {
+    ...store,
+    [key]: {
+      count: rerunCount(store, key) + 1,
+      updatedAt: now(),
+    },
+  }
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`)
+
+  return next
+}
+
+export const rerunStatus = ({ store, key, max }) => {
+  const count = rerunCount(store, key)
+
+  return {
+    count,
+    nextAttempt: count + 1,
+    exhausted: count >= max,
+  }
+}

--- a/scripts/qa-runner/lib/rerun-state.js
+++ b/scripts/qa-runner/lib/rerun-state.js
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { checkIdentity } from './ci-policy.js'
+import { stableCheckIdentity } from './ci-policy.js'
 
 const QA_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
 const STATE_DIR = join(QA_DIR, '.state')
@@ -9,7 +9,7 @@ const STATE_DIR = join(QA_DIR, '.state')
 export const rerunStorePath = (pr) => join(STATE_DIR, `ci-reruns-pr-${pr}.json`)
 
 export const rerunKey = ({ pr, headSha, check }) =>
-  [pr, headSha || 'unknown-head', checkIdentity(check)].join('|')
+  [pr, headSha || 'unknown-head', stableCheckIdentity(check)].join('|')
 
 export const readRerunStore = (file) => {
   if (!existsSync(file)) {

--- a/scripts/qa-runner/lib/rerun-state.test.js
+++ b/scripts/qa-runner/lib/rerun-state.test.js
@@ -1,0 +1,57 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  markRerunAttempt,
+  readRerunStore,
+  rerunKey,
+  rerunStatus,
+} from './rerun-state.js'
+
+const tempRoots = []
+
+const makeStore = () => {
+  const root = mkdtempSync(join(tmpdir(), 'rerun-state-'))
+  tempRoots.push(root)
+
+  return join(root, 'reruns.json')
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+describe('rerun state', () => {
+  test('tracks reruns by PR, head SHA, and check identity', () => {
+    const file = makeStore()
+
+    const key = rerunKey({
+      pr: 330,
+      headSha: 'abc',
+      check: {
+        name: 'Claude Code Review',
+        workflow: 'Claude PR Review',
+        link: 'https://github.com/winoooops/vimeflow/actions/runs/123',
+      },
+    })
+
+    const empty = readRerunStore(file)
+    expect(rerunStatus({ store: empty, key, max: 3 })).toEqual({
+      count: 0,
+      nextAttempt: 1,
+      exhausted: false,
+    })
+
+    markRerunAttempt(empty, key, file, () => '2026-06-02T00:00:00.000Z')
+    const once = readRerunStore(file)
+
+    expect(rerunStatus({ store: once, key, max: 1 })).toEqual({
+      count: 1,
+      nextAttempt: 2,
+      exhausted: true,
+    })
+  })
+})

--- a/scripts/qa-runner/lib/review-rerun.js
+++ b/scripts/qa-runner/lib/review-rerun.js
@@ -1,0 +1,38 @@
+import { runIdFromCheck } from './ci-policy.js'
+import {
+  readRerunStore,
+  rerunKey,
+  rerunStatus,
+  rerunStorePath,
+} from './rerun-state.js'
+
+const defaultStatusForCheck = ({ pr, check, headSha, maxCiReruns }) => {
+  const storeFile = rerunStorePath(pr)
+  const store = readRerunStore(storeFile)
+  const key = rerunKey({ pr, headSha, check })
+
+  return rerunStatus({ store, key, max: maxCiReruns })
+}
+
+export const pickReviewRerunCheck = ({
+  pr,
+  checks,
+  headSha,
+  maxCiReruns,
+  statusForCheck = defaultStatusForCheck,
+}) => {
+  let firstOpen = null
+  for (const check of checks) {
+    const status = statusForCheck({ pr, check, headSha, maxCiReruns })
+    if (status.exhausted) {
+      continue
+    }
+    if (runIdFromCheck(check)) {
+      return check
+    }
+
+    firstOpen ||= check
+  }
+
+  return firstOpen || checks[0]
+}

--- a/scripts/qa-runner/lib/review-rerun.test.js
+++ b/scripts/qa-runner/lib/review-rerun.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest'
+import { pickReviewRerunCheck } from './review-rerun.js'
+
+const check = (name, runId) => ({
+  name,
+  workflow: 'Claude PR Review',
+  bucket: 'fail',
+  link: runId
+    ? `https://github.com/winoooops/vimeflow/actions/runs/${runId}/job/1`
+    : null,
+})
+
+const statusFor =
+  (statuses) =>
+  ({ check: reviewCheck }) =>
+    statuses[reviewCheck.name] || { count: 0, nextAttempt: 1, exhausted: false }
+
+describe('pickReviewRerunCheck', () => {
+  test('selects a later failing reviewer when the first is exhausted', () => {
+    const claude = check('Claude Code Review', '100')
+    const codex = check('Codex Code Review', '200')
+
+    expect(
+      pickReviewRerunCheck({
+        pr: 331,
+        checks: [claude, codex],
+        headSha: 'abc123',
+        maxCiReruns: 3,
+        statusForCheck: statusFor({
+          'Claude Code Review': {
+            count: 3,
+            nextAttempt: 4,
+            exhausted: true,
+          },
+        }),
+      })
+    ).toBe(codex)
+  })
+
+  test('prefers a runnable check over an open check without an Actions run id', () => {
+    const postComment = check('Post Review Comment', null)
+    const codex = check('Codex Code Review', '200')
+
+    expect(
+      pickReviewRerunCheck({
+        pr: 331,
+        checks: [postComment, codex],
+        headSha: 'abc123',
+        maxCiReruns: 3,
+        statusForCheck: statusFor({}),
+      })
+    ).toBe(codex)
+  })
+
+  test('returns the first check when all rerun budgets are exhausted', () => {
+    const claude = check('Claude Code Review', '100')
+    const codex = check('Codex Code Review', '200')
+
+    expect(
+      pickReviewRerunCheck({
+        pr: 331,
+        checks: [claude, codex],
+        headSha: 'abc123',
+        maxCiReruns: 0,
+        statusForCheck: statusFor({
+          'Claude Code Review': {
+            count: 0,
+            nextAttempt: 1,
+            exhausted: true,
+          },
+          'Codex Code Review': {
+            count: 0,
+            nextAttempt: 1,
+            exhausted: true,
+          },
+        }),
+      })
+    ).toBe(claude)
+  })
+})

--- a/scripts/qa-runner/lib/worker.js
+++ b/scripts/qa-runner/lib/worker.js
@@ -14,6 +14,12 @@
 import { execFileSync, spawn } from 'node:child_process'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import {
+  DISPATCH_BLOCKED_EXIT,
+  clearDispatchBlocker,
+  dispatchBlockerDetail,
+  readDispatchBlocker,
+} from './dispatch-blocker.js'
 import { linkedVimForPr } from './pr-utils.js'
 
 const WATCH = join(dirname(dirname(fileURLToPath(import.meta.url))), 'watch.js')
@@ -96,7 +102,7 @@ export const watchArgs = (
   if (linearTeamKey) {
     args.push('--linear-team', linearTeamKey)
   }
-  if (maxCiReruns) {
+  if (maxCiReruns != null) {
     args.push('--max-ci-reruns', String(maxCiReruns))
   }
   if (reason) {
@@ -120,7 +126,12 @@ const tick = (pr, config, reason) =>
 // Run one cycle for `pr`. deps: { config, state, log, events, now?,
 // snapshotExec? }. Async — the heavy watch.js/kimi run is awaited, keeping the
 // daemon responsive. Returns an outcome tag:
-// 'done' | 'progress' | 'error' | 'waiting' | 'paused' | 'skip' | 'retry'.
+const pauseLabel = (st, maxNoops) =>
+  st.pauseReason === 'dispatch_blocked'
+    ? 'dispatch blocked'
+    : `${st.noopCount}/${maxNoops} failed`
+
+// 'done' | 'progress' | 'error' | 'waiting' | 'paused' | 'blocked' | 'skip' | 'retry'.
 export const runOne = async (pr, reason, deps) => {
   const {
     config,
@@ -129,6 +140,7 @@ export const runOne = async (pr, reason, deps) => {
     events,
     now = () => new Date().toISOString(),
     snapshotExec = execFileSync,
+    tickRunner = tick,
   } = deps
   const st = state.get(pr)
   const tracked = state.has(pr)
@@ -187,15 +199,13 @@ export const runOne = async (pr, reason, deps) => {
   // unsticks it (CI finishing, a human re-triggering) arrives as an event, and
   // refusing those is how a paused PR gets permanently stuck.
   if (st.pausedAt && reason === 'poll' && !headMoved) {
-    log(
-      `#${pr}: paused (${st.noopCount}/${config.maxNoops} failed) — poll skip`
-    )
+    log(`#${pr}: paused (${pauseLabel(st, config.maxNoops)}) — poll skip`)
 
     return 'paused'
   }
 
   events.emit({ type: 'cycle', pr, round: st.roundCount, detail: reason })
-  const code = await tick(pr, config, reason)
+  const code = await tickRunner(pr, config, reason)
   const after = snapshot(pr, snapshotExec)
 
   // Post-tick read failed (same rule as the pre-tick guard): never interpret null
@@ -233,12 +243,14 @@ export const runOne = async (pr, reason, deps) => {
     Boolean(before.headSha) &&
     after.headSha !== before.headSha
   if (fixed) {
+    clearDispatchBlocker(pr)
     const round = st.roundCount + 1
     state.update(pr, {
       lastHeadSha: after.headSha,
       roundCount: round,
       noopCount: 0,
       pausedAt: null,
+      pauseReason: null,
     })
     events.emit({ type: 'progress', pr, round }, after.vim)
 
@@ -247,8 +259,22 @@ export const runOne = async (pr, reason, deps) => {
 
   // watch.js exit codes: 1 = a dispatched fixer stalled (run.js non-zero — crash,
   // timeout, no commit, or commit-without-push); 2 = a transient infra failure
-  // (classification / approve); -1 = the spawn itself failed.
+  // (classification / approve); 3 = dispatch blocked before the fixer could run
+  // (for example, the PR branch is checked out in a dev worktree); -1 = spawn failed.
   if (code !== 0) {
+    if (code === DISPATCH_BLOCKED_EXIT) {
+      const blocker = readDispatchBlocker(pr)
+      const detail = dispatchBlockerDetail(blocker)
+      state.update(pr, {
+        lastHeadSha: after.headSha,
+        noopCount: 0,
+        pausedAt: now(),
+        pauseReason: 'dispatch_blocked',
+      })
+      events.emit({ type: 'dispatch_blocked', pr, detail }, after.vim)
+
+      return 'blocked'
+    }
     if (code !== 1) {
       // Transient (2) or a failed spawn (-1) — NOT a fixer stall. Retry next cycle
       // without touching the failure streak, so a gh/GraphQL blip can't pause a
@@ -268,6 +294,7 @@ export const runOne = async (pr, reason, deps) => {
       lastHeadSha: after.headSha,
       noopCount,
       pausedAt: paused ? now() : st.pausedAt,
+      pauseReason: paused ? 'fixer_stall' : st.pauseReason,
     })
 
     events.emit(
@@ -287,7 +314,13 @@ export const runOne = async (pr, reason, deps) => {
   // non-zero (above), this means NO fixer ran — the PR is genuinely WAITING on CI or
   // review. NOT a stall: reset the failure streak AND clear any pause, since a clean
   // recheck means it is no longer stuck and routine polling should resume.
-  state.update(pr, { lastHeadSha: after.headSha, noopCount: 0, pausedAt: null })
+  clearDispatchBlocker(pr)
+  state.update(pr, {
+    lastHeadSha: after.headSha,
+    noopCount: 0,
+    pausedAt: null,
+    pauseReason: null,
+  })
 
   return 'waiting'
 }

--- a/scripts/qa-runner/lib/worker.js
+++ b/scripts/qa-runner/lib/worker.js
@@ -14,7 +14,7 @@
 import { execFileSync, spawn } from 'node:child_process'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { linkedVim } from './pr-utils.js'
+import { linkedVimForPr } from './pr-utils.js'
 
 const WATCH = join(dirname(dirname(fileURLToPath(import.meta.url))), 'watch.js')
 
@@ -36,7 +36,7 @@ const snapshot = (pr, exec = execFileSync) => {
           'view',
           String(pr),
           '--json',
-          'headRefOid,state,body,isDraft,labels',
+          'headRefOid,state,body,isDraft,labels,headRefName',
         ],
         { encoding: 'utf8' }
       )
@@ -46,7 +46,11 @@ const snapshot = (pr, exec = execFileSync) => {
       ok: true,
       headSha: j.headRefOid,
       state: j.state,
-      vim: linkedVim(j.body),
+      vim: linkedVimForPr({
+        body: j.body,
+        branch: j.headRefName,
+        pr,
+      }),
       isDraft: Boolean(j.isDraft),
       labels: (j.labels || []).map((l) => l.name),
     }
@@ -69,7 +73,15 @@ const snapshot = (pr, exec = execFileSync) => {
 
 export const watchArgs = (
   pr,
-  { label, approve = false, linearDecisionComments = false, reason } = {}
+  {
+    label,
+    approve = false,
+    linearDecisionComments = false,
+    linearCreateIssues = false,
+    linearTeamKey,
+    maxCiReruns,
+    reason,
+  } = {}
 ) => {
   const args = [WATCH, 'tick', '--pr', String(pr), '--execute']
   if (approve) {
@@ -77,6 +89,15 @@ export const watchArgs = (
   }
   if (linearDecisionComments) {
     args.push('--linear-decisions')
+  }
+  if (linearCreateIssues) {
+    args.push('--linear-create-issues')
+  }
+  if (linearTeamKey) {
+    args.push('--linear-team', linearTeamKey)
+  }
+  if (maxCiReruns) {
+    args.push('--max-ci-reruns', String(maxCiReruns))
   }
   if (reason) {
     args.push('--reason', reason)

--- a/scripts/qa-runner/lib/worker.test.js
+++ b/scripts/qa-runner/lib/worker.test.js
@@ -66,6 +66,9 @@ describe('watchArgs', () => {
       watchArgs(123, {
         label: 'auto-review',
         linearDecisionComments: true,
+        linearCreateIssues: true,
+        linearTeamKey: 'VIM',
+        maxCiReruns: 3,
         reason: 'pr:ready_for_review',
       })
     ).toEqual([
@@ -75,6 +78,11 @@ describe('watchArgs', () => {
       '123',
       '--execute',
       '--linear-decisions',
+      '--linear-create-issues',
+      '--linear-team',
+      'VIM',
+      '--max-ci-reruns',
+      '3',
       '--reason',
       'pr:ready_for_review',
       '--label',

--- a/scripts/qa-runner/lib/worker.test.js
+++ b/scripts/qa-runner/lib/worker.test.js
@@ -1,4 +1,9 @@
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+  DISPATCH_BLOCKED_EXIT,
+  clearDispatchBlocker,
+  writeDispatchBlocker,
+} from './dispatch-blocker.js'
 import { isMissingPullRequestSnapshot, runOne, watchArgs } from './worker.js'
 
 const makeDeps = (overrides = {}) => ({
@@ -20,6 +25,10 @@ const makeDeps = (overrides = {}) => ({
   ...overrides,
 })
 
+afterEach(() => {
+  clearDispatchBlocker(42)
+})
+
 const missingPrSnapshotExec = (pr) => () => {
   const err = new Error(`Command failed: gh pr view ${pr}`)
   err.stderr = Buffer.from(
@@ -27,6 +36,22 @@ const missingPrSnapshotExec = (pr) => () => {
   )
   throw err
 }
+
+const openPrSnapshotExec = ({
+  headSha = 'abc123',
+  body = 'Closes VIM-20',
+  branch = 'feature/example',
+} = {}) =>
+  vi.fn(() =>
+    JSON.stringify({
+      headRefOid: headSha,
+      state: 'OPEN',
+      body,
+      isDraft: false,
+      labels: [{ name: 'auto-review' }],
+      headRefName: branch,
+    })
+  )
 
 describe('isMissingPullRequestSnapshot', () => {
   test('identifies GitHub PR-not-found snapshot failures', () => {
@@ -89,6 +114,15 @@ describe('watchArgs', () => {
       'auto-review',
     ])
   })
+
+  test('preserves maxCiReruns=0 as an explicit option', () => {
+    expect(
+      watchArgs(123, {
+        label: 'auto-review',
+        maxCiReruns: 0,
+      })
+    ).toContain('0')
+  })
 })
 
 describe('runOne', () => {
@@ -128,6 +162,70 @@ describe('runOne', () => {
     expect(outcome).toBe('retry')
     expect(deps.log).toHaveBeenCalledWith(
       '#42: snapshot unavailable (transient) — retry, state preserved'
+    )
+  })
+
+  test('pauses as dispatch-blocked without incrementing fixer failures', async () => {
+    writeDispatchBlocker(42, {
+      code: 4,
+      reason:
+        "refusing to review PR #42: branch 'feature/example' is checked out at /repo/dev (no self-review)",
+      logPath: '/repo/scripts/qa-runner/logs/pr-42.log',
+    })
+
+    const deps = makeDeps({
+      snapshotExec: openPrSnapshotExec(),
+      tickRunner: vi.fn(async () => DISPATCH_BLOCKED_EXIT),
+    })
+
+    const outcome = await runOne(42, 'poll', deps)
+
+    expect(outcome).toBe('blocked')
+    expect(deps.state.update).toHaveBeenCalledWith(42, {
+      lastHeadSha: 'abc123',
+      noopCount: 0,
+      pausedAt: '2024-01-01T00:00:00.000Z',
+      pauseReason: 'dispatch_blocked',
+    })
+
+    expect(deps.events.emit).toHaveBeenCalledWith(
+      {
+        type: 'dispatch_blocked',
+        pr: 42,
+        detail: expect.stringContaining('refusing to review PR #42'),
+      },
+      'VIM-20'
+    )
+
+    clearDispatchBlocker(42)
+  })
+
+  test('skips routine polls while dispatch-blocked', async () => {
+    const tickRunner = vi.fn(async () => 0)
+
+    const deps = makeDeps({
+      snapshotExec: openPrSnapshotExec(),
+      tickRunner,
+      state: {
+        has: vi.fn(() => true),
+        get: vi.fn(() => ({
+          roundCount: 0,
+          noopCount: 0,
+          lastHeadSha: 'abc123',
+          pausedAt: '2024-01-01T00:00:00.000Z',
+          pauseReason: 'dispatch_blocked',
+        })),
+        forget: vi.fn(),
+        update: vi.fn(),
+      },
+    })
+
+    const outcome = await runOne(42, 'poll', deps)
+
+    expect(outcome).toBe('paused')
+    expect(tickRunner).not.toHaveBeenCalled()
+    expect(deps.log).toHaveBeenCalledWith(
+      '#42: paused (dispatch blocked) — poll skip'
     )
   })
 })

--- a/scripts/qa-runner/run.js
+++ b/scripts/qa-runner/run.js
@@ -31,7 +31,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { botEnv, botLabel, loadBot } from './lib/bot-identity.js'
 import { formatFixerCycleComment } from './lib/decision-comment.js'
-import { linkedVim } from './lib/pr-utils.js'
+import { linkedVimForPr } from './lib/pr-utils.js'
 import { runUntilChange } from './lib/run-until-change.js'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
@@ -157,12 +157,28 @@ const ensureWorktree = (pr, branch, live, skillsDir, bot, repo) => {
   return wt
 }
 
+const fixContextText = () => {
+  const context = process.env.QA_FIX_CONTEXT
+  if (!context) {
+    return ''
+  }
+
+  return (
+    '\n\nAdditional orchestrator context for this fixer cycle:\n' +
+    '```json\n' +
+    context +
+    '\n```\n' +
+    'If this context describes deterministic CI failures, inspect the linked GitHub check logs and fix those failures even when there are no unresolved review threads.'
+  )
+}
+
 const invocation = (pr, live) => {
   const base =
     `/skill:upsource-review ${pr}\n\n` +
     `Run the lifeline upsource-review skill now on pull request #${pr} of this repository. ` +
     `"${pr}" is the PR number — not a line number or a count. Resolve PR #${pr}, fetch its ` +
-    `review findings, and fix every one. Do not ask for clarification; the target is PR #${pr}.`
+    `review findings, and fix every one. Do not ask for clarification; the target is PR #${pr}.` +
+    fixContextText()
   if (live) {
     // SINGLE PASS: the orchestrator owns re-dispatch — fix one round and exit, never poll.
     return (
@@ -322,7 +338,11 @@ const run = async (pr, live) => {
     out(worktreeStatus || '(none)')
     // r.killed (single-pass stop) is also success — every failure mode die()'d above.
     if (live && (r.status === 0 || r.killed)) {
-      const vim = linkedVim(info.body)
+      const vim = linkedVimForPr({
+        body: info.body,
+        branch,
+        pr,
+      })
       if (vim) {
         const kimiExit =
           r.status === null || r.status === undefined

--- a/scripts/qa-runner/run.js
+++ b/scripts/qa-runner/run.js
@@ -31,6 +31,8 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { botEnv, botLabel, loadBot } from './lib/bot-identity.js'
 import { formatFixerCycleComment } from './lib/decision-comment.js'
+import { RUN_SELF_REVIEW_EXIT } from './lib/dispatch-blocker.js'
+import { worktreePlan } from './lib/fixer-worktree.js'
 import { linkedVimForPr } from './lib/pr-utils.js'
 import { runUntilChange } from './lib/run-until-change.js'
 
@@ -100,24 +102,31 @@ const worktreeForBranch = (branch) => {
 }
 
 const ensureWorktree = (pr, branch, live, skillsDir, bot, repo) => {
-  const wt = join(mainRoot(), '.claude', 'worktrees', `qa-pr-${pr}`)
   // No self-review: refuse only when the branch is held by a DIFFERENT worktree (a
   // dev checkout). Our own qa-pr-N from a prior round is fine — reset + reuse it.
-  const held = worktreeForBranch(branch)
-  if (held && held !== wt) {
+  const heldPath = worktreeForBranch(branch)
+
+  const plan = worktreePlan({
+    repoRoot: mainRoot(),
+    pr,
+    branch,
+    live,
+    heldPath,
+  })
+  const wt = plan.path
+  if (plan.blockedBy) {
     die(
-      `refusing to review PR #${pr}: branch '${branch}' is checked out at ${held} (no self-review)`,
-      4
+      `refusing to review PR #${pr}: branch '${branch}' is checked out at ${plan.blockedBy} (no self-review)`,
+      RUN_SELF_REVIEW_EXIT
     )
   }
-  const ref = live ? branch : `qa/dryrun-${pr}`
   if (!existsSync(wt)) {
-    sh('git', ['fetch', 'origin', branch, '-q'])
-    sh('git', ['worktree', 'add', '-B', ref, wt, `origin/${branch}`])
+    sh('git', plan.fetchArgs)
+    sh('git', plan.addArgs)
   } else {
     // reset a stale qa-pr-N worktree from a prior run
-    sh('git', ['-C', wt, 'fetch', 'origin', branch, '-q'])
-    sh('git', ['-C', wt, 'checkout', '-B', ref, `origin/${branch}`])
+    sh('git', ['-C', wt, ...plan.fetchArgs])
+    sh('git', plan.checkoutArgs)
     sh('git', ['-C', wt, 'reset', '--hard'])
     sh('git', ['-C', wt, 'clean', '-fd'])
   }

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -47,6 +47,12 @@ import {
   readDecisionStore,
   shouldPostDecision,
 } from './lib/decision-comment.js'
+import {
+  DISPATCH_BLOCKED_EXIT,
+  RUN_SELF_REVIEW_EXIT,
+  clearDispatchBlocker,
+  writeDispatchBlocker,
+} from './lib/dispatch-blocker.js'
 import { orchestratorTool } from './lib/orchestrator-tools.js'
 import { linkedVimForPr, writeLinkedIssueCache } from './lib/pr-utils.js'
 import {
@@ -56,6 +62,7 @@ import {
   rerunStatus,
   rerunStorePath,
 } from './lib/rerun-state.js'
+import { pickReviewRerunCheck } from './lib/review-rerun.js'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const LOCK_DIR = join(SCRIPT_DIR, '.locks')
@@ -76,6 +83,15 @@ const gh = (args, env) =>
     ...(env ? { env } : {}),
   })
 const ghJson = (args) => JSON.parse(gh(args))
+
+const numericOption = (raw, fallback) => {
+  if (raw === undefined) {
+    return fallback
+  }
+  const n = Number(raw)
+
+  return Number.isFinite(n) ? n : fallback
+}
 
 const repoSlug = () => {
   const r = ghJson(['repo', 'view', '--json', 'owner,name'])
@@ -307,8 +323,8 @@ const rerunReviewCheck = (pr, check, headSha, ctx) => {
     }
   }
 
-  gh(['run', 'rerun', runId, '--failed'])
   markRerunAttempt(store, key, storeFile)
+  gh(['run', 'rerun', runId, '--failed'])
 
   return {
     state: 'WAITING',
@@ -347,6 +363,15 @@ const computeState = async (pr, ctx) => {
   let ciClassification
   let checkSummaries = []
   let fixContext
+  let threads = null
+
+  const openThreads = () => {
+    if (threads === null) {
+      threads = unresolvedThreads(ctx.owner, ctx.name, pr.number)
+    }
+
+    return threads
+  }
 
   if (ciResult.deterministicFailures.length) {
     checkSummaries = summarizeChecks(ciResult.deterministicFailures)
@@ -360,10 +385,17 @@ const computeState = async (pr, ctx) => {
         'The orchestrator dispatched this fixer because deterministic CI failed. Inspect the linked GitHub check logs, fix the code or generated artifacts, run relevant verification locally, commit, and push.',
       checks: checkSummaries,
     }
+  } else if (openThreads() > 0) {
+    ;[state, detail] = ['NEEDS_FIX', `${threads} unresolved thread(s)`]
   } else if (ciResult.reviewRerunFailures.length) {
     const rerun = rerunReviewCheck(
       pr,
-      ciResult.reviewRerunFailures[0],
+      pickReviewRerunCheck({
+        pr: pr.number,
+        checks: ciResult.reviewRerunFailures,
+        headSha: view.headRefOid,
+        maxCiReruns: ctx.maxCiReruns,
+      }),
       view.headRefOid,
       ctx
     )
@@ -378,29 +410,21 @@ const computeState = async (pr, ctx) => {
   } else if (!claudeReady || ciResult.ci === 'pending') {
     ;[state, detail] = ['WAITING', 'CI / Claude re-running']
   } else {
-    const threads = unresolvedThreads(ctx.owner, ctx.name, pr.number)
-    if (threads > 0) {
-      ;[state, detail] = ['NEEDS_FIX', `${threads} unresolved thread(s)`]
+    // verdict is irrelevant until threads are clear — defer the fetch to here
+    const verdict = claudeVerdictClean(ctx.owner, ctx.name, pr.number) // null|true|false
+    claude =
+      verdict === true ? 'clean' : verdict === false ? 'issues' : 'no verdict'
+    if (verdict === false) {
+      ;[state, detail] = ['NEEDS_FIX', 'Claude verdict: patch has issues']
+    } else if (verdict === null) {
+      ;[state, detail] = ['WAITING', 'no Claude review yet']
+    } else if (view.mergeable !== 'MERGEABLE') {
+      ;[state, detail] = ['WAITING', `not mergeable (${view.mergeStateStatus})`]
     } else {
-      // verdict is irrelevant until threads are clear — defer the fetch to here
-      const verdict = claudeVerdictClean(ctx.owner, ctx.name, pr.number) // null|true|false
-      claude =
-        verdict === true ? 'clean' : verdict === false ? 'issues' : 'no verdict'
-      if (verdict === false) {
-        ;[state, detail] = ['NEEDS_FIX', 'Claude verdict: patch has issues']
-      } else if (verdict === null) {
-        ;[state, detail] = ['WAITING', 'no Claude review yet']
-      } else if (view.mergeable !== 'MERGEABLE') {
-        ;[state, detail] = [
-          'WAITING',
-          `not mergeable (${view.mergeStateStatus})`,
-        ]
-      } else {
-        ;[state, detail] = [
-          'GOOD_SHAPE',
-          '0 threads · Claude clean · CI green · mergeable',
-        ]
-      }
+      ;[state, detail] = [
+        'GOOD_SHAPE',
+        '0 threads · Claude clean · CI green · mergeable',
+      ]
     }
 
     return {
@@ -487,7 +511,6 @@ const maybePostDecisionLinear = (pr, s, ctx) => {
     action,
     approve: ctx.approve,
     execute: ctx.execute,
-    selectedAction: s.action,
   })
   const storeFile = decisionStorePath(pr.number)
   const store = readDecisionStore(storeFile)
@@ -611,6 +634,8 @@ const dispatchFix = ({ pr, fixContext }) =>
     const logPath = join(LOG_DIR, `pr-${pr}.log`)
     const logFd = createWriteStream(logPath, { flags: 'a' })
     const tag = `[#${pr}]`
+    let lastLine = ''
+    clearDispatchBlocker(pr)
     out(`${tag} → run.js ${pr} --push   (log: ${logPath})`)
 
     const child = spawn(
@@ -633,13 +658,20 @@ const dispatchFix = ({ pr, fixContext }) =>
         buf += d.toString()
         let nl
         while ((nl = buf.indexOf('\n')) >= 0) {
-          out(`${tag} ${buf.slice(0, nl)}`)
+          const line = buf.slice(0, nl)
+          if (line.trim()) {
+            lastLine = line.trim()
+          }
+          out(`${tag} ${line}`)
           buf = buf.slice(nl + 1)
         }
       })
 
       stream.on('end', () => {
         if (buf) {
+          if (buf.trim()) {
+            lastLine = buf.trim()
+          }
           out(`${tag} ${buf}`)
         }
       })
@@ -648,14 +680,21 @@ const dispatchFix = ({ pr, fixContext }) =>
     pipe(child.stderr)
     child.on('close', (code) => {
       logFd.end()
+      if (code === RUN_SELF_REVIEW_EXIT) {
+        writeDispatchBlocker(pr, {
+          code,
+          reason: lastLine || `run.js exited ${code}`,
+          logPath,
+        })
+      }
       out(`${tag} ✓ run.js exited ${code}`)
-      resolve(code)
+      resolve({ code })
     })
 
     child.on('error', (e) => {
       logFd.end()
       out(`${tag} ✗ spawn error: ${e.message}`)
-      resolve(-1)
+      resolve({ code: -1 })
     })
   })
 
@@ -740,16 +779,21 @@ const tick = async (ctx) => {
     out('')
   }
   let fixerStall = false
+  let dispatchBlocked = false
   let transientChild = false
   if (needsFix.length) {
     out(
       `Dispatching ${needsFix.length} fix run(s), up to ${ctx.maxParallel} in parallel…\n`
     )
-    const codes = await pool(needsFix, ctx.maxParallel, dispatchFix)
+    const results = await pool(needsFix, ctx.maxParallel, dispatchFix)
     // dispatchFix resolves a real run.js exit code, null (signal-killed), or -1
-    // (spawn failed: node/run.js missing, OOM before fork). Only a real non-zero
-    // exit is a fixer stall; null and -1 are transient infra, not kimi's fault.
-    fixerStall = codes.some((c) => c !== null && c !== -1 && c !== 0)
+    // (spawn failed: node/run.js missing, OOM before fork). Self-review refusal is
+    // a local dispatch blocker, not a failed fixer attempt.
+    const codes = results.map((r) => r.code)
+    fixerStall = codes.some(
+      (c) => c !== null && c !== -1 && c !== 0 && c !== RUN_SELF_REVIEW_EXIT
+    )
+    dispatchBlocked = codes.some((c) => c === RUN_SELF_REVIEW_EXIT)
     transientChild = codes.some((c) => c === null || c === -1)
   }
   // Exit-code contract for the supervising daemon:
@@ -757,9 +801,13 @@ const tick = async (ctx) => {
   //       counts toward pausing the PR (kimi can't drive these findings to zero).
   //   2 = a TRANSIENT infra failure (classify / approve / signal-kill / spawn-fail) —
   //       the daemon retries WITHOUT pausing, so a blip or host OOM can't stick a PR.
+  //   3 = dispatch blocked before a fixer ran — the daemon pauses with the blocker
+  //       reason instead of burning fixer attempts.
   // Fixer stall wins when both happen in one tick.
   if (fixerStall) {
     process.exitCode = 1
+  } else if (dispatchBlocked) {
+    process.exitCode = DISPATCH_BLOCKED_EXIT
   } else if (classifyError || approveError || transientChild) {
     process.exitCode = 2
   }
@@ -833,8 +881,8 @@ const main = () => {
     reason: val('reason') || 'manual',
     all: has('all'),
     pr: val('pr') ? Number(val('pr')) : undefined,
-    maxParallel: Number(val('max')) || MAX_PARALLEL,
-    maxCiReruns: Number(val('max-ci-reruns')) || MAX_CI_RERUNS,
+    maxParallel: numericOption(val('max'), MAX_PARALLEL),
+    maxCiReruns: numericOption(val('max-ci-reruns'), MAX_CI_RERUNS),
     linearTeamKey: val('linear-team') || 'VIM',
     orchBot,
     approverLogin: orchBot?.user ?? ghJson(['api', 'user']).login,

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -323,8 +323,8 @@ const rerunReviewCheck = (pr, check, headSha, ctx) => {
     }
   }
 
-  markRerunAttempt(store, key, storeFile)
   gh(['run', 'rerun', runId, '--failed'])
+  markRerunAttempt(store, key, storeFile)
 
   return {
     state: 'WAITING',
@@ -385,8 +385,6 @@ const computeState = async (pr, ctx) => {
         'The orchestrator dispatched this fixer because deterministic CI failed. Inspect the linked GitHub check logs, fix the code or generated artifacts, run relevant verification locally, commit, and push.',
       checks: checkSummaries,
     }
-  } else if (openThreads() > 0) {
-    ;[state, detail] = ['NEEDS_FIX', `${threads} unresolved thread(s)`]
   } else if (ciResult.reviewRerunFailures.length) {
     const rerun = rerunReviewCheck(
       pr,
@@ -407,6 +405,8 @@ const computeState = async (pr, ctx) => {
     ciClassification =
       state === 'CI_RED' ? 'rerun exhausted' : 'transient review failure'
     checkSummaries = summarizeChecks(ciResult.reviewRerunFailures)
+  } else if (openThreads() > 0) {
+    ;[state, detail] = ['NEEDS_FIX', `${threads} unresolved thread(s)`]
   } else if (!claudeReady || ciResult.ci === 'pending') {
     ;[state, detail] = ['WAITING', 'CI / Claude re-running']
   } else {

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -881,7 +881,7 @@ const main = () => {
     reason: val('reason') || 'manual',
     all: has('all'),
     pr: val('pr') ? Number(val('pr')) : undefined,
-    maxParallel: numericOption(val('max'), MAX_PARALLEL),
+    maxParallel: Math.max(1, numericOption(val('max'), MAX_PARALLEL)),
     maxCiReruns: numericOption(val('max-ci-reruns'), MAX_CI_RERUNS),
     linearTeamKey: val('linear-team') || 'VIM',
     orchBot,

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -300,6 +300,7 @@ const rerunReviewCheck = (pr, check, headSha, ctx) => {
       action: 'none',
       rerunAttempt: status.count,
       rerunLimit: ctx.maxCiReruns,
+      ciClassification: 'no run id',
     }
   }
 
@@ -310,6 +311,7 @@ const rerunReviewCheck = (pr, check, headSha, ctx) => {
       action: 'none',
       rerunAttempt: status.count,
       rerunLimit: ctx.maxCiReruns,
+      ciClassification: 'rerun exhausted',
     }
   }
 
@@ -323,8 +325,8 @@ const rerunReviewCheck = (pr, check, headSha, ctx) => {
     }
   }
 
-  markRerunAttempt(store, key, storeFile)
   gh(['run', 'rerun', runId, '--failed'])
+  markRerunAttempt(store, key, storeFile)
 
   return {
     state: 'WAITING',
@@ -407,8 +409,7 @@ const computeState = async (pr, ctx) => {
     action = rerun.action
     rerunAttempt = rerun.rerunAttempt
     rerunLimit = rerun.rerunLimit
-    ciClassification =
-      state === 'CI_RED' ? 'rerun exhausted' : 'transient review failure'
+    ciClassification = rerun.ciClassification || 'transient review failure'
     checkSummaries = summarizeChecks(ciResult.reviewRerunFailures)
   } else if (openThreads() > 0) {
     ;[state, detail] = ['NEEDS_FIX', `${threads} unresolved thread(s)`]

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -323,12 +323,12 @@ const rerunReviewCheck = (pr, check, headSha, ctx) => {
     }
   }
 
-  gh(['run', 'rerun', runId, '--failed'])
   markRerunAttempt(store, key, storeFile)
+  gh(['run', 'rerun', runId, '--failed'])
 
   return {
     state: 'WAITING',
-    detail: `reran ${checkLabel(check)} (attempt ${status.nextAttempt}/${ctx.maxCiReruns})`,
+    detail: `reran ${checkLabel(check)}`,
     action: 'rerun check',
     rerunAttempt: status.nextAttempt,
     rerunLimit: ctx.maxCiReruns,
@@ -385,6 +385,11 @@ const computeState = async (pr, ctx) => {
         'The orchestrator dispatched this fixer because deterministic CI failed. Inspect the linked GitHub check logs, fix the code or generated artifacts, run relevant verification locally, commit, and push.',
       checks: checkSummaries,
     }
+  } else if (ciResult.reviewNonRerunFailures.length) {
+    checkSummaries = summarizeChecks(ciResult.reviewNonRerunFailures)
+    ciClassification = 'non-rerun review failure'
+    state = 'CI_RED'
+    detail = `review check failed (not eligible for rerun): ${checkNames(ciResult.reviewNonRerunFailures)}`
   } else if (ciResult.reviewRerunFailures.length) {
     const rerun = rerunReviewCheck(
       pr,

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -3,11 +3,12 @@
 //
 //   scan   — read-only: list eligible PRs (auto-review label) + why.
 //   tick   — one pass: per eligible PR, compute the review state and act:
-//              NEEDS_FIX  → (with --execute) run.js <pr> --push   (an upsource cycle)
+//              NEEDS_FIX  → (with --execute) run.js <pr> --push   (review/CI fix)
 //                           dispatched CONCURRENTLY, capped at --max (default 2).
 //              GOOD_SHAPE → (with --approve) squash-merge AS THE ORCHESTRATOR BOT
 //                           (orchestrator.env) + delete branch.
-//              WAITING / CI_RED → report only.
+//              WAITING   → report only, or rerun transient reviewer checks.
+//              CI_RED    → report only after reruns are exhausted/unavailable.
 //            State is mirrored to the linked Linear issue (a VIM-N in the PR body)
 //            via lib/linear-status.js — Linear is the control plane / observability.
 //   watch  — loop `tick` every pollSeconds (Ctrl-C to stop).
@@ -31,6 +32,13 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { botLabel, botProcessEnv, loadBot } from './lib/bot-identity.js'
 import {
+  REVIEW_CHECKS,
+  checkLabel,
+  classifyChecks,
+  runIdFromCheck,
+  summarizeChecks,
+} from './lib/ci-policy.js'
+import {
   actionForDecision,
   decisionKey,
   decisionStorePath,
@@ -39,7 +47,15 @@ import {
   readDecisionStore,
   shouldPostDecision,
 } from './lib/decision-comment.js'
-import { linkedVim } from './lib/pr-utils.js'
+import { orchestratorTool } from './lib/orchestrator-tools.js'
+import { linkedVimForPr, writeLinkedIssueCache } from './lib/pr-utils.js'
+import {
+  markRerunAttempt,
+  readRerunStore,
+  rerunKey,
+  rerunStatus,
+  rerunStorePath,
+} from './lib/rerun-state.js'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const LOCK_DIR = join(SCRIPT_DIR, '.locks')
@@ -47,13 +63,7 @@ const LOG_DIR = join(SCRIPT_DIR, 'logs')
 const DEFAULT_LABEL = 'auto-review'
 const POLL_SECONDS = 60
 const MAX_PARALLEL = 2
-
-// CI checks that are the *reviewers*, not the build/test gate — excluded from "CI green".
-const REVIEW_CHECKS = new Set([
-  'Claude Code Review',
-  'Codex Code Review',
-  'Post Review Comment',
-])
+const MAX_CI_RERUNS = 3
 
 const out = (s = '') => process.stdout.write(`${s}\n`)
 const err = (s = '') => process.stderr.write(`${s}\n`)
@@ -182,7 +192,7 @@ const claudeVerdictClean = (owner, name, pr) => {
 }
 
 const checksFor = (pr) =>
-  ghJson(['pr', 'checks', String(pr), '--json', 'name,bucket'])
+  ghJson(['pr', 'checks', String(pr), '--json', 'name,bucket,link,workflow'])
 
 // Is a runner holding this PR's lock? Lazily reaps a STALE lock — one whose owner
 // PID is gone (host crash / SIGKILL before run.js released it) — so a requeued PR
@@ -222,20 +232,100 @@ const isLocked = (pr) => {
 }
 const hasLabel = (pr, label) => (pr.labels || []).some((l) => l.name === label)
 
+const checkNames = (checks) => checks.map(checkLabel).join(', ')
+
+const resolveLinkedIssue = async (pr, view, ctx) => {
+  const existing = linkedVimForPr({
+    body: view.body,
+    branch: pr.headRefName,
+    pr: pr.number,
+  })
+  if (existing || !ctx.linearCreateIssues) {
+    return existing
+  }
+
+  const tool = orchestratorTool('create_linear_issue_for_pr')
+  if (!tool) {
+    return null
+  }
+
+  try {
+    const issue = await tool.execute({
+      teamKey: ctx.linearTeamKey,
+      pr: pr.number,
+      title: pr.title,
+      url: view.url,
+      branch: pr.headRefName,
+    })
+    const identifier = writeLinkedIssueCache(pr.number, issue)
+    out(
+      `           ↳ Linear ${identifier}: created for unlinked PR #${pr.number}`
+    )
+
+    return identifier
+  } catch (e) {
+    out(`           ↳ Linear create skipped: ${e.message.split('\n')[0]}`)
+
+    return null
+  }
+}
+
+const rerunReviewCheck = (pr, check, headSha, ctx) => {
+  const runId = runIdFromCheck(check)
+  const storeFile = rerunStorePath(pr.number)
+  const store = readRerunStore(storeFile)
+  const key = rerunKey({ pr: pr.number, headSha, check })
+  const status = rerunStatus({ store, key, max: ctx.maxCiReruns })
+
+  if (!runId) {
+    return {
+      state: 'CI_RED',
+      detail: `review check failed with no Actions run to rerun: ${checkLabel(check)}`,
+      action: 'none',
+      rerunAttempt: status.count,
+      rerunLimit: ctx.maxCiReruns,
+    }
+  }
+
+  if (status.exhausted) {
+    return {
+      state: 'CI_RED',
+      detail: `rerun exhausted for ${checkLabel(check)} (${status.count}/${ctx.maxCiReruns})`,
+      action: 'none',
+      rerunAttempt: status.count,
+      rerunLimit: ctx.maxCiReruns,
+    }
+  }
+
+  if (!ctx.execute) {
+    return {
+      state: 'WAITING',
+      detail: `review check failed and can be rerun: ${checkLabel(check)} (${status.count}/${ctx.maxCiReruns})`,
+      action: 'none',
+      rerunAttempt: status.count,
+      rerunLimit: ctx.maxCiReruns,
+    }
+  }
+
+  gh(['run', 'rerun', runId, '--failed'])
+  markRerunAttempt(store, key, storeFile)
+
+  return {
+    state: 'WAITING',
+    detail: `reran ${checkLabel(check)} (attempt ${status.nextAttempt}/${ctx.maxCiReruns})`,
+    action: 'rerun check',
+    rerunAttempt: status.nextAttempt,
+    rerunLimit: ctx.maxCiReruns,
+  }
+}
+
 // The review state machine.
-const computeState = (pr, ctx) => {
+const computeState = async (pr, ctx) => {
   if (pr.isDraft) {
     return { state: 'WAITING', detail: 'draft' }
   }
   const checks = checksFor(pr.number)
-  const nonReview = checks.filter((c) => !REVIEW_CHECKS.has(c.name))
-
-  // 'cancel' (aborted) is not a pass — block it; only 'pass'/'skipping' count as green.
-  const ci = nonReview.some((c) => c.bucket === 'fail' || c.bucket === 'cancel')
-    ? 'fail'
-    : nonReview.some((c) => c.bucket === 'pending')
-      ? 'pending'
-      : 'green'
+  const ciResult = classifyChecks(checks, { reviewChecks: REVIEW_CHECKS })
   const claudeCheck = checks.find((c) => c.name === 'Claude Code Review')
   const claudeReady = claudeCheck?.bucket === 'pass'
   let claude = claudeReady
@@ -247,13 +337,45 @@ const computeState = (pr, ctx) => {
     'view',
     String(pr.number),
     '--json',
-    'mergeable,mergeStateStatus,body,headRefOid',
+    'mergeable,mergeStateStatus,body,headRefOid,url',
   ])
-  const vim = linkedVim(view.body)
+  const vim = await resolveLinkedIssue(pr, view, ctx)
   let state, detail
-  if (ci === 'fail') {
-    ;[state, detail] = ['CI_RED', 'non-review CI failing or canceled']
-  } else if (!claudeReady || ci === 'pending') {
+  let action
+  let rerunAttempt
+  let rerunLimit
+  let ciClassification
+  let checkSummaries = []
+  let fixContext
+
+  if (ciResult.deterministicFailures.length) {
+    checkSummaries = summarizeChecks(ciResult.deterministicFailures)
+    ciClassification = 'deterministic failure'
+    state = 'NEEDS_FIX'
+    detail = `deterministic CI failure: ${checkNames(ciResult.deterministicFailures)}`
+
+    fixContext = {
+      kind: 'deterministic_ci_failure',
+      instruction:
+        'The orchestrator dispatched this fixer because deterministic CI failed. Inspect the linked GitHub check logs, fix the code or generated artifacts, run relevant verification locally, commit, and push.',
+      checks: checkSummaries,
+    }
+  } else if (ciResult.reviewRerunFailures.length) {
+    const rerun = rerunReviewCheck(
+      pr,
+      ciResult.reviewRerunFailures[0],
+      view.headRefOid,
+      ctx
+    )
+    state = rerun.state
+    detail = rerun.detail
+    action = rerun.action
+    rerunAttempt = rerun.rerunAttempt
+    rerunLimit = rerun.rerunLimit
+    ciClassification =
+      state === 'CI_RED' ? 'rerun exhausted' : 'transient review failure'
+    checkSummaries = summarizeChecks(ciResult.reviewRerunFailures)
+  } else if (!claudeReady || ciResult.ci === 'pending') {
     ;[state, detail] = ['WAITING', 'CI / Claude re-running']
   } else {
     const threads = unresolvedThreads(ctx.owner, ctx.name, pr.number)
@@ -287,10 +409,16 @@ const computeState = (pr, ctx) => {
       vim,
       threads,
       headSha: view.headRefOid,
-      ci,
+      ci: ciResult.ci,
       claude,
       mergeable: view.mergeable,
       mergeStateStatus: view.mergeStateStatus,
+      action,
+      rerunAttempt,
+      rerunLimit,
+      ciClassification,
+      checkSummaries,
+      fixContext,
     }
   }
 
@@ -300,10 +428,16 @@ const computeState = (pr, ctx) => {
     vim,
     threads: null,
     headSha: view.headRefOid,
-    ci,
+    ci: ciResult.ci,
     claude,
     mergeable: view.mergeable,
     mergeStateStatus: view.mergeStateStatus,
+    action,
+    rerunAttempt,
+    rerunLimit,
+    ciClassification,
+    checkSummaries,
+    fixContext,
   }
 }
 
@@ -343,7 +477,7 @@ const maybePostDecisionLinear = (pr, s, ctx) => {
     return
   }
 
-  const action = actionForDecision(s.state, ctx)
+  const action = s.action || actionForDecision(s.state, ctx)
 
   const key = decisionKey({
     pr: pr.number,
@@ -353,6 +487,7 @@ const maybePostDecisionLinear = (pr, s, ctx) => {
     action,
     approve: ctx.approve,
     execute: ctx.execute,
+    selectedAction: s.action,
   })
   const storeFile = decisionStorePath(pr.number)
   const store = readDecisionStore(storeFile)
@@ -377,6 +512,10 @@ const maybePostDecisionLinear = (pr, s, ctx) => {
     threads: s.threads,
     mergeable: s.mergeable,
     mergeStateStatus: s.mergeStateStatus,
+    ciClassification: s.ciClassification,
+    checkSummaries: s.checkSummaries,
+    rerunAttempt: s.rerunAttempt,
+    rerunLimit: s.rerunLimit,
   })
 
   const stateName =
@@ -466,7 +605,7 @@ const approve = (pr, vim, headSha, ctx) => {
 // the console so concurrent runs stay legible. Resolves the exit code; never
 // rejects — a failed child must not abort the pool. run.js adopts the INNER
 // (fixer) bot identity itself, so we just inherit the env here.
-const dispatchFix = (pr) =>
+const dispatchFix = ({ pr, fixContext }) =>
   new Promise((resolve) => {
     mkdirSync(LOG_DIR, { recursive: true })
     const logPath = join(LOG_DIR, `pr-${pr}.log`)
@@ -478,7 +617,12 @@ const dispatchFix = (pr) =>
       'node',
       [join(SCRIPT_DIR, 'run.js'), String(pr), '--push'],
       {
-        env: process.env,
+        env: {
+          ...process.env,
+          ...(fixContext
+            ? { QA_FIX_CONTEXT: JSON.stringify(fixContext, null, 2) }
+            : {}),
+        },
       }
     )
 
@@ -558,7 +702,7 @@ const tick = async (ctx) => {
     }
     let s
     try {
-      s = computeState(pr, ctx)
+      s = await computeState(pr, ctx)
     } catch (e) {
       // A transient classification failure (gh checks / GraphQL) is NOT a clean tick —
       // flag it so the exit is non-zero and a supervising daemon counts it, rather
@@ -574,7 +718,7 @@ const tick = async (ctx) => {
     maybePostDecisionLinear(pr, s, ctx)
     if (s.state === 'NEEDS_FIX') {
       if (ctx.execute) {
-        needsFix.push(pr.number)
+        needsFix.push({ pr: pr.number, fixContext: s.fixContext })
       } else {
         out(`           (report-only — pass --execute to run the cycle)`)
       }
@@ -685,10 +829,13 @@ const main = () => {
     approve: has('approve'),
     execute: has('execute'),
     linearDecisions: has('linear-decisions'),
+    linearCreateIssues: has('linear-create-issues'),
     reason: val('reason') || 'manual',
     all: has('all'),
     pr: val('pr') ? Number(val('pr')) : undefined,
     maxParallel: Number(val('max')) || MAX_PARALLEL,
+    maxCiReruns: Number(val('max-ci-reruns')) || MAX_CI_RERUNS,
+    linearTeamKey: val('linear-team') || 'VIM',
     orchBot,
     approverLogin: orchBot?.user ?? ghJson(['api', 'user']).login,
   }
@@ -702,7 +849,7 @@ const main = () => {
     return watch(ctx)
   }
   err(
-    `unknown command: ${cmd}. Use: scan | tick | watch  [--pr N] [--approve] [--execute] [--linear-decisions] [--reason EVENT] [--all] [--max N] [--label NAME]`
+    `unknown command: ${cmd}. Use: scan | tick | watch  [--pr N] [--approve] [--execute] [--linear-decisions] [--linear-create-issues] [--max-ci-reruns N] [--linear-team KEY] [--reason EVENT] [--all] [--max N] [--label NAME]`
   )
   process.exit(1)
 }

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -450,7 +450,7 @@ const computeState = async (pr, ctx) => {
     state,
     detail,
     vim,
-    threads: null,
+    threads,
     headSha: view.headRefOid,
     ci: ciResult.ci,
     claude,

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -411,10 +411,10 @@ const computeState = async (pr, ctx) => {
     rerunLimit = rerun.rerunLimit
     ciClassification = rerun.ciClassification || 'transient review failure'
     checkSummaries = summarizeChecks(ciResult.reviewRerunFailures)
-  } else if (openThreads() > 0) {
-    ;[state, detail] = ['NEEDS_FIX', `${threads} unresolved thread(s)`]
   } else if (!claudeReady || ciResult.ci === 'pending') {
     ;[state, detail] = ['WAITING', 'CI / Claude re-running']
+  } else if (openThreads() > 0) {
+    ;[state, detail] = ['NEEDS_FIX', `${threads} unresolved thread(s)`]
   } else {
     // verdict is irrelevant until threads are clear — defer the fetch to here
     const verdict = claudeVerdictClean(ctx.owner, ctx.name, pr.number) // null|true|false


### PR DESCRIPTION
## Summary

- classify deterministic non-review CI failures as actionable `NEEDS_FIX` work
- rerun transient reviewer checks with a PR/head/check cap
- add structured Linear CI/rerun observability and opt-in missing issue creation

## Validation

- `npm test -- scripts/qa-runner/lib/ci-policy.test.js scripts/qa-runner/lib/rerun-state.test.js scripts/qa-runner/lib/linear-issue.test.js scripts/qa-runner/lib/pr-utils.test.js scripts/qa-runner/lib/linear-status.test.js scripts/qa-runner/lib/decision-comment.test.js scripts/qa-runner/lib/worker.test.js`
- `npx eslint` on touched QA runner files
- `npx prettier --check` on touched QA runner files
- `git diff --check`

Closes VIM-20