### PR TITLE
feat(agent-status): stabilize VIM-127 sidebar rendering (PR4)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                                                              | Category           | Findings | Refs | Last Updated |
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 22       | 4    | 2026-06-13   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 38       | 15   | 2026-06-15   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 39       | 15   | 2026-06-15   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 64       | 30   | 2026-06-12   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 54       | 23   | 2026-06-15   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 22   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |
@@ -88,4 +88,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
-| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 2        | 0    | 2026-06-15   |
+| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 3        | 0    | 2026-06-15   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                                                              | Category           | Findings | Refs | Last Updated |
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 22       | 4    | 2026-06-13   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 39       | 15   | 2026-06-15   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 40       | 15   | 2026-06-15   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,7 +2,7 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-13
+last_updated: 2026-06-15
 ref_count: 23
 ---
 
@@ -531,4 +531,22 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/workspace/components/panels/FileExplorer.tsx`
 - **Finding:** `window.prompt` and `window.confirm` blocked the renderer thread, used unstyled OS chrome, and could not display formatted validation hints or be cancelled via Escape reliably.
 - **Fix:** Replaced native dialogs with an inline rename input and a delete-confirmation strip styled with design tokens; kept actions non-blocking.
+- **Commit:** see `git blame` / `git log` on this line
+
+### 50. Reduced-motion media query leaves animated element visible at rest
+
+- **Source:** github-claude | PR #464 round 1 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/index.css`
+- **Finding:** The `prefers-reduced-motion: reduce` block set `animation: none` on `.vf-activity-refresh-comet` but left the 45%-wide gradient `div` mounted at `translateX(0)`. Because keyframe positions are not applied when animation is disabled, users who opted out of motion saw a static semi-transparent bar in the header divider.
+- **Fix:** Added `transform: translateX(-100%)` as a base style on `.vf-activity-refresh-comet` so the rest position is off-screen regardless of animation state.
+- **Commit:** see `git blame` / `git log` on this line
+
+### 51. `aria-live` region announces completion on every refresh cycle
+
+- **Source:** github-claude | PR #464 round 1 | 2026-06-15
+- **Severity:** LOW
+- **File:** `src/features/agent-status/components/AgentStatusPanel/index.tsx`
+- **Finding:** The live region alternated between `'Fetching latest agent status'` and `'Agent status updated'`. Screen readers queued both strings on every hot-load cycle, producing background chatter during rapid pane switches.
+- **Fix:** Changed the idle branch to an empty string so only the refresh-start state is announced; the visual header affordance communicates completion.
 - **Commit:** see `git blame` / `git log` on this line

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -34,3 +34,12 @@ code and should be removed.
 - **Finding:** `clearAgentStatusRefreshCoordinator` was exported from the singleton module but had no call sites. Without a comment, a future refactor would likely delete it.
 - **Fix:** Added a comment documenting that the export is intentionally reserved for PR4 lifecycle hooks (session close / workspace teardown) and should not be wired to a `useEffect` cleanup today.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 3. Redundant Tailwind padding shorthand alongside explicit overrides
+
+- **Source:** github-claude | PR #464 round 1 | 2026-06-15
+- **Severity:** LOW
+- **File:** `src/features/agent-status/components/AgentStatusPanel/Header.tsx`
+- **Finding:** The header root carried `px-2 pr-2 pl-3.5`. `px-2` set both sides to `0.5rem`, `pr-2` repeated the right value, and `pl-3.5` overrode the left value. The shorthand was a dead no-op that made the cascade harder to reason about.
+- **Fix:** Removed `px-2`; kept only `pr-2 pl-3.5`.
+- **Commit:** see `git blame` / `git log` on this line

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -356,3 +356,12 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** `visibleAgentStatusPtyIds` was derived from every shell pane in the active session, so hidden panes (e.g., after shrinking to `single`/`vsplit`) still received prefetches and warm snapshots. The background-work boundary diverged from the UI visibility boundary.
 - **Fix:** Replaced the all-panes filter with `selectVisiblePanes(session.panes, LAYOUTS[session.layout].capacity)` so hot-loading targets exactly the panes rendered by `SplitView`.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 36. Scroll-anchor compensation inferred prepend from list length
+
+- **Source:** github-claude + github-codex-connector (P2) | PR #464 round 1 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/components/AgentStatusPanel/index.tsx`
+- **Finding:** The prepend detector compared `feedEvents.length` to a stored count. When the capped activity feed replaced its oldest row (total length unchanged) or appended rows at the bottom, the detector produced false negatives/positives. The compensation amount also relied on total `scrollHeight` growth, which is zero when an equal-height row drops off the bottom.
+- **Fix:** Replaced the count heuristic with first-event identity (`feedEvents[0]?.id`). Measured the new first row's `offsetHeight` (with `CSS.escape` on the selector) and used it as the compensation delta, falling back to `scrollHeightDelta` when the row is not rendered.
+- **Commit:** see `git blame` / `git log` on this line

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -365,3 +365,12 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** The prepend detector compared `feedEvents.length` to a stored count. When the capped activity feed replaced its oldest row (total length unchanged) or appended rows at the bottom, the detector produced false negatives/positives. The compensation amount also relied on total `scrollHeight` growth, which is zero when an equal-height row drops off the bottom.
 - **Fix:** Replaced the count heuristic with first-event identity (`feedEvents[0]?.id`). Measured the new first row's `offsetHeight` (with `CSS.escape` on the selector) and used it as the compensation delta, falling back to `scrollHeightDelta` when the row is not rendered.
 - **Commit:** see `git blame` / `git log` on this line
