### PR TITLE
fix(agent-status): suppress replayed NOW flashes (VIM-137)

### DIFF
--- a/crates/backend/src/agent/adapter/claude_code/transcript.rs
+++ b/crates/backend/src/agent/adapter/claude_code/transcript.rs
@@ -310,6 +310,7 @@ impl TranscriptDecoder for ClaudeTranscriptDecoder {
                     phase,
                 );
             }
+            emit_replay_in_flight_tool_calls(&self.session_id, &self.events, &self.in_flight);
         }
         self.emitter.finish_replay();
     }
@@ -406,7 +407,7 @@ fn process_line(
 
     match dto.line_type.as_deref().unwrap_or("") {
         "assistant" => {
-            process_assistant_message(&dto, session_id, cwd, events, in_flight);
+            process_assistant_message(&dto, session_id, cwd, events, in_flight, replay_done);
         }
         "user" => {
             process_user_message(
@@ -519,6 +520,7 @@ fn process_assistant_message(
     cwd: Option<&Path>,
     events: &Arc<dyn EventSink>,
     in_flight: &mut InFlightToolCalls,
+    replay_done: bool,
 ) {
     let content = match message_content_items(dto) {
         Some(arr) => arr,
@@ -576,19 +578,21 @@ fn process_assistant_message(
             },
         );
 
-        let event = AgentToolCallEvent {
-            session_id: session_id.to_string(),
-            tool_use_id: id,
-            tool: name.to_string(),
-            args,
-            status: ToolCallStatus::Running,
-            timestamp: timestamp.clone(),
-            duration_ms: 0,
-            is_test_file,
-        };
+        if replay_done {
+            let event = AgentToolCallEvent {
+                session_id: session_id.to_string(),
+                tool_use_id: id,
+                tool: name.to_string(),
+                args,
+                status: ToolCallStatus::Running,
+                timestamp: timestamp.clone(),
+                duration_ms: 0,
+                is_test_file,
+            };
 
-        if let Err(e) = emit_agent_tool_call(events.as_ref(), &event) {
-            log::warn!("Failed to emit agent-tool-call event: {}", e);
+            if let Err(e) = emit_agent_tool_call(events.as_ref(), &event) {
+                log::warn!("Failed to emit agent-tool-call event: {}", e);
+            }
         }
     }
 }
@@ -739,6 +743,29 @@ fn process_tool_result(
 
     if let Err(e) = emit_agent_tool_call(events.as_ref(), &event) {
         log::warn!("Failed to emit agent-tool-call event: {}", e);
+    }
+}
+
+fn emit_replay_in_flight_tool_calls(
+    session_id: &str,
+    events: &Arc<dyn EventSink>,
+    in_flight: &InFlightToolCalls,
+) {
+    for (tool_use_id, call) in in_flight {
+        let event = AgentToolCallEvent {
+            session_id: session_id.to_string(),
+            tool_use_id: tool_use_id.clone(),
+            tool: call.tool.clone(),
+            args: call.args.clone(),
+            status: ToolCallStatus::Running,
+            timestamp: call.started_at_iso.clone(),
+            duration_ms: 0,
+            is_test_file: call.is_test_file,
+        };
+
+        if let Err(e) = emit_agent_tool_call(events.as_ref(), &event) {
+            log::warn!("Failed to emit agent-tool-call event: {}", e);
+        }
     }
 }
 
@@ -977,6 +1004,14 @@ mod tests {
             .collect()
     }
 
+    fn tool_call_payloads(sink: &FakeEventSink) -> Vec<Value> {
+        sink.recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-tool-call")
+            .map(|(_, payload)| payload)
+            .collect()
+    }
+
     #[test]
     fn claude_replay_flushes_only_the_settled_phase_once() {
         let sink = Arc::new(FakeEventSink::new());
@@ -1009,6 +1044,47 @@ mod tests {
             r#"{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}}"#,
         );
         assert_eq!(lifecycle_phases(&sink), vec!["idle", "running", "idle"]);
+    }
+
+    #[test]
+    fn claude_replay_does_not_emit_running_for_settled_tool_calls() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut decoder =
+            ClaudeTranscriptDecoder::new(sink.clone(), "sid".into(), None, "agent-1".into());
+
+        decoder.decode_line(
+            r#"{"timestamp":"2026-05-04T10:00:01Z","type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"src/main.ts"}}],"stop_reason":"tool_use"}}"#,
+        );
+        assert_eq!(sink.count("agent-tool-call"), 0);
+
+        decoder.decode_line(
+            r#"{"timestamp":"2026-05-04T10:00:02Z","type":"tool_result","tool_use_id":"toolu_1","content":"ok","is_error":false}"#,
+        );
+        decoder.on_caught_up();
+
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0]["toolUseId"], "toolu_1");
+        assert_eq!(payloads[0]["status"], "done");
+    }
+
+    #[test]
+    fn claude_replay_emits_running_for_unsettled_tool_call_at_catch_up() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut decoder =
+            ClaudeTranscriptDecoder::new(sink.clone(), "sid".into(), None, "agent-1".into());
+
+        decoder.decode_line(
+            r#"{"timestamp":"2026-05-04T10:00:01Z","type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"src/main.ts"}}],"stop_reason":"tool_use"}}"#,
+        );
+        assert_eq!(sink.count("agent-tool-call"), 0);
+
+        decoder.on_caught_up();
+
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0]["toolUseId"], "toolu_1");
+        assert_eq!(payloads[0]["status"], "running");
     }
 
     #[test]

