### PR TITLE
feat(terminal): add Ghostty byte adapter spike

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -1,0 +1,170 @@
+// cspell:ignore ghostty
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+  GHOSTTY_TERMINAL_RENDERER_ID,
+  createGhosttyTerminal,
+  ghosttyTerminalRenderer,
+} from './ghosttyInstance'
+
+const encodeBase64 = (bytes: Uint8Array): string => {
+  let binary = ''
+
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+
+  return globalThis.btoa(binary)
+}
+
+const encodeText = (text: string): string =>
+  encodeBase64(new TextEncoder().encode(text))
+
+const createdTerminals = new Set<ReturnType<typeof createGhosttyTerminal>>()
+
+const createTrackedGhosttyTerminal = (): ReturnType<
+  typeof createGhosttyTerminal
+> => {
+  const created = createGhosttyTerminal()
+  createdTerminals.add(created)
+
+  return created
+}
+
+afterEach(() => {
+  createdTerminals.forEach((created) => {
+    created.terminal.dispose()
+  })
+  createdTerminals.clear()
+  document.body.innerHTML = ''
+  vi.clearAllMocks()
+})
+
+describe('ghosttyInstance', () => {
+  test('exposes the opt-in ghostty renderer adapter', () => {
+    expect(ghosttyTerminalRenderer.id).toBe(GHOSTTY_TERMINAL_RENDERER_ID)
+    expect(ghosttyTerminalRenderer.createInstance).toBe(createGhosttyTerminal)
+  })
+
+  test('prefers byte payloads over lossy text fallback', () => {
+    const created = createTrackedGhosttyTerminal()
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText('bytes win'),
+      offsetStart: 0,
+      byteLen: 9,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe('bytes win')
+  })
+
+  test('falls back to text when byte payloads are unavailable', () => {
+    const created = createTrackedGhosttyTerminal()
+
+    created.output.writeOutput({
+      text: 'text fallback',
+      offsetStart: 0,
+      byteLen: 13,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe('text fallback')
+  })
+
+  test('streams split UTF-8 byte payloads before rendering text', () => {
+    const created = createTrackedGhosttyTerminal()
+    const character = String.fromCodePoint(0x4f60)
+    const bytes = new TextEncoder().encode(character)
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeBase64(bytes.slice(0, 2)),
+      offsetStart: 0,
+      byteLen: 2,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe('')
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeBase64(bytes.slice(2)),
+      offsetStart: 2,
+      byteLen: 1,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe(character)
+  })
+
+  test('emits OSC 7 cwd events parsed from byte payloads', () => {
+    const created = createTrackedGhosttyTerminal()
+    const handler = vi.fn()
+
+    created.parser.onEvent(handler)
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(
+        'before \x1b]7;file://localhost/tmp/ghostty-project\x07 after'
+      ),
+      offsetStart: 40,
+      byteLen: 58,
+      phase: 'live',
+    })
+
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/ghostty-project',
+      output: {
+        offsetStart: 40,
+        byteLen: 58,
+        phase: 'live',
+      },
+    })
+    expect(created.viewportReader.readVisibleText()).toBe('before  after')
+  })
+
+  test('reassembles split OSC 7 byte payloads with completion context', () => {
+    const created = createTrackedGhosttyTerminal()
+    const handler = vi.fn()
+
+    created.parser.onEvent(handler)
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText('before \x1b]7;file://local'),
+      offsetStart: 0,
+      byteLen: 24,
+      phase: 'restore',
+    })
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText('host/tmp/ghostty\x07 after'),
+      offsetStart: 24,
+      byteLen: 23,
+      phase: 'restore',
+    })
+
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/ghostty',
+      output: {
+        offsetStart: 24,
+        byteLen: 23,
+        phase: 'restore',
+      },
+    })
+    expect(created.viewportReader.readVisibleText()).toBe('before  after')
+  })
+
+  test('marks the composed terminal surface as the ghostty spike renderer', () => {
+    const created = createTrackedGhosttyTerminal()
+
+    expect(created.terminal.element?.dataset.terminalRenderer).toBe(
+      GHOSTTY_TERMINAL_RENDERER_ID
+    )
+  })
+})

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -1,0 +1,66 @@
+// cspell:ignore ghostty
+import type {
+  TerminalInstance,
+  TerminalOutputChunk,
+  TerminalParserOutputContext,
+  TerminalRendererAdapter,
+  TerminalRendererHandle,
+  TerminalOutputWriter,
+} from '../../types'
+import { createPlainTextTerminal } from './plainTextInstance'
+import { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
+import { TerminalControlSequenceParser } from './terminalControlParser'
+import { TerminalOutputPayloadDecoder } from './terminalOutputPayload'
+
+export { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
+
+const outputContextFromChunk = (
+  chunk: TerminalOutputChunk
+): TerminalParserOutputContext => ({
+  offsetStart: chunk.offsetStart,
+  byteLen: chunk.byteLen,
+  phase: chunk.phase,
+})
+
+class GhosttyTerminalModel {
+  private readonly base = createPlainTextTerminal()
+  private readonly parser = new TerminalControlSequenceParser()
+  private readonly decoder = new TerminalOutputPayloadDecoder()
+
+  readonly output: TerminalOutputWriter = {
+    writeOutput: (chunk, callback): void => {
+      const text = this.decoder.decode(chunk)
+
+      const visibleText = this.parser.transformOutput(
+        text,
+        outputContextFromChunk(chunk)
+      )
+
+      this.base.terminal.write(visibleText, callback)
+    },
+  }
+
+  createInstance(): TerminalInstance {
+    if (this.base.terminal.element) {
+      this.base.terminal.element.dataset.terminalRenderer =
+        GHOSTTY_TERMINAL_RENDERER_ID
+    }
+
+    return {
+      terminal: this.base.terminal,
+      output: this.output,
+      parser: this.parser,
+      viewportReader: this.base.viewportReader,
+      fitController: this.base.fitController,
+      attachRenderer: (): TerminalRendererHandle => this.base.attachRenderer(),
+    }
+  }
+}
+
+export const createGhosttyTerminal = (): TerminalInstance =>
+  new GhosttyTerminalModel().createInstance()
+
+export const ghosttyTerminalRenderer: TerminalRendererAdapter = {
+  id: GHOSTTY_TERMINAL_RENDERER_ID,
+  createInstance: createGhosttyTerminal,
+}

--- a/src/features/terminal/components/TerminalPane/ghosttyRendererMetadata.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyRendererMetadata.ts
@@ -1,0 +1,2 @@
+// cspell:ignore GHOSTTY ghostty
+export const GHOSTTY_TERMINAL_RENDERER_ID = 'ghostty'

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, vi } from 'vitest'
+import { TerminalControlSequenceParser } from './terminalControlParser'
+
+describe('TerminalControlSequenceParser', () => {
+  test('emits OSC 7 cwd events and strips them from visible output', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+    const output = { offsetStart: 12, byteLen: 48, phase: 'live' as const }
+
+    parser.onEvent(handler)
+
+    const visible = parser.transformOutput(
+      'before \x1b]7;file://localhost/tmp/project\x07 after',
+      output
+    )
+
+    expect(visible).toBe('before  after')
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/project',
+      output,
+    })
+  })
+
+  test('reassembles OSC 7 sequences split across output chunks', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+    const firstOutput = { offsetStart: 0, byteLen: 24, phase: 'live' as const }
+
+    const secondOutput = {
+      offsetStart: 24,
+      byteLen: 20,
+      phase: 'live' as const,
+    }
+
+    parser.onEvent(handler)
+
+    expect(
+      parser.transformOutput('before \x1b]7;file://local', firstOutput)
+    ).toBe('before ')
+
+    expect(
+      parser.transformOutput('host/tmp/project\x07 after', secondOutput)
+    ).toBe(' after')
+
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/project',
+      output: secondOutput,
+    })
+  })
+
+  test('passes through non-cwd OSC sequences', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    const visible = parser.transformOutput('a\x1b]0;title\x07b', null)
+
+    expect(visible).toBe('a\x1b]0;title\x07b')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('passes through control sequences when there are no subscribers', () => {
+    const parser = new TerminalControlSequenceParser()
+
+    const visible = parser.transformOutput(
+      '\x1b]7;file://localhost/tmp/project\x07',
+      null
+    )
+
+    expect(visible).toBe('\x1b]7;file://localhost/tmp/project\x07')
+  })
+})

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -1,0 +1,169 @@
+import type {
+  TerminalDisposable,
+  TerminalParser,
+  TerminalParserEvent,
+  TerminalParserEventHandler,
+  TerminalParserOutputContext,
+} from '../../types'
+
+const BEL = '\x07'
+const ESC = '\x1b'
+const OSC_PREFIX = `${ESC}]`
+const STRING_TERMINATOR = `${ESC}\\`
+const MAX_PENDING_CONTROL_SEQUENCE_LENGTH = 16_384
+
+interface SequenceTerminator {
+  readonly index: number
+  readonly length: number
+}
+
+const createDisposable = (dispose: () => void): TerminalDisposable => ({
+  dispose,
+})
+
+const findSequenceTerminator = (
+  data: string,
+  startIndex: number
+): SequenceTerminator | null => {
+  const belIndex = data.indexOf(BEL, startIndex)
+  const stringTerminatorIndex = data.indexOf(STRING_TERMINATOR, startIndex)
+
+  if (belIndex === -1 && stringTerminatorIndex === -1) {
+    return null
+  }
+
+  if (
+    belIndex !== -1 &&
+    (stringTerminatorIndex === -1 || belIndex < stringTerminatorIndex)
+  ) {
+    return { index: belIndex, length: BEL.length }
+  }
+
+  return {
+    index: stringTerminatorIndex,
+    length: STRING_TERMINATOR.length,
+  }
+}
+
+const parseOscIdentifier = (content: string): string | null => {
+  const separatorIndex = content.indexOf(';')
+
+  if (separatorIndex <= 0) {
+    return null
+  }
+
+  return content.slice(0, separatorIndex)
+}
+
+const parseOscPayload = (content: string): string | null => {
+  const separatorIndex = content.indexOf(';')
+
+  if (separatorIndex <= 0) {
+    return null
+  }
+
+  return content.slice(separatorIndex + 1)
+}
+
+export class TerminalControlSequenceParser implements TerminalParser {
+  private readonly handlers = new Set<TerminalParserEventHandler>()
+  private pendingControlSequence = ''
+
+  onEvent(handler: TerminalParserEventHandler): TerminalDisposable {
+    this.handlers.add(handler)
+
+    return createDisposable((): void => {
+      this.handlers.delete(handler)
+    })
+  }
+
+  transformOutput(
+    data: string,
+    output: TerminalParserOutputContext | null
+  ): string {
+    if (this.handlers.size === 0) {
+      const visible = `${this.pendingControlSequence}${data}`
+      this.pendingControlSequence = ''
+
+      return visible
+    }
+
+    const source = `${this.pendingControlSequence}${data}`
+    this.pendingControlSequence = ''
+
+    return this.consumeControlSequences(source, output)
+  }
+
+  private consumeControlSequences(
+    data: string,
+    output: TerminalParserOutputContext | null
+  ): string {
+    let visible = ''
+    let cursor = 0
+
+    while (cursor < data.length) {
+      const sequenceStart = data.indexOf(OSC_PREFIX, cursor)
+
+      if (sequenceStart === -1) {
+        visible += data.slice(cursor)
+        break
+      }
+
+      visible += data.slice(cursor, sequenceStart)
+
+      const contentStart = sequenceStart + OSC_PREFIX.length
+      const terminator = findSequenceTerminator(data, contentStart)
+
+      if (!terminator) {
+        this.pendingControlSequence = data.slice(sequenceStart)
+        break
+      }
+
+      const sequenceEnd = terminator.index + terminator.length
+      const content = data.slice(contentStart, terminator.index)
+      const sequence = data.slice(sequenceStart, sequenceEnd)
+
+      if (!this.consumeOsc(content, output)) {
+        visible += sequence
+      }
+
+      cursor = sequenceEnd
+    }
+
+    if (
+      this.pendingControlSequence.length > MAX_PENDING_CONTROL_SEQUENCE_LENGTH
+    ) {
+      visible += this.pendingControlSequence
+      this.pendingControlSequence = ''
+    }
+
+    return visible
+  }
+
+  private consumeOsc(
+    content: string,
+    output: TerminalParserOutputContext | null
+  ): boolean {
+    const identifier = parseOscIdentifier(content)
+    const payload = parseOscPayload(content)
+
+    if (identifier === null || payload === null || Number(identifier) !== 7) {
+      return false
+    }
+
+    this.emit({
+      type: 'cwd',
+      source: 'osc7',
+      uri: payload,
+      output,
+    })
+
+    return true
+  }
+
+  private emit(event: TerminalParserEvent): void {
+    this.handlers.forEach((handler) => {
+      handler(event)
+    })
+  }
+}

