### PR TITLE
fix(sidebar): refine rename input, toggle hover, header cursor, model badge

### DIFF
--- a/src/features/sessions/components/Card.test.tsx
+++ b/src/features/sessions/components/Card.test.tsx
@@ -195,6 +195,23 @@ describe('Card — active variant', () => {
     ).toHaveFocus()
   })
 
+  test('hides the kebab while renaming so it cannot overlap the input', async () => {
+    const user = userEvent.setup()
+    renderActiveCard(session(), { onRename: vi.fn(), onRemove: vi.fn() })
+
+    // Focusing the rename input would otherwise reveal the kebab via
+    // group-focus-within, landing it on top of the full-width input.
+    await user.dblClick(screen.getByText('auth middleware'))
+
+    expect(
+      screen.getByRole('textbox', { name: 'Rename session' })
+    ).toHaveFocus()
+
+    expect(
+      screen.queryByRole('button', { name: 'Session actions' })
+    ).not.toBeInTheDocument()
+  })
+
   test('Escape cancels rename without calling onRename', async () => {
     const onRename = vi.fn()
     renderActiveCard(session(), { onRename })

--- a/src/features/sessions/components/Card.tsx
+++ b/src/features/sessions/components/Card.tsx
@@ -226,8 +226,10 @@ const CardComponent = ({
 
       {/* Kebab — sibling of the activation button (not nested), absolutely
           positioned so the row height stays constant; revealed on hover/focus
-          and kept mounted so keyboard users can reach it. */}
-      {hasActions && (
+          and kept mounted so keyboard users can reach it. Suppressed while
+          renaming: focusing the input would otherwise reveal it (via
+          group-focus-within) right on top of the full-width rename field. */}
+      {hasActions && !isEditing && (
         <div
           className={`pointer-events-auto absolute right-2 top-[7px] opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 ${
             menuOpen ? 'opacity-100' : ''

--- a/src/features/sessions/components/Group.test.tsx
+++ b/src/features/sessions/components/Group.test.tsx
@@ -29,6 +29,15 @@ describe('Group.Header', () => {
     )
   })
 
+  test('label is non-interactive chrome: default cursor, not text-selectable', () => {
+    render(<Group.Header label="Active" count={1} />)
+    // The "ACTIVE · 1" label is a heading, not editable text — hovering it
+    // must not flip to the text I-beam, and it should not select on drag.
+    const header = screen.getByTestId('session-group-active')
+    expect(header).toHaveClass('cursor-default')
+    expect(header).toHaveClass('select-none')
+  })
+
   test('renders headerAction next to the label when provided', () => {
     render(
       <Group.Header

--- a/src/features/sessions/components/Group.tsx
+++ b/src/features/sessions/components/Group.tsx
@@ -16,7 +16,7 @@ const GroupHeader = ({
   <div className="flex items-center justify-between pr-3">
     <h3
       data-testid={`session-group-${label.toLowerCase()}`}
-      className="px-3 pb-1 pt-2 font-mono text-[10.5px] uppercase tracking-[0.08em] text-on-surface-variant/70"
+      className="cursor-default select-none px-3 pb-1 pt-2 font-mono text-[10.5px] uppercase tracking-[0.08em] text-on-surface-variant/70"
     >
       {count !== undefined ? `${label} · ${count}` : label}
     </h3>

--- a/src/features/workspace/components/AgentStatusCard.test.tsx
+++ b/src/features/workspace/components/AgentStatusCard.test.tsx
@@ -25,6 +25,27 @@ describe('AgentStatusCard', () => {
     expect(screen.getByText('claude-sonnet-4-6')).toBeInTheDocument()
   })
 
+  test('splits a "(<size> context)" title into a name + compact context badge', () => {
+    render(<AgentStatusCard title="Opus 4.8 (1M context)" state="running" />)
+
+    expect(screen.getByText('Opus 4.8')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-card-context-badge')).toHaveTextContent(
+      '1M'
+    )
+
+    // The raw "(1M context)" suffix must not render inline — it truncated to
+    // "Opus 4.8 (1M cont…" before this split.
+    expect(screen.queryByText('Opus 4.8 (1M context)')).not.toBeInTheDocument()
+  })
+
+  test('omits the context badge when the title has no context suffix', () => {
+    render(<AgentStatusCard title="claude-sonnet-4-6" state="running" />)
+
+    expect(
+      screen.queryByTestId('agent-card-context-badge')
+    ).not.toBeInTheDocument()
+  })
+
   test('no longer renders the in-card sidebar toggle (moved to the top bar / tab bar)', () => {
     render(<AgentStatusCard title="m" state="running" />)
 

--- a/src/features/workspace/components/AgentStatusCard.tsx
+++ b/src/features/workspace/components/AgentStatusCard.tsx
@@ -1,6 +1,7 @@
 // cspell:ignore cheatsheet incard powershell pwsh tcsh xonsh zsh
 import type { ReactElement } from 'react'
 import { RateLimitBar } from '../../agent-status/components/RateLimitBar'
+import { parseModelTitle } from '../utils/parseModelTitle'
 
 // Fused agent-status card (VIM-66 — AGENT-STATUS-CARD-HANDOFF + SHELL-CARD-KIT).
 // ONE fixed card height in every state: switching the active pane between an
@@ -183,6 +184,10 @@ export const AgentStatusCard = ({
 }: AgentStatusCardProps): ReactElement => {
   const hasUsage = fiveHourPct !== null || weekPct !== null
   const resolvedShellName = normalizeShellName(shellName)
+  // Claude reports the model as "Opus 4.8 (1M context)"; rendered whole it
+  // truncates to "Opus 4.8 (1M cont…". Peel the context size off so the name
+  // shows in full beside a compact badge.
+  const { name: modelName, contextLabel } = parseModelTitle(title)
   void state
   void elapsed
   void contextPct
@@ -212,8 +217,19 @@ export const AgentStatusCard = ({
       ) : (
         <>
           <div className="flex min-h-6 items-center gap-2.5">
-            <div className="min-w-0 flex-1 truncate font-display text-[15px] font-semibold leading-6 text-on-surface">
-              {title}
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
+              <span className="min-w-0 truncate font-display text-[15px] font-semibold leading-6 text-on-surface">
+                {modelName}
+              </span>
+              {contextLabel !== null && (
+                <span
+                  data-testid="agent-card-context-badge"
+                  title={`${contextLabel} context window`}
+                  className="shrink-0 rounded-[5px] bg-surface-container-highest px-[5px] py-[2px] font-mono text-[9.5px] font-semibold leading-none text-on-surface-variant"
+                >
+                  {contextLabel}
+                </span>
+              )}
             </div>
             <TurnPill turns={turns} />
           </div>

--- a/src/features/workspace/components/SidebarToggle.test.tsx
+++ b/src/features/workspace/components/SidebarToggle.test.tsx
@@ -97,7 +97,9 @@ describe('SidebarToggle', () => {
   test('variant=inset: className includes the recessed-well background', () => {
     renderToggle({ collapsed: false, variant: 'inset' })
 
-    expect(screen.getByRole('button')).toHaveClass('bg-[rgba(13,13,28,0.45)]')
+    expect(screen.getByRole('button')).toHaveClass(
+      'bg-surface-container-lowest/[0.45]'
+    )
   })
 
   test('variant=inset: keeps the button border transparent', () => {
@@ -112,23 +114,26 @@ describe('SidebarToggle', () => {
     renderToggle({ collapsed: false })
 
     expect(screen.getByRole('button')).not.toHaveClass(
-      'bg-[rgba(13,13,28,0.45)]'
+      'bg-surface-container-lowest/[0.45]'
     )
   })
 
-  test('variant=inset, expanded (collapsed=false): uses the darker navy hover background', () => {
+  test('variant=inset, expanded (collapsed=false): lifts with the lighter primary hover', () => {
     renderToggle({ collapsed: false, variant: 'inset' })
 
     const button = screen.getByRole('button')
-    expect(button).toHaveClass('hover:bg-[rgba(13,13,28,0.72)]')
-    expect(button).not.toHaveClass('hover:bg-[rgba(226,199,255,0.14)]')
+    expect(button).toHaveClass('hover:bg-primary/[0.14]')
+    // Regression guard (#416): the expanded toggle deepened toward a dark navy
+    // well on hover, which read as "no change" against the now-transparent
+    // sidebar. It must lift lighter instead.
+    expect(button).not.toHaveClass('hover:bg-[rgba(13,13,28,0.72)]')
   })
 
-  test('variant=inset, collapsed=true: uses the lighter lavender hover background', () => {
+  test('variant=inset, collapsed=true: uses the lighter primary hover background', () => {
     renderToggle({ collapsed: true, variant: 'inset' })
 
     const button = screen.getByRole('button')
-    expect(button).toHaveClass('hover:bg-[rgba(226,199,255,0.14)]')
+    expect(button).toHaveClass('hover:bg-primary/[0.14]')
     expect(button).not.toHaveClass('hover:bg-[rgba(13,13,28,0.72)]')
   })
 

--- a/src/features/workspace/components/SidebarToggle.tsx
+++ b/src/features/workspace/components/SidebarToggle.tsx
@@ -24,19 +24,13 @@ export interface SidebarToggleProps {
 const VARIANT_CLASS: Record<SidebarToggleVariant, string> = {
   ghost:
     'border border-transparent text-on-surface-muted hover:bg-primary/[0.08] hover:text-primary',
-  // The inset hover *background* is applied separately (INSET_HOVER_BG) because
-  // it depends on collapse state; the recessed well + text hover live here.
+  // Inset = a recessed well at rest (surface-container-lowest); on hover it
+  // lifts with a primary (lavender) tint in both collapse states, matching the
+  // ghost variant's primary hover. An earlier revision deepened the well toward
+  // navy on hover when expanded, but against the now-transparent sidebar that
+  // read as no change at all — so the toggle always lifts lighter.
   inset:
-    'border border-transparent bg-[rgba(13,13,28,0.45)] text-on-surface-muted hover:text-primary',
-}
-
-// Inset-toggle hover tint, keyed by collapse state. The sidebar surface is now
-// transparent, so the toggle reads against a different backdrop in each state:
-// expanded deepens toward the navy well (darker), while collapsed lifts with a
-// lavender tint (lighter) since the control then floats over the main content.
-const INSET_HOVER_BG: Record<'expanded' | 'collapsed', string> = {
-  expanded: 'hover:bg-[rgba(13,13,28,0.72)]',
-  collapsed: 'hover:bg-[rgba(226,199,255,0.14)]',
+    'border border-transparent bg-surface-container-lowest/[0.45] text-on-surface-muted hover:bg-primary/[0.14] hover:text-primary',
 }
 
 // Codex / VS-Code-style "panel-left" glyph. Outline + left-rail divider are
@@ -70,7 +64,7 @@ export const SidebarToggle = forwardRef<HTMLButtonElement, SidebarToggleProps>(
         aria-label={collapsed ? 'Show sidebar' : 'Hide sidebar'}
         aria-expanded={!collapsed}
         style={{ width: size, height: size }}
-        className={`vf-app-no-drag grid shrink-0 cursor-pointer place-items-center rounded-[7px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container ${VARIANT_CLASS[variant]} ${variant === 'inset' ? (collapsed ? INSET_HOVER_BG.collapsed : INSET_HOVER_BG.expanded) : ''}`}
+        className={`vf-app-no-drag grid shrink-0 cursor-pointer place-items-center rounded-[7px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container ${VARIANT_CLASS[variant]}`}
       >
         <svg
           width="16"

--- a/src/features/workspace/utils/parseModelTitle.test.ts
+++ b/src/features/workspace/utils/parseModelTitle.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from 'vitest'
+import { parseModelTitle } from './parseModelTitle'
+
+describe('parseModelTitle', () => {
+  test('splits a trailing "(<size> context)" suffix into name + context label', () => {
+    expect(parseModelTitle('Opus 4.8 (1M context)')).toEqual({
+      name: 'Opus 4.8',
+      contextLabel: '1M',
+    })
+  })
+
+  test('handles a kilobyte-scale context window', () => {
+    expect(parseModelTitle('Sonnet 4.6 (200K context)')).toEqual({
+      name: 'Sonnet 4.6',
+      contextLabel: '200K',
+    })
+  })
+
+  test('returns the title unchanged when there is no context suffix', () => {
+    expect(parseModelTitle('claude-sonnet-4-6')).toEqual({
+      name: 'claude-sonnet-4-6',
+      contextLabel: null,
+    })
+  })
+
+  test('leaves a non-context parenthetical attached to the name', () => {
+    expect(parseModelTitle('Some Model (beta)')).toEqual({
+      name: 'Some Model (beta)',
+      contextLabel: null,
+    })
+  })
+
+  test('does not treat a placeholder/session-name fallback as a model', () => {
+    expect(parseModelTitle('No session')).toEqual({
+      name: 'No session',
+      contextLabel: null,
+    })
+  })
+
+  test('matches the "context" suffix case-insensitively and trims spacing', () => {
+    expect(parseModelTitle('Opus 4.8  (1M Context)')).toEqual({
+      name: 'Opus 4.8',
+      contextLabel: '1M',
+    })
+  })
+})

--- a/src/features/workspace/utils/parseModelTitle.ts
+++ b/src/features/workspace/utils/parseModelTitle.ts
@@ -1,0 +1,30 @@
+export interface ParsedModelTitle {
+  /** Model name with any trailing context-window suffix stripped. */
+  name: string
+  /** Compact context-window label (e.g. "1M", "200K"), or null when absent. */
+  contextLabel: string | null
+}
+
+// Claude Code reports the model display name with the context window folded
+// into a trailing parenthetical, e.g. "Opus 4.8 (1M context)". Rendered as a
+// single string it truncates ("Opus 4.8 (1M cont…"); splitting the size out
+// lets the card show the name plus a compact badge. Only a parenthetical that
+// actually names the *context* window is peeled off — other parenthetical
+// notes (e.g. "(beta)") and plain fallbacks (a session name, "No session")
+// stay whole.
+const CONTEXT_SUFFIX = /^(.*?)\s*\(\s*(\S+)\s+context\s*\)\s*$/iu
+
+export const parseModelTitle = (title: string): ParsedModelTitle => {
+  const match = CONTEXT_SUFFIX.exec(title)
+  if (!match) {
+    return { name: title, contextLabel: null }
+  }
+
+  const name = match[1].trim()
+  const contextLabel = match[2].trim()
+  if (name.length === 0 || contextLabel.length === 0) {
+    return { name: title, contextLabel: null }
+  }
+
+  return { name, contextLabel }
+}


### PR DESCRIPTION
## Summary
Four UI refinements to the VIM-66 sidebar, stacked on `feat/vim-66-sidebar`:

- **Rename overlap** — hide the session-card kebab (⋯) while renaming so it no longer overlaps the inline rename input.
- **Toggle hover (regression from #416)** — the inset sidebar toggle now lifts with a lighter `primary` tint on hover in *both* collapse states; expanded previously deepened to a dark navy well that read as "no change" against the now-transparent sidebar.
- **Header cursor** — the session group header ("ACTIVE/RECENT · N") is now non-interactive chrome (`cursor-default`, `select-none`), so hovering no longer shows a text I-beam.
- **Model context badge** — the agent model name ("Opus 4.8 (1M context)") is split into the name plus a compact `1M` badge instead of truncating ("Opus 4.8 (1M cont…").

Colors use semantic tokens (`surface-container-lowest`, `primary`), not hardcoded rgba.

## Test plan
- [x] Test-first for each change (tests beside each component + a `parseModelTitle` util)
- [x] `type-check`, `lint`, full `test` suite (3222 passed / 3 skipped, 244 files)
- [x] Two clean Codex review rounds (`codex exec review --uncommitted`)
- [ ] Visual check in-app: toggle hover lightens; `1M` badge matches the compact reference; rename input no longer overlapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)