### PR TITLE
fix(settings): navigate search results to option rows (VIM-146)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 71       | 31   | 2026-06-16   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 26   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 68       | 23   | 2026-06-17   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 69       | 23   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 22   | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |
@@ -74,7 +74,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 7    | 2026-06-15   |
-| [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-15   |
+| [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 18       | 3    | 2026-06-18   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 11       | 3    | 2026-06-12   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 29       | 5    | 2026-06-15   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,7 +2,7 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-17
+last_updated: 2026-06-18
 ref_count: 25
 ---
 
@@ -647,4 +647,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/settings/components/panes/KeymapPane.tsx`
 - **Finding:** After a successful binding save, `saveDraft` called `stopEditing()` without setting a focus-restoration ref. The `useLayoutEffect` that returns focus to the row edit button only runs when `pendingCancelFocusRef` or `pendingTabFocusRef` is set, so keyboard and assistive-technology users who activate the Save button landed on `document.body`.
 - **Fix:** Set `pendingCancelFocusRef.current = id` in the `result.ok` branch before calling `stopEditing()`, reusing the same focus-restoration path as Escape and Cancel. Added a co-located test asserting the edit button regains focus after Save.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 71. Programmatically focused settings target rows are excluded from the dialog focus trap
+
+- **Source:** github-codex-connector | PR #537 round 1 | 2026-06-18
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/SettingsDialog.tsx` L174
+- **Finding:** When a keyboard user activated an option search result, the target row (marked `tabIndex={-1}`) received focus, but the dialog focus trap only indexed `[tabindex]:not([tabindex="-1"])`. The next Tab saw `currentIndex === -1` and jumped to the close button, so keyboard users could not continue from the search result they just opened.
+- **Fix:** Added `orderedFocusable(dialog)` to include the currently focused programmatic target row in the trap's ordering (sorted by DOM position), so Tab from a focused target moves to the next focusable control naturally. Added a co-located test asserting Tab from a focused search result lands on the setting control.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/module-boundaries.md
+++ b/docs/reviews/patterns/module-boundaries.md
@@ -2,7 +2,7 @@
 id: module-boundaries
 category: code-quality
 created: 2026-04-30
-last_updated: 2026-06-15
+last_updated: 2026-06-18
 ref_count: 3
 ---
 
@@ -193,4 +193,13 @@ Don't widen the coupling by adding a second importer.
 - **File:** `src/features/workspace/WorkspaceView.tsx` L1492-1509, `src/features/workspace/commands/buildWorkspaceCommands.ts` L187-204
 - **Finding:** Both files implemented an identical wrap-around session cycle (empty-sessions guard, `findIndex` on `activeSessionId`, modulo wrap, `setActiveSessionId`). The two closures differed only in variable names (`idx`/`nextIdx` vs `index`/`nextIndex`), making the duplication non-obvious in future diffs. A behavior change — different empty-list message, skip-locked-session guard, etc. — would have to be applied independently in both places, and the compiler would not warn on divergence.
 - **Fix:** Extracted a pure `cycleSession(items, activeId, delta)` utility into `src/features/sessions/utils/cycleSession.ts` with co-located `cycleSession.test.ts`. Replaced both closures with one-liner delegates that call the utility and surface the same "No open sessions" toast when it returns `null`.
+- **Commit:** same commit as this entry
+
+### 18. Trivial `isActiveTarget` helper duplicated across four settings pane files
+
+- **Source:** github-claude | PR #537 round 1 | 2026-06-18
+- **Severity:** LOW
+- **File:** `src/features/settings/components/panes/AppearancePane.tsx` L7-10, `GeneralPane.tsx` L7-10, `KeymapPane.tsx` L109-112, `AgentsPane.tsx` L26-29
+- **Finding:** The same one-line helper `const isActiveTarget = (id, activeTargetId) => activeTargetId === id` was copy-pasted into all four settings pane files. The body was a single equality comparison that needed no helper name to be readable; keeping it local in each pane created a four-file edit surface for any future semantic change to "active target" matching.
+- **Fix:** Removed the helper from each pane and inlined the equality as `activeTargetId === targetId` at every call site. This keeps each pane self-contained without the duplicated helper surface.
 - **Commit:** same commit as this entry

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -180,6 +180,30 @@ describe('SettingsDialog', () => {
     expect(target).toHaveAttribute('data-settings-target-active', 'true')
   })
 
+  test('Tab from a focused search result moves to the setting control', async () => {
+    const user = userEvent.setup()
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Search settings...'), 'redact')
+    await user.click(
+      screen.getByRole('button', { name: 'Redact Private Values' })
+    )
+
+    const target = screen.getByTestId(
+      `settings-target-${SETTINGS_TARGET_IDS.generalRedactPrivateValues}`
+    )
+
+    await waitFor(() => {
+      expect(target).toHaveFocus()
+    })
+
+    await user.tab()
+
+    expect(
+      screen.getByRole('switch', { name: 'Redact Private Values' })
+    ).toHaveFocus()
+  })
+
   test('renders the footer hint and close shortcut', () => {
     render(<SettingsDialog open onClose={vi.fn()} />)
 

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -3,7 +3,11 @@ import { render as rtlRender, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState, type ReactElement } from 'react'
 import { SettingsDialog } from './SettingsDialog'
-import { SETTINGS_SECTIONS } from './sections'
+import {
+  SETTINGS_SECTIONS,
+  SETTINGS_TARGET_IDS,
+  keymapCommandTargetId,
+} from './sections'
 import { DEFAULT_SETTINGS } from './store/settingsDefaults'
 import { SettingsProvider } from './SettingsProvider'
 
@@ -109,6 +113,71 @@ describe('SettingsDialog', () => {
 
     expect(screen.getByRole('button', { name: 'Terminal' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'General' })).toBeNull()
+  })
+
+  test('navigates search result clicks to the matching settings row', async () => {
+    const user = userEvent.setup()
+
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => undefined)
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Search settings...'), 'redact')
+    await user.click(
+      screen.getByRole('button', { name: 'Redact Private Values' })
+    )
+
+    const target = screen.getByTestId(
+      `settings-target-${SETTINGS_TARGET_IDS.generalRedactPrivateValues}`
+    )
+
+    await waitFor(() => {
+      expect(target).toHaveFocus()
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'General', current: 'page' })
+    ).toBeInTheDocument()
+    expect(target).toHaveAttribute('data-settings-target-active', 'true')
+    expect(scrollIntoView).toHaveBeenCalled()
+
+    scrollIntoView.mockRestore()
+  })
+
+  test('keeps command palette and leader keymap targets independently navigable', async () => {
+    const user = userEvent.setup()
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    await user.type(
+      screen.getByPlaceholderText('Search settings...'),
+      'command palette'
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Open command palette' })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: 'Command palette leader' })
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Command palette leader' })
+    )
+
+    const target = screen.getByTestId(
+      `settings-target-${keymapCommandTargetId('palette-leader')}`
+    )
+
+    await waitFor(() => {
+      expect(target).toHaveFocus()
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'Keymap', current: 'page' })
+    ).toBeInTheDocument()
+    expect(target).toHaveAttribute('data-settings-target-active', 'true')
   })
 
   test('renders the footer hint and close shortcut', () => {

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -1,7 +1,12 @@
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef, useState, type ReactElement } from 'react'
-import type { SettingsSectionId, SettingsDialogProps } from './types'
-import { SETTINGS_SECTIONS } from './sections'
+import type {
+  SettingsDialogProps,
+  SettingsSectionId,
+  SettingsTarget,
+  SettingsTargetId,
+} from './types'
+import { SETTINGS_SECTIONS, SETTINGS_TARGETS } from './sections'
 import { Icon } from './components/Icon'
 import { Tooltip } from '@/components/Tooltip'
 import { Kbd } from './components/Kbd'
@@ -20,6 +25,11 @@ const REAL_PANES: readonly SettingsSectionId[] = [
   'agents',
 ]
 
+const matchesQuery = (
+  value: string | undefined,
+  normalizedQuery: string
+): boolean => value?.toLowerCase().includes(normalizedQuery) ?? false
+
 export const SettingsDialog = ({
   open,
   onClose,
@@ -28,17 +38,51 @@ export const SettingsDialog = ({
   const [scope, setScope] = useState<'User' | 'vimeflow'>('User')
   const [query, setQuery] = useState('')
 
+  const [activeTargetId, setActiveTargetId] = useState<SettingsTargetId | null>(
+    null
+  )
+  const [targetNavigationKey, setTargetNavigationKey] = useState(0)
+
   const dialogRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
 
-  const filtered = query.trim()
-    ? SETTINGS_SECTIONS.filter((s) =>
-        s.label.toLowerCase().includes(query.toLowerCase())
+  const normalizedQuery = query.trim().toLowerCase()
+
+  const sectionMatches = normalizedQuery
+    ? SETTINGS_SECTIONS.filter((s) => matchesQuery(s.label, normalizedQuery))
+    : SETTINGS_SECTIONS
+
+  const targetMatches = normalizedQuery
+    ? SETTINGS_TARGETS.filter(
+        (target) =>
+          matchesQuery(target.label, normalizedQuery) ||
+          matchesQuery(target.hint, normalizedQuery)
       )
+    : []
+
+  const filteredSectionIds = new Set<SettingsSectionId>([
+    ...sectionMatches.map((s) => s.id),
+    ...targetMatches.map((target) => target.section),
+  ])
+
+  const filtered = normalizedQuery
+    ? SETTINGS_SECTIONS.filter((s) => filteredSectionIds.has(s.id))
     : SETTINGS_SECTIONS
 
   const activeSection = SETTINGS_SECTIONS.find((s) => s.id === section)
+
+  const handlePickSection = (id: SettingsSectionId): void => {
+    setSection(id)
+    setActiveTargetId(null)
+  }
+
+  const handlePickTarget = (target: SettingsTarget): void => {
+    setSection(target.section)
+    setActiveTargetId(target.id)
+    setTargetNavigationKey((key) => key + 1)
+  }
 
   useEffect(() => {
     if (open) {
@@ -109,8 +153,26 @@ export const SettingsDialog = ({
   useEffect(() => {
     if (!open) {
       setQuery('')
+      setActiveTargetId(null)
     }
   }, [open])
+
+  useEffect(() => {
+    if (!open || activeTargetId === null) {
+      return
+    }
+
+    const target = contentRef.current?.querySelector<HTMLElement>(
+      `[data-settings-target="${activeTargetId}"]`
+    )
+
+    if (!target) {
+      return
+    }
+
+    target.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    target.focus({ preventScroll: true })
+  }, [activeTargetId, open, section, targetNavigationKey])
 
   return (
     <AnimatePresence>
@@ -162,8 +224,11 @@ export const SettingsDialog = ({
             <div className="flex min-h-0 flex-1">
               <SettingsSidebar
                 sections={filtered}
+                targets={targetMatches}
                 active={section}
-                onPick={setSection}
+                activeTargetId={activeTargetId}
+                onPick={handlePickSection}
+                onPickTarget={handlePickTarget}
                 query={query}
                 onQuery={setQuery}
               />
@@ -171,11 +236,22 @@ export const SettingsDialog = ({
               <div className="flex min-w-0 flex-1 flex-col">
                 <SettingsHeader scope={scope} onScope={setScope} />
 
-                <div className="thin-scrollbar flex-1 overflow-auto px-7 py-5">
-                  {section === 'general' && <GeneralPane />}
-                  {section === 'appearance' && <AppearancePane />}
-                  {section === 'keymap' && <KeymapPane />}
-                  {section === 'agents' && <AgentsPane />}
+                <div
+                  ref={contentRef}
+                  className="thin-scrollbar flex-1 overflow-auto px-7 py-5"
+                >
+                  {section === 'general' && (
+                    <GeneralPane activeTargetId={activeTargetId} />
+                  )}
+                  {section === 'appearance' && (
+                    <AppearancePane activeTargetId={activeTargetId} />
+                  )}
+                  {section === 'keymap' && (
+                    <KeymapPane activeTargetId={activeTargetId} />
+                  )}
+                  {section === 'agents' && (
+                    <AgentsPane activeTargetId={activeTargetId} />
+                  )}
                   {!REAL_PANES.includes(section) && activeSection && (
                     <PlaceholderPane section={activeSection} />
                   )}

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -30,6 +30,39 @@ const matchesQuery = (
   normalizedQuery: string
 ): boolean => value?.toLowerCase().includes(normalizedQuery) ?? false
 
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+
+const orderedFocusable = (dialog: HTMLElement): HTMLElement[] => {
+  const staticFocusable = Array.from(
+    dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+  ).filter(
+    (el) =>
+      !el.matches(':disabled') && el.getAttribute('aria-hidden') !== 'true'
+  )
+
+  const active = document.activeElement as HTMLElement | null
+  if (
+    active === null ||
+    !dialog.contains(active) ||
+    staticFocusable.includes(active)
+  ) {
+    return staticFocusable
+  }
+
+  // The active element is programmatically focused but not in the natural tab
+  // order (e.g. a settings target row with tabIndex={-1}). Include it in the
+  // ordering so the focus trap can Tab away from it naturally.
+  const all = [...staticFocusable, active]
+  all.sort((a, b) => {
+    const position = a.compareDocumentPosition(b)
+
+    return position & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
+  })
+
+  return all
+}
+
 export const SettingsDialog = ({
   open,
   onClose,
@@ -112,14 +145,7 @@ export const SettingsDialog = ({
         return
       }
 
-      const focusable = Array.from(
-        dialog.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        )
-      ).filter(
-        (el) =>
-          !el.matches(':disabled') && el.getAttribute('aria-hidden') !== 'true'
-      )
+      const focusable = orderedFocusable(dialog)
 
       if (focusable.length === 0) {
         event.preventDefault()

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -2,8 +2,16 @@ import { useState, type ReactElement } from 'react'
 import { describe, expect, test, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { SETTINGS_SECTIONS } from '../sections'
+import {
+  SETTINGS_SECTIONS,
+  SETTINGS_TARGET_IDS,
+  SETTINGS_TARGETS,
+} from '../sections'
 import { SettingsSidebar } from './SettingsSidebar'
+
+const redactTarget = SETTINGS_TARGETS.find(
+  (target) => target.id === SETTINGS_TARGET_IDS.generalRedactPrivateValues
+)!
 
 const StatefulSidebar = (): ReactElement => {
   const [query, setQuery] = useState('')
@@ -83,5 +91,62 @@ describe('SettingsSidebar', () => {
     expect(screen.getByRole('button', { name: 'Keymap' })).not.toHaveAttribute(
       'aria-current'
     )
+  })
+
+  test('renders matching option targets under their owning section', () => {
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        sections={SETTINGS_SECTIONS.filter(
+          (section) => section.id === 'general'
+        )}
+        targets={[redactTarget]}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Redact Private Values' })
+    ).toBeInTheDocument()
+  })
+
+  test('calls onPickTarget when an option target is clicked', async () => {
+    const user = userEvent.setup()
+    const onPickTarget = vi.fn()
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        sections={SETTINGS_SECTIONS.filter(
+          (section) => section.id === 'general'
+        )}
+        targets={[redactTarget]}
+        onPickTarget={onPickTarget}
+      />
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Redact Private Values' })
+    )
+
+    expect(onPickTarget).toHaveBeenCalledWith(redactTarget)
+  })
+
+  test('marks the active option target with aria-current', () => {
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        sections={SETTINGS_SECTIONS.filter(
+          (section) => section.id === 'general'
+        )}
+        targets={[redactTarget]}
+        activeTargetId={redactTarget.id}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Redact Private Values',
+        current: 'location',
+      })
+    ).toBeInTheDocument()
   })
 })

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -4,8 +4,11 @@ import { Icon } from './Icon'
 
 export const SettingsSidebar = ({
   sections,
+  targets = [],
   active,
+  activeTargetId = null,
   onPick,
+  onPickTarget = (): void => undefined,
   query,
   onQuery,
 }: SettingsSidebarProps): ReactElement => (
@@ -28,30 +31,68 @@ export const SettingsSidebar = ({
       {sections.map((s) => {
         const isActive = s.id === active
 
+        const sectionTargets = targets.filter(
+          (target) => target.section === s.id
+        )
+
         return (
-          <button
-            key={s.id}
-            type="button"
-            aria-current={isActive ? 'page' : undefined}
-            onClick={() => onPick(s.id)}
-            className={`relative mb-px flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left font-body text-[13px] transition-colors ${
-              isActive
-                ? 'bg-primary-container/10 text-primary'
-                : 'bg-transparent text-on-surface-variant hover:bg-on-surface/[0.03]'
-            }`}
-          >
-            {isActive && (
-              <span className="absolute -left-0.5 top-2 bottom-2 w-0.5 rounded-sm bg-primary-container" />
+          <div key={s.id} className="mb-px">
+            <button
+              type="button"
+              aria-current={isActive ? 'page' : undefined}
+              onClick={() => onPick(s.id)}
+              className={`relative flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left font-body text-[13px] transition-colors ${
+                isActive
+                  ? 'bg-primary-container/10 text-primary'
+                  : 'bg-transparent text-on-surface-variant hover:bg-on-surface/[0.03]'
+              }`}
+            >
+              {isActive && (
+                <span className="absolute -left-0.5 top-2 bottom-2 w-0.5 rounded-sm bg-primary-container" />
+              )}
+              <Icon
+                name="chevron_right"
+                size={13}
+                className={
+                  isActive ? 'text-primary-container' : 'text-on-surface-muted'
+                }
+              />
+              {s.label}
+            </button>
+
+            {sectionTargets.length > 0 && (
+              <div className="mt-0.5 mb-1 space-y-px pl-5">
+                {sectionTargets.map((target) => {
+                  const isTargetActive = target.id === activeTargetId
+
+                  return (
+                    <button
+                      key={target.id}
+                      type="button"
+                      aria-current={isTargetActive ? 'location' : undefined}
+                      onClick={() => onPickTarget(target)}
+                      className={`flex w-full items-center gap-1.5 rounded-md border-none px-2 py-1.5 text-left font-body text-[12px] transition-colors ${
+                        isTargetActive
+                          ? 'bg-primary-container/[0.08] text-primary'
+                          : 'bg-transparent text-on-surface-muted hover:bg-on-surface/[0.03] hover:text-on-surface-variant'
+                      }`}
+                    >
+                      <Icon
+                        name="subdirectory_arrow_right"
+                        size={12}
+                        className={
+                          isTargetActive
+                            ? 'text-primary-container'
+                            : 'text-on-surface-muted'
+                        }
+                      />
+                      <span className="min-w-0 truncate">{target.label}</span>
+                    </button>
+                  )
+                })}
+              </div>
             )}
-            <Icon
-              name="chevron_right"
-              size={13}
-              className={
-                isActive ? 'text-primary-container' : 'text-on-surface-muted'
-              }
-            />
-            {s.label}
-          </button>
+          </div>
         )
       })}
     </nav>

--- a/src/features/settings/components/controls.test.tsx
+++ b/src/features/settings/components/controls.test.tsx
@@ -40,6 +40,22 @@ describe('Row', () => {
 
     expect(screen.getByTestId('row')).not.toHaveClass('border-b')
   })
+
+  test('marks target rows as focusable settings targets', () => {
+    render(
+      <Row
+        label="Density"
+        settingsTargetId="appearance-density"
+        settingsTargetActive
+      />
+    )
+
+    const row = screen.getByTestId('settings-target-appearance-density')
+
+    expect(row).toHaveAttribute('data-settings-target', 'appearance-density')
+    expect(row).toHaveAttribute('data-settings-target-active', 'true')
+    expect(row).toHaveAttribute('tabindex', '-1')
+  })
 })
 
 describe('PaneTitle', () => {

--- a/src/features/settings/components/controls.tsx
+++ b/src/features/settings/components/controls.tsx
@@ -14,26 +14,42 @@ export const Row = ({
   hint,
   children,
   last = false,
-}: RowProps): ReactElement => (
-  <div
-    data-testid="row"
-    className={`flex items-center gap-6 py-3.5 ${
-      last ? '' : 'border-b border-outline-variant/18'
-    }`}
-  >
-    <div className="min-w-0 flex-1">
-      <div className="mb-1 font-display text-sm font-medium text-on-surface">
-        {label}
-      </div>
-      {hint && (
-        <div className="font-body text-xs leading-relaxed text-on-surface-muted">
-          {hint}
+  settingsTargetId = undefined,
+  settingsTargetActive = false,
+}: RowProps): ReactElement => {
+  const targetAttrs =
+    settingsTargetId === undefined
+      ? { 'data-testid': 'row' }
+      : {
+          'data-testid': `settings-target-${settingsTargetId}`,
+          'data-settings-target': settingsTargetId,
+          'data-settings-target-active': settingsTargetActive
+            ? 'true'
+            : undefined,
+          tabIndex: -1,
+        }
+
+  return (
+    <div
+      {...targetAttrs}
+      className={`flex scroll-mt-4 items-center gap-6 rounded-lg py-3.5 outline-none transition-colors focus-visible:ring-1 focus-visible:ring-primary/65 ${
+        settingsTargetActive ? 'bg-primary-container/[0.08]' : ''
+      } ${last ? '' : 'border-b border-outline-variant/18'}`}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 font-display text-sm font-medium text-on-surface">
+          {label}
         </div>
-      )}
+        {hint && (
+          <div className="font-body text-xs leading-relaxed text-on-surface-muted">
+            {hint}
+          </div>
+        )}
+      </div>
+      <div className="shrink-0">{children}</div>
     </div>
-    <div className="shrink-0">{children}</div>
-  </div>
-)
+  )
+}
 
 export const PaneTitle = ({ title, sub }: PaneTitleProps): ReactElement => (
   <div className="mb-4">

--- a/src/features/settings/components/panes/AgentsPane.tsx
+++ b/src/features/settings/components/panes/AgentsPane.tsx
@@ -5,11 +5,7 @@ import {
   useState,
   type ReactElement,
 } from 'react'
-import type {
-  AgentAlias,
-  SettingsPaneTargetProps,
-  SettingsTargetId,
-} from '../../types'
+import type { AgentAlias, SettingsPaneTargetProps } from '../../types'
 import { DEFAULT_ALIASES, SETTINGS_TARGET_IDS } from '../../sections'
 import { useSettings } from '../../hooks/useSettings'
 import { Icon } from '../Icon'
@@ -23,11 +19,6 @@ import {
   Toggle,
 } from '../controls'
 
-const isActiveTarget = (
-  id: SettingsTargetId,
-  activeTargetId?: SettingsTargetId | null
-): boolean => activeTargetId === id
-
 export const AgentsPane = ({
   activeTargetId = null,
 }: SettingsPaneTargetProps): ReactElement => {
@@ -39,10 +30,8 @@ export const AgentsPane = ({
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
   const hasInteractedRef = useRef(false)
 
-  const shellAliasesActive = isActiveTarget(
-    SETTINGS_TARGET_IDS.agentsShellAliases,
-    activeTargetId
-  )
+  const shellAliasesActive =
+    activeTargetId === SETTINGS_TARGET_IDS.agentsShellAliases
 
   useEffect(() => {
     const load = async (): Promise<void> => {
@@ -150,10 +139,9 @@ export const AgentsPane = ({
         label="Manage agent shell aliases"
         hint="Vimeflow injects these into each pane's PTY environment. Your .bashrc / .zshrc is never touched."
         settingsTargetId={SETTINGS_TARGET_IDS.agentsManageAliases}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.agentsManageAliases,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.agentsManageAliases
+        }
       >
         <Toggle
           on={shimOn}

--- a/src/features/settings/components/panes/AgentsPane.tsx
+++ b/src/features/settings/components/panes/AgentsPane.tsx
@@ -5,8 +5,12 @@ import {
   useState,
   type ReactElement,
 } from 'react'
-import type { AgentAlias } from '../../types'
-import { DEFAULT_ALIASES } from '../../sections'
+import type {
+  AgentAlias,
+  SettingsPaneTargetProps,
+  SettingsTargetId,
+} from '../../types'
+import { DEFAULT_ALIASES, SETTINGS_TARGET_IDS } from '../../sections'
 import { useSettings } from '../../hooks/useSettings'
 import { Icon } from '../Icon'
 import { Tooltip } from '@/components/Tooltip'
@@ -19,7 +23,14 @@ import {
   Toggle,
 } from '../controls'
 
-export const AgentsPane = (): ReactElement => {
+const isActiveTarget = (
+  id: SettingsTargetId,
+  activeTargetId?: SettingsTargetId | null
+): boolean => activeTargetId === id
+
+export const AgentsPane = ({
+  activeTargetId = null,
+}: SettingsPaneTargetProps): ReactElement => {
   const { settings, update } = useSettings()
   const shimOn = settings.agentShimEnabled
   const [aliases, setAliases] = useState<AgentAlias[]>([])
@@ -27,6 +38,11 @@ export const AgentsPane = (): ReactElement => {
   const [saveError, setSaveError] = useState<string | null>(null)
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
   const hasInteractedRef = useRef(false)
+
+  const shellAliasesActive = isActiveTarget(
+    SETTINGS_TARGET_IDS.agentsShellAliases,
+    activeTargetId
+  )
 
   useEffect(() => {
     const load = async (): Promise<void> => {
@@ -133,6 +149,11 @@ export const AgentsPane = (): ReactElement => {
       <Row
         label="Manage agent shell aliases"
         hint="Vimeflow injects these into each pane's PTY environment. Your .bashrc / .zshrc is never touched."
+        settingsTargetId={SETTINGS_TARGET_IDS.agentsManageAliases}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.agentsManageAliases,
+          activeTargetId
+        )}
       >
         <Toggle
           on={shimOn}
@@ -141,7 +162,15 @@ export const AgentsPane = (): ReactElement => {
         />
       </Row>
 
-      <div className="mt-4">
+      <div
+        data-testid={`settings-target-${SETTINGS_TARGET_IDS.agentsShellAliases}`}
+        data-settings-target={SETTINGS_TARGET_IDS.agentsShellAliases}
+        data-settings-target-active={shellAliasesActive ? 'true' : undefined}
+        tabIndex={-1}
+        className={`mt-4 scroll-mt-4 rounded-lg outline-none transition-colors focus-visible:ring-1 focus-visible:ring-primary/65 ${
+          shellAliasesActive ? 'bg-primary-container/[0.08]' : ''
+        }`}
+      >
         <div className="mb-2.5 flex items-center">
           <div>
             <div className="font-display text-sm font-medium text-on-surface">

--- a/src/features/settings/components/panes/AppearancePane.tsx
+++ b/src/features/settings/components/panes/AppearancePane.tsx
@@ -1,20 +1,41 @@
 import { useState, type ReactElement } from 'react'
-import { BUILTIN_SCHEMES } from '../../sections'
+import { BUILTIN_SCHEMES, SETTINGS_TARGET_IDS } from '../../sections'
+import type { SettingsPaneTargetProps, SettingsTargetId } from '../../types'
 import { Icon } from '../Icon'
 import { GhostButton, PaneTitle, Row, Select } from '../controls'
 
-export const AppearancePane = (): ReactElement => {
+const isActiveTarget = (
+  id: SettingsTargetId,
+  activeTargetId?: SettingsTargetId | null
+): boolean => activeTargetId === id
+
+export const AppearancePane = ({
+  activeTargetId = null,
+}: SettingsPaneTargetProps): ReactElement => {
   const [activeScheme, setActiveScheme] = useState('obsidian')
   const [accentHue, setAccentHue] = useState(285)
   const [density, setDensity] = useState('comfortable')
   const [uiFont, setUiFont] = useState('instrument')
   const [monoFont, setMonoFont] = useState('jetbrains')
 
+  const colorSchemeActive = isActiveTarget(
+    SETTINGS_TARGET_IDS.appearanceColorScheme,
+    activeTargetId
+  )
+
   return (
     <>
       <PaneTitle title="Appearance" sub="Theme · Color Scheme · Typography" />
 
-      <div className="mb-4">
+      <div
+        data-testid={`settings-target-${SETTINGS_TARGET_IDS.appearanceColorScheme}`}
+        data-settings-target={SETTINGS_TARGET_IDS.appearanceColorScheme}
+        data-settings-target-active={colorSchemeActive ? 'true' : undefined}
+        tabIndex={-1}
+        className={`mb-4 scroll-mt-4 rounded-lg outline-none transition-colors focus-visible:ring-1 focus-visible:ring-primary/65 ${
+          colorSchemeActive ? 'bg-primary-container/[0.08]' : ''
+        }`}
+      >
         <div className="mb-1 font-display text-sm font-medium text-on-surface">
           Color Scheme
         </div>
@@ -102,6 +123,11 @@ export const AppearancePane = (): ReactElement => {
       <Row
         label="Accent Hue"
         hint={`Shift the primary accent around the wheel. Current: ${accentHue}°`}
+        settingsTargetId={SETTINGS_TARGET_IDS.appearanceAccentHue}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.appearanceAccentHue,
+          activeTargetId
+        )}
       >
         <input
           type="range"
@@ -118,6 +144,11 @@ export const AppearancePane = (): ReactElement => {
       <Row
         label="Density"
         hint="Compact for power users; comfortable for readability."
+        settingsTargetId={SETTINGS_TARGET_IDS.appearanceDensity}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.appearanceDensity,
+          activeTargetId
+        )}
       >
         <Select
           value={density}
@@ -133,6 +164,11 @@ export const AppearancePane = (): ReactElement => {
       <Row
         label="UI Font"
         hint="Sans-serif used for labels, sidebars, headings."
+        settingsTargetId={SETTINGS_TARGET_IDS.appearanceUiFont}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.appearanceUiFont,
+          activeTargetId
+        )}
       >
         <Select
           value={uiFont}
@@ -149,6 +185,11 @@ export const AppearancePane = (): ReactElement => {
       <Row
         label="Mono Font"
         hint="Used in the terminal, editor, and all code blocks."
+        settingsTargetId={SETTINGS_TARGET_IDS.appearanceMonoFont}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.appearanceMonoFont,
+          activeTargetId
+        )}
         last
       >
         <Select

--- a/src/features/settings/components/panes/AppearancePane.tsx
+++ b/src/features/settings/components/panes/AppearancePane.tsx
@@ -1,13 +1,8 @@
 import { useState, type ReactElement } from 'react'
 import { BUILTIN_SCHEMES, SETTINGS_TARGET_IDS } from '../../sections'
-import type { SettingsPaneTargetProps, SettingsTargetId } from '../../types'
+import type { SettingsPaneTargetProps } from '../../types'
 import { Icon } from '../Icon'
 import { GhostButton, PaneTitle, Row, Select } from '../controls'
-
-const isActiveTarget = (
-  id: SettingsTargetId,
-  activeTargetId?: SettingsTargetId | null
-): boolean => activeTargetId === id
 
 export const AppearancePane = ({
   activeTargetId = null,
@@ -18,10 +13,8 @@ export const AppearancePane = ({
   const [uiFont, setUiFont] = useState('instrument')
   const [monoFont, setMonoFont] = useState('jetbrains')
 
-  const colorSchemeActive = isActiveTarget(
-    SETTINGS_TARGET_IDS.appearanceColorScheme,
-    activeTargetId
-  )
+  const colorSchemeActive =
+    activeTargetId === SETTINGS_TARGET_IDS.appearanceColorScheme
 
   return (
     <>
@@ -124,10 +117,9 @@ export const AppearancePane = ({
         label="Accent Hue"
         hint={`Shift the primary accent around the wheel. Current: ${accentHue}°`}
         settingsTargetId={SETTINGS_TARGET_IDS.appearanceAccentHue}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.appearanceAccentHue,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.appearanceAccentHue
+        }
       >
         <input
           type="range"
@@ -145,10 +137,9 @@ export const AppearancePane = ({
         label="Density"
         hint="Compact for power users; comfortable for readability."
         settingsTargetId={SETTINGS_TARGET_IDS.appearanceDensity}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.appearanceDensity,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.appearanceDensity
+        }
       >
         <Select
           value={density}
@@ -165,10 +156,9 @@ export const AppearancePane = ({
         label="UI Font"
         hint="Sans-serif used for labels, sidebars, headings."
         settingsTargetId={SETTINGS_TARGET_IDS.appearanceUiFont}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.appearanceUiFont,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.appearanceUiFont
+        }
       >
         <Select
           value={uiFont}
@@ -186,10 +176,9 @@ export const AppearancePane = ({
         label="Mono Font"
         hint="Used in the terminal, editor, and all code blocks."
         settingsTargetId={SETTINGS_TARGET_IDS.appearanceMonoFont}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.appearanceMonoFont,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.appearanceMonoFont
+        }
         last
       >
         <Select

--- a/src/features/settings/components/panes/GeneralPane.tsx
+++ b/src/features/settings/components/panes/GeneralPane.tsx
@@ -1,8 +1,17 @@
 import type { ReactElement } from 'react'
+import { SETTINGS_TARGET_IDS } from '../../sections'
 import { useSettings } from '../../hooks/useSettings'
+import type { SettingsPaneTargetProps, SettingsTargetId } from '../../types'
 import { PaneTitle, Row, Select, Toggle } from '../controls'
 
-export const GeneralPane = (): ReactElement => {
+const isActiveTarget = (
+  id: SettingsTargetId,
+  activeTargetId?: SettingsTargetId | null
+): boolean => activeTargetId === id
+
+export const GeneralPane = ({
+  activeTargetId = null,
+}: SettingsPaneTargetProps): ReactElement => {
   const { settings, update } = useSettings()
 
   return (
@@ -12,6 +21,11 @@ export const GeneralPane = (): ReactElement => {
       <Row
         label="When Closing With No Tabs"
         hint="What to do when using the 'close active item' action with no tabs."
+        settingsTargetId={SETTINGS_TARGET_IDS.generalCloseWithNoTabs}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.generalCloseWithNoTabs,
+          activeTargetId
+        )}
       >
         <Select
           value={settings.closeWithNoTabs}
@@ -28,6 +42,11 @@ export const GeneralPane = (): ReactElement => {
       <Row
         label="On Last Window Closed"
         hint="What to do when the last window is closed."
+        settingsTargetId={SETTINGS_TARGET_IDS.generalOnLastWindowClosed}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.generalOnLastWindowClosed,
+          activeTargetId
+        )}
       >
         <Select
           value={settings.onLastWindowClosed}
@@ -43,6 +62,11 @@ export const GeneralPane = (): ReactElement => {
       <Row
         label="Use System Path Prompts"
         hint="Use native OS dialogs for 'Open' and 'Save As'."
+        settingsTargetId={SETTINGS_TARGET_IDS.generalUseSystemPathPrompts}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.generalUseSystemPathPrompts,
+          activeTargetId
+        )}
       >
         <Toggle
           on={settings.useSystemPathPrompts}
@@ -54,6 +78,11 @@ export const GeneralPane = (): ReactElement => {
       <Row
         label="Use System Prompts"
         hint="Use native OS dialogs for confirmations."
+        settingsTargetId={SETTINGS_TARGET_IDS.generalUseSystemPrompts}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.generalUseSystemPrompts,
+          activeTargetId
+        )}
       >
         <Toggle
           on={settings.useSystemPrompts}
@@ -65,6 +94,11 @@ export const GeneralPane = (): ReactElement => {
       <Row
         label="Redact Private Values"
         hint="Hide the values of variables in private files."
+        settingsTargetId={SETTINGS_TARGET_IDS.generalRedactPrivateValues}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.generalRedactPrivateValues,
+          activeTargetId
+        )}
       >
         <Toggle
           on={settings.redactPrivateValues}
@@ -76,6 +110,11 @@ export const GeneralPane = (): ReactElement => {
       <Row
         label="CLI Default Open Behavior"
         hint="How `vf <path>` opens directories when no flag is specified."
+        settingsTargetId={SETTINGS_TARGET_IDS.generalCliOpenBehavior}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.generalCliOpenBehavior,
+          activeTargetId
+        )}
         last
       >
         <Select

--- a/src/features/settings/components/panes/GeneralPane.tsx
+++ b/src/features/settings/components/panes/GeneralPane.tsx
@@ -1,13 +1,8 @@
 import type { ReactElement } from 'react'
 import { SETTINGS_TARGET_IDS } from '../../sections'
 import { useSettings } from '../../hooks/useSettings'
-import type { SettingsPaneTargetProps, SettingsTargetId } from '../../types'
+import type { SettingsPaneTargetProps } from '../../types'
 import { PaneTitle, Row, Select, Toggle } from '../controls'
-
-const isActiveTarget = (
-  id: SettingsTargetId,
-  activeTargetId?: SettingsTargetId | null
-): boolean => activeTargetId === id
 
 export const GeneralPane = ({
   activeTargetId = null,
@@ -22,10 +17,9 @@ export const GeneralPane = ({
         label="When Closing With No Tabs"
         hint="What to do when using the 'close active item' action with no tabs."
         settingsTargetId={SETTINGS_TARGET_IDS.generalCloseWithNoTabs}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.generalCloseWithNoTabs,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.generalCloseWithNoTabs
+        }
       >
         <Select
           value={settings.closeWithNoTabs}
@@ -43,10 +37,9 @@ export const GeneralPane = ({
         label="On Last Window Closed"
         hint="What to do when the last window is closed."
         settingsTargetId={SETTINGS_TARGET_IDS.generalOnLastWindowClosed}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.generalOnLastWindowClosed,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.generalOnLastWindowClosed
+        }
       >
         <Select
           value={settings.onLastWindowClosed}
@@ -63,10 +56,9 @@ export const GeneralPane = ({
         label="Use System Path Prompts"
         hint="Use native OS dialogs for 'Open' and 'Save As'."
         settingsTargetId={SETTINGS_TARGET_IDS.generalUseSystemPathPrompts}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.generalUseSystemPathPrompts,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.generalUseSystemPathPrompts
+        }
       >
         <Toggle
           on={settings.useSystemPathPrompts}
@@ -79,10 +71,9 @@ export const GeneralPane = ({
         label="Use System Prompts"
         hint="Use native OS dialogs for confirmations."
         settingsTargetId={SETTINGS_TARGET_IDS.generalUseSystemPrompts}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.generalUseSystemPrompts,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.generalUseSystemPrompts
+        }
       >
         <Toggle
           on={settings.useSystemPrompts}
@@ -95,10 +86,9 @@ export const GeneralPane = ({
         label="Redact Private Values"
         hint="Hide the values of variables in private files."
         settingsTargetId={SETTINGS_TARGET_IDS.generalRedactPrivateValues}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.generalRedactPrivateValues,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.generalRedactPrivateValues
+        }
       >
         <Toggle
           on={settings.redactPrivateValues}
@@ -111,10 +101,9 @@ export const GeneralPane = ({
         label="CLI Default Open Behavior"
         hint="How `vf <path>` opens directories when no flag is specified."
         settingsTargetId={SETTINGS_TARGET_IDS.generalCliOpenBehavior}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.generalCliOpenBehavior,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.generalCliOpenBehavior
+        }
         last
       >
         <Select

--- a/src/features/settings/components/panes/KeymapPane.tsx
+++ b/src/features/settings/components/panes/KeymapPane.tsx
@@ -14,7 +14,13 @@ import {
   type ShortcutInput,
 } from '../../../../lib/formatShortcut'
 import { useSettings } from '../../hooks/useSettings'
-import { KEYMAP_GROUPS, VIM_KEYMAP_GROUPS } from '../../sections'
+import {
+  KEYMAP_GROUPS,
+  SETTINGS_TARGET_IDS,
+  VIM_KEYMAP_GROUPS,
+  keymapCommandTargetId,
+  keymapStaticTargetId,
+} from '../../sections'
 import { CATALOG, type CommandId } from '../../../keymap/catalog'
 import {
   eventToChord,
@@ -26,7 +32,13 @@ import {
   useKeybindings,
   type SetBindingResult,
 } from '../../../keymap/useKeybindings'
-import type { KeymapBinding, KeymapGroup, KeymapKeys } from '../../types'
+import type {
+  KeymapBinding,
+  KeymapGroup,
+  KeymapKeys,
+  SettingsPaneTargetProps,
+  SettingsTargetId,
+} from '../../types'
 import { Icon } from '../Icon'
 import { Kbd } from '../Kbd'
 import { PaneTitle, Row, Select } from '../controls'
@@ -94,10 +106,15 @@ const focusAfterTabCancel = (id: CommandId, direction: TabDirection): void => {
   focusable[nextIndex]?.focus()
 }
 
-const rowClass = (last: boolean): string =>
-  `flex items-center gap-3.5 px-3.5 py-2.5 ${
-    last ? '' : 'border-b border-outline-variant/15'
-  }`
+const isActiveTarget = (
+  id: SettingsTargetId,
+  activeTargetId?: SettingsTargetId | null
+): boolean => activeTargetId === id
+
+const rowClass = (last: boolean, active = false): string =>
+  `flex scroll-mt-4 items-center gap-3.5 rounded-lg px-3.5 py-2.5 outline-none transition-colors focus-visible:ring-1 focus-visible:ring-primary/65 ${
+    active ? 'bg-primary-container/[0.08]' : ''
+  } ${last ? '' : 'border-b border-outline-variant/15'}`
 
 const groupShell = (zone: string, rows: ReactElement[]): ReactElement => (
   <div key={zone} className="mb-4">
@@ -143,7 +160,9 @@ const resultMessage = (
 const resolveKeys = (keys: KeymapKeys): ShortcutInput[] =>
   typeof keys === 'function' ? keys(isMacPlatform()) : keys
 
-export const KeymapPane = (): ReactElement => {
+export const KeymapPane = ({
+  activeTargetId = null,
+}: SettingsPaneTargetProps): ReactElement => {
   const { settings, update } = useSettings()
   const { bindingFor, resetBinding, setUserBinding } = useKeybindings()
   const [editingId, setEditingId] = useState<CommandId | null>(null)
@@ -336,9 +355,18 @@ export const KeymapPane = (): ReactElement => {
     const isEditing = editingId === cmd.id
     const isOverridden = settings.customKeybindings[cmd.id] !== undefined
     const rowFeedback = feedback?.id === cmd.id ? feedback : null
+    const targetId = keymapCommandTargetId(cmd.id)
+    const targetActive = isActiveTarget(targetId, activeTargetId)
 
     return (
-      <div key={cmd.id} className={rowClass(last)}>
+      <div
+        key={cmd.id}
+        data-testid={`settings-target-${targetId}`}
+        data-settings-target={targetId}
+        data-settings-target-active={targetActive ? 'true' : undefined}
+        tabIndex={-1}
+        className={rowClass(last, targetActive)}
+      >
         {labelCell(cmd.label)}
         <div className="flex shrink-0 items-center gap-2">
           <span className="flex min-w-[72px] justify-end gap-1">
@@ -417,16 +445,28 @@ export const KeymapPane = (): ReactElement => {
   const staticGroup = (group: KeymapGroup): ReactElement =>
     groupShell(
       group.zone,
-      group.bindings.map((b: KeymapBinding, i) => (
-        <div key={b.id} className={rowClass(i === group.bindings.length - 1)}>
-          {labelCell(b.label)}
-          <span className="flex gap-1">
-            {resolveKeys(b.keys).map((k, j) => (
-              <Kbd key={`${b.id}-${j}`}>{formatShortcut(k)}</Kbd>
-            ))}
-          </span>
-        </div>
-      ))
+      group.bindings.map((b: KeymapBinding, i) => {
+        const targetId = keymapStaticTargetId(b.id)
+        const targetActive = isActiveTarget(targetId, activeTargetId)
+
+        return (
+          <div
+            key={b.id}
+            data-testid={`settings-target-${targetId}`}
+            data-settings-target={targetId}
+            data-settings-target-active={targetActive ? 'true' : undefined}
+            tabIndex={-1}
+            className={rowClass(i === group.bindings.length - 1, targetActive)}
+          >
+            {labelCell(b.label)}
+            <span className="flex gap-1">
+              {resolveKeys(b.keys).map((k, j) => (
+                <Kbd key={`${b.id}-${j}`}>{formatShortcut(k)}</Kbd>
+              ))}
+            </span>
+          </div>
+        )
+      })
     )
 
   return (
@@ -436,6 +476,11 @@ export const KeymapPane = (): ReactElement => {
       <Row
         label="Preset"
         hint="Switch between the default Vimeflow binding set and Vim-style bindings."
+        settingsTargetId={SETTINGS_TARGET_IDS.keymapPreset}
+        settingsTargetActive={isActiveTarget(
+          SETTINGS_TARGET_IDS.keymapPreset,
+          activeTargetId
+        )}
       >
         <Select
           value={settings.keymapPreset}

--- a/src/features/settings/components/panes/KeymapPane.tsx
+++ b/src/features/settings/components/panes/KeymapPane.tsx
@@ -37,7 +37,6 @@ import type {
   KeymapGroup,
   KeymapKeys,
   SettingsPaneTargetProps,
-  SettingsTargetId,
 } from '../../types'
 import { Icon } from '../Icon'
 import { Kbd } from '../Kbd'
@@ -105,11 +104,6 @@ const focusAfterTabCancel = (id: CommandId, direction: TabDirection): void => {
   const nextIndex = (currentIndex + delta + focusable.length) % focusable.length
   focusable[nextIndex]?.focus()
 }
-
-const isActiveTarget = (
-  id: SettingsTargetId,
-  activeTargetId?: SettingsTargetId | null
-): boolean => activeTargetId === id
 
 const rowClass = (last: boolean, active = false): string =>
   `flex scroll-mt-4 items-center gap-3.5 rounded-lg px-3.5 py-2.5 outline-none transition-colors focus-visible:ring-1 focus-visible:ring-primary/65 ${
@@ -356,7 +350,7 @@ export const KeymapPane = ({
     const isOverridden = settings.customKeybindings[cmd.id] !== undefined
     const rowFeedback = feedback?.id === cmd.id ? feedback : null
     const targetId = keymapCommandTargetId(cmd.id)
-    const targetActive = isActiveTarget(targetId, activeTargetId)
+    const targetActive = activeTargetId === targetId
 
     return (
       <div
@@ -447,7 +441,7 @@ export const KeymapPane = ({
       group.zone,
       group.bindings.map((b: KeymapBinding, i) => {
         const targetId = keymapStaticTargetId(b.id)
-        const targetActive = isActiveTarget(targetId, activeTargetId)
+        const targetActive = activeTargetId === targetId
 
         return (
           <div
@@ -477,10 +471,9 @@ export const KeymapPane = ({
         label="Preset"
         hint="Switch between the default Vimeflow binding set and Vim-style bindings."
         settingsTargetId={SETTINGS_TARGET_IDS.keymapPreset}
-        settingsTargetActive={isActiveTarget(
-          SETTINGS_TARGET_IDS.keymapPreset,
-          activeTargetId
-        )}
+        settingsTargetActive={
+          activeTargetId === SETTINGS_TARGET_IDS.keymapPreset
+        }
       >
         <Select
           value={settings.keymapPreset}

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -6,8 +6,12 @@ export {
   BUILTIN_SCHEMES,
   DEFAULT_ALIASES,
   KEYMAP_GROUPS,
+  SETTINGS_TARGET_IDS,
+  SETTINGS_TARGETS,
   SETTINGS_SECTIONS,
   VIM_KEYMAP_GROUPS,
+  keymapCommandTargetId,
+  keymapStaticTargetId,
 } from './sections'
 
 export type {
@@ -19,8 +23,11 @@ export type {
   KeymapGroup,
   SettingsDialogProps,
   SettingsHeaderProps,
+  SettingsPaneTargetProps,
   SettingsScope,
   SettingsSection,
   SettingsSectionId,
   SettingsSidebarProps,
+  SettingsTarget,
+  SettingsTargetId,
 } from './types'

--- a/src/features/settings/sections.test.ts
+++ b/src/features/settings/sections.test.ts
@@ -3,8 +3,11 @@ import {
   BUILTIN_SCHEMES,
   DEFAULT_ALIASES,
   KEYMAP_GROUPS,
+  SETTINGS_TARGET_IDS,
+  SETTINGS_TARGETS,
   SETTINGS_SECTIONS,
   VIM_KEYMAP_GROUPS,
+  keymapCommandTargetId,
 } from './sections'
 
 describe('SETTINGS_SECTIONS', () => {
@@ -34,6 +37,36 @@ describe('SETTINGS_SECTIONS', () => {
       expect(s.label).toBeDefined()
       expect(s.icon).toBeDefined()
     })
+  })
+})
+
+describe('SETTINGS_TARGETS', () => {
+  test('contains unique option target ids', () => {
+    const ids = SETTINGS_TARGETS.map((target) => target.id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  test('contains real settings rows and independent keymap command targets', () => {
+    expect(SETTINGS_TARGETS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: SETTINGS_TARGET_IDS.generalRedactPrivateValues,
+          section: 'general',
+          label: 'Redact Private Values',
+        }),
+        expect.objectContaining({
+          id: keymapCommandTargetId('palette'),
+          section: 'keymap',
+          label: 'Open command palette',
+        }),
+        expect.objectContaining({
+          id: keymapCommandTargetId('palette-leader'),
+          section: 'keymap',
+          label: 'Command palette leader',
+        }),
+      ])
+    )
   })
 })
 

--- a/src/features/settings/sections.ts
+++ b/src/features/settings/sections.ts
@@ -3,7 +3,10 @@ import type {
   AppearanceScheme,
   KeymapGroup,
   SettingsSection,
+  SettingsTarget,
+  SettingsTargetId,
 } from './types'
+import { CATALOG, type CommandId } from '../keymap/catalog'
 
 export const SETTINGS_SECTIONS: SettingsSection[] = [
   { id: 'general', label: 'General', icon: 'settings' },
@@ -21,6 +24,29 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
   { id: 'ai', label: 'AI', icon: 'psychology' },
   { id: 'network', label: 'Network', icon: 'lan' },
 ]
+
+export const SETTINGS_TARGET_IDS = {
+  generalCloseWithNoTabs: 'general-close-with-no-tabs',
+  generalOnLastWindowClosed: 'general-on-last-window-closed',
+  generalUseSystemPathPrompts: 'general-use-system-path-prompts',
+  generalUseSystemPrompts: 'general-use-system-prompts',
+  generalRedactPrivateValues: 'general-redact-private-values',
+  generalCliOpenBehavior: 'general-cli-open-behavior',
+  appearanceColorScheme: 'appearance-color-scheme',
+  appearanceAccentHue: 'appearance-accent-hue',
+  appearanceDensity: 'appearance-density',
+  appearanceUiFont: 'appearance-ui-font',
+  appearanceMonoFont: 'appearance-mono-font',
+  keymapPreset: 'keymap-preset',
+  agentsManageAliases: 'agents-manage-aliases',
+  agentsShellAliases: 'agents-shell-aliases',
+} as const satisfies Record<string, SettingsTargetId>
+
+export const keymapCommandTargetId = (id: CommandId): SettingsTargetId =>
+  `keymap-command-${id}`
+
+export const keymapStaticTargetId = (id: string): SettingsTargetId =>
+  `keymap-static-${id}`
 
 /* eslint-disable vimeflow/no-hardcoded-colors -- literal preview swatches for the
    appearance scheme picker (AppearancePane): each entry intentionally shows that
@@ -194,6 +220,120 @@ export const VIM_KEYMAP_GROUPS: KeymapGroup[] = [
   },
 ]
 // cspell:enable
+
+const KEYMAP_TARGET_GROUPS = new Set([
+  'Global',
+  'Panes & Layout',
+  'Terminal',
+  'Browser',
+])
+
+export const SETTINGS_TARGETS: SettingsTarget[] = [
+  {
+    id: SETTINGS_TARGET_IDS.generalCloseWithNoTabs,
+    section: 'general',
+    label: 'When Closing With No Tabs',
+    hint: "What to do when using the 'close active item' action with no tabs.",
+  },
+  {
+    id: SETTINGS_TARGET_IDS.generalOnLastWindowClosed,
+    section: 'general',
+    label: 'On Last Window Closed',
+    hint: 'What to do when the last window is closed.',
+  },
+  {
+    id: SETTINGS_TARGET_IDS.generalUseSystemPathPrompts,
+    section: 'general',
+    label: 'Use System Path Prompts',
+    hint: "Use native OS dialogs for 'Open' and 'Save As'.",
+  },
+  {
+    id: SETTINGS_TARGET_IDS.generalUseSystemPrompts,
+    section: 'general',
+    label: 'Use System Prompts',
+    hint: 'Use native OS dialogs for confirmations.',
+  },
+  {
+    id: SETTINGS_TARGET_IDS.generalRedactPrivateValues,
+    section: 'general',
+    label: 'Redact Private Values',
+    hint: 'Hide the values of variables in private files.',
+  },
+  {
+    id: SETTINGS_TARGET_IDS.generalCliOpenBehavior,
+    section: 'general',
+    label: 'CLI Default Open Behavior',
+    hint: 'How `vf <path>` opens directories when no flag is specified.',
+  },
+  {
+    id: SETTINGS_TARGET_IDS.appearanceColorScheme,
+    section: 'appearance',
+    label: 'Color Scheme',
+    hint: 'The base palette for all surfaces, text, and accents.',
+  },
+  {
+    id: SETTINGS_TARGET_IDS.appearanceAccentHue,
+    section: 'appearance',
+    label: 'Accent Hue',
+    hint: 'Shift the primary accent around the wheel.',
+  },
+  {
+    id: SETTINGS_TARGET_IDS.appearanceDensity,
+    section: 'appearance',
+    label: 'Density',
+    hint: 'Compact for power users; comfortable for readability.',
+  },
+  {
+    id: SETTINGS_TARGET_IDS.appearanceUiFont,
+    section: 'appearance',
+    label: 'UI Font',
+    hint: 'Sans-serif used for labels, sidebars, headings.',
+  },
+  {
+    id: SETTINGS_TARGET_IDS.appearanceMonoFont,
+    section: 'appearance',
+    label: 'Mono Font',
+    hint: 'Used in the terminal, editor, and all code blocks.',
+  },
+  {
+    id: SETTINGS_TARGET_IDS.keymapPreset,
+    section: 'keymap',
+    label: 'Preset',
+    hint: 'Switch between the default Vimeflow binding set and Vim-style bindings.',
+  },
+  ...CATALOG.filter((cmd) => KEYMAP_TARGET_GROUPS.has(cmd.group)).map(
+    (cmd): SettingsTarget => ({
+      id: keymapCommandTargetId(cmd.id),
+      section: 'keymap',
+      label: cmd.label,
+      hint: `${cmd.group} shortcut`,
+    })
+  ),
+  ...KEYMAP_GROUPS.filter(
+    (group) => group.zone === 'Diff (when focused)'
+  ).flatMap((group) =>
+    group.bindings.map(
+      (binding): SettingsTarget => ({
+        id: keymapStaticTargetId(binding.id),
+        section: 'keymap',
+        label: binding.label,
+        hint: `${group.zone} shortcut`,
+      })
+    )
+  ),
+  {
+    id: SETTINGS_TARGET_IDS.agentsManageAliases,
+    section: 'agents',
+    label: 'Manage agent shell aliases',
+    hint: "Vimeflow injects these into each pane's PTY environment.",
+  },
+  {
+    id: SETTINGS_TARGET_IDS.agentsShellAliases,
+    section: 'agents',
+    label: 'Shell aliases',
+    hint: 'Type the alias in any pane and Vimeflow swaps it for the full agent invocation.',
+  },
+]
 
 export const DEFAULT_ALIASES: AgentAlias[] = [
   {

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -23,6 +23,15 @@ export interface SettingsSection {
   icon: string
 }
 
+export type SettingsTargetId = string
+
+export interface SettingsTarget {
+  id: SettingsTargetId
+  section: SettingsSectionId
+  label: string
+  hint?: string
+}
+
 export interface SettingsDialogProps {
   open: boolean
   onClose: () => void
@@ -30,8 +39,11 @@ export interface SettingsDialogProps {
 
 export interface SettingsSidebarProps {
   sections: SettingsSection[]
+  targets?: SettingsTarget[]
   active: SettingsSectionId
+  activeTargetId?: SettingsTargetId | null
   onPick: (id: SettingsSectionId) => void
+  onPickTarget?: (target: SettingsTarget) => void
   query: string
   onQuery: (query: string) => void
 }
@@ -59,11 +71,17 @@ export interface RowProps {
   hint?: string
   children?: ReactNode
   last?: boolean
+  settingsTargetId?: SettingsTargetId
+  settingsTargetActive?: boolean
 }
 
 export interface PaneTitleProps {
   title: string
   sub?: string
+}
+
+export interface SettingsPaneTargetProps {
+  activeTargetId?: SettingsTargetId | null
 }
 
 export interface ToggleProps {


### PR DESCRIPTION
## Summary

- Add stable settings option target metadata and mark the real rendered rows/custom blocks as focusable targets.
- Show matching option results under their owning section in Settings search.
- Make option result clicks switch to the owning pane, scroll/focus the concrete row, and keep it highlighted.
- Cover command palette and command palette leader as independent keymap targets.

## Root Cause

Settings search only filtered section labels, so navigation could select dialog sections but could not land on actual setting options.

## Validation

- `npm run lint`
- `npm run type-check:generated`
- `npm test -- --run`
- `npm test -- --run src/features/settings/SettingsDialog.test.tsx src/features/settings/components/SettingsSidebar.test.tsx src/features/settings/components/controls.test.tsx src/features/settings/sections.test.ts`