### PR TITLE
refactor(terminal): add renderer focus scope

### DIFF
--- a/docs/explorations/ghostty-terminal-review-batches.md
+++ b/docs/explorations/ghostty-terminal-review-batches.md
@@ -1,0 +1,114 @@
+# Ghostty Terminal Review Batches
+
+Date: 2026-06-16
+
+Branch family: `umbrella/ghostty-terminal-investigation`
+
+## Purpose
+
+The Ghostty exploration should continue as small, reviewable PRs. Each batch
+should remove one kind of xterm coupling or prove one adapter boundary. Do not
+bundle renderer experiments, keyboard behavior, E2E bridge behavior, and
+comment-only cleanup into the same PR.
+
+The production default remains xterm until a real Ghostty adapter is explicitly
+selected behind a reviewed switch.
+
+## Review Rules
+
+- One runtime behavior change per PR.
+- Keep xterm as the default renderer until the Ghostty path is opt-in.
+- Every runtime decoupling PR needs a fake or non-xterm terminal test.
+- Keep xterm adapter internals in `xtermInstance.ts` and adapter tests.
+- Treat `.xterm-*` DOM selectors outside the adapter as legacy compatibility
+  fallbacks, not primary integration points.
+- Do not mix broad comment/test wording cleanup with runtime logic unless the
+  same lines are already touched by the behavior change.
+
+## Batch 1: Terminal Focus Ownership
+
+Branch: `codex/ghostty-terminal-focus-ownership`
+
+Scope:
+
+- Mark the terminal renderer host with a generic terminal focus scope.
+- Replace `usePaneShortcuts` checks for `.xterm-helper-textarea` with the
+  renderer-neutral focus scope helper.
+- Extend fake-terminal coverage to prove `Body` exposes the focus scope without
+  relying on an xterm DOM class.
+
+Why this is its own batch:
+
+Keyboard shortcut capture is user-facing behavior. Keeping it isolated makes it
+easy to review whether the pass-through and reclaim behavior is unchanged.
+
+Validation:
+
+- `npx vitest run src/features/terminal/terminalFocusScope.test.ts src/features/terminal/hooks/usePaneShortcuts.test.ts src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx`
+- `npm --ignore-scripts run lint`
+- `npm --ignore-scripts run format:check`
+- `npx tsc -b --pretty false`
+
+## Batch 2: E2E Buffer Fallback Boundary
+
+Scope:
+
+- Keep `TerminalViewportReader` as the primary E2E buffer source.
+- Make the remaining `.xterm-rows` path in `src/lib/e2e-bridge.ts` explicit as
+  a legacy DOM fallback.
+- Ensure tests cover a renderer with no xterm DOM rows and a stale DOM rows
+  fallback case.
+
+Why this is separate:
+
+Automation buffer reads affect CI and E2E diagnostics. They should not be
+reviewed together with keyboard shortcut behavior.
+
+## Batch 3: Burner Popup Terminal Focus Language
+
+Scope:
+
+- Rename xterm-specific comments and test fixture names in
+  `BurnerTerminalPopup` to generic terminal language.
+- Keep behavior unchanged unless a real focus-scope bug is found.
+
+Why this is separate:
+
+Most of this batch is wording and test fixture cleanup. It is useful, but it
+should not obscure runtime behavior changes.
+
+## Batch 4: Workspace Shortcut and Terminal Zone Residue
+
+Scope:
+
+- Update remaining workspace shortcut tests and comments that describe terminal
+  focus as xterm-specific.
+- Preserve the current guards that avoid stealing terminal and CodeMirror input.
+
+Why this is separate:
+
+These files are adjacent to several global keyboard shortcuts. Even if the
+changes are mostly comments and fixtures, they deserve a small review surface.
+
+## Batch 5: Renderer Selection and Ghostty Adapter Spike
+
+Scope:
+
+- Add an explicit opt-in renderer selection path.
+- Prototype a second adapter only behind that selection path.
+- Decide whether the prototype consumes frontend string chunks or requires a
+  raw-byte PTY path first.
+
+Why this comes last:
+
+The earlier batches make the app less xterm-shaped without claiming Ghostty
+support. A Ghostty adapter should start only after the generic contracts, focus
+ownership, E2E reads, and keyboard behavior are reviewed.
+
+## Non-goals For These Batches
+
+- Do not set `TERM=xterm-ghostty` while xterm remains the default renderer.
+- Do not replace xterm production behavior in the cleanup batches.
+- Do not move PTY ownership out of the backend sidecar as part of renderer
+  cleanup.
+- Do not claim Ghostty support until a real adapter exists and is opt-in.

