### PR TITLE
fix(agent-status): show Codex account usage in sidebar (VIM-66)

### DIFF
--- a/crates/backend/src/agent/adapter/codex/locator.rs
+++ b/crates/backend/src/agent/adapter/codex/locator.rs
@@ -1,6 +1,7 @@
 //! Codex session locator.
 
 use super::types::BindContext;
+use crate::agent::types::{RateLimitInfo, RateLimits};
 use chrono::{Datelike, Duration as ChronoDuration, Local};
 use rusqlite::{named_params, Connection, OpenFlags};
 use serde_json::Value;
@@ -654,6 +655,72 @@ pub struct CompositeLocator {
     pty_start: SystemTime,
 }
 
+impl CompositeLocator {
+    pub(super) fn latest_account_rate_limits(&self, thread_id: &str) -> Option<RateLimits> {
+        if thread_id.is_empty() {
+            return None;
+        }
+
+        let logs_db = discover_db(&self.codex_home, "logs").ok().flatten()?;
+        let conn = Connection::open_with_flags(&logs_db, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT feedback_log_body
+                 FROM logs
+                 WHERE thread_id = :thread_id
+                   AND feedback_log_body IS NOT NULL
+                   AND feedback_log_body LIKE '%x-codex-primary-used-percent%'
+                 ORDER BY ts DESC, ts_nanos DESC
+                 LIMIT 1",
+            )
+            .ok()?;
+        let body: String = stmt
+            .query_row(named_params! { ":thread_id": thread_id }, |row| row.get(0))
+            .ok()?;
+
+        account_rate_limits_from_log_body(&body)
+    }
+}
+
+fn account_rate_limits_from_log_body(body: &str) -> Option<RateLimits> {
+    let five_hour = RateLimitInfo {
+        used_percentage: header_f64(body, "x-codex-primary-used-percent")?,
+        resets_at: header_u64(body, "x-codex-primary-reset-at")?,
+    };
+
+    let seven_day = match (
+        header_f64(body, "x-codex-secondary-used-percent"),
+        header_u64(body, "x-codex-secondary-reset-at"),
+    ) {
+        (Some(used_percentage), Some(resets_at)) => Some(RateLimitInfo {
+            used_percentage,
+            resets_at,
+        }),
+        _ => None,
+    };
+
+    Some(RateLimits {
+        five_hour,
+        seven_day,
+    })
+}
+
+fn header_f64(body: &str, name: &str) -> Option<f64> {
+    header_value(body, name)?.parse::<f64>().ok()
+}
+
+fn header_u64(body: &str, name: &str) -> Option<u64> {
+    header_value(body, name)?.parse::<u64>().ok()
+}
+
+fn header_value<'a>(body: &'a str, name: &str) -> Option<&'a str> {
+    let needle = format!("\"{}\": \"", name);
+    let start = body.find(&needle)? + needle.len();
+    let rest = &body[start..];
+    let end = rest.find('"')?;
+    Some(&rest[..end])
+}
+
 // ----- Step B' retry budget (moved here from `codex/mod.rs`) -----
 //
 // Per frozen constraint #2: "Codex retry lives inside
