### PR TITLE
feat(terminal): add grid3x2 pane layout

### DIFF
--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -645,7 +645,8 @@ pub(crate) fn kill_pty_inner(
                         Some("single") => count == 1,
                         Some("vsplit") | Some("hsplit") => count == 2,
                         Some("threeRight") => count == 3,
-                        Some("quad") => count >= 4,
+                        Some("quad") => count == 4,
+                        Some("grid3x2") => count >= 5,
                         _ => false,
                     };
                     if compatible {
@@ -655,7 +656,8 @@ pub(crate) fn kill_pty_inner(
                             1 => Some("single".to_string()),
                             2 => Some("vsplit".to_string()),
                             3 => Some("threeRight".to_string()),
-                            _ => Some("quad".to_string()),
+                            4 => Some("quad".to_string()),
+                            _ => Some("grid3x2".to_string()),
                         }
                     }
                 };
@@ -2320,6 +2322,78 @@ mod tests {
         assert!(!d.active);
 
         for id in ["pty-a", "pty-b", "pty-d"] {
+            let _ = state.remove(&id.to_string());
+        }
+    }
+
+    #[tokio::test]
+    async fn kill_pty_keeps_grid3x2_layout_when_five_siblings_remain() {
+        let (state, cache, events, _temp_dir) = create_test_state_with_cache();
+
+        let cwd = std::env::current_dir()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+
+        for id in ["pty-a", "pty-b", "pty-c", "pty-d", "pty-e", "pty-f"] {
+            spawn_pty_inner(
+                state.clone(),
+                cache.clone(),
+                events.clone(),
+                SpawnPtyRequest {
+                    session_id: id.into(),
+                    cwd: cwd.clone(),
+                    shell: None,
+                    env: None,
+                    enable_agent_bridge: false,
+                    ephemeral: false,
+                },
+            )
+            .await
+            .expect("spawn should succeed");
+        }
+
+        set_workspace_sessions_inner(
+            &cache,
+            SetWorkspaceSessionsRequest {
+                sessions: vec![WorkspaceSessionSnapshot {
+                    id: "ws-grid".into(),
+                    layout: "grid3x2".into(),
+                    working_directory: Some(cwd.clone()),
+                    panes: vec![
+                        WorkspacePaneSnapshot { pty_id: "pty-a".into(), pane_id: "p0".into(), pane_index: 0, agent_type: "generic".into(), active: true },
+                        WorkspacePaneSnapshot { pty_id: "pty-b".into(), pane_id: "p1".into(), pane_index: 1, agent_type: "generic".into(), active: false },
+                        WorkspacePaneSnapshot { pty_id: "pty-c".into(), pane_id: "p2".into(), pane_index: 2, agent_type: "generic".into(), active: false },
+                        WorkspacePaneSnapshot { pty_id: "pty-d".into(), pane_id: "p3".into(), pane_index: 3, agent_type: "generic".into(), active: false },
+                        WorkspacePaneSnapshot { pty_id: "pty-e".into(), pane_id: "p4".into(), pane_index: 4, agent_type: "generic".into(), active: false },
+                        WorkspacePaneSnapshot { pty_id: "pty-f".into(), pane_id: "p5".into(), pane_index: 5, agent_type: "generic".into(), active: false },
+                    ],
+                }],
+            },
+        )
+        .expect("set_workspace_sessions should succeed");
+
+        kill_pty_inner(
+            &state,
+            &cache,
+            KillPtyRequest {
+                session_id: "pty-c".into(),
+            },
+        )
+        .expect("kill_pty should succeed");
+
+        let snap = cache.snapshot();
+        let survivors = ["pty-a", "pty-b", "pty-d", "pty-e", "pty-f"];
+
+        for (idx, id) in survivors.iter().enumerate() {
+            let grouping = snap.groupings.get(*id).expect("survivor grouping");
+            assert_eq!(grouping.layout, "grid3x2");
+            assert_eq!(grouping.workspace_session_id, "ws-grid");
+            assert_eq!(grouping.pane_index, idx as u32);
+            assert_eq!(grouping.pane_id, format!("p{}", idx));
+        }
+
+        for id in ["pty-a", "pty-b", "pty-d", "pty-e", "pty-f"] {
             let _ = state.remove(&id.to_string());
         }
     }

