### PR TITLE
feat(settings): search individual setting rows

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                                                              | Category           | Findings | Refs | Last Updated |
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 23       | 4    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 38       | 16   | 2026-06-18   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 39       | 17   | 2026-06-19   |
 | [React Key Stability](patterns/react-key-stability.md)                                               | react-patterns     | 2        | 0    | 2026-06-11   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 71       | 31   | 2026-06-16   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 26   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 74       | 27   | 2026-06-19   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 75       | 27   | 2026-06-19   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 22   | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |
@@ -96,3 +96,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
 | [Modulo Correctness](patterns/modulo-correctness.md)                                                 | correctness        | 1        | 0    | 2026-06-15   |
 | [Catalog Identifier Safety](patterns/catalog-identifier-safety.md)                                   | correctness        | 1        | 0    | 2026-06-18   |
+| [String Protocol Coupling](patterns/string-protocol-coupling.md)                                     | code-quality       | 1        | 0    | 2026-06-19   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -684,3 +684,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** In `handleConfirmSearchResult`, when `activeSearchResultKey` is null the code always falls back to `searchResults[0]`. With an empty query, `searchResults` contains all settings sections, so pressing Enter while the empty search field is focused switches the user to General even when they were on another section. This is unexpected for keyboard users who merely press Enter in the empty search box.
 - **Fix:** Guarded the fallback so it only applies when `normalizedQuery` is non-empty; when the query is empty and no active search result exists, Enter is now a no-op. Added a co-located test asserting that pressing Enter in an empty search field preserves the current pane and focus.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 75. Active descendant and Enter confirmation disagree for target-only section matches
+
+- **Source:** github-codex-connector | PR #544 round 2 | 2026-06-19
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/SettingsDialog.tsx` L109-114
+- **Finding:** For contextual queries such as `appearance fonts`, the settings sidebar still renders the Appearance section as a clickable `role="option"` because it is in `filteredSections`, but the navigable `results` array contains only the matching target rows. With no explicit selection, `activeSearchResultKey` was `null`, so `SettingsSidebar` fell back to `aria-activedescendant` for the active Appearance section while `handleConfirmSearchResult` would confirm `searchResults[0]` (a target). Keyboard/screen-reader users were told one option was active but a different one was activated on Enter.
+- **Fix:** In `SettingsDialog`, default `activeSearchResultKey` to `searchResults[0].key` when the query is non-empty and no explicit selection exists, so the announced active descendant always matches the result that Enter confirms. Preserved the empty-query no-op behavior fixed in #74.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,8 +2,8 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-18
-ref_count: 16
+last_updated: 2026-06-19
+ref_count: 17
 ---
 
 # React Lifecycle
@@ -355,4 +355,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/workspace/WorkspaceView.tsx` L1454-1468
 - **Finding:** `useEffect([paletteBinding, paletteLeaderBinding])` uses Chord object references as deps. `resolveBindings` (called inside `useMemo`) builds a new `Map` with freshly-constructed Chord instances on every invocation. Because `overrides` (the full `customKeybindings` record) is the memoization key, any
 - **Fix:** Hoisted `formatChord(paletteBinding)` and `formatChord(paletteLeaderBinding)` above the effect and used the resulting string tokens as dependencies, so the effect only re-runs when the actual binding values change.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 36. Settings search model recomputes on every unrelated render
