### PR TITLE
feat(settings): add Zed-style Settings dialog wired to the sidebar footer (VIM-29)

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -2,6 +2,18 @@ version: '0.2'
 language: en
 
 words:
+  # Settings dialog domain terms (UI labels / scheme + font names)
+  - keymap
+  - Keymap
+  - KEYMAPS
+  - collab
+  - flexoki
+  - Flexoki
+  - fraunces
+  - Fraunces
+  - fira
+  - Fira
+
   # Claude Code tool names (also used uppercased in UI labels)
   - webfetch
   - websearch

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                              | Category           | Findings | Refs | Last Updated |
 | -------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security           | 21       | 3    | 2026-05-20   |
- | [React Lifecycle](patterns/react-lifecycle.md) | react-patterns | 34 | 14 | 2026-06-11 |  |
+| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 35       | 14   | 2026-06-11   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 11       | 10   | 2026-06-08   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 6        | 3    | 2026-05-30   |
@@ -55,8 +55,8 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Hot-Path Caching](patterns/hot-path-caching.md)                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 62       | 30   | 2026-06-11   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 85       | 25   | 2026-06-08   |
- | [Accessibility](patterns/accessibility.md) | a11y | 57 | 21 | 2026-06-11 |  |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 87       | 25   | 2026-06-11   |
+| [Accessibility](patterns/accessibility.md)                           | a11y               | 57       | 21   | 2026-06-11   |
 | [Event Identity Guard](patterns/event-identity-guard.md)             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 63       | 21   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 62       | 30   | 2026-06-11   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 87       | 25   | 2026-06-11   |
-| [Accessibility](patterns/accessibility.md)                           | a11y               | 57       | 21   | 2026-06-11   |
+| [Accessibility](patterns/accessibility.md)                           | a11y               | 59       | 22   | 2026-06-11   |
 | [Event Identity Guard](patterns/event-identity-guard.md)             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 63       | 21   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,6 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | -------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security           | 21       | 3    | 2026-05-20   |
 | [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 36       | 15   | 2026-06-11   |
+| [React Key Stability](patterns/react-key-stability.md)               | react-patterns     | 2        | 0    | 2026-06-11   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 11       | 10   | 2026-06-08   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 6        | 3    | 2026-05-30   |
@@ -56,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 62       | 30   | 2026-06-11   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 87       | 25   | 2026-06-11   |
-| [Accessibility](patterns/accessibility.md)                           | a11y               | 60       | 23   | 2026-06-11   |
+| [Accessibility](patterns/accessibility.md)                           | a11y               | 61       | 23   | 2026-06-11   |
 | [Event Identity Guard](patterns/event-identity-guard.md)             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 63       | 21   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                              | Category           | Findings | Refs | Last Updated |
 | -------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security           | 21       | 3    | 2026-05-20   |
-| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 33       | 14   | 2026-06-11   |
+ | [React Lifecycle](patterns/react-lifecycle.md) | react-patterns | 34 | 14 | 2026-06-11 |  |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 11       | 10   | 2026-06-08   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 6        | 3    | 2026-05-30   |
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 62       | 30   | 2026-06-11   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 85       | 25   | 2026-06-08   |
-| [Accessibility](patterns/accessibility.md)                           | a11y               | 49       | 21   | 2026-06-11   |
+ | [Accessibility](patterns/accessibility.md) | a11y | 57 | 21 | 2026-06-11 |  |
 | [Event Identity Guard](patterns/event-identity-guard.md)             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 63       | 21   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                              | Category           | Findings | Refs | Last Updated |
 | -------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                     | security           | 21       | 3    | 2026-05-20   |
-| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 35       | 14   | 2026-06-11   |
+| [React Lifecycle](patterns/react-lifecycle.md)                       | react-patterns     | 36       | 15   | 2026-06-11   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                     | react-patterns     | 11       | 10   | 2026-06-08   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)             | cross-platform     | 6        | 3    | 2026-05-30   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 62       | 30   | 2026-06-11   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 87       | 25   | 2026-06-11   |
-| [Accessibility](patterns/accessibility.md)                           | a11y               | 59       | 22   | 2026-06-11   |
+| [Accessibility](patterns/accessibility.md)                           | a11y               | 60       | 23   | 2026-06-11   |
 | [Event Identity Guard](patterns/event-identity-guard.md)             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 63       | 21   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                             | testing            | 62       | 30   | 2026-06-11   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)         | code-quality       | 87       | 25   | 2026-06-11   |
-| [Accessibility](patterns/accessibility.md)                           | a11y               | 61       | 23   | 2026-06-11   |
+| [Accessibility](patterns/accessibility.md)                           | a11y               | 63       | 23   | 2026-06-11   |
 | [Event Identity Guard](patterns/event-identity-guard.md)             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)           | react-patterns     | 63       | 21   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-11
-ref_count: 21
+ref_count: 22
 ---
 
 # Accessibility
@@ -531,4 +531,22 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/settings/components/controls.tsx`
 - **Finding:** The settings toggles rendered as plain `<button>` elements with only an accessible label, so screen readers could not tell whether settings like "Use System Prompts" were currently on or off.
 - **Fix:** Added `role="switch"` and `aria-checked={on}` to the `Toggle` button so assistive technology exposes the current on/off state.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 50. Settings search input lacks a programmatic accessible name
+
+- **Source:** github-claude | PR #422 round 3 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/SettingsSidebar.tsx`
+- **Finding:** The sidebar search `<input>` carried only a `placeholder` attribute with no `aria-label`, `id`/`<label>` pair, or `aria-labelledby`. Placeholder text is not a reliable accessible name across screen reader and browser combinations, so a screen-reader user could encounter an unnamed primary search control inside the modal.
+- **Fix:** Added `aria-label="Search settings"` to the `<input>` and updated the co-located test to query by the accessible name (`getByRole('textbox', { name: 'Search settings' })`).
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 51. Settings scope switcher has no accessible selected state
+
+- **Source:** github-claude | PR #422 round 3 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/SettingsHeader.tsx`
+- **Finding:** The "User" / "vimeflow" scope controls were plain `<button>` elements whose active state was represented only by CSS classes. Screen-reader users could activate the controls but could not determine which scope was selected or receive a semantic state change.
+- **Fix:** Wrapped the scope controls in a `<div role="radiogroup" aria-label="Settings scope">` and gave each scope button `role="radio"` with `aria-checked={scope === s}`. Updated co-located tests to query by `radio` role and assert `aria-checked` values.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,7 +2,7 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-11
+P26-06-11
 ref_count: 21
 ---
 
@@ -504,4 +504,31 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/sessions/components/Card.tsx`
 - **Finding:** The actions popup closed on `onBlur` (when focus left the wrapper) and on Escape, but clicking a non-focusable area of the sidebar did not move focus and therefore did not trigger blur, leaving the popup visibly stuck open during normal pointer use.
 - **Fix:** Added a document-level `mousedown` listener active while `menuOpen === true` that calls `setMenuOpen(false)` when the event target is outside the kebab/menu container. The listener is registered in a `useEffect` with cleanup on unmount or menu close.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 47. SettingsDialog opens without focus management or Tab trap
+
+- **Source:** github-claude | PR #422 round 1 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/SettingsDialog.tsx`
+- **Finding:** The dialog declared `role="dialog"` and `aria-modal="true"` but performed no focus management on open or close. The triggering button retained focus, `Tab` could escape into the workspace behind the modal, and focus was not restored when the dialog closed.
+- **Fix:** Captured `previousFocusRef` on open, focused the close button via `useEffect`, added a document `keydown` listener that traps `Tab`/`Shift+Tab` within the dialog's focusable elements, and restored the prior focus on close.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 48. SettingsDialog lacks initial focus and Tab trap for modal keyboard users
+
+- **Source:** github-codex-connector | PR #422 round 1 | 2026-06-11
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/SettingsDialog.tsx`
+- **Finding:** Opening the dialog from the sidebar footer left focus on the footer; there was no initial focus move, no Tab trap, and no inerting of the background workspace, so keyboard users could Tab into and activate underlying workspace controls while `aria-modal` advertised a modal dialog.
+- **Fix:** Same focus-management change as the previous entry: capture prior focus, focus the close button on open, trap Tab within the dialog, and restore focus on close.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 49. SettingsToggle button exposes only a label, not its on/off state
+
+- **Source:** github-codex-connector | PR #422 round 1 | 2026-06-11
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/components/controls.tsx`
+- **Finding:** The settings toggles rendered as plain `<button>` elements with only an accessible label, so screen readers could not tell whether settings like "Use System Prompts" were currently on or off.
+- **Fix:** Added `role="switch"` and `aria-checked={on}` to the `Toggle` button so assistive technology exposes the current on/off state.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -568,3 +568,21 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The focusable-element filter in the Tab trap used `!el.hasAttribute('disabled')`, which only checks whether the DOM attribute is literally present on the element. Descendant controls inside a disabled `<fieldset>` inherit disabled state without the attribute, so they passed the filter and the trap tried to focus them, causing Tab to stall on alias-row controls when alias management is off.
 - **Fix:** Replaced `!el.hasAttribute('disabled')` with `!el.matches(':disabled')` so the filter respects the HTML spec's disabled-fieldset-descendant semantics.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 54. Active settings sidebar section button missing `aria-current` — invisible to AT
+
+- **Source:** github-claude | PR #422 round 7 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/SettingsSidebar.tsx`
+- **Finding:** The currently-active section button was distinguished only by CSS classes (`text-primary`, `bg-primary-container/10`). No accessible attribute communicated the selection state to assistive technology, so screen-reader users heard each item announced identically as a button with no indication of which section was shown in the pane.
+- **Fix:** Added `aria-current={isActive ? 'page' : undefined}` to the active section button and added a co-located test asserting the attribute on the active item and its absence on inactive items.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 55. AppearancePane scheme selector cards convey active state only via CSS, not ARIA
+
+- **Source:** github-claude | PR #422 round 7 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/panes/AppearancePane.tsx`
+- **Finding:** Each color-scheme card was a `<button>` whose selected state was indicated only by border/background CSS classes and an `aria-hidden` checkmark icon. Screen readers received no ARIA attribute communicating which scheme was currently active, so every button was announced identically.
+- **Fix:** Added `aria-pressed={isActive}` to each scheme button and added a co-located test asserting the pressed state for the default active scheme and an inactive scheme.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-11
-ref_count: 22
+ref_count: 23
 ---
 
 # Accessibility
@@ -549,4 +549,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/settings/components/SettingsHeader.tsx`
 - **Finding:** The "User" / "vimeflow" scope controls were plain `<button>` elements whose active state was represented only by CSS classes. Screen-reader users could activate the controls but could not determine which scope was selected or receive a semantic state change.
 - **Fix:** Wrapped the scope controls in a `<div role="radiogroup" aria-label="Settings scope">` and gave each scope button `role="radio"` with `aria-checked={scope === s}`. Updated co-located tests to query by `radio` role and assert `aria-checked` values.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 52. Alias rows look disabled but remain interactive when alias management is off
+
+- **Source:** github-claude | PR #422 round 5 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/panes/AgentsPane.tsx`
+- **Finding:** When the alias-management toggle was off, each alias row received only `opacity-45`; the descendant text inputs, selects, and remove button remained enabled and tabbable. This created a keyboard and assistive-technology mismatch because users encountered controls that were visually presented as inactive but announced and operated as active.
+- **Fix:** Wrapped the alias-row controls in a `<fieldset disabled={!shimOn} className="contents">` so that all descendant form controls and buttons are semantically disabled when alias management is off. Added a co-located test verifying the disabled fieldset state.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,7 +2,7 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-P26-06-11
+last_updated: 2026-06-11
 ref_count: 21
 ---
 

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -559,3 +559,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** When the alias-management toggle was off, each alias row received only `opacity-45`; the descendant text inputs, selects, and remove button remained enabled and tabbable. This created a keyboard and assistive-technology mismatch because users encountered controls that were visually presented as inactive but announced and operated as active.
 - **Fix:** Wrapped the alias-row controls in a `<fieldset disabled={!shimOn} className="contents">` so that all descendant form controls and buttons are semantically disabled when alias management is off. Added a co-located test verifying the disabled fieldset state.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 53. Tab trap hasAttribute check misses fieldset-inherited disabled state
+
+- **Source:** github-claude | PR #422 round 6 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/SettingsDialog.tsx`
+- **Finding:** The focusable-element filter in the Tab trap used `!el.hasAttribute('disabled')`, which only checks whether the DOM attribute is literally present on the element. Descendant controls inside a disabled `<fieldset>` inherit disabled state without the attribute, so they passed the filter and the trap tried to focus them, causing Tab to stall on alias-row controls when alias management is off.
+- **Fix:** Replaced `!el.hasAttribute('disabled')` with `!el.matches(':disabled')` so the filter respects the HTML spec's disabled-fieldset-descendant semantics.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -2,7 +2,7 @@
 id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
-last_updated: 2026-06-08
+last_updated: 2026-06-11
 ref_count: 25
 ---
 
@@ -800,4 +800,22 @@ Stale documentation misleads future contributors and review agents.
 - **File:** `electron/browser-pane.ts`
 - **Finding:** `installFaviconEmitter` had to run before history restore or URL load because Electron can emit `page-favicon-updated` during replay, but no inline comment documented that ordering contract. A future refactor could move the emitter after restore and silently drop restored-tab favicons.
 - **Fix:** Added a short comment directly above `installFaviconEmitter` stating that it must precede history restore/load because the favicon event can fire during that work.
+- **Commit:** same commit as this entry
+
+### 86. Corrupted YAML frontmatter in review-pattern files after count update
+
+- **Source:** github-claude | PR #422 round 1 | 2026-06-11
+- **Severity:** MEDIUM
+- **File:** `docs/reviews/patterns/accessibility.md`, `docs/reviews/patterns/react-lifecycle.md`
+- **Finding:** `last_updated: 2026-06-11` was replaced with the bare string `P26-06-11` (no key, no colon) in both files during an automated frontmatter edit. A bare scalar inside a YAML mapping block is a parse error; strict YAML parsers reject the document and lenient ones silently drop the field.
+- **Fix:** Restored both lines to `last_updated: 2026-06-11`.
+- **Commit:** same commit as this entry
+
+### 87. Review index table rows malformatted after count update
+
+- **Source:** github-claude | PR #422 round 1 | 2026-06-11
+- **Severity:** LOW
+- **File:** `docs/reviews/CLAUDE.md`
+- **Finding:** The React Lifecycle and Accessibility rows in the index table were rewritten with a leading space before the opening `|`, collapsed column widths, and an extra empty cell `|  |` at the end. Most Markdown renderers produce broken output for misaligned pipe tables.
+- **Fix:** Re-aligned both rows to match the surrounding pipe-table style and removed the trailing empty cell.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-key-stability.md
+++ b/docs/reviews/patterns/react-key-stability.md
@@ -1,0 +1,37 @@
+---
+id: react-key-stability
+category: react-patterns
+created: 2026-06-11
+last_updated: 2026-06-11
+ref_count: 0
+---
+
+# React Key Stability
+
+## Summary
+
+React list keys must be stable and unique for the identity of each child.
+Time-based IDs can collide when events fire within the same millisecond, and
+array indices produce duplicate or shifting identities whenever items reorder.
+Prefer collision-free identifiers (`crypto.randomUUID()`, ref counters) and
+stable composite keys derived from item identity.
+
+## Findings
+
+### 1. Date.now() for new-alias IDs risks React key collision
+
+- **Source:** github-claude | PR #422 round 6 | 2026-06-11
+- **Severity:** LOW
+- **File:** `src/features/settings/components/panes/AgentsPane.tsx`
+- **Finding:** `addAlias` generated new alias rows with `` `id: `a${Date.now()}` ``. A fast double-click or keyboard repeat could create two rows within the same millisecond, producing duplicate React `key` values and misapplied state updates.
+- **Fix:** Switched to `` `id: `a${crypto.randomUUID()}` ``, which is collision-free in modern Electron renderer contexts.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 2. Array index used as key for Kbd chips in KeymapPane
+
+- **Source:** github-claude | PR #422 round 6 | 2026-06-11
+- **Severity:** LOW
+- **File:** `src/features/settings/components/panes/KeymapPane.tsx`
+- **Finding:** `b.keys.map((k, j) => <Kbd key={j}>{k}</Kbd>)` used the array index as the React key. If the key array is ever reordered (e.g., by a future preset editor), React may misplace chip DOM nodes and apply stale transitions.
+- **Fix:** Replaced the index key with a stable composite key `` `key={\`${b.id}-${k}\`}` `` derived from the binding id and the key character.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,7 +2,7 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-P26-06-11
+last_updated: 2026-06-11
 ref_count: 14
 ---
 
