### PR TITLE
[codex] adopt macOS hidden titlebar

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -77,4 +77,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Status Indicator Display](patterns/status-indicator-display.md)     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                   | code-quality       | 7        | 5    | 2026-06-08   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md) | correctness        | 6        | 3    | 2026-06-08   |
-| [macOS Window Chrome](patterns/macos-window-chrome.md)               | cross-platform     | 4        | 0    | 2026-06-09   |
+| [macOS Window Chrome](patterns/macos-window-chrome.md)               | cross-platform     | 6        | 0    | 2026-06-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -77,3 +77,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Status Indicator Display](patterns/status-indicator-display.md)     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                   | code-quality       | 7        | 5    | 2026-06-08   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md) | correctness        | 6        | 3    | 2026-06-08   |
+| [macOS Window Chrome](patterns/macos-window-chrome.md)               | cross-platform     | 4        | 0    | 2026-06-09   |

--- a/docs/reviews/patterns/macos-window-chrome.md
+++ b/docs/reviews/patterns/macos-window-chrome.md
@@ -49,3 +49,19 @@ dimensions so the controls do not overlay adjacent UI columns.
 - **File:** `src/features/workspace/components/IconRail.tsx`
 - **Finding:** The `52` in `paddingTop: reserveWindowControls ? 52 : 10` encoded `trafficLightPosition.y (13) + button diameter (~28) + gap (~11)` from `electron/main.ts` with no comment or named constant.
 - **Fix:** Introduced `MACOS_TRAFFIC_LIGHT_RESERVE_PX = 52` with an inline comment explaining the derivation.
