### PR TITLE
feat(agent-status): surface per-pane shell + refine agent status card (VIM-66)

### DIFF
--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -1,6 +1,6 @@
 //! PTY operation helpers consumed by the runtime-neutral backend state.
 
-use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -82,6 +82,14 @@ fn locale_env_plan(
     }
 }
 
+fn system_shell() -> String {
+    if cfg!(target_os = "windows") {
+        "powershell.exe".to_string()
+    } else {
+        std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
+    }
+}
+
 /// Spawn a new PTY session with a shell
 pub(crate) async fn spawn_pty_inner(
     state: PtyState,
@@ -104,11 +112,7 @@ pub(crate) async fn spawn_pty_inner(
 
     // Determine shell path — ignore user-supplied shell for security;
     // only allow the system default shell to prevent arbitrary binary execution.
-    let shell = if cfg!(target_os = "windows") {
-        "powershell.exe".to_string()
-    } else {
-        std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
-    };
+    let shell = system_shell();
 
     if request.shell.is_some() {
         log::warn!(
@@ -366,7 +370,9 @@ pub(crate) async fn spawn_pty_inner(
         writer,
         child,
         cwd: cwd.to_string_lossy().to_string(),
-        shim_dir: bridge_files.as_ref().map(|f| f.shim_dir_path.to_string_lossy().to_string()),
+        shim_dir: bridge_files
+            .as_ref()
+            .map(|f| f.shim_dir_path.to_string_lossy().to_string()),
         generation,
         ring,
         cancelled,
@@ -461,6 +467,7 @@ pub(crate) async fn spawn_pty_inner(
         id: request.session_id,
         pid,
         cwd: cwd.to_string_lossy().to_string(),
+        shell,
     })
 }
 
@@ -545,7 +552,10 @@ pub(crate) fn kill_pty_inner(
     // Clean up bridge files and shim directory for the session.
     if let Some(session) = removed {
         let cwd = std::path::Path::new(&session.cwd);
-        let bridge_dir = cwd.join(".vimeflow").join("sessions").join(&request.session_id);
+        let bridge_dir = cwd
+            .join(".vimeflow")
+            .join("sessions")
+            .join(&request.session_id);
         let _ = super::bridge::cleanup_bridge_files(
             &bridge_dir.to_string_lossy(),
             session.shim_dir.as_deref(),
@@ -640,6 +650,7 @@ pub(crate) fn list_sessions_inner(
         session_infos.push(SessionInfo {
             id: id.clone(),
             cwd: cached.cwd,
+            shell: Some(system_shell()),
             status,
             activity_panel_collapsed: cached.activity_panel_collapsed,
         });
@@ -1514,7 +1525,7 @@ mod tests {
 
     fn make_failing_kill_session() -> crate::terminal::state::ManagedSession {
         use crate::terminal::state::{ManagedSession, RingBuffer};
-        use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+        use portable_pty::{CommandBuilder, PtySize, native_pty_system};
         let pty_system = native_pty_system();
         let pty_pair = pty_system
             .openpty(PtySize {

--- a/crates/backend/src/terminal/types.rs
+++ b/crates/backend/src/terminal/types.rs
@@ -18,6 +18,8 @@ pub struct PtySession {
     pub pid: u32,
     /// Current working directory
     pub cwd: String,
+    /// Resolved system shell path used for this PTY.
+    pub shell: String,
 }
 
 /// Request payload for spawning a new PTY session
@@ -146,6 +148,8 @@ pub enum SessionStatus {
 pub struct SessionInfo {
     pub id: String,
     pub cwd: String,
+    #[cfg_attr(test, ts(optional))]
+    pub shell: Option<String>,
     pub status: SessionStatus,
     #[cfg_attr(test, ts(optional))]
     #[cfg_attr(test, ts(type = "boolean | null"))]

--- a/src/bindings/PtySession.ts
+++ b/src/bindings/PtySession.ts
@@ -16,4 +16,8 @@ export type PtySession = {
    * Current working directory
    */
   cwd: string
+  /**
+   * Resolved system shell path used for this PTY.
+   */
+  shell: string
 }

--- a/src/bindings/SessionInfo.ts
+++ b/src/bindings/SessionInfo.ts
@@ -7,6 +7,7 @@ import type { SessionStatus } from './SessionStatus'
 export type SessionInfo = {
   id: string
   cwd: string
+  shell?: string
   status: SessionStatus
   activityPanelCollapsed?: boolean | null
 }

--- a/src/features/sessions/hooks/useSessionManager.test.ts
+++ b/src/features/sessions/hooks/useSessionManager.test.ts
@@ -2037,10 +2037,20 @@ describe('useSessionManager', () => {
 
     // Suspend spawn so we can race a tab switch in.
     let resolveSpawn:
-      | ((v: { sessionId: string; pid: number; cwd: string }) => void)
+      | ((v: {
+          sessionId: string
+          pid: number
+          cwd: string
+          shell: string
+        }) => void)
       | null = null
     service.spawn = vi.fn(
-      (): Promise<{ sessionId: string; pid: number; cwd: string }> =>
+      (): Promise<{
+        sessionId: string
+        pid: number
+        cwd: string
+        shell: string
+      }> =>
         new Promise((resolve) => {
           resolveSpawn = resolve
         })
@@ -2065,7 +2075,12 @@ describe('useSessionManager', () => {
     // The fix reads activeSessionIdRef.current ('alive') so wasActive=false,
     // and the swap commits without promoting 'fresh'.
     act(() => {
-      resolveSpawn?.({ sessionId: 'fresh', pid: 9000, cwd: '/tmp' })
+      resolveSpawn?.({
+        sessionId: 'fresh',
+        pid: 9000,
+        cwd: '/tmp',
+        shell: '/bin/zsh',
+      })
     })
 
     // Wait for the swap to commit.
@@ -2214,10 +2229,20 @@ describe('useSessionManager', () => {
     })
 
     let resolveSpawn:
-      | ((v: { sessionId: string; pid: number; cwd: string }) => void)
+      | ((v: {
+          sessionId: string
+          pid: number
+          cwd: string
+          shell: string
+        }) => void)
       | null = null
     service.spawn = vi.fn(
-      (): Promise<{ sessionId: string; pid: number; cwd: string }> =>
+      (): Promise<{
+        sessionId: string
+        pid: number
+        cwd: string
+        shell: string
+      }> =>
         new Promise((resolve) => {
           resolveSpawn = resolve
         })
@@ -2242,7 +2267,12 @@ describe('useSessionManager', () => {
 
     // Step 3: spawn now resolves with the orphan id.
     act(() => {
-      resolveSpawn?.({ sessionId: 'orphan-fresh', pid: 1234, cwd: '/tmp' })
+      resolveSpawn?.({
+        sessionId: 'orphan-fresh',
+        pid: 1234,
+        cwd: '/tmp',
+        shell: '/bin/zsh',
+      })
     })
 
     // Wait until the orphan-kill IPC has fired. Cast through the typed
@@ -4301,6 +4331,7 @@ describe('useSessionManager', () => {
             sessionId: `pty-${index}`,
             pid: 100 + index,
             cwd: resolvedCwds[index] ?? `/workspace-${index}`,
+            shell: '/bin/zsh',
           })
         }
       )

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -850,6 +850,7 @@ export const useSessionManager = (
                   id: 'p0',
                   ptyId: result.sessionId,
                   cwd: result.cwd,
+                  shell: result.shell,
                   agentType: 'generic',
                   status: 'running',
                   active: true,
@@ -1356,6 +1357,7 @@ export const useSessionManager = (
             id: nextFreePaneId(fresh.panes),
             ptyId: result.sessionId,
             cwd: result.cwd,
+            shell: result.shell,
             agentType: 'generic',
             status: 'running',
             active: true,
@@ -1602,7 +1604,12 @@ export const useSessionManager = (
         }
         const cachedCwd = oldPane.cwd
 
-        let result: { sessionId: string; pid: number; cwd: string }
+        let result: {
+          sessionId: string
+          pid: number
+          cwd: string
+          shell: string
+        }
         try {
           result = await service.spawn({
             cwd: cachedCwd,
@@ -1672,6 +1679,7 @@ export const useSessionManager = (
               ...oldPane,
               ptyId: result.sessionId,
               cwd: result.cwd,
+              shell: result.shell,
               status: 'running',
               agentType: 'generic',
               pid: result.pid,

--- a/src/features/sessions/types/index.ts
+++ b/src/features/sessions/types/index.ts
@@ -37,6 +37,9 @@ export interface Pane {
   /** Per-pane working directory. */
   cwd: string
 
+  /** Resolved shell path for shell panes, e.g. `/bin/zsh`. */
+  shell?: string
+
   /** Detected agent CLI for this pane. */
   agentType: 'claude-code' | 'codex' | 'aider' | 'generic'
 

--- a/src/features/sessions/utils/sessionFromInfo.test.ts
+++ b/src/features/sessions/utils/sessionFromInfo.test.ts
@@ -6,6 +6,7 @@ import { writeActivityPanelCollapsed } from './activityPanelCollapsedStore'
 const aliveInfo = (id: string, cwd: string): SessionInfo => ({
   id,
   cwd,
+  shell: '/bin/zsh',
   status: { kind: 'Alive', pid: 1234, replay_data: '', replay_end_offset: 0n },
 })
 
@@ -66,6 +67,7 @@ describe('sessionFromInfo (pre-pane shape)', () => {
     expect(session.panes[0].status).toBe('running')
     expect(session.panes[0].restoreData).toBeDefined()
     expect(session.panes[0].restoreData?.pid).toBe(1234)
+    expect(session.panes[0].shell).toBe('/bin/zsh')
     expect(session.layout).toBe('single')
   })
 

--- a/src/features/sessions/utils/sessionFromInfo.ts
+++ b/src/features/sessions/utils/sessionFromInfo.ts
@@ -18,6 +18,7 @@ export const sessionFromInfo = (info: SessionInfo, index: number): Session => {
     id: 'p0',
     ptyId: info.id,
     cwd: info.cwd,
+    shell: info.shell,
     agentType: 'generic',
     status,
     active: true,

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -136,7 +136,12 @@ const makeSession = (
 
 const makeMockService = (): ITerminalService => ({
   spawn: vi.fn(() =>
-    Promise.resolve({ sessionId: 'mock', pid: 0, cwd: '/tmp' })
+    Promise.resolve({
+      sessionId: 'mock',
+      pid: 0,
+      cwd: '/tmp',
+      shell: '/bin/zsh',
+    })
   ),
   write: vi.fn(() => Promise.resolve(undefined)),
   resize: vi.fn(() => Promise.resolve(undefined)),

--- a/src/features/terminal/services/desktopTerminalService.test.ts
+++ b/src/features/terminal/services/desktopTerminalService.test.ts
@@ -63,6 +63,7 @@ describe('DesktopTerminalService', () => {
         id: 'test-session-id',
         pid: 12345,
         cwd: '/home/user',
+        shell: '/bin/zsh',
       })
 
       const result = await service.spawn({
@@ -80,6 +81,7 @@ describe('DesktopTerminalService', () => {
       })
       expect(result.sessionId).toBe('test-session-id')
       expect(result.pid).toBe(12345)
+      expect(result.shell).toBe('/bin/zsh')
     })
 
     test('generates a UUID sessionId in the request', async () => {

--- a/src/features/terminal/services/desktopTerminalService.ts
+++ b/src/features/terminal/services/desktopTerminalService.ts
@@ -175,6 +175,7 @@ export class DesktopTerminalService implements ITerminalService {
       sessionId: response.id,
       pid: response.pid,
       cwd: response.cwd,
+      shell: response.shell,
     }
   }
 

--- a/src/features/terminal/services/terminalService.test.ts
+++ b/src/features/terminal/services/terminalService.test.ts
@@ -17,6 +17,7 @@ describe('MockTerminalService', () => {
 
       expect(result.sessionId).toMatch(/^mock-session-\d+$/)
       expect(result.pid).toBeGreaterThan(0)
+      expect(result.shell).toBe('/bin/bash')
     })
 
     test('assigns unique session IDs', async () => {

--- a/src/features/terminal/services/terminalService.ts
+++ b/src/features/terminal/services/terminalService.ts
@@ -147,7 +147,12 @@ export class MockTerminalService implements ITerminalService {
     // Mock returns the cwd that was requested. Real Desktop side resolves
     // '~' to the absolute home dir; we keep the mock pass-through so test
     // expectations stay deterministic without depending on the host.
-    return Promise.resolve({ sessionId, pid, cwd: params.cwd })
+    return Promise.resolve({
+      sessionId,
+      pid,
+      cwd: params.cwd,
+      shell: params.shell ?? '/bin/bash',
+    })
   }
 
   write(params: PTYWriteParams): Promise<void> {

--- a/src/features/terminal/types/index.test.ts
+++ b/src/features/terminal/types/index.test.ts
@@ -111,11 +111,13 @@ describe('Terminal Types', () => {
         sessionId: 'session-1',
         pid: 12345,
         cwd: '/home/user',
+        shell: '/bin/bash',
       }
 
       expect(result.sessionId).toBe('session-1')
       expect(result.pid).toBe(12345)
       expect(result.cwd).toBe('/home/user')
+      expect(result.shell).toBe('/bin/bash')
     })
 
     test('PTYWriteParams structure', () => {

--- a/src/features/terminal/types/index.ts
+++ b/src/features/terminal/types/index.ts
@@ -88,6 +88,8 @@ export interface PTYSpawnResult {
   pid: number
   /** Resolved working directory (absolute path from Rust) — Rust always returns this */
   cwd: string
+  /** Resolved shell path used for this PTY. */
+  shell: string
 }
 
 /**

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -982,8 +982,8 @@ export const WorkspaceView = (): ReactElement => {
     : null
 
   // Fused AgentStatusCard props, derived from the same live signals the status
-  // bar uses (VIM-66). Each metric is guarded inside the card, so an idle
-  // session renders gracefully with an empty metric row.
+  // bar uses (VIM-66). The compact card keeps only the turn count in the
+  // header and shows usage bars when live rate-limit data is present.
   // Completed/errored come from the pane lifecycle and must NOT be masked by
   // the agent going inactive after it finishes; `running` requires a live
   // agent; everything else (no session, paused, inactive) reads as idle.
@@ -1000,7 +1000,7 @@ export const WorkspaceView = (): ReactElement => {
           : 'idle'
 
   // A pure shell pane has no detected agent (and therefore no model / usage);
-  // the card renders its fixed-height "SHELL" placeholder in that case so the
+  // the card renders its fixed-height shell placeholder in that case so the
   // session list below never reflows when switching panes.
   const sidebarCardIsShell =
     !agentStatus.agentType || !agentStatus.isActive || agentStatus.agentExited
@@ -1013,11 +1013,7 @@ export const WorkspaceView = (): ReactElement => {
     agentStatus.modelId ??
     activeSession?.name ??
     'No session'
-  const sidebarCardElapsed = statusBarSession?.startedAgo ?? null
   const sidebarCardTurns = statusBarSession?.turns ?? null
-
-  const sidebarCardContextPct =
-    statusBarContextPct !== null ? Math.round(statusBarContextPct) : null
 
   const sidebarCardFiveHourPct = agentStatus.rateLimits
     ? Math.round(agentStatus.rateLimits.fiveHour.usedPercentage)
@@ -1505,11 +1501,10 @@ export const WorkspaceView = (): ReactElement => {
                 title={sidebarCardTitle}
                 state={sidebarCardState}
                 isShell={sidebarCardIsShell}
-                elapsed={sidebarCardElapsed}
                 turns={sidebarCardTurns}
-                contextPct={sidebarCardContextPct}
                 fiveHourPct={sidebarCardFiveHourPct}
                 weekPct={sidebarCardWeekPct}
+                shellName={activePtyBackedPane?.shell ?? null}
               />
             }
             content={

--- a/src/features/workspace/components/AgentStatusCard.test.tsx
+++ b/src/features/workspace/components/AgentStatusCard.test.tsx
@@ -1,4 +1,4 @@
-// cspell:ignore incard
+// cspell:ignore cheatsheet incard powershell pwsh zsh
 import { render, screen } from '@testing-library/react'
 import { describe, test, expect, vi } from 'vitest'
 import { AgentStatusCard } from './AgentStatusCard'
@@ -43,17 +43,45 @@ describe('AgentStatusCard', () => {
     ).not.toBeInTheDocument()
   })
 
-  test('renders the SHELL placeholder for a shell pane', () => {
-    render(<AgentStatusCard title="ignored-model" state="idle" isShell />)
+  test('renders a shell placeholder without a SHELL title', () => {
+    render(
+      <AgentStatusCard
+        title="ignored-model"
+        state="idle"
+        isShell
+        shellName="/bin/zsh"
+      />
+    )
 
-    expect(screen.getByText('SHELL')).toBeInTheDocument()
+    expect(screen.queryByText('SHELL')).not.toBeInTheDocument()
     expect(screen.queryByText('ignored-model')).not.toBeInTheDocument()
     expect(
       screen.getByTestId('agent-status-card-shell-body')
     ).toBeInTheDocument()
     expect(screen.getByText('No active agent')).toBeInTheDocument()
-    expect(screen.getByText('Idle · shell only')).toBeInTheDocument()
+    expect(screen.getByText('Idle · zsh shell')).toBeInTheDocument()
     expect(screen.getByText('terminal')).toBeInTheDocument()
+  })
+
+  test('normalizes shell executable names for shell status and cheatsheet link', () => {
+    render(
+      <AgentStatusCard
+        title="ignored-model"
+        state="idle"
+        isShell
+        shellName="C:\\Program Files\\PowerShell\\7\\pwsh.exe"
+      />
+    )
+
+    expect(screen.getByText('Idle · pwsh shell')).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: /pwsh cheatsheet/u })
+    expect(link).toHaveAttribute(
+      'href',
+      'https://www.google.com/search?q=pwsh%20commands%20cheatsheet'
+    )
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
   test('hides agent metrics and usage bars on a shell pane', () => {
@@ -75,7 +103,7 @@ describe('AgentStatusCard', () => {
     expect(screen.queryByText('Weekly Usage')).not.toBeInTheDocument()
   })
 
-  test('renders the session metrics when provided', () => {
+  test('renders only the turn count from the old metrics row', () => {
     render(
       <AgentStatusCard
         title="m"
@@ -86,12 +114,12 @@ describe('AgentStatusCard', () => {
       />
     )
 
-    expect(screen.getByText('schedule')).toBeInTheDocument()
-    expect(screen.getByText('2m')).toBeInTheDocument()
+    expect(screen.queryByText('schedule')).not.toBeInTheDocument()
+    expect(screen.queryByText('2m')).not.toBeInTheDocument()
+    expect(screen.queryByText('data_usage')).not.toBeInTheDocument()
+    expect(screen.queryByText('64%')).not.toBeInTheDocument()
     expect(screen.getByText('forum')).toBeInTheDocument()
-    expect(screen.getByText('12')).toBeInTheDocument()
-    expect(screen.getByText('data_usage')).toBeInTheDocument()
-    expect(screen.getByText('64%')).toBeInTheDocument()
+    expect(screen.getByText('12 turns')).toBeInTheDocument()
   })
 
   test('renders 5-hour and weekly usage bars when provided', () => {
@@ -124,7 +152,7 @@ describe('AgentStatusCard', () => {
     expect(screen.queryByText('Weekly Usage')).not.toBeInTheDocument()
   })
 
-  test('guards a zero turn count from the metric row', () => {
+  test('renders zero turns in the header pill', () => {
     render(
       <AgentStatusCard
         title="m"
@@ -135,9 +163,32 @@ describe('AgentStatusCard', () => {
       />
     )
 
-    expect(screen.queryByText('forum')).not.toBeInTheDocument()
-    expect(screen.queryByText('0')).not.toBeInTheDocument()
-    expect(screen.getByText('schedule')).toBeInTheDocument()
-    expect(screen.getByText('data_usage')).toBeInTheDocument()
+    expect(screen.getByText('forum')).toBeInTheDocument()
+    expect(screen.getByText('0 turns')).toBeInTheDocument()
+    expect(screen.queryByText('schedule')).not.toBeInTheDocument()
+    expect(screen.queryByText('data_usage')).not.toBeInTheDocument()
+  })
+
+  test('keeps the outer card height stable across agent and shell states', () => {
+    const { rerender } = render(
+      <AgentStatusCard
+        title="m"
+        state="running"
+        turns={3}
+        fiveHourPct={12}
+        weekPct={34}
+      />
+    )
+
+    const card = screen.getByTestId('sidebar-agent-status-card')
+    expect(card).toHaveStyle({ height: '125px' })
+
+    rerender(
+      <AgentStatusCard title="ignored" state="idle" isShell shellName="bash" />
+    )
+
+    expect(screen.getByTestId('sidebar-agent-status-card')).toHaveStyle({
+      height: '125px',
+    })
   })
 })

--- a/src/features/workspace/components/AgentStatusCard.tsx
+++ b/src/features/workspace/components/AgentStatusCard.tsx
@@ -1,15 +1,13 @@
-// cspell:ignore incard
+// cspell:ignore cheatsheet incard powershell pwsh tcsh xonsh zsh
 import type { ReactElement } from 'react'
 import { RateLimitBar } from '../../agent-status/components/RateLimitBar'
 
 // Fused agent-status card (VIM-66 — AGENT-STATUS-CARD-HANDOFF + SHELL-CARD-KIT).
-// ONE fixed height in every state: the below-header body is locked to
-// CARD_BODY_H, so switching the active pane between an agent and a pure shell
-// never changes the card height (and never reflows the session list below it).
-// Agent panes fill the body with model metrics + rate-limit bars; a pure shell
-// fills the same box with a placeholder tile. Borderless elevated surface with
-// a faint state-tinted corner wash. The explicit running dot/label was removed
-// by request.
+// ONE fixed card height in every state: switching the active pane between an
+// agent and a pure shell never reflows the session list below it. Agent panes
+// keep only the turn count in the header and fill the body with usage bars; a
+// shell pane omits the header entirely and uses the same card height for its
+// two-zone empty state.
 
 export type AgentCardState =
   | 'running'
@@ -19,15 +17,15 @@ export type AgentCardState =
   | 'idle'
 
 export interface AgentStatusCardProps {
-  /** Agent model name shown as the title; ignored when `isShell` (shows "SHELL"). */
+  /** Agent model name shown as the title; ignored when `isShell`. */
   title: string
-  /** Drives the ambient corner wash. */
+  /** Retained for API stability; visual wash was removed from the compact card. */
   state: AgentCardState
   /** True when the active pane is a pure shell (no agent / model / usage). */
   isShell?: boolean
-  /** Elapsed-time string (e.g. "8m"); omitted when falsy. */
+  /** Retained for API stability; compact card shows turn count only. */
   elapsed?: string | null
-  /** Turn count; omitted when 0/absent. */
+  /** Turn count rendered in the compact header pill; absent values render as 0. */
   turns?: number | null
   /** Context-window usage percent; omitted when null. */
   contextPct?: number | null
@@ -35,80 +33,135 @@ export interface AgentStatusCardProps {
   fiveHourPct?: number | null
   /** 7-day (weekly) rate-limit usage percent; omitted when null. */
   weekPct?: number | null
+  /** Resolved shell path/name for pure shell panes, e.g. `/bin/zsh`. */
+  shellName?: string | null
 }
 
-// Fixed below-header body height — the whole point of the SHELL kit. Agent
-// content and the shell placeholder both render inside this exact height so the
-// card never changes height and nothing below it reflows.
-const CARD_BODY_H = 92
+// 125 = 12 (top pad) + 24 (header: h-6 pill / leading-6 title) + 9 (gap)
+// + 66 (CARD_BODY_H) + 14 (bottom pad). Still ONE fixed height across agent
+// and shell states, so switching panes never reflows the session list.
+const CARD_H = 125
+const CARD_BODY_H = 66
 
-const STATE_WASH: Record<AgentCardState, string> = {
-  running: 'var(--wash-running)',
-  awaiting: 'var(--wash-awaiting)',
-  completed: 'var(--wash-completed)',
-  errored: 'var(--wash-errored)',
-  idle: 'var(--wash-idle)',
+const KNOWN_SHELLS = new Set([
+  'bash',
+  'zsh',
+  'fish',
+  'sh',
+  'dash',
+  'ksh',
+  'csh',
+  'tcsh',
+  'nu',
+  'xonsh',
+  'powershell',
+  'pwsh',
+  'cmd',
+])
+
+const normalizeShellName = (shellName: string | null | undefined): string => {
+  if (!shellName) {
+    return 'shell'
+  }
+
+  const parts = shellName.replace(/\\/gu, '/').split('/')
+  const basename = parts[parts.length - 1]?.trim().toLowerCase() ?? ''
+  const stripped = basename.replace(/^-+/, '').replace(/\.exe$/, '')
+
+  if (!stripped) {
+    return 'shell'
+  }
+
+  if (stripped === 'powershell') {
+    return 'powershell'
+  }
+
+  if (KNOWN_SHELLS.has(stripped)) {
+    return stripped
+  }
+
+  return stripped
 }
 
-interface MetricCell {
-  icon: string
-  value: string
-  title: string
-}
+const shellCheatsheetUrl = (shellName: string): string =>
+  `https://www.google.com/search?q=${encodeURIComponent(
+    `${shellName} commands cheatsheet`
+  )}`
 
-const Metric = ({
-  cell,
-  last,
-}: {
-  cell: MetricCell
-  last: boolean
-}): ReactElement => (
+const TurnPill = ({ turns }: { turns: number | null }): ReactElement => (
   <span
-    style={{ display: 'inline-flex', alignItems: 'center' }}
-    title={cell.title}
+    className="inline-flex h-6 max-w-[86px] shrink-0 items-center justify-center whitespace-nowrap rounded-full border border-outline-variant/40 bg-surface-container-lowest/35 px-[7px] font-mono text-[10px] font-bold leading-none text-on-surface-variant"
+    title={`${turns ?? 0} turns`}
   >
-    <span
-      className="material-symbols-outlined text-syn-comment"
-      aria-hidden="true"
-      style={{ fontSize: 12, lineHeight: 1 }}
-    >
-      {cell.icon}
+    {/* Both the Material icon and the descender-less mono label ride ~1px high
+        in their own line-boxes. Wrap them in one flex row so items-center keeps
+        them aligned to each other, then nudge the whole row down ~1px to center
+        the pair in the pill. Relative offset → no layout/height change. */}
+    <span className="relative top-px inline-flex items-center gap-[5px]">
+      <span
+        className="material-symbols-outlined text-syn-comment"
+        aria-hidden="true"
+        style={{ fontSize: 12, lineHeight: 1 }}
+      >
+        forum
+      </span>
+      <span>{turns ?? 0} turns</span>
     </span>
-    <span className="ml-1 text-on-surface-variant">{cell.value}</span>
-    {!last && <span className="mx-[9px] text-[#3a3450]">·</span>}
   </span>
 )
 
-// Pure-shell placeholder. Fills the exact CARD_BODY_H so the card height
-// matches an agent pane's.
-const ShellBody = (): ReactElement => (
+const ShellBody = ({ shellName }: { shellName: string }): ReactElement => (
   <div
     data-testid="agent-status-card-shell-body"
-    className="mt-[11px] flex items-center gap-[11px] rounded-[9px] border border-dashed border-outline-variant/50 bg-surface-container-lowest/28 py-0 px-[13px]"
-    style={{ height: CARD_BODY_H }}
+    className="flex h-full flex-col justify-between rounded-[9px] border border-dashed border-outline-variant/50 bg-surface-container-lowest/30 py-2 pr-2 pl-[11px]"
   >
-    <div
-      className="grid shrink-0 place-items-center rounded-lg bg-syn-comment/14"
-      style={{ width: 34, height: 34 }}
-    >
-      <span
-        className="material-symbols-outlined text-[18px] text-[#9b93ab]"
-        aria-hidden="true"
+    <div className="flex min-w-0 items-center gap-2.5">
+      <div
+        className="grid shrink-0 place-items-center rounded-lg bg-syn-comment/14"
+        style={{ width: 30, height: 30 }}
       >
-        terminal
-      </span>
-    </div>
-    <div className="min-w-0">
-      <div className="truncate font-display text-[13px] font-semibold text-on-surface-variant">
-        No active agent
-      </div>
-      <div className="mt-1 flex items-center gap-1.5">
-        <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full border-[1.5px] border-solid border-outline-variant" />
-        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-on-surface-muted">
-          Idle · shell only
+        <span
+          className="material-symbols-outlined text-[17px] text-[#9b93ab]"
+          aria-hidden="true"
+        >
+          terminal
         </span>
       </div>
+      <div className="min-w-0">
+        <div className="truncate font-display text-[12.5px] font-semibold text-on-surface-variant">
+          No active agent
+        </div>
+        <div className="mt-1 flex items-center gap-1.5">
+          <span className="inline-block h-[7px] w-[7px] shrink-0 rounded-full border-[1.5px] border-solid border-outline-variant" />
+          <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-on-surface-muted">
+            Idle · {shellName} shell
+          </span>
+        </div>
+      </div>
     </div>
+
+    <a
+      href={shellCheatsheetUrl(shellName)}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={`${shellName} command cheatsheet`}
+      className="flex w-full items-center gap-[7px] rounded-[7px] bg-surface-container-lowest/45 py-[5px] pr-[7px] pl-[9px] font-mono text-[10.5px] leading-none text-[#9b93ab] no-underline transition-colors hover:bg-primary/10 hover:text-primary"
+    >
+      <span
+        className="material-symbols-outlined text-[15px]"
+        aria-hidden="true"
+      >
+        menu_book
+      </span>
+      <span>{shellName} cheatsheet</span>
+      <span className="flex-1" />
+      <span
+        className="material-symbols-outlined text-[13px] opacity-[0.55]"
+        aria-hidden="true"
+      >
+        open_in_new
+      </span>
+    </a>
   </div>
 )
 
@@ -121,26 +174,13 @@ export const AgentStatusCard = ({
   contextPct = null,
   fiveHourPct = null,
   weekPct = null,
+  shellName = null,
 }: AgentStatusCardProps): ReactElement => {
-  // Guard each metric so a metric-less agent pane collapses gracefully (the
-  // fixed-height body keeps the card the same size regardless).
-  const metrics: MetricCell[] = []
-  if (elapsed) {
-    metrics.push({ icon: 'schedule', value: elapsed, title: 'Elapsed' })
-  }
-  if (turns && turns > 0) {
-    metrics.push({ icon: 'forum', value: String(turns), title: 'Turns' })
-  }
-  if (contextPct !== null) {
-    metrics.push({
-      icon: 'data_usage',
-      value: `${contextPct}%`,
-      title: 'Context window',
-    })
-  }
-
   const hasUsage = fiveHourPct !== null || weekPct !== null
-  const wash = isShell ? STATE_WASH.idle : STATE_WASH[state]
+  const resolvedShellName = normalizeShellName(shellName)
+  void state
+  void elapsed
+  void contextPct
 
   return (
     <div
@@ -148,8 +188,9 @@ export const AgentStatusCard = ({
       style={{
         position: 'relative',
         borderRadius: 13,
-        padding: '13px 14px 14px',
-        background: `radial-gradient(120% 90% at 0% 0%, ${wash} 0%, rgba(34,34,52,0) 55%), rgba(33,33,51,0.55)`,
+        height: CARD_H,
+        padding: '12px 14px 14px',
+        background: 'rgba(33,33,51,0.55)',
         boxShadow:
           '0 5px 20px rgba(0,0,0,0.22), inset 0 1px 0 rgba(255,255,255,0.045)',
         overflow: 'hidden',
@@ -159,44 +200,41 @@ export const AgentStatusCard = ({
         cursor: 'default',
       }}
     >
-      <div className="min-w-0 truncate font-display text-sm font-semibold text-on-surface">
-        {isShell ? 'SHELL' : title}
-      </div>
-
       {isShell ? (
-        <ShellBody />
+        <ShellBody shellName={resolvedShellName} />
       ) : (
-        <div style={{ height: CARD_BODY_H, marginTop: 11 }}>
-          {metrics.length > 0 && (
-            <div className="flex flex-wrap items-center font-mono text-[10px] text-on-surface-muted">
-              {metrics.map((cell, index) => (
-                <Metric
-                  key={cell.icon}
-                  cell={cell}
-                  last={index === metrics.length - 1}
-                />
-              ))}
+        <>
+          <div className="flex min-h-6 items-center gap-2.5">
+            <div className="min-w-0 flex-1 truncate font-display text-[15px] font-semibold leading-6 text-on-surface">
+              {title}
             </div>
-          )}
-
-          {hasUsage && (
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 8,
-                marginTop: metrics.length > 0 ? 12 : 0,
-              }}
-            >
-              {fiveHourPct !== null && (
-                <RateLimitBar label="5-hour Session" percentage={fiveHourPct} />
-              )}
-              {weekPct !== null && (
-                <RateLimitBar label="Weekly Usage" percentage={weekPct} />
-              )}
-            </div>
-          )}
-        </div>
+            <TurnPill turns={turns} />
+          </div>
+          <div
+            className="mt-[9px] flex flex-col justify-center"
+            style={{ height: CARD_BODY_H }}
+          >
+            {hasUsage && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 9,
+                }}
+              >
+                {fiveHourPct !== null && (
+                  <RateLimitBar
+                    label="5-hour Session"
+                    percentage={fiveHourPct}
+                  />
+                )}
+                {weekPct !== null && (
+                  <RateLimitBar label="Weekly Usage" percentage={weekPct} />
+                )}
+              </div>
+            )}
+          </div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
Stacks on `feat/vim-66-sidebar`.

## What

- **Per-pane shell surfacing** — plumb the resolved shell path (e.g. `/bin/zsh`) from the Rust PTY through `SessionInfo` / `Pane` into the fused agent status card. A pure-shell pane now shows the shell name (`Idle · zsh shell`) plus a cheatsheet link.
- **Agent status card refinements** — turn-count pill, 5-hour / weekly usage bars, a taller pill with the icon and label centered to the same baseline, and a larger model-name title. All within one fixed **125px** card height so the session list never reflows when switching panes.

## Verification

- `npm run lint` ✅ · `npm run test` ✅ (240 files, 3184 passed / 3 skipped)
- Local `codex review --uncommitted`: clean apart from one **P2** noting that *untracked* handoff docs fail `format:check` — sidestepped by not committing them.

## Excluded from this PR

- Untracked design-doc dirs `docs/design/agent-card-compact-demo/` and `docs/design/shell-card-handoff/` were left out to keep the PR focused on code.
- A stray repo-root `shell-card-handoff/` (byte-identical duplicate of `docs/design/shell-card-handoff/`) was left on disk — recommend deleting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
