### PR TITLE
[codex] ensure Linear issue links on QA PRs

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -84,3 +84,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Persisted State Invariants](patterns/persisted-state-invariants.md) | correctness        | 6        | 3    | 2026-06-08   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)               | cross-platform     | 8        | 2    | 2026-06-11   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)     | correctness        | 1        | 0    | 2026-06-11   |
+| [Identifier Prefix Matching](patterns/identifier-prefix-matching.md) | correctness        | 2        | 0    | 2026-06-12   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -84,4 +84,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Persisted State Invariants](patterns/persisted-state-invariants.md) | correctness        | 6        | 3    | 2026-06-08   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)               | cross-platform     | 8        | 2    | 2026-06-11   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)     | correctness        | 1        | 0    | 2026-06-11   |
-| [Identifier Prefix Matching](patterns/identifier-prefix-matching.md) | correctness        | 2        | 0    | 2026-06-12   |
+| [Identifier Prefix Matching](patterns/identifier-prefix-matching.md) | correctness        | 3        | 1    | 2026-06-12   |

--- a/docs/reviews/patterns/identifier-prefix-matching.md
+++ b/docs/reviews/patterns/identifier-prefix-matching.md
@@ -3,7 +3,7 @@ id: identifier-prefix-matching
 category: correctness
 created: 2026-06-12
 last_updated: 2026-06-12
-ref_count: 0
+ref_count: 1
 ---
 
 # Identifier Prefix Matching
@@ -48,5 +48,23 @@ the returned record really refers to the intended entity before reusing it.
   `nodes[0]` linked the wrong PR to the existing Linear issue.
 - **Fix:** Same as finding 1: search with the created-title delimiter
   `PR #${prNumber}:` and verify the returned issue before reuse.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on
+  this line)
+
+### 3. findIssueForPr: post-fetch guard only checked on `nodes[0]`
+
+- **Source:** github-claude | PR #434 round 2 | 2026-06-12
+- **Severity:** MEDIUM
+- **File:** `scripts/qa-runner/lib/linear-client.mjs` L96-103
+- **Finding:** After round 1 added a post-fetch guard, the helper still
+  assigned only `d.issues.nodes[0]` to `candidate` and returned `null` when
+  that single node failed the guard. Because the GraphQL query requests
+  `first:10`, a false-positive node at position 0 could hide the real
+  auto-created issue at `nodes[1+]` and cause `ensureLinearLink` to create
+  a duplicate Linear issue.
+- **Fix:** Compute `expectedPrLine` once, then use `d.issues.nodes.find(...)`
+  to return the first node whose title starts with `PR #${prNumber}:` or
+  whose description contains the exact `PR: <url>\n` line, falling back to
+  `null` when none match.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on
   this line)

--- a/docs/reviews/patterns/identifier-prefix-matching.md
+++ b/docs/reviews/patterns/identifier-prefix-matching.md
@@ -1,0 +1,52 @@
+---
+id: identifier-prefix-matching
+category: correctness
+created: 2026-06-12
+last_updated: 2026-06-12
+ref_count: 0
+---
+
+# Identifier Prefix Matching
+
+## Summary
+
+When matching records by a numeric identifier through a substring or
+`contains` search, a shorter number can falsely match a longer one that
+starts with the same digits (e.g. `31` matching `317`). Always include an
+unambiguous delimiter in the search term — such as the colon after a title
+prefix or a newline after a URL — and add a post-fetch guard that verifies
+the returned record really refers to the intended entity before reusing it.
+
+## Findings
+
+### 1. findIssueForPr: 'contains' filter falsely matches numerically-related PR issues
+
+- **Source:** github-claude | PR #434 round 1 | 2026-06-12
+- **Severity:** HIGH
+- **File:** `scripts/qa-runner/lib/linear-client.mjs` L90-97
+- **Finding:** `findIssueForPr` searched Linear issues with an `or` filter
+  using `description:{contains:prUrl}` and `title:{contains:titlePrefix}`.
+  Because Linear's `contains` is a substring match, `/pull/31` matches
+  `/pull/317` and `PR #31` matches `PR #317: ...`. `nodes[0]` then returned
+  the wrong issue, causing a lower-numbered PR to be patched with a higher-
+  numbered PR's Linear identifier.
+- **Fix:** Changed the URL search term to `${prUrl}\n` and the title prefix
+  to `PR #${prNumber}:`, then added a post-fetch guard that requires either
+  an exact title prefix or the expected `PR: <url>\n` line in the issue
+  description before returning a candidate.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on
+  this line)
+
+### 2. Avoid matching PR titles by numeric prefix
+
+- **Source:** github-codex-connector | PR #434 round 1 | 2026-06-12
+- **Severity:** P2 / MEDIUM
+- **File:** `scripts/qa-runner/lib/linear-client.mjs` L94
+- **Finding:** When no exact URL match existed, the title-prefix query
+  `title contains "PR #43"` could return an automatically-created issue
+  for PR #433 because `PR #433: ...` contains `PR #43`. Accepting
+  `nodes[0]` linked the wrong PR to the existing Linear issue.
+- **Fix:** Same as finding 1: search with the created-title delimiter
+  `PR #${prNumber}:` and verify the returned issue before reuse.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on
+  this line)