+
+### 5. IconRail.test.tsx missing conditional vf-app-drag-region assertions
+
+- **Source:** github-claude | PR #407 round 2 | 2026-06-09
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/components/IconRail.test.tsx`
+- **Finding:** The `reserveWindowControls` test only asserted `paddingTop: '52px'`; it did not check that `vf-app-drag-region` is present when the prop is true, nor that it is absent when false. A regression reverting the class to unconditional application would pass tests undetected.
+- **Fix:** Added `toHaveClass('vf-app-drag-region')` and `toHaveClass('w-[68px]')` assertions to the existing test, plus a mirroring no-reserve test asserting `not.toHaveClass('vf-app-drag-region')`.
+
+### 6. backgroundColor '#121221' undocumented in main-process options
+
+- **Source:** github-claude | PR #407 round 2 | 2026-06-09
+- **Severity:** LOW
+- **File:** `electron/main.ts`
+- **Finding:** `backgroundColor: '#121221'` in `macosWindowChromeOptions` mirrored the Tailwind `bg-background` token with no comment linking the two. A future design iteration updating the token would leave the native window flash color stale.
+- **Fix:** Added an inline comment documenting the relationship to the Tailwind token and warning to keep them in sync.

--- a/docs/reviews/patterns/macos-window-chrome.md
+++ b/docs/reviews/patterns/macos-window-chrome.md
@@ -1,0 +1,51 @@
+---
+id: macos-window-chrome
+category: cross-platform
+created: 2026-06-09
+last_updated: 2026-06-09
+ref_count: 0
+---
+
+# macOS Window Chrome
+
+## Summary
+
+When implementing Electron's hidden-titlebar chrome on macOS, renderer-side
+changes must stay gated to macOS just as strictly as main-process options.
+Unconditional `-webkit-app-region: drag` classes leak window-drag behavior to
+Windows and Linux, and native traffic-light geometry must be reserved in both
+dimensions so the controls do not overlay adjacent UI columns.
+
+## Findings
+
+### 1. vf-app-drag-region applied on all platforms, not just macOS
+
+- **Source:** github-claude | PR #407 round 1 | 2026-06-09
+- **Severity:** MEDIUM
+- **File:** `src/features/sessions/components/Tabs.tsx`, `src/features/workspace/components/IconRail.tsx`
+- **Finding:** Both components unconditionally added `vf-app-drag-region` to their root elements. Electron honors `-webkit-app-region: drag` on Windows and Linux even with `frame: true`, turning empty chrome areas into unintended window-drag handles.
+- **Fix:** Made the class conditional on `reserveWindowControls` (macOS-only) in both `Tabs` and `IconRail`, and passed the flag down from `WorkspaceView`.
+
+### 2. Reserve the full traffic-light width
+
+- **Source:** github-codex-connector | PR #407 round 1 | 2026-06-09
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/workspace/components/IconRail.tsx`
+- **Finding:** The 48px icon rail was narrower than the native traffic-light group placed at `x: 16` in `electron/main.ts`, so the yellow/green controls extended into the sidebar column.
+- **Fix:** Widened the rail to 68px (`w-[68px]`) when `reserveWindowControls` is true and updated the parent `gridTemplateColumns` in `WorkspaceView.tsx` to match.
+
+### 3. reserveWindowControls uses a redundant double platform check
+
+- **Source:** github-claude | PR #407 round 1 | 2026-06-09
+- **Severity:** LOW
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** `reserveWindowControls = preferModifier === 'meta' && isMacPlatform()` — both sub-expressions resolve via the exact same macOS detection, making the `&&` a logical no-op.
+- **Fix:** Simplified to `const reserveWindowControls = preferModifier === 'meta'` and removed the now-unused `isMacPlatform` helper.
+
+### 4. Magic number 52 in IconRail paddingTop is undocumented
+
+- **Source:** github-claude | PR #407 round 1 | 2026-06-09
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/IconRail.tsx`
+- **Finding:** The `52` in `paddingTop: reserveWindowControls ? 52 : 10` encoded `trafficLightPosition.y (13) + button diameter (~28) + gap (~11)` from `electron/main.ts` with no comment or named constant.
+- **Fix:** Introduced `MACOS_TRAFFIC_LIGHT_RESERVE_PX = 52` with an inline comment explaining the derivation.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -69,6 +69,15 @@ protocol.registerSchemesAsPrivileged([
 const BINARY_NAME =
   process.platform === 'win32' ? 'vimeflow-backend.exe' : 'vimeflow-backend'
 
+const macosWindowChromeOptions =
+  process.platform === 'darwin'
+    ? {
+        backgroundColor: '#121221',
+        titleBarStyle: 'hiddenInset' as const,
+        trafficLightPosition: { x: 16, y: 13 },
+      }
+    : {}
+
 const resolveSidecarBin = (): string => {
   if (app.isPackaged) {
     return path.join(process.resourcesPath, 'bin', BINARY_NAME)
@@ -274,6 +283,7 @@ const createWindow = (): void => {
     minHeight: 600,
     title: 'Vimeflow',
     resizable: true,
+    ...macosWindowChromeOptions,
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -72,6 +72,8 @@ const BINARY_NAME =
 const macosWindowChromeOptions =
   process.platform === 'darwin'
     ? {
+        // Matches Tailwind bg-background token — update if
+        // tailwind.config.js colors.background changes.
         backgroundColor: '#121221',
         titleBarStyle: 'hiddenInset' as const,
         trafficLightPosition: { x: 16, y: 13 },

--- a/src/features/sessions/components/Tabs.test.tsx
+++ b/src/features/sessions/components/Tabs.test.tsx
@@ -67,6 +67,16 @@ describe('Tabs', () => {
     expect(strip.className).toContain('h-[38px]')
   })
 
+  test('makes only empty tab-strip chrome draggable', () => {
+    renderTabs([buildSession()], 'sess-1')
+
+    expect(screen.getByTestId('session-tabs')).toHaveClass('vf-app-drag-region')
+    expect(screen.getByRole('tablist')).toHaveClass('vf-app-no-drag')
+    expect(screen.getByRole('button', { name: 'New session' })).toHaveClass(
+      'vf-app-no-drag'
+    )
+  })
+
   test('exposes a tablist for assistive navigation', () => {
     renderTabs([buildSession()], 'sess-1')
     expect(screen.getByRole('tablist')).toHaveAccessibleName('Open sessions')

--- a/src/features/sessions/components/Tabs.test.tsx
+++ b/src/features/sessions/components/Tabs.test.tsx
@@ -48,7 +48,8 @@ const renderTabs = (
     onSelect: (id: string) => void
     onClose: (id: string) => void
     onNew: () => void
-  }> = {}
+  }> = {},
+  reserveWindowControls = false
 ): ReturnType<typeof render> =>
   render(
     <Tabs
@@ -57,6 +58,7 @@ const renderTabs = (
       onSelect={handlers.onSelect ?? vi.fn()}
       onClose={handlers.onClose ?? vi.fn()}
       onNew={handlers.onNew ?? vi.fn()}
+      reserveWindowControls={reserveWindowControls}
     />
   )
 
@@ -67,13 +69,21 @@ describe('Tabs', () => {
     expect(strip.className).toContain('h-[38px]')
   })
 
-  test('makes only empty tab-strip chrome draggable', () => {
-    renderTabs([buildSession()], 'sess-1')
+  test('makes only empty tab-strip chrome draggable on macOS', () => {
+    renderTabs([buildSession()], 'sess-1', {}, true)
 
     expect(screen.getByTestId('session-tabs')).toHaveClass('vf-app-drag-region')
     expect(screen.getByRole('tablist')).toHaveClass('vf-app-no-drag')
     expect(screen.getByRole('button', { name: 'New session' })).toHaveClass(
       'vf-app-no-drag'
+    )
+  })
+
+  test('does NOT apply drag region on non-macOS platforms', () => {
+    renderTabs([buildSession()], 'sess-1')
+
+    expect(screen.getByTestId('session-tabs')).not.toHaveClass(
+      'vf-app-drag-region'
     )
   })
 

--- a/src/features/sessions/components/Tabs.tsx
+++ b/src/features/sessions/components/Tabs.tsx
@@ -84,7 +84,7 @@ export const Tabs = ({
   return (
     <div
       data-testid="session-tabs"
-      className="flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest px-2"
+      className="vf-app-drag-region flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest px-2"
     >
       {/* WAI-ARIA 1.2 §3.27 requires `tablist` to own only `tab` children.
           Keeping the `+` button and the spacer outside the tablist boundary. */}
@@ -103,7 +103,7 @@ export const Tabs = ({
         // currently active — pre-announcing #177's binding before it
         // lands would mislead AT users into trying a non-functional
         // shortcut.
-        className="flex items-end gap-0.5"
+        className="vf-app-no-drag flex items-end gap-0.5"
       >
         {open.map((session, idx) => {
           const isActive = session.id === activeSessionId
@@ -130,7 +130,7 @@ export const Tabs = ({
         onClick={onNew}
         aria-label="New session"
         title="New session"
-        className="mb-px ml-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-on-surface-variant transition-colors hover:bg-primary/10 hover:text-primary"
+        className="vf-app-no-drag mb-px ml-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-on-surface-variant transition-colors hover:bg-primary/10 hover:text-primary"
       >
         <span className="material-symbols-outlined text-[15px]">add</span>
       </button>

--- a/src/features/sessions/components/Tabs.tsx
+++ b/src/features/sessions/components/Tabs.tsx
@@ -13,6 +13,7 @@ export interface TabsProps {
   onSelect: (sessionId: string) => void
   onClose: (sessionId: string) => SessionCloseResult
   onNew: () => void
+  reserveWindowControls?: boolean
 }
 
 export const Tabs = ({
@@ -21,6 +22,7 @@ export const Tabs = ({
   onSelect,
   onClose,
   onNew,
+  reserveWindowControls = false,
 }: TabsProps): ReactElement => {
   // Single source of truth for "what's visible in the strip" — see
   // `getVisibleSessions` for the predicate. Both this component and
@@ -84,7 +86,7 @@ export const Tabs = ({
   return (
     <div
       data-testid="session-tabs"
-      className="vf-app-drag-region flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest px-2"
+      className={`flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest px-2${reserveWindowControls ? ' vf-app-drag-region' : ''}`}
     >
       {/* WAI-ARIA 1.2 §3.27 requires `tablist` to own only `tab` children.
           Keeping the `+` button and the spacer outside the tablist boundary. */}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -135,19 +135,6 @@ const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
   { id: 'files', label: 'FILES' },
 ]
 
-const isMacPlatform = (): boolean => {
-  if (typeof navigator === 'undefined') {
-    return false
-  }
-
-  const uad = (
-    navigator as Navigator & { userAgentData?: { platform?: string } }
-  ).userAgentData
-  const detected = (uad?.platform ?? navigator.platform).toLowerCase()
-
-  return detected.startsWith('mac')
-}
-
 type DockTab = 'editor' | 'diff'
 
 export const WorkspaceView = (): ReactElement => {
@@ -222,7 +209,7 @@ export const WorkspaceView = (): ReactElement => {
     return detected.startsWith('mac') ? 'meta' : 'ctrl'
   }, [])
 
-  const reserveWindowControls = preferModifier === 'meta' && isMacPlatform()
+  const reserveWindowControls = preferModifier === 'meta'
 
   const { message: infoMessage, notifyInfo, dismiss } = useNotifyInfo()
   const { activeTab, setActiveTab } = useSidebarTab()
@@ -1478,7 +1465,7 @@ export const WorkspaceView = (): ReactElement => {
         {
           // `--workspace-sidebar-width` is owned by previewSidebarWidth so
           // React rerenders cannot overwrite an in-progress drag preview.
-          gridTemplateColumns: `48px var(--workspace-sidebar-width, ${SIDEBAR_INITIAL}px) 1fr auto`,
+          gridTemplateColumns: `${reserveWindowControls ? 68 : 48}px var(--workspace-sidebar-width, ${SIDEBAR_INITIAL}px) 1fr auto`,
         } as CSSProperties
       }
     >
@@ -1555,6 +1542,7 @@ export const WorkspaceView = (): ReactElement => {
           onSelect={handleSetActiveSessionId}
           onClose={handleRemoveSession}
           onNew={handleCreateSession}
+          reserveWindowControls={reserveWindowControls}
         />
 
         <div

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -135,6 +135,19 @@ const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
   { id: 'files', label: 'FILES' },
 ]
 
+const isMacPlatform = (): boolean => {
+  if (typeof navigator === 'undefined') {
+    return false
+  }
+
+  const uad = (
+    navigator as Navigator & { userAgentData?: { platform?: string } }
+  ).userAgentData
+  const detected = (uad?.platform ?? navigator.platform).toLowerCase()
+
+  return detected.startsWith('mac')
+}
+
 type DockTab = 'editor' | 'diff'
 
 export const WorkspaceView = (): ReactElement => {
@@ -208,6 +221,8 @@ export const WorkspaceView = (): ReactElement => {
 
     return detected.startsWith('mac') ? 'meta' : 'ctrl'
   }, [])
+
+  const reserveWindowControls = preferModifier === 'meta' && isMacPlatform()
 
   const { message: infoMessage, notifyInfo, dismiss } = useNotifyInfo()
   const { activeTab, setActiveTab } = useSidebarTab()
@@ -1472,6 +1487,7 @@ export const WorkspaceView = (): ReactElement => {
         onCommand={commandPalette.open}
         items={mockNavigationItems}
         settingsItem={mockSettingsItem}
+        reserveWindowControls={reserveWindowControls}
       />
 
       {/* Sidebar - resizable */}

--- a/src/features/workspace/components/IconRail.test.tsx
+++ b/src/features/workspace/components/IconRail.test.tsx
@@ -18,9 +18,20 @@ describe('IconRail', () => {
   test('can reserve the macOS traffic-light area', () => {
     render(<IconRail settingsIssueNumber={1} reserveWindowControls />)
 
-    expect(screen.getByTestId('icon-rail')).toHaveStyle({
+    const rail = screen.getByTestId('icon-rail')
+    expect(rail).toHaveClass('vf-app-drag-region')
+    expect(rail).toHaveClass('w-[68px]')
+    expect(rail).toHaveStyle({
       paddingTop: '52px',
     })
+  })
+
+  test('does NOT apply drag region on non-macOS platforms', () => {
+    render(<IconRail settingsIssueNumber={1} />)
+
+    expect(screen.getByTestId('icon-rail')).not.toHaveClass(
+      'vf-app-drag-region'
+    )
   })
 
   test('truncates a multi-char initial to the first grapheme', () => {

--- a/src/features/workspace/components/IconRail.test.tsx
+++ b/src/features/workspace/components/IconRail.test.tsx
@@ -15,6 +15,14 @@ describe('IconRail', () => {
     expect(screen.getByRole('img', { name: 'Account' })).toHaveTextContent('M')
   })
 
+  test('can reserve the macOS traffic-light area', () => {
+    render(<IconRail settingsIssueNumber={1} reserveWindowControls />)
+
+    expect(screen.getByTestId('icon-rail')).toHaveStyle({
+      paddingTop: '52px',
+    })
+  })
+
   test('truncates a multi-char initial to the first grapheme', () => {
     render(<IconRail settingsIssueNumber={1} identity={{ initial: 'AB' }} />)
     expect(screen.getByRole('img', { name: 'Account' })).toHaveTextContent('A')

--- a/src/features/workspace/components/IconRail.tsx
+++ b/src/features/workspace/components/IconRail.tsx
@@ -44,6 +44,11 @@ interface RailBtnProps {
 
 type RailIconName = 'search' | 'settings'
 
+// Vertical padding that clears the macOS traffic-light buttons.
+// Matches trafficLightPosition.y (13) + button diameter (~28) + gap (~11)
+// from electron/main.ts.
+const MACOS_TRAFFIC_LIGHT_RESERVE_PX = 52
+
 const RailIcon = ({ icon }: { icon: RailIconName }): ReactElement => (
   <span
     aria-hidden="true"
@@ -110,11 +115,11 @@ export const IconRail = ({
   return (
     <nav
       data-testid="icon-rail"
-      className="
-        vf-app-drag-region relative z-[5] flex h-full w-12 flex-col items-center
+      className={`
+        ${reserveWindowControls ? 'vf-app-drag-region' : ''} relative z-[5] flex h-full ${reserveWindowControls ? 'w-[68px]' : 'w-12'} flex-col items-center
         bg-surface-container-lowest border-r border-outline-variant/25
