### PR TITLE
fix(qa-runner): accept status token header

### DIFF
--- a/scripts/qa-runner/lib/host.js
+++ b/scripts/qa-runner/lib/host.js
@@ -3,21 +3,38 @@
 // always gets a quick 2xx.
 //   POST /webhooks/github   verify sig → parse → enqueue → 202 · 401 bad sig · 200 ignored
 //   GET  /healthz           liveness (no state — always open)
-//   GET  /status            queue depth + in-flight + per-PR state — Bearer-gated
+//   GET  /status            queue depth + in-flight + per-PR state — auth-gated
 import { createServer } from 'node:http'
 import { timingSafeEqual } from 'node:crypto'
 import { parseEvent, verifySignature } from './webhook.js'
 
-// Constant-time Bearer check for /status. No token configured ⇒ always false, so
+// Constant-time token check for /status. No token configured ⇒ always false, so
 // the caller disables the endpoint (the 0.0.0.0 webhook bind never leaks state).
-const bearerOk = (header, token) => {
+const tokenOk = (gotValue, expectedValue) => {
+  if (!expectedValue) {
+    return false
+  }
+  const expected = Buffer.from(expectedValue)
+  const got = Buffer.from(gotValue || '')
+
+  return got.length === expected.length && timingSafeEqual(got, expected)
+}
+
+const bearerToken = (header) => {
+  const prefix = 'Bearer '
+
+  return header?.startsWith(prefix) ? header.slice(prefix.length) : ''
+}
+
+const statusAuthOk = (headers, token) => {
   if (!token) {
     return false
   }
-  const expected = Buffer.from(`Bearer ${token}`)
-  const got = Buffer.from(header || '')
 
-  return got.length === expected.length && timingSafeEqual(got, expected)
+  return (
+    tokenOk(headers['x-qa-status-token'], token) ||
+    tokenOk(bearerToken(headers.authorization), token)
+  )
 }
 
 const readRawBody = (req, limit = 2 * 1024 * 1024) =>
@@ -122,7 +139,7 @@ export const createHost = (deps) => {
 
           return
         }
-        if (!bearerOk(req.headers.authorization, config.statusToken)) {
+        if (!statusAuthOk(req.headers, config.statusToken)) {
           sendJson(res, 401, { error: 'unauthorized' })
 
           return

--- a/scripts/qa-runner/lib/host.test.js
+++ b/scripts/qa-runner/lib/host.test.js
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { createHost } from './host.js'
+
+const servers = []
+
+const STATUS_AUTH_FIXTURE = 'qa-status-auth-fixture'
+const INVALID_STATUS_AUTH_FIXTURE = 'qa-status-auth-invalid'
+const WEBHOOK_AUTH_FIXTURE = 'qa-webhook-auth-fixture'
+const AUTHORIZATION_SCHEME = 'Bearer'
+
+const makeDeps = (statusToken = STATUS_AUTH_FIXTURE) => ({
+  config: {
+    statusToken,
+    trustedSenders: [],
+    triggerPhrase: '/upsource-review',
+    webhookSecret: WEBHOOK_AUTH_FIXTURE,
+  },
+  queue: {
+    depth: () => 2,
+    inFlight: () => [341],
+    enqueue: () => true,
+  },
+  state: {
+    all: () => ({
+      341: {
+        lastHeadSha: 'abc123',
+      },
+    }),
+  },
+  log: () => undefined,
+})
+
+const startServer = async (deps) => {
+  const server = createHost(deps)
+
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  servers.push(server)
+
+  const { port } = server.address()
+
+  return {
+    request: (path, init = {}) =>
+      fetch(`http://127.0.0.1:${port}${path}`, init),
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise((resolve) => {
+          server.close(resolve)
+        })
+    )
+  )
+})
+
+describe('createHost /status auth', () => {
+  test('keeps status disabled when no status token is configured', async () => {
+    const host = await startServer(makeDeps(''))
+
+    const response = await host.request('/status', {
+      headers: {
+        'X-QA-Status-Token': STATUS_AUTH_FIXTURE,
+      },
+    })
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: 'not found' })
+  })
+
+  test('accepts the existing Bearer token contract', async () => {
+    const host = await startServer(makeDeps())
+
+    const response = await host.request('/status', {
+      headers: {
+        Authorization: `${AUTHORIZATION_SCHEME} ${STATUS_AUTH_FIXTURE}`,
+      },
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      queueDepth: 2,
+      inFlight: [341],
+      prs: {
+        341: {
+          lastHeadSha: 'abc123',
+        },
+      },
+    })
+  })
+
+  test('accepts X-QA-Status-Token for proxies that do not pass Authorization', async () => {
+    const host = await startServer(makeDeps())
+
+    const response = await host.request('/status', {
+      headers: {
+        'X-QA-Status-Token': STATUS_AUTH_FIXTURE,
+      },
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      queueDepth: 2,
+      inFlight: [341],
+    })
+  })
+
+  test('rejects missing or incorrect status tokens', async () => {
+    const host = await startServer(makeDeps())
+    const missing = await host.request('/status')
+
+    const wrong = await host.request('/status', {
+      headers: {
+        Authorization: `${AUTHORIZATION_SCHEME} ${INVALID_STATUS_AUTH_FIXTURE}`,
+        'X-QA-Status-Token': INVALID_STATUS_AUTH_FIXTURE,
+      },
+    })
+
+    expect(missing.status).toBe(401)
+    expect(wrong.status).toBe(401)
+  })
+})


### PR DESCRIPTION
Refs VIM-55

## Summary
- allow `/status` to authenticate with `X-QA-Status-Token`
- keep the existing `Authorization` header contract working
- keep `/status` fail-closed with 404 when no status token is configured
- add focused host tests for disabled, authorization-header, status-header, and rejected-token cases

## Why
The control host returns 200 for local `/status` with the hydrated token, but the Cloudflare public path still returns 401. Supporting a dedicated status-token header gives us a less fragile public smoke path while preserving the current authorization-header behavior.

## Verification
- `npm test -- --run scripts/qa-runner/lib/host.test.js scripts/qa-runner/lib/webhook.test.js`
- `npx eslint scripts/qa-runner/lib/host.js scripts/qa-runner/lib/host.test.js`
- `npm test -- --run scripts/qa-runner/lib/host.test.js`
- `npm test -- --run scripts/qa-runner/lib/*.test.js`
- `npx prettier --check scripts/qa-runner/lib/host.js scripts/qa-runner/lib/host.test.js`