### PR TITLE
refactor(terminal): add renderer-neutral terminal registry

### DIFF
--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -21,8 +21,12 @@ import type {
   TerminalFitController,
   TerminalRendererHandle,
   TerminalSurface,
-  TerminalViewportReader,
 } from '../../types'
+import {
+  terminalCache,
+  clearTerminalCache,
+  disposeTerminalSession,
+} from '../../terminalRegistry'
 import { registerPtySession, unregisterPtySession } from '../../ptySessionMap'
 import { TerminalContextMenu } from '../TerminalContextMenu'
 import {
@@ -59,54 +63,7 @@ const logAgentCwdDebug = (
   console.info(`[vimeflow:terminal-cwd] ${event} ${JSON.stringify(details)}`)
 }
 
-// Module-level cache of terminal instances per sessionId.
-//
-// HISTORICAL NOTE (corrected 2026-05-09): the original comment claimed
-// this cache "allows terminals to persist when switching between
-// sessions". That's not what makes tab switching work today —
-// `TerminalZone` always-renders inactive panes and hides them via
-// CSS `display: none` rather than unmount/remount, so Body never
-// unmounts on a tab switch and the cache hit/miss branch in the mount
-// effect is not the persistence mechanism. Body's stable mount is.
-//
-// What the cache actually serves:
-//   - the imperative `focusTerminal()` handle, which reads
-//     `terminalCache.get(sessionId)?.terminal.focus()` to focus the renderer
-//     without reaching into Body's internals;
-//   - tests + the existing public `clearTerminalCache` /
-//     `disposeTerminalSession` API surface (preserved per the step-4
-//     migration spec — external imports would break otherwise).
-//
-// New internal code should NOT add to the cache for "tab persistence"
-// reasons; terminal renderer lifetime is scoped to Body's mount.
-export const terminalCache = new Map<
-  string,
-  {
-    terminal: TerminalSurface
-    fitController: TerminalFitController
-    viewportReader: TerminalViewportReader
-  }
->()
-
-/**
- * Clear terminal cache (for testing only)
- */
-export const clearTerminalCache = (): void => {
-  terminalCache.forEach(({ terminal }) => terminal.dispose())
-  terminalCache.clear()
-}
-
-/**
- * Dispose and remove a single session's terminal from cache.
- * Call when a session is permanently closed (not just hidden).
- */
-export const disposeTerminalSession = (sessionId: string): void => {
-  const cached = terminalCache.get(sessionId)
-  if (cached) {
-    cached.terminal.dispose()
-    terminalCache.delete(sessionId)
-  }
-}
+export { clearTerminalCache, disposeTerminalSession, terminalCache }
 
 export type BodyMode = 'attach' | 'spawn'
 

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -61,7 +61,7 @@ export {
   clearTerminalCache,
   disposeTerminalSession,
   terminalCache,
-} from './Body'
+} from '../../terminalRegistry'
 
 export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
   function TerminalPane(

--- a/src/features/terminal/terminalRegistry.test.ts
+++ b/src/features/terminal/terminalRegistry.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+  clearTerminalCache,
+  disposeTerminalSession,
+  terminalCache,
+} from './terminalRegistry'
+import type { TerminalRegistryEntry } from './terminalRegistry'
+
+const createEntry = (): TerminalRegistryEntry => ({
+  terminal: {
+    cols: 80,
+    rows: 24,
+    element: undefined,
+    open: vi.fn(),
+    focus: vi.fn(),
+    dispose: vi.fn(),
+    clear: vi.fn(),
+    write: vi.fn(),
+    refresh: vi.fn(),
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    onResize: vi.fn(() => ({ dispose: vi.fn() })),
+    hasSelection: vi.fn((): boolean => false),
+    getSelection: vi.fn((): string => ''),
+    paste: vi.fn(),
+    selectAll: vi.fn(),
+    onSelectionChange: vi.fn(() => ({ dispose: vi.fn() })),
+    attachKeyEventHandler: vi.fn(),
+    applyTheme: vi.fn(),
+  },
+  fitController: { fit: vi.fn() },
+  viewportReader: { readVisibleText: vi.fn((): string => '') },
+})
+
+describe('terminalRegistry', () => {
+  afterEach(() => {
+    terminalCache.clear()
+  })
+
+  test('clears and disposes every cached terminal', () => {
+    const first = createEntry()
+    const second = createEntry()
+
+    terminalCache.set('pty-a', first)
+    terminalCache.set('pty-b', second)
+
+    clearTerminalCache()
+
+    expect(first.terminal.dispose).toHaveBeenCalledOnce()
+    expect(second.terminal.dispose).toHaveBeenCalledOnce()
+    expect(terminalCache.size).toBe(0)
+  })
+
+  test('disposes one terminal session without touching other entries', () => {
+    const first = createEntry()
+    const second = createEntry()
+
+    terminalCache.set('pty-a', first)
+    terminalCache.set('pty-b', second)
+
+    disposeTerminalSession('pty-a')
+
+    expect(first.terminal.dispose).toHaveBeenCalledOnce()
+    expect(second.terminal.dispose).not.toHaveBeenCalled()
+    expect(terminalCache.has('pty-a')).toBe(false)
+    expect(terminalCache.get('pty-b')).toBe(second)
+  })
+})