+
+- **Source:** github-claude | PR #544 round 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/SettingsDialog.tsx` L96-103
+- **Finding:** `SettingsDialog` called `searchSettings({ sections: SETTINGS_SECTIONS, targets: SETTINGS_TARGETS, query })` directly in the render body, so navigation, focus state, and selection updates reran the full scoring, sorting, and map construction even when `query` was unchanged.
+- **Fix:** Wrapped the `searchSettings` call in `useMemo` with `[query]` as its dependency so the search model is only recomputed when the query changes.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/string-protocol-coupling.md
+++ b/docs/reviews/patterns/string-protocol-coupling.md
@@ -1,0 +1,30 @@
+---
+id: string-protocol-coupling
+category: code-quality
+created: 2026-06-19
+last_updated: 2026-06-19
+ref_count: 0
+---
+
+# String Protocol Coupling
+
+## Summary
+
+When one module owns a structured-string protocol (for example `prefix:<id>`
+result keys or `type:<namespace>:<name>` identifiers), any other module that
+parses the same format is a latent break. Renaming or extending the protocol in
+its owner silently breaks the downstream parser with no type-checker warning and
+often no runtime error until an accessibility or correctness path misfires.
+Centralize the parser alongside the formatter so the protocol is authored and
+consumed in one place.
+
+## Findings
+
+### 1. SettingsSidebar re-implements the section:/target: result-key protocol
+
+- **Source:** github-claude | PR #544 round 2 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/SettingsSidebar.tsx` L19-29
+- **Finding:** `resultIdFromKey` parsed `section:<id>` and `target:<id>` inline and converted the slice to a `SettingsSectionId` with `as SettingsSectionId`. The key format was already owned by `settingsSectionResultKey` / `settingsTargetResultKey` in `search.ts`. A future rename of either prefix would make `resultIdFromKey` return `undefined` for every key, silently clearing `aria-activedescendant` with no console error.
+- **Fix:** Exported `resultKeyToAriaId(key: string): string | undefined` from `search.ts` next to the key constructors and replaced `resultIdFromKey` in `SettingsSidebar.tsx` with an import and call to the new helper.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -115,6 +115,38 @@ describe('SettingsDialog', () => {
     expect(screen.queryByRole('option', { name: 'General' })).toBeNull()
   })
 