--- a/src/features/terminal/components/TerminalPane/terminalOutputPayload.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalOutputPayload.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+import type { TerminalOutputChunk } from '../../types'
+import {
+  TerminalOutputPayloadDecoder,
+  decodeBase64ToBytes,
+  readTerminalOutputBytes,
+} from './terminalOutputPayload'
+
+const encodeBase64 = (bytes: Uint8Array): string => {
+  let binary = ''
+
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+
+  return globalThis.btoa(binary)
+}
+
+const outputChunk = (
+  text: string,
+  bytesBase64?: string
+): TerminalOutputChunk => ({
+  text,
+  ...(bytesBase64 === undefined ? {} : { bytesBase64 }),
+  offsetStart: 0,
+  byteLen: bytesBase64?.length ?? text.length,
+  phase: 'live',
+})
+
+describe('terminalOutputPayload', () => {
+  test('decodes base64 payloads to raw bytes', () => {
+    expect(decodeBase64ToBytes('//4=')).toEqual(new Uint8Array([255, 254]))
+  })
+
+  test('returns null for invalid base64 payloads', () => {
+    expect(decodeBase64ToBytes('not base64?')).toBeNull()
+  })
+
+  test('reads optional bytes from terminal output chunks', () => {
+    const chunk = outputChunk('fallback', 'aGk=')
+
+    expect(readTerminalOutputBytes(chunk)).toEqual(new Uint8Array([104, 105]))
+    expect(readTerminalOutputBytes(outputChunk('fallback'))).toBeNull()
+  })
+
+  test('prefers streaming byte payloads over fallback text', () => {
+    const decoder = new TerminalOutputPayloadDecoder()
+    const character = String.fromCodePoint(0x4f60)
+    const bytes = new TextEncoder().encode(character)
+    const first = outputChunk('wrong', encodeBase64(bytes.slice(0, 2)))
+    const second = outputChunk('wrong', encodeBase64(bytes.slice(2)))
+
+    expect(decoder.decode(first)).toBe('')
+    expect(decoder.decode(second)).toBe(character)
+  })
+
+  test('falls back to text when bytes are unavailable or invalid', () => {
+    const decoder = new TerminalOutputPayloadDecoder()
+
+    expect(decoder.decode(outputChunk('fallback'))).toBe('fallback')
+    expect(decoder.decode(outputChunk('fallback', 'not base64?'))).toBe(
+      'fallback'
+    )
+  })
+
+  test('resets streaming bytes before falling back to text', () => {
+    const decoder = new TerminalOutputPayloadDecoder()
+    const character = String.fromCodePoint(0x4f60)
+    const bytes = new TextEncoder().encode(character)
+    const partial = outputChunk('wrong', encodeBase64(bytes.slice(0, 2)))
+    const complete = outputChunk('wrong', encodeBase64(bytes))
+
+    expect(decoder.decode(partial)).toBe('')
+    expect(decoder.decode(outputChunk('fallback'))).toBe('fallback')
+    expect(decoder.decode(complete)).toBe(character)
+  })
+})

