### PR TITLE
feat(components): add Dialog primitive

### DIFF
--- a/docs/design/UNIFIED.md
+++ b/docs/design/UNIFIED.md
@@ -380,6 +380,44 @@ Rules:
 - Pass `middleware={{ ancestorScroll: false }}` for confirm dialogs that should dismiss only on outside-press or Escape, not on scroll.
 - Consumer owns the body layout; the primitive supplies the glass chrome and focus management only.
 
+### 5.9.1 `Dialog`
+
+The app-level viewport modal shell. Lives at `src/components/Dialog.tsx`; import via the alias: `import { Dialog } from '@/components/Dialog'`.
+
+```ts
+interface DialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  placement?: 'center' | 'top'
+  size?: 'sm' | 'md' | 'lg' | 'xl'
+  closeOnBackdrop?: boolean
+  closeOnEscape?: boolean
+  dismissDisabled?: boolean
+  restoreFocus?: boolean
+  initialFocusRef?: React.RefObject<HTMLElement | null>
+  'aria-label'?: string
+  'aria-labelledby'?: string
+  'aria-describedby'?: string
+  testId?: string
+  backdropTestId?: string
+  children: ReactNode
+}
+
+// Optional structure helpers:
+// <Dialog.Header>...</Dialog.Header>
+// <Dialog.Body>...</Dialog.Body>
+// <Dialog.Footer>...</Dialog.Footer>
+```
+
+Rules:
+
+- Use `Dialog` for full-screen app modal shells that block workspace interaction, such as unsaved-change confirmation and command-palette style overlays.
+- Do **not** use `Dialog` for anchored or cursor-positioned surfaces. Use `Popover`, `Menu`, or `Dropdown` for those; they stay on `base/floating`.
+- `Dialog` owns the fixed viewport overlay, `z-[100]` stacking, backdrop, Lens glass panel, focus trap, focus restore, Escape/backdrop dismissal, and `aria-modal`.
+- Consumer code owns domain content and callbacks. The primitive must not know about save/discard, command palette selection, terminal focus, or settings state.
+- `dismissDisabled` locks Escape and backdrop dismissal for in-flight actions. Direct child buttons may still call their feature callbacks.
+- `Dialog.Header` / `Body` / `Footer` provide the standard confirmation-dialog spacing and dividers. More complex bodies may render custom layout inside the panel.
+
 ### 5.10 `Button`
 
 The text/primary foundation. Lives at `src/components/Button.tsx`; import via the alias: `import { Button } from '@/components/Button'`.

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 24       | 6    | 2026-06-17   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 52       | 23   | 2026-06-19   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 53       | 24   | 2026-06-19   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 24       | 6    | 2026-06-17   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 53       | 24   | 2026-06-19   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 54       | 25   | 2026-06-19   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 68       | 28   | 2026-06-19   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 69       | 29   | 2026-06-19   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 24       | 6    | 2026-06-17   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 51       | 22   | 2026-06-19   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 52       | 23   | 2026-06-19   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 67       | 27   | 2026-06-18   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 68       | 28   | 2026-06-19   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 69       | 29   | 2026-06-19   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 62       | 30   | 2026-06-19   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-19
-ref_count: 29
+ref_count: 30
 ---
 
 # Accessibility
@@ -639,4 +639,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/components/Dialog.tsx` L69-79
 - **Finding:** `getFocusableElements` filtered disabled, `aria-hidden`, and explicit `tabindex` state, but not `display: none`, `visibility: hidden`, or hidden ancestors. `focusInitialElement` also focused `initialFocusRef.current` without checking visibility. Conditionally hidden controls inside dialogs could receive invisible/no-op initial focus or be included in the Tab cycle, leaving keyboard users with no visible focus target or an apparent skipped focus step.
 - **Fix:** Added `isVisibleFocusableElement`, which walks from the element up through its ancestors and checks `window.getComputedStyle` for `display: none` and `visibility: hidden`. Applied the guard to both `getFocusableElements` and the `initialFocusRef` branch in `focusInitialElement`. Added co-located tests asserting that `display:none`, `visibility:hidden`, and hidden-ancestor elements are skipped when choosing initial focus.
+- **Commit:** same commit as this entry
+
+### 62. Dialog visibility check excludes visible descendants of visibility:hidden ancestors
+
+- **Source:** github-codex-connector | PR #548 round 4 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/components/Dialog.tsx` L69-91
+- **Finding:** `isVisibleFocusableElement` walked ancestors and rejected any ancestor with `visibility: hidden`. CSS `visibility` is inherited but can be overridden by a descendant with `visibility: visible`, so an element's own computed visibility is the authoritative check for that property. In that valid CSS layout, a visibly focusable control would be skipped by initial focus and the Tab trap.
+- **Fix:** Checked `visibility` only on the focusable element itself and limited the ancestor walk to `display: none`. Added a co-located regression test asserting that a visible button inside a `visibility:hidden` ancestor receives initial focus.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-19
-ref_count: 28
+ref_count: 29
 ---
 
 # Accessibility
@@ -630,4 +630,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/components/Dialog.tsx` L59-66
 - **Finding:** `FOCUSABLE_SELECTOR` omitted `[contenteditable]:not([contenteditable="false"])`, so CodeMirror or rich-text surfaces inside a Dialog were skipped by the manual Tab trap and focus could escape the modal.
 - **Fix:** Added the contenteditable selector to `FOCUSABLE_SELECTOR` and updated `getFocusableElements` filter to treat contenteditable surfaces as focusable even when `tabIndex` is implicitly `-1`. Added a co-located test that tabs through a contenteditable element inside a Dialog and asserts focus stays trapped.
+- **Commit:** same commit as this entry
+
+### 61. Dialog focus collection includes CSS-hidden elements
+
+- **Source:** github-codex-connector | PR #548 round 3 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/components/Dialog.tsx` L69-79
+- **Finding:** `getFocusableElements` filtered disabled, `aria-hidden`, and explicit `tabindex` state, but not `display: none`, `visibility: hidden`, or hidden ancestors. `focusInitialElement` also focused `initialFocusRef.current` without checking visibility. Conditionally hidden controls inside dialogs could receive invisible/no-op initial focus or be included in the Tab cycle, leaving keyboard users with no visible focus target or an apparent skipped focus step.
+- **Fix:** Added `isVisibleFocusableElement`, which walks from the element up through its ancestors and checks `window.getComputedStyle` for `display: none` and `visibility: hidden`. Applied the guard to both `getFocusableElements` and the `initialFocusRef` branch in `focusInitialElement`. Added co-located tests asserting that `display:none`, `visibility:hidden`, and hidden-ancestor elements are skipped when choosing initial focus.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,8 +2,8 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-18
-ref_count: 27
+last_updated: 2026-06-19
+ref_count: 28
 ---
 
 # Accessibility
@@ -621,4 +621,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx`
 - **Finding:** The new `LayoutDisplayMenu` trigger was an icon-only button with an `aria-label` but no visible hover label. The prior stub in `WorkspaceView` had a `Tooltip` wrapper and the design system requires unified `Tooltip` usage for icon-only controls, so the new functional control was harder for sighted users to discover.
 - **Fix:** Added `tooltip` and `tooltipPlacement` props to the `Menu` primitive so it can wrap its cloned trigger with the shared `Tooltip`. `LayoutDisplayMenu` now passes `tooltip="Configure displayed layouts"` to `Menu`; `Tooltip` composes its hover/focus handlers with `Menu`'s trigger reference props so keyboard and click behavior are preserved.
+- **Commit:** same commit as this entry
+
+### 60. Dialog focus trap misses contenteditable elements
+
+- **Source:** github-claude | PR #548 round 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/components/Dialog.tsx` L59-66
+- **Finding:** `FOCUSABLE_SELECTOR` omitted `[contenteditable]:not([contenteditable="false"])`, so CodeMirror or rich-text surfaces inside a Dialog were skipped by the manual Tab trap and focus could escape the modal.
+- **Fix:** Added the contenteditable selector to `FOCUSABLE_SELECTOR` and updated `getFocusableElements` filter to treat contenteditable surfaces as focusable even when `tabIndex` is implicitly `-1`. Added a co-located test that tabs through a contenteditable element inside a Dialog and asserts focus stays trapped.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -3,7 +3,7 @@ id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-19
-ref_count: 24
+ref_count: 25
 ---
 
 # React Lifecycle
