### PR TITLE
[VIM-26] Multiplex backend event listeners

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -50,7 +50,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality       | 5        | 0    | 2026-05-09   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)       | backend            | 7        | 1    | 2026-06-03   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 59       | 26   | 2026-06-06   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 61       | 27   | 2026-06-07   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 83       | 24   | 2026-06-03   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -50,7 +50,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality       | 5        | 0    | 2026-05-09   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)       | backend            | 7        | 1    | 2026-06-03   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 58       | 25   | 2026-05-30   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 59       | 26   | 2026-06-06   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 83       | 24   | 2026-06-03   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 25       | 6    | 2026-05-09   |

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-05-28
-ref_count: 25
+last_updated: 2026-06-06
+ref_count: 26
 ---
 
 # Testing Gaps
@@ -582,3 +582,13 @@ filesystem scope restrictions).
 - **Finding:** Cycle 4's signal-based refactor (#56) eliminated SCHEDULER flakiness — the watcher emits explicit phase signals (`"initial-read"`, `"mtime-update"`) the test waits on with `recv_timeout`, so thread-startup timing doesn't matter. But the test still calls `write_index` to seed the file and then later calls `std::fs::write` to rewrite — and the watcher's change-detection compares `modified_time(&path)` against the previously-observed `last_mtime`. On any filesystem with 1-second mtime resolution (HFS+ pre-APFS, FAT32, some FUSE-mounted tmpdirs), the seed write and the rewrite can both land in the same wall-clock second when the test runs fast. Identical mtimes → `current_mtime == last_mtime` → watcher skips the change → `"mtime-update"` signal never sent → test's 5-second `recv_timeout` expires as a spurious flake that looks indistinguishable from a real deadlock. The dominant CI surfaces use ext4 / APFS / NTFS (nanosecond resolution) so this rarely materializes, but it's a real portability hole that future macOS pre-Catalina runners or atypical CI mounts would trip.
 - **Fix:** After the initial `write_index` and BEFORE spawning the watcher, force the seed file's mtime two seconds into the past via `std::fs::File::set_modified(SystemTime::now() - Duration::from_secs(2))`. `File::set_modified` is stable since Rust 1.75, so this works without a direct dep on the `filetime` crate (which is already transitively pulled in by `notify`). The watcher's `last_mtime = modified_time(&path)` now records a value 2 seconds in the past; the test's subsequent rewrite at NOW has an mtime unambiguously later than `last_mtime` regardless of filesystem resolution (1-second or finer). 2 seconds is enough margin to cover the worst-case 1-second resolution + clock skew without making the test wait. Code-review heuristic: filesystem timestamp tests that mutate a file twice in rapid succession have a latent flake mode on coarse-resolution filesystems unless they explicitly control the mtime ordering. The fix is mechanical: either force the first write's mtime backward (cheap, what we did here), or force the second write's mtime forward (also works but awkward since you'd be writing a future-dated mtime). The naive "two `fs::write` calls separated by sleep" pattern has BOTH this issue AND the scheduler-flake issue #56 addresses; both fixes are independent and both should be applied to any new poll-loop FS test.
 - **Commit:** _(PR #302 upsource cycle 7 fix commit)_
+
+### 59. Module-level backend event subscription registry leaks across tests, causing cascading failures when a listener test fails before cleanup
+
+- **Source:** github-claude | PR #375 round 1 | 2026-06-06
+- **Severity:** MEDIUM
+- **File:** `src/lib/backend.test.ts` L34-36, `src/lib/backend.ts` L68
+- **Finding:** `backendEventSubscriptions` is a module-level `Map<string, BackendEventSubscription>` that persists across test boundaries. The existing `afterEach` only deleted `window.vimeflow` but never cleared the Map. In the happy path each test calls its returned `unlisten()`, which cleans up the entry. But if an assertion fails before `unlisten()` runs, the stale subscription — with its stale `rawUnlisten` mock and callback Set — remains. A subsequent test using the same event name reuses the leaked subscription, skips `bridge.listen()`, and asserts against stale mocks, producing confusing cascading failures.
+- **Fix:** Exported a test-only helper `__resetBackendEventSubscriptions(): void` from `backend.ts` that calls `backendEventSubscriptions.clear()`. Added a top-level `afterEach(() => { __resetBackendEventSubscriptions() })` in `backend.test.ts` so every test starts with a clean registry regardless of prior test outcome.
+- **Code-review heuristic:** Any module-level singleton state (Maps, Sets, counters, caches) that outlives a single test must have an explicit reset path called from `afterEach` or `beforeEach`. Relying on per-test cleanup callbacks (like `unlisten()`) is insufficient because assertion failures can short-circuit cleanup. The reset helper should be clearly marked as test-only (`__` prefix or `/* @test-only */` comment) so it doesn't leak into production usage.
+- **Commit:** _(PR #375 upsource cycle 1 fix commit)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-06
-ref_count: 26
+last_updated: 2026-06-07
+ref_count: 27
 ---
 
 # Testing Gaps
@@ -601,3 +601,13 @@ filesystem scope restrictions).
 - **Fix:** Exported a test-only helper `__resetBackendEventSubscriptions(): void` from `backend.ts` that calls `backendEventSubscriptions.clear()`. Added a top-level `afterEach(() => { __resetBackendEventSubscriptions() })` in `backend.test.ts` so every test starts with a clean registry regardless of prior test outcome.
 - **Code-review heuristic:** Any module-level singleton state (Maps, Sets, counters, caches) that outlives a single test must have an explicit reset path called from `afterEach` or `beforeEach`. Relying on per-test cleanup callbacks (like `unlisten()`) is insufficient because assertion failures can short-circuit cleanup. The reset helper should be clearly marked as test-only (`__` prefix or `/* @test-only */` comment) so it doesn't leak into production usage.
 - **Commit:** _(PR #375 upsource cycle 1 fix commit)_
+
+### 61. New attach-failure cleanup path lacks regression coverage
+
+- **Source:** github-claude | PR #375 round 2 | 2026-06-07
+- **Severity:** MEDIUM
+- **File:** `src/lib/backend.ts` L124-140 and `src/lib/backend.test.ts`
+- **Finding:** The PR introduces module-level subscription state plus a new catch path that deletes the failed event entry and clears callbacks when `bridge.listen` rejects. That behavior is correctness-critical for retryability: if a future edit drops the map delete, later `listen` calls for the same event will reuse a subscription whose `attachPromise` is already rejected; if callback clearing is dropped, stale callbacks can remain registered after a failed attach. The existing happy-path tests do not exercise this rejection-and-retry sequence.
+- **Fix:** Added a focused `backend.test.ts` case where `bridge.listen` rejects once, `listen` rejects, and a second `listen` for the same event retries the bridge instead of reusing the rejected subscription. Asserts `mockListen` is called twice and the retry succeeds with a fresh subscription.
+- **Code-review heuristic:** When a PR changes direct bridge delegation into shared module-level subscription state, the bridge rejection path now performs important state mutation that did not exist before. A single retry-focused test is sufficient to guard the cleanup contract; validate through mock call counts and successful retry rather than test-only introspection of internal maps.
+- **Commit:** _(PR #375 upsource cycle 2 fix commit)_

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -35,6 +35,7 @@ const electronMock = vi.hoisted(() => {
       invoke: vi.fn(),
       on: vi.fn(),
       off: vi.fn(),
+      setMaxListeners: vi.fn(),
     },
   }
 })
@@ -43,6 +44,10 @@ vi.mock('electron', () => ({
   contextBridge: electronMock.contextBridge,
   ipcRenderer: electronMock.ipcRenderer,
 }))
+
+const preloadSetMaxListenersCalls = [
+  ...electronMock.ipcRenderer.setMaxListeners.mock.calls,
+]
 
 const browserPane = (): Record<string, unknown> => {
   const api = electronMock.exposed
@@ -63,6 +68,10 @@ const browserPane = (): Record<string, unknown> => {
 describe('preload browserPane wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  test('raises the shared ipcRenderer listener cap during preload startup', () => {
+    expect(preloadSetMaxListenersCalls).toEqual([[64]])
   })
 
   test.each([

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -23,6 +23,10 @@ import {
   BROWSER_PANE_URL_CHANGED,
 } from './browser-pane-channels'
 
+const BACKEND_EVENT_MAX_LISTENERS = 64
+
+ipcRenderer.setMaxListeners(BACKEND_EVENT_MAX_LISTENERS)
+
 type InvokeEnvelope<T> =
   | { ok: true; result: T }
   | { ok: false; error: string; errorReason?: string }

--- a/src/lib/backend.test.ts
+++ b/src/lib/backend.test.ts
@@ -206,6 +206,25 @@ describe('backend (window.vimeflow bridge)', () => {
     expect(rawUnlisten).toHaveBeenCalledTimes(1)
   })
 
+  test('listen retries bridge attachment after rejection instead of reusing failed subscription', async () => {
+    mockListen.mockRejectedValueOnce(new Error('bridge attach failed'))
+
+    await expect(listen('retry-event', noop)).rejects.toThrow(
+      'bridge attach failed'
+    )
+
+    const rawUnlisten = vi.fn()
+    mockListen.mockResolvedValueOnce(rawUnlisten)
+
+    const cb = vi.fn()
+    const unlisten = await listen('retry-event', cb)
+
+    expect(mockListen).toHaveBeenCalledTimes(2)
+    expect(typeof unlisten).toBe('function')
+
+    unlisten()
+  })
+
   test('UnlistenFn is idempotent', async () => {
     const rawUnlisten = vi.fn()
     mockListen.mockResolvedValueOnce(rawUnlisten)

--- a/src/lib/backend.test.ts
+++ b/src/lib/backend.test.ts
@@ -6,9 +6,14 @@ import {
   listenCommandPaletteToggle,
   renameAgentSession,
   type BackendApi,
+  __resetBackendEventSubscriptions,
 } from './backend'
 
 const noop = (): void => undefined
+
+afterEach(() => {
+  __resetBackendEventSubscriptions()
+})
 
 const observeResolution = async (
   promise: Promise<unknown>,

--- a/src/lib/backend.test.ts
+++ b/src/lib/backend.test.ts
@@ -80,9 +80,12 @@ describe('backend (window.vimeflow bridge)', () => {
       expect.any(Function)
     )
     expect(typeof unlisten).toBe('function')
+
+    unlisten()
   })
 
   test('listen callback receives bare payload', async () => {
+    const rawUnlisten = vi.fn()
     mockListen.mockImplementationOnce(
       (
         _event: string,
@@ -90,18 +93,24 @@ describe('backend (window.vimeflow bridge)', () => {
       ): Promise<() => void> => {
         cb({ sessionId: 's1', data: 'hi' })
 
-        return Promise.resolve(vi.fn())
+        return Promise.resolve(rawUnlisten)
       }
     )
     const cb = vi.fn()
 
-    await listen<{ sessionId: string; data: string }>('pty-data', cb)
+    const unlisten = await listen<{ sessionId: string; data: string }>(
+      'pty-data',
+      cb
+    )
 
     expect(cb).toHaveBeenCalledWith({ sessionId: 's1', data: 'hi' })
+
+    unlisten()
   })
 
   test('listen resolves only after window.vimeflow.listen resolves', async () => {
     let resolveTransport!: (unlisten: () => void) => void
+    const rawUnlisten = vi.fn()
     mockListen.mockReturnValueOnce(
       new Promise<() => void>((resolve) => {
         resolveTransport = resolve
@@ -117,10 +126,79 @@ describe('backend (window.vimeflow bridge)', () => {
 
     await Promise.resolve()
     expect(resolved).toBe(false)
-    resolveTransport(vi.fn())
-    await bridgePromise
+    resolveTransport(rawUnlisten)
+    const unlisten = await bridgePromise
     await resolutionPromise
     expect(resolved).toBe(true)
+
+    unlisten()
+  })
+
+  test('listen shares one bridge listener per backend event', async () => {
+    let bridgeCallback!: (payload: { value: string }) => void
+    const rawUnlisten = vi.fn()
+    mockListen.mockImplementationOnce(
+      (
+        _event: string,
+        cb: (payload: { value: string }) => void
+      ): Promise<() => void> => {
+        bridgeCallback = cb
+
+        return Promise.resolve(rawUnlisten)
+      }
+    )
+    const first = vi.fn()
+    const second = vi.fn()
+
+    const unlistenFirst = await listen<{ value: string }>('shared-event', first)
+
+    const unlistenSecond = await listen<{ value: string }>(
+      'shared-event',
+      second
+    )
+
+    expect(mockListen).toHaveBeenCalledTimes(1)
+
+    bridgeCallback({ value: 'first-payload' })
+    expect(first).toHaveBeenCalledWith({ value: 'first-payload' })
+    expect(second).toHaveBeenCalledWith({ value: 'first-payload' })
+
+    unlistenFirst()
+    bridgeCallback({ value: 'second-payload' })
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenCalledWith({ value: 'second-payload' })
+    expect(rawUnlisten).not.toHaveBeenCalled()
+
+    unlistenSecond()
+    expect(rawUnlisten).toHaveBeenCalledTimes(1)
+  })
+
+  test('listen shares an in-flight bridge attachment for same-event subscribers', async () => {
+    let resolveTransport!: (unlisten: () => void) => void
+    const rawUnlisten = vi.fn()
+    mockListen.mockReturnValueOnce(
+      new Promise<() => void>((resolve) => {
+        resolveTransport = resolve
+      })
+    )
+
+    const firstPromise = listen('pending-event', noop)
+    const secondPromise = listen('pending-event', noop)
+
+    expect(mockListen).toHaveBeenCalledTimes(1)
+
+    resolveTransport(rawUnlisten)
+
+    const [unlistenFirst, unlistenSecond] = await Promise.all([
+      firstPromise,
+      secondPromise,
+    ])
+
+    unlistenFirst()
+    expect(rawUnlisten).not.toHaveBeenCalled()
+
+    unlistenSecond()
+    expect(rawUnlisten).toHaveBeenCalledTimes(1)
   })
 
   test('UnlistenFn is idempotent', async () => {

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -57,6 +57,16 @@ const isStructuredBackendError = (
 
 const noop = (): void => undefined
 
+type BackendEventCallback = (payload: unknown) => void
+
+interface BackendEventSubscription {
+  attachPromise: Promise<void> | null
+  callbacks: Set<BackendEventCallback>
+  rawUnlisten: UnlistenFn | null
+}
+
+const backendEventSubscriptions = new Map<string, BackendEventSubscription>()
+
 const requireBridge = (): BackendApi => {
   if (typeof window === 'undefined' || !window.vimeflow) {
     throw new Error(
@@ -65,6 +75,81 @@ const requireBridge = (): BackendApi => {
   }
 
   return window.vimeflow
+}
+
+const getEventSubscription = (event: string): BackendEventSubscription => {
+  const existing = backendEventSubscriptions.get(event)
+
+  if (existing) {
+    return existing
+  }
+
+  const subscription: BackendEventSubscription = {
+    attachPromise: null,
+    callbacks: new Set(),
+    rawUnlisten: null,
+  }
+  backendEventSubscriptions.set(event, subscription)
+
+  return subscription
+}
+
+const dispatchBackendEvent = (event: string, payload: unknown): void => {
+  const subscription = backendEventSubscriptions.get(event)
+
+  if (!subscription) {
+    return
+  }
+
+  Array.from(subscription.callbacks).forEach((callback) => {
+    callback(payload)
+  })
+}
+
+const ensureEventSubscriptionAttached = (
+  bridge: BackendApi,
+  event: string,
+  subscription: BackendEventSubscription
+): Promise<void> => {
+  if (subscription.attachPromise) {
+    return subscription.attachPromise
+  }
+
+  subscription.attachPromise = (async (): Promise<void> => {
+    try {
+      const rawUnlisten = await bridge.listen<unknown>(event, (payload) => {
+        dispatchBackendEvent(event, payload)
+      })
+      subscription.rawUnlisten = rawUnlisten
+    } catch (error) {
+      if (backendEventSubscriptions.get(event) === subscription) {
+        backendEventSubscriptions.delete(event)
+      }
+
+      subscription.callbacks.clear()
+      throw error
+    }
+  })()
+
+  return subscription.attachPromise
+}
+
+const detachBackendEventCallback = (
+  event: string,
+  subscription: BackendEventSubscription,
+  callback: BackendEventCallback
+): void => {
+  subscription.callbacks.delete(callback)
+
+  if (subscription.callbacks.size > 0) {
+    return
+  }
+
+  subscription.rawUnlisten?.()
+
+  if (backendEventSubscriptions.get(event) === subscription) {
+    backendEventSubscriptions.delete(event)
+  }
 }
 
 /**
@@ -106,7 +191,20 @@ export const listen = async <T>(
   event: string,
   callback: (payload: T) => void
 ): Promise<UnlistenFn> => {
-  const rawUnlisten = await requireBridge().listen<T>(event, callback)
+  const bridge = requireBridge()
+  const subscription = getEventSubscription(event)
+
+  const wrappedCallback = (payload: unknown): void => {
+    callback(payload as T)
+  }
+  subscription.callbacks.add(wrappedCallback)
+
+  try {
+    await ensureEventSubscriptionAttached(bridge, event, subscription)
+  } catch (error) {
+    subscription.callbacks.delete(wrappedCallback)
+    throw error
+  }
 
   let called = false
 
@@ -116,7 +214,7 @@ export const listen = async <T>(
     }
 
     called = true
-    rawUnlisten()
+    detachBackendEventCallback(event, subscription, wrappedCallback)
   }
 }
 

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -67,6 +67,15 @@ interface BackendEventSubscription {
 
 const backendEventSubscriptions = new Map<string, BackendEventSubscription>()
 
+/**
+ * Test-only helper: clears the module-level backend event subscription
+ * registry so that a failed test cannot leak listeners into subsequent
+ * tests.  This is NOT part of the public production API.
+ */
+export const __resetBackendEventSubscriptions = (): void => {
+  backendEventSubscriptions.clear()
+}
+
 const requireBridge = (): BackendApi => {
   if (typeof window === 'undefined' || !window.vimeflow) {
     throw new Error(


### PR DESCRIPTION
## Summary
- Raise the preload `ipcRenderer` listener cap to 64 so the shared backend event channel matches the backend PTY ceiling.
- Multiplex same-event backend subscriptions in `src/lib/backend.ts` so React panes share one bridge listener per backend event and fan out callbacks in-process.
- Add regression coverage for shared listener fan-out, in-flight attach sharing, and preload listener-cap setup.

## Verification
- `npm run test -- src/lib/backend.test.ts electron/preload.test.ts`
- `npm run lint`
- `npm run type-check`
- `git diff --check`
- `npm run test`
- `npm run build`
- `codex exec --sandbox read-only review --base origin/main --output-last-message /tmp/vimeflow-vim26-codex-review.txt`

Closes VIM-26