### PR TITLE
refactor(ui): unify chip and progress primitives

### DIFF
--- a/docs/design/UNIFIED.md
+++ b/docs/design/UNIFIED.md
@@ -87,9 +87,9 @@ Separation is **tonal-first** with two planes:
 
 **`TerminalPane`** — a self-contained card (`bg-surface`, `radius 10`), `flex-col`:
 
-- **Header** (`font-mono` 10.5px, `border-b outline-variant/[0.18]`): agent chip (glyph + short name, `accentDim` bg / `accentSoft` border / `accent` text) · `StatusDot` (size 6) · truncating title (`userLabel ?? agentTitle ?? session.name`) · metadata (`GitRefChip` · `+added/−removed` · relative time) · `HeaderActions` (burner · collapse · close, 22×22). Focused header gets an `accentDim` gradient wash.
+- **Header** (`font-mono` 10.5px, `border-b outline-variant/[0.18]`): agent chip (glyph + short name, `accentDim` bg / `accentSoft` border / `accent` text) · truncating title (`userLabel ?? agentTitle ?? session.name`) · metadata (`GitRefChip` · `+added/−removed` · relative time) · `HeaderActions` (burner · collapse · close, 22×22). Focused header gets an `accentDim` gradient wash.
 - **Body:** xterm.js, or `RestartAffordance` ("Session exited." + Restart) when the PTY exited.
-- **Footer** (`font-mono` 11px, `border-t outline-variant/20`): `StatusDot` + a click-to-focus prompt line (`>` in `accent` + state-aware placeholder).
+- **Footer** (`font-mono` 11px, `border-t outline-variant/20`): click-to-focus prompt line (`>` in `accent` + state-aware placeholder).
 - **Focus ring:** absolute `inset-0` span — resting `1px outline-variant/22`; focused `2px agent.accent` border + `6px accentDim` glow.
 - Keyed by `pane.ptyId` (clean remount on PTY restart); slot wrapper keyed by `pane.id`.
 
