### PR TITLE
refactor(workspace): rename persisted restore pane DTOs

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -94,7 +94,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 3        | 0    | 2026-06-15   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
-| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 4        | 2    | 2026-06-18   |
+| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 6        | 3    | 2026-06-18   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 3        | 2    | 2026-06-15   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 5        | 3    | 2026-06-17   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -94,7 +94,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 3        | 0    | 2026-06-15   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
-| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 3        | 1    | 2026-06-15   |
+| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 4        | 2    | 2026-06-18   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 3        | 2    | 2026-06-15   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 5        | 3    | 2026-06-17   |

--- a/docs/reviews/patterns/type-contract-safety.md
+++ b/docs/reviews/patterns/type-contract-safety.md
@@ -2,8 +2,8 @@
 id: type-contract-safety
 category: code-quality
 created: 2026-06-15
-last_updated: 2026-06-15
-ref_count: 1
+last_updated: 2026-06-18
+ref_count: 2
 ---
 
 # Type Contract Safety
@@ -50,4 +50,13 @@ expands.
 - **File:** `src/features/workspace/overlays/useOverlayRegistration.ts`
 - **Finding:** The proxy object in `useLayoutEffect` is cast to `OverlayDescriptor` via `as` (line 27) rather than satisfying the discriminated union. Because `get nativeOcclusion()` reads `latestDescriptorRef.current.nativeOcclusion` live, the runtime variant can shift from `'none'`/`'global'` to `'intersects'` without re-running the effect (only `id` and `plane` changes trigger a re-run). When that shift occurs, `overlayOccludesNativeSurface` branches into `rectsIntersect` but `overlay.getRect()` returns `null` (the proxy calls `latestDescriptorRef.current.getRect?.() ?? null`), so the overlay silently fails to occlude. Fix: include `nativeOcclusion` in the effect deps so re-registration fires on variant changes, or close over it in the proxy to hold it stable.
 - **Fix:** Added nativeOcclusion to the useLayoutEffect dependency array so the proxy re-registers when the occlusion variant changes.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 4. Duplicate `PersistedBrowserPane` interface declarations silently merge
+
+- **Source:** github-claude | PR #531 round 1 | 2026-06-18
+- **Severity:** HIGH
+- **File:** `electron/workspace-layout-types.ts`
+- **Finding:** The shape-only DTO pane interface was renamed to `PersistedBrowserPane`, but a `PersistedBrowserPane` store pane interface already existed in the same file. TypeScript merges the two declarations, so the merged type requires `tabs: PersistedTab[]` even for the shape-only DTO. This erased the distinction between the persisted store pane type and the shape-only DTO type, causing `tsc` errors wherever a browser shape was constructed without tabs.
+- **Fix:** Renamed the shape-only interfaces to `PersistedShellPaneShape` and `PersistedBrowserPaneShape`, then updated `PersistedWorkspacePaneShape` to reference the new names so it no longer merges with the store-side types.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/type-contract-safety.md
+++ b/docs/reviews/patterns/type-contract-safety.md
@@ -3,7 +3,7 @@ id: type-contract-safety
 category: code-quality
 created: 2026-06-15
 last_updated: 2026-06-18
-ref_count: 2
+ref_count: 3
 ---
 
 # Type Contract Safety
@@ -59,4 +59,22 @@ expands.
 - **File:** `electron/workspace-layout-types.ts`
 - **Finding:** The shape-only DTO pane interface was renamed to `PersistedBrowserPane`, but a `PersistedBrowserPane` store pane interface already existed in the same file. TypeScript merges the two declarations, so the merged type requires `tabs: PersistedTab[]` even for the shape-only DTO. This erased the distinction between the persisted store pane type and the shape-only DTO type, causing `tsc` errors wherever a browser shape was constructed without tabs.
 - **Fix:** Renamed the shape-only interfaces to `PersistedShellPaneShape` and `PersistedBrowserPaneShape`, then updated `PersistedWorkspacePaneShape` to reference the new names so it no longer merges with the store-side types.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 5. Renderer bridge shape-only pane types share names with electron store-side types
+
+- **Source:** github-claude | PR #531 round 2 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/sessions/workspaceLayoutBridge.ts`
+- **Finding:** The renderer-side bridge exported `PersistedShellPane`, `PersistedBrowserPane`, and `PersistedWorkspacePane` as the shape-only DTO types. In `electron/workspace-layout-types.ts` those same identifiers belonged to the full persisted-store types (where `PersistedBrowserPane` carries `tabs: PersistedTab[]`). The structural mismatch made the two definitions of `PersistedBrowserPane` incompatible across the IPC boundary, and a future developer adding resume/reopen fields would have to update both files in lockstep without a clear naming signal.
+- **Fix:** Renamed the renderer bridge's shape-only pane leaf types to `PersistedShellPaneShape`, `PersistedBrowserPaneShape`, and `PersistedWorkspacePaneShape` to match the electron-side shape-only naming convention, then updated the three consumer files (`useSessionRestore.ts`, `groupSessionsFromInfos.ts`, `usePushWorkspaceGrouping.ts`) and the co-located test fixture to import the new names.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 6. Shape-only browser pane type not distinct from full persisted pane type
+
+- **Source:** github-codex-connector | PR #531 round 2 | 2026-06-18
+- **Severity:** P1 / HIGH
+- **File:** `electron/workspace-layout-types.ts`
+- **Finding:** The shape-only DTO browser pane was named `PersistedBrowserPane`, identical to the full persisted-store pane type that includes `tabs: PersistedTab[]`. TypeScript declaration merging meant `PersistedWorkspacePaneShape` required `tabs` even though shape DTOs intentionally strip browser tab/history, breaking `paneToShape` and round-trip test fixtures that construct browser shapes without tabs.
+- **Fix:** Same rename as finding 5: the renderer bridge's browser shape type is now `PersistedBrowserPaneShape`, so the shape-only DTO and the full persisted-store type are distinct identifiers and no longer merge.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/electron/workspace-layout-controller.test.ts
+++ b/electron/workspace-layout-controller.test.ts
@@ -14,7 +14,7 @@ import type {
   IpcMainLike,
   PersistedWorkspaceLayoutStore,
   WorkspaceLayoutWriterPort,
-  WorkspaceShapeDto,
+  PersistedWorkspaceShape,
 } from './workspace-layout-types'
 
 const makeWriter = (): WorkspaceLayoutWriterPort & {
@@ -31,7 +31,7 @@ const makeSidecar = (
   invoke: vi.fn().mockResolvedValue(result),
 })
 