@@ -515,4 +515,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/components/Dialog.tsx` L220-250
 - **Finding:** Each open `Dialog` registered its own `document.addEventListener('keydown', ...)` listener. When two or more dialogs were open, every instance processed the same `Escape` press, so pressing Escape could close the wrong layer or multiple layers at once. The same per-instance listener pattern also meant Tab focus-trapping ran in every open dialog, not just the topmost.
 - **Fix:** Introduced a module-level LIFO `dialogStack` of open dialog layers. A single document listener reads the top layer on each `keydown`; Escape calls only the top layer's close handler and `stopImmediatePropagation()`, and Tab only traps focus inside the top layer's container. Each Dialog pushes its layer on open and removes it on close/unmount. Added regression tests covering (a) Escape closes only the topmost dialog, (b) Escape does not propagate to a lower dialog when the topmost is `dismissDisabled`, and (c) Escape does not propagate when the topmost has `closeOnEscape={false}`.
+- **Commit:** same commit as this entry
+
+### 54. Dialog layer registration reorders the stack on parent re-renders
+
+- **Source:** github-codex-connector | PR #548 round 3 | 2026-06-19
+- **Severity:** HIGH
+- **File:** `src/components/Dialog.tsx` L266-291
+- **Finding:** The layer-registration `useEffect` listed `requestClose` (which depends on `onOpenChange`) and `closeOnEscape` in its dependency array. Because parents often pass an inline `onOpenChange` callback, every parent re-render unregistered and re-registered an already-open lower dialog, pushing it to the top of the module-level `dialogStack`. In stacked modal use, Escape and Tab then targeted the background dialog instead of the visible top dialog.
+- **Fix:** Captured `requestClose` and `closeOnEscape` in refs that are updated synchronously each render, and keyed the registration effect only to `open`. The layer's close handler now reads the latest ref values, so prop changes are honored without re-registering the layer and corrupting stack order. Added a regression test that re-renders a parent with two open dialogs and asserts Escape still closes only the topmost.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -3,7 +3,7 @@ id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-19
-ref_count: 23
+ref_count: 24
 ---
 
 # React Lifecycle
@@ -506,4 +506,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/components/Dialog.tsx` L183-204
 - **Finding:** Focus restoration only ran when the controlled `open` prop transitioned from `true` to `false`. If a parent conditionally rendered `<Dialog open>` and removed the component while it was open, no cleanup restored the previously focused element, leaving keyboard focus on `document.body`.
 - **Fix:** Added a dedicated `useEffect` with an empty dependency array whose cleanup restores `previousFocusRef.current` when `wasOpenRef.current` is true and `restoreFocus` is enabled. Captured `restoreFocus` in a ref so the cleanup closure sees the latest value. Added a co-located test that unmounts an open Dialog and asserts focus returns to the prior element.
+- **Commit:** same commit as this entry
+
+### 53. Per-instance document keydown listeners allow stacked dialogs to all process Escape
+
+- **Source:** github-codex-connector | PR #548 round 2 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/components/Dialog.tsx` L220-250
+- **Finding:** Each open `Dialog` registered its own `document.addEventListener('keydown', ...)` listener. When two or more dialogs were open, every instance processed the same `Escape` press, so pressing Escape could close the wrong layer or multiple layers at once. The same per-instance listener pattern also meant Tab focus-trapping ran in every open dialog, not just the topmost.
+- **Fix:** Introduced a module-level LIFO `dialogStack` of open dialog layers. A single document listener reads the top layer on each `keydown`; Escape calls only the top layer's close handler and `stopImmediatePropagation()`, and Tab only traps focus inside the top layer's container. Each Dialog pushes its layer on open and removes it on close/unmount. Added regression tests covering (a) Escape closes only the topmost dialog, (b) Escape does not propagate to a lower dialog when the topmost is `dismissDisabled`, and (c) Escape does not propagate when the topmost has `closeOnEscape={false}`.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -3,7 +3,7 @@ id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-19
-ref_count: 22
+ref_count: 23
 ---
 
 # React Lifecycle