--- a/src/features/terminal/terminalRegistry.ts
+++ b/src/features/terminal/terminalRegistry.ts
@@ -1,0 +1,30 @@
+import type {
+  TerminalFitController,
+  TerminalSurface,
+  TerminalViewportReader,
+} from './types'
+
+export interface TerminalRegistryEntry {
+  terminal: TerminalSurface
+  fitController: TerminalFitController
+  viewportReader: TerminalViewportReader
+}
+
+// Registry of live terminal renderer instances keyed by pane PTY id.
+//
+// This is intentionally renderer-neutral: app code can focus, theme, resize, or
+// read visible text from a terminal without knowing which adapter backs it.
+export const terminalCache = new Map<string, TerminalRegistryEntry>()
+
+export const clearTerminalCache = (): void => {
+  terminalCache.forEach(({ terminal }) => terminal.dispose())
+  terminalCache.clear()
+}
+
+export const disposeTerminalSession = (sessionId: string): void => {
+  const cached = terminalCache.get(sessionId)
+  if (cached) {
+    cached.terminal.dispose()
+    terminalCache.delete(sessionId)
+  }
+}

--- a/src/features/terminal/theme/themeBridge.test.ts
+++ b/src/features/terminal/theme/themeBridge.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, expect, test, vi } from 'vitest'
 import { themeService } from '../../../theme'
-import {
-  clearTerminalCache,
-  terminalCache,
-} from '../components/TerminalPane/Body'
+import { clearTerminalCache, terminalCache } from '../terminalRegistry'
 import type { TerminalSurface } from '../types'
 import { initTerminalThemeBridge } from './themeBridge'
 

--- a/src/features/terminal/theme/themeBridge.ts
+++ b/src/features/terminal/theme/themeBridge.ts
@@ -1,5 +1,5 @@
 import { themeService } from '../../../theme'
