### PR TITLE
test(terminal): add Ghostty smoke gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ coverage/
 .nyc_output/
 playwright-report/
 test-results/
+tests/e2e/.wdio-cache/
 
 # Environment
 .env

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,8 +54,8 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 64       | 30   | 2026-06-12   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 7        | 2    | 2026-06-17   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 8        | 3    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |
@@ -89,4 +89,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
-| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 1        | 0    | 2026-06-13   |
+| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 2        | 1    | 2026-06-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,7 +55,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 8        | 3    | 2026-06-18   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 9        | 4    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -2,8 +2,8 @@
 id: dead-code
 category: code-quality
 created: 2026-06-13
-last_updated: 2026-06-13
-ref_count: 0
+last_updated: 2026-06-18
+ref_count: 1
 ---
 
 # Dead Code
@@ -25,3 +25,12 @@ code and should be removed.
 - **Finding:** All entries in `contextMenuActions` carried explicit `id` fields, so the early `return action.id` made the subsequent `switch (action.label)` block unreachable. The dead code risked misleading maintainers into thinking new actions could rely on label matching.
 - **Fix:** Removed the unreachable `switch` fallback; `actionIdFor` now returns `action.id ?? null` directly.
 - **Commit:** see `git blame` / `git log` on this line
+
+### 2. VITE_TERMINAL_RENDERER assignment in E2E onPrepare is dead code
+
+- **Source:** github-claude | PR #524 round 1 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `tests/e2e/ghostty/wdio.conf.ts` L31-34
+- **Finding:** `process.env.VITE_TERMINAL_RENDERER = 'ghostty'` in the WDIO `onPrepare` hook has no effect on the Electron renderer because `VITE_*` variables are baked into the renderer bundle by Vite at build time. The same variable is already injected by the `test:e2e:ghostty:run` script via `cross-env`, making the assignment doubly redundant.
+- **Fix:** Removed the `VITE_TERMINAL_RENDERER` assignment from `onPrepare`; kept `VIMEFLOW_DISABLE_AGENT_DETECTION`, which is a genuine runtime env var.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -3,7 +3,7 @@ id: terminal-control-sequence-handling
 category: terminal
 created: 2026-06-17
 last_updated: 2026-06-18
-ref_count: 3
+ref_count: 4
 ---
 
 # Terminal Control Sequence Handling
@@ -90,4 +90,13 @@ all required state through pure display-state helpers.
 - **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L284
 - **Finding:** The parser emitted the same clear-screen sentinel for both `CSI 2 J` (erase whole display) and `CSI 3 J` (erase scrollback/saved lines). Because `TerminalDisplayBuffer` drops all buffered text on that sentinel, a program sending only `CSI 3 J` lost the currently visible prompt/output even though mode 3 should leave visible cells intact.
 - **Fix:** Narrowed the clear-screen sentinel branch to only `mode === 2`, so `CSI 3 J` no longer clears the visible buffer.
+- **Commit:** same commit as this entry
+
+### 9. CSI D/C/G explicit zero count is treated as no movement
+
+- **Source:** github-claude | PR #524 round 2 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L288-325
+- **Finding:** The parser passed `parseCsiIntegerParameter` results directly to sentinel emission for `CSI D`, `CSI C`, and `CSI G`. For cursor movement/count parameters, an omitted value and an explicit `0` should both behave as the default count/column `1`. The original code emitted no D/C movement for `CSI 0D`/`CSI 0C` and only a carriage return for `CSI 0G`, which corrupts progress or prompt redraw output.
+- **Fix:** Normalized parsed zero values to `1` in the D, C, and G branches before emitting cursor-left/cursor-right/carriage-return sentinels, and added a regression test that asserts `CSI 0D`, `CSI 0C`, and `CSI 0G` each produce the same result as the default value.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -2,8 +2,8 @@
 id: terminal-control-sequence-handling
 category: terminal
 created: 2026-06-17
-last_updated: 2026-06-17
-ref_count: 2
+last_updated: 2026-06-18
+ref_count: 3
 ---
 
 # Terminal Control Sequence Handling
@@ -81,4 +81,13 @@ all required state through pure display-state helpers.
 - **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L16
 - **Finding:** The in-band erase-line markers used U+E000 through U+E002, which are in the same BMP Private Use Area commonly used by terminal icon fonts. A real prompt glyph at one of those codepoints passed through the parser as visible text and was then consumed by `applyDisplayData` as an erase-line operation.
 - **Fix:** Moved the sentinels to Supplementary Private Use Area codepoints U+F0000, U+F0001, and U+F0002, and added a regression test that writes the legacy sentinel codepoint as visible text and expects it to render unchanged.
+- **Commit:** same commit as this entry
+
+### 8. CSI 3J clear-scrollback was clearing visible text
+
+- **Source:** github-codex-connector | PR #524 round 1 | 2026-06-18
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L284
+- **Finding:** The parser emitted the same clear-screen sentinel for both `CSI 2 J` (erase whole display) and `CSI 3 J` (erase scrollback/saved lines). Because `TerminalDisplayBuffer` drops all buffered text on that sentinel, a program sending only `CSI 3 J` lost the currently visible prompt/output even though mode 3 should leave visible cells intact.
+- **Fix:** Narrowed the clear-screen sentinel branch to only `mode === 2`, so `CSI 3 J` no longer clears the visible buffer.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-14
-ref_count: 31
+last_updated: 2026-06-18
+ref_count: 32
 ---
 
 # Testing Gaps
