### PR TITLE
feat(diff): redesign the hunk diff toolbar

### DIFF
--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -1323,8 +1323,8 @@ describe('DiffPanelContent', () => {
         'word'
       )
 
-      // HIGHLIGHT dropdown trigger shows the current value 'Word'.
-      await user.click(screen.getByRole('button', { name: 'Word' }))
+      // The Highlight config chip surfaces its key + current value ("Word").
+      await user.click(screen.getByRole('button', { name: /highlight.*word/i }))
       const menu = await screen.findByRole('menu')
       await user.click(
         within(menu).getByRole('menuitem', { name: /character/i })

--- a/src/features/diff/components/toolbar/ChangeStepper.tsx
+++ b/src/features/diff/components/toolbar/ChangeStepper.tsx
@@ -40,7 +40,7 @@ export const ChangeStepper = ({
   <span
     role="group"
     aria-label={`hunk ${counterText}`}
-    className="inline-flex items-center gap-[7px] h-[30px] pl-2.5 pr-1 rounded-md bg-secondary/[0.08] ring-1 ring-inset ring-secondary/[0.16]"
+    className="inline-flex items-center gap-[7px] h-7 pl-2.5 pr-1 rounded-md bg-secondary/[0.08] ring-1 ring-inset ring-secondary/[0.16]"
   >
     <Tooltip content="Jump between changes in this file">
       <span className="inline-flex items-center gap-[7px]">

--- a/src/features/diff/components/toolbar/ConfigChip.test.tsx
+++ b/src/features/diff/components/toolbar/ConfigChip.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import { CONFIG_CHIP_CLASSES, ConfigChipContent } from './ConfigChip'
+
+describe('ConfigChipContent', () => {
+  test('renders lead glyph, small-caps key, value and a caret', () => {
+    render(
+      <button type="button" className={CONFIG_CHIP_CLASSES}>
+        <ConfigChipContent
+          icon="palette"
+          label="Theme"
+          value="catppuccin-mocha"
+        />
+      </button>
+    )
+
+    // Accessible name is the visible key + value — the glyph + caret are
+    // aria-hidden ligatures so the label lives INSIDE the control.
+    const button = screen.getByRole('button', {
+      name: /theme.*catppuccin-mocha/i,
+    })
+    expect(button).toBeInTheDocument()
+    // The material-symbol ligatures render even though they're hidden from AT.
+    expect(button.textContent).toContain('palette')
+    expect(button.textContent).toContain('expand_more')
+  })
+
+  test('omits the small-caps key for a value-only chip (e.g. View)', () => {
+    render(
+      <button type="button" className={CONFIG_CHIP_CLASSES}>
+        <ConfigChipContent icon="tune" value="View" />
+      </button>
+    )
+
+    // No key prefix — the value itself names the control.
+    expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument()
+  })
+})

--- a/src/features/diff/components/toolbar/ConfigChip.tsx
+++ b/src/features/diff/components/toolbar/ConfigChip.tsx
@@ -1,0 +1,53 @@
+import type { ReactElement } from 'react'
+
+// Shared chrome for the labelled config chips (Highlight / Theme / View): a
+// quiet outlined container that brightens on hover. The trigger BUTTON that
+// owns this class is supplied by the consumer (Dropdown.renderTrigger or
+// Menu.trigger) so the floating-reference ref + interaction props land on the
+// real interactive element — `ConfigChipContent` only renders the inner spans.
+export const CONFIG_CHIP_CLASSES =
+  'inline-flex items-center gap-2 h-7 px-2.5 rounded-md bg-transparent ' +
+  'border border-outline-variant/50 text-on-surface-variant ' +
+  'hover:bg-surface-container hover:border-outline-variant/80 transition-colors'
+
+export interface ConfigChipContentProps {
+  // Leading material-symbol glyph (e.g. `palette` for Theme, `tune` for View).
+  icon: string
+  // Small-caps key shown beside the value (e.g. `Highlight`, `Theme`). Omit for
+  // a value-only chip (e.g. `View`), where the value itself names the control.
+  label?: string
+  // Resolved value text (e.g. `Word`, `catppuccin-mocha`, `View`).
+  value: string
+}
+
+// Inner content of a config chip: lead glyph + optional small-caps key + value
+// + a caret. Rendered inside a consumer-owned <button> so the key lives INSIDE
+// the control rather than floating as an all-caps caption in the toolbar gaps.
+export const ConfigChipContent = ({
+  icon,
+  label = undefined,
+  value,
+}: ConfigChipContentProps): ReactElement => (
+  <>
+    <span
+      aria-hidden="true"
+      className="material-symbols-outlined text-[0.9375rem] leading-none"
+    >
+      {icon}
+    </span>
+    {label !== undefined ? (
+      <span className="font-mono text-[0.5625rem] font-semibold uppercase tracking-[0.1em] text-on-surface-muted">
+        {label}
+      </span>
+    ) : null}
+    <span className="font-mono text-[0.6875rem] font-medium truncate max-w-[8rem]">
+      {value}
+    </span>
+    <span
+      aria-hidden="true"
+      className="material-symbols-outlined text-sm leading-none text-on-surface-muted"
+    >
+      expand_more
+    </span>
+  </>
+)

--- a/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
@@ -231,8 +231,11 @@ describe('DiffChipToolbar', () => {
       screen.queryByRole('button', { name: /unstage/i })
     ).not.toBeInTheDocument()
 
-    // Dropdown triggers — value labels surface on the chip itself.
-    expect(screen.getByRole('button', { name: /^Word$/ })).toBeInTheDocument() // highlight
+    // Config chips — the small-caps key + value both surface on the chip
+    // itself (e.g. "Highlight" + "Word"), not as an external caption.
+    expect(
+      screen.getByRole('button', { name: /highlight.*word/i })
+    ).toBeInTheDocument() // highlight chip
 
     expect(
       screen.getByRole('button', { name: /pierre-dark/i })
@@ -395,7 +398,7 @@ describe('DiffChipToolbar', () => {
 
     renderToolbar({ onLineDiffTypeChange })
 
-    await user.click(screen.getByRole('button', { name: /^Word$/ }))
+    await user.click(screen.getByRole('button', { name: /highlight.*word/i }))
     const menu = await screen.findByRole('menu')
     await user.click(within(menu).getByRole('menuitem', { name: /^Character/ }))
 

--- a/src/features/diff/components/toolbar/DiffChipToolbar.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.tsx
@@ -14,6 +14,8 @@ import {
   WELL_DANGER_BUTTON_CLASSES,
   WELL_DISABLED_BUTTON_CLASSES,
 } from './ToolWell'
+import { ToolbarSeparator } from './ToolbarSeparator'
+import { CONFIG_CHIP_CLASSES, ConfigChipContent } from './ConfigChip'
 
 // Floating-UI popover confirmation for the Discard All action. Rendered as
 // a floating box anchored to the trigger so it escapes any overflow clipping
@@ -336,6 +338,9 @@ export const DiffChipToolbar = ({
   //
   // Collapse order (lowest priority overflows FIRST):
   //   View → Theme → Hi-lite → Change-stepper → Tool-well → File-pill → Segmented
+  // Group hairlines (ToolbarSeparator) sit between the major clusters and are
+  // overflow-safe: PriorityPlus trims a trailing separator and drops them from
+  // the `…` tray, so a hairline never dangles or appears in the menu.
   const chips: ReactNode[] = [
     // 1. split / unified segmented — top priority; the most-used control.
     <Segmented
@@ -343,7 +348,10 @@ export const DiffChipToolbar = ({
       value={diffStyle}
       options={['split', 'unified'] as const}
       onChange={onDiffStyleChange}
+      icons={{ split: 'vertical_split', unified: 'view_headline' }}
     />,
+    // hairline between the view-mode control and the navigation cluster.
+    <ToolbarSeparator key="sep-nav" />,
     // 2. file pill — lavender (primary) file-nav group (prev arrow + basename
     // pill + N/M badge + next arrow). FUNCTIONAL: steps the selection through
     // the changed-files list; inert on a single file.
@@ -355,7 +363,8 @@ export const DiffChipToolbar = ({
       onPrev={onPrevFile}
       onNext={onNextFile}
     />,
-    // 3. tool-well — annotation placeholders + staging group (one unit).
+    // 3. tool-well — staging group (stage / unstage / discard / discard-all) as
+    // a flat ghost-icon group (one unit).
     <ToolWell
       key="tool-well"
       showUnstage={diffMode === 'staged'}
@@ -374,24 +383,55 @@ export const DiffChipToolbar = ({
       onPrev={onPrevHunk}
       onNext={onNextHunk}
     />,
-    // 5. highlight dropdown — `lineDiffType` Pierre option.
+    // hairline between the navigation cluster and the config chips.
+    <ToolbarSeparator key="sep-config" />,
+    // 5. highlight chip — `lineDiffType` Pierre option as a labelled config chip
+    // (small-caps key + value inside the control).
     <Dropdown
       key="highlight"
-      label="highlight"
       value={lineDiffType}
       options={LINE_DIFF_OPTIONS}
       onChange={onLineDiffTypeChange}
       width={260}
+      renderTrigger={({ ref, props, current }): ReactElement => (
+        <Tooltip content="Intra-line highlight granularity">
+          <button
+            ref={ref}
+            type="button"
+            className={CONFIG_CHIP_CLASSES}
+            {...props}
+          >
+            <ConfigChipContent
+              icon="format_ink_highlighter"
+              label="Highlight"
+              value={current?.label ?? lineDiffType}
+            />
+          </button>
+        </Tooltip>
+      )}
     />,
-    // 6. theme dropdown — `DiffsThemeNames` enumeration, with a palette lead
-    // icon.
+    // 6. theme chip — `DiffsThemeNames` enumeration, with a palette lead icon.
     <Dropdown
       key="theme"
-      label="theme"
       value={theme}
       options={THEME_OPTIONS}
       onChange={onThemeChange}
-      leadingIcon="palette"
+      renderTrigger={({ ref, props, current }): ReactElement => (
+        <Tooltip content="Syntax theme">
+          <button
+            ref={ref}
+            type="button"
+            className={CONFIG_CHIP_CLASSES}
+            {...props}
+          >
+            <ConfigChipContent
+              icon="palette"
+              label="Theme"
+              value={current?.label ?? theme}
+            />
+          </button>
+        </Tooltip>
+      )}
     />,
     // 7. View ▾ gear chip — consolidates the indicators / overflow dropdowns
     // and the four boolean toggle chips into a single portal-rendered popover
@@ -423,7 +463,7 @@ export const DiffChipToolbar = ({
     <div
       role="toolbar"
       aria-label="Diff toolbar"
-      className="px-3 py-2 rounded-lg bg-surface-container-low/[0.88] backdrop-blur-xl backdrop-saturate-150 border border-outline-variant/15"
+      className="flex min-h-[46px] items-center px-3 bg-surface-container-lowest border-b border-outline-variant/45"
     >
       <div className="flex w-full items-center">
         <PriorityPlus
@@ -439,7 +479,7 @@ export const DiffChipToolbar = ({
               aria-label="discard all feedback"
               disabled={!canDiscardFeedback}
               onClick={onDiscardFeedback}
-              className="inline-flex items-center gap-[7px] h-[30px] px-3.5 rounded-md font-body text-[0.78rem] font-semibold bg-surface-container-highest text-on-surface-variant hover:bg-error/15 hover:text-error transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-surface-container-highest disabled:hover:text-on-surface-variant"
+              className="inline-flex items-center h-7 px-3.5 rounded-md font-mono text-[0.6875rem] font-medium bg-transparent border border-outline-variant/60 text-on-surface hover:bg-surface-container hover:border-error/50 hover:text-error transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:border-outline-variant/60 disabled:hover:text-on-surface"
             >
               Discard
             </button>
@@ -448,11 +488,11 @@ export const DiffChipToolbar = ({
               aria-label={`finish feedback (${feedbackCount})`}
               disabled={!canFinishFeedback}
               onClick={onFinishFeedback}
-              className="inline-flex items-center gap-[7px] h-[30px] px-3.5 rounded-md font-body text-[0.78rem] font-semibold text-on-primary bg-gradient-to-br from-primary to-primary-container shadow-[0_4px_14px_color-mix(in_srgb,var(--color-primary-container)_22%,transparent)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center gap-[7px] h-7 pl-[11px] pr-2 rounded-md font-mono text-[0.6875rem] font-bold text-on-primary bg-primary hover:bg-primary-container shadow-[0_1px_5px_color-mix(in_srgb,var(--color-primary)_40%,transparent)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
             >
               <span
                 aria-hidden="true"
-                className="material-symbols-outlined text-base leading-none"
+                className="material-symbols-outlined text-sm leading-none"
               >
                 check
               </span>

--- a/src/features/diff/components/toolbar/FilePill.tsx
+++ b/src/features/diff/components/toolbar/FilePill.tsx
@@ -26,8 +26,8 @@ export interface FilePillProps {
 // `not-allowed` cursor, no hover, no tooltip — rather than showing the blocked
 // cursor (matches the design's unavailable affordance).
 const GHOST_ARROW_CLASSES =
-  'w-[26px] h-[30px] grid place-items-center rounded-md bg-transparent ' +
-  'text-on-surface-muted hover:bg-surface-bright hover:text-primary-container ' +
+  'w-[26px] h-7 grid place-items-center rounded-md bg-transparent ' +
+  'text-on-surface-muted hover:bg-surface-container hover:text-primary ' +
   'transition-colors disabled:opacity-40 disabled:pointer-events-none'
 
 export const FilePill = ({
@@ -71,7 +71,7 @@ export const FilePill = ({
               ? `file ${counterText}: ${fileName}`
               : `file ${counterText}`
           }
-          className="inline-flex items-center gap-2 h-[30px] px-3 rounded-md bg-primary/10 ring-1 ring-inset ring-primary/20"
+          className="inline-flex items-center gap-2 h-7 px-3 rounded-md bg-primary/10 ring-1 ring-inset ring-primary/20"
         >
           <span
             aria-hidden="true"
@@ -79,7 +79,11 @@ export const FilePill = ({
           >
             description
           </span>
-          <span className="font-mono text-xs font-medium text-on-surface truncate max-w-[12rem]">
+          {/* Fixed-width name slot: keeps the pill — and the whole toolbar's
+              control rhythm — a consistent length regardless of filename. Long
+              names truncate with `…`; the full path stays on the group tooltip
+              + aria-label so it is never lost. */}
+          <span className="font-mono text-xs font-medium text-on-surface truncate w-28">
             {baseName}
           </span>
           <span className="font-mono text-[0.625rem] text-primary-dim bg-primary/[0.14] px-1.5 py-0.5 rounded-full whitespace-nowrap">

--- a/src/features/diff/components/toolbar/PriorityPlus.test.tsx
+++ b/src/features/diff/components/toolbar/PriorityPlus.test.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactElement } from 'react'
 import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { PriorityPlus } from './PriorityPlus'
+import { ToolbarSeparator } from './ToolbarSeparator'
 
 // Capture the ResizeObserver callback so the test can flush measurements
 // synchronously. The test setup file already stubs a global ResizeObserver
@@ -314,6 +315,13 @@ describe('PriorityPlus', () => {
   })
 
   test('restores overflowed items when the toolbar expands', () => {
+    // SCOPE: this validates the measurement LOGIC only — given a re-measure
+    // against a wider container, overflowed items come back. It deliberately
+    // fires the observer by hand because jsdom has no layout engine. It does
+    // NOT prove a real-world widen triggers that re-measure: that depends on
+    // the container actually growing with the pane, which is the separate
+    // layout-contract guard ('the measurement container fills its row …').
+    // Both are required — the manual fire alone once masked a real expand bug.
     render(<PriorityPlus maxRows={1}>{renderItems(4)}</PriorityPlus>)
 
     const root = rootContainer('item-0')
@@ -584,5 +592,109 @@ describe('PriorityPlus', () => {
     expect(
       screen.getByRole('dialog', { name: 'More controls' })
     ).toBeInTheDocument()
+  })
+
+  test('trims a trailing separator and excludes separators from the tray', () => {
+    render(
+      <PriorityPlus maxRows={1}>
+        {[
+          <button key="i0" type="button" data-testid="item-0">
+            item 0
+          </button>,
+          <ToolbarSeparator key="sep" />,
+          <button key="i1" type="button" data-testid="item-1">
+            item 1
+          </button>,
+          <button key="i2" type="button" data-testid="item-2">
+            item 2
+          </button>,
+        ]}
+      </PriorityPlus>
+    )
+
+    // item-0 + separator sit on row 1; item-1 + item-2 wrap to row 2. The raw
+    // cutoff (item-1's index) would leave the separator as the last VISIBLE
+    // item — the trim pulls the cutoff back so only item-0 stays and the
+    // hairline never dangles before the `…` chip.
+    stubLayout(
+      rootContainer('item-0'),
+      [
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 0, offsetWidth: 60 },
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 66, offsetWidth: 1 },
+        { offsetTop: 30, offsetHeight: 24, offsetLeft: 0, offsetWidth: 60 },
+        { offsetTop: 30, offsetHeight: 24, offsetLeft: 72, offsetWidth: 60 },
+      ],
+      400
+    )
+    fireResize()
+
+    // The count excludes the separator: 2 controls (item-1, item-2), not 3.
+    expect(
+      screen.getByRole('button', { name: /more controls/i })
+    ).toHaveAttribute('aria-label', 'Show 2 more controls')
+
+    // The trailing separator wrapper is hidden — it folds away with its group.
+    const root = rootContainer('item-0')
+    // eslint-disable-next-line testing-library/no-node-access -- locate the separator wrapper
+    const separatorWrapper = root.querySelector('[data-pp-separator]')
+    expect(separatorWrapper?.className).toContain('hidden')
+
+    // item-0 stays visible.
+    expect(wrapperFor('item-0').className).not.toContain('hidden')
+  })
+
+  test('keeps an interior separator visible between two visible groups', () => {
+    render(
+      <PriorityPlus maxRows={1}>
+        {[
+          <button key="i0" type="button" data-testid="item-0">
+            item 0
+          </button>,
+          <ToolbarSeparator key="sep" />,
+          <button key="i1" type="button" data-testid="item-1">
+            item 1
+          </button>,
+          <button key="i2" type="button" data-testid="item-2">
+            item 2
+          </button>,
+        ]}
+      </PriorityPlus>
+    )
+
+    // item-0, separator and item-1 all fit on row 1; only item-2 wraps. The
+    // last visible item is item-1 (not the separator), so no trim happens and
+    // the divider stays between the two visible groups.
+    stubLayout(
+      rootContainer('item-0'),
+      [
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 0, offsetWidth: 60 },
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 66, offsetWidth: 1 },
+        { offsetTop: 0, offsetHeight: 24, offsetLeft: 72, offsetWidth: 60 },
+        { offsetTop: 30, offsetHeight: 24, offsetLeft: 0, offsetWidth: 60 },
+      ],
+      400
+    )
+    fireResize()
+
+    expect(
+      screen.getByRole('button', { name: /more controls/i })
+    ).toHaveAttribute('aria-label', 'Show 1 more controls')
+
+    const root = rootContainer('item-0')
+    // eslint-disable-next-line testing-library/no-node-access -- locate the separator wrapper
+    const separatorWrapper = root.querySelector('[data-pp-separator]')
+    expect(separatorWrapper?.className).not.toContain('hidden')
+  })
+
+  test('the measurement container fills its row so a widen triggers re-measure', () => {
+    // Regression guard for the real-app expand bug: a shrink-to-fit container
+    // only narrows when the pane shrinks and never widens back, so overflowed
+    // items stay stuck in the `…` tray on expand. The observed container must
+    // FILL the row (flex-1) so its own width tracks the pane and the
+    // ResizeObserver fires on widen. jsdom has no layout/observer, so this
+    // asserts the load-bearing fill class rather than re-measurement directly.
+    render(<PriorityPlus maxRows={1}>{renderItems(2)}</PriorityPlus>)
+
+    expect(rootContainer('item-0').className).toMatch(/\bflex-1\b/)
   })
 })

--- a/src/features/diff/components/toolbar/PriorityPlus.tsx
+++ b/src/features/diff/components/toolbar/PriorityPlus.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 import { Popover } from '@/components/Popover'
 import { Tooltip } from '@/components/Tooltip'
+import { isSeparatorElement } from './ToolbarSeparator'
 
 // Rendered overflow chip width (`w-8 h-8` = 32 px) and toolbar `gap-x-3`
 // (= 12 px). Exported through index.ts so consumers and measurement logic keep
@@ -32,6 +33,19 @@ interface PriorityPlusProps {
 // beyond `maxRows` into a portal-rendered `...` menu. Re-measures on container
 // resize via ResizeObserver. Children must be stable across renders (use
 // `key`) so refs map consistently.
+//
+// LAYOUT CONTRACT — PriorityPlus FILLS the width of its row (its root carries
+// `flex-1 min-w-0`, and a `display:flex` root is block-level so it also fills a
+// non-flex parent). This is not cosmetic: overflow is detected by which items
+// WRAP past `maxRows`, which can only happen while the container is constrained
+// to the available width. A content-width ("hug") container would (a) never
+// wrap, so nothing ever folds, and (b) — once narrowed by flex-shrink — never
+// widen back, so the ResizeObserver (which only fires when this observed
+// element's own width changes) would miss every expand and leave items stuck
+// in the `…` tray. Consumers must therefore give PriorityPlus a full row; do
+// not place it in an inline / content-sized / horizontally-scrolling context.
+// Pinned, never-overflow controls belong in a SIBLING after PriorityPlus (see
+// DiffChipToolbar's feedback actions), not inside it.
 //
 // Measurement is a two-phase pass:
 //   Phase A — overflowFrom === null: render every child with real layout so we
@@ -138,15 +152,43 @@ export const PriorityPlus = ({
       }
     }
 
+    // Never leave a group separator dangling at the trailing edge of the
+    // visible run: when the last visible item is a hairline, pull the cutoff
+    // back so it folds away with its group instead of floating before the `…`
+    // chip. Reads the marker off the wrapper's dataset (set in render) so this
+    // effect needn't depend on the `children` array identity. Trimmed
+    // separators are also dropped from the overflow tray (see `hiddenItems`).
+    while (
+      cutoff !== null &&
+      cutoff > 0 &&
+      items[cutoff - 1]?.dataset.ppSeparator !== undefined
+    ) {
+      cutoff -= 1
+    }
+
     setOverflowFrom(cutoff)
   }, [overflowFrom, maxRows, resizeTick])
 
   const showOverflow = overflowFrom !== null && overflowFrom < children.length
   const visibleEnd = showOverflow ? overflowFrom : children.length
-  const hiddenItems = showOverflow ? children.slice(overflowFrom) : []
+
+  // Drop separators from the tray — a 1px vertical hairline is meaningless in
+  // the vertical `…` menu and would inflate the "N more controls" count.
+  const hiddenItems = showOverflow
+    ? children.slice(overflowFrom).filter((child) => !isSeparatorElement(child))
+    : []
 
   return (
-    <div ref={containerRef} className={`flex flex-wrap items-center ${gap}`}>
+    // `flex-1 min-w-0` makes the container FILL its row rather than hug its
+    // content. This is load-bearing for re-expansion: the ResizeObserver fires
+    // only when this observed element's own width changes. A content-width
+    // container shrinks (and folds) when the pane narrows but never grows back
+    // when it widens, leaving items stuck in the `…` tray. Filling the row ties
+    // the observed width to the pane so a widen triggers a fresh measurement.
+    <div
+      ref={containerRef}
+      className={`flex min-w-0 flex-1 flex-wrap items-center ${gap}`}
+    >
       {children.map((child, index) => {
         const isHidden = overflowFrom !== null && index >= visibleEnd
 
@@ -156,6 +198,10 @@ export const PriorityPlus = ({
             ref={(el): void => {
               itemRefs.current[index] = el
             }}
+            // `data-pp-separator` flags hairline children so the measurement
+            // pass can trim a trailing separator off the visible run by reading
+            // the DOM, with no dependency on the `children` array identity.
+            data-pp-separator={isSeparatorElement(child) ? '' : undefined}
             // Hidden items get `hidden` so they're laid out only during the
             // Phase A measurement pass; once measured we drop them from the
             // visible flow without breaking the ref map.
@@ -165,7 +211,9 @@ export const PriorityPlus = ({
           </div>
         )
       })}
-      {showOverflow ? <OverflowMenu hiddenItems={hiddenItems} /> : null}
+      {hiddenItems.length > 0 ? (
+        <OverflowMenu hiddenItems={hiddenItems} />
+      ) : null}
     </div>
   )
 }

--- a/src/features/diff/components/toolbar/Segmented.tsx
+++ b/src/features/diff/components/toolbar/Segmented.tsx
@@ -4,20 +4,28 @@ interface SegmentedProps<T extends string | number> {
   value: T
   options: readonly T[]
   onChange: (next: T) => void
+  // Optional leading material-symbol glyph per option (keyed by the stringified
+  // option value, e.g. `{ split: 'vertical_split', unified: 'view_headline' }`).
+  // Options without an entry render label-only.
+  icons?: Partial<Record<string, string>>
 }
 
-// Pill segmented control. The active option uses primary tones for emphasis;
-// inactive options sit on the surface tint and shift to the on-surface tone
-// on hover. Generic over string | number so future non-string enums (e.g.
-// numeric font-size buckets) can use the same primitive without copy-paste.
+// Segmented control on a recessed track: the active option rides an accent
+// `primary` thumb (with a soft accent-tinted shadow), inactive options sit
+// quietly on the tonal track and lift to the on-surface tone on hover. The
+// 24px buttons + 2px track padding give the toolbar's shared 28px rhythm.
+// Generic over string | number so future non-string enums (e.g. numeric
+// font-size buckets) can reuse the primitive without copy-paste.
 export const Segmented = <T extends string | number>({
   value,
   options,
   onChange,
+  icons = undefined,
 }: SegmentedProps<T>): ReactElement => (
-  <span className="inline-flex items-center gap-0.5 bg-surface-container/40 rounded-full p-0.5">
+  <span className="inline-flex items-center gap-0.5 p-0.5 rounded-lg bg-surface-container ring-1 ring-inset ring-outline-variant/35">
     {options.map((option) => {
       const active = option === value
+      const icon = icons?.[String(option)]
 
       return (
         <button
@@ -25,12 +33,20 @@ export const Segmented = <T extends string | number>({
           type="button"
           onClick={(): void => onChange(option)}
           aria-pressed={active}
-          className={`px-3 py-1 rounded-full text-[0.65rem] font-bold uppercase tracking-wider transition-colors ${
+          className={`inline-flex items-center gap-1.5 h-6 px-3 rounded-md font-mono text-[0.625rem] font-semibold uppercase tracking-[0.07em] transition-colors ${
             active
-              ? 'bg-primary text-on-primary'
+              ? 'bg-primary text-on-primary shadow-[0_1px_4px_color-mix(in_srgb,var(--color-primary)_35%,transparent)]'
               : 'text-on-surface-variant hover:text-on-surface'
           }`}
         >
+          {icon !== undefined ? (
+            <span
+              aria-hidden="true"
+              className="material-symbols-outlined text-[0.8125rem] leading-none"
+            >
+              {icon}
+            </span>
+          ) : null}
           {String(option)}
         </button>
       )

--- a/src/features/diff/components/toolbar/ToolWell.tsx
+++ b/src/features/diff/components/toolbar/ToolWell.tsx
@@ -12,7 +12,7 @@ import { Tooltip } from '@/components/Tooltip'
 // surface; brighter on hover. Exported so the discard-all button matches.
 export const WELL_BUTTON_CLASSES =
   'w-7 h-7 grid place-items-center rounded-md bg-transparent ' +
-  'text-on-surface-variant hover:bg-surface-bright hover:text-on-surface ' +
+  'text-on-surface-variant hover:bg-surface-container hover:text-on-surface ' +
   'transition-colors'
 
 // Disabled placeholder variant — muted, inert. Mirrors the not-allowed cursor
@@ -125,9 +125,11 @@ export interface ToolWellProps {
   discardAllSlot: ReactNode
 }
 
-// Tool-well: one tonal container holding the per-file staging actions (stage /
-// unstage / discard / discard-all), rendered as a single unit so PriorityPlus
-// overflows the whole well together rather than spilling individual buttons.
+// Tool-well: the per-file staging actions (stage / unstage / discard /
+// discard-all) as a flat ghost-icon group — no tonal container block, so the
+// buttons share the bar's quiet rhythm and only lift on hover. Rendered as a
+// single inline-flex unit so PriorityPlus overflows the whole group together
+// rather than spilling individual buttons.
 //
 // The speculative annotation tools (comment / highlight / erase) were dropped —
 // commenting is the gutter `+` affordance, and highlight/erase had no backend
@@ -140,7 +142,7 @@ export const ToolWell = ({
   onDiscard,
   discardAllSlot,
 }: ToolWellProps): ReactElement => (
-  <span className="inline-flex items-center gap-0.5 bg-surface-container-highest rounded-md px-0.5 py-px">
+  <span className="inline-flex items-center gap-px">
     {/* Staging group — fully wired when handlers are provided. */}
     {onStage !== undefined ? (
       <WellButton

--- a/src/features/diff/components/toolbar/ToolbarSeparator.test.tsx
+++ b/src/features/diff/components/toolbar/ToolbarSeparator.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import { ToolbarSeparator, isSeparatorElement } from './ToolbarSeparator'
+
+describe('ToolbarSeparator', () => {
+  test('renders a decorative, aria-hidden hairline', () => {
+    const { container } = render(<ToolbarSeparator />)
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- a decorative aria-hidden hairline has no role to query
+    const sep = container.querySelector('span')
+
+    expect(sep).not.toBeNull()
+    expect(sep).toHaveAttribute('aria-hidden', 'true')
+    // 1px-wide vertical hairline — the visual group divider.
+    expect(sep?.className).toContain('w-px')
+  })
+
+  test('isSeparatorElement identifies only ToolbarSeparator elements', () => {
+    expect(isSeparatorElement(<ToolbarSeparator />)).toBe(true)
+    expect(isSeparatorElement(<span />)).toBe(false)
+    expect(isSeparatorElement('text')).toBe(false)
+    expect(isSeparatorElement(null)).toBe(false)
+  })
+})

--- a/src/features/diff/components/toolbar/ToolbarSeparator.tsx
+++ b/src/features/diff/components/toolbar/ToolbarSeparator.tsx
@@ -1,0 +1,23 @@
+import { isValidElement, type ReactElement, type ReactNode } from 'react'
+
+// A 1px vertical hairline that visually groups the toolbar's clusters (e.g.
+// between the view-mode segmented control and the file/hunk navigation, and
+// between navigation and the config chips). Tonal depth only — no heavy
+// container blocks.
+//
+// It is rendered as a normal PriorityPlus child so it participates in width
+// measurement, but PriorityPlus special-cases it (via `isSeparatorElement`) so
+// a separator never (a) dangles at the trailing edge of the visible run or (b)
+// shows up as a meaningless vertical line inside the vertical `…` overflow
+// tray.
+export const ToolbarSeparator = (): ReactElement => (
+  <span
+    aria-hidden="true"
+    className="h-5 w-px shrink-0 bg-outline-variant/60"
+  />
+)
+
+// Identity check PriorityPlus uses to identify separators without coupling to
+// class names or markup. Kept beside the component so the two never drift.
+export const isSeparatorElement = (node: ReactNode): boolean =>
+  isValidElement(node) && node.type === ToolbarSeparator

--- a/src/features/diff/components/toolbar/ViewSettingsDropdown.tsx
+++ b/src/features/diff/components/toolbar/ViewSettingsDropdown.tsx
@@ -2,6 +2,7 @@ import { type ReactElement } from 'react'
 import type { BaseDiffOptions } from '@pierre/diffs'
 import { type DropdownOption } from '@/components/Dropdown'
 import { Menu } from '@/components/Menu'
+import { CONFIG_CHIP_CLASSES, ConfigChipContent } from './ConfigChip'
 
 // Pierre option subtypes — same pattern as DiffChipToolbar.tsx so a Pierre
 // version bump that widens / renames the enums is caught at type-check time.
@@ -73,21 +74,9 @@ export const ViewSettingsDropdown = ({
       <button
         type="button"
         aria-label="View settings"
-        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md bg-surface-container-high/60 hover:bg-surface-container-highest/80 text-on-surface text-xs font-medium transition-colors"
+        className={CONFIG_CHIP_CLASSES}
       >
-        <span
-          aria-hidden="true"
-          className="material-symbols-outlined text-base leading-none opacity-70"
-        >
-          tune
-        </span>
-        View
-        <span
-          aria-hidden="true"
-          className="material-symbols-outlined text-sm leading-none"
-        >
-          expand_more
-        </span>
+        <ConfigChipContent icon="tune" value="View" />
       </button>
     }
   >


### PR DESCRIPTION
## Summary

Migrates the hunk diff toolbar to the **Lens** design (from the `Hunk Toolbar.html` handoff) as a **visual restyle that preserves all behavior**. Every colour resolves through Lens semantic tokens — no hardcoded values — so it renders correctly in both Catppuccin (dark) and Flexoki (light).

## What changed

- **Flat bar** on `surface-container-lowest` with a single bottom hairline (was a rounded glassmorphic card).
- **Segmented** Split/Unified: recessed track + accent `primary` thumb + Split/Unified glyphs.
- **Config chips** (Highlight / Theme / View): the label now lives *inside* the control (small-caps key + value); Theme leads with a `palette` glyph. Rendered via `Dropdown.renderTrigger` / `Menu.trigger`, so dropdown/menu behaviour is unchanged.
- **Staging ToolWell**: keeps all wiring (Stage / Unstage / Discard / Discard-all); restyled to a flat ghost-icon group (no gray container block).
- **Actions**: ghost Discard (hover → `error`) + flat-`primary` Finish + count badge.
- **New primitives**: `ToolbarSeparator` (overflow-safe group hairline) and `ConfigChip` (shared in-chip key+value content), each with sibling tests.

## Bug fixes (surfaced during in-app review)

- **Expand didn't restore controls.** `PriorityPlus`'s container was shrink-to-fit, so it folded on narrow but never restored on widen — its `ResizeObserver` only fires when the observed element's own width changes, and a content-width container never grows back. Fixed by making the observed container fill its row (`flex-1 min-w-0`), documented as an explicit layout contract, with a guard test.
- **FilePill width jittered** with filename length → inconsistent toolbar rhythm. Now a fixed-width name slot with `…` truncation (the full path stays on the tooltip + aria-label).
- **`PriorityPlus` is now separator-aware**: it trims a trailing separator off the visible run and filters separators out of the overflow `…` tray.

## Testing

- `vitest run` — **297 files, 3786 pass / 3 skipped**.
- `tsc -b`, repo-wide `eslint .`, and `prettier --check .` all clean.
- Added/updated tests: `ToolbarSeparator`, `ConfigChip`, `PriorityPlus` (separator trim + tray filter + fill-contract guard), plus toolbar / `DiffPanelContent` chip-name assertions.

## Not in this PR

The mockup showed a fold-action group (Expand / Collapse / Hide unchanged / Line numbers) in place of staging. We **kept staging** for now and deferred that swap to **VIM-141**, which captures the Pierre-wiring research and the open "where does staging go?" question. This PR does **not** close VIM-141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
