### PR TITLE
feat(qa-runner): explain QA runner cycle exits

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -63,14 +63,14 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CSP Configuration](patterns/csp-configuration.md)                   | security           | 8        | 5    | 2026-05-16   |
 | [PTY Session Management](patterns/pty-session-management.md)         | backend            | 8        | 2    | 2026-05-28   |
 | [Git Operations](patterns/git-operations.md)                         | correctness        | 25       | 10   | 2026-05-31   |
-| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 11       | 3    | 2026-06-02   |
+| [CI Orchestration State](patterns/ci-orchestration-state.md)         | correctness        | 12       | 3    | 2026-06-03   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)         | editor             | 12       | 0    | 2026-04-11   |
 | [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 46       | 11   | 2026-06-02   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 7        | 2    | 2026-05-12   |
 | [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-20   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 4        | 1    | 2026-06-02   |
-| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
+| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 10       | 2    | 2026-06-03   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 18       | 0    | 2026-05-26   |
 | [Promise Patterns](patterns/promise-patterns.md)                     | code-quality       | 1        | 0    | 2026-05-31   |
 | [Verify Render Target](patterns/verify-render-target.md)             | code-quality       | 2        | 0    | 2026-05-24   |

--- a/docs/reviews/patterns/ci-orchestration-state.md
+++ b/docs/reviews/patterns/ci-orchestration-state.md
@@ -2,7 +2,7 @@
 id: ci-orchestration-state
 category: correctness
 created: 2026-06-02
-last_updated: 2026-06-02
+last_updated: 2026-06-03
 ref_count: 3
 ---
 
@@ -119,3 +119,12 @@ Findings in the CI orchestration / QA runner pipeline where state is either lost
 - **Finding:** Round-1 changed `shouldPostDecision` to use `!('commentId' in entry)`, which correctly triggered reposts for legacy string entries missing the property. But it did not handle two related cases: (a) an entry whose `commentId` was explicitly `null` (e.g., Linear API returned success with no comment ID) was treated as already-posted because `'commentId' in entry` is `true`; and (b) `markDecisionPosted` conditionally spread `...(commentId != null && { commentId })`, so when a new post returned `null` after an earlier post had returned a real ID, the old ID survived in the store.
 - **Fix:** Changed `shouldPostDecision` to `!entry.commentId` so any falsy/missing/null `commentId` triggers a repost. Changed `markDecisionPosted` to explicitly write `commentId: null` when the caller passes `commentId: null`, ensuring stale IDs are cleared rather than silently retained.
 - **Commit:** same commit as this entry
+
+### 12. `error` events mapped to Linear comments for all categories create unbounded spam on transient failures
+
+- **Source:** github-codex-connector | PR #334 round 1 | 2026-06-03
+- **Severity:** P2 / MEDIUM
+- **File:** `scripts/qa-runner/lib/events.js`
+- **Finding:** `LINEAR_COMMENT` mapped every `type: 'error'` event to `formatCycleExitComment`, including `category: 'fixer_stall'` non-terminal exits. Each incremental fixer stall below `maxNoops` posted a new Linear "RETRY" comment, and transient errors (gh/GraphQL blips, exit 2) were unbounded in frequency. The pre-PR design intentionally kept types absent from `LINEAR_COMMENT` as pool-only to avoid spam.
+- **Fix:** Changed `LINEAR_COMMENT.error` to a gated formatter: `e.category === 'transient' ? formatCycleExitComment(e) : null`. Non-terminal fixer stalls are now pool-only; terminal stalls still surface via the `paused` type. Updated the test to assert `null` for fixer-stall errors.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/diagnostic-instrumentation.md
+++ b/docs/reviews/patterns/diagnostic-instrumentation.md
@@ -2,7 +2,7 @@
 id: diagnostic-instrumentation
 category: code-quality
 created: 2026-04-30
-last_updated: 2026-06-02
+last_updated: 2026-06-03
 ref_count: 3
 ---
 
@@ -115,4 +115,13 @@ The discipline:
 - **File:** `scripts/qa-runner/lib/decision-comment.js`
 - **Finding:** `shortSha` returns `` `abc1234` `` for a truthy SHA but the plain string `'unknown'` for a falsy one. Both `formatDecisionComment` and `formatFixerCycleComment` use the helper for the Head table row, producing inconsistent Markdown formatting: `| Head | unknown |` (plain text) versus `| Head | \`1b5cb1a\` |` (inline code).
 - **Fix:** Changed the falsy branch to return `` `unknown` `` so both branches produce inline-code spans.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 10. FIXER_EXIT log prefix includes dispatch-blocked exits, falsely implying a fixer failure
+
+- **Source:** github-claude | PR #334 round 1 | 2026-06-03
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/watch.js`
+- **Finding:** `results.filter((r) => r.code !== 0)` included `RUN_SELF_REVIEW_EXIT` (code 3). When run.js refused self-review, the loop logged `FIXER_EXIT #42: refusing to review PR #42 (exit 3; ...)`, which falsely implied the fixer ran and failed. The existing comment explicitly states "Self-review refusal is a local dispatch blocker, not a failed fixer attempt." This eroded `FIXER_EXIT` as a reliable fixer-failure signal.
+- **Fix:** Added `&& r.code !== RUN_SELF_REVIEW_EXIT` to the filter so dispatch-blocked exits are excluded from `FIXER_EXIT` logging. They remain correctly handled downstream by the `dispatchBlocked` branch.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/scripts/qa-runner/daemon.js
+++ b/scripts/qa-runner/daemon.js
@@ -144,19 +144,41 @@ const shutdown = (sig) => {
   const exitWhenDrained = () => {
     const inFlight = queue.inFlight()
     if (!inFlight.length) {
+      events.emit({
+        type: 'daemon_exit',
+        detail: 'drain complete',
+        signal: sig,
+        inFlight,
+        terminal: true,
+      })
       log('drain complete — exiting')
       process.exit(0)
     }
     setTimeout(exitWhenDrained, DRAIN_POLL_MS)
   }
 
-  log(`${sig} — draining; in-flight: ${queue.inFlight().join(', ') || 'none'}`)
+  const inFlight = queue.inFlight()
+  events.emit({
+    type: 'daemon_shutdown',
+    detail: `${sig} received; draining in-flight work`,
+    signal: sig,
+    inFlight,
+    terminal: false,
+  })
+  log(`${sig} — draining; in-flight: ${inFlight.join(', ') || 'none'}`)
   exitWhenDrained()
   server.close(() => {
     log('http server closed')
   })
 
   setTimeout(() => {
+    events.emit({
+      type: 'daemon_exit',
+      detail: 'drain window elapsed',
+      signal: sig,
+      inFlight: queue.inFlight(),
+      terminal: true,
+    })
     log('drain window elapsed — exiting')
     process.exit(0)
   }, DRAIN_TIMEOUT_MS)

--- a/scripts/qa-runner/lib/events.js
+++ b/scripts/qa-runner/lib/events.js
@@ -16,10 +16,51 @@ const STATE_DIR = join(dirname(LIB_DIR), '.state')
 const EVENTS_FILE = join(STATE_DIR, 'events.jsonl')
 const LINEAR_STATUS = join(LIB_DIR, 'linear-status.js')
 
+const tableValue = (value) =>
+  String(value ?? 'unknown')
+    .replace(/\r?\n/g, ' ')
+    .replace(/\|/g, '\\|')
+
+const formatCycleExitComment = (e) => {
+  const terminal = e.type === 'paused' || e.terminal
+
+  const lines = [
+    `## QA runner cycle exit: ${terminal ? 'PAUSED' : 'RETRY'}`,
+    '',
+    '| Field | Value |',
+    '| --- | --- |',
+    `| PR | #${tableValue(e.pr)} |`,
+    `| Category | ${tableValue(e.category || e.type)} |`,
+    `| Detail | ${tableValue(e.detail)} |`,
+    `| Exit code | \`${tableValue(e.exitCode)}\` |`,
+    `| Signal | \`${tableValue(e.signal || 'none')}\` |`,
+    `| Reason | ${tableValue(e.exitReason || e.detail)} |`,
+  ]
+
+  if (e.noopCount != null) {
+    lines.push(
+      `| Failed attempts | ${tableValue(e.noopCount)} / ${tableValue(e.maxNoops)} |`
+    )
+  }
+  if (e.logPath) {
+    lines.push(`| Log | \`${tableValue(e.logPath)}\` |`)
+  }
+
+  lines.push(
+    '',
+    terminal
+      ? 'Action: loop paused. A new head, CI/review event, or manual requeue is required before routine polling resumes.'
+      : 'Action: recorded the exit and will retry without incrementing the fixer failure streak.'
+  )
+
+  return lines.join('\n')
+}
+
 // type → a one-line Linear comment. Types absent here are pool/log only (no spam).
 const LINEAR_COMMENT = {
   progress: (e) =>
     `✅ Fix pushed for #${e.pr} (round ${e.round}). Re-review pending.`,
+  error: formatCycleExitComment,
   dispatch_blocked: (e) =>
     [
       '## QA runner dispatch blocked',
@@ -31,11 +72,13 @@ const LINEAR_COMMENT = {
       '',
       'The fixer did not run and this was not counted as a failed fix attempt. Run the daemon from a neutral checkout, free the PR branch worktree, or push a new head event to resume.',
     ].join('\n'),
-  paused: (e) =>
-    `⏸️ Paused #${e.pr} after ${e.noopCount} failed fix attempts — ${e.detail || 'needs a look'}.`,
+  paused: formatCycleExitComment,
   merged: (e) => formatMergedComment(e.pr),
   closed: (e) => `🚫 #${e.pr} closed without merge — review loop stopped.`,
 }
+
+export const formatLinearEventComment = (event) =>
+  LINEAR_COMMENT[event.type]?.(event) ?? null
 
 export const createEvents = (log) => {
   // Append to the pool + log every event; returns the stamped record.
@@ -57,12 +100,12 @@ export const createEvents = (log) => {
   // Milestone events post to the VIM issue as the orchestrator agent. Async +
   // fire-and-forget so a slow/down Linear never blocks the daemon.
   const toLinear = (vim, e) => {
-    const fmt = LINEAR_COMMENT[e.type]
-    if (!vim || !fmt) {
+    const body = formatLinearEventComment(e)
+    if (!vim || !body) {
       return
     }
 
-    const args = [LINEAR_STATUS, vim, fmt(e), '--as', 'orchestrator']
+    const args = [LINEAR_STATUS, vim, body, '--as', 'orchestrator']
     if (e.parentId) {
       args.push('--parent', e.parentId)
     }

--- a/scripts/qa-runner/lib/events.js
+++ b/scripts/qa-runner/lib/events.js
@@ -68,7 +68,7 @@ const formatCycleExitComment = (e) => {
 const LINEAR_COMMENT = {
   progress: (e) =>
     `✅ Fix pushed for #${e.pr} (round ${e.round}). Re-review pending.`,
-  error: formatCycleExitComment,
+  error: (e) => (e.category === 'transient' ? formatCycleExitComment(e) : null),
   dispatch_blocked: (e) =>
     [
       '## QA runner dispatch blocked',

--- a/scripts/qa-runner/lib/events.js
+++ b/scripts/qa-runner/lib/events.js
@@ -23,9 +23,11 @@ const tableValue = (value) =>
 
 const formatCycleExitComment = (e) => {
   const terminal = e.type === 'paused' || e.terminal
+  const fixerStall = e.category === 'fixer_stall'
+  const cycleState = terminal ? 'PAUSED' : fixerStall ? 'FIXER_STALL' : 'RETRY'
 
   const lines = [
-    `## QA runner cycle exit: ${terminal ? 'PAUSED' : 'RETRY'}`,
+    `## QA runner cycle exit: ${cycleState}`,
     '',
     '| Field | Value |',
     '| --- | --- |',
@@ -54,7 +56,9 @@ const formatCycleExitComment = (e) => {
     '',
     terminal
       ? 'Action: loop paused. A new head, CI/review event, or manual requeue is required before routine polling resumes.'
-      : 'Action: recorded the recoverable exit without incrementing the fixer failure streak. Poll-triggered exits retry on the next poll tick; webhook/manual exits are requeued by daemon backoff.'
+      : fixerStall
+        ? 'Action: recorded a failed fixer attempt without daemon backoff. Routine polling or a new review/CI event may dispatch another fixer cycle until the failed-attempt limit is reached.'
+        : 'Action: recorded the recoverable exit without incrementing the fixer failure streak. Poll-triggered exits retry on the next poll tick; webhook/manual exits are requeued by daemon backoff.'
   )
 
   return lines.join('\n')

--- a/scripts/qa-runner/lib/events.js
+++ b/scripts/qa-runner/lib/events.js
@@ -30,6 +30,7 @@ const formatCycleExitComment = (e) => {
     '| Field | Value |',
     '| --- | --- |',
     `| PR | #${tableValue(e.pr)} |`,
+    `| Source event | ${tableValue(e.sourceEvent)} |`,
     `| Category | ${tableValue(e.category || e.type)} |`,
     `| Detail | ${tableValue(e.detail)} |`,
     `| Exit code | \`${tableValue(e.exitCode)}\` |`,
@@ -45,12 +46,15 @@ const formatCycleExitComment = (e) => {
   if (e.logPath) {
     lines.push(`| Log | \`${tableValue(e.logPath)}\` |`)
   }
+  if (e.retryMode) {
+    lines.push(`| Retry mode | ${tableValue(e.retryMode)} |`)
+  }
 
   lines.push(
     '',
     terminal
       ? 'Action: loop paused. A new head, CI/review event, or manual requeue is required before routine polling resumes.'
-      : 'Action: recorded the exit and will retry without incrementing the fixer failure streak.'
+      : 'Action: recorded the recoverable exit without incrementing the fixer failure streak. Poll-triggered exits retry on the next poll tick; webhook/manual exits are requeued by daemon backoff.'
   )
 
   return lines.join('\n')

--- a/scripts/qa-runner/lib/events.test.js
+++ b/scripts/qa-runner/lib/events.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+import { formatLinearEventComment } from './events.js'
+
+describe('formatLinearEventComment', () => {
+  test('formats retryable process exits with explicit reason and log path', () => {
+    const body = formatLinearEventComment({
+      type: 'error',
+      pr: 42,
+      category: 'transient',
+      detail: 'watch.js transient (exit -1)',
+      exitCode: -1,
+      signal: 'SIGTERM',
+      exitReason: 'watch.js terminated by SIGTERM',
+      logPath: '/repo/scripts/qa-runner/logs/pr-42.log',
+      terminal: false,
+    })
+
+    expect(body).toContain('## QA runner cycle exit: RETRY')
+    expect(body).toContain('| PR | #42 |')
+    expect(body).toContain('| Category | transient |')
+    expect(body).toContain('| Exit code | `-1` |')
+    expect(body).toContain('| Signal | `SIGTERM` |')
+    expect(body).toContain('| Reason | watch.js terminated by SIGTERM |')
+    expect(body).toContain('| Log | `/repo/scripts/qa-runner/logs/pr-42.log` |')
+    expect(body).toContain('will retry')
+  })
+
+  test('formats paused process exits as terminal loop stops', () => {
+    const body = formatLinearEventComment({
+      type: 'paused',
+      pr: 42,
+      category: 'fixer_stall',
+      detail: 'fixer stall (watch.js exit 1)',
+      exitCode: 1,
+      signal: null,
+      exitReason: 'kimi produced no commit',
+      noopCount: 3,
+      maxNoops: 3,
+      terminal: true,
+    })
+
+    expect(body).toContain('## QA runner cycle exit: PAUSED')
+    expect(body).toContain('| Failed attempts | 3 / 3 |')
+    expect(body).toContain('loop paused')
+  })
+})

--- a/scripts/qa-runner/lib/events.test.js
+++ b/scripts/qa-runner/lib/events.test.js
@@ -6,29 +6,34 @@ describe('formatLinearEventComment', () => {
     const body = formatLinearEventComment({
       type: 'error',
       pr: 42,
+      sourceEvent: 'poll',
       category: 'transient',
       detail: 'watch.js transient (exit -1)',
       exitCode: -1,
       signal: 'SIGTERM',
       exitReason: 'watch.js terminated by SIGTERM',
       logPath: '/repo/scripts/qa-runner/logs/pr-42.log',
+      retryMode: 'next poll tick',
       terminal: false,
     })
 
     expect(body).toContain('## QA runner cycle exit: RETRY')
     expect(body).toContain('| PR | #42 |')
+    expect(body).toContain('| Source event | poll |')
     expect(body).toContain('| Category | transient |')
     expect(body).toContain('| Exit code | `-1` |')
     expect(body).toContain('| Signal | `SIGTERM` |')
     expect(body).toContain('| Reason | watch.js terminated by SIGTERM |')
     expect(body).toContain('| Log | `/repo/scripts/qa-runner/logs/pr-42.log` |')
-    expect(body).toContain('will retry')
+    expect(body).toContain('| Retry mode | next poll tick |')
+    expect(body).toContain('Poll-triggered exits retry on the next poll tick')
   })
 
   test('formats paused process exits as terminal loop stops', () => {
     const body = formatLinearEventComment({
       type: 'paused',
       pr: 42,
+      sourceEvent: 'poll',
       category: 'fixer_stall',
       detail: 'fixer stall (watch.js exit 1)',
       exitCode: 1,

--- a/scripts/qa-runner/lib/events.test.js
+++ b/scripts/qa-runner/lib/events.test.js
@@ -49,7 +49,7 @@ describe('formatLinearEventComment', () => {
     expect(body).toContain('loop paused')
   })
 
-  test('formats non-paused fixer stalls as failed attempts', () => {
+  test('returns null for non-paused fixer stall errors to avoid Linear spam', () => {
     const body = formatLinearEventComment({
       type: 'error',
       pr: 42,
@@ -64,9 +64,6 @@ describe('formatLinearEventComment', () => {
       terminal: false,
     })
 
-    expect(body).toContain('## QA runner cycle exit: FIXER_STALL')
-    expect(body).toContain('| Source event | comment:/upsource-review |')
-    expect(body).toContain('| Failed attempts | 1 / 3 |')
-    expect(body).toContain('without daemon backoff')
+    expect(body).toBeNull()
   })
 })

--- a/scripts/qa-runner/lib/events.test.js
+++ b/scripts/qa-runner/lib/events.test.js
@@ -48,4 +48,25 @@ describe('formatLinearEventComment', () => {
     expect(body).toContain('| Failed attempts | 3 / 3 |')
     expect(body).toContain('loop paused')
   })
+
+  test('formats non-paused fixer stalls as failed attempts', () => {
+    const body = formatLinearEventComment({
+      type: 'error',
+      pr: 42,
+      sourceEvent: 'comment:/upsource-review',
+      category: 'fixer_stall',
+      detail: 'fixer stall (watch.js exit 1)',
+      exitCode: 1,
+      signal: null,
+      exitReason: 'FIXER_EXIT #42: kimi failed (42)',
+      noopCount: 1,
+      maxNoops: 3,
+      terminal: false,
+    })
+
+    expect(body).toContain('## QA runner cycle exit: FIXER_STALL')
+    expect(body).toContain('| Source event | comment:/upsource-review |')
+    expect(body).toContain('| Failed attempts | 1 / 3 |')
+    expect(body).toContain('without daemon backoff')
+  })
 })

--- a/scripts/qa-runner/lib/worker.js
+++ b/scripts/qa-runner/lib/worker.js
@@ -403,18 +403,20 @@ export const runOne = async (pr, reason, deps) => {
         {
           type: 'error',
           pr,
+          sourceEvent: reason,
           category: 'transient',
           detail: `watch.js transient (exit ${code})`,
           exitCode: code,
           signal: tickResult.signal,
           exitReason: tickResult.exitReason,
           logPath: tickResult.logPath,
+          retryMode: reason === 'poll' ? 'next poll tick' : 'daemon backoff',
           terminal: false,
         },
         after.vim
       )
 
-      return 'error'
+      return 'retry'
     }
     // exit 1 = the fixer ran and couldn't advance the head. THE stall signal: count
     // consecutive failures and pause at the cap so a broken PR stops burning cycles.
@@ -431,6 +433,7 @@ export const runOne = async (pr, reason, deps) => {
       {
         type: paused ? 'paused' : 'error',
         pr,
+        sourceEvent: reason,
         noopCount,
         maxNoops: config.maxNoops,
         category: 'fixer_stall',

--- a/scripts/qa-runner/lib/worker.js
+++ b/scripts/qa-runner/lib/worker.js
@@ -124,9 +124,71 @@ export const watchArgs = (
 const tick = (pr, config, reason) =>
   new Promise((resolve) => {
     const args = watchArgs(pr, { ...config, reason })
-    const child = spawn('node', args, { stdio: 'inherit' })
-    child.on('exit', (code) => resolve(code ?? -1))
-    child.on('error', () => resolve(-1))
+
+    const child = spawn('node', args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let lastLine = ''
+    let logPath = null
+    let settled = false
+
+    const remember = (line) => {
+      const trimmed = line.trim()
+      if (!trimmed) {
+        return
+      }
+      lastLine = trimmed
+      logPath = logPath || trimmed.match(/\(log: ([^)]+)\)/)?.[1] || null
+    }
+
+    const pipe = (stream, target) => {
+      let buf = ''
+      stream.on('data', (d) => {
+        target.write(d)
+        buf += d.toString()
+        let nl
+        while ((nl = buf.indexOf('\n')) >= 0) {
+          remember(buf.slice(0, nl))
+          buf = buf.slice(nl + 1)
+        }
+      })
+
+      stream.on('end', () => {
+        remember(buf)
+      })
+    }
+
+    pipe(child.stdout, process.stdout)
+    pipe(child.stderr, process.stderr)
+    child.on('close', (code, signal) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      resolve({
+        code: code ?? -1,
+        signal: signal ?? null,
+        exitReason:
+          lastLine ||
+          (signal
+            ? `watch.js terminated by ${signal}`
+            : `watch.js exited ${code}`),
+        logPath,
+      })
+    })
+
+    child.on('error', (error) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      resolve({
+        code: -1,
+        signal: null,
+        exitReason: `watch.js spawn error: ${error.message}`,
+        logPath,
+      })
+    })
   })
 
 // Run one cycle for `pr`. deps: { config, state, log, events, now?,
@@ -148,6 +210,28 @@ const needsFixParentId = (pr, headSha) =>
 
 const shouldPostMergedLinear = (pr) =>
   !hasMergeLinearPosted(decisionStore(pr), pr)
+
+const normalizeTickResult = (result) => {
+  if (typeof result === 'number' || result == null) {
+    return {
+      code: result ?? -1,
+      signal: null,
+      exitReason: `watch.js exited ${result ?? -1}`,
+      logPath: null,
+    }
+  }
+
+  return {
+    code: result.code ?? -1,
+    signal: result.signal ?? null,
+    exitReason:
+      result.exitReason ||
+      (result.signal
+        ? `watch.js terminated by ${result.signal}`
+        : `watch.js exited ${result.code ?? -1}`),
+    logPath: result.logPath ?? null,
+  }
+}
 
 // 'done' | 'progress' | 'error' | 'waiting' | 'paused' | 'blocked' | 'skip' | 'retry'.
 export const runOne = async (pr, reason, deps) => {
@@ -228,7 +312,8 @@ export const runOne = async (pr, reason, deps) => {
   }
 
   events.emit({ type: 'cycle', pr, round: st.roundCount, detail: reason })
-  const code = await tickRunner(pr, config, reason)
+  const tickResult = normalizeTickResult(await tickRunner(pr, config, reason))
+  const { code } = tickResult
   const after = snapshot(pr, snapshotExec)
 
   // Post-tick read failed (same rule as the pre-tick guard): never interpret null
@@ -315,7 +400,17 @@ export const runOne = async (pr, reason, deps) => {
       // without touching the failure streak, so a gh/GraphQL blip can't pause a
       // healthy PR (which the poll guard would then keep skipping).
       events.emit(
-        { type: 'error', pr, detail: `watch.js transient (exit ${code})` },
+        {
+          type: 'error',
+          pr,
+          category: 'transient',
+          detail: `watch.js transient (exit ${code})`,
+          exitCode: code,
+          signal: tickResult.signal,
+          exitReason: tickResult.exitReason,
+          logPath: tickResult.logPath,
+          terminal: false,
+        },
         after.vim
       )
 
@@ -337,7 +432,14 @@ export const runOne = async (pr, reason, deps) => {
         type: paused ? 'paused' : 'error',
         pr,
         noopCount,
+        maxNoops: config.maxNoops,
+        category: 'fixer_stall',
         detail: `fixer stall (watch.js exit ${code})`,
+        exitCode: code,
+        signal: tickResult.signal,
+        exitReason: tickResult.exitReason,
+        logPath: tickResult.logPath,
+        terminal: paused,
       },
       after.vim
     )

--- a/scripts/qa-runner/lib/worker.test.js
+++ b/scripts/qa-runner/lib/worker.test.js
@@ -332,18 +332,20 @@ describe('runOne', () => {
 
     const outcome = await runOne(42, 'poll', deps)
 
-    expect(outcome).toBe('error')
+    expect(outcome).toBe('retry')
     expect(deps.state.update).not.toHaveBeenCalled()
     expect(deps.events.emit).toHaveBeenCalledWith(
       {
         type: 'error',
         pr: 42,
+        sourceEvent: 'poll',
         category: 'transient',
         detail: 'watch.js transient (exit -1)',
         exitCode: -1,
         signal: 'SIGTERM',
         exitReason: 'watch.js terminated by SIGTERM',
         logPath: '/repo/scripts/qa-runner/logs/pr-42.log',
+        retryMode: 'next poll tick',
         terminal: false,
       },
       'VIM-20'
@@ -387,6 +389,7 @@ describe('runOne', () => {
       {
         type: 'paused',
         pr: 42,
+        sourceEvent: 'poll',
         noopCount: 3,
         maxNoops: 3,
         category: 'fixer_stall',

--- a/scripts/qa-runner/lib/worker.test.js
+++ b/scripts/qa-runner/lib/worker.test.js
@@ -318,4 +318,86 @@ describe('runOne', () => {
       undefined
     )
   })
+
+  test('records retryable watch exits with reason and log metadata', async () => {
+    const deps = makeDeps({
+      snapshotExec: openPrSnapshotExec(),
+      tickRunner: vi.fn(async () => ({
+        code: -1,
+        signal: 'SIGTERM',
+        exitReason: 'watch.js terminated by SIGTERM',
+        logPath: '/repo/scripts/qa-runner/logs/pr-42.log',
+      })),
+    })
+
+    const outcome = await runOne(42, 'poll', deps)
+
+    expect(outcome).toBe('error')
+    expect(deps.state.update).not.toHaveBeenCalled()
+    expect(deps.events.emit).toHaveBeenCalledWith(
+      {
+        type: 'error',
+        pr: 42,
+        category: 'transient',
+        detail: 'watch.js transient (exit -1)',
+        exitCode: -1,
+        signal: 'SIGTERM',
+        exitReason: 'watch.js terminated by SIGTERM',
+        logPath: '/repo/scripts/qa-runner/logs/pr-42.log',
+        terminal: false,
+      },
+      'VIM-20'
+    )
+  })
+
+  test('pauses repeated fixer stalls with explicit exit context', async () => {
+    const deps = makeDeps({
+      snapshotExec: openPrSnapshotExec(),
+      tickRunner: vi.fn(async () => ({
+        code: 1,
+        signal: null,
+        exitReason: 'kimi produced no commit - findings left unaddressed',
+        logPath: '/repo/scripts/qa-runner/logs/pr-42.log',
+      })),
+      state: {
+        has: vi.fn(() => true),
+        get: vi.fn(() => ({
+          roundCount: 1,
+          noopCount: 2,
+          lastHeadSha: 'abc123',
+          pausedAt: null,
+          pauseReason: null,
+        })),
+        forget: vi.fn(),
+        update: vi.fn(),
+      },
+    })
+
+    const outcome = await runOne(42, 'poll', deps)
+
+    expect(outcome).toBe('paused')
+    expect(deps.state.update).toHaveBeenCalledWith(42, {
+      lastHeadSha: 'abc123',
+      noopCount: 3,
+      pausedAt: '2024-01-01T00:00:00.000Z',
+      pauseReason: 'fixer_stall',
+    })
+
+    expect(deps.events.emit).toHaveBeenCalledWith(
+      {
+        type: 'paused',
+        pr: 42,
+        noopCount: 3,
+        maxNoops: 3,
+        category: 'fixer_stall',
+        detail: 'fixer stall (watch.js exit 1)',
+        exitCode: 1,
+        signal: null,
+        exitReason: 'kimi produced no commit - findings left unaddressed',
+        logPath: '/repo/scripts/qa-runner/logs/pr-42.log',
+        terminal: true,
+      },
+      'VIM-20'
+    )
+  })
 })

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -719,23 +719,36 @@ const dispatchFix = ({ pr, fixContext }) =>
     }
     pipe(child.stdout)
     pipe(child.stderr)
-    child.on('close', (code) => {
+    child.on('close', (code, signal) => {
       logFd.end()
+      const exitCode = code ?? null
+
+      const reason =
+        lastLine ||
+        (signal
+          ? `run.js terminated by ${signal}`
+          : `run.js exited ${exitCode}`)
       if (code === RUN_SELF_REVIEW_EXIT) {
         writeDispatchBlocker(pr, {
           code,
-          reason: lastLine || `run.js exited ${code}`,
+          reason,
           logPath,
         })
       }
       out(`${tag} ✓ run.js exited ${code}`)
-      resolve({ code })
+      resolve({ pr, code: exitCode, signal: signal ?? null, reason, logPath })
     })
 
     child.on('error', (e) => {
       logFd.end()
       out(`${tag} ✗ spawn error: ${e.message}`)
-      resolve({ code: -1 })
+      resolve({
+        pr,
+        code: -1,
+        signal: null,
+        reason: `run.js spawn error: ${e.message}`,
+        logPath,
+      })
     })
   })
 
@@ -830,6 +843,12 @@ const tick = async (ctx) => {
     // dispatchFix resolves a real run.js exit code, null (signal-killed), or -1
     // (spawn failed: node/run.js missing, OOM before fork). Self-review refusal is
     // a local dispatch blocker, not a failed fixer attempt.
+    for (const result of results.filter((r) => r.code !== 0)) {
+      out(
+        `FIXER_EXIT #${result.pr}: ${result.reason} ` +
+          `(exit ${result.code ?? 'signal'}; log: ${result.logPath})`
+      )
+    }
     const codes = results.map((r) => r.code)
     fixerStall = codes.some(
       (c) => c !== null && c !== -1 && c !== 0 && c !== RUN_SELF_REVIEW_EXIT

--- a/scripts/qa-runner/watch.js
+++ b/scripts/qa-runner/watch.js
@@ -843,7 +843,9 @@ const tick = async (ctx) => {
     // dispatchFix resolves a real run.js exit code, null (signal-killed), or -1
     // (spawn failed: node/run.js missing, OOM before fork). Self-review refusal is
     // a local dispatch blocker, not a failed fixer attempt.
-    for (const result of results.filter((r) => r.code !== 0)) {
+    for (const result of results.filter(
+      (r) => r.code !== 0 && r.code !== RUN_SELF_REVIEW_EXIT
+    )) {
       out(
         `FIXER_EXIT #${result.pr}: ${result.reason} ` +
           `(exit ${result.code ?? 'signal'}; log: ${result.logPath})`


### PR DESCRIPTION
## Summary

Adds observability for QA runner loop exits so failed or terminated daemon cycles explain why they stopped instead of only leaving a generic pause/error signal.

## Changes

- Capture `watch.js` exit code, signal, final reason line, and log path in the worker.
- Emit structured `.state/events.jsonl` records for retryable exits and terminal paused fixer stalls.
- Post formatted Linear comments for retryable cycle exits and paused loop exits.
- Add daemon-level shutdown/drain events to local event history for SIGINT/SIGTERM.
- Emit an explicit `FIXER_EXIT #PR: ...` line from `watch.js` so Linear comments include the actionable fixer failure reason and log path.

## Validation

- `npm test -- --run scripts/qa-runner/lib/*.test.js`
- `npx eslint scripts/qa-runner/daemon.js scripts/qa-runner/watch.js scripts/qa-runner/lib/events.js scripts/qa-runner/lib/events.test.js scripts/qa-runner/lib/worker.js scripts/qa-runner/lib/worker.test.js`
- `npx prettier --check scripts/qa-runner/daemon.js scripts/qa-runner/watch.js scripts/qa-runner/lib/events.js scripts/qa-runner/lib/events.test.js scripts/qa-runner/lib/worker.js scripts/qa-runner/lib/worker.test.js`
- `git diff --check`

Refs VIM-17