### PR TITLE
feat(terminal): render Ghostty SGR style runs

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,7 +55,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 10       | 4    | 2026-06-18   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 11       | 4    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -50,12 +50,12 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 6        | 3    | 2026-05-30   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 8        | 6    | 2026-06-13   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 9        | 6    | 2026-06-18   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 9        | 4    | 2026-06-18   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 10       | 4    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,7 +2,7 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-06-13
+last_updated: 2026-06-18
 ref_count: 6
 ---
 
@@ -121,4 +121,13 @@ base data is technically "correct."
 - **Finding:** The restore effect correctly recomputes `activePtyId` when `restartPersistedActiveShell` spawns a replacement PTY for the persisted active shell. That updated value is passed to `reconstructWorkspace`, but the subsequent `activate()` call still used the original `list.activeSessionId`. In the graceful-quit restart path that original value is `null`, so callers that rely on the active-PTY activation branch (no `onActivePersisted` handler) fall back to the first session instead of selecting the restarted active shell.
 - **Fix:** Pass the updated `activePtyId` local to `activate()` instead of `list.activeSessionId`.
 - **Verification:** Added regression test that restarts a persisted active shell without an `onActivePersisted` handler and asserts `onActiveResolved` is called with the workspace session id.
+- **Commit:** same commit as this entry
+
+### 9. `readStyledRuns()` rescans the entire display buffer on every `write()`
+
+- **Source:** github-claude | PR #530 round 1 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L577-609
+- **Finding:** `renderOutput()` called `readStyledRuns()` on every `writeParsedOutput()`, iterating every character in the display buffer to recompute style-run boundaries. With the default 10_000-line scrollback this produced ~800k style comparisons per write for a full buffer, and high-throughput terminal output could trigger 50-100+ such writes per second.
+- **Fix:** Removed the parallel `styles` array and made `DisplayState` maintain an incremental `runs` list. `applyDisplayData` now pushes, splits, and merges run entries as characters are appended or erased, so `readStyledRuns()` returns the pre-computed list in O(1) instead of rescanning the buffer.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -109,3 +109,12 @@ all required state through pure display-state helpers.
 - **Finding:** `createOutputFragments` split a styled run at the cursor offset into two separate `<span data-terminal-style-run>` elements, each carrying identical CSS. Code that queries `data-terminal-style-run` elements to read run text or style (including E2E helpers) saw a fragmented view of what is logically one run.
 - **Fix:** When the cursor lands strictly inside a styled run, wrap the cursor element inside a single `data-terminal-style-run` span rather than emitting two sibling spans. Added a regression test that asserts only one style-run span exists and that it contains the cursor element.
 - **Commit:** same commit as this entry
+
+### 11. applySgrStyle: invalid color sub-params fall through, misread as style codes
+
+- **Source:** github-claude | PR #530 round 2 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L254-288
+- **Finding:** When a `38;2;R;G;B` true-color sequence has invalid or missing component values, the guard rejected the color but did not advance the parameter index past the sub-parameters. Control fell through to `index += 1`, so the color-mode byte (`2` or `5`) was consumed as a standalone SGR attribute in the next iteration, applying `dim` or corrupting subsequent styles.
+- **Fix:** Restructured the true-color and indexed branches to advance `index` by the full arity (5 for mode 2, 3 for mode 5) unconditionally, applying the style only when the color resolves. Added a regression test for out-of-range RGB and truncated indexed sequences.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -100,3 +100,12 @@ all required state through pure display-state helpers.
 - **Finding:** The parser passed `parseCsiIntegerParameter` results directly to sentinel emission for `CSI D`, `CSI C`, and `CSI G`. For cursor movement/count parameters, an omitted value and an explicit `0` should both behave as the default count/column `1`. The original code emitted no D/C movement for `CSI 0D`/`CSI 0C` and only a carriage return for `CSI 0G`, which corrupts progress or prompt redraw output.
 - **Fix:** Normalized parsed zero values to `1` in the D, C, and G branches before emitting cursor-left/cursor-right/carriage-return sentinels, and added a regression test that asserts `CSI 0D`, `CSI 0C`, and `CSI 0G` each produce the same result as the default value.
 - **Commit:** same commit as this entry