--- a/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
@@ -1,9 +1,13 @@
-import { render, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
 import { Body } from './Body'
 import { createTerminalInstance } from './terminalInstance'
 import { useTerminal, type UseTerminalReturn } from '../../hooks/useTerminal'
 import type { ITerminalService } from '../../services/terminalService'
+import {
+  TERMINAL_FOCUS_SCOPE_ATTRIBUTE,
+  TERMINAL_FOCUS_SCOPE_VALUE,
+} from '../../terminalFocusScope'
 import type {
   TerminalDisposable,
   TerminalInstance,
@@ -167,6 +171,11 @@ test('Body can run against a non-xterm TerminalInstance contract', async () => {
 
   expect(useTerminal).toHaveBeenCalledWith(
     expect.objectContaining({ terminal: fake.terminal })
+  )
+
+  expect(screen.getByTestId('terminal-pane')).toHaveAttribute(
+    TERMINAL_FOCUS_SCOPE_ATTRIBUTE,
+    TERMINAL_FOCUS_SCOPE_VALUE
   )
 
   expect(fake.emitOsc(7, 'file://localhost/tmp/fake-project')).toBe(true)

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -27,6 +27,7 @@ import {
   clearTerminalCache,
   disposeTerminalSession,
 } from '../../terminalRegistry'
+import { TERMINAL_FOCUS_SCOPE_VALUE } from '../../terminalFocusScope'
 import { registerPtySession, unregisterPtySession } from '../../ptySessionMap'
 import { TerminalContextMenu } from '../TerminalContextMenu'
 import {
@@ -856,6 +857,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         ref={containerRef}
         data-testid="terminal-pane"
         data-pty-id={sessionId}
+        data-terminal-focus-scope={TERMINAL_FOCUS_SCOPE_VALUE}
         className="h-full w-full"
       />
       <TerminalContextMenu

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -3,6 +3,10 @@ import { renderHook } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 import { emptyActivity } from '../../sessions/constants'
 import type { LayoutId, Session } from '../../sessions/types'
+import {
+  TERMINAL_FOCUS_SCOPE_ATTRIBUTE,
+  TERMINAL_FOCUS_SCOPE_VALUE,
+} from '../terminalFocusScope'
 import { usePaneShortcuts } from './usePaneShortcuts'
 
 const makeSession = (
@@ -432,11 +436,16 @@ describe('usePaneShortcuts container reclaim extensions', () => {
     document.body.removeChild(dialog)
   })
 
-  test('Ctrl+1 on active pane inside xterm helper textarea passes through', () => {
+  test('Ctrl+1 on active pane inside terminal focus scope passes through', () => {
     const onTerminalZoneFocus = vi.fn()
+    const scope = document.createElement('div')
+    scope.setAttribute(
+      TERMINAL_FOCUS_SCOPE_ATTRIBUTE,
+      TERMINAL_FOCUS_SCOPE_VALUE
+    )
     const textarea = document.createElement('textarea')
-    textarea.className = 'xterm-helper-textarea'
-    document.body.appendChild(textarea)
+    scope.appendChild(textarea)
+    document.body.appendChild(scope)
     textarea.focus()
 
     renderHook(() =>
@@ -455,10 +464,10 @@ describe('usePaneShortcuts container reclaim extensions', () => {
     expect(onTerminalZoneFocus).not.toHaveBeenCalled()
     expect(event.preventDefaultSpy).not.toHaveBeenCalled()
 
-    document.body.removeChild(textarea)
+    document.body.removeChild(scope)
   })
 
-  test('Ctrl+1 on active pane outside xterm reclaims terminal focus', () => {
+  test('Ctrl+1 on active pane outside terminal focus scope reclaims terminal focus', () => {
     const onTerminalZoneFocus = vi.fn()
     blurActiveElement()
 

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -8,6 +8,7 @@ import {
   DIALOG_SELECTOR,
   DOCK_CONTAINER_ID,
 } from '../../workspace/containerIds'
+import { isElementInTerminalFocusScope } from '../terminalFocusScope'
 
 // Derive the cycle order from the canonical LAYOUTS record so a future
 // LayoutId added in `layouts.ts` automatically participates in ⌘\
@@ -66,7 +67,7 @@ export const usePaneShortcuts = ({
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
       // Match exactly the modifier the toolbar advertises. On macOS
-      // (preferModifier='meta'), Ctrl+1 flows through to xterm so
+      // (preferModifier='meta'), Ctrl+1 flows through to the terminal so
       // terminal apps keep their Ctrl-shortcuts. Same logic mirrored
       // on Linux/Windows for Cmd combos. (Codex P2 cycle 10.)
       const mod = preferModifierRef.current
@@ -136,7 +137,7 @@ export const usePaneShortcuts = ({
           } else if (paneIndex < activeSession.panes.length) {
             const target = activeSession.panes[paneIndex]
             if (target.active) {
-              if (activeElement?.closest('.xterm-helper-textarea')) {
+              if (isElementInTerminalFocusScope(activeElement)) {
                 return
               }
 

--- a/src/features/terminal/terminalFocusScope.test.ts
+++ b/src/features/terminal/terminalFocusScope.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+import {
+  isElementInTerminalFocusScope,
+  TERMINAL_FOCUS_SCOPE_ATTRIBUTE,
+  TERMINAL_FOCUS_SCOPE_SELECTOR,
+  TERMINAL_FOCUS_SCOPE_VALUE,
+} from './terminalFocusScope'
+
+describe('terminalFocusScope', () => {
+  test('matches descendants inside a terminal focus scope', () => {
+    const scope = document.createElement('div')
+    scope.setAttribute(
+      TERMINAL_FOCUS_SCOPE_ATTRIBUTE,
+      TERMINAL_FOCUS_SCOPE_VALUE
+    )
+    const child = document.createElement('textarea')
+    scope.appendChild(child)
+    document.body.appendChild(scope)
+
+    expect(scope.matches(TERMINAL_FOCUS_SCOPE_SELECTOR)).toBe(true)
+    expect(isElementInTerminalFocusScope(child)).toBe(true)
+
+    document.body.removeChild(scope)
+  })
+
+  test('rejects elements outside a terminal focus scope', () => {
+    const element = document.createElement('textarea')
+    document.body.appendChild(element)
+
+    expect(isElementInTerminalFocusScope(element)).toBe(false)
+    expect(isElementInTerminalFocusScope(null)).toBe(false)
+
+    document.body.removeChild(element)
+  })
+})

--- a/src/features/terminal/terminalFocusScope.ts
+++ b/src/features/terminal/terminalFocusScope.ts
@@ -1,0 +1,9 @@
+export const TERMINAL_FOCUS_SCOPE_ATTRIBUTE = 'data-terminal-focus-scope'
+
+export const TERMINAL_FOCUS_SCOPE_VALUE = 'true'
+
+export const TERMINAL_FOCUS_SCOPE_SELECTOR = `[${TERMINAL_FOCUS_SCOPE_ATTRIBUTE}="${TERMINAL_FOCUS_SCOPE_VALUE}"]`
+
+export const isElementInTerminalFocusScope = (
+  element: Element | null
+): boolean => Boolean(element?.closest(TERMINAL_FOCUS_SCOPE_SELECTOR))


### PR DESCRIPTION
## Summary

- add a renderer-neutral terminal focus-scope marker and helper
- route `usePaneShortcuts` active-pane pass-through through that generic scope instead of `.xterm-helper-textarea`
- extend fake-terminal coverage so `Body` proves the marker exists without relying on xterm DOM classes
- document the remaining Ghostty/xterm exploration as reviewable batches

## Impact

This keeps current shortcut behavior intact while removing a production keyboard-path dependency on xterm's hidden textarea class. Future renderer adapters can participate in terminal focus ownership by hosting input focus under the shared marker.

## Batch Plan

This is Batch 1 from `docs/explorations/ghostty-terminal-review-batches.md`: terminal focus ownership. E2E buffer fallback cleanup, Burner popup wording, workspace shortcut residue, and Ghostty adapter selection are intentionally left for later PRs.

## Validation

- `npx vitest run src/features/terminal/terminalFocusScope.test.ts src/features/terminal/hooks/usePaneShortcuts.test.ts src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`