### PR TITLE
[VIM-23] Disable feedback actions without handlers

### DIFF
--- a/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
@@ -695,6 +695,22 @@ describe('DiffChipToolbar', () => {
     ).toBeInTheDocument()
   })
 
+  test('disables the pinned feedback actions when their handlers are omitted', () => {
+    renderToolbar({
+      feedbackCount: 3,
+      onFinishFeedback: undefined,
+      onDiscardFeedback: undefined,
+    })
+
+    expect(
+      screen.getByRole('button', { name: /finish feedback/i })
+    ).toBeDisabled()
+
+    expect(
+      screen.getByRole('button', { name: /discard all feedback/i })
+    ).toBeDisabled()
+  })
+
   test('clicking the Finish action calls onFinishFeedback once', async () => {
     const user = userEvent.setup()
     const onFinishFeedback = vi.fn<() => void>()

--- a/src/features/diff/components/toolbar/DiffChipToolbar.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.tsx
@@ -452,6 +452,8 @@ export const DiffChipToolbar = ({
   // Paired feedback actions — pinned right, NEVER overflow (rendered outside
   // PriorityPlus). Only present when there is pending inline-review feedback.
   const showActions = feedbackCount > 0
+  const canDiscardFeedback = onDiscardFeedback !== undefined
+  const canFinishFeedback = onFinishFeedback !== undefined
 
   return (
     <div
@@ -471,16 +473,18 @@ export const DiffChipToolbar = ({
             <button
               type="button"
               aria-label="discard all feedback"
+              disabled={!canDiscardFeedback}
               onClick={onDiscardFeedback}
-              className="inline-flex items-center gap-[7px] h-[30px] px-3.5 rounded-md font-body text-[0.78rem] font-semibold bg-surface-container-highest text-on-surface-variant hover:bg-error/15 hover:text-error transition-colors"
+              className="inline-flex items-center gap-[7px] h-[30px] px-3.5 rounded-md font-body text-[0.78rem] font-semibold bg-surface-container-highest text-on-surface-variant hover:bg-error/15 hover:text-error transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-surface-container-highest disabled:hover:text-on-surface-variant"
             >
               Discard
             </button>
             <button
               type="button"
               aria-label={`finish feedback (${feedbackCount})`}
+              disabled={!canFinishFeedback}
               onClick={onFinishFeedback}
-              className="inline-flex items-center gap-[7px] h-[30px] px-3.5 rounded-md font-body text-[0.78rem] font-semibold text-on-primary bg-gradient-to-br from-primary to-primary-container shadow-[0_4px_14px_rgba(203,166,247,0.22)] transition-colors"
+              className="inline-flex items-center gap-[7px] h-[30px] px-3.5 rounded-md font-body text-[0.78rem] font-semibold text-on-primary bg-gradient-to-br from-primary to-primary-container shadow-[0_4px_14px_rgba(203,166,247,0.22)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
             >
               <span
                 aria-hidden="true"


### PR DESCRIPTION
## Summary
- Disable the pinned Finish and Discard feedback actions when their corresponding callbacks are omitted.
- Add disabled styling so missing-handler actions no longer appear fully interactive.
- Cover the omitted-handler case in `DiffChipToolbar` tests.

## Verification
- `npm run test -- src/features/diff/components/toolbar/DiffChipToolbar.test.tsx`
- `npm run lint`
- `npm run type-check`
- `git diff --check`
- `npm run test`
- `npm run build`
- `codex exec --sandbox read-only review --base origin/main --output-last-message /tmp/vimeflow-vim23-codex-review.txt`

Closes VIM-23