### PR TITLE
fix: refine sidebar chrome for macOS controls

### DIFF
--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -52,10 +52,8 @@ vi.mock('../files/services/fileSystemService')
 vi.mock('../terminal/services/terminalService')
 vi.mock('../terminal/hooks/usePaneShortcuts')
 
-// Mock child components to keep test focused on integration. The Sidebar mock
-// renders its `topBar` slot so the real SidebarTopBar (VIM-76: home of the
-// Command Palette button that replaced the old icon rail) mounts and its
-// onCommand wiring stays under test.
+// Mock child components to keep test focused on command dispatch while still
+// rendering sidebar chrome needed by WorkspaceView.
 vi.mock('../../components/sidebar/Sidebar', () => ({
   Sidebar: ({ topBar = undefined }: { topBar?: ReactNode }): ReactElement => (
     <div data-testid="sidebar">{topBar}</div>
@@ -694,7 +692,10 @@ describe('WorkspaceView - Command Palette Integration', () => {
       screen.queryByRole('dialog', { name: 'Command palette' })
     ).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: 'Command Palette' }))
+    await user.click(
+      screen.getByRole('button', { name: /open command palette/i })
+    )
+
     expect(
       screen.queryByRole('dialog', { name: 'Command palette' })
     ).not.toBeInTheDocument()
@@ -829,13 +830,15 @@ describe('WorkspaceView - Command Palette Integration', () => {
     })
   })
 
