### PR TITLE
feat(agent-status): stabilize VIM-127 body refresh (PR5)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -89,5 +89,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 3        | 0    | 2026-06-15   |
-| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 1        | 0    | 2026-06-15   |
+| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 0    | 2026-06-15   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 0    | 2026-06-15   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -89,3 +89,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 3        | 0    | 2026-06-15   |
+| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 1        | 0    | 2026-06-15   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -90,3 +90,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 3        | 0    | 2026-06-15   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 1        | 0    | 2026-06-15   |
+| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 0    | 2026-06-15   |

--- a/docs/reviews/patterns/retained-state-identity.md
+++ b/docs/reviews/patterns/retained-state-identity.md
@@ -1,0 +1,24 @@
+---
+id: retained-state-identity
+category: react-patterns
+created: 2026-06-15
+last_updated: 2026-06-15
+ref_count: 0
+---
+
+# Retained State Identity
+
+## Summary
+
+When a React component renders retained (stale) content while fresh data for a new context loads asynchronously, state reads and writes must be keyed to the correct identity. Reading saved state against the retained key is correct — it preserves scroll position or selection continuity for the content the user currently sees. However, writes triggered by the user's current interactions must be keyed to the active/target context, not the retained one. Writing interaction state back to the retained key corrupts the source context's saved state and causes it to reopen at the wrong offset or in the wrong configuration later. Guard every write path with an identity check (`retainedKey === activeKey`) and include the active key in the relevant callback dependencies.
+
+## Findings
+
+### 1. Retained body scroll writes to the source pane anchor
+
+- **Source:** github-claude | PR #468 round 1 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/components/AgentStatusPanel/index.tsx`
+- **Finding:** During retained-body fetching, `bodySnapshotKey` referred to the previously rendered/source pane while `snapshotKey` referred to the current target pane. The `handleScroll` callback wrote user scroll events to `bodySnapshotKey`, so scrolling retained content during the refresh window overwrote the source pane's saved scroll position and caused it to reopen at the wrong offset later.
+- **Fix:** Added an identity guard before `writeStatusScrollAnchor` that returns early when `bodySnapshotKey !== snapshotKey`, and added `snapshotKey` to the `handleScroll` `useCallback` dependencies.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/stale-retained-interactions.md
+++ b/docs/reviews/patterns/stale-retained-interactions.md
@@ -22,3 +22,12 @@ When a React component renders retained or stale content while fresh data for a 
 - **Finding:** While `useRetainedBodyState` showed a previous pane's retained snapshot during a cold-pane fetch (`phase === 'fetching'`), the body content remained fully interactive. Clicking a retained `FilesChanged` row or live action dispatched `onOpenDiff`/`onOpenFile` callbacks bound to the current pane's `cwd`, which could open the wrong diff or fail even though the visible row came from the old repo.
 - **Fix:** Added `isRetainedBody = isBodyFetching && bodySnapshotKey !== snapshotKey` and applied `inert` plus `select-none` to a wrapper around the non-skeleton body content. Same-pane refreshes and loading skeletons are unaffected. Added unit tests covering both the retained (inert) and same-pane refresh (interactive) cases.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 2. Retained-body inert test clicked a non-actionable ActivityFeed node
