### PR TITLE
feat(browser): subscribe browser panes to overlay stack

### DIFF
--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -2,10 +2,13 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { Mock } from 'vitest'
+import type { ReactElement } from 'react'
 import type { BrowserPaneCreateResult } from '../types'
 import type { Pane, Session } from '../../sessions/types'
 import { emptyActivity } from '../../sessions/constants'
-import { BrowserPane } from './BrowserPane'
+import { BrowserPane, type BrowserPaneProps } from './BrowserPane'
+import { OverlayStackProvider } from '../../workspace/overlays/OverlayStackProvider'
+import { useOverlayRegistration } from '../../workspace/overlays/useOverlayRegistration'
 
 const bridgeMocks = vi.hoisted(() => ({
   activateBrowserPaneTab: vi.fn().mockResolvedValue(undefined),
@@ -101,6 +104,37 @@ const singleTab: BrowserPaneCreateResult = {
   navState: { canGoBack: false, canGoForward: false, isLoading: false },
 }
 
+const inactive = false
+
+interface OverlayProbeProps {
+  isOpen: boolean
+}
+
+const OverlayProbe = ({ isOpen }: OverlayProbeProps): ReactElement | null => {
+  useOverlayRegistration({
+    id: 'test-overlay',
+    plane: 'palette',
+    isOpen,
+    nativeOcclusion: 'global',
+  })
+
+  return null
+}
+
+interface BrowserPaneHarnessProps extends BrowserPaneProps {
+  overlayOpen?: boolean
+}
+
+const BrowserPaneHarness = ({
+  overlayOpen = false,
+  ...props
+}: BrowserPaneHarnessProps): ReactElement => (
+  <OverlayStackProvider>
+    <OverlayProbe isOpen={overlayOpen} />
+    <BrowserPane {...props} />
+  </OverlayStackProvider>
+)
+
 interface UrlEvent {
   sessionId: string
   paneId: string
@@ -191,7 +225,7 @@ describe('BrowserPane', () => {
   }
 
   test('applies bounds only after the native browser pane is created', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
 
     await waitFor(() => {
       expect(bridgeMocks.createBrowserPane).toHaveBeenCalledOnce()
@@ -211,7 +245,12 @@ describe('BrowserPane', () => {
 
   test('marks the native browser pane invisible while occluded, then restores it', async () => {
     const { rerender } = render(
-      <BrowserPane session={session} pane={browserPane} isActive isOccluded />
+      <BrowserPaneHarness
+        session={session}
+        pane={browserPane}
+        isActive
+        overlayOpen
+      />
     )
 
     await waitFor(() => {
@@ -227,7 +266,9 @@ describe('BrowserPane', () => {
       visible: false,
     })
 
-    rerender(<BrowserPane session={session} pane={browserPane} isActive />)
+    rerender(
+      <BrowserPaneHarness session={session} pane={browserPane} isActive />
+    )
 
     await waitFor(() => {
       expect(bridgeMocks.setBrowserPaneBounds).toHaveBeenLastCalledWith({
@@ -240,9 +281,32 @@ describe('BrowserPane', () => {
     })
   })
 
+  test('keeps the native browser pane invisible when the session panel is inactive', async () => {
+    render(
+      <BrowserPaneHarness
+        session={session}
+        pane={browserPane}
+        isActive={inactive}
+      />
+    )
+
+    await waitFor(() => {
+      expect(bridgeMocks.createBrowserPane).toHaveBeenCalledOnce()
+    })
+    await settle()
+
+    expect(bridgeMocks.setBrowserPaneBounds).toHaveBeenLastCalledWith({
+      sessionId: 'session-1',
+      paneId: 'p1',
+      bounds: { x: 10, y: 20, width: 640, height: 360 },
+      shortcutContext: { activePaneId: 'p1', paneIds: ['p0', 'p1'] },
+      visible: false,
+    })
+  })
+
   test('the focus border uses the cyan WEB accent only when the pane is active', () => {
     const { rerender } = render(
-      <BrowserPane session={session} pane={browserPane} isActive />
+      <BrowserPaneHarness session={session} pane={browserPane} isActive />
     )
     // accent is now a CSS var reference; jsdom preserves var() in style strings.
     expect(screen.getByTestId('browser-pane').style.border).toContain(
@@ -250,7 +314,7 @@ describe('BrowserPane', () => {
     )
 
     rerender(
-      <BrowserPane
+      <BrowserPaneHarness
         session={session}
         pane={{ ...browserPane, active: false }}
         isActive
@@ -264,7 +328,7 @@ describe('BrowserPane', () => {
 
   test('the address bar is a display button until it is edited', async () => {
     const user = userEvent.setup()
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     expect(screen.queryByLabelText('browser address')).toBeNull()
@@ -274,7 +338,7 @@ describe('BrowserPane', () => {
 
   test('submitting the address normalizes and navigates', async () => {
     const user = userEvent.setup()
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     const input = await beginEdit(user)
@@ -290,7 +354,7 @@ describe('BrowserPane', () => {
   })
 
   test('a nav-state event lights up back and toggles reload to stop', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     act(() =>
@@ -309,7 +373,7 @@ describe('BrowserPane', () => {
   })
 
   test('a nav-state event for a different pane is ignored', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     act(() =>
@@ -327,7 +391,7 @@ describe('BrowserPane', () => {
   })
 
   test('a tabs-changed event with a favicon updates the tab icon', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     act(() =>
@@ -353,7 +417,7 @@ describe('BrowserPane', () => {
   })
 
   test('the load bar shows when nav-state reports loading', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     act(() =>
@@ -372,7 +436,7 @@ describe('BrowserPane', () => {
 
   test('back and reload dispatch nav-action through the bridge', async () => {
     const user = userEvent.setup()
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     act(() =>
@@ -403,7 +467,7 @@ describe('BrowserPane', () => {
   })
 
   test('the create-result navState seeds the toolbar', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
 
     act(() =>
       resolveCreate({
@@ -420,7 +484,7 @@ describe('BrowserPane', () => {
   })
 
   test('a live nav-state event before create resolves is not clobbered by the seed', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
 
     // Live event arrives before createBrowserPane resolves.
     act(() =>
@@ -443,7 +507,7 @@ describe('BrowserPane', () => {
 
   test('the draft survives native url events while editing', async () => {
     const user = userEvent.setup()
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     const input = await beginEdit(user)
@@ -475,7 +539,7 @@ describe('BrowserPane', () => {
 
   test('blur cancels editing and reverts the display to the committed URL', async () => {
     const user = userEvent.setup()
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     const input = await beginEdit(user)
@@ -510,7 +574,7 @@ describe('BrowserPane', () => {
 
   test('the display follows redirects after a submit (not editing)', async () => {
     const user = userEvent.setup()
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     const input = await beginEdit(user)
@@ -542,7 +606,7 @@ describe('BrowserPane', () => {
   })
 
   test('Cmd/Ctrl+L from the chrome enters address edit', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await waitFor(() => {
       expect(bridgeMocks.createBrowserPane).toHaveBeenCalledOnce()
     })
@@ -556,7 +620,7 @@ describe('BrowserPane', () => {
   })
 
   test('a focus-address event enters edit only for the matching pane', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await waitFor(() => {
       expect(bridgeMocks.onBrowserPaneFocusAddress).toHaveBeenCalled()
     })
@@ -576,7 +640,7 @@ describe('BrowserPane', () => {
 
   test('open-external calls the bridge with the derived pane ref', async () => {
     const user = userEvent.setup()
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     await user.click(
@@ -593,7 +657,7 @@ describe('BrowserPane', () => {
     const user = userEvent.setup()
     const onClose = vi.fn()
     render(
-      <BrowserPane
+      <BrowserPaneHarness
         session={session}
         pane={browserPane}
         isActive
@@ -608,7 +672,7 @@ describe('BrowserPane', () => {
 
   test('tab activate / new / close call the bridge with the derived pane ref', async () => {
     const user = userEvent.setup()
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
 
     act(() =>
       resolveCreate({
@@ -662,7 +726,7 @@ describe('BrowserPane', () => {
   })
 
   test('a tabs-changed event updates the tab strip', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     const callback = bridgeMocks.onBrowserPaneTabsChange.mock
@@ -694,7 +758,7 @@ describe('BrowserPane', () => {
   })
 
   test('an empty tabs-changed event during teardown does not crash', async () => {
-    render(<BrowserPane session={session} pane={browserPane} isActive />)
+    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
     await settle()
 
     const callback = bridgeMocks.onBrowserPaneTabsChange.mock

--- a/src/features/browser/components/BrowserPane.tsx
+++ b/src/features/browser/components/BrowserPane.tsx
@@ -38,6 +38,7 @@ import type {
 import { DEFAULT_BROWSER_URL } from '../types'
 import { BrowserTabBar } from './BrowserTabBar'
 import { BrowserToolbar } from './BrowserToolbar'
+import { useNativeSurface } from '../../workspace/overlays/useNativeSurface'
 
 const LOCAL_DEV_HOST_PATTERN =
   /^(localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0|\[::1\])(?::\d+)?(?:[/?#]|$)/i
@@ -46,7 +47,6 @@ export interface BrowserPaneProps {
   session: Session
   pane: Pane
   isActive: boolean
-  isOccluded?: boolean
   onClose?: (sessionId: string, paneId: string) => void
   onRequestActive?: (sessionId: string, paneId: string) => void
   onRequestFocus?: () => void
@@ -77,7 +77,6 @@ export const BrowserPane = ({
   session,
   pane,
   isActive,
-  isOccluded = false,
   onClose = undefined,
   onRequestActive = undefined,
   onRequestFocus = undefined,
@@ -88,10 +87,8 @@ export const BrowserPane = ({
   const url = pane.browserUrl ?? DEFAULT_BROWSER_URL
   const initialUrlRef = useRef(url)
   const isActiveRef = useRef(isActive)
-  const isOccludedRef = useRef(isOccluded)
   const nativePaneReadyRef = useRef(false)
   const wasPaneActiveRef = useRef<boolean | undefined>(undefined)
-  const wasOccludedRef = useRef(isOccluded)
   const suppressNextNativeFocusRef = useRef(false)
   const lastBoundsKeyRef = useRef<string | null>(null)
   const onUrlChangeRef = useRef(onUrlChange)
@@ -119,6 +116,16 @@ export const BrowserPane = ({
     { id: 'tab-0', url, title: null, active: true, favicon: null },
   ])
   const browserSessionId = browserSessionIdForSession(session)
+
+  const nativeSurface = useNativeSurface({
+    id: `browser-pane:${browserSessionId}:${pane.id}`,
+    owner: 'browser-pane',
+    belowPlane: 'pane-chrome',
+    getRect: () => contentRef.current?.getBoundingClientRect() ?? null,
+  })
+  const isOccluded = nativeSurface.occluded
+  const isOccludedRef = useRef(isOccluded)
+  const wasOccludedRef = useRef(isOccluded)
 
   const paneIds = useMemo(
     () => session.panes.map((sessionPane) => sessionPane.id),

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -51,7 +51,6 @@ export interface SplitViewProps {
   activeBurnerPaneKeys?: ReadonlySet<string>
   /** Pane-keys with a live burner shell (idle or active) — drives a11y state (VIM-53). */
   runningBurnerPaneKeys?: ReadonlySet<string>
-  areBrowserPanesOccluded?: boolean
   deferTerminalFit?: boolean
   showPaneFocusHighlight?: boolean
 }
@@ -113,7 +112,6 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
       onBurner = undefined,
       activeBurnerPaneKeys = undefined,
       runningBurnerPaneKeys = undefined,
-      areBrowserPanesOccluded = false,
       deferTerminalFit = false,
       showPaneFocusHighlight = true,
     }: SplitViewProps,
@@ -323,7 +321,6 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                           session={session}
                           pane={pane}
                           isActive={isActive}
-                          isOccluded={areBrowserPanesOccluded}
                           onClose={closeHandler}
                           onRequestActive={onSetActivePane}
                           onRequestFocus={onRequestFocus}

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -7,8 +7,10 @@ import type { SessionManager } from '../sessions/hooks/useSessionManager'
 import type { AgentStatus } from '../agent-status/types'
 import type { Session } from '../sessions/types'
 import type { TerminalZoneProps } from './components/TerminalZone'
+import type { WorkspaceOverlayRegistrationsProps } from './overlays/WorkspaceOverlayRegistrations'
 
 const terminalZonePropsSpy = vi.hoisted(() => vi.fn())
+const overlayRegistrationPropsSpy = vi.hoisted(() => vi.fn())
 
 // Mock all WorkspaceView dependencies
 vi.mock('../sessions/hooks/useSessionManager')
@@ -52,6 +54,16 @@ vi.mock('../terminal/services/terminalService')
 vi.mock('../terminal/hooks/usePaneShortcuts')
 vi.mock('../terminal/hooks/useBurnerTerminals', () => ({
   useBurnerTerminals: vi.fn(),
+}))
+
+vi.mock('./overlays/WorkspaceOverlayRegistrations', () => ({
+  WorkspaceOverlayRegistrations: (
+    props: WorkspaceOverlayRegistrationsProps
+  ): null => {
+    overlayRegistrationPropsSpy(props)
+
+    return null
+  },
 }))
 
 // Mock child components to keep test focused on command dispatch while still
@@ -164,6 +176,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
     // Reset all mocks
     vi.clearAllMocks()
     terminalZonePropsSpy.mockClear()
+    overlayRegistrationPropsSpy.mockClear()
 
     // Create mock sessions
     mockSessions = [
@@ -331,6 +344,18 @@ describe('WorkspaceView - Command Palette Integration', () => {
     return call[0]
   }
 
+  const latestOverlayRegistrationProps =
+    (): WorkspaceOverlayRegistrationsProps => {
+      const call = overlayRegistrationPropsSpy.mock.calls[
+        overlayRegistrationPropsSpy.mock.calls.length - 1
+      ] as [WorkspaceOverlayRegistrationsProps] | undefined
+      if (!call) {
+        throw new Error('WorkspaceOverlayRegistrations was not rendered')
+      }
+
+      return call[0]
+    }
+
   test(':new command creates a new session', async () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)
@@ -372,32 +397,43 @@ describe('WorkspaceView - Command Palette Integration', () => {
     )
   })
 
-  test('occludes browser panes while the command palette is open', async () => {
+  test('does not thread browser occlusion state through TerminalZone', () => {
     render(<WorkspaceView />)
 
-    expect(latestTerminalZoneProps().areBrowserPanesOccluded).toBe(false)
-
-    openPalette()
-
-    await waitFor(() => {
-      expect(latestTerminalZoneProps().areBrowserPanesOccluded).toBe(true)
-    })
+    expect(latestTerminalZoneProps()).not.toHaveProperty(
+      'areBrowserPanesOccluded'
+    )
   })
 
-  test('occludes browser panes while a burner terminal popup is visible', async () => {
-    const { useBurnerTerminals } =
-      await import('../terminal/hooks/useBurnerTerminals')
-    vi.mocked(useBurnerTerminals).mockReturnValue({
-      renderNode: <div data-testid="burner-terminal-popup" />,
-      toggle: vi.fn().mockResolvedValue(undefined),
-      runningByPane: new Map(),
-      activeByPane: new Map(),
-      hasVisibleBurner: true,
-    })
+  test('does not mark the global drag overlay open during dock elastic drags', async () => {
+    const { useElasticContainer } =
+      await import('../../hooks/useElasticContainer')
+
+    const dockDragContainer = {
+      size: 400,
+      isDragging: true,
+      handleMouseDown: vi.fn(),
+      adjustBy: vi.fn(),
+      resetToSize: vi.fn(),
+      sizeRef: { current: 400 },
+      pixelMin: 40,
+      pixelMax: 640,
+      effectiveDimension: 800,
+    }
+
+    const idleDockContainer = {
+      ...dockDragContainer,
+      isDragging: false,
+    }
+
+    vi.mocked(useElasticContainer)
+      .mockReturnValueOnce(dockDragContainer)
+      .mockReturnValueOnce(idleDockContainer)
 
     render(<WorkspaceView />)
 
-    expect(latestTerminalZoneProps().areBrowserPanesOccluded).toBe(true)
+    expect(latestTerminalZoneProps().deferTerminalFit).toBe(true)
+    expect(latestOverlayRegistrationProps().dragOverlayOpen).toBe(false)
   })
 
   test('records detected agent type on the active session', async () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1766,15 +1766,6 @@ const WorkspaceViewContent = (): ReactElement => {
     verticalDockElastic.isDragging ||
     horizontalDockElastic.isDragging
 
-  const areBrowserPanesOccluded =
-    terminalFitDeferred ||
-    showUnsavedDialog ||
-    commandPalette.state.isOpen ||
-    hasVisibleBurner ||
-    paneRenameNode !== null ||
-    fileError !== null ||
-    infoMessage !== null
-
   const feedbackDispatch = useMemo(() => {
     // Inline-review feedback dispatches to the single CONNECTED (active) pane —
     // the one whose diff is on screen. We gate the candidate on LIVE agent
@@ -1920,7 +1911,7 @@ const WorkspaceViewContent = (): ReactElement => {
         unsavedChangesDialogOpen={showUnsavedDialog}
         burnerTerminalOpen={hasVisibleBurner}
         paneRenameOpen={paneRenameNode !== null}
-        dragOverlayOpen={terminalFitDeferred}
+        dragOverlayOpen={isDragging}
         bannerOpen={fileError !== null || infoMessage !== null}
       />
       {isCompactViewport && !isSidebarClosed && (
@@ -2231,7 +2222,6 @@ const WorkspaceViewContent = (): ReactElement => {
               updateBrowserPaneUrl={updateBrowserPaneUrl}
               addPane={addPane}
               removePane={removePane}
-              areBrowserPanesOccluded={areBrowserPanesOccluded}
               isZoneFocused={activeContainerId === TERMINAL_CONTAINER_ID}
               onContainerFocus={() => {
                 setActiveContainerId(TERMINAL_CONTAINER_ID)

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -56,7 +56,6 @@ export interface TerminalZoneProps {
   ) => void
   addPane: (sessionId: string, kind?: PaneKind) => void
   removePane: (sessionId: string, paneId: string) => void
-  areBrowserPanesOccluded?: boolean
   isZoneFocused?: boolean
   onContainerFocus?: () => void
   /** Toggle a pane's ephemeral burner terminal (VIM-53). */
@@ -86,7 +85,6 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
       updateBrowserPaneUrl = undefined,
       addPane,
       removePane,
-      areBrowserPanesOccluded = false,
       isZoneFocused = true,
       onContainerFocus = undefined,
       onBurner = undefined,
@@ -195,7 +193,6 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
                     onBurner={onBurner}
                     activeBurnerPaneKeys={activeBurnerPaneKeys}
                     runningBurnerPaneKeys={runningBurnerPaneKeys}
-                    areBrowserPanesOccluded={areBrowserPanesOccluded}
                     deferTerminalFit={deferTerminalFit}
                     // The active pane keeps its highlight even when the dock
                     // (or another container) has focus, so the user never


### PR DESCRIPTION
## Summary
- move BrowserPane native visibility from the threaded `areBrowserPanesOccluded` prop to `useNativeSurface`
- remove the WorkspaceView -> TerminalZone -> SplitView browser occlusion prop chain
- keep dock elastic drags out of the global drag-overlay registration so BrowserPanes do not disappear during dock resizing

## Validation
- npm exec vitest run src/features/browser/components/BrowserPane.test.tsx src/features/workspace/components/TerminalZone.test.tsx src/features/terminal/components/SplitView/SplitView.test.tsx src/features/workspace/WorkspaceView.command-palette.test.tsx src/features/workspace/overlays/WorkspaceOverlayRegistrations.test.tsx src/features/workspace/overlays/useNativeSurface.test.tsx
- npm exec eslint -- src/features/browser/components/BrowserPane.tsx src/features/browser/components/BrowserPane.test.tsx src/features/workspace/components/TerminalZone.tsx src/features/terminal/components/SplitView/SplitView.tsx src/features/workspace/WorkspaceView.tsx src/features/workspace/WorkspaceView.command-palette.test.tsx src/features/workspace/overlays/WorkspaceOverlayRegistrations.tsx src/features/workspace/overlays/WorkspaceOverlayRegistrations.test.tsx src/features/workspace/overlays/useNativeSurface.ts
- npm run type-check -- --pretty false
- git diff --check origin/feat/browser-pane-overlay-hierarchy..HEAD

Refs VIM-129.