### PR TITLE
feat(files): wire file explorer context menu actions

### DIFF
--- a/crates/backend/src/filesystem/SECURITY.md
+++ b/crates/backend/src/filesystem/SECURITY.md
@@ -64,7 +64,7 @@ map before approving changes to the module.
 | `canonicalize_within_home` (rejection)  | `scope_tests::canonicalize_within_home_rejects_escape`, `write_tests::write_file_rejects_path_outside_home`, `write_tests::write_file_refuses_intermediate_symlink_escape`                           |
 | `ensure_within_home`                    | `list_tests::list_dir_*`, `read_tests::read_file_rejects_path_outside_home`                                                                                                                          |
 | `open_nofollow` (Unix)                  | `read_tests::read_file_refuses_to_follow_symlink_escaping_home`, `write_tests::write_file_refuses_to_follow_symlink_escaping_home`, `write_tests::write_file_refuses_symlink_even_to_in_home_target` |
-| Symlink-leaf refusal for mutations      | `mutate_tests::delete_path_refuses_symlink_leaf`                                                                                                                                                     |
+| Symlink-leaf refusal for mutations      | `mutate_tests::delete_path_refuses_symlink_leaf`, `mutate_tests::rename_path_refuses_symlink_leaf`                                                                                                   |
 | `open_nofollow` (Windows)               | Currently uncovered — Windows CI is not yet running these tests. Tracked in follow-up (see Deferred Work below).                                                                                     |
 | Atomic write + counter                  | `write_tests::write_file_creates_file`, `write_tests::write_file_overwrites_existing`                                                                                                                |
 

--- a/crates/backend/src/filesystem/SECURITY.md
+++ b/crates/backend/src/filesystem/SECURITY.md
@@ -147,6 +147,24 @@ getting skipped).
 **Revisit when:** the project gains a Windows CI runner, OR when the
 Windows code path changes.
 
+### Rename-path target-existence check (TOCTOU)
+
+**Status:** Accepted limitation, documented.
+
+**Rationale:** `mutate.rs::rename_path_inner` checks
+`fs::symlink_metadata(&target)` before calling `fs::rename(&source,
+&target)` to refuse overwrites. These two syscalls are not atomic: a
+target created in the narrow window between the stat and the rename will
+be silently overwritten by `fs::rename` on most Unix filesystems.
+Portable safe Rust does not expose `renameat2(RENAME_NOREPLACE)` or
+`renamex_np(RENAME_NOREPLACE)`. The check prevents accidental clobbering
+in the common single-process case but cannot guarantee exclusion under
+concurrent writers.
+
+**Revisit when:** the project adds a platform-specific syscall wrapper
+for Linux `renameat2` / macOS `renamex_np`, or when a concrete
+concurrent-writer scenario makes this race worth mitigating.
+
 ## Review Checklist
 
 For reviewers touching this module, run through each item:

--- a/crates/backend/src/filesystem/SECURITY.md
+++ b/crates/backend/src/filesystem/SECURITY.md
@@ -9,9 +9,9 @@
 
 This module is the sidecar IPC boundary for all filesystem access. Any
 code that reads or writes user files from the Electron renderer MUST go
-through one of the three commands in this directory (`list_dir`,
-`read_file`, `write_file`). No other module in `crates/backend` should open
-files on behalf of the webview.
+through one of the commands in this directory (`list_dir`, `read_file`,
+`write_file`, `rename_path`, `delete_path`). No other module in
+`crates/backend` should open files on behalf of the webview.
 
 ## Threat Model
 
@@ -64,6 +64,7 @@ map before approving changes to the module.
 | `canonicalize_within_home` (rejection)  | `scope_tests::canonicalize_within_home_rejects_escape`, `write_tests::write_file_rejects_path_outside_home`, `write_tests::write_file_refuses_intermediate_symlink_escape`                           |
 | `ensure_within_home`                    | `list_tests::list_dir_*`, `read_tests::read_file_rejects_path_outside_home`                                                                                                                          |
 | `open_nofollow` (Unix)                  | `read_tests::read_file_refuses_to_follow_symlink_escaping_home`, `write_tests::write_file_refuses_to_follow_symlink_escaping_home`, `write_tests::write_file_refuses_symlink_even_to_in_home_target` |
+| Symlink-leaf refusal for mutations      | `mutate_tests::delete_path_refuses_symlink_leaf`                                                                                                                                                     |
 | `open_nofollow` (Windows)               | Currently uncovered — Windows CI is not yet running these tests. Tracked in follow-up (see Deferred Work below).                                                                                     |
 | Atomic write + counter                  | `write_tests::write_file_creates_file`, `write_tests::write_file_overwrites_existing`                                                                                                                |
 
@@ -131,8 +132,7 @@ mixed-concerns file. Fuzz findings deserve their own PR narrative
 **Revisit when either of the following becomes true:**
 
 - A CVE or near-miss surfaces in the write path.
-- New surface area is added (`move_file`, `delete_file`,
-  symlink creation, chmod).
+- New surface area is added (`move_file`, symlink creation, chmod).
 
 ### Windows CI coverage
 

--- a/crates/backend/src/filesystem/mod.rs
+++ b/crates/backend/src/filesystem/mod.rs
@@ -19,6 +19,7 @@
 //! See `SECURITY.md` for the full model.
 
 pub(crate) mod list;
+pub(crate) mod mutate;
 pub(crate) mod read;
 pub(crate) mod scope;
 pub(crate) mod types;

--- a/crates/backend/src/filesystem/mutate.rs
+++ b/crates/backend/src/filesystem/mutate.rs
@@ -1,0 +1,148 @@
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use super::scope::{ensure_within_home, expand_home, home_canonical, reject_parent_refs};
+use super::types::{DeletePathRequest, RenamePathRequest};
+
+#[cfg(test)]
+pub fn rename_path(request: RenamePathRequest) -> Result<(), String> {
+    rename_path_inner(request)
+}
+
+#[cfg(test)]
+pub fn delete_path(request: DeletePathRequest) -> Result<(), String> {
+    delete_path_inner(request)
+}
+
+pub(crate) fn rename_path_inner(request: RenamePathRequest) -> Result<(), String> {
+    let source = resolve_existing_path(&request.path)?;
+    let home = home_canonical()?;
+
+    if source == home {
+        return Err("access denied: refusing to rename home directory".to_string());
+    }
+
+    let new_name = validate_child_name(&request.new_name)?;
+    let parent = source.parent().ok_or_else(|| {
+        format!(
+            "invalid path: no parent directory for '{}'",
+            source.display()
+        )
+    })?;
+    let target = parent.join(new_name);
+
+    if target == source {
+        return Ok(());
+    }
+
+    match fs::symlink_metadata(&target) {
+        Ok(_) => {
+            return Err(format!(
+                "target already exists: {}",
+                target.to_string_lossy()
+            ));
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(format!(
+                "failed to stat target '{}': {}",
+                target.display(),
+                e
+            ));
+        }
+    }
+
+    log::info!(
+        "Renaming path: {} -> {}",
+        source.display(),
+        target.display()
+    );
+
+    fs::rename(&source, &target).map_err(|e| {
+        format!(
+            "failed to rename '{}' to '{}': {}",
+            source.display(),
+            target.display(),
+            e
+        )
+    })
+}
+
+pub(crate) fn delete_path_inner(request: DeletePathRequest) -> Result<(), String> {
+    let target = resolve_existing_path(&request.path)?;
+    let home = home_canonical()?;
+
+    if target == home {
+        return Err("access denied: refusing to delete home directory".to_string());
+    }
+
+    let metadata = fs::symlink_metadata(&target)
+        .map_err(|e| format!("failed to stat '{}': {}", target.display(), e))?;
+
+    log::info!("Deleting path: {}", target.display());
+
+    if metadata.is_file() {
+        fs::remove_file(&target)
+            .map_err(|e| format!("failed to delete file '{}': {}", target.display(), e))
+    } else if metadata.is_dir() {
+        fs::remove_dir_all(&target)
+            .map_err(|e| format!("failed to delete directory '{}': {}", target.display(), e))
+    } else {
+        Err(format!(
+            "unsupported path type for delete: {}",
+            target.display()
+        ))
+    }
+}
+
+fn resolve_existing_path(path: &str) -> Result<PathBuf, String> {
+    let raw = expand_home(path);
+
+    reject_parent_refs(&raw)?;
+
+    if !raw.is_absolute() {
+        return Err(format!(
+            "access denied: path must be absolute or ~-relative: {}",
+            raw.display()
+        ));
+    }
+
+    let metadata =
+        fs::symlink_metadata(&raw).map_err(|e| format!("invalid path '{}': {}", path, e))?;
+
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "access denied: refusing to mutate symlink: {}",
+            raw.display()
+        ));
+    }
+
+    let canonical =
+        fs::canonicalize(&raw).map_err(|e| format!("invalid path '{}': {}", path, e))?;
+    let home = home_canonical()?;
+    ensure_within_home(&canonical, &home)?;
+
+    Ok(canonical)
+}
+
+fn validate_child_name(name: &str) -> Result<&str, String> {
+    if name.is_empty() {
+        return Err("invalid name: new name must not be empty".to_string());
+    }
+
+    if name.contains('/') || name.contains('\\') {
+        return Err(format!(
+            "invalid name: new name must be a single path component: {}",
+            name
+        ));
+    }
+
+    let mut components = Path::new(name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(name),
+        _ => Err(format!(
+            "invalid name: new name must be a single path component: {}",
+            name
+        )),
+    }
+}

--- a/crates/backend/src/filesystem/tests/mod.rs
+++ b/crates/backend/src/filesystem/tests/mod.rs
@@ -1,7 +1,7 @@
 //! Test module for filesystem IPC commands.
 //!
-//! Tests are split by command (`list_tests`, `read_tests`, `write_tests`)
-//! plus unit tests for the sandbox primitives (`scope_tests`). Shared
+//! Tests are split by command (`list_tests`, `mutate_tests`, `read_tests`,
+//! `write_tests`) plus unit tests for the sandbox primitives (`scope_tests`). Shared
 //! helpers live here and are re-exported to child modules via
 //! `use super::*;`.
 //!
@@ -17,8 +17,12 @@ use std::path::PathBuf;
 
 // Re-export command items under test
 pub(super) use super::list::list_dir;
+pub(super) use super::mutate::{delete_path, rename_path};
 pub(super) use super::read::read_file;
-pub(super) use super::types::{EntryType, ListDirRequest, ReadFileRequest, WriteFileRequest};
+pub(super) use super::types::{
+    DeletePathRequest, EntryType, ListDirRequest, ReadFileRequest, RenamePathRequest,
+    WriteFileRequest,
+};
 pub(super) use super::write::write_file;
 
 // Re-export scope helpers for unit tests. Aliased with `scope_` prefix
@@ -36,6 +40,7 @@ pub(super) fn home_test_dir(name: &str) -> PathBuf {
 }
 
 mod list_tests;
+mod mutate_tests;
 mod read_tests;
 mod scope_tests;
 mod write_tests;

