### PR TITLE
refactor(terminal): split parser engine input modes

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -69,7 +69,11 @@ describe('ghosttyInstance', () => {
 
     const created = createTrackedGhosttyTerminal({
       createParserEngine: () => ({
+        inputMode: 'bytes',
         parser,
+        parseText: (text): TerminalParserEngineOutput => ({
+          visibleText: `parsed:${text}`,
+        }),
         parseOutput,
       }),
     })

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -8,7 +8,7 @@ import type {
 import { createPlainTextTerminal } from './plainTextInstance'
 import { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
 import {
-  createControlSequenceTerminalParserEngine,
+  createByteControlSequenceTerminalParserEngine,
   type TerminalParserEngine,
 } from './terminalParserEngine'
 
@@ -25,7 +25,7 @@ class GhosttyTerminalModel {
   constructor(options: GhosttyTerminalOptions = {}) {
     this.parserEngine =
       options.createParserEngine?.() ??
-      createControlSequenceTerminalParserEngine()
+      createByteControlSequenceTerminalParserEngine()
   }
 
   readonly output: TerminalOutputWriter = {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -22,6 +22,19 @@ const setElementSize = (
   })
 }
 
+const encodeBase64 = (bytes: Uint8Array): string => {
+  let binary = ''
+
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+
+  return globalThis.btoa(binary)
+}
+
+const encodeText = (text: string): string =>
+  encodeBase64(new TextEncoder().encode(text))
+
 const createdTerminals = new Set<ReturnType<typeof createPlainTextTerminal>>()
 
 const createTrackedPlainTextTerminal = (): ReturnType<
@@ -95,6 +108,20 @@ describe('plainTextInstance', () => {
     expect(callback).toHaveBeenCalledOnce()
   })
 
+  test('uses text output chunks even when byte payloads are present', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.output.writeOutput({
+      text: 'text wins',
+      bytesBase64: encodeText('bytes lose'),
+      offsetStart: 0,
+      byteLen: 10,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe('text wins')
+  })
+
   test('ignores writes after dispose while preserving the callback', () => {
     const created = createTrackedPlainTextTerminal()
     const callback = vi.fn()
@@ -104,6 +131,29 @@ describe('plainTextInstance', () => {
     created.terminal.write('after', callback)
 
     expect(created.viewportReader.readVisibleText()).toBe('before')
+    expect(callback).toHaveBeenCalledOnce()
+  })
+
+  test('ignores output chunks after dispose without parser side effects', () => {
+    const created = createTrackedPlainTextTerminal()
+    const callback = vi.fn()
+    const parserEventHandler = vi.fn()
+    const text = '\x1b]7;file://localhost/tmp/disposed\x07'
+
+    created.parser.onEvent(parserEventHandler)
+    created.terminal.dispose()
+    created.output.writeOutput(
+      {
+        text,
+        offsetStart: 0,
+        byteLen: new TextEncoder().encode(text).length,
+        phase: 'live',
+      },
+      callback
+    )
+
+    expect(parserEventHandler).not.toHaveBeenCalled()
+    expect(created.viewportReader.readVisibleText()).toBe('')
     expect(callback).toHaveBeenCalledOnce()
   })
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -4,9 +4,7 @@ import type {
   TerminalFitController,
   TerminalInstance,
   TerminalKeyEventHandler,
-  TerminalOutputChunk,
   TerminalOutputWriter,
-  TerminalParserOutputContext,
   TerminalParser,
   TerminalRendererAdapter,
   TerminalRendererHandle,
@@ -16,7 +14,7 @@ import type {
   TerminalViewportReader,
 } from '../../types'
 import { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
-import { TerminalControlSequenceParser } from './terminalControlParser'
+import { createTextControlSequenceTerminalParserEngine } from './terminalParserEngine'
 import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
 
 export { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
@@ -71,14 +69,6 @@ const trimScrollbackLines = (text: string): string => {
 
   return lines.slice(-MAX_SCROLLBACK_LINES).join('\n')
 }
-
-const outputContextFromChunk = (
-  chunk: TerminalOutputChunk
-): TerminalParserOutputContext => ({
-  offsetStart: chunk.offsetStart,
-  byteLen: chunk.byteLen,
-  phase: chunk.phase,
-})
 
 const readContainedSelection = (root: HTMLElement): string => {
   const selection = window.getSelection()
@@ -236,6 +226,10 @@ class PlainTextTerminalSurface implements TerminalSurface {
     this.root.remove()
   }
 
+  isDisposed(): boolean {
+    return this.disposed
+  }
+
   clear(): void {
     this.outputText = ''
     this.renderOutput()
@@ -248,7 +242,15 @@ class PlainTextTerminalSurface implements TerminalSurface {
       return
     }
 
-    const visibleData = this.transformOutput(data)
+    this.writeVisible(this.transformOutput(data), callback)
+  }
+
+  writeVisible(visibleData: string, callback?: () => void): void {
+    if (this.disposed) {
+      callback?.()
+
+      return
+    }
 
     if (visibleData.length > 0) {
       this.outputText = trimScrollbackLines(
@@ -436,23 +438,25 @@ class PlainTextTerminalSurface implements TerminalSurface {
 }
 
 class PlainTextTerminalModel {
-  private readonly controlParser = new TerminalControlSequenceParser()
-  private currentOutputContext: TerminalParserOutputContext | null = null
-  readonly terminal = new PlainTextTerminalSurface((data) =>
-    this.controlParser.transformOutput(data, this.currentOutputContext)
+  private readonly parserEngine =
+    createTextControlSequenceTerminalParserEngine()
+  readonly terminal = new PlainTextTerminalSurface(
+    (data) => this.parserEngine.parseText(data, null).visibleText
   )
 
-  readonly parser: TerminalParser = this.controlParser
+  readonly parser: TerminalParser = this.parserEngine.parser
 
   readonly output: TerminalOutputWriter = {
     writeOutput: (chunk, callback): void => {
-      this.currentOutputContext = outputContextFromChunk(chunk)
+      if (this.terminal.isDisposed()) {
+        callback?.()
 
-      try {
-        this.terminal.write(chunk.text, callback)
-      } finally {
-        this.currentOutputContext = null
+        return
       }
+
+      const { visibleText } = this.parserEngine.parseOutput(chunk)
+
+      this.terminal.writeVisible(visibleText, callback)
     },
   }
 

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts
@@ -1,7 +1,10 @@
 // cspell:ignore ghostty
 import { describe, expect, test, vi } from 'vitest'
 import type { TerminalOutputChunk, TerminalOutputPhase } from '../../types'
-import { createControlSequenceTerminalParserEngine } from './terminalParserEngine'
+import {
+  createByteControlSequenceTerminalParserEngine,
+  createTextControlSequenceTerminalParserEngine,
+} from './terminalParserEngine'
 
 const encodeBase64 = (bytes: Uint8Array): string => {
   let binary = ''
@@ -29,9 +32,32 @@ const createByteChunk = (
   }
 }
 
-describe('createControlSequenceTerminalParserEngine', () => {
+describe('terminal parser engine input modes', () => {
+  test('text mode records its input mode and ignores byte payloads', () => {
+    const engine = createTextControlSequenceTerminalParserEngine()
+    const chunk = createByteChunk('bytes lose', 0, 'live')
+
+    expect(engine.inputMode).toBe('text')
+    expect(engine.parseOutput({ ...chunk, text: 'text wins' })).toEqual({
+      visibleText: 'text wins',
+    })
+  })
+
+  test('byte mode records its input mode and prefers byte payloads', () => {
+    const engine = createByteControlSequenceTerminalParserEngine()
+
+    expect(engine.inputMode).toBe('bytes')
+    expect(engine.parseOutput(createByteChunk('bytes win', 0, 'live'))).toEqual(
+      {
+        visibleText: 'bytes win',
+      }
+    )
+  })
+})
+
+describe('createByteControlSequenceTerminalParserEngine', () => {
   test('emits OSC 7 cwd events from byte payloads', () => {
-    const engine = createControlSequenceTerminalParserEngine()
+    const engine = createByteControlSequenceTerminalParserEngine()
     const handler = vi.fn()
 
     const chunk = createByteChunk(
@@ -56,7 +82,7 @@ describe('createControlSequenceTerminalParserEngine', () => {
   })
 
   test('reassembles split OSC 7 byte payloads with completion context', () => {
-    const engine = createControlSequenceTerminalParserEngine()
+    const engine = createByteControlSequenceTerminalParserEngine()
     const handler = vi.fn()
 
     const firstChunk = createByteChunk(
@@ -88,7 +114,7 @@ describe('createControlSequenceTerminalParserEngine', () => {
   })
 
   test('supports OSC 7 sequences terminated with string terminator', () => {
-    const engine = createControlSequenceTerminalParserEngine()
+    const engine = createByteControlSequenceTerminalParserEngine()
     const handler = vi.fn()
 
     const chunk = createByteChunk(
@@ -113,7 +139,7 @@ describe('createControlSequenceTerminalParserEngine', () => {
   })
 
   test('preserves raw non-file OSC 7 payloads for consumer validation', () => {
-    const engine = createControlSequenceTerminalParserEngine()
+    const engine = createByteControlSequenceTerminalParserEngine()
     const handler = vi.fn()
 
     const chunk = createByteChunk(

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -10,8 +10,19 @@ export interface TerminalParserEngineOutput {
   readonly visibleText: string
 }
 
+export type TerminalParserEngineInputMode = 'text' | 'bytes'
+
+export interface TerminalParserEngineOptions {
+  readonly inputMode: TerminalParserEngineInputMode
+}
+
 export interface TerminalParserEngine {
+  readonly inputMode: TerminalParserEngineInputMode
   readonly parser: TerminalParser
+  parseText: (
+    text: string,
+    output: TerminalParserOutputContext | null
+  ) => TerminalParserEngineOutput
   parseOutput: (chunk: TerminalOutputChunk) => TerminalParserEngineOutput
 }
 
@@ -23,22 +34,44 @@ const outputContextFromChunk = (
   phase: chunk.phase,
 })
 
-export const createControlSequenceTerminalParserEngine =
-  (): TerminalParserEngine => {
-    const parser = new TerminalControlSequenceParser()
-    const decoder = new TerminalOutputPayloadDecoder()
-
-    return {
-      parser,
-      parseOutput: (chunk): TerminalParserEngineOutput => {
-        const text = decoder.decode(chunk)
-
-        return {
-          visibleText: parser.transformOutput(
-            text,
-            outputContextFromChunk(chunk)
-          ),
-        }
-      },
-    }
+const createOutputTextReader = (
+  inputMode: TerminalParserEngineInputMode
+): ((chunk: TerminalOutputChunk) => string) => {
+  if (inputMode === 'text') {
+    return (chunk): string => chunk.text
   }
+
+  const decoder = new TerminalOutputPayloadDecoder()
+
+  return (chunk): string => decoder.decode(chunk)
+}
+
+export const createControlSequenceTerminalParserEngine = (
+  options: TerminalParserEngineOptions
+): TerminalParserEngine => {
+  const parser = new TerminalControlSequenceParser()
+  const readOutputText = createOutputTextReader(options.inputMode)
+
+  const parseText = (
+    text: string,
+    output: TerminalParserOutputContext | null
+  ): TerminalParserEngineOutput => ({
+    visibleText: parser.transformOutput(text, output),
+  })
+
+  return {
+    inputMode: options.inputMode,
+    parser,
+    parseText,
+    parseOutput: (chunk): TerminalParserEngineOutput =>
+      parseText(readOutputText(chunk), outputContextFromChunk(chunk)),
+  }
+}
+
+export const createTextControlSequenceTerminalParserEngine =
+  (): TerminalParserEngine =>
+    createControlSequenceTerminalParserEngine({ inputMode: 'text' })
+
+export const createByteControlSequenceTerminalParserEngine =
+  (): TerminalParserEngine =>
+    createControlSequenceTerminalParserEngine({ inputMode: 'bytes' })


### PR DESCRIPTION
## Summary
- Add explicit text/bytes input modes to the shared terminal parser engine.
- Route the plain-text renderer through the text-mode parser engine while preserving direct terminal.write parser behavior.
- Keep the Ghostty spike on the byte-mode parser engine and update tests around injected parser engines.
- Add coverage proving plain-text ignores byte payloads while byte-mode parsing prefers them.

## Validation
- npx vitest run src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts src/features/terminal/components/TerminalPane/plainTextInstance.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts src/features/terminal/components/TerminalPane/terminalControlParser.test.ts src/features/terminal/components/TerminalPane/osc7.test.ts
- npx vitest run src/features/terminal/components/TerminalPane
- npm --ignore-scripts run lint
- npm --ignore-scripts run format:check
- npx tsc -b --pretty false
- git diff --check
