### PR TITLE
Stabilize compact sidebar cards

### DIFF
--- a/src/components/sidebar/SidebarTabs.test.tsx
+++ b/src/components/sidebar/SidebarTabs.test.tsx
@@ -112,6 +112,17 @@ describe('SidebarTabs', () => {
     )
   })
 
+  test('uses the default sidebar width instead of flexing with the sidebar', () => {
+    render(
+      <SidebarTabs<Tab> tabs={TABS} activeId="sessions" onChange={vi.fn()} />
+    )
+
+    const tabs = screen.getByTestId('sidebar-tabs')
+    expect(tabs).toHaveStyle({ width: '202px' })
+    expect(tabs).toHaveClass('shrink-0')
+    expect(tabs).not.toHaveClass('flex-1')
+  })
+
   test('aria-label can be overridden', () => {
     render(
       <SidebarTabs<Tab>

--- a/src/components/sidebar/SidebarTabs.tsx
+++ b/src/components/sidebar/SidebarTabs.tsx
@@ -18,6 +18,12 @@ export interface SidebarTabsProps<TId extends string = string> {
 // active segment is a sliding lavender thumb behind the buttons, not a per-tab
 // border. role="group" + aria-pressed — v1 ships no roving/arrow keyboard
 // contract, so this stays an honest group rather than a tablist/toolbar.
+//
+// 202px is the default sidebar row width left over for this switcher:
+// 272px sidebar - 24px row padding - 8px gap - 38px new-session button.
+// Keep it fixed so resizing the sidebar never stretches or squashes the tabs.
+const SIDEBAR_TABS_W = 202
+
 export const SidebarTabs = <TId extends string = string>({
   tabs,
   activeId,
@@ -40,7 +46,8 @@ export const SidebarTabs = <TId extends string = string>({
       role="group"
       aria-label={ariaLabel}
       data-testid={testId}
-      className="relative flex min-w-0 flex-1 rounded-[10px] border border-[rgba(74,68,79,0.3)] bg-[rgba(13,13,28,0.7)] p-[3px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.4)]"
+      style={{ width: SIDEBAR_TABS_W }}
+      className="relative flex min-w-0 shrink-0 rounded-[10px] border border-[rgba(74,68,79,0.3)] bg-[rgba(13,13,28,0.7)] p-[3px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.4)]"
     >
       <div
         aria-hidden="true"

--- a/src/features/sessions/components/Card.tsx
+++ b/src/features/sessions/components/Card.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, type ReactElement } from 'react'
+import { memo, useState, useRef, useEffect, type ReactElement } from 'react'
 import { Reorder } from 'framer-motion'
 import type { Session } from '../types'
 import { useRenameState } from '../hooks/useRenameState'
@@ -14,7 +14,12 @@ export interface CardProps {
   onClick: (id: string) => void
   onRemove?: (id: string) => void
   onRename?: (id: string, name: string) => void
+  reorderMotionEnabled?: boolean
+  onReorderDragStart?: () => void
+  onReorderDragEnd?: () => void
 }
+
+type ReorderItemLayout = true | 'position' | undefined
 
 // Status → flat colored text (no chip pill, no dot), per handoff §3.3.
 const STATUS_TEXT: Record<Session['status'], { tone: string; label: string }> =
@@ -25,6 +30,13 @@ const STATUS_TEXT: Record<Session['status'], { tone: string; label: string }> =
     completed: { tone: '#c9b3f0', label: 'Done' },
     errored: { tone: '#ffb4ab', label: 'Errored' },
   }
+
+// Reorder.Item's public type in this Framer version omits `false`, but the
+// component forwards `layout` to motion.li where `false` is the supported way
+// to keep projection layout disabled. Without an explicit false, Reorder.Item's
+// internal default is `layout = true`.
+const REORDER_LAYOUT_OFF = false as unknown as ReorderItemLayout
+const REORDER_DRAG_INTENT_THRESHOLD_PX = 4
 
 const MenuRow = ({
   icon,
@@ -53,14 +65,20 @@ const MenuRow = ({
   </button>
 )
 
-export const Card = ({
+const CardComponent = ({
   session,
   variant,
   isActive = false,
   onClick,
   onRemove = undefined,
   onRename = undefined,
+  reorderMotionEnabled = false,
+  onReorderDragStart = undefined,
+  onReorderDragEnd = undefined,
 }: CardProps): ReactElement => {
+  const dragStartPointRef = useRef<{ x: number; y: number } | null>(null)
+  const reorderDragIntentActiveRef = useRef(false)
+
   const {
     isEditing,
     editValue,
@@ -72,6 +90,26 @@ export const Card = ({
   } = useRenameState(session, onRename)
   const [menuOpen, setMenuOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
+
+  const beginReorderDragIntent = (): void => {
+    if (reorderDragIntentActiveRef.current) {
+      return
+    }
+
+    reorderDragIntentActiveRef.current = true
+    onReorderDragStart?.()
+  }
+
+  const finishReorderDragIntent = (): void => {
+    dragStartPointRef.current = null
+
+    if (!reorderDragIntentActiveRef.current) {
+      return
+    }
+
+    reorderDragIntentActiveRef.current = false
+    onReorderDragEnd?.()
+  }
 
   // Close the actions menu on Escape and return focus to the trigger button.
   useEffect(() => {
@@ -298,7 +336,43 @@ export const Card = ({
           boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
           zIndex: 50,
         }}
-        layout="position"
+        layout={reorderMotionEnabled ? 'position' : REORDER_LAYOUT_OFF}
+        onPointerDownCapture={(e) => {
+          if (e.button > 0) {
+            return
+          }
+
+          dragStartPointRef.current = { x: e.clientX, y: e.clientY }
+          reorderDragIntentActiveRef.current = false
+        }}
+        onPointerMoveCapture={(e) => {
+          const dragStartPoint = dragStartPointRef.current
+          if (dragStartPoint === null || reorderDragIntentActiveRef.current) {
+            return
+          }
+
+          const distance = Math.hypot(
+            e.clientX - dragStartPoint.x,
+            e.clientY - dragStartPoint.y
+          )
+          if (distance < REORDER_DRAG_INTENT_THRESHOLD_PX) {
+            return
+          }
+
+          beginReorderDragIntent()
+        }}
+        onPointerUpCapture={() => {
+          finishReorderDragIntent()
+        }}
+        onPointerCancelCapture={() => {
+          finishReorderDragIntent()
+        }}
+        onDragStart={() => {
+          beginReorderDragIntent()
+        }}
+        onDragEnd={() => {
+          finishReorderDragIntent()
+        }}
       >
         {inner}
       </Reorder.Item>
@@ -316,3 +390,6 @@ export const Card = ({
     </li>
   )
 }
+
+export const Card = memo(CardComponent)
+Card.displayName = 'Card'

--- a/src/features/sessions/components/List.motion.test.tsx
+++ b/src/features/sessions/components/List.motion.test.tsx
@@ -1,0 +1,225 @@
+import {
+  act,
+  type CSSProperties,
+  type PointerEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { List } from './List'
+import type { Session } from '../types'
+
+interface CapturedReorderItemHandlers {
+  onPointerDownCapture?: (event: PointerEvent<HTMLLIElement>) => void
+  onPointerMoveCapture?: (event: PointerEvent<HTMLLIElement>) => void
+  onPointerUpCapture?: () => void
+  onPointerCancelCapture?: () => void
+}
+
+const capturedReorderItemHandlers = vi.hoisted(
+  (): CapturedReorderItemHandlers[] => []
+)
+
+vi.mock('framer-motion', () => {
+  interface MockReorderGroupProps {
+    children: ReactNode
+    className?: string
+    'data-testid'?: string
+  }
+
+  interface MockReorderItemProps {
+    children: ReactNode
+    className?: string
+    style?: CSSProperties
+    layout?: boolean | 'position'
+    onPointerDownCapture?: (event: PointerEvent<HTMLLIElement>) => void
+    onPointerMoveCapture?: (event: PointerEvent<HTMLLIElement>) => void
+    onPointerUpCapture?: () => void
+    onPointerCancelCapture?: () => void
+    'data-testid'?: string
+    'data-session-id'?: string
+    'data-active'?: boolean
+  }
+
+  interface MockMotionDivProps {
+    children: ReactNode
+    className?: string
+    layoutScroll?: boolean
+    'data-testid'?: string
+  }
+
+  return {
+    Reorder: {
+      Group: ({
+        children,
+        className = undefined,
+        'data-testid': testId = undefined,
+      }: MockReorderGroupProps): ReactElement => {
+        capturedReorderItemHandlers.length = 0
+
+        return (
+          <ul className={className} data-testid={testId}>
+            {children}
+          </ul>
+        )
+      },
+      Item: ({
+        children,
+        className = undefined,
+        style = undefined,
+        layout = undefined,
+        onPointerDownCapture = undefined,
+        onPointerMoveCapture = undefined,
+        onPointerUpCapture = undefined,
+        onPointerCancelCapture = undefined,
+        'data-testid': testId = undefined,
+        'data-session-id': sessionId = undefined,
+        'data-active': active = undefined,
+      }: MockReorderItemProps): ReactElement => {
+        capturedReorderItemHandlers.push({
+          onPointerDownCapture,
+          onPointerMoveCapture,
+          onPointerUpCapture,
+          onPointerCancelCapture,
+        })
+
+        return (
+          <li
+            className={className}
+            data-active={active === undefined ? undefined : String(active)}
+            data-layout={layout === false ? 'false' : (layout ?? 'unset')}
+            data-session-id={sessionId}
+            data-testid={testId}
+            style={style}
+          >
+            {children}
+          </li>
+        )
+      },
+    },
+    motion: {
+      div: ({
+        children,
+        className = undefined,
+        'data-testid': testId = undefined,
+      }: MockMotionDivProps): ReactElement => (
+        <div className={className} data-testid={testId}>
+          {children}
+        </div>
+      ),
+    },
+  }
+})
+
+const session = (overrides: Partial<Session> = {}): Session =>
+  ({
+    id: 'sess-1',
+    projectId: 'proj-1',
+    name: 'auth middleware',
+    status: 'running',
+    workingDirectory: '/home/user/projects/Vimeflow',
+    agentType: 'claude-code',
+    layout: 'single',
+    terminalPid: 12345,
+    panes: [
+      {
+        id: 'p0',
+        ptyId: 'sess-1',
+        cwd: '/home/user/projects/Vimeflow',
+        agentType: 'claude-code',
+        status: 'running',
+        active: true,
+        pid: 12345,
+      },
+    ],
+    createdAt: '2026-04-07T03:45:00Z',
+    lastActivityAt: '2026-04-07T03:45:00Z',
+    activity: {
+      fileChanges: [],
+      toolCalls: [],
+      testResults: [],
+      contextWindow: { used: 0, total: 200000, percentage: 0, emoji: ':)' },
+      usage: {
+        sessionDuration: 0,
+        turnCount: 0,
+        messages: { sent: 0, limit: 200 },
+        tokens: { input: 0, output: 0, total: 0 },
+      },
+    },
+    ...overrides,
+  }) as Session
+
+const pointerEvent = ({
+  button = 0,
+  clientX,
+  clientY,
+}: {
+  button?: number
+  clientX: number
+  clientY: number
+}): PointerEvent<HTMLLIElement> =>
+  ({ button, clientX, clientY }) as PointerEvent<HTMLLIElement>
+
+describe('List reorder motion', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('enables Reorder.Item layout only during drag and settle', () => {
+    vi.useFakeTimers()
+
+    render(
+      <List
+        sessions={[
+          session({ id: 'sess-1', name: 'first' }),
+          session({ id: 'sess-2', name: 'second' }),
+        ]}
+        activeSessionId="sess-1"
+        onSessionClick={vi.fn()}
+      />
+    )
+
+    const rows = screen.getAllByTestId('session-row')
+    expect(rows[0]).toHaveAttribute('data-layout', 'false')
+    expect(rows[1]).toHaveAttribute('data-layout', 'false')
+
+    capturedReorderItemHandlers[0].onPointerDownCapture?.(
+      pointerEvent({ button: 0, clientX: 0, clientY: 0 })
+    )
+
+    act(() => {
+      capturedReorderItemHandlers[0].onPointerMoveCapture?.(
+        pointerEvent({ clientX: 0, clientY: 3 })
+      )
+    })
+    expect(rows[0]).toHaveAttribute('data-layout', 'false')
+
+    act(() => {
+      capturedReorderItemHandlers[0].onPointerMoveCapture?.(
+        pointerEvent({ clientX: 0, clientY: 5 })
+      )
+    })
+
+    const draggingRows = screen.getAllByTestId('session-row')
+    expect(draggingRows[0]).toHaveAttribute('data-layout', 'position')
+    expect(draggingRows[1]).toHaveAttribute('data-layout', 'position')
+
+    act(() => {
+      capturedReorderItemHandlers[0].onPointerUpCapture?.()
+    })
+
+    expect(screen.getAllByTestId('session-row')[0]).toHaveAttribute(
+      'data-layout',
+      'position'
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(260)
+    })
+
+    const settledRows = screen.getAllByTestId('session-row')
+    expect(settledRows[0]).toHaveAttribute('data-layout', 'false')
+    expect(settledRows[1]).toHaveAttribute('data-layout', 'false')
+  })
+})

--- a/src/features/sessions/components/List.tsx
+++ b/src/features/sessions/components/List.tsx
@@ -1,4 +1,10 @@
-import { useRef, type ReactElement } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react'
 import { motion } from 'framer-motion'
 import type { Session, SessionCloseResult } from '../types'
 import { Card } from './Card'
@@ -15,6 +21,8 @@ export interface ListProps {
   onRenameSession?: (sessionId: string, name: string) => void
   onReorderSessions?: (sessions: Session[]) => void
 }
+
+const REORDER_MOTION_SETTLE_MS = 260
 
 export const List = ({
   sessions,
@@ -44,6 +52,42 @@ export const List = ({
   const recentGroupRef = useRef(recentGroup)
   recentGroupRef.current = recentGroup
 
+  const [reorderMotionEnabled, setReorderMotionEnabled] = useState(false)
+
+  const reorderMotionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  )
+
+  const clearReorderMotionTimeout = useCallback((): void => {
+    const timeoutId = reorderMotionTimeoutRef.current
+    if (timeoutId === null) {
+      return
+    }
+
+    clearTimeout(timeoutId)
+    reorderMotionTimeoutRef.current = null
+  }, [])
+
+  const handleReorderDragStart = useCallback((): void => {
+    clearReorderMotionTimeout()
+    setReorderMotionEnabled(true)
+  }, [clearReorderMotionTimeout])
+
+  const handleReorderDragEnd = useCallback((): void => {
+    clearReorderMotionTimeout()
+    reorderMotionTimeoutRef.current = setTimeout(() => {
+      reorderMotionTimeoutRef.current = null
+      setReorderMotionEnabled(false)
+    }, REORDER_MOTION_SETTLE_MS)
+  }, [clearReorderMotionTimeout])
+
+  useEffect(
+    () => (): void => {
+      clearReorderMotionTimeout()
+    },
+    [clearReorderMotionTimeout]
+  )
+
   // Mirror SessionTabs.handleClose using the shared visible-order helper.
   // useSessionManager.removeSession uses `flushSync` internally to apply
   // its own setActiveSessionId mid-call, so we must remove first and
@@ -66,33 +110,40 @@ export const List = ({
   // re-render, then lands focus on the new active row's overlay
   // activation button. Mirrors SessionTabs.handleClose §4.4.3 behavior
   // for keyboard users who navigate via group-focus-within.
-  const handleRemoveSession = onRemoveSession
-    ? (id: string): void => {
-        const nextId =
-          id === activeSessionId
-            ? pickNextVisibleSessionId(sessions, id, activeSessionId)
-            : undefined
-        const didRemove = onRemoveSession(id)
-        if (didRemove === false) {
-          return
-        }
-
-        if (nextId !== undefined) {
-          onSessionClick(nextId)
-          queueMicrotask(() => {
-            // Mirror SessionTabs' `getElementById('session-tab-...')`
-            // pattern: the overlay button carries
-            // `id="sidebar-activate-${session.id}"`, so id-based lookup
-            // is both consistent across the two strips AND avoids the
-            // CSS-attribute-selector escaping path entirely. A session
-            // id containing `"` or `]` would otherwise corrupt the
-            // selector and either silently fail (`querySelector` →
-            // null) or throw `SyntaxError`.
-            document.getElementById(`sidebar-activate-${nextId}`)?.focus()
-          })
-        }
+  const handleRemoveSession = useCallback(
+    (id: string): void => {
+      if (!onRemoveSession) {
+        return
       }
-    : undefined
+
+      const nextId =
+        id === activeSessionId
+          ? pickNextVisibleSessionId(sessions, id, activeSessionId)
+          : undefined
+      const didRemove = onRemoveSession(id)
+      if (didRemove === false) {
+        return
+      }
+
+      if (nextId !== undefined) {
+        onSessionClick(nextId)
+        queueMicrotask(() => {
+          // Mirror SessionTabs' `getElementById('session-tab-...')`
+          // pattern: the overlay button carries
+          // `id="sidebar-activate-${session.id}"`, so id-based lookup
+          // is both consistent across the two strips AND avoids the
+          // CSS-attribute-selector escaping path entirely. A session
+          // id containing `"` or `]` would otherwise corrupt the
+          // selector and either silently fail (`querySelector` →
+          // null) or throw `SyntaxError`.
+          document.getElementById(`sidebar-activate-${nextId}`)?.focus()
+        })
+      }
+    },
+    [activeSessionId, onRemoveSession, onSessionClick, sessions]
+  )
+
+  const cardRemoveSession = onRemoveSession ? handleRemoveSession : undefined
 
   return (
     <>
@@ -140,8 +191,11 @@ export const List = ({
               variant="active"
               isActive={session.id === activeSessionId}
               onClick={onSessionClick}
-              onRemove={handleRemoveSession}
+              onRemove={cardRemoveSession}
               onRename={onRenameSession}
+              reorderMotionEnabled={reorderMotionEnabled}
+              onReorderDragStart={handleReorderDragStart}
+              onReorderDragEnd={handleReorderDragEnd}
             />
           ))}
         </Group>
@@ -157,7 +211,7 @@ export const List = ({
                   variant="recent"
                   isActive={session.id === activeSessionId}
                   onClick={onSessionClick}
-                  onRemove={handleRemoveSession}
+                  onRemove={cardRemoveSession}
                   onRename={onRenameSession}
                 />
               ))}

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -19,6 +19,10 @@ import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 import { usePaneShortcuts } from '../terminal/hooks/usePaneShortcuts'
 import { setSidebarCollapsed } from './utils/sidebarCollapsedStore'
 import type { SessionList } from '../../bindings'
+import {
+  MockResizeObserver,
+  installMockResizeObserver,
+} from '../../test/mockResizeObserver'
 
 const workspaceTerminalMock = vi.hoisted(() => {
   const defaultSessionList = (): SessionList => ({
@@ -187,6 +191,26 @@ const makeAgentStatus = (
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => workspaceTerminalMock.service),
 }))
+
+const createDomRect = (width: number, height: number): DOMRect =>
+  ({
+    width,
+    height,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  }) as DOMRect
+
+const findObservedResizeObserver = (
+  element: HTMLElement
+): MockResizeObserver | undefined =>
+  MockResizeObserver.instances.find((instance) =>
+    instance.observe.mock.calls.some(([observed]) => observed === element)
+  )
 
 describe('WorkspaceView', () => {
   beforeEach(() => {
@@ -1238,6 +1262,20 @@ describe('WorkspaceView', () => {
     expect(mainWorkspace).toHaveClass('flex-col')
   })
 
+  test('main workspace uses a rounded sheet edge while the sidebar is visible', () => {
+    render(<WorkspaceView />)
+
+    const workspaceView = screen.getByTestId('workspace-view')
+    const mainWorkspace = workspaceView.children[1] as HTMLElement
+
+    expect(mainWorkspace).toHaveClass('bg-background')
+    expect(mainWorkspace.style.borderTopLeftRadius).toBe('16px')
+    expect(mainWorkspace.style.borderBottomLeftRadius).toBe('16px')
+    expect(mainWorkspace.style.boxShadow).toContain('-18px')
+    expect(mainWorkspace.style.boxShadow).toContain('36px')
+    expect(mainWorkspace.style.transition).toContain('border-radius 220ms')
+  })
+
   test('applies overflow-hidden to prevent scrollbars', () => {
     render(<WorkspaceView />)
 
@@ -1323,9 +1361,16 @@ describe('WorkspaceView', () => {
       const { rerender } = render(<WorkspaceView />)
 
       const workspace = screen.getByTestId('workspace-view')
+      const sidebarShell = screen.getByTestId('workspace-sidebar-shell')
+      const mainWorkspace = workspace.children[1] as HTMLElement
       const handle = screen.getByTestId('sidebar-resize-handle')
 
+      expect(sidebarShell.className).toContain('transition-[width]')
+
       fireEvent.mouseDown(handle, { clientX: 200 })
+
+      expect(sidebarShell.className).not.toContain('transition-[width]')
+      expect(mainWorkspace.style.transition).toBe('none')
 
       fireEvent.mouseMove(document, { clientX: 300 })
 
@@ -1360,6 +1405,108 @@ describe('WorkspaceView', () => {
       expect(handle).toHaveAttribute('aria-valuenow', '372')
     } finally {
       requestAnimationFrameSpy.mockRestore()
+    }
+  })
+
+  test('collapses the sidebar when drag ends below the default minimum width', async () => {
+    render(<WorkspaceView />)
+
+    const workspace = screen.getByTestId('workspace-view')
+    const handle = screen.getByTestId('sidebar-resize-handle')
+
+    expect(workspace.style.getPropertyValue('--workspace-sidebar-width')).toBe(
+      '272px'
+    )
+
+    fireEvent.mouseDown(handle, { clientX: 200 })
+    fireEvent.mouseMove(document, { clientX: 190 })
+    fireEvent.mouseUp(document)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('sidebar-resize-handle')).toBeNull()
+    })
+
+    expect(screen.getByTestId('sidebar-toggle-tabs')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('sidebar-top-bar-placeholder')
+    ).toBeInTheDocument()
+
+    const sidebarShell = screen.getByTestId('workspace-sidebar-shell')
+    const mainWorkspace = workspace.children[1] as HTMLElement
+
+    expect(sidebarShell.className).toContain('transition-[width]')
+    expect(sidebarShell).toHaveStyle({ width: '0px' })
+    expect(mainWorkspace.style.borderTopLeftRadius).toBe('0')
+    expect(mainWorkspace.style.borderBottomLeftRadius).toBe('0')
+  })
+
+  test('collapses the sidebar below the capped main-column threshold on large workspaces', async () => {
+    const originalResizeObserver = globalThis.ResizeObserver
+    installMockResizeObserver()
+
+    try {
+      render(<WorkspaceView />)
+
+      const workspace = screen.getByTestId('workspace-view')
+      const mainWorkspace = workspace.children[1] as HTMLElement
+      vi.spyOn(workspace, 'getBoundingClientRect').mockReturnValue(
+        createDomRect(1600, 900)
+      )
+
+      const observer = findObservedResizeObserver(mainWorkspace)
+      if (!observer) {
+        throw new Error('Expected main workspace ResizeObserver')
+      }
+
+      act(() => {
+        observer.trigger({ width: 499, height: 700 })
+      })
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('sidebar-resize-handle')).toBeNull()
+      })
+
+      expect(screen.getByTestId('sidebar-toggle-tabs')).toBeInTheDocument()
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver
+    }
+  })
+
+  test('keeps the sidebar open until the lower-resolution main-column threshold is crossed', async () => {
+    const originalResizeObserver = globalThis.ResizeObserver
+    installMockResizeObserver()
+
+    try {
+      render(<WorkspaceView />)
+
+      const workspace = screen.getByTestId('workspace-view')
+      const mainWorkspace = workspace.children[1] as HTMLElement
+      vi.spyOn(workspace, 'getBoundingClientRect').mockReturnValue(
+        createDomRect(900, 700)
+      )
+
+      const observer = findObservedResizeObserver(mainWorkspace)
+      if (!observer) {
+        throw new Error('Expected main workspace ResizeObserver')
+      }
+
+      act(() => {
+        observer.trigger({ width: 420, height: 700 })
+      })
+
+      expect(screen.getByTestId('sidebar-resize-handle')).toBeInTheDocument()
+
+      act(() => {
+        observer.trigger({ width: 359, height: 700 })
+      })
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('sidebar-resize-handle')).toBeNull()
+      })
+
+      expect(screen.getByTestId('sidebar-toggle-tabs')).toBeInTheDocument()
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver
     }
   })
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -55,7 +55,11 @@ import {
 import { formatShortcut } from '../../lib/formatShortcut'
 import { renameAgentSession } from '../../lib/backend'
 import { useSessionManager } from '../sessions/hooks/useSessionManager'
-import { clampSize, useResizable } from '../../hooks/useResizable'
+import {
+  clampSize,
+  useResizable,
+  type ResizeDragEndEvent,
+} from '../../hooks/useResizable'
 import { useElasticContainer } from '../../hooks/useElasticContainer'
 import { useSidebarTab, type SidebarTab } from '../../hooks/useSidebarTab'
 import { useNotifyInfo } from './hooks/useNotifyInfo'
@@ -156,9 +160,14 @@ const formatStatusDuration = (durationMs: number): string | undefined => {
 // this const and the gear's `aria-disabled` once the dialog lands.
 const SETTINGS_FOLLOWUP_ISSUE_NUMBER = 252
 
-const SIDEBAR_MIN = 240
-const SIDEBAR_MAX = 560
 const SIDEBAR_DEFAULT = 272
+const SIDEBAR_MIN = SIDEBAR_DEFAULT
+const SIDEBAR_MAX = 520
+const MAIN_AUTO_COLLAPSE_MIN = 360
+const MAIN_AUTO_COLLAPSE_MAX = 500
+const MAIN_AUTO_COLLAPSE_RATIO = 0.36
+const SIDEBAR_MOTION_MS = 220
+const SIDEBAR_MOTION_EASING = 'cubic-bezier(0.32, 0.72, 0, 1)'
 
 const SIDEBAR_INITIAL = clampSize(SIDEBAR_DEFAULT, SIDEBAR_MIN, SIDEBAR_MAX)
 
@@ -167,10 +176,18 @@ const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
   { id: 'files', label: 'FILES', icon: 'folder_open' },
 ]
 
+const mainAutoCollapseThreshold = (workspaceWidth: number): number =>
+  clampSize(
+    Math.round(workspaceWidth * MAIN_AUTO_COLLAPSE_RATIO),
+    MAIN_AUTO_COLLAPSE_MIN,
+    MAIN_AUTO_COLLAPSE_MAX
+  )
+
 type DockTab = 'editor' | 'diff'
 
 export const WorkspaceView = (): ReactElement => {
   const workspaceRef = useRef<HTMLDivElement>(null)
+  const mainWorkspaceRef = useRef<HTMLDivElement>(null)
   const sidebarResizeHandleRef = useRef<HTMLDivElement | null>(null)
   // Imperative resize previews keep this ref, the CSS variable, and
   // aria-valuenow in sync without per-frame React commits.
@@ -254,8 +271,11 @@ export const WorkspaceView = (): ReactElement => {
   // slot when collapsed — both in-flow at the same {12,5} box. The sidebar is
   // hidden instantly (no drawer slide), so there is no transition window where
   // the toggle floats or a tab slips under it.
-  const { collapsed: sidebarCollapsed, toggle: toggleSidebar } =
-    useSidebarCollapsed()
+  const {
+    collapsed: sidebarCollapsed,
+    toggle: toggleSidebar,
+    setCollapsed: setSidebarCollapsed,
+  } = useSidebarCollapsed()
 
   // Imperative refs to the two SidebarToggle instances so the post-toggle focus
   // guard can refocus the visible one without relying on data-testid selectors.
@@ -573,6 +593,15 @@ export const WorkspaceView = (): ReactElement => {
     resizeHandle.setAttribute('aria-valuenow', String(nextWidth))
   }, [])
 
+  const handleSidebarDragEnd = useCallback(
+    ({ rawSize }: ResizeDragEndEvent): void => {
+      if (rawSize < SIDEBAR_MIN) {
+        setSidebarCollapsed(true)
+      }
+    },
+    [setSidebarCollapsed]
+  )
+
   const {
     size: sidebarWidth,
     isDragging,
@@ -583,11 +612,43 @@ export const WorkspaceView = (): ReactElement => {
     max: SIDEBAR_MAX,
     updateMode: 'commit-on-end',
     onDragPreview: previewSidebarWidth,
+    onDragEnd: handleSidebarDragEnd,
   })
 
   useLayoutEffect(() => {
     previewSidebarWidth(sidebarWidth)
   }, [previewSidebarWidth, sidebarWidth])
+
+  useEffect(() => {
+    const mainWorkspace = mainWorkspaceRef.current
+
+    if (!mainWorkspace || typeof ResizeObserver === 'undefined') {
+      return
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const width =
+        entries[0]?.contentRect.width ??
+        mainWorkspace.getBoundingClientRect().width
+
+      const workspaceWidth =
+        workspaceRef.current?.getBoundingClientRect().width ?? window.innerWidth
+
+      if (
+        !sidebarCollapsed &&
+        width > 0 &&
+        width < mainAutoCollapseThreshold(workspaceWidth)
+      ) {
+        setSidebarCollapsed(true)
+      }
+    })
+
+    observer.observe(mainWorkspace)
+
+    return (): void => {
+      observer.disconnect()
+    }
+  }, [sidebarCollapsed, setSidebarCollapsed])
 
   const activeCwd = activePtyBackedPane?.cwd ?? '.'
   // Distinct fallback for the FILES-tab file explorer: when no session
@@ -1472,21 +1533,24 @@ export const WorkspaceView = (): ReactElement => {
           // `--workspace-sidebar-width` is owned by previewSidebarWidth so
           // React rerenders cannot overwrite an in-progress drag preview.
           // VIM-76: icon rail removed — layout is [sidebar | main | activity].
-          // The sidebar `auto` track follows the shell width; collapse sets it
-          // to 0 INSTANTLY (no slide), so <main> (1fr) reclaims with no gutter
-          // and no transition window.
+          // The sidebar `auto` track follows the shell width; collapse animates
+          // that shell to 0 so <main> reclaims the space like a responsive page.
           gridTemplateColumns: `auto 1fr auto`,
         } as CSSProperties
       }
     >
-      {/* Sidebar — collapses instantly (VIM-76: no drawer slide). The shell
-          width snaps to 0 and the inner panel unmounts, so the `auto` track is
-          0 and <main> reclaims. The collapse toggle's collapsed-state home is
-          the session-tab bar's leading slot (below), not a floating overlay. */}
+      {/* Sidebar — the shell clips the inner panel during animated collapse.
+          Live drag previews stay direct; only non-drag collapse/expand motions
+          use the page-turn width transition. The collapse toggle's collapsed-
+          state home is the session-tab bar's leading slot (below), not a
+          floating overlay. */}
       <div
         aria-hidden={sidebarCollapsed || undefined}
         inert={sidebarCollapsed || undefined}
-        className="relative h-full overflow-hidden"
+        data-testid="workspace-sidebar-shell"
+        className={`relative h-full overflow-hidden will-change-[width] ${
+          isDragging ? '' : 'transition-[width] duration-[220ms] ease-pane'
+        }`}
         style={{
           width: sidebarCollapsed
             ? 0
@@ -1500,9 +1564,19 @@ export const WorkspaceView = (): ReactElement => {
           }}
         >
           <Sidebar
-            // Gate on !collapsed: unmounts the top bar + its portaled tooltips on collapse (they would otherwise escape the inert, clipped shell and linger); header/content stay mounted for state.
+            // Collapse keeps a same-height placeholder so the header/session
+            // list do not jump vertically while the shell width animates. The
+            // real top-bar controls still unmount so their portaled tooltips
+            // cannot escape the inert, clipped sidebar shell.
             topBar={
-              sidebarCollapsed ? undefined : (
+              sidebarCollapsed ? (
+                <div
+                  aria-hidden="true"
+                  data-testid="sidebar-top-bar-placeholder"
+                  className="bg-surface-container-low"
+                  style={{ height: 38, flexShrink: 0 }}
+                />
+              ) : (
                 <SidebarTopBar
                   onToggleSidebar={toggleSidebar}
                   onCommand={commandPalette.open}
@@ -1582,7 +1656,21 @@ export const WorkspaceView = (): ReactElement => {
           `relative` establishes a containing block so the fileError
           banner's `absolute` positioning is scoped to this column
           rather than climbing to the viewport. */}
-      <div className="relative flex flex-col overflow-hidden">
+      <div
+        ref={mainWorkspaceRef}
+        className="relative flex flex-col overflow-hidden bg-background"
+        style={{
+          borderTopLeftRadius: sidebarCollapsed ? 0 : 16,
+          borderBottomLeftRadius: sidebarCollapsed ? 0 : 16,
+          boxShadow: sidebarCollapsed
+            ? 'none'
+            : '-18px 0 36px rgba(0,0,0,0.22)',
+          transition: isDragging
+            ? 'none'
+            : `border-radius ${SIDEBAR_MOTION_MS}ms ${SIDEBAR_MOTION_EASING}, box-shadow ${SIDEBAR_MOTION_MS}ms ${SIDEBAR_MOTION_EASING}`,
+          willChange: 'border-radius, box-shadow',
+        }}
+      >
         <Tabs
           sessions={sessions}
           activeSessionId={activeSessionId}

--- a/src/features/workspace/components/AgentStatusCard.test.tsx
+++ b/src/features/workspace/components/AgentStatusCard.test.tsx
@@ -169,7 +169,7 @@ describe('AgentStatusCard', () => {
     expect(screen.queryByText('data_usage')).not.toBeInTheDocument()
   })
 
-  test('keeps the outer card height stable across agent and shell states', () => {
+  test('keeps a stable height and caps responsive width across agent and shell states', () => {
     const { rerender } = render(
       <AgentStatusCard
         title="m"
@@ -181,13 +181,19 @@ describe('AgentStatusCard', () => {
     )
 
     const card = screen.getByTestId('sidebar-agent-status-card')
-    expect(card).toHaveStyle({ height: '125px' })
+    expect(card).toHaveStyle({
+      width: '100%',
+      maxWidth: '320px',
+      height: '125px',
+    })
 
     rerender(
       <AgentStatusCard title="ignored" state="idle" isShell shellName="bash" />
     )
 
     expect(screen.getByTestId('sidebar-agent-status-card')).toHaveStyle({
+      width: '100%',
+      maxWidth: '320px',
       height: '125px',
     })
   })

--- a/src/features/workspace/components/AgentStatusCard.tsx
+++ b/src/features/workspace/components/AgentStatusCard.tsx
@@ -37,6 +37,10 @@ export interface AgentStatusCardProps {
   shellName?: string | null
 }
 
+// The 272px minimum/default sidebar gives this card 248px of available header
+// width after horizontal padding. Wider sidebars may give the card more room,
+// but cap at 320px so the chrome stays composed and left-pinned.
+const CARD_MAX_W = 320
 // 125 = 12 (top pad) + 24 (header: h-6 pill / leading-6 title) + 9 (gap)
 // + 66 (CARD_BODY_H) + 14 (bottom pad). Still ONE fixed height across agent
 // and shell states, so switching panes never reflows the session list.
@@ -188,6 +192,8 @@ export const AgentStatusCard = ({
       style={{
         position: 'relative',
         borderRadius: 13,
+        width: '100%',
+        maxWidth: CARD_MAX_W,
         height: CARD_H,
         padding: '12px 14px 14px',
         background: 'rgba(33,33,51,0.55)',

--- a/src/hooks/useResizable.test.ts
+++ b/src/hooks/useResizable.test.ts
@@ -296,6 +296,37 @@ describe('useResizable', () => {
     }
   })
 
+  test('drag end reports the raw size and the clamped size', () => {
+    const onDragEnd = vi.fn()
+
+    const { result } = renderHook(() =>
+      useResizable({
+        initial: 256,
+        min: 100,
+        max: 500,
+        onDragEnd,
+      })
+    )
+
+    act(() => {
+      result.current.handleMouseDown({
+        preventDefault: () => undefined,
+        clientX: 200,
+        clientY: 0,
+      } as React.MouseEvent)
+    })
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: -10 }))
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+
+    expect(onDragEnd).toHaveBeenCalledWith({
+      rawSize: 46,
+      size: 100,
+    })
+  })
+
   test('new drag cancels pending preview from previous drag', () => {
     const frameCallbacks: FrameRequestCallback[] = []
     const onDragPreview = vi.fn()

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -40,6 +40,17 @@ export interface UseResizableOptions {
    * should mirror committed keyboard resize through their normal render path.
    */
   onDragPreview?: (size: number) => void
+  /**
+   * Receives both the unclamped and clamped size when a mouse drag ends.
+   * Useful for controls that treat dragging past a clamp as a semantic action,
+   * such as collapsing a pane when the user pulls below its minimum size.
+   */
+  onDragEnd?: (event: ResizeDragEndEvent) => void
+}
+
+export interface ResizeDragEndEvent {
+  rawSize: number
+  size: number
 }
 
 export interface UseResizableResult {
@@ -71,6 +82,7 @@ export const useResizable = ({
   invert = false,
   updateMode = 'live',
   onDragPreview = undefined,
+  onDragEnd = undefined,
 }: UseResizableOptions): UseResizableResult => {
   // Clamp `initial` on mount so an out-of-range default doesn't briefly
   // surface (in ARIA attributes, in the rendered size) before the first
@@ -81,6 +93,7 @@ export const useResizable = ({
   const previewSize = useRef(size)
   const updateModeRef = useRef(updateMode)
   const onDragPreviewRef = useRef(onDragPreview)
+  const onDragEndRef = useRef(onDragEnd)
   const isDraggingRef = useRef(false)
   const startPos = useRef(0)
   const startSize = useRef(0)
@@ -99,6 +112,10 @@ export const useResizable = ({
   useLayoutEffect(() => {
     onDragPreviewRef.current = onDragPreview
   }, [onDragPreview])
+
+  useLayoutEffect(() => {
+    onDragEndRef.current = onDragEnd
+  }, [onDragEnd])
 
   const preview = useCallback((nextSize: number): void => {
     if (previewSize.current === nextSize) {
@@ -229,6 +246,14 @@ export const useResizable = ({
       ) {
         commitSize(finalSize, updateModeRef.current === 'commit-on-end')
       }
+
+      const rawDelta = currentPos.current - startPos.current
+      const delta = invert ? -rawDelta : rawDelta
+      const rawSize = Math.round(startSize.current + delta)
+      onDragEndRef.current?.({
+        rawSize,
+        size: clampSize(rawSize, min, max),
+      })
 
       isDraggingRef.current = false
       setIsDragging(false)


### PR DESCRIPTION
## Summary
- Compact the agent and shell cards while keeping their height stable across states.
- Fix sidebar tab and agent-card widths during resize, with the sidebar capped at 520px and collapsed when dragged below the minimum width.
- Preserve session reorder motion while disabling Framer layout projection for ordinary sidebar/session changes.

## Verification
- `npm run type-check`
- `npm run lint`
- `npx vitest run src/components/sidebar/SidebarTabs.test.tsx src/features/workspace/components/AgentStatusCard.test.tsx src/hooks/useResizable.test.ts src/features/sessions/components/Card.test.tsx src/features/sessions/components/List.test.tsx src/features/sessions/components/List.motion.test.tsx src/features/workspace/WorkspaceView.test.tsx`
- pre-push `npm run test` passed after rebase: 241 test files, 3194 tests passed, 3 skipped