### PR TITLE
feat(agent-status): add VIM-127 status snapshot store (PR2)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                                                              | Category           | Findings | Refs | Last Updated |
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 22       | 4    | 2026-06-13   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 33       | 15   | 2026-06-11   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 35       | 15   | 2026-06-15   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,7 +2,7 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-11
+last_updated: 2026-06-15
 ref_count: 15
 ---
 
@@ -310,4 +310,22 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/workspace/WorkspaceView.tsx`, `src/features/workspace/components/AgentStatusCard.tsx`
 - **Finding:** `sidebarCardState` was computed through a 5-branch ternary over `activityPanelStatus` and `agentStatus.isActive` on every render, then passed as `state={sidebarCardState}` to `AgentStatusCard` where it was immediately discarded via `void state`. No state-driven visual output existed in the card, so the computation served no purpose and misled the component interface.
 - **Fix:** Removed `sidebarCardState` computation from `WorkspaceView`, removed the `state` prop from `AgentStatusCardProps`, and updated co-located tests to match the new prop contract.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 31. Ref mutation + store write inside setStatus updater breaks React StrictMode
+
+- **Source:** github-claude | PR #456 round 1 | 2026-06-15
+- **Severity:** HIGH
+- **File:** `src/features/agent-status/hooks/useAgentStatus.ts`
+- **Finding:** `seenToolUseIdsRef.current.has/add` and `writeStatusSeenToolUseIds` were called inside the functional `setStatus` updater. React 18 StrictMode double-invokes state updaters with the same `prev` in development, so the first invocation mutated the ref and the second invocation treated the legitimate tool call as a duplicate, returning `prev` unchanged.
+- **Fix:** Hoisted the ref mutation and store write out of the updater into the listener closure (before `setStatus`), capturing the `duplicate` boolean so both StrictMode invocations see the same value. The updater now only computes the next state from `prev`.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 32. Move seen-tool ID writes out of the state updater
+
+- **Source:** github-codex-connector | PR #456 round 1 | 2026-06-15
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/agent-status/hooks/useAgentStatus.ts`
+- **Finding:** The functional updater for tool-call completion state mutated `seenToolUseIdsRef` before computing the new state. Under React StrictMode the updater can run twice, so the second invocation saw the ID as already seen and dropped the completed tool call from counts and the recent-calls list.
+- **Fix:** Same change as entry 31: computed the duplicate decision and persisted the seen set outside the updater, keeping the updater pure and StrictMode-safe.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/superpowers/specs/2026-06-14-activity-panel-hot-reload/pr-2-status-store.md
+++ b/docs/superpowers/specs/2026-06-14-activity-panel-hot-reload/pr-2-status-store.md
@@ -17,6 +17,12 @@ Introduce a stable activity/status snapshot layer so pane switching does not for
 - Merge updates incrementally using stable item ids; do not replace the entire list when only a few rows changed.
 - Keep terminal states and error states explicit so retained content never hides a real failure.
 
+## PR2 Boundary Decision
+
+The current sidebar already has a usable status identity: `WorkspaceView` passes the active PTY-backed pane id into `useAgentStatus`, and backend agent events are already keyed by the same PTY id. PR2 therefore keys snapshots by that PTY-backed pane id and stays frontend-only. No Rust IPC or binding change is required for this slice.
+
+The PR2 store is intentionally in-memory and bounded to the most recent pane snapshots. PR3 owns request orchestration and should add stale-response guards in the hot-load coordinator, where the async refresh lifecycle has a real production caller.
+
 ## Interface Guidance
 
 - Prefer existing feature-local hooks and stores over a new global state framework.

--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -1,10 +1,15 @@
 // cspell:ignore winoooops
-import { describe, test, expect, vi } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { afterEach, describe, test, expect, vi } from 'vitest'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AGENTS } from '../../../../agents/registry'
 import type { AgentStatus } from '../../types'
 import * as useGitStatusModule from '../../../diff/hooks/useGitStatus'
