### PR TITLE
fix(terminal): render Ghostty text cursor

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -199,6 +199,30 @@ describe('ghosttyInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('Start')
   })
 
+  test('renders a visual cursor from the Ghostty byte parser state', () => {
+    const created = createTrackedGhosttyTerminal()
+    const output = `abc${ESC}[2D`
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    const terminalOutput = created.terminal.element?.querySelector('pre')
+
+    const cursor = terminalOutput?.querySelector(
+      '[data-terminal-cursor="true"]'
+    )
+
+    expect(terminalOutput?.textContent).toBe('abc')
+    expect(created.viewportReader.readVisibleText()).toBe('abc')
+    expect(cursor?.previousSibling?.textContent).toBe('a')
+    expect(cursor?.nextSibling?.textContent).toBe('bc')
+  })
+
   test('renders invalid byte payloads through the byte path', () => {
     const created = createTrackedGhosttyTerminal()
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -114,6 +114,36 @@ describe('plainTextInstance', () => {
     expect(callback).toHaveBeenCalledOnce()
   })
 
+  test('renders a visual cursor without adding transcript text', () => {
+    const created = createTrackedPlainTextTerminal()
+    const container = document.createElement('div')
+
+    setElementSize(container, 640, 360)
+    created.terminal.open(container)
+
+    const output = created.terminal.element?.querySelector('pre')
+    const cursor = output?.querySelector('[data-terminal-cursor="true"]')
+
+    expect(cursor).not.toBeNull()
+    expect(output?.textContent).toBe('')
+    expect(created.viewportReader.readVisibleText()).toBe('')
+  })
+
+  test('places the visual cursor at the renderer buffer offset', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    // cspell:disable-next-line
+    created.terminal.write('abc\x1b[2D')
+
+    const output = created.terminal.element?.querySelector('pre')
+    const cursor = output?.querySelector('[data-terminal-cursor="true"]')
+
+    expect(output?.textContent).toBe('abc')
+    expect(created.viewportReader.readVisibleText()).toBe('abc')
+    expect(cursor?.previousSibling?.textContent).toBe('a')
+    expect(cursor?.nextSibling?.textContent).toBe('bc')
+  })
+
   test('rewrites the current line when carriage return output arrives', () => {
     const created = createTrackedPlainTextTerminal()
 
@@ -563,5 +593,10 @@ describe('plainTextInstance', () => {
 
     expect(created.terminal.element?.style.background).not.toBe('')
     expect(created.terminal.element?.style.color).not.toBe('')
+    expect(
+      created.terminal.element?.style.getPropertyValue(
+        '--terminal-cursor-color'
+      )
+    ).toBe(terminalTheme.cursor)
   })
 })

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -68,6 +68,18 @@ describe('TerminalDisplayBuffer', () => {
     expect(buffer.readVisibleText()).toBe('Started!')
   })
 
+  test('exposes the current cursor offset for renderer caret placement', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('abc')
+
+    expect(buffer.readCursorOffset()).toBe(3)
+
+    buffer.write(getCursorLeftSentinel().repeat(2))
+
+    expect(buffer.readCursorOffset()).toBe(1)
+  })
+
   test('clears viewport text when a clear-screen display control arrives', () => {
     const buffer = new TerminalDisplayBuffer()
 

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -245,6 +245,10 @@ export class TerminalDisplayBuffer {
     return this.state.text
   }
 
+  readCursorOffset(): number {
+    return this.state.cursor
+  }
+
   readVisibleText(): string {
     return this.readText().replace(/\n+$/, '')
   }

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -161,6 +161,7 @@ export class TerminalTextSurface implements TerminalSurface {
     this.input.addEventListener('keydown', this.handleKeyDown)
     this.input.addEventListener('paste', this.handlePaste)
     this.applyTheme(themeService.current().terminal)
+    this.renderOutput()
   }
 
   get cols(): number {
@@ -307,6 +308,7 @@ export class TerminalTextSurface implements TerminalSurface {
     this.root.style.background = theme.background
     this.root.style.color = theme.foreground
     this.output.style.caretColor = theme.cursor
+    this.root.style.setProperty('--terminal-cursor-color', theme.cursor)
     this.root.style.setProperty(
       '--terminal-selection-background',
       theme.selectionBackground
@@ -396,8 +398,46 @@ export class TerminalTextSurface implements TerminalSurface {
     })
   }
 
+  private createCursorElement(): HTMLElement {
+    const cursor = document.createElement('span')
+    cursor.dataset.terminalCursor = 'true'
+    cursor.setAttribute('aria-hidden', 'true')
+
+    Object.assign(cursor.style, {
+      borderLeft: '2px solid var(--terminal-cursor-color)',
+      display: 'inline-block',
+      height: '1em',
+      marginRight: '-2px',
+      pointerEvents: 'none',
+      userSelect: 'none',
+      verticalAlign: '-0.12em',
+      width: '0',
+    })
+
+    return cursor
+  }
+
   private renderOutput(): void {
-    this.output.textContent = this.outputBuffer.readText()
+    const text = this.outputBuffer.readText()
+
+    const cursorOffset = Math.min(
+      this.outputBuffer.readCursorOffset(),
+      text.length
+    )
+
+    const fragments: Node[] = []
+
+    if (cursorOffset > 0) {
+      fragments.push(document.createTextNode(text.slice(0, cursorOffset)))
+    }
+
+    fragments.push(this.createCursorElement())
+
+    if (cursorOffset < text.length) {
+      fragments.push(document.createTextNode(text.slice(cursorOffset)))
+    }
+
+    this.output.replaceChildren(...fragments)
     this.root.scrollTop = this.root.scrollHeight
   }
 

--- a/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
+++ b/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
@@ -32,6 +32,14 @@ const writeOutputToVisibleTerminal = async (data: string): Promise<void> => {
 const readTerminalBuffer = async (): Promise<string> =>
   browser.execute(() => window.__VIMEFLOW_E2E__?.getTerminalBuffer() ?? '')
 
+const hasGhosttyCursor = async (): Promise<boolean> =>
+  browser.execute(
+    () =>
+      document.querySelector(
+        '[data-terminal-renderer="ghostty"] [data-terminal-cursor="true"]'
+      ) !== null
+  )
+
 describe('Ghostty renderer smoke', () => {
   before(async () => {
     await waitForE2eBridge()
@@ -54,6 +62,11 @@ describe('Ghostty renderer smoke', () => {
           'Ghostty renderer root was not mounted; rebuild with VITE_TERMINAL_RENDERER=ghostty',
       }
     )
+
+    await browser.waitUntil(hasGhosttyCursor, {
+      timeout: 20_000,
+      timeoutMsg: 'Ghostty renderer did not mount a visible cursor marker',
+    })
 
     await browser.waitUntil(
       async () => (await readTerminalBuffer()).trim().length > 0,
@@ -86,5 +99,6 @@ describe('Ghostty renderer smoke', () => {
     expect(buffer).not.toContain(']2;ghostty-e2e')
     expect(buffer).not.toContain('[38;2;243;139;168m')
     expect(buffer).not.toContain('[0m')
+    expect(await hasGhosttyCursor()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- render a zero-text cursor marker in the shared text terminal surface at the display-buffer cursor offset
- expose the display-buffer cursor offset without leaking cursor state into transcript text
- add plain-text, Ghostty byte-path, and Ghostty E2E smoke coverage for cursor rendering

## Validation
- npx vitest run src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts src/features/terminal/components/TerminalPane/plainTextInstance.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
- npx vitest run src/features/terminal src/lib/e2e-bridge.test.ts
- npm run test:e2e:ghostty
- npx tsc -b --pretty false
- npx tsc -p tests/e2e/tsconfig.json --pretty false
- npm --ignore-scripts run lint
- npm --ignore-scripts run format:check
- git diff --check
- pre-push npm test

Linear: VIM-139