### PR TITLE
feat(terminal): carry PTY bytes payload

### DIFF
--- a/crates/backend/src/terminal/bytes.rs
+++ b/crates/backend/src/terminal/bytes.rs
@@ -1,4 +1,18 @@
 const BASE64_TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const PTY_BYTES_BASE64_ENV: &str = "VIMEFLOW_EXPERIMENTAL_PTY_BYTES_BASE64";
+
+fn is_truthy_flag(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+pub(crate) fn should_emit_bytes_base64() -> bool {
+    std::env::var(PTY_BYTES_BASE64_ENV)
+        .map(|value| is_truthy_flag(&value))
+        .unwrap_or(false)
+}
 
 pub(crate) fn encode_base64(bytes: &[u8]) -> String {
     let mut output = String::with_capacity(((bytes.len() + 2) / 3) * 4);
@@ -51,5 +65,21 @@ mod tests {
     #[test]
     fn preserves_non_utf8_bytes() {
         assert_eq!(encode_base64(&[0xff, 0xfe, 0x00, 0x61]), "//4AYQ==");
+    }
+
+    #[test]
+    fn accepts_truthy_feature_flag_values() {
+        assert!(super::is_truthy_flag("1"));
+        assert!(super::is_truthy_flag("true"));
+        assert!(super::is_truthy_flag("YES"));
+        assert!(super::is_truthy_flag("on"));
+    }
+
+    #[test]
+    fn rejects_non_truthy_feature_flag_values() {
+        assert!(!super::is_truthy_flag(""));
+        assert!(!super::is_truthy_flag("0"));
+        assert!(!super::is_truthy_flag("false"));
+        assert!(!super::is_truthy_flag("disabled"));
     }
 }

--- a/crates/backend/src/terminal/bytes.rs
+++ b/crates/backend/src/terminal/bytes.rs
@@ -1,0 +1,55 @@
+const BASE64_TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+pub(crate) fn encode_base64(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(((bytes.len() + 2) / 3) * 4);
+
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = chunk.get(1).copied().unwrap_or(0);
+        let b2 = chunk.get(2).copied().unwrap_or(0);
+
+        output.push(BASE64_TABLE[(b0 >> 2) as usize] as char);
+        output.push(BASE64_TABLE[(((b0 & 0b0000_0011) << 4) | (b1 >> 4)) as usize] as char);
+
+        if chunk.len() > 1 {
+            output.push(BASE64_TABLE[(((b1 & 0b0000_1111) << 2) | (b2 >> 6)) as usize] as char);
+        } else {
+            output.push('=');
+        }
+
+        if chunk.len() > 2 {
+            output.push(BASE64_TABLE[(b2 & 0b0011_1111) as usize] as char);
+        } else {
+            output.push('=');
+        }
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::encode_base64;
+
+    #[test]
+    fn encodes_empty_input() {
+        assert_eq!(encode_base64(b""), "");
+    }
+
+    #[test]
+    fn encodes_padded_inputs() {
+        assert_eq!(encode_base64(b"f"), "Zg==");
+        assert_eq!(encode_base64(b"fo"), "Zm8=");
+    }
+
+    #[test]
+    fn encodes_unpadded_inputs() {
+        assert_eq!(encode_base64(b"foo"), "Zm9v");
+        assert_eq!(encode_base64(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn preserves_non_utf8_bytes() {
+        assert_eq!(encode_base64(&[0xff, 0xfe, 0x00, 0x61]), "//4AYQ==");
+    }
+}

--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex};
 use crate::debug::debug_log;
 use crate::runtime::EventSink;
 
+use super::bytes::encode_base64;
 use super::events::{emit_pty_data, emit_pty_error, emit_pty_exit};
 use super::state::{ManagedSession, PtyState, RingBuffer};
 use super::types::*;
@@ -1175,6 +1176,7 @@ async fn read_pty_output(
                     &PtyDataEvent {
                         session_id: session_id.clone(),
                         data,
+                        bytes_base64: Some(encode_base64(&buf[..n])),
                         offset_start: chunk_start,
                         // Raw byte count — the unit the producer's offset
                         // arithmetic (RingBuffer::append) used. Subscribers

--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use crate::debug::debug_log;
 use crate::runtime::EventSink;
 
-use super::bytes::encode_base64;
+use super::bytes::{encode_base64, should_emit_bytes_base64};
 use super::events::{emit_pty_data, emit_pty_error, emit_pty_exit};
 use super::state::{ManagedSession, PtyState, RingBuffer};
 use super::types::*;
@@ -1116,6 +1116,7 @@ async fn read_pty_output(
     // This prevents race conditions where concurrent writes/resizes would fail
     // with "session not found" if we removed the session temporarily
     let mut reader = state.clone_reader(&session_id)?;
+    let emit_bytes_base64 = should_emit_bytes_base64();
 
     // Read loop
     let mut buf = [0u8; 8192];
@@ -1176,7 +1177,7 @@ async fn read_pty_output(
                     &PtyDataEvent {
                         session_id: session_id.clone(),
                         data,
-                        bytes_base64: Some(encode_base64(&buf[..n])),
+                        bytes_base64: emit_bytes_base64.then(|| encode_base64(&buf[..n])),
                         offset_start: chunk_start,
                         // Raw byte count — the unit the producer's offset
                         // arithmetic (RingBuffer::append) used. Subscribers

--- a/crates/backend/src/terminal/mod.rs
+++ b/crates/backend/src/terminal/mod.rs
@@ -4,6 +4,7 @@
 //! and IPC communication with the frontend.
 
 pub mod bridge;
+pub(crate) mod bytes;
 pub mod cache;
 pub mod commands;
 pub(crate) mod events;

--- a/crates/backend/src/terminal/types.rs
+++ b/crates/backend/src/terminal/types.rs
@@ -93,6 +93,11 @@ pub struct PtyDataEvent {
     pub session_id: SessionId,
     /// Output data from PTY stdout (lossy UTF-8 — invalid bytes become U+FFFD)
     pub data: String,
+    /// Raw PTY stdout bytes encoded as base64 for byte-preserving renderer
+    /// adapters. Existing xterm-compatible renderers continue to use `data`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(test, ts(optional))]
+    pub bytes_base64: Option<String>,
     /// Starting byte offset of this chunk in the session's lifetime stream
     pub offset_start: u64,
     /// Raw byte count of this chunk from the PTY read (matches the producer's
@@ -314,4 +319,37 @@ pub struct WorkspaceSessionSnapshot {
 #[serde(rename_all = "camelCase")]
 pub struct SetWorkspaceSessionsRequest {
     pub sessions: Vec<WorkspaceSessionSnapshot>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PtyDataEvent;
+
+    #[test]
+    fn pty_data_event_serializes_bytes_base64_when_present() {
+        let value = serde_json::to_value(PtyDataEvent {
+            session_id: "session-1".to_string(),
+            data: "��".to_string(),
+            bytes_base64: Some("//4=".to_string()),
+            offset_start: 0,
+            byte_len: 2,
+        })
+        .expect("serialize event");
+
+        assert_eq!(value["bytesBase64"], "//4=");
+    }
+
+    #[test]
+    fn pty_data_event_omits_bytes_base64_when_absent() {
+        let value = serde_json::to_value(PtyDataEvent {
+            session_id: "session-1".to_string(),
+            data: "hello".to_string(),
+            bytes_base64: None,
+            offset_start: 0,
+            byte_len: 5,
+        })
+        .expect("serialize event");
+
+        assert!(value.get("bytesBase64").is_none());
+    }
 }

--- a/src/features/sessions/hooks/useSessionRestore.ts
+++ b/src/features/sessions/hooks/useSessionRestore.ts
@@ -343,8 +343,14 @@ export const useSessionRestore = ({
     void (async (): Promise<void> => {
       try {
         stopBuffering = await service.onData(
-          (sessionId, data, offsetStart, byteLen) => {
-            bufferRef.current.bufferEvent(sessionId, data, offsetStart, byteLen)
+          (sessionId, data, offsetStart, byteLen, bytesBase64) => {
+            bufferRef.current.bufferEvent(
+              sessionId,
+              data,
+              offsetStart,
+              byteLen,
+              bytesBase64
+            )
           }
         )
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/src/features/terminal/hooks/useTerminal.test.ts
+++ b/src/features/terminal/hooks/useTerminal.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore QlVGRkVSRUQ
 import { renderHook, waitFor } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useTerminal } from './useTerminal'
@@ -159,6 +160,37 @@ describe('useTerminal', () => {
       phase: 'live',
     })
     expect(mockTerminal.write).toHaveBeenCalledWith('Hello from PTY\r\n')
+  })
+
+  test('writes PTY raw bytes payload to terminal output chunks', async () => {
+    const { result } = renderHook(() =>
+      useTerminal({
+        terminal: mockTerminal,
+        output: mockOutput,
+        service: mockService,
+        cwd: '/home/user',
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('running')
+    })
+
+    mockService.emit('data', {
+      sessionId: result.current.session!.id,
+      data: '��',
+      offsetStart: 0,
+      byteLen: 2,
+      bytesBase64: '//4=',
+    })
+
+    expect(mockOutput.writeOutput).toHaveBeenCalledWith({
+      text: '��',
+      bytesBase64: '//4=',
+      offsetStart: 0,
+      byteLen: 2,
+      phase: 'live',
+    })
   })
 
   test('reports accepted PTY output chunks', async () => {
@@ -705,7 +737,14 @@ describe('useTerminal', () => {
             pid: 1234,
             replayData: 'REPLAY',
             replayEndOffset: 50,
-            bufferedEvents: [{ data: 'BUFFERED', offsetStart: 50, byteLen: 8 }],
+            bufferedEvents: [
+              {
+                data: 'BUFFERED',
+                offsetStart: 50,
+                byteLen: 8,
+                bytesBase64: 'QlVGRkVSRUQ=',
+              },
+            ],
           },
           onOutput,
           onRestoreOutput,
@@ -720,6 +759,17 @@ describe('useTerminal', () => {
       expect(writes[0]).toBe('REPLAY')
       // Then buffered events
       expect(writes[1]).toBe('BUFFERED')
+      expect(mockOutput.writeOutput).toHaveBeenNthCalledWith(
+        2,
+        {
+          text: 'BUFFERED',
+          bytesBase64: 'QlVGRkVSRUQ=',
+          offsetStart: 50,
+          byteLen: 8,
+          phase: 'restore',
+        },
+        expect.any(Function)
+      )
       expect(onOutput).not.toHaveBeenCalled()
 
       expect(onRestoreOutput).not.toHaveBeenCalled()

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -22,7 +22,12 @@ export interface RestoreData {
   pid: number
   replayData: string
   replayEndOffset: number
-  bufferedEvents: { data: string; offsetStart: number; byteLen: number }[]
+  bufferedEvents: {
+    data: string
+    offsetStart: number
+    byteLen: number
+    bytesBase64?: string
+  }[]
 }
 
 /**
@@ -34,7 +39,12 @@ export interface RestoreData {
  */
 export type NotifyPaneReady = (
   ptyId: string,
-  handler: (data: string, offsetStart: number, byteLen: number) => void
+  handler: (
+    data: string,
+    offsetStart: number,
+    byteLen: number,
+    bytesBase64?: string
+  ) => void
 ) => () => void
 
 /**
@@ -369,6 +379,9 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
             .map(
               (event): TerminalOutputChunk => ({
                 text: event.data,
+                ...(event.bytesBase64 === undefined
+                  ? {}
+                  : { bytesBase64: event.bytesBase64 }),
                 offsetStart: event.offsetStart,
                 byteLen: event.byteLen,
                 phase: 'restore',
@@ -528,7 +541,8 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
       eventSessionId: string,
       data: string,
       offsetStart: number,
-      byteLen: number
+      byteLen: number,
+      bytesBase64?: string
     ): void => {
       if (eventSessionId === session.id && isMountedRef.current) {
         // Cursor dedupe: drop events whose offset predates what we've
@@ -536,6 +550,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
         if (offsetStart >= cursorRef.current) {
           writeLiveTerminalOutput(output, {
             text: data,
+            ...(bytesBase64 === undefined ? {} : { bytesBase64 }),
             offsetStart,
             byteLen,
             phase: 'live',
@@ -559,9 +574,10 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     const handleDataForDrain = (
       data: string,
       offsetStart: number,
-      byteLen: number
+      byteLen: number,
+      bytesBase64?: string
     ): void => {
-      handleData(session.id, data, offsetStart, byteLen)
+      handleData(session.id, data, offsetStart, byteLen, bytesBase64)
     }
 
     const handleExit = (eventSessionId: string, code: number | null): void => {

--- a/src/features/terminal/orchestration/usePtyBufferDrain.test.ts
+++ b/src/features/terminal/orchestration/usePtyBufferDrain.test.ts
@@ -42,6 +42,22 @@ describe('usePtyBufferDrain', () => {
     expect(handler).toHaveBeenNthCalledWith(2, 'second', 5, 6)
   })
 
+  test('preserves raw bytes payload while buffering and draining events', () => {
+    const { result } = renderHook(() => usePtyBufferDrain())
+    const handler = vi.fn()
+
+    result.current.registerPending('pty-1')
+    result.current.bufferEvent('pty-1', '��', 0, 2, '//4=')
+
+    expect(result.current.getBufferedSnapshot('pty-1')).toEqual([
+      { data: '��', offsetStart: 0, byteLen: 2, bytesBase64: '//4=' },
+    ])
+
+    result.current.notifyPaneReady('pty-1', handler)
+
+    expect(handler).toHaveBeenCalledWith('��', 0, 2, '//4=')
+  })
+
   test('notifyPaneReady cleanup re-arms pending state on remount', () => {
     const { result } = renderHook(() => usePtyBufferDrain())
     const handler = vi.fn()

--- a/src/features/terminal/orchestration/usePtyBufferDrain.ts
+++ b/src/features/terminal/orchestration/usePtyBufferDrain.ts
@@ -5,6 +5,7 @@ interface BufferedEvent {
   data: string
   offsetStart: number
   byteLen: number
+  bytesBase64?: string
 }
 
 export interface PtyBufferDrain {
@@ -12,7 +13,8 @@ export interface PtyBufferDrain {
     ptyId: string,
     data: string,
     offsetStart: number,
-    byteLen: number
+    byteLen: number,
+    bytesBase64?: string
   ) => void
   notifyPaneReady: (
     ptyId: string,
@@ -39,7 +41,7 @@ export const usePtyBufferDrain = (): PtyBufferDrain => {
   const tombstonedPanesRef = useRef(new Set<string>())
 
   const bufferEvent = useCallback<PtyBufferDrain['bufferEvent']>(
-    (ptyId, data, offsetStart, byteLen) => {
+    (ptyId, data, offsetStart, byteLen, bytesBase64) => {
       if (
         tombstonedPanesRef.current.has(ptyId) ||
         readyPanesRef.current.has(ptyId)
@@ -52,7 +54,12 @@ export const usePtyBufferDrain = (): PtyBufferDrain => {
         queue = []
         bufferedRef.current.set(ptyId, queue)
       }
-      queue.push({ data, offsetStart, byteLen })
+      queue.push({
+        data,
+        offsetStart,
+        byteLen,
+        ...(bytesBase64 === undefined ? {} : { bytesBase64 }),
+      })
     },
     []
   )
@@ -72,7 +79,18 @@ export const usePtyBufferDrain = (): PtyBufferDrain => {
       const events = bufferedRef.current.get(ptyId)
       if (events && events.length > 0) {
         for (const event of events) {
-          handler(event.data, event.offsetStart, event.byteLen)
+          if (event.bytesBase64 === undefined) {
+            handler(event.data, event.offsetStart, event.byteLen)
+
+            continue
+          }
+
+          handler(
+            event.data,
+            event.offsetStart,
+            event.byteLen,
+            event.bytesBase64
+          )
         }
         bufferedRef.current.delete(ptyId)
       }

--- a/src/features/terminal/services/desktopTerminalService.test.ts
+++ b/src/features/terminal/services/desktopTerminalService.test.ts
@@ -215,6 +215,22 @@ describe('DesktopTerminalService', () => {
       expect(callback).toHaveBeenCalledWith('sess-1', 'hello world', 0, 11)
     })
 
+    test('onData forwards optional raw bytes payload', async () => {
+      const callback = vi.fn()
+      await service.onData(callback)
+      await mockSpawnAndInit(service)
+
+      emitDesktopEvent('pty-data', {
+        sessionId: 'sess-1',
+        data: '��',
+        bytesBase64: '//4=',
+        offsetStart: 0,
+        byteLen: 2,
+      })
+
+      expect(callback).toHaveBeenCalledWith('sess-1', '��', 0, 2, '//4=')
+    })
+
     test('onExit delivers pty-exit events to callback', async () => {
       const callback = vi.fn()
       await service.onExit(callback)

--- a/src/features/terminal/services/desktopTerminalService.ts
+++ b/src/features/terminal/services/desktopTerminalService.ts
@@ -33,7 +33,8 @@ export class DesktopTerminalService implements ITerminalService {
     sessionId: string,
     data: string,
     offsetStart: number,
-    byteLen: number
+    byteLen: number,
+    bytesBase64?: string
   ) => void)[] = []
   private exitCallbacks: ((sessionId: string, code: number | null) => void)[] =
     []
@@ -88,7 +89,8 @@ export class DesktopTerminalService implements ITerminalService {
         const unlistenData = await listen<PtyDataEvent>(
           'pty-data',
           (payload) => {
-            const { sessionId, data, offsetStart, byteLen } = payload
+            const { sessionId, data, offsetStart, byteLen, bytesBase64 } =
+              payload
 
             // PtyDataEvent.offset_start and .byte_len are u64 — bindings may emit
             // as bigint or number. Coerce to number; safe up to 2^53 = ~9 PB per
@@ -98,7 +100,15 @@ export class DesktopTerminalService implements ITerminalService {
                 ? Number(offsetStart)
                 : offsetStart
             const len = typeof byteLen === 'bigint' ? Number(byteLen) : byteLen
-            this.dataCallbacks.forEach((cb) => cb(sessionId, data, offset, len))
+            this.dataCallbacks.forEach((cb) => {
+              if (bytesBase64 === undefined) {
+                cb(sessionId, data, offset, len)
+
+                return
+              }
+
+              cb(sessionId, data, offset, len, bytesBase64)
+            })
           }
         )
         pendingUnlistenFns.push(unlistenData)

--- a/src/features/terminal/services/desktopTerminalService.ts
+++ b/src/features/terminal/services/desktopTerminalService.ts
@@ -248,7 +248,8 @@ export class DesktopTerminalService implements ITerminalService {
       sessionId: string,
       data: string,
       offsetStart: number,
-      byteLen: number
+      byteLen: number,
+      bytesBase64?: string
     ) => void
   ): Promise<() => void> {
     // Push the callback BEFORE awaiting so that any callbacks already queued

--- a/src/features/terminal/services/terminalService.ts
+++ b/src/features/terminal/services/terminalService.ts
@@ -47,6 +47,8 @@ export interface ITerminalService {
    * UTF-8 becomes U+FFFD (3 bytes when re-encoded), which would skew any
    * cursor derived from `data.length` away from the producer's offsets.
    * Subscribers MUST advance their cursor with `offsetStart + byteLen`.
+   * `bytesBase64`, when present, preserves the producer's raw bytes for
+   * renderer adapters that can parse bytes directly.
    *
    * Returns a Promise that resolves to the unsubscribe function once the
    * underlying transport listener is fully attached. Callers in the restore
@@ -59,7 +61,8 @@ export interface ITerminalService {
       sessionId: string,
       data: string,
       offsetStart: number,
-      byteLen: number
+      byteLen: number,
+      bytesBase64?: string
     ) => void
   ): Promise<() => void>
 
@@ -150,7 +153,8 @@ export class MockTerminalService implements ITerminalService {
     sessionId: string,
     data: string,
     offsetStart: number,
-    byteLen: number
+    byteLen: number,
+    bytesBase64?: string
   ) => void)[] = []
   private exitCallbacks: ((sessionId: string, code: number | null) => void)[] =
     []
@@ -358,16 +362,26 @@ export class MockTerminalService implements ITerminalService {
    * here (the real producer must emit the raw `buf[..n]` byte count, which
    * may differ from the re-encoded length). Tests can pass an explicit
    * `byteLen` to exercise the producer-vs-decoded mismatch case.
+   * `bytesBase64` can be supplied to test byte-preserving renderer paths.
    */
   emitData(
     sessionId: string,
     data: string,
     offsetStart?: number,
-    byteLen?: number
+    byteLen?: number,
+    bytesBase64?: string
   ): void {
     const offset = offsetStart ?? this.nextOffset.get(sessionId) ?? 0
     const len = byteLen ?? new TextEncoder().encode(data).length
-    this.dataCallbacks.forEach((cb) => cb(sessionId, data, offset, len))
+    this.dataCallbacks.forEach((cb) => {
+      if (bytesBase64 === undefined) {
+        cb(sessionId, data, offset, len)
+
+        return
+      }
+
+      cb(sessionId, data, offset, len, bytesBase64)
+    })
     // Always advance the per-session cursor past this chunk so future
     // auto-assigned offsets stay monotonic, even when the caller passed
     // an explicit offset.
@@ -394,6 +408,7 @@ export class MockTerminalService implements ITerminalService {
       data?: string
       offsetStart?: number
       byteLen?: number
+      bytesBase64?: string
       code?: number | null
       message?: string
     }
@@ -403,7 +418,8 @@ export class MockTerminalService implements ITerminalService {
         payload.sessionId,
         payload.data,
         payload.offsetStart,
-        payload.byteLen
+        payload.byteLen,
+        payload.bytesBase64
       )
     } else if (event === 'exit') {
       this.emitExit(payload.sessionId, payload.code ?? null)

--- a/src/features/terminal/types/index.test.ts
+++ b/src/features/terminal/types/index.test.ts
@@ -153,12 +153,14 @@ describe('Terminal Types', () => {
       const event: PTYDataEvent = {
         sessionId: 'session-1',
         data: 'hello world\n',
+        bytesBase64: 'aGVsbG8gd29ybGQK',
         offsetStart: 0n,
         byteLen: 12n,
       }
 
       expect(event.sessionId).toBe('session-1')
       expect(event.data).toBe('hello world\n')
+      expect(event.bytesBase64).toBe('aGVsbG8gd29ybGQK')
       expect(event.offsetStart).toBe(0n)
       expect(event.byteLen).toBe(12n)
     })

--- a/src/features/terminal/types/index.ts
+++ b/src/features/terminal/types/index.ts
@@ -191,14 +191,20 @@ export interface RestoreData {
   pid: number
   replayData: string
   replayEndOffset: number
-  bufferedEvents: { data: string; offsetStart: number; byteLen: number }[]
+  bufferedEvents: {
+    data: string
+    offsetStart: number
+    byteLen: number
+    bytesBase64?: string
+  }[]
 }
 
 /** Handler that receives a buffered PTY event during pane drain. */
 export type PaneEventHandler = (
   data: string,
   offsetStart: number,
-  byteLen: number
+  byteLen: number,
+  bytesBase64?: string
 ) => void
 
 /** Cleanup callback returned by `notifyPaneReady` — call on pane unmount. */


### PR DESCRIPTION
## Summary
- Add optional bytesBase64 to backend pty-data events using raw PTY read bytes
- Carry bytesBase64 through DesktopTerminalService, restore buffering, and TerminalOutputChunk
- Keep xterm/plain-text rendering on the existing text path while preserving raw bytes for future byte parser adapters

## Verification
- npm run generate:bindings
- npm --ignore-scripts run lint
- npm --ignore-scripts run format:check
- npx tsc -b --pretty false
- npx vitest run src/features/terminal/hooks/useTerminal.test.ts src/features/terminal/orchestration/usePtyBufferDrain.test.ts src/features/terminal/services/desktopTerminalService.test.ts src/features/terminal/services/terminalService.test.ts src/features/terminal/types/index.test.ts
- cargo test --manifest-path crates/backend/Cargo.toml terminal::bytes
- cargo test --manifest-path crates/backend/Cargo.toml terminal::types::tests
- cargo test --manifest-path crates/backend/Cargo.toml export_bindings_ptydataevent
- git diff --check