### PR TITLE
fix(agent-status): clear stale Codex NOW card (VIM-137)

### DIFF
--- a/crates/backend/src/agent/adapter/codex/transcript.rs
+++ b/crates/backend/src/agent/adapter/codex/transcript.rs
@@ -315,6 +315,16 @@ fn process_line(
     // then derive a phase from the event_msg turn boundary; replay-bounded.
     if matches!(record_type, CodexRecordType::SessionMeta) {
         if let Some(id) = payload.id.as_deref() {
+            if !codex_agent_session_id.is_empty() && codex_agent_session_id != id {
+                let timestamp = dto.timestamp.clone().unwrap_or_else(now_iso8601);
+                flush_in_flight_tool_calls(
+                    session_id,
+                    events,
+                    in_flight,
+                    ToolCallStatus::Failed,
+                    &timestamp,
+                );
+            }
             *codex_agent_session_id = id.to_string();
         }
     }
@@ -365,7 +375,7 @@ fn process_line(
 
     match record_type {
         CodexRecordType::ResponseItem => {
-            process_response_item(&dto, &payload, session_id, cwd, events, in_flight);
+            process_response_item(&dto, &payload, session_id, cwd, events, emitter, in_flight);
         }
         CodexRecordType::EventMsg => {
             process_event_msg(
@@ -382,6 +392,7 @@ fn process_response_item(
     session_id: &str,
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
+    emitter: &mut TestRunEmitter,
     in_flight: &mut InFlightToolCalls,
 ) {
     let timestamp = dto.timestamp.clone().unwrap_or_else(now_iso8601);
@@ -394,10 +405,14 @@ fn process_response_item(
             start_custom_tool_call(payload, session_id, events, in_flight, &timestamp);
         }
         CodexPayloadType::FunctionCallOutput => {
-            process_output_completion(payload, session_id, events, in_flight, &timestamp, false);
+            process_output_completion(
+                payload, session_id, cwd, events, emitter, in_flight, &timestamp, false,
+            );
         }
         CodexPayloadType::CustomToolCallOutput => {
-            process_output_completion(payload, session_id, events, in_flight, &timestamp, true);
+            process_output_completion(
+                payload, session_id, cwd, events, emitter, in_flight, &timestamp, true,
+            );
         }
         _ => {}
     }
@@ -426,6 +441,15 @@ fn process_event_msg(
         }
         CodexPayloadType::PatchApplyEnd => {
             process_patch_apply_end(payload, session_id, events, in_flight, &timestamp);
+        }
+        CodexPayloadType::TaskComplete => {
+            flush_in_flight_tool_calls(
+                session_id,
+                events,
+                in_flight,
+                ToolCallStatus::Done,
+                &timestamp,
+            );
         }
         _ => {}
     }
@@ -555,7 +579,9 @@ fn start_custom_tool_call(
 fn process_output_completion(
     payload: &CodexPayloadDto,
     session_id: &str,
+    cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
+    emitter: &mut TestRunEmitter,
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
     is_custom_tool_output: bool,
@@ -564,26 +590,24 @@ fn process_output_completion(
         return;
     };
 
-    let Some(call) = in_flight.get(call_id) else {
-        return;
-    };
-    if matches!(
-        call.completion_mode,
-        CompletionMode::ExecCommandEnd | CompletionMode::PatchApplyEnd
-    ) {
-        return;
-    }
-
     let call = match in_flight.remove(call_id) {
         Some(call) => call,
         None => return,
     };
 
-    let status = if is_custom_tool_output && custom_tool_output_failed(payload.output.as_deref()) {
-        ToolCallStatus::Failed
-    } else {
-        ToolCallStatus::Done
-    };
+    let status = output_completion_status(&call, payload, is_custom_tool_output);
+
+    if matches!(call.completion_mode, CompletionMode::ExecCommandEnd) {
+        emit_exec_test_run_snapshot(
+            session_id,
+            cwd,
+            emitter,
+            &call,
+            payload.output.as_deref().unwrap_or_default(),
+            matches!(status, ToolCallStatus::Failed),
+            timestamp,
+        );
+    }
 
     emit_tool_call(
         events,
@@ -602,6 +626,28 @@ fn process_output_completion(
             is_test_file: call.is_test_file,
         },
     );
+}
+
+fn output_completion_status(
+    call: &InFlightToolCall,
+    payload: &CodexPayloadDto,
+    is_custom_tool_output: bool,
+) -> ToolCallStatus {
+    if matches!(call.completion_mode, CompletionMode::ExecCommandEnd) {
+        return if exec_function_output_exit_code(payload.output.as_deref())
+            .is_some_and(|code| code != 0)
+        {
+            ToolCallStatus::Failed
+        } else {
+            ToolCallStatus::Done
+        };
+    }
+
+    if is_custom_tool_output && custom_tool_output_failed(payload.output.as_deref()) {
+        ToolCallStatus::Failed
+    } else {
+        ToolCallStatus::Done
+    }
 }
 
 fn process_exec_command_end(
@@ -669,6 +715,45 @@ fn process_exec_command_end(
     );
 }
 
+fn emit_exec_test_run_snapshot(
+    session_id: &str,
+    cwd: Option<&Path>,
+    emitter: &mut TestRunEmitter,
+    call: &InFlightToolCall,
+    output: &str,
+    is_error: bool,
+    timestamp: &str,
+) {
+    let Some(matched) = call.test_match.as_ref() else {
+        return;
+    };
+
+    let Some(cwd_ref) = cwd else {
+        log::debug!(
+            "Skipping Codex test-run snapshot for session {}: no workspace cwd resolved",
+            session_id
+        );
+        return;
+    };
+
+    let captured = CapturedOutput {
+        content: output.to_string(),
+        is_error,
+    };
+
+    if let Some(snapshot) = maybe_build_snapshot(BuildArgs {
+        session_id,
+        matched,
+        started_at: &call.started_at_iso,
+        finished_at: timestamp,
+        instant_fallback: call.started_at.elapsed(),
+        captured,
+        cwd: cwd_ref,
+    }) {
+        emitter.submit(snapshot);
+    }
+}
+
 fn process_patch_apply_end(
     payload: &CodexPayloadDto,
     session_id: &str,
@@ -707,6 +792,34 @@ fn process_patch_apply_end(
             is_test_file: call.is_test_file,
         },
     );
+}
+
+fn flush_in_flight_tool_calls(
+    session_id: &str,
+    events: &Arc<dyn EventSink>,
+    in_flight: &mut InFlightToolCalls,
+    status: ToolCallStatus,
+    timestamp: &str,
+) {
+    for (call_id, call) in in_flight.drain() {
+        emit_tool_call(
+            events,
+            AgentToolCallEvent {
+                session_id: session_id.to_string(),
+                tool_use_id: call_id,
+                tool: call.tool,
+                args: call.args,
+                status: status.clone(),
+                timestamp: timestamp.to_string(),
+                duration_ms: compute_duration_ms(
+                    &call.started_at_iso,
+                    timestamp,
+                    call.started_at.elapsed(),
+                ),
+                is_test_file: call.is_test_file,
+            },
+        );
+    }
 }
 
 fn emit_tool_call(events: &Arc<dyn EventSink>, event: AgentToolCallEvent) {
@@ -773,6 +886,15 @@ fn custom_tool_output_failed(output: Option<&str>) -> bool {
     };
 
     parsed.metadata.and_then(|m| m.exit_code).is_some_and(|code| code != 0)
+}
+
+fn exec_function_output_exit_code(output: Option<&str>) -> Option<i64> {
+    let output = output?;
+
+    output.lines().find_map(|line| {
+        let code = line.trim().strip_prefix("Process exited with code ")?;
+        code.trim().parse::<i64>().ok()
+    })
 }
 
 fn exec_command_duration_ms(payload: &CodexPayloadDto) -> Option<u64> {
@@ -1493,6 +1615,236 @@ mod tests {
         let tool_calls: Vec<_> = sink.recorded().into_iter().filter(|(n, _)| n == "agent-tool-call").collect();
         assert_eq!(tool_calls.len(), 2);
         assert_eq!(tool_calls[1].1["status"], "done");
+    }
+
+    #[test]
+    fn process_line_function_call_output_completes_exec_command_without_exec_end() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let start = r#"{"timestamp":"2026-06-15T10:00:00Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call_cmd","arguments":"{\"cmd\":\"git status\"}"}}"#;
+        process_line(
+            start,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let output = r#"{"timestamp":"2026-06-15T10:00:02Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_cmd","output":"Chunk ID: abc\nWall time: 1.2345 seconds\nProcess exited with code 0\nOutput:\n## main\n"}}"#;
+        process_line(
+            output,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let tool_calls: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-tool-call")
+            .collect();
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[0].1["status"], "running");
+        assert_eq!(tool_calls[1].1["toolUseId"], "call_cmd");
+        assert_eq!(tool_calls[1].1["status"], "done");
+        assert!(
+            in_flight.is_empty(),
+            "function_call_output must clear exec_command in-flight state"
+        );
+    }
+
+    #[test]
+    fn process_line_function_call_output_marks_failed_exec_command() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let start = r#"{"timestamp":"2026-06-15T10:00:00Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call_cmd","arguments":"{\"cmd\":\"false\"}"}}"#;
+        process_line(
+            start,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let output = r#"{"timestamp":"2026-06-15T10:00:02Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_cmd","output":"Chunk ID: abc\nWall time: 0.0100 seconds\nProcess exited with code 1\nOutput:\n"}}"#;
+        process_line(
+            output,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let tool_calls: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-tool-call")
+            .collect();
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[1].1["toolUseId"], "call_cmd");
+        assert_eq!(tool_calls[1].1["status"], "failed");
+        assert!(in_flight.is_empty());
+    }
+
+    #[test]
+    fn process_line_task_complete_flushes_unfinished_exec_command() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let start = r#"{"timestamp":"2026-06-15T10:00:00Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call_cmd","arguments":"{\"cmd\":\"git status\"}"}}"#;
+        process_line(
+            start,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let complete = r#"{"timestamp":"2026-06-15T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","duration_ms":3000}}"#;
+        process_line(
+            complete,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let tool_calls: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-tool-call")
+            .collect();
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[1].1["toolUseId"], "call_cmd");
+        assert_eq!(tool_calls[1].1["status"], "done");
+        assert!(in_flight.is_empty());
+    }
+
+    #[test]
+    fn process_line_session_meta_reset_flushes_unfinished_exec_command() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+        let mut codex_agent_session_id = String::new();
+
+        let session_start = r#"{"timestamp":"2026-06-15T10:00:00Z","type":"session_meta","payload":{"id":"codex-old","cwd":"/workspace/A"}}"#;
+        process_line(
+            session_start,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut codex_agent_session_id,
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let start = r#"{"timestamp":"2026-06-15T10:00:01Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call_cmd","arguments":"{\"cmd\":\"git status\"}"}}"#;
+        process_line(
+            start,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut codex_agent_session_id,
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let session_reset = r#"{"timestamp":"2026-06-15T10:00:04Z","type":"session_meta","payload":{"id":"codex-new","cwd":"/workspace/A"}}"#;
+        process_line(
+            session_reset,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut codex_agent_session_id,
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let tool_calls: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-tool-call")
+            .collect();
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[1].1["toolUseId"], "call_cmd");
+        assert_eq!(tool_calls[1].1["status"], "failed");
+        assert_eq!(codex_agent_session_id, "codex-new");
+        assert!(in_flight.is_empty());
     }
 
     #[test]

--- a/crates/backend/src/agent/adapter/codex/transcript.rs
+++ b/crates/backend/src/agent/adapter/codex/transcript.rs
@@ -590,6 +590,17 @@ fn process_output_completion(
         return;
     };
 
+    // Preserve the PatchApplyEnd guard: custom_tool_call_output is not
+    // authoritative for patch completion. Wait for the matching
+    // patch_apply_end event so a failed patch is not reported as done.
+    if is_custom_tool_output {
+        if let Some(call) = in_flight.get(call_id) {
+            if matches!(call.completion_mode, CompletionMode::PatchApplyEnd) {
+                return;
+            }
+        }
+    }
+
     let call = match in_flight.remove(call_id) {
         Some(call) => call,
         None => return,
@@ -1721,6 +1732,82 @@ mod tests {
             .collect();
         assert_eq!(tool_calls.len(), 2);
         assert_eq!(tool_calls[1].1["toolUseId"], "call_cmd");
+        assert_eq!(tool_calls[1].1["status"], "failed");
+        assert!(in_flight.is_empty());
+    }
+
+    #[test]
+    fn process_line_custom_tool_call_output_preserves_patch_apply_end_guard() {
+        let sink = Arc::new(FakeEventSink::new());
+        let events: Arc<dyn EventSink> = sink.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight = empty_in_flight();
+        let mut num_turns = 0u32;
+        let mut last_cwd: Option<String> = None;
+
+        let start = r#"{"timestamp":"2026-06-15T10:00:00Z","type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","call_id":"call_patch","input":"*** Begin Patch\n*** Update File: foo.ts\n*** End Patch"}}"#;
+        process_line(
+            start,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let output = r#"{"timestamp":"2026-06-15T10:00:02Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_patch","output":"done"}}"#;
+        process_line(
+            output,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let tool_calls_after_output: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-tool-call")
+            .collect();
+        assert_eq!(tool_calls_after_output.len(), 1, "custom_tool_call_output must not finalize apply_patch");
+        assert!(in_flight.contains_key("call_patch"), "apply_patch must stay in-flight until patch_apply_end");
+
+        let end = r#"{"timestamp":"2026-06-15T10:00:03Z","type":"event_msg","payload":{"type":"patch_apply_end","call_id":"call_patch","success":false}}"#;
+        process_line(
+            end,
+            "sid",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            &mut String::new(),
+            &mut None,
+            &mut None,
+            true,
+        );
+
+        let tool_calls: Vec<_> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-tool-call")
+            .collect();
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[1].1["toolUseId"], "call_patch");
         assert_eq!(tool_calls[1].1["status"], "failed");
         assert!(in_flight.is_empty());
     }

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -91,3 +91,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 3        | 0    | 2026-06-15   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 0    | 2026-06-15   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 0    | 2026-06-15   |
+| [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 1        | 0    | 2026-06-16   |

--- a/docs/reviews/patterns/authoritative-completion-guard.md
+++ b/docs/reviews/patterns/authoritative-completion-guard.md
@@ -10,7 +10,7 @@ ref_count: 0
 
 ## Summary
 
-When a state machine or lifecycle tracks an in-flight operation, multiple events may arrive that *could* signal completion. Only one of them is authoritative. Adding a fallback or convenience completion path must not bypass the authoritative guard: premature finalization from a non-authoritative event can report success before the real outcome is known, hide failures, or leave downstream observers with stale active-state. Keep the authoritative event as the sole terminator for its completion mode, and make fallback paths narrowly scoped to the modes they are intended to cover.
+When a state machine or lifecycle tracks an in-flight operation, multiple events may arrive that _could_ signal completion. Only one of them is authoritative. Adding a fallback or convenience completion path must not bypass the authoritative guard: premature finalization from a non-authoritative event can report success before the real outcome is known, hide failures, or leave downstream observers with stale active-state. Keep the authoritative event as the sole terminator for its completion mode, and make fallback paths narrowly scoped to the modes they are intended to cover.
 
 ## Findings
 

--- a/docs/reviews/patterns/authoritative-completion-guard.md
+++ b/docs/reviews/patterns/authoritative-completion-guard.md
@@ -1,0 +1,24 @@
+---
+id: authoritative-completion-guard
+category: correctness
+created: 2026-06-16
+last_updated: 2026-06-16
+ref_count: 0
+---
+
+# Authoritative Completion Guard
+
+## Summary
+
+When a state machine or lifecycle tracks an in-flight operation, multiple events may arrive that *could* signal completion. Only one of them is authoritative. Adding a fallback or convenience completion path must not bypass the authoritative guard: premature finalization from a non-authoritative event can report success before the real outcome is known, hide failures, or leave downstream observers with stale active-state. Keep the authoritative event as the sole terminator for its completion mode, and make fallback paths narrowly scoped to the modes they are intended to cover.
+
+## Findings
+
+### 1. Preserve patch completion mode until patch_apply_end
+
+- **Source:** github-codex-connector | PR #475 round 1 | 2026-06-16
+- **Severity:** P2 / MEDIUM
+- **File:** `crates/backend/src/agent/adapter/codex/transcript.rs` L598
+- **Finding:** `process_output_completion` treated `custom_tool_call_output` as a terminal completion signal for every in-flight call, including `apply_patch` calls whose `completion_mode` is `PatchApplyEnd`. In transcripts where `custom_tool_call_output` precedes the authoritative `event_msg.patch_apply_end`, the patch was removed from `in_flight` and reported as done before the real patch status arrived, allowing a failed patch to clear the active NOW card incorrectly.
+- **Fix:** Added an early return in `process_output_completion` when `is_custom_tool_output` is true and the matched call uses `CompletionMode::PatchApplyEnd`, leaving the call in `in_flight` until `process_patch_apply_end` handles the authoritative event. Added a regression test proving `custom_tool_call_output` does not finalize `apply_patch` and that a subsequent failed `patch_apply_end` still emits the correct failed status.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -1369,6 +1369,63 @@ describe('AgentStatusPanel — live action card', () => {
     )
   })
 
+  test('removes the NOW card when a running exec_command completes', () => {
+    const { rerender } = render(
+      <AgentStatusPanel
+        {...defaultProps}
+        cwd="/tmp/repo"
+        agentStatus={{
+          ...activeAgentStatus,
+          toolCalls: {
+            total: 0,
+            byType: {},
+            active: {
+              tool: 'exec_command',
+              args: '{"cmd":"gh pr view 420 --repo winoooops/vimeflow"}',
+              startedAt: '2026-04-22T11:59:42Z',
+              toolUseId: 'cmd-1',
+            },
+          },
+          recentToolCalls: [],
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('live-action-card')).toBeInTheDocument()
+
+    rerender(
+      <AgentStatusPanel
+        {...defaultProps}
+        cwd="/tmp/repo"
+        agentStatus={{
+          ...activeAgentStatus,
+          toolCalls: {
+            total: 1,
+            byType: { exec_command: 1 },
+            active: null,
+          },
+          recentToolCalls: [
+            {
+              id: 'cmd-1',
+              tool: 'exec_command',
+              args: '{"cmd":"gh pr view 420 --repo winoooops/vimeflow"}',
+              status: 'done',
+              durationMs: 500,
+              timestamp: '2026-04-22T12:00:00Z',
+              isTestFile: false,
+            },
+          ],
+        }}
+      />
+    )
+
+    expect(screen.queryByText('NOW')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('live-action-card')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /activity\s*1/i })
+    ).toBeInTheDocument()
+  })
+
   test('does not also list the running action in the activity feed', () => {
     render(
       <AgentStatusPanel

--- a/src/features/agent-status/utils/statusRefreshCoordinator.test.ts
+++ b/src/features/agent-status/utils/statusRefreshCoordinator.test.ts
@@ -199,6 +199,49 @@ describe('statusRefreshCoordinator', () => {
     })
   })
 
+  test('does not preserve stale active tool calls when detection warms a pane', async () => {
+    const staleRunningStatus: AgentStatus = {
+      ...createDefaultAgentStatus('pty-a'),
+      toolCalls: {
+        total: 12,
+        byType: { exec_command: 12 },
+        active: {
+          tool: 'exec_command',
+          args: 'nl -ba scripts/qa-runner/lib/worker-instance.mjs',
+          startedAt: '2026-06-15T19:50:00Z',
+          toolUseId: 'call-stale',
+        },
+      },
+    }
+
+    let storedStatus = staleRunningStatus
+
+    const coordinator = createAgentStatusRefreshCoordinator({
+      detectAgent: () => Promise.resolve(createDetectedEvent('pty-a', 'codex')),
+      readStatus: () => storedStatus,
+      writeStatus: (_ptyId, status) => {
+        storedStatus = status
+
+        return {
+          status,
+          scrollTop: 0,
+          updatedAt: 1,
+        }
+      },
+    })
+
+    await coordinator.refreshVisiblePanes({
+      activePtyId: 'pty-a',
+      visiblePtyIds: ['pty-a'],
+    })
+
+    expect(storedStatus.toolCalls).toEqual({
+      total: 12,
+      byType: { exec_command: 12 },
+      active: null,
+    })
+  })
+
   test('writes a default snapshot when detection returns null for a previously active pane', async () => {
     const previousStatus: AgentStatus = {
       ...createDefaultAgentStatus('pty-a'),

--- a/src/features/agent-status/utils/statusRefreshCoordinator.ts
+++ b/src/features/agent-status/utils/statusRefreshCoordinator.ts
@@ -80,13 +80,21 @@ const mergeDetectedAgent = (
   ptyId: string,
   detected: AgentDetectedEvent,
   previous: AgentStatus | null
-): AgentStatus => ({
-  ...(previous ?? createDefaultAgentStatus(ptyId)),
-  sessionId: ptyId,
-  isActive: true,
-  agentExited: false,
-  agentType: mapDetectedAgentType(detected.agentType as string),
-})
+): AgentStatus => {
+  const base = previous ?? createDefaultAgentStatus(ptyId)
+
+  return {
+    ...base,
+    sessionId: ptyId,
+    isActive: true,
+    agentExited: false,
+    agentType: mapDetectedAgentType(detected.agentType as string),
+    toolCalls: {
+      ...base.toolCalls,
+      active: null,
+    },
+  }
+}
 
 export const createAgentStatusRefreshCoordinator = ({
   detectAgent = defaultDetectAgent,

--- a/src/features/agent-status/utils/statusSnapshotStore.test.ts
+++ b/src/features/agent-status/utils/statusSnapshotStore.test.ts
@@ -77,6 +77,33 @@ describe('statusSnapshotStore', () => {
     )
   })
 
+  test('does not persist active tool calls in pane snapshots', () => {
+    const store = createAgentStatusSnapshotStore(() => 100)
+
+    const runningStatus = createStatus({
+      toolCalls: {
+        total: 9,
+        byType: { exec_command: 9 },
+        active: {
+          tool: 'exec_command',
+          args: 'nl -ba scripts/qa-runner/lib/worker-instance.mjs',
+          startedAt: '2026-06-15T19:50:00Z',
+          toolUseId: 'call-running',
+        },
+      },
+    })
+
+    const snapshot = store.writeStatus('pane-a', runningStatus)
+
+    expect(runningStatus.toolCalls.active?.toolUseId).toBe('call-running')
+    expect(snapshot.status.toolCalls).toEqual({
+      total: 9,
+      byType: { exec_command: 9 },
+      active: null,
+    })
+    expect(store.readStatus('pane-a')?.toolCalls.active).toBeNull()
+  })
+
   test('preserves unchanged recent tool-call object identity while merging', () => {
     const existingCall = {
       id: 'toolu_1',

--- a/src/features/agent-status/utils/statusSnapshotStore.ts
+++ b/src/features/agent-status/utils/statusSnapshotStore.ts
@@ -119,6 +119,20 @@ const mergeToolCalls = (
   }
 }
 
+const stripActiveToolCall = (status: AgentStatus): AgentStatus => {
+  if (status.toolCalls.active === null) {
+    return status
+  }
+
+  return {
+    ...status,
+    toolCalls: {
+      ...status.toolCalls,
+      active: null,
+    },
+  }
+}
+
 export const mergeAgentStatusSnapshot = (
   previous: AgentStatus,
   next: AgentStatus
@@ -216,7 +230,7 @@ export const createAgentStatusSnapshotStore = (
     }
 
     return {
-      status: entry.status,
+      status: stripActiveToolCall(entry.status),
       scrollTop: scrollAnchors.get(key) ?? 0,
       updatedAt: entry.updatedAt,
     }
@@ -228,10 +242,15 @@ export const createAgentStatusSnapshotStore = (
   ): AgentStatusSnapshot => {
     const previous = statuses.get(key)
 
+    const nextSnapshotStatus = stripActiveToolCall(status)
+
+    const previousSnapshotStatus =
+      previous === undefined ? undefined : stripActiveToolCall(previous.status)
+
     const nextStatus =
-      previous === undefined
-        ? status
-        : mergeAgentStatusSnapshot(previous.status, status)
+      previousSnapshotStatus === undefined
+        ? nextSnapshotStatus
+        : mergeAgentStatusSnapshot(previousSnapshotStatus, nextSnapshotStatus)
 
     const updatedAt = now()
 


### PR DESCRIPTION
## Summary

- Treat Codex `function_call_output` as a terminal completion signal for `exec_command` when current transcripts omit `exec_command_end`.
- Flush leftover in-flight Codex tool calls on `task_complete` or Codex session reset so the panel cannot keep a stale NOW card.
- Keep cached pane snapshots and visible-pane refresh warming from restoring volatile `toolCalls.active` during pane switches.
- Add backend, snapshot, refresh, and panel regressions for the NOW card lifecycle.

## Root Cause

The first VIM-137 issue was backend-side: current Codex rollout transcripts can emit `response_item.function_call_output` after `exec_command` without a matching `event_msg.exec_command_end`. The backend previously kept `exec_command` calls in `in_flight` while waiting for that missing end event, so the frontend never received a terminal `agent-tool-call` event and could keep rendering the NOW card.

The latest recording showed a second, switch-time variant: the stale `NOW` card appeared briefly after switching panes, then disappeared once replay/detection caught up. That was caused by persisting `toolCalls.active` inside the per-pane status snapshot. Hidden panes are not continuously subscribed to live status, so a hidden pane could retain an old active command in its snapshot. On switch, `useAgentStatus` synchronously restored that snapshot before live transcript replay cleared it, producing the flash.

The fix treats `toolCalls.active` as live-only state. Snapshots still retain durable panel data such as context, cache, totals, activity history, and scroll anchors, but snapshot reads/writes and detection warming strip `active` so the NOW card only appears from live/replayed running events.

## Validation

- `cargo test --manifest-path crates/backend/Cargo.toml process_line_`
- `npm run test -- src/features/agent-status/utils/statusSnapshotStore.test.ts src/features/agent-status/utils/statusRefreshCoordinator.test.ts src/features/agent-status/components/AgentStatusPanel/index.test.tsx`
- `npm run lint`
- `npm run type-check`
- `cargo test --manifest-path crates/backend/Cargo.toml`
- `npm run build`
- pre-push `npm run test` hook: 289 files passed, 3726 tests passed, 3 skipped

Linear: VIM-137