### PR TITLE
fix(sidebar): refine sidebar surface, hover, and width (VIM-66)

### DIFF
--- a/src/components/sidebar/Sidebar.test.tsx
+++ b/src/components/sidebar/Sidebar.test.tsx
@@ -8,6 +8,14 @@ describe('Sidebar — slot composition', () => {
     expect(screen.getByTestId('sidebar')).toBeInTheDocument()
   })
 
+  test('root surface is transparent so the sidebar blends into its parent', () => {
+    render(<Sidebar content={<div>content</div>} />)
+
+    const root = screen.getByTestId('sidebar')
+    expect(root).toHaveClass('bg-transparent')
+    expect(root).not.toHaveClass('bg-surface-container-low')
+  })
+
   test('renders the header slot when provided', () => {
     render(
       <Sidebar

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -110,7 +110,7 @@ export const Sidebar = ({
 
   return (
     <div
-      className="flex h-full w-full flex-col bg-surface-container-low"
+      className="flex h-full w-full flex-col bg-transparent"
       data-testid={testId}
     >
       {renderSlot(topBar) && topBar}

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -1581,8 +1581,9 @@ describe('WorkspaceView', () => {
     expect(mainWorkspace).toHaveClass('bg-background')
     expect(mainWorkspace.style.borderTopLeftRadius).toBe('16px')
     expect(mainWorkspace.style.borderBottomLeftRadius).toBe('16px')
-    expect(mainWorkspace.style.boxShadow).toContain('-18px')
-    expect(mainWorkspace.style.boxShadow).toContain('36px')
+    // No drop shadow: it would read as a dark gradient seam against the
+    // transparent sidebar. The rounded corners alone carry the sheet edge.
+    expect(mainWorkspace.style.boxShadow).toBe('')
     expect(mainWorkspace.style.transition).toContain('border-radius 220ms')
   })
 
@@ -1718,6 +1719,14 @@ describe('WorkspaceView', () => {
     }
   })
 
+  test('caps the sidebar resize range so the card + new-session row fit with even padding', () => {
+    render(<WorkspaceView />)
+
+    const handle = screen.getByTestId('sidebar-resize-handle')
+    expect(handle).toHaveAttribute('aria-valuemin', '272')
+    expect(handle).toHaveAttribute('aria-valuemax', '384')
+  })
+
   test('collapses the sidebar when drag ends below the default minimum width', async () => {
     render(<WorkspaceView />)
 
@@ -1749,6 +1758,11 @@ describe('WorkspaceView', () => {
     expect(sidebarShell.className).toContain('transition-[width]')
     expect(sidebarShell).toHaveStyle({ width: '0px' })
     expect(toggleSurface).toHaveStyle({ width: '0px' })
+    expect(toggleSurface.className).toContain('bg-transparent')
+    expect(toggleSurface.className).not.toContain('bg-surface-container-low')
+    expect(screen.getByTestId('sidebar-top-bar-placeholder')).toHaveClass(
+      'bg-transparent'
+    )
     expect(mainWorkspace.style.borderTopLeftRadius).toBe('0')
     expect(mainWorkspace.style.borderBottomLeftRadius).toBe('0')
   })

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -162,7 +162,12 @@ const SETTINGS_FOLLOWUP_ISSUE_NUMBER = 252
 
 const SIDEBAR_DEFAULT = 272
 const SIDEBAR_MIN = SIDEBAR_DEFAULT
-const SIDEBAR_MAX = 520
+// Cap the sidebar at the width where the agent-status card and the
+// tabs + new-session row both hit their own maximums and sit with even 12px
+// padding: 360px content cap (202 SidebarTabs + 8 gap + 150 NewSessionButton
+// max-width, matching AgentStatusCard's CARD_MAX_W) + 24px (px-3 left/right) =
+// 384. Past this the card/button stop growing, so extra width is dead space.
+const SIDEBAR_MAX = 384
 const MAIN_AUTO_COLLAPSE_MIN = 360
 const MAIN_AUTO_COLLAPSE_MAX = 500
 const MAIN_AUTO_COLLAPSE_RATIO = 0.36
@@ -1685,7 +1690,7 @@ export const WorkspaceView = (): ReactElement => {
         <div
           aria-hidden="true"
           data-testid="sidebar-toggle-slide-surface"
-          className={`pointer-events-none absolute left-0 top-0 z-20 bg-surface-container-low ${
+          className={`pointer-events-none absolute left-0 top-0 z-20 bg-transparent ${
             isDragging ? '' : 'transition-[width] duration-[220ms] ease-pane'
           }`}
           style={{
@@ -1735,7 +1740,7 @@ export const WorkspaceView = (): ReactElement => {
                   <div
                     aria-hidden="true"
                     data-testid="sidebar-top-bar-placeholder"
-                    className="bg-surface-container-low"
+                    className="bg-transparent"
                     style={{ height: SIDEBAR_TOP_BAR_HEIGHT, flexShrink: 0 }}
                   />
                 ) : (
@@ -1831,14 +1836,13 @@ export const WorkspaceView = (): ReactElement => {
           borderTopLeftRadius: sidebarCollapsed || isCompactViewport ? 0 : 16,
           borderBottomLeftRadius:
             sidebarCollapsed || isCompactViewport ? 0 : 16,
-          boxShadow:
-            sidebarCollapsed || isCompactViewport
-              ? 'none'
-              : '-18px 0 36px rgba(0,0,0,0.22)',
+          // No elevation shadow on the sheet edge: the sidebar is transparent,
+          // so a leftward drop shadow would read as a dark gradient seam against
+          // it. The rounded corners alone carry the inset-sheet treatment.
           transition: isDragging
             ? 'none'
-            : `border-radius ${SIDEBAR_MOTION_MS}ms ${SIDEBAR_MOTION_EASING}, box-shadow ${SIDEBAR_MOTION_MS}ms ${SIDEBAR_MOTION_EASING}`,
-          willChange: 'border-radius, box-shadow',
+            : `border-radius ${SIDEBAR_MOTION_MS}ms ${SIDEBAR_MOTION_EASING}`,
+          willChange: 'border-radius',
         }}
       >
         <Tabs

--- a/src/features/workspace/WorkspaceView.verification.test.tsx
+++ b/src/features/workspace/WorkspaceView.verification.test.tsx
@@ -244,12 +244,13 @@ describe('Feature 23: Final Phase 2 Verification', () => {
       expect(workspace).toHaveClass('h-screen')
     })
 
-    test('uses Obsidian Lens color tokens', () => {
+    test('sidebar is transparent so it blends into the workspace surface', () => {
       render(<WorkspaceView />)
 
       const sidebar = screen.getByTestId('sidebar')
 
-      expect(sidebar).toHaveClass('bg-surface-container-low')
+      expect(sidebar).toHaveClass('bg-transparent')
+      expect(sidebar).not.toHaveClass('bg-surface-container-low')
     })
   })
 

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -245,11 +245,12 @@ describe('WorkspaceView - Visual Verification (Feature #20)', () => {
   })
 
   describe('Surface Hierarchy: Component Backgrounds', () => {
-    test('Sidebar uses Level 1 surface (surface-container-low)', () => {
+    test('Sidebar is transparent so it inherits the workspace surface', () => {
       render(<WorkspaceView />)
       const sidebar = screen.getByTestId('sidebar')
 
-      expect(sidebar.className).toContain('bg-surface-container-low')
+      expect(sidebar.className).toContain('bg-transparent')
+      expect(sidebar.className).not.toContain('bg-surface-container-low')
     })
 
     test('Terminal Zone content uses Level 0 surface (bg-surface)', () => {

--- a/src/features/workspace/components/SidebarToggle.test.tsx
+++ b/src/features/workspace/components/SidebarToggle.test.tsx
@@ -116,6 +116,22 @@ describe('SidebarToggle', () => {
     )
   })
 
+  test('variant=inset, expanded (collapsed=false): uses the darker navy hover background', () => {
+    renderToggle({ collapsed: false, variant: 'inset' })
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('hover:bg-[rgba(13,13,28,0.72)]')
+    expect(button).not.toHaveClass('hover:bg-[rgba(226,199,255,0.14)]')
+  })
+
+  test('variant=inset, collapsed=true: uses the lighter lavender hover background', () => {
+    renderToggle({ collapsed: true, variant: 'inset' })
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('hover:bg-[rgba(226,199,255,0.14)]')
+    expect(button).not.toHaveClass('hover:bg-[rgba(13,13,28,0.72)]')
+  })
+
   test('size: sets the button width/height inline style', () => {
     renderToggle({ collapsed: false, size: 34 })
 

--- a/src/features/workspace/components/SidebarToggle.tsx
+++ b/src/features/workspace/components/SidebarToggle.tsx
@@ -24,8 +24,19 @@ export interface SidebarToggleProps {
 const VARIANT_CLASS: Record<SidebarToggleVariant, string> = {
   ghost:
     'border border-transparent text-on-surface-muted hover:bg-primary/[0.08] hover:text-primary',
+  // The inset hover *background* is applied separately (INSET_HOVER_BG) because
+  // it depends on collapse state; the recessed well + text hover live here.
   inset:
-    'border border-transparent bg-[rgba(13,13,28,0.45)] text-on-surface-muted hover:bg-[rgba(226,199,255,0.08)] hover:text-primary',
+    'border border-transparent bg-[rgba(13,13,28,0.45)] text-on-surface-muted hover:text-primary',
+}
+
+// Inset-toggle hover tint, keyed by collapse state. The sidebar surface is now
+// transparent, so the toggle reads against a different backdrop in each state:
+// expanded deepens toward the navy well (darker), while collapsed lifts with a
+// lavender tint (lighter) since the control then floats over the main content.
+const INSET_HOVER_BG: Record<'expanded' | 'collapsed', string> = {
+  expanded: 'hover:bg-[rgba(13,13,28,0.72)]',
+  collapsed: 'hover:bg-[rgba(226,199,255,0.14)]',
 }
 
 // Codex / VS-Code-style "panel-left" glyph. Outline + left-rail divider are
@@ -59,7 +70,7 @@ export const SidebarToggle = forwardRef<HTMLButtonElement, SidebarToggleProps>(
         aria-label={collapsed ? 'Show sidebar' : 'Hide sidebar'}
         aria-expanded={!collapsed}
         style={{ width: size, height: size }}
-        className={`vf-app-no-drag grid shrink-0 cursor-pointer place-items-center rounded-[7px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container ${VARIANT_CLASS[variant]}`}
+        className={`vf-app-no-drag grid shrink-0 cursor-pointer place-items-center rounded-[7px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container ${VARIANT_CLASS[variant]} ${variant === 'inset' ? (collapsed ? INSET_HOVER_BG.collapsed : INSET_HOVER_BG.expanded) : ''}`}
       >
         <svg
           width="16"

--- a/src/features/workspace/components/SidebarTopBar.test.tsx
+++ b/src/features/workspace/components/SidebarTopBar.test.tsx
@@ -15,6 +15,14 @@ describe('SidebarTopBar', () => {
     ).not.toBeInTheDocument()
   })
 
+  test('renders a transparent surface so the top bar blends into the sidebar', () => {
+    renderTopBar()
+
+    const topBar = screen.getByTestId('sidebar-top-bar')
+    expect(topBar).toHaveClass('bg-transparent')
+    expect(topBar).not.toHaveClass('bg-surface-container-low')
+  })
+
   test('keeps expanded top-bar chrome draggable around the toggle slot on macOS', () => {
     renderTopBar({
       reserveWindowControls: true,

--- a/src/features/workspace/components/SidebarTopBar.tsx
+++ b/src/features/workspace/components/SidebarTopBar.tsx
@@ -10,11 +10,11 @@ const SIDEBAR_TOGGLE_LEFT =
 const SIDEBAR_TOGGLE_SIZE = 'var(--workspace-sidebar-toggle-size, 28px)'
 const SIDEBAR_TOGGLE_TOP = 'var(--workspace-sidebar-toggle-top, 7px)'
 
-// The new sidebar chrome row. Uses the sidebar's own surface
-// (bg-surface-container-low) with no bottom divider, so the top bar blends into
-// the sidebar. The persistent sidebar toggle is owned by WorkspaceView so it
-// never changes position while this row slides beneath it. Native drag surrounds
-// the toggle slot but does not sit under the clickable toggle rectangle.
+// The new sidebar chrome row. Transparent so it blends into the now-transparent
+// sidebar surface with no bottom divider. The persistent sidebar toggle is owned
+// by WorkspaceView so it never changes position while this row slides beneath it.
+// Native drag surrounds the toggle slot but does not sit under the clickable
+// toggle rectangle.
 export const SidebarTopBar = ({
   reserveWindowControls = false,
 }: SidebarTopBarProps): ReactElement => {
@@ -23,7 +23,7 @@ export const SidebarTopBar = ({
   return (
     <div
       data-testid="sidebar-top-bar"
-      className="bg-surface-container-low"
+      className="bg-transparent"
       style={{
         height: 42,
         flexShrink: 0,


### PR DESCRIPTION
## Summary

Refines the sidebar so it integrates cleanly with the workspace surround (VIM-66):

- **Transparent sidebar** — the sidebar surfaces (panel root, top bar, toggle slide-surface, collapsed placeholder) are now `bg-transparent`, so the panel inherits the workspace background instead of sitting on its own `surface-container-low` elevation.
- **State-dependent toggle hover** — the inset sidebar toggle's hover keys off collapse state: **expanded** deepens toward the navy well (darker), **collapsed** lifts with a lavender tint (lighter), since the control reads against a different backdrop in each state.
- **Capped max width** — `SIDEBAR_MAX` drops 520 → **384px** (360px content cap [202 tabs + 8 gap + 150 new-session = `AgentStatusCard` `CARD_MAX_W`] + 24px `px-3`), so at max width the agent-status card and the tabs + new-session row reach their own maximums with even left/right padding and no dead space.
- **No seam gradient** — removed the main view's leftward drop shadow (`-18px 0 36px`), which read as a dark gradient seam against the now-transparent sidebar. The rounded sheet corners alone carry the inset-sheet treatment.

## Validation

- `npx vitest run` — 3212 passed, 3 skipped (incl. 8 new/updated sidebar tests)
- `npx eslint <changed files>` — clean
- `npm run type-check` (`tsc -b`) — clean
- `npx prettier --check <changed files>` — clean
- Manual (Vite dev app): verified transparent blend, darker/lighter toggle hover per state, symmetric padding at max width, and a clean seam.

Based on the latest `feat/vim-66-sidebar` (#415).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