--- a/crates/backend/src/terminal/workspace_layout.rs
+++ b/crates/backend/src/terminal/workspace_layout.rs
@@ -94,7 +94,7 @@ const DEFAULT_BROWSER_URL: &str = "https://www.google.com/";
 // Mirrors the spawn-path session cap (`commands.rs` try_insert(..., 64)) so a
 // valid full workspace is never treated as malformed and partly dropped.
 const MAX_SESSIONS: usize = 64;
-const MAX_PANES: usize = 4; // quad capacity
+const MAX_PANES: usize = 6; // grid3x2 capacity
 const MAX_TABS: usize = 50;
 const MAX_HISTORY: usize = 100;
 const MAX_URL_LEN: usize = 4096;
@@ -107,6 +107,7 @@ fn layout_capacity(layout: &str) -> Option<usize> {
         "vsplit" | "hsplit" => Some(2),
         "threeRight" => Some(3),
         "quad" => Some(4),
+        "grid3x2" => Some(6),
         _ => None,
     }
 }
@@ -116,7 +117,8 @@ fn layout_for_count(n: usize) -> &'static str {
         0 | 1 => "single",
         2 => "vsplit",
         3 => "threeRight",
-        _ => "quad",
+        4 => "quad",
+        _ => "grid3x2",
     }
 }
 
@@ -246,7 +248,7 @@ pub fn repair_workspace_layout(
             continue; // session emptied by repair → drop (floor: ≥1 pane)
         }
 
-        // Layout: unknown → smallest fitting; widen to fit the pane count, cap quad.
+        // Layout: unknown → smallest fitting; widen to fit the pane count, cap grid3x2.
         let mut layout = str_field(rs, "layout")
             .filter(|l| layout_capacity(l).is_some())
             .unwrap_or_else(|| layout_for_count(panes.len()).to_string());
@@ -794,7 +796,7 @@ mod tests {
     }
 
     #[test]
