### PR TITLE
feat(keymap): migrate command palette leader binding (VIM-136 PR3)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -84,7 +84,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 12       | 6    | 2026-06-13   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 9        | 2    | 2026-06-15   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                     | correctness        | 1        | 0    | 2026-06-11   |
-| [IPC Trust Boundary](patterns/ipc-trust-boundary.md)                                                 | security           | 1        | 0    | 2026-06-12   |
+| [IPC Trust Boundary](patterns/ipc-trust-boundary.md)                                                 | security           | 2        | 1    | 2026-06-18   |
 | [Synchronous Calls in Async Electron Handlers](patterns/sync-calls-in-async-electron-handlers.md)    | code-quality       | 1        | 0    | 2026-06-12   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 2        | 1    | 2026-06-15   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                                                              | Category           | Findings | Refs | Last Updated |
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 23       | 4    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 37       | 16   | 2026-06-12   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 38       | 16   | 2026-06-18   |
 | [React Key Stability](patterns/react-key-stability.md)                                               | react-patterns     | 2        | 0    | 2026-06-11   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |
@@ -95,3 +95,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 1        | 0    | 2026-06-13   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
 | [Modulo Correctness](patterns/modulo-correctness.md)                                                 | correctness        | 1        | 0    | 2026-06-15   |
+| [Catalog Identifier Safety](patterns/catalog-identifier-safety.md)                                   | correctness        | 1        | 0    | 2026-06-18   |

--- a/docs/reviews/patterns/catalog-identifier-safety.md
+++ b/docs/reviews/patterns/catalog-identifier-safety.md
@@ -1,0 +1,24 @@
+---
+id: catalog-identifier-safety
+category: correctness
+created: 2026-06-18
+last_updated: 2026-06-18
+ref_count: 0
+---
+
+# Catalog Identifier Safety
+
+## Summary
+
+When a central catalog defines identifiers that other parts of the codebase reference by string, a typo in one of those references can compile successfully and only surface as silent runtime misbehavior. Derive a strict, closed union type from the catalog itself, then use that union for cross-references and relationship fields so the type checker rejects invalid identifiers before the change ships.
+
+## Findings
+
+### 1. intentionalShadowWith is stringly typed instead of constrained to catalog command IDs
+
+- **Source:** local-codex | PR #523 round 2 | 2026-06-18
+- **Severity:** MEDIUM / adjudication
+- **File:** `src/features/keymap/catalog.ts` L21
+- **Finding:** The new intentionalShadowWith field controls whether the conflict detector suppresses the deliberately shared palette/palette-leader binding, but it is declared as readonly string[]. A typo in a future catalog entry would compile and then make intentionallyShadowed return false, producing a spurious keymap conflict for a relationship the catalog intended to allow.
+- **Fix:** Derived CommandId from a literal CATALOG_LITERAL array before declaring CommandDescriptor, then changed intentionalShadowWith to readonly CommandId[] so future shadow pairs are type-checked against the actual command ids.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/ipc-trust-boundary.md
+++ b/docs/reviews/patterns/ipc-trust-boundary.md
@@ -2,8 +2,8 @@
 id: ipc-trust-boundary
 category: security
 created: 2026-06-12
-last_updated: 2026-06-12
-ref_count: 0
+last_updated: 2026-06-18
+ref_count: 1
 ---
 
 # IPC Trust Boundary
@@ -21,4 +21,13 @@ The Electron main process must treat every renderer IPC payload as untrusted inp
 - **File:** `electron/main.ts` L489-494
 - **Finding:** The `SETTINGS_SYNC_SNAPSHOT` handler accepted the renderer's payload typed as `AppSettings` and assigned it directly to a main-process variable. Because TypeScript types do not exist at runtime, any renderer-sent object would be stored as the authoritative settings snapshot, creating a trust-boundary violation and future-change risk if other main-process code reused the value.
 - **Fix:** Changed the handler parameter to `unknown`, validated that the payload is a record and that `onLastWindowClosed` is a string, and stored only that validated string in a renamed `lastKnownOnLastWindowClosed` variable. The `window-all-closed` handler now reads the narrow string value instead of the full settings object.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 2. COMMAND_PALETTE_BINDING IPC handler accepts unbounded string payloads
+
+- **Source:** github-claude | PR #523 round 1 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `electron/main.ts` L491-513
+- **Finding:** The `COMMAND_PALETTE_BINDING` handler accepted either a string binding or an object with `palette`/`leader` string fields and forwarded them to the shortcut setters without a length cap. Renderer-controlled IPC payloads should be bounded even after primitive type checks, because a compromised or buggy renderer could force the main process to parse and allocate very large strings.
+- **Fix:** Added a `COMMAND_PALETTE_BINDING_MAX_LENGTH = 64` constant and guarded both the singular string binding and the two split binding fields before calling `setCommandPaletteShortcutBinding` / `setCommandPaletteShortcutBindings`.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,7 +2,7 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-12
+last_updated: 2026-06-18
 ref_count: 16
 ---
 
@@ -347,3 +347,12 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** The `update()` callback computed the merged settings and called `bridge.save(merged)` from inside the functional `setSettings` updater. React Strict Mode double-invokes updaters in development, so every user-triggered settings change would emit two `save_app_settings` IPC requests and break the `toHaveBeenCalledTimes(1)` test assertion under StrictMode.
 - **Fix:** Moved the merged-state computation and persistence out of the updater. A `settingsRef` tracks the latest state, `update()` computes `next` synchronously, calls `setSettings(next)` with a pure value setter, then enqueues `bridge.save(next)` through an async queue so saves remain ordered and the updater stays pure.
 - **Commit:** same commit as this entry
