### PR TITLE
[codex] Restore macOS drag-region cutouts

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,7 +54,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 64       | 30   | 2026-06-12   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 30   | 2026-06-15   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |
@@ -82,7 +82,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 11       | 8    | 2026-06-12   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 8        | 4    | 2026-06-13   |
-| [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 8        | 2    | 2026-06-11   |
+| [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 9        | 2    | 2026-06-15   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                     | correctness        | 1        | 0    | 2026-06-11   |
 | [Identifier Prefix Matching](patterns/identifier-prefix-matching.md)                                 | correctness        | 3        | 1    | 2026-06-12   |
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |

--- a/docs/reviews/patterns/macos-window-chrome.md
+++ b/docs/reviews/patterns/macos-window-chrome.md
@@ -2,7 +2,7 @@
 id: macos-window-chrome
 category: cross-platform
 created: 2026-06-09
-last_updated: 2026-06-11
+last_updated: 2026-06-15
 ref_count: 2
 ---
 
@@ -81,3 +81,13 @@ dimensions so the controls do not overlay adjacent UI columns.
 - **File:** `src/features/workspace/components/SidebarTopBar.tsx`, `src/features/sessions/components/Tabs.tsx`
 - **Finding:** Both bars moved `vf-app-drag-region` from the outer container to inner grid/flex children, but left `paddingRight: 10` (`SidebarTopBar`) and `pr-2` (`Tabs`) on the non-draggable outer containers. CSS grid/flex children occupy the content box, not the parent padding area, so the rightmost 10 px / 8 px strips stopped being draggable on macOS compared with the previous behavior.
 - **Fix:** Removed the outer right padding from both containers and placed the same spacing on the rightmost inner element that already owns the drag/no-drag behavior, restoring the full right-edge draggable strip.
+- **Commit:** same commit as this entry
+
+### 9. Bucket tooltip triggers inside collapsed activity rail are swallowed by the drag region
+
+- **Source:** github-codex-connector | PR #458 round 1 | 2026-06-15
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/agent-status/components/AgentStatusRail.tsx` L57-102
+- **Finding:** On macOS when the activity panel is collapsed and CTX/CACHE stats are present, applying `vf-app-drag-region` to the whole rail made the `Bucket` tooltip triggers part of an Electron drag region. Electron drag regions suppress pointer and mouse-enter events unless an area is excluded with `no-drag`, so the bucket tooltips stopped appearing.
+- **Fix:** Wrapped the CTX bucket in a `vf-app-no-drag` div and added `vf-app-no-drag` to the existing CACHE bucket container so both bucket tooltip triggers receive pointer events while the empty rail chrome remains draggable.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,7 +2,7 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-14
+last_updated: 2026-06-15
 ref_count: 31
 ---
 
@@ -638,4 +638,13 @@ filesystem scope restrictions).
 - **File:** `src/features/editor/components/MarkdownReadingView.test.tsx` L226-266
 - **Finding:** The `falls back to execCommand copy` test replaced both `window.navigator.clipboard` and `document.execCommand`, but the `finally` block only restored the clipboard property. The leaked `execCommand` mock persisted in the shared jsdom document for every subsequent test in the file, creating a false-positive risk for any future test that exercised the textarea fallback path without its own mock.
 - **Fix:** Saved the original `document.execCommand` value before overriding it and restored it in the same `finally` block alongside `navigator.clipboard`, mirroring the symmetric cleanup already used by the `installClipboardMock` helper.
+- **Commit:** same commit as this entry
+
+### 64. Global `navigator.platform` mutation in macOS drag tests leaks to subsequent tests
+
+- **Source:** github-claude | PR #458 round 1 | 2026-06-15
+- **Severity:** LOW
+- **File:** `src/features/workspace/WorkspaceView.top-chrome.test.tsx` L324-402
+- **Finding:** Three macOS drag-region tests set `navigator.platform = "MacIntel"` via `Object.defineProperty` but never reset the value. Vitest runs tests in declaration order within a file, so every later test inherits the mutated platform and macOS behavior (`preferModifier = "meta"`, `reserveWindowControls = true`). No existing assertion checks the absence of `vf-app-drag-region`, so the suite stays green, but any future non-macOS test added below the macOS blocks silently receives macOS behavior and fails spuriously.
+- **Fix:** Added an `Object.defineProperty(navigator, "platform", { value: "", configurable: true })` reset at the top of the file's `beforeEach` so every test starts with a clean platform value.
 - **Commit:** same commit as this entry

--- a/src/features/agent-status/components/AgentStatusPanel/Header.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.test.tsx
@@ -47,3 +47,36 @@ test('gradient wash uses agent.accentDim in inline style', () => {
     /var\(--color-agent-codex-accent-dim\)/
   )
 })
+
+test('adds macOS drag coverage while keeping collapse clickable', () => {
+  render(
+    <AgentStatusPanelHeader
+      agent={AGENTS.claude}
+      status="running"
+      onCollapse={() => undefined}
+      reserveWindowControls
+    />
+  )
+
+  expect(screen.getByTestId('agent-status-panel-header')).toHaveClass(
+    'vf-app-drag-region'
+  )
+
+  expect(
+    screen.getByRole('button', { name: /collapse activity panel/i })
+  ).toHaveClass('vf-app-no-drag')
+})
+
+test('does not add drag coverage when native controls are not reserved', () => {
+  render(
+    <AgentStatusPanelHeader
+      agent={AGENTS.claude}
+      status="running"
+      onCollapse={() => undefined}
+    />
+  )
+
+  expect(screen.getByTestId('agent-status-panel-header')).not.toHaveClass(
+    'vf-app-drag-region'
+  )
+})

--- a/src/features/agent-status/components/AgentStatusPanel/Header.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.tsx
@@ -7,16 +7,20 @@ export interface AgentStatusPanelHeaderProps {
   agent: Agent
   status: SessionStatus
   onCollapse: () => void
+  reserveWindowControls?: boolean
 }
 
 export const AgentStatusPanelHeader = ({
   agent,
   status,
   onCollapse,
+  reserveWindowControls = false,
 }: AgentStatusPanelHeaderProps): ReactElement => (
   <div
     data-testid="agent-status-panel-header"
-    className="flex items-center gap-2.5 px-3 py-2.5"
+    className={`flex items-center gap-2.5 px-3 py-2.5 ${
+      reserveWindowControls ? 'vf-app-drag-region' : ''
+    }`}
     style={{
       background: `linear-gradient(180deg, ${agent.accentDim}, transparent 80%)`,
     }}
@@ -38,7 +42,7 @@ export const AgentStatusPanelHeader = ({
       type="button"
       onClick={onCollapse}
       aria-label="Collapse activity panel"
-      className="grid h-6 w-6 shrink-0 place-items-center rounded-md text-outline transition-colors hover:bg-surface-container-high hover:text-on-surface"
+      className="vf-app-no-drag grid h-6 w-6 shrink-0 place-items-center rounded-md text-outline transition-colors hover:bg-surface-container-high hover:text-on-surface"
     >
       <span className="material-symbols-outlined text-base">chevron_right</span>
     </button>

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -34,6 +34,7 @@ interface AgentStatusPanelProps {
   status: SessionStatus
   onCollapse: () => void
   cacheHistory: number[]
+  reserveWindowControls?: boolean
 }
 
 // Exported so WorkspaceView can target this width as the
@@ -53,6 +54,7 @@ export const AgentStatusPanel = ({
   status: sessionStatus,
   onCollapse,
   cacheHistory,
+  reserveWindowControls = false,
 }: AgentStatusPanelProps): ReactElement => {
   const status = agentStatus
   const events = useActivityEvents(status)
@@ -138,6 +140,7 @@ export const AgentStatusPanel = ({
         agent={agent}
         status={sessionStatus}
         onCollapse={onCollapse}
+        reserveWindowControls={reserveWindowControls}
       />
 
       <div className="flex flex-col gap-2 p-2">

--- a/src/features/agent-status/components/AgentStatusRail.test.tsx
+++ b/src/features/agent-status/components/AgentStatusRail.test.tsx
@@ -194,3 +194,40 @@ test('rail sits on the canvas surface token', () => {
   expect(rail.className).toContain('bg-surface')
   expect(rail.className).not.toContain('bg-surface-container')
 })
+
+test('adds macOS drag coverage while keeping expand clickable', () => {
+  render(
+    <AgentStatusRail
+      agent={AGENTS.claude}
+      contextUsedPercentage={50}
+      cacheHitPercentage={null}
+      isRunning={notRunning}
+      onExpand={() => undefined}
+      reserveWindowControls
+    />
+  )
+
+  expect(screen.getByTestId('agent-status-rail')).toHaveClass(
+    'vf-app-drag-region'
+  )
+
+  expect(
+    screen.getByRole('button', { name: /expand activity panel/i })
+  ).toHaveClass('vf-app-no-drag')
+})
+
+test('does not add rail drag coverage when native controls are not reserved', () => {
+  render(
+    <AgentStatusRail
+      agent={AGENTS.claude}
+      contextUsedPercentage={50}
+      cacheHitPercentage={null}
+      isRunning={notRunning}
+      onExpand={() => undefined}
+    />
+  )
+
+  expect(screen.getByTestId('agent-status-rail')).not.toHaveClass(
+    'vf-app-drag-region'
+  )
+})

--- a/src/features/agent-status/components/AgentStatusRail.tsx
+++ b/src/features/agent-status/components/AgentStatusRail.tsx
@@ -9,6 +9,7 @@ export interface AgentStatusRailProps {
   cacheHitPercentage: number | null
   isRunning: boolean
   onExpand: () => void
+  reserveWindowControls?: boolean
 }
 
 // Exported so WorkspaceView can drive the `transition-[width]` animation on
@@ -44,6 +45,7 @@ export const AgentStatusRail = ({
   cacheHitPercentage,
   isRunning,
   onExpand,
+  reserveWindowControls = false,
 }: AgentStatusRailProps): ReactElement => {
   const ctxPct = contextUsedPercentage
   const cachePct = cacheHitPercentage
@@ -51,14 +53,16 @@ export const AgentStatusRail = ({
   return (
     <aside
       data-testid="agent-status-rail"
-      className="flex h-full flex-col items-center bg-surface pb-3 pt-2"
+      className={`flex h-full flex-col items-center bg-surface pb-3 pt-2 ${
+        reserveWindowControls ? 'vf-app-drag-region' : ''
+      }`}
       style={{ width: RAIL_WIDTH_PX }}
     >
       <button
         type="button"
         onClick={onExpand}
         aria-label="Expand activity panel"
-        className="grid h-7 w-7 shrink-0 place-items-center rounded-md text-on-surface-muted transition-colors hover:bg-surface-container-high hover:text-on-surface"
+        className="vf-app-no-drag grid h-7 w-7 shrink-0 place-items-center rounded-md text-on-surface-muted transition-colors hover:bg-surface-container-high hover:text-on-surface"
       >
         <span className="material-symbols-outlined text-base">
           chevron_left

--- a/src/features/agent-status/components/AgentStatusRail.tsx
+++ b/src/features/agent-status/components/AgentStatusRail.tsx
@@ -82,16 +82,18 @@ export const AgentStatusRail = ({
       </div>
 
       {ctxPct !== null && (
-        <Bucket
-          pct={ctxPct}
-          color={ctxTone(ctxPct).base}
-          label="CTX"
-          tooltip={`Context: ${Math.round(ctxPct)}%`}
-        />
+        <div className="vf-app-no-drag">
+          <Bucket
+            pct={ctxPct}
+            color={ctxTone(ctxPct).base}
+            label="CTX"
+            tooltip={`Context: ${Math.round(ctxPct)}%`}
+          />
+        </div>
       )}
 
       {cachePct !== null && (
-        <div className="mt-4">
+        <div className="vf-app-no-drag mt-4">
           <Bucket
             pct={cachePct}
             color={cacheTone(cachePct)}

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
@@ -87,6 +87,12 @@ describe('LayoutSwitcher', () => {
     expect(screen.getByRole('group')).toHaveAccessibleName('Pane layout')
   })
 
+  test('cuts the layout pillar out of parent drag regions', () => {
+    render(<LayoutSwitcher activeLayoutId="single" onPick={vi.fn()} />)
+
+    expect(screen.getByTestId('layout-switcher')).toHaveClass('vf-app-no-drag')
+  })
+
   // Layout buttons render the layout name only — no shortcut chip.
   // `Mod+\` cycles to the NEXT layout (usePaneShortcuts), not to any
   // specific one, so attaching the chip to individual layout buttons

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
@@ -40,7 +40,7 @@ export const LayoutSwitcher = ({
     // sequence — adequate for a 5-item picker.
     role="group"
     aria-label="Pane layout"
-    className="inline-flex items-center gap-0.5 rounded-md bg-surface-container/60 p-0.5"
+    className="vf-app-no-drag inline-flex items-center gap-0.5 rounded-md bg-surface-container/60 p-0.5"
   >
     {Object.values(LAYOUTS).map((layout) => {
       const isActive = activeLayoutId === layout.id

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -170,12 +170,14 @@ const capturedAgentStatusPanelProps: {
   onOpenFile?: (path: string) => void
   onOpenDiff?: unknown
   agentStatus?: AgentStatus
+  reserveWindowControls?: boolean
 } = {}
 
 interface MockAgentStatusPanelProps {
   onOpenFile?: (path: string) => void
   onOpenDiff?: unknown
   agentStatus?: AgentStatus
+  reserveWindowControls?: boolean
 }
 
 vi.mock('../agent-status/components/AgentStatusPanel', () => ({
@@ -183,10 +185,12 @@ vi.mock('../agent-status/components/AgentStatusPanel', () => ({
     onOpenFile = undefined,
     onOpenDiff = undefined,
     agentStatus = undefined,
+    reserveWindowControls = undefined,
   }: MockAgentStatusPanelProps): ReactElement => {
     capturedAgentStatusPanelProps.onOpenFile = onOpenFile
     capturedAgentStatusPanelProps.onOpenDiff = onOpenDiff
     capturedAgentStatusPanelProps.agentStatus = agentStatus
+    capturedAgentStatusPanelProps.reserveWindowControls = reserveWindowControls
 
     // Render the panel testid so the existing zone-presence tests
     // (`getByTestId('agent-status-panel')`) keep passing without
@@ -271,6 +275,7 @@ describe('WorkspaceView', () => {
     capturedAgentStatusPanelProps.onOpenFile = undefined
     capturedAgentStatusPanelProps.onOpenDiff = undefined
     capturedAgentStatusPanelProps.agentStatus = undefined
+    capturedAgentStatusPanelProps.reserveWindowControls = undefined
     workspaceTerminalMock.service.spawn.mockResolvedValue({
       sessionId: 'new-id',
       pid: 999,
@@ -355,13 +360,9 @@ describe('WorkspaceView', () => {
     expect(screen.getByTestId('sidebar-top-bar-right-drag-region')).toHaveClass(
       'vf-app-drag-region'
     )
-  })
 
-  // The main-stage chrome removes the session-tab strip, which previously
-  // carried the macOS window-drag regions. Per the merge decision we keep
-  // main's SidebarTopBar drag region (covered by SidebarTopBar.test) and do
-  // not re-home the drag region onto the auto-hide top chrome, so the old
-  // "collapsed macOS tab chrome" test no longer applies.
+    expect(capturedAgentStatusPanelProps.reserveWindowControls).toBe(true)
+  })
 
   test('uses a single-column workspace with a dismissible inert sidebar drawer on compact viewports', async () => {
     const restoreMatchMedia = mockMatchMedia(true)

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -186,6 +186,10 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
   }
 
   beforeEach(async () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: '',
+      configurable: true,
+    })
     vi.clearAllMocks()
     act(() => {
       setSidebarCollapsed(false)

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -321,6 +321,86 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     expect(chromeClasses).not.toContain('absolute')
   })
 
+  test('macOS top chrome is draggable with the layout pillar cut out', () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    })
+
+    render(<WorkspaceView />)
+
+    expect(screen.getByTestId('top-chrome')).toHaveClass('vf-app-drag-region')
+
+    expect(screen.getByTestId('layout-switcher')).toHaveClass('vf-app-no-drag')
+
+    expect(screen.getByTestId('sidebar-toggle-fixed')).toHaveClass(
+      'vf-app-no-drag'
+    )
+  })
+
+  test('macOS collapsed activity rail keeps only its expand control clickable', async () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    })
+
+    await setupSessionManager(
+      [
+        {
+          ...mockSessions[0],
+          activityPanelCollapsed: true,
+        },
+      ],
+      'session-1'
+    )
+
+    render(<WorkspaceView />)
+
+    expect(screen.getByTestId('top-chrome')).toHaveClass('vf-app-drag-region')
+
+    expect(screen.getByTestId('layout-switcher')).toHaveClass('vf-app-no-drag')
+
+    expect(screen.getByTestId('agent-status-rail')).toHaveClass(
+      'vf-app-drag-region'
+    )
+
+    expect(
+      screen.getByRole('button', { name: /expand activity panel/i })
+    ).toHaveClass('vf-app-no-drag')
+  })
+
+  test('macOS collapsed left-sidebar toggle is cut out of the draggable top chrome', () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    })
+
+    render(<WorkspaceView />)
+
+    expect(
+      screen.queryByTestId('top-chrome-sidebar-toggle-clearance')
+    ).toBeNull()
+
+    act(() => {
+      setSidebarCollapsed(true)
+    })
+
+    expect(screen.getByTestId('top-chrome')).toHaveClass('vf-app-drag-region')
+    expect(screen.getByTestId('sidebar-toggle-fixed-shell')).toHaveClass(
+      'vf-app-no-drag'
+    )
+
+    const clearance = screen.getByTestId('top-chrome-sidebar-toggle-clearance')
+    expect(clearance).toHaveClass('vf-app-no-drag')
+    expect(clearance).toHaveClass('pointer-events-none')
+    expect(clearance).toHaveStyle({
+      left: '82px',
+      top: '7px',
+      width: '28px',
+      height: '28px',
+    })
+  })
+
   test('split layout: label-free pills right-aligned; config docked in the pillar (J3)', async () => {
     await setupSessionManager(mockSessions, 'session-2')
     render(<WorkspaceView />)
@@ -408,8 +488,10 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
 
     // Open: a single toggle, anchored to the workspace root — NOT inside the
     // chrome, and there is no separate in-shell anchor element anymore.
+    const toggleShell = screen.getByTestId('sidebar-toggle-fixed-shell')
     const toggleOpen = screen.getByTestId('sidebar-toggle-fixed')
     expect(toggleOpen).toBeInTheDocument()
+    expect(toggleShell).toHaveClass('vf-app-no-drag')
     expect(chrome).not.toContainElement(toggleOpen)
     expect(screen.queryByTestId('sidebar-toggle-anchor')).toBeNull()
 
@@ -422,6 +504,7 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     // shell and main columns animate.
     const toggleCollapsed = screen.getByTestId('sidebar-toggle-fixed')
     expect(toggleCollapsed).toBe(toggleOpen)
+    expect(toggleShell).toHaveClass('vf-app-no-drag')
     expect(chrome).not.toContainElement(toggleCollapsed)
 
     act(() => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1936,7 +1936,8 @@ export const WorkspaceView = (): ReactElement => {
           the sidebar and main surfaces so focus order matches its visual
           position; z-40 keeps it on top. */}
       <div
-        className="absolute z-40"
+        data-testid="sidebar-toggle-fixed-shell"
+        className="vf-app-no-drag absolute z-40"
         style={{ left: sidebarToggleLeft, top: SIDEBAR_TOGGLE_TOP }}
       >
         <SidebarToggle
@@ -2127,8 +2128,23 @@ export const WorkspaceView = (): ReactElement => {
             frosted-glass treatment now lives in <GlassSurface>. */}
         <div
           data-testid="top-chrome"
-          className="relative flex h-[44px] shrink-0 items-center gap-[12px] border-b border-outline-variant/25 bg-surface pl-[14px] pr-[14px]"
+          className={`relative flex h-[44px] shrink-0 items-center gap-[12px] border-b border-outline-variant/25 bg-surface pl-[14px] pr-[14px] ${
+            reserveWindowControls ? 'vf-app-drag-region' : ''
+          }`}
         >
+          {reserveWindowControls && isSidebarClosed && (
+            <span
+              aria-hidden="true"
+              data-testid="top-chrome-sidebar-toggle-clearance"
+              className="vf-app-no-drag pointer-events-none absolute"
+              style={{
+                left: sidebarToggleLeft,
+                top: SIDEBAR_TOGGLE_TOP,
+                width: SIDEBAR_TOGGLE_SIZE,
+                height: SIDEBAR_TOGGLE_SIZE,
+              }}
+            />
+          )}
           <span className="min-w-[10px] flex-1" />
 
           {/* Pills render in every layout, with the layout-display config
@@ -2298,6 +2314,7 @@ export const WorkspaceView = (): ReactElement => {
               onExpand={() => {
                 handleActivityPanelCollapsed(false)
               }}
+              reserveWindowControls={reserveWindowControls}
             />
           ) : (
             <AgentStatusPanel
@@ -2312,6 +2329,7 @@ export const WorkspaceView = (): ReactElement => {
               onCollapse={() => {
                 handleActivityPanelCollapsed(true)
               }}
+              reserveWindowControls={reserveWindowControls}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary

- Add macOS drag coverage to the persistent top chrome and the right activity panel header/rail.
- Keep layout switcher, left sidebar toggle, and right activity collapse/expand controls clickable with explicit `vf-app-no-drag` cutouts.
- Add regression coverage for expanded/collapsed sidebar and activity-panel states.

## Root Cause

The main top chrome became the persistent first row, but drag-region coverage still only existed reliably in the expanded sidebar chrome. Adding `-webkit-app-region: drag` to the top row also required cutouts inside the same draggable region; a sibling overlay around the collapsed sidebar toggle was not enough for Electron hit testing.

## Validation

- Live Electron dev window: collapsed the sidebar with `Cmd+B`, clicked the visible `Show sidebar` toggle, and verified it reopened.
- `npx vitest run --silent --reporter=dot src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx src/features/agent-status/components/AgentStatusPanel/Header.test.tsx src/features/agent-status/components/AgentStatusRail.test.tsx src/features/workspace/WorkspaceView.top-chrome.test.tsx src/features/workspace/WorkspaceView.test.tsx`
- `npx eslint src/features/workspace/WorkspaceView.tsx src/features/workspace/WorkspaceView.top-chrome.test.tsx`
- `npx prettier --check src/features/workspace/WorkspaceView.tsx src/features/workspace/WorkspaceView.top-chrome.test.tsx`
- `npm run type-check:generated`
- Pre-push hook: `npm test` (`286` files passed, `3700` tests passed, `3` skipped).