### PR TITLE
refactor(terminal): add renderer adapter registry

### DIFF
--- a/src/features/terminal/components/TerminalPane/terminalInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalInstance.test.ts
@@ -1,9 +1,9 @@
 import { expect, test, vi } from 'vitest'
 import { createTerminalInstance } from './terminalInstance'
-import { createXtermTerminal } from './xtermInstance'
+import { createConfiguredTerminalInstance } from './terminalRendererRegistry'
 
-vi.mock('./xtermInstance', () => ({
-  createXtermTerminal: vi.fn(),
+vi.mock('./terminalRendererRegistry', () => ({
+  createConfiguredTerminalInstance: vi.fn(),
 }))
 
 test('creates the configured terminal renderer instance', () => {
@@ -14,7 +14,7 @@ test('creates the configured terminal renderer instance', () => {
     fitController: {},
     attachRenderer: vi.fn(),
   }
-  vi.mocked(createXtermTerminal).mockReturnValue(instance as never)
+  vi.mocked(createConfiguredTerminalInstance).mockReturnValue(instance as never)
 
   expect(createTerminalInstance()).toBe(instance)
 })

--- a/src/features/terminal/components/TerminalPane/terminalInstance.ts
+++ b/src/features/terminal/components/TerminalPane/terminalInstance.ts
@@ -1,5 +1,5 @@
 import type { TerminalInstance } from '../../types'
-import { createXtermTerminal } from './xtermInstance'
+import { createConfiguredTerminalInstance } from './terminalRendererRegistry'
 
 export const createTerminalInstance = (): TerminalInstance =>
-  createXtermTerminal()
+  createConfiguredTerminalInstance()

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import type { TerminalInstance, TerminalRendererAdapter } from '../../types'
+import {
+  _resetTerminalRendererRegistryForTest,
+  createConfiguredTerminalInstance,
+  getTerminalRendererAdapter,
+  registerTerminalRendererAdapter,
+  setTerminalRendererAdapter,
+} from './terminalRendererRegistry'
+import { xtermTerminalRenderer } from './xtermInstance'
+
+const xtermRendererMocks = vi.hoisted(() => ({
+  createInstance: vi.fn(),
+}))
+
+vi.mock('./xtermInstance', () => ({
+  xtermTerminalRenderer: {
+    id: 'xterm',
+    createInstance: xtermRendererMocks.createInstance,
+  },
+}))
+
+const createTerminalInstance = (): TerminalInstance => ({
+  terminal: {
+    cols: 80,
+    rows: 24,
+    element: undefined,
+    open: vi.fn(),
+    focus: vi.fn(),
+    dispose: vi.fn(),
+    clear: vi.fn(),
+    write: vi.fn(),
+    refresh: vi.fn(),
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    onResize: vi.fn(() => ({ dispose: vi.fn() })),
+    hasSelection: vi.fn((): boolean => false),
+    getSelection: vi.fn((): string => ''),
+    paste: vi.fn(),
+    selectAll: vi.fn(),
+    onSelectionChange: vi.fn(() => ({ dispose: vi.fn() })),
+    attachKeyEventHandler: vi.fn(),
+    applyTheme: vi.fn(),
+  },
+  parser: {
+    registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
+  },
+  viewportReader: {
+    readVisibleText: vi.fn((): string => ''),
+  },
+  fitController: {
+    fit: vi.fn(),
+  },
+  attachRenderer: vi.fn(() => ({ dispose: vi.fn() })),
+})
+
+const createTerminalRendererAdapter = (
+  id: string,
+  instance: TerminalInstance
+): TerminalRendererAdapter => ({
+  id,
+  createInstance: vi.fn((): TerminalInstance => instance),
+})
+
+describe('terminalRendererRegistry', () => {
+  afterEach(() => {
+    _resetTerminalRendererRegistryForTest()
+    vi.clearAllMocks()
+  })
+
+  test('uses the xterm renderer adapter by default', () => {
+    const instance = createTerminalInstance()
+    xtermRendererMocks.createInstance.mockReturnValue(instance)
+
+    expect(getTerminalRendererAdapter()).toBe(xtermTerminalRenderer)
+    expect(createConfiguredTerminalInstance()).toBe(instance)
+    expect(xtermRendererMocks.createInstance).toHaveBeenCalledOnce()
+  })
+
+  test('creates instances through a registered non-xterm renderer adapter', () => {
+    const instance = createTerminalInstance()
+    const customRenderer = createTerminalRendererAdapter('custom', instance)
+
+    registerTerminalRendererAdapter(customRenderer)
+    setTerminalRendererAdapter('custom')
+
+    expect(getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'custom' })
+    )
+    expect(createConfiguredTerminalInstance()).toBe(instance)
+    expect(customRenderer.createInstance).toHaveBeenCalledOnce()
+    expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
+  })
+
+  test('rejects unknown renderer adapters', () => {
+    expect(() => setTerminalRendererAdapter('missing')).toThrow(
+      'Unknown terminal renderer adapter: missing'
+    )
+  })
+
+  test('normalizes registered renderer adapter ids', () => {
+    const instance = createTerminalInstance()
+    const renderer = createTerminalRendererAdapter(' custom ', instance)
+
+    registerTerminalRendererAdapter(renderer)
+    setTerminalRendererAdapter('custom')
+
+    expect(getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'custom' })
+    )
+  })
+
+  test('rejects empty renderer adapter ids', () => {
+    const instance = createTerminalInstance()
+    const renderer = createTerminalRendererAdapter(' ', instance)
+
+    expect(() => registerTerminalRendererAdapter(renderer)).toThrow(
+      'Terminal renderer adapter id is required'
+    )
+  })
+
+  test('resets to the default renderer adapter', () => {
+    const instance = createTerminalInstance()
+    const customRenderer = createTerminalRendererAdapter('custom', instance)
+
+    registerTerminalRendererAdapter(customRenderer)
+    setTerminalRendererAdapter('custom')
+
+    _resetTerminalRendererRegistryForTest()
+
+    expect(getTerminalRendererAdapter()).toBe(xtermTerminalRenderer)
+    expect(() => setTerminalRendererAdapter('custom')).toThrow(
+      'Unknown terminal renderer adapter: custom'
+    )
+  })
+})

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
@@ -1,0 +1,52 @@
+import type { TerminalInstance, TerminalRendererAdapter } from '../../types'
+import { xtermTerminalRenderer } from './xtermInstance'
+
+const terminalRendererAdapters = new Map<string, TerminalRendererAdapter>([
+  [xtermTerminalRenderer.id, xtermTerminalRenderer],
+])
+
+let activeTerminalRendererId = xtermTerminalRenderer.id
+
+export const registerTerminalRendererAdapter = (
+  adapter: TerminalRendererAdapter
+): void => {
+  const rendererId = adapter.id.trim()
+
+  if (rendererId.length === 0) {
+    throw new Error('Terminal renderer adapter id is required')
+  }
+
+  terminalRendererAdapters.set(rendererId, {
+    ...adapter,
+    id: rendererId,
+  })
+}
+
+export const setTerminalRendererAdapter = (rendererId: string): void => {
+  if (!terminalRendererAdapters.has(rendererId)) {
+    throw new Error(`Unknown terminal renderer adapter: ${rendererId}`)
+  }
+
+  activeTerminalRendererId = rendererId
+}
+
+export const getTerminalRendererAdapter = (): TerminalRendererAdapter => {
+  const adapter = terminalRendererAdapters.get(activeTerminalRendererId)
+
+  if (!adapter) {
+    throw new Error(
+      `Active terminal renderer adapter is unavailable: ${activeTerminalRendererId}`
+    )
+  }
+
+  return adapter
+}
+
+export const createConfiguredTerminalInstance = (): TerminalInstance =>
+  getTerminalRendererAdapter().createInstance()
+
+export const _resetTerminalRendererRegistryForTest = (): void => {
+  terminalRendererAdapters.clear()
+  terminalRendererAdapters.set(xtermTerminalRenderer.id, xtermTerminalRenderer)
+  activeTerminalRendererId = xtermTerminalRenderer.id
+}

