### PR TITLE
[codex] fix browser pane native bounds resync

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -46,7 +46,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 23       | 5    | 2026-06-13   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
 | [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 39       | 20   | 2026-06-15   |
-| [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 4        | 1    | 2026-06-17   |
+| [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 6        | 2    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 15       | 12   | 2026-06-16   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -46,7 +46,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 23       | 5    | 2026-06-13   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
 | [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 39       | 20   | 2026-06-15   |
-| [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 6        | 2    | 2026-06-17   |
+| [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 15       | 12   | 2026-06-16   |
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 2        | 0    | 2026-06-16   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 30   | 2026-06-17   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 68       | 32   | 2026-06-17   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 59       | 24   | 2026-06-15   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -46,7 +46,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 23       | 5    | 2026-06-13   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
 | [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 39       | 20   | 2026-06-15   |
-| [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 2        | 1    | 2026-06-15   |
+| [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 4        | 1    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 15       | 12   | 2026-06-16   |
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 2        | 0    | 2026-06-16   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 30   | 2026-06-15   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 30   | 2026-06-17   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 59       | 24   | 2026-06-15   |

--- a/docs/reviews/patterns/imperative-animation-ownership.md
+++ b/docs/reviews/patterns/imperative-animation-ownership.md
@@ -2,7 +2,7 @@
 id: imperative-animation-ownership
 category: react-patterns
 created: 2026-06-15
-last_updated: 2026-06-15
+last_updated: 2026-06-17
 ref_count: 1
 ---
 
@@ -60,4 +60,22 @@ The fix shape:
   write a resting `buildReservoirSurface` path to both SVG paths using the
   current geometry. Added test coverage verifying the surface returns to the
   resting crest when reduced motion is enabled mid-hover.
+- **Commit:** _(same commit as this entry)_
+
+### 3. Perpetual rAF loop polls `getBoundingClientRect` at 60+ fps per pane forever
+
+- **Source:** github-claude | PR #515 round 1 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/features/browser/components/BrowserPane.tsx`
+- **Finding:** A `requestAnimationFrame` loop scheduled on mount called `syncBounds()` every frame for the component's entire lifetime. `syncBounds` ran `getBoundingClientRect()` and built a string key on every tick even when nothing had moved; the dedup only short-circuited the IPC call, not the DOM read.
+- **Fix:** Added a 60-frame idle counter inside the rAF tick. When the bounds key is unchanged for 60 consecutive frames the loop stops rescheduling. A `useLayoutEffect` that already fires `syncBounds()` on every React render bumps a `boundsGeneration` key whenever the bounds actually change, causing the rAF effect to re-run and restart the loop.
+- **Commit:** _(same commit as this entry)_
+
+### 4. Bounds-sync rAF runs for hidden/background browser panes
+
+- **Source:** github-codex-connector | PR #515 round 1 | 2026-06-17
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/browser/components/BrowserPane.tsx`
+- **Finding:** `TerminalZone` keeps inactive session panels mounted and only hides them with CSS, so the unconditional rAF loop started for every background `BrowserPane`. Hidden panes kept calling `syncBounds()`/`getBoundingClientRect()` once per frame even after they had already sent invisible/0×0 bounds.
+- **Fix:** Gated the rAF effect on `nativePaneReady && isActive && !isOccluded` so the loop only runs while the pane is visible. The existing focus/occlusion effects still send a final invisible bounds update when the pane becomes inactive or occluded.
 - **Commit:** _(same commit as this entry)_

--- a/docs/reviews/patterns/imperative-animation-ownership.md
+++ b/docs/reviews/patterns/imperative-animation-ownership.md
@@ -3,7 +3,7 @@ id: imperative-animation-ownership
 category: react-patterns
 created: 2026-06-15
 last_updated: 2026-06-17
-ref_count: 1
+ref_count: 2
 ---
 
 # Imperative Animation Ownership
@@ -78,4 +78,22 @@ The fix shape:
 - **File:** `src/features/browser/components/BrowserPane.tsx`
 - **Finding:** `TerminalZone` keeps inactive session panels mounted and only hides them with CSS, so the unconditional rAF loop started for every background `BrowserPane`. Hidden panes kept calling `syncBounds()`/`getBoundingClientRect()` once per frame even after they had already sent invisible/0×0 bounds.
 - **Fix:** Gated the rAF effect on `nativePaneReady && isActive && !isOccluded` so the loop only runs while the pane is visible. The existing focus/occlusion effects still send a final invisible bounds update when the pane becomes inactive or occluded.
+- **Commit:** _(same commit as this entry)_
+
+### 5. rAF idle cutoff leaves stale native bounds after position-only ancestor moves
+
+- **Source:** github-claude | PR #515 round 2 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/features/browser/components/BrowserPane.tsx`
+- **Finding:** After 60 unchanged frames the rAF bounds-sync loop stopped and only restarted from React-visible dependencies. A later CSS transform or other position-only ancestor move that did not cause a React render left the native `WebContentsView` at stale coordinates until an unrelated render occurred.
+- **Fix:** Added a 250 ms post-idle polling interval and an ancestor `MutationObserver` watching `style`/`class` attributes up to 10 ancestors deep. Either detector restarts a short rAF burst that calls `syncBounds()`, catching CSS-only moves without restoring a perpetual 60 fps loop.
+- **Commit:** _(same commit as this entry)_
+
+### 6. `nativePaneReady` state is not reset in creation-effect cleanup
+
+- **Source:** github-claude | PR #515 round 2 | 2026-06-17
+- **Severity:** LOW
+- **File:** `src/features/browser/components/BrowserPane.tsx`
+- **Finding:** The creation effect cleanup set `nativePaneReadyRef.current = false` but did not call `setNativePaneReady(false)`. If `browserSessionId` or `pane.id` changed and the effect re-ran, the rAF guard stayed `true` and the loop spun for up to 60 idle frames before `syncBounds()`'s ref guard short-circuited each tick.
+- **Fix:** Added `setNativePaneReady(false)` to the cleanup so the reactive state mirror matches the ref and reliably restarts the rAF effect on re-mount.
 - **Commit:** _(same commit as this entry)_

--- a/docs/reviews/patterns/imperative-animation-ownership.md
+++ b/docs/reviews/patterns/imperative-animation-ownership.md
@@ -3,7 +3,7 @@ id: imperative-animation-ownership
 category: react-patterns
 created: 2026-06-15
 last_updated: 2026-06-17
-ref_count: 2
+ref_count: 3
 ---
 
 # Imperative Animation Ownership
@@ -96,4 +96,13 @@ The fix shape:
 - **File:** `src/features/browser/components/BrowserPane.tsx`
 - **Finding:** The creation effect cleanup set `nativePaneReadyRef.current = false` but did not call `setNativePaneReady(false)`. If `browserSessionId` or `pane.id` changed and the effect re-ran, the rAF guard stayed `true` and the loop spun for up to 60 idle frames before `syncBounds()`'s ref guard short-circuited each tick.
 - **Fix:** Added `setNativePaneReady(false)` to the cleanup so the reactive state mirror matches the ref and reliably restarts the rAF effect on re-mount.
+- **Commit:** _(same commit as this entry)_
+
+### 7. MutationObserver restarts rAF burst unconditionally on ancestor class/style mutations
+
+- **Source:** github-claude | PR #515 round 3 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/features/browser/components/BrowserPane.tsx`
+- **Finding:** In `startPostIdleDetection`, the `MutationObserver` callback called `restart()` for every `style` or `class` attribute change on any observed ancestor, with no bounds-change guard. Hover/focus/active CSS classes on split-view ancestors therefore triggered a 60-frame rAF burst even when the browser pane had not moved.
+- **Fix:** Mirrored the interval guard inside the MO callback: call `syncBounds()`, then only call `restart()` if `lastBoundsKeyRef.current` changed. This catches transform-driven moves while ignoring cosmetic class mutations.
 - **Commit:** _(same commit as this entry)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,7 +2,7 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-15
+last_updated: 2026-06-17
 ref_count: 31
 ---
 
@@ -657,3 +657,12 @@ filesystem scope restrictions).
 - **Finding:** `makeMql` returned `addEventListener`/`removeEventListener` as `vi.fn()` stubs that recorded nothing and fired nothing, so the hook's `onMqlChange` handler was unreachable in tests. The unmount test also only asserted pointer-event cleanup, never `mql.removeEventListener('change', onMqlChange)`.
 - **Fix:** Upgraded the mock to a `MockMql` helper that captures listeners and exposes a `fire()` method, then added a reduced-motion-toggle test and a cleanup assertion for the `'change'` listener. (Carried forward across the swell-model rewrite of the hook.)
 - **Commit:** same commit as this entry
+
+### 66. `requestAnimationFrame` mock always returns the same frame ID
+
+- **Source:** github-claude | PR #515 round 1 | 2026-06-17
+- **Severity:** LOW
+- **File:** `src/features/browser/components/BrowserPane.test.tsx`
+- **Finding:** The test spy mocked `window.requestAnimationFrame` to always return `1`. After the spy was restored, the component's unmount cleanup called `window.cancelAnimationFrame(1)` against the real API. In jsdom frame IDs start at `1`, so any other real rAF queued with that ID would be silently dropped.
+- **Fix:** Changed the mock to return incrementing IDs (`let nextFrameId = 1; return nextFrameId++`) so each scheduled frame is unique and cleanup cancels only this component's own frame.
+- **Commit:** _(same commit as this entry)_

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-06-17
-ref_count: 31
+ref_count: 32
 ---
 
 # Testing Gaps
@@ -665,4 +665,22 @@ filesystem scope restrictions).
 - **File:** `src/features/browser/components/BrowserPane.test.tsx`
 - **Finding:** The test spy mocked `window.requestAnimationFrame` to always return `1`. After the spy was restored, the component's unmount cleanup called `window.cancelAnimationFrame(1)` against the real API. In jsdom frame IDs start at `1`, so any other real rAF queued with that ID would be silently dropped.
 - **Fix:** Changed the mock to return incrementing IDs (`let nextFrameId = 1; return nextFrameId++`) so each scheduled frame is unique and cleanup cancels only this component's own frame.
+- **Commit:** _(same commit as this entry)_
+
+### 67. e2e helper hard-codes pane ID format `p${slotIndex}` without DOM read
+
+- **Source:** github-claude | PR #515 round 3 | 2026-06-17
+- **Severity:** LOW
+- **File:** `tests/e2e/core/specs/browser-pane-overlay.spec.ts`
+- **Finding:** `prepareBrowserPaneAtSlot` constructed `paneId = \`p${slotIndex}\``and passed it to`readBrowserPaneIdentity` without verifying the ID against the DOM. A future change to pane-ID format would fail every parametrized slot test with an opaque "identity not available" error.
+- **Fix:** Read `dataset.paneId` from the Nth `[data-testid="split-view-slot"]` node in the active split view and throw a clear error if the slot has no pane ID.
+- **Commit:** _(same commit as this entry)_
+
+### 68. Post-idle unit test asserts interval cleanup but not MutationObserver disconnect
+
+- **Source:** github-claude | PR #515 round 3 | 2026-06-17
+- **Severity:** LOW
+- **File:** `src/features/browser/components/BrowserPane.test.tsx`
+- **Finding:** The `detects position-only moves after the rAF loop has idled` test verified `clearInterval` was called on unmount, but did not assert that the `MutationObserver` from `startPostIdleDetection` was disconnected. A regression that omitted `disconnect()` would leave a live MO after unmount undetected.
+- **Fix:** Added `vi.spyOn(MutationObserver.prototype, 'disconnect')` before render and asserted it was called after `unmount()`.
 - **Commit:** _(same commit as this entry)_

--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -293,6 +293,86 @@ describe('BrowserPane', () => {
     }
   })
 
+  test('detects position-only moves after the rAF loop has idled', async () => {
+    let frameCallback: FrameRequestCallback | null = null
+    let nextFrameId = 1
+    let intervalCallback: (() => void) | null = null
+    let intervalCleared = false
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallback = callback
+
+        return nextFrameId++
+      })
+
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => undefined)
+
+    const setIntervalSpy = vi
+      .spyOn(window, 'setInterval')
+      .mockImplementation(
+        (
+          handler: unknown,
+          _timeout?: unknown,
+          ..._args: unknown[]
+        ): ReturnType<typeof window.setInterval> => {
+          if (typeof handler === 'function') {
+            intervalCallback = handler as () => void
+          }
+
+          return 123 as unknown as ReturnType<typeof window.setInterval>
+        }
+      )
+
+    const clearIntervalSpy = vi
+      .spyOn(window, 'clearInterval')
+      .mockImplementation((id: unknown): void => {
+        if (id === 123) {
+          intervalCleared = true
+        }
+      })
+
+    try {
+      const { unmount } = render(
+        <BrowserPaneHarness session={session} pane={browserPane} isActive />
+      )
+      await settle()
+      bridgeMocks.setBrowserPaneBounds.mockClear()
+
+      for (let i = 0; i < 60; i += 1) {
+        act(() => {
+          frameCallback?.(performance.now())
+        })
+      }
+
+      expect(intervalCallback).not.toBeNull()
+
+      rectSpy.mockReturnValue(movedRect)
+      act(() => {
+        intervalCallback?.()
+      })
+
+      expect(bridgeMocks.setBrowserPaneBounds).toHaveBeenLastCalledWith({
+        sessionId: 'session-1',
+        paneId: 'p1',
+        bounds: { x: 120, y: 20, width: 640, height: 360 },
+        shortcutContext: { activePaneId: 'p1', paneIds: ['p0', 'p1'] },
+        visible: true,
+      })
+
+      unmount()
+      expect(intervalCleared).toBe(true)
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+      cancelAnimationFrameSpy.mockRestore()
+      setIntervalSpy.mockRestore()
+      clearIntervalSpy.mockRestore()
+    }
+  })
+
   test('marks the native browser pane invisible while occluded, then restores it', async () => {
     const { rerender } = render(
       <BrowserPaneHarness

--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -88,6 +88,13 @@ const rect = {
   toJSON: (): Record<string, number> => ({}),
 } as DOMRect
 
+const movedRect = {
+  ...rect,
+  x: 120,
+  left: 120,
+  right: 760,
+} as DOMRect
+
 const singleTab: BrowserPaneCreateResult = {
   url: 'https://example.com/',
   title: 'Example',
@@ -241,6 +248,48 @@ describe('BrowserPane', () => {
       shortcutContext: { activePaneId: 'p1', paneIds: ['p0', 'p1'] },
       visible: true,
     })
+  })
+
+  test('updates bounds when the content position changes without resize or rerender', async () => {
+    let frameCallback: FrameRequestCallback | null = null
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        frameCallback = callback
+
+        return 1
+      })
+
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => undefined)
+
+    try {
+      render(
+        <BrowserPaneHarness session={session} pane={browserPane} isActive />
+      )
+      await settle()
+      bridgeMocks.setBrowserPaneBounds.mockClear()
+
+      rectSpy.mockReturnValue(movedRect)
+      act(() => {
+        frameCallback?.(performance.now())
+      })
+
+      await waitFor(() => {
+        expect(bridgeMocks.setBrowserPaneBounds).toHaveBeenLastCalledWith({
+          sessionId: 'session-1',
+          paneId: 'p1',
+          bounds: { x: 120, y: 20, width: 640, height: 360 },
+          shortcutContext: { activePaneId: 'p1', paneIds: ['p0', 'p1'] },
+          visible: true,
+        })
+      })
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+      cancelAnimationFrameSpy.mockRestore()
+    }
   })
 
   test('marks the native browser pane invisible while occluded, then restores it', async () => {

--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -252,13 +252,14 @@ describe('BrowserPane', () => {
 
   test('updates bounds when the content position changes without resize or rerender', async () => {
     let frameCallback: FrameRequestCallback | null = null
+    let nextFrameId = 1
 
     const requestAnimationFrameSpy = vi
       .spyOn(window, 'requestAnimationFrame')
       .mockImplementation((callback: FrameRequestCallback): number => {
         frameCallback = callback
 
-        return 1
+        return nextFrameId++
       })
 
     const cancelAnimationFrameSpy = vi

--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -299,6 +299,10 @@ describe('BrowserPane', () => {
     let intervalCallback: (() => void) | null = null
     let intervalCleared = false
 
+    const disconnectSpy = vi
+      .spyOn(MutationObserver.prototype, 'disconnect')
+      .mockImplementation(() => undefined)
+
     const requestAnimationFrameSpy = vi
       .spyOn(window, 'requestAnimationFrame')
       .mockImplementation((callback: FrameRequestCallback): number => {
@@ -314,11 +318,7 @@ describe('BrowserPane', () => {
     const setIntervalSpy = vi
       .spyOn(window, 'setInterval')
       .mockImplementation(
-        (
-          handler: unknown,
-          _timeout?: unknown,
-          ..._args: unknown[]
-        ): ReturnType<typeof window.setInterval> => {
+        (handler: unknown): ReturnType<typeof window.setInterval> => {
           if (typeof handler === 'function') {
             intervalCallback = handler as () => void
           }
@@ -365,11 +365,13 @@ describe('BrowserPane', () => {
 
       unmount()
       expect(intervalCleared).toBe(true)
+      expect(disconnectSpy).toHaveBeenCalled()
     } finally {
       requestAnimationFrameSpy.mockRestore()
       cancelAnimationFrameSpy.mockRestore()
       setIntervalSpy.mockRestore()
       clearIntervalSpy.mockRestore()
+      disconnectSpy.mockRestore()
     }
   })
 

--- a/src/features/browser/components/BrowserPane.tsx
+++ b/src/features/browser/components/BrowserPane.tsx
@@ -293,6 +293,7 @@ export const BrowserPane = ({
     return (): void => {
       lifecycle.cancelled = true
       nativePaneReadyRef.current = false
+      setNativePaneReady(false)
       offNavState()
     }
   }, [browserSessionId, pane.id, session.id, session.projectId, syncBounds])
@@ -325,15 +326,76 @@ export const BrowserPane = ({
   // also need to follow ancestor transforms and other position-only moves.
   // The loop runs only while the pane is visible and stops once bounds have
   // been stable for a short interval, restarting automatically when visibility
-  // or layout changes.
+  // or layout changes. After the rAF window idles, a low-frequency interval
+  // plus an ancestor mutation observer detect CSS-only position moves that
+  // do not trigger a React render.
   useEffect(() => {
     if (!nativePaneReady || !isActive || isOccluded) {
       return
     }
 
+    const IDLE_CUTOFF = 60
+    const POST_IDLE_INTERVAL_MS = 250
+    const MAX_MUTATION_ANCESTOR_DEPTH = 10
+
     let frameId: number | null = null
+    let postIdleIntervalId: number | null = null
+    let mutationObserver: MutationObserver | null = null
     let idleFrames = 0
     let running = true
+
+    const stopPostIdleDetection = (): void => {
+      if (postIdleIntervalId !== null) {
+        window.clearInterval(postIdleIntervalId)
+        postIdleIntervalId = null
+      }
+
+      if (mutationObserver !== null) {
+        mutationObserver.disconnect()
+        mutationObserver = null
+      }
+    }
+
+    const restart = (): void => {
+      if (running) {
+        return
+      }
+
+      running = true
+      idleFrames = 0
+      stopPostIdleDetection()
+      frameId = window.requestAnimationFrame(tick)
+    }
+
+    const startPostIdleDetection = (): void => {
+      const node = contentRef.current
+      if (!node) {
+        return
+      }
+
+      postIdleIntervalId = window.setInterval(() => {
+        const previousKey = lastBoundsKeyRef.current
+        syncBounds()
+        if (lastBoundsKeyRef.current !== previousKey) {
+          restart()
+        }
+      }, POST_IDLE_INTERVAL_MS)
+
+      mutationObserver = new MutationObserver(() => {
+        restart()
+      })
+
+      let ancestor: Element | null = node.parentElement
+      let depth = 0
+      while (ancestor !== null && depth < MAX_MUTATION_ANCESTOR_DEPTH) {
+        mutationObserver.observe(ancestor, {
+          attributes: true,
+          attributeFilter: ['style', 'class'],
+        })
+        ancestor = ancestor.parentElement
+        depth += 1
+      }
+    }
 
     const tick = (): void => {
       if (!running) {
@@ -349,8 +411,9 @@ export const BrowserPane = ({
         idleFrames = 0
       }
 
-      if (idleFrames >= 60) {
+      if (idleFrames >= IDLE_CUTOFF) {
         running = false
+        startPostIdleDetection()
 
         return
       }
@@ -365,6 +428,8 @@ export const BrowserPane = ({
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId)
       }
+
+      stopPostIdleDetection()
     }
   }, [isActive, isOccluded, nativePaneReady, boundsGeneration, syncBounds])
 

--- a/src/features/browser/components/BrowserPane.tsx
+++ b/src/features/browser/components/BrowserPane.tsx
@@ -309,6 +309,29 @@ export const BrowserPane = ({
     }
   }, [browserSessionId, pane.id, syncBounds])
 
+  // ResizeObserver only sees box-size changes; native WebContentsView bounds
+  // also need to follow ancestor transforms and other position-only moves.
+  useEffect(() => {
+    let frameId: number | null = null
+    let stopped = false
+
+    const tick = (): void => {
+      syncBounds()
+      if (!stopped) {
+        frameId = window.requestAnimationFrame(tick)
+      }
+    }
+
+    frameId = window.requestAnimationFrame(tick)
+
+    return (): void => {
+      stopped = true
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId)
+      }
+    }
+  }, [syncBounds])
+
   useEffect(() => {
     const becameVisibleAgain = wasOccludedRef.current && !isOccluded
     isActiveRef.current = isActive

--- a/src/features/browser/components/BrowserPane.tsx
+++ b/src/features/browser/components/BrowserPane.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
   type KeyboardEvent,
@@ -104,6 +105,12 @@ export const BrowserPane = ({
   const [isEditing, setIsEditing] = useState(false)
   const [cdpInfo, setCdpInfo] = useState<BrowserCdpInfo | null>(null)
   const [createError, setCreateError] = useState<string | null>(null)
+  const [nativePaneReady, setNativePaneReady] = useState(false)
+
+  const [boundsGeneration, bumpBoundsGeneration] = useReducer(
+    (generation: number): number => generation + 1,
+    0
+  )
 
   const [navState, setNavState] = useState<BrowserPaneNavState>({
     canGoBack: false,
@@ -216,7 +223,11 @@ export const BrowserPane = ({
     // ResizeObserver does not fire for pure position changes. Ancestor layout
     // changes such as moving the dock still re-render this component, so sync
     // after every render and let syncBounds de-dupe unchanged rectangles.
+    const previousKey = lastBoundsKeyRef.current
     syncBounds()
+    if (lastBoundsKeyRef.current !== previousKey) {
+      bumpBoundsGeneration()
+    }
   })
 
   useEffect(() => {
@@ -250,6 +261,7 @@ export const BrowserPane = ({
         }
 
         nativePaneReadyRef.current = true
+        setNativePaneReady(true)
         setCommittedUrl(result.url)
         setTabs(result.tabs)
         if (!receivedLiveNavRef.current) {
@@ -311,26 +323,50 @@ export const BrowserPane = ({
 
   // ResizeObserver only sees box-size changes; native WebContentsView bounds
   // also need to follow ancestor transforms and other position-only moves.
+  // The loop runs only while the pane is visible and stops once bounds have
+  // been stable for a short interval, restarting automatically when visibility
+  // or layout changes.
   useEffect(() => {
+    if (!nativePaneReady || !isActive || isOccluded) {
+      return
+    }
+
     let frameId: number | null = null
-    let stopped = false
+    let idleFrames = 0
+    let running = true
 
     const tick = (): void => {
-      syncBounds()
-      if (!stopped) {
-        frameId = window.requestAnimationFrame(tick)
+      if (!running) {
+        return
       }
+
+      const previousKey = lastBoundsKeyRef.current
+      syncBounds()
+
+      if (lastBoundsKeyRef.current === previousKey) {
+        idleFrames += 1
+      } else {
+        idleFrames = 0
+      }
+
+      if (idleFrames >= 60) {
+        running = false
+
+        return
+      }
+
+      frameId = window.requestAnimationFrame(tick)
     }
 
     frameId = window.requestAnimationFrame(tick)
 
     return (): void => {
-      stopped = true
+      running = false
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId)
       }
     }
-  }, [syncBounds])
+  }, [isActive, isOccluded, nativePaneReady, boundsGeneration, syncBounds])
 
   useEffect(() => {
     const becameVisibleAgain = wasOccludedRef.current && !isOccluded

--- a/src/features/browser/components/BrowserPane.tsx
+++ b/src/features/browser/components/BrowserPane.tsx
@@ -382,7 +382,11 @@ export const BrowserPane = ({
       }, POST_IDLE_INTERVAL_MS)
 
       mutationObserver = new MutationObserver(() => {
-        restart()
+        const previousKey = lastBoundsKeyRef.current
+        syncBounds()
+        if (lastBoundsKeyRef.current !== previousKey) {
+          restart()
+        }
       })
 
       let ancestor: Element | null = node.parentElement

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -633,7 +633,28 @@ const prepareBrowserPaneAtSlot = async (
 
   await waitForPaneKinds(expectedKinds)
 
-  const paneId = `p${slotIndex}`
+  const paneId = await browser.execute((index: number) => {
+    const splitViews = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+    )
+    const splitView = splitViews.find((candidate) => {
+      const rect = candidate.getBoundingClientRect()
+
+      return rect.width > 0 && rect.height > 0
+    })
+    const slots = Array.from(
+      splitView?.querySelectorAll<HTMLElement>(
+        '[data-testid="split-view-slot"]'
+      ) ?? []
+    )
+
+    return slots[index]?.dataset.paneId ?? null
+  }, slotIndex)
+
+  if (!paneId) {
+    throw new Error(`no pane id found for slot ${String(slotIndex)}`)
+  }
+
   const identity = await readBrowserPaneIdentity(paneId)
   await waitForBrowserPaneCdpInfo(identity)
 

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -1,4 +1,9 @@
 import { clickBySelector } from '../../shared/actions.js'
+import type { LayoutId, PaneKind } from '@/features/sessions/types'
+import {
+  LAYOUTS,
+  type LayoutShape,
+} from '@/features/terminal/components/SplitView/layouts'
 
 interface BrowserPaneIdentity {
   sessionId: string
@@ -24,57 +29,376 @@ interface BrowserPaneBridgeWindow {
   }
 }
 
+interface BrowserPaneDomRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 const commandPaletteSelector = '[role="dialog"][aria-label="Command palette"]'
+const commandPaletteInputSelector = '[aria-label="Command palette search"]'
+const enterKey = '\uE007'
 
-const waitForBrowserPane = async (): Promise<void> => {
-  await (
-    await $('[data-testid="terminal-pane"]')
-  ).waitForDisplayed({
-    timeout: 20_000,
-  })
+const layouts = Object.values(LAYOUTS)
 
-  await clickBySelector('button[aria-label="Vertical split"]')
+const browserSlotCases = layouts.flatMap((layout) =>
+  Array.from({ length: layout.capacity }, (_, slotIndex) => ({
+    layout,
+    slotIndex,
+  }))
+)
 
-  await browser.waitUntil(
-    async () =>
-      await browser.execute(
-        () =>
-          document.querySelector('[data-testid="split-view-empty-slot"]') !==
-          null
-      ),
-    {
-      timeout: 10_000,
-      interval: 250,
-      timeoutMsg: 'empty split slot did not render',
-    }
-  )
-
-  await clickBySelector('button[aria-label="add browser pane"]')
-  await (
-    await $('[data-testid="browser-pane"]')
-  ).waitForDisplayed({
-    timeout: 15_000,
+const dispatchCommandPaletteShortcut = async (): Promise<void> => {
+  await browser.execute(() => {
+    const platform =
+      (
+        navigator as Navigator & {
+          userAgentData?: { platform?: string }
+        }
+      ).userAgentData?.platform ?? navigator.platform
+    const isMac = platform.toLowerCase().includes('mac')
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: ';',
+        code: 'Semicolon',
+        ctrlKey: !isMac,
+        metaKey: isMac,
+        bubbles: true,
+        cancelable: true,
+      })
+    )
   })
 }
 
-const readBrowserPaneIdentity = async (): Promise<BrowserPaneIdentity> => {
-  const identity = await browser.execute(() => {
-    const pane = document.querySelector<HTMLElement>(
-      '[data-testid="browser-pane"][data-browser-pane-id]'
-    )
-    const splitView = pane?.closest<HTMLElement>('[data-testid="split-view"]')
-    const sessionId =
-      splitView?.dataset.browserSessionId ?? splitView?.dataset.sessionId
-    const paneId = pane?.dataset.browserPaneId
+const openCommandPalette = async (): Promise<void> => {
+  await dispatchCommandPaletteShortcut()
+  await (
+    await $(commandPaletteSelector)
+  ).waitForDisplayed({
+    timeout: 3_000,
+  })
+}
 
-    return sessionId && paneId ? { sessionId, paneId } : null
+const closeCommandPalette = async (): Promise<void> => {
+  await browser.execute(() => {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        code: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
   })
 
+  await waitForCommandPaletteClosed()
+}
+
+const waitForCommandPaletteClosed = async (): Promise<void> => {
+  await browser.waitUntil(
+    async () =>
+      await browser.execute(
+        (selector: string) => document.querySelector(selector) === null,
+        commandPaletteSelector
+      ),
+    {
+      timeout: 3_000,
+      interval: 100,
+      timeoutMsg: 'command palette did not close',
+    }
+  )
+}
+
+const runWorkspaceCommand = async (
+  command: ':new' | ':new-browser'
+): Promise<void> => {
+  await openCommandPalette()
+  const input = await $(commandPaletteInputSelector)
+  await input.waitForDisplayed({ timeout: 3_000 })
+  await input.setValue(command)
+  await browser.execute((selector: string) => {
+    document.querySelector<HTMLInputElement>(selector)?.focus()
+  }, commandPaletteInputSelector)
+  await browser.action('key').down(enterKey).up(enterKey).perform()
+  await waitForCommandPaletteClosed()
+}
+
+const waitForActiveSplitView = async (): Promise<void> => {
+  await browser.waitUntil(
+    async () =>
+      await browser.execute(() => {
+        const splitViews = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+        )
+
+        return splitViews.some((splitView) => {
+          const rect = splitView.getBoundingClientRect()
+
+          return rect.width > 0 && rect.height > 0
+        })
+      }),
+    {
+      timeout: 20_000,
+      interval: 250,
+      timeoutMsg: 'active split view did not render',
+    }
+  )
+}
+
+const readVisibleSessionId = async (): Promise<string | null> =>
+  await browser.execute(
+    () => window.__VIMEFLOW_E2E__?.getVisibleSessionId() ?? null
+  )
+
+const waitForVisibleSessionChange = async (
+  previousSessionId: string | null
+): Promise<void> => {
+  await browser.waitUntil(
+    async () => {
+      const currentSessionId = await readVisibleSessionId()
+
+      return currentSessionId !== null && currentSessionId !== previousSessionId
+    },
+    {
+      timeout: 20_000,
+      interval: 250,
+      timeoutMsg: 'active session did not change',
+    }
+  )
+}
+
+const waitForPaneKinds = async (
+  expectedKinds: readonly PaneKind[]
+): Promise<void> => {
+  await browser.waitUntil(
+    async () =>
+      await browser.execute((kinds: readonly PaneKind[]) => {
+        const splitViews = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+        )
+        const splitView = splitViews.find((candidate) => {
+          const rect = candidate.getBoundingClientRect()
+
+          return rect.width > 0 && rect.height > 0
+        })
+
+        if (!splitView) {
+          return false
+        }
+
+        const actualKinds = Array.from(
+          splitView.querySelectorAll<HTMLElement>(
+            '[data-testid="split-view-slot"]'
+          )
+        ).map((slot) => slot.dataset.paneKind)
+
+        return (
+          actualKinds.length === kinds.length &&
+          actualKinds.every((kind, index) => kind === kinds[index])
+        )
+      }, expectedKinds),
+    {
+      timeout: 20_000,
+      interval: 250,
+      timeoutMsg: `active pane kinds did not become ${expectedKinds.join(',')}`,
+    }
+  )
+}
+
+const switchToLayout = async (layout: LayoutShape): Promise<void> => {
+  await waitForActiveSplitView()
+  await clickBySelector(`button[aria-label="${layout.name}"]`)
+
+  await browser.waitUntil(
+    async () =>
+      await browser.execute((layoutId: LayoutId) => {
+        const splitViews = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+        )
+        const splitView = splitViews.find((candidate) => {
+          const rect = candidate.getBoundingClientRect()
+
+          return rect.width > 0 && rect.height > 0
+        })
+
+        return splitView?.dataset.layout === layoutId
+      }, layout.id),
+    {
+      timeout: 10_000,
+      interval: 250,
+      timeoutMsg: `${layout.id} split did not render`,
+    }
+  )
+}
+
+const clickActiveSplitViewButton = async (label: string): Promise<void> => {
+  const clicked = await browser.execute((buttonLabel: string) => {
+    const splitViews = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+    )
+    const splitView = splitViews.find((candidate) => {
+      const rect = candidate.getBoundingClientRect()
+
+      return rect.width > 0 && rect.height > 0
+    })
+    const button = Array.from(
+      splitView?.querySelectorAll<HTMLButtonElement>('button') ?? []
+    ).find((candidate) => candidate.getAttribute('aria-label') === buttonLabel)
+
+    button?.click()
+
+    return button !== undefined
+  }, label)
+
+  if (!clicked) {
+    throw new Error(`active split view had no ${label} button`)
+  }
+}
+
+const addShellPane = async (nextPaneCount: number): Promise<void> => {
+  await clickActiveSplitViewButton('add shell pane')
+  await browser.waitUntil(
+    async () =>
+      await browser.execute((count: number) => {
+        const splitViews = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+        )
+        const splitView = splitViews.find((candidate) => {
+          const rect = candidate.getBoundingClientRect()
+
+          return rect.width > 0 && rect.height > 0
+        })
+
+        return (
+          splitView?.querySelectorAll('[data-testid="split-view-slot"]')
+            .length === count
+        )
+      }, nextPaneCount),
+    {
+      timeout: 20_000,
+      interval: 250,
+      timeoutMsg: `split view did not reach ${String(nextPaneCount)} panes`,
+    }
+  )
+}
+
+const addBrowserPane = async (nextPaneCount: number): Promise<void> => {
+  await clickActiveSplitViewButton('add browser pane')
+  await browser.waitUntil(
+    async () =>
+      await browser.execute((count: number) => {
+        const splitViews = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+        )
+        const splitView = splitViews.find((candidate) => {
+          const rect = candidate.getBoundingClientRect()
+
+          return rect.width > 0 && rect.height > 0
+        })
+
+        return (
+          splitView?.querySelectorAll('[data-testid="split-view-slot"]')
+            .length === count &&
+          splitView.querySelector('[data-testid="browser-pane"]') !== null
+        )
+      }, nextPaneCount),
+    {
+      timeout: 20_000,
+      interval: 250,
+      timeoutMsg: `browser pane did not mount at pane count ${String(
+        nextPaneCount
+      )}`,
+    }
+  )
+}
+
+const createFreshShellSession = async (): Promise<void> => {
+  await waitForActiveSplitView()
+  const previousSessionId = await readVisibleSessionId()
+  await runWorkspaceCommand(':new')
+  await waitForVisibleSessionChange(previousSessionId)
+  await waitForPaneKinds(['shell'])
+}
+
+const createFreshBrowserSession = async (): Promise<void> => {
+  await waitForActiveSplitView()
+  const previousSessionId = await readVisibleSessionId()
+  await runWorkspaceCommand(':new-browser')
+  await waitForVisibleSessionChange(previousSessionId)
+  await waitForPaneKinds(['browser'])
+}
+
+const readBrowserPaneIdentity = async (
+  paneId: string
+): Promise<BrowserPaneIdentity> => {
+  const identity = await browser.execute((targetPaneId: string) => {
+    const splitViews = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+    )
+    const splitView = splitViews.find((candidate) => {
+      const rect = candidate.getBoundingClientRect()
+
+      return rect.width > 0 && rect.height > 0
+    })
+    const pane = Array.from(
+      splitView?.querySelectorAll<HTMLElement>(
+        '[data-testid="browser-pane"][data-browser-pane-id]'
+      ) ?? []
+    ).find((candidate) => candidate.dataset.browserPaneId === targetPaneId)
+    const sessionId =
+      splitView?.dataset.browserSessionId ?? splitView?.dataset.sessionId
+    const browserPaneId = pane?.dataset.browserPaneId
+
+    return sessionId && browserPaneId
+      ? { sessionId, paneId: browserPaneId }
+      : null
+  }, paneId)
+
   if (!identity) {
-    throw new Error('browser pane identity was not available in the DOM')
+    throw new Error(`browser pane identity ${paneId} was not available`)
   }
 
   return identity
+}
+
+const readBrowserPaneContentRect = async (
+  paneId: string
+): Promise<BrowserPaneDomRect> => {
+  const rect = await browser.execute((targetPaneId: string) => {
+    const splitViews = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+    )
+    const splitView = splitViews.find((candidate) => {
+      const measured = candidate.getBoundingClientRect()
+
+      return measured.width > 0 && measured.height > 0
+    })
+    const slot = Array.from(
+      splitView?.querySelectorAll<HTMLElement>(
+        '[data-testid="split-view-slot"]'
+      ) ?? []
+    ).find((candidate) => candidate.dataset.paneId === targetPaneId)
+    const content = slot?.querySelector<HTMLElement>(
+      '[data-testid="browser-pane-content"]'
+    )
+    const measured = content?.getBoundingClientRect()
+
+    return measured
+      ? {
+          x: Math.round(measured.left),
+          y: Math.round(measured.top),
+          width: Math.round(measured.width),
+          height: Math.round(measured.height),
+        }
+      : null
+  }, paneId)
+
+  if (!rect) {
+    throw new Error(`browser pane ${paneId} content rect was not available`)
+  }
+
+  return rect
 }
 
 const waitForBrowserPaneCdpInfo = async (
@@ -141,7 +465,7 @@ const assertCdpTarget = async (
   }
 }
 
-const startBoundsCapture = async (): Promise<void> => {
+const resetBoundsCapture = async (): Promise<void> => {
   const started = await browser.execute(
     () => window.__VIMEFLOW_E2E__?.startBrowserPaneBoundsCapture() ?? false
   )
@@ -149,6 +473,10 @@ const startBoundsCapture = async (): Promise<void> => {
   if (!started) {
     throw new Error('browser pane bounds capture helper is unavailable')
   }
+
+  await browser.execute(() => {
+    window.__VIMEFLOW_E2E__?.clearBrowserPaneBoundsCaptures()
+  })
 }
 
 const stopBoundsCapture = async (): Promise<void> => {
@@ -161,108 +489,25 @@ const stopBoundsCapture = async (): Promise<void> => {
 const matchingBoundsCaptures = (
   captures: BrowserPaneBoundsCapture[],
   identity: BrowserPaneIdentity,
-  visible: boolean,
-  minSequence = -1
+  visible: boolean
 ): BrowserPaneBoundsCapture[] =>
   captures.filter(
     (capture) =>
       capture.sessionId === identity.sessionId &&
       capture.paneId === identity.paneId &&
-      capture.visible === visible &&
-      capture.sequence > minSequence
+      capture.visible === visible
   )
 
-const waitForBoundsCapture = async (
+const latestBoundsCapture = async (
   identity: BrowserPaneIdentity,
-  visible: boolean,
-  minSequence?: number
-): Promise<BrowserPaneBoundsCapture> => {
-  let capture: BrowserPaneBoundsCapture | undefined
-
-  await browser.waitUntil(
-    async () => {
-      const captures = await browser.execute(
-        () => window.__VIMEFLOW_E2E__?.getBrowserPaneBoundsCaptures() ?? []
-      )
-      const matching = matchingBoundsCaptures(
-        captures,
-        identity,
-        visible,
-        minSequence
-      )
-
-      capture = matching[matching.length - 1]
-      return capture !== undefined
-    },
-    {
-      timeout: 5_000,
-      interval: 100,
-      timeoutMsg: `browser pane never sent visible=${String(visible)} bounds`,
-    }
+  visible: boolean
+): Promise<BrowserPaneBoundsCapture | undefined> => {
+  const captures = await browser.execute(
+    () => window.__VIMEFLOW_E2E__?.getBrowserPaneBoundsCaptures() ?? []
   )
+  const matching = matchingBoundsCaptures(captures, identity, visible)
 
-  if (!capture) {
-    throw new Error(`missing visible=${String(visible)} bounds capture`)
-  }
-
-  return capture
-}
-
-const dispatchCommandPaletteShortcut = async (): Promise<void> => {
-  await browser.execute(() => {
-    const platform =
-      (
-        navigator as Navigator & {
-          userAgentData?: { platform?: string }
-        }
-      ).userAgentData?.platform ?? navigator.platform
-    const isMac = platform.toLowerCase().includes('mac')
-    document.dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: ';',
-        code: 'Semicolon',
-        ctrlKey: !isMac,
-        metaKey: isMac,
-        bubbles: true,
-        cancelable: true,
-      })
-    )
-  })
-}
-
-const openCommandPalette = async (): Promise<void> => {
-  await dispatchCommandPaletteShortcut()
-  await (
-    await $(commandPaletteSelector)
-  ).waitForDisplayed({
-    timeout: 3_000,
-  })
-}
-
-const closeCommandPalette = async (): Promise<void> => {
-  await browser.execute(() => {
-    document.dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: 'Escape',
-        code: 'Escape',
-        bubbles: true,
-        cancelable: true,
-      })
-    )
-  })
-
-  await browser.waitUntil(
-    async () =>
-      await browser.execute(
-        (selector: string) => document.querySelector(selector) === null,
-        commandPaletteSelector
-      ),
-    {
-      timeout: 3_000,
-      interval: 100,
-      timeoutMsg: 'command palette did not close',
-    }
-  )
+  return matching[matching.length - 1]
 }
 
 const assertRealLayoutBounds = (
@@ -276,28 +521,201 @@ const assertRealLayoutBounds = (
   }
 }
 
+const boundsMatchContentRect = (
+  capture: BrowserPaneBoundsCapture,
+  rect: BrowserPaneDomRect
+): boolean => {
+  const tolerance = 1
+  const deltas = {
+    x: Math.abs(capture.bounds.x - rect.x),
+    y: Math.abs(capture.bounds.y - rect.y),
+    width: Math.abs(capture.bounds.width - rect.width),
+    height: Math.abs(capture.bounds.height - rect.height),
+  }
+
+  return Object.values(deltas).every((delta) => delta <= tolerance)
+}
+
+const waitForBoundsToMatchContentRect = async (
+  identity: BrowserPaneIdentity,
+  paneId: string,
+  context: string,
+  timeout = 7_000
+): Promise<void> => {
+  let latestMessage = 'no bounds capture yet'
+
+  try {
+    await browser.waitUntil(
+      async () => {
+        const capture = await latestBoundsCapture(identity, true)
+        const rect = await readBrowserPaneContentRect(paneId)
+
+        if (!capture) {
+          latestMessage = `rect=${JSON.stringify(rect)}`
+
+          return false
+        }
+
+        latestMessage =
+          `bounds=${JSON.stringify(capture.bounds)} ` +
+          `rect=${JSON.stringify(rect)}`
+
+        if (capture.bounds.width <= 0 || capture.bounds.height <= 0) {
+          return false
+        }
+
+        return boundsMatchContentRect(capture, rect)
+      },
+      {
+        timeout,
+        interval: 100,
+        timeoutMsg: `${context} native bounds did not match browser content rect`,
+      }
+    )
+  } catch (error) {
+    throw new Error(
+      `${context} native bounds did not match browser content rect: ${latestMessage}`,
+      { cause: error }
+    )
+  }
+}
+
+const translateActiveSplitView = async (x: number): Promise<void> => {
+  const moved = await browser.execute((translateX: number) => {
+    const splitViews = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+    )
+    const splitView = splitViews.find((candidate) => {
+      const rect = candidate.getBoundingClientRect()
+
+      return rect.width > 0 && rect.height > 0
+    })
+
+    if (!splitView) {
+      return false
+    }
+
+    splitView.style.transform = `translateX(${String(translateX)}px)`
+
+    return true
+  }, x)
+
+  if (!moved) {
+    throw new Error('active split view was not available to translate')
+  }
+}
+
+const prepareBrowserPaneAtSlot = async (
+  layout: LayoutShape,
+  slotIndex: number
+): Promise<BrowserPaneIdentity> => {
+  await resetBoundsCapture()
+
+  if (slotIndex === 0) {
+    await createFreshBrowserSession()
+  } else {
+    await createFreshShellSession()
+  }
+
+  await switchToLayout(layout)
+
+  const expectedKinds: PaneKind[] = slotIndex === 0 ? ['browser'] : ['shell']
+
+  for (let index = 1; index < slotIndex; index += 1) {
+    await addShellPane(index + 1)
+    expectedKinds.push('shell')
+  }
+
+  if (slotIndex > 0) {
+    await addBrowserPane(slotIndex + 1)
+    expectedKinds.push('browser')
+  }
+
+  await waitForPaneKinds(expectedKinds)
+
+  const paneId = `p${slotIndex}`
+  const identity = await readBrowserPaneIdentity(paneId)
+  await waitForBrowserPaneCdpInfo(identity)
+
+  return identity
+}
+
 describe('BrowserPane native overlay occlusion', () => {
   afterEach(async () => {
     await stopBoundsCapture()
   })
 
   it('hides a real WebContentsView browser pane behind the command palette', async () => {
-    await waitForBrowserPane()
-    const identity = await readBrowserPaneIdentity()
+    const identity = await prepareBrowserPaneAtSlot(LAYOUTS.vsplit, 1)
     const cdpInfo = await waitForBrowserPaneCdpInfo(identity)
     await assertCdpTarget(identity, cdpInfo)
 
-    await startBoundsCapture()
+    await resetBoundsCapture()
     await openCommandPalette()
-    const hiddenCapture = await waitForBoundsCapture(identity, false)
-    assertRealLayoutBounds(hiddenCapture, 'occluded')
+    await browser.waitUntil(
+      async () => {
+        const hiddenCapture = await latestBoundsCapture(identity, false)
+        if (!hiddenCapture) {
+          return false
+        }
+
+        assertRealLayoutBounds(hiddenCapture, 'occluded')
+
+        return true
+      },
+      {
+        timeout: 5_000,
+        interval: 100,
+        timeoutMsg: 'browser pane never sent occluded bounds',
+      }
+    )
 
     await closeCommandPalette()
-    const shownCapture = await waitForBoundsCapture(
-      identity,
-      true,
-      hiddenCapture.sequence
+    await browser.waitUntil(
+      async () => {
+        const shownCapture = await latestBoundsCapture(identity, true)
+        if (!shownCapture) {
+          return false
+        }
+
+        assertRealLayoutBounds(shownCapture, 'restored')
+
+        return true
+      },
+      {
+        timeout: 5_000,
+        interval: 100,
+        timeoutMsg: 'browser pane never restored visible bounds',
+      }
     )
-    assertRealLayoutBounds(shownCapture, 'restored')
-  }).timeout(60_000)
+  }).timeout(90_000)
+
+  for (const { layout, slotIndex } of browserSlotCases) {
+    it(`keeps a ${layout.id} WebContentsView clipped to slot ${String(
+      slotIndex + 1
+    )}`, async () => {
+      const identity = await prepareBrowserPaneAtSlot(layout, slotIndex)
+
+      await waitForBoundsToMatchContentRect(
+        identity,
+        `p${slotIndex}`,
+        `${layout.id} slot ${String(slotIndex + 1)}`
+      )
+    }).timeout(90_000)
+  }
+
+  it('resyncs a quad WebContentsView after a position-only ancestor move', async () => {
+    const identity = await prepareBrowserPaneAtSlot(LAYOUTS.quad, 3)
+    await waitForBoundsToMatchContentRect(identity, 'p3', 'quad slot 4')
+
+    await resetBoundsCapture()
+    await translateActiveSplitView(24)
+
+    await waitForBoundsToMatchContentRect(
+      identity,
+      'p3',
+      'quad slot 4 after position-only move',
+      2_000
+    )
+  }).timeout(90_000)
 })

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -3,6 +3,10 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "baseUrl": "../..",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- resync BrowserPane native WebContentsView bounds on animation frames so position-only ancestor moves cannot leave stale native coordinates
- add a unit regression for bounds drift without resize/rerender
- expand browser-pane e2e coverage across all canonical SplitView layouts and browser slot positions, including quad slot 4 after a position-only move

## Root Cause

BrowserPane relied on React commits, ResizeObserver, and window resize to push native bounds. ResizeObserver only observes size changes, so hierarchy changes, transforms, or other position-only moves could shift the React browser content rect without sending new WebContentsView bounds.

## Validation

- `npm run test -- src/features/browser/components/BrowserPane.test.tsx`
- `npx tsc -p tests/e2e/tsconfig.json --noEmit`
- `npx prettier --check src/features/browser/components/BrowserPane.tsx src/features/browser/components/BrowserPane.test.tsx tests/e2e/core/specs/browser-pane-overlay.spec.ts tests/e2e/tsconfig.json`
- `npm run test:e2e:build`
- `VITE_E2E=1 npx wdio tests/e2e/core/wdio.conf.ts --spec tests/e2e/core/specs/browser-pane-overlay.spec.ts`
- pre-push hook: full `npm run test` (`297` files passed, `3796` tests passed, `3` skipped)


Refs VIM-143