### PR TITLE
test(terminal): generalize burner focus language

### DIFF
--- a/src/features/terminal/components/BurnerTerminalPopup/index.test.tsx
+++ b/src/features/terminal/components/BurnerTerminalPopup/index.test.tsx
@@ -5,9 +5,9 @@ import { BurnerTerminalPopup } from './index'
 import type { ITerminalService } from '../../services/terminalService'
 import type { NotifyPaneReady } from '../../hooks/useTerminal'
 
-// Body owns the xterm instance (canvas/webgl), which jsdom can't render. Stub
-// it as a forwardRef exposing a focusTerminal spy and capturing the onPaneReady
-// it receives, so the popup's focus + drain wiring is unit-tested in isolation;
+// Body owns the terminal renderer instance, which jsdom can't render. Stub it
+// as a forwardRef exposing a focusTerminal spy and capturing the onPaneReady it
+// receives, so the popup's focus + drain wiring is unit-tested in isolation;
 // Body's attach behavior is covered in Body.test.tsx.
 const { focusTerminal, captured } = vi.hoisted(() => ({
   focusTerminal: vi.fn(),
@@ -36,9 +36,9 @@ vi.mock('../TerminalPane/Body', async () => {
           data-has-on-ready={props.onPaneReady ? 'yes' : 'no'}
           data-has-on-cwd-change={props.onCwdChange ? 'yes' : 'no'}
         >
-          {/* xterm renders a textarea for keyboard input; keep one in the stub
-              so focus-trap tests can simulate the terminal holding focus. */}
-          <textarea data-testid="xterm-textarea" />
+          {/* Terminal renderers typically own an input element; keep one in the
+              stub so focus-trap tests can simulate the terminal holding focus. */}
+          <textarea data-testid="terminal-input" />
         </div>
       )
     }),
@@ -211,7 +211,7 @@ test('Escape hides the popup instead of reaching the terminal', () => {
   render(popup(true, { onHide }))
 
   // Fire on the terminal stub so the event captures up through the overlay —
-  // the capture listener must intercept before the keydown reaches xterm.
+  // the capture listener must intercept before the keydown reaches the renderer.
   fireEvent.keyDown(screen.getByTestId('body-stub'), { key: 'Escape' })
 
   expect(onHide).toHaveBeenCalledTimes(1)
@@ -277,7 +277,7 @@ test('refocuses the burner terminal after aligning so typing continues there', (
     screen.getByRole('button', { name: /align burner to pane directory/i })
   )
 
-  // The button took focus on click; hand it back to xterm so keys land there.
+  // The button took focus on click; hand it back to the terminal so keys land there.
   expect(onAlignCwd).toHaveBeenCalledTimes(1)
   expect(focusTerminal).toHaveBeenCalled()
 })
@@ -327,10 +327,10 @@ test('backdrop dismiss button is removed from the tab order', () => {
   ).toHaveAttribute('tabIndex', '-1')
 })
 
-test('Tab from terminal passes through to xterm for shell autocomplete', () => {
+test('Tab from terminal passes through for shell autocomplete', () => {
   render(popup(true, { onAlignCwd: vi.fn() }))
 
-  const textarea = screen.getByTestId('xterm-textarea')
+  const textarea = screen.getByTestId('terminal-input')
   textarea.focus()
   expect(textarea).toHaveFocus()
 
@@ -371,10 +371,10 @@ test('Shift+Tab from first button wraps focus back to the terminal', () => {
   expect(focusTerminal).toHaveBeenCalledTimes(1)
 })
 
-test('Shift+Tab from terminal passes through to xterm', () => {
+test('Shift+Tab from terminal passes through to the renderer', () => {
   render(popup(true, { onAlignCwd: vi.fn() }))
 
-  const textarea = screen.getByTestId('xterm-textarea')
+  const textarea = screen.getByTestId('terminal-input')
   textarea.focus()
   expect(textarea).toHaveFocus()
 

--- a/src/features/terminal/components/BurnerTerminalPopup/index.tsx
+++ b/src/features/terminal/components/BurnerTerminalPopup/index.tsx
@@ -75,7 +75,7 @@ export interface BurnerTerminalPopupProps {
  * `<Body>` in `attach` mode against `burnerPtyId`.
  *
  * Because it renders `<Body>` directly (no `TerminalPane` wrapper to drive
- * focus), it moves DOM focus into the burner xterm itself when shown —
+ * focus), it moves DOM focus into the burner terminal itself when shown —
  * otherwise a chord-opened popup leaves focus on the pane underneath and sends
  * keystrokes there.
  */
@@ -111,10 +111,10 @@ export const BurnerTerminalPopup = ({
     }
   }, [open])
 
-  // Esc hides the popup. The burner xterm holds focus, so without a native
+  // Esc hides the popup. The burner terminal holds focus, so without a native
   // capture-phase intercept the keydown reaches the terminal and is sent to the
-  // shell as ^[. Capturing on the overlay fires before xterm's textarea handler.
-  // Tab / Shift+Tab must pass through while the xterm body has focus so shell
+  // shell as ^[. Capturing on the overlay fires before the renderer input handler.
+  // Tab / Shift+Tab must pass through while the terminal body has focus so shell
   // autocomplete and reverse-complete keep working. Toolbar focus still cycles
   // back to the terminal when a toolbar button owns focus.
   useEffect(() => {
@@ -211,7 +211,7 @@ export const BurnerTerminalPopup = ({
     }
   }, [open, onHide])
 
-  // First open: focus once Body signals its xterm attached (also drains).
+  // First open: focus once Body signals its terminal attached (also drains).
   const handlePaneReady = useCallback<NotifyPaneReady>(
     (ptyId, handler) => {
       const release = onPaneReady?.(ptyId, handler)
@@ -224,7 +224,7 @@ export const BurnerTerminalPopup = ({
     [onPaneReady]
   )
 
-  // Aligning moves DOM focus onto the toolbar button; hand it back to the xterm
+  // Aligning moves DOM focus onto the toolbar button; hand it back to the terminal
   // so the next keystrokes land in the burner instead of the document.
   const handleAlign = useCallback((): void => {
     onAlignCwd?.()


### PR DESCRIPTION
## Summary

- replace xterm-specific BurnerTerminalPopup comments with renderer-neutral terminal language
- rename the test stub input from `xterm-textarea` to `terminal-input`
- keep the existing focus and Tab pass-through behavior unchanged

## Impact

This removes misleading xterm-specific wording from the burner popup tests and comments while keeping the runtime behavior untouched. It keeps the popup aligned with the terminal adapter boundary introduced in the previous batches.

## Batch Plan

This is Batch 3 from `docs/explorations/ghostty-terminal-review-batches.md`: Burner popup terminal focus language. It intentionally does not include workspace shortcut cleanup or renderer selection work.

## Validation

- `npx vitest run src/features/terminal/components/BurnerTerminalPopup/index.test.tsx`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`