### PR TITLE
refactor(terminal): share plain text control parser

### DIFF
--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -155,6 +155,38 @@ describe('plainTextInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('before after')
   })
 
+  test('reassembles split OSC sequences before emitting parser events', () => {
+    const created = createTrackedPlainTextTerminal()
+    const parserEventHandler = vi.fn()
+
+    created.parser.onEvent(parserEventHandler)
+    created.output.writeOutput({
+      text: 'before \x1b]7;file://local',
+      offsetStart: 0,
+      byteLen: 24,
+      phase: 'restore',
+    })
+
+    created.output.writeOutput({
+      text: 'host/tmp/plain-text\x07 after',
+      offsetStart: 24,
+      byteLen: 27,
+      phase: 'restore',
+    })
+
+    expect(parserEventHandler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/plain-text',
+      output: {
+        offsetStart: 24,
+        byteLen: 27,
+        phase: 'restore',
+      },
+    })
+    expect(created.viewportReader.readVisibleText()).toBe('before  after')
+  })
+
   test('notifies parser event subscribers in registration order', () => {
     const created = createTrackedPlainTextTerminal()
     const firstHandler = vi.fn()

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -6,8 +6,6 @@ import type {
   TerminalKeyEventHandler,
   TerminalOutputChunk,
   TerminalOutputWriter,
-  TerminalParserEvent,
-  TerminalParserEventHandler,
   TerminalParserOutputContext,
   TerminalParser,
   TerminalRendererAdapter,
@@ -18,6 +16,7 @@ import type {
   TerminalViewportReader,
 } from '../../types'
 import { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
+import { TerminalControlSequenceParser } from './terminalControlParser'
 import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
 
 export { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
@@ -437,21 +436,13 @@ class PlainTextTerminalSurface implements TerminalSurface {
 }
 
 class PlainTextTerminalModel {
-  private readonly parserEventHandlers = new Set<TerminalParserEventHandler>()
+  private readonly controlParser = new TerminalControlSequenceParser()
   private currentOutputContext: TerminalParserOutputContext | null = null
   readonly terminal = new PlainTextTerminalSurface((data) =>
-    this.consumeControlSequences(data)
+    this.controlParser.transformOutput(data, this.currentOutputContext)
   )
 
-  readonly parser: TerminalParser = {
-    onEvent: (handler): TerminalDisposable => {
-      this.parserEventHandlers.add(handler)
-
-      return createDisposable((): void => {
-        this.parserEventHandlers.delete(handler)
-      })
-    },
-  }
+  readonly parser: TerminalParser = this.controlParser
 
   readonly output: TerminalOutputWriter = {
     writeOutput: (chunk, callback): void => {
@@ -477,36 +468,6 @@ class PlainTextTerminalModel {
 
   readonly rendererHandle: TerminalRendererHandle = {
     dispose: (): void => undefined,
-  }
-
-  private consumeControlSequences(data: string): string {
-    const oscSequencePattern = /\x1b\](\d+);([^\x07\x1b]*)(?:\x07|\x1b\\)/g
-
-    return data.replace(
-      oscSequencePattern,
-      (sequence, identifier: string, payload: string): string => {
-        const numericIdentifier = Number(identifier)
-
-        if (numericIdentifier !== 7 || this.parserEventHandlers.size === 0) {
-          return sequence
-        }
-
-        this.emitParserEvent({
-          type: 'cwd',
-          source: 'osc7',
-          uri: payload,
-          output: this.currentOutputContext,
-        })
-
-        return ''
-      }
-    )
-  }
-
-  private emitParserEvent(event: TerminalParserEvent): void {
-    this.parserEventHandlers.forEach((handler) => {
-      handler(event)
-    })
   }
 }
 


### PR DESCRIPTION
## Summary
- Route the plain-text terminal adapter through the shared `TerminalControlSequenceParser`.
- Remove the adapter-local OSC 7 regex/event-set implementation.
- Add plain-text coverage for split OSC 7 reassembly with restore-phase output context.

## Verification
- `npx vitest run src/features/terminal/components/TerminalPane/plainTextInstance.test.ts src/features/terminal/components/TerminalPane/terminalControlParser.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts`
- `npx vitest run src/features/terminal/components/TerminalPane`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`
- `git diff --check`