### PR TITLE
feat(sessions): preserve open sessions on reopen

### DIFF
--- a/crates/backend/src/runtime/ipc.rs
+++ b/crates/backend/src/runtime/ipc.rs
@@ -1917,7 +1917,7 @@ mod tests {
             "version": 1,
             "sessions": [{
                 "id": "s", "projectId": "proj", "layout": "single",
-                "workingDirectory": "/", "active": true,
+                "workingDirectory": "/", "active": true, "open": true,
                 "panes": [{ "kind": "browser", "paneId": "p0", "paneIndex": 0, "active": true,
                     "tabs": [{ "active": true, "historyIndex": 0,
                         "history": [{ "url": "https://x", "title": null }] }] }]

--- a/crates/backend/src/terminal/workspace_layout.rs
+++ b/crates/backend/src/terminal/workspace_layout.rs
@@ -33,6 +33,7 @@ pub struct WorkspaceSession {
     pub layout: String,
     pub working_directory: String,
     pub active: bool,
+    pub open: bool,
     pub panes: Vec<WorkspacePane>,
 }
 
@@ -257,7 +258,11 @@ pub fn repair_workspace_layout(
         }
 
         // At most one active session in the loop (first active:true wins).
+        // `open` is independent: it records Active-section membership, so many
+        // sessions can be open while only one is selected. Old stores lacked
+        // the field; fall back to raw_active to preserve selected-only restore.
         let raw_active = bool_field(rs, "active").unwrap_or(false);
+        let open = bool_field(rs, "open").unwrap_or(raw_active);
         let active = raw_active && !active_session_seen;
         if active {
             active_session_seen = true;
@@ -272,6 +277,7 @@ pub fn repair_workspace_layout(
             layout,
             working_directory,
             active,
+            open,
             panes,
         });
     }
@@ -598,6 +604,7 @@ mod tests {
                 layout: "vsplit".into(),
                 working_directory: "/w".into(),
                 active: true,
+                open: true,
                 panes: vec![
                     WorkspacePane::Shell(ShellPane {
                         pane_id: "p0".into(),
@@ -631,6 +638,7 @@ mod tests {
         assert!(json.contains("\"historyIndex\":0"), "json: {json}");
         assert!(json.contains("\"kind\":\"shell\""), "json: {json}");
         assert!(json.contains("\"kind\":\"browser\""), "json: {json}");
+        assert!(json.contains("\"open\":true"), "json: {json}");
         let back: WorkspaceLayoutStore = serde_json::from_str(&json).unwrap();
         assert_eq!(back, store);
     }
@@ -655,6 +663,32 @@ mod tests {
         let store = repair_workspace_layout(json!({ "version": 999, "sessions": [] }), "proj", "/");
         assert!(store.sessions.is_empty());
         assert_eq!(store.version, CURRENT_WORKSPACE_LAYOUT_VERSION);
+    }
+
+    #[test]
+    fn preserves_many_open_sessions_but_normalizes_one_active() {
+        let store = repair_workspace_layout(
+            json!({
+              "version": 1,
+              "sessions": [
+                { "id": "s1", "projectId": "p", "layout": "single",
+                  "workingDirectory": "/", "active": true, "open": true,
+                  "panes": [ { "kind": "browser", "paneId": "b1",
+                    "paneIndex": 0, "active": true } ] },
+                { "id": "s2", "projectId": "p", "layout": "single",
+                  "workingDirectory": "/", "active": true, "open": true,
+                  "panes": [ { "kind": "browser", "paneId": "b2",
+                    "paneIndex": 0, "active": true } ] }
+              ]}),
+            "proj",
+            "/",
+        );
+
+        assert_eq!(store.sessions.len(), 2);
+        assert!(store.sessions[0].active);
+        assert!(!store.sessions[1].active);
+        assert!(store.sessions[0].open);
+        assert!(store.sessions[1].open);
     }
 
     #[test]
@@ -839,6 +873,7 @@ mod tests {
                 layout: "single".into(),
                 working_directory: "/".into(),
                 active: true,
+                open: true,
                 panes: vec![WorkspacePane::Shell(ShellPane {
                     pane_id: "p0".into(),
                     pane_index: 0,
@@ -874,6 +909,7 @@ mod tests {
                     layout: "single".into(),
                     working_directory: "/".into(),
                     active: true,
+                    open: true,
                     panes: vec![WorkspacePane::Browser(BrowserPane {
                         pane_id: "p0".into(),
                         pane_index: 0,
@@ -915,6 +951,7 @@ mod tests {
                 layout: "single".into(),
                 working_directory: "/".into(),
                 active: true,
+                open: true,
                 panes: vec![WorkspacePane::Browser(BrowserPane {
                     pane_id: "p0".into(),
                     pane_index: 0,
@@ -970,6 +1007,7 @@ mod tests {
                 layout: "single".into(),
                 working_directory: "/".into(),
                 active: true,
+                open: true,
                 panes: vec![WorkspacePane::Shell(ShellPane {
                     pane_id: "p0".into(),
                     pane_index: 0,

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 3        | 0    | 2026-06-16   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 72       | 33   | 2026-06-18   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 67       | 27   | 2026-06-18   |

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-06-18
-ref_count: 33
+ref_count: 34
 ---
 
 # Testing Gaps
@@ -756,3 +756,19 @@ filesystem scope restrictions).
 - **Finding:** The test captured `window.requestAnimationFrame` callback in a local variable and invoked it once synchronously after `settle()`. In CI the effect that schedules the rAF loop could resolve after the single invocation, so `setBrowserPaneBounds` was never called and `waitFor` timed out.
 - **Fix:** Moved the callback invocation inside the `waitFor` poll so each retry ticks the latest captured animation-frame callback until the moved-bounds assertion passes.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 74. `findActiveStoreShell` open guard lacks coverage for active-but-closed session
+
+- **Source:** github-claude | PR #538 round 1 | 2026-06-18
+- **Severity:** MEDIUM
+- **File:** `src/features/sessions/hooks/useSessionRestore.ts` L47-49
+- **Finding:** The `!activeSession?.open` guard added to `findActiveStoreShell` prevents spawning a PTY when the persisted active session was already closed. Every existing restore test used `active: true, open: true`; the `active: true, open: false` branch that exercises the guard had no coverage, so dropping or inverting the condition would not fail any test.
+- **Fix:** Added a restore test with `active: true, open: false` in the store fixture, asserting `service.spawn` is never called and the persisted active session is still activated via `onActivePersisted`.
+
+### 75. `isOpenSession` unit tests omit explicit `open: false` cases
+
+- **Source:** github-claude | PR #538 round 1 | 2026-06-18
+- **Severity:** LOW
+- **File:** `src/features/sessions/utils/sessionStatus.test.ts` L90-110
+- **Finding:** The unit tests covered `open: true` (placeholder treated as open) and `open: undefined` (fallback to pane liveness), but not the explicit `open: false` path. Both `open: false, dead panes → false` and `open: false, live panes → true via hasLivePane` were untested, leaving the defensive fallback undocumented.
+- **Fix:** Added two focused tests: one asserting `isOpenSession({ open: false, panes: [completed] }) === false`, and one asserting `isOpenSession({ open: false, panes: [running] }) === true`.

--- a/electron/workspace-layout-controller.test.ts
+++ b/electron/workspace-layout-controller.test.ts
@@ -39,6 +39,7 @@ const sampleShape = (): PersistedWorkspaceShape => ({
       layout: 'vsplit',
       workingDirectory: '/repo',
       active: true,
+      open: true,
       panes: [
         {
           kind: 'shell',
@@ -65,6 +66,7 @@ const sampleStore = (): PersistedWorkspaceLayoutStore => ({
       layout: 'vsplit',
       workingDirectory: '/repo',
       active: true,
+      open: true,
       panes: [
         {
           kind: 'shell',
@@ -358,6 +360,7 @@ describe('WorkspaceLayoutController', () => {
             layout: 'vsplit',
             workingDirectory: '/repo',
             active: true,
+            open: true,
             panes: [
               {
                 kind: 'browser',
@@ -377,6 +380,7 @@ describe('WorkspaceLayoutController', () => {
             layout: 'vsplit',
             workingDirectory: '/repo',
             active: true,
+            open: true,
             panes: [
               {
                 kind: 'shell',

--- a/electron/workspace-layout-controller.ts
+++ b/electron/workspace-layout-controller.ts
@@ -72,6 +72,7 @@ const storeToShape = (
     layout: session.layout,
     workingDirectory: session.workingDirectory,
     active: session.active,
+    open: session.open,
     panes: session.panes.map(paneToShape),
   })),
 })
@@ -136,6 +137,7 @@ const isPersistedWorkspaceSessionShape = (
     typeof session.layout === 'string' &&
     typeof session.workingDirectory === 'string' &&
     typeof session.active === 'boolean' &&
+    typeof session.open === 'boolean' &&
     Array.isArray(session.panes) &&
     session.panes.every(isPersistedWorkspacePaneShape)
   )

--- a/electron/workspace-layout-roundtrip.test.ts
+++ b/electron/workspace-layout-roundtrip.test.ts
@@ -47,6 +47,7 @@ const roundTripShape = (): PersistedWorkspaceShape => ({
       layout: 'single',
       workingDirectory: '/repo',
       active: true,
+      open: true,
       panes: [{ kind: 'browser', paneId: 'p0', paneIndex: 0, active: true }],
     },
     {
@@ -55,6 +56,7 @@ const roundTripShape = (): PersistedWorkspaceShape => ({
       layout: 'vsplit',
       workingDirectory: '/repo',
       active: false,
+      open: true,
       panes: [
         {
           kind: 'shell',

--- a/electron/workspace-layout-types.ts
+++ b/electron/workspace-layout-types.ts
@@ -49,6 +49,7 @@ export interface PersistedWorkspaceSession {
   layout: string
   workingDirectory: string
   active: boolean
+  open: boolean
   panes: PersistedWorkspacePane[]
 }
 
@@ -87,6 +88,7 @@ export interface PersistedWorkspaceSessionShape {
   layout: string
   workingDirectory: string
   active: boolean
+  open: boolean
   panes: PersistedWorkspacePaneShape[]
 }
 

--- a/electron/workspace-layout-writer.test.ts
+++ b/electron/workspace-layout-writer.test.ts
@@ -16,6 +16,7 @@ const shape = (): PersistedWorkspaceShape => ({
       layout: 'vsplit',
       workingDirectory: '/repo',
       active: true,
+      open: true,
       panes: [
         {
           kind: 'shell',
@@ -80,6 +81,7 @@ describe('WorkspaceLayoutWriter', () => {
           layout: 'vsplit',
           workingDirectory: '/repo',
           active: true,
+          open: true,
           panes: [
             {
               kind: 'shell',

--- a/electron/workspace-layout-writer.ts
+++ b/electron/workspace-layout-writer.ts
@@ -167,6 +167,7 @@ export class WorkspaceLayoutWriter
         layout: session.layout,
         workingDirectory: session.workingDirectory,
         active: session.active,
+        open: session.open,
         panes,
       })
     }

--- a/src/features/sessions/components/List.test.tsx
+++ b/src/features/sessions/components/List.test.tsx
@@ -202,6 +202,29 @@ describe('List', () => {
     ).not.toBeInTheDocument()
   })
 
+  test('keeps lazy-restored open placeholders in Active', () => {
+    const restoredOpen: Session = {
+      ...mockSessions[2],
+      id: 'sess-restored-open',
+      name: 'resume after reopen',
+      open: true,
+    }
+
+    render(
+      <List
+        sessions={[restoredOpen]}
+        activeSessionId="sess-restored-open"
+        onSessionClick={mockOnSessionClick}
+      />
+    )
+
+    const activeList = screen.getByTestId('session-list')
+    expect(
+      within(activeList).getByText('resume after reopen')
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('session-group-recent')).not.toBeInTheDocument()
+  })
+
   test('renders empty state when no active sessions', () => {
     render(
       <List

--- a/src/features/sessions/components/List.tsx
+++ b/src/features/sessions/components/List.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion'
 import type { Session, SessionCloseResult } from '../types'
 import { Card } from './Card'
 import { Group } from './Group'
-import { hasLivePane } from '../utils/sessionStatus'
+import { isOpenSession } from '../utils/sessionStatus'
 import { pickNextVisibleSessionId } from '../utils/pickNextVisibleSessionId'
 import { mediateReorder } from '../utils/mediateReorder'
 
@@ -28,8 +28,8 @@ export const List = ({
   // in pickNextVisibleSessionId.ts. Recent = the complement so any
   // future non-open status (e.g. `suspended`) lands in Recent rather
   // than being silently dropped from both groups.
-  const activeGroup = sessions.filter((s) => hasLivePane(s.panes))
-  const recentGroup = sessions.filter((s) => !hasLivePane(s.panes))
+  const activeGroup = sessions.filter(isOpenSession)
+  const recentGroup = sessions.filter((s) => !isOpenSession(s))
 
   // Mirror `recentGroup` into a ref synchronously on every render so
   // Framer Motion's `onReorder` callback reads the current Recent section

--- a/src/features/sessions/components/Tab.tsx
+++ b/src/features/sessions/components/Tab.tsx
@@ -2,7 +2,7 @@ import { type ReactElement, type KeyboardEvent } from 'react'
 import type { Session } from '../types'
 import type { Agent } from '../../../agents/registry'
 import { AgentGlyph } from '@/components/AgentGlyph'
-import { hasLivePane } from '../utils/sessionStatus'
+import { isOpenSession } from '../utils/sessionStatus'
 import { IconButton } from '@/components/IconButton'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
 
@@ -62,7 +62,7 @@ export const Tab = ({
       id={`session-tab-${session.id}`}
       role="tab"
       aria-label={
-        !hasLivePane(session.panes) ? `${session.name} (ended)` : session.name
+        !isOpenSession(session) ? `${session.name} (ended)` : session.name
       }
       aria-selected={isActive}
       aria-controls={`session-panel-${session.id}`}

--- a/src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts
+++ b/src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts
@@ -87,6 +87,7 @@ describe('buildWorkspaceShape', () => {
           layout: 'vsplit',
           workingDirectory: '/repo',
           active: true,
+          open: true,
           panes: [
             {
               kind: 'shell',

--- a/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
+++ b/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
@@ -25,6 +25,7 @@ import {
   type PersistedWorkspacePaneShape,
 } from '../workspaceLayoutBridge'
 import { isShellPane } from '../utils/paneKind'
+import { isOpenSession } from '../utils/sessionStatus'
 import type { Session } from '../types'
 
 const log = createLogger('grouping')
@@ -57,6 +58,7 @@ export const buildWorkspaceShape = (
     layout: session.layout,
     workingDirectory: session.workingDirectory,
     active: session.id === activeSessionId,
+    open: isOpenSession(session),
     panes: session.panes.map(
       (pane, paneIndex): PersistedWorkspacePaneShape =>
         isShellPane(pane)
@@ -90,6 +92,7 @@ const structuralSignature = (shape: PersistedWorkspaceShape): string =>
       layout: session.layout,
       workingDirectory: session.workingDirectory,
       active: session.active,
+      open: session.open,
       panes: session.panes.map((pane) => ({
         kind: pane.kind,
         paneId: pane.paneId,

--- a/src/features/sessions/hooks/useSessionManager.test.ts
+++ b/src/features/sessions/hooks/useSessionManager.test.ts
@@ -1476,6 +1476,7 @@ describe('useSessionManager', () => {
           layout: 'single',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             { kind: 'browser', paneId: 'p0', paneIndex: 0, active: true },
           ],
@@ -1510,6 +1511,7 @@ describe('useSessionManager', () => {
           layout: 'single',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             {
               kind: 'shell',
@@ -1568,6 +1570,7 @@ describe('useSessionManager', () => {
           layout: 'single',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             {
               kind: 'shell',
@@ -1695,6 +1698,7 @@ describe('useSessionManager', () => {
           layout: 'single',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             { kind: 'browser', paneId: 'p0', paneIndex: 0, active: true },
           ],

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -33,6 +33,7 @@ import {
 } from '../utils/paneLifecycle'
 import {
   deriveShellSessionStatus,
+  hasLivePane,
   isLiveStatus,
   isTerminalStatus,
 } from '../utils/sessionStatus'
@@ -363,6 +364,7 @@ export const useSessionManager = (
           ...s,
           status: deriveShellSessionStatus(newPanes),
           agentType: activePane?.agentType ?? s.agentType,
+          open: hasLivePane(newPanes) ? s.open : false,
           panes: newPanes,
           lastActivityAt: exitedAt,
         }
@@ -396,6 +398,7 @@ export const useSessionManager = (
           ...s,
           status: deriveShellSessionStatus(newPanes),
           agentType: activePane?.agentType ?? s.agentType,
+          open: hasLivePane(newPanes) ? s.open : false,
           panes: newPanes,
           lastActivityAt: exitedAt,
         }

--- a/src/features/sessions/hooks/useSessionRestore.test.ts
+++ b/src/features/sessions/hooks/useSessionRestore.test.ts
@@ -476,6 +476,7 @@ describe('useSessionRestore', () => {
           layout: 'single',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             { kind: 'browser', paneId: 'p0', paneIndex: 0, active: true },
           ],
@@ -551,6 +552,7 @@ describe('useSessionRestore', () => {
           layout: 'single',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             {
               kind: 'shell',
@@ -635,6 +637,108 @@ describe('useSessionRestore', () => {
     expect(onActiveResolved).not.toHaveBeenCalled()
   })
 
+  test('keeps non-selected previously open shell workspaces open as lazy placeholders', async () => {
+    const store: PersistedWorkspaceShape = {
+      sessions: [
+        {
+          id: 'ws-selected',
+          projectId: 'proj-1',
+          layout: 'single',
+          workingDirectory: '/home/will/selected',
+          active: true,
+          open: true,
+          panes: [
+            {
+              kind: 'shell',
+              paneId: 'p0',
+              paneIndex: 0,
+              active: true,
+              ptyId: 'pty-selected-old',
+              cwd: '/home/will/selected',
+              agentType: 'codex',
+              agentSessionId: null,
+            },
+          ],
+        },
+        {
+          id: 'ws-background',
+          projectId: 'proj-1',
+          layout: 'single',
+          workingDirectory: '/home/will/background',
+          active: false,
+          open: true,
+          panes: [
+            {
+              kind: 'shell',
+              paneId: 'p0',
+              paneIndex: 0,
+              active: true,
+              ptyId: 'pty-background-old',
+              cwd: '/home/will/background',
+              agentType: 'claude-code',
+              agentSessionId: null,
+            },
+          ],
+        },
+      ],
+    }
+    loadWorkspaceForRestore.mockResolvedValue(store)
+
+    const service = {
+      onData: vi.fn().mockResolvedValue(() => undefined),
+      listSessions: vi
+        .fn()
+        .mockResolvedValue({ sessions: [], activeSessionId: null }),
+      spawn: vi.fn().mockResolvedValue({
+        sessionId: 'pty-selected-new',
+        pid: 4321,
+        cwd: '/home/will/selected',
+        shell: '/bin/zsh',
+      }),
+    } as unknown as ITerminalService
+    const onRestore = vi.fn<(sessions: Session[]) => void>()
+
+    const { result } = renderHook(() =>
+      useSessionRestore({
+        service,
+        buffer: buildBuffer(),
+        onRestore,
+        onActiveResolved: vi.fn(),
+        onActivePersisted: vi.fn(),
+      })
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(service.spawn).toHaveBeenCalledTimes(1)
+    const restoredSessions = onRestore.mock.calls[0]?.[0]
+    if (!restoredSessions) {
+      throw new Error('expected onRestore to be called')
+    }
+
+    expect(restoredSessions).toHaveLength(2)
+    expect(restoredSessions[0]).toEqual(
+      expect.objectContaining({
+        id: 'ws-selected',
+        open: true,
+        status: 'running',
+      })
+    )
+    expect(restoredSessions[1]).toEqual(
+      expect.objectContaining({
+        id: 'ws-background',
+        open: true,
+        status: 'completed',
+      })
+    )
+    expect(restoredSessions[1].panes[0]).toEqual(
+      expect.objectContaining({
+        ptyId: 'pty-background-old',
+        status: 'completed',
+      })
+    )
+  })
+
   test('resolves active session from the restarted PTY id when no persisted-active handler is registered', async () => {
     const store: PersistedWorkspaceShape = {
       sessions: [
@@ -644,6 +748,7 @@ describe('useSessionRestore', () => {
           layout: 'single',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             {
               kind: 'shell',
@@ -699,6 +804,7 @@ describe('useSessionRestore', () => {
           layout: 'single',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             {
               kind: 'shell',
@@ -767,6 +873,7 @@ describe('useSessionRestore', () => {
           layout: 'vsplit',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             {
               kind: 'shell',
@@ -838,6 +945,7 @@ describe('useSessionRestore', () => {
           layout: 'vsplit',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             { kind: 'browser', paneId: 'p0', paneIndex: 0, active: true },
             {
@@ -913,6 +1021,7 @@ describe('useSessionRestore', () => {
           layout: 'vsplit',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             { kind: 'browser', paneId: 'p0', paneIndex: 0, active: true },
             {
@@ -987,6 +1096,7 @@ describe('useSessionRestore', () => {
           layout: 'single',
           workingDirectory: '/home/will/proj',
           active: true,
+          open: true,
           panes: [
             {
               kind: 'shell',

--- a/src/features/sessions/hooks/useSessionRestore.test.ts
+++ b/src/features/sessions/hooks/useSessionRestore.test.ts
@@ -724,6 +724,7 @@ describe('useSessionRestore', () => {
         status: 'running',
       })
     )
+
     expect(restoredSessions[1]).toEqual(
       expect.objectContaining({
         id: 'ws-background',
@@ -731,12 +732,72 @@ describe('useSessionRestore', () => {
         status: 'completed',
       })
     )
+
     expect(restoredSessions[1].panes[0]).toEqual(
       expect.objectContaining({
         ptyId: 'pty-background-old',
         status: 'completed',
       })
     )
+  })
+
+  test('does not spawn a PTY for the persisted-active session when it is closed', async () => {
+    const store: PersistedWorkspaceShape = {
+      sessions: [
+        {
+          id: 'ws-closed',
+          projectId: 'proj-1',
+          layout: 'single',
+          workingDirectory: '/home/will/closed',
+          active: true,
+          open: false,
+          panes: [
+            {
+              kind: 'shell',
+              paneId: 'p0',
+              paneIndex: 0,
+              active: true,
+              ptyId: 'pty-closed-old',
+              cwd: '/home/will/closed',
+              agentType: 'generic',
+              agentSessionId: null,
+            },
+          ],
+        },
+      ],
+    }
+    loadWorkspaceForRestore.mockResolvedValue(store)
+
+    const service = {
+      onData: vi.fn().mockResolvedValue(() => undefined),
+      listSessions: vi
+        .fn()
+        .mockResolvedValue({ sessions: [], activeSessionId: null }),
+      spawn: vi.fn().mockResolvedValue({
+        sessionId: 'pty-new',
+        pid: 4321,
+        cwd: '/home/will/closed',
+        shell: '/bin/zsh',
+      }),
+    } as unknown as ITerminalService
+    const onRestore = vi.fn<(sessions: Session[]) => void>()
+    const onActivePersisted = vi.fn()
+
+    const { result } = renderHook(() =>
+      useSessionRestore({
+        service,
+        buffer: buildBuffer(),
+        onRestore,
+        onActiveResolved: vi.fn(),
+        onActivePersisted,
+      })
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(service.spawn).not.toHaveBeenCalled()
+    expect(onRestore).toHaveBeenCalled()
+    expect(onActivePersisted).toHaveBeenCalledWith('ws-closed')
   })
 
   test('resolves active session from the restarted PTY id when no persisted-active handler is registered', async () => {

--- a/src/features/sessions/hooks/useSessionRestore.ts
+++ b/src/features/sessions/hooks/useSessionRestore.ts
@@ -45,7 +45,7 @@ const findActiveStoreShell = (
   storeShape: PersistedWorkspaceShape | null
 ): StoreShellSelection | null => {
   const activeSession = storeShape?.sessions.find((session) => session.active)
-  if (!activeSession || !activeSession.open) {
+  if (!activeSession?.open) {
     return null
   }
 

--- a/src/features/sessions/hooks/useSessionRestore.ts
+++ b/src/features/sessions/hooks/useSessionRestore.ts
@@ -45,7 +45,7 @@ const findActiveStoreShell = (
   storeShape: PersistedWorkspaceShape | null
 ): StoreShellSelection | null => {
   const activeSession = storeShape?.sessions.find((session) => session.active)
-  if (!activeSession) {
+  if (!activeSession || !activeSession.open) {
     return null
   }
 

--- a/src/features/sessions/types/index.ts
+++ b/src/features/sessions/types/index.ts
@@ -104,6 +104,12 @@ export interface Session {
   id: string
   projectId: string
   name: string // user-assigned or derived from prompt
+  /**
+   * Sidebar Active-section membership. Undefined means derive from live panes
+   * for legacy/runtime sessions; restored lazy placeholders set this true even
+   * before their PTY is rehydrated.
+   */
+  open?: boolean
   status: SessionStatus
   /** Stable session/project cwd used as the baseline for new panes. */
   workingDirectory: string

--- a/src/features/sessions/utils/groupSessionsFromInfos.test.ts
+++ b/src/features/sessions/utils/groupSessionsFromInfos.test.ts
@@ -350,6 +350,7 @@ const storeSession = (
   layout: 'single',
   workingDirectory: '/home/will/repo',
   active: true,
+  open: true,
   panes: [shellShape({ active: true })],
   ...overrides,
 })
@@ -437,6 +438,29 @@ describe('reconstructWorkspace', () => {
     expect(pane.pid).toBeUndefined()
     expect(sessions[0].status).toBe('completed')
     expect(sessions[0].agentType).toBe('codex')
+  })
+
+  test('preserves store open state for lazy restored shell placeholders', () => {
+    const store = storeOf([
+      storeSession({
+        id: 'ws-open',
+        open: true,
+        panes: [shellShape({ ptyId: 'pty-open', active: true })],
+      }),
+      storeSession({
+        id: 'ws-recent',
+        active: false,
+        open: false,
+        panes: [shellShape({ ptyId: 'pty-recent', active: true })],
+      }),
+    ])
+
+    const sessions = reconstructWorkspace(store, [], null)
+
+    expect(sessions.map((session) => [session.id, session.open])).toEqual([
+      ['ws-open', true],
+      ['ws-recent', false],
+    ])
   })
 
   // A persisted `agentType: 'kimi'` must survive restore (not coerce to

--- a/src/features/sessions/utils/groupSessionsFromInfos.ts
+++ b/src/features/sessions/utils/groupSessionsFromInfos.ts
@@ -363,6 +363,7 @@ const buildStoreSession = (
     id: shape.id,
     projectId: shape.projectId,
     name: tabName(shape.workingDirectory, fallbackIndex),
+    open: shape.open,
     status: deriveShellSessionStatus(panes),
     workingDirectory: shape.workingDirectory,
     agentType: activePane.agentType,

--- a/src/features/sessions/utils/pickNextVisibleSessionId.ts
+++ b/src/features/sessions/utils/pickNextVisibleSessionId.ts
@@ -1,13 +1,12 @@
 import type { Session } from '../types'
-import { hasLivePane } from './sessionStatus'
+import { isOpenSession } from './sessionStatus'
 
 /**
  * Returns the sessions visible in the SessionTabs strip — sessions with a
- * live (running/awaiting/idle) pane plus the currently active one (so a
- * just-exited active session keeps its tab even after status flips to
- * completed/errored). Liveness is pane-level, not the errored-dominant
- * aggregate status, so a split session with one crashed pane and one live
- * pane stays visible. Single source of truth for "open" semantics; both
+ * open pane plus the currently active one (so a just-exited active session
+ * keeps its tab even after status flips to completed/errored). Open state is
+ * pane-level liveness plus restore-time lazy placeholders, not the
+ * errored-dominant aggregate status. Single source of truth for "open" semantics; both
  * `SessionTabs` and `pickNextVisibleSessionId` consume it so the visible-set
  * definition can never drift between render and close-fallback navigation.
  */
@@ -15,7 +14,7 @@ export const getVisibleSessions = (
   sessions: Session[],
   activeSessionId: string | null
 ): Session[] =>
-  sessions.filter((s) => hasLivePane(s.panes) || s.id === activeSessionId)
+  sessions.filter((s) => isOpenSession(s) || s.id === activeSessionId)
 
 /**
  * Pick the next visible session id when the user removes the currently

--- a/src/features/sessions/utils/sessionStatus.test.ts
+++ b/src/features/sessions/utils/sessionStatus.test.ts
@@ -4,8 +4,9 @@ import {
   deriveShellSessionStatus,
   isTerminalStatus,
   isLiveStatus,
+  isOpenSession,
 } from './sessionStatus'
-import type { Pane } from '../types'
+import type { Pane, Session } from '../types'
 
 const pane = (status: Pane['status']): Pane =>
   ({
@@ -84,4 +85,26 @@ test('deriveShellSessionStatus keeps completed shells completed when a browser r
 
 test('deriveShellSessionStatus treats browser-only sessions as idle', () => {
   expect(deriveShellSessionStatus([browserPane('running')])).toBe('idle')
+})
+
+test('isOpenSession treats restored open placeholders as open', () => {
+  expect(
+    isOpenSession({
+      open: true,
+      panes: [pane('completed')],
+    } satisfies Pick<Session, 'open' | 'panes'>)
+  ).toBe(true)
+})
+
+test('isOpenSession falls back to pane liveness when open is absent', () => {
+  expect(
+    isOpenSession({
+      panes: [pane('completed')],
+    } satisfies Pick<Session, 'open' | 'panes'>)
+  ).toBe(false)
+  expect(
+    isOpenSession({
+      panes: [pane('running')],
+    } satisfies Pick<Session, 'open' | 'panes'>)
+  ).toBe(true)
 })

--- a/src/features/sessions/utils/sessionStatus.test.ts
+++ b/src/features/sessions/utils/sessionStatus.test.ts
@@ -102,8 +102,27 @@ test('isOpenSession falls back to pane liveness when open is absent', () => {
       panes: [pane('completed')],
     } satisfies Pick<Session, 'open' | 'panes'>)
   ).toBe(false)
+
   expect(
     isOpenSession({
+      panes: [pane('running')],
+    } satisfies Pick<Session, 'open' | 'panes'>)
+  ).toBe(true)
+})
+
+test('isOpenSession treats explicit open:false as closed when panes are dead', () => {
+  expect(
+    isOpenSession({
+      open: false,
+      panes: [pane('completed')],
+    } satisfies Pick<Session, 'open' | 'panes'>)
+  ).toBe(false)
+})
+
+test('isOpenSession falls back to pane liveness when open:false but panes are live', () => {
+  expect(
+    isOpenSession({
+      open: false,
       panes: [pane('running')],
     } satisfies Pick<Session, 'open' | 'panes'>)
   ).toBe(true)

--- a/src/features/sessions/utils/sessionStatus.ts
+++ b/src/features/sessions/utils/sessionStatus.ts
@@ -1,4 +1,4 @@
-import type { Pane, SessionStatus } from '../types'
+import type { Pane, Session, SessionStatus } from '../types'
 import { isShellPane } from './paneKind'
 
 // precedence high → low; exhaustive Record — a new SessionStatus must be ranked
@@ -27,6 +27,10 @@ export const isLiveStatus = (s: SessionStatus): boolean => !TERMINAL[s]
 // errored-dominant (display), so check panes, not the rolled-up status.
 export const hasLivePane = (panes: Pane[]): boolean =>
   panes.some((pane) => isLiveStatus(pane.status))
+
+export const isOpenSession = (
+  session: Pick<Session, 'open' | 'panes'>
+): boolean => session.open === true || hasLivePane(session.panes)
 
 export const deriveSessionStatus = (panes: Pane[]): SessionStatus => {
   // empty panes is an invariant violation; flag it errored, not vacuously completed

--- a/src/features/sessions/workspaceLayoutBridge.ts
+++ b/src/features/sessions/workspaceLayoutBridge.ts
@@ -33,6 +33,7 @@ export interface PersistedWorkspaceSessionShape {
   layout: string
   workingDirectory: string
   active: boolean
+  open: boolean
   panes: PersistedWorkspacePaneShape[]
 }
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -84,7 +84,7 @@ import { isShellPane } from '../sessions/utils/paneKind'
 import { LAYOUTS, selectVisiblePanes } from '../terminal/components/SplitView'
 import { LAYOUT_IDS } from '../terminal/layout-registry'
 import { lineDelta } from '../sessions/utils/lineDelta'
-import { hasLivePane, isLiveStatus } from '../sessions/utils/sessionStatus'
+import { isLiveStatus, isOpenSession } from '../sessions/utils/sessionStatus'
 import { pickNextVisibleSessionId } from '../sessions/utils/pickNextVisibleSessionId'
 import { AGENTS, agentTypeToRegistryKey } from '../../agents/registry'
 import type { LayoutId, SessionCloseResult } from '../sessions/types'
@@ -743,7 +743,7 @@ const WorkspaceViewContent = (): ReactElement => {
   // effect is cheap even though it fires on every sessions array change.
   useEffect(() => {
     for (const session of sessions) {
-      if (hasLivePane(session.panes)) {
+      if (isOpenSession(session)) {
         continue
       }
       // Effect-path: skip silently on transient invariant violations


### PR DESCRIPTION
## Summary
- Persist session open state separately from the selected active session in the workspace layout store.
- Use open state for sidebar Active grouping and tab visibility so lazy-restored shell placeholders do not move to Recent after app restart.
- Keep ended sessions moving to Recent by clearing open once no live pane remains.

## Test plan
- [x] PATH=/Users/winoooops/projects/vimeflow/node_modules/.bin:$PATH npx vitest run src/features/sessions/utils/sessionStatus.test.ts src/features/sessions/components/List.test.tsx src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts src/features/sessions/hooks/useSessionRestore.test.ts src/features/sessions/hooks/useSessionManager.test.ts src/features/sessions/utils/groupSessionsFromInfos.test.ts electron/workspace-layout-writer.test.ts electron/workspace-layout-controller.test.ts electron/workspace-layout-roundtrip.test.ts
- [x] cargo test -p vimeflow workspace_layout -- --nocapture
- [x] PATH=/Users/winoooops/projects/vimeflow/node_modules/.bin:$PATH npm run type-check

Refs VIM-157