--- a/crates/backend/src/filesystem/tests/mutate_tests.rs
+++ b/crates/backend/src/filesystem/tests/mutate_tests.rs
@@ -1,0 +1,136 @@
+use super::*;
+use std::fs;
+
+#[test]
+fn rename_path_renames_file_within_parent_directory() {
+    let dir = home_test_dir("rename_file");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let original = dir.join("old.txt");
+    let renamed = dir.join("new.txt");
+    fs::write(&original, "content").unwrap();
+
+    let result = rename_path(RenamePathRequest {
+        path: original.to_string_lossy().to_string(),
+        new_name: "new.txt".to_string(),
+    });
+
+    assert!(result.is_ok(), "rename should succeed: {:?}", result.err());
+    assert!(!original.exists());
+    assert_eq!(fs::read_to_string(&renamed).unwrap(), "content");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rename_path_rejects_nested_target_name() {
+    let dir = home_test_dir("rename_nested_target");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let original = dir.join("old.txt");
+    fs::write(&original, "content").unwrap();
+
+    let result = rename_path(RenamePathRequest {
+        path: original.to_string_lossy().to_string(),
+        new_name: "../evil.txt".to_string(),
+    });
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("single path component"));
+    assert!(original.exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rename_path_rejects_existing_target() {
+    let dir = home_test_dir("rename_existing_target");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let original = dir.join("old.txt");
+    let existing = dir.join("new.txt");
+    fs::write(&original, "old").unwrap();
+    fs::write(&existing, "existing").unwrap();
+
+    let result = rename_path(RenamePathRequest {
+        path: original.to_string_lossy().to_string(),
+        new_name: "new.txt".to_string(),
+    });
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("target already exists"));
+    assert_eq!(fs::read_to_string(&existing).unwrap(), "existing");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn delete_path_removes_file() {
+    let dir = home_test_dir("delete_file");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let target = dir.join("delete-me.txt");
+    fs::write(&target, "content").unwrap();
+
+    let result = delete_path(DeletePathRequest {
+        path: target.to_string_lossy().to_string(),
+    });
+
+    assert!(result.is_ok(), "delete should succeed: {:?}", result.err());
+    assert!(!target.exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn delete_path_removes_directory_tree() {
+    let dir = home_test_dir("delete_dir");
+    let _ = fs::remove_dir_all(&dir);
+    let target = dir.join("folder");
+    fs::create_dir_all(target.join("nested")).unwrap();
+    fs::write(target.join("nested").join("file.txt"), "content").unwrap();
+
+    let result = delete_path(DeletePathRequest {
+        path: target.to_string_lossy().to_string(),
+    });
+
+    assert!(result.is_ok(), "delete should succeed: {:?}", result.err());
+    assert!(!target.exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn delete_path_rejects_path_outside_home() {
+    let result = delete_path(DeletePathRequest {
+        path: "/etc/passwd".to_string(),
+    });
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("access denied"));
+}
+
+#[cfg(unix)]
+#[test]
+fn delete_path_refuses_symlink_leaf() {
+    use std::os::unix::fs::symlink;
+
+    let dir = home_test_dir("delete_symlink_leaf");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let target = dir.join("target.txt");
+    let link = dir.join("link.txt");
+    fs::write(&target, "content").unwrap();
+    symlink(&target, &link).unwrap();
+
+    let result = delete_path(DeletePathRequest {
+        path: link.to_string_lossy().to_string(),
+    });
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("refusing to mutate symlink"));
+    assert!(link.exists());
+    assert!(target.exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/backend/src/filesystem/tests/mutate_tests.rs
+++ b/crates/backend/src/filesystem/tests/mutate_tests.rs
@@ -65,6 +65,43 @@ fn rename_path_rejects_existing_target() {
 }
 
 #[test]
+fn rename_path_rejects_path_outside_home() {
+    let result = rename_path(RenamePathRequest {
+        path: "/etc/passwd".to_string(),
+        new_name: "renamed.txt".to_string(),
+    });
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("access denied"));
+}
+
+#[cfg(unix)]
+#[test]
+fn rename_path_refuses_symlink_leaf() {
+    use std::os::unix::fs::symlink;
+
+    let dir = home_test_dir("rename_symlink_leaf");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let target = dir.join("target.txt");
+    let link = dir.join("link.txt");
+    fs::write(&target, "content").unwrap();
+    symlink(&target, &link).unwrap();
+
+    let result = rename_path(RenamePathRequest {
+        path: link.to_string_lossy().to_string(),
+        new_name: "renamed.txt".to_string(),
+    });
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("refusing to mutate symlink"));
+    assert!(link.exists());
+    assert!(target.exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn delete_path_removes_file() {
     let dir = home_test_dir("delete_file");
     let _ = fs::remove_dir_all(&dir);

--- a/crates/backend/src/filesystem/types.rs
+++ b/crates/backend/src/filesystem/types.rs
@@ -46,3 +46,20 @@ pub struct WriteFileRequest {
     pub path: String,
     pub content: String,
 }
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
+#[cfg_attr(test, ts(export))]
+#[serde(rename_all = "camelCase")]
+pub struct RenamePathRequest {
+    pub path: String,
+    pub new_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
+#[cfg_attr(test, ts(export))]
+#[serde(rename_all = "camelCase")]
+pub struct DeletePathRequest {
+    pub path: String,
+}

--- a/crates/backend/src/git/mod.rs
+++ b/crates/backend/src/git/mod.rs
@@ -494,6 +494,17 @@ pub struct ChangedFile {
     pub deletions: Option<u32>,
 }
 
+/// Response payload for the `git_status` command.
+///
+/// Paths in `files` are repo-root-relative so the frontend can correlate them
+/// with diff requests regardless of which subdirectory `cwd` points to.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitStatusResponse {
+    pub files: Vec<ChangedFile>,
+    pub repo_root: String,
+}
+
 /// Parse `git diff --numstat -z` output into a path → (added, removed) map.
 ///
 /// Format (NUL-separated, LF-stripped inside records):
@@ -1079,11 +1090,11 @@ fn parse_hunk_range(range: &str) -> (u32, u32) {
 /// Get all files with git changes.
 // Git unit tests call the command name directly with plain args.
 #[cfg(test)]
-pub async fn git_status(cwd: String) -> Result<Vec<ChangedFile>, String> {
+pub async fn git_status(cwd: String) -> Result<GitStatusResponse, String> {
     git_status_inner(cwd).await
 }
 
-pub(crate) async fn git_status_inner(cwd: String) -> Result<Vec<ChangedFile>, String> {
+pub(crate) async fn git_status_inner(cwd: String) -> Result<GitStatusResponse, String> {
     let safe_cwd = validate_cwd(&cwd)?;
 
     // Resolve repo toplevel — if not in a repo, return empty list
@@ -1099,7 +1110,10 @@ pub(crate) async fn git_status_inner(cwd: String) -> Result<Vec<ChangedFile>, St
 
     if !toplevel_output.status.success() {
         // Not a git repo — return empty list (no error state)
-        return Ok(vec![]);
+        return Ok(GitStatusResponse {
+            files: vec![],
+            repo_root: String::new(),
+        });
     }
 
     let toplevel_str = String::from_utf8_lossy(&toplevel_output.stdout);
@@ -1265,7 +1279,10 @@ pub(crate) async fn git_status_inner(cwd: String) -> Result<Vec<ChangedFile>, St
         }
     }
 
-    Ok(files)
+    Ok(GitStatusResponse {
+        files,
+        repo_root: canonical_toplevel.to_string_lossy().into_owned(),
+    })
 }
 
 /// Check whether a repo-relative file path is untracked under the given
@@ -2547,7 +2564,7 @@ copy to copy.txt
         let result = git_status(subdir_str).await;
 
         assert!(result.is_ok(), "git_status should succeed from subdir");
-        let files = result.unwrap();
+        let files = result.unwrap().files;
 
         // Should see root.txt even though we called from src/
         assert_eq!(files.len(), 1, "should return repo-level changes");
@@ -2565,7 +2582,7 @@ copy to copy.txt
         let result = git_status(non_repo).await;
 
         assert!(result.is_ok(), "non-repo should return Ok, not error");
-        let files = result.unwrap();
+        let files = result.unwrap().files;
         assert_eq!(files.len(), 0, "non-repo should return empty vec");
     }
 
@@ -2625,7 +2642,7 @@ copy to copy.txt
         let result = git_status(repo_str).await;
 
         assert!(result.is_ok(), "git_status should succeed");
-        let files = result.unwrap();
+        let files = result.unwrap().files;
 
         assert_eq!(files.len(), 2, "MM should produce two entries");
 
@@ -3086,7 +3103,7 @@ copy to copy.txt
         let result = git_status(repo_str).await;
 
         assert!(result.is_ok(), "git_status should succeed");
-        let files = result.unwrap();
+        let files = result.unwrap().files;
         let untracked_entry = files
             .iter()
             .find(|f| f.path == "fresh.txt")
@@ -3134,7 +3151,7 @@ copy to copy.txt
         let result = git_status(repo_str).await;
 
         assert!(result.is_ok(), "git_status should succeed");
-        let files = result.unwrap();
+        let files = result.unwrap().files;
         let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
 
         assert!(

--- a/crates/backend/src/runtime/ipc.rs
+++ b/crates/backend/src/runtime/ipc.rs
@@ -587,6 +587,28 @@ mod router {
                 state.write_file(p.request)?;
                 Ok(Value::Null)
             }
+            "rename_path" => {
+                #[derive(Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                struct P {
+                    request: crate::filesystem::types::RenamePathRequest,
+                }
+
+                let p: P = serde_json::from_value(params).map_err(|e| format!("params: {e}"))?;
+                state.rename_path(p.request)?;
+                Ok(Value::Null)
+            }
+            "delete_path" => {
+                #[derive(Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                struct P {
+                    request: crate::filesystem::types::DeletePathRequest,
+                }
+
+                let p: P = serde_json::from_value(params).map_err(|e| format!("params: {e}"))?;
+                state.delete_path(p.request)?;
+                Ok(Value::Null)
+            }
             "git_status" => {
                 #[derive(Deserialize)]
                 #[serde(rename_all = "camelCase")]

--- a/crates/backend/src/runtime/state.rs
+++ b/crates/backend/src/runtime/state.rs
@@ -283,7 +283,7 @@ impl BackendState {
         crate::filesystem::mutate::delete_path_inner(request)
     }
 
-    pub async fn git_status(&self, cwd: String) -> Result<Vec<crate::git::ChangedFile>, String> {
+    pub async fn git_status(&self, cwd: String) -> Result<crate::git::GitStatusResponse, String> {
         crate::git::git_status_inner(cwd).await
     }
 

--- a/crates/backend/src/runtime/state.rs
+++ b/crates/backend/src/runtime/state.rs
@@ -269,6 +269,20 @@ impl BackendState {
         crate::filesystem::write::write_file_inner(request)
     }
 
+    pub fn rename_path(
+        &self,
+        request: crate::filesystem::types::RenamePathRequest,
+    ) -> Result<(), String> {
+        crate::filesystem::mutate::rename_path_inner(request)
+    }
+
+    pub fn delete_path(
+        &self,
+        request: crate::filesystem::types::DeletePathRequest,
+    ) -> Result<(), String> {
+        crate::filesystem::mutate::delete_path_inner(request)
+    }
+
     pub async fn git_status(&self, cwd: String) -> Result<Vec<crate::git::ChangedFile>, String> {
         crate::git::git_status_inner(cwd).await
     }

--- a/crates/backend/tests/ipc_subprocess.rs
+++ b/crates/backend/tests/ipc_subprocess.rs
@@ -508,6 +508,14 @@ fn every_production_method_returns_well_formed_response_frame() {
             "write_file",
             json!({"request": {"path": "/tmp/no-such-dir/out.txt", "content": ""}}),
         ),
+        (
+            "rename_path",
+            json!({"request": {"path": "/tmp/no-such-file-vimeflow-test", "newName": "renamed.txt"}}),
+        ),
+        (
+            "delete_path",
+            json!({"request": {"path": "/tmp/no-such-file-vimeflow-test"}}),
+        ),
         ("git_status", json!({"cwd": "/tmp/no-such-dir"})),
         ("git_branch", json!({"cwd": "/tmp/no-such-dir"})),
         (

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -135,6 +135,7 @@ words:
   - nowarn
   - worktree
   - worktrees
+  - revparse
 
 ignorePaths:
   - node_modules

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -70,7 +70,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [PTY Session Management](patterns/pty-session-management.md)                                         | backend            | 9        | 3    | 2026-06-13   |
 | [Git Operations](patterns/git-operations.md)                                                         | correctness        | 26       | 11   | 2026-06-13   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)                                         | editor             | 19       | 4    | 2026-06-06   |
-| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 39       | 12   | 2026-06-13   |
+| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 40       | 12   | 2026-06-13   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 19       | 7    | 2026-06-06   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -43,7 +43,7 @@ When appending findings to a pattern file, label the source so future readers ca
 
 | Pattern                                                                                              | Category           | Findings | Refs | Last Updated |
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
-| [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 21       | 3    | 2026-05-20   |
+| [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 22       | 4    | 2026-06-13   |
 | [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 33       | 15   | 2026-06-11   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 64       | 30   | 2026-06-12   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 22   | 2026-06-12   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 22   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |
@@ -68,9 +68,9 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CSP Configuration](patterns/csp-configuration.md)                                                   | security           | 8        | 5    | 2026-05-16   |
 | [Network Request Hardening](patterns/network-request-hardening.md)                                   | security           | 1        | 1    | 2026-06-08   |
 | [PTY Session Management](patterns/pty-session-management.md)                                         | backend            | 9        | 3    | 2026-06-13   |
-| [Git Operations](patterns/git-operations.md)                                                         | correctness        | 25       | 10   | 2026-05-31   |
+| [Git Operations](patterns/git-operations.md)                                                         | correctness        | 26       | 11   | 2026-06-13   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)                                         | editor             | 19       | 4    | 2026-06-06   |
-| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 38       | 11   | 2026-06-12   |
+| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 39       | 12   | 2026-06-13   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 19       | 7    | 2026-06-06   |
@@ -88,3 +88,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
+| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 1        | 0    | 2026-06-13   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -524,7 +524,6 @@ handlers must not trap focus without implementing the promised behavior.
 - **Fix:** Moved the same root-anchored, absolutely positioned toggle wrapper earlier in the DOM (right after the compact scrim and before the sidebar shell) so sequential focus order matches the visual layout. Preserved `z-40` and the existing left/top absolute coordinates. Updated co-located tests that asserted on `workspace.children[1]` to query `screen.getByTestId('workspace-main')` directly, since the DOM reordering changed sibling indices.
 - **Commit:** _(see git blame / git log on this line)_
 
-
 ### 49. FileExplorer rename/delete uses native blocking dialogs
 
 - **Source:** github-claude | PR #444 round 1 | 2026-06-13

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,8 +2,8 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-12
-ref_count: 22
+last_updated: 2026-06-13
+ref_count: 23
 ---
 
 # Accessibility
@@ -523,3 +523,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The persistent `SidebarToggle` was absolutely positioned at the workspace root so it stayed visually fixed during sidebar collapse/expand animations, but it was rendered as the last child of the workspace root. Keyboard users therefore reached it only after tabbing through the main workspace, activity panel, overlays, and command palette — a WCAG focus-order regression relative to its visual position at the top-left boundary.
 - **Fix:** Moved the same root-anchored, absolutely positioned toggle wrapper earlier in the DOM (right after the compact scrim and before the sidebar shell) so sequential focus order matches the visual layout. Preserved `z-40` and the existing left/top absolute coordinates. Updated co-located tests that asserted on `workspace.children[1]` to query `screen.getByTestId('workspace-main')` directly, since the DOM reordering changed sibling indices.
 - **Commit:** _(see git blame / git log on this line)_
+
+
+### 49. FileExplorer rename/delete uses native blocking dialogs
+
+- **Source:** github-claude | PR #444 round 1 | 2026-06-13
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/components/panels/FileExplorer.tsx`
+- **Finding:** `window.prompt` and `window.confirm` blocked the renderer thread, used unstyled OS chrome, and could not display formatted validation hints or be cancelled via Escape reliably.
+- **Fix:** Replaced native dialogs with an inline rename input and a delete-confirmation strip styled with design tokens; kept actions non-blocking.
+- **Commit:** see `git blame` / `git log` on this line

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -1,0 +1,27 @@
+---
+id: dead-code
+category: code-quality
+created: 2026-06-13
+last_updated: 2026-06-13
+ref_count: 0
+---
+
+# Dead Code
+
+## Summary
+
+Unreachable or obsolete code paths add maintenance surface, mislead future
+refactors, and can mask API-contract bugs. When every call site satisfies a
+stricter precondition, fallback branches that were once necessary become dead
+code and should be removed.
+
+## Findings
+
+### 1. Label-matching fallback in actionIdFor is unreachable
+
+- **Source:** github-claude | PR #444 round 1 | 2026-06-13
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/panels/FileExplorer.tsx`
+- **Finding:** All entries in `contextMenuActions` carried explicit `id` fields, so the early `return action.id` made the subsequent `switch (action.label)` block unreachable. The dead code risked misleading maintainers into thinking new actions could rely on label matching.
+- **Fix:** Removed the unreachable `switch` fallback; `actionIdFor` now returns `action.id ?? null` directly.
+- **Commit:** see `git blame` / `git log` on this line

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -2,8 +2,8 @@
 id: error-surfacing
 category: error-handling
 created: 2026-04-10
-last_updated: 2026-06-12
-ref_count: 10
+last_updated: 2026-06-13
+ref_count: 11
 ---
 
 # Error Surfacing
@@ -378,3 +378,13 @@ failed" must mean the editor shows the original file, not the requested one.
 - **Finding:** The new reading-view context-menu Copy action called `void clipboard?.writeText?.(selectedText)`, discarding both missing-API and rejection cases. In Electron's `loadFile` runtime or when clipboard permission is denied the copy surface silently does nothing, leaving the user without the selected text on the clipboard. Same `void promise` anti-pattern as #1–#5 and #36, but the fix here is graceful fallback rather than user-facing error surfacing.
 - **Fix:** Replaced the direct call with the existing `writeClipboardText` helper from `useCodeMirror.ts`, which tries `navigator.clipboard.writeText` and falls back to a hidden-textarea / `document.execCommand('copy')` path when the modern API is missing or rejects. Exported the helper so the reading view can share the editor's battle-tested fallback. Added a regression test asserting the fallback path is exercised when `navigator.clipboard.writeText` is absent.
 - **Commit:** same commit as this entry
+
+
+### 39. FileExplorer actionError banner cannot be dismissed
+
+- **Source:** github-claude | PR #444 round 1 | 2026-06-13
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/components/panels/FileExplorer.tsx`
+- **Finding:** The error banner set by `actionError` stayed visible indefinitely; it was only cleared at the start of the next context-menu action, leaving stale errors pinned in the sidebar.
+- **Fix:** Added a close button to the banner that calls `setActionError(null)` so users can dismiss it immediately.
+- **Commit:** see `git blame` / `git log` on this line

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -3,7 +3,7 @@ id: error-surfacing
 category: error-handling
 created: 2026-04-10
 last_updated: 2026-06-13
-ref_count: 11
+ref_count: 12
 ---
 
 # Error Surfacing
@@ -387,3 +387,12 @@ failed" must mean the editor shows the original file, not the requested one.
 - **Finding:** The error banner set by `actionError` stayed visible indefinitely; it was only cleared at the start of the next context-menu action, leaving stale errors pinned in the sidebar.
 - **Fix:** Added a close button to the banner that calls `setActionError(null)` so users can dismiss it immediately.
 - **Commit:** see `git blame` / `git log` on this line
+
+### 40. Detached native clipboard method throws `TypeError: Illegal invocation` in Electron
+
+- **Source:** github-codex-connector | PR #444 round 2 | 2026-06-13
+- **Severity:** HIGH
+- **File:** `src/features/workspace/components/panels/FileExplorer.tsx`
+- **Finding:** `copy-path` extracted `clipboard?.writeText` into a local `writeText` variable and later called `writeText(fullPath)`. Native Chromium DOM methods validate their receiver, so the detached call can throw `TypeError: Illegal invocation` in Electron even though the Vitest mock passes (vi.fn() does not enforce `this`). The existing try/catch surfaced the error via `actionError`, but the action failed every time in the real renderer.
+- **Fix:** Removed the intermediate `writeText` variable. The guard now checks `typeof clipboard?.writeText !== 'function'` and the call site uses `await clipboard.writeText(fullPath)` directly so the Clipboard object remains the receiver. (Related but distinct from #38, which was about silently discarding missing-API/rejection cases; this finding is about preserving the method's `this` binding.)
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -379,7 +379,6 @@ failed" must mean the editor shows the original file, not the requested one.
 - **Fix:** Replaced the direct call with the existing `writeClipboardText` helper from `useCodeMirror.ts`, which tries `navigator.clipboard.writeText` and falls back to a hidden-textarea / `document.execCommand('copy')` path when the modern API is missing or rejects. Exported the helper so the reading view can share the editor's battle-tested fallback. Added a regression test asserting the fallback path is exercised when `navigator.clipboard.writeText` is absent.
 - **Commit:** same commit as this entry
 
-
 ### 39. FileExplorer actionError banner cannot be dismissed
 
 - **Source:** github-claude | PR #444 round 1 | 2026-06-13

--- a/docs/reviews/patterns/filesystem-scope.md
+++ b/docs/reviews/patterns/filesystem-scope.md
@@ -211,7 +211,6 @@ preserve their original Tauri-era paths.
 - **Fix:** Reject null bytes before path conversion, keep transcript files scoped under canonical `~/.claude`, and document the helper as a best-effort single-user desktop guard. The comment now calls out that fd-pinned traversal or `cap-std`-style APIs are required if the threat model expands to shared writable roots or hostile same-user races.
 - **Commit:** _(pending on this branch)_
 
-
 ### 22. rename_path lacks out-of-home and symlink-leaf rejection tests
 
 - **Source:** github-claude | PR #444 round 1 | 2026-06-13

--- a/docs/reviews/patterns/filesystem-scope.md
+++ b/docs/reviews/patterns/filesystem-scope.md
@@ -2,8 +2,8 @@
 id: filesystem-scope
 category: security
 created: 2026-04-09
-last_updated: 2026-05-20
-ref_count: 3
+last_updated: 2026-06-13
+ref_count: 4
 ---
 
 # Filesystem Scope
@@ -210,3 +210,13 @@ preserve their original Tauri-era paths.
 - **Finding:** Transcript path validation built a `PathBuf` from raw statusline text without first rejecting embedded null bytes, and the path-security helper documented its two-phase canonicalize/create/check flow without stating the accepted single-user desktop threat model. That left future maintainers unsure whether the residual same-user TOCTOU window was intentional or overlooked.
 - **Fix:** Reject null bytes before path conversion, keep transcript files scoped under canonical `~/.claude`, and document the helper as a best-effort single-user desktop guard. The comment now calls out that fd-pinned traversal or `cap-std`-style APIs are required if the threat model expands to shared writable roots or hostile same-user races.
 - **Commit:** _(pending on this branch)_
+
+
+### 22. rename_path lacks out-of-home and symlink-leaf rejection tests
+
+- **Source:** github-claude | PR #444 round 1 | 2026-06-13
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/filesystem/tests/mutate_tests.rs`
+- **Finding:** `rename_path` shared the `resolve_existing_path` enforcement path with `delete_path` but had no tests proving it rejected paths outside home or symlink leaves; SECURITY.md coverage table mapped symlink-leaf refusal only to delete.
+- **Fix:** Added `rename_path_rejects_path_outside_home` and `rename_path_refuses_symlink_leaf` tests and updated the SECURITY.md coverage map.
+- **Commit:** see `git blame` / `git log` on this line

--- a/docs/reviews/patterns/git-operations.md
+++ b/docs/reviews/patterns/git-operations.md
@@ -2,8 +2,8 @@
 id: git-operations
 category: correctness
 created: 2026-04-09
-last_updated: 2026-05-31
-ref_count: 10
+last_updated: 2026-06-13
+ref_count: 11
 ---
 
 # Git Operations
@@ -239,3 +239,13 @@ between display and mutation operations.
 - **Finding:** `approve()` unconditionally deleted the remote branch via base-repo API after merge. For fork PRs, `headRefName` is the contributor's branch name; the deletion would remove a same-named base-repo branch instead.
 - **Fix:** Fetched `isCrossRepository` from `gh pr view\' and gated the remote ref-delete on `!isCrossRepository`.
 - **Commit:** same commit as this entry
+
+
+### 26. Diff path computed relative to activeCwd instead of repo root
+
+- **Source:** github-codex-connector | PR #444 round 1 | 2026-06-13
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** `handleFileViewDiff` computed `relativePath` from `activeCwd`, but the git backend normalizes status and diff to the repository top level. For terminals in a subdirectory, this produced a repo-root-relative path that missed the nested prefix and targeted the wrong file.
+- **Fix:** Extended `git_status_inner` to return the repository root (`repoRoot`) and updated `useGitStatus` / `WorkspaceView` to compute diff paths relative to `repoRoot` when available, falling back to `activeCwd`.
+- **Commit:** see `git blame` / `git log` on this line

--- a/docs/reviews/patterns/git-operations.md
+++ b/docs/reviews/patterns/git-operations.md
@@ -240,7 +240,6 @@ between display and mutation operations.
 - **Fix:** Fetched `isCrossRepository` from `gh pr view\' and gated the remote ref-delete on `!isCrossRepository`.
 - **Commit:** same commit as this entry
 
-
 ### 26. Diff path computed relative to activeCwd instead of repo root
 
 - **Source:** github-codex-connector | PR #444 round 1 | 2026-06-13

--- a/electron/backend-methods.test.ts
+++ b/electron/backend-methods.test.ts
@@ -21,6 +21,8 @@ describe('isAllowedBackendMethod', () => {
     'list_dir',
     'read_file',
     'write_file',
+    'rename_path',
+    'delete_path',
     'git_status',
     'git_branch',
     'git_worktree_name',

--- a/electron/backend-methods.ts
+++ b/electron/backend-methods.ts
@@ -18,6 +18,8 @@ const backendMethods = new Set([
   'list_dir',
   'read_file',
   'write_file',
+  'rename_path',
+  'delete_path',
   'git_status',
   'git_branch',
   'git_worktree_name',

--- a/src/bindings/index.ts
+++ b/src/bindings/index.ts
@@ -30,6 +30,8 @@ export type { FileEntry } from './FileEntry'
 export type { EntryType } from './EntryType'
 export type { ReadFileRequest } from './ReadFileRequest'
 export type { WriteFileRequest } from './WriteFileRequest'
+export type { RenamePathRequest } from './RenamePathRequest'
+export type { DeletePathRequest } from './DeletePathRequest'
 
 // Agent types
 export type { AgentType } from './AgentType'

--- a/src/features/diff/hooks/useGitStatus.test.ts
+++ b/src/features/diff/hooks/useGitStatus.test.ts
@@ -84,7 +84,7 @@ describe('useGitStatus', () => {
       expect(result.current.error).toBeNull()
     })
 
-    test('returns correct structure with filesCwd', async () => {
+    test('returns correct structure with filesCwd and repoRoot', async () => {
       const { result } = renderHook(() => useGitStatus('/home/test/project'))
 
       await waitFor(() => {
@@ -93,6 +93,7 @@ describe('useGitStatus', () => {
 
       expect(result.current).toHaveProperty('files')
       expect(result.current).toHaveProperty('filesCwd')
+      expect(result.current).toHaveProperty('repoRoot')
       expect(result.current).toHaveProperty('loading')
       expect(result.current).toHaveProperty('error')
       expect(result.current).toHaveProperty('refresh')

--- a/src/features/diff/hooks/useGitStatus.ts
+++ b/src/features/diff/hooks/useGitStatus.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { invoke, listen, type UnlistenFn } from '../../../lib/backend'
 import { createGitService } from '../services/gitService'
-import type { ChangedFile } from '../types'
+import type { ChangedFile, GitStatusResponse } from '../types'
 
 interface GitStatusChangedPayload {
   /** List of current working directory paths subscribed to the watcher */
@@ -19,6 +19,11 @@ export interface UseGitStatusReturn {
   files: ChangedFile[]
   /** The cwd of the last successful fetch — never updates on failure or fetch-start */
   filesCwd: string | null
+  /**
+   * Absolute path to the repository toplevel for the last successful fetch.
+   * Empty string when the cwd is not inside a git repo.
+   */
+  repoRoot?: string | null
   loading: boolean
   error: Error | null
   refresh: () => void
@@ -51,6 +56,7 @@ export const useGitStatus = (
 
   const [files, setFiles] = useState<ChangedFile[]>([])
   const [filesCwd, setFilesCwd] = useState<string | null>(null)
+  const [repoRoot, setRepoRoot] = useState<string | null>(null)
   const [loading, setLoading] = useState(() => enabled && isValidCwd(cwd))
   const [error, setError] = useState<Error | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
@@ -76,6 +82,7 @@ export const useGitStatus = (
     if (!enabled || !isValidCwd(cwd)) {
       setFiles([])
       setFilesCwd(null)
+      setRepoRoot(null)
       setLoading(false)
       setError(null)
 
@@ -89,11 +96,13 @@ export const useGitStatus = (
         setLoading(true)
         setError(null)
 
-        const changedFiles = await createGitService(cwd).getStatus()
+        const { files: changedFiles, repoRoot: changedRepoRoot }: GitStatusResponse =
+          await createGitService(cwd).getStatus()
 
         if (!cancelled) {
           setFiles(changedFiles)
           setFilesCwd(cwd) // Only update on success
+          setRepoRoot(changedRepoRoot || null)
         }
       } catch (err) {
         if (!cancelled) {
@@ -222,6 +231,7 @@ export const useGitStatus = (
   return {
     files,
     filesCwd,
+    repoRoot,
     loading,
     error,
     refresh,

--- a/src/features/diff/hooks/useGitStatus.ts
+++ b/src/features/diff/hooks/useGitStatus.ts
@@ -96,8 +96,10 @@ export const useGitStatus = (
         setLoading(true)
         setError(null)
 
-        const { files: changedFiles, repoRoot: changedRepoRoot }: GitStatusResponse =
-          await createGitService(cwd).getStatus()
+        const {
+          files: changedFiles,
+          repoRoot: changedRepoRoot,
+        }: GitStatusResponse = await createGitService(cwd).getStatus()
 
         if (!cancelled) {
           setFiles(changedFiles)

--- a/src/features/diff/services/gitService.test.ts
+++ b/src/features/diff/services/gitService.test.ts
@@ -38,10 +38,11 @@ describe('MockGitService', () => {
   })
 
   test('getStatus returns all changed files', async () => {
-    const files = await service.getStatus()
+    const response = await service.getStatus()
 
-    expect(files).toHaveLength(4)
-    expect(files).toEqual(mockChangedFiles)
+    expect(response.files).toHaveLength(4)
+    expect(response.files).toEqual(mockChangedFiles)
+    expect(response.repoRoot).toBe('')
   })
 
   test('getDiff returns GetGitDiffResponse for existing file', async () => {
@@ -293,13 +294,15 @@ describe('HttpGitService', () => {
     test('fetches status from /api/git/status', async () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockChangedFiles),
+        json: () =>
+          Promise.resolve({ files: mockChangedFiles, repoRoot: '/repo' }),
       })
 
-      const files = await service.getStatus()
+      const response = await service.getStatus()
 
       expect(fetchMock).toHaveBeenCalledWith('/api/git/status')
-      expect(files).toEqual(mockChangedFiles)
+      expect(response.files).toEqual(mockChangedFiles)
+      expect(response.repoRoot).toBe('/repo')
     })
 
     test('throws error on failed request', async () => {
@@ -555,14 +558,18 @@ describe('DesktopGitService', () => {
 
   describe('getStatus', () => {
     test('calls invoke with git_status command and correct args', async () => {
-      invokeMock.mockResolvedValueOnce(mockChangedFiles)
+      invokeMock.mockResolvedValueOnce({
+        files: mockChangedFiles,
+        repoRoot: '/repo',
+      })
 
-      const files = await service.getStatus()
+      const response = await service.getStatus()
 
       expect(invokeMock).toHaveBeenCalledWith('git_status', {
         cwd: '/home/user/project',
       })
-      expect(files).toEqual(mockChangedFiles)
+      expect(response.files).toEqual(mockChangedFiles)
+      expect(response.repoRoot).toBe('/repo')
     })
 
     test('throws error on invoke failure', async () => {

--- a/src/features/diff/services/gitService.ts
+++ b/src/features/diff/services/gitService.ts
@@ -1,4 +1,4 @@
-import type { ChangedFile, FileDiff } from '../types'
+import type { FileDiff, GitStatusResponse } from '../types'
 import { mockChangedFiles, mockFileDiffs } from '../data/mockDiff'
 import { invoke } from '../../../lib/backend'
 import { isDesktop } from '../../../lib/environment'
@@ -160,8 +160,8 @@ const diffHeaderPaths = (
 
 /** Git service interface for diff operations */
 export interface GitService {
-  /** Get all files with git changes */
-  getStatus(): Promise<ChangedFile[]>
+  /** Get all files with git changes and the repository toplevel. */
+  getStatus(): Promise<GitStatusResponse>
 
   /**
    * Get diff for a specific file. Returns the parsed `FileDiff` plus the raw
@@ -210,8 +210,8 @@ export interface GitService {
 
 /** Mock implementation using static mock data (for tests) */
 export class MockGitService implements GitService {
-  async getStatus(): Promise<ChangedFile[]> {
-    return Promise.resolve([...mockChangedFiles])
+  async getStatus(): Promise<GitStatusResponse> {
+    return Promise.resolve({ files: [...mockChangedFiles], repoRoot: '' })
   }
 
   async getDiff(file: string): Promise<GetGitDiffResponse> {
@@ -237,14 +237,14 @@ export class MockGitService implements GitService {
 
 /** HTTP implementation calling Vite dev middleware (for dev) */
 export class HttpGitService implements GitService {
-  async getStatus(): Promise<ChangedFile[]> {
+  async getStatus(): Promise<GitStatusResponse> {
     const response = await fetch('/api/git/status')
 
     if (!response.ok) {
       throw new Error(`Failed to fetch git status: ${response.statusText}`)
     }
 
-    return response.json() as Promise<ChangedFile[]>
+    return response.json() as Promise<GitStatusResponse>
   }
 
   async getDiff(
@@ -333,9 +333,9 @@ export class DesktopGitService implements GitService {
     this.cwd = cwd
   }
 
-  async getStatus(): Promise<ChangedFile[]> {
+  async getStatus(): Promise<GitStatusResponse> {
     try {
-      return await invoke<ChangedFile[]>('git_status', { cwd: this.cwd })
+      return await invoke<GitStatusResponse>('git_status', { cwd: this.cwd })
     } catch (error) {
       throw new Error(`Failed to get git status: ${String(error)}`)
     }

--- a/src/features/diff/types/index.ts
+++ b/src/features/diff/types/index.ts
@@ -12,6 +12,13 @@ export interface ChangedFile {
   staged: boolean // whether file is in the index
 }
 
+/** Response from the git_status backend command. */
+export interface GitStatusResponse {
+  files: ChangedFile[]
+  /** Absolute path to the repository toplevel; empty when cwd is not inside a git repo. */
+  repoRoot: string
+}
+
 /** Selected diff file with cwd tag (for cross-cwd staleness detection) */
 export interface SelectedDiffFile {
   path: string

--- a/src/features/editor/hooks/useEditorBuffer.test.ts
+++ b/src/features/editor/hooks/useEditorBuffer.test.ts
@@ -11,6 +11,8 @@ describe('useEditorBuffer', () => {
       listDir: vi.fn(),
       readFile: vi.fn(),
       writeFile: vi.fn(),
+      renamePath: vi.fn(),
+      deletePath: vi.fn(),
     }
   })
 

--- a/src/features/files/components/ContextMenu.test.tsx
+++ b/src/features/files/components/ContextMenu.test.tsx
@@ -98,6 +98,20 @@ describe('ContextMenu', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  test('calls onAction with clicked item', () => {
+    const onAction = vi.fn()
+    render(<ContextMenu {...defaultProps} onAction={onAction} />)
+
+    const copyPathButton = screen.getByRole('menuitem', {
+      name: /copy path/i,
+    })
+    fireEvent.click(copyPathButton)
+
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'Copy Path' })
+    )
+  })
+
   test('closes menu on Escape key', () => {
     const onClose = vi.fn()
     render(<ContextMenu {...defaultProps} onClose={onClose} />)

--- a/src/features/files/components/ContextMenu.tsx
+++ b/src/features/files/components/ContextMenu.tsx
@@ -8,6 +8,7 @@ interface ContextMenuProps {
   y: number
   actions: ContextMenuAction[]
   onClose: () => void
+  onAction?: (action: ContextMenuAction) => void
 }
 
 /**
@@ -19,6 +20,7 @@ export const ContextMenu = ({
   y,
   actions,
   onClose,
+  onAction = undefined,
 }: ContextMenuProps): ReactElement | null => {
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -74,7 +76,7 @@ export const ContextMenu = ({
         return (
           <button
             key={action.label}
-            className={`flex items-center gap-3 px-4 py-2 text-sm w-full text-left cursor-pointer transition-colors ${
+            className={`flex items-center gap-3 px-4 py-2 text-[15px] w-full text-left cursor-pointer transition-colors ${
               action.variant === 'danger'
                 ? 'hover:bg-error/20 text-error'
                 : 'hover:bg-surface-bright/50 text-on-surface'
@@ -82,6 +84,7 @@ export const ContextMenu = ({
             role="menuitem"
             onClick={() => {
               onClose()
+              onAction?.(action)
             }}
           >
             <span

--- a/src/features/files/components/FileTree.test.tsx
+++ b/src/features/files/components/FileTree.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vi } from 'vitest'
 import { FileTree } from './FileTree'
 import type { FileNode, ContextMenuAction } from '../types'
 
@@ -120,6 +120,27 @@ describe('FileTree', () => {
     // Click menu item
     fireEvent.click(renameButton)
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  test('calls context menu action with target node and full path', () => {
+    const onContextMenuAction = vi.fn()
+    render(
+      <FileTree
+        nodes={mockNodes}
+        contextMenuActions={mockActions}
+        rootPath="~/project"
+        onContextMenuAction={onContextMenuAction}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByText('test.ts'))
+    fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
+
+    expect(onContextMenuAction).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'Rename' }),
+      expect.objectContaining({ id: '2', name: 'test.ts' }),
+      '~/project/src/test.ts'
+    )
   })
 
   test('tree container has no wrapper styling (inherits from parent)', () => {

--- a/src/features/files/components/FileTree.tsx
+++ b/src/features/files/components/FileTree.tsx
@@ -20,7 +20,7 @@ interface FileTreeProps {
     action: ContextMenuAction,
     node: FileNode,
     fullPath: string
-  ) => void
+  ) => void | Promise<void>
 }
 
 /**
@@ -70,7 +70,7 @@ export const FileTree = ({
       return
     }
 
-    onContextMenuAction?.(
+    void onContextMenuAction?.(
       action,
       contextMenuState.targetNode,
       contextMenuState.targetPath

--- a/src/features/files/components/FileTree.tsx
+++ b/src/features/files/components/FileTree.tsx
@@ -16,6 +16,11 @@ interface FileTreeProps {
    */
   rootPath?: string
   onNodeSelect?: (node: FileNode, fullPath: string) => void
+  onContextMenuAction?: (
+    action: ContextMenuAction,
+    node: FileNode,
+    fullPath: string
+  ) => void
 }
 
 /**
@@ -26,20 +31,27 @@ export const FileTree = ({
   contextMenuActions,
   rootPath = '~',
   onNodeSelect = undefined,
+  onContextMenuAction = undefined,
 }: FileTreeProps): ReactElement => {
   const [contextMenuState, setContextMenuState] = useState<ContextMenuState>({
     visible: false,
     x: 0,
     y: 0,
     targetNode: null,
+    targetPath: null,
   })
 
-  const handleContextMenu = (event: MouseEvent, node: FileNode): void => {
+  const handleContextMenu = (
+    event: MouseEvent,
+    node: FileNode,
+    fullPath: string
+  ): void => {
     setContextMenuState({
       visible: true,
       x: event.clientX,
       y: event.clientY,
       targetNode: node,
+      targetPath: fullPath,
     })
   }
 
@@ -49,7 +61,20 @@ export const FileTree = ({
       x: 0,
       y: 0,
       targetNode: null,
+      targetPath: null,
     })
+  }
+
+  const handleContextMenuAction = (action: ContextMenuAction): void => {
+    if (!contextMenuState.targetNode || !contextMenuState.targetPath) {
+      return
+    }
+
+    onContextMenuAction?.(
+      action,
+      contextMenuState.targetNode,
+      contextMenuState.targetPath
+    )
   }
 
   return (
@@ -73,6 +98,7 @@ export const FileTree = ({
         y={contextMenuState.y}
         actions={contextMenuActions}
         onClose={handleCloseContextMenu}
+        onAction={handleContextMenuAction}
       />
     </>
   )

--- a/src/features/files/components/FileTreeNode.test.tsx
+++ b/src/features/files/components/FileTreeNode.test.tsx
@@ -1,10 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, test, expect, vi } from 'vitest'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { FileTreeNode } from './FileTreeNode'
 import type { FileNode } from '../types'
 
 describe('FileTreeNode', () => {
   const mockOnContextMenu = vi.fn()
+
+  beforeEach(() => {
+    mockOnContextMenu.mockClear()
+  })
 
   test('renders file node', () => {
     const fileNode: FileNode = {
@@ -187,7 +191,35 @@ describe('FileTreeNode', () => {
     fireEvent.contextMenu(screen.getByText('test.ts'))
 
     expect(mockOnContextMenu).toHaveBeenCalledTimes(1)
-    expect(mockOnContextMenu).toHaveBeenCalledWith(expect.any(Object), fileNode)
+    expect(mockOnContextMenu).toHaveBeenCalledWith(
+      expect.any(Object),
+      fileNode,
+      'test.ts'
+    )
+  })
+
+  test('passes full path to onContextMenu for nested files', () => {
+    const fileNode: FileNode = {
+      id: '1',
+      name: 'test.ts',
+      type: 'file',
+    }
+
+    render(
+      <FileTreeNode
+        node={fileNode}
+        parentPath="~/src"
+        onContextMenu={mockOnContextMenu}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByText('test.ts'))
+
+    expect(mockOnContextMenu).toHaveBeenCalledWith(
+      expect.any(Object),
+      fileNode,
+      '~/src/test.ts'
+    )
   })
 
   test('renders TypeScript file with description icon', () => {

--- a/src/features/files/components/FileTreeNode.tsx
+++ b/src/features/files/components/FileTreeNode.tsx
@@ -7,7 +7,7 @@ interface FileTreeNodeProps {
   depth?: number
   /** Path of the parent directory (e.g. `~/src/middleware`). Used to compute the full path on select. */
   parentPath?: string
-  onContextMenu: (event: MouseEvent, node: FileNode) => void
+  onContextMenu: (event: MouseEvent, node: FileNode, fullPath: string) => void
   onNodeSelect?: (node: FileNode, fullPath: string) => void
 }
 
@@ -96,7 +96,7 @@ export const FileTreeNode = ({
 
   const handleContextMenu = (event: React.MouseEvent): void => {
     event.preventDefault()
-    onContextMenu(event, node)
+    onContextMenu(event, node, fullPath)
   }
 
   const isFolder = node.type === 'folder'

--- a/src/features/files/data/mockFileTree.ts
+++ b/src/features/files/data/mockFileTree.ts
@@ -53,12 +53,21 @@ export const mockBreadcrumbs: string[] = ['vibm-project', 'src', 'middleware']
  * Context menu action definitions.
  */
 export const contextMenuActions = [
-  { label: 'Rename', icon: 'edit' },
-  { label: 'Delete', icon: 'delete', variant: 'danger' as const },
+  { id: 'rename' as const, label: 'Rename', icon: 'edit' },
+  {
+    id: 'delete' as const,
+    label: 'Delete',
+    icon: 'delete',
+    variant: 'danger' as const,
+  },
   { label: '', icon: '', separator: true },
-  { label: 'Copy Path', icon: 'content_copy' },
-  { label: 'Open in Editor', icon: 'open_in_new' },
-  { label: 'View Diff', icon: 'difference' },
+  { id: 'copy-path' as const, label: 'Copy Path', icon: 'content_copy' },
+  {
+    id: 'open-in-editor' as const,
+    label: 'Open in Editor',
+    icon: 'open_in_new',
+  },
+  { id: 'view-diff' as const, label: 'View Diff', icon: 'difference' },
 ]
 
 /**

--- a/src/features/files/hooks/useFileTree.ts
+++ b/src/features/files/hooks/useFileTree.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import type { FileNode } from '../types'
-import { createFileSystemService } from '../services/fileSystemService'
+import {
+  createFileSystemService,
+  type IFileSystemService,
+} from '../services/fileSystemService'
 
 export interface UseFileTreeResult {
   nodes: FileNode[]
@@ -40,12 +43,16 @@ const normalizeToTilde = (path: string): string => {
   return path
 }
 
-export const useFileTree = (externalCwd: string): UseFileTreeResult => {
+export const useFileTree = (
+  externalCwd: string,
+  providedService?: IFileSystemService
+): UseFileTreeResult => {
   const [currentPath, setCurrentPath] = useState(normalizeToTilde(externalCwd))
   const [nodes, setNodes] = useState<FileNode[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const service = useMemo(() => createFileSystemService(), [])
+  const defaultService = useMemo(() => createFileSystemService(), [])
+  const service = providedService ?? defaultService
   // Generation counter — incremented on every load to discard stale responses
   const generation = useRef(0)
 

--- a/src/features/files/services/fileSystemService.test.ts
+++ b/src/features/files/services/fileSystemService.test.ts
@@ -64,6 +64,8 @@ describe('fileSystemService', () => {
 
     expect(service).toBeDefined()
     expect(typeof service.writeFile).toBe('function')
+    expect(typeof service.renamePath).toBe('function')
+    expect(typeof service.deletePath).toBe('function')
   })
 
   test('mock service writeFile resolves without error', async () => {
@@ -72,5 +74,19 @@ describe('fileSystemService', () => {
     await expect(
       service.writeFile('~/test.txt', 'content')
     ).resolves.toBeUndefined()
+  })
+
+  test('mock service renamePath resolves without error', async () => {
+    const service = createFileSystemService()
+
+    await expect(
+      service.renamePath('~/test.txt', 'renamed.txt')
+    ).resolves.toBeUndefined()
+  })
+
+  test('mock service deletePath resolves without error', async () => {
+    const service = createFileSystemService()
+
+    await expect(service.deletePath('~/test.txt')).resolves.toBeUndefined()
   })
 })

--- a/src/features/files/services/fileSystemService.ts
+++ b/src/features/files/services/fileSystemService.ts
@@ -1,5 +1,9 @@
 import type { FileNode } from '../types'
-import type { FileEntry } from '../../../bindings'
+import type {
+  DeletePathRequest,
+  FileEntry,
+  RenamePathRequest,
+} from '../../../bindings'
 import { isDesktop } from '../../../lib/environment'
 import { invoke } from '../../../lib/backend'
 import { mockFileTree } from '../data/mockFileTree'
@@ -8,6 +12,8 @@ export interface IFileSystemService {
   listDir(path: string): Promise<FileNode[]>
   readFile(path: string): Promise<string>
   writeFile(path: string, content: string): Promise<void>
+  renamePath(path: string, newName: string): Promise<void>
+  deletePath(path: string): Promise<void>
 }
 
 // Join a parent directory path and a child name. Matches the semantics
@@ -60,6 +66,18 @@ class DesktopFileSystemService implements IFileSystemService {
       request: { path, content },
     })
   }
+
+  async renamePath(path: string, newName: string): Promise<void> {
+    const request = { path, newName } satisfies RenamePathRequest
+
+    await invoke<void>('rename_path', { request })
+  }
+
+  async deletePath(path: string): Promise<void> {
+    const request = { path } satisfies DeletePathRequest
+
+    await invoke<void>('delete_path', { request })
+  }
 }
 
 /** Walk mock tree to find children matching a path like "~/src" */
@@ -97,6 +115,14 @@ class MockFileSystemService implements IFileSystemService {
   writeFile(): Promise<void> {
     // Mock implementation - no-op
     // This service is only used in browser mode (not desktop)
+    return Promise.resolve()
+  }
+
+  renamePath(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  deletePath(): Promise<void> {
     return Promise.resolve()
   }
 }

--- a/src/features/files/types/index.test.ts
+++ b/src/features/files/types/index.test.ts
@@ -164,6 +164,7 @@ describe('ContextMenuAction type guard', () => {
   test('returns true for valid action', () => {
     expect(
       isContextMenuAction({
+        id: 'rename',
         label: 'Rename',
         icon: 'edit',
       })
@@ -216,6 +217,16 @@ describe('ContextMenuAction type guard', () => {
     ).toBe(false)
   })
 
+  test('returns false for invalid action id', () => {
+    expect(
+      isContextMenuAction({
+        id: 'invalid',
+        label: 'Rename',
+        icon: 'edit',
+      })
+    ).toBe(false)
+  })
+
   test('returns false for null', () => {
     expect(isContextMenuAction(null)).toBe(false)
   })
@@ -233,6 +244,7 @@ describe('ContextMenuState type guard', () => {
         x: 0,
         y: 0,
         targetNode: null,
+        targetPath: null,
       })
     ).toBe(true)
   })
@@ -248,6 +260,7 @@ describe('ContextMenuState type guard', () => {
           name: 'test.ts',
           type: 'file',
         },
+        targetPath: '~/test.ts',
       })
     ).toBe(true)
   })
@@ -258,6 +271,7 @@ describe('ContextMenuState type guard', () => {
         x: 0,
         y: 0,
         targetNode: null,
+        targetPath: null,
       })
     ).toBe(false)
   })
@@ -268,6 +282,7 @@ describe('ContextMenuState type guard', () => {
         visible: false,
         y: 0,
         targetNode: null,
+        targetPath: null,
       })
     ).toBe(false)
   })
@@ -278,6 +293,7 @@ describe('ContextMenuState type guard', () => {
         visible: false,
         x: 0,
         targetNode: null,
+        targetPath: null,
       })
     ).toBe(false)
   })
@@ -289,6 +305,19 @@ describe('ContextMenuState type guard', () => {
         x: 100,
         y: 200,
         targetNode: { invalid: 'node' },
+        targetPath: '~/test.ts',
+      })
+    ).toBe(false)
+  })
+
+  test('returns false for invalid targetPath', () => {
+    expect(
+      isContextMenuState({
+        visible: true,
+        x: 100,
+        y: 200,
+        targetNode: null,
+        targetPath: 123,
       })
     ).toBe(false)
   })

--- a/src/features/files/types/index.ts
+++ b/src/features/files/types/index.ts
@@ -8,6 +8,13 @@ export type GitStatus =
   | 'renamed'
   | 'untracked'
 
+export type ContextMenuActionId =
+  | 'rename'
+  | 'delete'
+  | 'copy-path'
+  | 'open-in-editor'
+  | 'view-diff'
+
 /**
  * Represents a file or folder node in the file tree.
  */
@@ -27,6 +34,7 @@ export interface FileNode {
  * Represents an action in the context menu.
  */
 export interface ContextMenuAction {
+  id?: ContextMenuActionId
   label: string
   icon: string
   variant?: 'danger'
@@ -41,6 +49,7 @@ export interface ContextMenuState {
   x: number
   y: number
   targetNode: FileNode | null
+  targetPath: string | null
 }
 
 /**
@@ -129,6 +138,20 @@ export const isContextMenuAction = (
     return false
   }
 
+  if (
+    obj.id !== undefined &&
+    (typeof obj.id !== 'string' ||
+      ![
+        'rename',
+        'delete',
+        'copy-path',
+        'open-in-editor',
+        'view-diff',
+      ].includes(obj.id))
+  ) {
+    return false
+  }
+
   // Validate optional variant
   if (obj.variant !== undefined && obj.variant !== 'danger') {
     return false
@@ -182,7 +205,8 @@ export const isContextMenuState = (
   if (
     typeof obj.visible !== 'boolean' ||
     typeof obj.x !== 'number' ||
-    typeof obj.y !== 'number'
+    typeof obj.y !== 'number' ||
+    (obj.targetPath !== null && typeof obj.targetPath !== 'string')
   ) {
     return false
   }

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -266,6 +266,8 @@ describe('WorkspaceView - Command Palette Integration', () => {
       listDir: vi.fn().mockResolvedValue([]),
       readFile: vi.fn().mockResolvedValue(''),
       writeFile: vi.fn().mockResolvedValue(undefined),
+      renamePath: vi.fn().mockResolvedValue(undefined),
+      deletePath: vi.fn().mockResolvedValue(undefined),
     })
 
     // Mock terminalService

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -252,6 +252,8 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
       listDir: vi.fn().mockResolvedValue([]),
       readFile: vi.fn().mockResolvedValue(''),
       writeFile: vi.fn().mockResolvedValue(undefined),
+      renamePath: vi.fn().mockResolvedValue(undefined),
+      deletePath: vi.fn().mockResolvedValue(undefined),
     })
 
     const { createTerminalService } =

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1485,7 +1485,14 @@ export const WorkspaceView = (): ReactElement => {
         return
       }
 
-      const relativePath = relativePathFromCwd(node.id, activeCwd)
+      // The backend normalizes git status/diff to the repository toplevel, so
+      // derive repo-root-relative paths when we know the toplevel. Fall back
+      // to cwd-relative for directories that are not inside a git repo.
+      const repoRoot = gitStatus.repoRoot
+      const relativePath =
+        repoRoot && repoRoot.length > 0
+          ? relativePathFromCwd(node.id, repoRoot)
+          : relativePathFromCwd(node.id, activeCwd)
 
       if (!relativePath) {
         setFileError(`Cannot view diff outside ${activeCwd}: ${node.id}`)
@@ -1512,7 +1519,7 @@ export const WorkspaceView = (): ReactElement => {
       })
       openDock('diff')
     },
-    [activeCwd, gitStatus.files, gitStatus.filesCwd, openDock]
+    [activeCwd, gitStatus.files, gitStatus.filesCwd, gitStatus.repoRoot, openDock]
   )
 
   // Open a test file from the activity panel. Mirrors handleFileSelect's

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1488,7 +1488,8 @@ export const WorkspaceView = (): ReactElement => {
       // The backend normalizes git status/diff to the repository toplevel, so
       // derive repo-root-relative paths when we know the toplevel. Fall back
       // to cwd-relative for directories that are not inside a git repo.
-      const repoRoot = gitStatus.repoRoot
+      const repoRoot =
+        gitStatus.filesCwd === activeCwd ? gitStatus.repoRoot : null
 
       const relativePath =
         repoRoot && repoRoot.length > 0

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -186,6 +186,36 @@ const SIDEBAR_TAB_ITEMS: readonly SidebarTabItem<SidebarTab>[] = [
   { id: 'files', label: 'FILES', icon: 'folder_open' },
 ]
 
+const normalizePathForComparison = (path: string): string =>
+  path.replace(/\\/g, '/').replace(/\/+$/u, '')
+
+const relativePathFromCwd = (path: string, cwd: string): string | null => {
+  const normalizedPath = normalizePathForComparison(path)
+  const normalizedCwd = normalizePathForComparison(cwd)
+
+  if (normalizedCwd === '') {
+    return null
+  }
+
+  if (normalizedPath === normalizedCwd) {
+    return ''
+  }
+
+  if (normalizedCwd === '/') {
+    return normalizedPath.startsWith('/')
+      ? normalizedPath.replace(/^\/+/u, '')
+      : null
+  }
+
+  const cwdPrefix = `${normalizedCwd}/`
+
+  if (!normalizedPath.startsWith(cwdPrefix)) {
+    return null
+  }
+
+  return normalizedPath.slice(cwdPrefix.length)
+}
+
 const mainAutoCollapseThreshold = (workspaceWidth: number): number =>
   clampSize(
     Math.round(workspaceWidth * MAIN_AUTO_COLLAPSE_RATIO),
@@ -1443,6 +1473,48 @@ export const WorkspaceView = (): ReactElement => {
     ]
   )
 
+  const handleFileViewDiff = useCallback(
+    (node: { id: string; type: 'file' | 'folder' }): void => {
+      if (node.type !== 'file') {
+        return
+      }
+
+      if (activeCwd === '.' || activeCwd === '~' || activeCwd.length === 0) {
+        setFileError('Cannot view diff without an active workspace directory')
+
+        return
+      }
+
+      const relativePath = relativePathFromCwd(node.id, activeCwd)
+
+      if (!relativePath) {
+        setFileError(`Cannot view diff outside ${activeCwd}: ${node.id}`)
+
+        return
+      }
+
+      const statusFile =
+        gitStatus.filesCwd === activeCwd
+          ? gitStatus.files.find((file) => file.path === relativePath)
+          : undefined
+
+      if (gitStatus.filesCwd === activeCwd && !statusFile) {
+        setFileError(`No uncommitted changes found for ${relativePath}`)
+
+        return
+      }
+
+      setFileError(null)
+      setSelectedDiffFile({
+        path: relativePath,
+        staged: statusFile?.staged ?? false,
+        cwd: activeCwd,
+      })
+      openDock('diff')
+    },
+    [activeCwd, gitStatus.files, gitStatus.filesCwd, openDock]
+  )
+
   // Open a test file from the activity panel. Mirrors handleFileSelect's
   // dirty-state guard so clicking a test result row never silently
   // discards unsaved editor changes — the same unsaved-dialog flow
@@ -1974,6 +2046,7 @@ export const WorkspaceView = (): ReactElement => {
                     hidden={activeTab !== 'files'}
                     cwd={fileExplorerCwd}
                     onFileSelect={handleFileSelect}
+                    onViewDiff={handleFileViewDiff}
                   />
                 </div>
               }

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1489,6 +1489,7 @@ export const WorkspaceView = (): ReactElement => {
       // derive repo-root-relative paths when we know the toplevel. Fall back
       // to cwd-relative for directories that are not inside a git repo.
       const repoRoot = gitStatus.repoRoot
+
       const relativePath =
         repoRoot && repoRoot.length > 0
           ? relativePathFromCwd(node.id, repoRoot)
@@ -1519,7 +1520,13 @@ export const WorkspaceView = (): ReactElement => {
       })
       openDock('diff')
     },
-    [activeCwd, gitStatus.files, gitStatus.filesCwd, gitStatus.repoRoot, openDock]
+    [
+      activeCwd,
+      gitStatus.files,
+      gitStatus.filesCwd,
+      gitStatus.repoRoot,
+      openDock,
+    ]
   )
 
   // Open a test file from the activity panel. Mirrors handleFileSelect's

--- a/src/features/workspace/components/FilesView.test.tsx
+++ b/src/features/workspace/components/FilesView.test.tsx
@@ -41,6 +41,17 @@ describe('FilesView', () => {
     )
   })
 
+  test('forwards onViewDiff to FileExplorer', () => {
+    const onViewDiff = vi.fn()
+
+    render(<FilesView cwd="~" onFileSelect={vi.fn()} onViewDiff={onViewDiff} />)
+
+    expect(FileExplorerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ onViewDiff }),
+      undefined
+    )
+  })
+
   test('hidden=true applies the `hidden` Tailwind utility class on the testid root', () => {
     render(<FilesView cwd="~" onFileSelect={vi.fn()} hidden />)
 

--- a/src/features/workspace/components/FilesView.tsx
+++ b/src/features/workspace/components/FilesView.tsx
@@ -6,12 +6,14 @@ export interface FilesViewProps {
   hidden?: boolean
   cwd: string
   onFileSelect: (file: FileNode) => void
+  onViewDiff?: (file: FileNode) => void
 }
 
 export const FilesView = ({
   hidden = false,
   cwd,
   onFileSelect,
+  onViewDiff = undefined,
 }: FilesViewProps): ReactElement => (
   // See SessionsView for why we use a conditional class instead of the HTML
   // `hidden` attribute (Tailwind v4 cascade-layer order).
@@ -19,6 +21,10 @@ export const FilesView = ({
     className={`min-h-0 flex-1 flex-col ${hidden ? 'hidden' : 'flex'}`}
     data-testid="files-view"
   >
-    <FileExplorer cwd={cwd} onFileSelect={onFileSelect} />
+    <FileExplorer
+      cwd={cwd}
+      onFileSelect={onFileSelect}
+      onViewDiff={onViewDiff}
+    />
   </div>
 )

--- a/src/features/workspace/components/panels/FileExplorer.test.tsx
+++ b/src/features/workspace/components/panels/FileExplorer.test.tsx
@@ -1,56 +1,77 @@
-import { describe, test, expect, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { describe, test, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { FileExplorer } from './FileExplorer'
+import { mockFileTree } from '../../../files/data/mockFileTree'
+import type { IFileSystemService } from '../../../files/services/fileSystemService'
+
+const originalClipboard = navigator.clipboard
+
+const createTestFileSystemService = (): IFileSystemService => ({
+  listDir: vi.fn().mockResolvedValue(mockFileTree),
+  readFile: vi.fn().mockResolvedValue('content'),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  renamePath: vi.fn().mockResolvedValue(undefined),
+  deletePath: vi.fn().mockResolvedValue(undefined),
+})
+
+const waitForFileTree = async (): Promise<void> => {
+  await waitFor(() => {
+    expect(screen.getByRole('tree', { name: 'File tree' })).toBeInTheDocument()
+  })
+}
 
 describe('FileExplorer', () => {
-  test('renders with file-explorer testid', () => {
-    render(<FileExplorer />)
-    expect(screen.getByTestId('file-explorer')).toBeInTheDocument()
+  afterEach(() => {
+    vi.restoreAllMocks()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    })
   })
 
-  test('fills parent height (sized by sidebar resize)', () => {
+  test('renders with file-explorer testid', async () => {
+    render(<FileExplorer />)
+    expect(screen.getByTestId('file-explorer')).toBeInTheDocument()
+    await waitForFileTree()
+  })
+
+  test('fills parent height (sized by sidebar resize)', async () => {
     render(<FileExplorer />)
     const explorer = screen.getByTestId('file-explorer')
     expect(explorer).toHaveClass('h-full')
+    await waitForFileTree()
   })
 
-  test('renders FILE EXPLORER header with folder_open icon', () => {
+  test('renders FILE EXPLORER header with folder_open icon', async () => {
     render(<FileExplorer />)
     expect(screen.getByText('File Explorer')).toBeInTheDocument()
     expect(screen.getAllByText('folder_open').length).toBeGreaterThan(0)
+    await waitForFileTree()
   })
 
-  test('renders refresh button', () => {
+  test('renders refresh button', async () => {
     render(<FileExplorer />)
     expect(
       screen.getByRole('button', { name: 'Refresh file tree' })
     ).toBeInTheDocument()
+    await waitForFileTree()
   })
 
   test('renders FileTree after loading', async () => {
     render(<FileExplorer />)
-    // Service is async — wait for tree to appear
-    await waitFor(() => {
-      expect(
-        screen.getByRole('tree', { name: 'File tree' })
-      ).toBeInTheDocument()
-    })
+    await waitForFileTree()
+    expect(screen.getByRole('tree', { name: 'File tree' })).toBeInTheDocument()
   })
 
   test('calls onFileSelect with canonical full path for nested files', async () => {
     const handleFileSelect = vi.fn()
     render(<FileExplorer onFileSelect={handleFileSelect} />)
 
-    // Wait for tree to load
-    await waitFor(() => {
-      expect(
-        screen.getByRole('tree', { name: 'File tree' })
-      ).toBeInTheDocument()
-    })
+    await waitForFileTree()
 
     // Click a file nested under src/middleware/ — the mock tree auto-expands it.
     const fileNode = screen.getByText('auth.ts')
-    fileNode.click()
+    fireEvent.click(fileNode)
 
     // The full ancestry must be preserved so the editor reads/saves the right file.
     expect(handleFileSelect).toHaveBeenCalledTimes(1)
@@ -67,15 +88,11 @@ describe('FileExplorer', () => {
     const handleFileSelect = vi.fn()
     render(<FileExplorer onFileSelect={handleFileSelect} />)
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole('tree', { name: 'File tree' })
-      ).toBeInTheDocument()
-    })
+    await waitForFileTree()
 
     // package.json sits at the tree root under cwd `~`
     const fileNode = screen.getByText('package.json')
-    fileNode.click()
+    fireEvent.click(fileNode)
 
     expect(handleFileSelect).toHaveBeenCalledTimes(1)
     expect(handleFileSelect).toHaveBeenCalledWith(
@@ -91,18 +108,109 @@ describe('FileExplorer', () => {
     const handleFileSelect = vi.fn()
     render(<FileExplorer onFileSelect={handleFileSelect} />)
 
-    // Wait for tree to load
-    await waitFor(() => {
-      expect(
-        screen.getByRole('tree', { name: 'File tree' })
-      ).toBeInTheDocument()
-    })
+    await waitForFileTree()
 
     // Click on a folder node (src/)
     const folderNode = screen.getByText('src/')
-    folderNode.click()
+    fireEvent.click(folderNode)
+
+    await waitFor(() => {
+      expect(screen.getByText('middleware/')).toBeInTheDocument()
+    })
 
     // Verify callback was NOT called (folders navigate, don't select)
     expect(handleFileSelect).not.toHaveBeenCalled()
+  })
+
+  test('opens a context-menu file in the editor', async () => {
+    const handleFileSelect = vi.fn()
+    render(<FileExplorer onFileSelect={handleFileSelect} />)
+
+    await waitForFileTree()
+
+    fireEvent.contextMenu(screen.getByText('package.json'))
+    fireEvent.click(screen.getByRole('menuitem', { name: /open in editor/i }))
+
+    expect(handleFileSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: '~/package.json',
+        name: 'package.json',
+        type: 'file',
+      })
+    )
+  })
+
+  test('opens a context-menu file in the diff viewer', async () => {
+    const handleViewDiff = vi.fn()
+    render(<FileExplorer onViewDiff={handleViewDiff} />)
+
+    await waitForFileTree()
+
+    fireEvent.contextMenu(screen.getByText('package.json'))
+    fireEvent.click(screen.getByRole('menuitem', { name: /view diff/i }))
+
+    expect(handleViewDiff).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: '~/package.json',
+        name: 'package.json',
+        type: 'file',
+      })
+    )
+  })
+
+  test('copies the context-menu target path', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    render(<FileExplorer />)
+
+    await waitForFileTree()
+
+    fireEvent.contextMenu(screen.getByText('package.json'))
+    fireEvent.click(screen.getByRole('menuitem', { name: /copy path/i }))
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('~/package.json')
+    })
+  })
+
+  test('renames the context-menu target and refreshes the tree', async () => {
+    const service = createTestFileSystemService()
+    vi.spyOn(window, 'prompt').mockReturnValue('renamed.json')
+
+    render(<FileExplorer fileSystemService={service} />)
+
+    await waitForFileTree()
+
+    fireEvent.contextMenu(screen.getByText('package.json'))
+    fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
+
+    await waitFor(() => {
+      expect(service.renamePath).toHaveBeenCalledWith(
+        '~/package.json',
+        'renamed.json'
+      )
+    })
+    expect(service.listDir).toHaveBeenCalledTimes(2)
+  })
+
+  test('deletes the context-menu target and refreshes the tree', async () => {
+    const service = createTestFileSystemService()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<FileExplorer fileSystemService={service} />)
+
+    await waitForFileTree()
+
+    fireEvent.contextMenu(screen.getByText('package.json'))
+    fireEvent.click(screen.getByRole('menuitem', { name: /delete/i }))
+
+    await waitFor(() => {
+      expect(service.deletePath).toHaveBeenCalledWith('~/package.json')
+    })
+    expect(service.listDir).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/features/workspace/components/panels/FileExplorer.test.tsx
+++ b/src/features/workspace/components/panels/FileExplorer.test.tsx
@@ -20,6 +20,11 @@ const waitForFileTree = async (): Promise<void> => {
   })
 }
 
+const openContextMenu = async (name: string): Promise<void> => {
+  await waitForFileTree()
+  fireEvent.contextMenu(screen.getByText(name))
+}
+
 describe('FileExplorer', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -126,9 +131,7 @@ describe('FileExplorer', () => {
     const handleFileSelect = vi.fn()
     render(<FileExplorer onFileSelect={handleFileSelect} />)
 
-    await waitForFileTree()
-
-    fireEvent.contextMenu(screen.getByText('package.json'))
+    await openContextMenu('package.json')
     fireEvent.click(screen.getByRole('menuitem', { name: /open in editor/i }))
 
     expect(handleFileSelect).toHaveBeenCalledWith(
@@ -144,9 +147,7 @@ describe('FileExplorer', () => {
     const handleViewDiff = vi.fn()
     render(<FileExplorer onViewDiff={handleViewDiff} />)
 
-    await waitForFileTree()
-
-    fireEvent.contextMenu(screen.getByText('package.json'))
+    await openContextMenu('package.json')
     fireEvent.click(screen.getByRole('menuitem', { name: /view diff/i }))
 
     expect(handleViewDiff).toHaveBeenCalledWith(
@@ -167,9 +168,7 @@ describe('FileExplorer', () => {
 
     render(<FileExplorer />)
 
-    await waitForFileTree()
-
-    fireEvent.contextMenu(screen.getByText('package.json'))
+    await openContextMenu('package.json')
     fireEvent.click(screen.getByRole('menuitem', { name: /copy path/i }))
 
     await waitFor(() => {
@@ -179,14 +178,15 @@ describe('FileExplorer', () => {
 
   test('renames the context-menu target and refreshes the tree', async () => {
     const service = createTestFileSystemService()
-    vi.spyOn(window, 'prompt').mockReturnValue('renamed.json')
 
     render(<FileExplorer fileSystemService={service} />)
 
-    await waitForFileTree()
-
-    fireEvent.contextMenu(screen.getByText('package.json'))
+    await openContextMenu('package.json')
     fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
+
+    const renameInput = screen.getByLabelText('Rename file')
+    fireEvent.change(renameInput, { target: { value: 'renamed.json' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm rename' }))
 
     await waitFor(() => {
       expect(service.renamePath).toHaveBeenCalledWith(
@@ -197,20 +197,87 @@ describe('FileExplorer', () => {
     expect(service.listDir).toHaveBeenCalledTimes(2)
   })
 
-  test('deletes the context-menu target and refreshes the tree', async () => {
+  test('cancels rename without calling the service', async () => {
     const service = createTestFileSystemService()
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     render(<FileExplorer fileSystemService={service} />)
 
-    await waitForFileTree()
+    await openContextMenu('package.json')
+    fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
 
-    fireEvent.contextMenu(screen.getByText('package.json'))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel rename' }))
+
+    expect(service.renamePath).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText('Rename file')).not.toBeInTheDocument()
+  })
+
+  test('shows an error when the rename target contains a path separator', async () => {
+    const service = createTestFileSystemService()
+
+    render(<FileExplorer fileSystemService={service} />)
+
+    await openContextMenu('package.json')
+    fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
+
+    const renameInput = screen.getByLabelText('Rename file')
+    fireEvent.change(renameInput, { target: { value: 'foo/bar.json' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm rename' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Name must not contain "/": foo/bar.json')
+      ).toBeInTheDocument()
+    })
+    expect(service.renamePath).not.toHaveBeenCalled()
+  })
+
+  test('deletes the context-menu target and refreshes the tree', async () => {
+    const service = createTestFileSystemService()
+
+    render(<FileExplorer fileSystemService={service} />)
+
+    await openContextMenu('package.json')
     fireEvent.click(screen.getByRole('menuitem', { name: /delete/i }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }))
 
     await waitFor(() => {
       expect(service.deletePath).toHaveBeenCalledWith('~/package.json')
     })
     expect(service.listDir).toHaveBeenCalledTimes(2)
+  })
+
+  test('cancels delete without calling the service', async () => {
+    const service = createTestFileSystemService()
+
+    render(<FileExplorer fileSystemService={service} />)
+
+    await openContextMenu('package.json')
+    fireEvent.click(screen.getByRole('menuitem', { name: /delete/i }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel delete' }))
+
+    expect(service.deletePath).not.toHaveBeenCalled()
+  })
+
+  test('dismisses the action error banner', async () => {
+    const service = createTestFileSystemService()
+    vi.spyOn(service, 'deletePath').mockRejectedValue(
+      new Error('permission denied')
+    )
+
+    render(<FileExplorer fileSystemService={service} />)
+
+    await openContextMenu('package.json')
+    fireEvent.click(screen.getByRole('menuitem', { name: /delete/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to delete/i)).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss error' }))
+
+    expect(screen.queryByText(/Failed to delete/i)).not.toBeInTheDocument()
   })
 })

--- a/src/features/workspace/components/panels/FileExplorer.tsx
+++ b/src/features/workspace/components/panels/FileExplorer.tsx
@@ -209,9 +209,8 @@ export const FileExplorer = ({
 
       if (actionId === 'copy-path') {
         const clipboard = readClipboardWriter()
-        const writeText = clipboard?.writeText
 
-        if (typeof writeText !== 'function') {
+        if (typeof clipboard?.writeText !== 'function') {
           setActionError('Clipboard is unavailable')
 
           return
@@ -219,7 +218,7 @@ export const FileExplorer = ({
 
         void (async (): Promise<void> => {
           try {
-            await writeText(fullPath)
+            await clipboard.writeText(fullPath)
           } catch (caughtError: unknown) {
             const message =
               caughtError instanceof Error

--- a/src/features/workspace/components/panels/FileExplorer.tsx
+++ b/src/features/workspace/components/panels/FileExplorer.tsx
@@ -148,30 +148,25 @@ export const FileExplorer = ({
     [fileSystemService, refresh]
   )
 
-  const startRename = useCallback(
-    (node: FileNode, fullPath: string): void => {
-      setActionError(null)
-      setPendingRename({
-        node,
-        fullPath,
-        value: displayNameFor(node),
-      })
-      // Focus the input on the next tick so the DOM element is mounted.
-      requestAnimationFrame(() => {
-        renameInputRef.current?.focus()
-        renameInputRef.current?.select()
-      })
-    },
-    []
-  )
+  const startRename = useCallback((node: FileNode, fullPath: string): void => {
+    setActionError(null)
+    setPendingRename({
+      node,
+      fullPath,
+      value: displayNameFor(node),
+    })
 
-  const startDelete = useCallback(
-    (node: FileNode, fullPath: string): void => {
-      setActionError(null)
-      setPendingDelete({ node, fullPath })
-    },
-    []
-  )
+    // Focus the input on the next tick so the DOM element is mounted.
+    requestAnimationFrame(() => {
+      renameInputRef.current?.focus()
+      renameInputRef.current?.select()
+    })
+  }, [])
+
+  const startDelete = useCallback((node: FileNode, fullPath: string): void => {
+    setActionError(null)
+    setPendingDelete({ node, fullPath })
+  }, [])
 
   const cancelRename = useCallback((): void => {
     setPendingRename(null)
@@ -214,18 +209,25 @@ export const FileExplorer = ({
 
       if (actionId === 'copy-path') {
         const clipboard = readClipboardWriter()
+        const writeText = clipboard?.writeText
 
-        if (typeof clipboard?.writeText !== 'function') {
+        if (typeof writeText !== 'function') {
           setActionError('Clipboard is unavailable')
 
           return
         }
 
-        void clipboard.writeText(fullPath).catch((caughtError: unknown) => {
-          const message =
-            caughtError instanceof Error ? caughtError.message : String(caughtError)
-          setActionError(`Failed to copy path: ${message}`)
-        })
+        void (async (): Promise<void> => {
+          try {
+            await writeText(fullPath)
+          } catch (caughtError: unknown) {
+            const message =
+              caughtError instanceof Error
+                ? caughtError.message
+                : String(caughtError)
+            setActionError(`Failed to copy path: ${message}`)
+          }
+        })()
 
         return
       }
@@ -365,9 +367,7 @@ export const FileExplorer = ({
             <button
               type="button"
               onClick={() => {
-                if (pendingRename) {
-                  void executeRename(pendingRename)
-                }
+                void executeRename(pendingRename)
               }}
               className="material-symbols-outlined text-sm text-secondary hover:text-secondary/80"
               aria-label="Confirm rename"
@@ -393,9 +393,7 @@ export const FileExplorer = ({
             <button
               type="button"
               onClick={() => {
-                if (pendingDelete) {
-                  void executeDelete(pendingDelete)
-                }
+                void executeDelete(pendingDelete)
               }}
               className="rounded bg-error/20 px-2 py-0.5 font-semibold hover:bg-error/30"
               aria-label="Confirm delete"

--- a/src/features/workspace/components/panels/FileExplorer.tsx
+++ b/src/features/workspace/components/panels/FileExplorer.tsx
@@ -190,7 +190,11 @@ export const FileExplorer = ({
   )
 
   const handleContextMenuAction = useCallback(
-    (action: ContextMenuAction, node: FileNode, fullPath: string): void => {
+    async (
+      action: ContextMenuAction,
+      node: FileNode,
+      fullPath: string
+    ): Promise<void> => {
       setActionError(null)
 
       const actionId = actionIdFor(action)
@@ -216,15 +220,15 @@ export const FileExplorer = ({
           return
         }
 
-        clipboard
-          .writeText(fullPath)
-          .catch((caughtError: unknown) => {
-            const message =
-              caughtError instanceof Error
-                ? caughtError.message
-                : String(caughtError)
-            setActionError(`Failed to copy path: ${message}`)
-          })
+        try {
+          await clipboard.writeText(fullPath)
+        } catch (caughtError: unknown) {
+          const message =
+            caughtError instanceof Error
+              ? caughtError.message
+              : String(caughtError)
+          setActionError(`Failed to copy path: ${message}`)
+        }
 
         return
       }

--- a/src/features/workspace/components/panels/FileExplorer.tsx
+++ b/src/features/workspace/components/panels/FileExplorer.tsx
@@ -210,23 +210,21 @@ export const FileExplorer = ({
       if (actionId === 'copy-path') {
         const clipboard = readClipboardWriter()
 
-        if (typeof clipboard?.writeText !== 'function') {
+        if (clipboard == null || typeof clipboard.writeText !== 'function') {
           setActionError('Clipboard is unavailable')
 
           return
         }
 
-        void (async (): Promise<void> => {
-          try {
-            await clipboard.writeText(fullPath)
-          } catch (caughtError: unknown) {
+        clipboard
+          .writeText(fullPath)
+          .catch((caughtError: unknown) => {
             const message =
               caughtError instanceof Error
                 ? caughtError.message
                 : String(caughtError)
             setActionError(`Failed to copy path: ${message}`)
-          }
-        })()
+          })
 
         return
       }

--- a/src/features/workspace/components/panels/FileExplorer.tsx
+++ b/src/features/workspace/components/panels/FileExplorer.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useState, type ReactElement } from 'react'
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+} from 'react'
 import { Tooltip } from '@/components/Tooltip'
 import { FileTree } from '../../../files/components/FileTree'
 import { contextMenuActions } from '../../../files/data/mockFileTree'
@@ -27,28 +34,21 @@ interface ClipboardWriter {
 const readClipboardWriter = (): ClipboardWriter | null =>
   (navigator as { clipboard?: ClipboardWriter }).clipboard ?? null
 
-const actionIdFor = (action: ContextMenuAction): ContextMenuActionId | null => {
-  if (action.id) {
-    return action.id
-  }
-
-  switch (action.label) {
-    case 'Rename':
-      return 'rename'
-    case 'Delete':
-      return 'delete'
-    case 'Copy Path':
-      return 'copy-path'
-    case 'Open in Editor':
-      return 'open-in-editor'
-    case 'View Diff':
-      return 'view-diff'
-    default:
-      return null
-  }
-}
+const actionIdFor = (action: ContextMenuAction): ContextMenuActionId | null =>
+  action.id ?? null
 
 const displayNameFor = (node: FileNode): string => node.name.replace(/\/$/u, '')
+
+interface PendingRename {
+  node: FileNode
+  fullPath: string
+  value: string
+}
+
+interface PendingDelete {
+  node: FileNode
+  fullPath: string
+}
 
 /**
  * FileExplorer displays the file tree in the sidebar.
@@ -67,6 +67,9 @@ export const FileExplorer = ({
     providedFileSystemService ?? defaultFileSystemService
 
   const [actionError, setActionError] = useState<string | null>(null)
+  const [pendingRename, setPendingRename] = useState<PendingRename | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null)
+  const renameInputRef = useRef<HTMLInputElement>(null)
 
   const {
     nodes,
@@ -91,58 +94,120 @@ export const FileExplorer = ({
     [navigateTo, onFileSelect]
   )
 
-  const runContextMenuAction = useCallback(
-    async (
-      action: ContextMenuAction,
-      node: FileNode,
-      fullPath: string
-    ): Promise<void> => {
+  const executeRename = useCallback(
+    async (pending: PendingRename): Promise<void> => {
+      const displayName = displayNameFor(pending.node)
+      const trimmedName = pending.value.trim()
+
+      if (trimmedName.length === 0 || trimmedName === displayName) {
+        setPendingRename(null)
+
+        return
+      }
+
+      if (trimmedName.includes('/')) {
+        setActionError(`Name must not contain "/": ${trimmedName}`)
+        setPendingRename(null)
+
+        return
+      }
+
+      try {
+        await fileSystemService.renamePath(pending.fullPath, trimmedName)
+        setPendingRename(null)
+        refresh()
+      } catch (caughtError: unknown) {
+        const message =
+          caughtError instanceof Error
+            ? caughtError.message
+            : String(caughtError)
+        setActionError(`Failed to rename ${displayName}: ${message}`)
+        setPendingRename(null)
+      }
+    },
+    [fileSystemService, refresh]
+  )
+
+  const executeDelete = useCallback(
+    async (pending: PendingDelete): Promise<void> => {
+      const displayName = displayNameFor(pending.node)
+
+      try {
+        await fileSystemService.deletePath(pending.fullPath)
+        setPendingDelete(null)
+        refresh()
+      } catch (caughtError: unknown) {
+        const message =
+          caughtError instanceof Error
+            ? caughtError.message
+            : String(caughtError)
+        setActionError(`Failed to delete ${displayName}: ${message}`)
+        setPendingDelete(null)
+      }
+    },
+    [fileSystemService, refresh]
+  )
+
+  const startRename = useCallback(
+    (node: FileNode, fullPath: string): void => {
+      setActionError(null)
+      setPendingRename({
+        node,
+        fullPath,
+        value: displayNameFor(node),
+      })
+      // Focus the input on the next tick so the DOM element is mounted.
+      requestAnimationFrame(() => {
+        renameInputRef.current?.focus()
+        renameInputRef.current?.select()
+      })
+    },
+    []
+  )
+
+  const startDelete = useCallback(
+    (node: FileNode, fullPath: string): void => {
+      setActionError(null)
+      setPendingDelete({ node, fullPath })
+    },
+    []
+  )
+
+  const cancelRename = useCallback((): void => {
+    setPendingRename(null)
+  }, [])
+
+  const cancelDelete = useCallback((): void => {
+    setPendingDelete(null)
+  }, [])
+
+  const handleRenameKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>): void => {
+      if (event.key === 'Enter' && pendingRename) {
+        event.preventDefault()
+        void executeRename(pendingRename)
+      } else if (event.key === 'Escape') {
+        event.preventDefault()
+        cancelRename()
+      }
+    },
+    [pendingRename, executeRename, cancelRename]
+  )
+
+  const handleContextMenuAction = useCallback(
+    (action: ContextMenuAction, node: FileNode, fullPath: string): void => {
       setActionError(null)
 
       const actionId = actionIdFor(action)
-      const displayName = displayNameFor(node)
 
       if (actionId === 'rename') {
-        const nextName = window.prompt('Rename to', displayName)
-        if (nextName === null) {
-          return
-        }
-
-        const trimmedName = nextName.trim()
-        if (trimmedName.length === 0 || trimmedName === displayName) {
-          return
-        }
-
-        try {
-          await fileSystemService.renamePath(fullPath, trimmedName)
-          refresh()
-        } catch (caughtError: unknown) {
-          const message =
-            caughtError instanceof Error
-              ? caughtError.message
-              : String(caughtError)
-          setActionError(`Failed to rename ${displayName}: ${message}`)
-        }
+        startRename(node, fullPath)
 
         return
       }
 
       if (actionId === 'delete') {
-        const confirmed = window.confirm(`Delete ${displayName}?`)
-        if (!confirmed) {
-          return
-        }
-
-        try {
-          await fileSystemService.deletePath(fullPath)
-          refresh()
-        } catch (caughtError: unknown) {
-          const message =
-            caughtError instanceof Error
-              ? caughtError.message
-              : String(caughtError)
-          setActionError(`Failed to delete ${displayName}: ${message}`)
-        }
+        startDelete(node, fullPath)
 
         return
       }
@@ -156,15 +221,11 @@ export const FileExplorer = ({
           return
         }
 
-        try {
-          await clipboard.writeText(fullPath)
-        } catch (caughtError: unknown) {
+        void clipboard.writeText(fullPath).catch((caughtError: unknown) => {
           const message =
-            caughtError instanceof Error
-              ? caughtError.message
-              : String(caughtError)
+            caughtError instanceof Error ? caughtError.message : String(caughtError)
           setActionError(`Failed to copy path: ${message}`)
-        }
+        })
 
         return
       }
@@ -191,14 +252,7 @@ export const FileExplorer = ({
         onViewDiff?.({ ...node, id: fullPath })
       }
     },
-    [fileSystemService, onFileSelect, onViewDiff, refresh]
-  )
-
-  const handleContextMenuAction = useCallback(
-    (action: ContextMenuAction, node: FileNode, fullPath: string): void => {
-      void runContextMenuAction(action, node, fullPath)
-    },
-    [runContextMenuAction]
+    [startRename, startDelete, onFileSelect, onViewDiff]
   )
 
   // Display a short label for the current path
@@ -280,10 +334,85 @@ export const FileExplorer = ({
           </div>
         )}
         {actionError && (
-          <div className="mb-2 rounded bg-error/10 px-2 py-1 font-mono text-xs text-error">
-            {actionError}
+          <div className="mb-2 flex items-center gap-2 rounded bg-error/10 px-2 py-1 font-mono text-xs text-error">
+            <span className="flex-1">{actionError}</span>
+            <button
+              type="button"
+              onClick={() => setActionError(null)}
+              className="material-symbols-outlined shrink-0 text-sm hover:text-error/80"
+              aria-label="Dismiss error"
+            >
+              close
+            </button>
           </div>
         )}
+
+        {pendingRename && (
+          <div className="mb-2 flex items-center gap-2 rounded bg-surface px-2 py-1.5">
+            <input
+              ref={renameInputRef}
+              type="text"
+              value={pendingRename.value}
+              onChange={(event) =>
+                setPendingRename((current) =>
+                  current ? { ...current, value: event.target.value } : null
+                )
+              }
+              onKeyDown={handleRenameKeyDown}
+              className="flex-1 rounded border border-on-surface/20 bg-base px-1.5 py-1 font-mono text-xs text-on-surface outline-none focus:border-secondary"
+              aria-label="Rename file"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                if (pendingRename) {
+                  void executeRename(pendingRename)
+                }
+              }}
+              className="material-symbols-outlined text-sm text-secondary hover:text-secondary/80"
+              aria-label="Confirm rename"
+            >
+              check
+            </button>
+            <button
+              type="button"
+              onClick={cancelRename}
+              className="material-symbols-outlined text-sm text-on-surface/50 hover:text-on-surface"
+              aria-label="Cancel rename"
+            >
+              close
+            </button>
+          </div>
+        )}
+
+        {pendingDelete && (
+          <div className="mb-2 flex items-center gap-2 rounded bg-error/10 px-2 py-1.5 font-mono text-xs text-error">
+            <span className="flex-1">
+              Delete <strong>{displayNameFor(pendingDelete.node)}</strong>?
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                if (pendingDelete) {
+                  void executeDelete(pendingDelete)
+                }
+              }}
+              className="rounded bg-error/20 px-2 py-0.5 font-semibold hover:bg-error/30"
+              aria-label="Confirm delete"
+            >
+              Delete
+            </button>
+            <button
+              type="button"
+              onClick={cancelDelete}
+              className="rounded px-2 py-0.5 hover:bg-error/20"
+              aria-label="Cancel delete"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+
         {!isLoading && !error && (
           <FileTree
             nodes={nodes}

--- a/src/features/workspace/components/panels/FileExplorer.tsx
+++ b/src/features/workspace/components/panels/FileExplorer.tsx
@@ -1,14 +1,54 @@
-import type { ReactElement } from 'react'
+import { useCallback, useMemo, useState, type ReactElement } from 'react'
 import { Tooltip } from '@/components/Tooltip'
 import { FileTree } from '../../../files/components/FileTree'
 import { contextMenuActions } from '../../../files/data/mockFileTree'
 import { useFileTree } from '../../../files/hooks/useFileTree'
-import type { FileNode } from '../../../files/types'
+import {
+  createFileSystemService,
+  type IFileSystemService,
+} from '../../../files/services/fileSystemService'
+import type {
+  ContextMenuAction,
+  ContextMenuActionId,
+  FileNode,
+} from '../../../files/types'
 
 export interface FileExplorerProps {
   cwd?: string
   onFileSelect?: (node: FileNode) => void
+  onViewDiff?: (node: FileNode) => void
+  fileSystemService?: IFileSystemService
 }
+
+interface ClipboardWriter {
+  writeText?: (text: string) => Promise<void>
+}
+
+const readClipboardWriter = (): ClipboardWriter | null =>
+  (navigator as { clipboard?: ClipboardWriter }).clipboard ?? null
+
+const actionIdFor = (action: ContextMenuAction): ContextMenuActionId | null => {
+  if (action.id) {
+    return action.id
+  }
+
+  switch (action.label) {
+    case 'Rename':
+      return 'rename'
+    case 'Delete':
+      return 'delete'
+    case 'Copy Path':
+      return 'copy-path'
+    case 'Open in Editor':
+      return 'open-in-editor'
+    case 'View Diff':
+      return 'view-diff'
+    default:
+      return null
+  }
+}
+
+const displayNameFor = (node: FileNode): string => node.name.replace(/\/$/u, '')
 
 /**
  * FileExplorer displays the file tree in the sidebar.
@@ -18,7 +58,16 @@ export interface FileExplorerProps {
 export const FileExplorer = ({
   cwd = '~',
   onFileSelect = undefined,
+  onViewDiff = undefined,
+  fileSystemService: providedFileSystemService = undefined,
 }: FileExplorerProps): ReactElement => {
+  const defaultFileSystemService = useMemo(() => createFileSystemService(), [])
+
+  const fileSystemService =
+    providedFileSystemService ?? defaultFileSystemService
+
+  const [actionError, setActionError] = useState<string | null>(null)
+
   const {
     nodes,
     currentPath,
@@ -27,17 +76,130 @@ export const FileExplorer = ({
     refresh,
     navigateTo,
     navigateUp,
-  } = useFileTree(cwd)
+  } = useFileTree(cwd, fileSystemService)
 
-  const handleNodeSelect = (node: FileNode, fullPath: string): void => {
-    if (node.type === 'folder') {
-      // Navigate into the folder — the `fullPath` already includes the ancestry.
-      navigateTo(fullPath)
-    } else {
-      // File: emit with canonical full path as the id so consumers can read/save it.
-      onFileSelect?.({ ...node, id: fullPath })
-    }
-  }
+  const handleNodeSelect = useCallback(
+    (node: FileNode, fullPath: string): void => {
+      if (node.type === 'folder') {
+        // Navigate into the folder — the `fullPath` already includes the ancestry.
+        navigateTo(fullPath)
+      } else {
+        // File: emit with canonical full path as the id so consumers can read/save it.
+        onFileSelect?.({ ...node, id: fullPath })
+      }
+    },
+    [navigateTo, onFileSelect]
+  )
+
+  const runContextMenuAction = useCallback(
+    async (
+      action: ContextMenuAction,
+      node: FileNode,
+      fullPath: string
+    ): Promise<void> => {
+      setActionError(null)
+
+      const actionId = actionIdFor(action)
+      const displayName = displayNameFor(node)
+
+      if (actionId === 'rename') {
+        const nextName = window.prompt('Rename to', displayName)
+        if (nextName === null) {
+          return
+        }
+
+        const trimmedName = nextName.trim()
+        if (trimmedName.length === 0 || trimmedName === displayName) {
+          return
+        }
+
+        try {
+          await fileSystemService.renamePath(fullPath, trimmedName)
+          refresh()
+        } catch (caughtError: unknown) {
+          const message =
+            caughtError instanceof Error
+              ? caughtError.message
+              : String(caughtError)
+          setActionError(`Failed to rename ${displayName}: ${message}`)
+        }
+
+        return
+      }
+
+      if (actionId === 'delete') {
+        const confirmed = window.confirm(`Delete ${displayName}?`)
+        if (!confirmed) {
+          return
+        }
+
+        try {
+          await fileSystemService.deletePath(fullPath)
+          refresh()
+        } catch (caughtError: unknown) {
+          const message =
+            caughtError instanceof Error
+              ? caughtError.message
+              : String(caughtError)
+          setActionError(`Failed to delete ${displayName}: ${message}`)
+        }
+
+        return
+      }
+
+      if (actionId === 'copy-path') {
+        const clipboard = readClipboardWriter()
+
+        if (typeof clipboard?.writeText !== 'function') {
+          setActionError('Clipboard is unavailable')
+
+          return
+        }
+
+        try {
+          await clipboard.writeText(fullPath)
+        } catch (caughtError: unknown) {
+          const message =
+            caughtError instanceof Error
+              ? caughtError.message
+              : String(caughtError)
+          setActionError(`Failed to copy path: ${message}`)
+        }
+
+        return
+      }
+
+      if (actionId === 'open-in-editor') {
+        if (node.type !== 'file') {
+          setActionError('Only files can be opened in the editor')
+
+          return
+        }
+
+        onFileSelect?.({ ...node, id: fullPath })
+
+        return
+      }
+
+      if (actionId === 'view-diff') {
+        if (node.type !== 'file') {
+          setActionError('Only files can be opened in the diff viewer')
+
+          return
+        }
+
+        onViewDiff?.({ ...node, id: fullPath })
+      }
+    },
+    [fileSystemService, onFileSelect, onViewDiff, refresh]
+  )
+
+  const handleContextMenuAction = useCallback(
+    (action: ContextMenuAction, node: FileNode, fullPath: string): void => {
+      void runContextMenuAction(action, node, fullPath)
+    },
+    [runContextMenuAction]
+  )
 
   // Display a short label for the current path
   const pathLabel =
@@ -117,12 +279,18 @@ export const FileExplorer = ({
             {error}
           </div>
         )}
+        {actionError && (
+          <div className="mb-2 rounded bg-error/10 px-2 py-1 font-mono text-xs text-error">
+            {actionError}
+          </div>
+        )}
         {!isLoading && !error && (
           <FileTree
             nodes={nodes}
             contextMenuActions={contextMenuActions}
             rootPath={currentPath}
             onNodeSelect={handleNodeSelect}
+            onContextMenuAction={handleContextMenuAction}
           />
         )}
       </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -342,6 +342,13 @@ function gitApiPlugin(): Plugin {
             const baseBranch = url.searchParams.get('base') ?? 'main'
             const changedFiles: ChangedFile[] = []
 
+            let statusRepoRoot = ''
+            try {
+              statusRepoRoot = await git.revparse(['--show-toplevel'])
+            } catch {
+              // Not a git repo — leave repoRoot empty and continue with empty files.
+            }
+
             // Get all files changed on this branch vs base (committed changes)
             const branchDiffSummary = await git.diffSummary([baseBranch])
 
@@ -419,7 +426,9 @@ function gitApiPlugin(): Plugin {
             }
 
             res.writeHead(200, { 'Content-Type': 'application/json' })
-            res.end(JSON.stringify(changedFiles))
+            res.end(
+              JSON.stringify({ files: changedFiles, repoRoot: statusRepoRoot })
+            )
 
             return
           }


### PR DESCRIPTION
## Summary

- Wire the Files Explorer context menu actions to real behavior for rename, delete, copy path, open in editor, and view diff.
- Add backend filesystem mutation IPC for scoped rename/delete operations and Electron allowlist coverage.
- Pass full file paths through the file tree context-menu flow and bump the Files Explorer context-menu label size.

## Impact

Right-click actions in the Files Explorer now perform the expected workspace operations instead of only rendering the dropdown UI.

## Validation

- `npm run type-check`
- focused Vitest suite for files/workspace/editor/electron changes
- targeted ESLint for touched TS/TSX files
- `cargo test --manifest-path crates/backend/Cargo.toml`
- `git diff --check`
- pre-commit lint-staged checks
- pre-push `npm test` full Vitest suite passed with existing React `act(...)` warnings in unrelated tests