### PR TITLE
refactor(terminal): add parser event bridge

### DIFF
--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -10,6 +10,8 @@ import type {
   TerminalDisposable,
   TerminalInstance,
   TerminalOutputChunk,
+  TerminalParserEventHandler,
+  TerminalParserOutputContext,
   TerminalParser,
   TerminalRendererHandle,
   TerminalSurface,
@@ -22,7 +24,6 @@ vi.mock('./terminalInstance', () => ({
 
 type DataCallback = Parameters<ITerminalService['onData']>[0]
 type ExitCallback = Parameters<ITerminalService['onExit']>[0]
-type OscHandler = (data: string) => boolean
 
 let deferWriteCallbacks = false
 let skipOscParsing = false
@@ -76,17 +77,22 @@ class FakeTerminal implements TerminalSurface {
     }
   )
   readonly parser: TerminalParser = {
-    registerOscHandler: vi.fn(
-      (identifier: number, handler: OscHandler): TerminalDisposable => {
-        this.oscHandlers.set(identifier, handler)
+    onEvent: vi.fn(
+      (handler: TerminalParserEventHandler): TerminalDisposable => {
+        this.parserEventHandlers.add(handler)
 
-        return { dispose: vi.fn() }
+        return {
+          dispose: vi.fn(() => {
+            this.parserEventHandlers.delete(handler)
+          }),
+        }
       }
     ),
   }
 
-  private readonly oscHandlers = new Map<number, OscHandler>()
+  private readonly parserEventHandlers = new Set<TerminalParserEventHandler>()
   private readonly inputHandlers = new Set<(data: string) => void>()
+  private outputContext: TerminalParserOutputContext | null = null
   private oscBuffer = ''
 
   readonly write = vi.fn((data: string, callback?: () => void): void => {
@@ -99,6 +105,20 @@ class FakeTerminal implements TerminalSurface {
 
     callback?.()
   })
+
+  writeOutput(chunk: TerminalOutputChunk, callback?: () => void): void {
+    this.outputContext = {
+      offsetStart: chunk.offsetStart,
+      byteLen: chunk.byteLen,
+      phase: chunk.phase,
+    }
+
+    try {
+      this.write(chunk.text, callback)
+    } finally {
+      this.outputContext = null
+    }
+  }
 
   emitInput(data: string): void {
     this.inputHandlers.forEach((handler) => {
@@ -116,8 +136,19 @@ class FakeTerminal implements TerminalSurface {
     let lastMatchEnd = 0
 
     for (const match of this.oscBuffer.matchAll(oscPattern)) {
-      const handler = this.oscHandlers.get(Number(match[1]))
-      handler?.(match[2] ?? '')
+      const identifier = Number(match[1])
+
+      if (identifier === 7) {
+        this.parserEventHandlers.forEach((handler) => {
+          handler({
+            type: 'osc',
+            identifier,
+            data: match[2] ?? '',
+            output: this.outputContext,
+          })
+        })
+      }
+
       lastMatchEnd = (match.index ?? 0) + match[0].length
     }
 
@@ -147,7 +178,7 @@ const createFakeTerminalInstance = (): TerminalInstance => {
     output: {
       writeOutput: vi.fn(
         (chunk: TerminalOutputChunk, callback?: () => void): void => {
-          terminal.write(chunk.text, callback)
+          terminal.writeOutput(chunk, callback)
         }
       ),
     },

--- a/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
@@ -12,6 +12,7 @@ import type {
   TerminalDisposable,
   TerminalInstance,
   TerminalOutputChunk,
+  TerminalParserEventHandler,
   TerminalParser,
   TerminalRendererHandle,
   TerminalSurface,
@@ -32,7 +33,7 @@ interface FakeTerminalControls {
   parser: TerminalParser
   rendererHandle: TerminalRendererHandle
   viewportReader: TerminalViewportReader
-  emitOsc: (identifier: number, data: string) => boolean | undefined
+  emitOsc: (identifier: number, data: string) => void
 }
 
 const createDisposable = (): TerminalDisposable => ({
@@ -41,7 +42,7 @@ const createDisposable = (): TerminalDisposable => ({
 
 const createFakeTerminalInstance = (): FakeTerminalControls => {
   const element = document.createElement('div')
-  const oscHandlers = new Map<number, (data: string) => boolean>()
+  const parserEventHandlers = new Set<TerminalParserEventHandler>()
 
   const terminal: TerminalSurface = {
     cols: 120,
@@ -68,14 +69,15 @@ const createFakeTerminalInstance = (): FakeTerminalControls => {
   }
 
   const parser: TerminalParser = {
-    registerOscHandler: vi.fn(
-      (
-        identifier: number,
-        handler: (data: string) => boolean
-      ): TerminalDisposable => {
-        oscHandlers.set(identifier, handler)
+    onEvent: vi.fn(
+      (handler: TerminalParserEventHandler): TerminalDisposable => {
+        parserEventHandlers.add(handler)
 
-        return createDisposable()
+        return {
+          dispose: vi.fn(() => {
+            parserEventHandlers.delete(handler)
+          }),
+        }
       }
     ),
   }
@@ -109,8 +111,16 @@ const createFakeTerminalInstance = (): FakeTerminalControls => {
     parser,
     rendererHandle,
     viewportReader,
-    emitOsc: (identifier, data): boolean | undefined =>
-      oscHandlers.get(identifier)?.(data),
+    emitOsc: (identifier, data): void => {
+      parserEventHandlers.forEach((handler) => {
+        handler({
+          type: 'osc',
+          identifier,
+          data,
+          output: { offsetStart: 0, byteLen: data.length, phase: 'live' },
+        })
+      })
+    },
   }
 }
 
@@ -172,10 +182,7 @@ test('Body can run against a non-xterm TerminalInstance contract', async () => {
   })
 
   expect(fake.instance.attachRenderer).toHaveBeenCalledOnce()
-  expect(fake.parser.registerOscHandler).toHaveBeenCalledWith(
-    7,
-    expect.any(Function)
-  )
+  expect(fake.parser.onEvent).toHaveBeenCalledWith(expect.any(Function))
 
   expect(useTerminal).toHaveBeenCalledWith(
     expect.objectContaining({ terminal: fake.terminal })
@@ -186,7 +193,7 @@ test('Body can run against a non-xterm TerminalInstance contract', async () => {
     TERMINAL_FOCUS_SCOPE_VALUE
   )
 
-  expect(fake.emitOsc(7, 'file://localhost/tmp/fake-project')).toBe(true)
+  fake.emitOsc(7, 'file://localhost/tmp/fake-project')
   expect(onCwdChange).toHaveBeenCalledWith('/tmp/fake-project')
 
   unmount()

--- a/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
@@ -31,6 +31,7 @@ interface FakeTerminalControls {
   instance: TerminalInstance
   terminal: TerminalSurface
   parser: TerminalParser
+  parserEventDisposable: TerminalDisposable
   rendererHandle: TerminalRendererHandle
   viewportReader: TerminalViewportReader
   emitOsc: (identifier: number, data: string) => void
@@ -43,6 +44,18 @@ const createDisposable = (): TerminalDisposable => ({
 const createFakeTerminalInstance = (): FakeTerminalControls => {
   const element = document.createElement('div')
   const parserEventHandlers = new Set<TerminalParserEventHandler>()
+  let subscribedParserEventHandler: TerminalParserEventHandler | null = null
+
+  const parserEventDisposable: TerminalDisposable = {
+    dispose: vi.fn((): void => {
+      if (subscribedParserEventHandler === null) {
+        return
+      }
+
+      parserEventHandlers.delete(subscribedParserEventHandler)
+      subscribedParserEventHandler = null
+    }),
+  }
 
   const terminal: TerminalSurface = {
     cols: 120,
@@ -72,12 +85,9 @@ const createFakeTerminalInstance = (): FakeTerminalControls => {
     onEvent: vi.fn(
       (handler: TerminalParserEventHandler): TerminalDisposable => {
         parserEventHandlers.add(handler)
+        subscribedParserEventHandler = handler
 
-        return {
-          dispose: vi.fn(() => {
-            parserEventHandlers.delete(handler)
-          }),
-        }
+        return parserEventDisposable
       }
     ),
   }
@@ -109,6 +119,7 @@ const createFakeTerminalInstance = (): FakeTerminalControls => {
     instance,
     terminal,
     parser,
+    parserEventDisposable,
     rendererHandle,
     viewportReader,
     emitOsc: (identifier, data): void => {
@@ -198,6 +209,7 @@ test('Body can run against a non-xterm TerminalInstance contract', async () => {
 
   unmount()
 
+  expect(fake.parserEventDisposable.dispose).toHaveBeenCalledOnce()
   expect(fake.rendererHandle.dispose).toHaveBeenCalledOnce()
   expect(fake.terminal.dispose).toHaveBeenCalledOnce()
 })

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -16,6 +16,7 @@ import type {
   TerminalInstance,
   TerminalOutputChunk,
   TerminalParser,
+  TerminalParserEvent,
   TerminalRendererHandle,
   TerminalSurface,
   TerminalViewportReader,
@@ -93,7 +94,7 @@ type MockFitController = TerminalFitController & {
 }
 
 type MockParser = TerminalParser & {
-  registerOscHandler: ReturnType<typeof vi.fn>
+  onEvent: ReturnType<typeof vi.fn>
 }
 
 type MockViewportReader = TerminalViewportReader & {
@@ -143,7 +144,7 @@ const createMockTerminalControls = (): MockTerminalControls => {
   }
 
   const parser: MockParser = {
-    registerOscHandler: vi.fn((): TerminalDisposable => createDisposable()),
+    onEvent: vi.fn((): TerminalDisposable => createDisposable()),
   }
 
   const fitController: MockFitController = {
@@ -2044,18 +2045,18 @@ describe('Body', () => {
       )
 
       await waitFor(() => {
-        expect(mockParser.registerOscHandler).toHaveBeenCalledWith(
-          7,
-          expect.any(Function)
-        )
+        expect(mockParser.onEvent).toHaveBeenCalledWith(expect.any(Function))
       })
 
-      const oscHandler = vi.mocked(mockParser.registerOscHandler).mock
-        .calls[0]?.[1]
+      const parserEventHandler = vi.mocked(mockParser.onEvent).mock
+        .calls[0]?.[0] as ((event: TerminalParserEvent) => void) | undefined
 
-      ;(oscHandler as ((data: string) => void) | undefined)?.(
-        'file://localhost/home/user/projects'
-      )
+      parserEventHandler?.({
+        type: 'osc',
+        identifier: 7,
+        data: 'file://localhost/home/user/projects',
+        output: { offsetStart: 0, byteLen: 41, phase: 'live' },
+      })
 
       await waitFor(() => {
         expect(onCwdChange).toHaveBeenCalledWith('/home/user/projects')
@@ -2107,18 +2108,18 @@ describe('Body', () => {
       )
 
       await waitFor(() => {
-        expect(mockParser.registerOscHandler).toHaveBeenCalledWith(
-          7,
-          expect.any(Function)
-        )
+        expect(mockParser.onEvent).toHaveBeenCalledWith(expect.any(Function))
       })
 
-      const oscHandler = vi.mocked(mockParser.registerOscHandler).mock
-        .calls[0]?.[1]
+      const parserEventHandler = vi.mocked(mockParser.onEvent).mock
+        .calls[0]?.[0] as ((event: TerminalParserEvent) => void) | undefined
 
-      ;(oscHandler as ((data: string) => void) | undefined)?.(
-        'file://server/share/project'
-      )
+      parserEventHandler?.({
+        type: 'osc',
+        identifier: 7,
+        data: 'file://server/share/project',
+        output: { offsetStart: 0, byteLen: 27, phase: 'live' },
+      })
 
       await waitFor(() => {
         expect(onCwdChange).toHaveBeenCalledWith('//server/share/project')
@@ -2170,13 +2171,18 @@ describe('Body', () => {
       )
 
       await waitFor(() => {
-        expect(mockParser.registerOscHandler).toHaveBeenCalled()
+        expect(mockParser.onEvent).toHaveBeenCalled()
       })
 
-      const oscHandler = vi.mocked(mockParser.registerOscHandler).mock
-        .calls[0]?.[1]
+      const parserEventHandler = vi.mocked(mockParser.onEvent).mock
+        .calls[0]?.[0] as ((event: TerminalParserEvent) => void) | undefined
 
-      ;(oscHandler as ((data: string) => void) | undefined)?.('/tmp')
+      parserEventHandler?.({
+        type: 'osc',
+        identifier: 7,
+        data: '/tmp',
+        output: { offsetStart: 0, byteLen: 4, phase: 'live' },
+      })
 
       await waitFor(() => {
         expect(onCwdChange).toHaveBeenCalledWith('/tmp')

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -479,6 +479,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     let newTerminal: TerminalSurface | null = null
     let newTerminalOutput: TerminalOutputWriter | null = null
     let fitController: TerminalFitController | null = null
+    let parserEventDisposable: TerminalDisposable | null = null
     let rendererHandle: TerminalRendererHandle | null = null
     let fitFrameId: number | null = null
     let lastFitSize: { width: number; height: number } | null = null
@@ -628,7 +629,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
           // Subscribe to parser events for cwd tracking. Shell prompts and
           // agent/tool output both arrive through the renderer parser, so this
           // stays pane-local while remaining adapter-neutral.
-          created.parser.onEvent((event) => {
+          parserEventDisposable = created.parser.onEvent((event) => {
             if (event.identifier !== 7) {
               return
             }
@@ -875,6 +876,9 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
           return
         }
 
+        parserEventDisposable?.dispose()
+        parserEventDisposable = null
+
         rendererHandle?.dispose()
         rendererHandle = null
 
@@ -918,6 +922,8 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
       removeFocusListeners = null
       removeVisibilityListeners?.()
       removeVisibilityListeners = null
+      parserEventDisposable?.dispose()
+      parserEventDisposable = null
       // Renderer addons must dispose before the terminal itself; the handle
       // owns that adapter-specific ordering.
       rendererHandle?.dispose()

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -21,6 +21,7 @@ import type {
   TerminalDisposable,
   TerminalFitController,
   TerminalOutputWriter,
+  TerminalParserEvent,
   TerminalRendererHandle,
   TerminalSurface,
 } from '../../types'
@@ -73,6 +74,9 @@ const terminalStartupErrorMessage = (error: unknown): string => {
 
   return 'Unknown terminal startup error'
 }
+
+const isRestoreParserEvent = (event: TerminalParserEvent): boolean =>
+  event.output?.phase === 'restore'
 
 export { clearTerminalCache, disposeTerminalSession, terminalCache }
 
@@ -621,16 +625,22 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
           // Fit terminal to container — guard against hidden (display:none) containers
           didInitialFit = fitInitialWhenReady(fitController)
 
-          // Register OSC 7 handler for cwd tracking. Shell prompts and agent/tool
-          // output both arrive through the terminal parser, so this stays pane-local.
-          created.parser.registerOscHandler(7, (data) => {
+          // Subscribe to parser events for cwd tracking. Shell prompts and
+          // agent/tool output both arrive through the renderer parser, so this
+          // stays pane-local while remaining adapter-neutral.
+          created.parser.onEvent((event) => {
+            if (event.identifier !== 7) {
+              return
+            }
+
             const previousCwd = agentCwdRef.current
 
-            const path = parseOsc7Cwd(data, {
+            const path = parseOsc7Cwd(event.data, {
               preserveFileUrlHost: shouldPreserveOsc7FileUrlHost(previousCwd),
             })
 
-            const shouldSuppressRestoreOsc7 = isRestoringOutputRef.current
+            const shouldSuppressRestoreOsc7 =
+              isRestoreParserEvent(event) || isRestoringOutputRef.current
 
             const shouldIgnore =
               path !== null &&
@@ -643,7 +653,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
             logAgentCwdDebug('osc7', {
               sessionId,
-              raw: data,
+              raw: event.data,
               previousCwd,
               nextCwd: path,
               changed: path !== null && path !== previousCwd,
@@ -651,7 +661,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
             })
 
             if (shouldSuppressRestoreOsc7) {
-              return true
+              return
             }
 
             if (path && path === agentCwdRef.current) {
@@ -663,8 +673,6 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
               agentCwdSourceRef.current = 'osc7'
               onCwdChangeRef.current?.(path)
             }
-
-            return true
           })
 
           // Cache the terminal instance for this session

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -124,92 +124,91 @@ describe('plainTextInstance', () => {
     expect(lines[lines.length - 1]).toBe('line-10004')
   })
 
-  test('consumes registered OSC handlers without rendering control sequences', () => {
+  test('emits parser events without rendering consumed OSC sequences', () => {
     const created = createTrackedPlainTextTerminal()
-    const oscHandler = vi.fn((): boolean => true)
+    const parserEventHandler = vi.fn()
     const container = document.createElement('div')
+
+    const text =
+      'before \x1b]7;file://localhost/tmp/plain-text-project\x07after'
 
     setElementSize(container, 640, 360)
     created.terminal.open(container)
-    created.parser.registerOscHandler(7, oscHandler)
-    created.terminal.write(
-      'before \x1b]7;file://localhost/tmp/plain-text-project\x07after'
-    )
+    created.parser.onEvent(parserEventHandler)
+    created.output.writeOutput({
+      text,
+      offsetStart: 12,
+      byteLen: new TextEncoder().encode(text).length,
+      phase: 'live',
+    })
 
-    expect(oscHandler).toHaveBeenCalledWith(
-      'file://localhost/tmp/plain-text-project'
-    )
+    expect(parserEventHandler).toHaveBeenCalledWith({
+      type: 'osc',
+      identifier: 7,
+      data: 'file://localhost/tmp/plain-text-project',
+      output: {
+        offsetStart: 12,
+        byteLen: new TextEncoder().encode(text).length,
+        phase: 'live',
+      },
+    })
     expect(created.viewportReader.readVisibleText()).toBe('before after')
   })
 
-  test('tries stacked OSC handlers in reverse registration order', () => {
+  test('notifies parser event subscribers in registration order', () => {
     const created = createTrackedPlainTextTerminal()
-    const firstHandler = vi.fn((): boolean => true)
-    const secondHandler = vi.fn((): boolean => false)
+    const firstHandler = vi.fn()
+    const secondHandler = vi.fn()
 
-    created.parser.registerOscHandler(7, firstHandler)
-    created.parser.registerOscHandler(7, secondHandler)
+    created.parser.onEvent(firstHandler)
+    created.parser.onEvent(secondHandler)
     created.terminal.write(
       'before \x1b]7;file://localhost/tmp/plain-text-project\x07after'
-    )
-
-    expect(secondHandler).toHaveBeenCalledWith(
-      'file://localhost/tmp/plain-text-project'
     )
 
     expect(firstHandler).toHaveBeenCalledWith(
-      'file://localhost/tmp/plain-text-project'
+      expect.objectContaining({
+        type: 'osc',
+        identifier: 7,
+        data: 'file://localhost/tmp/plain-text-project',
+      })
     )
 
-    expect(secondHandler.mock.invocationCallOrder[0]).toBeLessThan(
-      firstHandler.mock.invocationCallOrder[0]
+    expect(secondHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'osc',
+        identifier: 7,
+        data: 'file://localhost/tmp/plain-text-project',
+      })
+    )
+
+    expect(firstHandler.mock.invocationCallOrder[0]).toBeLessThan(
+      secondHandler.mock.invocationCallOrder[0]
     )
     expect(created.viewportReader.readVisibleText()).toBe('before after')
   })
 
-  test('stops stacked OSC handling after the newest handler consumes', () => {
+  test('renders OSC sequences when no parser event subscribers exist', () => {
     const created = createTrackedPlainTextTerminal()
-    const firstHandler = vi.fn((): boolean => true)
-    const secondHandler = vi.fn((): boolean => true)
-
-    created.parser.registerOscHandler(7, firstHandler)
-    created.parser.registerOscHandler(7, secondHandler)
-    created.terminal.write('\x1b]7;file://localhost/tmp/plain-text-project\x07')
-
-    expect(secondHandler).toHaveBeenCalledWith(
-      'file://localhost/tmp/plain-text-project'
-    )
-    expect(firstHandler).not.toHaveBeenCalled()
-    expect(created.viewportReader.readVisibleText()).toBe('')
-  })
-
-  test('renders OSC sequences when registered handlers decline them', () => {
-    const created = createTrackedPlainTextTerminal()
-    const oscHandler = vi.fn((): boolean => false)
     const sequence = '\x1b]7;file://localhost/tmp/plain-text-project\x07'
 
-    created.parser.registerOscHandler(7, oscHandler)
     created.terminal.write(`before ${sequence}after`)
-
-    expect(oscHandler).toHaveBeenCalledWith(
-      'file://localhost/tmp/plain-text-project'
-    )
 
     expect(created.viewportReader.readVisibleText()).toBe(
       `before ${sequence}after`
     )
   })
 
-  test('stops invoking disposed OSC handlers', () => {
+  test('stops invoking disposed parser event handlers', () => {
     const created = createTrackedPlainTextTerminal()
-    const oscHandler = vi.fn((): boolean => true)
-    const sequence = '\x1b]7;file://localhost/tmp/ignored\x07'
-    const disposable = created.parser.registerOscHandler(7, oscHandler)
+    const parserEventHandler = vi.fn()
+    const sequence = '\x1b]7;file://localhost/tmp/plain-text-project\x07'
+    const disposable = created.parser.onEvent(parserEventHandler)
 
     disposable.dispose()
     created.terminal.write(sequence)
 
-    expect(oscHandler).not.toHaveBeenCalled()
+    expect(parserEventHandler).not.toHaveBeenCalled()
     expect(created.viewportReader.readVisibleText()).toBe(sequence)
   })
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -4,7 +4,11 @@ import type {
   TerminalFitController,
   TerminalInstance,
   TerminalKeyEventHandler,
+  TerminalOutputChunk,
   TerminalOutputWriter,
+  TerminalParserEvent,
+  TerminalParserEventHandler,
+  TerminalParserOutputContext,
   TerminalParser,
   TerminalRendererAdapter,
   TerminalRendererHandle,
@@ -38,12 +42,6 @@ const KEYBOARD_SEQUENCES = new Map<string, string>([
   ['PageDown', '\x1b[6~'],
 ])
 
-type OscHandler = (data: string) => boolean
-
-interface OscHandlerRegistration {
-  readonly handler: OscHandler
-}
-
 const getControlKeyData = (key: string): string | null => {
   if (key.length !== 1) {
     return null
@@ -74,6 +72,14 @@ const trimScrollbackLines = (text: string): string => {
 
   return lines.slice(-MAX_SCROLLBACK_LINES).join('\n')
 }
+
+const outputContextFromChunk = (
+  chunk: TerminalOutputChunk
+): TerminalParserOutputContext => ({
+  offsetStart: chunk.offsetStart,
+  byteLen: chunk.byteLen,
+  phase: chunk.phase,
+})
 
 const readContainedSelection = (root: HTMLElement): string => {
   const selection = window.getSelection()
@@ -431,46 +437,31 @@ class PlainTextTerminalSurface implements TerminalSurface {
 }
 
 class PlainTextTerminalModel {
-  private readonly oscHandlers = new Map<number, OscHandlerRegistration[]>()
+  private readonly parserEventHandlers = new Set<TerminalParserEventHandler>()
+  private currentOutputContext: TerminalParserOutputContext | null = null
   readonly terminal = new PlainTextTerminalSurface((data) =>
     this.consumeControlSequences(data)
   )
 
   readonly parser: TerminalParser = {
-    registerOscHandler: (
-      identifier: number,
-      handler: OscHandler
-    ): TerminalDisposable => {
-      const registration = { handler }
-      const registrations = this.oscHandlers.get(identifier) ?? []
-
-      this.oscHandlers.set(identifier, [...registrations, registration])
+    onEvent: (handler): TerminalDisposable => {
+      this.parserEventHandlers.add(handler)
 
       return createDisposable((): void => {
-        const currentRegistrations = this.oscHandlers.get(identifier)
-
-        if (!currentRegistrations) {
-          return
-        }
-
-        const nextRegistrations = currentRegistrations.filter(
-          (currentRegistration) => currentRegistration !== registration
-        )
-
-        if (nextRegistrations.length === 0) {
-          this.oscHandlers.delete(identifier)
-
-          return
-        }
-
-        this.oscHandlers.set(identifier, nextRegistrations)
+        this.parserEventHandlers.delete(handler)
       })
     },
   }
 
   readonly output: TerminalOutputWriter = {
     writeOutput: (chunk, callback): void => {
-      this.terminal.write(chunk.text, callback)
+      this.currentOutputContext = outputContextFromChunk(chunk)
+
+      try {
+        this.terminal.write(chunk.text, callback)
+      } finally {
+        this.currentOutputContext = null
+      }
     },
   }
 
@@ -494,17 +485,28 @@ class PlainTextTerminalModel {
     return data.replace(
       oscSequencePattern,
       (sequence, identifier: string, payload: string): string => {
-        const registrations = this.oscHandlers.get(Number(identifier)) ?? []
+        const numericIdentifier = Number(identifier)
 
-        for (const registration of registrations.slice().reverse()) {
-          if (registration.handler(payload)) {
-            return ''
-          }
+        if (numericIdentifier !== 7 || this.parserEventHandlers.size === 0) {
+          return sequence
         }
 
-        return sequence
+        this.emitParserEvent({
+          type: 'osc',
+          identifier: numericIdentifier,
+          data: payload,
+          output: this.currentOutputContext,
+        })
+
+        return ''
       }
     )
+  }
+
+  private emitParserEvent(event: TerminalParserEvent): void {
+    this.parserEventHandlers.forEach((handler) => {
+      handler(event)
+    })
   }
 }
 

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
@@ -60,7 +60,7 @@ const createTerminalInstance = (): TerminalInstance => ({
     writeOutput: vi.fn(),
   },
   parser: {
-    registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
+    onEvent: vi.fn(() => ({ dispose: vi.fn() })),
   },
   viewportReader: {
     readVisibleText: vi.fn((): string => ''),

--- a/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
@@ -153,6 +153,8 @@ describe('xtermInstance', () => {
       'visible one\nvisible two'
     )
 
+    const parserEventHandler = vi.fn()
+    created.parser.onEvent(parserEventHandler)
     const writeCallback = vi.fn()
     created.output.writeOutput(
       {
@@ -163,7 +165,6 @@ describe('xtermInstance', () => {
       },
       writeCallback
     )
-    created.parser.registerOscHandler(7, () => true)
 
     created.terminal.open(container)
     created.terminal.applyTheme(obsidianLens.terminal)
@@ -172,7 +173,34 @@ describe('xtermInstance', () => {
       7,
       expect.any(Function)
     )
-    expect(terminal.write).toHaveBeenCalledWith('chunk output', writeCallback)
+
+    const oscHandler = terminal.parser.registerOscHandler.mock.calls[0]?.[1] as
+      | ((data: string) => boolean)
+      | undefined
+    oscHandler?.('file://localhost/tmp/xterm')
+
+    expect(parserEventHandler).toHaveBeenCalledWith({
+      type: 'osc',
+      identifier: 7,
+      data: 'file://localhost/tmp/xterm',
+      output: {
+        offsetStart: 8,
+        byteLen: 12,
+        phase: 'live',
+      },
+    })
+
+    expect(terminal.write).toHaveBeenCalledWith(
+      'chunk output',
+      expect.any(Function)
+    )
+
+    const writeCompletion = terminal.write.mock.calls[0]?.[1] as
+      | (() => void)
+      | undefined
+    writeCompletion?.()
+
+    expect(writeCallback).toHaveBeenCalledOnce()
     expect(terminal.open).toHaveBeenCalledWith(container)
     expect(terminal.options.theme).toEqual(
       expect.objectContaining({

--- a/src/features/terminal/components/TerminalPane/xtermInstance.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.ts
@@ -5,7 +5,11 @@ import { CanvasAddon } from '@xterm/addon-canvas'
 import { themeService } from '../../../../theme'
 import type {
   TerminalInstance,
+  TerminalOutputChunk,
   TerminalOutputWriter,
+  TerminalParserEvent,
+  TerminalParserEventHandler,
+  TerminalParserOutputContext,
   TerminalParser,
   TerminalRendererHandle,
   TerminalRendererAdapter,
@@ -29,11 +33,12 @@ export const createXtermTerminal = (): TerminalInstance => {
 
   const fitAddon = new FitAddon()
   terminal.loadAddon(fitAddon)
+  const outputContext = createTerminalOutputContext()
 
   return {
     terminal: createTerminalSurface(terminal),
-    output: createTerminalOutputWriter(terminal),
-    parser: createTerminalParser(terminal),
+    output: createTerminalOutputWriter(terminal, outputContext),
+    parser: createTerminalParser(terminal, outputContext),
     viewportReader: createTerminalViewportReader(terminal),
     fitController: fitAddon,
     attachRenderer: () => attachXtermRenderer(terminal),
@@ -94,20 +99,116 @@ const createTerminalSurface = (terminal: Terminal): TerminalSurface => ({
   },
 })
 
+interface TerminalOutputContextTracker {
+  readonly current: () => TerminalParserOutputContext | null
+  readonly push: (chunk: TerminalOutputChunk) => void
+  readonly finish: (chunk: TerminalOutputChunk) => void
+}
+
+const outputContextFromChunk = (
+  chunk: TerminalOutputChunk
+): TerminalParserOutputContext => ({
+  offsetStart: chunk.offsetStart,
+  byteLen: chunk.byteLen,
+  phase: chunk.phase,
+})
+
+const createTerminalOutputContext = (): TerminalOutputContextTracker => {
+  const pendingChunks: TerminalOutputChunk[] = []
+  let activeChunk: TerminalOutputChunk | null = null
+
+  const activateNext = (): void => {
+    activeChunk = pendingChunks[0] ?? null
+  }
+
+  return {
+    current: (): TerminalParserOutputContext | null =>
+      activeChunk ? outputContextFromChunk(activeChunk) : null,
+    push: (chunk): void => {
+      pendingChunks.push(chunk)
+
+      activeChunk ??= chunk
+    },
+    finish: (chunk): void => {
+      const index = pendingChunks.indexOf(chunk)
+
+      if (index !== -1) {
+        pendingChunks.splice(index, 1)
+      }
+
+      if (activeChunk === chunk) {
+        activateNext()
+      }
+    },
+  }
+}
+
 const createTerminalOutputWriter = (
-  terminal: Terminal
+  terminal: Terminal,
+  outputContext: TerminalOutputContextTracker
 ): TerminalOutputWriter => ({
   writeOutput: (chunk, callback): void => {
-    terminal.write(chunk.text, callback)
+    outputContext.push(chunk)
+    terminal.write(chunk.text, () => {
+      outputContext.finish(chunk)
+      callback?.()
+    })
   },
 })
 
-const createTerminalParser = (terminal: Terminal): TerminalParser => ({
-  registerOscHandler: (
-    identifier: number,
-    handler: (data: string) => boolean
-  ) => terminal.parser.registerOscHandler(identifier, handler),
-})
+const createTerminalParser = (
+  terminal: Terminal,
+  outputContext: TerminalOutputContextTracker
+): TerminalParser => {
+  const handlers = new Set<TerminalParserEventHandler>()
+  let osc7Disposable: { dispose: () => void } | null = null
+
+  const emit = (event: TerminalParserEvent): void => {
+    handlers.forEach((handler) => {
+      handler(event)
+    })
+  }
+
+  const ensureOsc7Handler = (): void => {
+    if (osc7Disposable) {
+      return
+    }
+
+    osc7Disposable = terminal.parser.registerOscHandler(7, (data) => {
+      emit({
+        type: 'osc',
+        identifier: 7,
+        data,
+        output: outputContext.current(),
+      })
+
+      return true
+    })
+  }
+
+  const removeOsc7HandlerIfIdle = (): void => {
+    if (handlers.size > 0) {
+      return
+    }
+
+    osc7Disposable?.dispose()
+    osc7Disposable = null
+  }
+
+  return {
+    onEvent: (handler): { dispose: () => void } => {
+      handlers.add(handler)
+      ensureOsc7Handler()
+
+      return {
+        dispose: (): void => {
+          handlers.delete(handler)
+          removeOsc7HandlerIfIdle()
+        },
+      }
+    },
+  }
+}
 
 const createTerminalViewportReader = (
   terminal: Terminal

--- a/src/features/terminal/types/index.ts
+++ b/src/features/terminal/types/index.ts
@@ -232,6 +232,13 @@ export interface TerminalOutputChunk {
   readonly phase: TerminalOutputPhase
 }
 
+/** Output metadata attached to parser events when a renderer can provide it. */
+export interface TerminalParserOutputContext {
+  readonly offsetStart: number | null
+  readonly byteLen: number | null
+  readonly phase: TerminalOutputPhase
+}
+
 /** Renderer-level keyboard event hook. Return false to stop the terminal. */
 export type TerminalKeyEventHandler = (event: KeyboardEvent) => boolean
 
@@ -272,12 +279,20 @@ export interface TerminalRendererHandle {
   dispose: () => void
 }
 
+/** Parser event emitted from terminal control sequences. */
+export interface TerminalParserEvent {
+  readonly type: 'osc'
+  readonly identifier: number
+  readonly data: string
+  readonly output: TerminalParserOutputContext | null
+}
+
+/** Handler for semantic parser events. */
+export type TerminalParserEventHandler = (event: TerminalParserEvent) => void
+
 /** Parser hooks emitted from terminal control sequences. */
 export interface TerminalParser {
-  registerOscHandler: (
-    identifier: number,
-    handler: (data: string) => boolean
-  ) => TerminalDisposable
+  onEvent: (handler: TerminalParserEventHandler) => TerminalDisposable
 }
 
 /** Reads the currently visible terminal text for automation and diagnostics. */


### PR DESCRIPTION
## Summary

- replace app-level `registerOscHandler(7)` usage with a renderer-neutral `TerminalParser.onEvent` contract
- let xterm/plain-text adapters translate OSC 7 into parser events while consuming the control sequence
- attach output phase and byte cursor context to parser events when output chunks provide it
- preserve the existing OSC 7 cwd parsing and pane cwd update path in `Body`

## Validation

- npm --ignore-scripts run lint
- npm --ignore-scripts run format:check
- npx tsc -b --pretty false
- npx vitest run src/features/terminal/hooks/useTerminal.test.ts src/features/terminal/components/TerminalPane/Body.test.tsx src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx src/features/terminal/components/TerminalPane/plainTextInstance.test.ts src/features/terminal/components/TerminalPane/xtermInstance.test.ts src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts src/features/terminal/terminalRegistry.test.ts src/features/terminal/theme/themeBridge.test.ts