### PR TITLE
fix(agent-status): reset sidebar on codex clear

### DIFF
--- a/crates/backend/src/agent/adapter/claude_code/test_runners/emitter.rs
+++ b/crates/backend/src/agent/adapter/claude_code/test_runners/emitter.rs
@@ -34,6 +34,10 @@ impl TestRunEmitter {
         }
     }
 
+    pub fn clear_pending(&mut self) {
+        self.pending = None;
+    }
+
     pub fn finish_replay(&mut self) {
         if self.replay_done {
             return;
@@ -89,6 +93,16 @@ mod tests {
         let v = sink.recorded();
         assert_eq!(v.len(), 1);
         assert_eq!(v[0].1["summary"]["passed"], 3);
+    }
+
+    #[test]
+    fn clear_pending_drops_replay_buffer_without_ending_replay() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut e = TestRunEmitter::new(sink.clone());
+        e.submit(snap(1));
+        e.clear_pending();
+        e.finish_replay();
+        assert_eq!(sink.count("test-run"), 0);
     }
 
     #[test]

--- a/crates/backend/src/agent/adapter/codex/parser.rs
+++ b/crates/backend/src/agent/adapter/codex/parser.rs
@@ -28,9 +28,9 @@
 use serde::Deserialize;
 
 use super::super::serde_helpers::{lenient_f64, lenient_object, lenient_string, lenient_u64};
+use crate::agent::adapter::types::StatusSnapshot;
 #[cfg(test)]
 use crate::agent::adapter::types::{stamp_snapshot, ParsedStatus};
-use crate::agent::adapter::types::StatusSnapshot;
 use crate::agent::types::{
     ContextWindowStatus, CostMetrics, CurrentUsage, RateLimitInfo, RateLimits,
 };
@@ -323,7 +323,10 @@ fn fold_event(state: &mut CodexFoldState, line: CodexRolloutLine) {
     match line {
         CodexRolloutLine::SessionMeta { payload } => {
             if let Some(p) = payload {
-                if let Some(id) = p.id {
+                if let Some(id) = p.id.filter(|id| !id.is_empty()) {
+                    if !state.agent_session_id.is_empty() && state.agent_session_id != id {
+                        *state = CodexFoldState::default();
+                    }
                     state.agent_session_id = id;
                 }
                 if let Some(version) = p.cli_version {
@@ -507,6 +510,30 @@ mod tests {
     }
 
     #[test]
+    fn new_session_meta_resets_run_scoped_status() {
+        let raw = r#"{"timestamp":"...","type":"session_meta","payload":{"id":"old-run","cli_version":"0.139.0"}}
+{"timestamp":"...","type":"turn_context","payload":{"model":"gpt-old"}}
+{"timestamp":"...","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":9000,"output_tokens":1000,"cached_input_tokens":7000,"total_tokens":10000},"model_context_window":20000}}}
+{"timestamp":"...","type":"event_msg","payload":{"type":"task_complete","duration_ms":5000}}
+{"timestamp":"...","type":"session_meta","payload":{"id":"new-run","cli_version":"0.139.0"}}
+{"timestamp":"...","type":"turn_context","payload":{"model":"gpt-new"}}
+{"timestamp":"...","type":"event_msg","payload":{"type":"task_started","model_context_window":258000}}
+"#;
+
+        let parsed = parse_rollout("pty-clear", raw).expect("clear reset");
+        let event = parsed.event;
+
+        assert_eq!(event.agent_session_id, "new-run");
+        assert_eq!(event.model_id, "gpt-new");
+        assert_eq!(event.context_window.context_window_size, 258000);
+        assert_eq!(event.context_window.total_input_tokens, 0);
+        assert_eq!(event.context_window.total_output_tokens, 0);
+        assert!(event.context_window.current_usage.is_none());
+        assert_eq!(event.context_window.used_percentage, None);
+        assert_eq!(event.cost.total_duration_ms, 0);
+    }
+
+    #[test]
     fn multi_turn_sums_durations() {
         let raw = fixture("rollout-multi-turn.jsonl");
         let parsed = parse_rollout("pty-multi", &raw).expect("multi-turn");
@@ -542,8 +569,8 @@ mod tests {
     #[test]
     fn parse_rollout_snapshot_returns_session_id_free_status() {
         let raw = fixture("rollout-minimal.jsonl");
-        let snapshot = parse_rollout_snapshot(Some("pty-direct"), &raw)
-            .expect("snapshot should parse");
+        let snapshot =
+            parse_rollout_snapshot(Some("pty-direct"), &raw).expect("snapshot should parse");
         // R2.2: snapshot carries `agent_session_id` (from JSONL
         // payload) but NO Vimeflow session_id field — that's stamped
         // by the runtime via `stamp_snapshot`.

--- a/crates/backend/src/agent/adapter/codex/transcript.rs
+++ b/crates/backend/src/agent/adapter/codex/transcript.rs
@@ -314,7 +314,15 @@ fn process_line(
     // Capture Codex's own session id (session_meta) as the lifecycle identity,
     // then derive a phase from the event_msg turn boundary; replay-bounded.
     if matches!(record_type, CodexRecordType::SessionMeta) {
-        if let Some(id) = payload.id.as_deref() {
+        if let Some(id) = payload.id.as_deref().filter(|id| !id.is_empty()) {
+            if !codex_agent_session_id.is_empty() && codex_agent_session_id != id {
+                in_flight.clear();
+                *num_turns = 0;
+                *last_cwd = None;
+                *last_phase = None;
+                *replay_phase = None;
+                emitter.clear_pending();
+            }
             *codex_agent_session_id = id.to_string();
         }
     }
@@ -624,7 +632,11 @@ fn process_exec_command_end(
     if let Some(matched) = call.test_match {
         if let Some(cwd_ref) = cwd {
             let captured = CapturedOutput {
-                content: payload.aggregated_output.as_deref().unwrap_or("").to_string(),
+                content: payload
+                    .aggregated_output
+                    .as_deref()
+                    .unwrap_or("")
+                    .to_string(),
                 is_error: payload.exit_code.is_some_and(|code| code != 0),
             };
             if let Some(snapshot) = maybe_build_snapshot(BuildArgs {
@@ -772,7 +784,10 @@ fn custom_tool_output_failed(output: Option<&str>) -> bool {
         Err(_) => return false,
     };
 
-    parsed.metadata.and_then(|m| m.exit_code).is_some_and(|code| code != 0)
+    parsed
+        .metadata
+        .and_then(|m| m.exit_code)
+        .is_some_and(|code| code != 0)
 }
 
 fn exec_command_duration_ms(payload: &CodexPayloadDto) -> Option<u64> {
@@ -854,8 +869,9 @@ mod tests {
         let sink = Arc::new(FakeEventSink::new());
         let mut decoder = CodexTranscriptDecoder::new(sink.clone(), "sid".into(), None);
         decoder.decode_line(r#"{"type":"session_meta","payload":{"id":"cx-1","cwd":"/ws"}}"#);
-        decoder
-            .decode_line(r#"{"type":"event_msg","payload":{"type":"user_message","message":"hi"}}"#);
+        decoder.decode_line(
+            r#"{"type":"event_msg","payload":{"type":"user_message","message":"hi"}}"#,
+        );
         decoder.decode_line(
             r#"{"type":"event_msg","payload":{"type":"task_started","model_context_window":1}}"#,
         );
@@ -1154,9 +1170,21 @@ mod tests {
         let transcript_path = tmp.path().join("rollout.jsonl");
 
         let mut records = Vec::new();
-        records.extend(exec_test_pair("call_exec1", "2026-05-04T10:00:00Z", "2026-05-04T10:00:01Z"));
-        records.extend(exec_test_pair("call_exec2", "2026-05-04T10:00:02Z", "2026-05-04T10:00:03Z"));
-        records.extend(exec_test_pair("call_exec3", "2026-05-04T10:00:04Z", "2026-05-04T10:00:05Z"));
+        records.extend(exec_test_pair(
+            "call_exec1",
+            "2026-05-04T10:00:00Z",
+            "2026-05-04T10:00:01Z",
+        ));
+        records.extend(exec_test_pair(
+            "call_exec2",
+            "2026-05-04T10:00:02Z",
+            "2026-05-04T10:00:03Z",
+        ));
+        records.extend(exec_test_pair(
+            "call_exec3",
+            "2026-05-04T10:00:04Z",
+            "2026-05-04T10:00:05Z",
+        ));
         write_rollout(&transcript_path, &records);
 
         let handle = start_tailing(
@@ -1203,14 +1231,18 @@ mod tests {
     #[test]
     fn summarize_function_call_args_prefers_exec_command_cmd() {
         assert_eq!(
-            summarize_function_call_args(Some("{\"cmd\":\"cargo test --workspace --all-features\",\"workdir\":\"/tmp/ws\"}")),
+            summarize_function_call_args(Some(
+                "{\"cmd\":\"cargo test --workspace --all-features\",\"workdir\":\"/tmp/ws\"}"
+            )),
             "cargo test --workspace --all-features"
         );
     }
 
     #[test]
     fn custom_tool_output_failed_reads_metadata_exit_code() {
-        assert!(custom_tool_output_failed(Some("{\"output\":\"nope\",\"metadata\":{\"exit_code\":1}}")));
+        assert!(custom_tool_output_failed(Some(
+            "{\"output\":\"nope\",\"metadata\":{\"exit_code\":1}}"
+        )));
     }
 
     // ---- extract_session_cwd unit tests (v2: session_meta ONLY) ----
@@ -1223,7 +1255,9 @@ mod tests {
 
     #[test]
     fn extract_session_cwd_session_meta_returns_cwd() {
-        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"session_meta","payload":{"cwd":"/workspace/A"}}"#).unwrap();
+        let dto: CodexLineDto =
+            serde_json::from_str(r#"{"type":"session_meta","payload":{"cwd":"/workspace/A"}}"#)
+                .unwrap();
         assert_eq!(
             extract_session_cwd(dto.record_type(), &payload_of(&dto)),
             Some("/workspace/A".to_string())
@@ -1236,20 +1270,34 @@ mod tests {
         // Codex's turn_context.cwd is pinned to session-start and treating
         // it as live would cause false reverts after exec_command transitions.
         // This test is a defensive guard against re-introduction.
-        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"turn_context","payload":{"cwd":"/workspace/A"}}"#).unwrap();
-        assert_eq!(extract_session_cwd(dto.record_type(), &payload_of(&dto)), None);
+        let dto: CodexLineDto =
+            serde_json::from_str(r#"{"type":"turn_context","payload":{"cwd":"/workspace/A"}}"#)
+                .unwrap();
+        assert_eq!(
+            extract_session_cwd(dto.record_type(), &payload_of(&dto)),
+            None
+        );
     }
 
     #[test]
     fn extract_session_cwd_other_type_returns_none() {
-        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"event_msg","payload":{"cwd":"/workspace/A"}}"#).unwrap();
-        assert_eq!(extract_session_cwd(dto.record_type(), &payload_of(&dto)), None);
+        let dto: CodexLineDto =
+            serde_json::from_str(r#"{"type":"event_msg","payload":{"cwd":"/workspace/A"}}"#)
+                .unwrap();
+        assert_eq!(
+            extract_session_cwd(dto.record_type(), &payload_of(&dto)),
+            None
+        );
     }
 
     #[test]
     fn extract_session_cwd_empty_string_returns_none() {
-        let dto: CodexLineDto = serde_json::from_str(r#"{"type":"session_meta","payload":{"cwd":""}}"#).unwrap();
-        assert_eq!(extract_session_cwd(dto.record_type(), &payload_of(&dto)), None);
+        let dto: CodexLineDto =
+            serde_json::from_str(r#"{"type":"session_meta","payload":{"cwd":""}}"#).unwrap();
+        assert_eq!(
+            extract_session_cwd(dto.record_type(), &payload_of(&dto)),
+            None
+        );
     }
 
     // ---- extract_exec_workdir unit tests (the mid-session signal) ----
@@ -1268,31 +1316,46 @@ mod tests {
         // event_msg carrying a function_call-shaped payload should still
         // be rejected — the outer event type gate is response_item.
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"event_msg","payload":{"type":"function_call","name":"exec_command","arguments":"{\"workdir\":\"/x\"}"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(dto.record_type(), &payload_of(&dto)), None);
+        assert_eq!(
+            extract_exec_workdir(dto.record_type(), &payload_of(&dto)),
+            None
+        );
     }
 
     #[test]
     fn extract_exec_workdir_non_function_call_returns_none() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"custom_tool_call","name":"exec_command","input":"{\"workdir\":\"/x\"}"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(dto.record_type(), &payload_of(&dto)), None);
+        assert_eq!(
+            extract_exec_workdir(dto.record_type(), &payload_of(&dto)),
+            None
+        );
     }
 
     #[test]
     fn extract_exec_workdir_non_exec_command_returns_none() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"read_file","arguments":"{\"path\":\"/x\"}"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(dto.record_type(), &payload_of(&dto)), None);
+        assert_eq!(
+            extract_exec_workdir(dto.record_type(), &payload_of(&dto)),
+            None
+        );
     }
 
     #[test]
     fn extract_exec_workdir_malformed_arguments_json_returns_none() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{not json"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(dto.record_type(), &payload_of(&dto)), None);
+        assert_eq!(
+            extract_exec_workdir(dto.record_type(), &payload_of(&dto)),
+            None
+        );
     }
 
     #[test]
     fn extract_exec_workdir_missing_workdir_field_returns_none() {
         let dto: CodexLineDto = serde_json::from_str(r#"{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"}}"#).unwrap();
-        assert_eq!(extract_exec_workdir(dto.record_type(), &payload_of(&dto)), None);
+        assert_eq!(
+            extract_exec_workdir(dto.record_type(), &payload_of(&dto)),
+            None
+        );
     }
 
     // ---- process_line transition-semantics tests ----
@@ -1473,6 +1536,114 @@ mod tests {
         assert_eq!(last_cwd.as_deref(), Some("/workspace/B"));
     }
 
+    #[test]
+    fn process_line_new_session_meta_resets_run_scoped_tail_state() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+        let mut codex_agent_session_id = String::new();
+        let mut last_phase = None;
+        let mut replay_phase = None;
+
+        let lines = [
+            r#"{"timestamp":"2026-05-22T10:00:00Z","type":"session_meta","payload":{"id":"old-run","cwd":"/workspace/A"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:01Z","type":"event_msg","payload":{"type":"user_message","message":"old prompt"}}"#,
+            r#"{"timestamp":"2026-05-22T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"old-call","arguments":"{\"cmd\":\"npm run lint\"}"}}"#,
+        ];
+        for line in lines {
+            process_line(
+                line,
+                "sid-1",
+                None,
+                &events,
+                &mut emitter,
+                &mut in_flight,
+                &mut num_turns,
+                &mut last_cwd,
+                &mut codex_agent_session_id,
+                &mut last_phase,
+                &mut replay_phase,
+                true,
+            );
+        }
+
+        assert_eq!(codex_agent_session_id, "old-run");
+        assert_eq!(num_turns, 1);
+        assert_eq!(in_flight.len(), 1);
+
+        process_line(
+            r#"{"timestamp":"2026-05-22T10:00:03Z","type":"session_meta","payload":{"id":"new-run","cwd":"/workspace/A"}}"#,
+            "sid-1",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut codex_agent_session_id,
+            &mut last_phase,
+            &mut replay_phase,
+            true,
+        );
+
+        assert_eq!(codex_agent_session_id, "new-run");
+        assert_eq!(num_turns, 0);
+        assert!(in_flight.is_empty());
+        assert_eq!(last_cwd.as_deref(), Some("/workspace/A"));
+
+        process_line(
+            r#"{"timestamp":"2026-05-22T10:00:04Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"old-call","exit_code":0,"duration":10}}"#,
+            "sid-1",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut codex_agent_session_id,
+            &mut last_phase,
+            &mut replay_phase,
+            true,
+        );
+        process_line(
+            r#"{"timestamp":"2026-05-22T10:00:05Z","type":"event_msg","payload":{"type":"user_message","message":"new prompt"}}"#,
+            "sid-1",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut codex_agent_session_id,
+            &mut last_phase,
+            &mut replay_phase,
+            true,
+        );
+
+        let tool_calls: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-tool-call")
+            .collect();
+        assert_eq!(
+            tool_calls.len(),
+            1,
+            "the old running tool call must not complete after a /clear boundary"
+        );
+        assert_eq!(num_turns, 1);
+
+        let turns: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-turn")
+            .map(|(_, payload)| payload["numTurns"].clone())
+            .collect();
+        assert_eq!(turns, vec![json!(1), json!(1)]);
+    }
+
     // ---- DTO-migration regression tests (Task 1.6) ----
 
     #[test]
@@ -1485,12 +1656,42 @@ mod tests {
         let mut last_cwd: Option<String> = None;
 
         let start = r#"{"timestamp":"2026-05-22T10:00:00Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\"}"}}"#;
-        process_line(start, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd, &mut String::new(), &mut None, &mut None, true);
+        process_line(
+            start,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
 
         let end = r#"{"timestamp":"2026-05-22T10:00:01Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"c1","exit_code":"bad","aggregated_output":"ok"}}"#;
-        process_line(end, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd, &mut String::new(), &mut None, &mut None, true);
+        process_line(
+            end,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
 
-        let tool_calls: Vec<_> = sink.recorded().into_iter().filter(|(n, _)| n == "agent-tool-call").collect();
+        let tool_calls: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-tool-call")
+            .collect();
         assert_eq!(tool_calls.len(), 2);
         assert_eq!(tool_calls[1].1["status"], "done");
     }
@@ -1505,12 +1706,42 @@ mod tests {
         let mut last_cwd: Option<String> = None;
 
         let start = r#"{"timestamp":"2026-05-22T10:00:00Z","type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","call_id":"c1","input":"*** Begin Patch\n*** Update File: foo.ts\n*** End Patch"}}"#;
-        process_line(start, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd, &mut String::new(), &mut None, &mut None, true);
+        process_line(
+            start,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
 
         let end = r#"{"timestamp":"2026-05-22T10:00:01Z","type":"event_msg","payload":{"type":"patch_apply_end","call_id":"c1","success":"bad"}}"#;
-        process_line(end, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd, &mut String::new(), &mut None, &mut None, true);
+        process_line(
+            end,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
 
-        let tool_calls: Vec<_> = sink.recorded().into_iter().filter(|(n, _)| n == "agent-tool-call").collect();
+        let tool_calls: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-tool-call")
+            .collect();
         assert_eq!(tool_calls.len(), 2);
         assert_eq!(tool_calls[1].1["status"], "failed");
     }
@@ -1525,12 +1756,42 @@ mod tests {
         let mut last_cwd: Option<String> = None;
 
         let start = r#"{"timestamp":"2026-05-22T10:00:00Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"ls\"}"}}"#;
-        process_line(start, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd, &mut String::new(), &mut None, &mut None, true);
+        process_line(
+            start,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
 
         let end = r#"{"timestamp":"2026-05-22T10:00:01Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"c1","exit_code":0,"duration":null}}"#;
-        process_line(end, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd, &mut String::new(), &mut None, &mut None, true);
+        process_line(
+            end,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
 
-        let tool_calls: Vec<_> = sink.recorded().into_iter().filter(|(n, _)| n == "agent-tool-call").collect();
+        let tool_calls: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-tool-call")
+            .collect();
         assert_eq!(tool_calls.len(), 2);
         assert_eq!(tool_calls[1].1["durationMs"], 0);
     }
@@ -1545,9 +1806,26 @@ mod tests {
         let mut last_cwd: Option<String> = None;
 
         let line = r#"{"timestamp":42,"type":"event_msg","payload":{"type":"user_message","message":"hello"}}"#;
-        process_line(line, "sid", None, &events, &mut emitter, &mut in_flight, &mut num_turns, &mut last_cwd, &mut String::new(), &mut None, &mut None, true);
+        process_line(
+            line,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
 
-        let turns: Vec<_> = sink.recorded().into_iter().filter(|(n, _)| n == "agent-turn").collect();
+        let turns: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-turn")
+            .collect();
         assert_eq!(turns.len(), 1);
     }
 

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -91,3 +91,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 1        | 0    | 2026-06-13   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
+| [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 1        | 0    | 2026-06-15   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -91,4 +91,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 1        | 0    | 2026-06-13   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
-| [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 1        | 0    | 2026-06-15   |
+| [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 2        | 1    | 2026-06-15   |

--- a/docs/reviews/patterns/agent-state-guards.md
+++ b/docs/reviews/patterns/agent-state-guards.md
@@ -3,7 +3,7 @@ id: agent-state-guards
 category: correctness
 created: 2026-06-15
 last_updated: 2026-06-15
-ref_count: 0
+ref_count: 1
 ---
 
 # Agent-State Guards
@@ -21,4 +21,13 @@ UI state that tracks an active agent session must validate the agent's identity 
 - **File:** `src/features/workspace/WorkspaceView.tsx` L544-564
 - **Finding:** `handleTerminalCommandSubmit` incremented the agent-status reset generation for any `/clear` command submitted from any terminal pane, with no check that the pane was actually running Codex. A false positive in a subprocess (e.g. searching `/clear` in vim and pressing Enter) captured the still-running Codex session ID and token total, causing `useAgentStatus` to suppress every subsequent same-run status, tool-call, turn, and test-run event until a real session boundary or pane switch.
 - **Fix:** Gated `setAgentStatusReset` on `agentStatus.agentType === 'codex'` when the submitted `/clear` came from the active PTY-backed pane. Cache-history clearing for the matching pane remained unconditional because it is harmless on a false positive. Added a regression test covering the non-Codex case.
+- **Commit:** same commit as this entry
+
+### 2. Stale status event leaks through null priorTokenTotal gate
+
+- **Source:** github-claude | PR #469 round 2 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/hooks/useAgentStatus.ts` L480-512
+- **Finding:** After a local `/clear` reset, `useAgentStatus` compared arriving `agent-status` token totals against a pre-reset snapshot to decide whether the event was stale. If the React state had no `contextWindow` snapshot at reset time (`priorTokenTotal === null`), neither suppression branch fired, so a concurrent stale same-run status event repopulated `agentSessionId` and `contextWindow` and also cleared the run-scoped event latch, allowing old tool-call, turn, and test-run events to refill the sidebar.
+- **Fix:** Added a conservative `priorTokenTotal === null` early-return inside the same-session reset guard. When freshness cannot be measured, the hook keeps the previous cleared state and preserves the run-scoped suppression latch until a fresh session boundary (different `agentSessionId`) arrives. Added a regression test covering the null-snapshot case.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/agent-state-guards.md
+++ b/docs/reviews/patterns/agent-state-guards.md
@@ -1,0 +1,24 @@
+---
+id: agent-state-guards
+category: correctness
+created: 2026-06-15
+last_updated: 2026-06-15
+ref_count: 0
+---
+
+# Agent-State Guards
+
+## Summary
+
+UI state that tracks an active agent session must validate the agent's identity and lifecycle phase before reacting to events that could originate from the agent, the shell, or a subprocess running inside the same PTY. Raw terminal input — keystrokes, command submissions, or PTY data — is not self-describing; the same byte sequence can come from the user typing in a shell, a full-screen tool like vim, or an actual agent command. Acting on such input without confirming the pane is running the expected agent type can reset, suppress, or corrupt agent-scoped state and leave the UI inconsistent for the remainder of the session. Always gate agent-scoped mutations on an explicit agent-type or session-identity signal, and keep non-agent side effects scoped so a false positive does not cascade.
+
+## Findings
+
+### 1. Missing agent-type guard: false /clear detection silences live Codex events
+
+- **Source:** github-claude | PR #469 round 1 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.tsx` L544-564
+- **Finding:** `handleTerminalCommandSubmit` incremented the agent-status reset generation for any `/clear` command submitted from any terminal pane, with no check that the pane was actually running Codex. A false positive in a subprocess (e.g. searching `/clear` in vim and pressing Enter) captured the still-running Codex session ID and token total, causing `useAgentStatus` to suppress every subsequent same-run status, tool-call, turn, and test-run event until a real session boundary or pane switch.
+- **Fix:** Gated `setAgentStatusReset` on `agentStatus.agentType === 'codex'` when the submitted `/clear` came from the active PTY-backed pane. Cache-history clearing for the matching pane remained unconditional because it is harmless on a false positive. Added a regression test covering the non-Codex case.
+- **Commit:** same commit as this entry

--- a/src/features/agent-status/hooks/useAgentStatus.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.test.ts
@@ -1257,6 +1257,131 @@ describe('useAgentStatus', () => {
     expect(result.current.toolCalls.active?.toolUseId).toBe('new-running-call')
   })
 
+  test('resetGeneration with null contextWindow suppresses same-run status until new session boundary', async () => {
+    const { result, rerender } = renderHook(
+      ({ resetGeneration }: { resetGeneration: number }) =>
+        useAgentStatus('session-1', resetGeneration),
+      { initialProps: { resetGeneration: 0 } }
+    )
+
+    await vi.waitFor(() => {
+      expect(eventListeners.get('agent-status')?.length).toBe(1)
+      expect(eventListeners.get('agent-tool-call')?.length).toBe(1)
+      expect(eventListeners.get('agent-turn')?.length).toBe(1)
+    })
+
+    // Establish a run with a known agentSessionId but no contextWindow snapshot.
+    act(() => {
+      emit('agent-status', {
+        sessionId: 'pty-session-1',
+        modelId: 'gpt-5.5',
+        modelDisplayName: 'GPT-5.5',
+        version: '0.139.0',
+        agentSessionId: 'codex-old',
+        contextWindow: null,
+        cost: null,
+        rateLimits: null,
+      })
+    })
+
+    expect(result.current.agentSessionId).toBe('codex-old')
+    expect(result.current.contextWindow).toBeNull()
+
+    // Trigger the local reset before any token total is known.
+    rerender({ resetGeneration: 1 })
+
+    expect(result.current.agentSessionId).toBeNull()
+    expect(result.current.contextWindow).toBeNull()
+
+    // A stale same-run status event with a non-null contextWindow must not
+    // repopulate the cleared sidebar, because freshness is undecidable when
+    // the pre-reset snapshot lacked a token total.
+    act(() => {
+      emit('agent-status', {
+        sessionId: 'pty-session-1',
+        modelId: 'gpt-5.5',
+        modelDisplayName: 'GPT-5.5',
+        version: '0.139.0',
+        agentSessionId: 'codex-old',
+        contextWindow: {
+          usedPercentage: 80,
+          remainingPercentage: 20,
+          contextWindowSize: 258000,
+          totalInputTokens: 9000,
+          totalOutputTokens: 1000,
+          currentUsage: null,
+        },
+        cost: null,
+        rateLimits: null,
+      })
+    })
+
+    expect(result.current.agentSessionId).toBeNull()
+    expect(result.current.contextWindow).toBeNull()
+
+    // Run-scoped events must stay suppressed for the same session.
+    act(() => {
+      emit('agent-tool-call', {
+        sessionId: 'pty-session-1',
+        toolUseId: 'stale-running-call',
+        tool: 'exec_command',
+        args: 'aws ssm get-command-invocation',
+        status: 'running',
+        timestamp: '2026-06-15T12:01:00Z',
+        durationMs: null,
+      })
+
+      emit('agent-turn', {
+        sessionId: 'pty-session-1',
+        numTurns: 9,
+      })
+    })
+
+    expect(result.current.toolCalls.active).toBeNull()
+    expect(result.current.toolCalls.total).toBe(0)
+    expect(result.current.numTurns).toBe(0)
+
+    // A fresh session boundary clears the suppression latch and allows updates.
+    act(() => {
+      emit('agent-status', {
+        sessionId: 'pty-session-1',
+        modelId: 'gpt-5.5',
+        modelDisplayName: 'GPT-5.5',
+        version: '0.139.0',
+        agentSessionId: 'codex-new',
+        contextWindow: {
+          usedPercentage: 1,
+          remainingPercentage: 99,
+          contextWindowSize: 258000,
+          totalInputTokens: 10,
+          totalOutputTokens: 1,
+          currentUsage: null,
+        },
+        cost: null,
+        rateLimits: null,
+      })
+    })
+
+    expect(result.current.agentSessionId).toBe('codex-new')
+    expect(result.current.contextWindow?.usedPercentage).toBe(1)
+
+    act(() => {
+      emit('agent-tool-call', {
+        sessionId: 'pty-session-1',
+        toolUseId: 'fresh-running-call',
+        tool: 'exec_command',
+        args: 'npm test',
+        status: 'running',
+        timestamp: '2026-06-15T12:02:00Z',
+        durationMs: null,
+      })
+    })
+
+    expect(result.current.toolCalls.active?.toolUseId).toBe(
+      'fresh-running-call'
+    )
+  })
+
   test('does not invoke start_agent_watcher again while a prior start is in flight', async () => {
     let resolveStart: (() => void) | undefined
 

--- a/src/features/agent-status/hooks/useAgentStatus.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.test.ts
@@ -1113,6 +1113,150 @@ describe('useAgentStatus', () => {
     expect(result.current.toolCalls.total).toBe(0)
   })
 
+  test('resetGeneration clears run-scoped state and ignores stale same-run status', async () => {
+    const { result, rerender } = renderHook(
+      ({ resetGeneration }: { resetGeneration: number }) =>
+        useAgentStatus('session-1', resetGeneration),
+      { initialProps: { resetGeneration: 0 } }
+    )
+
+    await vi.waitFor(() => {
+      expect(eventListeners.get('agent-status')?.length).toBe(1)
+      expect(eventListeners.get('agent-tool-call')?.length).toBe(1)
+      expect(eventListeners.get('agent-turn')?.length).toBe(1)
+    })
+
+    act(() => {
+      emit('agent-status', {
+        sessionId: 'pty-session-1',
+        modelId: 'gpt-5.5',
+        modelDisplayName: 'GPT-5.5',
+        version: '0.139.0',
+        agentSessionId: 'codex-old',
+        contextWindow: {
+          usedPercentage: 80,
+          remainingPercentage: 20,
+          contextWindowSize: 258000,
+          totalInputTokens: 9000,
+          totalOutputTokens: 1000,
+          currentUsage: null,
+        },
+        cost: null,
+        rateLimits: null,
+      })
+
+      emit('agent-tool-call', {
+        sessionId: 'pty-session-1',
+        tool: 'exec_command',
+        args: 'npm run lint',
+        status: 'done',
+        durationMs: 100,
+        timestamp: '2026-06-15T12:00:00Z',
+        toolUseId: 'call-1',
+        isTestFile: false,
+      })
+
+      emit('agent-turn', {
+        sessionId: 'pty-session-1',
+        numTurns: 3,
+      })
+    })
+
+    expect(result.current.agentSessionId).toBe('codex-old')
+    expect(result.current.contextWindow?.usedPercentage).toBe(80)
+    expect(result.current.recentToolCalls).toHaveLength(1)
+    expect(result.current.numTurns).toBe(3)
+
+    rerender({ resetGeneration: 1 })
+
+    expect(result.current.agentSessionId).toBeNull()
+    expect(result.current.modelId).toBe('gpt-5.5')
+    expect(result.current.contextWindow).toBeNull()
+    expect(result.current.recentToolCalls).toEqual([])
+    expect(result.current.numTurns).toBe(0)
+
+    act(() => {
+      emit('agent-status', {
+        sessionId: 'pty-session-1',
+        modelId: 'gpt-5.5',
+        modelDisplayName: 'GPT-5.5',
+        version: '0.139.0',
+        agentSessionId: 'codex-old',
+        contextWindow: {
+          usedPercentage: 80,
+          remainingPercentage: 20,
+          contextWindowSize: 258000,
+          totalInputTokens: 9000,
+          totalOutputTokens: 1000,
+          currentUsage: null,
+        },
+        cost: null,
+        rateLimits: null,
+      })
+    })
+
+    expect(result.current.agentSessionId).toBeNull()
+    expect(result.current.contextWindow).toBeNull()
+
+    act(() => {
+      emit('agent-tool-call', {
+        sessionId: 'pty-session-1',
+        toolUseId: 'old-running-call',
+        tool: 'exec_command',
+        args: 'aws ssm get-command-invocation',
+        status: 'running',
+        timestamp: '2026-06-15T12:01:00Z',
+        durationMs: null,
+      })
+
+      emit('agent-turn', {
+        sessionId: 'pty-session-1',
+        numTurns: 9,
+      })
+    })
+
+    expect(result.current.toolCalls.active).toBeNull()
+    expect(result.current.toolCalls.total).toBe(0)
+    expect(result.current.numTurns).toBe(0)
+
+    act(() => {
+      emit('agent-status', {
+        sessionId: 'pty-session-1',
+        modelId: 'gpt-5.5',
+        modelDisplayName: 'GPT-5.5',
+        version: '0.139.0',
+        agentSessionId: 'codex-old',
+        contextWindow: {
+          usedPercentage: 1,
+          remainingPercentage: 99,
+          contextWindowSize: 258000,
+          totalInputTokens: 10,
+          totalOutputTokens: 1,
+          currentUsage: null,
+        },
+        cost: null,
+        rateLimits: null,
+      })
+    })
+
+    expect(result.current.agentSessionId).toBe('codex-old')
+    expect(result.current.contextWindow?.usedPercentage).toBe(1)
+
+    act(() => {
+      emit('agent-tool-call', {
+        sessionId: 'pty-session-1',
+        toolUseId: 'new-running-call',
+        tool: 'exec_command',
+        args: 'npm test',
+        status: 'running',
+        timestamp: '2026-06-15T12:02:00Z',
+        durationMs: null,
+      })
+    })
+
+    expect(result.current.toolCalls.active?.toolUseId).toBe('new-running-call')
+  })
+
   test('does not invoke start_agent_watcher again while a prior start is in flight', async () => {
     let resolveStart: (() => void) | undefined
 

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -482,15 +482,18 @@ export const useAgentStatus = (
             ) {
               const priorTokenTotal = locallyResetTokenTotalRef.current
               const nextTokenTotal = eventTokenTotal(p.contextWindow)
+              if (priorTokenTotal === null) {
+                return prev
+              }
+
               if (
-                priorTokenTotal !== null &&
                 nextTokenTotal !== null &&
                 nextTokenTotal >= priorTokenTotal
               ) {
                 return prev
               }
 
-              if (priorTokenTotal !== null && nextTokenTotal === null) {
+              if (nextTokenTotal === null) {
                 return prev
               }
 

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -50,6 +50,35 @@ const createDefaultStatus = (sessionId: string | null): AgentStatus => ({
   testRun: null,
 })
 
+const createRunResetStatus = (
+  prev: AgentStatus,
+  sessionId: string | null
+): AgentStatus => ({
+  ...createDefaultStatus(sessionId),
+  isActive: prev.isActive,
+  agentExited: prev.agentExited,
+  agentType: prev.agentType,
+  modelId: prev.modelId,
+  modelDisplayName: prev.modelDisplayName,
+  version: prev.version,
+  cwd: prev.cwd,
+})
+
+const statusTokenTotal = (
+  contextWindow: AgentStatus['contextWindow']
+): number | null =>
+  contextWindow === null
+    ? null
+    : contextWindow.totalInputTokens + contextWindow.totalOutputTokens
+
+const eventTokenTotal = (
+  contextWindow: AgentStatusEvent['contextWindow']
+): number | null =>
+  contextWindow === null
+    ? null
+    : Number(contextWindow.totalInputTokens) +
+      Number(contextWindow.totalOutputTokens)
+
 /**
  * Stop all agent watchers for a given session (best-effort, logs on failure).
  *
@@ -76,11 +105,18 @@ const stopWatchers = async (
   }
 }
 
-export const useAgentStatus = (sessionId: string | null): AgentStatus => {
+export const useAgentStatus = (
+  sessionId: string | null,
+  resetGeneration = 0
+): AgentStatus => {
   const [status, setStatus] = useState<AgentStatus>(() =>
     createDefaultStatus(sessionId)
   )
   const prevSessionIdRef = useRef<string | null>(sessionId)
+  const prevResetGenerationRef = useRef(resetGeneration)
+  const locallyResetAgentSessionIdRef = useRef<string | null>(null)
+  const locallyResetTokenTotalRef = useRef<number | null>(null)
+  const locallyResetRunScopedEventsRef = useRef(false)
 
   // Two refs with distinct semantics — DO NOT collapse them. Collapsing
   // them was the source of the F1 panel-stuck bug Codex flagged twice
@@ -147,6 +183,26 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
   // fire before the event listeners below are attached.
   const listenersReadyRef = useRef(false)
 
+  useEffect(() => {
+    if (prevResetGenerationRef.current === resetGeneration) {
+      return
+    }
+
+    prevResetGenerationRef.current = resetGeneration
+    if (collapseTimeoutRef.current) {
+      clearTimeout(collapseTimeoutRef.current)
+      collapseTimeoutRef.current = null
+    }
+
+    setStatus((prev) => {
+      locallyResetAgentSessionIdRef.current = prev.agentSessionId
+      locallyResetTokenTotalRef.current = statusTokenTotal(prev.contextWindow)
+      locallyResetRunScopedEventsRef.current = true
+
+      return createRunResetStatus(prev, sessionId)
+    })
+  }, [resetGeneration, sessionId])
+
   // Reset state when sessionId changes
   useEffect(() => {
     if (prevSessionIdRef.current !== sessionId) {
@@ -169,6 +225,9 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
       watcherStartGenerationRef.current += 1
       knownPtyIdRef.current = undefined
       detectedAgentPidRef.current = null
+      locallyResetAgentSessionIdRef.current = null
+      locallyResetTokenTotalRef.current = null
+      locallyResetRunScopedEventsRef.current = false
       listenersReadyRef.current = false
       if (collapseTimeoutRef.current) {
         clearTimeout(collapseTimeoutRef.current)
@@ -415,6 +474,43 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
           const p = payload
 
           setStatus((prev) => {
+            const locallyResetAgentSessionId =
+              locallyResetAgentSessionIdRef.current
+            if (
+              locallyResetAgentSessionId !== null &&
+              p.agentSessionId === locallyResetAgentSessionId
+            ) {
+              const priorTokenTotal = locallyResetTokenTotalRef.current
+              const nextTokenTotal = eventTokenTotal(p.contextWindow)
+              if (
+                priorTokenTotal !== null &&
+                nextTokenTotal !== null &&
+                nextTokenTotal >= priorTokenTotal
+              ) {
+                return prev
+              }
+
+              if (priorTokenTotal !== null && nextTokenTotal === null) {
+                return prev
+              }
+
+              locallyResetAgentSessionIdRef.current = null
+              locallyResetTokenTotalRef.current = null
+            }
+
+            if (
+              locallyResetAgentSessionId !== null &&
+              p.agentSessionId !== locallyResetAgentSessionId
+            ) {
+              locallyResetAgentSessionIdRef.current = null
+              locallyResetTokenTotalRef.current = null
+              locallyResetRunScopedEventsRef.current = false
+            }
+
+            if (locallyResetAgentSessionIdRef.current === null) {
+              locallyResetRunScopedEventsRef.current = false
+            }
+
             const base =
               p.agentSessionId !== null &&
               prev.agentSessionId !== null &&
@@ -507,6 +603,10 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
             return
           }
 
+          if (locallyResetRunScopedEventsRef.current) {
+            return
+          }
+
           const p = payload
 
           if (p.status === 'running') {
@@ -573,6 +673,10 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
             return
           }
 
+          if (locallyResetRunScopedEventsRef.current) {
+            return
+          }
+
           // numTurns is u32 in the Rust binding — fits safely in JS number,
           // no Number() coercion needed (those are reserved for u64/i64
           // fields where serde-json may emit values past Number.MAX_SAFE_INTEGER).
@@ -616,6 +720,10 @@ export const useAgentStatus = (sessionId: string | null): AgentStatus => {
         'test-run',
         (payload) => {
           if (payload.sessionId !== resolvePtyId()) {
+            return
+          }
+
+          if (locallyResetRunScopedEventsRef.current) {
             return
           }
 

--- a/src/features/agent-status/hooks/useCacheHistoryCollector.test.tsx
+++ b/src/features/agent-status/hooks/useCacheHistoryCollector.test.tsx
@@ -16,10 +16,12 @@ describe('useCacheHistoryCollector', () => {
 
     const props = {
       ptyId: 'p',
+      runId: 'run-1',
       sessionId: 's',
       paneId: 'p0',
       usage: usage(7500, 1800, 700),
       onReading,
+      onReset: vi.fn(),
     }
 
     const { rerender } = renderHook((p) => useCacheHistoryCollector(p), {
@@ -35,10 +37,12 @@ describe('useCacheHistoryCollector', () => {
     renderHook(() =>
       useCacheHistoryCollector({
         ptyId: 'p',
+        runId: 'run-1',
         sessionId: 's',
         paneId: 'p0',
         usage: null,
         onReading,
+        onReset: vi.fn(),
       })
     )
     expect(onReading).not.toHaveBeenCalled()
@@ -48,10 +52,12 @@ describe('useCacheHistoryCollector', () => {
     const onReading = vi.fn()
 
     const base = {
+      runId: 'run-1',
       sessionId: 's',
       paneId: 'p0',
       usage: usage(7500, 1800, 700),
       onReading,
+      onReset: vi.fn(),
     }
 
     const { rerender } = renderHook((p) => useCacheHistoryCollector(p), {
@@ -59,5 +65,37 @@ describe('useCacheHistoryCollector', () => {
     })
     rerender({ ...base, ptyId: 'q' })
     expect(onReading).toHaveBeenCalledTimes(2)
+  })
+
+  test('resets without appending a stale duplicate when runId changes on the same ptyId', () => {
+    const onReading = vi.fn()
+    const onReset = vi.fn()
+
+    const base = {
+      ptyId: 'p',
+      sessionId: 's',
+      paneId: 'p0',
+      usage: usage(7500, 1800, 700),
+      onReading,
+      onReset,
+    }
+
+    const { rerender } = renderHook((p) => useCacheHistoryCollector(p), {
+      initialProps: { ...base, runId: 'run-1' },
+    })
+
+    rerender({ ...base, runId: 'run-2' })
+
+    expect(onReset).toHaveBeenCalledWith('s', 'p0')
+    expect(onReading).toHaveBeenCalledTimes(1)
+
+    rerender({
+      ...base,
+      runId: 'run-2',
+      usage: usage(4000, 1000, 5000),
+    })
+
+    expect(onReading).toHaveBeenCalledTimes(2)
+    expect(onReading).toHaveBeenLastCalledWith('s', 'p0', 40)
   })
 })

--- a/src/features/agent-status/hooks/useCacheHistoryCollector.ts
+++ b/src/features/agent-status/hooks/useCacheHistoryCollector.ts
@@ -4,26 +4,61 @@ import { cacheHitPercentage } from '../utils/cacheRate'
 
 export interface UseCacheHistoryCollectorArgs {
   ptyId: string | null
+  runId: string | null
   sessionId: string | null
   paneId: string | null
   usage: CurrentUsageState | null
   onReading: (sessionId: string, paneId: string, percentage: number) => void
+  onReset: (sessionId: string, paneId: string) => void
 }
 
-// Emits one reading per changed percentage; resets when the ptyId changes.
+// Emits one reading per changed percentage; clears history when the agent run
+// changes on the same PTY.
 export const useCacheHistoryCollector = ({
   ptyId,
+  runId,
   sessionId,
   paneId,
   usage,
   onReading,
+  onReset,
 }: UseCacheHistoryCollectorArgs): void => {
   const lastRef = useRef<{ ptyId: string | null; pct: number | null }>({
     ptyId: null,
     pct: null,
   })
+
+  const lastRunRef = useRef<{ ptyId: string | null; runId: string | null }>({
+    ptyId: null,
+    runId: null,
+  })
   const onReadingRef = useRef(onReading)
+  const onResetRef = useRef(onReset)
   onReadingRef.current = onReading
+  onResetRef.current = onReset
+
+  useEffect(() => {
+    if (
+      ptyId === null ||
+      runId === null ||
+      sessionId === null ||
+      paneId === null
+    ) {
+      return
+    }
+
+    const lastRun = lastRunRef.current
+    if (
+      lastRun.ptyId === ptyId &&
+      lastRun.runId !== null &&
+      lastRun.runId !== runId
+    ) {
+      lastRef.current = { ptyId, pct: cacheHitPercentage(usage) }
+      onResetRef.current(sessionId, paneId)
+    }
+
+    lastRunRef.current = { ptyId, runId }
+  }, [ptyId, runId, sessionId, paneId, usage])
 
   useEffect(() => {
     if (ptyId === null || sessionId === null || paneId === null) {

--- a/src/features/sessions/hooks/useSessionManager.test.ts
+++ b/src/features/sessions/hooks/useSessionManager.test.ts
@@ -300,6 +300,45 @@ describe('useSessionManager', () => {
     ).toEqual([75])
   })
 
+  test('clearPaneCacheHistory clears pane cacheHistory and deletes its persisted key', async () => {
+    window.localStorage.clear()
+    const service = createMockService()
+    service.listSessions = vi.fn().mockResolvedValue({
+      activeSessionId: 'pty-1',
+      sessions: [
+        {
+          id: 'pty-1',
+          cwd: '/tmp',
+          status: {
+            kind: 'Alive',
+            pid: 1,
+            replay_data: '',
+            replay_end_offset: BigInt(0),
+          },
+        },
+      ],
+    })
+
+    const { result } = renderHook(() =>
+      useSessionManager(service, { autoCreateOnEmpty: false })
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => {
+      result.current.appendPaneCacheReading('pty-1', 'p0', 75)
+    })
+    expect(result.current.sessions[0].panes[0].cacheHistory).toEqual([75])
+
+    act(() => {
+      result.current.clearPaneCacheHistory('pty-1', 'p0')
+    })
+
+    expect(result.current.sessions[0].panes[0].cacheHistory).toEqual([])
+    expect(
+      window.localStorage.getItem('vimeflow:agent:cacheHistory:pty-1')
+    ).toBeNull()
+  })
+
   test('removeSession deletes the pane cacheHistory key for the killed pty', async () => {
     window.localStorage.clear()
     const service = createMockService()

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -108,6 +108,7 @@ export interface SessionManager {
     paneId: string,
     percentage: number
   ) => void
+  clearPaneCacheHistory: (sessionId: string, paneId: string) => void
   updateBrowserPaneUrl?: (
     sessionId: string,
     paneId: string,
@@ -1794,6 +1795,33 @@ export const useSessionManager = (
     []
   )
 
+  const clearPaneCacheHistory = useCallback(
+    (sessionId: string, paneId: string): void => {
+      const target = sessionsRef.current.find((s) => s.id === sessionId)
+      const targetPane = target?.panes.find((p) => p.id === paneId)
+      if (!targetPane) {
+        return
+      }
+
+      deleteCacheHistory(targetPane.ptyId)
+
+      setSessions((prev) =>
+        prev.map((session) => {
+          if (session.id !== sessionId) {
+            return session
+          }
+
+          const panes = session.panes.map((pane) =>
+            pane.id === paneId ? { ...pane, cacheHistory: [] } : pane
+          )
+
+          return { ...session, panes }
+        })
+      )
+    },
+    []
+  )
+
   const updatePaneAgentType = useCallback(
     (
       sessionId: string,
@@ -1938,6 +1966,7 @@ export const useSessionManager = (
     reorderSessions,
     updatePaneCwd,
     appendPaneCacheReading,
+    clearPaneCacheHistory,
     updatePaneAgentType,
     updateBrowserPaneUrl,
     setSessionActivityPanelCollapsed,

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -35,6 +35,7 @@ export interface SplitViewProps {
   isActive: boolean
   onSessionCwdChange?: (sessionId: string, paneId: string, cwd: string) => void
   onPaneReady?: NotifyPaneReady
+  onCommandSubmit?: (ptyId: string, command: string) => void
   onSessionRestart?: (sessionId: string) => void
   onSetActivePane?: (sessionId: string, paneId: string) => void
   onBrowserPaneUrlChange?: (
@@ -104,6 +105,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
       isActive,
       onSessionCwdChange = undefined,
       onPaneReady = undefined,
+      onCommandSubmit = undefined,
       onSessionRestart = undefined,
       onSetActivePane = undefined,
       onBrowserPaneUrlChange = undefined,
@@ -342,6 +344,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                             onSessionCwdChange?.(session.id, pane.id, cwd)
                           }
                           onPaneReady={onPaneReady}
+                          onCommandSubmit={onCommandSubmit}
                           onRestart={onSessionRestart}
                           onClose={closeHandler}
                           onBurner={onBurner}

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -12,7 +12,11 @@ import {
   type BodyHandle,
 } from './Body'
 import { TERMINAL_FONT_FAMILY } from './terminalFont'
-import { useTerminal, type UseTerminalReturn } from '../../hooks/useTerminal'
+import {
+  useTerminal,
+  type UseTerminalOptions,
+  type UseTerminalReturn,
+} from '../../hooks/useTerminal'
 import type { ITerminalService } from '../../services/terminalService'
 import { obsidianLens } from '../../../../theme'
 
@@ -81,6 +85,16 @@ vi.mock('@xterm/addon-canvas', () => ({
 vi.mock('../../hooks/useTerminal', () => ({
   useTerminal: vi.fn(),
 }))
+
+let latestUseTerminalOptionsValue: UseTerminalOptions | null = null
+
+const latestUseTerminalOptions = (): UseTerminalOptions => {
+  if (latestUseTerminalOptionsValue === null) {
+    throw new Error('useTerminal was not called')
+  }
+
+  return latestUseTerminalOptionsValue
+}
 
 describe('Body', () => {
   let mockTerminal: {
@@ -157,7 +171,14 @@ describe('Body', () => {
     vi.mocked(Terminal).mockImplementation(() => mockTerminal as never)
     vi.mocked(FitAddon).mockImplementation(() => mockFitAddon as never)
     vi.mocked(CanvasAddon).mockImplementation(() => mockCanvasAddon as never)
-    vi.mocked(useTerminal).mockReturnValue(mockUseTerminal)
+    latestUseTerminalOptionsValue = null
+    vi.mocked(useTerminal).mockImplementation(
+      (options: UseTerminalOptions): UseTerminalReturn => {
+        latestUseTerminalOptionsValue = options
+
+        return mockUseTerminal
+      }
+    )
   })
 
   afterEach(() => {
@@ -190,6 +211,57 @@ describe('Body', () => {
     expect(screen.getByTestId('terminal-pane-body-wrapper')).toHaveClass(
       'terminal-pane-body'
     )
+  })
+
+  test('reports submitted terminal command lines from xterm input', async () => {
+    const onCommandSubmit = vi.fn()
+
+    render(
+      <Body
+        sessionId="test-session"
+        cwd="/home/user"
+        service={defaultMockService}
+        onCommandSubmit={onCommandSubmit}
+      />
+    )
+
+    await waitFor(() => {
+      expect(useTerminal).toHaveBeenCalled()
+    })
+
+    const options = latestUseTerminalOptions()
+    act(() => {
+      options.onInput?.('/')
+      options.onInput?.('clears')
+      options.onInput?.('\x7f')
+      options.onInput?.('\r')
+    })
+
+    expect(onCommandSubmit).toHaveBeenCalledWith('test-session', '/clear')
+  })
+
+  test('reports slash commands submitted through bracketed paste input', async () => {
+    const onCommandSubmit = vi.fn()
+
+    render(
+      <Body
+        sessionId="test-session"
+        cwd="/home/user"
+        service={defaultMockService}
+        onCommandSubmit={onCommandSubmit}
+      />
+    )
+
+    await waitFor(() => {
+      expect(useTerminal).toHaveBeenCalled()
+    })
+
+    const options = latestUseTerminalOptions()
+    act(() => {
+      options.onInput?.('\x1b[200~/clear\x1b[201~\r')
+    })
+
+    expect(onCommandSubmit).toHaveBeenCalledWith('test-session', '/clear')
   })
 
   test('initializes xterm terminal on mount', async () => {

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -376,52 +376,55 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     [applyAgentCwdHint, flushAgentCwdOutputBuffer]
   )
 
-  const handleTerminalInput = useCallback((data: string): void => {
-    if (agentCwdSourceRef.current !== 'text-hint') {
-      // Continue below; command submission still needs to be tracked even when
-      // the cwd hint guard has nothing to unlock.
-    } else {
-      agentCwdSourceRef.current = 'user-input'
-      logAgentCwdDebug('user-input', {
-        sessionId,
-        agentCwd: agentCwdRef.current,
-        unlocked: true,
-      })
-    }
+  const handleTerminalInput = useCallback(
+    (data: string): void => {
+      if (agentCwdSourceRef.current !== 'text-hint') {
+        // Continue below; command submission still needs to be tracked even when
+        // the cwd hint guard has nothing to unlock.
+      } else {
+        agentCwdSourceRef.current = 'user-input'
+        logAgentCwdDebug('user-input', {
+          sessionId,
+          agentCwd: agentCwdRef.current,
+          unlocked: true,
+        })
+      }
 
-    for (const char of stripTerminalInputControlSequences(data)) {
-      if (char === '\r' || char === '\n') {
-        const submitted = submittedInputLineRef.current.trim()
-        submittedInputLineRef.current = ''
-        if (submitted.length > 0) {
-          onCommandSubmitRef.current?.(sessionIdRef.current, submitted)
+      for (const char of stripTerminalInputControlSequences(data)) {
+        if (char === '\r' || char === '\n') {
+          const submitted = submittedInputLineRef.current.trim()
+          submittedInputLineRef.current = ''
+          if (submitted.length > 0) {
+            onCommandSubmitRef.current?.(sessionIdRef.current, submitted)
+          }
+
+          continue
         }
 
-        continue
+        if (char === '\b' || char === '\x7f') {
+          submittedInputLineRef.current = submittedInputLineRef.current.slice(
+            0,
+            -1
+          )
+
+          continue
+        }
+
+        if (char === '\u0003' || char === '\u0015') {
+          submittedInputLineRef.current = ''
+
+          continue
+        }
+
+        if (char < ' ' || char === '\u001b') {
+          continue
+        }
+
+        submittedInputLineRef.current += char
       }
-
-      if (char === '\b' || char === '\x7f') {
-        submittedInputLineRef.current = submittedInputLineRef.current.slice(
-          0,
-          -1
-        )
-
-        continue
-      }
-
-      if (char === '\u0003' || char === '\u0015') {
-        submittedInputLineRef.current = ''
-
-        continue
-      }
-
-      if (char < ' ' || char === '\u001b') {
-        continue
-      }
-
-      submittedInputLineRef.current += char
-    }
-  }, [sessionId])
+    },
+    [sessionId]
+  )
 
   const handleRestoreStart = useCallback((): void => {
     isRestoringOutputRef.current = true

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -44,6 +44,12 @@ import '@xterm/xterm/css/xterm.css'
 
 const AGENT_CWD_HINT_BUFFER_SIZE = 4096
 
+const TERMINAL_INPUT_CONTROL_SEQUENCE_PATTERN =
+  /\u001b\[[0-?]*[ -/]*[@-~]|\u001b\][^\u0007]*(?:\u0007|\u001b\\)|\u001b[@-Z\\-_]/g
+
+const stripTerminalInputControlSequences = (data: string): string =>
+  data.replace(TERMINAL_INPUT_CONTROL_SEQUENCE_PATTERN, '')
+
 const shouldPreserveOsc7FileUrlHost = (currentCwd?: string): boolean =>
   Boolean(
     currentCwd &&
@@ -168,6 +174,11 @@ export interface BodyProps {
   onPaneReady?: NotifyPaneReady
 
   /**
+   * Called when the user submits a full terminal command line.
+   */
+  onCommandSubmit?: (ptyId: string, command: string) => void
+
+  /**
    * Explicit lifecycle mode — see {@link BodyMode}.
    * @default 'spawn'
    */
@@ -204,6 +215,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     restoredFrom = undefined,
     onCwdChange = undefined,
     onPaneReady = undefined,
+    onCommandSubmit = undefined,
     mode = 'spawn',
     onPtyStatusChange = undefined,
     onFocusChange = undefined,
@@ -227,6 +239,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const cwdPropRef = useRef(cwd)
   const agentCwdRef = useRef(cwd)
   const agentCwdSourceRef = useRef<AgentCwdSource>('prop')
+  const submittedInputLineRef = useRef('')
   const sessionIdRef = useRef(sessionId)
   sessionIdRef.current = sessionId
 
@@ -239,6 +252,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   useEffect(() => {
     onCwdChangeRef.current = onCwdChange
   }, [onCwdChange])
+
+  const onCommandSubmitRef = useRef(onCommandSubmit)
+  useEffect(() => {
+    onCommandSubmitRef.current = onCommandSubmit
+  }, [onCommandSubmit])
 
   useEffect(() => {
     const previousCwd = agentCwdRef.current
@@ -358,17 +376,51 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     [applyAgentCwdHint, flushAgentCwdOutputBuffer]
   )
 
-  const handleTerminalInput = useCallback((): void => {
+  const handleTerminalInput = useCallback((data: string): void => {
     if (agentCwdSourceRef.current !== 'text-hint') {
-      return
+      // Continue below; command submission still needs to be tracked even when
+      // the cwd hint guard has nothing to unlock.
+    } else {
+      agentCwdSourceRef.current = 'user-input'
+      logAgentCwdDebug('user-input', {
+        sessionId,
+        agentCwd: agentCwdRef.current,
+        unlocked: true,
+      })
     }
 
-    agentCwdSourceRef.current = 'user-input'
-    logAgentCwdDebug('user-input', {
-      sessionId,
-      agentCwd: agentCwdRef.current,
-      unlocked: true,
-    })
+    for (const char of stripTerminalInputControlSequences(data)) {
+      if (char === '\r' || char === '\n') {
+        const submitted = submittedInputLineRef.current.trim()
+        submittedInputLineRef.current = ''
+        if (submitted.length > 0) {
+          onCommandSubmitRef.current?.(sessionIdRef.current, submitted)
+        }
+
+        continue
+      }
+
+      if (char === '\b' || char === '\x7f') {
+        submittedInputLineRef.current = submittedInputLineRef.current.slice(
+          0,
+          -1
+        )
+
+        continue
+      }
+
+      if (char === '\u0003' || char === '\u0015') {
+        submittedInputLineRef.current = ''
+
+        continue
+      }
+
+      if (char < ' ' || char === '\u001b') {
+        continue
+      }
+
+      submittedInputLineRef.current += char
+    }
   }, [sessionId])
 
   const handleRestoreStart = useCallback((): void => {

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -135,6 +135,16 @@ describe('TerminalPane index', () => {
     )
   })
 
+  test('forwards submitted terminal command callback to Body', () => {
+    const onCommandSubmit = vi.fn()
+
+    render(<TerminalPane {...baseProps} onCommandSubmit={onCommandSubmit} />)
+
+    expect(bodyPropsSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ onCommandSubmit })
+    )
+  })
+
   test('the burner button activates its pane (spec §8) then toggles its burner', async () => {
     const onBurner = vi.fn()
     const onRequestActive = vi.fn()

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -47,6 +47,7 @@ export interface TerminalPaneProps {
   /** Pane-keys with a live burner shell (idle or active) — drives a11y state (VIM-53). */
   runningBurnerPaneKeys?: ReadonlySet<string>
   onCwdChange?: (cwd: string) => void
+  onCommandSubmit?: (ptyId: string, command: string) => void
   onRestart?: (sessionId: string) => void
   deferFit?: boolean
   showFocusHighlight?: boolean
@@ -78,6 +79,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       activeBurnerPaneKeys = undefined,
       runningBurnerPaneKeys = undefined,
       onCwdChange = undefined,
+      onCommandSubmit = undefined,
       onRestart = undefined,
       deferFit = false,
       showFocusHighlight = true,
@@ -278,6 +280,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
               restoredFrom={pane.restoreData}
               onCwdChange={onCwdChange}
               onPaneReady={onPaneReady}
+              onCommandSubmit={onCommandSubmit}
               mode={mode}
               onPtyStatusChange={setPtyStatus}
               deferFit={deferFit}

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -373,9 +373,16 @@ describe('WorkspaceView - Command Palette Integration', () => {
     )
   })
 
-  test('terminal /clear resets the active pane status generation and cache history', async () => {
+  test('terminal /clear resets the active pane status generation and cache history when pane is Codex', async () => {
     const { useAgentStatus } =
       await import('../agent-status/hooks/useAgentStatus')
+
+    vi.mocked(useAgentStatus).mockReturnValue(
+      createAgentStatus({
+        sessionId: 'pty-session-1',
+        agentType: 'codex',
+      })
+    )
 
     render(<WorkspaceView />)
 
@@ -392,6 +399,36 @@ describe('WorkspaceView - Command Palette Integration', () => {
       expect(vi.mocked(useAgentStatus)).toHaveBeenLastCalledWith(
         'pty-session-1',
         1
+      )
+    })
+  })
+
+  test('terminal /clear does not reset agent-status generation for non-Codex panes', async () => {
+    const { useAgentStatus } =
+      await import('../agent-status/hooks/useAgentStatus')
+
+    vi.mocked(useAgentStatus).mockReturnValue(
+      createAgentStatus({
+        sessionId: 'pty-session-1',
+        agentType: 'claude-code',
+      })
+    )
+
+    render(<WorkspaceView />)
+
+    act(() => {
+      latestTerminalZoneProps().onCommandSubmit?.('pty-session-1', '/clear')
+    })
+
+    expect(mockSessionManager.clearPaneCacheHistory).toHaveBeenCalledWith(
+      'session-1',
+      'p0'
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(useAgentStatus)).toHaveBeenLastCalledWith(
+        'pty-session-1',
+        0
       )
     })
   })

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -190,6 +190,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
       reorderSessions: vi.fn(),
       updatePaneCwd: vi.fn(),
       appendPaneCacheReading: vi.fn(),
+      clearPaneCacheHistory: vi.fn(),
       updatePaneAgentType: vi.fn(),
       setSessionActivityPanelCollapsed: vi.fn(),
       updateSessionCwd: vi.fn(),
@@ -370,6 +371,29 @@ describe('WorkspaceView - Command Palette Integration', () => {
         removePane: mockSessionManager.removePane,
       })
     )
+  })
+
+  test('terminal /clear resets the active pane status generation and cache history', async () => {
+    const { useAgentStatus } =
+      await import('../agent-status/hooks/useAgentStatus')
+
+    render(<WorkspaceView />)
+
+    act(() => {
+      latestTerminalZoneProps().onCommandSubmit?.('pty-session-1', '/clear')
+    })
+
+    expect(mockSessionManager.clearPaneCacheHistory).toHaveBeenCalledWith(
+      'session-1',
+      'p0'
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(useAgentStatus)).toHaveBeenLastCalledWith(
+        'pty-session-1',
+        1
+      )
+    })
   })
 
   test('occludes browser panes while the command palette is open', async () => {

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -169,6 +169,7 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
       reorderSessions: vi.fn(),
       updatePaneCwd: vi.fn(),
       appendPaneCacheReading: vi.fn(),
+      clearPaneCacheHistory: vi.fn(),
       updatePaneAgentType: vi.fn(),
       setSessionActivityPanelCollapsed: vi.fn(),
       updateSessionCwd: vi.fn(),

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -256,6 +256,7 @@ export const WorkspaceView = (): ReactElement => {
     reorderSessions,
     updatePaneCwd,
     appendPaneCacheReading,
+    clearPaneCacheHistory,
     updatePaneAgentType,
     updateBrowserPaneUrl,
     setSessionActivityPanelCollapsed,
@@ -508,10 +509,28 @@ export const WorkspaceView = (): ReactElement => {
   const activePtyBackedPaneId = activePtyBackedPane?.id
   const activePtyBackedPanePtyId = activePtyBackedPane?.ptyId
 
-  const agentStatus = useAgentStatus(activePtyBackedPanePtyId ?? null)
+  const [agentStatusReset, setAgentStatusReset] = useState<{
+    ptyId: string
+    generation: number
+  } | null>(null)
+
+  const agentStatusResetGeneration =
+    agentStatusReset !== null &&
+    agentStatusReset.ptyId === activePtyBackedPanePtyId
+      ? agentStatusReset.generation
+      : 0
+
+  const agentStatus = useAgentStatus(
+    activePtyBackedPanePtyId ?? null,
+    agentStatusResetGeneration
+  )
 
   useCacheHistoryCollector({
     ptyId: activePtyBackedPanePtyId ?? null,
+    runId:
+      agentStatus.sessionId === activePtyBackedPanePtyId
+        ? agentStatus.agentSessionId
+        : null,
     sessionId: activeSessionId,
     paneId: activePtyBackedPaneId ?? null,
     usage:
@@ -519,7 +538,31 @@ export const WorkspaceView = (): ReactElement => {
         ? (agentStatus.contextWindow?.currentUsage ?? null)
         : null,
     onReading: appendPaneCacheReading,
+    onReset: clearPaneCacheHistory,
   })
+
+  const handleTerminalCommandSubmit = useCallback(
+    (ptyId: string, command: string): void => {
+      if (command !== '/clear') {
+        return
+      }
+
+      setAgentStatusReset((prev) => ({
+        ptyId,
+        generation: prev?.ptyId === ptyId ? prev.generation + 1 : 1,
+      }))
+
+      for (const session of sessions) {
+        const pane = session.panes.find((p) => p.ptyId === ptyId)
+        if (pane) {
+          clearPaneCacheHistory(session.id, pane.id)
+
+          return
+        }
+      }
+    },
+    [clearPaneCacheHistory, sessions]
+  )
 
   const activityPanelCollapsed = activeSession?.activityPanelCollapsed ?? false
 
@@ -2231,6 +2274,7 @@ export const WorkspaceView = (): ReactElement => {
               deferTerminalFit={terminalFitDeferred}
               loading={loading}
               onPaneReady={notifyPaneReady}
+              onCommandSubmit={handleTerminalCommandSubmit}
               onSessionRestart={restartSession}
               service={terminalService}
               setSessionActivePane={setSessionActivePane}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -547,10 +547,20 @@ export const WorkspaceView = (): ReactElement => {
         return
       }
 
-      setAgentStatusReset((prev) => ({
-        ptyId,
-        generation: prev?.ptyId === ptyId ? prev.generation + 1 : 1,
-      }))
+      // Only reset agent-status state when the active pane is actually running
+      // Codex. Raw PTY input (e.g. vim's `/clear` search followed by Enter) is
+      // syntactically identical to a Codex `/clear` command, and a false reset
+      // for a live Codex session would suppress same-run events until the next
+      // session boundary (Claude Code Review on PR #469).
+      if (
+        ptyId === activePtyBackedPanePtyId &&
+        agentStatus.agentType === 'codex'
+      ) {
+        setAgentStatusReset((prev) => ({
+          ptyId,
+          generation: prev?.ptyId === ptyId ? prev.generation + 1 : 1,
+        }))
+      }
 
       for (const session of sessions) {
         const pane = session.panes.find((p) => p.ptyId === ptyId)
@@ -561,7 +571,12 @@ export const WorkspaceView = (): ReactElement => {
         }
       }
     },
-    [clearPaneCacheHistory, sessions]
+    [
+      activePtyBackedPanePtyId,
+      agentStatus.agentType,
+      clearPaneCacheHistory,
+      sessions,
+    ]
   )
 
   const activityPanelCollapsed = activeSession?.activityPanelCollapsed ?? false

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -312,9 +312,7 @@ describe('TerminalZone', () => {
     const user = userEvent.setup()
     const onCommandSubmit = vi.fn()
 
-    render(
-      <TerminalZone {...defaultProps} onCommandSubmit={onCommandSubmit} />
-    )
+    render(<TerminalZone {...defaultProps} onCommandSubmit={onCommandSubmit} />)
 
     await user.click(screen.getByTestId('mock-command-sess-1'))
 

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -59,6 +59,7 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
       showFocusHighlight,
       onRestart,
       onClose,
+      onCommandSubmit,
       session,
       isActive,
     }: TerminalPaneProps): ReactElement => (
@@ -104,6 +105,15 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
             onClick={() => onCwdChange('/changed')}
           >
             mock-cwd
+          </button>
+        )}
+        {onCommandSubmit && (
+          <button
+            type="button"
+            data-testid={`mock-command-${pane.ptyId}`}
+            onClick={() => onCommandSubmit(pane.ptyId, '/clear')}
+          >
+            mock-command
           </button>
         )}
       </div>
@@ -296,6 +306,19 @@ describe('TerminalZone', () => {
     await user.click(screen.getByTestId('mock-cwd-sess-1'))
 
     expect(onSessionCwdChange).toHaveBeenCalledWith('sess-1', 'p0', '/changed')
+  })
+
+  test('forwards terminal command submissions from panes', async () => {
+    const user = userEvent.setup()
+    const onCommandSubmit = vi.fn()
+
+    render(
+      <TerminalZone {...defaultProps} onCommandSubmit={onCommandSubmit} />
+    )
+
+    await user.click(screen.getByTestId('mock-command-sess-1'))
+
+    expect(onCommandSubmit).toHaveBeenCalledWith('sess-1', '/clear')
   })
 
   test('forwards deferred terminal fit state to TerminalPane', () => {

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -33,6 +33,7 @@ export interface TerminalZoneProps {
     ptyId: string,
     handler: PaneEventHandler
   ) => NotifyPaneReadyResult
+  onCommandSubmit?: (ptyId: string, command: string) => void
   /**
    * Called when the user clicks Restart on an Exited (awaiting-restart) pane.
    */
@@ -79,6 +80,7 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
       onSessionCwdChange = undefined,
       loading = false,
       onPaneReady = undefined,
+      onCommandSubmit = undefined,
       onSessionRestart = undefined,
       deferTerminalFit = false,
       service,
@@ -186,6 +188,7 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
                     isActive={isActive}
                     onSessionCwdChange={onSessionCwdChange}
                     onPaneReady={onPaneReady}
+                    onCommandSubmit={onCommandSubmit}
                     onSessionRestart={onSessionRestart}
                     onSetActivePane={setSessionActivePane}
                     onBrowserPaneUrlChange={updateBrowserPaneUrl}


### PR DESCRIPTION
## Summary

Fixes the isolated `/clear` bug where Codex clears the terminal session but Vimeflow's right agent-status sidebar kept showing stale run state.

- Detects submitted `/clear` terminal commands and immediately resets the active pane's agent-status generation.
- Clears context-window state, cache history, Now card state, tool-call counts, activity history, turns, and test-run state for the pane.
- Suppresses stale same-run status/tool/turn/test events after the local reset until a fresh accepted status snapshot arrives.
- Resets Codex backend fold/transcript state when `session_meta.id` changes after `/clear`.
- Clears pending test-run replay data so old test snapshots do not leak into the next run.

## Root Cause

Codex `/clear` starts a new logical run on the same PTY. Vimeflow previously keyed too much right-sidebar state by PTY alone, so same-PTY stale snapshots and replayed events could repopulate the context bucket, cache card, Now card, and activity list after the terminal had already cleared.

## Validation

- `npm exec vitest run src/features/terminal/components/TerminalPane/Body.test.tsx src/features/terminal/components/TerminalPane/index.test.tsx src/features/workspace/components/TerminalZone.test.tsx src/features/agent-status/hooks/useAgentStatus.test.ts src/features/workspace/WorkspaceView.command-palette.test.tsx src/features/agent-status/hooks/useCacheHistoryCollector.test.tsx src/features/sessions/hooks/useSessionManager.test.ts`
- `npm run type-check -- --pretty false`
- scoped ESLint on changed frontend files
- `rustfmt --check crates/backend/src/agent/adapter/codex/parser.rs crates/backend/src/agent/adapter/codex/transcript.rs crates/backend/src/agent/adapter/claude_code/test_runners/emitter.rs`
- `cargo test -p vimeflow agent::adapter::codex::parser::tests::new_session_meta_resets_run_scoped_status`
- `cargo test -p vimeflow agent::adapter::codex::transcript::tests::process_line_new_session_meta_resets_run_scoped_tail_state`
- `cargo test -p vimeflow agent::adapter::claude_code::test_runners::emitter::tests::clear_pending_drops_replay_buffer_without_ending_replay`
- `git diff --check`

Notes: focused Vitest still emits pre-existing React `act(...)` warnings, and binding generation emits the repo's existing `ts-rs` serde attribute warnings.