-    fn widens_layout_and_drops_panes_beyond_quad() {
+    fn widens_layout_and_preserves_panes_up_to_grid3x2() {
         let panes: Vec<_> = (0..6)
             .map(|i| json!({ "kind": "shell", "paneId": format!("p{i}"), "paneIndex": i, "active": i == 0, "ptyId": format!("pty{i}"), "cwd": "/", "agentType": "generic" }))
             .collect();
@@ -803,8 +805,8 @@ mod tests {
             "proj",
             "/",
         );
-        assert_eq!(store.sessions[0].panes.len(), 4); // dropped beyond quad
-        assert_eq!(store.sessions[0].layout, "quad"); // widened
+        assert_eq!(store.sessions[0].panes.len(), 6); // preserved up to grid3x2
+        assert_eq!(store.sessions[0].layout, "grid3x2"); // widened
     }
 
     #[test]
@@ -1025,22 +1027,22 @@ mod tests {
     }
 
     #[test]
-    fn active_pane_beyond_quad_still_leaves_exactly_one_active() {
-        let panes: Vec<_> = (0..6)
-            .map(|i| json!({ "kind": "shell", "paneId": format!("p{i}"), "paneIndex": i, "active": i == 5, "ptyId": format!("pty{i}"), "cwd": "/", "agentType": "generic" }))
+    fn active_pane_beyond_grid3x2_still_leaves_exactly_one_active() {
+        let panes: Vec<_> = (0..8)
+            .map(|i| json!({ "kind": "shell", "paneId": format!("p{i}"), "paneIndex": i, "active": i == 7, "ptyId": format!("pty{i}"), "cwd": "/", "agentType": "generic" }))
             .collect();
         let store = repair_workspace_layout(
             json!({ "version": 1, "sessions": [{ "id": "s", "layout": "single", "active": true, "panes": panes }] }),
             "proj",
             "/",
         );
-        assert_eq!(store.sessions[0].panes.len(), 4); // truncated to quad
+        assert_eq!(store.sessions[0].panes.len(), 6); // truncated to grid3x2
         let actives = store.sessions[0]
             .panes
             .iter()
             .filter(|p| pane_active(p))
             .count();
-        assert_eq!(actives, 1); // exactly one, never zero (the beyond-quad active was truncated)
+        assert_eq!(actives, 1); // exactly one, never zero (the beyond-grid3x2 active was truncated)
     }
 
     #[test]
@@ -1193,20 +1195,20 @@ mod tests {
 
     #[test]
     fn truncated_pane_does_not_poison_pty_id() {
-        let panes: Vec<_> = (0..5)
+        let panes: Vec<_> = (0..7)
             .map(|i| json!({ "kind": "shell", "paneId": format!("p{i}"), "paneIndex": i, "active": i == 0, "ptyId": format!("pty{i}"), "cwd": "/", "agentType": "generic" }))
             .collect();
         let store = repair_workspace_layout(
             json!({ "version": 1, "sessions": [
-                { "id": "s1", "layout": "quad", "active": true, "panes": panes },
-                // reuses pty4 (the 5th pane of s1, dropped by the quad cap) → must be KEPT
-                { "id": "s2", "layout": "single", "active": false, "panes": [{ "kind": "shell", "paneId": "p0", "paneIndex": 0, "active": true, "ptyId": "pty4", "cwd": "/", "agentType": "generic" }] } ] }),
+                { "id": "s1", "layout": "grid3x2", "active": true, "panes": panes },
+                // reuses pty6 (the 7th pane of s1, dropped by the grid3x2 cap) → must be KEPT
+                { "id": "s2", "layout": "single", "active": false, "panes": [{ "kind": "shell", "paneId": "p0", "paneIndex": 0, "active": true, "ptyId": "pty6", "cwd": "/", "agentType": "generic" }] } ] }),
             "proj",
             "/",
         );
-        assert_eq!(store.sessions[0].panes.len(), 4); // s1 capped to quad
-        assert_eq!(store.sessions.len(), 2); // s2 survived (pty4 un-reserved after the cap)
-        assert_eq!(shell(&store.sessions[1].panes[0]).pty_id, "pty4");
+        assert_eq!(store.sessions[0].panes.len(), 6); // s1 capped to grid3x2
+        assert_eq!(store.sessions.len(), 2); // s2 survived (pty6 un-reserved after the cap)
+        assert_eq!(shell(&store.sessions[1].panes[0]).pty_id, "pty6");
     }
 
     #[test]

