### PR TITLE
[VIM-24] Enforce feedback batch cap during batched adds

### DIFF
--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -65,34 +65,27 @@ describe('useFeedbackBatch', () => {
     expect(first).toBe(second)
   })
 
-  test('add 50 then 51st addAnnotation returns cap-reached and totalAnnotations stays 50', () => {
+  test('batched 51st addAnnotation returns cap-reached and totalAnnotations stays 50', () => {
     const { result } = renderHook(() => useFeedbackBatch())
+    const returnValues: ('ok' | 'cap-reached')[] = []
 
-    // Add 50 annotations across multiple files to hit the cap
+    // Add 51 annotations in one React batch to exercise the stale-closure
+    // window that can otherwise let the soft cap drift past 50.
     act(() => {
-      for (let i = 0; i < 50; i++) {
-        result.current.addAnnotation(
-          '/repo',
-          `file-${i}.ts`,
-          false,
-          makeAnnotation(`id-${i}`, 'x', i + 1)
+      for (let i = 0; i < 51; i++) {
+        returnValues.push(
+          result.current.addAnnotation(
+            '/repo',
+            `file-${i}.ts`,
+            false,
+            makeAnnotation(`id-${i}`, 'x', i + 1)
+          )
         )
       }
     })
 
-    expect(result.current.totalAnnotations()).toBe(50)
-
-    let returnValue: 'ok' | 'cap-reached' = 'ok'
-    act(() => {
-      returnValue = result.current.addAnnotation(
-        '/repo',
-        'extra.ts',
-        false,
-        makeAnnotation('id-extra')
-      )
-    })
-
-    expect(returnValue).toBe('cap-reached')
+    expect(returnValues.slice(0, 50)).toEqual(Array(50).fill('ok'))
+    expect(returnValues[50]).toBe('cap-reached')
     expect(result.current.totalAnnotations()).toBe(50)
   })
 

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { DiffLineAnnotation } from '@pierre/diffs'
 
 export interface ReviewComment {
@@ -59,6 +59,78 @@ export const parseBatchKey = (key: string): ParsedBatchKey => {
 
 const SOFT_CAP = 50
 
+const countAnnotationsInBatch = (batch: FeedbackBatch): number => {
+  let count = 0
+  for (const list of batch.values()) {
+    count += list.length
+  }
+
+  return count
+}
+
+const addAnnotationToBatch = (
+  batch: FeedbackBatch,
+  key: string,
+  annotation: DiffLineAnnotation<ReviewComment>
+): FeedbackBatch => {
+  const next = new Map(batch)
+  const existing = next.get(key) ?? []
+  next.set(key, [...existing, annotation])
+
+  return next
+}
+
+const updateAnnotationInBatch = (
+  batch: FeedbackBatch,
+  key: string,
+  id: string,
+  patch: Partial<ReviewComment>
+): FeedbackBatch => {
+  const list = batch.get(key)
+  if (!list) {
+    return batch
+  }
+  const idx = list.findIndex((a) => a.metadata.id === id)
+  if (idx === -1) {
+    return batch
+  }
+  const next = new Map(batch)
+
+  const updated = list.map((a, i) => {
+    if (i !== idx) {
+      return a
+    }
+
+    return {
+      ...a,
+      metadata: { ...a.metadata, ...patch },
+    }
+  })
+  next.set(key, updated)
+
+  return next
+}
+
+const removeAnnotationFromBatch = (
+  batch: FeedbackBatch,
+  key: string,
+  id: string
+): FeedbackBatch => {
+  const list = batch.get(key)
+  if (!list) {
+    return batch
+  }
+  const filtered = list.filter((a) => a.metadata.id !== id)
+  const next = new Map(batch)
+  if (filtered.length === 0) {
+    next.delete(key)
+  } else {
+    next.set(key, filtered)
+  }
+
+  return next
+}
+
 /**
  * Stable empty array returned for absent file keys.
  * Must be module-level and frozen so callers get referential equality
@@ -99,15 +171,17 @@ export interface UseFeedbackBatchReturn {
 
 export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
   const [batch, setBatch] = useState<FeedbackBatch>(() => new Map())
+  const optimisticBatchRef = useRef<FeedbackBatch>(batch)
+  const addAnnotationResultRef = useRef<'ok' | 'cap-reached'>('ok')
 
-  const totalAnnotations = useCallback((): number => {
-    let count = 0
-    for (const list of batch.values()) {
-      count += list.length
-    }
-
-    return count
+  useEffect(() => {
+    optimisticBatchRef.current = batch
   }, [batch])
+
+  const totalAnnotations = useCallback(
+    (): number => countAnnotationsInBatch(batch),
+    [batch]
+  )
 
   const annotationsForFile = useCallback(
     (
@@ -129,21 +203,38 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
       staged: boolean,
       annotation: DiffLineAnnotation<ReviewComment>
     ): 'ok' | 'cap-reached' => {
-      if (totalAnnotations() >= SOFT_CAP) {
-        return 'cap-reached'
-      }
       const key = makeBatchKey(cwd, filePath, staged)
+
+      if (countAnnotationsInBatch(optimisticBatchRef.current) >= SOFT_CAP) {
+        addAnnotationResultRef.current = 'cap-reached'
+
+        return addAnnotationResultRef.current
+      }
+
+      optimisticBatchRef.current = addAnnotationToBatch(
+        optimisticBatchRef.current,
+        key,
+        annotation
+      )
+      addAnnotationResultRef.current = 'ok'
       setBatch((prev) => {
-        const next = new Map(prev)
-        const existing = next.get(key) ?? []
-        next.set(key, [...existing, annotation])
+        if (countAnnotationsInBatch(prev) >= SOFT_CAP) {
+          addAnnotationResultRef.current = 'cap-reached'
+          optimisticBatchRef.current = prev
+
+          return prev
+        }
+
+        addAnnotationResultRef.current = 'ok'
+        const next = addAnnotationToBatch(prev, key, annotation)
+        optimisticBatchRef.current = next
 
         return next
       })
 
-      return 'ok'
+      return addAnnotationResultRef.current
     },
-    [totalAnnotations]
+    []
   )
 
   const updateAnnotation = useCallback(
@@ -155,28 +246,16 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
       patch: Partial<ReviewComment>
     ): void => {
       const key = makeBatchKey(cwd, filePath, staged)
+      optimisticBatchRef.current = updateAnnotationInBatch(
+        optimisticBatchRef.current,
+        key,
+        id,
+        patch
+      )
+
       setBatch((prev) => {
-        const list = prev.get(key)
-        if (!list) {
-          return prev
-        }
-        const idx = list.findIndex((a) => a.metadata.id === id)
-        if (idx === -1) {
-          return prev
-        }
-        const next = new Map(prev)
-
-        const updated = list.map((a, i) => {
-          if (i !== idx) {
-            return a
-          }
-
-          return {
-            ...a,
-            metadata: { ...a.metadata, ...patch },
-          }
-        })
-        next.set(key, updated)
+        const next = updateAnnotationInBatch(prev, key, id, patch)
+        optimisticBatchRef.current = next
 
         return next
       })
@@ -187,18 +266,15 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
   const removeAnnotation = useCallback(
     (cwd: string, filePath: string, staged: boolean, id: string): void => {
       const key = makeBatchKey(cwd, filePath, staged)
+      optimisticBatchRef.current = removeAnnotationFromBatch(
+        optimisticBatchRef.current,
+        key,
+        id
+      )
+
       setBatch((prev) => {
-        const list = prev.get(key)
-        if (!list) {
-          return prev
-        }
-        const filtered = list.filter((a) => a.metadata.id !== id)
-        const next = new Map(prev)
-        if (filtered.length === 0) {
-          next.delete(key)
-        } else {
-          next.set(key, filtered)
-        }
+        const next = removeAnnotationFromBatch(prev, key, id)
+        optimisticBatchRef.current = next
 
         return next
       })
@@ -207,7 +283,9 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
   )
 
   const clearBatch = useCallback((): void => {
-    setBatch(() => new Map())
+    const next: FeedbackBatch = new Map()
+    optimisticBatchRef.current = next
+    setBatch(() => next)
   }, [])
 
   return {


### PR DESCRIPTION
## Summary
- Move feedback batch counting into shared helpers and guard add operations against the current queued batch state.
- Track an optimistic batch ref so multiple synchronous `addAnnotation` calls return `cap-reached` at the soft cap instead of all seeing a stale render snapshot.
- Update the hook regression test to add 51 annotations inside one React `act()` batch.

## Verification
- `npm run test -- src/features/diff/hooks/useFeedbackBatch.test.ts`
- `npm run lint`
- `npm run type-check`
- `git diff --check origin/main..HEAD`
- `npm run test`
- `npm run build`
- `codex exec --sandbox read-only review --base origin/main --output-last-message /tmp/vimeflow-vim24-codex-review.txt`

Closes VIM-24