+
+- **Source:** github-codex-connector + local-codex verify | PR #468 round 2 | 2026-06-15
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/agent-status/components/AgentStatusPanel/index.test.tsx`
+- **Finding:** The test named `makes retained body non-interactive while fetching a cold target pane` clicked `src/retained.ts`, but that text was rendered by `ActivityFeed`, while `onOpenDiff` is only wired through `FilesChanged`. Because the retained snapshot used an empty `gitStatus`, there was no `FilesChanged` row to click, so `expect(onOpenDiff).not.toHaveBeenCalled()` stayed true even if `inert` were removed from the actionable body.
+- **Fix:** Populated the retained snapshot with a `gitStatus.files` entry and changed the click target to the rendered `FilesChanged` row button. Added an inert click-blocking polyfill to the jsdom test setup because jsdom exposes the `inert` attribute but does not suppress activation of inert subtrees, so synthetic clicks on the row would otherwise still dispatch `onOpenDiff` and make the meaningful assertion fail.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/stale-retained-interactions.md
+++ b/docs/reviews/patterns/stale-retained-interactions.md
@@ -1,0 +1,24 @@
+---
+id: stale-retained-interactions
+category: react-patterns
+created: 2026-06-15
+last_updated: 2026-06-15
+ref_count: 0
+---
+
+# Stale Retained Interactions
+
+## Summary
+
+When a React component renders retained or stale content while fresh data for a new context is loading asynchronously, interactive descendants must be made inert. If clicks, keyboard activation, or assistive-tech interaction remain enabled on the retained content, actions dispatch against callbacks bound to the current context and produce wrong results — for example, opening a diff or file for the old pane's path against the new pane's working directory. The fix is to detect the retained-content state and apply the `inert` attribute (or equivalent `pointer-events`/`select` disabling) to the retained-content wrapper, not to loading skeletons or to current-pane content.
+
+## Findings
+
+### 1. Make retained body non-interactive during pane switches
+
+- **Source:** github-codex-connector | PR #468 round 1 | 2026-06-15
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/agent-status/components/AgentStatusPanel/index.tsx`
+- **Finding:** While `useRetainedBodyState` showed a previous pane's retained snapshot during a cold-pane fetch (`phase === 'fetching'`), the body content remained fully interactive. Clicking a retained `FilesChanged` row or live action dispatched `onOpenDiff`/`onOpenFile` callbacks bound to the current pane's `cwd`, which could open the wrong diff or fail even though the visible row came from the old repo.
+- **Fix:** Added `isRetainedBody = isBodyFetching && bodySnapshotKey !== snapshotKey` and applied `inert` plus `select-none` to a wrapper around the non-skeleton body content. Same-pane refreshes and loading skeletons are unaffected. Added unit tests covering both the retained (inert) and same-pane refresh (interactive) cases.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/superpowers/specs/2026-06-14-activity-panel-hot-reload/README.md
+++ b/docs/superpowers/specs/2026-06-14-activity-panel-hot-reload/README.md
@@ -3,7 +3,7 @@
 **Linear:** [VIM-127](https://linear.app/vimeflow/issue/VIM-127/epic-stabilize-activity-panel-hot-reload-across-pane-switching)
 **Integration branch:** `feat/vim-127-activity-panel-hot-reload`
 **PR1 branch / worktree:** `feature/vim-127` on `worktrees/vim-127-activity-panel-hot-reload`
-**Status:** draft
+**Status:** PR5 in progress
 **Supporting design analysis:** [`docs/design/activity-panel-hot-reload-analysis.html`](../../../design/activity-panel-hot-reload-analysis.html)
 
 ## Overview
@@ -51,6 +51,7 @@ If Claude returns `overall_correctness: "patch has issues"`, fix only issues tha
 
 - The final implementation removes the visible jump/flicker behavior in the recording scenario: long histories, multiple panes, and fast pane switching.
 - Pane switches retain existing content and per-pane scroll position while fresh data loads.
+- Warm pane switches keep a retained below-header body visible until cold target status settles; first-load cases use fixed skeleton footprints instead of flashing empty content.
 - Prefetch stays bounded to visible panes in the current session unless a later PR explicitly revises that boundary.
 - Tests cover snapshot reuse, stale request drops, bounded prefetch, and scroll retention.
 - The final docs explain the implemented behavior and any remaining limitations.

--- a/docs/superpowers/specs/2026-06-14-activity-panel-hot-reload/pr-5-polish-observability.md
+++ b/docs/superpowers/specs/2026-06-14-activity-panel-hot-reload/pr-5-polish-observability.md
@@ -1,30 +1,41 @@
 # PR5 — Verification, Polish, And Observability
 
-**Status:** draft
-**Scope:** final validation, metrics, and docs
+**Status:** implementation
+**Scope:** body-level retained loading, final validation, and docs
 **Depends on:** PR4
 
 ## Goal
 
-Close VIM-127 with focused regression coverage, lightweight observability, and final documentation that reflects what was actually implemented.
+Close VIM-127 by addressing the remaining recording issue after PR4: scroll position is stable, but pane switches can still visually jump when the right panel body swaps from a rich pane to a cold/empty target before refresh completes.
+
+PR5 makes the body itself participate in the refresh phase. Header refresh remains the primary affordance, but the scroll/body region now retains the last stable rendered snapshot during a cold target refresh, exposes a subtle body-level sweep that is visible even when the header is cropped out of a recording, and uses fixed skeleton footprints only for genuine first-load cases with no retained content.
 
 ## Implementation Plan
 
-- Add or extend tests around the complete pane-switch workflow.
-- Capture lightweight development diagnostics for snapshot hit/miss, refresh duration, stale-result drops, and prefetch count.
+- Add a local `fresh | fetching | loading` body phase inside `AgentStatusPanel`.
+- Retain a bounded set of body snapshots keyed by `snapshotKey`; each snapshot carries status, cwd, cache history, and parent git status together so the below-header surface does not partially switch.
+- During refresh, render the target pane's retained body if available; otherwise retain the previously rendered content body while the target is still cold/empty.
+- Show fixed skeleton blocks only when refresh is active and there is no retained body content.
+- Add a body-level refresh sweep that overlays the scroll region without changing layout height.
+- Hold the hot-loading refresh flag for a short minimum duration so the phase is perceptible rather than a one-frame flash.
+- Add focused regression tests for retained body rendering, release after refresh, cold-load skeletons, and minimum refresh visibility.
 - Update the VIM-127 docs with final behavior, limitations, and follow-up ideas.
-- Run a manual verification pass against the original recording scenario: long status history, multiple panes, and quick switching.
-- Remove any temporary debugging affordances introduced during implementation.
 
 ## Tests
 
-- End-to-end or integration-level coverage for switching panes with long histories.
-- Unit coverage for scroll anchor restore, stale response drops, and bounded prefetch.
-- Regression coverage for retained content while refresh is pending.
+- Component coverage for switching from a rich pane to a cold pane while refresh is pending.
+- Component coverage that retained content releases after refresh settles.
+- Component coverage for cold-load skeletons when no retained content exists.
+- Hook coverage for minimum visible refresh duration.
+- Existing coverage for scroll anchor restore, stale response drops, and bounded prefetch.
 - Format, lint, type-check, and relevant Vitest suites.
 
 ## Acceptance Criteria
 
+- Switching from a long-history pane to a cold/empty pane does not immediately flash the empty body during refresh.
+- The body refresh affordance is visible inside the scroll/body region and does not alter layout height.
+- Cold loading is distinct from warm fetching: skeletons appear only when there is no retained content.
+- The hot-loading phase remains visible for a short minimum duration.
 - The final branch passes the agreed checks or clearly isolates unrelated pre-existing failures.
 - The final docs match the shipped behavior rather than the first-draft plan.
 - Claude Code reviewer returns `overall_correctness: "patch is correct"`.

--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -1092,6 +1092,89 @@ describe('AgentStatusPanel', () => {
     ).toHaveAttribute('data-body-phase', 'fresh')
   })
 
