### PR TITLE
test(browser): verify native overlay occlusion

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -73,7 +73,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 40       | 12   | 2026-06-13   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 7    | 2026-06-15   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 8    | 2026-06-15   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 16       | 3    | 2026-06-15   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 19       | 1    | 2026-06-06   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -74,7 +74,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 19       | 7    | 2026-06-06   |
-| [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 15       | 3    | 2026-06-12   |
+| [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 16       | 3    | 2026-06-15   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 11       | 3    | 2026-06-12   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 19       | 1    | 2026-06-06   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -73,9 +73,9 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 40       | 12   | 2026-06-13   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 19       | 7    | 2026-06-06   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 7    | 2026-06-15   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 16       | 3    | 2026-06-15   |
-| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 11       | 3    | 2026-06-12   |
+| [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 19       | 1    | 2026-06-06   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 9        | 4    | 2026-06-13   |

--- a/docs/reviews/patterns/diagnostic-instrumentation.md
+++ b/docs/reviews/patterns/diagnostic-instrumentation.md
@@ -2,7 +2,7 @@
 id: diagnostic-instrumentation
 category: code-quality
 created: 2026-04-30
-last_updated: 2026-06-12
+last_updated: 2026-06-15
 ref_count: 3
 ---
 
@@ -134,3 +134,21 @@ The discipline:
 - **Finding:** Cycle 4's initial fix for #9 above moved the production Codex init log into `CompositeLocator::new`, since both `CodexAdapter::new` and `CodexAdapter::with_home` reach that constructor. But `AgentBindings::for_attach` for the Codex arm constructs `CompositeLocator::new` TWICE per attach — once for `bindings.locator` (the outer locator used by watcher*runtime) and once inside `CodexAdapter::with_home` (the adapter's internal locator for the transitional `adapter_for_transcript_state`). That meant every production attach emitted two identical init lines, weakening the observability F11 was trying to restore. Local codex verify caught this as a new LOW finding \_introduced by the F11 fix itself* before push.
 - **Fix:** Moved the log up one more level to `AgentBindings::for_attach` (single attach-once site, one log per attach regardless of how many CompositeLocator instances are constructed downstream). Reverted the log from `CompositeLocator::new`. Updated comments in both `CodexAdapter::new` and `CompositeLocator::new` to point at the actual log site. Lesson: when picking a logging site, count the call sites that reach it per logical operation, not just the number of constructors. "Shared constructor" sounds like the right place but isn't if any caller path traverses it more than once. Audit the call graph from the user-facing event (here: "Codex attach") to every emit site. Pre-push codex verify (the local layer) caught this in the same cycle that introduced it — keeping the verify gate before push paid for itself.
 - **Commit:** _(PR #261 round 4 `/lifeline:upsource-review` cycle 4)_
+
+### 12. Capture recorded before bridge delivers the call produces phantom E2E captures
+
+- **Source:** github-claude | PR #472 round 2 | 2026-06-15
+- **Severity:** LOW
+- **File:** `src/features/browser/browserBridge.ts` `setBrowserPaneBounds`
+- **Finding:** `browserPaneBoundsCaptures.push(cloneBoundsCapture(request))` ran unconditionally when capture was active, before `bridge()?.setBounds(request)` was awaited. `bridge()` reads `window.vimeflow?.browserPane` live, so if the preload bridge disappeared after `startBrowserPaneBoundsCapture` returned `true`, the optional chain no-ops silently while a capture entry was already recorded. `waitForBoundsCapture` in the E2E spec could then match a phantom capture that never crossed the IPC boundary, making the test appear to pass while the native hide/restore path was broken.
+- **Fix:** Snapshot `bridge()` once at the top of `setBrowserPaneBounds` and return early when it is `undefined`; record the capture only after `await bri.setBounds(request)` succeeds. This gates capture on the same reference used for the IPC call and ensures the logged event represents an actual forwarded request. Added a regression test that starts capture, removes the bridge, calls `setBrowserPaneBounds`, and asserts no capture is recorded.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 13. Capture bounds only after setBounds succeeds so the E2E log proves the native path ran
+
+- **Source:** github-codex-connector | PR #472 round 2 | 2026-06-15
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/browser/browserBridge.ts` `setBrowserPaneBounds` L134
+- **Finding:** Because the capture was recorded before `bridge()?.setBounds(request)` was awaited, the WDIO smoke test could observe hidden/restored captures even when the preload/main `setBounds` IPC rejected, was miswired, or became unavailable after capture started. `waitForBoundsCapture` only reads the renderer-side log, so a broken native path could still let the test pass without proving the WebContentsView was actually hidden or restored.
+- **Fix:** Same structural change as #12: await `bri.setBounds(request)` first, then push to `browserPaneBoundsCaptures` only when capture is active. The promise resolving from the bridge is the acknowledgement that the request reached the main process; capture is now a post-success observability record rather than a pre-forward intent log.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -3,7 +3,7 @@ id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
 last_updated: 2026-06-15
-ref_count: 7
+ref_count: 8
 ---
 
 # E2E Testing
@@ -223,7 +223,7 @@ completely different root causes. The generic fast-failure modes:
 
 - **Source:** github-codex-connector | PR #472 round 2 | 2026-06-15
 - **Severity:** P2 / MEDIUM
-- **File:** `tests/e2e/core/specs/browser-pane-overlay.spec.ts` L284
+- **File:** `tests/e2e/core/specs/browser-pane-overlay.spec.ts` L302
 - **Finding:** The core WDIO config keeps Mocha's per-test timeout at 30s, but the browser overlay spec can legitimately spend more than that across sequential helper waits: 20s for the terminal, 10s for the split slot, 15s for the browser pane, 15s for CDP registration, plus the command-palette and bounds-capture waits. On a cold CI run Mocha aborted the test with a generic timeout even though the helper-specific budgets were still in progress, hiding the real bottleneck.
-- **Fix:** Chained `.timeout(60_000)` on the `it(...)` call in the browser overlay spec, using Mocha's per-test timeout API to give the sequential waits enough headroom while leaving the project-wide 30s default in place for faster specs. This keeps the timeout local to the one spec that needs it.
+- **Fix:** Chained `.timeout(60_000)` on the `it(…)` call — the Mocha `Runnable.prototype.timeout()` API — in the browser overlay spec, giving the sequential waits enough headroom while leaving the project-wide 30s default in place for faster specs. This keeps the timeout local to the one spec that needs it.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -2,7 +2,7 @@
 id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
-last_updated: 2026-05-20
+last_updated: 2026-06-15
 ref_count: 7
 ---
 
@@ -218,3 +218,12 @@ completely different root causes. The generic fast-failure modes:
 - **Finding:** After computing `filePaths` from `listTypeScriptFiles(E2E_ROOT)`, the test immediately evaluates `expect(findings).toEqual([])`. If `tests/e2e` is empty, or if all e2e files are temporarily moved or renamed (e.g., during a directory restructure), `filePaths` is `[]`, `findings` is `[]`, and the assertion trivially passes — the guard silently grants a clean bill of health without having scanned a single file. The guard's stated purpose (preventing `browser.keys(...)` usage in e2e tests) evaporates silently.
 - **Fix:** Added `expect(filePaths.length).toBeGreaterThan(0)` immediately after computing `filePaths`, requiring the guard to scan at least one e2e TypeScript file before checking findings. This distinguishes "no violations found" from "no files scanned".
 - **Commit:** _(this cycle)_
+
+### 20. Per-test Mocha timeout shorter than the sum of nested helper waits
+
+- **Source:** github-codex-connector | PR #472 round 2 | 2026-06-15
+- **Severity:** P2 / MEDIUM
+- **File:** `tests/e2e/core/specs/browser-pane-overlay.spec.ts` L284
+- **Finding:** The core WDIO config keeps Mocha's per-test timeout at 30s, but the browser overlay spec can legitimately spend more than that across sequential helper waits: 20s for the terminal, 10s for the split slot, 15s for the browser pane, 15s for CDP registration, plus the command-palette and bounds-capture waits. On a cold CI run Mocha aborted the test with a generic timeout even though the helper-specific budgets were still in progress, hiding the real bottleneck.
+- **Fix:** Passed `60_000` as the third argument to `it(...)` in the browser overlay spec, giving the sequential waits enough headroom while leaving the project-wide 30s default in place for faster specs. This keeps the timeout local to the one spec that needs it.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -225,5 +225,5 @@ completely different root causes. The generic fast-failure modes:
 - **Severity:** P2 / MEDIUM
 - **File:** `tests/e2e/core/specs/browser-pane-overlay.spec.ts` L284
 - **Finding:** The core WDIO config keeps Mocha's per-test timeout at 30s, but the browser overlay spec can legitimately spend more than that across sequential helper waits: 20s for the terminal, 10s for the split slot, 15s for the browser pane, 15s for CDP registration, plus the command-palette and bounds-capture waits. On a cold CI run Mocha aborted the test with a generic timeout even though the helper-specific budgets were still in progress, hiding the real bottleneck.
-- **Fix:** Passed `60_000` as the third argument to `it(...)` in the browser overlay spec, giving the sequential waits enough headroom while leaving the project-wide 30s default in place for faster specs. This keeps the timeout local to the one spec that needs it.
+- **Fix:** Chained `.timeout(60_000)` on the `it(...)` call in the browser overlay spec, using Mocha's per-test timeout API to give the sequential waits enough headroom while leaving the project-wide 30s default in place for faster specs. This keeps the timeout local to the one spec that needs it.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/module-boundaries.md
+++ b/docs/reviews/patterns/module-boundaries.md
@@ -2,7 +2,7 @@
 id: module-boundaries
 category: code-quality
 created: 2026-04-30
-last_updated: 2026-06-12
+last_updated: 2026-06-15
 ref_count: 3
 ---
 
@@ -176,4 +176,13 @@ Don't widen the coupling by adding a second importer.
 - **File:** `src/features/editor/hooks/useCodeMirror.ts` L175-193
 - **Finding:** `writeClipboardText` and its private `writeViaTextarea` fallback were defined inside `useCodeMirror.ts`, a module dense with CodeMirror view/state, Vim-mode wiring, and React hook concerns. The helper has zero imports from `@codemirror/*` and is a general-purpose DOM clipboard writer; `MarkdownReadingView.tsx` already needed to call it, forcing a cross-module import from an unrelated hook file. Future maintainers looking for clipboard fallback logic are unlikely to check a CodeMirror hook first, and refactors of `useCodeMirror.ts` risk silently breaking the reading view's copy path.
 - **Fix:** Promoted the helper to `src/features/editor/utils/clipboard.ts`, exported `ClipboardLike` from the same module, and added the required co-located `clipboard.test.ts`. Updated `useCodeMirror.ts` and `MarkdownReadingView.tsx` to import from the new utility module. The move keeps the hook focused on CodeMirror integration and places the clipboard abstraction next to `readingStyleStore.ts`, the existing stateless utility in `src/features/editor/utils/`.
+- **Commit:** same commit as this entry
+
+### 16. `BrowserPaneBoundsCapture` re-declared in `e2e.d.ts` instead of imported from canonical source
+
+- **Source:** github-claude | PR #472 round 1 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/types/e2e.d.ts` L6-9
+- **Finding:** `src/types/e2e.d.ts` re-declared `BrowserPaneBoundsCapture` as a global ambient interface that independently extended `BrowserPaneBoundsRequest` with `sequence: number`. The canonical type already existed as a named export in `src/features/browser/browserBridge.ts`. TypeScript could not enforce that the two declarations stayed in sync; a required field added to the module type would silently leave the global type stale.
+- **Fix:** Replaced the ambient interface block with a global type alias that imports the canonical `BrowserPaneBoundsCapture` from `../features/browser/browserBridge` (aliased to avoid naming collision). E2E specs continue to consume the type globally while the renderer-side type remains the single source of truth.
 - **Commit:** same commit as this entry

--- a/electron/browser-pane.test.ts
+++ b/electron/browser-pane.test.ts
@@ -316,6 +316,7 @@ const electronMock = vi.hoisted(() => {
   interface LocalFakeView {
     webContents: LocalFakeWebContents
     setBounds: (bounds: LocalBounds) => void
+    setVisible: (visible: boolean) => void
   }
 
   interface LocalFakeWindow {
@@ -445,6 +446,7 @@ const electronMock = vi.hoisted(() => {
     const view: LocalFakeView = {
       webContents: createWebContents(),
       setBounds: vi.fn(),
+      setVisible: vi.fn(),
     }
 
     views.push(view)
@@ -1835,6 +1837,44 @@ describe('BrowserPaneController', () => {
       electronMock.views[0]
     )
     expect(electronMock.views[0]?.webContents.close).toHaveBeenCalledOnce()
+  })
+
+  test('keeps zero-bounds projection for an occluded native view', async () => {
+    await handler(BROWSER_PANE_CREATE)(eventForSender(), {
+      sessionId: 'pty-1',
+      paneId: 'p1',
+      workspaceId: 'proj-1',
+      initialUrl: 'https://example.com/',
+    })
+
+    handler(BROWSER_PANE_SET_BOUNDS)(eventForSender(), {
+      sessionId: 'pty-1',
+      paneId: 'p1',
+      bounds: { x: 1, y: 2, width: 300, height: 200 },
+      visible: true,
+    })
+
+    expect(electronMock.views[0]?.setBounds).toHaveBeenLastCalledWith({
+      x: 1,
+      y: 2,
+      width: 300,
+      height: 200,
+    })
+
+    handler(BROWSER_PANE_SET_BOUNDS)(eventForSender(), {
+      sessionId: 'pty-1',
+      paneId: 'p1',
+      bounds: { x: 1, y: 2, width: 300, height: 200 },
+      visible: false,
+    })
+
+    expect(electronMock.views[0]?.setBounds).toHaveBeenLastCalledWith({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+    })
+    expect(electronMock.views[0]?.setVisible).not.toHaveBeenCalled()
   })
 
   test('tab-0 destroyed after teardown does not emit a spurious empty tabs-changed', async () => {

--- a/src/features/browser/browserBridge.test.ts
+++ b/src/features/browser/browserBridge.test.ts
@@ -305,6 +305,46 @@ describe('browserBridge', () => {
     ])
   })
 
+  test('does not capture bounds requests after preload bridge disappears', async () => {
+    const bridge: BrowserPaneBridge = {
+      createPane: vi.fn(),
+      setBounds: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      newTab: vi.fn(),
+      destroyPane: vi.fn(),
+      focusPane: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+      openExternal: vi.fn(),
+      navAction: vi.fn(),
+      getCdpInfo: vi.fn(),
+      onFocus: vi.fn(() => (): void => undefined),
+      onFocusAddress: vi.fn(() => (): void => undefined),
+      onUrlChange: vi.fn(() => (): void => undefined),
+      onTabsChange: vi.fn(() => (): void => undefined),
+      onNavStateChange: vi.fn(() => (): void => undefined),
+    }
+    browserWindow().vimeflow = {
+      invoke: vi.fn(),
+      listen: vi.fn(),
+      browserPane: bridge,
+    }
+
+    expect(startBrowserPaneBoundsCapture()).toBe(true)
+
+    delete browserWindow().vimeflow?.browserPane
+
+    await setBrowserPaneBounds({
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: false,
+    })
+
+    expect(bridge.setBounds).not.toHaveBeenCalled()
+    expect(getBrowserPaneBoundsCaptures()).toEqual([])
+  })
+
   test('returns cloned browser pane bounds captures', async () => {
     const bridge: BrowserPaneBridge = {
       createPane: vi.fn(),

--- a/src/features/browser/browserBridge.test.ts
+++ b/src/features/browser/browserBridge.test.ts
@@ -6,6 +6,7 @@ import {
   destroyBrowserPane,
   focusBrowserPane,
   getBrowserCdpInfo,
+  getBrowserPaneBoundsCaptures,
   navActionBrowserPane,
   navigateBrowserPane,
   newBrowserPaneTab,
@@ -16,8 +17,10 @@ import {
   onBrowserPaneUrlChange,
   openExternalBrowserPane,
   setBrowserPaneBounds,
+  startBrowserPaneBoundsCapture,
+  stopBrowserPaneBoundsCapture,
 } from './browserBridge'
-import type { BrowserPaneBridge } from './types'
+import type { BrowserPaneBoundsRequest, BrowserPaneBridge } from './types'
 
 type BrowserBridgeWindow = Window & {
   vimeflow?: {
@@ -37,6 +40,7 @@ const request = {
 
 describe('browserBridge', () => {
   afterEach(() => {
+    stopBrowserPaneBoundsCapture()
     delete browserWindow().vimeflow
   })
 
@@ -248,5 +252,117 @@ describe('browserBridge', () => {
     expect(urlCleanup).toBe(unlistenUrl)
     expect(tabsCleanup).toBe(unlistenTabs)
     expect(navStateCleanup).toBe(unlistenNavState)
+  })
+
+  test('captures browser pane bounds requests before forwarding to preload', async () => {
+    const bridge: BrowserPaneBridge = {
+      createPane: vi.fn(),
+      setBounds: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      newTab: vi.fn(),
+      destroyPane: vi.fn(),
+      focusPane: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+      openExternal: vi.fn(),
+      navAction: vi.fn(),
+      getCdpInfo: vi.fn(),
+      onFocus: vi.fn(() => (): void => undefined),
+      onFocusAddress: vi.fn(() => (): void => undefined),
+      onUrlChange: vi.fn(() => (): void => undefined),
+      onTabsChange: vi.fn(() => (): void => undefined),
+      onNavStateChange: vi.fn(() => (): void => undefined),
+    }
+    browserWindow().vimeflow = {
+      invoke: vi.fn(),
+      listen: vi.fn(),
+      browserPane: bridge,
+    }
+
+    expect(startBrowserPaneBoundsCapture()).toBe(true)
+
+    const boundsRequest: BrowserPaneBoundsRequest = {
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: false,
+      shortcutContext: {
+        paneIds: ['p0', 'browser-1'],
+        activePaneId: 'browser-1',
+      },
+    }
+
+    await setBrowserPaneBounds(boundsRequest)
+
+    expect(bridge.setBounds).toHaveBeenCalledWith(boundsRequest)
+    expect(getBrowserPaneBoundsCaptures()).toEqual([
+      {
+        sequence: 0,
+        ...boundsRequest,
+      },
+    ])
+  })
+
+  test('returns cloned browser pane bounds captures', async () => {
+    const bridge: BrowserPaneBridge = {
+      createPane: vi.fn(),
+      setBounds: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      newTab: vi.fn(),
+      destroyPane: vi.fn(),
+      focusPane: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+      openExternal: vi.fn(),
+      navAction: vi.fn(),
+      getCdpInfo: vi.fn(),
+      onFocus: vi.fn(() => (): void => undefined),
+      onFocusAddress: vi.fn(() => (): void => undefined),
+      onUrlChange: vi.fn(() => (): void => undefined),
+      onTabsChange: vi.fn(() => (): void => undefined),
+      onNavStateChange: vi.fn(() => (): void => undefined),
+    }
+    browserWindow().vimeflow = {
+      invoke: vi.fn(),
+      listen: vi.fn(),
+      browserPane: bridge,
+    }
+
+    expect(startBrowserPaneBoundsCapture()).toBe(true)
+
+    await setBrowserPaneBounds({
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: true,
+      shortcutContext: {
+        paneIds: ['browser-1'],
+        activePaneId: 'browser-1',
+      },
+    })
+
+    const captures = getBrowserPaneBoundsCaptures()
+    const firstCapture = captures[0]
+    if (!firstCapture?.shortcutContext) {
+      throw new Error('expected a bounds capture with shortcut context')
+    }
+    firstCapture.bounds.width = 1
+    firstCapture.shortcutContext.paneIds.push('mutated')
+
+    expect(getBrowserPaneBoundsCaptures()).toEqual([
+      expect.objectContaining({
+        bounds: { x: 10, y: 20, width: 640, height: 480 },
+        shortcutContext: {
+          paneIds: ['browser-1'],
+          activePaneId: 'browser-1',
+        },
+      }),
+    ])
+  })
+
+  test('does not start bounds capture without the preload browser bridge', () => {
+    delete browserWindow().vimeflow
+
+    expect(startBrowserPaneBoundsCapture()).toBe(false)
   })
 })

--- a/src/features/browser/browserBridge.test.ts
+++ b/src/features/browser/browserBridge.test.ts
@@ -3,6 +3,7 @@ import {
   activateBrowserPaneTab,
   closeBrowserPaneTab,
   createBrowserPane,
+  clearBrowserPaneBoundsCaptures,
   destroyBrowserPane,
   focusBrowserPane,
   getBrowserCdpInfo,
@@ -356,6 +357,59 @@ describe('browserBridge', () => {
           paneIds: ['browser-1'],
           activePaneId: 'browser-1',
         },
+      }),
+    ])
+  })
+
+  test('keeps bounds capture sequence monotonic after clearing captures', async () => {
+    const bridge: BrowserPaneBridge = {
+      createPane: vi.fn(),
+      setBounds: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      newTab: vi.fn(),
+      destroyPane: vi.fn(),
+      focusPane: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+      openExternal: vi.fn(),
+      navAction: vi.fn(),
+      getCdpInfo: vi.fn(),
+      onFocus: vi.fn(() => (): void => undefined),
+      onFocusAddress: vi.fn(() => (): void => undefined),
+      onUrlChange: vi.fn(() => (): void => undefined),
+      onTabsChange: vi.fn(() => (): void => undefined),
+      onNavStateChange: vi.fn(() => (): void => undefined),
+    }
+    browserWindow().vimeflow = {
+      invoke: vi.fn(),
+      listen: vi.fn(),
+      browserPane: bridge,
+    }
+
+    expect(startBrowserPaneBoundsCapture()).toBe(true)
+
+    await setBrowserPaneBounds({
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: false,
+    })
+    const hiddenSequence = getBrowserPaneBoundsCaptures()[0]?.sequence
+
+    clearBrowserPaneBoundsCaptures()
+
+    await setBrowserPaneBounds({
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: true,
+    })
+
+    expect(hiddenSequence).toBe(0)
+    expect(getBrowserPaneBoundsCaptures()).toEqual([
+      expect.objectContaining({
+        sequence: 1,
+        visible: true,
       }),
     ])
   })

--- a/src/features/browser/browserBridge.test.ts
+++ b/src/features/browser/browserBridge.test.ts
@@ -415,6 +415,61 @@ describe('browserBridge', () => {
     ])
   })
 
+  test('keeps active bounds capture when start is called twice', async () => {
+    const bridge: BrowserPaneBridge = {
+      createPane: vi.fn(),
+      setBounds: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      newTab: vi.fn(),
+      destroyPane: vi.fn(),
+      focusPane: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+      openExternal: vi.fn(),
+      navAction: vi.fn(),
+      getCdpInfo: vi.fn(),
+      onFocus: vi.fn(() => (): void => undefined),
+      onFocusAddress: vi.fn(() => (): void => undefined),
+      onUrlChange: vi.fn(() => (): void => undefined),
+      onTabsChange: vi.fn(() => (): void => undefined),
+      onNavStateChange: vi.fn(() => (): void => undefined),
+    }
+    browserWindow().vimeflow = {
+      invoke: vi.fn(),
+      listen: vi.fn(),
+      browserPane: bridge,
+    }
+
+    expect(startBrowserPaneBoundsCapture()).toBe(true)
+
+    await setBrowserPaneBounds({
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: false,
+    })
+
+    expect(startBrowserPaneBoundsCapture()).toBe(true)
+
+    await setBrowserPaneBounds({
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: true,
+    })
+
+    expect(getBrowserPaneBoundsCaptures()).toEqual([
+      expect.objectContaining({
+        sequence: 0,
+        visible: false,
+      }),
+      expect.objectContaining({
+        sequence: 1,
+        visible: true,
+      }),
+    ])
+  })
+
   test('stops bounds capture without discarding collected captures', async () => {
     const bridge: BrowserPaneBridge = {
       createPane: vi.fn(),

--- a/src/features/browser/browserBridge.test.ts
+++ b/src/features/browser/browserBridge.test.ts
@@ -42,6 +42,7 @@ const request = {
 describe('browserBridge', () => {
   afterEach(() => {
     stopBrowserPaneBoundsCapture()
+    clearBrowserPaneBoundsCaptures()
     delete browserWindow().vimeflow
   })
 
@@ -410,6 +411,57 @@ describe('browserBridge', () => {
       expect.objectContaining({
         sequence: 1,
         visible: true,
+      }),
+    ])
+  })
+
+  test('stops bounds capture without discarding collected captures', async () => {
+    const bridge: BrowserPaneBridge = {
+      createPane: vi.fn(),
+      setBounds: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      newTab: vi.fn(),
+      destroyPane: vi.fn(),
+      focusPane: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+      openExternal: vi.fn(),
+      navAction: vi.fn(),
+      getCdpInfo: vi.fn(),
+      onFocus: vi.fn(() => (): void => undefined),
+      onFocusAddress: vi.fn(() => (): void => undefined),
+      onUrlChange: vi.fn(() => (): void => undefined),
+      onTabsChange: vi.fn(() => (): void => undefined),
+      onNavStateChange: vi.fn(() => (): void => undefined),
+    }
+    browserWindow().vimeflow = {
+      invoke: vi.fn(),
+      listen: vi.fn(),
+      browserPane: bridge,
+    }
+
+    expect(startBrowserPaneBoundsCapture()).toBe(true)
+
+    await setBrowserPaneBounds({
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: false,
+    })
+
+    stopBrowserPaneBoundsCapture()
+
+    await setBrowserPaneBounds({
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: true,
+    })
+
+    expect(getBrowserPaneBoundsCaptures()).toEqual([
+      expect.objectContaining({
+        sequence: 0,
+        visible: false,
       }),
     ])
   })

--- a/src/features/browser/browserBridge.test.ts
+++ b/src/features/browser/browserBridge.test.ts
@@ -521,6 +521,67 @@ describe('browserBridge', () => {
     ])
   })
 
+  test('starts a fresh bounds capture session after stopping', async () => {
+    const bridge: BrowserPaneBridge = {
+      createPane: vi.fn(),
+      setBounds: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      newTab: vi.fn(),
+      destroyPane: vi.fn(),
+      focusPane: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+      openExternal: vi.fn(),
+      navAction: vi.fn(),
+      getCdpInfo: vi.fn(),
+      onFocus: vi.fn(() => (): void => undefined),
+      onFocusAddress: vi.fn(() => (): void => undefined),
+      onUrlChange: vi.fn(() => (): void => undefined),
+      onTabsChange: vi.fn(() => (): void => undefined),
+      onNavStateChange: vi.fn(() => (): void => undefined),
+    }
+    browserWindow().vimeflow = {
+      invoke: vi.fn(),
+      listen: vi.fn(),
+      browserPane: bridge,
+    }
+
+    expect(startBrowserPaneBoundsCapture()).toBe(true)
+
+    await setBrowserPaneBounds({
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: false,
+    })
+
+    stopBrowserPaneBoundsCapture()
+
+    expect(getBrowserPaneBoundsCaptures()).toEqual([
+      expect.objectContaining({
+        sequence: 0,
+        visible: false,
+      }),
+    ])
+
+    expect(startBrowserPaneBoundsCapture()).toBe(true)
+    expect(getBrowserPaneBoundsCaptures()).toEqual([])
+
+    await setBrowserPaneBounds({
+      sessionId: 'sess-1',
+      paneId: 'browser-1',
+      bounds: { x: 10, y: 20, width: 640, height: 480 },
+      visible: true,
+    })
+
+    expect(getBrowserPaneBoundsCaptures()).toEqual([
+      expect.objectContaining({
+        sequence: 0,
+        visible: true,
+      }),
+    ])
+  })
+
   test('does not start bounds capture without the preload browser bridge', () => {
     delete browserWindow().vimeflow
 

--- a/src/features/browser/browserBridge.test.ts
+++ b/src/features/browser/browserBridge.test.ts
@@ -256,7 +256,7 @@ describe('browserBridge', () => {
     expect(navStateCleanup).toBe(unlistenNavState)
   })
 
-  test('captures browser pane bounds requests before forwarding to preload', async () => {
+  test('captures browser pane bounds requests after forwarding to preload succeeds', async () => {
     const bridge: BrowserPaneBridge = {
       createPane: vi.fn(),
       setBounds: vi.fn().mockResolvedValue(undefined),

--- a/src/features/browser/browserBridge.ts
+++ b/src/features/browser/browserBridge.ts
@@ -17,11 +17,18 @@ import type {
   BrowserPaneNavStateChangedEvent,
 } from './types'
 
+export interface BrowserPaneBoundsCapture extends BrowserPaneBoundsRequest {
+  sequence: number
+}
+
 type BrowserCapableWindow = Window & {
   vimeflow?: {
     browserPane?: BrowserPaneBridge
   }
 }
+
+let browserPaneBoundsCaptureActive = false
+let browserPaneBoundsCaptures: BrowserPaneBoundsCapture[] = []
 
 const bridge = (): BrowserPaneBridge | undefined => {
   if (typeof window === 'undefined') {
@@ -30,6 +37,64 @@ const bridge = (): BrowserPaneBridge | undefined => {
 
   return (window as BrowserCapableWindow).vimeflow?.browserPane
 }
+
+const cloneBoundsCapture = (
+  request: BrowserPaneBoundsRequest
+): BrowserPaneBoundsCapture => {
+  const capture: BrowserPaneBoundsCapture = {
+    sequence: browserPaneBoundsCaptures.length,
+    sessionId: request.sessionId,
+    paneId: request.paneId,
+    bounds: { ...request.bounds },
+    visible: request.visible,
+  }
+
+  if (request.shortcutContext) {
+    capture.shortcutContext = {
+      paneIds: [...request.shortcutContext.paneIds],
+      activePaneId: request.shortcutContext.activePaneId,
+    }
+  }
+
+  return capture
+}
+
+export const startBrowserPaneBoundsCapture = (): boolean => {
+  if (!bridge()) {
+    return false
+  }
+
+  browserPaneBoundsCaptureActive = true
+  browserPaneBoundsCaptures = []
+
+  return true
+}
+
+export const clearBrowserPaneBoundsCaptures = (): void => {
+  browserPaneBoundsCaptures = []
+}
+
+export const stopBrowserPaneBoundsCapture = (): void => {
+  browserPaneBoundsCaptureActive = false
+  browserPaneBoundsCaptures = []
+}
+
+export const getBrowserPaneBoundsCaptures = (): BrowserPaneBoundsCapture[] =>
+  browserPaneBoundsCaptures.map((capture) => {
+    const nextCapture: BrowserPaneBoundsCapture = {
+      ...capture,
+      bounds: { ...capture.bounds },
+    }
+
+    if (capture.shortcutContext) {
+      nextCapture.shortcutContext = {
+        paneIds: [...capture.shortcutContext.paneIds],
+        activePaneId: capture.shortcutContext.activePaneId,
+      }
+    }
+
+    return nextCapture
+  })
 
 export const createBrowserPane = async (
   request: BrowserPaneCreateRequest
@@ -59,6 +124,10 @@ export const createBrowserPane = async (
 export const setBrowserPaneBounds = async (
   request: BrowserPaneBoundsRequest
 ): Promise<void> => {
+  if (browserPaneBoundsCaptureActive) {
+    browserPaneBoundsCaptures.push(cloneBoundsCapture(request))
+  }
+
   await bridge()?.setBounds(request)
 }
 

--- a/src/features/browser/browserBridge.ts
+++ b/src/features/browser/browserBridge.ts
@@ -130,13 +130,16 @@ export const createBrowserPane = async (
 export const setBrowserPaneBounds = async (
   request: BrowserPaneBoundsRequest
 ): Promise<void> => {
-  const browserBridge = bridge()
-
-  if (browserPaneBoundsCaptureActive && browserBridge) {
-    browserPaneBoundsCaptures.push(cloneBoundsCapture(request))
+  const bri = bridge()
+  if (!bri) {
+    return
   }
 
-  await browserBridge?.setBounds(request)
+  await bri.setBounds(request)
+
+  if (browserPaneBoundsCaptureActive) {
+    browserPaneBoundsCaptures.push(cloneBoundsCapture(request))
+  }
 }
 
 export const navigateBrowserPane = async (

--- a/src/features/browser/browserBridge.ts
+++ b/src/features/browser/browserBridge.ts
@@ -79,8 +79,6 @@ export const clearBrowserPaneBoundsCaptures = (): void => {
 
 export const stopBrowserPaneBoundsCapture = (): void => {
   browserPaneBoundsCaptureActive = false
-  browserPaneBoundsCaptures = []
-  browserPaneBoundsSequence = 0
 }
 
 export const getBrowserPaneBoundsCaptures = (): BrowserPaneBoundsCapture[] =>

--- a/src/features/browser/browserBridge.ts
+++ b/src/features/browser/browserBridge.ts
@@ -66,6 +66,10 @@ export const startBrowserPaneBoundsCapture = (): boolean => {
     return false
   }
 
+  if (browserPaneBoundsCaptureActive) {
+    return true
+  }
+
   browserPaneBoundsCaptureActive = true
   browserPaneBoundsCaptures = []
   browserPaneBoundsSequence = 0

--- a/src/features/browser/browserBridge.ts
+++ b/src/features/browser/browserBridge.ts
@@ -130,11 +130,13 @@ export const createBrowserPane = async (
 export const setBrowserPaneBounds = async (
   request: BrowserPaneBoundsRequest
 ): Promise<void> => {
-  if (browserPaneBoundsCaptureActive) {
+  const browserBridge = bridge()
+
+  if (browserPaneBoundsCaptureActive && browserBridge) {
     browserPaneBoundsCaptures.push(cloneBoundsCapture(request))
   }
 
-  await bridge()?.setBounds(request)
+  await browserBridge?.setBounds(request)
 }
 
 export const navigateBrowserPane = async (

--- a/src/features/browser/browserBridge.ts
+++ b/src/features/browser/browserBridge.ts
@@ -29,6 +29,7 @@ type BrowserCapableWindow = Window & {
 
 let browserPaneBoundsCaptureActive = false
 let browserPaneBoundsCaptures: BrowserPaneBoundsCapture[] = []
+let browserPaneBoundsSequence = 0
 
 const bridge = (): BrowserPaneBridge | undefined => {
   if (typeof window === 'undefined') {
@@ -42,12 +43,13 @@ const cloneBoundsCapture = (
   request: BrowserPaneBoundsRequest
 ): BrowserPaneBoundsCapture => {
   const capture: BrowserPaneBoundsCapture = {
-    sequence: browserPaneBoundsCaptures.length,
+    sequence: browserPaneBoundsSequence,
     sessionId: request.sessionId,
     paneId: request.paneId,
     bounds: { ...request.bounds },
     visible: request.visible,
   }
+  browserPaneBoundsSequence += 1
 
   if (request.shortcutContext) {
     capture.shortcutContext = {
@@ -66,6 +68,7 @@ export const startBrowserPaneBoundsCapture = (): boolean => {
 
   browserPaneBoundsCaptureActive = true
   browserPaneBoundsCaptures = []
+  browserPaneBoundsSequence = 0
 
   return true
 }
@@ -77,6 +80,7 @@ export const clearBrowserPaneBoundsCaptures = (): void => {
 export const stopBrowserPaneBoundsCapture = (): void => {
   browserPaneBoundsCaptureActive = false
   browserPaneBoundsCaptures = []
+  browserPaneBoundsSequence = 0
 }
 
 export const getBrowserPaneBoundsCaptures = (): BrowserPaneBoundsCapture[] =>

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -6,6 +6,7 @@ import {
   clearBrowserPaneBoundsCaptures,
   getBrowserPaneBoundsCaptures,
   startBrowserPaneBoundsCapture,
+  stopBrowserPaneBoundsCapture,
 } from '../features/browser/browserBridge'
 
 const isVisible = (el: HTMLElement): boolean => {
@@ -140,6 +141,7 @@ if (import.meta.env.VITE_E2E) {
       invoke<string[]>('list_active_pty_sessions'),
     startBrowserPaneBoundsCapture,
     clearBrowserPaneBoundsCaptures,
+    stopBrowserPaneBoundsCapture,
     getBrowserPaneBoundsCaptures,
   }
 }

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -9,6 +9,19 @@ import {
   stopBrowserPaneBoundsCapture,
 } from '../features/browser/browserBridge'
 
+type AssertExtends<Target, Source extends Target> = Source
+
+export type BrowserPaneBoundsCaptureE2eContract = [
+  AssertExtends<
+    BrowserPaneBoundsCapture,
+    ReturnType<typeof getBrowserPaneBoundsCaptures>[number]
+  >,
+  AssertExtends<
+    ReturnType<typeof getBrowserPaneBoundsCaptures>[number],
+    BrowserPaneBoundsCapture
+  >,
+]
+
 const isVisible = (el: HTMLElement): boolean => {
   const r = el.getBoundingClientRect()
 

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -2,6 +2,11 @@ import type { Terminal } from '@xterm/xterm'
 import { invoke } from './backend'
 import { getAllPtySessionIds } from '../features/terminal/ptySessionMap'
 import { terminalCache } from '../features/terminal/components/TerminalPane/Body'
+import {
+  clearBrowserPaneBoundsCaptures,
+  getBrowserPaneBoundsCaptures,
+  startBrowserPaneBoundsCapture,
+} from '../features/browser/browserBridge'
 
 const isVisible = (el: HTMLElement): boolean => {
   const r = el.getBoundingClientRect()
@@ -133,5 +138,8 @@ if (import.meta.env.VITE_E2E) {
     getActiveSessionIds: getAllPtySessionIds,
     listActivePtySessions: async (): Promise<string[]> =>
       invoke<string[]>('list_active_pty_sessions'),
+    startBrowserPaneBoundsCapture,
+    clearBrowserPaneBoundsCaptures,
+    getBrowserPaneBoundsCaptures,
   }
 }

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -9,19 +9,6 @@ import {
   stopBrowserPaneBoundsCapture,
 } from '../features/browser/browserBridge'
 
-type AssertExtends<Target, Source extends Target> = Source
-
-export type BrowserPaneBoundsCaptureE2eContract = [
-  AssertExtends<
-    BrowserPaneBoundsCapture,
-    ReturnType<typeof getBrowserPaneBoundsCaptures>[number]
-  >,
-  AssertExtends<
-    ReturnType<typeof getBrowserPaneBoundsCaptures>[number],
-    BrowserPaneBoundsCapture
-  >,
-]
-
 const isVisible = (el: HTMLElement): boolean => {
   const r = el.getBoundingClientRect()
 

--- a/src/types/e2e.d.ts
+++ b/src/types/e2e.d.ts
@@ -1,6 +1,23 @@
 export {}
 
 declare global {
+  interface BrowserPaneBoundsCapture {
+    sequence: number
+    sessionId: string
+    paneId: string
+    bounds: {
+      x: number
+      y: number
+      width: number
+      height: number
+    }
+    visible: boolean
+    shortcutContext?: {
+      paneIds: string[]
+      activePaneId: string | null
+    }
+  }
+
   interface Window {
     __VIMEFLOW_E2E__?: {
       getTerminalBuffer(): string
@@ -8,6 +25,9 @@ declare global {
       getVisibleSessionId(): string | null
       getActiveSessionIds(): string[]
       listActivePtySessions(): Promise<string[]>
+      startBrowserPaneBoundsCapture(): boolean
+      clearBrowserPaneBoundsCaptures(): void
+      getBrowserPaneBoundsCaptures(): BrowserPaneBoundsCapture[]
     }
   }
 }

--- a/src/types/e2e.d.ts
+++ b/src/types/e2e.d.ts
@@ -1,6 +1,7 @@
 export {}
 
 declare global {
+  // Mirrors BrowserPaneBoundsCapture in src/features/browser/browserBridge.ts.
   interface BrowserPaneBoundsCapture {
     sequence: number
     sessionId: string
@@ -27,6 +28,7 @@ declare global {
       listActivePtySessions(): Promise<string[]>
       startBrowserPaneBoundsCapture(): boolean
       clearBrowserPaneBoundsCaptures(): void
+      stopBrowserPaneBoundsCapture(): void
       getBrowserPaneBoundsCaptures(): BrowserPaneBoundsCapture[]
     }
   }

--- a/src/types/e2e.d.ts
+++ b/src/types/e2e.d.ts
@@ -1,22 +1,10 @@
+import type { BrowserPaneBoundsRequest } from '../features/browser/types'
+
 export {}
 
 declare global {
-  // Mirrors BrowserPaneBoundsCapture in src/features/browser/browserBridge.ts.
-  interface BrowserPaneBoundsCapture {
+  interface BrowserPaneBoundsCapture extends BrowserPaneBoundsRequest {
     sequence: number
-    sessionId: string
-    paneId: string
-    bounds: {
-      x: number
-      y: number
-      width: number
-      height: number
-    }
-    visible: boolean
-    shortcutContext?: {
-      paneIds: string[]
-      activePaneId: string | null
-    }
   }
 
   interface Window {

--- a/src/types/e2e.d.ts
+++ b/src/types/e2e.d.ts
@@ -1,11 +1,9 @@
-import type { BrowserPaneBoundsRequest } from '../features/browser/types'
+import type { BrowserPaneBoundsCapture as BrowserPaneBoundsCaptureSource } from '../features/browser/browserBridge'
 
 export {}
 
 declare global {
-  interface BrowserPaneBoundsCapture extends BrowserPaneBoundsRequest {
-    sequence: number
-  }
+  type BrowserPaneBoundsCapture = BrowserPaneBoundsCaptureSource
 
   interface Window {
     __VIMEFLOW_E2E__?: {

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -177,16 +177,22 @@ const waitForBoundsCapture = async (
   visible: boolean,
   minSequence?: number
 ): Promise<BrowserPaneBoundsCapture> => {
+  let capture: BrowserPaneBoundsCapture | undefined
+
   await browser.waitUntil(
     async () => {
       const captures = await browser.execute(
         () => window.__VIMEFLOW_E2E__?.getBrowserPaneBoundsCaptures() ?? []
       )
-
-      return (
-        matchingBoundsCaptures(captures, identity, visible, minSequence)
-          .length > 0
+      const matching = matchingBoundsCaptures(
+        captures,
+        identity,
+        visible,
+        minSequence
       )
+
+      capture = matching[matching.length - 1]
+      return capture !== undefined
     },
     {
       timeout: 5_000,
@@ -195,16 +201,6 @@ const waitForBoundsCapture = async (
     }
   )
 
-  const captures = await browser.execute(
-    () => window.__VIMEFLOW_E2E__?.getBrowserPaneBoundsCaptures() ?? []
-  )
-  const matching = matchingBoundsCaptures(
-    captures,
-    identity,
-    visible,
-    minSequence
-  )
-  const capture = matching[matching.length - 1]
   if (!capture) {
     throw new Error(`missing visible=${String(visible)} bounds capture`)
   }

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -148,6 +148,12 @@ const startBoundsCapture = async (): Promise<void> => {
   }
 }
 
+const stopBoundsCapture = async (): Promise<void> => {
+  await browser.execute(() => {
+    window.__VIMEFLOW_E2E__?.stopBrowserPaneBoundsCapture()
+  })
+}
+
 const matchingBoundsCaptures = (
   captures: BrowserPaneBoundsCapture[],
   identity: BrowserPaneIdentity,
@@ -265,6 +271,10 @@ const assertRealLayoutBounds = (
 }
 
 describe('BrowserPane native overlay occlusion', () => {
+  afterEach(async () => {
+    await stopBoundsCapture()
+  })
+
   it('hides a real WebContentsView browser pane behind the command palette', async () => {
     await waitForBrowserPane()
     const identity = await readBrowserPaneIdentity()

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -1,0 +1,276 @@
+import { clickBySelector } from '../../shared/actions.js'
+
+interface BrowserPaneIdentity {
+  sessionId: string
+  paneId: string
+}
+
+interface BrowserCdpInfo {
+  url: string
+  token: string
+  targetId: string
+}
+
+interface BrowserCdpListTarget {
+  id: string
+  type: string
+}
+
+interface BrowserPaneBridgeWindow {
+  vimeflow?: {
+    browserPane?: {
+      getCdpInfo: (request: BrowserPaneIdentity) => Promise<BrowserCdpInfo>
+    }
+  }
+}
+
+const commandPaletteSelector = '[role="dialog"][aria-label="Command palette"]'
+
+const waitForBrowserPane = async (): Promise<void> => {
+  await (
+    await $('[data-testid="terminal-pane"]')
+  ).waitForDisplayed({
+    timeout: 20_000,
+  })
+
+  await clickBySelector('button[aria-label="Vertical split"]')
+
+  await browser.waitUntil(
+    async () =>
+      await browser.execute(
+        () =>
+          document.querySelector('[data-testid="split-view-empty-slot"]') !==
+          null
+      ),
+    {
+      timeout: 10_000,
+      interval: 250,
+      timeoutMsg: 'empty split slot did not render',
+    }
+  )
+
+  await clickBySelector('button[aria-label="add browser pane"]')
+  await (
+    await $('[data-testid="browser-pane"]')
+  ).waitForDisplayed({
+    timeout: 15_000,
+  })
+}
+
+const readBrowserPaneIdentity = async (): Promise<BrowserPaneIdentity> => {
+  const identity = await browser.execute(() => {
+    const pane = document.querySelector<HTMLElement>(
+      '[data-testid="browser-pane"][data-browser-pane-id]'
+    )
+    const splitView = pane?.closest<HTMLElement>('[data-testid="split-view"]')
+    const sessionId =
+      splitView?.dataset.browserSessionId ?? splitView?.dataset.sessionId
+    const paneId = pane?.dataset.browserPaneId
+
+    return sessionId && paneId ? { sessionId, paneId } : null
+  })
+
+  if (!identity) {
+    throw new Error('browser pane identity was not available in the DOM')
+  }
+
+  return identity
+}
+
+const waitForBrowserPaneCdpInfo = async (
+  identity: BrowserPaneIdentity
+): Promise<BrowserCdpInfo> => {
+  let latestInfo: BrowserCdpInfo | null = null
+
+  await browser.waitUntil(
+    async () => {
+      latestInfo = await browser.execute(async (request) => {
+        const bridge = (window as unknown as BrowserPaneBridgeWindow).vimeflow
+          ?.browserPane
+
+        try {
+          return (await bridge?.getCdpInfo(request)) ?? null
+        } catch {
+          return null
+        }
+      }, identity)
+
+      return latestInfo !== null
+    },
+    {
+      timeout: 15_000,
+      interval: 250,
+      timeoutMsg: 'browser pane CDP target was not registered',
+    }
+  )
+
+  if (!latestInfo) {
+    throw new Error('browser pane CDP target was not registered')
+  }
+
+  return latestInfo
+}
+
+const assertCdpTarget = async (
+  identity: BrowserPaneIdentity,
+  cdpInfo: BrowserCdpInfo
+): Promise<void> => {
+  const response = await fetch(
+    `${cdpInfo.url}/json/list?token=${cdpInfo.token}`
+  )
+  if (!response.ok) {
+    throw new Error(`CDP list endpoint failed with ${String(response.status)}`)
+  }
+
+  const targets = (await response.json()) as BrowserCdpListTarget[]
+  const expectedTargetId = `${identity.sessionId}:${identity.paneId}`
+  const targetExists = targets.some(
+    (target) =>
+      target.id === cdpInfo.targetId &&
+      target.id === expectedTargetId &&
+      target.type === 'page'
+  )
+
+  if (!targetExists) {
+    throw new Error(
+      `CDP list did not include the browser pane target ${expectedTargetId}`
+    )
+  }
+}
+
+const startBoundsCapture = async (): Promise<void> => {
+  const started = await browser.execute(
+    () => window.__VIMEFLOW_E2E__?.startBrowserPaneBoundsCapture() ?? false
+  )
+
+  if (!started) {
+    throw new Error('browser pane bounds capture helper is unavailable')
+  }
+}
+
+const matchingBoundsCaptures = (
+  captures: BrowserPaneBoundsCapture[],
+  identity: BrowserPaneIdentity,
+  visible: boolean
+): BrowserPaneBoundsCapture[] =>
+  captures.filter(
+    (capture) =>
+      capture.sessionId === identity.sessionId &&
+      capture.paneId === identity.paneId &&
+      capture.visible === visible
+  )
+
+const waitForBoundsCapture = async (
+  identity: BrowserPaneIdentity,
+  visible: boolean
+): Promise<BrowserPaneBoundsCapture> => {
+  await browser.waitUntil(
+    async () => {
+      const captures = await browser.execute(
+        () => window.__VIMEFLOW_E2E__?.getBrowserPaneBoundsCaptures() ?? []
+      )
+
+      return matchingBoundsCaptures(captures, identity, visible).length > 0
+    },
+    {
+      timeout: 5_000,
+      interval: 100,
+      timeoutMsg: `browser pane never sent visible=${String(visible)} bounds`,
+    }
+  )
+
+  const captures = await browser.execute(
+    () => window.__VIMEFLOW_E2E__?.getBrowserPaneBoundsCaptures() ?? []
+  )
+  const matching = matchingBoundsCaptures(captures, identity, visible)
+  const capture = matching[matching.length - 1]
+  if (!capture) {
+    throw new Error(`missing visible=${String(visible)} bounds capture`)
+  }
+
+  return capture
+}
+
+const dispatchCommandPaletteShortcut = async (): Promise<void> => {
+  await browser.execute(() => {
+    const isMac = navigator.platform.toLowerCase().includes('mac')
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: ';',
+        code: 'Semicolon',
+        ctrlKey: !isMac,
+        metaKey: isMac,
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+  })
+}
+
+const openCommandPalette = async (): Promise<void> => {
+  await dispatchCommandPaletteShortcut()
+  await (
+    await $(commandPaletteSelector)
+  ).waitForDisplayed({
+    timeout: 3_000,
+  })
+}
+
+const closeCommandPalette = async (): Promise<void> => {
+  await browser.execute(() => {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        code: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+  })
+
+  await browser.waitUntil(
+    async () =>
+      await browser.execute(
+        (selector: string) => document.querySelector(selector) === null,
+        commandPaletteSelector
+      ),
+    {
+      timeout: 3_000,
+      interval: 100,
+      timeoutMsg: 'command palette did not close',
+    }
+  )
+}
+
+const assertRealLayoutBounds = (
+  capture: BrowserPaneBoundsCapture,
+  context: string
+): void => {
+  if (capture.bounds.width <= 0 || capture.bounds.height <= 0) {
+    throw new Error(
+      `${context} bounds did not retain a real browser pane layout rectangle`
+    )
+  }
+}
+
+describe('BrowserPane native overlay occlusion', () => {
+  it('hides a real WebContentsView browser pane behind the command palette', async () => {
+    await waitForBrowserPane()
+    const identity = await readBrowserPaneIdentity()
+    const cdpInfo = await waitForBrowserPaneCdpInfo(identity)
+    await assertCdpTarget(identity, cdpInfo)
+
+    await startBoundsCapture()
+    await openCommandPalette()
+    const hiddenCapture = await waitForBoundsCapture(identity, false)
+    assertRealLayoutBounds(hiddenCapture, 'occluded')
+
+    await closeCommandPalette()
+    const shownCapture = await waitForBoundsCapture(identity, true)
+    assertRealLayoutBounds(shownCapture, 'restored')
+
+    if (shownCapture.sequence <= hiddenCapture.sequence) {
+      throw new Error('browser pane did not restore after it was hidden')
+    }
+  })
+})

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -299,5 +299,5 @@ describe('BrowserPane native overlay occlusion', () => {
       hiddenCapture.sequence
     )
     assertRealLayoutBounds(shownCapture, 'restored')
-  })
+  }, 60_000)
 })

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -125,15 +125,18 @@ const assertCdpTarget = async (
   const targets = (await response.json()) as BrowserCdpListTarget[]
   const expectedTargetId = `${identity.sessionId}:${identity.paneId}`
   const targetExists = targets.some(
-    (target) =>
-      target.id === cdpInfo.targetId &&
-      target.id === expectedTargetId &&
-      target.type === 'page'
+    (target) => target.id === cdpInfo.targetId && target.type === 'page'
   )
 
   if (!targetExists) {
     throw new Error(
-      `CDP list did not include the browser pane target ${expectedTargetId}`
+      `CDP list did not include browser pane target ${cdpInfo.targetId}`
+    )
+  }
+
+  if (cdpInfo.targetId !== expectedTargetId) {
+    throw new Error(
+      `CDP target id mismatch: got ${cdpInfo.targetId}, expected ${expectedTargetId}`
     )
   }
 }
@@ -293,9 +296,5 @@ describe('BrowserPane native overlay occlusion', () => {
       hiddenCapture.sequence
     )
     assertRealLayoutBounds(shownCapture, 'restored')
-
-    if (shownCapture.sequence <= hiddenCapture.sequence) {
-      throw new Error('browser pane did not restore after it was hidden')
-    }
   })
 })

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -299,5 +299,5 @@ describe('BrowserPane native overlay occlusion', () => {
       hiddenCapture.sequence
     )
     assertRealLayoutBounds(shownCapture, 'restored')
-  }, 60_000)
+  }).timeout(60_000)
 })

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -154,6 +154,7 @@ const startBoundsCapture = async (): Promise<void> => {
 const stopBoundsCapture = async (): Promise<void> => {
   await browser.execute(() => {
     window.__VIMEFLOW_E2E__?.stopBrowserPaneBoundsCapture()
+    window.__VIMEFLOW_E2E__?.clearBrowserPaneBoundsCaptures()
   })
 }
 

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -214,7 +214,13 @@ const waitForBoundsCapture = async (
 
 const dispatchCommandPaletteShortcut = async (): Promise<void> => {
   await browser.execute(() => {
-    const isMac = navigator.platform.toLowerCase().includes('mac')
+    const platform =
+      (
+        navigator as Navigator & {
+          userAgentData?: { platform?: string }
+        }
+      ).userAgentData?.platform ?? navigator.platform
+    const isMac = platform.toLowerCase().includes('mac')
     document.dispatchEvent(
       new KeyboardEvent('keydown', {
         key: ';',

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -151,18 +151,21 @@ const startBoundsCapture = async (): Promise<void> => {
 const matchingBoundsCaptures = (
   captures: BrowserPaneBoundsCapture[],
   identity: BrowserPaneIdentity,
-  visible: boolean
+  visible: boolean,
+  minSequence = -1
 ): BrowserPaneBoundsCapture[] =>
   captures.filter(
     (capture) =>
       capture.sessionId === identity.sessionId &&
       capture.paneId === identity.paneId &&
-      capture.visible === visible
+      capture.visible === visible &&
+      capture.sequence > minSequence
   )
 
 const waitForBoundsCapture = async (
   identity: BrowserPaneIdentity,
-  visible: boolean
+  visible: boolean,
+  minSequence?: number
 ): Promise<BrowserPaneBoundsCapture> => {
   await browser.waitUntil(
     async () => {
@@ -170,7 +173,10 @@ const waitForBoundsCapture = async (
         () => window.__VIMEFLOW_E2E__?.getBrowserPaneBoundsCaptures() ?? []
       )
 
-      return matchingBoundsCaptures(captures, identity, visible).length > 0
+      return (
+        matchingBoundsCaptures(captures, identity, visible, minSequence)
+          .length > 0
+      )
     },
     {
       timeout: 5_000,
@@ -182,7 +188,12 @@ const waitForBoundsCapture = async (
   const captures = await browser.execute(
     () => window.__VIMEFLOW_E2E__?.getBrowserPaneBoundsCaptures() ?? []
   )
-  const matching = matchingBoundsCaptures(captures, identity, visible)
+  const matching = matchingBoundsCaptures(
+    captures,
+    identity,
+    visible,
+    minSequence
+  )
   const capture = matching[matching.length - 1]
   if (!capture) {
     throw new Error(`missing visible=${String(visible)} bounds capture`)
@@ -266,7 +277,11 @@ describe('BrowserPane native overlay occlusion', () => {
     assertRealLayoutBounds(hiddenCapture, 'occluded')
 
     await closeCommandPalette()
-    const shownCapture = await waitForBoundsCapture(identity, true)
+    const shownCapture = await waitForBoundsCapture(
+      identity,
+      true,
+      hiddenCapture.sequence
+    )
     assertRealLayoutBounds(shownCapture, 'restored')
 
     if (shownCapture.sequence <= hiddenCapture.sequence) {


### PR DESCRIPTION
## Summary

- Add an E2E-only browser-pane bounds capture helper at the renderer bridge boundary.
- Expose the capture helper through the E2E bridge and add a WDIO smoke test that creates a real browser pane, verifies its CDP target, hides it behind the command palette, and observes a later restore.
- Add main-process coverage documenting the current native hide behavior: occlusion keeps zero-bounds projection and does not call `setVisible`.

## Validation

- `npm exec vitest run src/features/browser/browserBridge.test.ts src/lib/e2e-bridge.test.ts electron/browser-pane.test.ts`
- `npm exec eslint -- --no-warn-ignored electron/browser-pane.test.ts src/features/browser/browserBridge.ts src/features/browser/browserBridge.test.ts src/lib/e2e-bridge.ts src/lib/e2e-bridge.test.ts src/types/e2e.d.ts tests/e2e/core/specs/browser-pane-overlay.spec.ts`
- `npx prettier --check electron/browser-pane.test.ts src/features/browser/browserBridge.ts src/features/browser/browserBridge.test.ts src/lib/e2e-bridge.ts src/lib/e2e-bridge.test.ts src/types/e2e.d.ts tests/e2e/core/specs/browser-pane-overlay.spec.ts`
- `npx tsc -p tests/e2e/tsconfig.json`
- `npm run type-check -- --pretty false`
- `git diff --check`
- `npm run test:e2e:build`
- `npx wdio tests/e2e/core/wdio.conf.ts --spec tests/e2e/core/specs/browser-pane-overlay.spec.ts`

Notes: `type-check` and `test:e2e:build` still print the existing ts-rs serde warnings; `test:e2e:build` also still prints the existing Vite chunk-size warning.