### PR TITLE
feat(terminal): add plain text renderer spike

### DIFF
--- a/docs/explorations/ghostty-terminal-review-batches.md
+++ b/docs/explorations/ghostty-terminal-review-batches.md
@@ -103,12 +103,24 @@ Scope:
 Selection contract:
 
 - The app still defaults to the registered `xterm` renderer.
+- `plain-text` is a selectable prototype adapter that exercises the renderer
+  contract without importing xterm.
 - A non-empty `VITE_TERMINAL_RENDERER` value must match a registered renderer
   adapter id.
 - Unknown renderer ids fail during terminal instance creation instead of
   silently falling back to xterm.
 - This selector does not claim Ghostty support by itself; it only creates the
   reviewed switch needed before a real Ghostty adapter can be added.
+
+Spike finding:
+
+- The prototype consumes the current frontend string chunks and can satisfy the
+  existing `TerminalSurface`/`TerminalParser`/`TerminalViewportReader`
+  contracts for basic pane lifecycle tests.
+- A real Ghostty adapter still needs a separate byte-preserving PTY transport
+  design. The backend currently emits decoded strings with
+  `String::from_utf8_lossy`, so renderer work alone cannot preserve arbitrary
+  terminal bytes across chunk boundaries.
 
 Why this comes last:
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -22,7 +22,22 @@ const setElementSize = (
   })
 }
 