@@ -497,4 +497,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/sessions/hooks/usePushWorkspaceGrouping.ts` L124-134
 - **Finding:** The destructuring default `customPaneLayouts = []` created a new array every time callers omitted the option. Because `customPaneLayouts` was listed in the `useMemo` dependency array, the workspace shape and its structural JSON signature were recomputed on every render even when the semantic input had not changed.
 - **Fix:** Introduced a module-scope `EMPTY_CUSTOM_PANE_LAYOUTS: readonly PaneLayoutDefinition[] = []` constant and used it as the destructuring default. The array reference is now stable across renders, so omitted layouts no longer trigger `buildWorkspaceShape` and `structuralSignature` recomputation.
+- **Commit:** same commit as this entry
+
+### 52. Open Dialog unmount leaves focus on document.body
+
+- **Source:** github-claude | PR #548 round 1 | 2026-06-19
+- **Severity:** LOW
+- **File:** `src/components/Dialog.tsx` L183-204
+- **Finding:** Focus restoration only ran when the controlled `open` prop transitioned from `true` to `false`. If a parent conditionally rendered `<Dialog open>` and removed the component while it was open, no cleanup restored the previously focused element, leaving keyboard focus on `document.body`.
+- **Fix:** Added a dedicated `useEffect` with an empty dependency array whose cleanup restores `previousFocusRef.current` when `wasOpenRef.current` is true and `restoreFocus` is enabled. Captured `restoreFocus` in a ref so the cleanup closure sees the latest value. Added a co-located test that unmounts an open Dialog and asserts focus returns to the prior element.
 - **Commit:** same commit as this entry

--- a/docs/technical-notes/vim-116-dialog-modal-refactor.zh-CN.html
+++ b/docs/technical-notes/vim-116-dialog-modal-refactor.zh-CN.html
@@ -1,0 +1,787 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vimeflow 技术说明：Dialog / ModalDialog 全局化重构</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0f111a;
+        --surface: rgba(22, 25, 36, 0.94);
+        --surface-2: rgba(31, 36, 52, 0.94);
+        --surface-3: rgba(42, 48, 68, 0.9);
+        --text: #e8ecff;
+        --muted: #aab3d8;
+        --accent: #8bd5ca;
+        --accent-2: #f5c2e7;
+        --warn: #f9e2af;
+        --danger: #f38ba8;
+        --line: rgba(232, 236, 255, 0.1);
+        --shadow: 0 22px 70px rgba(0, 0, 0, 0.35);
+        --mono:
+          'SFMono-Regular', 'SF Mono', 'JetBrains Mono', 'Menlo', monospace;
+        --sans:
+          'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', 'PingFang SC',
+          'Noto Serif SC', serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        color: var(--text);
+        font-family: var(--sans);
+        background: linear-gradient(180deg, #090b11 0%, var(--bg) 100%);
+      }
+
+      a {
+        color: var(--accent);
+      }
+
+      code,
+      pre,
+      .mono {
+        font-family: var(--mono);
+      }
+
+      .page {
+        width: min(1180px, calc(100vw - 40px));
+        margin: 0 auto;
+        padding: 40px 0 72px;
+      }
+
+      .hero,
+      .section {
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        background: var(--surface);
+        box-shadow: var(--shadow);
+      }
+
+      .hero {
+        padding: 34px;
+      }
+
+      .eyebrow {
+        display: inline-block;
+        margin-bottom: 12px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: rgba(139, 213, 202, 0.13);
+        color: var(--accent);
+        font: 600 12px/1.1 var(--mono);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      h1,
+      h2,
+      h3 {
+        margin: 0;
+        line-height: 1.15;
+      }
+
+      h1 {
+        max-width: 900px;
+        font-size: 46px;
+      }
+
+      h2 {
+        margin-bottom: 16px;
+        font-size: 28px;
+      }
+
+      h3 {
+        margin-bottom: 10px;
+        font-size: 20px;
+      }
+
+      p,
+      li,
+      td,
+      th {
+        font-size: 16px;
+        line-height: 1.78;
+      }
+
+      p,
+      li,
+      td {
+        color: var(--muted);
+      }
+
+      .lede {
+        max-width: 920px;
+        margin: 18px 0 0;
+        color: var(--text);
+        font-size: 18px;
+      }
+
+      .meta,
+      .cards,
+      .two-up,
+      .timeline {
+        display: grid;
+        gap: 18px;
+      }
+
+      .meta {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        margin-top: 24px;
+      }
+
+      .cards {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+
+      .two-up {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        align-items: start;
+      }
+
+      .section {
+        margin-top: 24px;
+        padding: 30px;
+      }
+
+      .stat,
+      .card,
+      .note,
+      .code {
+        border: 1px solid var(--line);
+        border-radius: 18px;
+        background: var(--surface-2);
+      }
+
+      .stat,
+      .card {
+        padding: 18px 20px;
+      }
+
+      .stat .label,
+      .label {
+        display: block;
+        margin-bottom: 8px;
+        color: var(--accent-2);
+        font: 600 12px/1.2 var(--mono);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .stat strong {
+        display: block;
+        color: var(--text);
+        font-size: 21px;
+      }
+
+      .note {
+        margin-top: 16px;
+        padding: 14px 16px;
+        border-left: 3px solid var(--warn);
+      }
+
+      .note strong {
+        color: var(--text);
+      }
+
+      .code {
+        margin-top: 14px;
+        padding: 16px 18px;
+        overflow-x: auto;
+        background: rgba(8, 10, 18, 0.92);
+        color: #f6f8ff;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th,
+      td {
+        border-bottom: 1px solid var(--line);
+        padding: 13px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        color: var(--text);
+        font: 700 12px/1.2 var(--mono);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      tr:last-child td {
+        border-bottom: 0;
+      }
+
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        margin: 2px 6px 2px 0;
+        padding: 4px 8px;
+        border-radius: 999px;
+        background: var(--surface-3);
+        color: var(--text);
+        font: 600 12px/1.2 var(--mono);
+      }
+
+      .yes {
+        color: var(--accent);
+      }
+
+      .warn {
+        color: var(--warn);
+      }
+
+      .danger {
+        color: var(--danger);
+      }
+
+      @media (max-width: 860px) {
+        .page {
+          width: min(100vw - 28px, 720px);
+          padding-top: 24px;
+        }
+
+        h1 {
+          font-size: 34px;
+        }
+
+        .meta,
+        .cards,
+        .two-up {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <header class="hero">
+        <span class="eyebrow">VIM-116 follow-up</span>
+        <h1>Dialog / ModalDialog 全局化重构技术说明</h1>
+        <p class="lede">
+          VIM-116 已经完成 Tooltip、Floating Surface、Button、Grouped Control、
+          Chip 和 ProgressBar 的抽取。剩下最值得继续做的组件族，是全屏 dialog /
+          modal dialog 壳层：现在多个 feature 在重复实现遮罩、
+          面板、焦点管理、Escape、backdrop dismiss 和 aria 语义。
+        </p>
+        <div class="meta">
+          <div class="stat">
+            <span class="label">Branch</span>
+            <strong>refactor/vim-116-dialog-primitive</strong>
+          </div>
+          <div class="stat">
+            <span class="label">Base</span>
+            <strong>main @ a91bd9ff</strong>
+          </div>
+          <div class="stat">
+            <span class="label">Scope</span>
+            <strong>技术说明 + 组件边界文档</strong>
+          </div>
+          <div class="stat">
+            <span class="label">Recommendation</span>
+            <strong>先抽 Dialog，再迁移 Unsaved / Palette</strong>
+          </div>
+        </div>
+      </header>
+
+      <section class="section">
+        <h2>1. 当前有哪些“dialog”</h2>
+        <p>
+          这里要先分清两个层级：<code>role="dialog"</code> 是语义，modal dialog
+          是行为。Vimeflow 里既有 anchored 的 dialog card，也有真正挡住
+          workspace 的 modal overlay。
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>类型</th>
+              <th>当前文件</th>
+              <th>行为</th>
+              <th>是否进入这次抽取</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <span class="tag">Anchored Popover</span>
+              </td>
+              <td>
+                <code>src/components/Popover.tsx</code><br />
+                <code>DiffChipToolbar</code> confirm<br />
+                <code>FinishFeedbackPopover</code><br />
+                <code>PriorityPlus</code>
+              </td>
+              <td>
+                由 anchor 元素定位，走 <code>base/floating</code> substrate，
+                使用 <code>role="dialog"</code> 和 modal focus manager。
+              </td>
+              <td class="warn">
+                不抽成 Dialog。它已经是全局 primitive，解决的是“锚点旁边的
+                dialog card”；后续非阻塞、anchored 的 dialog-like surface
+                应继续走 <code>Popover</code>。
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <span class="tag">Blocking Modal</span>
+              </td>
+              <td>
+                <code
+                  >src/features/editor/components/UnsavedChangesDialog.tsx</code
+                >
+              </td>
+              <td>
+                全屏固定 overlay，居中 panel，backdrop 点击取消，Escape 取消，
+                保存中禁止 dismiss，手写焦点捕获、焦点恢复和 Tab trap。
+              </td>
+              <td class="yes">
+                第一迁移目标。重复逻辑最多，也有 raw text button 漂移。
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <span class="tag">Command Modal</span>
+              </td>
+              <td>
+                <code>src/features/command-palette/CommandPalette.tsx</code>
+              </td>
+              <td>
+                全屏固定 overlay，top placement，backdrop 点击关闭，panel 壳层和
+                UnsavedChangesDialog 高度相似，内部是 input / results / footer。
+              </td>
+              <td class="yes">
+                第二迁移目标。保留 palette 的 input 和结果列表，只替换 shell。
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <span class="tag">Workspace Overlay</span>
+              </td>
+              <td>
+                <code
+                  >src/features/terminal/components/BurnerTerminalPopup/index.tsx</code
+                >
+              </td>
+              <td>
+                全屏 overlay，但不会 unmount，隐藏只是
+                <code>display: none</code>。 打开时把焦点交给
+                xterm，关闭时恢复之前焦点；Tooltip 还需要 提升到
+                <code>z-[110]</code>。
+              </td>
+              <td class="warn">
+                先作为设计约束，不建议第一轮迁移。它验证 primitive
+                是否足够通用。
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <span class="tag">Inline Dialog</span>
+              </td>
+              <td>
+                <code
+                  >src/features/diff/components/ReviewCommentComposer.tsx</code
+                >
+              </td>
+              <td>
+                在 diff 行内渲染，虽然有 <code>role="dialog"</code>，但不是
+                overlay， 不控制背景、stacking、focus trap。
+              </td>
+              <td class="danger">
+                不进入本 primitive。后续可单独考虑 inline composer 的 Button
+                化。
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="section">
+        <h2>2. Dialog 和 ModalDialog 应该如何分工</h2>
+        <div class="two-up">
+          <div class="card">
+            <h3>Dialog 是语义和结构</h3>
+            <p>
+              Web / ARIA 层面，dialog 只说明“这是一个独立交互区域”。它可以是
+              anchored popover，也可以是 inline composer，也可以是全屏 modal。
+              因此 <code>Popover</code> 继续保留：它是 anchored dialog card，
+              不是 app-level modal。
+            </p>
+            <p>
+              新 primitive 如果命名为 <code>Dialog</code>，语义上仍然合理，
+              但文档必须明确：它负责的是 app-level modal shell，不替代
+              <code>Popover</code>。
+            </p>
+          </div>
+          <div class="card">
+            <h3>ModalDialog 是行为集合</h3>
+            <p>
+              modal 的关键不是视觉上像弹窗，而是背景不可交互、焦点被限制在内部、
+              Escape / backdrop 有明确 dismiss 策略、关闭后能恢复原焦点。
+              这些行为现在散落在 feature 里，应该集中到全局组件。
+            </p>
+            <p>
+              代码命名建议先用 <code>Dialog</code>，因为项目里的 public
+              primitive 都是短名；如果未来确实需要 non-modal app dialog，再扩展
+              <code>modal={false}</code> 或拆出 <code>ModalDialog</code>。
+            </p>
+          </div>
+        </div>
+        <div class="note">
+          <strong>结论：</strong>
+          不要把 <code>Popover</code> 改造成全屏 modal。它依赖 anchor 定位和
+          <code>base/floating</code>，适合小型 card。新的 <code>Dialog</code>
+          应该拥有自己的 overlay substrate，专门处理 viewport-level modal。
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>3. 和 floating surface 的共享边界</h2>
+        <p>
+          你的疑问是关键：非阻塞 dialog 和 menu / popover 的确共享很多逻辑，
+          但共享点在“anchored floating surface”，不是在“所有 overlay 都做成一个
+          Dialog”。因此规划里要把 substrate 分清。
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>层</th>
+              <th>负责什么</th>
+              <th>使用者</th>
+              <th>规划决策</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>base/floating</code></td>
+              <td>
+                anchor / cursor 定位、flip / shift、outside press、portal、 list
+                navigation、anchored focus manager。
+              </td>
+              <td>
+                <code>Dropdown</code>、<code>Menu</code>、<code>Popover</code>
+              </td>
+              <td class="yes">
+                保持为非阻塞 anchored surface 的默认路径。缺功能时优先扩展
+                <code>Popover</code> 或 <code>Menu</code>。
+              </td>
+            </tr>
+            <tr>
+              <td><code>Dialog</code></td>
+              <td>
+                viewport-level fixed overlay、scrim、modal stacking、focus
+                trap/restore、Escape/backdrop dismiss、aria-modal。
+              </td>
+              <td>
+                <code>UnsavedChangesDialog</code>、<code>CommandPalette</code>，
+                后续 settings-style app dialog。
+              </td>
+              <td class="yes">
+                新增 public primitive，但不吞并 <code>Popover</code>。它只处理
+                全屏 app modal shell。
+              </td>
+            </tr>
+            <tr>
+              <td>共享视觉语言</td>
+              <td>
+                Lens glass panel、backdrop 色彩、z-index 策略、motion timing、
+                focus/dismiss 纪律。
+              </td>
+              <td>所有 overlay primitive</td>
+              <td class="warn">
+                可以抽 token / className helper，但不要让 <code>Dialog</code>
+                依赖不需要的 anchor-positioning machinery。
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="note">
+          <strong>规划约束：</strong>
+          如果一个 surface 需要 anchor 或 cursor 定位，它不应该使用
+          <code>Dialog</code>；如果一个 surface 需要挡住整个 workspace
+          并限制背景交互， 它不应该使用 <code>Popover</code>。
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>4. 共同逻辑应该放进全局组件</h2>
+        <div class="cards">
+          <div class="card">
+            <h3>Stacking 与遮罩</h3>
+            <ul>
+              <li>
+                统一 <code>fixed inset-0</code> root 和
+                <code>z-[100]</code> 层级。
+              </li>
+              <li>统一 backdrop 颜色、blur、点击 dismiss 策略。</li>
+              <li>
+                支持 center / top 两种 placement，覆盖 Unsaved 和 Palette。
+              </li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Focus 与键盘</h3>
+            <ul>
+              <li>打开时记录 previous focus，关闭后恢复。</li>
+              <li>
+                支持 <code>initialFocusRef</code>，没有则聚焦第一个 tabbable
+                元素。
+              </li>
+              <li>统一 Tab trap、Shift+Tab 循环、Escape dismiss。</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>ARIA 与可访问性</h3>
+            <ul>
+              <li>
+                统一 <code>role="dialog"</code> 和
+                <code>aria-modal="true"</code>。
+              </li>
+              <li>
+                支持 <code>aria-label</code> 或 <code>aria-labelledby</code>。
+              </li>
+              <li>
+                支持 <code>aria-describedby</code>，让确认弹窗能被完整读出。
+              </li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Motion 与面板壳层</h3>
+            <ul>
+              <li>
+                集中 <code>AnimatePresence</code>、backdrop fade、panel spring。
+              </li>
+              <li>
+                统一 glass panel chrome，避免每个 feature 复制 className。
+              </li>
+              <li>
+                面板尺寸走受控的 <code>size</code> /
+                <code>placement</code>，不开放任意皮肤。
+              </li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Dismiss 策略</h3>
+            <ul>
+              <li>
+                <code>closeOnBackdrop</code> 和
+                <code>closeOnEscape</code> 默认开启。
+              </li>
+              <li>
+                <code>dismissDisabled</code>
+                支持保存中、提交中、危险操作中锁定关闭。
+              </li>
+              <li>
+                所有关闭都通过同一个 <code>onOpenChange(false)</code> 或
+                <code>onDismiss</code>。
+              </li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>测试边界</h3>
+            <ul>
+              <li>
+                primitive 测 focus trap、Escape、backdrop、aria 和 restore
+                focus。
+              </li>
+              <li>
+                feature 测业务文案、按钮回调、query/results 或 terminal
+                lifecycle。
+              </li>
+              <li>避免每个 consumer 重测 primitive 已覆盖的键盘细节。</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>5. 不应该放进全局组件的东西</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>不要放入 Dialog</th>
+              <th>原因</th>
+              <th>保留在哪里</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>“保存 / 丢弃 / 取消”的业务动作</td>
+              <td>这是 editor 的文件状态语义，不是 dialog 的通用能力。</td>
+              <td><code>UnsavedChangesDialog</code> consumer</td>
+            </tr>
+            <tr>
+              <td>Command palette 的 query、selectedIndex、activeDescendant</td>
+              <td>这是 command registry 和 combobox/listbox 行为。</td>
+              <td><code>CommandPalette</code> 及其 hook</td>
+            </tr>
+            <tr>
+              <td>xterm attach、focusTerminal、Tab pass-through</td>
+              <td>这是 terminal workspace overlay 的生命周期和输入模型。</td>
+              <td><code>BurnerTerminalPopup</code></td>
+            </tr>
+            <tr>
+              <td>任意 panel className 皮肤</td>
+              <td>会重新打开 VIM-116 要关闭的视觉漂移。</td>
+              <td>Dialog 只允许尺寸、placement、布局级 className 逃生口</td>
+            </tr>
+            <tr>
+              <td>anchor positioning / cursor positioning</td>
+              <td>
+                这些已经由 <code>base/floating</code> 和 <code>Popover</code> /
+                <code>Menu.Context</code> 解决。
+              </td>
+              <td>
+                <code>Popover</code>、<code>Menu</code>、<code>Dropdown</code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="section">
+        <h2>6. 建议的 public API 草案</h2>
+        <p>
+          这个 API 的目标是：足够 generic，可以承载 Unsaved、CommandPalette
+          和后续 Settings dialog；同时不把 feature 逻辑塞进 primitive。
+        </p>
+        <pre class="code"><code>interface DialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) =&gt; void
+  placement?: 'center' | 'top'
+  size?: 'sm' | 'md' | 'lg' | 'xl'
+  closeOnBackdrop?: boolean
+  closeOnEscape?: boolean
+  dismissDisabled?: boolean
+  restoreFocus?: boolean
+  initialFocusRef?: React.RefObject&lt;HTMLElement | null&gt;
+  'aria-label'?: string
+  'aria-labelledby'?: string
+  'aria-describedby'?: string
+  testId?: string
+  backdropTestId?: string
+  children: React.ReactNode
+}
+
+// 可选结构 helpers，保持 spacing / divider / footer 对齐。
+Dialog.Header
+Dialog.Body
+Dialog.Footer</code></pre>
+        <div class="note">
+          <strong>API 原则：</strong>
+          <code>Dialog</code> owns shell and behavior；consumer owns content and
+          callbacks。只把跨 feature 重复、可测试、和 accessibility
+          相关的逻辑放进 primitive。
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>7. 与 <code>src/components</code> 架构保持一致</h2>
+        <div class="two-up">
+          <div class="card">
+            <h3>现有模式</h3>
+            <p>
+              <code>Dropdown</code>、<code>Menu</code>、<code>Popover</code>
+              是 public primitive，底层共享
+              <code>src/components/base/floating</code>。<code>Button</code>、
+              <code>IconButton</code>、<code>ToolbarButton</code> 共享
+              <code>base/button</code>。feature 只能 import public primitive，
+              不能 import <code>base/**</code>。
+            </p>
+          </div>
+          <div class="card">
+            <h3>Dialog 应该遵守</h3>
+            <p>
+              <code>Dialog.tsx</code> 平铺在 <code>src/components/</code>，
+              和其他 public primitive 同级。若需要 low-level focus/overlay
+              helper， 放在 <code>src/components/base/dialog/</code>，继续遵守
+              <code>base/**</code> package-private 边界。
+            </p>
+            <p>
+              不建议让 <code>Dialog</code> 直接复用 <code>SurfacePanel</code>：
+              现在 <code>SurfacePanel</code> 需要 <code>FloatingContext</code>，
+              强行复用会让 viewport modal 依赖 anchor 定位栈。更合理的是抽小型
+              chrome helper，或在 <code>Dialog</code> 中保持同一套 token。
+            </p>
+          </div>
+        </div>
+        <p>
+          这次 branch 也新增了 <code>src/components/README.md</code> 和
+          <code>src/components/AGENTS.md</code>，把这些边界直接放进组件目录，
+          以后做新的 shared primitive 时不需要重新从设计文档里拼规则。
+        </p>
+      </section>
+
+      <section class="section">
+        <h2>8. 推荐迁移顺序</h2>
+        <div class="timeline">
+          <div class="card">
+            <span class="label">PR 1</span>
+            <h3>实现 <code>Dialog</code> primitive 和测试</h3>
+            <p>
+              添加 <code>src/components/Dialog.tsx</code> 和
+              <code>Dialog.test.tsx</code>。测试覆盖 open/closed、aria name /
+              description、backdrop、Escape、dismissDisabled、initial focus、
+              Tab trap、restore focus。
+            </p>
+            <p>
+              先不迁移任何 feature。PR 1 的验收标准是 primitive 自己稳定：
+              API、focus 行为、dismiss 行为、motion 和 Lens chrome 都可测试。
+            </p>
+          </div>
+          <div class="card">
+            <span class="label">PR 2</span>
+            <h3>迁移 UnsavedChangesDialog</h3>
+            <p>
+              删除手写 focus trap 和 motion shell，改用 <code>Dialog</code>。
+              同时用 <code>Button</code> 替换 raw Save / Discard / Cancel 按钮。
+              保留保存中禁止 dismiss 的行为。
+            </p>
+          </div>
+          <div class="card">
+            <span class="label">PR 3</span>
+            <h3>迁移 CommandPalette shell</h3>
+            <p>
+              保留 <code>CommandInput</code>、<code>CommandResults</code>、
+              <code>CommandFooter</code>，只替换 overlay、backdrop 和 panel
+              wrapper。确认 input focus、selected option 和 backdrop close
+              行为不变。
+            </p>
+          </div>
+          <div class="card">
+            <span class="label">PR 4</span>
+            <h3>评估 BurnerTerminalPopup</h3>
+            <p>
+              只有在 <code>Dialog</code> 能干净支持 persistent mount、 terminal
+              focus handoff、tooltip z-lift 和 Tab pass-through 时才迁移。
+              否则保留 bespoke，但记录清楚为什么它是 workspace overlay 例外。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>9. 旁支：Context menu cleanup</h2>
+        <p>
+          审计中还发现 editor / files / sessions / reading style 仍有部分手写
+          menu。 这也是值得做的 VIM-116 后续，但它不是新 primitive：<code
+            >Menu</code
+          >
+          已经存在，后续应该作为“迁移 straggler 到 Menu”的独立 issue。
+        </p>
+        <div class="note">
+          <strong>优先级判断：</strong>
+          先做 <code>Dialog</code>，因为它补的是缺失 primitive，并且包含真实的
+          accessibility / focus 风险；menu cleanup 是关闭剩余漂移的第二条线。
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/rules/typescript/coding-style/CLAUDE.md
+++ b/rules/typescript/coding-style/CLAUDE.md
@@ -266,9 +266,10 @@ Cross-feature UI primitives live in `src/components/` and are imported via the `
 - **Dropdowns**: always `Dropdown` from `@/components/Dropdown`. Contract: `docs/design/UNIFIED.md` §5.7.
 - **Menus**: always `Menu` from `@/components/Menu` (click-anchored or cursor-anchored via `Menu.Context`). Contract: `docs/design/UNIFIED.md` §5.8.
 - **Popovers**: always `Popover` from `@/components/Popover` for arbitrary dialog cards. Contract: `docs/design/UNIFIED.md` §5.9.
