### PR TITLE
refactor(terminal): emit cwd parser events

### DIFF
--- a/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx
@@ -141,9 +141,9 @@ class FakeTerminal implements TerminalSurface {
       if (identifier === 7) {
         this.parserEventHandlers.forEach((handler) => {
           handler({
-            type: 'osc',
-            identifier,
-            data: match[2] ?? '',
+            type: 'cwd',
+            source: 'osc7',
+            uri: match[2] ?? '',
             output: this.outputContext,
           })
         })

--- a/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx
@@ -34,7 +34,7 @@ interface FakeTerminalControls {
   parserEventDisposable: TerminalDisposable
   rendererHandle: TerminalRendererHandle
   viewportReader: TerminalViewportReader
-  emitOsc: (identifier: number, data: string) => void
+  emitCwd: (uri: string) => void
 }
 
 const createDisposable = (): TerminalDisposable => ({
@@ -122,13 +122,13 @@ const createFakeTerminalInstance = (): FakeTerminalControls => {
     parserEventDisposable,
     rendererHandle,
     viewportReader,
-    emitOsc: (identifier, data): void => {
+    emitCwd: (uri): void => {
       parserEventHandlers.forEach((handler) => {
         handler({
-          type: 'osc',
-          identifier,
-          data,
-          output: { offsetStart: 0, byteLen: data.length, phase: 'live' },
+          type: 'cwd',
+          source: 'osc7',
+          uri,
+          output: { offsetStart: 0, byteLen: uri.length, phase: 'live' },
         })
       })
     },
@@ -204,7 +204,7 @@ test('Body can run against a non-xterm TerminalInstance contract', async () => {
     TERMINAL_FOCUS_SCOPE_VALUE
   )
 
-  fake.emitOsc(7, 'file://localhost/tmp/fake-project')
+  fake.emitCwd('file://localhost/tmp/fake-project')
   expect(onCwdChange).toHaveBeenCalledWith('/tmp/fake-project')
 
   unmount()

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -2052,9 +2052,9 @@ describe('Body', () => {
         .calls[0]?.[0] as ((event: TerminalParserEvent) => void) | undefined
 
       parserEventHandler?.({
-        type: 'osc',
-        identifier: 7,
-        data: 'file://localhost/home/user/projects',
+        type: 'cwd',
+        source: 'osc7',
+        uri: 'file://localhost/home/user/projects',
         output: { offsetStart: 0, byteLen: 41, phase: 'live' },
       })
 
@@ -2115,9 +2115,9 @@ describe('Body', () => {
         .calls[0]?.[0] as ((event: TerminalParserEvent) => void) | undefined
 
       parserEventHandler?.({
-        type: 'osc',
-        identifier: 7,
-        data: 'file://server/share/project',
+        type: 'cwd',
+        source: 'osc7',
+        uri: 'file://server/share/project',
         output: { offsetStart: 0, byteLen: 27, phase: 'live' },
       })
 
@@ -2178,9 +2178,9 @@ describe('Body', () => {
         .calls[0]?.[0] as ((event: TerminalParserEvent) => void) | undefined
 
       parserEventHandler?.({
-        type: 'osc',
-        identifier: 7,
-        data: '/tmp',
+        type: 'cwd',
+        source: 'osc7',
+        uri: '/tmp',
         output: { offsetStart: 0, byteLen: 4, phase: 'live' },
       })
 

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -630,13 +630,9 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
           // agent/tool output both arrive through the renderer parser, so this
           // stays pane-local while remaining adapter-neutral.
           parserEventDisposable = created.parser.onEvent((event) => {
-            if (event.identifier !== 7) {
-              return
-            }
-
             const previousCwd = agentCwdRef.current
 
-            const path = parseOsc7Cwd(event.data, {
+            const path = parseOsc7Cwd(event.uri, {
               preserveFileUrlHost: shouldPreserveOsc7FileUrlHost(previousCwd),
             })
 
@@ -654,7 +650,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
             logAgentCwdDebug('osc7', {
               sessionId,
-              raw: event.data,
+              raw: event.uri,
               previousCwd,
               nextCwd: path,
               changed: path !== null && path !== previousCwd,

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -143,9 +143,9 @@ describe('plainTextInstance', () => {
     })
 
     expect(parserEventHandler).toHaveBeenCalledWith({
-      type: 'osc',
-      identifier: 7,
-      data: 'file://localhost/tmp/plain-text-project',
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/plain-text-project',
       output: {
         offsetStart: 12,
         byteLen: new TextEncoder().encode(text).length,
@@ -168,17 +168,17 @@ describe('plainTextInstance', () => {
 
     expect(firstHandler).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'osc',
-        identifier: 7,
-        data: 'file://localhost/tmp/plain-text-project',
+        type: 'cwd',
+        source: 'osc7',
+        uri: 'file://localhost/tmp/plain-text-project',
       })
     )
 
     expect(secondHandler).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'osc',
-        identifier: 7,
-        data: 'file://localhost/tmp/plain-text-project',
+        type: 'cwd',
+        source: 'osc7',
+        uri: 'file://localhost/tmp/plain-text-project',
       })
     )
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -492,9 +492,9 @@ class PlainTextTerminalModel {
         }
 
         this.emitParserEvent({
-          type: 'osc',
-          identifier: numericIdentifier,
-          data: payload,
+          type: 'cwd',
+          source: 'osc7',
+          uri: payload,
           output: this.currentOutputContext,
         })
 

--- a/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
@@ -180,9 +180,9 @@ describe('xtermInstance', () => {
     oscHandler?.('file://localhost/tmp/xterm')
 
     expect(parserEventHandler).toHaveBeenCalledWith({
-      type: 'osc',
-      identifier: 7,
-      data: 'file://localhost/tmp/xterm',
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/xterm',
       output: {
         offsetStart: 8,
         byteLen: 12,

--- a/src/features/terminal/components/TerminalPane/xtermInstance.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.ts
@@ -176,9 +176,9 @@ const createTerminalParser = (
 
     osc7Disposable = terminal.parser.registerOscHandler(7, (data) => {
       emit({
-        type: 'osc',
-        identifier: 7,
-        data,
+        type: 'cwd',
+        source: 'osc7',
+        uri: data,
         output: outputContext.current(),
       })
 

--- a/src/features/terminal/types/index.ts
+++ b/src/features/terminal/types/index.ts
@@ -279,18 +279,29 @@ export interface TerminalRendererHandle {
   dispose: () => void
 }
 
-/** Parser event emitted from terminal control sequences. */
-export interface TerminalParserEvent {
-  readonly type: 'osc'
-  readonly identifier: number
-  readonly data: string
+/** Cwd event emitted from OSC 7 terminal control sequences. */
+export interface TerminalCwdParserEvent {
+  readonly type: 'cwd'
+  readonly source: 'osc7'
+  /** Raw OSC 7 URI/path payload. Consumers own context-sensitive path normalization. */
+  readonly uri: string
   readonly output: TerminalParserOutputContext | null
 }
+
+/** Parser event emitted from terminal control sequences. */
+export type TerminalParserEvent = TerminalCwdParserEvent
 
 /** Handler for semantic parser events. */
 export type TerminalParserEventHandler = (event: TerminalParserEvent) => void
 
-/** Parser hooks emitted from terminal control sequences. */
+/**
+ * Parser hooks emitted from terminal control sequences.
+ *
+ * The current adapter contract emits cwd events derived from OSC 7. Adapters may
+ * consume matched control sequences from rendered output while subscribers are
+ * registered; callers should treat subscription as observing terminal semantics,
+ * not as a passive raw stream tap.
+ */
 export interface TerminalParser {
   onEvent: (handler: TerminalParserEventHandler) => TerminalDisposable
 }


### PR DESCRIPTION
## Summary
- Narrow terminal parser events from generic OSC identifiers to an OSC7-derived cwd event
- Keep raw OSC7 URI payload plus output context on the parser event while preserving pane-local cwd normalization
- Update xterm, plain-text, and non-xterm fake terminal coverage for the semantic parser event shape

## Verification
- npm --ignore-scripts run lint
- npm --ignore-scripts run format:check
- npx tsc -b --pretty false
- npx vitest run src/features/terminal/hooks/useTerminal.test.ts src/features/terminal/components/TerminalPane/Body.test.tsx src/features/terminal/components/TerminalPane/Body.fake-terminal.test.tsx src/features/terminal/components/TerminalPane/Body.agent-osc.test.tsx src/features/terminal/components/TerminalPane/plainTextInstance.test.ts src/features/terminal/components/TerminalPane/xtermInstance.test.ts src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts src/features/terminal/terminalRegistry.test.ts src/features/terminal/theme/themeBridge.test.ts
- git diff --check