### PR TITLE
[VIM-31] Guard e2e terminal input against batched key delivery

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -67,7 +67,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                       | error-handling     | 34       | 8    | 2026-05-31   |
 | [File Tree Paths](patterns/file-tree-paths.md)                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 18       | 6    | 2026-05-20   |
+| [E2E Testing](patterns/e2e-testing.md)                               | e2e-testing        | 19       | 7    | 2026-06-06   |
 | [Module Boundaries](patterns/module-boundaries.md)                   | code-quality       | 12       | 1    | 2026-05-30   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 18       | 0    | 2026-05-26   |

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -3,7 +3,7 @@ id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
 last_updated: 2026-05-20
-ref_count: 6
+ref_count: 7
 ---
 
 # E2E Testing
@@ -209,3 +209,12 @@ completely different root causes. The generic fast-failure modes:
 - **Finding:** Even after narrowing the detection to Linux hosts without display variables, `electron:dev` still inferred `--no-sandbox` automatically on headless Linux. That made every CI/container/dev-shell run in that state silently drop Chromium's renderer sandbox with no visible opt-in.
 - **Fix:** Removed runtime auto-detection from the Vite startup path. `electron:dev` now passes `--no-sandbox` only when `VIMEFLOW_NO_SANDBOX=1` is explicitly set, keeping normal dev and CI sandboxed by default while preserving a documented escape hatch for Linux hosts that cannot launch Chromium's sandbox.
 - **Commit:** _(see git log for the PR #214 explicit sandbox opt-in review-fix commit)_
+
+### 19. E2E input guard passes vacuously when `E2E_ROOT` contains no `.ts` files
+
+- **Source:** github-claude | PR #374 cycle 1 | 2026-06-06
+- **Severity:** MEDIUM
+- **File:** `src/test/e2eInputGuard.test.ts`
+- **Finding:** After computing `filePaths` from `listTypeScriptFiles(E2E_ROOT)`, the test immediately evaluates `expect(findings).toEqual([])`. If `tests/e2e` is empty, or if all e2e files are temporarily moved or renamed (e.g., during a directory restructure), `filePaths` is `[]`, `findings` is `[]`, and the assertion trivially passes — the guard silently grants a clean bill of health without having scanned a single file. The guard's stated purpose (preventing `browser.keys(...)` usage in e2e tests) evaporates silently.
+- **Fix:** Added `expect(filePaths.length).toBeGreaterThan(0)` immediately after computing `filePaths`, requiring the guard to scan at least one e2e TypeScript file before checking findings. This distinguishes "no violations found" from "no files scanned".
+- **Commit:** _(this cycle)_

--- a/src/test/e2eInputGuard.test.ts
+++ b/src/test/e2eInputGuard.test.ts
@@ -1,0 +1,78 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import * as ts from 'typescript'
+import { describe, expect, test } from 'vitest'
+
+const E2E_ROOT = path.join(process.cwd(), 'tests/e2e')
+
+const listTypeScriptFiles = async (dir: string): Promise<string[]> => {
+  const entries = await readdir(dir, { withFileTypes: true })
+
+  const nested = await Promise.all(
+    entries.map(async (entry): Promise<string[]> => {
+      const fullPath = path.join(dir, entry.name)
+
+      if (entry.isDirectory()) {
+        return listTypeScriptFiles(fullPath)
+      }
+
+      return entry.isFile() && entry.name.endsWith('.ts') ? [fullPath] : []
+    })
+  )
+
+  return nested.flat()
+}
+
+const isBrowserKeysCall = (node: ts.Node): node is ts.CallExpression =>
+  ts.isCallExpression(node) &&
+  ts.isPropertyAccessExpression(node.expression) &&
+  ts.isIdentifier(node.expression.expression) &&
+  node.expression.expression.text === 'browser' &&
+  node.expression.name.text === 'keys'
+
+const findBrowserKeysCalls = (sourceFile: ts.SourceFile): string[] => {
+  const calls: string[] = []
+
+  const visit = (node: ts.Node): void => {
+    if (isBrowserKeysCall(node)) {
+      const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+        node.getStart(sourceFile)
+      )
+      calls.push(
+        `${path.relative(process.cwd(), sourceFile.fileName)}:${line + 1}:${character + 1}`
+      )
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+
+  return calls
+}
+
+describe('e2e terminal input guard', () => {
+  test('does not use batched browser.keys calls in e2e files', async () => {
+    const filePaths = await listTypeScriptFiles(E2E_ROOT)
+
+    const findings = (
+      await Promise.all(
+        filePaths.map(async (filePath): Promise<string[]> => {
+          const source = await readFile(filePath, 'utf8')
+
+          const sourceFile = ts.createSourceFile(
+            filePath,
+            source,
+            ts.ScriptTarget.Latest,
+            true,
+            ts.ScriptKind.TS
+          )
+
+          return findBrowserKeysCalls(sourceFile)
+        })
+      )
+    ).flat()
+
+    expect(findings).toEqual([])
+  })
+})

--- a/src/test/e2eInputGuard.test.ts
+++ b/src/test/e2eInputGuard.test.ts
@@ -55,6 +55,8 @@ describe('e2e terminal input guard', () => {
   test('does not use batched browser.keys calls in e2e files', async () => {
     const filePaths = await listTypeScriptFiles(E2E_ROOT)
 
+    expect(filePaths.length).toBeGreaterThan(0)
+
     const findings = (
       await Promise.all(
         filePaths.map(async (filePath): Promise<string[]> => {

--- a/tests/e2e/terminal/specs/pane-lifecycle.spec.ts
+++ b/tests/e2e/terminal/specs/pane-lifecycle.spec.ts
@@ -84,7 +84,7 @@ describe('Pane lifecycle split focus', () => {
       }
     )
 
-    await clickBySelector('button[aria-label="add pane"]')
+    await clickBySelector('button[aria-label="add shell pane"]')
     await waitForPaneCount(2)
 
     await clickBySelector('[data-testid="split-view-slot"][data-pane-id="p0"]')


### PR DESCRIPTION
## Summary
- Add a Vitest AST guard that fails if e2e files call `browser.keys(...)`, preserving the ordered terminal input helper contract.
- Update the pane lifecycle e2e spec to click the current `add shell pane` control after the empty-slot UI split.
- Leave the existing 8 ms per-character pause unchanged because the terminal and agent e2e suites pass with the current value.

## Verification
- `npm run test -- src/test/e2eInputGuard.test.ts`
- `npm run lint`
- `npm run type-check`
- `git diff --check`
- `npm run test`
- `npm run build`
- `npm run test:e2e:build`
- `npm run test:e2e:terminal:run -- --spec tests/e2e/terminal/specs/pane-lifecycle.spec.ts`
- `npm run test:e2e:terminal:run`
- `npm run test:e2e:agent:run`
- `codex exec --sandbox read-only review --base origin/main --output-last-message /tmp/vimeflow-vim31-codex-review.txt`

Closes VIM-31