-      "
-      style={{ paddingTop: reserveWindowControls ? 52 : 10, paddingBottom: 10 }}
+      `}
+      style={{ paddingTop: reserveWindowControls ? MACOS_TRAFFIC_LIGHT_RESERVE_PX : 10, paddingBottom: 10 }}
     >
       <Tooltip content={accountLabel} placement="right">
         <div

--- a/src/features/workspace/components/IconRail.tsx
+++ b/src/features/workspace/components/IconRail.tsx
@@ -119,7 +119,10 @@ export const IconRail = ({
         ${reserveWindowControls ? 'vf-app-drag-region' : ''} relative z-[5] flex h-full ${reserveWindowControls ? 'w-[68px]' : 'w-12'} flex-col items-center
         bg-surface-container-lowest border-r border-outline-variant/25
       `}
-      style={{ paddingTop: reserveWindowControls ? MACOS_TRAFFIC_LIGHT_RESERVE_PX : 10, paddingBottom: 10 }}
+      style={{
+        paddingTop: reserveWindowControls ? MACOS_TRAFFIC_LIGHT_RESERVE_PX : 10,
+        paddingBottom: 10,
+      }}
     >
       <Tooltip content={accountLabel} placement="right">
         <div

--- a/src/features/workspace/components/IconRail.tsx
+++ b/src/features/workspace/components/IconRail.tsx
@@ -14,6 +14,8 @@ export interface IconRailProps {
   onCommand?: () => void
   onSettings?: () => void
   identity?: IconRailIdentity
+  /** Reserve the macOS hidden-titlebar traffic-light area. */
+  reserveWindowControls?: boolean
   /**
    * @deprecated Ignored by the new rail body — the rail no longer
    * iterates this array. Kept for one cycle so existing callers
@@ -78,6 +80,7 @@ const RailBtn = ({
             ? 'cursor-not-allowed text-on-surface-muted/60'
             : 'cursor-pointer text-on-surface-muted hover:bg-primary/[0.06] hover:text-primary'
         }
+        vf-app-no-drag
       `}
     >
       <RailIcon icon={icon} />
@@ -90,6 +93,7 @@ export const IconRail = ({
   onCommand = undefined,
   onSettings = undefined,
   identity = undefined,
+  reserveWindowControls = false,
 }: IconRailProps): ReactElement => {
   const initial = Array.from(identity?.initial ?? 'w')[0] ?? 'w'
   const candidateAccountLabel = identity?.ariaLabel ?? 'Account'
@@ -107,16 +111,17 @@ export const IconRail = ({
     <nav
       data-testid="icon-rail"
       className="
-        relative z-[5] flex h-full w-12 flex-col items-center
+        vf-app-drag-region relative z-[5] flex h-full w-12 flex-col items-center
         bg-surface-container-lowest border-r border-outline-variant/25
-        py-2.5
       "
+      style={{ paddingTop: reserveWindowControls ? 52 : 10, paddingBottom: 10 }}
     >
       <Tooltip content={accountLabel} placement="right">
         <div
           role="img"
           aria-label={accountLabel}
           className="
+            vf-app-no-drag
             mb-3.5 h-[30px] w-[30px] grid place-items-center
             rounded-full border border-primary/35
             bg-[linear-gradient(135deg,theme(colors.primary-deep),theme(colors.surface-container-low))]

--- a/src/index.css
+++ b/src/index.css
@@ -106,6 +106,15 @@
     @apply bg-background text-on-surface font-body overflow-hidden m-0;
   }
 
+  .vf-app-drag-region {
+    -webkit-app-region: drag;
+    user-select: none;
+  }
+
+  .vf-app-no-drag {
+    -webkit-app-region: no-drag;
+  }
+
   .material-symbols-outlined {
     font-family: 'Material Symbols Outlined Variable';
     font-weight: normal;


### PR DESCRIPTION
## Summary

- Use Electron's native `hiddenInset` titlebar on macOS with a dark backing color and traffic-light positioning.
- Add renderer drag/no-drag helpers for Electron chrome regions.
- Reserve the macOS traffic-light area in the main-branch icon rail and keep tab-strip controls interactive.

## Validation

- `npx vitest run src/features/workspace/components/IconRail.test.tsx src/features/sessions/components/Tabs.test.tsx`
- `npm run type-check`
- `npx eslint electron/main.ts src/features/workspace/components/IconRail.tsx src/features/workspace/components/IconRail.test.tsx src/features/sessions/components/Tabs.tsx src/features/sessions/components/Tabs.test.tsx src/features/workspace/WorkspaceView.tsx`
- pre-push hook: full `npm test` passed (`253` files, `3428` passed, `3` skipped)