@@ -320,3 +320,12 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** `SettingsDialog` returned `null` when `open` was false before reaching the `<AnimatePresence>` wrapper. When `open` flipped to false, React unmounted the entire `AnimatePresence>` tree immediately, so the backdrop and panel `exit` animations never ran and the dialog snapped closed.
 - **Fix:** Removed the early `if (!open) return null` guard and moved the condition inside `<AnimatePresence>` as `{open && (...)}`, matching the existing `CommandPalette` and `UnsavedChangesDialog` pattern.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 32. Unused `section` prop widens SettingsHeader public API surface
+
+- **Source:** github-claude | PR #422 round 1 | 2026-06-11
+- **Severity:** LOW
+- **File:** `src/features/settings/components/SettingsHeader.tsx`, `src/features/settings/types.ts`, `src/features/settings/SettingsDialog.tsx`
+- **Finding:** `SettingsHeaderProps` declared `section: SettingsSection | undefined` and `SettingsDialog` passed `section={activeSection}`, but `SettingsHeader` destructured only `{ scope, onScope }` — the prop was silently dropped. Callers were forced to provide a value for a field that had no consumer, and tests passed the prop without asserting on any section-related output.
+- **Fix:** Removed the `section` field from `SettingsHeaderProps`, removed `section={activeSection}` from the `SettingsDialog` call site, and cleaned up the co-located test props.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -3,7 +3,7 @@ id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-11
-ref_count: 14
+ref_count: 15
 ---
 
 # React Lifecycle
@@ -329,3 +329,12 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** `SettingsHeaderProps` declared `section: SettingsSection | undefined` and `SettingsDialog` passed `section={activeSection}`, but `SettingsHeader` destructured only `{ scope, onScope }` — the prop was silently dropped. Callers were forced to provide a value for a field that had no consumer, and tests passed the prop without asserting on any section-related output.
 - **Fix:** Removed the `section` field from `SettingsHeaderProps`, removed `section={activeSection}` from the `SettingsDialog` call site, and cleaned up the co-located test props.
 - **Commit:** same commit as this entry
+
+### 33. Component state survives open/close cycles when the component is permanently mounted
+
+- **Source:** github-claude | PR #422 round 3 | 2026-06-11
+- **Severity:** LOW
+- **File:** `src/features/settings/SettingsDialog.tsx`
+- **Finding:** `SettingsDialog` is permanently mounted in `WorkspaceView` (inside `AnimatePresence` with an `{open && ...}` guard rather than being conditionally rendered). The `query` state lived in the component body above the `open` guard, so it survived dialog close and was still active when the dialog reopened. A user who typed a search term, closed the dialog, and reopened it would see a filtered sidebar with no visible indication that a filter was active.
+- **Fix:** Added `useEffect(() => { if (!open) setQuery('') }, [open])` to reset the search query whenever the dialog closes. Added a co-located test asserting the query is cleared on close/reopen.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,7 +2,7 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-11
+P26-06-11
 ref_count: 14
 ---
 
