### PR TITLE
[codex] tint token cache fresh segment

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -51,7 +51,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Derived State Consistency](patterns/derived-state-consistency.md)   | code-quality       | 5        | 3    | 2026-06-08   |
 | [Generated Artifacts](patterns/generated-artifacts.md)               | code-quality       | 3        | 2    | 2026-05-25   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)       | backend            | 7        | 1    | 2026-06-03   |
-| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 61       | 27   | 2026-06-07   |
+| [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 62       | 28   | 2026-06-11   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                           | a11y               | 33       | 11   | 2026-06-08   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -74,6 +74,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md) | code-quality       | 7        | 2    | 2026-05-02   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)     | keyboard-shortcuts | 18       | 1    | 2026-05-26   |
 | [Verify Render Target](patterns/verify-render-target.md)             | code-quality       | 2        | 0    | 2026-05-24   |
+| [UI Visual Regression](patterns/ui-visual-regression.md)             | code-quality       | 1        | 0    | 2026-06-11   |
 | [Status Indicator Display](patterns/status-indicator-display.md)     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                   | code-quality       | 7        | 5    | 2026-06-08   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md) | correctness        | 6        | 3    | 2026-06-08   |

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-07
-ref_count: 27
+last_updated: 2026-06-11
+ref_count: 28
 ---
 
 # Testing Gaps
@@ -611,3 +611,13 @@ filesystem scope restrictions).
 - **Fix:** Added a focused `backend.test.ts` case where `bridge.listen` rejects once, `listen` rejects, and a second `listen` for the same event retries the bridge instead of reusing the rejected subscription. Asserts `mockListen` is called twice and the retry succeeds with a fresh subscription.
 - **Code-review heuristic:** When a PR changes direct bridge delegation into shared module-level subscription state, the bridge rejection path now performs important state mutation that did not exist before. A single retry-focused test is sufficient to guard the cleanup contract; validate through mock call counts and successful retry rather than test-only introspection of internal maps.
 - **Commit:** _(PR #375 upsource cycle 2 fix commit)_
+
+### 62. Cold-cache color-collision test assertion is trivially true
+
+- **Source:** github-claude | PR #419 round 2 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/components/TokenCache.test.tsx` L150-162
+- **Finding:** The test `cached and fresh styles differ in cold-cache state` compared full `style` attribute strings via `expect(cachedStyle).not.toBe(freshStyle)`. The cached segment carries `boxShadow` and a different `width` than the fresh segment, so the strings always differ regardless of color values. If `FRESH_STACK_GRADIENT` were reverted to the colliding cold-state color `#ff94a5`, the test would still pass, providing zero protection against the regression.
+- **Fix:** Replaced the broad string inequality with a targeted `not.toContain('#ff94a5')` assertion on the fresh segment's style, directly verifying the fresh segment never carries the cold-cache pink color.
+- **Code-review heuristic:** When a test asserts inequality of two computed DOM style strings, check whether structural differences (width, box-shadow, margin, etc.) already guarantee the strings differ. If so, the test is trivially true. Narrow the assertion to the specific property or value that actually matters (e.g., `background`, `color`, or `not.toContain(expectedColor)`).
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/ui-visual-regression.md
+++ b/docs/reviews/patterns/ui-visual-regression.md
@@ -1,0 +1,44 @@
+---
+id: ui-visual-regression
+category: code-quality
+created: 2026-06-11
+last_updated: 2026-06-11
+ref_count: 0
+---
+
+# UI Visual Regression
+
+## Summary
+
+UI color and styling choices must be verified against the full state matrix of
+the component. A new gradient, border, or accent color can silently collide with
+an existing state color and render two distinct segments indistinguishable.
+Regressions are especially likely when:
+- A named palette constant (e.g. Catppuccin Mocha hex) is reused for a new
+  semantic purpose without checking existing usages.
+- Tests exercise only the "healthy" or default state and omit edge states
+  (cold, empty, error) where the collision occurs.
+
+The fix shape: pick a visually distinct color from the palette, and add a
+test case for the state that triggers the collision.
+
+## Findings
+
+### 1. Fresh-segment gradient collides with cold-state cached segment
+
+- **Source:** github-claude | PR #419 round 1 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/components/TokenCache.tsx`
+- **Finding:** `FRESH_STACK_GRADIENT` was changed to
+  `linear-gradient(90deg, #ff94a5, #ffb4ab)`. The existing `cachedShareHex`
+  function already returns `#ff94a5` for the cold-state cached segment
+  (`sharePct < 40`). In a cold-cache scenario both the cached and fresh
+  segments opened with the same pink, merging visually into one block.
+  The new test only used a healthy-cache input (`makeUsage(7500, 1800, 700)`),
+  so the collision was never exercised.
+- **Fix:** Changed `FRESH_STACK_GRADIENT` to
+  `linear-gradient(90deg, #fab387, #f9a87b)` (Catppuccin Peach), which does
+  not overlap with any `cachedShareHex` output (`#7defa1`, `#cba6f7`,
+  `#ff94a5`). Added a cold-cache test case asserting that cached and fresh
+  stack styles differ.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/ui-visual-regression.md
+++ b/docs/reviews/patterns/ui-visual-regression.md
@@ -14,6 +14,7 @@ UI color and styling choices must be verified against the full state matrix of
 the component. A new gradient, border, or accent color can silently collide with
 an existing state color and render two distinct segments indistinguishable.
 Regressions are especially likely when:
+
 - A named palette constant (e.g. Catppuccin Mocha hex) is reused for a new
   semantic purpose without checking existing usages.
 - Tests exercise only the "healthy" or default state and omit edge states

--- a/src/features/agent-status/components/TokenCache.test.tsx
+++ b/src/features/agent-status/components/TokenCache.test.tsx
@@ -141,8 +141,23 @@ describe('TokenCache — stack bar', () => {
     expect(
       screen.getByTestId('token-cache-stack-wrote').getAttribute('style')
     ).toContain('linear-gradient(90deg, #a8c8ff, #8aa9d8)')
+
     expect(
       screen.getByTestId('token-cache-stack-fresh').getAttribute('style')
-    ).toContain('linear-gradient(90deg, #ff94a5, #ffb4ab)')
+    ).toContain('linear-gradient(90deg, #fab387, #f9a87b)')
+  })
+
+  test('cached and fresh styles differ in cold-cache state', () => {
+    render(<TokenCache usage={makeUsage(300, 200, 500)} history={[75]} />)
+
+    const cachedStyle = screen
+      .getByTestId('token-cache-stack-cached')
+      .getAttribute('style')
+
+    const freshStyle = screen
+      .getByTestId('token-cache-stack-fresh')
+      .getAttribute('style')
+
+    expect(cachedStyle).not.toBe(freshStyle)
   })
 })

