### PR TITLE
[codex] Clear macOS titlebar controls in sidebar

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -76,3 +76,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Verify Render Target](patterns/verify-render-target.md)             | code-quality       | 2        | 0    | 2026-05-24   |
 | [Status Indicator Display](patterns/status-indicator-display.md)     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                   | code-quality       | 7        | 5    | 2026-06-09   |
+| [Persisted State Invariants](patterns/persisted-state-invariants.md) | correctness        | 6        | 3    | 2026-06-08   |
+| [macOS Window Chrome](patterns/macos-window-chrome.md)               | cross-platform     | 6        | 0    | 2026-06-09   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -77,4 +77,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Status Indicator Display](patterns/status-indicator-display.md)     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                   | code-quality       | 7        | 5    | 2026-06-09   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md) | correctness        | 6        | 3    | 2026-06-08   |
-| [macOS Window Chrome](patterns/macos-window-chrome.md)               | cross-platform     | 6        | 0    | 2026-06-09   |
+| [macOS Window Chrome](patterns/macos-window-chrome.md)               | cross-platform     | 7        | 1    | 2026-06-10   |

--- a/docs/reviews/patterns/macos-window-chrome.md
+++ b/docs/reviews/patterns/macos-window-chrome.md
@@ -1,0 +1,67 @@
+---
+id: macos-window-chrome
+category: cross-platform
+created: 2026-06-09
+last_updated: 2026-06-09
+ref_count: 0
+---
+
+# macOS Window Chrome
+
+## Summary
+
+When implementing Electron's hidden-titlebar chrome on macOS, renderer-side
+changes must stay gated to macOS just as strictly as main-process options.
+Unconditional `-webkit-app-region: drag` classes leak window-drag behavior to
+Windows and Linux, and native traffic-light geometry must be reserved in both
+dimensions so the controls do not overlay adjacent UI columns.
+
+## Findings
+
+### 1. vf-app-drag-region applied on all platforms, not just macOS
+
+- **Source:** github-claude | PR #407 round 1 | 2026-06-09
+- **Severity:** MEDIUM
+- **File:** `src/features/sessions/components/Tabs.tsx`, `src/features/workspace/components/IconRail.tsx`
+- **Finding:** Both components unconditionally added `vf-app-drag-region` to their root elements. Electron honors `-webkit-app-region: drag` on Windows and Linux even with `frame: true`, turning empty chrome areas into unintended window-drag handles.
+- **Fix:** Made the class conditional on `reserveWindowControls` (macOS-only) in both `Tabs` and `IconRail`, and passed the flag down from `WorkspaceView`.
+
+### 2. Reserve the full traffic-light width
+
+- **Source:** github-codex-connector | PR #407 round 1 | 2026-06-09
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/workspace/components/IconRail.tsx`
+- **Finding:** The 48px icon rail was narrower than the native traffic-light group placed at `x: 16` in `electron/main.ts`, so the yellow/green controls extended into the sidebar column.
+- **Fix:** Widened the rail to 68px (`w-[68px]`) when `reserveWindowControls` is true and updated the parent `gridTemplateColumns` in `WorkspaceView.tsx` to match.
+
+### 3. reserveWindowControls uses a redundant double platform check
+
+- **Source:** github-claude | PR #407 round 1 | 2026-06-09
+- **Severity:** LOW
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** `reserveWindowControls = preferModifier === 'meta' && isMacPlatform()` — both sub-expressions resolve via the exact same macOS detection, making the `&&` a logical no-op.
+- **Fix:** Simplified to `const reserveWindowControls = preferModifier === 'meta'` and removed the now-unused `isMacPlatform` helper.
+
+### 4. Magic number 52 in IconRail paddingTop is undocumented
+
+- **Source:** github-claude | PR #407 round 1 | 2026-06-09
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/IconRail.tsx`
+- **Finding:** The `52` in `paddingTop: reserveWindowControls ? 52 : 10` encoded `trafficLightPosition.y (13) + button diameter (~28) + gap (~11)` from `electron/main.ts` with no comment or named constant.
+- **Fix:** Introduced `MACOS_TRAFFIC_LIGHT_RESERVE_PX = 52` with an inline comment explaining the derivation.
+
+### 5. IconRail.test.tsx missing conditional vf-app-drag-region assertions
+
+- **Source:** github-claude | PR #407 round 2 | 2026-06-09
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/components/IconRail.test.tsx`
+- **Finding:** The `reserveWindowControls` test only asserted `paddingTop: '52px'`; it did not check that `vf-app-drag-region` is present when the prop is true, nor that it is absent when false. A regression reverting the class to unconditional application would pass tests undetected.
+- **Fix:** Added `toHaveClass('vf-app-drag-region')` and `toHaveClass('w-[68px]')` assertions to the existing test, plus a mirroring no-reserve test asserting `not.toHaveClass('vf-app-drag-region')`.
+
+### 6. backgroundColor '#121221' undocumented in main-process options
+
+- **Source:** github-claude | PR #407 round 2 | 2026-06-09
+- **Severity:** LOW
+- **File:** `electron/main.ts`
+- **Finding:** `backgroundColor: '#121221'` in `macosWindowChromeOptions` mirrored the Tailwind `bg-background` token with no comment linking the two. A future design iteration updating the token would leave the native window flash color stale.
+- **Fix:** Added an inline comment documenting the relationship to the Tailwind token and warning to keep them in sync.

--- a/docs/reviews/patterns/macos-window-chrome.md
+++ b/docs/reviews/patterns/macos-window-chrome.md
@@ -2,8 +2,8 @@
 id: macos-window-chrome
 category: cross-platform
 created: 2026-06-09
-last_updated: 2026-06-09
-ref_count: 0
+last_updated: 2026-06-10
+ref_count: 1
 ---
 
 # macOS Window Chrome
@@ -65,3 +65,11 @@ dimensions so the controls do not overlay adjacent UI columns.
 - **File:** `electron/main.ts`
 - **Finding:** `backgroundColor: '#121221'` in `macosWindowChromeOptions` mirrored the Tailwind `bg-background` token with no comment linking the two. A future design iteration updating the token would leave the native window flash color stale.
 - **Fix:** Added an inline comment documenting the relationship to the Tailwind token and warning to keep them in sync.
+
+### 7. SidebarTopBar drag region applied unconditionally on all platforms
+
+- **Source:** github-codex-connector | PR #412 round 1 | 2026-06-10
+- **Severity:** HIGH
+- **File:** `src/features/workspace/components/SidebarTopBar.tsx`
+- **Finding:** `SidebarTopBar` unconditionally added `vf-app-drag-region` to its root element, while `WorkspaceView` already computed the macOS-only `reserveWindowControls` flag and `Tabs` correctly gated the same class behind it. Electron honors `-webkit-app-region: drag` on Windows and Linux, turning the expanded sidebar top bar into an unintended window-drag handle.
+- **Fix:** Added a `reserveWindowControls` prop to `SidebarTopBar`, made `vf-app-drag-region` conditional on it, passed the existing `reserveWindowControls` value from `WorkspaceView`, and added a non-macOS test asserting the class is absent.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -61,6 +61,17 @@ protocol.registerSchemesAsPrivileged([
 const BINARY_NAME =
   process.platform === 'win32' ? 'vimeflow-backend.exe' : 'vimeflow-backend'
 
+const macosWindowChromeOptions =
+  process.platform === 'darwin'
+    ? {
+        // Matches Tailwind bg-background token — update if
+        // tailwind.config.js colors.background changes.
+        backgroundColor: '#121221',
+        titleBarStyle: 'hiddenInset' as const,
+        trafficLightPosition: { x: 16, y: 13 },
+      }
+    : {}
+
 const resolveSidecarBin = (): string => {
   if (app.isPackaged) {
     return path.join(process.resourcesPath, 'bin', BINARY_NAME)
@@ -264,6 +275,7 @@ const createWindow = (): void => {
     minHeight: 600,
     title: 'Vimeflow',
     resizable: true,
+    ...macosWindowChromeOptions,
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,

--- a/src/features/sessions/components/Tabs.test.tsx
+++ b/src/features/sessions/components/Tabs.test.tsx
@@ -95,9 +95,22 @@ describe('Tabs', () => {
   })
 
   test('makes only empty tab-strip chrome draggable on macOS', () => {
-    renderTabs([buildSession()], 'sess-1', {}, true)
+    render(
+      <Tabs
+        sessions={[buildSession()]}
+        activeSessionId="sess-1"
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        onNew={vi.fn()}
+        leading={<button data-testid="leading-fixture">L</button>}
+        reserveWindowControls
+      />
+    )
 
     expect(screen.getByTestId('session-tabs')).toHaveClass('vf-app-drag-region')
+    expect(screen.getByTestId('session-tabs-leading')).toHaveClass(
+      'vf-app-no-drag'
+    )
     expect(screen.getByRole('tablist')).toHaveClass('vf-app-no-drag')
     expect(screen.getByRole('button', { name: 'New session' })).toHaveClass(
       'vf-app-no-drag'

--- a/src/features/sessions/components/Tabs.test.tsx
+++ b/src/features/sessions/components/Tabs.test.tsx
@@ -48,7 +48,8 @@ const renderTabs = (
     onSelect: (id: string) => void
     onClose: (id: string) => void
     onNew: () => void
-  }> = {}
+  }> = {},
+  reserveWindowControls = false
 ): ReturnType<typeof render> =>
   render(
     <Tabs
@@ -57,6 +58,7 @@ const renderTabs = (
       onSelect={handlers.onSelect ?? vi.fn()}
       onClose={handlers.onClose ?? vi.fn()}
       onNew={handlers.onNew ?? vi.fn()}
+      reserveWindowControls={reserveWindowControls}
     />
   )
 
@@ -90,6 +92,24 @@ describe('Tabs', () => {
     renderTabs([buildSession()], 'sess-1')
     const strip = screen.getByTestId('session-tabs')
     expect(strip.className).toContain('h-[38px]')
+  })
+
+  test('makes only empty tab-strip chrome draggable on macOS', () => {
+    renderTabs([buildSession()], 'sess-1', {}, true)
+
+    expect(screen.getByTestId('session-tabs')).toHaveClass('vf-app-drag-region')
+    expect(screen.getByRole('tablist')).toHaveClass('vf-app-no-drag')
+    expect(screen.getByRole('button', { name: 'New session' })).toHaveClass(
+      'vf-app-no-drag'
+    )
+  })
+
+  test('does NOT apply drag region on non-macOS platforms', () => {
+    renderTabs([buildSession()], 'sess-1')
+
+    expect(screen.getByTestId('session-tabs')).not.toHaveClass(
+      'vf-app-drag-region'
+    )
   })
 
   test('exposes a tablist for assistive navigation', () => {

--- a/src/features/sessions/components/Tabs.tsx
+++ b/src/features/sessions/components/Tabs.tsx
@@ -15,6 +15,7 @@ export interface TabsProps {
   onNew: () => void
   /** Optional in-flow control seated at the bar's left (the sidebar toggle when the sidebar is collapsed); tabs flow after it, so they never sit under it. */
   leading?: ReactNode
+  reserveWindowControls?: boolean
 }
 
 export const Tabs = ({
@@ -24,6 +25,7 @@ export const Tabs = ({
   onClose,
   onNew,
   leading = undefined,
+  reserveWindowControls = false,
 }: TabsProps): ReactElement => {
   // Single source of truth for "what's visible in the strip" — see
   // `getVisibleSessions` for the predicate. Both this component and
@@ -89,7 +91,7 @@ export const Tabs = ({
       data-testid="session-tabs"
       className={`flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest pr-2 ${
         leading ? 'pl-[12px]' : 'pl-2'
-      }`}
+      }${reserveWindowControls ? ' vf-app-drag-region' : ''}`}
     >
       {leading && (
         <div className="mr-2 flex shrink-0 items-center self-center">
@@ -113,7 +115,7 @@ export const Tabs = ({
         // currently active — pre-announcing #177's binding before it
         // lands would mislead AT users into trying a non-functional
         // shortcut.
-        className="flex items-end gap-0.5"
+        className="vf-app-no-drag flex items-end gap-0.5"
       >
         {open.map((session, idx) => {
           const isActive = session.id === activeSessionId
@@ -140,7 +142,7 @@ export const Tabs = ({
         onClick={onNew}
         aria-label="New session"
         title="New session"
-        className="mb-px ml-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-on-surface-variant transition-colors hover:bg-primary/10 hover:text-primary"
+        className="vf-app-no-drag mb-px ml-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-on-surface-variant transition-colors hover:bg-primary/10 hover:text-primary"
       >
         <span className="material-symbols-outlined text-[15px]">add</span>
       </button>

--- a/src/features/sessions/components/Tabs.tsx
+++ b/src/features/sessions/components/Tabs.tsx
@@ -92,9 +92,18 @@ export const Tabs = ({
       className={`flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest pr-2 ${
         leading ? 'pl-[12px]' : 'pl-2'
       }${reserveWindowControls ? ' vf-app-drag-region' : ''}`}
+      style={{
+        paddingLeft:
+          leading && reserveWindowControls
+            ? 'max(12px, var(--workspace-window-controls-inset, 0px))'
+            : undefined,
+      }}
     >
       {leading && (
-        <div className="mr-2 flex shrink-0 items-center self-center">
+        <div
+          data-testid="session-tabs-leading"
+          className="vf-app-no-drag mr-2 flex shrink-0 items-center self-center"
+        >
           {leading}
         </div>
       )}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1714,6 +1714,7 @@ export const WorkspaceView = (): ReactElement => {
                   sidebarShortcutHint={sidebarShortcutHint}
                   settingsIssueNumber={SETTINGS_FOLLOWUP_ISSUE_NUMBER}
                   toggleRef={sidebarToggleTopbarRef}
+                  reserveWindowControls={reserveWindowControls}
                 />
               )
             }

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -268,6 +268,7 @@ export const WorkspaceView = (): ReactElement => {
   // Real command-palette chord for the top-bar utility hint (Ctrl+; / ⌘;),
   // not the ⌘K placeholder in the static design mock.
   const commandShortcutHint = formatShortcut(COMMAND_PALETTE_SHORTCUT_KEYS)
+  const reserveWindowControls = preferModifier === 'meta'
 
   const { message: infoMessage, notifyInfo, dismiss } = useNotifyInfo()
   const { activeTab, setActiveTab } = useSidebarTab()
@@ -1818,6 +1819,7 @@ export const WorkspaceView = (): ReactElement => {
               />
             ) : undefined
           }
+          reserveWindowControls={reserveWindowControls}
         />
 
         <div

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -168,6 +168,7 @@ const MAIN_AUTO_COLLAPSE_MAX = 500
 const MAIN_AUTO_COLLAPSE_RATIO = 0.36
 const SIDEBAR_MOTION_MS = 220
 const SIDEBAR_MOTION_EASING = 'cubic-bezier(0.32, 0.72, 0, 1)'
+const MACOS_WINDOW_CONTROL_SAFE_AREA_PX = 82
 
 const SIDEBAR_INITIAL = clampSize(SIDEBAR_DEFAULT, SIDEBAR_MIN, SIDEBAR_MAX)
 const COMPACT_WORKSPACE_QUERY = '(max-width: 899px)'
@@ -269,6 +270,10 @@ export const WorkspaceView = (): ReactElement => {
   // not the ⌘K placeholder in the static design mock.
   const commandShortcutHint = formatShortcut(COMMAND_PALETTE_SHORTCUT_KEYS)
   const reserveWindowControls = preferModifier === 'meta'
+
+  const windowControlsInset = reserveWindowControls
+    ? MACOS_WINDOW_CONTROL_SAFE_AREA_PX
+    : 0
 
   const { message: infoMessage, notifyInfo, dismiss } = useNotifyInfo()
   const { activeTab, setActiveTab } = useSidebarTab()
@@ -1631,6 +1636,7 @@ export const WorkspaceView = (): ReactElement => {
           // VIM-76: icon rail removed — layout is [sidebar | main | activity].
           // Desktop collapse animates the sidebar shell width; compact viewports
           // switch to a single-column workspace with the sidebar as an overlay.
+          '--workspace-window-controls-inset': `${windowControlsInset}px`,
           gridTemplateColumns: isCompactViewport ? '1fr' : `auto 1fr auto`,
         } as CSSProperties
       }
@@ -1698,7 +1704,7 @@ export const WorkspaceView = (): ReactElement => {
                   aria-hidden="true"
                   data-testid="sidebar-top-bar-placeholder"
                   className="bg-surface-container-low"
-                  style={{ height: 38, flexShrink: 0 }}
+                  style={{ height: 42, flexShrink: 0 }}
                 />
               ) : (
                 <SidebarTopBar

--- a/src/features/workspace/components/SidebarToggle.tsx
+++ b/src/features/workspace/components/SidebarToggle.tsx
@@ -59,7 +59,7 @@ export const SidebarToggle = forwardRef<HTMLButtonElement, SidebarToggleProps>(
         aria-label={collapsed ? 'Show sidebar' : 'Hide sidebar'}
         aria-expanded={!collapsed}
         style={{ width: size, height: size }}
-        className={`grid shrink-0 cursor-pointer place-items-center rounded-[7px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container ${VARIANT_CLASS[variant]}`}
+        className={`vf-app-no-drag grid shrink-0 cursor-pointer place-items-center rounded-[7px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container ${VARIANT_CLASS[variant]}`}
       >
         <svg
           width="16"

--- a/src/features/workspace/components/SidebarTopBar.test.tsx
+++ b/src/features/workspace/components/SidebarTopBar.test.tsx
@@ -21,8 +21,12 @@ describe('SidebarTopBar', () => {
     expect(screen.getByTestId('sidebar-toggle-topbar')).toBeInTheDocument()
   })
 
-  test('keeps empty expanded top-bar chrome draggable while controls remain clickable', () => {
-    renderTopBar({ onCommand: vi.fn(), onSettings: vi.fn() })
+  test('keeps empty expanded top-bar chrome draggable while controls remain clickable on macOS', () => {
+    renderTopBar({
+      onCommand: vi.fn(),
+      onSettings: vi.fn(),
+      reserveWindowControls: true,
+    })
 
     expect(screen.getByTestId('sidebar-top-bar')).toHaveClass(
       'vf-app-drag-region'
@@ -38,6 +42,18 @@ describe('SidebarTopBar', () => {
 
     expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass(
       'vf-app-no-drag'
+    )
+  })
+
+  test('does not apply drag-region class on non-macOS platforms', () => {
+    renderTopBar({
+      onCommand: vi.fn(),
+      onSettings: vi.fn(),
+      reserveWindowControls: false,
+    })
+
+    expect(screen.getByTestId('sidebar-top-bar')).not.toHaveClass(
+      'vf-app-drag-region'
     )
   })
 

--- a/src/features/workspace/components/SidebarTopBar.test.tsx
+++ b/src/features/workspace/components/SidebarTopBar.test.tsx
@@ -21,6 +21,26 @@ describe('SidebarTopBar', () => {
     expect(screen.getByTestId('sidebar-toggle-topbar')).toBeInTheDocument()
   })
 
+  test('keeps empty expanded top-bar chrome draggable while controls remain clickable', () => {
+    renderTopBar({ onCommand: vi.fn(), onSettings: vi.fn() })
+
+    expect(screen.getByTestId('sidebar-top-bar')).toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(screen.getByTestId('sidebar-toggle-topbar')).toHaveClass(
+      'vf-app-no-drag'
+    )
+
+    expect(screen.getByRole('button', { name: 'Command Palette' })).toHaveClass(
+      'vf-app-no-drag'
+    )
+
+    expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass(
+      'vf-app-no-drag'
+    )
+  })
+
   test('the toggle invokes onToggleSidebar', async () => {
     const user = userEvent.setup()
     const onToggleSidebar = vi.fn()

--- a/src/features/workspace/components/SidebarTopBar.tsx
+++ b/src/features/workspace/components/SidebarTopBar.tsx
@@ -60,6 +60,7 @@ const TopBarUtil = ({
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
         aria-label={label}
+        className="vf-app-no-drag"
         style={style}
       >
         <span
@@ -91,9 +92,9 @@ export interface SidebarTopBarProps {
   toggleRef?: Ref<HTMLButtonElement>
 }
 
-// The new sidebar chrome row (38px). Uses the sidebar's own surface
+// The new sidebar chrome row. Uses the sidebar's own surface
 // (bg-surface-container-low) with no bottom divider, so the top bar blends into
-// the sidebar. The 38px height still seats the open-state toggle at the same
+// the sidebar. The height seats the open-state toggle at the same
 // vertical position as the collapsed-state tab-bar toggle. Toggle pinned left;
 // Command Palette + Settings pinned right — all three are icon-only 28x28 buttons.
 export const SidebarTopBar = ({
@@ -107,14 +108,14 @@ export const SidebarTopBar = ({
 }: SidebarTopBarProps): ReactElement => (
   <div
     data-testid="sidebar-top-bar"
-    className="bg-surface-container-low"
+    className="vf-app-drag-region bg-surface-container-low"
     style={{
-      height: 38,
+      height: 42,
       flexShrink: 0,
       display: 'flex',
       alignItems: 'center',
       gap: 6,
-      paddingLeft: 12,
+      paddingLeft: 'max(12px, var(--workspace-window-controls-inset, 0px))',
       paddingRight: 10,
     }}
   >

--- a/src/features/workspace/components/SidebarTopBar.tsx
+++ b/src/features/workspace/components/SidebarTopBar.tsx
@@ -90,6 +90,8 @@ export interface SidebarTopBarProps {
   settingsIssueNumber?: number
   /** Ref forwarded to the collapse-toggle button for imperative focus. */
   toggleRef?: Ref<HTMLButtonElement>
+  /** Whether the platform reserves space for macOS inset window controls. */
+  reserveWindowControls?: boolean
 }
 
 // The new sidebar chrome row. Uses the sidebar's own surface
@@ -105,10 +107,13 @@ export const SidebarTopBar = ({
   sidebarShortcutHint = '⌘B',
   settingsIssueNumber = undefined,
   toggleRef = undefined,
+  reserveWindowControls = false,
 }: SidebarTopBarProps): ReactElement => (
   <div
     data-testid="sidebar-top-bar"
-    className="vf-app-drag-region bg-surface-container-low"
+    className={`bg-surface-container-low${
+      reserveWindowControls ? ' vf-app-drag-region' : ''
+    }`}
     style={{
       height: 42,
       flexShrink: 0,

--- a/src/index.css
+++ b/src/index.css
@@ -97,6 +97,15 @@
     @apply bg-background text-on-surface font-body overflow-hidden m-0;
   }
 
+  .vf-app-drag-region {
+    -webkit-app-region: drag;
+    user-select: none;
+  }
+
+  .vf-app-no-drag {
+    -webkit-app-region: no-drag;
+  }
+
   .material-symbols-outlined {
     font-family: 'Material Symbols Outlined Variable';
     font-weight: normal;


### PR DESCRIPTION
## Summary
- reserve a macOS traffic-light safe area for sidebar chrome when the hidden titlebar is active
- make expanded sidebar top-bar empty chrome draggable while keeping controls no-drag/clickable
- keep collapsed tab-strip dragging while preserving the sidebar toggle click target

## Root cause
Electron `-webkit-app-region: drag` made collapsed/expanded chrome usable as window drag regions, but controls inside those regions need explicit `no-drag` islands. The current sidebar also started controls inside the traffic-light hit zone when using macOS hidden titlebar chrome.

## Linear
Refs VIM-66

## Validation
- `npm run lint`
- `npm test -- --run`
- `npm run type-check`
- `npm run build`