### PR TITLE
fix(settings): add search clear and arrow navigation

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 71       | 31   | 2026-06-16   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 26   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 69       | 23   | 2026-06-18   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 70       | 26   | 2026-06-19   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 22   | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 71       | 31   | 2026-06-16   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 26   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 70       | 26   | 2026-06-19   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 73       | 26   | 2026-06-19   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 22   | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |
@@ -76,7 +76,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 7    | 2026-06-15   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 18       | 3    | 2026-06-18   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 11       | 3    | 2026-06-12   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 29       | 5    | 2026-06-15   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 36       | 5    | 2026-06-19   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 9        | 4    | 2026-06-13   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 71       | 31   | 2026-06-16   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 26   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 73       | 26   | 2026-06-19   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 74       | 27   | 2026-06-19   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 22   | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-19
-ref_count: 26
+ref_count: 27
 ---
 
 # Accessibility
@@ -674,4 +674,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/settings/components/SettingsSidebar.tsx` L115-117
 - **Finding:** The search input was promoted to `role="combobox"` with `aria-controls="settings-search-results"`, but the referenced element was a `<nav>` whose implicit ARIA role is `navigation`. ARIA 1.2 requires a combobox's controlled popup to have role `listbox`, `tree`, `grid`, or `dialog`; with `navigation` as the popup role, screen readers that validate the popup role may ignore `aria-activedescendant` updates and leave the keyboard navigation workflow invisible to assistive technology.
 - **Fix:** Added `role="listbox"` to the search results `<nav>` and `role="option"` with `aria-selected` to each navigable section and target `<button>`. Updated co-located tests to query the listbox and option roles and assert `aria-selected` state.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 74. Enter on empty settings search confirms the first result instead of doing nothing
+
+- **Source:** github-codex-connector | PR #540 round 2 | 2026-06-19
+- **Severity:** LOW
+- **File:** `src/features/settings/SettingsDialog.tsx` L243-256
+- **Finding:** In `handleConfirmSearchResult`, when `activeSearchResultKey` is null the code always falls back to `searchResults[0]`. With an empty query, `searchResults` contains all settings sections, so pressing Enter while the empty search field is focused switches the user to General even when they were on another section. This is unexpected for keyboard users who merely press Enter in the empty search box.
+- **Fix:** Guarded the fallback so it only applies when `normalizedQuery` is non-empty; when the query is empty and no active search result exists, Enter is now a no-op. Added a co-located test asserting that pressing Enter in an empty search field preserves the current pane and focus.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -667,7 +667,6 @@ handlers must not trap focus without implementing the promised behavior.
 - **Fix:** Promoted the search input to `role="combobox"` with `aria-expanded`, `aria-autocomplete="list"`, `aria-controls`, and `aria-activedescendant` pointing at the active result. Gave every section and target result button a stable id so the active-descendant reference is valid. Added co-located tests asserting the combobox attributes and active-descendant targets.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
 
-
 ### 73. Combobox popup has role=navigation, not a valid ARIA popup role
 
 - **Source:** github-claude | PR #540 round 1 | 2026-06-19

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,8 +2,8 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-18
-ref_count: 25
+last_updated: 2026-06-19
+ref_count: 26
 ---
 
 # Accessibility
@@ -656,4 +656,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/settings/SettingsDialog.tsx` L174
 - **Finding:** When a keyboard user activated an option search result, the target row (marked `tabIndex={-1}`) received focus, but the dialog focus trap only indexed `[tabindex]:not([tabindex="-1"])`. The next Tab saw `currentIndex === -1` and jumped to the close button, so keyboard users could not continue from the search result they just opened.
 - **Fix:** Added `orderedFocusable(dialog)` to include the currently focused programmatic target row in the trap's ordering (sorted by DOM position), so Tab from a focused target moves to the next focusable control naturally. Added a co-located test asserting Tab from a focused search result lands on the setting control.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 72. Settings search arrow navigation lacks combobox active-descendant semantics
+
+- **Source:** github-claude | PR #540 round 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/SettingsSidebar.tsx` L65-74
+- **Finding:** The PR added ArrowUp/ArrowDown handling that changes the selected sidebar result while keyboard focus remains on the search input, but the input stayed a plain textbox. Screen-reader users had no reliable announcement of the active sidebar option when navigating results, so the new keyboard workflow was effectively invisible to assistive technology.
+- **Fix:** Promoted the search input to `role="combobox"` with `aria-expanded`, `aria-autocomplete="list"`, `aria-controls`, and `aria-activedescendant` pointing at the active result. Gave every section and target result button a stable id so the active-descendant reference is valid. Added co-located tests asserting the combobox attributes and active-descendant targets.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -666,3 +666,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The PR added ArrowUp/ArrowDown handling that changes the selected sidebar result while keyboard focus remains on the search input, but the input stayed a plain textbox. Screen-reader users had no reliable announcement of the active sidebar option when navigating results, so the new keyboard workflow was effectively invisible to assistive technology.
 - **Fix:** Promoted the search input to `role="combobox"` with `aria-expanded`, `aria-autocomplete="list"`, `aria-controls`, and `aria-activedescendant` pointing at the active result. Gave every section and target result button a stable id so the active-descendant reference is valid. Added co-located tests asserting the combobox attributes and active-descendant targets.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+
+### 73. Combobox popup has role=navigation, not a valid ARIA popup role
+
+- **Source:** github-claude | PR #540 round 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/SettingsSidebar.tsx` L115-117
+- **Finding:** The search input was promoted to `role="combobox"` with `aria-controls="settings-search-results"`, but the referenced element was a `<nav>` whose implicit ARIA role is `navigation`. ARIA 1.2 requires a combobox's controlled popup to have role `listbox`, `tree`, `grid`, or `dialog`; with `navigation` as the popup role, screen readers that validate the popup role may ignore `aria-activedescendant` updates and leave the keyboard navigation workflow invisible to assistive technology.
+- **Fix:** Added `role="listbox"` to the search results `<nav>` and `role="option"` with `aria-selected` to each navigable section and target `<button>`. Updated co-located tests to query the listbox and option roles and assert `aria-selected` state.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -2,7 +2,7 @@
 id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
