### PR TITLE
refactor(terminal): route parser output by capabilities

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -72,15 +72,18 @@ describe('ghosttyInstance', () => {
       })
     )
 
-    const created = createTrackedGhosttyTerminal({
-      createParserEngine: () => ({
-        inputMode: 'bytes',
-        parser,
-        parseText: (text): TerminalParserEngineOutput => ({
-          visibleText: `parsed:${text}`,
-        }),
-        parseOutput,
+    const createParserEngine = vi.fn(() => ({
+      inputMode: 'bytes' as const,
+      capabilities: ghosttyTerminalRenderer.capabilities,
+      parser,
+      parseText: (text: string): TerminalParserEngineOutput => ({
+        visibleText: `parsed:${text}`,
       }),
+      parseOutput,
+    }))
+
+    const created = createTrackedGhosttyTerminal({
+      createParserEngine,
     })
 
     const chunk = {
@@ -93,6 +96,9 @@ describe('ghosttyInstance', () => {
     created.output.writeOutput(chunk)
 
     expect(created.parser).toBe(parser)
+    expect(createParserEngine).toHaveBeenCalledWith(
+      ghosttyTerminalRenderer.capabilities
+    )
     expect(parseOutput).toHaveBeenCalledWith(chunk)
     expect(created.viewportReader.readVisibleText()).toBe('parsed:from-engine')
   })

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -2,20 +2,29 @@
 import type {
   TerminalInstance,
   TerminalRendererAdapter,
+  TerminalRendererCapabilities,
   TerminalRendererHandle,
   TerminalOutputWriter,
 } from '../../types'
 import { createPlainTextTerminal } from './plainTextInstance'
 import { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
 import {
-  createByteControlSequenceTerminalParserEngine,
+  createControlSequenceTerminalParserEngine,
   type TerminalParserEngine,
 } from './terminalParserEngine'
 
 export { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
 
+const GHOSTTY_TERMINAL_CAPABILITIES: TerminalRendererCapabilities = {
+  preferredOutputInputMode: 'bytes',
+  acceptsText: true,
+  acceptsBytes: true,
+}
+
 export interface GhosttyTerminalOptions {
-  readonly createParserEngine?: () => TerminalParserEngine
+  readonly createParserEngine?: (
+    capabilities: TerminalRendererCapabilities
+  ) => TerminalParserEngine
 }
 
 class GhosttyTerminalModel {
@@ -24,8 +33,10 @@ class GhosttyTerminalModel {
 
   constructor(options: GhosttyTerminalOptions = {}) {
     this.parserEngine =
-      options.createParserEngine?.() ??
-      createByteControlSequenceTerminalParserEngine()
+      options.createParserEngine?.(GHOSTTY_TERMINAL_CAPABILITIES) ??
+      createControlSequenceTerminalParserEngine({
+        capabilities: GHOSTTY_TERMINAL_CAPABILITIES,
+      })
   }
 
   readonly output: TerminalOutputWriter = {
@@ -59,10 +70,6 @@ export const createGhosttyTerminal = (
 
 export const ghosttyTerminalRenderer: TerminalRendererAdapter = {
   id: GHOSTTY_TERMINAL_RENDERER_ID,
-  capabilities: {
-    preferredOutputInputMode: 'bytes',
-    acceptsText: true,
-    acceptsBytes: true,
-  },
+  capabilities: GHOSTTY_TERMINAL_CAPABILITIES,
   createInstance: createGhosttyTerminal,
 }

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -7,6 +7,7 @@ import type {
   TerminalOutputWriter,
   TerminalParser,
   TerminalRendererAdapter,
+  TerminalRendererCapabilities,
   TerminalRendererHandle,
   TerminalSize,
   TerminalSurface,
@@ -14,7 +15,7 @@ import type {
   TerminalViewportReader,
 } from '../../types'
 import { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
-import { createTextControlSequenceTerminalParserEngine } from './terminalParserEngine'
+import { createControlSequenceTerminalParserEngine } from './terminalParserEngine'
 import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
 
 export { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
@@ -26,6 +27,12 @@ const MIN_ROWS = 1
 const APPROXIMATE_CHAR_WIDTH = 8
 const APPROXIMATE_LINE_HEIGHT = 18
 const MAX_SCROLLBACK_LINES = 10_000
+
+const PLAIN_TEXT_TERMINAL_CAPABILITIES: TerminalRendererCapabilities = {
+  preferredOutputInputMode: 'text',
+  acceptsText: true,
+  acceptsBytes: false,
+}
 
 const KEYBOARD_SEQUENCES = new Map<string, string>([
   ['ArrowUp', '\x1b[A'],
@@ -438,8 +445,9 @@ class PlainTextTerminalSurface implements TerminalSurface {
 }
 
 class PlainTextTerminalModel {
-  private readonly parserEngine =
-    createTextControlSequenceTerminalParserEngine()
+  private readonly parserEngine = createControlSequenceTerminalParserEngine({
+    capabilities: PLAIN_TEXT_TERMINAL_CAPABILITIES,
+  })
   readonly terminal = new PlainTextTerminalSurface(
     (data) => this.parserEngine.parseText(data, null).visibleText
   )
@@ -490,10 +498,6 @@ export const createPlainTextTerminal = (): TerminalInstance => {
 
 export const plainTextTerminalRenderer: TerminalRendererAdapter = {
   id: PLAIN_TEXT_TERMINAL_RENDERER_ID,
-  capabilities: {
-    preferredOutputInputMode: 'text',
-    acceptsText: true,
-    acceptsBytes: false,
-  },
+  capabilities: PLAIN_TEXT_TERMINAL_CAPABILITIES,
   createInstance: createPlainTextTerminal,
 }

--- a/src/features/terminal/components/TerminalPane/terminalOutputPayload.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalOutputPayload.test.ts
@@ -1,10 +1,28 @@
 import { describe, expect, test } from 'vitest'
 import type { TerminalOutputChunk } from '../../types'
 import {
-  TerminalOutputPayloadDecoder,
+  TerminalOutputPayloadRouter,
   decodeBase64ToBytes,
   readTerminalOutputBytes,
 } from './terminalOutputPayload'
+
+const textOnlyCapabilities = {
+  preferredOutputInputMode: 'text',
+  acceptsText: true,
+  acceptsBytes: false,
+} as const
+
+const bytePreferredCapabilities = {
+  preferredOutputInputMode: 'bytes',
+  acceptsText: true,
+  acceptsBytes: true,
+} as const
+
+const byteOnlyCapabilities = {
+  preferredOutputInputMode: 'bytes',
+  acceptsText: false,
+  acceptsBytes: true,
+} as const
 
 const encodeBase64 = (bytes: Uint8Array): string => {
   let binary = ''
@@ -15,6 +33,9 @@ const encodeBase64 = (bytes: Uint8Array): string => {
 
   return globalThis.btoa(binary)
 }
+
+const encodeText = (text: string): string =>
+  encodeBase64(new TextEncoder().encode(text))
 
 const outputChunk = (
   text: string,
@@ -44,34 +65,92 @@ describe('terminalOutputPayload', () => {
   })
 
   test('prefers streaming byte payloads over fallback text', () => {
-    const decoder = new TerminalOutputPayloadDecoder()
+    const router = new TerminalOutputPayloadRouter(bytePreferredCapabilities)
     const character = String.fromCodePoint(0x4f60)
     const bytes = new TextEncoder().encode(character)
     const first = outputChunk('wrong', encodeBase64(bytes.slice(0, 2)))
     const second = outputChunk('wrong', encodeBase64(bytes.slice(2)))
 
-    expect(decoder.decode(first)).toBe('')
-    expect(decoder.decode(second)).toBe(character)
+    expect(router.read(first)).toEqual({ inputMode: 'bytes', text: '' })
+    expect(router.read(second)).toEqual({
+      inputMode: 'bytes',
+      text: character,
+    })
   })
 
   test('falls back to text when bytes are unavailable or invalid', () => {
-    const decoder = new TerminalOutputPayloadDecoder()
+    const router = new TerminalOutputPayloadRouter(bytePreferredCapabilities)
 
-    expect(decoder.decode(outputChunk('fallback'))).toBe('fallback')
-    expect(decoder.decode(outputChunk('fallback', 'not base64?'))).toBe(
-      'fallback'
-    )
+    expect(router.read(outputChunk('fallback'))).toEqual({
+      inputMode: 'text',
+      text: 'fallback',
+    })
+
+    expect(router.read(outputChunk('fallback', 'not base64?'))).toEqual({
+      inputMode: 'text',
+      text: 'fallback',
+    })
   })
 
   test('resets streaming bytes before falling back to text', () => {
-    const decoder = new TerminalOutputPayloadDecoder()
+    const router = new TerminalOutputPayloadRouter(bytePreferredCapabilities)
     const character = String.fromCodePoint(0x4f60)
     const bytes = new TextEncoder().encode(character)
     const partial = outputChunk('wrong', encodeBase64(bytes.slice(0, 2)))
     const complete = outputChunk('wrong', encodeBase64(bytes))
 
-    expect(decoder.decode(partial)).toBe('')
-    expect(decoder.decode(outputChunk('fallback'))).toBe('fallback')
-    expect(decoder.decode(complete)).toBe(character)
+    expect(router.read(partial)).toEqual({ inputMode: 'bytes', text: '' })
+    expect(router.read(outputChunk('fallback'))).toEqual({
+      inputMode: 'text',
+      text: 'fallback',
+    })
+
+    expect(router.read(complete)).toEqual({
+      inputMode: 'bytes',
+      text: character,
+    })
+  })
+
+  test('routes text-preferring renderers through text chunks', () => {
+    const router = new TerminalOutputPayloadRouter(textOnlyCapabilities)
+
+    expect(
+      router.read(outputChunk('text wins', encodeText('bytes lose')))
+    ).toEqual({
+      inputMode: 'text',
+      text: 'text wins',
+    })
+  })
+
+  test('routes byte-preferring renderers through byte chunks', () => {
+    const router = new TerminalOutputPayloadRouter(bytePreferredCapabilities)
+
+    expect(
+      router.read(outputChunk('text loses', encodeText('bytes win')))
+    ).toEqual({
+      inputMode: 'bytes',
+      text: 'bytes win',
+    })
+  })
+
+  test('falls back to text only when byte-preferring renderers accept text', () => {
+    const router = new TerminalOutputPayloadRouter(bytePreferredCapabilities)
+
+    expect(router.read(outputChunk('text fallback'))).toEqual({
+      inputMode: 'text',
+      text: 'text fallback',
+    })
+  })
+
+  test('throws when byte-only renderers receive no readable byte payload', () => {
+    const router = new TerminalOutputPayloadRouter(byteOnlyCapabilities)
+
+    expect(() => router.read(outputChunk('text fallback'))).toThrow(
+      'Terminal renderer requires bytesBase64 output'
+    )
+
+    expect(() =>
+      router.read(outputChunk('text fallback', 'not base64?'))
+    ).toThrow('Terminal renderer requires bytesBase64 output')
   })
 })

--- a/src/features/terminal/components/TerminalPane/terminalOutputPayload.ts
+++ b/src/features/terminal/components/TerminalPane/terminalOutputPayload.ts
@@ -1,4 +1,8 @@
-import type { TerminalOutputChunk } from '../../types'
+import type {
+  TerminalOutputChunk,
+  TerminalOutputInputMode,
+  TerminalRendererCapabilities,
+} from '../../types'
 
 export const decodeBase64ToBytes = (value: string): Uint8Array | null => {
   try {
@@ -22,16 +26,16 @@ export const readTerminalOutputBytes = (
     ? null
     : decodeBase64ToBytes(chunk.bytesBase64)
 
-export class TerminalOutputPayloadDecoder {
+class TerminalOutputBytePayloadDecoder {
   private readonly streamingDecoder = new TextDecoder()
 
-  decode(chunk: TerminalOutputChunk): string {
+  decode(chunk: TerminalOutputChunk): string | null {
     const bytes = readTerminalOutputBytes(chunk)
 
     if (!bytes) {
       this.reset()
 
-      return chunk.text
+      return null
     }
 
     return this.streamingDecoder.decode(bytes, { stream: true })
@@ -39,5 +43,50 @@ export class TerminalOutputPayloadDecoder {
 
   private reset(): void {
     this.streamingDecoder.decode()
+  }
+}
+
+export interface TerminalOutputPayloadSelection {
+  readonly inputMode: TerminalOutputInputMode
+  readonly text: string
+}
+
+export class TerminalOutputPayloadRouter {
+  private readonly byteDecoder: TerminalOutputBytePayloadDecoder | null
+
+  constructor(private readonly capabilities: TerminalRendererCapabilities) {
+    this.byteDecoder =
+      capabilities.preferredOutputInputMode === 'bytes'
+        ? new TerminalOutputBytePayloadDecoder()
+        : null
+  }
+
+  read(chunk: TerminalOutputChunk): TerminalOutputPayloadSelection {
+    if (this.capabilities.preferredOutputInputMode === 'text') {
+      return {
+        inputMode: 'text',
+        text: chunk.text,
+      }
+    }
+
+    const decodedBytes = this.byteDecoder?.decode(chunk) ?? null
+
+    if (decodedBytes !== null) {
+      return {
+        inputMode: 'bytes',
+        text: decodedBytes,
+      }
+    }
+
+    if (this.capabilities.acceptsText) {
+      return {
+        inputMode: 'text',
+        text: chunk.text,
+      }
+    }
+
+    throw new Error(
+      'Terminal renderer requires bytesBase64 output, but the chunk did not include readable bytesBase64'
+    )
   }
 }

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts
@@ -1,10 +1,32 @@
 // cspell:ignore ghostty
 import { describe, expect, test, vi } from 'vitest'
-import type { TerminalOutputChunk, TerminalOutputPhase } from '../../types'
+import type {
+  TerminalOutputChunk,
+  TerminalOutputPhase,
+  TerminalRendererCapabilities,
+} from '../../types'
 import {
-  createByteControlSequenceTerminalParserEngine,
-  createTextControlSequenceTerminalParserEngine,
+  TerminalControlSequenceParserEngine,
+  createControlSequenceTerminalParserEngine,
 } from './terminalParserEngine'
+
+const textOnlyCapabilities: TerminalRendererCapabilities = {
+  preferredOutputInputMode: 'text',
+  acceptsText: true,
+  acceptsBytes: false,
+}
+
+const bytePreferredCapabilities: TerminalRendererCapabilities = {
+  preferredOutputInputMode: 'bytes',
+  acceptsText: true,
+  acceptsBytes: true,
+}
+
+const byteOnlyCapabilities: TerminalRendererCapabilities = {
+  preferredOutputInputMode: 'bytes',
+  acceptsText: false,
+  acceptsBytes: true,
+}
 
 const encodeBase64 = (bytes: Uint8Array): string => {
   let binary = ''
@@ -32,9 +54,30 @@ const createByteChunk = (
   }
 }
 
+const createTextChunk = (
+  text: string,
+  offsetStart: number,
+  phase: TerminalOutputPhase
+): TerminalOutputChunk => ({
+  text,
+  offsetStart,
+  byteLen: new TextEncoder().encode(text).length,
+  phase,
+})
+
+const createTextEngine = (): TerminalControlSequenceParserEngine =>
+  new TerminalControlSequenceParserEngine({
+    capabilities: textOnlyCapabilities,
+  })
+
+const createByteEngine = (): TerminalControlSequenceParserEngine =>
+  new TerminalControlSequenceParserEngine({
+    capabilities: bytePreferredCapabilities,
+  })
+
 describe('terminal parser engine input modes', () => {
   test('text mode records its input mode and ignores byte payloads', () => {
-    const engine = createTextControlSequenceTerminalParserEngine()
+    const engine = createTextEngine()
     const chunk = createByteChunk('bytes lose', 0, 'live')
 
     expect(engine.inputMode).toBe('text')
@@ -44,7 +87,7 @@ describe('terminal parser engine input modes', () => {
   })
 
   test('byte mode records its input mode and prefers byte payloads', () => {
-    const engine = createByteControlSequenceTerminalParserEngine()
+    const engine = createByteEngine()
 
     expect(engine.inputMode).toBe('bytes')
     expect(engine.parseOutput(createByteChunk('bytes win', 0, 'live'))).toEqual(
@@ -53,11 +96,81 @@ describe('terminal parser engine input modes', () => {
       }
     )
   })
+
+  test('control parser class exposes the configured capabilities', () => {
+    const engine = new TerminalControlSequenceParserEngine({
+      capabilities: bytePreferredCapabilities,
+    })
+
+    expect(engine.inputMode).toBe('bytes')
+    expect(engine.capabilities).toBe(bytePreferredCapabilities)
+  })
+
+  test('capability-aware parser engines fall back to text only when allowed', () => {
+    const fallbackEngine = createControlSequenceTerminalParserEngine({
+      capabilities: bytePreferredCapabilities,
+    })
+
+    const byteOnlyEngine = createControlSequenceTerminalParserEngine({
+      capabilities: byteOnlyCapabilities,
+    })
+
+    expect(
+      fallbackEngine.parseOutput(createTextChunk('fallback', 0, 'live'))
+    ).toEqual({ visibleText: 'fallback' })
+
+    expect(() =>
+      byteOnlyEngine.parseOutput(createTextChunk('fallback', 0, 'live'))
+    ).toThrow('Terminal renderer requires bytesBase64 output')
+  })
+
+  test('emits matching OSC 7 cwd events from text and byte paths', () => {
+    const textEngine = createControlSequenceTerminalParserEngine({
+      capabilities: textOnlyCapabilities,
+    })
+
+    const byteEngine = createControlSequenceTerminalParserEngine({
+      capabilities: bytePreferredCapabilities,
+    })
+
+    const textHandler = vi.fn()
+    const byteHandler = vi.fn()
+    const output = 'before \x1b]7;file://localhost/tmp/generic-parser\x07 after'
+
+    textEngine.parser.onEvent(textHandler)
+    byteEngine.parser.onEvent(byteHandler)
+
+    expect(textEngine.parseOutput(createTextChunk(output, 12, 'live'))).toEqual(
+      {
+        visibleText: 'before  after',
+      }
+    )
+
+    expect(byteEngine.parseOutput(createByteChunk(output, 12, 'live'))).toEqual(
+      {
+        visibleText: 'before  after',
+      }
+    )
+
+    const expectedEvent = {
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/generic-parser',
+      output: {
+        offsetStart: 12,
+        byteLen: new TextEncoder().encode(output).length,
+        phase: 'live',
+      },
+    }
+
+    expect(textHandler).toHaveBeenCalledWith(expectedEvent)
+    expect(byteHandler).toHaveBeenCalledWith(expectedEvent)
+  })
 })
 
-describe('createByteControlSequenceTerminalParserEngine', () => {
+describe('byte-capable control sequence parser engine', () => {
   test('emits OSC 7 cwd events from byte payloads', () => {
-    const engine = createByteControlSequenceTerminalParserEngine()
+    const engine = createByteEngine()
     const handler = vi.fn()
 
     const chunk = createByteChunk(
@@ -82,7 +195,7 @@ describe('createByteControlSequenceTerminalParserEngine', () => {
   })
 
   test('reassembles split OSC 7 byte payloads with completion context', () => {
-    const engine = createByteControlSequenceTerminalParserEngine()
+    const engine = createByteEngine()
     const handler = vi.fn()
 
     const firstChunk = createByteChunk(
@@ -114,7 +227,7 @@ describe('createByteControlSequenceTerminalParserEngine', () => {
   })
 
   test('supports OSC 7 sequences terminated with string terminator', () => {
-    const engine = createByteControlSequenceTerminalParserEngine()
+    const engine = createByteEngine()
     const handler = vi.fn()
 
     const chunk = createByteChunk(
@@ -139,7 +252,7 @@ describe('createByteControlSequenceTerminalParserEngine', () => {
   })
 
   test('preserves raw non-file OSC 7 payloads for consumer validation', () => {
-    const engine = createByteControlSequenceTerminalParserEngine()
+    const engine = createByteEngine()
     const handler = vi.fn()
 
     const chunk = createByteChunk(

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -3,9 +3,10 @@ import type {
   TerminalOutputChunk,
   TerminalParser,
   TerminalParserOutputContext,
+  TerminalRendererCapabilities,
 } from '../../types'
 import { TerminalControlSequenceParser } from './terminalControlParser'
-import { TerminalOutputPayloadDecoder } from './terminalOutputPayload'
+import { TerminalOutputPayloadRouter } from './terminalOutputPayload'
 
 export interface TerminalParserEngineOutput {
   readonly visibleText: string
@@ -14,11 +15,12 @@ export interface TerminalParserEngineOutput {
 export type TerminalParserEngineInputMode = TerminalOutputInputMode
 
 export interface TerminalParserEngineOptions {
-  readonly inputMode: TerminalParserEngineInputMode
+  readonly capabilities: TerminalRendererCapabilities
 }
 
 export interface TerminalParserEngine {
   readonly inputMode: TerminalParserEngineInputMode
+  readonly capabilities: TerminalRendererCapabilities
   readonly parser: TerminalParser
   parseText: (
     text: string,
@@ -35,44 +37,36 @@ const outputContextFromChunk = (
   phase: chunk.phase,
 })
 
-const createOutputTextReader = (
-  inputMode: TerminalParserEngineInputMode
-): ((chunk: TerminalOutputChunk) => string) => {
-  if (inputMode === 'text') {
-    return (chunk): string => chunk.text
+export class TerminalControlSequenceParserEngine implements TerminalParserEngine {
+  readonly capabilities: TerminalRendererCapabilities
+  readonly parser = new TerminalControlSequenceParser()
+  private readonly outputRouter: TerminalOutputPayloadRouter
+
+  constructor(options: TerminalParserEngineOptions) {
+    this.capabilities = options.capabilities
+    this.outputRouter = new TerminalOutputPayloadRouter(options.capabilities)
   }
 
-  const decoder = new TerminalOutputPayloadDecoder()
+  get inputMode(): TerminalParserEngineInputMode {
+    return this.capabilities.preferredOutputInputMode
+  }
 
-  return (chunk): string => decoder.decode(chunk)
+  parseText(
+    text: string,
+    output: TerminalParserOutputContext | null
+  ): TerminalParserEngineOutput {
+    return {
+      visibleText: this.parser.transformOutput(text, output),
+    }
+  }
+
+  parseOutput(chunk: TerminalOutputChunk): TerminalParserEngineOutput {
+    const selection = this.outputRouter.read(chunk)
+
+    return this.parseText(selection.text, outputContextFromChunk(chunk))
+  }
 }
 
 export const createControlSequenceTerminalParserEngine = (
   options: TerminalParserEngineOptions
-): TerminalParserEngine => {
-  const parser = new TerminalControlSequenceParser()
-  const readOutputText = createOutputTextReader(options.inputMode)
-
-  const parseText = (
-    text: string,
-    output: TerminalParserOutputContext | null
-  ): TerminalParserEngineOutput => ({
-    visibleText: parser.transformOutput(text, output),
-  })
-
-  return {
-    inputMode: options.inputMode,
-    parser,
-    parseText,
-    parseOutput: (chunk): TerminalParserEngineOutput =>
-      parseText(readOutputText(chunk), outputContextFromChunk(chunk)),
-  }
-}
-
-export const createTextControlSequenceTerminalParserEngine =
-  (): TerminalParserEngine =>
-    createControlSequenceTerminalParserEngine({ inputMode: 'text' })
-
-export const createByteControlSequenceTerminalParserEngine =
-  (): TerminalParserEngine =>
-    createControlSequenceTerminalParserEngine({ inputMode: 'bytes' })
+): TerminalParserEngine => new TerminalControlSequenceParserEngine(options)

--- a/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.test.ts
@@ -124,6 +124,26 @@ describe('xtermInstance', () => {
     expect(xtermTerminalRenderer.createInstance).toBe(createXtermTerminal)
   })
 
+  test('writes text output chunks even when byte payloads are present', () => {
+    const terminal = createRawTerminal()
+    const fitAddon = { fit: vi.fn() }
+
+    vi.mocked(Terminal).mockImplementation(() => terminal as never)
+    vi.mocked(FitAddon).mockImplementation(() => fitAddon as never)
+
+    const created = createXtermTerminal()
+
+    created.output.writeOutput({
+      text: 'text wins',
+      bytesBase64: 'Ynl0ZXMgbG9zZQ==',
+      offsetStart: 0,
+      byteLen: 10,
+      phase: 'live',
+    })
+
+    expect(terminal.write).toHaveBeenCalledWith('text wins', expect.anything())
+  })
+
   test('creates a themed terminal surface with a loaded fit addon', () => {
     const terminal = createRawTerminal()
     const fitAddon = { fit: vi.fn() }

--- a/src/features/terminal/components/TerminalPane/xtermInstance.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.ts
@@ -13,13 +13,21 @@ import type {
   TerminalParser,
   TerminalRendererHandle,
   TerminalRendererAdapter,
+  TerminalRendererCapabilities,
   TerminalSurface,
   TerminalTheme,
   TerminalViewportReader,
 } from '../../types'
 import { toXtermTheme } from '../../theme/toXtermTheme'
 import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
+import { TerminalOutputPayloadRouter } from './terminalOutputPayload'
 import '@xterm/xterm/css/xterm.css'
+
+const XTERM_TERMINAL_CAPABILITIES: TerminalRendererCapabilities = {
+  preferredOutputInputMode: 'text',
+  acceptsText: true,
+  acceptsBytes: false,
+}
 
 export const createXtermTerminal = (): TerminalInstance => {
   const terminal = new Terminal({
@@ -47,11 +55,7 @@ export const createXtermTerminal = (): TerminalInstance => {
 
 export const xtermTerminalRenderer: TerminalRendererAdapter = {
   id: 'xterm',
-  capabilities: {
-    preferredOutputInputMode: 'text',
-    acceptsText: true,
-    acceptsBytes: false,
-  },
+  capabilities: XTERM_TERMINAL_CAPABILITIES,
   createInstance: createXtermTerminal,
 }
 
@@ -151,15 +155,23 @@ const createTerminalOutputContext = (): TerminalOutputContextTracker => {
 const createTerminalOutputWriter = (
   terminal: Terminal,
   outputContext: TerminalOutputContextTracker
-): TerminalOutputWriter => ({
-  writeOutput: (chunk, callback): void => {
-    outputContext.push(chunk)
-    terminal.write(chunk.text, () => {
-      outputContext.finish(chunk)
-      callback?.()
-    })
-  },
-})
+): TerminalOutputWriter => {
+  const outputRouter = new TerminalOutputPayloadRouter(
+    XTERM_TERMINAL_CAPABILITIES
+  )
+
+  return {
+    writeOutput: (chunk, callback): void => {
+      const selection = outputRouter.read(chunk)
+
+      outputContext.push(chunk)
+      terminal.write(selection.text, () => {
+        outputContext.finish(chunk)
+        callback?.()
+      })
+    },
+  }
+}
 
 const createTerminalParser = (
   terminal: Terminal,


### PR DESCRIPTION
## Summary

- Add a capability-aware terminal output payload router for text and byte renderer paths.
- Convert the control-sequence parser engine into an explicit class that owns routing, parser state, and output context construction.
- Wire xterm, plain-text, and Ghostty adapters so their declared capabilities drive the write/parser path.
- Add tests for text routing, byte routing, Ghostty text fallback, byte-only failure, xterm text behavior, and OSC 7 parity between text and byte parser paths.

## Validation

- npx tsc -b --pretty false
- npm --ignore-scripts run lint
- npm --ignore-scripts run format:check
- git diff --check
- npx vitest run src/features/terminal/components/TerminalPane
- npx vitest run src/features/terminal