### PR TITLE
Fix browser pane dialog occlusion

### DIFF
--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -209,6 +209,37 @@ describe('BrowserPane', () => {
     })
   })
 
+  test('marks the native browser pane invisible while occluded, then restores it', async () => {
+    const { rerender } = render(
+      <BrowserPane session={session} pane={browserPane} isActive isOccluded />
+    )
+
+    await waitFor(() => {
+      expect(bridgeMocks.createBrowserPane).toHaveBeenCalledOnce()
+    })
+    await settle()
+
+    expect(bridgeMocks.setBrowserPaneBounds).toHaveBeenLastCalledWith({
+      sessionId: 'session-1',
+      paneId: 'p1',
+      bounds: { x: 10, y: 20, width: 640, height: 360 },
+      shortcutContext: { activePaneId: 'p1', paneIds: ['p0', 'p1'] },
+      visible: false,
+    })
+
+    rerender(<BrowserPane session={session} pane={browserPane} isActive />)
+
+    await waitFor(() => {
+      expect(bridgeMocks.setBrowserPaneBounds).toHaveBeenLastCalledWith({
+        sessionId: 'session-1',
+        paneId: 'p1',
+        bounds: { x: 10, y: 20, width: 640, height: 360 },
+        shortcutContext: { activePaneId: 'p1', paneIds: ['p0', 'p1'] },
+        visible: true,
+      })
+    })
+  })
+
   test('the focus border uses the cyan WEB accent only when the pane is active', () => {
     const { rerender } = render(
       <BrowserPane session={session} pane={browserPane} isActive />

--- a/src/features/terminal/hooks/useBurnerTerminals.test.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.test.ts
@@ -183,6 +183,30 @@ test('hiding the popup does not kill the shell', async () => {
   expect(service.kill).not.toHaveBeenCalled()
 })
 
+test('hasVisibleBurner tracks only the visible popup, not hidden live shells', async () => {
+  const service = makeService()
+  const focused = makeFocusedPane()
+
+  const { result } = renderHook(() =>
+    useBurnerTerminals({ service, resolveFocusedPane: () => focused })
+  )
+
+  expect(result.current.hasVisibleBurner).toBe(false)
+
+  await act(async () => {
+    await result.current.toggle()
+  })
+
+  expect(result.current.hasVisibleBurner).toBe(true)
+
+  await act(async () => {
+    await result.current.toggle()
+  })
+
+  expect(result.current.hasVisibleBurner).toBe(false)
+  expect(result.current.renderNode).not.toBeNull()
+})
+
 test('renderNode stays non-null when hidden while a shell is alive', async () => {
   const service = makeService()
   const focused = makeFocusedPane()

--- a/src/features/terminal/hooks/useBurnerTerminals.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.ts
@@ -120,6 +120,8 @@ export interface UseBurnerTerminals {
    * distinct from `runningByPane`, which only means a shell exists.
    */
   activeByPane: ReadonlyMap<string, boolean>
+  /** True while a burner popup is visibly open over the workspace. */
+  hasVisibleBurner: boolean
 }
 
 /**
@@ -556,5 +558,11 @@ export const useBurnerTerminals = ({
         )
       : null
 
-  return { renderNode, toggle, runningByPane, activeByPane }
+  return {
+    renderNode,
+    toggle,
+    runningByPane,
+    activeByPane,
+    hasVisibleBurner: visibleKey !== null,
+  }
 }

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -51,6 +51,9 @@ vi.mock('../editor/hooks/useEditorBuffer')
 vi.mock('../files/services/fileSystemService')
 vi.mock('../terminal/services/terminalService')
 vi.mock('../terminal/hooks/usePaneShortcuts')
+vi.mock('../terminal/hooks/useBurnerTerminals', () => ({
+  useBurnerTerminals: vi.fn(),
+}))
 
 // Mock child components to keep test focused on command dispatch while still
 // rendering sidebar chrome needed by WorkspaceView.
@@ -293,6 +296,16 @@ describe('WorkspaceView - Command Palette Integration', () => {
       killEphemeralPtys: vi.fn(),
       setWorkspaceSessions: vi.fn().mockResolvedValue(undefined),
     })
+
+    const { useBurnerTerminals } =
+      await import('../terminal/hooks/useBurnerTerminals')
+    vi.mocked(useBurnerTerminals).mockReturnValue({
+      renderNode: null,
+      toggle: vi.fn().mockResolvedValue(undefined),
+      runningByPane: new Map(),
+      activeByPane: new Map(),
+      hasVisibleBurner: false,
+    })
   })
 
   const openPalette = (): void => {
@@ -304,6 +317,17 @@ describe('WorkspaceView - Command Palette Integration', () => {
       })
       document.dispatchEvent(event)
     })
+  }
+
+  const latestTerminalZoneProps = (): TerminalZoneProps => {
+    const call = terminalZonePropsSpy.mock.calls[
+      terminalZonePropsSpy.mock.calls.length - 1
+    ] as [TerminalZoneProps] | undefined
+    if (!call) {
+      throw new Error('TerminalZone was not rendered')
+    }
+
+    return call[0]
   }
 
   test(':new command creates a new session', async () => {
@@ -345,6 +369,34 @@ describe('WorkspaceView - Command Palette Integration', () => {
         removePane: mockSessionManager.removePane,
       })
     )
+  })
+
+  test('occludes browser panes while the command palette is open', async () => {
+    render(<WorkspaceView />)
+
+    expect(latestTerminalZoneProps().areBrowserPanesOccluded).toBe(false)
+
+    openPalette()
+
+    await waitFor(() => {
+      expect(latestTerminalZoneProps().areBrowserPanesOccluded).toBe(true)
+    })
+  })
+
+  test('occludes browser panes while a burner terminal popup is visible', async () => {
+    const { useBurnerTerminals } =
+      await import('../terminal/hooks/useBurnerTerminals')
+    vi.mocked(useBurnerTerminals).mockReturnValue({
+      renderNode: <div data-testid="burner-terminal-popup" />,
+      toggle: vi.fn().mockResolvedValue(undefined),
+      runningByPane: new Map(),
+      activeByPane: new Map(),
+      hasVisibleBurner: true,
+    })
+
+    render(<WorkspaceView />)
+
+    expect(latestTerminalZoneProps().areBrowserPanesOccluded).toBe(true)
   })
 
   test('records detected agent type on the active session', async () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -936,6 +936,7 @@ export const WorkspaceView = (): ReactElement => {
     toggle: toggleBurner,
     runningByPane: runningBurnerByPane,
     activeByPane: activeBurnerByPane,
+    hasVisibleBurner,
   } = useBurnerTerminals({
     service: terminalService,
     resolveFocusedPane,
@@ -1613,6 +1614,7 @@ export const WorkspaceView = (): ReactElement => {
     terminalFitDeferred ||
     showUnsavedDialog ||
     commandPalette.state.isOpen ||
+    hasVisibleBurner ||
     paneRenameNode !== null ||
     fileError !== null ||
     infoMessage !== null


### PR DESCRIPTION
## Summary

Fixes native browser pane layering for modal overlays by feeding visible burner terminal state into the existing browser pane occlusion path.

## Root Cause

The browser pane already supports an `isOccluded` tag that sends `visible: false` through `setBrowserPaneBounds`, which lets Electron move the native `WebContentsView` out of view. `WorkspaceView` included command palette and several dialogs in that occlusion flag, but did not include visible burner terminal popups, so a native browser pane could remain visible above the burner dialog.

## Changes

- Expose `hasVisibleBurner` from `useBurnerTerminals`, distinct from hidden-but-live burner shells.
- Include `hasVisibleBurner` in `WorkspaceView`'s browser-pane occlusion flag.
- Add BrowserPane coverage proving `isOccluded` sends `visible: false` and restores `visible: true` after the overlay clears.
- Add WorkspaceView coverage for command palette and burner popup occlusion.

## Notes

The current `main` branch still has Settings as a disabled footer stub. The existing `feat/settings-dialog-migration` branch already adds `settings.isOpen` to the same occlusion flag, and `git merge-tree` reports it combines cleanly with this branch.

## Validation

- `npm test -- --run src/features/browser/components/BrowserPane.test.tsx src/features/terminal/hooks/useBurnerTerminals.test.ts src/features/workspace/WorkspaceView.command-palette.test.tsx`
- `npm run lint -- --max-warnings=0`
- `npm run type-check`
- `git diff --check`
- `git merge-tree $(git merge-base HEAD feat/settings-dialog-migration) HEAD feat/settings-dialog-migration`

Closes VIM-109

Linear: https://linear.app/vimeflow/issue/VIM-109/fixbrowser-keep-native-browser-pane-below-dialogs-and-burner-terminal