--- a/src/features/terminal/components/TerminalPane/terminalOutputPayload.ts
+++ b/src/features/terminal/components/TerminalPane/terminalOutputPayload.ts
@@ -1,0 +1,43 @@
+import type { TerminalOutputChunk } from '../../types'
+
+export const decodeBase64ToBytes = (value: string): Uint8Array | null => {
+  try {
+    const binary = globalThis.atob(value)
+    const bytes = new Uint8Array(binary.length)
+
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index)
+    }
+
+    return bytes
+  } catch {
+    return null
+  }
+}
+
+export const readTerminalOutputBytes = (
+  chunk: TerminalOutputChunk
+): Uint8Array | null =>
+  chunk.bytesBase64 === undefined
+    ? null
+    : decodeBase64ToBytes(chunk.bytesBase64)
+
+export class TerminalOutputPayloadDecoder {
+  private readonly streamingDecoder = new TextDecoder()
+
+  decode(chunk: TerminalOutputChunk): string {
+    const bytes = readTerminalOutputBytes(chunk)
+
+    if (!bytes) {
+      this.reset()
+
+      return chunk.text
+    }
+
+    return this.streamingDecoder.decode(bytes, { stream: true })
+  }
+
+  private reset(): void {
+    this.streamingDecoder.decode()
+  }
+}

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore ghostty
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { TerminalInstance, TerminalRendererAdapter } from '../../types'
 
