### PR TITLE
Fix burner terminal cwd sync target

### DIFF
--- a/src/features/terminal/hooks/useBurnerTerminals.test.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.test.ts
@@ -860,6 +860,67 @@ test('the align callback writes `cd <live host cwd>` + Enter to the burner pty',
   })
 })
 
+test('the align callback prefers the agent cwd over the live host cwd', async () => {
+  const service = makeService()
+  const focused = makeFocusedPane('s1', 'p0', '/repo')
+  const livePaneCwds = new Map([['s1:p0', '/repo']])
+
+  const agentPaneCwds = new Map([
+    ['s1:p0', '/repo/.claude/worktrees/agent-task'],
+  ])
+
+  const { result } = renderHook(() =>
+    useBurnerTerminals({
+      service,
+      resolveFocusedPane: () => focused,
+      livePaneCwds,
+      agentPaneCwds,
+    })
+  )
+
+  await act(async () => {
+    await result.current.toggle({ sessionId: 's1', paneId: 'p0', cwd: '/repo' })
+  })
+
+  act(() => {
+    firstPopup(result.current.renderNode).props.onAlignCwd?.()
+  })
+
+  expect(service.write).toHaveBeenCalledWith({
+    sessionId: 'burner-pty',
+    data: "\x05\x15cd '/repo/.claude/worktrees/agent-task'\r",
+  })
+})
+
+test('the align callback falls back to the live host cwd when no agent cwd is available', async () => {
+  const service = makeService()
+  const focused = makeFocusedPane('s1', 'p0', '/repo')
+  const livePaneCwds = new Map([['s1:p0', '/repo/current-shell-pwd']])
+  const agentPaneCwds = new Map([['s1:other', '/repo/.claude/worktrees/task']])
+
+  const { result } = renderHook(() =>
+    useBurnerTerminals({
+      service,
+      resolveFocusedPane: () => focused,
+      livePaneCwds,
+      agentPaneCwds,
+    })
+  )
+
+  await act(async () => {
+    await result.current.toggle({ sessionId: 's1', paneId: 'p0', cwd: '/repo' })
+  })
+
+  act(() => {
+    firstPopup(result.current.renderNode).props.onAlignCwd?.()
+  })
+
+  expect(service.write).toHaveBeenCalledWith({
+    sessionId: 'burner-pty',
+    data: "\x05\x15cd '/repo/current-shell-pwd'\r",
+  })
+})
+
 test('the align callback resolves the latest host cwd at click-time, not a stale snapshot', async () => {
   const service = makeService()
   const focused = makeFocusedPane('s1', 'p0', '/repo')
@@ -1163,6 +1224,34 @@ test('the host pane moving makes the burner out-of-sync', async () => {
     rerender({ cwds: new Map([['s1:p0', '/other']]) })
   })
   expect(firstPopup(result.current.renderNode).props.outOfSync).toBe(true)
+})
+
+test('marks the align button out-of-sync against the agent cwd when one is available', async () => {
+  const service = makeService()
+  const focused = makeFocusedPane('s1', 'p0', '/repo')
+  const livePaneCwds = new Map([['s1:p0', '/repo']])
+  const agentPaneCwds = new Map([['s1:p0', '/repo/worktree']])
+
+  const { result } = renderHook(() =>
+    useBurnerTerminals({
+      service,
+      resolveFocusedPane: () => focused,
+      livePaneCwds,
+      agentPaneCwds,
+    })
+  )
+
+  await act(async () => {
+    await result.current.toggle({ sessionId: 's1', paneId: 'p0', cwd: '/repo' })
+  })
+
+  expect(firstPopup(result.current.renderNode).props.outOfSync).toBe(true)
+
+  act(() => {
+    firstPopup(result.current.renderNode).props.onCwdChange?.('/repo/worktree')
+  })
+
+  expect(firstPopup(result.current.renderNode).props.outOfSync).toBe(false)
 })
 
 test('a trailing-slash-only difference is not treated as out-of-sync', async () => {

--- a/src/features/terminal/hooks/useBurnerTerminals.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.ts
@@ -97,6 +97,12 @@ export interface UseBurnerTerminalsArgs {
    * pane is *now*, not the cwd it spawned at. Omitted ⇒ no align button.
    */
   livePaneCwds?: ReadonlyMap<string, string>
+  /**
+   * Live `${sessionId}:${paneId}` → structured agent cwd. When present for a
+   * pane, it wins over `livePaneCwds` so tool-call-driven worktree moves are
+   * the sync target even before the interactive shell's pwd catches up.
+   */
+  agentPaneCwds?: ReadonlyMap<string, string>
 }
 
 export interface UseBurnerTerminals {
@@ -138,6 +144,7 @@ export const useBurnerTerminals = ({
   livePaneKeys,
   dropAllForPty,
   livePaneCwds,
+  agentPaneCwds,
 }: UseBurnerTerminalsArgs): UseBurnerTerminals => {
   // Authoritative handles live in a ref so they never serialize; a projection
   // is mirrored into state so renderNode + cues re-render.
@@ -157,6 +164,8 @@ export const useBurnerTerminals = ({
   // current cwd at click-time instead of capturing a stale render snapshot.
   const livePaneCwdsRef = useRef(livePaneCwds)
   livePaneCwdsRef.current = livePaneCwds
+  const agentPaneCwdsRef = useRef(agentPaneCwds)
+  agentPaneCwdsRef.current = agentPaneCwds
   // Keys whose in-flight spawn was invalidated because the pane left the live set
   // mid-spawn. Checked when the spawn resolves so the shell is reaped even when a
   // new pane has since reused the freed id (`nextFreePaneId` recycles ids).
@@ -204,14 +213,21 @@ export const useBurnerTerminals = ({
     [service, dropAllForPty]
   )
 
-  // Pull the host pane's live cwd into the burner shell — one-directional
-  // (VIM-81). A real `cd` (queues behind any running command, shows in history),
-  // resolved at call-time from the ref so it tracks the pane's current cwd. The
-  // burner's own `cd` still never moves the pane (no OSC 7 wiring on the popup).
+  const resolveAlignCwd = useCallback(
+    (key: string): string | undefined =>
+      agentPaneCwdsRef.current?.get(key) ?? livePaneCwdsRef.current?.get(key),
+    []
+  )
+
+  // Pull the target cwd into the burner shell — one-directional (VIM-81). A
+  // real `cd` (queues behind any running command, shows in history), resolved at
+  // call-time from refs so it prefers the active agent's structured worktree cwd
+  // while falling back to the host pane's current cwd. The burner's own `cd`
+  // still never moves the pane (no OSC 7 wiring on the popup).
   const alignCwd = useCallback(
     (key: string): void => {
       const entry = entriesRef.current.get(key)
-      const cwd = livePaneCwdsRef.current?.get(key)
+      const cwd = resolveAlignCwd(key)
       // Skip while a foreground command owns the shell (VIM-71 active cue): the
       // `cd` would be delivered to that program's stdin, not the shell prompt.
       // `active` is the last ~750ms poll, so a command started inside that window
@@ -242,7 +258,7 @@ export const useBurnerTerminals = ({
         }
       })()
     },
-    [service]
+    [resolveAlignCwd, service]
   )
 
   // Lazily spawn a pane's burner shell on first open. Idempotent + guarded.
@@ -522,7 +538,7 @@ export const useBurnerTerminals = ({
           Fragment,
           null,
           [...entries.entries()].map(([key, entry]): ReactNode => {
-            const hostCwd = livePaneCwds?.get(key)
+            const targetCwd = agentPaneCwds?.get(key) ?? livePaneCwds?.get(key)
 
             return createElement(BurnerTerminalPopup, {
               // Keyed by pty so a re-spawned (post-exit) shell remounts a fresh
@@ -539,7 +555,7 @@ export const useBurnerTerminals = ({
               // macOS/Linux only: foreground detection is cfg(unix), so the
               // busy-guard is reliable on every platform we ship to.
               onAlignCwd:
-                livePaneCwds && entry.status === 'running'
+                (agentPaneCwds || livePaneCwds) && entry.status === 'running'
                   ? (): void => alignCwd(key)
                   : undefined,
               // ...and disable it while a foreground command owns the shell.
@@ -549,8 +565,8 @@ export const useBurnerTerminals = ({
               onCwdChange: (cwd: string): void => setBurnerCwd(key, cwd),
               outOfSync:
                 entry.status === 'running' &&
-                hostCwd !== undefined &&
-                normalizeCwd(entry.currentCwd) !== normalizeCwd(hostCwd),
+                targetCwd !== undefined &&
+                normalizeCwd(entry.currentCwd) !== normalizeCwd(targetCwd),
             })
           })
         )

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -931,6 +931,35 @@ export const WorkspaceView = (): ReactElement => {
     [sessions]
   )
 
+  // Preferred burner sync targets from the active agent's structured cwd.
+  // This captures agent-driven worktree moves that may not be reflected in the
+  // host shell's pwd yet; `useBurnerTerminals` falls back to `livePaneCwds`.
+  const agentPaneCwds = useMemo(() => {
+    if (
+      !activeSessionId ||
+      !activePtyBackedPaneId ||
+      !activePtyBackedPanePtyId ||
+      !agentCwd ||
+      agentStatus.sessionId !== activePtyBackedPanePtyId ||
+      !agentIsActive ||
+      agentHasExited ||
+      !isActivePaneLive
+    ) {
+      return new Map<string, string>()
+    }
+
+    return new Map([[`${activeSessionId}:${activePtyBackedPaneId}`, agentCwd]])
+  }, [
+    activeSessionId,
+    activePtyBackedPaneId,
+    activePtyBackedPanePtyId,
+    agentCwd,
+    agentHasExited,
+    agentIsActive,
+    agentStatus.sessionId,
+    isActivePaneLive,
+  ])
+
   const {
     renderNode: burnerTerminalNode,
     toggle: toggleBurner,
@@ -945,6 +974,7 @@ export const WorkspaceView = (): ReactElement => {
     livePaneKeys,
     dropAllForPty,
     livePaneCwds,
+    agentPaneCwds,
   })
 
   // Stable wrapper for the `:burner` palette command so the command-list memo


### PR DESCRIPTION
## Summary

Fixes the burner terminal cwd sync button so it targets the active agent's structured cwd before falling back to the host pane's live cwd.

## Root Cause

The align button only read the host pane cwd map. Agent-driven worktree moves can be reported through `agentStatus.cwd` before the interactive shell pwd reflects the same path, so syncing could send the burner to the stale host shell directory instead of the worktree where the agent is working.

## Changes

- Add `agentPaneCwds` to `useBurnerTerminals` as a preferred per-pane sync target.
- Keep the existing `livePaneCwds` behavior as the fallback target.
- Use the same preferred target for the out-of-sync highlight.
- Thread the active live agent cwd from `WorkspaceView` into the burner hook.
- Add regression coverage for agent-cwd preference, pane-cwd fallback, and out-of-sync comparison against agent cwd.

## Validation

- `npm test -- --run src/features/terminal/hooks/useBurnerTerminals.test.ts src/features/workspace/WorkspaceView.test.tsx`
- `npm test -- --run src/features/terminal/hooks/useBurnerTerminals.test.ts`
- `npm run format:check`
- `npm run lint -- --max-warnings=0`
- `npm run type-check`
- `git diff --check`

Note: `WorkspaceView.test.tsx` still emits existing React `act(...)` and CodeMirror jsdom warnings, but all tests pass.

Closes VIM-97

Linear: https://linear.app/vimeflow/issue/VIM-97/fixterminal-sync-button-should-pick-the-agent-worktree-path-or-active
