### PR TITLE
fix(agent-status): reserve NOW card placeholder (VIM-137)

### DIFF
--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -1287,6 +1287,9 @@ describe('AgentStatusPanel — live action card', () => {
 
     expect(screen.getByText('NOW')).toBeInTheDocument()
     expect(screen.getByText('LIVE')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('live-action-placeholder-card')
+    ).not.toBeInTheDocument()
   })
 
   test('does not duplicate a running exec_command in Tool Calls and NOW', () => {
@@ -1318,7 +1321,7 @@ describe('AgentStatusPanel — live action card', () => {
     ).toHaveLength(1)
   })
 
-  test('omits the live card when no tool call is active', () => {
+  test('reserves the live-action slot when no tool call is active', () => {
     render(
       <AgentStatusPanel
         {...defaultProps}
@@ -1329,6 +1332,10 @@ describe('AgentStatusPanel — live action card', () => {
 
     expect(screen.queryByText('NOW')).not.toBeInTheDocument()
     expect(screen.queryByTestId('live-action-card')).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('live-action-placeholder-card')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('LIVE')).not.toBeInTheDocument()
   })
 
   test('moves a completed exec_command into activity history', () => {
@@ -1360,6 +1367,10 @@ describe('AgentStatusPanel — live action card', () => {
 
     expect(screen.queryByText('NOW')).not.toBeInTheDocument()
     expect(screen.queryByTestId('live-action-card')).toBeNull()
+    expect(
+      screen.getByTestId('live-action-placeholder-card')
+    ).toBeInTheDocument()
+
     expect(
       screen.getByRole('button', { name: /activity\s*1/i })
     ).toBeInTheDocument()
@@ -1421,6 +1432,10 @@ describe('AgentStatusPanel — live action card', () => {
 
     expect(screen.queryByText('NOW')).not.toBeInTheDocument()
     expect(screen.queryByTestId('live-action-card')).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('live-action-placeholder-card')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('LIVE')).not.toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /activity\s*1/i })
     ).toBeInTheDocument()

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -17,7 +17,7 @@ import { ToolCallSummary } from '../ToolCallSummary'
 import { FilesChanged } from '../FilesChanged'
 import { TestResults } from '../TestResults'
 import { ActivityFeed } from '../ActivityFeed'
-import { LiveActionCard } from '../LiveActionCard'
+import { LiveActionCard, LiveActionPlaceholderCard } from '../LiveActionCard'
 import { useActivityEvents } from '../../hooks/useActivityEvents'
 import { matchChangedFile } from '../../utils/matchChangedFile'
 import {
@@ -601,6 +601,7 @@ export const AgentStatusPanel = ({
                   onActivate={canActivate ? handleLiveActivate : undefined}
                 />
               )}
+              {runningEvent === null && <LiveActionPlaceholderCard />}
               <ActivityFeed events={feedEvents} />
               <FilesChanged
                 files={effectiveFiles}

--- a/src/features/agent-status/components/LiveActionCard.test.tsx
+++ b/src/features/agent-status/components/LiveActionCard.test.tsx
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { LiveActionCard } from './LiveActionCard'
+import { LiveActionCard, LiveActionPlaceholderCard } from './LiveActionCard'
 import type { ToolActivityEvent } from '../types/activityEvent'
 
 const now = new Date('2026-04-22T12:00:00Z')
@@ -79,6 +79,19 @@ describe('LiveActionCard — presentation', () => {
     render(<LiveActionCard event={runningEvent()} now={now} />)
 
     expect(screen.getByText(/^running\s+18s$/)).toBeInTheDocument()
+  })
+})
+
+describe('LiveActionPlaceholderCard — presentation', () => {
+  test('reserves the live-action footprint without showing active status', () => {
+    render(<LiveActionPlaceholderCard />)
+
+    expect(
+      screen.getByTestId('live-action-placeholder-card')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('NOW')).not.toBeInTheDocument()
+    expect(screen.queryByText('LIVE')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('live-action-card')).not.toBeInTheDocument()
   })
 })
 

--- a/src/features/agent-status/components/LiveActionCard.tsx
+++ b/src/features/agent-status/components/LiveActionCard.tsx
@@ -19,6 +19,25 @@ interface LiveActionCardProps {
 const SECTION_LABEL =
   'mb-2 px-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-on-surface-muted'
 
+const LIVE_ACTION_SLOT = 'px-4 pb-3 pt-3.5'
+
+const LIVE_ACTION_CARD =
+  'min-h-[72px] rounded-lg border px-3 py-2.5 outline-none transition-colors'
+
+export const LiveActionPlaceholderCard = (): ReactElement => (
+  <div
+    data-testid="live-action-placeholder-slot"
+    className={LIVE_ACTION_SLOT}
+    aria-hidden="true"
+  >
+    <div className={SECTION_LABEL}>&nbsp;</div>
+    <div
+      data-testid="live-action-placeholder-card"
+      className={`${LIVE_ACTION_CARD} border-outline-variant/[0.08] bg-surface-container/30`}
+    />
+  </div>
+)
+
 export const LiveActionCard = ({
   event,
   now,
@@ -53,7 +72,7 @@ export const LiveActionCard = ({
       aria-label={`${verb} ${pathLabel ?? event.body}`}
       onClick={interactive ? onActivate : undefined}
       onKeyDown={handleKeyDown}
-      className={`rounded-lg border border-primary-container/20 bg-surface-container-high px-3 py-2.5 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary-container/50 ${
+      className={`${LIVE_ACTION_CARD} border-primary-container/20 bg-surface-container-high focus-visible:ring-2 focus-visible:ring-primary-container/50 ${
         interactive
           ? 'cursor-pointer hover:border-primary-container/40 hover:bg-surface-container-highest'
           : ''
@@ -100,7 +119,7 @@ export const LiveActionCard = ({
   )
 
   return (
-    <div className="px-4 pb-3 pt-3.5">
+    <div className={LIVE_ACTION_SLOT}>
       <div className={SECTION_LABEL}>NOW</div>
       <Tooltip
         content={<ActivityTooltipContent event={event} now={now} />}


### PR DESCRIPTION
## Summary

- Keep a reserved NOW-card footprint mounted when no tool action is active.
- Swap the inert placeholder for the real `LiveActionCard` only while a genuine running event exists.
- Keep inactive/completed states free of the visible `NOW` label, `LIVE` badge, focus target, and tooltip so the placeholder does not imply stale activity.
- Add component and panel regressions for active, inactive, and completed tool states.

## Why

After the replay-event fix, the remaining visual polish is the height change when the NOW card appears or disappears. The placeholder keeps the right sidebar body geometry stable without reintroducing fake active state.

## Validation

- `npx vitest run src/features/agent-status/components/LiveActionCard.test.tsx`
- `npx vitest run src/features/agent-status/components/AgentStatusPanel/index.test.tsx`
- `npx eslint src/features/agent-status/components/LiveActionCard.tsx src/features/agent-status/components/LiveActionCard.test.tsx src/features/agent-status/components/AgentStatusPanel/index.tsx src/features/agent-status/components/AgentStatusPanel/index.test.tsx`
- `npm run type-check`
- `git diff --check`
- `npm run test`: 289 files passed, 3727 tests passed, 3 skipped
- pre-push `npm run test`: 289 files passed, 3727 tests passed, 3 skipped

Linear: VIM-137