### PR TITLE
test(terminal): generalize workspace terminal wording

### DIFF
--- a/src/features/sessions/components/Tabs.tsx
+++ b/src/features/sessions/components/Tabs.tsx
@@ -55,7 +55,7 @@ export const Tabs = ({
 
   // STUB: tab cycling between sessions belongs on a global keybinding
   // (Cmd+Shift+] / [) routed through the command palette — see #177.
-  // xterm.js holds focus inside the terminal, so in-component
+  // The terminal renderer holds focus inside the terminal, so in-component
   // arrow-key handlers on the tab divs never fire; the user can't
   // Tab into the strip without leaving the terminal first. The
   // previous in-component handler was removed for that reason.
@@ -145,7 +145,7 @@ export const Tabs = ({
         role="tablist"
         aria-label="Open sessions"
         // Arrow-key cycling between tabs is required by WAI-ARIA Tabs
-        // §3.27, but cannot be hosted on the tablist itself — xterm.js
+        // §3.27, but cannot be hosted on the tablist itself — the renderer
         // holds keyboard focus inside the terminal pane, so an
         // in-component arrow handler would never fire. The proper fix
         // is the global Cmd+Shift+]/[ shortcut tracked in #177; in the

--- a/src/features/terminal/Terminal.integration.test.tsx
+++ b/src/features/terminal/Terminal.integration.test.tsx
@@ -137,7 +137,7 @@ describe('Terminal Integration Tests', () => {
         />
       )
 
-      // Wait for terminal to be ready (xterm.js initialized)
+      // Wait for terminal to be ready
       const terminalPane = await screen.findByTestId('terminal-pane')
       expect(terminalPane).toBeInTheDocument()
 
@@ -155,7 +155,7 @@ describe('Terminal Integration Tests', () => {
       expect(sessions).toHaveLength(1)
     })
 
-    test('emits PTY data events to xterm output', async (): Promise<void> => {
+    test('emits PTY data events to terminal output', async (): Promise<void> => {
       render(
         <TestTerminalPane
           service={mockServiceInstance}
@@ -177,7 +177,7 @@ describe('Terminal Integration Tests', () => {
       // Emit data to the terminal (simulate PTY output)
       mockServiceInstance.emitData(sessionId, 'Welcome to the terminal!\r\n')
 
-      // Wait for the data to appear in xterm
+      // Wait for the data to appear in the terminal
       await waitFor(() => {
         const terminalPane = screen.getByTestId('terminal-pane')
         const content = terminalPane.textContent || ''

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -53,7 +53,7 @@ export interface TerminalPaneProps {
 }
 
 export interface TerminalPaneHandle {
-  /** Returns true if xterm body focused successfully, false if not ready. */
+  /** Returns true if the terminal body focused successfully, false if not ready. */
   focusTerminal(): boolean
 }
 
@@ -89,7 +89,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     // Seeded `undefined` (NOT `pane.active`) so the first effect run can detect
     // initial mount distinctly from a stable `true → true` re-render. A pane
     // born active (createSession, addPane, restored on app launch) must focus
-    // on first paint — otherwise its xterm stays unfocused with no transition
+    // on first paint — otherwise its terminal stays unfocused with no transition
     // for the rising-edge branch below to catch.
     const wasActiveRef = useRef<boolean | undefined>(undefined)
     const [ptyStatus, setPtyStatus] = useState<PtyStatus>('idle')
@@ -148,7 +148,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     const handleContainerClick = useCallback((): void => {
       // SplitView owns click-to-focus state changes. If this pane is inactive,
       // the slot click flips pane.active first; the rising-edge effect above
-      // moves DOM focus into xterm after React commits the active state.
+      // moves DOM focus into the terminal after React commits the active state.
       if (!pane.active) {
         return
       }

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -178,7 +178,7 @@ describe('useTerminal', () => {
 
     const sessionId = result.current.session!.id
 
-    // Simulate user typing in xterm
+    // Simulate user typing in the terminal renderer
     mockTerminal._mockTriggerData('ls\r')
 
     await waitFor(() => {

--- a/src/features/terminal/orchestration/usePtyBufferDrain.ts
+++ b/src/features/terminal/orchestration/usePtyBufferDrain.ts
@@ -59,7 +59,7 @@ export const usePtyBufferDrain = (): PtyBufferDrain => {
 
   const notifyPaneReady = useCallback<PtyBufferDrain['notifyPaneReady']>(
     (ptyId, handler) => {
-      // F6: dead pane already tombstoned — caller's xterm subscription is
+      // F6: dead pane already tombstoned — caller's terminal subscription is
       // a no-op for this id, drain nothing, return a no-op release so
       // the pane unmount cleanup doesn't re-arm pending state.
       if (tombstonedPanesRef.current.has(ptyId)) {

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -7,7 +7,7 @@ import * as useCodeMirrorModule from '../editor/hooks/useCodeMirror'
 import * as useVimModeModule from '../editor/hooks/useVimMode'
 import { createTerminalService } from '../terminal/services/terminalService'
 
-// Mock TerminalPane to avoid xterm.js issues in tests
+// Mock TerminalPane to avoid terminal renderer work in tests
 vi.mock('../terminal/components/TerminalPane', () => ({
   TerminalPane: vi.fn(() => (
     <div data-testid="terminal-pane-mock">Mocked TerminalPane</div>

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -12,7 +12,7 @@ import type {
   UseFeedbackBatchReturn,
 } from '../diff/hooks/useFeedbackBatch'
 
-// Mock TerminalPane / TerminalZone deps to avoid xterm.js in jsdom
+// Mock TerminalPane / TerminalZone deps to avoid terminal renderer work in jsdom
 interface MockTerminalPaneProps {
   onCwdChange?: (cwd: string) => void
 }

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -105,7 +105,7 @@ const mockMatchMedia = (matches: boolean): (() => void) => {
   }
 }
 
-// Mock TerminalPane to avoid xterm.js issues in tests. Surface `pane.cwd`
+// Mock TerminalPane to avoid terminal renderer work in tests. Surface `pane.cwd`
 // as a data attribute so tests can observe the agent-cwd → pane.cwd bridge
 // without driving the full terminal mock surface.
 vi.mock('../terminal/components/TerminalPane', () => ({

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -2336,7 +2336,7 @@ export const WorkspaceView = (): ReactElement => {
         onCancel={handleCancel}
       />
 
-      {/* Drag overlay — prevents iframes/xterm from stealing mouse events */}
+      {/* Drag overlay — prevents embedded panes from stealing mouse events */}
       {isDragging && <div className="fixed inset-0 z-50 cursor-col-resize" />}
 
       {paneRenameNode}

--- a/src/features/workspace/WorkspaceView.verification.test.tsx
+++ b/src/features/workspace/WorkspaceView.verification.test.tsx
@@ -9,7 +9,7 @@ import { describe, test, expect, vi } from 'vitest'
 import fs from 'fs'
 import path from 'path'
 
-// Mock TerminalPane to avoid xterm.js issues in tests
+// Mock TerminalPane to avoid terminal renderer work in tests
 vi.mock('../terminal/components/TerminalPane', () => ({
   TerminalPane: vi.fn(() => (
     <div data-testid="terminal-pane-mock">Mocked TerminalPane</div>

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -5,7 +5,7 @@ import { describe, test, expect, vi } from 'vitest'
 // @ts-expect-error - tailwind.config.js has no type declarations
 import tailwindConfig from '../../../tailwind.config'
 
-// Mock TerminalPane to avoid xterm.js issues in tests
+// Mock TerminalPane to avoid terminal renderer work in tests
 vi.mock('../terminal/components/TerminalPane', () => ({
   TerminalPane: vi.fn(() => (
     <div data-testid="terminal-pane-mock">Mocked TerminalPane</div>

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -48,7 +48,7 @@ const mockService: ITerminalService = {
   setWorkspaceSessions: vi.fn().mockResolvedValue(undefined),
 }
 
-// Mock TerminalPane to avoid xterm.js issues in tests
+// Mock TerminalPane to avoid terminal renderer work in tests
 vi.mock('../../terminal/components/TerminalPane', () => ({
   TerminalPane: vi.fn(
     ({

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -38,7 +38,7 @@ export interface TerminalZoneProps {
    */
   onSessionRestart?: (sessionId: string) => void
   /**
-   * Temporarily hold xterm fitting while surrounding workspace chrome is being
+   * Temporarily hold terminal fitting while surrounding workspace chrome is being
    * dragged. The active terminal gets one final fit when the drag ends.
    */
   deferTerminalFit?: boolean
@@ -153,7 +153,7 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
         {/* Layout controls live in the workspace top chrome bar (main-stage
             handoff J3) — TerminalZone renders no toolbar of its own. */}
 
-        {/* Terminal content area — relative + absolute inner to give xterm explicit dimensions */}
+        {/* Terminal content area — relative + absolute inner to give the renderer explicit dimensions */}
         <div
           data-testid="terminal-content"
           className="relative min-h-0 flex-1 bg-surface"

--- a/src/features/workspace/hooks/useDockShortcuts.test.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.test.ts
@@ -173,18 +173,17 @@ describe('useDockShortcuts', () => {
     expect(props.openDock).not.toHaveBeenCalled()
   })
 
-  test('Ctrl+e does not fire when focus is inside terminal zone (xterm readline guard)', () => {
-    // xterm uses a hidden textarea for PTY input; Ctrl+e is readline "end-of-line".
+  test('Ctrl+e does not fire when focus is inside terminal zone (readline guard)', () => {
+    // Ctrl+e is readline "end-of-line"; do not steal it from terminal input.
     // The hook must pass through when the event originates from the terminal zone.
     const props = makeProps()
 
     const terminalZone = document.createElement('div')
     terminalZone.setAttribute('data-container-id', TERMINAL_CONTAINER_ID)
-    const xtermTextarea = document.createElement('textarea')
-    xtermTextarea.className = 'xterm-helper-textarea'
-    terminalZone.appendChild(xtermTextarea)
+    const terminalInput = document.createElement('textarea')
+    terminalZone.appendChild(terminalInput)
     document.body.appendChild(terminalZone)
-    xtermTextarea.focus()
+    terminalInput.focus()
 
     renderHook(() => useDockShortcuts(props))
     const event = fire('e', { ctrlKey: true })
@@ -195,16 +194,15 @@ describe('useDockShortcuts', () => {
     document.body.removeChild(terminalZone)
   })
 
-  test('Ctrl+g does not fire when focus is inside terminal zone (xterm abort guard)', () => {
+  test('Ctrl+g does not fire when focus is inside terminal zone (abort guard)', () => {
     const props = makeProps()
 
     const terminalZone = document.createElement('div')
     terminalZone.setAttribute('data-container-id', TERMINAL_CONTAINER_ID)
-    const xtermTextarea = document.createElement('textarea')
-    xtermTextarea.className = 'xterm-helper-textarea'
-    terminalZone.appendChild(xtermTextarea)
+    const terminalInput = document.createElement('textarea')
+    terminalZone.appendChild(terminalInput)
     document.body.appendChild(terminalZone)
-    xtermTextarea.focus()
+    terminalInput.focus()
 
     renderHook(() => useDockShortcuts(props))
     const event = fire('g', { ctrlKey: true })

--- a/src/features/workspace/hooks/useDockShortcuts.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.ts
@@ -72,7 +72,7 @@ export const useDockShortcuts = ({
 
       const key = event.key.toLowerCase()
 
-      // Ctrl+e / Ctrl+g: do not steal vim/readline shortcuts when xterm or
+      // Ctrl+e / Ctrl+g: do not steal vim/readline shortcuts when the terminal or
       // CodeMirror has focus. Ctrl+b is exempt — it only fires when dock is
       // active (checked below), so it can never originate from either surface.
       if ((key === 'e' || key === 'g') && (inTerminalZone || inCodeMirror)) {


### PR DESCRIPTION
## Summary

- remove xterm-specific wording from workspace terminal shortcut comments and tests
- rename terminal-zone fixture variables away from xterm textarea language
- update related TerminalZone, TerminalPane, Tabs, and terminal test comments to renderer-neutral language

## Impact

This is a wording and fixture cleanup batch. It preserves the existing terminal and CodeMirror shortcut guards while keeping tests and comments aligned with the renderer abstraction boundary.

## Batch Plan

This is Batch 4 from `docs/explorations/ghostty-terminal-review-batches.md`: workspace shortcut and terminal zone residue. Renderer selection and Ghostty adapter work remain separate.

## Validation

- `npx vitest run src/features/workspace/hooks/useDockShortcuts.test.ts src/features/workspace/components/TerminalZone.test.tsx src/features/terminal/components/TerminalPane/index.test.tsx src/features/sessions/components/Tabs.test.tsx src/features/terminal/hooks/useTerminal.test.ts src/features/terminal/Terminal.integration.test.tsx`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`