--- a/src/features/sessions/types/index.test.ts
+++ b/src/features/sessions/types/index.test.ts
@@ -33,15 +33,16 @@ describe('Session Types', () => {
   })
 
   describe('Session', () => {
-    test('LayoutId enumerates the five canonical layouts', () => {
+    test('LayoutId enumerates the six canonical layouts', () => {
       const ids: LayoutId[] = [
         'single',
         'vsplit',
         'hsplit',
         'threeRight',
         'quad',
+        'grid3x2',
       ]
-      expect(ids).toHaveLength(5)
+      expect(ids).toHaveLength(6)
     })
 
     test('Pane has the documented fields', () => {

--- a/src/features/sessions/types/index.ts
+++ b/src/features/sessions/types/index.ts
@@ -9,7 +9,13 @@ export type SessionStatus =
 
 export type SessionCloseResult = false | void
 
-export type LayoutId = 'single' | 'vsplit' | 'hsplit' | 'threeRight' | 'quad'
+export type LayoutId =
+  | 'single'
+  | 'vsplit'
+  | 'hsplit'
+  | 'threeRight'
+  | 'quad'
+  | 'grid3x2'
 
 export type PaneKind = 'shell' | 'browser'
 

--- a/src/features/sessions/utils/groupSessionsFromInfos.test.ts
+++ b/src/features/sessions/utils/groupSessionsFromInfos.test.ts
@@ -722,4 +722,28 @@ describe('reconstructWorkspace', () => {
     expect(sessions.map((s) => s.id)).toContain('pty-b')
     expect(sessions.find((s) => s.id === 'ws-valid')?.panes).toHaveLength(1)
   })
+
+  test('accepts grid3x2 from persisted groupings without falling back to single', () => {
+    const ws = 'ws-grid'
+
+    const live = Array.from({ length: 6 }, (_, index) => ({
+      ...alive(`pty-${index}`, '/home/will/repo'),
+      grouping: grouping({
+        workspaceSessionId: ws,
+        layout: 'grid3x2',
+        workspaceDirectory: '/home/will/repo',
+        paneId: `p${index}`,
+        paneIndex: index,
+        active: index === 0,
+        agentType: 'generic',
+      }),
+    }))
+
+    const sessions = reconstructWorkspace(null, live, 'pty-0')
+
+    expect(sessions).toHaveLength(1)
+
+    expect(sessions[0].layout).toBe('grid3x2')
+    expect(sessions[0].panes).toHaveLength(6)
+  })
 })

--- a/src/features/sessions/utils/paneLifecycle.test.ts
+++ b/src/features/sessions/utils/paneLifecycle.test.ts
@@ -55,6 +55,7 @@ describe('autoShrinkLayoutFor', () => {
     expect(autoShrinkLayoutFor(2, 'vsplit')).toBe('vsplit')
     expect(autoShrinkLayoutFor(2, 'threeRight')).toBe('vsplit')
     expect(autoShrinkLayoutFor(2, 'quad')).toBe('vsplit')
+    expect(autoShrinkLayoutFor(2, 'grid3x2')).toBe('vsplit')
     expect(autoShrinkLayoutFor(2, 'single')).toBe('vsplit')
   })
 
@@ -63,9 +64,11 @@ describe('autoShrinkLayoutFor', () => {
     expect(autoShrinkLayoutFor(3, 'vsplit')).toBe('threeRight')
   })
 
-  test('4 or more panes preserves current layout defensively', () => {
+  test('4 panes shrink to quad and 5+ panes shrink to grid3x2', () => {
     expect(autoShrinkLayoutFor(4, 'quad')).toBe('quad')
-    expect(autoShrinkLayoutFor(5, 'quad')).toBe('quad')
+    expect(autoShrinkLayoutFor(4, 'grid3x2')).toBe('quad')
+    expect(autoShrinkLayoutFor(5, 'grid3x2')).toBe('grid3x2')
+    expect(autoShrinkLayoutFor(6, 'grid3x2')).toBe('grid3x2')
   })
 })
 

--- a/src/features/terminal/components/LayoutSwitcher/LayoutGlyph.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutGlyph.test.tsx
@@ -14,6 +14,7 @@ const cases: readonly (readonly [LayoutId, number])[] = [
   ['hsplit', 1],
   ['threeRight', 2],
   ['quad', 2],
+  ['grid3x2', 3],
 ]
 
 describe('LayoutGlyph', () => {

--- a/src/features/terminal/components/LayoutSwitcher/LayoutGlyph.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutGlyph.tsx
@@ -66,6 +66,28 @@ export const LayoutGlyph = ({ layoutId }: LayoutGlyphProps): ReactElement => {
     />
   )
 
+  const grid3x2V1 = (
+    <line
+      x1="5.15"
+      y1="1.5"
+      x2="5.15"
+      y2="9.5"
+      stroke="currentColor"
+      strokeWidth={sw}
+    />
+  )
+
+  const grid3x2V2 = (
+    <line
+      x1="8.85"
+      y1="1.5"
+      x2="8.85"
+      y2="9.5"
+      stroke="currentColor"
+      strokeWidth={sw}
+    />
+  )
+
   return (
     <svg
       width="14"
@@ -86,6 +108,13 @@ export const LayoutGlyph = ({ layoutId }: LayoutGlyphProps): ReactElement => {
       {layoutId === 'quad' && (
         <>
           {v}
+          {h}
+        </>
+      )}
+      {layoutId === 'grid3x2' && (
+        <>
+          {grid3x2V1}
+          {grid3x2V2}
           {h}
         </>
       )}

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
@@ -4,10 +4,10 @@ import { describe, expect, test, vi } from 'vitest'
 import { LayoutSwitcher } from './LayoutSwitcher'
 
 describe('LayoutSwitcher', () => {
-  test('renders 5 buttons (one per LayoutId)', () => {
+  test('renders 6 buttons (one per LayoutId)', () => {
     render(<LayoutSwitcher activeLayoutId="single" onPick={vi.fn()} />)
 
-    expect(screen.getAllByRole('button')).toHaveLength(5)
+    expect(screen.getAllByRole('button')).toHaveLength(6)
   })
 
   test('marks the active button with data-active', () => {
@@ -28,6 +28,12 @@ describe('LayoutSwitcher', () => {
 
     expect(onPick).toHaveBeenCalledOnce()
     expect(onPick).toHaveBeenCalledWith('quad')
+  })
+
+  test('renders the new 3x2 grid pill', () => {
+    render(<LayoutSwitcher activeLayoutId="single" onPick={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: '3x2 grid' })).toBeInTheDocument()
   })
 
   test('clicking the already-active button does NOT fire onPick', async () => {
@@ -73,8 +79,8 @@ describe('LayoutSwitcher', () => {
     render(<LayoutSwitcher activeLayoutId="single" onPick={vi.fn()} />)
 
     expect(screen.queryByTestId('layout-switcher-divider')).toBeNull()
-    // Still just the 5 layout pills — no stray trailing button.
-    expect(screen.getAllByRole('button')).toHaveLength(5)
+    // Still just the 6 layout pills — no stray trailing button.
+    expect(screen.getAllByRole('button')).toHaveLength(6)
   })
 
   test('exposes role="group" with an aria-label', () => {

--- a/src/features/terminal/components/SplitView/SplitDividers.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.test.tsx
@@ -57,6 +57,7 @@ describe('SplitDividers', () => {
     ['hsplit', 1],
     ['threeRight', 2],
     ['quad', 3],
+    ['grid3x2', 5],
   ] as const)('%s renders %i handle element(s)', (layout, count) => {
     render(<Harness layout={layout} />)
     expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(count)

--- a/src/features/terminal/components/SplitView/SplitDividers.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.tsx
@@ -92,6 +92,48 @@ const DIVIDER_SPECS: Record<LayoutId, readonly DividerHandleSpec[]> = {
       trackIndex: 0,
     },
   ],
+  grid3x2: [
+    {
+      id: 'vdiv0a',
+      gridArea: 'vdiv0a',
+      dragAxis: 'horizontal',
+      orientation: 'vertical',
+      trackAxis: 'cols',
+      trackIndex: 0,
+    },
+    {
+      id: 'vdiv1a',
+      gridArea: 'vdiv1a',
+      dragAxis: 'horizontal',
+      orientation: 'vertical',
+      trackAxis: 'cols',
+      trackIndex: 1,
+    },
+    {
+      id: 'hdiv',
+      gridArea: 'hdiv',
+      dragAxis: 'vertical',
+      orientation: 'horizontal',
+      trackAxis: 'rows',
+      trackIndex: 0,
+    },
+    {
+      id: 'vdiv0b',
+      gridArea: 'vdiv0b',
+      dragAxis: 'horizontal',
+      orientation: 'vertical',
+      trackAxis: 'cols',
+      trackIndex: 0,
+    },
+    {
+      id: 'vdiv1b',
+      gridArea: 'vdiv1b',
+      dragAxis: 'horizontal',
+      orientation: 'vertical',
+      trackAxis: 'cols',
+      trackIndex: 1,
+    },
+  ],
 }
 
 const SplitDividerHandle = ({

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -289,6 +289,23 @@ describe('SplitView - multi-pane layouts', () => {
     expect(screen.getAllByTestId('split-view-slot')).toHaveLength(4)
   })
 
+  test('grid3x2 renders 6 slots', () => {
+    render(
+      <SplitView
+        session={makeSession('grid3x2', 6)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+
+    expect(screen.getByTestId('split-view')).toHaveStyle({
+      gridTemplateAreas:
+        '"p0 vdiv0a p1 vdiv1a p2" "hdiv hdiv hdiv hdiv hdiv" "p3 vdiv0b p4 vdiv1b p5"',
+    })
+    expect(screen.getAllByTestId('split-view-slot')).toHaveLength(6)
+    expect(screen.getAllByTestId('split-resize-handle')).toHaveLength(5)
+  })
+
   test('single layout renders no dividers', () => {
     render(
       <SplitView
@@ -480,6 +497,22 @@ describe('SplitView - under-capacity', () => {
     expect(screen.getByTestId('split-view')).toHaveStyle({
       gridTemplateAreas: '"p0 vdiv0 p1" "hdiv hdiv hdiv" "p2 vdiv1 p3"',
     })
+  })
+
+  test('grid3x2 with 5 panes renders one empty slot when add handler exists', () => {
+    render(
+      <SplitView
+        session={makeSession('grid3x2', 5)}
+        service={makeMockService()}
+        isActive
+        onAddPane={vi.fn()}
+      />
+    )
+
+    const emptySlots = screen.getAllByTestId('split-view-empty-slot')
+
+    expect(emptySlots).toHaveLength(1)
+    expect(emptySlots[0]).toHaveAttribute('data-slot-index', '5')
   })
 
   test('threeRight layout with 1 pane renders 1 slot', () => {

--- a/src/features/terminal/components/SplitView/layouts.test.ts
+++ b/src/features/terminal/components/SplitView/layouts.test.ts
@@ -9,10 +9,11 @@ const layoutIds: LayoutId[] = [
   'hsplit',
   'threeRight',
   'quad',
+  'grid3x2',
 ]
 
 describe('LAYOUTS', () => {
-  test('exposes all 5 canonical layout ids', () => {
+  test('exposes all 6 canonical layout ids', () => {
     expect(Object.keys(LAYOUTS).sort()).toEqual([...layoutIds].sort())
   })
 
@@ -30,6 +31,7 @@ describe('LAYOUTS', () => {
       'hsplit',
       'threeRight',
       'quad',
+      'grid3x2',
     ])
   })
 

--- a/src/features/terminal/components/SplitView/resolveGrid.test.ts
+++ b/src/features/terminal/components/SplitView/resolveGrid.test.ts
@@ -45,8 +45,18 @@ describe('resolveGrid', () => {
     ])
   })
 
+  test('grid3x2 segments both column bars around the full-width row bar', () => {
+    const g = resolveGrid('grid3x2', { cols: [1, 1, 1], rows: [1, 1] })
+    expect(g.areas).toEqual([
+      ['p0', 'vdiv0a', 'p1', 'vdiv1a', 'p2'],
+      ['hdiv', 'hdiv', 'hdiv', 'hdiv', 'hdiv'],
+      ['p3', 'vdiv0b', 'p4', 'vdiv1b', 'p5'],
+    ])
+  })
+
   test('default ratios reproduce current proportions', () => {
     expect(DEFAULT_RATIOS.vsplit.cols).toEqual([1, 1])
     expect(DEFAULT_RATIOS.threeRight.cols).toEqual([1.4, 1])
+    expect(DEFAULT_RATIOS.grid3x2.cols).toEqual([1, 1, 1])
   })
 })

--- a/src/features/terminal/components/SplitView/resolveGrid.ts
+++ b/src/features/terminal/components/SplitView/resolveGrid.ts
@@ -55,5 +55,15 @@ export const resolveGrid = (
           ['p2', 'vdiv1', 'p3'],
         ],
       }
+    case 'grid3x2':
+      return {
+        cols,
+        rows,
+        areas: [
+          ['p0', 'vdiv0a', 'p1', 'vdiv1a', 'p2'],
+          ['hdiv', 'hdiv', 'hdiv', 'hdiv', 'hdiv'],
+          ['p3', 'vdiv0b', 'p4', 'vdiv1b', 'p5'],
+        ],
+      }
   }
 }

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -85,11 +85,11 @@ describe('usePaneShortcuts', () => {
     expect(event.preventDefaultSpy).toHaveBeenCalled()
   })
 
-  test('Ctrl+\\ from quad wraps to single (default modifier)', () => {
+  test('Ctrl+\\ from grid3x2 wraps to single (default modifier)', () => {
     const setSessionLayout = vi.fn()
     renderHook(() =>
       usePaneShortcuts({
-        sessions: [makeSession('s1', 'quad', ['p0'])],
+        sessions: [makeSession('s1', 'grid3x2', ['p0'])],
         activeSessionId: 's1',
         setSessionActivePane: vi.fn(),
         setSessionLayout,

--- a/src/features/terminal/layout-registry/layoutIds.ts
+++ b/src/features/terminal/layout-registry/layoutIds.ts
@@ -7,4 +7,5 @@ export const LAYOUT_IDS = [
   'hsplit',
   'threeRight',
   'quad',
+  'grid3x2',
 ] as const satisfies readonly LayoutId[]

--- a/src/features/terminal/layout-registry/layoutRegistry.test.ts
+++ b/src/features/terminal/layout-registry/layoutRegistry.test.ts
@@ -16,6 +16,7 @@ describe('layoutRegistry', () => {
       'hsplit',
       'threeRight',
       'quad',
+      'grid3x2',
     ])
     expect(LAYOUT_CYCLE).toEqual(LAYOUT_IDS)
     expect(VISIBLE_LAYOUTS.map((layout) => layout.id)).toEqual(LAYOUT_IDS)
@@ -24,12 +25,13 @@ describe('layoutRegistry', () => {
   test('exposes record lookup by layout id', () => {
     expect(LAYOUTS.single.name).toBe('Single')
     expect(LAYOUTS.quad.capacity).toBe(4)
+    expect(LAYOUTS.grid3x2.capacity).toBe(6)
   })
 
   test('recognizes known layout ids and rejects unknown ones', () => {
     expect(isKnownLayoutId('single')).toBe(true)
     expect(isKnownLayoutId('quad')).toBe(true)
-    expect(isKnownLayoutId('grid3x2')).toBe(false)
+    expect(isKnownLayoutId('grid3x2')).toBe(true)
   })
 
   test('centralizes the current auto-shrink policy', () => {
@@ -38,5 +40,7 @@ describe('layoutRegistry', () => {
     expect(autoShrinkLayoutFor(2, 'quad')).toBe('vsplit')
     expect(autoShrinkLayoutFor(3, 'quad')).toBe('threeRight')
     expect(autoShrinkLayoutFor(4, 'quad')).toBe('quad')
+    expect(autoShrinkLayoutFor(5, 'grid3x2')).toBe('grid3x2')
+    expect(autoShrinkLayoutFor(4, 'grid3x2')).toBe('quad')
   })
 })

--- a/src/features/terminal/layout-registry/layoutRegistry.ts
+++ b/src/features/terminal/layout-registry/layoutRegistry.ts
@@ -27,5 +27,13 @@ export const autoShrinkLayoutFor = (
     return 'threeRight'
   }
 
+  if (nextPaneCount === 4) {
+    return 'quad'
+  }
+
+  if (nextPaneCount >= 5) {
+    return 'grid3x2'
+  }
+
   return currentLayoutId
 }

--- a/src/features/terminal/layout-registry/layoutSpecs.ts
+++ b/src/features/terminal/layout-registry/layoutSpecs.ts
@@ -6,7 +6,7 @@ export interface LayoutShape {
   readonly id: LayoutId
   readonly name: string
   /** Maximum pane count for this layout. SplitView clamps panes to capacity. */
-  readonly capacity: 1 | 2 | 3 | 4
+  readonly capacity: 1 | 2 | 3 | 4 | 6
   /** CSS grid-template-columns value. */
   readonly cols: string
   /** CSS grid-template-rows value. */
@@ -67,6 +67,17 @@ export const LAYOUTS: Record<LayoutId, LayoutShape> = {
     areas: [
       ['p0', 'p1'],
       ['p2', 'p3'],
+    ],
+  },
+  grid3x2: {
+    id: 'grid3x2',
+    name: '3x2 grid',
+    capacity: 6,
+    cols: 'minmax(0,1fr) minmax(0,1fr) minmax(0,1fr)',
+    rows: 'minmax(0,1fr) minmax(0,1fr)',
+    areas: [
+      ['p0', 'p1', 'p2'],
+      ['p3', 'p4', 'p5'],
     ],
   },
 } as const

--- a/src/features/terminal/layout-registry/ratioModel.test.ts
+++ b/src/features/terminal/layout-registry/ratioModel.test.ts
@@ -13,6 +13,7 @@ describe('ratioModel', () => {
     expect(DEFAULT_RATIOS.single).toEqual({ cols: [1], rows: [1] })
     expect(DEFAULT_RATIOS.threeRight.cols).toEqual([1.4, 1])
     expect(DEFAULT_RATIOS.quad.rows).toEqual([1, 1])
+    expect(DEFAULT_RATIOS.grid3x2.cols).toEqual([1, 1, 1])
   })
 
   test('builds CSS templates from track arrays', () => {

--- a/src/features/terminal/layout-registry/ratioModel.ts
+++ b/src/features/terminal/layout-registry/ratioModel.ts
@@ -14,6 +14,7 @@ export const DEFAULT_RATIOS: Record<LayoutId, LayoutRatios> = {
   hsplit: { cols: [1], rows: [1, 1] },
   threeRight: { cols: [1.4, 1], rows: [1, 1] },
   quad: { cols: [1, 1], rows: [1, 1] },
+  grid3x2: { cols: [1, 1, 1], rows: [1, 1] },
 }
 
 export const getTrackCssVar = (


### PR DESCRIPTION
## Summary
- add the new `grid3x2` pane layout end to end across the registry, layout switcher, keyboard cycle, split grid renderer, and autoshrink policy
- extend the ratio-model based divider geometry so `grid3x2` renders segmented vertical dividers and a full-width row divider with 6-pane capacity
- widen the Rust workspace layout repair and kill-path compatibility logic so persisted/workspace groupings can round-trip `grid3x2` instead of collapsing back to `quad`

## Linear
- Refs VIM-151

## Verification
- `npx vitest run src/features/sessions/types/index.test.ts src/features/terminal/layout-registry/layoutRegistry.test.ts src/features/terminal/layout-registry/ratioModel.test.ts src/features/terminal/components/LayoutSwitcher/LayoutGlyph.test.tsx src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx src/features/terminal/components/SplitView/layouts.test.ts src/features/terminal/components/SplitView/resolveGrid.test.ts src/features/terminal/components/SplitView/SplitDividers.test.tsx src/features/terminal/components/SplitView/SplitView.test.tsx src/features/terminal/hooks/usePaneShortcuts.test.ts src/features/sessions/utils/paneLifecycle.test.ts src/features/sessions/utils/groupSessionsFromInfos.test.ts`
- `cargo test --manifest-path crates/backend/Cargo.toml kill_pty_keeps_grid3x2_layout_when_five_siblings_remain`
- `cargo test --manifest-path crates/backend/Cargo.toml kill_pty_reindexes_sibling_groupings_in_same_workspace`
- `cargo test --manifest-path crates/backend/Cargo.toml widens_layout_and_preserves_panes_up_to_grid3x2`
- `cargo test --manifest-path crates/backend/Cargo.toml active_pane_beyond_grid3x2_still_leaves_exactly_one_active`
- `cargo test --manifest-path crates/backend/Cargo.toml truncated_pane_does_not_poison_pty_id`
- `npm run lint`
- `npm run type-check`

## Notes
- The targeted vitest run emitted passing results for the touched frontend suites but also printed pre-existing React `act(...)` warnings from `SplitView.test.tsx` before the process stalled on exit; the assertions themselves passed.
