### PR TITLE
Fix diff narrow placeholder icon direction

### DIFF
--- a/src/features/diff/components/DiffNarrowPlaceholder.test.tsx
+++ b/src/features/diff/components/DiffNarrowPlaceholder.test.tsx
@@ -21,4 +21,10 @@ describe('DiffNarrowPlaceholder', (): void => {
     render(<DiffNarrowPlaceholder min={360} />)
     expect(screen.getByRole('status')).toBeInTheDocument()
   })
+
+  test('rotates the resize glyph to indicate horizontal widening', (): void => {
+    render(<DiffNarrowPlaceholder min={360} />)
+
+    expect(screen.getByText('unfold_more')).toHaveClass('rotate-90')
+  })
 })

--- a/src/features/diff/components/DiffNarrowPlaceholder.tsx
+++ b/src/features/diff/components/DiffNarrowPlaceholder.tsx
@@ -11,7 +11,7 @@ export const DiffNarrowPlaceholder = ({
     role="status"
     className="flex flex-col items-center justify-center gap-2 px-4 py-10 rounded-lg bg-surface-container-low/40 text-on-surface-variant text-center"
   >
-    <span className="material-symbols-outlined text-2xl leading-none opacity-70">
+    <span className="material-symbols-outlined rotate-90 text-2xl leading-none opacity-70">
       unfold_more
     </span>
     <p className="text-xs leading-snug">


### PR DESCRIPTION
## Summary
- rotate the known-valid `unfold_more` Material Symbol so the placeholder indicates horizontal widening
- add a regression test for the horizontal icon affordance

Closes VIM-84

## Validation
- npm test -- --run src/features/diff/components/DiffNarrowPlaceholder.test.tsx
- npm run format:check
- npm run lint -- --max-warnings=0
- npm run type-check
- git diff --check
- Chrome headless rendered `/tmp/vimeflow-vim84-placeholder.html` with the bundled Material Symbols WOFF2; computed font family was `Material Symbols Outlined Variable`, transform was `matrix(0, 1, -1, 0, 0, 0)`, and screenshot showed left/right chevrons above the Widen copy