### PR TITLE
fix(sidebar): preserve toggle hit area

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -77,4 +77,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Status Indicator Display](patterns/status-indicator-display.md)     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                   | code-quality       | 7        | 5    | 2026-06-09   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md) | correctness        | 6        | 3    | 2026-06-08   |
-| [macOS Window Chrome](patterns/macos-window-chrome.md)               | cross-platform     | 7        | 1    | 2026-06-10   |
+| [macOS Window Chrome](patterns/macos-window-chrome.md)               | cross-platform     | 8        | 2    | 2026-06-11   |

--- a/docs/reviews/patterns/macos-window-chrome.md
+++ b/docs/reviews/patterns/macos-window-chrome.md
@@ -2,8 +2,8 @@
 id: macos-window-chrome
 category: cross-platform
 created: 2026-06-09
-last_updated: 2026-06-10
-ref_count: 1
+last_updated: 2026-06-11
+ref_count: 2
 ---
 
 # macOS Window Chrome
@@ -73,3 +73,11 @@ dimensions so the controls do not overlay adjacent UI columns.
 - **File:** `src/features/workspace/components/SidebarTopBar.tsx`
 - **Finding:** `SidebarTopBar` unconditionally added `vf-app-drag-region` to its root element, while `WorkspaceView` already computed the macOS-only `reserveWindowControls` flag and `Tabs` correctly gated the same class behind it. Electron honors `-webkit-app-region: drag` on Windows and Linux, turning the expanded sidebar top bar into an unintended window-drag handle.
 - **Fix:** Added a `reserveWindowControls` prop to `SidebarTopBar`, made `vf-app-drag-region` conditional on it, passed the existing `reserveWindowControls` value from `WorkspaceView`, and added a non-macOS test asserting the class is absent.
+
+### 8. Outer right padding excluded from drag region after moving class to inner children
+
+- **Source:** github-claude | PR #415 round 1 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/components/SidebarTopBar.tsx`, `src/features/sessions/components/Tabs.tsx`
+- **Finding:** Both bars moved `vf-app-drag-region` from the outer container to inner grid/flex children, but left `paddingRight: 10` (`SidebarTopBar`) and `pr-2` (`Tabs`) on the non-draggable outer containers. CSS grid/flex children occupy the content box, not the parent padding area, so the rightmost 10 px / 8 px strips stopped being draggable on macOS compared with the previous behavior.
+- **Fix:** Removed the outer right padding from both containers and placed the same spacing on the rightmost inner element that already owns the drag/no-drag behavior, restoring the full right-edge draggable strip.

