### PR TITLE
[VIM-43] Preserve inline feedback across dock lifecycle

### DIFF
--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -35,6 +35,7 @@ import {
   parseBatchKey,
   DRAFT_ID,
   type ReviewComment,
+  type UseFeedbackBatchReturn,
 } from '../hooks/useFeedbackBatch'
 import { ReviewCommentComposer } from './ReviewCommentComposer'
 import { ReviewCommentRow } from './ReviewCommentRow'
@@ -86,11 +87,19 @@ type DiffPanelSelectionControl =
       onSelectedFileChange: (file: SelectedDiffFile | null) => void
     }
 
+export interface FeedbackRepoRootRef {
+  current: string
+}
+
 interface DiffPanelContentBaseProps {
   /** Working directory for git commands */
   cwd?: string
   /** Optional shared git status from a parent-level watcher subscription */
   gitStatus?: UseGitStatusReturn
+  /** Optional shared feedback batch from the workspace shell. */
+  feedbackBatch?: UseFeedbackBatchReturn
+  /** Optional shared repo-root cache for feedback dispatch path resolution. */
+  feedbackRepoRootRef?: FeedbackRepoRootRef
   /** Optional feedback dispatch target for inline review comments */
   feedbackDispatch?: FeedbackDispatchTarget
 }
