### PR TITLE
feat(settings): keymap row rebinding controls (VIM-136 SP2)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 71       | 31   | 2026-06-16   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 26   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 67       | 23   | 2026-06-15   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 68       | 23   | 2026-06-17   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 22   | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,8 +2,8 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-15
-ref_count: 23
+last_updated: 2026-06-17
+ref_count: 25
 ---
 
 # Accessibility
@@ -620,4 +620,22 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/agent-status/hooks/useReservoirFlow.ts`
 - **Finding:** `onLeave` called `ensureLoop()` unconditionally, so it scheduled a rAF frame even when `prefers-reduced-motion: reduce` was active, the water refs were null, or the loop was already at rest. Under reduced motion this could re-apply a cached `translate(...)` transform after `onMqlChange` had explicitly cleared it.
 - **Fix:** Mirrored the `onEnter` guard (`mql.matches || refsRef.current === null`) and added an at-rest guard (`rafId === null && intensity < REST_EPSILON`) before calling `ensureLoop()`.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 56. Keymap capture cancellation dropped focus to document.body
+
+- **Source:** github-claude | PR #507 round 1 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/panes/KeymapPane.tsx`
+- **Finding:** When the user cancelled keymap recording via Escape or the Cancel (X) button, the capture UI was removed from the DOM but focus was not restored. Keyboard-only users landed on `document.body` and had to re-tab through the entire settings dialog to return to their place in the keymap list.
+- **Fix:** Added `pendingCancelFocusRef` to remember the command id being edited, then used `useLayoutEffect` to focus the row's edit button synchronously after `editingId` becomes `null` and the capture UI unmounts. Added tests asserting the edit button regains focus after Escape and Cancel.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 57. Settings dialog Tab trap intercepted Tab while leaving keymap capture
+
+- **Source:** github-codex-connector | PR #507 round 1 | 2026-06-17
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/components/panes/KeymapPane.tsx`
+- **Finding:** Pressing Tab to cancel recording inside `SettingsDialog` was intercepted by the dialog's document-level Tab focus trap, which called `preventDefault`. Focus jumped back to the start of the dialog instead of moving to the next keymap control.
+- **Fix:** Added `event.stopPropagation()` in the capture button's `onKeyDown` Tab handler so the dialog trap never sees the event, and kept the deferred `pendingTabFocusRef` restoration via `useLayoutEffect` so focus moves to the next logical control after the capture UI unmounts.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -639,3 +639,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** Pressing Tab to cancel recording inside `SettingsDialog` was intercepted by the dialog's document-level Tab focus trap, which called `preventDefault`. Focus jumped back to the start of the dialog instead of moving to the next keymap control.
 - **Fix:** Added `event.stopPropagation()` in the capture button's `onKeyDown` Tab handler so the dialog trap never sees the event, and kept the deferred `pendingTabFocusRef` restoration via `useLayoutEffect` so focus moves to the next logical control after the capture UI unmounts.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 58. Save success drops keyboard focus after persisting a keymap binding
+
+- **Source:** github-claude | PR #507 round 2 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/panes/KeymapPane.tsx`
+- **Finding:** After a successful binding save, `saveDraft` called `stopEditing()` without setting a focus-restoration ref. The `useLayoutEffect` that returns focus to the row edit button only runs when `pendingCancelFocusRef` or `pendingTabFocusRef` is set, so keyboard and assistive-technology users who activate the Save button landed on `document.body`.
+- **Fix:** Set `pendingCancelFocusRef.current = id` in the `result.ok` branch before calling `stopEditing()`, reusing the same focus-restoration path as Escape and Cancel. Added a co-located test asserting the edit button regains focus after Save.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -2,8 +2,8 @@
 id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
-last_updated: 2026-06-15
-ref_count: 5
+last_updated: 2026-06-17
+ref_count: 11
 ---
 
 # Keyboard Shortcut Guards
@@ -37,6 +37,27 @@ against three classes of false-fire:
    that show shortcuts must render the modifier that matches the runtime
    platform (`⌘` on macOS, `Ctrl` on Linux/Windows). Hardcoding `⌘` in the UI
    misleads non-Mac users and drifts from the behavior-side modifier choice.
+7. **Capture-target guard in renderer shortcut hooks** — capture-phase document
+   listeners that fire global shortcuts must check whether the active element is
+   inside a keymap-recorder (or similar capture target) and return early. A
+   button-level `onKeyDown` runs after capture-phase listeners, so it cannot
+   outrace them; the guard must live in the same hook that claims the keystroke.
+8. **Main-process guard parity for capture state** — when a shortcut is consumed
+   in the Electron main process (`before-input-event`) and the renderer already
+   has a capture-active guard, the main-process matcher must receive the same
+   state. `event.preventDefault()` in the main process suppresses the renderer
+   `keydown`, so a renderer-only guard is bypassed in packaged builds; route
+   capture state through an explicit IPC channel and WeakMap per window.
+9. **Platform-specific modifier enforcement** — shortcuts that are tied to a
+   single platform modifier (e.g. `Cmd+,` on macOS, `Ctrl+,` elsewhere) must
+   reject the cross-platform modifier and any Alt/Shift variants, otherwise a
+   recorded user binding can collide with the built-in toggle and fire both
+   actions.
+10. **Reserve non-rebindable catalog entries for system chords** — chords that
+    must remain available to the browser or shell (settings toggle, browser
+    location focus, etc.) should be represented as non-rebindable catalog
+    entries so the keymap validator rejects attempts to bind them to other
+    commands.
 
 ## Findings
 
