### PR TITLE
feat(agent-status): calm ambient water motion with hover quickening

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 30   | 2026-06-15   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 86       | 25   | 2026-06-15   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 58       | 23   | 2026-06-15   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 22   | 2026-06-08   |
@@ -90,3 +90,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 1        | 0    | 2026-06-13   |
+| [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 22       | 4    | 2026-06-13   |
 | [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 33       | 15   | 2026-06-11   |
-| [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 1        | 0    | 2026-06-15   |
+| [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 2        | 1    | 2026-06-15   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,6 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 22       | 4    | 2026-06-13   |
 | [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 33       | 15   | 2026-06-11   |
+| [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 1        | 0    | 2026-06-15   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,10 +54,10 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 64       | 30   | 2026-06-12   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 30   | 2026-06-15   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 58       | 23   | 2026-06-15   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 22   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,7 +2,7 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-13
+last_updated: 2026-06-15
 ref_count: 23
 ---
 
@@ -532,3 +532,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** `window.prompt` and `window.confirm` blocked the renderer thread, used unstyled OS chrome, and could not display formatted validation hints or be cancelled via Escape reliably.
 - **Fix:** Replaced native dialogs with an inline rename input and a delete-confirmation strip styled with design tokens; kept actions non-blocking.
 - **Commit:** see `git blame` / `git log` on this line
+
+### 50. Pointer-leave handler schedules drift under reduced-motion and when already at rest
+
+- **Source:** github-claude + github-codex-connector | PR #457 round 1 | 2026-06-15
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/agent-status/hooks/useReservoirFlow.ts`
+- **Finding:** `onLeave` called `ensureLoop()` unconditionally, so it scheduled a rAF frame even when `prefers-reduced-motion: reduce` was active, the water refs were null, or the loop was already at rest. Under reduced motion this could re-apply a cached `translate(...)` transform after `onMqlChange` had explicitly cleared it.
+- **Fix:** Mirrored the `onEnter` guard (`mql.matches || refsRef.current === null`) and added an at-rest guard (`rafId === null && intensity < REST_EPSILON`) before calling `ensureLoop()`.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -2,7 +2,7 @@
 id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
-last_updated: 2026-06-14
+last_updated: 2026-06-15
 ref_count: 26
 ---
 
@@ -809,4 +809,13 @@ Stale documentation misleads future contributors and review agents.
 - **File:** `docs/design/UNIFIED.md`
 - **Finding:** The Popover contract in `UNIFIED.md` §5.9 said focus is modal with `initialFocus: -1` and lands on the container on open, but `src/components/Popover.tsx` passes `focus={{ initialFocus: 0, modal: true }}` and `src/components/Popover.test.tsx` asserts focus lands on the first tabbable child. The mismatch creates a misleading public primitive contract that future consumers or tests may encode the wrong expectation against.
 - **Fix:** Updated the Popover focus rule to document `initialFocus: 0`, focus landing on the first tabbable child on open, and `modal: true` engaging the focus trap.
+- **Commit:** same commit as this entry
+
+### 87. Test alias comment mischaracterizes configured lint rule
+
+- **Source:** github-claude | PR #457 round 2 | 2026-06-15
+- **Severity:** LOW
+- **File:** `src/features/agent-status/hooks/useReservoirFlow.test.tsx`
+- **Finding:** `const INACTIVE = false // jsx-boolean-value wants false props omitted; alias it` described the rule as simply `jsx-boolean-value`, which is ambiguous because the rule only flags explicit `false` values when `assumeUndefinedIsFalse` is enabled. A future reader might delete the alias thinking the rule does not apply to `false`.
+- **Fix:** Updated the comment to name the fully configured rule: `react/jsx-boolean-value (assumeUndefinedIsFalse) flags explicit false props; alias it`.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/imperative-animation-ownership.md
+++ b/docs/reviews/patterns/imperative-animation-ownership.md
@@ -3,7 +3,7 @@ id: imperative-animation-ownership
 category: react-patterns
 created: 2026-06-15
 last_updated: 2026-06-15
-ref_count: 0
+ref_count: 1
 ---
 
 # Imperative Animation Ownership
@@ -44,4 +44,20 @@ The fix shape:
   the tank becomes non-empty, and a `useEffect` to re-sync the static path under
   `prefers-reduced-motion`. The rAF loop in `useReservoirFlow` now owns the
   animated `d` attributes without React interference.
+- **Commit:** _(same commit as this entry)_
+
+### 2. Reduced-motion toggle stopped rAF but left the water surface frozen in its animated state
+
+- **Source:** github-codex-connector | PR #457 round 3 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/hooks/useReservoirFlow.ts`
+- **Finding:** When `prefers-reduced-motion: reduce` was enabled mid-session,
+  `onMqlChange` only called `stop()`. It did not reset `amp`/`targetAmp` or
+  repaint the SVG paths, and `WaterTank`'s reduced-motion sync effect only ran
+  when `resting.fill`/`resting.crest` changed. Users could see the last animated
+  hover/drift frame frozen until another render-triggering data change occurred.
+- **Fix:** On `mql.matches === true`, reset swell state to rest and imperatively
+  write a resting `buildReservoirSurface` path to both SVG paths using the
+  current geometry. Added test coverage verifying the surface returns to the
+  resting crest when reduced motion is enabled mid-hover.
 - **Commit:** _(same commit as this entry)_

--- a/docs/reviews/patterns/imperative-animation-ownership.md
+++ b/docs/reviews/patterns/imperative-animation-ownership.md
@@ -1,0 +1,47 @@
+---
+id: imperative-animation-ownership
+category: react-patterns
+created: 2026-06-15
+last_updated: 2026-06-15
+ref_count: 0
+---
+
+# Imperative Animation Ownership
+
+## Summary
+
+When an imperative animation loop (e.g., `requestAnimationFrame`) mutates DOM
+attributes, React must not own those same attributes via JSX props. React's
+reconciler commits the prop value before the next animation frame, so ordinary
+prop updates can overwrite the live animated value for one frame and produce a
+visible snap or flicker.
+
+The fix shape:
+
+1. Remove the JSX prop that React would reconcile (e.g., `d={...}` on an SVG
+   path).
+2. Seed the initial / resting attribute value imperatively via refs, usually in
+   a layout effect so the first paint is valid.
+3. Let the animation loop own updates during normal operation.
+4. Under reduced motion (or whenever the loop is inactive), keep the static
+   attribute in sync with prop changes via a passive effect so the UI still
+   reflects current data.
+
+## Findings
+
+### 1. React-managed SVG `d` props overwrote the rAF-painted reservoir surface
+
+- **Source:** github-codex-connector | PR #457 round 1 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/components/WaterTank.tsx`
+- **Finding:** `WaterTank` rendered `d={resting.fill}` and `d={resting.crest}` on
+  the same `<path>` elements that `useReservoirFlow` mutated every animation
+  frame. When `pct` changed, React committed the new phase-0 resting path over
+  the live animated path until the next rAF tick, causing a brief water-surface
+  flicker.
+- **Fix:** Removed the React-managed `d` props from the JSX. Added a
+  `useLayoutEffect` to seed the initial/resting `d` attributes imperatively when
+  the tank becomes non-empty, and a `useEffect` to re-sync the static path under
+  `prefers-reduced-motion`. The rAF loop in `useReservoirFlow` now owns the
+  animated `d` attributes without React interference.
+- **Commit:** _(same commit as this entry)_

--- a/docs/reviews/patterns/string-construction-hygiene.md
+++ b/docs/reviews/patterns/string-construction-hygiene.md
@@ -1,0 +1,31 @@
+---
+id: string-construction-hygiene
+category: code-quality
+created: 2026-06-15
+last_updated: 2026-06-15
+ref_count: 0
+---
+
+# String Construction Hygiene
+
+## Summary
+
+When building structured strings (SVG path commands, query fragments, log lines,
+etc.) by accumulating values in a loop, the accumulator often carries a trailing
+separator or whitespace. Interpolating that accumulator into a larger template
+without trimming or using a join-based approach produces doubled delimiters,
+trailing spaces, or malformed commands. The defect is usually silent because the
+consumer (SVG parser, shell, template engine) tolerates the extra whitespace,
+but it makes the output inconsistent and can mask real formatting bugs. Prefer
+`Array.join` for separators, or trim the accumulator before interpolation.
+
+## Findings
+
+### 1. SVG fill path built from untrimmed crest accumulator
+
+- **Source:** github-claude | PR #457 round 2 | 2026-06-15
+- **Severity:** LOW
+- **File:** `src/features/agent-status/hooks/useReservoirFlow.ts`
+- **Finding:** `buildReservoirSurface` built `fill` by interpolating the raw `crest` accumulator (`fill: \`${crest}L ${TANK_WIDTH} ${height} L 0 ${height} Z\``). The loop appended a trailing space after each point, leaving a double space before the closing commands. SVG parsers tolerate the extra whitespace, but the returned `fill`was inconsistent with the already-trimmed`crest`.
+- **Fix:** Trimmed the accumulator before interpolation: `fill: \`${crest.trim()} L ${TANK_WIDTH} ${height} L 0 ${height} Z\``.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,7 +2,7 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-14
+last_updated: 2026-06-15
 ref_count: 31
 ---
 
@@ -639,3 +639,12 @@ filesystem scope restrictions).
 - **Finding:** The `falls back to execCommand copy` test replaced both `window.navigator.clipboard` and `document.execCommand`, but the `finally` block only restored the clipboard property. The leaked `execCommand` mock persisted in the shared jsdom document for every subsequent test in the file, creating a false-positive risk for any future test that exercised the textarea fallback path without its own mock.
 - **Fix:** Saved the original `document.execCommand` value before overriding it and restored it in the same `finally` block alongside `navigator.clipboard`, mirroring the symmetric cleanup already used by the `installClipboardMock` helper.
 - **Commit:** same commit as this entry
+
+### 64. MQL change handler and cleanup untested because the mock is a no-op
+
+- **Source:** github-claude | PR #457 round 1 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/hooks/useReservoirFlow.test.tsx` L12-22
+- **Finding:** `makeMql` returned `addEventListener`/`removeEventListener` as `vi.fn()` stubs that recorded nothing and fired nothing, so the hook's `onMqlChange` handler was unreachable in tests. The unmount test also only asserted pointer-event cleanup, never `mql.removeEventListener('change', onMqlChange)`.
+- **Fix:** Upgraded the mock to a `MockMql` helper that captures listeners and exposes a `fire()` method, then added a reduced-motion-mid-hover test and a cleanup assertion for the `'change'` listener.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/agent-status/components/ContextBucket.tsx
+++ b/src/features/agent-status/components/ContextBucket.tsx
@@ -132,7 +132,7 @@ export const ContextBucket = ({
           {pct !== null && (
             <div
               data-testid="context-pill"
-              className="absolute right-[6px] inline-flex -translate-y-1/2 items-center rounded-[5px] px-[6px] py-[1.5px] font-mono text-[9.5px] font-semibold"
+              className="pointer-events-none absolute right-[6px] inline-flex -translate-y-1/2 items-center rounded-[5px] px-[6px] py-[1.5px] font-mono text-[9.5px] font-semibold"
               style={{
                 top: `${waterlineTopPct}%`,
                 background: chrome.pillBg,

--- a/src/features/agent-status/components/WaterTank.test.tsx
+++ b/src/features/agent-status/components/WaterTank.test.tsx
@@ -31,11 +31,11 @@ describe('WaterTank', () => {
     expect(screen.queryByTestId('tank-water')).not.toBeInTheDocument()
   })
 
-  test('applies the seamless parallax wave classes', () => {
+  test('applies the slow base-drift classes', () => {
     render(<WaterTank pct={56} theme="dark" />)
 
-    expect(screen.getByTestId('tank-wave-front')).toHaveClass('vf-tank-wave-a')
-    expect(screen.getByTestId('tank-wave-back')).toHaveClass('vf-tank-wave-b')
+    expect(screen.getByTestId('tank-wave-front')).toHaveClass('vf-tank-drift-a')
+    expect(screen.getByTestId('tank-wave-back')).toHaveClass('vf-tank-drift-b')
   })
 
   test('honors a custom height in the viewBox', () => {

--- a/src/features/agent-status/components/WaterTank.test.tsx
+++ b/src/features/agent-status/components/WaterTank.test.tsx
@@ -31,11 +31,12 @@ describe('WaterTank', () => {
     expect(screen.queryByTestId('tank-water')).not.toBeInTheDocument()
   })
 
-  test('applies the slow base-drift classes', () => {
-    render(<WaterTank pct={56} theme="dark" />)
+  test('paints a resting surface that closes flat to the floor', () => {
+    render(<WaterTank pct={56} theme="dark" height={104} />)
 
-    expect(screen.getByTestId('tank-wave-front')).toHaveClass('vf-tank-drift-a')
-    expect(screen.getByTestId('tank-wave-back')).toHaveClass('vf-tank-drift-b')
+    expect(screen.getByTestId('tank-water').getAttribute('d')).toContain(
+      'L 248 104 L 0 104 Z'
+    )
   })
 
   test('honors a custom height in the viewBox', () => {

--- a/src/features/agent-status/components/WaterTank.tsx
+++ b/src/features/agent-status/components/WaterTank.tsx
@@ -6,7 +6,11 @@ import {
 } from '../utils/contextTone'
 import {
   useReservoirFlow,
-  type ReservoirFlowRefs,
+  buildReservoirSurface,
+  SWELL_PRESETS,
+  type ReservoirSurfaceRefs,
+  type ReservoirGeom,
+  type SwellVariant,
 } from '../hooks/useReservoirFlow'
 
 export interface WaterTankProps {
@@ -17,29 +21,19 @@ export interface WaterTankProps {
   height?: number
   /** When true (context unknown), render the empty tank with no water. */
   empty?: boolean
+  /**
+   * Hover-swell flavor — how the water rises toward the cursor. Three are
+   * available (see SWELL_PRESETS); defaults to `soft-mound`. A future user
+   * setting will choose this per preference — tracked in Linear VIM-128.
+   */
+  swell?: SwellVariant
 }
 
 // SVG is drawn in a fixed 248-wide user space and stretched to the container
-// (preserveAspectRatio="none"). Each wave path spans 3x the tank width: the CSS
-// keyframe (vf-tank-drift-*) drifts the outer group by exactly one tank
-// (translateX(-33.333%) of the 3x path under transform-box: fill-box) for a
-// calm, always-on, seamless loop, and a nested boost group adds an extra
-// hover-driven drift via useReservoirFlow. Three tiles (not two) give the
-// base + boost translate enough runway to never sample past the path's right
-// edge. Reduced-motion disables both layers.
+// (preserveAspectRatio="none"). The water surface is redrawn each frame by
+// useReservoirFlow: a calm drift plus a swell that rises toward the cursor on
+// hover. The fill always closes flat to the floor, so it reads as real water.
 const TANK_WIDTH = 248
-const WAVE_SPAN = TANK_WIDTH * 3
-// Wavelengths that divide the tank width evenly so each wave tiles without a
-// seam on loop (the handoff's back-wave length of 150 did not tile the 248px
-// translate). The back wave reads as a distinct, slower parallax layer: one
-// broad swell across the tank behind the front's two faster ripples.
-const WAVELENGTH_FRONT = TANK_WIDTH / 2 // 124 — two ripples across the tank
-const WAVELENGTH_BACK = TANK_WIDTH // 248 — one broad swell behind
-// Wave amplitudes (user units, of a 104 tank). Tall enough that the calm drift
-// reads as moving water rather than a flat fill — the front carries the bright
-// meniscus crest, the back is a broader, taller swell behind it.
-const AMP_FRONT = 5
-const AMP_BACK = 7
 
 /**
  * Y coordinate (in SVG user units) of the waterline for a given fill. A 2%
@@ -54,6 +48,7 @@ export const WaterTank = ({
   theme,
   height = 104,
   empty = false,
+  swell = 'soft-mound',
 }: WaterTankProps): ReactElement => {
   const tone = resolveContextTone(pct, theme)
   const chrome = tankChrome(theme)
@@ -63,40 +58,35 @@ export const WaterTank = ({
   const dryId = `tank-dry-${rid}`
   const clipId = `tank-clip-${rid}`
 
+  // Resting surface for the first paint / reduced-motion; the hook takes over
+  // the `d` attributes each frame once it starts. No swell at rest (amp 0).
+  const resting = buildReservoirSurface(
+    level,
+    height,
+    0,
+    0,
+    TANK_WIDTH / 2,
+    SWELL_PRESETS[swell].width
+  )
+
   const svgRef = useRef<SVGSVGElement>(null)
-  const frontRef = useRef<SVGGElement>(null)
-  const backRef = useRef<SVGGElement>(null)
-  const flowRefsRef = useRef<ReservoirFlowRefs | null>(null)
+  const fillRef = useRef<SVGPathElement>(null)
+  const meniscusRef = useRef<SVGPathElement>(null)
+  const flowRefsRef = useRef<ReservoirSurfaceRefs | null>(null)
+  const geomRef = useRef<ReservoirGeom | null>({ level, height })
+
+  // The hook reads the live waterline each frame (eased) without restarting on
+  // every pct change.
+  geomRef.current = { level, height }
 
   useEffect(() => {
     flowRefsRef.current =
-      frontRef.current !== null && backRef.current !== null
-        ? { front: frontRef.current, back: backRef.current }
+      fillRef.current !== null && meniscusRef.current !== null
+        ? { fill: fillRef.current, meniscus: meniscusRef.current }
         : null
   }, [empty])
 
-  useReservoirFlow(svgRef, flowRefsRef)
-
-  const wavePath = (
-    amplitude: number,
-    phase: number,
-    wavelength: number,
-    close = true
-  ): string => {
-    const yAt = (x: number): number =>
-      level + Math.sin((x / wavelength) * Math.PI * 2 + phase) * amplitude
-    const points: string[] = []
-    for (let x = 0; x < WAVE_SPAN; x += 6) {
-      points.push(`${x === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${yAt(x).toFixed(2)}`)
-    }
-    // Land the final point exactly on the span edge — a step of 6 doesn't
-    // divide 496, so without this the closed fill jumps from x=492 straight to
-    // the bottom corner, a slanted seam that scrolls into view on loop wrap.
-    points.push(`L ${WAVE_SPAN} ${yAt(WAVE_SPAN).toFixed(2)}`)
-    const d = points.join(' ')
-
-    return close ? `${d} L ${WAVE_SPAN} ${height} L 0 ${height} Z` : d
-  }
+  useReservoirFlow(svgRef, flowRefsRef, geomRef, !empty, swell)
 
   return (
     <svg
@@ -159,35 +149,22 @@ export const WaterTank = ({
 
         {!empty && (
           <>
-            {/* back wave — slow CSS drift; inner group takes the hover boost */}
-            <g data-testid="tank-wave-back" className="vf-tank-drift-b">
-              <g ref={backRef}>
-                <path
-                  d={wavePath(AMP_BACK, 0.9, WAVELENGTH_BACK)}
-                  fill={`url(#${fillId})`}
-                  opacity="0.5"
-                />
-              </g>
-            </g>
-            {/* front wave — the primary body + bright meniscus crest */}
-            <g data-testid="tank-wave-front" className="vf-tank-drift-a">
-              <g ref={frontRef}>
-                <path
-                  data-testid="tank-water"
-                  d={wavePath(AMP_FRONT, 2.4, WAVELENGTH_FRONT)}
-                  fill={`url(#${fillId})`}
-                />
-                <path
-                  data-testid="tank-meniscus"
-                  d={wavePath(AMP_FRONT, 2.4, WAVELENGTH_FRONT, false)}
-                  fill="none"
-                  stroke={tone.meniscus}
-                  strokeWidth="1.5"
-                  strokeOpacity="0.9"
-                  style={{ filter: `drop-shadow(0 0 5px ${tone.base})` }}
-                />
-              </g>
-            </g>
+            <path
+              ref={fillRef}
+              data-testid="tank-water"
+              d={resting.fill}
+              fill={`url(#${fillId})`}
+            />
+            <path
+              ref={meniscusRef}
+              data-testid="tank-meniscus"
+              d={resting.crest}
+              fill="none"
+              stroke={tone.meniscus}
+              strokeWidth="1.5"
+              strokeOpacity="0.9"
+              style={{ filter: `drop-shadow(0 0 5px ${tone.base})` }}
+            />
           </>
         )}
 

--- a/src/features/agent-status/components/WaterTank.tsx
+++ b/src/features/agent-status/components/WaterTank.tsx
@@ -91,9 +91,7 @@ export const WaterTank = ({
     const fill = fillRef.current
     const meniscus = meniscusRef.current
     flowRefsRef.current =
-      fill !== null && meniscus !== null
-        ? { fill, meniscus }
-        : null
+      fill !== null && meniscus !== null ? { fill, meniscus } : null
     // Seed the first paint / reduced-motion surface before the browser paints.
     // Compute from the mutable geom ref rather than the render-scoped `resting`
     // so this effect does not re-run on every `pct` change.

--- a/src/features/agent-status/components/WaterTank.tsx
+++ b/src/features/agent-status/components/WaterTank.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useId, useRef, type ReactElement } from 'react'
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  type ReactElement,
+} from 'react'
 import {
   resolveContextTone,
   tankChrome,
@@ -58,8 +64,10 @@ export const WaterTank = ({
   const dryId = `tank-dry-${rid}`
   const clipId = `tank-clip-${rid}`
 
-  // Resting surface for the first paint / reduced-motion; the hook takes over
-  // the `d` attributes each frame once it starts. No swell at rest (amp 0).
+  // Resting surface for the first paint / reduced-motion. React no longer owns
+  // the animated `d` attributes — we seed them imperatively below so `pct`
+  // updates cannot overwrite the rAF-painted surface for a frame. No swell at
+  // rest (amp 0).
   const resting = buildReservoirSurface(
     level,
     height,
@@ -79,12 +87,49 @@ export const WaterTank = ({
   // every pct change.
   geomRef.current = { level, height }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    const fill = fillRef.current
+    const meniscus = meniscusRef.current
     flowRefsRef.current =
-      fillRef.current !== null && meniscusRef.current !== null
-        ? { fill: fillRef.current, meniscus: meniscusRef.current }
+      fill !== null && meniscus !== null
+        ? { fill, meniscus }
         : null
-  }, [empty])
+    // Seed the first paint / reduced-motion surface before the browser paints.
+    // Compute from the mutable geom ref rather than the render-scoped `resting`
+    // so this effect does not re-run on every `pct` change.
+    const geom = geomRef.current
+    if (fill === null || meniscus === null || geom === null) {
+      return
+    }
+
+    const { fill: fillPath, crest } = buildReservoirSurface(
+      geom.level,
+      geom.height,
+      0,
+      0,
+      TANK_WIDTH / 2,
+      SWELL_PRESETS[swell].width
+    )
+    fill.setAttribute('d', fillPath)
+    meniscus.setAttribute('d', crest)
+  }, [empty, swell])
+
+  // Keep the static surface in sync with `pct` under reduced motion. During
+  // normal animation the rAF loop in useReservoirFlow owns the `d` attributes
+  // and reads geomRef.current each frame, so this passive effect deliberately
+  // does nothing when reduced motion is not requested.
+  useEffect(() => {
+    const fill = fillRef.current
+    const meniscus = meniscusRef.current
+    if (fill === null || meniscus === null) {
+      return
+    }
+    if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return
+    }
+    fill.setAttribute('d', resting.fill)
+    meniscus.setAttribute('d', resting.crest)
+  }, [resting.fill, resting.crest])
 
   useReservoirFlow(svgRef, flowRefsRef, geomRef, !empty, swell)
 
@@ -152,13 +197,11 @@ export const WaterTank = ({
             <path
               ref={fillRef}
               data-testid="tank-water"
-              d={resting.fill}
               fill={`url(#${fillId})`}
             />
             <path
               ref={meniscusRef}
               data-testid="tank-meniscus"
-              d={resting.crest}
               fill="none"
               stroke={tone.meniscus}
               strokeWidth="1.5"

--- a/src/features/agent-status/components/WaterTank.tsx
+++ b/src/features/agent-status/components/WaterTank.tsx
@@ -1,9 +1,13 @@
-import { useId, type ReactElement } from 'react'
+import { useEffect, useId, useRef, type ReactElement } from 'react'
 import {
   resolveContextTone,
   tankChrome,
   type ReservoirTheme,
 } from '../utils/contextTone'
+import {
+  useReservoirFlow,
+  type ReservoirFlowRefs,
+} from '../hooks/useReservoirFlow'
 
 export interface WaterTankProps {
   /** Context fill, 0-100. Drives the waterline height and the tone. */
@@ -15,14 +19,16 @@ export interface WaterTankProps {
   empty?: boolean
 }
 
-// The parallax waves always animate; prefers-reduced-motion disables them via
-// CSS (the static filled tank is fully legible).
-
 // SVG is drawn in a fixed 248-wide user space and stretched to the container
-// (preserveAspectRatio="none"); each wave path spans 2x the width and the
-// keyframe translates it by exactly one width (-50%), so the loop is seamless.
+// (preserveAspectRatio="none"). Each wave path spans 3x the tank width: the CSS
+// keyframe (vf-tank-drift-*) drifts the outer group by exactly one tank
+// (translateX(-33.333%) of the 3x path under transform-box: fill-box) for a
+// calm, always-on, seamless loop, and a nested boost group adds an extra
+// hover-driven drift via useReservoirFlow. Three tiles (not two) give the
+// base + boost translate enough runway to never sample past the path's right
+// edge. Reduced-motion disables both layers.
 const TANK_WIDTH = 248
-const WAVE_SPAN = TANK_WIDTH * 2
+const WAVE_SPAN = TANK_WIDTH * 3
 // Wavelengths that divide the tank width evenly so each wave tiles without a
 // seam on loop (the handoff's back-wave length of 150 did not tile the 248px
 // translate). The back wave reads as a distinct, slower parallax layer: one
@@ -52,6 +58,20 @@ export const WaterTank = ({
   const dryId = `tank-dry-${rid}`
   const clipId = `tank-clip-${rid}`
 
+  const svgRef = useRef<SVGSVGElement>(null)
+  const frontRef = useRef<SVGGElement>(null)
+  const backRef = useRef<SVGGElement>(null)
+  const flowRefsRef = useRef<ReservoirFlowRefs | null>(null)
+
+  useEffect(() => {
+    flowRefsRef.current =
+      frontRef.current !== null && backRef.current !== null
+        ? { front: frontRef.current, back: backRef.current }
+        : null
+  }, [empty])
+
+  useReservoirFlow(svgRef, flowRefsRef)
+
   const wavePath = (
     amplitude: number,
     phase: number,
@@ -75,6 +95,7 @@ export const WaterTank = ({
 
   return (
     <svg
+      ref={svgRef}
       data-testid="water-tank"
       viewBox={`0 0 ${TANK_WIDTH} ${height}`}
       width="100%"
@@ -133,30 +154,34 @@ export const WaterTank = ({
 
         {!empty && (
           <>
-            {/* back wave — slower, taller, dim */}
-            <g data-testid="tank-wave-back" className="vf-tank-wave-b">
-              <path
-                d={wavePath(3.2, 0.9, WAVELENGTH_BACK)}
-                fill={`url(#${fillId})`}
-                opacity="0.5"
-              />
+            {/* back wave — slow CSS drift; inner group takes the hover boost */}
+            <g data-testid="tank-wave-back" className="vf-tank-drift-b">
+              <g ref={backRef}>
+                <path
+                  d={wavePath(3.2, 0.9, WAVELENGTH_BACK)}
+                  fill={`url(#${fillId})`}
+                  opacity="0.5"
+                />
+              </g>
             </g>
             {/* front wave — the primary body + bright meniscus crest */}
-            <g data-testid="tank-wave-front" className="vf-tank-wave-a">
-              <path
-                data-testid="tank-water"
-                d={wavePath(2.4, 2.4, WAVELENGTH_FRONT)}
-                fill={`url(#${fillId})`}
-              />
-              <path
-                data-testid="tank-meniscus"
-                d={wavePath(2.4, 2.4, WAVELENGTH_FRONT, false)}
-                fill="none"
-                stroke={tone.meniscus}
-                strokeWidth="1.5"
-                strokeOpacity="0.9"
-                style={{ filter: `drop-shadow(0 0 5px ${tone.base})` }}
-              />
+            <g data-testid="tank-wave-front" className="vf-tank-drift-a">
+              <g ref={frontRef}>
+                <path
+                  data-testid="tank-water"
+                  d={wavePath(2.4, 2.4, WAVELENGTH_FRONT)}
+                  fill={`url(#${fillId})`}
+                />
+                <path
+                  data-testid="tank-meniscus"
+                  d={wavePath(2.4, 2.4, WAVELENGTH_FRONT, false)}
+                  fill="none"
+                  stroke={tone.meniscus}
+                  strokeWidth="1.5"
+                  strokeOpacity="0.9"
+                  style={{ filter: `drop-shadow(0 0 5px ${tone.base})` }}
+                />
+              </g>
             </g>
           </>
         )}

--- a/src/features/agent-status/components/WaterTank.tsx
+++ b/src/features/agent-status/components/WaterTank.tsx
@@ -35,6 +35,11 @@ const WAVE_SPAN = TANK_WIDTH * 3
 // broad swell across the tank behind the front's two faster ripples.
 const WAVELENGTH_FRONT = TANK_WIDTH / 2 // 124 — two ripples across the tank
 const WAVELENGTH_BACK = TANK_WIDTH // 248 — one broad swell behind
+// Wave amplitudes (user units, of a 104 tank). Tall enough that the calm drift
+// reads as moving water rather than a flat fill — the front carries the bright
+// meniscus crest, the back is a broader, taller swell behind it.
+const AMP_FRONT = 5
+const AMP_BACK = 7
 
 /**
  * Y coordinate (in SVG user units) of the waterline for a given fill. A 2%
@@ -158,7 +163,7 @@ export const WaterTank = ({
             <g data-testid="tank-wave-back" className="vf-tank-drift-b">
               <g ref={backRef}>
                 <path
-                  d={wavePath(3.2, 0.9, WAVELENGTH_BACK)}
+                  d={wavePath(AMP_BACK, 0.9, WAVELENGTH_BACK)}
                   fill={`url(#${fillId})`}
                   opacity="0.5"
                 />
@@ -169,12 +174,12 @@ export const WaterTank = ({
               <g ref={frontRef}>
                 <path
                   data-testid="tank-water"
-                  d={wavePath(2.4, 2.4, WAVELENGTH_FRONT)}
+                  d={wavePath(AMP_FRONT, 2.4, WAVELENGTH_FRONT)}
                   fill={`url(#${fillId})`}
                 />
                 <path
                   data-testid="tank-meniscus"
-                  d={wavePath(2.4, 2.4, WAVELENGTH_FRONT, false)}
+                  d={wavePath(AMP_FRONT, 2.4, WAVELENGTH_FRONT, false)}
                   fill="none"
                   stroke={tone.meniscus}
                   strokeWidth="1.5"

--- a/src/features/agent-status/hooks/useReservoirFlow.test.tsx
+++ b/src/features/agent-status/hooks/useReservoirFlow.test.tsx
@@ -228,6 +228,27 @@ describe('useReservoirFlow', () => {
     expect(pending).not.toBeNull()
   })
 
+  test('paints the resting surface when reduced-motion is enabled mid-hover', () => {
+    const refs = makeRefs()
+    render(<Harness refs={refs} />)
+    const hover = screen.getByTestId('hover')
+    mockBox(hover)
+    fireEnter(hover)
+    fireMove(hover, 124)
+    runFrames(40)
+
+    const crestBefore = refs.meniscus.getAttribute('d') ?? ''
+    expect(yAt(crestBefore, 124)).toBeLessThan(yAt(crestBefore, 0))
+
+    mql.matches = true
+    mql.fire()
+    expect(pending).toBeNull()
+
+    const expected = buildReservoirSurface(62, 104, 0, 0, 124, 30).crest
+    expect(refs.meniscus.getAttribute('d')).toBe(expected)
+    expect(refs.fill.getAttribute('d')).toContain('L 248 104 L 0 104 Z')
+  })
+
   test('stops the loop when the tank goes inactive (context unknown)', () => {
     const { rerender } = render(<Harness refs={makeRefs()} active />)
     runFrames(5)

--- a/src/features/agent-status/hooks/useReservoirFlow.test.tsx
+++ b/src/features/agent-status/hooks/useReservoirFlow.test.tsx
@@ -18,7 +18,7 @@ import {
 } from './useReservoirFlow'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
-const INACTIVE = false // jsx-boolean-value wants false props omitted; alias it
+const INACTIVE = false // react/jsx-boolean-value (assumeUndefinedIsFalse) flags explicit false props; alias it
 
 const fireEnter = (el: Element): void => {
   el.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }))

--- a/src/features/agent-status/hooks/useReservoirFlow.test.tsx
+++ b/src/features/agent-status/hooks/useReservoirFlow.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen } from '@testing-library/react'
 import { useEffect, useRef, type ReactElement } from 'react'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+  type Mock,
+} from 'vitest'
 import { useReservoirFlow, type ReservoirFlowRefs } from './useReservoirFlow'
 
 // jsdom lacks PointerEvent; dispatch a typed MouseEvent — the hook only keys
@@ -9,17 +17,29 @@ const fire = (el: Element, type: 'pointerenter' | 'pointerleave'): void => {
   el.dispatchEvent(new MouseEvent(type, { bubbles: true }))
 }
 
-const makeMql = (
+interface MockMql {
   matches: boolean
-): {
-  matches: boolean
-  addEventListener: () => void
-  removeEventListener: () => void
-} => ({
-  matches,
-  addEventListener: vi.fn(),
-  removeEventListener: vi.fn(),
-})
+  addEventListener: Mock<(type: string, cb: EventListener) => void>
+  removeEventListener: Mock<(type: string, cb: EventListener) => void>
+  fire: () => void
+}
+
+const makeMql = (matches: boolean): MockMql => {
+  const listeners: EventListener[] = []
+
+  return {
+    matches,
+    addEventListener: vi.fn((_: string, cb: EventListener) => {
+      listeners.push(cb)
+    }),
+    removeEventListener: vi.fn(),
+    fire: (): void => {
+      listeners.forEach((cb) => {
+        cb(new Event('change'))
+      })
+    },
+  }
+}
 
 const makeRefs = (): ReservoirFlowRefs => ({
   front: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
@@ -156,6 +176,25 @@ describe('useReservoirFlow', () => {
     expect(pending).toBeNull()
   })
 
+  test('stops the loop and clears transforms when reduced-motion is enabled mid-hover', () => {
+    const refs = makeRefs()
+    render(<Harness refs={refs} />)
+
+    fire(screen.getByTestId('hover'), 'pointerenter')
+    for (let i = 0; i < 10; i++) {
+      frame()
+    }
+    expect(pending).not.toBeNull()
+    expect(refs.front.getAttribute('transform')).not.toBeNull()
+
+    mql.matches = true
+    mql.fire()
+
+    expect(pending).toBeNull()
+    expect(refs.front.getAttribute('transform')).toBeNull()
+    expect(refs.back.getAttribute('transform')).toBeNull()
+  })
+
   test('removes its listeners on unmount', () => {
     const { unmount } = render(<Harness refs={makeRefs()} />)
 
@@ -169,5 +208,9 @@ describe('useReservoirFlow', () => {
     const removed = removeSpy.mock.calls.map((c) => c[0])
     expect(removed).toContain('pointerenter')
     expect(removed).toContain('pointerleave')
+    expect(mql.removeEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function)
+    )
   })
 })

--- a/src/features/agent-status/hooks/useReservoirFlow.test.tsx
+++ b/src/features/agent-status/hooks/useReservoirFlow.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen } from '@testing-library/react'
+import { useEffect, useRef, type ReactElement } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { useReservoirFlow, type ReservoirFlowRefs } from './useReservoirFlow'
+
+// jsdom lacks PointerEvent; dispatch a typed MouseEvent — the hook only keys
+// off the event type.
+const fire = (el: Element, type: 'pointerenter' | 'pointerleave'): void => {
+  el.dispatchEvent(new MouseEvent(type, { bubbles: true }))
+}
+
+const makeMql = (
+  matches: boolean
+): {
+  matches: boolean
+  addEventListener: () => void
+  removeEventListener: () => void
+} => ({
+  matches,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+})
+
+const makeRefs = (): ReservoirFlowRefs => ({
+  front: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+  back: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+})
+
+const txOffset = (el: SVGGElement): number => {
+  const m = /translate\((-?\d+(?:\.\d+)?) 0\)/.exec(
+    el.getAttribute('transform') ?? ''
+  )
+
+  return m === null ? 0 : parseFloat(m[1])
+}
+
+// Manual rAF clock so frames step deterministically.
+let now = 0
+let pending: FrameRequestCallback | null = null
+
+const frame = (dtMs = 16): void => {
+  now += dtMs
+  const cb = pending
+  pending = null
+  if (cb !== null) {
+    cb(now)
+  }
+}
+
+let mql: ReturnType<typeof makeMql>
+
+beforeEach(() => {
+  now = 0
+  pending = null
+  mql = makeMql(false)
+  vi.spyOn(window, 'matchMedia').mockReturnValue(
+    mql as unknown as MediaQueryList
+  )
+
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+    pending = cb
+
+    return 1
+  })
+
+  vi.stubGlobal('cancelAnimationFrame', (): void => {
+    pending = null
+  })
+  vi.spyOn(performance, 'now').mockImplementation(() => now)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+const Harness = ({
+  refs,
+}: {
+  refs: ReservoirFlowRefs | null
+}): ReactElement => {
+  const hoverRef = useRef<HTMLDivElement>(null)
+  const refsRef = useRef<ReservoirFlowRefs | null>(refs)
+  // Keep current in sync so a rerender can drop the refs to null mid-hover
+  // (the tank emptying while the pointer is still over it).
+  useEffect(() => {
+    refsRef.current = refs
+  }, [refs])
+  useReservoirFlow(hoverRef, refsRef)
+
+  return <div ref={hoverRef} data-testid="hover" />
+}
+
+describe('useReservoirFlow', () => {
+  test('eases an extra leftward drift in while the pointer is over the tank', () => {
+    const refs = makeRefs()
+    render(<Harness refs={refs} />)
+
+    fire(screen.getByTestId('hover'), 'pointerenter')
+    for (let i = 0; i < 20; i++) {
+      frame()
+    }
+    const after20 = txOffset(refs.front)
+    expect(after20).toBeLessThan(0)
+
+    for (let i = 0; i < 10; i++) {
+      frame()
+    }
+    expect(txOffset(refs.front)).toBeLessThan(after20)
+  })
+
+  test('eases back to rest and stops the loop after the pointer leaves', () => {
+    const refs = makeRefs()
+    render(<Harness refs={refs} />)
+
+    fire(screen.getByTestId('hover'), 'pointerenter')
+    for (let i = 0; i < 10; i++) {
+      frame()
+    }
+    fire(screen.getByTestId('hover'), 'pointerleave')
+    for (let i = 0; i < 200; i++) {
+      frame()
+    }
+
+    expect(pending).toBeNull()
+    const frozen = refs.front.getAttribute('transform')
+    frame()
+    expect(refs.front.getAttribute('transform')).toBe(frozen)
+  })
+
+  test('does nothing under prefers-reduced-motion', () => {
+    mql.matches = true
+    const refs = makeRefs()
+    render(<Harness refs={refs} />)
+
+    fire(screen.getByTestId('hover'), 'pointerenter')
+
+    expect(pending).toBeNull()
+    frame()
+    expect(refs.front.getAttribute('transform')).toBeNull()
+    expect(refs.back.getAttribute('transform')).toBeNull()
+  })
+
+  test('stops the loop when the water refs disappear mid-hover', () => {
+    const { rerender } = render(<Harness refs={makeRefs()} />)
+
+    fire(screen.getByTestId('hover'), 'pointerenter')
+    for (let i = 0; i < 5; i++) {
+      frame()
+    }
+    expect(pending).not.toBeNull()
+
+    rerender(<Harness refs={null} />)
+    frame()
+
+    expect(pending).toBeNull()
+  })
+
+  test('removes its listeners on unmount', () => {
+    const { unmount } = render(<Harness refs={makeRefs()} />)
+
+    const removeSpy = vi.spyOn(
+      screen.getByTestId('hover'),
+      'removeEventListener'
+    )
+
+    unmount()
+
+    const removed = removeSpy.mock.calls.map((c) => c[0])
+    expect(removed).toContain('pointerenter')
+    expect(removed).toContain('pointerleave')
+  })
+})

--- a/src/features/agent-status/hooks/useReservoirFlow.test.tsx
+++ b/src/features/agent-status/hooks/useReservoirFlow.test.tsx
@@ -1,12 +1,23 @@
 import { render, screen } from '@testing-library/react'
 import { useEffect, useRef, type ReactElement } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { useReservoirFlow, type ReservoirFlowRefs } from './useReservoirFlow'
+import {
+  useReservoirFlow,
+  buildReservoirSurface,
+  SWELL_PRESETS,
+  type ReservoirSurfaceRefs,
+  type ReservoirGeom,
+} from './useReservoirFlow'
 
-// jsdom lacks PointerEvent; dispatch a typed MouseEvent — the hook only keys
-// off the event type.
-const fire = (el: Element, type: 'pointerenter' | 'pointerleave'): void => {
-  el.dispatchEvent(new MouseEvent(type, { bubbles: true }))
+const SVG_NS = 'http://www.w3.org/2000/svg'
+const INACTIVE = false // jsx-boolean-value wants false props omitted; alias it
+
+const fireEnter = (el: Element): void => {
+  el.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }))
+}
+
+const fireMove = (el: Element, clientX: number): void => {
+  el.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX }))
 }
 
 const makeMql = (
@@ -15,26 +26,34 @@ const makeMql = (
   matches: boolean
   addEventListener: () => void
   removeEventListener: () => void
-} => ({
-  matches,
-  addEventListener: vi.fn(),
-  removeEventListener: vi.fn(),
+} => ({ matches, addEventListener: vi.fn(), removeEventListener: vi.fn() })
+
+const makeRefs = (): ReservoirSurfaceRefs => ({
+  fill: document.createElementNS(SVG_NS, 'path'),
+  meniscus: document.createElementNS(SVG_NS, 'path'),
 })
 
-const makeRefs = (): ReservoirFlowRefs => ({
-  front: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
-  back: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
-})
-
-const txOffset = (el: SVGGElement): number => {
-  const m = /translate\((-?\d+(?:\.\d+)?) 0\)/.exec(
-    el.getAttribute('transform') ?? ''
-  )
-
-  return m === null ? 0 : parseFloat(m[1])
+// Make the hover element report a 248-wide box so clientX maps to user units.
+const mockBox = (el: Element): void => {
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    left: 0,
+    top: 0,
+    width: 248,
+    height: 104,
+    right: 248,
+    bottom: 104,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect)
 }
 
-// Manual rAF clock so frames step deterministically.
+const yAt = (crest: string, x: number): number => {
+  const m = new RegExp(`[ML] ${x}\\.0 (-?\\d+(?:\\.\\d+)?)`).exec(crest)
+
+  return m === null ? NaN : parseFloat(m[1])
+}
+
 let now = 0
 let pending: FrameRequestCallback | null = null
 
@@ -44,6 +63,12 @@ const frame = (dtMs = 16): void => {
   pending = null
   if (cb !== null) {
     cb(now)
+  }
+}
+
+const runFrames = (n: number): void => {
+  for (let i = 0; i < n; i++) {
+    frame()
   }
 }
 
@@ -76,56 +101,80 @@ afterEach(() => {
 
 const Harness = ({
   refs,
+  active = true,
 }: {
-  refs: ReservoirFlowRefs | null
+  refs: ReservoirSurfaceRefs | null
+  active?: boolean
 }): ReactElement => {
   const hoverRef = useRef<HTMLDivElement>(null)
-  const refsRef = useRef<ReservoirFlowRefs | null>(refs)
-  // Keep current in sync so a rerender can drop the refs to null mid-hover
-  // (the tank emptying while the pointer is still over it).
+  const refsRef = useRef<ReservoirSurfaceRefs | null>(refs)
+  const geomRef = useRef<ReservoirGeom | null>({ level: 62, height: 104 })
   useEffect(() => {
     refsRef.current = refs
   }, [refs])
-  useReservoirFlow(hoverRef, refsRef)
+  useReservoirFlow(hoverRef, refsRef, geomRef, active)
 
   return <div ref={hoverRef} data-testid="hover" />
 }
 
-describe('useReservoirFlow', () => {
-  test('eases an extra leftward drift in while the pointer is over the tank', () => {
-    const refs = makeRefs()
-    render(<Harness refs={refs} />)
+describe('buildReservoirSurface', () => {
+  test('closes the fill flat to the floor', () => {
+    const { fill } = buildReservoirSurface(50, 104, 1.2, 8, 124, 30)
 
-    fire(screen.getByTestId('hover'), 'pointerenter')
-    for (let i = 0; i < 20; i++) {
-      frame()
-    }
-    const after20 = txOffset(refs.front)
-    expect(after20).toBeLessThan(0)
-
-    for (let i = 0; i < 10; i++) {
-      frame()
-    }
-    expect(txOffset(refs.front)).toBeLessThan(after20)
+    expect(fill.endsWith('L 248 104 L 0 104 Z')).toBe(true)
   })
 
-  test('eases back to rest and stops the loop after the pointer leaves', () => {
+  test('raises a mound under the swell centre', () => {
+    const { crest } = buildReservoirSurface(50, 104, 0, 8, 124, 30)
+
+    // surface at the mound centre sits higher (smaller y) than far away
+    expect(yAt(crest, 124)).toBeLessThan(yAt(crest, 0))
+  })
+})
+
+describe('SWELL_PRESETS', () => {
+  test('exposes the three selectable flavors', () => {
+    expect(Object.keys(SWELL_PRESETS)).toEqual([
+      'soft-mound',
+      'trailing',
+      'wide-lift',
+    ])
+  })
+})
+
+describe('useReservoirFlow', () => {
+  test('drifts the surface over time', () => {
     const refs = makeRefs()
     render(<Harness refs={refs} />)
 
-    fire(screen.getByTestId('hover'), 'pointerenter')
-    for (let i = 0; i < 10; i++) {
-      frame()
-    }
-    fire(screen.getByTestId('hover'), 'pointerleave')
-    for (let i = 0; i < 200; i++) {
-      frame()
-    }
+    runFrames(6)
+    const first = refs.fill.getAttribute('d')
+    runFrames(20)
 
-    expect(pending).toBeNull()
-    const frozen = refs.front.getAttribute('transform')
-    frame()
-    expect(refs.front.getAttribute('transform')).toBe(frozen)
+    expect(first).not.toBeNull()
+    expect(refs.fill.getAttribute('d')).not.toBe(first)
+  })
+
+  test('raises the surface under the cursor on hover', () => {
+    // Baseline (no hover) and the hover run share the same mocked clock, so the
+    // ambient phase is identical and only the swell differs.
+    const base = makeRefs()
+    const view = render(<Harness refs={base} />)
+    runFrames(40)
+    const baseY = yAt(base.meniscus.getAttribute('d') ?? '', 124)
+    view.unmount()
+
+    now = 0
+    pending = null
+    const hov = makeRefs()
+    render(<Harness refs={hov} />)
+    const hover = screen.getByTestId('hover')
+    mockBox(hover)
+    fireEnter(hover)
+    fireMove(hover, 124)
+    runFrames(40)
+
+    expect(yAt(hov.meniscus.getAttribute('d') ?? '', 124)).toBeLessThan(baseY)
   })
 
   test('does nothing under prefers-reduced-motion', () => {
@@ -133,25 +182,17 @@ describe('useReservoirFlow', () => {
     const refs = makeRefs()
     render(<Harness refs={refs} />)
 
-    fire(screen.getByTestId('hover'), 'pointerenter')
-
     expect(pending).toBeNull()
     frame()
-    expect(refs.front.getAttribute('transform')).toBeNull()
-    expect(refs.back.getAttribute('transform')).toBeNull()
+    expect(refs.fill.getAttribute('d')).toBeNull()
   })
 
-  test('stops the loop when the water refs disappear mid-hover', () => {
-    const { rerender } = render(<Harness refs={makeRefs()} />)
-
-    fire(screen.getByTestId('hover'), 'pointerenter')
-    for (let i = 0; i < 5; i++) {
-      frame()
-    }
+  test('stops the loop when the tank goes inactive (context unknown)', () => {
+    const { rerender } = render(<Harness refs={makeRefs()} active />)
+    runFrames(5)
     expect(pending).not.toBeNull()
 
-    rerender(<Harness refs={null} />)
-    frame()
+    rerender(<Harness refs={makeRefs()} active={INACTIVE} />)
 
     expect(pending).toBeNull()
   })
@@ -168,6 +209,6 @@ describe('useReservoirFlow', () => {
 
     const removed = removeSpy.mock.calls.map((c) => c[0])
     expect(removed).toContain('pointerenter')
-    expect(removed).toContain('pointerleave')
+    expect(removed).toContain('pointermove')
   })
 })

--- a/src/features/agent-status/hooks/useReservoirFlow.ts
+++ b/src/features/agent-status/hooks/useReservoirFlow.ts
@@ -11,11 +11,11 @@ export interface ReservoirFlowRefs {
 // a visible jump.
 const WRAP = 248
 // Extra drift (user units / second) added at full hover intensity, on top of
-// the always-on CSS base drift. Deliberately gentle: the reservoir should
-// quicken "a bit" on hover, not race. Front ripples gain more than the broad
-// back swell, preserving the parallax.
-const FRONT_BOOST = WRAP / 14
-const BACK_BOOST = WRAP / 20
+// the always-on CSS base drift. Tuned for a clear, obvious quickening on hover
+// (~2.2x the base 6s/9s drift), eased in and out. Front ripples gain more than
+// the broad back swell, preserving the parallax.
+const FRONT_BOOST = WRAP / 5
+const BACK_BOOST = WRAP / 7
 // Per-second easing of the hover intensity (0..1) so the speed ramps in and
 // out smoothly instead of stepping — the calm, natural feel of the old spring.
 const EASE_PER_SECOND = 5

--- a/src/features/agent-status/hooks/useReservoirFlow.ts
+++ b/src/features/agent-status/hooks/useReservoirFlow.ts
@@ -109,6 +109,16 @@ export const useReservoirFlow = (
 
     const onLeave = (): void => {
       targetIntensity = 0
+      // Skip under reduced-motion and when there is no water to drift, mirroring
+      // onEnter. Also avoid scheduling a single spurious frame when the loop is
+      // already at rest.
+      if (
+        mql.matches ||
+        refsRef.current === null ||
+        (rafId === null && intensity < REST_EPSILON)
+      ) {
+        return
+      }
       ensureLoop()
     }
 

--- a/src/features/agent-status/hooks/useReservoirFlow.ts
+++ b/src/features/agent-status/hooks/useReservoirFlow.ts
@@ -187,6 +187,28 @@ export const useReservoirFlow = (
     const onMqlChange = (): void => {
       if (mql.matches) {
         stop()
+        // Reset swell state to rest and paint the static resting surface
+        // immediately. React no longer owns the `d` attributes, so the same
+        // imperative owner must restore them when animation is disabled live.
+        amp = 0
+        targetAmp = 0
+        swellX = TANK_WIDTH / 2
+        cursorX = TANK_WIDTH / 2
+        phase = 0
+        const refs = refsRef.current
+        const geom = geomRef.current
+        if (refs !== null && geom !== null) {
+          const { fill, crest } = buildReservoirSurface(
+            geom.level,
+            geom.height,
+            0,
+            0,
+            TANK_WIDTH / 2,
+            preset.width
+          )
+          refs.fill.setAttribute('d', fill)
+          refs.meniscus.setAttribute('d', crest)
+        }
       } else {
         start()
       }

--- a/src/features/agent-status/hooks/useReservoirFlow.ts
+++ b/src/features/agent-status/hooks/useReservoirFlow.ts
@@ -84,7 +84,7 @@ export const buildReservoirSurface = (
 
   return {
     crest: crest.trim(),
-    fill: `${crest}L ${TANK_WIDTH} ${height} L 0 ${height} Z`,
+    fill: `${crest.trim()} L ${TANK_WIDTH} ${height} L 0 ${height} Z`,
   }
 }
 

--- a/src/features/agent-status/hooks/useReservoirFlow.ts
+++ b/src/features/agent-status/hooks/useReservoirFlow.ts
@@ -1,88 +1,158 @@
 import { useEffect, type RefObject } from 'react'
 
-export interface ReservoirFlowRefs {
-  front: SVGGElement
-  back: SVGGElement
+export interface ReservoirSurfaceRefs {
+  /** The filled water body (surface down to a flat floor). */
+  fill: SVGPathElement
+  /** The bright crest line tracing the surface. */
+  meniscus: SVGPathElement
 }
 
-// Seamless wrap distance: the wave paths tile every tank width (the front 124u
-// and back 248u wavelengths both divide it), so a boost offset taken modulo
-// this is an invisible phase shift — the loop can freeze at any offset without
-// a visible jump.
-const WRAP = 248
-// Extra drift (user units / second) added at full hover intensity, on top of
-// the always-on CSS base drift. Tuned for a clear, obvious quickening on hover
-// (~2.2x the base 6s/9s drift), eased in and out. Front ripples gain more than
-// the broad back swell, preserving the parallax.
-const FRONT_BOOST = WRAP / 5
-const BACK_BOOST = WRAP / 7
-// Per-second easing of the hover intensity (0..1) so the speed ramps in and
-// out smoothly instead of stepping — the calm, natural feel of the old spring.
-const EASE_PER_SECOND = 5
-// Below this intensity, once the pointer has left, the boost is considered at
-// rest and the rAF loop stops (offsets freeze at an invisible phase).
-const REST_EPSILON = 0.002
+export interface ReservoirGeom {
+  /** Waterline y (user units) for the current fill. */
+  level: number
+  /** Tank height (user units) — the fill always closes flat to this floor. */
+  height: number
+}
 
 /**
- * Eases a small extra water drift in while the pointer is over `hoverRef` and
- * back out when it leaves, by translating the boost groups in `refsRef`. The
- * always-on calm drift lives in CSS; this only adds the hover quickening, so
- * the rAF loop runs solely during a hover and its ease-out. No-op (and never
- * schedules rAF) under `prefers-reduced-motion`.
+ * Hover "swell" flavor — how the water rises toward the cursor. Three are
+ * available; `soft-mound` is the default. A future user setting will let people
+ * pick among them (see Linear VIM-128); today the `WaterTank` `swell` prop just
+ * defaults and nothing wires it.
+ */
+export type SwellVariant = 'soft-mound' | 'trailing' | 'wide-lift'
+
+interface SwellPreset {
+  /** Gaussian half-width of the mound (user units). */
+  width: number
+  /** Peak rise under the cursor at full hover (user units). */
+  peakAmp: number
+  /** Per-second easing of the mound's horizontal follow (higher = snappier). */
+  followEase: number
+  /** Per-second easing of the rise/fall. */
+  ampEase: number
+}
+
+export const SWELL_PRESETS: Record<SwellVariant, SwellPreset> = {
+  // A single soft mound that follows the cursor closely (default).
+  'soft-mound': { width: 30, peakAmp: 8, followEase: 12, ampEase: 6 },
+  // The mound lags behind the cursor, giving a sense of mass / inertia.
+  trailing: { width: 30, peakAmp: 8, followEase: 4.5, ampEase: 6 },
+  // A broad, low rise instead of a focused peak — the calmest.
+  'wide-lift': { width: 64, peakAmp: 5, followEase: 9, ampEase: 5 },
+}
+
+const TANK_WIDTH = 248
+const TAU = Math.PI * 2
+// Two surface components summed into one waterline: fast front ripples + a
+// broad slow swell. Both wavelengths divide the width so the endpoints stay
+// equal (no seam) regardless of phase.
+const WL_FRONT = TANK_WIDTH / 2
+const WL_BACK = TANK_WIDTH
+const AMP_FRONT = 5
+const AMP_BACK = 7
+const STEP = 4
+// Base drift: phase advances ~0.7 rad/s — a calm, always-on flow.
+const BASE_RATE = 0.7
+const LEVEL_EASE_PER_SECOND = 4
+
+/**
+ * Builds the surface path. A Gaussian mound of height `swellAmp` centred at
+ * `swellX` (width `swellWidth`) lifts the waterline toward the cursor while the
+ * fill still closes flat to the floor (`height`). Exported so the component can
+ * paint a resting first frame.
+ */
+export const buildReservoirSurface = (
+  level: number,
+  height: number,
+  phase: number,
+  swellAmp: number,
+  swellX: number,
+  swellWidth: number
+): { fill: string; crest: string } => {
+  let crest = ''
+  for (let x = 0; x <= TANK_WIDTH; x += STEP) {
+    const mound = swellAmp * Math.exp(-Math.pow((x - swellX) / swellWidth, 2))
+
+    const y =
+      level +
+      Math.sin((x / WL_FRONT) * TAU + phase) * AMP_FRONT +
+      Math.sin((x / WL_BACK) * TAU + phase * 0.7 + 0.9) * AMP_BACK -
+      mound
+    crest += `${x === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(2)} `
+  }
+
+  return {
+    crest: crest.trim(),
+    fill: `${crest}L ${TANK_WIDTH} ${height} L 0 ${height} Z`,
+  }
+}
+
+/**
+ * Drives the reservoir's water: a calm always-on drift, plus a swell that rises
+ * toward the cursor while the pointer is over `hoverRef` (shape per `variant`).
+ * Redraws the surface each frame so the floor stays flat. The rAF loop runs only
+ * while `active`, and is a no-op under `prefers-reduced-motion` (the component
+ * paints a static resting surface).
  */
 export const useReservoirFlow = (
   hoverRef: RefObject<Element | null>,
-  refsRef: RefObject<ReservoirFlowRefs | null>
+  refsRef: RefObject<ReservoirSurfaceRefs | null>,
+  geomRef: RefObject<ReservoirGeom | null>,
+  active: boolean,
+  variant: SwellVariant = 'soft-mound'
 ): void => {
   useEffect(() => {
+    if (!active) {
+      return
+    }
     const hoverEl = hoverRef.current
     if (hoverEl === null) {
       return
     }
+    const preset = SWELL_PRESETS[variant]
     const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
 
-    let frontOffset = 0
-    let backOffset = 0
-    let intensity = 0
-    let targetIntensity = 0
+    let phase = 0
+    let amp = 0
+    let targetAmp = 0
+    let swellX = TANK_WIDTH / 2
+    let cursorX = TANK_WIDTH / 2
+    let curLevel = geomRef.current?.level ?? 0
     let rafId: number | null = null
     let lastT = 0
 
-    // Drive the boost via the SVG `transform` attribute (unambiguously user
-    // units) rather than CSS px, so the offset stays in the tank's coordinate
-    // space and wraps cleanly at one tank width.
-    const place = (el: SVGGElement, offset: number): void => {
-      el.setAttribute('transform', `translate(${(-offset).toFixed(2)} 0)`)
-    }
-
     const step = (t: number): void => {
       const refs = refsRef.current
-      if (refs === null) {
-        // The water was removed (e.g. the context reset to unknown) while the
-        // loop was running — stop instead of scheduling no-op frames forever.
-        intensity = 0
+      const geom = geomRef.current
+      if (refs === null || geom === null) {
         rafId = null
 
         return
       }
       const dt = Math.max(0, Math.min(0.05, (t - lastT) / 1000))
       lastT = t
-      intensity +=
-        (targetIntensity - intensity) * Math.min(1, dt * EASE_PER_SECOND)
-      frontOffset = (frontOffset + FRONT_BOOST * intensity * dt) % WRAP
-      backOffset = (backOffset + BACK_BOOST * intensity * dt) % WRAP
-      place(refs.front, frontOffset)
-      place(refs.back, backOffset)
+      amp += (targetAmp - amp) * Math.min(1, dt * preset.ampEase)
+      swellX += (cursorX - swellX) * Math.min(1, dt * preset.followEase)
+      curLevel +=
+        (geom.level - curLevel) * Math.min(1, dt * LEVEL_EASE_PER_SECOND)
+      phase += BASE_RATE * dt
 
-      if (targetIntensity === 0 && intensity < REST_EPSILON) {
-        rafId = null
+      const { fill, crest } = buildReservoirSurface(
+        curLevel,
+        geom.height,
+        phase,
+        amp,
+        swellX,
+        preset.width
+      )
+      refs.fill.setAttribute('d', fill)
+      refs.meniscus.setAttribute('d', crest)
 
-        return
-      }
       rafId = requestAnimationFrame(step)
     }
 
-    const ensureLoop = (): void => {
+    const start = (): void => {
       if (rafId !== null) {
         return
       }
@@ -98,43 +168,44 @@ export const useReservoirFlow = (
     }
 
     const onEnter = (): void => {
-      // Skip under reduced-motion, and when there is no water to drift (empty
-      // tank) so a hover doesn't spin the loop for nothing.
-      if (mql.matches || refsRef.current === null) {
+      if (mql.matches) {
         return
       }
-      targetIntensity = 1
-      ensureLoop()
+      targetAmp = preset.peakAmp
     }
 
     const onLeave = (): void => {
-      targetIntensity = 0
-      ensureLoop()
+      targetAmp = 0
+    }
+
+    const onMove = (e: Event): void => {
+      const r = hoverEl.getBoundingClientRect()
+      const x = ((e as MouseEvent).clientX - r.left) / r.width
+      cursorX = Math.max(0, Math.min(TANK_WIDTH, x * TANK_WIDTH))
     }
 
     const onMqlChange = (): void => {
-      if (!mql.matches) {
-        return
-      }
-      targetIntensity = 0
-      intensity = 0
-      stop()
-      const refs = refsRef.current
-      if (refs !== null) {
-        refs.front.removeAttribute('transform')
-        refs.back.removeAttribute('transform')
+      if (mql.matches) {
+        stop()
+      } else {
+        start()
       }
     }
 
     hoverEl.addEventListener('pointerenter', onEnter)
     hoverEl.addEventListener('pointerleave', onLeave)
+    hoverEl.addEventListener('pointermove', onMove)
     mql.addEventListener('change', onMqlChange)
+    if (!mql.matches) {
+      start()
+    }
 
     return (): void => {
       hoverEl.removeEventListener('pointerenter', onEnter)
       hoverEl.removeEventListener('pointerleave', onLeave)
+      hoverEl.removeEventListener('pointermove', onMove)
       mql.removeEventListener('change', onMqlChange)
       stop()
     }
-  }, [hoverRef, refsRef])
+  }, [hoverRef, refsRef, geomRef, active, variant])
 }

--- a/src/features/agent-status/hooks/useReservoirFlow.ts
+++ b/src/features/agent-status/hooks/useReservoirFlow.ts
@@ -1,0 +1,140 @@
+import { useEffect, type RefObject } from 'react'
+
+export interface ReservoirFlowRefs {
+  front: SVGGElement
+  back: SVGGElement
+}
+
+// Seamless wrap distance: the wave paths tile every tank width (the front 124u
+// and back 248u wavelengths both divide it), so a boost offset taken modulo
+// this is an invisible phase shift — the loop can freeze at any offset without
+// a visible jump.
+const WRAP = 248
+// Extra drift (user units / second) added at full hover intensity, on top of
+// the always-on CSS base drift. Deliberately gentle: the reservoir should
+// quicken "a bit" on hover, not race. Front ripples gain more than the broad
+// back swell, preserving the parallax.
+const FRONT_BOOST = WRAP / 14
+const BACK_BOOST = WRAP / 20
+// Per-second easing of the hover intensity (0..1) so the speed ramps in and
+// out smoothly instead of stepping — the calm, natural feel of the old spring.
+const EASE_PER_SECOND = 5
+// Below this intensity, once the pointer has left, the boost is considered at
+// rest and the rAF loop stops (offsets freeze at an invisible phase).
+const REST_EPSILON = 0.002
+
+/**
+ * Eases a small extra water drift in while the pointer is over `hoverRef` and
+ * back out when it leaves, by translating the boost groups in `refsRef`. The
+ * always-on calm drift lives in CSS; this only adds the hover quickening, so
+ * the rAF loop runs solely during a hover and its ease-out. No-op (and never
+ * schedules rAF) under `prefers-reduced-motion`.
+ */
+export const useReservoirFlow = (
+  hoverRef: RefObject<Element | null>,
+  refsRef: RefObject<ReservoirFlowRefs | null>
+): void => {
+  useEffect(() => {
+    const hoverEl = hoverRef.current
+    if (hoverEl === null) {
+      return
+    }
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+
+    let frontOffset = 0
+    let backOffset = 0
+    let intensity = 0
+    let targetIntensity = 0
+    let rafId: number | null = null
+    let lastT = 0
+
+    // Drive the boost via the SVG `transform` attribute (unambiguously user
+    // units) rather than CSS px, so the offset stays in the tank's coordinate
+    // space and wraps cleanly at one tank width.
+    const place = (el: SVGGElement, offset: number): void => {
+      el.setAttribute('transform', `translate(${(-offset).toFixed(2)} 0)`)
+    }
+
+    const step = (t: number): void => {
+      const refs = refsRef.current
+      if (refs === null) {
+        // The water was removed (e.g. the context reset to unknown) while the
+        // loop was running — stop instead of scheduling no-op frames forever.
+        intensity = 0
+        rafId = null
+
+        return
+      }
+      const dt = Math.max(0, Math.min(0.05, (t - lastT) / 1000))
+      lastT = t
+      intensity +=
+        (targetIntensity - intensity) * Math.min(1, dt * EASE_PER_SECOND)
+      frontOffset = (frontOffset + FRONT_BOOST * intensity * dt) % WRAP
+      backOffset = (backOffset + BACK_BOOST * intensity * dt) % WRAP
+      place(refs.front, frontOffset)
+      place(refs.back, backOffset)
+
+      if (targetIntensity === 0 && intensity < REST_EPSILON) {
+        rafId = null
+
+        return
+      }
+      rafId = requestAnimationFrame(step)
+    }
+
+    const ensureLoop = (): void => {
+      if (rafId !== null) {
+        return
+      }
+      lastT = performance.now()
+      rafId = requestAnimationFrame(step)
+    }
+
+    const stop = (): void => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
+    }
+
+    const onEnter = (): void => {
+      // Skip under reduced-motion, and when there is no water to drift (empty
+      // tank) so a hover doesn't spin the loop for nothing.
+      if (mql.matches || refsRef.current === null) {
+        return
+      }
+      targetIntensity = 1
+      ensureLoop()
+    }
+
+    const onLeave = (): void => {
+      targetIntensity = 0
+      ensureLoop()
+    }
+
+    const onMqlChange = (): void => {
+      if (!mql.matches) {
+        return
+      }
+      targetIntensity = 0
+      intensity = 0
+      stop()
+      const refs = refsRef.current
+      if (refs !== null) {
+        refs.front.removeAttribute('transform')
+        refs.back.removeAttribute('transform')
+      }
+    }
+
+    hoverEl.addEventListener('pointerenter', onEnter)
+    hoverEl.addEventListener('pointerleave', onLeave)
+    mql.addEventListener('change', onMqlChange)
+
+    return (): void => {
+      hoverEl.removeEventListener('pointerenter', onEnter)
+      hoverEl.removeEventListener('pointerleave', onLeave)
+      mql.removeEventListener('change', onMqlChange)
+      stop()
+    }
+  }, [hoverRef, refsRef])
+}

--- a/src/index.css
+++ b/src/index.css
@@ -277,11 +277,11 @@
 }
 
 .vf-tank-drift-a {
-  animation: vfTankDrift 9s linear infinite;
+  animation: vfTankDrift 6s linear infinite;
 }
 
 .vf-tank-drift-b {
-  animation: vfTankDrift 13s linear infinite;
+  animation: vfTankDrift 9s linear infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/index.css
+++ b/src/index.css
@@ -251,48 +251,42 @@
   }
 }
 
-/* Context reservoir (WaterTank) parallax. Each wave path is 2x the tank width
-   (496) and translates by exactly one tank width (248) for a seamless loop.
-   `transform-box: fill-box` is required so the -50% resolves against the 496px
-   path, not the 248px viewBox — without it the percentage is viewBox-relative
-   (-124px), half the back wave's 248px wavelength, so it resets mid-wave every
-   loop. Both waves move the same direction; the back wave reads as a distinct
-   layer through its longer wavelength, slower speed, taller amplitude, and
-   offset phase. Honors prefers-reduced-motion — the static tank is legible. */
-@keyframes vfTankWaveA {
+/* Context reservoir (WaterTank) ambient drift. Each wave path is 3x the tank
+   width (744) and the keyframe drifts the group by exactly one tank width
+   (248 = -33.333% of 744) for a seamless loop. `transform-box: fill-box` makes
+   the percentage resolve against the 744px path, not the 248px viewBox —
+   without it the percentage is viewBox-relative and resets mid-wave. Three
+   tiles (not two) leave runway for the JS hover boost (useReservoirFlow) to
+   stack on top of this -248 drift without sampling past the path's right edge.
+   The base drift is deliberately slow and calm; the back wave reads as a
+   distinct, slower parallax layer (longer wavelength, slower speed, taller
+   amplitude, offset phase). Honors prefers-reduced-motion — the static filled
+   tank is fully legible. */
+@keyframes vfTankDrift {
   from {
     transform: translateX(0);
   }
   to {
-    transform: translateX(-50%);
+    transform: translateX(-33.3333%);
   }
 }
 
-@keyframes vfTankWaveB {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-50%);
-  }
-}
-
-.vf-tank-wave-a,
-.vf-tank-wave-b {
+.vf-tank-drift-a,
+.vf-tank-drift-b {
   transform-box: fill-box;
 }
 
-.vf-tank-wave-a {
-  animation: vfTankWaveA 4.6s linear infinite;
+.vf-tank-drift-a {
+  animation: vfTankDrift 9s linear infinite;
 }
 
-.vf-tank-wave-b {
-  animation: vfTankWaveB 7s linear infinite;
+.vf-tank-drift-b {
+  animation: vfTankDrift 13s linear infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .vf-tank-wave-a,
-  .vf-tank-wave-b {
+  .vf-tank-drift-a,
+  .vf-tank-drift-b {
     animation: none;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -251,46 +251,6 @@
   }
 }
 
-/* Context reservoir (WaterTank) ambient drift. Each wave path is 3x the tank
-   width (744) and the keyframe drifts the group by exactly one tank width
-   (248 = -33.333% of 744) for a seamless loop. `transform-box: fill-box` makes
-   the percentage resolve against the 744px path, not the 248px viewBox —
-   without it the percentage is viewBox-relative and resets mid-wave. Three
-   tiles (not two) leave runway for the JS hover boost (useReservoirFlow) to
-   stack on top of this -248 drift without sampling past the path's right edge.
-   The base drift is deliberately slow and calm; the back wave reads as a
-   distinct, slower parallax layer (longer wavelength, slower speed, taller
-   amplitude, offset phase). Honors prefers-reduced-motion — the static filled
-   tank is fully legible. */
-@keyframes vfTankDrift {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-33.3333%);
-  }
-}
-
-.vf-tank-drift-a,
-.vf-tank-drift-b {
-  transform-box: fill-box;
-}
-
-.vf-tank-drift-a {
-  animation: vfTankDrift 6s linear infinite;
-}
-
-.vf-tank-drift-b {
-  animation: vfTankDrift 9s linear infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .vf-tank-drift-a,
-  .vf-tank-drift-b {
-    animation: none;
-  }
-}
-
 /* Diff viewer styling */
 .diff-added {
   background-color: var(--color-diff-added);


### PR DESCRIPTION
## Summary

Follow-up to #455. The reservoir's water used a fixed linear CSS speed, which read as mechanical/"hardcoded." This restores the calm, interactive feel of the pre-reservoir `LiquidFill`: **slow, natural drift by default, easing a little faster while the pointer is over the tank.**

- **`useReservoirFlow.ts`** (new) — eases an extra drift in on `pointerenter` and back out on `pointerleave` (rAF runs only during a hover + its ease-out; the offset freezes between, invisible because the wave is periodic). Stops if the water disappears mid-hover; no-op under `prefers-reduced-motion`.
- **`WaterTank.tsx`** — the always-on calm base drift stays in CSS (`9s`/`13s`); a nested boost group takes the hover quickening, driven by the SVG `transform` attribute (unambiguous user units).
- The wave path is now **3 tanks wide** and the CSS drifts exactly one tank (`translateX(-33.333%)` of the 744px path under `transform-box: fill-box`), giving the base + boost translate enough runway to never sample past the path's right edge.
- The value pill is `pointer-events-none` so the whole tank region registers the hover.

## Testing

- New `useReservoirFlow.test.tsx` covers the ease-in, ease-out-and-stop, reduced-motion no-op, mid-hover refs-disappear stop, and listener cleanup, using a mocked rAF clock.
- Full Vitest suite green (287 files, 3697 passed, 3 skipped); ESLint, `tsc -b`, Prettier all clean.
- Reviewed locally with `codex review` across 3 rounds to a greenlight — a perpetual-rAF leak (refs vanish mid-hover) and a wave-path sampling gap (base + boost translate exceeding the rendered tiles) were both found and fixed; the SVG-transform geometry was verified with a headless-Chrome CTM check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
