### PR TITLE
[VIM-35] Keep status card shell mounted across agent switches

### DIFF
--- a/src/features/agent-status/components/StatusCard.test.tsx
+++ b/src/features/agent-status/components/StatusCard.test.tsx
@@ -110,6 +110,24 @@ describe('StatusCard', () => {
     render(<StatusCard {...defaultProps} />)
 
     expect(screen.getByTestId('agent-status-card')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-status-card')).toHaveAttribute(
+      'data-agent-state',
+      'active'
+    )
+  })
+
+  test('renders idle content inside the status card shell', () => {
+    render(<StatusCard mode="idle" title="my session" />)
+
+    expect(screen.getByTestId('agent-status-card')).toHaveClass('min-h-44')
+    expect(screen.getByTestId('agent-status-card')).toHaveAttribute(
+      'data-agent-state',
+      'idle'
+    )
+    expect(screen.getByText('my session')).toBeInTheDocument()
+    expect(screen.getByText('Idle')).toBeInTheDocument()
+    expect(screen.getByTestId('status-dot')).toHaveClass('bg-on-surface/30')
+    expect(screen.queryByText('Tokens In')).not.toBeInTheDocument()
   })
 
   test('keeps card height and agent names stable across claude and codex', () => {

--- a/src/features/agent-status/components/StatusCard.tsx
+++ b/src/features/agent-status/components/StatusCard.tsx
@@ -6,7 +6,8 @@ import { BudgetMetrics } from './BudgetMetrics'
 type AgentType = 'claude-code' | 'codex' | 'aider' | 'generic'
 type StatusType = 'running' | 'paused' | 'completed' | 'errored'
 
-export interface StatusCardProps {
+interface ActiveStatusCardProps {
+  mode?: 'active'
   agentType: AgentType
   modelId: string | null
   modelDisplayName: string | null
@@ -17,11 +18,24 @@ export interface StatusCardProps {
   totalOutputTokens: number
 }
 
+interface IdleStatusCardProps {
+  mode: 'idle'
+  title: string
+}
+
+export type StatusCardProps = ActiveStatusCardProps | IdleStatusCardProps
+
 const agentNames: Record<AgentType, string> = {
   'claude-code': 'Claude Code',
   codex: 'Codex',
   aider: 'Aider',
   generic: 'Agent',
+}
+
+const idleStatusConfig = {
+  color: 'bg-on-surface/30',
+  glowClass: '',
+  label: 'Idle',
 }
 
 const getStatusConfig = (
@@ -56,22 +70,20 @@ const getStatusConfig = (
   return configs[status]
 }
 
-export const StatusCard = ({
-  agentType,
-  modelId,
-  modelDisplayName,
-  status,
-  cost,
-  rateLimits,
-  totalInputTokens,
-  totalOutputTokens,
-}: StatusCardProps): ReactElement => {
-  const statusConfig = getStatusConfig(status)
-  const displayModel = modelDisplayName ?? modelId
+export const StatusCard = (props: StatusCardProps): ReactElement => {
+  const isIdle = props.mode === 'idle'
+  const statusConfig = isIdle ? idleStatusConfig : getStatusConfig(props.status)
+  const title = isIdle ? props.title : agentNames[props.agentType]
+  const displayModel = isIdle ? null : (props.modelDisplayName ?? props.modelId)
+
+  const titleClassName = isIdle
+    ? 'truncate font-headline text-[13.5px] font-[800] text-on-surface'
+    : 'shrink-0 whitespace-nowrap font-headline text-sm font-[800] text-on-surface'
 
   return (
     <div
       data-testid="agent-status-card"
+      data-agent-state={isIdle ? 'idle' : 'active'}
       className="flex min-h-44 flex-col gap-3 rounded-xl bg-surface-container-high p-3"
     >
       {/* Agent identity row */}
@@ -81,9 +93,7 @@ export const StatusCard = ({
 
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <div className="flex min-w-0 items-center gap-2">
-            <span className="shrink-0 whitespace-nowrap font-headline text-sm font-[800] text-on-surface">
-              {agentNames[agentType]}
-            </span>
+            <span className={titleClassName}>{title}</span>
             {displayModel ? (
               <Tooltip content={displayModel} placement="bottom">
                 <span
@@ -110,12 +120,14 @@ export const StatusCard = ({
       </div>
 
       {/* Budget metrics */}
-      <BudgetMetrics
-        cost={cost}
-        rateLimits={rateLimits}
-        totalInputTokens={totalInputTokens}
-        totalOutputTokens={totalOutputTokens}
-      />
+      {isIdle ? null : (
+        <BudgetMetrics
+          cost={props.cost}
+          rateLimits={props.rateLimits}
+          totalInputTokens={props.totalInputTokens}
+          totalOutputTokens={props.totalOutputTokens}
+        />
+      )}
     </div>
   )
 }

--- a/src/features/workspace/components/SidebarStatusHeader.test.tsx
+++ b/src/features/workspace/components/SidebarStatusHeader.test.tsx
@@ -49,6 +49,10 @@ describe('SidebarStatusHeader', () => {
     )
 
     expect(screen.getByTestId('agent-status-card')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-status-card')).toHaveAttribute(
+      'data-agent-state',
+      'active'
+    )
     expect(screen.getByText('Claude Code')).toBeInTheDocument()
     expect(screen.getByText('Running')).toBeInTheDocument()
   })
@@ -61,12 +65,16 @@ describe('SidebarStatusHeader', () => {
       />
     )
 
-    expect(screen.queryByTestId('agent-status-card')).not.toBeInTheDocument()
+    expect(screen.getByTestId('agent-status-card')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-status-card')).toHaveAttribute(
+      'data-agent-state',
+      'idle'
+    )
     expect(screen.getByText('my session')).toBeInTheDocument()
     expect(screen.getByText('Idle')).toBeInTheDocument()
   })
 
-  test('keeps the idle placeholder at the live card height', () => {
+  test('keeps the idle state at the live card height', () => {
     render(
       <SidebarStatusHeader
         status={inactiveStatus}
@@ -74,9 +82,7 @@ describe('SidebarStatusHeader', () => {
       />
     )
 
-    expect(screen.getByTestId('sidebar-status-header-idle')).toHaveClass(
-      'min-h-44'
-    )
+    expect(screen.getByTestId('agent-status-card')).toHaveClass('min-h-44')
   })
 
   test('falls back to "No session" when there is no active session', () => {
@@ -96,7 +102,55 @@ describe('SidebarStatusHeader', () => {
       />
     )
 
-    expect(screen.queryByTestId('agent-status-card')).not.toBeInTheDocument()
+    expect(screen.getByTestId('agent-status-card')).toBeInTheDocument()
     expect(screen.getByText('my session')).toBeInTheDocument()
+  })
+
+  test('keeps the status card DOM node through agent switch idle gap', () => {
+    const { rerender } = render(
+      <SidebarStatusHeader
+        status={activeStatus}
+        activeSessionName="claude session"
+      />
+    )
+
+    const card = screen.getByTestId('agent-status-card')
+    expect(screen.getByText('Claude Code')).toBeInTheDocument()
+
+    rerender(
+      <SidebarStatusHeader
+        status={inactiveStatus}
+        activeSessionName="switching session"
+      />
+    )
+
+    expect(screen.getByTestId('agent-status-card')).toBe(card)
+    expect(screen.getByTestId('agent-status-card')).toHaveAttribute(
+      'data-agent-state',
+      'idle'
+    )
+    expect(screen.getByText('switching session')).toBeInTheDocument()
+    expect(screen.getByText('Idle')).toBeInTheDocument()
+
+    rerender(
+      <SidebarStatusHeader
+        status={{
+          ...activeStatus,
+          agentType: 'codex',
+          modelId: 'gpt-5.4',
+          modelDisplayName: 'GPT-5.4',
+          sessionId: 'session-2',
+        }}
+        activeSessionName="codex session"
+      />
+    )
+
+    expect(screen.getByTestId('agent-status-card')).toBe(card)
+    expect(screen.getByTestId('agent-status-card')).toHaveAttribute(
+      'data-agent-state',
+      'active'
+    )
+    expect(screen.getByText('Codex')).toBeInTheDocument()
+    expect(screen.getByText('GPT-5.4')).toBeInTheDocument()
   })
 })

--- a/src/features/workspace/components/SidebarStatusHeader.tsx
+++ b/src/features/workspace/components/SidebarStatusHeader.tsx
@@ -43,34 +43,11 @@ const mapStatusToCardProps = (
 export const SidebarStatusHeader = ({
   status,
   activeSessionName,
-}: SidebarStatusHeaderProps): ReactElement => {
-  if (status.isActive && status.agentType) {
-    return (
-      <StatusCard
-        {...mapStatusToCardProps({ ...status, agentType: status.agentType })}
-      />
-    )
-  }
-
-  const title = activeSessionName ?? 'No session'
-
-  return (
-    <div
-      data-testid="sidebar-status-header-idle"
-      className="flex min-h-44 flex-col gap-3 rounded-xl bg-surface-container-high p-3"
-    >
-      <div className="flex items-center gap-2.5">
-        <div className="h-8 w-8 shrink-0 rounded-lg bg-gradient-to-br from-primary-container to-secondary" />
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span className="truncate font-headline text-[13.5px] font-[800] text-on-surface">
-            {title}
-          </span>
-          <div className="flex items-center gap-1.5">
-            <span className="inline-block h-2 w-2 rounded-full bg-on-surface/30" />
-            <span className="text-[11px] font-medium text-outline">Idle</span>
-          </div>
-        </div>
-      </div>
-    </div>
+}: SidebarStatusHeaderProps): ReactElement =>
+  status.isActive && status.agentType ? (
+    <StatusCard
+      {...mapStatusToCardProps({ ...status, agentType: status.agentType })}
+    />
+  ) : (
+    <StatusCard mode="idle" title={activeSessionName ?? 'No session'} />
   )
-}

--- a/tests/e2e/agent/specs/agent-detect-fake.spec.ts
+++ b/tests/e2e/agent/specs/agent-detect-fake.spec.ts
@@ -45,7 +45,9 @@ describe('Agent detection (fake-claude)', function () {
     await pressEnterInActiveTerminal()
 
     // Detector polls /proc every ~2s for argv[0]="claude".
-    const statusCard = await $('[data-testid="agent-status-card"]')
+    const statusCard = await $(
+      '[data-testid="agent-status-card"][data-agent-state="active"]'
+    )
     await statusCard.waitForDisplayed({ timeout: 30_000 })
 
     const panel = await $('[data-testid="agent-status-panel"]')


### PR DESCRIPTION
## Summary
- Move the idle sidebar status state into `StatusCard` so the outer card shell stays mounted while active status changes.
- Keep `SidebarStatusHeader` on a single `StatusCard` component path for active and idle states.
- Preserve an active-only `data-agent-state="active"` signal for agent detection e2e waits.

## Verification
- npm run lint
- npm run type-check
- git diff --check
- npm run test -- src/features/agent-status/components/StatusCard.test.tsx src/features/workspace/components/SidebarStatusHeader.test.tsx
- npm run test
- npm run build
- codex exec --sandbox read-only review --base origin/main --output-last-message /tmp/vimeflow-vim35-codex-review-2.txt

Closes VIM-35