### PR TITLE
fix(terminal): model Ghostty TUI redraw controls

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,8 +55,8 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 20       | 7    | 2026-06-18   |
-| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 1        | 0    | 2026-06-18   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 21       | 7    | 2026-06-18   |
+| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 2        | 0    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,10 +55,11 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 15       | 4    | 2026-06-18   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 18       | 5    | 2026-06-18   |
+| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 1        | 0    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 22   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,7 +55,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 11       | 4    | 2026-06-18   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 15       | 4    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 52       | 23   | 2026-06-13   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,7 +55,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 18       | 5    | 2026-06-18   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 19       | 6    | 2026-06-18   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 1        | 0    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,7 +55,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 19       | 6    | 2026-06-18   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 20       | 7    | 2026-06-18   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 1        | 0    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-13
-ref_count: 23
+ref_count: 24
 ---
 
 # Accessibility
@@ -532,3 +532,21 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** `window.prompt` and `window.confirm` blocked the renderer thread, used unstyled OS chrome, and could not display formatted validation hints or be cancelled via Escape reliably.
 - **Fix:** Replaced native dialogs with an inline rename input and a delete-confirmation strip styled with design tokens; kept actions non-blocking.
 - **Commit:** see `git blame` / `git log` on this line
+
+### 50. prefers-reduced-motion targets outer cursor span, not the animated marker
+
+- **Source:** github-claude | PR #534 round 2 | 2026-06-18
+- **Severity:** HIGH
+- **File:** `src/index.css` L265-270
+- **Finding:** The `@media (prefers-reduced-motion: reduce)` rule targeted `[data-terminal-cursor='true']`, but the blinking `@keyframes vfTerminalCursorBlink` animation was applied inline to the child `[data-terminal-cursor-marker='true']` span. `animation` is not inherited, so reduced-motion users still saw the blinking cursor.
+- **Fix:** Changed the media-query selector to `[data-terminal-cursor-marker='true']` so the animation is actually disabled for users who prefer reduced motion.
+- **Commit:** same commit as this entry
+
+### 51. Disable cursor marker animation for reduced motion (connector duplicate)
+
+- **Source:** github-codex-connector | PR #534 round 2 | 2026-06-18
+- **Severity:** P2 / MEDIUM
+- **File:** `src/index.css` L268
+- **Finding:** Same root cause as finding 50: the reduced-motion override targeted the wrapper span while the animation lived on the inner marker span, so the override had no effect.
+- **Fix:** Addressed by the same CSS selector change as finding 50.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -118,3 +118,40 @@ all required state through pure display-state helpers.
 - **Finding:** When a `38;2;R;G;B` true-color sequence has invalid or missing component values, the guard rejected the color but did not advance the parameter index past the sub-parameters. Control fell through to `index += 1`, so the color-mode byte (`2` or `5`) was consumed as a standalone SGR attribute in the next iteration, applying `dim` or corrupting subsequent styles.
 - **Fix:** Restructured the true-color and indexed branches to advance `index` by the full arity (5 for mode 2, 3 for mode 5) unconditionally, applying the style only when the color resolves. Added a regression test for out-of-range RGB and truncated indexed sequences.
 - **Commit:** same commit as this entry
+
+### 12. eraseDisplayInState mode 1 (ESC[1J) has no buffer-level test
+
+- **Source:** github-claude | PR #534 round 1 | 2026-06-18
+- **Severity:** HIGH
+- **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L728-736
+- **Finding:** `eraseDisplayInState` is called for both mode 0 and mode 1, but `terminalDisplayBuffer.test.ts` only exercises mode 0 (`getEraseDisplaySentinel(0)`). The mode 1 branch (lines 728–736) — which removes text from position 0 through the cursor character ...
+- **Fix:** Addressed in the same commit that appended this entry.
+- **Commit:** same commit as this entry
+
+### 13. softWrapAtCursor inserts duplicate newline after erase on wrapped line
+
+- **Source:** github-claude | PR #534 round 1 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L408-431
+- **Finding:** `eraseLineInState` mode 2 splices `[lineStart, lineEnd)` where `lineEnd` is the index of `\n`, so the soft-wrap `\n` is kept as the first character of remaining text. When new content is then written from `cursor = 0`, `writeDisplayCharacter` inserts...
+- **Fix:** Addressed in the same commit that appended this entry.
+- **Commit:** same commit as this entry
+
+### 14. parseCsiCursorPosition calls content.split(';') twice
+
+- **Source:** github-claude | PR #534 round 1 | 2026-06-18
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L312-332
+- **Finding:** `parseCsiCursorPosition` destructures `content.split(';')` into `[rowText, columnText]` and then calls `content.split(';')` again solely to check `.length > 2`. Use `const parts = content.split(';')` once, destructure from `parts`, and compare `parts...
+- **Fix:** Addressed in the same commit that appended this entry.
+- **Commit:** same commit as this entry
+
+### 15. Avoid inserting wrap rows over existing TUI rows
+
+- **Source:** github-codex-connector | PR #534 round 1 | 2026-06-18
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L430-430
+- **Finding:** When repainting an existing screen row that is exactly `columns` wide, the next printable cell should wrap onto the already-existing next row and overwrite there. This branch always inserts a new `\n` at the cursor, so a redraw like an existing `abcd...
+- **Fix:** Addressed in the same commit that appended this entry.
+- **Commit:** same commit as this entry
+

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -3,7 +3,7 @@ id: terminal-control-sequence-handling
 category: terminal
 created: 2026-06-17
 last_updated: 2026-06-18
-ref_count: 5
+ref_count: 6
 ---
 
 # Terminal Control Sequence Handling
@@ -180,4 +180,13 @@ all required state through pure display-state helpers.
 - **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L626-643
 - **Finding:** `softWrapAtCursor` wrapped only when the current line width reached `columns`. A two-cell glyph written at `columns - 1` therefore produced a line wider than the terminal, clipping the glyph and throwing off later cursor math.
 - **Fix:** Pass the incoming character to `softWrapAtCursor` and wrap when `lineCellWidth + readTerminalCellWidth(character, 0) > columns`.
