### PR TITLE
refactor(terminal): add Ghostty byte parser adapter

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
@@ -4,6 +4,8 @@ import type { TerminalOutputChunk } from '../../types'
 import {
   GHOSTTY_PARSER_ENGINE_ID,
   createGhosttyParserEngine,
+  type GhosttyByteParserAdapter,
+  type GhosttyByteParserAdapterInput,
 } from './ghosttyParserEngine'
 import { getSgrStyleSentinel } from './terminalControlParser'
 import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
@@ -88,6 +90,34 @@ describe('ghosttyParserEngine', () => {
     })
   })
 
+  test('routes byte payloads through the Ghostty byte parser adapter', () => {
+    const parseBytes = vi.fn((input: GhosttyByteParserAdapterInput) => ({
+      visibleText: `${Array.from(input.bytes).join(',')}:${input.decodedText}:${
+        input.output?.offsetStart ?? 'missing'
+      }`,
+    }))
+
+    const reset = vi.fn()
+    const adapter: GhosttyByteParserAdapter = { parseBytes, reset }
+    const engine = createGhosttyParserEngine({ byteParserAdapter: adapter })
+    const bytes = new Uint8Array([0xff, 0xfe])
+
+    expect(engine.parseOutput(createRawByteChunk(bytes, 7, 'live'))).toEqual({
+      visibleText: '255,254:��:7',
+    })
+
+    expect(parseBytes).toHaveBeenCalledWith({
+      bytes,
+      decodedText: '��',
+      output: {
+        offsetStart: 7,
+        byteLen: 2,
+        phase: 'live',
+      },
+    })
+    expect(reset).not.toHaveBeenCalled()
+  })
+
   test('falls back to text when byte payloads are unreadable', () => {
     const engine = createGhosttyParserEngine()
 
@@ -102,6 +132,27 @@ describe('ghosttyParserEngine', () => {
     ).toEqual({
       visibleText: 'text fallback',
     })
+  })
+
+  test('resets the Ghostty byte parser adapter on text fallback', () => {
+    const parseBytes = vi.fn(() => ({ visibleText: 'bytes' }))
+    const reset = vi.fn()
+    const adapter: GhosttyByteParserAdapter = { parseBytes, reset }
+    const engine = createGhosttyParserEngine({ byteParserAdapter: adapter })
+
+    expect(
+      engine.parseOutput({
+        text: 'text fallback',
+        offsetStart: 0,
+        byteLen: 13,
+        phase: 'live',
+      })
+    ).toEqual({
+      visibleText: 'text fallback',
+    })
+
+    expect(parseBytes).not.toHaveBeenCalled()
+    expect(reset).toHaveBeenCalledTimes(1)
   })
 
   test('emits OSC 7 cwd events from byte payloads with output context', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -1,14 +1,56 @@
 // cspell:ignore ghostty
+import type { TerminalParserOutputContext } from '../../types'
 import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 import {
   TerminalControlSequenceParserEngine,
   type TerminalParserEngine,
+  type TerminalParserEngineInput,
+  type TerminalParserEngineOutput,
 } from './terminalParserEngine'
 
 export const GHOSTTY_PARSER_ENGINE_ID = 'ghostty-control-sequence-spike'
 
+export interface GhosttyByteParserAdapterInput {
+  readonly bytes: Uint8Array
+  readonly decodedText: string
+  readonly output: TerminalParserOutputContext | null
+}
+
+export interface GhosttyByteParserAdapter {
+  parseBytes: (
+    input: GhosttyByteParserAdapterInput
+  ) => TerminalParserEngineOutput
+  reset?: () => void
+}
+
+export interface GhosttyParserEngineOptions {
+  readonly byteParserAdapter?: GhosttyByteParserAdapter
+}
+
 export interface GhosttyParserEngine extends TerminalParserEngine {
   readonly id: typeof GHOSTTY_PARSER_ENGINE_ID
+}
+
+class ControlSequenceGhosttyByteParserAdapter implements GhosttyByteParserAdapter {
+  private readonly decoder = new TextDecoder()
+
+  constructor(
+    private readonly parseText: (
+      text: string,
+      output: TerminalParserOutputContext | null
+    ) => TerminalParserEngineOutput
+  ) {}
+
+  parseBytes(input: GhosttyByteParserAdapterInput): TerminalParserEngineOutput {
+    return this.parseText(
+      this.decoder.decode(input.bytes, { stream: true }),
+      input.output
+    )
+  }
+
+  reset(): void {
+    this.decoder.decode()
+  }
 }
 
 export class GhosttyControlSequenceParserEngine
@@ -16,15 +58,37 @@ export class GhosttyControlSequenceParserEngine
   implements GhosttyParserEngine
 {
   readonly id: typeof GHOSTTY_PARSER_ENGINE_ID = GHOSTTY_PARSER_ENGINE_ID
+  private readonly byteParserAdapter: GhosttyByteParserAdapter
 
-  constructor() {
+  constructor(options: GhosttyParserEngineOptions = {}) {
     super({
       capabilities: GHOSTTY_TERMINAL_CAPABILITIES,
       consumeControlsWithoutSubscribers: true,
       preserveSgrStyles: true,
     })
+
+    this.byteParserAdapter =
+      options.byteParserAdapter ??
+      new ControlSequenceGhosttyByteParserAdapter((text, output) =>
+        this.parseText(text, output)
+      )
+  }
+
+  parseInput(input: TerminalParserEngineInput): TerminalParserEngineOutput {
+    if (input.inputMode === 'bytes') {
+      return this.byteParserAdapter.parseBytes({
+        bytes: input.bytes,
+        decodedText: input.text,
+        output: input.output,
+      })
+    }
+
+    this.byteParserAdapter.reset?.()
+
+    return super.parseInput(input)
   }
 }
 
-export const createGhosttyParserEngine = (): GhosttyParserEngine =>
-  new GhosttyControlSequenceParserEngine()
+export const createGhosttyParserEngine = (
+  options?: GhosttyParserEngineOptions
+): GhosttyParserEngine => new GhosttyControlSequenceParserEngine(options)


### PR DESCRIPTION
## Summary

- Add an injectable Ghostty byte parser adapter boundary around the Ghostty parser engine.
- Keep the default adapter behavior delegated to the existing control-sequence parser while consuming raw byte payloads first.
- Preserve text fallback and reset byte adapter stream state when byte payloads are missing or unreadable.

## Verification

- `npx vitest run src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts src/features/terminal/components/TerminalPane/terminalOutputPayload.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run test:e2e:ghostty`
- pre-push `npm run test` hook: 299 files / 3874 tests passed

Refs VIM-161