### PR TITLE
feat(settings): wire the General pane to the settings store (VIM-101)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -84,4 +84,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Persisted State Invariants](patterns/persisted-state-invariants.md)                     | correctness        | 9        | 5    | 2026-06-12   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                   | cross-platform     | 8        | 2    | 2026-06-11   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                         | correctness        | 1        | 0    | 2026-06-11   |
-| [Synchronous Calls in Async Electron Handlers](patterns/sync-calls-in-async-handlers.md) | code-quality       | 1        | 0    | 2026-06-12   |
+| [IPC Trust Boundary](patterns/ipc-trust-boundary.md)                                     | security           | 1        | 0    | 2026-06-12   |
+| [Synchronous Calls in Async Electron Handlers](patterns/sync-calls-in-async-electron-handlers.md) | code-quality       | 1        | 0    | 2026-06-12   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -81,7 +81,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                 | code-quality       | 1        | 0    | 2026-06-11   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                         | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                       | code-quality       | 10       | 7    | 2026-06-11   |
-| [Persisted State Invariants](patterns/persisted-state-invariants.md)                     | correctness        | 8        | 4    | 2026-06-12   |
+| [Persisted State Invariants](patterns/persisted-state-invariants.md)                     | correctness        | 9        | 5    | 2026-06-12   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                   | cross-platform     | 8        | 2    | 2026-06-11   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                         | correctness        | 1        | 0    | 2026-06-11   |
 | [Synchronous Calls in Async Electron Handlers](patterns/sync-calls-in-async-handlers.md) | code-quality       | 1        | 0    | 2026-06-12   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -81,7 +81,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                          | code-quality       | 1        | 0    | 2026-06-11   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                  | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                                | code-quality       | 10       | 7    | 2026-06-11   |
-| [Persisted State Invariants](patterns/persisted-state-invariants.md)                              | correctness        | 9        | 5    | 2026-06-12   |
+| [Persisted State Invariants](patterns/persisted-state-invariants.md)                              | correctness        | 10       | 6    | 2026-06-12   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                            | cross-platform     | 8        | 2    | 2026-06-11   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                  | correctness        | 1        | 0    | 2026-06-11   |
 | [IPC Trust Boundary](patterns/ipc-trust-boundary.md)                                              | security           | 1        | 0    | 2026-06-12   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,12 +54,12 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                   | code-quality       | 4        | 2    | 2026-06-11   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                           | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                         | backend            | 1        | 0    | 2026-06-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                 | testing            | 64       | 31   | 2026-06-12   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                 | testing            | 65       | 31   | 2026-06-12   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                           | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                             | code-quality       | 88       | 26   | 2026-06-12   |
 | [Accessibility](patterns/accessibility.md)                                               | a11y               | 63       | 23   | 2026-06-11   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                 | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                               | react-patterns     | 64       | 22   | 2026-06-12   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                               | react-patterns     | 65       | 22   | 2026-06-12   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                           | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                                       | security           | 7        | 3    | 2026-05-02   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)                                 | security           | 15       | 2    | 2026-04-20   |
@@ -81,7 +81,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                 | code-quality       | 1        | 0    | 2026-06-11   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                         | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                       | code-quality       | 10       | 7    | 2026-06-11   |
-| [Persisted State Invariants](patterns/persisted-state-invariants.md)                     | correctness        | 7        | 4    | 2026-06-12   |
+| [Persisted State Invariants](patterns/persisted-state-invariants.md)                     | correctness        | 8        | 4    | 2026-06-12   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                   | cross-platform     | 8        | 2    | 2026-06-11   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                         | correctness        | 1        | 0    | 2026-06-11   |
 | [Synchronous Calls in Async Electron Handlers](patterns/sync-calls-in-async-handlers.md) | code-quality       | 1        | 0    | 2026-06-12   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -41,48 +41,48 @@ When appending findings to a pattern file, label the source so future readers ca
 - `local-codex` — local `codex exec` runs (e.g. `/lifeline:review` or post-fix verify in
   `/lifeline:upsource-review`).
 