@@ -142,6 +151,8 @@ export const DiffPanelContent = ({
   gitStatus = undefined,
   selectedFile: controlledSelectedFile,
   onSelectedFileChange,
+  feedbackBatch = undefined,
+  feedbackRepoRootRef = undefined,
   feedbackDispatch = undefined,
 }: DiffPanelContentProps): ReactElement => {
   const internalGitStatus = useGitStatus(cwd, {
@@ -277,24 +288,16 @@ export const DiffPanelContent = ({
   // "could not isolate hunk" informational messages.
   const { message: notifyMessage, notifyInfo } = useNotifyInfo()
 
-  // Inline review comment batch state.
-  //
-  // KNOWN LIMITATION (deferred — tracked in #307; part of the workspace-layer
-  // refactor #306): DockPanel conditionally mounts DiffPanelContent only while
-  // the diff tab is active and unmounts it on dock close, so leaving the diff
-  // tab before Finish/Discard tears this component down and silently drops an
-  // unsent batch. The fix is to hoist the batch (and its cwd-invalidation)
-  // above the dock lifecycle; deferred here to avoid a risky partial lift that
-  // could leak stale comments across cwd changes.
-  const feedback = useFeedbackBatch()
-  // Destructured so the cwd-clear effect can depend on the stable `clearBatch`
-  // identity (memoized, empty deps) rather than the whole `feedback` object —
-  // which is a fresh reference each render and would re-fire the effect every
-  // render (the if-guard makes it a no-op, but it is needless work).
-  const { clearBatch } = feedback
+  const localFeedback = useFeedbackBatch()
+  const { clearBatch: clearLocalFeedbackBatch } = localFeedback
+  const hasParentFeedbackBatch = feedbackBatch !== undefined
+  const feedback: UseFeedbackBatchReturn = feedbackBatch ?? localFeedback
+  const localRepoRootRef = useRef('')
+  const repoRootRef = feedbackRepoRootRef ?? localRepoRootRef
 
-  // Clear the feedback batch when cwd changes so stale comments from a
-  // previous workspace do not leak into the new one.
+  // Track cwd transitions that invalidate per-repo derived state. The
+  // workspace shell owns feedback-batch clearing when a parent batch is passed;
+  // standalone/uncontrolled usage keeps the prior local clear behavior.
   const previousCwdRef = useRef(cwd)
 
   // Last non-empty git repo root seen for the current cwd. `response.repoRoot`
@@ -303,21 +306,21 @@ export const DiffPanelContent = ({
   // an in-flight feedback batch sent during that window would fall back to
   // repo-relative paths and mis-resolve for agents in a repo subdirectory.
   // Reset on cwd change below (a new repo invalidates the old root).
-  const lastRepoRootRef = useRef('')
-
   useEffect(() => {
     if (previousCwdRef.current !== cwd) {
       previousCwdRef.current = cwd
-      lastRepoRootRef.current = ''
-      clearBatch()
+      repoRootRef.current = ''
+      if (!hasParentFeedbackBatch) {
+        clearLocalFeedbackBatch()
+      }
     }
-  }, [cwd, clearBatch])
+  }, [cwd, clearLocalFeedbackBatch, hasParentFeedbackBatch, repoRootRef])
 
   useEffect(() => {
     if (response?.repoRoot) {
-      lastRepoRootRef.current = response.repoRoot
+      repoRootRef.current = response.repoRoot
     }
-  }, [response])
+  }, [response, repoRootRef])
 
   // Composer target state: which line currently has an open composer.
   // `editId` set => editing an existing comment in place; absent => a new
@@ -447,7 +450,7 @@ export const DiffPanelContent = ({
         // in-flight batch keeps absolute paths. The empty-string (non-repo)
         // case needs no fallback — the ref is empty there too — so `??` (null/
         // undefined only) is exactly right.
-        const repoRoot = response?.repoRoot ?? lastRepoRootRef.current
+        const repoRoot = response?.repoRoot ?? repoRootRef.current
         const entries: DispatchEntry[] = []
         // parseBatchKey is the single source of truth for the key format (it
         // lives next to makeBatchKey in useFeedbackBatch). The staged flag rides
@@ -477,7 +480,7 @@ export const DiffPanelContent = ({
         }
       })()
     },
-    [feedback, feedbackDispatch, notifyInfo, response]
+    [feedback, feedbackDispatch, notifyInfo, repoRootRef, response]
   )
 
   // Single-flight staging flag — drops clicks while an IPC is in flight.

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -1,14 +1,35 @@
 import type { ReactElement, ReactNode } from 'react'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { WorkspaceView } from './WorkspaceView'
+import type { DiffLineAnnotation } from '@pierre/diffs'
 import type { AgentStatus } from '../agent-status/types'
 import { useGitStatus } from '../diff/hooks/useGitStatus'
 import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
+import type { FeedbackRepoRootRef } from '../diff/components/DiffPanelContent'
+import type {
+  ReviewComment,
+  UseFeedbackBatchReturn,
+} from '../diff/hooks/useFeedbackBatch'
 
 // Mock TerminalPane / TerminalZone deps to avoid xterm.js in jsdom
+interface MockTerminalPaneProps {
+  onCwdChange?: (cwd: string) => void
+}
+
 vi.mock('../terminal/components/TerminalPane', () => ({
-  TerminalPane: vi.fn(() => <div data-testid="terminal-pane-mock" />),
+  TerminalPane: vi.fn(
+    ({ onCwdChange = undefined }: MockTerminalPaneProps): ReactElement => (
+      <div data-testid="terminal-pane-mock">
+        <button
+          data-testid="mock-terminal-cwd-change"
+          onClick={() => onCwdChange?.('/repo/next')}
+        >
+          change cwd
+        </button>
+      </div>
+    )
+  ),
 }))
 
 interface MockEditorBuffer {
@@ -145,7 +166,12 @@ vi.mock('../../hooks/useElasticContainer', () => ({
 
 const capturedPanelProps: { agentStatus?: AgentStatus; gitStatus?: unknown } =
   {}
-const capturedDockPanelProps: { gitStatus?: unknown } = {}
+
+const capturedDockPanelProps: {
+  gitStatus?: unknown
+  feedbackBatch?: UseFeedbackBatchReturn
+  feedbackRepoRootRef?: FeedbackRepoRootRef
+} = {}
 
 interface MockPanelProps {
   agentStatus?: AgentStatus
@@ -154,6 +180,8 @@ interface MockPanelProps {
 
 interface MockDockPanelProps {
   gitStatus?: unknown
+  feedbackBatch?: UseFeedbackBatchReturn
+  feedbackRepoRootRef?: FeedbackRepoRootRef
   tab?: 'editor' | 'diff'
   onTabChange?: (tab: 'editor' | 'diff') => void
   onClose?: () => void
@@ -206,10 +234,14 @@ vi.mock('../agent-status/components/AgentStatusPanel', () => ({
 vi.mock('./components/DockPanel', () => ({
   default: ({
     gitStatus = undefined,
+    feedbackBatch = undefined,
+    feedbackRepoRootRef = undefined,
     onTabChange,
     onClose,
   }: MockDockPanelProps): ReactElement => {
     capturedDockPanelProps.gitStatus = gitStatus
+    capturedDockPanelProps.feedbackBatch = feedbackBatch
+    capturedDockPanelProps.feedbackRepoRootRef = feedbackRepoRootRef
 
     return (
       <div data-testid="dock-panel-mock">
@@ -236,6 +268,8 @@ describe('WorkspaceView lifted-subscription contract', () => {
     capturedPanelProps.agentStatus = undefined
     capturedPanelProps.gitStatus = undefined
     capturedDockPanelProps.gitStatus = undefined
+    capturedDockPanelProps.feedbackBatch = undefined
+    capturedDockPanelProps.feedbackRepoRootRef = undefined
     capturedStatusHeaderProps.status = undefined
     // Clear the mock between tests so `toHaveBeenCalledWith` assertions
     // see only the calls from THIS test's render. Without this,
@@ -296,6 +330,47 @@ describe('WorkspaceView lifted-subscription contract', () => {
     expect(capturedPanelProps.gitStatus).toBeDefined()
     expect(capturedDockPanelProps.gitStatus).toBeDefined()
     expect(capturedPanelProps.gitStatus).toBe(capturedDockPanelProps.gitStatus)
+  })
+
+  test('DockPanel receives a workspace feedback batch that clears on cwd change', async () => {
+    render(<WorkspaceView />)
+
+    await screen.findByTestId('dock-panel-mock')
+    await screen.findByTestId('terminal-pane-mock')
+
+    const feedbackBatch = capturedDockPanelProps.feedbackBatch
+    expect(feedbackBatch).toBeDefined()
+    const feedbackRepoRootRef = capturedDockPanelProps.feedbackRepoRootRef
+    expect(feedbackRepoRootRef).toBeDefined()
+
+    const annotation: DiffLineAnnotation<ReviewComment> = {
+      side: 'additions',
+      lineNumber: 1,
+      metadata: {
+        id: 'feedback-comment-test',
+        text: 'Review this change',
+        author: 'self',
+        createdAt: 1,
+      },
+    }
+
+    act(() => {
+      feedbackBatch?.addAnnotation('~', 'src/foo.ts', false, annotation)
+    })
+
+    await waitFor(() =>
+      expect(capturedDockPanelProps.feedbackBatch?.totalAnnotations()).toBe(1)
+    )
+    if (feedbackRepoRootRef) {
+      feedbackRepoRootRef.current = '/repo'
+    }
+
+    fireEvent.click(screen.getByTestId('mock-terminal-cwd-change'))
+
+    await waitFor(() =>
+      expect(capturedDockPanelProps.feedbackBatch?.totalAnnotations()).toBe(0)
+    )
+    expect(capturedDockPanelProps.feedbackRepoRootRef?.current).toBe('')
   })
 
   test('WorkspaceView calls useGitStatus with enabled: true when an agent is active', async () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -64,6 +64,7 @@ import { useDockShortcuts } from './hooks/useDockShortcuts'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
 import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 import { useGitStatus } from '../diff/hooks/useGitStatus'
+import { useFeedbackBatch } from '../diff/hooks/useFeedbackBatch'
 import type { PaneCandidate } from '../diff/services/activePanePicker'
 import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
@@ -853,6 +854,19 @@ export const WorkspaceView = (): ReactElement => {
   const [selectedDiffFile, setSelectedDiffFile] =
     useState<SelectedDiffFile | null>(null)
 
+  const feedbackBatch = useFeedbackBatch()
+  const feedbackRepoRootRef = useRef('')
+  const { clearBatch: clearFeedbackBatch } = feedbackBatch
+  const previousFeedbackCwdRef = useRef(activeCwd)
+
+  useEffect(() => {
+    if (previousFeedbackCwdRef.current !== activeCwd) {
+      previousFeedbackCwdRef.current = activeCwd
+      feedbackRepoRootRef.current = ''
+      clearFeedbackBatch()
+    }
+  }, [activeCwd, clearFeedbackBatch])
+
   const gitStatus = useGitStatus(activeCwd, {
     watch: true,
     enabled: agentStatus.isActive || (isDockOpen && dockTab === 'diff'),
@@ -1303,6 +1317,8 @@ export const WorkspaceView = (): ReactElement => {
       onContainerFocus={() => {
         setActiveContainerId(DOCK_CONTAINER_ID)
       }}
+      feedbackBatch={feedbackBatch}
+      feedbackRepoRootRef={feedbackRepoRootRef}
       feedbackDispatch={feedbackDispatch}
     />
   ) : (

--- a/src/features/workspace/components/DockPanel.test.tsx
+++ b/src/features/workspace/components/DockPanel.test.tsx
@@ -1,13 +1,23 @@
-import { render, screen, within, fireEvent } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
-import { createRef, forwardRef, type ReactElement } from 'react'
+import { createRef, forwardRef, useRef, type ReactElement } from 'react'
 import DockPanel, { type DockPanelHandle } from './DockPanel'
 import * as useCodeMirrorModule from '../../editor/hooks/useCodeMirror'
 import * as useVimModeModule from '../../editor/hooks/useVimMode'
 import * as languageServiceModule from '../../editor/services/languageService'
 import * as useGitStatusModule from '../../diff/hooks/useGitStatus'
 import * as useFileDiffModule from '../../diff/hooks/useFileDiff'
+import { useFeedbackBatch } from '../../diff/hooks/useFeedbackBatch'
+import type { UseFileDiffReturn } from '../../diff/hooks/useFileDiff'
+import type { ChangedFile } from '../../diff/types'
+import type { FeedbackDispatchTarget } from '../../diff/services/activePanePicker'
 import { javascript } from '@codemirror/lang-javascript'
 
 vi.mock('../../editor/hooks/useCodeMirror')
@@ -15,9 +25,53 @@ vi.mock('../../editor/hooks/useVimMode')
 vi.mock('../../editor/services/languageService')
 vi.mock('../../diff/hooks/useGitStatus')
 vi.mock('../../diff/hooks/useFileDiff')
+
+interface MockLineAnnotation {
+  lineNumber: number
+  side: string
+  metadata: {
+    id: string
+    text: string
+    author: string
+    createdAt: number
+  }
+}
+
 vi.mock('@pierre/diffs/react', () => ({
   useWorkerPool: vi.fn(() => null),
-  MultiFileDiff: vi.fn(() => <div data-testid="multi-file-diff" />),
+  MultiFileDiff: vi.fn(
+    ({
+      renderGutterUtility = undefined,
+      lineAnnotations = undefined,
+      renderAnnotation = undefined,
+    }: {
+      renderGutterUtility?: (
+        getHovered: () => { lineNumber: number; side: string }
+      ) => ReactElement
+      lineAnnotations?: MockLineAnnotation[]
+      renderAnnotation?: (annotation: MockLineAnnotation) => ReactElement
+    }) => (
+      <div data-testid="multi-file-diff">
+        {renderGutterUtility ? (
+          <div data-testid="gutter-utility-slot">
+            {renderGutterUtility(() => ({
+              lineNumber: 1,
+              side: 'additions',
+            }))}
+          </div>
+        ) : null}
+        {lineAnnotations && renderAnnotation ? (
+          <div data-testid="annotation-slot">
+            {lineAnnotations.map((annotation, index) => (
+              <div key={annotation.metadata.id ?? index}>
+                {renderAnnotation(annotation)}
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    )
+  ),
 }))
 
 // react-markdown is ESM-only and heavy in jsdom; the DockPanel test only needs
@@ -38,6 +92,120 @@ vi.mock('../../editor/components/MarkdownReadingView', () => ({
 }))
 
 type DockPanelTestProps = Parameters<typeof DockPanel>[0]
+
+const inlineChangedFile: ChangedFile = {
+  path: 'src/foo.ts',
+  status: 'modified',
+  staged: false,
+}
+
+const inlineDiffResponse: NonNullable<UseFileDiffReturn['response']> = {
+  fileDiff: {
+    filePath: 'src/foo.ts',
+    oldPath: 'src/foo.ts',
+    newPath: 'src/foo.ts',
+    hunks: [
+      {
+        id: 'hunk-0',
+        header: '@@ -1,3 +1,3 @@',
+        oldStart: 1,
+        oldLines: 3,
+        newStart: 1,
+        newLines: 3,
+        lines: [
+          { type: 'context', content: 'alpha' },
+          { type: 'added', content: 'beta' },
+          { type: 'context', content: 'gamma' },
+        ],
+      },
+    ],
+  },
+  oldText: 'old',
+  newText: 'new',
+  rawDiff: '',
+  repoRoot: '/repo',
+}
+
+const SharedFeedbackDockHarness = ({
+  tab,
+  open,
+  cwd = '/repo',
+  feedbackDispatch = undefined,
+}: {
+  tab: 'editor' | 'diff'
+  open: boolean
+  cwd?: string
+  feedbackDispatch?: FeedbackDispatchTarget
+}): ReactElement => {
+  const feedbackBatch = useFeedbackBatch()
+  const feedbackRepoRootRef = useRef('')
+  const isResizing = false
+
+  if (!open) {
+    return <div data-testid="dock-closed" />
+  }
+
+  return (
+    <DockPanel
+      position="bottom"
+      tab={tab}
+      onTabChange={vi.fn()}
+      onPositionChange={vi.fn()}
+      onClose={vi.fn()}
+      verticalSize={400}
+      onVerticalResizeMouseDown={vi.fn()}
+      isVerticalResizing={isResizing}
+      onVerticalSizeAdjust={vi.fn()}
+      verticalPixelMin={40}
+      verticalPixelMax={640}
+      horizontalSize={360}
+      onHorizontalResizeMouseDown={vi.fn()}
+      isHorizontalResizing={isResizing}
+      onHorizontalSizeAdjust={vi.fn()}
+      horizontalPixelMin={40}
+      horizontalPixelMax={640}
+      selectedFilePath={null}
+      content=""
+      cwd={cwd}
+      gitStatus={{
+        files: [inlineChangedFile],
+        filesCwd: cwd,
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      }}
+      selectedDiffFile={{
+        path: inlineChangedFile.path,
+        staged: inlineChangedFile.staged,
+        cwd,
+      }}
+      onSelectedDiffFileChange={vi.fn()}
+      feedbackBatch={feedbackBatch}
+      feedbackRepoRootRef={feedbackRepoRootRef}
+      feedbackDispatch={feedbackDispatch}
+    />
+  )
+}
+
+const addInlineComment = async (
+  user: ReturnType<typeof userEvent.setup>,
+  text: string
+): Promise<void> => {
+  const gutterSlot = screen.getByTestId('gutter-utility-slot')
+
+  await user.click(
+    within(gutterSlot).getByRole('button', {
+      name: 'Add comment on this line',
+    })
+  )
+
+  const dialog = screen.getByRole('dialog', { name: /Comment on line/ })
+  await user.type(within(dialog).getByPlaceholderText('Request change'), text)
+  await user.keyboard('{Enter}')
+
+  await screen.findByRole('button', { name: /finish feedback \(1\)/i })
+}
 
 const renderDockPanel = (
   overrides: Partial<DockPanelTestProps> = {}
@@ -747,6 +915,131 @@ describe('DockPanel', () => {
       expect.anything(),
       expect.objectContaining({ enabled: false })
     )
+  })
+
+  test('keeps pending inline feedback across Editor and Diff tab switches when parent-owned', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
+      response: inlineDiffResponse,
+      diff: inlineDiffResponse.fileDiff,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    const { rerender } = render(<SharedFeedbackDockHarness tab="diff" open />)
+
+    await addInlineComment(user, 'Survives tab switch')
+
+    rerender(<SharedFeedbackDockHarness tab="editor" open />)
+
+    expect(screen.queryByTestId('diff-panel')).not.toBeInTheDocument()
+
+    rerender(<SharedFeedbackDockHarness tab="diff" open />)
+
+    expect(
+      await screen.findByRole('button', { name: /finish feedback \(1\)/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Survives tab switch')).toBeInTheDocument()
+  })
+
+  test('keeps pending inline feedback after the dock unmounts and reopens when parent-owned', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue({
+      response: inlineDiffResponse,
+      diff: inlineDiffResponse.fileDiff,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    const { rerender } = render(<SharedFeedbackDockHarness tab="diff" open />)
+
+    await addInlineComment(user, 'Survives dock reopen')
+
+    const closed = false
+    rerender(<SharedFeedbackDockHarness tab="diff" open={closed} />)
+
+    expect(screen.getByTestId('dock-closed')).toBeInTheDocument()
+
+    rerender(<SharedFeedbackDockHarness tab="diff" open />)
+
+    expect(
+      await screen.findByRole('button', { name: /finish feedback \(1\)/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Survives dock reopen')).toBeInTheDocument()
+  })
+
+  test('keeps absolute feedback paths after dock reopen while the diff reloads', async () => {
+    const user = userEvent.setup()
+    let diffLoaded = true
+
+    vi.spyOn(useFileDiffModule, 'useFileDiff').mockImplementation(() => ({
+      response: diffLoaded ? inlineDiffResponse : null,
+      diff: diffLoaded ? inlineDiffResponse.fileDiff : null,
+      loading: !diffLoaded,
+      error: null,
+      refetch: vi.fn(),
+    }))
+
+    const writePty = vi.fn().mockResolvedValue(undefined)
+
+    const feedbackDispatch: FeedbackDispatchTarget = {
+      candidates: [
+        {
+          paneId: 'pane-1',
+          ptyId: 'pty-1',
+          tabName: 'Agent',
+          agentLabel: 'Claude Code',
+          cwd: '/repo/subdir',
+          status: 'running',
+          isFocused: true,
+        },
+      ],
+      writePty,
+    }
+
+    const { rerender } = render(
+      <SharedFeedbackDockHarness
+        tab="diff"
+        open
+        feedbackDispatch={feedbackDispatch}
+      />
+    )
+
+    await addInlineComment(user, 'Preserve the absolute path')
+
+    const closed = false
+    rerender(
+      <SharedFeedbackDockHarness
+        tab="diff"
+        open={closed}
+        feedbackDispatch={feedbackDispatch}
+      />
+    )
+
+    diffLoaded = false
+    rerender(
+      <SharedFeedbackDockHarness
+        tab="diff"
+        open
+        feedbackDispatch={feedbackDispatch}
+      />
+    )
+
+    await user.click(
+      await screen.findByRole('button', { name: /finish feedback \(1\)/i })
+    )
+
+    const popover = await screen.findByRole('dialog', {
+      name: 'Finish feedback',
+    })
+    await user.click(within(popover).getByRole('button', { name: 'Confirm' }))
+
+    await waitFor(() => expect(writePty).toHaveBeenCalledTimes(1))
+
+    const [, payload] = writePty.mock.calls[0]
+    expect(payload as string).toContain('/repo/src/foo.ts')
   })
 
   describe('focus highlight', () => {

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -16,12 +16,16 @@ import {
 } from '../../editor/components/CodeEditor'
 import { MarkdownReadingView } from '../../editor/components/MarkdownReadingView'
 import { ReadingStyleMenu } from '../../editor/components/ReadingStyleMenu'
-import { DiffPanelContent } from '../../diff/components/DiffPanelContent'
+import {
+  DiffPanelContent,
+  type FeedbackRepoRootRef,
+} from '../../diff/components/DiffPanelContent'
 import { DockSwitcher, type DockPosition } from './DockSwitcher'
 import { DockTab } from './DockTab'
 import { ViewModeToggle, type ViewMode } from './ViewModeToggle'
 import type { SelectedDiffFile } from '../../diff/types'
 import type { UseGitStatusReturn } from '../../diff/hooks/useGitStatus'
+import type { UseFeedbackBatchReturn } from '../../diff/hooks/useFeedbackBatch'
 import type { FeedbackDispatchTarget } from '../../diff/services/activePanePicker'
 import { DOCK_CONTAINER_ID } from '../containerIds'
 import {
@@ -80,6 +84,10 @@ interface DockPanelBaseProps {
   cwd?: string
   /** Optional shared git status from WorkspaceView. */
   gitStatus?: UseGitStatusReturn
+  /** Optional workspace-owned inline review feedback batch. */
+  feedbackBatch?: UseFeedbackBatchReturn
+  /** Optional workspace-owned repo root cache for feedback dispatch. */
+  feedbackRepoRootRef?: FeedbackRepoRootRef
   /** Optional feedback dispatch target for inline review comments. */
   feedbackDispatch?: FeedbackDispatchTarget
   isFocused?: boolean
@@ -121,6 +129,8 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
       isLoading = false,
       cwd = '.',
       gitStatus = undefined,
+      feedbackBatch = undefined,
+      feedbackRepoRootRef = undefined,
       feedbackDispatch = undefined,
       isFocused = false,
       onContainerFocus = undefined,
@@ -422,12 +432,16 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
                     gitStatus={gitStatus}
                     selectedFile={selectedDiffFile}
                     onSelectedFileChange={onSelectedDiffFileChange}
+                    feedbackBatch={feedbackBatch}
+                    feedbackRepoRootRef={feedbackRepoRootRef}
                     feedbackDispatch={feedbackDispatch}
                   />
                 ) : (
                   <DiffPanelContent
                     cwd={cwd}
                     gitStatus={gitStatus}
+                    feedbackBatch={feedbackBatch}
+                    feedbackRepoRootRef={feedbackRepoRootRef}
                     feedbackDispatch={feedbackDispatch}
                   />
                 )}


### PR DESCRIPTION
## Summary
- Hoist inline feedback batch and repo-root cache to WorkspaceView so pending comments survive diff tab switches and dock reopen.
- Clear pending feedback and path context when the active cwd changes.
- Add lifecycle regression coverage for tab switch, dock close/reopen, and dispatch while diff reloads.

## Verification
- npm run lint
- npm run type-check
- npm run test
- npm run build
- codex exec --sandbox read-only review --base origin/main --output-last-message /tmp/vimeflow-vim43-codex-review-3.txt

Closes VIM-43