@@ -915,6 +982,80 @@ mod discovery_tests {
             .expect("discover logs")
             .expect("logs db");
         assert!(picked.ends_with("logs_1.sqlite"));
+    }
+}
+
+#[cfg(test)]
+mod rate_limit_header_tests {
+    use super::*;
+
+    const LOG_BODY: &str = r#"Request completed method=POST headers={"x-codex-primary-used-percent": "10", "x-codex-secondary-used-percent": "50", "x-codex-primary-reset-at": "1781020167", "x-codex-secondary-reset-at": "1781144090", "x-codex-bengalfox-primary-used-percent": "0", "x-codex-bengalfox-secondary-used-percent": "0"}"#;
+
+    #[test]
+    fn parses_account_rate_limits_from_codex_response_headers() {
+        let rate_limits =
+            account_rate_limits_from_log_body(LOG_BODY).expect("account headers parse");
+
+        assert_eq!(rate_limits.five_hour.used_percentage, 10.0);
+        assert_eq!(rate_limits.five_hour.resets_at, 1781020167);
+
+        let seven_day = rate_limits.seven_day.expect("weekly limit");
+        assert_eq!(seven_day.used_percentage, 50.0);
+        assert_eq!(seven_day.resets_at, 1781144090);
+    }
+
+    #[test]
+    fn returns_none_when_account_headers_are_absent() {
+        let body = r#"headers={"x-codex-bengalfox-primary-used-percent": "0"}"#;
+
+        assert!(account_rate_limits_from_log_body(body).is_none());
+    }
+
+    #[test]
+    fn latest_account_rate_limits_reads_newest_thread_log_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let logs_path = dir.path().join("logs_1.sqlite");
+        let conn = Connection::open(&logs_path).expect("open logs db");
+        conn.execute_batch(
+            "CREATE TABLE logs (
+                id INTEGER PRIMARY KEY,
+                ts INTEGER NOT NULL,
+                ts_nanos INTEGER NOT NULL,
+                thread_id TEXT,
+                feedback_log_body TEXT
+            );",
+        )
+        .expect("logs schema");
+        conn.execute(
+            "INSERT INTO logs (ts, ts_nanos, thread_id, feedback_log_body)
+             VALUES (1, 0, 'thread-A', ?1)",
+            rusqlite::params![r#"headers={"x-codex-primary-used-percent": "1", "x-codex-secondary-used-percent": "2", "x-codex-primary-reset-at": "100", "x-codex-secondary-reset-at": "200"}"#],
+        )
+        .expect("insert old row");
+        conn.execute(
+            "INSERT INTO logs (ts, ts_nanos, thread_id, feedback_log_body)
+             VALUES (2, 0, 'thread-B', ?1)",
+            rusqlite::params![r#"headers={"x-codex-primary-used-percent": "90", "x-codex-secondary-used-percent": "91", "x-codex-primary-reset-at": "900", "x-codex-secondary-reset-at": "910"}"#],
+        )
+        .expect("insert other thread row");
+        conn.execute(
+            "INSERT INTO logs (ts, ts_nanos, thread_id, feedback_log_body)
+             VALUES (3, 0, 'thread-A', ?1)",
+            rusqlite::params![LOG_BODY],
+        )
+        .expect("insert newest row");
+
+        let locator =
+            CompositeLocator::new(dir.path().to_path_buf(), 123, SystemTime::UNIX_EPOCH, None);
+        let rate_limits = locator
+            .latest_account_rate_limits("thread-A")
+            .expect("latest headers should parse");
+
+        assert_eq!(rate_limits.five_hour.used_percentage, 10.0);
+        assert_eq!(
+            rate_limits.seven_day.expect("weekly limit").used_percentage,
+            50.0
+        );
     }
 }
 

