### PR TITLE
fix(agent-status): preserve clear reset latch

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -91,4 +91,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 1        | 0    | 2026-06-13   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
-| [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 2        | 1    | 2026-06-15   |
+| [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 3        | 2    | 2026-06-15   |

--- a/docs/reviews/patterns/agent-state-guards.md
+++ b/docs/reviews/patterns/agent-state-guards.md
@@ -3,7 +3,7 @@ id: agent-state-guards
 category: correctness
 created: 2026-06-15
 last_updated: 2026-06-15
-ref_count: 1
+ref_count: 2
 ---
 
 # Agent-State Guards
@@ -30,4 +30,13 @@ UI state that tracks an active agent session must validate the agent's identity 
 - **File:** `src/features/agent-status/hooks/useAgentStatus.ts` L480-512
 - **Finding:** After a local `/clear` reset, `useAgentStatus` compared arriving `agent-status` token totals against a pre-reset snapshot to decide whether the event was stale. If the React state had no `contextWindow` snapshot at reset time (`priorTokenTotal === null`), neither suppression branch fired, so a concurrent stale same-run status event repopulated `agentSessionId` and `contextWindow` and also cleared the run-scoped event latch, allowing old tool-call, turn, and test-run events to refill the sidebar.
 - **Fix:** Added a conservative `priorTokenTotal === null` early-return inside the same-session reset guard. When freshness cannot be measured, the hook keeps the previous cleared state and preserves the run-scoped suppression latch until a fresh session boundary (different `agentSessionId`) arrives. Added a regression test covering the null-snapshot case.
+- **Commit:** same commit as this entry
+
+### 3. Double clear overwrites the reset latch with null
+
+- **Source:** github-claude | PR #469 round 3 | 2026-06-15
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/hooks/useAgentStatus.ts` L197-200
+- **Finding:** A second `/clear` after the first reset committed saw `prev.agentSessionId === null` and overwrote `locallyResetAgentSessionIdRef` with null. That disabled the same-run staleness guard, so the next stale `agent-status` event could repopulate the cleared sidebar and clear the run-scoped suppression latch for old tool-call, turn, and test events.
+- **Fix:** Preserved the existing reset latch when `prev.agentSessionId` is already null, while still keeping run-scoped suppression active. Added a regression test that sends two reset generations across separate renders, then verifies same-run stale status, tool-call, and turn events remain suppressed until a fresh agent session ID arrives.
 - **Commit:** same commit as this entry

--- a/src/features/agent-status/hooks/useAgentStatus.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.test.ts
@@ -1382,6 +1382,113 @@ describe('useAgentStatus', () => {
     )
   })
 
+  test('double resetGeneration preserves the stale same-run suppression latch', async () => {
+    const { result, rerender } = renderHook(
+      ({ resetGeneration }: { resetGeneration: number }) =>
+        useAgentStatus('session-1', resetGeneration),
+      { initialProps: { resetGeneration: 0 } }
+    )
+
+    await vi.waitFor(() => {
+      expect(eventListeners.get('agent-status')?.length).toBe(1)
+      expect(eventListeners.get('agent-tool-call')?.length).toBe(1)
+      expect(eventListeners.get('agent-turn')?.length).toBe(1)
+    })
+
+    act(() => {
+      emit('agent-status', {
+        sessionId: 'pty-session-1',
+        modelId: 'gpt-5.5',
+        modelDisplayName: 'GPT-5.5',
+        version: '0.139.0',
+        agentSessionId: 'codex-old',
+        contextWindow: {
+          usedPercentage: 80,
+          remainingPercentage: 20,
+          contextWindowSize: 258000,
+          totalInputTokens: 9000,
+          totalOutputTokens: 1000,
+          currentUsage: null,
+        },
+        cost: null,
+        rateLimits: null,
+      })
+    })
+
+    expect(result.current.agentSessionId).toBe('codex-old')
+    expect(result.current.contextWindow?.usedPercentage).toBe(80)
+
+    rerender({ resetGeneration: 1 })
+    expect(result.current.agentSessionId).toBeNull()
+
+    rerender({ resetGeneration: 2 })
+    expect(result.current.agentSessionId).toBeNull()
+
+    act(() => {
+      emit('agent-status', {
+        sessionId: 'pty-session-1',
+        modelId: 'gpt-5.5',
+        modelDisplayName: 'GPT-5.5',
+        version: '0.139.0',
+        agentSessionId: 'codex-old',
+        contextWindow: {
+          usedPercentage: 81,
+          remainingPercentage: 19,
+          contextWindowSize: 258000,
+          totalInputTokens: 9100,
+          totalOutputTokens: 1000,
+          currentUsage: null,
+        },
+        cost: null,
+        rateLimits: null,
+      })
+
+      emit('agent-tool-call', {
+        sessionId: 'pty-session-1',
+        toolUseId: 'stale-running-call-after-double-clear',
+        tool: 'exec_command',
+        args: 'npm run lint',
+        status: 'running',
+        timestamp: '2026-06-15T12:01:00Z',
+        durationMs: null,
+      })
+
+      emit('agent-turn', {
+        sessionId: 'pty-session-1',
+        numTurns: 10,
+      })
+    })
+
+    expect(result.current.agentSessionId).toBeNull()
+    expect(result.current.contextWindow).toBeNull()
+    expect(result.current.toolCalls.active).toBeNull()
+    expect(result.current.toolCalls.total).toBe(0)
+    expect(result.current.numTurns).toBe(0)
+
+    act(() => {
+      emit('agent-status', {
+        sessionId: 'pty-session-1',
+        modelId: 'gpt-5.5',
+        modelDisplayName: 'GPT-5.5',
+        version: '0.139.0',
+        agentSessionId: 'codex-new',
+        contextWindow: {
+          usedPercentage: 1,
+          remainingPercentage: 99,
+          contextWindowSize: 258000,
+          totalInputTokens: 10,
+          totalOutputTokens: 1,
+          currentUsage: null,
+        },
+        cost: null,
+        rateLimits: null,
+      })
+    })
+
+    expect(result.current.agentSessionId).toBe('codex-new')
+    expect(result.current.contextWindow?.usedPercentage).toBe(1)
+  })
+
   test('does not invoke start_agent_watcher again while a prior start is in flight', async () => {
     let resolveStart: (() => void) | undefined
 

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -195,8 +195,10 @@ export const useAgentStatus = (
     }
 
     setStatus((prev) => {
-      locallyResetAgentSessionIdRef.current = prev.agentSessionId
-      locallyResetTokenTotalRef.current = statusTokenTotal(prev.contextWindow)
+      if (prev.agentSessionId !== null) {
+        locallyResetAgentSessionIdRef.current = prev.agentSessionId
+        locallyResetTokenTotalRef.current = statusTokenTotal(prev.contextWindow)
+      }
       locallyResetRunScopedEventsRef.current = true
 
       return createRunResetStatus(prev, sessionId)


### PR DESCRIPTION
## Summary
- Preserve the locally reset agent-session latch when a second `/clear` arrives after the first reset already cleared `agentSessionId`.
- Add a regression test covering double `/clear` across separate renders with stale same-run status, tool-call, and turn events.
- Record the PR #469 round-3 finding in the review knowledge base.

## Root Cause
PR #469 reset the right sidebar correctly for a single Codex `/clear`, but a second `/clear` could observe already-reset state (`agentSessionId === null`) and overwrite the saved stale-session guard with null. That let queued same-run events repopulate the context card, Now card, cache history, and activity state.

## Validation
- `npm exec vitest run src/features/agent-status/hooks/useAgentStatus.test.ts`
- `npx prettier --check src/features/agent-status/hooks/useAgentStatus.ts src/features/agent-status/hooks/useAgentStatus.test.ts docs/reviews/CLAUDE.md docs/reviews/patterns/agent-state-guards.md`
- `npm exec eslint -- --no-warn-ignored src/features/agent-status/hooks/useAgentStatus.ts src/features/agent-status/hooks/useAgentStatus.test.ts`
- `npm run type-check -- --pretty false`
- `git diff --check`