+const createdTerminals = new Set<ReturnType<typeof createPlainTextTerminal>>()
+
+const createTrackedPlainTextTerminal = (): ReturnType<
+  typeof createPlainTextTerminal
+> => {
+  const created = createPlainTextTerminal()
+  createdTerminals.add(created)
+
+  return created
+}
+
 afterEach(() => {
+  createdTerminals.forEach((created) => {
+    created.terminal.dispose()
+  })
+  createdTerminals.clear()
   window.getSelection()?.removeAllRanges()
   document.body.innerHTML = ''
   themeService.apply('obsidian-lens')
@@ -38,7 +53,7 @@ describe('plainTextInstance', () => {
   })
 
   test('opens in a container and reports fitted dimensions', () => {
-    const created = createPlainTextTerminal()
+    const created = createTrackedPlainTextTerminal()
     const resizeHandler = vi.fn()
     const container = document.createElement('div')
 
@@ -60,7 +75,7 @@ describe('plainTextInstance', () => {
   })
 
   test('writes frontend string chunks into the viewport reader', () => {
-    const created = createPlainTextTerminal()
+    const created = createTrackedPlainTextTerminal()
     const callback = vi.fn()
     const container = document.createElement('div')
 
@@ -73,7 +88,7 @@ describe('plainTextInstance', () => {
   })
 
   test('consumes registered OSC handlers without rendering control sequences', () => {
-    const created = createPlainTextTerminal()
+    const created = createTrackedPlainTextTerminal()
     const oscHandler = vi.fn((): boolean => true)
     const container = document.createElement('div')
 
@@ -90,8 +105,25 @@ describe('plainTextInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('before after')
   })
 
+  test('renders OSC sequences when registered handlers decline them', () => {
+    const created = createTrackedPlainTextTerminal()
+    const oscHandler = vi.fn((): boolean => false)
+    const sequence = '\x1b]7;file://localhost/tmp/plain-text-project\x07'
+
+    created.parser.registerOscHandler(7, oscHandler)
+    created.terminal.write(`before ${sequence}after`)
+
+    expect(oscHandler).toHaveBeenCalledWith(
+      'file://localhost/tmp/plain-text-project'
+    )
+
+    expect(created.viewportReader.readVisibleText()).toBe(
+      `before ${sequence}after`
+    )
+  })
+
   test('stops invoking disposed OSC handlers', () => {
-    const created = createPlainTextTerminal()
+    const created = createTrackedPlainTextTerminal()
     const oscHandler = vi.fn((): boolean => true)
     const disposable = created.parser.registerOscHandler(7, oscHandler)
 
@@ -102,7 +134,7 @@ describe('plainTextInstance', () => {
   })
 
   test('emits pasted text and keyboard input through onData', () => {
-    const created = createPlainTextTerminal()
+    const created = createTrackedPlainTextTerminal()
     const dataHandler = vi.fn()
     const container = document.createElement('div')
 
@@ -120,8 +152,42 @@ describe('plainTextInstance', () => {
     expect(dataHandler).toHaveBeenCalledWith('\r')
   })
 
+  test('emits ctrl-letter keyboard input as control sequences', () => {
+    const created = createTrackedPlainTextTerminal()
+    const dataHandler = vi.fn()
+    const container = document.createElement('div')
+
+    setElementSize(container, 640, 360)
+    created.terminal.open(container)
+    created.terminal.onData(dataHandler)
+
+    const input = created.terminal.element?.querySelector('textarea')
+
+    const interrupt = new KeyboardEvent('keydown', {
+      key: 'c',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    const eof = new KeyboardEvent('keydown', {
+      key: 'd',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    input?.dispatchEvent(interrupt)
+    input?.dispatchEvent(eof)
+
+    expect(dataHandler).toHaveBeenCalledWith('\x03')
+    expect(dataHandler).toHaveBeenCalledWith('\x04')
+    expect(interrupt.defaultPrevented).toBe(true)
+    expect(eof.defaultPrevented).toBe(true)
+  })
+
   test('ignores selections that leave the renderer root', () => {
-    const created = createPlainTextTerminal()
+    const created = createTrackedPlainTextTerminal()
     const container = document.createElement('div')
     const sibling = document.createElement('div')
 
@@ -152,7 +218,7 @@ describe('plainTextInstance', () => {
   })
 
   test('notifies selection listeners for native renderer selections', () => {
-    const created = createPlainTextTerminal()
+    const created = createTrackedPlainTextTerminal()
     const listener = vi.fn()
     const container = document.createElement('div')
 
@@ -199,7 +265,7 @@ describe('plainTextInstance', () => {
   })
 
   test('honors renderer key handlers before emitting input', () => {
-    const created = createPlainTextTerminal()
+    const created = createTrackedPlainTextTerminal()
     const dataHandler = vi.fn()
     const keyHandler = vi.fn((): boolean => false)
     const container = document.createElement('div')
@@ -219,7 +285,7 @@ describe('plainTextInstance', () => {
   })
 
   test('applies terminal theme colors', () => {
-    const created = createPlainTextTerminal()
+    const created = createTrackedPlainTextTerminal()
     const theme = themeService.current().terminal
 
     const terminalTheme = {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -87,6 +87,18 @@ describe('plainTextInstance', () => {
     expect(callback).toHaveBeenCalledOnce()
   })
 
+  test('ignores writes after dispose while preserving the callback', () => {
+    const created = createTrackedPlainTextTerminal()
+    const callback = vi.fn()
+
+    created.terminal.write('before')
+    created.terminal.dispose()
+    created.terminal.write('after', callback)
+
+    expect(created.viewportReader.readVisibleText()).toBe('before')
+    expect(callback).toHaveBeenCalledOnce()
+  })
+
   test('retains recent output when scrollback exceeds the line limit', () => {
     const created = createTrackedPlainTextTerminal()
 
@@ -120,6 +132,47 @@ describe('plainTextInstance', () => {
       'file://localhost/tmp/plain-text-project'
     )
     expect(created.viewportReader.readVisibleText()).toBe('before after')
+  })
+
+  test('tries stacked OSC handlers in reverse registration order', () => {
+    const created = createTrackedPlainTextTerminal()
+    const firstHandler = vi.fn((): boolean => true)
+    const secondHandler = vi.fn((): boolean => false)
+
+    created.parser.registerOscHandler(7, firstHandler)
+    created.parser.registerOscHandler(7, secondHandler)
+    created.terminal.write(
+      'before \x1b]7;file://localhost/tmp/plain-text-project\x07after'
+    )
+
+    expect(secondHandler).toHaveBeenCalledWith(
+      'file://localhost/tmp/plain-text-project'
+    )
+
+    expect(firstHandler).toHaveBeenCalledWith(
+      'file://localhost/tmp/plain-text-project'
+    )
+
+    expect(secondHandler.mock.invocationCallOrder[0]).toBeLessThan(
+      firstHandler.mock.invocationCallOrder[0]
+    )
+    expect(created.viewportReader.readVisibleText()).toBe('before after')
+  })
+
+  test('stops stacked OSC handling after the newest handler consumes', () => {
+    const created = createTrackedPlainTextTerminal()
+    const firstHandler = vi.fn((): boolean => true)
+    const secondHandler = vi.fn((): boolean => true)
+
+    created.parser.registerOscHandler(7, firstHandler)
+    created.parser.registerOscHandler(7, secondHandler)
+    created.terminal.write('\x1b]7;file://localhost/tmp/plain-text-project\x07')
+
+    expect(secondHandler).toHaveBeenCalledWith(
+      'file://localhost/tmp/plain-text-project'
+    )
+    expect(firstHandler).not.toHaveBeenCalled()
+    expect(created.viewportReader.readVisibleText()).toBe('')
   })
 
   test('renders OSC sequences when registered handlers decline them', () => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -125,12 +125,14 @@ describe('plainTextInstance', () => {
   test('stops invoking disposed OSC handlers', () => {
     const created = createTrackedPlainTextTerminal()
     const oscHandler = vi.fn((): boolean => true)
+    const sequence = '\x1b]7;file://localhost/tmp/ignored\x07'
     const disposable = created.parser.registerOscHandler(7, oscHandler)
 
     disposable.dispose()
-    created.terminal.write('\x1b]7;file://localhost/tmp/ignored\x07')
+    created.terminal.write(sequence)
 
     expect(oscHandler).not.toHaveBeenCalled()
+    expect(created.viewportReader.readVisibleText()).toBe(sequence)
   })
 
   test('emits pasted text and keyboard input through onData', () => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -23,6 +23,7 @@ const setElementSize = (
 }
 
 afterEach(() => {
+  window.getSelection()?.removeAllRanges()
   document.body.innerHTML = ''
   themeService.apply('obsidian-lens')
   vi.clearAllMocks()
@@ -148,6 +149,48 @@ describe('plainTextInstance', () => {
 
     expect(created.terminal.hasSelection()).toBe(false)
     expect(created.terminal.getSelection()).toBe('')
+  })
+
+  test('notifies selection listeners for native renderer selections', () => {
+    const created = createPlainTextTerminal()
+    const listener = vi.fn()
+    const container = document.createElement('div')
+
+    setElementSize(container, 640, 360)
+    document.body.append(container)
+    created.terminal.open(container)
+    created.terminal.write('inside terminal')
+    created.terminal.onSelectionChange(listener)
+
+    const outputText =
+      created.terminal.element?.querySelector('pre')?.firstChild
+
+    if (!outputText) {
+      throw new Error('selection test requires terminal text node')
+    }
+
+    const range = document.createRange()
+    range.setStart(outputText, 0)
+    range.setEnd(outputText, 'inside'.length)
+
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    document.dispatchEvent(new Event('selectionchange'))
+
+    expect(listener).toHaveBeenCalledOnce()
+
+    selection?.removeAllRanges()
+    document.dispatchEvent(new Event('selectionchange'))
+
+    expect(listener).toHaveBeenCalledTimes(2)
+
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    created.terminal.dispose()
+    document.dispatchEvent(new Event('selectionchange'))
+
+    expect(listener).toHaveBeenCalledTimes(2)
   })
 
   test('honors renderer key handlers before emitting input', () => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -119,6 +119,37 @@ describe('plainTextInstance', () => {
     expect(dataHandler).toHaveBeenCalledWith('\r')
   })
 
+  test('ignores selections that leave the renderer root', () => {
+    const created = createPlainTextTerminal()
+    const container = document.createElement('div')
+    const sibling = document.createElement('div')
+
+    setElementSize(container, 640, 360)
+    document.body.append(container, sibling)
+    created.terminal.open(container)
+    created.terminal.write('inside terminal')
+    sibling.textContent = 'outside pane'
+
+    const outputText =
+      created.terminal.element?.querySelector('pre')?.firstChild
+    const siblingText = sibling.firstChild
+
+    if (!outputText || !siblingText) {
+      throw new Error('selection test requires terminal and sibling text nodes')
+    }
+
+    const range = document.createRange()
+    range.setStart(outputText, 0)
+    range.setEnd(siblingText, 'outside pane'.length)
+
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    expect(created.terminal.hasSelection()).toBe(false)
+    expect(created.terminal.getSelection()).toBe('')
+  })
+
   test('honors renderer key handlers before emitting input', () => {
     const created = createPlainTextTerminal()
     const dataHandler = vi.fn()

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -180,17 +180,22 @@ describe('plainTextInstance', () => {
 
     expect(listener).toHaveBeenCalledOnce()
 
-    selection?.removeAllRanges()
+    range.setEnd(outputText, 'inside terminal'.length)
     document.dispatchEvent(new Event('selectionchange'))
 
     expect(listener).toHaveBeenCalledTimes(2)
+
+    selection?.removeAllRanges()
+    document.dispatchEvent(new Event('selectionchange'))
+
+    expect(listener).toHaveBeenCalledTimes(3)
 
     selection?.removeAllRanges()
     selection?.addRange(range)
     created.terminal.dispose()
     document.dispatchEvent(new Event('selectionchange'))
 
-    expect(listener).toHaveBeenCalledTimes(2)
+    expect(listener).toHaveBeenCalledTimes(3)
   })
 
   test('honors renderer key handlers before emitting input', () => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { themeService } from '../../../../theme'
+import {
+  createPlainTextTerminal,
+  PLAIN_TEXT_TERMINAL_RENDERER_ID,
+  plainTextTerminalRenderer,
+} from './plainTextInstance'
+
+const setElementSize = (
+  element: HTMLElement,
+  width: number,
+  height: number
+): void => {
+  Object.defineProperty(element, 'offsetWidth', {
+    configurable: true,
+    value: width,
+  })
+
+  Object.defineProperty(element, 'offsetHeight', {
+    configurable: true,
+    value: height,
+  })
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  themeService.apply('obsidian-lens')
+  vi.clearAllMocks()
+})
+
+describe('plainTextInstance', () => {
+  test('exposes the opt-in plain-text renderer adapter', () => {
+    expect(plainTextTerminalRenderer.id).toBe(PLAIN_TEXT_TERMINAL_RENDERER_ID)
+    expect(plainTextTerminalRenderer.createInstance).toBe(
+      createPlainTextTerminal
+    )
+  })
+
+  test('opens in a container and reports fitted dimensions', () => {
+    const created = createPlainTextTerminal()
+    const resizeHandler = vi.fn()
+    const container = document.createElement('div')
+
+    setElementSize(container, 640, 360)
+    created.terminal.onResize(resizeHandler)
+    created.terminal.open(container)
+
+    expect(container.firstElementChild).toBe(created.terminal.element)
+    expect(created.terminal.cols).toBe(80)
+    expect(created.terminal.rows).toBe(20)
+    expect(resizeHandler).toHaveBeenCalledWith({ cols: 80, rows: 20 })
+
+    setElementSize(container, 400, 180)
+    created.fitController.fit()
+
+    expect(created.terminal.cols).toBe(50)
+    expect(created.terminal.rows).toBe(10)
+    expect(resizeHandler).toHaveBeenLastCalledWith({ cols: 50, rows: 10 })
+  })
+
+  test('writes frontend string chunks into the viewport reader', () => {
+    const created = createPlainTextTerminal()
+    const callback = vi.fn()
+    const container = document.createElement('div')
+
+    setElementSize(container, 640, 360)
+    created.terminal.open(container)
+    created.terminal.write('hello\r\nworld\n', callback)
+
+    expect(created.viewportReader.readVisibleText()).toBe('hello\nworld')
+    expect(callback).toHaveBeenCalledOnce()
+  })
+
+  test('consumes registered OSC handlers without rendering control sequences', () => {
+    const created = createPlainTextTerminal()
+    const oscHandler = vi.fn((): boolean => true)
+    const container = document.createElement('div')
+
+    setElementSize(container, 640, 360)
+    created.terminal.open(container)
+    created.parser.registerOscHandler(7, oscHandler)
+    created.terminal.write(
+      'before \x1b]7;file://localhost/tmp/plain-text-project\x07after'
+    )
+
+    expect(oscHandler).toHaveBeenCalledWith(
+      'file://localhost/tmp/plain-text-project'
+    )
+    expect(created.viewportReader.readVisibleText()).toBe('before after')
+  })
+
+  test('stops invoking disposed OSC handlers', () => {
+    const created = createPlainTextTerminal()
+    const oscHandler = vi.fn((): boolean => true)
+    const disposable = created.parser.registerOscHandler(7, oscHandler)
+
+    disposable.dispose()
+    created.terminal.write('\x1b]7;file://localhost/tmp/ignored\x07')
+
+    expect(oscHandler).not.toHaveBeenCalled()
+  })
+
+  test('emits pasted text and keyboard input through onData', () => {
+    const created = createPlainTextTerminal()
+    const dataHandler = vi.fn()
+    const container = document.createElement('div')
+
+    setElementSize(container, 640, 360)
+    created.terminal.open(container)
+    created.terminal.onData(dataHandler)
+    created.terminal.paste('echo hi')
+
+    const input = created.terminal.element?.querySelector('textarea')
+    input?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    )
+
+    expect(dataHandler).toHaveBeenCalledWith('echo hi')
+    expect(dataHandler).toHaveBeenCalledWith('\r')
+  })
+
+  test('honors renderer key handlers before emitting input', () => {
+    const created = createPlainTextTerminal()
+    const dataHandler = vi.fn()
+    const keyHandler = vi.fn((): boolean => false)
+    const container = document.createElement('div')
+
+    setElementSize(container, 640, 360)
+    created.terminal.open(container)
+    created.terminal.onData(dataHandler)
+    created.terminal.attachKeyEventHandler(keyHandler)
+
+    const input = created.terminal.element?.querySelector('textarea')
+    input?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true })
+    )
+
+    expect(keyHandler).toHaveBeenCalledOnce()
+    expect(dataHandler).not.toHaveBeenCalled()
+  })
+
+  test('applies terminal theme colors', () => {
+    const created = createPlainTextTerminal()
+    const theme = themeService.current().terminal
+
+    const terminalTheme = {
+      ...theme,
+      background: theme.brightBlack,
+      foreground: theme.brightWhite,
+    }
+
+    created.terminal.applyTheme(terminalTheme)
+
+    expect(created.terminal.element?.style.background).not.toBe('')
+    expect(created.terminal.element?.style.color).not.toBe('')
+  })
+})

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -87,6 +87,23 @@ describe('plainTextInstance', () => {
     expect(callback).toHaveBeenCalledOnce()
   })
 
+  test('retains recent output when scrollback exceeds the line limit', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    const scrollbackText = Array.from(
+      { length: 10_005 },
+      (_, index) => `line-${index}`
+    ).join('\n')
+
+    created.terminal.write(scrollbackText)
+
+    const lines = created.viewportReader.readVisibleText().split('\n')
+
+    expect(lines).toHaveLength(10_000)
+    expect(lines[0]).toBe('line-5')
+    expect(lines[lines.length - 1]).toBe('line-10004')
+  })
+
   test('consumes registered OSC handlers without rendering control sequences', () => {
     const created = createTrackedPlainTextTerminal()
     const oscHandler = vi.fn((): boolean => true)

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -228,7 +228,10 @@ class PlainTextTerminalSurface implements TerminalSurface {
     callback?.()
   }
 
-  refresh(): void {
+  refresh(start: number, end: number): void {
+    void start
+    void end
+
     this.renderOutput()
   }
 
@@ -443,7 +446,11 @@ class PlainTextTerminalModel {
       (sequence, identifier: string, payload: string): string => {
         const handler = this.oscHandlers.get(Number(identifier))
 
-        return handler?.(payload) === false ? sequence : ''
+        if (!handler) {
+          return sequence
+        }
+
+        return handler(payload) === false ? sequence : ''
       }
     )
   }

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -106,6 +106,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
   private outputText = ''
   private colsValue = DEFAULT_COLS
   private rowsValue = DEFAULT_ROWS
+  private hasContainedSelection = false
   private disposed = false
 
   constructor(private readonly transformOutput: (data: string) => string) {
@@ -144,6 +145,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
 
     this.input.setAttribute('aria-label', 'Terminal input')
     this.root.addEventListener('mousedown', this.handlePointerDown)
+    document.addEventListener('selectionchange', this.handleSelectionChange)
     this.input.addEventListener('keydown', this.handleKeyDown)
     this.input.addEventListener('paste', this.handlePaste)
     this.applyTheme(themeService.current().terminal)
@@ -183,6 +185,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
   dispose(): void {
     this.disposed = true
     this.root.removeEventListener('mousedown', this.handlePointerDown)
+    document.removeEventListener('selectionchange', this.handleSelectionChange)
     this.input.removeEventListener('keydown', this.handleKeyDown)
     this.input.removeEventListener('paste', this.handlePaste)
     this.dataHandlers.clear()
@@ -251,6 +254,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
     const selection = window.getSelection()
     selection?.removeAllRanges()
     selection?.addRange(range)
+    this.hasContainedSelection = true
     this.notifySelectionChange()
   }
 
@@ -309,6 +313,17 @@ class PlainTextTerminalSurface implements TerminalSurface {
 
   private readonly handlePointerDown = (): void => {
     this.focus()
+  }
+
+  private readonly handleSelectionChange = (): void => {
+    const hasSelection = readContainedSelection(this.root).length > 0
+
+    if (hasSelection === this.hasContainedSelection) {
+      return
+    }
+
+    this.hasContainedSelection = hasSelection
+    this.notifySelectionChange()
   }
 
   private readonly handleKeyDown = (event: KeyboardEvent): void => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -22,7 +22,6 @@ const MIN_COLS = 2
 const MIN_ROWS = 1
 const APPROXIMATE_CHAR_WIDTH = 8
 const APPROXIMATE_LINE_HEIGHT = 18
-const OSC_SEQUENCE_PATTERN = /\x1b\](\d+);([^\x07\x1b]*)(?:\x07|\x1b\\)/g
 
 const KEYBOARD_SEQUENCES = new Map<string, string>([
   ['ArrowUp', '\x1b[A'],
@@ -106,7 +105,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
   private outputText = ''
   private colsValue = DEFAULT_COLS
   private rowsValue = DEFAULT_ROWS
-  private hasContainedSelection = false
+  private lastSelectionText = ''
   private disposed = false
 
   constructor(private readonly transformOutput: (data: string) => string) {
@@ -254,7 +253,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
     const selection = window.getSelection()
     selection?.removeAllRanges()
     selection?.addRange(range)
-    this.hasContainedSelection = true
+    this.lastSelectionText = readContainedSelection(this.root)
     this.notifySelectionChange()
   }
 
@@ -316,13 +315,13 @@ class PlainTextTerminalSurface implements TerminalSurface {
   }
 
   private readonly handleSelectionChange = (): void => {
-    const hasSelection = readContainedSelection(this.root).length > 0
+    const selectionText = readContainedSelection(this.root)
 
-    if (hasSelection === this.hasContainedSelection) {
+    if (selectionText === this.lastSelectionText) {
       return
     }
 
-    this.hasContainedSelection = hasSelection
+    this.lastSelectionText = selectionText
     this.notifySelectionChange()
   }
 
@@ -419,8 +418,10 @@ class PlainTextTerminalModel {
   }
 
   private consumeControlSequences(data: string): string {
+    const oscSequencePattern = /\x1b\](\d+);([^\x07\x1b]*)(?:\x07|\x1b\\)/g
+
     return data.replace(
-      OSC_SEQUENCE_PATTERN,
+      oscSequencePattern,
       (_sequence, identifier: string, payload: string): string => {
         const handler = this.oscHandlers.get(Number(identifier))
         handler?.(payload)

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -54,8 +54,10 @@ const readContainedSelection = (root: HTMLElement): string => {
   const focusNode = selection.focusNode
 
   if (
-    (!anchorNode || !root.contains(anchorNode)) &&
-    (!focusNode || !root.contains(focusNode))
+    !anchorNode ||
+    !root.contains(anchorNode) ||
+    !focusNode ||
+    !root.contains(focusNode)
   ) {
     return ''
   }

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -36,6 +36,12 @@ const KEYBOARD_SEQUENCES = new Map<string, string>([
   ['PageDown', '\x1b[6~'],
 ])
 
+type OscHandler = (data: string) => boolean
+
+interface OscHandlerRegistration {
+  readonly handler: OscHandler
+}
+
 const getControlKeyData = (key: string): string | null => {
   if (key.length !== 1) {
     return null
@@ -229,6 +235,12 @@ class PlainTextTerminalSurface implements TerminalSurface {
   }
 
   write(data: string, callback?: () => void): void {
+    if (this.disposed) {
+      callback?.()
+
+      return
+    }
+
     const visibleData = this.transformOutput(data)
 
     if (visibleData.length > 0) {
@@ -417,7 +429,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
 }
 
 class PlainTextTerminalModel {
-  private readonly oscHandlers = new Map<number, (data: string) => boolean>()
+  private readonly oscHandlers = new Map<number, OscHandlerRegistration[]>()
   readonly terminal = new PlainTextTerminalSurface((data) =>
     this.consumeControlSequences(data)
   )
@@ -425,14 +437,31 @@ class PlainTextTerminalModel {
   readonly parser: TerminalParser = {
     registerOscHandler: (
       identifier: number,
-      handler: (data: string) => boolean
+      handler: OscHandler
     ): TerminalDisposable => {
-      this.oscHandlers.set(identifier, handler)
+      const registration = { handler }
+      const registrations = this.oscHandlers.get(identifier) ?? []
+
+      this.oscHandlers.set(identifier, [...registrations, registration])
 
       return createDisposable((): void => {
-        if (this.oscHandlers.get(identifier) === handler) {
-          this.oscHandlers.delete(identifier)
+        const currentRegistrations = this.oscHandlers.get(identifier)
+
+        if (!currentRegistrations) {
+          return
         }
+
+        const nextRegistrations = currentRegistrations.filter(
+          (currentRegistration) => currentRegistration !== registration
+        )
+
+        if (nextRegistrations.length === 0) {
+          this.oscHandlers.delete(identifier)
+
+          return
+        }
+
+        this.oscHandlers.set(identifier, nextRegistrations)
       })
     },
   }
@@ -457,13 +486,15 @@ class PlainTextTerminalModel {
     return data.replace(
       oscSequencePattern,
       (sequence, identifier: string, payload: string): string => {
-        const handler = this.oscHandlers.get(Number(identifier))
+        const registrations = this.oscHandlers.get(Number(identifier)) ?? []
 
-        if (!handler) {
-          return sequence
+        for (const registration of registrations.slice().reverse()) {
+          if (registration.handler(payload)) {
+            return ''
+          }
         }
 
-        return handler(payload) === false ? sequence : ''
+        return sequence
       }
     )
   }

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -22,6 +22,7 @@ const MIN_COLS = 2
 const MIN_ROWS = 1
 const APPROXIMATE_CHAR_WIDTH = 8
 const APPROXIMATE_LINE_HEIGHT = 18
+const MAX_SCROLLBACK_LINES = 10_000
 
 const KEYBOARD_SEQUENCES = new Map<string, string>([
   ['ArrowUp', '\x1b[A'],
@@ -55,6 +56,16 @@ const createDisposable = (dispose: () => void): TerminalDisposable => ({
 
 const normalizeDisplayText = (data: string): string =>
   data.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
+const trimScrollbackLines = (text: string): string => {
+  const lines = text.split('\n')
+
+  if (lines.length <= MAX_SCROLLBACK_LINES) {
+    return text
+  }
+
+  return lines.slice(-MAX_SCROLLBACK_LINES).join('\n')
+}
 
 const readContainedSelection = (root: HTMLElement): string => {
   const selection = window.getSelection()
@@ -221,7 +232,9 @@ class PlainTextTerminalSurface implements TerminalSurface {
     const visibleData = this.transformOutput(data)
 
     if (visibleData.length > 0) {
-      this.outputText = `${this.outputText}${normalizeDisplayText(visibleData)}`
+      this.outputText = trimScrollbackLines(
+        `${this.outputText}${normalizeDisplayText(visibleData)}`
+      )
       this.renderOutput()
     }
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -35,6 +35,20 @@ const KEYBOARD_SEQUENCES = new Map<string, string>([
   ['PageDown', '\x1b[6~'],
 ])
 
+const getControlKeyData = (key: string): string | null => {
+  if (key.length !== 1) {
+    return null
+  }
+
+  const upperKey = key.toUpperCase()
+
+  if (upperKey < 'A' || upperKey > 'Z') {
+    return null
+  }
+
+  return String.fromCharCode(upperKey.charCodeAt(0) - 64)
+}
+
 const createDisposable = (dispose: () => void): TerminalDisposable => ({
   dispose,
 })
@@ -65,8 +79,12 @@ const readContainedSelection = (root: HTMLElement): string => {
 }
 
 const getKeyboardData = (event: KeyboardEvent): string | null => {
-  if (event.metaKey || event.ctrlKey || event.altKey) {
+  if (event.metaKey || event.altKey) {
     return null
+  }
+
+  if (event.ctrlKey) {
+    return getControlKeyData(event.key)
   }
 
   if (event.key === 'Enter') {
@@ -422,11 +440,10 @@ class PlainTextTerminalModel {
 
     return data.replace(
       oscSequencePattern,
-      (_sequence, identifier: string, payload: string): string => {
+      (sequence, identifier: string, payload: string): string => {
         const handler = this.oscHandlers.get(Number(identifier))
-        handler?.(payload)
 
-        return ''
+        return handler?.(payload) === false ? sequence : ''
       }
     )
   }

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -1,0 +1,432 @@
+import { themeService } from '../../../../theme'
+import type {
+  TerminalDisposable,
+  TerminalFitController,
+  TerminalInstance,
+  TerminalKeyEventHandler,
+  TerminalParser,
+  TerminalRendererAdapter,
+  TerminalRendererHandle,
+  TerminalSize,
+  TerminalSurface,
+  TerminalTheme,
+  TerminalViewportReader,
+} from '../../types'
+import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
+
+export const PLAIN_TEXT_TERMINAL_RENDERER_ID = 'plain-text'
+
+const DEFAULT_COLS = 80
+const DEFAULT_ROWS = 24
+const MIN_COLS = 2
+const MIN_ROWS = 1
+const APPROXIMATE_CHAR_WIDTH = 8
+const APPROXIMATE_LINE_HEIGHT = 18
+const OSC_SEQUENCE_PATTERN = /\x1b\](\d+);([^\x07\x1b]*)(?:\x07|\x1b\\)/g
+
+const KEYBOARD_SEQUENCES = new Map<string, string>([
+  ['ArrowUp', '\x1b[A'],
+  ['ArrowDown', '\x1b[B'],
+  ['ArrowRight', '\x1b[C'],
+  ['ArrowLeft', '\x1b[D'],
+  ['Home', '\x1b[H'],
+  ['End', '\x1b[F'],
+  ['Delete', '\x1b[3~'],
+  ['PageUp', '\x1b[5~'],
+  ['PageDown', '\x1b[6~'],
+])
+
+const createDisposable = (dispose: () => void): TerminalDisposable => ({
+  dispose,
+})
+
+const normalizeDisplayText = (data: string): string =>
+  data.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
+const readContainedSelection = (root: HTMLElement): string => {
+  const selection = window.getSelection()
+
+  if (!selection || selection.rangeCount === 0) {
+    return ''
+  }
+
+  const anchorNode = selection.anchorNode
+  const focusNode = selection.focusNode
+
+  if (
+    (!anchorNode || !root.contains(anchorNode)) &&
+    (!focusNode || !root.contains(focusNode))
+  ) {
+    return ''
+  }
+
+  return selection.toString()
+}
+
+const getKeyboardData = (event: KeyboardEvent): string | null => {
+  if (event.metaKey || event.ctrlKey || event.altKey) {
+    return null
+  }
+
+  if (event.key === 'Enter') {
+    return '\r'
+  }
+
+  if (event.key === 'Backspace') {
+    return '\x7f'
+  }
+
+  if (event.key === 'Tab') {
+    return '\t'
+  }
+
+  if (event.key === 'Escape') {
+    return '\x1b'
+  }
+
+  const sequence = KEYBOARD_SEQUENCES.get(event.key)
+  if (sequence) {
+    return sequence
+  }
+
+  return event.key.length === 1 ? event.key : null
+}
+
+class PlainTextTerminalSurface implements TerminalSurface {
+  private readonly root = document.createElement('div')
+  private readonly output = document.createElement('pre')
+  private readonly input = document.createElement('textarea')
+  private readonly dataHandlers = new Set<(data: string) => void>()
+  private readonly resizeHandlers = new Set<(size: TerminalSize) => void>()
+  private readonly selectionHandlers = new Set<() => void>()
+  private readonly keyHandlers = new Set<TerminalKeyEventHandler>()
+  private container: HTMLElement | null = null
+  private outputText = ''
+  private colsValue = DEFAULT_COLS
+  private rowsValue = DEFAULT_ROWS
+  private disposed = false
+
+  constructor(private readonly transformOutput: (data: string) => string) {
+    this.root.dataset.terminalRenderer = PLAIN_TEXT_TERMINAL_RENDERER_ID
+    this.root.tabIndex = -1
+    this.root.append(this.output, this.input)
+
+    Object.assign(this.root.style, {
+      height: '100%',
+      minHeight: '0',
+      overflow: 'auto',
+      position: 'relative',
+    })
+
+    Object.assign(this.output.style, {
+      boxSizing: 'border-box',
+      fontFamily: TERMINAL_FONT_FAMILY,
+      fontSize: `${TERMINAL_FONT_SIZE}px`,
+      lineHeight: `${APPROXIMATE_LINE_HEIGHT}px`,
+      margin: '0',
+      minHeight: '100%',
+      padding: '8px',
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-word',
+    })
+
+    Object.assign(this.input.style, {
+      height: '1px',
+      left: '0',
+      opacity: '0',
+      pointerEvents: 'none',
+      position: 'absolute',
+      top: '0',
+      width: '1px',
+    })
+
+    this.input.setAttribute('aria-label', 'Terminal input')
+    this.root.addEventListener('mousedown', this.handlePointerDown)
+    this.input.addEventListener('keydown', this.handleKeyDown)
+    this.input.addEventListener('paste', this.handlePaste)
+    this.applyTheme(themeService.current().terminal)
+  }
+
+  get cols(): number {
+    return this.colsValue
+  }
+
+  get rows(): number {
+    return this.rowsValue
+  }
+
+  get element(): HTMLElement | undefined {
+    return this.root
+  }
+
+  open(container: HTMLElement): void {
+    if (this.disposed) {
+      return
+    }
+
+    this.container = container
+
+    if (this.root.parentElement !== container) {
+      this.root.remove()
+      container.append(this.root)
+    }
+
+    this.fit()
+  }
+
+  focus(): void {
+    this.input.focus()
+  }
+
+  dispose(): void {
+    this.disposed = true
+    this.root.removeEventListener('mousedown', this.handlePointerDown)
+    this.input.removeEventListener('keydown', this.handleKeyDown)
+    this.input.removeEventListener('paste', this.handlePaste)
+    this.dataHandlers.clear()
+    this.resizeHandlers.clear()
+    this.selectionHandlers.clear()
+    this.keyHandlers.clear()
+    this.root.remove()
+  }
+
+  clear(): void {
+    this.outputText = ''
+    this.renderOutput()
+  }
+
+  write(data: string, callback?: () => void): void {
+    const visibleData = this.transformOutput(data)
+
+    if (visibleData.length > 0) {
+      this.outputText = `${this.outputText}${normalizeDisplayText(visibleData)}`
+      this.renderOutput()
+    }
+
+    callback?.()
+  }
+
+  refresh(): void {
+    this.renderOutput()
+  }
+
+  onData(handler: (data: string) => void): TerminalDisposable {
+    this.dataHandlers.add(handler)
+
+    return createDisposable((): void => {
+      this.dataHandlers.delete(handler)
+    })
+  }
+
+  onResize(handler: (size: TerminalSize) => void): TerminalDisposable {
+    this.resizeHandlers.add(handler)
+
+    return createDisposable((): void => {
+      this.resizeHandlers.delete(handler)
+    })
+  }
+
+  hasSelection(): boolean {
+    return readContainedSelection(this.root).length > 0
+  }
+
+  getSelection(): string {
+    return readContainedSelection(this.root)
+  }
+
+  paste(text: string): void {
+    this.emitData(text)
+  }
+
+  selectAll(): void {
+    if (!this.output.firstChild) {
+      return
+    }
+
+    const range = document.createRange()
+    range.selectNodeContents(this.output)
+
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    this.notifySelectionChange()
+  }
+
+  onSelectionChange(listener: () => void): TerminalDisposable {
+    this.selectionHandlers.add(listener)
+
+    return createDisposable((): void => {
+      this.selectionHandlers.delete(listener)
+    })
+  }
+
+  attachKeyEventHandler(handler: TerminalKeyEventHandler): void {
+    this.keyHandlers.add(handler)
+  }
+
+  applyTheme(theme: TerminalTheme): void {
+    this.root.style.background = theme.background
+    this.root.style.color = theme.foreground
+    this.output.style.caretColor = theme.cursor
+    this.root.style.setProperty(
+      '--terminal-selection-background',
+      theme.selectionBackground
+    )
+  }
+
+  fit(): void {
+    const width = this.container?.offsetWidth ?? 0
+    const height = this.container?.offsetHeight ?? 0
+
+    if (width <= 0 || height <= 0) {
+      return
+    }
+
+    const nextCols = Math.max(
+      MIN_COLS,
+      Math.floor(width / APPROXIMATE_CHAR_WIDTH)
+    )
+
+    const nextRows = Math.max(
+      MIN_ROWS,
+      Math.floor(height / APPROXIMATE_LINE_HEIGHT)
+    )
+
+    if (nextCols === this.colsValue && nextRows === this.rowsValue) {
+      return
+    }
+
+    this.colsValue = nextCols
+    this.rowsValue = nextRows
+    this.notifyResize()
+  }
+
+  readVisibleText(): string {
+    return this.outputText.replace(/\n+$/, '')
+  }
+
+  private readonly handlePointerDown = (): void => {
+    this.focus()
+  }
+
+  private readonly handleKeyDown = (event: KeyboardEvent): void => {
+    for (const handler of this.keyHandlers) {
+      if (!handler(event)) {
+        event.preventDefault()
+        event.stopPropagation()
+
+        return
+      }
+    }
+
+    const data = getKeyboardData(event)
+
+    if (!data) {
+      return
+    }
+
+    event.preventDefault()
+    this.emitData(data)
+  }
+
+  private readonly handlePaste = (event: ClipboardEvent): void => {
+    const text = event.clipboardData?.getData('text/plain') ?? ''
+
+    if (!text) {
+      return
+    }
+
+    event.preventDefault()
+    this.emitData(text)
+  }
+
+  private emitData(data: string): void {
+    this.dataHandlers.forEach((handler) => {
+      handler(data)
+    })
+  }
+
+  private renderOutput(): void {
+    this.output.textContent = this.outputText
+    this.root.scrollTop = this.root.scrollHeight
+  }
+
+  private notifyResize(): void {
+    const size = { cols: this.colsValue, rows: this.rowsValue }
+
+    this.resizeHandlers.forEach((handler) => {
+      handler(size)
+    })
+  }
+
+  private notifySelectionChange(): void {
+    this.selectionHandlers.forEach((handler) => {
+      handler()
+    })
+  }
+}
+
+class PlainTextTerminalModel {
+  private readonly oscHandlers = new Map<number, (data: string) => boolean>()
+  readonly terminal = new PlainTextTerminalSurface((data) =>
+    this.consumeControlSequences(data)
+  )
+
+  readonly parser: TerminalParser = {
+    registerOscHandler: (
+      identifier: number,
+      handler: (data: string) => boolean
+    ): TerminalDisposable => {
+      this.oscHandlers.set(identifier, handler)
+
+      return createDisposable((): void => {
+        if (this.oscHandlers.get(identifier) === handler) {
+          this.oscHandlers.delete(identifier)
+        }
+      })
+    },
+  }
+
+  readonly viewportReader: TerminalViewportReader = {
+    readVisibleText: (): string => this.terminal.readVisibleText(),
+  }
+
+  readonly fitController: TerminalFitController = {
+    fit: (): void => {
+      this.terminal.fit()
+    },
+  }
+
+  readonly rendererHandle: TerminalRendererHandle = {
+    dispose: (): void => undefined,
+  }
+
+  private consumeControlSequences(data: string): string {
+    return data.replace(
+      OSC_SEQUENCE_PATTERN,
+      (_sequence, identifier: string, payload: string): string => {
+        const handler = this.oscHandlers.get(Number(identifier))
+        handler?.(payload)
+
+        return ''
+      }
+    )
+  }
+}
+
+export const createPlainTextTerminal = (): TerminalInstance => {
+  const model = new PlainTextTerminalModel()
+
+  return {
+    terminal: model.terminal,
+    parser: model.parser,
+    viewportReader: model.viewportReader,
+    fitController: model.fitController,
+    attachRenderer: (): TerminalRendererHandle => model.rendererHandle,
+  }
+}
+
+export const plainTextTerminalRenderer: TerminalRendererAdapter = {
+  id: PLAIN_TEXT_TERMINAL_RENDERER_ID,
+  createInstance: createPlainTextTerminal,
+}

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
@@ -8,10 +8,22 @@ import {
   registerTerminalRendererAdapter,
   setTerminalRendererAdapter,
 } from './terminalRendererRegistry'
+import { plainTextTerminalRenderer } from './plainTextInstance'
 import { xtermTerminalRenderer } from './xtermInstance'
 
 const xtermRendererMocks = vi.hoisted(() => ({
   createInstance: vi.fn(),
+}))
+
+const plainTextRendererMocks = vi.hoisted(() => ({
+  createInstance: vi.fn(),
+}))
+
+vi.mock('./plainTextInstance', () => ({
+  plainTextTerminalRenderer: {
+    id: 'plain-text',
+    createInstance: plainTextRendererMocks.createInstance,
+  },
 }))
 
 vi.mock('./xtermInstance', () => ({
@@ -108,6 +120,18 @@ describe('terminalRendererRegistry', () => {
     expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
   })
 
+  test('creates instances through the bundled plain-text renderer when selected', () => {
+    const instance = createTerminalInstance()
+    plainTextRendererMocks.createInstance.mockReturnValue(instance)
+
+    vi.stubEnv('VITE_TERMINAL_RENDERER', 'plain-text')
+
+    expect(getTerminalRendererAdapter()).toBe(plainTextTerminalRenderer)
+    expect(createConfiguredTerminalInstance()).toBe(instance)
+    expect(plainTextRendererMocks.createInstance).toHaveBeenCalledOnce()
+    expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
+  })
+
   test('keeps xterm as the default when environment selection is blank', () => {
     const instance = createTerminalInstance()
     const customRenderer = createTerminalRendererAdapter('custom', instance)
@@ -185,5 +209,9 @@ describe('terminalRendererRegistry', () => {
     expect(() => setTerminalRendererAdapter('custom')).toThrow(
       'Unknown terminal renderer adapter: custom'
     )
+
+    setTerminalRendererAdapter('plain-text')
+
+    expect(getTerminalRendererAdapter()).toBe(plainTextTerminalRenderer)
   })
 })

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
@@ -1,8 +1,10 @@
 import type { TerminalInstance, TerminalRendererAdapter } from '../../types'
+import { plainTextTerminalRenderer } from './plainTextInstance'
 import { xtermTerminalRenderer } from './xtermInstance'
 
 const terminalRendererAdapters = new Map<string, TerminalRendererAdapter>([
   [xtermTerminalRenderer.id, xtermTerminalRenderer],
+  [plainTextTerminalRenderer.id, plainTextTerminalRenderer],
 ])
 
 let activeTerminalRendererId = xtermTerminalRenderer.id
@@ -87,6 +89,10 @@ export const createConfiguredTerminalInstance = (): TerminalInstance => {
 export const _resetTerminalRendererRegistryForTest = (): void => {
   terminalRendererAdapters.clear()
   terminalRendererAdapters.set(xtermTerminalRenderer.id, xtermTerminalRenderer)
+  terminalRendererAdapters.set(
+    plainTextTerminalRenderer.id,
+    plainTextTerminalRenderer
+  )
   activeTerminalRendererId = xtermTerminalRenderer.id
   hasConfiguredTerminalRendererFromEnvironment = false
 }


### PR DESCRIPTION
## Summary

- add an opt-in `plain-text` terminal renderer adapter that implements the renderer-neutral terminal contracts without importing xterm
- register the adapter behind the existing `VITE_TERMINAL_RENDERER` selection path while keeping xterm as the default
- cover the prototype adapter with tests for fit, output writes, viewport reads, OSC handling, input forwarding, key interception, and theme application
- record the spike finding that the current frontend renderer contract consumes decoded string chunks, so real Ghostty support still needs a byte-preserving PTY transport design

## Validation

- `npx vitest run src/features/terminal/components/TerminalPane/plainTextInstance.test.ts src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts`
- `npx vitest run src/features/terminal`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`

Refs VIM-139