@@ -638,4 +638,13 @@ filesystem scope restrictions).
 - **File:** `src/features/editor/components/MarkdownReadingView.test.tsx` L226-266
 - **Finding:** The `falls back to execCommand copy` test replaced both `window.navigator.clipboard` and `document.execCommand`, but the `finally` block only restored the clipboard property. The leaked `execCommand` mock persisted in the shared jsdom document for every subsequent test in the file, creating a false-positive risk for any future test that exercised the textarea fallback path without its own mock.
 - **Fix:** Saved the original `document.execCommand` value before overriding it and restored it in the same `finally` block alongside `navigator.clipboard`, mirroring the symmetric cleanup already used by the `installClipboardMock` helper.
+- **Commit:** same commit as this entry
+
+### 64. byteLen off by one in test fixture for renderer-handle disposal
+
+- **Source:** github-claude | PR #524 round 1 | 2026-06-18
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts` L171-177
+- **Finding:** The `continues stripping controls after renderer handle disposal` test hardcoded `byteLen: 15` for a payload that encodes to 16 UTF-8 bytes (`before ESC[0mafter`). The test passed only because `byteLen` was treated as opaque metadata, so it would silently assert the wrong length if the router ever validated it.
+- **Fix:** Replaced the hardcoded value with `new TextEncoder().encode(...).length` so the fixture is consistent with the surrounding tests and proof against future payload edits.
 - **Commit:** same commit as this entry

--- a/package.json
+++ b/package.json
@@ -35,9 +35,13 @@
     "test:e2e:core:run": "cross-env VITE_E2E=1 wdio tests/e2e/core/wdio.conf.ts",
     "test:e2e:terminal:run": "cross-env VITE_E2E=1 wdio tests/e2e/terminal/wdio.conf.ts",
     "test:e2e:agent:run": "cross-env VITE_E2E=1 wdio tests/e2e/agent/wdio.conf.ts",
+    "test:e2e:ghostty:build": "npm run generate:bindings && npm run test:e2e:ghostty:build:generated",
+    "test:e2e:ghostty:build:generated": "tsc -b && cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty vite build --mode electron && cargo build --bin vimeflow-backend --features e2e-test",
+    "test:e2e:ghostty:run": "cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty wdio tests/e2e/ghostty/wdio.conf.ts",
     "test:e2e": "npm run test:e2e:build && npm run test:e2e:core:run",
     "test:e2e:terminal": "npm run test:e2e:build && npm run test:e2e:terminal:run",
     "test:e2e:agent": "npm run test:e2e:build && npm run test:e2e:agent:run",
+    "test:e2e:ghostty": "npm run test:e2e:ghostty:build && npm run test:e2e:ghostty:run",
     "test:e2e:all": "npm run test:e2e:build && npm run test:e2e:core:run && npm run test:e2e:terminal:run && npm run test:e2e:agent:run"
   },
   "keywords": [

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -27,6 +27,9 @@ const encodeBase64 = (bytes: Uint8Array): string => {
 const encodeText = (text: string): string =>
   encodeBase64(new TextEncoder().encode(text))
 
+const ESC = '\x1b'
+const SGR_FINAL = 'm'
+
 const createdTerminals = new Set<ReturnType<typeof createGhosttyTerminal>>()
 
 const createTrackedGhosttyTerminal = (
@@ -137,6 +140,62 @@ describe('ghosttyInstance', () => {
     })
 
     expect(created.viewportReader.readVisibleText()).toBe('bytes win')
+  })
+
+  test('strips zsh title and color controls without app parser subscribers', () => {
+    const created = createTrackedGhosttyTerminal()
+
+    const output =
+      `${ESC}]2;user@host:~/project\x07` +
+      `${ESC}[38;2;243;139;168${SGR_FINAL}` +
+      `feat/ghostty-spike${ESC}[0${SGR_FINAL} % ${ESC}=`
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe(
+      'feat/ghostty-spike % '
+    )
+  })
+
+  test('continues stripping controls after renderer handle disposal', () => {
+    const created = createTrackedGhosttyTerminal()
+    const rendererHandle = created.attachRenderer()
+
+    rendererHandle.dispose()
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(`before ${ESC}[0${SGR_FINAL}after`),
+      offsetStart: 0,
+      byteLen: 15,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe('before after')
+  })
+
+  test('applies clear-screen and cursor movement controls from byte payloads', () => {
+    const created = createTrackedGhosttyTerminal()
+
+    const output =
+      `old prompt\nold output` +
+      `${ESC}[H${ESC}[2J` +
+      `S${ESC}[1DSt${ESC}[2DSta${ESC}[3DStart`
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe('Start')
   })
 
   test('renders invalid byte payloads through the byte path', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -172,7 +172,8 @@ describe('ghosttyInstance', () => {
       text: 'wrong',
       bytesBase64: encodeText(`before ${ESC}[0${SGR_FINAL}after`),
       offsetStart: 0,
-      byteLen: 15,
+      byteLen: new TextEncoder().encode(`before ${ESC}[0${SGR_FINAL}after`)
+        .length,
       phase: 'live',
     })
 

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -1,6 +1,5 @@
 // cspell:ignore ghostty
 import type {
-  TerminalDisposable,
   TerminalFitController,
   TerminalInstance,
   TerminalRendererAdapter,
@@ -23,7 +22,6 @@ export interface GhosttyTerminalOptions {
 
 class GhosttyTerminalModel {
   private readonly parserEngine: TerminalParserEngine
-  private readonly noOpParserDisposable: TerminalDisposable
   readonly terminal: TerminalTextSurface
   readonly parser: TerminalParser
 
@@ -36,13 +34,6 @@ class GhosttyTerminalModel {
       rendererId: GHOSTTY_TERMINAL_RENDERER_ID,
       transformOutput: (data): string =>
         this.parserEngine.parseText(data, null).visibleText,
-    })
-
-    // The Ghostty spike relies on the adapter parser stripping control
-    // sequences from the viewport even before app code subscribes to events.
-    this.noOpParserDisposable = this.parserEngine.parser.onEvent(() => {
-      // Intentionally empty: app-facing consumers subscribe separately through
-      // the exposed parser, while the surface consumes parsed visible text.
     })
   }
 
@@ -72,7 +63,7 @@ class GhosttyTerminalModel {
 
   readonly rendererHandle: TerminalRendererHandle = {
     dispose: (): void => {
-      this.noOpParserDisposable.dispose()
+      // The current Ghostty spike has no renderer addon lifecycle.
     },
   }
 

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
@@ -102,7 +102,7 @@ describe('ghosttyParserEngine', () => {
     const output =
       `${ESC}]2;user@host:~/project\x07` +
       `${ESC}[38;2;243;139;168${SGR_FINAL}` +
-      `feat/ghostty-spike${ESC}[0${SGR_FINAL} % `
+      `feat/ghostty-spike${ESC}[0${SGR_FINAL} % ${ESC}=`
 
     engine.parser.onEvent(handler)
 

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -20,6 +20,7 @@ export class GhosttyControlSequenceParserEngine
   constructor() {
     super({
       capabilities: GHOSTTY_TERMINAL_CAPABILITIES,
+      consumeControlsWithoutSubscribers: true,
     })
   }
 }

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -165,6 +165,25 @@ describe('plainTextInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('done')
   })
 
+  test('applies clear-screen CSI output to the visible buffer', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write('old prompt\nold output')
+    // cspell:disable-next-line
+    created.terminal.write('\x1b[H\x1b[2Jnew prompt')
+
+    expect(created.viewportReader.readVisibleText()).toBe('new prompt')
+  })
+
+  test('rewrites progress output that uses CSI cursor-left movement', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    // cspell:disable-next-line
+    created.terminal.write('S\x1b[1DSt\x1b[2DSta\x1b[3DStart')
+
+    expect(created.viewportReader.readVisibleText()).toBe('Start')
+  })
+
   test('erases from line start to cursor inclusive in erase-line mode 1', () => {
     const created = createTrackedPlainTextTerminal()
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -1,5 +1,4 @@
 import type {
-  TerminalDisposable,
   TerminalFitController,
   TerminalInstance,
   TerminalOutputWriter,
@@ -18,8 +17,8 @@ export { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
 class PlainTextTerminalModel {
   private readonly parserEngine = createControlSequenceTerminalParserEngine({
     capabilities: PLAIN_TEXT_TERMINAL_CAPABILITIES,
+    consumeControlsWithoutSubscribers: true,
   })
-  private readonly noOpParserDisposable: TerminalDisposable
   readonly terminal = new TerminalTextSurface({
     rendererId: PLAIN_TEXT_TERMINAL_RENDERER_ID,
     transformOutput: (data): string =>
@@ -42,17 +41,6 @@ class PlainTextTerminalModel {
     },
   }
 
-  constructor() {
-    // The plain-text renderer relies on the parser stripping control sequences
-    // (and replacing erase-line sequences with sentinels). Subscribing a no-op
-    // handler keeps the parser in stripping mode even when no external consumer
-    // is listening.
-    this.noOpParserDisposable = this.parserEngine.parser.onEvent(() => {
-      // Intentionally empty: visible-text transformation is handled by the
-      // parser, and erase-line sentinels are interpreted by the surface.
-    })
-  }
-
   readonly viewportReader: TerminalViewportReader = {
     readVisibleText: (): string => this.terminal.readVisibleText(),
   }
@@ -65,7 +53,7 @@ class PlainTextTerminalModel {
 
   readonly rendererHandle: TerminalRendererHandle = {
     dispose: (): void => {
-      this.noOpParserDisposable.dispose()
+      // The plain-text surface has no renderer addon lifecycle.
     },
   }
 }

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
@@ -153,6 +153,23 @@ describe('TerminalControlSequenceParser', () => {
     expect(handler).not.toHaveBeenCalled()
   })
 
+  test('treats explicit zero cursor movement counts as the default of one', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    const visible = parser.transformOutput(
+      `abc${ESC}[0DXY${ESC}[0Cz${ESC}[0G!`,
+      null
+    )
+
+    expect(visible).toBe(
+      `abc${getCursorLeftSentinel()}` + `XY${getCursorRightSentinel()}z` + `\r!`
+    )
+    expect(handler).not.toHaveBeenCalled()
+  })
+
   test('reassembles short ESC controls split across output chunks', () => {
     const parser = new TerminalControlSequenceParser()
     const handler = vi.fn()

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test, vi } from 'vitest'
-import { TerminalControlSequenceParser } from './terminalControlParser'
+import {
+  TerminalControlSequenceParser,
+  getClearScreenSentinel,
+  getCursorLeftSentinel,
+  getCursorRightSentinel,
+} from './terminalControlParser'
 
 const ESC = '\x1b'
 const SGR_FINAL = 'm'
@@ -67,6 +72,19 @@ describe('TerminalControlSequenceParser', () => {
     expect(handler).not.toHaveBeenCalled()
   })
 
+  test('strips control sequences without subscribers when configured', () => {
+    const parser = new TerminalControlSequenceParser({
+      consumeControlsWithoutSubscribers: true,
+    })
+
+    const visible = parser.transformOutput(
+      `a${ESC}]2;title\x07${ESC}[38;2;243;139;168${SGR_FINAL}b${ESC}=c`,
+      null
+    )
+
+    expect(visible).toBe('abc')
+  })
+
   test('strips CSI style sequences from visible output', () => {
     const parser = new TerminalControlSequenceParser()
     const handler = vi.fn()
@@ -80,6 +98,69 @@ describe('TerminalControlSequenceParser', () => {
     )
 
     expect(visible).toBe('prompt branch done')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('strips short ESC mode controls from visible output', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    const visible = parser.transformOutput(
+      `prompt ${ESC}=application ${ESC}>normal`,
+      null
+    )
+
+    expect(visible).toBe('prompt application normal')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('strips ESC charset designation controls from visible output', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    const charsetControl = `${ESC}(B`
+
+    const visible = parser.transformOutput(
+      `before ${charsetControl}after`,
+      null
+    )
+
+    expect(visible).toBe('before after')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('preserves clear-screen and cursor movement controls as display sentinels', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    const visible = parser.transformOutput(
+      `old${ESC}[2J` + `abc${ESC}[2DXY${ESC}[Cz${ESC}[3G!`,
+      null
+    )
+
+    expect(visible).toBe(
+      `old${getClearScreenSentinel()}abc` +
+        `${getCursorLeftSentinel()}${getCursorLeftSentinel()}` +
+        `XY${getCursorRightSentinel()}z` +
+        `\r${getCursorRightSentinel()}${getCursorRightSentinel()}!`
+    )
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('reassembles short ESC controls split across output chunks', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    expect(parser.transformOutput('before \x1b', null)).toBe('before ')
+    expect(parser.transformOutput('=after', null)).toBe('after')
     expect(handler).not.toHaveBeenCalled()
   })
 

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -12,11 +12,21 @@ const CSI_PREFIX = `${ESC}[`
 const OSC_PREFIX = `${ESC}]`
 const STRING_TERMINATOR = `${ESC}\\`
 const MAX_PENDING_CONTROL_SEQUENCE_LENGTH = 16_384
+const MAX_REPEATED_DISPLAY_CONTROL_COUNT = 4_096
 
 const ERASE_LINE_SENTINELS = ['\u{F0000}', '\u{F0001}', '\u{F0002}']
+const CLEAR_SCREEN_SENTINEL = '\u{F0003}'
+const CURSOR_LEFT_SENTINEL = '\u{F0004}'
+const CURSOR_RIGHT_SENTINEL = '\u{F0005}'
 
 export const getEraseLineSentinel = (mode: 0 | 1 | 2): string =>
   ERASE_LINE_SENTINELS[mode]
+
+export const getClearScreenSentinel = (): string => CLEAR_SCREEN_SENTINEL
+
+export const getCursorLeftSentinel = (): string => CURSOR_LEFT_SENTINEL
+
+export const getCursorRightSentinel = (): string => CURSOR_RIGHT_SENTINEL
 
 export const getEraseLineModeFromSentinel = (
   character: string
@@ -30,9 +40,22 @@ export const getEraseLineModeFromSentinel = (
   return index as 0 | 1 | 2
 }
 
+export const isClearScreenSentinel = (character: string): boolean =>
+  character === CLEAR_SCREEN_SENTINEL
+
+export const isCursorLeftSentinel = (character: string): boolean =>
+  character === CURSOR_LEFT_SENTINEL
+
+export const isCursorRightSentinel = (character: string): boolean =>
+  character === CURSOR_RIGHT_SENTINEL
+
 interface SequenceTerminator {
   readonly index: number
   readonly length: number
+}
+
+export interface TerminalControlSequenceParserOptions {
+  readonly consumeControlsWithoutSubscribers?: boolean
 }
 
 const createDisposable = (dispose: () => void): TerminalDisposable => ({
@@ -82,6 +105,37 @@ const findCsiTerminator = (
   return null
 }
 
+const isEscIntermediateByte = (char: string): boolean => {
+  const code = char.charCodeAt(0)
+
+  return code >= 0x20 && code <= 0x2f
+}
+
+const isEscFinalByte = (char: string): boolean => {
+  const code = char.charCodeAt(0)
+
+  return code >= 0x30 && code <= 0x7e
+}
+
+const findEscTerminator = (
+  data: string,
+  startIndex: number
+): SequenceTerminator | null => {
+  for (let index = startIndex; index < data.length; index += 1) {
+    const char = data[index] ?? ''
+
+    if (isEscFinalByte(char)) {
+      return { index, length: 1 }
+    }
+
+    if (!isEscIntermediateByte(char)) {
+      return { index, length: 0 }
+    }
+  }
+
+  return null
+}
+
 const parseOscIdentifier = (content: string): string | null => {
   const separatorIndex = content.indexOf(';')
 
@@ -102,9 +156,35 @@ const parseOscPayload = (content: string): string | null => {
   return content.slice(separatorIndex + 1)
 }
 
+const parseCsiIntegerParameter = (
+  content: string,
+  fallback: number
+): number | null => {
+  const firstParameter = content.split(';')[0] ?? ''
+
+  if (firstParameter.length === 0) {
+    return fallback
+  }
+
+  if (!/^\d+$/.test(firstParameter)) {
+    return null
+  }
+
+  return Number(firstParameter)
+}
+
+const repeatDisplayControl = (control: string, count: number): string =>
+  control.repeat(
+    Math.min(Math.max(count, 0), MAX_REPEATED_DISPLAY_CONTROL_COUNT)
+  )
+
 export class TerminalControlSequenceParser implements TerminalParser {
   private readonly handlers = new Set<TerminalParserEventHandler>()
   private pendingControlSequence = ''
+
+  constructor(
+    private readonly options: TerminalControlSequenceParserOptions = {}
+  ) {}
 
   onEvent(handler: TerminalParserEventHandler): TerminalDisposable {
     this.handlers.add(handler)
@@ -118,7 +198,10 @@ export class TerminalControlSequenceParser implements TerminalParser {
     data: string,
     output: TerminalParserOutputContext | null
   ): string {
-    if (this.handlers.size === 0) {
+    if (
+      this.handlers.size === 0 &&
+      !this.options.consumeControlsWithoutSubscribers
+    ) {
       const visible = `${this.pendingControlSequence}${data}`
       this.pendingControlSequence = ''
 
@@ -183,11 +266,61 @@ export class TerminalControlSequenceParser implements TerminalParser {
             sequenceStart + CSI_PREFIX.length,
             terminator.index
           )
-          const parameterMatch = /^(\d*)/.exec(content)
-          const mode = Number(parameterMatch?.[1] ?? '0')
+          const mode = parseCsiIntegerParameter(content, 0)
 
           if (mode === 0 || mode === 1 || mode === 2) {
             visible += getEraseLineSentinel(mode)
+          }
+        }
+
+        if (finalByte === 'J') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const mode = parseCsiIntegerParameter(content, 0)
+
+          if (mode === 2 || mode === 3) {
+            visible += getClearScreenSentinel()
+          }
+        }
+
+        if (finalByte === 'D') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const count = parseCsiIntegerParameter(content, 1)
+
+          if (count !== null) {
+            visible += repeatDisplayControl(getCursorLeftSentinel(), count)
+          }
+        }
+
+        if (finalByte === 'C') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const count = parseCsiIntegerParameter(content, 1)
+
+          if (count !== null) {
+            visible += repeatDisplayControl(getCursorRightSentinel(), count)
+          }
+        }
+
+        if (finalByte === 'G') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const column = parseCsiIntegerParameter(content, 1)
+
+          if (column !== null) {
+            visible += `\r${repeatDisplayControl(
+              getCursorRightSentinel(),
+              column - 1
+            )}`
           }
         }
 
@@ -202,8 +335,14 @@ export class TerminalControlSequenceParser implements TerminalParser {
         break
       }
 
-      visible += ESC
-      cursor = sequenceStart + ESC.length
+      const terminator = findEscTerminator(data, sequenceStart + ESC.length)
+
+      if (!terminator) {
+        this.pendingControlSequence = data.slice(sequenceStart)
+        break
+      }
+
+      cursor = terminator.index + terminator.length
     }
 
     if (

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -280,7 +280,7 @@ export class TerminalControlSequenceParser implements TerminalParser {
           )
           const mode = parseCsiIntegerParameter(content, 0)
 
-          if (mode === 2 || mode === 3) {
+          if (mode === 2) {
             visible += getClearScreenSentinel()
           }
         }

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -293,7 +293,12 @@ export class TerminalControlSequenceParser implements TerminalParser {
           const count = parseCsiIntegerParameter(content, 1)
 
           if (count !== null) {
-            visible += repeatDisplayControl(getCursorLeftSentinel(), count)
+            const normalizedCount = count === 0 ? 1 : count
+
+            visible += repeatDisplayControl(
+              getCursorLeftSentinel(),
+              normalizedCount
+            )
           }
         }
 
@@ -305,7 +310,12 @@ export class TerminalControlSequenceParser implements TerminalParser {
           const count = parseCsiIntegerParameter(content, 1)
 
           if (count !== null) {
-            visible += repeatDisplayControl(getCursorRightSentinel(), count)
+            const normalizedCount = count === 0 ? 1 : count
+
+            visible += repeatDisplayControl(
+              getCursorRightSentinel(),
+              normalizedCount
+            )
           }
         }
 
@@ -317,9 +327,11 @@ export class TerminalControlSequenceParser implements TerminalParser {
           const column = parseCsiIntegerParameter(content, 1)
 
           if (column !== null) {
+            const normalizedColumn = column === 0 ? 1 : column
+
             visible += `\r${repeatDisplayControl(
               getCursorRightSentinel(),
-              column - 1
+              normalizedColumn - 1
             )}`
           }
         }

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest'
-import { getEraseLineSentinel } from './terminalControlParser'
+import {
+  getClearScreenSentinel,
+  getCursorLeftSentinel,
+  getCursorRightSentinel,
+  getEraseLineSentinel,
+} from './terminalControlParser'
 import { TerminalDisplayBuffer } from './terminalDisplayBuffer'
 
 describe('TerminalDisplayBuffer', () => {
@@ -47,6 +52,30 @@ describe('TerminalDisplayBuffer', () => {
     buffer.write('ab\bcd')
 
     expect(buffer.readVisibleText()).toBe('acd')
+  })
+
+  test('moves the output cursor with parser display controls', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('S')
+    buffer.write(getCursorLeftSentinel())
+    buffer.write('St')
+    buffer.write(getCursorLeftSentinel().repeat(2))
+    buffer.write('Started')
+    buffer.write(getCursorRightSentinel())
+    buffer.write('!')
+
+    expect(buffer.readVisibleText()).toBe('Started!')
+  })
+
+  test('clears viewport text when a clear-screen display control arrives', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('old prompt\nold output')
+    buffer.write(getClearScreenSentinel())
+    buffer.write('new prompt')
+
+    expect(buffer.readVisibleText()).toBe('new prompt')
   })
 
   test('clears the current line when an erase-line sentinel arrives', () => {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -1,4 +1,9 @@
-import { getEraseLineModeFromSentinel } from './terminalControlParser'
+import {
+  getEraseLineModeFromSentinel,
+  isClearScreenSentinel,
+  isCursorLeftSentinel,
+  isCursorRightSentinel,
+} from './terminalControlParser'
 
 const DEFAULT_MAX_SCROLLBACK_LINES = 10_000
 
@@ -39,6 +44,26 @@ const findLineEnd = (text: string, cursor: number): number => {
 
 const readCodePointLength = (text: string, cursor: number): number =>
   (text.codePointAt(cursor) ?? 0) > 0xffff ? 2 : 1
+
+const readPreviousCodePointLength = (text: string, cursor: number): number => {
+  if (cursor <= 0) {
+    return 0
+  }
+
+  const previous = text.charCodeAt(cursor - 1)
+  const beforePrevious = cursor >= 2 ? text.charCodeAt(cursor - 2) : 0
+
+  if (
+    previous >= 0xdc00 &&
+    previous <= 0xdfff &&
+    beforePrevious >= 0xd800 &&
+    beforePrevious <= 0xdbff
+  ) {
+    return 2
+  }
+
+  return 1
+}
 
 const writeDisplayCharacter = (
   text: string,
@@ -110,6 +135,31 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
       )
       text = nextState.text
       cursor = nextState.cursor
+      pendingCr = false
+      continue
+    }
+
+    if (isClearScreenSentinel(character)) {
+      text = ''
+      cursor = 0
+      pendingCr = false
+      continue
+    }
+
+    if (isCursorLeftSentinel(character)) {
+      cursor = Math.max(
+        findLineStart(text, cursor),
+        cursor - readPreviousCodePointLength(text, cursor)
+      )
+      pendingCr = false
+      continue
+    }
+
+    if (isCursorRightSentinel(character)) {
+      cursor = Math.min(
+        findLineEnd(text, cursor),
+        cursor + readCodePointLength(text, cursor)
+      )
       pendingCr = false
       continue
     }

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -16,6 +16,7 @@ export type TerminalParserEngineInputMode = TerminalOutputInputMode
 
 export interface TerminalParserEngineOptions {
   readonly capabilities: TerminalRendererCapabilities
+  readonly consumeControlsWithoutSubscribers?: boolean
 }
 
 export interface TerminalParserEngine {
@@ -39,11 +40,15 @@ const outputContextFromChunk = (
 
 export class TerminalControlSequenceParserEngine implements TerminalParserEngine {
   readonly capabilities: TerminalRendererCapabilities
-  readonly parser = new TerminalControlSequenceParser()
+  readonly parser: TerminalControlSequenceParser
   private readonly outputRouter: TerminalOutputPayloadRouter
 
   constructor(options: TerminalParserEngineOptions) {
     this.capabilities = options.capabilities
+    this.parser = new TerminalControlSequenceParser({
+      consumeControlsWithoutSubscribers:
+        options.consumeControlsWithoutSubscribers,
+    })
     this.outputRouter = new TerminalOutputPayloadRouter(options.capabilities)
   }
 

--- a/src/lib/e2e-bridge.test.ts
+++ b/src/lib/e2e-bridge.test.ts
@@ -1,6 +1,6 @@
 // cspell:ignore vsplit
-import { describe, test, expect, beforeEach } from 'vitest'
-import { readPaneBuffer } from './e2e-bridge'
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { readPaneBuffer, writeOutputToVisibleTerminal } from './e2e-bridge'
 import { terminalCache } from '../features/terminal/terminalRegistry'
 
 type CacheEntry = ReturnType<typeof terminalCache.get>
@@ -20,6 +20,7 @@ const makeMockEntry = (rows: readonly string[]): CacheEntry => {
 
   return {
     terminal: { dispose: (): void => undefined },
+    output: { writeOutput: vi.fn() },
     fitController: { fit: (): void => undefined },
     viewportReader,
   } as unknown as CacheEntry
@@ -76,6 +77,7 @@ const buildSessionWrapper = (
 
 describe('readPaneBuffer', () => {
   beforeEach(() => {
+    document.body.innerHTML = ''
     terminalCache.clear()
   })
 
@@ -187,5 +189,39 @@ describe('readPaneBuffer', () => {
     const wrapper = buildSessionWrapper([''], 0)
 
     expect(readPaneBuffer(wrapper)).toBe('')
+  })
+
+  test('writes output chunks to the visible terminal renderer', () => {
+    const wrapper = buildSessionWrapper([''], 0)
+    wrapper.getBoundingClientRect = (): DOMRect =>
+      ({
+        bottom: 24,
+        height: 24,
+        left: 0,
+        right: 80,
+        top: 0,
+        width: 80,
+        x: 0,
+        y: 0,
+        toJSON: (): Record<string, never> => ({}),
+      }) as DOMRect
+
+    const entry = makeMockEntry([])
+
+    terminalCache.set('pty-0', entry!)
+    document.body.append(wrapper)
+
+    expect(writeOutputToVisibleTerminal('hello')).toBe(true)
+    expect(entry?.output.writeOutput).toHaveBeenCalledWith({
+      text: 'hello',
+      bytesBase64: 'aGVsbG8=',
+      offsetStart: expect.any(Number),
+      byteLen: 5,
+      phase: 'live',
+    })
+  })
+
+  test('does not write output when no visible terminal is mounted', () => {
+    expect(writeOutputToVisibleTerminal('hello')).toBe(false)
   })
 })

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -3,11 +3,22 @@ import { getAllPtySessionIds } from '../features/terminal/ptySessionMap'
 import { terminalCache } from '../features/terminal/terminalRegistry'
 
 const LEGACY_XTERM_ROWS_SELECTOR = '.xterm-rows'
+let e2eOutputOffset = 0
 
 const isVisible = (el: HTMLElement): boolean => {
   const r = el.getBoundingClientRect()
 
   return r.width > 0 && r.height > 0
+}
+
+const encodeBase64 = (bytes: Uint8Array): string => {
+  let binary = ''
+
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+
+  return btoa(binary)
 }
 
 // terminalCache is keyed by `pane.ptyId` (Body's `sessionId` prop). Find Body's `data-pty-id` descendant; fall back to the container's own data-pty-id when callers pass it directly.
@@ -124,6 +135,37 @@ const getVisibleSessionId = (): string | null => {
   return pane?.dataset.sessionId ?? null
 }
 
+export const writeOutputToVisibleTerminal = (data: string): boolean => {
+  const pane = findActivePane()
+  if (!pane) {
+    return false
+  }
+
+  const sessionId = resolveCacheKey(pane)
+  if (!sessionId) {
+    return false
+  }
+
+  const entry = terminalCache.get(sessionId)
+  if (!entry) {
+    return false
+  }
+
+  const bytes = new TextEncoder().encode(data)
+  const offsetStart = e2eOutputOffset
+  e2eOutputOffset += bytes.length
+
+  entry.output.writeOutput({
+    text: data,
+    bytesBase64: encodeBase64(bytes),
+    offsetStart,
+    byteLen: bytes.length,
+    phase: 'live',
+  })
+
+  return true
+}
+
 if (import.meta.env.VITE_E2E) {
   window.__VIMEFLOW_E2E__ = {
     getTerminalBuffer: readVisibleTerminalBuffer,
@@ -132,5 +174,6 @@ if (import.meta.env.VITE_E2E) {
     getActiveSessionIds: getAllPtySessionIds,
     listActivePtySessions: async (): Promise<string[]> =>
       invoke<string[]>('list_active_pty_sessions'),
+    writeOutputToVisibleTerminal,
   }
 }

--- a/src/types/e2e.d.ts
+++ b/src/types/e2e.d.ts
@@ -8,6 +8,7 @@ declare global {
       getVisibleSessionId(): string | null
       getActiveSessionIds(): string[]
       listActivePtySessions(): Promise<string[]>
+      writeOutputToVisibleTerminal(data: string): boolean
     }
   }
 }

--- a/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
+++ b/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
@@ -1,0 +1,90 @@
+// cspell:ignore ghostty
+const ESCAPE_SEQUENCE_TIMEOUT_MS = 15_000
+
+const waitForE2eBridge = async (): Promise<void> => {
+  await browser
+    .waitUntil(
+      async () =>
+        await browser.execute(
+          () => typeof window.__VIMEFLOW_E2E__ !== 'undefined'
+        ),
+      { timeout: 20_000, interval: 250 }
+    )
+    .catch(() => {
+      throw new Error(
+        'window.__VIMEFLOW_E2E__ missing; rebuild with VITE_E2E=1'
+      )
+    })
+}
+
+const writeOutputToVisibleTerminal = async (data: string): Promise<void> => {
+  const didWrite = await browser.execute(
+    (payload: string) =>
+      window.__VIMEFLOW_E2E__?.writeOutputToVisibleTerminal(payload) ?? false,
+    data
+  )
+
+  if (!didWrite) {
+    throw new Error('visible terminal renderer was unavailable for e2e output')
+  }
+}
+
+const readTerminalBuffer = async (): Promise<string> =>
+  browser.execute(() => window.__VIMEFLOW_E2E__?.getTerminalBuffer() ?? '')
+
+describe('Ghostty renderer smoke', () => {
+  before(async () => {
+    await waitForE2eBridge()
+  })
+
+  it('boots the Ghostty adapter and strips zsh-style OSC/CSI controls', async () => {
+    const pane = await $('[data-testid="terminal-pane"]')
+    await pane.waitForDisplayed({ timeout: 20_000 })
+
+    await browser.waitUntil(
+      async () =>
+        await browser.execute(
+          () =>
+            document.querySelector('[data-terminal-renderer="ghostty"]') !==
+            null
+        ),
+      {
+        timeout: 20_000,
+        timeoutMsg:
+          'Ghostty renderer root was not mounted; rebuild with VITE_TERMINAL_RENDERER=ghostty',
+      }
+    )
+
+    await browser.waitUntil(
+      async () => (await readTerminalBuffer()).trim().length > 0,
+      { timeout: 20_000, timeoutMsg: 'Ghostty PTY never produced a prompt' }
+    )
+
+    const marker = `GHOSTTY_E2E_${Date.now()}`
+    const progressText = 'Start'
+    const progressRewrite = 'S\x1b[1DSt\x1b[2DSta\x1b[3DStart'
+
+    await writeOutputToVisibleTerminal(
+      `\x1b[H\x1b[2J${progressRewrite} ` +
+        `\x1b]2;ghostty-e2e\x07\x1b[38;2;243;139;168m${marker}\x1b[0m\n`
+    )
+
+    await browser.waitUntil(
+      async () => (await readTerminalBuffer()).includes(marker),
+      {
+        timeout: ESCAPE_SEQUENCE_TIMEOUT_MS,
+        timeoutMsg: `Ghostty marker ${marker} never appeared in the terminal buffer`,
+      }
+    )
+
+    const buffer = await readTerminalBuffer()
+
+    expect(buffer).toContain(marker)
+    expect(buffer).toContain(`${progressText} ${marker}`)
+    expect(buffer).not.toContain('SStSta')
+    expect(buffer).not.toContain('\x1b')
+    expect(buffer).not.toContain(']2;ghostty-e2e')
+    expect(buffer).not.toContain('[38;2;243;139;168m')
+    expect(buffer).not.toContain('[0m')
+  })
+})

--- a/tests/e2e/ghostty/wdio.conf.ts
+++ b/tests/e2e/ghostty/wdio.conf.ts
@@ -1,0 +1,55 @@
+// cspell:ignore ghostty
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  appArgs,
+  appEntryPoint,
+  cleanupUserDataDirs,
+  injectFreshUserDataDir,
+} from '../shared/electron-app.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const cacheDir = path.resolve(
+  process.env.RUNNER_TEMP ?? path.resolve(__dirname, '..', '.wdio-cache'),
+  'ghostty'
+)
+
+export const config: WebdriverIO.Config = {
+  runner: 'local',
+  framework: 'mocha',
+  reporters: ['spec'],
+  cacheDir,
+
+  specs: [path.resolve(__dirname, 'specs/**/*.spec.ts')],
+  maxInstances: 1,
+  maxInstancesPerCapability: 1,
+
+  tsConfigPath: path.resolve(__dirname, '../tsconfig.json'),
+
+  services: ['electron'],
+
+  onPrepare: () => {
+    process.env.VIMEFLOW_DISABLE_AGENT_DETECTION = '1'
+    process.env.VITE_TERMINAL_RENDERER = 'ghostty'
+  },
+
+  beforeSession: (_config, capabilities) => {
+    injectFreshUserDataDir(capabilities as WebdriverIO.Capabilities)
+  },
+  afterSession: () => {
+    cleanupUserDataDirs()
+  },
+
+  capabilities: [
+    {
+      browserName: 'electron',
+      'wdio:electronServiceOptions': {
+        appEntryPoint,
+        appArgs,
+      },
+    },
+  ],
+
+  waitforTimeout: 20_000,
+  mochaOpts: { ui: 'bdd', timeout: 60_000 },
+}

--- a/tests/e2e/ghostty/wdio.conf.ts
+++ b/tests/e2e/ghostty/wdio.conf.ts
@@ -30,7 +30,6 @@ export const config: WebdriverIO.Config = {
 
   onPrepare: () => {
     process.env.VIMEFLOW_DISABLE_AGENT_DETECTION = '1'
-    process.env.VITE_TERMINAL_RENDERER = 'ghostty'
   },
 
   beforeSession: (_config, capabilities) => {


### PR DESCRIPTION
## Summary

- Add an opt-in Ghostty WDIO smoke suite built with `VITE_TERMINAL_RENDERER=ghostty`.
- Make Ghostty/plain-text control consumption explicit instead of relying on hidden no-op parser subscriptions.
- Preserve lightweight display semantics for clear-screen and cursor movement so progress output does not accumulate as visible noise.
- Add an E2E-only renderer output injection bridge for deterministic Ghostty adapter smoke coverage.

## Notes

This does not solve full renderer fidelity yet. Cursor rendering, SGR color/style support, and icon/width behavior remain follow-up Ghostty renderer work and are tracked in Linear `VIM-139`.

## Verification

- `npm run test:e2e:ghostty`
- `npx vitest run src/features/terminal src/lib/e2e-bridge.test.ts`
- `npx tsc -b --pretty false`
- `npx tsc -p tests/e2e/tsconfig.json --pretty false`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `git diff --check`
- Pre-push hook: `npm test`