### PR TITLE
[codex] Restore native session reorder motion

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,6 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | -------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security           | 21       | 3    | 2026-05-20   |
 | [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 29       | 11   | 2026-06-06   |
+| [Motion Layout Projection](patterns/motion-layout-projection.md)     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 4        | 3    | 2026-05-30   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 6        | 3    | 2026-05-30   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                       | code-quality       | 5        | 0    | 2026-05-09   |

--- a/docs/reviews/patterns/motion-layout-projection.md
+++ b/docs/reviews/patterns/motion-layout-projection.md
@@ -1,0 +1,28 @@
+---
+id: motion-layout-projection
+category: react-patterns
+created: 2026-06-10
+last_updated: 2026-06-10
+ref_count: 0
+---
+
+# Motion Layout Projection
+
+## Summary
+
+Framer Motion reorder interactions rely on continuous layout projection state.
+Do not toggle `Reorder.Item` layout projection on after a gesture has already
+started to suppress unrelated non-drag layout animations. Preserve the native
+reorder loop for drag smoothness, and solve non-drag layout animation at the
+container/visibility/transition boundary instead.
+
+## Findings
+
+### 1. Drag-intent layout gating broke session row reorder smoothness
+
+- **Source:** local-codex | local investigation | 2026-06-10
+- **Severity:** HIGH
+- **File:** `src/features/sessions/components/Card.tsx`, `src/features/sessions/components/List.tsx`
+- **Finding:** A prior sidebar stabilization changed session rows from always-on `layout="position"` to `layout={dragging ? 'position' : false}` with a 4px pointer-intent threshold. This suppressed a non-drag vertical animation seen when switching sidebar tabs, but it made Framer start measuring layout projection mid-gesture. Dragging the 3rd row toward the 2nd could jump to the 1st slot because Framer had no continuous pre-drag position cache.
+- **Fix:** Restore the native Framer reorder path: keep `Reorder.Item layout="position"` always enabled and let `Reorder.Group.onReorder` immediately commit the reordered Active subset with the current Recent suffix. Confirm competing strategies in a dev-only side-by-side demo before changing production behavior. If tab switching creates unwanted non-drag row motion, fix that by stabilizing container geometry or suppressing non-drag transitions, not by disabling reorder layout projection.
+- **Commit:** _(pending current change)_

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,14 @@
 import type { ReactElement } from 'react'
 import { render, screen } from '@testing-library/react'
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest'
 import App from './App'
 
 // Mock WorkspaceView to avoid rendering the full workspace in App tests.
@@ -12,6 +20,26 @@ vi.mock('./features/workspace/WorkspaceView', () => {
   return {
     WorkspaceView: MockedWorkspaceView,
     default: MockedWorkspaceView,
+  }
+})
+
+vi.mock('./features/diff/demo/InlineCommentDemo', () => {
+  const MockedInlineCommentDemo = (): ReactElement => (
+    <div data-testid="inline-comment-demo">Inline comment demo</div>
+  )
+
+  return {
+    InlineCommentDemo: MockedInlineCommentDemo,
+  }
+})
+
+vi.mock('./features/sessions/demo/ReorderMotionDemo', () => {
+  const MockedReorderMotionDemo = (): ReactElement => (
+    <div data-testid="session-reorder-demo">Session reorder demo</div>
+  )
+
+  return {
+    ReorderMotionDemo: MockedReorderMotionDemo,
   }
 })
 
@@ -48,6 +76,10 @@ describe('App', () => {
     vi.unstubAllGlobals()
   })
 
+  afterEach(() => {
+    window.history.replaceState(null, '', '/')
+  })
+
   test('renders without crashing', () => {
     render(<App />)
     expect(document.body).toBeTruthy()
@@ -72,5 +104,14 @@ describe('App', () => {
     expect(
       screen.queryByText('Workspace layout components will be added next')
     ).not.toBeInTheDocument()
+  })
+
+  test('renders session reorder demo behind dev query gate', () => {
+    window.history.replaceState(null, '', '/?demo=session-reorder')
+
+    render(<App />)
+
+    expect(screen.getByTestId('session-reorder-demo')).toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-view')).not.toBeInTheDocument()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react'
 import { WorkerPoolContextProvider } from '@pierre/diffs/react'
 import { WorkspaceView } from './features/workspace/WorkspaceView'
 import { InlineCommentDemo } from './features/diff/demo/InlineCommentDemo'
+import { ReorderMotionDemo } from './features/sessions/demo/ReorderMotionDemo'
 
 // Pierre's worker entry is exposed as a dedicated package export so Vite
 // bundles it via `new Worker(url, ...)` with the worker config in
@@ -24,19 +25,29 @@ const highlighterOptions = {
   theme: 'pierre-dark' as const,
 }
 
-// Dev-only gate for the PR4 inline-comment gutter demo (spec §7). Launch with
-// `npm run dev` then open `?demo=inline-comments`. Guarded by `import.meta.env.DEV`
-// so it can never render in a production build.
-const isInlineCommentDemo = (): boolean =>
-  import.meta.env.DEV &&
-  new URLSearchParams(window.location.search).get('demo') === 'inline-comments'
+const devDemoName = (): string | null =>
+  import.meta.env.DEV
+    ? new URLSearchParams(window.location.search).get('demo')
+    : null
+
+const renderDemo = (demoName: string | null): ReactElement => {
+  if (demoName === 'inline-comments') {
+    return <InlineCommentDemo />
+  }
+
+  if (demoName === 'session-reorder') {
+    return <ReorderMotionDemo />
+  }
+
+  return <WorkspaceView />
+}
 
 const App = (): ReactElement => (
   <WorkerPoolContextProvider
     poolOptions={poolOptions}
     highlighterOptions={highlighterOptions}
   >
-    {isInlineCommentDemo() ? <InlineCommentDemo /> : <WorkspaceView />}
+    {renderDemo(devDemoName())}
   </WorkerPoolContextProvider>
 )
 

--- a/src/features/sessions/components/Card.tsx
+++ b/src/features/sessions/components/Card.tsx
@@ -14,12 +14,9 @@ export interface CardProps {
   onClick: (id: string) => void
   onRemove?: (id: string) => void
   onRename?: (id: string, name: string) => void
-  reorderMotionEnabled?: boolean
   onReorderDragStart?: () => void
   onReorderDragEnd?: () => void
 }
-
-type ReorderItemLayout = true | 'position' | undefined
 
 // Status → flat colored text (no chip pill, no dot), per handoff §3.3.
 const STATUS_TEXT: Record<Session['status'], { tone: string; label: string }> =
@@ -30,13 +27,6 @@ const STATUS_TEXT: Record<Session['status'], { tone: string; label: string }> =
     completed: { tone: '#c9b3f0', label: 'Done' },
     errored: { tone: '#ffb4ab', label: 'Errored' },
   }
-
-// Reorder.Item's public type in this Framer version omits `false`, but the
-// component forwards `layout` to motion.li where `false` is the supported way
-// to keep projection layout disabled. Without an explicit false, Reorder.Item's
-// internal default is `layout = true`.
-const REORDER_LAYOUT_OFF = false as unknown as ReorderItemLayout
-const REORDER_DRAG_INTENT_THRESHOLD_PX = 4
 
 const MenuRow = ({
   icon,
@@ -72,13 +62,9 @@ const CardComponent = ({
   onClick,
   onRemove = undefined,
   onRename = undefined,
-  reorderMotionEnabled = false,
   onReorderDragStart = undefined,
   onReorderDragEnd = undefined,
 }: CardProps): ReactElement => {
-  const dragStartPointRef = useRef<{ x: number; y: number } | null>(null)
-  const reorderDragIntentActiveRef = useRef(false)
-
   const {
     isEditing,
     editValue,
@@ -90,26 +76,6 @@ const CardComponent = ({
   } = useRenameState(session, onRename)
   const [menuOpen, setMenuOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
-
-  const beginReorderDragIntent = (): void => {
-    if (reorderDragIntentActiveRef.current) {
-      return
-    }
-
-    reorderDragIntentActiveRef.current = true
-    onReorderDragStart?.()
-  }
-
-  const finishReorderDragIntent = (): void => {
-    dragStartPointRef.current = null
-
-    if (!reorderDragIntentActiveRef.current) {
-      return
-    }
-
-    reorderDragIntentActiveRef.current = false
-    onReorderDragEnd?.()
-  }
 
   // Close the actions menu on Escape and return focus to the trigger button.
   useEffect(() => {
@@ -336,42 +302,12 @@ const CardComponent = ({
           boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
           zIndex: 50,
         }}
-        layout={reorderMotionEnabled ? 'position' : REORDER_LAYOUT_OFF}
-        onPointerDownCapture={(e) => {
-          if (e.button > 0) {
-            return
-          }
-
-          dragStartPointRef.current = { x: e.clientX, y: e.clientY }
-          reorderDragIntentActiveRef.current = false
-        }}
-        onPointerMoveCapture={(e) => {
-          const dragStartPoint = dragStartPointRef.current
-          if (dragStartPoint === null || reorderDragIntentActiveRef.current) {
-            return
-          }
-
-          const distance = Math.hypot(
-            e.clientX - dragStartPoint.x,
-            e.clientY - dragStartPoint.y
-          )
-          if (distance < REORDER_DRAG_INTENT_THRESHOLD_PX) {
-            return
-          }
-
-          beginReorderDragIntent()
-        }}
-        onPointerUpCapture={() => {
-          finishReorderDragIntent()
-        }}
-        onPointerCancelCapture={() => {
-          finishReorderDragIntent()
-        }}
+        layout="position"
         onDragStart={() => {
-          beginReorderDragIntent()
+          onReorderDragStart?.()
         }}
         onDragEnd={() => {
-          finishReorderDragIntent()
+          onReorderDragEnd?.()
         }}
       >
         {inner}

--- a/src/features/sessions/components/List.motion.test.tsx
+++ b/src/features/sessions/components/List.motion.test.tsx
@@ -1,30 +1,23 @@
 import {
   act,
   type CSSProperties,
-  type PointerEvent,
   type ReactElement,
   type ReactNode,
 } from 'react'
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { List } from './List'
 import type { Session } from '../types'
 
-interface CapturedReorderItemHandlers {
-  onPointerDownCapture?: (event: PointerEvent<HTMLLIElement>) => void
-  onPointerMoveCapture?: (event: PointerEvent<HTMLLIElement>) => void
-  onPointerUpCapture?: () => void
-  onPointerCancelCapture?: () => void
-}
-
-const capturedReorderItemHandlers = vi.hoisted(
-  (): CapturedReorderItemHandlers[] => []
+const capturedReorderGroupHandlers = vi.hoisted(
+  (): { onReorder?: (sessions: Session[]) => void } => ({})
 )
 
 vi.mock('framer-motion', () => {
   interface MockReorderGroupProps {
     children: ReactNode
     className?: string
+    onReorder?: (sessions: Session[]) => void
     'data-testid'?: string
   }
 
@@ -33,10 +26,6 @@ vi.mock('framer-motion', () => {
     className?: string
     style?: CSSProperties
     layout?: boolean | 'position'
-    onPointerDownCapture?: (event: PointerEvent<HTMLLIElement>) => void
-    onPointerMoveCapture?: (event: PointerEvent<HTMLLIElement>) => void
-    onPointerUpCapture?: () => void
-    onPointerCancelCapture?: () => void
     'data-testid'?: string
     'data-session-id'?: string
     'data-active'?: boolean
@@ -54,9 +43,10 @@ vi.mock('framer-motion', () => {
       Group: ({
         children,
         className = undefined,
+        onReorder = undefined,
         'data-testid': testId = undefined,
       }: MockReorderGroupProps): ReactElement => {
-        capturedReorderItemHandlers.length = 0
+        capturedReorderGroupHandlers.onReorder = onReorder
 
         return (
           <ul className={className} data-testid={testId}>
@@ -69,34 +59,21 @@ vi.mock('framer-motion', () => {
         className = undefined,
         style = undefined,
         layout = undefined,
-        onPointerDownCapture = undefined,
-        onPointerMoveCapture = undefined,
-        onPointerUpCapture = undefined,
-        onPointerCancelCapture = undefined,
         'data-testid': testId = undefined,
         'data-session-id': sessionId = undefined,
         'data-active': active = undefined,
-      }: MockReorderItemProps): ReactElement => {
-        capturedReorderItemHandlers.push({
-          onPointerDownCapture,
-          onPointerMoveCapture,
-          onPointerUpCapture,
-          onPointerCancelCapture,
-        })
-
-        return (
-          <li
-            className={className}
-            data-active={active === undefined ? undefined : String(active)}
-            data-layout={layout === false ? 'false' : (layout ?? 'unset')}
-            data-session-id={sessionId}
-            data-testid={testId}
-            style={style}
-          >
-            {children}
-          </li>
-        )
-      },
+      }: MockReorderItemProps): ReactElement => (
+        <li
+          className={className}
+          data-active={active === undefined ? undefined : String(active)}
+          data-layout={layout === false ? 'false' : (layout ?? 'unset')}
+          data-session-id={sessionId}
+          data-testid={testId}
+          style={style}
+        >
+          {children}
+        </li>
+      ),
     },
     motion: {
       div: ({
@@ -121,6 +98,7 @@ const session = (overrides: Partial<Session> = {}): Session =>
     workingDirectory: '/home/user/projects/Vimeflow',
     agentType: 'claude-code',
     layout: 'single',
+    activityPanelCollapsed: false,
     terminalPid: 12345,
     panes: [
       {
@@ -139,7 +117,7 @@ const session = (overrides: Partial<Session> = {}): Session =>
       fileChanges: [],
       toolCalls: [],
       testResults: [],
-      contextWindow: { used: 0, total: 200000, percentage: 0, emoji: ':)' },
+      contextWindow: { used: 0, total: 200000, percentage: 0, emoji: '😊' },
       usage: {
         sessionDuration: 0,
         turnCount: 0,
@@ -150,25 +128,8 @@ const session = (overrides: Partial<Session> = {}): Session =>
     ...overrides,
   }) as Session
 
-const pointerEvent = ({
-  button = 0,
-  clientX,
-  clientY,
-}: {
-  button?: number
-  clientX: number
-  clientY: number
-}): PointerEvent<HTMLLIElement> =>
-  ({ button, clientX, clientY }) as PointerEvent<HTMLLIElement>
-
 describe('List reorder motion', () => {
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  test('enables Reorder.Item layout only during drag and settle', () => {
-    vi.useFakeTimers()
-
+  test('keeps Reorder.Item layout projection enabled while idle', () => {
     render(
       <List
         sessions={[
@@ -181,45 +142,52 @@ describe('List reorder motion', () => {
     )
 
     const rows = screen.getAllByTestId('session-row')
-    expect(rows[0]).toHaveAttribute('data-layout', 'false')
-    expect(rows[1]).toHaveAttribute('data-layout', 'false')
 
-    capturedReorderItemHandlers[0].onPointerDownCapture?.(
-      pointerEvent({ button: 0, clientX: 0, clientY: 0 })
+    expect(rows[0]).toHaveAttribute('data-layout', 'position')
+    expect(rows[1]).toHaveAttribute('data-layout', 'position')
+  })
+
+  test('commits native reordered active rows immediately with recent suffix', () => {
+    const first = session({ id: 'sess-1', name: 'first' })
+    const second = session({ id: 'sess-2', name: 'second' })
+
+    const recent = session({
+      id: 'sess-3',
+      name: 'recent',
+      status: 'completed',
+      panes: [
+        {
+          id: 'p0',
+          ptyId: 'sess-3',
+          cwd: '/home/user/projects/Vimeflow',
+          agentType: 'claude-code',
+          status: 'completed',
+          active: true,
+        },
+      ],
+    })
+    const onReorderSessions = vi.fn<(sessions: Session[]) => void>()
+
+    render(
+      <List
+        sessions={[first, second, recent]}
+        activeSessionId="sess-1"
+        onSessionClick={vi.fn()}
+        onReorderSessions={onReorderSessions}
+      />
     )
 
     act(() => {
-      capturedReorderItemHandlers[0].onPointerMoveCapture?.(
-        pointerEvent({ clientX: 0, clientY: 3 })
-      )
-    })
-    expect(rows[0]).toHaveAttribute('data-layout', 'false')
-
-    act(() => {
-      capturedReorderItemHandlers[0].onPointerMoveCapture?.(
-        pointerEvent({ clientX: 0, clientY: 5 })
-      )
+      capturedReorderGroupHandlers.onReorder?.([second, first])
     })
 
-    const draggingRows = screen.getAllByTestId('session-row')
-    expect(draggingRows[0]).toHaveAttribute('data-layout', 'position')
-    expect(draggingRows[1]).toHaveAttribute('data-layout', 'position')
+    expect(onReorderSessions).toHaveBeenCalledTimes(1)
+    const [committedSessions] = onReorderSessions.mock.calls[0]
 
-    act(() => {
-      capturedReorderItemHandlers[0].onPointerUpCapture?.()
-    })
-
-    expect(screen.getAllByTestId('session-row')[0]).toHaveAttribute(
-      'data-layout',
-      'position'
-    )
-
-    act(() => {
-      vi.advanceTimersByTime(260)
-    })
-
-    const settledRows = screen.getAllByTestId('session-row')
-    expect(settledRows[0]).toHaveAttribute('data-layout', 'false')
-    expect(settledRows[1]).toHaveAttribute('data-layout', 'false')
+    expect(committedSessions.map(({ id }) => id)).toEqual([
+      'sess-2',
+      'sess-1',
+      'sess-3',
+    ])
   })
 })

--- a/src/features/sessions/components/List.tsx
+++ b/src/features/sessions/components/List.tsx
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type ReactElement,
-} from 'react'
+import { useCallback, useRef, type ReactElement } from 'react'
 import { motion } from 'framer-motion'
 import type { Session, SessionCloseResult } from '../types'
 import { Card } from './Card'
@@ -22,8 +16,6 @@ export interface ListProps {
   onReorderSessions?: (sessions: Session[]) => void
 }
 
-const REORDER_MOTION_SETTLE_MS = 260
-
 export const List = ({
   sessions,
   activeSessionId,
@@ -40,52 +32,18 @@ export const List = ({
   const recentGroup = sessions.filter((s) => !hasLivePane(s.panes))
 
   // Mirror `recentGroup` into a ref synchronously on every render so
-  // Framer Motion's `onReorder` callback (which can be invoked mid-drag
-  // across multiple frames) reads the current value rather than the
-  // closure-captured one. Without this ref, a session that transitions
-  // to `completed` mid-drag re-renders Sidebar with a fresh recentGroup
-  // but Framer Motion may keep dispatching the original onReorder
-  // closure that captured the pre-transition recentGroup; the resulting
-  // `[...reordered, ...staleRecentGroup]` would either drop or
-  // duplicate the newly-completed session for one frame, and a
-  // session-store that persists eagerly could write the stale array.
+  // Framer Motion's `onReorder` callback reads the current Recent section
+  // rather than a closure-captured one. Without this ref, a session that
+  // transitions to `completed` mid-drag could be appended from a stale
+  // Recent snapshot when the reordered Active subset is committed.
   const recentGroupRef = useRef(recentGroup)
   recentGroupRef.current = recentGroup
 
-  const [reorderMotionEnabled, setReorderMotionEnabled] = useState(false)
-
-  const reorderMotionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  )
-
-  const clearReorderMotionTimeout = useCallback((): void => {
-    const timeoutId = reorderMotionTimeoutRef.current
-    if (timeoutId === null) {
-      return
-    }
-
-    clearTimeout(timeoutId)
-    reorderMotionTimeoutRef.current = null
-  }, [])
-
-  const handleReorderDragStart = useCallback((): void => {
-    clearReorderMotionTimeout()
-    setReorderMotionEnabled(true)
-  }, [clearReorderMotionTimeout])
-
-  const handleReorderDragEnd = useCallback((): void => {
-    clearReorderMotionTimeout()
-    reorderMotionTimeoutRef.current = setTimeout(() => {
-      reorderMotionTimeoutRef.current = null
-      setReorderMotionEnabled(false)
-    }, REORDER_MOTION_SETTLE_MS)
-  }, [clearReorderMotionTimeout])
-
-  useEffect(
-    () => (): void => {
-      clearReorderMotionTimeout()
+  const handleActiveReorder = useCallback(
+    (reordered: Session[]): void => {
+      onReorderSessions?.(mediateReorder(reordered, recentGroupRef.current))
     },
-    [clearReorderMotionTimeout]
+    [onReorderSessions]
   )
 
   // Mirror SessionTabs.handleClose using the shared visible-order helper.
@@ -162,19 +120,7 @@ export const List = ({
         <Group
           variant="active"
           sessions={activeGroup}
-          onReorder={(reordered) => {
-            // Preserve Recent ordering — only the Active subset reorders.
-            // Read recentGroup via the ref (synced every render in the
-            // outer component body) so a mid-drag status transition that
-            // re-renders Sidebar can't leave Framer Motion holding a
-            // stale closure that drops or duplicates the just-transitioned
-            // session. The concat lives in `mediateReorder` (with its own
-            // unit test) so the production path and the test path share
-            // one implementation.
-            onReorderSessions?.(
-              mediateReorder(reordered, recentGroupRef.current)
-            )
-          }}
+          onReorder={handleActiveReorder}
           emptyState={
             <li
               data-testid="active-empty"
@@ -193,9 +139,6 @@ export const List = ({
               onClick={onSessionClick}
               onRemove={cardRemoveSession}
               onRename={onRenameSession}
-              reorderMotionEnabled={reorderMotionEnabled}
-              onReorderDragStart={handleReorderDragStart}
-              onReorderDragEnd={handleReorderDragEnd}
             />
           ))}
         </Group>

--- a/src/features/sessions/demo/ReorderMotionDemo.test.tsx
+++ b/src/features/sessions/demo/ReorderMotionDemo.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import { ReorderMotionDemo } from './ReorderMotionDemo'
+
+describe('ReorderMotionDemo', () => {
+  test('renders native and current-list reorder surfaces side by side', () => {
+    render(<ReorderMotionDemo />)
+
+    expect(
+      screen.getByRole('heading', { name: 'Session Reorder' })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('heading', { name: 'Native Framer' })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('heading', { name: 'Current List' })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('heading', { name: 'Native Guarded' })
+    ).toBeInTheDocument()
+
+    expect(screen.getAllByRole('button', { name: 'Sessions' })).toHaveLength(3)
+    expect(screen.getAllByRole('button', { name: 'Other' })).toHaveLength(3)
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeInTheDocument()
+  })
+})

--- a/src/features/sessions/demo/ReorderMotionDemo.tsx
+++ b/src/features/sessions/demo/ReorderMotionDemo.tsx
@@ -1,0 +1,311 @@
+import {
+  useCallback,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+import type { Session, SessionStatus } from '../types'
+import { Card } from '../components/Card'
+import { Group } from '../components/Group'
+import { List } from '../components/List'
+
+const DEMO_CWD = '/demo/vimeflow'
+
+const DEMO_NAMES = [
+  'session 1',
+  'session 2',
+  'session 3',
+  'session 4',
+  'session 5',
+  'session 6',
+]
+
+const DEMO_STATUSES: SessionStatus[] = [
+  'running',
+  'awaiting',
+  'running',
+  'idle',
+  'running',
+  'awaiting',
+]
+
+const emptyActivity = (): Session['activity'] => ({
+  fileChanges: [],
+  toolCalls: [],
+  testResults: [],
+  contextWindow: {
+    used: 12000,
+    total: 200000,
+    percentage: 6,
+    emoji: '😊',
+  },
+  usage: {
+    sessionDuration: 420,
+    turnCount: 4,
+    messages: { sent: 4, limit: 200 },
+    tokens: { input: 6000, output: 6000, total: 12000 },
+  },
+})
+
+const buildDemoSessions = (): Session[] =>
+  DEMO_NAMES.map((name, index) => {
+    const id = `demo-session-${index + 1}`
+    const status = DEMO_STATUSES[index]
+
+    return {
+      id,
+      projectId: 'demo-project',
+      name,
+      status,
+      workingDirectory: DEMO_CWD,
+      agentType: index % 2 === 0 ? 'claude-code' : 'codex',
+      layout: index === 2 ? 'vsplit' : 'single',
+      activityPanelCollapsed: false,
+      panes: [
+        {
+          id: 'p0',
+          ptyId: id,
+          cwd: DEMO_CWD,
+          agentType: index % 2 === 0 ? 'claude-code' : 'codex',
+          status,
+          active: true,
+          pid: 20000 + index,
+        },
+      ],
+      createdAt: '2026-06-10T06:00:00Z',
+      lastActivityAt: `2026-06-10T06:0${index}:00Z`,
+      activity: emptyActivity(),
+    }
+  })
+
+const sessionIds = (sessions: Session[]): string =>
+  sessions.map((session) => session.name.replace('session ', '')).join(' ')
+
+interface DemoPanelProps {
+  title: string
+  children: ReactNode
+  order: string
+}
+
+const DemoPanel = ({
+  title,
+  children,
+  order,
+}: DemoPanelProps): ReactElement => {
+  const [activeTab, setActiveTab] = useState<'sessions' | 'other'>('sessions')
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col rounded-[10px] bg-[rgba(18,18,33,0.82)] shadow-[0_18px_60px_rgba(0,0,0,0.28)]">
+      <div className="flex shrink-0 items-center justify-between px-4 py-3">
+        <h2 className="font-label text-sm font-semibold text-[#f3eeff]">
+          {title}
+        </h2>
+        <span className="font-mono text-[10px] text-[#8a8299]">{order}</span>
+      </div>
+      <div className="flex shrink-0 items-center gap-2 px-3 pb-2">
+        <button
+          type="button"
+          onClick={() => setActiveTab('sessions')}
+          className={`h-7 rounded-[7px] px-2.5 font-label text-[11px] font-semibold transition-colors ${
+            activeTab === 'sessions'
+              ? 'bg-[rgba(203,166,247,0.16)] text-[#e2c7ff]'
+              : 'text-[#8a8299] hover:bg-[rgba(255,255,255,0.05)]'
+          }`}
+        >
+          Sessions
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab('other')}
+          className={`h-7 rounded-[7px] px-2.5 font-label text-[11px] font-semibold transition-colors ${
+            activeTab === 'other'
+              ? 'bg-[rgba(203,166,247,0.16)] text-[#e2c7ff]'
+              : 'text-[#8a8299] hover:bg-[rgba(255,255,255,0.05)]'
+          }`}
+        >
+          Other
+        </button>
+      </div>
+      <div
+        className={`min-h-0 flex-1 px-2 pb-3 ${
+          activeTab === 'sessions' ? 'block' : 'hidden'
+        }`}
+      >
+        {children}
+      </div>
+      <div
+        className={`min-h-0 flex-1 place-items-center px-2 pb-3 ${
+          activeTab === 'other' ? 'grid' : 'hidden'
+        }`}
+      >
+        <div className="rounded-[9px] bg-[rgba(255,255,255,0.04)] px-4 py-3 text-center font-label text-xs text-[#8a8299]">
+          Sessions stay mounted while this panel is visible.
+        </div>
+      </div>
+    </section>
+  )
+}
+
+interface NativeReorderListProps {
+  sessions: Session[]
+  activeSessionId: string
+  onActiveSessionChange: (id: string) => void
+  onReorder: (sessions: Session[]) => void
+}
+
+const NativeReorderList = ({
+  sessions,
+  activeSessionId,
+  onActiveSessionChange,
+  onReorder,
+}: NativeReorderListProps): ReactElement => (
+  <div className="flex h-full min-h-0 flex-col">
+    <Group.Header label="Active" count={sessions.length} />
+    <div className="thin-scrollbar min-h-0 flex-1 overflow-y-auto overflow-x-clip">
+      <Group variant="active" sessions={sessions} onReorder={onReorder}>
+        {sessions.map((session) => (
+          <Card
+            key={session.id}
+            session={session}
+            variant="active"
+            isActive={session.id === activeSessionId}
+            onClick={onActiveSessionChange}
+          />
+        ))}
+      </Group>
+    </div>
+  </div>
+)
+
+interface GuardedNativeReorderListProps {
+  sessions: Session[]
+  activeSessionId: string
+  onActiveSessionChange: (id: string) => void
+  onReorder: (sessions: Session[]) => void
+}
+
+const GuardedNativeReorderList = ({
+  sessions,
+  activeSessionId,
+  onActiveSessionChange,
+  onReorder,
+}: GuardedNativeReorderListProps): ReactElement => {
+  const draggingRef = useRef(false)
+
+  const handleDragStart = useCallback((): void => {
+    draggingRef.current = true
+  }, [])
+
+  const handleDragEnd = useCallback((): void => {
+    draggingRef.current = false
+  }, [])
+
+  const handleReorder = useCallback(
+    (reordered: Session[]): void => {
+      if (!draggingRef.current) {
+        return
+      }
+
+      onReorder(reordered)
+    },
+    [onReorder]
+  )
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <Group.Header label="Active" count={sessions.length} />
+      <div className="thin-scrollbar min-h-0 flex-1 overflow-y-auto overflow-x-clip">
+        <Group variant="active" sessions={sessions} onReorder={handleReorder}>
+          {sessions.map((session) => (
+            <Card
+              key={session.id}
+              session={session}
+              variant="active"
+              isActive={session.id === activeSessionId}
+              onClick={onActiveSessionChange}
+              onReorderDragStart={handleDragStart}
+              onReorderDragEnd={handleDragEnd}
+            />
+          ))}
+        </Group>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Dev-only side-by-side harness for comparing Framer's native reorder loop
+ * against Vimeflow reorder variants.
+ */
+export const ReorderMotionDemo = (): ReactElement => {
+  const [nativeSessions, setNativeSessions] = useState(buildDemoSessions)
+  const [approvedSessions, setApprovedSessions] = useState(buildDemoSessions)
+  const [guardedSessions, setGuardedSessions] = useState(buildDemoSessions)
+  const [nativeActiveId, setNativeActiveId] = useState('demo-session-1')
+  const [approvedActiveId, setApprovedActiveId] = useState('demo-session-1')
+  const [guardedActiveId, setGuardedActiveId] = useState('demo-session-1')
+
+  const reset = (): void => {
+    setNativeSessions(buildDemoSessions())
+    setApprovedSessions(buildDemoSessions())
+    setGuardedSessions(buildDemoSessions())
+    setNativeActiveId('demo-session-1')
+    setApprovedActiveId('demo-session-1')
+    setGuardedActiveId('demo-session-1')
+  }
+
+  return (
+    <main className="flex h-screen flex-col bg-[#0d0d1c] px-6 py-5 text-on-surface">
+      <div className="flex shrink-0 items-center justify-between pb-4">
+        <div>
+          <h1 className="font-headline text-xl font-semibold text-[#f3eeff]">
+            Session Reorder
+          </h1>
+          <p className="mt-1 font-label text-xs text-[#8a8299]">
+            Drag session 3 between session 1 and 2.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={reset}
+          className="inline-flex h-8 items-center gap-2 rounded-[8px] bg-[rgba(203,166,247,0.14)] px-3 font-label text-xs font-semibold text-[#e2c7ff] transition-colors hover:bg-[rgba(203,166,247,0.22)]"
+        >
+          <span
+            className="material-symbols-outlined text-[16px]"
+            aria-hidden="true"
+          >
+            restart_alt
+          </span>
+          Reset
+        </button>
+      </div>
+      <div className="grid min-h-0 flex-1 grid-cols-3 gap-4">
+        <DemoPanel title="Native Framer" order={sessionIds(nativeSessions)}>
+          <NativeReorderList
+            sessions={nativeSessions}
+            activeSessionId={nativeActiveId}
+            onActiveSessionChange={setNativeActiveId}
+            onReorder={setNativeSessions}
+          />
+        </DemoPanel>
+        <DemoPanel title="Current List" order={sessionIds(approvedSessions)}>
+          <List
+            sessions={approvedSessions}
+            activeSessionId={approvedActiveId}
+            onSessionClick={setApprovedActiveId}
+            onReorderSessions={setApprovedSessions}
+          />
+        </DemoPanel>
+        <DemoPanel title="Native Guarded" order={sessionIds(guardedSessions)}>
+          <GuardedNativeReorderList
+            sessions={guardedSessions}
+            activeSessionId={guardedActiveId}
+            onActiveSessionChange={setGuardedActiveId}
+            onReorder={setGuardedSessions}
+          />
+        </DemoPanel>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- Restore Framer Motion native layout projection for sidebar session rows.
- Remove the drag-intent layout gate and delayed reorder preview from production List/Card.
- Add a dev-only `?demo=session-reorder` comparison page for native/current/guarded reorder motion.
- Record the layout projection lesson in `docs/reviews` for future reviews.

## Root Cause
#410 disabled `Reorder.Item` layout projection while idle and enabled it only after drag intent. That suppressed non-drag tab-switch motion, but it also made Framer start measuring layout projection mid-gesture. The measurement discontinuity caused rows to jump during real drags, such as dragging the third item to second and seeing it jump to first.

## Validation
- `npm run test -- src/features/sessions/components/List.motion.test.tsx src/features/sessions/components/Card.test.tsx src/features/sessions/components/List.test.tsx src/features/sessions/demo/ReorderMotionDemo.test.tsx src/App.test.tsx`
- `npm run type-check`
- `npx eslint src/features/sessions/components/List.tsx src/features/sessions/components/Card.tsx src/features/sessions/components/List.motion.test.tsx src/features/sessions/demo/ReorderMotionDemo.tsx src/features/sessions/demo/ReorderMotionDemo.test.tsx src/App.tsx src/App.test.tsx`
- pre-push `npm run test`: 242 test files passed, 3202 tests passed, 3 skipped