### PR TITLE
refactor(terminal): lazy-load plain text renderer

### DIFF
--- a/docs/decisions/2026-06-16-ghostty-pty-parser-boundary.zh.html
+++ b/docs/decisions/2026-06-16-ghostty-pty-parser-boundary.zh.html
@@ -3,20 +3,20 @@
   ========================================================================
   REVIEW NOTE - for human and agent (Codex / Claude) reviewers
   ========================================================================
-  This file is a STATIC, hand-authored exploration document. It holds no
+  This file is a STATIC, hand-authored decision document. It holds no
   application logic, no runtime imports, no external scripts, and no tests.
   It is documentation: prose, inline CSS, and simple HTML diagrams only.
 
   Please do not line-by-line review CSS/markup nits or treat it as part of
   the app behavioral surface. To verify it, open it in a browser and confirm
-  that it renders. docs/explorations/*.html is Prettier-ignored.
+  that it renders.
   ========================================================================
 -->
 <html lang="zh-Hans">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Ghostty Spike 前的 PTY 传输与 Parser 责任边界</title>
+    <title>Ghostty PTY Parser 决策：Adapter 拥有 Parser，应用消费事件</title>
     <style>
       :root {
         --base: #11131a;
@@ -33,9 +33,10 @@
         --red: #ed8796;
         --purple: #c6a0f6;
         --peach: #f5a97f;
-        --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
-        --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-          "Segoe UI", sans-serif;
+        --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+        --sans:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          'Segoe UI', sans-serif;
       }
 
       * {
@@ -77,6 +78,19 @@
         font-family: var(--mono);
         font-size: 0.92em;
         padding: 1px 6px;
+      }
+
+      pre {
+        background: rgba(8, 10, 14, 0.72);
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 0.84rem;
+        line-height: 1.58;
+        margin: 14px 0 0;
+        overflow-x: auto;
+        padding: 16px;
       }
 
       .wrap {
@@ -356,37 +370,41 @@
       <header class="hero">
         <div>
           <p class="eyebrow">Ghostty terminal investigation</p>
-          <h1>Ghostty Spike 前的 PTY 传输与 Parser 责任边界</h1>
+          <h1>Ghostty PTY Parser 决策：Adapter 拥有 Parser，应用消费事件</h1>
           <p class="dek">
-            这份笔记讨论下一阶段最关键的架构问题：我们不能只把
-            xterm.js 的渲染器换成 Ghostty。真正的风险在 PTY 字节流、
-            terminal parser 归属，以及应用层如何消费 OSC、cwd、viewport
-            等语义事件。
+            这份决策记录下一阶段 Ghostty spike 的前置架构选择：parser 归
+            renderer adapter 所有，但应用层只消费统一事件；PTY 输出统一成 output
+            chunk，adapter 内部决定使用 string write 还是 byte write。
           </p>
         </div>
         <aside class="meta">
           <span class="chip"><strong>日期</strong> 2026-06-16</span>
-          <span class="chip"><strong>分支</strong> codex/ghostty-lazy-plain-text-renderer</span>
-          <span class="chip"><strong>目标</strong> 为 Ghostty spike 定义前置契约</span>
+          <span class="chip"
+            ><strong>分支</strong> codex/ghostty-lazy-plain-text-renderer</span
+          >
+          <span class="chip"><strong>状态</strong> Accepted for spike PR1</span>
         </aside>
       </header>
 
       <div class="callout">
         <p>
-          <strong>短结论：</strong>下一步不应该直接写 Ghostty adapter。
-          应先把 PTY 输出从“前端字符串事件”提升为“可保留原始字节的输出包”，
-          同时把 parser 产生的应用语义事件定义成 renderer-neutral contract。
-          否则 Ghostty spike 会被当前 xterm 形状的字符串管线和 OSC 处理方式限制住。
+          <strong>决策：</strong>采用 Option A+。Parser 留在 renderer adapter
+          内部，xterm adapter 继续使用 string write，Ghostty adapter 可以使用
+          byte write；应用层不再记忆不同 adapter 的写入机制，只把
+          <code>TerminalOutputChunk</code> 交给 parser adapter，并监听统一的
+          <code>TerminalParserEvent</code>。
         </p>
       </div>
 
       <nav class="toc" aria-label="目录">
         <a href="#current">当前链路</a>
+        <a href="#decision">决策</a>
         <a href="#why-bytes">为什么 PTY 字节重要</a>
         <a href="#parser">Parser 责任边界</a>
-        <a href="#options">三个可选方案</a>
+        <a href="#observability">OSC 7 与 agent observability</a>
+        <a href="#options">方案回顾</a>
         <a href="#spike">Ghostty spike 路线</a>
-        <a href="#questions">讨论问题</a>
+        <a href="#questions">术语与开放问题</a>
       </nav>
 
       <section id="current">
@@ -424,20 +442,82 @@
 
         <p>
           这里有一个很重要的好消息：<code>offsetStart</code> 和
-          <code>byteLen</code> 已经存在。这说明 restore/dedupe 的 cursor
-          已经是 byte-aware 的。坏消息是 payload 本身仍然不是 byte-preserving。
+          <code>byteLen</code> 已经存在。这说明 restore/dedupe 的 cursor 已经是
+          byte-aware 的。坏消息是 payload 本身仍然不是 byte-preserving。
         </p>
       </section>
 
+      <section id="decision">
+        <h2><span class="num">02</span> 已接受的决策：Option A+</h2>
+        <p>
+          我们选择“parser 属于 renderer adapter，但 app 只依赖 generic parser
+          contract”。这保留 xterm 和 Ghostty 各自 parser 的真实行为，同时避免
+          <code>Body</code>、<code>useTerminal</code>、session manager
+          这些上层代码知道 “哪个 adapter 要 string、哪个 adapter 要 bytes”。
+        </p>
+
+        <pre><code>type TerminalOutputChunk = {
+  text: string
+  bytesBase64?: string
+  offsetStart: number
+  byteLen: number
+  phase: 'live' | 'restore'
+}
+
+type TerminalParserEvent =
+  | {
+      type: 'cwd'
+      source: 'osc7'
+      uri: string
+      path: string
+      phase: 'live' | 'restore'
+      offsetStart: number
+    }
+
+interface TerminalParserAdapter {
+  readonly id: string
+  readonly capabilities: {
+    acceptsText: boolean
+    acceptsBytes: boolean
+  }
+
+  writeOutput(chunk: TerminalOutputChunk): void
+  onEvent(handler: (event: TerminalParserEvent) =&gt; void): TerminalDisposable
+}</code></pre>
+
+        <div class="wide-card decision">
+          <h3>边界要求</h3>
+          <ul>
+            <li>
+              xterm adapter 从 <code>TerminalOutputChunk.text</code> 写入 xterm
+              parser。
+            </li>
+            <li>
+              Ghostty adapter 优先从
+              <code>TerminalOutputChunk.bytesBase64</code>
+              还原 bytes，再写入 Ghostty/libghostty-vt parser。
+            </li>
+            <li>
+              上层只处理 <code>TerminalParserEvent</code>，不直接注册
+              <code>registerOscHandler(7)</code>。
+            </li>
+            <li>
+              Ghostty spike 必须继续挂在显式 feature flag / renderer selector
+              后面。
+            </li>
+          </ul>
+        </div>
+      </section>
+
       <section id="why-bytes">
-        <h2><span class="num">02</span> 为什么 Ghostty 需要认真对待 bytes</h2>
+        <h2><span class="num">03</span> 为什么 Ghostty 需要认真对待 bytes</h2>
         <div class="grid">
           <article class="card">
             <span class="tag red">Lossy decode</span>
             <h3>无效 UTF-8 会被替换</h3>
             <p>
-              <code>from_utf8_lossy</code> 会把非法字节替换成 U+FFFD。
-              对 xterm 当前字符串路径来说通常够用，但对一个严肃的 terminal parser
+              <code>from_utf8_lossy</code> 会把非法字节替换成 U+FFFD。 对 xterm
+              当前字符串路径来说通常够用，但对一个严肃的 terminal parser
               来说，这已经丢失了输入事实。
             </p>
           </article>
@@ -464,19 +544,19 @@
           <p>
             当前 string pipe 可以继续服务 xterm 默认路径，但 Ghostty spike
             应该被视为一个新的 transport contract 验证点。也就是说：
-            <code>xterm</code> 可以暂时从 byte chunk 解码成 string，
-            但 <code>ghostty</code> adapter 不应该被迫接受 lossy string。
+            <code>xterm</code> 可以暂时从 byte chunk 解码成 string， 但
+            <code>ghostty</code> adapter 不应该被迫接受 lossy string。
           </p>
         </div>
       </section>
 
       <section id="parser">
-        <h2><span class="num">03</span> Parser 到底归谁管</h2>
+        <h2><span class="num">04</span> Parser 到底归谁管</h2>
         <p>
           现在应用层最明显的 parser 依赖是 OSC 7：renderer 实例暴露
           <code>parser.registerOscHandler(7, ...)</code>，<code>Body.tsx</code>
-          在 handler 中解析 cwd、做 stale guard、restore suppression，并更新 pane
-          的 cwd 状态。
+          在 handler 中解析 cwd、做 stale guard、restore suppression，并更新
+          pane 的 cwd 状态。
         </p>
         <p>
           这说明 parser 不只是“渲染内部细节”。它已经在为应用层提供语义事件。
@@ -517,49 +597,107 @@
         </table>
       </section>
 
+      <section id="observability">
+        <h2>
+          <span class="num">05</span> OSC 7 与 agent observability 的真实关系
+        </h2>
+        <p>
+          这里必须分清两个 cwd 通道。它们都重要，但语义不同，不能在 Ghostty
+          spike 中混成一个状态源。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>通道</th>
+              <th>来源</th>
+              <th>当前消费者</th>
+              <th>必须保护的结构</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Pane live cwd</td>
+              <td>Terminal output 中的 OSC 7，以及 agent text hint fallback</td>
+              <td>
+                <code>Body.tsx</code> → <code>onCwdChange</code> →
+                <code>updatePaneCwd</code> → backend PTY cwd cache
+              </td>
+              <td>
+                <code>Session.panes[].cwd</code
+                >、<code>update_session_cwd</code>、 git header、burner
+                align、workspace restore
+              </td>
+            </tr>
+            <tr>
+              <td>Agent observed cwd</td>
+              <td>
+                Backend transcript watcher 发出的 <code>agent-cwd</code> event
+              </td>
+              <td><code>useAgentStatus</code> 和 agent status panel</td>
+              <td>
+                <code>AgentStatus.cwd</code>，来自 Claude/Codex transcript
+                的结构化 cwd/workdir
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="wide-card decision">
+          <h3>OSC 7 优先级</h3>
+          <p>
+            PR1 的最高优先级是保护 pane cwd 的现有数据路径。新的 parser event
+            只是把 <code>registerOscHandler(7)</code> 变成 generic
+            <code>{ type: 'cwd', source: 'osc7' }</code> 事件；它不能改变
+            <code>Session.panes[].cwd</code> 的存储位置，也不能替代
+            <code>agent-cwd</code> 这个 observability 通道。
+          </p>
+        </div>
+      </section>
+
       <section id="options">
-        <h2><span class="num">04</span> 三个可选方案</h2>
+        <h2><span class="num">06</span> 方案回顾</h2>
         <div class="grid">
           <article class="card">
             <span class="tag blue">A</span>
-            <h3>Parser 留在 renderer adapter</h3>
+            <h3>接受：Parser 留在 renderer adapter</h3>
             <p>
               xterm 用 xterm parser，Ghostty 用 Ghostty parser。adapter 负责把
               OSC/cwd/title 等事件翻译成统一的前端事件。
             </p>
             <p>
-              优点是迁移成本最低，真实 terminal 语义跟 renderer 一起走。缺点是应用语义
-              依赖每个 adapter 的实现质量。
+              这就是我们接受的方向，但补上 output chunk 和 parser event
+              contract， 所以更准确地叫 Option A+。
             </p>
           </article>
           <article class="card">
             <span class="tag green">B</span>
             <h3>Parser 下沉到 backend/native</h3>
             <p>
-              后端保留原始 bytes，并由一个 native parser 统一产出语义事件。
-              前端 renderer 只负责画面。
+              后端保留原始 bytes，并由一个 native parser 统一产出语义事件。 前端
+              renderer 只负责画面。
             </p>
             <p>
-              优点是语义来源单一，restore/cache 更可控。缺点是会和 xterm 内部 parser
-              重复，短期改动面也最大。
+              优点是语义来源单一，restore/cache 更可控。缺点是会和 xterm 内部
+              parser 重复，短期改动面也最大。
             </p>
           </article>
           <article class="card">
             <span class="tag yellow">C</span>
-            <h3>推荐：先做 split contract</h3>
+            <h3>并入 A+：先做 split contract</h3>
             <p>
               先定义 byte transport 和 parser event contract。parser 可以暂时由
               renderer adapter 提供，但应用层只消费统一事件。
             </p>
             <p>
-              这让 Ghostty spike 可以选择 native parser，同时不要求 xterm 默认路径一次性重写。
+              这个 contract 不作为单独方案推进，而是作为 Option A 的必要护栏。
             </p>
           </article>
         </div>
       </section>
 
       <section id="spike">
-        <h2><span class="num">05</span> 建议的 Ghostty spike 路线</h2>
+        <h2><span class="num">07</span> 建议的 Ghostty spike 路线</h2>
         <ol>
           <li>
             <strong>定义输出包：</strong>增加类似
@@ -575,45 +713,59 @@
           <li>
             <strong>建立 parser event bus：</strong>把 OSC 7 这类语义抽成
             <code>TerminalParserEvent</code>，例如
-            <code>{ type: 'cwd', path, sourceOffset, phase }</code>。
-            <code>phase</code> 至少要区分 live 和 restore replay。
+            <code>{ type: 'cwd', source: 'osc7', path, uri, phase }</code>。
+            <code>phase</code> 必须区分 live 和 restore replay。
           </li>
           <li>
             <strong>实现 Ghostty adapter spike：</strong>只在
             <code>VITE_TERMINAL_RENDERER=ghostty</code> 之类的 opt-in 路径启用。
-            第一版目标不是替换 UI，而是验证 bytes 能进入 Ghostty parser，并能产出 viewport
-            snapshot 与 parser events。
+            第一版目标不是替换 UI，而是验证 bytes 能进入 Ghostty
+            parser，并能产出 viewport snapshot 与 parser events。
           </li>
           <li>
-            <strong>补 contract tests：</strong>用跨 chunk OSC、多字节 UTF-8、非法 bytes、
-            restore replay OSC 这几类 fixture 证明新边界可靠。
+            <strong>补 contract tests：</strong>用跨 chunk OSC、多字节
+            UTF-8、非法 bytes、 restore replay OSC 这几类 fixture
+            证明新边界可靠。
           </li>
         </ol>
       </section>
 
       <section id="questions">
-        <h2><span class="num">06</span> 需要讨论的关键问题</h2>
+        <h2><span class="num">08</span> 术语与开放问题</h2>
         <div class="wide-card">
           <ul>
             <li>
-              Ghostty spike 的第一阶段是否必须 byte-perfect？我的建议是：parser 输入必须
-              byte-preserving，渲染输出可以先最小化。
+              <strong>byte-preserving</strong> 指传输层不丢原始 bytes。PTY
+              读到什么 bytes，Ghostty parser 就能拿到同样的 bytes。 这是 PR1
+              需要保护的能力。
             </li>
             <li>
-              <code>bytesBase64</code> 是否足够作为 IPC 初版？它简单、可测，但有性能成本。
-              如果高吞吐输出有问题，再优化成更直接的 binary transport。
+              <strong>byte-perfect</strong> 更强，表示最终 terminal
+              state、viewport、 restore、render 都和真实 terminal
+              完全一致。Ghostty spike 第一阶段不承诺这个，只先保证 parser 输入
+              byte-preserving。
             </li>
             <li>
-              OSC 7/cwd 是由 adapter 发 normalized event，还是 backend/native parser 统一发？
-              我建议先让 adapter 发统一 event，避免一次性重写 xterm 默认路径。
+              <code>bytesBase64</code> 只是 IPC 初版方案，不是 terminal 语义。
+              因为当前 IPC event 是 JSON/string，base64 是最小改动的 raw bytes
+              容器。它有性能成本；如果 Ghostty 路径高吞吐有问题，再换 binary
+              transport。
             </li>
             <li>
-              restore replay 是否应该进入 parser？如果进入，事件必须带
-              <code>phase: 'restore'</code>，否则历史 OSC 会污染当前 cwd。
+              <strong>restore replay</strong> 指 app 重新 attach 一个已有 PTY
+              时，把历史输出写回 terminal 以恢复
+              scrollback。历史输出里可能包含旧 OSC 7；所以 parser event 必须携带
+              <code>phase: 'restore'</code>，避免旧 cwd 污染 live pane cwd。
             </li>
             <li>
-              Ghostty adapter 的最小成功标准是什么？建议定义为：能吃 raw bytes、能产出 cwd
-              event、能提供 viewport reader、不会影响默认 xterm bundle。
+              OSC 7/cwd 第一阶段由 adapter 发 normalized event，不下沉到
+              backend。 这样可以保护 xterm 默认路径，并让 Ghostty spike
+              独立验证自己的 parser。
+            </li>
+            <li>
+              Ghostty adapter 的最小成功标准是什么？建议定义为：能吃 raw
+              bytes、能产出 cwd event、能提供 viewport reader、不会影响默认
+              xterm bundle。
             </li>
           </ul>
         </div>
@@ -626,7 +778,9 @@
           <code>src/features/terminal/services/terminalService.ts</code>,
           <code>src/features/terminal/hooks/useTerminal.ts</code>,
           <code>src/features/terminal/components/TerminalPane/Body.tsx</code>,
-          <code>src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts</code>.
+          <code
+            >src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts</code
+          >.
         </p>
       </footer>
     </main>

--- a/docs/decisions/CLAUDE.md
+++ b/docs/decisions/CLAUDE.md
@@ -12,6 +12,7 @@ This file is an index. Each linked record is self-contained. Read only what you 
 
 | Date       | Decision                                                                                             | Status                                                        |
 | ---------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| 2026-06-16 | [Ghostty PTY parser boundary](./2026-06-16-ghostty-pty-parser-boundary.zh.html)                      | Accepted for spike PR1                                        |
 | 2026-05-27 | [Terminal rendering: keep WebGL, fix the four real causes](./2026-05-27-terminal-rendering-fixes.md) | Accepted (3 of 4 shipped; backend UTF-8 chunk-split deferred) |
 | 2026-05-23 | [Diff renderer: `@pierre/diffs`](./2026-05-23-pierre-diffs-renderer.md)                              | Accepted (spike validated, integration pending)               |
 | 2026-05-16 | [In-repo skill symlinks for `/lifeline:*`](./2026-05-16-in-repo-skills-setup.md)                     | Accepted                                                      |

--- a/docs/explorations/ghostty-pty-parser-spike-note.zh.html
+++ b/docs/explorations/ghostty-pty-parser-spike-note.zh.html
@@ -1,0 +1,634 @@
+<!doctype html>
+<!--
+  ========================================================================
+  REVIEW NOTE - for human and agent (Codex / Claude) reviewers
+  ========================================================================
+  This file is a STATIC, hand-authored exploration document. It holds no
+  application logic, no runtime imports, no external scripts, and no tests.
+  It is documentation: prose, inline CSS, and simple HTML diagrams only.
+
+  Please do not line-by-line review CSS/markup nits or treat it as part of
+  the app behavioral surface. To verify it, open it in a browser and confirm
+  that it renders. docs/explorations/*.html is Prettier-ignored.
+  ========================================================================
+-->
+<html lang="zh-Hans">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ghostty Spike 前的 PTY 传输与 Parser 责任边界</title>
+    <style>
+      :root {
+        --base: #11131a;
+        --panel: #1a1d25;
+        --panel-high: #232834;
+        --text: #eceff4;
+        --muted: #b8c0cc;
+        --faint: #8590a0;
+        --line: rgba(216, 222, 233, 0.16);
+        --blue: #8aadf4;
+        --cyan: #91d7e3;
+        --green: #a6da95;
+        --yellow: #eed49f;
+        --red: #ed8796;
+        --purple: #c6a0f6;
+        --peach: #f5a97f;
+        --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+        --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background:
+          radial-gradient(
+            920px 520px at 92% -8%,
+            rgba(145, 215, 227, 0.12),
+            transparent 58%
+          ),
+          radial-gradient(
+            760px 520px at 4% 8%,
+            rgba(198, 160, 246, 0.1),
+            transparent 62%
+          ),
+          linear-gradient(180deg, #161923, var(--base) 48%, #0d0f14);
+        color: var(--text);
+        font-family: var(--sans);
+        line-height: 1.72;
+      }
+
+      a {
+        color: var(--cyan);
+        text-decoration: none;
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+
+      code {
+        border-radius: 6px;
+        background: rgba(8, 10, 14, 0.72);
+        color: var(--cyan);
+        font-family: var(--mono);
+        font-size: 0.92em;
+        padding: 1px 6px;
+      }
+
+      .wrap {
+        margin: 0 auto;
+        max-width: 1120px;
+        padding: 56px 28px 92px;
+      }
+
+      .hero {
+        border-bottom: 1px solid var(--line);
+        display: grid;
+        gap: 28px;
+        grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
+        margin-bottom: 36px;
+        padding-bottom: 34px;
+      }
+
+      .eyebrow {
+        color: var(--green);
+        font-family: var(--mono);
+        font-size: 0.76rem;
+        letter-spacing: 0.18em;
+        margin: 0 0 12px;
+        text-transform: uppercase;
+      }
+
+      h1,
+      h2,
+      h3 {
+        line-height: 1.16;
+        margin-top: 0;
+      }
+
+      h1 {
+        font-size: clamp(2.1rem, 5vw, 4.3rem);
+        margin-bottom: 16px;
+      }
+
+      h2 {
+        align-items: baseline;
+        display: flex;
+        font-size: 1.65rem;
+        gap: 10px;
+        margin-bottom: 12px;
+        scroll-margin-top: 20px;
+      }
+
+      h2 .num {
+        color: var(--purple);
+        font-family: var(--mono);
+        font-size: 0.86rem;
+      }
+
+      h3 {
+        color: var(--cyan);
+        font-size: 1.05rem;
+        margin-bottom: 8px;
+      }
+
+      p {
+        color: var(--muted);
+        margin: 0 0 14px;
+      }
+
+      .dek {
+        color: var(--muted);
+        font-size: 1.08rem;
+        max-width: 74ch;
+      }
+
+      .meta {
+        align-content: end;
+        display: grid;
+        gap: 10px;
+      }
+
+      .chip {
+        align-items: center;
+        background: rgba(35, 40, 52, 0.76);
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        color: var(--muted);
+        display: inline-flex;
+        font-family: var(--mono);
+        font-size: 0.76rem;
+        gap: 7px;
+        padding: 8px 12px;
+        width: fit-content;
+      }
+
+      .chip strong {
+        color: var(--text);
+        font-weight: 650;
+      }
+
+      .callout {
+        background:
+          linear-gradient(
+            135deg,
+            rgba(166, 218, 149, 0.13),
+            rgba(138, 173, 244, 0.07)
+          ),
+          rgba(26, 29, 37, 0.82);
+        border: 1px solid rgba(166, 218, 149, 0.24);
+        border-radius: 14px;
+        margin: 0 0 36px;
+        padding: 22px;
+      }
+
+      .callout strong {
+        color: var(--green);
+      }
+
+      .toc {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 0 0 46px;
+      }
+
+      .toc a {
+        background: rgba(35, 40, 52, 0.76);
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 0.76rem;
+        padding: 7px 11px;
+      }
+
+      section {
+        margin-bottom: 52px;
+      }
+
+      .grid {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+
+      .card,
+      .wide-card {
+        background: rgba(26, 29, 37, 0.72);
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 18px;
+      }
+
+      .wide-card {
+        margin-top: 16px;
+      }
+
+      .card p:last-child,
+      .wide-card p:last-child {
+        margin-bottom: 0;
+      }
+
+      .tag {
+        border-radius: 999px;
+        display: inline-flex;
+        font-family: var(--mono);
+        font-size: 0.72rem;
+        margin-bottom: 10px;
+        padding: 5px 9px;
+      }
+
+      .tag.blue {
+        background: rgba(138, 173, 244, 0.12);
+        color: var(--blue);
+      }
+
+      .tag.green {
+        background: rgba(166, 218, 149, 0.12);
+        color: var(--green);
+      }
+
+      .tag.yellow {
+        background: rgba(238, 212, 159, 0.12);
+        color: var(--yellow);
+      }
+
+      .tag.red {
+        background: rgba(237, 135, 150, 0.12);
+        color: var(--red);
+      }
+
+      .flow {
+        background: rgba(12, 14, 19, 0.68);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        display: grid;
+        gap: 10px;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        margin: 18px 0;
+        padding: 14px;
+      }
+
+      .flow-step {
+        background: rgba(35, 40, 52, 0.78);
+        border: 1px solid rgba(216, 222, 233, 0.1);
+        border-radius: 10px;
+        min-height: 114px;
+        padding: 13px;
+      }
+
+      .flow-step b {
+        color: var(--text);
+        display: block;
+        font-size: 0.93rem;
+        margin-bottom: 8px;
+      }
+
+      .flow-step span {
+        color: var(--faint);
+        display: block;
+        font-size: 0.86rem;
+      }
+
+      table {
+        border-collapse: collapse;
+        margin-top: 16px;
+        width: 100%;
+      }
+
+      th,
+      td {
+        border-bottom: 1px solid var(--line);
+        color: var(--muted);
+        padding: 13px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        color: var(--text);
+        font-size: 0.88rem;
+      }
+
+      ul,
+      ol {
+        color: var(--muted);
+        margin: 8px 0 0;
+        padding-left: 22px;
+      }
+
+      li {
+        margin-bottom: 8px;
+      }
+
+      .decision {
+        border-left: 3px solid var(--peach);
+        padding-left: 16px;
+      }
+
+      .foot {
+        border-top: 1px solid var(--line);
+        color: var(--faint);
+        font-size: 0.88rem;
+        padding-top: 24px;
+      }
+
+      @media (max-width: 860px) {
+        .hero,
+        .grid,
+        .flow {
+          grid-template-columns: 1fr;
+        }
+
+        .wrap {
+          padding: 36px 18px 70px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="wrap">
+      <header class="hero">
+        <div>
+          <p class="eyebrow">Ghostty terminal investigation</p>
+          <h1>Ghostty Spike 前的 PTY 传输与 Parser 责任边界</h1>
+          <p class="dek">
+            这份笔记讨论下一阶段最关键的架构问题：我们不能只把
+            xterm.js 的渲染器换成 Ghostty。真正的风险在 PTY 字节流、
+            terminal parser 归属，以及应用层如何消费 OSC、cwd、viewport
+            等语义事件。
+          </p>
+        </div>
+        <aside class="meta">
+          <span class="chip"><strong>日期</strong> 2026-06-16</span>
+          <span class="chip"><strong>分支</strong> codex/ghostty-lazy-plain-text-renderer</span>
+          <span class="chip"><strong>目标</strong> 为 Ghostty spike 定义前置契约</span>
+        </aside>
+      </header>
+
+      <div class="callout">
+        <p>
+          <strong>短结论：</strong>下一步不应该直接写 Ghostty adapter。
+          应先把 PTY 输出从“前端字符串事件”提升为“可保留原始字节的输出包”，
+          同时把 parser 产生的应用语义事件定义成 renderer-neutral contract。
+          否则 Ghostty spike 会被当前 xterm 形状的字符串管线和 OSC 处理方式限制住。
+        </p>
+      </div>
+
+      <nav class="toc" aria-label="目录">
+        <a href="#current">当前链路</a>
+        <a href="#why-bytes">为什么 PTY 字节重要</a>
+        <a href="#parser">Parser 责任边界</a>
+        <a href="#options">三个可选方案</a>
+        <a href="#spike">Ghostty spike 路线</a>
+        <a href="#questions">讨论问题</a>
+      </nav>
+
+      <section id="current">
+        <h2><span class="num">01</span> 当前链路是什么样</h2>
+        <p>
+          当前系统已经有一个比较清晰的 terminal service 边界，但输出数据仍然以
+          <code>string</code> 为主。后端 live 输出和 restore replay 都会把 PTY
+          读到的 bytes 通过 <code>String::from_utf8_lossy</code> 转成字符串。
+          前端再通过 <code>pty-data</code> 事件收到
+          <code>data</code>、<code>offsetStart</code>、<code>byteLen</code>。
+        </p>
+
+        <div class="flow" aria-label="当前 PTY 到 renderer 的链路">
+          <div class="flow-step">
+            <b>PTY</b>
+            <span>shell/agent 进程输出原始 bytes</span>
+          </div>
+          <div class="flow-step">
+            <b>Rust backend</b>
+            <span><code>String::from_utf8_lossy</code> 生成字符串</span>
+          </div>
+          <div class="flow-step">
+            <b>IPC event</b>
+            <span><code>pty-data</code> 携带 string + byte offset</span>
+          </div>
+          <div class="flow-step">
+            <b>useTerminal</b>
+            <span>写入 <code>TerminalSurface.write(data)</code></span>
+          </div>
+          <div class="flow-step">
+            <b>Renderer parser</b>
+            <span>xterm/plain-text parser 触发 OSC 7 等 handler</span>
+          </div>
+        </div>
+
+        <p>
+          这里有一个很重要的好消息：<code>offsetStart</code> 和
+          <code>byteLen</code> 已经存在。这说明 restore/dedupe 的 cursor
+          已经是 byte-aware 的。坏消息是 payload 本身仍然不是 byte-preserving。
+        </p>
+      </section>
+
+      <section id="why-bytes">
+        <h2><span class="num">02</span> 为什么 Ghostty 需要认真对待 bytes</h2>
+        <div class="grid">
+          <article class="card">
+            <span class="tag red">Lossy decode</span>
+            <h3>无效 UTF-8 会被替换</h3>
+            <p>
+              <code>from_utf8_lossy</code> 会把非法字节替换成 U+FFFD。
+              对 xterm 当前字符串路径来说通常够用，但对一个严肃的 terminal parser
+              来说，这已经丢失了输入事实。
+            </p>
+          </article>
+          <article class="card">
+            <span class="tag yellow">Chunk boundary</span>
+            <h3>多字节字符可能跨 read 边界</h3>
+            <p>
+              PTY read 的切分不等于 UTF-8 字符边界，也不等于 escape sequence
+              边界。逐 chunk lossy decode 会让 parser 无法还原原始流。
+            </p>
+          </article>
+          <article class="card">
+            <span class="tag blue">Native parser</span>
+            <h3>Ghostty/libghostty-vt 更像 byte parser</h3>
+            <p>
+              如果 spike 的目标是评估 Ghostty 的 terminal state machine，
+              它应该尽量吃原始 bytes，而不是吃已经被前端协议塑形过的字符串。
+            </p>
+          </article>
+        </div>
+
+        <div class="wide-card decision">
+          <h3>工程判断</h3>
+          <p>
+            当前 string pipe 可以继续服务 xterm 默认路径，但 Ghostty spike
+            应该被视为一个新的 transport contract 验证点。也就是说：
+            <code>xterm</code> 可以暂时从 byte chunk 解码成 string，
+            但 <code>ghostty</code> adapter 不应该被迫接受 lossy string。
+          </p>
+        </div>
+      </section>
+
+      <section id="parser">
+        <h2><span class="num">03</span> Parser 到底归谁管</h2>
+        <p>
+          现在应用层最明显的 parser 依赖是 OSC 7：renderer 实例暴露
+          <code>parser.registerOscHandler(7, ...)</code>，<code>Body.tsx</code>
+          在 handler 中解析 cwd、做 stale guard、restore suppression，并更新 pane
+          的 cwd 状态。
+        </p>
+        <p>
+          这说明 parser 不只是“渲染内部细节”。它已经在为应用层提供语义事件。
+          如果 Ghostty 也有自己的 parser，那么我们必须回答：
+          应用层应该监听谁产生的 OSC/cwd/title/hyperlink 事件？
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>责任</th>
+              <th>现在的位置</th>
+              <th>Ghostty 风险</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>字节流解析</td>
+              <td>xterm 或 plain-text renderer 内部</td>
+              <td>不同 renderer 可能对同一 stream 产生不同语义</td>
+            </tr>
+            <tr>
+              <td>OSC 7 cwd 提取</td>
+              <td><code>Body.tsx</code> 注册 parser handler 后处理</td>
+              <td>restore replay 和 live output 容易混在一起</td>
+            </tr>
+            <tr>
+              <td>Viewport/test buffer</td>
+              <td><code>TerminalViewportReader</code> contract</td>
+              <td>Ghostty 的 viewport 需要映射到现有 E2E 读取契约</td>
+            </tr>
+            <tr>
+              <td>渲染</td>
+              <td>xterm addon/canvas/DOM 或 plain-text DOM</td>
+              <td>Ghostty 可能需要 native surface，而不是普通 DOM writer</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="options">
+        <h2><span class="num">04</span> 三个可选方案</h2>
+        <div class="grid">
+          <article class="card">
+            <span class="tag blue">A</span>
+            <h3>Parser 留在 renderer adapter</h3>
+            <p>
+              xterm 用 xterm parser，Ghostty 用 Ghostty parser。adapter 负责把
+              OSC/cwd/title 等事件翻译成统一的前端事件。
+            </p>
+            <p>
+              优点是迁移成本最低，真实 terminal 语义跟 renderer 一起走。缺点是应用语义
+              依赖每个 adapter 的实现质量。
+            </p>
+          </article>
+          <article class="card">
+            <span class="tag green">B</span>
+            <h3>Parser 下沉到 backend/native</h3>
+            <p>
+              后端保留原始 bytes，并由一个 native parser 统一产出语义事件。
+              前端 renderer 只负责画面。
+            </p>
+            <p>
+              优点是语义来源单一，restore/cache 更可控。缺点是会和 xterm 内部 parser
+              重复，短期改动面也最大。
+            </p>
+          </article>
+          <article class="card">
+            <span class="tag yellow">C</span>
+            <h3>推荐：先做 split contract</h3>
+            <p>
+              先定义 byte transport 和 parser event contract。parser 可以暂时由
+              renderer adapter 提供，但应用层只消费统一事件。
+            </p>
+            <p>
+              这让 Ghostty spike 可以选择 native parser，同时不要求 xterm 默认路径一次性重写。
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="spike">
+        <h2><span class="num">05</span> 建议的 Ghostty spike 路线</h2>
+        <ol>
+          <li>
+            <strong>定义输出包：</strong>增加类似
+            <code>TerminalOutputChunk</code> 的结构，至少包含
+            <code>offsetStart</code>、<code>byteLen</code>、当前兼容用
+            <code>text</code>，以及实验用 <code>bytesBase64</code> 或等价 byte
+            payload。
+          </li>
+          <li>
+            <strong>保留兼容层：</strong>xterm adapter 继续走 string write，
+            但它应该从统一 output chunk 中取 text。这样默认行为不变。
+          </li>
+          <li>
+            <strong>建立 parser event bus：</strong>把 OSC 7 这类语义抽成
+            <code>TerminalParserEvent</code>，例如
+            <code>{ type: 'cwd', path, sourceOffset, phase }</code>。
+            <code>phase</code> 至少要区分 live 和 restore replay。
+          </li>
+          <li>
+            <strong>实现 Ghostty adapter spike：</strong>只在
+            <code>VITE_TERMINAL_RENDERER=ghostty</code> 之类的 opt-in 路径启用。
+            第一版目标不是替换 UI，而是验证 bytes 能进入 Ghostty parser，并能产出 viewport
+            snapshot 与 parser events。
+          </li>
+          <li>
+            <strong>补 contract tests：</strong>用跨 chunk OSC、多字节 UTF-8、非法 bytes、
+            restore replay OSC 这几类 fixture 证明新边界可靠。
+          </li>
+        </ol>
+      </section>
+
+      <section id="questions">
+        <h2><span class="num">06</span> 需要讨论的关键问题</h2>
+        <div class="wide-card">
+          <ul>
+            <li>
+              Ghostty spike 的第一阶段是否必须 byte-perfect？我的建议是：parser 输入必须
+              byte-preserving，渲染输出可以先最小化。
+            </li>
+            <li>
+              <code>bytesBase64</code> 是否足够作为 IPC 初版？它简单、可测，但有性能成本。
+              如果高吞吐输出有问题，再优化成更直接的 binary transport。
+            </li>
+            <li>
+              OSC 7/cwd 是由 adapter 发 normalized event，还是 backend/native parser 统一发？
+              我建议先让 adapter 发统一 event，避免一次性重写 xterm 默认路径。
+            </li>
+            <li>
+              restore replay 是否应该进入 parser？如果进入，事件必须带
+              <code>phase: 'restore'</code>，否则历史 OSC 会污染当前 cwd。
+            </li>
+            <li>
+              Ghostty adapter 的最小成功标准是什么？建议定义为：能吃 raw bytes、能产出 cwd
+              event、能提供 viewport reader、不会影响默认 xterm bundle。
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="foot">
+        <p>
+          相关代码入口：
+          <code>crates/backend/src/terminal/commands.rs</code>,
+          <code>src/features/terminal/services/terminalService.ts</code>,
+          <code>src/features/terminal/hooks/useTerminal.ts</code>,
+          <code>src/features/terminal/components/TerminalPane/Body.tsx</code>,
+          <code>src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts</code>.
+        </p>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/explorations/ghostty-terminal-review-batches.md
+++ b/docs/explorations/ghostty-terminal-review-batches.md
@@ -122,11 +122,47 @@ Spike finding:
   `String::from_utf8_lossy`, so renderer work alone cannot preserve arbitrary
   terminal bytes across chunk boundaries.
 
-Why this comes last:
+Why this is separate:
 
 The earlier batches make the app less xterm-shaped without claiming Ghostty
 support. A Ghostty adapter should start only after the generic contracts, focus
 ownership, E2E reads, and keyboard behavior are reviewed.
+
+## Batch 6: Lazy Experimental Renderer Loading
+
+Branch: `codex/ghostty-lazy-plain-text-renderer`
+
+Scope:
+
+- Keep xterm statically registered as the production default.
+- Move the `plain-text` prototype behind env-gated dynamic loading so the
+  default xterm path does not statically import the spike implementation.
+- Promote configured terminal creation to an async boundary so env-selected
+  experimental adapters can be loaded without top-level await.
+- Add registry tests that prove the default path does not load
+  `plainTextInstance`.
+
+Why this is separate:
+
+This is packaging and experiment-boundary work. It should not be reviewed
+together with adapter behavior, PTY transport, or a real Ghostty prototype.
+
+## Roadmap After Batch 6
+
+1. **Raw PTY byte transport design.** Decide how frontend renderers receive
+   byte-preserving output. The backend currently decodes PTY chunks with
+   `String::from_utf8_lossy`, which is acceptable for xterm's current string
+   path but not enough for a serious `libghostty-vt` parser.
+2. **Parser ownership decision.** Decide whether OSC parsing remains in the
+   frontend renderer adapter or becomes backend/native parser output events.
+   Keep cwd tracking tests as the compatibility contract.
+3. **Ghostty/libghostty-vt feasibility spike.** Add an opt-in prototype that
+   consumes the byte transport and reports parser/viewport state through the
+   existing `TerminalParser` and `TerminalViewportReader` contracts.
+4. **Production-readiness hardening.** Only after the prototype proves the
+   contract, evaluate selection rendering, IME, keyboard modifier fidelity,
+   accessibility, performance under long-running output, packaging size, and
+   platform support.
 
 ## Non-goals For These Batches
 

--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -271,8 +271,8 @@ describe('Body agent-emitted OSC 7', () => {
     skipOscParsing = false
     pendingWriteCallbacks.length = 0
     createdTerminals.length = 0
-    vi.mocked(createTerminalInstance).mockImplementation(
-      createFakeTerminalInstance
+    vi.mocked(createTerminalInstance).mockImplementation(() =>
+      Promise.resolve(createFakeTerminalInstance())
     )
   })
 

--- a/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
@@ -147,7 +147,7 @@ test('Body can run against a non-xterm TerminalInstance contract', async () => {
     resize: vi.fn(),
   }
 
-  vi.mocked(createTerminalInstance).mockReturnValue(fake.instance)
+  vi.mocked(createTerminalInstance).mockResolvedValue(fake.instance)
   vi.mocked(useTerminal).mockReturnValue(useTerminalReturn)
 
   const { unmount } = render(

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -216,7 +216,7 @@ describe('Body', () => {
     }
 
     // Setup mocks
-    vi.mocked(createTerminalInstance).mockReturnValue(
+    vi.mocked(createTerminalInstance).mockResolvedValue(
       mockTerminalControls.instance
     )
     vi.mocked(useTerminal).mockReturnValue(mockUseTerminal)
@@ -687,6 +687,8 @@ describe('Body', () => {
 
   test('clears pending deferred terminal font refresh when switching sessions', async () => {
     let resolveFonts: () => void = (): void => undefined
+    const firstTerminalControls = createMockTerminalControls()
+    const secondTerminalControls = createMockTerminalControls()
 
     const fontsLoaded = new Promise<FontFace[]>((resolve) => {
       resolveFonts = (): void => resolve([])
@@ -699,6 +701,10 @@ describe('Body', () => {
       configurable: true,
       value: { load },
     })
+
+    vi.mocked(createTerminalInstance)
+      .mockResolvedValueOnce(firstTerminalControls.instance)
+      .mockResolvedValueOnce(secondTerminalControls.instance)
 
     const offsetWidthSpy = vi
       .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
@@ -727,8 +733,8 @@ describe('Body', () => {
         await fontsLoaded
       })
 
-      mockFitController.fit.mockClear()
-      mockTerminal.refresh.mockClear()
+      firstTerminalControls.fitController.fit.mockClear()
+      firstTerminalControls.terminal.refresh.mockClear()
 
       rerender(
         <Body
@@ -738,8 +744,10 @@ describe('Body', () => {
         />
       )
 
-      expect(mockFitController.fit).toHaveBeenCalledTimes(1)
-      expect(mockTerminal.refresh).not.toHaveBeenCalled()
+      await waitFor(() => {
+        expect(secondTerminalControls.fitController.fit).toHaveBeenCalled()
+      })
+      expect(firstTerminalControls.terminal.refresh).not.toHaveBeenCalled()
     } finally {
       Object.defineProperty(document, 'fonts', {
         configurable: true,
@@ -1418,8 +1426,8 @@ describe('Body', () => {
       const frameCallbacks: FrameRequestCallback[] = []
 
       vi.mocked(createTerminalInstance)
-        .mockImplementationOnce(() => firstTerminalControls.instance)
-        .mockImplementationOnce(() => secondTerminalControls.instance)
+        .mockResolvedValueOnce(firstTerminalControls.instance)
+        .mockResolvedValueOnce(secondTerminalControls.instance)
 
       const offsetWidthSpy = vi
         .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
@@ -1751,8 +1759,8 @@ describe('Body', () => {
       const secondTerminalControls = createMockTerminalControls()
 
       vi.mocked(createTerminalInstance)
-        .mockImplementationOnce(() => firstTerminalControls.instance)
-        .mockImplementationOnce(() => secondTerminalControls.instance)
+        .mockResolvedValueOnce(firstTerminalControls.instance)
+        .mockResolvedValueOnce(secondTerminalControls.instance)
 
       // Render with session A
       const { rerender } = render(

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -270,6 +270,29 @@ describe('Body', () => {
     })
   })
 
+  test('surfaces terminal instance creation failures', async () => {
+    vi.mocked(createTerminalInstance).mockRejectedValueOnce(
+      new Error('Unknown terminal renderer adapter: custom-renderer')
+    )
+
+    render(
+      <Body
+        sessionId="test-session"
+        cwd="/home/user"
+        service={defaultMockService}
+      />
+    )
+
+    const alert = await screen.findByTestId('terminal-startup-error')
+
+    expect(alert).toHaveTextContent('Terminal failed to start')
+    expect(alert).toHaveTextContent(
+      'Unknown terminal renderer adapter: custom-renderer'
+    )
+    expect(mockTerminal.open).not.toHaveBeenCalled()
+    expect(terminalCache.has('test-session')).toBe(false)
+  })
+
   test('repaints the terminal when the window regains focus', async () => {
     render(
       <Body

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -18,6 +18,7 @@ import {
 import { useTerminalClipboard } from '../../hooks/useTerminalClipboard'
 import { type ITerminalService } from '../../services/terminalService'
 import type {
+  TerminalDisposable,
   TerminalFitController,
   TerminalRendererHandle,
   TerminalSurface,
@@ -452,11 +453,15 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
     // Check if we already have a terminal for this session
     const cached = terminalCache.get(sessionId)
-    let newTerminal: TerminalSurface
-    let fitController: TerminalFitController
+    let newTerminal: TerminalSurface | null = null
+    let fitController: TerminalFitController | null = null
     let rendererHandle: TerminalRendererHandle | null = null
     let fitFrameId: number | null = null
     let lastFitSize: { width: number; height: number } | null = null
+    let resizeDisposable: TerminalDisposable | null = null
+    let resizeObserver: ResizeObserver | null = null
+    let removeFocusListeners: (() => void) | null = null
+    let removeVisibilityListeners: (() => void) | null = null
     let disposed = false
 
     const cancelScheduledFit = (): void => {
@@ -553,261 +558,283 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       return fitIfNeeded(targetFitController, true)
     }
 
-    let didInitialFit = false
+    const startTerminal = async (): Promise<void> => {
+      let didInitialFit = false
 
-    if (cached) {
-      // Reuse existing terminal from cache
-      newTerminal = cached.terminal
-      fitController = cached.fitController
-      fitControllerRef.current = fitController
+      if (cached) {
+        // Reuse existing terminal from cache
+        newTerminal = cached.terminal
+        fitController = cached.fitController
+        fitControllerRef.current = fitController
 
-      // Re-open terminal in the new container
-      newTerminal.open(node)
+        // Re-open terminal in the new container
+        newTerminal.open(node)
 
-      // Re-fit to new container — guard against hidden (display:none) containers
-      // where offsetWidth is 0. Fitting at zero width tells the renderer cols≈1,
-      // which causes the PTY to re-wrap scrollback into a narrow column.
-      didInitialFit = fitInitialWhenReady(fitController)
-    } else {
-      const created = createTerminalInstance()
-      newTerminal = created.terminal
-      fitController = created.fitController
-      fitControllerRef.current = fitController
+        // Re-fit to new container — guard against hidden (display:none) containers
+        // where offsetWidth is 0. Fitting at zero width tells the renderer cols≈1,
+        // which causes the PTY to re-wrap scrollback into a narrow column.
+        didInitialFit = fitInitialWhenReady(fitController)
+      } else {
+        const created = await createTerminalInstance()
 
-      // Open terminal in container before adapter-specific renderer addons
-      // attach to DOM/canvas elements.
-      newTerminal.open(node)
+        if (disposed) {
+          created.terminal.dispose()
 
-      rendererHandle = created.attachRenderer()
+          return
+        }
 
-      // Fit terminal to container — guard against hidden (display:none) containers
-      didInitialFit = fitInitialWhenReady(fitController)
+        newTerminal = created.terminal
+        fitController = created.fitController
+        fitControllerRef.current = fitController
 
-      // Register OSC 7 handler for cwd tracking. Shell prompts and agent/tool
-      // output both arrive through the terminal parser, so this stays pane-local.
-      created.parser.registerOscHandler(7, (data) => {
-        const previousCwd = agentCwdRef.current
+        // Open terminal in container before adapter-specific renderer addons
+        // attach to DOM/canvas elements.
+        newTerminal.open(node)
 
-        const path = parseOsc7Cwd(data, {
-          preserveFileUrlHost: shouldPreserveOsc7FileUrlHost(previousCwd),
-        })
+        rendererHandle = created.attachRenderer()
 
-        const shouldSuppressRestoreOsc7 = isRestoringOutputRef.current
+        // Fit terminal to container — guard against hidden (display:none) containers
+        didInitialFit = fitInitialWhenReady(fitController)
 
-        const shouldIgnore =
-          path !== null &&
-          !shouldSuppressRestoreOsc7 &&
-          shouldIgnoreStaleOsc7Cwd(
-            agentCwdRef.current,
-            path,
-            agentCwdSourceRef.current
-          )
+        // Register OSC 7 handler for cwd tracking. Shell prompts and agent/tool
+        // output both arrive through the terminal parser, so this stays pane-local.
+        created.parser.registerOscHandler(7, (data) => {
+          const previousCwd = agentCwdRef.current
 
-        logAgentCwdDebug('osc7', {
-          sessionId,
-          raw: data,
-          previousCwd,
-          nextCwd: path,
-          changed: path !== null && path !== previousCwd,
-          ignored: shouldIgnore || shouldSuppressRestoreOsc7,
-        })
+          const path = parseOsc7Cwd(data, {
+            preserveFileUrlHost: shouldPreserveOsc7FileUrlHost(previousCwd),
+          })
 
-        if (shouldSuppressRestoreOsc7) {
+          const shouldSuppressRestoreOsc7 = isRestoringOutputRef.current
+
+          const shouldIgnore =
+            path !== null &&
+            !shouldSuppressRestoreOsc7 &&
+            shouldIgnoreStaleOsc7Cwd(
+              agentCwdRef.current,
+              path,
+              agentCwdSourceRef.current
+            )
+
+          logAgentCwdDebug('osc7', {
+            sessionId,
+            raw: data,
+            previousCwd,
+            nextCwd: path,
+            changed: path !== null && path !== previousCwd,
+            ignored: shouldIgnore || shouldSuppressRestoreOsc7,
+          })
+
+          if (shouldSuppressRestoreOsc7) {
+            return true
+          }
+
+          if (path && path === agentCwdRef.current) {
+            agentCwdSourceRef.current = 'osc7'
+          } else if (path && !shouldIgnore) {
+            agentCwdOutputBufferRef.current = ''
+            agentCwdHintContextRef.current = ''
+            agentCwdRef.current = path
+            agentCwdSourceRef.current = 'osc7'
+            onCwdChangeRef.current?.(path)
+          }
+
           return true
-        }
+        })
 
-        if (path && path === agentCwdRef.current) {
-          agentCwdSourceRef.current = 'osc7'
-        } else if (path && !shouldIgnore) {
-          agentCwdOutputBufferRef.current = ''
-          agentCwdHintContextRef.current = ''
-          agentCwdRef.current = path
-          agentCwdSourceRef.current = 'osc7'
-          onCwdChangeRef.current?.(path)
-        }
-
-        return true
-      })
-
-      // Cache the terminal instance for this session
-      terminalCache.set(sessionId, {
-        terminal: newTerminal,
-        fitController,
-        viewportReader: created.viewportReader,
-      })
-    }
-
-    const refreshAfterFontFit = (): void => {
-      newTerminal.refresh(0, Math.max(newTerminal.rows - 1, 0))
-    }
-
-    const clearPendingDeferredFit = (): void => {
-      pendingDeferredFitFlushRef.current = false
-      pendingDeferredRefreshAfterFitRef.current = false
-    }
-
-    const refitAfterTerminalFontsSettle = (): void => {
-      if (disposed) {
-        return
+        // Cache the terminal instance for this session
+        terminalCache.set(sessionId, {
+          terminal: newTerminal,
+          fitController,
+          viewportReader: created.viewportReader,
+        })
       }
 
-      lastFitSize = null
+      const terminalForSetup = newTerminal
+      const fitControllerForSetup = fitController
 
-      if (deferFitRef.current) {
-        pendingDeferredFitFlushRef.current = true
-        pendingDeferredRefreshAfterFitRef.current = true
-
-        return
+      const refreshAfterFontFit = (): void => {
+        terminalForSetup.refresh(0, Math.max(terminalForSetup.rows - 1, 0))
       }
 
-      pendingDeferredRefreshAfterFitRef.current = true
-      flushFit(fitController, {
-        force: true,
-        afterFit: (): void => {
-          clearPendingDeferredFit()
-          refreshAfterFontFit()
-        },
-      })
-    }
-
-    const refitWhenTerminalFontsSettle = async (): Promise<void> => {
-      const terminalFontsLoaded = loadTerminalFonts()
-
-      if (!terminalFontsLoaded) {
-        return
-      }
-
-      try {
-        await terminalFontsLoaded
-      } catch {
-        // Fall back to the available system stack, then remeasure whatever loaded.
-      }
-
-      refitAfterTerminalFontsSettle()
-    }
-
-    if (!cached) {
-      void refitWhenTerminalFontsSettle()
-    }
-
-    const flushDeferredFit = (): void => {
-      if (pendingDeferredRefreshAfterFitRef.current) {
+      const clearPendingDeferredFit = (): void => {
         pendingDeferredFitFlushRef.current = false
-        flushFit(fitController, {
+        pendingDeferredRefreshAfterFitRef.current = false
+      }
+
+      const refitAfterTerminalFontsSettle = (): void => {
+        if (disposed) {
+          return
+        }
+
+        lastFitSize = null
+
+        if (deferFitRef.current) {
+          pendingDeferredFitFlushRef.current = true
+          pendingDeferredRefreshAfterFitRef.current = true
+
+          return
+        }
+
+        pendingDeferredRefreshAfterFitRef.current = true
+        flushFit(fitControllerForSetup, {
           force: true,
           afterFit: (): void => {
             clearPendingDeferredFit()
             refreshAfterFontFit()
           },
         })
-
-        return
       }
 
-      pendingDeferredFitFlushRef.current = false
-      flushFit(fitController)
-    }
+      const refitWhenTerminalFontsSettle = async (): Promise<void> => {
+        const terminalFontsLoaded = loadTerminalFonts()
 
-    const refreshAfterPendingInitialFit = (): void => {
-      if (!pendingDeferredRefreshAfterFitRef.current) {
+        if (!terminalFontsLoaded) {
+          return
+        }
+
+        try {
+          await terminalFontsLoaded
+        } catch {
+          // Fall back to the available system stack, then remeasure whatever loaded.
+        }
+
+        refitAfterTerminalFontsSettle()
+      }
+
+      if (!cached) {
+        void refitWhenTerminalFontsSettle()
+      }
+
+      const flushDeferredFit = (): void => {
+        if (pendingDeferredRefreshAfterFitRef.current) {
+          pendingDeferredFitFlushRef.current = false
+          flushFit(fitControllerForSetup, {
+            force: true,
+            afterFit: (): void => {
+              clearPendingDeferredFit()
+              refreshAfterFontFit()
+            },
+          })
+
+          return
+        }
+
         pendingDeferredFitFlushRef.current = false
-
-        return
+        flushFit(fitControllerForSetup)
       }
 
-      clearPendingDeferredFit()
-      refreshAfterFontFit()
-    }
+      const refreshAfterPendingInitialFit = (): void => {
+        if (!pendingDeferredRefreshAfterFitRef.current) {
+          pendingDeferredFitFlushRef.current = false
 
-    cancelScheduledFitRef.current = cancelScheduledFit
-    flushFitRef.current = flushDeferredFit
-    flushFitSessionIdRef.current = sessionId
+          return
+        }
 
-    if (
-      (pendingDeferredFitFlushRef.current ||
-        pendingDeferredRefreshAfterFitRef.current) &&
-      !deferFitRef.current
-    ) {
-      if (!didInitialFit) {
-        flushDeferredFit()
-      } else {
-        refreshAfterPendingInitialFit()
+        clearPendingDeferredFit()
+        refreshAfterFontFit()
       }
-    }
 
-    // Send initial terminal size to PTY (avoids default 80×24 when terminal is actually larger)
-    // This will be a no-op on first render but ensures PTY gets correct size on subsequent recreations
-    resizeRef.current(newTerminal.cols, newTerminal.rows)
-
-    // Handle resize events - notify PTY of terminal size changes.
-    // The cols/rows from the terminal's onResize event are already correct because
-    // fitController.fit() (the trigger upstream) has already computed and applied
-    // them. Calling fit() again here would re-measure the container — pure
-    // overhead during rapid sidebar drag / window resize. Just forward to PTY.
-    let lastForwardedResize: { cols: number; rows: number } | null = null
-
-    const resizeDisposable = newTerminal.onResize(({ cols, rows }) => {
-      // Guard: don't forward resize when container is hidden (display:none).
-      // Otherwise the PTY receives cols≈1 and re-wraps scrollback.
-      const width = containerRef.current?.offsetWidth ?? 0
-      if (width <= 0) {
-        return
-      }
+      cancelScheduledFitRef.current = cancelScheduledFit
+      flushFitRef.current = flushDeferredFit
+      flushFitSessionIdRef.current = sessionId
 
       if (
-        lastForwardedResize?.cols === cols &&
-        lastForwardedResize.rows === rows
+        (pendingDeferredFitFlushRef.current ||
+          pendingDeferredRefreshAfterFitRef.current) &&
+        !deferFitRef.current
       ) {
-        return
+        if (!didInitialFit) {
+          flushDeferredFit()
+        } else {
+          refreshAfterPendingInitialFit()
+        }
       }
 
-      lastForwardedResize = { cols, rows }
+      // Send initial terminal size to PTY (avoids default 80×24 when terminal is actually larger)
+      // This will be a no-op on first render but ensures PTY gets correct size on subsequent recreations
+      resizeRef.current(terminalForSetup.cols, terminalForSetup.rows)
 
-      // Notify PTY service of size change using ref (stable across renders)
-      resizeRef.current(cols, rows)
-    })
+      // Handle resize events - notify PTY of terminal size changes.
+      // The cols/rows from the terminal's onResize event are already correct because
+      // fitController.fit() (the trigger upstream) has already computed and applied
+      // them. Calling fit() again here would re-measure the container — pure
+      // overhead during rapid sidebar drag / window resize. Just forward to PTY.
+      let lastForwardedResize: { cols: number; rows: number } | null = null
 
-    const handleFocusIn = (): void => {
-      onFocusChangeRef.current?.(true)
-    }
+      resizeDisposable = terminalForSetup.onResize(({ cols, rows }) => {
+        // Guard: don't forward resize when container is hidden (display:none).
+        // Otherwise the PTY receives cols≈1 and re-wraps scrollback.
+        const width = containerRef.current?.offsetWidth ?? 0
+        if (width <= 0) {
+          return
+        }
 
-    const handleFocusOut = (): void => {
-      onFocusChangeRef.current?.(false)
-    }
+        if (
+          lastForwardedResize?.cols === cols &&
+          lastForwardedResize.rows === rows
+        ) {
+          return
+        }
 
-    node.addEventListener('focusin', handleFocusIn)
-    node.addEventListener('focusout', handleFocusOut)
+        lastForwardedResize = { cols, rows }
 
-    // Root cause B (Claude + Codex consensus): the terminal renders on a debounced
-    // animation-frame loop and never forces a repaint when the OS window
-    // regains focus or visibility. The browser throttles that loop while the
-    // window is covered or unfocused, so rows that streamed in while we were
-    // away stay stale until something forces a repaint (the buffer is correct
-    // — a text selection fixes only the pixels). Repaint on focus/visibility
-    // recovery to flush them.
-    const repaintOnWindowVisible = (): void => {
-      if (document.visibilityState !== 'visible') {
-        return
+        // Notify PTY service of size change using ref (stable across renders)
+        resizeRef.current(cols, rows)
+      })
+
+      const handleFocusIn = (): void => {
+        onFocusChangeRef.current?.(true)
       }
 
-      newTerminal.refresh(0, Math.max(newTerminal.rows - 1, 0))
+      const handleFocusOut = (): void => {
+        onFocusChangeRef.current?.(false)
+      }
+
+      node.addEventListener('focusin', handleFocusIn)
+      node.addEventListener('focusout', handleFocusOut)
+      removeFocusListeners = (): void => {
+        node.removeEventListener('focusin', handleFocusIn)
+        node.removeEventListener('focusout', handleFocusOut)
+      }
+
+      // Root cause B (Claude + Codex consensus): the terminal renders on a debounced
+      // animation-frame loop and never forces a repaint when the OS window
+      // regains focus or visibility. The browser throttles that loop while the
+      // window is covered or unfocused, so rows that streamed in while we were
+      // away stay stale until something forces a repaint (the buffer is correct
+      // — a text selection fixes only the pixels). Repaint on focus/visibility
+      // recovery to flush them.
+      const repaintOnWindowVisible = (): void => {
+        if (document.visibilityState !== 'visible') {
+          return
+        }
+
+        terminalForSetup.refresh(0, Math.max(terminalForSetup.rows - 1, 0))
+      }
+
+      window.addEventListener('focus', repaintOnWindowVisible)
+      document.addEventListener('visibilitychange', repaintOnWindowVisible)
+      removeVisibilityListeners = (): void => {
+        window.removeEventListener('focus', repaintOnWindowVisible)
+        document.removeEventListener('visibilitychange', repaintOnWindowVisible)
+      }
+
+      // P2 Fix: Add ResizeObserver to detect container size changes
+      // When the container resizes (e.g., window resize, panel collapse),
+      // fit the terminal which will trigger the onResize event above.
+      // Guard: skip fit when container is hidden (display:none → width=0)
+      // to avoid PTY scrollback re-wrapping at a narrow column count.
+      resizeObserver = new ResizeObserver(() => {
+        scheduleFit(fitControllerForSetup)
+      })
+      resizeObserver.observe(node)
+
+      // Store terminal in state to trigger useTerminal hook
+      setTerminal(terminalForSetup)
     }
 
-    window.addEventListener('focus', repaintOnWindowVisible)
-    document.addEventListener('visibilitychange', repaintOnWindowVisible)
-
-    // P2 Fix: Add ResizeObserver to detect container size changes
-    // When the container resizes (e.g., window resize, panel collapse),
-    // fit the terminal which will trigger the onResize event above.
-    // Guard: skip fit when container is hidden (display:none → width=0)
-    // to avoid PTY scrollback re-wrapping at a narrow column count.
-    const resizeObserver = new ResizeObserver(() => {
-      scheduleFit(fitController)
-    })
-    resizeObserver.observe(node)
-
-    // Store terminal in state to trigger useTerminal hook
-    setTerminal(newTerminal)
+    void startTerminal()
 
     // Cleanup: disconnect observers and dispose terminal from cache
     // When Body unmounts, the session is closed — free resources
@@ -821,12 +848,14 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         flushFitRef.current = null
         flushFitSessionIdRef.current = null
       }
-      resizeObserver.disconnect()
-      resizeDisposable.dispose()
-      node.removeEventListener('focusin', handleFocusIn)
-      node.removeEventListener('focusout', handleFocusOut)
-      window.removeEventListener('focus', repaintOnWindowVisible)
-      document.removeEventListener('visibilitychange', repaintOnWindowVisible)
+      resizeObserver?.disconnect()
+      resizeObserver = null
+      resizeDisposable?.dispose()
+      resizeDisposable = null
+      removeFocusListeners?.()
+      removeFocusListeners = null
+      removeVisibilityListeners?.()
+      removeVisibilityListeners = null
       // Renderer addons must dispose before the terminal itself; the handle
       // owns that adapter-specific ordering.
       rendererHandle?.dispose()
@@ -835,7 +864,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       if (entry) {
         entry.terminal.dispose()
         terminalCache.delete(sessionId)
+      } else {
+        newTerminal?.dispose()
       }
+      newTerminal = null
+      fitController = null
       setTerminal(null)
       fitControllerRef.current = null
     }

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -65,6 +65,14 @@ const logAgentCwdDebug = (
   console.info(`[vimeflow:terminal-cwd] ${event} ${JSON.stringify(details)}`)
 }
 
+const terminalStartupErrorMessage = (error: unknown): string => {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message
+  }
+
+  return 'Unknown terminal startup error'
+}
+
 export { clearTerminalCache, disposeTerminalSession, terminalCache }
 
 export type BodyMode = 'attach' | 'spawn'
@@ -170,7 +178,13 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   ref
 ): ReactElement {
   const containerRef = useRef<HTMLDivElement>(null)
+
   const [terminal, setTerminal] = useState<TerminalSurface | null>(null)
+
+  const [terminalStartupError, setTerminalStartupError] = useState<
+    string | null
+  >(null)
+
   const fitControllerRef = useRef<TerminalFitController | null>(null)
   const deferFitRef = useRef(deferFit)
   const previousDeferFitRef = useRef(deferFit)
@@ -559,156 +573,127 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     }
 
     const startTerminal = async (): Promise<void> => {
-      let didInitialFit = false
+      setTerminalStartupError(null)
 
-      if (cached) {
-        // Reuse existing terminal from cache
-        newTerminal = cached.terminal
-        fitController = cached.fitController
-        fitControllerRef.current = fitController
+      try {
+        let didInitialFit = false
 
-        // Re-open terminal in the new container
-        newTerminal.open(node)
+        if (cached) {
+          // Reuse existing terminal from cache
+          newTerminal = cached.terminal
+          fitController = cached.fitController
+          fitControllerRef.current = fitController
 
-        // Re-fit to new container — guard against hidden (display:none) containers
-        // where offsetWidth is 0. Fitting at zero width tells the renderer cols≈1,
-        // which causes the PTY to re-wrap scrollback into a narrow column.
-        didInitialFit = fitInitialWhenReady(fitController)
-      } else {
-        const created = await createTerminalInstance()
+          // Re-open terminal in the new container
+          newTerminal.open(node)
 
-        if (disposed) {
-          created.terminal.dispose()
+          // Re-fit to new container — guard against hidden (display:none) containers
+          // where offsetWidth is 0. Fitting at zero width tells the renderer cols≈1,
+          // which causes the PTY to re-wrap scrollback into a narrow column.
+          didInitialFit = fitInitialWhenReady(fitController)
+        } else {
+          const created = await createTerminalInstance()
 
-          return
-        }
+          if (disposed) {
+            created.terminal.dispose()
 
-        newTerminal = created.terminal
-        fitController = created.fitController
-        fitControllerRef.current = fitController
+            return
+          }
 
-        // Open terminal in container before adapter-specific renderer addons
-        // attach to DOM/canvas elements.
-        newTerminal.open(node)
+          newTerminal = created.terminal
+          fitController = created.fitController
+          fitControllerRef.current = fitController
 
-        rendererHandle = created.attachRenderer()
+          // Open terminal in container before adapter-specific renderer addons
+          // attach to DOM/canvas elements.
+          newTerminal.open(node)
 
-        // Fit terminal to container — guard against hidden (display:none) containers
-        didInitialFit = fitInitialWhenReady(fitController)
+          rendererHandle = created.attachRenderer()
 
-        // Register OSC 7 handler for cwd tracking. Shell prompts and agent/tool
-        // output both arrive through the terminal parser, so this stays pane-local.
-        created.parser.registerOscHandler(7, (data) => {
-          const previousCwd = agentCwdRef.current
+          // Fit terminal to container — guard against hidden (display:none) containers
+          didInitialFit = fitInitialWhenReady(fitController)
 
-          const path = parseOsc7Cwd(data, {
-            preserveFileUrlHost: shouldPreserveOsc7FileUrlHost(previousCwd),
-          })
+          // Register OSC 7 handler for cwd tracking. Shell prompts and agent/tool
+          // output both arrive through the terminal parser, so this stays pane-local.
+          created.parser.registerOscHandler(7, (data) => {
+            const previousCwd = agentCwdRef.current
 
-          const shouldSuppressRestoreOsc7 = isRestoringOutputRef.current
+            const path = parseOsc7Cwd(data, {
+              preserveFileUrlHost: shouldPreserveOsc7FileUrlHost(previousCwd),
+            })
 
-          const shouldIgnore =
-            path !== null &&
-            !shouldSuppressRestoreOsc7 &&
-            shouldIgnoreStaleOsc7Cwd(
-              agentCwdRef.current,
-              path,
-              agentCwdSourceRef.current
-            )
+            const shouldSuppressRestoreOsc7 = isRestoringOutputRef.current
 
-          logAgentCwdDebug('osc7', {
-            sessionId,
-            raw: data,
-            previousCwd,
-            nextCwd: path,
-            changed: path !== null && path !== previousCwd,
-            ignored: shouldIgnore || shouldSuppressRestoreOsc7,
-          })
+            const shouldIgnore =
+              path !== null &&
+              !shouldSuppressRestoreOsc7 &&
+              shouldIgnoreStaleOsc7Cwd(
+                agentCwdRef.current,
+                path,
+                agentCwdSourceRef.current
+              )
 
-          if (shouldSuppressRestoreOsc7) {
+            logAgentCwdDebug('osc7', {
+              sessionId,
+              raw: data,
+              previousCwd,
+              nextCwd: path,
+              changed: path !== null && path !== previousCwd,
+              ignored: shouldIgnore || shouldSuppressRestoreOsc7,
+            })
+
+            if (shouldSuppressRestoreOsc7) {
+              return true
+            }
+
+            if (path && path === agentCwdRef.current) {
+              agentCwdSourceRef.current = 'osc7'
+            } else if (path && !shouldIgnore) {
+              agentCwdOutputBufferRef.current = ''
+              agentCwdHintContextRef.current = ''
+              agentCwdRef.current = path
+              agentCwdSourceRef.current = 'osc7'
+              onCwdChangeRef.current?.(path)
+            }
+
             return true
-          }
+          })
 
-          if (path && path === agentCwdRef.current) {
-            agentCwdSourceRef.current = 'osc7'
-          } else if (path && !shouldIgnore) {
-            agentCwdOutputBufferRef.current = ''
-            agentCwdHintContextRef.current = ''
-            agentCwdRef.current = path
-            agentCwdSourceRef.current = 'osc7'
-            onCwdChangeRef.current?.(path)
-          }
-
-          return true
-        })
-
-        // Cache the terminal instance for this session
-        terminalCache.set(sessionId, {
-          terminal: newTerminal,
-          fitController,
-          viewportReader: created.viewportReader,
-        })
-      }
-
-      const terminalForSetup = newTerminal
-      const fitControllerForSetup = fitController
-
-      const refreshAfterFontFit = (): void => {
-        terminalForSetup.refresh(0, Math.max(terminalForSetup.rows - 1, 0))
-      }
-
-      const clearPendingDeferredFit = (): void => {
-        pendingDeferredFitFlushRef.current = false
-        pendingDeferredRefreshAfterFitRef.current = false
-      }
-
-      const refitAfterTerminalFontsSettle = (): void => {
-        if (disposed) {
-          return
+          // Cache the terminal instance for this session
+          terminalCache.set(sessionId, {
+            terminal: newTerminal,
+            fitController,
+            viewportReader: created.viewportReader,
+          })
         }
 
-        lastFitSize = null
+        const terminalForSetup = newTerminal
+        const fitControllerForSetup = fitController
 
-        if (deferFitRef.current) {
-          pendingDeferredFitFlushRef.current = true
-          pendingDeferredRefreshAfterFitRef.current = true
-
-          return
+        const refreshAfterFontFit = (): void => {
+          terminalForSetup.refresh(0, Math.max(terminalForSetup.rows - 1, 0))
         }
 
-        pendingDeferredRefreshAfterFitRef.current = true
-        flushFit(fitControllerForSetup, {
-          force: true,
-          afterFit: (): void => {
-            clearPendingDeferredFit()
-            refreshAfterFontFit()
-          },
-        })
-      }
-
-      const refitWhenTerminalFontsSettle = async (): Promise<void> => {
-        const terminalFontsLoaded = loadTerminalFonts()
-
-        if (!terminalFontsLoaded) {
-          return
-        }
-
-        try {
-          await terminalFontsLoaded
-        } catch {
-          // Fall back to the available system stack, then remeasure whatever loaded.
-        }
-
-        refitAfterTerminalFontsSettle()
-      }
-
-      if (!cached) {
-        void refitWhenTerminalFontsSettle()
-      }
-
-      const flushDeferredFit = (): void => {
-        if (pendingDeferredRefreshAfterFitRef.current) {
+        const clearPendingDeferredFit = (): void => {
           pendingDeferredFitFlushRef.current = false
+          pendingDeferredRefreshAfterFitRef.current = false
+        }
+
+        const refitAfterTerminalFontsSettle = (): void => {
+          if (disposed) {
+            return
+          }
+
+          lastFitSize = null
+
+          if (deferFitRef.current) {
+            pendingDeferredFitFlushRef.current = true
+            pendingDeferredRefreshAfterFitRef.current = true
+
+            return
+          }
+
+          pendingDeferredRefreshAfterFitRef.current = true
           flushFit(fitControllerForSetup, {
             force: true,
             afterFit: (): void => {
@@ -716,122 +701,179 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
               refreshAfterFontFit()
             },
           })
-
-          return
         }
 
-        pendingDeferredFitFlushRef.current = false
-        flushFit(fitControllerForSetup)
-      }
+        const refitWhenTerminalFontsSettle = async (): Promise<void> => {
+          const terminalFontsLoaded = loadTerminalFonts()
 
-      const refreshAfterPendingInitialFit = (): void => {
-        if (!pendingDeferredRefreshAfterFitRef.current) {
+          if (!terminalFontsLoaded) {
+            return
+          }
+
+          try {
+            await terminalFontsLoaded
+          } catch {
+            // Fall back to the available system stack, then remeasure whatever loaded.
+          }
+
+          refitAfterTerminalFontsSettle()
+        }
+
+        if (!cached) {
+          void refitWhenTerminalFontsSettle()
+        }
+
+        const flushDeferredFit = (): void => {
+          if (pendingDeferredRefreshAfterFitRef.current) {
+            pendingDeferredFitFlushRef.current = false
+            flushFit(fitControllerForSetup, {
+              force: true,
+              afterFit: (): void => {
+                clearPendingDeferredFit()
+                refreshAfterFontFit()
+              },
+            })
+
+            return
+          }
+
           pendingDeferredFitFlushRef.current = false
-
-          return
+          flushFit(fitControllerForSetup)
         }
 
-        clearPendingDeferredFit()
-        refreshAfterFontFit()
-      }
+        const refreshAfterPendingInitialFit = (): void => {
+          if (!pendingDeferredRefreshAfterFitRef.current) {
+            pendingDeferredFitFlushRef.current = false
 
-      cancelScheduledFitRef.current = cancelScheduledFit
-      flushFitRef.current = flushDeferredFit
-      flushFitSessionIdRef.current = sessionId
+            return
+          }
 
-      if (
-        (pendingDeferredFitFlushRef.current ||
-          pendingDeferredRefreshAfterFitRef.current) &&
-        !deferFitRef.current
-      ) {
-        if (!didInitialFit) {
-          flushDeferredFit()
-        } else {
-          refreshAfterPendingInitialFit()
+          clearPendingDeferredFit()
+          refreshAfterFontFit()
         }
-      }
 
-      // Send initial terminal size to PTY (avoids default 80×24 when terminal is actually larger)
-      // This will be a no-op on first render but ensures PTY gets correct size on subsequent recreations
-      resizeRef.current(terminalForSetup.cols, terminalForSetup.rows)
-
-      // Handle resize events - notify PTY of terminal size changes.
-      // The cols/rows from the terminal's onResize event are already correct because
-      // fitController.fit() (the trigger upstream) has already computed and applied
-      // them. Calling fit() again here would re-measure the container — pure
-      // overhead during rapid sidebar drag / window resize. Just forward to PTY.
-      let lastForwardedResize: { cols: number; rows: number } | null = null
-
-      resizeDisposable = terminalForSetup.onResize(({ cols, rows }) => {
-        // Guard: don't forward resize when container is hidden (display:none).
-        // Otherwise the PTY receives cols≈1 and re-wraps scrollback.
-        const width = containerRef.current?.offsetWidth ?? 0
-        if (width <= 0) {
-          return
-        }
+        cancelScheduledFitRef.current = cancelScheduledFit
+        flushFitRef.current = flushDeferredFit
+        flushFitSessionIdRef.current = sessionId
 
         if (
-          lastForwardedResize?.cols === cols &&
-          lastForwardedResize.rows === rows
+          (pendingDeferredFitFlushRef.current ||
+            pendingDeferredRefreshAfterFitRef.current) &&
+          !deferFitRef.current
         ) {
+          if (!didInitialFit) {
+            flushDeferredFit()
+          } else {
+            refreshAfterPendingInitialFit()
+          }
+        }
+
+        // Send initial terminal size to PTY (avoids default 80×24 when terminal is actually larger)
+        // This will be a no-op on first render but ensures PTY gets correct size on subsequent recreations
+        resizeRef.current(terminalForSetup.cols, terminalForSetup.rows)
+
+        // Handle resize events - notify PTY of terminal size changes.
+        // The cols/rows from the terminal's onResize event are already correct because
+        // fitController.fit() (the trigger upstream) has already computed and applied
+        // them. Calling fit() again here would re-measure the container — pure
+        // overhead during rapid sidebar drag / window resize. Just forward to PTY.
+        let lastForwardedResize: { cols: number; rows: number } | null = null
+
+        resizeDisposable = terminalForSetup.onResize(({ cols, rows }) => {
+          // Guard: don't forward resize when container is hidden (display:none).
+          // Otherwise the PTY receives cols≈1 and re-wraps scrollback.
+          const width = containerRef.current?.offsetWidth ?? 0
+          if (width <= 0) {
+            return
+          }
+
+          if (
+            lastForwardedResize?.cols === cols &&
+            lastForwardedResize.rows === rows
+          ) {
+            return
+          }
+
+          lastForwardedResize = { cols, rows }
+
+          // Notify PTY service of size change using ref (stable across renders)
+          resizeRef.current(cols, rows)
+        })
+
+        const handleFocusIn = (): void => {
+          onFocusChangeRef.current?.(true)
+        }
+
+        const handleFocusOut = (): void => {
+          onFocusChangeRef.current?.(false)
+        }
+
+        node.addEventListener('focusin', handleFocusIn)
+        node.addEventListener('focusout', handleFocusOut)
+        removeFocusListeners = (): void => {
+          node.removeEventListener('focusin', handleFocusIn)
+          node.removeEventListener('focusout', handleFocusOut)
+        }
+
+        // Root cause B (Claude + Codex consensus): the terminal renders on a debounced
+        // animation-frame loop and never forces a repaint when the OS window
+        // regains focus or visibility. The browser throttles that loop while the
+        // window is covered or unfocused, so rows that streamed in while we were
+        // away stay stale until something forces a repaint (the buffer is correct
+        // — a text selection fixes only the pixels). Repaint on focus/visibility
+        // recovery to flush them.
+        const repaintOnWindowVisible = (): void => {
+          if (document.visibilityState !== 'visible') {
+            return
+          }
+
+          terminalForSetup.refresh(0, Math.max(terminalForSetup.rows - 1, 0))
+        }
+
+        window.addEventListener('focus', repaintOnWindowVisible)
+        document.addEventListener('visibilitychange', repaintOnWindowVisible)
+        removeVisibilityListeners = (): void => {
+          window.removeEventListener('focus', repaintOnWindowVisible)
+          document.removeEventListener(
+            'visibilitychange',
+            repaintOnWindowVisible
+          )
+        }
+
+        // P2 Fix: Add ResizeObserver to detect container size changes
+        // When the container resizes (e.g., window resize, panel collapse),
+        // fit the terminal which will trigger the onResize event above.
+        // Guard: skip fit when container is hidden (display:none → width=0)
+        // to avoid PTY scrollback re-wrapping at a narrow column count.
+        resizeObserver = new ResizeObserver(() => {
+          scheduleFit(fitControllerForSetup)
+        })
+        resizeObserver.observe(node)
+
+        // Store terminal in state to trigger useTerminal hook
+        setTerminal(terminalForSetup)
+      } catch (error) {
+        if (disposed) {
           return
         }
 
-        lastForwardedResize = { cols, rows }
+        rendererHandle?.dispose()
+        rendererHandle = null
 
-        // Notify PTY service of size change using ref (stable across renders)
-        resizeRef.current(cols, rows)
-      })
-
-      const handleFocusIn = (): void => {
-        onFocusChangeRef.current?.(true)
-      }
-
-      const handleFocusOut = (): void => {
-        onFocusChangeRef.current?.(false)
-      }
-
-      node.addEventListener('focusin', handleFocusIn)
-      node.addEventListener('focusout', handleFocusOut)
-      removeFocusListeners = (): void => {
-        node.removeEventListener('focusin', handleFocusIn)
-        node.removeEventListener('focusout', handleFocusOut)
-      }
-
-      // Root cause B (Claude + Codex consensus): the terminal renders on a debounced
-      // animation-frame loop and never forces a repaint when the OS window
-      // regains focus or visibility. The browser throttles that loop while the
-      // window is covered or unfocused, so rows that streamed in while we were
-      // away stay stale until something forces a repaint (the buffer is correct
-      // — a text selection fixes only the pixels). Repaint on focus/visibility
-      // recovery to flush them.
-      const repaintOnWindowVisible = (): void => {
-        if (document.visibilityState !== 'visible') {
-          return
+        const entry = terminalCache.get(sessionId)
+        if (entry?.terminal === newTerminal) {
+          entry.terminal.dispose()
+          terminalCache.delete(sessionId)
+        } else {
+          newTerminal?.dispose()
         }
 
-        terminalForSetup.refresh(0, Math.max(terminalForSetup.rows - 1, 0))
+        newTerminal = null
+        fitController = null
+        fitControllerRef.current = null
+        setTerminal(null)
+        setTerminalStartupError(terminalStartupErrorMessage(error))
       }
-
-      window.addEventListener('focus', repaintOnWindowVisible)
-      document.addEventListener('visibilitychange', repaintOnWindowVisible)
-      removeVisibilityListeners = (): void => {
-        window.removeEventListener('focus', repaintOnWindowVisible)
-        document.removeEventListener('visibilitychange', repaintOnWindowVisible)
-      }
-
-      // P2 Fix: Add ResizeObserver to detect container size changes
-      // When the container resizes (e.g., window resize, panel collapse),
-      // fit the terminal which will trigger the onResize event above.
-      // Guard: skip fit when container is hidden (display:none → width=0)
-      // to avoid PTY scrollback re-wrapping at a narrow column count.
-      resizeObserver = new ResizeObserver(() => {
-        scheduleFit(fitControllerForSetup)
-      })
-      resizeObserver.observe(node)
-
-      // Store terminal in state to trigger useTerminal hook
-      setTerminal(terminalForSetup)
     }
 
     void startTerminal()
@@ -893,6 +935,22 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         data-terminal-focus-scope={TERMINAL_FOCUS_SCOPE_VALUE}
         className="h-full w-full"
       />
+      {terminalStartupError ? (
+        <div
+          role="alert"
+          data-testid="terminal-startup-error"
+          className="absolute inset-0 grid place-items-center bg-surface-container-lowest/85 px-6 text-center"
+        >
+          <div className="max-w-[34rem] rounded-[8px] bg-surface-container/90 px-4 py-3 shadow-[0_16px_44px_color-mix(in_srgb,var(--color-scrim)_35%,transparent)]">
+            <p className="text-[12px] font-medium text-error">
+              Terminal failed to start
+            </p>
+            <p className="mt-1 break-words font-mono text-[11px] text-on-surface-muted">
+              {terminalStartupError}
+            </p>
+          </div>
+        </div>
+      ) : null}
       <TerminalContextMenu
         isOpen={clipboard.isOpen}
         position={clipboard.openAt}

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -12,9 +12,10 @@ import type {
   TerminalTheme,
   TerminalViewportReader,
 } from '../../types'
+import { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
 import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
 
-export const PLAIN_TEXT_TERMINAL_RENDERER_ID = 'plain-text'
+export { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
 
 const DEFAULT_COLS = 80
 const DEFAULT_ROWS = 24

--- a/src/features/terminal/components/TerminalPane/plainTextRendererMetadata.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextRendererMetadata.ts
@@ -1,0 +1,1 @@
+export const PLAIN_TEXT_TERMINAL_RENDERER_ID = 'plain-text'

--- a/src/features/terminal/components/TerminalPane/terminalInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalInstance.test.ts
@@ -6,7 +6,7 @@ vi.mock('./terminalRendererRegistry', () => ({
   createConfiguredTerminalInstance: vi.fn(),
 }))
 
-test('creates the configured terminal renderer instance', () => {
+test('creates the configured terminal renderer instance', async () => {
   const instance = {
     terminal: {},
     parser: {},
@@ -14,7 +14,9 @@ test('creates the configured terminal renderer instance', () => {
     fitController: {},
     attachRenderer: vi.fn(),
   }
-  vi.mocked(createConfiguredTerminalInstance).mockReturnValue(instance as never)
+  vi.mocked(createConfiguredTerminalInstance).mockResolvedValue(
+    instance as never
+  )
 
-  expect(createTerminalInstance()).toBe(instance)
+  await expect(createTerminalInstance()).resolves.toBe(instance)
 })

--- a/src/features/terminal/components/TerminalPane/terminalInstance.ts
+++ b/src/features/terminal/components/TerminalPane/terminalInstance.ts
@@ -1,5 +1,5 @@
 import type { TerminalInstance } from '../../types'
 import { createConfiguredTerminalInstance } from './terminalRendererRegistry'
 
-export const createTerminalInstance = (): TerminalInstance =>
+export const createTerminalInstance = async (): Promise<TerminalInstance> =>
   createConfiguredTerminalInstance()

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
@@ -1,15 +1,8 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { TerminalInstance, TerminalRendererAdapter } from '../../types'
-import {
-  _resetTerminalRendererRegistryForTest,
-  configureTerminalRendererFromEnvironment,
-  createConfiguredTerminalInstance,
-  getTerminalRendererAdapter,
-  registerTerminalRendererAdapter,
-  setTerminalRendererAdapter,
-} from './terminalRendererRegistry'
-import { plainTextTerminalRenderer } from './plainTextInstance'
-import { xtermTerminalRenderer } from './xtermInstance'
+
+type TerminalRendererRegistryModule =
+  typeof import('./terminalRendererRegistry')
 
 const xtermRendererMocks = vi.hoisted(() => ({
   createInstance: vi.fn(),
@@ -17,14 +10,19 @@ const xtermRendererMocks = vi.hoisted(() => ({
 
 const plainTextRendererMocks = vi.hoisted(() => ({
   createInstance: vi.fn(),
+  moduleLoaded: vi.fn(),
 }))
 
-vi.mock('./plainTextInstance', () => ({
-  plainTextTerminalRenderer: {
-    id: 'plain-text',
-    createInstance: plainTextRendererMocks.createInstance,
-  },
-}))
+vi.mock('./plainTextInstance', () => {
+  plainTextRendererMocks.moduleLoaded()
+
+  return {
+    plainTextTerminalRenderer: {
+      id: 'plain-text',
+      createInstance: plainTextRendererMocks.createInstance,
+    },
+  }
+})
 
 vi.mock('./xtermInstance', () => ({
   xtermTerminalRenderer: {
@@ -32,6 +30,10 @@ vi.mock('./xtermInstance', () => ({
     createInstance: xtermRendererMocks.createInstance,
   },
 }))
+
+const importTerminalRendererRegistry =
+  async (): Promise<TerminalRendererRegistryModule> =>
+    import('./terminalRendererRegistry')
 
 const createTerminalInstance = (): TerminalInstance => ({
   terminal: {
@@ -76,142 +78,190 @@ const createTerminalRendererAdapter = (
 
 describe('terminalRendererRegistry', () => {
   afterEach(() => {
-    _resetTerminalRendererRegistryForTest()
     vi.unstubAllEnvs()
+    vi.resetModules()
     vi.clearAllMocks()
   })
 
-  test('uses the xterm renderer adapter by default', () => {
+  test('uses the xterm renderer adapter by default without loading the plain-text module', async () => {
+    const registry = await importTerminalRendererRegistry()
     const instance = createTerminalInstance()
+
     xtermRendererMocks.createInstance.mockReturnValue(instance)
 
-    expect(getTerminalRendererAdapter()).toBe(xtermTerminalRenderer)
-    expect(createConfiguredTerminalInstance()).toBe(instance)
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'xterm' })
+    )
+    expect(await registry.createConfiguredTerminalInstance()).toBe(instance)
     expect(xtermRendererMocks.createInstance).toHaveBeenCalledOnce()
+    expect(plainTextRendererMocks.moduleLoaded).not.toHaveBeenCalled()
   })
 
-  test('creates instances through a registered non-xterm renderer adapter', () => {
+  test('does not expose the bundled plain-text renderer on the default path', async () => {
+    const registry = await importTerminalRendererRegistry()
+
+    expect(() => registry.setTerminalRendererAdapter('plain-text')).toThrow(
+      'Unknown terminal renderer adapter: plain-text'
+    )
+    expect(plainTextRendererMocks.moduleLoaded).not.toHaveBeenCalled()
+  })
+
+  test('creates instances through a registered non-xterm renderer adapter', async () => {
+    const registry = await importTerminalRendererRegistry()
     const instance = createTerminalInstance()
     const customRenderer = createTerminalRendererAdapter('custom', instance)
 
-    registerTerminalRendererAdapter(customRenderer)
-    setTerminalRendererAdapter('custom')
+    registry.registerTerminalRendererAdapter(customRenderer)
+    registry.setTerminalRendererAdapter('custom')
 
-    expect(getTerminalRendererAdapter()).toEqual(
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
       expect.objectContaining({ id: 'custom' })
     )
-    expect(createConfiguredTerminalInstance()).toBe(instance)
+    expect(await registry.createConfiguredTerminalInstance()).toBe(instance)
     expect(customRenderer.createInstance).toHaveBeenCalledOnce()
     expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
   })
 
-  test('creates instances through the renderer selected by environment', () => {
-    const instance = createTerminalInstance()
-    const customRenderer = createTerminalRendererAdapter('custom', instance)
-
-    registerTerminalRendererAdapter(customRenderer)
+  test('creates instances through the renderer selected by environment', async () => {
     vi.stubEnv('VITE_TERMINAL_RENDERER', 'custom')
 
-    expect(getTerminalRendererAdapter()).toEqual(
+    const registry = await importTerminalRendererRegistry()
+    const instance = createTerminalInstance()
+    const customRenderer = createTerminalRendererAdapter('custom', instance)
+
+    registry.registerTerminalRendererAdapter(customRenderer)
+
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
       expect.objectContaining({ id: 'custom' })
     )
-    expect(createConfiguredTerminalInstance()).toBe(instance)
+    expect(await registry.createConfiguredTerminalInstance()).toBe(instance)
     expect(customRenderer.createInstance).toHaveBeenCalledOnce()
     expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
   })
 
-  test('creates instances through the bundled plain-text renderer when selected', () => {
+  test('loads the bundled plain-text renderer only when selected by environment', async () => {
     const instance = createTerminalInstance()
-    plainTextRendererMocks.createInstance.mockReturnValue(instance)
 
+    plainTextRendererMocks.createInstance.mockReturnValue(instance)
     vi.stubEnv('VITE_TERMINAL_RENDERER', 'plain-text')
 
-    expect(getTerminalRendererAdapter()).toBe(plainTextTerminalRenderer)
-    expect(createConfiguredTerminalInstance()).toBe(instance)
+    const registry = await importTerminalRendererRegistry()
+
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'plain-text' })
+    )
+    expect(await registry.createConfiguredTerminalInstance()).toBe(instance)
+    expect(plainTextRendererMocks.moduleLoaded).toHaveBeenCalledOnce()
     expect(plainTextRendererMocks.createInstance).toHaveBeenCalledOnce()
     expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
   })
 
-  test('keeps xterm as the default when environment selection is blank', () => {
+  test('keeps xterm as the default when environment selection is blank', async () => {
+    vi.stubEnv('VITE_TERMINAL_RENDERER', ' ')
+
+    const registry = await importTerminalRendererRegistry()
     const instance = createTerminalInstance()
     const customRenderer = createTerminalRendererAdapter('custom', instance)
 
     xtermRendererMocks.createInstance.mockReturnValue(instance)
-    registerTerminalRendererAdapter(customRenderer)
-    setTerminalRendererAdapter('xterm')
-    vi.stubEnv('VITE_TERMINAL_RENDERER', ' ')
+    registry.registerTerminalRendererAdapter(customRenderer)
+    registry.setTerminalRendererAdapter('xterm')
 
-    expect(createConfiguredTerminalInstance()).toBe(instance)
-    expect(getTerminalRendererAdapter()).toBe(xtermTerminalRenderer)
+    expect(await registry.createConfiguredTerminalInstance()).toBe(instance)
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'xterm' })
+    )
     expect(customRenderer.createInstance).not.toHaveBeenCalled()
     expect(xtermRendererMocks.createInstance).toHaveBeenCalledOnce()
   })
 
-  test('rejects unknown environment renderer selection', () => {
+  test('rejects unknown environment renderer selection', async () => {
     vi.stubEnv('VITE_TERMINAL_RENDERER', 'missing')
 
-    expect(() => createConfiguredTerminalInstance()).toThrow(
+    const registry = await importTerminalRendererRegistry()
+
+    await expect(registry.createConfiguredTerminalInstance()).rejects.toThrow(
       'Unknown terminal renderer adapter: missing'
     )
   })
 
-  test('allows explicit environment configuration after adapter registration', () => {
+  test('allows explicit environment configuration after adapter registration', async () => {
+    vi.stubEnv('VITE_TERMINAL_RENDERER', ' custom ')
+
+    const registry = await importTerminalRendererRegistry()
     const instance = createTerminalInstance()
     const customRenderer = createTerminalRendererAdapter(' custom ', instance)
 
-    registerTerminalRendererAdapter(customRenderer)
-    vi.stubEnv('VITE_TERMINAL_RENDERER', ' custom ')
+    registry.registerTerminalRendererAdapter(customRenderer)
 
-    configureTerminalRendererFromEnvironment()
+    await registry.configureTerminalRendererFromEnvironment()
 
-    expect(getTerminalRendererAdapter()).toEqual(
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
       expect.objectContaining({ id: 'custom' })
     )
   })
 
-  test('rejects unknown renderer adapters', () => {
-    expect(() => setTerminalRendererAdapter('missing')).toThrow(
+  test('rejects unknown renderer adapters', async () => {
+    const registry = await importTerminalRendererRegistry()
+
+    expect(() => registry.setTerminalRendererAdapter('missing')).toThrow(
       'Unknown terminal renderer adapter: missing'
     )
   })
 
-  test('normalizes registered renderer adapter ids', () => {
+  test('normalizes registered renderer adapter ids', async () => {
+    const registry = await importTerminalRendererRegistry()
     const instance = createTerminalInstance()
     const renderer = createTerminalRendererAdapter(' custom ', instance)
 
-    registerTerminalRendererAdapter(renderer)
-    setTerminalRendererAdapter('custom')
+    registry.registerTerminalRendererAdapter(renderer)
+    registry.setTerminalRendererAdapter('custom')
 
-    expect(getTerminalRendererAdapter()).toEqual(
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
       expect.objectContaining({ id: 'custom' })
     )
   })
 
-  test('rejects empty renderer adapter ids', () => {
+  test('rejects empty renderer adapter ids', async () => {
+    const registry = await importTerminalRendererRegistry()
     const instance = createTerminalInstance()
     const renderer = createTerminalRendererAdapter(' ', instance)
 
-    expect(() => registerTerminalRendererAdapter(renderer)).toThrow(
+    expect(() => registry.registerTerminalRendererAdapter(renderer)).toThrow(
       'Terminal renderer adapter id is required'
     )
   })
 
-  test('resets to the default renderer adapter', () => {
+  test('resets to the default renderer adapter', async () => {
+    const registry = await importTerminalRendererRegistry()
     const instance = createTerminalInstance()
     const customRenderer = createTerminalRendererAdapter('custom', instance)
 
-    registerTerminalRendererAdapter(customRenderer)
-    setTerminalRendererAdapter('custom')
+    registry.registerTerminalRendererAdapter(customRenderer)
+    registry.setTerminalRendererAdapter('custom')
 
-    _resetTerminalRendererRegistryForTest()
+    registry._resetTerminalRendererRegistryForTest()
 
-    expect(getTerminalRendererAdapter()).toBe(xtermTerminalRenderer)
-    expect(() => setTerminalRendererAdapter('custom')).toThrow(
-      'Unknown terminal renderer adapter: custom'
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'xterm' })
     )
 
-    setTerminalRendererAdapter('plain-text')
+    expect(() => registry.setTerminalRendererAdapter('custom')).toThrow(
+      'Unknown terminal renderer adapter: custom'
+    )
+  })
 
-    expect(getTerminalRendererAdapter()).toBe(plainTextTerminalRenderer)
+  test('retains environment-loaded bundled adapters after reset', async () => {
+    vi.stubEnv('VITE_TERMINAL_RENDERER', 'plain-text')
+
+    const registry = await importTerminalRendererRegistry()
+
+    await registry.configureTerminalRendererFromEnvironment()
+    registry._resetTerminalRendererRegistryForTest()
+    registry.setTerminalRendererAdapter('plain-text')
+
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'plain-text' })
+    )
   })
 })

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
@@ -1,14 +1,19 @@
 import type { TerminalInstance, TerminalRendererAdapter } from '../../types'
-import { plainTextTerminalRenderer } from './plainTextInstance'
+import { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
 import { xtermTerminalRenderer } from './xtermInstance'
 
 const terminalRendererAdapters = new Map<string, TerminalRendererAdapter>([
   [xtermTerminalRenderer.id, xtermTerminalRenderer],
-  [plainTextTerminalRenderer.id, plainTextTerminalRenderer],
 ])
 
 let activeTerminalRendererId = xtermTerminalRenderer.id
 let hasConfiguredTerminalRendererFromEnvironment = false
+let bundledPlainTextRenderer: TerminalRendererAdapter | null = null
+const initialEnvironmentRendererId = import.meta.env.VITE_TERMINAL_RENDERER
+
+const shouldRegisterBundledPlainTextRenderer =
+  typeof initialEnvironmentRendererId === 'string' &&
+  initialEnvironmentRendererId.trim() === PLAIN_TEXT_TERMINAL_RENDERER_ID
 
 const readEnvironmentRendererId = (): string | null => {
   const rendererId = import.meta.env.VITE_TERMINAL_RENDERER
@@ -37,6 +42,20 @@ export const registerTerminalRendererAdapter = (
   })
 }
 
+const registerBundledEnvironmentRenderer = async (): Promise<void> => {
+  if (
+    !shouldRegisterBundledPlainTextRenderer ||
+    terminalRendererAdapters.has(PLAIN_TEXT_TERMINAL_RENDERER_ID)
+  ) {
+    return
+  }
+
+  const { plainTextTerminalRenderer } = await import('./plainTextInstance')
+
+  bundledPlainTextRenderer = plainTextTerminalRenderer
+  registerTerminalRendererAdapter(plainTextTerminalRenderer)
+}
+
 export const setTerminalRendererAdapter = (rendererId: string): void => {
   if (!terminalRendererAdapters.has(rendererId)) {
     throw new Error(`Unknown terminal renderer adapter: ${rendererId}`)
@@ -45,54 +64,62 @@ export const setTerminalRendererAdapter = (rendererId: string): void => {
   activeTerminalRendererId = rendererId
 }
 
-export const configureTerminalRendererFromEnvironment = (): void => {
-  const rendererId = readEnvironmentRendererId()
+export const configureTerminalRendererFromEnvironment =
+  async (): Promise<void> => {
+    const rendererId = readEnvironmentRendererId()
 
-  if (!rendererId) {
+    if (!rendererId) {
+      hasConfiguredTerminalRendererFromEnvironment = true
+
+      return
+    }
+
+    await registerBundledEnvironmentRenderer()
+    setTerminalRendererAdapter(rendererId)
     hasConfiguredTerminalRendererFromEnvironment = true
-
-    return
   }
 
-  setTerminalRendererAdapter(rendererId)
-  hasConfiguredTerminalRendererFromEnvironment = true
-}
-
-const ensureTerminalRendererConfigured = (): void => {
+const ensureTerminalRendererConfigured = async (): Promise<void> => {
   if (hasConfiguredTerminalRendererFromEnvironment) {
     return
   }
 
-  configureTerminalRendererFromEnvironment()
+  await configureTerminalRendererFromEnvironment()
 }
 
-export const getTerminalRendererAdapter = (): TerminalRendererAdapter => {
-  ensureTerminalRendererConfigured()
+export const getTerminalRendererAdapter =
+  async (): Promise<TerminalRendererAdapter> => {
+    await ensureTerminalRendererConfigured()
 
-  const adapter = terminalRendererAdapters.get(activeTerminalRendererId)
+    const adapter = terminalRendererAdapters.get(activeTerminalRendererId)
 
-  if (!adapter) {
-    throw new Error(
-      `Active terminal renderer adapter is unavailable: ${activeTerminalRendererId}`
-    )
+    if (!adapter) {
+      throw new Error(
+        `Active terminal renderer adapter is unavailable: ${activeTerminalRendererId}`
+      )
+    }
+
+    return adapter
   }
 
-  return adapter
-}
+export const createConfiguredTerminalInstance =
+  async (): Promise<TerminalInstance> => {
+    const adapter = await getTerminalRendererAdapter()
 
-export const createConfiguredTerminalInstance = (): TerminalInstance => {
-  ensureTerminalRendererConfigured()
-
-  return getTerminalRendererAdapter().createInstance()
-}
+    return adapter.createInstance()
+  }
 
 export const _resetTerminalRendererRegistryForTest = (): void => {
   terminalRendererAdapters.clear()
   terminalRendererAdapters.set(xtermTerminalRenderer.id, xtermTerminalRenderer)
-  terminalRendererAdapters.set(
-    plainTextTerminalRenderer.id,
-    plainTextTerminalRenderer
-  )
+
+  if (bundledPlainTextRenderer) {
+    terminalRendererAdapters.set(
+      bundledPlainTextRenderer.id,
+      bundledPlainTextRenderer
+    )
+  }
+
   activeTerminalRendererId = xtermTerminalRenderer.id
   hasConfiguredTerminalRendererFromEnvironment = false
 }

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
@@ -9,6 +9,7 @@ const terminalRendererAdapters = new Map<string, TerminalRendererAdapter>([
 let activeTerminalRendererId = xtermTerminalRenderer.id
 let hasConfiguredTerminalRendererFromEnvironment = false
 let bundledPlainTextRenderer: TerminalRendererAdapter | null = null
+let configureTerminalRendererPromise: Promise<void> | null = null
 const initialEnvironmentRendererId = import.meta.env.VITE_TERMINAL_RENDERER
 
 const shouldRegisterBundledPlainTextRenderer =
@@ -84,7 +85,16 @@ const ensureTerminalRendererConfigured = async (): Promise<void> => {
     return
   }
 
-  await configureTerminalRendererFromEnvironment()
+  configureTerminalRendererPromise ??=
+    configureTerminalRendererFromEnvironment()
+
+  try {
+    await configureTerminalRendererPromise
+  } catch (error) {
+    configureTerminalRendererPromise = null
+
+    throw error
+  }
 }
 
 export const getTerminalRendererAdapter =
@@ -122,4 +132,5 @@ export const _resetTerminalRendererRegistryForTest = (): void => {
 
   activeTerminalRendererId = xtermTerminalRenderer.id
   hasConfiguredTerminalRendererFromEnvironment = false
+  configureTerminalRendererPromise = null
 }


### PR DESCRIPTION
## Summary

- Lazy-load the bundled `plain-text` terminal renderer only when `VITE_TERMINAL_RENDERER=plain-text` is selected.
- Make configured terminal instance creation async so experimental renderers can initialize behind the registry boundary without top-level await.
- Update `Body` and focused tests to keep cached terminal reuse synchronous while safely handling async renderer creation and unmount cancellation.
- Add the accepted Chinese decision record for the Ghostty PTY/parser boundary: `docs/decisions/2026-06-16-ghostty-pty-parser-boundary.zh.html`.

## Decision Record

This PR includes the first decision artifact for the next Ghostty spike: parser ownership stays inside renderer adapters, app code consumes generic `TerminalParserEvent`s, OSC 7 preserves the existing pane-cwd path, and agent observability remains a separate transcript-driven `agent-cwd` channel.

Linear tracking: `VIM-139`.

## Why

The default production path should remain xterm-only unless an experimental renderer is explicitly selected. This keeps the plain-text spike out of the normal bundle and gives the Ghostty exploration a cleaner async adapter loading boundary before PR1 starts extracting the generic parser/output chunk contract.

## Validation

- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`
- `npx vitest run src/features/terminal/components/TerminalPane`
- `npm --ignore-scripts run build:generated`
- `VITE_TERMINAL_RENDERER=plain-text npm --ignore-scripts run build:generated`
- `git diff --check`

Default production build does not emit a `plainTextInstance` asset. The `plain-text` selected build does emit the lazy chunk.