### PR TITLE
refactor(terminal): add output chunk writer

### DIFF
--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -9,6 +9,7 @@ import type { ITerminalService } from '../../services/terminalService'
 import type {
   TerminalDisposable,
   TerminalInstance,
+  TerminalOutputChunk,
   TerminalParser,
   TerminalRendererHandle,
   TerminalSurface,
@@ -143,6 +144,13 @@ const createFakeTerminalInstance = (): TerminalInstance => {
 
   return {
     terminal,
+    output: {
+      writeOutput: vi.fn(
+        (chunk: TerminalOutputChunk, callback?: () => void): void => {
+          terminal.write(chunk.text, callback)
+        }
+      ),
+    },
     parser: terminal.parser,
     viewportReader,
     fitController: { fit: vi.fn() },

--- a/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
@@ -11,6 +11,7 @@ import {
 import type {
   TerminalDisposable,
   TerminalInstance,
+  TerminalOutputChunk,
   TerminalParser,
   TerminalRendererHandle,
   TerminalSurface,
@@ -89,6 +90,13 @@ const createFakeTerminalInstance = (): FakeTerminalControls => {
 
   const instance: TerminalInstance = {
     terminal,
+    output: {
+      writeOutput: vi.fn(
+        (chunk: TerminalOutputChunk, callback?: () => void): void => {
+          terminal.write(chunk.text, callback)
+        }
+      ),
+    },
     parser,
     viewportReader,
     fitController: { fit: vi.fn((): void => undefined) },

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -14,6 +14,7 @@ import type {
   TerminalDisposable,
   TerminalFitController,
   TerminalInstance,
+  TerminalOutputChunk,
   TerminalParser,
   TerminalRendererHandle,
   TerminalSurface,
@@ -159,6 +160,13 @@ const createMockTerminalControls = (): MockTerminalControls => {
 
   const instance: TerminalInstance = {
     terminal,
+    output: {
+      writeOutput: vi.fn(
+        (chunk: TerminalOutputChunk, callback?: () => void): void => {
+          terminal.write(chunk.text, callback)
+        }
+      ),
+    },
     parser,
     viewportReader,
     fitController,
@@ -1597,6 +1605,7 @@ describe('Body', () => {
 
       terminalCache.set('cached-session', {
         terminal: cachedTerminal as unknown as TerminalSurface,
+        output: { writeOutput: vi.fn() },
         fitController: cachedFitController as unknown as TerminalFitController,
         viewportReader: { readVisibleText: vi.fn() },
       })
@@ -1651,6 +1660,7 @@ describe('Body', () => {
 
       terminalCache.set('cached-session', {
         terminal: cachedTerminal as unknown as TerminalSurface,
+        output: { writeOutput: vi.fn() },
         fitController: cachedFitController as unknown as TerminalFitController,
         viewportReader: { readVisibleText: vi.fn() },
       })

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -20,6 +20,7 @@ import { type ITerminalService } from '../../services/terminalService'
 import type {
   TerminalDisposable,
   TerminalFitController,
+  TerminalOutputWriter,
   TerminalRendererHandle,
   TerminalSurface,
 } from '../../types'
@@ -180,6 +181,9 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
   const containerRef = useRef<HTMLDivElement>(null)
 
   const [terminal, setTerminal] = useState<TerminalSurface | null>(null)
+
+  const [terminalOutput, setTerminalOutput] =
+    useState<TerminalOutputWriter | null>(null)
 
   const [terminalStartupError, setTerminalStartupError] = useState<
     string | null
@@ -358,6 +362,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     status,
   } = useTerminal({
     terminal,
+    output: terminalOutput,
     service,
     cwd,
     shell,
@@ -468,6 +473,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     // Check if we already have a terminal for this session
     const cached = terminalCache.get(sessionId)
     let newTerminal: TerminalSurface | null = null
+    let newTerminalOutput: TerminalOutputWriter | null = null
     let fitController: TerminalFitController | null = null
     let rendererHandle: TerminalRendererHandle | null = null
     let fitFrameId: number | null = null
@@ -581,6 +587,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         if (cached) {
           // Reuse existing terminal from cache
           newTerminal = cached.terminal
+          newTerminalOutput = cached.output
           fitController = cached.fitController
           fitControllerRef.current = fitController
 
@@ -601,6 +608,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
           }
 
           newTerminal = created.terminal
+          newTerminalOutput = created.output
           fitController = created.fitController
           fitControllerRef.current = fitController
 
@@ -662,6 +670,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
           // Cache the terminal instance for this session
           terminalCache.set(sessionId, {
             terminal: newTerminal,
+            output: newTerminalOutput,
             fitController,
             viewportReader: created.viewportReader,
           })
@@ -852,6 +861,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
         // Store terminal in state to trigger useTerminal hook
         setTerminal(terminalForSetup)
+        setTerminalOutput(newTerminalOutput)
       } catch (error) {
         if (disposed) {
           return
@@ -869,9 +879,11 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         }
 
         newTerminal = null
+        newTerminalOutput = null
         fitController = null
         fitControllerRef.current = null
         setTerminal(null)
+        setTerminalOutput(null)
         setTerminalStartupError(terminalStartupErrorMessage(error))
       }
     }
@@ -910,8 +922,10 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         newTerminal?.dispose()
       }
       newTerminal = null
+      newTerminalOutput = null
       fitController = null
       setTerminal(null)
+      setTerminalOutput(null)
       fitControllerRef.current = null
     }
   }, [sessionId])

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -74,14 +74,22 @@ describe('plainTextInstance', () => {
     expect(resizeHandler).toHaveBeenLastCalledWith({ cols: 50, rows: 10 })
   })
 
-  test('writes frontend string chunks into the viewport reader', () => {
+  test('writes output chunks into the viewport reader', () => {
     const created = createTrackedPlainTextTerminal()
     const callback = vi.fn()
     const container = document.createElement('div')
 
     setElementSize(container, 640, 360)
     created.terminal.open(container)
-    created.terminal.write('hello\r\nworld\n', callback)
+    created.output.writeOutput(
+      {
+        text: 'hello\r\nworld\n',
+        offsetStart: 0,
+        byteLen: 13,
+        phase: 'live',
+      },
+      callback
+    )
 
     expect(created.viewportReader.readVisibleText()).toBe('hello\nworld')
     expect(callback).toHaveBeenCalledOnce()

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -4,6 +4,7 @@ import type {
   TerminalFitController,
   TerminalInstance,
   TerminalKeyEventHandler,
+  TerminalOutputWriter,
   TerminalParser,
   TerminalRendererAdapter,
   TerminalRendererHandle,
@@ -467,6 +468,12 @@ class PlainTextTerminalModel {
     },
   }
 
+  readonly output: TerminalOutputWriter = {
+    writeOutput: (chunk, callback): void => {
+      this.terminal.write(chunk.text, callback)
+    },
+  }
+
   readonly viewportReader: TerminalViewportReader = {
     readVisibleText: (): string => this.terminal.readVisibleText(),
   }
@@ -506,6 +513,7 @@ export const createPlainTextTerminal = (): TerminalInstance => {
 
   return {
     terminal: model.terminal,
+    output: model.output,
     parser: model.parser,
     viewportReader: model.viewportReader,
     fitController: model.fitController,

--- a/src/features/terminal/components/TerminalPane/terminalInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalInstance.test.ts
@@ -9,6 +9,7 @@ vi.mock('./terminalRendererRegistry', () => ({
 test('creates the configured terminal renderer instance', async () => {
   const instance = {
     terminal: {},
+    output: {},
     parser: {},
     viewportReader: {},
     fitController: {},

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
@@ -56,6 +56,9 @@ const createTerminalInstance = (): TerminalInstance => ({
     attachKeyEventHandler: vi.fn(),
     applyTheme: vi.fn(),
   },
+  output: {
+    writeOutput: vi.fn(),
+  },
   parser: {
     registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
   },

--- a/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
@@ -153,6 +153,16 @@ describe('xtermInstance', () => {
       'visible one\nvisible two'
     )
 
+    const writeCallback = vi.fn()
+    created.output.writeOutput(
+      {
+        text: 'chunk output',
+        offsetStart: 8,
+        byteLen: 12,
+        phase: 'live',
+      },
+      writeCallback
+    )
     created.parser.registerOscHandler(7, () => true)
 
     created.terminal.open(container)
@@ -162,6 +172,7 @@ describe('xtermInstance', () => {
       7,
       expect.any(Function)
     )
+    expect(terminal.write).toHaveBeenCalledWith('chunk output', writeCallback)
     expect(terminal.open).toHaveBeenCalledWith(container)
     expect(terminal.options.theme).toEqual(
       expect.objectContaining({

--- a/src/features/terminal/components/TerminalPane/xtermInstance.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.ts
@@ -5,6 +5,7 @@ import { CanvasAddon } from '@xterm/addon-canvas'
 import { themeService } from '../../../../theme'
 import type {
   TerminalInstance,
+  TerminalOutputWriter,
   TerminalParser,
   TerminalRendererHandle,
   TerminalRendererAdapter,
@@ -31,6 +32,7 @@ export const createXtermTerminal = (): TerminalInstance => {
 
   return {
     terminal: createTerminalSurface(terminal),
+    output: createTerminalOutputWriter(terminal),
     parser: createTerminalParser(terminal),
     viewportReader: createTerminalViewportReader(terminal),
     fitController: fitAddon,
@@ -89,6 +91,14 @@ const createTerminalSurface = (terminal: Terminal): TerminalSurface => ({
   },
   applyTheme: (theme: TerminalTheme): void => {
     terminal.options.theme = toXtermTheme(theme)
+  },
+})
+
+const createTerminalOutputWriter = (
+  terminal: Terminal
+): TerminalOutputWriter => ({
+  writeOutput: (chunk, callback): void => {
+    terminal.write(chunk.text, callback)
   },
 })
 

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -643,6 +643,40 @@ describe('useTerminal', () => {
       expect(mockTerminal.write).toHaveBeenCalledWith('Restored output\r\n')
     })
 
+    test('ignores empty buffered restore events', async () => {
+      const onRestoreStart = vi.fn()
+      const onRestoreOutput = vi.fn()
+      const onRestoreEnd = vi.fn()
+
+      const { result } = renderHook(() =>
+        useTerminal({
+          terminal: mockTerminal,
+          output: mockOutput,
+          service: mockService,
+          restoredFrom: {
+            sessionId: 'session-1',
+            cwd: '/tmp',
+            pid: 1234,
+            replayData: '',
+            replayEndOffset: 0,
+            bufferedEvents: [{ data: '', offsetStart: 0, byteLen: 0 }],
+          },
+          onRestoreStart,
+          onRestoreOutput,
+          onRestoreEnd,
+        })
+      )
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('running')
+      })
+
+      expect(mockOutput.writeOutput).not.toHaveBeenCalled()
+      expect(onRestoreStart).not.toHaveBeenCalled()
+      expect(onRestoreOutput).toHaveBeenCalledWith('')
+      expect(onRestoreEnd).not.toHaveBeenCalled()
+    })
+
     test('reports restored output after the final restore write callback', async () => {
       const writes: string[] = []
       const writeCallbacks: (() => void)[] = []

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -2,7 +2,11 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useTerminal } from './useTerminal'
 import { MockTerminalService } from '../services/terminalService'
-import type { TerminalSurface } from '../types'
+import type {
+  TerminalOutputChunk,
+  TerminalOutputWriter,
+  TerminalSurface,
+} from '../types'
 
 // Mock terminal surface with test helpers
 interface MockTerminal extends TerminalSurface {
@@ -52,10 +56,24 @@ const createMockTerminal = (): MockTerminal => {
 describe('useTerminal', () => {
   let mockService: MockTerminalService
   let mockTerminal: MockTerminal
+  let mockOutput: TerminalOutputWriter
 
   beforeEach(() => {
     mockService = new MockTerminalService()
     mockTerminal = createMockTerminal()
+    mockOutput = {
+      writeOutput: vi.fn(
+        (chunk: TerminalOutputChunk, callback?: () => void): void => {
+          if (callback) {
+            mockTerminal.write(chunk.text, callback)
+
+            return
+          }
+
+          mockTerminal.write(chunk.text)
+        }
+      ),
+    }
 
     // Spy on all mock service methods
     vi.spyOn(mockService, 'spawn')
@@ -75,6 +93,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -103,6 +122,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -116,6 +136,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -131,6 +152,12 @@ describe('useTerminal', () => {
       data: 'Hello from PTY\r\n',
     })
 
+    expect(mockOutput.writeOutput).toHaveBeenCalledWith({
+      text: 'Hello from PTY\r\n',
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode('Hello from PTY\r\n').length,
+      phase: 'live',
+    })
     expect(mockTerminal.write).toHaveBeenCalledWith('Hello from PTY\r\n')
   })
 
@@ -140,6 +167,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
         onOutput,
@@ -167,6 +195,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -193,6 +222,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -222,6 +252,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -251,6 +282,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -285,6 +317,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -315,6 +348,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -350,6 +384,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -385,6 +420,7 @@ describe('useTerminal', () => {
     const { result, unmount } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -410,6 +446,7 @@ describe('useTerminal', () => {
     renderHook(() =>
       useTerminal({
         terminal: null,
+        output: null,
         service: mockService,
         cwd: '/home/user',
       })
@@ -428,6 +465,7 @@ describe('useTerminal', () => {
     renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -449,6 +487,7 @@ describe('useTerminal', () => {
     renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
         shell: '/bin/zsh',
@@ -470,6 +509,7 @@ describe('useTerminal', () => {
     renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
         env: customEnv,
@@ -494,6 +534,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -523,6 +564,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -538,6 +580,7 @@ describe('useTerminal', () => {
     const { result, unmount } = renderHook(() =>
       useTerminal({
         terminal: mockTerminal,
+        output: mockOutput,
         service: mockService,
         cwd: '/home/user',
       })
@@ -568,6 +611,7 @@ describe('useTerminal', () => {
       const { result } = renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           cwd: '/home/user',
           restoredFrom: {
@@ -590,6 +634,12 @@ describe('useTerminal', () => {
       expect(mockService.spawn).not.toHaveBeenCalled()
 
       // Should write replay data to terminal
+      expect(mockOutput.writeOutput).toHaveBeenCalledWith({
+        text: 'Restored output\r\n',
+        offsetStart: null,
+        byteLen: null,
+        phase: 'restore',
+      })
       expect(mockTerminal.write).toHaveBeenCalledWith('Restored output\r\n')
     })
 
@@ -613,6 +663,7 @@ describe('useTerminal', () => {
       renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           restoredFrom: {
             sessionId: 'session-1',
@@ -680,6 +731,7 @@ describe('useTerminal', () => {
       renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           restoredFrom: {
             sessionId: 'session-1',
@@ -729,6 +781,7 @@ describe('useTerminal', () => {
       renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           restoredFrom: {
             sessionId: 'session-1',
@@ -761,6 +814,7 @@ describe('useTerminal', () => {
       const { unmount } = renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           restoredFrom: {
             sessionId: 'restored-session-id',
@@ -787,6 +841,7 @@ describe('useTerminal', () => {
       const { result } = renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           restoredFrom: {
             sessionId: 'session-1',
@@ -820,6 +875,7 @@ describe('useTerminal', () => {
       const { result } = renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           restoredFrom: {
             sessionId: 'session-1',
@@ -845,6 +901,12 @@ describe('useTerminal', () => {
         offsetStart: 100,
       })
 
+      expect(mockOutput.writeOutput).toHaveBeenCalledWith({
+        text: 'AT_CURSOR',
+        offsetStart: 100,
+        byteLen: new TextEncoder().encode('AT_CURSOR').length,
+        phase: 'live',
+      })
       expect(mockTerminal.write).toHaveBeenCalledWith('AT_CURSOR')
 
       vi.mocked(mockTerminal.write).mockClear()
@@ -888,6 +950,7 @@ describe('useTerminal', () => {
       const { result } = renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           restoredFrom: {
             sessionId: 'session-1',
@@ -942,6 +1005,7 @@ describe('useTerminal', () => {
       const { result } = renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           mode: 'awaiting-restart',
         })
@@ -959,6 +1023,7 @@ describe('useTerminal', () => {
       const { result } = renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           mode: 'attach',
           restoredFrom: {
@@ -985,6 +1050,7 @@ describe('useTerminal', () => {
       const { result } = renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           mode: 'attach',
         })
@@ -1002,6 +1068,7 @@ describe('useTerminal', () => {
       const { result } = renderHook(() =>
         useTerminal({
           terminal: mockTerminal,
+          output: mockOutput,
           service: mockService,
           mode: 'spawn',
         })

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import type { ITerminalService } from '../services/terminalService'
-import type { TerminalSession, TerminalSurface } from '../types'
+import type {
+  TerminalOutputChunk,
+  TerminalOutputWriter,
+  TerminalSession,
+  TerminalSurface,
+} from '../types'
 
 /**
  * Data required to restore a terminal session from snapshot + live events.
@@ -52,6 +57,11 @@ interface UseTerminalBaseOptions {
    * Terminal renderer surface.
    */
   terminal: TerminalSurface | null
+
+  /**
+   * Renderer-owned PTY output writer.
+   */
+  output: TerminalOutputWriter | null
 
   /**
    * Terminal service (MockTerminalService or DesktopTerminalService)
@@ -172,6 +182,7 @@ export interface UseTerminalReturn {
 export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
   const {
     terminal,
+    output,
     service,
     cwd,
     shell,
@@ -247,16 +258,16 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     onInputRef.current = onInput
   }, [onInput])
 
-  const writeTerminalOutput = useCallback(
-    (targetTerminal: TerminalSurface, data: string): void => {
+  const writeLiveTerminalOutput = useCallback(
+    (targetOutput: TerminalOutputWriter, chunk: TerminalOutputChunk): void => {
       if (!onOutputRef.current) {
-        targetTerminal.write(data)
+        targetOutput.writeOutput(chunk)
 
         return
       }
 
-      targetTerminal.write(data, () => {
-        onOutputRef.current?.(data)
+      targetOutput.writeOutput(chunk, () => {
+        onOutputRef.current?.(chunk.text)
       })
     },
     []
@@ -285,7 +296,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     // the first fake unmount sets this to false and it never resets)
     isMountedRef.current = true
 
-    if (!terminal) {
+    if (!terminal || !output) {
       return
     }
 
@@ -342,16 +353,30 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
           }
         }
 
-        const restoredOutputParts = [
-          restore.replayData,
-          ...restoredBufferedEvents.map((event) => event.data),
+        const restoredOutputChunks: TerminalOutputChunk[] = [
+          ...(restore.replayData.length > 0
+            ? [
+                {
+                  text: restore.replayData,
+                  offsetStart: null,
+                  byteLen: null,
+                  phase: 'restore' as const,
+                },
+              ]
+            : []),
+          ...restoredBufferedEvents.map(
+            (event): TerminalOutputChunk => ({
+              text: event.data,
+              offsetStart: event.offsetStart,
+              byteLen: event.byteLen,
+              phase: 'restore',
+            })
+          ),
         ]
 
-        const restoredOutput = restoredOutputParts.join('')
-
-        const restoredOutputChunks = restoredOutputParts.filter(
-          (data) => data.length > 0
-        )
+        const restoredOutput = restoredOutputChunks
+          .map((chunk) => chunk.text)
+          .join('')
 
         const restoreStart = onRestoreStartRef.current
         const restoreEnd = onRestoreEndRef.current
@@ -372,15 +397,15 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
         }
 
         if (restoredOutputChunks.length > 0) {
-          restoredOutputChunks.forEach((data, index) => {
+          restoredOutputChunks.forEach((chunk, index) => {
             const isLastChunk = index === restoredOutputChunks.length - 1
             if (isLastChunk && (hasRestoreOutput || restoreEndCallback)) {
-              terminal.write(data, finishRestore)
+              output.writeOutput(chunk, finishRestore)
 
               return
             }
 
-            terminal.write(data)
+            output.writeOutput(chunk)
           })
         } else {
           finishRestore()
@@ -489,11 +514,11 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     // OSC 7 updates cwd continuously; including it here would kill the PTY on every cd.
     // restoredFrom intentionally excluded — it's read from restoredFromRef at init time.
     // Including it would cause infinite loops as object identity changes.
-  }, [terminal, service, shell, env, writeTerminalOutput])
+  }, [terminal, output, service, shell, env, writeLiveTerminalOutput])
 
   // Listen to PTY data events
   useEffect(() => {
-    if (!terminal || !session) {
+    if (!terminal || !output || !session) {
       return
     }
 
@@ -507,7 +532,12 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
         // Cursor dedupe: drop events whose offset predates what we've
         // already written (replay or earlier live/buffered event).
         if (offsetStart >= cursorRef.current) {
-          writeTerminalOutput(terminal, data)
+          writeLiveTerminalOutput(output, {
+            text: data,
+            offsetStart,
+            byteLen,
+            phase: 'live',
+          })
           // Advance the cursor by the producer's raw byte count, not by the
           // length of `data`. Lossy UTF-8 in the producer (invalid bytes →
           // U+FFFD = 3 bytes when re-encoded) would otherwise drift the
@@ -628,7 +658,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
       unsubscribeExit?.()
       unsubscribeError?.()
     }
-  }, [terminal, session, service, writeTerminalOutput])
+  }, [terminal, output, session, service, writeLiveTerminalOutput])
 
   // Handle keyboard input from the terminal renderer
   useEffect(() => {

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -364,14 +364,16 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
                 },
               ]
             : []),
-          ...restoredBufferedEvents.map(
-            (event): TerminalOutputChunk => ({
-              text: event.data,
-              offsetStart: event.offsetStart,
-              byteLen: event.byteLen,
-              phase: 'restore',
-            })
-          ),
+          ...restoredBufferedEvents
+            .filter((event) => event.data.length > 0)
+            .map(
+              (event): TerminalOutputChunk => ({
+                text: event.data,
+                offsetStart: event.offsetStart,
+                byteLen: event.byteLen,
+                phase: 'restore',
+              })
+            ),
         ]
 
         const restoredOutput = restoredOutputChunks

--- a/src/features/terminal/terminalRegistry.test.ts
+++ b/src/features/terminal/terminalRegistry.test.ts
@@ -27,6 +27,7 @@ const createEntry = (): TerminalRegistryEntry => ({
     attachKeyEventHandler: vi.fn(),
     applyTheme: vi.fn(),
   },
+  output: { writeOutput: vi.fn() },
   fitController: { fit: vi.fn() },
   viewportReader: { readVisibleText: vi.fn((): string => '') },
 })

--- a/src/features/terminal/terminalRegistry.ts
+++ b/src/features/terminal/terminalRegistry.ts
@@ -1,11 +1,13 @@
 import type {
   TerminalFitController,
+  TerminalOutputWriter,
   TerminalSurface,
   TerminalViewportReader,
 } from './types'
 
 export interface TerminalRegistryEntry {
   terminal: TerminalSurface
+  output: TerminalOutputWriter
   fitController: TerminalFitController
   viewportReader: TerminalViewportReader
 }

--- a/src/features/terminal/theme/themeBridge.test.ts
+++ b/src/features/terminal/theme/themeBridge.test.ts
@@ -13,6 +13,7 @@ test('live terminals receive the new terminal theme on switch', () => {
   const fake = { applyTheme: vi.fn(), dispose: vi.fn() }
   terminalCache.set('s1', {
     terminal: fake as unknown as TerminalSurface,
+    output: { writeOutput: vi.fn() },
     fitController: { fit: vi.fn() },
     viewportReader: { readVisibleText: vi.fn() },
   })

--- a/src/features/terminal/types/index.ts
+++ b/src/features/terminal/types/index.ts
@@ -215,6 +215,23 @@ export interface TerminalSize {
   rows: number
 }
 
+/** Source phase for output written into a terminal renderer. */
+export type TerminalOutputPhase = 'live' | 'restore'
+
+/** PTY output chunk delivered to a renderer-owned parser/writer. */
+export interface TerminalOutputChunk {
+  /** UTF-8 decoded text payload used by the current xterm-compatible path. */
+  readonly text: string
+  /** Optional raw byte payload for future byte-preserving renderer adapters. */
+  readonly bytesBase64?: string
+  /** Producer byte offset for this chunk, if known. */
+  readonly offsetStart: number | null
+  /** Producer byte length for this chunk, if known. */
+  readonly byteLen: number | null
+  /** Whether this chunk is live output or historical restore replay. */
+  readonly phase: TerminalOutputPhase
+}
+
 /** Renderer-level keyboard event hook. Return false to stop the terminal. */
 export type TerminalKeyEventHandler = (event: KeyboardEvent) => boolean
 
@@ -245,6 +262,11 @@ export interface TerminalFitController {
   fit: () => void
 }
 
+/** Adapter-owned writer for PTY output chunks. */
+export interface TerminalOutputWriter {
+  writeOutput: (chunk: TerminalOutputChunk, callback?: () => void) => void
+}
+
 /** Renderer addon handle owned by the terminal adapter. */
 export interface TerminalRendererHandle {
   dispose: () => void
@@ -266,6 +288,7 @@ export interface TerminalViewportReader {
 /** Complete terminal renderer instance created for a pane. */
 export interface TerminalInstance {
   terminal: TerminalSurface
+  output: TerminalOutputWriter
   parser: TerminalParser
   viewportReader: TerminalViewportReader
   fitController: TerminalFitController


### PR DESCRIPTION
## Summary

- introduce TerminalOutputChunk and TerminalOutputWriter as the renderer-owned PTY output boundary
- route live PTY data and restore replay writes through chunk metadata while keeping xterm/plain-text on the text path
- preserve exact offsetStart/byteLen for live and buffered restore chunks, and mark snapshot replay chunks as phase=restore with unknown offsets
- carry the output writer through TerminalInstance, terminal cache entries, and Body/useTerminal wiring

## Validation

- npm --ignore-scripts run lint
- npm --ignore-scripts run format:check
- npx tsc -b --pretty false
- npx vitest run src/features/terminal/hooks/useTerminal.test.ts src/features/terminal/components/TerminalPane/Body.test.tsx src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx src/features/terminal/components/TerminalPane/plainTextInstance.test.ts src/features/terminal/components/TerminalPane/xtermInstance.test.ts src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts src/features/terminal/terminalRegistry.test.ts src/features/terminal/theme/themeBridge.test.ts