+- **Dialogs**: always `Dialog` from `@/components/Dialog` for full-screen app modal shells. Anchored or cursor-positioned dialog-like surfaces stay on `Popover` / `Menu` / `Dropdown`. Contract: `docs/design/UNIFIED.md` §5.9.1.
 - **Buttons and grouped controls**: always use `Button` / `IconButton` / `ToolbarButton` / `SegmentedControl` / `Toggle` from `@/components`. A raw icon-only `<button>` wrapping a `material-symbols-outlined` glyph is banned by `vimeflow/no-raw-icon-button` — use `IconButton` (or `ToolbarButton` for icon + label). Do not hand-roll segmented/toggle button loops. Contract: `docs/design/UNIFIED.md` §5.10–5.13.
-- **Floating surfaces**: `@floating-ui/react` is confined to `src/components/base/floating/**` (the substrate) and the grandfathered `src/components/Tooltip.tsx`. Features compose `Dropdown`, `Menu`, or `Popover` — never hand-roll a floating surface.
-- **`base/` convention**: `src/components/base/**` is internal substrate that wraps a third-party engine (or owns low-level behaviour) and **must not be imported from `src/features/**`** or any other module outside `src/components/`. Everything under `base/`is package-private to`src/components/`. Features compose the public primitives (`Dropdown`, `Menu`, `Popover`) instead. This boundary is enforced by ESLint ring 2 in `eslint.config.js`.
+- **Floating surfaces**: `@floating-ui/react` is confined to `src/components/base/floating/**` (the substrate) and the grandfathered `src/components/Tooltip.tsx`. Features compose `Dropdown`, `Menu`, or `Popover` — never hand-roll an anchored floating surface.
+- **`base/` convention**: `src/components/base/**` is internal substrate that wraps a third-party engine (or owns low-level behaviour) and **must not be imported from `src/features/**`** or any other module outside `src/components/`. Everything under `base/`is package-private to`src/components/`. Features compose the public primitives (`Dropdown`, `Menu`, `Popover`, `Dialog`) instead. This boundary is enforced by ESLint ring 2 in `eslint.config.js`.
 
 ## Linting
 

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+Instructions for agents editing `src/components/**`.
+
+## Read First
+
+- `src/components/README.md`
+- `docs/design/UNIFIED.md` component contracts
+- Relevant existing primitive and sibling tests before changing an API
+
+## Boundary Rules
+
+- Public primitives live flat in `src/components/*.tsx`.
+- `src/components/base/**` is package-private substrate. Do not make feature code import it.
+- Do not import `@floating-ui/react` outside `src/components/base/floating/**` or `src/components/Tooltip.tsx`.
+- Do not add native `title=` attributes.
+- Do not add raw icon-only Material Symbols buttons outside the existing button primitives.
+
+## Extraction Rules
+
+- Start from real call sites. Name the duplicated behavior before naming the component.
+- Keep feature domain logic out of shared primitives.
+- Shared primitives should own accessibility, focus, keyboard behavior, dismissal policy, tokenized chrome, and stable sizing contracts.
+- Expose narrow props and documented presets. Avoid broad restyle props that reopen visual drift.
+- Add a sibling test for every new source file and keep consumer tests focused on integration.
+- When a primitive becomes canonical, update `docs/design/UNIFIED.md` and any relevant lint guard.
+
+## Dialog Work
+
+For the VIM-116 dialog follow-up, treat `Dialog` as an app-level modal shell, not a replacement for anchored `Popover`.
+
+- First targets: `UnsavedChangesDialog` and the `CommandPalette` shell.
+- Keep anchored non-blocking dialog-like surfaces on `Popover` / `base/floating`.
+- Do not force `Dialog` through `SurfacePanel`; viewport modals should not depend on anchor-positioning state unless a smaller shared chrome helper is extracted.
+- Validation target: `BurnerTerminalPopup`, because it needs persistent mount, terminal focus handoff, and custom overlay behavior.
+- Out of scope: inline `role="dialog"` surfaces such as `ReviewCommentComposer`.

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -231,9 +231,7 @@ describe('Dialog', () => {
       ).toHaveFocus()
 
       await user.tab()
-      expect(
-        within(dialog).getByRole('button', { name: 'Last' })
-      ).toHaveFocus()
+      expect(within(dialog).getByRole('button', { name: 'Last' })).toHaveFocus()
 
       await user.tab()
       expect(

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -420,6 +420,22 @@ describe('Dialog', () => {
     )
   })
 
+  test('focuses visible descendants of visibility:hidden ancestors', async () => {
+    render(
+      <Dialog open onOpenChange={vi.fn()} aria-label="Settings">
+        <div style={{ visibility: 'hidden' }}>
+          <button style={{ visibility: 'visible' }} type="button">
+            Visible
+          </button>
+        </div>
+      </Dialog>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Visible' })).toHaveFocus()
+    )
+  })
+
   test('restores focus to the previously focused element after close', async () => {
     const prior = document.createElement('button')
     prior.textContent = 'Prior'

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -203,6 +203,73 @@ describe('Dialog', () => {
     }
   })
 
+  test('includes contenteditable elements in Tab focus trap', async () => {
+    const user = userEvent.setup()
+    const outside = document.createElement('button')
+    outside.textContent = 'Outside'
+    document.body.appendChild(outside)
+
+    try {
+      render(
+        <Dialog open onOpenChange={vi.fn()} aria-label="Settings">
+          <button type="button">First</button>
+          <div contentEditable role="textbox" aria-label="Editor" />
+          <button type="button">Last</button>
+        </Dialog>
+      )
+
+      const dialog = screen.getByRole('dialog', { name: 'Settings' })
+      await waitFor(() =>
+        expect(
+          within(dialog).getByRole('button', { name: 'First' })
+        ).toHaveFocus()
+      )
+
+      await user.tab()
+      expect(
+        within(dialog).getByRole('textbox', { name: 'Editor' })
+      ).toHaveFocus()
+
+      await user.tab()
+      expect(
+        within(dialog).getByRole('button', { name: 'Last' })
+      ).toHaveFocus()
+
+      await user.tab()
+      expect(
+        within(dialog).getByRole('button', { name: 'First' })
+      ).toHaveFocus()
+      expect(outside).not.toHaveFocus()
+    } finally {
+      outside.remove()
+    }
+  })
+
+  test('restores focus when an open Dialog unmounts', async () => {
+    const prior = document.createElement('button')
+    prior.textContent = 'Prior'
+    document.body.appendChild(prior)
+    prior.focus()
+
+    const { unmount } = render(
+      <Dialog open onOpenChange={vi.fn()} aria-label="Settings">
+        <button type="button">Inside</button>
+      </Dialog>
+    )
+
+    try {
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Inside' })).toHaveFocus()
+      )
+
+      unmount()
+
+      await waitFor(() => expect(prior).toHaveFocus())
+    } finally {
+      prior.remove()
+    }
+  })
+
   test('restores focus to the previously focused element after close', async () => {
     const prior = document.createElement('button')
     prior.textContent = 'Prior'

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -132,6 +132,83 @@ describe('Dialog', () => {
     expect(onOpenChange).not.toHaveBeenCalled()
   })
 
+  test('closes only the topmost dialog when multiple dialogs are open', async () => {
+    const user = userEvent.setup()
+    const onCloseBottom = vi.fn()
+    const onCloseTop = vi.fn()
+
+    render(
+      <>
+        <Dialog open onOpenChange={onCloseBottom} aria-label="Bottom">
+          <button type="button">Bottom</button>
+        </Dialog>
+        <Dialog open onOpenChange={onCloseTop} aria-label="Top">
+          <button type="button">Top</button>
+        </Dialog>
+      </>
+    )
+
+    await user.keyboard('{Escape}')
+
+    expect(onCloseTop).toHaveBeenCalledWith(false)
+    expect(onCloseBottom).not.toHaveBeenCalled()
+  })
+
+  test('does not propagate Escape to a lower dialog when topmost is dismiss-disabled', async () => {
+    const user = userEvent.setup()
+    const onCloseBottom = vi.fn()
+    const onCloseTop = vi.fn()
+
+    render(
+      <>
+        <Dialog open onOpenChange={onCloseBottom} aria-label="Bottom">
+          <button type="button">Bottom</button>
+        </Dialog>
+        <Dialog
+          open
+          dismissDisabled
+          onOpenChange={onCloseTop}
+          aria-label="Top"
+        >
+          <button type="button">Top</button>
+        </Dialog>
+      </>
+    )
+
+    await user.keyboard('{Escape}')
+
+    expect(onCloseTop).not.toHaveBeenCalled()
+    expect(onCloseBottom).not.toHaveBeenCalled()
+  })
+
+  test('does not propagate Escape to a lower dialog when topmost has closeOnEscape disabled', async () => {
+    const user = userEvent.setup()
+    const onCloseBottom = vi.fn()
+    const onCloseTop = vi.fn()
+
+    render(
+      <>
+        <Dialog open onOpenChange={onCloseBottom} aria-label="Bottom">
+          <button type="button">Bottom</button>
+        </Dialog>
+        <Dialog
+          open
+          // eslint-disable-next-line react/jsx-boolean-value -- closeOnEscape defaults to true; explicit false is required for this regression test
+          closeOnEscape={false}
+          onOpenChange={onCloseTop}
+          aria-label="Top"
+        >
+          <button type="button">Top</button>
+        </Dialog>
+      </>
+    )
+
+    await user.keyboard('{Escape}')
+
+    expect(onCloseTop).not.toHaveBeenCalled()
+    expect(onCloseBottom).not.toHaveBeenCalled()
+  })
+
   test('moves focus to initialFocusRef on open', async () => {
     const initialFocusRef = createRef<HTMLButtonElement>()
 

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -1,0 +1,270 @@
+import { createRef, useState, type ReactElement } from 'react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, test, vi } from 'vitest'
+import { Dialog } from './Dialog'
+
+describe('Dialog', () => {
+  test('renders nothing when open is false', () => {
+    const open = false
+
+    render(
+      <Dialog open={open} onOpenChange={vi.fn()} aria-label="Settings">
+        <p>Hidden body</p>
+      </Dialog>
+    )
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByText('Hidden body')).not.toBeInTheDocument()
+  })
+
+  test('renders children with modal dialog aria wiring', () => {
+    render(
+      <Dialog open onOpenChange={vi.fn()} aria-label="Settings">
+        <p>Dialog body</p>
+      </Dialog>
+    )
+
+    const dialog = screen.getByRole('dialog', { name: 'Settings' })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(screen.getByText('Dialog body')).toBeInTheDocument()
+  })
+
+  test('supports aria-labelledby and aria-describedby wiring', () => {
+    render(
+      <Dialog
+        open
+        onOpenChange={vi.fn()}
+        aria-labelledby="dialog-title"
+        aria-describedby="dialog-description"
+      >
+        <Dialog.Header>
+          <h2 id="dialog-title">Unsaved Changes</h2>
+        </Dialog.Header>
+        <Dialog.Body>
+          <p id="dialog-description">example.ts has unsaved changes.</p>
+        </Dialog.Body>
+      </Dialog>
+    )
+
+    expect(
+      screen.getByRole('dialog', {
+        name: 'Unsaved Changes',
+        description: /example\.ts/,
+      })
+    ).toBeInTheDocument()
+  })
+
+  test('calls onOpenChange(false) when backdrop is clicked', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(
+      <Dialog
+        open
+        onOpenChange={onOpenChange}
+        aria-label="Command palette"
+        backdropTestId="dialog-backdrop"
+      >
+        <button type="button">Inside</button>
+      </Dialog>
+    )
+
+    await user.click(screen.getByTestId('dialog-backdrop'))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  test('does not dismiss from backdrop when closeOnBackdrop is false', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const closeOnBackdrop = false
+
+    render(
+      <Dialog
+        open
+        closeOnBackdrop={closeOnBackdrop}
+        onOpenChange={onOpenChange}
+        aria-label="Command palette"
+        backdropTestId="dialog-backdrop"
+      >
+        <button type="button">Inside</button>
+      </Dialog>
+    )
+
+    await user.click(screen.getByTestId('dialog-backdrop'))
+
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  test('calls onOpenChange(false) when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(
+      <Dialog open onOpenChange={onOpenChange} aria-label="Settings">
+        <button type="button">Inside</button>
+      </Dialog>
+    )
+
+    await user.keyboard('{Escape}')
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  test('does not dismiss from Escape while dismiss is disabled', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(
+      <Dialog
+        open
+        dismissDisabled
+        onOpenChange={onOpenChange}
+        aria-label="Settings"
+      >
+        <button type="button">Inside</button>
+      </Dialog>
+    )
+
+    await user.keyboard('{Escape}')
+
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  test('moves focus to initialFocusRef on open', async () => {
+    const initialFocusRef = createRef<HTMLButtonElement>()
+
+    render(
+      <Dialog
+        open
+        onOpenChange={vi.fn()}
+        initialFocusRef={initialFocusRef}
+        aria-label="Unsaved Changes"
+      >
+        <button type="button">Save</button>
+        <button ref={initialFocusRef} type="button">
+          Cancel
+        </button>
+      </Dialog>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus()
+    )
+  })
+
+  test('moves focus to first focusable child when no initialFocusRef is supplied', async () => {
+    render(
+      <Dialog open onOpenChange={vi.fn()} aria-label="Unsaved Changes">
+        <button type="button">Save</button>
+        <button type="button">Cancel</button>
+      </Dialog>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' })).toHaveFocus()
+    )
+  })
+
+  test('traps Tab navigation inside the dialog', async () => {
+    const user = userEvent.setup()
+    const outside = document.createElement('button')
+    outside.textContent = 'Outside'
+    document.body.appendChild(outside)
+
+    try {
+      render(
+        <Dialog open onOpenChange={vi.fn()} aria-label="Settings">
+          <button type="button">First</button>
+          <button type="button">Second</button>
+        </Dialog>
+      )
+
+      const dialog = screen.getByRole('dialog', { name: 'Settings' })
+      await waitFor(() =>
+        expect(
+          within(dialog).getByRole('button', { name: 'First' })
+        ).toHaveFocus()
+      )
+
+      await user.tab()
+      expect(
+        within(dialog).getByRole('button', { name: 'Second' })
+      ).toHaveFocus()
+
+      await user.tab()
+      expect(
+        within(dialog).getByRole('button', { name: 'First' })
+      ).toHaveFocus()
+      expect(outside).not.toHaveFocus()
+    } finally {
+      outside.remove()
+    }
+  })
+
+  test('restores focus to the previously focused element after close', async () => {
+    const prior = document.createElement('button')
+    prior.textContent = 'Prior'
+    document.body.appendChild(prior)
+    prior.focus()
+
+    const Harness = (): ReactElement => {
+      const [open, setOpen] = useState(true)
+
+      return (
+        <Dialog open={open} onOpenChange={setOpen} aria-label="Settings">
+          <button type="button" onClick={(): void => setOpen(false)}>
+            Close
+          </button>
+        </Dialog>
+      )
+    }
+
+    try {
+      const user = userEvent.setup()
+      render(<Harness />)
+
+      await user.click(screen.getByRole('button', { name: 'Close' }))
+
+      await waitFor(() => expect(prior).toHaveFocus())
+    } finally {
+      prior.remove()
+    }
+  })
+
+  test('applies placement, sizing, and section chrome', () => {
+    render(
+      <Dialog
+        open
+        placement="top"
+        size="lg"
+        onOpenChange={vi.fn()}
+        aria-label="Command palette"
+      >
+        <Dialog.Header>
+          <h2>Palette</h2>
+        </Dialog.Header>
+        <Dialog.Body>
+          <p>Search</p>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <button type="button">Done</button>
+        </Dialog.Footer>
+      </Dialog>
+    )
+
+    const dialog = screen.getByRole('dialog', { name: 'Command palette' })
+    expect(dialog).toHaveClass('items-start')
+    expect(dialog).toHaveClass('pt-[15vh]')
+
+    // eslint-disable-next-line testing-library/no-node-access -- asserting primitive panel chrome
+    const panel = screen.getByText('Palette').closest('.max-w-2xl')
+    expect(panel).not.toBeNull()
+    // eslint-disable-next-line testing-library/no-node-access -- asserting primitive section chrome
+    expect(screen.getByText('Palette').parentElement).toHaveClass('border-b')
+    // eslint-disable-next-line testing-library/no-node-access -- asserting primitive section chrome
+    const footer = screen.getByRole('button', { name: 'Done' }).parentElement
+    expect(footer).toHaveClass('justify-end')
+  })
+})

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -340,6 +340,86 @@ describe('Dialog', () => {
     }
   })
 
+  test('preserves dialog stack order when a parent re-renders', async () => {
+    const user = userEvent.setup()
+    const onCloseBottom = vi.fn()
+    const onCloseTop = vi.fn()
+
+    const Harness = (): ReactElement => {
+      const [, setTick] = useState(0)
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={(): void => setTick((value) => value + 1)}
+          >
+            Re-render
+          </button>
+          <Dialog open onOpenChange={onCloseBottom} aria-label="Bottom">
+            <button type="button">Bottom</button>
+          </Dialog>
+          <Dialog open onOpenChange={onCloseTop} aria-label="Top">
+            <button type="button">Top</button>
+          </Dialog>
+        </>
+      )
+    }
+
+    render(<Harness />)
+
+    await user.click(screen.getByRole('button', { name: 'Re-render' }))
+    await user.keyboard('{Escape}')
+
+    expect(onCloseTop).toHaveBeenCalledWith(false)
+    expect(onCloseBottom).not.toHaveBeenCalled()
+  })
+
+  test('skips display:none elements when choosing initial focus', async () => {
+    render(
+      <Dialog open onOpenChange={vi.fn()} aria-label="Settings">
+        <button style={{ display: 'none' }} type="button">
+          Hidden
+        </button>
+        <button type="button">Visible</button>
+      </Dialog>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Visible' })).toHaveFocus()
+    )
+  })
+
+  test('skips visibility:hidden elements when choosing initial focus', async () => {
+    render(
+      <Dialog open onOpenChange={vi.fn()} aria-label="Settings">
+        <button style={{ visibility: 'hidden' }} type="button">
+          Hidden
+        </button>
+        <button type="button">Visible</button>
+      </Dialog>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Visible' })).toHaveFocus()
+    )
+  })
+
+  test('skips elements inside a display:none ancestor when choosing initial focus', async () => {
+    render(
+      <Dialog open onOpenChange={vi.fn()} aria-label="Settings">
+        <div style={{ display: 'none' }}>
+          <button type="button">Hidden</button>
+        </div>
+        <button type="button">Visible</button>
+      </Dialog>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Visible' })).toHaveFocus()
+    )
+  })
+
   test('restores focus to the previously focused element after close', async () => {
     const prior = document.createElement('button')
     prior.textContent = 'Prior'

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -164,12 +164,7 @@ describe('Dialog', () => {
         <Dialog open onOpenChange={onCloseBottom} aria-label="Bottom">
           <button type="button">Bottom</button>
         </Dialog>
-        <Dialog
-          open
-          dismissDisabled
-          onOpenChange={onCloseTop}
-          aria-label="Top"
-        >
+        <Dialog open dismissDisabled onOpenChange={onCloseTop} aria-label="Top">
           <button type="button">Top</button>
         </Dialog>
       </>

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -66,6 +66,30 @@ const FOCUSABLE_SELECTOR = [
   '[contenteditable]:not([contenteditable="false"])',
 ].join(',')
 
+const isVisibleFocusableElement = (element: HTMLElement): boolean => {
+  const isNodeVisible = (node: Element): boolean => {
+    const style = window.getComputedStyle(node)
+
+    return style.display !== 'none' && style.visibility !== 'hidden'
+  }
+
+  if (!isNodeVisible(element)) {
+    return false
+  }
+
+  let ancestor: Element | null = element.parentElement
+
+  while (ancestor !== null) {
+    if (!isNodeVisible(ancestor)) {
+      return false
+    }
+
+    ancestor = ancestor.parentElement
+  }
+
+  return true
+}
+
 const getFocusableElements = (container: HTMLElement): HTMLElement[] =>
   Array.from(
     container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
@@ -75,7 +99,8 @@ const getFocusableElements = (container: HTMLElement): HTMLElement[] =>
       element.getAttribute('aria-hidden') !== 'true' &&
       (element.tabIndex >= 0 ||
         (element.hasAttribute('contenteditable') &&
-          element.getAttribute('contenteditable') !== 'false'))
+          element.getAttribute('contenteditable') !== 'false')) &&
+      isVisibleFocusableElement(element)
   )
 
 interface DialogLayer {
@@ -133,7 +158,8 @@ const focusInitialElement = (
   if (
     initial !== null &&
     initial !== undefined &&
-    !initial.hasAttribute('disabled')
+    !initial.hasAttribute('disabled') &&
+    isVisibleFocusableElement(initial)
   ) {
     initial.focus()
 
@@ -231,6 +257,12 @@ const DialogRoot = ({
     onOpenChange(false)
   }, [dismissDisabled, onOpenChange])
 
+  const requestCloseRef = useRef(requestClose)
+  requestCloseRef.current = requestClose
+
+  const closeOnEscapeRef = useRef(closeOnEscape)
+  closeOnEscapeRef.current = closeOnEscape
+
   useEffect(() => {
     if (open && !wasOpenRef.current) {
       previousFocusRef.current =
@@ -276,8 +308,8 @@ const DialogRoot = ({
 
     const layer: DialogLayer = {
       close: (): void => {
-        if (closeOnEscape) {
-          requestClose()
+        if (closeOnEscapeRef.current) {
+          requestCloseRef.current()
         }
       },
       container: dialog,
@@ -288,7 +320,7 @@ const DialogRoot = ({
     return (): void => {
       unregisterDialogLayer(layer)
     }
-  }, [closeOnEscape, open, requestClose])
+  }, [open])
 
   if (typeof document === 'undefined') {
     return null

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,0 +1,286 @@
+import { AnimatePresence, motion } from 'framer-motion'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type ReactElement,
+  type ReactNode,
+  type RefObject,
+} from 'react'
+import { createPortal } from 'react-dom'
+
+type DialogPlacement = 'center' | 'top'
+type DialogSize = 'sm' | 'md' | 'lg' | 'xl'
+
+interface DialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  placement?: DialogPlacement
+  size?: DialogSize
+  closeOnBackdrop?: boolean
+  closeOnEscape?: boolean
+  dismissDisabled?: boolean
+  restoreFocus?: boolean
+  initialFocusRef?: RefObject<HTMLElement | null>
+  'aria-label'?: string
+  'aria-labelledby'?: string
+  'aria-describedby'?: string
+  testId?: string
+  backdropTestId?: string
+  children: ReactNode
+}
+
+interface DialogSectionProps {
+  children: ReactNode
+}
+
+type DialogComponent = ((props: DialogProps) => ReactElement | null) & {
+  Header: (props: DialogSectionProps) => ReactElement
+  Body: (props: DialogSectionProps) => ReactElement
+  Footer: (props: DialogSectionProps) => ReactElement
+}
+
+const PLACEMENT_CLASSES: Record<DialogPlacement, string> = {
+  center: 'items-center justify-center',
+  top: 'items-start justify-center pt-[15vh]',
+}
+
+const PANEL_SIZE_CLASSES: Record<DialogSize, string> = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-2xl',
+  xl: 'max-w-4xl',
+}
+
+const DIALOG_PANEL_CLASSES =
+  'relative w-full mx-4 bg-surface-container/90 glass-panel rounded-2xl ' +
+  'border border-outline-variant/30 shadow-2xl overflow-hidden'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+const getFocusableElements = (container: HTMLElement): HTMLElement[] =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+  ).filter(
+    (element) =>
+      !element.hasAttribute('disabled') &&
+      element.getAttribute('aria-hidden') !== 'true' &&
+      element.tabIndex >= 0
+  )
+
+const focusInitialElement = (
+  container: HTMLElement,
+  initialFocusRef: RefObject<HTMLElement | null> | undefined
+): void => {
+  const initial = initialFocusRef?.current
+
+  if (
+    initial !== null &&
+    initial !== undefined &&
+    !initial.hasAttribute('disabled')
+  ) {
+    initial.focus()
+
+    return
+  }
+
+  const focusableElements = getFocusableElements(container)
+
+  if (focusableElements.length > 0) {
+    focusableElements[0]?.focus()
+
+    return
+  }
+
+  container.focus()
+}
+
+const focusRelativeElement = (
+  container: HTMLElement,
+  event: KeyboardEvent
+): void => {
+  const focusableElements = getFocusableElements(container)
+
+  if (focusableElements.length === 0) {
+    event.preventDefault()
+    container.focus()
+
+    return
+  }
+
+  const activeElement =
+    document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null
+
+  const currentIndex =
+    activeElement === null ? -1 : focusableElements.indexOf(activeElement)
+
+  const nextIndex =
+    currentIndex === -1
+      ? event.shiftKey
+        ? focusableElements.length - 1
+        : 0
+      : (currentIndex + (event.shiftKey ? -1 : 1) + focusableElements.length) %
+        focusableElements.length
+
+  event.preventDefault()
+  focusableElements[nextIndex]?.focus()
+}
+
+const DialogHeader = ({ children }: DialogSectionProps): ReactElement => (
+  <div className="px-6 py-4 border-b border-surface-container-low/30">
+    {children}
+  </div>
+)
+
+const DialogBody = ({ children }: DialogSectionProps): ReactElement => (
+  <div className="px-6 py-5">{children}</div>
+)
+
+const DialogFooter = ({ children }: DialogSectionProps): ReactElement => (
+  <div className="px-6 py-4 border-t border-surface-container-low/30 flex gap-3 justify-end">
+    {children}
+  </div>
+)
+
+const DialogRoot = ({
+  open,
+  onOpenChange,
+  placement = 'center',
+  size = 'md',
+  closeOnBackdrop = true,
+  closeOnEscape = true,
+  dismissDisabled = false,
+  restoreFocus = true,
+  initialFocusRef = undefined,
+  'aria-label': ariaLabel = undefined,
+  'aria-labelledby': ariaLabelledBy = undefined,
+  'aria-describedby': ariaDescribedBy = undefined,
+  testId = undefined,
+  backdropTestId = undefined,
+  children,
+}: DialogProps): ReactElement | null => {
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+  const wasOpenRef = useRef(false)
+
+  const requestClose = useCallback((): void => {
+    if (dismissDisabled) {
+      return
+    }
+
+    onOpenChange(false)
+  }, [dismissDisabled, onOpenChange])
+
+  useEffect(() => {
+    if (open && !wasOpenRef.current) {
+      previousFocusRef.current =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null
+      wasOpenRef.current = true
+      const dialog = dialogRef.current
+
+      if (dialog !== null) {
+        focusInitialElement(dialog, initialFocusRef)
+      }
+    } else if (!open && wasOpenRef.current) {
+      wasOpenRef.current = false
+
+      if (restoreFocus) {
+        previousFocusRef.current?.focus()
+      }
+
+      previousFocusRef.current = null
+    }
+  }, [initialFocusRef, open, restoreFocus])
+
+  useEffect(() => {
+    if (!open) {
+      return undefined
+    }
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        if (closeOnEscape) {
+          requestClose()
+        }
+
+        return
+      }
+
+      if (event.key !== 'Tab') {
+        return
+      }
+
+      const dialog = dialogRef.current
+
+      if (dialog !== null) {
+        focusRelativeElement(dialog, event)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return (): void => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [closeOnEscape, open, requestClose])
+
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  return createPortal(
+    <AnimatePresence>
+      {open ? (
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
+          aria-describedby={ariaDescribedBy}
+          tabIndex={-1}
+          data-testid={testId}
+          className={`fixed inset-0 z-[100] flex ${PLACEMENT_CLASSES[placement]}`}
+        >
+          <motion.div
+            aria-hidden="true"
+            data-testid={backdropTestId}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="absolute inset-0 backdrop-blur-sm bg-surface-container-lowest/40"
+            onClick={closeOnBackdrop ? requestClose : undefined}
+          />
+          <motion.div
+            initial={{ scale: 0.96, opacity: 0, y: -8 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.96, opacity: 0, y: -8 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+            className={`${DIALOG_PANEL_CLASSES} ${PANEL_SIZE_CLASSES[size]}`}
+          >
+            {children}
+          </motion.div>
+        </div>
+      ) : null}
+    </AnimatePresence>,
+    document.body
+  )
+}
+
+export const Dialog: DialogComponent = Object.assign(DialogRoot, {
+  Header: DialogHeader,
+  Body: DialogBody,
+  Footer: DialogFooter,
+})

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -63,6 +63,7 @@ const FOCUSABLE_SELECTOR = [
   'input:not([disabled])',
   'select:not([disabled])',
   '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable]:not([contenteditable="false"])',
 ].join(',')
 
 const getFocusableElements = (container: HTMLElement): HTMLElement[] =>
@@ -72,7 +73,9 @@ const getFocusableElements = (container: HTMLElement): HTMLElement[] =>
     (element) =>
       !element.hasAttribute('disabled') &&
       element.getAttribute('aria-hidden') !== 'true' &&
-      element.tabIndex >= 0
+      (element.tabIndex >= 0 ||
+        (element.hasAttribute('contenteditable') &&
+          element.getAttribute('contenteditable') !== 'false'))
   )
 
 const focusInitialElement = (
@@ -171,6 +174,8 @@ const DialogRoot = ({
   const dialogRef = useRef<HTMLDivElement | null>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
   const wasOpenRef = useRef(false)
+  const restoreFocusRef = useRef(restoreFocus)
+  restoreFocusRef.current = restoreFocus
 
   const requestClose = useCallback((): void => {
     if (dismissDisabled) {
@@ -202,6 +207,15 @@ const DialogRoot = ({
       previousFocusRef.current = null
     }
   }, [initialFocusRef, open, restoreFocus])
+
+  useEffect(
+    () => (): void => {
+      if (wasOpenRef.current && restoreFocusRef.current) {
+        previousFocusRef.current?.focus()
+      }
+    },
+    []
+  )
 
   useEffect(() => {
     if (!open) {

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -78,6 +78,52 @@ const getFocusableElements = (container: HTMLElement): HTMLElement[] =>
           element.getAttribute('contenteditable') !== 'false'))
   )
 
+interface DialogLayer {
+  close: () => void
+  container: HTMLDivElement
+}
+
+const dialogStack: DialogLayer[] = []
+
+const handleDocumentKeyDown = (event: KeyboardEvent): void => {
+  if (dialogStack.length === 0) {
+    return
+  }
+
+  const topLayer = dialogStack[dialogStack.length - 1]
+
+  if (event.key === 'Escape') {
+    topLayer.close()
+    event.stopImmediatePropagation()
+
+    return
+  }
+
+  if (event.key === 'Tab') {
+    focusRelativeElement(topLayer.container, event)
+  }
+}
+
+const registerDialogLayer = (layer: DialogLayer): void => {
+  if (dialogStack.length === 0) {
+    document.addEventListener('keydown', handleDocumentKeyDown)
+  }
+
+  dialogStack.push(layer)
+}
+
+const unregisterDialogLayer = (layer: DialogLayer): void => {
+  const index = dialogStack.indexOf(layer)
+
+  if (index !== -1) {
+    dialogStack.splice(index, 1)
+  }
+
+  if (dialogStack.length === 0) {
+    document.removeEventListener('keydown', handleDocumentKeyDown)
+  }
+}
+
 const focusInitialElement = (
   container: HTMLElement,
   initialFocusRef: RefObject<HTMLElement | null> | undefined
@@ -222,30 +268,25 @@ const DialogRoot = ({
       return undefined
     }
 
-    const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === 'Escape') {
+    const dialog = dialogRef.current
+
+    if (dialog === null) {
+      return undefined
+    }
+
+    const layer: DialogLayer = {
+      close: (): void => {
         if (closeOnEscape) {
           requestClose()
         }
-
-        return
-      }
-
-      if (event.key !== 'Tab') {
-        return
-      }
-
-      const dialog = dialogRef.current
-
-      if (dialog !== null) {
-        focusRelativeElement(dialog, event)
-      }
+      },
+      container: dialog,
     }
 
-    document.addEventListener('keydown', handleKeyDown)
+    registerDialogLayer(layer)
 
     return (): void => {
-      document.removeEventListener('keydown', handleKeyDown)
+      unregisterDialogLayer(layer)
     }
   }, [closeOnEscape, open, requestClose])
 

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -67,20 +67,16 @@ const FOCUSABLE_SELECTOR = [
 ].join(',')
 
 const isVisibleFocusableElement = (element: HTMLElement): boolean => {
-  const isNodeVisible = (node: Element): boolean => {
-    const style = window.getComputedStyle(node)
+  const elementStyle = window.getComputedStyle(element)
 
-    return style.display !== 'none' && style.visibility !== 'hidden'
-  }
-
-  if (!isNodeVisible(element)) {
+  if (elementStyle.display === 'none' || elementStyle.visibility === 'hidden') {
     return false
   }
 
   let ancestor: Element | null = element.parentElement
 
   while (ancestor !== null) {
-    if (!isNodeVisible(ancestor)) {
+    if (window.getComputedStyle(ancestor).display === 'none') {
       return false
     }
 

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,0 +1,39 @@
+# Shared Component Library
+
+`src/components` is the public UI primitive layer for Vimeflow. Feature code should compose these primitives instead of re-implementing chrome, accessibility wiring, keyboard behavior, or third-party integration.
+
+## Layers
+
+- Public primitives live flat in `src/components/*.tsx`: `Tooltip`, `Dropdown`, `Menu`, `Popover`, `Dialog`, `Button`, `IconButton`, `ToolbarButton`, `SegmentedControl`, `Toggle`, `Chip`, `ProgressBar`, and similar app-wide components.
+- Package-private substrate lives under `src/components/base/**`. It may wrap a third-party engine or own low-level behavior that public primitives share.
+- Feature code must not import from `src/components/base/**`. The ESLint ring-2 rule enforces this outside `src/components`.
+- `@floating-ui/react` is confined to `src/components/base/floating/**` and the grandfathered `Tooltip`. Feature code composes `Dropdown`, `Menu`, or `Popover`.
+
+## Adding A Primitive
+
+Add a shared primitive only when at least two real call sites need the same behavior, or when one call site owns behavior that must be centralized for accessibility, security, or consistency.
+
+Before adding one:
+
+- Audit the real consumers and list what behavior is shared.
+- Keep domain logic in the feature. Shared components own shell, accessibility, focus, dismissal, sizing presets, and tokenized chrome.
+- Prefer a flat public file such as `Dialog.tsx`; put reusable internals in `base/<area>/` only when they hide meaningful complexity.
+- Add a sibling test file for every new `.tsx` or `.ts` file.
+- Document the contract in `docs/design/UNIFIED.md` when the primitive becomes part of the design system.
+- Add or update a lint guard when the primitive closes a repeated anti-pattern.
+
+## Overlay Choice
+
+- Use `Tooltip` for hover or focus labels. Do not use native `title=`.
+- Use `Dropdown` for controlled option selection.
+- Use `Menu` for command menus, including cursor-anchored context menus via `Menu.Context`.
+- Use `Popover` for anchored arbitrary dialog cards, including non-blocking dialog-like surfaces that position against a trigger.
+- Use `Dialog` for full-screen modal shells. Do not route anchored or cursor-positioned surfaces through `Dialog` just because they use `role="dialog"`.
+
+## Styling
+
+Shared components use semantic theme tokens and the existing Lens surface language. Avoid call-site-specific chrome escape hatches. If a component exposes `className`, treat it as a layout escape hatch, not a way to restyle the primitive.
+
+## Tests
+
+Primitive tests cover primitive behavior: ARIA wiring, focus management, keyboard interaction, disabled states, dismissal, ref forwarding, and visual state attributes. Consumer tests should verify only the consumer-specific integration, copy, and callbacks.


### PR DESCRIPTION
## Summary

- adds a shared `Dialog` primitive for viewport-level app modal shells
- covers backdrop dismissal, Escape handling, focus trap/restore, aria wiring, placement/size presets, and `Dialog.Header` / `Body` / `Footer`
- documents the Dialog vs Popover boundary in the design system, component README/AGENTS guidance, and a Chinese technical note for the VIM-116 follow-up

## Why

The existing app-level dialogs duplicate fixed overlay, backdrop, focus, keyboard, and aria behavior in feature code. This PR creates the primitive first without migrating consumers so the API and behavior can be reviewed independently before stacking the Unsaved Changes migration on top.

## Stack

Base: `refactor/dialog-component`
Head: `refactor/vim-116-dialog-primitive`

## Validation

- `npx vitest run src/components/Dialog.test.tsx`
- `npm run type-check:generated`
- `npm run lint`
