### PR TITLE
[codex] fix context tank endpoints

### DIFF
--- a/src/features/agent-status/components/ContextReservoirCard.test.tsx
+++ b/src/features/agent-status/components/ContextReservoirCard.test.tsx
@@ -108,19 +108,27 @@ describe('ContextReservoirCard tank + waterline', () => {
     expect(screen.getByTestId('tank-water')).toBeInTheDocument()
   })
 
+  test('renders a dry tank, not a tiny animated fill, at 0%', () => {
+    render(<ContextReservoirCard {...defaultProps} usedPercentage={0} />)
+
+    expect(screen.getByTestId('water-tank')).toBeInTheDocument()
+    expect(screen.queryByTestId('tank-water')).not.toBeInTheDocument()
+    expect(screen.getByTestId('context-pill')).toHaveTextContent('0')
+  })
+
   test('rides a value pill on the waterline showing the used tokens', () => {
     render(<ContextReservoirCard {...defaultProps} />)
 
     expect(screen.getByTestId('context-pill')).toHaveTextContent('560k')
   })
 
-  test('top scale tick shows the window size, bottom shows zero', () => {
+  test('top scale tick shows the window size without a bottom zero label', () => {
     render(
       <ContextReservoirCard {...defaultProps} contextWindowSize={200_000} />
     )
 
     expect(screen.getByText('200k')).toBeInTheDocument()
-    expect(screen.getByText('0')).toBeInTheDocument()
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
   })
 })
 

