### PR TITLE
refactor(terminal): add Ghostty parser engine seam

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -1,9 +1,16 @@
 // cspell:ignore ghostty
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import type {
+  TerminalDisposable,
+  TerminalOutputChunk,
+  TerminalParser,
+} from '../../types'
+import type { TerminalParserEngineOutput } from './terminalParserEngine'
 import {
   GHOSTTY_TERMINAL_RENDERER_ID,
   createGhosttyTerminal,
   ghosttyTerminalRenderer,
+  type GhosttyTerminalOptions,
 } from './ghosttyInstance'
 
 const encodeBase64 = (bytes: Uint8Array): string => {
@@ -21,10 +28,10 @@ const encodeText = (text: string): string =>
 
 const createdTerminals = new Set<ReturnType<typeof createGhosttyTerminal>>()
 
-const createTrackedGhosttyTerminal = (): ReturnType<
-  typeof createGhosttyTerminal
-> => {
-  const created = createGhosttyTerminal()
+const createTrackedGhosttyTerminal = (
+  options: GhosttyTerminalOptions = {}
+): ReturnType<typeof createGhosttyTerminal> => {
+  const created = createGhosttyTerminal(options)
   createdTerminals.add(created)
 
   return created
@@ -43,6 +50,42 @@ describe('ghosttyInstance', () => {
   test('exposes the opt-in ghostty renderer adapter', () => {
     expect(ghosttyTerminalRenderer.id).toBe(GHOSTTY_TERMINAL_RENDERER_ID)
     expect(ghosttyTerminalRenderer.createInstance).toBe(createGhosttyTerminal)
+  })
+
+  test('delegates output parsing through an injected parser engine', () => {
+    const parser: TerminalParser = {
+      onEvent: (handler): TerminalDisposable => {
+        void handler
+
+        return { dispose: vi.fn() }
+      },
+    }
+
+    const parseOutput = vi.fn(
+      (chunk: TerminalOutputChunk): TerminalParserEngineOutput => ({
+        visibleText: `parsed:${chunk.text}`,
+      })
+    )
+
+    const created = createTrackedGhosttyTerminal({
+      createParserEngine: () => ({
+        parser,
+        parseOutput,
+      }),
+    })
+
+    const chunk = {
+      text: 'from-engine',
+      offsetStart: 3,
+      byteLen: 11,
+      phase: 'live' as const,
+    }
+
+    created.output.writeOutput(chunk)
+
+    expect(created.parser).toBe(parser)
+    expect(parseOutput).toHaveBeenCalledWith(chunk)
+    expect(created.viewportReader.readVisibleText()).toBe('parsed:from-engine')
   })
 
   test('prefers byte payloads over lossy text fallback', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -1,40 +1,36 @@
 // cspell:ignore ghostty
 import type {
   TerminalInstance,
-  TerminalOutputChunk,
-  TerminalParserOutputContext,
   TerminalRendererAdapter,
   TerminalRendererHandle,
   TerminalOutputWriter,
 } from '../../types'
 import { createPlainTextTerminal } from './plainTextInstance'
 import { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
-import { TerminalControlSequenceParser } from './terminalControlParser'
-import { TerminalOutputPayloadDecoder } from './terminalOutputPayload'
+import {
+  createControlSequenceTerminalParserEngine,
+  type TerminalParserEngine,
+} from './terminalParserEngine'
 
 export { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
 
-const outputContextFromChunk = (
-  chunk: TerminalOutputChunk
-): TerminalParserOutputContext => ({
-  offsetStart: chunk.offsetStart,
-  byteLen: chunk.byteLen,
-  phase: chunk.phase,
-})
+export interface GhosttyTerminalOptions {
+  readonly createParserEngine?: () => TerminalParserEngine
+}
 
 class GhosttyTerminalModel {
   private readonly base = createPlainTextTerminal()
-  private readonly parser = new TerminalControlSequenceParser()
-  private readonly decoder = new TerminalOutputPayloadDecoder()
+  private readonly parserEngine: TerminalParserEngine
+
+  constructor(options: GhosttyTerminalOptions = {}) {
+    this.parserEngine =
+      options.createParserEngine?.() ??
+      createControlSequenceTerminalParserEngine()
+  }
 
   readonly output: TerminalOutputWriter = {
     writeOutput: (chunk, callback): void => {
-      const text = this.decoder.decode(chunk)
-
-      const visibleText = this.parser.transformOutput(
-        text,
-        outputContextFromChunk(chunk)
-      )
+      const { visibleText } = this.parserEngine.parseOutput(chunk)
 
       this.base.terminal.write(visibleText, callback)
     },
@@ -49,7 +45,7 @@ class GhosttyTerminalModel {
     return {
       terminal: this.base.terminal,
       output: this.output,
-      parser: this.parser,
+      parser: this.parserEngine.parser,
       viewportReader: this.base.viewportReader,
       fitController: this.base.fitController,
       attachRenderer: (): TerminalRendererHandle => this.base.attachRenderer(),
@@ -57,8 +53,9 @@ class GhosttyTerminalModel {
   }
 }
 
-export const createGhosttyTerminal = (): TerminalInstance =>
-  new GhosttyTerminalModel().createInstance()
+export const createGhosttyTerminal = (
+  options: GhosttyTerminalOptions = {}
+): TerminalInstance => new GhosttyTerminalModel(options).createInstance()
 
 export const ghosttyTerminalRenderer: TerminalRendererAdapter = {
   id: GHOSTTY_TERMINAL_RENDERER_ID,

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts
@@ -1,0 +1,139 @@
+// cspell:ignore ghostty
+import { describe, expect, test, vi } from 'vitest'
+import type { TerminalOutputChunk, TerminalOutputPhase } from '../../types'
+import { createControlSequenceTerminalParserEngine } from './terminalParserEngine'
+
+const encodeBase64 = (bytes: Uint8Array): string => {
+  let binary = ''
+
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+
+  return globalThis.btoa(binary)
+}
+
+const createByteChunk = (
+  text: string,
+  offsetStart: number,
+  phase: TerminalOutputPhase
+): TerminalOutputChunk => {
+  const bytes = new TextEncoder().encode(text)
+
+  return {
+    text: 'fallback',
+    bytesBase64: encodeBase64(bytes),
+    offsetStart,
+    byteLen: bytes.length,
+    phase,
+  }
+}
+
+describe('createControlSequenceTerminalParserEngine', () => {
+  test('emits OSC 7 cwd events from byte payloads', () => {
+    const engine = createControlSequenceTerminalParserEngine()
+    const handler = vi.fn()
+
+    const chunk = createByteChunk(
+      'before \x1b]7;file://localhost/tmp/ghostty-project\x07 after',
+      40,
+      'live'
+    )
+
+    engine.parser.onEvent(handler)
+
+    expect(engine.parseOutput(chunk)).toEqual({ visibleText: 'before  after' })
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/ghostty-project',
+      output: {
+        offsetStart: chunk.offsetStart,
+        byteLen: chunk.byteLen,
+        phase: chunk.phase,
+      },
+    })
+  })
+
+  test('reassembles split OSC 7 byte payloads with completion context', () => {
+    const engine = createControlSequenceTerminalParserEngine()
+    const handler = vi.fn()
+
+    const firstChunk = createByteChunk(
+      'before \x1b]7;file://local',
+      0,
+      'restore'
+    )
+
+    const secondChunk = createByteChunk(
+      'host/tmp/ghostty\x07 after',
+      firstChunk.byteLen ?? 0,
+      'restore'
+    )
+
+    engine.parser.onEvent(handler)
+
+    expect(engine.parseOutput(firstChunk)).toEqual({ visibleText: 'before ' })
+    expect(engine.parseOutput(secondChunk)).toEqual({ visibleText: ' after' })
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/ghostty',
+      output: {
+        offsetStart: secondChunk.offsetStart,
+        byteLen: secondChunk.byteLen,
+        phase: secondChunk.phase,
+      },
+    })
+  })
+
+  test('supports OSC 7 sequences terminated with string terminator', () => {
+    const engine = createControlSequenceTerminalParserEngine()
+    const handler = vi.fn()
+
+    const chunk = createByteChunk(
+      'before \x1b]7;file://localhost/tmp/st\x1b\\ after',
+      8,
+      'live'
+    )
+
+    engine.parser.onEvent(handler)
+
+    expect(engine.parseOutput(chunk)).toEqual({ visibleText: 'before  after' })
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/st',
+      output: {
+        offsetStart: chunk.offsetStart,
+        byteLen: chunk.byteLen,
+        phase: chunk.phase,
+      },
+    })
+  })
+
+  test('preserves raw non-file OSC 7 payloads for consumer validation', () => {
+    const engine = createControlSequenceTerminalParserEngine()
+    const handler = vi.fn()
+
+    const chunk = createByteChunk(
+      'before \x1b]7;javascript:alert(1)\x07 after',
+      4,
+      'live'
+    )
+
+    engine.parser.onEvent(handler)
+
+    expect(engine.parseOutput(chunk)).toEqual({ visibleText: 'before  after' })
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'javascript:alert(1)',
+      output: {
+        offsetStart: chunk.offsetStart,
+        byteLen: chunk.byteLen,
+        phase: chunk.phase,
+      },
+    })
+  })
+})

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -1,0 +1,44 @@
+import type {
+  TerminalOutputChunk,
+  TerminalParser,
+  TerminalParserOutputContext,
+} from '../../types'
+import { TerminalControlSequenceParser } from './terminalControlParser'
+import { TerminalOutputPayloadDecoder } from './terminalOutputPayload'
+
+export interface TerminalParserEngineOutput {
+  readonly visibleText: string
+}
+
+export interface TerminalParserEngine {
+  readonly parser: TerminalParser
+  parseOutput: (chunk: TerminalOutputChunk) => TerminalParserEngineOutput
+}
+
+const outputContextFromChunk = (
+  chunk: TerminalOutputChunk
+): TerminalParserOutputContext => ({
+  offsetStart: chunk.offsetStart,
+  byteLen: chunk.byteLen,
+  phase: chunk.phase,
+})
+
+export const createControlSequenceTerminalParserEngine =
+  (): TerminalParserEngine => {
+    const parser = new TerminalControlSequenceParser()
+    const decoder = new TerminalOutputPayloadDecoder()
+
+    return {
+      parser,
+      parseOutput: (chunk): TerminalParserEngineOutput => {
+        const text = decoder.decode(chunk)
+
+        return {
+          visibleText: parser.transformOutput(
+            text,
+            outputContextFromChunk(chunk)
+          ),
+        }
+      },
+    }
+  }


### PR DESCRIPTION
## Summary
- Introduce a generic terminal parser engine contract for renderer-owned parsing.
- Route the Ghostty spike adapter through the default control-sequence parser engine, with an injection seam for a future byte-native Ghostty parser.
- Add OSC7 byte-path tests for live chunks, restore split chunks, ST termination, and raw non-file payload emission.

## Validation
- npx vitest run src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts src/features/terminal/components/TerminalPane/terminalControlParser.test.ts src/features/terminal/components/TerminalPane/osc7.test.ts src/features/terminal/components/TerminalPane/Body.test.tsx
- npx vitest run src/features/terminal/components/TerminalPane
- npm --ignore-scripts run lint
- npm --ignore-scripts run format:check
- npx tsc -b --pretty false
- git diff --check
