### PR TITLE
feat(agent-status): add VIM-127 visible pane hot loading (PR3)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                                                              | Category           | Findings | Refs | Last Updated |
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 22       | 4    | 2026-06-13   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 35       | 15   | 2026-06-15   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 38       | 15   | 2026-06-15   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |
@@ -53,7 +53,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 8        | 6    | 2026-06-13   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
-| [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
+| [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 2        | 0    | 2026-06-15   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 64       | 30   | 2026-06-12   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
@@ -88,4 +88,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
-| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 1        | 0    | 2026-06-13   |
+| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 2        | 0    | 2026-06-15   |

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -25,6 +25,7 @@ code and should be removed.
 - **Finding:** All entries in `contextMenuActions` carried explicit `id` fields, so the early `return action.id` made the subsequent `switch (action.label)` block unreachable. The dead code risked misleading maintainers into thinking new actions could rely on label matching.
 - **Fix:** Removed the unreachable `switch` fallback; `actionIdFor` now returns `action.id ?? null` directly.
 - **Commit:** see `git blame` / `git log` on this line
+
 ### 2. `clearAgentStatusRefreshCoordinator` exported but never called
 
 - **Source:** github-claude | PR #459 round 1 | 2026-06-15

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -2,7 +2,7 @@
 id: dead-code
 category: code-quality
 created: 2026-06-13
-last_updated: 2026-06-13
+last_updated: 2026-06-15
 ref_count: 0
 ---
 
@@ -25,3 +25,11 @@ code and should be removed.
 - **Finding:** All entries in `contextMenuActions` carried explicit `id` fields, so the early `return action.id` made the subsequent `switch (action.label)` block unreachable. The dead code risked misleading maintainers into thinking new actions could rely on label matching.
 - **Fix:** Removed the unreachable `switch` fallback; `actionIdFor` now returns `action.id ?? null` directly.
 - **Commit:** see `git blame` / `git log` on this line
+### 2. `clearAgentStatusRefreshCoordinator` exported but never called
+
+- **Source:** github-claude | PR #459 round 1 | 2026-06-15
+- **Severity:** LOW
+- **File:** `src/features/agent-status/utils/statusRefreshCoordinator.ts`
+- **Finding:** `clearAgentStatusRefreshCoordinator` was exported from the singleton module but had no call sites. Without a comment, a future refactor would likely delete it.
+- **Fix:** Added a comment documenting that the export is intentionally reserved for PR4 lifecycle hooks (session close / workspace teardown) and should not be wired to a `useEffect` cleanup today.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/hot-path-caching.md
+++ b/docs/reviews/patterns/hot-path-caching.md
@@ -31,6 +31,7 @@ feature.
 - **Finding:** `latest_account_rate_limits` called `discover_db(&self.codex_home, "logs")` on every invocation. `discover_db` does `std::fs::read_dir(codex_home)`, then opens a read-only SQLite connection for each `.sqlite` file and queries `sqlite_master` to check if the target table exists. Over a busy session this accumulates repeated directory reads and SQLite open/close cycles for every decoded status event.
 - **Fix:** Added a `logs_db_cache: std::sync::OnceLock<PathBuf>` field to `CompositeLocator`. `latest_account_rate_limits` checks the cache first; on a miss it runs `discover_db`, stores the result only on success, and retries on subsequent calls if the earlier discovery returned `None`. This eliminates repeated filesystem I/O without changing per-call read-query behavior.
 - **Commit:** same commit as this entry
+
 ### 2. Stale active snapshot returned when detection returns null
 
 - **Source:** github-codex-connector (P2) | PR #459 round 1 | 2026-06-15

--- a/docs/reviews/patterns/hot-path-caching.md
+++ b/docs/reviews/patterns/hot-path-caching.md
@@ -2,7 +2,7 @@
 id: hot-path-caching
 category: backend
 created: 2026-06-09
-last_updated: 2026-06-09
+last_updated: 2026-06-15
 ref_count: 0
 ---
 
@@ -31,3 +31,11 @@ feature.
 - **Finding:** `latest_account_rate_limits` called `discover_db(&self.codex_home, "logs")` on every invocation. `discover_db` does `std::fs::read_dir(codex_home)`, then opens a read-only SQLite connection for each `.sqlite` file and queries `sqlite_master` to check if the target table exists. Over a busy session this accumulates repeated directory reads and SQLite open/close cycles for every decoded status event.
 - **Fix:** Added a `logs_db_cache: std::sync::OnceLock<PathBuf>` field to `CompositeLocator`. `latest_account_rate_limits` checks the cache first; on a miss it runs `discover_db`, stores the result only on success, and retries on subsequent calls if the earlier discovery returned `None`. This eliminates repeated filesystem I/O without changing per-call read-query behavior.
 - **Commit:** same commit as this entry
+### 2. Stale active snapshot returned when detection returns null
+
+- **Source:** github-codex-connector (P2) | PR #459 round 1 | 2026-06-15
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/agent-status/utils/statusRefreshCoordinator.ts`
+- **Finding:** When `detect_agent_in_session` returned `null` for a pane with a cached active snapshot, the coordinator returned the stale snapshot unchanged. Switching back to that pane restored `isActive: true` until the primary polling hook caught up.
+- **Fix:** Changed the null-detection branch to write a default (inactive) snapshot instead of returning the previous one, so hot-loaded panes never display a dead agent as active.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -329,6 +329,7 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** The functional updater for tool-call completion state mutated `seenToolUseIdsRef` before computing the new state. Under React StrictMode the updater can run twice, so the second invocation saw the ID as already seen and dropped the completed tool call from counts and the recent-calls list.
 - **Fix:** Same change as entry 31: computed the duplicate decision and persisted the seen set outside the updater, keeping the updater pure and StrictMode-safe.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
 ### 33. Fragile `\n` separator in effect dependency signature
 
 - **Source:** github-claude | PR #459 round 1 | 2026-06-15

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -329,3 +329,29 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** The functional updater for tool-call completion state mutated `seenToolUseIdsRef` before computing the new state. Under React StrictMode the updater can run twice, so the second invocation saw the ID as already seen and dropped the completed tool call from counts and the recent-calls list.
 - **Fix:** Same change as entry 31: computed the duplicate decision and persisted the seen set outside the updater, keeping the updater pure and StrictMode-safe.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+### 33. Fragile `\n` separator in effect dependency signature
+
+- **Source:** github-claude | PR #459 round 1 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/hooks/useAgentStatusHotLoading.ts`
+- **Finding:** `plannedPtyIds.join('\n')` and `.split('\n')` assumed PTY IDs never contain newlines. A future backend ID containing `\n` would split into phantom tokens and refresh wrong panes.
+- **Fix:** Replaced the join/split signature with `JSON.stringify({ activePtyId, visiblePtyIds })` and parsed it inside the effect. JSON escapes any special characters, making the dependency string robust.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 34. Hook pre-plans then coordinator re-plans
+
+- **Source:** github-claude | PR #459 round 1 | 2026-06-15
+- **Severity:** LOW
+- **File:** `src/features/agent-status/hooks/useAgentStatusHotLoading.ts`
+- **Finding:** The hook called `planVisibleStatusRefreshes` to build a stable effect dep, then passed the planned IDs to `refreshVisibleAgentStatusPanes`, which called the same planner again. The double-planning is idempotent today but creates silent coupling if the algorithm evolves.
+- **Fix:** Removed the hook's pre-planning; it now serializes the raw `{ activePtyId, visiblePtyIds }` request as the effect dep and lets the coordinator do all planning internally.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 35. Hot-loading scope should match SplitView visibility
+
+- **Source:** github-codex-connector (P2) | PR #459 round 1 | 2026-06-15
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** `visibleAgentStatusPtyIds` was derived from every shell pane in the active session, so hidden panes (e.g., after shrinking to `single`/`vsplit`) still received prefetches and warm snapshots. The background-work boundary diverged from the UI visibility boundary.
+- **Fix:** Replaced the all-panes filter with `selectVisiblePanes(session.panes, LAYOUTS[session.layout].capacity)` so hot-loading targets exactly the panes rendered by `SplitView`.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/superpowers/specs/2026-06-14-activity-panel-hot-reload/pr-3-prefetch-hotload.md
+++ b/docs/superpowers/specs/2026-06-14-activity-panel-hot-reload/pr-3-prefetch-hotload.md
@@ -1,6 +1,6 @@
 # PR3 — Visible-Pane Hot Loading And Prefetch
 
-**Status:** draft
+**Status:** implemented in PR3
 **Scope:** bounded refresh orchestration
 **Depends on:** PR2
 
@@ -16,6 +16,22 @@ Warm the status snapshots for panes the user is likely to switch to next without
 - Deduplicate concurrent refreshes for the same pane.
 - Track request generation or abort signals so late responses from older pane selections are ignored.
 - Keep hidden sessions and non-visible historical panes out of prefetch for v1.
+
+## PR3 Implementation Notes
+
+- Added `statusRefreshCoordinator` as the small refresh coordinator API.
+- The coordinator runs bounded `detect_agent_in_session` refreshes and writes
+  pane-keyed warm snapshots; it does not replace the existing active
+  `useAgentStatus` live event subscription.
+- Active pane refresh is planned first, then visible sibling shell panes.
+- Refreshes are capped at four visible PTY-backed panes, matching the current
+  split layout ceiling.
+- In-flight refreshes for the same pane coalesce.
+- Late responses are applied only if the pane is still in the current visible
+  set, so old active-pane responses cannot warm hidden sessions.
+- Detection refreshes preserve existing rich snapshot fields such as context,
+  cost, tool calls, and tests; they only update the minimal active/detected
+  identity fields.
 
 ## Interface Guidance
 

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -7,6 +7,10 @@ import {
   writeStatusSeenToolUseIds,
   writeStatusSnapshot,
 } from '../utils/statusSnapshotStore'
+import {
+  createDefaultAgentStatus,
+  mapDetectedAgentType,
+} from '../utils/agentStatusModel'
 import type {
   AgentCwdEvent,
   AgentDetectedEvent,
@@ -25,43 +29,12 @@ const RECENT_TOOL_CALLS_LIMIT = 50
 const DETECTION_POLL_MS = 500
 const EXIT_HOLD_MS = 5000
 
-const AGENT_TYPE_MAP = {
-  claudeCode: 'claude-code',
-  codex: 'codex',
-  aider: 'aider',
-  generic: 'generic',
-} as const
-
-const isKnownAgentType = (
-  value: string
-): value is keyof typeof AGENT_TYPE_MAP =>
-  Object.prototype.hasOwnProperty.call(AGENT_TYPE_MAP, value)
-
-const createDefaultStatus = (sessionId: string | null): AgentStatus => ({
-  isActive: false,
-  agentExited: false,
-  agentType: null,
-  modelId: null,
-  modelDisplayName: null,
-  version: null,
-  sessionId,
-  agentSessionId: null,
-  cwd: null,
-  contextWindow: null,
-  cost: null,
-  rateLimits: null,
-  numTurns: 0,
-  toolCalls: { total: 0, byType: {}, active: null },
-  recentToolCalls: [],
-  testRun: null,
-})
-
 const createStatusForSession = (sessionId: string | null): AgentStatus => {
   if (sessionId === null) {
-    return createDefaultStatus(null)
+    return createDefaultAgentStatus(null)
   }
 
-  return readStatusSnapshot(sessionId) ?? createDefaultStatus(sessionId)
+  return readStatusSnapshot(sessionId) ?? createDefaultAgentStatus(sessionId)
 }
 
 const shouldTreatStatusAsDetected = (status: AgentStatus): boolean =>
@@ -260,12 +233,6 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
           collapseTimeoutRef.current = null
         }
 
-        const agentKey = result.agentType as string
-
-        const mapped = isKnownAgentType(agentKey)
-          ? AGENT_TYPE_MAP[agentKey]
-          : 'generic'
-
         const detectedPid = result.pid
 
         const agentProcessChanged =
@@ -292,10 +259,10 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
         setStatus((prev) =>
           prev.sessionId === sid
             ? {
-                ...(agentProcessChanged ? createDefaultStatus(sid) : prev),
+                ...(agentProcessChanged ? createDefaultAgentStatus(sid) : prev),
                 isActive: true,
                 agentExited: false,
-                agentType: mapped,
+                agentType: mapDetectedAgentType(result.agentType as string),
               }
             : prev
         )
@@ -398,7 +365,7 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
         collapseTimeoutRef.current = setTimeout(() => {
           collapseTimeoutRef.current = null
           setStatus((prev) =>
-            prev.sessionId === sid ? createDefaultStatus(sid) : prev
+            prev.sessionId === sid ? createDefaultAgentStatus(sid) : prev
           )
         }, EXIT_HOLD_MS)
       }
@@ -483,7 +450,7 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
 
             const base = agentSessionChanged
               ? {
-                  ...createDefaultStatus(prev.sessionId),
+                  ...createDefaultAgentStatus(prev.sessionId),
                   isActive: prev.isActive,
                   agentExited: prev.agentExited,
                   agentType: prev.agentType,

--- a/src/features/agent-status/hooks/useAgentStatusHotLoading.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatusHotLoading.test.ts
@@ -30,7 +30,7 @@ describe('useAgentStatusHotLoading', () => {
     expect(refreshVisibleAgentStatusPanes).not.toHaveBeenCalled()
   })
 
-  test('refreshes active pane before deduplicated visible siblings', async () => {
+  test('refreshes visible panes through the coordinator', async () => {
     renderHook(() =>
       useAgentStatusHotLoading({
         activePtyId: 'pty-b',
@@ -41,7 +41,7 @@ describe('useAgentStatusHotLoading', () => {
     await waitFor(() => {
       expect(refreshVisibleAgentStatusPanes).toHaveBeenCalledWith({
         activePtyId: 'pty-b',
-        visiblePtyIds: ['pty-b', 'pty-a'],
+        visiblePtyIds: ['pty-a', 'pty-b', 'pty-a'],
       })
     })
   })

--- a/src/features/agent-status/hooks/useAgentStatusHotLoading.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatusHotLoading.test.ts
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { refreshVisibleAgentStatusPanes } from '../utils/statusRefreshCoordinator'
+import { useAgentStatusHotLoading } from './useAgentStatusHotLoading'
+
+vi.mock('../utils/statusRefreshCoordinator', async () => {
+  const actual = await vi.importActual<
+    typeof import('../utils/statusRefreshCoordinator')
+  >('../utils/statusRefreshCoordinator')
+
+  return {
+    ...actual,
+    refreshVisibleAgentStatusPanes: vi.fn().mockResolvedValue([]),
+  }
+})
+
+describe('useAgentStatusHotLoading', () => {
+  beforeEach(() => {
+    vi.mocked(refreshVisibleAgentStatusPanes).mockClear()
+  })
+
+  test('does not refresh when no visible panes are available', () => {
+    renderHook(() =>
+      useAgentStatusHotLoading({
+        activePtyId: null,
+        visiblePtyIds: [],
+      })
+    )
+
+    expect(refreshVisibleAgentStatusPanes).not.toHaveBeenCalled()
+  })
+
+  test('refreshes active pane before deduplicated visible siblings', async () => {
+    renderHook(() =>
+      useAgentStatusHotLoading({
+        activePtyId: 'pty-b',
+        visiblePtyIds: ['pty-a', 'pty-b', 'pty-a'],
+      })
+    )
+
+    await waitFor(() => {
+      expect(refreshVisibleAgentStatusPanes).toHaveBeenCalledWith({
+        activePtyId: 'pty-b',
+        visiblePtyIds: ['pty-b', 'pty-a'],
+      })
+    })
+  })
+})

--- a/src/features/agent-status/hooks/useAgentStatusHotLoading.ts
+++ b/src/features/agent-status/hooks/useAgentStatusHotLoading.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import {
-  planVisibleStatusRefreshes,
   refreshVisibleAgentStatusPanes,
+  type VisibleStatusRefreshRequest,
 } from '../utils/statusRefreshCoordinator'
 
 interface UseAgentStatusHotLoadingOptions {
@@ -13,26 +13,18 @@ export const useAgentStatusHotLoading = ({
   activePtyId,
   visiblePtyIds,
 }: UseAgentStatusHotLoadingOptions): void => {
-  const plannedPtyIds = useMemo(
-    () => planVisibleStatusRefreshes({ activePtyId, visiblePtyIds }),
+  const refreshSignature = useMemo(
+    () => JSON.stringify({ activePtyId, visiblePtyIds }),
     [activePtyId, visiblePtyIds]
   )
 
-  const plannedPtyIdSignature = plannedPtyIds.join('\n')
-
   useEffect(() => {
-    const nextVisiblePtyIds =
-      plannedPtyIdSignature.length === 0
-        ? []
-        : plannedPtyIdSignature.split('\n')
+    const request = JSON.parse(refreshSignature) as VisibleStatusRefreshRequest
 
-    if (nextVisiblePtyIds.length === 0) {
+    if (request.visiblePtyIds.length === 0) {
       return
     }
 
-    void refreshVisibleAgentStatusPanes({
-      activePtyId,
-      visiblePtyIds: nextVisiblePtyIds,
-    })
-  }, [activePtyId, plannedPtyIdSignature])
+    void refreshVisibleAgentStatusPanes(request)
+  }, [refreshSignature])
 }

--- a/src/features/agent-status/hooks/useAgentStatusHotLoading.ts
+++ b/src/features/agent-status/hooks/useAgentStatusHotLoading.ts
@@ -1,0 +1,38 @@
+import { useEffect, useMemo } from 'react'
+import {
+  planVisibleStatusRefreshes,
+  refreshVisibleAgentStatusPanes,
+} from '../utils/statusRefreshCoordinator'
+
+interface UseAgentStatusHotLoadingOptions {
+  activePtyId: string | null
+  visiblePtyIds: readonly string[]
+}
+
+export const useAgentStatusHotLoading = ({
+  activePtyId,
+  visiblePtyIds,
+}: UseAgentStatusHotLoadingOptions): void => {
+  const plannedPtyIds = useMemo(
+    () => planVisibleStatusRefreshes({ activePtyId, visiblePtyIds }),
+    [activePtyId, visiblePtyIds]
+  )
+
+  const plannedPtyIdSignature = plannedPtyIds.join('\n')
+
+  useEffect(() => {
+    const nextVisiblePtyIds =
+      plannedPtyIdSignature.length === 0
+        ? []
+        : plannedPtyIdSignature.split('\n')
+
+    if (nextVisiblePtyIds.length === 0) {
+      return
+    }
+
+    void refreshVisibleAgentStatusPanes({
+      activePtyId,
+      visiblePtyIds: nextVisiblePtyIds,
+    })
+  }, [activePtyId, plannedPtyIdSignature])
+}

--- a/src/features/agent-status/utils/agentStatusModel.test.ts
+++ b/src/features/agent-status/utils/agentStatusModel.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import {
+  createDefaultAgentStatus,
+  mapDetectedAgentType,
+} from './agentStatusModel'
+
+describe('agentStatusModel', () => {
+  test('maps backend agent type keys to UI agent types', () => {
+    expect(mapDetectedAgentType('claudeCode')).toBe('claude-code')
+    expect(mapDetectedAgentType('codex')).toBe('codex')
+    expect(mapDetectedAgentType('aider')).toBe('aider')
+    expect(mapDetectedAgentType('unknown')).toBe('generic')
+  })
+
+  test('creates a default status snapshot with null test-run state', () => {
+    expect(createDefaultAgentStatus('pty-a')).toMatchObject({
+      sessionId: 'pty-a',
+      isActive: false,
+      agentExited: false,
+      agentType: null,
+      numTurns: 0,
+      toolCalls: { total: 0, byType: {}, active: null },
+      recentToolCalls: [],
+      testRun: null,
+    })
+  })
+})

--- a/src/features/agent-status/utils/agentStatusModel.ts
+++ b/src/features/agent-status/utils/agentStatusModel.ts
@@ -1,0 +1,39 @@
+import type { AgentStatus } from '../types'
+
+const AGENT_TYPE_MAP = {
+  claudeCode: 'claude-code',
+  codex: 'codex',
+  aider: 'aider',
+  generic: 'generic',
+} as const
+
+const isKnownAgentType = (
+  value: string
+): value is keyof typeof AGENT_TYPE_MAP =>
+  Object.prototype.hasOwnProperty.call(AGENT_TYPE_MAP, value)
+
+export const mapDetectedAgentType = (
+  value: string
+): NonNullable<AgentStatus['agentType']> =>
+  isKnownAgentType(value) ? AGENT_TYPE_MAP[value] : 'generic'
+
+export const createDefaultAgentStatus = (
+  sessionId: string | null
+): AgentStatus => ({
+  isActive: false,
+  agentExited: false,
+  agentType: null,
+  modelId: null,
+  modelDisplayName: null,
+  version: null,
+  sessionId,
+  agentSessionId: null,
+  cwd: null,
+  contextWindow: null,
+  cost: null,
+  rateLimits: null,
+  numTurns: 0,
+  toolCalls: { total: 0, byType: {}, active: null },
+  recentToolCalls: [],
+  testRun: null,
+})

--- a/src/features/agent-status/utils/statusRefreshCoordinator.test.ts
+++ b/src/features/agent-status/utils/statusRefreshCoordinator.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test, vi } from 'vitest'
+import type { AgentDetectedEvent, AgentStatus } from '../types'
+import { createDefaultAgentStatus } from './agentStatusModel'
+import {
+  createAgentStatusRefreshCoordinator,
+  MAX_VISIBLE_STATUS_REFRESH_PANES,
+  planVisibleStatusRefreshes,
+} from './statusRefreshCoordinator'
+
+const createDetectedEvent = (
+  ptyId: string,
+  agentType: AgentDetectedEvent['agentType'] = 'claudeCode'
+): AgentDetectedEvent => ({
+  sessionId: ptyId,
+  agentType,
+  pid: 123,
+})
+
+const createDeferred = <Value>(): {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+} => {
+  let resolvePromise: ((value: Value) => void) | undefined
+
+  const promise = new Promise<Value>((resolve) => {
+    resolvePromise = resolve
+  })
+
+  return {
+    promise,
+    resolve: (value): void => {
+      resolvePromise?.(value)
+    },
+  }
+}
+
+describe('statusRefreshCoordinator', () => {
+  test('plans the active pane before visible sibling prefetch', () => {
+    expect(
+      planVisibleStatusRefreshes({
+        activePtyId: 'pty-b',
+        visiblePtyIds: ['pty-a', 'pty-b', 'pty-c'],
+      })
+    ).toEqual(['pty-b', 'pty-a', 'pty-c'])
+  })
+
+  test('deduplicates visible panes and applies the explicit pane limit', () => {
+    expect(
+      planVisibleStatusRefreshes({
+        activePtyId: 'pty-3',
+        visiblePtyIds: ['pty-1', 'pty-2', 'pty-2', 'pty-3', 'pty-4', 'pty-5'],
+      })
+    ).toEqual(['pty-3', 'pty-1', 'pty-2', 'pty-4'])
+
+    expect(MAX_VISIBLE_STATUS_REFRESH_PANES).toBe(4)
+  })
+
+  test('prefetches visible siblings once and leaves hidden panes untouched', async () => {
+    const detectAgent = vi.fn((ptyId: string) =>
+      Promise.resolve(createDetectedEvent(ptyId))
+    )
+
+    const writeStatus = vi.fn((_ptyId: string, status: AgentStatus) => ({
+      status,
+      scrollTop: 0,
+      updatedAt: 100,
+    }))
+
+    const coordinator = createAgentStatusRefreshCoordinator({
+      detectAgent,
+      writeStatus,
+    })
+
+    await coordinator.refreshVisiblePanes({
+      activePtyId: 'pty-active',
+      visiblePtyIds: ['pty-active', 'pty-sibling', 'pty-sibling'],
+    })
+
+    expect(detectAgent).toHaveBeenCalledTimes(2)
+    expect(detectAgent).toHaveBeenNthCalledWith(1, 'pty-active')
+    expect(detectAgent).toHaveBeenNthCalledWith(2, 'pty-sibling')
+    expect(detectAgent).not.toHaveBeenCalledWith('pty-hidden')
+    expect(writeStatus).toHaveBeenCalledTimes(2)
+  })
+
+  test('coalesces duplicate requests for the same pane while in flight', async () => {
+    const deferred = createDeferred<AgentDetectedEvent | null>()
+    const detectAgent = vi.fn(() => deferred.promise)
+    const coordinator = createAgentStatusRefreshCoordinator({ detectAgent })
+
+    void coordinator.refreshVisiblePanes({
+      activePtyId: 'pty-a',
+      visiblePtyIds: ['pty-a'],
+    })
+
+    const first = coordinator.refreshPane('pty-a')
+    const second = coordinator.refreshPane('pty-a')
+
+    expect(first).toBe(second)
+    expect(detectAgent).toHaveBeenCalledTimes(1)
+
+    deferred.resolve(createDetectedEvent('pty-a'))
+
+    await expect(first).resolves.toMatchObject({
+      sessionId: 'pty-a',
+      agentType: 'claude-code',
+      isActive: true,
+    })
+  })
+
+  test('drops stale responses for panes outside the current visible set', async () => {
+    const requests = new Map<
+      string,
+      ReturnType<typeof createDeferred<AgentDetectedEvent | null>>
+    >()
+    const writes: string[] = []
+
+    const coordinator = createAgentStatusRefreshCoordinator({
+      detectAgent: (ptyId) => {
+        const deferred = createDeferred<AgentDetectedEvent | null>()
+        requests.set(ptyId, deferred)
+
+        return deferred.promise
+      },
+      writeStatus: (ptyId, status) => {
+        writes.push(ptyId)
+
+        return {
+          status,
+          scrollTop: 0,
+          updatedAt: writes.length,
+        }
+      },
+    })
+
+    const oldRefresh = coordinator.refreshVisiblePanes({
+      activePtyId: 'pty-old',
+      visiblePtyIds: ['pty-old'],
+    })
+
+    const currentRefresh = coordinator.refreshVisiblePanes({
+      activePtyId: 'pty-current',
+      visiblePtyIds: ['pty-current'],
+    })
+
+    requests.get('pty-current')?.resolve(createDetectedEvent('pty-current'))
+    requests.get('pty-old')?.resolve(createDetectedEvent('pty-old'))
+
+    await Promise.all([oldRefresh, currentRefresh])
+
+    expect(writes).toEqual(['pty-current'])
+  })
+
+  test('preserves rich snapshot fields when detection warms an existing pane', async () => {
+    const richStatus: AgentStatus = {
+      ...createDefaultAgentStatus('pty-a'),
+      contextWindow: {
+        usedPercentage: 42,
+        contextWindowSize: 200000,
+        totalInputTokens: 1000,
+        totalOutputTokens: 200,
+        currentUsage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          cacheCreationInputTokens: 4,
+          cacheReadInputTokens: 80,
+        },
+      },
+      toolCalls: { total: 7, byType: { Read: 7 }, active: null },
+    }
+
+    let storedStatus = richStatus
+
+    const coordinator = createAgentStatusRefreshCoordinator({
+      detectAgent: () => Promise.resolve(createDetectedEvent('pty-a', 'codex')),
+      readStatus: () => storedStatus,
+      writeStatus: (_ptyId, status) => {
+        storedStatus = status
+
+        return {
+          status,
+          scrollTop: 0,
+          updatedAt: 1,
+        }
+      },
+    })
+
+    await coordinator.refreshVisiblePanes({
+      activePtyId: 'pty-a',
+      visiblePtyIds: ['pty-a'],
+    })
+
+    expect(storedStatus).toMatchObject({
+      sessionId: 'pty-a',
+      agentType: 'codex',
+      isActive: true,
+      contextWindow: richStatus.contextWindow,
+      toolCalls: richStatus.toolCalls,
+    })
+  })
+})

--- a/src/features/agent-status/utils/statusRefreshCoordinator.test.ts
+++ b/src/features/agent-status/utils/statusRefreshCoordinator.test.ts
@@ -198,4 +198,39 @@ describe('statusRefreshCoordinator', () => {
       toolCalls: richStatus.toolCalls,
     })
   })
+
+  test('writes a default snapshot when detection returns null for a previously active pane', async () => {
+    const previousStatus: AgentStatus = {
+      ...createDefaultAgentStatus('pty-a'),
+      isActive: true,
+      agentType: 'claude-code',
+    }
+
+    const writeStatus = vi.fn((_ptyId: string, status: AgentStatus) => ({
+      status,
+      scrollTop: 0,
+      updatedAt: 1,
+    }))
+
+    const coordinator = createAgentStatusRefreshCoordinator({
+      detectAgent: () => Promise.resolve(null),
+      readStatus: () => previousStatus,
+      writeStatus,
+    })
+
+    await coordinator.refreshVisiblePanes({
+      activePtyId: 'pty-a',
+      visiblePtyIds: ['pty-a'],
+    })
+
+    expect(writeStatus).toHaveBeenCalledTimes(1)
+    expect(writeStatus).toHaveBeenCalledWith(
+      'pty-a',
+      expect.objectContaining({
+        sessionId: 'pty-a',
+        isActive: false,
+        agentType: null,
+      })
+    )
+  })
 })

--- a/src/features/agent-status/utils/statusRefreshCoordinator.ts
+++ b/src/features/agent-status/utils/statusRefreshCoordinator.ts
@@ -107,10 +107,6 @@ export const createAgentStatusRefreshCoordinator = ({
       const previous = readStatus(ptyId)
 
       if (detected === null) {
-        if (previous !== null) {
-          return previous
-        }
-
         return writeStatus(ptyId, createDefaultAgentStatus(ptyId)).status
       }
 
@@ -177,6 +173,10 @@ export const refreshVisibleAgentStatusPanes = (
 ): Promise<AgentStatus[]> =>
   agentStatusRefreshCoordinator.refreshVisiblePanes(request)
 
+// Intentionally reserved for PR4 lifecycle hooks (session close / workspace
+// teardown). Calling it from a `useEffect` cleanup today would drop in-flight
+// prefetches on every `WorkspaceView` unmount; PR4 will wire it to the
+// appropriate long-lived lifecycle boundary.
 export const clearAgentStatusRefreshCoordinator = (): void => {
   agentStatusRefreshCoordinator.clear()
 }

--- a/src/features/agent-status/utils/statusRefreshCoordinator.ts
+++ b/src/features/agent-status/utils/statusRefreshCoordinator.ts
@@ -1,0 +1,182 @@
+import { invoke } from '../../../lib/backend'
+import type { AgentDetectedEvent, AgentStatus } from '../types'
+import {
+  createDefaultAgentStatus,
+  mapDetectedAgentType,
+} from './agentStatusModel'
+import {
+  readStatusSnapshot,
+  writeStatusSnapshot,
+  type AgentStatusSnapshot,
+} from './statusSnapshotStore'
+
+export const MAX_VISIBLE_STATUS_REFRESH_PANES = 4
+
+export interface VisibleStatusRefreshRequest {
+  activePtyId: string | null
+  visiblePtyIds: readonly string[]
+}
+
+export interface AgentStatusRefreshCoordinator {
+  refreshPane: (ptyId: string) => Promise<AgentStatus | null>
+  refreshVisiblePanes: (
+    request: VisibleStatusRefreshRequest
+  ) => Promise<AgentStatus[]>
+  clear: () => void
+}
+
+interface AgentStatusRefreshCoordinatorDeps {
+  detectAgent?: (ptyId: string) => Promise<AgentDetectedEvent | null>
+  readStatus?: (ptyId: string) => AgentStatus | null
+  writeStatus?: (ptyId: string, status: AgentStatus) => AgentStatusSnapshot
+}
+
+const defaultDetectAgent = async (
+  ptyId: string
+): Promise<AgentDetectedEvent | null> =>
+  invoke<AgentDetectedEvent | null>('detect_agent_in_session', {
+    sessionId: ptyId,
+  })
+
+const normalizePtyId = (ptyId: string | null | undefined): string | null => {
+  if (ptyId === undefined || ptyId === null || ptyId.length === 0) {
+    return null
+  }
+
+  return ptyId
+}
+
+export const planVisibleStatusRefreshes = ({
+  activePtyId,
+  visiblePtyIds,
+}: VisibleStatusRefreshRequest): string[] => {
+  const uniqueVisible = new Set<string>()
+
+  for (const ptyId of visiblePtyIds) {
+    const normalized = normalizePtyId(ptyId)
+
+    if (normalized !== null) {
+      uniqueVisible.add(normalized)
+    }
+  }
+
+  const normalizedActive = normalizePtyId(activePtyId)
+  const ordered: string[] = []
+
+  if (normalizedActive !== null && uniqueVisible.has(normalizedActive)) {
+    ordered.push(normalizedActive)
+  }
+
+  for (const ptyId of uniqueVisible) {
+    if (ptyId !== normalizedActive) {
+      ordered.push(ptyId)
+    }
+  }
+
+  return ordered.slice(0, MAX_VISIBLE_STATUS_REFRESH_PANES)
+}
+
+const mergeDetectedAgent = (
+  ptyId: string,
+  detected: AgentDetectedEvent,
+  previous: AgentStatus | null
+): AgentStatus => ({
+  ...(previous ?? createDefaultAgentStatus(ptyId)),
+  sessionId: ptyId,
+  isActive: true,
+  agentExited: false,
+  agentType: mapDetectedAgentType(detected.agentType as string),
+})
+
+export const createAgentStatusRefreshCoordinator = ({
+  detectAgent = defaultDetectAgent,
+  readStatus = readStatusSnapshot,
+  writeStatus = writeStatusSnapshot,
+}: AgentStatusRefreshCoordinatorDeps = {}): AgentStatusRefreshCoordinator => {
+  const inFlight = new Map<string, Promise<AgentStatus | null>>()
+  let visiblePtyIds: Set<string> | null = null
+
+  const runRefresh = async (ptyId: string): Promise<AgentStatus | null> => {
+    try {
+      const detected = await detectAgent(ptyId)
+
+      if (visiblePtyIds !== null && !visiblePtyIds.has(ptyId)) {
+        return null
+      }
+
+      const previous = readStatus(ptyId)
+
+      if (detected === null) {
+        if (previous !== null) {
+          return previous
+        }
+
+        return writeStatus(ptyId, createDefaultAgentStatus(ptyId)).status
+      }
+
+      return writeStatus(ptyId, mergeDetectedAgent(ptyId, detected, previous))
+        .status
+    } catch {
+      return null
+    }
+  }
+
+  const clearInFlightAfter = async (
+    ptyId: string,
+    request: Promise<AgentStatus | null>
+  ): Promise<void> => {
+    await request
+
+    if (inFlight.get(ptyId) === request) {
+      inFlight.delete(ptyId)
+    }
+  }
+
+  const refreshPane = (ptyId: string): Promise<AgentStatus | null> => {
+    const existing = inFlight.get(ptyId)
+
+    if (existing !== undefined) {
+      return existing
+    }
+
+    const request = runRefresh(ptyId)
+
+    inFlight.set(ptyId, request)
+    void clearInFlightAfter(ptyId, request)
+
+    return request
+  }
+
+  const refreshVisiblePanes = async (
+    request: VisibleStatusRefreshRequest
+  ): Promise<AgentStatus[]> => {
+    const plannedPtyIds = planVisibleStatusRefreshes(request)
+    visiblePtyIds = new Set(plannedPtyIds)
+
+    const results = await Promise.all(plannedPtyIds.map(refreshPane))
+
+    return results.filter((status): status is AgentStatus => status !== null)
+  }
+
+  const clear = (): void => {
+    visiblePtyIds = new Set()
+    inFlight.clear()
+  }
+
+  return {
+    refreshPane,
+    refreshVisiblePanes,
+    clear,
+  }
+}
+
+const agentStatusRefreshCoordinator = createAgentStatusRefreshCoordinator()
+
+export const refreshVisibleAgentStatusPanes = (
+  request: VisibleStatusRefreshRequest
+): Promise<AgentStatus[]> =>
+  agentStatusRefreshCoordinator.refreshVisiblePanes(request)
+
+export const clearAgentStatusRefreshCoordinator = (): void => {
+  agentStatusRefreshCoordinator.clear()
+}

--- a/src/features/terminal/components/SplitView/index.ts
+++ b/src/features/terminal/components/SplitView/index.ts
@@ -1,5 +1,6 @@
 export {
   SplitView,
+  selectVisiblePanes,
   type SplitViewHandle,
   type SplitViewProps,
 } from './SplitView'

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -6,6 +6,7 @@ import type { DiffLineAnnotation } from '@pierre/diffs'
 import type { AgentStatus } from '../agent-status/types'
 import { useGitStatus } from '../diff/hooks/useGitStatus'
 import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
+import { useAgentStatusHotLoading } from '../agent-status/hooks/useAgentStatusHotLoading'
 import type { FeedbackRepoRootRef } from '../diff/components/DiffPanelContent'
 import type {
   ReviewComment,
@@ -134,6 +135,10 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
       testRun: null,
     })
   ),
+}))
+
+vi.mock('../agent-status/hooks/useAgentStatusHotLoading', () => ({
+  useAgentStatusHotLoading: vi.fn(),
 }))
 
 vi.mock('../diff/hooks/useGitStatus', () => ({
@@ -287,6 +292,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
     // making test 3's assertion pass even if test 3's own render
     // computed `enabled: false`.
     vi.mocked(useAgentStatus).mockClear()
+    vi.mocked(useAgentStatusHotLoading).mockClear()
     vi.mocked(useGitStatus).mockClear()
   })
 
@@ -298,6 +304,17 @@ describe('WorkspaceView lifted-subscription contract', () => {
     await screen.findByTestId('agent-status-panel-mock')
 
     expect(capturedPanelProps.agentStatus).toBeDefined()
+  })
+
+  test('WorkspaceView hot-loads only visible PTY-backed panes in the active session', async () => {
+    render(<WorkspaceView />)
+
+    await screen.findByTestId('agent-status-panel-mock')
+
+    expect(useAgentStatusHotLoading).toHaveBeenCalledWith({
+      activePtyId: 'sess-1',
+      visiblePtyIds: ['sess-1'],
+    })
   })
 
   test('AgentStatusCard and AgentStatusPanel both render from the single useAgentStatus subscription', async () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -79,6 +79,7 @@ import type { PaneCandidate } from '../diff/services/activePanePicker'
 import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
 import { isShellPane } from '../sessions/utils/paneKind'
+import { LAYOUTS, selectVisiblePanes } from '../terminal/components/SplitView'
 import { lineDelta } from '../sessions/utils/lineDelta'
 import { hasLivePane, isLiveStatus } from '../sessions/utils/sessionStatus'
 import { pickNextVisibleSessionId } from '../sessions/utils/pickNextVisibleSessionId'
@@ -513,10 +514,12 @@ export const WorkspaceView = (): ReactElement => {
 
   const visibleAgentStatusPtyIds = useMemo(
     () =>
-      activeSession?.panes
-        .filter((pane) => isShellPane(pane))
-        .map((pane) => pane.ptyId) ?? [],
-    [activeSession?.panes]
+      activeSession === undefined
+        ? []
+        : selectVisiblePanes(activeSession.panes, LAYOUTS[activeSession.layout].capacity)
+            .filter((pane) => isShellPane(pane))
+            .map((pane) => pane.ptyId),
+    [activeSession]
   )
 
   useAgentStatusHotLoading({

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -516,7 +516,10 @@ export const WorkspaceView = (): ReactElement => {
     () =>
       activeSession === undefined
         ? []
-        : selectVisiblePanes(activeSession.panes, LAYOUTS[activeSession.layout].capacity)
+        : selectVisiblePanes(
+            activeSession.panes,
+            LAYOUTS[activeSession.layout].capacity
+          )
             .filter((pane) => isShellPane(pane))
             .map((pane) => pane.ptyId),
     [activeSession]

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -72,6 +72,7 @@ import { useNewSessionShortcut } from './hooks/useNewSessionShortcut'
 import { useSidebarCollapsed } from './hooks/useSidebarCollapsed'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
 import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
+import { useAgentStatusHotLoading } from '../agent-status/hooks/useAgentStatusHotLoading'
 import { useGitStatus } from '../diff/hooks/useGitStatus'
 import { useFeedbackBatch } from '../diff/hooks/useFeedbackBatch'
 import type { PaneCandidate } from '../diff/services/activePanePicker'
@@ -509,6 +510,19 @@ export const WorkspaceView = (): ReactElement => {
   const activePtyBackedPanePtyId = activePtyBackedPane?.ptyId
 
   const agentStatus = useAgentStatus(activePtyBackedPanePtyId ?? null)
+
+  const visibleAgentStatusPtyIds = useMemo(
+    () =>
+      activeSession?.panes
+        .filter((pane) => isShellPane(pane))
+        .map((pane) => pane.ptyId) ?? [],
+    [activeSession?.panes]
+  )
+
+  useAgentStatusHotLoading({
+    activePtyId: activePtyBackedPanePtyId ?? null,
+    visiblePtyIds: visibleAgentStatusPtyIds,
+  })
 
   useCacheHistoryCollector({
     ptyId: activePtyBackedPanePtyId ?? null,


### PR DESCRIPTION
## Summary

- Add a bounded agent-status refresh coordinator for visible PTY-backed panes.
- Plan active-pane refresh first, then visible sibling pane prefetch, capped to the current split-layout ceiling.
- Coalesce in-flight refreshes by PTY id and drop late responses for panes that are no longer visible.
- Preserve rich PR2 snapshots while detection refreshes only update minimal active/detected identity fields.
- Wire `WorkspaceView` to hot-load only the active session's visible shell panes and update the PR3 spec notes.

## Branch Strategy

- Base: `feat/vim-127-activity-panel-hot-reload`
- Head: `feature/vim-127-pr3-prefetch-hotload`
- PR2 is already merged into the integration branch, so PR3 is a clean one-commit stack on the integration branch.

## Validation

- `npm run format:check`
- `npm run lint`
- focused Vitest for agent-status model/coordinator/hot-loading hook, active status hook, and WorkspaceView wiring
- `npm run type-check`
- `npm run test` (`289` files, `3705` passed, `3` skipped)
- Claude Code implementation review: `VERDICT: patch is correct`

## Notes For PR4

PR3 deliberately keeps the live stream owner in `useAgentStatus`; the coordinator performs bounded detection refreshes and snapshot warming only. PR4 should focus on sidebar rendering stability and subtle loading/stale affordances using the warmed snapshot state.

Linear: VIM-127