--- a/src/features/agent-status/components/ContextReservoirCard.tsx
+++ b/src/features/agent-status/components/ContextReservoirCard.tsx
@@ -56,7 +56,7 @@ export const ContextReservoirCard = ({
   const used = Math.round(contextWindowSize * (effectivePct / 100))
   const headroom = contextWindowSize - used
 
-  // Pill rides the waterline (shares the tank's 2% visibility floor).
+  // Pill anchors near the tank floor at 0%; the clamp keeps it inside bounds.
   const visibleWaterPct =
     effectivePct <= 0 ? 2 : Math.min(100, Math.max(2, effectivePct))
   const waterlineTopPct = (1 - visibleWaterPct / 100) * 100

--- a/src/features/agent-status/components/ContextReservoirCard.tsx
+++ b/src/features/agent-status/components/ContextReservoirCard.tsx
@@ -57,8 +57,9 @@ export const ContextReservoirCard = ({
   const headroom = contextWindowSize - used
 
   // Pill rides the waterline (shares the tank's 2% visibility floor).
-  const waterlineTopPct =
-    (1 - Math.min(100, Math.max(2, effectivePct)) / 100) * 100
+  const visibleWaterPct =
+    effectivePct <= 0 ? 2 : Math.min(100, Math.max(2, effectivePct))
+  const waterlineTopPct = (1 - visibleWaterPct / 100) * 100
 
   // Card chrome matches the sibling TokenCache directly below it in the panel
   // (radius 10, 135deg tone wash, tinted border, no elevation) so the two
@@ -123,7 +124,7 @@ export const ContextReservoirCard = ({
           </span>
         </div>
 
-        {/* Tank with scale ticks + floating waterline value */}
+        {/* Tank with top scale tick + floating waterline value */}
         <div className="relative">
           <WaterTank pct={effectivePct} theme={mode} empty={pct === null} />
 
@@ -132,12 +133,6 @@ export const ContextReservoirCard = ({
             style={{ color: chrome.tick }}
           >
             {compactTokens(contextWindowSize)}
-          </span>
-          <span
-            className="pointer-events-none absolute bottom-[6px] right-[7px] font-mono text-[8.5px] font-semibold tracking-[0.04em]"
-            style={{ color: chrome.tick }}
-          >
-            0
           </span>
 
           {pct !== null && (

--- a/src/features/agent-status/components/WaterTank.test.tsx
+++ b/src/features/agent-status/components/WaterTank.test.tsx
@@ -7,8 +7,12 @@ describe('computeTankLevel', () => {
     expect(computeTankLevel(80, 104)).toBeLessThan(computeTankLevel(40, 104))
   })
 
-  test('clamps to a 2% floor so the waterline stays visible', () => {
-    expect(computeTankLevel(0, 104)).toBe(computeTankLevel(2, 104))
+  test('treats zero as a dry tank', () => {
+    expect(computeTankLevel(0, 104)).toBe(104)
+  })
+
+  test('clamps non-zero fills to a 2% floor so tiny amounts stay visible', () => {
+    expect(computeTankLevel(1, 104)).toBe(computeTankLevel(2, 104))
   })
 
   test('clamps overfill to the top', () => {
@@ -29,6 +33,22 @@ describe('WaterTank', () => {
 
     expect(screen.getByTestId('water-tank')).toBeInTheDocument()
     expect(screen.queryByTestId('tank-water')).not.toBeInTheDocument()
+  })
+
+  test('renders no water at 0% even when context is known', () => {
+    render(<WaterTank pct={0} theme="dark" />)
+
+    expect(screen.getByTestId('water-tank')).toBeInTheDocument()
+    expect(screen.queryByTestId('tank-water')).not.toBeInTheDocument()
+  })
+
+  test('renders a full tank without a doubled meniscus line at 100%', () => {
+    render(<WaterTank pct={100} theme="dark" height={104} />)
+
+    expect(screen.getByTestId('tank-water').getAttribute('d')).toContain(
+      'M 0.0 0.00'
+    )
+    expect(screen.queryByTestId('tank-meniscus')).not.toBeInTheDocument()
   })
 
   test('paints a resting surface that closes flat to the floor', () => {

--- a/src/features/agent-status/components/WaterTank.tsx
+++ b/src/features/agent-status/components/WaterTank.tsx
@@ -42,12 +42,18 @@ export interface WaterTankProps {
 const TANK_WIDTH = 248
 
 /**
- * Y coordinate (in SVG user units) of the waterline for a given fill. A 2%
- * floor keeps the waterline visible even at very low fill. Exported for
- * geometry assertions.
+ * Y coordinate (in SVG user units) of the waterline for a given fill. Zero is
+ * a truly dry tank; non-zero values keep the old 2% visibility floor so a tiny
+ * amount of water still reads as present. Exported for geometry assertions.
  */
-export const computeTankLevel = (pct: number, height: number): number =>
-  (1 - Math.min(100, Math.max(2, pct)) / 100) * height
+export const computeTankLevel = (pct: number, height: number): number => {
+  const clamped = Math.min(100, Math.max(0, pct))
+  if (clamped <= 0) {
+    return height
+  }
+
+  return (1 - Math.max(2, clamped) / 100) * height
+}
 
 export const WaterTank = ({
   pct,
@@ -56,6 +62,9 @@ export const WaterTank = ({
   empty = false,
   swell = 'soft-mound',
 }: WaterTankProps): ReactElement => {
+  const shouldRenderWater = !empty && pct > 0
+  const shouldRenderMeniscus = shouldRenderWater && pct < 100
+  const shouldAnimateWater = shouldRenderWater && pct < 100
   const tone = resolveContextTone(pct, theme)
   const chrome = tankChrome(theme)
   const level = computeTankLevel(pct, height)
@@ -96,7 +105,7 @@ export const WaterTank = ({
     // Compute from the mutable geom ref rather than the render-scoped `resting`
     // so this effect does not re-run on every `pct` change.
     const geom = geomRef.current
-    if (fill === null || meniscus === null || geom === null) {
+    if (fill === null || geom === null) {
       return
     }
 
@@ -109,8 +118,22 @@ export const WaterTank = ({
       SWELL_PRESETS[swell].width
     )
     fill.setAttribute('d', fillPath)
-    meniscus.setAttribute('d', crest)
-  }, [empty, swell])
+    meniscus?.setAttribute('d', crest)
+  }, [shouldRenderMeniscus, shouldRenderWater, swell])
+
+  useLayoutEffect(() => {
+    if (shouldAnimateWater) {
+      return
+    }
+    const fill = fillRef.current
+    const meniscus = meniscusRef.current
+    if (fill === null) {
+      return
+    }
+
+    fill.setAttribute('d', resting.fill)
+    meniscus?.setAttribute('d', resting.crest)
+  }, [resting.crest, resting.fill, shouldAnimateWater])
 
   // Keep the static surface in sync with `pct` under reduced motion. During
   // normal animation the rAF loop in useReservoirFlow owns the `d` attributes
@@ -119,17 +142,17 @@ export const WaterTank = ({
   useEffect(() => {
     const fill = fillRef.current
     const meniscus = meniscusRef.current
-    if (fill === null || meniscus === null) {
+    if (fill === null) {
       return
     }
     if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       return
     }
     fill.setAttribute('d', resting.fill)
-    meniscus.setAttribute('d', resting.crest)
+    meniscus?.setAttribute('d', resting.crest)
   }, [resting.fill, resting.crest])
 
-  useReservoirFlow(svgRef, flowRefsRef, geomRef, !empty, swell)
+  useReservoirFlow(svgRef, flowRefsRef, geomRef, shouldAnimateWater, swell)
 
   return (
     <svg
@@ -190,22 +213,24 @@ export const WaterTank = ({
           fill={`url(#${dryId})`}
         />
 
-        {!empty && (
+        {shouldRenderWater && (
           <>
             <path
               ref={fillRef}
               data-testid="tank-water"
               fill={`url(#${fillId})`}
             />
-            <path
-              ref={meniscusRef}
-              data-testid="tank-meniscus"
-              fill="none"
-              stroke={tone.meniscus}
-              strokeWidth="1.5"
-              strokeOpacity="0.9"
-              style={{ filter: `drop-shadow(0 0 5px ${tone.base})` }}
-            />
+            {shouldRenderMeniscus && (
+              <path
+                ref={meniscusRef}
+                data-testid="tank-meniscus"
+                fill="none"
+                stroke={tone.meniscus}
+                strokeWidth="1.5"
+                strokeOpacity="0.9"
+                style={{ filter: `drop-shadow(0 0 5px ${tone.base})` }}
+              />
+            )}
           </>
         )}
 

--- a/src/features/agent-status/components/WaterTank.tsx
+++ b/src/features/agent-status/components/WaterTank.tsx
@@ -64,7 +64,9 @@ export const WaterTank = ({
 }: WaterTankProps): ReactElement => {
   const shouldRenderWater = !empty && pct > 0
   const shouldRenderMeniscus = shouldRenderWater && pct < 100
-  const shouldAnimateWater = shouldRenderWater && pct < 100
+  // The rAF loop updates both fill and meniscus refs, so it only runs while
+  // the meniscus element is mounted.
+  const shouldAnimateWater = shouldRenderMeniscus
   const tone = resolveContextTone(pct, theme)
   const chrome = tankChrome(theme)
   const level = computeTankLevel(pct, height)
@@ -120,20 +122,6 @@ export const WaterTank = ({
     fill.setAttribute('d', fillPath)
     meniscus?.setAttribute('d', crest)
   }, [shouldRenderMeniscus, shouldRenderWater, swell])
-
-  useLayoutEffect(() => {
-    if (shouldAnimateWater) {
-      return
-    }
-    const fill = fillRef.current
-    const meniscus = meniscusRef.current
-    if (fill === null) {
-      return
-    }
-
-    fill.setAttribute('d', resting.fill)
-    meniscus?.setAttribute('d', resting.crest)
-  }, [resting.crest, resting.fill, shouldAnimateWater])
 
   // Keep the static surface in sync with `pct` under reduced motion. During
   // normal animation the rAF loop in useReservoirFlow owns the `d` attributes

--- a/src/features/agent-status/hooks/useReservoirFlow.test.tsx
+++ b/src/features/agent-status/hooks/useReservoirFlow.test.tsx
@@ -12,6 +12,7 @@ import {
 import {
   useReservoirFlow,
   buildReservoirSurface,
+  computeSurfaceMotionScale,
   SWELL_PRESETS,
   type ReservoirSurfaceRefs,
   type ReservoirGeom,
@@ -79,6 +80,11 @@ const yAt = (crest: string, x: number): number => {
 
   return m === null ? NaN : parseFloat(m[1])
 }
+
+const yValues = (crest: string): number[] =>
+  [...crest.matchAll(/[ML] \d+\.0 (-?\d+(?:\.\d+)?)/g)].map((m) =>
+    parseFloat(m[1])
+  )
 
 let now = 0
 let pending: FrameRequestCallback | null = null
@@ -155,6 +161,36 @@ describe('buildReservoirSurface', () => {
 
     // surface at the mound centre sits higher (smaller y) than far away
     expect(yAt(crest, 124)).toBeLessThan(yAt(crest, 0))
+  })
+
+  test('keeps the ambient wave height restrained', () => {
+    const { crest } = buildReservoirSurface(52, 104, 0, 0, 124, 30)
+    const ys = yValues(crest)
+
+    expect(Math.max(...ys) - Math.min(...ys)).toBeLessThanOrEqual(10)
+  })
+
+  test('keeps a full tank flat against the top edge', () => {
+    const { crest } = buildReservoirSurface(0, 104, 1.2, 8, 124, 30)
+
+    expect(new Set(yValues(crest))).toEqual(new Set([0]))
+  })
+
+  test('bounds near-empty waves to the tank floor', () => {
+    const { crest } = buildReservoirSurface(102, 104, 1.2, 8, 124, 30)
+
+    expect(Math.max(...yValues(crest))).toBeLessThanOrEqual(104)
+  })
+})
+
+describe('computeSurfaceMotionScale', () => {
+  test('turns off motion at the top and floor', () => {
+    expect(computeSurfaceMotionScale(0, 104, 8)).toBe(0)
+    expect(computeSurfaceMotionScale(104, 104, 8)).toBe(0)
+  })
+
+  test('allows full motion away from the endpoints', () => {
+    expect(computeSurfaceMotionScale(52, 104, 8)).toBe(1)
   })
 })
 

--- a/src/features/agent-status/hooks/useReservoirFlow.ts
+++ b/src/features/agent-status/hooks/useReservoirFlow.ts
@@ -35,11 +35,11 @@ interface SwellPreset {
 
 export const SWELL_PRESETS: Record<SwellVariant, SwellPreset> = {
   // A single soft mound that follows the cursor closely (default).
-  'soft-mound': { width: 30, peakAmp: 8, followEase: 12, ampEase: 6 },
+  'soft-mound': { width: 30, peakAmp: 4.2, followEase: 12, ampEase: 6 },
   // The mound lags behind the cursor, giving a sense of mass / inertia.
-  trailing: { width: 30, peakAmp: 8, followEase: 4.5, ampEase: 6 },
+  trailing: { width: 30, peakAmp: 4.2, followEase: 4.5, ampEase: 6 },
   // A broad, low rise instead of a focused peak — the calmest.
-  'wide-lift': { width: 64, peakAmp: 5, followEase: 9, ampEase: 5 },
+  'wide-lift': { width: 64, peakAmp: 2.8, followEase: 9, ampEase: 5 },
 }
 
 const TANK_WIDTH = 248
@@ -49,12 +49,35 @@ const TAU = Math.PI * 2
 // equal (no seam) regardless of phase.
 const WL_FRONT = TANK_WIDTH / 2
 const WL_BACK = TANK_WIDTH
-const AMP_FRONT = 5
-const AMP_BACK = 7
+const AMP_FRONT = 2.5
+const AMP_BACK = 3.5
 const STEP = 4
+const MAX_AMBIENT_AMP = AMP_FRONT + AMP_BACK
 // Base drift: phase advances ~0.7 rad/s — a calm, always-on flow.
 const BASE_RATE = 0.7
 const LEVEL_EASE_PER_SECOND = 4
+
+const clamp = (n: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, n))
+
+/**
+ * Scales surface motion down near a dry floor or full ceiling. Without this,
+ * the ambient waves are larger than the available water at 1-2% and
+ * larger than the available headroom at 98-100%, which creates impossible
+ * bumps and dry gaps at the endpoints.
+ */
+export const computeSurfaceMotionScale = (
+  level: number,
+  height: number,
+  swellAmp: number
+): number => {
+  const riseBudget = MAX_AMBIENT_AMP + Math.max(0, swellAmp)
+  const fallBudget = MAX_AMBIENT_AMP
+  const topScale = riseBudget === 0 ? 1 : level / riseBudget
+  const bottomScale = fallBudget === 0 ? 1 : (height - level) / fallBudget
+
+  return clamp(Math.min(topScale, bottomScale), 0, 1)
+}
 
 /**
  * Builds the surface path. A Gaussian mound of height `swellAmp` centred at
@@ -70,15 +93,22 @@ export const buildReservoirSurface = (
   swellX: number,
   swellWidth: number
 ): { fill: string; crest: string } => {
+  const motionScale = computeSurfaceMotionScale(level, height, swellAmp)
   let crest = ''
   for (let x = 0; x <= TANK_WIDTH; x += STEP) {
-    const mound = swellAmp * Math.exp(-Math.pow((x - swellX) / swellWidth, 2))
+    const mound =
+      swellAmp * motionScale * Math.exp(-Math.pow((x - swellX) / swellWidth, 2))
 
-    const y =
+    const y = clamp(
       level +
-      Math.sin((x / WL_FRONT) * TAU + phase) * AMP_FRONT +
-      Math.sin((x / WL_BACK) * TAU + phase * 0.7 + 0.9) * AMP_BACK -
-      mound
+        Math.sin((x / WL_FRONT) * TAU + phase) * AMP_FRONT * motionScale +
+        Math.sin((x / WL_BACK) * TAU + phase * 0.7 + 0.9) *
+          AMP_BACK *
+          motionScale -
+        mound,
+      0,
+      height
+    )
     crest += `${x === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(2)} `
   }
 

--- a/src/features/agent-status/hooks/useReservoirFlow.ts
+++ b/src/features/agent-status/hooks/useReservoirFlow.ts
@@ -73,8 +73,8 @@ export const computeSurfaceMotionScale = (
 ): number => {
   const riseBudget = MAX_AMBIENT_AMP + Math.max(0, swellAmp)
   const fallBudget = MAX_AMBIENT_AMP
-  const topScale = riseBudget === 0 ? 1 : level / riseBudget
-  const bottomScale = fallBudget === 0 ? 1 : (height - level) / fallBudget
+  const topScale = level / riseBudget
+  const bottomScale = (height - level) / fallBudget
 
   return clamp(Math.min(topScale, bottomScale), 0, 1)
 }


### PR DESCRIPTION
## Summary
- Treat 0% context usage as a truly dry tank with no water path or animation.
- Keep 100% usage visually full while hiding the meniscus stroke so the tank does not show a doubled top border.
- Reduce reservoir wave and hover swell amplitudes while preserving dynamic motion.
- Remove the in-tank bottom `0` scale label and update focused tests for the endpoint behavior.

## Root cause
The tank previously clamped all fills to a 2% minimum and kept the same wave amplitude at both endpoints. That made 0% show animated water, made 100% leave a visible surface line/gap, and made low/high percentages look physically exaggerated.

## Validation
- `npm test -- --run src/features/agent-status/components/WaterTank.test.tsx src/features/agent-status/hooks/useReservoirFlow.test.tsx src/features/agent-status/components/ContextReservoirCard.test.tsx`
- `npx eslint src/features/agent-status/components/WaterTank.tsx src/features/agent-status/hooks/useReservoirFlow.ts src/features/agent-status/components/ContextReservoirCard.tsx src/features/agent-status/components/WaterTank.test.tsx src/features/agent-status/hooks/useReservoirFlow.test.tsx src/features/agent-status/components/ContextReservoirCard.test.tsx`
- `npx prettier --check src/features/agent-status/components/WaterTank.tsx src/features/agent-status/hooks/useReservoirFlow.ts src/features/agent-status/components/ContextReservoirCard.tsx src/features/agent-status/components/WaterTank.test.tsx src/features/agent-status/hooks/useReservoirFlow.test.tsx src/features/agent-status/components/ContextReservoirCard.test.tsx`