### PR TITLE
fix(agent-status): stabilize Kimi telemetry

### DIFF
--- a/crates/backend/src/agent/adapter/kimi/locator.rs
+++ b/crates/backend/src/agent/adapter/kimi/locator.rs
@@ -4,9 +4,9 @@
 //! process, in priority order:
 //!
 //! 1. proc-fd (Linux): the kimi process holds its own session's
-//!    `agents/main/wire.jsonl` open — read `<proc_root>/<pid>/fd/*` and
-//!    match it. Fully disambiguates per-process (mirrors codex's
-//!    `open_rollout_paths_from_proc`).
+//!    `agents/main/wire.jsonl` open — read `<proc_root>/<pid>/fd/*`, keep
+//!    trusted main-wire candidates, and choose the most recently active one.
+//!    This disambiguates per-process while tolerating kimi's session handoff.
 //! 2. proc-environ (Linux): read the kimi process's own
 //!    `KIMI_CODE_HOME` from `<proc_root>/<pid>/environ` so a per-process
 //!    `KIMI_CODE_HOME=/tmp/kimi kimi` is honored.
@@ -14,9 +14,9 @@
 //!    A `workDir` matches when it equals `cwd` OR is a component-boundary
 //!    ancestor of it (kimi normalizes a worktree / subdirectory cwd to the
 //!    repo root). Among matches the longest (deepest) workDir wins, then the
-//!    newest (last) append-ordered entry — so it binds unconditionally even
-//!    when idle (its `wire.jsonl` may predate `pty_start` before the first
-//!    prompt), unless that wire does not exist yet (then it falls through).
+//!    process-owned session on Linux. On macOS, where `/proc` cannot prove
+//!    ownership, same-workDir ties use newest on-disk session activity so a
+//!    resumed session keeps winning after kimi appends a later empty index row.
 //! 4. exact-bucket sha256 scan: last-resort newest `session_*` under
 //!    this cwd's `wd_<basename>_<hex>` bucket, gated on a `pty_start`
 //!    mtime freshness check (no append ordering to tell current from
