### PR TITLE
feat(terminal): add workspace layout SSoT foundation

### DIFF
--- a/crates/backend/src/terminal/workspace_layout.rs
+++ b/crates/backend/src/terminal/workspace_layout.rs
@@ -20,7 +20,63 @@ pub const CURRENT_WORKSPACE_LAYOUT_VERSION: u32 = 1;
 #[cfg_attr(test, ts(export))]
 pub struct WorkspaceLayoutStore {
     pub version: u32,
+    #[serde(default, rename = "customPaneLayouts")]
+    pub custom_pane_layouts: Vec<PaneLayoutDefinition>,
     pub sessions: Vec<WorkspaceSession>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(test, ts(export))]
+pub struct PaneLayoutDefinition {
+    pub schema_version: u32,
+    pub id: String,
+    pub title: String,
+    pub source: String,
+    pub tracks: PaneLayoutTracks,
+    pub slots: Vec<PaneLayoutSlot>,
+    pub add_order: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
+#[cfg_attr(test, ts(export))]
+pub struct PaneLayoutTracks {
+    pub columns: Vec<PaneLayoutTrack>,
+    pub rows: Vec<PaneLayoutTrack>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(test, ts(export))]
+pub struct PaneLayoutTrack {
+    pub id: String,
+    pub units: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_px: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
+#[cfg_attr(test, ts(export))]
+pub struct PaneLayoutSlot {
+    pub id: String,
+    pub rect: PaneLayoutSlotRect,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accepts: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(test, ts(export))]
+pub struct PaneLayoutSlotRect {
+    pub col: u32,
+    pub row: u32,
+    pub col_span: u32,
+    pub row_span: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -95,14 +151,20 @@ const DEFAULT_BROWSER_URL: &str = "https://www.google.com/";
 // Mirrors the spawn-path session cap (`commands.rs` try_insert(..., 64)) so a
 // valid full workspace is never treated as malformed and partly dropped.
 const MAX_SESSIONS: usize = 64;
-const MAX_PANES: usize = 6; // grid3x2 capacity
+const MAX_BUILTIN_PANES: usize = 6; // grid3x2 capacity
+const MAX_CUSTOM_PANE_LAYOUTS: usize = 32;
+const MIN_LAYOUT_TRACKS: usize = 1;
+const MAX_LAYOUT_TRACKS: usize = 4;
+const MIN_LAYOUT_SLOTS: usize = 1;
+const MAX_LAYOUT_SLOTS: usize = 16;
 const MAX_TABS: usize = 50;
 const MAX_HISTORY: usize = 100;
 const MAX_URL_LEN: usize = 4096;
 const MAX_TITLE_LEN: usize = 1024;
 const KNOWN_AGENTS: [&str; 5] = ["claude-code", "codex", "kimi", "aider", "generic"];
+const PANE_KINDS: [&str; 2] = ["shell", "browser"];
 
-fn layout_capacity(layout: &str) -> Option<usize> {
+fn builtin_layout_capacity(layout: &str) -> Option<usize> {
     match layout {
         "single" => Some(1),
         "vsplit" | "hsplit" => Some(2),
@@ -111,6 +173,20 @@ fn layout_capacity(layout: &str) -> Option<usize> {
         "grid3x2" => Some(6),
         _ => None,
     }
+}
+
+fn custom_layout_capacity(
+    custom_pane_layouts: &[PaneLayoutDefinition],
+    layout: &str,
+) -> Option<usize> {
+    custom_pane_layouts
+        .iter()
+        .find(|definition| definition.id == layout)
+        .map(|definition| definition.slots.len())
+}
+
+fn layout_capacity(layout: &str, custom_pane_layouts: &[PaneLayoutDefinition]) -> Option<usize> {
+    builtin_layout_capacity(layout).or_else(|| custom_layout_capacity(custom_pane_layouts, layout))
 }
 
 fn layout_for_count(n: usize) -> &'static str {
@@ -157,6 +233,128 @@ fn bool_field(v: &serde_json::Value, k: &str) -> Option<bool> {
     v.get(k).and_then(|x| x.as_bool())
 }
 
+fn repair_custom_pane_layouts(raw_layouts: &[serde_json::Value]) -> Vec<PaneLayoutDefinition> {
+    let mut layouts = Vec::new();
+    let mut seen_ids = std::collections::HashSet::new();
+
+    for raw in raw_layouts.iter() {
+        if layouts.len() >= MAX_CUSTOM_PANE_LAYOUTS {
+            break;
+        }
+
+        let Ok(definition) = serde_json::from_value::<PaneLayoutDefinition>(raw.clone()) else {
+            continue;
+        };
+
+        if !is_valid_custom_pane_layout(&definition) || seen_ids.contains(&definition.id) {
+            continue;
+        }
+
+        seen_ids.insert(definition.id.clone());
+        layouts.push(definition);
+    }
+
+    layouts
+}
+
+fn valid_layout_tracks(tracks: &[PaneLayoutTrack]) -> bool {
+    if !(MIN_LAYOUT_TRACKS..=MAX_LAYOUT_TRACKS).contains(&tracks.len()) {
+        return false;
+    }
+
+    let mut ids = std::collections::HashSet::new();
+    tracks.iter().all(|track| {
+        !track.id.is_empty()
+            && ids.insert(track.id.as_str())
+            && track.units.is_finite()
+            && track.units > 0.0
+            && track
+                .min_px
+                .is_none_or(|min_px| min_px.is_finite() && min_px >= 0.0)
+    })
+}
+
+fn is_valid_custom_pane_layout(definition: &PaneLayoutDefinition) -> bool {
+    if definition.schema_version != CURRENT_WORKSPACE_LAYOUT_VERSION {
+        return false;
+    }
+    if definition.source != "workspace"
+        || !definition.id.starts_with("custom:")
+        || definition.id.len() <= "custom:".len()
+        || definition.title.trim().is_empty()
+    {
+        return false;
+    }
+    if !valid_layout_tracks(&definition.tracks.columns)
+        || !valid_layout_tracks(&definition.tracks.rows)
+    {
+        return false;
+    }
+    if !(MIN_LAYOUT_SLOTS..=MAX_LAYOUT_SLOTS).contains(&definition.slots.len()) {
+        return false;
+    }
+
+    let cols = definition.tracks.columns.len();
+    let rows = definition.tracks.rows.len();
+    let mut seen_slots = std::collections::HashSet::new();
+    let mut coverage = vec![vec![false; cols]; rows];
+
+    for slot in &definition.slots {
+        if !slot.id.starts_with("slot:")
+            || slot.id.len() <= "slot:".len()
+            || !seen_slots.insert(slot.id.as_str())
+            || !slot
+                .accepts
+                .iter()
+                .all(|kind| PANE_KINDS.contains(&kind.as_str()))
+        {
+            return false;
+        }
+
+        let Some(col_end) = slot.rect.col.checked_add(slot.rect.col_span) else {
+            return false;
+        };
+        let Some(row_end) = slot.rect.row.checked_add(slot.rect.row_span) else {
+            return false;
+        };
+        if slot.rect.col_span == 0
+            || slot.rect.row_span == 0
+            || col_end as usize > cols
+            || row_end as usize > rows
+        {
+            return false;
+        }
+
+        for row in slot.rect.row..row_end {
+            for col in slot.rect.col..col_end {
+                let covered = &mut coverage[row as usize][col as usize];
+                if *covered {
+                    return false;
+                }
+                *covered = true;
+            }
+        }
+    }
+
+    if coverage
+        .iter()
+        .any(|row| row.iter().any(|covered| !covered))
+    {
+        return false;
+    }
+
+    let slot_ids: std::collections::HashSet<&str> = definition
+        .slots
+        .iter()
+        .map(|slot| slot.id.as_str())
+        .collect();
+    let mut seen_add_order = std::collections::HashSet::new();
+    definition.add_order.len() == definition.slots.len()
+        && definition.add_order.iter().all(|slot_id| {
+            slot_ids.contains(slot_id.as_str()) && seen_add_order.insert(slot_id.as_str())
+        })
+}
+
 fn truncate_chars(s: String, max: usize) -> String {
     if s.chars().count() <= max {
         s
@@ -196,6 +394,7 @@ pub fn repair_workspace_layout(
 ) -> WorkspaceLayoutStore {
     let empty = WorkspaceLayoutStore {
         version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+        custom_pane_layouts: Vec::new(),
         sessions: Vec::new(),
     };
     // Version gate: only the current version is decodable; anything else → fresh.
@@ -209,6 +408,12 @@ pub fn repair_workspace_layout(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();
+    let raw_custom_pane_layouts = raw
+        .get("customPaneLayouts")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let custom_pane_layouts = repair_custom_pane_layouts(&raw_custom_pane_layouts);
 
     let mut seen_session_ids = std::collections::HashSet::new();
     // ptyId must be unique across the WHOLE store (restore overlays live PTYs
@@ -234,6 +439,13 @@ pub fn repair_workspace_layout(
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| active_project_id.to_string());
 
+        let raw_layout = str_field(rs, "layout");
+        let pane_limit = raw_layout
+            .as_deref()
+            .and_then(|layout| custom_layout_capacity(&custom_pane_layouts, layout))
+            .unwrap_or(MAX_BUILTIN_PANES)
+            .min(MAX_LAYOUT_SLOTS);
+
         let raw_panes = rs
             .get("panes")
             .and_then(|v| v.as_array())
@@ -244,16 +456,19 @@ pub fn repair_workspace_layout(
             &working_directory,
             active_cwd,
             &mut seen_pty_ids,
+            pane_limit,
         );
         if panes.is_empty() {
             continue; // session emptied by repair → drop (floor: ≥1 pane)
         }
 
-        // Layout: unknown → smallest fitting; widen to fit the pane count, cap grid3x2.
-        let mut layout = str_field(rs, "layout")
-            .filter(|l| layout_capacity(l).is_some())
+        // Layout: unknown → smallest fitting; widen built-ins to fit the pane count.
+        // Valid custom layouts are preserved when their definition covers the
+        // repaired pane count, allowing future layouts beyond grid3x2.
+        let mut layout = raw_layout
+            .filter(|l| layout_capacity(l, &custom_pane_layouts).is_some())
             .unwrap_or_else(|| layout_for_count(panes.len()).to_string());
-        if layout_capacity(&layout).unwrap_or(1) < panes.len() {
+        if layout_capacity(&layout, &custom_pane_layouts).unwrap_or(1) < panes.len() {
             layout = layout_for_count(panes.len()).to_string();
         }
 
@@ -292,6 +507,7 @@ pub fn repair_workspace_layout(
 
     WorkspaceLayoutStore {
         version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+        custom_pane_layouts,
         sessions,
     }
 }
@@ -301,6 +517,7 @@ fn repair_panes(
     session_cwd: &str,
     active_cwd: &str,
     seen_pty_ids: &mut std::collections::HashSet<String>,
+    max_panes: usize,
 ) -> Vec<WorkspacePane> {
     let mut seen_pane_ids = std::collections::HashSet::new();
     // (sort_key, original_index, pane); sort_key = paneIndex, missing → last.
@@ -375,15 +592,15 @@ fn repair_panes(
 
     built.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
     // Truncate to capacity BEFORE active-normalization, so an active pane beyond
-    // quad cannot be dropped after being chosen (which would leave none active).
+    // the layout limit cannot be dropped after being chosen (which would leave none active).
     // Un-reserve the ptyIds of capped panes so a later valid pane can reuse them.
-    if built.len() > MAX_PANES {
-        for (_, _, pane) in &built[MAX_PANES..] {
+    if built.len() > max_panes {
+        for (_, _, pane) in &built[max_panes..] {
             if let WorkspacePane::Shell(s) = pane {
                 seen_pty_ids.remove(&s.pty_id);
             }
         }
-        built.truncate(MAX_PANES);
+        built.truncate(max_panes);
     }
 
     let any_active = built.iter().any(|(_, _, p)| pane_active(p));
@@ -598,6 +815,7 @@ mod tests {
     fn round_trips_shell_and_browser_panes() {
         let store = WorkspaceLayoutStore {
             version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+            custom_pane_layouts: Vec::new(),
             sessions: vec![WorkspaceSession {
                 id: "s1".into(),
                 project_id: "p".into(),
@@ -645,6 +863,56 @@ mod tests {
 
     use serde_json::json;
 
+    fn custom_grid_layout_json(id: &str, columns: u32, rows: u32) -> serde_json::Value {
+        let column_tracks: Vec<_> = (0..columns)
+            .map(|col| json!({ "id": format!("c{col}"), "units": 1 }))
+            .collect();
+        let row_tracks: Vec<_> = (0..rows)
+            .map(|row| json!({ "id": format!("r{row}"), "units": 1 }))
+            .collect();
+        let slots: Vec<_> = (0..rows)
+            .flat_map(|row| {
+                (0..columns).map(move |col| {
+                    let index = row * columns + col;
+                    json!({
+                        "id": format!("slot:p{index}"),
+                        "rect": { "col": col, "row": row, "colSpan": 1, "rowSpan": 1 }
+                    })
+                })
+            })
+            .collect();
+        let add_order: Vec<_> = (0..(columns * rows))
+            .map(|index| format!("slot:p{index}"))
+            .collect();
+
+        json!({
+            "schemaVersion": 1,
+            "id": id,
+            "title": "Custom grid",
+            "source": "workspace",
+            "tracks": {
+                "columns": column_tracks,
+                "rows": row_tracks
+            },
+            "slots": slots,
+            "addOrder": add_order
+        })
+    }
+
+    fn browser_panes_json(count: u32) -> Vec<serde_json::Value> {
+        (0..count)
+            .map(|index| {
+                json!({
+                    "kind": "browser",
+                    "paneId": format!("p{index}"),
+                    "paneIndex": index,
+                    "active": index == 0,
+                    "tabs": []
+                })
+            })
+            .collect()
+    }
+
     fn browser_tab(b: &WorkspacePane) -> &BrowserPane {
         match b {
             WorkspacePane::Browser(x) => x,
@@ -666,20 +934,133 @@ mod tests {
     }
 
     #[test]
-    fn preserves_many_open_sessions_but_normalizes_one_active() {
+    fn repairs_custom_pane_layout_definitions_without_blocking_sessions() {
+        let valid_layout = json!({
+            "schemaVersion": 1,
+            "id": "custom:main-side",
+            "title": "Main + side",
+            "source": "workspace",
+            "tracks": {
+                "columns": [{ "id": "main", "units": 16 }, { "id": "side", "units": 8 }],
+                "rows": [{ "id": "only", "units": 24 }]
+            },
+            "slots": [
+                { "id": "slot:main", "rect": { "col": 0, "row": 0, "colSpan": 1, "rowSpan": 1 }},
+                { "id": "slot:side", "rect": { "col": 1, "row": 0, "colSpan": 1, "rowSpan": 1 }}
+            ],
+            "addOrder": ["slot:main", "slot:side"]
+        });
+
+        let store = repair_workspace_layout(
+            json!({
+            "version": 1,
+            "customPaneLayouts": [
+              valid_layout,
+              { "schemaVersion": 1, "id": "single", "title": "Bad", "source": "workspace" },
+              { "schemaVersion": 1, "id": "custom:main-side", "title": "Duplicate", "source": "workspace" }
+            ],
+            "sessions": [
+              { "id": "s", "projectId": "p", "layout": "single",
+                "workingDirectory": "/", "active": true, "open": true,
+                "panes": [ { "kind": "browser", "paneId": "b1",
+                  "paneIndex": 0, "active": true } ] }
+            ]}),
+            "proj",
+            "/",
+        );
+
+        assert_eq!(store.custom_pane_layouts.len(), 1);
+        assert_eq!(store.custom_pane_layouts[0].id, "custom:main-side");
+        assert_eq!(store.sessions.len(), 1);
+    }
+
+    #[test]
+    fn preserves_custom_session_layout_when_definition_exists() {
         let store = repair_workspace_layout(
             json!({
               "version": 1,
-              "sessions": [
-                { "id": "s1", "projectId": "p", "layout": "single",
-                  "workingDirectory": "/", "active": true, "open": true,
-                  "panes": [ { "kind": "browser", "paneId": "b1",
-                    "paneIndex": 0, "active": true } ] },
-                { "id": "s2", "projectId": "p", "layout": "single",
-                  "workingDirectory": "/", "active": true, "open": true,
-                  "panes": [ { "kind": "browser", "paneId": "b2",
-                    "paneIndex": 0, "active": true } ] }
-              ]}),
+              "customPaneLayouts": [custom_grid_layout_json("custom:grid2x2", 2, 2)],
+              "sessions": [{
+                "id": "s",
+                "projectId": "p",
+                "layout": "custom:grid2x2",
+                "workingDirectory": "/",
+                "active": true,
+                "open": true,
+                "panes": browser_panes_json(4)
+              }]
+            }),
+            "proj",
+            "/",
+        );
+
+        assert_eq!(store.sessions[0].layout, "custom:grid2x2");
+        assert_eq!(store.sessions[0].panes.len(), 4);
+    }
+
+    #[test]
+    fn unknown_custom_session_layout_falls_back_to_builtin_capacity() {
+        let store = repair_workspace_layout(
+            json!({
+              "version": 1,
+              "customPaneLayouts": [],
+              "sessions": [{
+                "id": "s",
+                "projectId": "p",
+                "layout": "custom:missing",
+                "workingDirectory": "/",
+                "active": true,
+                "open": true,
+                "panes": browser_panes_json(4)
+              }]
+            }),
+            "proj",
+            "/",
+        );
+
+        assert_eq!(store.sessions[0].layout, "quad");
+        assert_eq!(store.sessions[0].panes.len(), 4);
+    }
+
+    #[test]
+    fn custom_session_layout_can_preserve_more_than_grid3x2_panes() {
+        let store = repair_workspace_layout(
+            json!({
+              "version": 1,
+              "customPaneLayouts": [custom_grid_layout_json("custom:grid4x2", 4, 2)],
+              "sessions": [{
+                "id": "s",
+                "projectId": "p",
+                "layout": "custom:grid4x2",
+                "workingDirectory": "/",
+                "active": true,
+                "open": true,
+                "panes": browser_panes_json(8)
+              }]
+            }),
+            "proj",
+            "/",
+        );
+
+        assert_eq!(store.sessions[0].layout, "custom:grid4x2");
+        assert_eq!(store.sessions[0].panes.len(), 8);
+    }
+
+    #[test]
+    fn preserves_many_open_sessions_but_normalizes_one_active() {
+        let store = repair_workspace_layout(
+            json!({
+            "version": 1,
+            "sessions": [
+              { "id": "s1", "projectId": "p", "layout": "single",
+                "workingDirectory": "/", "active": true, "open": true,
+                "panes": [ { "kind": "browser", "paneId": "b1",
+                  "paneIndex": 0, "active": true } ] },
+              { "id": "s2", "projectId": "p", "layout": "single",
+                "workingDirectory": "/", "active": true, "open": true,
+                "panes": [ { "kind": "browser", "paneId": "b2",
+                  "paneIndex": 0, "active": true } ] }
+            ]}),
             "proj",
             "/",
         );
@@ -867,6 +1248,7 @@ mod tests {
 
         let store = WorkspaceLayoutStore {
             version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+            custom_pane_layouts: Vec::new(),
             sessions: vec![WorkspaceSession {
                 id: "s".into(),
                 project_id: "proj".into(),
@@ -903,6 +1285,7 @@ mod tests {
         cache
             .save(&WorkspaceLayoutStore {
                 version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+                custom_pane_layouts: Vec::new(),
                 sessions: vec![WorkspaceSession {
                     id: "s".into(),
                     project_id: "proj".into(),
@@ -930,6 +1313,7 @@ mod tests {
         // A skewed-version save fails closed, leaving the good file intact.
         let bad = WorkspaceLayoutStore {
             version: 999,
+            custom_pane_layouts: Vec::new(),
             sessions: Vec::new(),
         };
         assert!(cache.save(&bad).is_err());
@@ -945,6 +1329,7 @@ mod tests {
 
         let store = WorkspaceLayoutStore {
             version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+            custom_pane_layouts: Vec::new(),
             sessions: vec![WorkspaceSession {
                 id: "s".into(),
                 project_id: "proj".into(),
@@ -1001,6 +1386,7 @@ mod tests {
         let wc = WorkspaceLayoutCache::new(layouts_path.clone());
         wc.save(&WorkspaceLayoutStore {
             version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+            custom_pane_layouts: Vec::new(),
             sessions: vec![WorkspaceSession {
                 id: "s".into(),
                 project_id: "proj".into(),

--- a/crates/backend/src/terminal/workspace_layout.rs
+++ b/crates/backend/src/terminal/workspace_layout.rs
@@ -14,6 +14,7 @@ use std::sync::Mutex;
 // ts-rs is a dev-dependency; derive TS only under cfg(test), matching `terminal/types.rs`.
 
 pub const CURRENT_WORKSPACE_LAYOUT_VERSION: u32 = 1;
+const PANE_LAYOUT_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]
@@ -264,7 +265,7 @@ fn valid_layout_tracks(tracks: &[PaneLayoutTrack]) -> bool {
 
     let mut ids = std::collections::HashSet::new();
     tracks.iter().all(|track| {
-        !track.id.is_empty()
+        !track.id.trim().is_empty()
             && ids.insert(track.id.as_str())
             && track.units.is_finite()
             && track.units > 0.0
@@ -275,7 +276,7 @@ fn valid_layout_tracks(tracks: &[PaneLayoutTrack]) -> bool {
 }
 
 fn is_valid_custom_pane_layout(definition: &PaneLayoutDefinition) -> bool {
-    if definition.schema_version != CURRENT_WORKSPACE_LAYOUT_VERSION {
+    if definition.schema_version != PANE_LAYOUT_SCHEMA_VERSION {
         return false;
     }
     if definition.source != "workspace"
@@ -972,6 +973,34 @@ mod tests {
         assert_eq!(store.custom_pane_layouts.len(), 1);
         assert_eq!(store.custom_pane_layouts[0].id, "custom:main-side");
         assert_eq!(store.sessions.len(), 1);
+    }
+
+    #[test]
+    fn rejects_custom_layout_with_whitespace_only_track_id() {
+        let store = repair_workspace_layout(
+            json!({
+                "version": 1,
+                "customPaneLayouts": [{
+                    "schemaVersion": 1,
+                    "id": "custom:bad-track",
+                    "title": "Bad track",
+                    "source": "workspace",
+                    "tracks": {
+                        "columns": [{ "id": "   ", "units": 24 }],
+                        "rows": [{ "id": "only", "units": 24 }]
+                    },
+                    "slots": [
+                        { "id": "slot:only", "rect": { "col": 0, "row": 0, "colSpan": 1, "rowSpan": 1 } }
+                    ],
+                    "addOrder": ["slot:only"]
+                }],
+                "sessions": []
+            }),
+            "proj",
+            "/",
+        );
+
+        assert!(store.custom_pane_layouts.is_empty());
     }
 
     #[test]

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 15       | 12   | 2026-06-16   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 7        | 3    | 2026-06-17   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 11       | 9    | 2026-06-19   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 12       | 9    | 2026-06-19   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 3        | 0    | 2026-06-16   |
@@ -94,7 +94,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 4        | 1    | 2026-06-19   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
-| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 6        | 3    | 2026-06-18   |
+| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 7        | 3    | 2026-06-19   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 3        | 2    | 2026-06-15   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 5        | 4    | 2026-06-17   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 24       | 6    | 2026-06-17   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 50       | 21   | 2026-06-18   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 51       | 22   | 2026-06-19   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
@@ -97,9 +97,9 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 6        | 3    | 2026-06-18   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 3        | 2    | 2026-06-15   |
-| [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 5        | 3    | 2026-06-17   |
+| [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 5        | 4    | 2026-06-17   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 0    | 2026-06-15   |
-| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 0    | 2026-06-15   |
+| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 1    | 2026-06-15   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 3        | 0    | 2026-06-17   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
 | [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 1    | 2026-06-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 15       | 12   | 2026-06-16   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 7        | 3    | 2026-06-17   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 10       | 9    | 2026-06-17   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 11       | 9    | 2026-06-19   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 3        | 0    | 2026-06-16   |
@@ -85,14 +85,14 @@ When appending findings to a pattern file, label the source so future readers ca
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 9        | 4    | 2026-06-13   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 11       | 8    | 2026-06-12   |
-| [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 8        | 4    | 2026-06-13   |
+| [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 10       | 4    | 2026-06-19   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 9        | 2    | 2026-06-15   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                     | correctness        | 1        | 0    | 2026-06-11   |
 | [Identifier Prefix Matching](patterns/identifier-prefix-matching.md)                                 | correctness        | 4        | 2    | 2026-06-17   |
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
-| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 3        | 1    | 2026-06-18   |
+| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 4        | 1    | 2026-06-19   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
 | [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 6        | 3    | 2026-06-18   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
@@ -103,5 +103,6 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 3        | 0    | 2026-06-17   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
 | [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 1    | 2026-06-18   |
+| [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -2,7 +2,7 @@
 id: dead-code
 category: code-quality
 created: 2026-06-13
-last_updated: 2026-06-15
+last_updated: 2026-06-19
 ref_count: 1
 ---
 
@@ -43,3 +43,12 @@ code and should be removed.
 - **Finding:** The header root carried `px-2 pr-2 pl-3.5`. `px-2` set both sides to `0.5rem`, `pr-2` repeated the right value, and `pl-3.5` overrode the left value. The shorthand was a dead no-op that made the cascade harder to reason about.
 - **Fix:** Removed `px-2`; kept only `pr-2 pl-3.5`.
 - **Commit:** see `git blame` / `git log` on this line
+
+### 4. `gridAreaForSlotIndex` fallback returns a legacy area name that cannot exist
+
+- **Source:** github-claude | PR #542 round 1 | 2026-06-19
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/SplitView/SplitView.tsx`
+- **Finding:** The helper returned `p${slotIndex}` when the index was outside `definition.slots.length`, but every caller is already bounded by `layout.capacity`, which equals `definition.slots.length`. The fallback was unreachable and, once custom non-`p{N}` slot ids are wired, would silently place a pane outside the generated CSS grid.
+- **Fix:** Replaced the silent fallback with an explicit out-of-bounds error so any future capacity/slot bookkeeping divergence fails loudly instead of dropping a pane.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,7 +2,7 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-06-13
+last_updated: 2026-06-19
 ref_count: 8
 ---
 
@@ -140,3 +140,12 @@ base data is technically "correct."
 - **Finding:** The crumb timestamp was set on every transition from dirty to clean, including undoing all edits back to the original content. No disk write occurred, yet the UI rendered `SAVED · just now`.
 - **Fix:** Replaced the heuristic with an explicit `savedAt` timestamp that `WorkspaceView` sets only after `editorBuffer.saveFile()` resolves successfully.
 - **Commit:** see current commit
+
+### 11. SplitView mapped pane index to `slots[N]` instead of persisted `addOrder[N]`
+
+- **Source:** github-codex-connector | PR #542 round 1 | 2026-06-19
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/SplitView/SplitView.tsx`
+- **Finding:** `gridAreaForSlotIndex` resolved the slot id from `definition.slots[slotIndex].id`. For custom layouts whose `addOrder` intentionally differs from the `slots` declaration order, pane index N would be placed in the wrong grid region even though the persisted definition specified a different insertion order.
+- **Fix:** Changed the helper to resolve the slot id from `definition.addOrder[slotIndex]` before converting it to a grid area, so restored and added panes follow the persisted insertion order.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -149,3 +149,12 @@ base data is technically "correct."
 - **Finding:** `gridAreaForSlotIndex` resolved the slot id from `definition.slots[slotIndex].id`. For custom layouts whose `addOrder` intentionally differs from the `slots` declaration order, pane index N would be placed in the wrong grid region even though the persisted definition specified a different insertion order.
 - **Fix:** Changed the helper to resolve the slot id from `definition.addOrder[slotIndex]` before converting it to a grid area, so restored and added panes follow the persisted insertion order.
 - **Commit:** same commit as this entry
+
+### 12. Prebuilt layout track units diverge numerically from `DEFAULT_RATIOS`
+
+- **Source:** github-claude | PR #542 round 2 | 2026-06-19
+- **Severity:** LOW
+- **File:** `src/features/terminal/layout-registry/layoutDefinition.ts` L136-141 and `src/features/terminal/layout-registry/prebuiltLayouts.ts`
+- **Finding:** `getPaneLayoutRatios(definition)` returned raw prebuilt track units such as `[14, 10]` for `threeRight`, while `DEFAULT_RATIOS.threeRight.cols` used `[1.4, 1]`. The proportions were identical for CSS grid rendering, but the numeric scales differed, so an equality check like `equalTrackRatios(currentRatios, getPaneLayoutRatios(layout.definition))` would report a mismatch even when the layout was at its default state.
+- **Fix:** Normalized all prebuilt track units to the same scale as `DEFAULT_RATIOS` (e.g., `columns(1.4, 1)` for `threeRight`) and added a JSDoc note to `getPaneLayoutRatios` clarifying that it returns raw definition units and that callers needing canonical defaults should read `layout.defaultRatios`.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/persisted-state-invariants.md
+++ b/docs/reviews/patterns/persisted-state-invariants.md
@@ -2,7 +2,7 @@
 id: persisted-state-invariants
 category: correctness
 created: 2026-06-08
-last_updated: 2026-06-13
+last_updated: 2026-06-19
 ref_count: 4
 ---
 
@@ -84,4 +84,22 @@ Durable user-facing state (workspace shapes, caches, settings files) can be malf
 - **File:** `src/features/sessions/hooks/useSessionRestore.ts`
 - **Finding:** `restartPersistedActiveShell` used `liveSessions.length > 0` as the "session is live" guard. The backend's lazy-reconciliation path can return a non-empty `listSessions()` result where every row has `status.kind === 'Exited'`. The guard treated this as a live restore and skipped restarting the persisted active shell, leaving a `completed` placeholder and forcing auto-create to open a second terminal.
 - **Fix:** Replace the length check with `liveSessions.some((session) => session.status.kind === 'Alive')` so only actually alive PTYs block the restart path. Added a regression test where `listSessions()` returns a single `Exited` record.
+- **Commit:** same commit as this entry
+
+### 9. Rust `valid_layout_tracks` accepts whitespace-only track IDs
+
+- **Source:** github-claude | PR #542 round 1 | 2026-06-19
+- **Severity:** LOW
+- **File:** `crates/backend/src/terminal/workspace_layout.rs`
+- **Finding:** `valid_layout_tracks` only checked `!track.id.is_empty()`, so a hand-crafted persisted layout with a whitespace-only track id (e.g., `" "`) passed validation. The resulting CSS grid track name would be invisible and produce no diagnostics.
+- **Fix:** Changed the guard to `!track.id.trim().is_empty()` so whitespace-only ids are rejected, matching the TypeScript validation.
+- **Commit:** same commit as this entry
+
+### 10. Custom slot ids can collide after grid-area sanitization
+
+- **Source:** github-codex-connector | PR #542 round 1 | 2026-06-19
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/layout-registry/layoutDefinition.ts`
+- **Finding:** `gridAreaNameForSlotId` replaces non-alphanumeric characters with `-`, so distinct ids such as `slot:a b` and `slot:a-b` map to the same CSS grid-area name. A persisted custom layout passing validation could therefore place multiple panes in one grid area, causing overlap or an invalid grid template at runtime.
+- **Fix:** Added `duplicate-grid-area` validation in `validateSlots` that rejects layouts whose sanitized slot ids produce colliding grid-area names.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,8 +2,8 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-18
-ref_count: 21
+last_updated: 2026-06-19
+ref_count: 22
 ---
 
 # React Lifecycle
@@ -489,3 +489,12 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **Finding:** `LayoutDisplayMenu` is rendered only when `activeSession` exists. If the active session closes while the menu is open, the menu unmounts without `MenuRoot` calling `onOpenChange(false)`, leaving `isLayoutDisplayMenuOpen` stuck `true`. On macOS this permanently removes `vf-app-drag-region` from the top chrome, making the title bar undraggable until the menu is mounted and closed again.
 - **Fix:** Added a `useEffect` in `WorkspaceView` that resets `isLayoutDisplayMenuOpen` to `false` whenever `activeSession` becomes `undefined`, restoring the drag region when the menu unmounts. Added a regression test that removes the active session while the menu is open and asserts the drag region returns.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 51. Unstable `customPaneLayouts` default invalidates `useMemo` on every render
+
+- **Source:** github-claude | PR #542 round 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/features/sessions/hooks/usePushWorkspaceGrouping.ts` L124-134
+- **Finding:** The destructuring default `customPaneLayouts = []` created a new array every time callers omitted the option. Because `customPaneLayouts` was listed in the `useMemo` dependency array, the workspace shape and its structural JSON signature were recomputed on every render even when the semantic input had not changed.
+- **Fix:** Introduced a module-scope `EMPTY_CUSTOM_PANE_LAYOUTS: readonly PaneLayoutDefinition[] = []` constant and used it as the destructuring default. The array reference is now stable across renders, so omitted layouts no longer trigger `buildWorkspaceShape` and `structuralSignature` recomputation.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-prop-contracts.md
+++ b/docs/reviews/patterns/react-prop-contracts.md
@@ -3,7 +3,7 @@ id: react-prop-contracts
 category: react-patterns
 created: 2026-06-15
 last_updated: 2026-06-17
-ref_count: 3
+ref_count: 4
 ---
 
 # React Prop Contracts

--- a/docs/reviews/patterns/retained-state-identity.md
+++ b/docs/reviews/patterns/retained-state-identity.md
@@ -3,7 +3,7 @@ id: retained-state-identity
 category: react-patterns
 created: 2026-06-15
 last_updated: 2026-06-15
-ref_count: 0
+ref_count: 1
 ---
 
 # Retained State Identity

--- a/docs/reviews/patterns/schema-version-decoupling.md
+++ b/docs/reviews/patterns/schema-version-decoupling.md
@@ -1,0 +1,29 @@
+---
+id: schema-version-decoupling
+category: correctness
+created: 2026-06-19
+last_updated: 2026-06-19
+ref_count: 0
+---
+
+# Schema Version Decoupling
+
+## Summary
+
+Durable file formats and the schemas of nested records they contain evolve on
+separate timelines. Reusing a top-level file-format version constant to gate
+nested record schemas couples the two lifecycles and silently rejects still-
+valid nested records whenever the file format bumps. Each nested schema should
+carry its own explicit version constant so migrations can advance the file
+format without orphaning records that conform to an older nested schema.
+
+## Findings
+
+### 1. Rust schema_version check reused workspace format version constant
+
+- **Source:** github-claude | PR #542 round 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/terminal/workspace_layout.rs`
+- **Finding:** `is_valid_custom_pane_layout` compared `definition.schema_version` against `CURRENT_WORKSPACE_LAYOUT_VERSION`, the constant that governs the workspace file format's `version` field. Both happened to be `1` today, but a future workspace-format v2 migration would silently reject every stored v1 `PaneLayoutDefinition`, causing all user-created custom layouts to vanish without error.
+- **Fix:** Introduced a dedicated `PANE_LAYOUT_SCHEMA_VERSION` constant and used it for the pane-layout schema check, decoupling it from the workspace file-format version.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/type-contract-safety.md
+++ b/docs/reviews/patterns/type-contract-safety.md
@@ -2,7 +2,7 @@
 id: type-contract-safety
 category: code-quality
 created: 2026-06-15
-last_updated: 2026-06-18
+last_updated: 2026-06-19
 ref_count: 3
 ---
 
@@ -77,4 +77,13 @@ expands.
 - **File:** `electron/workspace-layout-types.ts`
 - **Finding:** The shape-only DTO browser pane was named `PersistedBrowserPane`, identical to the full persisted-store pane type that includes `tabs: PersistedTab[]`. TypeScript declaration merging meant `PersistedWorkspacePaneShape` required `tabs` even though shape DTOs intentionally strip browser tab/history, breaking `paneToShape` and round-trip test fixtures that construct browser shapes without tabs.
 - **Fix:** Same rename as finding 5: the renderer bridge's browser shape type is now `PersistedBrowserPaneShape`, so the shape-only DTO and the full persisted-store type are distinct identifiers and no longer merge.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 7. `PersistedPaneLayoutDefinition` uses `Record<string, unknown>`
+
+- **Source:** github-human | PR #542 round 2 | 2026-06-19
+- **Severity:** HUMAN
+- **File:** `electron/workspace-layout-types.ts` L46
+- **Finding:** `PersistedPaneLayoutDefinition` was declared as `Record<string, unknown>`, which erased the concrete shape of persisted custom pane layouts. The loose type made it easy to pass malformed data across the Electron persistence boundary without compile-time feedback.
+- **Fix:** Replaced the `Record<string, unknown>` alias with a concrete `PersistedPaneLayoutDefinition` interface and supporting `PersistedTrackSpec`, `PersistedPaneSlotRect`, and `PersistedPaneSlotSpec` types that mirror the renderer-side `PaneLayoutDefinition` shape using plain strings for the persisted boundary.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/technical-notes/workspace-layout-customization-ssot.zh-CN.html
+++ b/docs/technical-notes/workspace-layout-customization-ssot.zh-CN.html
@@ -1,0 +1,1383 @@
+<!doctype html>
+<!-- cspell:words autoshrink hdiv lede vdiv -->
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vimeflow 技术说明：Workspace Pane Layout 自定义模型</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0b0d12;
+        --panel: rgba(20, 23, 33, 0.9);
+        --panel-2: rgba(30, 34, 48, 0.9);
+        --panel-3: rgba(12, 15, 23, 0.9);
+        --text: #eef2ff;
+        --muted: #aeb8d6;
+        --faint: #7782a3;
+        --accent: #a6e3a1;
+        --accent-2: #89dceb;
+        --warn: #f9e2af;
+        --danger: #f38ba8;
+        --line: rgba(238, 242, 255, 0.11);
+        --shadow: 0 24px 80px rgba(0, 0, 0, 0.38);
+        --mono:
+          'SFMono-Regular', 'SF Mono', 'JetBrains Mono', 'Menlo', monospace;
+        --sans:
+          'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', 'PingFang SC',
+          'Noto Serif SC', serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        color: var(--text);
+        font-family: var(--sans);
+        background:
+          radial-gradient(
+            circle at 10% 0%,
+            rgba(166, 227, 161, 0.13),
+            transparent 32%
+          ),
+          radial-gradient(
+            circle at 92% 12%,
+            rgba(137, 220, 235, 0.14),
+            transparent 30%
+          ),
+          linear-gradient(180deg, #07090f 0%, var(--bg) 100%);
+      }
+
+      code,
+      pre,
+      .mono {
+        font-family: var(--mono);
+      }
+
+      .page {
+        width: min(1180px, calc(100vw - 40px));
+        margin: 0 auto;
+        padding: 40px 0 72px;
+      }
+
+      .hero,
+      .section {
+        border: 1px solid var(--line);
+        border-radius: 28px;
+        background: var(--panel);
+        box-shadow: var(--shadow);
+        backdrop-filter: blur(18px);
+      }
+
+      .hero {
+        padding: 36px;
+        background:
+          linear-gradient(135deg, rgba(166, 227, 161, 0.1), transparent 55%),
+          linear-gradient(
+            180deg,
+            rgba(20, 23, 33, 0.96),
+            rgba(10, 12, 19, 0.97)
+          );
+      }
+
+      .section {
+        margin-top: 24px;
+        padding: 30px;
+      }
+
+      .eyebrow {
+        display: inline-block;
+        margin-bottom: 12px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: rgba(166, 227, 161, 0.13);
+        color: var(--accent);
+        font: 700 12px/1.1 var(--mono);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      h1,
+      h2,
+      h3 {
+        margin: 0;
+        line-height: 1.12;
+      }
+
+      h1 {
+        max-width: 960px;
+        font-size: clamp(34px, 5vw, 56px);
+        letter-spacing: -0.03em;
+      }
+
+      h2 {
+        margin-bottom: 16px;
+        font-size: 28px;
+      }
+
+      h3 {
+        margin-bottom: 10px;
+        font-size: 20px;
+      }
+
+      p,
+      li,
+      td,
+      th {
+        font-size: 16px;
+        line-height: 1.78;
+      }
+
+      p,
+      li,
+      td {
+        color: var(--muted);
+      }
+
+      .lede {
+        max-width: 940px;
+        margin: 18px 0 0;
+        color: var(--text);
+        font-size: 18px;
+      }
+
+      .grid-3,
+      .grid-2,
+      .two-up {
+        display: grid;
+        gap: 18px;
+      }
+
+      .grid-3 {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        margin-top: 24px;
+      }
+
+      .grid-2 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .two-up {
+        grid-template-columns: minmax(0, 1fr) minmax(360px, 0.72fr);
+        align-items: start;
+      }
+
+      .card,
+      .stat,
+      .note,
+      .code,
+      .diagram {
+        border: 1px solid var(--line);
+        border-radius: 22px;
+        background: var(--panel-2);
+      }
+
+      .card,
+      .stat,
+      .diagram {
+        padding: 18px 20px;
+      }
+
+      .stat .label,
+      .label {
+        display: block;
+        margin-bottom: 8px;
+        color: var(--accent-2);
+        font: 700 12px/1.2 var(--mono);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .stat strong {
+        display: block;
+        color: var(--text);
+        font-size: 22px;
+      }
+
+      .chip-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 16px;
+      }
+
+      .chip {
+        padding: 7px 10px;
+        border-radius: 999px;
+        border: 1px solid var(--line);
+        background: rgba(255, 255, 255, 0.035);
+        color: var(--text);
+        font: 600 12px/1.2 var(--mono);
+      }
+
+      .note {
+        margin-top: 16px;
+        padding: 14px 16px;
+        border-left: 3px solid var(--warn);
+      }
+
+      .note strong {
+        color: var(--text);
+      }
+
+      .code {
+        margin-top: 14px;
+        padding: 16px 18px;
+        overflow-x: auto;
+        background: rgba(7, 9, 15, 0.94);
+        color: #f6f8ff;
+      }
+
+      pre {
+        margin: 0;
+        font-size: 13px;
+        line-height: 1.62;
+      }
+
+      ul {
+        margin: 12px 0 0 18px;
+        padding: 0;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th,
+      td {
+        padding: 14px 12px;
+        border-bottom: 1px solid var(--line);
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        color: var(--text);
+        font: 700 12px/1.3 var(--mono);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .danger {
+        color: var(--danger);
+      }
+
+      .good {
+        color: var(--accent);
+      }
+
+      .muted {
+        color: var(--faint);
+      }
+
+      .layout-demo {
+        display: grid;
+        gap: 8px;
+        min-height: 210px;
+        padding: 10px;
+        border-radius: 18px;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent),
+          rgba(5, 7, 12, 0.58);
+      }
+
+      .slot {
+        display: grid;
+        place-items: center;
+        min-height: 46px;
+        border-radius: 14px;
+        border: 1px solid rgba(238, 242, 255, 0.15);
+        background:
+          linear-gradient(
+            135deg,
+            rgba(166, 227, 161, 0.12),
+            rgba(137, 220, 235, 0.07)
+          ),
+          rgba(255, 255, 255, 0.035);
+        color: var(--text);
+        font: 700 12px/1 var(--mono);
+        letter-spacing: 0.06em;
+      }
+
+      .demo-3x2 {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-rows: repeat(2, minmax(0, 1fr));
+      }
+
+      .demo-4x4 {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        grid-template-rows: repeat(4, minmax(0, 1fr));
+      }
+
+      .demo-stack {
+        grid-template-columns: minmax(0, 16fr) minmax(0, 8fr);
+        grid-template-rows: repeat(3, minmax(0, 1fr));
+      }
+
+      .demo-stack .main {
+        grid-row: 1 / span 3;
+      }
+
+      .demo-bottom {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-rows: minmax(0, 18fr) minmax(0, 6fr);
+      }
+
+      .demo-bottom .main-bottom {
+        grid-column: 1 / span 3;
+      }
+
+      .footer {
+        margin-top: 20px;
+        color: var(--faint);
+        font-size: 14px;
+      }
+
+      @media (max-width: 980px) {
+        .grid-3,
+        .grid-2,
+        .two-up {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section class="hero">
+        <span class="eyebrow">Technical Note</span>
+        <h1>Workspace Pane Layout 自定义：先定唯一数据结构，再画配置面板</h1>
+        <p class="lede">
+          目标不是再加几个预设按钮，而是让用户能创建终端形状、调整布局，并决定
+          workspace 使用什么布局。关键决策是：runtime、restore、divider、
+          ratio、icon、customization plane 都必须从同一个
+          <span class="mono">PaneLayoutDefinition</span>
+          派生，不能让配置页成为另一套事实来源。
+        </p>
+        <div class="chip-row">
+          <span class="chip">SSoT：Track + Slot Rect</span>
+          <span class="chip">支持：2x3 / 3x2 / 3x3 / 4x4</span>
+          <span class="chip">支持：Main + N Stack</span>
+          <span class="chip">Custom UI 只编辑 Draft</span>
+        </div>
+        <div class="grid-3">
+          <div class="stat">
+            <span class="label">核心原则</span>
+            <strong>一个 layout 定义</strong>
+            <span>所有渲染、校验、持久化都从它推导</span>
+          </div>
+          <div class="stat">
+            <span class="label">不做什么</span>
+            <strong>不存 CSS 字符串</strong>
+            <span>CSS grid、divider、glyph 都是派生产物</span>
+          </div>
+          <div class="stat">
+            <span class="label">第一版边界</span>
+            <strong>Rectilinear grid</strong>
+            <span>矩形 slot、无重叠、默认无洞</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>结论：合法 pane layout 的唯一数据结构</h2>
+        <div class="two-up">
+          <div>
+            <p>
+              推荐把 layout 表达为“行列轨道 + slot 矩形”。这比
+              <code>grid-template-areas</code> 更适合作为 domain
+              model，因为它能直接表达 resize ratio、slot 边界、capacity、pane
+              placement，也能稳定序列化。
+            </p>
+            <div class="code">
+              <pre>
+type PaneLayoutId = BuiltinLayoutId | `custom:${string}`
+type LayoutSlotId = `slot:${string}`
+
+interface PaneLayoutDefinition {
+  schemaVersion: 1
+  id: PaneLayoutId
+  title: string
+  source: 'builtin' | 'workspace'
+  tracks: {
+    columns: readonly TrackSpec[]
+    rows: readonly TrackSpec[]
+  }
+  slots: readonly PaneSlotSpec[]
+  addOrder: readonly LayoutSlotId[]
+}
+
+interface TrackSpec {
+  id: string
+  units: number
+  minPx?: number
+}
+
+interface PaneSlotSpec {
+  id: LayoutSlotId
+  rect: {
+    col: number
+    row: number
+    colSpan: number
+    rowSpan: number
+  }
+  accepts?: readonly PaneKind[]
+}</pre
+              >
+            </div>
+            <p>
+              <code>units</code> 是给用户和配置面板看的规格单位。runtime
+              可以直接把它当 <code>fr</code> 权重使用，也可以 normalize 成
+              ratio；关键是 UI 不再暴露 难以一眼理解的小数比例。
+            </p>
+          </div>
+          <aside class="diagram">
+            <span class="label">可以表达的布局</span>
+            <div class="layout-demo demo-stack">
+              <div class="slot main">p0</div>
+              <div class="slot">p1</div>
+              <div class="slot">p2</div>
+              <div class="slot">p3</div>
+            </div>
+            <p>
+              这个 “Main + 3 stack” 不是特殊 case。它只是
+              <code>p0</code> 的 <code>rowSpan = 3</code>，右侧三个 slot
+              各占一行。
+            </p>
+          </aside>
+        </div>
+        <div class="note">
+          <p>
+            <strong>重点：</strong>customization plane 应该编辑
+            <code>DraftPaneLayoutDefinition</code>，点击 Apply 时通过 validator
+            生成 <code>PaneLayoutDefinition</code>。只有 validated definition
+            能进入 session 和持久化层。
+          </p>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>用 Main + 3 sub panes 拆开看</h2>
+        <p>
+          “行列轨道 + slot 矩形” 可以先按字面理解：我们不是先画 CSS，
+          而是先描述一张逻辑网格。网格有几列、几行，每一块 pane 占从哪里开始、
+          横跨几列、竖跨几行。CSS、divider、icon、capacity
+          都是后面自动算出来的。
+        </p>
+        <div class="two-up">
+          <div>
+            <div class="code">
+              <pre>
+Main + 3 sub panes 的逻辑网格：
+
+columns: [main, side]
+rows:    [top, middle, bottom]
+
+视觉结果：
+
++----------------------+-------------+
+|                      | sub pane 1  |
+|                      +-------------+
+|      main pane       | sub pane 2  |
+|                      +-------------+
+|                      | sub pane 3  |
++----------------------+-------------+</pre
+              >
+            </div>
+            <p>
+              这里的 layout 本体不是上面这张 ASCII 图。真正的本体是：
+              <code>2</code> 列、<code>3</code> 行、<code>4</code> 个 slot。
+              main slot 从第 0 列第 0 行开始，占 1 列、3 行；右边三个 sub slot
+              各占第 1 列的一行。
+            </p>
+          </div>
+          <aside class="diagram">
+            <span class="label">同一个定义渲染出的结果</span>
+            <div class="layout-demo demo-stack">
+              <div class="slot main">main</div>
+              <div class="slot">sub 1</div>
+              <div class="slot">sub 2</div>
+              <div class="slot">sub 3</div>
+            </div>
+            <p>
+              这不是“threeRight 的另一个 hardcode case”。它只是普通矩形 slot
+              的组合。
+            </p>
+          </aside>
+        </div>
+
+        <div class="grid-2" style="margin-top: 18px">
+          <article class="card">
+            <span class="label">Step 1</span>
+            <h3>先定义 tracks：有几列、几行、比例是多少</h3>
+            <p>
+              tracks 是 resize ratio 的来源。不要用小数 ratio 当心智模型；
+              更推荐像 Tailwind / Bootstrap grid 一样， 把总宽度或总高度拆成
+              <code>24</code> 份。比如左侧 main 占 <code>16/24</code>，右侧
+              stack 占 <code>8/24</code>； 三行默认一样高，就各占
+              <code>8/24</code>。
+            </p>
+            <div class="code">
+              <pre>
+tracks: {
+  columns: [
+    { id: 'main', units: 16 },
+    { id: 'side', units: 8 },
+  ],
+  rows: [
+    { id: 'top', units: 8 },
+    { id: 'middle', units: 8 },
+    { id: 'bottom', units: 8 },
+  ],
+}</pre
+              >
+            </div>
+          </article>
+
+          <article class="card">
+            <span class="label">Step 2</span>
+            <h3>再定义 slots：每个 pane 形状占哪里</h3>
+            <p>
+              slot rect 是 layout 的核心。它不关心当前里面有没有
+              terminal，也不关心 terminal 的 PTY id。它只描述“这个位置可以放一个
+              pane”。
+            </p>
+            <div class="code">
+              <pre>
+slots: [
+  {
+    id: 'slot:main',
+    rect: { col: 0, row: 0, colSpan: 1, rowSpan: 3 },
+  },
+  {
+    id: 'slot:side-top',
+    rect: { col: 1, row: 0, colSpan: 1, rowSpan: 1 },
+  },
+  {
+    id: 'slot:side-middle',
+    rect: { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+  },
+  {
+    id: 'slot:side-bottom',
+    rect: { col: 1, row: 2, colSpan: 1, rowSpan: 1 },
+  },
+]</pre
+              >
+            </div>
+          </article>
+        </div>
+
+        <table style="margin-top: 18px">
+          <thead>
+            <tr>
+              <th>字段</th>
+              <th>在这个例子里的值</th>
+              <th>它回答的问题</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>tracks.columns</code></td>
+              <td><code>[main, side]</code></td>
+              <td>横向有几块？每块宽度比例是多少？</td>
+            </tr>
+            <tr>
+              <td><code>tracks.rows</code></td>
+              <td><code>[top, middle, bottom]</code></td>
+              <td>纵向有几块？每块高度比例是多少？</td>
+            </tr>
+            <tr>
+              <td><code>slot:main.rect</code></td>
+              <td><code>{ col: 0, row: 0, colSpan: 1, rowSpan: 3 }</code></td>
+              <td>main pane 从左上开始，占整条左列</td>
+            </tr>
+            <tr>
+              <td><code>slot:side-middle.rect</code></td>
+              <td><code>{ col: 1, row: 1, colSpan: 1, rowSpan: 1 }</code></td>
+              <td>第二个 sub pane 在右列中间</td>
+            </tr>
+            <tr>
+              <td><code>addOrder</code></td>
+              <td>
+                <code
+                  >['slot:main', 'slot:side-top', 'slot:side-middle',
+                  'slot:side-bottom']</code
+                >
+              </td>
+              <td>用户点 Add Pane 时，新的 pane 按什么顺序填空位</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="grid-2" style="margin-top: 18px">
+          <article class="card">
+            <span class="label">Step 3</span>
+            <h3>runtime 再从它派生 CSS grid</h3>
+            <p>
+              注意这里是“派生”。我们不把这段 CSS 当成 source of truth，
+              因为它只是浏览器需要的输出格式。
+            </p>
+            <div class="code">
+              <pre>
+grid-template-columns:
+  minmax(0, 16fr) 8px minmax(0, 8fr)
+
+grid-template-rows:
+  minmax(0, 8fr) 8px minmax(0, 8fr) 8px minmax(0, 8fr)
+
+grid-template-areas:
+  "slot-main vdiv slot-side-top"
+  "slot-main vdiv hdiv-side-0"
+  "slot-main vdiv slot-side-middle"
+  "slot-main vdiv hdiv-side-1"
+  "slot-main vdiv slot-side-bottom"</pre
+              >
+            </div>
+          </article>
+
+          <article class="card">
+            <span class="label">Step 4</span>
+            <h3>divider 也从 slot 边界派生</h3>
+            <p>
+              左右之间有一条完整竖向边界，所以生成一个 vertical
+              divider。右侧三个 sub pane 之间有两条水平边界，所以生成两个
+              horizontal divider。
+            </p>
+            <div class="code">
+              <pre>
+derived dividers:
+[
+  { axis: 'columns', trackIndex: 0 },
+  { axis: 'rows', trackIndex: 0, segment: 'right-column' },
+  { axis: 'rows', trackIndex: 1, segment: 'right-column' },
+]</pre
+              >
+            </div>
+            <p>
+              这就是为什么 divider 不应该手写在每个 layout case 里。只要 slot
+              rect 合法，divider 可以被统一算法算出来。
+            </p>
+          </article>
+        </div>
+
+        <div class="section" style="margin-top: 18px; box-shadow: none">
+          <h3>同一个模型的另一个形状：Main + bottom 3 panes</h3>
+          <p>
+            如果用户想要“上面一个大 main workspace，底部三个 workspace
+            横向排列”， 数据结构不用换，只是 tracks 和 slot rect
+            换一组。这里变成
+            <code>3</code> 列、<code>2</code> 行：main slot 横跨上方三列，
+            底部三个 sub slot 各占一列。
+          </p>
+          <div class="two-up">
+            <div>
+              <div class="code">
+                <pre>
+Main + bottom 3 panes 的逻辑网格：
+
+columns: [left, center, right]
+rows:    [main, bottom]
+
+视觉结果：
+
++-------------+-------------+-------------+
+|                                       |
+|              main pane                |
+|                                       |
++-------------+-------------+-------------+
+| sub pane 1  | sub pane 2  | sub pane 3  |
++-------------+-------------+-------------+</pre
+                >
+              </div>
+              <p>
+                这个例子说明：<code>rowSpan</code> 和 <code>colSpan</code>
+                是同一种能力的两个方向。右侧 stack 例子是 main 纵向跨 3 行；
+                底部横排例子是 main 横向跨 3 列。
+              </p>
+            </div>
+            <aside class="diagram">
+              <span class="label">横向底栏变体</span>
+              <div class="layout-demo demo-bottom">
+                <div class="slot main-bottom">main</div>
+                <div class="slot">sub 1</div>
+                <div class="slot">sub 2</div>
+                <div class="slot">sub 3</div>
+              </div>
+              <p>
+                同样是 4 个 slot、同样可以 resize、同样可 restore；只是 slot
+                rect 的占位方式不同。
+              </p>
+            </aside>
+          </div>
+
+          <div class="grid-2" style="margin-top: 18px">
+            <article class="card">
+              <span class="label">Tracks</span>
+              <h3>三列两行</h3>
+              <p>
+                columns 是三个底部 pane 的横向宽度来源；rows 是 main
+                区域和底部区域的高度比例。 这里同样按
+                <code>24</code> 份理解：底部三列各 <code>8/24</code>， 上方 main
+                高度 <code>18/24</code>，底部区域高度 <code>6/24</code>。
+              </p>
+              <div class="code">
+                <pre>
+tracks: {
+  columns: [
+    { id: 'left', units: 8 },
+    { id: 'center', units: 8 },
+    { id: 'right', units: 8 },
+  ],
+  rows: [
+    { id: 'main', units: 18 },
+    { id: 'bottom', units: 6 },
+  ],
+}</pre
+                >
+              </div>
+            </article>
+
+            <article class="card">
+              <span class="label">Slots</span>
+              <h3>main 横跨三列</h3>
+              <p>
+                main slot 从第 0 列第 0 行开始，横跨 3 列、只占 1 行。底部三个
+                slot 在第 1 行分别占第 0、1、2 列。
+              </p>
+              <div class="code">
+                <pre>
+slots: [
+  {
+    id: 'slot:main',
+    rect: { col: 0, row: 0, colSpan: 3, rowSpan: 1 },
+  },
+  {
+    id: 'slot:bottom-left',
+    rect: { col: 0, row: 1, colSpan: 1, rowSpan: 1 },
+  },
+  {
+    id: 'slot:bottom-center',
+    rect: { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+  },
+  {
+    id: 'slot:bottom-right',
+    rect: { col: 2, row: 1, colSpan: 1, rowSpan: 1 },
+  },
+]</pre
+                >
+              </div>
+            </article>
+          </div>
+
+          <div class="note">
+            <p>
+              <strong>对比：</strong>右侧 stack 和底部横排都不是新 layout 类型。
+              它们都是同一个 <code>PaneLayoutDefinition</code> schema
+              的不同数据。 这就是为什么我们要把 SSoT 定成 rect，而不是枚举一堆
+              <code>mainRight3</code>、<code>mainBottom3</code> 特殊 case。
+            </p>
+          </div>
+        </div>
+
+        <div class="note">
+          <p>
+            <strong>一句话理解：</strong>layout definition 描述的是“地图”；
+            session placement 描述的是“哪个 pane 住在哪个房间”；CSS grid 和
+            divider 是把这张地图画到屏幕上的方式，不是地图本身。
+          </p>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>为什么不用其他东西当 SSoT</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>候选</th>
+              <th>问题</th>
+              <th>结论</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>CSS grid-template-areas</code></td>
+              <td>
+                它适合渲染，但不适合作为 domain model。解析困难、slot
+                身份弱、ratio 和 divider 需要反推。
+              </td>
+              <td>只作为派生产物</td>
+            </tr>
+            <tr>
+              <td>divider specs</td>
+              <td>
+                divider 是 slot 边界的结果，不是 layout 本体。把它当事实来源会让
+                icon、capacity、restore 都缺数据。
+              </td>
+              <td>从 slot rect 自动生成</td>
+            </tr>
+            <tr>
+              <td>customization page 的 canvas state</td>
+              <td>
+                UI 需要 hover、drag、selection、preview、invalid intermediate
+                states； 这些状态不能直接进入 runtime。
+              </td>
+              <td>只能是 draft</td>
+            </tr>
+            <tr>
+              <td>pane 数组顺序</td>
+              <td>
+                pane 顺序只能说明添加顺序，不能说明 pane 应该放在哪个 slot。
+                一旦支持拖拽重排就会断。
+              </td>
+              <td>session 需要显式 placement</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="section">
+        <h2>Workspace / Session 应该存什么</h2>
+        <p>
+          这里要拆清楚两种 layout 来源：app 自带一组 prebuilt
+          layouts；用户可以在当前 workspace/session 里创建自己的 customized
+          layouts。运行时的 layout list
+          不是只看代码里的预设，也不是只看用户数据，而是把两者合并：
+          <code>[...prebuilt, ...customized]</code>。
+        </p>
+        <div class="code">
+          <pre>
+const availableLayouts = [
+  ...PREBUILT_PANE_LAYOUTS,
+  ...workspace.customPaneLayouts,
+]
+
+interface WorkspaceLayoutState {
+  customPaneLayouts: readonly PaneLayoutDefinition[]
+  sessions: readonly Session[]
+}
+
+interface SessionLayoutState {
+  layoutId: PaneLayoutId
+  placements: readonly PanePlacement[]
+}
+
+interface PanePlacement {
+  paneId: string
+  slotId: LayoutSlotId
+}
+
+interface Session {
+  // existing fields...
+  layout: SessionLayoutState
+  panes: Pane[]
+}</pre
+          >
+        </div>
+        <p>
+          也就是说，用户自定义 layout definition 要跟 workspace/session snapshot
+          一起持久化；session 自己选择某个 <code>layoutId</code>，并记录 pane 到
+          slot 的 placement。这样 restore 时可以先把 prebuilt 和 customized 合成
+          registry， 再恢复每个 session 的当前 layout。
+        </p>
+        <div class="note">
+          <p>
+            <strong>命名空间规则：</strong>prebuilt layout 使用固定 id，例如
+            <code>single</code>、<code>grid3x2</code>；用户自定义 layout 使用
+            <code>custom:&lt;uuid&gt;</code>。合并时不允许 custom 覆盖
+            prebuilt， 这样升级 app 时内置布局语义不会被用户数据 shadow 掉。
+          </p>
+        </div>
+        <div class="note">
+          <p>
+            <strong>迁移策略：</strong>第一步可以继续让旧的
+            <code>Session.layout: LayoutId</code> 存在，并用 pane index
+            隐式映射到 <code>addOrder</code>。但目标模型必须把 pane identity 和
+            slot placement 拆开。
+          </p>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Registry / Management 层职责</h2>
+        <p>
+          VIM-151 已经把一部分 layout 规则从 UI 组件里抽到了
+          <code>src/features/terminal/layout-registry</code
+          >。所以这里不是从零开始重构； 下一步是在现有 registry
+          基础上，把它从“prebuilt layout registry” 推进到“prebuilt + user
+          customized layout management”。
+        </p>
+        <table style="margin-bottom: 18px">
+          <thead>
+            <tr>
+              <th>职责</th>
+              <th>VIM-151 状态</th>
+              <th>剩余工作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>layout id / 文案 / pill 顺序</td>
+              <td class="good">
+                已完成：<code>LAYOUT_IDS</code>、<code>LAYOUTS</code>、
+                <code>LAYOUT_CYCLE</code> 已集中到 layout registry。
+              </td>
+              <td>
+                需要让 registry 接受 runtime catalog：
+                <code
+                  >[...PREBUILT_PANE_LAYOUTS,
+                  ...workspace.customPaneLayouts]</code
+                >。
+              </td>
+            </tr>
+            <tr>
+              <td>prebuilt layout specs</td>
+              <td class="good">
+                已完成：single / vsplit / hsplit / threeRight / quad / grid3x2
+                已作为 prebuilt specs 管理。
+              </td>
+              <td>
+                需要把 specs 升级成通用 <code>PaneLayoutDefinition</code>， 用
+                tracks + slot rect 表达，而不是只服务固定 enum。
+              </td>
+            </tr>
+            <tr>
+              <td>ratio model</td>
+              <td class="good">
+                已完成：ratio 已从单个 row/col 值扩成
+                <code>{ cols: number[], rows: number[] }</code>，能支撑多
+                track。
+              </td>
+              <td>
+                需要把用户可理解的 <code>units</code> 模型接入 runtime， 例如
+                24-unit 转成 ratio/fr。
+              </td>
+            </tr>
+            <tr>
+              <td>displayed layout menu</td>
+              <td class="good">
+                已完成：top chrome 里已有 displayed-layout floating menu，
+                可以控制哪些 prebuilt layout pill 显示。
+              </td>
+              <td>
+                需要扩展为 layout management 入口：显示 prebuilt + customized，
+                并提供创建、编辑、删除 custom layout 的 plane。
+              </td>
+            </tr>
+            <tr>
+              <td>autoshrink</td>
+              <td class="good">
+                已完成：当前 pane removal 的 shrink 规则已集中到
+                <code>autoShrinkLayoutFor</code>。
+              </td>
+              <td>
+                需要区分 prebuilt policy 和 custom policy。custom layout 里
+                empty slot 应该是合法状态，不能一关 pane 就强制坍缩 layout。
+              </td>
+            </tr>
+            <tr>
+              <td>divider / grid resolving</td>
+              <td>
+                部分完成：VIM-151 支撑了更宽的 ratio array 和 grid3x2 divider
+                ergonomics。
+              </td>
+              <td>
+                仍需从 slot rect 自动派生 grid areas、divider handles、divider
+                groups。
+                <code>SplitView</code> 不应该继续按 layout id switch。
+              </td>
+            </tr>
+            <tr>
+              <td>restore / persisted shape</td>
+              <td>
+                部分完成：restore 已能识别当前 prebuilt layout id，并恢复
+                grid3x2。
+              </td>
+              <td>
+                需要持久化 <code>customPaneLayouts</code> 和
+                <code>layoutId + placements</code>，否则 custom layout reload
+                后无法解析。
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="grid-2">
+          <article class="card">
+            <span class="label">Canonical API</span>
+            <h3><code>PaneLayoutRegistry</code></h3>
+            <p>
+              它可以是 class，也可以是纯函数模块。关键是调用方只能问 registry：
+              “这个 layout 是什么、是否有效、应该怎么渲染、pane 能不能加、关
+              pane 后怎么处理”。
+            </p>
+            <div class="code">
+              <pre>
+interface PaneLayoutRegistry {
+  getDefinition(id: PaneLayoutId): PaneLayoutDefinition | null
+  validateDraft(draft: DraftPaneLayoutDefinition): ValidationResult
+  resolveGrid(def: PaneLayoutDefinition): ResolvedGrid
+  resolveDividers(def: PaneLayoutDefinition): readonly DividerSpec[]
+  resolveRatios(def: PaneLayoutDefinition): LayoutRatios
+  resolveIcon(def: PaneLayoutDefinition): LayoutIconModel
+  chooseLayoutAfterPaneRemoval(
+    state: SessionLayoutState,
+    nextPaneCount: number
+  ): SessionLayoutState
+}</pre
+              >
+            </div>
+          </article>
+          <article class="card">
+            <span class="label">Registry owns policy</span>
+            <h3>不要再散落 switch</h3>
+            <ul>
+              <li>layout id 合法性判断</li>
+              <li>builtin 与 workspace custom 的合并顺序</li>
+              <li>displayed layout menu 可见项</li>
+              <li>layout icon / glyph 生成</li>
+              <li>autoshrink 或 empty-slot 策略</li>
+              <li>divider 边界和 ratio arrays</li>
+              <li>restore fallback 到 single 的规则</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Validator：什么是有效 layout</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>规则</th>
+              <th>建议 v1 行为</th>
+              <th>原因</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>行列数量</td>
+              <td><code>1..4</code> tracks，最多 <code>16</code> slots</td>
+              <td>覆盖 2x3、3x2、3x3、4x4，同时避免 first PR 复杂度失控</td>
+            </tr>
+            <tr>
+              <td>track units</td>
+              <td>必须是有限正数</td>
+              <td>
+                ratio 和 CSS fr 不能接受 0、负数、NaN；UI 用 24 份单位表达比例
+              </td>
+            </tr>
+            <tr>
+              <td>slot rect</td>
+              <td>整数、在 bounds 内、span 大于 0</td>
+              <td>保证可稳定映射到 grid area</td>
+            </tr>
+            <tr>
+              <td>重叠</td>
+              <td>禁止重叠</td>
+              <td>否则 pane focus、divider hit-test、placement 都不确定</td>
+            </tr>
+            <tr>
+              <td>洞</td>
+              <td>v1 禁止洞，要求完整覆盖网格</td>
+              <td>
+                后续可以明确设计 spacer slot；现在不要让 empty area 语义混乱
+              </td>
+            </tr>
+            <tr>
+              <td><code>addOrder</code></td>
+              <td>必须包含每个 slot 一次且只一次</td>
+              <td>新 pane 添加位置必须可预测</td>
+            </tr>
+            <tr>
+              <td>slot id</td>
+              <td>全局唯一且 stable</td>
+              <td>
+                pane placement 需要在 rename / resize / restart 后保持稳定
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="section">
+        <h2>从 SSoT 派生的 runtime 数据</h2>
+        <div class="grid-2">
+          <article class="card">
+            <span class="label">Derived rendering</span>
+            <h3>SplitView 不应该知道 layout 名字</h3>
+            <p>
+              <code>SplitView</code> 应该拿到 resolved model，而不是对
+              <code>grid3x2</code>、<code>quad</code>、<code>threeRight</code>
+              做 switch。
+            </p>
+            <ul>
+              <li><code>gridTemplateColumns</code></li>
+              <li><code>gridTemplateRows</code></li>
+              <li><code>gridTemplateAreas</code></li>
+              <li><code>slotId -&gt; gridArea</code></li>
+              <li><code>divider handles</code></li>
+            </ul>
+          </article>
+          <article class="card">
+            <span class="label">Derived interaction</span>
+            <h3>ratio 和 divider 都从边界来</h3>
+            <p>
+              column boundary 生成垂直 divider，row boundary 生成水平 divider。
+              span slot 会让某些 divider segment 被合并或跳过。
+            </p>
+            <ul>
+              <li>
+                <code>LayoutRatios.columns = tracks.columns.units[]</code>
+              </li>
+              <li><code>LayoutRatios.rows = tracks.rows.units[]</code></li>
+              <li>同一个边界上的多个 visual segment 共用一个 controller</li>
+              <li>resize 后只更新当前 session 的 in-memory ratio override</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>示例：同一个模型覆盖这些 layout</h2>
+        <div class="grid-3">
+          <article class="diagram">
+            <span class="label">3x2 / 2x3 grid</span>
+            <div class="layout-demo demo-3x2">
+              <div class="slot">p0</div>
+              <div class="slot">p1</div>
+              <div class="slot">p2</div>
+              <div class="slot">p3</div>
+              <div class="slot">p4</div>
+              <div class="slot">p5</div>
+            </div>
+            <p>
+              每个 slot 都是 <code>1x1</code> rect；改 columns/rows 就能得到
+              <code>2x3</code> 或 <code>3x2</code>。
+            </p>
+          </article>
+          <article class="diagram">
+            <span class="label">4x4 grid</span>
+            <div class="layout-demo demo-4x4">
+              <div class="slot">p0</div>
+              <div class="slot">p1</div>
+              <div class="slot">p2</div>
+              <div class="slot">p3</div>
+              <div class="slot">p4</div>
+              <div class="slot">p5</div>
+              <div class="slot">p6</div>
+              <div class="slot">p7</div>
+              <div class="slot">p8</div>
+              <div class="slot">p9</div>
+              <div class="slot">p10</div>
+              <div class="slot">p11</div>
+              <div class="slot">p12</div>
+              <div class="slot">p13</div>
+              <div class="slot">p14</div>
+              <div class="slot">p15</div>
+            </div>
+            <p>
+              这是上限示例。第一版如果担心 terminal
+              太小，可以先允许定义但提示低可用性。
+            </p>
+          </article>
+          <article class="diagram">
+            <span class="label">Main + 3 stack</span>
+            <div class="layout-demo demo-stack">
+              <div class="slot main">p0</div>
+              <div class="slot">p1</div>
+              <div class="slot">p2</div>
+              <div class="slot">p3</div>
+            </div>
+            <p>
+              左侧主 pane 是一个跨 3 行的矩形 slot。divider
+              仍然能从边界自动生成。
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Customization Plane 应该怎么接入</h2>
+        <div class="grid-2">
+          <article class="card">
+            <span class="label">UI state</span>
+            <h3>只维护 draft</h3>
+            <p>
+              配置面板可以有 selection、hover、drag ghost、invalid preview、undo
+              stack。 这些都属于
+              <code>DraftPaneLayoutDefinition</code>，不应该直接写进 session。
+            </p>
+            <div class="code">
+              <pre>
+interface DraftPaneLayoutDefinition {
+  base?: PaneLayoutId
+  title: string
+  columns: DraftTrack[]
+  rows: DraftTrack[]
+  slots: DraftSlot[]
+  selectedSlotId?: LayoutSlotId
+}</pre
+              >
+            </div>
+          </article>
+          <article class="card">
+            <span class="label">Commit path</span>
+            <h3>Apply 时才进入 registry</h3>
+            <ul>
+              <li>用户在 plane 里编辑 draft</li>
+              <li>validator 给出 inline errors 和 preview warnings</li>
+              <li>Apply 后生成 canonical definition</li>
+              <li>
+                写入当前 workspace/session snapshot 的
+                <code>customPaneLayouts</code>
+              </li>
+              <li>
+                运行时用 <code>[...prebuilt, ...customized]</code> 重新组装
+                layout list
+              </li>
+              <li>
+                当前 session 切换到新的 <code>layoutId</code> 并写入 placement
+              </li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>持久化建议</h2>
+        <p>
+          prebuilt layout 定义继续在代码里；用户自定义 layout 定义随
+          workspace/session snapshot 一起持久化。restore 时先组装
+          <code>[...PREBUILT_PANE_LAYOUTS, ...persisted.customPaneLayouts]</code
+          >， 再用每个 session 的 <code>layoutId</code> 和
+          <code>placements</code>
+          恢复 pane 布局。
+        </p>
+        <div class="code">
+          <pre>
+interface PersistedWorkspaceLayoutSnapshot {
+  schemaVersion: 1
+  customPaneLayouts: readonly PaneLayoutDefinition[]
+  sessions: readonly PersistedWorkspaceSessionShape[]
+}
+
+interface PersistedWorkspaceSessionShape {
+  id: string
+  projectId: string
+  layoutId: PaneLayoutId
+  placements: readonly PanePlacement[]
+  workingDirectory: string
+  active: boolean
+  panes: PersistedWorkspacePaneShape[]
+}</pre
+          >
+        </div>
+        <div class="note">
+          <p>
+            <strong>fallback：</strong>restore 时如果 layoutId
+            找不到、definition 无效、 或 placements 指向不存在的 slot，则降级到
+            <code>single</code> 或最近的 builtin grid，并记录 warning。不要让坏
+            layout 阻塞 session restore。
+          </p>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>实现顺序</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>阶段</th>
+              <th>目标</th>
+              <th>为什么先做</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>PR 1</td>
+              <td>
+                引入 <code>PaneLayoutDefinition</code>、validator、derived
+                grid/divider helpers
+              </td>
+              <td>先把 runtime SSoT 定住，避免 UI 设计绑死错误结构</td>
+            </tr>
+            <tr>
+              <td>PR 2</td>
+              <td>把现有 builtin layouts 迁移到 definition model</td>
+              <td>证明新模型能无回归表达 single/vsplit/hsplit/quad/grid3x2</td>
+            </tr>
+            <tr>
+              <td>PR 3</td>
+              <td>
+                workspace/session snapshot 增加
+                <code>customPaneLayouts</code> 与 placement restore 兼容层
+              </td>
+              <td>自定义布局必须能 reload，不然只是临时 UI</td>
+            </tr>
+            <tr>
+              <td>PR 4</td>
+              <td>增加 Workspace Customization Plane</td>
+              <td>此时 UI 只是在编辑 draft，不需要发明自己的 runtime model</td>
+            </tr>
+            <tr>
+              <td>PR 5</td>
+              <td>增加 templates：2x3、3x3、4x4、Main + 3 stack</td>
+              <td>模板只是 definition factory，不再污染 SplitView</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="section">
+        <h2>需要特别防范的耦合</h2>
+        <div class="grid-2">
+          <article class="card">
+            <span class="label danger">风险</span>
+            <h3>pane count 驱动 layout</h3>
+            <p>
+              旧 autoshrink 是按 pane 数决定 layout。自定义布局里 empty slot
+              是合法状态， 所以不能一关 pane 就自动坍缩 layout。autoshrink
+              应该变成 registry policy， 并且默认只作用于 builtin presets。
+            </p>
+          </article>
+          <article class="card">
+            <span class="label danger">风险</span>
+            <h3>layout id 到处 switch</h3>
+            <p>
+              新 layout 不应该要求修改
+              <code>SplitView</code>、<code>SplitDividers</code>、
+              <code>LayoutGlyph</code>、restore、shortcut
+              多个模块。调用方应只消费 registry 的 resolved model。
+            </p>
+          </article>
+          <article class="card">
+            <span class="label danger">风险</span>
+            <h3>customization draft 泄漏到 runtime</h3>
+            <p>
+              draft 可以暂时 invalid；runtime 不行。Apply 之前必须经过
+              validator， 且生成 canonical definition。
+            </p>
+          </article>
+          <article class="card">
+            <span class="label danger">风险</span>
+            <h3>只持久化 layoutId</h3>
+            <p>
+              对 custom layout 来说，只有 id 不够。必须把
+              <code>customPaneLayouts</code> 跟 workspace/session snapshot
+              一起持久化， 否则 reload 后 id 没有 definition 可解析。
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <p class="footer">
+        建议结论：先做 SSoT 数据结构和 validator，再做 customization plane。UI
+        可以大胆， 但 runtime 必须保守：只有合法、可派生、可恢复的 layout
+        definition 能进入 session。
+      </p>
+    </main>
+  </body>
+</html>

--- a/electron/workspace-layout-controller.test.ts
+++ b/electron/workspace-layout-controller.test.ts
@@ -32,6 +32,7 @@ const makeSidecar = (
 })
 
 const sampleShape = (): PersistedWorkspaceShape => ({
+  customPaneLayouts: [],
   sessions: [
     {
       id: 's1',
@@ -59,6 +60,7 @@ const sampleShape = (): PersistedWorkspaceShape => ({
 
 const sampleStore = (): PersistedWorkspaceLayoutStore => ({
   version: 1,
+  customPaneLayouts: [],
   sessions: [
     {
       id: 's1',
@@ -430,11 +432,18 @@ describe('WorkspaceLayoutController', () => {
         handlers.get(WORKSPACE_LAYOUT_LOAD_FOR_RESTORE)?.({}, payload)
       )
 
-    await expect(loadForRestore(null)).resolves.toEqual({ sessions: [] })
+    await expect(loadForRestore(null)).resolves.toEqual({
+      customPaneLayouts: [],
+      sessions: [],
+    })
 
-    await expect(loadForRestore({})).resolves.toEqual({ sessions: [] })
+    await expect(loadForRestore({})).resolves.toEqual({
+      customPaneLayouts: [],
+      sessions: [],
+    })
 
     await expect(loadForRestore({ projectId: 'proj-1' })).resolves.toEqual({
+      customPaneLayouts: [],
       sessions: [],
     })
 

--- a/electron/workspace-layout-controller.ts
+++ b/electron/workspace-layout-controller.ts
@@ -66,6 +66,7 @@ const paneToShape = (
 const storeToShape = (
   store: PersistedWorkspaceLayoutStore
 ): PersistedWorkspaceShape => ({
+  customPaneLayouts: store.customPaneLayouts,
   sessions: store.sessions.map((session) => ({
     id: session.id,
     projectId: session.projectId,
@@ -77,7 +78,10 @@ const storeToShape = (
   })),
 })
 
-const emptyWorkspaceShape = (): PersistedWorkspaceShape => ({ sessions: [] })
+const emptyWorkspaceShape = (): PersistedWorkspaceShape => ({
+  customPaneLayouts: [],
+  sessions: [],
+})
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -147,8 +151,18 @@ const isPersistedWorkspaceShape = (
   dto: unknown
 ): dto is PersistedWorkspaceShape =>
   isRecord(dto) &&
+  (dto.customPaneLayouts === undefined ||
+    (Array.isArray(dto.customPaneLayouts) &&
+      dto.customPaneLayouts.every(isRecord))) &&
   Array.isArray(dto.sessions) &&
   dto.sessions.every(isPersistedWorkspaceSessionShape)
+
+const normalizeWorkspaceShape = (
+  dto: PersistedWorkspaceShape
+): PersistedWorkspaceShape => ({
+  customPaneLayouts: dto.customPaneLayouts ?? [],
+  sessions: dto.sessions,
+})
 
 const cloneTabs = (tabs: PersistedTab[]): PersistedTab[] =>
   tabs.map((tab) => ({
@@ -188,9 +202,11 @@ export class WorkspaceLayoutController {
   }
 
   pushShape(dto: PersistedWorkspaceShape): void {
-    this.shape = dto
-    this.writer.onShapePushed(dto)
-    this.resolveFinalShape(dto)
+    const normalized = normalizeWorkspaceShape(dto)
+
+    this.shape = normalized
+    this.writer.onShapePushed(normalized)
+    this.resolveFinalShape(normalized)
   }
 
   async loadForRestore(

--- a/electron/workspace-layout-roundtrip.test.ts
+++ b/electron/workspace-layout-roundtrip.test.ts
@@ -6,10 +6,53 @@ import {
 } from './workspace-layout-writer'
 import { WorkspaceTeardown } from './workspace-teardown'
 import type {
+  PersistedPaneLayoutDefinition,
   PersistedTab,
   PersistedWorkspaceLayoutStore,
   PersistedWorkspaceShape,
 } from './workspace-layout-types'
+
+const customPaneLayout = (): PersistedPaneLayoutDefinition => ({
+  schemaVersion: 1,
+  id: 'custom:main-side-stack',
+  title: 'Main + side stack',
+  source: 'workspace',
+  tracks: {
+    columns: [
+      { id: 'main', units: 16 },
+      { id: 'side', units: 8 },
+    ],
+    rows: [
+      { id: 'top', units: 8 },
+      { id: 'middle', units: 8 },
+      { id: 'bottom', units: 8 },
+    ],
+  },
+  slots: [
+    {
+      id: 'slot:main',
+      rect: { col: 0, row: 0, colSpan: 1, rowSpan: 3 },
+    },
+    {
+      id: 'slot:side-top',
+      rect: { col: 1, row: 0, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: 'slot:side-middle',
+      rect: { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: 'slot:side-bottom',
+      rect: { col: 1, row: 2, colSpan: 1, rowSpan: 1 },
+    },
+  ],
+  addOrder: [
+    'slot:main',
+    'slot:side-top',
+    'slot:side-middle',
+    'slot:side-bottom',
+  ],
+})
 
 const browserOnlyTabs: PersistedTab[] = [
   {
@@ -40,6 +83,7 @@ const mixedTabs: PersistedTab[] = [
 ]
 
 const roundTripShape = (): PersistedWorkspaceShape => ({
+  customPaneLayouts: [customPaneLayout()],
   sessions: [
     {
       id: 'ws-browser',
@@ -99,6 +143,7 @@ const makeRoundTripHarness = (): {
       return Promise.resolve(
         (store ?? {
           version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+          customPaneLayouts: [],
           sessions: [],
         }) as T
       )
@@ -144,6 +189,7 @@ describe('workspace layout round trip', () => {
 
     expect(harness.savedStore()).toEqual({
       version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+      customPaneLayouts: shape.customPaneLayouts,
       sessions: [
         {
           ...shape.sessions[0],
@@ -192,6 +238,7 @@ describe('workspace layout round trip', () => {
     const shape = roundTripShape()
 
     const browserOnlyShape: PersistedWorkspaceShape = {
+      customPaneLayouts: shape.customPaneLayouts,
       sessions: [shape.sessions[0]],
     }
 
@@ -215,5 +262,8 @@ describe('workspace layout round trip', () => {
     })
 
     expect(restoreShape.sessions).toEqual(browserOnlyShape.sessions)
+    expect(restoreShape.customPaneLayouts).toEqual(
+      browserOnlyShape.customPaneLayouts
+    )
   })
 })

--- a/electron/workspace-layout-types.ts
+++ b/electron/workspace-layout-types.ts
@@ -43,7 +43,37 @@ export interface PersistedBrowserPane {
 
 export type PersistedWorkspacePane = PersistedShellPane | PersistedBrowserPane
 
-export type PersistedPaneLayoutDefinition = Record<string, unknown>
+export interface PersistedTrackSpec {
+  readonly id: string
+  readonly units: number
+  readonly minPx?: number
+}
+
+export interface PersistedPaneSlotRect {
+  readonly col: number
+  readonly row: number
+  readonly colSpan: number
+  readonly rowSpan: number
+}
+
+export interface PersistedPaneSlotSpec {
+  readonly id: string
+  readonly rect: PersistedPaneSlotRect
+  readonly accepts?: readonly string[]
+}
+
+export interface PersistedPaneLayoutDefinition {
+  readonly schemaVersion: number
+  readonly id: string
+  readonly title: string
+  readonly source: 'builtin' | 'workspace'
+  readonly tracks: {
+    readonly columns: readonly PersistedTrackSpec[]
+    readonly rows: readonly PersistedTrackSpec[]
+  }
+  readonly slots: readonly PersistedPaneSlotSpec[]
+  readonly addOrder: readonly string[]
+}
 
 export interface PersistedWorkspaceSession {
   id: string

--- a/electron/workspace-layout-types.ts
+++ b/electron/workspace-layout-types.ts
@@ -43,6 +43,8 @@ export interface PersistedBrowserPane {
 
 export type PersistedWorkspacePane = PersistedShellPane | PersistedBrowserPane
 
+export type PersistedPaneLayoutDefinition = Record<string, unknown>
+
 export interface PersistedWorkspaceSession {
   id: string
   projectId: string
@@ -55,6 +57,7 @@ export interface PersistedWorkspaceSession {
 
 export interface PersistedWorkspaceLayoutStore {
   version: number
+  customPaneLayouts: PersistedPaneLayoutDefinition[]
   sessions: PersistedWorkspaceSession[]
 }
 
@@ -93,6 +96,7 @@ export interface PersistedWorkspaceSessionShape {
 }
 
 export interface PersistedWorkspaceShape {
+  customPaneLayouts?: PersistedPaneLayoutDefinition[]
   sessions: PersistedWorkspaceSessionShape[]
 }
 

--- a/electron/workspace-layout-writer.test.ts
+++ b/electron/workspace-layout-writer.test.ts
@@ -9,6 +9,7 @@ import type {
 } from './workspace-layout-types'
 
 const shape = (): PersistedWorkspaceShape => ({
+  customPaneLayouts: [],
   sessions: [
     {
       id: 's1',
@@ -74,6 +75,7 @@ describe('WorkspaceLayoutWriter', () => {
 
     expect(writer.assemble()).toEqual({
       version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+      customPaneLayouts: [],
       sessions: [
         {
           id: 's1',

--- a/electron/workspace-layout-writer.ts
+++ b/electron/workspace-layout-writer.ts
@@ -174,6 +174,7 @@ export class WorkspaceLayoutWriter
 
     return {
       version: CURRENT_WORKSPACE_LAYOUT_VERSION,
+      customPaneLayouts: this.shape.customPaneLayouts ?? [],
       sessions,
     }
   }

--- a/src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts
+++ b/src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts
@@ -7,6 +7,7 @@ import {
 } from './usePushWorkspaceGrouping'
 import { emptyActivity } from '../constants'
 import type { Pane, Session } from '../types'
+import type { PaneLayoutDefinition } from '../../terminal/layout-registry'
 
 const workspaceLayoutMock = vi.hoisted(() => {
   const finalShapeCallbacks: (() => void)[] = []
@@ -77,9 +78,28 @@ const makeSession = (over: Partial<Session> = {}): Session => ({
   ...over,
 })
 
+const customLayout: PaneLayoutDefinition = {
+  schemaVersion: 1,
+  id: 'custom:test',
+  title: 'Custom test',
+  source: 'workspace',
+  tracks: {
+    columns: [{ id: 'main', units: 24 }],
+    rows: [{ id: 'main', units: 24 }],
+  },
+  slots: [
+    {
+      id: 'slot:main',
+      rect: { col: 0, row: 0, colSpan: 1, rowSpan: 1 },
+    },
+  ],
+  addOrder: ['slot:main'],
+}
+
 describe('buildWorkspaceShape', () => {
   test('maps the session tree to a kind-tagged shape DTO (no browser tabs)', () => {
     expect(buildWorkspaceShape([makeSession()], 's1')).toEqual({
+      customPaneLayouts: [],
       sessions: [
         {
           id: 's1',
@@ -110,6 +130,13 @@ describe('buildWorkspaceShape', () => {
     expect(
       buildWorkspaceShape([makeSession()], 'other').sessions[0].active
     ).toBe(false)
+  })
+
+  test('carries custom pane layout definitions in the same snapshot', () => {
+    expect(
+      buildWorkspaceShape([makeSession()], 's1', [customLayout])
+        .customPaneLayouts
+    ).toEqual([customLayout])
   })
 })
 
@@ -143,7 +170,11 @@ describe('usePushWorkspaceGrouping', () => {
         loading: false,
       })
     )
-    expect(pushWorkspaceShape).toHaveBeenCalledWith({ sessions: [] })
+
+    expect(pushWorkspaceShape).toHaveBeenCalledWith({
+      customPaneLayouts: [],
+      sessions: [],
+    })
   })
 
   test('does not push an empty shape when empty writes are disallowed', () => {
@@ -341,7 +372,11 @@ describe('usePushWorkspaceGrouping', () => {
       activeSessionId: null,
       loading: false,
     })
-    expect(pushWorkspaceShape).toHaveBeenCalledWith({ sessions: [] })
+
+    expect(pushWorkspaceShape).toHaveBeenCalledWith({
+      customPaneLayouts: [],
+      sessions: [],
+    })
 
     vi.advanceTimersByTime(500)
     expect(pushWorkspaceShape).toHaveBeenCalledTimes(1)

--- a/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
+++ b/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
@@ -24,6 +24,7 @@ import {
   type PersistedWorkspaceShape,
   type PersistedWorkspacePaneShape,
 } from '../workspaceLayoutBridge'
+import type { PaneLayoutDefinition } from '../../terminal/layout-registry'
 import { isShellPane } from '../utils/paneKind'
 import { isOpenSession } from '../utils/sessionStatus'
 import type { Session } from '../types'
@@ -50,8 +51,10 @@ const pushShapeWithLog = async (
  */
 export const buildWorkspaceShape = (
   sessions: readonly Session[],
-  activeSessionId: string | null
+  activeSessionId: string | null,
+  customPaneLayouts: readonly PaneLayoutDefinition[] = []
 ): PersistedWorkspaceShape => ({
+  customPaneLayouts,
   sessions: sessions.map((session) => ({
     id: session.id,
     projectId: session.projectId,
@@ -85,8 +88,9 @@ export const buildWorkspaceShape = (
 // Signature of the structural half (everything except cwd/agentType drift), so
 // a `cd` or agent-detection update debounces instead of pushing eagerly.
 const structuralSignature = (shape: PersistedWorkspaceShape): string =>
-  JSON.stringify(
-    shape.sessions.map((session) => ({
+  JSON.stringify({
+    customPaneLayouts: shape.customPaneLayouts ?? [],
+    sessions: shape.sessions.map((session) => ({
       id: session.id,
       projectId: session.projectId,
       layout: session.layout,
@@ -100,11 +104,12 @@ const structuralSignature = (shape: PersistedWorkspaceShape): string =>
         active: pane.active,
         ptyId: pane.kind === 'shell' ? pane.ptyId : null,
       })),
-    }))
-  )
+    })),
+  })
 
 export interface UsePushWorkspaceGroupingOptions {
   sessions: readonly Session[]
+  customPaneLayouts?: readonly PaneLayoutDefinition[]
   /** The active workspace session id, so the DTO marks which session restore
    *  should reselect. */
   activeSessionId: string | null
@@ -118,13 +123,14 @@ export interface UsePushWorkspaceGroupingOptions {
 
 export const usePushWorkspaceGrouping = ({
   sessions,
+  customPaneLayouts = [],
   activeSessionId,
   loading,
   canPushEmptyShape = true,
 }: UsePushWorkspaceGroupingOptions): void => {
   const shape = useMemo(
-    () => buildWorkspaceShape(sessions, activeSessionId),
-    [sessions, activeSessionId]
+    () => buildWorkspaceShape(sessions, activeSessionId, customPaneLayouts),
+    [sessions, activeSessionId, customPaneLayouts]
   )
 
   // Last full + structural shape JSON, to skip no-op rerenders and to tell a

--- a/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
+++ b/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
@@ -31,6 +31,8 @@ import type { Session } from '../types'
 
 const log = createLogger('grouping')
 
+const EMPTY_CUSTOM_PANE_LAYOUTS: readonly PaneLayoutDefinition[] = []
+
 const DRIFT_DEBOUNCE_MS = 500
 
 const pushShapeWithLog = async (
@@ -123,7 +125,7 @@ export interface UsePushWorkspaceGroupingOptions {
 
 export const usePushWorkspaceGrouping = ({
   sessions,
-  customPaneLayouts = [],
+  customPaneLayouts = EMPTY_CUSTOM_PANE_LAYOUTS,
   activeSessionId,
   loading,
   canPushEmptyShape = true,

--- a/src/features/sessions/hooks/useSessionRestore.ts
+++ b/src/features/sessions/hooks/useSessionRestore.ts
@@ -82,6 +82,7 @@ const shapeWithRestartedShell = (
   selection: StoreShellSelection,
   liveSession: SessionInfo
 ): PersistedWorkspaceShape => ({
+  customPaneLayouts: storeShape.customPaneLayouts,
   sessions: storeShape.sessions.map((session) =>
     session.id !== selection.sessionId
       ? session

--- a/src/features/sessions/workspaceLayoutBridge.ts
+++ b/src/features/sessions/workspaceLayoutBridge.ts
@@ -5,6 +5,8 @@
 // The shape-only DTO defined here is the renderer<->main contract: it carries
 // pane existence + shell fields, never browser tab/history (main owns those).
 
+import type { PaneLayoutDefinition } from '../terminal/layout-registry'
+
 export interface PersistedShellPaneShape {
   kind: 'shell'
   paneId: string
@@ -38,6 +40,7 @@ export interface PersistedWorkspaceSessionShape {
 }
 
 export interface PersistedWorkspaceShape {
+  customPaneLayouts?: readonly PaneLayoutDefinition[]
   sessions: PersistedWorkspaceSessionShape[]
 }
 

--- a/src/features/terminal/components/SplitView/SplitDividers.tsx
+++ b/src/features/terminal/components/SplitView/SplitDividers.tsx
@@ -3,7 +3,12 @@ import { Fragment, useCallback, type ReactElement, type RefObject } from 'react'
 import { ResizeHandle } from '@/components/ResizeHandle'
 import type { LayoutId } from '../../../sessions/types'
 import { useSplitDivider } from './useSplitDivider'
-import type { LayoutRatios, RatioAxis } from '../../layout-registry'
+import {
+  LAYOUTS,
+  type DividerHandleSpec,
+  type LayoutRatios,
+  type RatioAxis,
+} from '../../layout-registry'
 
 export interface SplitDividersProps {
   layout: LayoutId
@@ -14,133 +19,11 @@ export interface SplitDividersProps {
 
 const HANDLE_TEST_ID = 'split-resize-handle'
 
-type DividerDragAxis = 'horizontal' | 'vertical'
-type DividerOrientation = 'vertical' | 'horizontal'
-
-interface DividerHandleSpec {
-  readonly id: string
-  readonly gridArea: string
-  readonly dragAxis: DividerDragAxis
-  readonly orientation: DividerOrientation
-  readonly trackAxis: RatioAxis
-  readonly trackIndex: number
-}
-
 interface DividerGroup {
   readonly trackAxis: RatioAxis
   readonly trackIndex: number
-  readonly dragAxis: DividerDragAxis
+  readonly dragAxis: DividerHandleSpec['dragAxis']
   readonly handles: readonly DividerHandleSpec[]
-}
-
-const DIVIDER_SPECS: Record<LayoutId, readonly DividerHandleSpec[]> = {
-  single: [],
-  vsplit: [
-    {
-      id: 'vdiv',
-      gridArea: 'vdiv',
-      dragAxis: 'horizontal',
-      orientation: 'vertical',
-      trackAxis: 'cols',
-      trackIndex: 0,
-    },
-  ],
-  hsplit: [
-    {
-      id: 'hdiv',
-      gridArea: 'hdiv',
-      dragAxis: 'vertical',
-      orientation: 'horizontal',
-      trackAxis: 'rows',
-      trackIndex: 0,
-    },
-  ],
-  threeRight: [
-    {
-      id: 'vdiv',
-      gridArea: 'vdiv',
-      dragAxis: 'horizontal',
-      orientation: 'vertical',
-      trackAxis: 'cols',
-      trackIndex: 0,
-    },
-    {
-      id: 'hdiv',
-      gridArea: 'hdiv',
-      dragAxis: 'vertical',
-      orientation: 'horizontal',
-      trackAxis: 'rows',
-      trackIndex: 0,
-    },
-  ],
-  quad: [
-    {
-      id: 'vdiv0',
-      gridArea: 'vdiv0',
-      dragAxis: 'horizontal',
-      orientation: 'vertical',
-      trackAxis: 'cols',
-      trackIndex: 0,
-    },
-    {
-      id: 'vdiv1',
-      gridArea: 'vdiv1',
-      dragAxis: 'horizontal',
-      orientation: 'vertical',
-      trackAxis: 'cols',
-      trackIndex: 0,
-    },
-    {
-      id: 'hdiv',
-      gridArea: 'hdiv',
-      dragAxis: 'vertical',
-      orientation: 'horizontal',
-      trackAxis: 'rows',
-      trackIndex: 0,
-    },
-  ],
-  grid3x2: [
-    {
-      id: 'vdiv0a',
-      gridArea: 'vdiv0a',
-      dragAxis: 'horizontal',
-      orientation: 'vertical',
-      trackAxis: 'cols',
-      trackIndex: 0,
-    },
-    {
-      id: 'vdiv0b',
-      gridArea: 'vdiv0b',
-      dragAxis: 'horizontal',
-      orientation: 'vertical',
-      trackAxis: 'cols',
-      trackIndex: 0,
-    },
-    {
-      id: 'vdiv1a',
-      gridArea: 'vdiv1a',
-      dragAxis: 'horizontal',
-      orientation: 'vertical',
-      trackAxis: 'cols',
-      trackIndex: 1,
-    },
-    {
-      id: 'vdiv1b',
-      gridArea: 'vdiv1b',
-      dragAxis: 'horizontal',
-      orientation: 'vertical',
-      trackAxis: 'cols',
-      trackIndex: 1,
-    },
-    {
-      id: 'hdiv',
-      gridArea: 'hdiv',
-      dragAxis: 'vertical',
-      orientation: 'horizontal',
-      trackAxis: 'rows',
-      trackIndex: 0,
-    },
-  ],
 }
 
 const groupKey = (trackAxis: RatioAxis, trackIndex: number): string =>
@@ -231,7 +114,7 @@ export const SplitDividers = ({
   ratios,
   onRatioChange,
 }: SplitDividersProps): ReactElement | null => {
-  const specs = DIVIDER_SPECS[layout]
+  const specs = LAYOUTS[layout].dividers
 
   if (specs.length === 0) {
     return null

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -240,7 +240,7 @@ describe('SplitView - multi-pane layouts', () => {
     ])
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
-      gridTemplateAreas: '"p0 vdiv p1"',
+      gridTemplateAreas: '"p0 vdiv-c0 p1"',
     })
   })
 
@@ -254,7 +254,7 @@ describe('SplitView - multi-pane layouts', () => {
     )
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
-      gridTemplateAreas: '"p0" "hdiv" "p1"',
+      gridTemplateAreas: '"p0" "hdiv-r0" "p1"',
     })
     expect(screen.getAllByTestId('split-view-slot')).toHaveLength(2)
   })
@@ -269,7 +269,8 @@ describe('SplitView - multi-pane layouts', () => {
     )
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
-      gridTemplateAreas: '"p0 vdiv p1" "p0 vdiv hdiv" "p0 vdiv p2"',
+      gridTemplateAreas:
+        '"p0 vdiv-c0 p1" "p0 vdiv-c0 hdiv-r0-c1" "p0 vdiv-c0 p2"',
     })
     expect(screen.getAllByTestId('split-view-slot')).toHaveLength(3)
   })
@@ -284,7 +285,8 @@ describe('SplitView - multi-pane layouts', () => {
     )
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
-      gridTemplateAreas: '"p0 vdiv0 p1" "hdiv hdiv hdiv" "p2 vdiv1 p3"',
+      gridTemplateAreas:
+        '"p0 vdiv-c0-r0 p1" "hdiv-r0 hdiv-r0 hdiv-r0" "p2 vdiv-c0-r1 p3"',
     })
     expect(screen.getAllByTestId('split-view-slot')).toHaveLength(4)
   })
@@ -300,7 +302,7 @@ describe('SplitView - multi-pane layouts', () => {
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
       gridTemplateAreas:
-        '"p0 vdiv0a p1 vdiv1a p2" "hdiv hdiv hdiv hdiv hdiv" "p3 vdiv0b p4 vdiv1b p5"',
+        '"p0 vdiv-c0-r0 p1 vdiv-c1-r0 p2" "hdiv-r0 hdiv-r0 hdiv-r0 hdiv-r0 hdiv-r0" "p3 vdiv-c0-r1 p4 vdiv-c1-r1 p5"',
     })
     expect(screen.getAllByTestId('split-view-slot')).toHaveLength(6)
     expect(screen.getAllByTestId('split-resize-handle')).toHaveLength(5)
@@ -534,7 +536,8 @@ describe('SplitView - under-capacity', () => {
     )
 
     expect(screen.getByTestId('split-view')).toHaveStyle({
-      gridTemplateAreas: '"p0 vdiv0 p1" "hdiv hdiv hdiv" "p2 vdiv1 p3"',
+      gridTemplateAreas:
+        '"p0 vdiv-c0-r0 p1" "hdiv-r0 hdiv-r0 hdiv-r0" "p2 vdiv-c0-r1 p3"',
     })
   })
 

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -29,6 +29,7 @@ import { resolveGrid } from './resolveGrid'
 import {
   DEFAULT_RATIOS,
   equalTrackRatios,
+  gridAreaNameForSlotId,
   type LayoutRatios,
   type RatioAxis,
 } from '../../layout-registry'
@@ -239,6 +240,14 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
       .map((row) => `"${row.join(' ')}"`)
       .join(' ')
 
+    const gridAreaForSlotIndex = (slotIndex: number): string => {
+      if (slotIndex < 0 || slotIndex >= layout.definition.slots.length) {
+        return `p${slotIndex}`
+      }
+
+      return gridAreaNameForSlotId(layout.definition.slots[slotIndex].id)
+    }
+
     return (
       <div
         data-testid="split-view-canvas"
@@ -293,7 +302,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                   data-mode={mode}
                   data-cwd={pane.cwd}
                   className="relative min-h-0 min-w-0"
-                  style={{ gridArea: `p${i}` }}
+                  style={{ gridArea: gridAreaForSlotIndex(i) }}
                 >
                   {/* Inner Tooltip wrapper. The motion.div above carries
                   the click handler + grid placement; this inner Tooltip
@@ -375,7 +384,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                     data-testid="split-view-empty-slot"
                     data-slot-index={slotIndex}
                     className="relative min-h-0 min-w-0"
-                    style={{ gridArea: `p${slotIndex}` }}
+                    style={{ gridArea: gridAreaForSlotIndex(slotIndex) }}
                   >
                     <EmptySlot sessionId={session.id} onAddPane={onAddPane} />
                   </motion.div>

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -241,11 +241,13 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
       .join(' ')
 
     const gridAreaForSlotIndex = (slotIndex: number): string => {
-      if (slotIndex < 0 || slotIndex >= layout.definition.slots.length) {
-        return `p${slotIndex}`
+      if (slotIndex < 0 || slotIndex >= layout.definition.addOrder.length) {
+        throw new Error(
+          `Slot index ${slotIndex} is out of bounds for layout ${layout.definition.id}`
+        )
       }
 
-      return gridAreaNameForSlotId(layout.definition.slots[slotIndex].id)
+      return gridAreaNameForSlotId(layout.definition.addOrder[slotIndex])
     }
 
     return (

--- a/src/features/terminal/components/SplitView/resolveGrid.test.ts
+++ b/src/features/terminal/components/SplitView/resolveGrid.test.ts
@@ -16,7 +16,7 @@ describe('resolveGrid', () => {
       `var(--split-cols-0, 1fr) ${SPLIT_DIVIDER_PX}px var(--split-cols-1, 1fr)`
     )
     expect(g.rows).toBe('minmax(0,1fr)')
-    expect(g.areas).toEqual([['p0', 'vdiv', 'p1']])
+    expect(g.areas).toEqual([['p0', 'vdiv-c0', 'p1']])
   })
 
   test('hsplit emits two row fr vars summing to 1', () => {
@@ -24,33 +24,33 @@ describe('resolveGrid', () => {
     expect(g.rows).toBe(
       `var(--split-rows-0, 0.4fr) ${SPLIT_DIVIDER_PX}px var(--split-rows-1, 0.6fr)`
     )
-    expect(g.areas).toEqual([['p0'], ['hdiv'], ['p1']])
+    expect(g.areas).toEqual([['p0'], ['hdiv-r0'], ['p1']])
   })
 
   test('threeRight spans p0 + vdiv across all rows; hdiv only in right column', () => {
     const g = resolveGrid('threeRight', { cols: [1.4, 1], rows: [1, 1] })
     expect(g.areas).toEqual([
-      ['p0', 'vdiv', 'p1'],
-      ['p0', 'vdiv', 'hdiv'],
-      ['p0', 'vdiv', 'p2'],
+      ['p0', 'vdiv-c0', 'p1'],
+      ['p0', 'vdiv-c0', 'hdiv-r0-c1'],
+      ['p0', 'vdiv-c0', 'p2'],
     ])
   })
 
   test('quad segments the column bar around the full-width row bar', () => {
     const g = resolveGrid('quad', { cols: [1, 1], rows: [1, 1] })
     expect(g.areas).toEqual([
-      ['p0', 'vdiv0', 'p1'],
-      ['hdiv', 'hdiv', 'hdiv'],
-      ['p2', 'vdiv1', 'p3'],
+      ['p0', 'vdiv-c0-r0', 'p1'],
+      ['hdiv-r0', 'hdiv-r0', 'hdiv-r0'],
+      ['p2', 'vdiv-c0-r1', 'p3'],
     ])
   })
 
   test('grid3x2 segments both column bars around the full-width row bar', () => {
     const g = resolveGrid('grid3x2', { cols: [1, 1, 1], rows: [1, 1] })
     expect(g.areas).toEqual([
-      ['p0', 'vdiv0a', 'p1', 'vdiv1a', 'p2'],
-      ['hdiv', 'hdiv', 'hdiv', 'hdiv', 'hdiv'],
-      ['p3', 'vdiv0b', 'p4', 'vdiv1b', 'p5'],
+      ['p0', 'vdiv-c0-r0', 'p1', 'vdiv-c1-r0', 'p2'],
+      ['hdiv-r0', 'hdiv-r0', 'hdiv-r0', 'hdiv-r0', 'hdiv-r0'],
+      ['p3', 'vdiv-c0-r1', 'p4', 'vdiv-c1-r1', 'p5'],
     ])
   })
 

--- a/src/features/terminal/components/SplitView/resolveGrid.ts
+++ b/src/features/terminal/components/SplitView/resolveGrid.ts
@@ -2,14 +2,13 @@
 import type { LayoutId } from '../../../sessions/types'
 import {
   DEFAULT_RATIOS,
+  LAYOUTS,
+  SPLIT_DIVIDER_PX,
   buildTrackTemplate,
   type LayoutRatios,
 } from '../../layout-registry'
 
-export { DEFAULT_RATIOS }
-
-/** Width of the divider track that replaces the inter-pane gap (px). */
-export const SPLIT_DIVIDER_PX = 8
+export { DEFAULT_RATIOS, SPLIT_DIVIDER_PX }
 
 export interface ResolvedGrid {
   cols: string
@@ -23,47 +22,7 @@ export const resolveGrid = (
 ): ResolvedGrid => {
   const cols = buildTrackTemplate('cols', ratios.cols, SPLIT_DIVIDER_PX)
   const rows = buildTrackTemplate('rows', ratios.rows, SPLIT_DIVIDER_PX)
+  const layout = LAYOUTS[layoutId]
 
-  switch (layoutId) {
-    case 'single':
-      return { cols: 'minmax(0,1fr)', rows: 'minmax(0,1fr)', areas: [['p0']] }
-    case 'vsplit':
-      return { cols, rows: 'minmax(0,1fr)', areas: [['p0', 'vdiv', 'p1']] }
-    case 'hsplit':
-      return {
-        cols: 'minmax(0,1fr)',
-        rows,
-        areas: [['p0'], ['hdiv'], ['p1']],
-      }
-    case 'threeRight':
-      return {
-        cols,
-        rows,
-        areas: [
-          ['p0', 'vdiv', 'p1'],
-          ['p0', 'vdiv', 'hdiv'],
-          ['p0', 'vdiv', 'p2'],
-        ],
-      }
-    case 'quad':
-      return {
-        cols,
-        rows,
-        areas: [
-          ['p0', 'vdiv0', 'p1'],
-          ['hdiv', 'hdiv', 'hdiv'],
-          ['p2', 'vdiv1', 'p3'],
-        ],
-      }
-    case 'grid3x2':
-      return {
-        cols,
-        rows,
-        areas: [
-          ['p0', 'vdiv0a', 'p1', 'vdiv1a', 'p2'],
-          ['hdiv', 'hdiv', 'hdiv', 'hdiv', 'hdiv'],
-          ['p3', 'vdiv0b', 'p4', 'vdiv1b', 'p5'],
-        ],
-      }
-  }
+  return { cols, rows, areas: layout.gridAreas }
 }

--- a/src/features/terminal/layout-registry/index.ts
+++ b/src/features/terminal/layout-registry/index.ts
@@ -11,7 +11,60 @@ export { LAYOUT_IDS } from './layoutIds'
 export { LAYOUT_SPECS, type LayoutShape } from './layoutSpecs'
 
 export {
+  assemblePaneLayoutRegistry,
+  createIndexedPaneSlotId,
+  createPaneSlotId,
+  getPaneLayoutCapacity,
+  getPaneLayoutRatios,
+  gridAreaNameForSlotId,
+  isBuiltinPaneLayoutId,
+  isCustomPaneLayoutId,
+  isLayoutSlotId,
+  isPaneLayoutId,
+  validatePaneLayoutDefinition,
+  CUSTOM_PANE_LAYOUT_ID_PREFIX,
+  LAYOUT_SLOT_ID_PREFIX,
+  MAX_LAYOUT_SLOTS,
+  MAX_LAYOUT_TRACKS,
+  MIN_LAYOUT_SLOTS,
+  MIN_LAYOUT_TRACKS,
+  PANE_LAYOUT_SCHEMA_VERSION,
+  type BuiltinPaneLayoutId,
+  type CustomPaneLayoutId,
+  type LayoutSlotId,
+  type PaneLayoutDefinition,
+  type PaneLayoutId,
+  type PaneLayoutRegistrySnapshot,
+  type PaneLayoutSchemaVersion,
+  type PaneLayoutSource,
+  type PaneLayoutValidationCode,
+  type PaneLayoutValidationError,
+  type PaneLayoutValidationResult,
+  type PaneSlotRect,
+  type PaneSlotSpec,
+  type RejectedPaneLayoutDefinition,
+  type TrackSpec,
+} from './layoutDefinition'
+
+export {
+  areaMatrixFromDefinition,
+  resolveAreaGeometry,
+  resolvePaneLayoutGeometry,
+  type DividerDragAxis,
+  type DividerHandleSpec,
+  type DividerOrientation,
+  type LayoutGeometry,
+  type SlotGridArea,
+} from './layoutGeometry'
+
+export {
+  PREBUILT_PANE_LAYOUTS,
+  PREBUILT_PANE_LAYOUTS_BY_ID,
+} from './prebuiltLayouts'
+
+export {
   DEFAULT_RATIOS,
+  SPLIT_DIVIDER_PX,
   buildTrackTemplate,
   equalTrackRatios,
   getTrackBoundaryBounds,

--- a/src/features/terminal/layout-registry/layoutDefinition.test.ts
+++ b/src/features/terminal/layout-registry/layoutDefinition.test.ts
@@ -113,6 +113,38 @@ describe('layoutDefinition', () => {
     expect(codes).toContain('layout-hole')
   })
 
+  test('rejects slots whose sanitized ids collide in the CSS grid', () => {
+    const colliding: PaneLayoutDefinition = {
+      schemaVersion: 1,
+      id: 'custom:colliding',
+      title: 'Colliding',
+      source: 'workspace',
+      tracks: {
+        columns: [{ id: 'only', units: 24 }],
+        rows: [
+          { id: 'top', units: 12 },
+          { id: 'bottom', units: 12 },
+        ],
+      },
+      slots: [
+        {
+          id: createPaneSlotId('a b'),
+          rect: { col: 0, row: 0, colSpan: 1, rowSpan: 1 },
+        },
+        {
+          id: createPaneSlotId('a-b'),
+          rect: { col: 0, row: 1, colSpan: 1, rowSpan: 1 },
+        },
+      ],
+      addOrder: [createPaneSlotId('a b'), createPaneSlotId('a-b')],
+    }
+
+    const codes = validatePaneLayoutDefinition(colliding).errors.map(
+      (error) => error.code
+    )
+    expect(codes).toContain('duplicate-grid-area')
+  })
+
   test('rejects invalid track units and non-unique add order', () => {
     const invalid: PaneLayoutDefinition = {
       ...mainWithSideStack(),

--- a/src/features/terminal/layout-registry/layoutDefinition.test.ts
+++ b/src/features/terminal/layout-registry/layoutDefinition.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from 'vitest'
+import {
+  PREBUILT_PANE_LAYOUTS,
+  assemblePaneLayoutRegistry,
+  createPaneSlotId,
+  getPaneLayoutCapacity,
+  getPaneLayoutRatios,
+  gridAreaNameForSlotId,
+  validatePaneLayoutDefinition,
+  type PaneLayoutDefinition,
+} from '.'
+
+const mainWithSideStack = (): PaneLayoutDefinition => ({
+  schemaVersion: 1,
+  id: 'custom:main-side-stack',
+  title: 'Main + side stack',
+  source: 'workspace',
+  tracks: {
+    columns: [
+      { id: 'main', units: 16 },
+      { id: 'side', units: 8 },
+    ],
+    rows: [
+      { id: 'top', units: 8 },
+      { id: 'middle', units: 8 },
+      { id: 'bottom', units: 8 },
+    ],
+  },
+  slots: [
+    {
+      id: createPaneSlotId('main'),
+      rect: { col: 0, row: 0, colSpan: 1, rowSpan: 3 },
+    },
+    {
+      id: createPaneSlotId('side-top'),
+      rect: { col: 1, row: 0, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('side-middle'),
+      rect: { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('side-bottom'),
+      rect: { col: 1, row: 2, colSpan: 1, rowSpan: 1 },
+    },
+  ],
+  addOrder: [
+    createPaneSlotId('main'),
+    createPaneSlotId('side-top'),
+    createPaneSlotId('side-middle'),
+    createPaneSlotId('side-bottom'),
+  ],
+})
+
+describe('layoutDefinition', () => {
+  test('validates a workspace custom main + side stack layout', () => {
+    const definition = mainWithSideStack()
+    const result = validatePaneLayoutDefinition(definition)
+
+    expect(result.ok).toBe(true)
+    expect(result.errors).toEqual([])
+    expect(getPaneLayoutCapacity(definition)).toBe(4)
+    expect(getPaneLayoutRatios(definition)).toEqual({
+      cols: [16, 8],
+      rows: [8, 8, 8],
+    })
+  })
+
+  test('validates every prebuilt layout definition', () => {
+    expect(PREBUILT_PANE_LAYOUTS).toHaveLength(6)
+    expect(
+      PREBUILT_PANE_LAYOUTS.map((definition) => ({
+        id: definition.id,
+        valid: validatePaneLayoutDefinition(definition).ok,
+      }))
+    ).toEqual([
+      { id: 'single', valid: true },
+      { id: 'vsplit', valid: true },
+      { id: 'hsplit', valid: true },
+      { id: 'threeRight', valid: true },
+      { id: 'quad', valid: true },
+      { id: 'grid3x2', valid: true },
+    ])
+  })
+
+  test('maps indexed prebuilt slots to legacy grid areas and custom slots to safe names', () => {
+    expect(gridAreaNameForSlotId(createPaneSlotId('p0'))).toBe('p0')
+    expect(gridAreaNameForSlotId(createPaneSlotId('main pane'))).toBe(
+      'slot-main-pane'
+    )
+  })
+
+  test('rejects overlap and holes so runtime never receives ambiguous slots', () => {
+    const overlapping: PaneLayoutDefinition = {
+      ...mainWithSideStack(),
+      slots: [
+        {
+          id: createPaneSlotId('a'),
+          rect: { col: 0, row: 0, colSpan: 2, rowSpan: 1 },
+        },
+        {
+          id: createPaneSlotId('b'),
+          rect: { col: 1, row: 0, colSpan: 1, rowSpan: 2 },
+        },
+      ],
+      addOrder: [createPaneSlotId('a'), createPaneSlotId('b')],
+    }
+
+    const codes = validatePaneLayoutDefinition(overlapping).errors.map(
+      (error) => error.code
+    )
+    expect(codes).toContain('slot-overlap')
+    expect(codes).toContain('layout-hole')
+  })
+
+  test('rejects invalid track units and non-unique add order', () => {
+    const invalid: PaneLayoutDefinition = {
+      ...mainWithSideStack(),
+      tracks: {
+        columns: [
+          { id: 'main', units: 0 },
+          { id: 'main', units: 8 },
+        ],
+        rows: [{ id: 'top', units: Number.NaN }],
+      },
+      addOrder: [
+        createPaneSlotId('main'),
+        createPaneSlotId('main'),
+        createPaneSlotId('missing'),
+      ],
+    }
+
+    const codes = validatePaneLayoutDefinition(invalid).errors.map(
+      (error) => error.code
+    )
+    expect(codes).toContain('invalid-track-units')
+    expect(codes).toContain('duplicate-track-id')
+    expect(codes).toContain('invalid-add-order')
+    expect(codes).toContain('duplicate-add-order-slot')
+    expect(codes).toContain('unknown-add-order-slot')
+  })
+
+  test('keeps prebuilt and custom layouts in separate id namespaces', () => {
+    const custom = mainWithSideStack()
+
+    const shadowingCustom: PaneLayoutDefinition = {
+      ...custom,
+      id: 'single',
+      title: 'Bad single override',
+    }
+
+    const registry = assemblePaneLayoutRegistry({
+      prebuilt: PREBUILT_PANE_LAYOUTS,
+      custom: [custom, shadowingCustom],
+    })
+
+    expect(registry.layouts.map((definition) => definition.id)).toEqual([
+      'single',
+      'vsplit',
+      'hsplit',
+      'threeRight',
+      'quad',
+      'grid3x2',
+      'custom:main-side-stack',
+    ])
+    expect(registry.rejected).toHaveLength(1)
+    expect(registry.rejected[0].definition.id).toBe('single')
+    expect(registry.rejected[0].errors.map((error) => error.code)).toContain(
+      'invalid-id-namespace'
+    )
+  })
+})

--- a/src/features/terminal/layout-registry/layoutDefinition.ts
+++ b/src/features/terminal/layout-registry/layoutDefinition.ts
@@ -58,6 +58,7 @@ export type PaneLayoutValidationCode =
   | 'invalid-slot-count'
   | 'invalid-slot-id'
   | 'duplicate-slot-id'
+  | 'duplicate-grid-area'
   | 'invalid-slot-rect'
   | 'slot-out-of-bounds'
   | 'slot-overlap'
@@ -353,6 +354,7 @@ const validateSlots = (
 
   const seenSlots = new Set<LayoutSlotId>()
   const occupiedCells = new Map<string, LayoutSlotId>()
+  const seenGridAreas = new Map<string, LayoutSlotId>()
 
   slots.forEach((slot, index) => {
     const path = `slots.${index}`
@@ -376,6 +378,21 @@ const validateSlots = (
       )
     }
     seenSlots.add(slot.id)
+
+    if (isLayoutSlotId(slot.id)) {
+      const gridArea = gridAreaNameForSlotId(slot.id)
+      const existing = seenGridAreas.get(gridArea)
+      if (existing !== undefined) {
+        errors.push(
+          validationError(
+            'duplicate-grid-area',
+            `${path}.id`,
+            `Slot ${slot.id} produces the same grid area as ${existing} after sanitization.`
+          )
+        )
+      }
+      seenGridAreas.set(gridArea, slot.id)
+    }
 
     for (const paneKind of slot.accepts ?? []) {
       if (!isSupportedPaneKind(paneKind)) {

--- a/src/features/terminal/layout-registry/layoutDefinition.ts
+++ b/src/features/terminal/layout-registry/layoutDefinition.ts
@@ -133,6 +133,13 @@ export const getPaneLayoutCapacity = (
   definition: PaneLayoutDefinition
 ): number => definition.slots.length
 
+/**
+ * Returns the raw track units from a layout definition. For prebuilt layouts
+ * these are normalized to the same scale as the canonical default ratios; for
+ * custom layouts they reflect the values supplied by the caller. Callers that
+ * need the canonical default ratios for drag-state initialization should read
+ * `layout.defaultRatios` instead.
+ */
 export const getPaneLayoutRatios = (
   definition: PaneLayoutDefinition
 ): LayoutRatios => ({

--- a/src/features/terminal/layout-registry/layoutDefinition.ts
+++ b/src/features/terminal/layout-registry/layoutDefinition.ts
@@ -1,0 +1,542 @@
+import type { LayoutId, PaneKind } from '../../sessions/types'
+import { LAYOUT_IDS } from './layoutIds'
+import type { LayoutRatios } from './ratioModel'
+
+export type BuiltinPaneLayoutId = LayoutId
+
+export type CustomPaneLayoutId = `custom:${string}`
+
+export type PaneLayoutId = BuiltinPaneLayoutId | CustomPaneLayoutId
+
+export type LayoutSlotId = `slot:${string}`
+
+export type PaneLayoutSource = 'builtin' | 'workspace'
+
+export type PaneLayoutSchemaVersion = 1
+
+export interface TrackSpec {
+  readonly id: string
+  readonly units: number
+  readonly minPx?: number
+}
+
+export interface PaneSlotRect {
+  readonly col: number
+  readonly row: number
+  readonly colSpan: number
+  readonly rowSpan: number
+}
+
+export interface PaneSlotSpec {
+  readonly id: LayoutSlotId
+  readonly rect: PaneSlotRect
+  readonly accepts?: readonly string[]
+}
+
+export interface PaneLayoutDefinition {
+  readonly schemaVersion: number
+  readonly id: PaneLayoutId
+  readonly title: string
+  readonly source: PaneLayoutSource
+  readonly tracks: {
+    readonly columns: readonly TrackSpec[]
+    readonly rows: readonly TrackSpec[]
+  }
+  readonly slots: readonly PaneSlotSpec[]
+  readonly addOrder: readonly LayoutSlotId[]
+}
+
+export type PaneLayoutValidationCode =
+  | 'unsupported-schema-version'
+  | 'invalid-id-namespace'
+  | 'empty-title'
+  | 'invalid-track-count'
+  | 'duplicate-track-id'
+  | 'invalid-track-id'
+  | 'invalid-track-units'
+  | 'invalid-track-min-px'
+  | 'invalid-slot-count'
+  | 'invalid-slot-id'
+  | 'duplicate-slot-id'
+  | 'invalid-slot-rect'
+  | 'slot-out-of-bounds'
+  | 'slot-overlap'
+  | 'layout-hole'
+  | 'invalid-add-order'
+  | 'unknown-add-order-slot'
+  | 'duplicate-add-order-slot'
+  | 'unsupported-pane-kind'
+
+export interface PaneLayoutValidationError {
+  readonly code: PaneLayoutValidationCode
+  readonly path: string
+  readonly message: string
+}
+
+export interface PaneLayoutValidationResult {
+  readonly ok: boolean
+  readonly errors: readonly PaneLayoutValidationError[]
+}
+
+export interface PaneLayoutRegistrySnapshot {
+  readonly layouts: readonly PaneLayoutDefinition[]
+  readonly rejected: readonly RejectedPaneLayoutDefinition[]
+}
+
+export interface RejectedPaneLayoutDefinition {
+  readonly definition: PaneLayoutDefinition
+  readonly errors: readonly PaneLayoutValidationError[]
+}
+
+export const CUSTOM_PANE_LAYOUT_ID_PREFIX = 'custom:'
+
+export const LAYOUT_SLOT_ID_PREFIX = 'slot:'
+
+export const PANE_LAYOUT_SCHEMA_VERSION: PaneLayoutSchemaVersion = 1
+
+export const MIN_LAYOUT_TRACKS = 1
+
+export const MAX_LAYOUT_TRACKS = 4
+
+export const MIN_LAYOUT_SLOTS = 1
+
+export const MAX_LAYOUT_SLOTS = 16
+
+const BUILTIN_LAYOUT_IDS = new Set<string>(LAYOUT_IDS)
+const PANE_KINDS: readonly PaneKind[] = ['shell', 'browser']
+
+export const isBuiltinPaneLayoutId = (
+  value: string
+): value is BuiltinPaneLayoutId => BUILTIN_LAYOUT_IDS.has(value)
+
+export const isCustomPaneLayoutId = (
+  value: string
+): value is CustomPaneLayoutId =>
+  value.startsWith(CUSTOM_PANE_LAYOUT_ID_PREFIX) &&
+  value.length > CUSTOM_PANE_LAYOUT_ID_PREFIX.length
+
+export const isPaneLayoutId = (value: string): value is PaneLayoutId =>
+  isBuiltinPaneLayoutId(value) || isCustomPaneLayoutId(value)
+
+export const isLayoutSlotId = (value: string): value is LayoutSlotId =>
+  value.startsWith(LAYOUT_SLOT_ID_PREFIX) &&
+  value.length > LAYOUT_SLOT_ID_PREFIX.length
+
+export const createPaneSlotId = (suffix: string): LayoutSlotId =>
+  `${LAYOUT_SLOT_ID_PREFIX}${suffix}`
+
+export const createIndexedPaneSlotId = (index: number): LayoutSlotId =>
+  createPaneSlotId(`p${index}`)
+
+export const getPaneLayoutCapacity = (
+  definition: PaneLayoutDefinition
+): number => definition.slots.length
+
+export const getPaneLayoutRatios = (
+  definition: PaneLayoutDefinition
+): LayoutRatios => ({
+  cols: definition.tracks.columns.map((track) => track.units),
+  rows: definition.tracks.rows.map((track) => track.units),
+})
+
+export const gridAreaNameForSlotId = (slotId: LayoutSlotId): string => {
+  const suffix = slotId.slice(LAYOUT_SLOT_ID_PREFIX.length)
+  if (/^p\d+$/.test(suffix)) {
+    return suffix
+  }
+
+  const sanitized = suffix.replace(/[^a-zA-Z0-9_-]/g, '-')
+
+  return `slot-${sanitized}`
+}
+
+const validationError = (
+  code: PaneLayoutValidationCode,
+  path: string,
+  message: string
+): PaneLayoutValidationError => ({ code, path, message })
+
+const isFinitePositive = (value: number): boolean =>
+  Number.isFinite(value) && value > 0
+
+const isFiniteNonNegative = (value: number): boolean =>
+  Number.isFinite(value) && value >= 0
+
+const isSupportedPaneKind = (value: string): value is PaneKind =>
+  (PANE_KINDS as readonly string[]).includes(value)
+
+const validateSourceAndId = (
+  definition: PaneLayoutDefinition
+): readonly PaneLayoutValidationError[] => {
+  if (
+    definition.source === 'workspace' &&
+    !isCustomPaneLayoutId(definition.id)
+  ) {
+    return [
+      validationError(
+        'invalid-id-namespace',
+        'id',
+        'Workspace layouts must use custom:<id> ids.'
+      ),
+    ]
+  }
+
+  if (
+    definition.source === 'builtin' &&
+    !isBuiltinPaneLayoutId(definition.id)
+  ) {
+    return [
+      validationError(
+        'invalid-id-namespace',
+        'id',
+        'Builtin layouts must use a known prebuilt layout id.'
+      ),
+    ]
+  }
+
+  return []
+}
+
+const validateTracks = (
+  axis: 'columns' | 'rows',
+  tracks: readonly TrackSpec[]
+): readonly PaneLayoutValidationError[] => {
+  const errors: PaneLayoutValidationError[] = []
+
+  if (tracks.length < MIN_LAYOUT_TRACKS || tracks.length > MAX_LAYOUT_TRACKS) {
+    errors.push(
+      validationError(
+        'invalid-track-count',
+        `tracks.${axis}`,
+        `Layouts must have ${MIN_LAYOUT_TRACKS}-${MAX_LAYOUT_TRACKS} ${axis}.`
+      )
+    )
+  }
+
+  const seen = new Set<string>()
+  tracks.forEach((track, index) => {
+    const path = `tracks.${axis}.${index}`
+
+    if (track.id.trim().length === 0) {
+      errors.push(
+        validationError(
+          'invalid-track-id',
+          `${path}.id`,
+          'Track id must not be empty.'
+        )
+      )
+    }
+
+    if (seen.has(track.id)) {
+      errors.push(
+        validationError(
+          'duplicate-track-id',
+          `${path}.id`,
+          `Duplicate ${axis} track id: ${track.id}.`
+        )
+      )
+    }
+    seen.add(track.id)
+
+    if (!isFinitePositive(track.units)) {
+      errors.push(
+        validationError(
+          'invalid-track-units',
+          `${path}.units`,
+          'Track units must be a finite positive number.'
+        )
+      )
+    }
+
+    if (track.minPx !== undefined && !isFiniteNonNegative(track.minPx)) {
+      errors.push(
+        validationError(
+          'invalid-track-min-px',
+          `${path}.minPx`,
+          'Track minimum size must be finite and non-negative.'
+        )
+      )
+    }
+  })
+
+  return errors
+}
+
+const validateSlotRect = (
+  slot: PaneSlotSpec,
+  index: number,
+  colCount: number,
+  rowCount: number,
+  occupiedCells: Map<string, LayoutSlotId>
+): readonly PaneLayoutValidationError[] => {
+  const errors: PaneLayoutValidationError[] = []
+  const { rect } = slot
+  const path = `slots.${index}.rect`
+
+  const rectValues = [rect.col, rect.row, rect.colSpan, rect.rowSpan]
+  if (!rectValues.every(Number.isInteger)) {
+    errors.push(
+      validationError(
+        'invalid-slot-rect',
+        path,
+        'Slot rect values must be integers.'
+      )
+    )
+
+    return errors
+  }
+
+  if (rect.col < 0 || rect.row < 0 || rect.colSpan <= 0 || rect.rowSpan <= 0) {
+    errors.push(
+      validationError(
+        'invalid-slot-rect',
+        path,
+        'Slot rect must start in bounds and use positive spans.'
+      )
+    )
+
+    return errors
+  }
+
+  const colEnd = rect.col + rect.colSpan
+  const rowEnd = rect.row + rect.rowSpan
+  if (colEnd > colCount || rowEnd > rowCount) {
+    errors.push(
+      validationError(
+        'slot-out-of-bounds',
+        path,
+        'Slot rect must fit within the declared tracks.'
+      )
+    )
+
+    return errors
+  }
+
+  for (let row = rect.row; row < rowEnd; row += 1) {
+    for (let col = rect.col; col < colEnd; col += 1) {
+      const cellKey = `${col}:${row}`
+      const existing = occupiedCells.get(cellKey)
+      if (existing) {
+        errors.push(
+          validationError(
+            'slot-overlap',
+            path,
+            `Slot ${slot.id} overlaps ${existing} at ${cellKey}.`
+          )
+        )
+      } else {
+        occupiedCells.set(cellKey, slot.id)
+      }
+    }
+  }
+
+  return errors
+}
+
+const validateSlots = (
+  definition: PaneLayoutDefinition
+): readonly PaneLayoutValidationError[] => {
+  const errors: PaneLayoutValidationError[] = []
+  const { slots } = definition
+  const colCount = definition.tracks.columns.length
+  const rowCount = definition.tracks.rows.length
+
+  if (slots.length < MIN_LAYOUT_SLOTS || slots.length > MAX_LAYOUT_SLOTS) {
+    errors.push(
+      validationError(
+        'invalid-slot-count',
+        'slots',
+        `Layouts must have ${MIN_LAYOUT_SLOTS}-${MAX_LAYOUT_SLOTS} slots.`
+      )
+    )
+  }
+
+  const seenSlots = new Set<LayoutSlotId>()
+  const occupiedCells = new Map<string, LayoutSlotId>()
+
+  slots.forEach((slot, index) => {
+    const path = `slots.${index}`
+    if (!isLayoutSlotId(slot.id)) {
+      errors.push(
+        validationError(
+          'invalid-slot-id',
+          `${path}.id`,
+          'Slot ids must use the slot:<id> namespace.'
+        )
+      )
+    }
+
+    if (seenSlots.has(slot.id)) {
+      errors.push(
+        validationError(
+          'duplicate-slot-id',
+          `${path}.id`,
+          `Duplicate slot id: ${slot.id}.`
+        )
+      )
+    }
+    seenSlots.add(slot.id)
+
+    for (const paneKind of slot.accepts ?? []) {
+      if (!isSupportedPaneKind(paneKind)) {
+        errors.push(
+          validationError(
+            'unsupported-pane-kind',
+            `${path}.accepts`,
+            `Unsupported pane kind: ${paneKind}.`
+          )
+        )
+      }
+    }
+
+    errors.push(
+      ...validateSlotRect(slot, index, colCount, rowCount, occupiedCells)
+    )
+  })
+
+  const expectedCellCount = colCount * rowCount
+  if (occupiedCells.size < expectedCellCount) {
+    errors.push(
+      validationError(
+        'layout-hole',
+        'slots',
+        'Slots must cover every grid cell in v1 layouts.'
+      )
+    )
+  }
+
+  return errors
+}
+
+const validateAddOrder = (
+  definition: PaneLayoutDefinition
+): readonly PaneLayoutValidationError[] => {
+  const errors: PaneLayoutValidationError[] = []
+  const slotIds = new Set(definition.slots.map((slot) => slot.id))
+  const seen = new Set<LayoutSlotId>()
+
+  if (definition.addOrder.length !== definition.slots.length) {
+    errors.push(
+      validationError(
+        'invalid-add-order',
+        'addOrder',
+        'Add order must include every slot exactly once.'
+      )
+    )
+  }
+
+  definition.addOrder.forEach((slotId, index) => {
+    const path = `addOrder.${index}`
+    if (!slotIds.has(slotId)) {
+      errors.push(
+        validationError(
+          'unknown-add-order-slot',
+          path,
+          `Add order references unknown slot: ${slotId}.`
+        )
+      )
+    }
+
+    if (seen.has(slotId)) {
+      errors.push(
+        validationError(
+          'duplicate-add-order-slot',
+          path,
+          `Add order repeats slot: ${slotId}.`
+        )
+      )
+    }
+    seen.add(slotId)
+  })
+
+  return errors
+}
+
+export const validatePaneLayoutDefinition = (
+  definition: PaneLayoutDefinition
+): PaneLayoutValidationResult => {
+  const errors: PaneLayoutValidationError[] = []
+
+  if (definition.schemaVersion !== PANE_LAYOUT_SCHEMA_VERSION) {
+    errors.push(
+      validationError(
+        'unsupported-schema-version',
+        'schemaVersion',
+        `Unsupported pane layout schema version: ${definition.schemaVersion}.`
+      )
+    )
+  }
+
+  errors.push(...validateSourceAndId(definition))
+
+  if (definition.title.trim().length === 0) {
+    errors.push(
+      validationError('empty-title', 'title', 'Layout title must not be empty.')
+    )
+  }
+
+  errors.push(
+    ...validateTracks('columns', definition.tracks.columns),
+    ...validateTracks('rows', definition.tracks.rows),
+    ...validateSlots(definition),
+    ...validateAddOrder(definition)
+  )
+
+  return {
+    ok: errors.length === 0,
+    errors,
+  }
+}
+
+export const assemblePaneLayoutRegistry = ({
+  prebuilt,
+  custom,
+}: {
+  readonly prebuilt: readonly PaneLayoutDefinition[]
+  readonly custom: readonly PaneLayoutDefinition[]
+}): PaneLayoutRegistrySnapshot => {
+  const layouts: PaneLayoutDefinition[] = []
+  const rejected: RejectedPaneLayoutDefinition[] = []
+  const prebuiltIds = new Set(prebuilt.map((definition) => definition.id))
+  const acceptedIds = new Set<PaneLayoutId>()
+
+  const acceptOrReject = (definition: PaneLayoutDefinition): void => {
+    const validation = validatePaneLayoutDefinition(definition)
+
+    const shadowErrors =
+      definition.source === 'workspace' && prebuiltIds.has(definition.id)
+        ? [
+            validationError(
+              'invalid-id-namespace',
+              'id',
+              'Custom layouts must not shadow prebuilt layout ids.'
+            ),
+          ]
+        : []
+
+    const duplicateErrors = acceptedIds.has(definition.id)
+      ? [
+          validationError(
+            'invalid-id-namespace',
+            'id',
+            `Duplicate layout id: ${definition.id}.`
+          ),
+        ]
+      : []
+
+    const errors = [...validation.errors, ...shadowErrors, ...duplicateErrors]
+    if (errors.length > 0) {
+      rejected.push({ definition, errors })
+
+      return
+    }
+
+    layouts.push(definition)
+    acceptedIds.add(definition.id)
+  }
+
+  prebuilt.forEach(acceptOrReject)
+  custom.forEach(acceptOrReject)
+
+  return { layouts, rejected }
+}

--- a/src/features/terminal/layout-registry/layoutGeometry.test.ts
+++ b/src/features/terminal/layout-registry/layoutGeometry.test.ts
@@ -1,0 +1,165 @@
+// cspell:ignore vdiv hdiv
+import { describe, expect, test } from 'vitest'
+import {
+  createPaneSlotId,
+  resolvePaneLayoutGeometry,
+  type PaneLayoutDefinition,
+} from '.'
+
+const mainWithSideStack = (): PaneLayoutDefinition => ({
+  schemaVersion: 1,
+  id: 'custom:main-side-stack',
+  title: 'Main + side stack',
+  source: 'workspace',
+  tracks: {
+    columns: [
+      { id: 'main', units: 16 },
+      { id: 'side', units: 8 },
+    ],
+    rows: [
+      { id: 'top', units: 8 },
+      { id: 'middle', units: 8 },
+      { id: 'bottom', units: 8 },
+    ],
+  },
+  slots: [
+    {
+      id: createPaneSlotId('main'),
+      rect: { col: 0, row: 0, colSpan: 1, rowSpan: 3 },
+    },
+    {
+      id: createPaneSlotId('side-top'),
+      rect: { col: 1, row: 0, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('side-middle'),
+      rect: { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('side-bottom'),
+      rect: { col: 1, row: 2, colSpan: 1, rowSpan: 1 },
+    },
+  ],
+  addOrder: [
+    createPaneSlotId('main'),
+    createPaneSlotId('side-top'),
+    createPaneSlotId('side-middle'),
+    createPaneSlotId('side-bottom'),
+  ],
+})
+
+const mainWithBottomRow = (): PaneLayoutDefinition => ({
+  schemaVersion: 1,
+  id: 'custom:main-bottom-row',
+  title: 'Main + bottom row',
+  source: 'workspace',
+  tracks: {
+    columns: [
+      { id: 'left', units: 8 },
+      { id: 'center', units: 8 },
+      { id: 'right', units: 8 },
+    ],
+    rows: [
+      { id: 'main', units: 18 },
+      { id: 'bottom', units: 6 },
+    ],
+  },
+  slots: [
+    {
+      id: createPaneSlotId('main'),
+      rect: { col: 0, row: 0, colSpan: 3, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('bottom-left'),
+      rect: { col: 0, row: 1, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('bottom-center'),
+      rect: { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('bottom-right'),
+      rect: { col: 2, row: 1, colSpan: 1, rowSpan: 1 },
+    },
+  ],
+  addOrder: [
+    createPaneSlotId('main'),
+    createPaneSlotId('bottom-left'),
+    createPaneSlotId('bottom-center'),
+    createPaneSlotId('bottom-right'),
+  ],
+})
+
+describe('layoutGeometry', () => {
+  test('derives grid areas and dividers for main + side stack', () => {
+    const geometry = resolvePaneLayoutGeometry(mainWithSideStack())
+
+    expect(geometry.areas).toEqual([
+      ['slot-main', 'vdiv-c0', 'slot-side-top'],
+      ['slot-main', 'vdiv-c0', 'hdiv-r0-c1'],
+      ['slot-main', 'vdiv-c0', 'slot-side-middle'],
+      ['slot-main', 'vdiv-c0', 'hdiv-r1-c1'],
+      ['slot-main', 'vdiv-c0', 'slot-side-bottom'],
+    ])
+
+    expect(geometry.dividers).toEqual([
+      {
+        id: 'vdiv-c0',
+        gridArea: 'vdiv-c0',
+        dragAxis: 'horizontal',
+        orientation: 'vertical',
+        trackAxis: 'cols',
+        trackIndex: 0,
+      },
+      {
+        id: 'hdiv-r0-c1',
+        gridArea: 'hdiv-r0-c1',
+        dragAxis: 'vertical',
+        orientation: 'horizontal',
+        trackAxis: 'rows',
+        trackIndex: 0,
+      },
+      {
+        id: 'hdiv-r1-c1',
+        gridArea: 'hdiv-r1-c1',
+        dragAxis: 'vertical',
+        orientation: 'horizontal',
+        trackAxis: 'rows',
+        trackIndex: 1,
+      },
+    ])
+  })
+
+  test('derives grid areas and dividers for main + bottom row', () => {
+    const geometry = resolvePaneLayoutGeometry(mainWithBottomRow())
+
+    expect(geometry.areas).toEqual([
+      ['slot-main', 'slot-main', 'slot-main', 'slot-main', 'slot-main'],
+      ['hdiv-r0', 'hdiv-r0', 'hdiv-r0', 'hdiv-r0', 'hdiv-r0'],
+      [
+        'slot-bottom-left',
+        'vdiv-c0-r1',
+        'slot-bottom-center',
+        'vdiv-c1-r1',
+        'slot-bottom-right',
+      ],
+    ])
+
+    expect(geometry.dividers.map((divider) => divider.id)).toEqual([
+      'vdiv-c0-r1',
+      'vdiv-c1-r1',
+      'hdiv-r0',
+    ])
+  })
+
+  test('exposes a stable slot id to css grid-area mapping', () => {
+    const geometry = resolvePaneLayoutGeometry(mainWithBottomRow())
+
+    expect(geometry.slotAreas).toEqual([
+      { slotId: 'slot:main', gridArea: 'slot-main' },
+      { slotId: 'slot:bottom-left', gridArea: 'slot-bottom-left' },
+      { slotId: 'slot:bottom-center', gridArea: 'slot-bottom-center' },
+      { slotId: 'slot:bottom-right', gridArea: 'slot-bottom-right' },
+    ])
+  })
+})

--- a/src/features/terminal/layout-registry/layoutGeometry.ts
+++ b/src/features/terminal/layout-registry/layoutGeometry.ts
@@ -1,0 +1,317 @@
+// cspell:ignore vdiv hdiv
+import {
+  gridAreaNameForSlotId,
+  type PaneLayoutDefinition,
+} from './layoutDefinition'
+import type { RatioAxis } from './ratioModel'
+
+export type DividerDragAxis = 'horizontal' | 'vertical'
+
+export type DividerOrientation = 'vertical' | 'horizontal'
+
+export interface DividerHandleSpec {
+  readonly id: string
+  readonly gridArea: string
+  readonly dragAxis: DividerDragAxis
+  readonly orientation: DividerOrientation
+  readonly trackAxis: RatioAxis
+  readonly trackIndex: number
+}
+
+export interface SlotGridArea {
+  readonly slotId: string
+  readonly gridArea: string
+}
+
+export interface LayoutGeometry {
+  readonly areas: readonly (readonly string[])[]
+  readonly dividers: readonly DividerHandleSpec[]
+  readonly slotAreas: readonly SlotGridArea[]
+}
+
+const verticalDividerName = (colIndex: number): string => `vdiv-c${colIndex}`
+
+const verticalDividerSegmentName = (
+  colIndex: number,
+  rowIndex: number
+): string => `${verticalDividerName(colIndex)}-r${rowIndex}`
+
+const horizontalDividerName = (rowIndex: number): string => `hdiv-r${rowIndex}`
+
+const horizontalDividerSegmentName = (
+  rowIndex: number,
+  colIndex: number
+): string => `${horizontalDividerName(rowIndex)}-c${colIndex}`
+
+const allEqual = (values: readonly string[]): boolean =>
+  values.length > 0 && values.every((value) => value === values[0])
+
+const hasFullHorizontalBoundary = (
+  areas: readonly (readonly string[])[],
+  rowIndex: number
+): boolean =>
+  areas[rowIndex].every(
+    (area, colIndex) => area !== areas[rowIndex + 1][colIndex]
+  )
+
+const hasFullVerticalBoundary = (
+  areas: readonly (readonly string[])[],
+  colIndex: number,
+  fullHorizontalRows: ReadonlySet<number>
+): boolean =>
+  fullHorizontalRows.size === 0 &&
+  areas.every((row) => row[colIndex] !== row[colIndex + 1])
+
+const horizontalNameForCell = (
+  areas: readonly (readonly string[])[],
+  rowIndex: number,
+  colIndex: number,
+  fullHorizontalRows: ReadonlySet<number>
+): string => {
+  const top = areas[rowIndex][colIndex]
+  const bottom = areas[rowIndex + 1][colIndex]
+
+  if (top === bottom) {
+    return top
+  }
+
+  return fullHorizontalRows.has(rowIndex)
+    ? horizontalDividerName(rowIndex)
+    : horizontalDividerSegmentName(rowIndex, colIndex)
+}
+
+const verticalNameForCell = (
+  areas: readonly (readonly string[])[],
+  rowIndex: number,
+  colIndex: number,
+  fullVerticalCols: ReadonlySet<number>
+): string => {
+  const left = areas[rowIndex][colIndex]
+  const right = areas[rowIndex][colIndex + 1]
+
+  if (left === right) {
+    return left
+  }
+
+  return fullVerticalCols.has(colIndex)
+    ? verticalDividerName(colIndex)
+    : verticalDividerSegmentName(colIndex, rowIndex)
+}
+
+const junctionName = (
+  areas: readonly (readonly string[])[],
+  rowIndex: number,
+  colIndex: number,
+  fullHorizontalRows: ReadonlySet<number>,
+  fullVerticalCols: ReadonlySet<number>
+): string => {
+  const topLeft = areas[rowIndex][colIndex]
+  const topRight = areas[rowIndex][colIndex + 1]
+  const bottomLeft = areas[rowIndex + 1][colIndex]
+  const bottomRight = areas[rowIndex + 1][colIndex + 1]
+
+  if (allEqual([topLeft, topRight, bottomLeft, bottomRight])) {
+    return topLeft
+  }
+
+  if (fullHorizontalRows.has(rowIndex)) {
+    return horizontalDividerName(rowIndex)
+  }
+
+  if (fullVerticalCols.has(colIndex)) {
+    return verticalDividerName(colIndex)
+  }
+
+  return '.'
+}
+
+const addDivider = (
+  dividers: DividerHandleSpec[],
+  seen: Set<string>,
+  spec: DividerHandleSpec
+): void => {
+  if (seen.has(spec.id)) {
+    return
+  }
+
+  seen.add(spec.id)
+  dividers.push(spec)
+}
+
+export const areaMatrixFromDefinition = (
+  definition: PaneLayoutDefinition
+): readonly (readonly string[])[] => {
+  const colCount = definition.tracks.columns.length
+  const rowCount = definition.tracks.rows.length
+
+  const areas = Array.from({ length: rowCount }, () =>
+    Array.from({ length: colCount }, () => '.')
+  )
+
+  for (const slot of definition.slots) {
+    const areaName = gridAreaNameForSlotId(slot.id)
+    const colEnd = slot.rect.col + slot.rect.colSpan
+    const rowEnd = slot.rect.row + slot.rect.rowSpan
+
+    for (let row = slot.rect.row; row < rowEnd; row += 1) {
+      for (let col = slot.rect.col; col < colEnd; col += 1) {
+        if (row >= 0 && row < rowCount && col >= 0 && col < colCount) {
+          areas[row][col] = areaName
+        }
+      }
+    }
+  }
+
+  return areas
+}
+
+export const resolveAreaGeometry = (
+  areas: readonly (readonly string[])[]
+): Pick<LayoutGeometry, 'areas' | 'dividers'> => {
+  const rowCount = areas.length
+  const colCount = areas[0]?.length ?? 0
+
+  if (rowCount === 0 || colCount === 0) {
+    return { areas: [], dividers: [] }
+  }
+
+  const fullHorizontalRows = new Set<number>()
+  for (let rowIndex = 0; rowIndex < rowCount - 1; rowIndex += 1) {
+    if (hasFullHorizontalBoundary(areas, rowIndex)) {
+      fullHorizontalRows.add(rowIndex)
+    }
+  }
+
+  const fullVerticalCols = new Set<number>()
+  for (let colIndex = 0; colIndex < colCount - 1; colIndex += 1) {
+    if (hasFullVerticalBoundary(areas, colIndex, fullHorizontalRows)) {
+      fullVerticalCols.add(colIndex)
+    }
+  }
+
+  const expanded: string[][] = []
+  for (let expandedRow = 0; expandedRow < rowCount * 2 - 1; expandedRow += 1) {
+    const row: string[] = []
+    const logicalRow = Math.floor(expandedRow / 2)
+
+    for (
+      let expandedCol = 0;
+      expandedCol < colCount * 2 - 1;
+      expandedCol += 1
+    ) {
+      const logicalCol = Math.floor(expandedCol / 2)
+
+      if (expandedRow % 2 === 0 && expandedCol % 2 === 0) {
+        row.push(areas[logicalRow][logicalCol])
+      } else if (expandedRow % 2 === 0) {
+        row.push(
+          verticalNameForCell(areas, logicalRow, logicalCol, fullVerticalCols)
+        )
+      } else if (expandedCol % 2 === 0) {
+        row.push(
+          horizontalNameForCell(
+            areas,
+            logicalRow,
+            logicalCol,
+            fullHorizontalRows
+          )
+        )
+      } else {
+        row.push(
+          junctionName(
+            areas,
+            logicalRow,
+            logicalCol,
+            fullHorizontalRows,
+            fullVerticalCols
+          )
+        )
+      }
+    }
+
+    expanded.push(row)
+  }
+
+  const dividers: DividerHandleSpec[] = []
+  const seen = new Set<string>()
+
+  for (let colIndex = 0; colIndex < colCount - 1; colIndex += 1) {
+    if (fullVerticalCols.has(colIndex)) {
+      const id = verticalDividerName(colIndex)
+      addDivider(dividers, seen, {
+        id,
+        gridArea: id,
+        dragAxis: 'horizontal',
+        orientation: 'vertical',
+        trackAxis: 'cols',
+        trackIndex: colIndex,
+      })
+
+      continue
+    }
+
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
+      if (areas[rowIndex][colIndex] === areas[rowIndex][colIndex + 1]) {
+        continue
+      }
+
+      const id = verticalDividerSegmentName(colIndex, rowIndex)
+      addDivider(dividers, seen, {
+        id,
+        gridArea: id,
+        dragAxis: 'horizontal',
+        orientation: 'vertical',
+        trackAxis: 'cols',
+        trackIndex: colIndex,
+      })
+    }
+  }
+
+  for (let rowIndex = 0; rowIndex < rowCount - 1; rowIndex += 1) {
+    if (fullHorizontalRows.has(rowIndex)) {
+      const id = horizontalDividerName(rowIndex)
+      addDivider(dividers, seen, {
+        id,
+        gridArea: id,
+        dragAxis: 'vertical',
+        orientation: 'horizontal',
+        trackAxis: 'rows',
+        trackIndex: rowIndex,
+      })
+
+      continue
+    }
+
+    for (let colIndex = 0; colIndex < colCount; colIndex += 1) {
+      if (areas[rowIndex][colIndex] === areas[rowIndex + 1][colIndex]) {
+        continue
+      }
+
+      const id = horizontalDividerSegmentName(rowIndex, colIndex)
+      addDivider(dividers, seen, {
+        id,
+        gridArea: id,
+        dragAxis: 'vertical',
+        orientation: 'horizontal',
+        trackAxis: 'rows',
+        trackIndex: rowIndex,
+      })
+    }
+  }
+
+  return { areas: expanded, dividers }
+}
+
+export const resolvePaneLayoutGeometry = (
+  definition: PaneLayoutDefinition
+): LayoutGeometry => {
+  const areas = areaMatrixFromDefinition(definition)
+  const geometry = resolveAreaGeometry(areas)
+
+  const slotAreas = definition.slots.map((slot) => ({
+    slotId: slot.id,
+    gridArea: gridAreaNameForSlotId(slot.id),
+  }))
+
+  return { ...geometry, slotAreas }
+}

--- a/src/features/terminal/layout-registry/layoutSpecs.ts
+++ b/src/features/terminal/layout-registry/layoutSpecs.ts
@@ -1,85 +1,76 @@
 // cspell:ignore vsplit hsplit
 import type { LayoutId } from '../../sessions/types'
 import { LAYOUT_IDS } from './layoutIds'
+import {
+  getPaneLayoutCapacity,
+  type PaneLayoutDefinition,
+} from './layoutDefinition'
+import { PREBUILT_PANE_LAYOUTS_BY_ID } from './prebuiltLayouts'
+import { DEFAULT_RATIOS, type LayoutRatios } from './ratioModel'
+import {
+  areaMatrixFromDefinition,
+  resolvePaneLayoutGeometry,
+  type DividerHandleSpec,
+  type LayoutGeometry,
+} from './layoutGeometry'
 
 export interface LayoutShape {
   readonly id: LayoutId
   readonly name: string
   /** Maximum pane count for this layout. SplitView clamps panes to capacity. */
-  readonly capacity: 1 | 2 | 3 | 4 | 6
+  readonly capacity: number
   /** CSS grid-template-columns value. */
   readonly cols: string
   /** CSS grid-template-rows value. */
   readonly rows: string
   /** 2D layout of pane-slot names: p0..pN. */
   readonly areas: readonly (readonly string[])[]
+  /** Full CSS grid-template-areas matrix, including divider tracks. */
+  readonly gridAreas: LayoutGeometry['areas']
+  /** Divider handles derived from the canonical layout definition. */
+  readonly dividers: readonly DividerHandleSpec[]
+  /** Canonical VIM-156 definition. Runtime still consumes legacy fields. */
+  readonly definition: PaneLayoutDefinition
+  readonly defaultRatios: LayoutRatios
+}
+
+const logicalTrackTemplate = (tracks: readonly number[]): string =>
+  tracks.length <= 1
+    ? 'minmax(0,1fr)'
+    : tracks.map((track) => `minmax(0,${track}fr)`).join(' ')
+
+const defineLayout = (id: LayoutId): LayoutShape => {
+  const definition = PREBUILT_PANE_LAYOUTS_BY_ID[id]
+  const geometry = resolvePaneLayoutGeometry(definition)
+  const defaultRatios = DEFAULT_RATIOS[id]
+
+  return {
+    id,
+    name: definition.title,
+    capacity: getPaneLayoutCapacity(definition),
+    cols: logicalTrackTemplate(defaultRatios.cols),
+    rows: logicalTrackTemplate(defaultRatios.rows),
+    areas: areaMatrixFromDefinition(definition),
+    gridAreas: geometry.areas,
+    dividers: geometry.dividers,
+    defaultRatios,
+    definition,
+  }
 }
 
 /**
- * Canonical layout definitions for the current terminal layout system.
- *
- * The array order is deliberate: it is the visible pill order and the keyboard
- * cycle order. New layouts should be appended unless changing that order is an
- * intentional user-facing behavior change.
+ * Canonical prebuilt layout definitions for the current terminal layout
+ * system. The array order is deliberate: it is the visible pill order and the
+ * keyboard cycle order. Custom/user layouts are not appended here; VIM-156
+ * runtime assembly will combine prebuilt + workspace custom definitions.
  */
 export const LAYOUTS: Record<LayoutId, LayoutShape> = {
-  single: {
-    id: 'single',
-    name: 'Single',
-    capacity: 1,
-    cols: 'minmax(0,1fr)',
-    rows: 'minmax(0,1fr)',
-    areas: [['p0']],
-  },
-  vsplit: {
-    id: 'vsplit',
-    name: 'Vertical split',
-    capacity: 2,
-    cols: 'minmax(0,1fr) minmax(0,1fr)',
-    rows: 'minmax(0,1fr)',
-    areas: [['p0', 'p1']],
-  },
-  hsplit: {
-    id: 'hsplit',
-    name: 'Horizontal split',
-    capacity: 2,
-    cols: 'minmax(0,1fr)',
-    rows: 'minmax(0,1fr) minmax(0,1fr)',
-    areas: [['p0'], ['p1']],
-  },
-  threeRight: {
-    id: 'threeRight',
-    name: 'Main + 2 stack',
-    capacity: 3,
-    cols: 'minmax(0,1.4fr) minmax(0,1fr)',
-    rows: 'minmax(0,1fr) minmax(0,1fr)',
-    areas: [
-      ['p0', 'p1'],
-      ['p0', 'p2'],
-    ],
-  },
-  quad: {
-    id: 'quad',
-    name: 'Quad',
-    capacity: 4,
-    cols: 'minmax(0,1fr) minmax(0,1fr)',
-    rows: 'minmax(0,1fr) minmax(0,1fr)',
-    areas: [
-      ['p0', 'p1'],
-      ['p2', 'p3'],
-    ],
-  },
-  grid3x2: {
-    id: 'grid3x2',
-    name: '3x2 grid',
-    capacity: 6,
-    cols: 'minmax(0,1fr) minmax(0,1fr) minmax(0,1fr)',
-    rows: 'minmax(0,1fr) minmax(0,1fr)',
-    areas: [
-      ['p0', 'p1', 'p2'],
-      ['p3', 'p4', 'p5'],
-    ],
-  },
+  single: defineLayout('single'),
+  vsplit: defineLayout('vsplit'),
+  hsplit: defineLayout('hsplit'),
+  threeRight: defineLayout('threeRight'),
+  quad: defineLayout('quad'),
+  grid3x2: defineLayout('grid3x2'),
 } as const
 
 export const LAYOUT_SPECS: readonly LayoutShape[] = LAYOUT_IDS.map(

--- a/src/features/terminal/layout-registry/prebuiltLayouts.ts
+++ b/src/features/terminal/layout-registry/prebuiltLayouts.ts
@@ -52,8 +52,8 @@ export const PREBUILT_PANE_LAYOUTS_BY_ID: Record<
     id: 'single',
     title: 'Single',
     tracks: {
-      columns: columns(24),
-      rows: rows(24),
+      columns: columns(1),
+      rows: rows(1),
     },
     slots: [slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 1 })],
   }),
@@ -61,8 +61,8 @@ export const PREBUILT_PANE_LAYOUTS_BY_ID: Record<
     id: 'vsplit',
     title: 'Vertical split',
     tracks: {
-      columns: columns(12, 12),
-      rows: rows(24),
+      columns: columns(1, 1),
+      rows: rows(1),
     },
     slots: [
       slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 1 }),
@@ -73,8 +73,8 @@ export const PREBUILT_PANE_LAYOUTS_BY_ID: Record<
     id: 'hsplit',
     title: 'Horizontal split',
     tracks: {
-      columns: columns(24),
-      rows: rows(12, 12),
+      columns: columns(1),
+      rows: rows(1, 1),
     },
     slots: [
       slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 1 }),
@@ -85,8 +85,8 @@ export const PREBUILT_PANE_LAYOUTS_BY_ID: Record<
     id: 'threeRight',
     title: 'Main + 2 stack',
     tracks: {
-      columns: columns(14, 10),
-      rows: rows(12, 12),
+      columns: columns(1.4, 1),
+      rows: rows(1, 1),
     },
     slots: [
       slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 2 }),
@@ -98,8 +98,8 @@ export const PREBUILT_PANE_LAYOUTS_BY_ID: Record<
     id: 'quad',
     title: 'Quad',
     tracks: {
-      columns: columns(12, 12),
-      rows: rows(12, 12),
+      columns: columns(1, 1),
+      rows: rows(1, 1),
     },
     slots: [
       slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 1 }),
@@ -112,8 +112,8 @@ export const PREBUILT_PANE_LAYOUTS_BY_ID: Record<
     id: 'grid3x2',
     title: '3x2 grid',
     tracks: {
-      columns: columns(8, 8, 8),
-      rows: rows(12, 12),
+      columns: columns(1, 1, 1),
+      rows: rows(1, 1),
     },
     slots: [
       slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 1 }),

--- a/src/features/terminal/layout-registry/prebuiltLayouts.ts
+++ b/src/features/terminal/layout-registry/prebuiltLayouts.ts
@@ -1,0 +1,130 @@
+// cspell:ignore vsplit hsplit
+import type { LayoutId } from '../../sessions/types'
+import { LAYOUT_IDS } from './layoutIds'
+import {
+  createIndexedPaneSlotId,
+  PANE_LAYOUT_SCHEMA_VERSION,
+  type PaneLayoutDefinition,
+  type PaneSlotSpec,
+  type TrackSpec,
+} from './layoutDefinition'
+
+const columns = (...units: readonly number[]): readonly TrackSpec[] =>
+  units.map((unit, index) => ({ id: `c${index}`, units: unit }))
+
+const rows = (...units: readonly number[]): readonly TrackSpec[] =>
+  units.map((unit, index) => ({ id: `r${index}`, units: unit }))
+
+const slot = (paneIndex: number, rect: PaneSlotSpec['rect']): PaneSlotSpec => ({
+  id: createIndexedPaneSlotId(paneIndex),
+  rect,
+})
+
+const addOrderFor = (
+  slots: readonly PaneSlotSpec[]
+): readonly PaneSlotSpec['id'][] => slots.map((paneSlot) => paneSlot.id)
+
+const definePrebuiltLayout = ({
+  id,
+  title,
+  tracks,
+  slots,
+}: {
+  readonly id: LayoutId
+  readonly title: string
+  readonly tracks: PaneLayoutDefinition['tracks']
+  readonly slots: readonly PaneSlotSpec[]
+}): PaneLayoutDefinition => ({
+  schemaVersion: PANE_LAYOUT_SCHEMA_VERSION,
+  id,
+  title,
+  source: 'builtin',
+  tracks,
+  slots,
+  addOrder: addOrderFor(slots),
+})
+
+export const PREBUILT_PANE_LAYOUTS_BY_ID: Record<
+  LayoutId,
+  PaneLayoutDefinition
+> = {
+  single: definePrebuiltLayout({
+    id: 'single',
+    title: 'Single',
+    tracks: {
+      columns: columns(24),
+      rows: rows(24),
+    },
+    slots: [slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 1 })],
+  }),
+  vsplit: definePrebuiltLayout({
+    id: 'vsplit',
+    title: 'Vertical split',
+    tracks: {
+      columns: columns(12, 12),
+      rows: rows(24),
+    },
+    slots: [
+      slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 1 }),
+      slot(1, { col: 1, row: 0, colSpan: 1, rowSpan: 1 }),
+    ],
+  }),
+  hsplit: definePrebuiltLayout({
+    id: 'hsplit',
+    title: 'Horizontal split',
+    tracks: {
+      columns: columns(24),
+      rows: rows(12, 12),
+    },
+    slots: [
+      slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 1 }),
+      slot(1, { col: 0, row: 1, colSpan: 1, rowSpan: 1 }),
+    ],
+  }),
+  threeRight: definePrebuiltLayout({
+    id: 'threeRight',
+    title: 'Main + 2 stack',
+    tracks: {
+      columns: columns(14, 10),
+      rows: rows(12, 12),
+    },
+    slots: [
+      slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 2 }),
+      slot(1, { col: 1, row: 0, colSpan: 1, rowSpan: 1 }),
+      slot(2, { col: 1, row: 1, colSpan: 1, rowSpan: 1 }),
+    ],
+  }),
+  quad: definePrebuiltLayout({
+    id: 'quad',
+    title: 'Quad',
+    tracks: {
+      columns: columns(12, 12),
+      rows: rows(12, 12),
+    },
+    slots: [
+      slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 1 }),
+      slot(1, { col: 1, row: 0, colSpan: 1, rowSpan: 1 }),
+      slot(2, { col: 0, row: 1, colSpan: 1, rowSpan: 1 }),
+      slot(3, { col: 1, row: 1, colSpan: 1, rowSpan: 1 }),
+    ],
+  }),
+  grid3x2: definePrebuiltLayout({
+    id: 'grid3x2',
+    title: '3x2 grid',
+    tracks: {
+      columns: columns(8, 8, 8),
+      rows: rows(12, 12),
+    },
+    slots: [
+      slot(0, { col: 0, row: 0, colSpan: 1, rowSpan: 1 }),
+      slot(1, { col: 1, row: 0, colSpan: 1, rowSpan: 1 }),
+      slot(2, { col: 2, row: 0, colSpan: 1, rowSpan: 1 }),
+      slot(3, { col: 0, row: 1, colSpan: 1, rowSpan: 1 }),
+      slot(4, { col: 1, row: 1, colSpan: 1, rowSpan: 1 }),
+      slot(5, { col: 2, row: 1, colSpan: 1, rowSpan: 1 }),
+    ],
+  }),
+}
+
+export const PREBUILT_PANE_LAYOUTS: readonly PaneLayoutDefinition[] =
+  LAYOUT_IDS.map((layoutId) => PREBUILT_PANE_LAYOUTS_BY_ID[layoutId])

--- a/src/features/terminal/layout-registry/ratioModel.ts
+++ b/src/features/terminal/layout-registry/ratioModel.ts
@@ -9,6 +9,9 @@ export interface LayoutRatios {
   readonly rows: readonly number[]
 }
 
+/** Width of the divider track that replaces the inter-pane gap (px). */
+export const SPLIT_DIVIDER_PX = 8
+
 export const DEFAULT_RATIOS: Record<LayoutId, LayoutRatios> = {
   single: { cols: [1], rows: [1] },
   vsplit: { cols: [1, 1], rows: [1] },


### PR DESCRIPTION
## Summary

- Add a canonical pane layout definition model for workspace layouts, including validation, slot ids, track ratios, and registry assembly.
- Derive prebuilt layout geometry/dividers from the new registry instead of maintaining SplitView divider maps by hand.
- Persist `customPaneLayouts` through the renderer, Electron writer/controller, and Rust workspace-layout repair boundary.
- Add the Chinese technical note for the workspace layout SSoT decision and phase plan.

## Step 1 scope

Complete in this PR:

- SSoT data structure for valid pane layouts: tracks + slot rectangles + add order.
- Prebuilt layout definitions migrated into the registry while preserving current runtime behavior.
- Generic divider geometry generation for current and future layouts.
- Workspace custom-layout persistence boundary and Rust validation/repair support.
- Tests for layout validation, geometry, SplitView wiring, Electron round trip, and Rust repair.

Deferred to the next PR:

- The actual workspace customization plane/editor UI.
- Full runtime widening of `Session.layout` from built-in `LayoutId` to arbitrary `PaneLayoutId` across session manager, shortcuts, cards, picker, and SplitView registry props.
- User-created layout CRUD and picker integration.

Refs VIM-156.

## Validation

- `cargo test --manifest-path crates/backend/Cargo.toml terminal::workspace_layout`
- `npx vitest run src/features/terminal/layout-registry/layoutDefinition.test.ts src/features/terminal/layout-registry/layoutGeometry.test.ts src/features/terminal/layout-registry/layoutRegistry.test.ts src/features/terminal/layout-registry/ratioModel.test.ts src/features/terminal/components/SplitView/resolveGrid.test.ts src/features/terminal/components/SplitView/SplitDividers.test.tsx src/features/terminal/components/SplitView/SplitView.test.tsx src/features/terminal/components/SplitView/layouts.test.ts src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts src/features/sessions/hooks/useSessionRestore.test.ts src/features/sessions/utils/groupSessionsFromInfos.test.ts electron/workspace-layout-writer.test.ts electron/workspace-layout-controller.test.ts electron/workspace-layout-roundtrip.test.ts`
- `npx eslint electron/workspace-layout-controller.test.ts electron/workspace-layout-controller.ts electron/workspace-layout-roundtrip.test.ts electron/workspace-layout-types.ts electron/workspace-layout-writer.test.ts electron/workspace-layout-writer.ts src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts src/features/sessions/hooks/usePushWorkspaceGrouping.ts src/features/sessions/hooks/useSessionRestore.ts src/features/sessions/workspaceLayoutBridge.ts src/features/terminal/components/SplitView/SplitDividers.tsx src/features/terminal/components/SplitView/SplitView.test.tsx src/features/terminal/components/SplitView/SplitView.tsx src/features/terminal/components/SplitView/resolveGrid.test.ts src/features/terminal/components/SplitView/resolveGrid.ts src/features/terminal/layout-registry/index.ts src/features/terminal/layout-registry/layoutSpecs.ts src/features/terminal/layout-registry/ratioModel.ts src/features/terminal/layout-registry/layoutDefinition.test.ts src/features/terminal/layout-registry/layoutDefinition.ts src/features/terminal/layout-registry/layoutGeometry.test.ts src/features/terminal/layout-registry/layoutGeometry.ts src/features/terminal/layout-registry/prebuiltLayouts.ts`
- `npm run type-check:generated`
- `npx prettier --check docs/technical-notes/workspace-layout-customization-ssot.zh-CN.html electron/workspace-layout-controller.test.ts electron/workspace-layout-controller.ts electron/workspace-layout-roundtrip.test.ts electron/workspace-layout-types.ts electron/workspace-layout-writer.test.ts electron/workspace-layout-writer.ts src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts src/features/sessions/hooks/usePushWorkspaceGrouping.ts src/features/sessions/hooks/useSessionRestore.ts src/features/sessions/workspaceLayoutBridge.ts src/features/terminal/components/SplitView/SplitDividers.tsx src/features/terminal/components/SplitView/SplitView.test.tsx src/features/terminal/components/SplitView/SplitView.tsx src/features/terminal/components/SplitView/resolveGrid.test.ts src/features/terminal/components/SplitView/resolveGrid.ts src/features/terminal/layout-registry/index.ts src/features/terminal/layout-registry/layoutSpecs.ts src/features/terminal/layout-registry/ratioModel.ts src/features/terminal/layout-registry/layoutDefinition.test.ts src/features/terminal/layout-registry/layoutDefinition.ts src/features/terminal/layout-registry/layoutGeometry.test.ts src/features/terminal/layout-registry/layoutGeometry.ts src/features/terminal/layout-registry/prebuiltLayouts.ts`
- `npx cspell docs/technical-notes/workspace-layout-customization-ssot.zh-CN.html`
- `git diff --check`
