### PR TITLE
refactor(terminal): add Ghostty parser engine seam

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,7 +55,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 64       | 30   | 2026-06-12   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 3        | 0    | 2026-06-17   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 5        | 1    | 2026-06-17   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,7 +55,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 64       | 30   | 2026-06-12   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 5        | 1    | 2026-06-17   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 7        | 2    | 2026-06-17   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,6 +55,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 64       | 30   | 2026-06-12   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 3        | 0    | 2026-06-17   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -3,7 +3,7 @@ id: terminal-control-sequence-handling
 category: terminal
 created: 2026-06-17
 last_updated: 2026-06-17
-ref_count: 1
+ref_count: 2
 ---
 
 # Terminal Control Sequence Handling
@@ -63,4 +63,22 @@ all required state through pure display-state helpers.
 - **File:** `src/features/terminal/components/TerminalPane/plainTextInstance.ts` L620-624
 - **Finding:** The `onEvent(...)` call in `PlainTextTerminalModel`'s constructor returned a `TerminalDisposable` that was silently dropped, leaving the no-op handler in the parser's internal set for the parser's lifetime and providing no cleanup path if a model-level dispose were added.
 - **Fix:** Stored the disposable as `private readonly noOpParserDisposable` and made `rendererHandle.dispose()` call it, aligning the internal subscription with the codebase's pattern of storing and disposing disposables.
+- **Commit:** same commit as this entry
+
+### 6. Same-chunk CRLF still skips the carriage-return cursor step
+
+- **Source:** github-claude | PR #516 round 3 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/plainTextInstance.ts` L150
+- **Finding:** `applyDisplayData` normalized `\r\n` to `\n` before iterating, so a same-chunk CRLF bypassed the `\r` branch that sets `pendingCr` and moves the cursor to line start. When the cursor was mid-line, the newline was inserted at the current cursor position rather than after the current line, making output depend on PTY chunk boundaries.
+- **Fix:** Removed the `data.replace(/\r\n/g, '\n')` pre-pass so same-chunk and split-chunk CRLF both use the existing `\r` + `pendingCr` + `\n` path, and added a regression test that backspaces into the middle of a line before writing `\r\n`.
+- **Commit:** same commit as this entry
+
+### 7. Erase-line sentinels collide with visible Private Use Area glyphs
+
+- **Source:** github-claude | PR #516 round 3 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L16
+- **Finding:** The in-band erase-line markers used U+E000 through U+E002, which are in the same BMP Private Use Area commonly used by terminal icon fonts. A real prompt glyph at one of those codepoints passed through the parser as visible text and was then consumed by `applyDisplayData` as an erase-line operation.
+- **Fix:** Moved the sentinels to Supplementary Private Use Area codepoints U+F0000, U+F0001, and U+F0002, and added a regression test that writes the legacy sentinel codepoint as visible text and expects it to render unchanged.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -1,0 +1,48 @@
+---
+id: terminal-control-sequence-handling
+category: terminal
+created: 2026-06-17
+last_updated: 2026-06-17
+ref_count: 0
+---
+
+# Terminal Control Sequence Handling
+
+## Summary
+
+The plain-text terminal renderer processes PTY output as a stream of visible
+characters and control sequences. Correctness depends on state that spans
+multiple `write()` calls (cursor position, pending carriage returns) and on
+control sequences that are stripped or reinterpreted by the parser. Fixes in
+this area must preserve ordering between control sequences and visible text,
+must keep partial sequences pending across chunk boundaries, and must carry
+all required state through pure display-state helpers.
+
+## Findings
+
+### 1. Split \r\n across writes inserts blank line instead of advancing cursor
+
+- **Source:** github-claude | PR #516 round 1 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/plainTextInstance.ts` L103-126
+- **Finding:** When `\r` arrives in one `write()` call and `\n` in the next, `applyDisplayData` moves the cursor to line-start on `\r`, then the `\n` branch inserts a newline *before* the existing line content rather than advancing past it, producing a leading blank line and losing the prior line.
+- **Fix:** Added `pendingCr` to `DisplayState`; set it on `\r`, clear it on any other character, and advance the cursor to the end of the current line before inserting the newline when `\n` follows a pending `\r`. Narrowed `writeDisplayCharacter`'s return type and preserved `pendingCr` through `trimScrollbackLines`.
+- **Commit:** same commit as this entry
+
+### 2. Handle erase-line CSI before stripping it
+
+- **Source:** github-codex-connector | PR #516 round 1 | 2026-06-17
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L163
+- **Finding:** The parser dropped every CSI sequence before the display layer could act on it. For progress output like `building 100%\r\x1b[Kdone`, stripping `ESC[K` left stale characters (`doneing 100%`) instead of clearing the line.
+- **Fix:** The parser now replaces CSI `K` sequences with private-use sentinels that encode the erase mode (0, 1, or 2). `applyDisplayData` interprets each sentinel at its original stream position, so ordering between erase-line and later visible text in the same chunk is preserved. A no-op parser-event subscription keeps the plain-text renderer in sequence-stripping mode.
+- **Commit:** same commit as this entry
+
+### 3. Buffer split ESC prefixes across chunks
+
+- **Source:** github-codex-connector | PR #516 round 1 | 2026-06-17
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L167
+- **Finding:** When a PTY chunk ended with just `ESC` and the next chunk started `[38;...m`, the parser emitted the escape byte as visible output and advanced, so the following chunk no longer matched `CSI_PREFIX` and rendered literal color/control text.
+- **Fix:** When an `ESC` byte appears at the very end of a chunk, store it in `pendingControlSequence` instead of emitting it as visible output, allowing the next chunk to complete the sequence.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -3,7 +3,7 @@ id: terminal-control-sequence-handling
 category: terminal
 created: 2026-06-17
 last_updated: 2026-06-17
-ref_count: 0
+ref_count: 1
 ---
 
 # Terminal Control Sequence Handling