@@ -310,4 +310,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/workspace/WorkspaceView.tsx`, `src/features/workspace/components/AgentStatusCard.tsx`
 - **Finding:** `sidebarCardState` was computed through a 5-branch ternary over `activityPanelStatus` and `agentStatus.isActive` on every render, then passed as `state={sidebarCardState}` to `AgentStatusCard` where it was immediately discarded via `void state`. No state-driven visual output existed in the card, so the computation served no purpose and misled the component interface.
 - **Fix:** Removed `sidebarCardState` computation from `WorkspaceView`, removed the `state` prop from `AgentStatusCardProps`, and updated co-located tests to match the new prop contract.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 31. AnimatePresence condition placed before the wrapper, killing exit animations
+
+- **Source:** github-claude | PR #422 round 1 | 2026-06-11
+- **Severity:** HIGH
+- **File:** `src/features/settings/SettingsDialog.tsx`
+- **Finding:** `SettingsDialog` returned `null` when `open` was false before reaching the `<AnimatePresence>` wrapper. When `open` flipped to false, React unmounted the entire `AnimatePresence>` tree immediately, so the backdrop and panel `exit` animations never ran and the dialog snapped closed.
+- **Fix:** Removed the early `if (!open) return null` guard and moved the condition inside `<AnimatePresence>` as `{open && (...)}`, matching the existing `CommandPalette` and `UnsavedChangesDialog` pattern.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/settings/SettingsDialog.integration.test.tsx
+++ b/src/features/settings/SettingsDialog.integration.test.tsx
@@ -1,0 +1,46 @@
+import { type ReactElement } from 'react'
+import { describe, expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SettingsDialog } from './SettingsDialog'
+import { useSettingsDialog } from './hooks/useSettingsDialog'
+import { SidebarSettingsFooter } from '../workspace/components/SidebarSettingsFooter'
+
+const SettingsIntegration = (): ReactElement => {
+  const settings = useSettingsDialog()
+
+  return (
+    <>
+      <SidebarSettingsFooter onSettings={settings.open} />
+      <SettingsDialog open={settings.isOpen} onClose={settings.close} />
+    </>
+  )
+}
+
+describe('SettingsDialog integration', () => {
+  test('opens from sidebar footer trigger and closes via Escape', async () => {
+    const user = userEvent.setup()
+    render(<SettingsIntegration />)
+
+    await user.click(screen.getByRole('button', { name: 'Settings' }))
+
+    expect(screen.getByRole('dialog', { name: 'Settings' })).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  test('closes when backdrop is clicked', async () => {
+    const user = userEvent.setup()
+    render(<SettingsIntegration />)
+
+    await user.click(screen.getByRole('button', { name: 'Settings' }))
+
+    expect(screen.getByRole('dialog', { name: 'Settings' })).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('settings-dialog-backdrop'))
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})

--- a/src/features/settings/SettingsDialog.integration.test.tsx
+++ b/src/features/settings/SettingsDialog.integration.test.tsx
@@ -1,6 +1,10 @@
 import { type ReactElement } from 'react'
 import { describe, expect, test } from 'vitest'
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react'
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SettingsDialog } from './SettingsDialog'
 import { useSettingsDialog } from './hooks/useSettingsDialog'

--- a/src/features/settings/SettingsDialog.integration.test.tsx
+++ b/src/features/settings/SettingsDialog.integration.test.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement } from 'react'
 import { describe, expect, test } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SettingsDialog } from './SettingsDialog'
 import { useSettingsDialog } from './hooks/useSettingsDialog'
@@ -28,7 +28,7 @@ describe('SettingsDialog integration', () => {
 
     await user.keyboard('{Escape}')
 
-    expect(screen.queryByRole('dialog')).toBeNull()
+    await waitForElementToBeRemoved(() => screen.queryByRole('dialog'))
   })
 
   test('closes when backdrop is clicked', async () => {
@@ -41,6 +41,6 @@ describe('SettingsDialog integration', () => {
 
     await user.click(screen.getByTestId('settings-dialog-backdrop'))
 
-    expect(screen.queryByRole('dialog')).toBeNull()
+    await waitForElementToBeRemoved(() => screen.queryByRole('dialog'))
   })
 })

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -1,8 +1,26 @@
 import { describe, expect, test, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState, type ReactElement } from 'react'
 import { SettingsDialog } from './SettingsDialog'
 import { SETTINGS_SECTIONS } from './sections'
+
+const DialogWithTrigger = ({
+  initialOpen = false,
+}: {
+  initialOpen?: boolean
+}): ReactElement => {
+  const [open, setOpen] = useState(initialOpen)
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open settings
+      </button>
+      <SettingsDialog open={open} onClose={() => setOpen(false)} />
+    </>
+  )
+}
 
 describe('SettingsDialog', () => {
   test('returns null and renders no dialog when open is false', () => {
@@ -102,5 +120,39 @@ describe('SettingsDialog', () => {
     expect(
       screen.getByText(/Terminal settings haven't been wired yet/)
     ).toBeInTheDocument()
+  })
+
+  test('moves focus to the close button when opened', async () => {
+    const user = userEvent.setup()
+    render(<DialogWithTrigger />)
+
+    await user.click(screen.getByRole('button', { name: 'Open settings' }))
+
+    expect(screen.getByTitle('close')).toHaveFocus()
+  })
+
+  test('traps Tab focus inside the dialog', async () => {
+    const user = userEvent.setup()
+    render(<DialogWithTrigger initialOpen />)
+
+    // Move focus to the last focusable element in the default Appearance pane
+    // and press Tab; focus should wrap back to the close button.
+    const lastFocusable = screen.getByLabelText('Mono font')
+
+    lastFocusable.focus()
+    await user.tab()
+
+    expect(screen.getByTitle('close')).toHaveFocus()
+  })
+
+  test('restores focus to the triggering element on close', async () => {
+    const user = userEvent.setup()
+    render(<DialogWithTrigger />)
+
+    const trigger = screen.getByRole('button', { name: 'Open settings' })
+    await user.click(trigger)
+    await user.click(screen.getByTitle('close'))
+
+    expect(trigger).toHaveFocus()
   })
 })

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -155,4 +155,25 @@ describe('SettingsDialog', () => {
 
     expect(trigger).toHaveFocus()
   })
+
+  test('clears search query when the dialog is reopened', async () => {
+    const user = userEvent.setup()
+    render(<DialogWithTrigger />)
+
+    const trigger = screen.getByRole('button', { name: 'Open settings' })
+    await user.click(trigger)
+
+    await user.type(screen.getByPlaceholderText('Search settings...'), 'term')
+
+    expect(screen.queryByRole('button', { name: 'General' })).toBeNull()
+
+    await user.click(screen.getByTitle('close'))
+    await user.click(trigger)
+
+    expect(screen.getByRole('button', { name: 'General' })).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: 'Appearance' })
+    ).toBeInTheDocument()
+  })
 })

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, test, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SettingsDialog } from './SettingsDialog'
+import { SETTINGS_SECTIONS } from './sections'
+
+describe('SettingsDialog', () => {
+  test('returns null and renders no dialog when open is false', () => {
+    // eslint-disable-next-line react/jsx-boolean-value
+    render(<SettingsDialog open={false} onClose={vi.fn()} />)
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  test('renders the dialog with aria-label when open is true', () => {
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    expect(screen.getByRole('dialog', { name: 'Settings' })).toBeInTheDocument()
+  })
+
+  test('calls onClose when the backdrop is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<SettingsDialog open onClose={onClose} />)
+
+    await user.click(screen.getByTestId('settings-dialog-backdrop'))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  test('calls onClose when the close button is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<SettingsDialog open onClose={onClose} />)
+
+    await user.click(screen.getByTitle('close'))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  test('renders the sidebar sections', () => {
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    SETTINGS_SECTIONS.forEach((s) => {
+      expect(screen.getByRole('button', { name: s.label })).toBeInTheDocument()
+    })
+  })
+
+  test('defaults to the appearance pane', () => {
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Appearance' })).toHaveClass(
+      'text-primary'
+    )
+    expect(screen.getByText('Color Scheme')).toBeInTheDocument()
+  })
+
+  test('switches panes when a sidebar section is clicked', async () => {
+    const user = userEvent.setup()
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: 'Keymap' }))
+
+    expect(screen.getByText('Keyboard shortcuts')).toBeInTheDocument()
+  })
+
+  test('filters sidebar sections via search', async () => {
+    const user = userEvent.setup()
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Search settings...'), 'term')
+
+    expect(screen.getByRole('button', { name: 'Terminal' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'General' })).toBeNull()
+  })
+
+  test('renders the footer hint and close shortcut', () => {
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    expect(screen.getByText('Focus')).toBeInTheDocument()
+    expect(screen.getByText('Navbar')).toBeInTheDocument()
+    expect(screen.getByText('esc')).toBeInTheDocument()
+  })
+
+  test('keeps placeholder pane visible when active section is filtered out', async () => {
+    const user = userEvent.setup()
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    // Click a placeholder section (Terminal)
+    await user.click(screen.getByRole('button', { name: 'Terminal' }))
+
+    // Type a query that filters Terminal out of the sidebar
+    await user.type(
+      screen.getByPlaceholderText('Search settings...'),
+      'general'
+    )
+
+    // Terminal button should be gone from sidebar
+    expect(screen.queryByRole('button', { name: 'Terminal' })).toBeNull()
+
+    // But the placeholder pane for Terminal should still render
+    expect(
+      screen.getByText(/Terminal settings haven't been wired yet/)
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -73,7 +73,7 @@ export const SettingsDialog = ({
         )
       ).filter(
         (el) =>
-          !el.hasAttribute('disabled') &&
+          !el.matches(':disabled') &&
           el.getAttribute('aria-hidden') !== 'true'
       )
 

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -73,8 +73,7 @@ export const SettingsDialog = ({
         )
       ).filter(
         (el) =>
-          !el.matches(':disabled') &&
-          el.getAttribute('aria-hidden') !== 'true'
+          !el.matches(':disabled') && el.getAttribute('aria-hidden') !== 'true'
       )
 
       if (focusable.length === 0) {

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'framer-motion'
-import { useState, type ReactElement } from 'react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
 import type { SettingsSectionId, SettingsDialogProps } from './types'
 import { SETTINGS_SECTIONS } from './sections'
 import { Icon } from './components/Icon'
@@ -27,6 +27,10 @@ export const SettingsDialog = ({
   const [scope, setScope] = useState<'User' | 'vimeflow'>('User')
   const [query, setQuery] = useState('')
 
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+
   const filtered = query.trim()
     ? SETTINGS_SECTIONS.filter((s) =>
         s.label.toLowerCase().includes(query.toLowerCase())
@@ -35,93 +39,160 @@ export const SettingsDialog = ({
 
   const activeSection = SETTINGS_SECTIONS.find((s) => s.id === section)
 
-  if (!open) {
-    return null
-  }
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null
+      closeButtonRef.current?.focus()
+    } else if (previousFocusRef.current) {
+      previousFocusRef.current.focus()
+      previousFocusRef.current = null
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) {
+      return undefined
+    }
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Tab') {
+        return
+      }
+
+      const dialog = dialogRef.current
+      if (!dialog) {
+        return
+      }
+
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter(
+        (el) =>
+          !el.hasAttribute('disabled') &&
+          el.getAttribute('aria-hidden') !== 'true'
+      )
+
+      if (focusable.length === 0) {
+        event.preventDefault()
+
+        return
+      }
+
+      const currentIndex = focusable.indexOf(
+        document.activeElement as HTMLElement
+      )
+      const delta = event.shiftKey ? -1 : 1
+
+      let nextIndex: number
+      if (currentIndex === -1) {
+        nextIndex = event.shiftKey ? focusable.length - 1 : 0
+      } else {
+        nextIndex = (currentIndex + delta + focusable.length) % focusable.length
+      }
+
+      event.preventDefault()
+      focusable[nextIndex]?.focus()
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return (): void => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
 
   return (
     <AnimatePresence>
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="Settings"
-        className="fixed inset-0 z-[100] flex items-center justify-center p-10"
-      >
-        <motion.div
-          data-testid="settings-dialog-backdrop"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.15 }}
-          className="absolute inset-0 backdrop-blur-sm bg-black/40"
-          onClick={onClose}
-        />
-
-        <motion.div
-          initial={{ scale: 0.96, opacity: 0, y: -8 }}
-          animate={{ scale: 1, opacity: 1, y: 0 }}
-          exit={{ scale: 0.96, opacity: 0, y: -8 }}
-          transition={{
-            type: 'spring',
-            stiffness: 400,
-            damping: 30,
-          }}
-          onClick={(e) => e.stopPropagation()}
-          className="relative flex h-[640px] w-[920px] max-h-[90vh] max-w-[95vw] flex-col overflow-hidden rounded-xl border border-outline-variant/45 bg-surface-container/95 backdrop-blur-2xl shadow-[0_28px_72px_rgba(0,0,0,0.6),0_0_0_1px_rgba(203,166,247,0.08)]"
+      {open && (
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Settings"
+          className="fixed inset-0 z-[100] flex items-center justify-center p-10"
         >
-          {/* Title bar */}
-          <div className="flex h-9 shrink-0 items-center justify-end gap-1.5 border-b border-outline-variant/25 bg-surface-container px-2.5">
-            <button
-              type="button"
-              title="close"
-              onClick={onClose}
-              className="grid h-[22px] w-[22px] place-items-center rounded border-none bg-transparent text-on-surface-muted transition-colors hover:bg-white/[0.04] hover:text-on-surface"
-            >
-              <Icon name="close" size={14} />
-            </button>
-          </div>
+          <motion.div
+            data-testid="settings-dialog-backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="absolute inset-0 backdrop-blur-sm bg-black/40"
+            onClick={onClose}
+          />
 
-          <div className="flex min-h-0 flex-1">
-            <SettingsSidebar
-              sections={filtered}
-              active={section}
-              onPick={setSection}
-              query={query}
-              onQuery={setQuery}
-            />
+          <motion.div
+            initial={{ scale: 0.96, opacity: 0, y: -8 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.96, opacity: 0, y: -8 }}
+            transition={{
+              type: 'spring',
+              stiffness: 400,
+              damping: 30,
+            }}
+            onClick={(e) => e.stopPropagation()}
+            className="relative flex h-[640px] w-[920px] max-h-[90vh] max-w-[95vw] flex-col overflow-hidden rounded-xl border border-outline-variant/45 bg-surface-container/95 backdrop-blur-2xl shadow-[0_28px_72px_rgba(0,0,0,0.6),0_0_0_1px_rgba(203,166,247,0.08)]"
+          >
+            {/* Title bar */}
+            <div className="flex h-9 shrink-0 items-center justify-end gap-1.5 border-b border-outline-variant/25 bg-surface-container px-2.5">
+              <button
+                ref={closeButtonRef}
+                type="button"
+                title="close"
+                onClick={onClose}
+                className="grid h-[22px] w-[22px] place-items-center rounded border-none bg-transparent text-on-surface-muted transition-colors hover:bg-white/[0.04] hover:text-on-surface"
+              >
+                <Icon name="close" size={14} />
+              </button>
+            </div>
 
-            <div className="flex min-w-0 flex-1 flex-col">
-              <SettingsHeader
-                scope={scope}
-                onScope={setScope}
-                section={activeSection}
+            <div className="flex min-h-0 flex-1">
+              <SettingsSidebar
+                sections={filtered}
+                active={section}
+                onPick={setSection}
+                query={query}
+                onQuery={setQuery}
               />
 
-              <div className="thin-scrollbar flex-1 overflow-auto px-7 py-5">
-                {section === 'general' && <GeneralPane />}
-                {section === 'appearance' && <AppearancePane />}
-                {section === 'keymap' && <KeymapPane />}
-                {section === 'agents' && <AgentsPane />}
-                {!REAL_PANES.includes(section) && activeSection && (
-                  <PlaceholderPane section={activeSection} />
-                )}
+              <div className="flex min-w-0 flex-1 flex-col">
+                <SettingsHeader
+                  scope={scope}
+                  onScope={setScope}
+                  section={activeSection}
+                />
+
+                <div className="thin-scrollbar flex-1 overflow-auto px-7 py-5">
+                  {section === 'general' && <GeneralPane />}
+                  {section === 'appearance' && <AppearancePane />}
+                  {section === 'keymap' && <KeymapPane />}
+                  {section === 'agents' && <AgentsPane />}
+                  {!REAL_PANES.includes(section) && activeSection && (
+                    <PlaceholderPane section={activeSection} />
+                  )}
+                </div>
               </div>
             </div>
-          </div>
 
-          {/* Footer */}
-          <div className="flex h-7 shrink-0 items-center gap-2.5 border-t border-outline-variant/25 bg-surface-container-lowest px-3.5 font-mono text-[10px] text-on-surface-muted/80">
-            <Kbd>⌘</Kbd>
-            <Kbd>⇧</Kbd>
-            <Kbd>E</Kbd>
-            <span className="text-primary-container">Focus</span>
-            <span>Navbar</span>
-            <span className="min-w-0 flex-1" />
-            <Kbd>esc</Kbd>
-            <span>close</span>
-          </div>
-        </motion.div>
-      </div>
+            {/* Footer */}
+            <div className="flex h-7 shrink-0 items-center gap-2.5 border-t border-outline-variant/25 bg-surface-container-lowest px-3.5 font-mono text-[10px] text-on-surface-muted/80">
+              <Kbd>⌘</Kbd>
+              <Kbd>⇧</Kbd>
+              <Kbd>E</Kbd>
+              <span className="text-primary-container">Focus</span>
+              <span>Navbar</span>
+              <span className="min-w-0 flex-1" />
+              <Kbd>esc</Kbd>
+              <span>close</span>
+            </div>
+          </motion.div>
+        </div>
+      )}
     </AnimatePresence>
   )
 }

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -106,6 +106,12 @@ export const SettingsDialog = ({
     }
   }, [open])
 
+  useEffect(() => {
+    if (!open) {
+      setQuery('')
+    }
+  }, [open])
+
   return (
     <AnimatePresence>
       {open && (

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -1,0 +1,127 @@
+import { AnimatePresence, motion } from 'framer-motion'
+import { useState, type ReactElement } from 'react'
+import type { SettingsSectionId, SettingsDialogProps } from './types'
+import { SETTINGS_SECTIONS } from './sections'
+import { Icon } from './components/Icon'
+import { Kbd } from './components/Kbd'
+import { SettingsHeader } from './components/SettingsHeader'
+import { SettingsSidebar } from './components/SettingsSidebar'
+import { AgentsPane } from './components/panes/AgentsPane'
+import { AppearancePane } from './components/panes/AppearancePane'
+import { GeneralPane } from './components/panes/GeneralPane'
+import { KeymapPane } from './components/panes/KeymapPane'
+import { PlaceholderPane } from './components/panes/PlaceholderPane'
+
+const REAL_PANES: readonly SettingsSectionId[] = [
+  'general',
+  'appearance',
+  'keymap',
+  'agents',
+]
+
+export const SettingsDialog = ({
+  open,
+  onClose,
+}: SettingsDialogProps): ReactElement | null => {
+  const [section, setSection] = useState<SettingsSectionId>('appearance')
+  const [scope, setScope] = useState<'User' | 'vimeflow'>('User')
+  const [query, setQuery] = useState('')
+
+  const filtered = query.trim()
+    ? SETTINGS_SECTIONS.filter((s) =>
+        s.label.toLowerCase().includes(query.toLowerCase())
+      )
+    : SETTINGS_SECTIONS
+
+  const activeSection = SETTINGS_SECTIONS.find((s) => s.id === section)
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <AnimatePresence>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Settings"
+        className="fixed inset-0 z-[100] flex items-center justify-center p-10"
+      >
+        <motion.div
+          data-testid="settings-dialog-backdrop"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+          className="absolute inset-0 backdrop-blur-sm bg-black/40"
+          onClick={onClose}
+        />
+
+        <motion.div
+          initial={{ scale: 0.96, opacity: 0, y: -8 }}
+          animate={{ scale: 1, opacity: 1, y: 0 }}
+          exit={{ scale: 0.96, opacity: 0, y: -8 }}
+          transition={{
+            type: 'spring',
+            stiffness: 400,
+            damping: 30,
+          }}
+          onClick={(e) => e.stopPropagation()}
+          className="relative flex h-[640px] w-[920px] max-h-[90vh] max-w-[95vw] flex-col overflow-hidden rounded-xl border border-outline-variant/45 bg-surface-container/95 backdrop-blur-2xl shadow-[0_28px_72px_rgba(0,0,0,0.6),0_0_0_1px_rgba(203,166,247,0.08)]"
+        >
+          {/* Title bar */}
+          <div className="flex h-9 shrink-0 items-center justify-end gap-1.5 border-b border-outline-variant/25 bg-surface-container px-2.5">
+            <button
+              type="button"
+              title="close"
+              onClick={onClose}
+              className="grid h-[22px] w-[22px] place-items-center rounded border-none bg-transparent text-on-surface-muted transition-colors hover:bg-white/[0.04] hover:text-on-surface"
+            >
+              <Icon name="close" size={14} />
+            </button>
+          </div>
+
+          <div className="flex min-h-0 flex-1">
+            <SettingsSidebar
+              sections={filtered}
+              active={section}
+              onPick={setSection}
+              query={query}
+              onQuery={setQuery}
+            />
+
+            <div className="flex min-w-0 flex-1 flex-col">
+              <SettingsHeader
+                scope={scope}
+                onScope={setScope}
+                section={activeSection}
+              />
+
+              <div className="thin-scrollbar flex-1 overflow-auto px-7 py-5">
+                {section === 'general' && <GeneralPane />}
+                {section === 'appearance' && <AppearancePane />}
+                {section === 'keymap' && <KeymapPane />}
+                {section === 'agents' && <AgentsPane />}
+                {!REAL_PANES.includes(section) && activeSection && (
+                  <PlaceholderPane section={activeSection} />
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="flex h-7 shrink-0 items-center gap-2.5 border-t border-outline-variant/25 bg-surface-container-lowest px-3.5 font-mono text-[10px] text-on-surface-muted/80">
+            <Kbd>⌘</Kbd>
+            <Kbd>⇧</Kbd>
+            <Kbd>E</Kbd>
+            <span className="text-primary-container">Focus</span>
+            <span>Navbar</span>
+            <span className="min-w-0 flex-1" />
+            <Kbd>esc</Kbd>
+            <span>close</span>
+          </div>
+        </motion.div>
+      </div>
+    </AnimatePresence>
+  )
+}

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -161,11 +161,7 @@ export const SettingsDialog = ({
               />
 
               <div className="flex min-w-0 flex-1 flex-col">
-                <SettingsHeader
-                  scope={scope}
-                  onScope={setScope}
-                  section={activeSection}
-                />
+                <SettingsHeader scope={scope} onScope={setScope} />
 
                 <div className="thin-scrollbar flex-1 overflow-auto px-7 py-5">
                   {section === 'general' && <GeneralPane />}

--- a/src/features/settings/components/Icon.test.tsx
+++ b/src/features/settings/components/Icon.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Icon } from './Icon'
+
+describe('Icon', () => {
+  test('renders a Material Symbols span with the given name', () => {
+    render(<Icon name="settings" />)
+    const span = screen.getByText('settings')
+
+    expect(span.tagName).toBe('SPAN')
+    expect(span).toHaveClass('material-symbols-outlined')
+    expect(span).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  test('applies the custom size via inline style', () => {
+    render(<Icon name="close" size={24} />)
+
+    expect(screen.getByText('close')).toHaveStyle({ fontSize: '24px' })
+  })
+
+  test('toggles fill via font-variation-settings', () => {
+    render(<Icon name="check" fill />)
+
+    expect(screen.getByText('check')).toHaveStyle({
+      fontVariationSettings: "'FILL' 1",
+    })
+  })
+
+  test('appends the optional className', () => {
+    render(<Icon name="palette" className="text-primary" />)
+
+    expect(screen.getByText('palette')).toHaveClass('text-primary')
+  })
+})

--- a/src/features/settings/components/Icon.tsx
+++ b/src/features/settings/components/Icon.tsx
@@ -1,0 +1,25 @@
+import type { CSSProperties, ReactElement } from 'react'
+import type { IconProps } from '../types'
+
+export const Icon = ({
+  name,
+  size = 16,
+  fill = false,
+  className = '',
+}: IconProps): ReactElement => {
+  const style: CSSProperties = { fontSize: size }
+
+  if (fill) {
+    style.fontVariationSettings = "'FILL' 1"
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className={`material-symbols-outlined ${className}`}
+      style={style}
+    >
+      {name}
+    </span>
+  )
+}

--- a/src/features/settings/components/Kbd.test.tsx
+++ b/src/features/settings/components/Kbd.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Kbd } from './Kbd'
+
+describe('Kbd', () => {
+  test('renders a kbd element containing the children', () => {
+    render(<Kbd>⌘</Kbd>)
+
+    expect(screen.getByText('⌘').tagName).toBe('KBD')
+  })
+
+  test('uses the mono pill styling', () => {
+    render(<Kbd>esc</Kbd>)
+    const kbd = screen.getByText('esc')
+
+    expect(kbd).toHaveClass('font-mono', 'border', 'text-on-surface-variant')
+  })
+})

--- a/src/features/settings/components/Kbd.tsx
+++ b/src/features/settings/components/Kbd.tsx
@@ -1,0 +1,8 @@
+import type { ReactElement } from 'react'
+import type { KbdProps } from '../types'
+
+export const Kbd = ({ children }: KbdProps): ReactElement => (
+  <kbd className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-[4px] border border-outline-variant/60 bg-surface-container-high/60 px-[5px] font-mono text-[10px] font-semibold leading-none text-on-surface-variant">
+    {children}
+  </kbd>
+)

--- a/src/features/settings/components/SettingsHeader.test.tsx
+++ b/src/features/settings/components/SettingsHeader.test.tsx
@@ -23,10 +23,12 @@ describe('SettingsHeader', () => {
       'aria-checked',
       'true'
     )
+
     expect(screen.getByRole('radio', { name: 'User' })).toHaveAttribute(
       'aria-checked',
       'false'
     )
+
     expect(screen.getByRole('radio', { name: 'vimeflow' })).toHaveClass(
       'border-primary-container'
     )

--- a/src/features/settings/components/SettingsHeader.test.tsx
+++ b/src/features/settings/components/SettingsHeader.test.tsx
@@ -1,16 +1,12 @@
 import { describe, expect, test, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { SETTINGS_SECTIONS } from '../sections'
 import { SettingsHeader } from './SettingsHeader'
 
 describe('SettingsHeader', () => {
-  const section = SETTINGS_SECTIONS[0]
-
   const baseProps = {
     scope: 'User' as const,
     onScope: vi.fn(),
-    section,
   }
 
   test('renders User and vimeflow scope tabs', () => {

--- a/src/features/settings/components/SettingsHeader.test.tsx
+++ b/src/features/settings/components/SettingsHeader.test.tsx
@@ -9,17 +9,25 @@ describe('SettingsHeader', () => {
     onScope: vi.fn(),
   }
 
-  test('renders User and vimeflow scope tabs', () => {
+  test('renders User and vimeflow scope radios', () => {
     render(<SettingsHeader {...baseProps} />)
 
-    expect(screen.getByRole('button', { name: 'User' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'vimeflow' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'User' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'vimeflow' })).toBeInTheDocument()
   })
 
-  test('active scope has accent underline styling', () => {
+  test('active scope has aria-checked and accent underline styling', () => {
     render(<SettingsHeader {...baseProps} scope="vimeflow" />)
 
-    expect(screen.getByRole('button', { name: 'vimeflow' })).toHaveClass(
+    expect(screen.getByRole('radio', { name: 'vimeflow' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    )
+    expect(screen.getByRole('radio', { name: 'User' })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    )
+    expect(screen.getByRole('radio', { name: 'vimeflow' })).toHaveClass(
       'border-primary-container'
     )
   })
@@ -29,7 +37,7 @@ describe('SettingsHeader', () => {
     const onScope = vi.fn()
     render(<SettingsHeader {...baseProps} onScope={onScope} />)
 
-    await user.click(screen.getByRole('button', { name: 'vimeflow' }))
+    await user.click(screen.getByRole('radio', { name: 'vimeflow' }))
 
     expect(onScope).toHaveBeenCalledWith('vimeflow')
   })

--- a/src/features/settings/components/SettingsHeader.test.tsx
+++ b/src/features/settings/components/SettingsHeader.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, test, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SETTINGS_SECTIONS } from '../sections'
+import { SettingsHeader } from './SettingsHeader'
+
+describe('SettingsHeader', () => {
+  const section = SETTINGS_SECTIONS[0]
+
+  const baseProps = {
+    scope: 'User' as const,
+    onScope: vi.fn(),
+    section,
+  }
+
+  test('renders User and vimeflow scope tabs', () => {
+    render(<SettingsHeader {...baseProps} />)
+
+    expect(screen.getByRole('button', { name: 'User' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'vimeflow' })).toBeInTheDocument()
+  })
+
+  test('active scope has accent underline styling', () => {
+    render(<SettingsHeader {...baseProps} scope="vimeflow" />)
+
+    expect(screen.getByRole('button', { name: 'vimeflow' })).toHaveClass(
+      'border-primary-container'
+    )
+  })
+
+  test('calls onScope when a tab is clicked', async () => {
+    const user = userEvent.setup()
+    const onScope = vi.fn()
+    render(<SettingsHeader {...baseProps} onScope={onScope} />)
+
+    await user.click(screen.getByRole('button', { name: 'vimeflow' }))
+
+    expect(onScope).toHaveBeenCalledWith('vimeflow')
+  })
+
+  test('renders the Edit in settings.json ghost button', () => {
+    render(<SettingsHeader {...baseProps} />)
+
+    expect(
+      screen.getByRole('button', { name: 'Edit in settings.json' })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/settings/components/SettingsHeader.tsx
+++ b/src/features/settings/components/SettingsHeader.tsx
@@ -9,11 +9,17 @@ export const SettingsHeader = ({
   onScope,
 }: SettingsHeaderProps): ReactElement => (
   <div className="flex shrink-0 items-center gap-3.5 border-b border-outline-variant/25 px-7 py-4">
-    <div className="flex items-center gap-4">
+    <div
+      className="flex items-center gap-4"
+      role="radiogroup"
+      aria-label="Settings scope"
+    >
       {SCOPES.map((s) => (
         <button
           key={s}
           type="button"
+          role="radio"
+          aria-checked={scope === s}
           onClick={() => onScope(s)}
           className={`border-b-[1.5px] border-solid bg-transparent p-0 pb-0.5 font-body text-[13px] cursor-pointer transition-colors ${
             scope === s

--- a/src/features/settings/components/SettingsHeader.tsx
+++ b/src/features/settings/components/SettingsHeader.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from 'react'
+import type { SettingsHeaderProps, SettingsScope } from '../types'
+import { GhostButton } from './controls'
+
+const SCOPES: SettingsScope[] = ['User', 'vimeflow']
+
+export const SettingsHeader = ({
+  scope,
+  onScope,
+}: SettingsHeaderProps): ReactElement => (
+  <div className="flex shrink-0 items-center gap-3.5 border-b border-outline-variant/25 px-7 py-4">
+    <div className="flex items-center gap-4">
+      {SCOPES.map((s) => (
+        <button
+          key={s}
+          type="button"
+          onClick={() => onScope(s)}
+          className={`border-b-[1.5px] border-solid bg-transparent p-0 pb-0.5 font-body text-[13px] cursor-pointer transition-colors ${
+            scope === s
+              ? 'border-primary-container font-semibold text-primary-container'
+              : 'border-transparent text-on-surface-muted hover:text-on-surface'
+          }`}
+        >
+          {s}
+        </button>
+      ))}
+    </div>
+
+    <span className="min-w-0 flex-1" />
+
+    <GhostButton>Edit in settings.json</GhostButton>
+  </div>
+)

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -72,4 +72,16 @@ describe('SettingsSidebar', () => {
       'text-primary'
     )
   })
