### PR TITLE
refactor(terminal): add renderer selection env

### DIFF
--- a/docs/explorations/ghostty-terminal-review-batches.md
+++ b/docs/explorations/ghostty-terminal-review-batches.md
@@ -94,10 +94,21 @@ changes are mostly comments and fixtures, they deserve a small review surface.
 
 Scope:
 
-- Add an explicit opt-in renderer selection path.
+- Add an explicit opt-in renderer selection path via
+  `VITE_TERMINAL_RENDERER`.
 - Prototype a second adapter only behind that selection path.
 - Decide whether the prototype consumes frontend string chunks or requires a
   raw-byte PTY path first.
+
+Selection contract:
+
+- The app still defaults to the registered `xterm` renderer.
+- A non-empty `VITE_TERMINAL_RENDERER` value must match a registered renderer
+  adapter id.
+- Unknown renderer ids fail during terminal instance creation instead of
+  silently falling back to xterm.
+- This selector does not claim Ghostty support by itself; it only creates the
+  reviewed switch needed before a real Ghostty adapter can be added.
 
 Why this comes last:
 

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { TerminalInstance, TerminalRendererAdapter } from '../../types'
 import {
   _resetTerminalRendererRegistryForTest,
+  configureTerminalRendererFromEnvironment,
   createConfiguredTerminalInstance,
   getTerminalRendererAdapter,
   registerTerminalRendererAdapter,
@@ -64,6 +65,7 @@ const createTerminalRendererAdapter = (
 describe('terminalRendererRegistry', () => {
   afterEach(() => {
     _resetTerminalRendererRegistryForTest()
+    vi.unstubAllEnvs()
     vi.clearAllMocks()
   })
 
@@ -89,6 +91,58 @@ describe('terminalRendererRegistry', () => {
     expect(createConfiguredTerminalInstance()).toBe(instance)
     expect(customRenderer.createInstance).toHaveBeenCalledOnce()
     expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
+  })
+
+  test('creates instances through the renderer selected by environment', () => {
+    const instance = createTerminalInstance()
+    const customRenderer = createTerminalRendererAdapter('custom', instance)
+
+    registerTerminalRendererAdapter(customRenderer)
+    vi.stubEnv('VITE_TERMINAL_RENDERER', 'custom')
+
+    expect(getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'custom' })
+    )
+    expect(createConfiguredTerminalInstance()).toBe(instance)
+    expect(customRenderer.createInstance).toHaveBeenCalledOnce()
+    expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
+  })
+
+  test('keeps xterm as the default when environment selection is blank', () => {
+    const instance = createTerminalInstance()
+    const customRenderer = createTerminalRendererAdapter('custom', instance)
+
+    xtermRendererMocks.createInstance.mockReturnValue(instance)
+    registerTerminalRendererAdapter(customRenderer)
+    setTerminalRendererAdapter('xterm')
+    vi.stubEnv('VITE_TERMINAL_RENDERER', ' ')
+
+    expect(createConfiguredTerminalInstance()).toBe(instance)
+    expect(getTerminalRendererAdapter()).toBe(xtermTerminalRenderer)
+    expect(customRenderer.createInstance).not.toHaveBeenCalled()
+    expect(xtermRendererMocks.createInstance).toHaveBeenCalledOnce()
+  })
+
+  test('rejects unknown environment renderer selection', () => {
+    vi.stubEnv('VITE_TERMINAL_RENDERER', 'missing')
+
+    expect(() => createConfiguredTerminalInstance()).toThrow(
+      'Unknown terminal renderer adapter: missing'
+    )
+  })
+
+  test('allows explicit environment configuration after adapter registration', () => {
+    const instance = createTerminalInstance()
+    const customRenderer = createTerminalRendererAdapter(' custom ', instance)
+
+    registerTerminalRendererAdapter(customRenderer)
+    vi.stubEnv('VITE_TERMINAL_RENDERER', ' custom ')
+
+    configureTerminalRendererFromEnvironment()
+
+    expect(getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'custom' })
+    )
   })
 
   test('rejects unknown renderer adapters', () => {

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
@@ -6,6 +6,19 @@ const terminalRendererAdapters = new Map<string, TerminalRendererAdapter>([
 ])
 
 let activeTerminalRendererId = xtermTerminalRenderer.id
+let hasConfiguredTerminalRendererFromEnvironment = false
+
+const readEnvironmentRendererId = (): string | null => {
+  const rendererId = import.meta.env.VITE_TERMINAL_RENDERER
+
+  if (typeof rendererId !== 'string') {
+    return null
+  }
+
+  const normalizedRendererId = rendererId.trim()
+
+  return normalizedRendererId.length > 0 ? normalizedRendererId : null
+}
 
 export const registerTerminalRendererAdapter = (
   adapter: TerminalRendererAdapter
@@ -30,7 +43,30 @@ export const setTerminalRendererAdapter = (rendererId: string): void => {
   activeTerminalRendererId = rendererId
 }
 
+export const configureTerminalRendererFromEnvironment = (): void => {
+  const rendererId = readEnvironmentRendererId()
+
+  if (!rendererId) {
+    hasConfiguredTerminalRendererFromEnvironment = true
+
+    return
+  }
+
+  setTerminalRendererAdapter(rendererId)
+  hasConfiguredTerminalRendererFromEnvironment = true
+}
+
+const ensureTerminalRendererConfigured = (): void => {
+  if (hasConfiguredTerminalRendererFromEnvironment) {
+    return
+  }
+
+  configureTerminalRendererFromEnvironment()
+}
+
 export const getTerminalRendererAdapter = (): TerminalRendererAdapter => {
+  ensureTerminalRendererConfigured()
+
   const adapter = terminalRendererAdapters.get(activeTerminalRendererId)
 
   if (!adapter) {
@@ -42,11 +78,15 @@ export const getTerminalRendererAdapter = (): TerminalRendererAdapter => {
   return adapter
 }
 
-export const createConfiguredTerminalInstance = (): TerminalInstance =>
-  getTerminalRendererAdapter().createInstance()
+export const createConfiguredTerminalInstance = (): TerminalInstance => {
+  ensureTerminalRendererConfigured()
+
+  return getTerminalRendererAdapter().createInstance()
+}
 
 export const _resetTerminalRendererRegistryForTest = (): void => {
   terminalRendererAdapters.clear()
   terminalRendererAdapters.set(xtermTerminalRenderer.id, xtermTerminalRenderer)
   activeTerminalRendererId = xtermTerminalRenderer.id
+  hasConfiguredTerminalRendererFromEnvironment = false
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,7 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_TERMINAL_RENDERER?: string
+}
+
 declare const __APP_VERSION__: string


### PR DESCRIPTION
## Summary

- add an opt-in `VITE_TERMINAL_RENDERER` selection path for registered terminal renderer adapters
- keep xterm as the default when the selector is unset or blank
- reject unknown renderer ids instead of silently falling back to xterm
- document the current selection contract for the Ghostty exploration batch

## Validation

- `npx vitest run src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`