+  test('surfaces font setting rows and jumps to the selected result', async () => {
+    const user = userEvent.setup()
+
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => undefined)
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Search settings...'), 'font')
+
+    expect(screen.getByRole('option', { name: 'UI Font' })).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('option', { name: 'Mono Font' })
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('option', { name: 'UI Font' }))
+
+    const target = screen.getByTestId(
+      `settings-target-${SETTINGS_TARGET_IDS.appearanceUiFont}`
+    )
+
+    await waitFor(() => {
+      expect(target).toHaveFocus()
+    })
+
+    expect(target).toHaveAttribute('data-settings-target-active', 'true')
+    expect(scrollIntoView).toHaveBeenCalled()
+
+    scrollIntoView.mockRestore()
+  })
+
   test('clears search from the search field button', async () => {
     const user = userEvent.setup()
     render(<SettingsDialog open onClose={vi.fn()} />)

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'framer-motion'
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
 import type {
   SettingsDialogProps,
   SettingsSearchNavigationDirection,
@@ -93,11 +93,15 @@ export const SettingsDialog = ({
   const contentRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
 
-  const searchModel = searchSettings({
-    sections: SETTINGS_SECTIONS,
-    targets: SETTINGS_TARGETS,
-    query,
-  })
+  const searchModel = useMemo(
+    () =>
+      searchSettings({
+        sections: SETTINGS_SECTIONS,
+        targets: SETTINGS_TARGETS,
+        query,
+      }),
+    [query]
+  )
   const filtered = searchModel.sections
   const targetMatches = searchModel.targets
   const searchResults = searchModel.results

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -3,12 +3,17 @@ import { useEffect, useRef, useState, type ReactElement } from 'react'
 import type {
   SettingsDialogProps,
   SettingsSearchNavigationDirection,
-  SettingsSection,
   SettingsSectionId,
   SettingsTarget,
   SettingsTargetId,
 } from './types'
 import { SETTINGS_SECTIONS, SETTINGS_TARGETS } from './sections'
+import {
+  searchSettings,
+  settingsSectionResultKey,
+  settingsTargetResultKey,
+  type SettingsSearchResult,
+} from './search'
 import { Icon } from './components/Icon'
 import { Tooltip } from '@/components/Tooltip'
 import { Kbd } from './components/Kbd'
@@ -26,23 +31,6 @@ const REAL_PANES: readonly SettingsSectionId[] = [
   'keymap',
   'agents',
 ]
-
-const matchesQuery = (
-  value: string | undefined,
-  normalizedQuery: string
-): boolean => value?.toLowerCase().includes(normalizedQuery) ?? false
-
-type SettingsSearchResult =
-  | {
-      key: string
-      kind: 'section'
-      section: SettingsSection
-    }
-  | {
-      key: string
-      kind: 'target'
-      target: SettingsTarget
-    }
 
 type TargetFocusMode = 'focus-target' | 'preserve-search-focus'
 
@@ -105,56 +93,14 @@ export const SettingsDialog = ({
   const contentRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
 
-  const normalizedQuery = query.trim().toLowerCase()
-
-  const sectionMatches = normalizedQuery
-    ? SETTINGS_SECTIONS.filter((s) => matchesQuery(s.label, normalizedQuery))
-    : SETTINGS_SECTIONS
-
-  const targetMatches = normalizedQuery
-    ? SETTINGS_TARGETS.filter(
-        (target) =>
-          matchesQuery(target.label, normalizedQuery) ||
-          matchesQuery(target.hint, normalizedQuery)
-      )
-    : []
-
-  const filteredSectionIds = new Set<SettingsSectionId>([
-    ...sectionMatches.map((s) => s.id),
-    ...targetMatches.map((target) => target.section),
-  ])
-
-  const filtered = normalizedQuery
-    ? SETTINGS_SECTIONS.filter((s) => filteredSectionIds.has(s.id))
-    : SETTINGS_SECTIONS
-
-  const sectionMatchIds = new Set<SettingsSectionId>(
-    sectionMatches.map((s) => s.id)
-  )
-
-  const searchResults = filtered.flatMap((s): SettingsSearchResult[] => {
-    const results: SettingsSearchResult[] = []
-
-    if (!normalizedQuery || sectionMatchIds.has(s.id)) {
-      results.push({
-        key: `section:${s.id}`,
-        kind: 'section',
-        section: s,
-      })
-    }
-
-    targetMatches
-      .filter((target) => target.section === s.id)
-      .forEach((target) => {
-        results.push({
-          key: `target:${target.id}`,
-          kind: 'target',
-          target,
-        })
-      })
-
-    return results
+  const searchModel = searchSettings({
+    sections: SETTINGS_SECTIONS,
+    targets: SETTINGS_TARGETS,
+    query,
   })
+  const filtered = searchModel.sections
+  const targetMatches = searchModel.targets
+  const searchResults = searchModel.results
 
   const activeSearchResultKey =
     selectedSearchResultKey !== null &&
@@ -167,7 +113,7 @@ export const SettingsDialog = ({
   const handlePickSection = (id: SettingsSectionId): void => {
     setSection(id)
     setActiveTargetId(null)
-    setSelectedSearchResultKey(`section:${id}`)
+    setSelectedSearchResultKey(settingsSectionResultKey(id))
   }
 
   const handleQuery = (nextQuery: string): void => {
@@ -203,11 +149,18 @@ export const SettingsDialog = ({
   }
 
   const handlePickTarget = (target: SettingsTarget): void => {
+    const owningSection = SETTINGS_SECTIONS.find((s) => s.id === target.section)
+    if (owningSection === undefined) {
+      return
+    }
+
     applySearchResult(
       {
-        key: `target:${target.id}`,
+        key: settingsTargetResultKey(target),
         kind: 'target',
+        section: owningSection,
         target,
+        score: 0,
       },
       'focus-target'
     )
@@ -251,7 +204,7 @@ export const SettingsDialog = ({
         : searchResults.find((result) => result.key === activeSearchResultKey)
 
     const resultToConfirm =
-      currentResult ?? (normalizedQuery ? searchResults[0] : undefined)
+      currentResult ?? (query.trim() ? searchResults[0] : undefined)
 
     if (!resultToConfirm) {
       return
@@ -399,6 +352,7 @@ export const SettingsDialog = ({
                 targets={targetMatches}
                 active={section}
                 activeTargetId={activeTargetId}
+                activeSearchResultKey={activeSearchResultKey}
                 onPick={handlePickSection}
                 onPickTarget={handlePickTarget}
                 onClearQuery={handleClearQuery}

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -110,7 +110,9 @@ export const SettingsDialog = ({
     selectedSearchResultKey !== null &&
     searchResults.some((result) => result.key === selectedSearchResultKey)
       ? selectedSearchResultKey
-      : null
+      : query.trim() !== '' && searchResults.length > 0
+        ? searchResults[0].key
+        : null
 
   const activeSection = SETTINGS_SECTIONS.find((s) => s.id === section)
 

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -86,6 +86,27 @@ describe('SettingsSidebar', () => {
     )
   })
 
+  test('uses the selected search result key for aria-activedescendant', () => {
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        sections={SETTINGS_SECTIONS.filter(
+          (section) => section.id === 'general'
+        )}
+        targets={[redactTarget]}
+        active="general"
+        activeSearchResultKey={`target:${redactTarget.id}`}
+      />
+    )
+
+    expect(
+      screen.getByRole('combobox', { name: 'Search settings' })
+    ).toHaveAttribute(
+      'aria-activedescendant',
+      `settings-search-result-target-${redactTarget.id}`
+    )
+  })
+
   test('renders the result list as a listbox', () => {
     render(<SettingsSidebar {...baseProps} />)
 

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -6,6 +6,7 @@ import type {
   SettingsSidebarProps,
   SettingsTargetId,
 } from '../types'
+import { resultKeyToAriaId } from '../search'
 import { Icon } from './Icon'
 
 const SEARCH_RESULTS_ID = 'settings-search-results'
@@ -15,18 +16,6 @@ const sectionResultId = (id: SettingsSectionId): string =>
 
 const targetResultId = (id: SettingsTargetId): string =>
   `settings-search-result-target-${id}`
-
-const resultIdFromKey = (key: string): string | undefined => {
-  if (key.startsWith('section:')) {
-    return sectionResultId(key.slice('section:'.length) as SettingsSectionId)
-  }
-
-  if (key.startsWith('target:')) {
-    return targetResultId(key.slice('target:'.length))
-  }
-
-  return undefined
-}
 
 export const SettingsSidebar = ({
   sections,
@@ -55,7 +44,7 @@ export const SettingsSidebar = ({
   const activeResultId =
     activeSearchResultKey === null
       ? fallbackActiveResultId
-      : resultIdFromKey(activeSearchResultKey)
+      : resultKeyToAriaId(activeSearchResultKey)
 
   const hasResults = sections.length > 0 || targets.length > 0
 

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -16,11 +16,24 @@ const sectionResultId = (id: SettingsSectionId): string =>
 const targetResultId = (id: SettingsTargetId): string =>
   `settings-search-result-target-${id}`
 
+const resultIdFromKey = (key: string): string | undefined => {
+  if (key.startsWith('section:')) {
+    return sectionResultId(key.slice('section:'.length) as SettingsSectionId)
+  }
+
+  if (key.startsWith('target:')) {
+    return targetResultId(key.slice('target:'.length))
+  }
+
+  return undefined
+}
+
 export const SettingsSidebar = ({
   sections,
   targets = [],
   active,
   activeTargetId = null,
+  activeSearchResultKey = null,
   onPick,
   onPickTarget = (): void => undefined,
   onClearQuery = (): void => undefined,
@@ -31,13 +44,18 @@ export const SettingsSidebar = ({
 }: SettingsSidebarProps): ReactElement => {
   const searchInputRef = useRef<HTMLInputElement>(null)
 
-  const activeResultId =
+  const fallbackActiveResultId =
     activeTargetId !== null &&
     targets.some((target) => target.id === activeTargetId)
       ? targetResultId(activeTargetId)
       : sections.some((section) => section.id === active)
         ? sectionResultId(active)
         : undefined
+
+  const activeResultId =
+    activeSearchResultKey === null
+      ? fallbackActiveResultId
+      : resultIdFromKey(activeSearchResultKey)
 
   const hasResults = sections.length > 0 || targets.length > 0
 

--- a/src/features/settings/search.test.ts
+++ b/src/features/settings/search.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest'
+import { SETTINGS_SECTIONS, SETTINGS_TARGETS } from './sections'
+import { searchSettings, type SettingsSearchModel } from './search'
+
+const search = (query: string): SettingsSearchModel =>
+  searchSettings({
+    sections: SETTINGS_SECTIONS,
+    targets: SETTINGS_TARGETS,
+    query,
+  })
+
+const targetLabels = (query: string): string[] =>
+  search(query).targets.map((target) => target.label)
+
+describe('searchSettings', () => {
+  test('returns section results when the query is empty', () => {
+    const model = search('')
+
+    expect(model.sections.map((section) => section.label)).toEqual(
+      SETTINGS_SECTIONS.map((section) => section.label)
+    )
+    expect(model.targets).toEqual([])
+    expect(model.results.map((result) => result.key)).toContain(
+      'section:appearance'
+    )
+  })
+
+  test('surfaces individual font setting rows before category results', () => {
+    const model = search('font')
+
+    expect(model.sections.map((section) => section.label)).toEqual([
+      'Appearance',
+    ])
+
+    expect(model.targets.slice(0, 2).map((target) => target.label)).toEqual([
+      'UI Font',
+      'Mono Font',
+    ])
+
+    expect(model.results[0]).toMatchObject({
+      kind: 'target',
+      key: 'target:appearance-ui-font',
+    })
+  })
+
+  test('matches fuzzy abbreviations against setting labels', () => {
+    expect(targetLabels('ui fnt')).toContain('UI Font')
+    expect(targetLabels('ui fnt')).not.toContain('Mono Font')
+  })
+
+  test('matches category and subsection context for settings', () => {
+    expect(targetLabels('appearance fonts')).toEqual(['UI Font', 'Mono Font'])
+  })
+})

--- a/src/features/settings/search.ts
+++ b/src/features/settings/search.ts
@@ -1,0 +1,342 @@
+import type {
+  SettingsSection,
+  SettingsSectionId,
+  SettingsTarget,
+} from './types'
+
+interface ParsedSearchQuery {
+  normalized: string
+  compact: string
+  tokens: string[]
+}
+
+interface SettingsSearchInput {
+  sections: SettingsSection[]
+  targets: SettingsTarget[]
+  query: string
+}
+
+export type SettingsSearchResult =
+  | {
+      key: string
+      kind: 'section'
+      section: SettingsSection
+      score: number
+    }
+  | {
+      key: string
+      kind: 'target'
+      section: SettingsSection
+      target: SettingsTarget
+      score: number
+    }
+
+export interface SettingsSearchModel {
+  sections: SettingsSection[]
+  targets: SettingsTarget[]
+  results: SettingsSearchResult[]
+}
+
+export const settingsSectionResultKey = (id: SettingsSectionId): string =>
+  `section:${id}`
+
+export const settingsTargetResultKey = (target: SettingsTarget): string =>
+  `target:${target.id}`
+
+const normalizeSearchText = (value: string | undefined): string =>
+  value
+    ?.toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim() ?? ''
+
+const compactText = (value: string): string => value.replace(/\s+/g, '')
+
+const parseSearchQuery = (query: string): ParsedSearchQuery => {
+  const normalized = normalizeSearchText(query)
+
+  return {
+    normalized,
+    compact: compactText(normalized),
+    tokens: normalized.split(/\s+/).filter(Boolean),
+  }
+}
+
+const isSubsequence = (needle: string, haystack: string): boolean => {
+  let needleIndex = 0
+
+  for (const char of haystack) {
+    if (char === needle[needleIndex]) {
+      needleIndex += 1
+    }
+
+    if (needleIndex === needle.length) {
+      return true
+    }
+  }
+
+  return false
+}
+
+const tokenScore = (text: string, token: string): number | null => {
+  const words = text.split(/\s+/).filter(Boolean)
+
+  if (words.includes(token)) {
+    return 36
+  }
+
+  if (words.some((word) => word.startsWith(token))) {
+    return 30
+  }
+
+  if (text.includes(token)) {
+    return 24
+  }
+
+  if (
+    token.length > 2 &&
+    words.some(
+      (word) => word.length >= token.length && isSubsequence(token, word)
+    )
+  ) {
+    return 12
+  }
+
+  return null
+}
+
+const scoreSearchText = (
+  text: string,
+  query: ParsedSearchQuery
+): number | null => {
+  if (!text || query.tokens.length === 0) {
+    return null
+  }
+
+  const tokenScores = query.tokens.map((token) => tokenScore(text, token))
+  if (tokenScores.some((score) => score === null)) {
+    return null
+  }
+
+  const numericTokenScores = tokenScores.filter(
+    (score): score is number => score !== null
+  )
+
+  const phraseScore =
+    text === query.normalized
+      ? 72
+      : text.includes(query.normalized)
+        ? 54
+        : compactText(text).includes(query.compact)
+          ? 42
+          : 0
+
+  return (
+    phraseScore + numericTokenScores.reduce((total, score) => total + score, 0)
+  )
+}
+
+const scoreSection = (
+  section: SettingsSection,
+  query: ParsedSearchQuery
+): number | null => {
+  const score = scoreSearchText(normalizeSearchText(section.label), query)
+
+  return score === null ? null : score + 20
+}
+
+const scoreTarget = (
+  target: SettingsTarget,
+  section: SettingsSection,
+  query: ParsedSearchQuery
+): number | null => {
+  const fields = [
+    { value: target.label, weight: 90 },
+    { value: target.subsection, weight: 58 },
+    { value: section.label, weight: 46 },
+    { value: target.hint, weight: 32 },
+  ]
+
+  const combined = normalizeSearchText(
+    fields
+      .map((field) => field.value)
+      .filter(Boolean)
+      .join(' ')
+  )
+  const combinedScore = scoreSearchText(combined, query)
+
+  if (combinedScore === null) {
+    return null
+  }
+
+  const bestFieldScore = Math.max(
+    0,
+    ...fields.map((field) => {
+      const score = scoreSearchText(normalizeSearchText(field.value), query)
+
+      return score === null ? 0 : score + field.weight
+    })
+  )
+
+  return combinedScore + bestFieldScore + 30
+}
+
+const sectionOrderOf = (
+  sectionOrder: Map<SettingsSectionId, number>,
+  section: SettingsSection
+): number => sectionOrder.get(section.id) ?? Number.MAX_SAFE_INTEGER
+
+const targetOrderOf = (
+  targetOrder: Map<string, number>,
+  target: SettingsTarget
+): number => targetOrder.get(target.id) ?? Number.MAX_SAFE_INTEGER
+
+export const searchSettings = ({
+  sections,
+  targets,
+  query,
+}: SettingsSearchInput): SettingsSearchModel => {
+  const parsedQuery = parseSearchQuery(query)
+
+  if (parsedQuery.normalized === '') {
+    return {
+      sections,
+      targets: [],
+      results: sections.map((section) => ({
+        key: settingsSectionResultKey(section.id),
+        kind: 'section',
+        section,
+        score: 0,
+      })),
+    }
+  }
+
+  const sectionById = new Map(sections.map((section) => [section.id, section]))
+
+  const sectionOrder = new Map(
+    sections.map((section, index) => [section.id, index])
+  )
+
+  const targetOrder = new Map(
+    targets.map((target, index) => [target.id, index])
+  )
+
+  const sectionResults = sections.flatMap((section): SettingsSearchResult[] => {
+    const score = scoreSection(section, parsedQuery)
+
+    return score === null
+      ? []
+      : [
+          {
+            key: settingsSectionResultKey(section.id),
+            kind: 'section',
+            section,
+            score,
+          },
+        ]
+  })
+
+  const targetResults = targets.flatMap((target): SettingsSearchResult[] => {
+    const section = sectionById.get(target.section)
+    if (section === undefined) {
+      return []
+    }
+
+    const score = scoreTarget(target, section, parsedQuery)
+
+    return score === null
+      ? []
+      : [
+          {
+            key: settingsTargetResultKey(target),
+            kind: 'target',
+            section,
+            target,
+            score,
+          },
+        ]
+  })
+
+  const scoreBySection = new Map<SettingsSectionId, number>()
+
+  sectionResults.forEach((result) => {
+    scoreBySection.set(result.section.id, result.score)
+  })
+
+  targetResults.forEach((result) => {
+    const currentScore = scoreBySection.get(result.section.id) ?? 0
+    scoreBySection.set(result.section.id, Math.max(currentScore, result.score))
+  })
+
+  const filteredSections = sections
+    .filter((section) => scoreBySection.has(section.id))
+    .sort((a, b) => {
+      const scoreDelta =
+        (scoreBySection.get(b.id) ?? 0) - (scoreBySection.get(a.id) ?? 0)
+
+      return (
+        scoreDelta ||
+        sectionOrderOf(sectionOrder, a) - sectionOrderOf(sectionOrder, b)
+      )
+    })
+
+  const filteredTargets = targetResults
+    .sort((a, b) => {
+      if (a.kind !== 'target' || b.kind !== 'target') {
+        return 0
+      }
+
+      const scoreDelta = b.score - a.score
+      if (scoreDelta !== 0) {
+        return scoreDelta
+      }
+
+      const sectionDelta =
+        sectionOrderOf(sectionOrder, a.section) -
+        sectionOrderOf(sectionOrder, b.section)
+      if (sectionDelta !== 0) {
+        return sectionDelta
+      }
+
+      return (
+        targetOrderOf(targetOrder, a.target) -
+        targetOrderOf(targetOrder, b.target)
+      )
+    })
+    .flatMap((result) => (result.kind === 'target' ? [result.target] : []))
+
+  const sectionResultById = new Map(
+    sectionResults.map((result) => [result.section.id, result])
+  )
+
+  const targetResultById = new Map(
+    targetResults.flatMap((result) =>
+      result.kind === 'target' ? [[result.target.id, result] as const] : []
+    )
+  )
+
+  const results = filteredSections.flatMap(
+    (section): SettingsSearchResult[] => {
+      const sectionResult = sectionResultById.get(section.id)
+
+      const sectionTargets = filteredTargets
+        .filter((target) => target.section === section.id)
+        .flatMap((target) => {
+          const result = targetResultById.get(target.id)
+
+          return result === undefined ? [] : [result]
+        })
+
+      return sectionResult === undefined
+        ? sectionTargets
+        : [sectionResult, ...sectionTargets]
+    }
+  )
+
+  return {
+    sections: filteredSections,
+    targets: filteredTargets,
+    results,
+  }
+}

--- a/src/features/settings/search.ts
+++ b/src/features/settings/search.ts
@@ -43,6 +43,18 @@ export const settingsSectionResultKey = (id: SettingsSectionId): string =>
 export const settingsTargetResultKey = (target: SettingsTarget): string =>
   `target:${target.id}`
 
+export const resultKeyToAriaId = (key: string): string | undefined => {
+  if (key.startsWith('section:')) {
+    return `settings-search-result-section-${key.slice('section:'.length)}`
+  }
+
+  if (key.startsWith('target:')) {
+    return `settings-search-result-target-${key.slice('target:'.length)}`
+  }
+
+  return undefined
+}
+
 const normalizeSearchText = (value: string | undefined): string =>
   value
     ?.toLowerCase()

--- a/src/features/settings/sections.ts
+++ b/src/features/settings/sections.ts
@@ -234,72 +234,84 @@ export const SETTINGS_TARGETS: SettingsTarget[] = [
     section: 'general',
     label: 'When Closing With No Tabs',
     hint: "What to do when using the 'close active item' action with no tabs.",
+    subsection: 'Window lifecycle',
   },
   {
     id: SETTINGS_TARGET_IDS.generalOnLastWindowClosed,
     section: 'general',
     label: 'On Last Window Closed',
     hint: 'What to do when the last window is closed.',
+    subsection: 'Window lifecycle',
   },
   {
     id: SETTINGS_TARGET_IDS.generalUseSystemPathPrompts,
     section: 'general',
     label: 'Use System Path Prompts',
     hint: "Use native OS dialogs for 'Open' and 'Save As'.",
+    subsection: 'Prompts',
   },
   {
     id: SETTINGS_TARGET_IDS.generalUseSystemPrompts,
     section: 'general',
     label: 'Use System Prompts',
     hint: 'Use native OS dialogs for confirmations.',
+    subsection: 'Prompts',
   },
   {
     id: SETTINGS_TARGET_IDS.generalRedactPrivateValues,
     section: 'general',
     label: 'Redact Private Values',
     hint: 'Hide the values of variables in private files.',
+    subsection: 'Privacy',
   },
   {
     id: SETTINGS_TARGET_IDS.generalCliOpenBehavior,
     section: 'general',
     label: 'CLI Default Open Behavior',
     hint: 'How `vf <path>` opens directories when no flag is specified.',
+    subsection: 'CLI',
   },
   {
     id: SETTINGS_TARGET_IDS.appearanceColorScheme,
     section: 'appearance',
     label: 'Color Scheme',
     hint: 'The base palette for all surfaces, text, and accents.',
+    subsection: 'Theme',
   },
   {
     id: SETTINGS_TARGET_IDS.appearanceAccentHue,
     section: 'appearance',
     label: 'Accent Hue',
     hint: 'Shift the primary accent around the wheel.',
+    subsection: 'Theme',
   },
   {
     id: SETTINGS_TARGET_IDS.appearanceDensity,
     section: 'appearance',
     label: 'Density',
     hint: 'Compact for power users; comfortable for readability.',
+    subsection: 'Interface',
   },
   {
     id: SETTINGS_TARGET_IDS.appearanceUiFont,
     section: 'appearance',
     label: 'UI Font',
     hint: 'Sans-serif used for labels, sidebars, headings.',
+    subsection: 'Fonts',
   },
   {
     id: SETTINGS_TARGET_IDS.appearanceMonoFont,
     section: 'appearance',
     label: 'Mono Font',
     hint: 'Used in the terminal, editor, and all code blocks.',
+    subsection: 'Fonts',
   },
   {
     id: SETTINGS_TARGET_IDS.keymapPreset,
     section: 'keymap',
     label: 'Preset',
     hint: 'Switch between the default Vimeflow binding set and Vim-style bindings.',
+    subsection: 'Base Keymap',
   },
   ...CATALOG.filter((cmd) => KEYMAP_TARGET_GROUPS.has(cmd.group)).map(
     (cmd): SettingsTarget => ({
@@ -307,6 +319,7 @@ export const SETTINGS_TARGETS: SettingsTarget[] = [
       section: 'keymap',
       label: cmd.label,
       hint: `${cmd.group} shortcut`,
+      subsection: cmd.group,
     })
   ),
   ...KEYMAP_GROUPS.filter(
@@ -318,6 +331,7 @@ export const SETTINGS_TARGETS: SettingsTarget[] = [
         section: 'keymap',
         label: binding.label,
         hint: `${group.zone} shortcut`,
+        subsection: group.zone,
       })
     )
   ),
@@ -326,12 +340,14 @@ export const SETTINGS_TARGETS: SettingsTarget[] = [
     section: 'agents',
     label: 'Manage agent shell aliases',
     hint: "Vimeflow injects these into each pane's PTY environment.",
+    subsection: 'Aliases',
   },
   {
     id: SETTINGS_TARGET_IDS.agentsShellAliases,
     section: 'agents',
     label: 'Shell aliases',
     hint: 'Type the alias in any pane and Vimeflow swaps it for the full agent invocation.',
+    subsection: 'Aliases',
   },
 ]
 

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -30,6 +30,7 @@ export interface SettingsTarget {
   section: SettingsSectionId
   label: string
   hint?: string
+  subsection?: string
 }
 
 export type SettingsSearchNavigationDirection = 'next' | 'previous'
@@ -44,6 +45,7 @@ export interface SettingsSidebarProps {
   targets?: SettingsTarget[]
   active: SettingsSectionId
   activeTargetId?: SettingsTargetId | null
+  activeSearchResultKey?: string | null
   onPick: (id: SettingsSectionId) => void
   onPickTarget?: (target: SettingsTarget) => void
   onClearQuery?: () => void


### PR DESCRIPTION
## Summary
- Add a ranked settings search model for section labels, setting labels, hints, subsections, and owning categories
- Wire SettingsDialog to use the shared model so queries like `font` surface UI Font / Mono Font row results
- Preserve the active search result key for sidebar `aria-activedescendant` during keyboard navigation

Refs VIM-107

## Validation
- `npm test -- --run src/features/settings/search.test.ts src/features/settings/SettingsDialog.test.tsx src/features/settings/components/SettingsSidebar.test.tsx src/features/settings/sections.test.ts src/features/settings/types.test.ts`
- `npm run type-check:generated`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- `npm test -- --run`