### PR TITLE
refactor(terminal): add Ghostty VT parser bridge

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,7 +55,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 21       | 7    | 2026-06-18   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 23       | 7    | 2026-06-19   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 2        | 0    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,7 +55,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 23       | 7    | 2026-06-19   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 24       | 7    | 2026-06-19   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 2        | 0    | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -2,7 +2,7 @@
 id: terminal-control-sequence-handling
 category: terminal
 created: 2026-06-17
-last_updated: 2026-06-18
+last_updated: 2026-06-19
 ref_count: 7
 ---
 
@@ -208,3 +208,22 @@ all required state through pure display-state helpers.
 - **Finding:** `readCursorRow` counted newlines from offset 0 to the cursor and was invoked for every cursor-horizontal-absolute sentinel and every cursor-down-at-EOF event in `applyDisplayData`. With large scrollback and frequent CHA repaint sequences, a single output batch could perform millions of redundant character comparisons.
 - **Fix:** Added `cursorRow` to `DisplayState` and threaded it through `applyDisplayData`. `moveCursorToPosition` and `moveCursorToHorizontalAbsoluteColumn` return the resolved row; cursor-left/backspace report a row delta when crossing a soft-wrap newline; other row-changing paths update or recompute `cursorRow` so CHA and cursor-down can read the current row in O(1).
 - **Commit:** same commit as this entry
+
+### 22. GhosttyVtByteParserAdapter.reset() has no isDisposed guard
+
+- **Source:** github-claude | PR #547 round 1 | 2026-06-19
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts` L51-53
+- **Finding:** `dispose()` set `isDisposed` and called `driver.dispose()`, but `reset()` delegated to `driver.reset()` without checking the disposed flag. After renderer-handle disposal tore down the driver, later text-mode `parseInput` paths could call `reset()` on the already-torn-down driver.
+- **Fix:** Added an `if (this.isDisposed) return` guard at the top of `reset()` and added a regression test that verifies `reset()` is a no-op after `dispose()`.
+- **Commit:** same commit as this entry (see `git blame` / `git log`)
+
+### 23. Keep parser disposal tied to terminal lifetime
+
+- **Source:** github-codex-connector | PR #547 round 1 | 2026-06-19
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyInstance.ts` L75
+- **Finding:** `rendererHandle.dispose()` disposed the parser engine, but the Ghostty terminal can still receive `output.writeOutput()` after the renderer handle is detached (and terminal-only disposal paths never hit the renderer handle). Tearing down the driver early left later writes calling into a disposed driver.
+- **Fix:** Moved `parserEngine.dispose()` into a wrapper around `terminal.dispose()` and added an idempotent `isDisposed` guard so the engine is disposed exactly once when the terminal surface is disposed. `rendererHandle.dispose()` now only tracks renderer-addon detachment.
+- **Commit:** same commit as this entry (see `git blame` / `git log`)
+

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -227,3 +227,11 @@ all required state through pure display-state helpers.
 - **Fix:** Moved `parserEngine.dispose()` into a wrapper around `terminal.dispose()` and added an idempotent `isDisposed` guard so the engine is disposed exactly once when the terminal surface is disposed. `rendererHandle.dispose()` now only tracks renderer-addon detachment.
 - **Commit:** same commit as this entry (see `git blame` / `git log`)
 
