### PR TITLE
fix(shell): link shell card cheatsheet to cheat.sh, not a web search

### DIFF
--- a/src/features/workspace/components/AgentStatusCard.test.tsx
+++ b/src/features/workspace/components/AgentStatusCard.test.tsx
@@ -96,13 +96,42 @@ describe('AgentStatusCard', () => {
 
     expect(screen.getByText('Idle · pwsh shell')).toBeInTheDocument()
 
+    // pwsh has no cheat.sh topic of its own — cheat.sh serves it as a bare
+    // "alias of powershell" stub — so the link maps to the populated
+    // `powershell` topic while the label still names the real binary.
     const link = screen.getByRole('link', { name: /pwsh cheatsheet/u })
-    expect(link).toHaveAttribute(
-      'href',
-      'https://www.google.com/search?q=pwsh%20commands%20cheatsheet'
-    )
+    expect(link).toHaveAttribute('href', 'https://cheat.sh/powershell')
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  test('links to the cheat.sh cheatsheet for the resolved shell (bash, not just zsh)', () => {
+    const { rerender } = render(
+      <AgentStatusCard title="x" state="idle" isShell shellName="/bin/zsh" />
+    )
+
+    expect(
+      screen.getByRole('link', { name: /zsh cheatsheet/u })
+    ).toHaveAttribute('href', 'https://cheat.sh/zsh')
+
+    rerender(
+      <AgentStatusCard title="x" state="idle" isShell shellName="/bin/bash" />
+    )
+
+    expect(
+      screen.getByRole('link', { name: /bash cheatsheet/u })
+    ).toHaveAttribute('href', 'https://cheat.sh/bash')
+  })
+
+  test('falls back to the POSIX sh cheatsheet when no concrete shell name is resolved', () => {
+    // `activePtyBackedPane?.shell ?? null` can pass null for a shell pane;
+    // normalizeShellName yields the `shell` sentinel, which is NOT a cheat.sh
+    // topic — so the link must resolve to the real POSIX `sh` cheatsheet.
+    render(<AgentStatusCard title="x" state="idle" isShell shellName={null} />)
+
+    expect(
+      screen.getByRole('link', { name: /shell cheatsheet/u })
+    ).toHaveAttribute('href', 'https://cheat.sh/sh')
   })
 
   test('hides agent metrics and usage bars on a shell pane', () => {

--- a/src/features/workspace/components/AgentStatusCard.tsx
+++ b/src/features/workspace/components/AgentStatusCard.tsx
@@ -89,9 +89,22 @@ const normalizeShellName = (shellName: string | null | undefined): string => {
   return stripped
 }
 
+// cheat.sh serves a real, populated cheatsheet at /<topic>; every normalized
+// shell name in KNOWN_SHELLS resolves to one, except for two topics cheat.sh
+// has no page of its own for:
+//   - `shell`: the sentinel normalizeShellName returns when no concrete shell
+//     is resolved (e.g. a shell pane whose `shell` is still null) — fall back
+//     to the POSIX `sh` cheatsheet rather than the unknown `shell` topic.
+//   - `pwsh`: cheat.sh treats it as a bare alias and serves no content — use
+//     the populated `powershell` topic.
+const CHEATSHEET_TOPIC: Record<string, string> = {
+  shell: 'sh',
+  pwsh: 'powershell',
+}
+
 const shellCheatsheetUrl = (shellName: string): string =>
-  `https://www.google.com/search?q=${encodeURIComponent(
-    `${shellName} commands cheatsheet`
+  `https://cheat.sh/${encodeURIComponent(
+    CHEATSHEET_TOPIC[shellName] ?? shellName
   )}`
 
 const TurnPill = ({ turns }: { turns: number | null }): ReactElement => (


### PR DESCRIPTION
## What

The "No active agent" shell card's cheatsheet link pointed at a **Google search** (`google.com/search?q=<shell> commands cheatsheet`). This points it at a **real per-shell cheatsheet** on [cheat.sh](https://cheat.sh) — `https://cheat.sh/<shell>`.

The topic is derived from the same resolved `$SHELL` the card already displays (`normalizeShellName` → basename of the backend's resolved shell path), so it is **not zsh-specific**:

| default shell | link |
| --- | --- |
| zsh | `cheat.sh/zsh` |
| bash | `cheat.sh/bash` |
| fish | `cheat.sh/fish` |
| … | `cheat.sh/<shell>` |

### Two remapped topics
cheat.sh has no page of its own for two normalized names, so they map to real topics:
- `pwsh` → `powershell` — cheat.sh serves `pwsh` as a bare "alias of powershell" stub.
- `shell` → `sh` — the sentinel `normalizeShellName` returns when no concrete shell is resolved (a shell pane whose `shell` is still `null`); the bare `shell` topic returns "unknown topic".

All other `KNOWN_SHELLS` topics (`bash zsh fish sh dash ksh csh tcsh nu xonsh powershell cmd`) were verified to resolve to populated cheatsheets.

## Does it work for bash (not just zsh)?
Yes — the chain is fully data-driven: backend `$SHELL` (`crates/backend/src/terminal/commands.rs`) → `PtySession.shell` → `pane.shell` → `AgentStatusCard` `shellName` → `normalizeShellName`. A bash user sees **"bash cheatsheet" → cheat.sh/bash**.

## Review
Reviewed locally with `codex review` (2 rounds): round 1 caught a real fallback regression (`cheat.sh/shell` 404'd for null shell names), now fixed + regression-tested. Round 2: **clean / no actionable issues**.

## Test plan
- `npm run test` — 3224 passed / 3 skipped (244 files)
- `npm run lint`, `npm run type-check`, `prettier --check` — all clean
- New tests: bash/zsh resolve to `cheat.sh/{shell}`; `pwsh` → `cheat.sh/powershell`; null shell → `cheat.sh/sh`

## Notes
- Branched off the latest `origin/feat/vim-66-sidebar` (applied cleanly on top of the `parseModelTitle` work); scoped to the cheatsheet change only.
- `cheat.sh` is a third-party service the link opens in a browser — destination quality depends on it (verified good for all current shells today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)