### PR TITLE
fix(qa-runner): thread Linear lifecycle comments

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,9 +63,9 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CSP Configuration](patterns/csp-configuration.md)                   | security           | 8        | 5    | 2026-05-16   |
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
-| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 10       | 2    | 2026-06-02   |
+| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 11       | 3    | 2026-06-02   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
-| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 43       | 10   | 2026-06-02   |
+| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 46       | 11   | 2026-06-02   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 7        | 2    | 2026-05-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,13 +63,13 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CSP Configuration](patterns/csp-configuration.md)                   | security           | 8        | 5    | 2026-05-16   |
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
-| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 9        | 2    | 2026-06-02   |
+| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 10       | 2    | 2026-06-02   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
-| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 41       | 10   | 2026-06-02   |
+| [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 43       | 10   | 2026-06-02   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 7        | 2    | 2026-05-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-20   |
-| [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 3        | 1    | 2026-05-07   |
+| [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 4        | 1    | 2026-06-02   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 18       | 0    | 2026-05-26   |
 | [Promise Patterns](patterns/promise-patterns.md)                     | code-quality       | 1        | 0    | 2026-05-31   |

--- a/docs/reviews/patterns/ci-orchestration-state.md
+++ b/docs/reviews/patterns/ci-orchestration-state.md
@@ -3,7 +3,7 @@ id: ci-orchestration-state
 category: correctness
 created: 2026-06-02
 last_updated: 2026-06-02
-ref_count: 2
+ref_count: 3
 ---
 
 # CI Orchestration State
@@ -109,4 +109,13 @@ Findings in the CI orchestration / QA runner pipeline where state is either lost
 - **File:** `scripts/qa-runner/lib/decision-comment.js`
 - **Finding:** When a PR had a legacy decision store (`{ "<pr>": "<key>" }`), `decisionEntry` converted it to `{ key }` and `shouldPostDecision` treated an unchanged decision as already posted. No `commentId`, `state`, or `headSha` was ever captured, so threading paths kept falling back to top-level Linear comments.
 - **Fix:** Updated `shouldPostDecision` to return `true` when the entry lacks a `commentId` property, forcing a one-time repost that backfills the metadata.
+- **Commit:** same commit as this entry
+
+### 11. Null commentId poisons store and stale IDs survive across reposts
+
+- **Source:** github-codex-connector | PR #332 round 2 | 2026-06-02
+- **Severity:** P2 / MEDIUM
+- **File:** `scripts/qa-runner/lib/decision-comment.js`
+- **Finding:** Round-1 changed `shouldPostDecision` to use `!('commentId' in entry)`, which correctly triggered reposts for legacy string entries missing the property. But it did not handle two related cases: (a) an entry whose `commentId` was explicitly `null` (e.g., Linear API returned success with no comment ID) was treated as already-posted because `'commentId' in entry` is `true`; and (b) `markDecisionPosted` conditionally spread `...(commentId != null && { commentId })`, so when a new post returned `null` after an earlier post had returned a real ID, the old ID survived in the store.
+- **Fix:** Changed `shouldPostDecision` to `!entry.commentId` so any falsy/missing/null `commentId` triggers a repost. Changed `markDecisionPosted` to explicitly write `commentId: null` when the caller passes `commentId: null`, ensuring stale IDs are cleared rather than silently retained.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/ci-orchestration-state.md
+++ b/docs/reviews/patterns/ci-orchestration-state.md
@@ -101,3 +101,12 @@ Findings in the CI orchestration / QA runner pipeline where state is either lost
 - **Finding:** `classifyChecks` produced `deterministicFailures` for non-review checks and `reviewRerunFailures` for failed review checks in `reviewRerunChecks`. A failed review check not in `reviewRerunChecks` fell through both lists, so `computeState` never saw it and the PR could reach `GOOD_SHAPE` despite the failure.
 - **Fix:** Added a `reviewNonRerunFailures` list to `classifyChecks` and mapped it to `CI_RED` in `computeState` before the `reviewRerunFailures` branch.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 10. Legacy decision store entries never backfill commentId
+
+- **Source:** github-codex-connector | PR #332 round 1 | 2026-06-02
+- **Severity:** P2 / MEDIUM
+- **File:** `scripts/qa-runner/lib/decision-comment.js`
+- **Finding:** When a PR had a legacy decision store (`{ "<pr>": "<key>" }`), `decisionEntry` converted it to `{ key }` and `shouldPostDecision` treated an unchanged decision as already posted. No `commentId`, `state`, or `headSha` was ever captured, so threading paths kept falling back to top-level Linear comments.
+- **Fix:** Updated `shouldPostDecision` to return `true` when the entry lacks a `commentId` property, forcing a one-time repost that backfills the metadata.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -3,7 +3,7 @@ id: error-surfacing
 category: error-handling
 created: 2026-04-10
 last_updated: 2026-06-02
-ref_count: 10
+ref_count: 11
 ---
 
 # Error Surfacing
@@ -439,4 +439,13 @@ failed" must mean the editor shows the original file, not the requested one.
 - **File:** `scripts/qa-runner/lib/decision-comment.js`
 - **Finding:** `markDecisionPosted` destructured `{ commentId, state, headSha, action } = {}` and unconditionally spread those names into the stored entry. When called with the 4-arg form, all four fields became `undefined` and `JSON.stringify` dropped them, erasing any previously stored `commentId`.
 - **Fix:** Replaced unconditional spread with conditional spreading: `...(commentId !== undefined && { commentId })`, etc.
+- **Commit:** same commit as this entry
+
+### 46. Parser for structured Linear output remains untested and silent-failure path has no log
+
+- **Source:** github-claude | PR #332 round 2 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** Round-1 added a structured `comment-id:\t<id>` line to `linear-status.js` and updated the regex in `watch.js`, but the parser (`commentIdFromLinearOutput`) was still defined inline in an untested file. When `createLinearComment` returned `null`, the regex matched the empty `comment-id:\t` line and silently returned `null`; the threaded reply was skipped and `markMergePosted` gated off the fallback path with no operator-visible indication.
+- **Fix:** Moved `commentIdFromLinearOutput` to `linear-status.js` as the exported `parseLinearCommentId`, added unit tests covering missing/empty/malformed output, and added an explicit `⚠ ... comment-id missing — threaded reply skipped` log in `approve()` so operators see the failure immediately.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -422,3 +422,21 @@ failed" must mean the editor shows the original file, not the requested one.
 - **Finding:** In `computeState`, `openThreads()` — a `gh api` GraphQL call — was evaluated before the `reviewRerunFailures` check. Prior to the PR, threads were fetched only in the fully-clean path. After the PR they were fetched whenever `deterministicFailures.length === 0`, including every case where a reviewer check had failed and a rerun was warranted. If the GraphQL thread-count API was down, the exception propagated out of `computeState` and the tick exited 2 — the rerun logic was never reached.
 - **Fix:** Moved the `reviewRerunFailures` check above `openThreads()` so reruns are attempted before the GraphQL thread query. Unresolved threads are still checked before `GOOD_SHAPE` approval, preserving the original priority semantics without adding a fragile API dependency to the rerun hot path.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 44. Fragile stdout-scraping in commentIdFromLinearOutput
+
+- **Source:** github-claude | PR #332 round 1 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `commentIdFromLinearOutput` regex-matched the human-readable stdout of `linear-status.js` to extract a comment ID. If the output format changed or `createLinearComment` returned `null`, the regex silently returned `null`, causing the threaded reply to be skipped with no log or alert.
+- **Fix:** Added a structured `comment-id:\t<id>` output line in `linear-status.js` and updated the parser to match the machine-readable token explicitly.
+- **Commit:** same commit as this entry
+
+### 45. markDecisionPosted undefined args silently erase stored commentId
+
+- **Source:** github-claude | PR #332 round 1 | 2026-06-02
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/lib/decision-comment.js`
+- **Finding:** `markDecisionPosted` destructured `{ commentId, state, headSha, action } = {}` and unconditionally spread those names into the stored entry. When called with the 4-arg form, all four fields became `undefined` and `JSON.stringify` dropped them, erasing any previously stored `commentId`.
+- **Fix:** Replaced unconditional spread with conditional spreading: `...(commentId !== undefined && { commentId })`, etc.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/module-boundaries.md
+++ b/docs/reviews/patterns/module-boundaries.md
@@ -2,7 +2,7 @@
 id: module-boundaries
 category: code-quality
 created: 2026-04-30
-last_updated: 2026-05-07
+last_updated: 2026-06-02
 ref_count: 1
 ---
 
@@ -51,3 +51,12 @@ Don't widen the coupling by adding a second importer.
 - **Finding:** `TerminalZone` decided whether to wire `aria-labelledby` on each panel by recomputing `isActive || status === 'running' || status === 'paused'` inline. The exact same predicate (modulo the `isActive` half) lives in `pickNextVisibleSessionId.ts` as `isOpenSessionStatus`, which `Sidebar` and `SessionTabs` both consume. Today the two are equivalent, but the moment `isOpenSessionStatus` is widened (e.g. to admit a future `suspended` status), `TerminalZone`'s `hasVisibleTab` would silently lag — panels for the new status would emit `aria-labelledby={undefined}` even though `SessionTabs` would render a visible tab for them, breaking the WAI-ARIA tablist↔tabpanel linkage with no build error and no test failure. Same finding-class as #2 above (sibling-shape mismatch is a coupling smell) but the consequence here is functional, not stylistic.
 - **Fix:** Imported `isOpenSessionStatus` from `../utils/pickNextVisibleSessionId`. Replaced the inline three-line OR with `isActive || isOpenSessionStatus(session.status)`. Updated the comment to state the canonical-predicate consumption rationale ("a future non-open status auto-flows into both visibility surfaces without TerminalZone needing a separate update"). Code-review heuristic: when two files in the same feature directory implement the same predicate inline, ONE of them should host the helper and the other(s) should consume it — and reviewers should flag the duplicate the moment the second copy lands, not after a status-set extension surfaces the drift.
 - **Commit:** _(see git log for the cycle-17 fix commit on PR #174)_
+
+### 4. Celebration message duplicated across events.js and watch.js
+
+- **Source:** github-claude | PR #332 round 1 | 2026-06-02
+- **Severity:** LOW
+- **File:** `scripts/qa-runner/lib/events.js`
+- **Finding:** The merged-celebration string was independently composed in two files. Editing one would silently cause divergent Linear comments depending on which code path ran.
+- **Fix:** Exported a shared `formatMergedComment(pr)` from `decision-comment.js` (the existing home for message formatters) and consumed it at both callsites.
+- **Commit:** same commit as this entry

--- a/scripts/qa-runner/lib/decision-comment.js
+++ b/scripts/qa-runner/lib/decision-comment.js
@@ -201,7 +201,7 @@ const decisionEntry = (store, pr) => {
 export const shouldPostDecision = (store, pr, key) => {
   const entry = decisionEntry(store, pr)
 
-  return entry.key !== key || !('commentId' in entry)
+  return entry.key !== key || !entry.commentId
 }
 
 export const decisionCommentId = (
@@ -248,7 +248,7 @@ export const markDecisionPosted = (
     [String(pr)]: {
       ...decisionEntry(store, pr),
       key,
-      ...(commentId !== undefined && { commentId }),
+      ...(commentId !== undefined && { commentId: commentId ?? null }),
       ...(state !== undefined && { state }),
       ...(headSha !== undefined && { headSha }),
       ...(action !== undefined && { action }),

--- a/scripts/qa-runner/lib/decision-comment.js
+++ b/scripts/qa-runner/lib/decision-comment.js
@@ -183,12 +183,83 @@ export const readDecisionStore = (file) => {
   }
 }
 
-export const shouldPostDecision = (store, pr, key) => store[String(pr)] !== key
+const decisionEntry = (store, pr) => {
+  const entry = store[String(pr)]
+  if (!entry) {
+    return {}
+  }
+  if (typeof entry === 'string') {
+    return { key: entry }
+  }
 
-export const markDecisionPosted = (store, pr, key, file) => {
-  const next = { ...store, [String(pr)]: key }
+  return entry
+}
+
+export const shouldPostDecision = (store, pr, key) =>
+  decisionEntry(store, pr).key !== key
+
+export const decisionCommentId = (
+  store,
+  pr,
+  { state, headSha, action } = {}
+) => {
+  const entry = decisionEntry(store, pr)
+  if (!entry.commentId) {
+    return null
+  }
+  if (state && entry.state !== state) {
+    return null
+  }
+  if (headSha && entry.headSha !== headSha) {
+    return null
+  }
+  if (action && entry.action !== action) {
+    return null
+  }
+
+  return entry.commentId
+}
+
+export const hasMergeLinearPosted = (store, pr) =>
+  Boolean(decisionEntry(store, pr).mergeLinearPosted)
+
+const writeDecisionStore = (next, file) => {
   mkdirSync(dirname(file), { recursive: true })
   writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`)
 
   return next
+}
+
+export const markDecisionPosted = (
+  store,
+  pr,
+  key,
+  file,
+  { commentId, state, headSha, action } = {}
+) => {
+  const next = {
+    ...store,
+    [String(pr)]: {
+      ...decisionEntry(store, pr),
+      key,
+      commentId,
+      state,
+      headSha,
+      action,
+    },
+  }
+
+  return writeDecisionStore(next, file)
+}
+
+export const markMergeLinearPosted = (store, pr, file) => {
+  const next = {
+    ...store,
+    [String(pr)]: {
+      ...decisionEntry(store, pr),
+      mergeLinearPosted: true,
+    },
+  }
+
+  return writeDecisionStore(next, file)
 }

--- a/scripts/qa-runner/lib/decision-comment.js
+++ b/scripts/qa-runner/lib/decision-comment.js
@@ -142,6 +142,9 @@ export const formatDecisionComment = ({
   return lines.join('\n')
 }
 
+export const formatMergedComment = (pr) =>
+  `🎉 #${pr} merged — review loop complete.`
+
 export const formatFixerCycleComment = ({
   pr,
   url,
@@ -195,8 +198,11 @@ const decisionEntry = (store, pr) => {
   return entry
 }
 
-export const shouldPostDecision = (store, pr, key) =>
-  decisionEntry(store, pr).key !== key
+export const shouldPostDecision = (store, pr, key) => {
+  const entry = decisionEntry(store, pr)
+
+  return entry.key !== key || !('commentId' in entry)
+}
 
 export const decisionCommentId = (
   store,
@@ -242,10 +248,10 @@ export const markDecisionPosted = (
     [String(pr)]: {
       ...decisionEntry(store, pr),
       key,
-      commentId,
-      state,
-      headSha,
-      action,
+      ...(commentId !== undefined && { commentId }),
+      ...(state !== undefined && { state }),
+      ...(headSha !== undefined && { headSha }),
+      ...(action !== undefined && { action }),
     },
   }
 

--- a/scripts/qa-runner/lib/decision-comment.test.js
+++ b/scripts/qa-runner/lib/decision-comment.test.js
@@ -187,7 +187,12 @@ describe('decision store', () => {
 
     expect(shouldPostDecision(empty, 329, key)).toBe(true)
 
-    const updated = markDecisionPosted(empty, 329, key, file)
+    const updated = markDecisionPosted(empty, 329, key, file, {
+      commentId: 'test-comment-id',
+      state: 'GOOD_SHAPE',
+      headSha: 'abc',
+      action: 'none',
+    })
 
     expect(shouldPostDecision(updated, 329, key)).toBe(false)
     expect(shouldPostDecision(readDecisionStore(file), 329, key)).toBe(false)
@@ -196,7 +201,8 @@ describe('decision store', () => {
   test('keeps old string store entries compatible', () => {
     const store = { 329: 'legacy-key' }
 
-    expect(shouldPostDecision(store, 329, 'legacy-key')).toBe(false)
+    // Legacy entries are posted again once to backfill commentId for threading
+    expect(shouldPostDecision(store, 329, 'legacy-key')).toBe(true)
     expect(shouldPostDecision(store, 329, 'new-key')).toBe(true)
   })
 

--- a/scripts/qa-runner/lib/decision-comment.test.js
+++ b/scripts/qa-runner/lib/decision-comment.test.js
@@ -206,6 +206,12 @@ describe('decision store', () => {
     expect(shouldPostDecision(store, 329, 'new-key')).toBe(true)
   })
 
+  test('re-posts when commentId is null or missing', () => {
+    const store = { 329: { key: 'same-key', commentId: null } }
+
+    expect(shouldPostDecision(store, 329, 'same-key')).toBe(true)
+  })
+
   test('records the decision comment id for threaded follow-up comments', () => {
     const file = makeStore()
 

--- a/scripts/qa-runner/lib/decision-comment.test.js
+++ b/scripts/qa-runner/lib/decision-comment.test.js
@@ -4,10 +4,13 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'vitest'
 import {
   actionForDecision,
+  decisionCommentId,
   decisionKey,
   formatDecisionComment,
   formatFixerCycleComment,
+  hasMergeLinearPosted,
   markDecisionPosted,
+  markMergeLinearPosted,
   readDecisionStore,
   shouldPostDecision,
 } from './decision-comment.js'
@@ -188,5 +191,55 @@ describe('decision store', () => {
 
     expect(shouldPostDecision(updated, 329, key)).toBe(false)
     expect(shouldPostDecision(readDecisionStore(file), 329, key)).toBe(false)
+  })
+
+  test('keeps old string store entries compatible', () => {
+    const store = { 329: 'legacy-key' }
+
+    expect(shouldPostDecision(store, 329, 'legacy-key')).toBe(false)
+    expect(shouldPostDecision(store, 329, 'new-key')).toBe(true)
+  })
+
+  test('records the decision comment id for threaded follow-up comments', () => {
+    const file = makeStore()
+
+    const key = decisionKey({
+      pr: 331,
+      state: 'NEEDS_FIX',
+      detail: 'Claude verdict: patch has issues',
+      headSha: '8cd325f2efe5f0af0147257343cadfadc06b987c',
+      action: 'dispatch fixer',
+      approve: false,
+      execute: true,
+    })
+
+    const updated = markDecisionPosted({}, 331, key, file, {
+      commentId: 'linear-comment-id',
+      state: 'NEEDS_FIX',
+      headSha: '8cd325f2efe5f0af0147257343cadfadc06b987c',
+      action: 'dispatch fixer',
+    })
+
+    expect(
+      decisionCommentId(updated, 331, {
+        state: 'NEEDS_FIX',
+        headSha: '8cd325f2efe5f0af0147257343cadfadc06b987c',
+        action: 'dispatch fixer',
+      })
+    ).toBe('linear-comment-id')
+
+    expect(
+      decisionCommentId(updated, 331, {
+        state: 'GOOD_SHAPE',
+      })
+    ).toBeNull()
+  })
+
+  test('tracks when the approval path already posted the merged Linear thread', () => {
+    const file = makeStore()
+    const updated = markMergeLinearPosted({}, 331, file)
+
+    expect(hasMergeLinearPosted(updated, 331)).toBe(true)
+    expect(hasMergeLinearPosted(readDecisionStore(file), 331)).toBe(true)
   })
 })

--- a/scripts/qa-runner/lib/events.js
+++ b/scripts/qa-runner/lib/events.js
@@ -61,11 +61,15 @@ export const createEvents = (log) => {
       return
     }
 
-    const child = spawn(
-      'node',
-      [LINEAR_STATUS, vim, fmt(e), '--as', 'orchestrator'],
-      { stdio: 'ignore' }
-    )
+    const args = [LINEAR_STATUS, vim, fmt(e), '--as', 'orchestrator']
+    if (e.parentId) {
+      args.push('--parent', e.parentId)
+    }
+    if (e.type === 'merged') {
+      args.push('--state', 'Done')
+    }
+
+    const child = spawn('node', args, { stdio: 'ignore' })
     child.on('error', () => {
       // best-effort: Linear observability must never break the loop
     })

--- a/scripts/qa-runner/lib/events.js
+++ b/scripts/qa-runner/lib/events.js
@@ -9,6 +9,7 @@ import { spawn } from 'node:child_process'
 import { appendFileSync, mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { formatMergedComment } from './decision-comment.js'
 
 const LIB_DIR = dirname(fileURLToPath(import.meta.url))
 const STATE_DIR = join(dirname(LIB_DIR), '.state')
@@ -32,7 +33,7 @@ const LINEAR_COMMENT = {
     ].join('\n'),
   paused: (e) =>
     `⏸️ Paused #${e.pr} after ${e.noopCount} failed fix attempts — ${e.detail || 'needs a look'}.`,
-  merged: (e) => `🎉 #${e.pr} merged — review loop complete.`,
+  merged: (e) => formatMergedComment(e.pr),
   closed: (e) => `🚫 #${e.pr} closed without merge — review loop stopped.`,
 }
 

--- a/scripts/qa-runner/lib/linear-status.js
+++ b/scripts/qa-runner/lib/linear-status.js
@@ -209,6 +209,7 @@ export const main = async () => {
   process.stdout.write(
     `commented on ${identifier} (as ${auth.who}${commentId ? `, comment ${commentId}` : ''}${parentId ? `, parent ${parentId}` : ''})\n`
   )
+  process.stdout.write(`comment-id:\t${commentId ?? ''}\n`)
 
   if (stateName) {
     const s = await linearGql(

--- a/scripts/qa-runner/lib/linear-status.js
+++ b/scripts/qa-runner/lib/linear-status.js
@@ -158,6 +158,9 @@ export const linearGql = async (auth, query, variables, fetchImpl = fetch) => {
   return json.data
 }
 
+export const parseLinearCommentId = (stdout) =>
+  (stdout.match(/comment-id:\t([0-9a-f-]*)/) || [])[1] || null
+
 export const createLinearComment = async (
   auth,
   { issueId, parentId, body },

--- a/scripts/qa-runner/lib/linear-status.js
+++ b/scripts/qa-runner/lib/linear-status.js
@@ -9,7 +9,7 @@
 // access token is kept as a compatibility fallback; without either, it falls back
 // to the personal LINEAR_API_KEY ($env or repo-root linear.env).
 //
-// Usage: node linear-status.js <VIM-N> "<comment>" [--state "<name>"] [--as <role>]
+// Usage: node linear-status.js <VIM-N> "<comment>" [--state "<name>"] [--as <role>] [--parent <comment-id>]
 
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
@@ -158,15 +158,38 @@ export const linearGql = async (auth, query, variables, fetchImpl = fetch) => {
   return json.data
 }
 
+export const createLinearComment = async (
+  auth,
+  { issueId, parentId, body },
+  fetchImpl = fetch
+) => {
+  const data = parentId
+    ? await linearGql(
+        auth,
+        'mutation($parentId:String!,$body:String!){commentCreate(input:{parentId:$parentId,body:$body}){success comment{id}}}',
+        { parentId, body },
+        fetchImpl
+      )
+    : await linearGql(
+        auth,
+        'mutation($id:String!,$body:String!){commentCreate(input:{issueId:$id,body:$body}){success comment{id}}}',
+        { id: issueId, body },
+        fetchImpl
+      )
+
+  return data.commentCreate?.comment?.id ?? null
+}
+
 export const main = async () => {
   const [identifier, body, ...rest] = process.argv.slice(2)
   if (!identifier || !body) {
     throw new Error(
-      'usage: linear-status.js <VIM-N> "<comment>" [--state "<name>"] [--as <role>]'
+      'usage: linear-status.js <VIM-N> "<comment>" [--state "<name>"] [--as <role>] [--parent <comment-id>]'
     )
   }
   const flag = (n) => (rest.includes(n) ? rest[rest.indexOf(n) + 1] : undefined)
   const stateName = flag('--state')
+  const parentId = flag('--parent')
   const auth = await loadAuth(flag('--as'))
 
   const d = await linearGql(
@@ -178,12 +201,14 @@ export const main = async () => {
     throw new Error(`issue ${identifier} not found`)
   }
 
-  await linearGql(
-    auth.header,
-    'mutation($id:String!,$body:String!){commentCreate(input:{issueId:$id,body:$body}){success}}',
-    { id: d.issue.id, body }
+  const commentId = await createLinearComment(auth.header, {
+    issueId: d.issue.id,
+    parentId,
+    body,
+  })
+  process.stdout.write(
+    `commented on ${identifier} (as ${auth.who}${commentId ? `, comment ${commentId}` : ''}${parentId ? `, parent ${parentId}` : ''})\n`
   )
-  process.stdout.write(`commented on ${identifier} (as ${auth.who})\n`)
 
   if (stateName) {
     const s = await linearGql(

--- a/scripts/qa-runner/lib/linear-status.test.js
+++ b/scripts/qa-runner/lib/linear-status.test.js
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { loadAuthFromRoot } from './linear-status.js'
+import { createLinearComment, loadAuthFromRoot } from './linear-status.js'
 
 const tempRoots = []
 const originalLinearApiKey = process.env.LINEAR_API_KEY
@@ -117,6 +117,65 @@ describe('loadAuthFromRoot', () => {
     await expect(loadAuthFromRoot(undefined, root, vi.fn())).resolves.toEqual({
       header: 'lin_api_test',
       who: 'you (personal key)',
+    })
+  })
+})
+
+describe('createLinearComment', () => {
+  test('creates a top-level issue comment when no parent is provided', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: {
+          commentCreate: {
+            success: true,
+            comment: { id: 'top-level-comment' },
+          },
+        },
+      }),
+    }))
+
+    await expect(
+      createLinearComment(
+        'Bearer token',
+        { issueId: 'issue-id', body: 'body' },
+        fetchImpl
+      )
+    ).resolves.toBe('top-level-comment')
+
+    const payload = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(payload.query).toContain('issueId')
+    expect(payload.query).not.toContain('parentId')
+    expect(payload.variables).toEqual({ id: 'issue-id', body: 'body' })
+  })
+
+  test('creates a threaded reply when parent is provided', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: {
+          commentCreate: {
+            success: true,
+            comment: { id: 'reply-comment' },
+          },
+        },
+      }),
+    }))
+
+    await expect(
+      createLinearComment(
+        'Bearer token',
+        { issueId: 'issue-id', parentId: 'parent-comment', body: 'body' },
+        fetchImpl
+      )
+    ).resolves.toBe('reply-comment')
+
+    const payload = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(payload.query).toContain('parentId')
+    expect(payload.query).not.toContain('issueId')
+    expect(payload.variables).toEqual({
+      parentId: 'parent-comment',
+      body: 'body',
     })
   })
 })

--- a/scripts/qa-runner/lib/linear-status.test.js
+++ b/scripts/qa-runner/lib/linear-status.test.js
@@ -2,7 +2,11 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { createLinearComment, loadAuthFromRoot } from './linear-status.js'
+import {
+  createLinearComment,
+  loadAuthFromRoot,
+  parseLinearCommentId,
+} from './linear-status.js'
 
 const tempRoots = []
 const originalLinearApiKey = process.env.LINEAR_API_KEY
@@ -177,5 +181,33 @@ describe('createLinearComment', () => {
       parentId: 'parent-comment',
       body: 'body',
     })
+  })
+})
+
+describe('parseLinearCommentId', () => {
+  test('extracts comment id from structured stdout', () => {
+    expect(
+      parseLinearCommentId(
+        'commented on VIM-20 (as orchestrator, comment abc-123)\ncomment-id:\tabc-123\n'
+      )
+    ).toBe('abc-123')
+  })
+
+  test('returns null when comment-id line is empty', () => {
+    expect(
+      parseLinearCommentId(
+        'commented on VIM-20 (as orchestrator)\ncomment-id:\t\n'
+      )
+    ).toBeNull()
+  })
+
+  test('returns null when comment-id line is missing', () => {
+    expect(
+      parseLinearCommentId('commented on VIM-20 (as orchestrator)\n')
+    ).toBeNull()
+  })
+
+  test('returns null for empty stdout', () => {
+    expect(parseLinearCommentId('')).toBeNull()
   })
 })

