### PR TITLE
chore(terminal): polish grid3x2 layout ergonomics

### DIFF
--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -646,7 +646,7 @@ pub(crate) fn kill_pty_inner(
                         Some("vsplit") | Some("hsplit") => count == 2,
                         Some("threeRight") => count == 3,
                         Some("quad") => count == 4,
-                        Some("grid3x2") => count >= 5,
+                        Some("grid3x2") => count == 5 || count == 6,
                         _ => false,
                     };
                     if compatible {

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 24       | 6    | 2026-06-17   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 47       | 20   | 2026-06-18   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 48       | 20   | 2026-06-18   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 3        | 0    | 2026-06-16   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 70       | 33   | 2026-06-17   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 72       | 33   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 62       | 25   | 2026-06-17   |
@@ -102,5 +102,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 0    | 2026-06-15   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 3        | 0    | 2026-06-17   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
-| [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 1        | 0    | 2026-06-18   |
+| [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 2        | 0    | 2026-06-18   |
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 24       | 6    | 2026-06-17   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 46       | 20   | 2026-06-17   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 47       | 20   | 2026-06-18   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,7 +2,7 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-17
+last_updated: 2026-06-18
 ref_count: 20
 ---
 
@@ -435,4 +435,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/agent-status/components/AgentStatusPanel/index.tsx`
 - **Finding:** The round-1 fix computed `prependDelta = firstRowHeight > 0 ? firstRowHeight : scrollHeightDelta`. When hot-loading delivered multiple new activity rows in one snapshot, the viewport adjusted by one row instead of the total inserted height, causing visible content jump and undermining scroll-stability.
 - **Fix:** Prefer total positive `scrollHeightDelta` for growing prepends and fall back to the measured first-row height only when the container does not grow. Added a regression test that stubs `offsetHeight` to a single-row value while growing `scrollHeight` by several rows' worth, asserting the viewport compensates by the full delta.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 45. Duplicate divider bindings write conflicting CSS vars for the same logical boundary
+
+- **Source:** github-codex-connector | PR #528 round 1 | 2026-06-18
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/SplitView/SplitDividers.tsx`
+- **Finding:** In `quad` and `grid3x2` layouts, two visual divider segments represent the same logical column boundary (`trackAxis: 'cols'`, same `trackIndex`). Each segment created its own `useSplitDivider` instance, and each instance's commit-size effect wrote the same `--split-cols-*` CSS variables. Dragging one segment updated parent state, but the untouched segment's effect re-ran with its stale `size` and overwrote the live ratio, making the resize snap back or become inconsistent.
+- **Fix:** Group divider specs by `(trackAxis, trackIndex)` and create exactly one `useSplitDivider` binding per logical boundary. Render every visual segment in the group from that shared binding so all handles read the same live `size` and no two effects compete for the same CSS vars.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -445,3 +445,12 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** In `quad` and `grid3x2` layouts, two visual divider segments represent the same logical column boundary (`trackAxis: 'cols'`, same `trackIndex`). Each segment created its own `useSplitDivider` instance, and each instance's commit-size effect wrote the same `--split-cols-*` CSS variables. Dragging one segment updated parent state, but the untouched segment's effect re-ran with its stale `size` and overwrote the live ratio, making the resize snap back or become inconsistent.
 - **Fix:** Group divider specs by `(trackAxis, trackIndex)` and create exactly one `useSplitDivider` binding per logical boundary. Render every visual segment in the group from that shared binding so all handles read the same live `size` and no two effects compete for the same CSS vars.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 46. Unstable `initialRatios` dependency recreates `writeRatio` and triggers sibling divider feedback loop
+
+- **Source:** github-claude | PR #528 round 2 | 2026-06-18
+- **Severity:** HIGH
+- **File:** `src/features/terminal/components/SplitView/useSplitDivider.ts` L58-78
+- **Finding:** `writeRatio` listed `initialRatios` in its `useCallback` deps. In `quad` and `grid3x2` layouts, sibling dividers on the same axis share the axis ratios; committing one divider created a new `ratios` array reference, which was passed as `initialRatios` to all sibling handles. Each sibling's `writeRatio` was recreated, firing its commit effect with a stale `size` from `useElasticContainer`, producing wrong track weights and an infinite state oscillation that ended in React's "Maximum update depth exceeded" crash.
+- **Fix:** Store `initialRatios` in a ref (`initialRatiosRef`) updated synchronously during render, and read `initialRatiosRef.current` inside `writeRatio`. Removed `initialRatios` from the `useCallback` deps so `writeRatio` stays stable across sibling commits.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/resizable-layout-bounds.md
+++ b/docs/reviews/patterns/resizable-layout-bounds.md
@@ -33,3 +33,12 @@ model and the rendered grid stay consistent and no pane becomes inaccessible.
   guaranteeing every track stays above the configured minimum.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this
   line)
+
+### 2. grid3x2 compatibility check accepts pane counts above its capacity
+
+- **Source:** github-claude | PR #528 round 2 | 2026-06-18
+- **Severity:** LOW
+- **File:** `crates/backend/src/terminal/commands.rs` L649, `src/features/terminal/layout-registry/layoutRegistry.ts` L34
+- **Finding:** Both the Rust kill-pty re-layout check and the frontend `autoShrinkLayoutFor` used an open lower bound (`count >= 5` / `nextPaneCount >= 5`) for `grid3x2` compatibility. `grid3x2` capacity is 6, so malformed or migrated snapshots with 7+ panes would be accepted as valid and `resolveGrid` would reference non-existent named pane areas (p6, p7, …).
+- **Fix:** Tightened both checks to `count == 5 || count == 6` / `nextPaneCount === 5 || nextPaneCount === 6` so the compatibility test matches the layout's defined capacity.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,7 +2,7 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-17
+last_updated: 2026-06-18
 ref_count: 33
 ---
 
@@ -729,4 +729,22 @@ filesystem scope restrictions).
   only in the test file that actually exercises inert click behavior
   (`AgentStatusPanel/index.test.tsx`), removing the global side-effect from
   `src/test/setup.ts`.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 71. Test script memory flag not mirrored to `test:coverage`
+
+- **Source:** github-claude | PR #528 round 2 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `package.json` L28-30
+- **Finding:** The `test` script was prefixed with `cross-env NODE_OPTIONS=--max-old-space-size=8192` to prevent CI OOM, but the `test:coverage` script was not. Coverage instrumentation holds more live objects than a plain run, so any CI step invoking `npm run test:coverage` would still hit the default heap limit and crash with the same OOM that the `test` change was meant to fix.
+- **Fix:** Added the identical `cross-env NODE_OPTIONS=--max-old-space-size=8192` prefix to the `test:coverage` script.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 72. `requestAnimationFrame` callback captured before effect scheduling races in CI
+
+- **Source:** deterministic-ci-failure | PR #528 round 2 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/browser/components/BrowserPane.test.tsx` L253-294
+- **Finding:** The test captured `window.requestAnimationFrame` callback in a local variable and invoked it once synchronously after `settle()`. In CI the effect that schedules the rAF loop could resolve after the single invocation, so `setBrowserPaneBounds` was never called and `waitFor` timed out.
+- **Fix:** Moved the callback invocation inside the `waitFor` poll so each retry ticks the latest captured animation-frame callback until the moved-bounds assertion passes.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/roadmap/progress.yaml
+++ b/docs/roadmap/progress.yaml
@@ -7,8 +7,8 @@
 #   Tauri runtime fully removed; vimeflow now ships as an Electron shell with
 #   a runtime-neutral Rust sidecar binary (vimeflow-backend).
 
-version: 11
-updated: '2026-06-16'
+version: 12
+updated: '2026-06-17'
 roadmap: docs/roadmap/ui-update-roadmap.md
 changelog:
   en: CHANGELOG.md
@@ -952,9 +952,13 @@ phases:
       lifecycle mutations (#204). BottomDrawer was replaced by DockPanel
       (#215), then shared focus/shortcuts (#218), elastic resize (#219),
       command-palette result styling (#221), and tooltip shortcut chips
-      (#224) followed. Remaining active gaps: 5d auto-grow on layout pick,
-      activity-panel polish, full command-palette modal polish, and issue
-      #225 for Mod+\ / Mod+B shortcut discovery.
+      (#224) followed. The pane-layout registry / ratio-model / `grid3x2`
+      expansion is now in progress on VIM-151: the active branch adds a
+      central layout registry, track-array resize state, 6-pane `grid3x2`
+      rendering, restore support, and `Mod+1-6` pane focus. Remaining
+      active gaps: 5d auto-grow on layout pick, activity-panel polish, full
+      command-palette modal polish, and issue #225 for Mod+\ / Mod+B
+      shortcut discovery.
     steps:
       - id: ui-s1
         name: 'Tokens + agents registry'
@@ -984,17 +988,17 @@ phases:
         pr: 198
         notes: 'Data model — Session.layout + Session.panes[], per-pane PTY ownership, exactly-one-active invariant.'
       - id: ui-s5b
-        name: 'SplitView render (CSS Grid mapping session.panes → 5 layouts)'
+        name: 'SplitView render (CSS Grid mapping session.panes → canonical layouts)'
         status: done
         commit: c0b7e88
         pr: 199
-        notes: 'Pure render refactor — CSS Grid SplitView maps Session.panes into single/vsplit/hsplit/threeRight/quad. Spec: docs/superpowers/specs/2026-05-11-step-5b-splitview-render-design.md.'
+        notes: 'Pure render refactor — CSS Grid SplitView maps Session.panes into the canonical layouts. The original merge shipped single/vsplit/hsplit/threeRight/quad; VIM-151 later widens that set with grid3x2. Spec: docs/superpowers/specs/2026-05-11-step-5b-splitview-render-design.md.'
       - id: ui-s5c-1
         name: 'Layout picker + focus controls (passive, animated)'
         status: done
         commit: fed7ee8
         pr: 203
-        notes: 'LayoutSwitcher passive UI + click-to-focus + ⌘1-4 / ⌘\ cycle + Framer Motion animations. Spec: docs/superpowers/specs/2026-05-12-step-5c-1-layout-picker-design.md.'
+        notes: 'LayoutSwitcher passive UI + click-to-focus + ⌘1-4 / ⌘\ cycle + Framer Motion animations. VIM-151 later widens pane focus to ⌘1-6 for grid3x2. Spec: docs/superpowers/specs/2026-05-12-step-5c-1-layout-picker-design.md.'
       - id: ui-s5c-2
         name: 'addPane / removePane / placeholder spawn / X-close / auto-shrink'
         status: done

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "type-check": "npm run generate:bindings && npm run type-check:generated",
     "type-check:generated": "tsc -b && tsc -p electron/tsconfig.json",
     "test": "npm run generate:bindings:if-missing && cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest --passWithNoTests",
-    "test:coverage": "npm run generate:bindings:if-missing && vitest run --coverage",
+    "test:coverage": "npm run generate:bindings:if-missing && cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest run --coverage",
     "clean:bindings": "mkdir -p src/bindings && find src/bindings -name '*.ts' ! -name 'index.ts' -delete",
     "generate:bindings": "npm run clean:bindings && cargo test --manifest-path crates/backend/Cargo.toml export_bindings && prettier --write src/bindings/",
     "generate:bindings:if-missing": "node scripts/generate-bindings-if-missing.mjs",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "format:check": "prettier --check .",
     "type-check": "npm run generate:bindings && npm run type-check:generated",
     "type-check:generated": "tsc -b && tsc -p electron/tsconfig.json",
-    "test": "npm run generate:bindings:if-missing && vitest --passWithNoTests",
+    "test": "npm run generate:bindings:if-missing && cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest --passWithNoTests",
     "test:coverage": "npm run generate:bindings:if-missing && vitest run --coverage",
     "clean:bindings": "mkdir -p src/bindings && find src/bindings -name '*.ts' ! -name 'index.ts' -delete",
     "generate:bindings": "npm run clean:bindings && cargo test --manifest-path crates/backend/Cargo.toml export_bindings && prettier --write src/bindings/",

--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -278,11 +278,16 @@ describe('BrowserPane', () => {
       bridgeMocks.setBrowserPaneBounds.mockClear()
 
       rectSpy.mockReturnValue(movedRect)
-      act(() => {
-        frameCallback?.(performance.now())
-      })
 
+      // Poll while ticking the captured rAF callback. The effect that schedules
+      // requestAnimationFrame can resolve after settle() in CI, so a single
+      // synchronous invocation may run before the loop exists; waiting lets the
+      // latest callback drive syncBounds until the moved bounds land.
       await waitFor(() => {
+        act(() => {
+          frameCallback?.(performance.now())
+        })
+
         expect(bridgeMocks.setBrowserPaneBounds).toHaveBeenLastCalledWith({
           sessionId: 'session-1',
           paneId: 'p1',

--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -271,6 +271,10 @@ describe('BrowserPane', () => {
         <BrowserPaneHarness session={session} pane={browserPane} isActive />
       )
       await settle()
+      await waitFor(() => {
+        expect(requestAnimationFrameSpy).toHaveBeenCalled()
+        expect(frameCallback).not.toBeNull()
+      })
       bridgeMocks.setBrowserPaneBounds.mockClear()
 
       rectSpy.mockReturnValue(movedRect)
@@ -340,6 +344,10 @@ describe('BrowserPane', () => {
         <BrowserPaneHarness session={session} pane={browserPane} isActive />
       )
       await settle()
+      await waitFor(() => {
+        expect(requestAnimationFrameSpy).toHaveBeenCalled()
+        expect(frameCallback).not.toBeNull()
+      })
       bridgeMocks.setBrowserPaneBounds.mockClear()
 
       for (let i = 0; i < 60; i += 1) {

--- a/src/features/sessions/hooks/useSessionManager.test.ts
+++ b/src/features/sessions/hooks/useSessionManager.test.ts
@@ -5414,7 +5414,7 @@ describe('useSessionManager', () => {
     // Rust briefly pointing at a dying PTY; the cleanest fix is to make
     // focus rotation a no-op while a lifecycle op holds pendingPaneOps.
     // Round 14, Claude LOW: the guarded early-return must also warn so
-    // a developer chasing a "⌘1-4 stopped working briefly" report sees
+    // a developer chasing a "⌘1-6 stopped working briefly" report sees
     // the suppression in devtools (parity with every other guard in the
     // file).
     test('setSessionActivePane is a no-op while removePane is in flight', async () => {

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -1078,7 +1078,7 @@ export const useSessionManager = (
       // (the target pane may evaporate anyway when the remove commits).
       // Warn for parity with every other guarded early-return in this
       // function (and in addPane / removePane): otherwise a developer
-      // chasing a "⌘1-4 stopped working for 50–300ms" report sees
+      // chasing a "⌘1-6 stopped working for 50–300ms" report sees
       // nothing in devtools and can't distinguish the transient
       // suppression from a real bug.
       if (pendingPaneOps.current.has(sessionId)) {

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
@@ -27,6 +27,12 @@ export const LayoutSwitcher = ({
 }: LayoutSwitcherProps): ReactElement => (
   <div
     data-testid="layout-switcher"
+    // `role="group"` (not "toolbar") because we don't implement the
+    // roving-tabindex / arrow-key navigation pattern the ARIA toolbar
+    // role implies. `role="group"` + `aria-label` correctly names the
+    // region for screen readers without advertising an unimplemented
+    // keyboard contract. The layout buttons remain in the natural tab
+    // sequence — adequate for this small picker.
     role="group"
     aria-label="Pane layout"
     className="vf-app-no-drag inline-flex items-center gap-0.5 rounded-md bg-surface-container/60 p-0.5"

--- a/src/features/terminal/components/SplitView/SplitDividers.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.tsx
@@ -26,6 +26,13 @@ interface DividerHandleSpec {
   readonly trackIndex: number
 }
 
+interface DividerGroup {
+  readonly trackAxis: RatioAxis
+  readonly trackIndex: number
+  readonly dragAxis: DividerDragAxis
+  readonly handles: readonly DividerHandleSpec[]
+}
+
 const DIVIDER_SPECS: Record<LayoutId, readonly DividerHandleSpec[]> = {
   single: [],
   vsplit: [
@@ -76,14 +83,6 @@ const DIVIDER_SPECS: Record<LayoutId, readonly DividerHandleSpec[]> = {
       trackIndex: 0,
     },
     {
-      id: 'hdiv',
-      gridArea: 'hdiv',
-      dragAxis: 'vertical',
-      orientation: 'horizontal',
-      trackAxis: 'rows',
-      trackIndex: 0,
-    },
-    {
       id: 'vdiv1',
       gridArea: 'vdiv1',
       dragAxis: 'horizontal',
@@ -91,11 +90,27 @@ const DIVIDER_SPECS: Record<LayoutId, readonly DividerHandleSpec[]> = {
       trackAxis: 'cols',
       trackIndex: 0,
     },
+    {
+      id: 'hdiv',
+      gridArea: 'hdiv',
+      dragAxis: 'vertical',
+      orientation: 'horizontal',
+      trackAxis: 'rows',
+      trackIndex: 0,
+    },
   ],
   grid3x2: [
     {
       id: 'vdiv0a',
       gridArea: 'vdiv0a',
+      dragAxis: 'horizontal',
+      orientation: 'vertical',
+      trackAxis: 'cols',
+      trackIndex: 0,
+    },
+    {
+      id: 'vdiv0b',
+      gridArea: 'vdiv0b',
       dragAxis: 'horizontal',
       orientation: 'vertical',
       trackAxis: 'cols',
@@ -110,22 +125,6 @@ const DIVIDER_SPECS: Record<LayoutId, readonly DividerHandleSpec[]> = {
       trackIndex: 1,
     },
     {
-      id: 'hdiv',
-      gridArea: 'hdiv',
-      dragAxis: 'vertical',
-      orientation: 'horizontal',
-      trackAxis: 'rows',
-      trackIndex: 0,
-    },
-    {
-      id: 'vdiv0b',
-      gridArea: 'vdiv0b',
-      dragAxis: 'horizontal',
-      orientation: 'vertical',
-      trackAxis: 'cols',
-      trackIndex: 0,
-    },
-    {
       id: 'vdiv1b',
       gridArea: 'vdiv1b',
       dragAxis: 'horizontal',
@@ -133,28 +132,56 @@ const DIVIDER_SPECS: Record<LayoutId, readonly DividerHandleSpec[]> = {
       trackAxis: 'cols',
       trackIndex: 1,
     },
+    {
+      id: 'hdiv',
+      gridArea: 'hdiv',
+      dragAxis: 'vertical',
+      orientation: 'horizontal',
+      trackAxis: 'rows',
+      trackIndex: 0,
+    },
   ],
 }
 
-interface SplitBoundaryProps extends Omit<SplitDividersProps, 'layout'> {
-  readonly axis: DividerDragAxis
-  readonly trackAxis: RatioAxis
-  readonly trackIndex: number
-  readonly specs: readonly DividerHandleSpec[]
+const groupKey = (trackAxis: RatioAxis, trackIndex: number): string =>
+  `${trackAxis}:${trackIndex}`
+
+const groupSpecsByBoundary = (
+  specs: readonly DividerHandleSpec[]
+): readonly DividerGroup[] => {
+  const groups = new Map<string, DividerGroup>()
+
+  for (const spec of specs) {
+    const key = groupKey(spec.trackAxis, spec.trackIndex)
+    const existing = groups.get(key)
+
+    if (existing) {
+      groups.set(key, {
+        ...existing,
+        handles: [...existing.handles, spec],
+      })
+    } else {
+      groups.set(key, {
+        trackAxis: spec.trackAxis,
+        trackIndex: spec.trackIndex,
+        dragAxis: spec.dragAxis,
+        handles: [spec],
+      })
+    }
+  }
+
+  return Array.from(groups.values())
 }
 
-const boundaryKey = (spec: DividerHandleSpec): string =>
-  `${spec.trackAxis}-${spec.trackIndex}`
-
-const SplitBoundary = ({
+const SplitDividerGroup = ({
   containerRef,
-  axis,
+  ratios,
   trackAxis,
   trackIndex,
-  ratios,
+  dragAxis,
+  handles,
   onRatioChange,
-  specs,
-}: SplitBoundaryProps): ReactElement => {
+}: Omit<SplitDividersProps, 'layout'> & DividerGroup): ReactElement => {
   const onTrackChange = useCallback(
     (nextRatios: readonly number[]): void =>
       onRatioChange(trackAxis, nextRatios),
@@ -163,7 +190,7 @@ const SplitBoundary = ({
 
   const binding = useSplitDivider({
     containerRef,
-    axis,
+    axis: dragAxis,
     trackAxis,
     trackIndex,
     initialRatios: ratios[trackAxis],
@@ -172,10 +199,10 @@ const SplitBoundary = ({
 
   return (
     <Fragment>
-      {specs.map((spec) => (
+      {handles.map((handle) => (
         <ResizeHandle
-          key={spec.id}
-          orientation={spec.orientation}
+          key={handle.id}
+          orientation={handle.orientation}
           testId={HANDLE_TEST_ID}
           ariaLabel="Resize panes"
           isDragging={binding.isDragging}
@@ -185,7 +212,7 @@ const SplitBoundary = ({
           onMouseDown={binding.handleMouseDown}
           onKeyDown={binding.onKeyDown}
           className="h-full w-full"
-          style={{ gridArea: spec.gridArea }}
+          style={{ gridArea: handle.gridArea }}
         />
       ))}
     </Fragment>
@@ -204,29 +231,17 @@ export const SplitDividers = ({
     return null
   }
 
-  const grouped = specs.reduce<Record<string, DividerHandleSpec[]>>(
-    (acc, spec) => {
-      const key = boundaryKey(spec)
-      acc[key] ??= []
-      acc[key].push(spec)
-
-      return acc
-    },
-    {}
-  )
+  const groups = groupSpecsByBoundary(specs)
 
   return (
     <Fragment>
-      {Object.values(grouped).map((groupSpecs) => (
-        <SplitBoundary
-          key={boundaryKey(groupSpecs[0])}
+      {groups.map((group) => (
+        <SplitDividerGroup
+          key={groupKey(group.trackAxis, group.trackIndex)}
           containerRef={containerRef}
-          axis={groupSpecs[0].dragAxis}
-          trackAxis={groupSpecs[0].trackAxis}
-          trackIndex={groupSpecs[0].trackIndex}
           ratios={ratios}
           onRatioChange={onRatioChange}
-          specs={groupSpecs}
+          {...group}
         />
       ))}
     </Fragment>

--- a/src/features/terminal/components/SplitView/useSplitDivider.ts
+++ b/src/features/terminal/components/SplitView/useSplitDivider.ts
@@ -54,13 +54,15 @@ export const useSplitDivider = ({
   const startVar = getTrackCssVar(trackAxis, trackIndex)
   const endVar = getTrackCssVar(trackAxis, trackIndex + 1)
   const effectiveDimensionRef = useRef(0)
+  const initialRatiosRef = useRef(initialRatios)
+  initialRatiosRef.current = initialRatios
 
   const writeRatio = useCallback(
     (ratio: number): readonly number[] => {
       const el = containerRef.current
 
       const nextRatios = updateTrackBoundaryRatio(
-        initialRatios,
+        initialRatiosRef.current,
         trackIndex,
         ratio
       )
@@ -74,7 +76,7 @@ export const useSplitDivider = ({
 
       return nextRatios
     },
-    [containerRef, endVar, initialRatios, startVar, trackIndex]
+    [containerRef, endVar, startVar, trackIndex]
   )
 
   // useElasticContainer hands us pixel previews during a drag; convert to a

--- a/src/features/terminal/components/SplitView/useSplitDivider.ts
+++ b/src/features/terminal/components/SplitView/useSplitDivider.ts
@@ -109,12 +109,35 @@ export const useSplitDivider = ({
   // Committed `size` change (drag end | keyboard | resize): set both fr tracks
   // and mirror the ratio up for remember-within-session. Covers the keyboard /
   // ResizeObserver paths where onDragPreview never fires.
+  //
+  // When the committed pixel size lines up with the ratio model (within the
+  // one-pixel rounding of the ResizeObserver / getBoundingClientRect path),
+  // use the model's exact boundary ratio instead of `size / effectiveDimension`.
+  // This keeps multi-track layouts like `grid3x2` stable on mount: two dividers
+  // share the same axis, and propagating a rounded pixel ratio back into the
+  // model can make the track weights oscillate instead of converging.
   useEffect(() => {
-    if (effectiveDimension > 0) {
-      const ratio = clampRatio(size / effectiveDimension)
-      onRatioChange(writeRatio(ratio))
+    if (effectiveDimension <= 0) {
+      return
     }
-  }, [size, effectiveDimension, writeRatio, onRatioChange])
+
+    const impliedRatio = getTrackBoundaryRatio(initialRatios, trackIndex)
+    const impliedSize = Math.round(effectiveDimension * impliedRatio)
+
+    const ratio =
+      size === impliedSize
+        ? impliedRatio
+        : clampRatio(size / effectiveDimension)
+
+    onRatioChange(writeRatio(ratio))
+  }, [
+    size,
+    effectiveDimension,
+    writeRatio,
+    onRatioChange,
+    initialRatios,
+    trackIndex,
+  ])
 
   // Restore the fr fallback when this divider unmounts (session deactivates).
   useEffect(

--- a/src/features/terminal/layout-registry/layoutRegistry.ts
+++ b/src/features/terminal/layout-registry/layoutRegistry.ts
@@ -31,7 +31,7 @@ export const autoShrinkLayoutFor = (
     return 'quad'
   }
 
-  if (nextPaneCount >= 5) {
+  if (nextPaneCount === 5 || nextPaneCount === 6) {
     return 'grid3x2'
   }
 

--- a/src/features/workspace/hooks/useDockToggleShortcut.ts
+++ b/src/features/workspace/hooks/useDockToggleShortcut.ts
@@ -9,7 +9,7 @@ export interface UseDockToggleShortcutParams {
 }
 
 // Workspace-global toggle for the editor/diff dock: ⌘0 on macOS, Ctrl+0 on
-// Linux. The 0 slot sits beside the pane-focus digits (⌘1-4 in
+// Linux. The 0 slot sits beside the pane-focus digits (⌘1-6 in
 // usePaneShortcuts) and the sidebar's ⌘B, so the panel controls read as one
 // number row. Matches the physical Digit0 key (event.code) — like the pane
 // shortcuts — so AZERTY/QWERTZ layouts that reach 0 via Shift still fire. The


### PR DESCRIPTION
## Summary
- widen pane-focus shortcuts from `Mod+1-4` to `Mod+1-6` so the new `grid3x2` layout does not strand panes 5-6 behind mouse-only focus
- align nearby shortcut copy/comments with the widened pane range to remove stale maintainer-facing guidance
- update `docs/roadmap/progress.yaml` to reflect the canonical-layout expansion and the in-flight VIM-151 pane-layout work

## Linear
- Refs VIM-151

## Verification
- `npx vitest run src/features/terminal/hooks/usePaneShortcuts.test.ts src/features/sessions/hooks/useSessionManager.test.ts src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx`
- `npm run lint`
- `npm run type-check`