@@ -376,4 +397,58 @@ against three classes of false-fire:
 - **File:** `src/features/terminal/hooks/usePaneShortcuts.ts` L187-203
 - **Finding:** The `event.code === 'Backslash'` branch called `setSessionLayout` but did not `return`. The branch happened to be safe because `arrowDirection` was `null` for Backslash and the subsequent guard exited, but any future case inserted between the Backslash block and the arrow block would execute on every `⌘\` / `Ctrl+\` keypress.
 - **Fix:** Added an explicit `return` immediately after `setSessionLayout(activeSession.id, LAYOUT_CYCLE[nextIndex])` so the Backslash branch exclusively owns the keystroke.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 30. Keymap recorder lost chords to document-capture workspace shortcuts
+
+- **Source:** github-codex-connector | PR #507 round 1 | 2026-06-17
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/components/panes/KeymapPane.tsx`, `src/features/workspace/hooks/useSidebarTabShortcut.ts`, `src/features/workspace/hooks/useSidebarShortcut.ts`, `src/features/workspace/hooks/useSessionNavShortcut.ts`, `src/features/workspace/hooks/useNewSessionShortcut.ts`, `src/features/workspace/hooks/useDockShortcuts.ts`, `src/features/workspace/hooks/useBurnerToggleShortcut.ts`, `src/features/workspace/hooks/useDockToggleShortcut.ts`
+- **Finding:** The keymap capture UI only handled `onKeyDown` on the focused button. Because the app's workspace shortcuts register at the document capture phase, they consumed chords such as `Cmd/Ctrl+,`, `Cmd/Ctrl+Shift+S`, and layout-cycle chords before the recorder's button handler ever saw them. A button-level handler cannot outrace a capture-phase listener, so recording silently failed or triggered unrelated global actions.
+- **Fix:** Added `isKeymapCaptureTarget(event.target)` guard to every workspace document-capture shortcut hook and returned early when the event originated inside the keymap recorder. Added tests verifying the recorder can capture `Cmd/Ctrl+,` without opening Settings.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 31. Electron command-palette shortcut fired while keymap recorder was active
+
+- **Source:** github-codex-connector | PR #507 round 1 | 2026-06-17
+- **Severity:** P2 / MEDIUM
+- **File:** `electron/command-palette-shortcut.ts`, `electron/ipc-channels.ts`, `electron/preload.ts`, `electron/main.ts`, `src/lib/backend.ts`, `src/features/settings/components/panes/KeymapPane.tsx`
+- **Finding:** `Cmd/Ctrl+;` toggles the command palette via Electron's `before-input-event` in packaged builds. The renderer-side capture-target guard did not run because `event.preventDefault()` in the main process suppresses the renderer `keydown`. Recording `Cmd/Ctrl+;` inside the keymap pane therefore opened the palette instead of capturing the chord.
+- **Fix:** Added a new `KEYMAP_CAPTURE_ACTIVE` IPC channel and preload helper `setKeymapCaptureActive(active)`. `KeymapPane` calls this whenever `editingId !== null`. `command-palette-shortcut.ts` stores capture state in a per-window WeakMap and returns early from `isCommandPaletteShortcutInput` while capture is active, mirroring the renderer guard in the main process.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 32. Settings toggle shortcut accepted wrong modifiers and collided with recorded bindings
+
+- **Source:** github-codex-connector | PR #507 round 1 | 2026-06-17
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/hooks/useSettingsDialog.ts`, `src/features/keymap/catalog.ts`
+- **Finding:** `useSettingsDialog` toggled for `metaKey || ctrlKey` together with `event.key === ','`, without rejecting `altKey`/`shiftKey`. On macOS a user could record `Control+Comma` or `Command+Shift+Comma` for another command, and pressing it would both run the rebound command and open Settings.
+- **Fix:** Tightened the matcher to the exact platform super chord (`Cmd` on macOS, `Ctrl` elsewhere) and added explicit `!event.altKey && !event.shiftKey` checks. Added non-rebindable catalog entries (`settings`, `settings-control`) so the validator also blocks these chords at save time.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 33. Browser-location chord not reserved in the keymap catalog
+
+- **Source:** github-codex-connector | PR #507 round 1 | 2026-06-17
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/keymap/catalog.ts`, `src/features/keymap/hooks/useKeybindings.test.ts`
+- **Finding:** `setUserBinding` only validated against `CATALOG`, which did not include a reservation for the browser's `Mod+L` address-bar focus chord. A user could bind `Mod+L` to a workspace command such as dock-toggle, after which the browser still focused the address bar and the app also ran the bound command.
+- **Fix:** Added a `browser-location` catalog entry (`Mod+KeyL`, non-rebindable, `preserveStoredOverrides`) so the validator rejects `Mod+L` rebindings. Existing stored overrides are preserved to avoid breaking users who already remapped it.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 34. macOS Ctrl+Comma not reserved alongside Command+Comma for settings
+
+- **Source:** github-codex-connector | PR #507 round 1 | 2026-06-17
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/keymap/catalog.ts`, `src/features/keymap/hooks/useKeybindings.test.ts`
+- **Finding:** On macOS the keymap recorder stores a literal `Control+Comma` chord separately from `Mod+Comma`. The catalog only reserved `Mod+Comma` for settings, so `Control+Comma` could be saved as a user binding and collide with the settings toggle path.
+- **Fix:** Added a `settings-control` catalog entry (`Ctrl+Comma`, non-rebindable, `preserveStoredOverrides`) to reserve the literal Ctrl+Comma chord on macOS. `useSettingsDialog` now only toggles on the platform super chord, so Ctrl+Comma no longer opens Settings.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 35. Alt/Shift-modified comma chords could toggle Settings while bound elsewhere
+
+- **Source:** github-codex-connector | PR #507 round 1 | 2026-06-17
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/hooks/useSettingsDialog.ts`
+- **Finding:** The settings shortcut matcher ignored modifier state beyond `metaKey`/`ctrlKey`. A user could record `Ctrl+Alt+Comma` (Linux/Windows) or `Cmd+Shift+Comma` (macOS) for a rebindable command, and the settings toggle would still fire because it did not reject `altKey` or `shiftKey`.
+- **Fix:** Added `!event.altKey && !event.shiftKey` to the platform-super matcher so only the bare `Cmd/Ctrl+Comma` chord toggles Settings. Added tests for `Ctrl+Alt+Comma` and `Cmd+Shift+Comma` to confirm they pass through.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/electron/command-palette-shortcut.test.ts
+++ b/electron/command-palette-shortcut.test.ts
@@ -6,6 +6,7 @@ import {
   type CommandPaletteShortcutOverrideOptions,
   installCommandPaletteShortcutOverride,
   isCommandPaletteShortcutInput,
+  setKeymapCaptureActive,
 } from './command-palette-shortcut'
 
 vi.mock('electron', () => ({
@@ -476,5 +477,33 @@ describe('command palette shortcut override', () => {
     expect(registry.register).toHaveBeenCalledTimes(
       COMMAND_PALETTE_GLOBAL_ACCELERATORS.length
     )
+  })
+
+  test('suppresses toggle while keymap capture is active', () => {
+    const { beforeInputHandlers, send, win } = createFakeWindow()
+    const preventDefault = vi.fn()
+
+    installCommandPaletteShortcutOverride(win, { platform: 'linux' })
+    setKeymapCaptureActive(win, true)
+
+    const handler = beforeInputHandlers[0]
+
+    if (handler === undefined) {
+      throw new Error('before-input-event handler was not registered')
+    }
+
+    handler(
+      { preventDefault },
+      {
+        type: 'keyDown',
+        key: ';',
+        control: true,
+        meta: false,
+        alt: false,
+      }
+    )
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
   })
 })

--- a/electron/command-palette-shortcut.ts
+++ b/electron/command-palette-shortcut.ts
@@ -68,6 +68,14 @@ const sendCommandPaletteToggle = (win: BrowserWindow): void => {
 }
 
 const commandPaletteToggleDispatchers = new WeakMap<BrowserWindow, () => void>()
+const captureActiveByWindow = new WeakMap<BrowserWindow, boolean>()
+
+export const setKeymapCaptureActive = (
+  win: BrowserWindow,
+  active: boolean
+): void => {
+  captureActiveByWindow.set(win, active)
+}
 
 const createCommandPaletteToggleDispatcher = (
   win: BrowserWindow
@@ -136,6 +144,10 @@ export const installCommandPaletteShortcutOverride = (
 
   win.webContents.on('before-input-event', (event, input) => {
     if (!isCommandPaletteShortcutInput(input, shortcutConfig)) {
+      return
+    }
+
+    if (captureActiveByWindow.get(win)) {
       return
     }
 

--- a/electron/ipc-channels.ts
+++ b/electron/ipc-channels.ts
@@ -7,6 +7,8 @@ export const BACKEND_EVENT = 'backend:event'
 
 export const COMMAND_PALETTE_TOGGLE = 'command-palette:toggle'
 
+export const KEYMAP_CAPTURE_ACTIVE = 'keymap:capture-active'
+
 export const SETTINGS_OPEN_FILE = 'settings:open-file'
 
 export const SETTINGS_SYNC_SNAPSHOT = 'settings:sync-snapshot'

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,12 +17,16 @@ import {
   developmentContentSecurityPolicy,
   packagedContentSecurityPolicy,
 } from './csp'
-import { installCommandPaletteShortcutOverride } from './command-palette-shortcut'
+import {
+  installCommandPaletteShortcutOverride,
+  setKeymapCaptureActive,
+} from './command-palette-shortcut'
 import { installApplicationEditMenu } from './edit-menu'
 import { installNavigationGuard } from './navigation-guard'
 import {
   BACKEND_EVENT,
   BACKEND_INVOKE,
+  KEYMAP_CAPTURE_ACTIVE,
   SETTINGS_OPEN_FILE,
   SETTINGS_SYNC_SNAPSHOT,
 } from './ipc-channels'
@@ -462,6 +466,13 @@ const setupApp = async (): Promise<void> => {
       }
     }
   )
+
+  ipcMain.on(KEYMAP_CAPTURE_ACTIVE, (ipcEvent, active: unknown) => {
+    const win = BrowserWindow.fromWebContents(ipcEvent.sender)
+    if (win !== null) {
+      setKeymapCaptureActive(win, active === true)
+    }
+  })
 
   ipcMain.handle(SETTINGS_OPEN_FILE, async (): Promise<void> => {
     const settingsPath = path.join(app.getPath('userData'), 'settings.json')

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -3,6 +3,7 @@ import {
   BACKEND_EVENT,
   BACKEND_INVOKE,
   COMMAND_PALETTE_TOGGLE,
+  KEYMAP_CAPTURE_ACTIVE,
   SETTINGS_OPEN_FILE,
   SETTINGS_SYNC_SNAPSHOT,
 } from './ipc-channels'
@@ -101,10 +102,15 @@ const onCommandPaletteToggle = (callback: () => void): (() => void) => {
   }
 }
 
+const setKeymapCaptureActive = (active: boolean): void => {
+  ipcRenderer.send(KEYMAP_CAPTURE_ACTIVE, active)
+}
+
 contextBridge.exposeInMainWorld('vimeflow', {
   invoke,
   listen,
   onCommandPaletteToggle,
+  setKeymapCaptureActive,
   browserPane: {
     createPane: (request: unknown): Promise<unknown> =>
       ipcRenderer.invoke(BROWSER_PANE_CREATE, request),

--- a/src/features/command-palette/hooks/useCommandPalette.test.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.test.ts
@@ -7,6 +7,7 @@ import {
 import type { Command } from '../registry/types'
 import * as chordRegistry from '../chordRegistry'
 import type { BackendApi } from '../../../lib/backend'
+import { KEYMAP_CAPTURE_TARGET_ATTRIBUTE } from '../../keymap/capture'
 
 describe('useCommandPalette', () => {
   beforeEach(() => {
@@ -232,6 +233,7 @@ describe('useCommandPalette', () => {
         bubbles: true,
         cancelable: true,
       })
+
       const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
       const stopPropagationSpy = vi.spyOn(event, 'stopPropagation')
 
@@ -467,6 +469,40 @@ describe('useCommandPalette', () => {
       expect(stopImmediatePropagationSpy).toHaveBeenCalled()
     })
 
+    test('Ctrl+; from the keymap recorder is left for capture mode', () => {
+      const { result } = renderHook(() => useCommandPalette())
+      const recorder = document.createElement('button')
+      recorder.setAttribute(KEYMAP_CAPTURE_TARGET_ATTRIBUTE, 'true')
+      document.body.append(recorder)
+
+      try {
+        const event = new KeyboardEvent('keydown', {
+          key: ';',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true,
+        })
+        const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+        const stopPropagationSpy = vi.spyOn(event, 'stopPropagation')
+
+        const stopImmediatePropagationSpy = vi.spyOn(
+          event,
+          'stopImmediatePropagation'
+        )
+
+        act(() => {
+          recorder.dispatchEvent(event)
+        })
+
+        expect(result.current.state.isOpen).toBe(false)
+        expect(preventDefaultSpy).not.toHaveBeenCalled()
+        expect(stopPropagationSpy).not.toHaveBeenCalled()
+        expect(stopImmediatePropagationSpy).not.toHaveBeenCalled()
+      } finally {
+        recorder.remove()
+      }
+    })
+
     test('Ctrl+; trigger overrides later document-level global shortcuts', async () => {
       const { result } = renderHook(() => useCommandPalette())
       const globalShortcut = vi.fn()
@@ -533,6 +569,42 @@ describe('useCommandPalette', () => {
         unmount()
         expect(unlisten).toHaveBeenCalledOnce()
       } finally {
+        delete window.vimeflow
+      }
+    })
+
+    test('Electron shortcut toggle is left for focused keymap recorder', () => {
+      let toggleFromMain: (() => void) | null = null
+      const unlisten = vi.fn()
+
+      window.vimeflow = {
+        invoke: vi.fn(),
+        listen: vi.fn(),
+        onCommandPaletteToggle: (callback: () => void): (() => void) => {
+          toggleFromMain = callback
+
+          return unlisten
+        },
+      } as unknown as BackendApi
+
+      const recorder = document.createElement('button')
+      recorder.setAttribute(KEYMAP_CAPTURE_TARGET_ATTRIBUTE, 'true')
+      document.body.append(recorder)
+      recorder.focus()
+
+      const { result, unmount } = renderHook(() => useCommandPalette())
+
+      try {
+        act(() => {
+          toggleFromMain?.()
+        })
+
+        expect(result.current.state.isOpen).toBe(false)
+
+        unmount()
+        expect(unlisten).toHaveBeenCalledOnce()
+      } finally {
+        recorder.remove()
         delete window.vimeflow
       }
     })

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -22,6 +22,7 @@ import {
   COMMAND_PALETTE_SHORTCUT_KEYS,
   isCommandPaletteToggle,
 } from '../shortcutConfig'
+import { isKeymapCaptureTarget } from '../../keymap/capture'
 
 const LEADER_WINDOW_MS = 500
 
@@ -342,6 +343,10 @@ export const useCommandPalette = (
     // the follow-up chord key (NOT intercepted) still reaches handleKeyDown
     // below and routes through chordRegistry / usePaneRenameChord.
     const handlePaletteShortcut = (): void => {
+      if (isKeymapCaptureTarget(document.activeElement)) {
+        return
+      }
+
       if (!isEnabledRef.current) {
         handlersRef.current.close()
 
@@ -365,6 +370,10 @@ export const useCommandPalette = (
     }
 
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isKeymapCaptureTarget(event.target)) {
+        return
+      }
+
       if (isCommandPaletteToggle(event) && event.repeat) {
         fullyConsumeEvent(event)
 

--- a/src/features/keymap/acceptance.test.tsx
+++ b/src/features/keymap/acceptance.test.tsx
@@ -46,7 +46,7 @@ const sessions: Session[] = [
 // End-to-end: a persisted override flows settings → useKeybindings → the migrated
 // hook, so it dispatches on the new combo and not the old default. jsdom is
 // non-mac, so useKeybindings resolves `Mod` to `ctrl`.
-test('persisted override changes the live shortcut (focus-pane-2 → Mod+KeyL)', () => {
+test('persisted override changes the live shortcut (focus-pane-2 -> Mod+KeyL)', () => {
   const setSessionActivePane = vi.fn()
 
   const settings: AppSettings = {

--- a/src/features/keymap/capture.test.ts
+++ b/src/features/keymap/capture.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'vitest'
+import {
+  eventToChord,
+  isKeymapCaptureTarget,
+  KEYMAP_CAPTURE_TARGET_ATTRIBUTE,
+} from './capture'
+
+const keydown = (
+  code: string,
+  init: {
+    metaKey?: boolean
+    ctrlKey?: boolean
+    altKey?: boolean
+    shiftKey?: boolean
+  } = {}
+): KeyboardEvent => new KeyboardEvent('keydown', { code, ...init })
+
+describe('eventToChord', () => {
+  test('maps macOS Command to Mod and Control to literal Ctrl', () => {
+    expect(
+      eventToChord(keydown('KeyK', { metaKey: true, shiftKey: true }), true)
+    ).toEqual({
+      code: 'KeyK',
+      mods: new Set(['Mod', 'Shift']),
+    })
+
+    expect(eventToChord(keydown('KeyC', { ctrlKey: true }), true)).toEqual({
+      code: 'KeyC',
+      mods: new Set(['Ctrl']),
+    })
+  })
+
+  test('maps non-mac Control to Mod', () => {
+    expect(
+      eventToChord(keydown('KeyK', { ctrlKey: true, altKey: true }), false)
+    ).toEqual({
+      code: 'KeyK',
+      mods: new Set(['Mod', 'Alt']),
+    })
+  })
+
+  test('ignores non-mac meta because the runtime matcher uses Control for Mod', () => {
+    expect(eventToChord(keydown('KeyK', { metaKey: true }), false)).toEqual({
+      code: 'KeyK',
+      mods: new Set(),
+    })
+  })
+
+  test('returns null when the browser event does not expose a physical code', () => {
+    expect(eventToChord(keydown(''), false)).toBeNull()
+  })
+
+  test('ignores bare modifier and lock key codes', () => {
+    for (const code of [
+      'ShiftLeft',
+      'ShiftRight',
+      'ControlLeft',
+      'ControlRight',
+      'AltLeft',
+      'AltRight',
+      'MetaLeft',
+      'MetaRight',
+      'CapsLock',
+      'NumLock',
+      'ScrollLock',
+    ]) {
+      expect(eventToChord(keydown(code), false)).toBeNull()
+    }
+  })
+})
+
+describe('isKeymapCaptureTarget', () => {
+  test('detects the recorder element and its descendants', () => {
+    const recorder = document.createElement('button')
+    recorder.setAttribute(KEYMAP_CAPTURE_TARGET_ATTRIBUTE, 'true')
+    const child = document.createElement('span')
+    recorder.append(child)
+
+    expect(isKeymapCaptureTarget(recorder)).toBe(true)
+    expect(isKeymapCaptureTarget(child)).toBe(true)
+    expect(isKeymapCaptureTarget(document.createElement('button'))).toBe(false)
+    expect(isKeymapCaptureTarget(null)).toBe(false)
+  })
+})

--- a/src/features/keymap/capture.ts
+++ b/src/features/keymap/capture.ts
@@ -1,0 +1,53 @@
+import type { Chord, Mod } from './chord'
+
+export const KEYMAP_CAPTURE_TARGET_ATTRIBUTE = 'data-keymap-capture-target'
+
+const KEYMAP_CAPTURE_TARGET_SELECTOR = `[${KEYMAP_CAPTURE_TARGET_ATTRIBUTE}="true"]`
+
+const MODIFIER_CODES: ReadonlySet<string> = new Set([
+  'ShiftLeft',
+  'ShiftRight',
+  'ControlLeft',
+  'ControlRight',
+  'AltLeft',
+  'AltRight',
+  'MetaLeft',
+  'MetaRight',
+  'CapsLock',
+  'NumLock',
+  'ScrollLock',
+])
+
+export const isKeymapCaptureTarget = (target: EventTarget | null): boolean =>
+  target instanceof Element &&
+  target.closest(KEYMAP_CAPTURE_TARGET_SELECTOR) !== null
+
+export const eventToChord = (
+  event: KeyboardEvent,
+  isMac: boolean
+): Chord | null => {
+  if (event.code === '' || MODIFIER_CODES.has(event.code)) {
+    return null
+  }
+
+  const mods = new Set<Mod>()
+  if (isMac) {
+    if (event.metaKey) {
+      mods.add('Mod')
+    }
+    if (event.ctrlKey) {
+      mods.add('Ctrl')
+    }
+  } else if (event.ctrlKey) {
+    mods.add('Mod')
+  }
+
+  if (event.altKey) {
+    mods.add('Alt')
+  }
+  if (event.shiftKey) {
+    mods.add('Shift')
+  }
+
+  return { code: event.code, mods }
+}

--- a/src/features/keymap/catalog.ts
+++ b/src/features/keymap/catalog.ts
@@ -1,6 +1,12 @@
 import type { Chord } from './chord'
 
-export type BindingContext = 'global' | 'terminal' | 'editor' | 'diff' | 'dock'
+export type BindingContext =
+  | 'global'
+  | 'terminal'
+  | 'editor'
+  | 'diff'
+  | 'dock'
+  | 'browser'
 
 export interface CommandDescriptor {
   readonly id: string
@@ -10,6 +16,8 @@ export interface CommandDescriptor {
   readonly matchPolicy: 'exact' | 'tolerant'
   readonly defaultCombo: Chord | ((isMac: boolean) => Chord)
   readonly rebindable: boolean
+  readonly preserveStoredOverrides?: boolean
+  readonly intentionalShadow?: boolean
 }
 
 const c = (
@@ -125,6 +133,27 @@ export const CATALOG = [
     defaultCombo: c('Semicolon', 'Mod'),
   },
   {
+    id: 'settings',
+    label: 'Open settings',
+    group: 'Global',
+    context: 'global',
+    matchPolicy: 'exact',
+    rebindable: false,
+    preserveStoredOverrides: true,
+    defaultCombo: c('Comma', 'Mod'),
+  },
+  {
+    id: 'settings-control',
+    label: 'Open settings (Control)',
+    group: 'Reserved',
+    context: 'global',
+    matchPolicy: 'exact',
+    rebindable: false,
+    preserveStoredOverrides: true,
+    intentionalShadow: true,
+    defaultCombo: c('Comma', 'Ctrl'),
+  },
+  {
     id: 'new-session',
     label: 'New terminal session',
     group: 'Global',
@@ -238,6 +267,18 @@ export const CATALOG = [
     matchPolicy: 'exact',
     rebindable: false,
     defaultCombo: c('KeyC', 'Ctrl'),
+  },
+
+  // ── Browser (display-only; browser chrome owns address-bar focus) ──
+  {
+    id: 'browser-location',
+    label: 'Focus browser address bar',
+    group: 'Browser',
+    context: 'browser',
+    matchPolicy: 'exact',
+    rebindable: false,
+    preserveStoredOverrides: true,
+    defaultCombo: c('KeyL', 'Mod'),
   },
 ] as const satisfies readonly CommandDescriptor[]
 

--- a/src/features/keymap/conflicts.test.ts
+++ b/src/features/keymap/conflicts.test.ts
@@ -59,7 +59,9 @@ describe('chordsOverlap', () => {
 describe('contextsOverlap', () => {
   test('global overlaps everything; surfaces are mutually exclusive', () => {
     expect(contextsOverlap('global', 'terminal')).toBe(true)
+    expect(contextsOverlap('global', 'browser')).toBe(true)
     expect(contextsOverlap('terminal', 'dock')).toBe(false)
+    expect(contextsOverlap('browser', 'terminal')).toBe(false)
     expect(contextsOverlap('diff', 'diff')).toBe(true)
   })
 })
@@ -84,5 +86,25 @@ describe('detectConflicts', () => {
       ['focus-pane-2', c('Digit2', 'Mod')],
     ])
     expect(detectConflicts(resolved, 'meta')).toHaveLength(0)
+  })
+
+  test('does not report intentionally overlapping fixed reservations', () => {
+    const resolved = new Map<CommandId, Chord>([
+      ['settings', c('Comma', 'Mod')],
+      ['settings-control', c('Comma', 'Ctrl')],
+    ])
+
+    expect(detectConflicts(resolved, 'ctrl')).toHaveLength(0)
+  })
+
+  test('reports accidental fixed command overlaps outside reserved shadows', () => {
+    const resolved = new Map<CommandId, Chord>([
+      ['palette', c('KeyN', 'Mod')],
+      ['new-session', c('KeyN', 'Mod')],
+    ])
+    const conflicts = detectConflicts(resolved, 'meta')
+
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0].commandIds.sort()).toEqual(['new-session', 'palette'])
   })
 })

--- a/src/features/keymap/conflicts.ts
+++ b/src/features/keymap/conflicts.ts
@@ -78,6 +78,9 @@ export const overrideCollides = (
       continue
     }
     const other = getCommand(otherId)
+    if (other.preserveStoredOverrides) {
+      continue
+    }
     if (
       contextsOverlap(me.context, other.context) &&
       chordsOverlap(
@@ -107,6 +110,13 @@ export const detectConflicts = (
       const b = getCommand(ids[j])
       const ca = resolved.get(ids[i])!
       const cb = resolved.get(ids[j])!
+      if (
+        !a.rebindable &&
+        !b.rebindable &&
+        (a.intentionalShadow || b.intentionalShadow)
+      ) {
+        continue
+      }
       if (
         !contextsOverlap(a.context, b.context) ||
         !chordsOverlap(ca, a.matchPolicy, cb, b.matchPolicy, superKey)

--- a/src/features/keymap/index.ts
+++ b/src/features/keymap/index.ts
@@ -1,5 +1,7 @@
 export * from './catalog'
 
+export * from './capture'
+
 export * from './chord'
 
 export * from './conflicts'

--- a/src/features/keymap/resolve.test.ts
+++ b/src/features/keymap/resolve.test.ts
@@ -43,6 +43,12 @@ describe('resolveBindings', () => {
     )
   })
 
+  test('stored overrides are preserved when they hit new-binding-only reservations', () => {
+    expect(tokenOf({ 'focus-pane-2': 'Mod+KeyL' }, 'focus-pane-2')).toBe(
+      'Mod+KeyL'
+    )
+  })
+
   test('override on a rebindable:false command is ignored', () => {
     expect(tokenOf({ palette: 'Mod+KeyP' }, 'palette')).toBe('Mod+Semicolon')
   })

--- a/src/features/keymap/useKeybindings.test.tsx
+++ b/src/features/keymap/useKeybindings.test.tsx
@@ -57,6 +57,48 @@ describe('useKeybindings', () => {
     expect(update).not.toHaveBeenCalled()
   })
 
+  test("setUserBinding rejects shadowing the settings shortcut as 'reserved'", () => {
+    const { result, update } = renderKeybindings()
+    expect(
+      result.current.setUserBinding('dock-toggle', {
+        code: 'Comma',
+        mods: new Set(['Mod']),
+      })
+    ).toEqual({ ok: false, reason: 'reserved' })
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  test("setUserBinding rejects macOS literal Ctrl+, as 'reserved'", () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      platform: 'MacIntel',
+    })
+    const { result, update } = renderKeybindings()
+
+    try {
+      expect(
+        result.current.setUserBinding('dock-toggle', {
+          code: 'Comma',
+          mods: new Set(['Ctrl']),
+        })
+      ).toEqual({ ok: false, reason: 'reserved' })
+      expect(update).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  test("setUserBinding rejects shadowing the browser address shortcut as 'reserved'", () => {
+    const { result, update } = renderKeybindings()
+    expect(
+      result.current.setUserBinding('dock-toggle', {
+        code: 'KeyL',
+        mods: new Set(['Mod']),
+      })
+    ).toEqual({ ok: false, reason: 'reserved' })
+    expect(update).not.toHaveBeenCalled()
+  })
+
   test("setUserBinding rejects display-only commands as 'reserved'", () => {
     const { result, update } = renderKeybindings()
     expect(

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
-import { render as rtlRender, screen } from '@testing-library/react'
+import { render as rtlRender, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState, type ReactElement } from 'react'
 import { SettingsDialog } from './SettingsDialog'
@@ -162,6 +162,32 @@ describe('SettingsDialog', () => {
     await user.tab()
 
     expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus()
+  })
+
+  test('keeps Tab from recorder on the next keymap control', async () => {
+    const user = userEvent.setup()
+    render(<DialogWithTrigger initialOpen />)
+
+    await user.click(screen.getByRole('button', { name: 'Keymap' }))
+    await user.click(
+      screen.getByRole('button', { name: 'Edit Focus pane 1 binding' })
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Capture Focus pane 1 binding' })
+    ).toHaveFocus()
+
+    await user.tab()
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Capture Focus pane 1 binding' })
+      ).not.toBeInTheDocument()
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'Edit Focus pane 2 binding' })
+    ).toHaveFocus()
   })
 
   test('restores focus to the triggering element on close', async () => {

--- a/src/features/settings/components/panes/KeymapPane.test.tsx
+++ b/src/features/settings/components/panes/KeymapPane.test.tsx
@@ -227,6 +227,49 @@ describe('KeymapPane', () => {
     vi.unstubAllGlobals()
   })
 
+  test('bare Escape returns focus to the row edit button', () => {
+    renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Show / hide editor & diff dock binding',
+    })
+    fireEvent.keyDown(capture, { key: 'Escape', code: 'Escape' })
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    ).toHaveFocus()
+  })
+
+  test('Cancel button returns focus to the row edit button', () => {
+    renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Cancel Show / hide editor & diff dock binding edit',
+      })
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    ).toHaveFocus()
+  })
+
   test('Tab cancels recording and moves focus to the next stable keymap control', () => {
     renderWithSettings()
 

--- a/src/features/settings/components/panes/KeymapPane.test.tsx
+++ b/src/features/settings/components/panes/KeymapPane.test.tsx
@@ -270,6 +270,33 @@ describe('KeymapPane', () => {
     ).toHaveFocus()
   })
 
+  test('Save button returns focus to the row edit button', () => {
+    renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Show / hide editor & diff dock binding',
+    })
+    fireEvent.keyDown(capture, { key: 'k', code: 'KeyK', ctrlKey: true })
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save Show / hide editor & diff dock binding',
+      })
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    ).toHaveFocus()
+  })
+
   test('Tab cancels recording and moves focus to the next stable keymap control', () => {
     renderWithSettings()
 

--- a/src/features/settings/components/panes/KeymapPane.test.tsx
+++ b/src/features/settings/components/panes/KeymapPane.test.tsx
@@ -1,10 +1,11 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
-import { render as rtlRender, screen } from '@testing-library/react'
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createElement, type ReactElement } from 'react'
 import { DEFAULT_SETTINGS } from '../../store/settingsDefaults'
 import { SettingsProvider, SettingsContext } from '../../SettingsProvider'
 import type { AppSettings } from '../../../../bindings/AppSettings'
+import { KEYMAP_CAPTURE_TARGET_ATTRIBUTE } from '../../../keymap/capture'
 import { KeymapPane } from './KeymapPane'
 
 const render = (ui: ReactElement): ReturnType<typeof rtlRender> =>
@@ -14,16 +15,19 @@ const render = (ui: ReactElement): ReturnType<typeof rtlRender> =>
 // (bypassing the provider's async load).
 const renderWithSettings = (
   customKeybindings: Record<string, string> = {}
-): ReturnType<typeof rtlRender> => {
+): ReturnType<typeof rtlRender> & { update: ReturnType<typeof vi.fn> } => {
   const settings: AppSettings = { ...DEFAULT_SETTINGS, customKeybindings }
+  const update = vi.fn()
 
-  return rtlRender(
+  const view = rtlRender(
     createElement(
       SettingsContext.Provider,
-      { value: { settings, saveError: null, update: vi.fn() } },
+      { value: { settings, saveError: null, update } },
       createElement(KeymapPane)
     )
   )
+
+  return { ...view, update }
 }
 
 describe('KeymapPane', () => {
@@ -63,7 +67,9 @@ describe('KeymapPane', () => {
     expect(
       screen.getByText('Show / hide editor & diff dock')
     ).toBeInTheDocument()
+    expect(screen.getByText('Open settings')).toBeInTheDocument()
     expect(screen.getByText('Open command palette')).toBeInTheDocument()
+    expect(screen.getByText('Focus browser address bar')).toBeInTheDocument()
     // The bare-key Diff zone still renders from KEYMAP_GROUPS.
     expect(screen.getByText('Next / previous file')).toBeInTheDocument()
   })
@@ -121,6 +127,377 @@ describe('KeymapPane', () => {
     renderWithSettings({ 'dock-toggle': 'Mod+KeyK' })
 
     expect(screen.getByText('⌘K')).toBeInTheDocument()
+
+    vi.unstubAllGlobals()
+  })
+
+  test('saves a captured chord for a rebindable row', () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      platform: 'Linux x86_64',
+    })
+    const { update } = renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Show / hide editor & diff dock binding',
+    })
+    expect(capture).toHaveAttribute(KEYMAP_CAPTURE_TARGET_ATTRIBUTE, 'true')
+    fireEvent.keyDown(capture, { key: 'k', code: 'KeyK', ctrlKey: true })
+    expect(screen.getByText('Ctrl+K')).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save Show / hide editor & diff dock binding',
+      })
+    )
+
+    expect(update).toHaveBeenCalledWith({
+      customKeybindings: { 'dock-toggle': 'Mod+KeyK' },
+    })
+    expect(screen.getByRole('status')).toHaveTextContent('Saved.')
+
+    vi.unstubAllGlobals()
+  })
+
+  test('bare modifier key presses do not replace the captured draft', () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      platform: 'Linux x86_64',
+    })
+    renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Show / hide editor & diff dock binding',
+    })
+    fireEvent.keyDown(capture, { key: 'k', code: 'KeyK', ctrlKey: true })
+    fireEvent.keyDown(capture, {
+      key: 'Shift',
+      code: 'ShiftLeft',
+      shiftKey: true,
+    })
+
+    expect(screen.getByText('Ctrl+K')).toBeInTheDocument()
+    expect(screen.queryByText('ShiftLeft')).not.toBeInTheDocument()
+
+    vi.unstubAllGlobals()
+  })
+
+  test('bare Escape cancels a row binding edit', () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      platform: 'Linux x86_64',
+    })
+    renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Show / hide editor & diff dock binding',
+    })
+    fireEvent.keyDown(capture, { key: 'Escape', code: 'Escape' })
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Capture Show / hide editor & diff dock binding',
+      })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    ).toBeInTheDocument()
+
+    vi.unstubAllGlobals()
+  })
+
+  test('Tab cancels recording and moves focus to the next stable keymap control', () => {
+    renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Focus pane 1 binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Focus pane 1 binding',
+    })
+    capture.focus()
+
+    const tabEvent = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      code: 'Tab',
+      bubbles: true,
+      cancelable: true,
+    })
+    const preventDefaultSpy = vi.spyOn(tabEvent, 'preventDefault')
+
+    fireEvent(capture, tabEvent)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Capture Focus pane 1 binding',
+      })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: 'Edit Focus pane 2 binding' })
+    ).toHaveFocus()
+  })
+
+  test('Shift+Tab cancels recording and moves focus to the previous stable keymap control', () => {
+    renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Focus pane 2 binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Focus pane 2 binding',
+    })
+    capture.focus()
+
+    const tabEvent = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      code: 'Tab',
+      bubbles: true,
+      cancelable: true,
+      shiftKey: true,
+    })
+    const preventDefaultSpy = vi.spyOn(tabEvent, 'preventDefault')
+
+    fireEvent(capture, tabEvent)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Capture Focus pane 2 binding',
+      })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: 'Edit Focus pane 1 binding' })
+    ).toHaveFocus()
+  })
+
+  test('modified Escape stays in capture mode', () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      platform: 'Linux x86_64',
+    })
+    renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Show / hide editor & diff dock binding',
+    })
+    fireEvent.keyDown(capture, {
+      key: 'Escape',
+      code: 'Escape',
+      shiftKey: true,
+    })
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Capture Show / hide editor & diff dock binding',
+      })
+    ).toBeInTheDocument()
+
+    vi.unstubAllGlobals()
+  })
+
+  test('focus leaving the binding edit controls cancels recording', () => {
+    renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Show / hide editor & diff dock binding',
+    })
+    const outside = document.createElement('button')
+    document.body.append(outside)
+
+    try {
+      fireEvent.focusOut(capture, { relatedTarget: outside })
+    } finally {
+      outside.remove()
+    }
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Capture Show / hide editor & diff dock binding',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  test('focus can move from recording to save without cancelling', () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      platform: 'Linux x86_64',
+    })
+    const { update } = renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Show / hide editor & diff dock binding',
+    })
+    fireEvent.keyDown(capture, { key: 'k', code: 'KeyK', ctrlKey: true })
+
+    const save = screen.getByRole('button', {
+      name: 'Save Show / hide editor & diff dock binding',
+    })
+    fireEvent.focusOut(capture, { relatedTarget: save })
+    fireEvent.click(save)
+
+    expect(update).toHaveBeenCalledWith({
+      customKeybindings: { 'dock-toggle': 'Mod+KeyK' },
+    })
+
+    vi.unstubAllGlobals()
+  })
+
+  test('resetting a row removes only that override', () => {
+    const { update } = renderWithSettings({
+      'dock-toggle': 'Mod+KeyK',
+      'focus-pane-1': 'Mod+KeyJ',
+    })
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Reset Show / hide editor & diff dock binding',
+      })
+    )
+
+    expect(update).toHaveBeenCalledWith({
+      customKeybindings: { 'focus-pane-1': 'Mod+KeyJ' },
+    })
+    expect(screen.getByRole('status')).toHaveTextContent('Reset.')
+  })
+
+  test('does not render edit controls for display-only rows', () => {
+    renderWithSettings()
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Edit Open command palette binding',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  test('shows a conflict warning without persisting', () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      platform: 'Linux x86_64',
+    })
+    const { update } = renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    fireEvent.keyDown(
+      screen.getByRole('button', {
+        name: 'Capture Show / hide editor & diff dock binding',
+      }),
+      { key: '1', code: 'Digit1', ctrlKey: true }
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save Show / hide editor & diff dock binding',
+      })
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Shortcut conflicts with another command.'
+    )
+    expect(update).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(
+      screen.getByRole('button', {
+        name: 'Capture Show / hide editor & diff dock binding',
+      }),
+      { key: 'k', code: 'KeyK', ctrlKey: true }
+    )
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+    vi.unstubAllGlobals()
+  })
+
+  test('cancel clears validation feedback from a failed edit', () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      platform: 'Linux x86_64',
+    })
+    renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Show / hide editor & diff dock binding',
+      })
+    )
+
+    fireEvent.keyDown(
+      screen.getByRole('button', {
+        name: 'Capture Show / hide editor & diff dock binding',
+      }),
+      { key: '1', code: 'Digit1', ctrlKey: true }
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save Show / hide editor & diff dock binding',
+      })
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Shortcut conflicts with another command.'
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Cancel Show / hide editor & diff dock binding edit',
+      })
+    )
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
 
     vi.unstubAllGlobals()
   })

