### PR TITLE
[codex] Improve responsive sidebar accessibility

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,7 +54,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 59       | 26   | 2026-06-06   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 83       | 24   | 2026-06-03   |
-| [Accessibility](patterns/accessibility.md)                           | a11y               | 38       | 11   | 2026-06-10   |
+| [Accessibility](patterns/accessibility.md)                           | a11y               | 40       | 12   | 2026-06-10   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 56       | 15   | 2026-05-31   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                   | security           | 7        | 3    | 2026-05-02   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,7 +54,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 59       | 26   | 2026-06-06   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 83       | 24   | 2026-06-03   |
-| [Accessibility](patterns/accessibility.md)                           | a11y               | 35       | 11   | 2026-06-07   |
+| [Accessibility](patterns/accessibility.md)                           | a11y               | 38       | 11   | 2026-06-10   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 56       | 15   | 2026-05-31   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                   | security           | 7        | 3    | 2026-05-02   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,7 +54,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 59       | 26   | 2026-06-06   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 83       | 24   | 2026-06-03   |
-| [Accessibility](patterns/accessibility.md)                           | a11y               | 40       | 12   | 2026-06-10   |
+| [Accessibility](patterns/accessibility.md)                           | a11y               | 41       | 14   | 2026-06-10   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 56       | 15   | 2026-05-31   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                   | security           | 7        | 3    | 2026-05-02   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,7 +54,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 59       | 26   | 2026-06-06   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 83       | 24   | 2026-06-03   |
-| [Accessibility](patterns/accessibility.md)                           | a11y               | 41       | 14   | 2026-06-10   |
+| [Accessibility](patterns/accessibility.md)                           | a11y               | 42       | 15   | 2026-06-10   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 56       | 15   | 2026-05-31   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                   | security           | 7        | 3    | 2026-05-02   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-10
-ref_count: 12
+ref_count: 13
 ---
 
 # Accessibility
@@ -361,3 +361,21 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The test found the main workspace div with `screen.getByTestId('dock-canvas-wrapper').parentElement!`. If any intermediate wrapper were inserted, the assertion would check the wrong element's `inert` / `aria-hidden` attributes.
 - **Fix:** Added `data-testid="workspace-main"` to the main workspace div in `WorkspaceView.tsx` and updated the test to query `screen.getByTestId('workspace-main')` directly.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 39. Compact sidebar drawer lacks dialog semantics while behaving as a modal overlay
+
+- **Source:** github-codex-connector | PR #409 round 2 | 2026-06-10
+- **Severity:** HIGH
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** The changed compact sidebar path makes the main workspace inert/aria-hidden and displays a scrim, so the sidebar is presented as a modal overlay in real use whenever a compact viewport user opens it. Without `role="dialog"`, `aria-modal`, and an accessible label on the active drawer container, assistive technology users do not get a programmatic modal context.
+- **Fix:** Added conditional dialog semantics to the sidebar wrapper when the compact drawer is open: `role={isCompactViewport && !isSidebarClosed ? 'dialog' : undefined}`, `aria-modal={isCompactViewport && !isSidebarClosed ? true : undefined}`, and `aria-label={isCompactViewport && !isSidebarClosed ? 'Sidebar' : undefined}`. The props are only applied on the compact open path; the non-compact sidebar path is unchanged.
+- **Commit:** see `git blame` / `git log` on this line
+
+### 40. Scrim close path does not opt into focus restoration
+
+- **Source:** github-codex-connector | PR #409 round 2 | 2026-06-10
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** The scrim is a newly added dismissal path for the compact drawer. Its `onClick` closes the drawer without setting the existing `shouldRestoreSidebarToggleFocusRef` flag, unlike the Escape path, so focus can fall back to `document.body` after the clicked scrim unmounts. This affects mixed pointer/keyboard users.
+- **Fix:** Set `shouldRestoreSidebarToggleFocusRef.current = true` before calling `setCompactSidebarOpen(false)` in the scrim `onClick` handler, aligning the scrim dismissal path with the existing Escape behavior and letting the post-toggle focus guard refocus the visible toggle.
+- **Commit:** see `git blame` / `git log` on this line

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-10
-ref_count: 13
+ref_count: 14
 ---
 
 # Accessibility
