### PR TITLE
refactor(terminal): extract renderer abstraction around xterm

### DIFF
--- a/docs/explorations/ghostty-xterm-replacement-investigation.html
+++ b/docs/explorations/ghostty-xterm-replacement-investigation.html
@@ -1,0 +1,1060 @@
+<!doctype html>
+<!--
+  ========================================================================
+  REVIEW NOTE - for human and agent (Codex / Claude) reviewers
+  ========================================================================
+  This file is a STATIC, hand-authored exploration document. It holds no
+  application logic, no runtime imports, no external scripts, and no tests.
+  It is documentation: prose, inline CSS, and simple HTML diagrams only.
+
+  Please do not line-by-line review CSS/markup nits or treat it as part of
+  the app behavioral surface. To verify it, open it in a browser and confirm
+  that it renders. docs/explorations/*.html is Prettier-ignored.
+  ========================================================================
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Replacing xterm.js with Ghostty - Vimeflow Technical Investigation</title>
+    <style>
+      :root {
+        --base: #121221;
+        --mantle: #181825;
+        --surface: #1e1e2e;
+        --surface-high: #292839;
+        --surface-higher: #333344;
+        --text: #e3e0f7;
+        --muted: #a6adc8;
+        --faint: #7f849c;
+        --line: rgba(186, 194, 222, 0.18);
+        --green: #a6e3a1;
+        --yellow: #f9e2af;
+        --blue: #89b4fa;
+        --sapphire: #74c7ec;
+        --red: #f38ba8;
+        --peach: #fab387;
+        --mauve: #cba6f7;
+        --lavender: #b4befe;
+        --teal: #94e2d5;
+        --shadow: 0 22px 70px rgba(0, 0, 0, 0.36);
+        --font-body: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+        --font-display: "Manrope", "Inter", system-ui, -apple-system, sans-serif;
+        --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        margin: 0;
+        background:
+          radial-gradient(
+            1200px 700px at 82% -14%,
+            rgba(116, 199, 236, 0.12),
+            transparent 62%
+          ),
+          radial-gradient(
+            900px 640px at -12% 12%,
+            rgba(203, 166, 247, 0.1),
+            transparent 58%
+          ),
+          linear-gradient(180deg, var(--mantle), var(--base) 42%, #0d0d18);
+        color: var(--text);
+        font-family: var(--font-body);
+        line-height: 1.62;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      a {
+        color: var(--sapphire);
+        text-decoration: none;
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+
+      code {
+        border-radius: 6px;
+        background: rgba(13, 13, 24, 0.78);
+        color: var(--lavender);
+        font-family: var(--font-mono);
+        font-size: 0.9em;
+        padding: 1px 6px;
+      }
+
+      .wrap {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 58px 28px 100px;
+      }
+
+      .masthead {
+        display: grid;
+        grid-template-columns: 1.15fr 0.85fr;
+        gap: 30px;
+        align-items: end;
+        border-bottom: 1px solid var(--line);
+        padding-bottom: 34px;
+        margin-bottom: 40px;
+      }
+
+      .eyebrow {
+        color: var(--teal);
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        letter-spacing: 0.2em;
+        margin: 0 0 12px;
+        text-transform: uppercase;
+      }
+
+      h1,
+      h2,
+      h3 {
+        font-family: var(--font-display);
+        letter-spacing: -0.015em;
+        line-height: 1.12;
+      }
+
+      h1 {
+        font-size: clamp(2.2rem, 4.8vw, 4.4rem);
+        margin: 0 0 16px;
+      }
+
+      .dek {
+        color: var(--muted);
+        font-size: 1.08rem;
+        max-width: 72ch;
+        margin: 0;
+      }
+
+      .meta {
+        display: grid;
+        gap: 8px;
+      }
+
+      .chip {
+        align-items: center;
+        background: rgba(41, 40, 57, 0.72);
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        color: var(--muted);
+        display: inline-flex;
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        gap: 6px;
+        padding: 7px 12px;
+        width: fit-content;
+      }
+
+      .chip strong {
+        color: var(--text);
+        font-weight: 650;
+      }
+
+      .verdict {
+        background:
+          linear-gradient(
+            135deg,
+            rgba(166, 227, 161, 0.14),
+            rgba(137, 180, 250, 0.07)
+          ),
+          rgba(30, 30, 46, 0.78);
+        border: 1px solid rgba(166, 227, 161, 0.24);
+        border-radius: 16px;
+        box-shadow: var(--shadow);
+        margin: 0 0 36px;
+        padding: 24px;
+      }
+
+      .verdict h2 {
+        color: var(--green);
+        font-size: 1.15rem;
+        margin: 0 0 8px;
+      }
+
+      .verdict p {
+        color: var(--muted);
+        margin: 8px 0 0;
+      }
+
+      .toc {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 9px;
+        margin: 0 0 44px;
+      }
+
+      .toc a {
+        background: rgba(41, 40, 57, 0.74);
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        color: var(--muted);
+        font-family: var(--font-mono);
+        font-size: 0.73rem;
+        padding: 7px 12px;
+      }
+
+      section {
+        margin: 0 0 54px;
+      }
+
+      h2 {
+        align-items: baseline;
+        color: var(--text);
+        display: flex;
+        font-size: 1.65rem;
+        gap: 12px;
+        margin: 0 0 8px;
+        scroll-margin-top: 18px;
+      }
+
+      h2 .num {
+        color: var(--mauve);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+      }
+
+      h3 {
+        color: var(--text);
+        font-size: 1.05rem;
+        margin: 26px 0 8px;
+      }
+
+      p {
+        color: var(--muted);
+        margin: 8px 0;
+      }
+
+      .grid {
+        display: grid;
+        gap: 14px;
+      }
+
+      .grid.cols-2 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .grid.cols-3 {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+
+      .card {
+        background: rgba(30, 30, 46, 0.78);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 18px;
+      }
+
+      .card h3 {
+        margin-top: 0;
+      }
+
+      .card p:last-child,
+      .card ul:last-child {
+        margin-bottom: 0;
+      }
+
+      .tag {
+        border-radius: 999px;
+        display: inline-flex;
+        font-family: var(--font-mono);
+        font-size: 0.68rem;
+        margin-bottom: 10px;
+        padding: 4px 9px;
+      }
+
+      .tag.good {
+        background: rgba(166, 227, 161, 0.13);
+        color: var(--green);
+      }
+
+      .tag.warn {
+        background: rgba(249, 226, 175, 0.13);
+        color: var(--yellow);
+      }
+
+      .tag.bad {
+        background: rgba(243, 139, 168, 0.12);
+        color: var(--red);
+      }
+
+      .tag.info {
+        background: rgba(116, 199, 236, 0.12);
+        color: var(--sapphire);
+      }
+
+      ul {
+        color: var(--muted);
+        margin: 8px 0;
+        padding-left: 20px;
+      }
+
+      li {
+        margin: 5px 0;
+      }
+
+      table {
+        border-collapse: collapse;
+        margin: 16px 0 0;
+        width: 100%;
+      }
+
+      th,
+      td {
+        border-bottom: 1px solid var(--line);
+        color: var(--muted);
+        padding: 11px 10px;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        color: var(--text);
+        font-family: var(--font-mono);
+        font-size: 0.73rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      tr:last-child td {
+        border-bottom: 0;
+      }
+
+      .matrix td:first-child,
+      .matrix th:first-child {
+        width: 22%;
+      }
+
+      .flow {
+        background: rgba(13, 13, 24, 0.72);
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        display: grid;
+        gap: 12px;
+        grid-template-columns: 1fr auto 1fr auto 1fr;
+        margin-top: 18px;
+        padding: 18px;
+      }
+
+      .node {
+        background: rgba(41, 40, 57, 0.8);
+        border: 1px solid rgba(186, 194, 222, 0.18);
+        border-radius: 12px;
+        min-height: 88px;
+        padding: 14px;
+      }
+
+      .node strong {
+        color: var(--text);
+        display: block;
+        font-size: 0.95rem;
+        margin-bottom: 5px;
+      }
+
+      .node span {
+        color: var(--muted);
+        font-size: 0.85rem;
+      }
+
+      .arrow {
+        align-self: center;
+        color: var(--faint);
+        font-family: var(--font-mono);
+        font-size: 1rem;
+      }
+
+      .callout {
+        border-left: 3px solid var(--peach);
+        background: rgba(250, 179, 135, 0.08);
+        border-radius: 12px;
+        margin: 16px 0 0;
+        padding: 14px 16px;
+      }
+
+      .callout strong {
+        color: var(--peach);
+      }
+
+      .source-list {
+        display: grid;
+        gap: 10px;
+        margin-top: 16px;
+      }
+
+      .source-list a {
+        background: rgba(41, 40, 57, 0.62);
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        color: var(--muted);
+        display: block;
+        padding: 12px 14px;
+      }
+
+      .source-list strong {
+        color: var(--text);
+      }
+
+      .footnote {
+        color: var(--faint);
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+      }
+
+      @media (max-width: 820px) {
+        .masthead,
+        .grid.cols-2,
+        .grid.cols-3,
+        .flow {
+          grid-template-columns: 1fr;
+        }
+
+        .arrow {
+          display: none;
+        }
+
+        .wrap {
+          padding: 38px 18px 78px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="wrap">
+      <header class="masthead">
+        <div>
+          <p class="eyebrow">Vimeflow terminal architecture</p>
+          <h1>Replacing xterm.js with Ghostty</h1>
+          <p class="dek">
+            A technical investigation into whether Vimeflow should replace its
+            current browser terminal renderer with Ghostty, what would actually
+            have to change, and where the upside is real.
+          </p>
+        </div>
+        <div class="meta">
+          <span class="chip"><strong>Date</strong> 2026-06-15</span>
+          <span class="chip"><strong>Worktree</strong> docs/ghostty-terminal-investigation</span>
+          <span class="chip"><strong>Scope</strong> research note, no runtime changes</span>
+        </div>
+      </header>
+
+      <aside class="verdict" id="verdict">
+        <h2>Recommendation</h2>
+        <p>
+          Do not attempt a direct "swap xterm for Ghostty" inside the current
+          React terminal pane. Ghostty is not a drop-in web component, and
+          Vimeflow currently depends on many xterm.js browser APIs beyond text
+          rendering.
+        </p>
+        <p>
+          The credible path is a staged R&amp;D track: keep xterm.js as the
+          production pane, introduce a terminal-renderer adapter boundary, and
+          prototype <code>libghostty-vt</code> as a parser/state engine with raw
+          PTY bytes. Revisit a full replacement only after the API, renderer
+          story, packaging, and test harness prove out.
+        </p>
+      </aside>
+
+      <nav class="toc" aria-label="Table of contents">
+        <a href="#current">Current xterm contract</a>
+        <a href="#ghostty">What Ghostty offers</a>
+        <a href="#options">Integration options</a>
+        <a href="#implications">Implications</a>
+        <a href="#plan">Suggested plan</a>
+        <a href="#sources">Sources</a>
+      </nav>
+
+      <section id="current">
+        <h2><span class="num">01</span> Current xterm Contract</h2>
+        <p>
+          Vimeflow's terminal pane is not a thin "bytes in, pixels out" wrapper.
+          It uses xterm.js as a browser-native terminal emulator, parser, input
+          bridge, selection model, fit engine, and rendering surface.
+        </p>
+
+        <div class="flow" aria-label="Current terminal flow">
+          <div class="node">
+            <strong>Rust sidecar</strong>
+            <span>
+              <code>portable-pty</code>, ring buffer, byte offsets, IPC events,
+              session cache, burner foreground polling.
+            </span>
+          </div>
+          <div class="arrow">-&gt;</div>
+          <div class="node">
+            <strong>Terminal service</strong>
+            <span>
+              <code>spawn_pty</code>, <code>write_pty</code>,
+              <code>resize_pty</code>, <code>pty-data</code>,
+              <code>pty-exit</code>, <code>pty-error</code>.
+            </span>
+          </div>
+          <div class="arrow">-&gt;</div>
+          <div class="node">
+            <strong>xterm.js pane</strong>
+            <span>
+              Parser, buffer, WebGL/Canvas/DOM renderer, selection, keyboard
+              input, OSC 7 cwd, fit-to-grid.
+            </span>
+          </div>
+        </div>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Vimeflow surface</th>
+              <th>Current xterm dependency</th>
+              <th>Replacement consequence</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>TerminalPane/Body.tsx</code></td>
+              <td>
+                Creates <code>new Terminal()</code>, loads
+                <code>FitAddon</code>, tries WebGL, falls back to Canvas, then
+                DOM rendering.
+              </td>
+              <td>
+                A new engine must expose an equivalent lifecycle, dispose path,
+                renderer fallback story, and host element contract.
+              </td>
+            </tr>
+            <tr>
+              <td>Resize and layout</td>
+              <td>
+                <code>FitAddon.fit()</code> calculates columns and rows from a
+                hidden-or-visible browser container. <code>onResize</code>
+                forwards dimensions to the PTY.
+              </td>
+              <td>
+                Ghostty integration must own cell measurement, font loading,
+                hidden-pane behavior, and PTY resize dedupe.
+              </td>
+            </tr>
+            <tr>
+              <td>cwd tracking</td>
+              <td>
+                <code>terminal.parser.registerOscHandler(7)</code> parses OSC 7
+                from shell prompts and agent output.
+              </td>
+              <td>
+                Need an effect/callback path for OSC, plus stale-restore
+                suppression and the existing text-hint fallback.
+              </td>
+            </tr>
+            <tr>
+              <td>Restore and replay</td>
+              <td>
+                <code>Terminal.write(data, callback)</code> sequences historical
+                replay, buffered events, and live writes through cursor dedupe.
+              </td>
+              <td>
+                A Ghostty path should consume raw bytes, maintain equivalent
+                replay cursors, and provide a "processed" callback or event.
+              </td>
+            </tr>
+            <tr>
+              <td>Clipboard and selection</td>
+              <td>
+                <code>hasSelection()</code>, <code>getSelection()</code>,
+                <code>paste()</code>, <code>selectAll()</code>, and
+                <code>attachCustomKeyEventHandler()</code>.
+              </td>
+              <td>
+                Selection, copy-on-selection, context menu, and paste safety
+                must be rebuilt or bridged through libghostty selection APIs.
+              </td>
+            </tr>
+            <tr>
+              <td>Burner terminals</td>
+              <td>
+                Hidden xterm <code>Body</code> instances stay mounted so hide
+                does not lose scrollback or detach from live PTY output.
+              </td>
+              <td>
+                Replacement must support cheap hidden instances or introduce a
+                real snapshot API for remounting.
+              </td>
+            </tr>
+            <tr>
+              <td>Production build</td>
+              <td>
+                Vite uses Terser because esbuild mangles an xterm 6.0.0 pattern.
+              </td>
+              <td>
+                Removing xterm could delete that workaround, but any native or
+                WASM Ghostty path introduces its own build/packaging risks.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="callout">
+          <strong>Important low-level mismatch:</strong> Vimeflow currently
+          emits PTY output as lossy UTF-8 strings plus byte offsets. xterm.js can
+          accept strings or <code>Uint8Array</code>, and its decoder is stream
+          aware for byte input. <code>libghostty-vt</code> expects VT bytes, so
+          a serious prototype should add a raw-byte IPC path or a stream-aware
+          decode layer before changing the visible pane.
+        </div>
+      </section>
+
+      <section id="ghostty">
+        <h2><span class="num">02</span> What Ghostty Offers</h2>
+        <p>
+          Ghostty should be treated as three related but different things:
+          the standalone app, the emerging embeddable library family, and the
+          future full-renderer/widget story. Only the library path is relevant
+          to Vimeflow's integrated React workspace.
+        </p>
+
+        <div class="grid cols-3">
+          <article class="card">
+            <span class="tag info">Standalone app</span>
+            <h3>Fast native terminal</h3>
+            <p>
+              Ghostty is a native terminal emulator for macOS and Linux, using
+              Metal on macOS and OpenGL on Linux. Its own GUI has windows, tabs,
+              splits, native platform integration, and a separate terminfo entry.
+            </p>
+            <p>
+              This is excellent for end users, but it is not a React component
+              that can replace <code>&lt;Body /&gt;</code>.
+            </p>
+          </article>
+          <article class="card">
+            <span class="tag good">Plausible R&amp;D path</span>
+            <h3><code>libghostty-vt</code></h3>
+            <p>
+              The current library exposes terminal state, VT stream processing,
+              scrollback, reflow on resize, render-state snapshots, formatter
+              APIs, key encoding, mouse encoding, paste utilities, and WASM
+              helpers.
+            </p>
+            <p>
+              This is the most interesting direction for Vimeflow, but its API
+              is explicitly unstable.
+            </p>
+          </article>
+          <article class="card">
+            <span class="tag warn">Future path</span>
+            <h3>Renderer/widgets</h3>
+            <p>
+              Ghostty's roadmap mentions later libraries for input handling,
+              GPU rendering, GTK widgets, Swift frameworks, and full terminal
+              views.
+            </p>
+            <p>
+              Those would matter for a native embedded pane, but they are not
+              the low-risk path today.
+            </p>
+          </article>
+        </div>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Ghostty capability</th>
+              <th>Potential Vimeflow value</th>
+              <th>Current caveat</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Parser and terminal state</td>
+              <td>
+                More native-grade VT behavior, reflow, scrollback, state queries,
+                and modern protocol coverage.
+              </td>
+              <td>
+                Requires raw bytes and a new adapter boundary. The C API is new
+                and breaking changes are expected.
+              </td>
+            </tr>
+            <tr>
+              <td>Render state API</td>
+              <td>
+                Could drive a custom canvas/WebGL/DOM renderer with dirty-region
+                updates rather than relying on xterm's renderer.
+              </td>
+              <td>
+                Vimeflow would own the renderer, selection painting, IME details,
+                accessibility, and performance tuning.
+              </td>
+            </tr>
+            <tr>
+              <td>Formatter to plain/VT/HTML</td>
+              <td>
+                Useful for transcript capture, copy/export, debug snapshots, and
+                test fixtures even without replacing the live pane.
+              </td>
+              <td>
+                Not a replacement for interactive rendering.
+              </td>
+            </tr>
+            <tr>
+              <td>Key and mouse encoding</td>
+              <td>
+                Could reduce hand-rolled keyboard/mouse protocol code, including
+                Kitty keyboard and mouse modes.
+              </td>
+              <td>
+                Needs full DOM input mapping, IME handling, platform shortcuts,
+                and focus integration.
+              </td>
+            </tr>
+            <tr>
+              <td><code>xterm-ghostty</code> terminfo</td>
+              <td>
+                More accurate feature advertising if Vimeflow truly behaves like
+                Ghostty.
+              </td>
+              <td>
+                Do not set <code>TERM=xterm-ghostty</code> while xterm.js still
+                renders the pane. Current backend honestly advertises
+                <code>xterm-256color</code>.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="options">
+        <h2><span class="num">03</span> Integration Options</h2>
+
+        <table class="matrix">
+          <thead>
+            <tr>
+              <th>Option</th>
+              <th>Pros</th>
+              <th>Cons</th>
+              <th>Fit for Vimeflow</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <strong>Keep xterm.js</strong><br />
+                production baseline
+              </td>
+              <td>
+                Minimal risk, existing tests remain valid, browser integration is
+                already solved, current UX surfaces keep working.
+              </td>
+              <td>
+                Keeps known browser renderer limitations and xterm-specific
+                workarounds.
+              </td>
+              <td>
+                Best default while the UI handoff migration is still active.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <strong>Use <code>libghostty-vt</code> as a companion</strong><br />
+                parser/state experiments
+              </td>
+              <td>
+                Lets Vimeflow evaluate correctness, raw-byte handling, HTML
+                snapshots, and state extraction without disrupting the live pane.
+              </td>
+              <td>
+                Requires a native/WASM build path and a stable adapter contract.
+              </td>
+              <td>
+                Strongest near-term R&amp;D option.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <strong>Replace renderer with libghostty-vt plus custom UI</strong><br />
+                canvas/WebGL/DOM renderer
+              </td>
+              <td>
+                Could remove xterm renderer quirks while keeping the React shell
+                and Vimeflow pane UX.
+              </td>
+              <td>
+                Vimeflow owns rendering, selection, accessibility, IME, scroll,
+                dirty-region painting, and test fixtures.
+              </td>
+              <td>
+                Feasible only as a major platform project.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <strong>Embed native Ghostty renderer/widget</strong><br />
+                AppKit/GTK/Metal/OpenGL
+              </td>
+              <td>
+                Maximum performance and closest to Ghostty's native experience.
+              </td>
+              <td>
+                Electron composes web views through <code>View</code> and
+                <code>WebContentsView</code>, not arbitrary AppKit/GTK terminal
+                widgets. Overlay, focus, z-order, accessibility, and packaging
+                become platform-specific.
+              </td>
+              <td>
+                Not a good match for the current Electron/React architecture.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <strong>Launch Ghostty externally</strong><br />
+                separate app/window
+              </td>
+              <td>
+                Quickest way to let a user run a Ghostty terminal at a workspace
+                cwd.
+              </td>
+              <td>
+                Loses integrated panes, agent observability, PTY replay, burner
+                lifecycle, command palette focus, and session persistence.
+              </td>
+              <td>
+                Useful as an "open in external terminal" feature, not as a
+                replacement.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="implications">
+        <h2><span class="num">04</span> Implications</h2>
+
+        <div class="grid cols-2">
+          <article class="card">
+            <span class="tag bad">High risk</span>
+            <h3>Frontend contract churn</h3>
+            <ul>
+              <li>Define a <code>TerminalViewAdapter</code> before any swap.</li>
+              <li>Move xterm-specific calls behind adapter methods.</li>
+              <li>
+                Preserve <code>focusTerminal</code>, selection, copy/paste,
+                context menu, hidden-pane fit, and OSC cwd callbacks.
+              </li>
+              <li>
+                Rework tests that currently mock <code>Terminal</code>,
+                <code>FitAddon</code>, <code>WebglAddon</code>, and
+                <code>CanvasAddon</code>.
+              </li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="tag warn">Medium risk</span>
+            <h3>Backend byte semantics</h3>
+            <ul>
+              <li>
+                Replace lossy UTF-8 replay with stream-aware raw bytes or a
+                lossless byte transport.
+              </li>
+              <li>
+                Keep raw byte offsets as the source of replay dedupe truth.
+              </li>
+              <li>
+                Decide whether the renderer, sidecar, or both own terminal state.
+              </li>
+              <li>
+                Avoid setting <code>TERM=xterm-ghostty</code> until the behavior
+                actually matches Ghostty.
+              </li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="tag warn">Medium risk</span>
+            <h3>Packaging and portability</h3>
+            <ul>
+              <li>Build Zig/C artifacts or WASM alongside the Rust sidecar.</li>
+              <li>Bundle artifacts for macOS and Linux in Electron Builder.</li>
+              <li>Plan for Windows separately: Ghostty GUI Windows support is not the current stable target.</li>
+              <li>Track ABI/API churn because <code>libghostty-vt</code> is not stable.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="tag good">Upside</span>
+            <h3>Where the payoff could be real</h3>
+            <ul>
+              <li>Better VT correctness and modern protocol support.</li>
+              <li>Cleaner terminal-state snapshots for restore, export, and testing.</li>
+              <li>Potentially fewer browser renderer workarounds in the long run.</li>
+              <li>Shared state engine for terminal, logs, transcripts, and agent-status parsing.</li>
+            </ul>
+          </article>
+        </div>
+
+        <div class="callout">
+          <strong>Architecture warning:</strong> Vimeflow's sidecar is already
+          the PTY owner. Replacing xterm with Ghostty should not move PTY
+          lifecycle ownership into a second terminal app process. Keep the
+          sidecar as the process/session authority and evaluate Ghostty as an
+          emulator/rendering component only.
+        </div>
+      </section>
+
+      <section id="plan">
+        <h2><span class="num">05</span> Suggested Plan</h2>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Stage</th>
+              <th>Goal</th>
+              <th>Exit criteria</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>0. Baseline</strong></td>
+              <td>
+                Keep xterm production behavior. Add no user-facing Ghostty
+                dependency.
+              </td>
+              <td>
+                Document current xterm contracts and test fixtures. Fix the
+                deferred backend UTF-8 chunk-boundary issue independently.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>1. Adapter seam</strong></td>
+              <td>
+                Introduce an internal adapter around xterm without changing
+                behavior.
+              </td>
+              <td>
+                Existing terminal, burner, restore, clipboard, and resize tests
+                pass with xterm behind the adapter.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>2. Raw byte path</strong></td>
+              <td>
+                Preserve PTY bytes losslessly to the renderer or to a terminal
+                state engine.
+              </td>
+              <td>
+                Replay offsets remain correct for split multibyte sequences,
+                invalid UTF-8, and large agent output.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>3. Headless Ghostty prototype</strong></td>
+              <td>
+                Feed the same PTY stream into <code>libghostty-vt</code> in a
+                hidden/dev-only path.
+              </td>
+              <td>
+                Compare cursor position, scrollback, title/OSC effects, HTML
+                formatter output, resize reflow, and keyboard/mouse encoders.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>4. Visual prototype</strong></td>
+              <td>
+                Build a single-pane proof of concept using render-state snapshots
+                and a Vimeflow-owned renderer.
+              </td>
+              <td>
+                Handles nvim, tmux, Claude/Codex output, selection/copy, paste,
+                hidden/reveal, focus restore, and resize without regressions.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>5. Decision record</strong></td>
+              <td>
+                Decide whether Ghostty should replace xterm, augment it, or stay
+                external.
+              </td>
+              <td>
+                Quantified performance/correctness data, packaging plan, and a
+                rollback strategy.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="sources">
+        <h2><span class="num">06</span> Sources</h2>
+        <p>
+          Sources were checked during this investigation on 2026-06-15. External
+          links prefer official project documentation and repository material.
+        </p>
+
+        <div class="source-list">
+          <a href="https://github.com/ghostty-org/ghostty">
+            <strong>Ghostty GitHub README</strong> - project status,
+            architecture, roadmap, <code>libghostty</code>, and performance notes.
+          </a>
+          <a href="https://ghostty.org/docs/about">
+            <strong>About Ghostty</strong> - native app architecture and
+            <code>libghostty</code> overview.
+          </a>
+          <a href="https://ghostty.org/docs/features">
+            <strong>Ghostty features</strong> - platform support, GPU rendering,
+            modern terminal features, and xterm compatibility stance.
+          </a>
+          <a href="https://ghostty.org/docs/help/terminfo">
+            <strong>Ghostty terminfo</strong> - <code>xterm-ghostty</code> TERM
+            behavior and compatibility rationale.
+          </a>
+          <a href="https://libghostty.tip.ghostty.org/">
+            <strong>libghostty-vt API reference</strong> - terminal state,
+            render state, formatter, key/mouse encoders, paste utilities, and
+            instability warning.
+          </a>
+          <a href="https://mitchellh.com/writing/libghostty-is-coming">
+            <strong>Libghostty Is Coming</strong> - roadmap context for
+            <code>libghostty-vt</code>, later renderer/input/widget libraries,
+            and API maturity.
+          </a>
+          <a href="https://github.com/xtermjs/xterm.js/">
+            <strong>xterm.js README</strong> - browser terminal component,
+            addons, PTY hookup model, Electron support, and feature set.
+          </a>
+          <a href="https://xtermjs.org/docs/api/terminal/classes/terminal/">
+            <strong>xterm.js Terminal API</strong> - <code>onData</code>,
+            <code>onResize</code>, parser, selection, paste, write callbacks,
+            and refresh APIs.
+          </a>
+          <a href="https://xtermjs.org/docs/guides/encoding/">
+            <strong>xterm.js encoding guide</strong> - string vs
+            <code>Uint8Array</code> input and stream-aware UTF-8 decoding.
+          </a>
+          <a href="https://www.electronjs.org/docs/latest/api/base-window">
+            <strong>Electron BaseWindow</strong> - multi-view composition through
+            Electron web views.
+          </a>
+          <a href="https://www.electronjs.org/docs/latest/api/web-contents-view">
+            <strong>Electron WebContentsView</strong> - the supported embedded
+            web-content view model.
+          </a>
+        </div>
+
+        <p class="footnote">
+          Local Vimeflow files reviewed include
+          <code>src/features/terminal/components/TerminalPane/Body.tsx</code>,
+          <code>src/features/terminal/hooks/useTerminal.ts</code>,
+          <code>src/features/terminal/hooks/useTerminalClipboard.ts</code>,
+          <code>src/features/terminal/hooks/useBurnerTerminals.ts</code>,
+          <code>src/features/terminal/services/desktopTerminalService.ts</code>,
+          <code>crates/backend/src/terminal/commands.rs</code>,
+          <code>crates/backend/src/terminal/state.rs</code>,
+          <code>vite.config.ts</code>, and the existing terminal decision docs.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/explorations/terminal-renderer-abstraction-retrospective.md
+++ b/docs/explorations/terminal-renderer-abstraction-retrospective.md
@@ -1,0 +1,157 @@
+# Terminal Renderer Abstraction Retrospective
+
+Date: 2026-06-15
+
+Worktree: `/Users/winoooops/projects/vimeflow/worktrees/ghostty-terminal-investigation`
+
+## Current Status
+
+The terminal UI now has a renderer abstraction boundary in front of xterm.
+Application code uses `TerminalInstance`, `TerminalSurface`,
+`TerminalParser`, `TerminalViewportReader`, and `TerminalFitController`.
+
+The xterm-specific details are concentrated in:
+
+- `src/features/terminal/components/TerminalPane/xtermInstance.ts`
+- adapter-oriented tests that mock `@xterm/*`
+
+The implementation passed:
+
+- `npx eslint ...`
+- focused `npx vitest run ...`
+- `npx tsc -b --pretty false`
+
+There are no current compile or test blockers from the abstraction work.
+
+## What Changed
+
+### 1. xterm Imports Are Guarded
+
+`eslint.config.js` now blocks production imports from `@xterm/*` outside the
+xterm adapter. This prevents new app logic from binding directly to xterm.
+
+Tests and `src/test/**` remain excluded because they still use mocks and global
+setup.
+
+### 2. TerminalSurface Was Trimmed
+
+The first abstraction pass placed OSC parsing and viewport text reads on
+`TerminalSurface`. That was too xterm-shaped.
+
+The second pass split the contract:
+
+- `TerminalSurface`: visual terminal lifecycle, focus, writes, resize, selection,
+  clipboard, key handling, theme application
+- `TerminalParser`: terminal control-sequence hooks such as OSC handlers
+- `TerminalViewportReader`: visible text extraction for automation and diagnostics
+- `TerminalFitController`: container fit behavior
+- `TerminalRendererHandle`: adapter-owned renderer cleanup
+
+This is a better split because parser and buffer access are not inherently the
+same responsibility as rendering.
+
+### 3. E2E Bridge Had Hidden xterm Coupling
+
+`src/lib/e2e-bridge.ts` previously read `terminal.buffer.active` directly from
+xterm when canvas/WebGL left `.xterm-rows` empty.
+
+That was a real coupling leak. It now calls
+`entry.viewportReader.readVisibleText()` instead. The xterm adapter implements
+that by walking xterm's active buffer; a future adapter can provide its own
+viewport reader without changing E2E code.
+
+### 4. Body Can Run Against a Non-xterm Contract
+
+`Body.fake-terminal.test.tsx` proves `Body` can mount, register OSC 7, pass the
+surface to `useTerminal`, emit cwd changes, and clean up using a fake
+`TerminalInstance` with no xterm imports.
+
+This is the strongest proof so far that the boundary is not just a type alias
+over xterm.
+
+## Findings
+
+### App Logic Was Cleaner Than Tests
+
+The runtime code could be moved behind the interface fairly directly. The tests
+were more tightly coupled to xterm constructors and addon behavior.
+
+This is not necessarily bad: xterm adapter behavior still needs direct tests.
+But Body-level tests should gradually move away from asserting xterm constructor
+details. Those assertions now belong in `xtermInstance.test.ts`.
+
+### OSC 7 Is a Parser Concern, Not a Renderer Concern
+
+The cwd tracking logic depends on terminal control sequence parsing, not on
+visual rendering. Treating it as `TerminalParser` makes the next adapter design
+clearer.
+
+For a Ghostty/libghostty-vt path, this is important because the parser may be
+native/Rust-owned while the visual surface may be DOM/canvas/WebView-owned.
+
+### String-based PTY Data Is Still a Future Constraint
+
+The frontend still works with string chunks. That is fine for xterm's current
+integration, but a Ghostty parser path may want raw bytes to preserve encoding
+and control sequence fidelity.
+
+This is not a blocker for the abstraction PR, but it is likely a future design
+decision before a serious Ghostty prototype.
+
+### Theme Shape Is Still xterm-biased Internally
+
+The app-level bridge now sends `TerminalTheme` to the terminal surface. The xterm
+adapter converts it with `toXtermTheme`.
+
+This is acceptable. A future adapter can map the same project-level theme to its
+own palette format.
+
+### Renderer Fallback Logic Is Adapter-owned Now
+
+WebGL, Canvas2D, DOM fallback, and WebGL context-loss behavior are no longer in
+`Body`. That is the right ownership boundary. `Body` should not know whether the
+adapter uses WebGL, a native view, a canvas, or something else.
+
+## Current Blockers
+
+No hard blockers for opening a PR for this abstraction work.
+
+Known non-blocking issues:
+
+- `useTerminal.test.ts` still emits existing React `act(...)` warnings. Tests
+  pass, but the warnings are noisy.
+- Some Body tests still mock `@xterm/*`. This is allowed by the guard because
+  tests are excluded, but it is still a coupling smell. Adapter-specific checks
+  should continue moving into `xtermInstance.test.ts`.
+- `createTerminalInstance()` still delegates to xterm. This PR creates the seam;
+  it does not implement a Ghostty adapter.
+- A real Ghostty prototype will need a decision on string chunks vs raw byte
+  streams.
+
+## Suggested PR Framing
+
+The PR should be framed as an abstraction and containment change, not as a
+Ghostty implementation.
+
+Recommended title:
+
+`Extract terminal renderer abstraction around xterm`
+
+Recommended scope:
+
+- introduce renderer-neutral terminal contracts
+- isolate xterm construction and addons in an adapter
+- route Body, hooks, theme bridge, and E2E buffer reads through the contracts
+- add lint guard against direct production xterm imports
+- add fake terminal contract test proving Body is not hard-bound to xterm
+
+Do not claim Ghostty support yet.
+
+## Recommended Next Steps After Review
+
+1. Move remaining Body tests that assert xterm constructor/addon details into
+   adapter-level tests.
+2. Decide whether `TerminalParser` should stay frontend-side or become a bridge
+   to backend/native parser events.
+3. Design a raw-byte PTY path for any serious Ghostty/libghostty-vt prototype.
+4. Add a second experimental adapter only after the abstraction PR is reviewed.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -128,6 +128,29 @@ export default defineConfig([
     },
   },
   {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: [
+      'src/**/*.test.ts',
+      'src/**/*.test.tsx',
+      'src/test/**',
+      'src/features/terminal/components/TerminalPane/xtermInstance.ts',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@xterm/*'],
+              message:
+                'Terminal renderer code must go through TerminalSurface/TerminalInstance; keep xterm imports inside xtermInstance.ts.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     // The react-markdown component map pulls `node`/`className` out to drop
     // them before spreading `...props`; those discarded siblings are
     // intentional, not dead code. Scope the strip-and-spread relaxation to just

--- a/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
@@ -1,0 +1,179 @@
+import { render, waitFor } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { Body } from './Body'
+import { createTerminalInstance } from './terminalInstance'
+import { useTerminal, type UseTerminalReturn } from '../../hooks/useTerminal'
+import type { ITerminalService } from '../../services/terminalService'
+import type {
+  TerminalDisposable,
+  TerminalInstance,
+  TerminalParser,
+  TerminalRendererHandle,
+  TerminalSurface,
+  TerminalViewportReader,
+} from '../../types'
+
+vi.mock('./terminalInstance', () => ({
+  createTerminalInstance: vi.fn(),
+}))
+
+vi.mock('../../hooks/useTerminal', () => ({
+  useTerminal: vi.fn(),
+}))
+
+interface FakeTerminalControls {
+  instance: TerminalInstance
+  terminal: TerminalSurface
+  parser: TerminalParser
+  rendererHandle: TerminalRendererHandle
+  viewportReader: TerminalViewportReader
+  emitOsc: (identifier: number, data: string) => boolean | undefined
+}
+
+const createDisposable = (): TerminalDisposable => ({
+  dispose: vi.fn(),
+})
+
+const createFakeTerminalInstance = (): FakeTerminalControls => {
+  const element = document.createElement('div')
+  const oscHandlers = new Map<number, (data: string) => boolean>()
+
+  const terminal: TerminalSurface = {
+    cols: 120,
+    rows: 40,
+    element,
+    open: vi.fn((): void => undefined),
+    focus: vi.fn((): void => undefined),
+    dispose: vi.fn((): void => undefined),
+    clear: vi.fn((): void => undefined),
+    write: vi.fn((data: string, callback?: () => void): void => {
+      void data
+      callback?.()
+    }),
+    refresh: vi.fn((): void => undefined),
+    onData: vi.fn((): TerminalDisposable => createDisposable()),
+    onResize: vi.fn((): TerminalDisposable => createDisposable()),
+    hasSelection: vi.fn((): boolean => false),
+    getSelection: vi.fn((): string => ''),
+    paste: vi.fn((): void => undefined),
+    selectAll: vi.fn((): void => undefined),
+    onSelectionChange: vi.fn((): TerminalDisposable => createDisposable()),
+    attachKeyEventHandler: vi.fn((): void => undefined),
+    applyTheme: vi.fn((): void => undefined),
+  }
+
+  const parser: TerminalParser = {
+    registerOscHandler: vi.fn(
+      (
+        identifier: number,
+        handler: (data: string) => boolean
+      ): TerminalDisposable => {
+        oscHandlers.set(identifier, handler)
+
+        return createDisposable()
+      }
+    ),
+  }
+
+  const viewportReader: TerminalViewportReader = {
+    readVisibleText: vi.fn((): string => 'fake visible text'),
+  }
+
+  const rendererHandle: TerminalRendererHandle = {
+    dispose: vi.fn((): void => undefined),
+  }
+
+  const instance: TerminalInstance = {
+    terminal,
+    parser,
+    viewportReader,
+    fitController: { fit: vi.fn((): void => undefined) },
+    attachRenderer: vi.fn((): TerminalRendererHandle => rendererHandle),
+  }
+
+  return {
+    instance,
+    terminal,
+    parser,
+    rendererHandle,
+    viewportReader,
+    emitOsc: (identifier, data): boolean | undefined =>
+      oscHandlers.get(identifier)?.(data),
+  }
+}
+
+const createService = (): ITerminalService =>
+  ({
+    spawn: vi.fn().mockResolvedValue({ sessionId: 'pty-1', pid: 1 }),
+    write: vi.fn().mockResolvedValue(undefined),
+    resize: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(
+      (): Promise<() => void> => Promise.resolve((): void => undefined)
+    ),
+    onExit: vi.fn(
+      (): Promise<() => void> => Promise.resolve((): void => undefined)
+    ),
+    onError: vi.fn(
+      (): Promise<() => void> => Promise.resolve((): void => undefined)
+    ),
+    onBurnerForeground: vi.fn(
+      (): Promise<() => void> => Promise.resolve((): void => undefined)
+    ),
+    listSessions: vi.fn().mockResolvedValue({
+      activeSessionId: null,
+      sessions: [],
+    }),
+    setActiveSession: vi.fn().mockResolvedValue(undefined),
+    reorderSessions: vi.fn().mockResolvedValue(undefined),
+    updateSessionCwd: vi.fn().mockResolvedValue(undefined),
+    setSessionActivityPanelCollapsed: vi.fn().mockResolvedValue(undefined),
+    killEphemeralPtys: vi.fn().mockResolvedValue([]),
+    setWorkspaceSessions: vi.fn().mockResolvedValue(undefined),
+  }) as ITerminalService
+
+test('Body can run against a non-xterm TerminalInstance contract', async () => {
+  const fake = createFakeTerminalInstance()
+  const onCwdChange = vi.fn()
+
+  const useTerminalReturn: UseTerminalReturn = {
+    session: null,
+    status: 'idle',
+    error: null,
+    resize: vi.fn(),
+  }
+
+  vi.mocked(createTerminalInstance).mockReturnValue(fake.instance)
+  vi.mocked(useTerminal).mockReturnValue(useTerminalReturn)
+
+  const { unmount } = render(
+    <Body
+      sessionId="fake-session"
+      cwd="/home/user"
+      service={createService()}
+      onCwdChange={onCwdChange}
+    />
+  )
+
+  await waitFor(() => {
+    expect(fake.terminal.open).toHaveBeenCalledWith(expect.any(HTMLElement))
+  })
+
+  expect(fake.instance.attachRenderer).toHaveBeenCalledOnce()
+  expect(fake.parser.registerOscHandler).toHaveBeenCalledWith(
+    7,
+    expect.any(Function)
+  )
+
+  expect(useTerminal).toHaveBeenCalledWith(
+    expect.objectContaining({ terminal: fake.terminal })
+  )
+
+  expect(fake.emitOsc(7, 'file://localhost/tmp/fake-project')).toBe(true)
+  expect(onCwdChange).toHaveBeenCalledWith('/tmp/fake-project')
+
+  unmount()
+
+  expect(fake.rendererHandle.dispose).toHaveBeenCalledOnce()
+  expect(fake.terminal.dispose).toHaveBeenCalledOnce()
+})

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -14,6 +14,7 @@ import {
 import { TERMINAL_FONT_FAMILY } from './terminalFont'
 import { useTerminal, type UseTerminalReturn } from '../../hooks/useTerminal'
 import type { ITerminalService } from '../../services/terminalService'
+import type { TerminalFitController, TerminalSurface } from '../../types'
 import { obsidianLens } from '../../../../theme'
 
 // Shared mock service for tests that don't exercise service-specific behavior.
@@ -1285,7 +1286,7 @@ describe('Body', () => {
         resizeCallback([mockEntry], {} as ResizeObserver)
       }
 
-      // fitAddon.fit() should be called when container resizes
+      // fitController.fit() should be called when container resizes
       await waitFor(() => {
         expect(mockFitAddon.fit).toHaveBeenCalled()
       })
@@ -1646,7 +1647,7 @@ describe('Body', () => {
         resizeCallback([], {} as ResizeObserver)
       }
 
-      // fitAddon must NOT fire — this is the exact bug path that squashes scrollback
+      // fitController must NOT fire — this is the exact bug path that squashes scrollback
       expect(mockFitAddon.fit).not.toHaveBeenCalled()
 
       // Simulate tab becoming visible again: offsetWidth > 0
@@ -1659,7 +1660,7 @@ describe('Body', () => {
         resizeCallback([], {} as ResizeObserver)
       }
 
-      // fitAddon SHOULD fire now that the container has real dimensions
+      // fitController SHOULD fire now that the container has real dimensions
       await waitFor(() => {
         expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
       })
@@ -1680,8 +1681,9 @@ describe('Body', () => {
       }
 
       terminalCache.set('cached-session', {
-        terminal: cachedTerminal as unknown as Terminal,
-        fitAddon: cachedFitAddon as unknown as FitAddon,
+        terminal: cachedTerminal as unknown as TerminalSurface,
+        fitController: cachedFitAddon as unknown as TerminalFitController,
+        viewportReader: { readVisibleText: vi.fn() },
       })
 
       // Simulate hidden container (display:none → offsetWidth = 0)
@@ -1702,7 +1704,7 @@ describe('Body', () => {
           expect(cachedTerminal.open).toHaveBeenCalled()
         })
 
-        // fitAddon.fit must be suppressed on the reuse path when width is 0
+        // fitController.fit must be suppressed on the reuse path when width is 0
         expect(cachedFitAddon.fit).not.toHaveBeenCalled()
       } finally {
         offsetSpy.mockRestore()
@@ -1733,8 +1735,9 @@ describe('Body', () => {
       })
 
       terminalCache.set('cached-session', {
-        terminal: cachedTerminal as unknown as Terminal,
-        fitAddon: cachedFitAddon as unknown as FitAddon,
+        terminal: cachedTerminal as unknown as TerminalSurface,
+        fitController: cachedFitAddon as unknown as TerminalFitController,
+        viewportReader: { readVisibleText: vi.fn() },
       })
 
       const offsetWidthSpy = vi

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -10,13 +10,6 @@ import {
   useRef,
   useState,
 } from 'react'
-import { Terminal } from '@xterm/xterm'
-import { FitAddon } from '@xterm/addon-fit'
-import { WebglAddon } from '@xterm/addon-webgl'
-import { CanvasAddon } from '@xterm/addon-canvas'
-// WebGL→Canvas2D→DOM renderer chain keeps customGlyphs active for block-element glyphs (see PR #228).
-import { themeService } from '../../../../theme'
-import { toXtermTheme } from '../../theme/toXtermTheme'
 import {
   useTerminal,
   type RestoreData,
@@ -24,6 +17,12 @@ import {
 } from '../../hooks/useTerminal'
 import { useTerminalClipboard } from '../../hooks/useTerminalClipboard'
 import { type ITerminalService } from '../../services/terminalService'
+import type {
+  TerminalFitController,
+  TerminalRendererHandle,
+  TerminalSurface,
+  TerminalViewportReader,
+} from '../../types'
 import { registerPtySession, unregisterPtySession } from '../../ptySessionMap'
 import { TerminalContextMenu } from '../TerminalContextMenu'
 import {
@@ -35,12 +34,8 @@ import {
 } from './agentCwdGuard'
 import { parseAgentCwdHint } from './agentCwdHint'
 import { parseOsc7Cwd, WINDOWS_DRIVE_PATH } from './osc7'
-import {
-  TERMINAL_FONT_FAMILY,
-  TERMINAL_FONT_SIZE,
-  loadTerminalFonts,
-} from './terminalFont'
-import '@xterm/xterm/css/xterm.css'
+import { loadTerminalFonts } from './terminalFont'
+import { createTerminalInstance } from './terminalInstance'
 
 const AGENT_CWD_HINT_BUFFER_SIZE = 4096
 
@@ -76,17 +71,21 @@ const logAgentCwdDebug = (
 //
 // What the cache actually serves:
 //   - the imperative `focusTerminal()` handle, which reads
-//     `terminalCache.get(sessionId)?.terminal.focus()` to focus xterm
+//     `terminalCache.get(sessionId)?.terminal.focus()` to focus the renderer
 //     without reaching into Body's internals;
 //   - tests + the existing public `clearTerminalCache` /
 //     `disposeTerminalSession` API surface (preserved per the step-4
 //     migration spec — external imports would break otherwise).
 //
 // New internal code should NOT add to the cache for "tab persistence"
-// reasons; xterm lifetime is scoped to Body's mount.
+// reasons; terminal renderer lifetime is scoped to Body's mount.
 export const terminalCache = new Map<
   string,
-  { terminal: Terminal; fitAddon: FitAddon }
+  {
+    terminal: TerminalSurface
+    fitController: TerminalFitController
+    viewportReader: TerminalViewportReader
+  }
 >()
 
 /**
@@ -114,7 +113,7 @@ export type BodyMode = 'attach' | 'spawn'
 export interface BodyProps {
   /**
    * Rust PTY handle. This is the value Rust IPC calls `sessionId`; in the
-   * pane model it flows from `pane.ptyId` and keys xterm cache entries.
+   * pane model it flows from `pane.ptyId` and keys terminal cache entries.
    */
   sessionId: string
 