--- a/src/features/settings/components/panes/KeymapPane.tsx
+++ b/src/features/settings/components/panes/KeymapPane.tsx
@@ -1,5 +1,6 @@
 import {
   type FocusEvent as ReactFocusEvent,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -61,6 +62,14 @@ const focusableElements = (container: ParentNode): HTMLElement[] =>
     (el) =>
       !el.matches(':disabled') && el.getAttribute('aria-hidden') !== 'true'
   )
+
+const focusEditButton = (id: CommandId): void => {
+  document
+    .querySelector<HTMLButtonElement>(
+      `[${KEYMAP_EDIT_BUTTON_ATTRIBUTE}="${id}"]`
+    )
+    ?.focus()
+}
 
 const focusAfterTabCancel = (id: CommandId, direction: TabDirection): void => {
   const editButton = document.querySelector<HTMLButtonElement>(
@@ -140,11 +149,32 @@ export const KeymapPane = (): ReactElement => {
   const [draftChord, setDraftChord] = useState<Chord | null>(null)
   const [feedback, setFeedback] = useState<Feedback | null>(null)
   const pendingTabFocusRef = useRef<PendingTabFocus | null>(null)
+  const pendingCancelFocusRef = useRef<CommandId | null>(null)
   const showVim = settings.keymapPreset === 'vim'
   const isMac = isMacPlatform()
 
+  useEffect(() => {
+    window.vimeflow?.setKeymapCaptureActive?.(editingId !== null)
+
+    return (): void => {
+      window.vimeflow?.setKeymapCaptureActive?.(false)
+    }
+  }, [editingId])
+
   useLayoutEffect(() => {
-    if (editingId !== null || pendingTabFocusRef.current === null) {
+    if (editingId !== null) {
+      return
+    }
+
+    if (pendingCancelFocusRef.current !== null) {
+      const id = pendingCancelFocusRef.current
+      pendingCancelFocusRef.current = null
+      focusEditButton(id)
+
+      return
+    }
+
+    if (pendingTabFocusRef.current === null) {
       return
     }
 
@@ -158,7 +188,10 @@ export const KeymapPane = (): ReactElement => {
     setDraftChord(null)
   }
 
-  const cancelEditing = (): void => {
+  const cancelEditing = (restoreId?: CommandId): void => {
+    if (restoreId !== undefined) {
+      pendingCancelFocusRef.current = restoreId
+    }
     stopEditing()
     setFeedback(null)
   }
@@ -182,7 +215,7 @@ export const KeymapPane = (): ReactElement => {
     ) {
       event.preventDefault()
       event.stopPropagation()
-      cancelEditing()
+      cancelEditing(id)
 
       return
     }
@@ -320,7 +353,7 @@ export const KeymapPane = (): ReactElement => {
                   {iconButton({
                     label: `Cancel ${cmd.label} binding edit`,
                     icon: 'close',
-                    onClick: cancelEditing,
+                    onClick: () => cancelEditing(cmd.id),
                   })}
                 </div>
               ) : (

--- a/src/features/settings/components/panes/KeymapPane.tsx
+++ b/src/features/settings/components/panes/KeymapPane.tsx
@@ -1,4 +1,12 @@
-import type { ReactElement } from 'react'
+import {
+  type FocusEvent as ReactFocusEvent,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
+} from 'react'
+import { Tooltip } from '@/components/Tooltip'
 import {
   formatShortcut,
   isMacPlatform,
@@ -6,17 +14,75 @@ import {
 } from '../../../../lib/formatShortcut'
 import { useSettings } from '../../hooks/useSettings'
 import { KEYMAP_GROUPS, VIM_KEYMAP_GROUPS } from '../../sections'
-import { CATALOG } from '../../../keymap/catalog'
+import { CATALOG, type CommandId } from '../../../keymap/catalog'
+import {
+  eventToChord,
+  KEYMAP_CAPTURE_TARGET_ATTRIBUTE,
+} from '../../../keymap/capture'
+import type { Chord } from '../../../keymap/chord'
 import { chordToShortcutInput } from '../../../keymap/displayKey'
-import { useKeybindings } from '../../../keymap/useKeybindings'
+import {
+  useKeybindings,
+  type SetBindingResult,
+} from '../../../keymap/useKeybindings'
 import type { KeymapBinding, KeymapGroup, KeymapKeys } from '../../types'
+import { Icon } from '../Icon'
 import { Kbd } from '../Kbd'
 import { PaneTitle, Row, Select } from '../controls'
 
-// The catalog owns the modifier-based rows (Global / Panes & Layout / Terminal).
+// The catalog owns the modifier-based rows (Global / Panes & Layout / Terminal / Browser).
 // The bare-key Diff zone keeps rendering from KEYMAP_GROUPS (no platform-modifier
 // drift; vim-style lowercase display), as do the Vim ex-command rows. (§6.4)
-const GROUP_ORDER = ['Global', 'Panes & Layout', 'Terminal'] as const
+const GROUP_ORDER = ['Global', 'Panes & Layout', 'Terminal', 'Browser'] as const
+type CatalogCommand = (typeof CATALOG)[number]
+type FeedbackTone = 'info' | 'danger'
+type TabDirection = 'forward' | 'backward'
+
+interface Feedback {
+  id: CommandId
+  tone: FeedbackTone
+  text: string
+}
+
+interface PendingTabFocus {
+  id: CommandId
+  direction: TabDirection
+}
+
+const KEYMAP_EDIT_BUTTON_ATTRIBUTE = 'data-keymap-edit-command'
+
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+
+const focusableElements = (container: ParentNode): HTMLElement[] =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+  ).filter(
+    (el) =>
+      !el.matches(':disabled') && el.getAttribute('aria-hidden') !== 'true'
+  )
+
+const focusAfterTabCancel = (id: CommandId, direction: TabDirection): void => {
+  const editButton = document.querySelector<HTMLButtonElement>(
+    `[${KEYMAP_EDIT_BUTTON_ATTRIBUTE}="${id}"]`
+  )
+  if (editButton === null) {
+    return
+  }
+
+  const scope = editButton.closest('[role="dialog"]') ?? document
+  const focusable = focusableElements(scope)
+  const currentIndex = focusable.indexOf(editButton)
+  if (currentIndex === -1) {
+    editButton.focus()
+
+    return
+  }
+
+  const delta = direction === 'backward' ? -1 : 1
+  const nextIndex = (currentIndex + delta + focusable.length) % focusable.length
+  focusable[nextIndex]?.focus()
+}
 
 const rowClass = (last: boolean): string =>
   `flex items-center gap-3.5 px-3.5 py-2.5 ${
@@ -40,26 +106,258 @@ const labelCell = (text: string): ReactElement => (
   </span>
 )
 
+const shortcutLabel = (chord: Chord): string =>
+  formatShortcut(chordToShortcutInput(chord))
+
+const iconButtonClass = (disabled = false): string =>
+  `inline-flex h-7 w-7 items-center justify-center rounded-md border border-outline-variant/35 bg-surface-container-low/70 text-on-surface-muted transition-colors ${
+    disabled
+      ? 'cursor-not-allowed opacity-40'
+      : 'hover:bg-surface-container-high hover:text-on-surface'
+  }`
+
+const resultMessage = (
+  reason: Exclude<SetBindingResult, { ok: true }>['reason']
+): string => {
+  if (reason === 'invalid-super') {
+    return 'Use exactly one primary modifier.'
+  }
+  if (reason === 'reserved') {
+    return 'Shortcut is reserved.'
+  }
+
+  return 'Shortcut conflicts with another command.'
+}
+
 // Vim ex-command rows keep their existing string-token rendering.
 const resolveKeys = (keys: KeymapKeys): ShortcutInput[] =>
   typeof keys === 'function' ? keys(isMacPlatform()) : keys
 
 export const KeymapPane = (): ReactElement => {
   const { settings, update } = useSettings()
-  const { bindingFor } = useKeybindings()
+  const { bindingFor, resetBinding, setUserBinding } = useKeybindings()
+  const [editingId, setEditingId] = useState<CommandId | null>(null)
+  const [draftChord, setDraftChord] = useState<Chord | null>(null)
+  const [feedback, setFeedback] = useState<Feedback | null>(null)
+  const pendingTabFocusRef = useRef<PendingTabFocus | null>(null)
   const showVim = settings.keymapPreset === 'vim'
+  const isMac = isMacPlatform()
 
-  const commandRow = (
-    cmd: (typeof CATALOG)[number],
-    last: boolean
-  ): ReactElement => (
-    <div key={cmd.id} className={rowClass(last)}>
-      {labelCell(cmd.label)}
-      <span className="flex gap-1">
-        <Kbd>{formatShortcut(chordToShortcutInput(bindingFor(cmd.id)))}</Kbd>
-      </span>
-    </div>
+  useLayoutEffect(() => {
+    if (editingId !== null || pendingTabFocusRef.current === null) {
+      return
+    }
+
+    const pending = pendingTabFocusRef.current
+    pendingTabFocusRef.current = null
+    focusAfterTabCancel(pending.id, pending.direction)
+  }, [editingId])
+
+  const stopEditing = (): void => {
+    setEditingId(null)
+    setDraftChord(null)
+  }
+
+  const cancelEditing = (): void => {
+    stopEditing()
+    setFeedback(null)
+  }
+
+  const startEditing = (id: CommandId): void => {
+    setEditingId(id)
+    setDraftChord(null)
+    setFeedback(null)
+  }
+
+  const captureChord = (
+    id: CommandId,
+    event: ReactKeyboardEvent<HTMLButtonElement>
+  ): void => {
+    if (
+      event.key === 'Escape' &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.shiftKey
+    ) {
+      event.preventDefault()
+      event.stopPropagation()
+      cancelEditing()
+
+      return
+    }
+
+    if (
+      event.key === 'Tab' &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey
+    ) {
+      event.preventDefault()
+      event.stopPropagation()
+      pendingTabFocusRef.current = {
+        id,
+        direction: event.shiftKey ? 'backward' : 'forward',
+      }
+      cancelEditing()
+
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const chord = eventToChord(event.nativeEvent, isMac)
+    if (chord !== null) {
+      setDraftChord(chord)
+      setFeedback(null)
+    }
+  }
+
+  const cancelEditingOnFocusLeave = (
+    event: ReactFocusEvent<HTMLDivElement>
+  ): void => {
+    if (event.currentTarget.contains(event.relatedTarget)) {
+      return
+    }
+
+    cancelEditing()
+  }
+
+  const saveDraft = (id: CommandId): void => {
+    if (draftChord === null) {
+      return
+    }
+
+    const result = setUserBinding(id, draftChord)
+    if (result.ok) {
+      setFeedback({ id, tone: 'info', text: 'Saved.' })
+      stopEditing()
+
+      return
+    }
+
+    setFeedback({ id, tone: 'danger', text: resultMessage(result.reason) })
+  }
+
+  const resetCommand = (id: CommandId): void => {
+    resetBinding(id)
+    if (editingId === id) {
+      stopEditing()
+    }
+    setFeedback({ id, tone: 'info', text: 'Reset.' })
+  }
+
+  const iconButton = ({
+    label,
+    icon,
+    onClick,
+    disabled = false,
+    editCommandId = undefined,
+  }: {
+    label: string
+    icon: string
+    onClick: () => void
+    disabled?: boolean
+    editCommandId?: CommandId
+  }): ReactElement => (
+    <Tooltip content={label}>
+      <button
+        type="button"
+        aria-label={label}
+        {...(editCommandId === undefined
+          ? {}
+          : { [KEYMAP_EDIT_BUTTON_ATTRIBUTE]: editCommandId })}
+        onClick={onClick}
+        disabled={disabled}
+        className={iconButtonClass(disabled)}
+      >
+        <Icon name={icon} size={14} />
+      </button>
+    </Tooltip>
   )
+
+  const commandRow = (cmd: CatalogCommand, last: boolean): ReactElement => {
+    const isEditing = editingId === cmd.id
+    const isOverridden = settings.customKeybindings[cmd.id] !== undefined
+    const rowFeedback = feedback?.id === cmd.id ? feedback : null
+
+    return (
+      <div key={cmd.id} className={rowClass(last)}>
+        {labelCell(cmd.label)}
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="flex min-w-[72px] justify-end gap-1">
+            <Kbd>{shortcutLabel(bindingFor(cmd.id))}</Kbd>
+          </span>
+
+          {cmd.rebindable && (
+            <>
+              {isEditing ? (
+                <div
+                  className="flex items-center gap-1.5"
+                  onBlur={cancelEditingOnFocusLeave}
+                >
+                  <button
+                    type="button"
+                    autoFocus
+                    aria-label={`Capture ${cmd.label} binding`}
+                    {...{ [KEYMAP_CAPTURE_TARGET_ATTRIBUTE]: 'true' }}
+                    onKeyDown={(event) => captureChord(cmd.id, event)}
+                    className="inline-flex h-7 min-w-[92px] items-center justify-center rounded-md border border-primary/45 bg-primary-container/20 px-2 font-mono text-[10px] font-semibold text-on-surface outline-none focus:ring-1 focus:ring-primary"
+                  >
+                    {draftChord === null ? (
+                      'Recording'
+                    ) : (
+                      <Kbd>{shortcutLabel(draftChord)}</Kbd>
+                    )}
+                  </button>
+                  {iconButton({
+                    label: `Save ${cmd.label} binding`,
+                    icon: 'check',
+                    onClick: () => saveDraft(cmd.id),
+                    disabled: draftChord === null,
+                  })}
+                  {iconButton({
+                    label: `Cancel ${cmd.label} binding edit`,
+                    icon: 'close',
+                    onClick: cancelEditing,
+                  })}
+                </div>
+              ) : (
+                <div className="flex items-center gap-1.5">
+                  {iconButton({
+                    label: `Edit ${cmd.label} binding`,
+                    icon: 'edit',
+                    onClick: () => startEditing(cmd.id),
+                    editCommandId: cmd.id,
+                  })}
+                  {iconButton({
+                    label: `Reset ${cmd.label} binding`,
+                    icon: 'restart_alt',
+                    onClick: () => resetCommand(cmd.id),
+                    disabled: !isOverridden,
+                  })}
+                </div>
+              )}
+            </>
+          )}
+
+          {rowFeedback && (
+            <span
+              role={rowFeedback.tone === 'danger' ? 'alert' : 'status'}
+              className={`min-w-[148px] text-right font-body text-xs ${
+                rowFeedback.tone === 'danger'
+                  ? 'text-error'
+                  : 'text-on-surface-muted'
+              }`}
+            >
+              {rowFeedback.text}
+            </span>
+          )}
+        </div>
+      </div>
+    )
+  }
 
   const staticGroup = (group: KeymapGroup): ReactElement =>
     groupShell(

--- a/src/features/settings/components/panes/KeymapPane.tsx
+++ b/src/features/settings/components/panes/KeymapPane.tsx
@@ -265,6 +265,7 @@ export const KeymapPane = (): ReactElement => {
     const result = setUserBinding(id, draftChord)
     if (result.ok) {
       setFeedback({ id, tone: 'info', text: 'Saved.' })
+      pendingCancelFocusRef.current = id
       stopEditing()
 
       return

--- a/src/features/settings/hooks/useSettingsDialog.test.ts
+++ b/src/features/settings/hooks/useSettingsDialog.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 import { KEYMAP_CAPTURE_TARGET_ATTRIBUTE } from '../../keymap/capture'
 import { useSettingsDialog } from './useSettingsDialog'
@@ -55,7 +55,8 @@ describe('useSettingsDialog', () => {
     expect(result.current.isOpen).toBe(false)
   })
 
-  test('Meta+, toggles the dialog open', () => {
+  test('Meta+, toggles the dialog open on macOS', () => {
+    vi.stubGlobal('navigator', { userAgent: 'test-mac', platform: 'MacIntel' })
     const { result } = renderHook(() => useSettingsDialog())
 
     act(() => {
@@ -68,9 +69,14 @@ describe('useSettingsDialog', () => {
     })
 
     expect(result.current.isOpen).toBe(true)
+    vi.unstubAllGlobals()
   })
 
-  test('Ctrl+, toggles the dialog open', () => {
+  test('Ctrl+, toggles the dialog open on non-macOS', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'test-linux',
+      platform: 'Linux x86_64',
+    })
     const { result } = renderHook(() => useSettingsDialog())
 
     act(() => {
@@ -83,6 +89,7 @@ describe('useSettingsDialog', () => {
     })
 
     expect(result.current.isOpen).toBe(true)
+    vi.unstubAllGlobals()
   })
 
   test('Escape closes the dialog when open', () => {

--- a/src/features/settings/hooks/useSettingsDialog.test.ts
+++ b/src/features/settings/hooks/useSettingsDialog.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, test } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
+import { KEYMAP_CAPTURE_TARGET_ATTRIBUTE } from '../../keymap/capture'
 import { useSettingsDialog } from './useSettingsDialog'
+
+const dispatchFromRecorder = (init: KeyboardEventInit): void => {
+  const recorder = document.createElement('button')
+  recorder.setAttribute(KEYMAP_CAPTURE_TARGET_ATTRIBUTE, 'true')
+  document.body.append(recorder)
+
+  try {
+    recorder.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      })
+    )
+  } finally {
+    recorder.remove()
+  }
+}
 
 describe('useSettingsDialog', () => {
   test('initial state is closed', () => {
@@ -94,5 +113,22 @@ describe('useSettingsDialog', () => {
     })
 
     expect(result.current.isOpen).toBe(false)
+  })
+
+  test('keymap recorder events do not toggle or close the dialog', () => {
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => {
+      dispatchFromRecorder({ ctrlKey: true, key: ',' })
+    })
+
+    expect(result.current.isOpen).toBe(false)
+
+    act(() => result.current.open())
+    act(() => {
+      dispatchFromRecorder({ key: 'Escape' })
+    })
+
+    expect(result.current.isOpen).toBe(true)
   })
 })

--- a/src/features/settings/hooks/useSettingsDialog.ts
+++ b/src/features/settings/hooks/useSettingsDialog.ts
@@ -28,12 +28,7 @@ export const useSettingsDialog = (): UseSettingsDialogReturn => {
         ? event.metaKey && !event.ctrlKey
         : event.ctrlKey && !event.metaKey
 
-      if (
-        isSuper &&
-        event.key === ',' &&
-        !event.altKey &&
-        !event.shiftKey
-      ) {
+      if (isSuper && event.key === ',' && !event.altKey && !event.shiftKey) {
         event.preventDefault()
         handlersRef.current.toggle()
 

--- a/src/features/settings/hooks/useSettingsDialog.ts
+++ b/src/features/settings/hooks/useSettingsDialog.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { isKeymapCaptureTarget } from '../../keymap/capture'
 import type { UseSettingsDialogReturn } from '../types'
 
 export const useSettingsDialog = (): UseSettingsDialogReturn => {
@@ -16,6 +17,10 @@ export const useSettingsDialog = (): UseSettingsDialogReturn => {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isKeymapCaptureTarget(event.target)) {
+        return
+      }
+
       if ((event.metaKey || event.ctrlKey) && event.key === ',') {
         event.preventDefault()
         handlersRef.current.toggle()

--- a/src/features/settings/hooks/useSettingsDialog.ts
+++ b/src/features/settings/hooks/useSettingsDialog.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { isMacPlatform } from '../../../lib/formatShortcut'
 import { isKeymapCaptureTarget } from '../../keymap/capture'
 import type { UseSettingsDialogReturn } from '../types'
 
@@ -21,7 +22,18 @@ export const useSettingsDialog = (): UseSettingsDialogReturn => {
         return
       }
 
-      if ((event.metaKey || event.ctrlKey) && event.key === ',') {
+      const isMac = isMacPlatform()
+
+      const isSuper = isMac
+        ? event.metaKey && !event.ctrlKey
+        : event.ctrlKey && !event.metaKey
+
+      if (
+        isSuper &&
+        event.key === ',' &&
+        !event.altKey &&
+        !event.shiftKey
+      ) {
         event.preventDefault()
         handlersRef.current.toggle()
 

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -10,6 +10,7 @@ import {
 import { eventMatchesChord, type PlatformSuper } from '../../keymap/match'
 import { resolveBinding } from '../../keymap/resolve'
 import { getCommand, type CommandId } from '../../keymap/catalog'
+import { KEYMAP_CAPTURE_TARGET_ATTRIBUTE } from '../../keymap/capture'
 
 const makeSession = (
   id: string,
@@ -110,6 +111,37 @@ describe('usePaneShortcuts', () => {
     expect(setSessionLayout).toHaveBeenCalledOnce()
     expect(setSessionLayout).toHaveBeenCalledWith('s1', 'vsplit')
     expect(event.preventDefaultSpy).toHaveBeenCalled()
+  })
+
+  test('Ctrl+\\ from the keymap recorder does not cycle layout', () => {
+    const setSessionLayout = vi.fn()
+    renderPane({
+      sessions: [makeSession('s1', 'single', ['p0'])],
+      activeSessionId: 's1',
+      setSessionActivePane: vi.fn(),
+      setSessionLayout,
+    })
+
+    const recorder = document.createElement('button')
+    recorder.setAttribute(KEYMAP_CAPTURE_TARGET_ATTRIBUTE, 'true')
+    document.body.append(recorder)
+
+    try {
+      const event = new KeyboardEvent('keydown', {
+        key: '\\',
+        code: 'Backslash',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+      recorder.dispatchEvent(event)
+
+      expect(setSessionLayout).not.toHaveBeenCalled()
+      expect(preventDefaultSpy).not.toHaveBeenCalled()
+    } finally {
+      recorder.remove()
+    }
   })
 
   test('Ctrl+\\ from quad wraps to single (default modifier)', () => {

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -14,6 +14,7 @@ import {
 } from '../../workspace/containerIds'
 import { selectVisiblePanes } from '../utils/selectVisiblePanes'
 import type { CommandId } from '../../keymap/catalog'
+import { isKeymapCaptureTarget } from '../../keymap/capture'
 
 // Derive the cycle order from the canonical LAYOUTS record so a future
 // LayoutId added in `layouts.ts` automatically participates in ⌘\
@@ -65,6 +66,10 @@ export const usePaneShortcuts = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isKeymapCaptureTarget(event.target)) {
+        return
+      }
+
       // The platform-super check AND the per-key match both live in the
       // registry's `match` (called per command below), so an override changes
       // the live shortcut. The former shared super early-return is gone; every

--- a/src/features/workspace/hooks/useBurnerToggleShortcut.ts
+++ b/src/features/workspace/hooks/useBurnerToggleShortcut.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { isKeymapCaptureTarget } from '../../keymap/capture'
 import { DIALOG_SELECTOR } from '../containerIds'
 
 export interface UseBurnerToggleShortcutParams {
@@ -19,6 +20,10 @@ export const useBurnerToggleShortcut = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isKeymapCaptureTarget(event.target)) {
+        return
+      }
+
       // Exactly Ctrl+` — reject ⌘/Alt/Shift-modified and held-key repeats.
       if (
         event.repeat ||

--- a/src/features/workspace/hooks/useDockShortcuts.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { isKeymapCaptureTarget } from '../../keymap/capture'
 import {
   DIALOG_SELECTOR,
   DOCK_CONTAINER_ID,
@@ -33,6 +34,10 @@ export const useDockShortcuts = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isKeymapCaptureTarget(event.target)) {
+        return
+      }
+
       const expectedModifier =
         modKeyRef.current === '⌘'
           ? event.metaKey && !event.ctrlKey

--- a/src/features/workspace/hooks/useDockToggleShortcut.test.ts
+++ b/src/features/workspace/hooks/useDockToggleShortcut.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import { KEYMAP_CAPTURE_TARGET_ATTRIBUTE } from '../../keymap/capture'
 import { useDockToggleShortcut } from './useDockToggleShortcut'
 
 const appended: HTMLElement[] = []
@@ -91,6 +92,29 @@ describe('useDockToggleShortcut', () => {
 
     unmount()
     press('Digit0')
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  test('ignores keydown when the keymap capture target is focused', () => {
+    const captureButton = document.createElement('button')
+    captureButton.setAttribute(KEYMAP_CAPTURE_TARGET_ATTRIBUTE, 'true')
+    append(captureButton)
+
+    const onToggle = vi.fn()
+    renderHook(() =>
+      useDockToggleShortcut({ onToggle, matches: matchesFor('Digit0') })
+    )
+
+    const event = new KeyboardEvent('keydown', {
+      code: 'Digit0',
+      bubbles: true,
+      cancelable: true,
+    })
+    act(() => {
+      captureButton.dispatchEvent(event)
+    })
+
+    expect(event.defaultPrevented).toBe(false)
     expect(onToggle).not.toHaveBeenCalled()
   })
 })

--- a/src/features/workspace/hooks/useDockToggleShortcut.ts
+++ b/src/features/workspace/hooks/useDockToggleShortcut.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { isKeymapCaptureTarget } from '../../keymap/capture'
 import { DIALOG_SELECTOR } from '../containerIds'
 import type { CommandId } from '../../keymap/catalog'
 
@@ -24,6 +25,10 @@ export const useDockToggleShortcut = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isKeymapCaptureTarget(event.target)) {
+        return
+      }
+
       if (!matchesRef.current(event, 'dock-toggle')) {
         return
       }

--- a/src/features/workspace/hooks/useNewSessionShortcut.ts
+++ b/src/features/workspace/hooks/useNewSessionShortcut.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { isKeymapCaptureTarget } from '../../keymap/capture'
 import { DIALOG_SELECTOR, TERMINAL_CONTAINER_ID } from '../containerIds'
 
 export interface UseNewSessionShortcutParams {
@@ -26,6 +27,10 @@ export const useNewSessionShortcut = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isKeymapCaptureTarget(event.target)) {
+        return
+      }
+
       // Auto-repeat (held key) would spawn a PTY per repeat — fire once.
       if (event.repeat) {
         return

--- a/src/features/workspace/hooks/useSessionNavShortcut.ts
+++ b/src/features/workspace/hooks/useSessionNavShortcut.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { isKeymapCaptureTarget } from '../../keymap/capture'
 import { DIALOG_SELECTOR, TERMINAL_CONTAINER_ID } from '../containerIds'
 
 export interface UseSessionNavShortcutParams {
@@ -34,6 +35,10 @@ export const useSessionNavShortcut = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isKeymapCaptureTarget(event.target)) {
+        return
+      }
+
       if (event.repeat || event.altKey) {
         return
       }

--- a/src/features/workspace/hooks/useSidebarShortcut.ts
+++ b/src/features/workspace/hooks/useSidebarShortcut.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { isKeymapCaptureTarget } from '../../keymap/capture'
 import {
   DIALOG_SELECTOR,
   DOCK_CONTAINER_ID,
@@ -38,6 +39,10 @@ export const useSidebarShortcut = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isKeymapCaptureTarget(event.target)) {
+        return
+      }
+
       if (event.key.toLowerCase() !== 'b' || event.altKey) {
         return
       }

--- a/src/features/workspace/hooks/useSidebarTabShortcut.ts
+++ b/src/features/workspace/hooks/useSidebarTabShortcut.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { isKeymapCaptureTarget } from '../../keymap/capture'
 import { DIALOG_SELECTOR, TERMINAL_CONTAINER_ID } from '../containerIds'
 
 export interface UseSidebarTabShortcutParams {
@@ -35,6 +36,10 @@ export const useSidebarTabShortcut = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isKeymapCaptureTarget(event.target)) {
+        return
+      }
+
       // Shift is mandatory (bare ⌘S/Ctrl+S = save); reject Alt-modified chords.
       if (event.repeat || event.altKey || !event.shiftKey) {
         return

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -35,6 +35,7 @@ export interface BackendApi {
   ) => Promise<UnlistenFn>
 
   onCommandPaletteToggle?: (callback: () => void) => UnlistenFn
+  setKeymapCaptureActive?: (active: boolean) => void
 
   settings?: SettingsBridge
   aliases?: AliasesBridge

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,6 +3,27 @@ import { afterEach, vi } from 'vitest'
 import * as chordRegistry from '../features/command-palette/chordRegistry'
 import * as paneHeaderRefs from '../features/terminal/paneHeaderRefs'
 
+// jsdom populates navigator.userAgent/platform, but tests that stub globals
+// can leave it in a state where third-party listeners (e.g. floating-ui's
+// focus-visible detection) crash. Provide a stable fallback.
+interface NavigatorLike {
+  userAgent?: string
+  platform?: string
+}
+
+const existingNavigator: NavigatorLike =
+  (globalThis.navigator as NavigatorLike | undefined) ?? {}
+
+Object.defineProperty(globalThis, 'navigator', {
+  writable: true,
+  configurable: true,
+  value: {
+    ...existingNavigator,
+    userAgent: existingNavigator.userAgent ?? 'vitest-jsdom',
+    platform: existingNavigator.platform ?? 'Linux x86_64',
+  },
+})
+
 const ensureLocalStorageClear = (): void => {
   if (typeof window.localStorage.clear === 'function') {
     return


### PR DESCRIPTION
## SP2 — Keymap row rebinding controls

Starts the VIM-136 SP2 editing UI on top of the merged SP1 keybinding engine.

### What changed

- Adds `eventToChord`, a small pure helper that converts a captured `KeyboardEvent` into the engine `Chord` shape.
- Adds inline Keymap pane controls for rebindable catalog rows: edit, capture, save, cancel, and reset.
- Routes saves through `setUserBinding`, so `invalid-super`, `reserved`, and `conflict` validation stays centralized in the SP1 access layer.
- Keeps display-only commands non-editable, so unmigrated or reserved commands cannot write dead overrides.

### Scope notes

This is the first SP2 slice. Import/export, unbind sentinel support, and broader preset work remain follow-ups.

Part of VIM-136.

### Verification

- `npm run test -- src/features/keymap src/features/settings/components/panes/KeymapPane.test.tsx`
- `npm run lint`
- `npm run type-check:generated`
- `npx prettier --check src/features/keymap/capture.ts src/features/keymap/capture.test.ts src/features/keymap/index.ts src/features/settings/components/panes/KeymapPane.tsx src/features/settings/components/panes/KeymapPane.test.tsx`