@@ -378,4 +378,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/workspace/WorkspaceView.tsx`
 - **Finding:** The scrim is a newly added dismissal path for the compact drawer. Its `onClick` closes the drawer without setting the existing `shouldRestoreSidebarToggleFocusRef` flag, unlike the Escape path, so focus can fall back to `document.body` after the clicked scrim unmounts. This affects mixed pointer/keyboard users.
 - **Fix:** Set `shouldRestoreSidebarToggleFocusRef.current = true` before calling `setCompactSidebarOpen(false)` in the scrim `onClick` handler, aligning the scrim dismissal path with the existing Escape behavior and letting the post-toggle focus guard refocus the visible toggle.
+- **Commit:** see `git blame` / `git log` on this line
+
+### 41. Compact sidebar shortcut opens modal drawer without focus restoration
+
+- **Source:** github-claude | PR #409 round 3 | 2026-06-10
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** `handleToggleSidebar` sets `shouldRestoreSidebarToggleFocusRef.current` only when the active element is one of the sidebar toggle buttons. `useSidebarShortcut` intentionally fires from terminal/editor focus, so on compact viewports the shortcut can open the dialog-style sidebar while the main workspace becomes `inert` and the focus guard returns early. This plausibly leaves keyboard users on `document.body` or otherwise outside the newly opened modal drawer, a WCAG focus-order regression in new compact-mode behavior.
+- **Fix:** When compact mode is about to open the sidebar, set `shouldRestoreSidebarToggleFocusRef.current = true` regardless of which element was focused (based on action intent `!compactSidebarOpen` rather than prior active element). Keep the guard for non-compact and close paths. Add a regression test that mocks `requestAnimationFrame`, fires the shortcut from `document.body`, simulates browser inert-focus-eviction by refocusing body, flushes the guard frame, and asserts the topbar toggle receives focus.
 - **Commit:** see `git blame` / `git log` on this line

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,7 +2,7 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-07
+last_updated: 2026-06-10
 ref_count: 12
 ---
 
@@ -343,3 +343,21 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The newly added `session-pane-count` span was nested inside a parent `<span aria-hidden="true">` that wraps the decorative layout glyph. The sibling overlay activation `<button>` carried only `aria-label={session.name}`, so screen-reader users navigating session cards received the session name but not the newly added multi-pane count — meaningful workspace state that sighted users see.
 - **Fix:** Computed an `ariaLabel` constant: when `showGlyph` is true, `${session.name} (${LAYOUTS[session.layout].capacity} panes)`; otherwise `session.name`. Wired `aria-label={ariaLabel}` into the activation button. Added co-located regression tests asserting both the multi-pane suffix and the single-pane absence.
 - **Commit:** see `git blame` / `git log` on this line
+
+### 37. Escape-close doesn't restore focus — keyboard users stranded on <body>
+
+- **Source:** github-claude | PR #409 round 1 | 2026-06-10
+- **Severity:** HIGH
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** When the compact sidebar is open and the user presses Escape to close it, `closeOnEscape` calls `setCompactSidebarOpen(false)` without setting `shouldRestoreSidebarToggleFocusRef.current = true`. The focus-guard effect then finds the flag false and returns early, leaving focus on `document.body` — a WCAG 2.4.3 violation.
+- **Fix:** Added `shouldRestoreSidebarToggleFocusRef.current = true` immediately before `setCompactSidebarOpen(false)` inside `closeOnEscape` so the existing focus-guard RAF picks it up and refocuses the tabs-bar toggle.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 38. Test locates inert wrapper via `parentElement!` — fragile DOM traversal
+
+- **Source:** github-claude | PR #409 round 1 | 2026-06-10
+- **Severity:** LOW
+- **File:** `src/features/workspace/WorkspaceView.test.tsx`
+- **Finding:** The test found the main workspace div with `screen.getByTestId('dock-canvas-wrapper').parentElement!`. If any intermediate wrapper were inserted, the assertion would check the wrong element's `inert` / `aria-hidden` attributes.
+- **Fix:** Added `data-testid="workspace-main"` to the main workspace div in `WorkspaceView.tsx` and updated the test to query `screen.getByTestId('workspace-main')` directly.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-10
-ref_count: 14
+ref_count: 15
 ---
 
 # Accessibility
@@ -388,3 +388,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** `handleToggleSidebar` sets `shouldRestoreSidebarToggleFocusRef.current` only when the active element is one of the sidebar toggle buttons. `useSidebarShortcut` intentionally fires from terminal/editor focus, so on compact viewports the shortcut can open the dialog-style sidebar while the main workspace becomes `inert` and the focus guard returns early. This plausibly leaves keyboard users on `document.body` or otherwise outside the newly opened modal drawer, a WCAG focus-order regression in new compact-mode behavior.
 - **Fix:** When compact mode is about to open the sidebar, set `shouldRestoreSidebarToggleFocusRef.current = true` regardless of which element was focused (based on action intent `!compactSidebarOpen` rather than prior active element). Keep the guard for non-compact and close paths. Add a regression test that mocks `requestAnimationFrame`, fires the shortcut from `document.body`, simulates browser inert-focus-eviction by refocusing body, flushes the guard frame, and asserts the topbar toggle receives focus.
 - **Commit:** see `git blame` / `git log` on this line
+
+### 42. Compact sidebar shortcut close from drawer content drops focus to body
+
+- **Source:** github-codex-connector | PR #409 round 4 | 2026-06-10
+- **Severity:** HIGH
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** In compact mode, `handleToggleSidebar` sets `shouldRestoreSidebarToggleFocusRef.current = isToggleButtonFocused || !compactSidebarOpen`. On the close path, `compactSidebarOpen` is true, so a keyboard user who has tabbed from the drawer toggle into sidebar content and then uses the sidebar shortcut will leave the flag false. Closing makes the drawer content inert/hidden, the focus guard exits early, and focus can land on `document.body` with no visible focus target. This is a deterministic new compact-mode WCAG focus-order regression.
+- **Fix:** In the compact branch of `handleToggleSidebar`, unconditionally set `shouldRestoreSidebarToggleFocusRef.current = true` for all user-triggered compact toggles (both open and close). This aligns with the Escape and scrim dismissal paths. Also fixed `useSidebarShortcut` to not bail on the compact sidebar drawer itself (which carries `role="dialog"` for a11y) while preserving the existing bailout for real dialogs such as the command palette. Added a regression test that opens the drawer, focuses the Command Palette button inside it, fires the sidebar shortcut, and asserts focus lands back on the tabs toggle.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -241,8 +241,10 @@ describe('TerminalPane index', () => {
   test('renders focus ring overlay above scrollable terminal body', () => {
     render(<TerminalPane {...baseProps} />)
 
+    const wrapper = screen.getByTestId('terminal-pane-wrapper')
     const focusRing = screen.getByTestId('terminal-pane-focus-ring')
 
+    expect(wrapper).toHaveClass('isolate')
     expect(focusRing).toHaveClass('absolute')
     expect(focusRing).toHaveClass('z-30')
     expect(focusRing).toHaveClass('pointer-events-none')

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -211,7 +211,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
           transition: 'box-shadow 220ms ease, opacity 220ms ease',
           opacity: isPaneActive ? 1 : 0.78,
         }}
-        className="relative flex h-full w-full flex-col overflow-hidden"
+        className="relative isolate flex h-full w-full flex-col overflow-hidden"
       >
         <Header
           agent={agent}

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -73,6 +73,33 @@ const workspaceTerminalMock = vi.hoisted(() => {
   return { defaultSessionList, service }
 })
 
+const mockMatchMedia = (matches: boolean): (() => void) => {
+  const originalMatchMedia = window.matchMedia
+
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(() => false),
+    })),
+  })
+
+  return (): void => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    })
+  }
+}
+
 // Mock TerminalPane to avoid xterm.js issues in tests. Surface `pane.cwd`
 // as a data attribute so tests can observe the agent-cwd → pane.cwd bridge
 // without driving the full terminal mock surface.
@@ -266,6 +293,45 @@ describe('WorkspaceView', () => {
     expect(screen.getByTestId('terminal-zone')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /editor/i })).toBeInTheDocument() // DockPanel
     expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
+  })
+
+  test('uses a single-column workspace with a dismissible inert sidebar drawer on compact viewports', async () => {
+    const restoreMatchMedia = mockMatchMedia(true)
+    const user = userEvent.setup()
+
+    try {
+      render(<WorkspaceView />)
+
+      await screen.findByTestId('terminal-pane-mock')
+
+      const workspace = screen.getByTestId('workspace-view')
+      expect(workspace.style.gridTemplateColumns).toBe('1fr')
+      expect(
+        screen.queryByTestId('activity-panel-shell')
+      ).not.toBeInTheDocument()
+      expect(screen.queryByTestId('sidebar-scrim')).not.toBeInTheDocument()
+      expect(screen.getByTestId('sidebar-toggle-tabs')).not.toHaveFocus()
+
+      await user.click(screen.getByTestId('sidebar-toggle-tabs'))
+
+      expect(screen.getByTestId('sidebar-scrim')).toBeInTheDocument()
+
+      const mainWorkspace = screen.getByTestId(
+        'dock-canvas-wrapper'
+      ).parentElement!
+      expect(mainWorkspace).toHaveAttribute('inert')
+      expect(mainWorkspace).toHaveAttribute('aria-hidden', 'true')
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('sidebar-scrim')).not.toBeInTheDocument()
+      })
+      expect(mainWorkspace).not.toHaveAttribute('inert')
+      expect(mainWorkspace).not.toHaveAttribute('aria-hidden')
+    } finally {
+      restoreMatchMedia()
+    }
   })
 
   test('wires usePaneShortcuts to session-manager handlers', () => {

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -416,6 +416,74 @@ describe('WorkspaceView', () => {
     }
   })
 
+  test('compact sidebar shortcut from focused drawer content restores focus to the tabs toggle', async () => {
+    const restoreMatchMedia = mockMatchMedia(true)
+    const user = userEvent.setup()
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      render(<WorkspaceView />)
+      await screen.findByTestId('terminal-pane-mock')
+
+      // Open the compact sidebar via the tabs toggle
+      await user.click(screen.getByTestId('sidebar-toggle-tabs'))
+      expect(screen.getByTestId('sidebar-scrim')).toBeInTheDocument()
+
+      // Move focus into the drawer content (Command Palette button), not the toggle
+      const commandButton = screen.getByRole('button', {
+        name: 'Command Palette',
+      })
+      act(() => {
+        commandButton.focus()
+      })
+      expect(commandButton).toHaveFocus()
+
+      // Fire the global sidebar shortcut to close the drawer
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'b',
+            ctrlKey: true,
+            shiftKey: true,
+            bubbles: true,
+          })
+        )
+      })
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('sidebar-scrim')).not.toBeInTheDocument()
+      })
+
+      // jsdom does not evict focus from inert elements; simulate the browser
+      // by moving focus to body before the focus guard frame fires.
+      act(() => {
+        document.body.focus()
+      })
+
+      // Flush the focus guard's animation frame
+      const lastFrame = frameCallbacks[frameCallbacks.length - 1]
+      if (lastFrame) {
+        act(() => {
+          lastFrame(16)
+        })
+      }
+
+      // Focus should land on the now-visible tabs toggle
+      expect(screen.getByTestId('sidebar-toggle-tabs')).toHaveFocus()
+    } finally {
+      restoreMatchMedia()
+      requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
   test('wires usePaneShortcuts to session-manager handlers', () => {
     render(<WorkspaceView />)
 

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -298,6 +298,15 @@ describe('WorkspaceView', () => {
   test('uses a single-column workspace with a dismissible inert sidebar drawer on compact viewports', async () => {
     const restoreMatchMedia = mockMatchMedia(true)
     const user = userEvent.setup()
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
 
     try {
       render(<WorkspaceView />)
@@ -327,8 +336,83 @@ describe('WorkspaceView', () => {
       })
       expect(mainWorkspace).not.toHaveAttribute('inert')
       expect(mainWorkspace).not.toHaveAttribute('aria-hidden')
+
+      // jsdom does not evict focus from inert elements; simulate the browser
+      // by moving focus to body before the focus guard frame fires.
+      act(() => {
+        document.body.focus()
+      })
+
+      const lastFrame = frameCallbacks[frameCallbacks.length - 1]
+      if (lastFrame) {
+        act(() => {
+          lastFrame(16)
+        })
+      }
+
+      expect(screen.getByTestId('sidebar-toggle-tabs')).toHaveFocus()
     } finally {
       restoreMatchMedia()
+      requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
+  test('compact sidebar shortcut from main workspace restores focus into the opened drawer', async () => {
+    const restoreMatchMedia = mockMatchMedia(true)
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    try {
+      render(<WorkspaceView />)
+      await screen.findByTestId('terminal-pane-mock')
+
+      // Focus body so the active element is not a sidebar toggle
+      act(() => {
+        document.body.focus()
+      })
+      expect(document.activeElement).toBe(document.body)
+
+      // Fire the global sidebar shortcut (Ctrl+⇧B on Linux)
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'b',
+            ctrlKey: true,
+            shiftKey: true,
+            bubbles: true,
+          })
+        )
+      })
+
+      // The modal drawer is now open
+      expect(screen.getByTestId('sidebar-scrim')).toBeInTheDocument()
+
+      // jsdom does not evict focus from inert elements; simulate the browser
+      // by moving focus to body before the focus guard frame fires.
+      act(() => {
+        document.body.focus()
+      })
+
+      // Flush the focus guard's animation frame
+      const lastFrame = frameCallbacks[frameCallbacks.length - 1]
+      if (lastFrame) {
+        act(() => {
+          lastFrame(16)
+        })
+      }
+
+      // Focus should land on the now-visible topbar toggle inside the drawer
+      expect(screen.getByTestId('sidebar-toggle-topbar')).toHaveFocus()
+    } finally {
+      restoreMatchMedia()
+      requestAnimationFrameSpy.mockRestore()
     }
   })
 

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -316,9 +316,7 @@ describe('WorkspaceView', () => {
 
       expect(screen.getByTestId('sidebar-scrim')).toBeInTheDocument()
 
-      const mainWorkspace = screen.getByTestId(
-        'dock-canvas-wrapper'
-      ).parentElement!
+      const mainWorkspace = screen.getByTestId('workspace-main')
       expect(mainWorkspace).toHaveAttribute('inert')
       expect(mainWorkspace).toHaveAttribute('aria-hidden', 'true')
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -350,6 +350,7 @@ export const WorkspaceView = (): ReactElement => {
   const handleToggleSidebar = useCallback((): void => {
     const activeElement =
       typeof document === 'undefined' ? null : document.activeElement
+
     const isToggleButtonFocused =
       activeElement === sidebarToggleTopbarRef.current ||
       activeElement === sidebarToggleTabsRef.current

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -356,11 +356,11 @@ export const WorkspaceView = (): ReactElement => {
       activeElement === sidebarToggleTabsRef.current
 
     if (isCompactViewport) {
-      // When opening the compact sidebar from a non-toggle element (e.g. via
-      // keyboard shortcut from terminal/editor), force focus restoration so
-      // the focus guard moves focus into the newly opened modal drawer.
-      shouldRestoreSidebarToggleFocusRef.current =
-        isToggleButtonFocused || !compactSidebarOpen
+      // User-triggered compact toggles (toggle button or keyboard shortcut)
+      // always restore focus so the focus guard moves focus to the visible
+      // toggle. This prevents focus from being lost to document.body when
+      // closing the drawer from inside its content.
+      shouldRestoreSidebarToggleFocusRef.current = true
       setCompactSidebarOpen((open) => !open)
 
       return
@@ -368,7 +368,7 @@ export const WorkspaceView = (): ReactElement => {
 
     shouldRestoreSidebarToggleFocusRef.current = isToggleButtonFocused
     toggleSidebar()
-  }, [isCompactViewport, toggleSidebar, compactSidebarOpen])
+  }, [isCompactViewport, toggleSidebar])
 
   // Post-toggle focus guard: collapse/expand removes the active toggle from the
   // tab order (open toggle's shell goes inert; collapsed toggle's slot unmounts),

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -326,6 +326,7 @@ export const WorkspaceView = (): ReactElement => {
       }
 
       event.preventDefault()
+      shouldRestoreSidebarToggleFocusRef.current = true
       setCompactSidebarOpen(false)
     }
 
@@ -1767,6 +1768,7 @@ export const WorkspaceView = (): ReactElement => {
           rather than climbing to the viewport. */}
       <div
         ref={mainWorkspaceRef}
+        data-testid="workspace-main"
         className="relative flex flex-col overflow-hidden bg-background"
         inert={isCompactViewport && !isSidebarClosed ? true : undefined}
         aria-hidden={isCompactViewport && !isSidebarClosed ? true : undefined}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -170,6 +170,12 @@ const SIDEBAR_MOTION_MS = 220
 const SIDEBAR_MOTION_EASING = 'cubic-bezier(0.32, 0.72, 0, 1)'
 
 const SIDEBAR_INITIAL = clampSize(SIDEBAR_DEFAULT, SIDEBAR_MIN, SIDEBAR_MAX)
+const COMPACT_WORKSPACE_QUERY = '(max-width: 899px)'
+
+const readCompactViewport = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia(COMPACT_WORKSPACE_QUERY).matches
 
 const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
   { id: 'sessions', label: 'SESSIONS', icon: 'view_agenda' },
@@ -277,16 +283,91 @@ export const WorkspaceView = (): ReactElement => {
     setCollapsed: setSidebarCollapsed,
   } = useSidebarCollapsed()
 
+  const [isCompactViewport, setIsCompactViewport] =
+    useState(readCompactViewport)
+  const [compactSidebarOpen, setCompactSidebarOpen] = useState(false)
+
+  useEffect(() => {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.matchMedia !== 'function'
+    ) {
+      return
+    }
+
+    const mediaQuery = window.matchMedia(COMPACT_WORKSPACE_QUERY)
+
+    const applyViewport = (): void => {
+      setIsCompactViewport(mediaQuery.matches)
+    }
+
+    applyViewport()
+    mediaQuery.addEventListener('change', applyViewport)
+
+    return (): void => {
+      mediaQuery.removeEventListener('change', applyViewport)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isCompactViewport) {
+      setCompactSidebarOpen(false)
+    }
+  }, [isCompactViewport])
+
+  useEffect(() => {
+    if (!isCompactViewport || !compactSidebarOpen) {
+      return
+    }
+
+    const closeOnEscape = (event: globalThis.KeyboardEvent): void => {
+      if (event.key !== 'Escape') {
+        return
+      }
+
+      event.preventDefault()
+      setCompactSidebarOpen(false)
+    }
+
+    document.addEventListener('keydown', closeOnEscape)
+
+    return (): void => {
+      document.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [compactSidebarOpen, isCompactViewport])
+
+  const isSidebarClosed = isCompactViewport
+    ? !compactSidebarOpen
+    : sidebarCollapsed
+
   // Imperative refs to the two SidebarToggle instances so the post-toggle focus
   // guard can refocus the visible one without relying on data-testid selectors.
   const sidebarToggleTopbarRef = useRef<HTMLButtonElement>(null)
   const sidebarToggleTabsRef = useRef<HTMLButtonElement>(null)
+  const shouldRestoreSidebarToggleFocusRef = useRef(false)
+
+  const handleToggleSidebar = useCallback((): void => {
+    const activeElement =
+      typeof document === 'undefined' ? null : document.activeElement
+    shouldRestoreSidebarToggleFocusRef.current =
+      activeElement === sidebarToggleTopbarRef.current ||
+      activeElement === sidebarToggleTabsRef.current
+
+    if (isCompactViewport) {
+      setCompactSidebarOpen((open) => !open)
+
+      return
+    }
+
+    toggleSidebar()
+  }, [isCompactViewport, toggleSidebar])
 
   // Post-toggle focus guard: collapse/expand removes the active toggle from the
   // tab order (open toggle's shell goes inert; collapsed toggle's slot unmounts),
-  // dropping focus to <body>. Refocus the now-visible toggle when that happens.
-  // Skips the initial mount; deferred a frame so it runs after the inert flip /
-  // palette focus-restore settles.
+  // dropping focus to <body>. Refocus the now-visible toggle only when the user
+  // actually toggled from one of the toggle buttons. Plain viewport changes
+  // during first app launch must not programmatically focus the toggle and show
+  // a sticky ring.
   const sidebarFocusGuardMountedRef = useRef(false)
   useEffect(() => {
     if (!sidebarFocusGuardMountedRef.current) {
@@ -294,14 +375,20 @@ export const WorkspaceView = (): ReactElement => {
 
       return
     }
+    if (!shouldRestoreSidebarToggleFocusRef.current) {
+      return
+    }
     if (typeof requestAnimationFrame !== 'function') {
+      shouldRestoreSidebarToggleFocusRef.current = false
+
       return
     }
 
     const frame = requestAnimationFrame((): void => {
+      shouldRestoreSidebarToggleFocusRef.current = false
       const active = document.activeElement
       if (!active || active === document.body) {
-        const target = sidebarCollapsed
+        const target = isSidebarClosed
           ? sidebarToggleTabsRef.current
           : sidebarToggleTopbarRef.current
         target?.focus()
@@ -311,7 +398,7 @@ export const WorkspaceView = (): ReactElement => {
     return (): void => {
       cancelAnimationFrame(frame)
     }
-  }, [sidebarCollapsed])
+  }, [isSidebarClosed])
 
   const paneRenameRequestIdRef = useRef(0)
 
@@ -937,7 +1024,7 @@ export const WorkspaceView = (): ReactElement => {
         isCurrentPaneRenameRequest,
         setActiveSessionId,
         notifyInfo,
-        toggleSidebar,
+        toggleSidebar: handleToggleSidebar,
       }),
     // sessionsSignature captures every field the closures read; activity-only
     // changes keep the signature stable so the memo (and downstream
@@ -957,7 +1044,7 @@ export const WorkspaceView = (): ReactElement => {
       isCurrentPaneRenameRequest,
       setActiveSessionId,
       notifyInfo,
-      toggleSidebar,
+      handleToggleSidebar,
     ]
   )
 
@@ -983,7 +1070,7 @@ export const WorkspaceView = (): ReactElement => {
   })
 
   useSidebarShortcut({
-    onToggle: toggleSidebar,
+    onToggle: handleToggleSidebar,
     modKey: preferModifier === 'meta' ? '⌘' : 'Ctrl',
     activeContainerId,
   })
@@ -1527,40 +1614,62 @@ export const WorkspaceView = (): ReactElement => {
       // `grid-rows-1` pins the implicit row to `1fr`; without it
       // `grid-auto-rows: auto` lets the row grow to content size and
       // `h-full` stops propagating the 100vh constraint downward.
-      className="grid h-screen grid-rows-1 overflow-hidden"
+      className="relative grid h-screen grid-rows-1 overflow-hidden"
       style={
         {
           // `--workspace-sidebar-width` is owned by previewSidebarWidth so
           // React rerenders cannot overwrite an in-progress drag preview.
           // VIM-76: icon rail removed — layout is [sidebar | main | activity].
-          // The sidebar `auto` track follows the shell width; collapse animates
-          // that shell to 0 so <main> reclaims the space like a responsive page.
-          gridTemplateColumns: `auto 1fr auto`,
+          // Desktop collapse animates the sidebar shell width; compact viewports
+          // switch to a single-column workspace with the sidebar as an overlay.
+          gridTemplateColumns: isCompactViewport ? '1fr' : `auto 1fr auto`,
         } as CSSProperties
       }
     >
-      {/* Sidebar — the shell clips the inner panel during animated collapse.
-          Live drag previews stay direct; only non-drag collapse/expand motions
-          use the page-turn width transition. The collapse toggle's collapsed-
-          state home is the session-tab bar's leading slot (below), not a
-          floating overlay. */}
+      {isCompactViewport && !isSidebarClosed && (
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label="Close sidebar"
+          data-testid="sidebar-scrim"
+          onClick={() => {
+            setCompactSidebarOpen(false)
+          }}
+          className="fixed inset-0 z-20 cursor-default bg-background/55 backdrop-blur-[2px]"
+        />
+      )}
+
+      {/* Sidebar — the shell clips the inner panel during animated desktop
+          collapse; compact viewports lift the same shell above main content. */}
       <div
-        aria-hidden={sidebarCollapsed || undefined}
-        inert={sidebarCollapsed || undefined}
+        aria-hidden={isSidebarClosed || undefined}
+        inert={isSidebarClosed || undefined}
         data-testid="workspace-sidebar-shell"
         className={`relative h-full overflow-hidden will-change-[width] ${
-          isDragging ? '' : 'transition-[width] duration-[220ms] ease-pane'
+          isDragging || isCompactViewport
+            ? ''
+            : 'transition-[width] duration-[220ms] ease-pane'
         }`}
         style={{
-          width: sidebarCollapsed
+          position: isCompactViewport ? 'absolute' : undefined,
+          zIndex: isCompactViewport ? 30 : undefined,
+          left: isCompactViewport ? 0 : undefined,
+          top: isCompactViewport ? 0 : undefined,
+          bottom: isCompactViewport ? 0 : undefined,
+          maxWidth: isCompactViewport ? '100vw' : undefined,
+          width: isSidebarClosed
             ? 0
-            : `var(--workspace-sidebar-width, ${SIDEBAR_INITIAL}px)`,
+            : isCompactViewport
+              ? `min(100vw, var(--workspace-sidebar-width, ${SIDEBAR_INITIAL}px))`
+              : `var(--workspace-sidebar-width, ${SIDEBAR_INITIAL}px)`,
         }}
       >
         <div
           className="relative flex h-full"
           style={{
-            width: `var(--workspace-sidebar-width, ${SIDEBAR_INITIAL}px)`,
+            width: isCompactViewport
+              ? `min(100vw, var(--workspace-sidebar-width, ${SIDEBAR_INITIAL}px))`
+              : `var(--workspace-sidebar-width, ${SIDEBAR_INITIAL}px)`,
           }}
         >
           <Sidebar
@@ -1569,7 +1678,7 @@ export const WorkspaceView = (): ReactElement => {
             // real top-bar controls still unmount so their portaled tooltips
             // cannot escape the inert, clipped sidebar shell.
             topBar={
-              sidebarCollapsed ? (
+              isSidebarClosed ? (
                 <div
                   aria-hidden="true"
                   data-testid="sidebar-top-bar-placeholder"
@@ -1578,7 +1687,7 @@ export const WorkspaceView = (): ReactElement => {
                 />
               ) : (
                 <SidebarTopBar
-                  onToggleSidebar={toggleSidebar}
+                  onToggleSidebar={handleToggleSidebar}
                   onCommand={commandPalette.open}
                   commandShortcutHint={commandShortcutHint}
                   sidebarShortcutHint={sidebarShortcutHint}
@@ -1631,7 +1740,7 @@ export const WorkspaceView = (): ReactElement => {
           />
 
           {/* Resize handle (hidden while collapsed) */}
-          {!sidebarCollapsed && (
+          {!isSidebarClosed && !isCompactViewport && (
             <div
               ref={setSidebarResizeHandle}
               data-testid="sidebar-resize-handle"
@@ -1659,10 +1768,14 @@ export const WorkspaceView = (): ReactElement => {
       <div
         ref={mainWorkspaceRef}
         className="relative flex flex-col overflow-hidden bg-background"
+        inert={isCompactViewport && !isSidebarClosed ? true : undefined}
+        aria-hidden={isCompactViewport && !isSidebarClosed ? true : undefined}
         style={{
-          borderTopLeftRadius: sidebarCollapsed ? 0 : 16,
-          borderBottomLeftRadius: sidebarCollapsed ? 0 : 16,
-          boxShadow: sidebarCollapsed
+          borderTopLeftRadius:
+            sidebarCollapsed || isCompactViewport ? 0 : 16,
+          borderBottomLeftRadius:
+            sidebarCollapsed || isCompactViewport ? 0 : 16,
+          boxShadow: sidebarCollapsed || isCompactViewport
             ? 'none'
             : '-18px 0 36px rgba(0,0,0,0.22)',
           transition: isDragging
@@ -1678,11 +1791,11 @@ export const WorkspaceView = (): ReactElement => {
           onClose={handleRemoveSession}
           onNew={handleCreateSession}
           leading={
-            sidebarCollapsed ? (
+            isSidebarClosed ? (
               <SidebarToggle
                 ref={sidebarToggleTabsRef}
                 collapsed
-                onClick={toggleSidebar}
+                onClick={handleToggleSidebar}
                 size={28}
                 variant="inset"
                 data-testid="sidebar-toggle-tabs"
@@ -1769,42 +1882,44 @@ export const WorkspaceView = (): ReactElement => {
         />
       </div>
 
-      <div
-        data-testid="activity-panel-shell"
-        className="h-full shrink-0 overflow-hidden transition-[width] duration-[220ms] ease-pane"
-        style={{
-          width: activityPanelCollapsed ? RAIL_WIDTH_PX : PANEL_WIDTH_PX,
-        }}
-      >
-        {activityPanelCollapsed ? (
-          <AgentStatusRail
-            agent={activityPanelAgent}
-            contextUsedPercentage={
-              agentStatus.contextWindow?.usedPercentage ?? null
-            }
-            cacheHitPercentage={cacheHitPercentage(
-              agentStatus.contextWindow?.currentUsage
-            )}
-            isRunning={agentStatus.isActive}
-            onExpand={() => {
-              handleActivityPanelCollapsed(false)
-            }}
-          />
-        ) : (
-          <AgentStatusPanel
-            agentStatus={agentStatus}
-            cwd={activeCwd}
-            gitStatus={gitStatus}
-            onOpenDiff={handleOpenDiff}
-            onOpenFile={handleOpenTestFile}
-            agent={activityPanelAgent}
-            status={activityPanelStatus}
-            onCollapse={() => {
-              handleActivityPanelCollapsed(true)
-            }}
-          />
-        )}
-      </div>
+      {!isCompactViewport && (
+        <div
+          data-testid="activity-panel-shell"
+          className="h-full shrink-0 overflow-hidden transition-[width] duration-[220ms] ease-pane"
+          style={{
+            width: activityPanelCollapsed ? RAIL_WIDTH_PX : PANEL_WIDTH_PX,
+          }}
+        >
+          {activityPanelCollapsed ? (
+            <AgentStatusRail
+              agent={activityPanelAgent}
+              contextUsedPercentage={
+                agentStatus.contextWindow?.usedPercentage ?? null
+              }
+              cacheHitPercentage={cacheHitPercentage(
+                agentStatus.contextWindow?.currentUsage
+              )}
+              isRunning={agentStatus.isActive}
+              onExpand={() => {
+                handleActivityPanelCollapsed(false)
+              }}
+            />
+          ) : (
+            <AgentStatusPanel
+              agentStatus={agentStatus}
+              cwd={activeCwd}
+              gitStatus={gitStatus}
+              onOpenDiff={handleOpenDiff}
+              onOpenFile={handleOpenTestFile}
+              agent={activityPanelAgent}
+              status={activityPanelStatus}
+              onCollapse={() => {
+                handleActivityPanelCollapsed(true)
+              }}
+            />
+          )}
+        </div>
+      )}
 
       {/* Unsaved Changes Dialog — shows the CURRENTLY dirty file, not the
           destination the user is switching to. */}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1779,13 +1779,13 @@ export const WorkspaceView = (): ReactElement => {
         inert={isCompactViewport && !isSidebarClosed ? true : undefined}
         aria-hidden={isCompactViewport && !isSidebarClosed ? true : undefined}
         style={{
-          borderTopLeftRadius:
-            sidebarCollapsed || isCompactViewport ? 0 : 16,
+          borderTopLeftRadius: sidebarCollapsed || isCompactViewport ? 0 : 16,
           borderBottomLeftRadius:
             sidebarCollapsed || isCompactViewport ? 0 : 16,
-          boxShadow: sidebarCollapsed || isCompactViewport
-            ? 'none'
-            : '-18px 0 36px rgba(0,0,0,0.22)',
+          boxShadow:
+            sidebarCollapsed || isCompactViewport
+              ? 'none'
+              : '-18px 0 36px rgba(0,0,0,0.22)',
           transition: isDragging
             ? 'none'
             : `border-radius ${SIDEBAR_MOTION_MS}ms ${SIDEBAR_MOTION_EASING}, box-shadow ${SIDEBAR_MOTION_MS}ms ${SIDEBAR_MOTION_EASING}`,

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -309,6 +309,12 @@ export const WorkspaceView = (): ReactElement => {
     }
   }, [])
 
+  // Imperative refs to the two SidebarToggle instances so the post-toggle focus
+  // guard can refocus the visible one without relying on data-testid selectors.
+  const sidebarToggleTopbarRef = useRef<HTMLButtonElement>(null)
+  const sidebarToggleTabsRef = useRef<HTMLButtonElement>(null)
+  const shouldRestoreSidebarToggleFocusRef = useRef(false)
+
   useEffect(() => {
     if (!isCompactViewport) {
       setCompactSidebarOpen(false)
@@ -341,27 +347,27 @@ export const WorkspaceView = (): ReactElement => {
     ? !compactSidebarOpen
     : sidebarCollapsed
 
-  // Imperative refs to the two SidebarToggle instances so the post-toggle focus
-  // guard can refocus the visible one without relying on data-testid selectors.
-  const sidebarToggleTopbarRef = useRef<HTMLButtonElement>(null)
-  const sidebarToggleTabsRef = useRef<HTMLButtonElement>(null)
-  const shouldRestoreSidebarToggleFocusRef = useRef(false)
-
   const handleToggleSidebar = useCallback((): void => {
     const activeElement =
       typeof document === 'undefined' ? null : document.activeElement
-    shouldRestoreSidebarToggleFocusRef.current =
+    const isToggleButtonFocused =
       activeElement === sidebarToggleTopbarRef.current ||
       activeElement === sidebarToggleTabsRef.current
 
     if (isCompactViewport) {
+      // When opening the compact sidebar from a non-toggle element (e.g. via
+      // keyboard shortcut from terminal/editor), force focus restoration so
+      // the focus guard moves focus into the newly opened modal drawer.
+      shouldRestoreSidebarToggleFocusRef.current =
+        isToggleButtonFocused || !compactSidebarOpen
       setCompactSidebarOpen((open) => !open)
 
       return
     }
 
+    shouldRestoreSidebarToggleFocusRef.current = isToggleButtonFocused
     toggleSidebar()
-  }, [isCompactViewport, toggleSidebar])
+  }, [isCompactViewport, toggleSidebar, compactSidebarOpen])
 
   // Post-toggle focus guard: collapse/expand removes the active toggle from the
   // tab order (open toggle's shell goes inert; collapsed toggle's slot unmounts),

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1634,6 +1634,7 @@ export const WorkspaceView = (): ReactElement => {
           aria-label="Close sidebar"
           data-testid="sidebar-scrim"
           onClick={() => {
+            shouldRestoreSidebarToggleFocusRef.current = true
             setCompactSidebarOpen(false)
           }}
           className="fixed inset-0 z-20 cursor-default bg-background/55 backdrop-blur-[2px]"
@@ -1646,6 +1647,11 @@ export const WorkspaceView = (): ReactElement => {
         aria-hidden={isSidebarClosed || undefined}
         inert={isSidebarClosed || undefined}
         data-testid="workspace-sidebar-shell"
+        role={isCompactViewport && !isSidebarClosed ? 'dialog' : undefined}
+        aria-modal={isCompactViewport && !isSidebarClosed ? true : undefined}
+        aria-label={
+          isCompactViewport && !isSidebarClosed ? 'Sidebar' : undefined
+        }
         className={`relative h-full overflow-hidden will-change-[width] ${
           isDragging || isCompactViewport
             ? ''

--- a/src/features/workspace/components/SidebarToggle.test.tsx
+++ b/src/features/workspace/components/SidebarToggle.test.tsx
@@ -100,6 +100,14 @@ describe('SidebarToggle', () => {
     expect(screen.getByRole('button')).toHaveClass('bg-[rgba(13,13,28,0.45)]')
   })
 
+  test('variant=inset: keeps the button border transparent', () => {
+    renderToggle({ collapsed: false, variant: 'inset' })
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('border-transparent')
+    expect(button).not.toHaveClass('border-[rgba(74,68,79,0.35)]')
+  })
+
   test('default variant (ghost): className omits the inset background', () => {
     renderToggle({ collapsed: false })
 

--- a/src/features/workspace/components/SidebarToggle.tsx
+++ b/src/features/workspace/components/SidebarToggle.tsx
@@ -12,8 +12,8 @@ export interface SidebarToggleProps {
   size?: number
   /**
    * `ghost` (default): transparent with a hover tint — for the icon rail.
-   * `inset`: a recessed well (fill + border, lavender hover border) so the
-   * control reads as belonging to the card it is docked inside.
+   * `inset`: a recessed well (fill only, no visible border) so the control
+   * belongs to the top bar without leaving a sticky outline after focus restore.
    */
   variant?: SidebarToggleVariant
   'data-testid'?: string
@@ -25,7 +25,7 @@ const VARIANT_CLASS: Record<SidebarToggleVariant, string> = {
   ghost:
     'border border-transparent text-on-surface-muted hover:bg-primary/[0.08] hover:text-primary',
   inset:
-    'border border-[rgba(74,68,79,0.35)] bg-[rgba(13,13,28,0.45)] text-on-surface-muted hover:bg-[rgba(226,199,255,0.08)] hover:text-primary',
+    'border border-transparent bg-[rgba(13,13,28,0.45)] text-on-surface-muted hover:bg-[rgba(226,199,255,0.08)] hover:text-primary',
 }
 
 // Codex / VS-Code-style "panel-left" glyph. Outline + left-rail divider are

--- a/src/features/workspace/hooks/useSidebarShortcut.test.ts
+++ b/src/features/workspace/hooks/useSidebarShortcut.test.ts
@@ -119,10 +119,11 @@ describe('useSidebarShortcut', () => {
     })
   })
 
-  test('bails when a dialog matching DIALOG_SELECTOR is in the DOM', () => {
+  test('bails when a real dialog matching DIALOG_SELECTOR is in the DOM', () => {
     const props = makeProps({ modKey: '⌘' })
     const dialog = document.createElement('div')
     dialog.setAttribute('role', 'dialog')
+    dialog.setAttribute('aria-label', 'Unsaved changes')
     append(dialog)
     const target = append(document.createElement('div'))
     renderHook(() => useSidebarShortcut(props))
@@ -130,6 +131,21 @@ describe('useSidebarShortcut', () => {
     fireFrom(target, { metaKey: true })
 
     expect(props.onToggle).not.toHaveBeenCalled()
+  })
+
+  test('toggles when the compact sidebar drawer (role=dialog aria-label=Sidebar) is open', () => {
+    const props = makeProps({ modKey: 'Ctrl' })
+    const sidebarDialog = document.createElement('div')
+    sidebarDialog.setAttribute('role', 'dialog')
+    sidebarDialog.setAttribute('aria-label', 'Sidebar')
+    const target = document.createElement('button')
+    sidebarDialog.appendChild(target)
+    append(sidebarDialog)
+    renderHook(() => useSidebarShortcut(props))
+
+    fireFrom(target, { ctrlKey: true, shiftKey: true })
+
+    expect(props.onToggle).toHaveBeenCalledOnce()
   })
 
   test('meta: bails when dock is active and target is inside the dock', () => {

--- a/src/features/workspace/hooks/useSidebarShortcut.ts
+++ b/src/features/workspace/hooks/useSidebarShortcut.ts
@@ -56,16 +56,24 @@ export const useSidebarShortcut = ({
         return
       }
 
-      if (document.querySelector(DIALOG_SELECTOR)) {
-        return
-      }
-
       const target =
         event.target instanceof Element
           ? event.target
           : document.activeElement instanceof Element
             ? document.activeElement
             : document.body
+
+      // Bail on real dialogs (command palette, unsaved-changes, etc.), but
+      // allow the shortcut when the compact sidebar drawer is open — it has
+      // role="dialog" for a11y, yet the sidebar shortcut must still close it.
+      const openDialogs = document.querySelectorAll(DIALOG_SELECTOR)
+
+      const inSidebarDialog = !!target.closest(
+        '[role="dialog"][aria-label="Sidebar"]'
+      )
+      if (openDialogs.length > 0 && !inSidebarDialog) {
+        return
+      }
 
       // On macOS, defer to the dock's ⌘B (close dock) when the dock is focused.
       if (


### PR DESCRIPTION
## Summary

This PR carries the responsive/a11y pass for the sidebar and workspace shell on top of `feat/vim-66-sidebar`.

- Makes the compact workspace use a single-column canvas with a dismissible sidebar drawer and hides the activity panel on narrow viewports.
- Improves focus, contrast, target-size, and sidebar-toggle behavior, including the terminal focus-ring stacking fix and the sticky toggle-border fix.
- Adds the `a11y-responsive-review` review skill and records the audit findings/fixes in docs.
- Updates sidebar/session/status components and tests to match the new accessible shell behavior.

## Why

Narrow viewport and assistive-use flows had several usability regressions: the sidebar could be covered by terminal focus chrome, the toggle could show a sticky border after startup or Super-key interaction, and compact layouts needed stronger drawer semantics, keyboard dismissal, contrast, and target-size coverage.

## Validation

- `git diff --check HEAD`
- `npm run build`
- `npm run backend:build`
- `npx vitest run src/features/workspace/components/SidebarToggle.test.tsx`
- `npx vitest run src/features/workspace/WorkspaceView.test.tsx`
- `npx vitest run tailwind.config.test.js src/features/workspace/components/DockPanel.test.tsx`
- pre-push `npm run test`: 258 files passed, 3508 tests passed, 3 skipped
- CDP visual checks at 390px for sidebar drawer, terminal focus-ring stacking, toggle hover + Meta/Super state, and first compact startup focus state