-last_updated: 2026-06-17
+last_updated: 2026-06-19
 ref_count: 11
 ---
 
@@ -451,4 +451,14 @@ against three classes of false-fire:
 - **File:** `src/features/settings/hooks/useSettingsDialog.ts`
 - **Finding:** The settings shortcut matcher ignored modifier state beyond `metaKey`/`ctrlKey`. A user could record `Ctrl+Alt+Comma` (Linux/Windows) or `Cmd+Shift+Comma` (macOS) for a rebindable command, and the settings toggle would still fire because it did not reject `altKey` or `shiftKey`.
 - **Fix:** Added `!event.altKey && !event.shiftKey` to the platform-super matcher so only the bare `Cmd/Ctrl+Comma` chord toggles Settings. Added tests for `Ctrl+Alt+Comma` and `Cmd+Shift+Comma` to confirm they pass through.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+
+### 36. Bypass search shortcuts during IME composition
+
+- **Source:** github-codex-connector | PR #540 round 1 | 2026-06-19
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/components/SettingsSidebar.tsx` L43-43
+- **Finding:** The search input's ArrowDown/ArrowUp/Enter handlers always called `preventDefault()` and repurposed those keys for settings navigation. When a user types with a CJK/IME input method active, those same keys are used to choose or commit composition candidates, so the custom handlers interrupted composing text.
+- **Fix:** Added an early return in `handleSearchKeyDown` when `event.nativeEvent.isComposing` is true, before the Arrow/Enter branches. Added a co-located test firing composing keydown events to confirm navigation/confirmation callbacks are not invoked during composition.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -453,7 +453,6 @@ against three classes of false-fire:
 - **Fix:** Added `!event.altKey && !event.shiftKey` to the platform-super matcher so only the bare `Cmd/Ctrl+Comma` chord toggles Settings. Added tests for `Ctrl+Alt+Comma` and `Cmd+Shift+Comma` to confirm they pass through.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
 
-
 ### 36. Bypass search shortcuts during IME composition
 
 - **Source:** github-codex-connector | PR #540 round 1 | 2026-06-19

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -83,14 +83,14 @@ describe('SettingsDialog', () => {
     render(<SettingsDialog open onClose={vi.fn()} />)
 
     SETTINGS_SECTIONS.forEach((s) => {
-      expect(screen.getByRole('button', { name: s.label })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: s.label })).toBeInTheDocument()
     })
   })
 
   test('defaults to the appearance pane', () => {
     render(<SettingsDialog open onClose={vi.fn()} />)
 
-    expect(screen.getByRole('button', { name: 'Appearance' })).toHaveClass(
+    expect(screen.getByRole('option', { name: 'Appearance' })).toHaveClass(
       'text-primary'
     )
     expect(screen.getByText('Color Scheme')).toBeInTheDocument()
@@ -100,7 +100,7 @@ describe('SettingsDialog', () => {
     const user = userEvent.setup()
     render(<SettingsDialog open onClose={vi.fn()} />)
 
-    await user.click(screen.getByRole('button', { name: 'Keymap' }))
+    await user.click(screen.getByRole('option', { name: 'Keymap' }))
 
     expect(screen.getByText('Keyboard shortcuts')).toBeInTheDocument()
   })
@@ -111,8 +111,8 @@ describe('SettingsDialog', () => {
 
     await user.type(screen.getByPlaceholderText('Search settings...'), 'term')
 
-    expect(screen.getByRole('button', { name: 'Terminal' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'General' })).toBeNull()
+    expect(screen.getByRole('option', { name: 'Terminal' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'General' })).toBeNull()
   })
 
   test('clears search from the search field button', async () => {
@@ -124,7 +124,7 @@ describe('SettingsDialog', () => {
     await user.type(input, 'term')
 
     expect(input).toHaveValue('term')
-    expect(screen.queryByRole('button', { name: 'General' })).toBeNull()
+    expect(screen.queryByRole('option', { name: 'General' })).toBeNull()
 
     await user.click(
       screen.getByRole('button', { name: 'Clear settings search' })
@@ -132,7 +132,7 @@ describe('SettingsDialog', () => {
 
     expect(input).toHaveValue('')
     expect(input).toHaveFocus()
-    expect(screen.getByRole('button', { name: 'General' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'General' })).toBeInTheDocument()
   })
 
   test('navigates search result clicks to the matching settings row', async () => {
@@ -145,7 +145,7 @@ describe('SettingsDialog', () => {
 
     await user.type(screen.getByPlaceholderText('Search settings...'), 'redact')
     await user.click(
-      screen.getByRole('button', { name: 'Redact Private Values' })
+      screen.getByRole('option', { name: 'Redact Private Values' })
     )
 
     const target = screen.getByTestId(
@@ -157,7 +157,7 @@ describe('SettingsDialog', () => {
     })
 
     expect(
-      screen.getByRole('button', { name: 'General', current: 'page' })
+      screen.getByRole('option', { name: 'General', current: 'page' })
     ).toBeInTheDocument()
     expect(target).toHaveAttribute('data-settings-target-active', 'true')
     expect(scrollIntoView).toHaveBeenCalled()
@@ -188,7 +188,7 @@ describe('SettingsDialog', () => {
 
     expect(input).toHaveFocus()
     expect(
-      screen.getByRole('button', { name: 'General', current: 'page' })
+      screen.getByRole('option', { name: 'General', current: 'page' })
     ).toBeInTheDocument()
     expect(scrollIntoView).toHaveBeenCalled()
 
@@ -206,7 +206,7 @@ describe('SettingsDialog', () => {
 
     expect(input).toHaveFocus()
     expect(
-      screen.getByRole('button', { name: 'General', current: 'page' })
+      screen.getByRole('option', { name: 'General', current: 'page' })
     ).toBeInTheDocument()
   })
 
@@ -220,15 +220,15 @@ describe('SettingsDialog', () => {
     )
 
     expect(
-      screen.getByRole('button', { name: 'Open command palette' })
+      screen.getByRole('option', { name: 'Open command palette' })
     ).toBeInTheDocument()
 
     expect(
-      screen.getByRole('button', { name: 'Command palette leader' })
+      screen.getByRole('option', { name: 'Command palette leader' })
     ).toBeInTheDocument()
 
     await user.click(
-      screen.getByRole('button', { name: 'Command palette leader' })
+      screen.getByRole('option', { name: 'Command palette leader' })
     )
 
     const target = screen.getByTestId(
@@ -240,7 +240,7 @@ describe('SettingsDialog', () => {
     })
 
     expect(
-      screen.getByRole('button', { name: 'Keymap', current: 'page' })
+      screen.getByRole('option', { name: 'Keymap', current: 'page' })
     ).toBeInTheDocument()
     expect(target).toHaveAttribute('data-settings-target-active', 'true')
   })
@@ -251,7 +251,7 @@ describe('SettingsDialog', () => {
 
     await user.type(screen.getByPlaceholderText('Search settings...'), 'redact')
     await user.click(
-      screen.getByRole('button', { name: 'Redact Private Values' })
+      screen.getByRole('option', { name: 'Redact Private Values' })
     )
 
     const target = screen.getByTestId(
@@ -282,7 +282,7 @@ describe('SettingsDialog', () => {
     render(<SettingsDialog open onClose={vi.fn()} />)
 
     // Click a placeholder section (Terminal)
-    await user.click(screen.getByRole('button', { name: 'Terminal' }))
+    await user.click(screen.getByRole('option', { name: 'Terminal' }))
 
     // Type a query that filters Terminal out of the sidebar
     await user.type(
@@ -291,7 +291,7 @@ describe('SettingsDialog', () => {
     )
 
     // Terminal button should be gone from sidebar
-    expect(screen.queryByRole('button', { name: 'Terminal' })).toBeNull()
+    expect(screen.queryByRole('option', { name: 'Terminal' })).toBeNull()
 
     // But the placeholder pane for Terminal should still render
     expect(
@@ -326,7 +326,7 @@ describe('SettingsDialog', () => {
     const user = userEvent.setup()
     render(<DialogWithTrigger initialOpen />)
 
-    await user.click(screen.getByRole('button', { name: 'Keymap' }))
+    await user.click(screen.getByRole('option', { name: 'Keymap' }))
     await user.click(
       screen.getByRole('button', { name: 'Edit Focus pane 1 binding' })
     )
@@ -368,15 +368,15 @@ describe('SettingsDialog', () => {
 
     await user.type(screen.getByPlaceholderText('Search settings...'), 'term')
 
-    expect(screen.queryByRole('button', { name: 'General' })).toBeNull()
+    expect(screen.queryByRole('option', { name: 'General' })).toBeNull()
 
     await user.click(screen.getByRole('button', { name: 'Close' }))
     await user.click(trigger)
 
-    expect(screen.getByRole('button', { name: 'General' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'General' })).toBeInTheDocument()
 
     expect(
-      screen.getByRole('button', { name: 'Appearance' })
+      screen.getByRole('option', { name: 'Appearance' })
     ).toBeInTheDocument()
   })
 })

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -115,6 +115,26 @@ describe('SettingsDialog', () => {
     expect(screen.queryByRole('button', { name: 'General' })).toBeNull()
   })
 
+  test('clears search from the search field button', async () => {
+    const user = userEvent.setup()
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    const input = screen.getByPlaceholderText('Search settings...')
+
+    await user.type(input, 'term')
+
+    expect(input).toHaveValue('term')
+    expect(screen.queryByRole('button', { name: 'General' })).toBeNull()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Clear settings search' })
+    )
+
+    expect(input).toHaveValue('')
+    expect(input).toHaveFocus()
+    expect(screen.getByRole('button', { name: 'General' })).toBeInTheDocument()
+  })
+
   test('navigates search result clicks to the matching settings row', async () => {
     const user = userEvent.setup()
 
@@ -143,6 +163,51 @@ describe('SettingsDialog', () => {
     expect(scrollIntoView).toHaveBeenCalled()
 
     scrollIntoView.mockRestore()
+  })
+
+  test('navigates search results with arrow keys without leaving the search field', async () => {
+    const user = userEvent.setup()
+
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => undefined)
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    const input = screen.getByPlaceholderText('Search settings...')
+
+    await user.type(input, 'redact')
+    await user.keyboard('{ArrowDown}')
+
+    const target = screen.getByTestId(
+      `settings-target-${SETTINGS_TARGET_IDS.generalRedactPrivateValues}`
+    )
+
+    await waitFor(() => {
+      expect(target).toHaveAttribute('data-settings-target-active', 'true')
+    })
+
+    expect(input).toHaveFocus()
+    expect(
+      screen.getByRole('button', { name: 'General', current: 'page' })
+    ).toBeInTheDocument()
+    expect(scrollIntoView).toHaveBeenCalled()
+
+    scrollIntoView.mockRestore()
+  })
+
+  test('starts default arrow navigation at the first visible search result', async () => {
+    const user = userEvent.setup()
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    const input = screen.getByPlaceholderText('Search settings...')
+
+    await user.click(input)
+    await user.keyboard('{ArrowDown}')
+
+    expect(input).toHaveFocus()
+    expect(
+      screen.getByRole('button', { name: 'General', current: 'page' })
+    ).toBeInTheDocument()
   })
 
   test('keeps command palette and leader keymap targets independently navigable', async () => {

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -210,6 +210,21 @@ describe('SettingsDialog', () => {
     ).toBeInTheDocument()
   })
 
+  test('does not confirm a search result on Enter with an empty query and no selection', async () => {
+    const user = userEvent.setup()
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    const input = screen.getByPlaceholderText('Search settings...')
+
+    await user.click(input)
+    await user.keyboard('{Enter}')
+
+    expect(input).toHaveFocus()
+    expect(
+      screen.getByRole('option', { name: 'Appearance', current: 'page' })
+    ).toBeInTheDocument()
+  })
+
   test('keeps command palette and leader keymap targets independently navigable', async () => {
     const user = userEvent.setup()
     render(<SettingsDialog open onClose={vi.fn()} />)

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -2,6 +2,8 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef, useState, type ReactElement } from 'react'
 import type {
   SettingsDialogProps,
+  SettingsSearchNavigationDirection,
+  SettingsSection,
   SettingsSectionId,
   SettingsTarget,
   SettingsTargetId,
@@ -29,6 +31,20 @@ const matchesQuery = (
   value: string | undefined,
   normalizedQuery: string
 ): boolean => value?.toLowerCase().includes(normalizedQuery) ?? false
+
+type SettingsSearchResult =
+  | {
+      key: string
+      kind: 'section'
+      section: SettingsSection
+    }
+  | {
+      key: string
+      kind: 'target'
+      target: SettingsTarget
+    }
+
+type TargetFocusMode = 'focus-target' | 'preserve-search-focus'
 
 const FOCUSABLE_SELECTOR =
   'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
@@ -74,7 +90,15 @@ export const SettingsDialog = ({
   const [activeTargetId, setActiveTargetId] = useState<SettingsTargetId | null>(
     null
   )
+
+  const [selectedSearchResultKey, setSelectedSearchResultKey] = useState<
+    string | null
+  >(null)
+
   const [targetNavigationKey, setTargetNavigationKey] = useState(0)
+
+  const [targetFocusMode, setTargetFocusMode] =
+    useState<TargetFocusMode>('focus-target')
 
   const dialogRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
@@ -104,17 +128,131 @@ export const SettingsDialog = ({
     ? SETTINGS_SECTIONS.filter((s) => filteredSectionIds.has(s.id))
     : SETTINGS_SECTIONS
 
+  const sectionMatchIds = new Set<SettingsSectionId>(
+    sectionMatches.map((s) => s.id)
+  )
+
+  const searchResults = filtered.flatMap((s): SettingsSearchResult[] => {
+    const results: SettingsSearchResult[] = []
+
+    if (!normalizedQuery || sectionMatchIds.has(s.id)) {
+      results.push({
+        key: `section:${s.id}`,
+        kind: 'section',
+        section: s,
+      })
+    }
+
+    targetMatches
+      .filter((target) => target.section === s.id)
+      .forEach((target) => {
+        results.push({
+          key: `target:${target.id}`,
+          kind: 'target',
+          target,
+        })
+      })
+
+    return results
+  })
+
+  const activeSearchResultKey =
+    selectedSearchResultKey !== null &&
+    searchResults.some((result) => result.key === selectedSearchResultKey)
+      ? selectedSearchResultKey
+      : null
+
   const activeSection = SETTINGS_SECTIONS.find((s) => s.id === section)
 
   const handlePickSection = (id: SettingsSectionId): void => {
     setSection(id)
     setActiveTargetId(null)
+    setSelectedSearchResultKey(`section:${id}`)
   }
 
-  const handlePickTarget = (target: SettingsTarget): void => {
+  const handleQuery = (nextQuery: string): void => {
+    setQuery(nextQuery)
+    setActiveTargetId(null)
+    setSelectedSearchResultKey(null)
+  }
+
+  const handleClearQuery = (): void => {
+    setQuery('')
+    setActiveTargetId(null)
+    setSelectedSearchResultKey(null)
+    setTargetFocusMode('focus-target')
+  }
+
+  const applySearchResult = (
+    result: SettingsSearchResult,
+    focusMode: TargetFocusMode
+  ): void => {
+    setTargetFocusMode(focusMode)
+    setSelectedSearchResultKey(result.key)
+
+    if (result.kind === 'section') {
+      handlePickSection(result.section.id)
+
+      return
+    }
+
+    const { target } = result
     setSection(target.section)
     setActiveTargetId(target.id)
     setTargetNavigationKey((key) => key + 1)
+  }
+
+  const handlePickTarget = (target: SettingsTarget): void => {
+    applySearchResult(
+      {
+        key: `target:${target.id}`,
+        kind: 'target',
+        target,
+      },
+      'focus-target'
+    )
+  }
+
+  const handleNavigateSearchResult = (
+    direction: SettingsSearchNavigationDirection
+  ): void => {
+    if (searchResults.length === 0) {
+      return
+    }
+
+    const currentIndex =
+      activeSearchResultKey === null
+        ? -1
+        : searchResults.findIndex(
+            (result) => result.key === activeSearchResultKey
+          )
+    const delta = direction === 'next' ? 1 : -1
+    let nextIndex: number
+    if (currentIndex === -1) {
+      nextIndex = direction === 'next' ? 0 : searchResults.length - 1
+    } else {
+      nextIndex =
+        (currentIndex + delta + searchResults.length) % searchResults.length
+    }
+
+    const nextResult = searchResults[nextIndex]
+
+    applySearchResult(nextResult, 'preserve-search-focus')
+  }
+
+  const handleConfirmSearchResult = (): void => {
+    if (searchResults.length === 0) {
+      return
+    }
+
+    const currentResult =
+      activeSearchResultKey === null
+        ? undefined
+        : searchResults.find((result) => result.key === activeSearchResultKey)
+
+    const resultToConfirm = currentResult ?? searchResults[0]
+
+    applySearchResult(resultToConfirm, 'focus-target')
   }
 
   useEffect(() => {
@@ -180,6 +318,7 @@ export const SettingsDialog = ({
     if (!open) {
       setQuery('')
       setActiveTargetId(null)
+      setSelectedSearchResultKey(null)
     }
   }, [open])
 
@@ -197,8 +336,10 @@ export const SettingsDialog = ({
     }
 
     target.scrollIntoView({ block: 'center', behavior: 'smooth' })
-    target.focus({ preventScroll: true })
-  }, [activeTargetId, open, section, targetNavigationKey])
+    if (targetFocusMode === 'focus-target') {
+      target.focus({ preventScroll: true })
+    }
+  }, [activeTargetId, open, section, targetFocusMode, targetNavigationKey])
 
   return (
     <AnimatePresence>
@@ -255,8 +396,11 @@ export const SettingsDialog = ({
                 activeTargetId={activeTargetId}
                 onPick={handlePickSection}
                 onPickTarget={handlePickTarget}
+                onClearQuery={handleClearQuery}
+                onNavigateSearchResult={handleNavigateSearchResult}
+                onConfirmSearchResult={handleConfirmSearchResult}
                 query={query}
-                onQuery={setQuery}
+                onQuery={handleQuery}
               />
 
               <div className="flex min-w-0 flex-1 flex-col">

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -250,7 +250,12 @@ export const SettingsDialog = ({
         ? undefined
         : searchResults.find((result) => result.key === activeSearchResultKey)
 
-    const resultToConfirm = currentResult ?? searchResults[0]
+    const resultToConfirm =
+      currentResult ?? (normalizedQuery ? searchResults[0] : undefined)
+
+    if (!resultToConfirm) {
+      return
+    }
 
     applySearchResult(resultToConfirm, 'focus-target')
   }

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -59,7 +59,10 @@ describe('SettingsSidebar', () => {
 
     expect(
       screen.getByRole('combobox', { name: 'Search settings' })
-    ).toHaveAttribute('aria-activedescendant', 'settings-search-result-section-keymap')
+    ).toHaveAttribute(
+      'aria-activedescendant',
+      'settings-search-result-section-keymap'
+    )
   })
 
   test('points aria-activedescendant at the active target result', () => {

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -1,6 +1,6 @@
 import { useState, type ReactElement } from 'react'
 import { describe, expect, test, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   SETTINGS_SECTIONS,
@@ -86,11 +86,20 @@ describe('SettingsSidebar', () => {
     )
   })
 
-  test('renders all section buttons', () => {
+  test('renders the result list as a listbox', () => {
+    render(<SettingsSidebar {...baseProps} />)
+
+    expect(screen.getByRole('listbox')).toHaveAttribute(
+      'id',
+      'settings-search-results'
+    )
+  })
+
+  test('renders all section options', () => {
     render(<SettingsSidebar {...baseProps} />)
 
     SETTINGS_SECTIONS.forEach((s) => {
-      expect(screen.getByRole('button', { name: s.label })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: s.label })).toBeInTheDocument()
     })
   })
 
@@ -152,12 +161,33 @@ describe('SettingsSidebar', () => {
     expect(onConfirmSearchResult).toHaveBeenCalledTimes(1)
   })
 
-  test('calls onPick with the section id when a button is clicked', async () => {
+  test('bypasses search shortcuts while IME composition is active', () => {
+    const onNavigateSearchResult = vi.fn()
+    const onConfirmSearchResult = vi.fn()
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        query="redact"
+        onNavigateSearchResult={onNavigateSearchResult}
+        onConfirmSearchResult={onConfirmSearchResult}
+      />
+    )
+
+    const input = screen.getByRole('combobox', { name: 'Search settings' })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown', isComposing: true })
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
+
+    expect(onNavigateSearchResult).not.toHaveBeenCalled()
+    expect(onConfirmSearchResult).not.toHaveBeenCalled()
+  })
+
+  test('calls onPick with the section id when an option is clicked', async () => {
     const user = userEvent.setup()
     const onPick = vi.fn()
     render(<SettingsSidebar {...baseProps} onPick={onPick} />)
 
-    await user.click(screen.getByRole('button', { name: 'Keymap' }))
+    await user.click(screen.getByRole('option', { name: 'Keymap' }))
 
     expect(onPick).toHaveBeenCalledWith('keymap')
   })
@@ -165,20 +195,25 @@ describe('SettingsSidebar', () => {
   test('marks the active section with primary text', () => {
     render(<SettingsSidebar {...baseProps} />)
 
-    expect(screen.getByRole('button', { name: 'Appearance' })).toHaveClass(
+    expect(screen.getByRole('option', { name: 'Appearance' })).toHaveClass(
       'text-primary'
     )
   })
 
-  test('marks the active section with aria-current', () => {
+  test('marks the active section with aria-current and aria-selected', () => {
     render(<SettingsSidebar {...baseProps} />)
 
     expect(
-      screen.getByRole('button', { name: 'Appearance', current: 'page' })
-    ).toBeInTheDocument()
+      screen.getByRole('option', { name: 'Appearance', current: 'page' })
+    ).toHaveAttribute('aria-selected', 'true')
 
-    expect(screen.getByRole('button', { name: 'Keymap' })).not.toHaveAttribute(
+    expect(screen.getByRole('option', { name: 'Keymap' })).not.toHaveAttribute(
       'aria-current'
+    )
+
+    expect(screen.getByRole('option', { name: 'Keymap' })).toHaveAttribute(
+      'aria-selected',
+      'false'
     )
   })
 
@@ -194,7 +229,7 @@ describe('SettingsSidebar', () => {
     )
 
     expect(
-      screen.getByRole('button', { name: 'Redact Private Values' })
+      screen.getByRole('option', { name: 'Redact Private Values' })
     ).toBeInTheDocument()
   })
 
@@ -213,13 +248,13 @@ describe('SettingsSidebar', () => {
     )
 
     await user.click(
-      screen.getByRole('button', { name: 'Redact Private Values' })
+      screen.getByRole('option', { name: 'Redact Private Values' })
     )
 
     expect(onPickTarget).toHaveBeenCalledWith(redactTarget)
   })
 
-  test('marks the active option target with aria-current', () => {
+  test('marks the active option target with aria-current and aria-selected', () => {
     render(
       <SettingsSidebar
         {...baseProps}
@@ -232,10 +267,10 @@ describe('SettingsSidebar', () => {
     )
 
     expect(
-      screen.getByRole('button', {
+      screen.getByRole('option', {
         name: 'Redact Private Values',
         current: 'location',
       })
-    ).toBeInTheDocument()
+    ).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -36,12 +36,51 @@ describe('SettingsSidebar', () => {
     onQuery: vi.fn(),
   }
 
-  test('renders the search input with accessible name', () => {
+  test('renders the search input as a combobox with accessible name', () => {
     render(<SettingsSidebar {...baseProps} />)
 
     expect(
-      screen.getByRole('textbox', { name: 'Search settings' })
+      screen.getByRole('combobox', { name: 'Search settings' })
     ).toBeInTheDocument()
+  })
+
+  test('exposes combobox list semantics on the search input', () => {
+    render(<SettingsSidebar {...baseProps} />)
+
+    const input = screen.getByRole('combobox', { name: 'Search settings' })
+
+    expect(input).toHaveAttribute('aria-autocomplete', 'list')
+    expect(input).toHaveAttribute('aria-controls', 'settings-search-results')
+    expect(input).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  test('points aria-activedescendant at the active section result', () => {
+    render(<SettingsSidebar {...baseProps} active="keymap" />)
+
+    expect(
+      screen.getByRole('combobox', { name: 'Search settings' })
+    ).toHaveAttribute('aria-activedescendant', 'settings-search-result-section-keymap')
+  })
+
+  test('points aria-activedescendant at the active target result', () => {
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        sections={SETTINGS_SECTIONS.filter(
+          (section) => section.id === 'general'
+        )}
+        targets={[redactTarget]}
+        active="general"
+        activeTargetId={redactTarget.id}
+      />
+    )
+
+    expect(
+      screen.getByRole('combobox', { name: 'Search settings' })
+    ).toHaveAttribute(
+      'aria-activedescendant',
+      `settings-search-result-target-${redactTarget.id}`
+    )
   })
 
   test('renders all section buttons', () => {
@@ -102,7 +141,7 @@ describe('SettingsSidebar', () => {
       />
     )
 
-    await user.click(screen.getByRole('textbox', { name: 'Search settings' }))
+    await user.click(screen.getByRole('combobox', { name: 'Search settings' }))
     await user.keyboard('{ArrowDown}{ArrowUp}{Enter}')
 
     expect(onNavigateSearchResult).toHaveBeenNthCalledWith(1, 'next')

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -63,6 +63,53 @@ describe('SettingsSidebar', () => {
     )
   })
 
+  test('renders a clear search button when the query has text', async () => {
+    const user = userEvent.setup()
+    const onClearQuery = vi.fn()
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        query="term"
+        onClearQuery={onClearQuery}
+      />
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Clear settings search' })
+    )
+
+    expect(onClearQuery).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not render the clear search button when the query is empty', () => {
+    render(<SettingsSidebar {...baseProps} />)
+
+    expect(
+      screen.queryByRole('button', { name: 'Clear settings search' })
+    ).not.toBeInTheDocument()
+  })
+
+  test('forwards search result keyboard navigation', async () => {
+    const user = userEvent.setup()
+    const onNavigateSearchResult = vi.fn()
+    const onConfirmSearchResult = vi.fn()
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        query="redact"
+        onNavigateSearchResult={onNavigateSearchResult}
+        onConfirmSearchResult={onConfirmSearchResult}
+      />
+    )
+
+    await user.click(screen.getByRole('textbox', { name: 'Search settings' }))
+    await user.keyboard('{ArrowDown}{ArrowUp}{Enter}')
+
+    expect(onNavigateSearchResult).toHaveBeenNthCalledWith(1, 'next')
+    expect(onNavigateSearchResult).toHaveBeenNthCalledWith(2, 'previous')
+    expect(onConfirmSearchResult).toHaveBeenCalledTimes(1)
+  })
+
   test('calls onPick with the section id when a button is clicked', async () => {
     const user = userEvent.setup()
     const onPick = vi.fn()

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -2,9 +2,19 @@ import { useRef, type KeyboardEvent, type ReactElement } from 'react'
 import { Tooltip } from '@/components/Tooltip'
 import type {
   SettingsSearchNavigationDirection,
+  SettingsSectionId,
   SettingsSidebarProps,
+  SettingsTargetId,
 } from '../types'
 import { Icon } from './Icon'
+
+const SEARCH_RESULTS_ID = 'settings-search-results'
+
+const sectionResultId = (id: SettingsSectionId): string =>
+  `settings-search-result-section-${id}`
+
+const targetResultId = (id: SettingsTargetId): string =>
+  `settings-search-result-target-${id}`
 
 export const SettingsSidebar = ({
   sections,
@@ -20,6 +30,16 @@ export const SettingsSidebar = ({
   onQuery,
 }: SettingsSidebarProps): ReactElement => {
   const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const activeResultId =
+    activeTargetId !== null &&
+    targets.some((target) => target.id === activeTargetId)
+      ? targetResultId(activeTargetId)
+      : sections.some((section) => section.id === active)
+        ? sectionResultId(active)
+        : undefined
+
+  const hasResults = sections.length > 0 || targets.length > 0
 
   const handleClearQuery = (): void => {
     onClearQuery()
@@ -70,6 +90,11 @@ export const SettingsSidebar = ({
             onKeyDown={handleSearchKeyDown}
             placeholder="Search settings..."
             aria-label="Search settings"
+            role="combobox"
+            aria-expanded={hasResults}
+            aria-autocomplete="list"
+            aria-controls={SEARCH_RESULTS_ID}
+            aria-activedescendant={activeResultId}
             className="min-w-0 flex-1 border-none bg-transparent font-body text-xs text-on-surface outline-none placeholder:text-on-surface-muted"
           />
           {query.trim() !== '' && (
@@ -87,7 +112,10 @@ export const SettingsSidebar = ({
         </div>
       </div>
 
-      <nav className="thin-scrollbar flex-1 overflow-auto px-2 pb-3.5">
+      <nav
+        id={SEARCH_RESULTS_ID}
+        className="thin-scrollbar flex-1 overflow-auto px-2 pb-3.5"
+      >
         {sections.map((s) => {
           const isActive = s.id === active
 
@@ -98,6 +126,7 @@ export const SettingsSidebar = ({
           return (
             <div key={s.id} className="mb-px">
               <button
+                id={sectionResultId(s.id)}
                 type="button"
                 aria-current={isActive ? 'page' : undefined}
                 onClick={() => onPick(s.id)}
@@ -129,6 +158,7 @@ export const SettingsSidebar = ({
 
                     return (
                       <button
+                        id={targetResultId(target.id)}
                         key={target.id}
                         type="button"
                         aria-current={isTargetActive ? 'location' : undefined}

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -58,6 +58,10 @@ export const SettingsSidebar = ({
   const handleSearchKeyDown = (
     event: KeyboardEvent<HTMLInputElement>
   ): void => {
+    if (event.nativeEvent.isComposing) {
+      return
+    }
+
     if (event.key === 'ArrowDown') {
       handleNavigate(event, 'next')
 
@@ -114,6 +118,7 @@ export const SettingsSidebar = ({
 
       <nav
         id={SEARCH_RESULTS_ID}
+        role="listbox"
         className="thin-scrollbar flex-1 overflow-auto px-2 pb-3.5"
       >
         {sections.map((s) => {
@@ -128,6 +133,8 @@ export const SettingsSidebar = ({
               <button
                 id={sectionResultId(s.id)}
                 type="button"
+                role="option"
+                aria-selected={isActive}
                 aria-current={isActive ? 'page' : undefined}
                 onClick={() => onPick(s.id)}
                 className={`relative flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left font-body text-[13px] transition-colors ${
@@ -161,6 +168,8 @@ export const SettingsSidebar = ({
                         id={targetResultId(target.id)}
                         key={target.id}
                         type="button"
+                        role="option"
+                        aria-selected={isTargetActive}
                         aria-current={isTargetActive ? 'location' : undefined}
                         onClick={() => onPickTarget(target)}
                         className={`flex w-full items-center gap-1.5 rounded-md border-none px-2 py-1.5 text-left font-body text-[12px] transition-colors ${

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -1,5 +1,9 @@
-import type { ReactElement } from 'react'
-import type { SettingsSidebarProps } from '../types'
+import { useRef, type KeyboardEvent, type ReactElement } from 'react'
+import { Tooltip } from '@/components/Tooltip'
+import type {
+  SettingsSearchNavigationDirection,
+  SettingsSidebarProps,
+} from '../types'
 import { Icon } from './Icon'
 
 export const SettingsSidebar = ({
@@ -9,92 +13,151 @@ export const SettingsSidebar = ({
   activeTargetId = null,
   onPick,
   onPickTarget = (): void => undefined,
+  onClearQuery = (): void => undefined,
+  onNavigateSearchResult = (): void => undefined,
+  onConfirmSearchResult = (): void => undefined,
   query,
   onQuery,
-}: SettingsSidebarProps): ReactElement => (
-  <aside className="flex w-[220px] shrink-0 flex-col border-r border-outline-variant/25 bg-surface-container">
-    <div className="px-3 pt-3.5 pb-2.5">
-      <div className="flex items-center gap-2 rounded-lg border border-outline-variant/35 bg-surface-container-lowest/60 px-2.5 py-2">
-        <Icon name="search" size={13} className="text-on-surface-muted" />
-        <input
-          type="text"
-          value={query}
-          onChange={(e) => onQuery(e.target.value)}
-          placeholder="Search settings..."
-          aria-label="Search settings"
-          className="min-w-0 flex-1 border-none bg-transparent font-body text-xs text-on-surface outline-none placeholder:text-on-surface-muted"
-        />
+}: SettingsSidebarProps): ReactElement => {
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const handleClearQuery = (): void => {
+    onClearQuery()
+    searchInputRef.current?.focus()
+  }
+
+  const handleNavigate = (
+    event: KeyboardEvent<HTMLInputElement>,
+    direction: SettingsSearchNavigationDirection
+  ): void => {
+    event.preventDefault()
+    event.stopPropagation()
+    onNavigateSearchResult(direction)
+  }
+
+  const handleSearchKeyDown = (
+    event: KeyboardEvent<HTMLInputElement>
+  ): void => {
+    if (event.key === 'ArrowDown') {
+      handleNavigate(event, 'next')
+
+      return
+    }
+
+    if (event.key === 'ArrowUp') {
+      handleNavigate(event, 'previous')
+
+      return
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      event.stopPropagation()
+      onConfirmSearchResult()
+    }
+  }
+
+  return (
+    <aside className="flex w-[220px] shrink-0 flex-col border-r border-outline-variant/25 bg-surface-container">
+      <div className="px-3 pt-3.5 pb-2.5">
+        <div className="flex items-center gap-2 rounded-lg border border-outline-variant/35 bg-surface-container-lowest/60 px-2.5 py-2">
+          <Icon name="search" size={13} className="text-on-surface-muted" />
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={query}
+            onChange={(e) => onQuery(e.target.value)}
+            onKeyDown={handleSearchKeyDown}
+            placeholder="Search settings..."
+            aria-label="Search settings"
+            className="min-w-0 flex-1 border-none bg-transparent font-body text-xs text-on-surface outline-none placeholder:text-on-surface-muted"
+          />
+          {query.trim() !== '' && (
+            <Tooltip content="Clear search">
+              <button
+                type="button"
+                aria-label="Clear settings search"
+                onClick={handleClearQuery}
+                className="grid h-5 w-5 shrink-0 place-items-center rounded border-none bg-transparent text-on-surface-muted transition-colors hover:bg-on-surface/[0.04] hover:text-on-surface"
+              >
+                <Icon name="close" size={12} />
+              </button>
+            </Tooltip>
+          )}
+        </div>
       </div>
-    </div>
 
-    <nav className="thin-scrollbar flex-1 overflow-auto px-2 pb-3.5">
-      {sections.map((s) => {
-        const isActive = s.id === active
+      <nav className="thin-scrollbar flex-1 overflow-auto px-2 pb-3.5">
+        {sections.map((s) => {
+          const isActive = s.id === active
 
-        const sectionTargets = targets.filter(
-          (target) => target.section === s.id
-        )
+          const sectionTargets = targets.filter(
+            (target) => target.section === s.id
+          )
 
-        return (
-          <div key={s.id} className="mb-px">
-            <button
-              type="button"
-              aria-current={isActive ? 'page' : undefined}
-              onClick={() => onPick(s.id)}
-              className={`relative flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left font-body text-[13px] transition-colors ${
-                isActive
-                  ? 'bg-primary-container/10 text-primary'
-                  : 'bg-transparent text-on-surface-variant hover:bg-on-surface/[0.03]'
-              }`}
-            >
-              {isActive && (
-                <span className="absolute -left-0.5 top-2 bottom-2 w-0.5 rounded-sm bg-primary-container" />
-              )}
-              <Icon
-                name="chevron_right"
-                size={13}
-                className={
-                  isActive ? 'text-primary-container' : 'text-on-surface-muted'
-                }
-              />
-              {s.label}
-            </button>
+          return (
+            <div key={s.id} className="mb-px">
+              <button
+                type="button"
+                aria-current={isActive ? 'page' : undefined}
+                onClick={() => onPick(s.id)}
+                className={`relative flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left font-body text-[13px] transition-colors ${
+                  isActive
+                    ? 'bg-primary-container/10 text-primary'
+                    : 'bg-transparent text-on-surface-variant hover:bg-on-surface/[0.03]'
+                }`}
+              >
+                {isActive && (
+                  <span className="absolute -left-0.5 top-2 bottom-2 w-0.5 rounded-sm bg-primary-container" />
+                )}
+                <Icon
+                  name="chevron_right"
+                  size={13}
+                  className={
+                    isActive
+                      ? 'text-primary-container'
+                      : 'text-on-surface-muted'
+                  }
+                />
+                {s.label}
+              </button>
 
-            {sectionTargets.length > 0 && (
-              <div className="mt-0.5 mb-1 space-y-px pl-5">
-                {sectionTargets.map((target) => {
-                  const isTargetActive = target.id === activeTargetId
+              {sectionTargets.length > 0 && (
+                <div className="mt-0.5 mb-1 space-y-px pl-5">
+                  {sectionTargets.map((target) => {
+                    const isTargetActive = target.id === activeTargetId
 
-                  return (
-                    <button
-                      key={target.id}
-                      type="button"
-                      aria-current={isTargetActive ? 'location' : undefined}
-                      onClick={() => onPickTarget(target)}
-                      className={`flex w-full items-center gap-1.5 rounded-md border-none px-2 py-1.5 text-left font-body text-[12px] transition-colors ${
-                        isTargetActive
-                          ? 'bg-primary-container/[0.08] text-primary'
-                          : 'bg-transparent text-on-surface-muted hover:bg-on-surface/[0.03] hover:text-on-surface-variant'
-                      }`}
-                    >
-                      <Icon
-                        name="subdirectory_arrow_right"
-                        size={12}
-                        className={
+                    return (
+                      <button
+                        key={target.id}
+                        type="button"
+                        aria-current={isTargetActive ? 'location' : undefined}
+                        onClick={() => onPickTarget(target)}
+                        className={`flex w-full items-center gap-1.5 rounded-md border-none px-2 py-1.5 text-left font-body text-[12px] transition-colors ${
                           isTargetActive
-                            ? 'text-primary-container'
-                            : 'text-on-surface-muted'
-                        }
-                      />
-                      <span className="min-w-0 truncate">{target.label}</span>
-                    </button>
-                  )
-                })}
-              </div>
-            )}
-          </div>
-        )
-      })}
-    </nav>
-  </aside>
-)
+                            ? 'bg-primary-container/[0.08] text-primary'
+                            : 'bg-transparent text-on-surface-muted hover:bg-on-surface/[0.03] hover:text-on-surface-variant'
+                        }`}
+                      >
+                        <Icon
+                          name="subdirectory_arrow_right"
+                          size={12}
+                          className={
+                            isTargetActive
+                              ? 'text-primary-container'
+                              : 'text-on-surface-muted'
+                          }
+                        />
+                        <span className="min-w-0 truncate">{target.label}</span>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </nav>
+    </aside>
+  )
+}

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -32,6 +32,8 @@ export interface SettingsTarget {
   hint?: string
 }
 
+export type SettingsSearchNavigationDirection = 'next' | 'previous'
+
 export interface SettingsDialogProps {
   open: boolean
   onClose: () => void
@@ -44,6 +46,11 @@ export interface SettingsSidebarProps {
   activeTargetId?: SettingsTargetId | null
   onPick: (id: SettingsSectionId) => void
   onPickTarget?: (target: SettingsTarget) => void
+  onClearQuery?: () => void
+  onNavigateSearchResult?: (
+    direction: SettingsSearchNavigationDirection
+  ) => void
+  onConfirmSearchResult?: () => void
   query: string
   onQuery: (query: string) => void
 }


### PR DESCRIPTION
## Summary

- Add an `x` clear control inside the Settings search field.
- Keep focus in the search field after clearing.
- Make ArrowUp and ArrowDown cycle through visible Settings search results.
- Keep arrow navigation from bubbling into the dialog focus trap.
- Make Enter focus the selected result while preserving click-to-focus behavior for option rows.

## Context

Follow-up to VIM-146 / PR #537 after the initial option-row navigation landed.

## Validation

- `npm run lint`
- `npm run type-check:generated`
- `npm test -- --run`
- `npm test -- --run src/features/settings/SettingsDialog.test.tsx src/features/settings/components/SettingsSidebar.test.tsx src/features/settings/components/controls.test.tsx src/features/settings/sections.test.ts`