--- a/crates/backend/src/agent/adapter/codex/locator.rs
+++ b/crates/backend/src/agent/adapter/codex/locator.rs
@@ -653,6 +653,16 @@ pub struct CompositeLocator {
     /// SQLite filter to exclude stale rollout rows from earlier
     /// processes.
     pty_start: SystemTime,
+    /// Lazy cache for the discovered logs database path.
+    /// `discover_db` enumerates and open-checks sqlite files in
+    /// `codex_home` on every call; the logs DB location is stable
+    /// for a locator/session lifetime, so caching avoids repeated
+    /// filesystem I/O on the status-poll hot path (PR #408 review
+    /// finding — logs database discovery runs on every status decode).
+    /// Only successful discoveries are cached; misses are retried on
+    /// subsequent calls so that early polling before the DB exists
+    /// does not permanently freeze account rate-limit reporting.
+    logs_db_cache: std::sync::OnceLock<PathBuf>,
 }
 
 impl CompositeLocator {
@@ -661,8 +671,15 @@ impl CompositeLocator {
             return None;
         }
 
-        let logs_db = discover_db(&self.codex_home, "logs").ok().flatten()?;
-        let conn = Connection::open_with_flags(&logs_db, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
+        let logs_db = match self.logs_db_cache.get() {
+            Some(path) => path,
+            None => {
+                let path = discover_db(&self.codex_home, "logs").ok().flatten()?;
+                let _ = self.logs_db_cache.set(path);
+                self.logs_db_cache.get().expect("just set")
+            }
+        };
+        let conn = Connection::open_with_flags(logs_db, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
         let mut stmt = conn
             .prepare(
                 "SELECT feedback_log_body
@@ -794,6 +811,7 @@ impl CompositeLocator {
             codex_home,
             pid,
             pty_start,
+            logs_db_cache: std::sync::OnceLock::new(),
         }
     }
 }

--- a/crates/backend/src/agent/adapter/codex/locator.rs
+++ b/crates/backend/src/agent/adapter/codex/locator.rs
@@ -685,7 +685,7 @@ impl CompositeLocator {
 fn account_rate_limits_from_log_body(body: &str) -> Option<RateLimits> {
     let five_hour = RateLimitInfo {
         used_percentage: header_f64(body, "x-codex-primary-used-percent")?,
-        resets_at: header_u64(body, "x-codex-primary-reset-at")?,
+        resets_at: header_u64(body, "x-codex-primary-reset-at").unwrap_or(0),
     };
 
     let seven_day = match (
@@ -695,6 +695,10 @@ fn account_rate_limits_from_log_body(body: &str) -> Option<RateLimits> {
         (Some(used_percentage), Some(resets_at)) => Some(RateLimitInfo {
             used_percentage,
             resets_at,
+        }),
+        (Some(used_percentage), None) => Some(RateLimitInfo {
+            used_percentage,
+            resets_at: 0,
         }),
         _ => None,
     };
@@ -714,11 +718,34 @@ fn header_u64(body: &str, name: &str) -> Option<u64> {
 }
 
 fn header_value<'a>(body: &'a str, name: &str) -> Option<&'a str> {
-    let needle = format!("\"{}\": \"", name);
-    let start = body.find(&needle)? + needle.len();
-    let rest = &body[start..];
-    let end = rest.find('"')?;
-    Some(&rest[..end])
+    let key = format!("\"{}\"", name);
+    let mut rest = body;
+
+    loop {
+        let pos = rest.find(&key)?;
+        rest = &rest[pos + key.len()..];
+
+        // Skip whitespace after key
+        rest = rest.trim_start();
+
+        // Expect colon
+        if !rest.starts_with(':') {
+            continue;
+        }
+        rest = &rest[1..];
+
+        // Skip whitespace after colon
+        rest = rest.trim_start();
+
+        // Expect opening quote for value
+        if !rest.starts_with('"') {
+            continue;
+        }
+        rest = &rest[1..];
+
+        let end = rest.find('"')?;
+        return Some(&rest[..end]);
+    }
 }
 
 // ----- Step B' retry budget (moved here from `codex/mod.rs`) -----
@@ -1056,6 +1083,35 @@ mod rate_limit_header_tests {
             rate_limits.seven_day.expect("weekly limit").used_percentage,
             50.0
         );
+    }
+
+    #[test]
+    fn parses_varied_json_whitespace() {
+        // compact — no spaces
+        let body_compact = r#"headers={"x-codex-primary-used-percent":"75","x-codex-primary-reset-at":"1781020167"}"#;
+        let rate_limits =
+            account_rate_limits_from_log_body(body_compact).expect("compact headers parse");
+        assert_eq!(rate_limits.five_hour.used_percentage, 75.0);
+        assert_eq!(rate_limits.five_hour.resets_at, 1781020167);
+
+        // extra spaces around colon
+        let body_spaced = r#"headers={"x-codex-primary-used-percent" : "60", "x-codex-primary-reset-at" : "1000"}"#;
+        let rate_limits =
+            account_rate_limits_from_log_body(body_spaced).expect("spaced headers parse");
+        assert_eq!(rate_limits.five_hour.used_percentage, 60.0);
+        assert_eq!(rate_limits.five_hour.resets_at, 1000);
+    }
+
+    #[test]
+    fn preserves_usage_when_reset_header_is_absent() {
+        let body = r#"headers={"x-codex-primary-used-percent": "80"}"#;
+
+        let rate_limits =
+            account_rate_limits_from_log_body(body).expect("usage without reset parses");
+
+        assert_eq!(rate_limits.five_hour.used_percentage, 80.0);
+        assert_eq!(rate_limits.five_hour.resets_at, 0);
+        assert!(rate_limits.seven_day.is_none());
     }
 }
 

--- a/crates/backend/src/agent/adapter/codex/mod.rs
+++ b/crates/backend/src/agent/adapter/codex/mod.rs
@@ -131,12 +131,15 @@ impl StateDecoder for CodexAdapter {
     /// multi-session debugging could correlate the warning to the
     /// affected PTY session. The session id is NOT incorporated into
     /// the returned `StatusSnapshot` (R2.2 — output is identity-free).
-    fn decode(
-        &self,
-        session_id: Option<&str>,
-        raw: &str,
-    ) -> Result<StatusSnapshot, String> {
-        parser::parse_rollout_snapshot(session_id, raw)
+    fn decode(&self, session_id: Option<&str>, raw: &str) -> Result<StatusSnapshot, String> {
+        let mut snapshot = parser::parse_rollout_snapshot(session_id, raw)?;
+        if let Some(rate_limits) = self
+            .locator()
+            .latest_account_rate_limits(&snapshot.agent_session_id)
+        {
+            snapshot.rate_limits = rate_limits;
+        }
+        Ok(snapshot)
     }
 }
 
@@ -200,6 +203,7 @@ impl AgentAdapter for CodexAdapter {
 #[cfg(test)]
 mod adapter_tests {
     use super::*;
+    use rusqlite::Connection;
     use std::time::SystemTime;
 
     /// Cycle-11 F31 single-allocation invariant, pinned at its source.
@@ -240,6 +244,49 @@ mod adapter_tests {
             .expect("minimal codex status parses");
 
         assert_eq!(parsed.event.agent_session_id, "sess");
+    }
+
+    #[test]
+    fn decode_prefers_account_rate_limits_from_response_headers() {
+        let codex_home = tempfile::tempdir().expect("tempdir");
+        let logs_path = codex_home.path().join("logs_1.sqlite");
+        let logs = Connection::open(logs_path).expect("open logs db");
+        logs.execute_batch(
+            "CREATE TABLE logs (
+                id INTEGER PRIMARY KEY,
+                ts INTEGER NOT NULL,
+                ts_nanos INTEGER NOT NULL,
+                thread_id TEXT,
+                feedback_log_body TEXT
+            );",
+        )
+        .expect("logs schema");
+        logs.execute(
+            "INSERT INTO logs (ts, ts_nanos, thread_id, feedback_log_body)
+             VALUES (1, 0, 'thread-headers', ?1)",
+            rusqlite::params![r#"Request completed headers={"x-codex-primary-used-percent": "10", "x-codex-secondary-used-percent": "50", "x-codex-primary-reset-at": "1781020167", "x-codex-secondary-reset-at": "1781144090", "x-codex-bengalfox-primary-used-percent": "0", "x-codex-bengalfox-secondary-used-percent": "0"}"#],
+        )
+        .expect("insert headers row");
+
+        let adapter = CodexAdapter::with_locator(Arc::new(CompositeLocator::new(
+            codex_home.path().to_path_buf(),
+            12345,
+            SystemTime::UNIX_EPOCH,
+            None,
+        )));
+        let raw = r#"{"timestamp":"...","type":"session_meta","payload":{"id":"thread-headers","cli_version":"0.138.0"}}
+{"timestamp":"...","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"output_tokens":200,"cached_input_tokens":0,"total_tokens":1200},"model_context_window":200000},"rate_limits":{"limit_id":"codex_bengalfox","limit_name":"GPT-5.3-Codex-Spark","primary":{"used_percent":0,"resets_at":1781035343},"secondary":{"used_percent":0,"resets_at":1781622143}}}}
+"#;
+
+        let snapshot = <CodexAdapter as StateDecoder>::decode(&adapter, Some("pty"), raw)
+            .expect("codex snapshot");
+
+        assert_eq!(snapshot.rate_limits.five_hour.used_percentage, 10.0);
+        assert_eq!(snapshot.rate_limits.five_hour.resets_at, 1781020167);
+
+        let seven_day = snapshot.rate_limits.seven_day.expect("weekly limit");
+        assert_eq!(seven_day.used_percentage, 50.0);
+        assert_eq!(seven_day.resets_at, 1781144090);
     }
 
     // Step B': the former `parse_status_includes_resolved_rollout_path_when_available`

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -50,6 +50,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality       | 5        | 0    | 2026-05-09   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)       | backend            | 7        | 1    | 2026-06-03   |
+| [Hot-Path Caching](patterns/hot-path-caching.md)                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 59       | 26   | 2026-06-06   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 83       | 24   | 2026-06-03   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -73,4 +73,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 19       | 1    | 2026-06-06   |
 | [Verify Render Target](patterns/verify-render-target.md)             | code-quality       | 2        | 0    | 2026-05-24   |
 | [Status Indicator Display](patterns/status-indicator-display.md)     | code-quality       | 3        | 0    | 2026-05-26   |
-| [Parser Resilience](patterns/parser-resilience.md)                   | code-quality       | 5        | 4    | 2026-05-31   |
+| [Parser Resilience](patterns/parser-resilience.md)                   | code-quality       | 7        | 5    | 2026-06-09   |

--- a/docs/reviews/patterns/hot-path-caching.md
+++ b/docs/reviews/patterns/hot-path-caching.md
@@ -1,0 +1,33 @@
+---
+id: hot-path-caching
+category: backend
+created: 2026-06-09
+last_updated: 2026-06-09
+ref_count: 0
+---
+
+# Hot-Path Caching
+
+## Summary
+
+Status-polling and decode hot paths must not repeat expensive I/O or
+computation whose inputs are stable for the session lifetime. A
+`read_dir` + per-file SQLite schema probe, a network discovery call, or a
+heavy derivation that runs on every tick accumulates avoidable latency
+and degrades the user-visible refresh rate. When the looked-up value is
+stable (a database path, a configuration root, a capability flag), cache
+it after the first successful resolution and reuse it for the remainder
+of the session. Cache misses must remain retryable so that early
+polling before a resource is ready does not permanently freeze the
+feature.
+
+## Findings
+
+### 1. `discover_db` directory scan runs on every `decode()` call
+
+- **Source:** github-claude | PR #408 round 2 | 2026-06-09
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/agent/adapter/codex/locator.rs`
+- **Finding:** `latest_account_rate_limits` called `discover_db(&self.codex_home, "logs")` on every invocation. `discover_db` does `std::fs::read_dir(codex_home)`, then opens a read-only SQLite connection for each `.sqlite` file and queries `sqlite_master` to check if the target table exists. Over a busy session this accumulates repeated directory reads and SQLite open/close cycles for every decoded status event.
+- **Fix:** Added a `logs_db_cache: std::sync::OnceLock<PathBuf>` field to `CompositeLocator`. `latest_account_rate_limits` checks the cache first; on a miss it runs `discover_db`, stores the result only on success, and retries on subsequent calls if the earlier discovery returned `None`. This eliminates repeated filesystem I/O without changing per-call read-query behavior.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/parser-resilience.md
+++ b/docs/reviews/patterns/parser-resilience.md
@@ -2,8 +2,8 @@
 id: parser-resilience
 category: code-quality
 created: 2026-05-24
-last_updated: 2026-05-30
-ref_count: 4
+last_updated: 2026-06-09
+ref_count: 5
 ---
 
 # Parser Resilience
@@ -158,3 +158,21 @@ true` and drop the chunk.
 - **Regression-test discipline:** Cycle 20's first regression test ended with `Step::EofStop` (returns `Ok(0)`), which gave the pre-cycle-20 Ok-arm-only watchdog a final EOF to fire from — so the test passed against both old and new implementations and didn't actually distinguish the fix. Codex-verify retry-1 (MED 0.93) caught this. Added a `Step::ErrStop` variant to the scripted reader that flips `stop` while returning `Err(...)`, so the loop exits via the Err arm with NO `Ok(0)` ever served. Pre-cycle-20 implementation has `caught.load() == 0` on this script; cycle-20 fires the watchdog and `caught.load() >= 1`.
 - **Code-review heuristic (extends #4's "deferred-until-X" rule):** When the recovery escape hatch is placed inside ONE specific arm of a state machine, audit whether there are other arms that can also fail to make progress without ever reaching that arm. The natural placement (the "nothing-to-read" branch) is rarely the only branch where the precondition holds. Hoist the escape to a shared point that EVERY non-progress branch reaches, or replicate it in each — but never let a single arm silently swallow the recovery path. **Test discipline:** when a regression test scripts an error scenario, end the script through the same arm that triggers the bug, not through an adjacent arm that happens to terminate the loop. Otherwise the test passes against the unfixed code and gives false confidence. The `ErrStop` shape (flips `stop` while returning the variant of interest) generalizes: when a scripted-reader / state-machine test harness has terminator variants, every error or boundary case needs its own terminator that exits via the same code path.
 - **Commit:** _(PR #302 upsource cycle 20 fix commit)_
+
+### 6. Substring JSON parser embeds a whitespace assumption that silently disables the feature on format drift
+
+- **Source:** github-claude | PR #408 round 1 | 2026-06-09
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/agent/adapter/codex/locator.rs`
+- **Finding:** `header_value` searched for the exact substring `"name": "` (colon, space, quote). If Codex CLI ever serialized headers as compact JSON (`"name":"value"`) or with any other whitespace variant, every header lookup returned `None`. Because `account_rate_limits_from_log_body` propagated that `None` with `?`, the entire rate-limit snapshot was discarded and the sidebar fell back to rollout placeholder data — silently, with no diagnostic.
+- **Fix:** Replaced the exact-substring needle with a small state machine that locates the quoted key, skips optional whitespace, expects `:`, skips optional whitespace, then reads the quoted value. This handles compact, spaced, and any other valid JSON whitespace around the colon. Added regression tests for compact JSON and extra-space variants. Also added a test for the partial-data case (usage present, reset absent) which exercises the same code path.
+- **Commit:** same commit as this entry
+
+### 7. Strict all-or-nothing parsing of partial rate-limit headers discards available usage data
+
+- **Source:** github-codex-connector | PR #408 round 1 | 2026-06-09
+- **Severity:** P2 / MEDIUM
+- **File:** `crates/backend/src/agent/adapter/codex/locator.rs`
+- **Finding:** `account_rate_limits_from_log_body` used `?` on both `header_f64(..., "x-codex-primary-used-percent")` and `header_u64(..., "x-codex-primary-reset-at")`. When the used-percent header was present but the reset-at header was absent (e.g. error responses or older header shapes), the `?` on the missing reset header made the entire function return `None`. The available usage percentage was lost and the sidebar showed the model-specific `0%` placeholder.
+- **Fix:** Changed the primary `five_hour` construction to require only `used_percentage` via `?`; `resets_at` now falls back to `0` (unknown reset) via `unwrap_or(0)`. Applied the same fallback to the optional `seven_day` block: `(Some(used), None) → Some(RateLimitInfo { used_percentage: used, resets_at: 0 })`. Added a regression test proving usage is preserved when reset headers are absent.
+- **Commit:** same commit as this entry

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -160,6 +160,29 @@ vi.mock('../agent-status/components/AgentStatusPanel', () => ({
   PANEL_WIDTH_PX: 280,
 }))
 
+const makeAgentStatus = (
+  sessionId: string | null,
+  overrides: Partial<AgentStatus> = {}
+): AgentStatus => ({
+  isActive: sessionId !== null,
+  agentExited: false,
+  agentType: sessionId === null ? null : 'claude-code',
+  modelId: null,
+  modelDisplayName: null,
+  version: null,
+  sessionId,
+  agentSessionId: null,
+  cwd: null,
+  contextWindow: null,
+  cost: null,
+  rateLimits: null,
+  numTurns: 0,
+  toolCalls: { total: 0, byType: {}, active: null },
+  recentToolCalls: [],
+  testRun: null,
+  ...overrides,
+})
+
 // Mock terminal service to return initial session data synchronously
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => workspaceTerminalMock.service),
@@ -1647,6 +1670,86 @@ describe('WorkspaceView', () => {
       isActive: true,
       agentType: 'claude-code',
     })
+  })
+
+  test('forwards real rate-limit usage to the sidebar agent card', async () => {
+    vi.mocked(useAgentStatus).mockImplementation(
+      (sessionId: string | null): AgentStatus =>
+        makeAgentStatus(sessionId, {
+          modelDisplayName: sessionId === null ? null : 'Claude Sonnet',
+          rateLimits:
+            sessionId === null
+              ? null
+              : {
+                  fiveHour: {
+                    usedPercentage: 12.4,
+                    resetsAt: 1_776_000_000_000,
+                  },
+                  sevenDay: {
+                    usedPercentage: 34.4,
+                    resetsAt: 1_776_086_400_000,
+                  },
+                },
+        })
+    )
+
+    render(<WorkspaceView />)
+
+    await screen.findByRole('button', { name: 'session 1' })
+
+    expect(await screen.findByText('5-hour Session')).toBeInTheDocument()
+    expect(screen.getByText('12%')).toBeInTheDocument()
+    expect(screen.getByText('Weekly Usage')).toBeInTheDocument()
+    expect(screen.getByText('34%')).toBeInTheDocument()
+  })
+
+  test('does not render empty rate-limit placeholders as sidebar usage', async () => {
+    vi.mocked(useAgentStatus).mockImplementation(
+      (sessionId: string | null): AgentStatus =>
+        makeAgentStatus(sessionId, {
+          modelDisplayName: sessionId === null ? null : 'Claude Sonnet',
+          rateLimits:
+            sessionId === null
+              ? null
+              : {
+                  fiveHour: { usedPercentage: 0, resetsAt: 0 },
+                  sevenDay: { usedPercentage: 0, resetsAt: 0 },
+                },
+        })
+    )
+
+    render(<WorkspaceView />)
+
+    await screen.findByRole('button', { name: 'session 1' })
+    await screen.findByText('Claude Sonnet')
+
+    expect(screen.queryByText('5-hour Session')).not.toBeInTheDocument()
+    expect(screen.queryByText('Weekly Usage')).not.toBeInTheDocument()
+  })
+
+  test('preserves real zero rate-limit usage when reset time is known', async () => {
+    vi.mocked(useAgentStatus).mockImplementation(
+      (sessionId: string | null): AgentStatus =>
+        makeAgentStatus(sessionId, {
+          modelDisplayName: sessionId === null ? null : 'Claude Sonnet',
+          rateLimits:
+            sessionId === null
+              ? null
+              : {
+                  fiveHour: {
+                    usedPercentage: 0,
+                    resetsAt: 1_776_000_000_000,
+                  },
+                },
+        })
+    )
+
+    render(<WorkspaceView />)
+
+    await screen.findByRole('button', { name: 'session 1' })
+
+    expect(await screen.findByText('5-hour Session')).toBeInTheDocument()
+    expect(screen.getByText('0%')).toBeInTheDocument()
   })
 
   test('mirrors agentStatus.cwd into the active pane.cwd', async () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -40,7 +40,7 @@ import {
   RAIL_WIDTH_PX,
 } from '../agent-status/components/AgentStatusRail'
 import { cacheHitRate } from '../agent-status/utils/cacheRate'
-import type { CurrentUsageState } from '../agent-status/types'
+import type { CurrentUsageState, RateLimitsState } from '../agent-status/types'
 import { UnsavedChangesDialog } from '../editor/components/UnsavedChangesDialog'
 import { InfoBanner } from './components/InfoBanner'
 import { CommandPalette } from '../command-palette/CommandPalette'
@@ -102,6 +102,23 @@ const cacheHitPercentage = (
   const rate = cacheHitRate(usage)
 
   return rate === null ? null : Math.round(rate * 100)
+}
+
+const rateLimitPercentage = (
+  limit: RateLimitsState['fiveHour'] | null | undefined
+): number | null => {
+  if (!limit || !Number.isFinite(limit.usedPercentage)) {
+    return null
+  }
+
+  if (
+    limit.usedPercentage === 0 &&
+    (!Number.isFinite(limit.resetsAt) || limit.resetsAt <= 0)
+  ) {
+    return null
+  }
+
+  return Math.round(limit.usedPercentage)
 }
 
 const formatStatusDuration = (durationMs: number): string | undefined => {
@@ -1015,13 +1032,13 @@ export const WorkspaceView = (): ReactElement => {
     'No session'
   const sidebarCardTurns = statusBarSession?.turns ?? null
 
-  const sidebarCardFiveHourPct = agentStatus.rateLimits
-    ? Math.round(agentStatus.rateLimits.fiveHour.usedPercentage)
-    : null
+  const sidebarCardFiveHourPct = rateLimitPercentage(
+    agentStatus.rateLimits?.fiveHour
+  )
 
-  const sidebarCardWeekPct = agentStatus.rateLimits?.sevenDay
-    ? Math.round(agentStatus.rateLimits.sevenDay.usedPercentage)
-    : null
+  const sidebarCardWeekPct = rateLimitPercentage(
+    agentStatus.rateLimits?.sevenDay
+  )
 
   // Open a file directly (no unsaved-changes guard). Errors were previously
   // swallowed via `void editorBuffer.openFile(...)`, leaving the user with


### PR DESCRIPTION
## Summary

- Read Codex account-level rate-limit headers from the local Codex logs database and prefer them over rollout `token_count.rate_limits` when present.
- Hide empty `0%` placeholder rate-limit values in the sidebar card while preserving real zero usage when reset metadata is available.
- Add backend and workspace sidebar regression coverage for Codex 0.138-style telemetry.

## Root Cause

Codex CLI 0.138 can write model-specific rollout limits such as `codex_bengalfox` as `0%`, while the TUI `/status` usage comes from generic account-level response headers like `x-codex-primary-used-percent` and `x-codex-secondary-used-percent`. The sidebar was only rendering the rollout shape, so it stayed at `0%` even when `/status` showed real usage.

## CI Fix

The failed local CI reproduction was `npm run format:check`; Prettier wanted the edited `WorkspaceView.tsx` import collapsed to one line. The amended commit includes that formatting fix.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run type-check`
- `npm test`
- `npm run generate:bindings`
- `cargo test`
- `git diff --check`