@@ -179,12 +178,12 @@ export interface BodyProps {
   onPtyStatusChange?: (status: 'idle' | 'running' | 'exited' | 'error') => void
 
   /**
-   * Called when xterm gains or loses focus.
+   * Called when the terminal renderer gains or loses focus.
    */
   onFocusChange?: (focused: boolean) => void
 
   /**
-   * Defer expensive xterm fitting while surrounding layout is actively being
+   * Defer expensive terminal fitting while surrounding layout is actively being
    * dragged. The final size is fitted when this flips back to false.
    */
   deferFit?: boolean
@@ -212,8 +211,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   ref
 ): ReactElement {
   const containerRef = useRef<HTMLDivElement>(null)
-  const [terminal, setTerminal] = useState<Terminal | null>(null)
-  const fitAddonRef = useRef<FitAddon | null>(null)
+  const [terminal, setTerminal] = useState<TerminalSurface | null>(null)
+  const fitControllerRef = useRef<TerminalFitController | null>(null)
   const deferFitRef = useRef(deferFit)
   const previousDeferFitRef = useRef(deferFit)
   const cancelScheduledFitRef = useRef<(() => void) | null>(null)
@@ -495,12 +494,9 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
     // Check if we already have a terminal for this session
     const cached = terminalCache.get(sessionId)
-    let newTerminal: Terminal
-    let fitAddon: FitAddon
-    // Renderer addons (at most one non-null) — kept in closure so cleanup disposes them before the terminal.
-    let webglAddon: WebglAddon | null = null
-    let webglContextLossDisposable: { dispose: () => void } | null = null
-    let canvasAddon: CanvasAddon | null = null
+    let newTerminal: TerminalSurface
+    let fitController: TerminalFitController
+    let rendererHandle: TerminalRendererHandle | null = null
     let fitFrameId: number | null = null
     let lastFitSize: { width: number; height: number } | null = null
     let disposed = false
@@ -512,7 +508,10 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       }
     }
 