--- a/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
@@ -5,7 +5,7 @@ import { WebglAddon } from '@xterm/addon-webgl'
 import { CanvasAddon } from '@xterm/addon-canvas'
 import { obsidianLens } from '../../../../theme'
 import { TERMINAL_FONT_FAMILY } from './terminalFont'
-import { createXtermTerminal } from './xtermInstance'
+import { createXtermTerminal, xtermTerminalRenderer } from './xtermInstance'
 
 vi.mock('@xterm/xterm', () => ({
   Terminal: vi.fn(),
@@ -112,6 +112,11 @@ const createRawTerminal = (): RawTerminalMock => {
 describe('xtermInstance', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  test('exports the default xterm renderer adapter', () => {
+    expect(xtermTerminalRenderer.id).toBe('xterm')
+    expect(xtermTerminalRenderer.createInstance).toBe(createXtermTerminal)
   })
 
   test('creates a themed terminal surface with a loaded fit addon', () => {

--- a/src/features/terminal/components/TerminalPane/xtermInstance.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.ts
@@ -7,6 +7,7 @@ import type {
   TerminalInstance,
   TerminalParser,
   TerminalRendererHandle,
+  TerminalRendererAdapter,
   TerminalSurface,
   TerminalTheme,
   TerminalViewportReader,
@@ -35,6 +36,11 @@ export const createXtermTerminal = (): TerminalInstance => {
     fitController: fitAddon,
     attachRenderer: () => attachXtermRenderer(terminal),
   }
+}
+
+export const xtermTerminalRenderer: TerminalRendererAdapter = {
+  id: 'xterm',
+  createInstance: createXtermTerminal,
 }
 
 const createTerminalSurface = (terminal: Terminal): TerminalSurface => ({

--- a/src/features/terminal/types/index.ts
+++ b/src/features/terminal/types/index.ts
@@ -271,3 +271,9 @@ export interface TerminalInstance {
   fitController: TerminalFitController
   attachRenderer: () => TerminalRendererHandle
 }
+
+/** Adapter that creates complete terminal renderer instances. */
+export interface TerminalRendererAdapter {
+  readonly id: string
+  createInstance: () => TerminalInstance
+}


### PR DESCRIPTION
## Summary

- add a renderer adapter registry for terminal instance creation
- register xterm as the default adapter without requiring `createTerminalInstance` to import the xterm factory directly
- add coverage showing a non-xterm adapter can create terminal instances without calling the xterm adapter

## Impact

This keeps the current xterm behavior intact while making the next Ghostty experiment a matter of registering/selecting another adapter behind the shared `TerminalInstance` contract.

## Validation

- `npx vitest run src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts src/features/terminal/components/TerminalPane/terminalInstance.test.ts src/features/terminal/components/TerminalPane/xtermInstance.test.ts src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx src/features/terminal/types/index.test.ts`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`