### PR TITLE
[VIM-16] Keep liquid wave duration stable

### DIFF
--- a/src/features/agent-status/hooks/useWaterCursor.test.tsx
+++ b/src/features/agent-status/hooks/useWaterCursor.test.tsx
@@ -185,6 +185,22 @@ describe('useWaterCursor — spring loop', () => {
     expect(refs.slosh.style.transform).not.toMatch(/rotate\(0(\.0+)?deg\)/)
   })
 
+  test('pointermove does not rewrite CSS wave animation durations', async () => {
+    mockMatchMedia(makeMql(false))
+    const refs = makeRefs()
+    render(<Harness refs={refs} addSpy={vi.fn()} removeSpy={vi.fn()} />)
+    const wrap = screen.getByTestId('wrap')
+    stubRect(wrap, 100, 100)
+
+    act(() => {
+      firePointer(wrap, 'pointermove', { clientX: 80, clientY: 50 })
+    })
+    await flushRaf(3)
+
+    expect(refs.waveAAnim.style.animationDuration).toBe('')
+    expect(refs.waveBAnim.style.animationDuration).toBe('')
+  })
+
   test('pointerleave settles back and clears inline', async () => {
     mockMatchMedia(makeMql(false))
     const refs = makeRefs()

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -20,7 +20,6 @@ export const LIQUID_DEFAULTS = {
   maxShift: 1.0,
   maxLift: 1.0,
   meniscus: 2.3,
-  speedup: 1.02,
 } as const
 
 export type LiquidTune = { [K in keyof typeof LIQUID_DEFAULTS]: number }
@@ -31,7 +30,6 @@ type Signal =
   | 'shiftX'
   | 'lift'
   | 'skew'
-  | 'speedT'
   | 'sheenX'
   | 'sheenA'
 
@@ -43,7 +41,6 @@ const initialTarget = (): SignalState => ({
   shiftX: 0,
   lift: 0,
   skew: 0,
-  speedT: 0,
   sheenX: 0,
   sheenA: 0,
 })
@@ -54,7 +51,6 @@ const initialVel = (): SignalState => ({
   shiftX: 0,
   lift: 0,
   skew: 0,
-  speedT: 0,
   sheenX: 0,
   sheenA: 0,
 })
@@ -66,8 +62,7 @@ export const useWaterCursor = (
   refsRef: RefObject<LiquidRefs | null>,
   tune: Partial<LiquidTune> = EMPTY_TUNE
 ): void => {
-  const { halo, omega, maxTilt, ampMax, maxShift, maxLift, meniscus, speedup } =
-    tune
+  const { halo, omega, maxTilt, ampMax, maxShift, maxLift, meniscus } = tune
 
   useEffect(() => {
     const wrap = wrapRef.current
@@ -85,7 +80,6 @@ export const useWaterCursor = (
       ...(maxShift !== undefined && { maxShift }),
       ...(maxLift !== undefined && { maxLift }),
       ...(meniscus !== undefined && { meniscus }),
-      ...(speedup !== undefined && { speedup }),
     }
 
     const target = initialTarget()
@@ -122,7 +116,6 @@ export const useWaterCursor = (
       target.shiftX = norm * proximity * T.maxShift
       target.lift = -aboveBelow * proximity * T.maxLift
       target.skew = norm * proximity * T.meniscus
-      target.speedT = proximity
       target.sheenX = norm
       target.sheenA = proximity
       ensureLoop()
@@ -134,7 +127,6 @@ export const useWaterCursor = (
       target.shiftX = 0
       target.lift = 0
       target.skew = 0
-      target.speedT = 0
       target.sheenA = 0
       target.sheenX = 0
       ensureLoop()
@@ -155,16 +147,15 @@ export const useWaterCursor = (
 
       // Hover-driven writes are skipped on pure-wake frames (pct change
       // with no hover). On a pure wake, hover targets stay at ambient,
-      // so the slosh/wave/animationDuration writes here would be no-op
-      // identity values that clearInline() reverses in the same frame —
-      // unnecessary DOM work and fragile against future style-flushes.
+      // so the slosh/wave writes here would be no-op identity values that
+      // clearInline() reverses in the same frame — unnecessary DOM work and
+      // fragile against future style-flushes.
       const hoverActive =
         target.tilt !== 0 ||
         target.amp !== 1 ||
         target.shiftX !== 0 ||
         target.lift !== 0 ||
         target.skew !== 0 ||
-        target.speedT !== 0 ||
         target.sheenA !== 0 ||
         target.sheenX !== 0
 
@@ -189,13 +180,6 @@ export const useWaterCursor = (
         ).toFixed(3)}px) skewX(${(-cur.skew).toFixed(3)}deg)`
         refs.waveAShift.style.transform = txA
         refs.waveBShift.style.transform = tx
-
-        const speedFactor = 1 + cur.speedT * (T.speedup - 1)
-        refs.waveAAnim.style.animationDuration =
-          (3.4 / speedFactor).toFixed(3) + 's'
-
-        refs.waveBAnim.style.animationDuration =
-          (4.8 / speedFactor).toFixed(3) + 's'
       }
 
       // Sheen position + opacity track currentWaterTop on every frame
@@ -231,8 +215,6 @@ export const useWaterCursor = (
       // next hover.
       refs.waveAShift.style.transform = ''
       refs.waveBShift.style.transform = ''
-      refs.waveAAnim.style.animationDuration = ''
-      refs.waveBAnim.style.animationDuration = ''
       refs.sheen.setAttribute('fill-opacity', '0')
     }
 
@@ -253,7 +235,6 @@ export const useWaterCursor = (
           'shiftX',
           'lift',
           'skew',
-          'speedT',
           'sheenX',
           'sheenA',
         ]
@@ -284,7 +265,6 @@ export const useWaterCursor = (
           Math.abs(cur.shiftX - target.shiftX) < 0.02 &&
           Math.abs(cur.lift - target.lift) < 0.02 &&
           Math.abs(cur.skew - target.skew) < 0.02 &&
-          Math.abs(cur.speedT - target.speedT) < 0.01 &&
           Math.abs(cur.sheenA - target.sheenA) < 0.01 &&
           Math.abs(cur.sheenX - target.sheenX) < 0.01 &&
           // Keep looping while waterTop is still chasing the CSS transition.
@@ -301,7 +281,6 @@ export const useWaterCursor = (
           target.shiftX === 0 &&
           target.lift === 0 &&
           target.skew === 0 &&
-          target.speedT === 0 &&
           target.sheenA === 0 &&
           target.sheenX === 0
         if (settled) {
@@ -313,7 +292,6 @@ export const useWaterCursor = (
             target.shiftX = 0
             target.lift = 0
             target.skew = 0
-            target.speedT = 0
             target.sheenX = 0
             target.sheenA = 0
             clearInline()
@@ -371,7 +349,6 @@ export const useWaterCursor = (
       target.shiftX = 0
       target.lift = 0
       target.skew = 0
-      target.speedT = 0
       target.sheenX = 0
       target.sheenA = 0
     }
@@ -405,6 +382,5 @@ export const useWaterCursor = (
     maxShift,
     maxLift,
     meniscus,
-    speedup,
   ])
 }

--- a/src/features/agent-status/hooks/useWaterCursor.ts
+++ b/src/features/agent-status/hooks/useWaterCursor.ts
@@ -24,14 +24,7 @@ export const LIQUID_DEFAULTS = {
 
 export type LiquidTune = { [K in keyof typeof LIQUID_DEFAULTS]: number }
 
-type Signal =
-  | 'tilt'
-  | 'amp'
-  | 'shiftX'
-  | 'lift'
-  | 'skew'
-  | 'sheenX'
-  | 'sheenA'
+type Signal = 'tilt' | 'amp' | 'shiftX' | 'lift' | 'skew' | 'sheenX' | 'sheenA'
 
 type SignalState = Record<Signal, number>
 


### PR DESCRIPTION
## Summary
- Stop `useWaterCursor` from rewriting liquid wave CSS `animationDuration` during hover frames.
- Keep the existing tilt, lift, skew, and sheen hover response while leaving wave timeline ownership in CSS.
- Add a regression test that pointer movement does not introduce inline wave animation durations.

## Validation
- `npm run test -- src/features/agent-status/hooks/useWaterCursor.test.tsx src/features/agent-status/components/LiquidFill.test.tsx`
- `npm run lint`
- `npm run type-check`
- `git diff --check origin/main..HEAD`
- `npm run test`
- `npm run build`
- `codex exec --sandbox read-only review --base origin/main --output-last-message /tmp/vimeflow-vim16-codex-review.txt`

Note: jsdom cannot reproduce the browser CSS timeline remapping directly, so the unit regression covers the cause by asserting hover does not write inline animation durations. The Codex read-only review could not run Vitest inside its sandbox because Vite attempted to write `.vite-temp`, but the writable local test runs above passed.

Closes VIM-16