-    const fitIfNeeded = (targetFitAddon: FitAddon, force = false): boolean => {
+    const fitIfNeeded = (
+      targetFitController: TerminalFitController,
+      force = false
+    ): boolean => {
       const width = node.offsetWidth
       const height = node.offsetHeight
 
@@ -530,12 +529,12 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       }
 
       lastFitSize = { width, height }
-      targetFitAddon.fit()
+      targetFitController.fit()
 
       return true
     }
 
-    const scheduleFit = (targetFitAddon: FitAddon): void => {
+    const scheduleFit = (targetFitController: TerminalFitController): void => {
       if (deferFitRef.current) {
         return
       }
@@ -549,12 +548,12 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         if (deferFitRef.current) {
           return
         }
-        fitIfNeeded(targetFitAddon)
+        fitIfNeeded(targetFitController)
       })
     }
 
     const flushFit = (
-      targetFitAddon: FitAddon,
+      targetFitController: TerminalFitController,
       options: { force?: boolean; afterFit?: () => void } = {}
     ): void => {
       cancelScheduledFit()
@@ -566,7 +565,12 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
             return
           }
           const width = node.offsetWidth
-          const didFit = fitIfNeeded(targetFitAddon, options.force ?? false)
+
+          const didFit = fitIfNeeded(
+            targetFitController,
+            options.force ?? false
+          )
+
           if (!didFit && width <= 0 && options.afterFit) {
             flushWithRetry()
 
@@ -581,12 +585,14 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       flushWithRetry()
     }
 