@@ -132,18 +132,18 @@ A throwaway terminal opens in a centered **`BurnerTerminalPopup`** (`role=dialog
 
 ## 4. Agent session states — the contract
 
-Users return _hours later_ and must answer "what happened?" at a glance. The five states are the contract; each surface signals them slightly differently — a `StatusDot` in pane headers and the activity panel, a status **text label** in the sidebar session list.
+Users return _hours later_ and must answer "what happened?" at a glance. The five states are the contract; shipped surfaces now signal them with status text, relative timestamps, active-action cards, and contextual chrome. Standalone status dots were removed in VIM-126 and should not be reintroduced.
 
-| State       | Meaning                                                               | `stateToken` contract               | Shipped `StatusDot`                      |
-| ----------- | --------------------------------------------------------------------- | ----------------------------------- | ---------------------------------------- |
-| `running`   | Agent is working.                                                     | `success`, solid, glow, 2s pulse    | `success` solid + `0_0_4px` glow + pulse |
-| `awaiting`  | **Blocked on the user** — needs input; must read louder than running. | `tertiary`, solid, glow, 1.4s pulse | `warning` solid + pulse (no glow)        |
-| `completed` | Done; diff ready.                                                     | `success-muted`, hollow ring        | `success-muted` solid                    |
-| `errored`   | Broke; stacktrace in the activity panel.                              | `error`, solid                      | `error` solid                            |
-| `idle`      | Fresh / pure-shell pane, no activity.                                 | `on-surface-muted`, hollow ring     | `on-surface-muted/70` solid              |
+| State       | Meaning                                                               | `stateToken` contract               | Shipped cue                                    |
+| ----------- | --------------------------------------------------------------------- | ----------------------------------- | ---------------------------------------------- |
+| `running`   | Agent is working.                                                     | `success`, solid, glow, 2s pulse    | live action / running text + relative duration |
+| `awaiting`  | **Blocked on the user** — needs input; must read louder than running. | `tertiary`, solid, glow, 1.4s pulse | approval/action surface                        |
+| `completed` | Done; diff ready.                                                     | `success-muted`, hollow ring        | "Done" status text + relative time             |
+| `errored`   | Broke; stacktrace in the activity panel.                              | `error`, solid                      | error text/details in activity surfaces        |
+| `idle`      | Fresh / pure-shell pane, no activity.                                 | `on-surface-muted`, hollow ring     | idle/shell text state                          |
 
-- The canonical visual map is `tokens.ts::stateToken` (color · solid/hollow · pulse · glow · label tone); `SessionState` is its union. The **shipped `StatusDot` renders the solid form of every state, with a glow only on `running` and Tailwind's uniform pulse** — the hollow-ring + per-state-duration + awaiting-glow details of the contract are not yet wired (the dim/hollow variant has no live caller). Treat `stateToken` as the intent; if you wire it, match the table. Add a state in **all three** (union · this table · the component) or none.
-- **`StatusDot` is not used in the sidebar session list.** `SessionCard` shows status as a flat **text label** + tone (`STATUS_TEXT`, e.g. `completed → "Done"`) — no dot, no border, no accent bar. `StatusDot` appears in `TerminalPane` headers (size 6), the `AgentStatusPanel` header / `StatusCard`, and tabs (size 5).
+- The canonical visual map is `tokens.ts::stateToken` (color · solid/hollow · pulse · glow · label tone); `SessionState` is its union. It remains the semantic source for state coloring, but no shipped component renders standalone state pips.
+- `SessionCard` shows status as a flat **text label** + tone (`STATUS_TEXT`, e.g. `completed → "Done"`) — no dot, no border, no accent bar.
 - **Labels are always relative** (`running · 2m 14s`, `awaits you · 4h 12m`, `done · 7h ago`); absolute timestamps appear only on hover.
 - The sidebar **Sessions** tab groups **Active** (any non-terminal pane — `running` / `awaiting` / `idle`, reorderable, first) above **Recent** (terminal — `completed` / `errored`).
 
@@ -167,11 +167,11 @@ The canonical surfaces and their key contracts. Full props live in the code; thi
 
 `AgentStatusPanel` (`280px`, exported `PANEL_WIDTH_PX`) — `bg-surface`, three regions:
 
-1. **Header** — `linear-gradient(180deg, agent.accentDim, transparent 80%)`, 26×26 mono glyph chip, agent short name (13px), `StatusDot`.
+1. **Header** — `linear-gradient(180deg, agent.accentDim, transparent 80%)`, 26×26 mono glyph chip, agent short name (13px).
 2. **Budget zone** (`p-2`) — **`ContextReservoirCard`** renders the context window as a **reservoir**: a water-drop identity chip (**no emoji**), `CONTEXT` label + big %, a 104px `WaterTank` (depth-graded fill, animated dual-wave meniscus, `{windowSize}`/`0` scale ticks, a value pill riding the waterline) and a `{used} tokens · {headroom} left` footer. Fill color is the continuous **`ctxTone`** seafoam→gold→coral→rose HSL sweep keyed to fill — **interpolated, no tiers** (`utils/contextTone.ts`, shared with the rail); dark/light flips via `resolveContextTone`/`tankChrome`; the waves honor `prefers-reduced-motion`. Then **`TokenCache`** (28px % + `Sparkline` + cached/wrote/fresh `StackBar`, tone `≥70` healthy / `≥40` warming / `<40` cold). The two cards share chrome (radius 10, 135° tone wash, tinted border, no elevation) so they read as one family.
-3. **Scroll zone** — `ToolCallSummary` · conditional `LiveActionCard` (the running tool lifted into a **NOW** card — bolt + verb + path + diff + pulsing LIVE chip; opens the diff on click) · `ActivityFeed` (`role=feed`, vertical `outline-variant/40` rail, 10 newest + "N earlier", roving-tabindex) · `FilesChanged` · `TestResults`.
+3. **Scroll zone** — `ToolCallSummary` · conditional `LiveActionCard` (the running tool lifted into a **NOW** card — bolt + verb + path + diff + LIVE chip; opens the diff on click) · `ActivityFeed` (`role=feed`, vertical `outline-variant/40` rail, 10 newest + "N earlier", roving-tabindex) · `FilesChanged` · `TestResults`.
 
-`AgentStatusRail` (`44px`, `RAIL_WIDTH_PX`) — expand chevron + glyph chip + vertical `CONTEXT` + `CACHE` `RailMeter` gauges (the `CONTEXT` gauge fills with the same continuous `ctxTone` sweep as the panel reservoir, so collapsed + expanded agree on the context color; `CACHE` keeps its `≥70`/`≥40`/`<40` tones) + running dot. **`BudgetMetrics`** has three variants: `Subscriber` (5h + Weekly bars), `ApiKey` (Cost / API Time / Tokens), `Fallback` (Tokens only). `CollapsibleSection` is the shared `border-t` section primitive. `PANEL_WIDTH_PX`/`RAIL_WIDTH_PX` are the single source of truth for the shell's width animation.
+`AgentStatusRail` (`44px`, `RAIL_WIDTH_PX`) — expand chevron + glyph chip + vertical `CONTEXT` + `CACHE` `RailMeter` gauges (the `CONTEXT` gauge fills with the same continuous `ctxTone` sweep as the panel reservoir, so collapsed + expanded agree on the context color; `CACHE` keeps its `≥70`/`≥40`/`<40` tones). **`BudgetMetrics`** has three variants: `Subscriber` (5h + Weekly bars), `ApiKey` (Cost / API Time / Tokens), `Fallback` (Tokens only). `CollapsibleSection` is the shared `border-t` section primitive. `PANEL_WIDTH_PX`/`RAIL_WIDTH_PX` are the single source of truth for the shell's width animation.
 
 ### 5.3 Command palette
 
@@ -190,6 +190,62 @@ The canonical surfaces and their key contracts. Full props live in the code; thi
 ### 5.5 GitRefChip
 
 A rounded 22px pill in the pane header / session metadata: optional worktree segment (`account_tree` + name + `›`) then branch (`fork_right` + name); `primary-container` tint normally, two-tone coral (`tertiary`/`error`) when detached. Tooltip lists branch / detached-HEAD / worktree / full cwd verbatim. Props: `branch` (req), `worktree?`, `detached?`.
+
+### 5.5.1 Chip
+
+`Chip` lives at `src/components/Chip.tsx`; import via `@/components/Chip`. It is the shared primitive for compact labels, counters, badges, file/git pills, activity kind tags, and toolbar count pills.
+
+```ts
+interface ChipProps {
+  variant?: 'subtle' | 'tinted' | 'solid'
+  tone?:
+    | 'neutral'
+    | 'primary'
+    | 'secondary'
+    | 'success'
+    | 'error'
+    | 'warning'
+    | 'tertiary'
+    | 'custom'
+  radius?: 'chip' | 'pill' | 'md'
+  size?: 'xs' | 'sm' | 'md' | 'custom'
+  label?: ReactNode
+  leading?: ReactNode
+  leadingIcon?: string
+  trailingCount?: ReactNode
+}
+```
+
+Rules: use `leadingIcon` for Material Symbols, `trailingCount` for small numeric badges, and `custom` only when preserving a specialized existing chip geometry or dynamic agent/accent colors.
+
+### 5.5.2 ProgressBar
+
+`ProgressBar` lives at `src/components/ProgressBar.tsx`; import via `@/components/ProgressBar`. It owns thin single-fill bars and segmented distribution bars.
+
+```ts
+interface ProgressBarProps {
+  label: string
+  value?: number
+  max?: number
+  tone?:
+    | 'neutral'
+    | 'primary'
+    | 'secondary'
+    | 'success'
+    | 'error'
+    | 'warning'
+    | 'tertiary'
+    | 'kimi'
+    | 'custom'
+  height?: 'thin' | 'sm' | 'md'
+  radius?: 'chip' | 'pill'
+  gradient?: boolean
+  decorative?: boolean
+  segments?: readonly ProgressBarSegment[]
+}
+```
+
+Rules: non-decorative bars expose `role="progressbar"` with clamped `aria-valuenow`; segmented decorative bars are for compact visual distributions such as token-cache buckets and test summaries.
 
 ### 5.6 Tooltip
 
@@ -460,7 +516,7 @@ If more density is needed, tighten _content_ (abbreviate, collapse), not the tok
 
 - ❌ **An icon rail / 4th–5th outer zone** — the shell is three zones; the rail was removed (VIM-76).
 - ❌ **A top navigation bar spanning the window** — the only top bar is the 44px in-canvas top-chrome.
-- ❌ **A "Status: Running" string with a dot** — show the `StatusDot` + a relative time. State is semantic.
+- ❌ **A "Status: Running" string with a dot** — standalone status dots are removed; show semantic status text, relative time, and the relevant activity surface.
 - ❌ **Absolute timestamps as first-class data** — always relative; absolute only on hover.
 - ❌ **Emoji as iconography** — Material Symbols Outlined only; emoji is reserved for the `ContextSmiley`.
 - ❌ **Pure `#000`/`#fff`** — always a `surface-*` / `on-surface` token.

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 2        | 0    | 2026-06-16   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 30   | 2026-06-15   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 32   | 2026-06-17   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 60       | 25   | 2026-06-17   |
@@ -96,4 +96,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 3        | 1    | 2026-06-15   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 3        | 2    | 2026-06-15   |
-| [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 2        | 1    | 2026-06-15   |
+| [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 4        | 2    | 2026-06-17   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -96,4 +96,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 3        | 1    | 2026-06-15   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 3        | 2    | 2026-06-15   |
-| [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 4        | 2    | 2026-06-17   |
+| [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 5        | 3    | 2026-06-17   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 2        | 0    | 2026-06-16   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 32   | 2026-06-17   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 67       | 33   | 2026-06-17   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 60       | 25   | 2026-06-17   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 30   | 2026-06-15   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 59       | 24   | 2026-06-15   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 60       | 25   | 2026-06-17   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 22   | 2026-06-08   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,8 +2,8 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-15
-ref_count: 24
+last_updated: 2026-06-17
+ref_count: 25
 ---
 
 # Accessibility
@@ -567,4 +567,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/components/SegmentedControl.tsx`
 - **Finding:** `activeIndex` was computed with `Math.max(0, options.findIndex(...))` and used for both the sidebar active-thumb transform and roving `tabIndex`. When a controlled `value` did not match any option, the control showed the thumb under option 0 and made option 0 tabbable while all buttons exposed `aria-pressed=false`, producing a visual/assistive-state mismatch.
 - **Fix:** Preserved the raw `findIndex` result as `activeIndex`, added a separate `focusIndex = Math.max(0, activeIndex)` used only for keyboard entry (`tabIndex`), and guarded thumb rendering with `activeIndex >= 0` so no thumb appears when no option is semantically selected. Added a regression test verifying the thumb is absent, the first option remains tabbable, and both options report `aria-pressed="false"` for an unmatched value.
+- **Commit:** same commit as this entry
+
+### 54. Segmented ProgressBar exposes `role="progressbar"` without a value
+
+- **Source:** github-codex-connector | PR #509 round 1 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/components/ProgressBar.tsx`
+- **Finding:** When `segments` was supplied and `decorative` was omitted, the component rendered proportional distribution segments but exposed `role="progressbar"` without `aria-valuenow`, which assistive technology treats as an indeterminate loading indicator. The co-located test also asserted the unsafe role, encoding the mismatch as the component's contract.
+- **Fix:** Derived an effective decorative state whenever `segments` is present (`const isDecorative = decorative || segments !== undefined`) so segmented bars are always `aria-hidden` and never emit progressbar semantics. Added a `trackTestId` prop to let tests query the track directly, and rewrote the segmented-bar test to assert `aria-hidden="true"` and the absence of a `progressbar` role.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-prop-contracts.md
+++ b/docs/reviews/patterns/react-prop-contracts.md
@@ -2,8 +2,8 @@
 id: react-prop-contracts
 category: react-patterns
 created: 2026-06-15
-last_updated: 2026-06-15
-ref_count: 1
+last_updated: 2026-06-17
+ref_count: 2
 ---
 
 # React Prop Contracts
@@ -30,4 +30,22 @@ Components that wrap native HTML elements and forward `...rest` props must expli
 - **File:** `src/components/SegmentedControl.tsx`
 - **Finding:** `SegmentedControl` applied `skipActiveReselect` only to the pointer `onClick` handler. Keyboard navigation (`Home`, `End`, arrow keys) in `handleKeyDown` called `onChange` unconditionally, so pressing `Home` while the first option was already active re-fired the callback with the same value.
 - **Fix:** Guarded `handleKeyDown` so `onChange` is skipped when `skipActiveReselect` is true and the computed `nextIndex` equals the current `index`.
+- **Commit:** same commit as this entry
+
+### 3. ProgressBar explicit `data-testid` overrides consumer `data-testid`
+
+- **Source:** local-codex | PR #509 round 2 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/components/ProgressBar.tsx` L176-180
+- **Finding:** The rendered track `<div>` spread `{...rest}` before an explicit `data-testid={trackTestId}`. Any consumer that passed `data-testid` via `...rest` (e.g. `TokenCache`'s empty-stack band) had its test id silently overwritten by `undefined`, breaking the co-located test and removing the element from `screen.getByTestId`.
+- **Fix:** Moved `data-testid={trackTestId}` before `{...rest}` so consumer-supplied `data-testid` takes precedence, while `trackTestId` still provides a default when no consumer id is present.
+- **Commit:** same commit as this entry
+
+### 4. RateLimitBar passes styling classes already owned by ProgressBar
+
+- **Source:** github-claude | PR #509 round 2 | 2026-06-17
+- **Severity:** LOW
+- **File:** `src/features/agent-status/components/RateLimitBar.tsx` L36-43
+- **Finding:** `RateLimitBar` passed `className="h-[3px] w-full overflow-hidden rounded-full bg-surface"`. `ProgressBar` already applies `h-[3px]` via `height="thin"`, `rounded-full` via the default `radius="pill"`, and `w-full overflow-hidden` on its track base; `bg-surface` is also the component's own fallback. The redundant classes leak abstraction internals and mislead future callers about the primitive's responsibilities.
+- **Fix:** Removed the `className` prop from the `ProgressBar` call; the existing `height="thin"`, `tone`, `value`, and `fillTestId` props fully specify the bar.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-prop-contracts.md
+++ b/docs/reviews/patterns/react-prop-contracts.md
@@ -3,7 +3,7 @@ id: react-prop-contracts
 category: react-patterns
 created: 2026-06-15
 last_updated: 2026-06-17
-ref_count: 2
+ref_count: 3
 ---
 
 # React Prop Contracts
@@ -48,4 +48,13 @@ Components that wrap native HTML elements and forward `...rest` props must expli
 - **File:** `src/features/agent-status/components/RateLimitBar.tsx` L36-43
 - **Finding:** `RateLimitBar` passed `className="h-[3px] w-full overflow-hidden rounded-full bg-surface"`. `ProgressBar` already applies `h-[3px]` via `height="thin"`, `rounded-full` via the default `radius="pill"`, and `w-full overflow-hidden` on its track base; `bg-surface` is also the component's own fallback. The redundant classes leak abstraction internals and mislead future callers about the primitive's responsibilities.
 - **Fix:** Removed the `className` prop from the `ProgressBar` call; the existing `height="thin"`, `tone`, `value`, and `fillTestId` props fully specify the bar.
+- **Commit:** same commit as this entry
+
+### 5. `Chip` `tone="success"` conflicts with caller-supplied `text-success-muted`
+
+- **Source:** github-claude | PR #509 round 3 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/components/LiveActionCard.tsx` L95-99
+- **Finding:** `Chip` with `tone="success"` injects `bg-success/[0.12] text-success` from `TONE_CLASS` before the caller-supplied `className`, which ends with `text-success-muted`. Both text-color utilities land on the same element; Tailwind resolves the conflict by compiled CSS source order rather than JSX class order, so the rendered color is non-deterministic from the author's perspective.
+- **Fix:** Changed `tone="success"` to `tone="custom"` so `Chip` does not inject any tone utilities and the caller's explicit `text-success-muted` (plus `bg-success/[0.12]`) remains the sole color source.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-06-17
-ref_count: 32
+ref_count: 33
 ---
 
 # Testing Gaps
@@ -665,4 +665,14 @@ filesystem scope restrictions).
 - **File:** `src/features/diff/components/DiffLegend.test.tsx` L62-78
 - **Finding:** Both indicator-dot tests asserted `greenDot.tagName === 'SPAN'` and `redDot.tagName === 'SPAN'`. The meaningful contract — that each dot carries the correct VCS color class (`bg-vcs-added` / `bg-vcs-deleted`) and is reachable by its `data-testid` — was already covered. The `tagName` check is pure implementation coupling: it would fail on any future refactor that swaps the element type for a semantically equivalent one, even when the visual contract is preserved.
 - **Fix:** Removed the two `tagName` assertions. The remaining `toHaveClass('bg-vcs-added')` / `toHaveClass('bg-vcs-deleted')` assertions plus `getByTestId` fully describe the contract.
+- **Commit:** same commit as this entry
+
+### 67. Production-used gradient rendering path in shared primitive lacks test coverage
+
+- **Source:** github-codex-connector | PR #509 round 3 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/components/ProgressBar.test.tsx` L46-L50
+- **Finding:** `ProgressBar` switches fill classes when `gradient` is true, and the PR uses that branch in `CommitInfoPanel` for context memory and token progress bars. Existing tests covered clamping, semantic mode, segmented mode, and decorative mode, but not the gradient lookup path, so a future token/class regression could make production fills visually disappear without test signal.
+- **Fix:** Added a focused test that renders `ProgressBar` with `gradient` and a production-used `secondary` tone, then asserts the fill element receives `bg-gradient-to-r`.
+- **Code-review heuristic:** When a PR centralizes rendering into a new shared primitive and production consumers exercise a non-default branch, add at least one targeted test for that branch. Simple lookup tables are still worth covering because theme-token or primitive refactors can silently break the mapped class.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-15
-ref_count: 31
+last_updated: 2026-06-17
+ref_count: 32
 ---
 
 # Testing Gaps
@@ -656,4 +656,13 @@ filesystem scope restrictions).
 - **File:** `src/features/agent-status/hooks/useReservoirFlow.test.tsx`
 - **Finding:** `makeMql` returned `addEventListener`/`removeEventListener` as `vi.fn()` stubs that recorded nothing and fired nothing, so the hook's `onMqlChange` handler was unreachable in tests. The unmount test also only asserted pointer-event cleanup, never `mql.removeEventListener('change', onMqlChange)`.
 - **Fix:** Upgraded the mock to a `MockMql` helper that captures listeners and exposes a `fire()` method, then added a reduced-motion-toggle test and a cleanup assertion for the `'change'` listener. (Carried forward across the swell-model rewrite of the hook.)
+- **Commit:** same commit as this entry
+
+### 66. DiffLegend tests assert tagName instead of behavioral contract
+
+- **Source:** github-claude | PR #509 round 2 | 2026-06-17
+- **Severity:** LOW
+- **File:** `src/features/diff/components/DiffLegend.test.tsx` L62-78
+- **Finding:** Both indicator-dot tests asserted `greenDot.tagName === 'SPAN'` and `redDot.tagName === 'SPAN'`. The meaningful contract — that each dot carries the correct VCS color class (`bg-vcs-added` / `bg-vcs-deleted`) and is reachable by its `data-testid` — was already covered. The `tagName` check is pure implementation coupling: it would fail on any future refactor that swaps the element type for a semantically equivalent one, even when the visual contract is preserved.
+- **Fix:** Removed the two `tagName` assertions. The remaining `toHaveClass('bg-vcs-added')` / `toHaveClass('bg-vcs-deleted')` assertions plus `getByTestId` fully describe the contract.
 - **Commit:** same commit as this entry

--- a/src/components/Chip.test.tsx
+++ b/src/components/Chip.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { expect, test } from 'vitest'
+import { Chip } from './Chip'
+
+test('renders a text label', () => {
+  render(<Chip label="Read" />)
+
+  expect(screen.getByText('Read')).toBeInTheDocument()
+})
+
+test('renders a material leading icon as aria-hidden', () => {
+  render(<Chip leadingIcon="description" label="File" />)
+
+  const icon = screen.getByText('description')
+  expect(icon).toHaveClass('material-symbols-outlined')
+  expect(icon).toHaveAttribute('aria-hidden', 'true')
+})
+
+test('renders a trailing count with mono emphasis', () => {
+  render(<Chip label="Edit" trailingCount={7} />)
+
+  expect(screen.getByText('7')).toHaveClass('font-mono', 'font-semibold')
+})
+
+test('applies variant, tone, radius, and size classes', () => {
+  render(
+    <Chip
+      data-testid="chip"
+      variant="tinted"
+      tone="primary"
+      radius="pill"
+      size="xs"
+      label="Live"
+    />
+  )
+
+  const chip = screen.getByTestId('chip')
+  expect(chip).toHaveClass('rounded-full')
+  expect(chip).toHaveClass('bg-primary/10')
+  expect(chip).toHaveClass('text-primary')
+  expect(chip).toHaveClass('text-[9px]')
+})
+
+test('renders custom children instead of the label shortcut', () => {
+  render(
+    <Chip label="Hidden">
+      <span>Custom chip</span>
+    </Chip>
+  )
+
+  expect(screen.getByText('Custom chip')).toBeInTheDocument()
+  expect(screen.queryByText('Hidden')).not.toBeInTheDocument()
+})

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,0 +1,168 @@
+import type { HTMLAttributes, ReactElement, ReactNode, Ref } from 'react'
+
+type ChipVariant = 'subtle' | 'tinted' | 'solid'
+type ChipTone =
+  | 'neutral'
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'tertiary'
+  | 'custom'
+type ChipRadius = 'chip' | 'pill' | 'md'
+type ChipSize = 'xs' | 'sm' | 'md' | 'custom'
+
+export interface ChipVariantProps {
+  variant?: ChipVariant
+  tone?: ChipTone
+  radius?: ChipRadius
+  size?: ChipSize
+}
+
+const BASE_CLASS = 'inline-flex shrink-0 items-center whitespace-nowrap'
+
+const VARIANT_CLASS: Record<ChipVariant, string> = {
+  subtle: '',
+  tinted: 'ring-1 ring-inset',
+  solid: '',
+}
+
+const RADIUS_CLASS: Record<ChipRadius, string> = {
+  chip: 'rounded-chip',
+  pill: 'rounded-full',
+  md: 'rounded-md',
+}
+
+const SIZE_CLASS: Record<ChipSize, string> = {
+  xs: 'gap-1 px-1.5 py-px text-[9px] leading-none',
+  sm: 'gap-1.5 px-2 py-0.5 text-[10px] leading-none',
+  md: 'gap-1.5 px-2.5 py-1 text-xs leading-none',
+  custom: '',
+}
+
+const TONE_CLASS: Record<ChipVariant, Record<ChipTone, string>> = {
+  subtle: {
+    neutral: 'bg-surface-container-high text-on-surface-variant',
+    primary: 'bg-primary/10 text-primary',
+    secondary: 'bg-secondary/[0.12] text-secondary',
+    success: 'bg-success/[0.12] text-success',
+    error: 'bg-error/[0.12] text-error',
+    warning: 'bg-warning/[0.12] text-warning',
+    tertiary: 'bg-tertiary/[0.12] text-tertiary',
+    custom: '',
+  },
+  tinted: {
+    neutral:
+      'bg-surface-container-lowest/50 text-on-surface-variant ring-outline-variant/30',
+    primary: 'bg-primary/10 text-primary ring-primary/20',
+    secondary: 'bg-secondary/[0.08] text-secondary ring-secondary/[0.16]',
+    success: 'bg-success/[0.08] text-success ring-success/20',
+    error: 'bg-error/[0.08] text-error ring-error/20',
+    warning: 'bg-warning/[0.08] text-warning ring-warning/20',
+    tertiary: 'bg-tertiary/[0.08] text-tertiary ring-tertiary/20',
+    custom: '',
+  },
+  solid: {
+    neutral: 'bg-surface-container-highest text-on-surface',
+    primary: 'bg-primary text-on-primary',
+    secondary: 'bg-secondary text-surface',
+    success: 'bg-success text-surface',
+    error: 'bg-error text-surface',
+    warning: 'bg-warning text-surface',
+    tertiary: 'bg-tertiary text-surface',
+    custom: '',
+  },
+}
+
+const classes = (...parts: (string | undefined)[]): string =>
+  parts
+    .filter((part): part is string => part !== undefined && part !== '')
+    .join(' ')
+
+const chipClassName = ({
+  variant,
+  tone,
+  radius,
+  size,
+  className,
+}: Required<ChipVariantProps> & { className?: string }): string =>
+  classes(
+    BASE_CLASS,
+    VARIANT_CLASS[variant],
+    TONE_CLASS[variant][tone],
+    RADIUS_CLASS[radius],
+    SIZE_CLASS[size],
+    className
+  )
+
+interface ChipProps
+  extends ChipVariantProps, Omit<HTMLAttributes<HTMLSpanElement>, 'className'> {
+  label?: ReactNode
+  leading?: ReactNode
+  leadingIcon?: string
+  trailingCount?: ReactNode
+  className?: string
+  iconClassName?: string
+  labelClassName?: string
+  countClassName?: string
+  ref?: Ref<HTMLSpanElement>
+}
+
+export const Chip = ({
+  variant = 'subtle',
+  tone = 'neutral',
+  radius = 'chip',
+  size = 'sm',
+  label = undefined,
+  leading = undefined,
+  leadingIcon = undefined,
+  trailingCount = undefined,
+  className = undefined,
+  iconClassName = undefined,
+  labelClassName = undefined,
+  countClassName = undefined,
+  children = undefined,
+  ref = undefined,
+  ...rest
+}: ChipProps): ReactElement => {
+  const leadingNode =
+    leading ??
+    (leadingIcon !== undefined ? (
+      <span
+        aria-hidden="true"
+        className={
+          iconClassName ?? 'material-symbols-outlined text-[1.1em] leading-none'
+        }
+      >
+        {leadingIcon}
+      </span>
+    ) : null)
+
+  return (
+    <span
+      {...rest}
+      ref={ref}
+      className={chipClassName({ variant, tone, radius, size, className })}
+    >
+      {children ?? (
+        <>
+          {leadingNode}
+          {label !== undefined && (
+            <span className={labelClassName}>{label}</span>
+          )}
+          {trailingCount !== undefined && (
+            <span
+              className={
+                countClassName ??
+                'shrink-0 font-mono font-semibold leading-none'
+              }
+            >
+              {trailingCount}
+            </span>
+          )}
+        </>
+      )}
+    </span>
+  )
+}

--- a/src/components/ProgressBar.test.tsx
+++ b/src/components/ProgressBar.test.tsx
@@ -50,7 +50,15 @@ test('can render decorative loading bars without progressbar role', () => {
 })
 
 test('renders gradient fills for production-used tones', () => {
-  render(<ProgressBar label="Memory" value={60} tone="secondary" gradient fillTestId="fill" />)
+  render(
+    <ProgressBar
+      label="Memory"
+      value={60}
+      tone="secondary"
+      gradient
+      fillTestId="fill"
+    />
+  )
 
   expect(screen.getByTestId('fill')).toHaveClass('bg-gradient-to-r')
 })

--- a/src/components/ProgressBar.test.tsx
+++ b/src/components/ProgressBar.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { expect, test } from 'vitest'
+import { ProgressBar } from './ProgressBar'
+
+test('renders progressbar semantics with a clamped rounded value', () => {
+  render(<ProgressBar label="Usage" value={42.6} />)
+
+  const bar = screen.getByRole('progressbar', { name: 'Usage' })
+  expect(bar).toHaveAttribute('aria-valuenow', '43')
+  expect(bar).toHaveAttribute('aria-valuemin', '0')
+  expect(bar).toHaveAttribute('aria-valuemax', '100')
+})
+
+test('clamps the fill width to the maximum', () => {
+  render(<ProgressBar label="Over" value={150} fillTestId="fill" />)
+
+  expect(screen.getByTestId('fill')).toHaveStyle({ width: '100%' })
+})
+
+test('clamps negative fill width to zero', () => {
+  render(<ProgressBar label="Under" value={-10} fillTestId="fill" />)
+
+  expect(screen.getByTestId('fill')).toHaveStyle({ width: '0%' })
+})
+
+test('renders segmented bars as proportional widths', () => {
+  render(
+    <ProgressBar
+      label="Buckets"
+      segments={[
+        { value: 3, testId: 'cached', className: 'bg-success' },
+        { value: 1, testId: 'fresh', className: 'bg-warning' },
+      ]}
+    />
+  )
+
+  expect(screen.getByTestId('cached')).toHaveStyle({ width: '75%' })
+  expect(screen.getByTestId('fresh')).toHaveStyle({ width: '25%' })
+})
+
+test('can render decorative loading bars without progressbar role', () => {
+  render(<ProgressBar label="Loading usage" value={100} decorative />)
+
+  expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+})

--- a/src/components/ProgressBar.test.tsx
+++ b/src/components/ProgressBar.test.tsx
@@ -34,6 +34,9 @@ test('renders segmented bars as proportional widths', () => {
     />
   )
 
+  expect(screen.getByRole('progressbar', { name: 'Buckets' })).toHaveClass(
+    'flex'
+  )
   expect(screen.getByTestId('cached')).toHaveStyle({ width: '75%' })
   expect(screen.getByTestId('fresh')).toHaveStyle({ width: '25%' })
 })

--- a/src/components/ProgressBar.test.tsx
+++ b/src/components/ProgressBar.test.tsx
@@ -23,10 +23,11 @@ test('clamps negative fill width to zero', () => {
   expect(screen.getByTestId('fill')).toHaveStyle({ width: '0%' })
 })
 
-test('renders segmented bars as proportional widths', () => {
+test('renders segmented bars as decorative proportional widths', () => {
   render(
     <ProgressBar
       label="Buckets"
+      trackTestId="bucket-track"
       segments={[
         { value: 3, testId: 'cached', className: 'bg-success' },
         { value: 1, testId: 'fresh', className: 'bg-warning' },
@@ -34,11 +35,12 @@ test('renders segmented bars as proportional widths', () => {
     />
   )
 
-  expect(screen.getByRole('progressbar', { name: 'Buckets' })).toHaveClass(
-    'flex'
-  )
+  const track = screen.getByTestId('bucket-track')
+  expect(track).toHaveAttribute('aria-hidden', 'true')
+  expect(track).toHaveClass('flex')
   expect(screen.getByTestId('cached')).toHaveStyle({ width: '75%' })
   expect(screen.getByTestId('fresh')).toHaveStyle({ width: '25%' })
+  expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
 })
 
 test('can render decorative loading bars without progressbar role', () => {

--- a/src/components/ProgressBar.test.tsx
+++ b/src/components/ProgressBar.test.tsx
@@ -48,3 +48,9 @@ test('can render decorative loading bars without progressbar role', () => {
 
   expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
 })
+
+test('renders gradient fills for production-used tones', () => {
+  render(<ProgressBar label="Memory" value={60} tone="secondary" gradient fillTestId="fill" />)
+
+  expect(screen.getByTestId('fill')).toHaveClass('bg-gradient-to-r')
+})

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -174,9 +174,9 @@ export const ProgressBar = ({
 
   return (
     <div
+      data-testid={trackTestId}
       {...rest}
       {...ariaProps}
-      data-testid={trackTestId}
       style={style}
       className={trackClassName({
         height,

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -115,6 +115,7 @@ interface ProgressBarProps
   fillClassName?: string
   fillStyle?: CSSProperties
   fillTestId?: string
+  trackTestId?: string
 }
 
 const boundedValue = (value: number, max: number): number => {
@@ -148,6 +149,7 @@ export const ProgressBar = ({
   fillClassName = undefined,
   fillStyle = undefined,
   fillTestId = undefined,
+  trackTestId = undefined,
   ...rest
 }: ProgressBarProps): ReactElement => {
   const safeMax = max > 0 ? max : 100
@@ -155,7 +157,9 @@ export const ProgressBar = ({
   const clampedValue =
     value === undefined ? undefined : boundedValue(value, safeMax)
 
-  const ariaProps = decorative
+  const isDecorative = decorative || segments !== undefined
+
+  const ariaProps = isDecorative
     ? { 'aria-hidden': true }
     : {
         role: 'progressbar',
@@ -172,6 +176,7 @@ export const ProgressBar = ({
     <div
       {...rest}
       {...ariaProps}
+      data-testid={trackTestId}
       style={style}
       className={trackClassName({
         height,

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -19,7 +19,7 @@ export interface ProgressBarVariantProps {
   radius?: ProgressBarRadius
 }
 
-const TRACK_BASE_CLASS = 'w-full overflow-hidden'
+const TRACK_BASE_CLASS = 'flex w-full overflow-hidden'
 
 const HEIGHT_CLASS: Record<ProgressBarHeight, string> = {
   thin: 'h-[3px]',

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,216 @@
+import type { CSSProperties, HTMLAttributes, ReactElement } from 'react'
+
+type ProgressBarHeight = 'thin' | 'sm' | 'md'
+type ProgressBarRadius = 'chip' | 'pill'
+
+export type ProgressBarTone =
+  | 'neutral'
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'tertiary'
+  | 'kimi'
+  | 'custom'
+
+export interface ProgressBarVariantProps {
+  height?: ProgressBarHeight
+  radius?: ProgressBarRadius
+}
+
+const TRACK_BASE_CLASS = 'w-full overflow-hidden'
+
+const HEIGHT_CLASS: Record<ProgressBarHeight, string> = {
+  thin: 'h-[3px]',
+  sm: 'h-1.5',
+  md: 'h-2',
+}
+
+const RADIUS_CLASS: Record<ProgressBarRadius, string> = {
+  chip: 'rounded-chip',
+  pill: 'rounded-full',
+}
+
+const SOLID_FILL_CLASS: Record<ProgressBarTone, string> = {
+  neutral: 'bg-surface-container-highest',
+  primary: 'bg-primary-container',
+  secondary: 'bg-secondary',
+  success: 'bg-success',
+  error: 'bg-error',
+  warning: 'bg-warning',
+  tertiary: 'bg-tertiary',
+  kimi: 'bg-[var(--color-agent-kimi-accent)]',
+  custom: '',
+}
+
+const GRADIENT_FILL_CLASS: Record<ProgressBarTone, string> = {
+  neutral:
+    'bg-gradient-to-r from-surface-container-high to-surface-container-highest',
+  primary: 'bg-gradient-to-r from-primary to-primary-container',
+  secondary: 'bg-gradient-to-r from-secondary to-secondary-container',
+  success: 'bg-gradient-to-r from-success to-success-muted',
+  error: 'bg-gradient-to-r from-error to-tertiary',
+  warning: 'bg-gradient-to-r from-warning to-tertiary',
+  tertiary: 'bg-gradient-to-r from-tertiary to-error',
+  kimi: 'bg-gradient-to-r from-[var(--color-agent-kimi-accent)] to-[color-mix(in_srgb,var(--color-agent-kimi-accent)_70%,var(--color-surface-container))]',
+  custom: '',
+}
+
+const classes = (...parts: (string | undefined)[]): string =>
+  parts
+    .filter((part): part is string => part !== undefined && part !== '')
+    .join(' ')
+
+const trackClassName = ({
+  height,
+  radius,
+  className,
+}: Required<ProgressBarVariantProps> & { className?: string }): string =>
+  classes(
+    TRACK_BASE_CLASS,
+    HEIGHT_CLASS[height],
+    RADIUS_CLASS[radius],
+    className
+  )
+
+const fillClassNameFor = ({
+  radius,
+  tone,
+  gradient,
+  className,
+}: {
+  radius: ProgressBarRadius
+  tone: ProgressBarTone
+  gradient: boolean
+  className?: string
+}): string =>
+  classes(
+    'h-full',
+    RADIUS_CLASS[radius],
+    gradient ? GRADIENT_FILL_CLASS[tone] : SOLID_FILL_CLASS[tone],
+    className
+  )
+
+export interface ProgressBarSegment {
+  value: number
+  className?: string
+  style?: CSSProperties
+  testId?: string
+}
+
+interface ProgressBarProps
+  extends
+    ProgressBarVariantProps,
+    Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'className' | 'style'> {
+  label: string
+  value?: number
+  max?: number
+  tone?: ProgressBarTone
+  gradient?: boolean
+  decorative?: boolean
+  segments?: readonly ProgressBarSegment[]
+  className?: string
+  style?: CSSProperties
+  fillClassName?: string
+  fillStyle?: CSSProperties
+  fillTestId?: string
+}
+
+const boundedValue = (value: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.min(Math.max(value, 0), max)
+}
+
+const formatPercent = (value: number): string => `${Number(value.toFixed(4))}%`
+
+const percentForValue = (value: number, max: number): number =>
+  max > 0 ? (boundedValue(value, max) / max) * 100 : 0
+
+const segmentTotal = (segments: readonly ProgressBarSegment[]): number =>
+  segments.reduce((sum, segment) => sum + Math.max(segment.value, 0), 0)
+
+export const ProgressBar = ({
+  label,
+  value = undefined,
+  max = 100,
+  tone = 'primary',
+  gradient = false,
+  decorative = false,
+  segments = undefined,
+  height = 'thin',
+  radius = 'pill',
+  className = undefined,
+  style = undefined,
+  fillClassName = undefined,
+  fillStyle = undefined,
+  fillTestId = undefined,
+  ...rest
+}: ProgressBarProps): ReactElement => {
+  const safeMax = max > 0 ? max : 100
+
+  const clampedValue =
+    value === undefined ? undefined : boundedValue(value, safeMax)
+
+  const ariaProps = decorative
+    ? { 'aria-hidden': true }
+    : {
+        role: 'progressbar',
+        'aria-label': label,
+        'aria-valuemin': 0,
+        'aria-valuemax': safeMax,
+        'aria-valuenow':
+          clampedValue === undefined ? undefined : Math.round(clampedValue),
+      }
+
+  const total = segments === undefined ? 0 : segmentTotal(segments)
+
+  return (
+    <div
+      {...rest}
+      {...ariaProps}
+      style={style}
+      className={trackClassName({
+        height,
+        radius,
+        className: className ?? 'bg-surface',
+      })}
+    >
+      {segments !== undefined ? (
+        segments.map((segment, index) => {
+          const width =
+            total > 0 ? (Math.max(segment.value, 0) / total) * 100 : 0
+
+          return (
+            <div
+              key={segment.testId ?? index}
+              data-testid={segment.testId}
+              className={`h-full ${segment.className ?? ''}`}
+              style={{
+                width: formatPercent(width),
+                ...segment.style,
+              }}
+            />
+          )
+        })
+      ) : (
+        <div
+          data-testid={fillTestId}
+          className={fillClassNameFor({
+            radius,
+            tone,
+            gradient,
+            className: fillClassName,
+          })}
+          style={{
+            width: formatPercent(percentForValue(value ?? 0, safeMax)),
+            ...fillStyle,
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/features/agent-status/components/ActivityEvent.tsx
+++ b/src/features/agent-status/components/ActivityEvent.tsx
@@ -444,7 +444,7 @@ const StatusChips = ({ event }: StatusChipsProps): ReactElement | null => {
           tone="custom"
           size="custom"
           radius="md"
-          className={`inline-block rounded-md px-2 py-0.5 text-[9px] font-bold uppercase ${palette}`}
+          className={`rounded-md px-2 py-0.5 text-[9px] font-bold uppercase ${palette}`}
         >
           {text}
         </Chip>

--- a/src/features/agent-status/components/ActivityEvent.tsx
+++ b/src/features/agent-status/components/ActivityEvent.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
   type Ref,
 } from 'react'
+import { Chip } from '@/components/Chip'
 import { IconButton } from '@/components/IconButton'
 import { Tooltip } from '@/components/Tooltip'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
@@ -195,9 +196,14 @@ const FilePathChip = ({
 }
 
 const Kbd = ({ children }: { children: ReactNode }): ReactElement => (
-  <span className="inline-flex items-center justify-center rounded border border-outline-variant/35 bg-[color-mix(in_srgb,var(--color-surface-container-lowest)_50%,transparent)] px-1 py-px font-mono text-[9.5px] text-syn-comment">
+  <Chip
+    tone="custom"
+    size="custom"
+    radius="chip"
+    className="justify-center rounded border border-outline-variant/35 bg-[color-mix(in_srgb,var(--color-surface-container-lowest)_50%,transparent)] px-1 py-px font-mono text-[9.5px] text-syn-comment"
+  >
     {children}
-  </span>
+  </Chip>
 )
 
 // Shared relative-time string for the feed row, the tooltip header, and the
@@ -285,22 +291,20 @@ export const ActivityTooltipContent = ({
       {/* Header */}
       <div className="flex items-center gap-2 px-3 pt-2.5 pb-2">
         {/* Kind chip */}
-        <div
-          className="inline-flex h-5 items-center gap-[5px] rounded-[5px] border px-2 pl-1.5 font-mono text-[10px] font-semibold lowercase tracking-[0.06em]"
+        <Chip
+          tone="custom"
+          size="custom"
+          radius="chip"
+          leadingIcon={KIND_ICON[event.kind]}
+          label={kindLabel}
+          iconClassName="material-symbols-outlined text-[11px]"
+          className="h-5 gap-[5px] rounded-[5px] border px-2 pl-1.5 font-mono text-[10px] font-semibold lowercase tracking-[0.06em]"
           style={{
             backgroundColor: `color-mix(in srgb, ${accent} 12%, transparent)`,
             borderColor: `color-mix(in srgb, ${accent} 24%, transparent)`,
             color: accent,
           }}
-        >
-          <span
-            className="material-symbols-outlined text-[11px]"
-            aria-hidden="true"
-          >
-            {KIND_ICON[event.kind]}
-          </span>
-          {kindLabel}
-        </div>
+        />
 
         {/* Meta pips */}
         <Pip>
@@ -436,11 +440,14 @@ const StatusChips = ({ event }: StatusChipsProps): ReactElement | null => {
 
     return (
       <div className="mt-0.5">
-        <span
+        <Chip
+          tone="custom"
+          size="custom"
+          radius="md"
           className={`inline-block rounded-md px-2 py-0.5 text-[9px] font-bold uppercase ${palette}`}
         >
           {text}
-        </span>
+        </Chip>
       </div>
     )
   }

--- a/src/features/agent-status/components/KimiUsageGate.tsx
+++ b/src/features/agent-status/components/KimiUsageGate.tsx
@@ -1,5 +1,6 @@
 // cspell:ignore Couldn
 import { useCallback, useEffect, useState, type ReactElement } from 'react'
+import { ProgressBar } from '@/components/ProgressBar'
 import { Tooltip } from '@/components/Tooltip'
 import { useKimiUsageConsent } from '../hooks/useKimiUsageConsent'
 import { RateLimitBar } from './RateLimitBar'
@@ -155,7 +156,15 @@ const SkeletonBar = ({ label }: { label: string }): ReactElement => (
     <span className="text-[10px] font-bold uppercase tracking-[0.08em] text-on-surface-muted">
       {label}
     </span>
-    <div className="h-[3px] w-full animate-pulse rounded-full bg-surface-container-highest" />
+    <ProgressBar
+      label={`${label} loading`}
+      value={100}
+      tone="custom"
+      height="thin"
+      decorative
+      className="bg-transparent"
+      fillClassName="animate-pulse bg-surface-container-highest"
+    />
   </div>
 )
 

--- a/src/features/agent-status/components/LiveActionCard.tsx
+++ b/src/features/agent-status/components/LiveActionCard.tsx
@@ -93,7 +93,7 @@ export const LiveActionCard = ({
         ) : null}
         <span className="flex-1" />
         <Chip
-          tone="success"
+          tone="custom"
           radius="pill"
           size="custom"
           className="gap-1 rounded-full bg-success/[0.12] px-1.5 py-px font-mono text-[9px] font-semibold uppercase tracking-[0.06em] text-success-muted"

--- a/src/features/agent-status/components/LiveActionCard.tsx
+++ b/src/features/agent-status/components/LiveActionCard.tsx
@@ -1,4 +1,5 @@
 import { type KeyboardEvent, type ReactElement } from 'react'
+import { Chip } from '@/components/Chip'
 import { Tooltip } from '@/components/Tooltip'
 import {
   ACTIVITY_CARD_SURFACE,
@@ -91,9 +92,14 @@ export const LiveActionCard = ({
           </>
         ) : null}
         <span className="flex-1" />
-        <span className="inline-flex items-center gap-1 rounded-full bg-success/[0.12] px-1.5 py-px font-mono text-[9px] font-semibold uppercase tracking-[0.06em] text-success-muted">
+        <Chip
+          tone="success"
+          radius="pill"
+          size="custom"
+          className="gap-1 rounded-full bg-success/[0.12] px-1.5 py-px font-mono text-[9px] font-semibold uppercase tracking-[0.06em] text-success-muted"
+        >
           LIVE
-        </span>
+        </Chip>
       </div>
     </div>
   )

--- a/src/features/agent-status/components/RateLimitBar.tsx
+++ b/src/features/agent-status/components/RateLimitBar.tsx
@@ -39,7 +39,6 @@ export const RateLimitBar = ({
       tone={FILL_TONE[accent]}
       height="thin"
       fillTestId="rate-limit-bar-fill"
-      className="h-[3px] w-full overflow-hidden rounded-full bg-surface"
     />
   </div>
 )

--- a/src/features/agent-status/components/RateLimitBar.tsx
+++ b/src/features/agent-status/components/RateLimitBar.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react'
+import { ProgressBar, type ProgressBarTone } from '@/components/ProgressBar'
 
 // `kimi` recolors the fill to the kimi peach accent for the plan-usage gate;
 // `primary` (default) keeps the Claude/Codex look unchanged.
@@ -10,9 +11,9 @@ export interface RateLimitBarProps {
   accent?: RateLimitBarAccent
 }
 
-const FILL_CLASS: Record<RateLimitBarAccent, string> = {
-  primary: 'bg-primary-container',
-  kimi: 'bg-[var(--color-agent-kimi-accent)]',
+const FILL_TONE: Record<RateLimitBarAccent, ProgressBarTone> = {
+  primary: 'primary',
+  kimi: 'kimi',
 }
 
 // Label + percentage + a thin progress bar. Shared by the agent-status budget
@@ -32,19 +33,13 @@ export const RateLimitBar = ({
         {Math.round(percentage)}%
       </span>
     </div>
-    <div
-      role="progressbar"
-      aria-label={label}
-      aria-valuenow={Math.min(Math.max(Math.round(percentage), 0), 100)}
-      aria-valuemin={0}
-      aria-valuemax={100}
+    <ProgressBar
+      label={label}
+      value={percentage}
+      tone={FILL_TONE[accent]}
+      height="thin"
+      fillTestId="rate-limit-bar-fill"
       className="h-[3px] w-full overflow-hidden rounded-full bg-surface"
-    >
-      <div
-        data-testid="rate-limit-bar-fill"
-        className={`h-full rounded-full ${FILL_CLASS[accent]}`}
-        style={{ width: `${Math.min(percentage, 100)}%` }}
-      />
-    </div>
+    />
   </div>
 )

--- a/src/features/agent-status/components/TestResults.tsx
+++ b/src/features/agent-status/components/TestResults.tsx
@@ -1,5 +1,6 @@
 import { useId, useState } from 'react'
 import type { ReactElement } from 'react'
+import { ProgressBar } from '@/components/ProgressBar'
 import type { TestGroup, TestRunSnapshot } from '../types'
 
 interface TestResultsProps {
@@ -138,18 +139,17 @@ const ProportionalBar = ({
   }
 
   return (
-    <div className="flex h-[3px] w-full overflow-hidden rounded-full">
-      {passed > 0 && (
-        <div style={{ flexGrow: passed }} className="bg-success" />
-      )}
-      {failed > 0 && <div style={{ flexGrow: failed }} className="bg-error" />}
-      {skipped > 0 && (
-        <div
-          style={{ flexGrow: skipped }}
-          className="bg-on-surface-variant/40"
-        />
-      )}
-    </div>
+    <ProgressBar
+      label="Test result summary"
+      height="thin"
+      decorative
+      className="flex bg-transparent"
+      segments={[
+        { value: passed, className: 'bg-success' },
+        { value: failed, className: 'bg-error' },
+        { value: skipped, className: 'bg-on-surface-variant/40' },
+      ]}
+    />
   )
 }
 

--- a/src/features/agent-status/components/TokenCache.tsx
+++ b/src/features/agent-status/components/TokenCache.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactElement } from 'react'
+import { ProgressBar } from '@/components/ProgressBar'
 import type { CurrentUsageState } from '../types'
 import {
   cacheBuckets,
@@ -58,9 +59,13 @@ const StackBar = ({
 }): ReactElement => {
   if (total === 0) {
     return (
-      <div
+      <ProgressBar
+        label="Token cache bucket distribution"
+        value={0}
+        height="md"
+        decorative
         data-testid="token-cache-stack-empty"
-        className="h-2 w-full rounded-full"
+        className="rounded-full"
         style={{
           background:
             'color-mix(in srgb, var(--color-outline-variant) 25%, transparent)',
@@ -70,43 +75,45 @@ const StackBar = ({
   }
 
   const cPct = (cached / total) * 100
-  const wPct = (wrote / total) * 100
-  const fPct = (fresh / total) * 100
   const cTone = cachedShareHex(cPct)
 
   return (
-    <div
-      className="flex h-2 w-full overflow-hidden rounded-full"
+    <ProgressBar
+      label="Token cache bucket distribution"
+      height="md"
+      decorative
+      className="flex rounded-full"
       style={{
         background:
           'color-mix(in srgb, var(--color-surface-container-lowest) 60%, transparent)',
         border:
           '1px solid color-mix(in srgb, var(--color-outline-variant) 25%, transparent)',
       }}
-    >
-      <div
-        data-testid="token-cache-stack-cached"
-        style={{
-          width: `${cPct}%`,
-          background: `linear-gradient(90deg, ${cTone}, color-mix(in srgb, ${cTone} 80%, transparent))`,
-          boxShadow: `inset 0 0 6px color-mix(in srgb, ${cTone} 33%, transparent)`,
-        }}
-      />
-      <div
-        data-testid="token-cache-stack-wrote"
-        style={{
-          width: `${wPct}%`,
-          background: WROTE_STACK_GRADIENT,
-        }}
-      />
-      <div
-        data-testid="token-cache-stack-fresh"
-        style={{
-          width: `${fPct}%`,
-          background: FRESH_STACK_GRADIENT,
-        }}
-      />
-    </div>
+      segments={[
+        {
+          value: cached,
+          testId: 'token-cache-stack-cached',
+          style: {
+            background: `linear-gradient(90deg, ${cTone}, color-mix(in srgb, ${cTone} 80%, transparent))`,
+            boxShadow: `inset 0 0 6px color-mix(in srgb, ${cTone} 33%, transparent)`,
+          },
+        },
+        {
+          value: wrote,
+          testId: 'token-cache-stack-wrote',
+          style: {
+            background: WROTE_STACK_GRADIENT,
+          },
+        },
+        {
+          value: fresh,
+          testId: 'token-cache-stack-fresh',
+          style: {
+            background: FRESH_STACK_GRADIENT,
+          },
+        },
+      ]}
+    />
   )
 }
 

--- a/src/features/agent-status/components/ToolCallSummary.tsx
+++ b/src/features/agent-status/components/ToolCallSummary.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react'
+import { Chip } from '@/components/Chip'
 import { Tooltip } from '@/components/Tooltip'
 import { CollapsibleSection } from './CollapsibleSection'
 import type { ActiveToolCall } from '../types'
@@ -22,14 +23,16 @@ export const ToolCallSummary = ({
         <div className="mb-2 flex flex-wrap gap-1">
           {sortedChips.map(([name, count]) => (
             <Tooltip key={name} content={name}>
-              <span className="inline-flex max-w-[10rem] items-center gap-1.5 rounded-md bg-surface-container-high px-2 py-1">
-                <span className="truncate text-[10px] leading-none text-on-surface-variant">
-                  {name}
-                </span>
-                <span className="shrink-0 font-mono text-[10px] font-semibold leading-none text-primary">
-                  {count}
-                </span>
-              </span>
+              <Chip
+                label={name}
+                trailingCount={count}
+                tone="neutral"
+                radius="md"
+                size="custom"
+                labelClassName="truncate text-[10px] leading-none text-on-surface-variant"
+                countClassName="shrink-0 font-mono text-[10px] font-semibold leading-none text-primary"
+                className="max-w-[10rem] gap-1.5 rounded-md bg-surface-container-high px-2 py-1"
+              />
             </Tooltip>
           ))}
         </div>

--- a/src/features/diff/components/CommitInfoPanel.tsx
+++ b/src/features/diff/components/CommitInfoPanel.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from 'react'
+import { Chip } from '@/components/Chip'
 import { IconButton } from '@/components/IconButton'
+import { ProgressBar } from '@/components/ProgressBar'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
 
 export interface CommitInfoPanelProps {
@@ -100,9 +102,14 @@ const CommitInfoPanel = ({
 
         {/* Commit Hash Badge */}
         <div>
-          <span className="font-label bg-surface-container-highest px-2 py-1 rounded text-xs text-on-surface">
+          <Chip
+            tone="custom"
+            size="custom"
+            radius="chip"
+            className="rounded bg-surface-container-highest px-2 py-1 font-label text-xs text-on-surface"
+          >
             {commitHash}
-          </span>
+          </Chip>
         </div>
 
         {/* Commit Message */}
@@ -137,12 +144,14 @@ const CommitInfoPanel = ({
               <span>Context Memory</span>
               <span>{contextMemoryPercent}%</span>
             </div>
-            <div className="h-1.5 w-full bg-surface-container-highest rounded-full overflow-hidden">
-              <div
-                className="h-full bg-gradient-to-r from-secondary to-secondary-container rounded-full"
-                style={{ width: `${contextMemoryPercent}%` }}
-              />
-            </div>
+            <ProgressBar
+              label="Context Memory"
+              value={contextMemoryPercent}
+              height="sm"
+              tone="secondary"
+              gradient
+              className="bg-surface-container-highest"
+            />
           </div>
 
           {/* Tokens Processed Progress */}
@@ -151,12 +160,14 @@ const CommitInfoPanel = ({
               <span>Tokens Processed</span>
               <span>{tokensProcessedPercent}%</span>
             </div>
-            <div className="h-1.5 w-full bg-surface-container-highest rounded-full overflow-hidden">
-              <div
-                className="h-full bg-gradient-to-r from-primary to-primary-container rounded-full"
-                style={{ width: `${tokensProcessedPercent}%` }}
-              />
-            </div>
+            <ProgressBar
+              label="Tokens Processed"
+              value={tokensProcessedPercent}
+              height="sm"
+              tone="primary"
+              gradient
+              className="bg-surface-container-highest"
+            />
           </div>
         </div>
 

--- a/src/features/diff/components/DiffLegend.test.tsx
+++ b/src/features/diff/components/DiffLegend.test.tsx
@@ -60,23 +60,21 @@ describe('DiffLegend', () => {
   })
 
   test('renders green indicator dot for ADDED', () => {
-    /* eslint-disable testing-library/no-container, testing-library/no-node-access */
-    const { container } = render(<DiffLegend />)
+    render(<DiffLegend />)
 
-    const greenDot = container.querySelector('[data-testid="added-dot"]')
+    const greenDot = screen.getByTestId('added-dot')
 
+    expect(greenDot.tagName).toBe('SPAN')
     expect(greenDot).toHaveClass('bg-vcs-added')
-    /* eslint-enable testing-library/no-container, testing-library/no-node-access */
   })
 
   test('renders red indicator dot for REMOVED', () => {
-    /* eslint-disable testing-library/no-container, testing-library/no-node-access */
-    const { container } = render(<DiffLegend />)
+    render(<DiffLegend />)
 
-    const redDot = container.querySelector('[data-testid="removed-dot"]')
+    const redDot = screen.getByTestId('removed-dot')
 
+    expect(redDot.tagName).toBe('SPAN')
     expect(redDot).toHaveClass('bg-vcs-deleted')
-    /* eslint-enable testing-library/no-container, testing-library/no-node-access */
   })
 
   test('has proper text styling', () => {

--- a/src/features/diff/components/DiffLegend.test.tsx
+++ b/src/features/diff/components/DiffLegend.test.tsx
@@ -64,7 +64,6 @@ describe('DiffLegend', () => {
 
     const greenDot = screen.getByTestId('added-dot')
 
-    expect(greenDot.tagName).toBe('SPAN')
     expect(greenDot).toHaveClass('bg-vcs-added')
   })
 
@@ -73,7 +72,6 @@ describe('DiffLegend', () => {
 
     const redDot = screen.getByTestId('removed-dot')
 
-    expect(redDot.tagName).toBe('SPAN')
     expect(redDot).toHaveClass('bg-vcs-deleted')
   })
 

--- a/src/features/diff/components/DiffLegend.tsx
+++ b/src/features/diff/components/DiffLegend.tsx
@@ -19,7 +19,7 @@ const DiffLegend = (): ReactElement => (
       size="custom"
       className="gap-2 bg-transparent p-0 text-on-surface"
     >
-      <div
+      <span
         data-testid="added-dot"
         className="h-2 w-2 rounded-full bg-vcs-added"
       />
@@ -35,7 +35,7 @@ const DiffLegend = (): ReactElement => (
       size="custom"
       className="gap-2 bg-transparent p-0 text-on-surface"
     >
-      <div
+      <span
         data-testid="removed-dot"
         className="h-2 w-2 rounded-full bg-vcs-deleted"
       />

--- a/src/features/diff/components/DiffLegend.tsx
+++ b/src/features/diff/components/DiffLegend.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react'
+import { Chip } from '@/components/Chip'
 
 /**
  * DiffLegend component
@@ -12,7 +13,12 @@ const DiffLegend = (): ReactElement => (
     className="fixed bottom-10 left-1/2 -translate-x-1/2 flex items-center gap-3 bg-surface-container-high/60 backdrop-blur-xl border border-outline-variant/20 shadow-2xl rounded-full px-6 py-3"
   >
     {/* Added indicator */}
-    <div className="flex items-center gap-2">
+    <Chip
+      tone="custom"
+      radius="pill"
+      size="custom"
+      className="gap-2 bg-transparent p-0 text-on-surface"
+    >
       <div
         data-testid="added-dot"
         className="h-2 w-2 rounded-full bg-vcs-added"
@@ -20,10 +26,15 @@ const DiffLegend = (): ReactElement => (
       <span className="text-[0.7rem] font-bold uppercase tracking-wider text-on-surface">
         ADDED
       </span>
-    </div>
+    </Chip>
 
     {/* Removed indicator */}
-    <div className="flex items-center gap-2">
+    <Chip
+      tone="custom"
+      radius="pill"
+      size="custom"
+      className="gap-2 bg-transparent p-0 text-on-surface"
+    >
       <div
         data-testid="removed-dot"
         className="h-2 w-2 rounded-full bg-vcs-deleted"
@@ -31,7 +42,7 @@ const DiffLegend = (): ReactElement => (
       <span className="text-[0.7rem] font-bold uppercase tracking-wider text-on-surface">
         REMOVED
       </span>
-    </div>
+    </Chip>
 
     {/* Divider */}
     <div

--- a/src/features/diff/components/toolbar/ChangeStepper.tsx
+++ b/src/features/diff/components/toolbar/ChangeStepper.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react'
+import { Chip } from '@/components/Chip'
 import { Tooltip } from '@/components/Tooltip'
 import { IconButton } from '@/components/IconButton'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
@@ -39,10 +40,14 @@ export const ChangeStepper = ({
   // role="group" makes the aria-label a valid author name — ARIA 1.2 forbids
   // names on the implicit `generic` role of a bare <span>, so the hunk
   // position would otherwise be discarded by screen readers.
-  <span
+  <Chip
     role="group"
     aria-label={`hunk ${counterText}`}
-    className="inline-flex items-center gap-[7px] h-[30px] pl-2.5 pr-1 rounded-md bg-secondary/[0.08] ring-1 ring-inset ring-secondary/[0.16]"
+    tone="secondary"
+    variant="tinted"
+    radius="md"
+    size="custom"
+    className="h-[30px] gap-[7px] rounded-md bg-secondary/[0.08] pl-2.5 pr-1 ring-1 ring-inset ring-secondary/[0.16]"
   >
     <Tooltip content="Jump between changes in this file">
       <span className="inline-flex items-center gap-[7px]">
@@ -81,5 +86,5 @@ export const ChangeStepper = ({
         />
       </Tooltip>
     </span>
-  </span>
+  </Chip>
 )

--- a/src/features/diff/components/toolbar/DiffChipToolbar.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactElement, type ReactNode } from 'react'
 import type { BaseDiffOptions, DiffsThemeNames } from '@pierre/diffs'
+import { Chip } from '@/components/Chip'
 import { Tooltip } from '@/components/Tooltip'
 import { IconButton } from '@/components/IconButton'
 import { Popover } from '@/components/Popover'
@@ -455,9 +456,14 @@ export const DiffChipToolbar = ({
                 check
               </span>
               Finish
-              <span className="font-mono text-[0.625rem] font-semibold bg-on-primary/20 text-on-primary px-1.5 py-px rounded-full">
+              <Chip
+                tone="custom"
+                radius="pill"
+                size="custom"
+                className="rounded-full bg-on-primary/20 px-1.5 py-px font-mono text-[0.625rem] font-semibold text-on-primary"
+              >
                 {feedbackCount}
-              </span>
+              </Chip>
             </button>
           </div>
         ) : null}

--- a/src/features/diff/components/toolbar/FilePill.tsx
+++ b/src/features/diff/components/toolbar/FilePill.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react'
+import { Chip } from '@/components/Chip'
 import { Tooltip } from '@/components/Tooltip'
 import { IconButton } from '@/components/IconButton'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
@@ -61,28 +62,25 @@ export const FilePill = ({
             forbids names on the implicit `generic` role of a bare <div>, so
             screen readers would otherwise discard the path + N/M position
             (the visible text only shows the basename). */}
-        <div
+        <Chip
           role="group"
           aria-label={
             fileName
               ? `file ${counterText}: ${fileName}`
               : `file ${counterText}`
           }
-          className="inline-flex items-center gap-2 h-[30px] px-3 rounded-md bg-primary/10 ring-1 ring-inset ring-primary/20"
-        >
-          <span
-            aria-hidden="true"
-            className="material-symbols-outlined text-base leading-none text-primary-container"
-          >
-            description
-          </span>
-          <span className="font-mono text-xs font-medium text-on-surface truncate max-w-[12rem]">
-            {baseName}
-          </span>
-          <span className="font-mono text-[0.625rem] text-primary-dim bg-primary/[0.14] px-1.5 py-0.5 rounded-full whitespace-nowrap">
-            {counterText}
-          </span>
-        </div>
+          tone="primary"
+          variant="tinted"
+          radius="md"
+          size="custom"
+          leadingIcon="description"
+          label={baseName}
+          trailingCount={counterText}
+          iconClassName="material-symbols-outlined text-base leading-none text-primary-container"
+          labelClassName="max-w-[12rem] truncate font-mono text-xs font-medium text-on-surface"
+          countClassName="whitespace-nowrap rounded-full bg-primary/[0.14] px-1.5 py-0.5 font-mono text-[0.625rem] text-primary-dim"
+          className="h-[30px] gap-2 rounded-md bg-primary/10 px-3 ring-1 ring-inset ring-primary/20"
+        />
       </Tooltip>
       <Tooltip content="Next file">
         <IconButton

--- a/src/features/terminal/components/TerminalPane/GitRefChip.tsx
+++ b/src/features/terminal/components/TerminalPane/GitRefChip.tsx
@@ -1,5 +1,6 @@
 // cspell:ignore worktree
 import type { ReactElement } from 'react'
+import { Chip } from '@/components/Chip'
 import { Tooltip } from '@/components/Tooltip'
 
 export interface GitRefChipProps {
@@ -101,7 +102,13 @@ export const GitRefChip = ({
       }
       placement="bottom"
     >
-      <span data-testid="git-ref-chip" className={frameClasses}>
+      <Chip
+        data-testid="git-ref-chip"
+        tone="custom"
+        size="custom"
+        radius="chip"
+        className={frameClasses}
+      >
         {hasWorktree && (
           <>
             <span
@@ -135,7 +142,7 @@ export const GitRefChip = ({
         <span data-testid="git-ref-chip-br-label" className={brLabelClasses}>
           {branch}
         </span>
-      </span>
+      </Chip>
     </Tooltip>
   )
 }

--- a/src/features/terminal/components/TerminalPane/Header.tsx
+++ b/src/features/terminal/components/TerminalPane/Header.tsx
@@ -1,5 +1,6 @@
 // cspell:ignore worktree
 import { useEffect, useRef, type ReactElement } from 'react'
+import { Chip } from '@/components/Chip'
 import type { Agent } from '../../../../agents/registry'
 import type { Session } from '../../../sessions/types'
 import { register, unregister } from '../../paneHeaderRefs'
@@ -71,8 +72,11 @@ export const Header = ({
         isCollapsed ? 'px-2.5 py-1.5' : 'pb-2 pl-2.5 pr-3 pt-2'
       }`}
     >
-      <div
-        className="inline-flex items-center gap-1.5 rounded-md border px-2 py-[3px] font-semibold tracking-[0.04em]"
+      <Chip
+        tone="custom"
+        radius="md"
+        size="custom"
+        className="gap-1.5 rounded-md border px-2 py-[3px] font-semibold tracking-[0.04em]"
         style={{
           background: agent.accentDim,
           borderColor: agent.accentSoft,
@@ -83,7 +87,7 @@ export const Header = ({
           {agent.glyph}
         </span>
         <span>{agent.short}</span>
-      </div>
+      </Chip>
 
       <span ref={titleRef} className="min-w-0 truncate text-on-surface">
         {paneUserLabel ?? paneAgentTitle ?? session.name}

--- a/src/features/workspace/components/AgentStatusCard.tsx
+++ b/src/features/workspace/components/AgentStatusCard.tsx
@@ -1,5 +1,6 @@
 // cspell:ignore cheatsheet incard powershell pwsh tcsh xonsh zsh
 import type { ReactElement } from 'react'
+import { Chip } from '@/components/Chip'
 import { Tooltip } from '@/components/Tooltip'
 import { RateLimitBar } from '../../agent-status/components/RateLimitBar'
 import { KimiUsageGate } from '../../agent-status/components/KimiUsageGate'
@@ -103,7 +104,12 @@ const shellCheatsheetUrl = (shellName: string): string =>
 
 const TurnPill = ({ turns }: { turns: number | null }): ReactElement => (
   <Tooltip content={`${turns ?? 0} turns`}>
-    <span className="inline-flex h-6 max-w-[86px] shrink-0 items-center justify-center whitespace-nowrap rounded-full border border-outline-variant/40 bg-surface-container-lowest/35 px-[7px] font-mono text-[10px] font-bold leading-none text-on-surface-variant">
+    <Chip
+      tone="custom"
+      radius="pill"
+      size="custom"
+      className="h-6 max-w-[86px] justify-center rounded-full border border-outline-variant/40 bg-surface-container-lowest/35 px-[7px] font-mono text-[10px] font-bold leading-none text-on-surface-variant"
+    >
       {/* Both the Material icon and the descender-less mono label ride ~1px high
         in their own line-boxes. Wrap them in one flex row so items-center keeps
         them aligned to each other, then nudge the whole row down ~1px to center
@@ -118,7 +124,7 @@ const TurnPill = ({ turns }: { turns: number | null }): ReactElement => (
         </span>
         <span>{turns ?? 0} turns</span>
       </span>
-    </span>
+    </Chip>
   </Tooltip>
 )
 
@@ -230,12 +236,14 @@ export const AgentStatusCard = ({
               </span>
               {contextLabel !== null && (
                 <Tooltip content={`${contextLabel} context window`}>
-                  <span
+                  <Chip
                     data-testid="agent-card-context-badge"
+                    tone="custom"
+                    radius="chip"
+                    size="custom"
+                    label={contextLabel}
                     className="shrink-0 rounded-[5px] bg-surface-container-highest px-[5px] py-[2px] font-mono text-[9.5px] font-semibold leading-none text-on-surface-variant"
-                  >
-                    {contextLabel}
-                  </span>
+                  />
                 </Tooltip>
               )}
             </div>


### PR DESCRIPTION
Continues VIM-126 after #497 removed the status-dot surface. This picks up the remaining primitive consolidation by introducing shared chip and progress-meter components, then migrating the remaining chip-like badges and thin/segmented progress bars onto them.

**Base:** the VIM-116 umbrella `refactor/button-component`, matching #497. This stacks on the merged status-dot removal and keeps the diff scoped to Chip + ProgressBar consolidation.

## Added
- Added shared `Chip` and `ProgressBar` primitives with focused component tests
- Migrated agent-status badges, tool metadata chips, usage gates, rate-limit bars, test progress, and token-cache meters
- Migrated diff toolbar/file pills/legend chips and terminal/workspace inline status badges
- Updated `docs/design/UNIFIED.md` to make status-dot removal explicit and document the new primitive contracts

## Verification
- `npm run type-check`
- `npx eslint <touched TS/TSX files>`
- `npx prettier --check <touched files>`
- `npx vitest run --passWithNoTests <focused migrated suites>`: 17 files, 245 tests passed
- `git diff --check`
- Earlier same-source pre-worktree full Vitest: 302 files, 3793 passed, 3 skipped

Note: full `npm run lint` still hangs silently in this environment; scoped ESLint over the full touched TS/TSX surface is green.

Part of VIM-116. Part of VIM-126 — Chip + ProgressBar follow-up after #497.