@@ -13,6 +14,11 @@ const plainTextRendererMocks = vi.hoisted(() => ({
   moduleLoaded: vi.fn(),
 }))
 
+const ghosttyRendererMocks = vi.hoisted(() => ({
+  createInstance: vi.fn(),
+  moduleLoaded: vi.fn(),
+}))
+
 vi.mock('./plainTextInstance', () => {
   plainTextRendererMocks.moduleLoaded()
 
@@ -20,6 +26,17 @@ vi.mock('./plainTextInstance', () => {
     plainTextTerminalRenderer: {
       id: 'plain-text',
       createInstance: plainTextRendererMocks.createInstance,
+    },
+  }
+})
+
+vi.mock('./ghosttyInstance', () => {
+  ghosttyRendererMocks.moduleLoaded()
+
+  return {
+    ghosttyTerminalRenderer: {
+      id: 'ghostty',
+      createInstance: ghosttyRendererMocks.createInstance,
     },
   }
 })
@@ -159,6 +176,24 @@ describe('terminalRendererRegistry', () => {
     expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
   })
 
+  test('loads the bundled ghostty renderer only when selected by environment', async () => {
+    const instance = createTerminalInstance()
+
+    ghosttyRendererMocks.createInstance.mockReturnValue(instance)
+    vi.stubEnv('VITE_TERMINAL_RENDERER', 'ghostty')
+
+    const registry = await importTerminalRendererRegistry()
+
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'ghostty' })
+    )
+    expect(await registry.createConfiguredTerminalInstance()).toBe(instance)
+    expect(ghosttyRendererMocks.moduleLoaded).toHaveBeenCalledOnce()
+    expect(ghosttyRendererMocks.createInstance).toHaveBeenCalledOnce()
+    expect(plainTextRendererMocks.moduleLoaded).not.toHaveBeenCalled()
+    expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
+  })
+
   test('keeps xterm as the default when environment selection is blank', async () => {
     vi.stubEnv('VITE_TERMINAL_RENDERER', ' ')
 
@@ -265,6 +300,20 @@ describe('terminalRendererRegistry', () => {
 
     expect(await registry.getTerminalRendererAdapter()).toEqual(
       expect.objectContaining({ id: 'plain-text' })
+    )
+  })
+
+  test('retains the environment-loaded ghostty adapter after reset', async () => {
+    vi.stubEnv('VITE_TERMINAL_RENDERER', 'ghostty')
+
+    const registry = await importTerminalRendererRegistry()
+
+    await registry.configureTerminalRendererFromEnvironment()
+    registry._resetTerminalRendererRegistryForTest()
+    registry.setTerminalRendererAdapter('ghostty')
+
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'ghostty' })
     )
   })
 })

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
@@ -1,4 +1,6 @@
+// cspell:ignore ghostty
 import type { TerminalInstance, TerminalRendererAdapter } from '../../types'