--- a/scripts/qa-runner/lib/worker.js
+++ b/scripts/qa-runner/lib/worker.js
@@ -15,6 +15,12 @@ import { execFileSync, spawn } from 'node:child_process'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
+  decisionCommentId,
+  decisionStorePath,
+  hasMergeLinearPosted,
+  readDecisionStore,
+} from './decision-comment.js'
+import {
   DISPATCH_BLOCKED_EXIT,
   clearDispatchBlocker,
   dispatchBlockerDetail,
@@ -131,6 +137,18 @@ const pauseLabel = (st, maxNoops) =>
     ? 'dispatch blocked'
     : `${st.noopCount}/${maxNoops} failed`
 
+const decisionStore = (pr) => readDecisionStore(decisionStorePath(pr))
+
+const needsFixParentId = (pr, headSha) =>
+  decisionCommentId(decisionStore(pr), pr, {
+    state: 'NEEDS_FIX',
+    headSha,
+    action: 'dispatch fixer',
+  })
+
+const shouldPostMergedLinear = (pr) =>
+  !hasMergeLinearPosted(decisionStore(pr), pr)
+
 // 'done' | 'progress' | 'error' | 'waiting' | 'paused' | 'blocked' | 'skip' | 'retry'.
 export const runOne = async (pr, reason, deps) => {
   const {
@@ -170,7 +188,12 @@ export const runOne = async (pr, reason, deps) => {
     state.forget(pr)
     if (tracked) {
       const type = before.state === 'MERGED' ? 'merged' : 'closed'
-      events.emit({ type, pr, detail: before.state }, before.vim)
+      events.emit(
+        { type, pr, detail: before.state },
+        type === 'merged' && !shouldPostMergedLinear(pr)
+          ? undefined
+          : before.vim
+      )
     }
 
     return 'done'
@@ -224,7 +247,10 @@ export const runOne = async (pr, reason, deps) => {
   // "merged" milestone for a PR a human just closed.
   if (after.state === 'MERGED') {
     state.forget(pr)
-    events.emit({ type: 'merged', pr, detail: after.state }, after.vim)
+    events.emit(
+      { type: 'merged', pr, detail: after.state },
+      shouldPostMergedLinear(pr) ? after.vim : undefined
+    )
 
     return 'done'
   }
@@ -252,7 +278,16 @@ export const runOne = async (pr, reason, deps) => {
       pausedAt: null,
       pauseReason: null,
     })
-    events.emit({ type: 'progress', pr, round }, after.vim)
+
+    events.emit(
+      {
+        type: 'progress',
+        pr,
+        round,
+        parentId: needsFixParentId(pr, before.headSha),
+      },
+      after.vim
+    )
 
     return 'progress'
   }

--- a/scripts/qa-runner/lib/worker.test.js
+++ b/scripts/qa-runner/lib/worker.test.js
@@ -1,4 +1,11 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import { rmSync } from 'node:fs'
+import {
+  decisionKey,
+  decisionStorePath,
+  markDecisionPosted,
+  markMergeLinearPosted,
+} from './decision-comment.js'
 import {
   DISPATCH_BLOCKED_EXIT,
   clearDispatchBlocker,
@@ -27,6 +34,7 @@ const makeDeps = (overrides = {}) => ({
 
 afterEach(() => {
   clearDispatchBlocker(42)
+  rmSync(decisionStorePath(42), { force: true })
 })
 
 const missingPrSnapshotExec = (pr) => () => {
@@ -52,6 +60,23 @@ const openPrSnapshotExec = ({
       headRefName: branch,
     })
   )
+
+const prSnapshot = ({
+  headSha = 'abc123',
+  state = 'OPEN',
+  body = 'Closes VIM-20',
+  branch = 'feature/example',
+  labels = [{ name: 'auto-review' }],
+  isDraft = false,
+} = {}) =>
+  JSON.stringify({
+    headRefOid: headSha,
+    state,
+    body,
+    isDraft,
+    labels,
+    headRefName: branch,
+  })
 
 describe('isMissingPullRequestSnapshot', () => {
   test('identifies GitHub PR-not-found snapshot failures', () => {
@@ -226,6 +251,71 @@ describe('runOne', () => {
     expect(tickRunner).not.toHaveBeenCalled()
     expect(deps.log).toHaveBeenCalledWith(
       '#42: paused (dispatch blocked) — poll skip'
+    )
+  })
+
+  test('threads progress events under the triggering NEEDS_FIX decision', async () => {
+    const key = decisionKey({
+      pr: 42,
+      state: 'NEEDS_FIX',
+      detail: 'Claude verdict: patch has issues',
+      headSha: 'old-head',
+      action: 'dispatch fixer',
+      approve: false,
+      execute: true,
+    })
+    markDecisionPosted({}, 42, key, decisionStorePath(42), {
+      commentId: 'needs-fix-comment',
+      state: 'NEEDS_FIX',
+      headSha: 'old-head',
+      action: 'dispatch fixer',
+    })
+
+    const deps = makeDeps({
+      snapshotExec: vi
+        .fn()
+        .mockReturnValueOnce(prSnapshot({ headSha: 'old-head' }))
+        .mockReturnValueOnce(prSnapshot({ headSha: 'new-head' })),
+      tickRunner: vi.fn(async () => 0),
+    })
+
+    const outcome = await runOne(42, 'poll', deps)
+
+    expect(outcome).toBe('progress')
+    expect(deps.events.emit).toHaveBeenCalledWith(
+      {
+        type: 'progress',
+        pr: 42,
+        round: 1,
+        parentId: 'needs-fix-comment',
+      },
+      'VIM-20'
+    )
+  })
+
+  test('does not post a duplicate merged Linear event after approval already posted it', async () => {
+    markMergeLinearPosted({}, 42, decisionStorePath(42))
+
+    const deps = makeDeps({
+      snapshotExec: vi
+        .fn()
+        .mockReturnValueOnce(prSnapshot({ headSha: 'clean-head' }))
+        .mockReturnValueOnce(
+          prSnapshot({ headSha: 'clean-head', state: 'MERGED' })
+        ),
+      tickRunner: vi.fn(async () => 0),
+    })
+
+    const outcome = await runOne(42, 'approval', deps)
+
+    expect(outcome).toBe('done')
+    expect(deps.events.emit).toHaveBeenCalledWith(
+      {
+        type: 'merged',
+        pr: 42,
+        detail: 'MERGED',
+      },
+      undefined
     )
   })
 })

--- a/scripts/qa-runner/run.js
+++ b/scripts/qa-runner/run.js
@@ -30,7 +30,12 @@ import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { botEnv, botLabel, loadBot } from './lib/bot-identity.js'
-import { formatFixerCycleComment } from './lib/decision-comment.js'
+import {
+  decisionCommentId,
+  decisionStorePath,
+  formatFixerCycleComment,
+  readDecisionStore,
+} from './lib/decision-comment.js'
 import { RUN_SELF_REVIEW_EXIT } from './lib/dispatch-blocker.js'
 import { worktreePlan } from './lib/fixer-worktree.js'
 import { linkedVimForPr } from './lib/pr-utils.js'
@@ -376,17 +381,28 @@ const run = async (pr, live) => {
           worktreeClean: !worktreeStatus,
         })
 
-        spawnSync(
-          'node',
-          [
-            join(SCRIPT_DIR, 'lib', 'linear-status.js'),
-            vim,
-            body,
-            '--as',
-            'fixer',
-          ],
-          { stdio: 'inherit' }
+        const parentId = decisionCommentId(
+          readDecisionStore(decisionStorePath(pr)),
+          pr,
+          {
+            state: 'NEEDS_FIX',
+            headSha: startHead,
+            action: 'dispatch fixer',
+          }
         )
+
+        const args = [
+          join(SCRIPT_DIR, 'lib', 'linear-status.js'),
+          vim,
+          body,
+          '--as',
+          'fixer',
+        ]
+        if (parentId) {
+          args.push('--parent', parentId)
+        }
+
+        spawnSync('node', args, { stdio: 'inherit' })
       } else {
         out('(no VIM-N in the PR body — skipped Linear status.)')
       }

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -44,6 +44,7 @@ import {
   decisionStorePath,
   formatDecisionComment,
   markDecisionPosted,
+  markMergeLinearPosted,
   readDecisionStore,
   shouldPostDecision,
 } from './lib/decision-comment.js'
@@ -471,9 +472,17 @@ const computeState = async (pr, ctx) => {
   }
 }
 
-const postLinear = (vim, body, stateName) => {
+const commentIdFromLinearOutput = (stdout) =>
+  (stdout.match(/comment ([0-9a-f-]+)/i) || [])[1] ?? null
+
+const postLinear = (
+  vim,
+  body,
+  stateName,
+  { parentId, role = 'orchestrator' } = {}
+) => {
   if (!vim) {
-    return false
+    return { ok: false, commentId: null }
   }
 
   const args = [
@@ -481,24 +490,28 @@ const postLinear = (vim, body, stateName) => {
     vim,
     body,
     '--as',
-    'orchestrator',
+    role,
   ]
+  if (parentId) {
+    args.push('--parent', parentId)
+  }
   if (stateName) {
     args.push('--state', stateName)
   }
   const r = spawnSync('node', args, { encoding: 'utf8' })
   if (r.status === 0) {
+    const commentId = commentIdFromLinearOutput(r.stdout || '')
     out(
-      `           ↳ Linear ${vim}${stateName ? ` → ${stateName}` : ''}: commented`
+      `           ↳ Linear ${vim}${stateName ? ` → ${stateName}` : ''}: ${parentId ? 'replied' : 'commented'}`
     )
 
-    return true
+    return { ok: true, commentId }
   } else {
     out(
       `           ↳ Linear ${vim}: skipped (${(r.stderr || '').trim().split('\n')[0] || 'no LINEAR_API_KEY'})`
     )
 
-    return false
+    return { ok: false, commentId: null }
   }
 }
 
@@ -551,9 +564,20 @@ const maybePostDecisionLinear = (pr, s, ctx) => {
     s.state === 'NEEDS_FIX' && action === 'dispatch fixer'
       ? 'In Progress'
       : undefined
-  if (postLinear(s.vim, body, stateName)) {
-    markDecisionPosted(store, pr.number, key, storeFile)
+  const posted = postLinear(s.vim, body, stateName)
+  if (posted.ok) {
+    markDecisionPosted(store, pr.number, key, storeFile, {
+      commentId: posted.commentId,
+      state: s.state,
+      headSha: s.headSha,
+      action,
+    })
   }
+}
+
+const markMergePosted = (pr) => {
+  const storeFile = decisionStorePath(pr)
+  markMergeLinearPosted(readDecisionStore(storeFile), pr, storeFile)
 }
 
 // Squash-merge + branch delete as the orchestrator bot (or you, if none).
@@ -623,11 +647,23 @@ const approve = (pr, vim, headSha, ctx) => {
   } else {
     out(`           (fork PR — skipped remote branch deletion)`)
   }
-  postLinear(
+
+  const merged = postLinear(
     vim,
-    `QA runner: PR #${pr.number} met all review success criteria → squash-merged by ${merger}.`,
+    `🎉 #${pr.number} merged — review loop complete.`,
     'Done'
   )
+  if (merged.ok && merged.commentId) {
+    postLinear(
+      vim,
+      `QA runner: PR #${pr.number} met all review success criteria → squash-merged by ${merger}.`,
+      undefined,
+      { parentId: merged.commentId }
+    )
+  }
+  if (merged.ok) {
+    markMergePosted(pr.number)
+  }
 }
 
 // Run run.js for one PR as a child, teeing output to a per-PR log and prefixing

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -43,6 +43,7 @@ import {
   decisionKey,
   decisionStorePath,
   formatDecisionComment,
+  formatMergedComment,
   markDecisionPosted,
   markMergeLinearPosted,
   readDecisionStore,
@@ -473,7 +474,7 @@ const computeState = async (pr, ctx) => {
 }
 
 const commentIdFromLinearOutput = (stdout) =>
-  (stdout.match(/comment ([0-9a-f-]+)/i) || [])[1] ?? null
+  (stdout.match(/comment-id:\t([0-9a-f-]*)/) || [])[1] || null
 
 const postLinear = (
   vim,
@@ -650,7 +651,7 @@ const approve = (pr, vim, headSha, ctx) => {
 
   const merged = postLinear(
     vim,
-    `🎉 #${pr.number} merged — review loop complete.`,
+    formatMergedComment(pr.number),
     'Done'
   )
   if (merged.ok && merged.commentId) {

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -55,6 +55,7 @@ import {
   clearDispatchBlocker,
   writeDispatchBlocker,
 } from './lib/dispatch-blocker.js'
+import { parseLinearCommentId } from './lib/linear-status.js'
 import { orchestratorTool } from './lib/orchestrator-tools.js'
 import { linkedVimForPr, writeLinkedIssueCache } from './lib/pr-utils.js'
 import {
@@ -473,9 +474,6 @@ const computeState = async (pr, ctx) => {
   }
 }
 
-const commentIdFromLinearOutput = (stdout) =>
-  (stdout.match(/comment-id:\t([0-9a-f-]*)/) || [])[1] || null
-
 const postLinear = (
   vim,
   body,
@@ -501,7 +499,7 @@ const postLinear = (
   }
   const r = spawnSync('node', args, { encoding: 'utf8' })
   if (r.status === 0) {
-    const commentId = commentIdFromLinearOutput(r.stdout || '')
+    const commentId = parseLinearCommentId(r.stdout || '')
     out(
       `           ↳ Linear ${vim}${stateName ? ` → ${stateName}` : ''}: ${parentId ? 'replied' : 'commented'}`
     )
@@ -649,17 +647,17 @@ const approve = (pr, vim, headSha, ctx) => {
     out(`           (fork PR — skipped remote branch deletion)`)
   }
 
-  const merged = postLinear(
-    vim,
-    formatMergedComment(pr.number),
-    'Done'
-  )
+  const merged = postLinear(vim, formatMergedComment(pr.number), 'Done')
   if (merged.ok && merged.commentId) {
     postLinear(
       vim,
       `QA runner: PR #${pr.number} met all review success criteria → squash-merged by ${merger}.`,
       undefined,
       { parentId: merged.commentId }
+    )
+  } else if (merged.ok) {
+    out(
+      `           ⚠ Linear ${vim}: merge comment posted but comment-id missing — threaded reply skipped`
     )
   }
   if (merged.ok) {


### PR DESCRIPTION
## Summary

- Thread Kimi fixer-cycle and orchestrator fix-pushed Linear updates under the triggering NEEDS_FIX decision.
- Post the merge-complete celebration as the top-level Linear comment and the detailed merge sentence as its reply.
- Store Linear decision comment IDs in the QA runner decision store so follow-up lifecycle events can target the right parent.

## Validation

- npm test -- --run scripts/qa-runner/lib/*.test.js
- npx eslint --max-warnings=0 --no-warn-ignored scripts/qa-runner/lib/decision-comment.js scripts/qa-runner/lib/decision-comment.test.js scripts/qa-runner/lib/events.js scripts/qa-runner/lib/linear-status.js scripts/qa-runner/lib/linear-status.test.js scripts/qa-runner/lib/worker.js scripts/qa-runner/lib/worker.test.js scripts/qa-runner/run.js scripts/qa-runner/watch.js
- Full pre-push Vitest suite: 239 files, 3091 passed, 3 skipped

Refs VIM-20