+  test('makes retained body non-interactive while fetching a cold target pane', () => {
+    const richStatus: AgentStatus = {
+      ...activeAgentStatus,
+      sessionId: 'pty-pane-1',
+      toolCalls: {
+        total: 1,
+        byType: { Read: 1 },
+        active: null,
+      },
+      recentToolCalls: [
+        {
+          id: 'old-read',
+          tool: 'Read',
+          args: 'src/retained.ts',
+          status: 'done',
+          durationMs: 100,
+          timestamp: '2026-04-22T11:59:00Z',
+          isTestFile: false,
+        },
+      ],
+    }
+
+    const coldStatus: AgentStatus = {
+      ...inactiveAgentStatus,
+      sessionId: 'pty-pane-2',
+    }
+
+    const onOpenDiff = vi.fn()
+
+    const { rerender } = render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={richStatus}
+        cwd="/tmp/repo"
+        gitStatus={createGitStatus()}
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={coldStatus}
+        cwd="/tmp/other"
+        gitStatus={createGitStatus({ filesCwd: '/tmp/other' })}
+        isRefreshing
+        snapshotKey="pty-pane-2"
+        onOpenDiff={onOpenDiff}
+      />
+    )
+
+    const content = screen.getByTestId('agent-status-panel-body-content')
+    expect(content).toHaveAttribute('inert')
+    expect(content).toHaveClass('select-none')
+    expect(screen.getByText('src/retained.ts')).toBeInTheDocument()
+
+    // Clicks on retained content must not dispatch while the snapshot is
+    // retained, because the action callbacks still belong to the current pane.
+    fireEvent.click(screen.getByText('src/retained.ts'))
+    expect(onOpenDiff).not.toHaveBeenCalled()
+  })
+
+  test('keeps the current body interactive during a same-pane refresh', () => {
+    const onOpenDiff = vi.fn()
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={activeAgentStatus}
+        cwd="/tmp/repo"
+        isRefreshing
+        snapshotKey="pty-pane-1"
+        onOpenDiff={onOpenDiff}
+      />
+    )
+
+    const content = screen.getByTestId('agent-status-panel-body-content')
+    expect(content).not.toHaveAttribute('inert')
+    expect(content).not.toHaveClass('select-none')
+
+    fireEvent.click(screen.getByText('a.ts'))
+    expect(onOpenDiff).toHaveBeenCalled()
+  })
+
   test('shows fixed body skeletons on a cold load with no retained content', () => {
     render(
       <AgentStatusPanel

--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { AGENTS } from '../../../../agents/registry'
 import type { AgentStatus } from '../../types'
 import * as useGitStatusModule from '../../../diff/hooks/useGitStatus'
+import type { UseGitStatusReturn } from '../../../diff/hooks/useGitStatus'
 import {
   clearStatusSnapshots,
   readStatusScrollAnchor,
@@ -103,6 +104,18 @@ const defaultProps = {
   onCollapse: (): void => undefined,
   cacheHistory: [],
 }
+
+const createGitStatus = (
+  overrides: Partial<UseGitStatusReturn> = {}
+): UseGitStatusReturn => ({
+  files: [],
+  filesCwd: '/tmp/repo',
+  loading: false,
+  error: null,
+  refresh: vi.fn(),
+  idle: false,
+  ...overrides,
+})
 
 describe('AgentStatusPanel', () => {
   afterEach(() => {
@@ -866,6 +879,167 @@ describe('AgentStatusPanel', () => {
 
     expect(scrollElement.scrollTop).toBe(120)
     expect(readStatusScrollAnchor('pty-pane-1')).toBe(120)
+  })
+
+  test('retains the previous content body while a cold target pane is refreshing', () => {
+    const richStatus: AgentStatus = {
+      ...activeAgentStatus,
+      sessionId: 'pty-pane-1',
+      toolCalls: {
+        total: 1,
+        byType: { Read: 1 },
+        active: null,
+      },
+      recentToolCalls: [
+        {
+          id: 'old-read',
+          tool: 'Read',
+          args: 'src/retained.ts',
+          status: 'done',
+          durationMs: 100,
+          timestamp: '2026-04-22T11:59:00Z',
+          isTestFile: false,
+        },
+      ],
+    }
+
+    const coldStatus: AgentStatus = {
+      ...inactiveAgentStatus,
+      sessionId: 'pty-pane-2',
+    }
+
+    const { rerender } = render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={richStatus}
+        cacheHistory={[75]}
+        cwd="/tmp/repo"
+        gitStatus={createGitStatus()}
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={coldStatus}
+        cacheHistory={[]}
+        cwd="/tmp/other"
+        gitStatus={createGitStatus({ filesCwd: '/tmp/other' })}
+        isRefreshing
+        snapshotKey="pty-pane-2"
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: /activity\s*1/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText('src/retained.ts')).toBeInTheDocument()
+    expect(screen.queryByText(/No activity yet/i)).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('agent-status-panel-body-refresh-indicator')
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByTestId('agent-status-panel-scroll-region')
+    ).toHaveAttribute('data-body-phase', 'fetching')
+  })
+
+  test('releases the retained body after refresh settles', () => {
+    const richStatus: AgentStatus = {
+      ...activeAgentStatus,
+      sessionId: 'pty-pane-1',
+      toolCalls: {
+        total: 1,
+        byType: { Read: 1 },
+        active: null,
+      },
+      recentToolCalls: [
+        {
+          id: 'old-read',
+          tool: 'Read',
+          args: 'src/retained.ts',
+          status: 'done',
+          durationMs: 100,
+          timestamp: '2026-04-22T11:59:00Z',
+          isTestFile: false,
+        },
+      ],
+    }
+
+    const coldStatus: AgentStatus = {
+      ...inactiveAgentStatus,
+      sessionId: 'pty-pane-2',
+    }
+
+    const { rerender } = render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={richStatus}
+        cwd="/tmp/repo"
+        gitStatus={createGitStatus()}
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={coldStatus}
+        cwd="/tmp/other"
+        gitStatus={createGitStatus({ filesCwd: '/tmp/other' })}
+        isRefreshing
+        snapshotKey="pty-pane-2"
+      />
+    )
+
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={coldStatus}
+        cwd="/tmp/other"
+        gitStatus={createGitStatus({ filesCwd: '/tmp/other' })}
+        snapshotKey="pty-pane-2"
+      />
+    )
+
+    expect(screen.queryByText('src/retained.ts')).not.toBeInTheDocument()
+    expect(screen.getByText(/No activity yet/i)).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('agent-status-panel-body-refresh-indicator')
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.getByTestId('agent-status-panel-scroll-region')
+    ).toHaveAttribute('data-body-phase', 'fresh')
+  })
+
+  test('shows fixed body skeletons on a cold load with no retained content', () => {
+    render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={{
+          ...inactiveAgentStatus,
+          sessionId: 'pty-pane-1',
+        }}
+        gitStatus={createGitStatus()}
+        isRefreshing
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    expect(
+      screen.getByTestId('agent-status-panel-overview-loading')
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByTestId('agent-status-panel-body-loading')
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/No activity yet/i)).not.toBeInTheDocument()
+    expect(screen.getByText('Loading agent status')).toHaveAttribute(
+      'aria-live',
+      'polite'
+    )
   })
 
   test('renders Header above the body with the provided agent status and onCollapse', async () => {

--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -945,6 +945,84 @@ describe('AgentStatusPanel', () => {
     ).toHaveAttribute('data-body-phase', 'fetching')
   })
 
+  test('keeps the last stable body during the pane-switch render before refresh starts', () => {
+    const richStatus: AgentStatus = {
+      ...activeAgentStatus,
+      sessionId: 'pty-pane-1',
+      toolCalls: {
+        total: 1,
+        byType: { Read: 1 },
+        active: null,
+      },
+      recentToolCalls: [
+        {
+          id: 'old-read',
+          tool: 'Read',
+          args: 'src/retained.ts',
+          status: 'done',
+          durationMs: 100,
+          timestamp: '2026-04-22T11:59:00Z',
+          isTestFile: false,
+        },
+      ],
+    }
+
+    const coldStatus: AgentStatus = {
+      ...inactiveAgentStatus,
+      sessionId: 'pty-pane-2',
+    }
+
+    const { rerender } = render(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={richStatus}
+        cacheHistory={[75]}
+        cwd="/tmp/repo"
+        gitStatus={createGitStatus()}
+        snapshotKey="pty-pane-1"
+      />
+    )
+
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={coldStatus}
+        cacheHistory={[]}
+        cwd="/tmp/other"
+        gitStatus={createGitStatus({ filesCwd: '/tmp/other' })}
+        snapshotKey="pty-pane-2"
+      />
+    )
+
+    expect(screen.getByText('fetching latest')).toBeInTheDocument()
+    expect(screen.getByText('src/retained.ts')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('agent-status-panel-body-loading')
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/No activity yet/i)).not.toBeInTheDocument()
+
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        agentStatus={coldStatus}
+        cacheHistory={[]}
+        cwd="/tmp/other"
+        gitStatus={createGitStatus({ filesCwd: '/tmp/other' })}
+        isRefreshing
+        snapshotKey="pty-pane-2"
+      />
+    )
+
+    expect(screen.getByText('src/retained.ts')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('agent-status-panel-body-loading')
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.getByTestId('agent-status-panel-scroll-region')
+    ).toHaveAttribute('data-body-phase', 'fetching')
+  })
+
   test('releases the retained body after refresh settles', () => {
     const richStatus: AgentStatus = {
       ...activeAgentStatus,

--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -1092,7 +1092,7 @@ describe('AgentStatusPanel', () => {
     ).toHaveAttribute('data-body-phase', 'fresh')
   })
 
-  test('makes retained body non-interactive while fetching a cold target pane', () => {
+  test('makes retained body non-interactive while fetching a cold target pane', async () => {
     const richStatus: AgentStatus = {
       ...activeAgentStatus,
       sessionId: 'pty-pane-1',
@@ -1121,12 +1121,24 @@ describe('AgentStatusPanel', () => {
 
     const onOpenDiff = vi.fn()
 
+    const retainedGitStatus = createGitStatus({
+      files: [
+        {
+          path: 'retained-diff.ts',
+          status: 'modified',
+          insertions: 3,
+          deletions: 1,
+          staged: false,
+        },
+      ],
+    })
+
     const { rerender } = render(
       <AgentStatusPanel
         {...defaultProps}
         agentStatus={richStatus}
         cwd="/tmp/repo"
-        gitStatus={createGitStatus()}
+        gitStatus={retainedGitStatus}
         snapshotKey="pty-pane-1"
       />
     )
@@ -1148,9 +1160,11 @@ describe('AgentStatusPanel', () => {
     expect(content).toHaveClass('select-none')
     expect(screen.getByText('src/retained.ts')).toBeInTheDocument()
 
-    // Clicks on retained content must not dispatch while the snapshot is
-    // retained, because the action callbacks still belong to the current pane.
-    fireEvent.click(screen.getByText('src/retained.ts'))
+    // Clicks on the retained FilesChanged row must not dispatch while the
+    // snapshot is retained, because onOpenDiff is wired through FilesChanged
+    // and would otherwise fire with the target pane's context.
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /retained-diff\.ts/ }))
     expect(onOpenDiff).not.toHaveBeenCalled()
   })
 

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -130,9 +130,15 @@ const useRetainedBodyState = ({
   isRefreshing,
   snapshotKey,
 }: RetainedBodyStateOptions): RetainedBodyState => {
-  const lastRenderedSnapshotRef = useRef<AgentStatusPanelBodySnapshot | null>(
+  const lastStableSnapshotRef = useRef<AgentStatusPanelBodySnapshot | null>(
     null
   )
+
+  const heldRefreshSnapshotRef = useRef<AgentStatusPanelBodySnapshot | null>(
+    null
+  )
+
+  const previousSnapshotKeyRef = useRef<string | null>(snapshotKey)
 
   const snapshotsByKeyRef = useRef<Map<string, AgentStatusPanelBodySnapshot>>(
     new Map()
@@ -155,6 +161,7 @@ const useRetainedBodyState = ({
       : (snapshotsByKeyRef.current.get(snapshotKey) ?? null)
 
   const currentHasContent = hasBodyContent(currentSnapshot)
+  const snapshotKeyChanged = previousSnapshotKeyRef.current !== snapshotKey
 
   const targetHasRetainedContent =
     targetSnapshot !== null && hasBodyContent(targetSnapshot)
@@ -162,37 +169,64 @@ const useRetainedBodyState = ({
   const retainedTargetSnapshot = targetHasRetainedContent
     ? targetSnapshot
     : null
-  const lastRenderedSnapshot = lastRenderedSnapshotRef.current
+  const lastStableSnapshot = lastStableSnapshotRef.current
 
-  const lastRenderedHasContent =
-    lastRenderedSnapshot !== null && hasBodyContent(lastRenderedSnapshot)
+  const lastStableHasContent =
+    lastStableSnapshot !== null && hasBodyContent(lastStableSnapshot)
 
-  const retainedLastSnapshot = lastRenderedHasContent
-    ? lastRenderedSnapshot
-    : null
+  const retainedLastSnapshot = lastStableHasContent ? lastStableSnapshot : null
 
-  const phase: AgentStatusPanelBodyPhase =
-    isRefreshing && !currentHasContent
-      ? targetHasRetainedContent || lastRenderedHasContent
-        ? 'fetching'
-        : 'loading'
+  const switchFallbackSnapshot =
+    snapshotKeyChanged && !currentHasContent
+      ? (retainedTargetSnapshot ?? retainedLastSnapshot)
+      : null
+
+  const retainedRefreshSnapshot =
+    retainedTargetSnapshot ??
+    heldRefreshSnapshotRef.current ??
+    switchFallbackSnapshot
+
+  const shouldRetainDuringRefresh =
+    (isRefreshing || snapshotKeyChanged) &&
+    !currentHasContent &&
+    retainedRefreshSnapshot !== null
+
+  const phase: AgentStatusPanelBodyPhase = shouldRetainDuringRefresh
+    ? 'fetching'
+    : isRefreshing && !currentHasContent
+      ? 'loading'
       : isRefreshing
         ? 'fetching'
         : 'fresh'
 
-  const snapshot =
-    phase === 'loading'
-      ? currentSnapshot
-      : isRefreshing && !currentHasContent && retainedTargetSnapshot !== null
-        ? retainedTargetSnapshot
-        : isRefreshing && !currentHasContent && retainedLastSnapshot !== null
-          ? retainedLastSnapshot
-          : currentSnapshot
+  const snapshot = shouldRetainDuringRefresh
+    ? retainedRefreshSnapshot
+    : currentSnapshot
+
+  useLayoutEffect(() => {
+    if (switchFallbackSnapshot !== null) {
+      heldRefreshSnapshotRef.current = switchFallbackSnapshot
+    }
+  }, [switchFallbackSnapshot])
 
   useEffect(() => {
-    rememberBodySnapshot(snapshotsByKeyRef.current, currentSnapshot)
-    lastRenderedSnapshotRef.current = snapshot
-  }, [currentSnapshot, snapshot])
+    previousSnapshotKeyRef.current = snapshotKey
+
+    if (currentHasContent) {
+      rememberBodySnapshot(snapshotsByKeyRef.current, currentSnapshot)
+      lastStableSnapshotRef.current = currentSnapshot
+    }
+
+    if (!isRefreshing && !snapshotKeyChanged) {
+      heldRefreshSnapshotRef.current = null
+    }
+  }, [
+    currentHasContent,
+    currentSnapshot,
+    isRefreshing,
+    snapshotKey,
+    snapshotKeyChanged,
+  ])
 
   return { phase, snapshot }
 }
@@ -290,6 +324,7 @@ export const AgentStatusPanel = ({
   const bodySnapshotKey = bodyState.snapshot.snapshotKey
   const isBodyLoading = bodyState.phase === 'loading'
   const isBodyRefreshing = bodyState.phase === 'fetching'
+  const showsRefreshing = isRefreshing || isBodyRefreshing
   const events = useActivityEvents(status)
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const programmaticScrollTopRef = useRef<number | null>(null)
@@ -497,7 +532,7 @@ export const AgentStatusPanel = ({
     >
       <AgentStatusPanelHeader
         agent={agent}
-        isRefreshing={isRefreshing}
+        isRefreshing={showsRefreshing}
         status={sessionStatus}
         onCollapse={onCollapse}
       />
@@ -505,7 +540,7 @@ export const AgentStatusPanel = ({
       <span className="sr-only" role="status" aria-live="polite">
         {isBodyLoading
           ? 'Loading agent status'
-          : isRefreshing
+          : showsRefreshing
             ? 'Fetching latest agent status'
             : ''}
       </span>

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -51,6 +51,216 @@ interface AgentStatusPanelProps {
 // parent's animation target from drifting away from the actual panel width.
 export const PANEL_WIDTH_PX = 280
 const DEFAULT_CONTEXT_WINDOW_SIZE = 200_000
+const MAX_RETAINED_BODY_SNAPSHOTS = 16
+
+type AgentStatusPanelBodyPhase = 'fresh' | 'fetching' | 'loading'
+
+interface AgentStatusPanelBodySnapshot {
+  cacheHistory: number[]
+  cwd: string
+  gitStatus: UseGitStatusReturn | undefined
+  snapshotKey: string | null
+  status: AgentStatus
+}
+
+interface RetainedBodyState {
+  phase: AgentStatusPanelBodyPhase
+  snapshot: AgentStatusPanelBodySnapshot
+}
+
+interface RetainedBodyStateOptions {
+  agentStatus: AgentStatus
+  cacheHistory: number[]
+  cwd: string
+  gitStatus: UseGitStatusReturn | undefined
+  isRefreshing: boolean
+  snapshotKey: string | null
+}
+
+const hasStatusContent = (status: AgentStatus): boolean =>
+  status.isActive ||
+  status.agentExited ||
+  status.agentType !== null ||
+  status.modelId !== null ||
+  status.modelDisplayName !== null ||
+  status.version !== null ||
+  status.agentSessionId !== null ||
+  status.contextWindow !== null ||
+  status.cost !== null ||
+  status.rateLimits !== null ||
+  status.numTurns > 0 ||
+  status.toolCalls.total > 0 ||
+  status.toolCalls.active !== null ||
+  status.recentToolCalls.length > 0 ||
+  status.testRun !== null
+
+const hasBodyContent = (snapshot: AgentStatusPanelBodySnapshot): boolean =>
+  hasStatusContent(snapshot.status) ||
+  snapshot.cacheHistory.length > 0 ||
+  (snapshot.gitStatus?.filesCwd === snapshot.cwd &&
+    snapshot.gitStatus.files.length > 0)
+
+const rememberBodySnapshot = (
+  snapshots: Map<string, AgentStatusPanelBodySnapshot>,
+  snapshot: AgentStatusPanelBodySnapshot
+): void => {
+  if (snapshot.snapshotKey === null) {
+    return
+  }
+
+  snapshots.delete(snapshot.snapshotKey)
+  snapshots.set(snapshot.snapshotKey, snapshot)
+
+  while (snapshots.size > MAX_RETAINED_BODY_SNAPSHOTS) {
+    const oldestKey = snapshots.keys().next().value
+
+    if (oldestKey === undefined) {
+      return
+    }
+
+    snapshots.delete(oldestKey)
+  }
+}
+
+const useRetainedBodyState = ({
+  agentStatus,
+  cacheHistory,
+  cwd,
+  gitStatus,
+  isRefreshing,
+  snapshotKey,
+}: RetainedBodyStateOptions): RetainedBodyState => {
+  const lastRenderedSnapshotRef = useRef<AgentStatusPanelBodySnapshot | null>(
+    null
+  )
+
+  const snapshotsByKeyRef = useRef<Map<string, AgentStatusPanelBodySnapshot>>(
+    new Map()
+  )
+
+  const currentSnapshot = useMemo<AgentStatusPanelBodySnapshot>(
+    () => ({
+      cacheHistory,
+      cwd,
+      gitStatus,
+      snapshotKey,
+      status: agentStatus,
+    }),
+    [agentStatus, cacheHistory, cwd, gitStatus, snapshotKey]
+  )
+
+  const targetSnapshot =
+    snapshotKey === null
+      ? null
+      : (snapshotsByKeyRef.current.get(snapshotKey) ?? null)
+
+  const currentHasContent = hasBodyContent(currentSnapshot)
+
+  const targetHasRetainedContent =
+    targetSnapshot !== null && hasBodyContent(targetSnapshot)
+
+  const retainedTargetSnapshot = targetHasRetainedContent
+    ? targetSnapshot
+    : null
+  const lastRenderedSnapshot = lastRenderedSnapshotRef.current
+
+  const lastRenderedHasContent =
+    lastRenderedSnapshot !== null && hasBodyContent(lastRenderedSnapshot)
+
+  const retainedLastSnapshot = lastRenderedHasContent
+    ? lastRenderedSnapshot
+    : null
+
+  const phase: AgentStatusPanelBodyPhase =
+    isRefreshing && !currentHasContent
+      ? targetHasRetainedContent || lastRenderedHasContent
+        ? 'fetching'
+        : 'loading'
+      : isRefreshing
+        ? 'fetching'
+        : 'fresh'
+
+  const snapshot =
+    phase === 'loading'
+      ? currentSnapshot
+      : isRefreshing && !currentHasContent && retainedTargetSnapshot !== null
+        ? retainedTargetSnapshot
+        : isRefreshing && !currentHasContent && retainedLastSnapshot !== null
+          ? retainedLastSnapshot
+          : currentSnapshot
+
+  useEffect(() => {
+    rememberBodySnapshot(snapshotsByKeyRef.current, currentSnapshot)
+    lastRenderedSnapshotRef.current = snapshot
+  }, [currentSnapshot, snapshot])
+
+  return { phase, snapshot }
+}
+
+const SkeletonLine = ({
+  className = '',
+}: {
+  className?: string
+}): ReactElement => (
+  <div
+    className={`rounded-full bg-outline-variant/20 motion-safe:animate-pulse ${className}`}
+  />
+)
+
+const AgentStatusPanelOverviewSkeleton = (): ReactElement => (
+  <div
+    data-testid="agent-status-panel-overview-loading"
+    className="flex flex-col gap-2 p-2"
+    aria-hidden="true"
+  >
+    <div className="rounded-md bg-surface-container/45 p-3">
+      <SkeletonLine className="h-2 w-24" />
+      <SkeletonLine className="mt-3 h-12 w-full rounded-md" />
+      <SkeletonLine className="mt-3 h-2 w-32" />
+    </div>
+    <div className="rounded-md bg-surface-container/35 p-3">
+      <SkeletonLine className="h-2 w-20" />
+      <SkeletonLine className="mt-3 h-7 w-16" />
+      <SkeletonLine className="mt-3 h-2 w-full" />
+    </div>
+  </div>
+)
+
+const AgentStatusPanelBodyRefreshIndicator = (): ReactElement => (
+  <div
+    data-testid="agent-status-panel-body-refresh-indicator"
+    className="pointer-events-none absolute inset-x-0 top-0 z-10 h-px overflow-hidden bg-outline-variant/15"
+    aria-hidden="true"
+  >
+    <div className="vf-activity-refresh-comet h-full" />
+  </div>
+)
+
+const AgentStatusPanelBodySkeleton = (): ReactElement => (
+  <div
+    data-testid="agent-status-panel-body-loading"
+    className="flex flex-col"
+    aria-hidden="true"
+  >
+    {[0, 1, 2].map((index) => (
+      <div
+        key={index}
+        className="border-t border-outline-variant/[0.08] px-5 py-3"
+      >
+        <div className="flex items-center gap-2">
+          <SkeletonLine className="h-2 w-2" />
+          <SkeletonLine className="h-2 w-24" />
+          <SkeletonLine className="h-2 w-6" />
+        </div>
+        <div className="mt-3 flex flex-col gap-2">
+          <SkeletonLine className="h-2 w-full" />
+          <SkeletonLine className="h-2 w-4/5" />
+          <SkeletonLine className="h-2 w-2/3" />
+        </div>
+      </div>
+    ))}
+  </div>
+)
 
 export const AgentStatusPanel = ({
   agentStatus,
@@ -65,7 +275,21 @@ export const AgentStatusPanel = ({
   cacheHistory,
   snapshotKey = null,
 }: AgentStatusPanelProps): ReactElement => {
-  const status = agentStatus
+  const bodyState = useRetainedBodyState({
+    agentStatus,
+    cacheHistory,
+    cwd,
+    gitStatus,
+    isRefreshing,
+    snapshotKey,
+  })
+  const status = bodyState.snapshot.status
+  const bodyCwd = bodyState.snapshot.cwd
+  const bodyGitStatus = bodyState.snapshot.gitStatus
+  const bodyCacheHistory = bodyState.snapshot.cacheHistory
+  const bodySnapshotKey = bodyState.snapshot.snapshotKey
+  const isBodyLoading = bodyState.phase === 'loading'
+  const isBodyRefreshing = bodyState.phase === 'fetching'
   const events = useActivityEvents(status)
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const programmaticScrollTopRef = useRef<number | null>(null)
@@ -77,15 +301,15 @@ export const AgentStatusPanel = ({
     scrollTop: number
   } | null>(null)
 
-  const internalGitStatus = useGitStatus(cwd, {
+  const internalGitStatus = useGitStatus(bodyCwd, {
     watch: true,
-    enabled: gitStatus === undefined && status.isActive,
+    enabled: bodyGitStatus === undefined && status.isActive,
   })
 
   const { files, filesCwd, loading, error, refresh, idle } =
-    gitStatus ?? internalGitStatus
+    bodyGitStatus ?? internalGitStatus
 
-  const filesAreFresh = filesCwd === cwd
+  const filesAreFresh = filesCwd === bodyCwd
 
   const effectiveFiles = useMemo(
     () => (filesAreFresh ? files : []),
@@ -127,7 +351,7 @@ export const AgentStatusPanel = ({
   const liveFile =
     runningEvent !== null &&
     (runningEvent.kind === 'edit' || runningEvent.kind === 'write')
-      ? matchChangedFile(effectiveFiles, runningEvent.body, cwd)
+      ? matchChangedFile(effectiveFiles, runningEvent.body, bodyCwd)
       : null
 
   const liveDiff =
@@ -147,7 +371,7 @@ export const AgentStatusPanel = ({
   const canActivate = liveFile !== null
 
   const restoreScrollAnchor = useCallback((): void => {
-    if (snapshotKey === null) {
+    if (bodySnapshotKey === null) {
       return
     }
 
@@ -157,22 +381,22 @@ export const AgentStatusPanel = ({
       return
     }
 
-    const scrollTop = readStatusScrollAnchor(snapshotKey)
+    const scrollTop = readStatusScrollAnchor(bodySnapshotKey)
 
     programmaticScrollTopRef.current = scrollTop
     scrollContainer.scrollTop = scrollTop
     programmaticScrollTopRef.current = scrollContainer.scrollTop
     scrollMetricsRef.current = {
       firstEventId: feedEvents[0]?.id ?? null,
-      snapshotKey,
+      snapshotKey: bodySnapshotKey,
       scrollHeight: scrollContainer.scrollHeight,
       scrollTop: scrollContainer.scrollTop,
     }
-    // restoreScrollAnchor intentionally depends only on snapshotKey. It runs on
-    // mount/key change to restore the saved scroll position; the latest feed
+    // restoreScrollAnchor intentionally depends only on bodySnapshotKey. It runs
+    // on mount/key change to restore the saved scroll position; the latest feed
     // identity is updated by the following layout effect on every render cycle.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [snapshotKey])
+  }, [bodySnapshotKey])
 
   useLayoutEffect(() => {
     restoreScrollAnchor()
@@ -187,7 +411,7 @@ export const AgentStatusPanel = ({
 
     const previousMetrics = scrollMetricsRef.current
 
-    if (previousMetrics?.snapshotKey === snapshotKey) {
+    if (previousMetrics?.snapshotKey === bodySnapshotKey) {
       const activityPrepended =
         (feedEvents[0]?.id ?? null) !== previousMetrics.firstEventId
 
@@ -211,8 +435,8 @@ export const AgentStatusPanel = ({
           scrollContainer.scrollTop = nextScrollTop
           programmaticScrollTopRef.current = scrollContainer.scrollTop
 
-          if (snapshotKey !== null) {
-            writeStatusScrollAnchor(snapshotKey, scrollContainer.scrollTop)
+          if (bodySnapshotKey !== null) {
+            writeStatusScrollAnchor(bodySnapshotKey, scrollContainer.scrollTop)
           }
         }
       }
@@ -220,12 +444,12 @@ export const AgentStatusPanel = ({
 
     scrollMetricsRef.current = {
       firstEventId: feedEvents[0]?.id ?? null,
-      snapshotKey,
+      snapshotKey: bodySnapshotKey,
       scrollHeight: scrollContainer.scrollHeight,
       scrollTop: scrollContainer.scrollTop,
     }
   }, [
-    snapshotKey,
+    bodySnapshotKey,
     feedEvents,
     runningId,
     status.toolCalls.total,
@@ -237,7 +461,7 @@ export const AgentStatusPanel = ({
 
   const handleScroll = useCallback(
     (event: UIEvent<HTMLDivElement>): void => {
-      if (snapshotKey === null) {
+      if (bodySnapshotKey === null) {
         return
       }
 
@@ -249,7 +473,7 @@ export const AgentStatusPanel = ({
         return
       }
 
-      writeStatusScrollAnchor(snapshotKey, nextScrollTop)
+      writeStatusScrollAnchor(bodySnapshotKey, nextScrollTop)
 
       const currentMetrics = scrollMetricsRef.current
       if (currentMetrics !== null) {
@@ -260,7 +484,7 @@ export const AgentStatusPanel = ({
         }
       }
     },
-    [snapshotKey]
+    [bodySnapshotKey]
   )
 
   return (
@@ -279,53 +503,72 @@ export const AgentStatusPanel = ({
       />
 
       <span className="sr-only" role="status" aria-live="polite">
-        {isRefreshing ? 'Fetching latest agent status' : ''}
+        {isBodyLoading
+          ? 'Loading agent status'
+          : isRefreshing
+            ? 'Fetching latest agent status'
+            : ''}
       </span>
 
-      <div className="flex flex-col gap-2 p-2">
-        <ContextBucket
-          usedPercentage={status.contextWindow?.usedPercentage ?? null}
-          contextWindowSize={
-            status.contextWindow?.contextWindowSize ??
-            DEFAULT_CONTEXT_WINDOW_SIZE
-          }
-          totalInputTokens={status.contextWindow?.totalInputTokens ?? 0}
-          totalOutputTokens={status.contextWindow?.totalOutputTokens ?? 0}
-        />
-        <TokenCache
-          usage={status.contextWindow?.currentUsage ?? null}
-          history={cacheHistory}
-        />
-      </div>
-
-      <div
-        ref={scrollContainerRef}
-        className="min-h-0 flex-1 overflow-y-auto overflow-x-clip"
-        onScroll={handleScroll}
-      >
-        <ToolCallSummary
-          total={status.toolCalls.total}
-          byType={status.toolCalls.byType}
-          active={runningEvent === null ? status.toolCalls.active : null}
-        />
-        {runningEvent !== null && (
-          <LiveActionCard
-            event={runningEvent}
-            now={now}
-            diff={liveDiff}
-            pathLabel={liveFile?.path}
-            onActivate={canActivate ? handleLiveActivate : undefined}
+      {isBodyLoading ? (
+        <AgentStatusPanelOverviewSkeleton />
+      ) : (
+        <div className="flex flex-col gap-2 p-2">
+          <ContextBucket
+            usedPercentage={status.contextWindow?.usedPercentage ?? null}
+            contextWindowSize={
+              status.contextWindow?.contextWindowSize ??
+              DEFAULT_CONTEXT_WINDOW_SIZE
+            }
+            totalInputTokens={status.contextWindow?.totalInputTokens ?? 0}
+            totalOutputTokens={status.contextWindow?.totalOutputTokens ?? 0}
           />
-        )}
-        <ActivityFeed events={feedEvents} />
-        <FilesChanged
-          files={effectiveFiles}
-          loading={effectiveLoading}
-          error={error}
-          onRetry={refresh}
-          onSelect={onOpenDiff}
-        />
-        <TestResults snapshot={status.testRun} onOpenFile={onOpenFile} />
+          <TokenCache
+            usage={status.contextWindow?.currentUsage ?? null}
+            history={bodyCacheHistory}
+          />
+        </div>
+      )}
+
+      <div className="relative min-h-0 flex-1">
+        {isBodyRefreshing && <AgentStatusPanelBodyRefreshIndicator />}
+        <div
+          ref={scrollContainerRef}
+          data-testid="agent-status-panel-scroll-region"
+          data-body-phase={bodyState.phase}
+          className="h-full overflow-y-auto overflow-x-clip"
+          onScroll={handleScroll}
+        >
+          {isBodyLoading ? (
+            <AgentStatusPanelBodySkeleton />
+          ) : (
+            <>
+              <ToolCallSummary
+                total={status.toolCalls.total}
+                byType={status.toolCalls.byType}
+                active={runningEvent === null ? status.toolCalls.active : null}
+              />
+              {runningEvent !== null && (
+                <LiveActionCard
+                  event={runningEvent}
+                  now={now}
+                  diff={liveDiff}
+                  pathLabel={liveFile?.path}
+                  onActivate={canActivate ? handleLiveActivate : undefined}
+                />
+              )}
+              <ActivityFeed events={feedEvents} />
+              <FilesChanged
+                files={effectiveFiles}
+                loading={effectiveLoading}
+                error={error}
+                onRetry={refresh}
+                onSelect={onOpenDiff}
+              />
+              <TestResults snapshot={status.testRun} onOpenFile={onOpenFile} />
+            </>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -509,6 +509,10 @@ export const AgentStatusPanel = ({
         return
       }
 
+      if (bodySnapshotKey !== snapshotKey) {
+        return
+      }
+
       writeStatusScrollAnchor(bodySnapshotKey, nextScrollTop)
 
       const currentMetrics = scrollMetricsRef.current
@@ -520,7 +524,7 @@ export const AgentStatusPanel = ({
         }
       }
     },
-    [bodySnapshotKey]
+    [bodySnapshotKey, snapshotKey]
   )
 
   return (

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -323,8 +323,9 @@ export const AgentStatusPanel = ({
   const bodyCacheHistory = bodyState.snapshot.cacheHistory
   const bodySnapshotKey = bodyState.snapshot.snapshotKey
   const isBodyLoading = bodyState.phase === 'loading'
-  const isBodyRefreshing = bodyState.phase === 'fetching'
-  const showsRefreshing = isRefreshing || isBodyRefreshing
+  const isBodyFetching = bodyState.phase === 'fetching'
+  const showsRefreshing = isRefreshing || isBodyFetching
+  const isRetainedBody = isBodyFetching && bodySnapshotKey !== snapshotKey
   const events = useActivityEvents(status)
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const programmaticScrollTopRef = useRef<number | null>(null)
@@ -566,7 +567,7 @@ export const AgentStatusPanel = ({
       )}
 
       <div className="relative min-h-0 flex-1">
-        {isBodyRefreshing && <AgentStatusPanelBodyRefreshIndicator />}
+        {isBodyFetching && <AgentStatusPanelBodyRefreshIndicator />}
         <div
           ref={scrollContainerRef}
           data-testid="agent-status-panel-scroll-region"
@@ -577,7 +578,11 @@ export const AgentStatusPanel = ({
           {isBodyLoading ? (
             <AgentStatusPanelBodySkeleton />
           ) : (
-            <>
+            <div
+              data-testid="agent-status-panel-body-content"
+              className={isRetainedBody ? 'select-none' : undefined}
+              inert={isRetainedBody || undefined}
+            >
               <ToolCallSummary
                 total={status.toolCalls.total}
                 byType={status.toolCalls.byType}
@@ -601,7 +606,7 @@ export const AgentStatusPanel = ({
                 onSelect={onOpenDiff}
               />
               <TestResults snapshot={status.testRun} onOpenFile={onOpenFile} />
-            </>
+            </div>
           )}
         </div>
       </div>

--- a/src/features/agent-status/hooks/useAgentStatusHotLoading.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatusHotLoading.test.ts
@@ -1,7 +1,10 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { refreshVisibleAgentStatusPanes } from '../utils/statusRefreshCoordinator'
-import { useAgentStatusHotLoading } from './useAgentStatusHotLoading'
+import {
+  MIN_AGENT_STATUS_REFRESH_MS,
+  useAgentStatusHotLoading,
+} from './useAgentStatusHotLoading'
 
 vi.mock('../utils/statusRefreshCoordinator', async () => {
   const actual = await vi.importActual<
@@ -73,5 +76,44 @@ describe('useAgentStatusHotLoading', () => {
     resolveRefresh([])
 
     await waitFor(() => expect(result.current).toBe(false))
+  })
+
+  test('keeps immediate refreshes visible for the minimum duration', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-15T12:00:00Z'))
+
+    try {
+      vi.mocked(refreshVisibleAgentStatusPanes).mockResolvedValueOnce([])
+
+      const { result } = renderHook(() =>
+        useAgentStatusHotLoading({
+          activePtyId: 'pty-a',
+          visiblePtyIds: ['pty-a'],
+        })
+      )
+
+      expect(refreshVisibleAgentStatusPanes).toHaveBeenCalledWith({
+        activePtyId: 'pty-a',
+        visiblePtyIds: ['pty-a'],
+      })
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(result.current).toBe(true)
+
+      act(() => {
+        vi.advanceTimersByTime(MIN_AGENT_STATUS_REFRESH_MS - 1)
+      })
+      expect(result.current).toBe(true)
+
+      act(() => {
+        vi.advanceTimersByTime(1)
+      })
+      expect(result.current).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/features/agent-status/hooks/useAgentStatusHotLoading.ts
+++ b/src/features/agent-status/hooks/useAgentStatusHotLoading.ts
@@ -9,6 +9,8 @@ interface UseAgentStatusHotLoadingOptions {
   visiblePtyIds: readonly string[]
 }
 
+export const MIN_AGENT_STATUS_REFRESH_MS = 320
+
 export const useAgentStatusHotLoading = ({
   activePtyId,
   visiblePtyIds,
@@ -33,6 +35,8 @@ export const useAgentStatusHotLoading = ({
     }
 
     let cancelled = false
+    let clearRefreshTimer: ReturnType<typeof setTimeout> | null = null
+    const startedAt = Date.now()
 
     setIsRefreshing(true)
 
@@ -43,9 +47,26 @@ export const useAgentStatusHotLoading = ({
         // A failed warm refresh should clear the subtle header affordance; the
         // live active-pane subscription remains the source of truth.
       } finally {
-        if (!cancelled && requestIdRef.current === requestId) {
-          setIsRefreshing(false)
+        const clearRefresh = (): void => {
+          if (!cancelled && requestIdRef.current === requestId) {
+            setIsRefreshing(false)
+          }
         }
+
+        if (cancelled || requestIdRef.current !== requestId) {
+          return
+        }
+
+        const elapsedMs = Date.now() - startedAt
+        const remainingMs = Math.max(0, MIN_AGENT_STATUS_REFRESH_MS - elapsedMs)
+
+        if (remainingMs === 0) {
+          clearRefresh()
+
+          return
+        }
+
+        clearRefreshTimer = setTimeout(clearRefresh, remainingMs)
       }
     }
 
@@ -53,6 +74,10 @@ export const useAgentStatusHotLoading = ({
 
     return (): void => {
       cancelled = true
+
+      if (clearRefreshTimer !== null) {
+        clearTimeout(clearRefreshTimer)
+      }
     }
   }, [refreshSignature])
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -98,6 +98,23 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   disconnect: vi.fn(),
 }))
 
+// jsdom exposes the `inert` attribute but does not suppress activation of
+// inert subtrees. Block click activation at capture so tests can assert the
+// real-browser non-interactivity behavior of retained/inert bodies.
+if (typeof document !== 'undefined') {
+  document.addEventListener(
+    'click',
+    (event): void => {
+      const target = event.target as Element | null
+      if (target !== null && target.closest('[inert]') !== null) {
+        event.stopImmediatePropagation()
+        event.preventDefault()
+      }
+    },
+    true
+  )
+}
+
 // Mock matchMedia for xterm.js (used for DPI detection and color scheme)
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
## Summary

- Add a body-level `fresh | fetching | loading` phase to the agent status panel.
- Retain the last stable below-header body during cold target pane refreshes, with a subtle body refresh sweep visible inside the scroll region.
- Add fixed cold-load skeletons and a minimum visible hot-loading duration so refresh state is not a one-frame flash.
- Update the VIM-127 PR5 docs to reflect the shipped follow-up scope.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `npm run test -- src/features/agent-status`
- `npm run test -- src/features/workspace/WorkspaceView.subscription.test.tsx`
- `npm run test` — 289 files, 3720 passed, 3 skipped
- `npm run build`
- Vite smoke: `curl -I http://127.0.0.1:5173/` returned HTTP 200

## Claude Review

- `claude -p "Reply with exactly: ok"` succeeded.
- Structured/broad Claude review could not complete: the first run attempted Bash under plan mode and ended with permission denials; two smaller no-tools review attempts hung without producing a verdict and were stopped.