--- a/crates/backend/src/agent/adapter/codex/transcript.rs
+++ b/crates/backend/src/agent/adapter/codex/transcript.rs
@@ -273,6 +273,7 @@ impl TranscriptDecoder for CodexTranscriptDecoder {
                     );
                 }
             }
+            emit_replay_in_flight_tool_calls(&self.session_id, &self.events, &self.in_flight);
         }
         self.emitter.finish_replay();
     }
@@ -375,7 +376,16 @@ fn process_line(
 
     match record_type {
         CodexRecordType::ResponseItem => {
-            process_response_item(&dto, &payload, session_id, cwd, events, emitter, in_flight);
+            process_response_item(
+                &dto,
+                &payload,
+                session_id,
+                cwd,
+                events,
+                emitter,
+                in_flight,
+                replay_done,
+            );
         }
         CodexRecordType::EventMsg => {
             process_event_msg(
@@ -394,15 +404,31 @@ fn process_response_item(
     events: &Arc<dyn EventSink>,
     emitter: &mut TestRunEmitter,
     in_flight: &mut InFlightToolCalls,
+    replay_done: bool,
 ) {
     let timestamp = dto.timestamp.clone().unwrap_or_else(now_iso8601);
 
     match payload.payload_type() {
         CodexPayloadType::FunctionCall => {
-            start_function_call(payload, session_id, cwd, events, in_flight, &timestamp);
+            start_function_call(
+                payload,
+                session_id,
+                cwd,
+                events,
+                in_flight,
+                &timestamp,
+                replay_done,
+            );
         }
         CodexPayloadType::CustomToolCall => {
-            start_custom_tool_call(payload, session_id, events, in_flight, &timestamp);
+            start_custom_tool_call(
+                payload,
+                session_id,
+                events,
+                in_flight,
+                &timestamp,
+                replay_done,
+            );
         }
         CodexPayloadType::FunctionCallOutput => {
             process_output_completion(
@@ -486,6 +512,7 @@ fn start_function_call(
     events: &Arc<dyn EventSink>,
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
+    replay_done: bool,
 ) {
     let Some(call_id) = payload.call_id.as_deref() else {
         return;
@@ -515,19 +542,21 @@ fn start_function_call(
         },
     );
 
-    emit_tool_call(
-        events,
-        AgentToolCallEvent {
-            session_id: session_id.to_string(),
-            tool_use_id: call_id.to_string(),
-            tool,
-            args,
-            status: ToolCallStatus::Running,
-            timestamp: timestamp.to_string(),
-            duration_ms: 0,
-            is_test_file: false,
-        },
-    );
+    if replay_done {
+        emit_tool_call(
+            events,
+            AgentToolCallEvent {
+                session_id: session_id.to_string(),
+                tool_use_id: call_id.to_string(),
+                tool,
+                args,
+                status: ToolCallStatus::Running,
+                timestamp: timestamp.to_string(),
+                duration_ms: 0,
+                is_test_file: false,
+            },
+        );
+    }
 }
 
 fn start_custom_tool_call(
@@ -536,6 +565,7 @@ fn start_custom_tool_call(
     events: &Arc<dyn EventSink>,
     in_flight: &mut InFlightToolCalls,
     timestamp: &str,
+    replay_done: bool,
 ) {
     let Some(call_id) = payload.call_id.as_deref() else {
         return;
@@ -561,19 +591,21 @@ fn start_custom_tool_call(
         },
     );
 
-    emit_tool_call(
-        events,
-        AgentToolCallEvent {
-            session_id: session_id.to_string(),
-            tool_use_id: call_id.to_string(),
-            tool,
-            args,
-            status: ToolCallStatus::Running,
-            timestamp: timestamp.to_string(),
-            duration_ms: 0,
-            is_test_file,
-        },
-    );
+    if replay_done {
+        emit_tool_call(
+            events,
+            AgentToolCallEvent {
+                session_id: session_id.to_string(),
+                tool_use_id: call_id.to_string(),
+                tool,
+                args,
+                status: ToolCallStatus::Running,
+                timestamp: timestamp.to_string(),
+                duration_ms: 0,
+                is_test_file,
+            },
+        );
+    }
 }
 
 fn process_output_completion(
@@ -833,6 +865,28 @@ fn flush_in_flight_tool_calls(
     }
 }
 
+fn emit_replay_in_flight_tool_calls(
+    session_id: &str,
+    events: &Arc<dyn EventSink>,
+    in_flight: &InFlightToolCalls,
+) {
+    for (call_id, call) in in_flight {
+        emit_tool_call(
+            events,
+            AgentToolCallEvent {
+                session_id: session_id.to_string(),
+                tool_use_id: call_id.clone(),
+                tool: call.tool.clone(),
+                args: call.args.clone(),
+                status: ToolCallStatus::Running,
+                timestamp: call.started_at_iso.clone(),
+                duration_ms: 0,
+                is_test_file: call.is_test_file,
+            },
+        );
+    }
+}
+
 fn emit_tool_call(events: &Arc<dyn EventSink>, event: AgentToolCallEvent) {
     if let Err(e) = emit_agent_tool_call(events.as_ref(), &event) {
         log::warn!("Failed to emit agent-tool-call event: {}", e);
@@ -982,6 +1036,14 @@ mod tests {
             .collect()
     }
 
+    fn tool_call_payloads(sink: &FakeEventSink) -> Vec<Value> {
+        sink.recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-tool-call")
+            .map(|(_, payload)| payload)
+            .collect()
+    }
+
     #[test]
     fn codex_replay_flushes_only_the_settled_phase_once() {
         let sink = Arc::new(FakeEventSink::new());
@@ -1015,6 +1077,45 @@ mod tests {
             r#"{"type":"event_msg","payload":{"type":"task_complete","duration_ms":5}}"#,
         );
         assert_eq!(lifecycle_phases(&sink), vec!["idle", "running", "idle"]);
+    }
+
+    #[test]
+    fn codex_replay_does_not_emit_running_for_settled_tool_calls() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut decoder = CodexTranscriptDecoder::new(sink.clone(), "sid".into(), None);
+
+        decoder.decode_line(
+            r#"{"timestamp":"2026-05-04T10:00:01Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"npm test\"}","call_id":"call_exec"}}"#,
+        );
+        assert_eq!(sink.count("agent-tool-call"), 0);
+
+        decoder.decode_line(
+            r#"{"timestamp":"2026-05-04T10:00:02Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_exec","output":"Process exited with code 0"}}"#,
+        );
+        decoder.on_caught_up();
+
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0]["toolUseId"], "call_exec");
+        assert_eq!(payloads[0]["status"], "done");
+    }
+
+    #[test]
+    fn codex_replay_emits_running_for_unsettled_tool_call_at_catch_up() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut decoder = CodexTranscriptDecoder::new(sink.clone(), "sid".into(), None);
+
+        decoder.decode_line(
+            r#"{"timestamp":"2026-05-04T10:00:01Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"npm test\"}","call_id":"call_exec"}}"#,
+        );
+        assert_eq!(sink.count("agent-tool-call"), 0);
+
+        decoder.on_caught_up();
+
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0]["toolUseId"], "call_exec");
+        assert_eq!(payloads[0]["status"], "running");
     }
 
     fn write_rollout(path: &Path, lines: &[Value]) {
@@ -1175,8 +1276,8 @@ mod tests {
         // each event type the assertions below count so the tail has
         // demonstrably emitted all of them before we stop and snapshot.
         assert!(
-            sink.wait_for_count("agent-tool-call", 4, Duration::from_secs(5)),
-            "expected 4 agent-tool-call events within 5s",
+            sink.wait_for_count("agent-tool-call", 2, Duration::from_secs(5)),
+            "expected 2 replay-settled agent-tool-call events within 5s",
         );
         assert!(
             sink.wait_for_count("agent-turn", 1, Duration::from_secs(5)),
@@ -1194,17 +1295,13 @@ mod tests {
             .filter(|(event, _)| event == "agent-tool-call")
             .map(|(_, payload)| payload.clone())
             .collect();
-        assert_eq!(tool_call_payloads.len(), 4);
+        assert_eq!(tool_call_payloads.len(), 2);
         assert_eq!(tool_call_payloads[0]["toolUseId"], "call_exec");
-        assert_eq!(tool_call_payloads[0]["status"], "running");
-        assert_eq!(tool_call_payloads[1]["toolUseId"], "call_exec");
+        assert_eq!(tool_call_payloads[0]["status"], "done");
+        assert_eq!(tool_call_payloads[0]["durationMs"], 1250);
+        assert_eq!(tool_call_payloads[1]["toolUseId"], "call_patch");
         assert_eq!(tool_call_payloads[1]["status"], "done");
-        assert_eq!(tool_call_payloads[1]["durationMs"], 1250);
-        assert_eq!(tool_call_payloads[2]["toolUseId"], "call_patch");
-        assert_eq!(tool_call_payloads[2]["status"], "running");
-        assert_eq!(tool_call_payloads[3]["toolUseId"], "call_patch");
-        assert_eq!(tool_call_payloads[3]["status"], "done");
-        assert_eq!(tool_call_payloads[3]["isTestFile"], true);
+        assert_eq!(tool_call_payloads[1]["isTestFile"], true);
 
         let turn_payloads: Vec<Value> = recorded
             .iter()


### PR DESCRIPTION
## Summary

- Suppress replayed historical `running` tool-call events for Codex and Claude Code transcripts.
- Keep replayed completed tool history (`done` / `failed`) so the activity list remains populated.
- Emit `running` at replay catch-up only for tool calls still in flight, preserving genuine live NOW state.
- Add Codex and Claude Code regressions for settled and unsettled replayed tool calls.

## Root Cause

#475 removed stale `toolCalls.active` from cached pane snapshots, but pane switching still restarts transcript watchers. During watcher catch-up, the backend replayed old transcript history as `running` then `done`. The frontend rendered the brief replayed `running` event as a NOW card, producing the flash even though the command was already completed.

This fix makes `running` a live/catch-up-current signal instead of a historical replay event.

## Local Testing

To test locally, restart `npm run electron:dev` from this branch/worktree because this is a Rust backend sidecar change; Vite hot reload will not replace the running sidecar binary. Also make sure only one Electron dev instance is running against the shared app data directory.

## Validation

- `cargo test --manifest-path crates/backend/Cargo.toml agent::adapter::codex::transcript --lib`
- `cargo test --manifest-path crates/backend/Cargo.toml agent::adapter::claude_code::transcript --lib`
- `cargo test --manifest-path crates/backend/Cargo.toml --lib -- --test-threads=1`
- pre-push `npm run test`: 289 files passed, 3726 tests passed, 3 skipped

Note: concurrent `cargo test --manifest-path crates/backend/Cargo.toml` hit unrelated terminal PTY timing flakes; the failed tests passed individually and the full lib suite passed serially.

Linear: VIM-137