@@ -25,7 +25,7 @@ all required state through pure display-state helpers.
 - **Source:** github-claude | PR #516 round 1 | 2026-06-17
 - **Severity:** MEDIUM
 - **File:** `src/features/terminal/components/TerminalPane/plainTextInstance.ts` L103-126
-- **Finding:** When `\r` arrives in one `write()` call and `\n` in the next, `applyDisplayData` moves the cursor to line-start on `\r`, then the `\n` branch inserts a newline *before* the existing line content rather than advancing past it, producing a leading blank line and losing the prior line.
+- **Finding:** When `\r` arrives in one `write()` call and `\n` in the next, `applyDisplayData` moves the cursor to line-start on `\r`, then the `\n` branch inserts a newline _before_ the existing line content rather than advancing past it, producing a leading blank line and losing the prior line.
 - **Fix:** Added `pendingCr` to `DisplayState`; set it on `\r`, clear it on any other character, and advance the cursor to the end of the current line before inserting the newline when `\n` follows a pending `\r`. Narrowed `writeDisplayCharacter`'s return type and preserved `pendingCr` through `trimScrollbackLines`.
 - **Commit:** same commit as this entry
 
@@ -45,4 +45,22 @@ all required state through pure display-state helpers.
 - **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L167
 - **Finding:** When a PTY chunk ended with just `ESC` and the next chunk started `[38;...m`, the parser emitted the escape byte as visible output and advanced, so the following chunk no longer matched `CSI_PREFIX` and rendered literal color/control text.
 - **Fix:** When an `ESC` byte appears at the very end of a chunk, store it in `pendingControlSequence` instead of emitting it as visible output, allowing the next chunk to complete the sequence.