+
+### 37. Batch prepends compensated by only the first inserted row height
+
+- **Source:** github-codex-connector (P2) | PR #464 round 2 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/components/AgentStatusPanel/index.tsx`
+- **Finding:** The round-1 fix computed `prependDelta = firstRowHeight > 0 ? firstRowHeight : scrollHeightDelta`. When hot-loading delivered multiple new activity rows in one snapshot, the viewport adjusted by one row instead of the total inserted height, causing visible content jump and undermining scroll-stability.
+- **Fix:** Prefer total positive `scrollHeightDelta` for growing prepends and fall back to the measured first-row height only when the container does not grow. Added a regression test that stubs `offsetHeight` to a single-row value while growing `scrollHeight` by several rows' worth, asserting the viewport compensates by the full delta.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/superpowers/specs/2026-06-14-activity-panel-hot-reload/pr-4-sidebar-rendering.md
+++ b/docs/superpowers/specs/2026-06-14-activity-panel-hot-reload/pr-4-sidebar-rendering.md
@@ -1,6 +1,6 @@
 # PR4 — Sidebar Rendering Stability
 
-**Status:** draft
+**Status:** implemented
 **Scope:** activity/status sidebar UI rendering
 **Depends on:** PR3
 
@@ -10,12 +10,20 @@ Make the sidebar visually stable during pane switches and live status updates.
 
 ## Implementation Plan
 
-- Render retained snapshot content while a refresh is in flight.
-- Show loading or stale state as a subtle header affordance.
-- Avoid full-list remounts by using stable keys and memoized row rendering where useful.
-- Keep layout dimensions stable for header, toolbar, empty state, skeleton rows, and timeline rows.
-- Evaluate virtualization only if real list sizes or profiling show row count as the dominant cost.
-- Restore the per-pane scroll anchor after the new pane content is mounted.
+- Render retained snapshot content while a refresh is in flight; fetching is expressed only in the header.
+- Show refresh state as a compact header affordance: fixed header height, sync glyph, glyph breathing, and a comet sweep inside the existing bottom hairline.
+- Avoid full-list remounts by keeping existing stable activity row keys and preserving the mounted panel across pane switches.
+- Keep layout dimensions stable for the header, empty state, and timeline rows. Cold-load skeletons remain deferred until the data flow has an explicit no-snapshot signal.
+- Do not introduce virtualization in PR4; the current feed already caps initial rows and no row-count bottleneck has been measured.
+- Restore the per-pane scroll anchor only when the pane key changes, then preserve the visual anchor when new activity prepends above a scrolled history viewport.
+
+## Implementation Notes
+
+- `useAgentStatusHotLoading` now returns a boolean refresh phase while retaining its existing bounded prefetch behavior from PR3.
+- `WorkspaceView` forwards that phase to `AgentStatusPanel`; no extra backend watcher or subscription path is added.
+- `AgentStatusPanelHeader` keeps a fixed 44px footprint and renders the refresh affordance without adding banners, overlays, or body opacity changes.
+- `AgentStatusPanel` no longer reapplies saved scroll anchors on every feed/git/status update. It restores on `snapshotKey` changes and adjusts scroll by `scrollHeight` deltas when new rows prepend while the user is reading older history.
+- `src/index.css` owns the refresh comet and glyph-breathing keyframes, with reduced-motion disabling both animations.
 
 ## Visual Guidance
 