+### 24. emitEvent made public on TerminalControlSequenceParser unnecessarily
+
+- **Source:** github-claude | PR #547 round 2 | 2026-06-19
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/terminalControlParser.ts` L787-791
+- **Finding:** `private emit` was renamed `emitEvent` and widened to public so `GhosttyControlSequenceParserEngine` could forward adapter parser events via `this.parser.emitEvent(event)`. Any holder of a `TerminalControlSequenceParser` reference could then inject synthetic parser events without going through a parse path.
+- **Fix:** Changed `emitEvent` to `protected emit`, introduced a file-local `EngineTerminalControlSequenceParser` subclass exposing a typed `emitParserEvent` method, and routed Ghostty adapter events through the engine's protected `emitParserEvent`.
+- **Commit:** same commit as this entry (see `git blame` / `git log`)

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -135,7 +135,40 @@ describe('ghosttyInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('parsed:from-engine')
   })
 
-  test('disposes the parser engine once through the renderer handle', () => {
+  test('disposes the parser engine once through terminal disposal', () => {
+    const parser: TerminalParser = {
+      onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),
+    }
+
+    const dispose = vi.fn()
+
+    const parserEngine: TerminalParserEngine = {
+      inputMode: 'bytes',
+      capabilities: ghosttyTerminalRenderer.capabilities,
+      parser,
+      parseText: (text): TerminalParserEngineOutput => ({
+        visibleText: text,
+      }),
+      parseInput: (input): TerminalParserEngineOutput => ({
+        visibleText: input.text,
+      }),
+      parseOutput: (chunk): TerminalParserEngineOutput => ({
+        visibleText: chunk.text,
+      }),
+      dispose,
+    }
+
+    const created = createGhosttyTerminal({
+      createParserEngine: () => parserEngine,
+    })
+
+    created.terminal.dispose()
+    created.terminal.dispose()
+
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  test('does not dispose the parser engine when the renderer handle is disposed', () => {
     const parser: TerminalParser = {
       onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),
     }
@@ -165,9 +198,8 @@ describe('ghosttyInstance', () => {
     const rendererHandle = created.attachRenderer()
 
     rendererHandle.dispose()
-    rendererHandle.dispose()
 
-    expect(dispose).toHaveBeenCalledOnce()
+    expect(dispose).not.toHaveBeenCalled()
   })
 
   test('routes direct terminal writes through the Ghostty parser', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -6,6 +6,7 @@ import type {
   TerminalParser,
 } from '../../types'
 import type {
+  TerminalParserEngine,
   TerminalParserEngineInput,
   TerminalParserEngineOutput,
 } from './terminalParserEngine'
@@ -132,6 +133,41 @@ describe('ghosttyInstance', () => {
     expect(createParserEngine).toHaveBeenCalledOnce()
     expect(parseOutput).toHaveBeenCalledWith(chunk)
     expect(created.viewportReader.readVisibleText()).toBe('parsed:from-engine')
+  })
+
+  test('disposes the parser engine once through the renderer handle', () => {
+    const parser: TerminalParser = {
+      onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),
+    }
+
+    const dispose = vi.fn()
+
+    const parserEngine: TerminalParserEngine = {
+      inputMode: 'bytes',
+      capabilities: ghosttyTerminalRenderer.capabilities,
+      parser,
+      parseText: (text): TerminalParserEngineOutput => ({
+        visibleText: text,
+      }),
+      parseInput: (input): TerminalParserEngineOutput => ({
+        visibleText: input.text,
+      }),
+      parseOutput: (chunk): TerminalParserEngineOutput => ({
+        visibleText: chunk.text,
+      }),
+      dispose,
+    }
+
+    const created = createTrackedGhosttyTerminal({
+      createParserEngine: () => parserEngine,
+    })
+
+    const rendererHandle = created.attachRenderer()
+
+    rendererHandle.dispose()
+    rendererHandle.dispose()
+
+    expect(dispose).toHaveBeenCalledOnce()
   })
 
   test('routes direct terminal writes through the Ghostty parser', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -25,6 +25,7 @@ export interface GhosttyTerminalOptions {
 
 class GhosttyTerminalModel {
   private readonly parserEngine: TerminalParserEngine
+  private isRendererDisposed = false
   readonly terminal: TerminalTextSurface
   readonly parser: TerminalParser
 
@@ -66,7 +67,12 @@ class GhosttyTerminalModel {
 
   readonly rendererHandle: TerminalRendererHandle = {
     dispose: (): void => {
-      // The current Ghostty spike has no renderer addon lifecycle.
+      if (this.isRendererDisposed) {
+        return
+      }
+
+      this.isRendererDisposed = true
+      this.parserEngine.dispose?.()
     },
   }
 

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -25,6 +25,7 @@ export interface GhosttyTerminalOptions {
 
 class GhosttyTerminalModel {
   private readonly parserEngine: TerminalParserEngine
+  private isDisposed = false
   private isRendererDisposed = false
   readonly terminal: TerminalTextSurface
   readonly parser: TerminalParser
@@ -39,6 +40,17 @@ class GhosttyTerminalModel {
       transformOutput: (data): TerminalTextSurfaceOutput =>
         this.parserEngine.parseText(data, null),
     })
+
+    const originalTerminalDispose = this.terminal.dispose.bind(this.terminal)
+    this.terminal.dispose = (): void => {
+      if (this.isDisposed) {
+        return
+      }
+
+      this.isDisposed = true
+      originalTerminalDispose()
+      this.parserEngine.dispose?.()
+    }
   }
 
   readonly output: TerminalOutputWriter = {
@@ -72,7 +84,6 @@ class GhosttyTerminalModel {
       }
 
       this.isRendererDisposed = true
-      this.parserEngine.dispose?.()
     },
   }
 

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
@@ -114,8 +114,62 @@ describe('ghosttyParserEngine', () => {
         byteLen: 2,
         phase: 'live',
       },
+      emitEvent: expect.any(Function),
     })
     expect(reset).not.toHaveBeenCalled()
+  })
+
+  test('routes adapter parser events through the existing parser surface', () => {
+    const parseBytes = vi.fn((input: GhosttyByteParserAdapterInput) => {
+      input.emitEvent({
+        type: 'cwd',
+        source: 'osc7',
+        uri: 'file://localhost/tmp/ghostty-vt',
+        output: input.output,
+      })
+
+      return { visibleText: 'from-adapter' }
+    })
+
+    const engine = createGhosttyParserEngine({
+      byteParserAdapter: { parseBytes },
+    })
+
+    const handler = vi.fn()
+    engine.parser.onEvent(handler)
+
+    expect(
+      engine.parseOutput(createRawByteChunk(new Uint8Array([0x47]), 11, 'live'))
+    ).toEqual({
+      visibleText: 'from-adapter',
+    })
+
+    expect(handler).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/ghostty-vt',
+      output: {
+        offsetStart: 11,
+        byteLen: 1,
+        phase: 'live',
+      },
+    })
+  })
+
+  test('disposes the Ghostty byte parser adapter once', () => {
+    const dispose = vi.fn()
+
+    const engine = createGhosttyParserEngine({
+      byteParserAdapter: {
+        parseBytes: vi.fn(() => ({ visibleText: '' })),
+        dispose,
+      },
+    })
+
+    engine.dispose?.()
+    engine.dispose?.()
+
+    expect(dispose).toHaveBeenCalledOnce()
   })
 
   test('falls back to text when byte payloads are unreadable', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -87,7 +87,7 @@ export class GhosttyControlSequenceParserEngine
         decodedText: input.text,
         output: input.output,
         emitEvent: (event) => {
-          this.parser.emitEvent(event)
+          this.emitParserEvent(event)
         },
       })
     }

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -1,5 +1,8 @@
 // cspell:ignore ghostty
-import type { TerminalParserOutputContext } from '../../types'
+import type {
+  TerminalParserEvent,
+  TerminalParserOutputContext,
+} from '../../types'
 import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 import {
   TerminalControlSequenceParserEngine,
@@ -14,6 +17,7 @@ export interface GhosttyByteParserAdapterInput {
   readonly bytes: Uint8Array
   readonly decodedText: string
   readonly output: TerminalParserOutputContext | null
+  readonly emitEvent: (event: TerminalParserEvent) => void
 }
 
 export interface GhosttyByteParserAdapter {
@@ -21,6 +25,7 @@ export interface GhosttyByteParserAdapter {
     input: GhosttyByteParserAdapterInput
   ) => TerminalParserEngineOutput
   reset?: () => void
+  dispose?: () => void
 }
 
 export interface GhosttyParserEngineOptions {
@@ -59,6 +64,7 @@ export class GhosttyControlSequenceParserEngine
 {
   readonly id: typeof GHOSTTY_PARSER_ENGINE_ID = GHOSTTY_PARSER_ENGINE_ID
   private readonly byteParserAdapter: GhosttyByteParserAdapter
+  private isDisposed = false
 
   constructor(options: GhosttyParserEngineOptions = {}) {
     super({
@@ -80,12 +86,24 @@ export class GhosttyControlSequenceParserEngine
         bytes: input.bytes,
         decodedText: input.text,
         output: input.output,
+        emitEvent: (event) => {
+          this.parser.emitEvent(event)
+        },
       })
     }
 
     this.byteParserAdapter.reset?.()
 
     return super.parseInput(input)
+  }
+
+  dispose(): void {
+    if (this.isDisposed) {
+      return
+    }
+
+    this.isDisposed = true
+    this.byteParserAdapter.dispose?.()
   }
 }
 

--- a/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts
@@ -1,0 +1,118 @@
+// cspell:ignore ghostty libghostty
+import { describe, expect, test, vi } from 'vitest'
+import type { GhosttyByteParserAdapterInput } from './ghosttyParserEngine'
+import type { TerminalParserEngineOutput } from './terminalParserEngine'
+import {
+  createGhosttyVtByteParserAdapter,
+  type GhosttyVtParserEffects,
+  type GhosttyVtParserDriver,
+} from './ghosttyVtByteParserAdapter'
+
+const createInput = (
+  bytes: Uint8Array,
+  emitEvent = vi.fn()
+): GhosttyByteParserAdapterInput => ({
+  bytes,
+  decodedText: 'decoded fallback',
+  output: {
+    offsetStart: 9,
+    byteLen: bytes.length,
+    phase: 'live',
+  },
+  emitEvent,
+})
+
+describe('ghosttyVtByteParserAdapter', () => {
+  test('passes raw bytes into the VT parser driver', () => {
+    const writeBytes = vi.fn(
+      (): TerminalParserEngineOutput => ({ visibleText: 'driver output' })
+    )
+
+    const adapter = createGhosttyVtByteParserAdapter(() => ({ writeBytes }))
+    const bytes = new Uint8Array([0xff, 0xfe])
+
+    expect(adapter.parseBytes(createInput(bytes))).toEqual({
+      visibleText: 'driver output',
+    })
+    expect(writeBytes).toHaveBeenCalledWith(bytes)
+  })
+
+  test('routes VT cwd effects into parser events with output context', () => {
+    const adapter = createGhosttyVtByteParserAdapter(
+      (createdEffects): GhosttyVtParserDriver => ({
+        writeBytes: (): TerminalParserEngineOutput => {
+          createdEffects.onCwdChange('file://localhost/tmp/from-libghostty')
+
+          return { visibleText: 'rendered' }
+        },
+      })
+    )
+
+    const emitEvent = vi.fn()
+
+    expect(
+      adapter.parseBytes(createInput(new Uint8Array([0x67]), emitEvent))
+    ).toEqual({
+      visibleText: 'rendered',
+    })
+
+    expect(emitEvent).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/from-libghostty',
+      output: {
+        offsetStart: 9,
+        byteLen: 1,
+        phase: 'live',
+      },
+    })
+  })
+
+  test('ignores VT cwd effects fired outside an active byte write', () => {
+    const capturedEffects: {
+      onCwdChange?: GhosttyVtParserEffects['onCwdChange']
+    } = {}
+
+    const adapter = createGhosttyVtByteParserAdapter(
+      (createdEffects): GhosttyVtParserDriver => {
+        capturedEffects.onCwdChange = createdEffects.onCwdChange
+
+        return {
+          writeBytes: (): TerminalParserEngineOutput => ({ visibleText: '' }),
+        }
+      }
+    )
+
+    const emitEvent = vi.fn()
+
+    adapter.parseBytes(createInput(new Uint8Array([0x67]), emitEvent))
+
+    const onCwdChange = capturedEffects.onCwdChange
+
+    if (!onCwdChange) {
+      throw new Error('Expected VT parser effect callback to be captured')
+    }
+
+    onCwdChange('file://localhost/tmp/outside-write')
+
+    expect(emitEvent).not.toHaveBeenCalled()
+  })
+
+  test('resets and disposes the VT parser driver once', () => {
+    const reset = vi.fn()
+    const dispose = vi.fn()
+
+    const adapter = createGhosttyVtByteParserAdapter(() => ({
+      writeBytes: (): TerminalParserEngineOutput => ({ visibleText: '' }),
+      reset,
+      dispose,
+    }))
+
+    adapter.reset?.()
+    adapter.dispose?.()
+    adapter.dispose?.()
+
+    expect(reset).toHaveBeenCalledOnce()
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts
@@ -115,4 +115,21 @@ describe('ghosttyVtByteParserAdapter', () => {
     expect(reset).toHaveBeenCalledOnce()
     expect(dispose).toHaveBeenCalledOnce()
   })
+
+  test('ignores reset after disposal', () => {
+    const reset = vi.fn()
+    const dispose = vi.fn()
+
+    const adapter = createGhosttyVtByteParserAdapter(() => ({
+      writeBytes: (): TerminalParserEngineOutput => ({ visibleText: '' }),
+      reset,
+      dispose,
+    }))
+
+    adapter.dispose?.()
+    adapter.reset?.()
+
+    expect(dispose).toHaveBeenCalledOnce()
+    expect(reset).not.toHaveBeenCalled()
+  })
 })

--- a/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts
@@ -1,0 +1,82 @@
+// cspell:ignore ghostty libghostty
+import type {
+  GhosttyByteParserAdapter,
+  GhosttyByteParserAdapterInput,
+} from './ghosttyParserEngine'
+import type { TerminalParserEngineOutput } from './terminalParserEngine'
+
+export interface GhosttyVtParserEffects {
+  readonly onCwdChange: (uri: string) => void
+}
+
+export interface GhosttyVtParserDriver {
+  /**
+   * Consume raw PTY bytes and return renderer-delta output for the text surface.
+   *
+   * A full libghostty-vt terminal bridge should diff terminal/render state before
+   * returning so callers do not append a whole-screen snapshot per chunk.
+   */
+  writeBytes: (bytes: Uint8Array) => TerminalParserEngineOutput
+  reset?: () => void
+  dispose?: () => void
+}
+
+export type GhosttyVtParserDriverFactory = (
+  effects: GhosttyVtParserEffects
+) => GhosttyVtParserDriver
+
+export class GhosttyVtByteParserAdapter implements GhosttyByteParserAdapter {
+  private readonly driver: GhosttyVtParserDriver
+  private activeInput: GhosttyByteParserAdapterInput | null = null
+  private isDisposed = false
+
+  constructor(createDriver: GhosttyVtParserDriverFactory) {
+    this.driver = createDriver({
+      onCwdChange: (uri) => {
+        this.emitCwdChange(uri)
+      },
+    })
+  }
+
+  parseBytes(input: GhosttyByteParserAdapterInput): TerminalParserEngineOutput {
+    this.activeInput = input
+
+    try {
+      return this.driver.writeBytes(input.bytes)
+    } finally {
+      this.activeInput = null
+    }
+  }
+
+  reset(): void {
+    this.driver.reset?.()
+  }
+
+  dispose(): void {
+    if (this.isDisposed) {
+      return
+    }
+
+    this.isDisposed = true
+    this.driver.dispose?.()
+  }
+
+  private emitCwdChange(uri: string): void {
+    const input = this.activeInput
+
+    if (!input) {
+      return
+    }
+
+    input.emitEvent({
+      type: 'cwd',
+      source: 'osc7',
+      uri,
+      output: input.output,
+    })
+  }
+}
+
+export const createGhosttyVtByteParserAdapter = (
+  createDriver: GhosttyVtParserDriverFactory
+): GhosttyByteParserAdapter => new GhosttyVtByteParserAdapter(createDriver)

--- a/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts
@@ -49,6 +49,10 @@ export class GhosttyVtByteParserAdapter implements GhosttyByteParserAdapter {
   }
 
   reset(): void {
+    if (this.isDisposed) {
+      return
+    }
+
     this.driver.reset?.()
   }
 

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -776,7 +776,7 @@ export class TerminalControlSequenceParser implements TerminalParser {
       return
     }
 
-    this.emit({
+    this.emitEvent({
       type: 'cwd',
       source: 'osc7',
       uri: payload,
@@ -784,7 +784,7 @@ export class TerminalControlSequenceParser implements TerminalParser {
     })
   }
 
-  private emit(event: TerminalParserEvent): void {
+  emitEvent(event: TerminalParserEvent): void {
     this.handlers.forEach((handler) => {
       handler(event)
     })

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -776,7 +776,7 @@ export class TerminalControlSequenceParser implements TerminalParser {
       return
     }
 
-    this.emitEvent({
+    this.emit({
       type: 'cwd',
       source: 'osc7',
       uri: payload,
@@ -784,7 +784,7 @@ export class TerminalControlSequenceParser implements TerminalParser {
     })
   }
 
-  emitEvent(event: TerminalParserEvent): void {
+  protected emit(event: TerminalParserEvent): void {
     this.handlers.forEach((handler) => {
       handler(event)
     })

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -2,6 +2,7 @@ import type {
   TerminalOutputInputMode,
   TerminalOutputChunk,
   TerminalParser,
+  TerminalParserEvent,
   TerminalParserOutputContext,
   TerminalRendererCapabilities,
 } from '../../types'

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -38,6 +38,7 @@ export interface TerminalParserEngine {
   ) => TerminalParserEngineOutput
   parseInput: (input: TerminalParserEngineInput) => TerminalParserEngineOutput
   parseOutput: (chunk: TerminalOutputChunk) => TerminalParserEngineOutput
+  dispose?: () => void
 }
 
 const outputContextFromChunk = (

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -49,18 +49,26 @@ const outputContextFromChunk = (
   phase: chunk.phase,
 })
 
+class EngineTerminalControlSequenceParser extends TerminalControlSequenceParser {
+  emitParserEvent(event: TerminalParserEvent): void {
+    this.emit(event)
+  }
+}
+
 export class TerminalControlSequenceParserEngine implements TerminalParserEngine {
   readonly capabilities: TerminalRendererCapabilities
   readonly parser: TerminalControlSequenceParser
+  private readonly emittableParser: EngineTerminalControlSequenceParser
   private readonly outputRouter: TerminalOutputPayloadRouter
 
   constructor(options: TerminalParserEngineOptions) {
     this.capabilities = options.capabilities
-    this.parser = new TerminalControlSequenceParser({
+    this.emittableParser = new EngineTerminalControlSequenceParser({
       consumeControlsWithoutSubscribers:
         options.consumeControlsWithoutSubscribers,
       preserveSgrStyles: options.preserveSgrStyles,
     })
+    this.parser = this.emittableParser
     this.outputRouter = new TerminalOutputPayloadRouter(options.capabilities)
   }
 
@@ -86,6 +94,10 @@ export class TerminalControlSequenceParserEngine implements TerminalParserEngine
       ...selection,
       output: outputContextFromChunk(chunk),
     })
+  }
+
+  protected emitParserEvent(event: TerminalParserEvent): void {
+    this.emittableParser.emitParserEvent(event)
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a Ghostty VT byte parser bridge that writes raw bytes into an injected driver and forwards cwd effects through the existing parser event surface.
- Allow Ghostty byte parser adapters to publish parser events, and dispose parser engines from the Ghostty renderer handle once.
- Keep xterm/default behavior unchanged while avoiding the current Bun-only unofficial `libghostty-vt` package as a hard Electron renderer dependency.

## Verification
- `npx vitest run src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts src/features/terminal/components/TerminalPane/terminalControlParser.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run test:e2e:ghostty`
- Pre-push `npm run test`


Refs VIM-162