+
+  test('marks the active section with aria-current', () => {
+    render(<SettingsSidebar {...baseProps} />)
+
+    expect(
+      screen.getByRole('button', { name: 'Appearance', current: 'page' })
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole('button', { name: 'Keymap' })).not.toHaveAttribute(
+      'aria-current'
+    )
+  })
 })

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -1,0 +1,75 @@
+import { useState, type ReactElement } from 'react'
+import { describe, expect, test, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SETTINGS_SECTIONS } from '../sections'
+import { SettingsSidebar } from './SettingsSidebar'
+
+const StatefulSidebar = (): ReactElement => {
+  const [query, setQuery] = useState('')
+
+  return (
+    <SettingsSidebar
+      sections={SETTINGS_SECTIONS}
+      active="appearance"
+      onPick={() => undefined}
+      query={query}
+      onQuery={setQuery}
+    />
+  )
+}
+
+describe('SettingsSidebar', () => {
+  const baseProps = {
+    sections: SETTINGS_SECTIONS,
+    active: 'appearance' as const,
+    onPick: vi.fn(),
+    query: '',
+    onQuery: vi.fn(),
+  }
+
+  test('renders the search input with placeholder', () => {
+    render(<SettingsSidebar {...baseProps} />)
+
+    expect(
+      screen.getByPlaceholderText('Search settings...')
+    ).toBeInTheDocument()
+  })
+
+  test('renders all section buttons', () => {
+    render(<SettingsSidebar {...baseProps} />)
+
+    SETTINGS_SECTIONS.forEach((s) => {
+      expect(screen.getByRole('button', { name: s.label })).toBeInTheDocument()
+    })
+  })
+
+  test('forwards query changes', async () => {
+    const user = userEvent.setup()
+    render(<StatefulSidebar />)
+
+    await user.type(screen.getByPlaceholderText('Search settings...'), 'term')
+
+    expect(screen.getByPlaceholderText('Search settings...')).toHaveValue(
+      'term'
+    )
+  })
+
+  test('calls onPick with the section id when a button is clicked', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    render(<SettingsSidebar {...baseProps} onPick={onPick} />)
+
+    await user.click(screen.getByRole('button', { name: 'Keymap' }))
+
+    expect(onPick).toHaveBeenCalledWith('keymap')
+  })
+
+  test('marks the active section with primary text', () => {
+    render(<SettingsSidebar {...baseProps} />)
+
+    expect(screen.getByRole('button', { name: 'Appearance' })).toHaveClass(
+      'text-primary'
+    )
+  })
+})

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -28,11 +28,11 @@ describe('SettingsSidebar', () => {
     onQuery: vi.fn(),
   }
 
-  test('renders the search input with placeholder', () => {
+  test('renders the search input with accessible name', () => {
     render(<SettingsSidebar {...baseProps} />)
 
     expect(
-      screen.getByPlaceholderText('Search settings...')
+      screen.getByRole('textbox', { name: 'Search settings' })
     ).toBeInTheDocument()
   })
 

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from 'react'
+import type { SettingsSidebarProps } from '../types'
+import { Icon } from './Icon'
+
+export const SettingsSidebar = ({
+  sections,
+  active,
+  onPick,
+  query,
+  onQuery,
+}: SettingsSidebarProps): ReactElement => (
+  <aside className="flex w-[220px] shrink-0 flex-col border-r border-outline-variant/25 bg-surface-container">
+    <div className="px-3 pt-3.5 pb-2.5">
+      <div className="flex items-center gap-2 rounded-lg border border-outline-variant/35 bg-surface-container-lowest/60 px-2.5 py-2">
+        <Icon name="search" size={13} className="text-on-surface-muted" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => onQuery(e.target.value)}
+          placeholder="Search settings..."
+          className="min-w-0 flex-1 border-none bg-transparent font-body text-xs text-on-surface outline-none placeholder:text-on-surface-muted"
+        />
+      </div>
+    </div>
+
+    <nav className="thin-scrollbar flex-1 overflow-auto px-2 pb-3.5">
+      {sections.map((s) => {
+        const isActive = s.id === active
+
+        return (
+          <button
+            key={s.id}
+            type="button"
+            onClick={() => onPick(s.id)}
+            className={`relative mb-px flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left font-body text-[13px] transition-colors ${
+              isActive
+                ? 'bg-primary-container/10 text-primary'
+                : 'bg-transparent text-on-surface-variant hover:bg-white/[0.03]'
+            }`}
+          >
+            {isActive && (
+              <span className="absolute -left-0.5 top-2 bottom-2 w-0.5 rounded-sm bg-primary-container" />
+            )}
+            <Icon
+              name="chevron_right"
+              size={13}
+              className={
+                isActive ? 'text-primary-container' : 'text-on-surface-muted'
+              }
+            />
+            {s.label}
+          </button>
+        )
+      })}
+    </nav>
+  </aside>
+)

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -18,6 +18,7 @@ export const SettingsSidebar = ({
           value={query}
           onChange={(e) => onQuery(e.target.value)}
           placeholder="Search settings..."
+          aria-label="Search settings"
           className="min-w-0 flex-1 border-none bg-transparent font-body text-xs text-on-surface outline-none placeholder:text-on-surface-muted"
         />
       </div>

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -32,6 +32,7 @@ export const SettingsSidebar = ({
           <button
             key={s.id}
             type="button"
+            aria-current={isActive ? 'page' : undefined}
             onClick={() => onPick(s.id)}
             className={`relative mb-px flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left font-body text-[13px] transition-colors ${
               isActive

--- a/src/features/settings/components/controls.test.tsx
+++ b/src/features/settings/components/controls.test.tsx
@@ -1,0 +1,136 @@
+import { useState, type ReactElement } from 'react'
+import { describe, expect, test, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  GhostButton,
+  PaneTitle,
+  Row,
+  Select,
+  TextInput,
+  Toggle,
+} from './controls'
+
+const StatefulTextInput = (): ReactElement => {
+  const [value, setValue] = useState('hello')
+
+  return <TextInput value={value} onChange={setValue} aria-label="Input" />
+}
+
+describe('Row', () => {
+  test('renders label and hint', () => {
+    render(<Row label="Density" hint="Compact or comfortable" />)
+
+    expect(screen.getByText('Density')).toBeInTheDocument()
+    expect(screen.getByText('Compact or comfortable')).toBeInTheDocument()
+  })
+
+  test('renders children on the right', () => {
+    render(
+      <Row label="Toggle">
+        <span data-testid="row-child">on</span>
+      </Row>
+    )
+
+    expect(screen.getByTestId('row-child')).toBeInTheDocument()
+  })
+
+  test('omits bottom border when last is true', () => {
+    render(<Row label="Last row" last />)
+
+    expect(screen.getByTestId('row')).not.toHaveClass('border-b')
+  })
+})
+
+describe('PaneTitle', () => {
+  test('renders title and optional sub eyebrow', () => {
+    render(<PaneTitle title="General" sub="General Settings" />)
+
+    expect(screen.getByText('General')).toBeInTheDocument()
+    expect(screen.getByText('General Settings')).toBeInTheDocument()
+  })
+})
+
+describe('Toggle', () => {
+  test('calls onChange with true when currently off', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Toggle onChange={onChange} aria-label="Enable" />)
+
+    await user.click(screen.getByRole('button', { name: 'Enable' }))
+
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+
+  test('calls onChange with false when currently on', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Toggle on onChange={onChange} aria-label="Enable" />)
+
+    await user.click(screen.getByRole('button', { name: 'Enable' }))
+
+    expect(onChange).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('Select', () => {
+  test('renders the current value and options', () => {
+    render(
+      <Select
+        value="b"
+        onChange={() => undefined}
+        aria-label="Pick"
+        options={[
+          { id: 'a', label: 'Alpha' },
+          { id: 'b', label: 'Beta' },
+        ]}
+      />
+    )
+
+    expect(screen.getByLabelText('Pick')).toHaveValue('b')
+  })
+
+  test('forwards changes', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <Select
+        value="a"
+        onChange={onChange}
+        aria-label="Pick"
+        options={['a', 'b']}
+      />
+    )
+
+    await user.selectOptions(screen.getByLabelText('Pick'), 'b')
+
+    expect(onChange).toHaveBeenCalledWith('b')
+  })
+})
+
+describe('GhostButton', () => {
+  test('renders children and fires onClick', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<GhostButton onClick={onClick}>Export</GhostButton>)
+
+    await user.click(screen.getByRole('button', { name: 'Export' }))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('TextInput', () => {
+  test('renders the value and forwards changes', async () => {
+    const user = userEvent.setup()
+    render(<StatefulTextInput />)
+
+    const input = screen.getByLabelText('Input')
+    expect(input).toHaveValue('hello')
+
+    await user.clear(input)
+    await user.type(input, 'world')
+
+    expect(input).toHaveValue('world')
+  })
+})

--- a/src/features/settings/components/controls.test.tsx
+++ b/src/features/settings/components/controls.test.tsx
@@ -57,7 +57,7 @@ describe('Toggle', () => {
     const onChange = vi.fn()
     render(<Toggle onChange={onChange} aria-label="Enable" />)
 
-    await user.click(screen.getByRole('button', { name: 'Enable' }))
+    await user.click(screen.getByRole('switch', { name: 'Enable' }))
 
     expect(onChange).toHaveBeenCalledWith(true)
   })
@@ -67,9 +67,27 @@ describe('Toggle', () => {
     const onChange = vi.fn()
     render(<Toggle on onChange={onChange} aria-label="Enable" />)
 
-    await user.click(screen.getByRole('button', { name: 'Enable' }))
+    await user.click(screen.getByRole('switch', { name: 'Enable' }))
 
     expect(onChange).toHaveBeenCalledWith(false)
+  })
+
+  test('exposes toggle state as aria-checked', () => {
+    const { rerender } = render(
+      <Toggle onChange={() => undefined} aria-label="Enable" />
+    )
+
+    expect(screen.getByRole('switch', { name: 'Enable' })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    )
+
+    rerender(<Toggle on onChange={() => undefined} aria-label="Enable" />)
+
+    expect(screen.getByRole('switch', { name: 'Enable' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    )
   })
 })
 

--- a/src/features/settings/components/controls.tsx
+++ b/src/features/settings/components/controls.tsx
@@ -1,0 +1,137 @@
+import type { ReactElement } from 'react'
+import type {
+  GhostButtonProps,
+  PaneTitleProps,
+  RowProps,
+  SelectOption,
+  SelectProps,
+  TextInputProps,
+  ToggleProps,
+} from '../types'
+
+export const Row = ({
+  label,
+  hint,
+  children,
+  last = false,
+}: RowProps): ReactElement => (
+  <div
+    data-testid="row"
+    className={`flex items-center gap-6 py-3.5 ${
+      last ? '' : 'border-b border-outline-variant/18'
+    }`}
+  >
+    <div className="min-w-0 flex-1">
+      <div className="mb-1 font-display text-sm font-medium text-on-surface">
+        {label}
+      </div>
+      {hint && (
+        <div className="font-body text-xs leading-relaxed text-on-surface-muted">
+          {hint}
+        </div>
+      )}
+    </div>
+    <div className="shrink-0">{children}</div>
+  </div>
+)
+
+export const PaneTitle = ({ title, sub }: PaneTitleProps): ReactElement => (
+  <div className="mb-4">
+    <div className="mb-1 font-display text-[22px] font-semibold tracking-tight text-on-surface">
+      {title}
+    </div>
+    {sub && (
+      <div className="font-mono text-[11px] uppercase tracking-widest text-on-surface-muted">
+        {sub}
+      </div>
+    )}
+  </div>
+)
+
+export const Toggle = ({
+  on = false,
+  onChange,
+  'aria-label': ariaLabel,
+}: ToggleProps): ReactElement => (
+  <button
+    type="button"
+    aria-label={ariaLabel}
+    onClick={() => onChange(!on)}
+    className={`relative h-5 w-9 cursor-pointer rounded-full border-none p-0 transition-colors duration-150 ${
+      on ? 'bg-primary-container' : 'bg-outline-variant/50'
+    }`}
+  >
+    <span
+      className={`absolute top-0.5 h-4 w-4 rounded-full transition-all duration-180 ${
+        on ? 'bg-on-surface' : 'bg-on-surface-variant'
+      }`}
+      style={{
+        left: on ? 18 : 2,
+        transitionTimingFunction: 'cubic-bezier(.2,.8,.2,1)',
+      }}
+    />
+  </button>
+)
+
+const normalizeOptions = (options: SelectOption[] | string[]): SelectOption[] =>
+  options.map((o) => (typeof o === 'string' ? { id: o, label: o } : o))
+
+export const Select = ({
+  value,
+  options,
+  onChange,
+  width = 180,
+  'aria-label': ariaLabel,
+}: SelectProps): ReactElement => {
+  const normalized = normalizeOptions(options)
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      aria-label={ariaLabel}
+      className="h-[30px] cursor-pointer appearance-none rounded-md border border-outline-variant/50 bg-surface-container px-2.5 font-body text-xs text-on-surface outline-none"
+      style={{ width }}
+    >
+      {normalized.map((o) => (
+        <option key={o.id} value={o.id}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+export const GhostButton = ({
+  children,
+  onClick = (): void => undefined,
+}: GhostButtonProps): ReactElement => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="rounded-md border border-outline-variant/50 bg-transparent px-3 py-1.5 font-body text-xs text-on-surface-variant transition-colors hover:bg-surface-container-high"
+  >
+    {children}
+  </button>
+)
+
+export const TextInput = ({
+  value,
+  onChange,
+  placeholder,
+  width = 200,
+  mono = false,
+  'aria-label': ariaLabel,
+}: TextInputProps): ReactElement => (
+  <input
+    type="text"
+    aria-label={ariaLabel}
+    value={value}
+    onChange={(e) => onChange(e.target.value)}
+    placeholder={placeholder}
+    className={`h-[30px] rounded-md border border-outline-variant/50 bg-surface-container px-2.5 text-xs text-on-surface outline-none placeholder:text-on-surface-muted ${
+      mono ? 'font-mono' : 'font-body'
+    }`}
+    style={{ width }}
+  />
+)

--- a/src/features/settings/components/controls.tsx
+++ b/src/features/settings/components/controls.tsx
@@ -55,7 +55,9 @@ export const Toggle = ({
 }: ToggleProps): ReactElement => (
   <button
     type="button"
+    role="switch"
     aria-label={ariaLabel}
+    aria-checked={on}
     onClick={() => onChange(!on)}
     className={`relative h-5 w-9 cursor-pointer rounded-full border-none p-0 transition-colors duration-150 ${
       on ? 'bg-primary-container' : 'bg-outline-variant/50'

--- a/src/features/settings/components/panes/AgentsPane.test.tsx
+++ b/src/features/settings/components/panes/AgentsPane.test.tsx
@@ -59,6 +59,22 @@ describe('AgentsPane', () => {
     })
   })
 
+  test('disables alias row controls when the shim toggle is turned off', async () => {
+    const user = userEvent.setup()
+    render(<AgentsPane />)
+
+    await user.click(
+      screen.getByRole('switch', { name: 'Manage agent shell aliases' })
+    )
+
+    const rows = screen.getAllByTestId('alias-row')
+    rows.forEach((row) => {
+      const fieldset = row.querySelector('fieldset')
+      expect(fieldset).toBeInTheDocument()
+      expect(fieldset).toBeDisabled()
+    })
+  })
+
   test('renders the info callout with the aliases.toml path', () => {
     render(<AgentsPane />)
 

--- a/src/features/settings/components/panes/AgentsPane.test.tsx
+++ b/src/features/settings/components/panes/AgentsPane.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { DEFAULT_ALIASES } from '../../sections'
 import { AgentsPane } from './AgentsPane'
@@ -69,7 +69,7 @@ describe('AgentsPane', () => {
 
     const rows = screen.getAllByTestId('alias-row')
     rows.forEach((row) => {
-      const fieldset = row.querySelector('fieldset')
+      const fieldset = within(row).getByRole('group')
       expect(fieldset).toBeInTheDocument()
       expect(fieldset).toBeDisabled()
     })

--- a/src/features/settings/components/panes/AgentsPane.test.tsx
+++ b/src/features/settings/components/panes/AgentsPane.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DEFAULT_ALIASES } from '../../sections'
+import { AgentsPane } from './AgentsPane'
+
+describe('AgentsPane', () => {
+  test('renders the pane title', () => {
+    render(<AgentsPane />)
+
+    expect(screen.getByText('Coding Agents')).toBeInTheDocument()
+    expect(
+      screen.getByText('Shell aliases · agent registry')
+    ).toBeInTheDocument()
+  })
+
+  test('renders the default aliases', () => {
+    render(<AgentsPane />)
+
+    DEFAULT_ALIASES.forEach((a) => {
+      expect(screen.getByDisplayValue(a.alias)).toBeInTheDocument()
+    })
+  })
+
+  test('adds a new alias row when Add alias is clicked', async () => {
+    const user = userEvent.setup()
+    render(<AgentsPane />)
+
+    await user.click(screen.getByRole('button', { name: /Add alias/i }))
+
+    expect(screen.getAllByTestId('alias-row').length).toBe(
+      DEFAULT_ALIASES.length + 1
+    )
+  })
+
+  test('removes an alias row when its delete button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<AgentsPane />)
+
+    const deleteButtons = screen.getAllByTestId('remove-alias')
+    await user.click(deleteButtons[0])
+
+    expect(screen.getAllByTestId('alias-row').length).toBe(
+      DEFAULT_ALIASES.length - 1
+    )
+  })
+
+  test('dims alias rows when the shim toggle is turned off', async () => {
+    const user = userEvent.setup()
+    render(<AgentsPane />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Manage agent shell aliases' })
+    )
+
+    const rows = screen.getAllByTestId('alias-row')
+    rows.forEach((row) => {
+      expect(row).toHaveClass('opacity-45')
+    })
+  })
+
+  test('renders the info callout with the aliases.toml path', () => {
+    render(<AgentsPane />)
+
+    expect(screen.getByText(/aliases.toml/)).toBeInTheDocument()
+    expect(screen.getByText(/How this works/)).toBeInTheDocument()
+  })
+})

--- a/src/features/settings/components/panes/AgentsPane.test.tsx
+++ b/src/features/settings/components/panes/AgentsPane.test.tsx
@@ -50,7 +50,7 @@ describe('AgentsPane', () => {
     render(<AgentsPane />)
 
     await user.click(
-      screen.getByRole('button', { name: 'Manage agent shell aliases' })
+      screen.getByRole('switch', { name: 'Manage agent shell aliases' })
     )
 
     const rows = screen.getAllByTestId('alias-row')

--- a/src/features/settings/components/panes/AgentsPane.tsx
+++ b/src/features/settings/components/panes/AgentsPane.tsx
@@ -1,0 +1,172 @@
+import { useState, type ReactElement } from 'react'
+import type { AgentAlias } from '../../types'
+import { DEFAULT_ALIASES } from '../../sections'
+import { Icon } from '../Icon'
+import {
+  GhostButton,
+  PaneTitle,
+  Row,
+  Select,
+  TextInput,
+  Toggle,
+} from '../controls'
+
+export const AgentsPane = (): ReactElement => {
+  const [shimOn, setShimOn] = useState(true)
+  const [aliases, setAliases] = useState<AgentAlias[]>(DEFAULT_ALIASES)
+
+  const addAlias = (): void =>
+    setAliases((prev) => [
+      ...prev,
+      {
+        id: `a${Date.now()}`,
+        alias: '',
+        agent: 'claude',
+        model: 'sonnet-4',
+        extra: '',
+      },
+    ])
+
+  const update = (id: string, key: keyof AgentAlias, value: string): void =>
+    setAliases((prev) =>
+      prev.map((a) => (a.id === id ? { ...a, [key]: value } : a))
+    )
+
+  const remove = (id: string): void =>
+    setAliases((prev) => prev.filter((a) => a.id !== id))
+
+  return (
+    <>
+      <PaneTitle title="Coding Agents" sub="Shell aliases · agent registry" />
+
+      <Row
+        label="Manage agent shell aliases"
+        hint="Vimeflow injects these into each pane's PTY environment. Your .bashrc / .zshrc is never touched."
+      >
+        <Toggle
+          on={shimOn}
+          onChange={setShimOn}
+          aria-label="Manage agent shell aliases"
+        />
+      </Row>
+
+      <div className="mt-4">
+        <div className="mb-2.5 flex items-center">
+          <div>
+            <div className="font-display text-sm font-medium text-on-surface">
+              Shell aliases
+            </div>
+            <div className="mt-1 font-body text-xs text-on-surface-muted">
+              Type the alias in any pane and Vimeflow swaps it for the full
+              agent invocation.
+            </div>
+          </div>
+
+          <span className="min-w-0 flex-1" />
+
+          <GhostButton onClick={addAlias}>
+            <Icon name="add" size={12} className="mr-1 align-middle" />
+            Add alias
+          </GhostButton>
+        </div>
+
+        <div className="grid grid-cols-[80px_120px_140px_1fr_30px] gap-2 px-3 pb-2 font-mono text-[10px] uppercase tracking-widest text-on-surface-muted">
+          <span>Alias</span>
+          <span>Agent</span>
+          <span>Model</span>
+          <span>Extra flags</span>
+          <span />
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-outline-variant/30 bg-surface-container-lowest/50">
+          {aliases.map((a, i) => (
+            <div
+              key={a.id}
+              data-testid="alias-row"
+              className={`grid grid-cols-[80px_120px_140px_1fr_30px] items-center gap-2 px-3 py-2.5 ${
+                i === aliases.length - 1
+                  ? ''
+                  : 'border-b border-outline-variant/15'
+              } ${shimOn ? '' : 'opacity-45'}`}
+            >
+              <TextInput
+                width="100%"
+                mono
+                placeholder="cc"
+                value={a.alias}
+                onChange={(v) => update(a.id, 'alias', v)}
+                aria-label={`Alias for ${a.agent}`}
+              />
+              <Select
+                width="100%"
+                value={a.agent}
+                onChange={(v) => update(a.id, 'agent', v)}
+                aria-label={`Agent for ${a.alias || 'new alias'}`}
+                options={[
+                  { id: 'claude', label: 'Claude Code' },
+                  { id: 'codex', label: 'Codex CLI' },
+                  { id: 'gemini', label: 'Gemini CLI' },
+                  { id: 'shell', label: 'Shell only' },
+                ]}
+              />
+              <Select
+                width="100%"
+                value={a.model}
+                onChange={(v) => update(a.id, 'model', v)}
+                aria-label={`Model for ${a.alias || 'new alias'}`}
+                options={[
+                  { id: 'sonnet-4', label: 'sonnet-4' },
+                  { id: 'opus-4', label: 'opus-4' },
+                  { id: 'gpt-5-codex', label: 'gpt-5-codex' },
+                  { id: 'gemini-2.5', label: 'gemini-2.5' },
+                ]}
+              />
+              <TextInput
+                width="100%"
+                mono
+                placeholder="--continue"
+                value={a.extra}
+                onChange={(v) => update(a.id, 'extra', v)}
+                aria-label={`Extra flags for ${a.agent}`}
+              />
+              <button
+                type="button"
+                title="Remove alias"
+                onClick={() => remove(a.id)}
+                className="grid h-[22px] w-[22px] place-items-center rounded border-none bg-transparent text-on-surface-muted transition-colors hover:bg-tertiary/10 hover:text-tertiary"
+                data-testid="remove-alias"
+              >
+                <Icon name="delete" size={13} />
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-2.5 font-mono text-[10.5px] text-on-surface-muted">
+          Try it: in any pane, type{' '}
+          <span className="text-primary-container">
+            cc &quot;fix the auth bug&quot;
+          </span>{' '}
+          — Vimeflow expands it to the full agent invocation before sending to
+          the PTY.
+        </div>
+      </div>
+
+      <div className="mt-6 flex items-start gap-3 rounded-lg border border-secondary/22 bg-secondary/[0.06] p-3.5">
+        <Icon name="info" size={14} className="mt-0.5 text-secondary" />
+        <div className="font-body text-[12.5px] leading-relaxed text-on-surface-variant">
+          <strong className="font-semibold text-secondary">
+            How this works.
+          </strong>{' '}
+          Aliases are scoped to Vimeflow&apos;s PTY layer. They live in{' '}
+          <code className="rounded bg-surface-container-lowest/60 px-[5px] py-px font-mono text-[11.5px] text-primary">
+            ~/.config/vimeflow/aliases.toml
+          </code>{' '}
+          and are injected into each pane&apos;s process environment via a tiny
+          shim. Your real shell rc files stay untouched, so the aliases
+          don&apos;t leak into other terminals.
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/features/settings/components/panes/AgentsPane.tsx
+++ b/src/features/settings/components/panes/AgentsPane.tsx
@@ -89,55 +89,57 @@ export const AgentsPane = (): ReactElement => {
                   : 'border-b border-outline-variant/15'
               } ${shimOn ? '' : 'opacity-45'}`}
             >
-              <TextInput
-                width="100%"
-                mono
-                placeholder="cc"
-                value={a.alias}
-                onChange={(v) => update(a.id, 'alias', v)}
-                aria-label={`Alias for ${a.agent}`}
-              />
-              <Select
-                width="100%"
-                value={a.agent}
-                onChange={(v) => update(a.id, 'agent', v)}
-                aria-label={`Agent for ${a.alias || 'new alias'}`}
-                options={[
-                  { id: 'claude', label: 'Claude Code' },
-                  { id: 'codex', label: 'Codex CLI' },
-                  { id: 'gemini', label: 'Gemini CLI' },
-                  { id: 'shell', label: 'Shell only' },
-                ]}
-              />
-              <Select
-                width="100%"
-                value={a.model}
-                onChange={(v) => update(a.id, 'model', v)}
-                aria-label={`Model for ${a.alias || 'new alias'}`}
-                options={[
-                  { id: 'sonnet-4', label: 'sonnet-4' },
-                  { id: 'opus-4', label: 'opus-4' },
-                  { id: 'gpt-5-codex', label: 'gpt-5-codex' },
-                  { id: 'gemini-2.5', label: 'gemini-2.5' },
-                ]}
-              />
-              <TextInput
-                width="100%"
-                mono
-                placeholder="--continue"
-                value={a.extra}
-                onChange={(v) => update(a.id, 'extra', v)}
-                aria-label={`Extra flags for ${a.agent}`}
-              />
-              <button
-                type="button"
-                title="Remove alias"
-                onClick={() => remove(a.id)}
-                className="grid h-[22px] w-[22px] place-items-center rounded border-none bg-transparent text-on-surface-muted transition-colors hover:bg-tertiary/10 hover:text-tertiary"
-                data-testid="remove-alias"
-              >
-                <Icon name="delete" size={13} />
-              </button>
+              <fieldset disabled={!shimOn} className="contents">
+                <TextInput
+                  width="100%"
+                  mono
+                  placeholder="cc"
+                  value={a.alias}
+                  onChange={(v) => update(a.id, 'alias', v)}
+                  aria-label={`Alias for ${a.agent}`}
+                />
+                <Select
+                  width="100%"
+                  value={a.agent}
+                  onChange={(v) => update(a.id, 'agent', v)}
+                  aria-label={`Agent for ${a.alias || 'new alias'}`}
+                  options={[
+                    { id: 'claude', label: 'Claude Code' },
+                    { id: 'codex', label: 'Codex CLI' },
+                    { id: 'gemini', label: 'Gemini CLI' },
+                    { id: 'shell', label: 'Shell only' },
+                  ]}
+                />
+                <Select
+                  width="100%"
+                  value={a.model}
+                  onChange={(v) => update(a.id, 'model', v)}
+                  aria-label={`Model for ${a.alias || 'new alias'}`}
+                  options={[
+                    { id: 'sonnet-4', label: 'sonnet-4' },
+                    { id: 'opus-4', label: 'opus-4' },
+                    { id: 'gpt-5-codex', label: 'gpt-5-codex' },
+                    { id: 'gemini-2.5', label: 'gemini-2.5' },
+                  ]}
+                />
+                <TextInput
+                  width="100%"
+                  mono
+                  placeholder="--continue"
+                  value={a.extra}
+                  onChange={(v) => update(a.id, 'extra', v)}
+                  aria-label={`Extra flags for ${a.agent}`}
+                />
+                <button
+                  type="button"
+                  title="Remove alias"
+                  onClick={() => remove(a.id)}
+                  className="grid h-[22px] w-[22px] place-items-center rounded border-none bg-transparent text-on-surface-muted transition-colors hover:bg-tertiary/10 hover:text-tertiary"
+                  data-testid="remove-alias"
+                >
+                  <Icon name="delete" size={13} />
+                </button>
+              </fieldset>
             </div>
           ))}
         </div>

--- a/src/features/settings/components/panes/AgentsPane.tsx
+++ b/src/features/settings/components/panes/AgentsPane.tsx
@@ -19,7 +19,7 @@ export const AgentsPane = (): ReactElement => {
     setAliases((prev) => [
       ...prev,
       {
-        id: `a${Date.now()}`,
+        id: `a${crypto.randomUUID()}`,
         alias: '',
         agent: 'claude',
         model: 'sonnet-4',

--- a/src/features/settings/components/panes/AppearancePane.test.tsx
+++ b/src/features/settings/components/panes/AppearancePane.test.tsx
@@ -34,6 +34,18 @@ describe('AppearancePane', () => {
     )
   })
 
+  test('marks the default active scheme with aria-pressed', () => {
+    render(<AppearancePane />)
+
+    expect(
+      screen.getByRole('button', { name: /Obsidian/i, pressed: true })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: /Dense/i, pressed: false })
+    ).toBeInTheDocument()
+  })
+
   test('renders the accent hue slider', () => {
     render(<AppearancePane />)
 

--- a/src/features/settings/components/panes/AppearancePane.test.tsx
+++ b/src/features/settings/components/panes/AppearancePane.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BUILTIN_SCHEMES } from '../../sections'
+import { AppearancePane } from './AppearancePane'
+
+describe('AppearancePane', () => {
+  test('renders the pane title', () => {
+    render(<AppearancePane />)
+
+    expect(screen.getByText('Appearance')).toBeInTheDocument()
+    expect(
+      screen.getByText('Theme · Color Scheme · Typography')
+    ).toBeInTheDocument()
+  })
+
+  test('renders all builtin scheme cards', () => {
+    render(<AppearancePane />)
+
+    BUILTIN_SCHEMES.forEach((s) => {
+      expect(screen.getByText(s.label)).toBeInTheDocument()
+    })
+  })
+
+  test('selects a scheme card on click', async () => {
+    const user = userEvent.setup()
+    render(<AppearancePane />)
+
+    const dense = screen.getByText('Dense')
+    await user.click(dense)
+
+    expect(screen.getByRole('button', { name: /Dense/i })).toHaveClass(
+      'bg-primary-container/[0.08]'
+    )
+  })
+
+  test('renders the accent hue slider', () => {
+    render(<AppearancePane />)
+
+    expect(screen.getByLabelText('Accent hue')).toBeInTheDocument()
+  })
+
+  test('changes density via the select', async () => {
+    const user = userEvent.setup()
+    render(<AppearancePane />)
+
+    const density = screen.getByLabelText('Density')
+    await user.selectOptions(density, 'compact')
+
+    expect(density).toHaveValue('compact')
+  })
+})

--- a/src/features/settings/components/panes/AppearancePane.tsx
+++ b/src/features/settings/components/panes/AppearancePane.tsx
@@ -1,0 +1,166 @@
+import { useState, type ReactElement } from 'react'
+import { BUILTIN_SCHEMES } from '../../sections'
+import { Icon } from '../Icon'
+import { GhostButton, PaneTitle, Row, Select } from '../controls'
+
+export const AppearancePane = (): ReactElement => {
+  const [activeScheme, setActiveScheme] = useState('obsidian')
+  const [accentHue, setAccentHue] = useState(285)
+  const [density, setDensity] = useState('comfortable')
+  const [uiFont, setUiFont] = useState('instrument')
+  const [monoFont, setMonoFont] = useState('jetbrains')
+
+  return (
+    <>
+      <PaneTitle title="Appearance" sub="Theme · Color Scheme · Typography" />
+
+      <div className="mb-4">
+        <div className="mb-1 font-display text-sm font-medium text-on-surface">
+          Color Scheme
+        </div>
+        <div className="mb-3 font-body text-xs text-on-surface-muted">
+          The base palette for all surfaces, text, and accents. Affects every
+          panel including this dialog.
+        </div>
+
+        <div className="grid grid-cols-2 gap-2.5">
+          {BUILTIN_SCHEMES.map((s) => {
+            const isActive = activeScheme === s.id
+
+            return (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => setActiveScheme(s.id)}
+                className={`flex items-center gap-3 rounded-lg border p-2.5 text-left transition-colors ${
+                  isActive
+                    ? 'border-primary-container/45 bg-primary-container/[0.08]'
+                    : 'border-outline-variant/35 bg-surface-container/60'
+                }`}
+              >
+                <div
+                  className="relative h-7 w-9 shrink-0 overflow-hidden rounded border border-outline-variant/40"
+                  style={{ background: s.surface }}
+                >
+                  <span
+                    className="absolute left-1 top-1 h-1 w-3 rounded-sm"
+                    style={{ background: s.accent }}
+                  />
+                  <span
+                    className="absolute left-1 top-3 h-0.5 w-4.5 rounded-sm opacity-70"
+                    style={{ background: s.text }}
+                  />
+                  <span
+                    className="absolute left-1 top-[18px] h-0.5 w-5.5 rounded-sm opacity-40"
+                    style={{ background: s.text }}
+                  />
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  <div
+                    className={`font-display text-[13px] font-medium ${
+                      isActive ? 'text-primary' : 'text-on-surface'
+                    }`}
+                  >
+                    {s.label}
+                  </div>
+                  <div className="mt-0.5 font-mono text-[10px] tracking-wide text-on-surface-muted">
+                    {s.id}
+                  </div>
+                </div>
+
+                {isActive && (
+                  <Icon
+                    name="check"
+                    size={14}
+                    className="text-primary-container"
+                  />
+                )}
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="mt-3.5 flex gap-2">
+          <GhostButton>
+            <Icon
+              name="file_upload"
+              size={12}
+              className="mr-1.5 align-middle"
+            />
+            Import scheme...
+          </GhostButton>
+          <GhostButton>
+            <Icon name="download" size={12} className="mr-1.5 align-middle" />
+            Export current
+          </GhostButton>
+          <GhostButton>Browse community</GhostButton>
+        </div>
+      </div>
+
+      <Row
+        label="Accent Hue"
+        hint={`Shift the primary accent around the wheel. Current: ${accentHue}°`}
+      >
+        <input
+          type="range"
+          min={240}
+          max={360}
+          step={2}
+          value={accentHue}
+          onChange={(e) => setAccentHue(Number(e.target.value))}
+          className="w-[180px]"
+          aria-label="Accent hue"
+        />
+      </Row>
+
+      <Row
+        label="Density"
+        hint="Compact for power users; comfortable for readability."
+      >
+        <Select
+          value={density}
+          onChange={setDensity}
+          aria-label="Density"
+          options={[
+            { id: 'comfortable', label: 'Comfortable' },
+            { id: 'compact', label: 'Compact' },
+          ]}
+        />
+      </Row>
+
+      <Row
+        label="UI Font"
+        hint="Sans-serif used for labels, sidebars, headings."
+      >
+        <Select
+          value={uiFont}
+          onChange={setUiFont}
+          aria-label="UI font"
+          options={[
+            { id: 'instrument', label: 'Instrument Sans' },
+            { id: 'inter', label: 'Inter' },
+            { id: 'fraunces', label: 'Fraunces (display)' },
+          ]}
+        />
+      </Row>
+
+      <Row
+        label="Mono Font"
+        hint="Used in the terminal, editor, and all code blocks."
+        last
+      >
+        <Select
+          value={monoFont}
+          onChange={setMonoFont}
+          aria-label="Mono font"
+          options={[
+            { id: 'jetbrains', label: 'JetBrains Mono' },
+            { id: 'iosevka', label: 'Iosevka' },
+            { id: 'fira', label: 'Fira Code' },
+          ]}
+        />
+      </Row>
+    </>
+  )
+}

--- a/src/features/settings/components/panes/AppearancePane.tsx
+++ b/src/features/settings/components/panes/AppearancePane.tsx
@@ -31,6 +31,7 @@ export const AppearancePane = (): ReactElement => {
               <button
                 key={s.id}
                 type="button"
+                aria-pressed={isActive}
                 onClick={() => setActiveScheme(s.id)}
                 className={`flex items-center gap-3 rounded-lg border p-2.5 text-left transition-colors ${
                   isActive

--- a/src/features/settings/components/panes/GeneralPane.test.tsx
+++ b/src/features/settings/components/panes/GeneralPane.test.tsx
@@ -26,7 +26,7 @@ describe('GeneralPane', () => {
     const user = userEvent.setup()
     render(<GeneralPane />)
 
-    const toggle = screen.getByRole('button', {
+    const toggle = screen.getByRole('switch', {
       name: 'Redact Private Values',
     })
     expect(toggle).toHaveClass('bg-outline-variant/50')

--- a/src/features/settings/components/panes/GeneralPane.test.tsx
+++ b/src/features/settings/components/panes/GeneralPane.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { GeneralPane } from './GeneralPane'
+
+describe('GeneralPane', () => {
+  test('renders the pane title', () => {
+    render(<GeneralPane />)
+
+    expect(screen.getByText('General')).toBeInTheDocument()
+    expect(screen.getByText('General Settings')).toBeInTheDocument()
+  })
+
+  test('renders all setting rows', () => {
+    render(<GeneralPane />)
+
+    expect(screen.getByText('When Closing With No Tabs')).toBeInTheDocument()
+    expect(screen.getByText('On Last Window Closed')).toBeInTheDocument()
+    expect(screen.getByText('Use System Path Prompts')).toBeInTheDocument()
+    expect(screen.getByText('Use System Prompts')).toBeInTheDocument()
+    expect(screen.getByText('Redact Private Values')).toBeInTheDocument()
+    expect(screen.getByText('CLI Default Open Behavior')).toBeInTheDocument()
+  })
+
+  test('toggles Redact Private Values when its toggle is clicked', async () => {
+    const user = userEvent.setup()
+    render(<GeneralPane />)
+
+    const toggle = screen.getByRole('button', {
+      name: 'Redact Private Values',
+    })
+    expect(toggle).toHaveClass('bg-outline-variant/50')
+
+    await user.click(toggle)
+
+    expect(toggle).toHaveClass('bg-primary-container')
+  })
+
+  test('changes the close-no-tabs select value', async () => {
+    const user = userEvent.setup()
+    render(<GeneralPane />)
+
+    const select = screen.getByLabelText('When closing with no tabs')
+    await user.selectOptions(select, 'nothing')
+
+    expect(select).toHaveValue('nothing')
+  })
+})

--- a/src/features/settings/components/panes/GeneralPane.tsx
+++ b/src/features/settings/components/panes/GeneralPane.tsx
@@ -1,0 +1,97 @@
+import { useState, type ReactElement } from 'react'
+import { PaneTitle, Row, Select, Toggle } from '../controls'
+
+export const GeneralPane = (): ReactElement => {
+  const [closeNoTabs, setCloseNoTabs] = useState('platform')
+  const [lastWindow, setLastWindow] = useState('platform')
+  const [systemPathPrompts, setSystemPathPrompts] = useState(true)
+  const [systemPrompts, setSystemPrompts] = useState(true)
+  const [redactPrivate, setRedactPrivate] = useState(false)
+  const [cliOpenBehavior, setCliOpenBehavior] = useState('existing')
+
+  return (
+    <>
+      <PaneTitle title="General" sub="General Settings" />
+
+      <Row
+        label="When Closing With No Tabs"
+        hint="What to do when using the 'close active item' action with no tabs."
+      >
+        <Select
+          value={closeNoTabs}
+          onChange={setCloseNoTabs}
+          aria-label="When closing with no tabs"
+          options={[
+            { id: 'platform', label: 'Platform Default' },
+            { id: 'close', label: 'Close Window' },
+            { id: 'nothing', label: 'Do Nothing' },
+          ]}
+        />
+      </Row>
+
+      <Row
+        label="On Last Window Closed"
+        hint="What to do when the last window is closed."
+      >
+        <Select
+          value={lastWindow}
+          onChange={setLastWindow}
+          aria-label="On last window closed"
+          options={[
+            { id: 'platform', label: 'Platform Default' },
+            { id: 'quit', label: 'Quit Application' },
+          ]}
+        />
+      </Row>
+
+      <Row
+        label="Use System Path Prompts"
+        hint="Use native OS dialogs for 'Open' and 'Save As'."
+      >
+        <Toggle
+          on={systemPathPrompts}
+          onChange={setSystemPathPrompts}
+          aria-label="Use System Path Prompts"
+        />
+      </Row>
+
+      <Row
+        label="Use System Prompts"
+        hint="Use native OS dialogs for confirmations."
+      >
+        <Toggle
+          on={systemPrompts}
+          onChange={setSystemPrompts}
+          aria-label="Use System Prompts"
+        />
+      </Row>
+
+      <Row
+        label="Redact Private Values"
+        hint="Hide the values of variables in private files."
+      >
+        <Toggle
+          on={redactPrivate}
+          onChange={setRedactPrivate}
+          aria-label="Redact Private Values"
+        />
+      </Row>
+
+      <Row
+        label="CLI Default Open Behavior"
+        hint="How `vf <path>` opens directories when no flag is specified."
+        last
+      >
+        <Select
+          value={cliOpenBehavior}
+          onChange={setCliOpenBehavior}
+          aria-label="CLI default open behavior"
+          options={[
+            { id: 'existing', label: 'Add to Existing Window' },
+            { id: 'new', label: 'Open in New Window' },
+          ]}
+        />
+      </Row>
+    </>
+  )
+}

--- a/src/features/settings/components/panes/KeymapPane.test.tsx
+++ b/src/features/settings/components/panes/KeymapPane.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { KEYMAPS } from '../../sections'
+import { KeymapPane } from './KeymapPane'
+
+describe('KeymapPane', () => {
+  test('renders the pane title', () => {
+    render(<KeymapPane />)
+
+    expect(screen.getByText('Keymap')).toBeInTheDocument()
+    expect(screen.getByText('Keyboard shortcuts')).toBeInTheDocument()
+  })
+
+  test('renders the preset select', () => {
+    render(<KeymapPane />)
+
+    expect(screen.getByLabelText('Keymap preset')).toHaveValue('vimeflow')
+  })
+
+  test('renders every keymap binding', () => {
+    render(<KeymapPane />)
+
+    KEYMAPS.forEach((b) => {
+      expect(screen.getByText(b.label)).toBeInTheDocument()
+    })
+  })
+
+  test('switches preset via the select', async () => {
+    const user = userEvent.setup()
+    render(<KeymapPane />)
+
+    const select = screen.getByLabelText('Keymap preset')
+    await user.selectOptions(select, 'vim')
+
+    expect(select).toHaveValue('vim')
+  })
+
+  test('renders the reset/import/export ghost buttons', () => {
+    render(<KeymapPane />)
+
+    expect(
+      screen.getByRole('button', { name: 'Reset to preset' })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: 'Import bindings...' })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: 'Export bindings' })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/settings/components/panes/KeymapPane.tsx
+++ b/src/features/settings/components/panes/KeymapPane.tsx
@@ -48,8 +48,8 @@ export const KeymapPane = (): ReactElement => {
                 {b.label}
               </span>
               <span className="flex gap-1">
-                {b.keys.map((k, j) => (
-                  <Kbd key={j}>{k}</Kbd>
+                {b.keys.map((k) => (
+                  <Kbd key={`${b.id}-${k}`}>{k}</Kbd>
                 ))}
               </span>
               <button

--- a/src/features/settings/components/panes/KeymapPane.tsx
+++ b/src/features/settings/components/panes/KeymapPane.tsx
@@ -1,0 +1,75 @@
+import { useState, type ReactElement } from 'react'
+import { KEYMAPS } from '../../sections'
+import { Icon } from '../Icon'
+import { Kbd } from '../Kbd'
+import { GhostButton, PaneTitle, Row, Select } from '../controls'
+
+export const KeymapPane = (): ReactElement => {
+  const [preset, setPreset] = useState('vimeflow')
+
+  return (
+    <>
+      <PaneTitle title="Keymap" sub="Keyboard shortcuts" />
+
+      <Row
+        label="Preset"
+        hint="Switch between vim-style, default, or a custom binding set."
+      >
+        <Select
+          value={preset}
+          onChange={setPreset}
+          aria-label="Keymap preset"
+          options={[
+            { id: 'vimeflow', label: 'Vimeflow (default)' },
+            { id: 'vim', label: 'Vim' },
+            { id: 'vscode', label: 'VS Code' },
+            { id: 'jetbrains', label: 'JetBrains' },
+            { id: 'custom', label: 'Custom' },
+          ]}
+        />
+      </Row>
+
+      <div className="mb-2 mt-4">
+        <div className="mb-2.5 font-mono text-[10px] uppercase tracking-widest text-on-surface-muted">
+          Bindings
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-outline-variant/30 bg-surface-container-lowest/50">
+          {KEYMAPS.map((b, i) => (
+            <div
+              key={b.id}
+              className={`flex items-center gap-3.5 px-3.5 py-2.5 ${
+                i === KEYMAPS.length - 1
+                  ? ''
+                  : 'border-b border-outline-variant/15'
+              }`}
+            >
+              <span className="min-w-0 flex-1 font-body text-[13px] text-on-surface-variant">
+                {b.label}
+              </span>
+              <span className="flex gap-1">
+                {b.keys.map((k, j) => (
+                  <Kbd key={j}>{k}</Kbd>
+                ))}
+              </span>
+              <button
+                type="button"
+                title="Edit binding"
+                onClick={() => undefined}
+                className="grid h-[22px] w-[22px] place-items-center rounded border-none bg-transparent text-on-surface-muted transition-colors hover:bg-white/[0.04] hover:text-primary"
+              >
+                <Icon name="edit" size={12} />
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-3.5 flex gap-2">
+        <GhostButton>Reset to preset</GhostButton>
+        <GhostButton>Import bindings...</GhostButton>
+        <GhostButton>Export bindings</GhostButton>
+      </div>
+    </>
+  )
+}

--- a/src/features/settings/components/panes/PlaceholderPane.test.tsx
+++ b/src/features/settings/components/panes/PlaceholderPane.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SETTINGS_SECTIONS } from '../../sections'
+import { PlaceholderPane } from './PlaceholderPane'
+
+describe('PlaceholderPane', () => {
+  test('renders the section label as title and coming soon eyebrow', () => {
+    const section = SETTINGS_SECTIONS.find((s) => s.id === 'terminal')!
+    render(<PlaceholderPane section={section} />)
+
+    expect(screen.getByText('Terminal')).toBeInTheDocument()
+    expect(screen.getByText('Coming soon')).toBeInTheDocument()
+  })
+
+  test('renders the placeholder message', () => {
+    const section = SETTINGS_SECTIONS.find((s) => s.id === 'editor')!
+    render(<PlaceholderPane section={section} />)
+
+    expect(
+      screen.getByText("Editor settings haven't been wired yet.")
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByText(
+        'This pane will host the editor configuration in a future build.'
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/settings/components/panes/PlaceholderPane.tsx
+++ b/src/features/settings/components/panes/PlaceholderPane.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from 'react'
+import type { PlaceholderPaneProps } from '../../types'
+import { Icon } from '../Icon'
+import { PaneTitle } from '../controls'
+
+export const PlaceholderPane = ({
+  section,
+}: PlaceholderPaneProps): ReactElement => (
+  <>
+    <PaneTitle title={section.label} sub="Coming soon" />
+    <div className="mt-3 rounded-[10px] border border-dashed border-outline-variant/40 p-10 text-center">
+      <Icon
+        name={section.icon}
+        size={32}
+        className="mx-auto mb-3 text-primary-container/40"
+      />
+      <div className="mb-1.5 font-display text-sm text-on-surface">
+        {section.label} settings haven&apos;t been wired yet.
+      </div>
+      <div className="font-body text-xs text-on-surface-muted">
+        This pane will host the {section.label.toLowerCase()} configuration in a
+        future build.
+      </div>
+    </div>
+  </>
+)

--- a/src/features/settings/hooks/useSettingsDialog.test.ts
+++ b/src/features/settings/hooks/useSettingsDialog.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useSettingsDialog } from './useSettingsDialog'
+
+describe('useSettingsDialog', () => {
+  test('initial state is closed', () => {
+    const { result } = renderHook(() => useSettingsDialog())
+
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  test('open sets isOpen to true', () => {
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => result.current.open())
+
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  test('close sets isOpen to false', () => {
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => result.current.open())
+    act(() => result.current.close())
+
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  test('toggle flips isOpen', () => {
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => result.current.toggle())
+    expect(result.current.isOpen).toBe(true)
+
+    act(() => result.current.toggle())
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  test('Meta+, toggles the dialog open', () => {
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', {
+        metaKey: true,
+        key: ',',
+        bubbles: true,
+      })
+      document.dispatchEvent(event)
+    })
+
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  test('Ctrl+, toggles the dialog open', () => {
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', {
+        ctrlKey: true,
+        key: ',',
+        bubbles: true,
+      })
+      document.dispatchEvent(event)
+    })
+
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  test('Escape closes the dialog when open', () => {
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => result.current.open())
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+      })
+      document.dispatchEvent(event)
+    })
+
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  test('Escape does nothing when dialog is closed', () => {
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+      })
+      document.dispatchEvent(event)
+    })
+
+    expect(result.current.isOpen).toBe(false)
+  })
+})

--- a/src/features/settings/hooks/useSettingsDialog.ts
+++ b/src/features/settings/hooks/useSettingsDialog.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { UseSettingsDialogReturn } from '../types'
+
+export const useSettingsDialog = (): UseSettingsDialogReturn => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), [])
+
+  const isOpenRef = useRef(isOpen)
+  const handlersRef = useRef({ close, toggle })
+
+  isOpenRef.current = isOpen
+  handlersRef.current = { close, toggle }
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if ((event.metaKey || event.ctrlKey) && event.key === ',') {
+        event.preventDefault()
+        handlersRef.current.toggle()
+
+        return
+      }
+
+      if (event.key === 'Escape' && isOpenRef.current) {
+        event.preventDefault()
+        handlersRef.current.close()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, { capture: true })
+
+    return (): void => {
+      document.removeEventListener('keydown', handleKeyDown, { capture: true })
+    }
+  }, [])
+
+  return { isOpen, open, close, toggle }
+}

--- a/src/features/settings/index.test.ts
+++ b/src/features/settings/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest'
+import {
+  BUILTIN_SCHEMES,
+  DEFAULT_ALIASES,
+  KEYMAPS,
+  SETTINGS_SECTIONS,
+  SettingsDialog,
+  useSettingsDialog,
+} from './index'
+
+describe('settings feature barrel', () => {
+  test('exports the SettingsDialog component', () => {
+    expect(SettingsDialog).toBeInstanceOf(Function)
+  })
+
+  test('exports the useSettingsDialog hook', () => {
+    expect(useSettingsDialog).toBeInstanceOf(Function)
+  })
+
+  test('exports section and scheme constants', () => {
+    expect(SETTINGS_SECTIONS.length).toBeGreaterThan(0)
+    expect(BUILTIN_SCHEMES.length).toBeGreaterThan(0)
+    expect(KEYMAPS.length).toBeGreaterThan(0)
+    expect(DEFAULT_ALIASES.length).toBeGreaterThan(0)
+  })
+})

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,0 +1,24 @@
+export { SettingsDialog } from './SettingsDialog'
+
+export { useSettingsDialog } from './hooks/useSettingsDialog'
+
+export {
+  BUILTIN_SCHEMES,
+  DEFAULT_ALIASES,
+  KEYMAPS,
+  SETTINGS_SECTIONS,
+} from './sections'
+
+export type {
+  AgentAlias,
+  AppearanceScheme,
+  IconProps,
+  KbdProps,
+  KeymapBinding,
+  SettingsDialogProps,
+  SettingsHeaderProps,
+  SettingsScope,
+  SettingsSection,
+  SettingsSectionId,
+  SettingsSidebarProps,
+} from './types'

--- a/src/features/settings/sections.test.ts
+++ b/src/features/settings/sections.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'vitest'
+import {
+  BUILTIN_SCHEMES,
+  DEFAULT_ALIASES,
+  KEYMAPS,
+  SETTINGS_SECTIONS,
+} from './sections'
+
+describe('SETTINGS_SECTIONS', () => {
+  test('contains the fourteen expected categories', () => {
+    expect(SETTINGS_SECTIONS).toHaveLength(14)
+    expect(SETTINGS_SECTIONS.map((s) => s.id)).toEqual([
+      'general',
+      'appearance',
+      'keymap',
+      'agents',
+      'editor',
+      'terminal',
+      'languages',
+      'search',
+      'window',
+      'panels',
+      'version',
+      'collab',
+      'ai',
+      'network',
+    ])
+  })
+
+  test('each section has id, label, and icon', () => {
+    SETTINGS_SECTIONS.forEach((s) => {
+      expect(s.id).toBeDefined()
+      expect(s.label).toBeDefined()
+      expect(s.icon).toBeDefined()
+    })
+  })
+})
+
+describe('BUILTIN_SCHEMES', () => {
+  test('contains the five expected schemes with literal hex', () => {
+    expect(BUILTIN_SCHEMES).toHaveLength(5)
+    expect(BUILTIN_SCHEMES.map((s) => s.id)).toEqual([
+      'obsidian',
+      'editorial',
+      'dense',
+      'navigator',
+      'flexoki',
+    ])
+  })
+
+  test('each scheme defines literal accent, surface, and text colors', () => {
+    BUILTIN_SCHEMES.forEach((s) => {
+      expect(s.accent).toMatch(/^#/)
+      expect(s.surface).toMatch(/^#/)
+      expect(s.text).toMatch(/^#/)
+    })
+  })
+})
+
+describe('KEYMAPS', () => {
+  test('contains the expected bindings', () => {
+    expect(KEYMAPS.some((b) => b.id === 'open_settings')).toBe(true)
+    expect(KEYMAPS.some((b) => b.id === 'open_palette')).toBe(true)
+  })
+
+  test('each binding has id, label, and keys', () => {
+    KEYMAPS.forEach((b) => {
+      expect(b.id).toBeDefined()
+      expect(b.label).toBeDefined()
+      expect(b.keys.length).toBeGreaterThan(0)
+    })
+  })
+})
+
+describe('DEFAULT_ALIASES', () => {
+  test('contains three default aliases', () => {
+    expect(DEFAULT_ALIASES).toHaveLength(3)
+  })
+
+  test('each alias has the required fields', () => {
+    DEFAULT_ALIASES.forEach((a) => {
+      expect(a.id).toBeDefined()
+      expect(a.alias).toBeDefined()
+      expect(a.agent).toBeDefined()
+      expect(a.model).toBeDefined()
+      expect(a.extra).toBeDefined()
+    })
+  })
+})

--- a/src/features/settings/sections.ts
+++ b/src/features/settings/sections.ts
@@ -1,0 +1,100 @@
+import type {
+  AgentAlias,
+  AppearanceScheme,
+  KeymapBinding,
+  SettingsSection,
+} from './types'
+
+export const SETTINGS_SECTIONS: SettingsSection[] = [
+  { id: 'general', label: 'General', icon: 'settings' },
+  { id: 'appearance', label: 'Appearance', icon: 'palette' },
+  { id: 'keymap', label: 'Keymap', icon: 'keyboard' },
+  { id: 'agents', label: 'Coding Agents', icon: 'bolt' },
+  { id: 'editor', label: 'Editor', icon: 'code' },
+  { id: 'terminal', label: 'Terminal', icon: 'terminal' },
+  { id: 'languages', label: 'Languages & Tools', icon: 'data_object' },
+  { id: 'search', label: 'Search & Files', icon: 'search' },
+  { id: 'window', label: 'Window & Layout', icon: 'grid_view' },
+  { id: 'panels', label: 'Panels', icon: 'dock_to_bottom' },
+  { id: 'version', label: 'Version Control', icon: 'difference' },
+  { id: 'collab', label: 'Collaboration', icon: 'group' },
+  { id: 'ai', label: 'AI', icon: 'psychology' },
+  { id: 'network', label: 'Network', icon: 'lan' },
+]
+
+export const BUILTIN_SCHEMES: AppearanceScheme[] = [
+  {
+    id: 'obsidian',
+    label: 'Obsidian Lens',
+    accent: '#cba6f7',
+    surface: '#121221',
+    text: '#cdc3d1',
+  },
+  {
+    id: 'editorial',
+    label: 'Editorial',
+    accent: '#a8c8ff',
+    surface: '#141424',
+    text: '#cdc3d1',
+  },
+  {
+    id: 'dense',
+    label: 'Dense',
+    accent: '#7defa1',
+    surface: '#0d0d1c',
+    text: '#cdc3d1',
+  },
+  {
+    id: 'navigator',
+    label: 'W.W. Navigator',
+    accent: '#c9a55a',
+    surface: '#1a1408',
+    text: '#d8cbb0',
+  },
+  {
+    id: 'flexoki',
+    label: 'Flexoki',
+    accent: '#6e4caa',
+    surface: '#fffcf0',
+    text: '#343331',
+  },
+]
+
+export const KEYMAPS: KeymapBinding[] = [
+  { id: 'open_palette', label: 'Open command palette', keys: ['⌘', 'K'] },
+  { id: 'focus_pane_1', label: 'Focus pane 1', keys: ['⌘', '1'] },
+  { id: 'focus_pane_2', label: 'Focus pane 2', keys: ['⌘', '2'] },
+  { id: 'focus_pane_3', label: 'Focus pane 3', keys: ['⌘', '3'] },
+  { id: 'focus_pane_4', label: 'Focus pane 4', keys: ['⌘', '4'] },
+  { id: 'toggle_split', label: 'Toggle split layout', keys: ['⌘', '\\'] },
+  { id: 'new_session', label: 'New agent session', keys: ['⌘', 'T'] },
+  { id: 'close_pane', label: 'Close focused pane', keys: ['⌘', 'W'] },
+  { id: 'open_settings', label: 'Open settings', keys: ['⌘', ','] },
+  { id: 'toggle_dock', label: 'Show/hide editor & diff', keys: ['⌘', 'J'] },
+  { id: 'next_pane', label: 'Next pane', keys: ['⌘', '⇥'] },
+  { id: 'pause_agent', label: 'Pause focused agent', keys: ['⌃', 'C'] },
+]
+
+export const DEFAULT_ALIASES: AgentAlias[] = [
+  {
+    id: 'a1',
+    alias: 'cc',
+    agent: 'claude',
+    model: 'sonnet-4',
+    extra: '--continue',
+  },
+  {
+    id: 'a2',
+    alias: 'cdx',
+    agent: 'codex',
+    model: 'gpt-5-codex',
+    extra: '',
+  },
+  {
+    id: 'a3',
+    alias: 'gem',
+    agent: 'gemini',
+    model: 'gemini-2.5',
+    extra: '--chat',
+  },
+]

--- a/src/features/settings/types.test.ts
+++ b/src/features/settings/types.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi } from 'vitest'
+import type {
+  AgentAlias,
+  AppearanceScheme,
+  KeymapBinding,
+  SettingsDialogProps,
+  SettingsSection,
+} from './types'
+import { BUILTIN_SCHEMES } from './sections'
+
+describe('settings types compile and shape contracts', () => {
+  test('SettingsDialogProps shape', () => {
+    const props: SettingsDialogProps = {
+      open: true,
+      onClose: vi.fn(),
+    }
+
+    expect(props.open).toBe(true)
+    expect(typeof props.onClose).toBe('function')
+  })
+
+  test('SettingsSection shape', () => {
+    const section: SettingsSection = {
+      id: 'appearance',
+      label: 'Appearance',
+      icon: 'palette',
+    }
+
+    expect(section.id).toBe('appearance')
+  })
+
+  test('AppearanceScheme shape', () => {
+    const scheme: AppearanceScheme | undefined = BUILTIN_SCHEMES[0]
+
+    expect(scheme?.accent).toMatch(/^#/)
+    expect(scheme?.surface).toMatch(/^#/)
+  })
+
+  test('KeymapBinding shape', () => {
+    const binding: KeymapBinding = {
+      id: 'open_settings',
+      label: 'Open settings',
+      keys: ['⌘', ','],
+    }
+
+    expect(binding.keys).toContain(',')
+  })
+
+  test('AgentAlias shape', () => {
+    const alias: AgentAlias = {
+      id: 'a1',
+      alias: 'cc',
+      agent: 'claude',
+      model: 'sonnet-4',
+      extra: '',
+    }
+
+    expect(alias.agent).toBe('claude')
+  })
+})

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -1,0 +1,133 @@
+import type { ReactNode } from 'react'
+
+export type SettingsSectionId =
+  | 'general'
+  | 'appearance'
+  | 'keymap'
+  | 'agents'
+  | 'editor'
+  | 'terminal'
+  | 'languages'
+  | 'search'
+  | 'window'
+  | 'panels'
+  | 'version'
+  | 'collab'
+  | 'ai'
+  | 'network'
+
+export interface SettingsSection {
+  id: SettingsSectionId
+  label: string
+  icon: string
+}
+
+export interface SettingsDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+export interface SettingsSidebarProps {
+  sections: SettingsSection[]
+  active: SettingsSectionId
+  onPick: (id: SettingsSectionId) => void
+  query: string
+  onQuery: (query: string) => void
+}
+
+export type SettingsScope = 'User' | 'vimeflow'
+
+export interface SettingsHeaderProps {
+  scope: SettingsScope
+  onScope: (scope: SettingsScope) => void
+  section: SettingsSection | undefined
+}
+
+export interface IconProps {
+  name: string
+  size?: number
+  fill?: boolean
+  className?: string
+}
+
+export interface KbdProps {
+  children: ReactNode
+}
+
+export interface RowProps {
+  label: string
+  hint?: string
+  children?: ReactNode
+  last?: boolean
+}
+
+export interface PaneTitleProps {
+  title: string
+  sub?: string
+}
+
+export interface ToggleProps {
+  on?: boolean
+  onChange: (value: boolean) => void
+  'aria-label'?: string
+}
+
+export interface SelectOption {
+  id: string
+  label: string
+}
+
+export interface SelectProps {
+  value: string
+  options: SelectOption[] | string[]
+  onChange: (value: string) => void
+  width?: string | number
+  'aria-label'?: string
+}
+
+export interface GhostButtonProps {
+  children: ReactNode
+  onClick?: () => void
+}
+
+export interface TextInputProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  width?: string | number
+  mono?: boolean
+  'aria-label'?: string
+}
+
+export interface AppearanceScheme {
+  id: string
+  label: string
+  accent: string
+  surface: string
+  text: string
+}
+
+export interface KeymapBinding {
+  id: string
+  label: string
+  keys: string[]
+}
+
+export interface AgentAlias {
+  id: string
+  alias: string
+  agent: string
+  model: string
+  extra: string
+}
+
+export interface PlaceholderPaneProps {
+  section: SettingsSection
+}
+
+export interface UseSettingsDialogReturn {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+  toggle: () => void
+}

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -40,7 +40,6 @@ export type SettingsScope = 'User' | 'vimeflow'
 export interface SettingsHeaderProps {
   scope: SettingsScope
   onScope: (scope: SettingsScope) => void
-  section: SettingsSection | undefined
 }
 
 export interface IconProps {

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -1207,10 +1207,10 @@ describe('WorkspaceView', () => {
       within(topBar).queryByRole('button', { name: 'Command Palette' })
     ).not.toBeInTheDocument()
 
-    // Settings aria-label is "Settings — coming (see issue #252)".
+    // Settings button is now wired and enabled.
     expect(
       within(footer).getByRole('button', { name: /^Settings/ })
-    ).toHaveAttribute('aria-disabled', 'true')
+    ).not.toHaveAttribute('aria-disabled')
   })
 
   test('passes sessions to Sidebar', () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -47,6 +47,7 @@ import {
   COMMAND_PALETTE_SHORTCUT_KEYS,
   useCommandPalette,
 } from '../command-palette/hooks/useCommandPalette'
+import { SettingsDialog, useSettingsDialog } from '../settings'
 import {
   usePaneRenameChord,
   type FocusedPaneRef,
@@ -146,11 +147,6 @@ const formatStatusDuration = (durationMs: number): string | undefined => {
 
   return `${minutes}m`
 }
-
-// Follow-up tracked at https://github.com/winoooops/vimeflow/issues/252
-// (Settings dialog — Zed-style modal with 14 categories). Remove
-// this const and the gear's `aria-disabled` once the dialog lands.
-const SETTINGS_FOLLOWUP_ISSUE_NUMBER = 252
 
 const SIDEBAR_DEFAULT = 272
 const SIDEBAR_MIN = SIDEBAR_DEFAULT
@@ -1176,8 +1172,10 @@ export const WorkspaceView = (): ReactElement => {
     ]
   )
 
+  const settings = useSettingsDialog()
+
   const commandPalette = useCommandPalette(workspaceCommands, {
-    enabled: !showUnsavedDialog,
+    enabled: !showUnsavedDialog && !settings.isOpen,
   })
 
   usePaneShortcuts({
@@ -1613,6 +1611,7 @@ export const WorkspaceView = (): ReactElement => {
     terminalFitDeferred ||
     showUnsavedDialog ||
     commandPalette.state.isOpen ||
+    settings.isOpen ||
     paneRenameNode !== null ||
     fileError !== null ||
     infoMessage !== null
@@ -1904,9 +1903,7 @@ export const WorkspaceView = (): ReactElement => {
               }
               footer={
                 isSidebarClosed ? undefined : (
-                  <SidebarSettingsFooter
-                    settingsIssueNumber={SETTINGS_FOLLOWUP_ISSUE_NUMBER}
-                  />
+                  <SidebarSettingsFooter onSettings={settings.open} />
                 )
               }
             />
@@ -2133,6 +2130,8 @@ export const WorkspaceView = (): ReactElement => {
         setQuery={commandPalette.setQuery}
         selectIndex={commandPalette.selectIndex}
       />
+
+      <SettingsDialog open={settings.isOpen} onClose={settings.close} />
     </div>
   )
 }

--- a/src/features/workspace/WorkspaceView.verification.test.tsx
+++ b/src/features/workspace/WorkspaceView.verification.test.tsx
@@ -132,10 +132,10 @@ describe('Feature 23: Final Phase 2 Verification', () => {
         within(topBar).queryByRole('button', { name: 'Command Palette' })
       ).not.toBeInTheDocument()
 
-      // Settings aria-label is "Settings — coming (see issue #252)".
+      // Settings button is now wired and enabled.
       expect(
         within(footer).getByRole('button', { name: /^Settings/ })
-      ).toHaveAttribute('aria-disabled', 'true')
+      ).not.toHaveAttribute('aria-disabled')
     })
   })
 


### PR DESCRIPTION
## Summary

Migrates the **Settings dialog** prototype into the real app as a self-contained
`src/features/settings/` feature and wires it to the sidebar **Settings** footer
(`SidebarSettingsFooter`). Clicking the footer (or **⌘,**) opens a Zed-style glass
dialog: a search-filtered 14-category sidebar over scoped panes.

Closes **VIM-29**. This PR targets the `feat/settings` integration branch (the
settings-epic dev branch); the follow-up work is tracked in **VIM-100..VIM-108**.

## What's included
- **Feature** (`src/features/settings/`, ~30 files, presentational): dialog shell,
  sidebar, header, shared controls, four real panes (General / Appearance / Keymap /
  Coding Agents) + Placeholder, and the `useSettingsDialog` hook (⌘, toggle, Esc +
  backdrop close). Translated to the app's semantic tokens (no new colors), with a
  framer-motion entrance. 81 co-located tests.
- **Wiring** (`WorkspaceView`): `onSettings` on the sidebar footer, dialog mount,
  command-palette gating while open.
- **Browser overlap fix**: `settings.isOpen` added to `areBrowserPanesOccluded` so the
  native browser `WebContentsView` is hidden while the dialog is open (it paints above
  the DOM otherwise).

## Scope notes
**Presentational only** — every pane is local-state / no-op; nothing persists yet. Real
behavior is tracked as follow-ups in the Settings project:
- **VIM-100** settings.json persistence (foundation; blocks the panes)
- **VIM-101..104** General / Appearance / Coding Agents / Keymap → no stubs
- **VIM-105** native window · **VIM-106** expandable sidebar · **VIM-107** fuzzy search ·
  **VIM-108** shell cleanup (drop User/vimeflow scope tabs, fix the ⌘⇧E hint)

## Verification
- type-check ✅ · eslint (settings + workspace) ✅ · full vitest **3633 passed / 3 skipped / 0 failed**
- Reviewed by codex across stages (`complete: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
