### PR TITLE
feat(terminal): enable Ghostty byte PTY events

### DIFF
--- a/crates/backend/src/terminal/bytes.rs
+++ b/crates/backend/src/terminal/bytes.rs
@@ -1,5 +1,7 @@
 const BASE64_TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 const PTY_BYTES_BASE64_ENV: &str = "VIMEFLOW_EXPERIMENTAL_PTY_BYTES_BASE64";
+const TERMINAL_RENDERER_ENV: &str = "VITE_TERMINAL_RENDERER";
+const GHOSTTY_RENDERER_ID: &str = "ghostty";
 
 fn is_truthy_flag(value: &str) -> bool {
     matches!(
@@ -9,9 +11,22 @@ fn is_truthy_flag(value: &str) -> bool {
 }
 
 pub(crate) fn should_emit_bytes_base64() -> bool {
-    std::env::var(PTY_BYTES_BASE64_ENV)
-        .map(|value| is_truthy_flag(&value))
-        .unwrap_or(false)
+    should_emit_bytes_base64_for_env(
+        std::env::var(PTY_BYTES_BASE64_ENV).ok().as_deref(),
+        std::env::var(TERMINAL_RENDERER_ENV).ok().as_deref(),
+    )
+}
+
+fn is_ghostty_renderer(value: &str) -> bool {
+    value.trim() == GHOSTTY_RENDERER_ID
+}
+
+fn should_emit_bytes_base64_for_env(
+    explicit_flag: Option<&str>,
+    terminal_renderer: Option<&str>,
+) -> bool {
+    explicit_flag.map(is_truthy_flag).unwrap_or(false)
+        || terminal_renderer.map(is_ghostty_renderer).unwrap_or(false)
 }
 
 pub(crate) fn encode_base64(bytes: &[u8]) -> String {
@@ -43,7 +58,7 @@ pub(crate) fn encode_base64(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::encode_base64;
+    use super::{encode_base64, should_emit_bytes_base64_for_env};
 
     #[test]
     fn encodes_empty_input() {
@@ -81,5 +96,32 @@ mod tests {
         assert!(!super::is_truthy_flag("0"));
         assert!(!super::is_truthy_flag("false"));
         assert!(!super::is_truthy_flag("disabled"));
+    }
+
+    #[test]
+    fn enables_byte_payloads_when_explicit_flag_is_truthy() {
+        assert!(should_emit_bytes_base64_for_env(Some("1"), None));
+        assert!(should_emit_bytes_base64_for_env(
+            Some("true"),
+            Some("xterm")
+        ));
+    }
+
+    #[test]
+    fn enables_byte_payloads_for_ghostty_renderer_selection() {
+        assert!(should_emit_bytes_base64_for_env(None, Some("ghostty")));
+        assert!(should_emit_bytes_base64_for_env(Some("0"), Some("ghostty")));
+        assert!(should_emit_bytes_base64_for_env(None, Some(" ghostty ")));
+    }
+
+    #[test]
+    fn keeps_byte_payloads_disabled_for_default_text_renderers() {
+        assert!(!should_emit_bytes_base64_for_env(None, None));
+        assert!(!should_emit_bytes_base64_for_env(Some("0"), None));
+        assert!(!should_emit_bytes_base64_for_env(None, Some("xterm")));
+        assert!(!should_emit_bytes_base64_for_env(
+            Some("false"),
+            Some("plain-text")
+        ));
     }
 }

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -75,7 +75,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 40       | 12   | 2026-06-13   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 19       | 7    | 2026-06-06   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 8    | 2026-06-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 15       | 3    | 2026-06-12   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 11       | 3    | 2026-06-12   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 19       | 1    | 2026-06-06   |

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -2,8 +2,8 @@
 id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
-last_updated: 2026-05-20
-ref_count: 7
+last_updated: 2026-06-19
+ref_count: 8
 ---
 
 # E2E Testing
@@ -217,4 +217,13 @@ completely different root causes. The generic fast-failure modes:
 - **File:** `src/test/e2eInputGuard.test.ts`
 - **Finding:** After computing `filePaths` from `listTypeScriptFiles(E2E_ROOT)`, the test immediately evaluates `expect(findings).toEqual([])`. If `tests/e2e` is empty, or if all e2e files are temporarily moved or renamed (e.g., during a directory restructure), `filePaths` is `[]`, `findings` is `[]`, and the assertion trivially passes — the guard silently grants a clean bill of health without having scanned a single file. The guard's stated purpose (preventing `browser.keys(...)` usage in e2e tests) evaporates silently.
 - **Fix:** Added `expect(filePaths.length).toBeGreaterThan(0)` immediately after computing `filePaths`, requiring the guard to scan at least one e2e TypeScript file before checking findings. This distinguishes "no violations found" from "no files scanned".
+- **Commit:** _(this cycle)_
+
+### 20. Ghostty byte smoke assertion assumes 0xff 0xfe stays inside one PTY data event
+
+- **Source:** github-codex-connector | PR #541 cycle 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `tests/e2e/ghostty/specs/ghostty-smoke.spec.ts`
+- **Finding:** The new `eventContainsInvalidBytePair` helper decoded each recorded PTY event independently and only reported the probe bytes found when `0xff` was immediately followed by `0xfe` within a single event. OS PTY reads can split the two-byte probe across adjacent events, so the test could time out even though Ghostty had correctly received and preserved both bytes. The false negative would surface as a flaky CI failure rather than a product bug.
+- **Fix:** Replaced the per-event predicate with `recordedEventsContainInvalidBytePair(events)`, which concatenates decoded `bytesBase64` payloads from every recorded event in order (skipping events without byte metadata) and scans the resulting byte stream for the adjacent `0xff 0xfe` sequence. Post-wait assertions were moved to stream-level checks: at least one event carries `bytesBase64`, the total decoded byte length is at least 2, the stream contains `0xff` followed by `0xfe`, and at least one event's decoded `data` contains the Unicode replacement character.
 - **Commit:** _(this cycle)_

--- a/src/lib/e2e-bridge.test.ts
+++ b/src/lib/e2e-bridge.test.ts
@@ -1,13 +1,27 @@
 // cspell:ignore vsplit
 import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { __resetBackendEventSubscriptions, type BackendApi } from './backend'
 import {
+  clearRecordedPtyDataEvents,
+  getRecordedPtyDataEvents,
   getVisibleTerminalSize,
   readPaneBuffer,
+  startRecordingPtyDataEvents,
+  stopRecordingPtyDataEvents,
+  writeInputToVisibleTerminal,
   writeOutputToVisibleTerminal,
 } from './e2e-bridge'
 import { terminalCache } from '../features/terminal/terminalRegistry'
 
 type CacheEntry = ReturnType<typeof terminalCache.get>
+type BackendEventCallback = (payload: unknown) => void
+type BackendInvokeMock = (
+  method: string,
+  args?: Record<string, unknown>
+) => Promise<unknown>
+
+let backendEventCallbacks = new Map<string, BackendEventCallback>()
+let invokeMock: ReturnType<typeof vi.fn<BackendInvokeMock>>
 
 interface MockViewportReader {
   readVisibleText: () => string
@@ -28,6 +42,50 @@ const makeMockEntry = (rows: readonly string[]): CacheEntry => {
     fitController: { fit: (): void => undefined },
     viewportReader,
   } as unknown as CacheEntry
+}
+
+const visibleDomRect = (): DOMRect =>
+  ({
+    bottom: 24,
+    height: 24,
+    left: 0,
+    right: 80,
+    top: 0,
+    width: 80,
+    x: 0,
+    y: 0,
+    toJSON: (): Record<string, never> => ({}),
+  }) as DOMRect
+
+const emitBackendEvent = (event: string, payload: unknown): void => {
+  backendEventCallbacks.get(event)?.(payload)
+}
+
+const installBackendBridge = (): void => {
+  invokeMock = vi.fn<BackendInvokeMock>().mockResolvedValue(null)
+
+  const invokeBridge: BackendApi['invoke'] = async <T>(
+    method: string,
+    args?: Record<string, unknown>
+  ): Promise<T> => (await invokeMock(method, args)) as T
+
+  const listenBridge: BackendApi['listen'] = <T>(
+    event: string,
+    callback: (payload: T) => void
+  ): Promise<() => void> => {
+    backendEventCallbacks.set(event, (payload: unknown): void => {
+      callback(payload as T)
+    })
+
+    return Promise.resolve((): void => {
+      backendEventCallbacks.delete(event)
+    })
+  }
+
+  window.vimeflow = {
+    invoke: invokeBridge,
+    listen: listenBridge,
+  }
 }
 
 /**
@@ -83,6 +141,11 @@ describe('readPaneBuffer', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
     terminalCache.clear()
+    backendEventCallbacks = new Map()
+    stopRecordingPtyDataEvents()
+    clearRecordedPtyDataEvents()
+    __resetBackendEventSubscriptions()
+    installBackendBridge()
   })
 
   test('returns the focused pane legacy DOM fallback in multi-pane DOM', () => {
@@ -197,18 +260,7 @@ describe('readPaneBuffer', () => {
 
   test('writes output chunks to the visible terminal renderer', () => {
     const wrapper = buildSessionWrapper([''], 0)
-    wrapper.getBoundingClientRect = (): DOMRect =>
-      ({
-        bottom: 24,
-        height: 24,
-        left: 0,
-        right: 80,
-        top: 0,
-        width: 80,
-        x: 0,
-        y: 0,
-        toJSON: (): Record<string, never> => ({}),
-      }) as DOMRect
+    wrapper.getBoundingClientRect = visibleDomRect
 
     const entry = makeMockEntry([])
 
@@ -225,20 +277,57 @@ describe('readPaneBuffer', () => {
     })
   })
 
+  test('writes input to the visible pane pty through the backend bridge', async () => {
+    const wrapper = buildSessionWrapper([''], 0)
+    wrapper.getBoundingClientRect = visibleDomRect
+
+    terminalCache.set('pty-0', makeMockEntry([])!)
+    document.body.append(wrapper)
+
+    await expect(writeInputToVisibleTerminal('printf ok\n')).resolves.toBe(true)
+    expect(invokeMock).toHaveBeenCalledWith('write_pty', {
+      request: {
+        sessionId: 'pty-0',
+        data: 'printf ok\n',
+      },
+    })
+  })
+
+  test('does not write input when no visible terminal is mounted', async () => {
+    await expect(writeInputToVisibleTerminal('printf nope\n')).resolves.toBe(
+      false
+    )
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+
+  test('records pty-data events with byte payload metadata', async () => {
+    await startRecordingPtyDataEvents()
+
+    emitBackendEvent('pty-data', {
+      sessionId: 'pty-0',
+      data: '��',
+      bytesBase64: '//4=',
+      offsetStart: BigInt(42),
+      byteLen: BigInt(2),
+    })
+
+    expect(getRecordedPtyDataEvents()).toEqual([
+      {
+        sessionId: 'pty-0',
+        data: '��',
+        bytesBase64: '//4=',
+        offsetStart: 42,
+        byteLen: 2,
+      },
+    ])
+
+    clearRecordedPtyDataEvents()
+    expect(getRecordedPtyDataEvents()).toEqual([])
+  })
+
   test('returns the visible terminal size from the active cached renderer', () => {
     const wrapper = buildSessionWrapper([''], 0)
-    wrapper.getBoundingClientRect = (): DOMRect =>
-      ({
-        bottom: 24,
-        height: 24,
-        left: 0,
-        right: 80,
-        top: 0,
-        width: 80,
-        x: 0,
-        y: 0,
-        toJSON: (): Record<string, never> => ({}),
-      }) as DOMRect
+    wrapper.getBoundingClientRect = visibleDomRect
 
     terminalCache.set('pty-0', makeMockEntry([])!)
     document.body.append(wrapper)

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -1,9 +1,35 @@
-import { invoke } from './backend'
+import { invoke, listen, type UnlistenFn } from './backend'
 import { getAllPtySessionIds } from '../features/terminal/ptySessionMap'
 import { terminalCache } from '../features/terminal/terminalRegistry'
+import type { PtyDataEvent } from '../bindings'
 
 const LEGACY_XTERM_ROWS_SELECTOR = '.xterm-rows'
 let e2eOutputOffset = 0
+let ptyDataRecorderUnlisten: UnlistenFn | null = null
+let recordedPtyDataEvents: RecordedPtyDataEvent[] = []
+
+export interface RecordedPtyDataEvent {
+  readonly sessionId: string
+  readonly data: string
+  readonly bytesBase64?: string
+  readonly offsetStart: number
+  readonly byteLen: number
+}
+
+const coerceEventOffset = (value: number | bigint): number =>
+  typeof value === 'bigint' ? Number(value) : value
+
+const recordPtyDataEvent = (event: PtyDataEvent): void => {
+  recordedPtyDataEvents.push({
+    sessionId: event.sessionId,
+    data: event.data,
+    ...(event.bytesBase64 === undefined
+      ? {}
+      : { bytesBase64: event.bytesBase64 }),
+    offsetStart: coerceEventOffset(event.offsetStart),
+    byteLen: coerceEventOffset(event.byteLen),
+  })
+}
 
 const isVisible = (el: HTMLElement): boolean => {
   const r = el.getBoundingClientRect()
@@ -191,8 +217,56 @@ export const writeOutputToVisibleTerminal = (data: string): boolean => {
   return true
 }
 
+export const writeInputToVisibleTerminal = async (
+  data: string
+): Promise<boolean> => {
+  const pane = findActivePane()
+  if (!pane) {
+    return false
+  }
+
+  const sessionId = resolveCacheKey(pane)
+  if (!sessionId) {
+    return false
+  }
+
+  await invoke<null>('write_pty', {
+    request: {
+      sessionId,
+      data,
+    },
+  })
+
+  return true
+}
+
+export const startRecordingPtyDataEvents = async (): Promise<void> => {
+  if (ptyDataRecorderUnlisten !== null) {
+    return
+  }
+
+  ptyDataRecorderUnlisten = await listen<PtyDataEvent>(
+    'pty-data',
+    recordPtyDataEvent
+  )
+}
+
+export const stopRecordingPtyDataEvents = (): void => {
+  ptyDataRecorderUnlisten?.()
+  ptyDataRecorderUnlisten = null
+}
+
+export const clearRecordedPtyDataEvents = (): void => {
+  recordedPtyDataEvents = []
+}
+
+export const getRecordedPtyDataEvents = (): readonly RecordedPtyDataEvent[] =>
+  recordedPtyDataEvents
+
 if (import.meta.env.VITE_E2E) {
   window.__VIMEFLOW_E2E__ = {
+    clearRecordedPtyDataEvents,
+    getRecordedPtyDataEvents,
     getTerminalBuffer: readVisibleTerminalBuffer,
     getTerminalBufferForSession: readTerminalBufferForSession,
     getVisibleTerminalSize,
@@ -200,6 +274,8 @@ if (import.meta.env.VITE_E2E) {
     getActiveSessionIds: getAllPtySessionIds,
     listActivePtySessions: async (): Promise<string[]> =>
       invoke<string[]>('list_active_pty_sessions'),
+    startRecordingPtyDataEvents,
+    writeInputToVisibleTerminal,
     writeOutputToVisibleTerminal,
   }
 }

--- a/src/types/e2e.d.ts
+++ b/src/types/e2e.d.ts
@@ -1,14 +1,26 @@
 export {}
 
 declare global {
+  interface VimeflowE2ePtyDataEvent {
+    readonly sessionId: string
+    readonly data: string
+    readonly bytesBase64?: string
+    readonly offsetStart: number
+    readonly byteLen: number
+  }
+
   interface Window {
     __VIMEFLOW_E2E__?: {
+      clearRecordedPtyDataEvents(): void
+      getRecordedPtyDataEvents(): readonly VimeflowE2ePtyDataEvent[]
       getTerminalBuffer(): string
       getTerminalBufferForSession(sessionId: string): string
       getVisibleTerminalSize(): { readonly cols: number; readonly rows: number } | null
       getVisibleSessionId(): string | null
       getActiveSessionIds(): string[]
       listActivePtySessions(): Promise<string[]>
+      startRecordingPtyDataEvents(): Promise<void>
+      writeInputToVisibleTerminal(data: string): Promise<boolean>
       writeOutputToVisibleTerminal(data: string): boolean
     }
   }

--- a/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
+++ b/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
@@ -174,16 +174,18 @@ const readGhosttyStyleRuns = async (): Promise<readonly GhosttyStyleRun[]> =>
     }))
   )
 
-const eventContainsInvalidBytePair = (
-  event: VimeflowE2ePtyDataEvent
+const recordedEventsContainInvalidBytePair = (
+  events: readonly VimeflowE2ePtyDataEvent[]
 ): boolean => {
-  if (event.bytesBase64 === undefined) {
-    return false
-  }
+  const bytes = events
+    .map((event) => event.bytesBase64)
+    .filter((bytesBase64): bytesBase64 is string => bytesBase64 !== undefined)
+    .flatMap((bytesBase64) => Array.from(Buffer.from(bytesBase64, 'base64')))
 
-  const bytes = Buffer.from(event.bytesBase64, 'base64')
-
-  return bytes.some((byte, index) => byte === 0xff && bytes[index + 1] === 0xfe)
+  return bytes.some(
+    (byte, index) =>
+      byte === 0xff && index < bytes.length - 1 && bytes[index + 1] === 0xfe
+  )
 }
 
 describe('Ghostty renderer smoke', () => {
@@ -314,7 +316,7 @@ describe('Ghostty renderer smoke', () => {
 
     await browser.waitUntil(
       async () =>
-        (await readRecordedPtyDataEvents()).some(eventContainsInvalidBytePair),
+        recordedEventsContainInvalidBytePair(await readRecordedPtyDataEvents()),
       {
         timeout: ESCAPE_SEQUENCE_TIMEOUT_MS,
         timeoutMsg:
@@ -323,10 +325,16 @@ describe('Ghostty renderer smoke', () => {
     )
 
     const events = await readRecordedPtyDataEvents()
-    const byteEvent = events.find(eventContainsInvalidBytePair)
+    const byteEvents = events.filter((event) => event.bytesBase64 !== undefined)
+    const allBytes = byteEvents
+      .map((event) => event.bytesBase64)
+      .filter((bytesBase64): bytesBase64 is string => bytesBase64 !== undefined)
+      .flatMap((bytesBase64) => Array.from(Buffer.from(bytesBase64, 'base64')))
 
-    expect(byteEvent?.bytesBase64).toEqual(expect.any(String))
-    expect(byteEvent?.byteLen).toBeGreaterThanOrEqual(2)
-    expect(byteEvent?.data).toContain('�')
+    expect(byteEvents.length).toBeGreaterThanOrEqual(1)
+    expect(allBytes.length).toBeGreaterThanOrEqual(2)
+    expect(allBytes).toContain(0xff)
+    expect(allBytes[allBytes.indexOf(0xff) + 1]).toBe(0xfe)
+    expect(events.some((event) => event.data.includes('�'))).toBe(true)
   })
 })

--- a/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
+++ b/tests/e2e/ghostty/specs/ghostty-smoke.spec.ts
@@ -36,6 +36,37 @@ const writeOutputToVisibleTerminal = async (data: string): Promise<void> => {
 const readTerminalBuffer = async (): Promise<string> =>
   browser.execute(() => window.__VIMEFLOW_E2E__?.getTerminalBuffer() ?? '')
 
+const writeInputToVisibleTerminal = async (data: string): Promise<void> => {
+  const didWrite = await browser.execute(
+    (payload: string) =>
+      window.__VIMEFLOW_E2E__?.writeInputToVisibleTerminal(payload) ?? false,
+    data
+  )
+
+  if (!didWrite) {
+    throw new Error('visible terminal PTY was unavailable for e2e input')
+  }
+}
+
+const startRecordingPtyDataEvents = async (): Promise<void> => {
+  await browser.execute(
+    async () => await window.__VIMEFLOW_E2E__?.startRecordingPtyDataEvents()
+  )
+}
+
+const clearRecordedPtyDataEvents = async (): Promise<void> => {
+  await browser.execute(() =>
+    window.__VIMEFLOW_E2E__?.clearRecordedPtyDataEvents()
+  )
+}
+
+const readRecordedPtyDataEvents = async (): Promise<
+  readonly VimeflowE2ePtyDataEvent[]
+> =>
+  browser.execute(
+    () => window.__VIMEFLOW_E2E__?.getRecordedPtyDataEvents() ?? []
+  )
+
 const readTerminalSize = async (): Promise<{
   readonly cols: number
   readonly rows: number
@@ -142,6 +173,18 @@ const readGhosttyStyleRuns = async (): Promise<readonly GhosttyStyleRun[]> =>
       text: element.textContent ?? '',
     }))
   )
+
+const eventContainsInvalidBytePair = (
+  event: VimeflowE2ePtyDataEvent
+): boolean => {
+  if (event.bytesBase64 === undefined) {
+    return false
+  }
+
+  const bytes = Buffer.from(event.bytesBase64, 'base64')
+
+  return bytes.some((byte, index) => byte === 0xff && bytes[index + 1] === 0xfe)
+}
 
 describe('Ghostty renderer smoke', () => {
   before(async () => {
@@ -259,5 +302,31 @@ describe('Ghostty renderer smoke', () => {
     } finally {
       await setTerminalContentWidth(null)
     }
+  })
+
+  it('receives byte-preserving PTY events when Ghostty is selected', async () => {
+    await waitForGhosttyRenderer()
+    await waitForGhosttyPrompt()
+    await startRecordingPtyDataEvents()
+    await clearRecordedPtyDataEvents()
+
+    await writeInputToVisibleTerminal("printf '\\377\\376'\n")
+
+    await browser.waitUntil(
+      async () =>
+        (await readRecordedPtyDataEvents()).some(eventContainsInvalidBytePair),
+      {
+        timeout: ESCAPE_SEQUENCE_TIMEOUT_MS,
+        timeoutMsg:
+          'Ghostty PTY data never included bytesBase64 for raw 0xff 0xfe output',
+      }
+    )
+
+    const events = await readRecordedPtyDataEvents()
+    const byteEvent = events.find(eventContainsInvalidBytePair)
+
+    expect(byteEvent?.bytesBase64).toEqual(expect.any(String))
+    expect(byteEvent?.byteLen).toBeGreaterThanOrEqual(2)
+    expect(byteEvent?.data).toContain('�')
   })
 })


### PR DESCRIPTION
## Summary
- Enable PTY bytesBase64 emission automatically when VITE_TERMINAL_RENDERER=ghostty is selected
- Add E2E bridge helpers that can write to the visible PTY and record backend pty-data events
- Extend the Ghostty smoke spec to verify real raw 0xff 0xfe bytes arrive through bytesBase64 while text remains lossy

## Test plan
- [x] cargo test --manifest-path crates/backend/Cargo.toml terminal::bytes --lib
- [x] npx vitest run src/lib/e2e-bridge.test.ts
- [x] npx tsc -b --pretty false
- [x] npx tsc -p tests/e2e/tsconfig.json --pretty false
- [x] npm --ignore-scripts run lint
- [x] npm --ignore-scripts run format:check
- [x] npm run test:e2e:ghostty
- [x] npm test (pre-push hook)

Refs VIM-159