--- a/src/features/agent-status/components/TokenCache.test.tsx
+++ b/src/features/agent-status/components/TokenCache.test.tsx
@@ -134,4 +134,15 @@ describe('TokenCache — stack bar', () => {
     expect(sum).toBeGreaterThan(99.9)
     expect(sum).toBeLessThan(100.1)
   })
+
+  test('uses distinct bucket colors for wrote and fresh segments', () => {
+    render(<TokenCache usage={makeUsage(7500, 1800, 700)} history={[75]} />)
+
+    expect(
+      screen.getByTestId('token-cache-stack-wrote').getAttribute('style')
+    ).toContain('linear-gradient(90deg, #a8c8ff, #8aa9d8)')
+    expect(
+      screen.getByTestId('token-cache-stack-fresh').getAttribute('style')
+    ).toContain('linear-gradient(90deg, #ff94a5, #ffb4ab)')
+  })
 })

--- a/src/features/agent-status/components/TokenCache.test.tsx
+++ b/src/features/agent-status/components/TokenCache.test.tsx
@@ -150,14 +150,10 @@ describe('TokenCache — stack bar', () => {
   test('cached and fresh styles differ in cold-cache state', () => {
     render(<TokenCache usage={makeUsage(300, 200, 500)} history={[75]} />)
 
-    const cachedStyle = screen
-      .getByTestId('token-cache-stack-cached')
-      .getAttribute('style')
-
     const freshStyle = screen
       .getByTestId('token-cache-stack-fresh')
       .getAttribute('style')
 
-    expect(cachedStyle).not.toBe(freshStyle)
+    expect(freshStyle).not.toContain('#ff94a5')
   })
 })

--- a/src/features/agent-status/components/TokenCache.tsx
+++ b/src/features/agent-status/components/TokenCache.tsx
@@ -35,7 +35,7 @@ const cachedShareHex = (sharePct: number): string =>
   sharePct >= 70 ? '#7defa1' : sharePct >= 40 ? '#cba6f7' : '#ff94a5'
 
 const WROTE_STACK_GRADIENT = 'linear-gradient(90deg, #a8c8ff, #8aa9d8)'
-const FRESH_STACK_GRADIENT = 'linear-gradient(90deg, #ff94a5, #ffb4ab)'
+const FRESH_STACK_GRADIENT = 'linear-gradient(90deg, #fab387, #f9a87b)'
 
 const StackBar = ({
   cached,

--- a/src/features/agent-status/components/TokenCache.tsx
+++ b/src/features/agent-status/components/TokenCache.tsx
@@ -34,6 +34,9 @@ const fmt = (n: number): string =>
 const cachedShareHex = (sharePct: number): string =>
   sharePct >= 70 ? '#7defa1' : sharePct >= 40 ? '#cba6f7' : '#ff94a5'
 
+const WROTE_STACK_GRADIENT = 'linear-gradient(90deg, #a8c8ff, #8aa9d8)'
+const FRESH_STACK_GRADIENT = 'linear-gradient(90deg, #ff94a5, #ffb4ab)'
+
 const StackBar = ({
   cached,
   wrote,
@@ -80,12 +83,15 @@ const StackBar = ({
         data-testid="token-cache-stack-wrote"
         style={{
           width: `${wPct}%`,
-          background: 'linear-gradient(90deg, #a8c8ff, #8aa9d8)',
+          background: WROTE_STACK_GRADIENT,
         }}
       />
       <div
         data-testid="token-cache-stack-fresh"
-        style={{ width: `${fPct}%`, background: 'rgba(205,195,209,0.4)' }}
+        style={{
+          width: `${fPct}%`,
+          background: FRESH_STACK_GRADIENT,
+        }}
       />
     </div>
   )


### PR DESCRIPTION
## What changed
- Updated the token cache stacked bar so the `fresh` segment uses a pink/coral gradient instead of muted gray.
- Kept the existing PR #395 card layout and JSX structure intact.
- Added a focused regression test for distinct `wrote` and `fresh` bucket colors.

## Why
The cache card already separates cached, wrote, and fresh buckets, but the fresh segment was too visually muted. This makes the fresh-token portion readable without changing the component layout.

## Validation
- `npm test -- --run src/features/agent-status/components/TokenCache.test.tsx`