--- a/src/features/agent-status/components/ActivityEvent.tsx
+++ b/src/features/agent-status/components/ActivityEvent.tsx
@@ -492,6 +492,7 @@ export const ActivityEvent = ({
     >
       <article
         ref={rowRef}
+        data-event-id={event.id}
         aria-label={label}
         aria-posinset={ariaPosInSet}
         aria-setsize={ariaSetSize}

--- a/src/features/agent-status/components/AgentStatusPanel/Header.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.test.tsx
@@ -17,6 +17,37 @@ test('renders agent glyph, short label, and a status dot', () => {
   expect(screen.getByTestId('status-dot')).toBeInTheDocument()
 })
 
+test('reserves a fixed 44px header height', () => {
+  render(
+    <AgentStatusPanelHeader
+      agent={AGENTS.claude}
+      status="running"
+      onCollapse={() => undefined}
+    />
+  )
+
+  expect(screen.getByTestId('agent-status-panel-header')).toHaveClass('h-11')
+})
+
+test('shows compact refresh affordance without replacing status', () => {
+  render(
+    <AgentStatusPanelHeader
+      agent={AGENTS.claude}
+      isRefreshing
+      status="running"
+      onCollapse={() => undefined}
+    />
+  )
+
+  expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+  expect(screen.getByText('fetching latest')).toBeInTheDocument()
+  expect(screen.getByText('sync')).toBeInTheDocument()
+  expect(screen.getByTestId('agent-glyph-chip')).toHaveAttribute(
+    'data-refreshing',
+    'true'
+  )
+})
+
 test('chevron button fires onCollapse when clicked', async () => {
   const onCollapse = vi.fn()
   render(

--- a/src/features/agent-status/components/AgentStatusPanel/Header.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.tsx
@@ -5,34 +5,50 @@ import { StatusDot } from '../../../sessions/components/StatusDot'
 
 export interface AgentStatusPanelHeaderProps {
   agent: Agent
+  isRefreshing?: boolean
   status: SessionStatus
   onCollapse: () => void
 }
 
 export const AgentStatusPanelHeader = ({
   agent,
+  isRefreshing = false,
   status,
   onCollapse,
 }: AgentStatusPanelHeaderProps): ReactElement => (
   <div
     data-testid="agent-status-panel-header"
-    className="flex items-center gap-2.5 px-3 py-2.5"
+    className="relative flex h-11 shrink-0 items-center gap-2.5 px-2 pr-2 pl-3.5"
     style={{
       background: `linear-gradient(180deg, ${agent.accentDim}, transparent 80%)`,
     }}
   >
     <div
       data-testid="agent-glyph-chip"
-      className="grid h-[26px] w-[26px] shrink-0 place-items-center rounded-md font-mono text-[13px] font-bold"
+      data-refreshing={isRefreshing ? 'true' : 'false'}
+      className={`grid h-6 w-6 shrink-0 place-items-center rounded-md border font-mono text-xs font-bold ${isRefreshing ? 'vf-activity-glyph-refresh' : ''}`}
       style={{ background: agent.accentDim, color: agent.accent }}
     >
       {agent.glyph}
     </div>
-    <div className="flex min-w-0 flex-1 items-center gap-1.5">
-      <span className="font-headline text-[13px] font-semibold text-on-surface">
-        {agent.short}
+    <div className="flex min-w-0 flex-1 flex-col justify-center">
+      <div className="flex min-w-0 items-center gap-1.5">
+        <span className="truncate font-headline text-[13px] font-semibold text-on-surface">
+          {agent.short}
+        </span>
+        <StatusDot status={status} size={6} aria-label={`agent ${status}`} />
+        {isRefreshing && (
+          <span
+            className="material-symbols-outlined text-[11px] text-on-surface-muted motion-safe:animate-spin"
+            aria-hidden="true"
+          >
+            sync
+          </span>
+        )}
+      </div>
+      <span className="h-3 truncate font-mono text-[10px] leading-3 text-on-surface-muted">
+        {isRefreshing ? 'fetching latest' : 'updated now'}
       </span>
-      <StatusDot status={status} size={6} aria-label={`agent ${status}`} />
     </div>
     <button
       type="button"
@@ -42,5 +58,11 @@ export const AgentStatusPanelHeader = ({
     >
       <span className="material-symbols-outlined text-base">chevron_right</span>
     </button>
+    <div
+      className="absolute right-0 bottom-0 left-0 h-px overflow-hidden bg-outline-variant/25"
+      aria-hidden="true"
+    >
+      {isRefreshing && <div className="vf-activity-refresh-comet h-full" />}
+    </div>
   </div>
 )

--- a/src/features/agent-status/components/AgentStatusPanel/Header.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.tsx
@@ -18,7 +18,7 @@ export const AgentStatusPanelHeader = ({
 }: AgentStatusPanelHeaderProps): ReactElement => (
   <div
     data-testid="agent-status-panel-header"
-    className="relative flex h-11 shrink-0 items-center gap-2.5 px-2 pr-2 pl-3.5"
+    className="relative flex h-11 shrink-0 items-center gap-2.5 pr-2 pl-3.5"
     style={{
       background: `linear-gradient(180deg, ${agent.accentDim}, transparent 80%)`,
     }}

--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -486,6 +486,119 @@ describe('AgentStatusPanel', () => {
     expect(readStatusScrollAnchor('pty-pane-1')).toBe(180)
   })
 
+  test('compensates by total scroll growth when multiple rows prepend at once', () => {
+    const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetHeight'
+    )
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 30,
+    })
+
+    const oldHistoryStatus: AgentStatus = {
+      ...activeAgentStatus,
+      toolCalls: {
+        total: 1,
+        byType: { Read: 1 },
+        active: null,
+      },
+      recentToolCalls: [
+        {
+          id: 'old-read',
+          tool: 'Read',
+          args: 'src/old.ts',
+          status: 'done',
+          durationMs: 100,
+          timestamp: '2026-04-22T11:59:00Z',
+          isTestFile: false,
+        },
+      ],
+    }
+
+    const { rerender } = render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={oldHistoryStatus}
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    const panel = screen.getByTestId('agent-status-panel')
+
+    /* eslint-disable testing-library/no-node-access */
+    const scrollContainer = panel.querySelector('.overflow-y-auto')
+    expect(scrollContainer).toBeInstanceOf(HTMLDivElement)
+
+    let scrollHeight = 500
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    })
+
+    const scrollElement = scrollContainer as HTMLDivElement
+    scrollElement.scrollTop = 120
+    fireEvent.scroll(scrollElement)
+
+    scrollHeight = 620
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={{
+          ...oldHistoryStatus,
+          toolCalls: {
+            total: 4,
+            byType: { Read: 4 },
+            active: null,
+          },
+          recentToolCalls: [
+            {
+              id: 'new-read-3',
+              tool: 'Read',
+              args: 'src/new3.ts',
+              status: 'done',
+              durationMs: 70,
+              timestamp: '2026-04-22T12:02:00Z',
+              isTestFile: false,
+            },
+            {
+              id: 'new-read-2',
+              tool: 'Read',
+              args: 'src/new2.ts',
+              status: 'done',
+              durationMs: 80,
+              timestamp: '2026-04-22T12:01:00Z',
+              isTestFile: false,
+            },
+            {
+              id: 'new-read-1',
+              tool: 'Read',
+              args: 'src/new1.ts',
+              status: 'done',
+              durationMs: 90,
+              timestamp: '2026-04-22T12:00:00Z',
+              isTestFile: false,
+            },
+            ...oldHistoryStatus.recentToolCalls,
+          ],
+        }}
+        snapshotKey="pty-pane-1"
+      />
+    )
+    /* eslint-enable testing-library/no-node-access */
+
+    expect(scrollElement.scrollTop).toBe(240)
+    expect(readStatusScrollAnchor('pty-pane-1')).toBe(240)
+
+    if (originalOffsetHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'offsetHeight',
+        originalOffsetHeight
+      )
+    }
+  })
+
   test('preserves the visual scroll anchor when prepending replaces the oldest row', () => {
     const cappedHistoryStatus: AgentStatus = {
       ...activeAgentStatus,

--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -408,6 +408,147 @@ describe('AgentStatusPanel', () => {
     expect(readStatusScrollAnchor('pty-pane-1')).toBe(260)
   })
 
+  test('preserves the visual scroll anchor when new activity prepends above history', () => {
+    const oldHistoryStatus: AgentStatus = {
+      ...activeAgentStatus,
+      toolCalls: {
+        total: 1,
+        byType: { Read: 1 },
+        active: null,
+      },
+      recentToolCalls: [
+        {
+          id: 'old-read',
+          tool: 'Read',
+          args: 'src/old.ts',
+          status: 'done',
+          durationMs: 100,
+          timestamp: '2026-04-22T11:59:00Z',
+          isTestFile: false,
+        },
+      ],
+    }
+
+    const { rerender } = render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={oldHistoryStatus}
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    const panel = screen.getByTestId('agent-status-panel')
+
+    /* eslint-disable testing-library/no-node-access */
+    const scrollContainer = panel.querySelector('.overflow-y-auto')
+    expect(scrollContainer).toBeInstanceOf(HTMLDivElement)
+
+    let scrollHeight = 500
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    })
+
+    const scrollElement = scrollContainer as HTMLDivElement
+    scrollElement.scrollTop = 120
+    fireEvent.scroll(scrollElement)
+
+    scrollHeight = 560
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={{
+          ...oldHistoryStatus,
+          toolCalls: {
+            total: 2,
+            byType: { Read: 2 },
+            active: null,
+          },
+          recentToolCalls: [
+            {
+              id: 'new-read',
+              tool: 'Read',
+              args: 'src/new.ts',
+              status: 'done',
+              durationMs: 90,
+              timestamp: '2026-04-22T12:00:00Z',
+              isTestFile: false,
+            },
+            ...oldHistoryStatus.recentToolCalls,
+          ],
+        }}
+        snapshotKey="pty-pane-1"
+      />
+    )
+    /* eslint-enable testing-library/no-node-access */
+
+    expect(scrollElement.scrollTop).toBe(180)
+    expect(readStatusScrollAnchor('pty-pane-1')).toBe(180)
+  })
+
+  test('does not adjust scroll when a lower sidebar section grows', () => {
+    const emptyGitStatus = {
+      files: [],
+      filesCwd: '/tmp/repo',
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      idle: false,
+    }
+
+    const { rerender } = render(
+      <AgentStatusPanel
+        {...defaultProps}
+        cwd="/tmp/repo"
+        gitStatus={emptyGitStatus}
+        agentStatus={activeAgentStatus}
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    const panel = screen.getByTestId('agent-status-panel')
+
+    /* eslint-disable testing-library/no-node-access */
+    const scrollContainer = panel.querySelector('.overflow-y-auto')
+    expect(scrollContainer).toBeInstanceOf(HTMLDivElement)
+
+    let scrollHeight = 500
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    })
+
+    const scrollElement = scrollContainer as HTMLDivElement
+    scrollElement.scrollTop = 120
+    fireEvent.scroll(scrollElement)
+
+    scrollHeight = 560
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        cwd="/tmp/repo"
+        gitStatus={{
+          ...emptyGitStatus,
+          files: [
+            {
+              path: 'later.ts',
+              status: 'modified',
+              insertions: 4,
+              deletions: 1,
+              staged: false,
+            },
+          ],
+        }}
+        agentStatus={activeAgentStatus}
+        snapshotKey="pty-pane-1"
+      />
+    )
+    /* eslint-enable testing-library/no-node-access */
+
+    expect(scrollElement.scrollTop).toBe(120)
+    expect(readStatusScrollAnchor('pty-pane-1')).toBe(120)
+  })
+
   test('renders Header above the body with the provided agent status and onCollapse', async () => {
     const onCollapse = vi.fn()
     render(
@@ -431,6 +572,22 @@ describe('AgentStatusPanel', () => {
       screen.getByRole('button', { name: /collapse activity panel/i })
     )
     expect(onCollapse).toHaveBeenCalledTimes(1)
+  })
+
+  test('passes refreshing state into the fixed header affordance', () => {
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={activeAgentStatus}
+        isRefreshing
+      />
+    )
+
+    expect(screen.getByText('fetching latest')).toBeInTheDocument()
+    expect(screen.getByText('Fetching latest agent status')).toHaveAttribute(
+      'aria-live',
+      'polite'
+    )
   })
 })
 