+import {
+  clearStatusSnapshots,
+  readStatusScrollAnchor,
+  writeStatusScrollAnchor,
+} from '../../utils/statusSnapshotStore'
 import { AgentStatusPanel } from '.'
 
 const inactiveAgentStatus: AgentStatus = {
@@ -100,6 +105,10 @@ const defaultProps = {
 }
 
 describe('AgentStatusPanel', () => {
+  afterEach(() => {
+    clearStatusSnapshots()
+  })
+
   test('renders at 280px width when agent is not active', () => {
     render(
       <AgentStatusPanel {...defaultProps} agentStatus={inactiveAgentStatus} />
@@ -370,6 +379,33 @@ describe('AgentStatusPanel', () => {
 
     // Sparkline renders when history is present.
     expect(screen.getByTestId('token-cache-sparkline')).toBeInTheDocument()
+  })
+
+  test('restores and stores the pane scroll anchor', () => {
+    writeStatusScrollAnchor('pty-pane-1', 148)
+
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={activeAgentStatus}
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    const panel = screen.getByTestId('agent-status-panel')
+
+    /* eslint-disable testing-library/no-node-access */
+    const scrollable = panel.querySelector('.overflow-y-auto')
+    expect(scrollable).toBeInstanceOf(HTMLDivElement)
+
+    const scrollContainer = scrollable as HTMLDivElement
+    expect(scrollContainer.scrollTop).toBe(148)
+
+    scrollContainer.scrollTop = 260
+    fireEvent.scroll(scrollContainer)
+    /* eslint-enable testing-library/no-node-access */
+
+    expect(readStatusScrollAnchor('pty-pane-1')).toBe(260)
   })
 
   test('renders Header above the body with the provided agent status and onCollapse', async () => {

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -1,9 +1,12 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
   type ReactElement,
+  type UIEvent,
 } from 'react'
 import type { Agent } from '../../../../agents/registry'
 import type { AgentStatus } from '../../types'
@@ -23,6 +26,10 @@ import {
 } from '../../../diff/hooks/useGitStatus'
 import type { ChangedFile } from '../../../diff/types'
 import { AgentStatusPanelHeader } from './Header'
+import {
+  readStatusScrollAnchor,
+  writeStatusScrollAnchor,
+} from '../../utils/statusSnapshotStore'
 
 interface AgentStatusPanelProps {
   agentStatus: AgentStatus
@@ -34,6 +41,7 @@ interface AgentStatusPanelProps {
   status: SessionStatus
   onCollapse: () => void
   cacheHistory: number[]
+  snapshotKey?: string | null
 }
 
 // Exported so WorkspaceView can target this width as the
@@ -53,9 +61,12 @@ export const AgentStatusPanel = ({
   status: sessionStatus,
   onCollapse,
   cacheHistory,
+  snapshotKey = null,
 }: AgentStatusPanelProps): ReactElement => {
   const status = agentStatus
   const events = useActivityEvents(status)
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const programmaticScrollTopRef = useRef<number | null>(null)
 
   const internalGitStatus = useGitStatus(cwd, {
     watch: true,
@@ -126,6 +137,51 @@ export const AgentStatusPanel = ({
 
   const canActivate = liveFile !== null
 
+  useLayoutEffect(() => {
+    if (snapshotKey === null) {
+      return
+    }
+
+    const scrollContainer = scrollContainerRef.current
+
+    if (scrollContainer === null) {
+      return
+    }
+
+    const scrollTop = readStatusScrollAnchor(snapshotKey)
+
+    programmaticScrollTopRef.current = scrollTop
+    scrollContainer.scrollTop = scrollTop
+    programmaticScrollTopRef.current = scrollContainer.scrollTop
+  }, [
+    snapshotKey,
+    feedEvents,
+    runningId,
+    effectiveFiles,
+    effectiveLoading,
+    error,
+    status.testRun,
+  ])
+
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>): void => {
+      if (snapshotKey === null) {
+        return
+      }
+
+      const nextScrollTop = event.currentTarget.scrollTop
+
+      if (programmaticScrollTopRef.current === nextScrollTop) {
+        programmaticScrollTopRef.current = null
+
+        return
+      }
+
+      writeStatusScrollAnchor(snapshotKey, nextScrollTop)
+    },
+    [snapshotKey]
+  )
+
   return (
     <div
       data-testid="agent-status-panel"
@@ -156,7 +212,11 @@ export const AgentStatusPanel = ({
         />
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-clip">
+      <div
+        ref={scrollContainerRef}
+        className="min-h-0 flex-1 overflow-y-auto overflow-x-clip"
+        onScroll={handleScroll}
+      >
         <ToolCallSummary
           total={status.toolCalls.total}
           byType={status.toolCalls.byType}

--- a/src/features/agent-status/hooks/useAgentStatus.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.test.ts
@@ -4,6 +4,7 @@ import { renderHook, act } from '@testing-library/react'
 import { invoke, listen } from '../../../lib/backend'
 import { getPtySessionId } from '../../terminal/ptySessionMap'
 import type { TestRunSnapshot } from '../types'
+import { clearStatusSnapshots } from '../utils/statusSnapshotStore'
 import { useAgentStatus } from './useAgentStatus'
 
 type EventCallback<T = unknown> = (payload: T) => void
@@ -56,6 +57,7 @@ const emit = <T>(eventName: string, payload: T): void => {
 describe('useAgentStatus', () => {
   beforeEach(() => {
     eventListeners.clear()
+    clearStatusSnapshots()
     vi.clearAllMocks()
     // Restore default implementations so per-test overrides don't leak.
     vi.mocked(invoke).mockImplementation(defaultInvokeImpl)
@@ -297,6 +299,96 @@ describe('useAgentStatus', () => {
     expect(result.current.isActive).toBe(false)
     expect(result.current.agentType).toBeNull()
     expect(result.current.sessionId).toBe('session-2')
+  })
+
+  test('restores a cached status snapshot when switching back to a pane', async () => {
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) => useAgentStatus(id),
+      { initialProps: { id: 'session-1' } }
+    )
+
+    await vi.waitFor(() => {
+      expect(eventListeners.get('agent-status')?.length).toBe(1)
+    })
+
+    act(() => {
+      emit('agent-status', {
+        sessionId: 'pty-session-1',
+        modelId: 'sonnet-4-5',
+        modelDisplayName: 'Sonnet 4.5',
+        version: '1.0',
+        agentSessionId: 'agent-session-1',
+        contextWindow: null,
+        cost: null,
+        rateLimits: null,
+      })
+    })
+
+    expect(result.current.modelId).toBe('sonnet-4-5')
+
+    rerender({ id: 'session-2' })
+
+    expect(result.current.sessionId).toBe('session-2')
+    expect(result.current.modelId).toBeNull()
+
+    rerender({ id: 'session-1' })
+
+    expect(result.current.sessionId).toBe('session-1')
+    expect(result.current.modelId).toBe('sonnet-4-5')
+    expect(result.current.agentSessionId).toBe('agent-session-1')
+  })
+
+  test('collapses a restored active snapshot when the inactive pane agent exited', async () => {
+    const detections = new Map<string, unknown>([
+      [
+        'pty-session-1',
+        {
+          sessionId: 'pty-session-1',
+          agentType: 'claudeCode',
+          pid: 123,
+        },
+      ],
+      ['pty-session-2', null],
+    ])
+
+    vi.mocked(invoke).mockImplementation(((cmd: string, args?: unknown) => {
+      if (cmd === 'detect_agent_in_session') {
+        const sessionId =
+          typeof args === 'object' && args !== null && 'sessionId' in args
+            ? String(args.sessionId)
+            : ''
+
+        return Promise.resolve(detections.get(sessionId) ?? null)
+      }
+
+      return Promise.resolve(null)
+    }) as unknown as typeof invoke)
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) => useAgentStatus(id),
+      { initialProps: { id: 'session-1' } }
+    )
+
+    await vi.waitFor(() => {
+      expect(result.current.isActive).toBe(true)
+      expect(result.current.agentExited).toBe(false)
+    })
+
+    detections.set('pty-session-1', null)
+
+    rerender({ id: 'session-2' })
+
+    expect(result.current.sessionId).toBe('session-2')
+    expect(result.current.isActive).toBe(false)
+
+    rerender({ id: 'session-1' })
+
+    expect(result.current.sessionId).toBe('session-1')
+    expect(result.current.isActive).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(result.current.agentExited).toBe(true)
+    })
   })
 
   test('surfaces currentUsage through normalization', async () => {
@@ -569,6 +661,60 @@ describe('useAgentStatus', () => {
     expect(result.current.recentToolCalls).toHaveLength(50)
     // Newest first — arrival order determines insertion, and #54 was last.
     expect(result.current.recentToolCalls[0].args).toBe('{"i":54}')
+  })
+
+  test('does not double count replayed tool calls after restoring a snapshot', async () => {
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) => useAgentStatus(id),
+      { initialProps: { id: 'session-1' } }
+    )
+
+    await vi.waitFor(() => {
+      expect(eventListeners.get('agent-tool-call')?.length).toBe(1)
+    })
+
+    for (let index = 0; index < 55; index += 1) {
+      act(() => {
+        emit('agent-tool-call', {
+          sessionId: 'pty-session-1',
+          toolUseId: `toolu_${String(index).padStart(3, '0')}`,
+          tool: 'Read',
+          args: `{"i":${String(index)}}`,
+          status: 'done',
+          timestamp: `2026-04-12T00:${String(Math.floor(index / 60)).padStart(2, '0')}:${String(index % 60).padStart(2, '0')}Z`,
+          durationMs: 100,
+        })
+      })
+    }
+
+    expect(result.current.toolCalls.total).toBe(55)
+    expect(result.current.recentToolCalls).toHaveLength(50)
+
+    rerender({ id: 'session-2' })
+    rerender({ id: 'session-1' })
+
+    expect(result.current.toolCalls.total).toBe(55)
+
+    for (let index = 0; index < 55; index += 1) {
+      act(() => {
+        emit('agent-tool-call', {
+          sessionId: 'pty-session-1',
+          toolUseId: `toolu_${String(index).padStart(3, '0')}`,
+          tool: 'Read',
+          args: `{"i":${String(index)}}`,
+          status: 'done',
+          timestamp: `2026-04-12T00:${String(Math.floor(index / 60)).padStart(2, '0')}:${String(index % 60).padStart(2, '0')}Z`,
+          durationMs: 100,
+        })
+      })
+    }
+
+    expect(result.current.toolCalls.total).toBe(55)
+    expect(result.current.toolCalls.byType).toEqual({ Read: 55 })
+    expect(result.current.recentToolCalls).toHaveLength(50)
+    expect(
+      new Set(result.current.recentToolCalls.map((call) => call.id)).size
+    ).toBe(50)
   })
 
   test('sets active tool call on running status', async () => {

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { invoke, listen } from '../../../lib/backend'
 import { getPtySessionId } from '../../terminal/ptySessionMap'
+import {
+  readStatusSeenToolUseIds,
+  readStatusSnapshot,
+  writeStatusSeenToolUseIds,
+  writeStatusSnapshot,
+} from '../utils/statusSnapshotStore'
 import type {
   AgentCwdEvent,
   AgentDetectedEvent,
@@ -50,6 +56,33 @@ const createDefaultStatus = (sessionId: string | null): AgentStatus => ({
   testRun: null,
 })
 
+const createStatusForSession = (sessionId: string | null): AgentStatus => {
+  if (sessionId === null) {
+    return createDefaultStatus(null)
+  }
+
+  return readStatusSnapshot(sessionId) ?? createDefaultStatus(sessionId)
+}
+
+const shouldTreatStatusAsDetected = (status: AgentStatus): boolean =>
+  status.isActive || status.agentExited
+
+const createSeenToolUseIds = (status: AgentStatus): Set<string> =>
+  new Set(status.recentToolCalls.map((call) => call.id))
+
+const createSeenToolUseIdsForSession = (
+  sessionId: string | null,
+  status: AgentStatus
+): Set<string> => {
+  if (sessionId === null) {
+    return createSeenToolUseIds(status)
+  }
+
+  const stored = readStatusSeenToolUseIds(sessionId)
+
+  return stored.size > 0 ? stored : createSeenToolUseIds(status)
+}
+
 /**
  * Stop all agent watchers for a given session (best-effort, logs on failure).
  *
@@ -78,7 +111,11 @@ const stopWatchers = async (
 
 export const useAgentStatus = (sessionId: string | null): AgentStatus => {
   const [status, setStatus] = useState<AgentStatus>(() =>
-    createDefaultStatus(sessionId)
+    createStatusForSession(sessionId)
+  )
+
+  const seenToolUseIdsRef = useRef<Set<string>>(
+    createSeenToolUseIdsForSession(sessionId, status)
   )
   const prevSessionIdRef = useRef<string | null>(sessionId)
 
@@ -103,7 +140,7 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
   // past and is now gone, regardless of whether the backend watcher
   // start succeeded — so transient `start_agent_watcher` failures no
   // longer leave the panel stuck.
-  const agentEverDetectedRef = useRef(false)
+  const agentEverDetectedRef = useRef(shouldTreatStatusAsDetected(status))
   const watcherStartedRef = useRef(false)
   // Distinct from watcherStartedRef: this guards the await window while
   // start_agent_watcher is in flight. Without it, overlapping detection
@@ -163,7 +200,12 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
       }
 
       prevSessionIdRef.current = sessionId
-      agentEverDetectedRef.current = false
+      const nextStatus = createStatusForSession(sessionId)
+      seenToolUseIdsRef.current = createSeenToolUseIdsForSession(
+        sessionId,
+        nextStatus
+      )
+      agentEverDetectedRef.current = shouldTreatStatusAsDetected(nextStatus)
       watcherStartedRef.current = false
       watcherStartInFlightRef.current = false
       watcherStartGenerationRef.current += 1
@@ -174,9 +216,18 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
         clearTimeout(collapseTimeoutRef.current)
         collapseTimeoutRef.current = null
       }
-      setStatus(createDefaultStatus(sessionId))
+      setStatus(nextStatus)
     }
   }, [sessionId])
+
+  useEffect(() => {
+    if (status.sessionId === null) {
+      return
+    }
+
+    writeStatusSnapshot(status.sessionId, status)
+    writeStatusSeenToolUseIds(status.sessionId, seenToolUseIdsRef.current)
+  }, [status])
 
   // Detection polling: poll detect_agent_in_session frequently enough that
   // pane chrome returns to shell styling promptly after an agent exits.
@@ -227,6 +278,8 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
           watcherStartedRef.current = false
           watcherStartInFlightRef.current = false
           watcherStartGenerationRef.current += 1
+          seenToolUseIdsRef.current = new Set()
+          writeStatusSeenToolUseIds(sid, seenToolUseIdsRef.current)
           await stopWatchers(sid, knownPtyIdRef.current ?? ptySessionId)
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (!isMountedRef.current || currentSessionIdRef.current !== sid) {
@@ -415,17 +468,27 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
           const p = payload
 
           setStatus((prev) => {
-            const base =
+            const agentSessionChanged =
               p.agentSessionId !== null &&
               prev.agentSessionId !== null &&
               p.agentSessionId !== prev.agentSessionId
-                ? {
-                    ...createDefaultStatus(prev.sessionId),
-                    isActive: prev.isActive,
-                    agentExited: prev.agentExited,
-                    agentType: prev.agentType,
-                  }
-                : prev
+
+            if (agentSessionChanged && prev.sessionId !== null) {
+              seenToolUseIdsRef.current = new Set()
+              writeStatusSeenToolUseIds(
+                prev.sessionId,
+                seenToolUseIdsRef.current
+              )
+            }
+
+            const base = agentSessionChanged
+              ? {
+                  ...createDefaultStatus(prev.sessionId),
+                  isActive: prev.isActive,
+                  agentExited: prev.agentExited,
+                  agentType: prev.agentType,
+                }
+              : prev
 
             return {
               ...base,
@@ -542,6 +605,29 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
             }
 
             setStatus((prev) => {
+              const duplicate = seenToolUseIdsRef.current.has(p.toolUseId)
+              seenToolUseIdsRef.current.add(p.toolUseId)
+              writeStatusSeenToolUseIds(sessionId, seenToolUseIdsRef.current)
+
+              if (duplicate) {
+                const active =
+                  prev.toolCalls.active?.toolUseId === p.toolUseId
+                    ? null
+                    : prev.toolCalls.active
+
+                if (active === prev.toolCalls.active) {
+                  return prev
+                }
+
+                return {
+                  ...prev,
+                  toolCalls: {
+                    ...prev.toolCalls,
+                    active,
+                  },
+                }
+              }
+
               const newByType = { ...prev.toolCalls.byType }
               newByType[p.tool] = (newByType[p.tool] ?? 0) + 1
 
@@ -684,5 +770,7 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
     []
   )
 
-  return status
+  return status.sessionId === sessionId
+    ? status
+    : createStatusForSession(sessionId)
 }

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -604,11 +604,11 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
               isTestFile: p.isTestFile,
             }
 
-            setStatus((prev) => {
-              const duplicate = seenToolUseIdsRef.current.has(p.toolUseId)
-              seenToolUseIdsRef.current.add(p.toolUseId)
-              writeStatusSeenToolUseIds(sessionId, seenToolUseIdsRef.current)
+            const duplicate = seenToolUseIdsRef.current.has(p.toolUseId)
+            seenToolUseIdsRef.current.add(p.toolUseId)
+            writeStatusSeenToolUseIds(sessionId, seenToolUseIdsRef.current)
 
+            setStatus((prev) => {
               if (duplicate) {
                 const active =
                   prev.toolCalls.active?.toolUseId === p.toolUseId

--- a/src/features/agent-status/utils/statusSnapshotStore.test.ts
+++ b/src/features/agent-status/utils/statusSnapshotStore.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'vitest'
+import type { AgentStatus } from '../types'
+import {
+  createAgentStatusSnapshotStore,
+  MAX_STATUS_SNAPSHOT_ENTRIES,
+  mergeAgentStatusSnapshot,
+} from './statusSnapshotStore'
+
+const createStatus = (overrides: Partial<AgentStatus> = {}): AgentStatus => ({
+  isActive: false,
+  agentExited: false,
+  agentType: null,
+  modelId: null,
+  modelDisplayName: null,
+  version: null,
+  sessionId: 'pty-a',
+  agentSessionId: null,
+  cwd: null,
+  contextWindow: null,
+  cost: null,
+  rateLimits: null,
+  numTurns: 0,
+  toolCalls: { total: 0, byType: {}, active: null },
+  recentToolCalls: [],
+  testRun: null,
+  ...overrides,
+})
+
+describe('statusSnapshotStore', () => {
+  test('stores and reads status snapshots by pane key', () => {
+    let timestamp = 100
+    const store = createAgentStatusSnapshotStore(() => timestamp)
+    const status = createStatus({ modelId: 'claude-sonnet-4-5' })
+
+    expect(store.readStatus('pane-a')).toBeNull()
+
+    const snapshot = store.writeStatus('pane-a', status)
+
+    expect(snapshot).toEqual({
+      status,
+      scrollTop: 0,
+      updatedAt: 100,
+    })
+    expect(store.readStatus('pane-a')).toBe(status)
+
+    timestamp = 125
+    const nextStatus = createStatus({ modelId: 'claude-opus-4-7' })
+    store.writeStatus('pane-b', nextStatus)
+
+    expect(store.readStatus('pane-a')).toBe(status)
+    expect(store.readSnapshot('pane-b')?.updatedAt).toBe(125)
+  })
+
+  test('stores scroll anchors independently from status snapshots', () => {
+    const store = createAgentStatusSnapshotStore(() => 100)
+
+    expect(store.readScrollAnchor('pane-a')).toBe(0)
+
+    store.writeScrollAnchor('pane-a', 220.5)
+    store.writeScrollAnchor('pane-b', -10)
+
+    expect(store.readScrollAnchor('pane-a')).toBe(220.5)
+    expect(store.readScrollAnchor('pane-b')).toBe(0)
+    expect(store.readSnapshot('pane-a')).toBeNull()
+  })
+
+  test('stores seen tool ids independently from the visible recent-call buffer', () => {
+    const store = createAgentStatusSnapshotStore(() => 100)
+
+    store.writeSeenToolUseIds('pane-a', ['toolu_1', 'toolu_2'])
+
+    const seen = store.readSeenToolUseIds('pane-a')
+    seen.add('mutated-copy')
+
+    expect(store.readSeenToolUseIds('pane-a')).toEqual(
+      new Set(['toolu_1', 'toolu_2'])
+    )
+  })
+
+  test('preserves unchanged recent tool-call object identity while merging', () => {
+    const existingCall = {
+      id: 'toolu_1',
+      tool: 'Read',
+      args: '{"file":"a.ts"}',
+      status: 'done' as const,
+      durationMs: 10,
+      timestamp: '2026-06-14T00:00:00Z',
+      isTestFile: false,
+    }
+
+    const previous = createStatus({
+      toolCalls: { total: 1, byType: { Read: 1 }, active: null },
+      recentToolCalls: [existingCall],
+    })
+
+    const next = createStatus({
+      toolCalls: { total: 1, byType: { Read: 1 }, active: null },
+      recentToolCalls: [{ ...existingCall }],
+    })
+
+    const merged = mergeAgentStatusSnapshot(previous, next)
+
+    expect(merged.toolCalls).toBe(previous.toolCalls)
+    expect(merged.recentToolCalls).toBe(previous.recentToolCalls)
+    expect(merged.recentToolCalls[0]).toBe(existingCall)
+  })
+
+  test('keeps unchanged row objects when a newer tool call is prepended', () => {
+    const existingCall = {
+      id: 'toolu_1',
+      tool: 'Read',
+      args: '{"file":"a.ts"}',
+      status: 'done' as const,
+      durationMs: 10,
+      timestamp: '2026-06-14T00:00:00Z',
+      isTestFile: false,
+    }
+
+    const newCall = {
+      id: 'toolu_2',
+      tool: 'Edit',
+      args: '{"file":"b.ts"}',
+      status: 'done' as const,
+      durationMs: 30,
+      timestamp: '2026-06-14T00:00:01Z',
+      isTestFile: false,
+    }
+
+    const previous = createStatus({ recentToolCalls: [existingCall] })
+
+    const next = createStatus({
+      recentToolCalls: [newCall, { ...existingCall }],
+    })
+
+    const merged = mergeAgentStatusSnapshot(previous, next)
+
+    expect(merged.recentToolCalls).not.toBe(previous.recentToolCalls)
+    expect(merged.recentToolCalls[0]).toBe(newCall)
+    expect(merged.recentToolCalls[1]).toBe(existingCall)
+  })
+
+  test('bounds stored pane snapshots and evicts the oldest entries', () => {
+    const store = createAgentStatusSnapshotStore(() => 100)
+
+    for (let index = 0; index <= MAX_STATUS_SNAPSHOT_ENTRIES; index += 1) {
+      const key = `pane-${index}`
+
+      store.writeStatus(key, createStatus({ sessionId: key }))
+      store.writeScrollAnchor(key, index + 100)
+      store.writeSeenToolUseIds(key, [`toolu_${index}`])
+    }
+
+    expect(store.readStatus('pane-0')).toBeNull()
+    expect(store.readScrollAnchor('pane-0')).toBe(0)
+    expect(store.readSeenToolUseIds('pane-0')).toEqual(new Set())
+    expect(store.readStatus('pane-1')?.sessionId).toBe('pane-1')
+    expect(store.readScrollAnchor('pane-1')).toBe(101)
+    expect(store.readSeenToolUseIds('pane-1')).toEqual(new Set(['toolu_1']))
+  })
+})

--- a/src/features/agent-status/utils/statusSnapshotStore.ts
+++ b/src/features/agent-status/utils/statusSnapshotStore.ts
@@ -1,0 +1,340 @@
+import type {
+  ActiveToolCall,
+  AgentStatus,
+  RecentToolCall,
+  ToolCallState,
+} from '../types'
+
+export interface AgentStatusSnapshot {
+  status: AgentStatus
+  scrollTop: number
+  updatedAt: number
+}
+
+export interface AgentStatusSnapshotStore {
+  readSnapshot: (key: string) => AgentStatusSnapshot | null
+  readStatus: (key: string) => AgentStatus | null
+  writeStatus: (key: string, status: AgentStatus) => AgentStatusSnapshot
+  readSeenToolUseIds: (key: string) => Set<string>
+  writeSeenToolUseIds: (key: string, toolUseIds: Iterable<string>) => void
+  readScrollAnchor: (key: string) => number
+  writeScrollAnchor: (key: string, scrollTop: number) => void
+  deleteSnapshot: (key: string) => void
+  clear: () => void
+}
+
+export const MAX_STATUS_SNAPSHOT_ENTRIES = 64
+
+const recordsEqual = (
+  left: Record<string, number>,
+  right: Record<string, number>
+): boolean => {
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+
+  if (leftKeys.length !== rightKeys.length) {
+    return false
+  }
+
+  return leftKeys.every((key) => left[key] === right[key])
+}
+
+const activeToolCallsEqual = (
+  left: ActiveToolCall | null,
+  right: ActiveToolCall | null
+): boolean =>
+  left === right ||
+  (left !== null &&
+    right !== null &&
+    left.tool === right.tool &&
+    left.args === right.args &&
+    left.startedAt === right.startedAt &&
+    left.toolUseId === right.toolUseId)
+
+const recentToolCallsEqual = (
+  left: RecentToolCall,
+  right: RecentToolCall
+): boolean =>
+  left.id === right.id &&
+  left.tool === right.tool &&
+  left.args === right.args &&
+  left.status === right.status &&
+  left.durationMs === right.durationMs &&
+  left.timestamp === right.timestamp &&
+  left.isTestFile === right.isTestFile
+
+const mergeRecentToolCalls = (
+  previous: RecentToolCall[],
+  next: RecentToolCall[]
+): RecentToolCall[] => {
+  const previousById = new Map(previous.map((call) => [call.id, call]))
+  let changed = previous.length !== next.length
+
+  const merged = next.map((nextCall, index) => {
+    const previousCall = previousById.get(nextCall.id)
+
+    if (
+      previousCall !== undefined &&
+      recentToolCallsEqual(previousCall, nextCall)
+    ) {
+      if (previous[index] !== previousCall) {
+        changed = true
+      }
+
+      return previousCall
+    }
+
+    changed = true
+
+    return nextCall
+  })
+
+  return changed ? merged : previous
+}
+
+const mergeToolCalls = (
+  previous: ToolCallState,
+  next: ToolCallState
+): ToolCallState => {
+  const byType = recordsEqual(previous.byType, next.byType)
+    ? previous.byType
+    : next.byType
+
+  const active = activeToolCallsEqual(previous.active, next.active)
+    ? previous.active
+    : next.active
+
+  if (
+    previous.total === next.total &&
+    previous.byType === byType &&
+    previous.active === active
+  ) {
+    return previous
+  }
+
+  return {
+    total: next.total,
+    byType,
+    active,
+  }
+}
+
+export const mergeAgentStatusSnapshot = (
+  previous: AgentStatus,
+  next: AgentStatus
+): AgentStatus => {
+  const toolCalls = mergeToolCalls(previous.toolCalls, next.toolCalls)
+
+  const recentToolCalls = mergeRecentToolCalls(
+    previous.recentToolCalls,
+    next.recentToolCalls
+  )
+
+  if (
+    previous === next ||
+    (previous.toolCalls === toolCalls &&
+      previous.recentToolCalls === recentToolCalls &&
+      previous.isActive === next.isActive &&
+      previous.agentExited === next.agentExited &&
+      previous.agentType === next.agentType &&
+      previous.modelId === next.modelId &&
+      previous.modelDisplayName === next.modelDisplayName &&
+      previous.version === next.version &&
+      previous.sessionId === next.sessionId &&
+      previous.agentSessionId === next.agentSessionId &&
+      previous.cwd === next.cwd &&
+      previous.contextWindow === next.contextWindow &&
+      previous.cost === next.cost &&
+      previous.rateLimits === next.rateLimits &&
+      previous.numTurns === next.numTurns &&
+      previous.testRun === next.testRun)
+  ) {
+    return previous
+  }
+
+  return {
+    ...next,
+    toolCalls,
+    recentToolCalls,
+  }
+}
+
+const normalizeScrollTop = (scrollTop: number): number =>
+  Number.isFinite(scrollTop) ? Math.max(0, scrollTop) : 0
+
+const deleteOldestEntry = <Value>(
+  entries: Map<string, Value>
+): string | null => {
+  const oldestKey = entries.keys().next().value
+
+  if (oldestKey === undefined) {
+    return null
+  }
+
+  entries.delete(oldestKey)
+
+  return oldestKey
+}
+
+export const createAgentStatusSnapshotStore = (
+  now: () => number = () => Date.now()
+): AgentStatusSnapshotStore => {
+  const statuses = new Map<string, { status: AgentStatus; updatedAt: number }>()
+  const seenToolUseIds = new Map<string, Set<string>>()
+  const scrollAnchors = new Map<string, number>()
+
+  const pruneStatusSnapshots = (): void => {
+    while (statuses.size > MAX_STATUS_SNAPSHOT_ENTRIES) {
+      const deletedKey = deleteOldestEntry(statuses)
+
+      if (deletedKey === null) {
+        return
+      }
+
+      seenToolUseIds.delete(deletedKey)
+      scrollAnchors.delete(deletedKey)
+    }
+  }
+
+  const pruneScrollAnchors = (): void => {
+    while (scrollAnchors.size > MAX_STATUS_SNAPSHOT_ENTRIES) {
+      deleteOldestEntry(scrollAnchors)
+    }
+  }
+
+  const pruneSeenToolUseIds = (): void => {
+    while (seenToolUseIds.size > MAX_STATUS_SNAPSHOT_ENTRIES) {
+      deleteOldestEntry(seenToolUseIds)
+    }
+  }
+
+  const readSnapshot = (key: string): AgentStatusSnapshot | null => {
+    const entry = statuses.get(key)
+
+    if (entry === undefined) {
+      return null
+    }
+
+    return {
+      status: entry.status,
+      scrollTop: scrollAnchors.get(key) ?? 0,
+      updatedAt: entry.updatedAt,
+    }
+  }
+
+  const writeStatus = (
+    key: string,
+    status: AgentStatus
+  ): AgentStatusSnapshot => {
+    const previous = statuses.get(key)
+
+    const nextStatus =
+      previous === undefined
+        ? status
+        : mergeAgentStatusSnapshot(previous.status, status)
+
+    const updatedAt = now()
+
+    statuses.delete(key)
+    statuses.set(key, {
+      status: nextStatus,
+      updatedAt,
+    })
+
+    if (!seenToolUseIds.has(key)) {
+      seenToolUseIds.set(
+        key,
+        new Set(nextStatus.recentToolCalls.map((call) => call.id))
+      )
+    }
+
+    pruneStatusSnapshots()
+
+    return {
+      status: nextStatus,
+      scrollTop: scrollAnchors.get(key) ?? 0,
+      updatedAt,
+    }
+  }
+
+  const readStatus = (key: string): AgentStatus | null =>
+    readSnapshot(key)?.status ?? null
+
+  const readSeenToolUseIds = (key: string): Set<string> =>
+    new Set(seenToolUseIds.get(key) ?? [])
+
+  const writeSeenToolUseIds = (
+    key: string,
+    toolUseIds: Iterable<string>
+  ): void => {
+    seenToolUseIds.delete(key)
+    seenToolUseIds.set(key, new Set(toolUseIds))
+    pruneSeenToolUseIds()
+  }
+
+  const readScrollAnchor = (key: string): number => scrollAnchors.get(key) ?? 0
+
+  const writeScrollAnchor = (key: string, scrollTop: number): void => {
+    scrollAnchors.delete(key)
+    scrollAnchors.set(key, normalizeScrollTop(scrollTop))
+    pruneScrollAnchors()
+  }
+
+  const deleteSnapshot = (key: string): void => {
+    statuses.delete(key)
+    seenToolUseIds.delete(key)
+    scrollAnchors.delete(key)
+  }
+
+  const clear = (): void => {
+    statuses.clear()
+    seenToolUseIds.clear()
+    scrollAnchors.clear()
+  }
+
+  return {
+    readSnapshot,
+    readStatus,
+    writeStatus,
+    readSeenToolUseIds,
+    writeSeenToolUseIds,
+    readScrollAnchor,
+    writeScrollAnchor,
+    deleteSnapshot,
+    clear,
+  }
+}
+
+const statusSnapshotStore = createAgentStatusSnapshotStore()
+
+export const readStatusSnapshot = (key: string): AgentStatus | null =>
+  statusSnapshotStore.readStatus(key)
+
+export const writeStatusSnapshot = (
+  key: string,
+  status: AgentStatus
+): AgentStatusSnapshot => statusSnapshotStore.writeStatus(key, status)
+
+export const readStatusSeenToolUseIds = (key: string): Set<string> =>
+  statusSnapshotStore.readSeenToolUseIds(key)
+
+export const writeStatusSeenToolUseIds = (
+  key: string,
+  toolUseIds: Iterable<string>
+): void => {
+  statusSnapshotStore.writeSeenToolUseIds(key, toolUseIds)
+}
+
+export const readStatusScrollAnchor = (key: string): number =>
+  statusSnapshotStore.readScrollAnchor(key)
+
+export const writeStatusScrollAnchor = (
+  key: string,
+  scrollTop: number
+): void => {
+  statusSnapshotStore.writeScrollAnchor(key, scrollTop)
+}
+
+export const clearStatusSnapshots = (): void => {
+  statusSnapshotStore.clear()
+}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -2309,6 +2309,7 @@ export const WorkspaceView = (): ReactElement => {
               onOpenFile={handleOpenTestFile}
               agent={activityPanelAgent}
               status={activityPanelStatus}
+              snapshotKey={activePtyBackedPanePtyId ?? null}
               onCollapse={() => {
                 handleActivityPanelCollapsed(true)
               }}


### PR DESCRIPTION
## Summary

- Add a bounded in-memory pane snapshot store for agent status, replay-safe tool-use IDs, and panel scroll anchors.
- Restore pane status synchronously when switching back to a PTY-backed pane so the right activity panel avoids empty/remount jumps.
- Wire the active PTY pane key through `WorkspaceView` into `AgentStatusPanel` and update the PR2 spec handoff notes.

## Branch Strategy

- Base: `feat/vim-127-activity-panel-hot-reload`
- Head: `feature/vim-127-pr2-status-store`
- This keeps PR2 stacked on the VIM-127 integration branch instead of `main`.

## Validation

- `npm run format:check`
- `npm run lint`
- `npx vitest run src/features/agent-status/hooks/useAgentStatus.test.ts src/features/agent-status/utils/statusSnapshotStore.test.ts src/features/agent-status/components/AgentStatusPanel/index.test.tsx src/features/workspace/WorkspaceView.subscription.test.tsx`
- `npm run type-check`
- `npm run test`
- Claude Code reviewer verdict: `VERDICT: patch is correct`

## Notes For PR3

PR2 keeps all snapshot state frontend-only. PR3 should add stale-response guards and lightweight prefetch/loading orchestration around async sidebar data rather than expanding the snapshot store into an IPC or persistence layer.

Linear: VIM-127