-    const fitInitialWhenReady = (targetFitAddon: FitAddon): boolean => {
+    const fitInitialWhenReady = (
+      targetFitController: TerminalFitController
+    ): boolean => {
       if (deferFitRef.current) {
         return false
       }
 
-      return fitIfNeeded(targetFitAddon, true)
+      return fitIfNeeded(targetFitController, true)
     }
 
     let didInitialFit = false
@@ -594,72 +600,34 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     if (cached) {
       // Reuse existing terminal from cache
       newTerminal = cached.terminal
-      fitAddon = cached.fitAddon
-      fitAddonRef.current = fitAddon
+      fitController = cached.fitController
+      fitControllerRef.current = fitController
 
       // Re-open terminal in the new container
       newTerminal.open(node)
 
       // Re-fit to new container — guard against hidden (display:none) containers
-      // where offsetWidth is 0. Fitting at zero width tells xterm cols≈1,
+      // where offsetWidth is 0. Fitting at zero width tells the renderer cols≈1,
       // which causes the PTY to re-wrap scrollback into a narrow column.
-      didInitialFit = fitInitialWhenReady(fitAddon)
+      didInitialFit = fitInitialWhenReady(fitController)
     } else {
-      // Create new terminal instance
-      newTerminal = new Terminal({
-        cursorBlink: true,
-        fontSize: TERMINAL_FONT_SIZE,
-        fontFamily: TERMINAL_FONT_FAMILY,
-        theme: toXtermTheme(themeService.current().terminal),
-        scrollback: 10000,
-        allowProposedApi: true,
-      })
+      const created = createTerminalInstance()
+      newTerminal = created.terminal
+      fitController = created.fitController
+      fitControllerRef.current = fitController
 
-      // Create and load fit addon
-      fitAddon = new FitAddon()
-      newTerminal.loadAddon(fitAddon)
-      fitAddonRef.current = fitAddon
-
-      // Open terminal in container — WebglAddon requires open() to have been
-      // called first (it needs the canvas elements xterm creates in open()).
+      // Open terminal in container before adapter-specific renderer addons
+      // attach to DOM/canvas elements.
       newTerminal.open(node)
 
-      // Try WebGL first (fastest); fall back to Canvas2D if WebGL is
-      // unavailable. Both renderers honor customGlyphs. See the file-level
-      // comment for why this matters and what happens if both fail.
-      try {
-        const addon = new WebglAddon()
-        webglContextLossDisposable = addon.onContextLoss(() => {
-          addon.dispose()
-          webglAddon = null
-          webglContextLossDisposable = null
-          // Reattach Canvas2D so customGlyphs survives WebGL context loss.
-          try {
-            const fallback = new CanvasAddon()
-            newTerminal.loadAddon(fallback)
-            canvasAddon = fallback
-          } catch {
-            // Canvas2D also unavailable — xterm reverts to DOM rendering.
-          }
-        })
-        newTerminal.loadAddon(addon)
-        webglAddon = addon
-      } catch {
-        try {
-          const addon = new CanvasAddon()
-          newTerminal.loadAddon(addon)
-          canvasAddon = addon
-        } catch {
-          // Both renderer addons failed — xterm reverts to its DOM renderer.
-        }
-      }
+      rendererHandle = created.attachRenderer()
 
       // Fit terminal to container — guard against hidden (display:none) containers
-      didInitialFit = fitInitialWhenReady(fitAddon)
+      didInitialFit = fitInitialWhenReady(fitController)
 
       // Register OSC 7 handler for cwd tracking. Shell prompts and agent/tool
-      // output both arrive through xterm's parser, so this stays pane-local.
-      newTerminal.parser.registerOscHandler(7, (data) => {
+      // output both arrive through the terminal parser, so this stays pane-local.
+      created.parser.registerOscHandler(7, (data) => {
         const previousCwd = agentCwdRef.current
 
         const path = parseOsc7Cwd(data, {
@@ -704,7 +672,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       })
 
       // Cache the terminal instance for this session
-      terminalCache.set(sessionId, { terminal: newTerminal, fitAddon })
+      terminalCache.set(sessionId, {
+        terminal: newTerminal,
+        fitController,
+        viewportReader: created.viewportReader,
+      })
     }
 
     const refreshAfterFontFit = (): void => {
@@ -731,7 +703,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       }
 
       pendingDeferredRefreshAfterFitRef.current = true
-      flushFit(fitAddon, {
+      flushFit(fitController, {
         force: true,
         afterFit: (): void => {
           clearPendingDeferredFit()
@@ -763,7 +735,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     const flushDeferredFit = (): void => {
       if (pendingDeferredRefreshAfterFitRef.current) {
         pendingDeferredFitFlushRef.current = false
-        flushFit(fitAddon, {
+        flushFit(fitController, {
           force: true,
           afterFit: (): void => {
             clearPendingDeferredFit()
@@ -775,7 +747,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       }
 
       pendingDeferredFitFlushRef.current = false
-      flushFit(fitAddon)
+      flushFit(fitController)
     }
 
     const refreshAfterPendingInitialFit = (): void => {
@@ -810,8 +782,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     resizeRef.current(newTerminal.cols, newTerminal.rows)
 
     // Handle resize events - notify PTY of terminal size changes.
-    // The cols/rows from xterm's onResize event are already correct because
-    // fitAddon.fit() (the trigger upstream) has already computed and applied
+    // The cols/rows from the terminal's onResize event are already correct because
+    // fitController.fit() (the trigger upstream) has already computed and applied
     // them. Calling fit() again here would re-measure the container — pure
     // overhead during rapid sidebar drag / window resize. Just forward to PTY.
     let lastForwardedResize: { cols: number; rows: number } | null = null
@@ -848,7 +820,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     node.addEventListener('focusin', handleFocusIn)
     node.addEventListener('focusout', handleFocusOut)
 
-    // Root cause B (Claude + Codex consensus): xterm renders on a debounced
+    // Root cause B (Claude + Codex consensus): the terminal renders on a debounced
     // animation-frame loop and never forces a repaint when the OS window
     // regains focus or visibility. The browser throttles that loop while the
     // window is covered or unfocused, so rows that streamed in while we were
@@ -872,7 +844,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     // Guard: skip fit when container is hidden (display:none → width=0)
     // to avoid PTY scrollback re-wrapping at a narrow column count.
     const resizeObserver = new ResizeObserver(() => {
-      scheduleFit(fitAddon)
+      scheduleFit(fitController)
     })
     resizeObserver.observe(node)
 
@@ -897,23 +869,17 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       node.removeEventListener('focusout', handleFocusOut)
       window.removeEventListener('focus', repaintOnWindowVisible)
       document.removeEventListener('visibilitychange', repaintOnWindowVisible)
-      // Dispose the renderer addon (and any WebGL context-loss subscription)
-      // before the terminal itself — order matters: the addon holds
-      // references to the terminal's renderer state and must clean up while
-      // that state is still valid. At most one renderer addon is non-null.
-      webglContextLossDisposable?.dispose()
-      webglContextLossDisposable = null
-      webglAddon?.dispose()
-      webglAddon = null
-      canvasAddon?.dispose()
-      canvasAddon = null
+      // Renderer addons must dispose before the terminal itself; the handle
+      // owns that adapter-specific ordering.
+      rendererHandle?.dispose()
+      rendererHandle = null
       const entry = terminalCache.get(sessionId)
       if (entry) {
         entry.terminal.dispose()
         terminalCache.delete(sessionId)
       }
       setTerminal(null)
-      fitAddonRef.current = null
+      fitControllerRef.current = null
     }
   }, [sessionId])
 

--- a/src/features/terminal/components/TerminalPane/terminalInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalInstance.test.ts
@@ -1,0 +1,20 @@
+import { expect, test, vi } from 'vitest'
+import { createTerminalInstance } from './terminalInstance'
+import { createXtermTerminal } from './xtermInstance'
+
+vi.mock('./xtermInstance', () => ({
+  createXtermTerminal: vi.fn(),
+}))
+
+test('creates the configured terminal renderer instance', () => {
+  const instance = {
+    terminal: {},
+    parser: {},
+    viewportReader: {},
+    fitController: {},
+    attachRenderer: vi.fn(),
+  }
+  vi.mocked(createXtermTerminal).mockReturnValue(instance as never)
+
+  expect(createTerminalInstance()).toBe(instance)
+})

--- a/src/features/terminal/components/TerminalPane/terminalInstance.ts
+++ b/src/features/terminal/components/TerminalPane/terminalInstance.ts
@@ -1,0 +1,5 @@
+import type { TerminalInstance } from '../../types'
+import { createXtermTerminal } from './xtermInstance'
+
+export const createTerminalInstance = (): TerminalInstance =>
+  createXtermTerminal()

--- a/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { WebglAddon } from '@xterm/addon-webgl'
+import { CanvasAddon } from '@xterm/addon-canvas'
+import { obsidianLens } from '../../../../theme'
+import { TERMINAL_FONT_FAMILY } from './terminalFont'
+import { createXtermTerminal } from './xtermInstance'
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(),
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(),
+}))
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: vi.fn(),
+}))
+
+vi.mock('@xterm/addon-canvas', () => ({
+  CanvasAddon: vi.fn(),
+}))
+
+interface RawTerminalMock {
+  cols: number
+  rows: number
+  element: HTMLElement
+  options: { theme?: Record<string, string> }
+  buffer: {
+    active: {
+      viewportY: number
+      getLine: (index: number) => RawBufferLine | undefined
+    }
+  }
+  loadAddon: ReturnType<typeof vi.fn>
+  open: ReturnType<typeof vi.fn>
+  focus: ReturnType<typeof vi.fn>
+  dispose: ReturnType<typeof vi.fn>
+  clear: ReturnType<typeof vi.fn>
+  write: ReturnType<typeof vi.fn>
+  refresh: ReturnType<typeof vi.fn>
+  onData: ReturnType<typeof vi.fn>
+  onResize: ReturnType<typeof vi.fn>
+  parser: {
+    registerOscHandler: ReturnType<typeof vi.fn>
+  }
+  hasSelection: ReturnType<typeof vi.fn>
+  getSelection: ReturnType<typeof vi.fn>
+  paste: ReturnType<typeof vi.fn>
+  selectAll: ReturnType<typeof vi.fn>
+  onSelectionChange: ReturnType<typeof vi.fn>
+  attachCustomKeyEventHandler: ReturnType<typeof vi.fn>
+}
+
+interface RawBufferLine {
+  translateToString: (trimRight: boolean) => string
+}
+
+const createRawTerminal = (): RawTerminalMock => {
+  const element = document.createElement('div')
+
+  const bufferRows = new Map([
+    [1, 'visible one  '],
+    [2, 'visible two'],
+    [3, 'outside viewport'],
+  ])
+
+  return {
+    cols: 80,
+    rows: 2,
+    element,
+    options: {},
+    buffer: {
+      active: {
+        viewportY: 1,
+        getLine: (index: number): RawBufferLine | undefined => {
+          const text = bufferRows.get(index)
+          if (text === undefined) {
+            return undefined
+          }
+
+          return {
+            translateToString: (trimRight: boolean): string =>
+              trimRight ? text.replace(/\s+$/, '') : text,
+          }
+        },
+      },
+    },
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    focus: vi.fn(),
+    dispose: vi.fn(),
+    clear: vi.fn(),
+    write: vi.fn(),
+    refresh: vi.fn(),
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    onResize: vi.fn(() => ({ dispose: vi.fn() })),
+    parser: {
+      registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
+    },
+    hasSelection: vi.fn(() => true),
+    getSelection: vi.fn(() => 'selected'),
+    paste: vi.fn(),
+    selectAll: vi.fn(),
+    onSelectionChange: vi.fn(() => ({ dispose: vi.fn() })),
+    attachCustomKeyEventHandler: vi.fn(),
+  }
+}
+
+describe('xtermInstance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('creates a themed terminal surface with a loaded fit addon', () => {
+    const terminal = createRawTerminal()
+    const fitAddon = { fit: vi.fn() }
+    const container = document.createElement('div')
+
+    vi.mocked(Terminal).mockImplementation(() => terminal as never)
+    vi.mocked(FitAddon).mockImplementation(() => fitAddon as never)
+
+    const created = createXtermTerminal()
+
+    expect(Terminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowProposedApi: true,
+        cursorBlink: true,
+        fontFamily: TERMINAL_FONT_FAMILY,
+        fontSize: 14,
+        scrollback: 10000,
+        theme: expect.objectContaining({
+          background: obsidianLens.terminal.background,
+          cursor: obsidianLens.terminal.cursor,
+          foreground: obsidianLens.terminal.foreground,
+        }),
+      })
+    )
+    expect(FitAddon).toHaveBeenCalledTimes(1)
+    expect(terminal.loadAddon).toHaveBeenCalledWith(fitAddon)
+    expect(created.fitController).toBe(fitAddon)
+    expect(created.terminal.cols).toBe(80)
+    expect(created.terminal.rows).toBe(2)
+    expect(created.terminal.element).toBe(terminal.element)
+    expect(created.viewportReader.readVisibleText()).toBe(
+      'visible one\nvisible two'
+    )
+
+    created.parser.registerOscHandler(7, () => true)
+
+    created.terminal.open(container)
+    created.terminal.applyTheme(obsidianLens.terminal)
+
+    expect(terminal.parser.registerOscHandler).toHaveBeenCalledWith(
+      7,
+      expect.any(Function)
+    )
+    expect(terminal.open).toHaveBeenCalledWith(container)
+    expect(terminal.options.theme).toEqual(
+      expect.objectContaining({
+        background: obsidianLens.terminal.background,
+        foreground: obsidianLens.terminal.foreground,
+      })
+    )
+  })
+
+  test('uses WebGL renderer when it is available', () => {
+    const terminal = createRawTerminal()
+    const fitAddon = { fit: vi.fn() }
+
+    const webglAddon = {
+      dispose: vi.fn(),
+      onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+    }
+
+    vi.mocked(Terminal).mockImplementation(() => terminal as never)
+    vi.mocked(FitAddon).mockImplementation(() => fitAddon as never)
+    vi.mocked(WebglAddon).mockImplementation(() => webglAddon as never)
+
+    const renderer = createXtermTerminal().attachRenderer()
+
+    expect(WebglAddon).toHaveBeenCalledTimes(1)
+    expect(CanvasAddon).not.toHaveBeenCalled()
+    expect(terminal.loadAddon).toHaveBeenCalledWith(webglAddon)
+
+    renderer.dispose()
+
+    expect(webglAddon.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to Canvas renderer when WebGL construction fails', () => {
+    const terminal = createRawTerminal()
+    const fitAddon = { fit: vi.fn() }
+    const canvasAddon = { dispose: vi.fn() }
+
+    vi.mocked(Terminal).mockImplementation(() => terminal as never)
+    vi.mocked(FitAddon).mockImplementation(() => fitAddon as never)
+    vi.mocked(WebglAddon).mockImplementation(() => {
+      throw new Error('no webgl')
+    })
+    vi.mocked(CanvasAddon).mockImplementation(() => canvasAddon as never)
+
+    const renderer = createXtermTerminal().attachRenderer()
+
+    expect(WebglAddon).toHaveBeenCalledTimes(1)
+    expect(CanvasAddon).toHaveBeenCalledTimes(1)
+    expect(terminal.loadAddon).toHaveBeenCalledWith(canvasAddon)
+
+    renderer.dispose()
+
+    expect(canvasAddon.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to Canvas renderer on WebGL context loss', () => {
+    const terminal = createRawTerminal()
+    const fitAddon = { fit: vi.fn() }
+    const contextLossDisposable = { dispose: vi.fn() }
+    let onContextLoss = (): void => {
+      throw new Error('context loss handler was not registered')
+    }
+
+    const webglAddon = {
+      dispose: vi.fn(),
+      onContextLoss: vi.fn((callback: () => void) => {
+        onContextLoss = callback
+
+        return contextLossDisposable
+      }),
+    }
+    const canvasAddon = { dispose: vi.fn() }
+
+    vi.mocked(Terminal).mockImplementation(() => terminal as never)
+    vi.mocked(FitAddon).mockImplementation(() => fitAddon as never)
+    vi.mocked(WebglAddon).mockImplementation(() => webglAddon as never)
+    vi.mocked(CanvasAddon).mockImplementation(() => canvasAddon as never)
+
+    const renderer = createXtermTerminal().attachRenderer()
+
+    onContextLoss()
+
+    expect(webglAddon.dispose).toHaveBeenCalledTimes(1)
+    expect(CanvasAddon).toHaveBeenCalledTimes(1)
+    expect(terminal.loadAddon).toHaveBeenLastCalledWith(canvasAddon)
+
+    renderer.dispose()
+
+    expect(contextLossDisposable.dispose).not.toHaveBeenCalled()
+    expect(canvasAddon.dispose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/terminal/components/TerminalPane/xtermInstance.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.ts
@@ -1,0 +1,164 @@
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { WebglAddon } from '@xterm/addon-webgl'
+import { CanvasAddon } from '@xterm/addon-canvas'
+import { themeService } from '../../../../theme'
+import type {
+  TerminalInstance,
+  TerminalParser,
+  TerminalRendererHandle,
+  TerminalSurface,
+  TerminalTheme,
+  TerminalViewportReader,
+} from '../../types'
+import { toXtermTheme } from '../../theme/toXtermTheme'
+import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
+import '@xterm/xterm/css/xterm.css'
+
+export const createXtermTerminal = (): TerminalInstance => {
+  const terminal = new Terminal({
+    cursorBlink: true,
+    fontSize: TERMINAL_FONT_SIZE,
+    fontFamily: TERMINAL_FONT_FAMILY,
+    theme: toXtermTheme(themeService.current().terminal),
+    scrollback: 10000,
+    allowProposedApi: true,
+  })
+
+  const fitAddon = new FitAddon()
+  terminal.loadAddon(fitAddon)
+
+  return {
+    terminal: createTerminalSurface(terminal),
+    parser: createTerminalParser(terminal),
+    viewportReader: createTerminalViewportReader(terminal),
+    fitController: fitAddon,
+    attachRenderer: () => attachXtermRenderer(terminal),
+  }
+}
+
+const createTerminalSurface = (terminal: Terminal): TerminalSurface => ({
+  get cols(): number {
+    return terminal.cols
+  },
+  get rows(): number {
+    return terminal.rows
+  },
+  get element(): HTMLElement | undefined {
+    return terminal.element ?? undefined
+  },
+  open: (container: HTMLElement): void => {
+    terminal.open(container)
+  },
+  focus: (): void => {
+    terminal.focus()
+  },
+  dispose: (): void => {
+    terminal.dispose()
+  },
+  clear: (): void => {
+    terminal.clear()
+  },
+  write: (data: string, callback?: () => void): void => {
+    terminal.write(data, callback)
+  },
+  refresh: (start: number, end: number): void => {
+    terminal.refresh(start, end)
+  },
+  onData: (handler: (data: string) => void) => terminal.onData(handler),
+  onResize: (handler: (size: { cols: number; rows: number }) => void) =>
+    terminal.onResize(handler),
+  hasSelection: (): boolean => terminal.hasSelection(),
+  getSelection: (): string => terminal.getSelection(),
+  paste: (text: string): void => {
+    terminal.paste(text)
+  },
+  selectAll: (): void => {
+    terminal.selectAll()
+  },
+  onSelectionChange: (listener: () => void) =>
+    terminal.onSelectionChange(listener),
+  attachKeyEventHandler: (handler): void => {
+    terminal.attachCustomKeyEventHandler(handler)
+  },
+  applyTheme: (theme: TerminalTheme): void => {
+    terminal.options.theme = toXtermTheme(theme)
+  },
+})
+
+const createTerminalParser = (terminal: Terminal): TerminalParser => ({
+  registerOscHandler: (
+    identifier: number,
+    handler: (data: string) => boolean
+  ) => terminal.parser.registerOscHandler(identifier, handler),
+})
+
+const createTerminalViewportReader = (
+  terminal: Terminal
+): TerminalViewportReader => ({
+  readVisibleText: (): string => {
+    const buffer = terminal.buffer.active
+    const start = buffer.viewportY
+    const end = start + terminal.rows
+    const lines: string[] = []
+
+    for (let i = start; i < end; i += 1) {
+      const line = buffer.getLine(i)
+      if (line) {
+        lines.push(line.translateToString(true))
+      }
+    }
+
+    return lines.join('\n').replace(/\n+$/, '')
+  },
+})
+
+const loadCanvasRenderer = (terminal: Terminal): CanvasAddon | null => {
+  try {
+    const addon = new CanvasAddon()
+    terminal.loadAddon(addon)
+
+    return addon
+  } catch {
+    // Canvas2D unavailable: xterm keeps its DOM renderer.
+    return null
+  }
+}
+
+/**
+ * Attach the preferred xterm renderer after `terminal.open(...)`.
+ *
+ * WebGL remains the primary renderer for large agent output throughput. Canvas2D
+ * is a fallback that keeps custom glyph rendering active; if both fail, xterm's
+ * built-in DOM renderer remains.
+ */
+const attachXtermRenderer = (terminal: Terminal): TerminalRendererHandle => {
+  let webglAddon: WebglAddon | null = null
+  let webglContextLossDisposable: { dispose: () => void } | null = null
+  let canvasAddon: CanvasAddon | null = null
+
+  try {
+    const addon = new WebglAddon()
+    webglContextLossDisposable = addon.onContextLoss(() => {
+      addon.dispose()
+      webglAddon = null
+      webglContextLossDisposable = null
+      canvasAddon = loadCanvasRenderer(terminal)
+    })
+    terminal.loadAddon(addon)
+    webglAddon = addon
+  } catch {
+    canvasAddon = loadCanvasRenderer(terminal)
+  }
+
+  return {
+    dispose: (): void => {
+      webglContextLossDisposable?.dispose()
+      webglContextLossDisposable = null
+      webglAddon?.dispose()
+      webglAddon = null
+      canvasAddon?.dispose()
+      canvasAddon = null
+    },
+  }
+}

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -1,11 +1,11 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
-import type { Terminal } from '@xterm/xterm'
 import { useTerminal } from './useTerminal'
 import { MockTerminalService } from '../services/terminalService'
+import type { TerminalSurface } from '../types'
 
-// Mock xterm Terminal with test helpers
-interface MockTerminal extends Terminal {
+// Mock terminal surface with test helpers
+interface MockTerminal extends TerminalSurface {
   _mockTriggerData: (data: string) => void
   _mockFlushWrites: () => void
 }
@@ -112,7 +112,7 @@ describe('useTerminal', () => {
     expect(result.current.session).toBeNull()
   })
 
-  test('writes PTY data to xterm terminal', async () => {
+  test('writes PTY data to terminal surface', async () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
@@ -163,7 +163,7 @@ describe('useTerminal', () => {
     expect(onOutput).toHaveBeenCalledWith('Hello from PTY\r\n')
   })
 
-  test('handles keyboard input from xterm', async () => {
+  test('handles keyboard input from terminal surface', async () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
-import type { Terminal } from '@xterm/xterm'
 import type { ITerminalService } from '../services/terminalService'
-import type { TerminalSession } from '../types'
+import type { TerminalSession, TerminalSurface } from '../types'
 
 /**
  * Data required to restore a terminal session from snapshot + live events.
@@ -50,9 +49,9 @@ export type UseTerminalMode = 'attach' | 'spawn' | 'awaiting-restart'
 
 interface UseTerminalBaseOptions {
   /**
-   * xterm.js Terminal instance
+   * Terminal renderer surface.
    */
-  terminal: Terminal | null
+  terminal: TerminalSurface | null
 
   /**
    * Terminal service (MockTerminalService or DesktopTerminalService)
@@ -124,7 +123,7 @@ type RestoreLifecycleOptions =
       /**
        * Restore lifecycle callbacks must be provided as a pair. `onRestoreStart`
        * fires immediately before historical replay/buffered output is written to
-       * xterm; `onRestoreEnd` fires after the final restore write callback.
+       * terminal; `onRestoreEnd` fires after the final restore write callback.
        */
       onRestoreStart: () => void
       onRestoreEnd: () => void
@@ -160,12 +159,12 @@ export interface UseTerminalReturn {
 }
 
 /**
- * useTerminal hook - manages PTY lifecycle and xterm integration
+ * useTerminal hook - manages PTY lifecycle and terminal renderer integration
  *
  * Features:
  * - Spawns PTY on mount (or restores from snapshot)
- * - Listens to PTY data events and writes to xterm
- * - Handles keyboard input from xterm
+ * - Listens to PTY data events and writes to the terminal renderer
+ * - Handles keyboard input from the terminal renderer
  * - Handles PTY exit and error events
  * - Cleans up on unmount
  * - Supports replay + cursor dedupe for session restoration
@@ -249,7 +248,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
   }, [onInput])
 
   const writeTerminalOutput = useCallback(
-    (targetTerminal: Terminal, data: string): void => {
+    (targetTerminal: TerminalSurface, data: string): void => {
       if (!onOutputRef.current) {
         targetTerminal.write(data)
 
@@ -631,7 +630,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     }
   }, [terminal, session, service, writeTerminalOutput])
 
-  // Handle keyboard input from xterm
+  // Handle keyboard input from the terminal renderer
   useEffect(() => {
     if (!terminal || !session) {
       return

--- a/src/features/terminal/hooks/useTerminalClipboard.test.ts
+++ b/src/features/terminal/hooks/useTerminalClipboard.test.ts
@@ -1,10 +1,14 @@
 import { act, renderHook } from '@testing-library/react'
-import type { IDisposable, Terminal } from '@xterm/xterm'
 import { expect, test, vi } from 'vitest'
 import { useTerminalClipboard } from './useTerminalClipboard'
+import type { TerminalDisposable, TerminalSurface } from '../types'
+
+interface MockClipboardTerminal extends TerminalSurface {
+  clearSelection: () => void
+}
 
 interface MockTerminalControls {
-  terminal: Terminal
+  terminal: MockClipboardTerminal
   fireSelectionChange: (hasSelection: boolean) => void
   element: HTMLElement
 }
@@ -28,8 +32,8 @@ const createMockTerminal = (): MockTerminalControls => {
       selectionText = 'EVERYTHING'
     },
     paste: (): void => undefined,
-    attachCustomKeyEventHandler: vi.fn(),
-    onSelectionChange: (listener: () => void): IDisposable => {
+    attachKeyEventHandler: vi.fn(),
+    onSelectionChange: (listener: () => void): TerminalDisposable => {
       selectionListeners.add(listener)
 
       return {
@@ -38,7 +42,7 @@ const createMockTerminal = (): MockTerminalControls => {
         },
       }
     },
-  } as unknown as Terminal
+  } as unknown as MockClipboardTerminal
 
   return {
     terminal,
@@ -129,7 +133,7 @@ const flushMicrotasks = async (): Promise<void> => {
 }
 
 const captureKeyHandler = (mock: MockTerminalControls): AttachedHandler => {
-  const attachSpy = mock.terminal.attachCustomKeyEventHandler as unknown as {
+  const attachSpy = mock.terminal.attachKeyEventHandler as unknown as {
     mock: { calls: [AttachedHandler][] }
   }
   const calls = attachSpy.mock.calls
@@ -792,7 +796,7 @@ test('re-render with new onCopyError reference does not re-attach handlers', () 
   const mock = createMockTerminal()
 
   const attachSpy = mock.terminal
-    .attachCustomKeyEventHandler as unknown as ReturnType<typeof vi.fn>
+    .attachKeyEventHandler as unknown as ReturnType<typeof vi.fn>
 
   const { rerender } = renderHook(
     ({ onCopyError }: { onCopyError: () => void }) =>
@@ -810,7 +814,7 @@ test('unmount disposes onSelectionChange, restores default key handler, and remo
   const mock = createMockTerminal()
 
   const attachSpy = mock.terminal
-    .attachCustomKeyEventHandler as unknown as ReturnType<typeof vi.fn>
+    .attachKeyEventHandler as unknown as ReturnType<typeof vi.fn>
 
   const { result, unmount } = renderHook(() =>
     useTerminalClipboard({ terminal: mock.terminal })
@@ -837,11 +841,11 @@ test('unmount disposes onSelectionChange, restores default key handler, and remo
   expect(result.current.isOpen).toBe(false)
 })
 
-test('unmount tolerates a terminal whose attachCustomKeyEventHandler throws', () => {
+test('unmount tolerates a terminal whose key event handler registration throws', () => {
   const mock = createMockTerminal()
 
   const attachSpy = mock.terminal
-    .attachCustomKeyEventHandler as unknown as ReturnType<typeof vi.fn>
+    .attachKeyEventHandler as unknown as ReturnType<typeof vi.fn>
 
   const { unmount } = renderHook(() =>
     useTerminalClipboard({ terminal: mock.terminal })
@@ -860,13 +864,13 @@ test('changing terminal identity cleans up old terminal and attaches to new one'
   const second = createMockTerminal()
 
   const firstAttach = first.terminal
-    .attachCustomKeyEventHandler as unknown as ReturnType<typeof vi.fn>
+    .attachKeyEventHandler as unknown as ReturnType<typeof vi.fn>
 
   const secondAttach = second.terminal
-    .attachCustomKeyEventHandler as unknown as ReturnType<typeof vi.fn>
+    .attachKeyEventHandler as unknown as ReturnType<typeof vi.fn>
 
   const { rerender } = renderHook(
-    ({ terminal }: { terminal: Terminal }) =>
+    ({ terminal }: { terminal: TerminalSurface }) =>
       useTerminalClipboard({ terminal }),
     { initialProps: { terminal: first.terminal } }
   )
@@ -884,9 +888,9 @@ test('terminal === null after non-null resets isOpen/openAt/hasSelection', () =>
   const mock = createMockTerminal()
 
   const { result, rerender } = renderHook(
-    ({ terminal }: { terminal: Terminal | null }) =>
+    ({ terminal }: { terminal: TerminalSurface | null }) =>
       useTerminalClipboard({ terminal }),
-    { initialProps: { terminal: mock.terminal as Terminal | null } }
+    { initialProps: { terminal: mock.terminal as TerminalSurface | null } }
   )
 
   act(() => {

--- a/src/features/terminal/hooks/useTerminalClipboard.ts
+++ b/src/features/terminal/hooks/useTerminalClipboard.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
-import type { Terminal } from '@xterm/xterm'
+import type { TerminalSurface } from '../types'
 
 export type ClipboardModifier = 'meta' | 'ctrl'
 
 export interface UseTerminalClipboardOptions {
-  terminal: Terminal | null
+  terminal: TerminalSurface | null
   preferModifier?: ClipboardModifier
   onCopyError?: (error: unknown) => void
   onPasteError?: (error: unknown) => void
@@ -255,7 +255,7 @@ export const useTerminalClipboard = ({
     }
 
     try {
-      terminal.attachCustomKeyEventHandler(handleKey)
+      terminal.attachKeyEventHandler(handleKey)
     } catch {
       /* terminal not ready; retrying is left to the next terminal identity */
     }
@@ -274,7 +274,7 @@ export const useTerminalClipboard = ({
       }
 
       try {
-        terminal.attachCustomKeyEventHandler((): boolean => true)
+        terminal.attachKeyEventHandler((): boolean => true)
       } catch {
         /* terminal already disposed */
       }

--- a/src/features/terminal/theme/themeBridge.test.ts
+++ b/src/features/terminal/theme/themeBridge.test.ts
@@ -1,32 +1,28 @@
-import { afterEach, expect, test } from 'vitest'
-import type { Terminal } from '@xterm/xterm'
+import { afterEach, expect, test, vi } from 'vitest'
 import { themeService } from '../../../theme'
 import {
   clearTerminalCache,
   terminalCache,
 } from '../components/TerminalPane/Body'
+import type { TerminalSurface } from '../types'
 import { initTerminalThemeBridge } from './themeBridge'
-import { toXtermTheme } from './toXtermTheme'
 
 afterEach(() => {
   clearTerminalCache()
   themeService.apply('obsidian-lens')
 })
 
-test('live terminals get the new xterm theme on switch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const fake = { options: { theme: {} }, dispose: (): void => {} }
+test('live terminals receive the new terminal theme on switch', () => {
+  const fake = { applyTheme: vi.fn(), dispose: vi.fn() }
   terminalCache.set('s1', {
-    terminal: fake as unknown as Terminal,
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    fitAddon: { fit: (): void => {} } as never,
+    terminal: fake as unknown as TerminalSurface,
+    fitController: { fit: vi.fn() },
+    viewportReader: { readVisibleText: vi.fn() },
   })
 
   const stop = initTerminalThemeBridge()
   themeService.apply('flexoki')
 
-  expect(fake.options.theme).toEqual(
-    toXtermTheme(themeService.current().terminal)
-  )
+  expect(fake.applyTheme).toHaveBeenCalledWith(themeService.current().terminal)
   stop()
 })

--- a/src/features/terminal/theme/themeBridge.ts
+++ b/src/features/terminal/theme/themeBridge.ts
@@ -1,16 +1,12 @@
 import { themeService } from '../../../theme'
 import { terminalCache } from '../components/TerminalPane/Body'
-import { toXtermTheme } from './toXtermTheme'
 
-/** Re-theme every live xterm instance when the workspace theme changes.
- * xterm renders to canvas and cannot read CSS variables — assigning a
- * fresh `options.theme` object triggers a colors-only repaint
- * (scrollback recolors, PTY untouched). */
+/** Re-theme every live terminal renderer when the workspace theme changes.
+ * Canvas-backed renderers cannot read CSS variables — applying a fresh theme
+ * triggers a colors-only repaint (scrollback recolors, PTY untouched). */
 export const initTerminalThemeBridge = (): (() => void) =>
   themeService.subscribe((theme) => {
-    const xtermTheme = toXtermTheme(theme.terminal)
-
     terminalCache.forEach(({ terminal }) => {
-      terminal.options.theme = xtermTheme
+      terminal.applyTheme(theme.terminal)
     })
   })

--- a/src/features/terminal/types/index.ts
+++ b/src/features/terminal/types/index.ts
@@ -203,3 +203,71 @@ export type PaneEventHandler = (
 
 /** Cleanup callback returned by `notifyPaneReady` — call on pane unmount. */
 export type NotifyPaneReadyResult = () => void
+
+/** Generic cleanup handle returned by terminal renderer subscriptions. */
+export interface TerminalDisposable {
+  dispose: () => void
+}
+
+/** Terminal grid dimensions. */
+export interface TerminalSize {
+  cols: number
+  rows: number
+}
+
+/** Renderer-level keyboard event hook. Return false to stop the terminal. */
+export type TerminalKeyEventHandler = (event: KeyboardEvent) => boolean
+
+/** Terminal viewport object consumed by app logic. */
+export interface TerminalSurface {
+  readonly cols: number
+  readonly rows: number
+  readonly element: HTMLElement | undefined
+  open: (container: HTMLElement) => void
+  focus: () => void
+  dispose: () => void
+  clear: () => void
+  write: (data: string, callback?: () => void) => void
+  refresh: (start: number, end: number) => void
+  onData: (handler: (data: string) => void) => TerminalDisposable
+  onResize: (handler: (size: TerminalSize) => void) => TerminalDisposable
+  hasSelection: () => boolean
+  getSelection: () => string
+  paste: (text: string) => void
+  selectAll: () => void
+  onSelectionChange: (listener: () => void) => TerminalDisposable
+  attachKeyEventHandler: (handler: TerminalKeyEventHandler) => void
+  applyTheme: (theme: TerminalTheme) => void
+}
+
+/** Controller used to fit a terminal surface to its container. */
+export interface TerminalFitController {
+  fit: () => void
+}
+
+/** Renderer addon handle owned by the terminal adapter. */
+export interface TerminalRendererHandle {
+  dispose: () => void
+}
+
+/** Parser hooks emitted from terminal control sequences. */
+export interface TerminalParser {
+  registerOscHandler: (
+    identifier: number,
+    handler: (data: string) => boolean
+  ) => TerminalDisposable
+}
+
+/** Reads the currently visible terminal text for automation and diagnostics. */
+export interface TerminalViewportReader {
+  readVisibleText: () => string
+}
+
+/** Complete terminal renderer instance created for a pane. */
+export interface TerminalInstance {
+  terminal: TerminalSurface
+  parser: TerminalParser
+  viewportReader: TerminalViewportReader
+  fitController: TerminalFitController
+  attachRenderer: () => TerminalRendererHandle
+}

--- a/src/lib/e2e-bridge.test.ts
+++ b/src/lib/e2e-bridge.test.ts
@@ -5,42 +5,24 @@ import { terminalCache } from '../features/terminal/components/TerminalPane/Body
 
 type CacheEntry = ReturnType<typeof terminalCache.get>
 
-interface MockLine {
-  translateToString: (trimRight: boolean) => string
+interface MockViewportReader {
+  readVisibleText: () => string
 }
 
-interface MockBuffer {
-  viewportY: number
-  getLine: (i: number) => MockLine | undefined
-}
+const makeMockEntry = (rows: readonly string[]): CacheEntry => {
+  const viewportReader: MockViewportReader = {
+    readVisibleText: (): string => {
+      const visibleRows = rows.map((row) => row.replace(/\s+$/, ''))
 
-interface MockTerminal {
-  rows: number
-  buffer: { active: MockBuffer }
-}
-
-const makeMockEntry = (rows: readonly string[], viewportY = 0): CacheEntry => {
-  const terminal: MockTerminal = {
-    rows: rows.length,
-    buffer: {
-      active: {
-        viewportY,
-        getLine: (i: number) => {
-          const text = rows[i - viewportY]
-          if (text === undefined) {
-            return undefined
-          }
-
-          return {
-            translateToString: (trimRight: boolean): string =>
-              trimRight ? text.replace(/\s+$/, '') : text,
-          }
-        },
-      },
+      return visibleRows.join('\n').replace(/\n+$/, '')
     },
   }
 
-  return { terminal, fitAddon: {} } as unknown as CacheEntry
+  return {
+    terminal: { dispose: (): void => undefined },
+    fitController: { fit: (): void => undefined },
+    viewportReader,
+  } as unknown as CacheEntry
 }
 
 /**
@@ -147,8 +129,8 @@ describe('readPaneBuffer', () => {
     expect(readPaneBuffer(slot!)).toBe('slot-buf')
   })
 
-  test('falls back to xterm buffer API when .xterm-rows is empty (canvas renderer path)', () => {
-    // Canvas/WebGL renderer leaves .xterm-rows empty. The fallback must reach into terminalCache by PTY id.
+  test('falls back to terminal surface text when .xterm-rows is empty (canvas renderer path)', () => {
+    // Canvas/WebGL renderers leave .xterm-rows empty. The fallback must reach into terminalCache by PTY id.
     const wrapper = buildSessionWrapper([''], 0)
     terminalCache.set('pty-0', makeMockEntry(['$ echo hi', 'hi', '$ '])!)
 
@@ -177,11 +159,9 @@ describe('readPaneBuffer', () => {
     expect(readPaneBuffer(inner!)).toBe('inner-pane-buf')
   })
 
-  test('respects viewportY so the fallback returns only the visible viewport, not scrollback', () => {
-    // viewportY=5, rows=2 → must return lines 5-6 only (round-1 F1 root cause).
+  test('uses cached terminal surface viewport text, not scrollback DOM', () => {
     const wrapper = buildSessionWrapper([''], 0)
-    const allRows = Array.from({ length: 7 }, (_, i) => `row-${i}`)
-    terminalCache.set('pty-0', makeMockEntry(allRows.slice(5, 7), 5)!)
+    terminalCache.set('pty-0', makeMockEntry(['row-5', 'row-6'])!)
 
     expect(readPaneBuffer(wrapper)).toBe('row-5\nrow-6')
   })

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -1,4 +1,3 @@
-import type { Terminal } from '@xterm/xterm'
 import { invoke } from './backend'
 import { getAllPtySessionIds } from '../features/terminal/ptySessionMap'
 import { terminalCache } from '../features/terminal/components/TerminalPane/Body'
@@ -7,22 +6,6 @@ const isVisible = (el: HTMLElement): boolean => {
   const r = el.getBoundingClientRect()
 
   return r.width > 0 && r.height > 0
-}
-
-// Reads the visible viewport via xterm's buffer API — used when canvas renderers leave `.xterm-rows` empty.
-const bufferToText = (terminal: Terminal): string => {
-  const buffer = terminal.buffer.active
-  const start = buffer.viewportY
-  const end = start + terminal.rows
-  const lines: string[] = []
-  for (let i = start; i < end; i++) {
-    const line = buffer.getLine(i)
-    if (line) {
-      lines.push(line.translateToString(true))
-    }
-  }
-
-  return lines.join('\n').replace(/\n+$/, '')
 }
 
 // terminalCache is keyed by `pane.ptyId` (Body's `sessionId` prop). Find Body's `data-pty-id` descendant; fall back to the container's own data-pty-id when callers pass it directly.
@@ -78,13 +61,13 @@ export const readPaneBuffer = (container: HTMLElement): string => {
     return domText
   }
 
-  // DOM read empty — WebGL/Canvas2D renderer is rendering to <canvas>.
-  // Fall back to xterm's buffer API via terminalCache.
+  // DOM read empty — the renderer may be drawing to <canvas>.
+  // Fall back to the terminal surface's viewport reader via terminalCache.
   const cacheKey = resolveCacheKey(scope)
   if (cacheKey) {
     const entry = terminalCache.get(cacheKey)
     if (entry) {
-      return bufferToText(entry.terminal)
+      return entry.viewportReader.readVisibleText()
     }
   }
 


### PR DESCRIPTION
## Summary

Extracts a renderer-neutral terminal boundary around the current xterm implementation so this exploration can continue on an umbrella branch without binding new app logic to xterm internals.

## What changed

- Added `TerminalSurface`, `TerminalParser`, `TerminalViewportReader`, `TerminalFitController`, and `TerminalInstance` contracts.
- Moved xterm construction, addon fallback, theme conversion, OSC registration, key handler mapping, and visible-buffer reads into `xtermInstance.ts`.
- Routed `Body`, terminal hooks, the theme bridge, and the E2E bridge through the generic contracts.
- Added an ESLint guard blocking production `@xterm/*` imports outside the xterm adapter.
- Added a fake terminal contract test proving `Body` can run against a non-xterm `TerminalInstance`.
- Added exploration notes for the Ghostty replacement investigation and renderer-abstraction retrospective.

## Scope note

This does not add Ghostty support yet. It creates the adapter seam and containment guard for the next exploration stage.

## Validation

- `npx eslint ...`
- `npx vitest run ...` focused terminal/E2E set: 158 passed, 3 skipped
- `npx tsc -b --pretty false`

Known noise: existing React `act(...)` warnings still print from `useTerminal.test.ts`, but the tests pass.