-  test('top-bar command button opens the palette', async () => {
+  test('status-bar command button opens the palette', async () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)
 
     expect(screen.queryByRole('dialog', { name: 'Command palette' })).toBeNull()
 
-    await user.click(screen.getByRole('button', { name: 'Command Palette' }))
+    await user.click(
+      screen.getByRole('button', { name: /open command palette/i })
+    )
 
     expect(
       screen.getByRole('dialog', { name: 'Command palette' })

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -437,14 +437,14 @@ describe('WorkspaceView', () => {
       await user.click(screen.getByTestId('sidebar-toggle-tabs'))
       expect(screen.getByTestId('sidebar-scrim')).toBeInTheDocument()
 
-      // Move focus into the drawer content (Command Palette button), not the toggle
-      const commandButton = screen.getByRole('button', {
-        name: 'Command Palette',
+      // Move focus into the drawer content (Settings footer), not the toggle.
+      const settingsButton = screen.getByRole('button', {
+        name: /^Settings/,
       })
       act(() => {
-        commandButton.focus()
+        settingsButton.focus()
       })
-      expect(commandButton).toHaveFocus()
+      expect(settingsButton).toHaveFocus()
 
       // Fire the global sidebar shortcut to close the drawer
       act(() => {
@@ -1101,21 +1101,23 @@ describe('WorkspaceView', () => {
     expect(container).toHaveClass('h-screen')
   })
 
-  test('renders sidebar top-bar utility buttons (no account avatar)', () => {
+  test('renders Settings in the sidebar footer and keeps utility buttons out of the top bar', () => {
     render(<WorkspaceView />)
 
-    // VIM-76: utilities moved from the icon rail to the sidebar top bar.
+    // VIM-76: icon rail removed. VIM-66 follow-up keeps traffic-light chrome
+    // clear by moving Settings into the footer.
     const topBar = screen.getByTestId('sidebar-top-bar')
+    const footer = screen.getByTestId('sidebar-footer-wrapper')
 
     expect(within(topBar).queryByRole('img', { name: 'Account' })).toBeNull()
 
     expect(
-      within(topBar).getByRole('button', { name: 'Command Palette' })
-    ).toBeInTheDocument()
+      within(topBar).queryByRole('button', { name: 'Command Palette' })
+    ).not.toBeInTheDocument()
 
     // Settings aria-label is "Settings — coming (see issue #252)".
     expect(
-      within(topBar).getByRole('button', { name: /^Settings/ })
+      within(footer).getByRole('button', { name: /^Settings/ })
     ).toHaveAttribute('aria-disabled', 'true')
   })
 
@@ -1149,17 +1151,18 @@ describe('WorkspaceView', () => {
     expect(panel).toBeInTheDocument()
   })
 
-  test('renders utility actions in the sidebar top bar', () => {
+  test('renders Settings in the sidebar footer', () => {
     render(<WorkspaceView />)
 
     const topBar = screen.getByTestId('sidebar-top-bar')
+    const footer = screen.getByTestId('sidebar-footer-wrapper')
 
     expect(
-      within(topBar).getByRole('button', { name: 'Command Palette' })
-    ).toBeInTheDocument()
+      within(topBar).queryByRole('button', { name: 'Command Palette' })
+    ).not.toBeInTheDocument()
 
     expect(
-      within(topBar).getByRole('button', { name: /^Settings/ })
+      within(footer).getByRole('button', { name: /^Settings/ })
     ).toBeInTheDocument()
   })
 
@@ -1229,12 +1232,14 @@ describe('WorkspaceView', () => {
     expect(screen.getByTestId('files-view')).not.toHaveClass('hidden')
   })
 
-  test('Sidebar footer slot is suppressed in WorkspaceView', () => {
+  test('Sidebar footer seats Settings at the bottom of WorkspaceView', () => {
     render(<WorkspaceView />)
 
     expect(
-      screen.queryByTestId('sidebar-footer-wrapper')
-    ).not.toBeInTheDocument()
+      within(screen.getByTestId('sidebar-footer-wrapper')).getByRole('button', {
+        name: /^Settings/,
+      })
+    ).toBeInTheDocument()
   })
 
   test('bottom-pane resize handle is gone in WorkspaceView', () => {
@@ -1320,13 +1325,15 @@ describe('WorkspaceView', () => {
     await screen.findByRole('button', { name: 'session 2' })
   })
 
-  test('opens command palette from the top-bar command button', async () => {
+  test('opens command palette from the status-bar command button', async () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)
 
     expect(screen.queryByRole('dialog', { name: 'Command palette' })).toBeNull()
 
-    await user.click(screen.getByRole('button', { name: 'Command Palette' }))
+    await user.click(
+      screen.getByRole('button', { name: /open command palette/i })
+    )
 
     expect(
       screen.getByRole('dialog', { name: 'Command palette' })

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react'
 import { SidebarToggle } from './components/SidebarToggle'
 import { SidebarTopBar } from './components/SidebarTopBar'
+import { SidebarSettingsFooter } from './components/SidebarSettingsFooter'
 import { Tabs } from '../sessions/components/Tabs'
 import { Sidebar } from '../../components/sidebar/Sidebar'
 import {
@@ -52,7 +53,6 @@ import {
   usePaneRenameChord,
   type FocusedPaneRef,
 } from '../command-palette/hooks/usePaneRenameChord'
-import { formatShortcut } from '../../lib/formatShortcut'
 import { renameAgentSession } from '../../lib/backend'
 import { useSessionManager } from '../sessions/hooks/useSessionManager'
 import {
@@ -266,9 +266,6 @@ export const WorkspaceView = (): ReactElement => {
 
   const newSessionAriaKeyshortcuts =
     preferModifier === 'meta' ? 'Meta+N' : 'Control+Shift+N'
-  // Real command-palette chord for the top-bar utility hint (Ctrl+; / ⌘;),
-  // not the ⌘K placeholder in the static design mock.
-  const commandShortcutHint = formatShortcut(COMMAND_PALETTE_SHORTCUT_KEYS)
   const reserveWindowControls = preferModifier === 'meta'
 
   const windowControlsInset = reserveWindowControls
@@ -1709,10 +1706,7 @@ export const WorkspaceView = (): ReactElement => {
               ) : (
                 <SidebarTopBar
                   onToggleSidebar={handleToggleSidebar}
-                  onCommand={commandPalette.open}
-                  commandShortcutHint={commandShortcutHint}
                   sidebarShortcutHint={sidebarShortcutHint}
-                  settingsIssueNumber={SETTINGS_FOLLOWUP_ISSUE_NUMBER}
                   toggleRef={sidebarToggleTopbarRef}
                   reserveWindowControls={reserveWindowControls}
                 />
@@ -1758,6 +1752,13 @@ export const WorkspaceView = (): ReactElement => {
                   onFileSelect={handleFileSelect}
                 />
               </div>
+            }
+            footer={
+              isSidebarClosed ? undefined : (
+                <SidebarSettingsFooter
+                  settingsIssueNumber={SETTINGS_FOLLOWUP_ISSUE_NUMBER}
+                />
+              )
             }
           />
 

--- a/src/features/workspace/WorkspaceView.verification.test.tsx
+++ b/src/features/workspace/WorkspaceView.verification.test.tsx
@@ -101,34 +101,36 @@ describe('Feature 23: Final Phase 2 Verification', () => {
     test('renders sidebar (with top bar), terminal, dock panel, and activity zones', () => {
       render(<WorkspaceView />)
 
-      // VIM-76: icon rail removed — its utilities moved to the sidebar top bar.
+      // VIM-76: icon rail removed; sidebar chrome remains in the sidebar.
       expect(screen.getByTestId('sidebar')).toBeInTheDocument()
       expect(screen.getByTestId('sidebar-top-bar')).toBeInTheDocument()
+      expect(screen.getByTestId('sidebar-footer-wrapper')).toBeInTheDocument()
       expect(screen.getByTestId('terminal-zone')).toBeInTheDocument()
       expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
       expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
     })
   })
 
-  describe('2. Sidebar top bar shows utility actions', () => {
+  describe('2. Sidebar footer shows utility actions', () => {
     test('no longer renders a placeholder account avatar (removed, VIM-66)', () => {
       render(<WorkspaceView />)
 
       expect(screen.queryByRole('img', { name: 'Account' })).toBeNull()
     })
 
-    test('displays command palette and disabled settings buttons', () => {
+    test('moves Settings to the footer and removes the command palette button', () => {
       render(<WorkspaceView />)
 
       const topBar = screen.getByTestId('sidebar-top-bar')
+      const footer = screen.getByTestId('sidebar-footer-wrapper')
 
       expect(
-        within(topBar).getByRole('button', { name: 'Command Palette' })
-      ).toBeInTheDocument()
+        within(topBar).queryByRole('button', { name: 'Command Palette' })
+      ).not.toBeInTheDocument()
 
       // Settings aria-label is "Settings — coming (see issue #252)".
       expect(
-        within(topBar).getByRole('button', { name: /^Settings/ })
+        within(footer).getByRole('button', { name: /^Settings/ })
       ).toHaveAttribute('aria-disabled', 'true')
     })
   })

--- a/src/features/workspace/components/AgentStatusCard.test.tsx
+++ b/src/features/workspace/components/AgentStatusCard.test.tsx
@@ -183,7 +183,7 @@ describe('AgentStatusCard', () => {
     const card = screen.getByTestId('sidebar-agent-status-card')
     expect(card).toHaveStyle({
       width: '100%',
-      maxWidth: '320px',
+      maxWidth: '360px',
       height: '125px',
     })
 
@@ -193,7 +193,7 @@ describe('AgentStatusCard', () => {
 
     expect(screen.getByTestId('sidebar-agent-status-card')).toHaveStyle({
       width: '100%',
-      maxWidth: '320px',
+      maxWidth: '360px',
       height: '125px',
     })
   })

--- a/src/features/workspace/components/AgentStatusCard.tsx
+++ b/src/features/workspace/components/AgentStatusCard.tsx
@@ -39,8 +39,9 @@ export interface AgentStatusCardProps {
 
 // The 272px minimum/default sidebar gives this card 248px of available header
 // width after horizontal padding. Wider sidebars may give the card more room,
-// but cap at 320px so the chrome stays composed and left-pinned.
-const CARD_MAX_W = 320
+// but cap at the same right edge as the tabs + new-session row:
+// 202px tabs + 8px gap + 150px new-session cap.
+const CARD_MAX_W = 360
 // 125 = 12 (top pad) + 24 (header: h-6 pill / leading-6 title) + 9 (gap)
 // + 66 (CARD_BODY_H) + 14 (bottom pad). Still ONE fixed height across agent
 // and shell states, so switching panes never reflows the session list.

--- a/src/features/workspace/components/NewSessionButton.test.tsx
+++ b/src/features/workspace/components/NewSessionButton.test.tsx
@@ -16,6 +16,24 @@ describe('NewSessionButton', () => {
     expect(
       screen.getByRole('button', { name: 'New session' })
     ).toBeInTheDocument()
+    expect(screen.getByText('New session')).toBeInTheDocument()
+  })
+
+  test('keeps the compact icon size while allowing the button to expand', () => {
+    render(
+      <NewSessionButton
+        onClick={vi.fn()}
+        shortcutHint="⌘N"
+        ariaKeyshortcuts="Meta+N"
+      />
+    )
+
+    expect(screen.getByTestId('sidebar-new-session')).toHaveClass(
+      'min-w-[38px]',
+      'max-w-[150px]',
+      'flex-1',
+      'vf-new-session-button'
+    )
   })
 
   test('clicking calls onClick', async () => {

--- a/src/features/workspace/components/NewSessionButton.tsx
+++ b/src/features/workspace/components/NewSessionButton.tsx
@@ -24,13 +24,18 @@ export const NewSessionButton = ({
       aria-label="New session"
       aria-keyshortcuts={ariaKeyshortcuts}
       data-testid="sidebar-new-session"
-      className="grid w-[38px] shrink-0 place-items-center self-stretch rounded-[10px] border border-[rgba(203,166,247,0.32)] bg-[rgba(203,166,247,0.1)] text-[#e2c7ff] transition-colors hover:bg-[rgba(203,166,247,0.2)] hover:text-[#f3eaff] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+      className="vf-new-session-button group grid min-w-[38px] max-w-[150px] flex-1 shrink place-items-center self-stretch overflow-hidden rounded-[10px] border border-[rgba(243,234,255,0.26)] bg-[linear-gradient(180deg,rgba(214,174,255,0.98)_0%,rgba(166,110,224,0.98)_100%)] text-[#20122c] shadow-[0_8px_18px_rgba(166,110,224,0.2),inset_0_1px_0_rgba(255,255,255,0.36)] transition-[filter,transform,box-shadow] hover:brightness-110 active:translate-y-px focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
     >
-      <span
-        className="material-symbols-outlined text-[19px]"
-        aria-hidden="true"
-      >
-        add
+      <span className="vf-new-session-button-content flex min-w-0 items-center justify-center">
+        <span
+          className="material-symbols-outlined text-[19px]"
+          aria-hidden="true"
+        >
+          add
+        </span>
+        <span className="vf-new-session-label overflow-hidden whitespace-nowrap font-body text-[13px] font-semibold">
+          New session
+        </span>
       </span>
     </button>
   </Tooltip>

--- a/src/features/workspace/components/SidebarSettingsFooter.test.tsx
+++ b/src/features/workspace/components/SidebarSettingsFooter.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, test, expect, vi } from 'vitest'
+import { SidebarSettingsFooter } from './SidebarSettingsFooter'
+
+describe('SidebarSettingsFooter', () => {
+  test('renders Settings as visible bottom-sidebar text', () => {
+    render(<SidebarSettingsFooter settingsIssueNumber={252} />)
+
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+    expect(screen.getByTestId('sidebar-settings-footer')).toHaveClass(
+      'vf-app-no-drag'
+    )
+  })
+
+  test('renders as a disabled stub when no handler is wired', async () => {
+    const user = userEvent.setup()
+    render(<SidebarSettingsFooter settingsIssueNumber={252} />)
+
+    const settings = screen.getByRole('button', { name: /^Settings/ })
+    expect(settings).toHaveAttribute('aria-disabled', 'true')
+    expect(settings).toHaveAccessibleName(/issue #252/)
+
+    await user.click(settings)
+  })
+
+  test('fires onSettings when a handler is provided', async () => {
+    const user = userEvent.setup()
+    const onSettings = vi.fn()
+    render(<SidebarSettingsFooter onSettings={onSettings} />)
+
+    const settings = screen.getByRole('button', { name: 'Settings' })
+    expect(settings).not.toHaveAttribute('aria-disabled')
+
+    await user.click(settings)
+
+    expect(onSettings).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/workspace/components/SidebarSettingsFooter.tsx
+++ b/src/features/workspace/components/SidebarSettingsFooter.tsx
@@ -1,0 +1,51 @@
+import { type ReactElement } from 'react'
+import { Tooltip } from '../../../components/Tooltip'
+
+export interface SidebarSettingsFooterProps {
+  /** Open Settings; when omitted the button renders as a disabled stub. */
+  onSettings?: () => void
+  /** Settings follow-up issue number, surfaced in the disabled tooltip. */
+  settingsIssueNumber?: number
+}
+
+export const SidebarSettingsFooter = ({
+  onSettings = undefined,
+  settingsIssueNumber = undefined,
+}: SidebarSettingsFooterProps): ReactElement => {
+  const disabled = !onSettings
+
+  const label = settingsIssueNumber
+    ? `Settings — coming (see issue #${settingsIssueNumber})`
+    : 'Settings'
+
+  return (
+    <Tooltip content={label} placement="top">
+      <button
+        type="button"
+        aria-label={label}
+        aria-disabled={disabled || undefined}
+        data-testid="sidebar-settings-footer"
+        onClick={() => {
+          if (disabled) {
+            return
+          }
+
+          onSettings()
+        }}
+        className={`vf-app-no-drag flex h-10 w-full items-center gap-2 rounded-[8px] px-3 text-left text-[13px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary ${
+          disabled
+            ? 'text-on-surface-muted'
+            : 'text-on-surface-variant hover:bg-white/[0.06] hover:text-on-surface'
+        }`}
+      >
+        <span
+          className="material-symbols-outlined text-[17px]"
+          aria-hidden="true"
+        >
+          settings
+        </span>
+        <span className="min-w-0 truncate">Settings</span>
+      </button>
+    </Tooltip>
+  )
+}

--- a/src/features/workspace/components/SidebarTopBar.test.tsx
+++ b/src/features/workspace/components/SidebarTopBar.test.tsx
@@ -6,13 +6,7 @@ import { SidebarTopBar, type SidebarTopBarProps } from './SidebarTopBar'
 const renderTopBar = (
   props: Partial<SidebarTopBarProps> = {}
 ): ReturnType<typeof render> =>
-  render(
-    <SidebarTopBar
-      onToggleSidebar={vi.fn()}
-      commandShortcutHint="Ctrl+;"
-      {...props}
-    />
-  )
+  render(<SidebarTopBar onToggleSidebar={vi.fn()} {...props} />)
 
 describe('SidebarTopBar', () => {
   test('renders the collapse toggle on the left', () => {
@@ -23,8 +17,6 @@ describe('SidebarTopBar', () => {
 
   test('keeps empty expanded top-bar chrome draggable while controls remain clickable on macOS', () => {
     renderTopBar({
-      onCommand: vi.fn(),
-      onSettings: vi.fn(),
       reserveWindowControls: true,
     })
 
@@ -35,20 +27,10 @@ describe('SidebarTopBar', () => {
     expect(screen.getByTestId('sidebar-toggle-topbar')).toHaveClass(
       'vf-app-no-drag'
     )
-
-    expect(screen.getByRole('button', { name: 'Command Palette' })).toHaveClass(
-      'vf-app-no-drag'
-    )
-
-    expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass(
-      'vf-app-no-drag'
-    )
   })
 
   test('does not apply drag-region class on non-macOS platforms', () => {
     renderTopBar({
-      onCommand: vi.fn(),
-      onSettings: vi.fn(),
       reserveWindowControls: false,
     })
 
@@ -67,63 +49,15 @@ describe('SidebarTopBar', () => {
     expect(onToggleSidebar).toHaveBeenCalledTimes(1)
   })
 
-  test('the Command Palette button is icon-only and fires onCommand', async () => {
-    const user = userEvent.setup()
-    const onCommand = vi.fn()
-    renderTopBar({ onCommand, commandShortcutHint: 'Ctrl+;' })
-
-    const button = screen.getByRole('button', { name: 'Command Palette' })
-    // Icon-only: the shortcut lives in the tooltip, not inline on the button.
-    expect(button).not.toHaveTextContent('Ctrl+;')
-
-    await user.click(button)
-
-    expect(onCommand).toHaveBeenCalledTimes(1)
-  })
-
-  test('utilities use the project tooltip, not a native title attribute', () => {
-    renderTopBar({ onCommand: vi.fn() })
+  test('does not render sidebar utility buttons in the traffic-light row', () => {
+    renderTopBar()
 
     expect(
-      screen.getByRole('button', { name: 'Command Palette' })
-    ).not.toHaveAttribute('title')
-  })
+      screen.queryByRole('button', { name: 'Command Palette' })
+    ).not.toBeInTheDocument()
 
-  test('hovering the Command Palette button surfaces the tooltip with the shortcut chip', async () => {
-    const user = userEvent.setup()
-    renderTopBar({ onCommand: vi.fn(), commandShortcutHint: 'Ctrl+;' })
-
-    await user.hover(screen.getByRole('button', { name: 'Command Palette' }))
-
-    const tooltip = await screen.findByRole('tooltip')
-    expect(tooltip).toHaveTextContent('Command Palette')
-    expect(screen.getByTestId('tooltip-shortcut')).toHaveTextContent('Ctrl+;')
-  })
-
-  test('Settings renders as a disabled stub when no handler is wired', async () => {
-    const user = userEvent.setup()
-    const onCommand = vi.fn()
-    renderTopBar({ onCommand, settingsIssueNumber: 252 })
-
-    const settings = screen.getByRole('button', { name: /^Settings/ })
-    expect(settings).toHaveAttribute('aria-disabled', 'true')
-    expect(settings).toHaveAccessibleName(/issue #252/)
-
-    // Clicking the disabled stub is a no-op (must not throw / call anything).
-    await user.click(settings)
-    expect(onCommand).not.toHaveBeenCalled()
-  })
-
-  test('Settings enables and fires onSettings when a handler is provided', async () => {
-    const user = userEvent.setup()
-    const onSettings = vi.fn()
-    renderTopBar({ onSettings })
-
-    const settings = screen.getByRole('button', { name: /^Settings/ })
-    expect(settings).not.toHaveAttribute('aria-disabled')
-
-    await user.click(settings)
-
-    expect(onSettings).toHaveBeenCalledTimes(1)
+    expect(
+      screen.queryByRole('button', { name: /^Settings/ })
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/features/workspace/components/SidebarTopBar.tsx
+++ b/src/features/workspace/components/SidebarTopBar.tsx
@@ -1,93 +1,11 @@
-import {
-  useState,
-  type CSSProperties,
-  type ReactElement,
-  type Ref,
-} from 'react'
+import { type ReactElement, type Ref } from 'react'
 import { SidebarToggle } from './SidebarToggle'
-import { Tooltip } from '../../../components/Tooltip'
-
-interface TopBarUtilProps {
-  icon: string
-  label: string
-  /** Optional shortcut surfaced as the tooltip's shortcut chip (e.g. 'Ctrl+;'). */
-  shortcut?: string
-  onClick?: () => void
-  disabled?: boolean
-}
-
-// Compact icon-only utility button (28x28) for the right side of the sidebar
-// top bar, matching the collapse toggle. Hover highlights the background only
-// (no border-color change). The label — and, where relevant, the shortcut chip —
-// surface through the project Tooltip, never a native title.
-const TopBarUtil = ({
-  icon,
-  label,
-  shortcut = undefined,
-  onClick = undefined,
-  disabled = false,
-}: TopBarUtilProps): ReactElement => {
-  const [hover, setHover] = useState(false)
-  const lit = hover && !disabled
-
-  const style: CSSProperties = {
-    width: 28,
-    height: 28,
-    flexShrink: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 8,
-    cursor: disabled ? 'not-allowed' : 'pointer',
-    background: lit ? 'rgba(226,199,255,0.08)' : 'rgba(26,26,42,0.6)',
-    border: '1px solid rgba(74,68,79,0.3)',
-    color: disabled ? '#6c7086' : lit ? '#e2c7ff' : '#9b93ab',
-    opacity: disabled ? 0.6 : 1,
-    transition: 'all 140ms ease',
-  }
-
-  return (
-    <Tooltip content={label} shortcut={shortcut} placement="bottom">
-      <button
-        type="button"
-        aria-disabled={disabled || undefined}
-        onClick={() => {
-          if (disabled) {
-            return
-          }
-          onClick?.()
-        }}
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
-        aria-label={label}
-        className="vf-app-no-drag"
-        style={style}
-      >
-        <span
-          className="material-symbols-outlined"
-          aria-hidden="true"
-          style={{ fontSize: 15, lineHeight: 1 }}
-        >
-          {icon}
-        </span>
-      </button>
-    </Tooltip>
-  )
-}
 
 export interface SidebarTopBarProps {
   /** Toggle the sidebar collapse flag (shared with ⌘B and the palette command). */
   onToggleSidebar: () => void
-  /** Open the command palette. */
-  onCommand?: () => void
-  /** Open Settings; when omitted the button renders as a disabled stub. */
-  onSettings?: () => void
-  /** Real command-palette chord (e.g. 'Ctrl+;' / '⌘;'); shown in the button's tooltip. */
-  commandShortcutHint: string
   /** Platform-appropriate sidebar-toggle hint forwarded to the toggle tooltip. */
   sidebarShortcutHint?: string
-  /** Settings follow-up issue number, surfaced in the (disabled) tooltip. */
-  settingsIssueNumber?: number
   /** Ref forwarded to the collapse-toggle button for imperative focus. */
   toggleRef?: Ref<HTMLButtonElement>
   /** Whether the platform reserves space for macOS inset window controls. */
@@ -97,15 +15,11 @@ export interface SidebarTopBarProps {
 // The new sidebar chrome row. Uses the sidebar's own surface
 // (bg-surface-container-low) with no bottom divider, so the top bar blends into
 // the sidebar. The height seats the open-state toggle at the same
-// vertical position as the collapsed-state tab-bar toggle. Toggle pinned left;
-// Command Palette + Settings pinned right — all three are icon-only 28x28 buttons.
+// vertical position as the collapsed-state tab-bar toggle. The remaining
+// empty chrome is intentionally left open for the macOS drag region.
 export const SidebarTopBar = ({
   onToggleSidebar,
-  onCommand = undefined,
-  onSettings = undefined,
-  commandShortcutHint,
   sidebarShortcutHint = '⌘B',
-  settingsIssueNumber = undefined,
   toggleRef = undefined,
   reserveWindowControls = false,
 }: SidebarTopBarProps): ReactElement => (
@@ -133,21 +47,5 @@ export const SidebarTopBar = ({
       shortcutHint={sidebarShortcutHint}
     />
     <div style={{ flex: 1 }} />
-    <TopBarUtil
-      icon="terminal"
-      label="Command Palette"
-      shortcut={commandShortcutHint}
-      onClick={onCommand}
-    />
-    <TopBarUtil
-      icon="settings"
-      label={
-        settingsIssueNumber
-          ? `Settings — coming (see issue #${settingsIssueNumber})`
-          : 'Settings'
-      }
-      onClick={onSettings}
-      disabled={!onSettings}
-    />
   </div>
 )

--- a/src/index.css
+++ b/src/index.css
@@ -106,6 +106,38 @@
     -webkit-app-region: no-drag;
   }
 
+  .vf-new-session-button {
+    container-type: inline-size;
+  }
+
+  .vf-new-session-button-content {
+    gap: 0;
+    padding-inline: 0;
+    transition:
+      gap 140ms ease,
+      padding-inline 140ms ease;
+  }
+
+  .vf-new-session-label {
+    max-width: 0;
+    opacity: 0;
+    transition:
+      max-width 140ms ease,
+      opacity 140ms ease;
+  }
+
+  @container (min-width: 96px) {
+    .vf-new-session-button-content {
+      gap: 6px;
+      padding-inline: 10px;
+    }
+
+    .vf-new-session-label {
+      max-width: 7rem;
+      opacity: 1;
+    }
+  }
+
   .material-symbols-outlined {
     font-family: 'Material Symbols Outlined Variable';
     font-weight: normal;

--- a/tests/e2e/core/specs/app-launch.spec.ts
+++ b/tests/e2e/core/specs/app-launch.spec.ts
@@ -8,5 +8,103 @@ describe('app launch', () => {
 
     const sidebar = await $('[data-testid="sidebar"]')
     await sidebar.waitForDisplayed()
+
+    const settingsFooter = await $('[data-testid="sidebar-settings-footer"]')
+    await settingsFooter.waitForDisplayed()
+
+    const settingsText = await settingsFooter.getText()
+    if (!settingsText.includes('Settings')) {
+      throw new Error('Settings did not render in the sidebar footer')
+    }
+
+    const commandButtonInTopBar = await browser.execute(() => {
+      const topBar = document.querySelector('[data-testid="sidebar-top-bar"]')
+      return Boolean(topBar?.querySelector('[aria-label="Command Palette"]'))
+    })
+    if (commandButtonInTopBar) {
+      throw new Error(
+        'Command Palette button still renders in the sidebar top bar'
+      )
+    }
+
+    const newSessionButton = await $('[data-testid="sidebar-new-session"]')
+    await newSessionButton.waitForDisplayed()
+    const compactWidth = await newSessionButton.getSize('width')
+
+    await browser.execute(() => {
+      document
+        .querySelector<HTMLElement>('[data-testid="workspace-view"]')
+        ?.style.setProperty('--workspace-sidebar-width', '360px')
+    })
+
+    await browser.waitUntil(
+      async () => {
+        const expandedWidth = await newSessionButton.getSize('width')
+        return expandedWidth > compactWidth + 60
+      },
+      {
+        timeout: 5_000,
+        timeoutMsg: 'New session button did not expand with the sidebar',
+      }
+    )
+
+    await browser.waitUntil(
+      async () => {
+        const labelOpacity = await browser.execute(() => {
+          const label = document.querySelector<HTMLElement>(
+            '.vf-new-session-label'
+          )
+          return label === null ? 0 : Number(getComputedStyle(label).opacity)
+        })
+        return labelOpacity > 0.95
+      },
+      {
+        timeout: 5_000,
+        timeoutMsg: 'New session label did not reveal at expanded width',
+      }
+    )
+
+    await browser.execute(() => {
+      document
+        .querySelector<HTMLElement>('[data-testid="workspace-view"]')
+        ?.style.setProperty('--workspace-sidebar-width', '520px')
+    })
+
+    await browser.waitUntil(
+      async () => {
+        const cappedWidth = await newSessionButton.getSize('width')
+        return cappedWidth <= 150 && cappedWidth >= 140
+      },
+      {
+        timeout: 5_000,
+        timeoutMsg: 'New session button did not respect the 150px width cap',
+      }
+    )
+
+    await browser.waitUntil(
+      async () => {
+        const alignment = await browser.execute(() => {
+          const card = document
+            .querySelector('[data-testid="sidebar-agent-status-card"]')
+            ?.getBoundingClientRect()
+          const button = document
+            .querySelector('[data-testid="sidebar-new-session"]')
+            ?.getBoundingClientRect()
+
+          return {
+            cardWidth: card?.width ?? 0,
+            rightEdgeDelta:
+              card && button ? Math.abs(card.right - button.right) : Infinity,
+          }
+        })
+
+        return alignment.cardWidth <= 360 && alignment.rightEdgeDelta <= 1
+      },
+      {
+        timeout: 5_000,
+        timeoutMsg:
+          'Agent status card did not align with the new session row cap',
+      }
+    )
   })
 })


### PR DESCRIPTION
## Summary

- Move Settings from the sidebar top bar into a bottom sidebar footer.
- Remove the sidebar Command Palette button while keeping the palette available elsewhere.
- Preserve the anchored sidebar toggle from the latest sidebar branch.
- Keep the top sidebar chrome clear for macOS traffic lights and drag space.
- Update the New session control to expand responsively, cap at 150px, and align with the agent status card at wider sidebar widths.

## Validation

- `npm run lint`
- `npm run type-check`
- `npm test -- --run src/features/workspace/components/SidebarTopBar.test.tsx src/features/workspace/components/SidebarSettingsFooter.test.tsx src/features/workspace/components/NewSessionButton.test.tsx src/features/workspace/components/AgentStatusCard.test.tsx src/features/workspace/WorkspaceView.test.tsx src/features/workspace/WorkspaceView.command-palette.test.tsx src/features/workspace/WorkspaceView.verification.test.tsx`
- `npm run test:e2e:build`
- `VITE_E2E=1 npx wdio tests/e2e/core/wdio.conf.ts --spec tests/e2e/core/specs/app-launch.spec.ts`
- pre-push `npm test` hook: 243 files passed, 3205 tests passed, 3 skipped

Refs VIM-66
