### PR TITLE
[codex] fix Linear threaded replies

### DIFF
--- a/scripts/qa-runner/lib/linear-status.js
+++ b/scripts/qa-runner/lib/linear-status.js
@@ -169,8 +169,8 @@ export const createLinearComment = async (
   const data = parentId
     ? await linearGql(
         auth,
-        'mutation($parentId:String!,$body:String!){commentCreate(input:{parentId:$parentId,body:$body}){success comment{id}}}',
-        { parentId, body },
+        'mutation($id:String!,$parentId:String!,$body:String!){commentCreate(input:{issueId:$id,parentId:$parentId,body:$body}){success comment{id}}}',
+        { id: issueId, parentId, body },
         fetchImpl
       )
     : await linearGql(

--- a/scripts/qa-runner/lib/linear-status.test.js
+++ b/scripts/qa-runner/lib/linear-status.test.js
@@ -153,7 +153,7 @@ describe('createLinearComment', () => {
     expect(payload.variables).toEqual({ id: 'issue-id', body: 'body' })
   })
 
-  test('creates a threaded reply when parent is provided', async () => {
+  test('creates a threaded reply with issue and parent ids', async () => {
     const fetchImpl = vi.fn(async () => ({
       ok: true,
       json: async () => ({
@@ -176,8 +176,9 @@ describe('createLinearComment', () => {
 
     const payload = JSON.parse(fetchImpl.mock.calls[0][1].body)
     expect(payload.query).toContain('parentId')
-    expect(payload.query).not.toContain('issueId')
+    expect(payload.query).toContain('issueId')
     expect(payload.variables).toEqual({
+      id: 'issue-id',
       parentId: 'parent-comment',
       body: 'body',
     })


### PR DESCRIPTION
## Summary

- include `issueId` alongside `parentId` when posting Linear threaded replies
- update the Linear status helper test to lock the required mutation shape

## Linear

Refs VIM-20

## Root Cause

The PR #325 smoke test showed Linear rejects `commentCreate(input:{parentId, body})` with `Linear GraphQL: Argument Validation Error`. The reply mutation succeeds when the already resolved issue id is sent as `commentCreate(input:{issueId, parentId, body})`.

## Validation

- `npm test -- --run scripts/qa-runner/lib/linear-status.test.js`
- `npm test -- --run scripts/qa-runner/lib/*.test.js`