-| Pattern                                                                                  | Category           | Findings | Refs | Last Updated |
-| ---------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
-| [Filesystem Scope](patterns/filesystem-scope.md)                                         | security           | 21       | 3    | 2026-05-20   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                           | react-patterns     | 37       | 16   | 2026-06-12   |
-| [React Key Stability](patterns/react-key-stability.md)                                   | react-patterns     | 2        | 0    | 2026-06-11   |
-| [Motion Layout Projection](patterns/motion-layout-projection.md)                         | react-patterns     | 1        | 0    | 2026-06-10   |
-| [Resource Cleanup](patterns/resource-cleanup.md)                                         | react-patterns     | 11       | 10   | 2026-06-08   |
-| [Cross-Platform Paths](patterns/cross-platform-paths.md)                                 | cross-platform     | 6        | 3    | 2026-05-30   |
-| [Debug Artifacts](patterns/debug-artifacts.md)                                           | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                       | code-quality       | 5        | 3    | 2026-06-08   |
-| [Generated Artifacts](patterns/generated-artifacts.md)                                   | code-quality       | 4        | 2    | 2026-06-11   |
-| [Generated Shell Scripts](patterns/generated-shell-scripts.md)                           | backend            | 7        | 1    | 2026-06-03   |
-| [Hot-Path Caching](patterns/hot-path-caching.md)                                         | backend            | 1        | 0    | 2026-06-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                 | testing            | 65       | 31   | 2026-06-12   |
-| [Terminal Input Handling](patterns/terminal-input-handling.md)                           | terminal           | 4        | 2    | 2026-05-24   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)                             | code-quality       | 88       | 26   | 2026-06-12   |
-| [Accessibility](patterns/accessibility.md)                                               | a11y               | 63       | 23   | 2026-06-11   |
-| [Event Identity Guard](patterns/event-identity-guard.md)                                 | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                               | react-patterns     | 65       | 22   | 2026-06-12   |
-| [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                           | backend            | 2        | 1    | 2026-05-20   |
-| [Command Injection](patterns/command-injection.md)                                       | security           | 7        | 3    | 2026-05-02   |
-| [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)                                 | security           | 15       | 2    | 2026-04-20   |
-| [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                                       | security           | 3        | 1    | 2026-04-20   |
-| [Preflight Checks](patterns/preflight-checks.md)                                         | error-handling     | 3        | 0    | 2026-05-31   |
-| [CSP Configuration](patterns/csp-configuration.md)                                       | security           | 8        | 5    | 2026-05-16   |
-| [Network Request Hardening](patterns/network-request-hardening.md)                       | security           | 1        | 1    | 2026-06-08   |
-| [PTY Session Management](patterns/pty-session-management.md)                             | backend            | 9        | 2    | 2026-06-03   |
-| [Git Operations](patterns/git-operations.md)                                             | correctness        | 25       | 10   | 2026-05-31   |
-| [CodeMirror Integration](patterns/codemirror-integration.md)                             | editor             | 19       | 4    | 2026-06-06   |
-| [Error Surfacing](patterns/error-surfacing.md)                                           | error-handling     | 39       | 13   | 2026-06-12   |
-| [File Tree Paths](patterns/file-tree-paths.md)                                           | files              | 4        | 0    | 2026-04-10   |
-| [Scope Boundary](patterns/scope-boundary.md)                                             | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                   | e2e-testing        | 19       | 7    | 2026-06-06   |
-| [Module Boundaries](patterns/module-boundaries.md)                                       | code-quality       | 14       | 3    | 2026-06-12   |
-| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                     | code-quality       | 7        | 2    | 2026-05-02   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                         | keyboard-shortcuts | 19       | 1    | 2026-06-06   |
-| [Verify Render Target](patterns/verify-render-target.md)                                 | code-quality       | 2        | 0    | 2026-05-24   |
-| [UI Visual Regression](patterns/ui-visual-regression.md)                                 | code-quality       | 1        | 0    | 2026-06-11   |
-| [Status Indicator Display](patterns/status-indicator-display.md)                         | code-quality       | 3        | 0    | 2026-05-26   |
-| [Parser Resilience](patterns/parser-resilience.md)                                       | code-quality       | 10       | 7    | 2026-06-11   |
-| [Persisted State Invariants](patterns/persisted-state-invariants.md)                     | correctness        | 9        | 5    | 2026-06-12   |
-| [macOS Window Chrome](patterns/macos-window-chrome.md)                                   | cross-platform     | 8        | 2    | 2026-06-11   |
-| [Guard Branch Correctness](patterns/guard-branch-correctness.md)                         | correctness        | 1        | 0    | 2026-06-11   |
-| [IPC Trust Boundary](patterns/ipc-trust-boundary.md)                                     | security           | 1        | 0    | 2026-06-12   |
+| Pattern                                                                                           | Category           | Findings | Refs | Last Updated |
+| ------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
+| [Filesystem Scope](patterns/filesystem-scope.md)                                                  | security           | 21       | 3    | 2026-05-20   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                    | react-patterns     | 37       | 16   | 2026-06-12   |
+| [React Key Stability](patterns/react-key-stability.md)                                            | react-patterns     | 2        | 0    | 2026-06-11   |
+| [Motion Layout Projection](patterns/motion-layout-projection.md)                                  | react-patterns     | 1        | 0    | 2026-06-10   |
+| [Resource Cleanup](patterns/resource-cleanup.md)                                                  | react-patterns     | 11       | 10   | 2026-06-08   |
+| [Cross-Platform Paths](patterns/cross-platform-paths.md)                                          | cross-platform     | 6        | 3    | 2026-05-30   |
+| [Debug Artifacts](patterns/debug-artifacts.md)                                                    | code-quality       | 7        | 0    | 2026-06-11   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                | code-quality       | 5        | 3    | 2026-06-08   |
+| [Generated Artifacts](patterns/generated-artifacts.md)                                            | code-quality       | 4        | 2    | 2026-06-11   |
+| [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                    | backend            | 7        | 1    | 2026-06-03   |
+| [Hot-Path Caching](patterns/hot-path-caching.md)                                                  | backend            | 1        | 0    | 2026-06-09   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                          | testing            | 65       | 31   | 2026-06-12   |
+| [Terminal Input Handling](patterns/terminal-input-handling.md)                                    | terminal           | 4        | 2    | 2026-05-24   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)                                      | code-quality       | 88       | 26   | 2026-06-12   |
+| [Accessibility](patterns/accessibility.md)                                                        | a11y               | 63       | 23   | 2026-06-11   |
+| [Event Identity Guard](patterns/event-identity-guard.md)                                          | backend            | 1        | 0    | 2026-06-11   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                        | react-patterns     | 65       | 22   | 2026-06-12   |
+| [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                    | backend            | 2        | 1    | 2026-05-20   |
+| [Command Injection](patterns/command-injection.md)                                                | security           | 7        | 3    | 2026-05-02   |
+| [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)                                          | security           | 15       | 2    | 2026-04-20   |
+| [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                                                | security           | 3        | 1    | 2026-04-20   |
+| [Preflight Checks](patterns/preflight-checks.md)                                                  | error-handling     | 3        | 0    | 2026-05-31   |
+| [CSP Configuration](patterns/csp-configuration.md)                                                | security           | 8        | 5    | 2026-05-16   |
+| [Network Request Hardening](patterns/network-request-hardening.md)                                | security           | 1        | 1    | 2026-06-08   |
+| [PTY Session Management](patterns/pty-session-management.md)                                      | backend            | 9        | 2    | 2026-06-03   |
+| [Git Operations](patterns/git-operations.md)                                                      | correctness        | 25       | 10   | 2026-05-31   |
+| [CodeMirror Integration](patterns/codemirror-integration.md)                                      | editor             | 19       | 4    | 2026-06-06   |
+| [Error Surfacing](patterns/error-surfacing.md)                                                    | error-handling     | 39       | 13   | 2026-06-12   |
+| [File Tree Paths](patterns/file-tree-paths.md)                                                    | files              | 4        | 0    | 2026-04-10   |
+| [Scope Boundary](patterns/scope-boundary.md)                                                      | review-process     | 8        | 3    | 2026-06-01   |
+| [E2E Testing](patterns/e2e-testing.md)                                                            | e2e-testing        | 19       | 7    | 2026-06-06   |
+| [Module Boundaries](patterns/module-boundaries.md)                                                | code-quality       | 14       | 3    | 2026-06-12   |
+| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                              | code-quality       | 7        | 2    | 2026-05-02   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                  | keyboard-shortcuts | 19       | 1    | 2026-06-06   |
+| [Verify Render Target](patterns/verify-render-target.md)                                          | code-quality       | 2        | 0    | 2026-05-24   |
+| [UI Visual Regression](patterns/ui-visual-regression.md)                                          | code-quality       | 1        | 0    | 2026-06-11   |
+| [Status Indicator Display](patterns/status-indicator-display.md)                                  | code-quality       | 3        | 0    | 2026-05-26   |
+| [Parser Resilience](patterns/parser-resilience.md)                                                | code-quality       | 10       | 7    | 2026-06-11   |
+| [Persisted State Invariants](patterns/persisted-state-invariants.md)                              | correctness        | 9        | 5    | 2026-06-12   |
+| [macOS Window Chrome](patterns/macos-window-chrome.md)                                            | cross-platform     | 8        | 2    | 2026-06-11   |
+| [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                  | correctness        | 1        | 0    | 2026-06-11   |
+| [IPC Trust Boundary](patterns/ipc-trust-boundary.md)                                              | security           | 1        | 0    | 2026-06-12   |
 | [Synchronous Calls in Async Electron Handlers](patterns/sync-calls-in-async-electron-handlers.md) | code-quality       | 1        | 0    | 2026-06-12   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -650,3 +650,12 @@ prevent showing previous data.
 - **Finding:** `update()` fired `bridge.save(merged)` as a fire-and-forget promise. If two updates happened before the first save resolved, both full snapshots were dispatched concurrently; the sidecar processes IPC requests concurrently, so an older snapshot could reach the Rust save mutex after a newer one and overwrite the newer preferences on disk.
 - **Fix:** Replaced fire-and-forget with a single-producer save queue. `saveQueueRef` always holds the tail promise; each new update awaits the previous save before invoking `bridge.save(next)`, guaranteeing that the last update to run is the last one persisted.
 - **Commit:** same commit as this entry
+
+### 64. window-all-closed reads stale settings.json before async save completes
+
+- **Source:** github-claude | PR #432 round 1 | 2026-06-12
+- **Severity:** MEDIUM
+- **File:** `electron/main.ts` L531-550
+- **Finding:** The `window-all-closed` handler read `onLastWindowClosed` from disk via `readFileSync`, but settings are persisted through an async IPC → Rust sidecar pipeline (`window.vimeflow.settings.save()`). If the user changed `onLastWindowClosed` to `'quit'` and immediately closed the last window before the queued save flushed to disk, `readFileSync` returned the pre-change value. On macOS the guard then evaluated `platform !== 'darwin'` → `false`, so `app.quit()` was never called and the app silently stayed alive despite the user's explicit quit preference.
+- **Fix:** Added an in-memory settings snapshot in the main process that the renderer updates via a new `settings:sync-snapshot` IPC channel. The close handler now prefers `lastKnownSettings.onLastWindowClosed`; it only falls back to reading `settings.json` when no snapshot has been received.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/ipc-trust-boundary.md
+++ b/docs/reviews/patterns/ipc-trust-boundary.md
@@ -1,0 +1,24 @@
+---
+id: ipc-trust-boundary
+category: security
+created: 2026-06-12
+last_updated: 2026-06-12
+ref_count: 0
+---
+
+# IPC Trust Boundary
+
+## Summary
+
+The Electron main process must treat every renderer IPC payload as untrusted input. TypeScript types are erased at runtime, so an `ipcMain.handle` callback annotated with a domain type is not validation. Storing the whole renderer-controlled object as a typed domain model (for example, `AppSettings`) creates a trusted-looking main-process value that future code may read without re-checking. The safer shape is to extract and validate only the specific fields the main process needs, guarding each field with a runtime `typeof` check and keeping the stored state narrowly typed.
+
+## Findings
+
+### 1. IPC snapshot handler stores unvalidated renderer payload as AppSettings
+
+- **Source:** github-claude | PR #432 round 3 | 2026-06-12
+- **Severity:** MEDIUM
+- **File:** `electron/main.ts` L489-494
+- **Finding:** The `SETTINGS_SYNC_SNAPSHOT` handler accepted the renderer's payload typed as `AppSettings` and assigned it directly to a main-process variable. Because TypeScript types do not exist at runtime, any renderer-sent object would be stored as the authoritative settings snapshot, creating a trust-boundary violation and future-change risk if other main-process code reused the value.
+- **Fix:** Changed the handler parameter to `unknown`, validated that the payload is a record and that `onLastWindowClosed` is a string, and stored only that validated string in a renamed `lastKnownOnLastWindowClosed` variable. The `window-all-closed` handler now reads the narrow string value instead of the full settings object.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/persisted-state-invariants.md
+++ b/docs/reviews/patterns/persisted-state-invariants.md
@@ -76,3 +76,12 @@ Durable user-facing state (workspace shapes, caches, settings files) can be malf
 - **Finding:** The `SETTINGS_OPEN_FILE` handler called `shell.openPath` on `userData/settings.json`. On a fresh profile, `load_app_settings` returns defaults without writing them, so the file does not exist and the open action silently fails (the renderer also ignores the returned error string).
 - **Fix:** Before opening, the handler checks whether `settings.json` exists; if missing, it asks the sidecar to `load_app_settings` (which returns defaults) and then `save_app_settings` so the default file is materialized on disk. The open is still attempted even if seeding fails, letting the OS surface any residual error.
 - **Commit:** same commit as this entry
+
+### 8. Settings version not validated before honoring close behavior
+
+- **Source:** github-codex-connector | PR #432 round 1 | 2026-06-12
+- **Severity:** P2 / MEDIUM
+- **File:** `electron/main.ts` L528
+- **Finding:** The `window-all-closed` handler parsed `onLastWindowClosed` from `settings.json` without validating the persisted `version`. The backend settings store intentionally discards files written by a newer app version and loads defaults on version mismatch, but this direct parse in the main process still honored the field. In a downgrade/unsupported-version scenario such as `{"version":999,"onLastWindowClosed":"quit"}`, the UI/store would behave as platform default while the main process quit on macOS after the last window closed.
+- **Fix:** When reading `settings.json` as a fallback (no in-memory snapshot yet), compare `parsed.version` against `DEFAULT_SETTINGS.version` and only honor `onLastWindowClosed` when the versions match. Mismatched versions fall back to the platform default.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/persisted-state-invariants.md
+++ b/docs/reviews/patterns/persisted-state-invariants.md
@@ -3,7 +3,7 @@ id: persisted-state-invariants
 category: correctness
 created: 2026-06-08
 last_updated: 2026-06-12
-ref_count: 4
+ref_count: 5
 ---
 
 # Persisted State Invariants
@@ -84,4 +84,13 @@ Durable user-facing state (workspace shapes, caches, settings files) can be malf
 - **File:** `electron/main.ts` L528
 - **Finding:** The `window-all-closed` handler parsed `onLastWindowClosed` from `settings.json` without validating the persisted `version`. The backend settings store intentionally discards files written by a newer app version and loads defaults on version mismatch, but this direct parse in the main process still honored the field. In a downgrade/unsupported-version scenario such as `{"version":999,"onLastWindowClosed":"quit"}`, the UI/store would behave as platform default while the main process quit on macOS after the last window closed.
 - **Fix:** When reading `settings.json` as a fallback (no in-memory snapshot yet), compare `parsed.version` against `DEFAULT_SETTINGS.version` and only honor `onLastWindowClosed` when the versions match. Mismatched versions fall back to the platform default.
+- **Commit:** same commit as this entry
+
+### 9. Settings version validation imported a renderer value into Electron main
+
+- **Source:** github-codex-connector | PR #432 round 2 | 2026-06-12
+- **Severity:** MEDIUM
+- **File:** `electron/main.ts` L15, L551
+- **Finding:** Round 1's fix for finding #8 imported `DEFAULT_SETTINGS` from `src/features/settings/store/settingsDefaults` into `electron/main.ts` so the fallback `settings.json` parse could compare `parsed.version === DEFAULT_SETTINGS.version`. That is a runtime value import from a renderer feature tree into the Electron main process. The defaults module is a plain object today, but a future edit can add browser/React-facing imports (e.g., a theme helper, a hook, or a component) without any type-system or build guard to stop Electron main from loading it. When that happens, main-process startup or bundling fails silently until runtime.
+- **Fix:** Removed the `DEFAULT_SETTINGS` value import. Added a main-process-local `SETTINGS_SCHEMA_VERSION = 1` constant in `electron/main.ts`, documented as mirroring `DEFAULT_SETTINGS.version` and `CURRENT_APP_SETTINGS_VERSION`. The fallback parse now compares `parsed.version === SETTINGS_SCHEMA_VERSION`. This keeps the version validation behavior identical while severing the runtime dependency on a renderer-owned module. Code-review heuristic: value imports from `src/features/**` into `electron/**` are a process-boundary smell; prefer a local constant, an `electron/`-scoped shared constant, or a type-only import. Type-only imports are erased at compile time and are safe; value imports execute at runtime and couple main-process startup to renderer module graphs.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/persisted-state-invariants.md
+++ b/docs/reviews/patterns/persisted-state-invariants.md
@@ -3,7 +3,7 @@ id: persisted-state-invariants
 category: correctness
 created: 2026-06-08
 last_updated: 2026-06-12
-ref_count: 5
+ref_count: 6
 ---
 
 # Persisted State Invariants
@@ -93,4 +93,13 @@ Durable user-facing state (workspace shapes, caches, settings files) can be malf
 - **File:** `electron/main.ts` L15, L551
 - **Finding:** Round 1's fix for finding #8 imported `DEFAULT_SETTINGS` from `src/features/settings/store/settingsDefaults` into `electron/main.ts` so the fallback `settings.json` parse could compare `parsed.version === DEFAULT_SETTINGS.version`. That is a runtime value import from a renderer feature tree into the Electron main process. The defaults module is a plain object today, but a future edit can add browser/React-facing imports (e.g., a theme helper, a hook, or a component) without any type-system or build guard to stop Electron main from loading it. When that happens, main-process startup or bundling fails silently until runtime.
 - **Fix:** Removed the `DEFAULT_SETTINGS` value import. Added a main-process-local `SETTINGS_SCHEMA_VERSION = 1` constant in `electron/main.ts`, documented as mirroring `DEFAULT_SETTINGS.version` and `CURRENT_APP_SETTINGS_VERSION`. The fallback parse now compares `parsed.version === SETTINGS_SCHEMA_VERSION`. This keeps the version validation behavior identical while severing the runtime dependency on a renderer-owned module. Code-review heuristic: value imports from `src/features/**` into `electron/**` are a process-boundary smell; prefer a local constant, an `electron/`-scoped shared constant, or a type-only import. Type-only imports are erased at compile time and are safe; value imports execute at runtime and couple main-process startup to renderer module graphs.
+- **Commit:** same commit as this entry
+
+### 10. Disk fallback omits runtime string check for onLastWindowClosed
+
+- **Source:** github-claude | PR #432 round 4 | 2026-06-12
+- **Severity:** LOW
+- **File:** `electron/main.ts` L549-567
+- **Finding:** The `window-all-closed` disk fallback parsed `onLastWindowClosed` from `settings.json` under a TypeScript assertion (`as { version?: number; onLastWindowClosed?: string }`), which is erased at runtime. A non-string persisted value such as `true` or `42` would be assigned unchecked, pass through `?? 'platform'`, and reach `shouldQuitOnAllWindowsClosed`. On macOS that produced the wrong quit decision because any non-`'darwin'` truthy value evaluates to quit instead of the platform-default stay-alive behavior.
+- **Fix:** Mirrored the IPC snapshot validation: the disk fallback now checks `parsed.version === SETTINGS_SCHEMA_VERSION && typeof parsed.onLastWindowClosed === 'string'` before assigning the value. This makes the cold-start fallback symmetric with the renderer-sync path and prevents malformed persisted state from altering close behavior.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -639,3 +639,12 @@ filesystem scope restrictions).
 - **Finding:** `SettingsProvider.test.tsx` covered hydration, update-success, bridge-absent, and load-rejection, but the `catch (error)` branch in `SettingsProvider.saveNext` (where `bridge.save()` rejects and `saveError` is populated) had zero coverage. `saveError` is the primary user-facing error signal for save failures and part of the public `SettingsContextValue` interface that VIM-101..104 panes will consume.
 - **Fix:** Added a fifth test that mocks `window.vimeflow.settings.save` to reject with `Error('disk full')`, triggers `update()`, and asserts `saveError.message` is surfaced in the context consumer.
 - **Commit:** same commit as this entry
+
+### 64. Missing 'General Settings' sub-title assertion in consolidated test
+
+- **Source:** github-claude | PR #432 round 1 | 2026-06-12
+- **Severity:** LOW
+- **File:** `src/features/settings/components/panes/GeneralPane.test.tsx` L56-70
+- **Finding:** The first `GeneralPane` test consolidated the original two pane-rendering tests but the `General Settings` sub-title assertion was inadvertently left out during consolidation. No runtime risk, but a future rename of the subtitle (e.g. during an i18n pass) would go undetected by the test suite.
+- **Fix:** Restored the missing assertion: `expect(screen.getByText('General Settings')).toBeInTheDocument()`.
+- **Commit:** same commit as this entry

--- a/electron/ipc-channels.ts
+++ b/electron/ipc-channels.ts
@@ -8,3 +8,5 @@ export const BACKEND_EVENT = 'backend:event'
 export const COMMAND_PALETTE_TOGGLE = 'command-palette:toggle'
 
 export const SETTINGS_OPEN_FILE = 'settings:open-file'
+
+export const SETTINGS_SYNC_SNAPSHOT = 'settings:sync-snapshot'

--- a/electron/last-window-close.test.ts
+++ b/electron/last-window-close.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+import { shouldQuitOnAllWindowsClosed } from './last-window-close'
+
+describe('shouldQuitOnAllWindowsClosed', () => {
+  test('always quits when the user explicitly chooses quit', () => {
+    expect(shouldQuitOnAllWindowsClosed('quit', 'darwin')).toBe(true)
+    expect(shouldQuitOnAllWindowsClosed('quit', 'win32')).toBe(true)
+    expect(shouldQuitOnAllWindowsClosed('quit', 'linux')).toBe(true)
+  })
+
+  test('follows the platform default when set to platform', () => {
+    expect(shouldQuitOnAllWindowsClosed('platform', 'darwin')).toBe(false)
+    expect(shouldQuitOnAllWindowsClosed('platform', 'win32')).toBe(true)
+    expect(shouldQuitOnAllWindowsClosed('platform', 'linux')).toBe(true)
+  })
+})

--- a/electron/last-window-close.ts
+++ b/electron/last-window-close.ts
@@ -1,0 +1,10 @@
+export const shouldQuitOnAllWindowsClosed = (
+  onLastWindowClosed: string,
+  platform: NodeJS.Platform
+): boolean => {
+  if (onLastWindowClosed === 'quit') {
+    return true
+  }
+
+  return platform !== 'darwin'
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -558,7 +558,10 @@ app.on('window-all-closed', () => {
 
       // Only honor values written by the current app version. A newer or
       // unsupported version is treated as a mismatch and falls back to default.
-      if (parsed.version === SETTINGS_SCHEMA_VERSION) {
+      if (
+        parsed.version === SETTINGS_SCHEMA_VERSION &&
+        typeof parsed.onLastWindowClosed === 'string'
+      ) {
         onLastWindowClosed = parsed.onLastWindowClosed
       }
     } catch {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,6 +12,7 @@ import { access } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import type { AppSettings } from '../src/bindings/AppSettings'
+import { DEFAULT_SETTINGS } from '../src/features/settings/store/settingsDefaults'
 import { isAllowedBackendMethod } from './backend-methods'
 import {
   developmentContentSecurityPolicy,
@@ -24,6 +25,7 @@ import {
   BACKEND_EVENT,
   BACKEND_INVOKE,
   SETTINGS_OPEN_FILE,
+  SETTINGS_SYNC_SNAPSHOT,
 } from './ipc-channels'
 import { spawnSidecar, type Sidecar } from './sidecar'
 import { setupBrowserPaneIpc, type BrowserPaneController } from './browser-pane'
@@ -210,6 +212,7 @@ let browserPaneController: BrowserPaneController | null = null
 let workspaceLayoutController: WorkspaceLayoutController | null = null
 let workspaceTeardown: WorkspaceTeardown | null = null
 let quitting = false
+let lastKnownSettings: AppSettings | undefined
 
 const RENDERER_DIAGNOSTIC_PREFIXES = [
   '[vimeflow:terminal-cwd]',
@@ -478,6 +481,13 @@ const setupApp = async (): Promise<void> => {
     }
   })
 
+  ipcMain.handle(
+    SETTINGS_SYNC_SNAPSHOT,
+    (_ipcEvent, settings: AppSettings): void => {
+      lastKnownSettings = settings
+    }
+  )
+
   spawnedSidecar.onEvent((event, payload) => {
     for (const win of BrowserWindow.getAllWindows()) {
       win.webContents.send(BACKEND_EVENT, { event, payload })
@@ -521,13 +531,29 @@ app.on('before-quit', (event) => {
 app.on('window-all-closed', () => {
   let onLastWindowClosed: string | undefined
 
-  try {
-    const settingsPath = path.join(app.getPath('userData'), 'settings.json')
-    const raw = readFileSync(settingsPath, 'utf8')
-    const parsed = JSON.parse(raw) as { onLastWindowClosed?: string }
-    onLastWindowClosed = parsed.onLastWindowClosed
-  } catch {
-    // Missing or corrupt settings.json falls back to the platform default.
+  if (lastKnownSettings !== undefined) {
+    // The renderer keeps this snapshot in sync whenever the user changes a
+    // setting, so we can read the latest value without racing the async save
+    // to disk / the Rust sidecar.
+    onLastWindowClosed = lastKnownSettings.onLastWindowClosed
+  } else {
+    try {
+      const settingsPath = path.join(app.getPath('userData'), 'settings.json')
+      const raw = readFileSync(settingsPath, 'utf8')
+
+      const parsed = JSON.parse(raw) as {
+        version?: number
+        onLastWindowClosed?: string
+      }
+
+      // Only honor values written by the current app version. A newer or
+      // unsupported version is treated as a mismatch and falls back to default.
+      if (parsed.version === DEFAULT_SETTINGS.version) {
+        onLastWindowClosed = parsed.onLastWindowClosed
+      }
+    } catch {
+      // Missing or corrupt settings.json falls back to the platform default.
+    }
   }
 
   if (

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -217,7 +217,7 @@ let browserPaneController: BrowserPaneController | null = null
 let workspaceLayoutController: WorkspaceLayoutController | null = null
 let workspaceTeardown: WorkspaceTeardown | null = null
 let quitting = false
-let lastKnownSettings: AppSettings | undefined
+let lastKnownOnLastWindowClosed: string | undefined
 
 const RENDERER_DIAGNOSTIC_PREFIXES = [
   '[vimeflow:terminal-cwd]',
@@ -488,8 +488,13 @@ const setupApp = async (): Promise<void> => {
 
   ipcMain.handle(
     SETTINGS_SYNC_SNAPSHOT,
-    (_ipcEvent, settings: AppSettings): void => {
-      lastKnownSettings = settings
+    (_ipcEvent, settings: unknown): void => {
+      if (
+        isRecord(settings) &&
+        typeof settings.onLastWindowClosed === 'string'
+      ) {
+        lastKnownOnLastWindowClosed = settings.onLastWindowClosed
+      }
     }
   )
 
@@ -536,11 +541,11 @@ app.on('before-quit', (event) => {
 app.on('window-all-closed', () => {
   let onLastWindowClosed: string | undefined
 
-  if (lastKnownSettings !== undefined) {
+  if (lastKnownOnLastWindowClosed !== undefined) {
     // The renderer keeps this snapshot in sync whenever the user changes a
     // setting, so we can read the latest value without racing the async save
     // to disk / the Rust sidecar.
-    onLastWindowClosed = lastKnownSettings.onLastWindowClosed
+    onLastWindowClosed = lastKnownOnLastWindowClosed
   } else {
     try {
       const settingsPath = path.join(app.getPath('userData'), 'settings.json')

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,7 +12,6 @@ import { access } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import type { AppSettings } from '../src/bindings/AppSettings'
-import { DEFAULT_SETTINGS } from '../src/features/settings/store/settingsDefaults'
 import { isAllowedBackendMethod } from './backend-methods'
 import {
   developmentContentSecurityPolicy,
@@ -56,6 +55,12 @@ const APP_PROTOCOL = 'vimeflow'
 const APP_HOST = 'app'
 const APP_ORIGIN = `${APP_PROTOCOL}://${APP_HOST}`
 const E2E_RUNTIME_ARG = '--vimeflow-e2e'
+
+// Mirrors DEFAULT_SETTINGS.version in src/features/settings/store/settingsDefaults.ts
+// and CURRENT_APP_SETTINGS_VERSION in crates/backend/src/settings/app_settings.rs.
+// Kept local to the main process so Electron startup never depends on a renderer
+// feature module that may later gain browser-only runtime imports.
+const SETTINGS_SCHEMA_VERSION = 1
 
 // E2E detection (env var OR CLI flag fallback). Hoisted above its first
 // caller (installContentSecurityPolicy at ~line 80) so the TDZ never
@@ -548,7 +553,7 @@ app.on('window-all-closed', () => {
 
       // Only honor values written by the current app version. A newer or
       // unsupported version is treated as a mismatch and falls back to default.
-      if (parsed.version === DEFAULT_SETTINGS.version) {
+      if (parsed.version === SETTINGS_SCHEMA_VERSION) {
         onLastWindowClosed = parsed.onLastWindowClosed
       }
     } catch {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,6 +7,7 @@ import {
   session,
   shell,
 } from 'electron'
+import { readFileSync } from 'node:fs'
 import { access } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -32,6 +33,7 @@ import {
 } from './workspace-layout-controller'
 import { WorkspaceLayoutWriter } from './workspace-layout-writer'
 import { WorkspaceTeardown } from './workspace-teardown'
+import { shouldQuitOnAllWindowsClosed } from './last-window-close'
 import type { PersistedTab } from './workspace-layout-types'
 
 // Keep the GPU serving this window while it is occluded (covered by another
@@ -517,7 +519,23 @@ app.on('before-quit', (event) => {
 })
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+  let onLastWindowClosed: string | undefined
+
+  try {
+    const settingsPath = path.join(app.getPath('userData'), 'settings.json')
+    const raw = readFileSync(settingsPath, 'utf8')
+    const parsed = JSON.parse(raw) as { onLastWindowClosed?: string }
+    onLastWindowClosed = parsed.onLastWindowClosed
+  } catch {
+    // Missing or corrupt settings.json falls back to the platform default.
+  }
+
+  if (
+    shouldQuitOnAllWindowsClosed(
+      onLastWindowClosed ?? 'platform',
+      process.platform
+    )
+  ) {
     app.quit()
   }
 })

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,6 +4,7 @@ import {
   BACKEND_INVOKE,
   COMMAND_PALETTE_TOGGLE,
   SETTINGS_OPEN_FILE,
+  SETTINGS_SYNC_SNAPSHOT,
 } from './ipc-channels'
 import type { AppSettings } from '../src/bindings/AppSettings'
 import {
@@ -208,5 +209,7 @@ contextBridge.exposeInMainWorld('vimeflow', {
     save: (settings: AppSettings): Promise<void> =>
       invoke('save_app_settings', { settings }),
     openFile: (): Promise<void> => ipcRenderer.invoke(SETTINGS_OPEN_FILE),
+    syncSnapshot: (settings: AppSettings): Promise<void> =>
+      ipcRenderer.invoke(SETTINGS_SYNC_SNAPSHOT, settings),
   },
 })

--- a/src/features/settings/SettingsProvider.test.tsx
+++ b/src/features/settings/SettingsProvider.test.tsx
@@ -99,6 +99,42 @@ describe('SettingsProvider', () => {
     )
   })
 
+  test('syncs an in-memory snapshot to the main process on load and update', async () => {
+    const loaded = createLoadedSettings()
+    const load = vi.fn().mockResolvedValue(loaded)
+    const save = vi.fn().mockResolvedValue(undefined)
+    const syncSnapshot = vi.fn().mockResolvedValue(undefined)
+
+    window.vimeflow = {
+      settings: { load, save, openFile: vi.fn(), syncSnapshot },
+    } as unknown as Window['vimeflow']
+
+    render(
+      <SettingsProvider>
+        <TestConsumer />
+      </SettingsProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('closeWithNoTabs').textContent).toBe('close')
+    })
+
+    expect(syncSnapshot).toHaveBeenCalledWith(loaded)
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('closeWithNoTabs').textContent).toBe('nothing')
+    })
+
+    await waitFor(() => {
+      expect(syncSnapshot).toHaveBeenLastCalledWith(
+        expect.objectContaining({ closeWithNoTabs: 'nothing' })
+      )
+    })
+  })
+
   test('falls back to DEFAULT_SETTINGS when the bridge is absent', () => {
     render(
       <SettingsProvider>

--- a/src/features/settings/SettingsProvider.tsx
+++ b/src/features/settings/SettingsProvider.tsx
@@ -34,6 +34,26 @@ export const SettingsProvider = ({
 
   settingsRef.current = settings
 
+  const syncSnapshotToMain = useCallback(
+    async (next: AppSettings): Promise<void> => {
+      const bridge =
+        typeof window !== 'undefined' ? window.vimeflow?.settings : undefined
+
+      if (!bridge?.syncSnapshot) {
+        return
+      }
+
+      try {
+        await bridge.syncSnapshot(next)
+      } catch {
+        // Best-effort: the async save queue is still the source of truth for
+        // persistence; the snapshot only helps the main process avoid a race
+        // when the last window closes.
+      }
+    },
+    []
+  )
+
   useEffect(() => {
     const load = async (): Promise<void> => {
       const bridge =
@@ -47,13 +67,14 @@ export const SettingsProvider = ({
         const loaded = await bridge.load()
         setSettings(loaded)
         settingsRef.current = loaded
+        await syncSnapshotToMain(loaded)
       } catch {
         // Fall back to defaults if the backend load fails.
       }
     }
 
     void load()
-  }, [])
+  }, [syncSnapshotToMain])
 
   const saveNext = useCallback(
     async (previous: Promise<void>, next: AppSettings): Promise<void> => {
@@ -86,9 +107,10 @@ export const SettingsProvider = ({
       setSettings(next)
       setSaveError(null)
 
+      void syncSnapshotToMain(next)
       saveQueueRef.current = saveNext(saveQueueRef.current, next)
     },
-    [saveNext]
+    [saveNext, syncSnapshotToMain]
   )
 
   return (

--- a/src/features/settings/components/panes/GeneralPane.test.tsx
+++ b/src/features/settings/components/panes/GeneralPane.test.tsx
@@ -32,7 +32,9 @@ const createLoadedSettings = (): AppSettings => ({
   agentShimEnabled: false,
 })
 
-const installBridge = (loaded: AppSettings): { save: ReturnType<typeof vi.fn> } => {
+const installBridge = (
+  loaded: AppSettings
+): { save: ReturnType<typeof vi.fn> } => {
   const save = vi.fn().mockResolvedValue(undefined)
 
   window.vimeflow = {
@@ -59,6 +61,7 @@ describe('GeneralPane', () => {
     )
 
     expect(screen.getByText('General')).toBeInTheDocument()
+    expect(screen.getByText('General Settings')).toBeInTheDocument()
     expect(screen.getByText('When Closing With No Tabs')).toBeInTheDocument()
     expect(screen.getByText('On Last Window Closed')).toBeInTheDocument()
     expect(screen.getByText('Use System Path Prompts')).toBeInTheDocument()
@@ -77,7 +80,11 @@ describe('GeneralPane', () => {
     expect(screen.getByLabelText('When closing with no tabs')).toHaveValue(
       'platform'
     )
-    expect(screen.getByLabelText('On last window closed')).toHaveValue('platform')
+
+    expect(screen.getByLabelText('On last window closed')).toHaveValue(
+      'platform'
+    )
+
     expect(
       screen.getByRole('switch', { name: 'Use System Path Prompts' })
     ).toHaveAttribute('aria-checked', 'true')
@@ -122,7 +129,10 @@ describe('GeneralPane', () => {
     expect(
       screen.getByRole('switch', { name: 'Redact Private Values' })
     ).toHaveAttribute('aria-checked', 'true')
-    expect(screen.getByLabelText('CLI default open behavior')).toHaveValue('new')
+
+    expect(screen.getByLabelText('CLI default open behavior')).toHaveValue(
+      'new'
+    )
   })
 
   test('persists every control through the settings store (update)', async () => {
@@ -181,7 +191,10 @@ describe('GeneralPane', () => {
       )
     })
 
-    await user.click(screen.getByRole('switch', { name: 'Redact Private Values' }))
+    await user.click(
+      screen.getByRole('switch', { name: 'Redact Private Values' })
+    )
+
     await waitFor(() => {
       expect(save).toHaveBeenCalledWith(
         expect.objectContaining({ redactPrivateValues: true })

--- a/src/features/settings/components/panes/GeneralPane.test.tsx
+++ b/src/features/settings/components/panes/GeneralPane.test.tsx
@@ -1,19 +1,64 @@
-import { describe, expect, test } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactElement, ReactNode } from 'react'
+import type { AppSettings } from '../../../../bindings/AppSettings'
+import { SettingsProvider } from '../../SettingsProvider'
+import { DEFAULT_SETTINGS } from '../../store/settingsDefaults'
 import { GeneralPane } from './GeneralPane'
 
-describe('GeneralPane', () => {
-  test('renders the pane title', () => {
-    render(<GeneralPane />)
+interface TestWrapperProps {
+  children: ReactNode
+}
 
-    expect(screen.getByText('General')).toBeInTheDocument()
-    expect(screen.getByText('General Settings')).toBeInTheDocument()
+const TestWrapper = ({ children }: TestWrapperProps): ReactElement => (
+  <SettingsProvider>{children}</SettingsProvider>
+)
+
+const createLoadedSettings = (): AppSettings => ({
+  version: 1,
+  closeWithNoTabs: 'close',
+  onLastWindowClosed: 'quit',
+  useSystemPathPrompts: false,
+  useSystemPrompts: false,
+  redactPrivateValues: true,
+  cliOpenBehavior: 'new',
+  aesthetic: 'obsidian',
+  accentHue: 285,
+  density: 'compact',
+  uiFont: 'inter',
+  monoFont: 'fira',
+  keymapPreset: 'vscode',
+  agentShimEnabled: false,
+})
+
+const installBridge = (loaded: AppSettings): { save: ReturnType<typeof vi.fn> } => {
+  const save = vi.fn().mockResolvedValue(undefined)
+
+  window.vimeflow = {
+    settings: {
+      load: vi.fn().mockResolvedValue(loaded),
+      save,
+      openFile: vi.fn(),
+    },
+  } as unknown as Window['vimeflow']
+
+  return { save }
+}
+
+describe('GeneralPane', () => {
+  afterEach(() => {
+    delete window.vimeflow
   })
 
-  test('renders all setting rows', () => {
-    render(<GeneralPane />)
+  test('renders the pane title and all setting rows', () => {
+    render(
+      <TestWrapper>
+        <GeneralPane />
+      </TestWrapper>
+    )
 
+    expect(screen.getByText('General')).toBeInTheDocument()
     expect(screen.getByText('When Closing With No Tabs')).toBeInTheDocument()
     expect(screen.getByText('On Last Window Closed')).toBeInTheDocument()
     expect(screen.getByText('Use System Path Prompts')).toBeInTheDocument()
@@ -22,27 +67,136 @@ describe('GeneralPane', () => {
     expect(screen.getByText('CLI Default Open Behavior')).toBeInTheDocument()
   })
 
-  test('toggles Redact Private Values when its toggle is clicked', async () => {
-    const user = userEvent.setup()
-    render(<GeneralPane />)
+  test('reflects default settings when no bridge is present', () => {
+    render(
+      <TestWrapper>
+        <GeneralPane />
+      </TestWrapper>
+    )
 
-    const toggle = screen.getByRole('switch', {
-      name: 'Redact Private Values',
-    })
-    expect(toggle).toHaveClass('bg-outline-variant/50')
+    expect(screen.getByLabelText('When closing with no tabs')).toHaveValue(
+      'platform'
+    )
+    expect(screen.getByLabelText('On last window closed')).toHaveValue('platform')
+    expect(
+      screen.getByRole('switch', { name: 'Use System Path Prompts' })
+    ).toHaveAttribute('aria-checked', 'true')
 
-    await user.click(toggle)
+    expect(
+      screen.getByRole('switch', { name: 'Use System Prompts' })
+    ).toHaveAttribute('aria-checked', 'true')
 
-    expect(toggle).toHaveClass('bg-primary-container')
+    expect(
+      screen.getByRole('switch', { name: 'Redact Private Values' })
+    ).toHaveAttribute('aria-checked', 'false')
+
+    expect(screen.getByLabelText('CLI default open behavior')).toHaveValue(
+      'existing'
+    )
   })
 
-  test('changes the close-no-tabs select value', async () => {
+  test('reflects loaded settings from the store (read)', async () => {
+    installBridge(createLoadedSettings())
+
+    render(
+      <TestWrapper>
+        <GeneralPane />
+      </TestWrapper>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('When closing with no tabs')).toHaveValue(
+        'close'
+      )
+    })
+
+    expect(screen.getByLabelText('On last window closed')).toHaveValue('quit')
+    expect(
+      screen.getByRole('switch', { name: 'Use System Path Prompts' })
+    ).toHaveAttribute('aria-checked', 'false')
+
+    expect(
+      screen.getByRole('switch', { name: 'Use System Prompts' })
+    ).toHaveAttribute('aria-checked', 'false')
+
+    expect(
+      screen.getByRole('switch', { name: 'Redact Private Values' })
+    ).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByLabelText('CLI default open behavior')).toHaveValue('new')
+  })
+
+  test('persists every control through the settings store (update)', async () => {
+    const { save } = installBridge(DEFAULT_SETTINGS)
     const user = userEvent.setup()
-    render(<GeneralPane />)
 
-    const select = screen.getByLabelText('When closing with no tabs')
-    await user.selectOptions(select, 'nothing')
+    render(
+      <TestWrapper>
+        <GeneralPane />
+      </TestWrapper>
+    )
 
-    expect(select).toHaveValue('nothing')
+    // Wait for the provider to hydrate from load() before exercising controls.
+    await waitFor(() => {
+      expect(screen.getByLabelText('When closing with no tabs')).toHaveValue(
+        'platform'
+      )
+    })
+
+    await user.selectOptions(
+      screen.getByLabelText('When closing with no tabs'),
+      'nothing'
+    )
+
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledWith(
+        expect.objectContaining({ closeWithNoTabs: 'nothing' })
+      )
+    })
+
+    await user.selectOptions(
+      screen.getByLabelText('On last window closed'),
+      'quit'
+    )
+
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledWith(
+        expect.objectContaining({ onLastWindowClosed: 'quit' })
+      )
+    })
+
+    await user.click(
+      screen.getByRole('switch', { name: 'Use System Path Prompts' })
+    )
+
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledWith(
+        expect.objectContaining({ useSystemPathPrompts: false })
+      )
+    })
+
+    await user.click(screen.getByRole('switch', { name: 'Use System Prompts' }))
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledWith(
+        expect.objectContaining({ useSystemPrompts: false })
+      )
+    })
+
+    await user.click(screen.getByRole('switch', { name: 'Redact Private Values' }))
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledWith(
+        expect.objectContaining({ redactPrivateValues: true })
+      )
+    })
+
+    await user.selectOptions(
+      screen.getByLabelText('CLI default open behavior'),
+      'new'
+    )
+
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledWith(
+        expect.objectContaining({ cliOpenBehavior: 'new' })
+      )
+    })
   })
 })

--- a/src/features/settings/components/panes/GeneralPane.tsx
+++ b/src/features/settings/components/panes/GeneralPane.tsx
@@ -1,13 +1,9 @@
-import { useState, type ReactElement } from 'react'
+import type { ReactElement } from 'react'
+import { useSettings } from '../../hooks/useSettings'
 import { PaneTitle, Row, Select, Toggle } from '../controls'
 
 export const GeneralPane = (): ReactElement => {
-  const [closeNoTabs, setCloseNoTabs] = useState('platform')
-  const [lastWindow, setLastWindow] = useState('platform')
-  const [systemPathPrompts, setSystemPathPrompts] = useState(true)
-  const [systemPrompts, setSystemPrompts] = useState(true)
-  const [redactPrivate, setRedactPrivate] = useState(false)
-  const [cliOpenBehavior, setCliOpenBehavior] = useState('existing')
+  const { settings, update } = useSettings()
 
   return (
     <>
@@ -18,8 +14,8 @@ export const GeneralPane = (): ReactElement => {
         hint="What to do when using the 'close active item' action with no tabs."
       >
         <Select
-          value={closeNoTabs}
-          onChange={setCloseNoTabs}
+          value={settings.closeWithNoTabs}
+          onChange={(value): void => update({ closeWithNoTabs: value })}
           aria-label="When closing with no tabs"
           options={[
             { id: 'platform', label: 'Platform Default' },
@@ -34,8 +30,8 @@ export const GeneralPane = (): ReactElement => {
         hint="What to do when the last window is closed."
       >
         <Select
-          value={lastWindow}
-          onChange={setLastWindow}
+          value={settings.onLastWindowClosed}
+          onChange={(value): void => update({ onLastWindowClosed: value })}
           aria-label="On last window closed"
           options={[
             { id: 'platform', label: 'Platform Default' },
@@ -49,8 +45,8 @@ export const GeneralPane = (): ReactElement => {
         hint="Use native OS dialogs for 'Open' and 'Save As'."
       >
         <Toggle
-          on={systemPathPrompts}
-          onChange={setSystemPathPrompts}
+          on={settings.useSystemPathPrompts}
+          onChange={(value): void => update({ useSystemPathPrompts: value })}
           aria-label="Use System Path Prompts"
         />
       </Row>
@@ -60,8 +56,8 @@ export const GeneralPane = (): ReactElement => {
         hint="Use native OS dialogs for confirmations."
       >
         <Toggle
-          on={systemPrompts}
-          onChange={setSystemPrompts}
+          on={settings.useSystemPrompts}
+          onChange={(value): void => update({ useSystemPrompts: value })}
           aria-label="Use System Prompts"
         />
       </Row>
@@ -71,8 +67,8 @@ export const GeneralPane = (): ReactElement => {
         hint="Hide the values of variables in private files."
       >
         <Toggle
-          on={redactPrivate}
-          onChange={setRedactPrivate}
+          on={settings.redactPrivateValues}
+          onChange={(value): void => update({ redactPrivateValues: value })}
           aria-label="Redact Private Values"
         />
       </Row>
@@ -83,8 +79,8 @@ export const GeneralPane = (): ReactElement => {
         last
       >
         <Select
-          value={cliOpenBehavior}
-          onChange={setCliOpenBehavior}
+          value={settings.cliOpenBehavior}
+          onChange={(value): void => update({ cliOpenBehavior: value })}
           aria-label="CLI default open behavior"
           options={[
             { id: 'existing', label: 'Add to Existing Window' },
@@ -92,6 +88,15 @@ export const GeneralPane = (): ReactElement => {
           ]}
         />
       </Row>
+
+      {/*
+        Persistence-only settings note:
+        closeWithNoTabs, useSystemPathPrompts, useSystemPrompts,
+        redactPrivateValues, and cliOpenBehavior are persisted through the
+        settings store above, but the app does not yet have runtime surfaces
+        that honor them (no native OS dialogs, no private-value redaction,
+        and no `vf` CLI). They will light up as those respective features land.
+      */}
     </>
   )
 }

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -17,6 +17,7 @@ export interface SettingsBridge {
   load: () => Promise<AppSettings>
   save: (settings: AppSettings) => Promise<void>
   openFile: () => Promise<void>
+  syncSnapshot: (settings: AppSettings) => Promise<void>
 }
 
 export interface BackendApi {


### PR DESCRIPTION
## Summary

Make the **General** settings pane functional — migrate it from local `useState` to the
`useSettings()` store (VIM-100) so all six controls persist to `settings.json`, and wire the
one control with a real runtime hook (**On Last Window Closed**) into Electron's
`window-all-closed` path.

Closes VIM-101. Targets `feat/settings`.

## What's included
- **GeneralPane** consumes `useSettings()`; each control binds to `settings.<field>` and writes
  via `update({ field })` — all six round-trip through the store.
- **On Last Window Closed (real behavior)**: `electron/last-window-close.ts` —
  `shouldQuitOnAllWindowsClosed(value, platform)` (`'quit'` → always quit; otherwise the platform
  default). `main.ts` `window-all-closed` reads `{userData}/settings.json` shutdown-safe
  (try/catch → `'platform'`) and delegates to the helper.
- **Persistence-only (documented)**: the other five controls (close-with-no-tabs, system path
  prompts, system prompts, redact private values, CLI open behavior) persist but the app has no
  feature that consumes them yet — flagged with a clear comment, not a silent no-op.

## Verification
- type-check ✅ · eslint (settings + electron) ✅ · settings vitest **101** · helper test **2**
- The pane test asserts both **read** (loads custom settings → all six reflect) and **persist**
  (`save()` called with each of the six fields), so it fails against the old local-state pane.
- codex-reviewed (`complete: true`).

## Scope note
General only. VIM-102 (Appearance/theming), VIM-103 (Coding Agents), VIM-104 (Keymap) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
