### PR TITLE
feat(terminal): polish configurable layout visibility and sizing

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 72       | 33   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 66       | 27   | 2026-06-18   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 67       | 27   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 24       | 6    | 2026-06-17   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 49       | 20   | 2026-06-18   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 50       | 21   | 2026-06-18   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -613,3 +613,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The round-2 contrast fix mapped `surface-container-highest` to `dark.bg2`, making it identical to `surface-container` and darker than `surface-container-high` (`dark.bg3`). In a dark theme, "highest" elevation must be the lightest step, so the elevation ramp was inverted for that tier and components relying on layered depth cues rendered with the wrong visual hierarchy.
 - **Fix:** Restored monotonic elevation order by mapping `surface-container-highest` → `dark.bg4` (#7c6f64). The `surface-bright` token already moved to `dark.bg3` in round 2, so the bg0 < bg1 < bg2 < bg3 < bg4 ramp is preserved across all surface tiers.
 - **Commit:** same commit as this entry
+
+### 59. Layout display trigger is missing the required shared Tooltip hover label
+
+- **Source:** github-codex-connector | PR #535 round 1 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx`
+- **Finding:** The new `LayoutDisplayMenu` trigger was an icon-only button with an `aria-label` but no visible hover label. The prior stub in `WorkspaceView` had a `Tooltip` wrapper and the design system requires unified `Tooltip` usage for icon-only controls, so the new functional control was harder for sighted users to discover.
+- **Fix:** Added `tooltip` and `tooltipPlacement` props to the `Menu` primitive so it can wrap its cloned trigger with the shared `Tooltip`. `LayoutDisplayMenu` now passes `tooltip="Configure displayed layouts"` to `Menu`; `Tooltip` composes its hover/focus handlers with `Menu`'s trigger reference props so keyboard and click behavior are preserved.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -3,7 +3,7 @@ id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-18
-ref_count: 20
+ref_count: 21
 ---
 
 # React Lifecycle
@@ -479,4 +479,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/terminal/components/SplitView/useSplitDivider.ts` L58-78
 - **Finding:** `writeRatio` listed `initialRatios` in its `useCallback` deps. In `quad` and `grid3x2` layouts, sibling dividers on the same axis share the axis ratios; committing one divider created a new `ratios` array reference, which was passed as `initialRatios` to all sibling handles. Each sibling's `writeRatio` was recreated, firing its commit effect with a stale `size` from `useElasticContainer`, producing wrong track weights and an infinite state oscillation that ended in React's "Maximum update depth exceeded" crash.
 - **Fix:** Store `initialRatios` in a ref (`initialRatiosRef`) updated synchronously during render, and read `initialRatiosRef.current` inside `writeRatio`. Removed `initialRatios` from the `useCallback` deps so `writeRatio` stays stable across sibling commits.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 50. Conditional child unmount leaves parent state stale
+
+- **Source:** github-claude, github-codex-connector | PR #535 round 1 | 2026-06-18
+- **Severity:** LOW / MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.tsx` L2365-2379
+- **Finding:** `LayoutDisplayMenu` is rendered only when `activeSession` exists. If the active session closes while the menu is open, the menu unmounts without `MenuRoot` calling `onOpenChange(false)`, leaving `isLayoutDisplayMenuOpen` stuck `true`. On macOS this permanently removes `vf-app-drag-region` from the top chrome, making the title bar undraggable until the menu is mounted and closed again.
+- **Fix:** Added a `useEffect` in `WorkspaceView` that resets `isLayoutDisplayMenuOpen` to `false` whenever `activeSession` becomes `undefined`, restoring the drag region when the menu unmounts. Added a regression test that removes the active session while the menu is open and asserts the drag region returns.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -462,6 +462,7 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/terminal/components/SplitView/SplitDividers.tsx` L154
 - **Finding:** Handles reused the same `spec.id` key across layouts (e.g. `hdiv` in `hsplit`/`threeRight`/`quad`, `vdiv` in `vsplit`/`threeRight`). Because `useElasticContainer` captures `initialPercent` at mount, switching layouts reused the existing instance and its old pixel size, which the commit effect then stored into the new layout's ratio.
 - **Fix:** Scoped the `SplitDividerHandle` key to the current layout with `key={`${layout}-${spec.id}`}`, forcing a remount and fresh mount-time state on every layout change.
+
 ### 48. Duplicate divider bindings write conflicting CSS vars for the same logical boundary
 
 - **Source:** github-codex-connector | PR #528 round 1 | 2026-06-18

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -738,6 +738,7 @@ filesystem scope restrictions).
 - **File:** `src/features/terminal/components/SplitView/useSplitDivider.test.tsx` L66-76
 - **Finding:** The keyboard resize assertion only checked `ratios[0] > ratios[1]`, verifying direction but not that the resulting boundary fraction stayed within `[SPLIT_ELASTIC_CONFIG.minPercent, SPLIT_ELASTIC_CONFIG.maxPercent]`. The old test was the only place in the file that validated the actual clamped bounds.
 - **Fix:** Derived the boundary fraction with `const frac = ratios[0] / (ratios[0] + ratios[1])` and added `toBeGreaterThanOrEqual(SPLIT_ELASTIC_CONFIG.minPercent)` / `toBeLessThanOrEqual(SPLIT_ELASTIC_CONFIG.maxPercent)` assertions.
+
 ### 72. Test script memory flag not mirrored to `test:coverage`
 
 - **Source:** github-claude | PR #528 round 2 | 2026-06-18

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -279,6 +279,54 @@ describe('Menu.Checkbox', () => {
     const indicator = checkbox.querySelector('.material-symbols-outlined')
     expect(indicator).not.toBeInTheDocument()
   })
+
+  test('a disabled checkbox ignores clicks', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn<(next: boolean) => void>()
+
+    render(
+      <Menu trigger={<button type="button">Open</button>}>
+        <Menu.Checkbox checked disabled onChange={onChange}>
+          Current layout
+        </Menu.Checkbox>
+      </Menu>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Open' }))
+
+    const checkbox = await screen.findByRole('menuitemcheckbox', {
+      name: 'Current layout',
+    })
+
+    expect(checkbox).toHaveAttribute('aria-disabled', 'true')
+
+    await user.click(checkbox)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('a disabled checked checkbox uses muted indicator styling', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Menu trigger={<button type="button">Open</button>}>
+        <Menu.Checkbox checked disabled onChange={vi.fn()}>
+          Required layout
+        </Menu.Checkbox>
+      </Menu>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Open' }))
+
+    const checkbox = await screen.findByRole('menuitemcheckbox', {
+      name: 'Required layout',
+    })
+    // eslint-disable-next-line testing-library/no-node-access -- inspect the visual check indicator container
+    const indicator = checkbox.lastElementChild
+
+    expect(indicator).toHaveClass('bg-on-surface-variant/12')
+    expect(indicator).toHaveClass('text-on-surface-variant/55')
+  })
 })
 
 const indicatorOptions = [

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -86,15 +86,24 @@ const SHORTCUT_CHIP_CLASSES =
   'text-on-surface-variant'
 
 // 18×18 rounded check square ported from ViewSettingsDropdown's CheckIndicator:
-// checked => filled primary square with a `check` glyph; unchecked => thin
-// outline-variant border.
-const CheckIndicator = ({ checked }: { checked: boolean }): ReactElement => (
+// checked => filled square with a `check` glyph; unchecked => thin
+// outline-variant border. Disabled rows tone the checked state down so the
+// indicator visually matches the muted label.
+const CheckIndicator = ({
+  checked,
+  disabled,
+}: {
+  checked: boolean
+  disabled: boolean
+}): ReactElement => (
   <span
     aria-hidden="true"
     className={
       'inline-flex items-center justify-center w-[18px] h-[18px] rounded-[4px] flex-shrink-0 ' +
       (checked
-        ? 'bg-primary text-on-primary'
+        ? disabled
+          ? 'bg-on-surface-variant/12 text-on-surface-variant/55 border-[1.5px] border-on-surface-variant/20'
+          : 'bg-primary text-on-primary'
         : 'bg-transparent border-[1.5px] border-on-surface-variant/30')
     }
     style={checked ? { fontVariationSettings: '"wght" 700' } : undefined}
@@ -256,6 +265,7 @@ interface MenuProps {
   // Opt out of scroll-dismiss where a consumer's behavior differs (spec §5.3).
   middleware?: { ancestorScroll?: boolean }
   'aria-label'?: string
+  onOpenChange?: (open: boolean) => void
   children: ReactNode
 }
 
@@ -270,6 +280,7 @@ const MenuRoot = ({
   width = undefined,
   middleware = undefined,
   'aria-label': ariaLabel = undefined,
+  onOpenChange = undefined,
   children,
 }: MenuProps): ReactElement => {
   const [open, setOpen] = useState(false)
@@ -283,11 +294,12 @@ const MenuRoot = ({
 
   const handleOpenChange = useCallback((nextOpen: boolean): void => {
     setOpen(nextOpen)
+    onOpenChange?.(nextOpen)
     if (!nextOpen) {
       setActiveIndex(null)
       setOpenSubmenuId(null)
     }
-  }, [])
+  }, [onOpenChange])
 
   // Keep a live ref so the stable dismissWhen callback can read the currently
   // open submenu id without re-registering the listener each time it changes.
@@ -488,6 +500,7 @@ const MenuItem = ({
 interface MenuCheckboxProps {
   icon?: string
   checked: boolean
+  disabled?: boolean
   onChange: (next: boolean) => void
   children: ReactNode
 }
@@ -495,23 +508,31 @@ interface MenuCheckboxProps {
 const MenuCheckbox = ({
   icon = undefined,
   checked,
+  disabled = false,
   onChange,
   children,
 }: MenuCheckboxProps): ReactElement => {
   const menu = useMenuContext()
   const label = typeof children === 'string' ? children : ''
-  const { index, ref } = useMenuRow(false, label)
+  const { index, ref } = useMenuRow(disabled, label)
 
   return (
     <button
       type="button"
       role="menuitemcheckbox"
       aria-checked={checked}
+      aria-disabled={disabled}
       ref={ref}
       tabIndex={menu.activeIndex === index ? 0 : -1}
-      className={ITEM_CLASSES}
+      className={`${ITEM_CLASSES} ${DISABLED_ITEM_CLASSES}`}
       {...menu.getItemProps({
-        onClick: (): void => onChange(!checked),
+        onClick: (): void => {
+          if (disabled) {
+            return
+          }
+
+          onChange(!checked)
+        },
       })}
     >
       <span className="flex items-center gap-2.5">
@@ -522,7 +543,7 @@ const MenuCheckbox = ({
         ) : null}
         {children}
       </span>
-      <CheckIndicator checked={checked} />
+      <CheckIndicator checked={checked} disabled={disabled} />
     </button>
   )
 }

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -17,6 +17,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react'
+import { Tooltip } from '@/components/Tooltip'
 import { useFloatingSurface } from '@/components/base/floating/useFloatingSurface'
 import { SurfacePanel } from '@/components/base/floating/SurfacePanel'
 import {
@@ -267,6 +268,11 @@ interface MenuProps {
   'aria-label'?: string
   onOpenChange?: (open: boolean) => void
   children: ReactNode
+  // Optional shared Tooltip label for the trigger. When provided, Menu clones
+  // the trigger with its floating reference props first, then Tooltip wraps that
+  // cloned element and composes its own hover/focus handlers with Menu's.
+  tooltip?: ReactNode
+  tooltipPlacement?: Placement
 }
 
 // Generic anchored menu: a trigger element opens a portal-rendered, glass
@@ -282,6 +288,8 @@ const MenuRoot = ({
   'aria-label': ariaLabel = undefined,
   onOpenChange = undefined,
   children,
+  tooltip = undefined,
+  tooltipPlacement = 'top',
 }: MenuProps): ReactElement => {
   const [open, setOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState<number | null>(null)
@@ -396,9 +404,17 @@ const MenuRoot = ({
     onKeyDown: consumerOnKeyDown,
   })
 
+  const triggerNode = <TriggerSlot trigger={trigger} props={triggerProps} />
+
   return (
     <>
-      <TriggerSlot trigger={trigger} props={triggerProps} />
+      {tooltip !== undefined ? (
+        <Tooltip content={tooltip} placement={tooltipPlacement}>
+          {triggerNode}
+        </Tooltip>
+      ) : (
+        triggerNode
+      )}
       {open ? (
         <MenuBody
           setFloating={refs.setFloating}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -292,14 +292,17 @@ const MenuRoot = ({
 
   const { disabledIndices, setRowDisabled, clearRow } = useMenuDisabledIndices()
 
-  const handleOpenChange = useCallback((nextOpen: boolean): void => {
-    setOpen(nextOpen)
-    onOpenChange?.(nextOpen)
-    if (!nextOpen) {
-      setActiveIndex(null)
-      setOpenSubmenuId(null)
-    }
-  }, [onOpenChange])
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean): void => {
+      setOpen(nextOpen)
+      onOpenChange?.(nextOpen)
+      if (!nextOpen) {
+        setActiveIndex(null)
+        setOpenSubmenuId(null)
+      }
+    },
+    [onOpenChange]
+  )
 
   // Keep a live ref so the stable dismissWhen callback can read the currently
   // open submenu id without re-registering the listener each time it changes.

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { useState, type ReactElement } from 'react'
 import type { LayoutId } from '../../../sessions/types'
 import { LayoutDisplayMenu } from './LayoutDisplayMenu'
@@ -21,7 +21,9 @@ const LayoutDisplayMenuHarness = ({
     'grid3x2',
   ],
 }: HarnessProps): ReactElement => {
-  const [visibleLayoutIds, setVisibleLayoutIds] = useState(initialVisibleLayoutIds)
+  const [visibleLayoutIds, setVisibleLayoutIds] = useState(
+    initialVisibleLayoutIds
+  )
 
   return (
     <>
@@ -46,9 +48,8 @@ describe('LayoutDisplayMenu', () => {
     )
 
     const menu = await screen.findByRole('menu')
-    expect(
-      within(menu).getAllByRole('menuitemcheckbox')
-    ).toHaveLength(6)
+    expect(within(menu).getAllByRole('menuitemcheckbox')).toHaveLength(6)
+
     expect(
       within(menu).getByRole('menuitemcheckbox', { name: '3x2 grid' })
     ).toBeInTheDocument()
@@ -72,8 +73,9 @@ describe('LayoutDisplayMenu', () => {
 
     await user.click(singleLayout)
 
-    expect(screen.getByText('single,vsplit,hsplit,threeRight,quad,grid3x2'))
-      .toBeInTheDocument()
+    expect(
+      screen.getByText('single,vsplit,hsplit,threeRight,quad,grid3x2')
+    ).toBeInTheDocument()
   })
 
   test('toggling a non-active layout updates the visible layout list', async () => {
@@ -84,12 +86,14 @@ describe('LayoutDisplayMenu', () => {
     await user.click(
       screen.getByRole('button', { name: 'Configure displayed layouts' })
     )
+
     await user.click(
       await screen.findByRole('menuitemcheckbox', { name: '3x2 grid' })
     )
 
-    expect(screen.getByText('single,vsplit,hsplit,threeRight,quad'))
-      .toBeInTheDocument()
+    expect(
+      screen.getByText('single,vsplit,hsplit,threeRight,quad')
+    ).toBeInTheDocument()
   })
 
   test('normalizes single back into the visible list when callers omitted it', async () => {
@@ -111,8 +115,9 @@ describe('LayoutDisplayMenu', () => {
 
     expect(singleLayout).toHaveAttribute('aria-checked', 'true')
     await waitFor(() => {
-      expect(screen.getByText('single,vsplit,hsplit,threeRight'))
-        .toBeInTheDocument()
+      expect(
+        screen.getByText('single,vsplit,hsplit,threeRight')
+      ).toBeInTheDocument()
     })
   })
 })

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, test, vi } from 'vitest'
+import { useState, type ReactElement } from 'react'
+import type { LayoutId } from '../../../sessions/types'
+import { LayoutDisplayMenu } from './LayoutDisplayMenu'
+
+interface HarnessProps {
+  activeLayoutId?: LayoutId
+  initialVisibleLayoutIds?: readonly LayoutId[]
+}
+
+const LayoutDisplayMenuHarness = ({
+  activeLayoutId = 'vsplit',
+  initialVisibleLayoutIds = [
+    'single',
+    'vsplit',
+    'hsplit',
+    'threeRight',
+    'quad',
+    'grid3x2',
+  ],
+}: HarnessProps): ReactElement => {
+  const [visibleLayoutIds, setVisibleLayoutIds] = useState(initialVisibleLayoutIds)
+
+  return (
+    <>
+      <LayoutDisplayMenu
+        activeLayoutId={activeLayoutId}
+        visibleLayoutIds={visibleLayoutIds}
+        onVisibleLayoutIdsChange={setVisibleLayoutIds}
+      />
+      <output>{visibleLayoutIds.join(',')}</output>
+    </>
+  )
+}
+
+describe('LayoutDisplayMenu', () => {
+  test('shows all layout rows with glyph labels and checkboxes', async () => {
+    const user = userEvent.setup()
+
+    render(<LayoutDisplayMenuHarness />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Configure displayed layouts' })
+    )
+
+    const menu = await screen.findByRole('menu')
+    expect(
+      within(menu).getAllByRole('menuitemcheckbox')
+    ).toHaveLength(6)
+    expect(
+      within(menu).getByRole('menuitemcheckbox', { name: '3x2 grid' })
+    ).toBeInTheDocument()
+  })
+
+  test('keeps single checked and disabled as the required baseline layout', async () => {
+    const user = userEvent.setup()
+
+    render(<LayoutDisplayMenuHarness activeLayoutId="vsplit" />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Configure displayed layouts' })
+    )
+
+    const singleLayout = await screen.findByRole('menuitemcheckbox', {
+      name: 'Single',
+    })
+
+    expect(singleLayout).toHaveAttribute('aria-disabled', 'true')
+    expect(singleLayout).toHaveAttribute('aria-checked', 'true')
+
+    await user.click(singleLayout)
+
+    expect(screen.getByText('single,vsplit,hsplit,threeRight,quad,grid3x2'))
+      .toBeInTheDocument()
+  })
+
+  test('toggling a non-active layout updates the visible layout list', async () => {
+    const user = userEvent.setup()
+
+    render(<LayoutDisplayMenuHarness />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Configure displayed layouts' })
+    )
+    await user.click(
+      await screen.findByRole('menuitemcheckbox', { name: '3x2 grid' })
+    )
+
+    expect(screen.getByText('single,vsplit,hsplit,threeRight,quad'))
+      .toBeInTheDocument()
+  })
+
+  test('normalizes single back into the visible list when callers omitted it', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <LayoutDisplayMenuHarness
+        initialVisibleLayoutIds={['vsplit', 'hsplit', 'threeRight']}
+      />
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Configure displayed layouts' })
+    )
+
+    const singleLayout = await screen.findByRole('menuitemcheckbox', {
+      name: 'Single',
+    })
+
+    expect(singleLayout).toHaveAttribute('aria-checked', 'true')
+    await waitFor(() => {
+      expect(screen.getByText('single,vsplit,hsplit,threeRight'))
+        .toBeInTheDocument()
+    })
+  })
+})

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
@@ -1,0 +1,131 @@
+import { useEffect, type ReactElement } from 'react'
+import { Menu } from '@/components/Menu'
+import type { LayoutId } from '../../../sessions/types'
+import { LAYOUT_IDS, LAYOUTS } from '../../layout-registry'
+import { LayoutGlyph } from './LayoutGlyph'
+
+export interface LayoutDisplayMenuProps {
+  activeLayoutId: LayoutId
+  visibleLayoutIds: readonly LayoutId[]
+  onVisibleLayoutIdsChange: (next: readonly LayoutId[]) => void
+  onOpenChange?: (open: boolean) => void
+}
+
+const normalizeVisibleLayoutIds = (
+  visibleLayoutIds: readonly LayoutId[]
+): readonly LayoutId[] =>
+  LAYOUT_IDS.filter(
+    (layoutId) => layoutId === 'single' || visibleLayoutIds.includes(layoutId)
+  )
+
+const buildNextVisibleLayoutIds = (
+  visibleLayoutIds: readonly LayoutId[],
+  layoutId: LayoutId,
+  checked: boolean
+): readonly LayoutId[] => {
+  const normalized = normalizeVisibleLayoutIds(visibleLayoutIds)
+
+  return checked
+    ? LAYOUT_IDS.filter(
+        (candidate) => candidate === layoutId || normalized.includes(candidate)
+      )
+    : normalized.filter((candidate) => candidate !== layoutId)
+}
+
+export const LayoutDisplayMenu = ({
+  activeLayoutId,
+  visibleLayoutIds,
+  onVisibleLayoutIdsChange,
+  onOpenChange = undefined,
+}: LayoutDisplayMenuProps): ReactElement => {
+  useEffect(() => {
+    const normalized = normalizeVisibleLayoutIds(visibleLayoutIds)
+
+    if (normalized.length !== visibleLayoutIds.length) {
+      onVisibleLayoutIdsChange(normalized)
+    }
+  }, [onVisibleLayoutIdsChange, visibleLayoutIds])
+
+  return (
+    <Menu
+      placement="bottom-end"
+      aria-label="Displayed layouts"
+      onOpenChange={onOpenChange}
+      trigger={
+        <button
+          type="button"
+          aria-label="Configure displayed layouts"
+          className="inline-flex h-5 w-6 items-center justify-center rounded text-on-surface-muted transition-colors hover:bg-primary/[0.08] hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M3 4.5H6.2M9.8 4.5H13M3 8H9.2M12.2 8H13M3 11.5H4.8M8.2 11.5H13"
+              stroke="currentColor"
+              strokeWidth="1.35"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="8"
+              cy="4.5"
+              r="1.6"
+              stroke="currentColor"
+              strokeWidth="1.25"
+            />
+            <circle
+              cx="10.7"
+              cy="8"
+              r="1.45"
+              stroke="currentColor"
+              strokeWidth="1.25"
+            />
+            <circle
+              cx="6.5"
+              cy="11.5"
+              r="1.55"
+              stroke="currentColor"
+              strokeWidth="1.25"
+            />
+          </svg>
+        </button>
+      }
+    >
+      <Menu.Section label="Displayed layouts">
+        {LAYOUT_IDS.map((layoutId) => {
+          const layout = LAYOUTS[layoutId]
+          const checked =
+            layoutId === 'single' || visibleLayoutIds.includes(layoutId)
+          const isActive = layoutId === activeLayoutId
+
+          return (
+            <Menu.Checkbox
+              key={layoutId}
+              checked={checked || isActive}
+              disabled={layoutId === 'single' || isActive}
+              onChange={(next): void =>
+                onVisibleLayoutIdsChange(
+                  buildNextVisibleLayoutIds(visibleLayoutIds, layoutId, next)
+                )
+              }
+            >
+              <span className="flex items-center gap-2.5">
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-on-surface-variant"
+                >
+                  <LayoutGlyph layoutId={layoutId} />
+                </span>
+                <span>{layout.name}</span>
+              </span>
+            </Menu.Checkbox>
+          )
+        })}
+      </Menu.Section>
+    </Menu>
+  )
+}

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
@@ -51,6 +51,8 @@ export const LayoutDisplayMenu = ({
       placement="bottom-end"
       aria-label="Displayed layouts"
       onOpenChange={onOpenChange}
+      tooltip="Configure displayed layouts"
+      tooltipPlacement="bottom"
       trigger={
         <button
           type="button"

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
@@ -98,6 +98,7 @@ export const LayoutDisplayMenu = ({
       <Menu.Section label="Displayed layouts">
         {LAYOUT_IDS.map((layoutId) => {
           const layout = LAYOUTS[layoutId]
+
           const checked =
             layoutId === 'single' || visibleLayoutIds.includes(layoutId)
           const isActive = layoutId === activeLayoutId

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
@@ -36,6 +36,40 @@ describe('LayoutSwitcher', () => {
     expect(screen.getByRole('button', { name: '3x2 grid' })).toBeInTheDocument()
   })
 
+  test('renders only the configured visible layouts in registry order', () => {
+    render(
+      <LayoutSwitcher
+        activeLayoutId="single"
+        visibleLayoutIds={['single', 'threeRight', 'grid3x2']}
+        onPick={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+    expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Main + 2 stack' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '3x2 grid' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Vertical split' })
+    ).toBeNull()
+  })
+
+  test('keeps the active layout visible even when it is not in the configured list', () => {
+    render(
+      <LayoutSwitcher
+        activeLayoutId="vsplit"
+        visibleLayoutIds={['single', 'grid3x2']}
+        onPick={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+    expect(
+      screen.getByRole('button', { name: 'Vertical split' })
+    ).toBeInTheDocument()
+  })
   test('clicking the already-active button does NOT fire onPick', async () => {
     // The component's contract is that onPick fires only when the
     // active layout actually changes. setSessionLayout already no-ops

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
@@ -51,9 +51,7 @@ describe('LayoutSwitcher', () => {
       screen.getByRole('button', { name: 'Main + 2 stack' })
     ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '3x2 grid' })).toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: 'Vertical split' })
-    ).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Vertical split' })).toBeNull()
   })
 
   test('keeps the active layout visible even when it is not in the configured list', () => {
@@ -70,6 +68,7 @@ describe('LayoutSwitcher', () => {
       screen.getByRole('button', { name: 'Vertical split' })
     ).toBeInTheDocument()
   })
+
   test('clicking the already-active button does NOT fire onPick', async () => {
     // The component's contract is that onPick fires only when the
     // active layout actually changes. setSessionLayout already no-ops

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
@@ -34,7 +34,8 @@ export const LayoutSwitcher = ({
 
   const renderedLayoutIds = LAYOUT_IDS.filter(
     (layoutId) =>
-      layoutId === activeLayoutId || normalizedVisibleLayoutIds.includes(layoutId)
+      layoutId === activeLayoutId ||
+      normalizedVisibleLayoutIds.includes(layoutId)
   )
 
   return (

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement, ReactNode } from 'react'
 import type { LayoutId } from '../../../sessions/types'
+import { LAYOUT_IDS } from '../../layout-registry'
 // Source the data constant directly from its module rather than the
 // `SplitView` component barrel — otherwise LayoutSwitcher silently
 // breaks if `SplitView/index.ts` ever narrows its re-exports. The
@@ -10,6 +11,7 @@ import { SegmentedControl } from '@/components/SegmentedControl'
 
 export interface LayoutSwitcherProps {
   activeLayoutId: LayoutId
+  visibleLayoutIds?: readonly LayoutId[]
   onPick: (next: LayoutId) => void
   /**
    * Optional control docked INSIDE the pill container, after a hairline
@@ -22,46 +24,58 @@ export interface LayoutSwitcherProps {
 
 export const LayoutSwitcher = ({
   activeLayoutId,
+  visibleLayoutIds = LAYOUT_IDS,
   onPick,
   trailing = undefined,
-}: LayoutSwitcherProps): ReactElement => (
-  <div
-    data-testid="layout-switcher"
-    // `role="group"` (not "toolbar") because we don't implement the
-    // roving-tabindex / arrow-key navigation pattern the ARIA toolbar
-    // role implies. `role="group"` + `aria-label` correctly names the
-    // region for screen readers without advertising an unimplemented
-    // keyboard contract. The layout buttons remain in the natural tab
-    // sequence — adequate for this small picker.
-    role="group"
-    aria-label="Pane layout"
-    className="vf-app-no-drag inline-flex items-center gap-0.5 rounded-md bg-surface-container/60 p-0.5"
-  >
-    <SegmentedControl
+}: LayoutSwitcherProps): ReactElement => {
+  const normalizedVisibleLayoutIds = LAYOUT_IDS.filter(
+    (layoutId) => layoutId === 'single' || visibleLayoutIds.includes(layoutId)
+  )
+
+  const renderedLayoutIds = LAYOUT_IDS.filter(
+    (layoutId) =>
+      layoutId === activeLayoutId || normalizedVisibleLayoutIds.includes(layoutId)
+  )
+
+  return (
+    <div
+      data-testid="layout-switcher"
+      // `role="group"` (not "toolbar") because we don't implement the
+      // roving-tabindex / arrow-key navigation pattern the ARIA toolbar
+      // role implies. `role="group"` + `aria-label` correctly names the
+      // region for screen readers without advertising an unimplemented
+      // keyboard contract. The layout buttons remain in the natural tab
+      // sequence — adequate for this small picker.
+      role="group"
       aria-label="Pane layout"
-      role="presentation"
-      variant="toolbarInline"
-      value={activeLayoutId}
-      options={Object.values(LAYOUTS).map((layout) => ({
-        value: layout.id,
-        label: layout.name,
-        tooltip: layout.name,
-      }))}
-      onChange={onPick}
-      skipActiveReselect
-      renderOption={(layout) => <LayoutGlyph layoutId={layout.value} />}
-    />
-    {trailing !== undefined && (
-      <>
-        {/* Hairline divider seats the docked control as part of the same
-            pillar without merging it into the pill toggle group visually. */}
-        <span
-          aria-hidden="true"
-          data-testid="layout-switcher-divider"
-          className="mx-0.5 h-[14px] w-px shrink-0 bg-outline-variant/50"
-        />
-        {trailing}
-      </>
-    )}
-  </div>
-)
+      className="vf-app-no-drag inline-flex items-center gap-0.5 rounded-md bg-surface-container/60 p-0.5"
+    >
+      <SegmentedControl
+        aria-label="Pane layout"
+        role="presentation"
+        variant="toolbarInline"
+        value={activeLayoutId}
+        options={renderedLayoutIds.map((layoutId) => ({
+          value: layoutId,
+          label: LAYOUTS[layoutId].name,
+          tooltip: LAYOUTS[layoutId].name,
+        }))}
+        onChange={onPick}
+        skipActiveReselect
+        renderOption={(layout) => <LayoutGlyph layoutId={layout.value} />}
+      />
+      {trailing !== undefined && (
+        <>
+          {/* Hairline divider seats the docked control as part of the same
+              pillar without merging it into the pill toggle group visually. */}
+          <span
+            aria-hidden="true"
+            data-testid="layout-switcher-divider"
+            className="mx-0.5 h-[14px] w-px shrink-0 bg-outline-variant/50"
+          />
+          {trailing}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/features/terminal/components/LayoutSwitcher/index.ts
+++ b/src/features/terminal/components/LayoutSwitcher/index.ts
@@ -1,3 +1,8 @@
 export { LayoutSwitcher, type LayoutSwitcherProps } from './LayoutSwitcher'
 
 export { LayoutGlyph, type LayoutGlyphProps } from './LayoutGlyph'
+
+export {
+  LayoutDisplayMenu,
+  type LayoutDisplayMenuProps,
+} from './LayoutDisplayMenu'

--- a/src/features/terminal/components/SplitView/SplitDividers.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.test.tsx
@@ -71,6 +71,16 @@ describe('SplitDividers', () => {
     // boundary means grid3x2 now creates exactly three controllers:
     // cols-0, cols-1, and rows-0 — even though it renders five handles.
     const onRatioChange = vi.fn()
+    const observerInstances: MockResizeObserver[] = []
+
+    class CountingResizeObserver extends MockResizeObserver {
+      constructor() {
+        super()
+        observerInstances.push(this)
+      }
+    }
+
+    vi.stubGlobal('ResizeObserver', CountingResizeObserver)
 
     const GridHarness = (): React.ReactElement => {
       const ref = useRef<HTMLDivElement>(document.createElement('div'))
@@ -91,7 +101,10 @@ describe('SplitDividers', () => {
     }
 
     render(<GridHarness />)
-    expect(onRatioChange).toHaveBeenCalledTimes(3)
+    expect(observerInstances).toHaveLength(3)
+    expect(onRatioChange).not.toHaveBeenCalled()
+
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
   })
 
   test('vsplit handle is a vertical separator (col-resize)', () => {

--- a/src/features/terminal/components/SplitView/SplitDividers.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.tsx
@@ -146,6 +146,12 @@ const DIVIDER_SPECS: Record<LayoutId, readonly DividerHandleSpec[]> = {
 const groupKey = (trackAxis: RatioAxis, trackIndex: number): string =>
   `${trackAxis}:${trackIndex}`
 
+const layoutGroupKey = (
+  layout: LayoutId,
+  trackAxis: RatioAxis,
+  trackIndex: number
+): string => `${layout}:${groupKey(trackAxis, trackIndex)}`
+
 const groupSpecsByBoundary = (
   specs: readonly DividerHandleSpec[]
 ): readonly DividerGroup[] => {
@@ -237,7 +243,7 @@ export const SplitDividers = ({
     <Fragment>
       {groups.map((group) => (
         <SplitDividerGroup
-          key={groupKey(group.trackAxis, group.trackIndex)}
+          key={layoutGroupKey(layout, group.trackAxis, group.trackIndex)}
           containerRef={containerRef}
           ratios={ratios}
           onRatioChange={onRatioChange}

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -405,6 +405,45 @@ describe('SplitView - multi-pane layouts', () => {
     expect(valueNow()).toBe(resized)
   })
 
+  test('an untouched layout returns to its default ratios after another layout was resized', () => {
+    const handleValues = (): string[] =>
+      screen
+        .getAllByTestId('split-resize-handle')
+        .map((handle) => handle.getAttribute('aria-valuenow') ?? '')
+
+    const pristine = render(
+      <SplitView
+        session={makeSession('grid3x2', 6)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+    const defaultGridValues = handleValues()
+    pristine.unmount()
+
+    const { rerender } = render(
+      <SplitView
+        session={makeSession('vsplit', 2)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+
+    fireEvent.keyDown(screen.getByTestId('split-resize-handle'), {
+      key: 'ArrowRight',
+    })
+
+    rerender(
+      <SplitView
+        session={makeSession('grid3x2', 6)}
+        service={makeMockService()}
+        isActive
+      />
+    )
+
+    expect(handleValues()).toEqual(defaultGridValues)
+  })
+
   test('each slot gets gridArea by index regardless of pane.id naming', () => {
     const session = makeSession('quad', 4)
 

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -411,7 +411,7 @@ describe('SplitView - multi-pane layouts', () => {
         .getAllByTestId('split-resize-handle')
         .map((handle) => handle.getAttribute('aria-valuenow') ?? '')
 
-    const pristine = render(
+    const view = render(
       <SplitView
         session={makeSession('grid3x2', 6)}
         service={makeMockService()}
@@ -419,7 +419,7 @@ describe('SplitView - multi-pane layouts', () => {
       />
     )
     const defaultGridValues = handleValues()
-    pristine.unmount()
+    view.unmount()
 
     const { rerender } = render(
       <SplitView

--- a/src/features/terminal/components/SplitView/useSplitDivider.test.tsx
+++ b/src/features/terminal/components/SplitView/useSplitDivider.test.tsx
@@ -64,6 +64,16 @@ const Harness = ({
 }
 
 describe('useSplitDivider', () => {
+  test('mount sync writes CSS vars without persisting a custom ratio', () => {
+    const onRatioChange = vi.fn()
+    render(<Harness active onRatioChange={onRatioChange} />)
+
+    const container = screen.getByTestId('container')
+    expect(container.style.getPropertyValue('--split-cols-0')).toMatch(/fr$/)
+    expect(container.style.getPropertyValue('--split-cols-1')).toMatch(/fr$/)
+    expect(onRatioChange).not.toHaveBeenCalled()
+  })
+
   test('keyboard resize mirrors updated track weights up and writes both fr vars', () => {
     const onRatioChange = vi.fn()
     render(<Harness active onRatioChange={onRatioChange} />)

--- a/src/features/terminal/components/SplitView/useSplitDivider.ts
+++ b/src/features/terminal/components/SplitView/useSplitDivider.ts
@@ -56,6 +56,7 @@ export const useSplitDivider = ({
   const effectiveDimensionRef = useRef(0)
   const initialRatiosRef = useRef(initialRatios)
   initialRatiosRef.current = initialRatios
+  const persistIntentRef = useRef(false)
 
   const writeRatio = useCallback(
     (ratio: number): readonly number[] => {
@@ -108,9 +109,10 @@ export const useSplitDivider = ({
     effectiveDimensionRef.current = effectiveDimension
   }, [effectiveDimension])
 
-  // Committed `size` change (drag end | keyboard | resize): set both fr tracks
-  // and mirror the ratio up for remember-within-session. Covers the keyboard /
-  // ResizeObserver paths where onDragPreview never fires.
+  // Committed `size` change (drag end | keyboard | resize): set both fr tracks.
+  // Only explicit user actions mirror the ratio up for remember-within-session;
+  // mount / ResizeObserver commits must keep untouched layouts on their model
+  // defaults instead of accidentally marking them customized.
   //
   // When the committed pixel size lines up with the ratio model (within the
   // one-pixel rounding of the ResizeObserver / getBoundingClientRect path),
@@ -131,7 +133,12 @@ export const useSplitDivider = ({
         ? impliedRatio
         : clampRatio(size / effectiveDimension)
 
-    onRatioChange(writeRatio(ratio))
+    const nextRatios = writeRatio(ratio)
+
+    if (persistIntentRef.current) {
+      persistIntentRef.current = false
+      onRatioChange(nextRatios)
+    }
   }, [
     size,
     effectiveDimension,
@@ -140,6 +147,12 @@ export const useSplitDivider = ({
     initialRatios,
     trackIndex,
   ])
+
+  useEffect(() => {
+    if (!isDragging) {
+      persistIntentRef.current = false
+    }
+  }, [isDragging])
 
   // Restore the fr fallback when this divider unmounts (session deactivates).
   useEffect(
@@ -158,15 +171,19 @@ export const useSplitDivider = ({
       const shrink = axis === 'horizontal' ? 'ArrowLeft' : 'ArrowUp'
       if (event.key === grow) {
         event.preventDefault()
+        persistIntentRef.current = true
         adjustBy(step)
       } else if (event.key === shrink) {
         event.preventDefault()
+        persistIntentRef.current = true
         adjustBy(-step)
       } else if (event.key === 'Home') {
         event.preventDefault()
+        persistIntentRef.current = true
         adjustBy(pixelMin - size)
       } else if (event.key === 'End') {
         event.preventDefault()
+        persistIntentRef.current = true
         adjustBy(pixelMax - size)
       }
     },
@@ -178,7 +195,10 @@ export const useSplitDivider = ({
     size,
     pixelMin,
     pixelMax,
-    handleMouseDown: elastic.handleMouseDown,
+    handleMouseDown: (event): void => {
+      persistIntentRef.current = true
+      elastic.handleMouseDown(event)
+    },
     onKeyDown,
   }
 }

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, within } from '@testing-library/react'
+import { render, screen, act, waitFor, within } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import type { ReactElement, ReactNode } from 'react'
@@ -407,6 +407,35 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     })
   })
 
+  test('macOS top chrome click closes the layout display menu while it is open', async () => {
+    const user = userEvent.setup()
+
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    })
+
+    await setupSessionManager(mockSessions, 'session-2')
+    render(<WorkspaceView />)
+
+    const chrome = screen.getByTestId('top-chrome')
+    expect(chrome).toHaveClass('vf-app-drag-region')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Configure displayed layouts' })
+    )
+
+    expect(await screen.findByRole('menu')).toBeInTheDocument()
+    expect(chrome).not.toHaveClass('vf-app-drag-region')
+
+    await user.click(chrome)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).toBeNull()
+    })
+    expect(chrome).toHaveClass('vf-app-drag-region')
+  })
+
   test('split layout: label-free pills right-aligned; config docked in the pillar (J3)', async () => {
     await setupSessionManager(mockSessions, 'session-2')
     render(<WorkspaceView />)
@@ -485,6 +514,38 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     expect(
       screen.queryByRole('button', { name: /keep top banner visible/i })
     ).toBeNull()
+  })
+
+  test('the layout display menu can hide a non-active layout pill from the pillar', async () => {
+    const user = userEvent.setup()
+
+    await setupSessionManager(mockSessions, 'session-2')
+    render(<WorkspaceView />)
+
+    const switcher = screen.getByTestId('layout-switcher')
+    expect(
+      within(switcher).getByRole('button', { name: '3x2 grid' })
+    ).toBeInTheDocument()
+
+    await user.click(
+      within(switcher).getByRole('button', {
+        name: 'Configure displayed layouts',
+      })
+    )
+    await user.click(
+      await screen.findByRole('menuitemcheckbox', { name: '3x2 grid' })
+    )
+
+    expect(
+      within(screen.getByTestId('layout-switcher')).queryByRole('button', {
+        name: '3x2 grid',
+      })
+    ).toBeNull()
+    expect(
+      within(screen.getByTestId('layout-switcher')).getByRole('button', {
+        name: 'Vertical split',
+      })
+    ).toBeInTheDocument()
   })
 
   test('the sidebar toggle is one persistent root control — it never relocates on collapse (J4)', () => {

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -532,6 +532,7 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
         name: 'Configure displayed layouts',
       })
     )
+
     await user.click(
       await screen.findByRole('menuitemcheckbox', { name: '3x2 grid' })
     )
@@ -541,6 +542,7 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
         name: '3x2 grid',
       })
     ).toBeNull()
+
     expect(
       within(screen.getByTestId('layout-switcher')).getByRole('button', {
         name: 'Vertical split',

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -436,6 +436,38 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     expect(chrome).toHaveClass('vf-app-drag-region')
   })
 
+  test('closing the active session while the layout display menu is open restores the macOS drag region', async () => {
+    const user = userEvent.setup()
+
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    })
+
+    await setupSessionManager(mockSessions, 'session-2')
+    const { rerender } = render(<WorkspaceView />)
+
+    const chrome = screen.getByTestId('top-chrome')
+    expect(chrome).toHaveClass('vf-app-drag-region')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Configure displayed layouts' })
+    )
+
+    expect(await screen.findByRole('menu')).toBeInTheDocument()
+    expect(chrome).not.toHaveClass('vf-app-drag-region')
+
+    // Simulate the active session being removed without an explicit menu close.
+    mockSessionManager.activeSessionId = null
+    mockSessionManager.sessions = []
+    rerender(<WorkspaceView />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).toBeNull()
+    })
+    expect(chrome).toHaveClass('vf-app-drag-region')
+  })
+
   test('split layout: label-free pills right-aligned; config docked in the pillar (J3)', async () => {
     await setupSessionManager(mockSessions, 'session-2')
     render(<WorkspaceView />)

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -475,6 +475,16 @@ const WorkspaceViewContent = (): ReactElement => {
   const activeSession = activeSessionId
     ? sessions.find((s) => s.id === activeSessionId)
     : undefined
+
+  // If the active session disappears while the layout-display menu is open,
+  // the menu unmounts without firing onOpenChange(false). Reset the flag so
+  // the top chrome restores the draggable region on macOS.
+  useEffect(() => {
+    if (!activeSession) {
+      setIsLayoutDisplayMenuOpen(false)
+    }
+  }, [activeSession])
+
   // Non-throwing variant: render-path callers cannot crash on transient
   // invariant violations. Mutation guards still use `getActivePane`.
   const activePane = activeSession ? findActivePane(activeSession) : undefined

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -310,6 +310,7 @@ const WorkspaceViewContent = (): ReactElement => {
   const [isCompactViewport, setIsCompactViewport] =
     useState(readCompactViewport)
   const [compactSidebarOpen, setCompactSidebarOpen] = useState(false)
+
   const [visibleLayoutIds, setVisibleLayoutIds] =
     useState<readonly LayoutId[]>(LAYOUT_IDS)
   const [isLayoutDisplayMenuOpen, setIsLayoutDisplayMenuOpen] = useState(false)

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -9,7 +9,10 @@ import {
   useState,
 } from 'react'
 import { SidebarToggle } from './components/SidebarToggle'
-import { LayoutSwitcher } from '../terminal/components/LayoutSwitcher'
+import {
+  LayoutDisplayMenu,
+  LayoutSwitcher,
+} from '../terminal/components/LayoutSwitcher'
 import { SidebarTopBar } from './components/SidebarTopBar'
 import { SidebarSettingsFooter } from './components/SidebarSettingsFooter'
 import { Sidebar } from '@/components/sidebar/Sidebar'
@@ -18,7 +21,6 @@ import {
   type SidebarTabItem,
 } from '@/components/sidebar/SidebarTabs'
 import { StatusBar, type StatusBarSession } from '@/components/StatusBar'
-import { Tooltip } from '@/components/Tooltip'
 import { AgentStatusCard } from './components/AgentStatusCard'
 import { FilesView } from './components/FilesView'
 import { NewSessionButton } from './components/NewSessionButton'
@@ -80,6 +82,7 @@ import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
 import { isShellPane } from '../sessions/utils/paneKind'
 import { LAYOUTS, selectVisiblePanes } from '../terminal/components/SplitView'
+import { LAYOUT_IDS } from '../terminal/layout-registry'
 import { lineDelta } from '../sessions/utils/lineDelta'
 import { hasLivePane, isLiveStatus } from '../sessions/utils/sessionStatus'
 import { pickNextVisibleSessionId } from '../sessions/utils/pickNextVisibleSessionId'
@@ -307,6 +310,9 @@ const WorkspaceViewContent = (): ReactElement => {
   const [isCompactViewport, setIsCompactViewport] =
     useState(readCompactViewport)
   const [compactSidebarOpen, setCompactSidebarOpen] = useState(false)
+  const [visibleLayoutIds, setVisibleLayoutIds] =
+    useState<readonly LayoutId[]>(LAYOUT_IDS)
+  const [isLayoutDisplayMenuOpen, setIsLayoutDisplayMenuOpen] = useState(false)
 
   useEffect(() => {
     if (
@@ -2333,7 +2339,9 @@ const WorkspaceViewContent = (): ReactElement => {
         <div
           data-testid="top-chrome"
           className={`relative flex h-[44px] shrink-0 items-center gap-[12px] border-b border-outline-variant/25 bg-surface pl-[14px] pr-[14px] ${
-            reserveWindowControls ? 'vf-app-drag-region' : ''
+            reserveWindowControls && !isLayoutDisplayMenuOpen
+              ? 'vf-app-drag-region'
+              : ''
           }`}
         >
           {reserveWindowControls && isSidebarClosed && (
@@ -2356,61 +2364,15 @@ const WorkspaceViewContent = (): ReactElement => {
           {activeSession && (
             <LayoutSwitcher
               activeLayoutId={activeSession.layout}
+              visibleLayoutIds={visibleLayoutIds}
               onPick={handlePickLayout}
               trailing={
-                // Disabled controls swallow pointer events in Chromium, so the
-                // hover target is a wrapper span rather than the button itself.
-                <Tooltip
-                  content="Configure displayed layouts"
-                  placement="bottom"
-                >
-                  <span className="inline-flex">
-                    <button
-                      type="button"
-                      aria-label="Configure displayed layouts"
-                      disabled
-                      aria-disabled="true"
-                      tabIndex={-1}
-                      className="inline-flex h-5 w-6 items-center justify-center rounded text-on-surface-muted opacity-50 transition-colors enabled:hover:bg-primary/[0.08] enabled:hover:text-primary"
-                    >
-                      <svg
-                        width="14"
-                        height="14"
-                        viewBox="0 0 16 16"
-                        fill="none"
-                        aria-hidden="true"
-                      >
-                        <path
-                          d="M3 4.5H6.2M9.8 4.5H13M3 8H9.2M12.2 8H13M3 11.5H4.8M8.2 11.5H13"
-                          stroke="currentColor"
-                          strokeWidth="1.35"
-                          strokeLinecap="round"
-                        />
-                        <circle
-                          cx="8"
-                          cy="4.5"
-                          r="1.6"
-                          stroke="currentColor"
-                          strokeWidth="1.25"
-                        />
-                        <circle
-                          cx="10.7"
-                          cy="8"
-                          r="1.45"
-                          stroke="currentColor"
-                          strokeWidth="1.25"
-                        />
-                        <circle
-                          cx="6.5"
-                          cy="11.5"
-                          r="1.55"
-                          stroke="currentColor"
-                          strokeWidth="1.25"
-                        />
-                      </svg>
-                    </button>
-                  </span>
-                </Tooltip>
+                <LayoutDisplayMenu
+                  activeLayoutId={activeSession.layout}
+                  visibleLayoutIds={visibleLayoutIds}
+                  onVisibleLayoutIdsChange={setVisibleLayoutIds}
+                  onOpenChange={setIsLayoutDisplayMenuOpen}
+                />
               }
             />
           )}


### PR DESCRIPTION
## Summary
- add a displayed-layout floating menu in the top chrome so users can choose which layout pills stay visible while keeping `single` always required
- mute disabled checked menu indicators and let the macOS top banner close the open layout menu so the floating surface behaves consistently with the shared `Menu` primitive
- keep untouched layouts on their default pane sizes, while remembering explicit per-layout split ratio changes only for the current app session

## Root cause
The VIM-151 polish work needed to sit on top of the true VIM-151 umbrella history (`main` + `#527` + `#528`). Separately, the layout display control did not exist yet, and split divider state was still persisting mount/resize synchronization plus reusing stale divider-local state across layouts.

## Test plan
- `npx vitest run src/components/Menu.test.tsx src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx src/features/terminal/components/SplitView/useSplitDivider.test.tsx`
- `npx vitest run src/features/terminal/components/SplitView/SplitView.test.tsx src/features/workspace/WorkspaceView.top-chrome.test.tsx` *(currently blocked in this worktree by missing `tailwind-merge` from the local dependency install path; the suites fail at module resolution before assertions run)*