+import { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
 import { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
 import { xtermTerminalRenderer } from './xtermInstance'
 
@@ -9,12 +11,17 @@ const terminalRendererAdapters = new Map<string, TerminalRendererAdapter>([
 let activeTerminalRendererId = xtermTerminalRenderer.id
 let hasConfiguredTerminalRendererFromEnvironment = false
 let bundledPlainTextRenderer: TerminalRendererAdapter | null = null
+let bundledGhosttyRenderer: TerminalRendererAdapter | null = null
 let configureTerminalRendererPromise: Promise<void> | null = null
 const initialEnvironmentRendererId = import.meta.env.VITE_TERMINAL_RENDERER
 
 const shouldRegisterBundledPlainTextRenderer =
   typeof initialEnvironmentRendererId === 'string' &&
   initialEnvironmentRendererId.trim() === PLAIN_TEXT_TERMINAL_RENDERER_ID
+
+const shouldRegisterBundledGhosttyRenderer =
+  typeof initialEnvironmentRendererId === 'string' &&
+  initialEnvironmentRendererId.trim() === GHOSTTY_TERMINAL_RENDERER_ID
 
 const readEnvironmentRendererId = (): string | null => {
   const rendererId = import.meta.env.VITE_TERMINAL_RENDERER
@@ -45,16 +52,24 @@ export const registerTerminalRendererAdapter = (
 
 const registerBundledEnvironmentRenderer = async (): Promise<void> => {
   if (
-    !shouldRegisterBundledPlainTextRenderer ||
-    terminalRendererAdapters.has(PLAIN_TEXT_TERMINAL_RENDERER_ID)
+    shouldRegisterBundledPlainTextRenderer &&
+    !terminalRendererAdapters.has(PLAIN_TEXT_TERMINAL_RENDERER_ID)
   ) {
-    return
+    const { plainTextTerminalRenderer } = await import('./plainTextInstance')
+
+    bundledPlainTextRenderer = plainTextTerminalRenderer
+    registerTerminalRendererAdapter(plainTextTerminalRenderer)
   }
 
-  const { plainTextTerminalRenderer } = await import('./plainTextInstance')
+  if (
+    shouldRegisterBundledGhosttyRenderer &&
+    !terminalRendererAdapters.has(GHOSTTY_TERMINAL_RENDERER_ID)
+  ) {
+    const { ghosttyTerminalRenderer } = await import('./ghosttyInstance')
 
-  bundledPlainTextRenderer = plainTextTerminalRenderer
-  registerTerminalRendererAdapter(plainTextTerminalRenderer)
+    bundledGhosttyRenderer = ghosttyTerminalRenderer
+    registerTerminalRendererAdapter(ghosttyTerminalRenderer)
+  }
 }
 
 export const setTerminalRendererAdapter = (rendererId: string): void => {
@@ -127,6 +142,13 @@ export const _resetTerminalRendererRegistryForTest = (): void => {
     terminalRendererAdapters.set(
       bundledPlainTextRenderer.id,
       bundledPlainTextRenderer
+    )
+  }
+
+  if (bundledGhosttyRenderer) {
+    terminalRendererAdapters.set(
+      bundledGhosttyRenderer.id,
+      bundledGhosttyRenderer
     )
   }
 


### PR DESCRIPTION
## Summary
- Add an opt-in `ghostty` terminal renderer adapter selected by `VITE_TERMINAL_RENDERER=ghostty`.
- Add shared terminal output byte decoding and OSC control-sequence parsing helpers.
- Have the Ghostty spike prefer `bytesBase64`, stream UTF-8 across split byte chunks, emit generic OSC 7 cwd events, and keep a viewport reader through the composed plain-text surface.

## Verification
- `npx vitest run src/features/terminal/components/TerminalPane/terminalControlParser.test.ts src/features/terminal/components/TerminalPane/terminalOutputPayload.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts`
- `npx vitest run src/features/terminal/components/TerminalPane`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`
- `git diff --check`