### PR TITLE
test(terminal): lock OSC7 cwd URI contract

### DIFF
--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -2128,6 +2128,36 @@ describe('Body', () => {
       expect(mockService.updateSessionCwd).not.toHaveBeenCalled()
     })
 
+    test('ignores non-file OSC 7 URI payloads', async () => {
+      const onCwdChange = vi.fn()
+
+      render(
+        <Body
+          sessionId="test-session"
+          cwd="/home/user"
+          service={defaultMockService}
+          onCwdChange={onCwdChange}
+        />
+      )
+
+      await waitFor(() => {
+        expect(mockParser.onEvent).toHaveBeenCalledWith(expect.any(Function))
+      })
+
+      const parserEventHandler = vi.mocked(mockParser.onEvent).mock
+        .calls[0]?.[0] as ((event: TerminalParserEvent) => void) | undefined
+
+      parserEventHandler?.({
+        type: 'cwd',
+        source: 'osc7',
+        uri: 'javascript:alert(1)',
+        output: { offsetStart: 0, byteLen: 19, phase: 'live' },
+      })
+
+      expect(onCwdChange).not.toHaveBeenCalled()
+      expect(defaultMockService.updateSessionCwd).not.toHaveBeenCalled()
+    })
+
     test('forwards plain absolute path to onCwdChange', async () => {
       const mockService = {
         spawn: vi.fn().mockResolvedValue({ sessionId: 'pty-1', pid: 123 }),

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -59,6 +59,20 @@ describe('ghosttyInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('bytes win')
   })
 
+  test('renders invalid byte payloads through the byte path', () => {
+    const created = createTrackedGhosttyTerminal()
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: '//4=',
+      offsetStart: 0,
+      byteLen: 2,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe('\uFFFD\uFFFD')
+  })
+
   test('falls back to text when byte payloads are unavailable', () => {
     const created = createTrackedGhosttyTerminal()
 

--- a/src/features/terminal/components/TerminalPane/osc7.test.ts
+++ b/src/features/terminal/components/TerminalPane/osc7.test.ts
@@ -73,4 +73,14 @@ describe('parseOsc7Cwd', () => {
     expect(parseOsc7Cwd('https://example.com/home/user')).toBeNull()
     expect(parseOsc7Cwd('relative/path')).toBeNull()
   })
+
+  test.each([
+    'https://example.com/home/user',
+    'javascript:alert(1)',
+    'mailto:user@example.com',
+    'ssh://server/home/user',
+    'vscode://file/home/user/project',
+  ])('rejects non-file URL scheme %s', (value) => {
+    expect(parseOsc7Cwd(value)).toBeNull()
+  })
 })

--- a/src/features/terminal/types/index.ts
+++ b/src/features/terminal/types/index.ts
@@ -289,7 +289,14 @@ export interface TerminalRendererHandle {
 export interface TerminalCwdParserEvent {
   readonly type: 'cwd'
   readonly source: 'osc7'
-  /** Raw OSC 7 URI/path payload. Consumers own context-sensitive path normalization. */
+  /**
+   * Raw OSC 7 URI/path payload from the terminal stream.
+   *
+   * This is untrusted terminal output, not a normalized filesystem path.
+   * Consumers that need a cwd must validate and normalize it with
+   * `parseOsc7Cwd` or an equivalent filesystem-only parser before storing it
+   * or passing it to any shell/open-external path.
+   */
   readonly uri: string
   readonly output: TerminalParserOutputContext | null
 }


### PR DESCRIPTION
## Summary
- Document `TerminalCwdParserEvent.uri` as untrusted raw terminal output that consumers must validate before storing or using externally.
- Add `parseOsc7Cwd` fixtures rejecting non-file URL schemes.
- Add Body coverage proving non-file OSC 7 payloads do not update pane cwd.
- Add Ghostty spike coverage for invalid byte payloads taking the byte path.

## Verification
- `npx vitest run src/features/terminal/components/TerminalPane/osc7.test.ts src/features/terminal/components/TerminalPane/Body.test.tsx src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts`
- `npx vitest run src/features/terminal/components/TerminalPane`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `npx tsc -b --pretty false`
- `git diff --check`