### PR TITLE
[VIM-11] Preserve diff review drafts and selection

### DIFF
--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -137,7 +137,7 @@ vi.mock('@pierre/diffs/react', () => ({
         </div>
       ) : null}
       {lineAnnotations != null && renderAnnotation != null ? (
-        <div data-testid="annotation-slot">
+        <div key={newFile.contents} data-testid="annotation-slot">
           {lineAnnotations.map((annotation, index) => (
             <div key={annotation.metadata.id ?? index}>
               {renderAnnotation(annotation)}
@@ -2237,6 +2237,107 @@ describe('DiffPanelContent', () => {
       expect(
         within(annotationSlot).getByText('Great change!')
       ).toBeInTheDocument()
+    })
+
+    test('preserves composer draft text across a same-file diff refresh remount', async (): Promise<void> => {
+      const user = userEvent.setup()
+      let newText = 'new'
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockImplementation(() =>
+        fileDiffMock({
+          diff: inlineFileDiff,
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText,
+          rawDiff: '',
+        })
+      )
+
+      const props = {
+        cwd: '/repo',
+        selectedFile: { path: 'src/foo.ts', staged: false, cwd: '/repo' },
+        onSelectedFileChange: vi.fn(),
+      } as const
+
+      const { rerender } = render(<DiffPanelContent {...props} />)
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const gutterSlot = screen.getByTestId('gutter-utility-slot')
+
+      await user.click(
+        within(gutterSlot).getByRole('button', {
+          name: 'Add comment on this line',
+        })
+      )
+
+      const textarea = within(
+        screen.getByRole('dialog', { name: /Comment on line/ })
+      ).getByPlaceholderText('Request change')
+
+      await user.type(textarea, 'Draft while agent edits')
+      expect(textarea).toHaveValue('Draft while agent edits')
+
+      newText = 'new after agent edit'
+      rerender(<DiffPanelContent {...props} />)
+
+      expect(screen.getByPlaceholderText('Request change')).toHaveValue(
+        'Draft while agent edits'
+      )
+    })
+
+    test('keeps a recoverable draft notice when refresh removes the target line', async (): Promise<void> => {
+      const user = userEvent.setup()
+      let currentDiff: FileDiff = inlineFileDiff
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockImplementation(() =>
+        fileDiffMock({
+          diff: currentDiff,
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText: 'new',
+          rawDiff: '',
+        })
+      )
+
+      const props = {
+        cwd: '/repo',
+        selectedFile: { path: 'src/foo.ts', staged: false, cwd: '/repo' },
+        onSelectedFileChange: vi.fn(),
+      } as const
+
+      const { rerender } = render(<DiffPanelContent {...props} />)
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      await user.click(
+        within(screen.getByTestId('gutter-utility-slot')).getByRole('button', {
+          name: 'Add comment on this line',
+        })
+      )
+
+      await user.type(
+        within(
+          screen.getByRole('dialog', { name: /Comment on line/ })
+        ).getByPlaceholderText('Request change'),
+        'Draft after disappearing hunk'
+      )
+
+      currentDiff = {
+        ...inlineFileDiff,
+        hunks: [],
+      }
+      rerender(<DiffPanelContent {...props} />)
+
+      expect(
+        screen.queryByRole('dialog', { name: /Comment on line/ })
+      ).not.toBeInTheDocument()
+
+      expect(screen.getByTestId('diff-draft-recovery')).toHaveTextContent(
+        'Draft after disappearing hunk'
+      )
     })
 
     test('onDiscardFeedback (Discard action) clears the batch', async (): Promise<void> => {

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -29,7 +29,7 @@ import { extractHunkPatch } from '../services/gitPatch'
 import { createGitService } from '../services/gitService'
 import { enqueuePoolWrite } from '../services/workerPoolWrites'
 import { useNotifyInfo } from '../../workspace/hooks/useNotifyInfo'
-import type { ChangedFile, SelectedDiffFile } from '../types'
+import type { ChangedFile, FileDiff, SelectedDiffFile } from '../types'
 import {
   useFeedbackBatch,
   parseBatchKey,
@@ -113,6 +113,63 @@ let feedbackCommentSeq = 0
 
 const nextFeedbackCommentId = (): string =>
   `feedback-comment-${(feedbackCommentSeq += 1)}`
+
+interface ComposerTarget {
+  lineNumber: number
+  side: AnnotationSide
+  filePath: string
+  staged: boolean
+  editId?: string
+}
+
+const composerTargetKey = (target: ComposerTarget): string =>
+  `${target.filePath}:${target.staged}:${target.side}:${target.lineNumber}:${
+    target.editId ?? 'draft'
+  }`
+
+const diffContainsComposerTarget = (
+  fileDiff: FileDiff,
+  target: ComposerTarget
+): boolean => {
+  for (const hunk of fileDiff.hunks) {
+    let oldLine = hunk.oldStart
+    let newLine = hunk.newStart
+
+    for (const line of hunk.lines) {
+      const oldLineNumber =
+        line.oldLineNumber ?? (line.type === 'added' ? undefined : oldLine)
+
+      const newLineNumber =
+        line.newLineNumber ?? (line.type === 'removed' ? undefined : newLine)
+
+      if (
+        target.side === 'deletions' &&
+        line.type !== 'added' &&
+        oldLineNumber === target.lineNumber
+      ) {
+        return true
+      }
+
+      if (
+        target.side === 'additions' &&
+        line.type !== 'removed' &&
+        newLineNumber === target.lineNumber
+      ) {
+        return true
+      }
+
+      if (line.type !== 'added') {
+        oldLine += 1
+      }
+
+      if (line.type !== 'removed') {
+        newLine += 1
+      }
+    }
+  }
+
+  return false
+}
 
 // Small inline status cards. They previously lived as an inline JSX ladder in
 // the right-pane block; extracting them keeps the populated-state JSX readable
@@ -218,8 +275,17 @@ export const DiffPanelContent = ({
     [isControlled, onSelectedFileChange]
   )
 
-  // Reset selection when cwd changes (belt-and-suspenders, render guard is primary)
+  // Reset selection when cwd actually changes (belt-and-suspenders, render
+  // guard is primary). Do not fire on initial mount: WorkspaceView owns this
+  // value across dock close/reopen, and clearing it on mount loses the user's
+  // previously selected changed file before auto-select falls back to row 1.
+  const previousSelectionCwdRef = useRef(cwd)
   useEffect(() => {
+    if (previousSelectionCwdRef.current === cwd) {
+      return
+    }
+
+    previousSelectionCwdRef.current = cwd
     commitSelection(null)
   }, [cwd, commitSelection])
 
@@ -333,13 +399,10 @@ export const DiffPanelContent = ({
   // Composer target state: which line currently has an open composer.
   // `editId` set => editing an existing comment in place; absent => a new
   // draft on that line.
-  const [composerTarget, setComposerTarget] = useState<{
-    lineNumber: number
-    side: AnnotationSide
-    filePath: string
-    staged: boolean
-    editId?: string
-  } | null>(null)
+  const [composerTarget, setComposerTarget] = useState<ComposerTarget | null>(
+    null
+  )
+  const [composerDraftText, setComposerDraftText] = useState('')
 
   // Finish feedback popover open state.
   const [finishOpen, setFinishOpen] = useState(false)
@@ -351,13 +414,41 @@ export const DiffPanelContent = ({
     selectedFileStaged
   )
 
+  const composerTargetIsCurrentFile =
+    composerTarget !== null &&
+    composerTarget.filePath === selectedFilePath &&
+    composerTarget.staged === selectedFileStaged
+
+  const composerTargetLineExists = useMemo((): boolean => {
+    if (
+      composerTarget === null ||
+      !composerTargetIsCurrentFile ||
+      activeResponse === null
+    ) {
+      return false
+    }
+
+    return diffContainsComposerTarget(activeResponse.fileDiff, composerTarget)
+  }, [activeResponse, composerTarget, composerTargetIsCurrentFile])
+
+  const composerDraftIsRecoverable =
+    composerTarget !== null &&
+    composerDraftText.trim().length > 0 &&
+    activeResponse !== null &&
+    (!composerTargetIsCurrentFile || !composerTargetLineExists)
+
   // Merge a transient draft annotation in only while composing a NEW comment,
   // so the composer renders inline below the target line. Editing reuses the
   // existing annotation's slot, so no draft is added there. When idle we pass
   // `realAnnotations` straight through to keep its identity stable (avoids
   // Pierre re-tokenizing on every render).
   const lineAnnotations = useMemo((): DiffLineAnnotation<ReviewComment>[] => {
-    if (composerTarget !== null && composerTarget.editId === undefined) {
+    if (
+      composerTarget !== null &&
+      composerTarget.editId === undefined &&
+      composerTargetIsCurrentFile &&
+      (activeResponse === null || composerTargetLineExists)
+    ) {
       const draft: DiffLineAnnotation<ReviewComment> = {
         side: composerTarget.side,
         lineNumber: composerTarget.lineNumber,
@@ -368,7 +459,13 @@ export const DiffPanelContent = ({
     }
 
     return realAnnotations
-  }, [realAnnotations, composerTarget])
+  }, [
+    realAnnotations,
+    composerTarget,
+    composerTargetIsCurrentFile,
+    composerTargetLineExists,
+    activeResponse,
+  ])
 
   const confirmComposer = useCallback(
     (text: string): void => {
@@ -385,6 +482,7 @@ export const DiffPanelContent = ({
         composerTarget.staged !== selectedFileStaged
       ) {
         setComposerTarget(null)
+        setComposerDraftText('')
 
         return
       }
@@ -398,6 +496,7 @@ export const DiffPanelContent = ({
           { text }
         )
         setComposerTarget(null)
+        setComposerDraftText('')
       } else {
         const result = feedback.addAnnotation(
           cwd,
@@ -420,6 +519,7 @@ export const DiffPanelContent = ({
           )
         } else {
           setComposerTarget(null)
+          setComposerDraftText('')
         }
       }
     },
@@ -435,6 +535,7 @@ export const DiffPanelContent = ({
 
   const closeComposer = useCallback((): void => {
     setComposerTarget(null)
+    setComposerDraftText('')
   }, [])
 
   const sendingFeedbackRef = useRef(false)
@@ -512,6 +613,7 @@ export const DiffPanelContent = ({
   // file is not accidentally submitted against another.
   useEffect(() => {
     setComposerTarget(null)
+    setComposerDraftText('')
   }, [selectedFilePath, selectedFileStaged])
 
   const hunkCount = activeResponse?.fileDiff.hunks.length ?? 0
@@ -1167,6 +1269,20 @@ export const DiffPanelContent = ({
               {notifyMessage}
             </div>
           ) : null}
+          {composerDraftIsRecoverable ? (
+            <div
+              role="status"
+              data-testid="diff-draft-recovery"
+              className="mx-3 mb-2 rounded-md bg-surface-container-high/70 px-3 py-2 text-[11px] leading-4 text-on-surface-variant"
+            >
+              Draft preserved for line{' '}
+              {composerTarget.side === 'deletions' ? 'L' : 'R'}
+              {composerTarget.lineNumber}:{' '}
+              <span className="font-medium text-on-surface">
+                {composerDraftText}
+              </span>
+            </div>
+          ) : null}
           {finishOpen && toolbarShellRef.current !== null ? (
             <FinishFeedbackPopover
               anchor={toolbarShellRef.current}
@@ -1237,12 +1353,21 @@ export const DiffPanelContent = ({
                     onClick={(): void => {
                       const hovered = getHoveredLine()
                       if (hovered && selectedFilePath !== null) {
-                        setComposerTarget({
+                        const nextTarget: ComposerTarget = {
                           lineNumber: hovered.lineNumber,
                           side: hovered.side,
                           filePath: selectedFilePath,
                           staged: selectedFileStaged,
-                        })
+                        }
+
+                        setComposerDraftText((current) =>
+                          composerTarget !== null &&
+                          composerTargetKey(composerTarget) ===
+                            composerTargetKey(nextTarget)
+                            ? current
+                            : ''
+                        )
+                        setComposerTarget(nextTarget)
                       }
                     }}
                   >
@@ -1276,7 +1401,8 @@ export const DiffPanelContent = ({
                         }`}
                         lineNumber={annotation.lineNumber}
                         side={annotation.side}
-                        initialText={isEditing ? annotation.metadata.text : ''}
+                        value={composerDraftText}
+                        onTextChange={setComposerDraftText}
                         onConfirm={confirmComposer}
                         onCancel={closeComposer}
                       />
@@ -1286,7 +1412,7 @@ export const DiffPanelContent = ({
                   return (
                     <ReviewCommentRow
                       comment={annotation.metadata}
-                      onEdit={(): void =>
+                      onEdit={(): void => {
                         setComposerTarget({
                           lineNumber: annotation.lineNumber,
                           side: annotation.side,
@@ -1294,7 +1420,8 @@ export const DiffPanelContent = ({
                           staged: selectedFileStaged,
                           editId: annotation.metadata.id,
                         })
-                      }
+                        setComposerDraftText(annotation.metadata.text)
+                      }}
                       onDelete={(): void =>
                         feedback.removeAnnotation(
                           cwd,

--- a/src/features/diff/components/ReviewCommentComposer.test.tsx
+++ b/src/features/diff/components/ReviewCommentComposer.test.tsx
@@ -63,6 +63,41 @@ describe('ReviewCommentComposer', () => {
     expect(textarea).toHaveValue('hello world')
   })
 
+  test('controlled value reports text changes without mutating display directly', async () => {
+    const user = userEvent.setup()
+    const handleTextChange = vi.fn()
+
+    const { rerender } = render(
+      <ReviewCommentComposer
+        lineNumber={1}
+        side="additions"
+        value="draft"
+        onTextChange={handleTextChange}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    const textarea = screen.getByRole('textbox')
+    await user.type(textarea, '!')
+
+    expect(handleTextChange).toHaveBeenCalledWith('draft!')
+    expect(textarea).toHaveValue('draft')
+
+    rerender(
+      <ReviewCommentComposer
+        lineNumber={1}
+        side="additions"
+        value="draft!"
+        onTextChange={handleTextChange}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('textbox')).toHaveValue('draft!')
+  })
+
   test('Enter confirms with trimmed text', async () => {
     const user = userEvent.setup()
     const handleConfirm = vi.fn()

--- a/src/features/diff/components/ReviewCommentComposer.tsx
+++ b/src/features/diff/components/ReviewCommentComposer.tsx
@@ -7,6 +7,8 @@ interface ReviewCommentComposerProps {
   /** Which side of the diff the line lives on (additions => R, deletions => L). */
   side: AnnotationSide
   initialText?: string
+  value?: string
+  onTextChange?: (text: string) => void
   onConfirm: (text: string) => void
   onCancel: () => void
 }
@@ -19,11 +21,22 @@ export const ReviewCommentComposer = ({
   lineNumber,
   side,
   initialText = '',
+  value = undefined,
+  onTextChange = undefined,
   onConfirm,
   onCancel,
 }: ReviewCommentComposerProps): ReactElement => {
-  const [text, setText] = useState(initialText)
+  const [uncontrolledText, setUncontrolledText] = useState(initialText)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const text = value ?? uncontrolledText
+
+  const updateText = (next: string): void => {
+    if (value === undefined) {
+      setUncontrolledText(next)
+    }
+
+    onTextChange?.(next)
+  }
 
   useEffect((): void => {
     const node = textareaRef.current
@@ -67,7 +80,7 @@ export const ReviewCommentComposer = ({
       <textarea
         ref={textareaRef}
         value={text}
-        onChange={(e): void => setText(e.target.value)}
+        onChange={(e): void => updateText(e.target.value)}
         onKeyDown={(e): void => {
           if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault()

--- a/src/features/diff/components/toolbar/PriorityPlus.test.tsx
+++ b/src/features/diff/components/toolbar/PriorityPlus.test.tsx
@@ -313,6 +313,47 @@ describe('PriorityPlus', () => {
     expect(wrapperFor('item-0').className).not.toContain('hidden')
   })
 
+  test('restores overflowed items when the toolbar expands', () => {
+    render(<PriorityPlus maxRows={1}>{renderItems(4)}</PriorityPlus>)
+
+    const root = rootContainer('item-0')
+
+    stubLayout(
+      root,
+      [
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 0, offsetWidth: 60 },
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 72, offsetWidth: 60 },
+        { offsetTop: 30, offsetHeight: 24, offsetLeft: 0, offsetWidth: 60 },
+        { offsetTop: 30, offsetHeight: 24, offsetLeft: 72, offsetWidth: 60 },
+      ],
+      180
+    )
+    fireResize()
+
+    expect(
+      screen.getByRole('button', { name: /more controls/i })
+    ).toHaveAttribute('aria-label', 'Show 2 more controls')
+    expect(wrapperFor('item-2').className).toContain('hidden')
+
+    stubLayout(
+      root,
+      [
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 0, offsetWidth: 60 },
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 72, offsetWidth: 60 },
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 144, offsetWidth: 60 },
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 216, offsetWidth: 60 },
+      ],
+      420
+    )
+    fireResize()
+
+    expect(
+      screen.queryByRole('button', { name: /more controls/i })
+    ).not.toBeInTheDocument()
+    expect(wrapperFor('item-2').className).not.toContain('hidden')
+    expect(wrapperFor('item-3').className).not.toContain('hidden')
+  })
+
   test('reserves chip space — pulls cutoff back when the chip will not fit on the last allowed row', () => {
     render(<PriorityPlus maxRows={1}>{renderItems(4)}</PriorityPlus>)
 

--- a/src/features/workspace/components/DockPanel.test.tsx
+++ b/src/features/workspace/components/DockPanel.test.tsx
@@ -7,7 +7,13 @@ import {
 } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
-import { createRef, forwardRef, useRef, type ReactElement } from 'react'
+import {
+  createRef,
+  forwardRef,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react'
 import DockPanel, { type DockPanelHandle } from './DockPanel'
 import * as useCodeMirrorModule from '../../editor/hooks/useCodeMirror'
 import * as useVimModeModule from '../../editor/hooks/useVimMode'
@@ -16,7 +22,7 @@ import * as useGitStatusModule from '../../diff/hooks/useGitStatus'
 import * as useFileDiffModule from '../../diff/hooks/useFileDiff'
 import { useFeedbackBatch } from '../../diff/hooks/useFeedbackBatch'
 import type { UseFileDiffReturn } from '../../diff/hooks/useFileDiff'
-import type { ChangedFile } from '../../diff/types'
+import type { ChangedFile, SelectedDiffFile } from '../../diff/types'
 import type { FeedbackDispatchTarget } from '../../diff/services/activePanePicker'
 import { javascript } from '@codemirror/lang-javascript'
 
@@ -184,6 +190,72 @@ const SharedFeedbackDockHarness = ({
       feedbackBatch={feedbackBatch}
       feedbackRepoRootRef={feedbackRepoRootRef}
       feedbackDispatch={feedbackDispatch}
+    />
+  )
+}
+
+const firstChangedFile: ChangedFile = {
+  path: 'src/first.ts',
+  status: 'modified',
+  staged: false,
+}
+
+const secondChangedFile: ChangedFile = {
+  path: 'src/second.ts',
+  status: 'modified',
+  staged: false,
+}
+
+const SelectedDiffLifecycleHarness = ({
+  open,
+}: {
+  open: boolean
+}): ReactElement => {
+  const isResizing = false
+
+  const [selectedDiffFile, setSelectedDiffFile] =
+    useState<SelectedDiffFile | null>({
+      path: secondChangedFile.path,
+      staged: secondChangedFile.staged,
+      cwd: '/repo',
+    })
+
+  if (!open) {
+    return <div data-testid="dock-closed" />
+  }
+
+  return (
+    <DockPanel
+      position="bottom"
+      tab="diff"
+      onTabChange={vi.fn()}
+      onPositionChange={vi.fn()}
+      onClose={vi.fn()}
+      verticalSize={400}
+      onVerticalResizeMouseDown={vi.fn()}
+      isVerticalResizing={isResizing}
+      onVerticalSizeAdjust={vi.fn()}
+      verticalPixelMin={40}
+      verticalPixelMax={640}
+      horizontalSize={360}
+      onHorizontalResizeMouseDown={vi.fn()}
+      isHorizontalResizing={isResizing}
+      onHorizontalSizeAdjust={vi.fn()}
+      horizontalPixelMin={40}
+      horizontalPixelMax={640}
+      selectedFilePath={null}
+      content=""
+      cwd="/repo"
+      gitStatus={{
+        files: [firstChangedFile, secondChangedFile],
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      }}
+      selectedDiffFile={selectedDiffFile}
+      onSelectedDiffFileChange={setSelectedDiffFile}
     />
   )
 }
@@ -871,6 +943,39 @@ describe('DockPanel', () => {
     })
 
     expect(screen.getByTestId('diff-panel')).toBeInTheDocument()
+  })
+
+  test('preserves selected diff file when the dock closes and reopens', () => {
+    const useFileDiffSpy = vi.mocked(useFileDiffModule.useFileDiff)
+    const { rerender } = render(<SelectedDiffLifecycleHarness open />)
+
+    expect(useFileDiffSpy).toHaveBeenLastCalledWith(
+      'src/second.ts',
+      false,
+      '/repo',
+      false
+    )
+
+    const closed = false
+
+    rerender(<SelectedDiffLifecycleHarness open={closed} />)
+    expect(screen.getByTestId('dock-closed')).toBeInTheDocument()
+
+    rerender(<SelectedDiffLifecycleHarness open />)
+
+    expect(useFileDiffSpy).toHaveBeenLastCalledWith(
+      'src/second.ts',
+      false,
+      '/repo',
+      false
+    )
+
+    const selectedButton = screen
+      .getAllByText('second.ts')
+      // eslint-disable-next-line testing-library/no-node-access -- find selected file-list row
+      .map((label) => label.closest('button'))
+      .find((button): button is HTMLButtonElement => button !== null)
+    expect(selectedButton).toHaveClass('bg-surface-container-highest/40')
   })
 
   test('forwards parent-provided gitStatus to DiffPanelContent on the unselected-file render branch', () => {


### PR DESCRIPTION
## Summary
- Preserve in-progress diff review composer text across same-file diff refreshes and annotation-slot remounts.
- Keep recoverable draft text visible when refreshed hunk data removes the target line.
- Preserve parent-owned selected diff file across dock close/reopen, while keeping deterministic fallback when the selected file is gone.
- Add a PriorityPlus regression for expanding toolbar width so overflowed controls return.

## Verification
- `npm run test -- src/features/diff/components/ReviewCommentComposer.test.tsx src/features/diff/components/DiffPanelContent.test.tsx src/features/diff/components/toolbar/PriorityPlus.test.tsx src/features/workspace/components/DockPanel.test.tsx`
- `npm run type-check`
- `npm run lint`
- `git diff --check origin/main..HEAD`
- `npm run test`
- `npm run build`
- `codex exec --sandbox read-only review --base origin/main --output-last-message /tmp/vimeflow-vim11-codex-review-post-rebase.txt`

Closes VIM-11