-const sampleShape = (): WorkspaceShapeDto => ({
+const sampleShape = (): PersistedWorkspaceShape => ({
   sessions: [
     {
       id: 's1',

--- a/electron/workspace-layout-controller.ts
+++ b/electron/workspace-layout-controller.ts
@@ -17,11 +17,11 @@ import type {
   PersistedTab,
   PersistedWorkspaceLayoutStore,
   PersistedWorkspacePane,
+  PersistedWorkspacePaneShape,
+  PersistedWorkspaceSessionShape,
+  PersistedWorkspaceShape,
   RendererSender,
   WorkspaceLayoutWriterPort,
-  WorkspaceShapeDto,
-  WorkspaceShapePane,
-  WorkspaceShapeSession,
 } from './workspace-layout-types'
 
 interface SidecarInvoker {
@@ -40,7 +40,9 @@ const noopWriter: WorkspaceLayoutWriterPort = {
   setHydrating: (): void => undefined,
 }
 
-const paneToShape = (pane: PersistedWorkspacePane): WorkspaceShapePane =>
+const paneToShape = (
+  pane: PersistedWorkspacePane
+): PersistedWorkspacePaneShape =>
   pane.kind === 'shell'
     ? {
         kind: 'shell',
@@ -63,7 +65,7 @@ const paneToShape = (pane: PersistedWorkspacePane): WorkspaceShapePane =>
 // fields, with browser tab/history stripped (those stay main-side).
 const storeToShape = (
   store: PersistedWorkspaceLayoutStore
-): WorkspaceShapeDto => ({
+): PersistedWorkspaceShape => ({
   sessions: store.sessions.map((session) => ({
     id: session.id,
     projectId: session.projectId,
@@ -74,7 +76,7 @@ const storeToShape = (
   })),
 })
 
-const emptyWorkspaceShape = (): WorkspaceShapeDto => ({ sessions: [] })
+const emptyWorkspaceShape = (): PersistedWorkspaceShape => ({ sessions: [] })
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -101,7 +103,9 @@ const hasShapePaneBase = (pane: Record<string, unknown>): boolean =>
   Number.isFinite(pane.paneIndex) &&
   typeof pane.active === 'boolean'
 
-const isWorkspaceShapePane = (pane: unknown): pane is WorkspaceShapePane => {
+const isPersistedWorkspacePaneShape = (
+  pane: unknown
+): pane is PersistedWorkspacePaneShape => {
   if (!isRecord(pane) || !hasShapePaneBase(pane)) {
     return false
   }
@@ -119,9 +123,9 @@ const isWorkspaceShapePane = (pane: unknown): pane is WorkspaceShapePane => {
   )
 }
 
-const isWorkspaceShapeSession = (
+const isPersistedWorkspaceSessionShape = (
   session: unknown
-): session is WorkspaceShapeSession => {
+): session is PersistedWorkspaceSessionShape => {
   if (!isRecord(session)) {
     return false
   }
@@ -133,14 +137,16 @@ const isWorkspaceShapeSession = (
     typeof session.workingDirectory === 'string' &&
     typeof session.active === 'boolean' &&
     Array.isArray(session.panes) &&
-    session.panes.every(isWorkspaceShapePane)
+    session.panes.every(isPersistedWorkspacePaneShape)
   )
 }
 
-const isWorkspaceShapeDto = (dto: unknown): dto is WorkspaceShapeDto =>
+const isPersistedWorkspaceShape = (
+  dto: unknown
+): dto is PersistedWorkspaceShape =>
   isRecord(dto) &&
   Array.isArray(dto.sessions) &&
-  dto.sessions.every(isWorkspaceShapeSession)
+  dto.sessions.every(isPersistedWorkspaceSessionShape)
 
 const cloneTabs = (tabs: PersistedTab[]): PersistedTab[] =>
   tabs.map((tab) => ({
@@ -153,14 +159,14 @@ const cloneTabs = (tabs: PersistedTab[]): PersistedTab[] =>
   }))
 
 interface PendingFinalShape {
-  resolve: (dto: WorkspaceShapeDto | null) => void
+  resolve: (dto: PersistedWorkspaceShape | null) => void
   timer: ReturnType<typeof setTimeout>
 }
 
 export class WorkspaceLayoutController {
   private readonly sidecar: SidecarInvoker
   private readonly writer: WorkspaceLayoutWriterPort
-  private shape: WorkspaceShapeDto | null = null
+  private shape: PersistedWorkspaceShape | null = null
   private store: PersistedWorkspaceLayoutStore | null = null
   private pendingFinalShape: PendingFinalShape | null = null
   private installedOn: IpcMainLike | null = null
@@ -171,7 +177,7 @@ export class WorkspaceLayoutController {
     this.writer = deps.writer ?? noopWriter
   }
 
-  get latestShapeDto(): WorkspaceShapeDto | null {
+  get latestShapeDto(): PersistedWorkspaceShape | null {
     return this.shape
   }
 
@@ -179,7 +185,7 @@ export class WorkspaceLayoutController {
     return this.store
   }
 
-  pushShape(dto: WorkspaceShapeDto): void {
+  pushShape(dto: PersistedWorkspaceShape): void {
     this.shape = dto
     this.writer.onShapePushed(dto)
     this.resolveFinalShape(dto)
@@ -187,7 +193,7 @@ export class WorkspaceLayoutController {
 
   async loadForRestore(
     request: LoadWorkspaceForRestoreRequest
-  ): Promise<WorkspaceShapeDto> {
+  ): Promise<PersistedWorkspaceShape> {
     const store = await this.sidecar.invoke<PersistedWorkspaceLayoutStore>(
       'load_workspace_layout',
       {
@@ -217,14 +223,14 @@ export class WorkspaceLayoutController {
   requestFinalShape(
     sender: RendererSender,
     timeoutMs = DEFAULT_FINAL_SHAPE_TIMEOUT_MS
-  ): Promise<WorkspaceShapeDto | null> {
+  ): Promise<PersistedWorkspaceShape | null> {
     if (this.pendingFinalShape !== null) {
       throw new Error('workspace layout final shape request already pending')
     }
 
     sender.send(WORKSPACE_LAYOUT_REQUEST_FINAL_SHAPE, {})
 
-    return new Promise<WorkspaceShapeDto | null>((resolve) => {
+    return new Promise<PersistedWorkspaceShape | null>((resolve) => {
       const timer = setTimeout(() => {
         this.pendingFinalShape = null
         resolve(this.shape)
@@ -256,7 +262,7 @@ export class WorkspaceLayoutController {
 
   install(ipcMain: IpcMainLike): void {
     ipcMain.handle(WORKSPACE_LAYOUT_PUSH_SHAPE, (_event, dto): void => {
-      if (!isWorkspaceShapeDto(dto)) {
+      if (!isPersistedWorkspaceShape(dto)) {
         return
       }
 
@@ -295,7 +301,7 @@ export class WorkspaceLayoutController {
     }
   }
 
-  private resolveFinalShape(dto: WorkspaceShapeDto | null): void {
+  private resolveFinalShape(dto: PersistedWorkspaceShape | null): void {
     if (!this.pendingFinalShape) {
       return
     }

--- a/electron/workspace-layout-roundtrip.test.ts
+++ b/electron/workspace-layout-roundtrip.test.ts
@@ -8,7 +8,7 @@ import { WorkspaceTeardown } from './workspace-teardown'
 import type {
   PersistedTab,
   PersistedWorkspaceLayoutStore,
-  WorkspaceShapeDto,
+  PersistedWorkspaceShape,
 } from './workspace-layout-types'
 
 const browserOnlyTabs: PersistedTab[] = [
@@ -39,7 +39,7 @@ const mixedTabs: PersistedTab[] = [
   },
 ]
 
-const roundTripShape = (): WorkspaceShapeDto => ({
+const roundTripShape = (): PersistedWorkspaceShape => ({
   sessions: [
     {
       id: 'ws-browser',
@@ -189,7 +189,7 @@ describe('workspace layout round trip', () => {
     const harness = makeRoundTripHarness()
     const shape = roundTripShape()
 
-    const browserOnlyShape: WorkspaceShapeDto = {
+    const browserOnlyShape: PersistedWorkspaceShape = {
       sessions: [shape.sessions[0]],
     }
 

--- a/electron/workspace-layout-types.ts
+++ b/electron/workspace-layout-types.ts
@@ -59,7 +59,7 @@ export interface PersistedWorkspaceLayoutStore {
 
 // Shape-only DTO (renderer <-> main). No browser tab/history.
 
-export interface PersistedShellPane {
+export interface PersistedShellPaneShape {
   kind: 'shell'
   paneId: string
   paneIndex: number
@@ -70,7 +70,7 @@ export interface PersistedShellPane {
   agentSessionId: string | null
 }
 
-export interface PersistedBrowserPane {
+export interface PersistedBrowserPaneShape {
   kind: 'browser'
   paneId: string
   paneIndex: number
@@ -78,8 +78,8 @@ export interface PersistedBrowserPane {
 }
 
 export type PersistedWorkspacePaneShape =
-  | PersistedShellPane
-  | PersistedBrowserPane
+  | PersistedShellPaneShape
+  | PersistedBrowserPaneShape
 
 export interface PersistedWorkspaceSessionShape {
   id: string

--- a/electron/workspace-layout-types.ts
+++ b/electron/workspace-layout-types.ts
@@ -3,7 +3,7 @@
 // Two distinct shapes:
 //  - The persisted store (`PersistedWorkspaceLayoutStore`) mirrors the Rust
 //    `WorkspaceLayoutStore` binding; it carries full browser tab + history.
-//  - The shape-only DTO (`WorkspaceShapeDto`) is what the renderer pushes and
+//  - The shape-only DTO (`PersistedWorkspaceShape`) is what the renderer pushes and
 //    what `load` returns to the renderer; it omits browser tab/history (main
 //    owns those via the WebContents) and keeps shell pane fields.
 //
@@ -59,7 +59,7 @@ export interface PersistedWorkspaceLayoutStore {
 
 // Shape-only DTO (renderer <-> main). No browser tab/history.
 
-export interface WorkspaceShapeShellPane {
+export interface PersistedShellPane {
   kind: 'shell'
   paneId: string
   paneIndex: number
@@ -70,28 +70,28 @@ export interface WorkspaceShapeShellPane {
   agentSessionId: string | null
 }
 
-export interface WorkspaceShapeBrowserPane {
+export interface PersistedBrowserPane {
   kind: 'browser'
   paneId: string
   paneIndex: number
   active: boolean
 }
 
-export type WorkspaceShapePane =
-  | WorkspaceShapeShellPane
-  | WorkspaceShapeBrowserPane
+export type PersistedWorkspacePaneShape =
+  | PersistedShellPane
+  | PersistedBrowserPane
 
-export interface WorkspaceShapeSession {
+export interface PersistedWorkspaceSessionShape {
   id: string
   projectId: string
   layout: string
   workingDirectory: string
   active: boolean
-  panes: WorkspaceShapePane[]
+  panes: PersistedWorkspacePaneShape[]
 }
 
-export interface WorkspaceShapeDto {
-  sessions: WorkspaceShapeSession[]
+export interface PersistedWorkspaceShape {
+  sessions: PersistedWorkspaceSessionShape[]
 }
 
 // Arguments the renderer passes to load-for-restore so Rust can apply project
@@ -104,7 +104,7 @@ export interface LoadWorkspaceForRestoreRequest {
 // Port the single-writer assembler plugs into so the controller can drive it
 // without depending on the concrete writer.
 export interface WorkspaceLayoutWriterPort {
-  onShapePushed: (dto: WorkspaceShapeDto) => void
+  onShapePushed: (dto: PersistedWorkspaceShape) => void
   setHydrating: (hydrating: boolean) => void
 }
 

--- a/electron/workspace-layout-writer.test.ts
+++ b/electron/workspace-layout-writer.test.ts
@@ -3,9 +3,12 @@ import {
   CURRENT_WORKSPACE_LAYOUT_VERSION,
   WorkspaceLayoutWriter,
 } from './workspace-layout-writer'
-import type { PersistedTab, WorkspaceShapeDto } from './workspace-layout-types'
+import type {
+  PersistedTab,
+  PersistedWorkspaceShape,
+} from './workspace-layout-types'
 
-const shape = (): WorkspaceShapeDto => ({
+const shape = (): PersistedWorkspaceShape => ({
   sessions: [
     {
       id: 's1',

--- a/electron/workspace-layout-writer.ts
+++ b/electron/workspace-layout-writer.ts
@@ -14,11 +14,11 @@
 
 import type {
   PersistedTab,
+  PersistedWorkspaceShape,
   PersistedWorkspaceLayoutStore,
   PersistedWorkspacePane,
   WorkspaceLayoutWriterPort,
   WorkspaceLayoutWriteSignals,
-  WorkspaceShapeDto,
 } from './workspace-layout-types'
 
 // Mirrors the Rust CURRENT_WORKSPACE_LAYOUT_VERSION; a reader accepts only this.
@@ -56,7 +56,9 @@ const cloneTabs = (tabs: PersistedTab[]): PersistedTab[] =>
     })),
   }))
 
-const browserPaneKeysFromShape = (shape: WorkspaceShapeDto): Set<string> =>
+const browserPaneKeysFromShape = (
+  shape: PersistedWorkspaceShape
+): Set<string> =>
   new Set(
     shape.sessions.flatMap((session) =>
       session.panes
@@ -72,7 +74,7 @@ export class WorkspaceLayoutWriter
   private readonly captureTabsForPane: CaptureTabs
   private readonly preservedTabsForPane: TabsForPane | null
   private readonly debounceMs: number
-  private shape: WorkspaceShapeDto | null = null
+  private shape: PersistedWorkspaceShape | null = null
   private hydrating = false
   private latestGeneration = 0
   private committedGeneration = 0
@@ -90,7 +92,7 @@ export class WorkspaceLayoutWriter
     this.debounceMs = deps.debounceMs ?? DEFAULT_VOLATILE_DEBOUNCE_MS
   }
 
-  onShapePushed(dto: WorkspaceShapeDto): void {
+  onShapePushed(dto: PersistedWorkspaceShape): void {
     this.noteBrowserPaneShape(dto)
     this.shape = dto
     this.markStructural()
@@ -256,7 +258,7 @@ export class WorkspaceLayoutWriter
     }
   }
 
-  private noteBrowserPaneShape(dto: WorkspaceShapeDto): void {
+  private noteBrowserPaneShape(dto: PersistedWorkspaceShape): void {
     const nextKeys = browserPaneKeysFromShape(dto)
 
     for (const key of this.browserPaneKeys) {

--- a/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
+++ b/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
@@ -21,8 +21,8 @@ import { createLogger } from '../../../lib/log'
 import {
   onWorkspaceRequestFinalShape,
   pushWorkspaceShape,
-  type WorkspaceShapeDto,
-  type WorkspaceShapePane,
+  type PersistedWorkspaceShape,
+  type PersistedWorkspacePane,
 } from '../workspaceLayoutBridge'
 import { isShellPane } from '../utils/paneKind'
 import type { Session } from '../types'
@@ -31,7 +31,9 @@ const log = createLogger('grouping')
 
 const DRIFT_DEBOUNCE_MS = 500
 
-const pushShapeWithLog = async (shape: WorkspaceShapeDto): Promise<void> => {
+const pushShapeWithLog = async (
+  shape: PersistedWorkspaceShape
+): Promise<void> => {
   try {
     await pushWorkspaceShape(shape)
   } catch (err) {
@@ -48,7 +50,7 @@ const pushShapeWithLog = async (shape: WorkspaceShapeDto): Promise<void> => {
 export const buildWorkspaceShape = (
   sessions: readonly Session[],
   activeSessionId: string | null
-): WorkspaceShapeDto => ({
+): PersistedWorkspaceShape => ({
   sessions: sessions.map((session) => ({
     id: session.id,
     projectId: session.projectId,
@@ -56,7 +58,7 @@ export const buildWorkspaceShape = (
     workingDirectory: session.workingDirectory,
     active: session.id === activeSessionId,
     panes: session.panes.map(
-      (pane, paneIndex): WorkspaceShapePane =>
+      (pane, paneIndex): PersistedWorkspacePane =>
         isShellPane(pane)
           ? {
               kind: 'shell',
@@ -80,7 +82,7 @@ export const buildWorkspaceShape = (
 
 // Signature of the structural half (everything except cwd/agentType drift), so
 // a `cd` or agent-detection update debounces instead of pushing eagerly.
-const structuralSignature = (shape: WorkspaceShapeDto): string =>
+const structuralSignature = (shape: PersistedWorkspaceShape): string =>
   JSON.stringify(
     shape.sessions.map((session) => ({
       id: session.id,

--- a/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
+++ b/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
@@ -22,7 +22,7 @@ import {
   onWorkspaceRequestFinalShape,
   pushWorkspaceShape,
   type PersistedWorkspaceShape,
-  type PersistedWorkspacePane,
+  type PersistedWorkspacePaneShape,
 } from '../workspaceLayoutBridge'
 import { isShellPane } from '../utils/paneKind'
 import type { Session } from '../types'
@@ -58,7 +58,7 @@ export const buildWorkspaceShape = (
     workingDirectory: session.workingDirectory,
     active: session.id === activeSessionId,
     panes: session.panes.map(
-      (pane, paneIndex): PersistedWorkspacePane =>
+      (pane, paneIndex): PersistedWorkspacePaneShape =>
         isShellPane(pane)
           ? {
               kind: 'shell',

--- a/src/features/sessions/hooks/useSessionManager.test.ts
+++ b/src/features/sessions/hooks/useSessionManager.test.ts
@@ -14,7 +14,7 @@ import {
   registerPtySession,
 } from '../../terminal/ptySessionMap'
 import { readActivityPanelCollapsed } from '../utils/activityPanelCollapsedStore'
-import type { WorkspaceShapeDto } from '../workspaceLayoutBridge'
+import type { PersistedWorkspaceShape } from '../workspaceLayoutBridge'
 import {
   loadWorkspaceForRestore,
   pushWorkspaceShape,
@@ -1468,7 +1468,7 @@ describe('useSessionManager', () => {
   // but its idle browser pane makes it a usable workspace — auto-create must
   // NOT seed an extra terminal tab on top of it.
   test('auto-create is skipped for a restored browser-only session', async () => {
-    const store: WorkspaceShapeDto = {
+    const store: PersistedWorkspaceShape = {
       sessions: [
         {
           id: 'ws-browser',
@@ -1560,7 +1560,7 @@ describe('useSessionManager', () => {
   // cache must NOT be merged — otherwise a pane closed before a crash (never
   // cleared from localStorage) would be resurrected on the next restore.
   test('store-driven restore ignores the stale localStorage browser cache', async () => {
-    const store: WorkspaceShapeDto = {
+    const store: PersistedWorkspaceShape = {
       sessions: [
         {
           id: 'ws-shell',

--- a/src/features/sessions/hooks/useSessionRestore.test.ts
+++ b/src/features/sessions/hooks/useSessionRestore.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { Session } from '../types'
 import type { PtyBufferDrain } from '../../terminal/orchestration/usePtyBufferDrain'
 import type { ITerminalService } from '../../terminal/services/terminalService'
-import type { WorkspaceShapeDto } from '../workspaceLayoutBridge'
+import type { PersistedWorkspaceShape } from '../workspaceLayoutBridge'
 import { useSessionRestore } from './useSessionRestore'
 
 const loadWorkspaceForRestore = vi.hoisted(() =>
-  vi.fn((): Promise<WorkspaceShapeDto | null> => Promise.resolve(null))
+  vi.fn((): Promise<PersistedWorkspaceShape | null> => Promise.resolve(null))
 )
 const beginWorkspaceHydration = vi.hoisted(() => vi.fn(() => Promise.resolve()))
 const endWorkspaceHydration = vi.hoisted(() => vi.fn(() => Promise.resolve()))
@@ -468,7 +468,7 @@ describe('useSessionRestore', () => {
   test('restores a browser-only session from the durable store', async () => {
     const order: string[] = []
 
-    const store: WorkspaceShapeDto = {
+    const store: PersistedWorkspaceShape = {
       sessions: [
         {
           id: 'ws-browser',
@@ -543,7 +543,7 @@ describe('useSessionRestore', () => {
   })
 
   test('restarts the persisted active shell workspace when graceful quit left no live PTYs', async () => {
-    const store: WorkspaceShapeDto = {
+    const store: PersistedWorkspaceShape = {
       sessions: [
         {
           id: 'ws-shell',
@@ -636,7 +636,7 @@ describe('useSessionRestore', () => {
   })
 
   test('resolves active session from the restarted PTY id when no persisted-active handler is registered', async () => {
-    const store: WorkspaceShapeDto = {
+    const store: PersistedWorkspaceShape = {
       sessions: [
         {
           id: 'ws-shell',
@@ -691,7 +691,7 @@ describe('useSessionRestore', () => {
   })
 
   test('kills restarted PTY when restore is cancelled while spawn is in flight', async () => {
-    const store: WorkspaceShapeDto = {
+    const store: PersistedWorkspaceShape = {
       sessions: [
         {
           id: 'ws-shell',
@@ -759,7 +759,7 @@ describe('useSessionRestore', () => {
   })
 
   test('kills restarted PTY when restore is cancelled after spawn resolves', async () => {
-    const store: WorkspaceShapeDto = {
+    const store: PersistedWorkspaceShape = {
       sessions: [
         {
           id: 'ws-mixed',
@@ -830,7 +830,7 @@ describe('useSessionRestore', () => {
   })
 
   test('does not restart an inactive shell when a browser pane is active', async () => {
-    const store: WorkspaceShapeDto = {
+    const store: PersistedWorkspaceShape = {
       sessions: [
         {
           id: 'ws-mixed',
@@ -905,7 +905,7 @@ describe('useSessionRestore', () => {
   // so restore must reconstruct the browser workspace and must NOT spawn a
   // background shell.
   test('does not restart shell when mixed workspace has browser normalized active', async () => {
-    const store: WorkspaceShapeDto = {
+    const store: PersistedWorkspaceShape = {
       sessions: [
         {
           id: 'ws-mixed',
@@ -979,7 +979,7 @@ describe('useSessionRestore', () => {
   // Exited SessionInfo rows after the cached PTY is gone. Those rows are not
   // live sessions, so restore must still restart the persisted active shell.
   test('restarts persisted active shell when listSessions only returns Exited rows', async () => {
-    const store: WorkspaceShapeDto = {
+    const store: PersistedWorkspaceShape = {
       sessions: [
         {
           id: 'ws-shell',

--- a/src/features/sessions/hooks/useSessionRestore.ts
+++ b/src/features/sessions/hooks/useSessionRestore.ts
@@ -8,9 +8,9 @@ import { createLogger } from '../../../lib/log'
 import { reconstructWorkspace } from '../utils/groupSessionsFromInfos'
 import { isBrowserPane } from '../utils/paneKind'
 import type {
-  WorkspaceShapeDto,
-  WorkspaceShapePane,
-  WorkspaceShapeShellPane,
+  PersistedWorkspaceShape,
+  PersistedWorkspacePane,
+  PersistedShellPane,
 } from '../workspaceLayoutBridge'
 import {
   beginWorkspaceHydration,
@@ -27,22 +27,22 @@ const log = createLogger('restore')
 const RESTORE_PANE_TIMEOUT_MS = 4000
 
 const isShapeShellPane = (
-  pane: WorkspaceShapePane
-): pane is WorkspaceShapeShellPane => pane.kind === 'shell'
+  pane: PersistedWorkspacePane
+): pane is PersistedShellPane => pane.kind === 'shell'
 
 interface StoreShellSelection {
   sessionId: string
   paneId: string
-  pane: WorkspaceShapeShellPane
+  pane: PersistedShellPane
 }
 
 interface RestartedStoreShell {
-  storeShape: WorkspaceShapeDto
+  storeShape: PersistedWorkspaceShape
   liveSession: SessionInfo
 }
 
 const findActiveStoreShell = (
-  storeShape: WorkspaceShapeDto | null
+  storeShape: PersistedWorkspaceShape | null
 ): StoreShellSelection | null => {
   const activeSession = storeShape?.sessions.find((session) => session.active)
   if (!activeSession) {
@@ -78,10 +78,10 @@ const findActiveStoreShell = (
 }
 
 const shapeWithRestartedShell = (
-  storeShape: WorkspaceShapeDto,
+  storeShape: PersistedWorkspaceShape,
   selection: StoreShellSelection,
   liveSession: SessionInfo
-): WorkspaceShapeDto => ({
+): PersistedWorkspaceShape => ({
   sessions: storeShape.sessions.map((session) =>
     session.id !== selection.sessionId
       ? session
@@ -104,7 +104,7 @@ const shapeWithRestartedShell = (
 
 const restartPersistedActiveShell = async (
   service: ITerminalService,
-  storeShape: WorkspaceShapeDto | null,
+  storeShape: PersistedWorkspaceShape | null,
   liveSessions: readonly SessionInfo[]
 ): Promise<RestartedStoreShell | null> => {
   const hasLiveSession = liveSessions.some(
@@ -290,7 +290,7 @@ export const useSessionRestore = ({
     // through the browser-capable `setActiveSessionId` so a browser-only
     // session is selectable); otherwise fall back to the PTY-driven order.
     const activate = (
-      storeShape: WorkspaceShapeDto | null,
+      storeShape: PersistedWorkspaceShape | null,
       sessions: Session[],
       activePtyId: string | null
     ): void => {

--- a/src/features/sessions/hooks/useSessionRestore.ts
+++ b/src/features/sessions/hooks/useSessionRestore.ts
@@ -9,8 +9,8 @@ import { reconstructWorkspace } from '../utils/groupSessionsFromInfos'
 import { isBrowserPane } from '../utils/paneKind'
 import type {
   PersistedWorkspaceShape,
-  PersistedWorkspacePane,
-  PersistedShellPane,
+  PersistedWorkspacePaneShape,
+  PersistedShellPaneShape,
 } from '../workspaceLayoutBridge'
 import {
   beginWorkspaceHydration,
@@ -27,13 +27,13 @@ const log = createLogger('restore')
 const RESTORE_PANE_TIMEOUT_MS = 4000
 
 const isShapeShellPane = (
-  pane: PersistedWorkspacePane
-): pane is PersistedShellPane => pane.kind === 'shell'
+  pane: PersistedWorkspacePaneShape
+): pane is PersistedShellPaneShape => pane.kind === 'shell'
 
 interface StoreShellSelection {
   sessionId: string
   paneId: string
-  pane: PersistedShellPane
+  pane: PersistedShellPaneShape
 }
 
 interface RestartedStoreShell {

--- a/src/features/sessions/utils/groupSessionsFromInfos.test.ts
+++ b/src/features/sessions/utils/groupSessionsFromInfos.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'vitest'
 import type { PaneGrouping, SessionInfo } from '../../../bindings'
 import type {
-  PersistedBrowserPane,
+  PersistedBrowserPaneShape,
   PersistedWorkspaceShape,
-  PersistedShellPane,
+  PersistedShellPaneShape,
 } from '../workspaceLayoutBridge'
 import {
   groupSessionsFromInfos,
@@ -315,8 +315,8 @@ describe('groupSessionsFromInfos', () => {
 })
 
 const shellShape = (
-  overrides: Partial<PersistedShellPane> = {}
-): PersistedShellPane => ({
+  overrides: Partial<PersistedShellPaneShape> = {}
+): PersistedShellPaneShape => ({
   kind: 'shell',
   paneId: 'p0',
   paneIndex: 0,
@@ -329,8 +329,8 @@ const shellShape = (
 })
 
 const browserShape = (
-  overrides: Partial<PersistedBrowserPane> = {}
-): PersistedBrowserPane => ({
+  overrides: Partial<PersistedBrowserPaneShape> = {}
+): PersistedBrowserPaneShape => ({
   kind: 'browser',
   paneId: 'p0',
   paneIndex: 0,

--- a/src/features/sessions/utils/groupSessionsFromInfos.test.ts
+++ b/src/features/sessions/utils/groupSessionsFromInfos.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'vitest'
 import type { PaneGrouping, SessionInfo } from '../../../bindings'
 import type {
-  WorkspaceShapeBrowserPane,
-  WorkspaceShapeDto,
-  WorkspaceShapeShellPane,
+  PersistedBrowserPane,
+  PersistedWorkspaceShape,
+  PersistedShellPane,
 } from '../workspaceLayoutBridge'
 import {
   groupSessionsFromInfos,
@@ -315,8 +315,8 @@ describe('groupSessionsFromInfos', () => {
 })
 
 const shellShape = (
-  overrides: Partial<WorkspaceShapeShellPane> = {}
-): WorkspaceShapeShellPane => ({
+  overrides: Partial<PersistedShellPane> = {}
+): PersistedShellPane => ({
   kind: 'shell',
   paneId: 'p0',
   paneIndex: 0,
@@ -329,8 +329,8 @@ const shellShape = (
 })
 
 const browserShape = (
-  overrides: Partial<WorkspaceShapeBrowserPane> = {}
-): WorkspaceShapeBrowserPane => ({
+  overrides: Partial<PersistedBrowserPane> = {}
+): PersistedBrowserPane => ({
   kind: 'browser',
   paneId: 'p0',
   paneIndex: 0,
@@ -339,12 +339,12 @@ const browserShape = (
 })
 
 const storeOf = (
-  sessions: WorkspaceShapeDto['sessions']
-): WorkspaceShapeDto => ({ sessions })
+  sessions: PersistedWorkspaceShape['sessions']
+): PersistedWorkspaceShape => ({ sessions })
 
 const storeSession = (
-  overrides: Partial<WorkspaceShapeDto['sessions'][number]> = {}
-): WorkspaceShapeDto['sessions'][number] => ({
+  overrides: Partial<PersistedWorkspaceShape['sessions'][number]> = {}
+): PersistedWorkspaceShape['sessions'][number] => ({
   id: 'ws-1',
   projectId: 'proj-1',
   layout: 'single',

--- a/src/features/sessions/utils/groupSessionsFromInfos.ts
+++ b/src/features/sessions/utils/groupSessionsFromInfos.ts
@@ -19,9 +19,9 @@ import { createLogger } from '../../../lib/log'
 import { emptyActivity } from '../constants'
 import type { LayoutId, Pane, Session } from '../types'
 import type {
-  WorkspaceShapeDto,
-  WorkspaceShapeSession,
-  WorkspaceShapeShellPane,
+  PersistedWorkspaceShape,
+  PersistedWorkspaceSessionShape,
+  PersistedShellPane,
 } from '../workspaceLayoutBridge'
 import { readActivityPanelCollapsed } from './activityPanelCollapsedStore'
 import { sessionFromInfo } from './sessionFromInfo'
@@ -293,14 +293,14 @@ const reconcileActivePane = (
 // store pane's `paneId` / `agentType` / `active`.
 const buildReattachedShellPane = (
   live: SessionInfo,
-  shape: WorkspaceShapeShellPane
+  shape: PersistedShellPane
 ): Pane =>
   buildPane(live, shape.paneId, toAgentType(shape.agentType), shape.active)
 
 // A shell pane whose PTY is gone (graceful quit / crash) returns as a
 // restartable `completed` placeholder seeded with the persisted cwd + agent —
 // the existing Restart UX spawns a fresh shell there.
-const buildPlaceholderShellPane = (shape: WorkspaceShapeShellPane): Pane => ({
+const buildPlaceholderShellPane = (shape: PersistedShellPane): Pane => ({
   id: shape.paneId,
   ptyId: shape.ptyId,
   cwd: shape.cwd,
@@ -327,7 +327,7 @@ const buildRestoredBrowserPane = (
 })
 
 const buildStoreSession = (
-  shape: WorkspaceShapeSession,
+  shape: PersistedWorkspaceSessionShape,
   liveByPtyId: Map<string, SessionInfo>,
   fallbackIndex: number
 ): Session => {
@@ -381,7 +381,7 @@ const buildStoreSession = (
 // `groupSessionsFromInfos` (+ active-pane reconcile) so a reload with no store
 // behaves exactly like #290.
 export const reconstructWorkspace = (
-  storeShape: WorkspaceShapeDto | null,
+  storeShape: PersistedWorkspaceShape | null,
   liveSessions: readonly SessionInfo[],
   activeSessionId: string | null
 ): Session[] => {

--- a/src/features/sessions/utils/groupSessionsFromInfos.ts
+++ b/src/features/sessions/utils/groupSessionsFromInfos.ts
@@ -21,7 +21,7 @@ import type { LayoutId, Pane, Session } from '../types'
 import type {
   PersistedWorkspaceShape,
   PersistedWorkspaceSessionShape,
-  PersistedShellPane,
+  PersistedShellPaneShape,
 } from '../workspaceLayoutBridge'
 import { readActivityPanelCollapsed } from './activityPanelCollapsedStore'
 import { sessionFromInfo } from './sessionFromInfo'
@@ -293,14 +293,14 @@ const reconcileActivePane = (
 // store pane's `paneId` / `agentType` / `active`.
 const buildReattachedShellPane = (
   live: SessionInfo,
-  shape: PersistedShellPane
+  shape: PersistedShellPaneShape
 ): Pane =>
   buildPane(live, shape.paneId, toAgentType(shape.agentType), shape.active)
 
 // A shell pane whose PTY is gone (graceful quit / crash) returns as a
 // restartable `completed` placeholder seeded with the persisted cwd + agent —
 // the existing Restart UX spawns a fresh shell there.
-const buildPlaceholderShellPane = (shape: PersistedShellPane): Pane => ({
+const buildPlaceholderShellPane = (shape: PersistedShellPaneShape): Pane => ({
   id: shape.paneId,
   ptyId: shape.ptyId,
   cwd: shape.cwd,

--- a/src/features/sessions/workspaceLayoutBridge.test.ts
+++ b/src/features/sessions/workspaceLayoutBridge.test.ts
@@ -6,10 +6,10 @@ import {
   onWorkspaceRequestFinalShape,
   pushWorkspaceShape,
   type WorkspaceLayoutBridge,
-  type WorkspaceShapeDto,
+  type PersistedWorkspaceShape,
 } from './workspaceLayoutBridge'
 
-const shape: WorkspaceShapeDto = { sessions: [] }
+const shape: PersistedWorkspaceShape = { sessions: [] }
 
 interface TestWindow {
   vimeflow?: { workspaceLayout?: WorkspaceLayoutBridge }

--- a/src/features/sessions/workspaceLayoutBridge.ts
+++ b/src/features/sessions/workspaceLayoutBridge.ts
@@ -5,7 +5,7 @@
 // The shape-only DTO defined here is the renderer<->main contract: it carries
 // pane existence + shell fields, never browser tab/history (main owns those).
 
-export interface WorkspaceShapeShellPane {
+export interface PersistedShellPane {
   kind: 'shell'
   paneId: string
   paneIndex: number
@@ -16,28 +16,26 @@ export interface WorkspaceShapeShellPane {
   agentSessionId: string | null
 }
 
-export interface WorkspaceShapeBrowserPane {
+export interface PersistedBrowserPane {
   kind: 'browser'
   paneId: string
   paneIndex: number
   active: boolean
 }
 
-export type WorkspaceShapePane =
-  | WorkspaceShapeShellPane
-  | WorkspaceShapeBrowserPane
+export type PersistedWorkspacePane = PersistedShellPane | PersistedBrowserPane
 
-export interface WorkspaceShapeSession {
+export interface PersistedWorkspaceSessionShape {
   id: string
   projectId: string
   layout: string
   workingDirectory: string
   active: boolean
-  panes: WorkspaceShapePane[]
+  panes: PersistedWorkspacePane[]
 }
 
-export interface WorkspaceShapeDto {
-  sessions: WorkspaceShapeSession[]
+export interface PersistedWorkspaceShape {
+  sessions: PersistedWorkspaceSessionShape[]
 }
 
 export interface LoadWorkspaceForRestoreRequest {
@@ -46,10 +44,10 @@ export interface LoadWorkspaceForRestoreRequest {
 }
 
 export interface WorkspaceLayoutBridge {
-  pushShape: (dto: WorkspaceShapeDto) => Promise<void>
+  pushShape: (dto: PersistedWorkspaceShape) => Promise<void>
   loadForRestore: (
     request: LoadWorkspaceForRestoreRequest
-  ) => Promise<WorkspaceShapeDto>
+  ) => Promise<PersistedWorkspaceShape>
   beginHydration: () => Promise<void>
   endHydration: () => Promise<void>
   onRequestFinalShape: (callback: () => void) => () => void
@@ -70,14 +68,14 @@ const bridge = (): WorkspaceLayoutBridge | undefined => {
 }
 
 export const pushWorkspaceShape = async (
-  dto: WorkspaceShapeDto
+  dto: PersistedWorkspaceShape
 ): Promise<void> => {
   await bridge()?.pushShape(dto)
 }
 
 export const loadWorkspaceForRestore = async (
   request: LoadWorkspaceForRestoreRequest
-): Promise<WorkspaceShapeDto | null> =>
+): Promise<PersistedWorkspaceShape | null> =>
   bridge()?.loadForRestore(request) ?? null
 
 export const beginWorkspaceHydration = async (): Promise<void> => {

--- a/src/features/sessions/workspaceLayoutBridge.ts
+++ b/src/features/sessions/workspaceLayoutBridge.ts
@@ -5,7 +5,7 @@
 // The shape-only DTO defined here is the renderer<->main contract: it carries
 // pane existence + shell fields, never browser tab/history (main owns those).
 
-export interface PersistedShellPane {
+export interface PersistedShellPaneShape {
   kind: 'shell'
   paneId: string
   paneIndex: number
@@ -16,14 +16,16 @@ export interface PersistedShellPane {
   agentSessionId: string | null
 }
 
-export interface PersistedBrowserPane {
+export interface PersistedBrowserPaneShape {
   kind: 'browser'
   paneId: string
   paneIndex: number
   active: boolean
 }
 
-export type PersistedWorkspacePane = PersistedShellPane | PersistedBrowserPane
+export type PersistedWorkspacePaneShape =
+  | PersistedShellPaneShape
+  | PersistedBrowserPaneShape
 
 export interface PersistedWorkspaceSessionShape {
   id: string
@@ -31,7 +33,7 @@ export interface PersistedWorkspaceSessionShape {
   layout: string
   workingDirectory: string
   active: boolean
-  panes: PersistedWorkspacePane[]
+  panes: PersistedWorkspacePaneShape[]
 }
 
 export interface PersistedWorkspaceShape {


### PR DESCRIPTION
## Summary
- rename persisted workspace restore DTOs to distinguish durable layout shapes from runtime pane/session models
- update restore/grouping bridges and Electron workspace layout helpers to use the new persisted naming
- keep the Rust-side schema names unchanged in this PR to avoid coupling the upcoming resume/reopen feature work to a larger cross-language rename

## Why
This is a base refactor PR for the upcoming reopen-resume feature branch. The current `WorkspaceShape*` naming is too ambiguous because it looks like runtime pane/session state, while these types actually represent persisted workspace layout snapshots.

Making that boundary explicit now reduces follow-up churn when we add persistent fields such as launch-trigger/agent resume metadata.

## Scope
- TypeScript/Electron rename only
- no wire-shape changes
- no behavior changes intended
- Rust schema names intentionally unchanged for now

## Validation
- `npx vitest run electron/workspace-layout-controller.test.ts electron/workspace-layout-writer.test.ts electron/workspace-layout-roundtrip.test.ts src/features/sessions/workspaceLayoutBridge.test.ts src/features/sessions/hooks/useSessionRestore.test.ts src/features/sessions/hooks/useSessionManager.test.ts src/features/sessions/utils/groupSessionsFromInfos.test.ts`

## Notes
The repository's full pre-push suite currently has unrelated baseline failures in this environment:
- missing `tailwind-merge` package import from existing tests
- existing `editorFileLifecycleStatus` home-path case-sensitivity assertion failure

Those are not introduced by this refactor.


Refs VIM-153