### PR TITLE
refactor(terminal): expose renderer output capabilities

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -49,6 +49,11 @@ afterEach(() => {
 describe('ghosttyInstance', () => {
   test('exposes the opt-in ghostty renderer adapter', () => {
     expect(ghosttyTerminalRenderer.id).toBe(GHOSTTY_TERMINAL_RENDERER_ID)
+    expect(ghosttyTerminalRenderer.capabilities).toEqual({
+      preferredOutputInputMode: 'bytes',
+      acceptsText: true,
+      acceptsBytes: true,
+    })
     expect(ghosttyTerminalRenderer.createInstance).toBe(createGhosttyTerminal)
   })
 

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -59,5 +59,10 @@ export const createGhosttyTerminal = (
 
 export const ghosttyTerminalRenderer: TerminalRendererAdapter = {
   id: GHOSTTY_TERMINAL_RENDERER_ID,
+  capabilities: {
+    preferredOutputInputMode: 'bytes',
+    acceptsText: true,
+    acceptsBytes: true,
+  },
   createInstance: createGhosttyTerminal,
 }

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -60,6 +60,12 @@ afterEach(() => {
 describe('plainTextInstance', () => {
   test('exposes the opt-in plain-text renderer adapter', () => {
     expect(plainTextTerminalRenderer.id).toBe(PLAIN_TEXT_TERMINAL_RENDERER_ID)
+    expect(plainTextTerminalRenderer.capabilities).toEqual({
+      preferredOutputInputMode: 'text',
+      acceptsText: true,
+      acceptsBytes: false,
+    })
+
     expect(plainTextTerminalRenderer.createInstance).toBe(
       createPlainTextTerminal
     )

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -490,5 +490,10 @@ export const createPlainTextTerminal = (): TerminalInstance => {
 
 export const plainTextTerminalRenderer: TerminalRendererAdapter = {
   id: PLAIN_TEXT_TERMINAL_RENDERER_ID,
+  capabilities: {
+    preferredOutputInputMode: 'text',
+    acceptsText: true,
+    acceptsBytes: false,
+  },
   createInstance: createPlainTextTerminal,
 }

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -1,4 +1,5 @@
 import type {
+  TerminalOutputInputMode,
   TerminalOutputChunk,
   TerminalParser,
   TerminalParserOutputContext,
@@ -10,7 +11,7 @@ export interface TerminalParserEngineOutput {
   readonly visibleText: string
 }
 
-export type TerminalParserEngineInputMode = 'text' | 'bytes'
+export type TerminalParserEngineInputMode = TerminalOutputInputMode
 
 export interface TerminalParserEngineOptions {
   readonly inputMode: TerminalParserEngineInputMode

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
@@ -1,6 +1,10 @@
 // cspell:ignore ghostty
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import type { TerminalInstance, TerminalRendererAdapter } from '../../types'
+import type {
+  TerminalInstance,
+  TerminalRendererAdapter,
+  TerminalRendererCapabilities,
+} from '../../types'
 
 type TerminalRendererRegistryModule =
   typeof import('./terminalRendererRegistry')
@@ -19,12 +23,29 @@ const ghosttyRendererMocks = vi.hoisted(() => ({
   moduleLoaded: vi.fn(),
 }))
 
+const rendererCapabilities = vi.hoisted(() => ({
+  text: {
+    preferredOutputInputMode: 'text',
+    acceptsText: true,
+    acceptsBytes: false,
+  } as const,
+  bytes: {
+    preferredOutputInputMode: 'bytes',
+    acceptsText: true,
+    acceptsBytes: true,
+  } as const,
+}))
+
+const textRendererCapabilities: TerminalRendererCapabilities =
+  rendererCapabilities.text
+
 vi.mock('./plainTextInstance', () => {
   plainTextRendererMocks.moduleLoaded()
 
   return {
     plainTextTerminalRenderer: {
       id: 'plain-text',
+      capabilities: rendererCapabilities.text,
       createInstance: plainTextRendererMocks.createInstance,
     },
   }
@@ -36,6 +57,7 @@ vi.mock('./ghosttyInstance', () => {
   return {
     ghosttyTerminalRenderer: {
       id: 'ghostty',
+      capabilities: rendererCapabilities.bytes,
       createInstance: ghosttyRendererMocks.createInstance,
     },
   }
@@ -44,6 +66,7 @@ vi.mock('./ghosttyInstance', () => {
 vi.mock('./xtermInstance', () => ({
   xtermTerminalRenderer: {
     id: 'xterm',
+    capabilities: rendererCapabilities.text,
     createInstance: xtermRendererMocks.createInstance,
   },
 }))
@@ -93,6 +116,7 @@ const createTerminalRendererAdapter = (
   instance: TerminalInstance
 ): TerminalRendererAdapter => ({
   id,
+  capabilities: textRendererCapabilities,
   createInstance: vi.fn((): TerminalInstance => instance),
 })
 

--- a/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
@@ -116,6 +116,11 @@ describe('xtermInstance', () => {
 
   test('exports the default xterm renderer adapter', () => {
     expect(xtermTerminalRenderer.id).toBe('xterm')
+    expect(xtermTerminalRenderer.capabilities).toEqual({
+      preferredOutputInputMode: 'text',
+      acceptsText: true,
+      acceptsBytes: false,
+    })
     expect(xtermTerminalRenderer.createInstance).toBe(createXtermTerminal)
   })
 

--- a/src/features/terminal/components/TerminalPane/xtermInstance.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.ts
@@ -47,6 +47,11 @@ export const createXtermTerminal = (): TerminalInstance => {
 
 export const xtermTerminalRenderer: TerminalRendererAdapter = {
   id: 'xterm',
+  capabilities: {
+    preferredOutputInputMode: 'text',
+    acceptsText: true,
+    acceptsBytes: false,
+  },
   createInstance: createXtermTerminal,
 }
 

--- a/src/features/terminal/types/index.test.ts
+++ b/src/features/terminal/types/index.test.ts
@@ -11,6 +11,7 @@ import type {
   PTYDataEvent,
   PTYExitEvent,
   PTYErrorEvent,
+  TerminalRendererCapabilities,
 } from './index'
 
 describe('Terminal Types', () => {
@@ -190,6 +191,53 @@ describe('Terminal Types', () => {
       }
 
       expect(event.message).toBe('Failed to spawn shell')
+    })
+  })
+
+  describe('TerminalRendererCapabilities', () => {
+    test('describes a byte-preferring renderer with text fallback', () => {
+      const capabilities: TerminalRendererCapabilities = {
+        preferredOutputInputMode: 'bytes',
+        acceptsText: true,
+        acceptsBytes: true,
+      }
+
+      expect(capabilities.preferredOutputInputMode).toBe('bytes')
+      expect(capabilities.acceptsText).toBe(true)
+      expect(capabilities.acceptsBytes).toBe(true)
+    })
+
+    test('requires preferred modes to be accepted', () => {
+      const textPreferred: TerminalRendererCapabilities = {
+        preferredOutputInputMode: 'text',
+        acceptsText: true,
+        acceptsBytes: false,
+      }
+
+      const bytesPreferred: TerminalRendererCapabilities = {
+        preferredOutputInputMode: 'bytes',
+        acceptsText: false,
+        acceptsBytes: true,
+      }
+
+      // @ts-expect-error text-preferring renderers must accept text
+      const invalidTextPreferred: TerminalRendererCapabilities = {
+        preferredOutputInputMode: 'text',
+        acceptsText: false,
+        acceptsBytes: true,
+      }
+
+      // @ts-expect-error byte-preferring renderers must accept bytes
+      const invalidBytesPreferred: TerminalRendererCapabilities = {
+        preferredOutputInputMode: 'bytes',
+        acceptsText: true,
+        acceptsBytes: false,
+      }
+
+      expect(textPreferred.acceptsText).toBe(true)
+      expect(bytesPreferred.acceptsBytes).toBe(true)
+      expect(invalidTextPreferred.acceptsText).toBe(false)
+      expect(invalidBytesPreferred.acceptsBytes).toBe(false)
     })
   })
 

--- a/src/features/terminal/types/index.ts
+++ b/src/features/terminal/types/index.ts
@@ -224,6 +224,9 @@ export interface TerminalSize {
 /** Source phase for output written into a terminal renderer. */
 export type TerminalOutputPhase = 'live' | 'restore'
 
+/** Payload format a renderer adapter consumes from terminal output chunks. */
+export type TerminalOutputInputMode = 'text' | 'bytes'
+
 /** PTY output chunk delivered to a renderer-owned parser/writer. */
 export interface TerminalOutputChunk {
   /** UTF-8 decoded text payload used by the current xterm-compatible path. */
@@ -279,6 +282,29 @@ export interface TerminalFitController {
 export interface TerminalOutputWriter {
   writeOutput: (chunk: TerminalOutputChunk, callback?: () => void) => void
 }
+
+interface TextPreferredTerminalRendererCapabilities {
+  /** Preferred payload format when both text and bytes are available. */
+  readonly preferredOutputInputMode: 'text'
+  /** Text-preferring renderers must consume `TerminalOutputChunk.text`. */
+  readonly acceptsText: true
+  /** Whether the renderer can consume `TerminalOutputChunk.bytesBase64`. */
+  readonly acceptsBytes: boolean
+}
+
+interface BytesPreferredTerminalRendererCapabilities {
+  /** Preferred payload format when both text and bytes are available. */
+  readonly preferredOutputInputMode: 'bytes'
+  /** Whether the renderer can consume `TerminalOutputChunk.text`. */
+  readonly acceptsText: boolean
+  /** Byte-preferring renderers must consume `TerminalOutputChunk.bytesBase64`. */
+  readonly acceptsBytes: true
+}
+
+/** Declares how a renderer adapter consumes terminal output chunks. */
+export type TerminalRendererCapabilities =
+  | TextPreferredTerminalRendererCapabilities
+  | BytesPreferredTerminalRendererCapabilities
 
 /** Renderer addon handle owned by the terminal adapter. */
 export interface TerminalRendererHandle {
@@ -337,5 +363,6 @@ export interface TerminalInstance {
 /** Adapter that creates complete terminal renderer instances. */
 export interface TerminalRendererAdapter {
   readonly id: string
+  readonly capabilities: TerminalRendererCapabilities
   createInstance: () => TerminalInstance
 }


### PR DESCRIPTION
## Summary

- Add renderer capability metadata for preferred terminal output input mode.
- Mark xterm and plain-text adapters as text-only, and Ghostty as byte-preferring with text fallback.
- Reuse the shared output input mode type between renderer capabilities and parser engine options.
- Cover bundled adapters, registry mocks, and the exported capability type with focused tests.

## Validation

- npx tsc -b --pretty false
- npm --ignore-scripts run lint
- npm --ignore-scripts run format:check
- git diff --check
- npx vitest run src/features/terminal/types/index.test.ts src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts src/features/terminal/components/TerminalPane/xtermInstance.test.ts src/features/terminal/components/TerminalPane/plainTextInstance.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts