### PR TITLE
Fix agent status active command history

### DIFF
--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -1,3 +1,4 @@
+// cspell:ignore winoooops
 import { describe, test, expect, vi } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -439,6 +440,35 @@ describe('AgentStatusPanel — live action card', () => {
     expect(screen.getByText('LIVE')).toBeInTheDocument()
   })
 
+  test('does not duplicate a running exec_command in Tool Calls and NOW', () => {
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        cwd="/tmp/repo"
+        agentStatus={{
+          ...activeAgentStatus,
+          toolCalls: {
+            total: 0,
+            byType: {},
+            active: {
+              tool: 'exec_command',
+              args: '{"cmd":"gh pr view 420 --repo winoooops/vimeflow"}',
+              startedAt: '2026-04-22T11:59:42Z',
+              toolUseId: 'cmd-1',
+            },
+          },
+          recentToolCalls: [],
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('live-action-card')).toBeInTheDocument()
+    expect(screen.queryByTestId('active-tool-indicator')).toBeNull()
+    expect(
+      screen.getAllByText(/gh pr view 420 --repo winoooops\/vimeflow/)
+    ).toHaveLength(1)
+  })
+
   test('omits the live card when no tool call is active', () => {
     render(
       <AgentStatusPanel
@@ -450,6 +480,44 @@ describe('AgentStatusPanel — live action card', () => {
 
     expect(screen.queryByText('NOW')).not.toBeInTheDocument()
     expect(screen.queryByTestId('live-action-card')).not.toBeInTheDocument()
+  })
+
+  test('moves a completed exec_command into activity history', () => {
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        cwd="/tmp/repo"
+        agentStatus={{
+          ...activeAgentStatus,
+          toolCalls: {
+            total: 1,
+            byType: { exec_command: 1 },
+            active: null,
+          },
+          recentToolCalls: [
+            {
+              id: 'cmd-1',
+              tool: 'exec_command',
+              args: '{"cmd":"gh pr view 420 --repo winoooops/vimeflow"}',
+              status: 'done',
+              durationMs: 500,
+              timestamp: '2026-04-22T12:00:00Z',
+              isTestFile: false,
+            },
+          ],
+        }}
+      />
+    )
+
+    expect(screen.queryByText('NOW')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('live-action-card')).toBeNull()
+    expect(
+      screen.getByRole('button', { name: /activity\s*1/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole('article')).toHaveTextContent(
+      'gh pr view 420 --repo winoooops/vimeflow'
+    )
   })
 
   test('does not also list the running action in the activity feed', () => {

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -160,7 +160,7 @@ export const AgentStatusPanel = ({
         <ToolCallSummary
           total={status.toolCalls.total}
           byType={status.toolCalls.byType}
-          active={status.toolCalls.active}
+          active={runningEvent === null ? status.toolCalls.active : null}
         />
         {runningEvent !== null && (
           <LiveActionCard


### PR DESCRIPTION
## Summary

Fixes duplicate active command rendering in the agent status panel by letting the NOW live-action card own the currently running event.

## Root Cause

A running tool call could be converted into the live NOW event while also remaining wired into `ToolCallSummary` as the active call. That rendered the same command twice: once in NOW and once in Tool Calls.

## Changes

- Pass `null` to `ToolCallSummary.active` whenever the same running event is already displayed by the NOW card.
- Add regression coverage for a running `exec_command` appearing only once.
- Add regression coverage for a completed `exec_command` moving into activity history instead of staying in NOW.

## Validation

- `npm test -- --run src/features/agent-status/components/AgentStatusPanel/index.test.tsx src/features/agent-status/utils/toolCallsToEvents.test.ts src/features/agent-status/hooks/useAgentStatus.test.ts`
- `npm run format:check`
- `npm run lint -- --max-warnings=0`
- `npm run type-check`
- `git diff --check`

Note: the targeted `useAgentStatus.test.ts` run still emits existing React `act(...)` warnings, but all tests pass.

Closes VIM-98

Linear: https://linear.app/vimeflow/issue/VIM-98/fixagent-status-avoid-duplicate-now-cards-and-move-completed-commands
