### PR TITLE
feat(workspace): register overlay sources

### DIFF
--- a/src/features/terminal/components/PaneRenameInput.tsx
+++ b/src/features/terminal/components/PaneRenameInput.tsx
@@ -165,6 +165,7 @@ export const PaneRenameInput = ({
     <div
       ref={frameRef}
       data-testid="pane-rename-frame"
+      data-workspace-overlay-id="pane-rename"
       style={style}
       className="z-50 rounded-md bg-surface-container/90 p-1 shadow-[0_12px_40px_color-mix(in_srgb,var(--color-scrim)_42%,transparent)] backdrop-blur-md"
     >

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -101,6 +101,8 @@ import {
   DOCK_VERTICAL_ELASTIC_CONFIG,
   DOCK_HORIZONTAL_ELASTIC_CONFIG,
 } from './panelConfig'
+import { OverlayStackProvider } from './overlays/OverlayStackProvider'
+import { WorkspaceOverlayRegistrations } from './overlays/WorkspaceOverlayRegistrations'
 
 const rateLimitPercentage = (
   limit: RateLimitsState['fiveHour'] | null | undefined
@@ -225,7 +227,7 @@ const mainAutoCollapseThreshold = (workspaceWidth: number): number =>
 
 type DockTab = 'editor' | 'diff'
 
-export const WorkspaceView = (): ReactElement => {
+const WorkspaceViewContent = (): ReactElement => {
   const workspaceRef = useRef<HTMLDivElement>(null)
   const mainWorkspaceRef = useRef<HTMLDivElement>(null)
   const sidebarResizeHandleRef = useRef<HTMLDivElement | null>(null)
@@ -1913,6 +1915,14 @@ export const WorkspaceView = (): ReactElement => {
         } as CSSProperties
       }
     >
+      <WorkspaceOverlayRegistrations
+        commandPaletteOpen={commandPalette.state.isOpen}
+        unsavedChangesDialogOpen={showUnsavedDialog}
+        burnerTerminalOpen={hasVisibleBurner}
+        paneRenameOpen={paneRenameNode !== null}
+        dragOverlayOpen={terminalFitDeferred}
+        bannerOpen={fileError !== null || infoMessage !== null}
+      />
       {isCompactViewport && !isSidebarClosed && (
         <button
           type="button"
@@ -2235,7 +2245,11 @@ export const WorkspaceView = (): ReactElement => {
         </div>
 
         {(fileError !== null || infoMessage !== null) && (
-          <div className="absolute top-2 left-1/2 z-40 flex w-[calc(100%-1rem)] max-w-2xl -translate-x-1/2 flex-col gap-2">
+          <div
+            data-testid="workspace-banner-stack"
+            data-workspace-overlay-id="workspace-banners"
+            className="absolute top-2 left-1/2 z-40 flex w-[calc(100%-1rem)] max-w-2xl -translate-x-1/2 flex-col gap-2"
+          >
             {/* File error banner — surfaces failures from direct file open
                 (openFileSafely) and vim :w saves (handleVimSave). Rendered at
                 the top of the main area so the user always sees what went wrong. */}
@@ -2337,7 +2351,12 @@ export const WorkspaceView = (): ReactElement => {
       />
 
       {/* Drag overlay — prevents iframes/xterm from stealing mouse events */}
-      {isDragging && <div className="fixed inset-0 z-50 cursor-col-resize" />}
+      {isDragging && (
+        <div
+          data-testid="workspace-drag-overlay"
+          className="fixed inset-0 z-50 cursor-col-resize"
+        />
+      )}
 
       {paneRenameNode}
       {burnerTerminalNode}
@@ -2354,5 +2373,11 @@ export const WorkspaceView = (): ReactElement => {
     </div>
   )
 }
+
+export const WorkspaceView = (): ReactElement => (
+  <OverlayStackProvider>
+    <WorkspaceViewContent />
+  </OverlayStackProvider>
+)
 
 export default WorkspaceView

--- a/src/features/workspace/overlays/WorkspaceOverlayRegistrations.test.tsx
+++ b/src/features/workspace/overlays/WorkspaceOverlayRegistrations.test.tsx
@@ -1,0 +1,165 @@
+import { type ReactElement } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import { OverlayStackProvider } from './OverlayStackProvider'
+import { useNativeSurface } from './useNativeSurface'
+import { WorkspaceOverlayRegistrations } from './WorkspaceOverlayRegistrations'
+
+const rect = (
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): DOMRectReadOnly => ({
+  x,
+  y,
+  width,
+  height,
+  left: x,
+  top: y,
+  right: x + width,
+  bottom: y + height,
+  toJSON: (): Record<string, number> => ({
+    x,
+    y,
+    width,
+    height,
+    left: x,
+    top: y,
+    right: x + width,
+    bottom: y + height,
+  }),
+})
+
+interface RectTargetProps {
+  overlayId: string
+  rectValue: DOMRectReadOnly
+}
+
+const RectTarget = ({
+  overlayId,
+  rectValue,
+}: RectTargetProps): ReactElement => (
+  <div
+    data-workspace-overlay-id={overlayId}
+    ref={(element): void => {
+      if (element) {
+        element.getBoundingClientRect = (): DOMRectReadOnly => rectValue
+      }
+    }}
+  />
+)
+
+const NativeSurfaceStatus = (): ReactElement => {
+  const nativeSurface = useNativeSurface({
+    id: 'surface',
+    owner: 'browser-pane',
+    belowPlane: 'pane-chrome',
+    getRect: () => rect(0, 0, 100, 100),
+  })
+
+  return (
+    <div role="status" aria-label="Native surface occlusion">
+      {nativeSurface.occluded
+        ? nativeSurface.occludingOverlayIds.join(',')
+        : 'clear'}
+    </div>
+  )
+}
+
+interface HarnessProps {
+  commandPaletteOpen?: boolean
+  unsavedChangesDialogOpen?: boolean
+  burnerTerminalOpen?: boolean
+  paneRenameOpen?: boolean
+  dragOverlayOpen?: boolean
+  bannerOpen?: boolean
+  paneRenameRect?: DOMRectReadOnly
+  bannerRect?: DOMRectReadOnly
+}
+
+const Harness = ({
+  commandPaletteOpen = false,
+  unsavedChangesDialogOpen = false,
+  burnerTerminalOpen = false,
+  paneRenameOpen = false,
+  dragOverlayOpen = false,
+  bannerOpen = false,
+  paneRenameRect = rect(200, 0, 50, 50),
+  bannerRect = rect(200, 0, 50, 50),
+}: HarnessProps): ReactElement => (
+  <OverlayStackProvider>
+    <WorkspaceOverlayRegistrations
+      commandPaletteOpen={commandPaletteOpen}
+      unsavedChangesDialogOpen={unsavedChangesDialogOpen}
+      burnerTerminalOpen={burnerTerminalOpen}
+      paneRenameOpen={paneRenameOpen}
+      dragOverlayOpen={dragOverlayOpen}
+      bannerOpen={bannerOpen}
+    />
+    <RectTarget overlayId="pane-rename" rectValue={paneRenameRect} />
+    <RectTarget overlayId="workspace-banners" rectValue={bannerRect} />
+    <NativeSurfaceStatus />
+  </OverlayStackProvider>
+)
+
+const nativeSurfaceStatus = (): HTMLElement =>
+  screen.getByRole('status', { name: /native surface occlusion/i })
+
+describe('WorkspaceOverlayRegistrations', () => {
+  test('registers global workspace overlays that occlude native browser panes', async () => {
+    const { rerender } = render(<Harness />)
+
+    expect(nativeSurfaceStatus()).toHaveTextContent('clear')
+
+    rerender(<Harness commandPaletteOpen />)
+
+    await waitFor(() =>
+      expect(nativeSurfaceStatus()).toHaveTextContent(/^command-palette$/u)
+    )
+
+    rerender(
+      <Harness unsavedChangesDialogOpen burnerTerminalOpen dragOverlayOpen />
+    )
+
+    await waitFor(() => {
+      expect(nativeSurfaceStatus()).toHaveTextContent(
+        /^burner-terminal-popup,unsaved-changes-dialog,workspace-drag-overlay$/u
+      )
+    })
+
+    rerender(<Harness />)
+
+    await waitFor(() =>
+      expect(nativeSurfaceStatus()).toHaveTextContent('clear')
+    )
+  })
+
+  test('registers intersecting pane rename and banner overlays', async () => {
+    const { rerender } = render(
+      <Harness
+        paneRenameOpen
+        bannerOpen
+        paneRenameRect={rect(200, 0, 50, 50)}
+        bannerRect={rect(20, 20, 60, 24)}
+      />
+    )
+
+    await waitFor(() =>
+      expect(nativeSurfaceStatus()).toHaveTextContent(/^workspace-banners$/u)
+    )
+
+    rerender(
+      <Harness
+        paneRenameOpen
+        bannerOpen
+        paneRenameRect={rect(10, 10, 40, 24)}
+        bannerRect={rect(200, 0, 50, 50)}
+      />
+    )
+
+    await waitFor(() =>
+      expect(nativeSurfaceStatus()).toHaveTextContent(/^pane-rename$/u)
+    )
+  })
+})

--- a/src/features/workspace/overlays/WorkspaceOverlayRegistrations.tsx
+++ b/src/features/workspace/overlays/WorkspaceOverlayRegistrations.tsx
@@ -1,0 +1,80 @@
+import type { ReactElement } from 'react'
+import { useOverlayRegistration } from './useOverlayRegistration'
+
+export interface WorkspaceOverlayRegistrationsProps {
+  commandPaletteOpen: boolean
+  unsavedChangesDialogOpen: boolean
+  burnerTerminalOpen: boolean
+  paneRenameOpen: boolean
+  dragOverlayOpen: boolean
+  bannerOpen: boolean
+}
+
+const rectForOverlayId = (overlayId: string): DOMRectReadOnly | null => {
+  const element = document.querySelector<HTMLElement>(
+    `[data-workspace-overlay-id="${overlayId}"]`
+  )
+
+  return element?.getBoundingClientRect() ?? null
+}
+
+const paneRenameRect = (): DOMRectReadOnly | null =>
+  rectForOverlayId('pane-rename')
+
+const bannerStackRect = (): DOMRectReadOnly | null =>
+  rectForOverlayId('workspace-banners')
+
+export const WorkspaceOverlayRegistrations = ({
+  commandPaletteOpen,
+  unsavedChangesDialogOpen,
+  burnerTerminalOpen,
+  paneRenameOpen,
+  dragOverlayOpen,
+  bannerOpen,
+}: WorkspaceOverlayRegistrationsProps): ReactElement | null => {
+  useOverlayRegistration({
+    id: 'command-palette',
+    plane: 'palette',
+    isOpen: commandPaletteOpen,
+    nativeOcclusion: 'global',
+  })
+
+  useOverlayRegistration({
+    id: 'unsaved-changes-dialog',
+    plane: 'dialog',
+    isOpen: unsavedChangesDialogOpen,
+    nativeOcclusion: 'global',
+  })
+
+  useOverlayRegistration({
+    id: 'burner-terminal-popup',
+    plane: 'dialog',
+    isOpen: burnerTerminalOpen,
+    nativeOcclusion: 'global',
+  })
+
+  useOverlayRegistration({
+    id: 'workspace-drag-overlay',
+    plane: 'drag',
+    isOpen: dragOverlayOpen,
+    nativeOcclusion: 'global',
+  })
+
+  useOverlayRegistration({
+    id: 'pane-rename',
+    plane: 'popover',
+    isOpen: paneRenameOpen,
+    nativeOcclusion: 'intersects',
+    getRect: paneRenameRect,
+  })
+
+  useOverlayRegistration({
+    id: 'workspace-banners',
+    plane: 'toast',
+    isOpen: bannerOpen,
+    nativeOcclusion: 'intersects',
+    getRect: bannerStackRect,
+  })
+
+  return null
+}

--- a/src/features/workspace/overlays/useNativeSurface.ts
+++ b/src/features/workspace/overlays/useNativeSurface.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef } from 'react'
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import {
   type NativeSurfaceDescriptor,
   type NativeSurfaceState,
@@ -32,6 +32,7 @@ export const useNativeSurface = (
   latestDescriptorRef.current = descriptor
 
   const { id, owner, belowPlane } = descriptor
+  const [, setLayoutRevision] = useState(0)
 
   const getRect = useCallback(
     (): DOMRectReadOnly | null => latestDescriptorRef.current.getRect(),
@@ -67,6 +68,28 @@ export const useNativeSurface = (
   if (!areOcclusionStatesEqual(stateRef.current, nextState)) {
     stateRef.current = nextState
   }
+
+  // Intersecting overlays can mount or move during the same commit that
+  // re-rendered the native surface; re-check after layout so DOM rects are
+  // committed before BrowserPane visibility decisions settle. This intentionally
+  // runs after every commit because rect getter values can change even when
+  // descriptor identity and overlay membership stay stable.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useLayoutEffect(() => {
+    const committedState = getNativeSurfaceState({
+      id,
+      owner,
+      belowPlane,
+      getRect,
+    })
+
+    if (areOcclusionStatesEqual(stateRef.current, committedState)) {
+      return
+    }
+
+    stateRef.current = committedState
+    setLayoutRevision((revision) => revision + 1)
+  })
 
   return stateRef.current
 }


### PR DESCRIPTION
## Summary
- Register the existing workspace overlay sources in the shared overlay stack: command palette, unsaved dialog, burner popup, workspace drag overlay, pane rename, and banners.
- Wrap `WorkspaceView` with `OverlayStackProvider` while leaving the legacy BrowserPane occlusion prop in place for the next PR.
- Add semantic overlay markers for intersecting pane rename/banner geometry and refresh native-surface occlusion after layout when committed DOM rects differ from render-time rects.

## Validation
- `npm exec vitest run src/features/workspace`
- `npm exec vitest run src/features/workspace/overlays/WorkspaceOverlayRegistrations.test.tsx src/features/workspace/overlays/useNativeSurface.test.tsx src/features/terminal/components/PaneRenameInput.test.tsx`
- `npm run lint`
- `npm run type-check -- --pretty false`