### PR TITLE
feat(keymap): migrate remaining workspace shortcuts (VIM-136 PR2)

### DIFF
--- a/src/features/keymap/catalog.test.ts
+++ b/src/features/keymap/catalog.test.ts
@@ -9,7 +9,7 @@ describe('CATALOG', () => {
     expect(new Set(ids).size).toBe(ids.length)
   })
 
-  test('the ten PR1-migrated commands are rebindable; the rest are display-only', () => {
+  test('PR1 + PR2 migrated commands are rebindable; the rest are display-only', () => {
     const rebindable = CATALOG.filter((cmd) => cmd.rebindable)
       .map((cmd) => cmd.id)
       .sort()
@@ -25,6 +25,15 @@ describe('CATALOG', () => {
         'focus-pane-right',
         'cycle-layout',
         'dock-toggle',
+        'new-session',
+        'session-prev',
+        'session-next',
+        'sidebar-toggle',
+        'sidebar-sessions',
+        'sidebar-files',
+        'focus-editor',
+        'focus-diff',
+        'burner-toggle',
       ].sort()
     )
   })

--- a/src/features/keymap/catalog.ts
+++ b/src/features/keymap/catalog.ts
@@ -25,10 +25,10 @@ const c = (
   ...mods: ('Mod' | 'Ctrl' | 'Shift' | 'Alt')[]
 ): Chord => ({ code, mods: new Set(mods) })
 
-// PR1 migrates usePaneShortcuts (the focus-pane / cycle-layout commands) and
-// useDockToggleShortcut. Their defaultCombo MUST equal today's hardcoded combos
-// (resolve.test asserts this). Everything else is rebindable:false display-only
-// for now; PR2 flips the workspace hooks, SP3 the leader.
+// PR1 migrated usePaneShortcuts (the focus-pane / cycle-layout commands) and
+// useDockToggleShortcut. PR2 migrates the remaining workspace hooks. Their
+// defaultCombo MUST equal today's hardcoded combos (resolve.test asserts this).
+// Terminal-owned rows and the SP3-owned palette leader remain display-only.
 export const CATALOG = [
   // ── Panes & Layout (MIGRATED — rebindable) ──
   {
@@ -159,7 +159,7 @@ export const CATALOG = [
     group: 'Global',
     context: 'global',
     matchPolicy: 'exact',
-    rebindable: false,
+    rebindable: true,
     defaultCombo: (isMac: boolean): Chord =>
       isMac ? c('KeyN', 'Mod') : c('KeyN', 'Mod', 'Shift'),
   },
@@ -169,7 +169,7 @@ export const CATALOG = [
     group: 'Global',
     context: 'global',
     matchPolicy: 'exact',
-    rebindable: false,
+    rebindable: true,
     defaultCombo: (isMac: boolean): Chord =>
       isMac ? c('BracketLeft', 'Mod') : c('BracketLeft', 'Mod', 'Shift'),
   },
@@ -179,7 +179,7 @@ export const CATALOG = [
     group: 'Global',
     context: 'global',
     matchPolicy: 'exact',
-    rebindable: false,
+    rebindable: true,
     defaultCombo: (isMac: boolean): Chord =>
       isMac ? c('BracketRight', 'Mod') : c('BracketRight', 'Mod', 'Shift'),
   },
@@ -189,7 +189,7 @@ export const CATALOG = [
     group: 'Global',
     context: 'global',
     matchPolicy: 'exact',
-    rebindable: false,
+    rebindable: true,
     defaultCombo: (isMac: boolean): Chord =>
       isMac ? c('KeyB', 'Mod') : c('KeyB', 'Mod', 'Shift'),
   },
@@ -199,7 +199,7 @@ export const CATALOG = [
     group: 'Global',
     context: 'global',
     matchPolicy: 'exact',
-    rebindable: false,
+    rebindable: true,
     defaultCombo: c('KeyS', 'Mod', 'Shift'),
   },
   {
@@ -208,7 +208,7 @@ export const CATALOG = [
     group: 'Global',
     context: 'global',
     matchPolicy: 'exact',
-    rebindable: false,
+    rebindable: true,
     defaultCombo: c('KeyF', 'Mod', 'Shift'),
   },
   {
@@ -217,7 +217,7 @@ export const CATALOG = [
     group: 'Global',
     context: 'global',
     matchPolicy: 'exact',
-    rebindable: false,
+    rebindable: true,
     defaultCombo: c('KeyE', 'Mod'),
   },
   {
@@ -226,7 +226,7 @@ export const CATALOG = [
     group: 'Global',
     context: 'global',
     matchPolicy: 'exact',
-    rebindable: false,
+    rebindable: true,
     defaultCombo: c('KeyG', 'Mod'),
   },
   {
@@ -235,7 +235,7 @@ export const CATALOG = [
     group: 'Global',
     context: 'global',
     matchPolicy: 'exact',
-    rebindable: false,
+    rebindable: true,
     defaultCombo: c('Backquote', 'Ctrl'),
   },
 

--- a/src/features/keymap/resolve.test.ts
+++ b/src/features/keymap/resolve.test.ts
@@ -25,6 +25,11 @@ describe('behavior preservation — migrated defaults equal today’s hardcoded 
     'focus-pane-up': 'Mod+Shift+ArrowUp',
     'focus-pane-right': 'Mod+Shift+ArrowRight',
     'dock-toggle': 'Mod+Digit0',
+    'sidebar-sessions': 'Mod+Shift+KeyS',
+    'sidebar-files': 'Mod+Shift+KeyF',
+    'focus-editor': 'Mod+KeyE',
+    'focus-diff': 'Mod+KeyG',
+    'burner-toggle': 'Ctrl+Backquote',
   }
   for (const isMac of [true, false]) {
     for (const [id, token] of Object.entries(expected)) {
@@ -33,6 +38,30 @@ describe('behavior preservation — migrated defaults equal today’s hardcoded 
         expect(formatChord(resolveDefault(cmd, isMac))).toBe(token)
       })
     }
+  }
+})
+
+describe('behavior preservation — platform-specific PR2 defaults equal today’s hardcoded combos', () => {
+  const expectedByPlatform: Record<string, { mac: string; other: string }> = {
+    'new-session': { mac: 'Mod+KeyN', other: 'Mod+Shift+KeyN' },
+    'session-prev': {
+      mac: 'Mod+BracketLeft',
+      other: 'Mod+Shift+BracketLeft',
+    },
+    'session-next': {
+      mac: 'Mod+BracketRight',
+      other: 'Mod+Shift+BracketRight',
+    },
+    'sidebar-toggle': { mac: 'Mod+KeyB', other: 'Mod+Shift+KeyB' },
+  }
+
+  for (const [id, expected] of Object.entries(expectedByPlatform)) {
+    test(`${id} has a platform-specific default`, () => {
+      const cmd = CATALOG.find((c) => c.id === id)!
+
+      expect(formatChord(resolveDefault(cmd, true))).toBe(expected.mac)
+      expect(formatChord(resolveDefault(cmd, false))).toBe(expected.other)
+    })
   }
 })
 

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -457,6 +457,7 @@ describe('WorkspaceView', () => {
         document.dispatchEvent(
           new KeyboardEvent('keydown', {
             key: 'b',
+            code: 'KeyB',
             ctrlKey: true,
             shiftKey: true,
             bubbles: true,
@@ -524,6 +525,7 @@ describe('WorkspaceView', () => {
         document.dispatchEvent(
           new KeyboardEvent('keydown', {
             key: 'b',
+            code: 'KeyB',
             ctrlKey: true,
             shiftKey: true,
             bubbles: true,
@@ -1374,6 +1376,7 @@ describe('WorkspaceView', () => {
       document.dispatchEvent(
         new KeyboardEvent('keydown', {
           key: 'n',
+          code: 'KeyN',
           ctrlKey: true,
           shiftKey: true,
           bubbles: true,

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1452,6 +1452,7 @@ export const WorkspaceView = (): ReactElement => {
     activeContainerId,
     openDock,
     claimTerminal,
+    matches,
     modKey: preferModifier === 'meta' ? '⌘' : 'Ctrl',
   })
 
@@ -1462,13 +1463,13 @@ export const WorkspaceView = (): ReactElement => {
 
   useSidebarShortcut({
     onToggle: handleToggleSidebar,
-    modKey: preferModifier === 'meta' ? '⌘' : 'Ctrl',
+    matches,
     activeContainerId,
   })
 
   useNewSessionShortcut({
     onNewSession: handleCreateSession,
-    modKey: preferModifier === 'meta' ? '⌘' : 'Ctrl',
+    matches,
   })
 
   // VIM-104: ⌘⇧S / ⌘⇧F switch the left sidebar between Sessions and Files,
@@ -1497,7 +1498,7 @@ export const WorkspaceView = (): ReactElement => {
   useSidebarTabShortcut({
     onShowSessions: handleShowSessions,
     onShowFiles: handleShowFiles,
-    modKey: preferModifier === 'meta' ? '⌘' : 'Ctrl',
+    matches,
   })
 
   // VIM-104: ⌘[ / ⌘] cycle to the previous / next session (Ctrl+⇧[ / Ctrl+⇧]
@@ -1528,11 +1529,11 @@ export const WorkspaceView = (): ReactElement => {
   useSessionNavShortcut({
     onPrevSession: handlePrevSession,
     onNextSession: handleNextSession,
-    modKey: preferModifier === 'meta' ? '⌘' : 'Ctrl',
+    matches,
   })
 
   // VIM-104: Ctrl+` toggles the burner terminal popup for the focused pane.
-  useBurnerToggleShortcut({ onToggle: toggleBurnerCommand })
+  useBurnerToggleShortcut({ onToggle: toggleBurnerCommand, matches })
 
   // One elastic size per axis so values survive dock unmounts and position changes.
   const verticalDockElastic = useElasticContainer({

--- a/src/features/workspace/hooks/useBurnerToggleShortcut.test.ts
+++ b/src/features/workspace/hooks/useBurnerToggleShortcut.test.ts
@@ -1,5 +1,8 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { getCommand, type CommandId } from '../../keymap/catalog'
+import { eventMatchesChord, type PlatformSuper } from '../../keymap/match'
+import { resolveBindings, type CustomKeybindings } from '../../keymap/resolve'
 import {
   useBurnerToggleShortcut,
   type UseBurnerToggleShortcutParams,
@@ -32,10 +35,27 @@ const fireBackquote = (
   return event.defaultPrevented
 }
 
+const matchesFor = (
+  isMac: boolean,
+  overrides: CustomKeybindings = {}
+): UseBurnerToggleShortcutParams['matches'] => {
+  const superKey: PlatformSuper = isMac ? 'meta' : 'ctrl'
+  const resolved = resolveBindings(overrides, isMac, superKey)
+
+  return (event: KeyboardEvent, id: CommandId): boolean =>
+    eventMatchesChord(
+      event,
+      resolved.get(id)!,
+      superKey,
+      getCommand(id).matchPolicy
+    )
+}
+
 const makeProps = (
   overrides: Partial<UseBurnerToggleShortcutParams> = {}
 ): UseBurnerToggleShortcutParams => ({
   onToggle: vi.fn(),
+  matches: matchesFor(true),
   ...overrides,
 })
 
@@ -133,5 +153,25 @@ describe('useBurnerToggleShortcut', () => {
     fireBackquote({ ctrlKey: true })
 
     expect(props.onToggle).not.toHaveBeenCalled()
+  })
+
+  test('fires on a rebound combo supplied by the registry matcher', () => {
+    const props = makeProps({
+      matches: matchesFor(true, { 'burner-toggle': 'Mod+KeyK' }),
+    })
+    renderHook(() => useBurnerToggleShortcut(props))
+
+    const event = new KeyboardEvent('keydown', {
+      code: 'KeyK',
+      key: 'k',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    act(() => {
+      document.body.dispatchEvent(event)
+    })
+
+    expect(props.onToggle).toHaveBeenCalledOnce()
   })
 })

--- a/src/features/workspace/hooks/useBurnerToggleShortcut.ts
+++ b/src/features/workspace/hooks/useBurnerToggleShortcut.ts
@@ -1,10 +1,13 @@
 import { useEffect, useRef } from 'react'
 import { isKeymapCaptureTarget } from '../../keymap/capture'
+import type { CommandId } from '../../keymap/catalog'
 import { DIALOG_SELECTOR } from '../containerIds'
 
 export interface UseBurnerToggleShortcutParams {
   /** Toggle the burner terminal popup for the focused pane. */
   onToggle: () => void
+  /** Registry matcher — true iff the event is the resolved command chord. */
+  matches: (event: KeyboardEvent, id: CommandId) => boolean
 }
 
 // Burner terminal toggle (VIM-53): Ctrl+` on every platform — the cross-editor
@@ -14,9 +17,12 @@ export interface UseBurnerToggleShortcutParams {
 // so it toggles from anywhere except an open modal.
 export const useBurnerToggleShortcut = ({
   onToggle,
+  matches,
 }: UseBurnerToggleShortcutParams): void => {
   const onToggleRef = useRef(onToggle)
+  const matchesRef = useRef(matches)
   onToggleRef.current = onToggle
+  matchesRef.current = matches
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -24,15 +30,11 @@ export const useBurnerToggleShortcut = ({
         return
       }
 
-      // Exactly Ctrl+` — reject ⌘/Alt/Shift-modified and held-key repeats.
-      if (
-        event.repeat ||
-        event.code !== 'Backquote' ||
-        !event.ctrlKey ||
-        event.metaKey ||
-        event.altKey ||
-        event.shiftKey
-      ) {
+      if (event.repeat) {
+        return
+      }
+
+      if (!matchesRef.current(event, 'burner-toggle')) {
         return
       }
 

--- a/src/features/workspace/hooks/useDockShortcuts.test.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.test.ts
@@ -1,5 +1,8 @@
 import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { getCommand, type CommandId } from '../../keymap/catalog'
+import { eventMatchesChord, type PlatformSuper } from '../../keymap/match'
+import { resolveBindings, type CustomKeybindings } from '../../keymap/resolve'
 import { DOCK_CONTAINER_ID, TERMINAL_CONTAINER_ID } from '../containerIds'
 import { useDockShortcuts } from './useDockShortcuts'
 
@@ -39,6 +42,22 @@ const blurActiveElement = (): void => {
   activeElement?.blur?.()
 }
 
+const matchesFor = (
+  isMac: boolean,
+  overrides: CustomKeybindings = {}
+): Parameters<typeof useDockShortcuts>[0]['matches'] => {
+  const superKey: PlatformSuper = isMac ? 'meta' : 'ctrl'
+  const resolved = resolveBindings(overrides, isMac, superKey)
+
+  return (event: KeyboardEvent, id: CommandId): boolean =>
+    eventMatchesChord(
+      event,
+      resolved.get(id)!,
+      superKey,
+      getCommand(id).matchPolicy
+    )
+}
+
 describe('useDockShortcuts', () => {
   const makeProps = (
     overrides: Partial<Parameters<typeof useDockShortcuts>[0]> = {}
@@ -46,6 +65,7 @@ describe('useDockShortcuts', () => {
     activeContainerId: DOCK_CONTAINER_ID,
     openDock: vi.fn(),
     claimTerminal: vi.fn(),
+    matches: matchesFor(false),
     modKey: 'Ctrl',
     ...overrides,
   })
@@ -134,6 +154,21 @@ describe('useDockShortcuts', () => {
     expect(event.preventDefaultSpy).not.toHaveBeenCalled()
   })
 
+  test('focus-editor fires on a rebound combo supplied by the registry matcher', () => {
+    const props = makeProps({
+      matches: matchesFor(false, { 'focus-editor': 'Mod+KeyK' }),
+    })
+    const dockElement = attachDockAndFocus()
+    renderHook(() => useDockShortcuts(props))
+
+    const event = fire('k', { ctrlKey: true })
+
+    expect(props.openDock).toHaveBeenCalledWith('editor')
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    removeElement(dockElement)
+  })
+
   test('Ctrl+e from within a dialog is a no-op', () => {
     const props = makeProps()
     const dialog = document.createElement('div')
@@ -153,7 +188,7 @@ describe('useDockShortcuts', () => {
   })
 
   test('macOS modifier mode accepts Cmd+e and ignores Ctrl+e', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true), modKey: '⌘' })
     renderHook(() => useDockShortcuts(props))
 
     fire('e', { ctrlKey: true })

--- a/src/features/workspace/hooks/useDockShortcuts.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { isKeymapCaptureTarget } from '../../keymap/capture'
+import type { CommandId } from '../../keymap/catalog'
 import {
   DIALOG_SELECTOR,
   DOCK_CONTAINER_ID,
@@ -13,6 +14,8 @@ export interface UseDockShortcutsParams {
   activeContainerId: string
   openDock: (tab: DockFocusTarget) => void
   claimTerminal: () => void
+  /** Registry matcher for focus-editor/focus-diff. Dock reclaim stays hardcoded. */
+  matches: (event: KeyboardEvent, id: CommandId) => boolean
   modKey: '⌘' | 'Ctrl'
 }
 
@@ -20,16 +23,19 @@ export const useDockShortcuts = ({
   activeContainerId,
   openDock,
   claimTerminal,
+  matches,
   modKey,
 }: UseDockShortcutsParams): void => {
   const activeContainerIdRef = useRef(activeContainerId)
   const openDockRef = useRef(openDock)
   const claimTerminalRef = useRef(claimTerminal)
+  const matchesRef = useRef(matches)
   const modKeyRef = useRef(modKey)
 
   activeContainerIdRef.current = activeContainerId
   openDockRef.current = openDock
   claimTerminalRef.current = claimTerminal
+  matchesRef.current = matches
   modKeyRef.current = modKey
 
   useEffect(() => {
@@ -38,12 +44,26 @@ export const useDockShortcuts = ({
         return
       }
 
-      const expectedModifier =
+      const dockTarget = matchesRef.current(event, 'focus-editor')
+        ? 'editor'
+        : matchesRef.current(event, 'focus-diff')
+          ? 'diff'
+          : null
+
+      const expectedReclaimModifier =
         modKeyRef.current === '⌘'
           ? event.metaKey && !event.ctrlKey
           : event.ctrlKey && !event.metaKey
 
-      if (!expectedModifier || event.shiftKey || event.altKey) {
+      const key = event.key.toLowerCase()
+
+      const canReclaimTerminal =
+        key === 'b' &&
+        expectedReclaimModifier &&
+        !event.shiftKey &&
+        !event.altKey
+
+      if (dockTarget === null && !canReclaimTerminal) {
         return
       }
 
@@ -75,32 +95,22 @@ export const useDockShortcuts = ({
         return
       }
 
-      const key = event.key.toLowerCase()
-
       // Ctrl+e / Ctrl+g: do not steal vim/readline shortcuts when xterm or
       // CodeMirror has focus. Ctrl+b is exempt — it only fires when dock is
       // active (checked below), so it can never originate from either surface.
-      if ((key === 'e' || key === 'g') && (inTerminalZone || inCodeMirror)) {
+      if (dockTarget !== null && (inTerminalZone || inCodeMirror)) {
         return
       }
 
-      if (key === 'e') {
+      if (dockTarget !== null) {
         event.preventDefault()
         event.stopPropagation()
-        openDockRef.current('editor')
+        openDockRef.current(dockTarget)
 
         return
       }
 
-      if (key === 'g') {
-        event.preventDefault()
-        event.stopPropagation()
-        openDockRef.current('diff')
-
-        return
-      }
-
-      if (key === 'b') {
+      if (canReclaimTerminal) {
         const activeElement = document.activeElement
         if (
           !inCodeMirror &&

--- a/src/features/workspace/hooks/useNewSessionShortcut.test.ts
+++ b/src/features/workspace/hooks/useNewSessionShortcut.test.ts
@@ -1,5 +1,8 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { getCommand, type CommandId } from '../../keymap/catalog'
+import { eventMatchesChord, type PlatformSuper } from '../../keymap/match'
+import { resolveBindings, type CustomKeybindings } from '../../keymap/resolve'
 import { TERMINAL_CONTAINER_ID } from '../containerIds'
 import {
   useNewSessionShortcut,
@@ -36,6 +39,7 @@ const fireFrom = (
 ): void => {
   const event = new KeyboardEvent('keydown', {
     key: 'n',
+    code: 'KeyN',
     bubbles: true,
     cancelable: true,
     ...modifiers,
@@ -45,11 +49,27 @@ const fireFrom = (
   })
 }
 
+const matchesFor = (
+  isMac: boolean,
+  overrides: CustomKeybindings = {}
+): UseNewSessionShortcutParams['matches'] => {
+  const superKey: PlatformSuper = isMac ? 'meta' : 'ctrl'
+  const resolved = resolveBindings(overrides, isMac, superKey)
+
+  return (event: KeyboardEvent, id: CommandId): boolean =>
+    eventMatchesChord(
+      event,
+      resolved.get(id)!,
+      superKey,
+      getCommand(id).matchPolicy
+    )
+}
+
 const makeProps = (
   overrides: Partial<UseNewSessionShortcutParams> = {}
 ): UseNewSessionShortcutParams => ({
   onNewSession: vi.fn(),
-  modKey: '⌘',
+  matches: matchesFor(true),
   ...overrides,
 })
 
@@ -66,7 +86,7 @@ describe('useNewSessionShortcut', () => {
 
   describe('meta (⌘) modifier', () => {
     test('⌘N (no shift) creates a session', () => {
-      const props = makeProps({ modKey: '⌘' })
+      const props = makeProps({ matches: matchesFor(true) })
       const target = append(document.createElement('div'))
       renderHook(() => useNewSessionShortcut(props))
 
@@ -76,7 +96,7 @@ describe('useNewSessionShortcut', () => {
     })
 
     test('⌘⇧N does not fire (shift not allowed on meta)', () => {
-      const props = makeProps({ modKey: '⌘' })
+      const props = makeProps({ matches: matchesFor(true) })
       const target = append(document.createElement('div'))
       renderHook(() => useNewSessionShortcut(props))
 
@@ -86,7 +106,7 @@ describe('useNewSessionShortcut', () => {
     })
 
     test('⌘⌥N does not fire (alt always bails)', () => {
-      const props = makeProps({ modKey: '⌘' })
+      const props = makeProps({ matches: matchesFor(true) })
       const target = append(document.createElement('div'))
       renderHook(() => useNewSessionShortcut(props))
 
@@ -98,7 +118,7 @@ describe('useNewSessionShortcut', () => {
 
   describe('Ctrl modifier', () => {
     test('Ctrl+⇧N creates a session', () => {
-      const props = makeProps({ modKey: 'Ctrl' })
+      const props = makeProps({ matches: matchesFor(false) })
       const target = append(document.createElement('div'))
       renderHook(() => useNewSessionShortcut(props))
 
@@ -108,7 +128,7 @@ describe('useNewSessionShortcut', () => {
     })
 
     test('bare Ctrl+N (no shift) does not fire — left to the terminal', () => {
-      const props = makeProps({ modKey: 'Ctrl' })
+      const props = makeProps({ matches: matchesFor(false) })
       const target = append(document.createElement('div'))
       renderHook(() => useNewSessionShortcut(props))
 
@@ -119,7 +139,7 @@ describe('useNewSessionShortcut', () => {
   })
 
   test('bails when a dialog matching DIALOG_SELECTOR is in the DOM', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     const dialog = document.createElement('div')
     dialog.setAttribute('role', 'dialog')
     append(dialog)
@@ -132,7 +152,7 @@ describe('useNewSessionShortcut', () => {
   })
 
   test('⌘N fires from inside the terminal zone', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     const target = appendContainerWithChild(TERMINAL_CONTAINER_ID, 'textarea')
     renderHook(() => useNewSessionShortcut(props))
 
@@ -142,7 +162,7 @@ describe('useNewSessionShortcut', () => {
   })
 
   test('bails when the target is a plain <input> (e.g. the rename field)', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     const target = append(document.createElement('input'))
     renderHook(() => useNewSessionShortcut(props))
 
@@ -152,7 +172,7 @@ describe('useNewSessionShortcut', () => {
   })
 
   test('removes the listener on unmount', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     const target = append(document.createElement('div'))
     const { unmount } = renderHook(() => useNewSessionShortcut(props))
 
@@ -163,12 +183,24 @@ describe('useNewSessionShortcut', () => {
   })
 
   test('ignores auto-repeat (held key) events', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     const target = append(document.createElement('div'))
     renderHook(() => useNewSessionShortcut(props))
 
     fireFrom(target, { metaKey: true, repeat: true })
 
     expect(props.onNewSession).not.toHaveBeenCalled()
+  })
+
+  test('fires on a rebound combo supplied by the registry matcher', () => {
+    const props = makeProps({
+      matches: matchesFor(true, { 'new-session': 'Mod+KeyK' }),
+    })
+    const target = append(document.createElement('div'))
+    renderHook(() => useNewSessionShortcut(props))
+
+    fireFrom(target, { key: 'k', code: 'KeyK', metaKey: true })
+
+    expect(props.onNewSession).toHaveBeenCalledOnce()
   })
 })

--- a/src/features/workspace/hooks/useNewSessionShortcut.ts
+++ b/src/features/workspace/hooks/useNewSessionShortcut.ts
@@ -1,29 +1,31 @@
 import { useEffect, useRef } from 'react'
 import { isKeymapCaptureTarget } from '../../keymap/capture'
+import type { CommandId } from '../../keymap/catalog'
 import { DIALOG_SELECTOR, TERMINAL_CONTAINER_ID } from '../containerIds'
 
 export interface UseNewSessionShortcutParams {
   /** Create a new session. */
   onNewSession: () => void
-  /** Visible modifier on this platform: '⌘' (meta) or 'Ctrl'. */
-  modKey: '⌘' | 'Ctrl'
+  /** Registry matcher — true iff the event is the resolved command chord. */
+  matches: (event: KeyboardEvent, id: CommandId) => boolean
 }
 
 // New-session shortcut (VIM-77), mirroring the sidebar-toggle convention:
-//   - macOS (modKey '⌘'): ⌘N — ⌘ chords never reach the PTY.
-//   - Linux/Windows (modKey 'Ctrl'): Ctrl+⇧N — bare Ctrl+N is reserved by the
-//     terminal (readline next-line / TUI bindings), so we require Shift.
+//   - macOS default: ⌘N — ⌘ chords never reach the PTY.
+//   - Linux/Windows default: Ctrl+⇧N — bare Ctrl+N is reserved by the terminal
+//     (readline next-line / TUI bindings), so we require Shift.
 // Allowed through from the terminal and the editor, but not from plain text
-// inputs (e.g. the session rename field).
+// inputs (e.g. the session rename field). The key match comes from the
+// keybinding registry so persisted overrides take effect.
 export const useNewSessionShortcut = ({
   onNewSession,
-  modKey,
+  matches,
 }: UseNewSessionShortcutParams): void => {
   const onNewSessionRef = useRef(onNewSession)
-  const modKeyRef = useRef(modKey)
+  const matchesRef = useRef(matches)
 
   onNewSessionRef.current = onNewSession
-  modKeyRef.current = modKey
+  matchesRef.current = matches
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -36,21 +38,7 @@ export const useNewSessionShortcut = ({
         return
       }
 
-      if (event.key.toLowerCase() !== 'n' || event.altKey) {
-        return
-      }
-
-      const isMeta = modKeyRef.current === '⌘'
-
-      const expectedModifier = isMeta
-        ? event.metaKey && !event.ctrlKey
-        : event.ctrlKey && !event.metaKey
-      if (!expectedModifier) {
-        return
-      }
-
-      // macOS: ⌘N (no Shift). Ctrl platforms: Ctrl+⇧N (Shift required).
-      if (isMeta ? event.shiftKey : !event.shiftKey) {
+      if (!matchesRef.current(event, 'new-session')) {
         return
       }
 

--- a/src/features/workspace/hooks/useSessionNavShortcut.test.ts
+++ b/src/features/workspace/hooks/useSessionNavShortcut.test.ts
@@ -1,5 +1,8 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { getCommand, type CommandId } from '../../keymap/catalog'
+import { eventMatchesChord, type PlatformSuper } from '../../keymap/match'
+import { resolveBindings, type CustomKeybindings } from '../../keymap/resolve'
 import {
   useSessionNavShortcut,
   type UseSessionNavShortcutParams,
@@ -33,12 +36,28 @@ const fireBracket = (
   return event.defaultPrevented
 }
 
+const matchesFor = (
+  isMac: boolean,
+  overrides: CustomKeybindings = {}
+): UseSessionNavShortcutParams['matches'] => {
+  const superKey: PlatformSuper = isMac ? 'meta' : 'ctrl'
+  const resolved = resolveBindings(overrides, isMac, superKey)
+
+  return (event: KeyboardEvent, id: CommandId): boolean =>
+    eventMatchesChord(
+      event,
+      resolved.get(id)!,
+      superKey,
+      getCommand(id).matchPolicy
+    )
+}
+
 const makeProps = (
   overrides: Partial<UseSessionNavShortcutParams> = {}
 ): UseSessionNavShortcutParams => ({
   onPrevSession: vi.fn(),
   onNextSession: vi.fn(),
-  modKey: '⌘',
+  matches: matchesFor(true),
   ...overrides,
 })
 
@@ -53,7 +72,7 @@ describe('useSessionNavShortcut', () => {
   })
 
   test('⌘[ / ⌘] cycle prev / next on macOS', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSessionNavShortcut(props))
 
     expect(fireBracket('BracketLeft', { metaKey: true })).toBe(true)
@@ -64,7 +83,7 @@ describe('useSessionNavShortcut', () => {
   })
 
   test('Ctrl+⇧[ / Ctrl+⇧] cycle on Linux', () => {
-    const props = makeProps({ modKey: 'Ctrl' })
+    const props = makeProps({ matches: matchesFor(false) })
     renderHook(() => useSessionNavShortcut(props))
 
     fireBracket('BracketLeft', { ctrlKey: true, shiftKey: true })
@@ -75,7 +94,7 @@ describe('useSessionNavShortcut', () => {
   })
 
   test('macOS rejects the Shift variant', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSessionNavShortcut(props))
 
     fireBracket('BracketLeft', { metaKey: true, shiftKey: true })
@@ -84,7 +103,7 @@ describe('useSessionNavShortcut', () => {
   })
 
   test('Linux leaves bare Ctrl+[ for the terminal ESC', () => {
-    const props = makeProps({ modKey: 'Ctrl' })
+    const props = makeProps({ matches: matchesFor(false) })
     renderHook(() => useSessionNavShortcut(props))
 
     const prevented = fireBracket('BracketLeft', { ctrlKey: true })
@@ -94,7 +113,7 @@ describe('useSessionNavShortcut', () => {
   })
 
   test('ignores the opposite modifier so it reaches the terminal', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSessionNavShortcut(props))
 
     const prevented = fireBracket('BracketLeft', { ctrlKey: true })
@@ -110,7 +129,7 @@ describe('useSessionNavShortcut', () => {
     content.setAttribute('contenteditable', 'true')
     editor.appendChild(content)
 
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSessionNavShortcut(props))
 
     const prevented = fireBracket('BracketLeft', { metaKey: true }, content)
@@ -125,7 +144,7 @@ describe('useSessionNavShortcut', () => {
     const textarea = document.createElement('textarea')
     zone.appendChild(textarea)
 
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSessionNavShortcut(props))
 
     fireBracket('BracketRight', { metaKey: true }, textarea)
@@ -137,7 +156,7 @@ describe('useSessionNavShortcut', () => {
     const dialog = append(document.createElement('div'))
     dialog.setAttribute('role', 'dialog')
 
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSessionNavShortcut(props))
 
     fireBracket('BracketLeft', { metaKey: true })
@@ -146,7 +165,7 @@ describe('useSessionNavShortcut', () => {
   })
 
   test('ignores other keys', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSessionNavShortcut(props))
 
     const event = new KeyboardEvent('keydown', {
@@ -165,12 +184,45 @@ describe('useSessionNavShortcut', () => {
   })
 
   test('detaches its listener on unmount', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     const { unmount } = renderHook(() => useSessionNavShortcut(props))
 
     unmount()
     fireBracket('BracketLeft', { metaKey: true })
 
     expect(props.onPrevSession).not.toHaveBeenCalled()
+  })
+
+  test('fires on rebound combos supplied by the registry matcher', () => {
+    const props = makeProps({
+      matches: matchesFor(true, {
+        'session-prev': 'Mod+KeyJ',
+        'session-next': 'Mod+KeyK',
+      }),
+    })
+    renderHook(() => useSessionNavShortcut(props))
+
+    const prev = new KeyboardEvent('keydown', {
+      code: 'KeyJ',
+      key: 'j',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    const next = new KeyboardEvent('keydown', {
+      code: 'KeyK',
+      key: 'k',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    act(() => {
+      document.body.dispatchEvent(prev)
+      document.body.dispatchEvent(next)
+    })
+
+    expect(props.onPrevSession).toHaveBeenCalledOnce()
+    expect(props.onNextSession).toHaveBeenCalledOnce()
   })
 })

--- a/src/features/workspace/hooks/useSessionNavShortcut.ts
+++ b/src/features/workspace/hooks/useSessionNavShortcut.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { isKeymapCaptureTarget } from '../../keymap/capture'
+import type { CommandId } from '../../keymap/catalog'
 import { DIALOG_SELECTOR, TERMINAL_CONTAINER_ID } from '../containerIds'
 
 export interface UseSessionNavShortcutParams {
@@ -7,8 +8,8 @@ export interface UseSessionNavShortcutParams {
   onPrevSession: () => void
   /** Activate the next session (wraps around). */
   onNextSession: () => void
-  /** Visible modifier on this platform: '⌘' (meta) or 'Ctrl'. */
-  modKey: '⌘' | 'Ctrl'
+  /** Registry matcher — true iff the event is the resolved command chord. */
+  matches: (event: KeyboardEvent, id: CommandId) => boolean
 }
 
 // Session navigation (VIM-104): ⌘[ / ⌘] cycle to the previous / next session
@@ -23,15 +24,15 @@ export interface UseSessionNavShortcutParams {
 export const useSessionNavShortcut = ({
   onPrevSession,
   onNextSession,
-  modKey,
+  matches,
 }: UseSessionNavShortcutParams): void => {
   const onPrevRef = useRef(onPrevSession)
   const onNextRef = useRef(onNextSession)
-  const modKeyRef = useRef(modKey)
+  const matchesRef = useRef(matches)
 
   onPrevRef.current = onPrevSession
   onNextRef.current = onNextSession
-  modKeyRef.current = modKey
+  matchesRef.current = matches
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -39,28 +40,17 @@ export const useSessionNavShortcut = ({
         return
       }
 
-      if (event.repeat || event.altKey) {
+      if (event.repeat) {
         return
       }
 
-      if (event.code !== 'BracketLeft' && event.code !== 'BracketRight') {
-        return
-      }
+      const commandId = matchesRef.current(event, 'session-prev')
+        ? 'session-prev'
+        : matchesRef.current(event, 'session-next')
+          ? 'session-next'
+          : null
 
-      // Match only this platform's modifier; reject the opposite so the other
-      // chord still reaches the terminal.
-      const isMeta = modKeyRef.current === '⌘'
-
-      const expectedModifier = isMeta
-        ? event.metaKey && !event.ctrlKey
-        : event.ctrlKey && !event.metaKey
-      if (!expectedModifier) {
-        return
-      }
-
-      // macOS: ⌘[ / ⌘] (no Shift). Ctrl platforms: Ctrl+⇧[ / Ctrl+⇧] (Shift
-      // required) — bare Ctrl+[ is the terminal's ESC.
-      if (isMeta ? event.shiftKey : !event.shiftKey) {
+      if (commandId === null) {
         return
       }
 
@@ -94,7 +84,7 @@ export const useSessionNavShortcut = ({
       event.preventDefault()
       event.stopPropagation()
 
-      if (event.code === 'BracketLeft') {
+      if (commandId === 'session-prev') {
         onPrevRef.current()
       } else {
         onNextRef.current()

--- a/src/features/workspace/hooks/useSidebarShortcut.test.ts
+++ b/src/features/workspace/hooks/useSidebarShortcut.test.ts
@@ -1,5 +1,8 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { getCommand, type CommandId } from '../../keymap/catalog'
+import { eventMatchesChord, type PlatformSuper } from '../../keymap/match'
+import { resolveBindings, type CustomKeybindings } from '../../keymap/resolve'
 import { DOCK_CONTAINER_ID, TERMINAL_CONTAINER_ID } from '../containerIds'
 import {
   useSidebarShortcut,
@@ -36,6 +39,7 @@ const fireFrom = (
 ): void => {
   const event = new KeyboardEvent('keydown', {
     key: 'b',
+    code: 'KeyB',
     bubbles: true,
     cancelable: true,
     ...modifiers,
@@ -45,11 +49,27 @@ const fireFrom = (
   })
 }
 
+const matchesFor = (
+  isMac: boolean,
+  overrides: CustomKeybindings = {}
+): UseSidebarShortcutParams['matches'] => {
+  const superKey: PlatformSuper = isMac ? 'meta' : 'ctrl'
+  const resolved = resolveBindings(overrides, isMac, superKey)
+
+  return (event: KeyboardEvent, id: CommandId): boolean =>
+    eventMatchesChord(
+      event,
+      resolved.get(id)!,
+      superKey,
+      getCommand(id).matchPolicy
+    )
+}
+
 const makeProps = (
   overrides: Partial<UseSidebarShortcutParams> = {}
 ): UseSidebarShortcutParams => ({
   onToggle: vi.fn(),
-  modKey: '⌘',
+  matches: matchesFor(true),
   activeContainerId: TERMINAL_CONTAINER_ID,
   ...overrides,
 })
@@ -67,7 +87,7 @@ describe('useSidebarShortcut', () => {
 
   describe('meta (⌘) modifier', () => {
     test('⌘B (no shift) toggles', () => {
-      const props = makeProps({ modKey: '⌘' })
+      const props = makeProps({ matches: matchesFor(true) })
       const target = append(document.createElement('div'))
       renderHook(() => useSidebarShortcut(props))
 
@@ -77,7 +97,7 @@ describe('useSidebarShortcut', () => {
     })
 
     test('⌘⇧B does not toggle (shift not allowed on meta)', () => {
-      const props = makeProps({ modKey: '⌘' })
+      const props = makeProps({ matches: matchesFor(true) })
       const target = append(document.createElement('div'))
       renderHook(() => useSidebarShortcut(props))
 
@@ -87,7 +107,7 @@ describe('useSidebarShortcut', () => {
     })
 
     test('⌘⌥B does not toggle (alt always bails)', () => {
-      const props = makeProps({ modKey: '⌘' })
+      const props = makeProps({ matches: matchesFor(true) })
       const target = append(document.createElement('div'))
       renderHook(() => useSidebarShortcut(props))
 
@@ -99,7 +119,7 @@ describe('useSidebarShortcut', () => {
 
   describe('Ctrl modifier', () => {
     test('Ctrl+⇧B toggles', () => {
-      const props = makeProps({ modKey: 'Ctrl' })
+      const props = makeProps({ matches: matchesFor(false) })
       const target = append(document.createElement('div'))
       renderHook(() => useSidebarShortcut(props))
 
@@ -109,7 +129,7 @@ describe('useSidebarShortcut', () => {
     })
 
     test('bare Ctrl+B (no shift) does not toggle — left to the terminal', () => {
-      const props = makeProps({ modKey: 'Ctrl' })
+      const props = makeProps({ matches: matchesFor(false) })
       const target = append(document.createElement('div'))
       renderHook(() => useSidebarShortcut(props))
 
@@ -120,7 +140,7 @@ describe('useSidebarShortcut', () => {
   })
 
   test('bails when a real dialog matching DIALOG_SELECTOR is in the DOM', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     const dialog = document.createElement('div')
     dialog.setAttribute('role', 'dialog')
     dialog.setAttribute('aria-label', 'Unsaved changes')
@@ -134,7 +154,7 @@ describe('useSidebarShortcut', () => {
   })
 
   test('toggles when the compact sidebar drawer (role=dialog aria-label=Sidebar) is open', () => {
-    const props = makeProps({ modKey: 'Ctrl' })
+    const props = makeProps({ matches: matchesFor(false) })
     const sidebarDialog = document.createElement('div')
     sidebarDialog.setAttribute('role', 'dialog')
     sidebarDialog.setAttribute('aria-label', 'Sidebar')
@@ -150,7 +170,7 @@ describe('useSidebarShortcut', () => {
 
   test('meta: bails when dock is active and target is inside the dock', () => {
     const props = makeProps({
-      modKey: '⌘',
+      matches: matchesFor(true),
       activeContainerId: DOCK_CONTAINER_ID,
     })
     const target = appendContainerWithChild(DOCK_CONTAINER_ID)
@@ -163,7 +183,7 @@ describe('useSidebarShortcut', () => {
 
   test('meta: ⌘B toggles when target is inside the terminal zone', () => {
     const props = makeProps({
-      modKey: '⌘',
+      matches: matchesFor(true),
       activeContainerId: TERMINAL_CONTAINER_ID,
     })
     const target = appendContainerWithChild(TERMINAL_CONTAINER_ID, 'textarea')
@@ -175,7 +195,7 @@ describe('useSidebarShortcut', () => {
   })
 
   test('bails when the target is a plain <input> (not terminal/codemirror)', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     const target = append(document.createElement('input'))
     renderHook(() => useSidebarShortcut(props))
 
@@ -185,7 +205,7 @@ describe('useSidebarShortcut', () => {
   })
 
   test('removes the listener on unmount', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     const target = append(document.createElement('div'))
     const { unmount } = renderHook(() => useSidebarShortcut(props))
 
@@ -193,5 +213,30 @@ describe('useSidebarShortcut', () => {
     fireFrom(target, { metaKey: true })
 
     expect(props.onToggle).not.toHaveBeenCalled()
+  })
+
+  test('fires on a rebound combo supplied by the registry matcher', () => {
+    const props = makeProps({
+      matches: matchesFor(true, { 'sidebar-toggle': 'Mod+KeyK' }),
+    })
+    const target = append(document.createElement('div'))
+    renderHook(() => useSidebarShortcut(props))
+
+    fireFrom(target, { key: 'k', code: 'KeyK', metaKey: true })
+
+    expect(props.onToggle).toHaveBeenCalledOnce()
+  })
+
+  test('does not defer rebound meta combos to the dock unless the key is B', () => {
+    const props = makeProps({
+      matches: matchesFor(true, { 'sidebar-toggle': 'Mod+KeyK' }),
+      activeContainerId: DOCK_CONTAINER_ID,
+    })
+    const target = appendContainerWithChild(DOCK_CONTAINER_ID)
+    renderHook(() => useSidebarShortcut(props))
+
+    fireFrom(target, { key: 'k', code: 'KeyK', metaKey: true })
+
+    expect(props.onToggle).toHaveBeenCalledOnce()
   })
 })

--- a/src/features/workspace/hooks/useSidebarShortcut.ts
+++ b/src/features/workspace/hooks/useSidebarShortcut.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { isKeymapCaptureTarget } from '../../keymap/capture'
+import type { CommandId } from '../../keymap/catalog'
 import {
   DIALOG_SELECTOR,
   DOCK_CONTAINER_ID,
@@ -9,32 +10,33 @@ import {
 export interface UseSidebarShortcutParams {
   /** Flip the workspace-global sidebar-collapse flag. */
   onToggle: () => void
-  /** Visible modifier on this platform: '⌘' (meta) or 'Ctrl'. */
-  modKey: '⌘' | 'Ctrl'
+  /** Registry matcher — true iff the event is the resolved command chord. */
+  matches: (event: KeyboardEvent, id: CommandId) => boolean
   /** Active focus container — used to defer to the dock's ⌘B when the dock is focused. */
   activeContainerId: string
 }
 
 // Workspace-global sidebar toggle (VIM-66).
-//   - macOS (modKey '⌘'): ⌘B — ⌘ chords never reach the PTY, so this is safe
+//   - macOS default: ⌘B — ⌘ chords never reach the PTY, so this is safe
 //     even with the terminal focused, matching the VS Code binding.
-//   - Linux/Windows (modKey 'Ctrl'): Ctrl+⇧B — bare Ctrl+B is reserved by the
-//     terminal (tmux prefix / readline backward-char), so we require Shift.
+//   - Linux/Windows default: Ctrl+⇧B — bare Ctrl+B is reserved by the terminal
+//     (tmux prefix / readline backward-char), so we require Shift.
 // Coexists with useDockShortcuts' ⌘B (which closes the dock only when the dock
 // is focused): on macOS we bail when the dock owns focus so the dock keeps ⌘B;
 // elsewhere ⌘B/Ctrl+⇧B toggles the sidebar. The keystroke is allowed through
-// from the terminal and the editor, but not from plain text inputs.
+// from the terminal and the editor, but not from plain text inputs. The key
+// match comes from the keybinding registry so persisted overrides take effect.
 export const useSidebarShortcut = ({
   onToggle,
-  modKey,
+  matches,
   activeContainerId,
 }: UseSidebarShortcutParams): void => {
   const onToggleRef = useRef(onToggle)
-  const modKeyRef = useRef(modKey)
+  const matchesRef = useRef(matches)
   const activeContainerIdRef = useRef(activeContainerId)
 
   onToggleRef.current = onToggle
-  modKeyRef.current = modKey
+  matchesRef.current = matches
   activeContainerIdRef.current = activeContainerId
 
   useEffect(() => {
@@ -43,21 +45,7 @@ export const useSidebarShortcut = ({
         return
       }
 
-      if (event.key.toLowerCase() !== 'b' || event.altKey) {
-        return
-      }
-
-      const isMeta = modKeyRef.current === '⌘'
-
-      const expectedModifier = isMeta
-        ? event.metaKey && !event.ctrlKey
-        : event.ctrlKey && !event.metaKey
-      if (!expectedModifier) {
-        return
-      }
-
-      // macOS: ⌘B (no Shift). Ctrl platforms: Ctrl+⇧B (Shift required).
-      if (isMeta ? event.shiftKey : !event.shiftKey) {
+      if (!matchesRef.current(event, 'sidebar-toggle')) {
         return
       }
 
@@ -82,7 +70,9 @@ export const useSidebarShortcut = ({
 
       // On macOS, defer to the dock's ⌘B (close dock) when the dock is focused.
       if (
-        isMeta &&
+        event.key.toLowerCase() === 'b' &&
+        event.metaKey &&
+        !event.ctrlKey &&
         activeContainerIdRef.current === DOCK_CONTAINER_ID &&
         target.closest(`[data-container-id="${DOCK_CONTAINER_ID}"]`)
       ) {

--- a/src/features/workspace/hooks/useSidebarTabShortcut.test.ts
+++ b/src/features/workspace/hooks/useSidebarTabShortcut.test.ts
@@ -1,5 +1,8 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { getCommand, type CommandId } from '../../keymap/catalog'
+import { eventMatchesChord, type PlatformSuper } from '../../keymap/match'
+import { resolveBindings, type CustomKeybindings } from '../../keymap/resolve'
 import {
   useSidebarTabShortcut,
   type UseSidebarTabShortcutParams,
@@ -39,12 +42,28 @@ const fireKey = (
   return event.defaultPrevented
 }
 
+const matchesFor = (
+  isMac: boolean,
+  overrides: CustomKeybindings = {}
+): UseSidebarTabShortcutParams['matches'] => {
+  const superKey: PlatformSuper = isMac ? 'meta' : 'ctrl'
+  const resolved = resolveBindings(overrides, isMac, superKey)
+
+  return (event: KeyboardEvent, id: CommandId): boolean =>
+    eventMatchesChord(
+      event,
+      resolved.get(id)!,
+      superKey,
+      getCommand(id).matchPolicy
+    )
+}
+
 const makeProps = (
   overrides: Partial<UseSidebarTabShortcutParams> = {}
 ): UseSidebarTabShortcutParams => ({
   onShowSessions: vi.fn(),
   onShowFiles: vi.fn(),
-  modKey: '⌘',
+  matches: matchesFor(true),
   ...overrides,
 })
 
@@ -59,7 +78,7 @@ describe('useSidebarTabShortcut', () => {
   })
 
   test('⌘⇧S shows Sessions on macOS', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     const prevented = fireKey('S', { metaKey: true, shiftKey: true })
@@ -70,7 +89,7 @@ describe('useSidebarTabShortcut', () => {
   })
 
   test('⌘⇧F shows Files on macOS', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     const prevented = fireKey('F', { metaKey: true, shiftKey: true })
@@ -81,7 +100,7 @@ describe('useSidebarTabShortcut', () => {
   })
 
   test('Ctrl+⇧S / Ctrl+⇧F switch on Linux', () => {
-    const props = makeProps({ modKey: 'Ctrl' })
+    const props = makeProps({ matches: matchesFor(false) })
     renderHook(() => useSidebarTabShortcut(props))
 
     fireKey('S', { ctrlKey: true, shiftKey: true })
@@ -92,7 +111,7 @@ describe('useSidebarTabShortcut', () => {
   })
 
   test('requires Shift — bare ⌘S falls through to save', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     const prevented = fireKey('s', { metaKey: true })
@@ -103,7 +122,7 @@ describe('useSidebarTabShortcut', () => {
 
   test('ignores the opposite modifier so it reaches the terminal', () => {
     // On macOS we only claim ⌘⇧S/F; Ctrl+⇧S must pass through to the PTY.
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     const prevented = fireKey('S', { ctrlKey: true, shiftKey: true })
@@ -113,7 +132,7 @@ describe('useSidebarTabShortcut', () => {
   })
 
   test('ignores other letters', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     fireKey('A', { metaKey: true, shiftKey: true })
@@ -125,7 +144,7 @@ describe('useSidebarTabShortcut', () => {
   test('matches physical S/F keys even when event.key is non-Latin', () => {
     // Cyrillic: the physical S key produces 'ы' in the active IME, but
     // event.code still identifies it as KeyS.
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     const prevented = fireKey('ы', {
@@ -143,7 +162,7 @@ describe('useSidebarTabShortcut', () => {
     dialog.setAttribute('role', 'dialog')
     append(dialog)
 
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     const prevented = fireKey('S', { metaKey: true, shiftKey: true })
@@ -155,7 +174,7 @@ describe('useSidebarTabShortcut', () => {
   test('defers to a plain text input (e.g. session rename field)', () => {
     const input = append(document.createElement('input'))
 
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     const prevented = fireKey('S', { metaKey: true, shiftKey: true }, input)
@@ -170,7 +189,7 @@ describe('useSidebarTabShortcut', () => {
     const textarea = document.createElement('textarea')
     zone.appendChild(textarea)
 
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     fireKey('F', { metaKey: true, shiftKey: true }, textarea)
@@ -184,7 +203,7 @@ describe('useSidebarTabShortcut', () => {
     sidebarDialog.setAttribute('aria-label', 'Sidebar')
     append(sidebarDialog)
 
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     // Focus is still on document.body (the opener/terminal did not move it).
@@ -203,7 +222,7 @@ describe('useSidebarTabShortcut', () => {
     otherDialog.setAttribute('role', 'dialog')
     append(otherDialog)
 
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     renderHook(() => useSidebarTabShortcut(props))
 
     const prevented = fireKey('F', { metaKey: true, shiftKey: true })
@@ -212,8 +231,24 @@ describe('useSidebarTabShortcut', () => {
     expect(prevented).toBe(false)
   })
 
+  test('fires on rebound combos supplied by the registry matcher', () => {
+    const props = makeProps({
+      matches: matchesFor(true, {
+        'sidebar-sessions': 'Mod+KeyJ',
+        'sidebar-files': 'Mod+KeyK',
+      }),
+    })
+    renderHook(() => useSidebarTabShortcut(props))
+
+    fireKey('j', { code: 'KeyJ', metaKey: true })
+    fireKey('k', { code: 'KeyK', metaKey: true })
+
+    expect(props.onShowSessions).toHaveBeenCalledOnce()
+    expect(props.onShowFiles).toHaveBeenCalledOnce()
+  })
+
   test('detaches its listener on unmount', () => {
-    const props = makeProps({ modKey: '⌘' })
+    const props = makeProps({ matches: matchesFor(true) })
     const { unmount } = renderHook(() => useSidebarTabShortcut(props))
 
     unmount()

--- a/src/features/workspace/hooks/useSidebarTabShortcut.ts
+++ b/src/features/workspace/hooks/useSidebarTabShortcut.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { isKeymapCaptureTarget } from '../../keymap/capture'
+import type { CommandId } from '../../keymap/catalog'
 import { DIALOG_SELECTOR, TERMINAL_CONTAINER_ID } from '../containerIds'
 
 export interface UseSidebarTabShortcutParams {
@@ -7,13 +8,13 @@ export interface UseSidebarTabShortcutParams {
   onShowSessions: () => void
   /** Reveal the sidebar (if collapsed) and show the Files view. */
   onShowFiles: () => void
-  /** Visible modifier on this platform: '⌘' (meta) or 'Ctrl'. */
-  modKey: '⌘' | 'Ctrl'
+  /** Registry matcher — true iff the event is the resolved command chord. */
+  matches: (event: KeyboardEvent, id: CommandId) => boolean
 }
 
 // Left-sidebar view switch (Sessions <-> Files):
-//   - macOS (modKey '⌘'): ⌘⇧S (Sessions) / ⌘⇧F (Files).
-//   - Linux/Windows (modKey 'Ctrl'): Ctrl+⇧S / Ctrl+⇧F.
+//   - macOS default: ⌘⇧S (Sessions) / ⌘⇧F (Files).
+//   - Linux/Windows default: Ctrl+⇧S / Ctrl+⇧F.
 // Shift is required on BOTH platforms because the bare chords are taken: ⌘S /
 // Ctrl+S is "save". The switch therefore sits one Shift away, beside the
 // sidebar-toggle (⌘B) and new-session (⌘N / Ctrl+⇧N) controls. ⌘ chords never
@@ -21,18 +22,20 @@ export interface UseSidebarTabShortcutParams {
 // app-shortcut convention here (copy = Ctrl+Shift+C, sidebar = Ctrl+Shift+B).
 // Allowed from the terminal and the editor (switch-from-anywhere) but not from
 // plain text inputs (e.g. the session rename field) or while a modal is open.
+// The key match comes from the keybinding registry so persisted overrides take
+// effect.
 export const useSidebarTabShortcut = ({
   onShowSessions,
   onShowFiles,
-  modKey,
+  matches,
 }: UseSidebarTabShortcutParams): void => {
   const onShowSessionsRef = useRef(onShowSessions)
   const onShowFilesRef = useRef(onShowFiles)
-  const modKeyRef = useRef(modKey)
+  const matchesRef = useRef(matches)
 
   onShowSessionsRef.current = onShowSessions
   onShowFilesRef.current = onShowFiles
-  modKeyRef.current = modKey
+  matchesRef.current = matches
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -40,27 +43,17 @@ export const useSidebarTabShortcut = ({
         return
       }
 
-      // Shift is mandatory (bare ⌘S/Ctrl+S = save); reject Alt-modified chords.
-      if (event.repeat || event.altKey || !event.shiftKey) {
+      if (event.repeat) {
         return
       }
 
-      // Match the physical S/F keys (event.code) so the binding survives Shift
-      // and non-Latin IME layouts (Cyrillic, Arabic, Hebrew, CJK).
-      if (event.code !== 'KeyS' && event.code !== 'KeyF') {
-        return
-      }
+      const commandId = matchesRef.current(event, 'sidebar-sessions')
+        ? 'sidebar-sessions'
+        : matchesRef.current(event, 'sidebar-files')
+          ? 'sidebar-files'
+          : null
 
-      const key = event.code === 'KeyS' ? 's' : 'f'
-
-      // Match only this platform's modifier; reject the opposite so the other
-      // chord still reaches the terminal.
-      const isMeta = modKeyRef.current === '⌘'
-
-      const expectedModifier = isMeta
-        ? event.metaKey && !event.ctrlKey
-        : event.ctrlKey && !event.metaKey
-      if (!expectedModifier) {
+      if (commandId === null) {
         return
       }
 
@@ -104,7 +97,7 @@ export const useSidebarTabShortcut = ({
       event.preventDefault()
       event.stopPropagation()
 
-      if (key === 's') {
+      if (commandId === 'sidebar-sessions') {
         onShowSessionsRef.current()
       } else {
         onShowFilesRef.current()


### PR DESCRIPTION
## Summary
- Migrate the remaining workspace shortcut hooks to the keybinding registry matcher: new session, session navigation, sidebar toggle/tabs, dock focus, and burner toggle.
- Mark the corresponding catalog rows rebindable while keeping terminal-owned rows and the command-palette leader display-only for later scope.
- Add default-preservation and rebound-chord regression coverage, including the dock-focused sidebar rebind edge.

## Stack
- Targets `feat/settings` after PR #507.
- Part of VIM-136 PR2; command-palette leader remains SP3.

## Test plan
- `npm run test -- src/features/keymap src/features/workspace/hooks/useNewSessionShortcut.test.ts src/features/workspace/hooks/useSidebarShortcut.test.ts src/features/workspace/hooks/useSidebarTabShortcut.test.ts src/features/workspace/hooks/useSessionNavShortcut.test.ts src/features/workspace/hooks/useDockShortcuts.test.ts src/features/workspace/hooks/useBurnerToggleShortcut.test.ts src/features/workspace/hooks/useDockToggleShortcut.test.ts src/features/settings/components/panes/KeymapPane.test.tsx src/features/workspace/WorkspaceView.test.tsx src/features/workspace/WorkspaceView.command-palette.test.tsx src/features/workspace/WorkspaceView.integration.test.tsx`
- `npm run lint`
- `npm run type-check:generated`
- `npx prettier --check src/features/keymap/catalog.ts src/features/keymap/catalog.test.ts src/features/keymap/resolve.test.ts src/features/workspace/WorkspaceView.tsx src/features/workspace/WorkspaceView.test.tsx src/features/workspace/hooks/useBurnerToggleShortcut.ts src/features/workspace/hooks/useBurnerToggleShortcut.test.ts src/features/workspace/hooks/useDockShortcuts.ts src/features/workspace/hooks/useDockShortcuts.test.ts src/features/workspace/hooks/useNewSessionShortcut.ts src/features/workspace/hooks/useNewSessionShortcut.test.ts src/features/workspace/hooks/useSessionNavShortcut.ts src/features/workspace/hooks/useSessionNavShortcut.test.ts src/features/workspace/hooks/useSidebarShortcut.ts src/features/workspace/hooks/useSidebarShortcut.test.ts src/features/workspace/hooks/useSidebarTabShortcut.ts src/features/workspace/hooks/useSidebarTabShortcut.test.ts`
- `git diff --check`