@@ -64,6 +64,15 @@ struct SessionIndexEntry {
     session_dir: Option<String>,
     #[serde(rename = "workDir")]
     work_dir: Option<String>,
+}
+
+struct IndexCandidate {
+    work_len: usize,
+    created: Option<SystemTime>,
+    activity: Option<SystemTime>,
+    index_order: usize,
+    session_dir: String,
+    entry: SessionIndexEntry,
 }
 
 pub(crate) struct KimiLocator {
@@ -151,10 +160,7 @@ impl KimiLocator {
     /// The kimi process's resolved cwd from the last `locate`. `None` until
     /// the first resolve.
     pub(crate) fn resolved_cwd(&self) -> Option<PathBuf> {
-        self.resolved_cwd
-            .lock()
-            .expect("resolved_cwd lock")
-            .clone()
+        self.resolved_cwd.lock().expect("resolved_cwd lock").clone()
     }
 
     /// The last successfully fetched plan-usage limits, for `decode` to merge
@@ -193,14 +199,12 @@ impl KimiLocator {
     /// caller (supervisor poll) has already confirmed consent is ON, so an idle
     /// session and a just-enabled consent both fetch without a fresh prompt.
     /// Non-blocking: spawns a detached, timeout-bounded thread, so the local
-    /// status path is never delayed by the network. Skips when a fetch is in
-    /// flight or the UA version is unknown. The worker RE-CHECKS consent at the
-    /// last moment, so a revoke after the gate sends no request and writes no
-    /// cache.
+    /// status path is never delayed by the network. Skips when a fetch is
+    /// already in flight; the usage fetcher resolves a Kimi-shaped User-Agent
+    /// version even when the transcript omits `metadata.app_version`. The
+    /// worker RE-CHECKS consent at the last moment, so a revoke after the gate
+    /// sends no request and writes no cache.
     pub(crate) fn maybe_refresh_usage(&self, settled_turn_count: u64, version: &str) {
-        if version.is_empty() {
-            return;
-        }
         {
             let mut usage = self.usage.lock().expect("usage lock");
             if !usage.fetch_due(settled_turn_count) {
@@ -272,6 +276,22 @@ impl KimiLocator {
             .unwrap_or_else(|| passed.to_path_buf())
     }
 
+    /// Re-run the locator for the cwd discovered during the initial attach.
+    ///
+    /// Kimi can create the real `session_*` after the PTY process is already
+    /// attached, so the transcript supervisor uses this to move from an older
+    /// same-cwd session to the one that actually starts receiving main-agent
+    /// writes. OS-specific details stay inside the locator: proc-fd wins on
+    /// Linux, while macOS/no-proc falls back through index/activity ranking.
+    pub(crate) fn refresh_located_source(&self) -> Option<LocatedStatusSource> {
+        let cwd = self.resolved_cwd()?;
+        let home = self.effective_home();
+        self.try_resolve_from_proc_fds(&home)
+            .or_else(|| self.try_resolve_from_index(&home, &cwd))
+            .or_else(|| self.try_resolve_fallback(&home, &cwd))
+            .map(|located| self.remember(located))
+    }
+
     /// Wall-clock start time of the detected kimi process, from
     /// `<proc_root>/<pid>/stat` field 22 (`starttime`, ticks since boot)
     /// anchored on the system boot epoch (`btime` in `<proc_root>/stat`).
@@ -301,25 +321,37 @@ impl KimiLocator {
 
     /// proc-fd primary: the kimi process holds its session's
     /// `agents/main/wire.jsonl` open, so a `<proc_root>/<pid>/fd/*`
-    /// symlink resolves to it. Disambiguates per-process with no workDir
-    /// ambiguity. Skips itself when `proc_root` is `None` (macOS).
+    /// symlink resolves to it. If multiple main wires are open during a
+    /// kimi session handoff, choose the most recently active trusted session.
+    /// Skips itself when `proc_root` is `None` (macOS).
     fn try_resolve_from_proc_fds(&self, home: &Path) -> Option<LocatedStatusSource> {
         let proc_root = self.proc_root.as_deref()?;
-        let wire = open_wire_path_from_proc(proc_root, self.agent_pid)?;
         // Anchor the trust root to THIS process's effective home and require
         // the fd target to live under it: a detected (or spoofed) process must
         // not steer the watcher at a wire.jsonl tree outside the kimi home.
         // Canonicalize both sides so symlinked homes (NFS mounts, Docker
         // volumes, $KIMI_CODE_HOME through a symlink) don't lose the binding.
         let sessions_root = home.join("sessions");
-        let (trusted_wire, trusted_root) =
-            match (std::fs::canonicalize(&wire), std::fs::canonicalize(&sessions_root)) {
-                (Ok(cwire), Ok(croot)) => (cwire, croot),
-                _ => (wire.clone(), sessions_root),
-            };
-        if !trusted_wire.starts_with(&trusted_root) {
-            return None;
+        let trusted_root = std::fs::canonicalize(&sessions_root).unwrap_or(sessions_root);
+        let mut newest: Option<(SystemTime, PathBuf)> = None;
+        for wire in open_wire_paths_from_proc(proc_root, self.agent_pid) {
+            let trusted_wire = std::fs::canonicalize(&wire).unwrap_or_else(|_| wire.clone());
+            if !trusted_wire.starts_with(&trusted_root) {
+                continue;
+            }
+            let activity = wire
+                .parent()
+                .and_then(Path::parent)
+                .and_then(Path::parent)
+                .and_then(|session_dir| session_dir.to_str())
+                .and_then(session_activity_mtime)
+                .or_else(|| modified_at(&wire))
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            if newest.as_ref().map_or(true, |(seen, _)| activity > *seen) {
+                newest = Some((activity, wire));
+            }
         }
+        let wire = newest.map(|(_, wire)| wire)?;
         let session_dir = wire.parent()?.parent()?.parent()?;
         let agent_session_id = session_dir
             .file_name()
@@ -338,11 +370,10 @@ impl KimiLocator {
     /// worktree / subdirectory cwd to the repo root), binding it
     /// unconditionally. Among all matching entries the winner is the LONGEST
     /// `workDir` (most specific / deepest ancestor beats a shallower one),
-    /// breaking ties by the LAST occurrence in the append-ordered index (the
-    /// newest session for that workDir IS this process's current session) —
-    /// so it binds even when idle (its `wire.jsonl` may predate `pty_start`
-    /// because the user has not submitted a prompt yet, leaving the
-    /// transcript at its config-only metadata lines).
+    /// then by process ownership when `/proc` is available. On macOS, where
+    /// process ownership is unavailable, same-`workDir` ties use newest
+    /// on-disk session activity rather than raw append order; kimi resume can
+    /// keep writing to an earlier index row after appending a later idle row.
     ///
     /// No freshness gate runs here: the authoritative newest-index match
     /// must never be rejected just because it is idle (the bug that left
@@ -359,13 +390,12 @@ impl KimiLocator {
         // kimi process owns — created at/after the process started (codex's
         // per-process discriminator, resolved via the session's metadata
         // `created_at`) — so a frozen same-cwd session left by an EARLIER run
-        // can't win the tie-break. Within the chosen group the original rule
-        // applies: longest workDir, ties to the last index occurrence. When
-        // the process start is unknown (macOS / no proc) nothing is "owned",
-        // so selection falls back to the prior newest-index behavior unchanged.
+        // can't win the tie-break. When the process start is unknown (macOS /
+        // no proc) nothing is "owned", so selection falls back to newest
+        // activity among matches.
         let process_start = self.process_start();
-        let mut matches: Vec<(usize, Option<SystemTime>, String, SessionIndexEntry)> = Vec::new();
-        for line in raw.lines() {
+        let mut matches: Vec<IndexCandidate> = Vec::new();
+        for (index_order, line) in raw.lines().enumerate() {
             let line = line.trim();
             if line.is_empty() {
                 continue;
@@ -385,7 +415,10 @@ impl KimiLocator {
             // otherwise untrusted sessionDir must not win selection on macOS
             // (where the process-start discriminator is unavailable) or steer
             // reads outside the trusted home.
-            let Some(session_dir) = entry.session_dir.clone().filter(|dir| path_under(dir, home))
+            let Some(session_dir) = entry
+                .session_dir
+                .clone()
+                .filter(|dir| path_under(dir, home))
             else {
                 continue;
             };
@@ -394,7 +427,19 @@ impl KimiLocator {
             } else {
                 None
             };
-            matches.push((work_len, created, session_dir, entry));
+            let activity = if process_start.is_none() {
+                session_activity_mtime(&session_dir)
+            } else {
+                None
+            };
+            matches.push(IndexCandidate {
+                work_len,
+                created,
+                activity,
+                index_order,
+                session_dir,
+                entry,
+            });
         }
 
         // Per-process discriminator: when the process start is KNOWN, only a
@@ -403,15 +448,20 @@ impl KimiLocator {
         // (longest workDir breaks ties), so two same-cwd panes each bind their
         // OWN run and a fresh attach whose row hasn't landed yet returns None
         // (→ retry) rather than latching an earlier run. When the start is
-        // unknown (macOS / no proc) fall back to the newest-index match
-        // (`max_by_key` keeps the LAST element among equal workDir lengths).
+        // unknown (macOS / no proc), fall back to the newest active session
+        // for the deepest matching workDir. Index order remains only the final
+        // tie-break for identical activity timestamps.
         let (entry, session_dir) = match process_start {
             Some(start) => matches
                 .into_iter()
-                .filter_map(|(work_len, created, session_dir, entry)| {
-                    let created = created?;
-                    created_in_own_window(created, start)
-                        .then_some((work_len, created, session_dir, entry))
+                .filter_map(|candidate| {
+                    let created = candidate.created?;
+                    created_in_own_window(created, start).then_some((
+                        candidate.work_len,
+                        created,
+                        candidate.session_dir,
+                        candidate.entry,
+                    ))
                 })
                 .min_by_key(|(work_len, created, _, _)| {
                     (abs_duration(*created, start), usize::MAX - *work_len)
@@ -419,8 +469,14 @@ impl KimiLocator {
                 .map(|(_, _, session_dir, entry)| (entry, session_dir)),
             None => matches
                 .into_iter()
-                .max_by_key(|(work_len, _, _, _)| *work_len)
-                .map(|(_, _, session_dir, entry)| (entry, session_dir)),
+                .max_by_key(|candidate| {
+                    (
+                        candidate.work_len,
+                        candidate.activity.unwrap_or(SystemTime::UNIX_EPOCH),
+                        candidate.index_order,
+                    )
+                })
+                .map(|candidate| (candidate.entry, candidate.session_dir)),
         }?;
         let status_path = PathBuf::from(&session_dir)
             .join("agents")
@@ -525,7 +581,9 @@ impl StatusSourceLocator for KimiLocator {
         let proc_fd = self.try_resolve_from_proc_fds(&home);
         kdbg(&format!(
             "LOCATE proc_fd={:?}",
-            proc_fd.as_ref().map(|l| l.status_path.display().to_string())
+            proc_fd
+                .as_ref()
+                .map(|l| l.status_path.display().to_string())
         ));
         if let Some(located) = proc_fd {
             kdbg(&format!(
@@ -600,9 +658,10 @@ fn clock_ticks_per_sec() -> u64 {
 /// canonicalized so `..` / symlinks can't escape). Refuses metadata reads
 /// from an index `sessionDir` outside the trusted kimi home.
 fn path_under(candidate: &str, root: &Path) -> bool {
-    let (Ok(candidate), Ok(root)) =
-        (std::fs::canonicalize(candidate), std::fs::canonicalize(root))
-    else {
+    let (Ok(candidate), Ok(root)) = (
+        std::fs::canonicalize(candidate),
+        std::fs::canonicalize(root),
+    ) else {
         return false;
     };
     candidate.starts_with(root)
@@ -612,7 +671,9 @@ fn path_under(candidate: &str, root: &Path) -> bool {
 /// started at `start` would: from a touch before (clock skew) through
 /// `KIMI_OWN_WINDOW` after (creation lags the fork).
 fn created_in_own_window(created: SystemTime, start: SystemTime) -> bool {
-    let lower = start.checked_sub(KIMI_INDEX_FRESHNESS_SLACK).unwrap_or(start);
+    let lower = start
+        .checked_sub(KIMI_INDEX_FRESHNESS_SLACK)
+        .unwrap_or(start);
     created >= lower && created <= start + KIMI_OWN_WINDOW
 }
 
@@ -643,28 +704,52 @@ fn session_created_at(session_dir: &str) -> Option<SystemTime> {
             continue;
         };
         if value.get("type").and_then(serde_json::Value::as_str) == Some("metadata") {
-            let ms = value.get("created_at").and_then(serde_json::Value::as_u64)?;
+            let ms = value
+                .get("created_at")
+                .and_then(serde_json::Value::as_u64)?;
             return Some(SystemTime::UNIX_EPOCH + Duration::from_millis(ms));
         }
     }
     None
 }
 
-/// Read `<proc_root>/<pid>/fd/*` and return the first symlink target that
-/// looks like a kimi session wire: ends with `agents/main/wire.jsonl` and
-/// lives under a `.../sessions/wd_*/session_*/` path.
-fn open_wire_path_from_proc(proc_root: &Path, pid: u32) -> Option<PathBuf> {
-    let fd_dir = proc_root.join(pid.to_string()).join("fd");
-    let entries = std::fs::read_dir(fd_dir).ok()?;
-    for entry in entries.flatten() {
-        let Ok(target) = std::fs::read_link(entry.path()) else {
-            continue;
-        };
-        if is_kimi_session_wire(&target) {
-            return Some(target);
+/// Best-effort activity timestamp for macOS/no-proc index tie-breaking.
+/// Looks at `state.json` and every `agents/*/wire.jsonl`; a resumed kimi
+/// session keeps updating these files even when a later index row is idle.
+fn session_activity_mtime(session_dir: &str) -> Option<SystemTime> {
+    let session_dir = PathBuf::from(session_dir);
+    let mut newest = modified_at(&session_dir.join("state.json"));
+
+    if let Ok(agent_dirs) = std::fs::read_dir(session_dir.join("agents")) {
+        for agent_dir in agent_dirs.flatten() {
+            if let Some(mtime) = modified_at(&agent_dir.path().join("wire.jsonl")) {
+                if newest.map_or(true, |seen| mtime > seen) {
+                    newest = Some(mtime);
+                }
+            }
         }
     }
-    None
+
+    newest
+}
+
+fn modified_at(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+/// Read `<proc_root>/<pid>/fd/*` and return symlink targets that look like
+/// kimi main-session wires: they end with `agents/main/wire.jsonl` and live
+/// under a `.../sessions/wd_*/session_*/` path.
+fn open_wire_paths_from_proc(proc_root: &Path, pid: u32) -> Vec<PathBuf> {
+    let fd_dir = proc_root.join(pid.to_string()).join("fd");
+    let Ok(entries) = std::fs::read_dir(fd_dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| std::fs::read_link(entry.path()).ok())
+        .filter(|target| is_kimi_session_wire(target))
+        .collect()
 }
 
 /// True when `path` ends with `agents/main/wire.jsonl` and sits under a
@@ -947,6 +1032,34 @@ mod tests {
         assert_eq!(located.trust_root, kimi_home.path());
     }
 
+    #[test]
+    fn proc_fd_prefers_newest_active_main_wire_when_multiple_are_open() {
+        let kimi_home = tempfile::tempdir().expect("kimi home");
+        let proc_root = tempfile::tempdir().expect("proc root");
+        let work = tempfile::tempdir().expect("work dir");
+        let pid = 7777;
+
+        let stale_dir = session_under(kimi_home.path(), "wd_a", "session_stale");
+        let stale_wire = write_wire(&stale_dir);
+        let active_dir = session_under(kimi_home.path(), "wd_a", "session_active");
+        let active_wire = write_wire(&active_dir);
+        let now = SystemTime::now();
+        set_mtime(&stale_wire, now - Duration::from_secs(60));
+        set_mtime(&active_wire, now + Duration::from_secs(1));
+        write_fd(proc_root.path(), pid, "3", &stale_wire);
+        write_fd(proc_root.path(), pid, "4", &active_wire);
+
+        let locator = locator_with_proc(kimi_home.path(), pid, now, proc_root.path());
+        let located = locator
+            .locate(work.path(), "pty-1")
+            .expect("proc-fd resolves");
+        assert_eq!(
+            located.status_path, active_wire,
+            "proc-fd must not treat fd directory order as session freshness"
+        );
+        assert_eq!(located.agent_session_id.as_deref(), Some("session_active"));
+    }
+
     /// proc-environ P2: the kimi process launched with
     /// `KIMI_CODE_HOME=<tmp>` writes state under `<tmp>`; the locator
     /// reads that env from `<proc>/<pid>/environ` even though its
@@ -987,44 +1100,42 @@ mod tests {
         assert_eq!(located.trust_root, env_home.path());
     }
 
-    /// The index is append-ordered, so the LAST same-cwd entry is the
-    /// current session and binds — even when an EARLIER same-cwd entry has
-    /// a newer `wire.jsonl` mtime. Pins that the newest-index match is
-    /// authoritative and no longer freshness-gated on the index path.
+    /// macOS/no-proc regression: kimi can resume an earlier same-cwd session
+    /// and then append a later config-only index row. With no `/proc` fd or
+    /// process-start discriminator, the active session's newer on-disk
+    /// activity must beat the later idle index row so context/cache metrics
+    /// keep flowing from the transcript that is actually receiving usage.
     #[test]
-    fn index_binds_newest_entry_regardless_of_wire_mtime() {
+    fn no_proc_index_prefers_active_resumed_entry_over_later_idle_row() {
         let kimi_home = tempfile::tempdir().expect("kimi home");
         let work = tempfile::tempdir().expect("work dir");
 
-        let older_dir = session_under(kimi_home.path(), "wd_a", "session_older");
-        let older_wire = write_wire(&older_dir);
-        let current_dir = session_under(kimi_home.path(), "wd_a", "session_current");
-        let current_wire = write_wire(&current_dir);
+        let resumed_dir = session_under(kimi_home.path(), "wd_a", "session_resumed");
+        let resumed_wire = write_wire(&resumed_dir);
+        let idle_dir = session_under(kimi_home.path(), "wd_a", "session_idle");
+        let idle_wire = write_wire(&idle_dir);
 
         let pty_start = SystemTime::now();
-        // The current (last-listed) session's wire is IDLE — its mtime
-        // predates pty_start — while the earlier session's wire looks fresh.
-        // The newest index entry must still win.
-        set_mtime(&current_wire, pty_start - Duration::from_secs(3600));
-        set_mtime(&older_wire, pty_start + Duration::from_secs(1));
+        set_mtime(&idle_wire, pty_start - Duration::from_secs(30));
+        set_mtime(&resumed_wire, pty_start + Duration::from_secs(1));
 
         write_index(
             kimi_home.path(),
             &[
-                ("session_older", &older_dir, work.path()),
-                ("session_current", &current_dir, work.path()),
+                ("session_resumed", &resumed_dir, work.path()),
+                ("session_idle", &idle_dir, work.path()),
             ],
         );
 
         let locator = locator_with(kimi_home.path(), 4242, pty_start);
         let located = locator
             .locate(work.path(), "pty-1")
-            .expect("newest index entry resolves");
+            .expect("active resumed index entry resolves");
         assert_eq!(
-            located.status_path, current_wire,
-            "newest (last) index entry binds even when its wire predates pty_start"
+            located.status_path, resumed_wire,
+            "active resumed session must beat a later idle index row on macOS"
         );
-        assert_eq!(located.agent_session_id.as_deref(), Some("session_current"));
+        assert_eq!(located.agent_session_id.as_deref(), Some("session_resumed"));
     }
 
     /// Regression pin for the blank-agent-status bug: an IDLE session whose
@@ -1090,8 +1201,7 @@ mod tests {
             ],
         );
 
-        let locator =
-            locator_with_proc(kimi_home.path(), pid, SystemTime::now(), proc_root.path());
+        let locator = locator_with_proc(kimi_home.path(), pid, SystemTime::now(), proc_root.path());
         let located = locator
             .locate(work.path(), "pty-1")
             .expect("owned session resolves");
@@ -1131,8 +1241,7 @@ mod tests {
             ],
         );
 
-        let locator =
-            locator_with_proc(kimi_home.path(), pid, SystemTime::now(), proc_root.path());
+        let locator = locator_with_proc(kimi_home.path(), pid, SystemTime::now(), proc_root.path());
         let located = locator.locate(work.path(), "pty-1").expect("ours resolves");
         assert_eq!(located.status_path, ours_wire);
         assert_eq!(located.agent_session_id.as_deref(), Some("session_ours"));
@@ -1160,10 +1269,12 @@ mod tests {
         // fallback can't pick it up either.
         let stale_dir = session_under(kimi_home.path(), "wd_a", "session_stale");
         write_wire_created(&stale_dir, process_start_ms - 3_600_000);
-        write_index(kimi_home.path(), &[("session_stale", &stale_dir, work.path())]);
+        write_index(
+            kimi_home.path(),
+            &[("session_stale", &stale_dir, work.path())],
+        );
 
-        let locator =
-            locator_with_proc(kimi_home.path(), pid, SystemTime::now(), proc_root.path());
+        let locator = locator_with_proc(kimi_home.path(), pid, SystemTime::now(), proc_root.path());
         assert!(
             locator.locate(work.path(), "pty-1").is_err(),
             "must not bind a session created before this process started"

--- a/crates/backend/src/agent/adapter/kimi/transcript.rs
+++ b/crates/backend/src/agent/adapter/kimi/transcript.rs
@@ -12,6 +12,7 @@ use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::thread::JoinHandle;
 use std::time::Instant;
 
 use super::transcript_dto::{KimiLineDto, KimiLoopEventType, KimiRecordType};
@@ -44,6 +45,7 @@ struct InFlightToolCall {
 }
 
 type InFlightToolCalls = HashMap<String, InFlightToolCall>;
+type ChildTailers = HashMap<PathBuf, (Arc<AtomicBool>, JoinHandle<()>)>;
 
 /// Dedupe key for supervisor `agent-status` refreshes: the token metrics that
 /// move the context display, plus the effective rate-limit values so a
@@ -135,16 +137,7 @@ pub(super) fn start_tailing(
     let stop_flag = Arc::new(AtomicBool::new(false));
     let stop_clone = stop_flag.clone();
 
-    // `transcript_path` is `<session>/agents/main/wire.jsonl`; three up is the
-    // session dir, which lets the supervisor follow EVERY `agents/*/wire.jsonl`
-    // so a sub-agent's tool calls / turns surface alongside main's.
-    let session_dir = transcript_path
-        .parent()
-        .and_then(Path::parent)
-        .and_then(Path::parent)
-        .map(Path::to_path_buf);
-
-    let Some(session_dir) = session_dir else {
+    let Some(session_dir) = session_dir_from_wire(&transcript_path) else {
         // No resolvable session dir — tail the single wire (legacy path).
         let file = open_wire(&transcript_path)?;
         let decoder = KimiTranscriptDecoder::new(events, session_id, String::new(), String::new());
@@ -170,6 +163,15 @@ pub(super) fn start_tailing(
         );
     });
     Ok(TranscriptHandle::new(stop_flag, join_handle))
+}
+
+/// `wire.jsonl` path is `<session>/agents/<agent-id>/wire.jsonl`; three up is
+/// the session dir, which lets the supervisor follow every sibling agent wire.
+fn session_dir_from_wire(wire: &Path) -> Option<PathBuf> {
+    wire.parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
 }
 
 /// kimi's `session_*` id from a session dir (its final path component); empty
@@ -292,19 +294,41 @@ fn run_session_supervisor(
     // wire must be canonicalized too or symlinked session/home layouts can
     // cause the same physical file to appear as two PathBuf values and get
     // tailed twice (duplicate events + inflated turn counts).
-    let main_wire = fs::canonicalize(&main_wire).unwrap_or(main_wire);
+    let mut main_wire = fs::canonicalize(&main_wire).unwrap_or(main_wire);
+    let mut session_dir = session_dir_from_wire(&main_wire).unwrap_or(session_dir);
 
     // Keyed by wire path so the always-tailed main wire is never double-spawned
     // when `state.json` lists it too.
-    let mut children: HashMap<PathBuf, (Arc<AtomicBool>, std::thread::JoinHandle<()>)> =
-        HashMap::new();
-    let agent_session_id = session_id_from_dir(&session_dir);
+    let mut children: ChildTailers = HashMap::new();
+    let mut agent_session_id = session_id_from_dir(&session_dir);
     let mut last_status: Option<StatusSignature> = None;
     // Track the refresh generation so a UI-requested refresh forces one fetch
     // (the start value is already covered by the attach catch-up).
     let mut acted_refresh_gen = crate::agent::kimi_usage_consent::refresh_gen();
 
     loop {
+        if let Some(located) = locator.refresh_located_source() {
+            let next_main_wire = fs::canonicalize(&located.status_path)
+                .unwrap_or_else(|_| located.status_path.clone());
+            if let Some(next_session_dir) = session_dir_from_wire(&next_main_wire) {
+                let changed = next_main_wire != main_wire || next_session_dir != session_dir;
+                if changed {
+                    super::kdbg(&format!(
+                        "SUPERVISOR switch session old={} new={} main_wire={}",
+                        session_dir.display(),
+                        next_session_dir.display(),
+                        next_main_wire.display()
+                    ));
+                    stop_child_tailers(&mut children);
+                    session_dir = next_session_dir;
+                    main_wire = next_main_wire;
+                    agent_session_id = session_id_from_dir(&session_dir);
+                    last_status = None;
+                    locator.disarm_usage();
+                }
+            }
+        }
+
         // Always tail the main wire; add sub-agent wires as `state.json`
         // reveals them (a `/init`-style delegation spawns `agent-0`
         // mid-session). When there is no `state.json`, only main is tailed.
@@ -375,7 +399,11 @@ fn run_session_supervisor(
         }
     }
 
-    for (_, (child_stop, join)) in children {
+    stop_child_tailers(&mut children);
+}
+
+fn stop_child_tailers(children: &mut ChildTailers) {
+    for (_, (child_stop, join)) in children.drain() {
         child_stop.store(true, Ordering::Relaxed);
         let _ = join.join();
     }
@@ -677,9 +705,10 @@ fn days_to_date(days_since_epoch: u64) -> (u64, u64, u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::adapter::traits::StatusSourceLocator as _;
     use crate::runtime::FakeEventSink;
-    use serde_json::Value;
-    use std::time::Duration;
+    use serde_json::{json, Value};
+    use std::time::{Duration, Instant, SystemTime};
 
     fn fixture_path() -> PathBuf {
         std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -756,6 +785,88 @@ mod tests {
         ))
     }
 
+    fn session_under(kimi_home: &Path, session_id: &str) -> PathBuf {
+        kimi_home
+            .join("sessions")
+            .join("wd_project_deadbeef0000")
+            .join(session_id)
+    }
+
+    fn write_main_session(session: &Path, raw: &str) -> PathBuf {
+        let main_dir = session.join("agents").join("main");
+        std::fs::create_dir_all(&main_dir).expect("main dir");
+        let wire = main_dir.join("wire.jsonl");
+        std::fs::write(&wire, raw).expect("main wire");
+        std::fs::write(
+            session.join("state.json"),
+            json!({
+                "agents": {
+                    "main": {
+                        "homedir": main_dir.to_string_lossy(),
+                        "type": "main",
+                    },
+                },
+            })
+            .to_string(),
+        )
+        .expect("state.json");
+        wire
+    }
+
+    fn write_session_index(kimi_home: &Path, entries: &[(&str, &Path, &Path)]) {
+        let raw = entries
+            .iter()
+            .map(|(session_id, session_dir, work_dir)| {
+                json!({
+                    "sessionId": session_id,
+                    "sessionDir": session_dir.to_string_lossy(),
+                    "workDir": work_dir.to_string_lossy(),
+                })
+                .to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(kimi_home.join("session_index.jsonl"), format!("{raw}\n"))
+            .expect("session index");
+    }
+
+    fn set_mtime(path: &Path, time: SystemTime) {
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .expect("open for mtime")
+            .set_modified(time)
+            .expect("set mtime");
+    }
+
+    fn set_session_activity(session: &Path, time: SystemTime) {
+        set_mtime(&session.join("state.json"), time);
+        set_mtime(
+            &session.join("agents").join("main").join("wire.jsonl"),
+            time,
+        );
+    }
+
+    fn wait_for_agent_status_session(
+        sink: &FakeEventSink,
+        agent_session_id: &str,
+        timeout: Duration,
+    ) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let found = sink.recorded().into_iter().any(|(name, payload)| {
+                name == "agent-status" && payload["agentSessionId"] == agent_session_id
+            });
+            if found {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
     #[test]
     fn fixture_replays_one_user_turn_and_paired_tool_call() {
         let sink = Arc::new(FakeEventSink::new());
@@ -764,8 +875,14 @@ mod tests {
         let transcript_path = tmp.path().join("wire.jsonl");
         std::fs::copy(fixture_path(), &transcript_path).expect("copy fixture");
 
-        let handle = start_tailing(sink.clone(), "sid-kimi".to_string(), transcript_path, None, test_locator())
-            .expect("tailing starts");
+        let handle = start_tailing(
+            sink.clone(),
+            "sid-kimi".to_string(),
+            transcript_path,
+            None,
+            test_locator(),
+        )
+        .expect("tailing starts");
 
         assert!(
             sink.wait_for_count("agent-tool-call", 2, Duration::from_secs(5)),
@@ -800,11 +917,7 @@ mod tests {
     fn supervisor_surfaces_sub_agent_tool_calls() {
         let sink = Arc::new(FakeEventSink::new());
         let tmp = tempfile::tempdir().expect("tempdir");
-        let session = tmp
-            .path()
-            .join("sessions")
-            .join("wd_x")
-            .join("session_y");
+        let session = tmp.path().join("sessions").join("wd_x").join("session_y");
         let main_dir = session.join("agents").join("main");
         let sub_dir = session.join("agents").join("agent-0");
         std::fs::create_dir_all(&main_dir).expect("main dir");
@@ -833,8 +946,14 @@ mod tests {
         .expect("state.json");
 
         let main_wire = main_dir.join("wire.jsonl");
-        let handle = start_tailing(sink.clone(), "sid".to_string(), main_wire, None, test_locator())
-            .expect("tailing starts");
+        let handle = start_tailing(
+            sink.clone(),
+            "sid".to_string(),
+            main_wire,
+            None,
+            test_locator(),
+        )
+        .expect("tailing starts");
 
         assert!(
             sink.wait_for_count("agent-tool-call", 2, Duration::from_secs(5)),
@@ -852,6 +971,77 @@ mod tests {
         assert_eq!(calls[0]["toolUseId"], "agent-0:t1");
         assert_eq!(calls[0]["tool"], "Read");
         assert_eq!(calls[1]["toolUseId"], "agent-0:t1");
+        assert_eq!(calls[1]["status"], "done");
+    }
+
+    #[test]
+    fn supervisor_switches_when_kimi_creates_new_main_session_after_attach() {
+        let sink = Arc::new(FakeEventSink::new());
+        let kimi_home = tempfile::tempdir().expect("kimi home");
+        let work = tempfile::tempdir().expect("work dir");
+        let old_session = session_under(kimi_home.path(), "session_old");
+        let old_wire = write_main_session(
+            &old_session,
+            "{\"type\":\"config.update\",\"modelAlias\":\"kimi-code/kimi-for-coding\"}\n",
+        );
+        let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        let new_time = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+        set_session_activity(&old_session, old_time);
+        write_session_index(
+            kimi_home.path(),
+            &[("session_old", &old_session, work.path())],
+        );
+
+        let locator = Arc::new(KimiLocator::new(
+            kimi_home.path().to_path_buf(),
+            4242,
+            SystemTime::UNIX_EPOCH,
+            None,
+        ));
+        let located = locator.locate(work.path(), "pty").expect("initial locate");
+        assert_eq!(located.status_path, old_wire);
+
+        let handle = start_tailing(
+            sink.clone(),
+            "sid".to_string(),
+            old_wire,
+            Some(work.path().to_path_buf()),
+            locator,
+        )
+        .expect("tailing starts");
+
+        let new_session = session_under(kimi_home.path(), "session_new");
+        write_main_session(
+            &new_session,
+            "{\"type\":\"config.update\",\"modelAlias\":\"kimi-code/kimi-for-coding\"}\n\
+             {\"type\":\"turn.prompt\",\"origin\":{\"kind\":\"user\"}}\n\
+             {\"type\":\"context.append_loop_event\",\"time\":1781345364384,\"event\":{\"type\":\"tool.call\",\"toolCallId\":\"new-tool\",\"name\":\"Glob\",\"args\":{\"path\":\"src\"}}}\n\
+             {\"type\":\"context.append_loop_event\",\"time\":1781345364999,\"event\":{\"type\":\"tool.result\",\"toolCallId\":\"new-tool\"}}\n\
+             {\"type\":\"usage.record\",\"usage\":{\"inputOther\":10,\"output\":2,\"inputCacheRead\":20,\"inputCacheCreation\":0}}\n",
+        );
+        set_session_activity(&new_session, new_time);
+        write_session_index(
+            kimi_home.path(),
+            &[
+                ("session_old", &old_session, work.path()),
+                ("session_new", &new_session, work.path()),
+            ],
+        );
+
+        assert!(
+            sink.wait_for_count("agent-tool-call", 2, Duration::from_secs(5)),
+            "new session START + DONE must surface after supervisor switch",
+        );
+        assert!(
+            wait_for_agent_status_session(&sink, "session_new", Duration::from_secs(5)),
+            "status must carry the new kimi session id after supervisor switch",
+        );
+        handle.stop();
+
+        let calls = tool_call_events(&sink);
+        assert_eq!(calls[0]["toolUseId"], "new-tool");
+        assert_eq!(calls[0]["tool"], "Glob");
+        assert_eq!(calls[1]["toolUseId"], "new-tool");
         assert_eq!(calls[1]["status"], "done");
     }
 
@@ -910,7 +1100,13 @@ mod tests {
         // Consent OFF: no merge, so the bars fall back to the zeroed default.
         crate::agent::kimi_usage_consent::set_for_test(false);
         let sink_off = Arc::new(FakeEventSink::new());
-        emit_session_status(sink_off.as_ref(), "sid", &session, locator.as_ref(), &mut None);
+        emit_session_status(
+            sink_off.as_ref(),
+            "sid",
+            &session,
+            locator.as_ref(),
+            &mut None,
+        );
         let status_off = sink_off
             .recorded()
             .into_iter()
@@ -964,13 +1160,25 @@ mod tests {
         // Consent OFF: no merge → usage_fetched=false; records the signature.
         crate::agent::kimi_usage_consent::set_for_test(false);
         let sink_off = Arc::new(FakeEventSink::new());
-        emit_session_status(sink_off.as_ref(), "sid", &session, locator.as_ref(), &mut last);
+        emit_session_status(
+            sink_off.as_ref(),
+            "sid",
+            &session,
+            locator.as_ref(),
+            &mut last,
+        );
 
         // Consent ON: same zero values, but usage_fetched flips true — the
         // dedupe must NOT suppress this emit.
         crate::agent::kimi_usage_consent::set_for_test(true);
         let sink_on = Arc::new(FakeEventSink::new());
-        emit_session_status(sink_on.as_ref(), "sid", &session, locator.as_ref(), &mut last);
+        emit_session_status(
+            sink_on.as_ref(),
+            "sid",
+            &session,
+            locator.as_ref(),
+            &mut last,
+        );
         let status = sink_on
             .recorded()
             .into_iter()
@@ -987,11 +1195,7 @@ mod tests {
     fn supervisor_does_not_double_tail_main_wire_through_symlink() {
         let sink = Arc::new(FakeEventSink::new());
         let tmp = tempfile::tempdir().expect("tempdir");
-        let session = tmp
-            .path()
-            .join("sessions")
-            .join("wd_x")
-            .join("session_y");
+        let session = tmp.path().join("sessions").join("wd_x").join("session_y");
         let main_dir = session.join("agents").join("main");
         std::fs::create_dir_all(&main_dir).expect("main dir");
 
@@ -1015,8 +1219,14 @@ mod tests {
         .expect("state.json");
 
         let main_wire = link_dir.join("agents").join("main").join("wire.jsonl");
-        let handle = start_tailing(sink.clone(), "sid".to_string(), main_wire, None, test_locator())
-            .expect("tailing starts");
+        let handle = start_tailing(
+            sink.clone(),
+            "sid".to_string(),
+            main_wire,
+            None,
+            test_locator(),
+        )
+        .expect("tailing starts");
 
         assert!(
             sink.wait_for_count("agent-turn", 1, Duration::from_secs(5)),
@@ -1067,7 +1277,8 @@ mod tests {
     #[test]
     fn tool_call_timestamp_derives_from_wire_time_not_now() {
         let sink = Arc::new(FakeEventSink::new());
-        let mut decoder = KimiTranscriptDecoder::new(sink.clone(), "sid".into(), String::new(), String::new());
+        let mut decoder =
+            KimiTranscriptDecoder::new(sink.clone(), "sid".into(), String::new(), String::new());
         // Mirrors the fixture's tool.call envelope `time` (epoch-ms).
         decoder.decode_line(
             r#"{"type":"context.append_loop_event","time":1781345364384,"event":{"type":"tool.call","toolCallId":"t1","name":"Read","args":{"path":"a"}}}"#,
@@ -1083,7 +1294,8 @@ mod tests {
     #[test]
     fn injection_turn_prompt_does_not_count() {
         let sink = Arc::new(FakeEventSink::new());
-        let mut decoder = KimiTranscriptDecoder::new(sink.clone(), "sid".into(), String::new(), String::new());
+        let mut decoder =
+            KimiTranscriptDecoder::new(sink.clone(), "sid".into(), String::new(), String::new());
         decoder.decode_line(
             r#"{"type":"turn.prompt","input":[{"type":"text","text":"x"}],"origin":{"kind":"injection","variant":"permission_mode"}}"#,
         );
@@ -1093,7 +1305,8 @@ mod tests {
     #[test]
     fn tool_call_dedups_by_id() {
         let sink = Arc::new(FakeEventSink::new());
-        let mut decoder = KimiTranscriptDecoder::new(sink.clone(), "sid".into(), String::new(), String::new());
+        let mut decoder =
+            KimiTranscriptDecoder::new(sink.clone(), "sid".into(), String::new(), String::new());
         let start = r#"{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"t1","name":"Read","args":{"path":"a"},"display":{"path":"/tmp/a"}}}"#;
         decoder.decode_line(start);
         decoder.decode_line(start);

--- a/crates/backend/src/agent/adapter/kimi/usage_fetch.rs
+++ b/crates/backend/src/agent/adapter/kimi/usage_fetch.rs
@@ -8,8 +8,9 @@
 //! providers with their OWN keys, so resolution is section-scoped. Response
 //! PII (`userId` / `region` / `membership`) and the token are never logged.
 
-use std::path::Path;
-use std::time::Duration;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use crate::agent::types::RateLimits;
 
@@ -19,6 +20,8 @@ use super::usage::parse_usage_payload;
 // last cached value simply stays until the next turn retries.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const CALL_TIMEOUT: Duration = Duration::from_secs(10);
+const VERSION_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+const FALLBACK_VERSION: &str = "0.0.0";
 
 // The managed-provider table key in config.toml. The file also holds
 // `providers."<other>"` entries (web search / fetch) with different keys.
@@ -69,7 +72,8 @@ fn oauth_token(home: &Path) -> Option<String> {
         .strip_prefix("managed:")
         .unwrap_or(MANAGED_PROVIDER);
     let path = home.join("credentials").join(format!("{profile}.json"));
-    let json: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()?;
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()?;
     for field in ["access_token", "accessToken", "token", "bearer"] {
         if let Some(token) = json.get(field).and_then(|value| value.as_str()) {
             let token = token.trim();
@@ -86,12 +90,113 @@ fn oauth_token(home: &Path) -> Option<String> {
 /// — usage is best-effort and never blocks the local status path.
 pub(super) fn fetch_rate_limits(home: &Path, version: &str) -> Option<RateLimits> {
     let endpoint = resolve_usage_endpoint(home)?;
-    match http_get_usages(&endpoint, version) {
+    let user_agent_version = usage_user_agent_version(home, version);
+    match http_get_usages(&endpoint, &user_agent_version) {
         Ok(body) => parse_usage_payload(&body),
         Err(reason) => {
             log::warn!("kimi usage fetch failed: {reason}");
             None
         }
+    }
+}
+
+fn usage_user_agent_version(home: &Path, transcript_version: &str) -> String {
+    clean_version(transcript_version)
+        .or_else(|| version_from_update_metadata(home))
+        .or_else(|| version_from_kimi_binary(home))
+        .unwrap_or_else(|| FALLBACK_VERSION.to_string())
+}
+
+fn clean_version(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    raw.split_whitespace()
+        .find_map(|token| {
+            let token = token.trim_start_matches('v').trim_matches(|ch: char| {
+                !(ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_'))
+            });
+            token.chars().any(|ch| ch.is_ascii_digit()).then_some(token)
+        })
+        .filter(|token| !token.is_empty())
+        .map(str::to_string)
+}
+
+fn version_from_update_metadata(home: &Path) -> Option<String> {
+    let install = read_json(&home.join("updates").join("install.json"));
+    if let Some(version) = install.as_ref().and_then(|root| {
+        string_at(root, &["active", "version"])
+            .or_else(|| string_at(root, &["lastSuccess", "version"]))
+            .or_else(|| string_at(root, &["version"]))
+    }) {
+        if let Some(version) = clean_version(version) {
+            return Some(version);
+        }
+    }
+
+    let latest = read_json(&home.join("updates").join("latest.json"));
+    latest.as_ref().and_then(|root| {
+        string_at(root, &["latest"])
+            .or_else(|| string_at(root, &["manifest", "version"]))
+            .and_then(clean_version)
+    })
+}
+
+fn read_json(path: &Path) -> Option<serde_json::Value> {
+    serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()
+}
+
+fn string_at<'a>(value: &'a serde_json::Value, path: &[&str]) -> Option<&'a str> {
+    path.iter()
+        .try_fold(value, |current, key| current.get(*key))
+        .and_then(serde_json::Value::as_str)
+}
+
+fn version_from_kimi_binary(home: &Path) -> Option<String> {
+    kimi_binary_candidates(home)
+        .into_iter()
+        .find_map(|path| version_from_command(&path))
+}
+
+fn kimi_binary_candidates(home: &Path) -> Vec<PathBuf> {
+    #[cfg(not(windows))]
+    {
+        vec![home.join("bin").join("kimi")]
+    }
+    #[cfg(windows)]
+    {
+        let mut candidates = vec![home.join("bin").join("kimi")];
+        candidates.push(home.join("bin").join("kimi.exe"));
+        candidates
+    }
+}
+
+fn version_from_command(path: &Path) -> Option<String> {
+    if !path.is_file() {
+        return None;
+    }
+    let mut child = Command::new(path)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+    let deadline = Instant::now() + VERSION_COMMAND_TIMEOUT;
+    loop {
+        if child.try_wait().ok()?.is_some() {
+            let output = child.wait_with_output().ok()?;
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return clean_version(&stdout).or_else(|| clean_version(&stderr));
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(25));
     }
 }
 
@@ -231,5 +336,68 @@ base_url = "https://api.kimi.com/coding/v1"
             usages_url("https://api.kimi.com/coding/v1/"),
             "https://api.kimi.com/coding/v1/usages"
         );
+    }
+
+    #[test]
+    fn user_agent_version_prefers_transcript_version() {
+        let home = tempfile::tempdir().expect("home");
+        std::fs::create_dir_all(home.path().join("updates")).expect("updates");
+        std::fs::write(
+            home.path().join("updates").join("install.json"),
+            r#"{"lastSuccess":{"version":"0.15.0"}}"#,
+        )
+        .expect("install metadata");
+
+        assert_eq!(usage_user_agent_version(home.path(), " 0.14.2 "), "0.14.2");
+    }
+
+    #[test]
+    fn user_agent_version_falls_back_to_install_metadata() {
+        let home = tempfile::tempdir().expect("home");
+        std::fs::create_dir_all(home.path().join("updates")).expect("updates");
+        std::fs::write(
+            home.path().join("updates").join("install.json"),
+            r#"{"lastSuccess":{"version":"0.15.0"}}"#,
+        )
+        .expect("install metadata");
+
+        assert_eq!(usage_user_agent_version(home.path(), ""), "0.15.0");
+    }
+
+    #[test]
+    fn user_agent_version_falls_back_to_latest_metadata() {
+        let home = tempfile::tempdir().expect("home");
+        std::fs::create_dir_all(home.path().join("updates")).expect("updates");
+        std::fs::write(
+            home.path().join("updates").join("latest.json"),
+            r#"{"latest":"0.16.0","manifest":{"version":"0.16.0"}}"#,
+        )
+        .expect("latest metadata");
+
+        assert_eq!(usage_user_agent_version(home.path(), ""), "0.16.0");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn user_agent_version_falls_back_to_kimi_binary() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = tempfile::tempdir().expect("home");
+        let bin_dir = home.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).expect("bin dir");
+        let kimi = bin_dir.join("kimi");
+        std::fs::write(&kimi, "#!/bin/sh\necho 0.17.0\n").expect("kimi shim");
+        let mut perms = std::fs::metadata(&kimi).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&kimi, perms).expect("chmod");
+
+        assert_eq!(usage_user_agent_version(home.path(), ""), "0.17.0");
+    }
+
+    #[test]
+    fn user_agent_version_keeps_kimi_shaped_default_when_everything_is_missing() {
+        let home = tempfile::tempdir().expect("home");
+
+        assert_eq!(usage_user_agent_version(home.path(), ""), FALLBACK_VERSION);
     }
 }

--- a/crates/backend/src/agent/adapter/kimi/usage_fetch.rs
+++ b/crates/backend/src/agent/adapter/kimi/usage_fetch.rs
@@ -8,9 +8,8 @@
 //! providers with their OWN keys, so resolution is section-scoped. Response
 //! PII (`userId` / `region` / `membership`) and the token are never logged.
 
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::path::Path;
+use std::time::Duration;
 
 use crate::agent::types::RateLimits;
 
@@ -20,7 +19,6 @@ use super::usage::parse_usage_payload;
 // last cached value simply stays until the next turn retries.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const CALL_TIMEOUT: Duration = Duration::from_secs(10);
-const VERSION_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
 const FALLBACK_VERSION: &str = "0.0.0";
 
 // The managed-provider table key in config.toml. The file also holds
@@ -103,7 +101,6 @@ pub(super) fn fetch_rate_limits(home: &Path, version: &str) -> Option<RateLimits
 fn usage_user_agent_version(home: &Path, transcript_version: &str) -> String {
     clean_version(transcript_version)
         .or_else(|| version_from_update_metadata(home))
-        .or_else(|| version_from_kimi_binary(home))
         .unwrap_or_else(|| FALLBACK_VERSION.to_string())
 }
 
@@ -151,53 +148,6 @@ fn string_at<'a>(value: &'a serde_json::Value, path: &[&str]) -> Option<&'a str>
     path.iter()
         .try_fold(value, |current, key| current.get(*key))
         .and_then(serde_json::Value::as_str)
-}
-
-fn version_from_kimi_binary(home: &Path) -> Option<String> {
-    kimi_binary_candidates(home)
-        .into_iter()
-        .find_map(|path| version_from_command(&path))
-}
-
-fn kimi_binary_candidates(home: &Path) -> Vec<PathBuf> {
-    #[cfg(not(windows))]
-    {
-        vec![home.join("bin").join("kimi")]
-    }
-    #[cfg(windows)]
-    {
-        let mut candidates = vec![home.join("bin").join("kimi")];
-        candidates.push(home.join("bin").join("kimi.exe"));
-        candidates
-    }
-}
-
-fn version_from_command(path: &Path) -> Option<String> {
-    if !path.is_file() {
-        return None;
-    }
-    let mut child = Command::new(path)
-        .arg("--version")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .ok()?;
-    let deadline = Instant::now() + VERSION_COMMAND_TIMEOUT;
-    loop {
-        if child.try_wait().ok()?.is_some() {
-            let output = child.wait_with_output().ok()?;
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return clean_version(&stdout).or_else(|| clean_version(&stderr));
-        }
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return None;
-        }
-        std::thread::sleep(Duration::from_millis(25));
-    }
 }
 
 /// `${base_url}/usages` — the endpoint is a `.../v1` base, plural `usages`.
@@ -375,23 +325,6 @@ base_url = "https://api.kimi.com/coding/v1"
         .expect("latest metadata");
 
         assert_eq!(usage_user_agent_version(home.path(), ""), "0.16.0");
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn user_agent_version_falls_back_to_kimi_binary() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let home = tempfile::tempdir().expect("home");
-        let bin_dir = home.path().join("bin");
-        std::fs::create_dir_all(&bin_dir).expect("bin dir");
-        let kimi = bin_dir.join("kimi");
-        std::fs::write(&kimi, "#!/bin/sh\necho 0.17.0\n").expect("kimi shim");
-        let mut perms = std::fs::metadata(&kimi).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&kimi, perms).expect("chmod");
-
-        assert_eq!(usage_user_agent_version(home.path(), ""), "0.17.0");
     }
 
     #[test]

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -47,7 +47,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 33       | 15   | 2026-06-11   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
-| [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |
+| [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 15       | 12   | 2026-06-16   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 6        | 3    | 2026-05-30   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
 | [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 8        | 6    | 2026-06-13   |
@@ -62,7 +62,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 22   | 2026-06-08   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 4        | 2    | 2026-06-14   |
-| [Command Injection](patterns/command-injection.md)                                                   | security           | 7        | 3    | 2026-05-02   |
+| [Command Injection](patterns/command-injection.md)                                                   | security           | 8        | 3    | 2026-06-16   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)                                             | security           | 15       | 2    | 2026-04-20   |
 | [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                                                   | security           | 3        | 1    | 2026-04-20   |
 | [Preflight Checks](patterns/preflight-checks.md)                                                     | error-handling     | 3        | 0    | 2026-05-31   |

--- a/docs/reviews/patterns/command-injection.md
+++ b/docs/reviews/patterns/command-injection.md
@@ -98,3 +98,12 @@ Beyond the general "no template-string shell commands" rule:
 - **Finding:** Round-1's regex tightening (#6) used `/^[a-zA-Z0-9_/][a-zA-Z0-9_/.-]*$/` — slash valid in BOTH the first-character class and the trailing class. Slash is a valid internal ref separator (`feature/cleanup`, `refs/heads/main`) but `git check-ref-format` rejects it as the leading character. So a value like `/foo/bar` passed our allowlist, reached `git diff /foo/bar -- file`, and bubbled up as a 500 from the outer error handler instead of falling through to the working-tree path. No file-read vector (git treats it as a tree-ish, not a filesystem path), but the error semantics are wrong: the user sees "internal server error" when the actual outcome should be "ignored, falling back to working-tree". Same finding-class as #4 (validation considered the obvious vectors but missed a related one).
 - **Fix:** Narrowed the first-character class to `[a-zA-Z0-9_]` (no `/`). Slash remains in the trailing class so internal-separator paths still pass. Test added asserting `/foo/bar` falls through to the working-tree path. The lesson: when an allowlist regex has a "first character" vs "rest" split, the first class is almost always strictly narrower — the underlying spec usually has a "must start with" rule that's stricter than its "may contain" rule.
 - **Commit:** _(see git log for the round-3 fix commit)_
+
+### 6. Avoid executing KIMI_CODE_HOME/bin/kimi for version discovery
+
+- **Source:** github-codex-connector | PR #477 round 1 | 2026-06-16
+- **Severity:** P1 / HIGH
+- **File:** `crates/backend/src/agent/adapter/kimi/usage_fetch.rs`
+- **Finding:** version_from_kimi_binary spawned <effective_home>/bin/kimi --version when metadata was missing; effective_home is derived from the attached process's KIMI_CODE_HOME, which can point to a writable directory containing an arbitrary executable, causing Vimeflow to run attacker-controlled code during a usage fetch.
+- **Fix:** Removed the binary-execution fallback; version discovery is now metadata-only and falls back to FALLBACK_VERSION instead of executing a file from a user-controlled path.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/resource-cleanup.md
+++ b/docs/reviews/patterns/resource-cleanup.md
@@ -145,3 +145,12 @@ causes listener accumulation and duplicate event handling.
 - **Finding:** After `pendingRestartId` is set to the restarted PTY id, synchronous code such as `reconstructWorkspace`, buffer attachment, `onRestoreRef.current`, or `activate` can throw before `pendingRestartId` is cleared. The catch block only logged and cleared loading state, so the backend PTY remained alive until a later unmount or dependency change, appearing as a phantom session in subsequent `listSessions()` results.
 - **Fix:** Call the existing idempotent `disposePendingRestart()` helper at the start of the restore IIFE's catch block so any uncommitted restarted PTY is killed on errors.
 - **Commit:** same commit as this entry
+
+### 15. Process zombie leak in version_from_command when try_wait returns an error
+
+- **Source:** github-claude | PR #477 round 1 | 2026-06-16
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/agent/adapter/kimi/usage_fetch.rs`
+- **Finding:** version_from_command used child.try_wait().ok()? to poll a spawned kimi binary; an Err from try_wait propagated None out of the loop, dropping the child without kill/wait and leaving a zombie process on Unix.
+- **Fix:** Removed version_from_command and the version_from_kimi_binary fallback entirely so the User-Agent version is resolved from transcript metadata or install/latest JSON only, eliminating the zombie-leak surface.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)


### PR DESCRIPTION
## Summary

Fixes two Kimi adapter telemetry failures seen on macOS after the Linux-oriented implementation landed:

- keeps the Kimi watcher attached to the active main session when Kimi creates or resumes a newer session after Vimeflow has already attached
- ranks Kimi session candidates by actual `state.json` / `agents/*/wire.jsonl` activity instead of relying on stale index order or proc-fd directory order
- allows consent-gated plan-usage fetches when Kimi 0.15 transcripts omit `metadata.app_version`, falling back to Kimi update metadata, `bin/kimi --version`, then a Kimi-shaped default User-Agent version

## Root Cause

Kimi can keep multiple session wires open while subagents and resumed sessions are active. The adapter could bind the first matching Linux proc-fd wire or the newest-looking macOS index row, which left the status panel watching an idle session. Separately, usage fetching was skipped when transcript metadata lacked `app_version`, so the UI gate timed out even though local OAuth/config data was present.

## Validation

- `git diff --check`
- `rustfmt crates/backend/src/agent/adapter/kimi/locator.rs crates/backend/src/agent/adapter/kimi/transcript.rs crates/backend/src/agent/adapter/kimi/usage_fetch.rs`
- `cargo test --manifest-path crates/backend/Cargo.toml agent::adapter::kimi::usage_fetch --lib`
- `cargo test --manifest-path crates/backend/Cargo.toml agent::adapter::kimi --lib`
- `cargo test --manifest-path crates/backend/Cargo.toml --lib -- --test-threads=1`
- pre-push `npm test` hook: 280 files passed, 3660 tests passed, 3 skipped

Notes: full `cargo fmt --check` still reports unrelated pre-existing backend formatting drift outside this PR scope; the modified Kimi files were formatted directly. Cargo still emits the existing `ts-rs failed to parse serde attribute` warnings.