+- **Commit:** same commit as this entry
+
+### 19. CSI H/CSI f absolute cursor snaps past wide glyphs when targeting their second cell
+
+- **Source:** github-claude | PR #534 round 3 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L430-443
+- **Finding:** `findOffsetForCellColumn` returned `cursor + readCodePointLength(...)` for both an exact column match and an overshoot. Overshoot only happens when the target terminal cell falls inside a two-cell glyph (CJK or emoji), so absolute cursor positioning landed after the glyph instead of at its boundary.
+- **Fix:** Changed the `nextColumn > targetColumn` branch to return the current glyph offset (`cursor`), matching the existing CHA-specific helper. Added a regression test that writes `a漢b`, positions the cursor at column 3 (the wide glyph's second cell), and asserts the cursor offset is the start of the wide glyph.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -154,4 +154,3 @@ all required state through pure display-state helpers.
 - **Finding:** When repainting an existing screen row that is exactly `columns` wide, the next printable cell should wrap onto the already-existing next row and overwrite there. This branch always inserts a new `\n` at the cursor, so a redraw like an existing `abcd...
 - **Fix:** Addressed in the same commit that appended this entry.
 - **Commit:** same commit as this entry
-

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -199,3 +199,12 @@ all required state through pure display-state helpers.
 - **Finding:** `eraseDisplayInState(mode=1)` removes `text.slice(0, endOffset)` and sets `cursor` to 0, but preserves `savedCursor` from the old buffer via `...state`. A later restore can therefore land `endOffset` bytes too far into the remaining text when save/restore is combined with ESC[1J.
 - **Fix:** Rebased `savedCursor` by subtracting `endOffset` and clamping to 0 when the saved position was inside the removed prefix, mirroring the existing scrollback-trim adjustment. Added a regression test that saves the cursor, erases from display start through the current cursor, restores, and asserts subsequent output lands at the correct offset.
 - **Commit:** same commit as this entry
+
+### 21. Track cursor row incrementally for CHA and cursor-down hot paths
+
+- **Source:** github-claude | PR #534 round 5 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L476
+- **Finding:** `readCursorRow` counted newlines from offset 0 to the cursor and was invoked for every cursor-horizontal-absolute sentinel and every cursor-down-at-EOF event in `applyDisplayData`. With large scrollback and frequent CHA repaint sequences, a single output batch could perform millions of redundant character comparisons.
+- **Fix:** Added `cursorRow` to `DisplayState` and threaded it through `applyDisplayData`. `moveCursorToPosition` and `moveCursorToHorizontalAbsoluteColumn` return the resolved row; cursor-left/backspace report a row delta when crossing a soft-wrap newline; other row-changing paths update or recompute `cursorRow` so CHA and cursor-down can read the current row in O(1).
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -3,7 +3,7 @@ id: terminal-control-sequence-handling
 category: terminal
 created: 2026-06-17
 last_updated: 2026-06-18
-ref_count: 4
+ref_count: 5
 ---
 
 # Terminal Control Sequence Handling
@@ -153,4 +153,31 @@ all required state through pure display-state helpers.
 - **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L430-430
 - **Finding:** When repainting an existing screen row that is exactly `columns` wide, the next printable cell should wrap onto the already-existing next row and overwrite there. This branch always inserts a new `\n` at the cursor, so a redraw like an existing `abcd...
 - **Fix:** Addressed in the same commit that appended this entry.
+- **Commit:** same commit as this entry
+
+### 16. ESC[G (cursor horizontal absolute) skips columns inside wide characters
+
+- **Source:** github-claude | PR #534 round 2 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L522-540
+- **Finding:** The `ESC[nG` handler translated the sequence to `\r` plus cursor-right sentinels. `moveCursorRight` advances by whole glyphs, so when the target column fell inside a wide character the cursor overshot to the character after it.
+- **Fix:** Added a dedicated `CursorHorizontalAbsoluteSentinel` that carries only the target column. The display buffer resolves it on the current row using a column lookup that lands on the wide-glyph start when the target falls inside the glyph.
+- **Commit:** same commit as this entry
+
+### 17. Create missing rows for cursor-down moves
+
+- **Source:** github-codex-connector | PR #534 round 2 | 2026-06-18
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L466-478
+- **Finding:** `moveCursorDown` returned the end of the last buffered line when asked to move below it. A subsequent `\r` then operated on the original line and overwrote it, so `line1\x1b[Eline2` rendered as `line2` instead of two rows.
+- **Fix:** In `applyDisplayData`, when a cursor-down sentinel is at the last line, route through `moveCursorToPosition(row + 1, current column + 1)` so the new row is materialized and padded to the original horizontal position.
+- **Commit:** same commit as this entry
+
+### 18. Wrap wide glyphs before appending them at the margin
+
+- **Source:** github-codex-connector | PR #534 round 2 | 2026-06-18
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L626-643
+- **Finding:** `softWrapAtCursor` wrapped only when the current line width reached `columns`. A two-cell glyph written at `columns - 1` therefore produced a line wider than the terminal, clipping the glyph and throwing off later cursor math.
+- **Fix:** Pass the incoming character to `softWrapAtCursor` and wrap when `lineCellWidth + readTerminalCellWidth(character, 0) > columns`.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -3,7 +3,7 @@ id: terminal-control-sequence-handling
 category: terminal
 created: 2026-06-17
 last_updated: 2026-06-18
-ref_count: 6
+ref_count: 7
 ---
 
 # Terminal Control Sequence Handling
@@ -189,4 +189,13 @@ all required state through pure display-state helpers.
 - **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L430-443
 - **Finding:** `findOffsetForCellColumn` returned `cursor + readCodePointLength(...)` for both an exact column match and an overshoot. Overshoot only happens when the target terminal cell falls inside a two-cell glyph (CJK or emoji), so absolute cursor positioning landed after the glyph instead of at its boundary.
 - **Fix:** Changed the `nextColumn > targetColumn` branch to return the current glyph offset (`cursor`), matching the existing CHA-specific helper. Added a regression test that writes `a漢b`, positions the cursor at column 3 (the wide glyph's second cell), and asserts the cursor offset is the start of the wide glyph.
+- **Commit:** same commit as this entry
+
+### 20. ED mode 1 removes a prefix without rebasing savedCursor
+
+- **Source:** github-codex-connector | PR #534 round 4 | 2026-06-18
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts` L1078-1106
+- **Finding:** `eraseDisplayInState(mode=1)` removes `text.slice(0, endOffset)` and sets `cursor` to 0, but preserves `savedCursor` from the old buffer via `...state`. A later restore can therefore land `endOffset` bytes too far into the remaining text when save/restore is combined with ESC[1J.
+- **Fix:** Rebased `savedCursor` by subtracting `endOffset` and clamping to 0 when the saved position was inside the removed prefix, mirroring the existing scrollback-trim adjustment. Added a regression test that saves the cursor, erases from display start through the current cursor, restores, and asserts subsequent output lands at the correct offset.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-dom-rendering.md
+++ b/docs/reviews/patterns/terminal-dom-rendering.md
@@ -1,0 +1,24 @@
+---
+id: terminal-dom-rendering
+category: terminal
+created: 2026-06-18
+last_updated: 2026-06-18
+ref_count: 0
+---
+
+# Terminal DOM Rendering
+
+## Summary
+
+The terminal renderer translates a buffered text/runs model into DOM rows for display. Because selection and clipboard operations read from the rendered DOM, the visual representation must preserve semantic whitespace (notably newlines) in a way that survives `Selection.toString()`. Block-level row elements alone are not always enough; an explicit, selectable newline character in the DOM prevents copied multi-line output from collapsing into a single line.
+
+## Findings
+
+### 1. Preserve newlines when rendering selectable rows
+
+- **Source:** github-codex-connector | PR #534 round 2 | 2026-06-18
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts` L671
+- **Finding:** `createOutputFragments` split buffered text on `\n` and created a new `display: block` row for each line, but it did not insert any newline text into the DOM. `TerminalTextSurface.getSelection()` returned `Selection.toString()`, so selecting or copying `hello\nworld` produced `helloworld`.
+- **Fix:** In `appendNewline`, append a zero-font-size span containing a newline text node to the current row before pushing the next row. The span contributes a selectable newline without affecting the row's visual height.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-dom-rendering.md
+++ b/docs/reviews/patterns/terminal-dom-rendering.md
@@ -22,3 +22,12 @@ The terminal renderer translates a buffered text/runs model into DOM rows for di
 - **Finding:** `createOutputFragments` split buffered text on `\n` and created a new `display: block` row for each line, but it did not insert any newline text into the DOM. `TerminalTextSurface.getSelection()` returned `Selection.toString()`, so selecting or copying `hello\nworld` produced `helloworld`.
 - **Fix:** In `appendNewline`, append a zero-font-size span containing a newline text node to the current row before pushing the next row. The span contributes a selectable newline without affecting the row's visual height.
 - **Commit:** same commit as this entry
+
+### 2. Cache measured terminal character width across fit() calls
+
+- **Source:** github-claude | PR #534 round 5 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts` L479
+- **Finding:** `measureCharacterWidth` appended a probe span, forced `getBoundingClientRect()`, and removed the span on every `fit()` call. During continuous pane/window resize this repeated a synchronous layout read for a font metric that is stable for the surface lifetime.
+- **Fix:** Added a nullable `cachedCharacterWidth` instance field. `measureCharacterWidth` returns the cached value after the first successful measurement; the cache is not invalidated because `TERMINAL_FONT_FAMILY` and `TERMINAL_FONT_SIZE` are constants for the surface.
+- **Commit:** same commit as this entry

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -318,6 +318,136 @@ describe('ghosttyInstance', () => {
     expect(visibleText.match(/Starting MCP servers/g)).toHaveLength(1)
   })
 
+  test('restores the editable cursor after byte-path right-prompt controls', () => {
+    const created = createTrackedGhosttyTerminal()
+    const output = `❯ ${ESC}7${ESC}[1;12H03:52${ESC}8a\b \b`
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    const row = created.terminal.element?.querySelector(
+      '[data-terminal-row="true"]'
+    )
+    const cursor = row?.querySelector('[data-terminal-cursor="true"]')
+
+    expect(created.viewportReader.readVisibleText()).toContain('03:52')
+    expect(row?.textContent?.startsWith('❯  ')).toBe(true)
+    expect(cursor?.previousSibling?.textContent).toBe('❯ ')
+  })
+
+  test('keeps the prompt cursor stable after narrow wrapped input deletes', () => {
+    const created = createTrackedGhosttyTerminal()
+    const dataHandler = vi.fn()
+    const container = document.createElement('div')
+    const prompt = '04:42 ❯ '
+    const typedText = 'hello world '.repeat(2)
+    const deleteEcho = '\b \b'.repeat(typedText.length)
+    const output = `${prompt}${typedText}${deleteEcho}`
+
+    setElementSize(container, 112, 180)
+    created.terminal.open(container)
+    created.terminal.onData(dataHandler)
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    const cursor = created.terminal.element?.querySelector(
+      '[data-terminal-cursor="true"]'
+    )
+    const cursorRow = cursor?.parentElement
+
+    const visibleTextBeforeExtraDelete =
+      created.viewportReader.readVisibleText()
+
+    expect(created.terminal.cols).toBe(12)
+    expect(visibleTextBeforeExtraDelete.split('\n')).toHaveLength(3)
+    expect(visibleTextBeforeExtraDelete).not.toContain('hello')
+    expect(visibleTextBeforeExtraDelete).not.toContain('world')
+    expect(cursorRow?.dataset.terminalRow).toBe('true')
+    expect(cursor?.previousSibling?.textContent).toBe(prompt)
+
+    const input = created.terminal.element?.querySelector('textarea')
+
+    input?.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Backspace',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(dataHandler).toHaveBeenCalledWith('\x7f')
+    expect(created.viewportReader.readVisibleText()).toBe(
+      visibleTextBeforeExtraDelete
+    )
+  })
+
+  test('keeps the prompt cursor stable when the prompt also wraps', () => {
+    const created = createTrackedGhosttyTerminal()
+    const dataHandler = vi.fn()
+    const container = document.createElement('div')
+    const prompt = 'prompt row one $ ❯ '
+    const typedText = 'wrapped input '.repeat(2)
+    const deleteEcho = '\b \b'.repeat(typedText.length)
+    const output = `${prompt}${typedText}${deleteEcho}`
+
+    setElementSize(container, 112, 180)
+    created.terminal.open(container)
+    created.terminal.onData(dataHandler)
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    const rows = Array.from(
+      created.terminal.element?.querySelectorAll(
+        '[data-terminal-row="true"]'
+      ) ?? []
+    )
+
+    const cursor = created.terminal.element?.querySelector(
+      '[data-terminal-cursor="true"]'
+    )
+
+    const visibleTextBeforeExtraDelete =
+      created.viewportReader.readVisibleText()
+
+    expect(created.terminal.cols).toBe(12)
+    expect(rows[0]?.textContent).toBe(prompt.slice(0, 12))
+    expect(cursor?.parentElement).toBe(rows[1])
+    expect(cursor?.previousSibling?.textContent).toBe(prompt.slice(12))
+    expect(visibleTextBeforeExtraDelete).not.toContain(typedText)
+
+    const input = created.terminal.element?.querySelector('textarea')
+
+    input?.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Backspace',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(dataHandler).toHaveBeenCalledWith('\x7f')
+    expect(created.viewportReader.readVisibleText()).toBe(
+      visibleTextBeforeExtraDelete
+    )
+    expect(cursor?.parentElement).toBe(rows[1])
+    expect(cursor?.previousSibling?.textContent).toBe(prompt.slice(12))
+  })
+
   test('renders a visual cursor from the Ghostty byte parser state', () => {
     const created = createTrackedGhosttyTerminal()
     const output = `abc${ESC}[2D`

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -425,7 +425,7 @@ describe('ghosttyInstance', () => {
       created.viewportReader.readVisibleText()
 
     expect(created.terminal.cols).toBe(12)
-    expect(rows[0]?.textContent).toBe(prompt.slice(0, 12))
+    expect(rows[0]?.textContent).toBe(`${prompt.slice(0, 12)}\n`)
     expect(cursor?.parentElement).toBe(rows[1])
     expect(cursor?.previousSibling?.textContent).toBe(prompt.slice(12))
     expect(visibleTextBeforeExtraDelete).not.toContain(typedText)

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -1,4 +1,4 @@
-// cspell:ignore ghostty
+// cspell:ignore ghostty xhigh
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type {
   TerminalDisposable,
@@ -13,6 +13,22 @@ import {
   type GhosttyTerminalOptions,
 } from './ghosttyInstance'
 import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
+
+const setElementSize = (
+  element: HTMLElement,
+  width: number,
+  height: number
+): void => {
+  Object.defineProperty(element, 'offsetWidth', {
+    configurable: true,
+    value: width,
+  })
+
+  Object.defineProperty(element, 'offsetHeight', {
+    configurable: true,
+    value: height,
+  })
+}
 
 const encodeBase64 = (bytes: Uint8Array): string => {
   let binary = ''
@@ -198,6 +214,108 @@ describe('ghosttyInstance', () => {
     })
 
     expect(created.viewportReader.readVisibleText()).toBe('Start')
+  })
+
+  test('rewrites Codex MCP progress output from byte payload row redraws', () => {
+    const created = createTrackedGhosttyTerminal()
+
+    const output =
+      'Starting MCP servers (1/3): codex_apps\nlinear pending' +
+      `${ESC}[1A\r${ESC}[2K` +
+      'Starting MCP servers (2/3): codex_apps, linear\n' +
+      `${ESC}[2K` +
+      'linear ready'
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe(
+      'Starting MCP servers (2/3): codex_apps, linear\nlinear ready'
+    )
+    expect(created.viewportReader.readVisibleText()).not.toContain('(1/3)')
+    expect(created.viewportReader.readVisibleText()).not.toContain('pending')
+  })
+
+  test('keeps previous soft-wrapped input rows when the wrapped byte tail redraws', () => {
+    const created = createTrackedGhosttyTerminal()
+    const container = document.createElement('div')
+    const output = `abcdef\r${ESC}[Kgh`
+
+    setElementSize(container, 40, 180)
+    created.terminal.open(container)
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    expect(created.terminal.cols).toBe(5)
+    expect(created.viewportReader.readVisibleText()).toBe('abcde\ngh')
+  })
+
+  test('erases stale rows below the cursor during TUI byte redraws', () => {
+    const created = createTrackedGhosttyTerminal()
+
+    const output =
+      '› Summarize recent commits\n' +
+      '› gpt-5.5 xhigh · ~/projects/aws\n' +
+      '  gpt-5.5 xhigh · ~/projects/aws' +
+      `${ESC}[2;1H${ESC}[J› gpt-5.5 xhigh · ~/projects/aws`
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    const visibleText = created.viewportReader.readVisibleText()
+
+    expect(visibleText).toBe(
+      '› Summarize recent commits\n› gpt-5.5 xhigh · ~/projects/aws'
+    )
+    expect(visibleText.match(/gpt-5.5 xhigh/g)).toHaveLength(1)
+  })
+
+  test('rewrites Codex startup TUI byte output positioned by absolute cursor controls', () => {
+    const created = createTrackedGhosttyTerminal()
+
+    const output =
+      `${ESC}[2J${ESC}[1;1H>_ OpenAI Codex` +
+      `${ESC}[1;42H` +
+      'model: loading' +
+      `${ESC}[2;1H~/projects/aws` +
+      `${ESC}[3;1HStarting MCP servers (1/3): codex_apps` +
+      `${ESC}[1;42H${ESC}[K` +
+      'model: gpt-5.5 default' +
+      `${ESC}[3;1H${ESC}[2KStarting MCP servers (2/3): codex_apps, linear`
+
+    created.output.writeOutput({
+      text: 'wrong',
+      bytesBase64: encodeText(output),
+      offsetStart: 0,
+      byteLen: new TextEncoder().encode(output).length,
+      phase: 'live',
+    })
+
+    const visibleText = created.viewportReader.readVisibleText()
+
+    expect(visibleText).toContain('>_ OpenAI Codex')
+    expect(visibleText).toContain('model: gpt-5.5 default')
+    expect(visibleText).toContain(
+      'Starting MCP servers (2/3): codex_apps, linear'
+    )
+    expect(visibleText).not.toContain('loading')
+    expect(visibleText).not.toContain('(1/3)')
+    expect(visibleText.match(/Starting MCP servers/g)).toHaveLength(1)
   })
 
   test('renders a visual cursor from the Ghostty byte parser state', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -246,7 +246,7 @@ describe('ghosttyInstance', () => {
     const container = document.createElement('div')
     const output = `abcdef\r${ESC}[Kgh`
 
-    setElementSize(container, 40, 180)
+    setElementSize(container, 56, 180)
     created.terminal.open(container)
     created.output.writeOutput({
       text: 'wrong',

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore xhigh
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { themeService } from '../../../../theme'
 import {
@@ -129,6 +130,25 @@ describe('plainTextInstance', () => {
     expect(cursor).not.toBeNull()
     expect(output?.textContent).toBe('')
     expect(created.viewportReader.readVisibleText()).toBe('')
+  })
+
+  test('renders the visual cursor as a blinking block marker', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write('abc')
+
+    const output = created.terminal.element?.querySelector('pre')
+
+    const cursor = output?.querySelector(
+      '[data-terminal-cursor="true"]'
+    ) as HTMLElement | null
+
+    expect(output?.textContent).toBe('abc')
+    expect(cursor?.style.backgroundColor).toBe('var(--terminal-cursor-color)')
+    expect(cursor?.style.borderLeft).toBe('')
+    expect(cursor?.style.animationName).toBe('vfTerminalCursorBlink')
+    expect(cursor?.style.width).toBe('0.62em')
+    expect(created.viewportReader.readVisibleText()).toBe('abc')
   })
 
   test('places the visual cursor at the renderer buffer offset', () => {
@@ -271,6 +291,92 @@ describe('plainTextInstance', () => {
     created.terminal.write('S\x1b[1DSt\x1b[2DSta\x1b[3DStart')
 
     expect(created.viewportReader.readVisibleText()).toBe('Start')
+  })
+
+  test('keeps previous soft-wrapped input rows when the wrapped tail redraws', () => {
+    const created = createTrackedPlainTextTerminal()
+    const container = document.createElement('div')
+
+    setElementSize(container, 40, 180)
+    created.terminal.open(container)
+    created.terminal.write('abcdef')
+    created.terminal.write('\r\x1b[Kgh')
+
+    expect(created.terminal.cols).toBe(5)
+    expect(created.viewportReader.readVisibleText()).toBe('abcde\ngh')
+    expect(
+      created.terminal.element?.querySelector('pre')?.style.whiteSpace
+    ).toBe('pre')
+  })
+
+  test('rewrites Codex MCP progress output that redraws previous rows', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write(
+      'Starting MCP servers (1/3): codex_apps\nlinear pending'
+    )
+
+    // cspell:disable-next-line
+    created.terminal.write(
+      '\x1b[1A\r\x1b[2K' +
+        'Starting MCP servers (2/3): codex_apps, linear\n' +
+        '\x1b[2K' +
+        'linear ready'
+    )
+
+    expect(created.viewportReader.readVisibleText()).toBe(
+      'Starting MCP servers (2/3): codex_apps, linear\nlinear ready'
+    )
+    expect(created.viewportReader.readVisibleText()).not.toContain('(1/3)')
+    expect(created.viewportReader.readVisibleText()).not.toContain('pending')
+  })
+
+  test('rewrites Codex startup TUI output positioned by absolute cursor controls', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write(
+      '\x1b[2J\x1b[1;1H>_ OpenAI Codex' +
+        '\x1b[1;42H' +
+        'model: loading' +
+        '\x1b[2;1H~/projects/aws' +
+        '\x1b[3;1HStarting MCP servers (1/3): codex_apps'
+    )
+
+    created.terminal.write(
+      '\x1b[1;42H\x1b[K' +
+        'model: gpt-5.5 default' +
+        '\x1b[3;1H\x1b[2KStarting MCP servers (2/3): codex_apps, linear'
+    )
+
+    const visibleText = created.viewportReader.readVisibleText()
+
+    expect(visibleText).toContain('>_ OpenAI Codex')
+    expect(visibleText).toContain('model: gpt-5.5 default')
+    expect(visibleText).toContain(
+      'Starting MCP servers (2/3): codex_apps, linear'
+    )
+    expect(visibleText).not.toContain('loading')
+    expect(visibleText).not.toContain('(1/3)')
+    expect(visibleText.match(/Starting MCP servers/g)).toHaveLength(1)
+  })
+
+  test('erases stale rows below the cursor during TUI redraws', () => {
+    const created = createTrackedPlainTextTerminal()
+
+    created.terminal.write(
+      '› Summarize recent commits\n' +
+        '› gpt-5.5 xhigh · ~/projects/aws\n' +
+        '  gpt-5.5 xhigh · ~/projects/aws'
+    )
+
+    created.terminal.write('\x1b[2;1H\x1b[J› gpt-5.5 xhigh · ~/projects/aws')
+
+    const visibleText = created.viewportReader.readVisibleText()
+
+    expect(visibleText).toBe(
+      '› Summarize recent commits\n› gpt-5.5 xhigh · ~/projects/aws'
+    )
+    expect(visibleText.match(/gpt-5.5 xhigh/g)).toHaveLength(1)
   })
 
   test('erases from line start to cursor inclusive in erase-line mode 1', () => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -347,7 +347,7 @@ describe('plainTextInstance', () => {
     )
 
     expect(rows).toHaveLength(2)
-    expect(rows?.[0]?.textContent).toBe('abcde')
+    expect(rows?.[0]?.textContent).toBe('abcde\n')
     expect(rows?.[1]?.textContent).toBe('gh')
   })
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -173,11 +173,18 @@ describe('plainTextInstance', () => {
       '[data-terminal-cursor="true"]'
     ) as HTMLElement | null
 
+    const marker = cursor?.querySelector(
+      '[data-terminal-cursor-marker="true"]'
+    ) as HTMLElement | null
+
     expect(output?.textContent).toBe('abc')
-    expect(cursor?.style.backgroundColor).toBe('var(--terminal-cursor-color)')
-    expect(cursor?.style.borderLeft).toBe('')
-    expect(cursor?.style.animationName).toBe('vfTerminalCursorBlink')
-    expect(cursor?.style.width).toBe('0.62em')
+    expect(cursor?.style.position).toBe('relative')
+    expect(cursor?.style.width).toBe('0px')
+    expect(marker?.style.backgroundColor).toBe('var(--terminal-cursor-color)')
+    expect(marker?.style.borderLeft).toBe('')
+    expect(marker?.style.animationName).toBe('vfTerminalCursorBlink')
+    expect(marker?.style.position).toBe('absolute')
+    expect(marker?.style.width).toBe('0.62em')
     expect(created.viewportReader.readVisibleText()).toBe('abc')
   })
 

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -84,16 +84,39 @@ describe('plainTextInstance', () => {
     created.terminal.open(container)
 
     expect(container.firstElementChild).toBe(created.terminal.element)
-    expect(created.terminal.cols).toBe(80)
+    expect(created.terminal.cols).toBe(78)
     expect(created.terminal.rows).toBe(20)
-    expect(resizeHandler).toHaveBeenCalledWith({ cols: 80, rows: 20 })
+    expect(resizeHandler).toHaveBeenCalledWith({ cols: 78, rows: 20 })
 
     setElementSize(container, 400, 180)
     created.fitController.fit()
 
-    expect(created.terminal.cols).toBe(50)
+    expect(created.terminal.cols).toBe(48)
     expect(created.terminal.rows).toBe(10)
-    expect(resizeHandler).toHaveBeenLastCalledWith({ cols: 50, rows: 10 })
+    expect(resizeHandler).toHaveBeenLastCalledWith({ cols: 48, rows: 10 })
+  })
+
+  test('clamps renderer output to the pane width', () => {
+    const created = createTrackedPlainTextTerminal()
+    const container = document.createElement('div')
+
+    setElementSize(container, 640, 360)
+    created.terminal.open(container)
+
+    const root = created.terminal.element
+    const output = root?.querySelector('pre')
+
+    expect(root?.style.overflowX).toBe('hidden')
+    expect(root?.style.overflowY).toBe('auto')
+    expect(root?.style.maxWidth).toBe('100%')
+    expect(root?.style.width).toBe('100%')
+    expect(output?.style.boxSizing).toBe('border-box')
+    expect(output?.style.maxWidth).toBe('100%')
+    expect(output?.style.overflowWrap).toBe('anywhere')
+    expect(output?.style.overflowX).toBe('hidden')
+    expect(output?.style.whiteSpace).toBe('pre-wrap')
+    expect(output?.style.width).toBe('100%')
+    expect(output?.style.wordBreak).toBe('break-word')
   })
 
   test('writes output chunks into the viewport reader', () => {
@@ -297,7 +320,7 @@ describe('plainTextInstance', () => {
     const created = createTrackedPlainTextTerminal()
     const container = document.createElement('div')
 
-    setElementSize(container, 40, 180)
+    setElementSize(container, 56, 180)
     created.terminal.open(container)
     created.terminal.write('abcdef')
     created.terminal.write('\r\x1b[Kgh')
@@ -306,7 +329,7 @@ describe('plainTextInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('abcde\ngh')
     expect(
       created.terminal.element?.querySelector('pre')?.style.whiteSpace
-    ).toBe('pre')
+    ).toBe('pre-wrap')
   })
 
   test('rewrites Codex MCP progress output that redraws previous rows', () => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -112,11 +112,18 @@ describe('plainTextInstance', () => {
     expect(root?.style.width).toBe('100%')
     expect(output?.style.boxSizing).toBe('border-box')
     expect(output?.style.maxWidth).toBe('100%')
-    expect(output?.style.overflowWrap).toBe('anywhere')
     expect(output?.style.overflowX).toBe('hidden')
-    expect(output?.style.whiteSpace).toBe('pre-wrap')
+    expect(output?.style.whiteSpace).toBe('normal')
     expect(output?.style.width).toBe('100%')
-    expect(output?.style.wordBreak).toBe('break-word')
+    expect(output?.style.wordBreak).toBe('normal')
+
+    const row = output?.querySelector('[data-terminal-row="true"]')
+
+    expect(row).toBeInstanceOf(HTMLElement)
+    expect((row as HTMLElement | null)?.style.maxWidth).toBe('100%')
+    expect((row as HTMLElement | null)?.style.overflowX).toBe('hidden')
+    expect((row as HTMLElement | null)?.style.whiteSpace).toBe('pre')
+    expect((row as HTMLElement | null)?.style.width).toBe('100%')
   })
 
   test('writes output chunks into the viewport reader', () => {
@@ -327,9 +334,14 @@ describe('plainTextInstance', () => {
 
     expect(created.terminal.cols).toBe(5)
     expect(created.viewportReader.readVisibleText()).toBe('abcde\ngh')
-    expect(
-      created.terminal.element?.querySelector('pre')?.style.whiteSpace
-    ).toBe('pre-wrap')
+
+    const rows = created.terminal.element?.querySelectorAll(
+      '[data-terminal-row="true"]'
+    )
+
+    expect(rows).toHaveLength(2)
+    expect(rows?.[0]?.textContent).toBe('abcde')
+    expect(rows?.[1]?.textContent).toBe('gh')
   })
 
   test('rewrites Codex MCP progress output that redraws previous rows', () => {
@@ -680,8 +692,9 @@ describe('plainTextInstance', () => {
     created.terminal.write('inside terminal')
     sibling.textContent = 'outside pane'
 
-    const outputText =
-      created.terminal.element?.querySelector('pre')?.firstChild
+    const outputText = created.terminal.element?.querySelector(
+      '[data-terminal-row="true"]'
+    )?.firstChild
     const siblingText = sibling.firstChild
 
     if (!outputText || !siblingText) {
@@ -711,8 +724,9 @@ describe('plainTextInstance', () => {
     created.terminal.write('inside terminal')
     created.terminal.onSelectionChange(listener)
 
-    const outputText =
-      created.terminal.element?.querySelector('pre')?.firstChild
+    const outputText = created.terminal.element?.querySelector(
+      '[data-terminal-row="true"]'
+    )?.firstChild
 
     if (!outputText) {
       throw new Error('selection test requires terminal text node')

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, test, vi } from 'vitest'
 import {
   TerminalControlSequenceParser,
   getClearScreenSentinel,
+  getCursorDownSentinel,
   getCursorLeftSentinel,
+  getCursorPositionSentinel,
   getCursorRightSentinel,
+  getCursorUpSentinel,
+  getEraseDisplaySentinel,
+  getEraseLineSentinel,
   getSgrStyleSentinel,
 } from './terminalControlParser'
 
@@ -174,6 +179,25 @@ describe('TerminalControlSequenceParser', () => {
     expect(handler).not.toHaveBeenCalled()
   })
 
+  test('preserves erase-display controls as display sentinels', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    const visible = parser.transformOutput(
+      `top${ESC}[J` + `middle${ESC}[1J` + `bottom${ESC}[2J` + 'reset',
+      null
+    )
+
+    expect(visible).toBe(
+      `top${getEraseDisplaySentinel(0)}middle` +
+        `${getEraseDisplaySentinel(1)}bottom` +
+        `${getClearScreenSentinel()}reset`
+    )
+    expect(handler).not.toHaveBeenCalled()
+  })
+
   test('treats explicit zero cursor movement counts as the default of one', () => {
     const parser = new TerminalControlSequenceParser()
     const handler = vi.fn()
@@ -187,6 +211,52 @@ describe('TerminalControlSequenceParser', () => {
 
     expect(visible).toBe(
       `abc${getCursorLeftSentinel()}` + `XY${getCursorRightSentinel()}z` + `\r!`
+    )
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('preserves vertical cursor movement controls as display sentinels', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    const visible = parser.transformOutput(
+      `top\nbottom${ESC}[A\r${ESC}[2K` +
+        `updated${ESC}[B` +
+        `tail${ESC}[F` +
+        'reset',
+      null
+    )
+
+    expect(visible).toBe(
+      `top\nbottom${getCursorUpSentinel()}\r` +
+        `${getEraseLineSentinel(2)}updated${getCursorDownSentinel()}tail` +
+        `${getCursorUpSentinel()}\rreset`
+    )
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('preserves absolute cursor positioning controls as display sentinels', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    const visible = parser.transformOutput(
+      `before${ESC}[2;5H` +
+        `cell${ESC}[H` +
+        `home${ESC}[3;4f` +
+        `there${ESC}[0;0H` +
+        'reset',
+      null
+    )
+
+    expect(visible).toBe(
+      `before${getCursorPositionSentinel(2, 5)}cell` +
+        `${getCursorPositionSentinel(1, 1)}home` +
+        `${getCursorPositionSentinel(3, 4)}there` +
+        `${getCursorPositionSentinel(1, 1)}reset`
     )
     expect(handler).not.toHaveBeenCalled()
   })

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
@@ -9,6 +9,8 @@ import {
   getCursorUpSentinel,
   getEraseDisplaySentinel,
   getEraseLineSentinel,
+  getRestoreCursorSentinel,
+  getSaveCursorSentinel,
   getSgrStyleSentinel,
 } from './terminalControlParser'
 
@@ -257,6 +259,30 @@ describe('TerminalControlSequenceParser', () => {
         `${getCursorPositionSentinel(1, 1)}home` +
         `${getCursorPositionSentinel(3, 4)}there` +
         `${getCursorPositionSentinel(1, 1)}reset`
+    )
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('preserves cursor save and restore controls as display sentinels', () => {
+    const parser = new TerminalControlSequenceParser()
+    const handler = vi.fn()
+
+    parser.onEvent(handler)
+
+    const csiSave = `${ESC}[s`
+    const csiRestore = `${ESC}[u`
+
+    const visible = parser.transformOutput(
+      `prompt${ESC}7right${ESC}8input` +
+        `alt${csiSave}status${csiRestore}again`,
+      null
+    )
+
+    expect(visible).toBe(
+      `prompt${getSaveCursorSentinel()}right` +
+        `${getRestoreCursorSentinel()}input` +
+        `alt${getSaveCursorSentinel()}status` +
+        `${getRestoreCursorSentinel()}again`
     )
     expect(handler).not.toHaveBeenCalled()
   })

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.test.ts
@@ -3,6 +3,7 @@ import {
   TerminalControlSequenceParser,
   getClearScreenSentinel,
   getCursorDownSentinel,
+  getCursorHorizontalAbsoluteSentinel,
   getCursorLeftSentinel,
   getCursorPositionSentinel,
   getCursorRightSentinel,
@@ -176,7 +177,7 @@ describe('TerminalControlSequenceParser', () => {
       `old${getClearScreenSentinel()}abc` +
         `${getCursorLeftSentinel()}${getCursorLeftSentinel()}` +
         `XY${getCursorRightSentinel()}z` +
-        `\r${getCursorRightSentinel()}${getCursorRightSentinel()}!`
+        `${getCursorHorizontalAbsoluteSentinel(3)}!`
     )
     expect(handler).not.toHaveBeenCalled()
   })
@@ -212,7 +213,9 @@ describe('TerminalControlSequenceParser', () => {
     )
 
     expect(visible).toBe(
-      `abc${getCursorLeftSentinel()}` + `XY${getCursorRightSentinel()}z` + `\r!`
+      `abc${getCursorLeftSentinel()}` +
+        `XY${getCursorRightSentinel()}z` +
+        `${getCursorHorizontalAbsoluteSentinel(1)}!`
     )
     expect(handler).not.toHaveBeenCalled()
   })

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -27,6 +27,8 @@ const CURSOR_POSITION_SENTINEL_END = '\u{F000B}'
 const ERASE_DISPLAY_SENTINELS = ['\u{F000C}', '\u{F000D}']
 const SAVE_CURSOR_SENTINEL = '\u{F000E}'
 const RESTORE_CURSOR_SENTINEL = '\u{F000F}'
+const CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_START = '\u{F0010}'
+const CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_END = '\u{F0011}'
 
 export interface TerminalControlSequenceOutput {
   readonly visibleText: string
@@ -40,6 +42,11 @@ export interface SgrStyleSentinel {
 
 export interface CursorPositionSentinel {
   readonly row: number
+  readonly column: number
+  readonly length: number
+}
+
+export interface CursorHorizontalAbsoluteSentinel {
   readonly column: number
   readonly length: number
 }
@@ -65,6 +72,11 @@ export const getCursorPositionSentinel = (
   column: number
 ): string =>
   `${CURSOR_POSITION_SENTINEL_START}${row};${column}${CURSOR_POSITION_SENTINEL_END}`
+
+export const getCursorHorizontalAbsoluteSentinel = (
+  column: number
+): string =>
+  `${CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_START}${column}${CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_END}`
 
 export const getSaveCursorSentinel = (): string => SAVE_CURSOR_SENTINEL
 
@@ -118,6 +130,10 @@ export const isSaveCursorSentinel = (character: string): boolean =>
 export const isRestoreCursorSentinel = (character: string): boolean =>
   character === RESTORE_CURSOR_SENTINEL
 
+export const isCursorHorizontalAbsoluteSentinel = (
+  character: string
+): boolean => character === CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_START
+
 export const readCursorPositionSentinel = (
   data: string,
   startIndex: number
@@ -143,6 +159,41 @@ export const readCursorPositionSentinel = (
     row: Number(rowText),
     column: Number(columnText),
     length: contentEnd + CURSOR_POSITION_SENTINEL_END.length - startIndex,
+  }
+}
+
+export const readCursorHorizontalAbsoluteSentinel = (
+  data: string,
+  startIndex: number
+): CursorHorizontalAbsoluteSentinel | null => {
+  if (!data.startsWith(CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_START, startIndex)) {
+    return null
+  }
+
+  const contentStart =
+    startIndex + CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_START.length
+
+  const contentEnd = data.indexOf(
+    CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_END,
+    contentStart
+  )
+
+  if (contentEnd === -1) {
+    return null
+  }
+
+  const columnText = data.slice(contentStart, contentEnd)
+
+  if (!/^\d+$/.test(columnText)) {
+    return null
+  }
+
+  return {
+    column: Number(columnText),
+    length:
+      contentEnd +
+      CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_END.length -
+      startIndex,
   }
 }
 
@@ -529,10 +580,7 @@ export class TerminalControlSequenceParser implements TerminalParser {
           if (column !== null) {
             const normalizedColumn = column === 0 ? 1 : column
 
-            const control = `\r${repeatDisplayControl(
-              getCursorRightSentinel(),
-              normalizedColumn - 1
-            )}`
+            const control = getCursorHorizontalAbsoluteSentinel(normalizedColumn)
 
             visible += control
             display += control

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -312,12 +312,14 @@ const parseCsiIntegerParameter = (
 const parseCsiCursorPosition = (
   content: string
 ): { readonly row: number; readonly column: number } | null => {
-  const [rowText = '', columnText = ''] = content.split(';')
+  const parts = content.split(';')
+  const rowText = parts[0] ?? ''
+  const columnText = parts[1] ?? ''
 
   if (
     !/^\d*$/.test(rowText) ||
     !/^\d*$/.test(columnText) ||
-    content.split(';').length > 2
+    parts.length > 2
   ) {
     return null
   }

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -20,6 +20,11 @@ const CURSOR_LEFT_SENTINEL = '\u{F0004}'
 const CURSOR_RIGHT_SENTINEL = '\u{F0005}'
 const SGR_STYLE_SENTINEL_START = '\u{F0006}'
 const SGR_STYLE_SENTINEL_END = '\u{F0007}'
+const CURSOR_UP_SENTINEL = '\u{F0008}'
+const CURSOR_DOWN_SENTINEL = '\u{F0009}'
+const CURSOR_POSITION_SENTINEL_START = '\u{F000A}'
+const CURSOR_POSITION_SENTINEL_END = '\u{F000B}'
+const ERASE_DISPLAY_SENTINELS = ['\u{F000C}', '\u{F000D}']
 
 export interface TerminalControlSequenceOutput {
   readonly visibleText: string
@@ -31,14 +36,33 @@ export interface SgrStyleSentinel {
   readonly length: number
 }
 
+export interface CursorPositionSentinel {
+  readonly row: number
+  readonly column: number
+  readonly length: number
+}
+
 export const getEraseLineSentinel = (mode: 0 | 1 | 2): string =>
   ERASE_LINE_SENTINELS[mode]
+
+export const getEraseDisplaySentinel = (mode: 0 | 1): string =>
+  ERASE_DISPLAY_SENTINELS[mode]
 
 export const getClearScreenSentinel = (): string => CLEAR_SCREEN_SENTINEL
 
 export const getCursorLeftSentinel = (): string => CURSOR_LEFT_SENTINEL
 
 export const getCursorRightSentinel = (): string => CURSOR_RIGHT_SENTINEL
+
+export const getCursorUpSentinel = (): string => CURSOR_UP_SENTINEL
+
+export const getCursorDownSentinel = (): string => CURSOR_DOWN_SENTINEL
+
+export const getCursorPositionSentinel = (
+  row: number,
+  column: number
+): string =>
+  `${CURSOR_POSITION_SENTINEL_START}${row};${column}${CURSOR_POSITION_SENTINEL_END}`
 
 export const getSgrStyleSentinel = (parameters: readonly number[]): string =>
   `${SGR_STYLE_SENTINEL_START}${parameters.join(';')}${SGR_STYLE_SENTINEL_END}`
@@ -55,6 +79,18 @@ export const getEraseLineModeFromSentinel = (
   return index as 0 | 1 | 2
 }
 
+export const getEraseDisplayModeFromSentinel = (
+  character: string
+): 0 | 1 | null => {
+  const index = ERASE_DISPLAY_SENTINELS.indexOf(character)
+
+  if (index === -1) {
+    return null
+  }
+
+  return index as 0 | 1
+}
+
 export const isClearScreenSentinel = (character: string): boolean =>
   character === CLEAR_SCREEN_SENTINEL
 
@@ -63,6 +99,40 @@ export const isCursorLeftSentinel = (character: string): boolean =>
 
 export const isCursorRightSentinel = (character: string): boolean =>
   character === CURSOR_RIGHT_SENTINEL
+
+export const isCursorUpSentinel = (character: string): boolean =>
+  character === CURSOR_UP_SENTINEL
+
+export const isCursorDownSentinel = (character: string): boolean =>
+  character === CURSOR_DOWN_SENTINEL
+
+export const readCursorPositionSentinel = (
+  data: string,
+  startIndex: number
+): CursorPositionSentinel | null => {
+  if (!data.startsWith(CURSOR_POSITION_SENTINEL_START, startIndex)) {
+    return null
+  }
+
+  const contentStart = startIndex + CURSOR_POSITION_SENTINEL_START.length
+  const contentEnd = data.indexOf(CURSOR_POSITION_SENTINEL_END, contentStart)
+
+  if (contentEnd === -1) {
+    return null
+  }
+
+  const [rowText, columnText] = data.slice(contentStart, contentEnd).split(';')
+
+  if (!/^\d+$/.test(rowText) || !/^\d+$/.test(columnText)) {
+    return null
+  }
+
+  return {
+    row: Number(rowText),
+    column: Number(columnText),
+    length: contentEnd + CURSOR_POSITION_SENTINEL_END.length - startIndex,
+  }
+}
 
 const parseSgrParameters = (content: string): readonly number[] | null => {
   if (content.length === 0) {
@@ -239,10 +309,35 @@ const parseCsiIntegerParameter = (
   return Number(firstParameter)
 }
 
+const parseCsiCursorPosition = (
+  content: string
+): { readonly row: number; readonly column: number } | null => {
+  const [rowText = '', columnText = ''] = content.split(';')
+
+  if (
+    !/^\d*$/.test(rowText) ||
+    !/^\d*$/.test(columnText) ||
+    content.split(';').length > 2
+  ) {
+    return null
+  }
+
+  const row = rowText.length === 0 ? 1 : Number(rowText)
+  const column = columnText.length === 0 ? 1 : Number(columnText)
+
+  return {
+    row: row === 0 ? 1 : row,
+    column: column === 0 ? 1 : column,
+  }
+}
+
 const repeatDisplayControl = (control: string, count: number): string =>
   control.repeat(
     Math.min(Math.max(count, 0), MAX_REPEATED_DISPLAY_CONTROL_COUNT)
   )
+
+const normalizeCursorMovementCount = (count: number): number =>
+  count === 0 ? 1 : count
 
 export class TerminalControlSequenceParser implements TerminalParser {
   private readonly handlers = new Set<TerminalParserEventHandler>()
@@ -359,6 +454,13 @@ export class TerminalControlSequenceParser implements TerminalParser {
           )
           const mode = parseCsiIntegerParameter(content, 0)
 
+          if (mode === 0 || mode === 1) {
+            const sentinel = getEraseDisplaySentinel(mode)
+
+            visible += sentinel
+            display += sentinel
+          }
+
           if (mode === 2) {
             const sentinel = getClearScreenSentinel()
 
@@ -375,7 +477,7 @@ export class TerminalControlSequenceParser implements TerminalParser {
           const count = parseCsiIntegerParameter(content, 1)
 
           if (count !== null) {
-            const normalizedCount = count === 0 ? 1 : count
+            const normalizedCount = normalizeCursorMovementCount(count)
 
             const control = repeatDisplayControl(
               getCursorLeftSentinel(),
@@ -395,7 +497,7 @@ export class TerminalControlSequenceParser implements TerminalParser {
           const count = parseCsiIntegerParameter(content, 1)
 
           if (count !== null) {
-            const normalizedCount = count === 0 ? 1 : count
+            const normalizedCount = normalizeCursorMovementCount(count)
 
             const control = repeatDisplayControl(
               getCursorRightSentinel(),
@@ -421,6 +523,96 @@ export class TerminalControlSequenceParser implements TerminalParser {
               getCursorRightSentinel(),
               normalizedColumn - 1
             )}`
+
+            visible += control
+            display += control
+          }
+        }
+
+        if (finalByte === 'A') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const count = parseCsiIntegerParameter(content, 1)
+
+          if (count !== null) {
+            const control = repeatDisplayControl(
+              getCursorUpSentinel(),
+              normalizeCursorMovementCount(count)
+            )
+
+            visible += control
+            display += control
+          }
+        }
+
+        if (finalByte === 'B') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const count = parseCsiIntegerParameter(content, 1)
+
+          if (count !== null) {
+            const control = repeatDisplayControl(
+              getCursorDownSentinel(),
+              normalizeCursorMovementCount(count)
+            )
+
+            visible += control
+            display += control
+          }
+        }
+
+        if (finalByte === 'E') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const count = parseCsiIntegerParameter(content, 1)
+
+          if (count !== null) {
+            const control = `${repeatDisplayControl(
+              getCursorDownSentinel(),
+              normalizeCursorMovementCount(count)
+            )}\r`
+
+            visible += control
+            display += control
+          }
+        }
+
+        if (finalByte === 'F') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const count = parseCsiIntegerParameter(content, 1)
+
+          if (count !== null) {
+            const control = `${repeatDisplayControl(
+              getCursorUpSentinel(),
+              normalizeCursorMovementCount(count)
+            )}\r`
+
+            visible += control
+            display += control
+          }
+        }
+
+        if (finalByte === 'H' || finalByte === 'f') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+          const position = parseCsiCursorPosition(content)
+
+          if (position) {
+            const control = getCursorPositionSentinel(
+              position.row,
+              position.column
+            )
 
             visible += control
             display += control

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -73,9 +73,7 @@ export const getCursorPositionSentinel = (
 ): string =>
   `${CURSOR_POSITION_SENTINEL_START}${row};${column}${CURSOR_POSITION_SENTINEL_END}`
 
-export const getCursorHorizontalAbsoluteSentinel = (
-  column: number
-): string =>
+export const getCursorHorizontalAbsoluteSentinel = (column: number): string =>
   `${CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_START}${column}${CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_END}`
 
 export const getSaveCursorSentinel = (): string => SAVE_CURSOR_SENTINEL
@@ -191,9 +189,7 @@ export const readCursorHorizontalAbsoluteSentinel = (
   return {
     column: Number(columnText),
     length:
-      contentEnd +
-      CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_END.length -
-      startIndex,
+      contentEnd + CURSOR_HORIZONTAL_ABSOLUTE_SENTINEL_END.length - startIndex,
   }
 }
 
@@ -580,7 +576,8 @@ export class TerminalControlSequenceParser implements TerminalParser {
           if (column !== null) {
             const normalizedColumn = column === 0 ? 1 : column
 
-            const control = getCursorHorizontalAbsoluteSentinel(normalizedColumn)
+            const control =
+              getCursorHorizontalAbsoluteSentinel(normalizedColumn)
 
             visible += control
             display += control

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -25,6 +25,8 @@ const CURSOR_DOWN_SENTINEL = '\u{F0009}'
 const CURSOR_POSITION_SENTINEL_START = '\u{F000A}'
 const CURSOR_POSITION_SENTINEL_END = '\u{F000B}'
 const ERASE_DISPLAY_SENTINELS = ['\u{F000C}', '\u{F000D}']
+const SAVE_CURSOR_SENTINEL = '\u{F000E}'
+const RESTORE_CURSOR_SENTINEL = '\u{F000F}'
 
 export interface TerminalControlSequenceOutput {
   readonly visibleText: string
@@ -63,6 +65,10 @@ export const getCursorPositionSentinel = (
   column: number
 ): string =>
   `${CURSOR_POSITION_SENTINEL_START}${row};${column}${CURSOR_POSITION_SENTINEL_END}`
+
+export const getSaveCursorSentinel = (): string => SAVE_CURSOR_SENTINEL
+
+export const getRestoreCursorSentinel = (): string => RESTORE_CURSOR_SENTINEL
 
 export const getSgrStyleSentinel = (parameters: readonly number[]): string =>
   `${SGR_STYLE_SENTINEL_START}${parameters.join(';')}${SGR_STYLE_SENTINEL_END}`
@@ -105,6 +111,12 @@ export const isCursorUpSentinel = (character: string): boolean =>
 
 export const isCursorDownSentinel = (character: string): boolean =>
   character === CURSOR_DOWN_SENTINEL
+
+export const isSaveCursorSentinel = (character: string): boolean =>
+  character === SAVE_CURSOR_SENTINEL
+
+export const isRestoreCursorSentinel = (character: string): boolean =>
+  character === RESTORE_CURSOR_SENTINEL
 
 export const readCursorPositionSentinel = (
   data: string,
@@ -617,6 +629,34 @@ export class TerminalControlSequenceParser implements TerminalParser {
           }
         }
 
+        if (finalByte === 's') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+
+          if (content.length === 0) {
+            const control = getSaveCursorSentinel()
+
+            visible += control
+            display += control
+          }
+        }
+
+        if (finalByte === 'u') {
+          const content = data.slice(
+            sequenceStart + CSI_PREFIX.length,
+            terminator.index
+          )
+
+          if (content.length === 0) {
+            const control = getRestoreCursorSentinel()
+
+            visible += control
+            display += control
+          }
+        }
+
         if (finalByte === 'm' && this.options.preserveSgrStyles) {
           const content = data.slice(
             sequenceStart + CSI_PREFIX.length,
@@ -648,6 +688,22 @@ export class TerminalControlSequenceParser implements TerminalParser {
       }
 
       cursor = terminator.index + terminator.length
+
+      const escFinalByte = data[terminator.index] ?? ''
+
+      if (escFinalByte === '7') {
+        const control = getSaveCursorSentinel()
+
+        visible += control
+        display += control
+      }
+
+      if (escFinalByte === '8') {
+        const control = getRestoreCursorSentinel()
+
+        visible += control
+        display += control
+      }
     }
 
     if (

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -316,11 +316,7 @@ const parseCsiCursorPosition = (
   const rowText = parts[0] ?? ''
   const columnText = parts[1] ?? ''
 
-  if (
-    !/^\d*$/.test(rowText) ||
-    !/^\d*$/.test(columnText) ||
-    parts.length > 2
-  ) {
+  if (!/^\d*$/.test(rowText) || !/^\d*$/.test(columnText) || parts.length > 2) {
     return null
   }
 

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -1,4 +1,4 @@
-// cspell:ignore xhigh
+// cspell:ignore xhigh,ghijkl,ghijk
 import { describe, expect, test } from 'vitest'
 import {
   getClearScreenSentinel,
@@ -93,6 +93,26 @@ describe('TerminalDisplayBuffer', () => {
     buffer.write(`\r${getEraseLineSentinel(0)}gh`)
 
     expect(buffer.readVisibleText()).toBe('abcde\ngh')
+  })
+
+  test('does not insert a second soft-wrap newline after a full-line erase', () => {
+    const buffer = new TerminalDisplayBuffer({ columns: 5 })
+
+    buffer.write('abcdef')
+    buffer.write(getCursorUpSentinel())
+    buffer.write(`\r${getEraseLineSentinel(2)}ghijkl`)
+
+    expect(buffer.readVisibleText()).toBe('ghijk\nl')
+  })
+
+  test('overwrites the existing next row when redrawing a full-width line', () => {
+    const buffer = new TerminalDisplayBuffer({ columns: 5 })
+
+    buffer.write('abcde\nrow2')
+    buffer.write(getCursorPositionSentinel(1, 1))
+    buffer.write('123456')
+
+    expect(buffer.readVisibleText()).toBe('12345\n6ow2')
   })
 
   test('moves the cursor vertically across existing rows', () => {
@@ -194,6 +214,16 @@ describe('TerminalDisplayBuffer', () => {
       '› Summarize recent commits\n› gpt-5.5 xhigh · ~/projects/aws'
     )
     expect(visibleText.match(/gpt-5.5 xhigh/g)).toHaveLength(1)
+  })
+
+  test('erases display content from the start through the cursor', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('hello\nworld')
+    buffer.write(getCursorPositionSentinel(2, 4))
+    buffer.write(getEraseDisplaySentinel(1))
+
+    expect(buffer.readVisibleText()).toBe('d')
   })
 
   test('exposes the current cursor offset for renderer caret placement', () => {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -1,8 +1,13 @@
+// cspell:ignore xhigh
 import { describe, expect, test } from 'vitest'
 import {
   getClearScreenSentinel,
+  getCursorDownSentinel,
   getCursorLeftSentinel,
+  getCursorPositionSentinel,
   getCursorRightSentinel,
+  getCursorUpSentinel,
+  getEraseDisplaySentinel,
   getEraseLineSentinel,
   getSgrStyleSentinel,
 } from './terminalControlParser'
@@ -71,6 +76,124 @@ describe('TerminalDisplayBuffer', () => {
     buffer.write('!')
 
     expect(buffer.readVisibleText()).toBe('Started!')
+  })
+
+  test('soft-wraps printable output at the configured terminal column', () => {
+    const buffer = new TerminalDisplayBuffer({ columns: 5 })
+
+    buffer.write('abcdef')
+
+    expect(buffer.readVisibleText()).toBe('abcde\nf')
+  })
+
+  test('keeps the previous soft-wrapped row when the wrapped tail redraws', () => {
+    const buffer = new TerminalDisplayBuffer({ columns: 5 })
+
+    buffer.write('abcdef')
+    buffer.write(`\r${getEraseLineSentinel(0)}gh`)
+
+    expect(buffer.readVisibleText()).toBe('abcde\ngh')
+  })
+
+  test('moves the cursor vertically across existing rows', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('top one\nmid two\nend row')
+    buffer.write(getCursorUpSentinel().repeat(2))
+    buffer.write('\r')
+    buffer.write('new one')
+    buffer.write(getCursorDownSentinel())
+    buffer.write('\r')
+    buffer.write('new two')
+
+    expect(buffer.readVisibleText()).toBe('new one\nnew two\nend row')
+  })
+
+  test('moves the cursor to absolute screen positions', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write(getCursorPositionSentinel(2, 5))
+    buffer.write('cell')
+    buffer.write(getCursorPositionSentinel(1, 1))
+    buffer.write('top')
+    buffer.write(getCursorPositionSentinel(2, 7))
+    buffer.write('XY')
+
+    expect(buffer.readVisibleText()).toBe('top\n    ceXY')
+  })
+
+  test('rewrites Codex MCP progress rows without duplicating stale fragments', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('Starting MCP servers (1/3): codex_apps\nlinear pending')
+    buffer.write(
+      getCursorUpSentinel() +
+        '\r' +
+        getEraseLineSentinel(2) +
+        'Starting MCP servers (2/3): codex_apps, linear\n' +
+        getEraseLineSentinel(2) +
+        'linear ready'
+    )
+
+    expect(buffer.readVisibleText()).toBe(
+      'Starting MCP servers (2/3): codex_apps, linear\nlinear ready'
+    )
+    expect(buffer.readVisibleText()).not.toContain('(1/3)')
+    expect(buffer.readVisibleText()).not.toContain('pending')
+  })
+
+  test('rewrites Codex startup TUI rows positioned by absolute cursor controls', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write(
+      getClearScreenSentinel() +
+        getCursorPositionSentinel(1, 1) +
+        '>_ OpenAI Codex' +
+        getCursorPositionSentinel(1, 42) +
+        'model: loading' +
+        getCursorPositionSentinel(2, 1) +
+        '~/projects/aws' +
+        getCursorPositionSentinel(3, 1) +
+        'Starting MCP servers (1/3): codex_apps'
+    )
+
+    buffer.write(
+      getCursorPositionSentinel(1, 42) +
+        getEraseLineSentinel(0) +
+        'model: gpt-5.5 default' +
+        getCursorPositionSentinel(3, 1) +
+        getEraseLineSentinel(2) +
+        'Starting MCP servers (2/3): codex_apps, linear'
+    )
+
+    const visibleText = buffer.readVisibleText()
+
+    expect(visibleText).toContain('>_ OpenAI Codex')
+    expect(visibleText).toContain('model: gpt-5.5 default')
+    expect(visibleText).toContain(
+      'Starting MCP servers (2/3): codex_apps, linear'
+    )
+    expect(visibleText).not.toContain('loading')
+    expect(visibleText).not.toContain('(1/3)')
+    expect(visibleText.match(/Starting MCP servers/g)).toHaveLength(1)
+  })
+
+  test('erases stale TUI rows from cursor to end of display', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('› Summarize recent commits\n')
+    buffer.write('› gpt-5.5 xhigh · ~/projects/aws\n')
+    buffer.write('  gpt-5.5 xhigh · ~/projects/aws')
+    buffer.write(getCursorPositionSentinel(2, 1))
+    buffer.write(getEraseDisplaySentinel(0))
+    buffer.write('› gpt-5.5 xhigh · ~/projects/aws')
+
+    const visibleText = buffer.readVisibleText()
+
+    expect(visibleText).toBe(
+      '› Summarize recent commits\n› gpt-5.5 xhigh · ~/projects/aws'
+    )
+    expect(visibleText.match(/gpt-5.5 xhigh/g)).toHaveLength(1)
   })
 
   test('exposes the current cursor offset for renderer caret placement', () => {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -187,6 +187,15 @@ describe('TerminalDisplayBuffer', () => {
     expect(buffer.readVisibleText()).toBe(`a${NERD_FONT_ICON}c!`)
   })
 
+  test('positions absolute cursor at wide glyph boundary when targeting its second cell', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write(`a${'漢'}b`)
+    buffer.write(getCursorPositionSentinel(1, 3))
+
+    expect(buffer.readCursorOffset()).toBe(1)
+  })
+
   test('rewrites Codex MCP progress rows without duplicating stale fragments', () => {
     const buffer = new TerminalDisplayBuffer()
 

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -299,6 +299,20 @@ describe('TerminalDisplayBuffer', () => {
     expect(buffer.readVisibleText()).toBe('d')
   })
 
+  test('rebase saved cursor when erasing display from start through cursor', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('hello\nworld')
+    buffer.write(getCursorPositionSentinel(2, 1))
+    buffer.write(getSaveCursorSentinel())
+    buffer.write(getCursorPositionSentinel(2, 4))
+    buffer.write(getEraseDisplaySentinel(1))
+    buffer.write(getRestoreCursorSentinel())
+    buffer.write('X')
+
+    expect(buffer.readVisibleText()).toBe('X')
+  })
+
   test('exposes the current cursor offset for renderer caret placement', () => {
     const buffer = new TerminalDisplayBuffer()
 

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -18,6 +18,7 @@ import { TerminalDisplayBuffer } from './terminalDisplayBuffer'
 const TRUE_COLOR_PINK = ['rgb', '(243, 139, 168)'].join('')
 const INDEXED_COLOR_RED = ['rgb', '(255, 0, 0)'].join('')
 const INDEXED_COLOR_GRAY = ['rgb', '(238, 238, 238)'].join('')
+const NERD_FONT_ICON = String.fromCodePoint(0xf0954)
 
 describe('TerminalDisplayBuffer', () => {
   test('appends visible text and trims trailing newlines from viewport reads', () => {
@@ -86,6 +87,19 @@ describe('TerminalDisplayBuffer', () => {
     buffer.write('abcdef')
 
     expect(buffer.readVisibleText()).toBe('abcde\nf')
+  })
+
+  test('counts supplementary private-use glyphs as one terminal column', () => {
+    const buffer = new TerminalDisplayBuffer({ columns: 4 })
+
+    buffer.write(`ab${NERD_FONT_ICON}c`)
+
+    expect(buffer.readVisibleText()).toBe(`ab${NERD_FONT_ICON}c`)
+    expect(buffer.readCursorOffset()).toBe(`ab${NERD_FONT_ICON}c`.length)
+
+    buffer.write('d')
+
+    expect(buffer.readVisibleText()).toBe(`ab${NERD_FONT_ICON}c\nd`)
   })
 
   test('keeps the previous soft-wrapped row when the wrapped tail redraws', () => {
@@ -161,6 +175,16 @@ describe('TerminalDisplayBuffer', () => {
     buffer.write('XY')
 
     expect(buffer.readVisibleText()).toBe('top\n    ceXY')
+  })
+
+  test('moves absolute cursor positions by terminal cells, not utf-16 units', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write(`a${NERD_FONT_ICON}c`)
+    buffer.write(getCursorPositionSentinel(1, 4))
+    buffer.write('!')
+
+    expect(buffer.readVisibleText()).toBe(`a${NERD_FONT_ICON}c!`)
   })
 
   test('rewrites Codex MCP progress rows without duplicating stale fragments', () => {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -9,6 +9,8 @@ import {
   getCursorUpSentinel,
   getEraseDisplaySentinel,
   getEraseLineSentinel,
+  getRestoreCursorSentinel,
+  getSaveCursorSentinel,
   getSgrStyleSentinel,
 } from './terminalControlParser'
 import { TerminalDisplayBuffer } from './terminalDisplayBuffer'
@@ -103,6 +105,25 @@ describe('TerminalDisplayBuffer', () => {
     buffer.write(`\r${getEraseLineSentinel(2)}ghijkl`)
 
     expect(buffer.readVisibleText()).toBe('ghijk\nl')
+  })
+
+  test('deletes wrapped input back across soft-wrap boundaries', () => {
+    const buffer = new TerminalDisplayBuffer({ columns: 12 })
+    const prompt = '04:42 ❯ '
+    const typedText = 'hello world '.repeat(2)
+
+    buffer.write(prompt)
+    buffer.write(typedText)
+
+    expect(buffer.readVisibleText().split('\n')).toHaveLength(3)
+
+    typedText.split('').forEach(() => {
+      buffer.write('\b \b')
+    })
+
+    expect(buffer.readCursorOffset()).toBe(prompt.length)
+    expect(buffer.readVisibleText()).not.toContain('hello')
+    expect(buffer.readVisibleText()).not.toContain('world')
   })
 
   test('overwrites the existing next row when redrawing a full-width line', () => {
@@ -214,6 +235,25 @@ describe('TerminalDisplayBuffer', () => {
       '› Summarize recent commits\n› gpt-5.5 xhigh · ~/projects/aws'
     )
     expect(visibleText.match(/gpt-5.5 xhigh/g)).toHaveLength(1)
+  })
+
+  test('restores the editable prompt cursor before right-prompt text', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('❯ ')
+    buffer.write(getSaveCursorSentinel())
+    buffer.write(getCursorPositionSentinel(1, 12))
+    buffer.write('03:52')
+    buffer.write(getRestoreCursorSentinel())
+
+    expect(buffer.readCursorOffset()).toBe('❯ '.length)
+
+    buffer.write('a')
+    buffer.write('\b \b')
+
+    expect(buffer.readCursorOffset()).toBe('❯ '.length)
+    expect(buffer.readText().startsWith('❯  ')).toBe(true)
+    expect(buffer.readVisibleText()).toContain('03:52')
   })
 
   test('erases display content from the start through the cursor', () => {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -6,6 +6,8 @@ import {
   isCursorRightSentinel,
   isCursorDownSentinel,
   isCursorUpSentinel,
+  isRestoreCursorSentinel,
+  isSaveCursorSentinel,
   readCursorPositionSentinel,
   readSgrStyleSentinel,
 } from './terminalControlParser'
@@ -39,6 +41,8 @@ interface DisplayState {
   readonly text: string
   readonly cursor: number
   readonly pendingCr: boolean
+  readonly savedCursor: number | null
+  readonly softWrapOffsets: readonly number[]
   readonly style: TerminalDisplayStyle
   readonly runs: readonly TerminalDisplayRun[]
 }
@@ -47,6 +51,7 @@ interface DisplayCharacterResult {
   readonly text: string
   readonly cursor: number
   readonly runs: readonly TerminalDisplayRun[]
+  readonly softWrapOffsets: readonly number[]
 }
 
 export interface TerminalDisplayBufferOptions {
@@ -58,6 +63,8 @@ const createEmptyState = (): DisplayState => ({
   text: '',
   cursor: 0,
   pendingCr: false,
+  savedCursor: null,
+  softWrapOffsets: [],
   style: {},
   runs: [],
 })
@@ -358,9 +365,63 @@ const normalizeCursorPositionValue = (value: number): number =>
 const normalizeSoftWrapColumns = (columns: number): number =>
   Math.max(MIN_SOFT_WRAP_COLUMNS, Math.floor(columns))
 
+const updateSoftWrapOffsetsForEdit = (
+  softWrapOffsets: readonly number[],
+  startOffset: number,
+  removedLength: number,
+  insertedLength: number
+): readonly number[] => {
+  const endOffset = startOffset + removedLength
+  const delta = insertedLength - removedLength
+
+  return softWrapOffsets.flatMap((offset) => {
+    if (offset >= startOffset && offset < endOffset) {
+      return []
+    }
+
+    if (offset >= endOffset) {
+      return [offset + delta]
+    }
+
+    return [offset]
+  })
+}
+
+const isSoftWrapOffset = (
+  softWrapOffsets: readonly number[],
+  offset: number
+): boolean => softWrapOffsets.includes(offset)
+
+const moveCursorLeft = (
+  text: string,
+  cursor: number,
+  softWrapOffsets: readonly number[]
+): number => {
+  const lineStart = findLineStart(text, cursor)
+
+  if (cursor > lineStart) {
+    return cursor - readPreviousCodePointLength(text, cursor)
+  }
+
+  const previousNewline = cursor - 1
+
+  if (
+    previousNewline <= 0 ||
+    !isSoftWrapOffset(softWrapOffsets, previousNewline)
+  ) {
+    return lineStart
+  }
+
+  return Math.max(
+    findLineStart(text, previousNewline),
+    previousNewline - readPreviousCodePointLength(text, previousNewline)
+  )
+}
+
 const moveCursorToPosition = (
   text: string,
   runs: readonly TerminalDisplayRun[],
+  softWrapOffsets: readonly number[],
   row: number,
   column: number,
   style: TerminalDisplayStyle
@@ -369,6 +430,7 @@ const moveCursorToPosition = (
   const targetColumn = normalizeCursorPositionValue(column)
   let nextText = text
   let nextRuns = runs
+  let nextSoftWrapOffsets = softWrapOffsets
   let cursor = 0
   let currentRow = 1
 
@@ -379,6 +441,12 @@ const moveCursorToPosition = (
       cursor = lineEnd + 1
     } else {
       nextRuns = insertRunText(nextRuns, nextText.length, '\n', style)
+      nextSoftWrapOffsets = updateSoftWrapOffsetsForEdit(
+        nextSoftWrapOffsets,
+        nextText.length,
+        0,
+        1
+      )
       nextText = `${nextText}\n`
       cursor = nextText.length
     }
@@ -393,6 +461,13 @@ const moveCursorToPosition = (
     const padding = ' '.repeat(targetCursor - lineEnd)
 
     nextRuns = insertRunText(nextRuns, lineEnd, padding, style)
+    nextSoftWrapOffsets = updateSoftWrapOffsetsForEdit(
+      nextSoftWrapOffsets,
+      lineEnd,
+      0,
+      padding.length
+    )
+
     nextText = `${nextText.slice(0, lineEnd)}${padding}${nextText.slice(
       lineEnd
     )}`
@@ -402,36 +477,48 @@ const moveCursorToPosition = (
     text: nextText,
     cursor: targetCursor,
     runs: nextRuns,
+    softWrapOffsets: nextSoftWrapOffsets,
   }
 }
 
 const softWrapAtCursor = (
   text: string,
   runs: readonly TerminalDisplayRun[],
+  softWrapOffsets: readonly number[],
   cursor: number,
   style: TerminalDisplayStyle,
   columns: number | null
 ): DisplayCharacterResult => {
   if (columns === null) {
-    return { text, cursor, runs }
+    return { text, cursor, runs, softWrapOffsets }
   }
 
   const lineStart = findLineStart(text, cursor)
 
   if (cursor <= lineStart || cursor - lineStart < columns) {
-    return { text, cursor, runs }
+    return { text, cursor, runs, softWrapOffsets }
   }
 
   if (text[cursor] === '\n') {
-    return { text, cursor: cursor + 1, runs }
+    return { text, cursor: cursor + 1, runs, softWrapOffsets }
   }
 
   const newText = `${text.slice(0, cursor)}\n${text.slice(cursor)}`
+
+  const shiftedSoftWrapOffsets = updateSoftWrapOffsetsForEdit(
+    softWrapOffsets,
+    cursor,
+    0,
+    1
+  )
 
   return {
     text: newText,
     cursor: cursor + 1,
     runs: insertRunText(runs, cursor, '\n', style),
+    softWrapOffsets: [...shiftedSoftWrapOffsets, cursor].sort(
+      (left, right) => left - right
+    ),
   }
 }
 
@@ -643,6 +730,7 @@ const spliceRuns = (
 const writeDisplayCharacter = (
   text: string,
   runs: readonly TerminalDisplayRun[],
+  softWrapOffsets: readonly number[],
   cursor: number,
   character: string,
   style: TerminalDisplayStyle
@@ -658,6 +746,12 @@ const writeDisplayCharacter = (
       text: newText,
       cursor: cursor + character.length,
       runs: replaceRunText(runs, cursor, nextLength, character, style),
+      softWrapOffsets: updateSoftWrapOffsetsForEdit(
+        softWrapOffsets,
+        cursor,
+        nextLength,
+        character.length
+      ),
     }
   }
 
@@ -667,6 +761,12 @@ const writeDisplayCharacter = (
     text: newText,
     cursor: cursor + character.length,
     runs: insertRunText(runs, cursor, character, style),
+    softWrapOffsets: updateSoftWrapOffsetsForEdit(
+      softWrapOffsets,
+      cursor,
+      0,
+      character.length
+    ),
   }
 }
 
@@ -686,6 +786,12 @@ const eraseLineInState = (
       ...state,
       text: newText,
       runs: spliceRuns(state.runs, cursor, lineEnd),
+      softWrapOffsets: updateSoftWrapOffsetsForEdit(
+        state.softWrapOffsets,
+        cursor,
+        lineEnd - cursor,
+        0
+      ),
     }
   }
 
@@ -701,6 +807,12 @@ const eraseLineInState = (
       text: newText,
       cursor: lineStart,
       runs: spliceRuns(state.runs, lineStart, cursor + cursorCodePointLength),
+      softWrapOffsets: updateSoftWrapOffsetsForEdit(
+        state.softWrapOffsets,
+        lineStart,
+        cursor + cursorCodePointLength - lineStart,
+        0
+      ),
     }
   }
 
@@ -711,6 +823,12 @@ const eraseLineInState = (
     text: newText,
     cursor: lineStart,
     runs: spliceRuns(state.runs, lineStart, lineEnd),
+    softWrapOffsets: updateSoftWrapOffsetsForEdit(
+      state.softWrapOffsets,
+      lineStart,
+      lineEnd - lineStart,
+      0
+    ),
   }
 }
 
@@ -726,6 +844,12 @@ const eraseDisplayInState = (
       ...state,
       text: text.slice(0, cursor),
       runs: spliceRuns(state.runs, cursor, text.length),
+      softWrapOffsets: updateSoftWrapOffsetsForEdit(
+        state.softWrapOffsets,
+        cursor,
+        text.length - cursor,
+        0
+      ),
     }
   }
 
@@ -737,6 +861,12 @@ const eraseDisplayInState = (
     text: text.slice(endOffset),
     cursor: 0,
     runs: spliceRuns(state.runs, 0, endOffset),
+    softWrapOffsets: updateSoftWrapOffsetsForEdit(
+      state.softWrapOffsets,
+      0,
+      endOffset,
+      0
+    ),
   }
 }
 
@@ -748,6 +878,8 @@ const applyDisplayData = (
   let text = state.text
   let cursor = Math.min(Math.max(state.cursor, 0), text.length)
   let pendingCr = state.pendingCr
+  let savedCursor = state.savedCursor
+  let softWrapOffsets = state.softWrapOffsets
   let style = state.style
   let runs = state.runs
   let index = 0
@@ -767,6 +899,7 @@ const applyDisplayData = (
       const next = moveCursorToPosition(
         text,
         runs,
+        softWrapOffsets,
         cursorPositionControl.row,
         cursorPositionControl.column,
         style
@@ -774,6 +907,7 @@ const applyDisplayData = (
 
       text = next.text
       runs = next.runs
+      softWrapOffsets = next.softWrapOffsets
       cursor = next.cursor
       pendingCr = false
       index += cursorPositionControl.length
@@ -789,24 +923,28 @@ const applyDisplayData = (
 
     if (eraseDisplayMode !== null) {
       const nextState = eraseDisplayInState(
-        { text, cursor, pendingCr, style, runs },
+        { text, cursor, pendingCr, savedCursor, softWrapOffsets, style, runs },
         eraseDisplayMode
       )
       text = nextState.text
       runs = nextState.runs
       cursor = nextState.cursor
+      savedCursor = nextState.savedCursor
+      softWrapOffsets = nextState.softWrapOffsets
       pendingCr = false
       continue
     }
 
     if (eraseLineMode !== null) {
       const nextState = eraseLineInState(
-        { text, cursor, pendingCr, style, runs },
+        { text, cursor, pendingCr, savedCursor, softWrapOffsets, style, runs },
         eraseLineMode
       )
       text = nextState.text
       runs = nextState.runs
       cursor = nextState.cursor
+      savedCursor = nextState.savedCursor
+      softWrapOffsets = nextState.softWrapOffsets
       pendingCr = false
       continue
     }
@@ -815,15 +953,14 @@ const applyDisplayData = (
       text = ''
       runs = []
       cursor = 0
+      savedCursor = null
+      softWrapOffsets = []
       pendingCr = false
       continue
     }
 
     if (isCursorLeftSentinel(character)) {
-      cursor = Math.max(
-        findLineStart(text, cursor),
-        cursor - readPreviousCodePointLength(text, cursor)
-      )
+      cursor = moveCursorLeft(text, cursor, softWrapOffsets)
       pendingCr = false
       continue
     }
@@ -849,6 +986,18 @@ const applyDisplayData = (
       continue
     }
 
+    if (isSaveCursorSentinel(character)) {
+      savedCursor = cursor
+      pendingCr = false
+      continue
+    }
+
+    if (isRestoreCursorSentinel(character)) {
+      cursor = Math.min(savedCursor ?? cursor, text.length)
+      pendingCr = false
+      continue
+    }
+
     if (character === '\r') {
       cursor = findLineStart(text, cursor)
       pendingCr = true
@@ -870,30 +1019,60 @@ const applyDisplayData = (
 
       text = `${text.slice(0, cursor)}\n${text.slice(cursor)}`
       runs = insertRunText(runs, cursor, '\n', style)
+      softWrapOffsets = updateSoftWrapOffsetsForEdit(
+        softWrapOffsets,
+        cursor,
+        0,
+        1
+      )
       cursor += 1
       pendingCr = false
       continue
     }
 
     if (character === '\b') {
-      cursor = Math.max(findLineStart(text, cursor), cursor - 1)
+      cursor = moveCursorLeft(text, cursor, softWrapOffsets)
       pendingCr = false
       continue
     }
 
-    const wrapped = softWrapAtCursor(text, runs, cursor, style, columns)
+    const wrapped = softWrapAtCursor(
+      text,
+      runs,
+      softWrapOffsets,
+      cursor,
+      style,
+      columns
+    )
     text = wrapped.text
     runs = wrapped.runs
+    softWrapOffsets = wrapped.softWrapOffsets
     cursor = wrapped.cursor
 
-    const next = writeDisplayCharacter(text, runs, cursor, character, style)
+    const next = writeDisplayCharacter(
+      text,
+      runs,
+      softWrapOffsets,
+      cursor,
+      character,
+      style
+    )
     text = next.text
     runs = next.runs
+    softWrapOffsets = next.softWrapOffsets
     cursor = next.cursor
     pendingCr = false
   }
 
-  return { text, cursor, pendingCr, style, runs }
+  return {
+    text,
+    cursor,
+    pendingCr,
+    savedCursor,
+    softWrapOffsets,
+    style,
+    runs,
+  }
 }
 
 const trimScrollbackLines = (
@@ -927,6 +1106,13 @@ const trimScrollbackLines = (
     text: text.slice(removedText.length),
     cursor: Math.max(0, state.cursor - removedText.length),
     pendingCr: state.pendingCr,
+    savedCursor:
+      state.savedCursor === null
+        ? null
+        : Math.max(0, state.savedCursor - removedText.length),
+    softWrapOffsets: state.softWrapOffsets.flatMap((offset) =>
+      offset >= removedText.length ? [offset - removedText.length] : []
+    ),
     style: state.style,
     runs: newRuns,
   }

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -8,6 +8,7 @@ import {
   isCursorUpSentinel,
   isRestoreCursorSentinel,
   isSaveCursorSentinel,
+  readCursorHorizontalAbsoluteSentinel,
   readCursorPositionSentinel,
   readSgrStyleSentinel,
 } from './terminalControlParser'
@@ -441,8 +442,48 @@ const findOffsetForCellColumn = (
   return lineEnd
 }
 
+const findOffsetForChaColumn = (
+  text: string,
+  lineStart: number,
+  lineEnd: number,
+  targetColumn: number
+): number => {
+  let cursor = lineStart
+  let column = 0
+
+  while (cursor < lineEnd) {
+    const width = readTerminalCellWidth(text, cursor)
+    const nextColumn = column + width
+
+    if (nextColumn > targetColumn) {
+      return cursor
+    }
+
+    if (nextColumn === targetColumn) {
+      return cursor + readCodePointLength(text, cursor)
+    }
+
+    column = nextColumn
+    cursor += readCodePointLength(text, cursor)
+  }
+
+  return lineEnd
+}
+
 const readCursorColumn = (text: string, cursor: number): number =>
   readCellWidth(text, findLineStart(text, cursor), cursor)
+
+const readCursorRow = (text: string, cursor: number): number => {
+  let row = 1
+
+  for (let index = 0; index < cursor; index += 1) {
+    if (text[index] === '\n') {
+      row += 1
+    }
+  }
+
+  return row
+}
 
 const moveCursorUp = (text: string, cursor: number): number => {
   const currentLineStart = findLineStart(text, cursor)
@@ -623,13 +664,85 @@ const moveCursorToPosition = (
   }
 }
 
+const moveCursorToHorizontalAbsoluteColumn = (
+  text: string,
+  runs: readonly TerminalDisplayRun[],
+  softWrapOffsets: readonly number[],
+  row: number,
+  column: number,
+  style: TerminalDisplayStyle
+): DisplayCharacterResult => {
+  const targetRow = normalizeCursorPositionValue(row)
+  const targetColumn = normalizeCursorPositionValue(column)
+  let nextText = text
+  let nextRuns = runs
+  let nextSoftWrapOffsets = softWrapOffsets
+  let cursor = 0
+  let currentRow = 1
+
+  while (currentRow < targetRow) {
+    const lineEnd = findLineEnd(nextText, cursor)
+
+    if (lineEnd < nextText.length) {
+      cursor = lineEnd + 1
+    } else {
+      nextRuns = insertRunText(nextRuns, nextText.length, '\n', style)
+      nextSoftWrapOffsets = updateSoftWrapOffsetsForEdit(
+        nextSoftWrapOffsets,
+        nextText.length,
+        0,
+        1
+      )
+      nextText = `${nextText}\n`
+      cursor = nextText.length
+    }
+
+    currentRow += 1
+  }
+
+  const lineEnd = findLineEnd(nextText, cursor)
+  const targetCellColumn = targetColumn - 1
+  const lineCellWidth = readCellWidth(nextText, cursor, lineEnd)
+  let targetCursor = findOffsetForChaColumn(
+    nextText,
+    cursor,
+    lineEnd,
+    targetCellColumn
+  )
+
+  if (targetCellColumn > lineCellWidth) {
+    const padding = ' '.repeat(targetCellColumn - lineCellWidth)
+
+    nextRuns = insertRunText(nextRuns, lineEnd, padding, style)
+    nextSoftWrapOffsets = updateSoftWrapOffsetsForEdit(
+      nextSoftWrapOffsets,
+      lineEnd,
+      0,
+      padding.length
+    )
+
+    nextText = `${nextText.slice(0, lineEnd)}${padding}${nextText.slice(
+      lineEnd
+    )}`
+    targetCursor = lineEnd + padding.length
+  }
+
+  return {
+    text: nextText,
+    cursor: targetCursor,
+    runs: nextRuns,
+    softWrapOffsets: nextSoftWrapOffsets,
+  }
+}
+
 const softWrapAtCursor = (
   text: string,
   runs: readonly TerminalDisplayRun[],
   softWrapOffsets: readonly number[],
   cursor: number,
   style: TerminalDisplayStyle,
-  columns: number | null
+  columns: number | null,
+  character: string
 ): DisplayCharacterResult => {
   if (columns === null) {
     return { text, cursor, runs, softWrapOffsets }
@@ -638,7 +751,10 @@ const softWrapAtCursor = (
   const lineStart = findLineStart(text, cursor)
   const lineCellWidth = readCellWidth(text, lineStart, cursor)
 
-  if (cursor <= lineStart || lineCellWidth < columns) {
+  if (
+    cursor <= lineStart ||
+    lineCellWidth + readTerminalCellWidth(character, 0) <= columns
+  ) {
     return { text, cursor, runs, softWrapOffsets }
   }
 
@@ -1034,6 +1150,30 @@ const applyDisplayData = (
       continue
     }
 
+    const cursorHorizontalAbsoluteControl = readCursorHorizontalAbsoluteSentinel(
+      data,
+      index
+    )
+
+    if (cursorHorizontalAbsoluteControl) {
+      const next = moveCursorToHorizontalAbsoluteColumn(
+        text,
+        runs,
+        softWrapOffsets,
+        readCursorRow(text, cursor),
+        cursorHorizontalAbsoluteControl.column,
+        style
+      )
+
+      text = next.text
+      runs = next.runs
+      softWrapOffsets = next.softWrapOffsets
+      cursor = next.cursor
+      pendingCr = false
+      index += cursorHorizontalAbsoluteControl.length
+      continue
+    }
+
     const characterLength = readCodePointLength(data, index)
     const character = data.slice(index, index + characterLength)
     const eraseDisplayMode = getEraseDisplayModeFromSentinel(character)
@@ -1098,7 +1238,26 @@ const applyDisplayData = (
     }
 
     if (isCursorDownSentinel(character)) {
-      cursor = moveCursorDown(text, cursor)
+      const currentLineEnd = findLineEnd(text, cursor)
+
+      if (currentLineEnd >= text.length) {
+        const next = moveCursorToPosition(
+          text,
+          runs,
+          softWrapOffsets,
+          readCursorRow(text, cursor) + 1,
+          readCursorColumn(text, cursor) + 1,
+          style
+        )
+
+        text = next.text
+        runs = next.runs
+        softWrapOffsets = next.softWrapOffsets
+        cursor = next.cursor
+      } else {
+        cursor = moveCursorDown(text, cursor)
+      }
+
       pendingCr = false
       continue
     }
@@ -1159,7 +1318,8 @@ const applyDisplayData = (
       softWrapOffsets,
       cursor,
       style,
-      columns
+      columns,
+      character
     )
     text = wrapped.text
     runs = wrapped.runs

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -1096,6 +1096,10 @@ const eraseDisplayInState = (
     ...state,
     text: text.slice(endOffset),
     cursor: 0,
+    savedCursor:
+      state.savedCursor === null
+        ? null
+        : Math.max(0, state.savedCursor - endOffset),
     runs: spliceRuns(state.runs, 0, endOffset),
     softWrapOffsets: updateSoftWrapOffsetsForEdit(
       state.softWrapOffsets,

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -428,7 +428,7 @@ const findOffsetForCellColumn = (
     const nextColumn = column + width
 
     if (nextColumn > targetColumn) {
-      return cursor + readCodePointLength(text, cursor)
+      return cursor
     }
 
     if (nextColumn === targetColumn) {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -422,6 +422,10 @@ const softWrapAtCursor = (
     return { text, cursor, runs }
   }
 
+  if (text[cursor] === '\n') {
+    return { text, cursor: cursor + 1, runs }
+  }
+
   const newText = `${text.slice(0, cursor)}\n${text.slice(cursor)}`
 
   return {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -330,6 +330,120 @@ const findLineEnd = (text: string, cursor: number): number => {
   return nextNewline === -1 ? text.length : nextNewline
 }
 
+const readCodePointLength = (text: string, cursor: number): number =>
+  (text.codePointAt(cursor) ?? 0) > 0xffff ? 2 : 1
+
+const readPreviousCodePointLength = (text: string, cursor: number): number => {
+  if (cursor <= 0) {
+    return 0
+  }
+
+  const previous = text.charCodeAt(cursor - 1)
+  const beforePrevious = cursor >= 2 ? text.charCodeAt(cursor - 2) : 0
+
+  if (
+    previous >= 0xdc00 &&
+    previous <= 0xdfff &&
+    beforePrevious >= 0xd800 &&
+    beforePrevious <= 0xdbff
+  ) {
+    return 2
+  }
+
+  return 1
+}
+
+const isCombiningCodePoint = (codePoint: number): boolean =>
+  (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+  (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+  (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+  (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
+  (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+  (codePoint >= 0xfe20 && codePoint <= 0xfe2f)
+
+const isPrivateUseCodePoint = (codePoint: number): boolean =>
+  (codePoint >= 0xe000 && codePoint <= 0xf8ff) ||
+  (codePoint >= 0xf0000 && codePoint <= 0xffffd) ||
+  (codePoint >= 0x100000 && codePoint <= 0x10fffd)
+
+const isWideCodePoint = (codePoint: number): boolean =>
+  (codePoint >= 0x1100 && codePoint <= 0x115f) ||
+  codePoint === 0x2329 ||
+  codePoint === 0x232a ||
+  (codePoint >= 0x2e80 && codePoint <= 0xa4cf) ||
+  (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+  (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+  (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+  (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+  (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+  (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+  (codePoint >= 0x1f300 && codePoint <= 0x1faff)
+
+const readTerminalCellWidth = (text: string, cursor: number): number => {
+  const codePoint = text.codePointAt(cursor)
+
+  if (codePoint === undefined || codePoint === 0 || codePoint === 0x0a) {
+    return 0
+  }
+
+  if (isCombiningCodePoint(codePoint)) {
+    return 0
+  }
+
+  if (isPrivateUseCodePoint(codePoint)) {
+    return 1
+  }
+
+  return isWideCodePoint(codePoint) ? 2 : 1
+}
+
+const readCellWidth = (text: string, start: number, end: number): number => {
+  let width = 0
+  let cursor = start
+
+  while (cursor < end) {
+    width += readTerminalCellWidth(text, cursor)
+    cursor += readCodePointLength(text, cursor)
+  }
+
+  return width
+}
+
+const findOffsetForCellColumn = (
+  text: string,
+  lineStart: number,
+  lineEnd: number,
+  targetColumn: number
+): number => {
+  if (targetColumn <= 0) {
+    return lineStart
+  }
+
+  let cursor = lineStart
+  let column = 0
+
+  while (cursor < lineEnd) {
+    const width = readTerminalCellWidth(text, cursor)
+    const nextColumn = column + width
+
+    if (nextColumn > targetColumn) {
+      return cursor + readCodePointLength(text, cursor)
+    }
+
+    if (nextColumn === targetColumn) {
+      return cursor + readCodePointLength(text, cursor)
+    }
+
+    column = nextColumn
+    cursor += readCodePointLength(text, cursor)
+  }
+
+  return lineEnd
+}
+
+const readCursorColumn = (text: string, cursor: number): number =>
+  readCellWidth(text, findLineStart(text, cursor), cursor)
+
 const moveCursorUp = (text: string, cursor: number): number => {
   const currentLineStart = findLineStart(text, cursor)
 
@@ -337,16 +451,20 @@ const moveCursorUp = (text: string, cursor: number): number => {
     return Math.min(cursor, findLineEnd(text, cursor))
   }
 
-  const column = cursor - currentLineStart
+  const column = readCursorColumn(text, cursor)
   const previousLineEnd = currentLineStart - 1
   const previousLineStart = findLineStart(text, previousLineEnd)
 
-  return Math.min(previousLineStart + column, previousLineEnd)
+  return findOffsetForCellColumn(
+    text,
+    previousLineStart,
+    previousLineEnd,
+    column
+  )
 }
 
 const moveCursorDown = (text: string, cursor: number): number => {
-  const currentLineStart = findLineStart(text, cursor)
-  const column = cursor - currentLineStart
+  const column = readCursorColumn(text, cursor)
   const currentLineEnd = findLineEnd(text, cursor)
 
   if (currentLineEnd >= text.length) {
@@ -356,7 +474,7 @@ const moveCursorDown = (text: string, cursor: number): number => {
   const nextLineStart = currentLineEnd + 1
   const nextLineEnd = findLineEnd(text, nextLineStart)
 
-  return Math.min(nextLineStart + column, nextLineEnd)
+  return findOffsetForCellColumn(text, nextLineStart, nextLineEnd, column)
 }
 
 const normalizeCursorPositionValue = (value: number): number =>
@@ -418,6 +536,22 @@ const moveCursorLeft = (
   )
 }
 
+const moveCursorRight = (text: string, cursor: number): number => {
+  const lineStart = findLineStart(text, cursor)
+  const lineEnd = findLineEnd(text, cursor)
+
+  if (cursor >= lineEnd) {
+    return lineEnd
+  }
+
+  return findOffsetForCellColumn(
+    text,
+    lineStart,
+    lineEnd,
+    readCursorColumn(text, cursor) + 1
+  )
+}
+
 const moveCursorToPosition = (
   text: string,
   runs: readonly TerminalDisplayRun[],
@@ -455,10 +589,17 @@ const moveCursorToPosition = (
   }
 
   const lineEnd = findLineEnd(nextText, cursor)
-  const targetCursor = cursor + targetColumn - 1
+  const targetCellColumn = targetColumn - 1
+  const lineCellWidth = readCellWidth(nextText, cursor, lineEnd)
+  let targetCursor = findOffsetForCellColumn(
+    nextText,
+    cursor,
+    lineEnd,
+    targetCellColumn
+  )
 
-  if (targetCursor > lineEnd) {
-    const padding = ' '.repeat(targetCursor - lineEnd)
+  if (targetCellColumn > lineCellWidth) {
+    const padding = ' '.repeat(targetCellColumn - lineCellWidth)
 
     nextRuns = insertRunText(nextRuns, lineEnd, padding, style)
     nextSoftWrapOffsets = updateSoftWrapOffsetsForEdit(
@@ -471,6 +612,7 @@ const moveCursorToPosition = (
     nextText = `${nextText.slice(0, lineEnd)}${padding}${nextText.slice(
       lineEnd
     )}`
+    targetCursor = lineEnd + padding.length
   }
 
   return {
@@ -494,8 +636,9 @@ const softWrapAtCursor = (
   }
 
   const lineStart = findLineStart(text, cursor)
+  const lineCellWidth = readCellWidth(text, lineStart, cursor)
 
-  if (cursor <= lineStart || cursor - lineStart < columns) {
+  if (cursor <= lineStart || lineCellWidth < columns) {
     return { text, cursor, runs, softWrapOffsets }
   }
 
@@ -520,29 +663,6 @@ const softWrapAtCursor = (
       (left, right) => left - right
     ),
   }
-}
-
-const readCodePointLength = (text: string, cursor: number): number =>
-  (text.codePointAt(cursor) ?? 0) > 0xffff ? 2 : 1
-
-const readPreviousCodePointLength = (text: string, cursor: number): number => {
-  if (cursor <= 0) {
-    return 0
-  }
-
-  const previous = text.charCodeAt(cursor - 1)
-  const beforePrevious = cursor >= 2 ? text.charCodeAt(cursor - 2) : 0
-
-  if (
-    previous >= 0xdc00 &&
-    previous <= 0xdfff &&
-    beforePrevious >= 0xd800 &&
-    beforePrevious <= 0xdbff
-  ) {
-    return 2
-  }
-
-  return 1
 }
 
 const findRunAtOffset = (
@@ -966,10 +1086,7 @@ const applyDisplayData = (
     }
 
     if (isCursorRightSentinel(character)) {
-      cursor = Math.min(
-        findLineEnd(text, cursor),
-        cursor + readCodePointLength(text, cursor)
-      )
+      cursor = moveCursorRight(text, cursor)
       pendingCr = false
       continue
     }

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -1150,10 +1150,8 @@ const applyDisplayData = (
       continue
     }
 
-    const cursorHorizontalAbsoluteControl = readCursorHorizontalAbsoluteSentinel(
-      data,
-      index
-    )
+    const cursorHorizontalAbsoluteControl =
+      readCursorHorizontalAbsoluteSentinel(data, index)
 
     if (cursorHorizontalAbsoluteControl) {
       const next = moveCursorToHorizontalAbsoluteColumn(

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -41,6 +41,7 @@ export interface TerminalDisplayRun {
 interface DisplayState {
   readonly text: string
   readonly cursor: number
+  readonly cursorRow: number
   readonly pendingCr: boolean
   readonly savedCursor: number | null
   readonly softWrapOffsets: readonly number[]
@@ -55,6 +56,10 @@ interface DisplayCharacterResult {
   readonly softWrapOffsets: readonly number[]
 }
 
+interface CursorPositionResult extends DisplayCharacterResult {
+  readonly cursorRow: number
+}
+
 export interface TerminalDisplayBufferOptions {
   readonly columns?: number
   readonly maxScrollbackLines?: number
@@ -63,6 +68,7 @@ export interface TerminalDisplayBufferOptions {
 const createEmptyState = (): DisplayState => ({
   text: '',
   cursor: 0,
+  cursorRow: 1,
   pendingCr: false,
   savedCursor: null,
   softWrapOffsets: [],
@@ -551,15 +557,23 @@ const isSoftWrapOffset = (
   offset: number
 ): boolean => softWrapOffsets.includes(offset)
 
+interface CursorLeftResult {
+  readonly cursor: number
+  readonly rowDelta: number
+}
+
 const moveCursorLeft = (
   text: string,
   cursor: number,
   softWrapOffsets: readonly number[]
-): number => {
+): CursorLeftResult => {
   const lineStart = findLineStart(text, cursor)
 
   if (cursor > lineStart) {
-    return cursor - readPreviousCodePointLength(text, cursor)
+    return {
+      cursor: cursor - readPreviousCodePointLength(text, cursor),
+      rowDelta: 0,
+    }
   }
 
   const previousNewline = cursor - 1
@@ -568,13 +582,16 @@ const moveCursorLeft = (
     previousNewline <= 0 ||
     !isSoftWrapOffset(softWrapOffsets, previousNewline)
   ) {
-    return lineStart
+    return { cursor: lineStart, rowDelta: 0 }
   }
 
-  return Math.max(
-    findLineStart(text, previousNewline),
-    previousNewline - readPreviousCodePointLength(text, previousNewline)
-  )
+  return {
+    cursor: Math.max(
+      findLineStart(text, previousNewline),
+      previousNewline - readPreviousCodePointLength(text, previousNewline)
+    ),
+    rowDelta: -1,
+  }
 }
 
 const moveCursorRight = (text: string, cursor: number): number => {
@@ -600,7 +617,7 @@ const moveCursorToPosition = (
   row: number,
   column: number,
   style: TerminalDisplayStyle
-): DisplayCharacterResult => {
+): CursorPositionResult => {
   const targetRow = normalizeCursorPositionValue(row)
   const targetColumn = normalizeCursorPositionValue(column)
   let nextText = text
@@ -659,6 +676,7 @@ const moveCursorToPosition = (
   return {
     text: nextText,
     cursor: targetCursor,
+    cursorRow: currentRow,
     runs: nextRuns,
     softWrapOffsets: nextSoftWrapOffsets,
   }
@@ -671,7 +689,7 @@ const moveCursorToHorizontalAbsoluteColumn = (
   row: number,
   column: number,
   style: TerminalDisplayStyle
-): DisplayCharacterResult => {
+): CursorPositionResult => {
   const targetRow = normalizeCursorPositionValue(row)
   const targetColumn = normalizeCursorPositionValue(column)
   let nextText = text
@@ -730,6 +748,7 @@ const moveCursorToHorizontalAbsoluteColumn = (
   return {
     text: nextText,
     cursor: targetCursor,
+    cursorRow: currentRow,
     runs: nextRuns,
     softWrapOffsets: nextSoftWrapOffsets,
   }
@@ -1021,6 +1040,7 @@ const eraseLineInState = (
     return {
       ...state,
       text: newText,
+      cursorRow: readCursorRow(newText, cursor),
       runs: spliceRuns(state.runs, cursor, lineEnd),
       softWrapOffsets: updateSoftWrapOffsetsForEdit(
         state.softWrapOffsets,
@@ -1042,6 +1062,7 @@ const eraseLineInState = (
       ...state,
       text: newText,
       cursor: lineStart,
+      cursorRow: readCursorRow(newText, lineStart),
       runs: spliceRuns(state.runs, lineStart, cursor + cursorCodePointLength),
       softWrapOffsets: updateSoftWrapOffsetsForEdit(
         state.softWrapOffsets,
@@ -1058,6 +1079,7 @@ const eraseLineInState = (
     ...state,
     text: newText,
     cursor: lineStart,
+    cursorRow: readCursorRow(newText, lineStart),
     runs: spliceRuns(state.runs, lineStart, lineEnd),
     softWrapOffsets: updateSoftWrapOffsetsForEdit(
       state.softWrapOffsets,
@@ -1079,6 +1101,7 @@ const eraseDisplayInState = (
     return {
       ...state,
       text: text.slice(0, cursor),
+      cursorRow: state.cursorRow,
       runs: spliceRuns(state.runs, cursor, text.length),
       softWrapOffsets: updateSoftWrapOffsetsForEdit(
         state.softWrapOffsets,
@@ -1096,6 +1119,7 @@ const eraseDisplayInState = (
     ...state,
     text: text.slice(endOffset),
     cursor: 0,
+    cursorRow: 1,
     savedCursor:
       state.savedCursor === null
         ? null
@@ -1117,6 +1141,7 @@ const applyDisplayData = (
 ): DisplayState => {
   let text = state.text
   let cursor = Math.min(Math.max(state.cursor, 0), text.length)
+  let cursorRow = state.cursorRow
   let pendingCr = state.pendingCr
   let savedCursor = state.savedCursor
   let softWrapOffsets = state.softWrapOffsets
@@ -1149,6 +1174,7 @@ const applyDisplayData = (
       runs = next.runs
       softWrapOffsets = next.softWrapOffsets
       cursor = next.cursor
+      cursorRow = next.cursorRow
       pendingCr = false
       index += cursorPositionControl.length
       continue
@@ -1162,7 +1188,7 @@ const applyDisplayData = (
         text,
         runs,
         softWrapOffsets,
-        readCursorRow(text, cursor),
+        cursorRow,
         cursorHorizontalAbsoluteControl.column,
         style
       )
@@ -1171,6 +1197,7 @@ const applyDisplayData = (
       runs = next.runs
       softWrapOffsets = next.softWrapOffsets
       cursor = next.cursor
+      cursorRow = next.cursorRow
       pendingCr = false
       index += cursorHorizontalAbsoluteControl.length
       continue
@@ -1185,12 +1212,22 @@ const applyDisplayData = (
 
     if (eraseDisplayMode !== null) {
       const nextState = eraseDisplayInState(
-        { text, cursor, pendingCr, savedCursor, softWrapOffsets, style, runs },
+        {
+          text,
+          cursor,
+          cursorRow,
+          pendingCr,
+          savedCursor,
+          softWrapOffsets,
+          style,
+          runs,
+        },
         eraseDisplayMode
       )
       text = nextState.text
       runs = nextState.runs
       cursor = nextState.cursor
+      cursorRow = nextState.cursorRow
       savedCursor = nextState.savedCursor
       softWrapOffsets = nextState.softWrapOffsets
       pendingCr = false
@@ -1199,12 +1236,22 @@ const applyDisplayData = (
 
     if (eraseLineMode !== null) {
       const nextState = eraseLineInState(
-        { text, cursor, pendingCr, savedCursor, softWrapOffsets, style, runs },
+        {
+          text,
+          cursor,
+          cursorRow,
+          pendingCr,
+          savedCursor,
+          softWrapOffsets,
+          style,
+          runs,
+        },
         eraseLineMode
       )
       text = nextState.text
       runs = nextState.runs
       cursor = nextState.cursor
+      cursorRow = nextState.cursorRow
       savedCursor = nextState.savedCursor
       softWrapOffsets = nextState.softWrapOffsets
       pendingCr = false
@@ -1215,6 +1262,7 @@ const applyDisplayData = (
       text = ''
       runs = []
       cursor = 0
+      cursorRow = 1
       savedCursor = null
       softWrapOffsets = []
       pendingCr = false
@@ -1222,7 +1270,9 @@ const applyDisplayData = (
     }
 
     if (isCursorLeftSentinel(character)) {
-      cursor = moveCursorLeft(text, cursor, softWrapOffsets)
+      const left = moveCursorLeft(text, cursor, softWrapOffsets)
+      cursor = left.cursor
+      cursorRow += left.rowDelta
       pendingCr = false
       continue
     }
@@ -1235,6 +1285,7 @@ const applyDisplayData = (
 
     if (isCursorUpSentinel(character)) {
       cursor = moveCursorUp(text, cursor)
+      cursorRow = readCursorRow(text, cursor)
       pendingCr = false
       continue
     }
@@ -1247,7 +1298,7 @@ const applyDisplayData = (
           text,
           runs,
           softWrapOffsets,
-          readCursorRow(text, cursor) + 1,
+          cursorRow + 1,
           readCursorColumn(text, cursor) + 1,
           style
         )
@@ -1256,8 +1307,10 @@ const applyDisplayData = (
         runs = next.runs
         softWrapOffsets = next.softWrapOffsets
         cursor = next.cursor
+        cursorRow = next.cursorRow
       } else {
         cursor = moveCursorDown(text, cursor)
+        cursorRow += 1
       }
 
       pendingCr = false
@@ -1272,6 +1325,7 @@ const applyDisplayData = (
 
     if (isRestoreCursorSentinel(character)) {
       cursor = Math.min(savedCursor ?? cursor, text.length)
+      cursorRow = readCursorRow(text, cursor)
       pendingCr = false
       continue
     }
@@ -1291,6 +1345,7 @@ const applyDisplayData = (
 
       if (lineEnd < text.length) {
         cursor = lineEnd + 1
+        cursorRow += 1
         pendingCr = false
         continue
       }
@@ -1304,12 +1359,15 @@ const applyDisplayData = (
         1
       )
       cursor += 1
+      cursorRow += 1
       pendingCr = false
       continue
     }
 
     if (character === '\b') {
-      cursor = moveCursorLeft(text, cursor, softWrapOffsets)
+      const left = moveCursorLeft(text, cursor, softWrapOffsets)
+      cursor = left.cursor
+      cursorRow += left.rowDelta
       pendingCr = false
       continue
     }
@@ -1323,6 +1381,11 @@ const applyDisplayData = (
       columns,
       character
     )
+
+    if (wrapped.cursor !== cursor) {
+      cursorRow += 1
+    }
+
     text = wrapped.text
     runs = wrapped.runs
     softWrapOffsets = wrapped.softWrapOffsets
@@ -1346,6 +1409,7 @@ const applyDisplayData = (
   return {
     text,
     cursor,
+    cursorRow,
     pendingCr,
     savedCursor,
     softWrapOffsets,
@@ -1381,9 +1445,13 @@ const trimScrollbackLines = (
     }
   }
 
+  const newText = text.slice(removedText.length)
+  const newCursor = Math.max(0, state.cursor - removedText.length)
+
   return {
-    text: text.slice(removedText.length),
-    cursor: Math.max(0, state.cursor - removedText.length),
+    text: newText,
+    cursor: newCursor,
+    cursorRow: readCursorRow(newText, newCursor),
     pendingCr: state.pendingCr,
     savedCursor:
       state.savedCursor === null

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -1,12 +1,18 @@
 import {
+  getEraseDisplayModeFromSentinel,
   getEraseLineModeFromSentinel,
   isClearScreenSentinel,
   isCursorLeftSentinel,
   isCursorRightSentinel,
+  isCursorDownSentinel,
+  isCursorUpSentinel,
+  readCursorPositionSentinel,
   readSgrStyleSentinel,
 } from './terminalControlParser'
 
 const DEFAULT_MAX_SCROLLBACK_LINES = 10_000
+const MIN_SOFT_WRAP_COLUMNS = 2
+const MAX_CURSOR_POSITION_VALUE = 4_096
 const CSS_RGB_FUNCTION = 'rgb'
 const XTERM_COLOR_CUBE_FIRST_INDEX = 16
 const XTERM_COLOR_CUBE_LAST_INDEX = 231
@@ -44,6 +50,7 @@ interface DisplayCharacterResult {
 }
 
 export interface TerminalDisplayBufferOptions {
+  readonly columns?: number
   readonly maxScrollbackLines?: number
 }
 
@@ -314,6 +321,114 @@ const findLineEnd = (text: string, cursor: number): number => {
   const nextNewline = text.indexOf('\n', cursor)
 
   return nextNewline === -1 ? text.length : nextNewline
+}
+
+const moveCursorUp = (text: string, cursor: number): number => {
+  const currentLineStart = findLineStart(text, cursor)
+
+  if (currentLineStart === 0) {
+    return Math.min(cursor, findLineEnd(text, cursor))
+  }
+
+  const column = cursor - currentLineStart
+  const previousLineEnd = currentLineStart - 1
+  const previousLineStart = findLineStart(text, previousLineEnd)
+
+  return Math.min(previousLineStart + column, previousLineEnd)
+}
+
+const moveCursorDown = (text: string, cursor: number): number => {
+  const currentLineStart = findLineStart(text, cursor)
+  const column = cursor - currentLineStart
+  const currentLineEnd = findLineEnd(text, cursor)
+
+  if (currentLineEnd >= text.length) {
+    return Math.min(cursor, currentLineEnd)
+  }
+
+  const nextLineStart = currentLineEnd + 1
+  const nextLineEnd = findLineEnd(text, nextLineStart)
+
+  return Math.min(nextLineStart + column, nextLineEnd)
+}
+
+const normalizeCursorPositionValue = (value: number): number =>
+  Math.min(Math.max(value, 1), MAX_CURSOR_POSITION_VALUE)
+
+const normalizeSoftWrapColumns = (columns: number): number =>
+  Math.max(MIN_SOFT_WRAP_COLUMNS, Math.floor(columns))
+
+const moveCursorToPosition = (
+  text: string,
+  runs: readonly TerminalDisplayRun[],
+  row: number,
+  column: number,
+  style: TerminalDisplayStyle
+): DisplayCharacterResult => {
+  const targetRow = normalizeCursorPositionValue(row)
+  const targetColumn = normalizeCursorPositionValue(column)
+  let nextText = text
+  let nextRuns = runs
+  let cursor = 0
+  let currentRow = 1
+
+  while (currentRow < targetRow) {
+    const lineEnd = findLineEnd(nextText, cursor)
+
+    if (lineEnd < nextText.length) {
+      cursor = lineEnd + 1
+    } else {
+      nextRuns = insertRunText(nextRuns, nextText.length, '\n', style)
+      nextText = `${nextText}\n`
+      cursor = nextText.length
+    }
+
+    currentRow += 1
+  }
+
+  const lineEnd = findLineEnd(nextText, cursor)
+  const targetCursor = cursor + targetColumn - 1
+
+  if (targetCursor > lineEnd) {
+    const padding = ' '.repeat(targetCursor - lineEnd)
+
+    nextRuns = insertRunText(nextRuns, lineEnd, padding, style)
+    nextText = `${nextText.slice(0, lineEnd)}${padding}${nextText.slice(
+      lineEnd
+    )}`
+  }
+
+  return {
+    text: nextText,
+    cursor: targetCursor,
+    runs: nextRuns,
+  }
+}
+
+const softWrapAtCursor = (
+  text: string,
+  runs: readonly TerminalDisplayRun[],
+  cursor: number,
+  style: TerminalDisplayStyle,
+  columns: number | null
+): DisplayCharacterResult => {
+  if (columns === null) {
+    return { text, cursor, runs }
+  }
+
+  const lineStart = findLineStart(text, cursor)
+
+  if (cursor <= lineStart || cursor - lineStart < columns) {
+    return { text, cursor, runs }
+  }
+
+  const newText = `${text.slice(0, cursor)}\n${text.slice(cursor)}`
+
+  return {
+    text: newText,
+    cursor: cursor + 1,
+    runs: insertRunText(runs, cursor, '\n', style),
+  }
 }
 
 const readCodePointLength = (text: string, cursor: number): number =>
@@ -595,7 +710,37 @@ const eraseLineInState = (
   }
 }
 
-const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
+const eraseDisplayInState = (
+  state: DisplayState,
+  mode: 0 | 1
+): DisplayState => {
+  const text = state.text
+  const cursor = state.cursor
+
+  if (mode === 0) {
+    return {
+      ...state,
+      text: text.slice(0, cursor),
+      runs: spliceRuns(state.runs, cursor, text.length),
+    }
+  }
+
+  const cursorCodePointLength = readCodePointLength(text, cursor)
+  const endOffset = Math.min(text.length, cursor + cursorCodePointLength)
+
+  return {
+    ...state,
+    text: text.slice(endOffset),
+    cursor: 0,
+    runs: spliceRuns(state.runs, 0, endOffset),
+  }
+}
+
+const applyDisplayData = (
+  state: DisplayState,
+  data: string,
+  columns: number | null
+): DisplayState => {
   let text = state.text
   let cursor = Math.min(Math.max(state.cursor, 0), text.length)
   let pendingCr = state.pendingCr
@@ -612,11 +757,43 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
       continue
     }
 
+    const cursorPositionControl = readCursorPositionSentinel(data, index)
+
+    if (cursorPositionControl) {
+      const next = moveCursorToPosition(
+        text,
+        runs,
+        cursorPositionControl.row,
+        cursorPositionControl.column,
+        style
+      )
+
+      text = next.text
+      runs = next.runs
+      cursor = next.cursor
+      pendingCr = false
+      index += cursorPositionControl.length
+      continue
+    }
+
     const characterLength = readCodePointLength(data, index)
     const character = data.slice(index, index + characterLength)
+    const eraseDisplayMode = getEraseDisplayModeFromSentinel(character)
     const eraseLineMode = getEraseLineModeFromSentinel(character)
 
     index += characterLength
+
+    if (eraseDisplayMode !== null) {
+      const nextState = eraseDisplayInState(
+        { text, cursor, pendingCr, style, runs },
+        eraseDisplayMode
+      )
+      text = nextState.text
+      runs = nextState.runs
+      cursor = nextState.cursor
+      pendingCr = false
+      continue
+    }
 
     if (eraseLineMode !== null) {
       const nextState = eraseLineInState(
@@ -656,6 +833,18 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
       continue
     }
 
+    if (isCursorUpSentinel(character)) {
+      cursor = moveCursorUp(text, cursor)
+      pendingCr = false
+      continue
+    }
+
+    if (isCursorDownSentinel(character)) {
+      cursor = moveCursorDown(text, cursor)
+      pendingCr = false
+      continue
+    }
+
     if (character === '\r') {
       cursor = findLineStart(text, cursor)
       pendingCr = true
@@ -665,6 +854,14 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
     if (character === '\n') {
       if (pendingCr) {
         cursor = findLineEnd(text, cursor)
+      }
+
+      const lineEnd = findLineEnd(text, cursor)
+
+      if (lineEnd < text.length) {
+        cursor = lineEnd + 1
+        pendingCr = false
+        continue
       }
 
       text = `${text.slice(0, cursor)}\n${text.slice(cursor)}`
@@ -679,6 +876,11 @@ const applyDisplayData = (state: DisplayState, data: string): DisplayState => {
       pendingCr = false
       continue
     }
+
+    const wrapped = softWrapAtCursor(text, runs, cursor, style, columns)
+    text = wrapped.text
+    runs = wrapped.runs
+    cursor = wrapped.cursor
 
     const next = writeDisplayCharacter(text, runs, cursor, character, style)
     text = next.text
@@ -728,11 +930,21 @@ const trimScrollbackLines = (
 
 export class TerminalDisplayBuffer {
   private state = createEmptyState()
+  private columns: number | null
   private readonly maxScrollbackLines: number
 
   constructor(options: TerminalDisplayBufferOptions = {}) {
+    this.columns =
+      options.columns === undefined
+        ? null
+        : normalizeSoftWrapColumns(options.columns)
+
     this.maxScrollbackLines =
       options.maxScrollbackLines ?? DEFAULT_MAX_SCROLLBACK_LINES
+  }
+
+  setColumns(columns: number): void {
+    this.columns = normalizeSoftWrapColumns(columns)
   }
 
   clear(): void {
@@ -745,7 +957,7 @@ export class TerminalDisplayBuffer {
     }
 
     this.state = trimScrollbackLines(
-      applyDisplayData(this.state, data),
+      applyDisplayData(this.state, data, this.columns),
       this.maxScrollbackLines
     )
   }

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -123,7 +123,9 @@ export class TerminalTextSurface implements TerminalSurface {
   private readonly resizeHandlers = new Set<(size: TerminalSize) => void>()
   private readonly selectionHandlers = new Set<() => void>()
   private readonly keyHandlers = new Set<TerminalKeyEventHandler>()
-  private readonly outputBuffer = new TerminalDisplayBuffer()
+  private readonly outputBuffer = new TerminalDisplayBuffer({
+    columns: DEFAULT_COLS,
+  })
   private container: HTMLElement | null = null
   private colsValue = DEFAULT_COLS
   private rowsValue = DEFAULT_ROWS
@@ -150,8 +152,8 @@ export class TerminalTextSurface implements TerminalSurface {
       margin: '0',
       minHeight: '100%',
       padding: '8px',
-      whiteSpace: 'pre-wrap',
-      wordBreak: 'break-word',
+      whiteSpace: 'pre',
+      wordBreak: 'normal',
     })
 
     Object.assign(this.input.style, {
@@ -390,6 +392,7 @@ export class TerminalTextSurface implements TerminalSurface {
 
     this.colsValue = nextCols
     this.rowsValue = nextRows
+    this.outputBuffer.setColumns(nextCols)
     this.notifyResize()
   }
 
@@ -455,14 +458,18 @@ export class TerminalTextSurface implements TerminalSurface {
     cursor.setAttribute('aria-hidden', 'true')
 
     Object.assign(cursor.style, {
-      borderLeft: '2px solid var(--terminal-cursor-color)',
+      animationDuration: '1.1s',
+      animationIterationCount: 'infinite',
+      animationName: 'vfTerminalCursorBlink',
+      animationTimingFunction: 'steps(1, end)',
+      backgroundColor: 'var(--terminal-cursor-color)',
       display: 'inline-block',
       height: '1em',
-      marginRight: '-2px',
+      marginRight: '-0.62em',
       pointerEvents: 'none',
       userSelect: 'none',
       verticalAlign: '-0.12em',
-      width: '0',
+      width: '0.62em',
     })
 
     return cursor

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -163,12 +163,11 @@ export class TerminalTextSurface implements TerminalSurface {
       margin: '0',
       maxWidth: '100%',
       minHeight: '100%',
-      overflowWrap: 'anywhere',
       overflowX: 'hidden',
       padding: '8px',
-      whiteSpace: 'pre-wrap',
+      whiteSpace: 'normal',
       width: '100%',
-      wordBreak: 'break-word',
+      wordBreak: 'normal',
     })
 
     Object.assign(this.input.style, {
@@ -579,7 +578,7 @@ export class TerminalTextSurface implements TerminalSurface {
   }
 
   private appendRunFragment(
-    fragments: Node[],
+    parent: HTMLElement,
     text: string,
     style: TerminalDisplayStyle
   ): void {
@@ -587,69 +586,114 @@ export class TerminalTextSurface implements TerminalSurface {
       return
     }
 
-    fragments.push(this.createTextNode(text, style))
+    parent.append(this.createTextNode(text, style))
+  }
+
+  private createOutputRow(): HTMLElement {
+    const row = document.createElement('span')
+    row.dataset.terminalRow = 'true'
+
+    Object.assign(row.style, {
+      display: 'block',
+      maxWidth: '100%',
+      minHeight: `${APPROXIMATE_LINE_HEIGHT}px`,
+      overflowX: 'hidden',
+      whiteSpace: 'pre',
+      width: '100%',
+    })
+
+    return row
   }
 
   private createOutputFragments(
     runs: readonly TerminalDisplayRun[],
     cursorOffset: number
   ): Node[] {
-    const fragments: Node[] = []
+    const rows: HTMLElement[] = [this.createOutputRow()]
     let offset = 0
-    let didRenderCursor = false
+    const cursorState = { didRender: false }
+    let currentRow = rows[0]
 
-    for (const run of runs) {
-      const runStart = offset
-      const runEnd = runStart + run.text.length
+    const appendCursor = (): void => {
+      currentRow.append(this.createCursorElement())
+      cursorState.didRender = true
+    }
+
+    const appendSegment = (text: string, style: TerminalDisplayStyle): void => {
+      if (text.length === 0) {
+        return
+      }
+
+      const segmentStart = offset
+      const segmentEnd = segmentStart + text.length
 
       if (
-        !didRenderCursor &&
-        cursorOffset >= runStart &&
-        cursorOffset <= runEnd
+        !cursorState.didRender &&
+        cursorOffset >= segmentStart &&
+        cursorOffset <= segmentEnd
       ) {
-        const splitOffset = cursorOffset - runStart
+        const splitOffset = cursorOffset - segmentStart
 
         if (
           splitOffset > 0 &&
-          splitOffset < run.text.length &&
-          this.hasStyle(run.style)
+          splitOffset < text.length &&
+          this.hasStyle(style)
         ) {
           const runElement = document.createElement('span')
           runElement.dataset.terminalStyleRun = 'true'
-          this.applyStyleToElement(runElement, run.style)
+          this.applyStyleToElement(runElement, style)
           runElement.append(
-            document.createTextNode(run.text.slice(0, splitOffset)),
+            document.createTextNode(text.slice(0, splitOffset)),
             this.createCursorElement(),
-            document.createTextNode(run.text.slice(splitOffset))
+            document.createTextNode(text.slice(splitOffset))
           )
-          fragments.push(runElement)
-          didRenderCursor = true
+          currentRow.append(runElement)
+          cursorState.didRender = true
         } else {
-          this.appendRunFragment(
-            fragments,
-            run.text.slice(0, splitOffset),
-            run.style
-          )
-          fragments.push(this.createCursorElement())
-          didRenderCursor = true
-          this.appendRunFragment(
-            fragments,
-            run.text.slice(splitOffset),
-            run.style
-          )
+          this.appendRunFragment(currentRow, text.slice(0, splitOffset), style)
+          appendCursor()
+          this.appendRunFragment(currentRow, text.slice(splitOffset), style)
         }
       } else {
-        this.appendRunFragment(fragments, run.text, run.style)
+        this.appendRunFragment(currentRow, text, style)
       }
 
-      offset = runEnd
+      offset = segmentEnd
     }
 
-    if (!didRenderCursor) {
-      fragments.push(this.createCursorElement())
+    const appendNewline = (): void => {
+      if (!cursorState.didRender && cursorOffset === offset) {
+        appendCursor()
+      }
+
+      offset += 1
+      currentRow = this.createOutputRow()
+      rows.push(currentRow)
     }
 
-    return fragments
+    for (const run of runs) {
+      let segmentStart = 0
+
+      while (segmentStart < run.text.length) {
+        const newlineIndex = run.text.indexOf('\n', segmentStart)
+
+        if (newlineIndex === -1) {
+          appendSegment(run.text.slice(segmentStart), run.style)
+          segmentStart = run.text.length
+          continue
+        }
+
+        appendSegment(run.text.slice(segmentStart, newlineIndex), run.style)
+        appendNewline()
+        segmentStart = newlineIndex + 1
+      }
+    }
+
+    if (!cursorState.didRender) {
+      appendCursor()
+    }
+
+    return rows
   }
 
   private renderOutput(): void {

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -19,6 +19,7 @@ const MIN_COLS = 2
 const MIN_ROWS = 1
 const APPROXIMATE_CHAR_WIDTH = 8
 const APPROXIMATE_LINE_HEIGHT = 18
+const MEASURED_CHAR_SAMPLE_LENGTH = 80
 
 const KEYBOARD_SEQUENCES = new Map<string, string>([
   ['ArrowUp', '\x1b[A'],
@@ -82,6 +83,12 @@ const readContainedSelection = (root: HTMLElement): string => {
   return selection.toString()
 }
 
+const parseCssPixels = (value: string): number => {
+  const parsed = Number.parseFloat(value)
+
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
 const getKeyboardData = (event: KeyboardEvent): string | null => {
   if (event.metaKey || event.altKey) {
     return null
@@ -139,21 +146,29 @@ export class TerminalTextSurface implements TerminalSurface {
 
     Object.assign(this.root.style, {
       height: '100%',
+      maxWidth: '100%',
       minHeight: '0',
-      overflow: 'auto',
+      overflowX: 'hidden',
+      overflowY: 'auto',
       position: 'relative',
+      width: '100%',
     })
 
     Object.assign(this.output.style, {
       boxSizing: 'border-box',
+      display: 'block',
       fontFamily: TERMINAL_FONT_FAMILY,
       fontSize: `${TERMINAL_FONT_SIZE}px`,
       lineHeight: `${APPROXIMATE_LINE_HEIGHT}px`,
       margin: '0',
+      maxWidth: '100%',
       minHeight: '100%',
+      overflowWrap: 'anywhere',
+      overflowX: 'hidden',
       padding: '8px',
-      whiteSpace: 'pre',
-      wordBreak: 'normal',
+      whiteSpace: 'pre-wrap',
+      width: '100%',
+      wordBreak: 'break-word',
     })
 
     Object.assign(this.input.style, {
@@ -376,9 +391,11 @@ export class TerminalTextSurface implements TerminalSurface {
       return
     }
 
+    const contentWidth = Math.max(0, width - this.readOutputHorizontalPadding())
+
     const nextCols = Math.max(
       MIN_COLS,
-      Math.floor(width / APPROXIMATE_CHAR_WIDTH)
+      Math.floor(contentWidth / this.measureCharacterWidth())
     )
 
     const nextRows = Math.max(
@@ -450,6 +467,39 @@ export class TerminalTextSurface implements TerminalSurface {
     this.dataHandlers.forEach((handler) => {
       handler(data)
     })
+  }
+
+  private readOutputHorizontalPadding(): number {
+    const style = window.getComputedStyle(this.output)
+
+    return (
+      parseCssPixels(style.paddingLeft) + parseCssPixels(style.paddingRight)
+    )
+  }
+
+  private measureCharacterWidth(): number {
+    const probe = document.createElement('span')
+    probe.textContent = '0'.repeat(MEASURED_CHAR_SAMPLE_LENGTH)
+
+    Object.assign(probe.style, {
+      fontFamily: TERMINAL_FONT_FAMILY,
+      fontSize: `${TERMINAL_FONT_SIZE}px`,
+      lineHeight: `${APPROXIMATE_LINE_HEIGHT}px`,
+      pointerEvents: 'none',
+      position: 'absolute',
+      visibility: 'hidden',
+      whiteSpace: 'pre',
+    })
+
+    this.root.append(probe)
+    const width = probe.getBoundingClientRect().width
+    probe.remove()
+
+    if (width <= 0) {
+      return APPROXIMATE_CHAR_WIDTH
+    }
+
+    return width / MEASURED_CHAR_SAMPLE_LENGTH
   }
 
   private createCursorElement(): HTMLElement {

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -681,6 +681,10 @@ export class TerminalTextSurface implements TerminalSurface {
       }
 
       offset += 1
+      const newlineMarker = document.createElement('span')
+      newlineMarker.style.fontSize = '0'
+      newlineMarker.appendChild(document.createTextNode('\n'))
+      currentRow.appendChild(newlineMarker)
       currentRow = this.createOutputRow()
       rows.push(currentRow)
     }

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -503,23 +503,37 @@ export class TerminalTextSurface implements TerminalSurface {
 
   private createCursorElement(): HTMLElement {
     const cursor = document.createElement('span')
+    const marker = document.createElement('span')
+
     cursor.dataset.terminalCursor = 'true'
     cursor.setAttribute('aria-hidden', 'true')
+    marker.dataset.terminalCursorMarker = 'true'
 
     Object.assign(cursor.style, {
+      display: 'inline-block',
+      height: '1em',
+      pointerEvents: 'none',
+      position: 'relative',
+      userSelect: 'none',
+      verticalAlign: '-0.12em',
+      width: '0',
+    })
+
+    Object.assign(marker.style, {
       animationDuration: '1.1s',
       animationIterationCount: 'infinite',
       animationName: 'vfTerminalCursorBlink',
       animationTimingFunction: 'steps(1, end)',
       backgroundColor: 'var(--terminal-cursor-color)',
-      display: 'inline-block',
+      display: 'block',
       height: '1em',
-      marginRight: '-0.62em',
-      pointerEvents: 'none',
-      userSelect: 'none',
-      verticalAlign: '-0.12em',
+      left: '0',
+      position: 'absolute',
+      top: '0',
       width: '0.62em',
     })
+
+    cursor.append(marker)
 
     return cursor
   }

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -136,6 +136,7 @@ export class TerminalTextSurface implements TerminalSurface {
   private container: HTMLElement | null = null
   private colsValue = DEFAULT_COLS
   private rowsValue = DEFAULT_ROWS
+  private cachedCharacterWidth: number | null = null
   private lastSelectionText = ''
   private disposed = false
 
@@ -477,6 +478,10 @@ export class TerminalTextSurface implements TerminalSurface {
   }
 
   private measureCharacterWidth(): number {
+    if (this.cachedCharacterWidth !== null) {
+      return this.cachedCharacterWidth
+    }
+
     const probe = document.createElement('span')
     probe.textContent = '0'.repeat(MEASURED_CHAR_SAMPLE_LENGTH)
 
@@ -498,7 +503,9 @@ export class TerminalTextSurface implements TerminalSurface {
       return APPROXIMATE_CHAR_WIDTH
     }
 
-    return width / MEASURED_CHAR_SAMPLE_LENGTH
+    this.cachedCharacterWidth = width / MEASURED_CHAR_SAMPLE_LENGTH
+
+    return this.cachedCharacterWidth
   }
 
   private createCursorElement(): HTMLElement {

--- a/src/index.css
+++ b/src/index.css
@@ -251,6 +251,24 @@
   }
 }
 
+@keyframes vfTerminalCursorBlink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-terminal-cursor='true'] {
+    animation: none !important;
+    opacity: 1 !important;
+  }
+}
+
 /* Diff viewer styling */
 .diff-added {
   background-color: var(--color-diff-added);

--- a/src/index.css
+++ b/src/index.css
@@ -263,7 +263,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-terminal-cursor='true'] {
+  [data-terminal-cursor-marker='true'] {
     animation: none !important;
     opacity: 1 !important;
   }

--- a/src/lib/e2e-bridge.test.ts
+++ b/src/lib/e2e-bridge.test.ts
@@ -1,6 +1,10 @@
 // cspell:ignore vsplit
 import { describe, test, expect, beforeEach, vi } from 'vitest'
-import { readPaneBuffer, writeOutputToVisibleTerminal } from './e2e-bridge'
+import {
+  getVisibleTerminalSize,
+  readPaneBuffer,
+  writeOutputToVisibleTerminal,
+} from './e2e-bridge'
 import { terminalCache } from '../features/terminal/terminalRegistry'
 
 type CacheEntry = ReturnType<typeof terminalCache.get>
@@ -19,7 +23,7 @@ const makeMockEntry = (rows: readonly string[]): CacheEntry => {
   }
 
   return {
-    terminal: { dispose: (): void => undefined },
+    terminal: { cols: 80, dispose: (): void => undefined, rows: 24 },
     output: { writeOutput: vi.fn() },
     fitController: { fit: (): void => undefined },
     viewportReader,
@@ -219,6 +223,27 @@ describe('readPaneBuffer', () => {
       byteLen: 5,
       phase: 'live',
     })
+  })
+
+  test('returns the visible terminal size from the active cached renderer', () => {
+    const wrapper = buildSessionWrapper([''], 0)
+    wrapper.getBoundingClientRect = (): DOMRect =>
+      ({
+        bottom: 24,
+        height: 24,
+        left: 0,
+        right: 80,
+        top: 0,
+        width: 80,
+        x: 0,
+        y: 0,
+        toJSON: (): Record<string, never> => ({}),
+      }) as DOMRect
+
+    terminalCache.set('pty-0', makeMockEntry([])!)
+    document.body.append(wrapper)
+
+    expect(getVisibleTerminalSize()).toEqual({ cols: 80, rows: 24 })
   })
 
   test('does not write output when no visible terminal is mounted', () => {

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -135,6 +135,31 @@ const getVisibleSessionId = (): string | null => {
   return pane?.dataset.sessionId ?? null
 }
 
+export const getVisibleTerminalSize = (): {
+  readonly cols: number
+  readonly rows: number
+} | null => {
+  const pane = findActivePane()
+  if (!pane) {
+    return null
+  }
+
+  const sessionId = resolveCacheKey(pane)
+  if (!sessionId) {
+    return null
+  }
+
+  const entry = terminalCache.get(sessionId)
+  if (!entry) {
+    return null
+  }
+
+  return {
+    cols: entry.terminal.cols,
+    rows: entry.terminal.rows,
+  }
+}
+
 export const writeOutputToVisibleTerminal = (data: string): boolean => {
   const pane = findActivePane()
   if (!pane) {
@@ -170,6 +195,7 @@ if (import.meta.env.VITE_E2E) {
   window.__VIMEFLOW_E2E__ = {
     getTerminalBuffer: readVisibleTerminalBuffer,
     getTerminalBufferForSession: readTerminalBufferForSession,
+    getVisibleTerminalSize,
     getVisibleSessionId,
     getActiveSessionIds: getAllPtySessionIds,
     listActivePtySessions: async (): Promise<string[]> =>

--- a/src/types/e2e.d.ts
+++ b/src/types/e2e.d.ts
@@ -5,6 +5,7 @@ declare global {
     __VIMEFLOW_E2E__?: {
       getTerminalBuffer(): string
       getTerminalBufferForSession(sessionId: string): string
+      getVisibleTerminalSize(): { readonly cols: number; readonly rows: number } | null
       getVisibleSessionId(): string | null
       getActiveSessionIds(): string[]
       listActivePtySessions(): Promise<string[]>

--- a/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
+++ b/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
@@ -33,6 +33,14 @@ const writeOutputToVisibleTerminal = async (data: string): Promise<void> => {
 const readTerminalBuffer = async (): Promise<string> =>
   browser.execute(() => window.__VIMEFLOW_E2E__?.getTerminalBuffer() ?? '')
 
+const readTerminalSize = async (): Promise<{
+  readonly cols: number
+  readonly rows: number
+} | null> =>
+  browser.execute(
+    () => window.__VIMEFLOW_E2E__?.getVisibleTerminalSize() ?? null
+  )
+
 const hasGhosttyCursor = async (): Promise<boolean> =>
   browser.execute(
     () =>
@@ -92,12 +100,36 @@ describe('Ghostty renderer smoke', () => {
     )
 
     const marker = `GHOSTTY_E2E_${Date.now()}`
+    const terminalSize = await readTerminalSize()
+    const terminalCols = terminalSize?.cols ?? 80
     const progressText = 'Start'
     const progressRewrite = 'S\x1b[1DSt\x1b[2DSta\x1b[3DStart'
+    const softWrapPreviousRow = 'w'.repeat(terminalCols)
+    const softWrapRewrite = `${softWrapPreviousRow}www\r\x1b[Ktail`
+    const mcpProgressText =
+      'Starting MCP servers (2/3): codex_apps, linear\nlinear ready'
+    const statusPromptText = '› gpt-5.5 xhigh · ~/projects/aws'
+    const statusGhostRewrite =
+      '› Summarize recent commits\n' +
+      `${statusPromptText}\n` +
+      `  ${statusPromptText}` +
+      `\x1b[6;1H\x1b[J${statusPromptText}` +
+      '\x1b[7;1H'
+    const codexStartupRewrite =
+      '\x1b[2J\x1b[1;1H>_ OpenAI Codex' +
+      '\x1b[1;42Hmodel: loading' +
+      '\x1b[2;1H~/projects/aws' +
+      '\x1b[3;1HStarting MCP servers (1/3): codex_apps' +
+      '\x1b[4;1Hlinear pending' +
+      '\x1b[1;42H\x1b[Kmodel: gpt-5.5 default' +
+      '\x1b[3;1H\x1b[2KStarting MCP servers (2/3): codex_apps, linear' +
+      '\x1b[4;1H\x1b[2Klinear ready' +
+      '\x1b[5;1H'
 
     await writeOutputToVisibleTerminal(
-      `\x1b[H\x1b[2J${progressRewrite} ` +
-        `\x1b]2;ghostty-e2e\x07\x1b[38;2;243;139;168m${marker}\x1b[0m\n`
+      `${codexStartupRewrite}${statusGhostRewrite}${progressRewrite} ` +
+        `\x1b]2;ghostty-e2e\x07\x1b[38;2;243;139;168m${marker}\x1b[0m\n` +
+        `${softWrapRewrite}\n`
     )
 
     await browser.waitUntil(
@@ -111,7 +143,15 @@ describe('Ghostty renderer smoke', () => {
     const buffer = await readTerminalBuffer()
 
     expect(buffer).toContain(marker)
+    expect(buffer).toContain(mcpProgressText)
+    expect(buffer).toContain('model: gpt-5.5 default')
+    expect(buffer).toContain(statusPromptText)
     expect(buffer).toContain(`${progressText} ${marker}`)
+    expect(buffer).toContain(`${softWrapPreviousRow}\ntail`)
+    expect(buffer).not.toContain(`\n  ${statusPromptText}`)
+    expect(buffer).not.toContain('loading')
+    expect(buffer).not.toContain('(1/3)')
+    expect(buffer).not.toContain('linear pending')
     expect(buffer).not.toContain('SStSta')
     expect(buffer).not.toContain('\x1b')
     expect(buffer).not.toContain(']2;ghostty-e2e')

--- a/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
+++ b/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
@@ -49,6 +49,22 @@ const hasGhosttyCursor = async (): Promise<boolean> =>
       ) !== null
   )
 
+const hasGhosttyHorizontalOverflow = async (): Promise<boolean> =>
+  browser.execute(() => {
+    const root = document.querySelector<HTMLElement>(
+      '[data-terminal-renderer="ghostty"]'
+    )
+    const output = root?.querySelector<HTMLElement>('pre') ?? null
+    const overflowTolerance = 1
+
+    return (
+      (root !== null &&
+        root.scrollWidth - root.clientWidth > overflowTolerance) ||
+      (output !== null &&
+        output.scrollWidth - output.clientWidth > overflowTolerance)
+    )
+  })
+
 interface GhosttyStyleRun {
   readonly color: string
   readonly text: string
@@ -166,5 +182,6 @@ describe('Ghostty renderer smoke', () => {
         (run) => run.text.includes(marker) && run.color === TRUE_COLOR_PINK
       )
     ).toBe(true)
+    expect(await hasGhosttyHorizontalOverflow()).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Extend the Ghostty/plain-text parser and display buffer to model TUI redraw controls instead of appending rewritten frames as text.
- Add cursor-up/down, absolute cursor positioning, erase-display handling, fitted-column soft wrap, and a blinking block cursor for the text renderer.
- Add E2E bridge size introspection and browser smoke coverage for Codex startup repaint, stale status-row clearing, and long input wrapping.

## Follow-ups
- VIM-154 tracks Codex input visibility and resume viewport/scroll state from the latest smoke screenshots.
- VIM-155 tracks Claude Code blank TUI rendering as a separate Ghostty renderer issue.

## Verification
- npm --ignore-scripts run lint
- npm --ignore-scripts run format:check
- git diff --check
- npx tsc -b --pretty false
- npx tsc -p tests/e2e/tsconfig.json --pretty false
- npx vitest run src/features/terminal/components/TerminalPane/terminalControlParser.test.ts src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts src/features/terminal/components/TerminalPane/plainTextInstance.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts src/lib/e2e-bridge.test.ts
- npm run test:e2e:ghostty
- npm test (pre-push hook)

Refs VIM-154