### PR TITLE
Fix burner terminal tab passthrough

### DIFF
--- a/src/features/terminal/components/BurnerTerminalPopup/index.test.tsx
+++ b/src/features/terminal/components/BurnerTerminalPopup/index.test.tsx
@@ -67,6 +67,31 @@ const popup = (
   } = {}
 ): ReactElement => <BurnerTerminalPopup open={open} {...baseProps} {...extra} />
 
+const dispatchTabFrom = (
+  target: HTMLElement,
+  init: KeyboardEventInit = {}
+): {
+  terminalKeyDown: ReturnType<typeof vi.fn>
+  preventDefaultSpy: ReturnType<typeof vi.spyOn>
+  stopPropagationSpy: ReturnType<typeof vi.spyOn>
+} => {
+  const terminalKeyDown = vi.fn()
+  target.addEventListener('keydown', terminalKeyDown)
+
+  const event = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  })
+  const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+  const stopPropagationSpy = vi.spyOn(event, 'stopPropagation')
+
+  target.dispatchEvent(event)
+
+  return { terminalKeyDown, preventDefaultSpy, stopPropagationSpy }
+}
+
 beforeEach(() => {
   focusTerminal.mockClear()
   captured.onPaneReady = undefined
@@ -302,18 +327,20 @@ test('backdrop dismiss button is removed from the tab order', () => {
   ).toHaveAttribute('tabIndex', '-1')
 })
 
-test('Tab from terminal traps focus to the first button', () => {
+test('Tab from terminal passes through to xterm for shell autocomplete', () => {
   render(popup(true, { onAlignCwd: vi.fn() }))
 
   const textarea = screen.getByTestId('xterm-textarea')
   textarea.focus()
   expect(textarea).toHaveFocus()
 
-  fireEvent.keyDown(textarea, { key: 'Tab' })
+  const { terminalKeyDown, preventDefaultSpy, stopPropagationSpy } =
+    dispatchTabFrom(textarea)
 
-  expect(
-    screen.getByRole('button', { name: /align burner to pane directory/i })
-  ).toHaveFocus()
+  expect(terminalKeyDown).toHaveBeenCalledTimes(1)
+  expect(preventDefaultSpy).not.toHaveBeenCalled()
+  expect(stopPropagationSpy).not.toHaveBeenCalled()
+  expect(textarea).toHaveFocus()
 })
 
 test('Tab from last button wraps focus back to the terminal', () => {
@@ -344,37 +371,31 @@ test('Shift+Tab from first button wraps focus back to the terminal', () => {
   expect(focusTerminal).toHaveBeenCalledTimes(1)
 })
 
-test('Shift+Tab from terminal traps focus to the last button', () => {
+test('Shift+Tab from terminal passes through to xterm', () => {
   render(popup(true, { onAlignCwd: vi.fn() }))
 
   const textarea = screen.getByTestId('xterm-textarea')
   textarea.focus()
   expect(textarea).toHaveFocus()
 
-  fireEvent.keyDown(textarea, { key: 'Tab', shiftKey: true })
+  const { terminalKeyDown, preventDefaultSpy, stopPropagationSpy } =
+    dispatchTabFrom(textarea, { shiftKey: true })
 
-  expect(
-    screen.getByRole('button', { name: /hide burner terminal/i })
-  ).toHaveFocus()
+  expect(terminalKeyDown).toHaveBeenCalledTimes(1)
+  expect(preventDefaultSpy).not.toHaveBeenCalled()
+  expect(stopPropagationSpy).not.toHaveBeenCalled()
+  expect(textarea).toHaveFocus()
 })
 
-test('Tab cycles between terminal and hide button when align is absent', () => {
+test('Tab from hide button wraps focus back to the terminal when align is absent', () => {
   render(popup(true))
   focusTerminal.mockClear()
 
-  const textarea = screen.getByTestId('xterm-textarea')
-  textarea.focus()
+  const hideBtn = screen.getByRole('button', { name: /hide burner terminal/i })
+  hideBtn.focus()
+  expect(hideBtn).toHaveFocus()
 
-  fireEvent.keyDown(textarea, { key: 'Tab' })
-
-  expect(
-    screen.getByRole('button', { name: /hide burner terminal/i })
-  ).toHaveFocus()
-
-  fireEvent.keyDown(
-    screen.getByRole('button', { name: /hide burner terminal/i }),
-    { key: 'Tab' }
-  )
+  fireEvent.keyDown(hideBtn, { key: 'Tab' })
 
   expect(focusTerminal).toHaveBeenCalledTimes(1)
 })

--- a/src/features/terminal/components/BurnerTerminalPopup/index.tsx
+++ b/src/features/terminal/components/BurnerTerminalPopup/index.tsx
@@ -112,8 +112,9 @@ export const BurnerTerminalPopup = ({
   // Esc hides the popup. The burner xterm holds focus, so without a native
   // capture-phase intercept the keydown reaches the terminal and is sent to the
   // shell as ^[. Capturing on the overlay fires before xterm's textarea handler.
-  // Tab / Shift+Tab are also trapped so focus cannot escape to background
-  // workspace controls while the modal is open.
+  // Tab / Shift+Tab must pass through while the xterm body has focus so shell
+  // autocomplete and reverse-complete keep working. Toolbar focus still cycles
+  // back to the terminal when a toolbar button owns focus.
   useEffect(() => {
     const overlay = overlayRef.current
     if (!open || !overlay) {
@@ -162,14 +163,6 @@ export const BurnerTerminalPopup = ({
         bodyEl?.contains(document.activeElement) ?? false
 
       if (isFocusInTerminal) {
-        event.preventDefault()
-        event.stopPropagation()
-        if (event.shiftKey) {
-          focusableElements[focusableElements.length - 1]?.focus()
-        } else {
-          focusableElements[0]?.focus()
-        }
-
         return
       }
 


### PR DESCRIPTION
## Summary

Fixes the burner terminal popup so Tab and Shift+Tab reach the focused xterm textarea instead of being consumed by the popup focus trap.

## Root Cause

The popup's capture-phase keydown handler intercepted Tab while the burner terminal body had focus, preventing shell autocomplete from receiving the key.

## Changes

- Let Tab and Shift+Tab pass through when focus is inside the burner terminal body.
- Keep Escape capture-to-hide behavior intact.
- Keep toolbar button Tab cycling back to the terminal.
- Update popup tests to assert Tab is delivered to the terminal listener without preventDefault/stopPropagation.

## Validation

- `npm test -- --run src/features/terminal/components/BurnerTerminalPopup/index.test.tsx`
- `npm run lint -- --max-warnings=0`
- `npm run type-check`
- `git diff --check`

Closes VIM-96

Linear: https://linear.app/vimeflow/issue/VIM-96/fixterminal-disable-tab-to-switch-in-the-burner-terminal-dialog