+
+### 35. useEffect syncs to Electron on every keybinding change, not just palette changes
+
+- **Source:** github-claude | PR #523 round 2 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.tsx` L1454-1468
+- **Finding:** `useEffect([paletteBinding, paletteLeaderBinding])` uses Chord object references as deps. `resolveBindings` (called inside `useMemo`) builds a new `Map` with freshly-constructed Chord instances on every invocation. Because `overrides` (the full `customKeybindings` record) is the memoization key, any
+- **Fix:** Hoisted `formatChord(paletteBinding)` and `formatChord(paletteLeaderBinding)` above the effect and used the resulting string tokens as dependencies, so the effect only re-runs when the actual binding values change.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/electron/browser-pane.ts
+++ b/electron/browser-pane.ts
@@ -40,8 +40,10 @@ import {
   BROWSER_PANE_URL_CHANGED,
 } from './browser-pane-channels'
 import {
+  commandPaletteShortcutBindingsConfigForWindow,
+  commandPaletteShortcutSourceForInput,
   commandPaletteToggleDispatcherForWindow,
-  isCommandPaletteShortcutInput,
+  type CommandPaletteShortcutSource,
 } from './command-palette-shortcut'
 import type {
   PersistedTab,
@@ -1822,14 +1824,16 @@ export class BrowserPaneController {
     record: BrowserPaneRecord,
     webContents: WebContents = record.view.webContents
   ): void {
-    const dispatchCommandPaletteToggle = (): void => {
+    const dispatchCommandPaletteToggle = (
+      source: CommandPaletteShortcutSource
+    ): void => {
       const win = BrowserWindow.fromId(record.windowId)
       if (!win || win.isDestroyed()) {
         return
       }
 
       win.webContents.focus()
-      commandPaletteToggleDispatcherForWindow(win)()
+      commandPaletteToggleDispatcherForWindow(win)(source)
     }
 
     webContents.on('before-input-event', (event, input) => {
@@ -1847,9 +1851,19 @@ export class BrowserPaneController {
         return
       }
 
-      if (isCommandPaletteShortcutInput(input)) {
+      const win = BrowserWindow.fromId(record.windowId)
+
+      const source =
+        win && !win.isDestroyed()
+          ? commandPaletteShortcutSourceForInput(
+              input,
+              commandPaletteShortcutBindingsConfigForWindow(win)
+            )
+          : null
+
+      if (source !== null) {
         event.preventDefault()
-        dispatchCommandPaletteToggle()
+        dispatchCommandPaletteToggle(source)
 
         return
       }

--- a/electron/command-palette-shortcut.test.ts
+++ b/electron/command-palette-shortcut.test.ts
@@ -2,10 +2,15 @@ import { describe, expect, test, vi } from 'vitest'
 import { COMMAND_PALETTE_TOGGLE } from './ipc-channels'
 import {
   COMMAND_PALETTE_GLOBAL_ACCELERATORS,
+  commandPaletteShortcutBindingsConfigForPlatform,
+  commandPaletteShortcutConfigForWindow,
   commandPaletteShortcutConfigForPlatform,
+  commandPaletteShortcutSourceForInput,
   type CommandPaletteShortcutOverrideOptions,
   installCommandPaletteShortcutOverride,
   isCommandPaletteShortcutInput,
+  setCommandPaletteShortcutBinding,
+  setCommandPaletteShortcutBindings,
   setKeymapCaptureActive,
 } from './command-palette-shortcut'
 
@@ -116,6 +121,108 @@ describe('command palette shortcut override', () => {
     )
   })
 
+  test('builds platform accelerators from a resolved keybinding token', () => {
+    expect(
+      commandPaletteShortcutConfigForPlatform('linux', 'Mod+KeyK')
+    ).toMatchObject({
+      modifier: 'control',
+      code: 'KeyK',
+      key: 'K',
+      alt: false,
+      shift: false,
+      globalAccelerators: ['Control+K'],
+    })
+
+    expect(
+      commandPaletteShortcutConfigForPlatform('darwin', 'Mod+Shift+KeyK')
+    ).toMatchObject({
+      modifier: 'command',
+      code: 'KeyK',
+      key: 'K',
+      alt: false,
+      shift: true,
+      globalAccelerators: ['Command+Shift+K'],
+    })
+
+    expect(
+      commandPaletteShortcutConfigForPlatform('darwin', 'Ctrl+Backquote')
+    ).toMatchObject({
+      modifier: 'control',
+      code: 'Backquote',
+      key: '`',
+      globalAccelerators: ['Control+`'],
+    })
+
+    expect(
+      commandPaletteShortcutConfigForPlatform('linux', 'Mod+Slash')
+    ).toMatchObject({
+      modifier: 'control',
+      code: 'Slash',
+      key: '/',
+      globalAccelerators: ['Control+/'],
+    })
+  })
+
+  test('falls back to the default shortcut when the binding token is invalid', () => {
+    expect(
+      commandPaletteShortcutConfigForPlatform('linux', 'Mod+Ctrl+KeyK')
+    ).toMatchObject({
+      modifier: 'control',
+      code: 'Semicolon',
+      key: ';',
+      globalAccelerators: ['Control+;'],
+    })
+  })
+
+  test('prioritizes the leader source when default palette bindings overlap', () => {
+    expect(
+      commandPaletteShortcutBindingsConfigForPlatform('linux')
+    ).toMatchObject({
+      palette: { code: 'Semicolon', globalAccelerators: ['Control+;'] },
+      leader: { code: 'Semicolon', globalAccelerators: ['Control+;'] },
+    })
+
+    expect(COMMAND_PALETTE_GLOBAL_ACCELERATORS).toEqual(['Control+;'])
+
+    expect(
+      commandPaletteShortcutSourceForInput(
+        {
+          type: 'keyDown',
+          key: ';',
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        commandPaletteShortcutBindingsConfigForPlatform('linux')
+      )
+    ).toBe('leader')
+  })
+
+  test('keeps a physical code binding even without an Electron accelerator spelling', () => {
+    expect(
+      commandPaletteShortcutConfigForPlatform('linux', 'Mod+NumpadEnter')
+    ).toMatchObject({
+      modifier: 'control',
+      code: 'NumpadEnter',
+      key: 'NumpadEnter',
+      globalAccelerators: [],
+    })
+
+    expect(
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: 'Enter',
+          code: 'NumpadEnter',
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        commandPaletteShortcutConfigForPlatform('linux', 'Mod+NumpadEnter')
+      )
+    ).toBe(true)
+  })
+
   test('matches Ctrl+; keydown on Linux without meta or alt modifiers', () => {
     expect(
       isCommandPaletteShortcutInput(
@@ -129,6 +236,36 @@ describe('command palette shortcut override', () => {
         commandPaletteShortcutConfigForPlatform('linux')
       )
     ).toBe(true)
+  })
+
+  test('matches rebound shortcuts by physical code when Electron supplies it', () => {
+    expect(
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: 'л',
+          code: 'KeyK',
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        commandPaletteShortcutConfigForPlatform('linux', 'Mod+KeyK')
+      )
+    ).toBe(true)
+
+    expect(
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: ';',
+          code: 'Semicolon',
+          control: true,
+          meta: false,
+          alt: false,
+        },
+        commandPaletteShortcutConfigForPlatform('linux', 'Mod+KeyK')
+      )
+    ).toBe(false)
   })
 
   test('ignores Ctrl+Shift+; keydown on Linux', () => {
@@ -267,7 +404,7 @@ describe('command palette shortcut override', () => {
     )
 
     expect(preventDefault).toHaveBeenCalledOnce()
-    expect(send).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE)
+    expect(send).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE, 'leader')
   })
 
   test('prevents renderer Cmd+; keydown and sends palette toggle IPC on macOS', () => {
@@ -294,7 +431,7 @@ describe('command palette shortcut override', () => {
     )
 
     expect(preventDefault).toHaveBeenCalledOnce()
-    expect(send).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE)
+    expect(send).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE, 'leader')
   })
 
   test('does not prevent renderer Cmd+Shift+; keydown on macOS', () => {
@@ -377,7 +514,72 @@ describe('command palette shortcut override', () => {
 
     callbacks.get('Control+;')?.()
 
-    expect(send).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE)
+    expect(send).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE, 'leader')
+  })
+
+  test('syncing a new binding re-registers the focused Linux global override', () => {
+    const { callbacks, registry } = createShortcutRegistry()
+    const { send, win, windowHandlers } = createFakeWindow()
+
+    installCommandPaletteShortcutOverride(win, {
+      platform: 'linux',
+      shortcutRegistry: registry,
+    })
+
+    emitWindowEvent(windowHandlers, 'focus')
+    expect([...callbacks.keys()]).toEqual(['Control+;'])
+
+    setCommandPaletteShortcutBinding(win, 'Mod+KeyK')
+
+    expect(registry.unregister).toHaveBeenCalledWith('Control+;')
+    expect([...callbacks.keys()]).toEqual(['Control+K'])
+    expect(commandPaletteShortcutConfigForWindow(win).code).toBe('KeyK')
+
+    callbacks.get('Control+;')?.()
+    expect(send).not.toHaveBeenCalled()
+
+    callbacks.get('Control+K')?.()
+    expect(send).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE, 'leader')
+  })
+
+  test('syncing split bindings registers direct palette and leader accelerators', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const { callbacks, registry } = createShortcutRegistry()
+    const { send, win, windowHandlers } = createFakeWindow()
+
+    try {
+      installCommandPaletteShortcutOverride(win, {
+        platform: 'linux',
+        shortcutRegistry: registry,
+      })
+
+      emitWindowEvent(windowHandlers, 'focus')
+      setCommandPaletteShortcutBindings(win, {
+        palette: 'Mod+KeyP',
+        leader: 'Mod+KeyK',
+      })
+
+      expect(registry.unregister).toHaveBeenCalledWith('Control+;')
+      expect([...callbacks.keys()]).toEqual(['Control+K', 'Control+P'])
+      expect(commandPaletteShortcutConfigForWindow(win, 'leader').code).toBe(
+        'KeyK'
+      )
+
+      expect(commandPaletteShortcutConfigForWindow(win, 'palette').code).toBe(
+        'KeyP'
+      )
+
+      callbacks.get('Control+K')?.()
+      expect(send).toHaveBeenLastCalledWith(COMMAND_PALETTE_TOGGLE, 'leader')
+
+      vi.setSystemTime(1_200)
+
+      callbacks.get('Control+P')?.()
+      expect(send).toHaveBeenLastCalledWith(COMMAND_PALETTE_TOGGLE, 'palette')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('deduplicates a global shortcut and renderer keydown for one press', () => {

--- a/electron/command-palette-shortcut.ts
+++ b/electron/command-palette-shortcut.ts
@@ -1,9 +1,11 @@
+// cspell:ignore Capslock Numlock Scrolllock numdec numadd numsub nummult numdiv
 import { globalShortcut, type BrowserWindow } from 'electron'
 import { COMMAND_PALETTE_TOGGLE } from './ipc-channels'
 
 interface ShortcutInput {
   type: string
   key: string
+  code?: string
   control: boolean
   meta: boolean
   alt: boolean
@@ -23,24 +25,249 @@ export interface CommandPaletteShortcutOverrideOptions {
 
 type CommandPaletteShortcutModifier = 'control' | 'command'
 
+export type CommandPaletteShortcutSource = 'palette' | 'leader'
+
+export interface CommandPaletteShortcutBindings {
+  palette: string
+  leader: string
+}
+
 export interface CommandPaletteShortcutConfig {
   modifier: CommandPaletteShortcutModifier
+  code: string
+  key: string
+  alt: boolean
+  shift: boolean
   globalAccelerators: readonly string[]
 }
 
-const CONTROL_ACCELERATORS = ['Control+;'] as const
+export interface CommandPaletteShortcutBindingsConfig {
+  palette: CommandPaletteShortcutConfig
+  leader: CommandPaletteShortcutConfig
+}
 
-const COMMAND_ACCELERATORS = ['Command+;'] as const
+interface CommandPaletteShortcutController {
+  setBinding: (binding: string) => void
+  setBindings: (bindings: CommandPaletteShortcutBindings) => void
+  config: () => CommandPaletteShortcutBindingsConfig
+}
+
+type KeybindingMod = 'Mod' | 'Ctrl' | 'Alt' | 'Shift'
+
+const KEYBINDING_MODS: ReadonlySet<string> = new Set([
+  'Mod',
+  'Ctrl',
+  'Alt',
+  'Shift',
+])
+
+const DEFAULT_COMMAND_PALETTE_CODE = 'Semicolon'
+
+const CODE_TO_ACCELERATOR_KEY: ReadonlyMap<string, string> = new Map([
+  ['Backslash', '\\'],
+  ['Semicolon', ';'],
+  ['Backquote', '`'],
+  ['Minus', '-'],
+  ['Equal', '='],
+  ['BracketLeft', '['],
+  ['BracketRight', ']'],
+  ['Quote', "'"],
+  ['Comma', ','],
+  ['Period', '.'],
+  ['Slash', '/'],
+  ['ArrowLeft', 'Left'],
+  ['ArrowRight', 'Right'],
+  ['ArrowUp', 'Up'],
+  ['ArrowDown', 'Down'],
+  ['Enter', 'Enter'],
+  ['Escape', 'Escape'],
+  ['Tab', 'Tab'],
+  ['Space', 'Space'],
+  ['Backspace', 'Backspace'],
+  ['Delete', 'Delete'],
+  ['Insert', 'Insert'],
+  ['Home', 'Home'],
+  ['End', 'End'],
+  ['PageUp', 'PageUp'],
+  ['PageDown', 'PageDown'],
+  ['CapsLock', 'Capslock'],
+  ['NumLock', 'Numlock'],
+  ['ScrollLock', 'Scrolllock'],
+  ['PrintScreen', 'PrintScreen'],
+  ['VolumeUp', 'VolumeUp'],
+  ['VolumeDown', 'VolumeDown'],
+  ['VolumeMute', 'VolumeMute'],
+  ['MediaTrackNext', 'MediaNextTrack'],
+  ['MediaTrackPrevious', 'MediaPreviousTrack'],
+  ['MediaStop', 'MediaStop'],
+  ['MediaPlayPause', 'MediaPlayPause'],
+  ['NumpadDecimal', 'numdec'],
+  ['NumpadAdd', 'numadd'],
+  ['NumpadSubtract', 'numsub'],
+  ['NumpadMultiply', 'nummult'],
+  ['NumpadDivide', 'numdiv'],
+])
+
+const codeToAcceleratorKey = (code: string): string | null => {
+  const mapped = CODE_TO_ACCELERATOR_KEY.get(code)
+  if (mapped !== undefined) {
+    return mapped
+  }
+
+  const digit = /^Digit(\d)$/.exec(code)
+  if (digit !== null) {
+    return digit[1]
+  }
+
+  const letter = /^Key([A-Z])$/.exec(code)
+  if (letter !== null) {
+    return letter[1]
+  }
+
+  const functionKey = /^F([1-9]|1\d|2[0-4])$/.exec(code)
+  if (functionKey !== null) {
+    return code
+  }
+
+  const numpadDigit = /^Numpad(\d)$/.exec(code)
+  if (numpadDigit !== null) {
+    return `num${numpadDigit[1]}`
+  }
+
+  return null
+}
+
+const codeToInputFallbackKey = (code: string): string =>
+  codeToAcceleratorKey(code) ?? code
+
+const parseKeybindingToken = (
+  binding: string
+): { code: string; mods: ReadonlySet<KeybindingMod> } | null => {
+  const parts = binding.split('+')
+  const code = parts.pop()
+
+  if (code === undefined || code.length === 0) {
+    return null
+  }
+
+  const mods = new Set<KeybindingMod>()
+  for (const part of parts) {
+    if (!KEYBINDING_MODS.has(part) || mods.has(part as KeybindingMod)) {
+      return null
+    }
+
+    mods.add(part as KeybindingMod)
+  }
+
+  if (mods.has('Mod') === mods.has('Ctrl')) {
+    return null
+  }
+
+  return { code, mods }
+}
+
+const acceleratorForConfig = (
+  config: Omit<CommandPaletteShortcutConfig, 'globalAccelerators'>
+): string | null => {
+  const key = codeToAcceleratorKey(config.code)
+  if (key === null) {
+    return null
+  }
+
+  const parts = [
+    config.modifier === 'command' ? 'Command' : 'Control',
+    config.alt ? 'Alt' : null,
+    config.shift ? 'Shift' : null,
+    key,
+  ].filter((part): part is string => part !== null)
+
+  return parts.join('+')
+}
+
+const buildShortcutConfig = (
+  platform: NodeJS.Platform,
+  code: string,
+  mods: ReadonlySet<KeybindingMod>
+): CommandPaletteShortcutConfig => {
+  const configWithoutAccelerators = {
+    modifier: mods.has('Ctrl')
+      ? 'control'
+      : platform === 'darwin'
+        ? 'command'
+        : 'control',
+    code,
+    key: codeToInputFallbackKey(code),
+    alt: mods.has('Alt'),
+    shift: mods.has('Shift'),
+  } satisfies Omit<CommandPaletteShortcutConfig, 'globalAccelerators'>
+
+  const accelerator = acceleratorForConfig(configWithoutAccelerators)
+
+  return {
+    ...configWithoutAccelerators,
+    globalAccelerators: accelerator === null ? [] : [accelerator],
+  }
+}
 
 export const commandPaletteShortcutConfigForPlatform = (
-  platform: NodeJS.Platform
-): CommandPaletteShortcutConfig =>
-  platform === 'darwin'
-    ? { modifier: 'command', globalAccelerators: COMMAND_ACCELERATORS }
-    : { modifier: 'control', globalAccelerators: CONTROL_ACCELERATORS }
+  platform: NodeJS.Platform,
+  binding = 'Mod+Semicolon'
+): CommandPaletteShortcutConfig => {
+  const parsed = parseKeybindingToken(binding)
 
-export const COMMAND_PALETTE_GLOBAL_ACCELERATORS =
-  commandPaletteShortcutConfigForPlatform('linux').globalAccelerators
+  if (parsed !== null) {
+    const custom = buildShortcutConfig(platform, parsed.code, parsed.mods)
+
+    return custom
+  }
+
+  return buildShortcutConfig(
+    platform,
+    DEFAULT_COMMAND_PALETTE_CODE,
+    new Set(['Mod'])
+  )
+}
+
+export const commandPaletteShortcutBindingsConfigForPlatform = (
+  platform: NodeJS.Platform,
+  bindings: CommandPaletteShortcutBindings = {
+    palette: 'Mod+Semicolon',
+    leader: 'Mod+Semicolon',
+  }
+): CommandPaletteShortcutBindingsConfig => ({
+  palette: commandPaletteShortcutConfigForPlatform(platform, bindings.palette),
+  leader: commandPaletteShortcutConfigForPlatform(platform, bindings.leader),
+})
+
+const acceleratorEntriesForConfig = (
+  config: CommandPaletteShortcutBindingsConfig
+): { source: CommandPaletteShortcutSource; accelerator: string }[] => {
+  const entries = [
+    ...config.leader.globalAccelerators.map((accelerator) => ({
+      source: 'leader' as const,
+      accelerator,
+    })),
+    ...config.palette.globalAccelerators.map((accelerator) => ({
+      source: 'palette' as const,
+      accelerator,
+    })),
+  ]
+  const seen = new Set<string>()
+
+  return entries.filter(({ accelerator }) => {
+    if (seen.has(accelerator)) {
+      return false
+    }
+
+    seen.add(accelerator)
+
+    return true
+  })
+}
+
+export const COMMAND_PALETTE_GLOBAL_ACCELERATORS = acceleratorEntriesForConfig(
+  commandPaletteShortcutBindingsConfigForPlatform('linux')
+).map(({ accelerator }) => accelerator)
 
 const SHORTCUT_TOGGLE_DEDUPLICATION_MS = 100
 
@@ -54,21 +281,51 @@ export const isCommandPaletteShortcutInput = (
   (config.modifier === 'command'
     ? input.meta && !input.control
     : input.control && !input.meta) &&
-  !input.alt &&
-  input.shift !== true &&
+  input.alt === config.alt &&
+  (input.shift === true) === config.shift &&
   !input.isAutoRepeat &&
-  input.key === ';'
+  (input.code !== undefined
+    ? input.code === config.code
+    : input.key === config.key)
 
-const sendCommandPaletteToggle = (win: BrowserWindow): void => {
+export const commandPaletteShortcutSourceForInput = (
+  input: ShortcutInput,
+  config: CommandPaletteShortcutBindingsConfig = commandPaletteShortcutBindingsConfigForPlatform(
+    process.platform
+  )
+): CommandPaletteShortcutSource | null => {
+  if (isCommandPaletteShortcutInput(input, config.leader)) {
+    return 'leader'
+  }
+
+  if (isCommandPaletteShortcutInput(input, config.palette)) {
+    return 'palette'
+  }
+
+  return null
+}
+
+const sendCommandPaletteToggle = (
+  win: BrowserWindow,
+  source: CommandPaletteShortcutSource
+): void => {
   if (win.isDestroyed()) {
     return
   }
 
-  win.webContents.send(COMMAND_PALETTE_TOGGLE)
+  win.webContents.send(COMMAND_PALETTE_TOGGLE, source)
 }
 
-const commandPaletteToggleDispatchers = new WeakMap<BrowserWindow, () => void>()
+const commandPaletteToggleDispatchers = new WeakMap<
+  BrowserWindow,
+  (source?: CommandPaletteShortcutSource) => void
+>()
 const captureActiveByWindow = new WeakMap<BrowserWindow, boolean>()
+
+const commandPaletteShortcutControllers = new WeakMap<
+  BrowserWindow,
+  CommandPaletteShortcutController
+>()
 
 export const setKeymapCaptureActive = (
   win: BrowserWindow,
@@ -79,10 +336,10 @@ export const setKeymapCaptureActive = (
 
 const createCommandPaletteToggleDispatcher = (
   win: BrowserWindow
-): (() => void) => {
+): ((source?: CommandPaletteShortcutSource) => void) => {
   let lastToggleAt = Number.NEGATIVE_INFINITY
 
-  return (): void => {
+  return (source = 'leader'): void => {
     const now = Date.now()
 
     if (now - lastToggleAt < SHORTCUT_TOGGLE_DEDUPLICATION_MS) {
@@ -90,13 +347,13 @@ const createCommandPaletteToggleDispatcher = (
     }
 
     lastToggleAt = now
-    sendCommandPaletteToggle(win)
+    sendCommandPaletteToggle(win, source)
   }
 }
 
 export const commandPaletteToggleDispatcherForWindow = (
   win: BrowserWindow
-): (() => void) => {
+): ((source?: CommandPaletteShortcutSource) => void) => {
   const existing = commandPaletteToggleDispatchers.get(win)
   if (existing) {
     return existing
@@ -108,13 +365,40 @@ export const commandPaletteToggleDispatcherForWindow = (
   return dispatcher
 }
 
+export const commandPaletteShortcutConfigForWindow = (
+  win: BrowserWindow,
+  source: CommandPaletteShortcutSource = 'leader'
+): CommandPaletteShortcutConfig =>
+  (commandPaletteShortcutControllers.get(win)?.config() ??
+    commandPaletteShortcutBindingsConfigForPlatform(process.platform))[source]
+
+export const commandPaletteShortcutBindingsConfigForWindow = (
+  win: BrowserWindow
+): CommandPaletteShortcutBindingsConfig =>
+  commandPaletteShortcutControllers.get(win)?.config() ??
+  commandPaletteShortcutBindingsConfigForPlatform(process.platform)
+
+export const setCommandPaletteShortcutBinding = (
+  win: BrowserWindow,
+  binding: string
+): void => {
+  commandPaletteShortcutControllers.get(win)?.setBinding(binding)
+}
+
+export const setCommandPaletteShortcutBindings = (
+  win: BrowserWindow,
+  bindings: CommandPaletteShortcutBindings
+): void => {
+  commandPaletteShortcutControllers.get(win)?.setBindings(bindings)
+}
+
 export const installCommandPaletteShortcutOverride = (
   win: BrowserWindow,
   options: CommandPaletteShortcutOverrideOptions = {}
 ): void => {
   const platform = options.platform ?? process.platform
   const shortcutRegistry = options.shortcutRegistry ?? globalShortcut
-  const shortcutConfig = commandPaletteShortcutConfigForPlatform(platform)
+  let shortcutConfig = commandPaletteShortcutBindingsConfigForPlatform(platform)
 
   const dispatchCommandPaletteToggle =
     commandPaletteToggleDispatcherForWindow(win)
@@ -125,10 +409,13 @@ export const installCommandPaletteShortcutOverride = (
       return
     }
 
-    registeredAccelerators = shortcutConfig.globalAccelerators.filter(
-      (accelerator) =>
-        shortcutRegistry.register(accelerator, dispatchCommandPaletteToggle)
-    )
+    registeredAccelerators = acceleratorEntriesForConfig(shortcutConfig)
+      .filter(({ accelerator, source }) =>
+        shortcutRegistry.register(accelerator, () => {
+          dispatchCommandPaletteToggle(source)
+        })
+      )
+      .map(({ accelerator }) => accelerator)
   }
 
   const unregisterFocusedLinuxShortcuts = (): void => {
@@ -142,8 +429,34 @@ export const installCommandPaletteShortcutOverride = (
     registeredAccelerators = []
   }
 
+  const setBindings = (bindings: CommandPaletteShortcutBindings): void => {
+    const wasRegistered = registeredAccelerators.length > 0
+
+    unregisterFocusedLinuxShortcuts()
+    shortcutConfig = commandPaletteShortcutBindingsConfigForPlatform(
+      platform,
+      bindings
+    )
+
+    if (wasRegistered || win.isFocused()) {
+      registerFocusedLinuxShortcuts()
+    }
+  }
+
+  const setBinding = (binding: string): void => {
+    setBindings({ palette: binding, leader: binding })
+  }
+
+  commandPaletteShortcutControllers.set(win, {
+    setBinding,
+    setBindings,
+    config: () => shortcutConfig,
+  })
+
   win.webContents.on('before-input-event', (event, input) => {
-    if (!isCommandPaletteShortcutInput(input, shortcutConfig)) {
+    const source = commandPaletteShortcutSourceForInput(input, shortcutConfig)
+
+    if (source === null) {
       return
     }
 
@@ -152,12 +465,15 @@ export const installCommandPaletteShortcutOverride = (
     }
 
     event.preventDefault()
-    dispatchCommandPaletteToggle()
+    dispatchCommandPaletteToggle(source)
   })
 
   win.on('focus', registerFocusedLinuxShortcuts)
   win.on('blur', unregisterFocusedLinuxShortcuts)
-  win.on('closed', unregisterFocusedLinuxShortcuts)
+  win.on('closed', () => {
+    unregisterFocusedLinuxShortcuts()
+    commandPaletteShortcutControllers.delete(win)
+  })
 
   if (win.isFocused()) {
     registerFocusedLinuxShortcuts()

--- a/electron/ipc-channels.ts
+++ b/electron/ipc-channels.ts
@@ -7,6 +7,8 @@ export const BACKEND_EVENT = 'backend:event'
 
 export const COMMAND_PALETTE_TOGGLE = 'command-palette:toggle'
 
+export const COMMAND_PALETTE_BINDING = 'command-palette:binding'
+
 export const KEYMAP_CAPTURE_ACTIVE = 'keymap:capture-active'
 
 export const SETTINGS_OPEN_FILE = 'settings:open-file'

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -19,6 +19,8 @@ import {
 } from './csp'
 import {
   installCommandPaletteShortcutOverride,
+  setCommandPaletteShortcutBinding,
+  setCommandPaletteShortcutBindings,
   setKeymapCaptureActive,
 } from './command-palette-shortcut'
 import { installApplicationEditMenu } from './edit-menu'
@@ -26,6 +28,7 @@ import { installNavigationGuard } from './navigation-guard'
 import {
   BACKEND_EVENT,
   BACKEND_INVOKE,
+  COMMAND_PALETTE_BINDING,
   KEYMAP_CAPTURE_ACTIVE,
   SETTINGS_OPEN_FILE,
   SETTINGS_SYNC_SNAPSHOT,
@@ -65,6 +68,17 @@ const E2E_RUNTIME_ARG = '--vimeflow-e2e'
 // Kept local to the main process so Electron startup never depends on a renderer
 // feature module that may later gain browser-only runtime imports.
 const SETTINGS_SCHEMA_VERSION = 1
+
+const isCommandPaletteBindingSync = (
+  value: unknown
+): value is { palette: string; leader: string } =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  'palette' in value &&
+  'leader' in value &&
+  typeof value.palette === 'string' &&
+  typeof value.leader === 'string'
 
 // E2E detection (env var OR CLI flag fallback). Hoisted above its first
 // caller (installContentSecurityPolicy at ~line 80) so the TDZ never
@@ -471,6 +485,23 @@ const setupApp = async (): Promise<void> => {
     const win = BrowserWindow.fromWebContents(ipcEvent.sender)
     if (win !== null) {
       setKeymapCaptureActive(win, active === true)
+    }
+  })
+
+  ipcMain.on(COMMAND_PALETTE_BINDING, (ipcEvent, binding: unknown) => {
+    const win = BrowserWindow.fromWebContents(ipcEvent.sender)
+    if (win === null) {
+      return
+    }
+
+    if (typeof binding === 'string') {
+      setCommandPaletteShortcutBinding(win, binding)
+
+      return
+    }
+
+    if (isCommandPaletteBindingSync(binding)) {
+      setCommandPaletteShortcutBindings(win, binding)
     }
   })
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -68,6 +68,7 @@ const E2E_RUNTIME_ARG = '--vimeflow-e2e'
 // Kept local to the main process so Electron startup never depends on a renderer
 // feature module that may later gain browser-only runtime imports.
 const SETTINGS_SCHEMA_VERSION = 1
+const COMMAND_PALETTE_BINDING_MAX_LENGTH = 64
 
 const isCommandPaletteBindingSync = (
   value: unknown
@@ -495,12 +496,18 @@ const setupApp = async (): Promise<void> => {
     }
 
     if (typeof binding === 'string') {
-      setCommandPaletteShortcutBinding(win, binding)
+      if (binding.length <= COMMAND_PALETTE_BINDING_MAX_LENGTH) {
+        setCommandPaletteShortcutBinding(win, binding)
+      }
 
       return
     }
 
-    if (isCommandPaletteBindingSync(binding)) {
+    if (
+      isCommandPaletteBindingSync(binding) &&
+      binding.palette.length <= COMMAND_PALETTE_BINDING_MAX_LENGTH &&
+      binding.leader.length <= COMMAND_PALETTE_BINDING_MAX_LENGTH
+    ) {
       setCommandPaletteShortcutBindings(win, binding)
     }
   })

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -17,6 +17,7 @@ import {
   BROWSER_PANE_TABS_CHANGED,
   BROWSER_PANE_URL_CHANGED,
 } from './browser-pane-channels'
+import { COMMAND_PALETTE_BINDING, COMMAND_PALETTE_TOGGLE } from './ipc-channels'
 import './preload'
 
 const electronMock = vi.hoisted(() => {
@@ -35,6 +36,7 @@ const electronMock = vi.hoisted(() => {
       invoke: vi.fn(),
       on: vi.fn(),
       off: vi.fn(),
+      send: vi.fn(),
       setMaxListeners: vi.fn(),
     },
   }
@@ -65,6 +67,16 @@ const browserPane = (): Record<string, unknown> => {
   return pane as Record<string, unknown>
 }
 
+const preloadApi = (): Record<string, unknown> => {
+  const api = electronMock.exposed
+
+  if (!api || typeof api !== 'object') {
+    throw new Error('preload API not exposed')
+  }
+
+  return api
+}
+
 describe('preload browserPane wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -72,6 +84,68 @@ describe('preload browserPane wiring', () => {
 
   test('raises the shared ipcRenderer listener cap during preload startup', () => {
     expect(preloadSetMaxListenersCalls).toEqual([[64]])
+  })
+
+  test('setCommandPaletteBinding sends the resolved binding to main', () => {
+    const setCommandPaletteBinding = preloadApi().setCommandPaletteBinding as (
+      binding: string
+    ) => void
+
+    setCommandPaletteBinding('Mod+KeyK')
+
+    expect(electronMock.ipcRenderer.send).toHaveBeenCalledWith(
+      COMMAND_PALETTE_BINDING,
+      'Mod+KeyK'
+    )
+  })
+
+  test('setCommandPaletteBindings sends split palette bindings to main', () => {
+    const setCommandPaletteBindings = preloadApi()
+      .setCommandPaletteBindings as (bindings: {
+      palette: string
+      leader: string
+    }) => void
+
+    setCommandPaletteBindings({
+      palette: 'Mod+KeyP',
+      leader: 'Mod+KeyK',
+    })
+
+    expect(electronMock.ipcRenderer.send).toHaveBeenCalledWith(
+      COMMAND_PALETTE_BINDING,
+      {
+        palette: 'Mod+KeyP',
+        leader: 'Mod+KeyK',
+      }
+    )
+  })
+
+  test('onCommandPaletteToggle forwards the shortcut source', () => {
+    const onCommandPaletteToggle = preloadApi().onCommandPaletteToggle as (
+      callback: (source?: 'palette' | 'leader') => void
+    ) => () => void
+    const callback = vi.fn()
+
+    const unlisten = onCommandPaletteToggle(callback)
+
+    const handler = electronMock.ipcRenderer.on.mock.calls.find(
+      ([channel]) => channel === COMMAND_PALETTE_TOGGLE
+    )?.[1] as ((event: unknown, source: unknown) => void) | undefined
+
+    if (handler === undefined) {
+      throw new Error('command palette listener was not registered')
+    }
+
+    handler({}, 'palette')
+    handler({}, 'invalid')
+    unlisten()
+
+    expect(callback).toHaveBeenNthCalledWith(1, 'palette')
+    expect(callback).toHaveBeenNthCalledWith(2, undefined)
+    expect(electronMock.ipcRenderer.off).toHaveBeenCalledWith(
+      COMMAND_PALETTE_TOGGLE,
+      handler
+    )
   })
 
   test.each([

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import {
   BACKEND_EVENT,
   BACKEND_INVOKE,
+  COMMAND_PALETTE_BINDING,
   COMMAND_PALETTE_TOGGLE,
   KEYMAP_CAPTURE_ACTIVE,
   SETTINGS_OPEN_FILE,
@@ -39,9 +40,21 @@ const BACKEND_EVENT_MAX_LISTENERS = 64
 
 ipcRenderer.setMaxListeners(BACKEND_EVENT_MAX_LISTENERS)
 
+type CommandPaletteShortcutSource = 'palette' | 'leader'
+
+interface CommandPaletteBindingSync {
+  palette: string
+  leader: string
+}
+
 type InvokeEnvelope<T> =
   | { ok: true; result: T }
   | { ok: false; error: string; errorReason?: string }
+
+const isCommandPaletteShortcutSource = (
+  value: unknown
+): value is CommandPaletteShortcutSource =>
+  value === 'palette' || value === 'leader'
 
 const invoke = async <T>(
   method: string,
@@ -90,9 +103,11 @@ const listen = <T>(
   return Promise.resolve(unlisten)
 }
 
-const onCommandPaletteToggle = (callback: () => void): (() => void) => {
-  const handler = (): void => {
-    callback()
+const onCommandPaletteToggle = (
+  callback: (source?: CommandPaletteShortcutSource) => void
+): (() => void) => {
+  const handler = (_event: IpcRendererEvent, source: unknown): void => {
+    callback(isCommandPaletteShortcutSource(source) ? source : undefined)
   }
 
   ipcRenderer.on(COMMAND_PALETTE_TOGGLE, handler)
@@ -106,11 +121,23 @@ const setKeymapCaptureActive = (active: boolean): void => {
   ipcRenderer.send(KEYMAP_CAPTURE_ACTIVE, active)
 }
 
+const setCommandPaletteBinding = (binding: string): void => {
+  ipcRenderer.send(COMMAND_PALETTE_BINDING, binding)
+}
+
+const setCommandPaletteBindings = (
+  bindings: CommandPaletteBindingSync
+): void => {
+  ipcRenderer.send(COMMAND_PALETTE_BINDING, bindings)
+}
+
 contextBridge.exposeInMainWorld('vimeflow', {
   invoke,
   listen,
   onCommandPaletteToggle,
   setKeymapCaptureActive,
+  setCommandPaletteBinding,
+  setCommandPaletteBindings,
   browserPane: {
     createPane: (request: unknown): Promise<unknown> =>
       ipcRenderer.invoke(BROWSER_PANE_CREATE, request),

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -98,6 +98,17 @@ describe('StatusBar', () => {
     )
   })
 
+  test('palette tooltip uses the supplied shortcut chips', async () => {
+    const user = userEvent.setup()
+    renderStatusBar({ paletteShortcut: ['Ctrl', 'K'] })
+
+    await user.hover(screen.getByTestId('status-bar-palette'))
+
+    expect(
+      within(await screen.findByRole('tooltip')).getByTestId('tooltip-shortcut')
+    ).toHaveTextContent('Ctrl+K')
+  })
+
   test('dock toggle indicates open state through icon color, not a filled background (J8)', () => {
     const { rerender } = renderStatusBar({ dockOpen: false })
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -5,11 +5,10 @@ import {
   type ReactNode,
 } from 'react'
 import { Tooltip } from './Tooltip'
-import type { ShortcutKey } from '../lib/formatShortcut'
+import type { ShortcutInput, ShortcutKey } from '../lib/formatShortcut'
 
-// Display-side chords for the bottom-bar actions. The behavior lives in the
-// command palette and dock-shortcut hooks; these mirror those bindings so the
-// Zed-style tooltip chips can't drift from the wired keys.
+// Display-side fallbacks for the bottom-bar actions. WorkspaceView passes the
+// live palette binding so the tooltip chip follows persisted overrides.
 const PALETTE_SHORTCUT = ['Mod', ';'] as const satisfies readonly ShortcutKey[]
 const DOCK_SHORTCUT = ['Mod', '0'] as const satisfies readonly ShortcutKey[]
 
@@ -37,6 +36,8 @@ export interface StatusBarProps {
   // the segment is suppressed rather than shown as a misleading 0%.
   contextPct: number | null
   onOpenPalette: () => void
+  /** Current command-palette shortcut — defaults to the app binding. */
+  paletteShortcut?: ShortcutInput
   /** Whether the editor/diff dock is open — drives the toggle's icon tone. */
   dockOpen: boolean
   onToggleDock: () => void
@@ -310,6 +311,7 @@ export const StatusBar = ({
   session,
   contextPct,
   onOpenPalette,
+  paletteShortcut = PALETTE_SHORTCUT,
   dockOpen,
   onToggleDock,
   burnerCount = 0,
@@ -327,7 +329,7 @@ export const StatusBar = ({
         data-testid="status-bar-actions"
         className="inline-flex items-center gap-[6px]"
       >
-        <Tooltip content="Command palette" shortcut={PALETTE_SHORTCUT}>
+        <Tooltip content="Command palette" shortcut={paletteShortcut}>
           <button
             type="button"
             aria-label="Open command palette"

--- a/src/features/command-palette/hooks/useCommandPalette.test.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.test.ts
@@ -6,7 +6,10 @@ import {
 } from './useCommandPalette'
 import type { Command } from '../registry/types'
 import * as chordRegistry from '../chordRegistry'
-import type { BackendApi } from '../../../lib/backend'
+import type {
+  BackendApi,
+  CommandPaletteShortcutSource,
+} from '../../../lib/backend'
 import { KEYMAP_CAPTURE_TARGET_ATTRIBUTE } from '../../keymap/capture'
 
 describe('useCommandPalette', () => {
@@ -156,6 +159,117 @@ describe('useCommandPalette', () => {
       })
 
       expect(result.current.state.isOpen).toBe(true)
+    })
+
+    test('uses the supplied leader matcher for a rebound palette leader', () => {
+      vi.useFakeTimers()
+
+      const isLeaderEvent = (event: KeyboardEvent): boolean =>
+        event.code === 'KeyK' && event.ctrlKey && !event.metaKey
+
+      const isPaletteToggleEvent = (event: KeyboardEvent): boolean =>
+        event.code === 'KeyP' && event.ctrlKey && !event.metaKey
+
+      const { result } = renderHook(() =>
+        useCommandPalette(undefined, { isLeaderEvent, isPaletteToggleEvent })
+      )
+
+      act(() => {
+        const oldDefault = new KeyboardEvent('keydown', {
+          key: ';',
+          code: 'Semicolon',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true,
+        })
+        document.dispatchEvent(oldDefault)
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+
+      expect(result.current.state.isOpen).toBe(false)
+
+      act(() => {
+        const rebound = new KeyboardEvent('keydown', {
+          key: 'k',
+          code: 'KeyK',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true,
+        })
+        document.dispatchEvent(rebound)
+      })
+
+      expect(result.current.state.isOpen).toBe(false)
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+
+      expect(result.current.state.isOpen).toBe(true)
+    })
+
+    test('uses a separate direct palette matcher without starting the leader window', () => {
+      vi.useFakeTimers()
+      const handler = vi.fn(() => true)
+      chordRegistry.registerChord('r', handler)
+
+      const isPaletteToggleEvent = (event: KeyboardEvent): boolean =>
+        event.code === 'KeyP' && event.ctrlKey && !event.metaKey
+
+      const isLeaderEvent = (event: KeyboardEvent): boolean =>
+        event.code === 'KeyK' && event.ctrlKey && !event.metaKey
+
+      const { result } = renderHook(() =>
+        useCommandPalette(undefined, { isLeaderEvent, isPaletteToggleEvent })
+      )
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'p',
+            code: 'KeyP',
+            ctrlKey: true,
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      })
+
+      expect(result.current.state.isOpen).toBe(true)
+
+      act(() => {
+        result.current.close()
+      })
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'k',
+            code: 'KeyK',
+            ctrlKey: true,
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      })
+
+      expect(result.current.state.isOpen).toBe(false)
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'r',
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      })
+
+      expect(handler).toHaveBeenCalledOnce()
+      expect(result.current.state.isOpen).toBe(false)
     })
 
     test('Ctrl+; with palette closed keeps palette closed during leader window', () => {
@@ -531,14 +645,18 @@ describe('useCommandPalette', () => {
       }
     })
 
-    test('toggles from the Electron main-process shortcut override', async () => {
-      let toggleFromMain: (() => void) | null = null
+    test('toggles directly from the Electron palette shortcut source', async () => {
+      let toggleFromMain:
+        | ((source?: CommandPaletteShortcutSource) => void)
+        | null = null
       const unlisten = vi.fn()
 
       window.vimeflow = {
         invoke: vi.fn(),
         listen: vi.fn(),
-        onCommandPaletteToggle: (callback: () => void): (() => void) => {
+        onCommandPaletteToggle: (
+          callback: (source?: CommandPaletteShortcutSource) => void
+        ): (() => void) => {
           toggleFromMain = callback
 
           return unlisten
@@ -551,7 +669,7 @@ describe('useCommandPalette', () => {
         expect(result.current.state.isOpen).toBe(false)
 
         act(() => {
-          toggleFromMain?.()
+          toggleFromMain?.('palette')
         })
 
         await waitFor(() => {
@@ -559,7 +677,7 @@ describe('useCommandPalette', () => {
         })
 
         act(() => {
-          toggleFromMain?.()
+          toggleFromMain?.('palette')
         })
 
         await waitFor(() => {
@@ -573,14 +691,59 @@ describe('useCommandPalette', () => {
       }
     })
 
-    test('Electron shortcut toggle is left for focused keymap recorder', () => {
-      let toggleFromMain: (() => void) | null = null
+    test('Electron shortcut without a source uses the leader window', () => {
+      vi.useFakeTimers()
+      let toggleFromMain:
+        | ((source?: CommandPaletteShortcutSource) => void)
+        | null = null
       const unlisten = vi.fn()
 
       window.vimeflow = {
         invoke: vi.fn(),
         listen: vi.fn(),
-        onCommandPaletteToggle: (callback: () => void): (() => void) => {
+        onCommandPaletteToggle: (
+          callback: (source?: CommandPaletteShortcutSource) => void
+        ): (() => void) => {
+          toggleFromMain = callback
+
+          return unlisten
+        },
+      } as unknown as BackendApi
+
+      const { result, unmount } = renderHook(() => useCommandPalette())
+
+      try {
+        act(() => {
+          toggleFromMain?.()
+        })
+
+        expect(result.current.state.isOpen).toBe(false)
+
+        act(() => {
+          vi.advanceTimersByTime(500)
+        })
+
+        expect(result.current.state.isOpen).toBe(true)
+
+        unmount()
+        expect(unlisten).toHaveBeenCalledOnce()
+      } finally {
+        delete window.vimeflow
+      }
+    })
+
+    test('Electron shortcut toggle is left for focused keymap recorder', () => {
+      let toggleFromMain:
+        | ((source?: CommandPaletteShortcutSource) => void)
+        | null = null
+      const unlisten = vi.fn()
+
+      window.vimeflow = {
+        invoke: vi.fn(),
+        listen: vi.fn(),
+        onCommandPaletteToggle: (
+          callback: (source?: CommandPaletteShortcutSource) => void
+        ): (() => void) => {
           toggleFromMain = callback
 
           return unlisten
@@ -596,7 +759,7 @@ describe('useCommandPalette', () => {
 
       try {
         act(() => {
-          toggleFromMain?.()
+          toggleFromMain?.('leader')
         })
 
         expect(result.current.state.isOpen).toBe(false)

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -57,6 +57,11 @@ export const useCommandPalette = (
   options: UseCommandPaletteOptions = {}
 ): UseCommandPaletteReturn => {
   const isEnabled = options.enabled ?? true
+  const fallbackToggleEvent = options.isToggleEvent ?? isCommandPaletteToggle
+
+  const isPaletteToggleEvent =
+    options.isPaletteToggleEvent ?? fallbackToggleEvent
+  const isLeaderEvent = options.isLeaderEvent ?? fallbackToggleEvent
 
   const [state, setState] = useState<CommandPaletteState>({
     isOpen: false,
@@ -67,8 +72,12 @@ export const useCommandPalette = (
   const leaderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const leaderActiveRef = useRef(false)
   const isEnabledRef = useRef(isEnabled)
+  const isPaletteToggleEventRef = useRef(isPaletteToggleEvent)
+  const isLeaderEventRef = useRef(isLeaderEvent)
 
   isEnabledRef.current = isEnabled
+  isPaletteToggleEventRef.current = isPaletteToggleEvent
+  isLeaderEventRef.current = isLeaderEvent
 
   const clearLeaderWindow = useCallback((): void => {
     if (leaderTimerRef.current) {
@@ -336,13 +345,33 @@ export const useCommandPalette = (
 
   // Global keyboard listener — registered once for the hook's lifetime.
   useEffect(() => {
-    // Platform command-palette toggle handling shared by the renderer keydown path and the Electron
-    // before-input-event override. In the packaged app Electron owns the
-    // toggle binding and consumes it before the renderer sees it, dispatching
-    // an IPC toggle instead; this callback drives the same leader window so
-    // the follow-up chord key (NOT intercepted) still reaches handleKeyDown
-    // below and routes through chordRegistry / usePaneRenameChord.
-    const handlePaletteShortcut = (): void => {
+    const handleDirectPaletteShortcut = (): void => {
+      if (isKeymapCaptureTarget(document.activeElement)) {
+        return
+      }
+
+      if (!isEnabledRef.current) {
+        handlersRef.current.close()
+
+        return
+      }
+
+      clearLeaderWindow()
+
+      if (stateRef.current.isOpen) {
+        handlersRef.current.close()
+      } else {
+        handlersRef.current.open()
+      }
+    }
+
+    // Platform leader handling shared by the renderer keydown path and the
+    // Electron before-input-event override. In the packaged app Electron owns
+    // the binding and consumes it before the renderer sees it, dispatching an
+    // IPC toggle instead; this callback drives the same leader window so the
+    // follow-up chord key (NOT intercepted) still reaches handleKeyDown below
+    // and routes through chordRegistry / usePaneRenameChord.
+    const handleLeaderShortcut = (): void => {
       if (isKeymapCaptureTarget(document.activeElement)) {
         return
       }
@@ -374,14 +403,17 @@ export const useCommandPalette = (
         return
       }
 
-      if (isCommandPaletteToggle(event) && event.repeat) {
+      const matchesLeaderEvent = isLeaderEventRef.current(event)
+      const matchesPaletteToggleEvent = isPaletteToggleEventRef.current(event)
+
+      if ((matchesLeaderEvent || matchesPaletteToggleEvent) && event.repeat) {
         fullyConsumeEvent(event)
 
         return
       }
 
       if (leaderActiveRef.current) {
-        if (isCommandPaletteToggle(event)) {
+        if (matchesLeaderEvent || matchesPaletteToggleEvent) {
           fullyConsumeEvent(event)
           clearLeaderWindow()
           handlersRef.current.open()
@@ -411,12 +443,20 @@ export const useCommandPalette = (
         return
       }
 
-      // The palette toggle starts a short leader window. If no chord consumes the
-      // follow-up key, the palette opens after the window or immediately on
-      // the non-chord key.
-      if (isCommandPaletteToggle(event)) {
+      // The leader prefix starts a short leader window. If no chord consumes
+      // the follow-up key, the palette opens after the window or immediately on
+      // the non-chord key. Check it before the direct palette shortcut so the
+      // shared default Mod+; preserves the existing leader behavior.
+      if (matchesLeaderEvent) {
         fullyConsumeEvent(event)
-        handlePaletteShortcut()
+        handleLeaderShortcut()
+
+        return
+      }
+
+      if (matchesPaletteToggleEvent) {
+        fullyConsumeEvent(event)
+        handleDirectPaletteShortcut()
 
         return
       }
@@ -452,7 +492,15 @@ export const useCommandPalette = (
     }
 
     const unlistenCommandPaletteToggle = listenCommandPaletteToggle(
-      handlePaletteShortcut
+      (source) => {
+        if (source === 'palette') {
+          handleDirectPaletteShortcut()
+
+          return
+        }
+
+        handleLeaderShortcut()
+      }
     )
 
     document.addEventListener('keydown', handleKeyDown, { capture: true })

--- a/src/features/command-palette/registry/types.ts
+++ b/src/features/command-palette/registry/types.ts
@@ -30,4 +30,7 @@ export interface UseCommandPaletteReturn {
 
 export interface UseCommandPaletteOptions {
   enabled?: boolean
+  isPaletteToggleEvent?: (event: KeyboardEvent) => boolean
+  isLeaderEvent?: (event: KeyboardEvent) => boolean
+  isToggleEvent?: (event: KeyboardEvent) => boolean
 }

--- a/src/features/keymap/catalog.test.ts
+++ b/src/features/keymap/catalog.test.ts
@@ -9,7 +9,7 @@ describe('CATALOG', () => {
     expect(new Set(ids).size).toBe(ids.length)
   })
 
-  test('PR1 + PR2 migrated commands are rebindable; the rest are display-only', () => {
+  test('PR1 + PR2 + PR3 migrated commands are rebindable; the rest are display-only', () => {
     const rebindable = CATALOG.filter((cmd) => cmd.rebindable)
       .map((cmd) => cmd.id)
       .sort()
@@ -25,6 +25,8 @@ describe('CATALOG', () => {
         'focus-pane-right',
         'cycle-layout',
         'dock-toggle',
+        'palette',
+        'palette-leader',
         'new-session',
         'session-prev',
         'session-next',

--- a/src/features/keymap/catalog.ts
+++ b/src/features/keymap/catalog.ts
@@ -18,6 +18,7 @@ export interface CommandDescriptor {
   readonly rebindable: boolean
   readonly preserveStoredOverrides?: boolean
   readonly intentionalShadow?: boolean
+  readonly intentionalShadowWith?: readonly string[]
 }
 
 const c = (
@@ -26,9 +27,10 @@ const c = (
 ): Chord => ({ code, mods: new Set(mods) })
 
 // PR1 migrated usePaneShortcuts (the focus-pane / cycle-layout commands) and
-// useDockToggleShortcut. PR2 migrates the remaining workspace hooks. Their
+// useDockToggleShortcut. PR2 migrates the remaining workspace hooks. PR3
+// migrates the command-palette direct toggle and leader prefix. Their
 // defaultCombo MUST equal today's hardcoded combos (resolve.test asserts this).
-// Terminal-owned rows and the SP3-owned palette leader remain display-only.
+// Terminal-owned rows remain display-only.
 export const CATALOG = [
   // ── Panes & Layout (MIGRATED — rebindable) ──
   {
@@ -113,7 +115,7 @@ export const CATALOG = [
     defaultCombo: c('Backslash', 'Mod'),
   },
 
-  // ── Global (dock-toggle MIGRATED; others display-only until PR2/SP3) ──
+  // ── Global (MIGRATED — rebindable except fixed settings shortcuts) ──
   {
     id: 'dock-toggle',
     label: 'Show / hide editor & diff dock',
@@ -129,7 +131,18 @@ export const CATALOG = [
     group: 'Global',
     context: 'global',
     matchPolicy: 'exact',
-    rebindable: false,
+    rebindable: true,
+    intentionalShadowWith: ['palette-leader'],
+    defaultCombo: c('Semicolon', 'Mod'),
+  },
+  {
+    id: 'palette-leader',
+    label: 'Command palette leader',
+    group: 'Global',
+    context: 'global',
+    matchPolicy: 'exact',
+    rebindable: true,
+    intentionalShadowWith: ['palette'],
     defaultCombo: c('Semicolon', 'Mod'),
   },
   {

--- a/src/features/keymap/catalog.ts
+++ b/src/features/keymap/catalog.ts
@@ -8,19 +8,6 @@ export type BindingContext =
   | 'dock'
   | 'browser'
 
-export interface CommandDescriptor {
-  readonly id: string
-  readonly label: string
-  readonly group: string
-  readonly context: BindingContext
-  readonly matchPolicy: 'exact' | 'tolerant'
-  readonly defaultCombo: Chord | ((isMac: boolean) => Chord)
-  readonly rebindable: boolean
-  readonly preserveStoredOverrides?: boolean
-  readonly intentionalShadow?: boolean
-  readonly intentionalShadowWith?: readonly string[]
-}
-
 const c = (
   code: string,
   ...mods: ('Mod' | 'Ctrl' | 'Shift' | 'Alt')[]
@@ -31,7 +18,7 @@ const c = (
 // migrates the command-palette direct toggle and leader prefix. Their
 // defaultCombo MUST equal today's hardcoded combos (resolve.test asserts this).
 // Terminal-owned rows remain display-only.
-export const CATALOG = [
+const CATALOG_LITERAL = [
   // ── Panes & Layout (MIGRATED — rebindable) ──
   {
     id: 'focus-pane-1',
@@ -293,11 +280,30 @@ export const CATALOG = [
     preserveStoredOverrides: true,
     defaultCombo: c('KeyL', 'Mod'),
   },
-] as const satisfies readonly CommandDescriptor[]
+] as const
 
-export type CommandId = (typeof CATALOG)[number]['id']
+export type CommandId = (typeof CATALOG_LITERAL)[number]['id']
 
-const BY_ID = new Map<string, CommandDescriptor>(
+export interface CommandDescriptor {
+  readonly id: CommandId
+  readonly label: string
+  readonly group: string
+  readonly context: BindingContext
+  readonly matchPolicy: 'exact' | 'tolerant'
+  readonly defaultCombo: Chord | ((isMac: boolean) => Chord)
+  readonly rebindable: boolean
+  readonly preserveStoredOverrides?: boolean
+  readonly intentionalShadow?: boolean
+  readonly intentionalShadowWith?: readonly CommandId[]
+}
+
+// Exported catalog is widened to CommandDescriptor so consumers see a uniform
+// array type, while CommandId is derived from the literal catalog above. This
+// breaks the circular dependency and lets intentionalShadowWith reject typos
+// at compile time.
+export const CATALOG: readonly CommandDescriptor[] = CATALOG_LITERAL
+
+const BY_ID = new Map<CommandId, CommandDescriptor>(
   CATALOG.map((cmd) => [cmd.id, cmd])
 )
 

--- a/src/features/keymap/conflicts.test.ts
+++ b/src/features/keymap/conflicts.test.ts
@@ -97,6 +97,15 @@ describe('detectConflicts', () => {
     expect(detectConflicts(resolved, 'ctrl')).toHaveLength(0)
   })
 
+  test('does not report the intentionally shared palette and leader binding', () => {
+    const resolved = new Map<CommandId, Chord>([
+      ['palette', c('Semicolon', 'Mod')],
+      ['palette-leader', c('Semicolon', 'Mod')],
+    ])
+
+    expect(detectConflicts(resolved, 'meta')).toHaveLength(0)
+  })
+
   test('reports accidental fixed command overlaps outside reserved shadows', () => {
     const resolved = new Map<CommandId, Chord>([
       ['palette', c('KeyN', 'Mod')],

--- a/src/features/keymap/conflicts.ts
+++ b/src/features/keymap/conflicts.ts
@@ -39,6 +39,16 @@ const intersects = (
   b: ReadonlySet<boolean>
 ): boolean => [...a].some((value) => b.has(value))
 
+export const intentionallyShadowed = (a: CommandId, b: CommandId): boolean => {
+  const cmdA = getCommand(a)
+  const cmdB = getCommand(b)
+
+  return (
+    cmdA.intentionalShadowWith?.includes(b) === true ||
+    cmdB.intentionalShadowWith?.includes(a) === true
+  )
+}
+
 // Two resolved bindings overlap iff same (super, code) AND a Shift/Alt
 // assignment matches both under their policies (spec §5.4).
 export const chordsOverlap = (
@@ -81,6 +91,9 @@ export const overrideCollides = (
     if (other.preserveStoredOverrides) {
       continue
     }
+    if (intentionallyShadowed(id, otherId)) {
+      continue
+    }
     if (
       contextsOverlap(me.context, other.context) &&
       chordsOverlap(
@@ -115,6 +128,9 @@ export const detectConflicts = (
         !b.rebindable &&
         (a.intentionalShadow || b.intentionalShadow)
       ) {
+        continue
+      }
+      if (intentionallyShadowed(ids[i], ids[j])) {
         continue
       }
       if (

--- a/src/features/keymap/resolve.test.ts
+++ b/src/features/keymap/resolve.test.ts
@@ -25,6 +25,8 @@ describe('behavior preservation — migrated defaults equal today’s hardcoded 
     'focus-pane-up': 'Mod+Shift+ArrowUp',
     'focus-pane-right': 'Mod+Shift+ArrowRight',
     'dock-toggle': 'Mod+Digit0',
+    palette: 'Mod+Semicolon',
+    'palette-leader': 'Mod+Semicolon',
     'sidebar-sessions': 'Mod+Shift+KeyS',
     'sidebar-files': 'Mod+Shift+KeyF',
     'focus-editor': 'Mod+KeyE',
@@ -78,8 +80,22 @@ describe('resolveBindings', () => {
     )
   })
 
+  test('override on the PR3-migrated palette command wins', () => {
+    expect(tokenOf({ palette: 'Mod+KeyP' }, 'palette')).toBe('Mod+KeyP')
+  })
+
+  test('palette and leader overrides may intentionally share a binding', () => {
+    const overrides: CustomKeybindings = {
+      palette: 'Mod+KeyP',
+      'palette-leader': 'Mod+KeyP',
+    }
+
+    expect(tokenOf(overrides, 'palette')).toBe('Mod+KeyP')
+    expect(tokenOf(overrides, 'palette-leader')).toBe('Mod+KeyP')
+  })
+
   test('override on a rebindable:false command is ignored', () => {
-    expect(tokenOf({ palette: 'Mod+KeyP' }, 'palette')).toBe('Mod+Semicolon')
+    expect(tokenOf({ settings: 'Mod+KeyP' }, 'settings')).toBe('Mod+Comma')
   })
 
   test('super-less / both-super / malformed overrides fall back to default', () => {

--- a/src/features/keymap/useKeybindings.test.tsx
+++ b/src/features/keymap/useKeybindings.test.tsx
@@ -46,15 +46,35 @@ describe('useKeybindings', () => {
     expect(update).not.toHaveBeenCalled()
   })
 
-  test("setUserBinding rejects shadowing the fixed ⌘; leader as 'reserved'", () => {
+  test("setUserBinding rejects shadowing the palette defaults as 'conflict'", () => {
     const { result, update } = renderKeybindings()
     expect(
       result.current.setUserBinding('dock-toggle', {
         code: 'Semicolon',
         mods: new Set(['Mod']),
       })
-    ).toEqual({ ok: false, reason: 'reserved' })
+    ).toEqual({ ok: false, reason: 'conflict' })
     expect(update).not.toHaveBeenCalled()
+  })
+
+  test('setUserBinding allows the palette and leader to intentionally overlap', () => {
+    const { result, update } = renderKeybindings({
+      palette: 'Mod+KeyP',
+    })
+
+    expect(
+      result.current.setUserBinding('palette-leader', {
+        code: 'KeyP',
+        mods: new Set(['Mod']),
+      })
+    ).toEqual({ ok: true })
+
+    expect(update).toHaveBeenCalledWith({
+      customKeybindings: {
+        palette: 'Mod+KeyP',
+        'palette-leader': 'Mod+KeyP',
+      },
+    })
   })
 
   test("setUserBinding rejects shadowing the settings shortcut as 'reserved'", () => {
@@ -102,7 +122,7 @@ describe('useKeybindings', () => {
   test("setUserBinding rejects display-only commands as 'reserved'", () => {
     const { result, update } = renderKeybindings()
     expect(
-      result.current.setUserBinding('palette', {
+      result.current.setUserBinding('settings', {
         code: 'KeyP',
         mods: new Set(['Mod']),
       })

--- a/src/features/keymap/useKeybindings.ts
+++ b/src/features/keymap/useKeybindings.ts
@@ -7,6 +7,7 @@ import {
   chordsOverlap,
   contextsOverlap,
   detectConflicts,
+  intentionallyShadowed,
   type Conflict,
 } from './conflicts'
 import { eventMatchesChord, type PlatformSuper } from './match'
@@ -65,6 +66,9 @@ export const useKeybindings = (): Keybindings => {
           continue
         }
         const other = getCommand(otherId)
+        if (intentionallyShadowed(id, otherId)) {
+          continue
+        }
         if (
           contextsOverlap(me.context, other.context) &&
           chordsOverlap(

--- a/src/features/settings/components/panes/KeymapPane.test.tsx
+++ b/src/features/settings/components/panes/KeymapPane.test.tsx
@@ -1,5 +1,10 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
-import { fireEvent, render as rtlRender, screen } from '@testing-library/react'
+import {
+  act,
+  fireEvent,
+  render as rtlRender,
+  screen,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createElement, type ReactElement } from 'react'
 import { DEFAULT_SETTINGS } from '../../store/settingsDefaults'
@@ -43,6 +48,7 @@ describe('KeymapPane', () => {
 
   afterEach(() => {
     delete window.vimeflow
+    vi.useRealTimers()
   })
 
   test('renders the pane title', () => {
@@ -69,6 +75,7 @@ describe('KeymapPane', () => {
     ).toBeInTheDocument()
     expect(screen.getByText('Open settings')).toBeInTheDocument()
     expect(screen.getByText('Open command palette')).toBeInTheDocument()
+    expect(screen.getByText('Command palette leader')).toBeInTheDocument()
     expect(screen.getByText('Focus browser address bar')).toBeInTheDocument()
     // The bare-key Diff zone still renders from KEYMAP_GROUPS.
     expect(screen.getByText('Next / previous file')).toBeInTheDocument()
@@ -95,7 +102,7 @@ describe('KeymapPane', () => {
 
     render(<KeymapPane />)
 
-    expect(screen.getByText('⌘;')).toBeInTheDocument()
+    expect(screen.getAllByText('⌘;')).toHaveLength(2)
     expect(screen.getByText('⌘B')).toBeInTheDocument()
     expect(screen.getByText('⌘C')).toBeInTheDocument()
 
@@ -110,7 +117,7 @@ describe('KeymapPane', () => {
 
     render(<KeymapPane />)
 
-    expect(screen.getByText('Ctrl+;')).toBeInTheDocument()
+    expect(screen.getAllByText('Ctrl+;')).toHaveLength(2)
     expect(screen.getByText('Ctrl+Shift+B')).toBeInTheDocument()
     expect(screen.getByText('Ctrl+Shift+C')).toBeInTheDocument()
 
@@ -461,6 +468,8 @@ describe('KeymapPane', () => {
   })
 
   test('resetting a row removes only that override', () => {
+    vi.useFakeTimers()
+
     const { update } = renderWithSettings({
       'dock-toggle': 'Mod+KeyK',
       'focus-pane-1': 'Mod+KeyJ',
@@ -476,14 +485,32 @@ describe('KeymapPane', () => {
       customKeybindings: { 'focus-pane-1': 'Mod+KeyJ' },
     })
     expect(screen.getByRole('status')).toHaveTextContent('Reset.')
+
+    act(() => {
+      vi.advanceTimersByTime(1800)
+    })
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 
   test('does not render edit controls for display-only rows', () => {
     renderWithSettings()
 
     expect(
-      screen.queryByRole('button', {
+      screen.getByRole('button', {
         name: 'Edit Open command palette binding',
+      })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Edit Command palette leader binding',
+      })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Edit Open settings binding',
       })
     ).not.toBeInTheDocument()
   })

--- a/src/features/settings/components/panes/KeymapPane.tsx
+++ b/src/features/settings/components/panes/KeymapPane.tsx
@@ -51,6 +51,7 @@ interface PendingTabFocus {
 }
 
 const KEYMAP_EDIT_BUTTON_ATTRIBUTE = 'data-keymap-edit-command'
+const FEEDBACK_TIMEOUT_MS = 1800
 
 const FOCUSABLE_SELECTOR =
   'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
@@ -182,6 +183,26 @@ export const KeymapPane = (): ReactElement => {
     pendingTabFocusRef.current = null
     focusAfterTabCancel(pending.id, pending.direction)
   }, [editingId])
+
+  useEffect(() => {
+    if (feedback === null || feedback.tone === 'danger') {
+      return
+    }
+
+    const timeout = window.setTimeout(() => {
+      setFeedback((current) =>
+        current?.id === feedback.id &&
+        current.tone === feedback.tone &&
+        current.text === feedback.text
+          ? null
+          : current
+      )
+    }, FEEDBACK_TIMEOUT_MS)
+
+    return (): void => {
+      window.clearTimeout(timeout)
+    }
+  }, [feedback])
 
   const stopEditing = (): void => {
     setEditingId(null)

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -4,7 +4,7 @@ import {
   waitFor,
   act,
 } from '@testing-library/react'
-import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import { useState, type ReactElement, type ReactNode } from 'react'
 import { WorkspaceView } from './WorkspaceView'
@@ -345,10 +345,15 @@ describe('WorkspaceView - Command Palette Integration', () => {
     })
   })
 
+  afterEach(() => {
+    delete window.vimeflow
+  })
+
   const openPalette = (): void => {
     act(() => {
       const event = new KeyboardEvent('keydown', {
         key: ';',
+        code: 'Semicolon',
         ctrlKey: true,
         bubbles: true,
       })
@@ -366,6 +371,39 @@ describe('WorkspaceView - Command Palette Integration', () => {
 
     return call[0]
   }
+
+  test('syncs separate palette and leader bindings to Electron', async () => {
+    const setCommandPaletteBindings = vi.fn()
+    const setCommandPaletteBinding = vi.fn()
+    window.vimeflow = {
+      setCommandPaletteBindings,
+      setCommandPaletteBinding,
+    } as unknown as Window['vimeflow']
+
+    const settings: AppSettings = {
+      ...DEFAULT_SETTINGS,
+      customKeybindings: {
+        palette: 'Mod+KeyP',
+        'palette-leader': 'Mod+KeyK',
+      },
+    }
+
+    rtlRender(
+      <SettingsContext.Provider
+        value={{ settings, saveError: null, update: vi.fn() }}
+      >
+        <WorkspaceView />
+      </SettingsContext.Provider>
+    )
+
+    await waitFor(() => {
+      expect(setCommandPaletteBindings).toHaveBeenCalledWith({
+        palette: 'Mod+KeyP',
+        leader: 'Mod+KeyK',
+      })
+    })
+    expect(setCommandPaletteBinding).not.toHaveBeenCalled()
+  })
 
   test(':new command creates a new session', async () => {
     const user = userEvent.setup()

--- a/src/features/workspace/WorkspaceView.notifyInfo.test.tsx
+++ b/src/features/workspace/WorkspaceView.notifyInfo.test.tsx
@@ -62,7 +62,12 @@ describe('WorkspaceView × notifyInfo banner', () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     act(() => {
       document.dispatchEvent(
-        new KeyboardEvent('keydown', { key: ';', ctrlKey: true })
+        new KeyboardEvent('keydown', {
+          key: ';',
+          code: 'Semicolon',
+          ctrlKey: true,
+          bubbles: true,
+        })
       )
     })
     await screen.findByRole('dialog')

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -2040,6 +2040,7 @@ describe('WorkspaceView', () => {
       document.dispatchEvent(
         new KeyboardEvent('keydown', {
           key: ';',
+          code: 'Semicolon',
           ctrlKey: true,
           bubbles: true,
         })

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1451,10 +1451,13 @@ export const WorkspaceView = (): ReactElement => {
     [matches]
   )
 
+  const paletteToken = formatChord(paletteBinding)
+  const leaderToken = formatChord(paletteLeaderBinding)
+
   useEffect(() => {
     const bindings = {
-      palette: formatChord(paletteBinding),
-      leader: formatChord(paletteLeaderBinding),
+      palette: paletteToken,
+      leader: leaderToken,
     }
     const bridge = window.vimeflow
 
@@ -1465,7 +1468,7 @@ export const WorkspaceView = (): ReactElement => {
     }
 
     bridge?.setCommandPaletteBinding?.(bindings.leader)
-  }, [paletteBinding, paletteLeaderBinding])
+  }, [paletteToken, leaderToken])
 
   const settingsDialog = useSettingsDialog()
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -71,6 +71,8 @@ import {
 import { useDockShortcuts } from './hooks/useDockShortcuts'
 import { useDockToggleShortcut } from './hooks/useDockToggleShortcut'
 import { useKeybindings } from '../keymap/useKeybindings'
+import { formatChord } from '../keymap/chord'
+import { chordToShortcutInput } from '../keymap/displayKey'
 import { useSidebarShortcut } from './hooks/useSidebarShortcut'
 import { useNewSessionShortcut } from './hooks/useNewSessionShortcut'
 import { useSidebarTabShortcut } from './hooks/useSidebarTabShortcut'
@@ -1428,15 +1430,50 @@ export const WorkspaceView = (): ReactElement => {
     ]
   )
 
+  // Keybinding registry matcher — keeps the palette and migrated workspace
+  // shortcuts aligned with persisted overrides.
+  const { bindingFor, matches } = useKeybindings()
+  const paletteBinding = bindingFor('palette')
+  const paletteLeaderBinding = bindingFor('palette-leader')
+
+  const paletteShortcut = useMemo(
+    () => chordToShortcutInput(paletteBinding),
+    [paletteBinding]
+  )
+
+  const isPaletteToggleEvent = useCallback(
+    (event: KeyboardEvent): boolean => matches(event, 'palette'),
+    [matches]
+  )
+
+  const isPaletteLeaderEvent = useCallback(
+    (event: KeyboardEvent): boolean => matches(event, 'palette-leader'),
+    [matches]
+  )
+
+  useEffect(() => {
+    const bindings = {
+      palette: formatChord(paletteBinding),
+      leader: formatChord(paletteLeaderBinding),
+    }
+    const bridge = window.vimeflow
+
+    if (bridge?.setCommandPaletteBindings) {
+      bridge.setCommandPaletteBindings(bindings)
+
+      return
+    }
+
+    bridge?.setCommandPaletteBinding?.(bindings.leader)
+  }, [paletteBinding, paletteLeaderBinding])
+
   const settingsDialog = useSettingsDialog()
 
   const commandPalette = useCommandPalette(workspaceCommands, {
     enabled: !showUnsavedDialog && !settingsDialog.isOpen,
+    isLeaderEvent: isPaletteLeaderEvent,
+    isPaletteToggleEvent,
   })
-
-  // Keybinding registry matcher — threaded into the migrated shortcut hooks so a
-  // persisted override changes the live shortcut (VIM-136 SP1).
-  const { matches } = useKeybindings()
 
   usePaneShortcuts({
     sessions,
@@ -2457,6 +2494,7 @@ export const WorkspaceView = (): ReactElement => {
           session={statusBarSession}
           contextPct={statusBarContextPct}
           onOpenPalette={commandPalette.open}
+          paletteShortcut={paletteShortcut}
           dockOpen={isDockOpen}
           onToggleDock={handleToggleDock}
           burnerCount={runningBurnerPaneKeys.size}

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -14,6 +14,13 @@ import type {
  */
 export type UnlistenFn = () => void
 
+export type CommandPaletteShortcutSource = 'palette' | 'leader'
+
+export interface CommandPaletteBindingSync {
+  palette: string
+  leader: string
+}
+
 export interface SettingsBridge {
   load: () => Promise<AppSettings>
   save: (settings: AppSettings) => Promise<void>
@@ -34,8 +41,12 @@ export interface BackendApi {
     callback: (payload: T) => void
   ) => Promise<UnlistenFn>
 
-  onCommandPaletteToggle?: (callback: () => void) => UnlistenFn
+  onCommandPaletteToggle?: (
+    callback: (source?: CommandPaletteShortcutSource) => void
+  ) => UnlistenFn
   setKeymapCaptureActive?: (active: boolean) => void
+  setCommandPaletteBinding?: (binding: string) => void
+  setCommandPaletteBindings?: (bindings: CommandPaletteBindingSync) => void
 
   settings?: SettingsBridge
   aliases?: AliasesBridge
@@ -246,7 +257,7 @@ export const listen = async <T>(
 }
 
 export const listenCommandPaletteToggle = (
-  callback: () => void
+  callback: (source?: CommandPaletteShortcutSource) => void
 ): UnlistenFn => {
   if (typeof window === 'undefined') {
     return noop


### PR DESCRIPTION
## Summary

- Make the command-palette leader (`palette`) rebindable in the keymap catalog and settings UI.
- Route renderer palette toggles through the keybinding registry matcher and sync the resolved binding to Electron.
- Teach the main-process, BrowserView, and focused Linux global-shortcut paths to use the synced palette binding.
- Keep the status-bar palette shortcut chip aligned with the live resolved binding.

## Validation

- `npm test`
- `npm run test -- src/features/keymap src/features/command-palette/hooks/useCommandPalette.test.ts src/features/command-palette/hooks/useCommandPalette.staleClosure.test.ts src/features/command-palette/shortcutConfig.test.ts src/components/StatusBar.test.tsx electron/command-palette-shortcut.test.ts electron/preload.test.ts electron/browser-pane.test.ts src/features/workspace/WorkspaceView.command-palette.test.tsx src/features/workspace/WorkspaceView.test.tsx src/features/workspace/WorkspaceView.notifyInfo.test.tsx`
- `npm run type-check:generated`
- `npm run lint`
- `npx prettier --check electron/browser-pane.ts electron/command-palette-shortcut.test.ts electron/command-palette-shortcut.ts electron/ipc-channels.ts electron/main.ts electron/preload.test.ts electron/preload.ts src/components/StatusBar.test.tsx src/components/StatusBar.tsx src/features/command-palette/hooks/useCommandPalette.test.ts src/features/command-palette/hooks/useCommandPalette.ts src/features/command-palette/registry/types.ts src/features/keymap/catalog.test.ts src/features/keymap/catalog.ts src/features/keymap/resolve.test.ts src/features/keymap/useKeybindings.test.tsx src/features/workspace/WorkspaceView.command-palette.test.tsx src/features/workspace/WorkspaceView.notifyInfo.test.tsx src/features/workspace/WorkspaceView.test.tsx src/features/workspace/WorkspaceView.tsx src/lib/backend.ts`
- `npx prettier --check src/features/settings/components/panes/KeymapPane.test.tsx`
- `git diff --check`

Refs VIM-147