-import { terminalCache } from '../components/TerminalPane/Body'
+import { terminalCache } from '../terminalRegistry'
 
 /** Re-theme every live terminal renderer when the workspace theme changes.
  * Canvas-backed renderers cannot read CSS variables — applying a fresh theme

--- a/src/lib/e2e-bridge.test.ts
+++ b/src/lib/e2e-bridge.test.ts
@@ -1,7 +1,7 @@
 // cspell:ignore vsplit
 import { describe, test, expect, beforeEach } from 'vitest'
 import { readPaneBuffer } from './e2e-bridge'
-import { terminalCache } from '../features/terminal/components/TerminalPane/Body'
+import { terminalCache } from '../features/terminal/terminalRegistry'
 
 type CacheEntry = ReturnType<typeof terminalCache.get>
 
@@ -28,9 +28,9 @@ const makeMockEntry = (rows: readonly string[]): CacheEntry => {
 /**
  * Build a session-level wrapper containing N split-view-slots, each with
  * an inner terminal-pane-wrapper (one carrying `data-focused="true"` when
- * `activeIndex` matches) and a `.xterm-rows` child with the provided
- * text content. Mirrors the post-5b DOM shape produced by SplitView →
- * TerminalPane → Body.
+ * `activeIndex` matches) and an xterm DOM rows child with the provided text
+ * content. Mirrors the post-5b DOM shape produced by SplitView → TerminalPane
+ * → Body.
  */
 const buildSessionWrapper = (
   paneTexts: readonly string[],
@@ -81,7 +81,7 @@ describe('readPaneBuffer', () => {
 
   test('returns the focused pane buffer in multi-pane DOM', () => {
     // Three panes; active = index 1. Bug class this catches: a naive
-    // `pane.querySelector('.xterm-rows')` would return panes[0]'s buffer.
+    // A naive DOM-only query would return panes[0]'s buffer.
     const wrapper = buildSessionWrapper(
       ['pane-zero-buf', 'pane-one-buf', 'pane-two-buf'],
       1
@@ -96,7 +96,7 @@ describe('readPaneBuffer', () => {
     expect(readPaneBuffer(wrapper)).toBe('solo-buf')
   })
 
-  test('falls back to first .xterm-rows when no pane carries data-focused', () => {
+  test('falls back to first terminal DOM rows when no pane carries data-focused', () => {
     // Defensive case — invariant violation (5a guarantees exactly-one
     // active per session). The function must still return SOMETHING
     // (not throw) so e2e specs don't fail cryptically. Returns the
@@ -106,15 +106,15 @@ describe('readPaneBuffer', () => {
     expect(readPaneBuffer(wrapper)).toBe('first-buf')
   })
 
-  test('returns empty string when no .xterm-rows is present', () => {
+  test('returns empty string when no terminal DOM rows are present', () => {
     const wrapper = document.createElement('div')
     wrapper.setAttribute('data-testid', 'terminal-pane')
-    // No inner content — no slot, no xterm-rows.
+    // No inner content — no slot, no terminal DOM rows.
 
     expect(readPaneBuffer(wrapper)).toBe('')
   })
 
-  test('reads xterm-rows directly when passed a split-view-slot (pty-id lookup path)', () => {
+  test('reads terminal DOM rows directly when passed a split-view-slot without cache', () => {
     // `readTerminalBufferForSession`'s pty-id fallback path resolves to
     // a `split-view-slot`, not the session wrapper. The function must
     // descend into the slot's inner terminal-pane-wrapper just the
@@ -129,12 +129,20 @@ describe('readPaneBuffer', () => {
     expect(readPaneBuffer(slot!)).toBe('slot-buf')
   })
 
-  test('falls back to terminal surface text when .xterm-rows is empty (canvas renderer path)', () => {
-    // Canvas/WebGL renderers leave .xterm-rows empty. The fallback must reach into terminalCache by PTY id.
+  test('reads terminal surface text when DOM rows are empty', () => {
+    // Canvas/WebGL renderers leave xterm DOM rows empty. The bridge must reach into terminalCache by PTY id.
     const wrapper = buildSessionWrapper([''], 0)
     terminalCache.set('pty-0', makeMockEntry(['$ echo hi', 'hi', '$ '])!)
 
     expect(readPaneBuffer(wrapper)).toBe('$ echo hi\nhi\n$')
+  })
+
+  test('reads terminal surface text when renderer exposes no xterm DOM rows', () => {
+    const wrapper = buildSessionWrapper(['stale-dom-row'], 0)
+    wrapper.querySelector('.xterm-rows')?.remove()
+    terminalCache.set('pty-0', makeMockEntry(['generic renderer text'])!)
+
+    expect(readPaneBuffer(wrapper)).toBe('generic renderer text')
   })
 
   test('uses data-pty-id from Body container, not data-session-id from TerminalZone', () => {
@@ -159,14 +167,21 @@ describe('readPaneBuffer', () => {
     expect(readPaneBuffer(inner!)).toBe('inner-pane-buf')
   })
 
-  test('uses cached terminal surface viewport text, not scrollback DOM', () => {
-    const wrapper = buildSessionWrapper([''], 0)
+  test('prefers terminal surface viewport text over renderer-specific DOM rows', () => {
+    const wrapper = buildSessionWrapper(['stale-dom-row'], 0)
     terminalCache.set('pty-0', makeMockEntry(['row-5', 'row-6'])!)
 
     expect(readPaneBuffer(wrapper)).toBe('row-5\nrow-6')
   })
 
-  test('returns empty string when .xterm-rows is empty and the cache has no entry', () => {
+  test('falls back to DOM rows when cached viewport text is empty', () => {
+    const wrapper = buildSessionWrapper(['dom-row'], 0)
+    terminalCache.set('pty-0', makeMockEntry([])!)
+
+    expect(readPaneBuffer(wrapper)).toBe('dom-row')
+  })
+
+  test('returns empty string when DOM rows are empty and the cache has no entry', () => {
     // No DOM text AND no cached terminal — the legacy fallback path.
     const wrapper = buildSessionWrapper([''], 0)
 

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -1,6 +1,6 @@
 import { invoke } from './backend'
 import { getAllPtySessionIds } from '../features/terminal/ptySessionMap'
-import { terminalCache } from '../features/terminal/components/TerminalPane/Body'
+import { terminalCache } from '../features/terminal/terminalRegistry'
 
 const isVisible = (el: HTMLElement): boolean => {
   const r = el.getBoundingClientRect()
@@ -28,22 +28,18 @@ const findActivePane = (): HTMLElement | null => {
   return Array.from(panes).find(isVisible) ?? null
 }
 
-// `rows.textContent` is typed as `string` by this project's lib.dom
-// (see similar `const text = rows.textContent` pattern in this file);
-// `?? ''` is rejected by @typescript-eslint/no-unnecessary-condition.
-//
 // Multi-pane sessions (post-5b): the session-level wrapper contains a
-// SplitView with N inner TerminalPanes, each carrying an xterm. Prefer
-// the focused pane's xterm (the active pane has `data-focused="true"`
-// on its inner wrapper) so callers reading by session id always get the
-// active pane's buffer instead of whichever pane happens to be first in
-// DOM. Falls back to the first `.xterm-rows` for single-pane sessions
-// and for the defensive case where no inner wrapper has `data-focused`.
+// SplitView with N inner TerminalPanes. Prefer the focused pane's renderer
+// (the active pane has `data-focused="true"` on its inner wrapper) so callers
+// reading by session id always get the active pane's buffer instead of whichever
+// pane happens to be first in DOM. Falls back to the first terminal DOM rows for
+// single-pane sessions and for the defensive case where no inner wrapper has
+// `data-focused`.
 //
 // Exported for unit testing — production callers go through
 // `readVisibleTerminalBuffer` / `readTerminalBufferForSession`.
 //
-// `container` is any xterm ancestor element: the session-level
+// `container` is any terminal ancestor element: the session-level
 // `terminal-pane` wrapper (preferred for multi-pane sessions —
 // triggers the `data-focused` first-pass), a single `split-view-slot`
 // (the pty-id lookup path), or any `terminal-pane-wrapper` directly.
@@ -55,20 +51,21 @@ export const readPaneBuffer = (container: HTMLElement): string => {
   )
   const scope = focusedWrapper ?? container
 
-  const rows = scope.querySelector<HTMLElement>('.xterm-rows')
-  const domText = rows?.textContent ?? ''
-  if (domText.trim().length > 0) {
-    return domText
-  }
-
-  // DOM read empty — the renderer may be drawing to <canvas>.
-  // Fall back to the terminal surface's viewport reader via terminalCache.
   const cacheKey = resolveCacheKey(scope)
   if (cacheKey) {
     const entry = terminalCache.get(cacheKey)
     if (entry) {
-      return entry.viewportReader.readVisibleText()
+      const surfaceText = entry.viewportReader.readVisibleText()
+      if (surfaceText.trim().length > 0) {
+        return surfaceText
+      }
     }
+  }
+
+  const rows = scope.querySelector<HTMLElement>('.xterm-rows')
+  const domText = rows?.textContent ?? ''
+  if (domText.trim().length > 0) {
+    return domText
   }
 
   return domText


### PR DESCRIPTION
## Summary

- Move the live terminal registry out of `Body.tsx` into a renderer-neutral `terminalRegistry` module.
- Keep the existing `Body` and `TerminalPane` cache/helper exports for compatibility while letting non-UI consumers import the registry directly.
- Update E2E buffer reads to prefer `TerminalViewportReader` before falling back to renderer-specific DOM rows.
- Add registry tests and E2E bridge coverage for renderers that expose no xterm DOM rows.

## Impact

This removes another Body/xterm-shaped coupling point from the terminal infrastructure. Theme updates and E2E automation now depend on the generic terminal surface/viewport contract, which makes a future non-xterm renderer easier to plug in without changing these consumers.

## Validation

- `npx vitest run src/features/terminal/terminalRegistry.test.ts src/lib/e2e-bridge.test.ts src/features/terminal/theme/themeBridge.test.ts src/features/terminal/components/TerminalPane/Body.test.tsx src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx src/features/terminal/components/TerminalPane/index.test.tsx src/features/terminal/Terminal.integration.test.tsx`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`
- `npx tsc -p electron/tsconfig.json --pretty false`