+
+### 10. Cursor inside a styled run splits it into two sibling `data-terminal-style-run` spans
+
+- **Source:** github-claude | PR #530 round 1 | 2026-06-18
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts` L530-572
+- **Finding:** `createOutputFragments` split a styled run at the cursor offset into two separate `<span data-terminal-style-run>` elements, each carrying identical CSS. Code that queries `data-terminal-style-run` elements to read run text or style (including E2E helpers) saw a fragmented view of what is logically one run.
+- **Fix:** When the cursor lands strictly inside a styled run, wrap the cursor element inside a single `data-terminal-style-run` span rather than emitting two sibling spans. Added a regression test that asserts only one style-run span exists and that it contains the cursor element.
+- **Commit:** same commit as this entry

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -29,6 +29,7 @@ const encodeText = (text: string): string =>
 
 const ESC = '\x1b'
 const SGR_FINAL = 'm'
+const TRUE_COLOR_PINK = ['rgb', '(243, 139, 168)'].join('')
 
 const createdTerminals = new Set<ReturnType<typeof createGhosttyTerminal>>()
 
@@ -221,6 +222,33 @@ describe('ghosttyInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('abc')
     expect(cursor?.previousSibling?.textContent).toBe('a')
     expect(cursor?.nextSibling?.textContent).toBe('bc')
+  })
+
+  test('renders SGR true-color styles from Ghostty byte payloads', () => {
+    const created = createTrackedGhosttyTerminal()
+
+    const output =
+      `prompt ${ESC}[38;2;243;139;168${SGR_FINAL}` +
+      `branch${ESC}[0${SGR_FINAL} done`
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    const terminalOutput = created.terminal.element?.querySelector('pre')
+
+    const styleRun = terminalOutput?.querySelector(
+      '[data-terminal-style-run="true"]'
+    )
+
+    expect(terminalOutput?.textContent).toBe('prompt branch done')
+    expect(created.viewportReader.readVisibleText()).toBe('prompt branch done')
+    expect(styleRun?.textContent).toBe('branch')
+    expect((styleRun as HTMLElement | null)?.style.color).toBe(TRUE_COLOR_PINK)
   })
 
   test('renders invalid byte payloads through the byte path', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -12,7 +12,10 @@ import { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
 import { createGhosttyParserEngine } from './ghosttyParserEngine'
 import type { TerminalParserEngine } from './terminalParserEngine'
 import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
-import { TerminalTextSurface } from './terminalTextSurface'
+import {
+  TerminalTextSurface,
+  type TerminalTextSurfaceOutput,
+} from './terminalTextSurface'
 
 export { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
 
@@ -32,8 +35,8 @@ class GhosttyTerminalModel {
 
     this.terminal = new TerminalTextSurface({
       rendererId: GHOSTTY_TERMINAL_RENDERER_ID,
-      transformOutput: (data): string =>
-        this.parserEngine.parseText(data, null).visibleText,
+      transformOutput: (data): TerminalTextSurfaceOutput =>
+        this.parserEngine.parseText(data, null),
     })
   }
 
@@ -45,9 +48,9 @@ class GhosttyTerminalModel {
         return
       }
 
-      const { visibleText } = this.parserEngine.parseOutput(chunk)
+      const output = this.parserEngine.parseOutput(chunk)
 
-      this.terminal.writeVisible(visibleText, callback)
+      this.terminal.writeParsedOutput(output, callback)
     },
   }
 

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
@@ -5,6 +5,7 @@ import {
   GHOSTTY_PARSER_ENGINE_ID,
   createGhosttyParserEngine,
 } from './ghosttyParserEngine'
+import { getSgrStyleSentinel } from './terminalControlParser'
 import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 
 const encodeBase64 = (bytes: Uint8Array): string => {
@@ -108,6 +109,9 @@ describe('ghosttyParserEngine', () => {
 
     expect(engine.parseOutput(createByteChunk(output, 0, 'live'))).toEqual({
       visibleText: 'feat/ghostty-spike % ',
+      displayText:
+        `${getSgrStyleSentinel([38, 2, 243, 139, 168])}` +
+        `feat/ghostty-spike${getSgrStyleSentinel([0])} % `,
     })
     expect(handler).not.toHaveBeenCalled()
   })

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -21,6 +21,7 @@ export class GhosttyControlSequenceParserEngine
     super({
       capabilities: GHOSTTY_TERMINAL_CAPABILITIES,
       consumeControlsWithoutSubscribers: true,
+      preserveSgrStyles: true,
     })
   }
 }

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -35,6 +35,8 @@ const encodeBase64 = (bytes: Uint8Array): string => {
 const encodeText = (text: string): string =>
   encodeBase64(new TextEncoder().encode(text))
 
+const TRUE_COLOR_PINK = ['rgb', '(243, 139, 168)'].join('')
+
 const createdTerminals = new Set<ReturnType<typeof createPlainTextTerminal>>()
 
 const createTrackedPlainTextTerminal = (): ReturnType<
@@ -142,6 +144,42 @@ describe('plainTextInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('abc')
     expect(cursor?.previousSibling?.textContent).toBe('a')
     expect(cursor?.nextSibling?.textContent).toBe('bc')
+  })
+
+  test('renders SGR true-color styles without adding transcript text', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    // cspell:disable-next-line
+    created.terminal.write('prompt \x1b[38;2;243;139;168mbranch\x1b[0m done')
+
+    const output = created.terminal.element?.querySelector('pre')
+    const styleRun = output?.querySelector('[data-terminal-style-run="true"]')
+
+    expect(output?.textContent).toBe('prompt branch done')
+    expect(created.viewportReader.readVisibleText()).toBe('prompt branch done')
+    expect(styleRun?.textContent).toBe('branch')
+    expect((styleRun as HTMLElement | null)?.style.color).toBe(TRUE_COLOR_PINK)
+  })
+
+  test('renders ANSI styles from theme variables', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    // cspell:disable-next-line
+    created.terminal.write('\x1b[1;4;31mred\x1b[0m')
+
+    const output = created.terminal.element?.querySelector('pre')
+    const styleRun = output?.querySelector('[data-terminal-style-run="true"]')
+
+    expect(output?.textContent).toBe('red')
+    expect(created.viewportReader.readVisibleText()).toBe('red')
+    expect(styleRun?.textContent).toBe('red')
+    expect((styleRun as HTMLElement | null)?.style.color).toBe(
+      'var(--terminal-ansi-red)'
+    )
+    expect((styleRun as HTMLElement | null)?.style.fontWeight).toBe('700')
+    expect((styleRun as HTMLElement | null)?.style.textDecoration).toBe(
+      'underline'
+    )
   })
 
   test('rewrites the current line when carriage return output arrives', () => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -189,7 +189,10 @@ describe('plainTextInstance', () => {
     created.terminal.write('\x1b[38;2;243;139;168mabc\x1b[2D')
 
     const output = created.terminal.element?.querySelector('pre')
-    const styleRuns = output?.querySelectorAll('[data-terminal-style-run="true"]')
+
+    const styleRuns = output?.querySelectorAll(
+      '[data-terminal-style-run="true"]'
+    )
     const cursor = output?.querySelector('[data-terminal-cursor="true"]')
 
     expect(output?.textContent).toBe('abc')

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -182,6 +182,24 @@ describe('plainTextInstance', () => {
     )
   })
 
+  test('keeps a styled run as a single span when the cursor is inside it', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    // cspell:disable-next-line
+    created.terminal.write('\x1b[38;2;243;139;168mabc\x1b[2D')
+
+    const output = created.terminal.element?.querySelector('pre')
+    const styleRuns = output?.querySelectorAll('[data-terminal-style-run="true"]')
+    const cursor = output?.querySelector('[data-terminal-cursor="true"]')
+
+    expect(output?.textContent).toBe('abc')
+    expect(created.viewportReader.readVisibleText()).toBe('abc')
+    expect(styleRuns?.length).toBe(1)
+    expect(styleRuns?.[0]?.contains(cursor ?? null)).toBe(true)
+    expect(cursor?.previousSibling?.textContent).toBe('a')
+    expect(cursor?.nextSibling?.textContent).toBe('bc')
+  })
+
   test('rewrites the current line when carriage return output arrives', () => {
     const created = createTrackedPlainTextTerminal()
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.ts
@@ -10,7 +10,10 @@ import type {
 import { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
 import { createControlSequenceTerminalParserEngine } from './terminalParserEngine'
 import { PLAIN_TEXT_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
-import { TerminalTextSurface } from './terminalTextSurface'
+import {
+  TerminalTextSurface,
+  type TerminalTextSurfaceOutput,
+} from './terminalTextSurface'
 
 export { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
 
@@ -18,11 +21,12 @@ class PlainTextTerminalModel {
   private readonly parserEngine = createControlSequenceTerminalParserEngine({
     capabilities: PLAIN_TEXT_TERMINAL_CAPABILITIES,
     consumeControlsWithoutSubscribers: true,
+    preserveSgrStyles: true,
   })
   readonly terminal = new TerminalTextSurface({
     rendererId: PLAIN_TEXT_TERMINAL_RENDERER_ID,
-    transformOutput: (data): string =>
-      this.parserEngine.parseText(data, null).visibleText,
+    transformOutput: (data): TerminalTextSurfaceOutput =>
+      this.parserEngine.parseText(data, null),
   })
 
   readonly parser: TerminalParser = this.parserEngine.parser
@@ -35,9 +39,9 @@ class PlainTextTerminalModel {
         return
       }
 
-      const { visibleText } = this.parserEngine.parseOutput(chunk)
+      const output = this.parserEngine.parseOutput(chunk)
 
-      this.terminal.writeVisible(visibleText, callback)
+      this.terminal.writeParsedOutput(output, callback)
     },
   }
 

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
@@ -4,6 +4,7 @@ import {
   getClearScreenSentinel,
   getCursorLeftSentinel,
   getCursorRightSentinel,
+  getSgrStyleSentinel,
 } from './terminalControlParser'
 
 const ESC = '\x1b'
@@ -99,6 +100,26 @@ describe('TerminalControlSequenceParser', () => {
 
     expect(visible).toBe('prompt branch done')
     expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('preserves CSI style sequences as display-only sentinels when configured', () => {
+    const parser = new TerminalControlSequenceParser({
+      consumeControlsWithoutSubscribers: true,
+      preserveSgrStyles: true,
+    })
+
+    const output = parser.transformDisplayOutput(
+      `prompt ${ESC}[38;2;243;139;168${SGR_FINAL}` +
+        `branch${ESC}[1;4${SGR_FINAL}!${ESC}[0${SGR_FINAL} done`,
+      null
+    )
+
+    expect(output.visibleText).toBe('prompt branch! done')
+    expect(output.displayText).toBe(
+      `prompt ${getSgrStyleSentinel([38, 2, 243, 139, 168])}` +
+        `branch${getSgrStyleSentinel([1, 4])}!` +
+        `${getSgrStyleSentinel([0])} done`
+    )
   })
 
   test('strips short ESC mode controls from visible output', () => {

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -18,6 +18,18 @@ const ERASE_LINE_SENTINELS = ['\u{F0000}', '\u{F0001}', '\u{F0002}']
 const CLEAR_SCREEN_SENTINEL = '\u{F0003}'
 const CURSOR_LEFT_SENTINEL = '\u{F0004}'
 const CURSOR_RIGHT_SENTINEL = '\u{F0005}'
+const SGR_STYLE_SENTINEL_START = '\u{F0006}'
+const SGR_STYLE_SENTINEL_END = '\u{F0007}'
+
+export interface TerminalControlSequenceOutput {
+  readonly visibleText: string
+  readonly displayText?: string
+}
+
+export interface SgrStyleSentinel {
+  readonly parameters: readonly number[]
+  readonly length: number
+}
 
 export const getEraseLineSentinel = (mode: 0 | 1 | 2): string =>
   ERASE_LINE_SENTINELS[mode]
@@ -27,6 +39,9 @@ export const getClearScreenSentinel = (): string => CLEAR_SCREEN_SENTINEL
 export const getCursorLeftSentinel = (): string => CURSOR_LEFT_SENTINEL
 
 export const getCursorRightSentinel = (): string => CURSOR_RIGHT_SENTINEL
+
+export const getSgrStyleSentinel = (parameters: readonly number[]): string =>
+  `${SGR_STYLE_SENTINEL_START}${parameters.join(';')}${SGR_STYLE_SENTINEL_END}`
 
 export const getEraseLineModeFromSentinel = (
   character: string
@@ -49,6 +64,56 @@ export const isCursorLeftSentinel = (character: string): boolean =>
 export const isCursorRightSentinel = (character: string): boolean =>
   character === CURSOR_RIGHT_SENTINEL
 
+const parseSgrParameters = (content: string): readonly number[] | null => {
+  if (content.length === 0) {
+    return [0]
+  }
+
+  const parameters: number[] = []
+
+  for (const parameter of content.split(';')) {
+    if (parameter.length === 0) {
+      parameters.push(0)
+      continue
+    }
+
+    if (!/^\d+$/.test(parameter)) {
+      return null
+    }
+
+    parameters.push(Number(parameter))
+  }
+
+  return parameters
+}
+
+export const readSgrStyleSentinel = (
+  data: string,
+  startIndex: number
+): SgrStyleSentinel | null => {
+  if (!data.startsWith(SGR_STYLE_SENTINEL_START, startIndex)) {
+    return null
+  }
+
+  const contentStart = startIndex + SGR_STYLE_SENTINEL_START.length
+  const contentEnd = data.indexOf(SGR_STYLE_SENTINEL_END, contentStart)
+
+  if (contentEnd === -1) {
+    return null
+  }
+
+  const parameters = parseSgrParameters(data.slice(contentStart, contentEnd))
+
+  if (!parameters) {
+    return null
+  }
+
+  return {
+    parameters,
+    length: contentEnd + SGR_STYLE_SENTINEL_END.length - startIndex,
+  }
+}
+
 interface SequenceTerminator {
   readonly index: number
   readonly length: number
@@ -56,6 +121,7 @@ interface SequenceTerminator {
 
 export interface TerminalControlSequenceParserOptions {
   readonly consumeControlsWithoutSubscribers?: boolean
+  readonly preserveSgrStyles?: boolean
 }
 
 const createDisposable = (dispose: () => void): TerminalDisposable => ({
@@ -198,6 +264,13 @@ export class TerminalControlSequenceParser implements TerminalParser {
     data: string,
     output: TerminalParserOutputContext | null
   ): string {
+    return this.transformDisplayOutput(data, output).visibleText
+  }
+
+  transformDisplayOutput(
+    data: string,
+    output: TerminalParserOutputContext | null
+  ): TerminalControlSequenceOutput {
     if (
       this.handlers.size === 0 &&
       !this.options.consumeControlsWithoutSubscribers
@@ -205,7 +278,7 @@ export class TerminalControlSequenceParser implements TerminalParser {
       const visible = `${this.pendingControlSequence}${data}`
       this.pendingControlSequence = ''
 
-      return visible
+      return { visibleText: visible }
     }
 
     const source = `${this.pendingControlSequence}${data}`
@@ -217,8 +290,9 @@ export class TerminalControlSequenceParser implements TerminalParser {
   private consumeControlSequences(
     data: string,
     output: TerminalParserOutputContext | null
-  ): string {
+  ): TerminalControlSequenceOutput {
     let visible = ''
+    let display = ''
     let cursor = 0
 
     while (cursor < data.length) {
@@ -226,10 +300,12 @@ export class TerminalControlSequenceParser implements TerminalParser {
 
       if (sequenceStart === -1) {
         visible += data.slice(cursor)
+        display += data.slice(cursor)
         break
       }
 
       visible += data.slice(cursor, sequenceStart)
+      display += data.slice(cursor, sequenceStart)
 
       if (data.startsWith(OSC_PREFIX, sequenceStart)) {
         const contentStart = sequenceStart + OSC_PREFIX.length
@@ -269,7 +345,10 @@ export class TerminalControlSequenceParser implements TerminalParser {
           const mode = parseCsiIntegerParameter(content, 0)
 
           if (mode === 0 || mode === 1 || mode === 2) {
-            visible += getEraseLineSentinel(mode)
+            const sentinel = getEraseLineSentinel(mode)
+
+            visible += sentinel
+            display += sentinel
           }
         }
 
@@ -281,7 +360,10 @@ export class TerminalControlSequenceParser implements TerminalParser {
           const mode = parseCsiIntegerParameter(content, 0)
 
           if (mode === 2) {
-            visible += getClearScreenSentinel()
+            const sentinel = getClearScreenSentinel()
+
+            visible += sentinel
+            display += sentinel
           }
         }
 
@@ -295,10 +377,13 @@ export class TerminalControlSequenceParser implements TerminalParser {
           if (count !== null) {
             const normalizedCount = count === 0 ? 1 : count
 
-            visible += repeatDisplayControl(
+            const control = repeatDisplayControl(
               getCursorLeftSentinel(),
               normalizedCount
             )
+
+            visible += control
+            display += control
           }
         }
 
@@ -312,10 +397,13 @@ export class TerminalControlSequenceParser implements TerminalParser {
           if (count !== null) {
             const normalizedCount = count === 0 ? 1 : count
 
-            visible += repeatDisplayControl(
+            const control = repeatDisplayControl(
               getCursorRightSentinel(),
               normalizedCount
             )
+
+            visible += control
+            display += control
           }
         }
 
@@ -329,10 +417,25 @@ export class TerminalControlSequenceParser implements TerminalParser {
           if (column !== null) {
             const normalizedColumn = column === 0 ? 1 : column
 
-            visible += `\r${repeatDisplayControl(
+            const control = `\r${repeatDisplayControl(
               getCursorRightSentinel(),
               normalizedColumn - 1
             )}`
+
+            visible += control
+            display += control
+          }
+        }
+
+        if (finalByte === 'm' && this.options.preserveSgrStyles) {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const parameters = parseSgrParameters(content)
+
+          if (parameters) {
+            display += getSgrStyleSentinel(parameters)
           }
         }
 
@@ -361,10 +464,14 @@ export class TerminalControlSequenceParser implements TerminalParser {
       this.pendingControlSequence.length > MAX_PENDING_CONTROL_SEQUENCE_LENGTH
     ) {
       visible += this.pendingControlSequence
+      display += this.pendingControlSequence
       this.pendingControlSequence = ''
     }
 
-    return visible
+    return {
+      visibleText: visible,
+      displayText: display === visible ? undefined : display,
+    }
   }
 
   private consumeOsc(

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -4,8 +4,13 @@ import {
   getCursorLeftSentinel,
   getCursorRightSentinel,
   getEraseLineSentinel,
+  getSgrStyleSentinel,
 } from './terminalControlParser'
 import { TerminalDisplayBuffer } from './terminalDisplayBuffer'
+
+const TRUE_COLOR_PINK = ['rgb', '(243, 139, 168)'].join('')
+const INDEXED_COLOR_RED = ['rgb', '(255, 0, 0)'].join('')
+const INDEXED_COLOR_GRAY = ['rgb', '(238, 238, 238)'].join('')
 
 describe('TerminalDisplayBuffer', () => {
   test('appends visible text and trims trailing newlines from viewport reads', () => {
@@ -78,6 +83,84 @@ describe('TerminalDisplayBuffer', () => {
     buffer.write(getCursorLeftSentinel().repeat(2))
 
     expect(buffer.readCursorOffset()).toBe(1)
+  })
+
+  test('consumes SGR style controls into style runs without adding text', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write(
+      `plain ${getSgrStyleSentinel([38, 2, 243, 139, 168])}` +
+        `pink${getSgrStyleSentinel([1, 4])}!${getSgrStyleSentinel([0])} done`
+    )
+
+    expect(buffer.readText()).toBe('plain pink! done')
+    expect(buffer.readStyledRuns()).toEqual([
+      { text: 'plain ', style: {} },
+      { text: 'pink', style: { foreground: TRUE_COLOR_PINK } },
+      {
+        text: '!',
+        style: {
+          bold: true,
+          foreground: TRUE_COLOR_PINK,
+          underline: true,
+        },
+      },
+      { text: ' done', style: {} },
+    ])
+  })
+
+  test('maps ANSI and indexed SGR colors to terminal theme variables', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write(
+      `${getSgrStyleSentinel([31])}red` +
+        `${getSgrStyleSentinel([38, 5, 12])}bright-blue` +
+        `${getSgrStyleSentinel([0])}`
+    )
+
+    expect(buffer.readText()).toBe('redbright-blue')
+    expect(buffer.readStyledRuns()).toEqual([
+      { text: 'red', style: { foreground: 'var(--terminal-ansi-red)' } },
+      {
+        text: 'bright-blue',
+        style: { foreground: 'var(--terminal-ansi-bright-blue)' },
+      },
+    ])
+  })
+
+  test('maps xterm 256-color indexed SGR colors to RGB values', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write(
+      `${getSgrStyleSentinel([38, 5, 196])}cube-red ` +
+        `${getSgrStyleSentinel([48, 5, 255])}gray-background` +
+        `${getSgrStyleSentinel([0])}`
+    )
+
+    expect(buffer.readText()).toBe('cube-red gray-background')
+    expect(buffer.readStyledRuns()).toEqual([
+      { text: 'cube-red ', style: { foreground: INDEXED_COLOR_RED } },
+      {
+        text: 'gray-background',
+        style: {
+          background: INDEXED_COLOR_GRAY,
+          foreground: INDEXED_COLOR_RED,
+        },
+      },
+    ])
+  })
+
+  test('preserves split CRLF pairing across SGR style controls', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('hello\r')
+    buffer.write(getSgrStyleSentinel([0]))
+    buffer.write('\nworld')
+
+    expect(buffer.readVisibleText()).toBe('hello\nworld')
+    expect(buffer.readStyledRuns()).toEqual([
+      { text: 'hello\nworld', style: {} },
+    ])
   })
 
   test('clears viewport text when a clear-screen display control arrives', () => {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -150,6 +150,24 @@ describe('TerminalDisplayBuffer', () => {
     ])
   })
 
+  test('ignores malformed true-color and indexed SGR sub-params without misreading them as style codes', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write(
+      `${getSgrStyleSentinel([38, 2, 256, 0, 0])}invalid-true-color ` +
+        `${getSgrStyleSentinel([38, 5])}invalid-indexed` +
+        `${getSgrStyleSentinel([0])}`
+    )
+
+    expect(buffer.readText()).toBe('invalid-true-color invalid-indexed')
+    expect(buffer.readStyledRuns()).toEqual([
+      {
+        text: 'invalid-true-color invalid-indexed',
+        style: {},
+      },
+    ])
+  })
+
   test('preserves split CRLF pairing across SGR style controls', () => {
     const buffer = new TerminalDisplayBuffer()
 

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -3,19 +3,44 @@ import {
   isClearScreenSentinel,
   isCursorLeftSentinel,
   isCursorRightSentinel,
+  readSgrStyleSentinel,
 } from './terminalControlParser'
 
 const DEFAULT_MAX_SCROLLBACK_LINES = 10_000
+const CSS_RGB_FUNCTION = 'rgb'
+const XTERM_COLOR_CUBE_FIRST_INDEX = 16
+const XTERM_COLOR_CUBE_LAST_INDEX = 231
+const XTERM_GRAYSCALE_FIRST_INDEX = 232
+const XTERM_GRAYSCALE_LAST_INDEX = 255
+const XTERM_GRAYSCALE_BASE = 8
+const XTERM_GRAYSCALE_STEP = 10
+
+export interface TerminalDisplayStyle {
+  readonly background?: string
+  readonly bold?: boolean
+  readonly dim?: boolean
+  readonly foreground?: string
+  readonly italic?: boolean
+  readonly underline?: boolean
+}
+
+export interface TerminalDisplayRun {
+  readonly text: string
+  readonly style: TerminalDisplayStyle
+}
 
 interface DisplayState {
   readonly text: string
   readonly cursor: number
   readonly pendingCr: boolean
+  readonly style: TerminalDisplayStyle
+  readonly styles: readonly TerminalDisplayStyle[]
 }
 
 interface DisplayCharacterResult {
   readonly text: string
   readonly cursor: number
+  readonly styles: TerminalDisplayStyle[]
 }
 
 export interface TerminalDisplayBufferOptions {
@@ -26,7 +51,265 @@ const createEmptyState = (): DisplayState => ({
   text: '',
   cursor: 0,
   pendingCr: false,
+  style: {},
+  styles: [],
 })
+
+const ANSI_COLOR_NAMES = [
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'white',
+] as const
+
+const ANSI_BRIGHT_COLOR_NAMES = [
+  'bright-black',
+  'bright-red',
+  'bright-green',
+  'bright-yellow',
+  'bright-blue',
+  'bright-magenta',
+  'bright-cyan',
+  'bright-white',
+] as const
+
+const isRgbComponent = (value: number | undefined): value is number =>
+  value !== undefined && Number.isInteger(value) && value >= 0 && value <= 255
+
+const formatRgbColor = (red: number, green: number, blue: number): string =>
+  `${CSS_RGB_FUNCTION}(${red}, ${green}, ${blue})`
+
+const styleWith = (
+  style: TerminalDisplayStyle,
+  patch: Partial<TerminalDisplayStyle>
+): TerminalDisplayStyle => ({
+  ...style,
+  ...patch,
+})
+
+const removeStyleKeys = (
+  style: TerminalDisplayStyle,
+  keys: readonly (keyof TerminalDisplayStyle)[]
+): TerminalDisplayStyle => {
+  const next: Partial<TerminalDisplayStyle> = { ...style }
+
+  keys.forEach((key) => {
+    delete next[key]
+  })
+
+  return next
+}
+
+const readAnsiForeground = (code: number): string | null => {
+  if (code >= 30 && code <= 37) {
+    return `var(--terminal-ansi-${ANSI_COLOR_NAMES[code - 30]})`
+  }
+
+  if (code >= 90 && code <= 97) {
+    return `var(--terminal-ansi-${ANSI_BRIGHT_COLOR_NAMES[code - 90]})`
+  }
+
+  return null
+}
+
+const readAnsiBackground = (code: number): string | null => {
+  if (code >= 40 && code <= 47) {
+    return `var(--terminal-ansi-${ANSI_COLOR_NAMES[code - 40]})`
+  }
+
+  if (code >= 100 && code <= 107) {
+    return `var(--terminal-ansi-${ANSI_BRIGHT_COLOR_NAMES[code - 100]})`
+  }
+
+  return null
+}
+
+const readIndexedAnsiColor = (index: number | undefined): string | null => {
+  if (
+    index === undefined ||
+    !Number.isInteger(index) ||
+    index < 0 ||
+    index > XTERM_GRAYSCALE_LAST_INDEX
+  ) {
+    return null
+  }
+
+  if (index <= 7) {
+    return `var(--terminal-ansi-${ANSI_COLOR_NAMES[index]})`
+  }
+
+  if (index <= 15) {
+    return `var(--terminal-ansi-${ANSI_BRIGHT_COLOR_NAMES[index - 8]})`
+  }
+
+  if (index <= XTERM_COLOR_CUBE_LAST_INDEX) {
+    const colorIndex = index - XTERM_COLOR_CUBE_FIRST_INDEX
+    const colorCubeSteps = [0, 95, 135, 175, 215, 255] as const
+    const red = colorCubeSteps[Math.floor(colorIndex / 36)]
+    const green = colorCubeSteps[Math.floor((colorIndex % 36) / 6)]
+    const blue = colorCubeSteps[colorIndex % 6]
+
+    return formatRgbColor(red, green, blue)
+  }
+
+  if (index >= XTERM_GRAYSCALE_FIRST_INDEX) {
+    const level =
+      XTERM_GRAYSCALE_BASE +
+      (index - XTERM_GRAYSCALE_FIRST_INDEX) * XTERM_GRAYSCALE_STEP
+
+    return formatRgbColor(level, level, level)
+  }
+
+  return null
+}
+
+const applySgrStyle = (
+  style: TerminalDisplayStyle,
+  parameters: readonly number[]
+): TerminalDisplayStyle => {
+  let next = style
+  let index = 0
+
+  while (index < parameters.length) {
+    const parameter = parameters[index] ?? 0
+
+    if (parameter === 0) {
+      next = {}
+      index += 1
+      continue
+    }
+
+    if (parameter === 1) {
+      next = styleWith(next, { bold: true })
+      index += 1
+      continue
+    }
+
+    if (parameter === 2) {
+      next = styleWith(next, { dim: true })
+      index += 1
+      continue
+    }
+
+    if (parameter === 3) {
+      next = styleWith(next, { italic: true })
+      index += 1
+      continue
+    }
+
+    if (parameter === 4) {
+      next = styleWith(next, { underline: true })
+      index += 1
+      continue
+    }
+
+    if (parameter === 22) {
+      next = removeStyleKeys(next, ['bold', 'dim'])
+      index += 1
+      continue
+    }
+
+    if (parameter === 23) {
+      next = removeStyleKeys(next, ['italic'])
+      index += 1
+      continue
+    }
+
+    if (parameter === 24) {
+      next = removeStyleKeys(next, ['underline'])
+      index += 1
+      continue
+    }
+
+    if (parameter === 39) {
+      next = removeStyleKeys(next, ['foreground'])
+      index += 1
+      continue
+    }
+
+    if (parameter === 49) {
+      next = removeStyleKeys(next, ['background'])
+      index += 1
+      continue
+    }
+
+    const ansiForeground = readAnsiForeground(parameter)
+
+    if (ansiForeground) {
+      next = styleWith(next, { foreground: ansiForeground })
+      index += 1
+      continue
+    }
+
+    const ansiBackground = readAnsiBackground(parameter)
+
+    if (ansiBackground) {
+      next = styleWith(next, { background: ansiBackground })
+      index += 1
+      continue
+    }
+
+    const colorMode = parameters[index + 1]
+
+    if ((parameter === 38 || parameter === 48) && colorMode === 2) {
+      const red = parameters[index + 2]
+      const green = parameters[index + 3]
+      const blue = parameters[index + 4]
+
+      if (
+        isRgbComponent(red) &&
+        isRgbComponent(green) &&
+        isRgbComponent(blue)
+      ) {
+        const color = formatRgbColor(red, green, blue)
+
+        next =
+          parameter === 38
+            ? styleWith(next, { foreground: color })
+            : styleWith(next, { background: color })
+        index += 5
+        continue
+      }
+    }
+
+    if ((parameter === 38 || parameter === 48) && colorMode === 5) {
+      const color = readIndexedAnsiColor(parameters[index + 2])
+
+      if (color) {
+        next =
+          parameter === 38
+            ? styleWith(next, { foreground: color })
+            : styleWith(next, { background: color })
+        index += 3
+        continue
+      }
+    }
+
+    index += 1
+  }
+
+  return next
+}
+
+const areStylesEqual = (
+  left: TerminalDisplayStyle,
+  right: TerminalDisplayStyle
+): boolean =>
+  left.background === right.background &&
+  left.bold === right.bold &&
+  left.dim === right.dim &&
+  left.foreground === right.foreground &&
+  left.italic === right.italic &&
+  left.underline === right.underline
+
+const createStyleCells = (
+  length: number,
+  style: TerminalDisplayStyle
+): TerminalDisplayStyle[] => Array.from({ length }, () => style)
 
 const findLineStart = (text: string, cursor: number): number => {
   if (cursor <= 0) {
@@ -67,23 +350,32 @@ const readPreviousCodePointLength = (text: string, cursor: number): number => {
 
 const writeDisplayCharacter = (
   text: string,
+  styles: TerminalDisplayStyle[],
   cursor: number,
-  character: string
+  character: string,
+  style: TerminalDisplayStyle
 ): DisplayCharacterResult => {
+  const characterStyles = createStyleCells(character.length, style)
+
   if (cursor < text.length && text[cursor] !== '\n') {
     const nextLength = readCodePointLength(text, cursor)
+    styles.splice(cursor, nextLength, ...characterStyles)
 
     return {
       text: `${text.slice(0, cursor)}${character}${text.slice(
         cursor + nextLength
       )}`,
       cursor: cursor + character.length,
+      styles,
     }
   }
+
+  styles.splice(cursor, 0, ...characterStyles)
 
   return {
     text: `${text.slice(0, cursor)}${character}${text.slice(cursor)}`,
     cursor: cursor + character.length,
+    styles,
   }
 }
 
@@ -100,6 +392,10 @@ const eraseLineInState = (
     return {
       ...state,
       text: `${text.slice(0, cursor)}${text.slice(lineEnd)}`,
+      styles: [
+        ...state.styles.slice(0, cursor),
+        ...state.styles.slice(lineEnd),
+      ],
     }
   }
 
@@ -110,6 +406,10 @@ const eraseLineInState = (
       ...state,
       text: `${text.slice(0, lineStart)}${text.slice(cursor + cursorCodePointLength)}`,
       cursor: lineStart,
+      styles: [
+        ...state.styles.slice(0, lineStart),
+        ...state.styles.slice(cursor + cursorCodePointLength),
+      ],
     }
   }
 
@@ -117,23 +417,43 @@ const eraseLineInState = (
     ...state,
     text: `${text.slice(0, lineStart)}${text.slice(lineEnd)}`,
     cursor: lineStart,
+    styles: [
+      ...state.styles.slice(0, lineStart),
+      ...state.styles.slice(lineEnd),
+    ],
   }
 }
 
 const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
   let text = state.text
+  let styles = [...state.styles]
   let cursor = Math.min(Math.max(state.cursor, 0), text.length)
   let pendingCr = state.pendingCr
+  let style = state.style
+  let index = 0
 
-  for (const character of data) {
+  while (index < data.length) {
+    const styleControl = readSgrStyleSentinel(data, index)
+
+    if (styleControl) {
+      style = applySgrStyle(style, styleControl.parameters)
+      index += styleControl.length
+      continue
+    }
+
+    const characterLength = readCodePointLength(data, index)
+    const character = data.slice(index, index + characterLength)
     const eraseLineMode = getEraseLineModeFromSentinel(character)
+
+    index += characterLength
 
     if (eraseLineMode !== null) {
       const nextState = eraseLineInState(
-        { text, cursor, pendingCr },
+        { text, cursor, pendingCr, style, styles },
         eraseLineMode
       )
       text = nextState.text
+      styles = [...nextState.styles]
       cursor = nextState.cursor
       pendingCr = false
       continue
@@ -141,6 +461,7 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
 
     if (isClearScreenSentinel(character)) {
       text = ''
+      styles = []
       cursor = 0
       pendingCr = false
       continue
@@ -176,6 +497,7 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
       }
 
       text = `${text.slice(0, cursor)}\n${text.slice(cursor)}`
+      styles.splice(cursor, 0, style)
       cursor += 1
       pendingCr = false
       continue
@@ -187,13 +509,14 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
       continue
     }
 
-    const next = writeDisplayCharacter(text, cursor, character)
+    const next = writeDisplayCharacter(text, styles, cursor, character, style)
     text = next.text
+    styles = next.styles
     cursor = next.cursor
     pendingCr = false
   }
 
-  return { text, cursor, pendingCr }
+  return { text, cursor, pendingCr, style, styles }
 }
 
 const trimScrollbackLines = (
@@ -214,6 +537,8 @@ const trimScrollbackLines = (
     text: text.slice(removedText.length),
     cursor: Math.max(0, state.cursor - removedText.length),
     pendingCr: state.pendingCr,
+    style: state.style,
+    styles: state.styles.slice(removedText.length),
   }
 }
 
@@ -247,6 +572,40 @@ export class TerminalDisplayBuffer {
 
   readCursorOffset(): number {
     return this.state.cursor
+  }
+
+  readStyledRuns(): readonly TerminalDisplayRun[] {
+    const text = this.state.text
+
+    if (text.length === 0) {
+      return []
+    }
+
+    const runs: TerminalDisplayRun[] = []
+    let runStart = 0
+    let runStyle = this.state.styles[0] ?? {}
+
+    for (let index = 1; index < text.length; index += 1) {
+      const style = this.state.styles[index] ?? {}
+
+      if (areStylesEqual(runStyle, style)) {
+        continue
+      }
+
+      runs.push({
+        text: text.slice(runStart, index),
+        style: runStyle,
+      })
+      runStart = index
+      runStyle = style
+    }
+
+    runs.push({
+      text: text.slice(runStart),
+      style: runStyle,
+    })
+
+    return runs
   }
 
   readVisibleText(): string {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -34,13 +34,13 @@ interface DisplayState {
   readonly cursor: number
   readonly pendingCr: boolean
   readonly style: TerminalDisplayStyle
-  readonly styles: readonly TerminalDisplayStyle[]
+  readonly runs: readonly TerminalDisplayRun[]
 }
 
 interface DisplayCharacterResult {
   readonly text: string
   readonly cursor: number
-  readonly styles: TerminalDisplayStyle[]
+  readonly runs: readonly TerminalDisplayRun[]
 }
 
 export interface TerminalDisplayBufferOptions {
@@ -52,7 +52,7 @@ const createEmptyState = (): DisplayState => ({
   cursor: 0,
   pendingCr: false,
   style: {},
-  styles: [],
+  runs: [],
 })
 
 const ANSI_COLOR_NAMES = [
@@ -156,15 +156,11 @@ const readIndexedAnsiColor = (index: number | undefined): string | null => {
     return formatRgbColor(red, green, blue)
   }
 
-  if (index >= XTERM_GRAYSCALE_FIRST_INDEX) {
-    const level =
-      XTERM_GRAYSCALE_BASE +
-      (index - XTERM_GRAYSCALE_FIRST_INDEX) * XTERM_GRAYSCALE_STEP
+  const level =
+    XTERM_GRAYSCALE_BASE +
+    (index - XTERM_GRAYSCALE_FIRST_INDEX) * XTERM_GRAYSCALE_STEP
 
-    return formatRgbColor(level, level, level)
-  }
-
-  return null
+  return formatRgbColor(level, level, level)
 }
 
 const applySgrStyle = (
@@ -306,11 +302,6 @@ const areStylesEqual = (
   left.italic === right.italic &&
   left.underline === right.underline
 
-const createStyleCells = (
-  length: number,
-  style: TerminalDisplayStyle
-): TerminalDisplayStyle[] => Array.from({ length }, () => style)
-
 const findLineStart = (text: string, cursor: number): number => {
   if (cursor <= 0) {
     return 0
@@ -348,34 +339,215 @@ const readPreviousCodePointLength = (text: string, cursor: number): number => {
   return 1
 }
 
+const findRunAtOffset = (
+  runs: readonly TerminalDisplayRun[],
+  offset: number
+): { runIndex: number; runOffset: number } => {
+  let current = 0
+
+  for (let index = 0; index < runs.length; index += 1) {
+    const run = runs[index]
+
+    if (offset < current + run.text.length) {
+      return { runIndex: index, runOffset: offset - current }
+    }
+
+    current += run.text.length
+  }
+
+  return { runIndex: runs.length, runOffset: 0 }
+}
+
+const mergeAdjacentRuns = (
+  runs: readonly TerminalDisplayRun[]
+): TerminalDisplayRun[] => {
+  const merged: TerminalDisplayRun[] = []
+  let current: TerminalDisplayRun | undefined
+
+  for (const run of runs) {
+    if (run.text.length === 0) {
+      continue
+    }
+
+    if (current && areStylesEqual(current.style, run.style)) {
+      current = { text: current.text + run.text, style: run.style }
+    } else {
+      if (current) {
+        merged.push(current)
+      }
+      current = run
+    }
+  }
+
+  if (current) {
+    merged.push(current)
+  }
+
+  return merged
+}
+
+const insertRunText = (
+  runs: readonly TerminalDisplayRun[],
+  offset: number,
+  text: string,
+  style: TerminalDisplayStyle
+): TerminalDisplayRun[] => {
+  if (runs.length === 0) {
+    return [{ text, style }]
+  }
+
+  const totalLength = runs.reduce((sum, run) => sum + run.text.length, 0)
+
+  if (offset >= totalLength) {
+    const last = runs[runs.length - 1]
+
+    if (areStylesEqual(last.style, style)) {
+      const newRuns = [...runs]
+      newRuns[newRuns.length - 1] = { text: last.text + text, style }
+
+      return newRuns
+    }
+
+    return [...runs, { text, style }]
+  }
+
+  const { runIndex, runOffset } = findRunAtOffset(runs, offset)
+  const run = runs[runIndex]
+  const before = run.text.slice(0, runOffset)
+  const after = run.text.slice(runOffset)
+  const replacement: TerminalDisplayRun[] = []
+
+  if (before.length > 0) {
+    replacement.push({ text: before, style: run.style })
+  }
+
+  replacement.push({ text, style })
+
+  if (after.length > 0) {
+    replacement.push({ text: after, style: run.style })
+  }
+
+  const newRuns = [...runs]
+  newRuns.splice(runIndex, 1, ...replacement)
+
+  return mergeAdjacentRuns(newRuns)
+}
+
+const replaceRunText = (
+  runs: readonly TerminalDisplayRun[],
+  offset: number,
+  length: number,
+  text: string,
+  style: TerminalDisplayStyle
+): TerminalDisplayRun[] => {
+  const { runIndex, runOffset } = findRunAtOffset(runs, offset)
+
+  if (runIndex >= runs.length) {
+    return [...runs, { text, style }]
+  }
+
+  const run = runs[runIndex]
+  const before = run.text.slice(0, runOffset)
+  const after = run.text.slice(runOffset + length)
+  const replacement: TerminalDisplayRun[] = []
+
+  if (before.length > 0) {
+    replacement.push({ text: before, style: run.style })
+  }
+
+  replacement.push({ text, style })
+
+  if (after.length > 0) {
+    replacement.push({ text: after, style: run.style })
+  }
+
+  const newRuns = [...runs]
+  newRuns.splice(runIndex, 1, ...replacement)
+
+  return mergeAdjacentRuns(newRuns)
+}
+
+const spliceRuns = (
+  runs: readonly TerminalDisplayRun[],
+  startOffset: number,
+  endOffset: number
+): TerminalDisplayRun[] => {
+  if (startOffset >= endOffset) {
+    return [...runs]
+  }
+
+  const start = findRunAtOffset(runs, startOffset)
+  const end = findRunAtOffset(runs, endOffset)
+  const newRuns: TerminalDisplayRun[] = []
+
+  newRuns.push(...runs.slice(0, start.runIndex))
+
+  if (start.runIndex === end.runIndex) {
+    if (start.runIndex < runs.length) {
+      const run = runs[start.runIndex]
+      const before = run.text.slice(0, start.runOffset)
+      const after = run.text.slice(end.runOffset)
+
+      if (before.length > 0) {
+        newRuns.push({ text: before, style: run.style })
+      }
+
+      if (after.length > 0) {
+        newRuns.push({ text: after, style: run.style })
+      }
+    }
+  } else {
+    if (start.runIndex < runs.length) {
+      const startRun = runs[start.runIndex]
+      const beforeStart = startRun.text.slice(0, start.runOffset)
+
+      if (beforeStart.length > 0) {
+        newRuns.push({ text: beforeStart, style: startRun.style })
+      }
+    }
+
+    if (end.runIndex < runs.length) {
+      const endRun = runs[end.runIndex]
+      const afterEnd = endRun.text.slice(end.runOffset)
+
+      if (afterEnd.length > 0) {
+        newRuns.push({ text: afterEnd, style: endRun.style })
+      }
+    }
+  }
+
+  newRuns.push(...runs.slice(end.runIndex + 1))
+
+  return mergeAdjacentRuns(newRuns)
+}
+
 const writeDisplayCharacter = (
   text: string,
-  styles: TerminalDisplayStyle[],
+  runs: readonly TerminalDisplayRun[],
   cursor: number,
   character: string,
   style: TerminalDisplayStyle
 ): DisplayCharacterResult => {
-  const characterStyles = createStyleCells(character.length, style)
-
   if (cursor < text.length && text[cursor] !== '\n') {
     const nextLength = readCodePointLength(text, cursor)
-    styles.splice(cursor, nextLength, ...characterStyles)
+
+    const newText = `${text.slice(0, cursor)}${character}${text.slice(
+      cursor + nextLength
+    )}`
 
     return {
-      text: `${text.slice(0, cursor)}${character}${text.slice(
-        cursor + nextLength
-      )}`,
+      text: newText,
       cursor: cursor + character.length,
-      styles,
+      runs: replaceRunText(runs, cursor, nextLength, character, style),
     }
   }
 
-  styles.splice(cursor, 0, ...characterStyles)
+  const newText = `${text.slice(0, cursor)}${character}${text.slice(cursor)}`
 
   return {
-    text: `${text.slice(0, cursor)}${character}${text.slice(cursor)}`,
+    text: newText,
     cursor: cursor + character.length,
-    styles,
+    runs: insertRunText(runs, cursor, character, style),
   }
 }
 
@@ -389,47 +561,46 @@ const eraseLineInState = (
   const lineEnd = findLineEnd(text, cursor)
 
   if (mode === 0) {
+    const newText = `${text.slice(0, cursor)}${text.slice(lineEnd)}`
+
     return {
       ...state,
-      text: `${text.slice(0, cursor)}${text.slice(lineEnd)}`,
-      styles: [
-        ...state.styles.slice(0, cursor),
-        ...state.styles.slice(lineEnd),
-      ],
+      text: newText,
+      runs: spliceRuns(state.runs, cursor, lineEnd),
     }
   }
 
   if (mode === 1) {
     const cursorCodePointLength = readCodePointLength(text, cursor)
 
+    const newText = `${text.slice(0, lineStart)}${text.slice(
+      cursor + cursorCodePointLength
+    )}`
+
     return {
       ...state,
-      text: `${text.slice(0, lineStart)}${text.slice(cursor + cursorCodePointLength)}`,
+      text: newText,
       cursor: lineStart,
-      styles: [
-        ...state.styles.slice(0, lineStart),
-        ...state.styles.slice(cursor + cursorCodePointLength),
-      ],
+      runs: spliceRuns(state.runs, lineStart, cursor + cursorCodePointLength),
     }
   }
 
+  const newText = `${text.slice(0, lineStart)}${text.slice(lineEnd)}`
+
   return {
     ...state,
-    text: `${text.slice(0, lineStart)}${text.slice(lineEnd)}`,
+    text: newText,
     cursor: lineStart,
-    styles: [
-      ...state.styles.slice(0, lineStart),
-      ...state.styles.slice(lineEnd),
-    ],
+    runs: spliceRuns(state.runs, lineStart, lineEnd),
   }
 }
 
 const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
   let text = state.text
-  let styles = [...state.styles]
   let cursor = Math.min(Math.max(state.cursor, 0), text.length)
   let pendingCr = state.pendingCr
   let style = state.style
+  let runs = state.runs
   let index = 0
 
   while (index < data.length) {
@@ -449,11 +620,11 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
 
     if (eraseLineMode !== null) {
       const nextState = eraseLineInState(
-        { text, cursor, pendingCr, style, styles },
+        { text, cursor, pendingCr, style, runs },
         eraseLineMode
       )
       text = nextState.text
-      styles = [...nextState.styles]
+      runs = nextState.runs
       cursor = nextState.cursor
       pendingCr = false
       continue
@@ -461,7 +632,7 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
 
     if (isClearScreenSentinel(character)) {
       text = ''
-      styles = []
+      runs = []
       cursor = 0
       pendingCr = false
       continue
@@ -497,7 +668,7 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
       }
 
       text = `${text.slice(0, cursor)}\n${text.slice(cursor)}`
-      styles.splice(cursor, 0, style)
+      runs = insertRunText(runs, cursor, '\n', style)
       cursor += 1
       pendingCr = false
       continue
@@ -509,14 +680,14 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
       continue
     }
 
-    const next = writeDisplayCharacter(text, styles, cursor, character, style)
+    const next = writeDisplayCharacter(text, runs, cursor, character, style)
     text = next.text
-    styles = next.styles
+    runs = next.runs
     cursor = next.cursor
     pendingCr = false
   }
 
-  return { text, cursor, pendingCr, style, styles }
+  return { text, cursor, pendingCr, style, runs }
 }
 
 const trimScrollbackLines = (
@@ -532,13 +703,26 @@ const trimScrollbackLines = (
 
   const firstKeptLine = lines.length - maxScrollbackLines
   const removedText = `${lines.slice(0, firstKeptLine).join('\n')}\n`
+  let remaining = removedText.length
+  const newRuns: TerminalDisplayRun[] = []
+
+  for (const run of state.runs) {
+    if (remaining <= 0) {
+      newRuns.push(run)
+    } else if (remaining >= run.text.length) {
+      remaining -= run.text.length
+    } else {
+      newRuns.push({ text: run.text.slice(remaining), style: run.style })
+      remaining = 0
+    }
+  }
 
   return {
     text: text.slice(removedText.length),
     cursor: Math.max(0, state.cursor - removedText.length),
     pendingCr: state.pendingCr,
     style: state.style,
-    styles: state.styles.slice(removedText.length),
+    runs: newRuns,
   }
 }
 
@@ -575,37 +759,7 @@ export class TerminalDisplayBuffer {
   }
 
   readStyledRuns(): readonly TerminalDisplayRun[] {
-    const text = this.state.text
-
-    if (text.length === 0) {
-      return []
-    }
-
-    const runs: TerminalDisplayRun[] = []
-    let runStart = 0
-    let runStyle = this.state.styles[0] ?? {}
-
-    for (let index = 1; index < text.length; index += 1) {
-      const style = this.state.styles[index] ?? {}
-
-      if (areStylesEqual(runStyle, style)) {
-        continue
-      }
-
-      runs.push({
-        text: text.slice(runStart, index),
-        style: runStyle,
-      })
-      runStart = index
-      runStyle = style
-    }
-
-    runs.push({
-      text: text.slice(runStart),
-      style: runStyle,
-    })
-
-    return runs
+    return this.state.runs
   }
 
   readVisibleText(): string {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -267,9 +267,9 @@ const applySgrStyle = (
           parameter === 38
             ? styleWith(next, { foreground: color })
             : styleWith(next, { background: color })
-        index += 5
-        continue
       }
+      index += 5
+      continue
     }
 
     if ((parameter === 38 || parameter === 48) && colorMode === 5) {
@@ -280,9 +280,9 @@ const applySgrStyle = (
           parameter === 38
             ? styleWith(next, { foreground: color })
             : styleWith(next, { background: color })
-        index += 3
-        continue
       }
+      index += 3
+      continue
     }
 
     index += 1

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -10,6 +10,7 @@ import { TerminalOutputPayloadRouter } from './terminalOutputPayload'
 
 export interface TerminalParserEngineOutput {
   readonly visibleText: string
+  readonly displayText?: string
 }
 
 export type TerminalParserEngineInputMode = TerminalOutputInputMode
@@ -17,6 +18,7 @@ export type TerminalParserEngineInputMode = TerminalOutputInputMode
 export interface TerminalParserEngineOptions {
   readonly capabilities: TerminalRendererCapabilities
   readonly consumeControlsWithoutSubscribers?: boolean
+  readonly preserveSgrStyles?: boolean
 }
 
 export interface TerminalParserEngine {
@@ -48,6 +50,7 @@ export class TerminalControlSequenceParserEngine implements TerminalParserEngine
     this.parser = new TerminalControlSequenceParser({
       consumeControlsWithoutSubscribers:
         options.consumeControlsWithoutSubscribers,
+      preserveSgrStyles: options.preserveSgrStyles,
     })
     this.outputRouter = new TerminalOutputPayloadRouter(options.capabilities)
   }
@@ -60,9 +63,7 @@ export class TerminalControlSequenceParserEngine implements TerminalParserEngine
     text: string,
     output: TerminalParserOutputContext | null
   ): TerminalParserEngineOutput {
-    return {
-      visibleText: this.parser.transformOutput(text, output),
-    }
+    return this.parser.transformDisplayOutput(text, output)
   }
 
   parseOutput(chunk: TerminalOutputChunk): TerminalParserEngineOutput {

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -6,7 +6,11 @@ import type {
   TerminalSurface,
   TerminalTheme,
 } from '../../types'
-import { TerminalDisplayBuffer } from './terminalDisplayBuffer'
+import {
+  TerminalDisplayBuffer,
+  type TerminalDisplayRun,
+  type TerminalDisplayStyle,
+} from './terminalDisplayBuffer'
 import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from './terminalFont'
 
 const DEFAULT_COLS = 80
@@ -30,7 +34,12 @@ const KEYBOARD_SEQUENCES = new Map<string, string>([
 
 export interface TerminalTextSurfaceOptions {
   readonly rendererId: string
-  readonly transformOutput: (data: string) => string
+  readonly transformOutput: (data: string) => TerminalTextSurfaceOutput
+}
+
+export interface TerminalTextSurfaceOutput {
+  readonly visibleText: string
+  readonly displayText?: string
 }
 
 const createDisposable = (dispose: () => void): TerminalDisposable => ({
@@ -224,18 +233,27 @@ export class TerminalTextSurface implements TerminalSurface {
       return
     }
 
-    this.writeVisible(this.options.transformOutput(data), callback)
+    this.writeParsedOutput(this.options.transformOutput(data), callback)
   }
 
   writeVisible(visibleData: string, callback?: () => void): void {
+    this.writeParsedOutput({ visibleText: visibleData }, callback)
+  }
+
+  writeParsedOutput(
+    output: TerminalTextSurfaceOutput,
+    callback?: () => void
+  ): void {
     if (this.disposed) {
       callback?.()
 
       return
     }
 
-    if (visibleData.length > 0) {
-      this.outputBuffer.write(visibleData)
+    const displayData = output.displayText ?? output.visibleText
+
+    if (displayData.length > 0) {
+      this.outputBuffer.write(displayData)
       this.renderOutput()
     }
 
@@ -307,6 +325,39 @@ export class TerminalTextSurface implements TerminalSurface {
   applyTheme(theme: TerminalTheme): void {
     this.root.style.background = theme.background
     this.root.style.color = theme.foreground
+    this.root.style.setProperty('--terminal-ansi-black', theme.black)
+    this.root.style.setProperty('--terminal-ansi-red', theme.red)
+    this.root.style.setProperty('--terminal-ansi-green', theme.green)
+    this.root.style.setProperty('--terminal-ansi-yellow', theme.yellow)
+    this.root.style.setProperty('--terminal-ansi-blue', theme.blue)
+    this.root.style.setProperty('--terminal-ansi-magenta', theme.magenta)
+    this.root.style.setProperty('--terminal-ansi-cyan', theme.cyan)
+    this.root.style.setProperty('--terminal-ansi-white', theme.white)
+    this.root.style.setProperty(
+      '--terminal-ansi-bright-black',
+      theme.brightBlack
+    )
+
+    this.root.style.setProperty('--terminal-ansi-bright-red', theme.brightRed)
+    this.root.style.setProperty(
+      '--terminal-ansi-bright-green',
+      theme.brightGreen
+    )
+
+    this.root.style.setProperty(
+      '--terminal-ansi-bright-yellow',
+      theme.brightYellow
+    )
+    this.root.style.setProperty('--terminal-ansi-bright-blue', theme.brightBlue)
+    this.root.style.setProperty(
+      '--terminal-ansi-bright-magenta',
+      theme.brightMagenta
+    )
+    this.root.style.setProperty('--terminal-ansi-bright-cyan', theme.brightCyan)
+    this.root.style.setProperty(
+      '--terminal-ansi-bright-white',
+      theme.brightWhite
+    )
     this.output.style.caretColor = theme.cursor
     this.root.style.setProperty('--terminal-cursor-color', theme.cursor)
     this.root.style.setProperty(
@@ -417,25 +468,120 @@ export class TerminalTextSurface implements TerminalSurface {
     return cursor
   }
 
+  private hasStyle(style: TerminalDisplayStyle): boolean {
+    return (
+      style.background !== undefined ||
+      style.bold === true ||
+      style.dim === true ||
+      style.foreground !== undefined ||
+      style.italic === true ||
+      style.underline === true
+    )
+  }
+
+  private createTextNode(text: string, style: TerminalDisplayStyle): Node {
+    if (!this.hasStyle(style)) {
+      return document.createTextNode(text)
+    }
+
+    const span = document.createElement('span')
+    span.dataset.terminalStyleRun = 'true'
+    span.textContent = text
+
+    if (style.background) {
+      span.style.backgroundColor = style.background
+    }
+
+    if (style.bold) {
+      span.style.fontWeight = '700'
+    }
+
+    if (style.dim) {
+      span.style.opacity = '0.72'
+    }
+
+    if (style.foreground) {
+      span.style.color = style.foreground
+    }
+
+    if (style.italic) {
+      span.style.fontStyle = 'italic'
+    }
+
+    if (style.underline) {
+      span.style.textDecoration = 'underline'
+    }
+
+    return span
+  }
+
+  private appendRunFragment(
+    fragments: Node[],
+    text: string,
+    style: TerminalDisplayStyle
+  ): void {
+    if (text.length === 0) {
+      return
+    }
+
+    fragments.push(this.createTextNode(text, style))
+  }
+
+  private createOutputFragments(
+    runs: readonly TerminalDisplayRun[],
+    cursorOffset: number
+  ): Node[] {
+    const fragments: Node[] = []
+    let offset = 0
+    let didRenderCursor = false
+
+    for (const run of runs) {
+      const runStart = offset
+      const runEnd = runStart + run.text.length
+
+      if (
+        !didRenderCursor &&
+        cursorOffset >= runStart &&
+        cursorOffset <= runEnd
+      ) {
+        const splitOffset = cursorOffset - runStart
+
+        this.appendRunFragment(
+          fragments,
+          run.text.slice(0, splitOffset),
+          run.style
+        )
+        fragments.push(this.createCursorElement())
+        didRenderCursor = true
+        this.appendRunFragment(
+          fragments,
+          run.text.slice(splitOffset),
+          run.style
+        )
+      } else {
+        this.appendRunFragment(fragments, run.text, run.style)
+      }
+
+      offset = runEnd
+    }
+
+    if (!didRenderCursor) {
+      fragments.push(this.createCursorElement())
+    }
+
+    return fragments
+  }
+
   private renderOutput(): void {
     const text = this.outputBuffer.readText()
+    const runs = this.outputBuffer.readStyledRuns()
 
     const cursorOffset = Math.min(
       this.outputBuffer.readCursorOffset(),
       text.length
     )
 
-    const fragments: Node[] = []
-
-    if (cursorOffset > 0) {
-      fragments.push(document.createTextNode(text.slice(0, cursorOffset)))
-    }
-
-    fragments.push(this.createCursorElement())
-
-    if (cursorOffset < text.length) {
-      fragments.push(document.createTextNode(text.slice(cursorOffset)))
-    }
+    const fragments = this.createOutputFragments(runs, cursorOffset)
 
     this.output.replaceChildren(...fragments)
     this.root.scrollTop = this.root.scrollHeight

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -479,6 +479,35 @@ export class TerminalTextSurface implements TerminalSurface {
     )
   }
 
+  private applyStyleToElement(
+    element: HTMLElement,
+    style: TerminalDisplayStyle
+  ): void {
+    if (style.background) {
+      element.style.backgroundColor = style.background
+    }
+
+    if (style.bold) {
+      element.style.fontWeight = '700'
+    }
+
+    if (style.dim) {
+      element.style.opacity = '0.72'
+    }
+
+    if (style.foreground) {
+      element.style.color = style.foreground
+    }
+
+    if (style.italic) {
+      element.style.fontStyle = 'italic'
+    }
+
+    if (style.underline) {
+      element.style.textDecoration = 'underline'
+    }
+  }
+
   private createTextNode(text: string, style: TerminalDisplayStyle): Node {
     if (!this.hasStyle(style)) {
       return document.createTextNode(text)
@@ -487,30 +516,7 @@ export class TerminalTextSurface implements TerminalSurface {
     const span = document.createElement('span')
     span.dataset.terminalStyleRun = 'true'
     span.textContent = text
-
-    if (style.background) {
-      span.style.backgroundColor = style.background
-    }
-
-    if (style.bold) {
-      span.style.fontWeight = '700'
-    }
-
-    if (style.dim) {
-      span.style.opacity = '0.72'
-    }
-
-    if (style.foreground) {
-      span.style.color = style.foreground
-    }
-
-    if (style.italic) {
-      span.style.fontStyle = 'italic'
-    }
-
-    if (style.underline) {
-      span.style.textDecoration = 'underline'
-    }
+    this.applyStyleToElement(span, style)
 
     return span
   }
@@ -546,18 +552,35 @@ export class TerminalTextSurface implements TerminalSurface {
       ) {
         const splitOffset = cursorOffset - runStart
 
-        this.appendRunFragment(
-          fragments,
-          run.text.slice(0, splitOffset),
-          run.style
-        )
-        fragments.push(this.createCursorElement())
-        didRenderCursor = true
-        this.appendRunFragment(
-          fragments,
-          run.text.slice(splitOffset),
-          run.style
-        )
+        if (
+          splitOffset > 0 &&
+          splitOffset < run.text.length &&
+          this.hasStyle(run.style)
+        ) {
+          const runElement = document.createElement('span')
+          runElement.dataset.terminalStyleRun = 'true'
+          this.applyStyleToElement(runElement, run.style)
+          runElement.append(
+            document.createTextNode(run.text.slice(0, splitOffset)),
+            this.createCursorElement(),
+            document.createTextNode(run.text.slice(splitOffset))
+          )
+          fragments.push(runElement)
+          didRenderCursor = true
+        } else {
+          this.appendRunFragment(
+            fragments,
+            run.text.slice(0, splitOffset),
+            run.style
+          )
+          fragments.push(this.createCursorElement())
+          didRenderCursor = true
+          this.appendRunFragment(
+            fragments,
+            run.text.slice(splitOffset),
+            run.style
+          )
+        }
       } else {
         this.appendRunFragment(fragments, run.text, run.style)
       }

--- a/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
+++ b/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
@@ -1,5 +1,6 @@
 // cspell:ignore ghostty
 const ESCAPE_SEQUENCE_TIMEOUT_MS = 15_000
+const TRUE_COLOR_PINK = ['rgb', '(243, 139, 168)'].join('')
 
 const waitForE2eBridge = async (): Promise<void> => {
   await browser
@@ -38,6 +39,23 @@ const hasGhosttyCursor = async (): Promise<boolean> =>
       document.querySelector(
         '[data-terminal-renderer="ghostty"] [data-terminal-cursor="true"]'
       ) !== null
+  )
+
+interface GhosttyStyleRun {
+  readonly color: string
+  readonly text: string
+}
+
+const readGhosttyStyleRuns = async (): Promise<readonly GhosttyStyleRun[]> =>
+  browser.execute(() =>
+    Array.from(
+      document.querySelectorAll(
+        '[data-terminal-renderer="ghostty"] [data-terminal-style-run="true"]'
+      )
+    ).map((element) => ({
+      color: (element as HTMLElement).style.color,
+      text: element.textContent ?? '',
+    }))
   )
 
 describe('Ghostty renderer smoke', () => {
@@ -100,5 +118,13 @@ describe('Ghostty renderer smoke', () => {
     expect(buffer).not.toContain('[38;2;243;139;168m')
     expect(buffer).not.toContain('[0m')
     expect(await hasGhosttyCursor()).toBe(true)
+
+    const styleRuns = await readGhosttyStyleRuns()
+
+    expect(
+      styleRuns.some(
+        (run) => run.text.includes(marker) && run.color === TRUE_COLOR_PINK
+      )
+    ).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- add a renderer-only SGR style channel to the shared terminal parser output
- teach the Ghostty/plain-text display buffer to track SGR style state and expose grouped style runs
- render styled spans in the shared text surface while preserving clean visible text, transcript reads, selection behavior, and the zero-text cursor marker
- support ANSI 8/16 colors, xterm indexed 0-255 colors, and true-color SGR foreground/background values
- extend Ghostty smoke coverage so byte-path true-color SGR output renders as a style run without leaking raw control bytes

## Review follow-up

- preserved split CRLF handling when display-only SGR controls appear between `\r` and `\n`
- added xterm 256-color cube/grayscale mapping for `38;5;n` and `48;5;n`

## Notes

Related tracker: VIM-139.

The Codex MCP startup progress replay artifact observed during manual smoke is not part of this SGR/color slice. I filed it separately as VIM-152 because it looks like in-place progress/status rewrite handling rather than style parsing.

## Verification

- `npx vitest run src/features/terminal/components/TerminalPane/terminalControlParser.test.ts src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts src/features/terminal/components/TerminalPane/plainTextInstance.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts`
- `npx vitest run src/features/terminal src/lib/e2e-bridge.test.ts`
- `npx tsc -b --pretty false`
- `npx tsc -p tests/e2e/tsconfig.json --pretty false`
- `npm --ignore-scripts run lint`
- `npm --ignore-scripts run format:check`
- `git diff --check`
- `npm run test:e2e:ghostty`
- pre-push `npm test` passed after review fixes: 299 files, 3831 passed, 3 skipped