+- **Commit:** same commit as this entry
+
+### 4. eraseLineInState mode 1 keeps character at cursor (off-by-one)
+
+- **Source:** github-claude | PR #516 round 2 | 2026-06-17
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/plainTextInstance.ts` L128-133
+- **Finding:** `text.slice(cursor)` in erase-line mode 1 starts at the cursor index, so the character AT the cursor position survives the erase. VT100/xterm specifies that `\x1b[1K` (erase from line start to cursor) is inclusive: the cursor cell must also be cleared.
+- **Fix:** Changed the slice to `text.slice(cursor + readCodePointLength(text, cursor))` so the cursor cell is removed, and added a unit test that writes `abc`, positions the cursor after `a`, emits `\x1b[1K`, and expects `c`.
+- **Commit:** same commit as this entry
+
+### 5. No-op handler TerminalDisposable discarded — parser handler set never cleaned up
+
+- **Source:** github-claude | PR #516 round 2 | 2026-06-17
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/plainTextInstance.ts` L620-624
+- **Finding:** The `onEvent(...)` call in `PlainTextTerminalModel`'s constructor returned a `TerminalDisposable` that was silently dropped, leaving the no-op handler in the parser's internal set for the parser's lifetime and providing no cleanup path if a model-level dispose were added.
+- **Fix:** Stored the disposable as `private readonly noOpParserDisposable` and made `rendererHandle.dispose()` call it, aligning the internal subscription with the codebase's pattern of storing and disposing disposables.
 - **Commit:** same commit as this entry

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -12,6 +12,7 @@ import {
   ghosttyTerminalRenderer,
   type GhosttyTerminalOptions,
 } from './ghosttyInstance'
+import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 
 const encodeBase64 = (bytes: Uint8Array): string => {
   let binary = ''
@@ -54,6 +55,10 @@ describe('ghosttyInstance', () => {
       acceptsText: true,
       acceptsBytes: true,
     })
+
+    expect(ghosttyTerminalRenderer.capabilities).toBe(
+      GHOSTTY_TERMINAL_CAPABILITIES
+    )
     expect(ghosttyTerminalRenderer.createInstance).toBe(createGhosttyTerminal)
   })
 
@@ -96,9 +101,7 @@ describe('ghosttyInstance', () => {
     created.output.writeOutput(chunk)
 
     expect(created.parser).toBe(parser)
-    expect(createParserEngine).toHaveBeenCalledWith(
-      ghosttyTerminalRenderer.capabilities
-    )
+    expect(createParserEngine).toHaveBeenCalledOnce()
     expect(parseOutput).toHaveBeenCalledWith(chunk)
     expect(created.viewportReader.readVisibleText()).toBe('parsed:from-engine')
   })

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -2,29 +2,19 @@
 import type {
   TerminalInstance,
   TerminalRendererAdapter,
-  TerminalRendererCapabilities,
   TerminalRendererHandle,
   TerminalOutputWriter,
 } from '../../types'
 import { createPlainTextTerminal } from './plainTextInstance'
 import { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
-import {
-  createControlSequenceTerminalParserEngine,
-  type TerminalParserEngine,
-} from './terminalParserEngine'
+import { createGhosttyParserEngine } from './ghosttyParserEngine'
+import type { TerminalParserEngine } from './terminalParserEngine'
+import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 
 export { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
 
-const GHOSTTY_TERMINAL_CAPABILITIES: TerminalRendererCapabilities = {
-  preferredOutputInputMode: 'bytes',
-  acceptsText: true,
-  acceptsBytes: true,
-}
-
 export interface GhosttyTerminalOptions {
-  readonly createParserEngine?: (
-    capabilities: TerminalRendererCapabilities
-  ) => TerminalParserEngine
+  readonly createParserEngine?: () => TerminalParserEngine
 }
 
 class GhosttyTerminalModel {
@@ -33,10 +23,7 @@ class GhosttyTerminalModel {
 
   constructor(options: GhosttyTerminalOptions = {}) {
     this.parserEngine =
-      options.createParserEngine?.(GHOSTTY_TERMINAL_CAPABILITIES) ??
-      createControlSequenceTerminalParserEngine({
-        capabilities: GHOSTTY_TERMINAL_CAPABILITIES,
-      })
+      options.createParserEngine?.() ?? createGhosttyParserEngine()
   }
 
   readonly output: TerminalOutputWriter = {

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
@@ -1,0 +1,157 @@
+// cspell:ignore ghostty
+import { describe, expect, test, vi } from 'vitest'
+import type { TerminalOutputChunk } from '../../types'
+import {
+  GHOSTTY_PARSER_ENGINE_ID,
+  createGhosttyParserEngine,
+} from './ghosttyParserEngine'
+import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
+
+const encodeBase64 = (bytes: Uint8Array): string => {
+  let binary = ''
+
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+
+  return globalThis.btoa(binary)
+}
+
+const encodeText = (text: string): string =>
+  encodeBase64(new TextEncoder().encode(text))
+
+const ESC = '\x1b'
+const SGR_FINAL = 'm'
+
+const createByteChunk = (
+  text: string,
+  offsetStart: number,
+  phase: TerminalOutputChunk['phase']
+): TerminalOutputChunk => ({
+  text: 'lossy fallback',
+  bytesBase64: encodeText(text),
+  offsetStart,
+  byteLen: new TextEncoder().encode(text).length,
+  phase,
+})
+
+describe('ghosttyParserEngine', () => {
+  test('exposes the Ghostty spike identity and byte-preferring capabilities', () => {
+    const engine = createGhosttyParserEngine()
+
+    expect(engine.id).toBe(GHOSTTY_PARSER_ENGINE_ID)
+    expect(engine.inputMode).toBe('bytes')
+    expect(engine.capabilities).toBe(GHOSTTY_TERMINAL_CAPABILITIES)
+  })
+
+  test('parses visible output from bytes before text fallback', () => {
+    const engine = createGhosttyParserEngine()
+
+    expect(engine.parseOutput(createByteChunk('bytes win', 0, 'live'))).toEqual(
+      {
+        visibleText: 'bytes win',
+      }
+    )
+  })
+
+  test('falls back to text when byte payloads are unreadable', () => {
+    const engine = createGhosttyParserEngine()
+
+    expect(
+      engine.parseOutput({
+        text: 'text fallback',
+        bytesBase64: 'not base64?',
+        offsetStart: 0,
+        byteLen: 13,
+        phase: 'live',
+      })
+    ).toEqual({
+      visibleText: 'text fallback',
+    })
+  })
+
+  test('emits OSC 7 cwd events from byte payloads with output context', () => {
+    const engine = createGhosttyParserEngine()
+    const handler = vi.fn()
+
+    const chunk = createByteChunk(
+      'before \x1b]7;file://localhost/tmp/ghostty-spike\x07 after',
+      32,
+      'live'
+    )
+
+    engine.parser.onEvent(handler)
+
+    expect(engine.parseOutput(chunk)).toEqual({ visibleText: 'before  after' })
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/ghostty-spike',
+      output: {
+        offsetStart: chunk.offsetStart,
+        byteLen: chunk.byteLen,
+        phase: chunk.phase,
+      },
+    })
+  })
+
+  test('hides zsh color and title controls from byte payload visible text', () => {
+    const engine = createGhosttyParserEngine()
+    const handler = vi.fn()
+
+    const output =
+      `${ESC}]2;user@host:~/project\x07` +
+      `${ESC}[38;2;243;139;168${SGR_FINAL}` +
+      `feat/ghostty-spike${ESC}[0${SGR_FINAL} % `
+
+    engine.parser.onEvent(handler)
+
+    expect(engine.parseOutput(createByteChunk(output, 0, 'live'))).toEqual({
+      visibleText: 'feat/ghostty-spike % ',
+    })
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('keeps restore OSC 7 events tagged as restore when split across chunks', () => {
+    const engine = createGhosttyParserEngine()
+    const handler = vi.fn()
+
+    const first = createByteChunk('before \x1b]7;file://local', 0, 'restore')
+
+    const second = createByteChunk(
+      'host/tmp/ghostty-restore\x07 after',
+      first.byteLen ?? 0,
+      'restore'
+    )
+
+    engine.parser.onEvent(handler)
+
+    expect(engine.parseOutput(first)).toEqual({ visibleText: 'before ' })
+    expect(engine.parseOutput(second)).toEqual({ visibleText: ' after' })
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/ghostty-restore',
+      output: {
+        offsetStart: second.offsetStart,
+        byteLen: second.byteLen,
+        phase: 'restore',
+      },
+    })
+  })
+
+  test('retains text fallback while the spike shares the existing transport', () => {
+    const engine = createGhosttyParserEngine()
+
+    expect(
+      engine.parseOutput({
+        text: 'text fallback',
+        offsetStart: 0,
+        byteLen: 13,
+        phase: 'live',
+      })
+    ).toEqual({
+      visibleText: 'text fallback',
+    })
+  })
+})

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -1,0 +1,28 @@
+// cspell:ignore ghostty
+import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
+import {
+  TerminalControlSequenceParserEngine,
+  type TerminalParserEngine,
+} from './terminalParserEngine'
+
+export const GHOSTTY_PARSER_ENGINE_ID = 'ghostty-control-sequence-spike'
+
+export interface GhosttyParserEngine extends TerminalParserEngine {
+  readonly id: typeof GHOSTTY_PARSER_ENGINE_ID
+}
+
+export class GhosttyControlSequenceParserEngine
+  extends TerminalControlSequenceParserEngine
+  implements GhosttyParserEngine
+{
+  readonly id: typeof GHOSTTY_PARSER_ENGINE_ID = GHOSTTY_PARSER_ENGINE_ID
+
+  constructor() {
+    super({
+      capabilities: GHOSTTY_TERMINAL_CAPABILITIES,
+    })
+  }
+}
+
+export const createGhosttyParserEngine = (): GhosttyParserEngine =>
+  new GhosttyControlSequenceParserEngine()

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -135,6 +135,16 @@ describe('plainTextInstance', () => {
     )
   })
 
+  test('moves the cursor to the line end before inserting a same-chunk CRLF', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write('hello world')
+    created.terminal.write('\b\b\b\b\b')
+    created.terminal.write('\r\nmore')
+
+    expect(created.viewportReader.readVisibleText()).toBe('hello world\nmore')
+  })
+
   test('clears the current line when an erase-line CSI event is emitted', () => {
     const created = createTrackedPlainTextTerminal()
 
@@ -164,6 +174,17 @@ describe('plainTextInstance', () => {
     created.terminal.write('\x1b[1K')
 
     expect(created.viewportReader.readVisibleText()).toBe('c')
+  })
+
+  test('does not erase visible glyphs at legacy Private Use Area codepoints', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    // Old erase-line sentinels used U+E000..U+E002; those must now render as
+    // visible glyphs so icon-font prompts are not silently erased.
+    // cspell:disable-next-line
+    created.terminal.write('prompt \uE000 icon')
+
+    expect(created.viewportReader.readVisibleText()).toBe('prompt \uE000 icon')
   })
 
   test('moves the output cursor backward for backspace rewrites', () => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -123,6 +123,38 @@ describe('plainTextInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('progress 20%')
   })
 
+  test('treats carriage-return/newline pairs split across writes as a single newline', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write('progress 10%')
+    created.terminal.write('\r')
+    created.terminal.write('\nprogress 20%')
+
+    expect(created.viewportReader.readVisibleText()).toBe(
+      'progress 10%\nprogress 20%'
+    )
+  })
+
+  test('clears the current line when an erase-line CSI event is emitted', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write('building 100%')
+    // cspell:disable-next-line
+    created.terminal.write('\r\x1b[Kdone')
+
+    expect(created.viewportReader.readVisibleText()).toBe('done')
+  })
+
+  test('applies erase-line before later text in the same chunk', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write('old')
+    // cspell:disable-next-line
+    created.terminal.write('\x1b[2K\rdone')
+
+    expect(created.viewportReader.readVisibleText()).toBe('done')
+  })
+
   test('moves the output cursor backward for backspace rewrites', () => {
     const created = createTrackedPlainTextTerminal()
 
@@ -293,18 +325,16 @@ describe('plainTextInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('before after')
   })
 
-  test('renders OSC sequences when no parser event subscribers exist', () => {
+  test('strips OSC sequences because the plain-text renderer consumes them internally', () => {
     const created = createTrackedPlainTextTerminal()
     const sequence = '\x1b]7;file://localhost/tmp/plain-text-project\x07'
 
     created.terminal.write(`before ${sequence}after`)
 
-    expect(created.viewportReader.readVisibleText()).toBe(
-      `before ${sequence}after`
-    )
+    expect(created.viewportReader.readVisibleText()).toBe('before after')
   })
 
-  test('stops invoking disposed parser event handlers', () => {
+  test('stops invoking disposed parser event handlers while keeping internal rendering', () => {
     const created = createTrackedPlainTextTerminal()
     const parserEventHandler = vi.fn()
     const sequence = '\x1b]7;file://localhost/tmp/plain-text-project\x07'
@@ -314,7 +344,7 @@ describe('plainTextInstance', () => {
     created.terminal.write(sequence)
 
     expect(parserEventHandler).not.toHaveBeenCalled()
-    expect(created.viewportReader.readVisibleText()).toBe(sequence)
+    expect(created.viewportReader.readVisibleText()).toBe('')
   })
 
   test('emits pasted text and keyboard input through onData', () => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -155,6 +155,17 @@ describe('plainTextInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('done')
   })
 
+  test('erases from line start to cursor inclusive in erase-line mode 1', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write('abc')
+    created.terminal.write('\ra')
+    // cspell:disable-next-line
+    created.terminal.write('\x1b[1K')
+
+    expect(created.viewportReader.readVisibleText()).toBe('c')
+  })
+
   test('moves the output cursor backward for backspace rewrites', () => {
     const created = createTrackedPlainTextTerminal()
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -114,6 +114,23 @@ describe('plainTextInstance', () => {
     expect(callback).toHaveBeenCalledOnce()
   })
 
+  test('rewrites the current line when carriage return output arrives', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write('progress 10%')
+    created.terminal.write('\rprogress 20%')
+
+    expect(created.viewportReader.readVisibleText()).toBe('progress 20%')
+  })
+
+  test('moves the output cursor backward for backspace rewrites', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write('ab\bcd')
+
+    expect(created.viewportReader.readVisibleText()).toBe('acd')
+  })
+
   test('uses text output chunks even when byte payloads are present', () => {
     const created = createTrackedPlainTextTerminal()
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -14,6 +14,7 @@ import type {
   TerminalViewportReader,
 } from '../../types'
 import { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
+import { getEraseLineModeFromSentinel } from './terminalControlParser'
 import { createControlSequenceTerminalParserEngine } from './terminalParserEngine'
 import { PLAIN_TEXT_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
@@ -61,6 +62,7 @@ const createDisposable = (dispose: () => void): TerminalDisposable => ({
 interface DisplayState {
   readonly text: string
   readonly cursor: number
+  readonly pendingCr: boolean
 }
 
 const findLineStart = (text: string, cursor: number): number => {
@@ -74,11 +76,16 @@ const findLineStart = (text: string, cursor: number): number => {
 const readCodePointLength = (text: string, cursor: number): number =>
   (text.codePointAt(cursor) ?? 0) > 0xffff ? 2 : 1
 
+interface DisplayCharacterResult {
+  readonly text: string
+  readonly cursor: number
+}
+
 const writeDisplayCharacter = (
   text: string,
   cursor: number,
   character: string
-): DisplayState => {
+): DisplayCharacterResult => {
   if (cursor < text.length && text[cursor] !== '\n') {
     const nextLength = readCodePointLength(text, cursor)
 
@@ -96,33 +103,89 @@ const writeDisplayCharacter = (
   }
 }
 
+const findLineEnd = (text: string, cursor: number): number => {
+  const nextNewline = text.indexOf('\n', cursor)
+
+  return nextNewline === -1 ? text.length : nextNewline
+}
+
+const eraseLineInState = (
+  state: DisplayState,
+  mode: 0 | 1 | 2
+): DisplayState => {
+  const text = state.text
+  const cursor = state.cursor
+  const lineStart = findLineStart(text, cursor)
+  const lineEnd = findLineEnd(text, cursor)
+
+  if (mode === 0) {
+    return {
+      ...state,
+      text: `${text.slice(0, cursor)}${text.slice(lineEnd)}`,
+    }
+  }
+
+  if (mode === 1) {
+    return {
+      ...state,
+      text: `${text.slice(0, lineStart)}${text.slice(cursor)}`,
+      cursor: lineStart,
+    }
+  }
+
+  return {
+    ...state,
+    text: `${text.slice(0, lineStart)}${text.slice(lineEnd)}`,
+    cursor: lineStart,
+  }
+}
+
 const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
   let text = state.text
   let cursor = Math.min(Math.max(state.cursor, 0), text.length)
+  let pendingCr = state.pendingCr
 
   for (const character of data.replace(/\r\n/g, '\n')) {
+    const eraseLineMode = getEraseLineModeFromSentinel(character)
+
+    if (eraseLineMode !== null) {
+      const nextState = eraseLineInState({ text, cursor, pendingCr }, eraseLineMode)
+      text = nextState.text
+      cursor = nextState.cursor
+      pendingCr = false
+      continue
+    }
+
     if (character === '\r') {
       cursor = findLineStart(text, cursor)
+      pendingCr = true
       continue
     }
 
     if (character === '\n') {
+      if (pendingCr) {
+        cursor = findLineEnd(text, cursor)
+      }
+
       text = `${text.slice(0, cursor)}\n${text.slice(cursor)}`
       cursor += 1
+      pendingCr = false
       continue
     }
 
     if (character === '\b') {
       cursor = Math.max(findLineStart(text, cursor), cursor - 1)
+      pendingCr = false
       continue
     }
 
     const next = writeDisplayCharacter(text, cursor, character)
     text = next.text
     cursor = next.cursor
+    pendingCr = false
   }
 
-  return { text, cursor }
+  return { text, cursor, pendingCr }
 }
 
 const trimScrollbackLines = (state: DisplayState): DisplayState => {
@@ -139,6 +202,7 @@ const trimScrollbackLines = (state: DisplayState): DisplayState => {
   return {
     text: text.slice(removedText.length),
     cursor: Math.max(0, state.cursor - removedText.length),
+    pendingCr: state.pendingCr,
   }
 }
 
@@ -208,6 +272,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
   private container: HTMLElement | null = null
   private outputText = ''
   private outputCursor = 0
+  private outputPendingCr = false
   private colsValue = DEFAULT_COLS
   private rowsValue = DEFAULT_ROWS
   private lastSelectionText = ''
@@ -306,6 +371,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
   clear(): void {
     this.outputText = ''
     this.outputCursor = 0
+    this.outputPendingCr = false
     this.renderOutput()
   }
 
@@ -329,13 +395,18 @@ class PlainTextTerminalSurface implements TerminalSurface {
     if (visibleData.length > 0) {
       const nextState = trimScrollbackLines(
         applyDisplayData(
-          { text: this.outputText, cursor: this.outputCursor },
+          {
+            text: this.outputText,
+            cursor: this.outputCursor,
+            pendingCr: this.outputPendingCr,
+          },
           visibleData
         )
       )
 
       this.outputText = nextState.text
       this.outputCursor = nextState.cursor
+      this.outputPendingCr = nextState.pendingCr
       this.renderOutput()
     }
 
@@ -539,6 +610,17 @@ class PlainTextTerminalModel {
 
       this.terminal.writeVisible(visibleText, callback)
     },
+  }
+
+  constructor() {
+    // The plain-text renderer relies on the parser stripping control sequences
+    // (and replacing erase-line sequences with sentinels). Subscribing a no-op
+    // handler keeps the parser in stripping mode even when no external consumer
+    // is listening.
+    this.parserEngine.parser.onEvent(() => {
+      // Intentionally empty: visible-text transformation is handled by the
+      // parser, and erase-line sentinels are interpreted by the surface.
+    })
   }
 
   readonly viewportReader: TerminalViewportReader = {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -147,7 +147,7 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
   let cursor = Math.min(Math.max(state.cursor, 0), text.length)
   let pendingCr = state.pendingCr
 
-  for (const character of data.replace(/\r\n/g, '\n')) {
+  for (const character of data) {
     const eraseLineMode = getEraseLineModeFromSentinel(character)
 
     if (eraseLineMode !== null) {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -7,7 +7,6 @@ import type {
   TerminalOutputWriter,
   TerminalParser,
   TerminalRendererAdapter,
-  TerminalRendererCapabilities,
   TerminalRendererHandle,
   TerminalSize,
   TerminalSurface,
@@ -16,6 +15,7 @@ import type {
 } from '../../types'
 import { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
 import { createControlSequenceTerminalParserEngine } from './terminalParserEngine'
+import { PLAIN_TEXT_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
 
 export { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
@@ -27,12 +27,6 @@ const MIN_ROWS = 1
 const APPROXIMATE_CHAR_WIDTH = 8
 const APPROXIMATE_LINE_HEIGHT = 18
 const MAX_SCROLLBACK_LINES = 10_000
-
-const PLAIN_TEXT_TERMINAL_CAPABILITIES: TerminalRendererCapabilities = {
-  preferredOutputInputMode: 'text',
-  acceptsText: true,
-  acceptsBytes: false,
-}
 
 const KEYBOARD_SEQUENCES = new Map<string, string>([
   ['ArrowUp', '\x1b[A'],
@@ -64,17 +58,88 @@ const createDisposable = (dispose: () => void): TerminalDisposable => ({
   dispose,
 })
 
-const normalizeDisplayText = (data: string): string =>
-  data.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+interface DisplayState {
+  readonly text: string
+  readonly cursor: number
+}
 
-const trimScrollbackLines = (text: string): string => {
+const findLineStart = (text: string, cursor: number): number => {
+  if (cursor <= 0) {
+    return 0
+  }
+
+  return text.lastIndexOf('\n', cursor - 1) + 1
+}
+
+const readCodePointLength = (text: string, cursor: number): number =>
+  (text.codePointAt(cursor) ?? 0) > 0xffff ? 2 : 1
+
+const writeDisplayCharacter = (
+  text: string,
+  cursor: number,
+  character: string
+): DisplayState => {
+  if (cursor < text.length && text[cursor] !== '\n') {
+    const nextLength = readCodePointLength(text, cursor)
+
+    return {
+      text: `${text.slice(0, cursor)}${character}${text.slice(
+        cursor + nextLength
+      )}`,
+      cursor: cursor + character.length,
+    }
+  }
+
+  return {
+    text: `${text.slice(0, cursor)}${character}${text.slice(cursor)}`,
+    cursor: cursor + character.length,
+  }
+}
+
+const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
+  let text = state.text
+  let cursor = Math.min(Math.max(state.cursor, 0), text.length)
+
+  for (const character of data.replace(/\r\n/g, '\n')) {
+    if (character === '\r') {
+      cursor = findLineStart(text, cursor)
+      continue
+    }
+
+    if (character === '\n') {
+      text = `${text.slice(0, cursor)}\n${text.slice(cursor)}`
+      cursor += 1
+      continue
+    }
+
+    if (character === '\b') {
+      cursor = Math.max(findLineStart(text, cursor), cursor - 1)
+      continue
+    }
+
+    const next = writeDisplayCharacter(text, cursor, character)
+    text = next.text
+    cursor = next.cursor
+  }
+
+  return { text, cursor }
+}
+
+const trimScrollbackLines = (state: DisplayState): DisplayState => {
+  const text = state.text
   const lines = text.split('\n')
 
   if (lines.length <= MAX_SCROLLBACK_LINES) {
-    return text
+    return state
   }
 
-  return lines.slice(-MAX_SCROLLBACK_LINES).join('\n')
+  const firstKeptLine = lines.length - MAX_SCROLLBACK_LINES
+  const removedText = `${lines.slice(0, firstKeptLine).join('\n')}\n`
+
+  return {
+    text: text.slice(removedText.length),
+    cursor: Math.max(0, state.cursor - removedText.length),
+  }
 }
 
 const readContainedSelection = (root: HTMLElement): string => {
@@ -142,6 +207,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
   private readonly keyHandlers = new Set<TerminalKeyEventHandler>()
   private container: HTMLElement | null = null
   private outputText = ''
+  private outputCursor = 0
   private colsValue = DEFAULT_COLS
   private rowsValue = DEFAULT_ROWS
   private lastSelectionText = ''
@@ -239,6 +305,7 @@ class PlainTextTerminalSurface implements TerminalSurface {
 
   clear(): void {
     this.outputText = ''
+    this.outputCursor = 0
     this.renderOutput()
   }
 
@@ -260,9 +327,15 @@ class PlainTextTerminalSurface implements TerminalSurface {
     }
 
     if (visibleData.length > 0) {
-      this.outputText = trimScrollbackLines(
-        `${this.outputText}${normalizeDisplayText(visibleData)}`
+      const nextState = trimScrollbackLines(
+        applyDisplayData(
+          { text: this.outputText, cursor: this.outputCursor },
+          visibleData
+        )
       )
+
+      this.outputText = nextState.text
+      this.outputCursor = nextState.cursor
       this.renderOutput()
     }
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -126,9 +126,11 @@ const eraseLineInState = (
   }
 
   if (mode === 1) {
+    const cursorCodePointLength = readCodePointLength(text, cursor)
+
     return {
       ...state,
-      text: `${text.slice(0, lineStart)}${text.slice(cursor)}`,
+      text: `${text.slice(0, lineStart)}${text.slice(cursor + cursorCodePointLength)}`,
       cursor: lineStart,
     }
   }
@@ -149,7 +151,10 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
     const eraseLineMode = getEraseLineModeFromSentinel(character)
 
     if (eraseLineMode !== null) {
-      const nextState = eraseLineInState({ text, cursor, pendingCr }, eraseLineMode)
+      const nextState = eraseLineInState(
+        { text, cursor, pendingCr },
+        eraseLineMode
+      )
       text = nextState.text
       cursor = nextState.cursor
       pendingCr = false
@@ -592,6 +597,7 @@ class PlainTextTerminalModel {
   private readonly parserEngine = createControlSequenceTerminalParserEngine({
     capabilities: PLAIN_TEXT_TERMINAL_CAPABILITIES,
   })
+  private readonly noOpParserDisposable: TerminalDisposable
   readonly terminal = new PlainTextTerminalSurface(
     (data) => this.parserEngine.parseText(data, null).visibleText
   )
@@ -617,7 +623,7 @@ class PlainTextTerminalModel {
     // (and replacing erase-line sequences with sentinels). Subscribing a no-op
     // handler keeps the parser in stripping mode even when no external consumer
     // is listening.
-    this.parserEngine.parser.onEvent(() => {
+    this.noOpParserDisposable = this.parserEngine.parser.onEvent(() => {
       // Intentionally empty: visible-text transformation is handled by the
       // parser, and erase-line sentinels are interpreted by the surface.
     })
@@ -634,7 +640,9 @@ class PlainTextTerminalModel {
   }
 
   readonly rendererHandle: TerminalRendererHandle = {
-    dispose: (): void => undefined,
+    dispose: (): void => {
+      this.noOpParserDisposable.dispose()
+    },
   }
 }
 

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
@@ -104,4 +104,19 @@ describe('TerminalControlSequenceParser', () => {
 
     expect(visible).toBe('\x1b]7;file://localhost/tmp/project\x07')
   })
+
+  test('keeps a trailing ESC pending until the next chunk completes the sequence', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    expect(parser.transformOutput('before \x1b', null)).toBe('before ')
+    // cspell:disable-next-line
+    expect(parser.transformOutput('[38;2;243;139;168mcolor', null)).toBe(
+      'color'
+    )
+    expect(handler).not.toHaveBeenCalled()
+  })
+
 })

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test, vi } from 'vitest'
 import { TerminalControlSequenceParser } from './terminalControlParser'
 
+const ESC = '\x1b'
+const SGR_FINAL = 'm'
+
 describe('TerminalControlSequenceParser', () => {
   test('emits OSC 7 cwd events and strips them from visible output', () => {
     const parser = new TerminalControlSequenceParser()
@@ -52,7 +55,7 @@ describe('TerminalControlSequenceParser', () => {
     })
   })
 
-  test('passes through non-cwd OSC sequences', () => {
+  test('strips non-cwd OSC sequences from visible output', () => {
     const parser = new TerminalControlSequenceParser()
     const handler = vi.fn()
 
@@ -60,7 +63,34 @@ describe('TerminalControlSequenceParser', () => {
 
     const visible = parser.transformOutput('a\x1b]0;title\x07b', null)
 
-    expect(visible).toBe('a\x1b]0;title\x07b')
+    expect(visible).toBe('ab')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('strips CSI style sequences from visible output', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    const visible = parser.transformOutput(
+      `prompt ${ESC}[38;2;243;139;168${SGR_FINAL}` +
+        `branch${ESC}[0${SGR_FINAL} done`,
+      null
+    )
+
+    expect(visible).toBe('prompt branch done')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('reassembles CSI sequences split across output chunks', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    expect(parser.transformOutput('before \x1b[38;2;', null)).toBe('before ')
+    expect(parser.transformOutput('243;139;168m' + 'color', null)).toBe('color')
     expect(handler).not.toHaveBeenCalled()
   })
 

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
@@ -118,5 +118,4 @@ describe('TerminalControlSequenceParser', () => {
     )
     expect(handler).not.toHaveBeenCalled()
   })
-
 })

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -8,6 +8,7 @@ import type {
 
 const BEL = '\x07'
 const ESC = '\x1b'
+const CSI_PREFIX = `${ESC}[`
 const OSC_PREFIX = `${ESC}]`
 const STRING_TERMINATOR = `${ESC}\\`
 const MAX_PENDING_CONTROL_SEQUENCE_LENGTH = 16_384
@@ -43,6 +44,25 @@ const findSequenceTerminator = (
     index: stringTerminatorIndex,
     length: STRING_TERMINATOR.length,
   }
+}
+
+const isCsiFinalByte = (char: string): boolean => {
+  const code = char.charCodeAt(0)
+
+  return code >= 0x40 && code <= 0x7e
+}
+
+const findCsiTerminator = (
+  data: string,
+  startIndex: number
+): SequenceTerminator | null => {
+  for (let index = startIndex; index < data.length; index += 1) {
+    if (isCsiFinalByte(data[index] ?? '')) {
+      return { index, length: 1 }
+    }
+  }
+
+  return null
 }
 
 const parseOscIdentifier = (content: string): string | null => {
@@ -102,7 +122,7 @@ export class TerminalControlSequenceParser implements TerminalParser {
     let cursor = 0
 
     while (cursor < data.length) {
-      const sequenceStart = data.indexOf(OSC_PREFIX, cursor)
+      const sequenceStart = data.indexOf(ESC, cursor)
 
       if (sequenceStart === -1) {
         visible += data.slice(cursor)
@@ -111,23 +131,40 @@ export class TerminalControlSequenceParser implements TerminalParser {
 
       visible += data.slice(cursor, sequenceStart)
 
-      const contentStart = sequenceStart + OSC_PREFIX.length
-      const terminator = findSequenceTerminator(data, contentStart)
+      if (data.startsWith(OSC_PREFIX, sequenceStart)) {
+        const contentStart = sequenceStart + OSC_PREFIX.length
+        const terminator = findSequenceTerminator(data, contentStart)
 
-      if (!terminator) {
-        this.pendingControlSequence = data.slice(sequenceStart)
-        break
+        if (!terminator) {
+          this.pendingControlSequence = data.slice(sequenceStart)
+          break
+        }
+
+        const sequenceEnd = terminator.index + terminator.length
+        const content = data.slice(contentStart, terminator.index)
+
+        this.consumeOsc(content, output)
+        cursor = sequenceEnd
+        continue
       }
 
-      const sequenceEnd = terminator.index + terminator.length
-      const content = data.slice(contentStart, terminator.index)
-      const sequence = data.slice(sequenceStart, sequenceEnd)
+      if (data.startsWith(CSI_PREFIX, sequenceStart)) {
+        const terminator = findCsiTerminator(
+          data,
+          sequenceStart + CSI_PREFIX.length
+        )
 
-      if (!this.consumeOsc(content, output)) {
-        visible += sequence
+        if (!terminator) {
+          this.pendingControlSequence = data.slice(sequenceStart)
+          break
+        }
+
+        cursor = terminator.index + terminator.length
+        continue
       }
 
-      cursor = sequenceEnd
+      visible += ESC
+      cursor = sequenceStart + ESC.length
     }
 
     if (
@@ -143,12 +180,12 @@ export class TerminalControlSequenceParser implements TerminalParser {
   private consumeOsc(
     content: string,
     output: TerminalParserOutputContext | null
-  ): boolean {
+  ): void {
     const identifier = parseOscIdentifier(content)
     const payload = parseOscPayload(content)
 
     if (identifier === null || payload === null || Number(identifier) !== 7) {
-      return false
+      return
     }
 
     this.emit({
@@ -157,8 +194,6 @@ export class TerminalControlSequenceParser implements TerminalParser {
       uri: payload,
       output,
     })
-
-    return true
   }
 
   private emit(event: TerminalParserEvent): void {

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -13,6 +13,23 @@ const OSC_PREFIX = `${ESC}]`
 const STRING_TERMINATOR = `${ESC}\\`
 const MAX_PENDING_CONTROL_SEQUENCE_LENGTH = 16_384
 
+const ERASE_LINE_SENTINELS = ['\uE000', '\uE001', '\uE002']
+
+export const getEraseLineSentinel = (mode: 0 | 1 | 2): string =>
+  ERASE_LINE_SENTINELS[mode]
+
+export const getEraseLineModeFromSentinel = (
+  character: string
+): 0 | 1 | 2 | null => {
+  const index = ERASE_LINE_SENTINELS.indexOf(character)
+
+  if (index === -1) {
+    return null
+  }
+
+  return index as 0 | 1 | 2
+}
+
 interface SequenceTerminator {
   readonly index: number
   readonly length: number
@@ -159,8 +176,30 @@ export class TerminalControlSequenceParser implements TerminalParser {
           break
         }
 
+        const finalByte = data[terminator.index] ?? ''
+
+        if (finalByte === 'K') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const parameterMatch = /^(\d*)/.exec(content)
+          const mode = Number(parameterMatch?.[1] ?? '0')
+
+          if (mode === 0 || mode === 1 || mode === 2) {
+            visible += getEraseLineSentinel(mode)
+          }
+        }
+
         cursor = terminator.index + terminator.length
         continue
+      }
+
+      // A lone ESC at the end of the chunk is likely the prefix of a control
+      // sequence split across PTY writes; keep it pending for the next chunk.
+      if (sequenceStart + ESC.length >= data.length) {
+        this.pendingControlSequence = data.slice(sequenceStart)
+        break
       }
 
       visible += ESC

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -13,7 +13,7 @@ const OSC_PREFIX = `${ESC}]`
 const STRING_TERMINATOR = `${ESC}\\`
 const MAX_PENDING_CONTROL_SEQUENCE_LENGTH = 16_384
 
-const ERASE_LINE_SENTINELS = ['\uE000', '\uE001', '\uE002']
+const ERASE_LINE_SENTINELS = ['\u{F0000}', '\u{F0001}', '\u{F0002}']
 
 export const getEraseLineSentinel = (mode: 0 | 1 | 2): string =>
   ERASE_LINE_SENTINELS[mode]

--- a/src/features/terminal/components/TerminalPane/terminalRendererCapabilities.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererCapabilities.test.ts
@@ -1,0 +1,31 @@
+// cspell:ignore ghostty
+import { describe, expect, test } from 'vitest'
+import {
+  GHOSTTY_TERMINAL_CAPABILITIES,
+  PLAIN_TEXT_TERMINAL_CAPABILITIES,
+  XTERM_TERMINAL_CAPABILITIES,
+} from './terminalRendererCapabilities'
+
+describe('terminalRendererCapabilities', () => {
+  test('keeps xterm and plain text on the text output path', () => {
+    expect(XTERM_TERMINAL_CAPABILITIES).toEqual({
+      preferredOutputInputMode: 'text',
+      acceptsText: true,
+      acceptsBytes: false,
+    })
+
+    expect(PLAIN_TEXT_TERMINAL_CAPABILITIES).toEqual({
+      preferredOutputInputMode: 'text',
+      acceptsText: true,
+      acceptsBytes: false,
+    })
+  })
+
+  test('keeps the Ghostty spike on the byte-preferring output path', () => {
+    expect(GHOSTTY_TERMINAL_CAPABILITIES).toEqual({
+      preferredOutputInputMode: 'bytes',
+      acceptsText: true,
+      acceptsBytes: true,
+    })
+  })
+})

--- a/src/features/terminal/components/TerminalPane/terminalRendererCapabilities.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererCapabilities.ts
@@ -1,0 +1,20 @@
+// cspell:ignore ghostty
+import type { TerminalRendererCapabilities } from '../../types'
+
+export const XTERM_TERMINAL_CAPABILITIES = {
+  preferredOutputInputMode: 'text',
+  acceptsText: true,
+  acceptsBytes: false,
+} as const satisfies TerminalRendererCapabilities
+
+export const PLAIN_TEXT_TERMINAL_CAPABILITIES = {
+  preferredOutputInputMode: 'text',
+  acceptsText: true,
+  acceptsBytes: false,
+} as const satisfies TerminalRendererCapabilities
+
+export const GHOSTTY_TERMINAL_CAPABILITIES = {
+  preferredOutputInputMode: 'bytes',
+  acceptsText: true,
+  acceptsBytes: true,
+} as const satisfies TerminalRendererCapabilities

--- a/src/features/terminal/components/TerminalPane/xtermInstance.ts
+++ b/src/features/terminal/components/TerminalPane/xtermInstance.ts
@@ -13,7 +13,6 @@ import type {
   TerminalParser,
   TerminalRendererHandle,
   TerminalRendererAdapter,
-  TerminalRendererCapabilities,
   TerminalSurface,
   TerminalTheme,
   TerminalViewportReader,
@@ -21,13 +20,8 @@ import type {
 import { toXtermTheme } from '../../theme/toXtermTheme'
 import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
 import { TerminalOutputPayloadRouter } from './terminalOutputPayload'
+import { XTERM_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 import '@xterm/xterm/css/xterm.css'
-
-const XTERM_TERMINAL_CAPABILITIES: TerminalRendererCapabilities = {
-  preferredOutputInputMode: 'text',
-  acceptsText: true,
-  acceptsBytes: false,
-}
 
 export const createXtermTerminal = (): TerminalInstance => {
   const terminal = new Terminal({


### PR DESCRIPTION
## Summary

- Add shared terminal renderer capability constants for xterm, plain-text, and Ghostty.
- Add a Ghostty parser engine seam that prefers byte payloads while retaining text fallback.
- Strip OSC title and CSI control/style sequences from the spike visible text path while preserving OSC7 cwd events.
- Improve the plain-text-backed Ghostty smoke surface for basic carriage-return and backspace rewrites.

## Impact

This keeps the default xterm path text-based while giving the opt-in `VITE_TERMINAL_RENDERER=ghostty` path a byte-preferring parser contract. It should reduce raw zsh/color/title escape leakage in the Ghostty smoke path without claiming full terminal-renderer parity yet.

## Validation

- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `git diff --check`
- `npx tsc -b --pretty false`
- `npx vitest run src/features/terminal`
- pre-push `npm test` passed: 298 files, 3785 tests passed, 3 skipped

Refs VIM-144