--- a/scripts/qa-runner/README.md
+++ b/scripts/qa-runner/README.md
@@ -20,8 +20,10 @@ Design + rationale: [`docs/explorations/linear-agent-cicd-pilot.html`](../../doc
                  │
                  ▼
  ③ Linear  — control plane / observability. Each state transition mirrors to the
-    linked issue (a `VIM-N` in the PR body). The native GitHub↔Linear sync moves
-    the issue → Done on merge; the watcher's own posts use the `linear.env` API key
+    linked issue (a `VIM-N` in the PR body). Armed runs ensure that link first:
+    if the PR body has no `VIM-N`, the watcher finds/creates a Linear issue and
+    patches the PR body with `Refs VIM-N`. The native GitHub↔Linear sync moves the
+    issue → Done on merge; the watcher's own posts use the `linear.env` API key
     (headless ⇒ scoped API key, not interactive MCP — see
     rules/common/linear-workflow.md) and no-op gracefully when no key is set.
 ```
@@ -84,11 +86,15 @@ node scripts/qa-runner/watch.mjs scan --pr 317   # a single PR
 node scripts/qa-runner/watch.mjs tick            # classify every eligible PR, do nothing
 node scripts/qa-runner/watch.mjs tick --pr 317   # classify one PR
 
+# explicitly ensure Linear PR-body links without fixing/merging
+node scripts/qa-runner/watch.mjs tick --ensure-linear
+
 # arm the actions (each is independent and opt-in)
 node scripts/qa-runner/watch.mjs tick --execute            # NEEDS_FIX  → run upsource cycles (parallel, cap 2)
 node scripts/qa-runner/watch.mjs tick --execute --max 3    # …up to 3 at once
 node scripts/qa-runner/watch.mjs tick --approve            # GOOD_SHAPE → squash-merge
 node scripts/qa-runner/watch.mjs tick --execute --approve  # full autonomy
+node scripts/qa-runner/watch.mjs tick --ensure-linear --linear-team VIM
 
 # loop forever (Ctrl-C to stop)
 node scripts/qa-runner/watch.mjs watch --execute --approve
@@ -99,8 +105,9 @@ default**, `--push` arms the live path, and it adopts the fixer bot identity fro
 `bot.env` if present:
 
 ```bash
-node scripts/qa-runner/run.mjs 317          # dry-run: kimi fixes + codex gate, nothing pushed
-node scripts/qa-runner/run.mjs 317 --push   # live: commit/push as the fixer bot, reply/resolve, Linear status
+node scripts/qa-runner/run.mjs 317                       # dry-run: kimi fixes + codex gate, nothing pushed
+node scripts/qa-runner/run.mjs 317 --push                # live: commit/push as the fixer bot, reply/resolve, Linear status
+node scripts/qa-runner/run.mjs 317 --push --linear-team VIM
 ```
 
 ## Host (v1 → v2)
@@ -130,6 +137,8 @@ commit author (`GIT_AUTHOR_*`), and HTTPS push (the `gh` credential helper).
 
 - **Opt-in only** (`auto-review` label) — narrow blast radius for the pilot.
 - **Report-only by default** — `--execute` / `--approve` must be passed explicitly.
+- `scan` is always read-only. PR-body patching only happens with `--ensure-linear`,
+  `--execute`, or `--approve`.
 - **One run per PR** — lock files under `.locks/` (gitignored); concurrency capped at `--max` (2).
 - kimi works **only on the PR branch in an isolated worktree**; never `main`, never `--force`.
 - **codex gate + bounded retry** before any commit.

--- a/scripts/qa-runner/lib/linear-client.mjs
+++ b/scripts/qa-runner/lib/linear-client.mjs
@@ -93,14 +93,16 @@ export const findIssueForPr = async (key, { teamKey, prNumber, prUrl }) => {
     'query($teamKey:String!,$url:String!,$titlePrefix:String!){issues(filter:{team:{key:{eqIgnoreCase:$teamKey}},or:[{description:{contains:$url}},{title:{contains:$titlePrefix}}]},first:10){nodes{id identifier title url description}}}',
     { teamKey, url: `${prUrl}\n`, titlePrefix: `PR #${prNumber}:` }
   )