--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -486,6 +486,212 @@ describe('AgentStatusPanel', () => {
     expect(readStatusScrollAnchor('pty-pane-1')).toBe(180)
   })
 
+  test('preserves the visual scroll anchor when prepending replaces the oldest row', () => {
+    const cappedHistoryStatus: AgentStatus = {
+      ...activeAgentStatus,
+      toolCalls: {
+        total: 2,
+        byType: { Read: 2 },
+        active: null,
+      },
+      recentToolCalls: [
+        {
+          id: 'middle-read',
+          tool: 'Read',
+          args: 'src/middle.ts',
+          status: 'done',
+          durationMs: 100,
+          timestamp: '2026-04-22T11:59:30Z',
+          isTestFile: false,
+        },
+        {
+          id: 'old-read',
+          tool: 'Read',
+          args: 'src/old.ts',
+          status: 'done',
+          durationMs: 100,
+          timestamp: '2026-04-22T11:58:00Z',
+          isTestFile: false,
+        },
+      ],
+    }
+
+    const { rerender } = render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={cappedHistoryStatus}
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    const panel = screen.getByTestId('agent-status-panel')
+
+    /* eslint-disable testing-library/no-node-access */
+    const scrollContainer = panel.querySelector('.overflow-y-auto')
+    expect(scrollContainer).toBeInstanceOf(HTMLDivElement)
+
+    let scrollHeight = 500
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    })
+
+    const scrollElement = scrollContainer as HTMLDivElement
+    scrollElement.scrollTop = 120
+    fireEvent.scroll(scrollElement)
+
+    scrollHeight = 560
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={{
+          ...cappedHistoryStatus,
+          toolCalls: {
+            total: 3,
+            byType: { Read: 3 },
+            active: null,
+          },
+          recentToolCalls: [
+            {
+              id: 'new-read',
+              tool: 'Read',
+              args: 'src/new.ts',
+              status: 'done',
+              durationMs: 90,
+              timestamp: '2026-04-22T12:00:00Z',
+              isTestFile: false,
+            },
+            {
+              id: 'middle-read',
+              tool: 'Read',
+              args: 'src/middle.ts',
+              status: 'done',
+              durationMs: 100,
+              timestamp: '2026-04-22T11:59:30Z',
+              isTestFile: false,
+            },
+          ],
+        }}
+        snapshotKey="pty-pane-1"
+      />
+    )
+    /* eslint-enable testing-library/no-node-access */
+
+    expect(scrollElement.scrollTop).toBe(180)
+    expect(readStatusScrollAnchor('pty-pane-1')).toBe(180)
+  })
+
+  test('compensates by inserted row height when total scroll height does not grow', () => {
+    const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetHeight'
+    )
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 60,
+    })
+
+    const cappedHistoryStatus: AgentStatus = {
+      ...activeAgentStatus,
+      toolCalls: {
+        total: 2,
+        byType: { Read: 2 },
+        active: null,
+      },
+      recentToolCalls: [
+        {
+          id: 'middle-read',
+          tool: 'Read',
+          args: 'src/middle.ts',
+          status: 'done',
+          durationMs: 100,
+          timestamp: '2026-04-22T11:59:30Z',
+          isTestFile: false,
+        },
+        {
+          id: 'old-read',
+          tool: 'Read',
+          args: 'src/old.ts',
+          status: 'done',
+          durationMs: 100,
+          timestamp: '2026-04-22T11:58:00Z',
+          isTestFile: false,
+        },
+      ],
+    }
+
+    const { rerender } = render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={cappedHistoryStatus}
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    const panel = screen.getByTestId('agent-status-panel')
+
+    /* eslint-disable testing-library/no-node-access */
+    const scrollContainer = panel.querySelector('.overflow-y-auto')
+    expect(scrollContainer).toBeInstanceOf(HTMLDivElement)
+
+    const scrollHeight = 500
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    })
+
+    const scrollElement = scrollContainer as HTMLDivElement
+    scrollElement.scrollTop = 120
+    fireEvent.scroll(scrollElement)
+
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={{
+          ...cappedHistoryStatus,
+          toolCalls: {
+            total: 3,
+            byType: { Read: 3 },
+            active: null,
+          },
+          recentToolCalls: [
+            {
+              id: 'new-read',
+              tool: 'Read',
+              args: 'src/new.ts',
+              status: 'done',
+              durationMs: 90,
+              timestamp: '2026-04-22T12:00:00Z',
+              isTestFile: false,
+            },
+            {
+              id: 'middle-read',
+              tool: 'Read',
+              args: 'src/middle.ts',
+              status: 'done',
+              durationMs: 100,
+              timestamp: '2026-04-22T11:59:30Z',
+              isTestFile: false,
+            },
+          ],
+        }}
+        snapshotKey="pty-pane-1"
+      />
+    )
+    /* eslint-enable testing-library/no-node-access */
+
+    expect(scrollElement.scrollTop).toBe(180)
+    expect(readStatusScrollAnchor('pty-pane-1')).toBe(180)
+
+    if (originalOffsetHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'offsetHeight',
+        originalOffsetHeight
+      )
+    }
+  })
+
   test('does not adjust scroll when a lower sidebar section grows', () => {
     const emptyGitStatus = {
       files: [],

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -71,7 +71,7 @@ export const AgentStatusPanel = ({
   const programmaticScrollTopRef = useRef<number | null>(null)
 
   const scrollMetricsRef = useRef<{
-    feedEventCount: number
+    firstEventId: string | null
     snapshotKey: string | null
     scrollHeight: number
     scrollTop: number
@@ -109,9 +109,6 @@ export const AgentStatusPanel = ({
         : events.filter((event) => event.id !== runningEvent.id),
     [events, runningEvent]
   )
-
-  const feedEventCountRef = useRef(feedEvents.length)
-  feedEventCountRef.current = feedEvents.length
 
   // Own the live "running Ns" clock: tick only while an action runs, resetting
   // immediately when a new one starts so the counter never reads stale.
@@ -166,11 +163,15 @@ export const AgentStatusPanel = ({
     scrollContainer.scrollTop = scrollTop
     programmaticScrollTopRef.current = scrollContainer.scrollTop
     scrollMetricsRef.current = {
-      feedEventCount: feedEventCountRef.current,
+      firstEventId: feedEvents[0]?.id ?? null,
       snapshotKey,
       scrollHeight: scrollContainer.scrollHeight,
       scrollTop: scrollContainer.scrollTop,
     }
+    // restoreScrollAnchor intentionally depends only on snapshotKey. It runs on
+    // mount/key change to restore the saved scroll position; the latest feed
+    // identity is updated by the following layout effect on every render cycle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [snapshotKey])
 
   useLayoutEffect(() => {
@@ -187,38 +188,45 @@ export const AgentStatusPanel = ({
     const previousMetrics = scrollMetricsRef.current
 
     if (previousMetrics?.snapshotKey === snapshotKey) {
-      const scrollHeightDelta =
-        scrollContainer.scrollHeight - previousMetrics.scrollHeight
-
       const activityPrepended =
-        feedEvents.length > previousMetrics.feedEventCount
+        (feedEvents[0]?.id ?? null) !== previousMetrics.firstEventId
 
-      if (
-        activityPrepended &&
-        scrollHeightDelta > 0 &&
-        previousMetrics.scrollTop > 0
-      ) {
-        const nextScrollTop = previousMetrics.scrollTop + scrollHeightDelta
+      if (activityPrepended && previousMetrics.scrollTop > 0) {
+        const firstRow = scrollContainer.querySelector<HTMLElement>(
+          `[data-event-id="${CSS.escape(feedEvents[0]?.id ?? '')}"]`
+        )
 
-        programmaticScrollTopRef.current = nextScrollTop
-        scrollContainer.scrollTop = nextScrollTop
-        programmaticScrollTopRef.current = scrollContainer.scrollTop
+        const firstRowHeight = firstRow?.offsetHeight ?? 0
 
-        if (snapshotKey !== null) {
-          writeStatusScrollAnchor(snapshotKey, scrollContainer.scrollTop)
+        const scrollHeightDelta =
+          scrollContainer.scrollHeight - previousMetrics.scrollHeight
+
+        const prependDelta =
+          firstRowHeight > 0 ? firstRowHeight : scrollHeightDelta
+
+        if (prependDelta > 0) {
+          const nextScrollTop = previousMetrics.scrollTop + prependDelta
+
+          programmaticScrollTopRef.current = nextScrollTop
+          scrollContainer.scrollTop = nextScrollTop
+          programmaticScrollTopRef.current = scrollContainer.scrollTop
+
+          if (snapshotKey !== null) {
+            writeStatusScrollAnchor(snapshotKey, scrollContainer.scrollTop)
+          }
         }
       }
     }
 
     scrollMetricsRef.current = {
-      feedEventCount: feedEvents.length,
+      firstEventId: feedEvents[0]?.id ?? null,
       snapshotKey,
       scrollHeight: scrollContainer.scrollHeight,
       scrollTop: scrollContainer.scrollTop,
     }
   }, [
     snapshotKey,
-    feedEvents.length,
+    feedEvents,
     runningId,
     status.toolCalls.total,
     effectiveFiles.length,
@@ -271,7 +279,7 @@ export const AgentStatusPanel = ({
       />
 
       <span className="sr-only" role="status" aria-live="polite">
-        {isRefreshing ? 'Fetching latest agent status' : 'Agent status updated'}
+        {isRefreshing ? 'Fetching latest agent status' : ''}
       </span>
 
       <div className="flex flex-col gap-2 p-2">

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -202,7 +202,7 @@ export const AgentStatusPanel = ({
           scrollContainer.scrollHeight - previousMetrics.scrollHeight
 
         const prependDelta =
-          firstRowHeight > 0 ? firstRowHeight : scrollHeightDelta
+          scrollHeightDelta > 0 ? scrollHeightDelta : firstRowHeight
 
         if (prependDelta > 0) {
           const nextScrollTop = previousMetrics.scrollTop + prependDelta

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -37,6 +37,7 @@ interface AgentStatusPanelProps {
   onOpenDiff: (file: ChangedFile) => void
   onOpenFile?: (path: string) => void
   gitStatus?: UseGitStatusReturn
+  isRefreshing?: boolean
   agent: Agent
   status: SessionStatus
   onCollapse: () => void
@@ -57,6 +58,7 @@ export const AgentStatusPanel = ({
   onOpenDiff,
   onOpenFile = undefined,
   gitStatus = undefined,
+  isRefreshing = false,
   agent,
   status: sessionStatus,
   onCollapse,
@@ -67,6 +69,13 @@ export const AgentStatusPanel = ({
   const events = useActivityEvents(status)
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const programmaticScrollTopRef = useRef<number | null>(null)
+
+  const scrollMetricsRef = useRef<{
+    feedEventCount: number
+    snapshotKey: string | null
+    scrollHeight: number
+    scrollTop: number
+  } | null>(null)
 
   const internalGitStatus = useGitStatus(cwd, {
     watch: true,
@@ -100,6 +109,9 @@ export const AgentStatusPanel = ({
         : events.filter((event) => event.id !== runningEvent.id),
     [events, runningEvent]
   )
+
+  const feedEventCountRef = useRef(feedEvents.length)
+  feedEventCountRef.current = feedEvents.length
 
   // Own the live "running Ns" clock: tick only while an action runs, resetting
   // immediately when a new one starts so the counter never reads stale.
@@ -137,7 +149,7 @@ export const AgentStatusPanel = ({
 
   const canActivate = liveFile !== null
 
-  useLayoutEffect(() => {
+  const restoreScrollAnchor = useCallback((): void => {
     if (snapshotKey === null) {
       return
     }
@@ -153,11 +165,63 @@ export const AgentStatusPanel = ({
     programmaticScrollTopRef.current = scrollTop
     scrollContainer.scrollTop = scrollTop
     programmaticScrollTopRef.current = scrollContainer.scrollTop
+    scrollMetricsRef.current = {
+      feedEventCount: feedEventCountRef.current,
+      snapshotKey,
+      scrollHeight: scrollContainer.scrollHeight,
+      scrollTop: scrollContainer.scrollTop,
+    }
+  }, [snapshotKey])
+
+  useLayoutEffect(() => {
+    restoreScrollAnchor()
+  }, [restoreScrollAnchor])
+
+  useLayoutEffect(() => {
+    const scrollContainer = scrollContainerRef.current
+
+    if (scrollContainer === null) {
+      return
+    }
+
+    const previousMetrics = scrollMetricsRef.current
+
+    if (previousMetrics?.snapshotKey === snapshotKey) {
+      const scrollHeightDelta =
+        scrollContainer.scrollHeight - previousMetrics.scrollHeight
+
+      const activityPrepended =
+        feedEvents.length > previousMetrics.feedEventCount
+
+      if (
+        activityPrepended &&
+        scrollHeightDelta > 0 &&
+        previousMetrics.scrollTop > 0
+      ) {
+        const nextScrollTop = previousMetrics.scrollTop + scrollHeightDelta
+
+        programmaticScrollTopRef.current = nextScrollTop
+        scrollContainer.scrollTop = nextScrollTop
+        programmaticScrollTopRef.current = scrollContainer.scrollTop
+
+        if (snapshotKey !== null) {
+          writeStatusScrollAnchor(snapshotKey, scrollContainer.scrollTop)
+        }
+      }
+    }
+
+    scrollMetricsRef.current = {
+      feedEventCount: feedEvents.length,
+      snapshotKey,
+      scrollHeight: scrollContainer.scrollHeight,
+      scrollTop: scrollContainer.scrollTop,
+    }
   }, [
     snapshotKey,
-    feedEvents,
+    feedEvents.length,
     runningId,
-    effectiveFiles,
+    status.toolCalls.total,
+    effectiveFiles.length,
     effectiveLoading,
     error,
     status.testRun,
@@ -178,6 +242,15 @@ export const AgentStatusPanel = ({
       }
 
       writeStatusScrollAnchor(snapshotKey, nextScrollTop)
+
+      const currentMetrics = scrollMetricsRef.current
+      if (currentMetrics !== null) {
+        scrollMetricsRef.current = {
+          ...currentMetrics,
+          scrollHeight: event.currentTarget.scrollHeight,
+          scrollTop: nextScrollTop,
+        }
+      }
     },
     [snapshotKey]
   )
@@ -192,9 +265,14 @@ export const AgentStatusPanel = ({
     >
       <AgentStatusPanelHeader
         agent={agent}
+        isRefreshing={isRefreshing}
         status={sessionStatus}
         onCollapse={onCollapse}
       />
+
+      <span className="sr-only" role="status" aria-live="polite">
+        {isRefreshing ? 'Fetching latest agent status' : 'Agent status updated'}
+      </span>
 
       <div className="flex flex-col gap-2 p-2">
         <ContextBucket

--- a/src/features/agent-status/hooks/useAgentStatusHotLoading.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatusHotLoading.test.ts
@@ -17,10 +17,11 @@ vi.mock('../utils/statusRefreshCoordinator', async () => {
 describe('useAgentStatusHotLoading', () => {
   beforeEach(() => {
     vi.mocked(refreshVisibleAgentStatusPanes).mockClear()
+    vi.mocked(refreshVisibleAgentStatusPanes).mockResolvedValue([])
   })
 
   test('does not refresh when no visible panes are available', () => {
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useAgentStatusHotLoading({
         activePtyId: null,
         visiblePtyIds: [],
@@ -28,10 +29,11 @@ describe('useAgentStatusHotLoading', () => {
     )
 
     expect(refreshVisibleAgentStatusPanes).not.toHaveBeenCalled()
+    expect(result.current).toBe(false)
   })
 
   test('refreshes visible panes through the coordinator', async () => {
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useAgentStatusHotLoading({
         activePtyId: 'pty-b',
         visiblePtyIds: ['pty-a', 'pty-b', 'pty-a'],
@@ -44,5 +46,32 @@ describe('useAgentStatusHotLoading', () => {
         visiblePtyIds: ['pty-a', 'pty-b', 'pty-a'],
       })
     })
+
+    await waitFor(() => expect(result.current).toBe(false))
+  })
+
+  test('reports refreshing until the coordinator settles', async () => {
+    let resolveRefresh: (
+      value: Awaited<ReturnType<typeof refreshVisibleAgentStatusPanes>>
+    ) => void = () => undefined
+
+    vi.mocked(refreshVisibleAgentStatusPanes).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRefresh = resolve
+      })
+    )
+
+    const { result } = renderHook(() =>
+      useAgentStatusHotLoading({
+        activePtyId: 'pty-a',
+        visiblePtyIds: ['pty-a'],
+      })
+    )
+
+    await waitFor(() => expect(result.current).toBe(true))
+
+    resolveRefresh([])
+
+    await waitFor(() => expect(result.current).toBe(false))
   })
 })

--- a/src/features/agent-status/hooks/useAgentStatusHotLoading.ts
+++ b/src/features/agent-status/hooks/useAgentStatusHotLoading.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   refreshVisibleAgentStatusPanes,
   type VisibleStatusRefreshRequest,
@@ -12,19 +12,49 @@ interface UseAgentStatusHotLoadingOptions {
 export const useAgentStatusHotLoading = ({
   activePtyId,
   visiblePtyIds,
-}: UseAgentStatusHotLoadingOptions): void => {
+}: UseAgentStatusHotLoadingOptions): boolean => {
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const requestIdRef = useRef(0)
+
   const refreshSignature = useMemo(
     () => JSON.stringify({ activePtyId, visiblePtyIds }),
     [activePtyId, visiblePtyIds]
   )
 
   useEffect(() => {
+    requestIdRef.current += 1
+    const requestId = requestIdRef.current
     const request = JSON.parse(refreshSignature) as VisibleStatusRefreshRequest
 
     if (request.visiblePtyIds.length === 0) {
+      setIsRefreshing(false)
+
       return
     }
 
-    void refreshVisibleAgentStatusPanes(request)
+    let cancelled = false
+
+    setIsRefreshing(true)
+
+    const refresh = async (): Promise<void> => {
+      try {
+        await refreshVisibleAgentStatusPanes(request)
+      } catch {
+        // A failed warm refresh should clear the subtle header affordance; the
+        // live active-pane subscription remains the source of truth.
+      } finally {
+        if (!cancelled && requestIdRef.current === requestId) {
+          setIsRefreshing(false)
+        }
+      }
+    }
+
+    void refresh()
+
+    return (): void => {
+      cancelled = true
+    }
   }, [refreshSignature])
+
+  return isRefreshing
 }

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -138,7 +138,7 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 }))
 
 vi.mock('../agent-status/hooks/useAgentStatusHotLoading', () => ({
-  useAgentStatusHotLoading: vi.fn(),
+  useAgentStatusHotLoading: vi.fn(() => false),
 }))
 
 vi.mock('../diff/hooks/useGitStatus', () => ({
@@ -174,8 +174,11 @@ vi.mock('../../hooks/useElasticContainer', () => ({
   })),
 }))
 
-const capturedPanelProps: { agentStatus?: AgentStatus; gitStatus?: unknown } =
-  {}
+const capturedPanelProps: {
+  agentStatus?: AgentStatus
+  gitStatus?: unknown
+  isRefreshing?: boolean
+} = {}
 
 const capturedDockPanelProps: {
   gitStatus?: unknown
@@ -186,6 +189,7 @@ const capturedDockPanelProps: {
 interface MockPanelProps {
   agentStatus?: AgentStatus
   gitStatus?: unknown
+  isRefreshing?: boolean
 }
 
 interface MockDockPanelProps {
@@ -230,9 +234,11 @@ vi.mock('../agent-status/components/AgentStatusPanel', () => ({
   AgentStatusPanel: ({
     agentStatus = undefined,
     gitStatus = undefined,
+    isRefreshing = undefined,
   }: MockPanelProps): ReactElement => {
     capturedPanelProps.agentStatus = agentStatus
     capturedPanelProps.gitStatus = gitStatus
+    capturedPanelProps.isRefreshing = isRefreshing
 
     return <div data-testid="agent-status-panel-mock" />
   },
@@ -281,6 +287,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
   beforeEach(() => {
     capturedPanelProps.agentStatus = undefined
     capturedPanelProps.gitStatus = undefined
+    capturedPanelProps.isRefreshing = undefined
     capturedDockPanelProps.gitStatus = undefined
     capturedCardProps.title = undefined
     capturedDockPanelProps.feedbackBatch = undefined
@@ -293,6 +300,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
     // computed `enabled: false`.
     vi.mocked(useAgentStatus).mockClear()
     vi.mocked(useAgentStatusHotLoading).mockClear()
+    vi.mocked(useAgentStatusHotLoading).mockReturnValue(false)
     vi.mocked(useGitStatus).mockClear()
   })
 
@@ -315,6 +323,16 @@ describe('WorkspaceView lifted-subscription contract', () => {
       activePtyId: 'sess-1',
       visiblePtyIds: ['sess-1'],
     })
+  })
+
+  test('AgentStatusPanel receives the hot-loading refresh phase', async () => {
+    vi.mocked(useAgentStatusHotLoading).mockReturnValue(true)
+
+    render(<WorkspaceView />)
+
+    await screen.findByTestId('agent-status-panel-mock')
+
+    expect(capturedPanelProps.isRefreshing).toBe(true)
   })
 
   test('AgentStatusCard and AgentStatusPanel both render from the single useAgentStatus subscription', async () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -525,7 +525,7 @@ export const WorkspaceView = (): ReactElement => {
     [activeSession]
   )
 
-  useAgentStatusHotLoading({
+  const isAgentStatusRefreshing = useAgentStatusHotLoading({
     activePtyId: activePtyBackedPanePtyId ?? null,
     visiblePtyIds: visibleAgentStatusPtyIds,
   })
@@ -2325,6 +2325,7 @@ export const WorkspaceView = (): ReactElement => {
               cacheHistory={activePtyBackedPane?.cacheHistory ?? []}
               cwd={activeCwd}
               gitStatus={gitStatus}
+              isRefreshing={isAgentStatusRefreshing}
               onOpenDiff={handleOpenDiff}
               onOpenFile={handleOpenTestFile}
               agent={activityPanelAgent}

--- a/src/index.css
+++ b/src/index.css
@@ -280,6 +280,7 @@
     color-mix(in srgb, var(--color-primary-container) 58%, transparent),
     transparent
   );
+  transform: translateX(-100%);
   animation: vfActivityRefreshComet 1.4s ease-in-out infinite;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -251,6 +251,49 @@
   }
 }
 
+/* Activity panel refresh affordance. The sweep rides inside the header
+   divider so refresh state never changes layout height. */
+@keyframes vfActivityRefreshComet {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(240%);
+  }
+}
+
+@keyframes vfActivityGlyphBreathe {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 0%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 22%, transparent);
+  }
+}
+
+.vf-activity-refresh-comet {
+  width: 45%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--color-primary-container) 58%, transparent),
+    transparent
+  );
+  animation: vfActivityRefreshComet 1.4s ease-in-out infinite;
+}
+
+.vf-activity-glyph-refresh {
+  animation: vfActivityGlyphBreathe 1.8s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vf-activity-refresh-comet,
+  .vf-activity-glyph-refresh {
+    animation: none;
+  }
+}
+
 /* Diff viewer styling */
 .diff-added {
   background-color: var(--color-diff-added);


### PR DESCRIPTION
## Summary

- Adds a bounded refresh phase from `useAgentStatusHotLoading` and forwards it into the right activity panel.
- Keeps the activity panel body mounted during refresh and shows only a compact fixed-height header affordance.
- Restores pane scroll anchors only on pane-key changes and preserves the visual anchor when new activity rows prepend above a scrolled history viewport.
- Updates the PR4 spec with the implemented rendering-stability behavior.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `npm run test`
- Focused Vitest coverage for hot-loading refresh state, header affordance, scroll-anchor retention, lower-section growth, and WorkspaceView prop forwarding.

## Review Notes

Local Claude Code review was attempted repeatedly, including broad diff, pasted diff, and a 2.5 KB scroll-snippet prompt. The CLI smoke prompt returned `ok`, but every review prompt hung without returning a verdict and had to be terminated. Deterministic repo checks are green; remote Claude/GitHub review should still run on the PR.

## PR4 Boundary

Cold-load skeletons from the design handoff remain deferred until the data flow exposes a reliable no-snapshot signal. This PR focuses on the common refresh path: retained content, header-only refresh state, and stable scroll behavior.