--- a/src/features/sessions/components/Tabs.test.tsx
+++ b/src/features/sessions/components/Tabs.test.tsx
@@ -63,7 +63,7 @@ const renderTabs = (
   )
 
 describe('Tabs — leading slot', () => {
-  test('renders the leading control before the tabs and pads the bar to clear it', () => {
+  test('renders the leading control before the tabs and spaces the bar to clear it', () => {
     render(
       <Tabs
         sessions={[buildSession()]}
@@ -76,7 +76,10 @@ describe('Tabs — leading slot', () => {
     )
 
     expect(screen.getByTestId('leading-fixture')).toBeInTheDocument()
-    expect(screen.getByTestId('session-tabs')).toHaveClass('pl-[12px]')
+    expect(screen.getByTestId('session-tabs')).not.toHaveClass('pl-[12px]')
+    expect(screen.getByTestId('session-tabs-leading-offset')).toHaveStyle({
+      width: '12px',
+    })
   })
 
   test('omitting leading uses the default left padding', () => {
@@ -107,13 +110,38 @@ describe('Tabs', () => {
       />
     )
 
-    expect(screen.getByTestId('session-tabs')).toHaveClass('vf-app-drag-region')
-    expect(screen.getByTestId('session-tabs-leading')).toHaveClass(
-      'vf-app-no-drag'
+    expect(screen.getByTestId('session-tabs')).not.toHaveClass(
+      'vf-app-drag-region'
     )
+
+    expect(screen.getByTestId('session-tabs-leading-offset')).toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(
+      screen.getByTestId('session-tabs-leading-upper-drag-region')
+    ).toHaveClass('vf-app-drag-region')
+
+    expect(
+      screen.getByTestId('session-tabs-leading-toggle-clearance')
+    ).toHaveClass('vf-app-no-drag')
+
+    expect(
+      screen.getByTestId('session-tabs-leading-lower-drag-region')
+    ).toHaveClass('vf-app-drag-region')
+
+    expect(screen.getByTestId('session-tabs-leading')).not.toHaveClass(
+      'vf-app-drag-region'
+    )
+
     expect(screen.getByRole('tablist')).toHaveClass('vf-app-no-drag')
+
     expect(screen.getByRole('button', { name: 'New session' })).toHaveClass(
       'vf-app-no-drag'
+    )
+
+    expect(screen.getByTestId('session-tabs-drag-region')).toHaveClass(
+      'vf-app-drag-region'
     )
   })
 
@@ -121,6 +149,10 @@ describe('Tabs', () => {
     renderTabs([buildSession()], 'sess-1')
 
     expect(screen.getByTestId('session-tabs')).not.toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(screen.getByTestId('session-tabs-drag-region')).not.toHaveClass(
       'vf-app-drag-region'
     )
   })

--- a/src/features/sessions/components/Tabs.tsx
+++ b/src/features/sessions/components/Tabs.tsx
@@ -7,6 +7,12 @@ import {
 } from '../utils/pickNextVisibleSessionId'
 import { Tab } from './Tab'
 
+const SIDEBAR_TOGGLE_SIZE = 'var(--workspace-sidebar-toggle-size, 28px)'
+const SIDEBAR_TOGGLE_TOP = 'var(--workspace-sidebar-toggle-top, 7px)'
+
+const WINDOW_CONTROLS_INSET =
+  'max(12px, var(--workspace-window-controls-inset, 0px))'
+
 export interface TabsProps {
   sessions: Session[]
   activeSessionId: string | null
@@ -90,22 +96,47 @@ export const Tabs = ({
     <div
       data-testid="session-tabs"
       className={`flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest pr-2 ${
-        leading ? 'pl-[12px]' : 'pl-2'
-      }${reserveWindowControls ? ' vf-app-drag-region' : ''}`}
-      style={{
-        paddingLeft:
-          leading && reserveWindowControls
-            ? 'max(12px, var(--workspace-window-controls-inset, 0px))'
-            : undefined,
-      }}
+        leading ? '' : 'pl-2'
+      }`}
     >
       {leading && (
-        <div
-          data-testid="session-tabs-leading"
-          className="vf-app-no-drag mr-2 flex shrink-0 items-center self-center"
-        >
-          {leading}
-        </div>
+        <>
+          <div
+            aria-hidden="true"
+            data-testid="session-tabs-leading-offset"
+            className={`h-full shrink-0 self-stretch${
+              reserveWindowControls ? ' vf-app-drag-region' : ''
+            }`}
+            style={{
+              width: reserveWindowControls ? WINDOW_CONTROLS_INSET : 12,
+            }}
+          />
+          <div
+            data-testid="session-tabs-leading"
+            className="mr-2 grid shrink-0 self-stretch"
+            style={{
+              width: SIDEBAR_TOGGLE_SIZE,
+              gridTemplateRows: `${SIDEBAR_TOGGLE_TOP} ${SIDEBAR_TOGGLE_SIZE} minmax(0, 1fr)`,
+            }}
+          >
+            <div
+              aria-hidden="true"
+              data-testid="session-tabs-leading-upper-drag-region"
+              className={reserveWindowControls ? 'vf-app-drag-region' : ''}
+            />
+            <div
+              data-testid="session-tabs-leading-toggle-clearance"
+              className="vf-app-no-drag flex items-center justify-center"
+            >
+              {leading}
+            </div>
+            <div
+              aria-hidden="true"
+              data-testid="session-tabs-leading-lower-drag-region"
+              className={reserveWindowControls ? 'vf-app-drag-region' : ''}
+            />
+          </div>
+        </>
       )}
       {/* WAI-ARIA 1.2 §3.27 requires `tablist` to own only `tab` children.
           Keeping the `+` button and the spacer outside the tablist boundary. */}
@@ -155,7 +186,13 @@ export const Tabs = ({
       >
         <span className="material-symbols-outlined text-[15px]">add</span>
       </button>
-      <span className="flex-1" />
+      <div
+        aria-hidden="true"
+        data-testid="session-tabs-drag-region"
+        className={`h-full flex-1 self-stretch${
+          reserveWindowControls ? ' vf-app-drag-region' : ''
+        }`}
+      />
     </div>
   )
 }

--- a/src/features/sessions/components/Tabs.tsx
+++ b/src/features/sessions/components/Tabs.tsx
@@ -95,7 +95,7 @@ export const Tabs = ({
   return (
     <div
       data-testid="session-tabs"
-      className={`flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest pr-2 ${
+      className={`flex h-[38px] shrink-0 items-end gap-0.5 border-b border-outline-variant/25 bg-surface-container-lowest ${
         leading ? '' : 'pl-2'
       }`}
     >
@@ -189,7 +189,7 @@ export const Tabs = ({
       <div
         aria-hidden="true"
         data-testid="session-tabs-drag-region"
-        className={`h-full flex-1 self-stretch${
+        className={`h-full flex-1 self-stretch pr-2${
           reserveWindowControls ? ' vf-app-drag-region' : ''
         }`}
       />

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -295,6 +295,93 @@ describe('WorkspaceView', () => {
     expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
   })
 
+  test('keeps expanded macOS drag chrome clear of the fixed sidebar toggle', () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    })
+
+    render(<WorkspaceView />)
+
+    const workspace = screen.getByTestId('workspace-view')
+    expect(
+      workspace.style.getPropertyValue('--workspace-sidebar-toggle-left')
+    ).toBe('82px')
+
+    expect(
+      workspace.style.getPropertyValue('--workspace-sidebar-toggle-size')
+    ).toBe('28px')
+
+    expect(
+      workspace.style.getPropertyValue('--workspace-sidebar-toggle-top')
+    ).toBe('7px')
+
+    expect(screen.getByTestId('sidebar-toggle-fixed')).toHaveClass(
+      'vf-app-no-drag'
+    )
+
+    expect(screen.getByTestId('sidebar-top-bar')).not.toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(screen.getByTestId('sidebar-top-bar-upper-drag-region')).toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(screen.getByTestId('sidebar-top-bar-toggle-clearance')).toHaveClass(
+      'vf-app-no-drag'
+    )
+
+    expect(screen.getByTestId('sidebar-top-bar-right-drag-region')).toHaveClass(
+      'vf-app-drag-region'
+    )
+  })
+
+  test('keeps collapsed macOS tab chrome clear of the fixed sidebar toggle', () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    })
+
+    setSidebarCollapsed(true)
+
+    render(<WorkspaceView />)
+
+    expect(screen.getByTestId('sidebar-toggle-fixed')).toHaveClass(
+      'vf-app-no-drag'
+    )
+
+    expect(screen.getByTestId('sidebar-toggle-tabs-spacer')).toBeInTheDocument()
+
+    expect(screen.getByTestId('session-tabs')).not.toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(screen.getByTestId('session-tabs-leading-offset')).toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(
+      screen.getByTestId('session-tabs-leading-upper-drag-region')
+    ).toHaveClass('vf-app-drag-region')
+
+    expect(
+      screen.getByTestId('session-tabs-leading-toggle-clearance')
+    ).toHaveClass('vf-app-no-drag')
+
+    expect(
+      screen.getByTestId('session-tabs-leading-lower-drag-region')
+    ).toHaveClass('vf-app-drag-region')
+
+    expect(screen.getByTestId('session-tabs-leading')).not.toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(screen.getByTestId('session-tabs-drag-region')).toHaveClass(
+      'vf-app-drag-region'
+    )
+  })
+
   test('uses a single-column workspace with a dismissible inert sidebar drawer on compact viewports', async () => {
     const restoreMatchMedia = mockMatchMedia(true)
     const user = userEvent.setup()

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1632,6 +1632,9 @@ export const WorkspaceView = (): ReactElement => {
           // Desktop collapse animates the sidebar shell width; compact viewports
           // switch to a single-column workspace with the sidebar as an overlay.
           '--workspace-window-controls-inset': `${windowControlsInset}px`,
+          '--workspace-sidebar-toggle-left': `${sidebarToggleLeft}px`,
+          '--workspace-sidebar-toggle-size': `${SIDEBAR_TOGGLE_SIZE}px`,
+          '--workspace-sidebar-toggle-top': `${SIDEBAR_TOGGLE_TOP}px`,
           gridTemplateColumns: isCompactViewport ? '1fr' : `auto 1fr auto`,
         } as CSSProperties
       }

--- a/src/features/workspace/components/SidebarTopBar.test.tsx
+++ b/src/features/workspace/components/SidebarTopBar.test.tsx
@@ -15,17 +15,44 @@ describe('SidebarTopBar', () => {
     ).not.toBeInTheDocument()
   })
 
-  test('keeps empty expanded top-bar chrome draggable on macOS', () => {
+  test('keeps expanded top-bar chrome draggable around the toggle slot on macOS', () => {
     renderTopBar({
       reserveWindowControls: true,
     })
 
-    expect(screen.getByTestId('sidebar-top-bar')).toHaveClass(
+    expect(screen.getByTestId('sidebar-top-bar')).not.toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(screen.getByTestId('sidebar-top-bar-upper-drag-region')).toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(screen.getByTestId('sidebar-top-bar-left-drag-region')).toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(screen.getByTestId('sidebar-top-bar-toggle-clearance')).toHaveClass(
+      'vf-app-no-drag'
+    )
+
+    expect(screen.getByTestId('sidebar-top-bar-right-drag-region')).toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(screen.getByTestId('sidebar-top-bar-lower-drag-region')).toHaveClass(
       'vf-app-drag-region'
     )
   })
 
   test('does not apply drag-region class on non-macOS platforms', () => {
+    const dragRegionTestIds = [
+      'sidebar-top-bar-upper-drag-region',
+      'sidebar-top-bar-left-drag-region',
+      'sidebar-top-bar-right-drag-region',
+      'sidebar-top-bar-lower-drag-region',
+    ]
+
     renderTopBar({
       reserveWindowControls: false,
     })
@@ -33,6 +60,10 @@ describe('SidebarTopBar', () => {
     expect(screen.getByTestId('sidebar-top-bar')).not.toHaveClass(
       'vf-app-drag-region'
     )
+
+    dragRegionTestIds.forEach((testId) => {
+      expect(screen.getByTestId(testId)).not.toHaveClass('vf-app-drag-region')
+    })
   })
 
   test('does not render sidebar utility buttons in the traffic-light row', () => {

--- a/src/features/workspace/components/SidebarTopBar.tsx
+++ b/src/features/workspace/components/SidebarTopBar.tsx
@@ -5,29 +5,64 @@ export interface SidebarTopBarProps {
   reserveWindowControls?: boolean
 }
 
+const SIDEBAR_TOGGLE_LEFT =
+  'var(--workspace-sidebar-toggle-left, max(12px, var(--workspace-window-controls-inset, 0px)))'
+const SIDEBAR_TOGGLE_SIZE = 'var(--workspace-sidebar-toggle-size, 28px)'
+const SIDEBAR_TOGGLE_TOP = 'var(--workspace-sidebar-toggle-top, 7px)'
+
 // The new sidebar chrome row. Uses the sidebar's own surface
 // (bg-surface-container-low) with no bottom divider, so the top bar blends into
 // the sidebar. The persistent sidebar toggle is owned by WorkspaceView so it
-// never changes position while this row slides beneath it. This row intentionally
-// stays empty for macOS traffic-light and drag space.
+// never changes position while this row slides beneath it. Native drag surrounds
+// the toggle slot but does not sit under the clickable toggle rectangle.
 export const SidebarTopBar = ({
   reserveWindowControls = false,
-}: SidebarTopBarProps): ReactElement => (
-  <div
-    data-testid="sidebar-top-bar"
-    className={`bg-surface-container-low${
-      reserveWindowControls ? ' vf-app-drag-region' : ''
-    }`}
-    style={{
-      height: 42,
-      flexShrink: 0,
-      display: 'flex',
-      alignItems: 'center',
-      gap: 6,
-      paddingLeft: 'max(12px, var(--workspace-window-controls-inset, 0px))',
-      paddingRight: 10,
-    }}
-  >
-    <div style={{ flex: 1 }} />
-  </div>
-)
+}: SidebarTopBarProps): ReactElement => {
+  const dragClassName = reserveWindowControls ? 'vf-app-drag-region' : ''
+
+  return (
+    <div
+      data-testid="sidebar-top-bar"
+      className="bg-surface-container-low"
+      style={{
+        height: 42,
+        flexShrink: 0,
+        display: 'grid',
+        gridTemplateColumns: `${SIDEBAR_TOGGLE_LEFT} ${SIDEBAR_TOGGLE_SIZE} minmax(0, 1fr)`,
+        gridTemplateRows: `${SIDEBAR_TOGGLE_TOP} ${SIDEBAR_TOGGLE_SIZE} minmax(0, 1fr)`,
+        paddingRight: 10,
+      }}
+    >
+      <div
+        aria-hidden="true"
+        data-testid="sidebar-top-bar-upper-drag-region"
+        className={dragClassName}
+        style={{ gridColumn: '1 / -1', gridRow: 1 }}
+      />
+      <div
+        aria-hidden="true"
+        data-testid="sidebar-top-bar-left-drag-region"
+        className={dragClassName}
+        style={{ gridColumn: 1, gridRow: 2 }}
+      />
+      <div
+        aria-hidden="true"
+        data-testid="sidebar-top-bar-toggle-clearance"
+        className="vf-app-no-drag"
+        style={{ gridColumn: 2, gridRow: 2 }}
+      />
+      <div
+        aria-hidden="true"
+        data-testid="sidebar-top-bar-right-drag-region"
+        className={dragClassName}
+        style={{ gridColumn: 3, gridRow: 2 }}
+      />
+      <div
+        aria-hidden="true"
+        data-testid="sidebar-top-bar-lower-drag-region"
+        className={dragClassName}
+        style={{ gridColumn: '1 / -1', gridRow: 3 }}
+      />
+    </div>
+  )
+}

--- a/src/features/workspace/components/SidebarTopBar.tsx
+++ b/src/features/workspace/components/SidebarTopBar.tsx
@@ -30,7 +30,6 @@ export const SidebarTopBar = ({
         display: 'grid',
         gridTemplateColumns: `${SIDEBAR_TOGGLE_LEFT} ${SIDEBAR_TOGGLE_SIZE} minmax(0, 1fr)`,
         gridTemplateRows: `${SIDEBAR_TOGGLE_TOP} ${SIDEBAR_TOGGLE_SIZE} minmax(0, 1fr)`,
-        paddingRight: 10,
       }}
     >
       <div
@@ -55,7 +54,7 @@ export const SidebarTopBar = ({
         aria-hidden="true"
         data-testid="sidebar-top-bar-right-drag-region"
         className={dragClassName}
-        style={{ gridColumn: 3, gridRow: 2 }}
+        style={{ gridColumn: 3, gridRow: 2, paddingRight: 10 }}
       />
       <div
         aria-hidden="true"


### PR DESCRIPTION
## Summary
- Split macOS drag chrome around the persistent sidebar toggle instead of making the whole left header area non-draggable.
- Keep the upper and surrounding empty chrome draggable while only the toggle-sized slot is `vf-app-no-drag`.
- Add guardrail tests for expanded and collapsed sidebar states.

## Root Cause
The full sidebar top bar and tab strip were native Electron drag regions under the fixed toggle. Electron native hit testing could treat toggle clicks as window drag gestures.

## Validation
- `npx eslint src/features/workspace/components/SidebarTopBar.tsx src/features/sessions/components/Tabs.tsx src/features/workspace/WorkspaceView.tsx src/features/workspace/components/SidebarTopBar.test.tsx src/features/sessions/components/Tabs.test.tsx src/features/workspace/WorkspaceView.test.tsx`
- `npx prettier --check src/features/workspace/components/SidebarTopBar.tsx src/features/sessions/components/Tabs.tsx src/features/workspace/WorkspaceView.tsx src/features/workspace/components/SidebarTopBar.test.tsx src/features/sessions/components/Tabs.test.tsx src/features/workspace/WorkspaceView.test.tsx`
- `npm test -- --run src/features/workspace/components/SidebarTopBar.test.tsx src/features/sessions/components/Tabs.test.tsx src/features/workspace/WorkspaceView.test.tsx`
- `npm test`