-  const candidate = d.issues.nodes[0]
-  if (!candidate) return null
   const expectedPrLine = `PR: ${prUrl}\n`
-  const titleOk = candidate.title?.startsWith(`PR #${prNumber}:`) ?? false
-  const descriptionOk =
-    typeof candidate.description === 'string' &&
-    candidate.description.includes(expectedPrLine)
-  return titleOk || descriptionOk ? candidate : null
+  return (
+    d.issues.nodes.find((candidate) => {
+      const titleOk = candidate.title?.startsWith(`PR #${prNumber}:`) ?? false
+      const descriptionOk =
+        typeof candidate.description === 'string' &&
+        candidate.description.includes(expectedPrLine)
+      return titleOk || descriptionOk
+    }) ?? null
+  )
 }
 
 export const createIssueForPr = async (

--- a/scripts/qa-runner/lib/linear-client.mjs
+++ b/scripts/qa-runner/lib/linear-client.mjs
@@ -90,10 +90,17 @@ export const teamByKey = async (key, teamKey) => {
 export const findIssueForPr = async (key, { teamKey, prNumber, prUrl }) => {
   const d = await gql(
     key,
-    'query($teamKey:String!,$url:String!,$titlePrefix:String!){issues(filter:{team:{key:{eqIgnoreCase:$teamKey}},or:[{description:{contains:$url}},{title:{contains:$titlePrefix}}]},first:10){nodes{id identifier title url}}}',
-    { teamKey, url: prUrl, titlePrefix: `PR #${prNumber}` }
+    'query($teamKey:String!,$url:String!,$titlePrefix:String!){issues(filter:{team:{key:{eqIgnoreCase:$teamKey}},or:[{description:{contains:$url}},{title:{contains:$titlePrefix}}]},first:10){nodes{id identifier title url description}}}',
+    { teamKey, url: `${prUrl}\n`, titlePrefix: `PR #${prNumber}:` }
   )
-  return d.issues.nodes[0]
+  const candidate = d.issues.nodes[0]
+  if (!candidate) return null
+  const expectedPrLine = `PR: ${prUrl}\n`
+  const titleOk = candidate.title?.startsWith(`PR #${prNumber}:`) ?? false
+  const descriptionOk =
+    typeof candidate.description === 'string' &&
+    candidate.description.includes(expectedPrLine)
+  return titleOk || descriptionOk ? candidate : null
 }
 
 export const createIssueForPr = async (

--- a/scripts/qa-runner/lib/linear-client.mjs
+++ b/scripts/qa-runner/lib/linear-client.mjs
@@ -1,0 +1,124 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+export const API = 'https://api.linear.app/graphql'
+
+export const loadKey = () => {
+  if (process.env.LINEAR_API_KEY) return process.env.LINEAR_API_KEY
+  const root = dirname(
+    execFileSync(
+      'git',
+      ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+      {
+        encoding: 'utf8',
+      }
+    ).trim()
+  )
+  const envFile = join(root, 'linear.env')
+  if (existsSync(envFile)) {
+    const m = readFileSync(envFile, 'utf8').match(
+      /^\s*(?:export\s+)?LINEAR_API_KEY\s*=\s*(.+?)\s*$/m
+    )
+    if (m) return m[1].replace(/^["']|["']$/g, '')
+  }
+  throw new Error(
+    'LINEAR_API_KEY not set (env or repo-root linear.env). See rules/common/linear-workflow.md'
+  )
+}
+
+export const gql = async (key, query, variables) => {
+  const res = await fetch(API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: key },
+    body: JSON.stringify({ query, variables }),
+  })
+  const json = await res.json()
+  if (json.errors?.length) {
+    throw new Error(
+      `Linear GraphQL: ${json.errors.map((e) => e.message).join('; ')}`
+    )
+  }
+  return json.data
+}
+
+export const issueByIdentifier = async (key, identifier) => {
+  const d = await gql(
+    key,
+    'query($id:String!){issue(id:$id){id identifier team{id}}}',
+    { id: identifier }
+  )
+  return d.issue
+}
+
+export const commentIssue = (key, issueId, body) =>
+  gql(
+    key,
+    'mutation($id:String!,$body:String!){commentCreate(input:{issueId:$id,body:$body}){success}}',
+    { id: issueId, body }
+  )
+
+export const workflowStateByName = async (key, teamId, stateName) => {
+  const s = await gql(
+    key,
+    'query($t:String!){workflowStates(filter:{team:{id:{eq:$t}}}){nodes{id name}}}',
+    { t: teamId }
+  )
+  return s.workflowStates.nodes.find(
+    (n) => n.name.toLowerCase() === stateName.toLowerCase()
+  )
+}
+
+export const updateIssueState = (key, issueId, stateId) =>
+  gql(
+    key,
+    'mutation($id:String!,$s:String!){issueUpdate(id:$id,input:{stateId:$s}){success}}',
+    { id: issueId, s: stateId }
+  )
+
+export const teamByKey = async (key, teamKey) => {
+  const d = await gql(
+    key,
+    'query($key:String!){teams(filter:{key:{eqIgnoreCase:$key}},first:2){nodes{id key name}}}',
+    { key: teamKey }
+  )
+  const team = d.teams.nodes[0]
+  if (!team) throw new Error(`Linear team key "${teamKey}" not found`)
+  return team
+}
+
+export const findIssueForPr = async (key, { teamKey, prNumber, prUrl }) => {
+  const d = await gql(
+    key,
+    'query($teamKey:String!,$url:String!,$titlePrefix:String!){issues(filter:{team:{key:{eqIgnoreCase:$teamKey}},or:[{description:{contains:$url}},{title:{contains:$titlePrefix}}]},first:10){nodes{id identifier title url}}}',
+    { teamKey, url: prUrl, titlePrefix: `PR #${prNumber}` }
+  )
+  return d.issues.nodes[0]
+}
+
+export const createIssueForPr = async (
+  key,
+  { teamId, prNumber, title, url, headRefName, repo }
+) => {
+  const d = await gql(
+    key,
+    'mutation($input:IssueCreateInput!){issueCreate(input:$input){success issue{id identifier title url}}}',
+    {
+      input: {
+        teamId,
+        title: `PR #${prNumber}: ${title}`,
+        description: [
+          `Created automatically for GitHub PR #${prNumber}.`,
+          '',
+          `PR: ${url}`,
+          `Repository: ${repo}`,
+          `Branch: ${headRefName}`,
+        ].join('\n'),
+      },
+    }
+  )
+  if (!d.issueCreate.success || !d.issueCreate.issue) {
+    throw new Error(`Linear issueCreate failed for PR #${prNumber}`)
+  }
+  return d.issueCreate.issue
+}

--- a/scripts/qa-runner/lib/linear-pr-link.mjs
+++ b/scripts/qa-runner/lib/linear-pr-link.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Ensure a PR has a Linear issue identifier in its body. If the PR body lacks a
+// VIM-N reference, find/create a Linear issue and patch the PR body with `Refs`.
+
+import { execFileSync } from 'node:child_process'
+import {
+  createIssueForPr,
+  findIssueForPr,
+  loadKey,
+  teamByKey,
+} from './linear-client.mjs'
+import { bodyWithLinearReference, linkedVim } from './pr-utils.mjs'
+
+const sh = (cmd, args, opts = {}) =>
+  execFileSync(cmd, args, {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    ...opts,
+  })
+
+const ghJson = (args, opts) => JSON.parse(sh('gh', args, opts))
+
+const patchPrBody = (repo, prNumber, body) => {
+  sh(
+    'gh',
+    [
+      'api',
+      '--method',
+      'PATCH',
+      `repos/${repo}/pulls/${prNumber}`,
+      '--input',
+      '-',
+    ],
+    { input: JSON.stringify({ body }) }
+  )
+}
+
+const main = async () => {
+  const argv = process.argv.slice(2)
+  const prNumber = Number(argv.find((a) => /^\d+$/.test(a)))
+  if (!prNumber) {
+    throw new Error('usage: linear-pr-link.mjs <PR#> [--team VIM]')
+  }
+  const teamArg = argv.indexOf('--team')
+  const teamKey = teamArg >= 0 ? argv[teamArg + 1] : 'VIM'
+  if (!teamKey) throw new Error('--team requires a Linear team key')
+
+  const pr = ghJson([
+    'pr',
+    'view',
+    String(prNumber),
+    '--json',
+    'number,title,body,url,headRefName',
+  ])
+  const existing = linkedVim(pr.body)
+  if (existing) {
+    process.stdout.write(
+      JSON.stringify({
+        identifier: existing,
+        created: false,
+        prPatched: false,
+        alreadyLinked: true,
+      }) + '\n'
+    )
+    return
+  }
+
+  const repo = ghJson(['repo', 'view', '--json', 'nameWithOwner']).nameWithOwner
+  const key = loadKey()
+  const team = await teamByKey(key, teamKey)
+  let issue = await findIssueForPr(key, {
+    teamKey,
+    prNumber,
+    prUrl: pr.url,
+  })
+  const created = !issue
+  if (!issue) {
+    issue = await createIssueForPr(key, {
+      teamId: team.id,
+      prNumber,
+      title: pr.title,
+      url: pr.url,
+      headRefName: pr.headRefName,
+      repo,
+    })
+  }
+
+  const nextBody = bodyWithLinearReference(pr.body, issue.identifier)
+  patchPrBody(repo, prNumber, nextBody)
+  process.stdout.write(
+    JSON.stringify({
+      identifier: issue.identifier,
+      created,
+      prPatched: true,
+      alreadyLinked: false,
+      issueUrl: issue.url,
+    }) + '\n'
+  )
+}
+
+main().catch((e) => {
+  process.stderr.write(`${e.message}\n`)
+  process.exit(1)
+})

--- a/scripts/qa-runner/lib/linear-status.mjs
+++ b/scripts/qa-runner/lib/linear-status.mjs
@@ -6,49 +6,13 @@
 //
 // Usage: node linear-status.mjs <VIM-N> "<comment markdown>" [--state "<name>"]
 
-import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-
-const API = 'https://api.linear.app/graphql'
-
-const loadKey = () => {
-  if (process.env.LINEAR_API_KEY) return process.env.LINEAR_API_KEY
-  const root = dirname(
-    execFileSync(
-      'git',
-      ['rev-parse', '--path-format=absolute', '--git-common-dir'],
-      {
-        encoding: 'utf8',
-      }
-    ).trim()
-  )
-  const envFile = join(root, 'linear.env')
-  if (existsSync(envFile)) {
-    const m = readFileSync(envFile, 'utf8').match(
-      /^\s*(?:export\s+)?LINEAR_API_KEY\s*=\s*(.+?)\s*$/m
-    )
-    if (m) return m[1].replace(/^["']|["']$/g, '')
-  }
-  throw new Error(
-    'LINEAR_API_KEY not set (env or repo-root linear.env). See rules/common/linear-workflow.md'
-  )
-}
-
-const gql = async (key, query, variables) => {
-  const res = await fetch(API, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: key },
-    body: JSON.stringify({ query, variables }),
-  })
-  const json = await res.json()
-  if (json.errors?.length) {
-    throw new Error(
-      `Linear GraphQL: ${json.errors.map((e) => e.message).join('; ')}`
-    )
-  }
-  return json.data
-}
+import {
+  commentIssue,
+  issueByIdentifier,
+  loadKey,
+  updateIssueState,
+  workflowStateByName,
+} from './linear-client.mjs'
 
 const main = async () => {
   const [identifier, body, ...rest] = process.argv.slice(2)
@@ -62,35 +26,16 @@ const main = async () => {
     : undefined
   const key = loadKey()
 
-  const d = await gql(
-    key,
-    'query($id:String!){issue(id:$id){id identifier team{id}}}',
-    { id: identifier }
-  )
-  if (!d.issue) throw new Error(`issue ${identifier} not found`)
+  const issue = await issueByIdentifier(key, identifier)
+  if (!issue) throw new Error(`issue ${identifier} not found`)
 
-  await gql(
-    key,
-    'mutation($id:String!,$body:String!){commentCreate(input:{issueId:$id,body:$body}){success}}',
-    { id: d.issue.id, body }
-  )
+  await commentIssue(key, issue.id, body)
   process.stdout.write(`commented on ${identifier}\n`)
 
   if (stateName) {
-    const s = await gql(
-      key,
-      'query($t:String!){workflowStates(filter:{team:{id:{eq:$t}}}){nodes{id name}}}',
-      { t: d.issue.team.id }
-    )
-    const st = s.workflowStates.nodes.find(
-      (n) => n.name.toLowerCase() === stateName.toLowerCase()
-    )
+    const st = await workflowStateByName(key, issue.team.id, stateName)
     if (!st) throw new Error(`state "${stateName}" not found for the team`)
-    await gql(
-      key,
-      'mutation($id:String!,$s:String!){issueUpdate(id:$id,input:{stateId:$s}){success}}',
-      { id: d.issue.id, s: st.id }
-    )
+    await updateIssueState(key, issue.id, st.id)
     process.stdout.write(`moved ${identifier} → ${st.name}\n`)
   }
 }

--- a/scripts/qa-runner/lib/pr-utils.mjs
+++ b/scripts/qa-runner/lib/pr-utils.mjs
@@ -8,3 +8,12 @@ export const linkedVim = (body) => {
   const closing = b.match(/\b(?:closes|fixes|resolves)\s+(VIM-\d+)\b/i)
   return (closing?.[1] || b.match(/\bVIM-\d+\b/i)?.[0])?.toUpperCase()
 }
+
+export const bodyWithLinearReference = (body, identifier) => {
+  const current = body || ''
+  const id = identifier?.toUpperCase()
+  if (!id || linkedVim(current)) return current
+  const trimmed = current.trimEnd()
+  const reference = `Refs ${id}`
+  return trimmed ? `${trimmed}\n\n${reference}\n` : `${reference}\n`
+}

--- a/scripts/qa-runner/run.mjs
+++ b/scripts/qa-runner/run.mjs
@@ -37,6 +37,7 @@ import { linkedVim } from './lib/pr-utils.mjs'
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const LOCK_DIR = join(SCRIPT_DIR, '.locks')
 const KIMI_TIMEOUT_MS = 45 * 60 * 1000
+const DEFAULT_LINEAR_TEAM_KEY = 'VIM'
 
 const out = (s = '') => process.stdout.write(`${s}\n`)
 const die = (s, code = 1) => {
@@ -50,6 +51,32 @@ const sh = (cmd, args, opts = {}) =>
     maxBuffer: 32 * 1024 * 1024,
     ...opts,
   })
+
+const ensureLinearLink = (pr, teamKey) => {
+  const r = spawnSync(
+    'node',
+    [
+      join(SCRIPT_DIR, 'lib', 'linear-pr-link.mjs'),
+      String(pr),
+      '--team',
+      teamKey,
+    ],
+    { encoding: 'utf8' }
+  )
+  if (r.status !== 0) {
+    out(
+      `Linear link skipped (${(r.stderr || '').trim().split('\n')[0] || 'linear-pr-link failed'})`
+    )
+    return null
+  }
+  const linked = JSON.parse(r.stdout)
+  if (linked.prPatched) {
+    out(
+      `Linear ${linked.identifier}: ${linked.created ? 'created' : 'found'} + patched PR body`
+    )
+  }
+  return linked.identifier
+}
 
 // Latest lifeline version in the plugin cache that ships the skill.
 const lifelineSkillsDir = () => {
@@ -162,7 +189,7 @@ const invocation = (pr, live) => {
   )
 }
 
-const run = (pr, live) => {
+const run = (pr, live, linearTeamKey) => {
   mkdirSync(LOCK_DIR, { recursive: true })
   const lock = join(LOCK_DIR, `pr-${pr}.lock`)
   try {
@@ -228,7 +255,7 @@ const run = (pr, live) => {
     out('--- worktree changes ---')
     out(sh('git', ['-C', wt, 'status', '--short']) || '(none)')
     if (live && r.status === 0) {
-      const vim = linkedVim(info.body)
+      const vim = linkedVim(info.body) || ensureLinearLink(pr, linearTeamKey)
       if (vim) {
         spawnSync(
           'node',
@@ -255,12 +282,20 @@ const run = (pr, live) => {
 const main = () => {
   const argv = process.argv.slice(2)
   const pr = Number(argv.find((a) => /^\d+$/.test(a)))
+  const val = (n) => {
+    const i = argv.indexOf(`--${n}`)
+    return i >= 0 ? argv[i + 1] : undefined
+  }
   if (!pr)
     die(
-      'usage: run.mjs <PR#> [--push]   (default = dry-run; --push arms the live path)'
+      'usage: run.mjs <PR#> [--push] [--linear-team VIM]   (default = dry-run; --push arms the live path)'
     )
   try {
-    run(pr, argv.includes('--push'))
+    run(
+      pr,
+      argv.includes('--push'),
+      val('linear-team') || DEFAULT_LINEAR_TEAM_KEY
+    )
   } catch (e) {
     process.stderr.write(`${e.message}\n`)
     process.exit(e.exitCode || 1)

--- a/scripts/qa-runner/watch.mjs
+++ b/scripts/qa-runner/watch.mjs
@@ -8,15 +8,16 @@
 //              GOOD_SHAPE → (with --approve) squash-merge AS THE ORCHESTRATOR BOT
 //                           (orchestrator.env) + delete branch.
 //              WAITING / CI_RED → report only.
-//            State is mirrored to the linked Linear issue (a VIM-N in the PR body)
-//            via lib/linear-status.mjs — Linear is the control plane / observability.
+//            Armed runs first ensure the PR body has a Linear issue reference, then
+//            mirror state to that issue via lib/linear-status.mjs.
 //   watch  — loop `tick` every pollSeconds (Ctrl-C to stop).
 //
 // Two identities: the INNER fixer runs as bot.env (handled inside run.mjs); the
 // OUTER merge runs as orchestrator.env so author ≠ approver. Either absent ⇒ that
 // action falls back to your own gh.
 //
-// Default is REPORT-ONLY. `--execute` arms fixing; `--approve` arms merging.
+// Default is REPORT-ONLY. `--ensure-linear` arms PR-body linking, `--execute`
+// arms fixing, and `--approve` arms merging.
 // `--pr N` targets one PR; `--max N` caps parallel fixes. See README.md.
 
 import { execFileSync, spawn, spawnSync } from 'node:child_process'
@@ -30,6 +31,7 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const LOCK_DIR = join(SCRIPT_DIR, '.locks')
 const LOG_DIR = join(SCRIPT_DIR, 'logs')
 const DEFAULT_LABEL = 'auto-review'
+const DEFAULT_LINEAR_TEAM_KEY = 'VIM'
 const POLL_SECONDS = 60
 const MAX_PARALLEL = 2
 // CI checks that are the *reviewers*, not the build/test gate — excluded from "CI green".
@@ -164,7 +166,8 @@ const computeState = (pr, ctx) => {
     '--json',
     'mergeable,mergeStateStatus,body,headRefOid',
   ])
-  const vim = linkedVim(view.body)
+  let vim = linkedVim(view.body)
+  if (!vim) vim = ensureLinearLink(pr, ctx)
   let state, detail
   if (ci === 'fail')
     [state, detail] = ['CI_RED', 'non-review CI failing or canceled']
@@ -210,6 +213,33 @@ const postLinear = (vim, body, stateName) => {
     out(
       `           ↳ Linear ${vim}: skipped (${(r.stderr || '').trim().split('\n')[0] || 'no LINEAR_API_KEY'})`
     )
+}
+
+const ensureLinearLink = (pr, ctx) => {
+  if (!ctx.ensureLinear) return null
+  const r = spawnSync(
+    'node',
+    [
+      join(SCRIPT_DIR, 'lib', 'linear-pr-link.mjs'),
+      String(pr.number),
+      '--team',
+      ctx.linearTeamKey,
+    ],
+    { encoding: 'utf8' }
+  )
+  if (r.status !== 0) {
+    out(
+      `           ↳ Linear link skipped (${(r.stderr || '').trim().split('\n')[0] || 'linear-pr-link failed'})`
+    )
+    return null
+  }
+  const linked = JSON.parse(r.stdout)
+  if (linked.prPatched) {
+    out(
+      `           ↳ Linear ${linked.identifier}: ${linked.created ? 'created' : 'found'} + patched PR body`
+    )
+  }
+  return linked.identifier
 }
 
 // Squash-merge + branch delete as the orchestrator bot (or you, if none).
@@ -288,7 +318,7 @@ const approve = (pr, vim, headSha, ctx) => {
 // the console so concurrent runs stay legible. Resolves the exit code; never
 // rejects — a failed child must not abort the pool. run.mjs adopts the INNER
 // (fixer) bot identity itself, so we just inherit the env here.
-const dispatchFix = (pr) =>
+const dispatchFix = (pr, ctx) =>
   new Promise((resolve) => {
     mkdirSync(LOG_DIR, { recursive: true })
     const logPath = join(LOG_DIR, `pr-${pr}.log`)
@@ -297,7 +327,13 @@ const dispatchFix = (pr) =>
     out(`${tag} → run.mjs ${pr} --push   (log: ${logPath})`)
     const child = spawn(
       'node',
-      [join(SCRIPT_DIR, 'run.mjs'), String(pr), '--push'],
+      [
+        join(SCRIPT_DIR, 'run.mjs'),
+        String(pr),
+        '--push',
+        '--linear-team',
+        ctx.linearTeamKey,
+      ],
       {
         env: process.env,
       }
@@ -352,7 +388,7 @@ const tick = async (ctx) => {
   }
   out(
     `QA watcher tick — ${ctx.owner}/${ctx.name} · ${prs.length} PR(s) · ` +
-      `approve=${ctx.approve} execute=${ctx.execute} max=${ctx.maxParallel}\n`
+      `approve=${ctx.approve} execute=${ctx.execute} ensureLinear=${ctx.ensureLinear} max=${ctx.maxParallel}\n`
   )
   const needsFix = []
   for (const pr of prs) {
@@ -397,14 +433,14 @@ const tick = async (ctx) => {
     out(
       `Dispatching ${needsFix.length} fix run(s), up to ${ctx.maxParallel} in parallel…\n`
     )
-    await pool(needsFix, ctx.maxParallel, dispatchFix)
+    await pool(needsFix, ctx.maxParallel, (pr) => dispatchFix(pr, ctx))
   }
 }
 
 const watch = async (ctx) => {
   out(
     `QA watcher — looping every ${POLL_SECONDS}s ` +
-      `(approve=${ctx.approve} execute=${ctx.execute} max=${ctx.maxParallel}). Ctrl-C to stop.\n`
+      `(approve=${ctx.approve} execute=${ctx.execute} ensureLinear=${ctx.ensureLinear} max=${ctx.maxParallel}). Ctrl-C to stop.\n`
   )
   const loop = async () => {
     try {
@@ -456,8 +492,10 @@ const main = () => {
     owner,
     name,
     label: val('label') || DEFAULT_LABEL,
+    linearTeamKey: val('linear-team') || DEFAULT_LINEAR_TEAM_KEY,
     approve: has('approve'),
     execute: has('execute'),
+    ensureLinear: has('ensure-linear') || has('execute') || has('approve'),
     all: has('all'),
     pr: val('pr') ? Number(val('pr')) : undefined,
     maxParallel: Number(val('max')) || MAX_PARALLEL,
@@ -468,7 +506,7 @@ const main = () => {
   if (cmd === 'tick') return tick(ctx)
   if (cmd === 'watch') return watch(ctx)
   err(
-    `unknown command: ${cmd}. Use: scan | tick | watch  [--pr N] [--approve] [--execute] [--all] [--max N] [--label NAME]`
+    `unknown command: ${cmd}. Use: scan | tick | watch  [--pr N] [--approve] [--execute] [--ensure-linear] [--linear-team VIM] [--all] [--max N] [--label NAME]`
   )
   process.exit(1)
 }


### PR DESCRIPTION
## What changed

- Adds a headless Linear PR-link helper for the QA runner.
- If an armed QA run sees a PR body without a `VIM-N` reference, it finds or creates the matching Linear issue and patches the PR body with `Refs VIM-N`.
- Shares Linear GraphQL helpers between status posting and PR-link creation.
- Keeps `scan` read-only; PR-body patching only happens with `--ensure-linear`, `--execute`, or `--approve`.

## Why

The QA runner previously skipped Linear status when a PR had no `VIM-N` in its body. That meant any automatically-created Linear issue could remain disconnected from the GitHub PR itself.

## Validation

- `node --check` on all touched QA-runner `.mjs` files
- PR-body helper behavior check
- `git diff --check`

## Operational note

The EC2 watcher needs this branch/code before using PR #433 as the missing-Linear-reference test case.

Refs VIM-73
