### PR TITLE
refactor(terminal): pass bytes into parser engines

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -5,7 +5,10 @@ import type {
   TerminalOutputChunk,
   TerminalParser,
 } from '../../types'
-import type { TerminalParserEngineOutput } from './terminalParserEngine'
+import type {
+  TerminalParserEngineInput,
+  TerminalParserEngineOutput,
+} from './terminalParserEngine'
 import {
   GHOSTTY_TERMINAL_RENDERER_ID,
   createGhosttyTerminal,
@@ -103,6 +106,11 @@ describe('ghosttyInstance', () => {
       parser,
       parseText: (text: string): TerminalParserEngineOutput => ({
         visibleText: `parsed:${text}`,
+      }),
+      parseInput: (
+        input: TerminalParserEngineInput
+      ): TerminalParserEngineOutput => ({
+        visibleText: `parsed:${input.text}`,
       }),
       parseOutput,
     }))

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
@@ -36,6 +36,18 @@ const createByteChunk = (
   phase,
 })
 
+const createRawByteChunk = (
+  bytes: Uint8Array,
+  offsetStart: number,
+  phase: TerminalOutputChunk['phase']
+): TerminalOutputChunk => ({
+  text: 'lossy fallback',
+  bytesBase64: encodeBase64(bytes),
+  offsetStart,
+  byteLen: bytes.length,
+  phase,
+})
+
 describe('ghosttyParserEngine', () => {
   test('exposes the Ghostty spike identity and byte-preferring capabilities', () => {
     const engine = createGhosttyParserEngine()
@@ -53,6 +65,27 @@ describe('ghosttyParserEngine', () => {
         visibleText: 'bytes win',
       }
     )
+  })
+
+  test('receives raw byte payloads at the Ghostty parser boundary', () => {
+    const engine = createGhosttyParserEngine()
+    const parseInput = vi.spyOn(engine, 'parseInput')
+    const bytes = new Uint8Array([0xff, 0xfe])
+
+    expect(engine.parseOutput(createRawByteChunk(bytes, 2, 'live'))).toEqual({
+      visibleText: '��',
+    })
+
+    expect(parseInput).toHaveBeenCalledWith({
+      inputMode: 'bytes',
+      text: '��',
+      bytes,
+      output: {
+        offsetStart: 2,
+        byteLen: 2,
+        phase: 'live',
+      },
+    })
   })
 
   test('falls back to text when byte payloads are unreadable', () => {

--- a/src/features/terminal/components/TerminalPane/terminalOutputPayload.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalOutputPayload.test.ts
@@ -48,6 +48,23 @@ const outputChunk = (
   phase: 'live',
 })
 
+const expectBytePayload = (
+  actual: ReturnType<TerminalOutputPayloadRouter['read']>,
+  expected: {
+    readonly text: string
+    readonly bytes: Uint8Array
+  }
+): void => {
+  expect(actual.inputMode).toBe('bytes')
+
+  if (actual.inputMode !== 'bytes') {
+    throw new Error('expected terminal output selection to use byte input')
+  }
+
+  expect(actual.text).toBe(expected.text)
+  expect(Array.from(actual.bytes)).toEqual(Array.from(expected.bytes))
+}
+
 describe('terminalOutputPayload', () => {
   test('decodes base64 payloads to raw bytes', () => {
     expect(decodeBase64ToBytes('//4=')).toEqual(new Uint8Array([255, 254]))
@@ -65,16 +82,22 @@ describe('terminalOutputPayload', () => {
   })
 
   test('prefers streaming byte payloads over fallback text', () => {
+    expect.hasAssertions()
+
     const router = new TerminalOutputPayloadRouter(bytePreferredCapabilities)
     const character = String.fromCodePoint(0x4f60)
     const bytes = new TextEncoder().encode(character)
     const first = outputChunk('wrong', encodeBase64(bytes.slice(0, 2)))
     const second = outputChunk('wrong', encodeBase64(bytes.slice(2)))
 
-    expect(router.read(first)).toEqual({ inputMode: 'bytes', text: '' })
-    expect(router.read(second)).toEqual({
-      inputMode: 'bytes',
+    expectBytePayload(router.read(first), {
+      text: '',
+      bytes: bytes.slice(0, 2),
+    })
+
+    expectBytePayload(router.read(second), {
       text: character,
+      bytes: bytes.slice(2),
     })
   })
 
@@ -99,15 +122,19 @@ describe('terminalOutputPayload', () => {
     const partial = outputChunk('wrong', encodeBase64(bytes.slice(0, 2)))
     const complete = outputChunk('wrong', encodeBase64(bytes))
 
-    expect(router.read(partial)).toEqual({ inputMode: 'bytes', text: '' })
+    expectBytePayload(router.read(partial), {
+      text: '',
+      bytes: bytes.slice(0, 2),
+    })
+
     expect(router.read(outputChunk('fallback'))).toEqual({
       inputMode: 'text',
       text: 'fallback',
     })
 
-    expect(router.read(complete)).toEqual({
-      inputMode: 'bytes',
+    expectBytePayload(router.read(complete), {
       text: character,
+      bytes,
     })
   })
 
@@ -123,14 +150,17 @@ describe('terminalOutputPayload', () => {
   })
 
   test('routes byte-preferring renderers through byte chunks', () => {
+    expect.hasAssertions()
+
     const router = new TerminalOutputPayloadRouter(bytePreferredCapabilities)
 
-    expect(
-      router.read(outputChunk('text loses', encodeText('bytes win')))
-    ).toEqual({
-      inputMode: 'bytes',
-      text: 'bytes win',
-    })
+    expectBytePayload(
+      router.read(outputChunk('text loses', encodeText('bytes win'))),
+      {
+        text: 'bytes win',
+        bytes: new TextEncoder().encode('bytes win'),
+      }
+    )
   })
 
   test('falls back to text only when byte-preferring renderers accept text', () => {

--- a/src/features/terminal/components/TerminalPane/terminalOutputPayload.ts
+++ b/src/features/terminal/components/TerminalPane/terminalOutputPayload.ts
@@ -1,6 +1,5 @@
 import type {
   TerminalOutputChunk,
-  TerminalOutputInputMode,
   TerminalRendererCapabilities,
 } from '../../types'
 
@@ -29,7 +28,9 @@ export const readTerminalOutputBytes = (
 class TerminalOutputBytePayloadDecoder {
   private readonly streamingDecoder = new TextDecoder()
 
-  decode(chunk: TerminalOutputChunk): string | null {
+  decode(
+    chunk: TerminalOutputChunk
+  ): { readonly text: string; readonly bytes: Uint8Array } | null {
     const bytes = readTerminalOutputBytes(chunk)
 
     if (!bytes) {
@@ -38,7 +39,10 @@ class TerminalOutputBytePayloadDecoder {
       return null
     }
 
-    return this.streamingDecoder.decode(bytes, { stream: true })
+    return {
+      text: this.streamingDecoder.decode(bytes, { stream: true }),
+      bytes,
+    }
   }
 
   private reset(): void {
@@ -46,10 +50,16 @@ class TerminalOutputBytePayloadDecoder {
   }
 }
 
-export interface TerminalOutputPayloadSelection {
-  readonly inputMode: TerminalOutputInputMode
-  readonly text: string
-}
+export type TerminalOutputPayloadSelection =
+  | {
+      readonly inputMode: 'text'
+      readonly text: string
+    }
+  | {
+      readonly inputMode: 'bytes'
+      readonly text: string
+      readonly bytes: Uint8Array
+    }
 
 export class TerminalOutputPayloadRouter {
   private readonly byteDecoder: TerminalOutputBytePayloadDecoder | null
@@ -74,7 +84,8 @@ export class TerminalOutputPayloadRouter {
     if (decodedBytes !== null) {
       return {
         inputMode: 'bytes',
-        text: decodedBytes,
+        text: decodedBytes.text,
+        bytes: decodedBytes.bytes,
       }
     }
 

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts
@@ -8,6 +8,8 @@ import type {
 import {
   TerminalControlSequenceParserEngine,
   createControlSequenceTerminalParserEngine,
+  type TerminalParserEngineInput,
+  type TerminalParserEngineOutput,
 } from './terminalParserEngine'
 
 const textOnlyCapabilities: TerminalRendererCapabilities = {
@@ -75,6 +77,16 @@ const createByteEngine = (): TerminalControlSequenceParserEngine =>
     capabilities: bytePreferredCapabilities,
   })
 
+class RecordingParserEngine extends TerminalControlSequenceParserEngine {
+  readonly inputs: TerminalParserEngineInput[] = []
+
+  parseInput(input: TerminalParserEngineInput): TerminalParserEngineOutput {
+    this.inputs.push(input)
+
+    return super.parseInput(input)
+  }
+}
+
 describe('terminal parser engine input modes', () => {
   test('text mode records its input mode and ignores byte payloads', () => {
     const engine = createTextEngine()
@@ -95,6 +107,37 @@ describe('terminal parser engine input modes', () => {
         visibleText: 'bytes win',
       }
     )
+  })
+
+  test('byte mode passes raw bytes to parser input before decoding fallback text', () => {
+    const engine = new RecordingParserEngine({
+      capabilities: bytePreferredCapabilities,
+    })
+
+    const bytes = new Uint8Array([0xff, 0xfe])
+
+    expect(
+      engine.parseOutput({
+        text: 'fallback',
+        bytesBase64: encodeBase64(bytes),
+        offsetStart: 10,
+        byteLen: bytes.length,
+        phase: 'live',
+      })
+    ).toEqual({ visibleText: '��' })
+
+    expect(engine.inputs).toEqual([
+      {
+        inputMode: 'bytes',
+        text: '��',
+        bytes,
+        output: {
+          offsetStart: 10,
+          byteLen: 2,
+          phase: 'live',
+        },
+      },
+    ])
   })
 
   test('control parser class exposes the configured capabilities', () => {

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -6,7 +6,10 @@ import type {
   TerminalRendererCapabilities,
 } from '../../types'
 import { TerminalControlSequenceParser } from './terminalControlParser'
-import { TerminalOutputPayloadRouter } from './terminalOutputPayload'
+import {
+  TerminalOutputPayloadRouter,
+  type TerminalOutputPayloadSelection,
+} from './terminalOutputPayload'
 
 export interface TerminalParserEngineOutput {
   readonly visibleText: string
@@ -14,6 +17,10 @@ export interface TerminalParserEngineOutput {
 }
 
 export type TerminalParserEngineInputMode = TerminalOutputInputMode
+
+export type TerminalParserEngineInput = TerminalOutputPayloadSelection & {
+  readonly output: TerminalParserOutputContext | null
+}
 
 export interface TerminalParserEngineOptions {
   readonly capabilities: TerminalRendererCapabilities
@@ -29,6 +36,7 @@ export interface TerminalParserEngine {
     text: string,
     output: TerminalParserOutputContext | null
   ) => TerminalParserEngineOutput
+  parseInput: (input: TerminalParserEngineInput) => TerminalParserEngineOutput
   parseOutput: (chunk: TerminalOutputChunk) => TerminalParserEngineOutput
 }
 
@@ -66,10 +74,17 @@ export class TerminalControlSequenceParserEngine implements TerminalParserEngine
     return this.parser.transformDisplayOutput(text, output)
   }
 
+  parseInput(input: TerminalParserEngineInput): TerminalParserEngineOutput {
+    return this.parseText(input.text, input.output)
+  }
+
   parseOutput(chunk: TerminalOutputChunk): TerminalParserEngineOutput {
     const selection = this.outputRouter.read(chunk)
 
-    return this.parseText(selection.text, outputContextFromChunk(chunk))
+    return this.parseInput({
+      ...selection,
+      output: outputContextFromChunk(chunk),
+    })
   }
 }
 


### PR DESCRIPTION
## Summary
- Carry raw Uint8Array data through TerminalOutputPayloadRouter for byte-preferring renderers
- Add a TerminalParserEngineInput boundary so parser engines receive text or bytes plus output context
- Verify the Ghostty parser boundary receives raw bytes while the current text parser fallback still renders decoded text

## Test plan
- [x] npx vitest run src/features/terminal/components/TerminalPane/terminalOutputPayload.test.ts src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
- [x] npx tsc -b --pretty false
- [x] npm --ignore-scripts run lint
- [x] npm --ignore-scripts run format:check
- [x] npm run test:e2e:ghostty
- [x] npm test (pre-push hook)

Refs VIM-160